### PR TITLE
refactor: stamp JSON outputs and harden DB schema resolution

### DIFF
--- a/polylogue/cli/imports.py
+++ b/polylogue/cli/imports.py
@@ -19,6 +19,7 @@ from ..importers.claude_code import DEFAULT_PROJECT_ROOT, list_claude_code_sessi
 from ..importers.base import ImportResult
 from ..pipeline_runner import Pipeline, PipelineContext
 from ..util import CODEX_SESSIONS_ROOT, format_run_brief, latest_run, path_order_key
+from ..schema import stamp_payload
 from .context import (
     DEFAULT_CLAUDE_CODE_SYNC_OUT,
     DEFAULT_CHATGPT_OUT,
@@ -109,7 +110,7 @@ def _emit_import_json(results: List[ImportResult]) -> None:
             for res in results
         ],
     }
-    print(json.dumps(payload, indent=2))
+    print(json.dumps(stamp_payload(payload), indent=2))
 
 
 def _emit_print_paths(results: List[ImportResult], ui) -> None:

--- a/polylogue/cli/open_helper.py
+++ b/polylogue/cli/open_helper.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from ..commands import CommandEnv
 from ..util import latest_run
+from ..schema import stamp_payload
 from .editor import open_in_editor, get_editor
 
 
@@ -18,7 +19,7 @@ def run_open_cli(args: argparse.Namespace, env: CommandEnv) -> None:
     if not entry and fallback:
         path = Path(fallback)
         if getattr(args, "json", False):
-            print(json.dumps({"path": str(path), "source": "fallback"}))
+            print(json.dumps(stamp_payload({"path": str(path), "source": "fallback"})))
             return
         ui.console.print(str(path))
         return
@@ -34,7 +35,7 @@ def run_open_cli(args: argparse.Namespace, env: CommandEnv) -> None:
         "path": str(path_value) if path_value else None,
     }
     if getattr(args, "json", False):
-        print(json.dumps(payload, indent=2))
+        print(json.dumps(stamp_payload(payload), indent=2))
         return
     if not path_value:
         ui.console.print("[yellow]No path recorded for last run.")

--- a/polylogue/cli/render.py
+++ b/polylogue/cli/render.py
@@ -11,6 +11,7 @@ from ..drive_client import DriveClient
 from ..importers import ImportResult
 from ..options import RenderOptions
 from ..version import POLYLOGUE_VERSION, SCHEMA_VERSION
+from ..schema import stamp_payload
 from ..ui import UI
 from ..util import write_clipboard_text
 from .context import (
@@ -97,7 +98,7 @@ def run_render_cli(args: argparse.Namespace, env: CommandEnv, json_output: bool)
             ],
             "total_stats": result.total_stats,
         }
-        print(json.dumps(payload, indent=2))
+        print(json.dumps(stamp_payload(payload), indent=2))
         return
     lines = [f"Rendered {result.count} file(s) → {result.output_dir}"]
     if getattr(args, "print_paths", False):

--- a/polylogue/cli/settings_cli.py
+++ b/polylogue/cli/settings_cli.py
@@ -13,6 +13,7 @@ from ..settings import (
     persist_settings,
 )
 from ..config import CONFIG, CONFIG_PATH, persist_config
+from ..schema import stamp_payload
 
 
 def _settings_snapshot(settings) -> dict:
@@ -102,7 +103,7 @@ def run_settings_cli(args: argparse.Namespace, env: CommandEnv) -> None:
 
     payload = _settings_snapshot(settings)
     if getattr(args, "json", False):
-        print(json.dumps(payload, indent=2))
+        print(json.dumps(stamp_payload(payload), indent=2))
         return
 
     summary_lines = [

--- a/polylogue/cli/sync.py
+++ b/polylogue/cli/sync.py
@@ -15,6 +15,7 @@ from ..local_sync import (
 )
 from ..options import ListOptions, SyncOptions
 from ..util import add_run, format_run_brief, latest_run, path_order_key
+from ..schema import stamp_payload
 from .context import (
     DEFAULT_COLLAPSE,
     DEFAULT_SYNC_OUT,
@@ -97,18 +98,16 @@ def run_list_cli(args: argparse.Namespace, env: CommandEnv, json_output: bool) -
     )
     result = list_command(options, env)
     if json_output:
-        print(
-            json.dumps(
-                {
-                    "cmd": "list",
-                    "folder_name": result.folder_name,
-                    "folder_id": result.folder_id,
-                    "count": len(result.files),
-                    "files": result.files,
-                },
-                indent=2,
+        payload = stamp_payload(
+            {
+                "cmd": "list",
+                "folder_name": result.folder_name,
+                "folder_id": result.folder_id,
+                "count": len(result.files),
+                "files": result.files,
+            }
         )
-        )
+        print(json.dumps(payload, indent=2))
         return
     console = env.ui.console
     console.print(f"{len(result.files)} chat(s) in {result.folder_name}:")
@@ -290,7 +289,7 @@ def _run_sync_drive(args: argparse.Namespace, env: CommandEnv) -> None:
         }
         if previous_run_note:
             payload["previousRun"] = previous_run_note
-        print(json.dumps(payload, indent=2))
+        print(json.dumps(stamp_payload(payload), indent=2))
         return
 
     lines = [f"Synced {result.count} chat(s) → {result.output_dir}"]
@@ -483,7 +482,7 @@ def _run_local_sync(provider_name: str, args: argparse.Namespace, env: CommandEn
         }
         if previous_run_note:
             payload["previousRun"] = previous_run_note
-        print(json.dumps(payload, indent=2))
+        print(json.dumps(stamp_payload(payload), indent=2))
     else:
         summarize_import(ui, f"{provider.title} Sync", result.written, extra_lines=footer_lines)
         console = ui.console

--- a/polylogue/config.py
+++ b/polylogue/config.py
@@ -158,7 +158,7 @@ def persist_config(
     html_previews: bool,
     html_theme: str,
     index: Optional[IndexConfig] = None,
-    roots: Optional[Dict[str, Path]] = None,
+    roots: Optional[Dict[str, object]] = None,
     path: Optional[Path] = None,
 ) -> Path:
     """Write a config.json that mirrors the sample schema.
@@ -193,7 +193,10 @@ def persist_config(
     if roots:
         mapped: Dict[str, Dict[str, str]] = {}
         for label, base in roots.items():
-            root_path = Path(base).expanduser()
+            if isinstance(base, OutputDirs):
+                root_path = base.render.parent.expanduser()
+            else:
+                root_path = Path(base).expanduser()
             mapped[label] = {
                 "render": str(root_path / "render"),
                 "sync_drive": str(root_path / "gemini"),

--- a/polylogue/doctor.py
+++ b/polylogue/doctor.py
@@ -10,7 +10,7 @@ import os
 
 from .archive import Archive
 from .config import CONFIG, CONFIG_ENV, CONFIG_PATH, DEFAULT_PATHS
-from .db import DB_PATH
+from .db import default_db_path
 from .drive_client import DEFAULT_CREDENTIALS, DEFAULT_TOKEN
 from .paths import STATE_HOME
 from .persistence.database import ConversationDatabase
@@ -355,13 +355,13 @@ def run_doctor(
     issues.extend(_credential_issues())
     issues.extend(_drive_failure_issues())
     try:
-        sqlite_notes = verify_sqlite_indexes(DB_PATH)
+        sqlite_notes = verify_sqlite_indexes(default_db_path())
         if sqlite_notes:
             counts["indexes"] = counts.get("indexes", 0) + len(sqlite_notes)
             for note in sqlite_notes:
-                issues.append(DoctorIssue("index", DB_PATH, note, "info"))
+                issues.append(DoctorIssue("index", default_db_path(), note, "info"))
     except Exception as exc:
-        issues.append(DoctorIssue("index", DB_PATH, str(exc), "error"))
+        issues.append(DoctorIssue("index", default_db_path(), str(exc), "error"))
     try:
         qdrant_notes = verify_qdrant_collection()
         if qdrant_notes:

--- a/polylogue/document_store.py
+++ b/polylogue/document_store.py
@@ -93,6 +93,9 @@ def _metadata_without_content_hash(metadata: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def _compute_content_hash(body: str, metadata: Dict[str, Any]) -> str:
+    # Normalise body so YAML/frontmatter round-trips don't change the hash
+    # solely due to trailing newlines/whitespace.
+    body = body.rstrip()
     payload_metadata = _metadata_without_content_hash(metadata)
     try:
         metadata_str = json.dumps(payload_metadata, sort_keys=True, ensure_ascii=False)

--- a/polylogue/importers/fallback_parser.py
+++ b/polylogue/importers/fallback_parser.py
@@ -67,9 +67,9 @@ def extract_timestamps(obj: Any, max_depth: int = 5) -> List[float]:
         if 1577836800 <= obj <= 1893456000:
             timestamps.append(float(obj))
     elif isinstance(obj, dict):
-        for key, value in obj.items():
-            if any(kw in key.lower() for kw in ["time", "timestamp", "created", "updated", "date"]):
-                timestamps.extend(extract_timestamps(value, max_depth - 1))
+        # Recurse through all values; timestamp candidates are filtered by range.
+        for _key, value in obj.items():
+            timestamps.extend(extract_timestamps(value, max_depth - 1))
     elif isinstance(obj, list):
         for item in obj:
             timestamps.extend(extract_timestamps(item, max_depth - 1))

--- a/polylogue/index_health.py
+++ b/polylogue/index_health.py
@@ -5,10 +5,11 @@ import sqlite3
 from pathlib import Path
 from typing import List
 
-from .db import DB_PATH
+from .db import default_db_path
 
 
-def verify_sqlite_indexes(db_path: Path = DB_PATH, *, attempt_rebuild: bool = True) -> List[str]:
+def verify_sqlite_indexes(db_path: Path | None = None, *, attempt_rebuild: bool = True) -> List[str]:
+    db_path = db_path or default_db_path()
     issues: List[str] = []
     conn = sqlite3.connect(db_path)
     try:

--- a/polylogue/persistence/database.py
+++ b/polylogue/persistence/database.py
@@ -25,4 +25,4 @@ class ConversationDatabase:
             conn.commit()
 
     def resolve_path(self) -> Optional[Path]:
-        return self.path or db_module.DB_PATH
+        return self.path or db_module.default_db_path()

--- a/polylogue/render.py
+++ b/polylogue/render.py
@@ -312,12 +312,13 @@ def _prepare_chunks_for_render(
     for idx, chunk in enumerate(chunks):
         if not isinstance(chunk, dict):
             continue
+        chunk = dict(chunk)
+        chunk["_polylogue_index"] = idx
         # Coerce ``text`` from structured ``content`` segments when available.
         text = chunk.get("text")
         if (text is None or not str(text).strip()) and isinstance(chunk.get("content"), list):
             rendered = _render_content_parts(chunk["content"])
             if rendered:
-                chunk = dict(chunk)
                 chunk["text"] = rendered
                 text = rendered
         text_str = (text or "").strip()
@@ -476,7 +477,8 @@ def build_markdown_from_chunks(
     i = 0
     while i < len(chunks):
         c = chunks[i]
-        parts.append(f"<a id=\"msg-{i}\"></a>\n")
+        anchor_id = c.get("_polylogue_index", i)
+        parts.append(f"<a id=\"msg-{anchor_id}\"></a>\n")
         role = c.get("role", "model")
         is_thought = bool(c.get("isThought", False))
         if role == "user":
@@ -515,7 +517,8 @@ def build_markdown_from_chunks(
             if not thought and isinstance(c.get("content"), list):
                 thought = _render_content_parts(c.get("content"))
             resp_chunk = chunks[i + 1]
-            parts.append(f"<a id=\"msg-{i + 1}\"></a>\n")
+            resp_anchor_id = resp_chunk.get("_polylogue_index", i + 1)
+            parts.append(f"<a id=\"msg-{resp_anchor_id}\"></a>\n")
             response = resp_chunk.get("text", "") or ""
             if not response and isinstance(resp_chunk.get("content"), list):
                 response = _render_content_parts(resp_chunk.get("content"))


### PR DESCRIPTION
## Summary

Every CLI command that emits JSON wraps its payload through `stamp_payload()`, making all machine-readable output self-describing with schema and application version metadata. Alongside that, the database layer gets three hardening changes that fix real breakage in tests and against older databases.

## Motivation

Two problems drove this work:

1. **JSON outputs were anonymous blobs.** Nothing in the output told a consumer which schema version produced the data, making it impossible to write forward-compatible parsers. Rather than documenting the version contract externally, embedding it in every payload is cheap and self-enforcing.

2. **DB_PATH was a module-level constant.** It captured `XDG_STATE_HOME` at import time, which meant tests that set the environment variable *after* importing `polylogue.db` would silently write to the real user database. This was a recurring source of flaky test failures and a data-safety concern.

A third issue surfaced during the same sprint: databases created before the conversation-aware `raw_imports` schema would crash on ingestion because the expected columns didn't exist. Since Alembic isn't available in the Nix devshell, an inline migration was the pragmatic fix.

## Changes by concern

### Schema-stamped JSON output

Every CLI module that prints JSON (`imports`, `open_helper`, `render`, `settings_cli`, `sync`) now imports `stamp_payload` from `polylogue.schema` and wraps its payload before serialization:

```python
# Before
print(json.dumps(payload, indent=2))

# After
print(json.dumps(stamp_payload(payload), indent=2))
```

`stamp_payload` adds `schemaVersion` and `polylogueVersion` via `setdefault()` (so callers can override), and dualizes snake_case keys to camelCase for JavaScript consumers.

The `sync/list` path was slightly restructured — the inline `json.dumps({"cmd": "list",...})` is a two-step build-then-print, which reads better and makes the stamping site obvious.

### Dynamic DB path resolution

`default_db_path()` replaces the module-level `DB_PATH` constant. It reads `XDG_STATE_HOME` at call time:

```python
def default_db_path() -> Path:
    raw = os.environ.get("XDG_STATE_HOME")
    state_root = Path(raw).expanduser() if raw else Path.home() / ".local/state"
    return state_root / "polylogue" / "polylogue.db"
```

All consumers (`open_connection`, `doctor.py`, `index_health.py`, `persistence/database.py`) call this function without referencing the constant. The legacy `DB_PATH` is kept for backward compatibility but computed once at import for non-test code paths.

### Legacy raw_imports migration

`_ensure_raw_imports_schema()` runs on every `open_connection()` call. It checks `PRAGMA table_info(raw_imports)` for the presence of `conversation_id` and `version` columns. When they're absent, it:

1. Renames the old table
2. Creates the new schema with conversation_id, version, imported_at_ns, and additional metadata columns
3. Copies existing rows, using `hash` as `conversation_id` and `1` as the default version
4. Drops the old table and creates indexes

This is idempotent — databases that already have the new schema skip the check in two column lookups.

### Messages table backward compatibility

`replace_messages()` now introspects the messages table before inserting. If `model` and `content_text` columns exist, it uses the full 20-column INSERT. Otherwise, it falls back to a 16-column INSERT that matches the legacy schema. This prevents crashes when running new code against an old database.

### Watch: auto-create base directory

In one-shot mode (`--once`) or when a provider sets `create_base_dir = True`, the watch command now creates the base directory instead of erroring. This removes a manual setup step for first-run workflows where the directory doesn't exist yet.

### Smaller fixes

- **config.py**: `persist_config()` accepts `OutputDirs` in the `roots` dict, calling `.render.parent` instead of blindly casting to `Path`
- **render.py**: Chunks receive `_polylogue_index` before any filtering, so `<a id="msg-N">` anchors stay stable when chunks are removed during preparation
- **document_store.py**: `_compute_content_hash()` strips trailing whitespace before hashing, preventing hash churn from YAML frontmatter round-trips
- **fallback_parser.py**: Timestamp extraction now recurses all dict values not only keys matching `time/timestamp/created/updated/date` — the range filter already gates valid candidates
- **local_sync.py**: Uses nanosecond-precision `os.utime(ns=...)` and creates an explicit registrar database inside the output directory's `.polylogue-state/` subdirectory

## Testing

The `default_db_path()` change was specifically motivated by test isolation failures — tests that previously needed to mock `polylogue.db.DB_PATH` can simply set `XDG_STATE_HOME` before calling the function. The migration and column-introspection changes were verified against both fresh databases and databases created with the pre-conversation schema.