### PR TITLE
refactor: move Drive sync to requests-based REST transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Polylogue is an interactive-first toolkit for archiving AI/LLM conversations—r
 
 ## Quick Start
 - Enable the direnv-managed dev shell: `direnv allow` (uses `.envrc` to call `nix develop`).
+- Drive integrations require optional Google client libraries; install them with `pip install "polylogue[drive]"`, run `nix develop .#drive`, or use the `polylogue-with-drive` package output.
 - Prefer manual entry? `nix develop` installs Python plus gum, skim, rich, bat, glow, etc.
 - Run `python3 polylogue.py` and pick an action from the gum menu (Render, Sync, Local Syncs, Doctor, Stats, etc.).
 - When a directory has multiple JSON logs, the skim picker previews files with `bat`; press `Ctrl+G` for a live `glow` render before confirming.
@@ -11,7 +12,7 @@ Polylogue is an interactive-first toolkit for archiving AI/LLM conversations—r
 
 ## What You Can Do
 - **Render local logs:** Choose a file or directory; skim previews candidates, rich shows progress, and outputs land in the configured render directory (default `/realm/data/chatlog/markdown/gemini-render`). Add `--html` for themed previews or `--diff` to see deltas when re-rendering.
-- **Sync Drive folders:** Connect to the default Drive folder (`AI Studio`) and pull chats to Markdown in `/realm/data/chatlog/markdown/gemini-sync`, downloading attachments unless you opt to link only.
+- **Sync Drive folders:** Connect to the default Drive folder (`AI Studio`) and pull chats to Markdown in `/realm/data/chatlog/markdown/gemini-sync`, downloading attachments unless you opt to link only. Install the Drive extras before running these commands.
 - **Sync Codex / Claude Code sessions:** Mirror local CLI transcripts from `~/.codex/sessions/` and `~/.claude/projects/` via `polylogue sync-codex` / `polylogue sync-claude-code`, with optional JSON summaries, pruning, diffs, and HTML previews. Outputs land in `/realm/data/chatlog/markdown/codex` and `/realm/data/chatlog/markdown/claude-code` by default.
 - **Watch local sessions in real time:** `polylogue watch codex` and `polylogue watch claude-code` keep those directories synced automatically; adjust debounce, HTML, collapse settings per watcher, or run a single pass with `--once`. Every sync is logged to `polylogue status --json` so scheduled runs and watchers share the same telemetry.
 - **Import exported providers:** Convert ChatGPT zips, Claude exports, Claude Code sessions, or Codex JSONLs via `polylogue import …` subcommands. Skim lets you cherry-pick conversations; `--all` batches them. Automation targets exist for Codex, Claude Code, Drive sync, Gemini render, and ChatGPT imports (see `polylogue automation describe`).

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ Polylogue is an interactive-first toolkit for archiving AI/LLM conversations—r
 
 ## Quick Start
 - Enable the direnv-managed dev shell: `direnv allow` (uses `.envrc` to call `nix develop`).
-- Drive integrations require optional Google client libraries; install them with `pip install "polylogue[drive]"`, run `nix develop .#drive`, or use the `polylogue-with-drive` package output.
 - Prefer manual entry? `nix develop` installs Python plus gum, skim, rich, bat, glow, etc.
 - Run `python3 polylogue.py` and pick an action from the gum menu (Render, Sync, Local Syncs, Doctor, Stats, etc.).
 - When a directory has multiple JSON logs, the skim picker previews files with `bat`; press `Ctrl+G` for a live `glow` render before confirming.
@@ -12,7 +11,7 @@ Polylogue is an interactive-first toolkit for archiving AI/LLM conversations—r
 
 ## What You Can Do
 - **Render local logs:** Choose a file or directory; skim previews candidates, rich shows progress, and outputs land in the configured render directory (default `/realm/data/chatlog/markdown/gemini-render`). Add `--html` for themed previews or `--diff` to see deltas when re-rendering.
-- **Sync Drive folders:** Connect to the default Drive folder (`AI Studio`) and pull chats to Markdown in `/realm/data/chatlog/markdown/gemini-sync`, downloading attachments unless you opt to link only. Install the Drive extras before running these commands.
+- **Sync Drive folders:** Connect to the default Drive folder (`AI Studio`) and pull chats to Markdown in `/realm/data/chatlog/markdown/gemini-sync`, downloading attachments unless you opt to link only.
 - **Sync Codex / Claude Code sessions:** Mirror local CLI transcripts from `~/.codex/sessions/` and `~/.claude/projects/` via `polylogue sync-codex` / `polylogue sync-claude-code`, with optional JSON summaries, pruning, diffs, and HTML previews. Outputs land in `/realm/data/chatlog/markdown/codex` and `/realm/data/chatlog/markdown/claude-code` by default.
 - **Watch local sessions in real time:** `polylogue watch codex` and `polylogue watch claude-code` keep those directories synced automatically; adjust debounce, HTML, collapse settings per watcher, or run a single pass with `--once`. Every sync is logged to `polylogue status --json` so scheduled runs and watchers share the same telemetry.
 - **Import exported providers:** Convert ChatGPT zips, Claude exports, Claude Code sessions, or Codex JSONLs via `polylogue import …` subcommands. Skim lets you cherry-pick conversations; `--all` batches them. Automation targets exist for Codex, Claude Code, Drive sync, Gemini render, and ChatGPT imports (see `polylogue automation describe`).

--- a/docs/providers/chatgpt.md
+++ b/docs/providers/chatgpt.md
@@ -1,0 +1,31 @@
+# ChatGPT Export & Import Workflow
+
+Polylogue ingests chat.openai.com exports (consumer ChatGPT) by walking the provider’s bundle and normalising the threaded “mapping” graph into a linear markdown transcript.
+
+## Export Bundle
+
+- Exports arrive as a ZIP that contains `conversations.json`, `user.json`, attachments, and shared threads.
+- Each conversation stores a `mapping` dictionary keyed by node IDs. Nodes expose:
+  - `parent` / `children` edges that describe the conversation tree.
+  - `message.content.parts` containing the rendered text, code blocks, lists, and tables.
+  - `metadata` with citations, attachments, and source pointers.
+- Attachments referenced through `attachment://` URIs (or attachment metadata) live in the ZIP beside the JSON payload.
+
+## Import Strategy
+
+- Flatten the `mapping` using the provider-supplied `current_node` as the canonical branch. A depth-first walk that follows `parent` pointers reconstructs the ordered turns.
+- For each `content.part`:
+  - Preserve lists and tables as Markdown structures.
+  - Render code blocks with their language hints (`code` parts expose `mime_type` or `language`).
+  - Convert citation markers (private-use characters such as `\uE200`) into Markdown footnotes using the accompanying entry in `message.metadata.citations`.
+- Tool/function messages show up as `recipient == "assistant"` payloads or `content_type == "tool_results"`. Pair the call/result when the export links them so the Markdown contains a single tool block.
+
+## Attachments
+
+- When attachments exist inside the ZIP, copy them into the conversation’s `_attachments/` directory and link from Markdown.
+- If the export references a remote Google Drive asset without including the file, fall back to an external link so the reader can still reach the asset.
+
+## Operational Notes
+
+- There is no public API for historical exports. Users must trigger the ZIP export manually (Settings → Data Controls → Export) or orchestrate a headless browser flow.
+- Polylogue runs are idempotent: once the ZIP is refreshed, `polylogue import chatgpt` reuses stored slugs and skips conversations whose hashes match previous runs.

--- a/docs/providers/claude-ai.md
+++ b/docs/providers/claude-ai.md
@@ -1,0 +1,24 @@
+# Claude.ai Export Notes
+
+Claude workspace exports (`claude-ai-data-*.zip`) provide a linear conversation log that Polylogue converts into Markdown with attachment metadata and paired tool usage traces.
+
+## Bundle Layout
+
+- `conversations.json` contains ordered `chat_messages` for each conversation.
+- Messages expose:
+  - `sender` (`user`, `assistant`, `system`).
+  - `content` segments (`text`, `tool_use`, `tool_result`) that represent individual blocks within a turn.
+  - `attachments` / `files` arrays with file metadata.
+- Workspace-level metadata (account, timestamps, optional summaries) sits alongside the conversation data.
+
+## Import Flow
+
+- Iterate `chat_messages` chronologically. Emit one Markdown section per content block, preserving the original order inside each turn.
+- Render `tool_use` blocks with the tool name and the JSON arguments; pair them with the subsequent `tool_result` block that references the same ID.
+- Capture attachments into `_attachments/`, recording the filename, type, and size so downstream summaries can surface them.
+- Populate YAML front matter with conversation metadata (`name`, timestamps, source bundle path) to support reruns and UI summaries.
+
+## Automation Considerations
+
+- Anthropic does not expose a public API for claude.ai history. Users must initiate exports by hand or automate a browser session (Playwright/Selenium) with a stored login.
+- Re-imports are idempotent: Polylogue reuses the cached slug and skips conversations whose content hash matches the previous run.

--- a/docs/providers/claude-code.md
+++ b/docs/providers/claude-code.md
@@ -1,0 +1,27 @@
+# Claude Code Session Imports
+
+Claude Code stores IDE transcripts beneath `~/.claude/projects/`. Polylogue mirrors those JSONL streams into Markdown while preserving workspace context, shell snapshots, and tool outputs.
+
+## Project Layout
+
+- `projects/<workspace>/*.jsonl`: primary session logs containing interleaved `summary`, `user`, `assistant`, `tool_use`, and `tool_result` entries. Workspace names mirror absolute paths with `/` replaced by `-` (e.g., `/realm/project/demo` → `-realm-project-demo`).
+- Supplemental folders:
+  - `commands/`: prompt macros and quick actions.
+  - `extras/`: binary artefacts linked from sessions.
+  - `ide/`: editor state metadata.
+  - `shell-snapshots/<session>/<timestamp>.jsonl`: captured terminal transcripts.
+  - `todos/`, `tools/`: aux data referenced by tool calls.
+- Workspace indexes (`history.json`, `activeProject.json`, `recentCommands.json`) summarise recent sessions and UI state.
+
+## Import Approach
+
+- Stream the per-session JSONL file in order, rebuilding parent/child relationships via `parentUuid`, `leafUuid`, and `sessionId` when branches arise.
+- Render `user` and `assistant` events as Markdown turns, keeping embedded code diffs or logs intact.
+- Treat `summary` nodes as front-matter notes or callouts—the compaction checkpoints provide useful context for truncated histories.
+- Pair `tool_use` entries with matching `tool_result` payloads (shared IDs) and decide whether to inline or extract long outputs using the same heuristics as the Codex importer.
+- Attach shell snapshots or referenced files from `shell-snapshots/` and `extras/` into the conversation’s `_attachments/` folder so nothing is lost during compaction.
+
+## Automation
+
+- Run `polylogue sync-claude-code` for one-shot mirroring or `polylogue watch claude-code` for continuous sync. Both commands honour collapse thresholds, HTML output, pruning, and diff generation.
+- The importer preserves file mtimes and reuses per-conversation slugs so reruns remain idempotent and Git-friendly.

--- a/docs/providers/gemini.md
+++ b/docs/providers/gemini.md
@@ -1,0 +1,21 @@
+# Gemini (Google AI Studio) Imports
+
+Polylogue renders Gemini conversation exports—whether pulled from Google AI Studio directly or synced via Drive—into consistent Markdown with attachment metadata and optional HTML previews.
+
+## Source Formats
+
+- **AI Studio JSON downloads**: Individual transcripts exported from the UI contain a `chunkedPrompt.chunks` array with interleaved user/model turns. Attachment references appear as `driveDocument.id` entries.
+- **Drive folders**: The AI Studio “chat exports” folder exposes the same JSON payloads plus attachments that can be fetched through the Drive API.
+
+## Import Strategy
+
+- Parse `chunkedPrompt.chunks` in order, validating each chunk with Polylogue’s shared schema to preserve role, text, and tool metadata.
+- Collect `driveDocument.id` references while rendering. When Drive access is configured, Polylogue resolves each ID, downloads the file, and writes it to `_attachments/`; otherwise, it falls back to a remote Drive link in the Markdown.
+- Populate YAML front matter with transcript metadata (title, provider, timestamps) so reruns can reuse slugs, hashes, and attachment decisions.
+- Optional HTML previews respect the configured theme (`--html-theme`) and include quick links to attachments and Drive assets.
+
+## Sync Notes
+
+- `polylogue render` targets local JSON exports; `polylogue sync` connects to the designated Drive folder (`AI Studio` by default) to pull new conversations, honouring filters like `--since`, `--until`, and `--name-filter`.
+- Collapse thresholds (`--collapse-threshold`) control how aggressively large Gemini responses are folded in the Markdown viewer.
+- Attachments downloaded from Drive inherit the remote modification timestamps; Polylogue applies the same mtime to the rendered Markdown/HTML so Git diffs reflect real content changes.

--- a/docs/providers/openai-codex.md
+++ b/docs/providers/openai-codex.md
@@ -1,0 +1,31 @@
+# OpenAI Codex CLI Sessions
+
+Polylogue mirrors `~/.codex` session logs, pairing tool calls with their outputs and capturing large payloads as attachments.
+
+## Directory Anatomy
+
+- `config.toml`, `auth.json`: CLI configuration and OAuth tokens (not required for transcript parsing).
+- `history.jsonl`: index of all sessions, each row containing `session_id`, timestamps, and summaries.
+- `sessions/`: JSONL transcripts, either legacy `rollout-*.jsonl` files or modern date-partitioned paths (`sessions/YYYY/MM/DD/<session_id>.jsonl`).
+- `log/codex-tui.log`: append-only ANSI log with `LocalShellCall`/`FunctionCall` traces that supplement the JSONL stream.
+
+## Transcript Structure
+
+- JSONL rows include:
+  - `session_meta`: metadata for the session.
+  - `response_item` entries with `type` values such as `message`, `function_call`, `function_call_output`, `reasoning`, or auxiliary `event_msg`.
+  - `turn_context` and environment records that describe the shell or editor state.
+- Every `session_id` in `history.jsonl` maps to one transcript file under `sessions/`.
+
+## Import Guidelines
+
+- Parse the JSONL stream, skipping boilerplate rows like `<user_instructions>` or `<environment_context>` that are repeated in every file.
+- Normalise `response_item:type == "message"` rows into user/assistant turns.
+- Pair `function_call` entries with their corresponding `function_call_output` (linked via `call_id`). Render them as a single tool block with arguments and results; spill oversized payloads into `_attachments/` while keeping a short inline preview.
+- Ignore encrypted `reasoning` payloads until OpenAI exposes a readable form.
+- When `log/codex-tui.log` contains extended shell output, attach it alongside the Markdown so the full transcript remains accessible.
+
+## Automation
+
+- `polylogue sync-codex` and `polylogue watch codex` traverse `sessions/`, apply the import pipeline, and preserve modification times on generated Markdown/HTML.
+- Repeated runs reuse stored slugs and hashes, skipping untouched sessions while logging summary statistics to `polylogue status`.

--- a/flake.nix
+++ b/flake.nix
@@ -46,9 +46,13 @@
         polylogueApp = pyPkgs.buildPythonApplication {
           pname = "polylogue";
           version = "0.1.0";
-          format = "pyproject";
+          pyproject = true;
           src = self;
           propagatedBuildInputs = baseDeps;
+          nativeBuildInputs = with pyPkgs; [
+            setuptools
+            wheel
+          ];
           nativeCheckInputs = with pyPkgs; [ pytest ];
           checkPhase = "pytest";
         };

--- a/flake.nix
+++ b/flake.nix
@@ -41,7 +41,6 @@
             pathvalidate
             aiohttp
             aiofiles
-            google-generativeai
             rich
             pydantic
             python-frontmatter

--- a/flake.nix
+++ b/flake.nix
@@ -30,6 +30,8 @@
         python = pkgs.python3;
         pyPkgs = pkgs.python3Packages;
         baseDeps = with pyPkgs; [
+          google-auth-oauthlib
+          requests
           pathvalidate
           aiohttp
           aiofiles
@@ -41,11 +43,6 @@
           pyperclip
           watchfiles
         ];
-        driveDeps = with pyPkgs; [
-          google-api-python-client
-          google-auth-oauthlib
-          google-auth-httplib2
-        ];
         polylogueApp = pyPkgs.buildPythonApplication {
           pname = "polylogue";
           version = "0.1.0";
@@ -55,36 +52,23 @@
           nativeCheckInputs = with pyPkgs; [ pytest ];
           checkPhase = "pytest";
         };
-        polylogueWithDrive = polylogueApp.overridePythonAttrs (old: {
-          propagatedBuildInputs = old.propagatedBuildInputs ++ driveDeps;
-        });
         cliApp = {
           type = "app";
           program = "${polylogueApp}/bin/polylogue";
-        };
-        cliAppWithDrive = {
-          type = "app";
-          program = "${polylogueWithDrive}/bin/polylogue";
         };
       in {
         packages = {
           default = polylogueApp;
           polylogue = polylogueApp;
-          polylogue-with-drive = polylogueWithDrive;
         };
 
         apps = {
           default = cliApp;
           polylogue = cliApp;
-          polylogue-with-drive = cliAppWithDrive;
         };
 
         devShells = {
           default = import ./nix/devshell.nix { inherit pkgs; };
-          drive = import ./nix/devshell.nix {
-            inherit pkgs;
-            extraPythonPackages = driveDeps;
-          };
           ci = pkgs.mkShell {
             buildInputs = [ polylogueApp pkgs.git pkgs.which ];
             shellHook = ''

--- a/flake.nix
+++ b/flake.nix
@@ -29,46 +29,62 @@
         };
         python = pkgs.python3;
         pyPkgs = pkgs.python3Packages;
+        baseDeps = with pyPkgs; [
+          pathvalidate
+          aiohttp
+          aiofiles
+          rich
+          pydantic
+          python-frontmatter
+          jinja2
+          markdown-it-py
+          pyperclip
+          watchfiles
+        ];
+        driveDeps = with pyPkgs; [
+          google-api-python-client
+          google-auth-oauthlib
+          google-auth-httplib2
+        ];
         polylogueApp = pyPkgs.buildPythonApplication {
           pname = "polylogue";
           version = "0.1.0";
           format = "pyproject";
           src = self;
-          propagatedBuildInputs = with pyPkgs; [
-            google-api-python-client
-            google-auth-oauthlib
-            google-auth-httplib2
-            pathvalidate
-            aiohttp
-            aiofiles
-            rich
-            pydantic
-            python-frontmatter
-            jinja2
-            markdown-it-py
-            pyperclip
-            watchfiles
-          ];
+          propagatedBuildInputs = baseDeps;
           nativeCheckInputs = with pyPkgs; [ pytest ];
           checkPhase = "pytest";
         };
+        polylogueWithDrive = polylogueApp.overridePythonAttrs (old: {
+          propagatedBuildInputs = old.propagatedBuildInputs ++ driveDeps;
+        });
         cliApp = {
           type = "app";
           program = "${polylogueApp}/bin/polylogue";
+        };
+        cliAppWithDrive = {
+          type = "app";
+          program = "${polylogueWithDrive}/bin/polylogue";
         };
       in {
         packages = {
           default = polylogueApp;
           polylogue = polylogueApp;
+          polylogue-with-drive = polylogueWithDrive;
         };
 
         apps = {
           default = cliApp;
           polylogue = cliApp;
+          polylogue-with-drive = cliAppWithDrive;
         };
 
         devShells = {
           default = import ./nix/devshell.nix { inherit pkgs; };
+          drive = import ./nix/devshell.nix {
+            inherit pkgs;
+            extraPythonPackages = driveDeps;
+          };
           ci = pkgs.mkShell {
             buildInputs = [ polylogueApp pkgs.git pkgs.which ];
             shellHook = ''

--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -1,33 +1,36 @@
-{ pkgs }:
+{ pkgs, extraPythonPackages ? [] }:
 
+let
+  py = pkgs.python3;
+  pyPkgs = pkgs.python3Packages;
+  pythonLibs = with pyPkgs; [
+    pathvalidate
+    aiohttp
+    aiofiles
+    rich
+    pydantic
+    python-frontmatter
+    jinja2
+    markdown-it-py
+    pyperclip
+    watchfiles
+  ] ++ extraPythonPackages;
+in
 pkgs.mkShell {
-  buildInputs = [
-    # Python + libraries
-    pkgs.python3
-    pkgs.python3Packages.google-api-python-client
-    pkgs.python3Packages.google-auth-oauthlib
-    pkgs.python3Packages.google-auth-httplib2
-    pkgs.python3Packages.pathvalidate
-    pkgs.python3Packages.aiohttp
-    pkgs.python3Packages.aiofiles
-    pkgs.python3Packages.rich
-    pkgs.python3Packages.pydantic
-    pkgs.python3Packages.python-frontmatter
-    pkgs.python3Packages.jinja2
-    pkgs.python3Packages.markdown-it-py
-    pkgs.python3Packages.pyperclip
-    pkgs.python3Packages.watchfiles
-
-    # CLI helpers used by Polylogue
-    pkgs.skim
-    pkgs.gum
-    pkgs.bat
-    pkgs.delta
-    pkgs.fd
-    pkgs.ripgrep
-    pkgs.glow
-    pkgs.jq
-  ];
+  buildInputs =
+    [ py ]
+    ++ pythonLibs
+    ++ [
+      # CLI helpers used by Polylogue
+      pkgs.skim
+      pkgs.gum
+      pkgs.bat
+      pkgs.delta
+      pkgs.fd
+      pkgs.ripgrep
+      pkgs.glow
+      pkgs.jq
+    ];
   shellHook = ''
     export PYTHONPATH="$PWD:${PYTHONPATH:-}"
     export SKIM_DEFAULT_COMMAND="rg --files"

--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -4,6 +4,8 @@ let
   py = pkgs.python3;
   pyPkgs = pkgs.python3Packages;
   pythonLibs = with pyPkgs; [
+    google-auth-oauthlib
+    requests
     pathvalidate
     aiohttp
     aiofiles

--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -10,7 +10,6 @@ pkgs.mkShell {
     pkgs.python3Packages.pathvalidate
     pkgs.python3Packages.aiohttp
     pkgs.python3Packages.aiofiles
-    pkgs.python3Packages.google-generativeai
     pkgs.python3Packages.rich
     pkgs.python3Packages.pydantic
     pkgs.python3Packages.python-frontmatter

--- a/polylogue/cli.py
+++ b/polylogue/cli.py
@@ -1268,7 +1268,7 @@ def run_stats_cli(args: argparse.Namespace, env: CommandEnv) -> None:
                 post = frontmatter.load(path)  # type: ignore[attr-defined]
                 return dict(post.metadata)
             except Exception:
-                return {}
+                pass
         # Minimal front matter parser: expects simple key: value pairs.
         try:
             text = path.read_text(encoding="utf-8")

--- a/polylogue/drive_client.py
+++ b/polylogue/drive_client.py
@@ -99,7 +99,14 @@ class DriveClient:
     def service(self):
         if self._service is None:
             cred_path = self.ensure_credentials()
-            svc = get_drive_service(cred_path, verbose=not self.ui.plain)
+            try:
+                svc = get_drive_service(cred_path, verbose=not self.ui.plain)
+            except RuntimeError as exc:
+                message = str(exc)
+                if self.ui.plain:
+                    raise SystemExit(message) from exc
+                self.ui.banner("Drive dependencies missing", message)
+                raise SystemExit(message) from exc
             if not svc:
                 raise SystemExit("Drive auth failed")
             self._service = svc

--- a/polylogue/util.py
+++ b/polylogue/util.py
@@ -7,7 +7,7 @@ import subprocess
 import sys
 import tempfile
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union
 
 try:  # pragma: no cover - optional dependency
     import pyperclip  # type: ignore
@@ -59,8 +59,23 @@ def parse_rfc3339_to_epoch(ts: Optional[str]) -> Optional[float]:
         return None
 
 
-def parse_input_time_to_epoch(s: Optional[str]) -> Optional[float]:
-    if not s:
+def parse_input_time_to_epoch(s: Optional[Union[str, float, int, datetime.date, datetime.datetime]]) -> Optional[float]:
+    if s is None:
+        return None
+    if isinstance(s, (int, float)):
+        try:
+            return float(s)
+        except Exception:
+            return None
+    if isinstance(s, datetime.datetime):
+        dt = s
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=datetime.timezone.utc)
+        return dt.timestamp()
+    if isinstance(s, datetime.date):
+        dt = datetime.datetime.combine(s, datetime.time.min, tzinfo=datetime.timezone.utc)
+        return dt.timestamp()
+    if not isinstance(s, str):
         return None
     try:
         if re.match(r"^\d{4}-\d{2}-\d{2}$", s):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,8 @@ readme = "README.md"
 authors = [{ name = "Polylogue Maintainers" }]
 requires-python = ">=3.10"
 dependencies = [
+  "google-auth-oauthlib",
+  "requests",
   "pathvalidate",
   "aiohttp",
   "aiofiles",
@@ -20,13 +22,6 @@ dependencies = [
   "markdown-it-py",
   "pyperclip",
   "watchfiles",
-]
-
-[project.optional-dependencies]
-drive = [
-  "google-api-python-client",
-  "google-auth-oauthlib",
-  "google-auth-httplib2",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,9 +10,6 @@ readme = "README.md"
 authors = [{ name = "Polylogue Maintainers" }]
 requires-python = ">=3.10"
 dependencies = [
-  "google-api-python-client",
-  "google-auth-oauthlib",
-  "google-auth-httplib2",
   "pathvalidate",
   "aiohttp",
   "aiofiles",
@@ -23,6 +20,13 @@ dependencies = [
   "markdown-it-py",
   "pyperclip",
   "watchfiles",
+]
+
+[project.optional-dependencies]
+drive = [
+  "google-api-python-client",
+  "google-auth-oauthlib",
+  "google-auth-httplib2",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ polylogue = "polylogue.cli:main"
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["polylogue"]
+include = ["polylogue", "polylogue.*"]
 
 [tool.setuptools.package-data]
 polylogue = ["automation_targets.json"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ dependencies = [
   "pathvalidate",
   "aiohttp",
   "aiofiles",
-  "google-generativeai",
   "rich",
   "pydantic",
   "python-frontmatter",


### PR DESCRIPTION
## Summary

I replaced the Google Drive client-library integration with direct Drive v3 REST calls built on `requests` and `AuthorizedSession`. The main effect is a much smaller and more explicit transport layer: `polylogue/drive.py` no longer depends on `googleapiclient.discovery.Resource`, `HttpError`, or `MediaIoBaseDownload`, and the packaging story no longer needs the full Drive client stack. Fixed the fallout that surfaced while making that swap, including package discovery for `polylogue.*`, typed stats filtering during builds, and a console-auth fallback for environments where `run_console()` is absent. The end result is still the same user-facing Drive feature set, but the implementation is leaner and easier to reason about.

## Motivation

The old Drive path hid a lot of complexity behind the generated Google client objects. That is convenient initially, but it couples the project to a large dependency surface, awkward packaging requirements, and library-specific exceptions/helpers. It also makes relatively simple operations — list files, get metadata, download media — look more magical than they need to be.

The branch history shows that I explored a packaging-only mitigation first. I dropped `google-generativeai`, then briefly split Drive dependencies into optional extras / separate Nix outputs. That reduced the default footprint a bit, but it did not address the deeper problem: we were still carrying the big client-library stack just to make a handful of Drive v3 calls. Once I switched the transport to direct REST requests, the separate “drive extras” experiment stopped being worth the cognitive overhead, so the branch collapses back to a simpler core dependency set.

The auth compatibility issue was another motivator. Relying on `run_console()` as though it were always present is brittle across auth library versions. Since I was already rewriting the transport, I took the chance to make console OAuth more explicit and resilient.

## Changes by concern

### 1. Replace generated client objects with explicit REST helpers

`polylogue/drive.py` builds an `AuthorizedSession` and uses it to call the Drive REST API directly. The important pieces are:

- `_drive_get_json()` for GET + JSON parsing
- `_raise_for_status()` for normalized HTTP failure handling
- `list_children()` / `find_folder_id()` / `get_file_meta()` built on those helpers
- `download_file()` implemented via streaming `iter_content()`

Before, the code looked conceptually like this:

```python
service.files().list(...).execute()
service.files().get(...).execute()
MediaIoBaseDownload(...)
```

Now it is closer to:

```python
session.get(f"{DRIVE_BASE}/files", params=...)
session.get(f"{DRIVE_BASE}/files/{file_id}", params=...)
session.get(..., params={"alt": "media"}, stream=True)
```

That makes pagination, metadata fields, retry boundaries, and download streaming visible in our own code instead of being implicit in the client library.

### 2. Normalize errors and auth compatibility

I introduced `DriveApiError` so the rest of the code does not have to know about `HttpError`. The new exception carries a message, status code, and payload, which is enough for the transport layer and substantially easier to test/reason about later.

Added a manual console-flow fallback for auth stacks where `run_console()` is missing. That keeps the existing “authenticate in a terminal” workflow alive without pinning Polylogue to one exact auth-library version.

`DriveClient.service` catches transport/runtime failures from the new layer and translates them into user-facing banners / `SystemExit`, which keeps the interactive UX in line with the rest of the tool.

### 3. Simplify packaging around the new transport

`pyproject.toml`, `flake.nix`, and `nix/devshell.nix` all change here. The net effect is:

- remove `google-api-python-client`
- remove `google-auth-httplib2`
- remove `google-generativeai`
- add `requests`
- keep `google-auth-oauthlib` for OAuth token handling

Collapsed the short-lived optional-drive packaging split that appeared mid-branch. Once Drive transport only depends on auth + requests, the extra complexity of separate `polylogue-with-drive` outputs and a dedicated drive shell no longer pays for itself.

Finally, I fixed the wheel packaging issue by broadening `setuptools` discovery from `polylogue` to `polylogue.*`; otherwise the importer subpackages disappear in built wheels.

### 4. Opportunistic fixes exposed by the refactor

Two smaller fixes landed because the transport/package rewrite made them visible:

- `parse_input_time_to_epoch()` accepts numeric/date/datetime inputs, which fixes stats filtering failures in Nix build contexts that pass typed values.
- the stats front-matter parser in `cli.py` falls through on failure instead of returning an empty dict for the whole aggregation.

These are not Drive features, but they were genuine regressions/paper cuts surfaced by running the tighter build path.

## Testing

This branch does not add dedicated new tests for the REST transport itself. The existing pytest suite still runs via the flake build, and I fixed package discovery and stats parsing so those existing tests/package builds keep passing. The obvious gaps remain:

- no transport-level tests for REST pagination or error payload mapping
- no auth compatibility tests for missing `run_console()`
- no large-file streaming download tests

Those are good follow-ups once the REST surface settles.

## Notes

- `get_drive_service()` is intentionally a session factory, not a Google Resource factory. Any internal code that expected `service.files()` semantics has to stay on the helper functions in `polylogue/drive.py`.
- The optional-drive packaging experiment was useful as an interim checkpoint, but the final branch lands in a simpler place than it started.
- The README no longer needs to describe Drive extras because Drive support is back in the core package with a much smaller dependency footprint.