### PR TITLE
feat: add Click CLI surface and restore file-write persistence

### DIFF
--- a/polylogue/cli/__init__.py
+++ b/polylogue/cli/__init__.py
@@ -2,9 +2,11 @@
 
 from ..commands import CommandEnv
 from .context import default_html_mode, resolve_html_enabled, resolve_html_settings
+from .click_app import main, cli  # Click entrypoint
+
+# Legacy exports kept for compatibility with code importing from cli.*
 from .app import (  # pylint: disable=unused-import
     build_parser,
-    main,
     _should_use_plain,
     run_completions_cli,
     run_complete_cli,
@@ -21,29 +23,14 @@ from .app import (  # pylint: disable=unused-import
     _run_sync_drive,
 )
 
-# Legacy compatibility alias; prefer resolve_html_settings.
 _resolve_html_settings = resolve_html_settings
 
 __all__ = [
     "CommandEnv",
-    "build_parser",
+    "cli",
     "default_html_mode",
     "main",
     "resolve_html_enabled",
     "resolve_html_settings",
-    "run_completions_cli",
-    "run_complete_cli",
-    "run_help_cli",
-    "run_import_cli",
-    "run_inspect_branches",
-    "run_inspect_search",
-    "run_prune_cli",
-    "run_stats_cli",
-    "run_attachments_cli",
-    "run_sync_cli",
-    "run_watch_cli",
-    "summarize_import",
-    "_run_sync_drive",
     "_resolve_html_settings",
-    "_should_use_plain",
 ]

--- a/polylogue/cli/app.py
+++ b/polylogue/cli/app.py
@@ -68,6 +68,7 @@ from .context import (
     default_sync_namespace,
     resolve_html_settings,
 )
+from .examples import COMMAND_EXAMPLES
 from .render import run_render_cli
 from ..settings import ensure_settings_defaults, persist_settings, clear_persisted_settings
 from ..config import CONFIG, CONFIG_PATH, DEFAULT_CREDENTIALS, DEFAULT_TOKEN
@@ -151,88 +152,6 @@ def _add_command_parser(subparsers: argparse._SubParsersAction, name: str, **kwa
             kwargs["epilog"] = epilog
     kwargs.setdefault("formatter_class", ExamplesHelpFormatter)
     return subparsers.add_parser(name, **kwargs)
-
-# Command Examples for --examples flag
-# Each command maps to list of (description, command_line) tuples
-COMMAND_EXAMPLES = {
-    "render": [
-        ("Render a single export", "polylogue render export.json --out ~/polylogue-data/render"),
-        ("Render with HTML previews", "polylogue render export.json --html on"),
-        ("Render multiple exports", "polylogue render exports/ --diff"),
-    ],
-    "sync": [
-        ("Sync all Drive chats", "polylogue sync drive --all"),
-        ("Sync from specific Drive folder", "polylogue sync drive --folder-name 'Work Chats'"),
-        ("Sync Codex sessions with preview", "polylogue sync codex --dry-run"),
-        ("Sync Claude Code with diff tracking", "polylogue sync claude-code --diff"),
-        ("Sync and prune deleted chats", "polylogue sync drive --all --prune"),
-        ("Watch Codex and auto-sync", "polylogue sync codex --watch"),
-        ("Watch Claude Code with HTML", "polylogue sync claude-code --watch --html on"),
-    ],
-    "import": [
-        ("Import ChatGPT export", "polylogue import chatgpt export.zip --html on"),
-        ("Import with interactive picker", "polylogue import claude-code pick"),
-        ("Import specific conversation", "polylogue import chatgpt export.zip --conversation-id abc123"),
-        ("Import all from Claude export", "polylogue import claude conversations.zip --all"),
-        ("Preview import without writing", "polylogue import codex session.jsonl --dry-run"),
-    ],
-    "search": [
-        ("Search for term", "polylogue search 'error handling'"),
-        ("Search with filters", "polylogue search 'API' --provider chatgpt --since 2024-01-01"),
-        ("Search with limit", "polylogue search 'authentication' --limit 10"),
-        ("Search and open anchored result", "polylogue search 'TODO' --limit 1 --open"),
-        ("Search with attachment filter", "polylogue search 'diagram' --with-attachments"),
-    ],
-    "browse": [
-        ("Browse branch graph", "polylogue browse branches --provider claude"),
-        ("View stats", "polylogue browse stats --provider chatgpt"),
-        ("Get stats with time filter", "polylogue browse stats --since 2024-01-01 --until 2024-12-31"),
-        ("Show status overview", "polylogue browse status"),
-        ("Watch status continuously", "polylogue browse status --watch"),
-        ("List recent runs", "polylogue browse runs --limit 20"),
-    ],
-    "maintain": [
-        ("Preview prune operation", "polylogue maintain prune --dry-run"),
-        ("Prune legacy files", "polylogue maintain prune --dir ~/polylogue-data/chatgpt"),
-        ("Check all providers", "polylogue maintain doctor"),
-        ("Check with JSON output", "polylogue maintain doctor --json"),
-        ("Validate indexes", "polylogue maintain index check"),
-        ("Repair indexes", "polylogue maintain index check --repair"),
-        ("Restore a snapshot", "polylogue maintain restore --from /tmp/snap --to ~/.local/share/polylogue/archive --force"),
-    ],
-    "config": [
-        ("Interactive setup wizard", "polylogue config init"),
-        ("Force re-initialization", "polylogue config init --force"),
-        ("Show current configuration", "polylogue config show"),
-        ("Get configuration as JSON", "polylogue config show --json"),
-        ("Enable HTML previews", "polylogue config set --html on"),
-        ("Set dark theme", "polylogue config set --theme dark"),
-        ("Reset to defaults", "polylogue config set --reset"),
-    ],
-    "compare": [
-        ("Compare coverage between two providers", "polylogue compare 'auth error' --provider-a codex --provider-b claude-code --limit 10"),
-    ],
-    "attachments": [
-        ("Show top attachments by size", "polylogue attachments stats --sort size --limit 5"),
-        ("Read attachment metadata from the index", "polylogue attachments stats --from-index --json"),
-        ("Extract PDFs to a folder", "polylogue attachments extract --ext .pdf --out ~/desk/pdfs"),
-    ],
-    "status": [
-        ("Watch status with JSON output", "polylogue status --json --watch --interval 10"),
-        ("Dump recent runs quietly", "polylogue status --dump - --runs-limit 50 --quiet"),
-        ("Summarize a single provider", "polylogue status --providers codex --summary -"),
-    ],
-    "prefs": [
-        ("Persist a search default", "polylogue prefs set search --flag --limit --value 5"),
-        ("List saved preferences", "polylogue prefs list"),
-        ("Clear all saved defaults", "polylogue prefs clear"),
-    ],
-    "help": [
-        ("Show all examples", "polylogue help --examples"),
-        ("View examples for a single command", "polylogue help search --examples"),
-    ],
-}
-
 
 def _examples_epilog(command: str) -> Optional[str]:
     examples = COMMAND_EXAMPLES.get(command)

--- a/polylogue/cli/click_app.py
+++ b/polylogue/cli/click_app.py
@@ -19,13 +19,15 @@ from ..ui import create_ui
 from . import (
     attachments,
     browse as browse_cmd,
-    config as config_cmd,
     imports,
     maintain,
     open_helper,
     prefs as prefs_cmd,
-    render as render_cmd,
     reprocess,
+)
+from .commands import (
+    config as config_cmd,
+    render as render_cmd,
     search as search_cmd,
     status as status_cmd,
     sync as sync_cmd,
@@ -213,6 +215,7 @@ def import_cmd_click(env: CommandEnv, **kwargs) -> None:
 @click.option("--collapse-threshold", type=int, default=None, help="Collapse threshold override")
 @click.option("--html", "html_mode", type=click.Choice(["on", "off", "auto"]), default="auto", show_default=True)
 @click.option("--force", is_flag=True, help="Overwrite outputs even when up-to-date")
+@click.option("--allow-dirty", is_flag=True, help="Allow overwriting files with local edits (requires --force)")
 @click.option("--links-only", is_flag=True, help="Link attachments instead of downloading")
 @click.option("--diff", is_flag=True, help="Write delta diff alongside updated Markdown")
 @click.option("--json", is_flag=True, help="Emit machine-readable summary")
@@ -223,6 +226,9 @@ def import_cmd_click(env: CommandEnv, **kwargs) -> None:
 @click.option("--max-disk", type=float, help="Abort if projected disk use exceeds this many GiB (approx)")
 @click.pass_obj
 def render(env: CommandEnv, **kwargs) -> None:
+    if kwargs.get("allow_dirty") and not kwargs.get("force"):
+        env.ui.console.print("--allow-dirty requires --force")
+        raise SystemExit(1)
     args = Namespace(**kwargs)
     render_cmd.dispatch(args, env)
 

--- a/polylogue/cli/click_app.py
+++ b/polylogue/cli/click_app.py
@@ -1,0 +1,354 @@
+"""Click-based CLI entrypoint that wraps existing command dispatchers.
+
+This preserves current behaviours by converting Click parameters into
+argparse-style Namespaces and deferring to the existing dispatch
+functions under polylogue.cli.commands.*.
+"""
+from __future__ import annotations
+
+import sys
+from argparse import Namespace
+from pathlib import Path
+from typing import Optional
+
+import click
+
+from ..commands import CommandEnv
+from ..ui import create_ui
+from . import (
+    attachments,
+    browse,
+    config as config_cmd,
+    env_cli,
+    imports,
+    maintain,
+    open_helper,
+    prefs as prefs_cmd,
+    render as render_cmd,
+    reprocess,
+    search as search_cmd,
+    status as status_cmd,
+    sync as sync_cmd,
+)
+
+
+def _build_env(plain: bool) -> CommandEnv:
+    return CommandEnv(ui=create_ui(plain))
+
+
+@click.group(context_settings={"help_option_names": ["-h", "--help"]})
+@click.option("--plain", is_flag=True, help="Force plain/CI-safe output even when running in a TTY")
+@click.option("--interactive", is_flag=True, help="Force interactive UI even when stdout/stderr are not TTYs")
+@click.pass_context
+def cli(ctx: click.Context, plain: bool, interactive: bool) -> None:
+    """Polylogue CLI (Click)."""
+    use_plain = plain or (not sys.stdout.isatty() or not sys.stderr.isatty()) and not interactive
+    ctx.obj = _build_env(use_plain)
+
+
+# ---------------------------- sync ----------------------------
+
+
+@cli.command()
+@click.argument("provider", type=click.Choice(["drive", "codex", "claude-code", "chatgpt", "claude"]))
+@click.option("--out", type=click.Path(path_type=Path), help="Override output directory")
+@click.option("--links-only", is_flag=True, help="Link attachments instead of downloading (Drive only)")
+@click.option("--attachment-ocr", is_flag=True, help="Attempt OCR on image attachments when indexing attachment text")
+@click.option("--dry-run", is_flag=True, help="Report actions without writing files")
+@click.option("--force", is_flag=True, help="Re-render even if conversations are up-to-date")
+@click.option("--prune", is_flag=True, help="Remove outputs for conversations that vanished upstream")
+@click.option("--prune-snapshot", is_flag=True, help="Snapshot outputs before pruning (STATE_HOME/rollback)")
+@click.option("--collapse-threshold", type=int, default=None, help="Collapse threshold override")
+@click.option("--html", "html_mode", type=click.Choice(["on", "off", "auto"]), default="auto", show_default=True)
+@click.option("--diff", is_flag=True, help="Write delta diff alongside updated Markdown")
+@click.option("--json", is_flag=True, help="Emit machine-readable summary")
+@click.option("--print-paths", is_flag=True, help="List written files after sync")
+@click.option("--chat-id", "chat_ids", multiple=True, help="Drive chat/file ID to sync (repeatable)")
+@click.option("--session", "sessions", multiple=True, type=click.Path(path_type=Path), help="Local session/export path to sync (repeatable)")
+@click.option("--all", is_flag=True, help="Process all available items without interactive selection")
+@click.option("--base-dir", type=click.Path(path_type=Path), help="Override local session/export directory")
+@click.option("--folder-name", type=str, help="Drive folder name (drive provider)")
+@click.option("--folder-id", type=str, help="Drive folder ID override")
+@click.option("--since", type=str, help="Only include Drive chats updated on/after this timestamp")
+@click.option("--until", type=str, help="Only include Drive chats updated on/before this timestamp")
+@click.option("--name-filter", type=str, help="Regex filter for Drive chat names")
+@click.option("--list-only", is_flag=True, help="List Drive chats without syncing")
+@click.option("--offline", is_flag=True, help="Skip network-dependent steps (Drive disallowed)")
+@click.option("--watch", is_flag=True, help="Watch for changes and sync continuously (local providers only)")
+@click.option("--debounce", type=float, default=2.0, show_default=True, help="Minimal seconds between sync runs in watch mode")
+@click.option("--stall-seconds", type=float, default=60.0, show_default=True, help="Warn when watch makes no progress for this many seconds")
+@click.option("--fail-on-stall", is_flag=True, help="Exit with non-zero status when watch detects a stall")
+@click.option("--tail", is_flag=True, help="Log changed paths as they are detected in watch mode")
+@click.option("--once", is_flag=True, help="In watch mode, run a single sync pass and exit")
+@click.option("--snapshot", is_flag=True, help="Create a rollback snapshot of the output directory before watching")
+@click.option("--watch-plan", is_flag=True, help="Print the assembled watch command and exit (no watch run)")
+@click.option("--drive-retries", type=int, help="Override Drive retry attempts (default: config or 3)")
+@click.option("--drive-retry-base", type=float, help="Override Drive retry base delay seconds (default: config or 0.5)")
+@click.option("--root", type=str, help="Named root label to use when configs support multi-root archives")
+@click.option("--max-disk", type=float, help="Abort if projected disk use exceeds this many GiB (approx)")
+@click.pass_obj
+def sync(env: CommandEnv, **kwargs) -> None:
+    args = Namespace(**kwargs)
+    sync_cmd.dispatch(args, env)
+
+
+# ---------------------------- import ----------------------------
+
+
+@cli.command(name="import")
+@click.argument("provider", type=click.Choice(["chatgpt", "claude", "claude-code", "codex"]))
+@click.argument("source", nargs=-1, type=click.Path(path_type=Path))
+@click.option("--out", type=click.Path(path_type=Path), help="Output directory")
+@click.option("--collapse-threshold", type=int, default=None, help="Collapse threshold override")
+@click.option("--html", "html_mode", type=click.Choice(["on", "off", "auto"]), default="auto", show_default=True)
+@click.option("--force", is_flag=True, help="Overwrite outputs even when up-to-date")
+@click.option("--all", is_flag=True, help="Process all conversations/sessions without selection")
+@click.option("--conversation-id", "conversation_ids", multiple=True, help="Conversation ID filter (repeatable)")
+@click.option("--json", is_flag=True, help="Emit machine-readable summary")
+@click.option("--to-clipboard", is_flag=True, help="Copy single imported Markdown file to the clipboard")
+@click.option("--base-dir", type=click.Path(path_type=Path), help="Base directory for local providers")
+@click.option("--attachment-ocr", is_flag=True, help="Attempt OCR on image attachments when indexing attachment text")
+@click.pass_obj
+def import_cmd_click(env: CommandEnv, **kwargs) -> None:
+    args = Namespace(**kwargs)
+    imports.run_import_cli(args, env)
+
+
+# ---------------------------- render ----------------------------
+
+
+@cli.command()
+@click.argument("input", type=click.Path(path_type=Path))
+@click.option("--out", type=click.Path(path_type=Path), help="Output directory")
+@click.option("--collapse-threshold", type=int, default=None, help="Collapse threshold override")
+@click.option("--html", "html_mode", type=click.Choice(["on", "off", "auto"]), default="auto", show_default=True)
+@click.option("--force", is_flag=True, help="Overwrite outputs even when up-to-date")
+@click.option("--links-only", is_flag=True, help="Link attachments instead of downloading")
+@click.option("--diff", is_flag=True, help="Write delta diff alongside updated Markdown")
+@click.option("--json", is_flag=True, help="Emit machine-readable summary")
+@click.option("--print-paths", is_flag=True, help="List written files after rendering")
+@click.option("--to-clipboard", is_flag=True, help="Copy a single rendered file to the clipboard")
+@click.option("--dry-run", is_flag=True, help="Report actions without writing files")
+@click.option("--attachment-ocr", is_flag=True, help="Attempt OCR on image attachments when indexing attachment text")
+@click.option("--max-disk", type=float, help="Abort if projected disk use exceeds this many GiB (approx)")
+@click.pass_obj
+def render(env: CommandEnv, **kwargs) -> None:
+    args = Namespace(**kwargs)
+    render_cmd.dispatch(args, env)
+
+
+# ---------------------------- search ----------------------------
+
+
+@cli.command()
+@click.argument("query", required=False)
+@click.option("--limit", type=int, default=20, show_default=True, help="Maximum number of hits to return")
+@click.option("--provider", type=str, help="Filter by provider slug")
+@click.option("--slug", type=str, help="Filter by conversation slug")
+@click.option("--conversation-id", type=str, help="Filter by provider conversation id")
+@click.option("--branch", type=str, help="Restrict to a single branch ID")
+@click.option("--model", type=str, help="Filter by source model when recorded")
+@click.option("--since", type=str, help="Only include messages on/after this timestamp")
+@click.option("--until", type=str, help="Only include messages on/before this timestamp")
+@click.option("--with-attachments", is_flag=True, help="Limit to messages with extracted attachments")
+@click.option("--without-attachments", is_flag=True, help="Limit to messages without attachments")
+@click.option("--in-attachments", is_flag=True, help="Search within attachment text when indexed")
+@click.option("--attachment-name", type=str, help="Filter by attachment filename substring")
+@click.option("--no-picker", is_flag=True, help="Skip skim picker preview even when interactive")
+@click.option("--json", is_flag=True, help="Emit machine-readable search results")
+@click.option("--json-lines", is_flag=True, help="Emit newline-delimited JSON hits (implies --json and disables tables)")
+@click.option("--csv", type=str, help="Write search hits to CSV ('-' for stdout)")
+@click.option("--fields", type=str, default="provider,conversationId,slug,branchId,messageId,position,timestamp,score,model,attachments,snippet,conversationPath,branchPath", show_default=True)
+@click.option("--from-stdin", is_flag=True, help="Read the search query from stdin (ignores positional query if present)")
+@click.option("--open", "open_result", is_flag=True, help="Open result file in $EDITOR after search")
+@click.pass_obj
+def search(env: CommandEnv, **kwargs) -> None:
+    kwargs["open"] = kwargs.pop("open_result")
+    args = Namespace(**kwargs)
+    search_cmd.dispatch(args, env)
+
+
+# ---------------------------- status ----------------------------
+
+
+@cli.command()
+@click.option("--json", is_flag=True, help="Emit machine-readable summary")
+@click.option("--json-lines", is_flag=True, help="Stream newline-delimited JSON records (auto-enables --json, useful with --watch)")
+@click.option("--json-verbose", is_flag=True, help="Allow status to print tables/logs alongside JSON/JSONL output")
+@click.option("--watch", is_flag=True, help="Continuously refresh the status output")
+@click.option("--dump-only", is_flag=True, help="Only perform the dump action without printing summaries")
+@click.option("--interval", type=float, default=5.0, show_default=True, help="Seconds between refresh while watching")
+@click.option("--dump", type=str, help="Write recent runs to a file ('-' for stdout)")
+@click.option("--dump-limit", type=int, default=100, show_default=True, help="Number of runs to include when dumping")
+@click.option("--runs-limit", type=int, default=200, show_default=True, help="Number of historical runs to include in summaries")
+@click.option("--top", type=int, default=0, show_default=True, help="Show top runs by attachments/tokens")
+@click.option("--inbox", is_flag=True, help="Include inbox coverage counts in summaries")
+@click.option("--providers", type=str, help="Comma-separated provider filter")
+@click.option("--quiet", is_flag=True, help="Suppress table output (useful with --json-lines)")
+@click.option("--summary", type=str, help="Write aggregated provider/run summary JSON to a file ('-' for stdout)")
+@click.option("--summary-only", is_flag=True, help="Only emit the summary JSON without printing tables")
+@click.pass_obj
+def status(env: CommandEnv, **kwargs) -> None:
+    args = Namespace(**kwargs)
+    status_cmd.dispatch(args, env)
+
+
+# ---------------------------- maintain ----------------------------
+
+
+@cli.group()
+@click.pass_context
+def maintain(ctx: click.Context) -> None:
+    """System maintenance and diagnostics."""
+
+
+@maintain.command(name="prune")
+@click.option("--dir", "dirs", multiple=True, type=click.Path(path_type=Path), help="Root directory to prune")
+@click.option("--dry-run", is_flag=True, help="Print planned actions without deleting files")
+@click.option("--max-disk", type=float, help="Abort if projected snapshot size exceeds this many GiB")
+@click.pass_obj
+def maintain_prune(env: CommandEnv, **kwargs) -> None:
+    args = Namespace(maintain_cmd="prune", **kwargs)
+    maintain.run_maintain_cli(args, env)
+
+
+@maintain.command(name="doctor")
+@click.option("--codex-dir", type=click.Path(path_type=Path), help="Override Codex sessions directory")
+@click.option("--claude-code-dir", type=click.Path(path_type=Path), help="Override Claude Code projects directory")
+@click.option("--limit", type=int, help="Limit number of files inspected per provider")
+@click.option("--json", is_flag=True, help="Emit machine-readable report")
+@click.option("--json-verbose", is_flag=True, help="Emit JSON with verbose details")
+@click.pass_obj
+def maintain_doctor(env: CommandEnv, **kwargs) -> None:
+    args = Namespace(maintain_cmd="doctor", **kwargs)
+    maintain.run_maintain_cli(args, env)
+
+
+# ---------------------------- config/env/prefs ----------------------------
+
+
+@cli.command()
+@click.option("--json", is_flag=True, help="Emit environment info as JSON")
+@click.pass_obj
+def env(env: CommandEnv, **kwargs) -> None:
+    run_env_cli(Namespace(**kwargs), env)
+
+
+@cli.group()
+@click.pass_context
+def config(ctx: click.Context) -> None:
+    """Configuration (init/set/show)."""
+
+
+@config.command(name="show")
+@click.option("--json", is_flag=True, help="Emit environment info as JSON")
+@click.pass_obj
+def config_show(env: CommandEnv, **kwargs) -> None:
+    args = Namespace(config_cmd="show", **kwargs)
+    config_cmd.dispatch(args, env)
+
+
+@config.command(name="set")
+@click.option("--html", type=click.Choice(["on", "off"]), help="Enable or disable default HTML previews")
+@click.option("--theme", type=click.Choice(["light", "dark"]), help="Set the default HTML theme")
+@click.option("--collapse-threshold", type=int, help="Set the default collapse threshold")
+@click.option("--output-root", type=click.Path(path_type=Path), help="Set the output root for archives")
+@click.option("--input-root", type=click.Path(path_type=Path), help="Set the inbox/input root for provider exports")
+@click.option("--reset", is_flag=True, help="Reset to config defaults")
+@click.option("--json", is_flag=True, help="Emit settings as JSON")
+@click.pass_obj
+def config_set(env: CommandEnv, **kwargs) -> None:
+    args = Namespace(config_cmd="set", **kwargs)
+    config_cmd.dispatch(args, env)
+
+
+@config.command(name="init")
+@click.option("--force", is_flag=True, help="Overwrite existing configuration")
+@click.pass_obj
+def config_init(env: CommandEnv, **kwargs) -> None:
+    args = Namespace(config_cmd="init", **kwargs)
+    config_cmd.dispatch(args, env)
+
+
+@cli.command()
+@click.argument("prefs_cmd", type=click.Choice(["list", "set", "clear"]))
+@click.option("--command", "command_name", type=str, help="Command name (e.g., search, sync)")
+@click.option("--flag", type=str, help="Flag name, e.g., --limit")
+@click.option("--value", type=str, help="Value for the flag")
+@click.option("--json", is_flag=True, help="Emit JSON output")
+@click.pass_obj
+def prefs(env: CommandEnv, prefs_cmd: str, command_name: Optional[str], flag: Optional[str], value: Optional[str], json: bool) -> None:  # type: ignore[func-returns-value]
+    args = Namespace(prefs_cmd=prefs_cmd, command=command_name, flag=flag, value=value, json=json)
+    prefs_cmd_mod = prefs_cmd  # quiet lint
+    prefs_cmd = prefs_cmd_mod
+    prefs_cmd.dispatch(args, env)  # type: ignore[attr-defined]
+
+
+# ---------------------------- attachments ----------------------------
+
+
+@cli.group()
+@click.pass_context
+def attachments_group(ctx: click.Context) -> None:
+    """Attachment utilities."""
+
+
+@attachments_group.command(name="stats")
+@click.option("--dir", type=click.Path(path_type=Path), help="Root directory containing archives")
+@click.option("--ext", type=str, help="Filter by file extension")
+@click.option("--hash", "hash_mode", is_flag=True, help="Hash attachments to compute deduped totals")
+@click.option("--sort", type=click.Choice(["size", "name"]), default="size")
+@click.option("--limit", type=int, default=10)
+@click.option("--csv", type=str, help="Write attachment rows to CSV")
+@click.option("--json", is_flag=True)
+@click.option("--json-lines", is_flag=True)
+@click.option("--from-index", is_flag=True, help="Read attachment metadata from the index DB")
+@click.pass_obj
+def attachments_stats(env: CommandEnv, **kwargs) -> None:
+    args = Namespace(attachments_cmd="stats", **kwargs)
+    attachments.run_attachments_cli(args, env)
+
+
+@attachments_group.command(name="extract")
+@click.option("--dir", type=click.Path(path_type=Path), help="Root directory containing archives")
+@click.option("--ext", type=str, required=True, help="File extension to extract (e.g., .pdf)")
+@click.option("--out", type=click.Path(path_type=Path), required=True, help="Destination directory")
+@click.option("--limit", type=int, default=0, help="Limit number of files extracted (0 for all)")
+@click.option("--overwrite", is_flag=True, help="Allow overwriting existing files in destination")
+@click.option("--json", is_flag=True, help="Emit extraction summary as JSON")
+@click.option("--json-lines", is_flag=True, help="Emit per-file JSONL")
+@click.pass_obj
+def attachments_extract(env: CommandEnv, **kwargs) -> None:
+    args = Namespace(attachments_cmd="extract", **kwargs)
+    attachments.run_attachments_cli(args, env)
+
+
+# ---------------------------- misc ----------------------------
+
+
+@cli.command()
+@click.argument("provider", required=False)
+@click.option("--command", "cmd", type=str, help="Filter by command (e.g., sync codex)")
+@click.option("--print", "print_only", is_flag=True, help="Only print the path without opening")
+@click.option("--json", is_flag=True, help="Emit JSON with the last run info")
+@click.option("--fallback", type=click.Path(path_type=Path), help="Fallback path if no run is found")
+@click.pass_obj
+def open(env: CommandEnv, **kwargs) -> None:  # type: ignore[func-returns-value]
+    args = Namespace(**kwargs)
+    open_helper.run_open_cli(args, env)
+
+
+@cli.command()
+@click.option("--provider", type=str, help="Provider filter for reprocess")
+@click.option("--fallback", is_flag=True, help="Use fallback parser")
+@click.pass_obj
+def reprocess_cmd(env: CommandEnv, **kwargs) -> None:
+    args = Namespace(**kwargs)
+    reprocess.run_reprocess_cli(args, env)
+
+
+def main() -> None:  # pragma: no cover
+    cli()
+
+
+__all__ = ["cli", "main"]

--- a/polylogue/cli/click_app.py
+++ b/polylogue/cli/click_app.py
@@ -19,7 +19,6 @@ from . import (
     attachments,
     browse as browse_cmd,
     config as config_cmd,
-    env_cli,
     imports,
     maintain,
     open_helper,
@@ -37,6 +36,7 @@ from .app import (
     run_help_cli,
     run_search_preview,
 )
+from .env_cli import run_env_cli
 
 
 def _build_env(plain: bool) -> CommandEnv:

--- a/polylogue/cli/commands/render.py
+++ b/polylogue/cli/commands/render.py
@@ -72,6 +72,11 @@ def setup_parser(subparsers: argparse._SubParsersAction, _add_command_parser, ad
         action="store_true",
         help="Regenerate markdown from database instead of reading source files"
     )
+    p.add_argument(
+        "--allow-dirty",
+        action="store_true",
+        help="Allow overwriting files with local edits (requires --force)",
+    )
 
 
 def dispatch(args: argparse.Namespace, env: CommandEnv) -> None:

--- a/polylogue/cli/env_cli.py
+++ b/polylogue/cli/env_cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import os
 from dataclasses import dataclass
 from pathlib import Path

--- a/polylogue/cli/examples.py
+++ b/polylogue/cli/examples.py
@@ -1,0 +1,88 @@
+"""Shared click/argparse command examples."""
+
+from __future__ import annotations
+
+from typing import Dict, List, Tuple
+
+# Command Examples for --examples flag
+# Each command maps to list of (description, command_line) tuples
+COMMAND_EXAMPLES: Dict[str, List[Tuple[str, str]]] = {
+    "render": [
+        ("Render a single export", "polylogue render export.json --out ~/polylogue-data/render"),
+        ("Render with HTML previews", "polylogue render export.json --html on"),
+        ("Render multiple exports", "polylogue render exports/ --diff"),
+    ],
+    "sync": [
+        ("Sync all Drive chats", "polylogue sync drive --all"),
+        ("Sync from specific Drive folder", "polylogue sync drive --folder-name 'Work Chats'"),
+        ("Sync Codex sessions with preview", "polylogue sync codex --dry-run"),
+        ("Sync Claude Code with diff tracking", "polylogue sync claude-code --diff"),
+        ("Sync and prune deleted chats", "polylogue sync drive --all --prune"),
+        ("Watch Codex and auto-sync", "polylogue sync codex --watch"),
+        ("Watch Claude Code with HTML", "polylogue sync claude-code --watch --html on"),
+    ],
+    "import": [
+        ("Import ChatGPT export", "polylogue import chatgpt export.zip --html on"),
+        ("Import with interactive picker", "polylogue import claude-code pick"),
+        ("Import specific conversation", "polylogue import chatgpt export.zip --conversation-id abc123"),
+        ("Import all from Claude export", "polylogue import claude conversations.zip --all"),
+        ("Preview import without writing", "polylogue import codex session.jsonl --dry-run"),
+    ],
+    "search": [
+        ("Search for term", "polylogue search 'error handling'"),
+        ("Search with filters", "polylogue search 'API' --provider chatgpt --since 2024-01-01"),
+        ("Search with limit", "polylogue search 'authentication' --limit 10"),
+        ("Search and open anchored result", "polylogue search 'TODO' --limit 1 --open"),
+        ("Search with attachment filter", "polylogue search 'diagram' --with-attachments"),
+    ],
+    "browse": [
+        ("Browse branch graph", "polylogue browse branches --provider claude"),
+        ("View stats", "polylogue browse stats --provider chatgpt"),
+        ("Get stats with time filter", "polylogue browse stats --since 2024-01-01 --until 2024-12-31"),
+        ("Show status overview", "polylogue browse status"),
+        ("Watch status continuously", "polylogue browse status --watch"),
+        ("List recent runs", "polylogue browse runs --limit 20"),
+    ],
+    "maintain": [
+        ("Preview prune operation", "polylogue maintain prune --dry-run"),
+        ("Prune legacy files", "polylogue maintain prune --dir ~/polylogue-data/chatgpt"),
+        ("Check all providers", "polylogue maintain doctor"),
+        ("Check with JSON output", "polylogue maintain doctor --json"),
+        ("Validate indexes", "polylogue maintain index check"),
+        ("Repair indexes", "polylogue maintain index check --repair"),
+        ("Restore a snapshot", "polylogue maintain restore --from /tmp/snap --to ~/.local/share/polylogue/archive --force"),
+    ],
+    "config": [
+        ("Interactive setup wizard", "polylogue config init"),
+        ("Force re-initialization", "polylogue config init --force"),
+        ("Show current configuration", "polylogue config show"),
+        ("Get configuration as JSON", "polylogue config show --json"),
+        ("Enable HTML previews", "polylogue config set --html on"),
+        ("Set dark theme", "polylogue config set --theme dark"),
+        ("Reset to defaults", "polylogue config set --reset"),
+    ],
+    "compare": [
+        ("Compare coverage between two providers", "polylogue compare 'auth error' --provider-a codex --provider-b claude-code --limit 10"),
+    ],
+    "attachments": [
+        ("Show top attachments by size", "polylogue attachments stats --sort size --limit 5"),
+        ("Read attachment metadata from the index", "polylogue attachments stats --from-index --json"),
+        ("Extract PDFs to a folder", "polylogue attachments extract --ext .pdf --out ~/desk/pdfs"),
+    ],
+    "status": [
+        ("Watch status with JSON output", "polylogue status --json --watch --interval 10"),
+        ("Dump recent runs quietly", "polylogue status --dump - --runs-limit 50 --quiet"),
+        ("Summarize a single provider", "polylogue status --providers codex --summary -"),
+    ],
+    "prefs": [
+        ("Persist a search default", "polylogue prefs set search --flag --limit --value 5"),
+        ("List saved preferences", "polylogue prefs list"),
+        ("Clear all saved defaults", "polylogue prefs clear"),
+    ],
+    "help": [
+        ("Show all examples", "polylogue help --examples"),
+        ("View examples for a single command", "polylogue help search --examples"),
+    ],
+}
+
+__all__ = ["COMMAND_EXAMPLES"]


### PR DESCRIPTION
## Summary

Restores on-disk file rendering that the DB-first migration dropped, and introduces a Click-based CLI entrypoint that wraps all existing command dispatchers. The database remains the canonical data store, but sync and import workflows need immediate file outputs to function — this commit makes both paths live simultaneously.

## Motivation

The previous commit moved conversation processing to a DB-only write path: `process_conversation()` returned stub `ImportResult` values with projected paths but never actually wrote markdown or HTML. That broke every downstream consumer that expected files on disk — the sync summary reporters, the branch explorer, the `--open` flag on search, and the import clipboard feature all read from the filesystem.

Rather than rewrite all consumers to query the database, the pragmatic fix is dual-write: persist to DB first (source of truth), then call `persist_document()` to materialize files. This preserves the DB-first guarantee while unblocking the existing CLI surface.

The Click migration is motivated by argparse's poor composability for nested subcommand groups. Commands like `maintain doctor`, `browse branches`, and `config set` are natural Click subgroups but awkward argparse sub-sub-parsers. Click also gives us typed path parameters, choice validation, and `--help` for free.

## Changes

### Conversation dual-write (`conversation.py`)

The core change: after `registrar.record_branch_plan()` and `registrar.record_attachments()`, we build a `MarkdownDocument`, call `persist_document()`, and populate `ImportResult` from the persistence result instead of returning stubs:

```python
persisted = persist_document(
    document=document,
    output_dir=output_dir,
    registrar=registrar,
    provider=provider,
    # ... full metadata
)

return ImportResult(
    markdown_path=persisted.markdown_path,
    html_path=persisted.html_path,
    skipped=persisted.skipped,
    # ...
)
```

Branch transcripts are written under `conversation_dir/branches/{branch_id}/` with overlay stubs. These are wrapped in try/except — branch files are auxiliary and must never block ingestion.

### Click CLI (`click_app.py`)

Every command follows the same translation pattern:

```python
@cli.command()
@click.argument("provider", type=click.Choice([...]))
@click.option("--dry-run", is_flag=True, ...)
@click.pass_obj
def sync(env: CommandEnv, **kwargs) -> None:
    args = Namespace(**kwargs)
    sync_cmd.dispatch(args, env)
```

Click collects typed kwargs, we wrap them in an `argparse.Namespace`, and delegate to the existing dispatch function unchanged. No business logic moves in this commit — the Click layer is purely a CLI-framework swap.

Subcommand groups: `browse` (branches/stats/status/runs/inbox), `maintain` (prune/doctor/index/restore), `config` (show/set/init), `attachments` (stats/extract).

### UI facade rewrite (`ui/facade.py`)

The `questionary` dependency is removed entirely. Interactive mode now shells out to `gum` for confirmation/input, `skim` for fuzzy selection, and expects `bat`/`glow`/`delta` for rendering. These are provided by the Nix devshell.

There's no graceful degradation — `_ensure_interactive_deps()` checks for all five binaries and raises `RuntimeError` with an actionable message if any are missing. This is deliberate: partial interactive support creates confusing UX.

### Registrar branch preservation

`record_document()` was clobbering `current_branch` with `None` on every re-render. Now it reads the existing value from the conversations table before upserting:

```python
row = conn.execute(
    "SELECT current_branch FROM conversations "
    "WHERE provider = ? AND conversation_id = ?",
    (provider, conversation_id),
).fetchone()
if row is not None:
    existing_branch = row["current_branch"]
```

This prevents branch state loss during re-sync operations.

### Drive download compatibility

`download_file()` previously used `with session.get(...) as resp:` which assumes httpx-style async context managers. The new code uses explicit `try/finally` with `resp.close()` and probes for both `iter_bytes` (httpx) and `iter_content` (requests) to support both session types.

### Config directory detection

`is_config_declarative()` was reporting false read-only when the config directory didn't exist yet (common on first run). The fix walks up to the nearest existing ancestor before checking `os.access()`.