### PR TITLE
feat: add automation, persistence layer, and NixOS module

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Polylogue is an interactive-first toolkit for archiving AI/LLM conversations—r
 - **Render local logs:** Choose a file or directory; skim previews candidates, rich shows progress, and outputs land in the configured render directory (default `/realm/data/chatlog/markdown/gemini-render`). Add `--html` for themed previews or `--diff` to see deltas when re-rendering.
 - **Sync Drive folders:** Connect to the default Drive folder (`AI Studio`) and pull chats to Markdown in `/realm/data/chatlog/markdown/gemini-sync`, downloading attachments unless you opt to link only.
 - **Sync Codex / Claude Code sessions:** Mirror local CLI transcripts from `~/.codex/sessions/` and `~/.claude/projects/` via `polylogue sync-codex` / `polylogue sync-claude-code`, with optional JSON summaries, pruning, diffs, and HTML previews. Outputs land in `/realm/data/chatlog/markdown/codex` and `/realm/data/chatlog/markdown/claude-code` by default.
+- **Watch local sessions in real time:** `polylogue watch codex` and `polylogue watch claude-code` keep those directories synced automatically; adjust debounce, HTML, and collapse settings per watcher.
 - **Import exported providers:** Convert ChatGPT zips, Claude exports, Claude Code sessions, or Codex JSONLs via `polylogue import …` subcommands. Skim lets you cherry-pick conversations; `--all` batches them.
 - **Doctor & Stats:** `polylogue doctor` sanity-checks source directories; `polylogue stats` aggregates attachment sizes, token counts, and provider summaries (with `--since/--until` filters).
 - **View recent runs:** The status dashboard shows the last operations, including attachment MiB and diff counts per command.
@@ -54,6 +55,7 @@ Although the CLI is interactive by default, the same functionality is available 
 - `python3 polylogue.py stats [--dir DIR] [--since DATE] [--until DATE] [--json]`
 
 `--plain` disables gum/skim/Rich styling for CI or scripts; `--json` prints machine-readable summaries.
+Use `--to-clipboard` on `render`/`import` commands to copy a single Markdown result directly to your system clipboard.
 
 ## Tooling & UX Stack
 The dev shell equips Polylogue with:
@@ -63,6 +65,8 @@ The dev shell equips Polylogue with:
 - `bat`, `delta`, `fd`, `ripgrep`, `glow` as supporting CLIs.
 
 Everything falls back gracefully when `--plain` is specified or stdout isn’t a TTY.
+
+See `docs/automation.md` for watcher usage and ready-made systemd/cron templates.
 
 ## Configuration
 - Polylogue reads configuration from `$POLYLOGUE_CONFIG`, `$XDG_CONFIG_HOME/polylogue/config.json`, or (legacy) `~/.polylogueconfig`.

--- a/flake.nix
+++ b/flake.nix
@@ -42,6 +42,8 @@
               python-frontmatter
               jinja2
               markdown-it-py
+              pyperclip
+              watchfiles
               pytest
             ]))
           ];

--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -16,6 +16,8 @@ pkgs.mkShell {
     pkgs.python3Packages.python-frontmatter
     pkgs.python3Packages.jinja2
     pkgs.python3Packages.markdown-it-py
+    pkgs.python3Packages.pyperclip
+    pkgs.python3Packages.watchfiles
 
     # CLI helpers used by Polylogue
     pkgs.skim

--- a/nix/modules/polylogue.nix
+++ b/nix/modules/polylogue.nix
@@ -1,0 +1,226 @@
+{ self }:
+{ config, lib, pkgs, ... }:
+let
+  inherit (lib) mkEnableOption mkOption mkIf mkMerge optionalAttrs escapeShellArgs types attrNames;
+
+  cfg = config.services.polylogue;
+  targetData = builtins.fromJSON (builtins.readFile ../../polylogue/automation_targets.json);
+
+  packagesForSystem = lib.attrByPath [pkgs.system] (self.packages or {}) {};
+  defaultPackage = packagesForSystem.polylogue or (
+    throw "polylogue package not available for system ${pkgs.system}; make sure self.packages.${pkgs.system}.polylogue is defined"
+  );
+
+  targetOption = name: types.submodule ({ ... }:
+    let meta = targetData.${name}; in {
+      options = {
+        enable = mkOption {
+          type = types.bool;
+          default = false;
+          description = "Enable automation for ${meta.description}.";
+        };
+        workingDir = mkOption {
+          type = types.nullOr types.path;
+          default = null;
+          description = "Working directory for ${meta.description}.";
+        };
+        outputDir = mkOption {
+          type = types.nullOr types.path;
+          default = null;
+          description = "Output directory passed as --out.";
+        };
+        extraArgs = mkOption {
+          type = types.listOf types.str;
+          default = [];
+          description = "Additional arguments appended to the Polylogue command.";
+        };
+        collapseThreshold = mkOption {
+          type = types.nullOr types.int;
+          default = null;
+          description = "Override collapse threshold passed to the CLI.";
+        };
+        html = mkOption {
+          type = types.bool;
+          default = false;
+          description = "Enable HTML output (--html).";
+        };
+        timer = mkOption {
+          type = types.submodule ({ ... }: {
+            options = {
+              interval = mkOption {
+                type = types.str;
+                default = "15m";
+                description = "systemd OnUnitActiveSec value.";
+              };
+              bootDelay = mkOption {
+                type = types.str;
+                default = "2m";
+                description = "systemd OnBootSec value.";
+              };
+            };
+          });
+          default = {};
+          description = "Timer configuration for the automation target.";
+        };
+        environment = mkOption {
+          type = types.attrsOf types.str;
+          default = {};
+          description = "Extra environment variables for this target.";
+        };
+        user = mkOption {
+          type = types.nullOr types.str;
+          default = null;
+          description = "Run this target as a specific user (overrides services.polylogue.user).";
+        };
+      };
+    }
+  );
+
+  targetsOption = types.attrsOf (types.submodule ({ name, ... }:
+    if targetData ? ${name}
+    then targetOption name
+    else throw "Unknown Polylogue automation target '${name}'"
+  ));
+
+  allTargets = cfg.targets;
+  activeTargets = lib.filterAttrs (_: t: t.enable) allTargets;
+
+  mkServiceFor = name: targetCfg:
+    let
+      meta = targetData.${name};
+      targetUser = targetCfg.user or cfg.user;
+      defaults = meta.defaults or {};
+      defaultExtra = lib.attrByPath ["extraArgs"] [] defaults;
+      defaultCollapse = lib.attrByPath ["collapseThreshold"] null defaults;
+      defaultHtml = lib.attrByPath ["html"] false defaults;
+      defaultOut = lib.attrByPath ["outputDir"] null defaults;
+      defaultWorking = lib.attrByPath ["workingDir"] null defaults;
+      workingDir = toString (targetCfg.workingDir or defaultWorking or cfg.workingDir);
+      baseArgs = meta.command
+        ++ defaultExtra
+        ++ targetCfg.extraArgs;
+      collapseValue = targetCfg.collapseThreshold or defaultCollapse;
+      argsWithCollapse = if collapseValue != null && !(lib.elem "--collapse-threshold" baseArgs)
+        then baseArgs ++ ["--collapse-threshold", toString collapseValue]
+        else baseArgs;
+      htmlFlag = if targetCfg.html then true else defaultHtml;
+      argsWithHtml = if htmlFlag && !(lib.elem "--html" argsWithCollapse)
+        then argsWithCollapse ++ ["--html"]
+        else if (!htmlFlag)
+        then lib.filter (arg: arg != "--html") argsWithCollapse
+        else argsWithCollapse;
+      resolvedOut = targetCfg.outputDir or defaultOut;
+      args = if resolvedOut != null && !(lib.elem "--out" argsWithHtml)
+        then argsWithHtml ++ ["--out", toString resolvedOut]
+        else argsWithHtml;
+      envVars = cfg.environment // targetCfg.environment // {
+        XDG_STATE_HOME = toString cfg.stateDir;
+      };
+      execStart = escapeShellArgs (["${cfg.package}/bin/polylogue"] ++ args);
+      preStart = lib.concatStringsSep "\n" (lib.unique (
+        ["mkdir -p ${workingDir}" "mkdir -p ${toString cfg.stateDir}"]
+        ++ lib.optionals (resolvedOut != null) ["mkdir -p ${toString resolvedOut}"]
+      ));
+    in {
+      systemd.services.${meta.name} = {
+        description = meta.description;
+        serviceConfig = {
+          Type = "oneshot";
+          WorkingDirectory = workingDir;
+          ExecStart = execStart;
+        } // optionalAttrs (targetUser != null) {
+          User = targetUser;
+        };
+        environment = envVars;
+        preStart = preStart;
+      };
+      systemd.timers.${meta.name} = {
+        description = meta.description + " timer";
+        wantedBy = [ "timers.target" ];
+        partOf = [ meta.name ];
+        timerConfig = {
+          OnBootSec = targetCfg.timer.bootDelay;
+          OnUnitActiveSec = targetCfg.timer.interval;
+          Persistent = true;
+        };
+      };
+    };
+
+  tmpfileDirs = lib.unique (
+    [ cfg.workingDir cfg.stateDir ]
+    ++ (lib.mapAttrsToList (n: t:
+      let
+        meta = targetData.${n};
+        defaults = meta.defaults or {};
+      in
+        t.outputDir or defaults.outputDir or null
+    ) cfg.targets)
+  );
+
+  tmpfilesRules = lib.map (dir:
+    let owner = cfg.user or "root"; in
+    "d ${toString dir} 0755 ${owner} ${owner} - -"
+  ) (lib.filter (dir: dir != null) tmpfileDirs);
+
+in {
+  options.services.polylogue = {
+    enable = mkEnableOption "Polylogue automation timers";
+
+    package = mkOption {
+      type = types.package;
+      default = defaultPackage;
+      description = "Polylogue package providing the CLI binary.";
+    };
+
+    user = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = "Run automation systemd units as this user.";
+    };
+
+    workingDir = mkOption {
+      type = types.path;
+      default = "/var/lib/polylogue";
+      description = "Default working directory for automation jobs.";
+    };
+
+    stateDir = mkOption {
+      type = types.path;
+      default = "/var/lib/polylogue/state";
+      description = "Directory that will be exported as XDG_STATE_HOME.";
+    };
+
+    environment = mkOption {
+      type = types.attrsOf types.str;
+      default = {};
+      description = "Environment variables applied to all targets.";
+    };
+
+    targets = mkOption {
+      type = targetsOption;
+      default = lib.genAttrs (attrNames targetData) (_: {});
+      description = "Automation target configuration keyed by target name.";
+      example = {
+        codex = {
+          enable = true;
+          outputDir = "/var/lib/polylogue/codex";
+          timer.interval = "10m";
+        };
+        "drive-sync" = {
+          enable = true;
+          outputDir = "/var/lib/polylogue/gemini-sync";
+          extraArgs = [ "--folder-name" "AI Studio" ];
+        };
+      };
+    };
+  };
+
+  config = mkIf cfg.enable (
+    mkMerge (
+      [
+        mkMerge (lib.mapAttrsToList mkServiceFor activeTargets)
+        { systemd.tmpfiles.rules = tmpfilesRules; }
+      ]
+    )
+  );
+}

--- a/polylogue/automation.py
+++ b/polylogue/automation.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import sys
+import json
+from dataclasses import dataclass, field
+from importlib import resources
+from pathlib import Path
+from textwrap import dedent
+from typing import Dict, Iterable, List, Optional
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT_PATH = REPO_ROOT / "polylogue.py"
+
+
+@dataclass
+class AutomationTarget:
+    name: str
+    description: str
+    command: List[str]
+    defaults: Dict[str, Any] = field(default_factory=dict)
+
+
+def _load_targets() -> Dict[str, AutomationTarget]:
+    data = json.loads(resources.files(__package__).joinpath("automation_targets.json").read_text())
+    return {key: AutomationTarget(**value) for key, value in data.items()}
+
+
+TARGETS = _load_targets()
+
+
+def resolve_target(target: str) -> AutomationTarget:
+    try:
+        return TARGETS[target]
+    except KeyError as exc:  # pragma: no cover - defensive
+        raise ValueError(f"Unsupported automation target: {target}") from exc
+
+
+def build_command(target: AutomationTarget, extra_args: Iterable[str]) -> str:
+    parts = [sys.executable, str(SCRIPT_PATH)] + target.command + list(extra_args)
+    return " ".join(parts)
+
+
+def describe_targets(target: Optional[str] = None) -> Dict[str, Dict[str, object]]:
+    if target is not None:
+        tgt = resolve_target(target)
+        return {target: {
+            "name": tgt.name,
+            "description": tgt.description,
+            "command": tgt.command,
+            "defaults": tgt.defaults,
+        }}
+    return {
+        key: {
+            "name": value.name,
+            "description": value.description,
+            "command": value.command,
+            "defaults": value.defaults,
+        }
+        for key, value in TARGETS.items()
+    }
+
+
+def _merge_args(
+    target: AutomationTarget,
+    user_extra: Iterable[str],
+    collapse_threshold: Optional[int],
+    html: Optional[bool],
+) -> List[str]:
+    defaults = target.defaults or {}
+    user_list = list(user_extra)
+    args = list(defaults.get("extraArgs", []))
+    args.extend(user_list)
+
+    if collapse_threshold is not None:
+        if "--collapse-threshold" not in args:
+            args.extend(["--collapse-threshold", str(collapse_threshold)])
+    else:
+        default_collapse = defaults.get("collapseThreshold")
+        if default_collapse is not None and "--collapse-threshold" not in args:
+            args.extend(["--collapse-threshold", str(default_collapse)])
+
+    user_requested_html = "--html" in user_list
+    html_pref: Optional[bool]
+    if html is None:
+        if user_requested_html:
+            html_pref = True
+        else:
+            html_pref = defaults.get("html")
+    else:
+        html_pref = html
+
+    if html_pref:
+        if "--html" not in args:
+            args.append("--html")
+    else:
+        args = [flag for flag in args if flag != "--html"]
+
+    return args
+
+
+def prepare_automation_command(
+    target_key: str,
+    *,
+    user_extra: Iterable[str],
+    collapse_threshold: Optional[int],
+    html: Optional[bool],
+) -> Tuple[AutomationTarget, List[str]]:
+    target = resolve_target(target_key)
+    merged = _merge_args(target, user_extra, collapse_threshold, html)
+    return target, merged
+
+
+def systemd_snippet(
+    *,
+    target_key: str,
+    interval: str,
+    working_dir: Path,
+    extra_args: Iterable[str] = (),
+    boot_delay: str = "2m",
+    collapse_threshold: Optional[int] = None,
+    html: Optional[bool] = None,
+) -> str:
+    target, merged_args = prepare_automation_command(
+        target_key,
+        user_extra=extra_args,
+        collapse_threshold=collapse_threshold,
+        html=html,
+    )
+    service_name = target.name
+    command = build_command(target, merged_args)
+    service = dedent(
+        f"""# ~/.config/systemd/user/{service_name}.service
+[Unit]
+Description={target.description}
+
+[Service]
+Type=oneshot
+WorkingDirectory={working_dir}
+ExecStart={command}
+"""
+    ).strip()
+
+    timer = dedent(
+        f"""# ~/.config/systemd/user/{service_name}.timer
+[Unit]
+Description={target.description} timer
+
+[Timer]
+OnBootSec={boot_delay}
+OnUnitActiveSec={interval}
+Persistent=true
+
+[Install]
+WantedBy=default.target
+"""
+    ).strip()
+
+    return f"{service}\n\n{timer}\n"
+
+
+def cron_snippet(
+    *,
+    target_key: str,
+    schedule: str,
+    working_dir: Path,
+    log_path: str,
+    extra_args: Iterable[str] = (),
+    state_env: str = '$HOME/.local/state',
+    collapse_threshold: Optional[int] = None,
+    html: Optional[bool] = None,
+) -> str:
+    target, merged_args = prepare_automation_command(
+        target_key,
+        user_extra=extra_args,
+        collapse_threshold=collapse_threshold,
+        html=html,
+    )
+    command = build_command(target, merged_args)
+    snippet = (
+        f"{schedule} XDG_STATE_HOME=\"{state_env}\" cd {working_dir} && {command} >> \"{log_path}\" 2>&1"
+    )
+    return snippet + "\n"

--- a/polylogue/automation_targets.json
+++ b/polylogue/automation_targets.json
@@ -1,0 +1,52 @@
+{
+  "codex": {
+    "name": "polylogue-sync-codex",
+    "description": "Polylogue Codex sync",
+    "command": ["sync-codex", "--plain", "--json"],
+    "defaults": {
+      "collapseThreshold": 24,
+      "extraArgs": [],
+      "html": false
+    }
+  },
+  "claude-code": {
+    "name": "polylogue-sync-claude-code",
+    "description": "Polylogue Claude Code sync",
+    "command": ["sync-claude-code", "--plain", "--json"],
+    "defaults": {
+      "collapseThreshold": 20,
+      "extraArgs": [],
+      "html": false
+    }
+  },
+  "drive-sync": {
+    "name": "polylogue-sync-drive",
+    "description": "Polylogue Drive folder sync",
+    "command": ["sync", "--plain", "--json"],
+    "defaults": {
+      "collapseThreshold": 16,
+      "extraArgs": ["--folder-name", "AI Studio"],
+      "html": false
+    }
+  },
+  "gemini-render": {
+    "name": "polylogue-render-gemini",
+    "description": "Polylogue Gemini render",
+    "command": ["render", "--plain", "--json"],
+    "defaults": {
+      "collapseThreshold": 16,
+      "extraArgs": [],
+      "html": false
+    }
+  },
+  "chatgpt-import": {
+    "name": "polylogue-import-chatgpt",
+    "description": "Polylogue ChatGPT import",
+    "command": ["import", "chatgpt", "--plain", "--json"],
+    "defaults": {
+      "collapseThreshold": 18,
+      "extraArgs": [],
+      "html": false
+    }
+  }
+}

--- a/polylogue/document_store.py
+++ b/polylogue/document_store.py
@@ -1,0 +1,416 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+try:  # pragma: no cover - optional dependency
+    import frontmatter  # type: ignore
+except Exception:  # pragma: no cover
+    frontmatter = None  # type: ignore
+
+from .render import AttachmentInfo, MarkdownDocument, build_markdown_from_chunks
+from .util import (
+    assign_conversation_slug,
+    conversation_is_current,
+    current_utc_timestamp,
+    get_conversation_state,
+    sanitize_filename,
+    update_conversation_state,
+)
+from .index import update_index
+
+
+@dataclass
+class ExistingDocument:
+    metadata: Dict[str, Any]
+    body: str
+    body_hash: str
+
+
+@dataclass
+class DocumentPersistenceResult:
+    markdown_path: Path
+    html_path: Optional[Path]
+    attachments_dir: Optional[Path]
+    document: Optional[MarkdownDocument]
+    slug: str
+    skipped: bool
+    skip_reason: Optional[str]
+    dirty: bool
+    content_hash: Optional[str]
+
+
+def _parse_front_matter(text: str) -> Tuple[Dict[str, Any], str]:
+    if frontmatter is not None:  # pragma: no branch
+        post = frontmatter.loads(text)
+        return dict(post.metadata), post.content
+    if not text.startswith("---\n"):
+        return {}, text
+    # Minimal YAML parser for key: value pairs.
+    lines = text.splitlines()
+    meta_lines: List[str] = []
+    i = 1
+    while i < len(lines):
+        if lines[i].strip() == "---":
+            i += 1
+            break
+        meta_lines.append(lines[i])
+        i += 1
+    body = "\n".join(lines[i:])
+    metadata: Dict[str, Any] = {}
+    for raw in meta_lines:
+        parts = raw.split(":", 1)
+        if len(parts) != 2:
+            continue
+        key = parts[0].strip()
+        value = parts[1].strip()
+        if value.startswith("\"") and value.endswith("\""):
+            metadata[key] = value[1:-1]
+        elif value.lower() in {"true", "false"}:
+            metadata[key] = value.lower() == "true"
+        else:
+            try:
+                metadata[key] = json.loads(value)
+            except Exception:
+                metadata[key] = value
+    return metadata, body
+
+
+def _dump_front_matter(metadata: Dict[str, Any], body: str) -> str:
+    if frontmatter is not None:
+        post = frontmatter.Post(body, **metadata)
+        return frontmatter.dumps(post)
+    header_lines = ["---"]
+    for key, value in metadata.items():
+        if isinstance(value, (dict, list)):
+            encoded = json.dumps(value, ensure_ascii=False)
+        elif isinstance(value, bool):
+            encoded = "true" if value else "false"
+        else:
+            encoded = json.dumps(value)
+        header_lines.append(f"{key}: {encoded}")
+    header_lines.append("---\n")
+    return "\n".join(header_lines) + body
+
+
+def read_existing_document(path: Path) -> Optional[ExistingDocument]:
+    if not path.exists():
+        return None
+    try:
+        text = path.read_text(encoding="utf-8")
+    except Exception:
+        return None
+    metadata, body = _parse_front_matter(text)
+    body_hash = hashlib.sha256(body.encode("utf-8")).hexdigest()
+    return ExistingDocument(metadata=metadata, body=body, body_hash=body_hash)
+
+
+def _write_markdown(path: Path, metadata: Dict[str, Any], body: str) -> None:
+    payload = _dump_front_matter(metadata, body)
+    path.write_text(payload, encoding="utf-8")
+
+
+def _default_attachment_policy() -> Dict[str, Any]:
+    from .importers.utils import CHAR_THRESHOLD, LINE_THRESHOLD, PREVIEW_LINES
+
+    return {
+        "previewLines": PREVIEW_LINES,
+        "lineThreshold": LINE_THRESHOLD,
+        "charThreshold": CHAR_THRESHOLD,
+    }
+
+
+def _attachment_policy_with_counts(
+    base_policy: Dict[str, Any],
+    attachments: List[AttachmentInfo],
+) -> Dict[str, Any]:
+    extracted = sum(1 for info in attachments if not info.remote and info.local_path is not None)
+    enriched = dict(base_policy)
+    enriched["extractedCount"] = extracted
+    return enriched
+
+
+def prepare_document(
+    *,
+    chunks: List[Dict[str, Any]],
+    per_chunk_links: Dict[int, List[Tuple[str, Union[Path, str]]]],
+    title: str,
+    collapse_threshold: int,
+    attachments: Optional[List[AttachmentInfo]] = None,
+    source_file_id: Optional[str] = None,
+    modified_time: Optional[str] = None,
+    created_time: Optional[str] = None,
+    run_settings: Optional[Dict[str, Any]] = None,
+    citations: Optional[List[Any]] = None,
+    source_mime: Optional[str] = None,
+    source_size: Optional[int] = None,
+    extra_yaml: Optional[Dict[str, Any]] = None,
+) -> MarkdownDocument:
+    return build_markdown_from_chunks(
+        chunks,
+        per_chunk_links,
+        title=title,
+        source_file_id=source_file_id,
+        modified_time=modified_time,
+        created_time=created_time,
+        run_settings=run_settings,
+        citations=citations,
+        source_mime=source_mime,
+        source_size=source_size,
+        collapse_threshold=collapse_threshold,
+        extra_yaml=extra_yaml,
+        attachments=attachments,
+    )
+
+
+def _ensure_polylogue_metadata(metadata: Dict[str, Any]) -> Dict[str, Any]:
+    data = dict(metadata)
+    polylogue = data.get("polylogue")
+    if not isinstance(polylogue, dict):
+        polylogue = {}
+    data["polylogue"] = polylogue
+    return data
+
+
+def persist_document(
+    *,
+    provider: Optional[str],
+    conversation_id: Optional[str],
+    title: str,
+    document: MarkdownDocument,
+    output_dir: Path,
+    collapse_threshold: int,
+    attachments: List[AttachmentInfo],
+    updated_at: Optional[str],
+    created_at: Optional[str],
+    html: bool,
+    html_theme: Optional[str],
+    attachment_policy: Optional[Dict[str, Any]] = None,
+    extra_state: Optional[Dict[str, Any]] = None,
+    slug_hint: Optional[str] = None,
+    id_hint: Optional[str] = None,
+    force: bool = False,
+) -> DocumentPersistenceResult:
+    if slug_hint:
+        slug = slug_hint
+    elif provider and conversation_id:
+        slug = assign_conversation_slug(provider, conversation_id, title, id_hint=id_hint)
+    else:
+        base = sanitize_filename(slug_hint or title)
+        slug = base or "document"
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    markdown_path = output_dir / f"{slug}.md"
+    attachments_dir = output_dir / f"{slug}_attachments"
+    html_path = markdown_path.with_suffix(".html") if html else None
+
+    state_entry: Optional[Dict[str, Any]] = None
+    if provider and conversation_id:
+        state_entry = get_conversation_state(provider, conversation_id)
+
+    existing = read_existing_document(markdown_path)
+    stored_hash = (state_entry or {}).get("contentHash")
+    existing_dirty = False
+    if existing and stored_hash and existing.body_hash != stored_hash:
+        existing_dirty = True
+
+    policy = _attachment_policy_with_counts(
+        attachment_policy or _default_attachment_policy(),
+        attachments,
+    )
+
+    content_hash = hashlib.sha256(document.body.encode("utf-8")).hexdigest()
+
+    if provider and conversation_id and existing_dirty and state_entry and not force:
+        remote_same = True
+        if updated_at and state_entry.get("lastUpdated") and state_entry["lastUpdated"] != updated_at:
+            remote_same = False
+        if state_entry.get("contentHash") and state_entry["contentHash"] != content_hash:
+            remote_same = False
+        if remote_same and existing:
+            dirty_meta = _ensure_polylogue_metadata(existing.metadata)
+            polylogue = dirty_meta.get("polylogue", {})
+            polylogue.update(
+                {
+                    "title": polylogue.get("title") or title,
+                    "slug": polylogue.get("slug") or slug,
+                    "provider": provider,
+                    "conversationId": conversation_id,
+                    "collapseThreshold": collapse_threshold,
+                    "attachmentPolicy": policy,
+                    "updatedAt": updated_at,
+                    "createdAt": created_at,
+                    "html": html,
+                    "attachmentsDir": polylogue.get("attachmentsDir") or (str(attachments_dir) if attachments else None),
+                    "htmlPath": polylogue.get("htmlPath"),
+                    "contentHash": state_entry.get("contentHash") or content_hash,
+                    "localHash": existing.body_hash,
+                    "dirty": True,
+                }
+            )
+            dirty_meta["polylogue"] = polylogue
+            _write_markdown(markdown_path, dirty_meta, existing.body)
+            html_state_path = state_entry.get("htmlPath")
+            html_existing_path = Path(html_state_path) if isinstance(html_state_path, str) else None
+            attach_state_path = state_entry.get("attachmentsDir")
+            attachments_existing_path = (
+                Path(attach_state_path) if isinstance(attach_state_path, str) else None
+            )
+            update_conversation_state(
+                provider,
+                conversation_id,
+                slug=slug,
+                title=title,
+                lastUpdated=updated_at,
+                contentHash=state_entry.get("contentHash") or content_hash,
+                collapseThreshold=collapse_threshold,
+                attachmentPolicy=policy,
+                outputPath=str(markdown_path),
+                htmlPath=html_state_path,
+                attachmentsDir=attach_state_path,
+                html=state_entry.get("html", html),
+                dirty=True,
+                localHash=existing.body_hash,
+            )
+            return DocumentPersistenceResult(
+                markdown_path=markdown_path,
+                html_path=html_existing_path,
+                attachments_dir=attachments_existing_path,
+                document=None,
+                slug=slug,
+                skipped=True,
+                skip_reason="dirty-local",
+                dirty=True,
+                content_hash=state_entry.get("contentHash") or content_hash,
+            )
+
+    can_skip = False
+    if provider and conversation_id and not force:
+        can_skip = conversation_is_current(
+            provider,
+            conversation_id,
+            updated_at=updated_at,
+            content_hash=content_hash,
+            output_path=markdown_path,
+            collapse_threshold=collapse_threshold,
+            attachment_policy=policy,
+            html=html,
+            dirty=existing_dirty,
+        )
+
+    if can_skip:
+        html_existing: Optional[Path] = None
+        attachments_existing: Optional[Path] = None
+        if state_entry:
+            html_entry = state_entry.get("htmlPath")
+            if isinstance(html_entry, str):
+                html_existing = Path(html_entry)
+            attach_entry = state_entry.get("attachmentsDir")
+            if isinstance(attach_entry, str):
+                attachments_existing = Path(attach_entry)
+        if html_existing is None and html:
+            html_existing = html_path
+        if attachments_existing is None and attachments:
+            attachments_existing = attachments_dir
+        return DocumentPersistenceResult(
+            markdown_path=markdown_path,
+            html_path=html_existing,
+            attachments_dir=attachments_existing,
+            document=None,
+            slug=slug,
+            skipped=True,
+            skip_reason="up-to-date",
+            dirty=existing_dirty,
+            content_hash=content_hash,
+        )
+
+    metadata = _ensure_polylogue_metadata(document.metadata)
+    polylogue_meta = metadata.get("polylogue", {})
+    polylogue_meta.update(
+        {
+            "title": title,
+            "slug": slug,
+            "collapseThreshold": collapse_threshold,
+            "attachmentPolicy": policy,
+            "updatedAt": updated_at,
+            "createdAt": created_at,
+            "html": html,
+            "contentHash": content_hash,
+            "lastImported": current_utc_timestamp(),
+            "attachmentsDir": str(attachments_dir) if attachments else None,
+            "dirty": False,
+        }
+    )
+    if html_path and html:
+        polylogue_meta["htmlPath"] = str(html_path)
+    if provider:
+        polylogue_meta["provider"] = provider
+    if conversation_id:
+        polylogue_meta["conversationId"] = conversation_id
+    if extra_state:
+        for key, value in extra_state.items():
+            if value is not None:
+                polylogue_meta[key] = value
+    metadata["polylogue"] = polylogue_meta
+    document.metadata = metadata
+
+    markdown_path.write_text(document.to_markdown(), encoding="utf-8")
+
+    if html:
+        from .html import write_html
+
+        write_html(document, html_path, html_theme)
+    else:
+        html_path = None
+
+    if not attachments:
+        try:
+            attachments_dir.rmdir()
+        except OSError:
+            pass
+
+    if provider and conversation_id:
+        state_payload = {
+            "slug": slug,
+            "title": title,
+            "lastUpdated": updated_at,
+            "lastImported": polylogue_meta.get("lastImported"),
+            "contentHash": content_hash,
+            "collapseThreshold": collapse_threshold,
+            "attachmentPolicy": policy,
+            "outputPath": str(markdown_path),
+            "htmlPath": str(html_path) if html_path else None,
+            "attachmentsDir": str(attachments_dir) if attachments else None,
+            "html": html,
+            "dirty": False,
+        }
+        if extra_state:
+            state_payload.update({k: v for k, v in extra_state.items() if v is not None})
+        update_conversation_state(provider, conversation_id, **state_payload)
+
+        try:  # pragma: no cover - indexing failures shouldn't abort writes
+            update_index(
+                provider=provider,
+                conversation_id=conversation_id,
+                slug=slug,
+                path=markdown_path,
+                document=document,
+                metadata=polylogue_meta,
+            )
+        except Exception:
+            pass
+
+    return DocumentPersistenceResult(
+        markdown_path=markdown_path,
+        html_path=html_path,
+        attachments_dir=attachments_dir if attachments else None,
+        document=document,
+        slug=slug,
+        skipped=False,
+        skip_reason=None,
+        dirty=False,
+        content_hash=content_hash,
+    )

--- a/polylogue/importers/base.py
+++ b/polylogue/importers/base.py
@@ -16,3 +16,5 @@ class ImportResult:
     diff_path: Optional[Path] = None
     skipped: bool = False
     skip_reason: Optional[str] = None
+    dirty: bool = False
+    content_hash: Optional[str] = None

--- a/polylogue/importers/base.py
+++ b/polylogue/importers/base.py
@@ -12,5 +12,7 @@ class ImportResult:
     markdown_path: Path
     html_path: Optional[Path]
     attachments_dir: Optional[Path]
-    document: MarkdownDocument
+    document: Optional[MarkdownDocument]
     diff_path: Optional[Path] = None
+    skipped: bool = False
+    skip_reason: Optional[str] = None

--- a/polylogue/importers/chatgpt.py
+++ b/polylogue/importers/chatgpt.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import zipfile
 from dataclasses import dataclass
@@ -8,7 +9,13 @@ from tempfile import TemporaryDirectory
 from typing import Dict, Iterable, List, Optional, Tuple
 
 from ..render import AttachmentInfo, MarkdownDocument, build_markdown_from_chunks
-from ..util import sanitize_filename
+from ..util import (
+    assign_conversation_slug,
+    conversation_is_current,
+    get_conversation_state,
+    current_utc_timestamp,
+    update_conversation_state,
+)
 from .base import ImportResult
 from .utils import estimate_token_count, store_large_text
 
@@ -197,9 +204,41 @@ def _render_chatgpt_conversation(
 ) -> ImportResult:
     title = conv.get("title") or "chatgpt-conversation"
     conv_id = conv.get("id") or conv.get("conversation_id") or "chat"
-    safe_name = sanitize_filename(f"{title}-{conv_id[:8]}")
-    markdown_path = output_dir / f"{safe_name}.md"
-    attachments_dir = markdown_path.parent / f"{markdown_path.stem}_attachments"
+    slug = assign_conversation_slug("chatgpt", conv_id, title, id_hint=conv_id[:8])
+    markdown_path = output_dir / f"{slug}.md"
+    attachments_dir = markdown_path.parent / f"{slug}_attachments"
+
+    state_entry = get_conversation_state("chatgpt", conv_id)
+    existing_html: Optional[Path] = None
+    existing_attachments_dir: Optional[Path] = None
+    if state_entry:
+        html_candidate = state_entry.get("htmlPath")
+        if html_candidate:
+            html_path = Path(html_candidate)
+            if html_path.exists():
+                existing_html = html_path
+        attach_candidate = state_entry.get("attachmentsDir")
+        if attach_candidate:
+            attach_path = Path(attach_candidate)
+            if attach_path.exists():
+                existing_attachments_dir = attach_path
+
+    updated_at = conv.get("update_time") or conv.get("modified_time")
+    if conversation_is_current(
+        "chatgpt",
+        conv_id,
+        updated_at=updated_at,
+        content_hash=None,
+        output_path=markdown_path,
+    ):
+        return ImportResult(
+            markdown_path=markdown_path,
+            html_path=existing_html,
+            attachments_dir=existing_attachments_dir,
+            document=None,
+            skipped=True,
+            skip_reason="up-to-date",
+        )
 
     chunks: List[Dict] = []
     attachments: List[AttachmentInfo] = []
@@ -288,6 +327,20 @@ def _render_chatgpt_conversation(
             attachments_dir = None
         except OSError:
             pass
+
+    content_hash = hashlib.sha256(document.body.encode("utf-8")).hexdigest()
+    update_conversation_state(
+        "chatgpt",
+        conv_id,
+        slug=slug,
+        lastUpdated=updated_at,
+        contentHash=content_hash,
+        outputPath=str(markdown_path),
+        htmlPath=str(html_path) if html_path else (state_entry.get("htmlPath") if state_entry else None),
+        attachmentsDir=str(attachments_dir) if attachments_dir else (state_entry.get("attachmentsDir") if state_entry else None),
+        title=title,
+        lastImported=current_utc_timestamp(),
+    )
 
     return ImportResult(
         markdown_path=markdown_path,

--- a/polylogue/index.py
+++ b/polylogue/index.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, Dict
+
+from .render import MarkdownDocument
+
+
+def update_index(
+    *,
+    provider: str,
+    conversation_id: str,
+    slug: str,
+    path: Path,
+    document: MarkdownDocument,
+    metadata: Dict[str, Any],
+) -> None:
+    backend = os.environ.get("POLYLOGUE_INDEX_BACKEND", "sqlite").strip().lower()
+    if backend in ("", "sqlite"):
+        from .index_sqlite import update_sqlite_index
+
+        update_sqlite_index(
+            provider=provider,
+            conversation_id=conversation_id,
+            slug=slug,
+            path=path,
+            document=document,
+            metadata=metadata,
+        )
+        return
+    if backend in ("none", "disabled"):
+        return
+    if backend == "qdrant":
+        try:
+            from .index_qdrant import update_qdrant_index
+        except ImportError:  # pragma: no cover - optional dependency
+            return
+        update_qdrant_index(
+            provider=provider,
+            conversation_id=conversation_id,
+            slug=slug,
+            path=path,
+            document=document,
+            metadata=metadata,
+        )
+        return
+    raise ValueError(f"Unknown POLYLOGUE_INDEX_BACKEND '{backend}'")

--- a/polylogue/index_qdrant.py
+++ b/polylogue/index_qdrant.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import os
+from typing import Any, Dict
+
+from .render import MarkdownDocument
+
+
+def update_qdrant_index(
+    *,
+    provider: str,
+    conversation_id: str,
+    slug: str,
+    path,
+    document: MarkdownDocument,
+    metadata: Dict[str, Any],
+) -> None:
+    url = os.environ.get("POLYLOGUE_QDRANT_URL")
+    if not url:  # pragma: no cover - requires external service
+        return
+    collection = os.environ.get("POLYLOGUE_QDRANT_COLLECTION", "polylogue")
+    size = int(os.environ.get("POLYLOGUE_QDRANT_VECTOR_SIZE", "1"))
+    api_key = os.environ.get("POLYLOGUE_QDRANT_API_KEY")
+
+    try:  # pragma: no cover - optional dependency
+        from qdrant_client import QdrantClient
+        from qdrant_client.http import models as rest
+    except Exception:
+        return
+
+    client = QdrantClient(url=url, api_key=api_key)
+    try:
+        client.get_collection(collection)
+    except Exception:
+        client.recreate_collection(
+            collection_name=collection,
+            vectors_config=rest.VectorParams(size=size, distance=rest.Distance.COSINE),
+        )
+
+    metric = float(document.stats.get("totalTokensApprox", 0) or len(document.body))
+    vector = [metric] + [0.0] * max(0, size - 1)
+
+    payload = {
+        "provider": provider,
+        "conversation_id": conversation_id,
+        "slug": slug,
+        "path": str(path),
+        "title": document.metadata.get("title"),
+        "updated_at": metadata.get("updatedAt"),
+        "tokens": document.stats.get("totalTokensApprox"),
+        "content": document.body,
+    }
+
+    point_id = f"{provider}:{conversation_id}"
+    client.upsert(
+        collection_name=collection,
+        points=[
+            rest.PointStruct(
+                id=point_id,
+                vector=vector,
+                payload=payload,
+            )
+        ],
+    )

--- a/polylogue/index_sqlite.py
+++ b/polylogue/index_sqlite.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from typing import Any, Dict
+
+from .render import MarkdownDocument
+from .util import STATE_HOME
+
+
+def _db_path() -> Path:
+    return STATE_HOME / "index.sqlite"
+
+
+def _ensure_schema(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS conversations (
+            provider TEXT NOT NULL,
+            conversation_id TEXT NOT NULL,
+            slug TEXT NOT NULL,
+            path TEXT NOT NULL,
+            title TEXT,
+            updated_at TEXT,
+            content_hash TEXT,
+            tokens INTEGER,
+            dirty INTEGER,
+            metadata_json TEXT,
+            PRIMARY KEY(provider, conversation_id)
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE VIRTUAL TABLE IF NOT EXISTS conversations_fts
+        USING fts5(provider, conversation_id, title, content)
+        """
+    )
+
+
+def update_sqlite_index(
+    *,
+    provider: str,
+    conversation_id: str,
+    slug: str,
+    path: Path,
+    document: MarkdownDocument,
+    metadata: Dict[str, Any],
+) -> None:
+    db_path = _db_path()
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    try:
+        _ensure_schema(conn)
+        content = document.body
+        title = document.metadata.get("title")
+        tokens = document.stats.get("totalTokensApprox") or 0
+        dirty = bool(metadata.get("dirty"))
+        content_hash = metadata.get("contentHash")
+        updated_at = metadata.get("updatedAt")
+        metadata_json = json.dumps(metadata, ensure_ascii=False)
+
+        conn.execute(
+            """
+            INSERT INTO conversations (provider, conversation_id, slug, path, title, updated_at, content_hash, tokens, dirty, metadata_json)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(provider, conversation_id) DO UPDATE SET
+                slug=excluded.slug,
+                path=excluded.path,
+                title=excluded.title,
+                updated_at=excluded.updated_at,
+                content_hash=excluded.content_hash,
+                tokens=excluded.tokens,
+                dirty=excluded.dirty,
+                metadata_json=excluded.metadata_json
+            """,
+            (
+                provider,
+                conversation_id,
+                slug,
+                str(path),
+                title,
+                updated_at,
+                content_hash,
+                int(tokens),
+                int(dirty),
+                metadata_json,
+            ),
+        )
+        conn.execute(
+            "DELETE FROM conversations_fts WHERE provider = ? AND conversation_id = ?",
+            (provider, conversation_id),
+        )
+        conn.execute(
+            "INSERT INTO conversations_fts(provider, conversation_id, title, content) VALUES (?, ?, ?, ?)",
+            (provider, conversation_id, title or "", content),
+        )
+        conn.commit()
+    finally:
+        conn.close()

--- a/polylogue/options.py
+++ b/polylogue/options.py
@@ -48,7 +48,9 @@ class ListOptions:
 
 @dataclass
 class StatusOptions:
-    pass
+    json: bool = False
+    watch: bool = False
+    interval: float = 5.0
 
 
 @dataclass
@@ -104,3 +106,4 @@ class StatusResult:
     runs_path: Path
     recent_runs: List[dict]
     run_summary: Dict[str, Any]
+    provider_summary: Dict[str, Any]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,37 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "polylogue"
+version = "0.1.0"
+description = "Polylogue CLI for AI chat archives"
+readme = "README.md"
+authors = [{ name = "Polylogue Maintainers" }]
+requires-python = ">=3.10"
+dependencies = [
+  "google-api-python-client",
+  "google-auth-oauthlib",
+  "google-auth-httplib2",
+  "pathvalidate",
+  "aiohttp",
+  "aiofiles",
+  "google-generativeai",
+  "rich",
+  "pydantic",
+  "python-frontmatter",
+  "jinja2",
+  "markdown-it-py",
+  "pyperclip",
+  "watchfiles",
+]
+
+[project.scripts]
+polylogue = "polylogue.cli:main"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["polylogue"]
+
+[tool.setuptools.package-data]
+polylogue = ["automation_targets.json"]

--- a/tests/test_automation_snippets.py
+++ b/tests/test_automation_snippets.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import json
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from polylogue.automation import SCRIPT_PATH, cron_snippet, describe_targets, systemd_snippet
+from polylogue.cli import run_automation_cli
+from polylogue.commands import CommandEnv
+
+
+class DummyConsole:
+    def print(self, *args, **kwargs):  # pragma: no cover - not needed
+        pass
+
+
+class DummyUI:
+    plain = True
+    console = DummyConsole()
+
+
+def test_systemd_snippet_includes_paths(tmp_path):
+    snippet = systemd_snippet(
+        target_key="codex",
+        interval="15m",
+        working_dir=tmp_path,
+        extra_args=["--out", str(tmp_path / "out")],
+        boot_delay="1m",
+    )
+    assert "polylogue-sync-codex.service" in snippet
+    assert str(SCRIPT_PATH) in snippet
+    assert f"WorkingDirectory={tmp_path}" in snippet
+    assert "OnUnitActiveSec=15m" in snippet
+    assert "--collapse-threshold 24" in snippet
+    assert "--out" in snippet and str(tmp_path / "out") in snippet
+
+
+def test_cron_snippet_default_schedule(tmp_path):
+    log_path = "/tmp/polylogue-test.log"
+    snippet = cron_snippet(
+        target_key="claude-code",
+        schedule="*/20 * * * *",
+        working_dir=tmp_path,
+        log_path=log_path,
+        extra_args=["--html"],
+        state_env="$HOME/.local/state",
+    )
+    assert snippet.startswith("*/20 * * * * ")
+    assert f"cd {tmp_path}" in snippet
+    assert log_path in snippet
+    assert "--html" in snippet
+    assert "--collapse-threshold 20" in snippet
+
+
+def test_describe_targets_roundtrip():
+    data = describe_targets()
+    assert "codex" in data and "claude-code" in data and "drive-sync" in data and "gemini-render" in data
+    codex = describe_targets("codex")
+    assert list(codex.keys()) == ["codex"]
+    assert codex["codex"]["command"][0] == "sync-codex"
+    drive = describe_targets("drive-sync")
+    assert drive["drive-sync"]["command"][0] == "sync"
+
+
+def test_run_automation_cli_systemd(capsys, tmp_path):
+    args = SimpleNamespace(
+        automation_format="systemd",
+        target="drive-sync",
+        interval="10m",
+        boot_delay="1m",
+        working_dir=str(tmp_path),
+        out=str(tmp_path / "out"),
+        extra_arg=["--plain"],
+        collapse_threshold=20,
+        html=True,
+    )
+    run_automation_cli(args, CommandEnv(ui=DummyUI()))
+    output = capsys.readouterr().out
+    assert "polylogue-sync-drive.service" in output
+    assert "--collapse-threshold 20" in output
+    assert "--html" in output
+    assert "--folder-name AI Studio" in output
+    assert "--plain" in output
+
+
+def test_run_automation_cli_describe(capsys):
+    args = SimpleNamespace(
+        automation_format="describe",
+        target="codex",
+        working_dir=None,
+        out=None,
+        extra_arg=[],
+        collapse_threshold=None,
+        html=False,
+        interval=5,
+        boot_delay=2,
+    )
+    run_automation_cli(args, CommandEnv(ui=DummyUI()))
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["codex"]["command"][0] == "sync-codex"
+    assert "defaults" in payload["codex"]

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import json
+import pytest
+
+from polylogue.commands import CommandEnv, status_command
+from polylogue import commands as cmd_module
+from polylogue import util
+
+
+class DummyConsole:
+    def print(self, *args, **kwargs):
+        pass
+
+
+class DummyUI:
+    plain = True
+    console = DummyConsole()
+
+
+def _patch_state(monkeypatch, tmp_path):
+    state_home = tmp_path / "state"
+    monkeypatch.setenv("XDG_STATE_HOME", str(state_home))
+    new_home = state_home / "polylogue"
+    state_path = new_home / "state.json"
+    runs_path = new_home / "runs.json"
+    monkeypatch.setattr(util, "STATE_HOME", new_home, raising=False)
+    monkeypatch.setattr(util, "STATE_PATH", state_path, raising=False)
+    monkeypatch.setattr(util, "RUNS_PATH", runs_path, raising=False)
+    monkeypatch.setattr(cmd_module, "STATE_PATH", state_path, raising=False)
+    monkeypatch.setattr(cmd_module, "RUNS_PATH", runs_path, raising=False)
+    return new_home
+
+
+@pytest.fixture
+def patched_state(tmp_path, monkeypatch):
+    return _patch_state(monkeypatch, tmp_path)
+
+
+def test_status_provider_summary(patched_state):
+    runs = [
+        {
+            "cmd": "sync",
+            "count": 1,
+            "attachments": 2,
+            "attachmentBytes": 2048,
+            "tokens": 120,
+            "skipped": 0,
+            "pruned": 0,
+            "diffs": 0,
+            "duration": 1.25,
+            "timestamp": "2024-01-01T00:00:00Z",
+            "out": "/tmp/drive",
+        },
+        {
+            "cmd": "codex-watch",
+            "count": 2,
+            "attachments": 3,
+            "attachmentBytes": 4096,
+            "tokens": 220,
+            "skipped": 1,
+            "pruned": 0,
+            "diffs": 1,
+            "duration": 2.5,
+            "timestamp": "2024-01-02T00:00:00Z",
+            "out": "/tmp/codex",
+        },
+    ]
+    util.RUNS_PATH.parent.mkdir(parents=True, exist_ok=True)
+    util.RUNS_PATH.write_text(json.dumps(runs), encoding="utf-8")
+
+    env = CommandEnv(ui=DummyUI())
+    result = status_command(env)
+
+    assert "drive-sync" in result.provider_summary
+    assert result.provider_summary["drive-sync"]["count"] == 1
+    assert result.provider_summary["drive-sync"]["commands"] == ["sync"]
+    assert result.provider_summary["drive-sync"]["duration"] > 0
+    assert "codex" in result.provider_summary
+    assert result.provider_summary["codex"]["count"] == 2
+    assert "codex-watch" in result.provider_summary["codex"]["commands"]
+    assert result.run_summary["sync"]["duration"] > 0


### PR DESCRIPTION
## Summary

Adds the infrastructure needed for Polylogue to run unattended: a document persistence layer that makes reruns idempotent, file watchers for continuous sync, systemd/cron snippet generation from a shared target registry, and a NixOS module that wires everything into declarative timers. Every successful write now also updates a local SQLite FTS index so downstream tooling can query metadata without reparsing Markdown.

## Motivation

Up to this point, every `polylogue import` or `polylogue sync` run rewrites all output files unconditionally. That means:

- Cron jobs waste IO rewriting identical files, and git repos accumulate no-op diffs
- Users who hand-edit rendered Markdown lose their changes silently on the next run
- There's no single place to check whether a conversation has already been processed
- Setting up unattended sync requires manually writing systemd units or cron entries, duplicating CLI flag knowledge

The persistence layer solves the first three problems; the automation framework and NixOS module solve the fourth.

I considered adding skip logic directly in each importer, but the duplication was already bad — four importers plus render and sync all had near-identical write-then-optionally-HTML-then-optionally-diff sequences. Extracting `persist_document()` as a shared function was the natural consolidation point, and it gave a clean place to hang content hashing, dirty detection, and index updates.

## Document persistence (`document_store.py`)

The core abstraction is `persist_document()`, which every importer and both render/sync commands call instead of writing files directly. It:

1. Computes a SHA-256 content hash of the document body
2. Checks `state.json` for a matching `(provider, conversation_id)` entry
3. Skips the write if the stored hash, collapse threshold, attachment policy, and HTML flag all match — returns a `DocumentPersistenceResult` with `skipped=True`
4. Detects dirty-local state: if the on-disk body hash doesn't match the stored hash, the file was manually edited; the importer preserves the local content, marks `dirty=True` in both state and front matter, and skips
5. On write: stamps a `polylogue:` front matter block, writes Markdown + optional HTML, updates conversation state, and calls `update_index()`

The dirty-local path deserves a code snippet because the logic is non-obvious:

```python
# If the user edited the file locally (body_hash != stored contentHash)
# AND the remote content hasn't changed, preserve local edits
if remote_same and existing:
    dirty_meta = _ensure_polylogue_metadata(existing.metadata)
    polylogue = dirty_meta.get("polylogue", {})
    polylogue["dirty"] = True
    polylogue["localHash"] = existing.body_hash
    _write_markdown(markdown_path, dirty_meta, existing.body)  # keeps their edits
    return DocumentPersistenceResult(skipped=True, skip_reason="dirty-local", ...)
```

## Automation framework

`automation_targets.json` defines five targets with their CLI commands and default arguments:

```json
{
  "codex": {
    "name": "polylogue-sync-codex",
    "command": ["sync-codex", "--plain", "--json"],
    "defaults": { "collapseThreshold": 24, "html": false }
  },
  ...
}
```

`automation.py` reads this registry and exposes `systemd_snippet()` and `cron_snippet()` that merge target defaults with user overrides to produce ready-to-paste scheduler entries. The CLI surfaces these as `polylogue automation systemd --target codex --interval 10m`.

The NixOS module (`nix/modules/polylogue.nix`) reads the same JSON at Nix eval time, validates target names, and generates systemd service/timer pairs. Users get:

```nix
services.polylogue = {
  enable = true;
  targets.codex = { enable = true; timer.interval = "10m"; };
  targets."claude-code".enable = true;
};
```

## File watchers

`polylogue watch codex` and `polylogue watch claude-code` use the `watchfiles` library to monitor session directories. Changes are debounced (default 2s), and only `.jsonl` file changes trigger a sync. `--once` runs a single sync pass and exits, useful for testing.

Watch runs log to the same `runs.json` telemetry as scheduled runs, so `polylogue status --json --watch` can monitor both watchers and cron jobs from a single dashboard.

## Indexing

Every `persist_document()` call fires `update_index()`, which dispatches to the configured backend:

- **sqlite** (default): maintains a `conversations` table with content hash, token count, and dirty flag, plus an FTS5 virtual table for full-text search
- **qdrant**: upserts into a Qdrant collection (requires `POLYLOGUE_QDRANT_URL`)
- **none**: no-op

The SQLite path is lightweight enough to run on every write without noticeable overhead.

## Packaging

- Added `pyproject.toml` with `polylogue` console_scripts entry point
- Rewrote `flake.nix` to use `buildPythonApplication` and export `packages`, `apps`, `devShells.ci`, and `nixosModules`
- Added `pyperclip` and `watchfiles` to the dev shell

## Changes grouped by concern

**Importers**: All four importers (chatgpt, claude_ai, claude_code, codex) call `persist_document()` instead of writing files directly. `ImportResult` gains `skipped`, `skip_reason`, `dirty`, and `content_hash` fields. The CLI summary display accounts for skipped conversations.

**State management**: `util.py` gains `assign_conversation_slug()` for stable provider-scoped slug allocation, `conversation_is_current()` for skip detection, and `update_conversation_state()` for per-conversation state tracking.

**Status command**: Gains `--json`, `--watch`, and `--interval` flags. A new provider-level summary aggregates stats across command types (e.g., both `sync` and `sync-codex` roll up under their respective providers). Duration tracking added to all run records.

**Clipboard**: `--to-clipboard` flag on render and all import subcommands copies single-file output. Drive credential setup checks the clipboard for an OAuth JSON payload before prompting for a file path.

**Documentation**: `multi-provider.md` deleted; content distributed into five focused docs under `docs/providers/`. README updated with watcher usage, automation targets, NixOS module example, and indexing configuration.

## Test coverage

- `test_automation_snippets.py`: systemd/cron generation, describe roundtrip, CLI dispatch
- `test_commands_logic.py`: render/sync through persistence layer with SQLite index verification, skip-on-rerun behavior
- `test_importers_multi.py`: repeat-import skip detection with dirty-local scenario
- `test_status.py`: provider summary aggregation from run records