### PR TITLE
feat: verify archives, export metrics, and resume failed syncs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ Thumbs.db
 # Local dev environment
 .direnv/
 
+# Local scratch
+.tmp/
+
 # Python
 __pycache__
 .pytest_cache/

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,11 +2,10 @@
 
 Polylogue now follows a modular structure that separates orchestration concerns from provider-specific logic. The key building blocks are:
 
-## Command Registry
+## CLI (Click)
 
-- `polylogue.cli.registry.CommandRegistry` maps CLI verbs to handlers.
-- `polylogue.cli.app` registers commands and uses the registry for dispatch.
-- Makes it easy to add new commands or reuse handlers across CLI/parsers/UI.
+- `polylogue.cli.click_app` defines the Click command tree and dispatches into `polylogue.cli.*` helpers.
+- This keeps parsing/help/examples in one place while leaving command logic in dedicated modules.
 
 ## Console Facade & UI
 
@@ -59,7 +58,7 @@ Polylogue now follows a modular structure that separates orchestration concerns 
 - Build end-to-end snapshots for `sync`/`render` flows that assert both Markdown output and metadata side effects (state + SQLite) to guard against regressions.
 - Explore richer CLI ergonomics (completions, faceted status dashboards) on top of the existing registry/facade stack. Planned completion work includes:
   - bringing the dynamic engine to bash/fish so every shell benefits from live suggestions;
-  - expanding suggestions beyond slugs/providers to include filtered Drive chats, recent session files, and constrained flag values discovered from argparse metadata;
+  - expanding suggestions beyond slugs/providers to include filtered Drive chats, recent session files, and constrained flag values discovered from Click metadata;
   - caching completions to stay snappy even on large archives;
   - rethinking annotation formats (e.g., structured JSON) so shells can render descriptions/tooltips cleanly.
 

--- a/polylogue/cli/attachments.py
+++ b/polylogue/cli/attachments.py
@@ -496,7 +496,7 @@ def _run_attachment_extract(args: SimpleNamespace, env: CommandEnv) -> None:
                 "destination": str(destination),
             }
         )
-        print(json.dumps(payload, indent=2))
+        print(json.dumps(payload, indent=2, sort_keys=True))
         return
 
     lines = [f"Roots: {', '.join(str(r) for r in roots)}", f"Copied: {copied}", f"Errors: {errors}", f"Destination: {destination}"]

--- a/polylogue/cli/attachments.py
+++ b/polylogue/cli/attachments.py
@@ -6,11 +6,19 @@ import json
 import shutil
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Set, Tuple
 
 from ..commands import CommandEnv
 from .context import DEFAULT_OUTPUT_ROOTS
 from ..schema import stamp_payload
+from ..util import parse_input_time_to_epoch
+
+
+def _parse_provider_filter(raw: Optional[str]) -> Optional[Set[str]]:
+    if not raw:
+        return None
+    values = {chunk.strip().lower() for chunk in raw.split(",") if chunk.strip()}
+    return values or None
 
 
 def _iter_indexed_attachments(env: CommandEnv) -> List[Dict[str, object]]:
@@ -18,18 +26,24 @@ def _iter_indexed_attachments(env: CommandEnv) -> List[Dict[str, object]]:
     try:
         query = """
             SELECT
-                provider,
-                conversation_id,
-                branch_id,
-                message_id,
-                attachment_name,
-                attachment_path,
-                size_bytes,
-                content_hash,
-                mime_type,
-                text_bytes,
-                ocr_used
-            FROM attachments
+                a.provider,
+                a.conversation_id,
+                a.branch_id,
+                a.message_id,
+                a.attachment_name,
+                a.attachment_path,
+                a.size_bytes,
+                a.content_hash,
+                a.mime_type,
+                a.text_bytes,
+                a.ocr_used,
+                m.timestamp AS message_timestamp
+            FROM attachments a
+            LEFT JOIN messages m
+              ON m.provider = a.provider
+             AND m.conversation_id = a.conversation_id
+             AND m.branch_id = a.branch_id
+             AND m.message_id = a.message_id
         """
         rows_raw = env.conversations.database.query(query)
     except Exception:
@@ -72,15 +86,115 @@ def run_attachments_cli(args: SimpleNamespace, env: CommandEnv) -> None:
 def _run_attachment_stats(args: SimpleNamespace, env: CommandEnv) -> None:
     ui = env.ui
     use_index = bool(getattr(args, "from_index", False))
+    provider_filter = _parse_provider_filter(getattr(args, "provider", None))
+    since_epoch = parse_input_time_to_epoch(getattr(args, "since", None))
+    until_epoch = parse_input_time_to_epoch(getattr(args, "until", None))
+    clean_orphans = bool(getattr(args, "clean_orphans", False))
+    dry_run = bool(getattr(args, "dry_run", False))
+    json_lines = bool(getattr(args, "json_lines", False))
+    json_mode = bool(getattr(args, "json", False) or json_lines)
+    if (since_epoch is not None or until_epoch is not None) and not use_index:
+        ui.console.print("[red]--since/--until require --from-index for attachment stats.")
+        raise SystemExit(1)
+    if clean_orphans and not use_index:
+        ui.console.print("[red]--clean-orphans requires --from-index.")
+        raise SystemExit(1)
+
+    orphan_summary: Dict[str, object] = {"requested": clean_orphans, "count": 0, "removed": 0, "bytes": 0, "errors": 0}
+    if clean_orphans:
+        roots = _collect_roots(getattr(args, "dir", None))
+        if not roots:
+            ui.console.print("[red]No output roots found for orphan cleanup.")
+            raise SystemExit(1)
+
+        referenced_rows = _iter_indexed_attachments(env)
+        if provider_filter:
+            referenced_rows = [r for r in referenced_rows if str(r.get("provider") or "").lower() in provider_filter]
+        referenced = _referenced_attachment_paths(referenced_rows)
+
+        disk_files: List[Path] = []
+        for root in roots:
+            disk_files.extend(_iter_attachment_files(root))
+        if provider_filter:
+            filtered_disk: List[Path] = []
+            for path in disk_files:
+                parts = {part.lower() for part in path.parts}
+                if any(provider in parts for provider in provider_filter):
+                    filtered_disk.append(path)
+            disk_files = filtered_disk
+
+        orphan_files: List[Path] = []
+        orphan_bytes = 0
+        for file in disk_files:
+            try:
+                resolved = file.resolve()
+            except Exception:
+                resolved = file
+            if resolved in referenced:
+                continue
+            orphan_files.append(file)
+            try:
+                orphan_bytes += file.stat().st_size
+            except OSError:
+                pass
+
+        orphan_summary["count"] = len(orphan_files)
+        orphan_summary["bytes"] = orphan_bytes
+        if dry_run:
+            if not json_mode:
+                for path in orphan_files[:50]:
+                    ui.console.print(f"[yellow][dry-run] Would remove orphan: {path}")
+                if len(orphan_files) > 50:
+                    ui.console.print(f"[yellow][dry-run] ... and {len(orphan_files) - 50} more")
+        else:
+            removed = 0
+            errors = 0
+            for path in orphan_files:
+                try:
+                    path.unlink()
+                    removed += 1
+                    parent = path.parent
+                    if parent.name == "attachments":
+                        try:
+                            if not any(parent.iterdir()):
+                                parent.rmdir()
+                        except Exception:
+                            pass
+                except Exception:
+                    errors += 1
+            orphan_summary["removed"] = removed
+            orphan_summary["errors"] = errors
+
     if use_index:
         rows = _iter_indexed_attachments(env)
         if not rows:
             ui.console.print("[yellow]No indexed attachments found.")
             return
+        if provider_filter:
+            rows = [r for r in rows if str(r.get("provider") or "").lower() in provider_filter]
         ext_filter = getattr(args, "ext", None)
         if ext_filter:
             ext_lower = ext_filter.lower()
             rows = [r for r in rows if str(r.get("attachment_name", "")).lower().endswith(ext_lower)]
+        missing_ts = 0
+        filtered_out_by_time = 0
+        if since_epoch is not None or until_epoch is not None:
+            filtered_rows: List[Dict[str, object]] = []
+            for row in rows:
+                ts = row.get("message_timestamp")
+                ts_epoch = parse_input_time_to_epoch(ts) if ts else None
+                if ts_epoch is None:
+                    missing_ts += 1
+                    continue
+                if since_epoch is not None and ts_epoch < since_epoch:
+                    filtered_out_by_time += 1
+                    continue
+                if until_epoch is not None and ts_epoch > until_epoch:
+                    filtered_out_by_time += 1
+                    continue
+                filtered_rows.append(row)
+            rows = filtered_rows
+
         total_bytes = sum(int(r.get("size_bytes") or 0) for r in rows)
         total_text_bytes = sum(int(r.get("text_bytes") or 0) for r in rows)
         ocr_used = sum(1 for r in rows if r.get("ocr_used"))
@@ -94,8 +208,6 @@ def _run_attachment_stats(args: SimpleNamespace, env: CommandEnv) -> None:
                     hashes[digest] = (size_val, r.get("attachment_path") or "")
                     hashed_bytes += size_val
         limit = getattr(args, "limit", 10)
-        json_lines = bool(getattr(args, "json_lines", False))
-        json_mode = bool(getattr(args, "json", False) or json_lines)
         top_rows = sorted(
             rows,
             key=lambda r: (int(r.get("size_bytes") or 0), str(r.get("attachment_name") or "")),
@@ -115,10 +227,16 @@ def _run_attachment_stats(args: SimpleNamespace, env: CommandEnv) -> None:
                     "textBytes": total_text_bytes,
                     "ocrUsed": ocr_used,
                     "uniqueBytes": hashed_bytes if getattr(args, "hash", False) else None,
+                    "providers": sorted(provider_filter) if provider_filter else None,
+                    "since": getattr(args, "since", None),
+                    "until": getattr(args, "until", None),
+                    "missingTimestamps": missing_ts,
+                    "filteredOutByTime": filtered_out_by_time,
+                    "orphans": orphan_summary,
                     "top": top_rows,
                 }
             )
-            print(json.dumps(payload, indent=2))
+            print(json.dumps(payload, indent=2, sort_keys=True))
             return
         csv_target = getattr(args, "csv", None)
         if csv_target:
@@ -151,8 +269,20 @@ def _run_attachment_stats(args: SimpleNamespace, env: CommandEnv) -> None:
             f"Indexed attachments: {len(rows)} (~{total_bytes / (1024 * 1024):.2f} MiB) text={total_text_bytes} bytes",
             f"OCR used on {ocr_used} attachment(s)",
         ]
+        if provider_filter:
+            lines.append(f"Providers: {', '.join(sorted(provider_filter))}")
+        if since_epoch is not None or until_epoch is not None:
+            lines.append(f"Time window: {getattr(args, 'since', None) or '-'} .. {getattr(args, 'until', None) or '-'}")
+            if missing_ts:
+                lines.append(f"Missing timestamps: {missing_ts}")
+            if filtered_out_by_time:
+                lines.append(f"Filtered out by time: {filtered_out_by_time}")
         if getattr(args, "hash", False):
             lines.append(f"Unique (by hash): {len(hashes)} (~{hashed_bytes / (1024 * 1024):.2f} MiB)")
+        if clean_orphans:
+            lines.append(
+                f"Orphans: {orphan_summary['count']} (~{int(orphan_summary['bytes']) / (1024 * 1024):.2f} MiB) removed={orphan_summary['removed']} errors={orphan_summary['errors']}"
+            )
         if top_rows:
             lines.append("Top attachments:")
             for row in top_rows:
@@ -170,6 +300,14 @@ def _run_attachment_stats(args: SimpleNamespace, env: CommandEnv) -> None:
     files: List[Path] = []
     for root in roots:
         files.extend(_iter_attachment_files(root))
+
+    if provider_filter:
+        filtered_files: List[Path] = []
+        for path in files:
+            parts = {part.lower() for part in path.parts}
+            if any(provider in parts for provider in provider_filter):
+                filtered_files.append(path)
+        files = filtered_files
 
     ext_filter = getattr(args, "ext", None)
     if ext_filter:
@@ -213,10 +351,12 @@ def _run_attachment_stats(args: SimpleNamespace, env: CommandEnv) -> None:
                 "count": len(files),
                 "bytes": total_bytes,
                 "uniqueBytes": hashed_bytes if getattr(args, "hash", False) else None,
+                "providers": sorted(provider_filter) if provider_filter else None,
+                "orphans": orphan_summary if clean_orphans else None,
                 "top": rows_sorted,
             }
         )
-        print(json.dumps(payload, indent=2))
+        print(json.dumps(payload, indent=2, sort_keys=True))
         return
 
     csv_target = getattr(args, "csv", None)
@@ -238,6 +378,8 @@ def _run_attachment_stats(args: SimpleNamespace, env: CommandEnv) -> None:
         return
 
     lines = [f"Roots: {', '.join(str(r) for r in roots)}"]
+    if provider_filter:
+        lines.append(f"Providers: {', '.join(sorted(provider_filter))}")
     lines.append(f"Attachments: {len(files)} (~{total_bytes / (1024 * 1024):.2f} MiB)")
     if getattr(args, "hash", False):
         lines.append(f"Unique (by hash): {len(hashes)} (~{hashed_bytes / (1024 * 1024):.2f} MiB)")
@@ -256,6 +398,39 @@ def _hash_file(path: Path) -> str:
     return h.hexdigest()
 
 
+def _referenced_attachment_paths(rows: List[Dict[str, object]]) -> Set[Path]:
+    referenced: Set[Path] = set()
+    for row in rows:
+        value = row.get("attachment_path")
+        if not value:
+            continue
+        try:
+            candidate = Path(str(value)).expanduser()
+        except Exception:
+            continue
+        if not candidate.is_absolute():
+            continue
+        try:
+            resolved = candidate.resolve()
+        except Exception:
+            resolved = candidate
+        referenced.add(resolved)
+    return referenced
+
+
+def _unique_destination(dest_dir: Path, filename: str) -> Path:
+    candidate = dest_dir / filename
+    if not candidate.exists():
+        return candidate
+    stem = Path(filename).stem
+    suffix = Path(filename).suffix
+    for idx in range(1, 10000):
+        variant = dest_dir / f"{stem}-{idx}{suffix}"
+        if not variant.exists():
+            return variant
+    raise SystemExit(f"Too many filename collisions for {filename} in {dest_dir}")
+
+
 def _run_attachment_extract(args: SimpleNamespace, env: CommandEnv) -> None:
     ui = env.ui
     roots = _collect_roots(getattr(args, "dir", None))
@@ -271,9 +446,12 @@ def _run_attachment_extract(args: SimpleNamespace, env: CommandEnv) -> None:
     destination.mkdir(parents=True, exist_ok=True)
     limit = max(0, getattr(args, "limit", 0))
     overwrite = bool(getattr(args, "overwrite", False))
+    json_lines = bool(getattr(args, "json_lines", False))
+    json_mode = bool(getattr(args, "json", False) or json_lines)
 
     copied = 0
     errors = 0
+    emitted: List[Dict[str, object]] = []
     for root in roots:
         for att_dir in root.rglob("attachments"):
             if not att_dir.is_dir():
@@ -283,10 +461,18 @@ def _run_attachment_extract(args: SimpleNamespace, env: CommandEnv) -> None:
                     continue
                 target = destination / file.name
                 if target.exists() and not overwrite:
-                    continue
+                    target = _unique_destination(destination, file.name)
                 try:
                     shutil.copy2(file, target)
                     copied += 1
+                    if json_lines:
+                        emitted.append(
+                            {
+                                "source": str(file),
+                                "dest": str(target),
+                                "sizeBytes": file.stat().st_size if file.exists() else None,
+                            }
+                        )
                 except Exception:
                     errors += 1
                 if limit and copied >= limit:
@@ -296,7 +482,12 @@ def _run_attachment_extract(args: SimpleNamespace, env: CommandEnv) -> None:
         if limit and copied >= limit:
             break
 
-    if getattr(args, "json", False):
+    if json_lines:
+        for row in emitted:
+            print(json.dumps(stamp_payload(row), separators=(",", ":")))
+        return
+
+    if json_mode:
         payload = stamp_payload(
             {
                 "roots": [str(r) for r in roots],

--- a/polylogue/cli/browse.py
+++ b/polylogue/cli/browse.py
@@ -10,6 +10,7 @@ def run_browse_cli(args: SimpleNamespace, env: CommandEnv) -> None:
     """Dispatch to appropriate browse subcommand."""
     from .branches_cli import run_branches_cli
     from .inbox import run_inbox_cli
+    from .metrics import run_metrics_cli
     from .runs import run_runs_cli
     from .status import run_stats_cli, run_status_cli
 
@@ -28,6 +29,8 @@ def run_browse_cli(args: SimpleNamespace, env: CommandEnv) -> None:
         run_runs_cli(args, env)
     elif browse_cmd == "inbox":
         run_inbox_cli(args, env)
+    elif browse_cmd == "metrics":
+        run_metrics_cli(args, env)
     else:
         raise SystemExit(f"Unknown browse sub-command: {browse_cmd}")
 

--- a/polylogue/cli/click_app.py
+++ b/polylogue/cli/click_app.py
@@ -460,6 +460,20 @@ def browse_runs(env: CommandEnv, **kwargs) -> None:
     browse_cmd.run_browse_cli(args, env)
 
 
+@browse_group.command(name="metrics")
+@click.option("--providers", type=str, help="Comma-separated provider filter")
+@click.option("--runs-limit", type=int, default=0, show_default=True, help="Limit historical runs considered (0 = all)")
+@click.option("--json", is_flag=True, help="Emit JSON instead of Prometheus text format")
+@click.option("--serve", is_flag=True, help="Serve metrics over HTTP at /metrics (Prometheus format)")
+@click.option("--host", type=str, default="127.0.0.1", show_default=True, help="Host to bind when serving metrics")
+@click.option("--port", type=int, default=8000, show_default=True, help="Port to bind when serving metrics")
+@click.pass_obj
+def browse_metrics(env: CommandEnv, **kwargs) -> None:
+    """Export Prometheus-friendly metrics from Polylogue state/run history."""
+    args = SimpleNamespace(browse_cmd="metrics", **kwargs)
+    browse_cmd.run_browse_cli(args, env)
+
+
 @browse_group.command(name="inbox")
 @click.option("--providers", type=str, default="chatgpt,claude", show_default=True, help="Comma-separated provider filter")
 @click.option("--dir", type=click.Path(path_type=Path), help="Override inbox root for a generic scan")

--- a/polylogue/cli/click_app.py
+++ b/polylogue/cli/click_app.py
@@ -616,6 +616,9 @@ def attachments_group(ctx: click.Context) -> None:
 
 @attachments_group.command(name="stats")
 @click.option("--dir", type=click.Path(path_type=Path), help="Root directory containing archives")
+@click.option("--provider", type=str, help="Filter by provider (comma-separated)")
+@click.option("--since", type=str, help="Only include attachments on/after this timestamp (index only)")
+@click.option("--until", type=str, help="Only include attachments on/before this timestamp (index only)")
 @click.option("--ext", type=str, help="Filter by file extension")
 @click.option("--hash", "hash", is_flag=True, help="Hash attachments to compute deduped totals")
 @click.option("--sort", type=click.Choice(["size", "name"]), default="size")
@@ -624,6 +627,8 @@ def attachments_group(ctx: click.Context) -> None:
 @click.option("--json", is_flag=True)
 @click.option("--json-lines", is_flag=True)
 @click.option("--from-index", is_flag=True, help="Read attachment metadata from the index DB")
+@click.option("--clean-orphans", is_flag=True, help="Remove on-disk attachments not referenced by the index DB (requires --from-index)")
+@click.option("--dry-run", is_flag=True, help="Preview actions without deleting files (used with --clean-orphans)")
 @click.pass_obj
 def attachments_stats(env: CommandEnv, **kwargs) -> None:
     args = SimpleNamespace(attachments_cmd="stats", **kwargs)

--- a/polylogue/cli/click_app.py
+++ b/polylogue/cli/click_app.py
@@ -173,6 +173,7 @@ def cli(ctx: click.Context, plain: bool, interactive: bool) -> None:
 @click.option("--list-only", is_flag=True, help="List Drive chats without syncing")
 @click.option("--offline", is_flag=True, help="Skip network-dependent steps (Drive disallowed)")
 @click.option("--watch", is_flag=True, help="Watch for changes and sync continuously (local providers only)")
+@click.option("--jobs", type=int, default=1, show_default=True, help="Parallelism for local providers (codex/claude-code)")
 @click.option("--debounce", type=float, default=2.0, show_default=True, help="Minimal seconds between sync runs in watch mode")
 @click.option("--stall-seconds", type=float, default=60.0, show_default=True, help="Warn when watch makes no progress for this many seconds")
 @click.option("--fail-on-stall", is_flag=True, help="Exit with non-zero status when watch detects a stall")

--- a/polylogue/cli/click_app.py
+++ b/polylogue/cli/click_app.py
@@ -182,6 +182,7 @@ def cli(ctx: click.Context, plain: bool, interactive: bool) -> None:
 @click.option("--watch-plan", is_flag=True, help="Print the assembled watch command and exit (no watch run)")
 @click.option("--drive-retries", type=int, help="Override Drive retry attempts (default: config or 3)")
 @click.option("--drive-retry-base", type=float, help="Override Drive retry base delay seconds (default: config or 0.5)")
+@click.option("--resume-from", type=int, help="Resume a previous run by run ID (reprocess failed items only)")
 @click.option("--meta", multiple=True, help="Attach custom metadata key=value (repeatable)")
 @click.option("--root", type=str, help="Named root label to use when configs support multi-root archives")
 @click.option("--max-disk", type=float, help="Abort if projected disk use exceeds this many GiB (approx)")

--- a/polylogue/cli/click_app.py
+++ b/polylogue/cli/click_app.py
@@ -284,6 +284,17 @@ def render(env: CommandEnv, **kwargs) -> None:
 @click.option("--slug", type=str, help="Filter to a single slug")
 @click.option("--conversation-id", "conversation_ids", multiple=True, help="Filter to a conversation ID (repeatable)")
 @click.option("--limit", type=int, help="Limit number of conversations verified")
+@click.option("--fix", is_flag=True, help="Rewrite conversation.md front matter into canonical form when possible")
+@click.option(
+    "--unknown",
+    "unknown_policy",
+    type=click.Choice(["ignore", "warn", "error"]),
+    default="warn",
+    show_default=True,
+    help="How to handle unknown polylogue front-matter keys",
+)
+@click.option("--allow-polylogue-key", "allow_polylogue_keys", multiple=True, help="Allow additional polylogue metadata key (repeatable)")
+@click.option("--strict", is_flag=True, help="Treat warnings as errors")
 @click.option("--json", is_flag=True, help="Emit machine-readable report")
 @click.pass_obj
 def verify(env: CommandEnv, **kwargs) -> None:

--- a/polylogue/cli/compare_cli.py
+++ b/polylogue/cli/compare_cli.py
@@ -71,7 +71,7 @@ def run_compare_cli(args: object, env: CommandEnv) -> None:
                 ],
             }
         )
-        print(json.dumps(payload, indent=2, ensure_ascii=False))
+        print(json.dumps(payload, indent=2, ensure_ascii=False, sort_keys=True))
         return
 
     lines = [f"Query: {query}", f"Limit: {limit}"]
@@ -90,4 +90,3 @@ def run_compare_cli(args: object, env: CommandEnv) -> None:
 
 
 __all__ = ["run_compare_cli"]
-

--- a/polylogue/cli/context.py
+++ b/polylogue/cli/context.py
@@ -21,6 +21,7 @@ def default_sync_namespace(provider: str, settings: Optional[Settings] = None) -
         dry_run=False,
         force=False,
         prune=False,
+        resume_from=None,
         collapse_threshold=None,
         html_mode="auto",
         diff=False,

--- a/polylogue/cli/context.py
+++ b/polylogue/cli/context.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Dict, Optional, Tuple
+from typing import Dict, Optional, Sequence, Tuple
 
 from ..config import CONFIG
 from ..settings import SETTINGS, Settings, ensure_settings_defaults
@@ -163,3 +163,21 @@ def resolve_collapse_thresholds(args: object, settings: Optional[Settings] = Non
         "message": msg if msg is not None else base,
         "tool": tool if tool is not None else base,
     }
+
+
+def parse_meta_items(items: Optional[Sequence[str]]) -> Dict[str, str]:
+    """Parse repeatable key=value pairs (e.g., Click's multiple=True option)."""
+
+    meta: Dict[str, str] = {}
+    if not items:
+        return meta
+    for item in items:
+        raw = str(item)
+        if "=" not in raw:
+            raise SystemExit(f"Invalid --meta value {raw!r} (expected key=value).")
+        key, value = raw.split("=", 1)
+        key = key.strip()
+        if not key:
+            raise SystemExit(f"Invalid --meta value {raw!r} (empty key).")
+        meta[key] = value
+    return meta

--- a/polylogue/cli/doctor.py
+++ b/polylogue/cli/doctor.py
@@ -55,7 +55,7 @@ def run_doctor_cli(args: SimpleNamespace, env: CommandEnv) -> None:
 
     if getattr(args, "json", False):
         payload = stamp_payload(config_hint)
-        print(json.dumps(payload, indent=2))
+        print(json.dumps(payload, indent=2, sort_keys=True))
         return
 
     lines = [

--- a/polylogue/cli/env_cli.py
+++ b/polylogue/cli/env_cli.py
@@ -129,7 +129,7 @@ def run_env_cli(args: SimpleNamespace, env: CommandEnv) -> None:
     if getattr(args, "json", False):
         import json
 
-        print(json.dumps(payload, indent=2))
+        print(json.dumps(payload, indent=2, sort_keys=True))
     else:
         lines = [f"polylogue={POLYLOGUE_VERSION} schema={SCHEMA_VERSION}"]
         lines.append(f"Config: {cfg_path}")

--- a/polylogue/cli/examples.py
+++ b/polylogue/cli/examples.py
@@ -67,6 +67,8 @@ COMMAND_EXAMPLES: Dict[str, List[Tuple[str, str]]] = {
     "attachments": [
         ("Show top attachments by size", "polylogue attachments stats --sort size --limit 5"),
         ("Read attachment metadata from the index", "polylogue attachments stats --from-index --json"),
+        ("Filter attachment stats by provider/time", "polylogue attachments stats --from-index --provider codex --since 2024-01-01 --until 2024-12-31 --json"),
+        ("Clean orphaned attachment files", "polylogue attachments stats --from-index --clean-orphans --dry-run"),
         ("Extract PDFs to a folder", "polylogue attachments extract --ext .pdf --out ~/desk/pdfs"),
     ],
     "status": [

--- a/polylogue/cli/imports.py
+++ b/polylogue/cli/imports.py
@@ -26,6 +26,7 @@ from .context import (
     DEFAULT_CLAUDE_OUT,
     DEFAULT_CODEX_SYNC_OUT,
     DEFAULT_COLLAPSE,
+    parse_meta_items,
     resolve_collapse_thresholds,
     resolve_collapse_value,
     resolve_html_enabled,
@@ -133,6 +134,7 @@ def run_import_cli(args: SimpleNamespace, env: CommandEnv) -> None:
     sources = args.source or []
     _apply_import_prefs(args, env)
     collapse_thresholds = resolve_collapse_thresholds(args, env.settings)
+    meta = parse_meta_items(getattr(args, "meta", None)) or None
 
     def _ensure_path() -> Path:
         if not sources:
@@ -154,6 +156,7 @@ def run_import_cli(args: SimpleNamespace, env: CommandEnv) -> None:
             to_clipboard=args.to_clipboard,
             attachment_ocr=args.attachment_ocr,
             sanitize_html=getattr(args, "sanitize_html", False),
+            meta=meta,
         )
         run_import_chatgpt(ns, env)
     elif provider == "claude":
@@ -171,6 +174,7 @@ def run_import_cli(args: SimpleNamespace, env: CommandEnv) -> None:
             to_clipboard=args.to_clipboard,
             attachment_ocr=args.attachment_ocr,
             sanitize_html=getattr(args, "sanitize_html", False),
+            meta=meta,
         )
         run_import_claude(ns, env)
     elif provider == "claude-code":
@@ -187,6 +191,7 @@ def run_import_cli(args: SimpleNamespace, env: CommandEnv) -> None:
             to_clipboard=args.to_clipboard,
             attachment_ocr=args.attachment_ocr,
             sanitize_html=getattr(args, "sanitize_html", False),
+            meta=meta,
         )
         run_import_claude_code(ns, env)
     elif provider == "codex":
@@ -203,6 +208,7 @@ def run_import_cli(args: SimpleNamespace, env: CommandEnv) -> None:
             to_clipboard=args.to_clipboard,
             attachment_ocr=args.attachment_ocr,
             sanitize_html=getattr(args, "sanitize_html", False),
+            meta=meta,
         )
         run_import_codex(ns, env)
     else:
@@ -271,6 +277,7 @@ def run_import_codex(args: SimpleNamespace, env: CommandEnv) -> None:
                 "registrar": env.registrar,
                 "attachment_ocr": getattr(args, "attachment_ocr", False),
                 "sanitize_html": getattr(args, "sanitize_html", False),
+                "meta": getattr(args, "meta", None),
             },
             "import_error_message": "Import failed",
             "summary_footer": footer,
@@ -381,6 +388,7 @@ def run_import_chatgpt(args: SimpleNamespace, env: CommandEnv) -> None:
                 "registrar": env.registrar,
                 "attachment_ocr": getattr(args, "attachment_ocr", False),
                 "sanitize_html": getattr(args, "sanitize_html", False),
+                "meta": getattr(args, "meta", None),
             },
             "import_error_message": "Import failed",
             "summary_footer": footer,
@@ -491,6 +499,7 @@ def run_import_claude(args: SimpleNamespace, env: CommandEnv) -> None:
                 "registrar": env.registrar,
                 "attachment_ocr": getattr(args, "attachment_ocr", False),
                 "sanitize_html": getattr(args, "sanitize_html", False),
+                "meta": getattr(args, "meta", None),
             },
             "import_error_message": "Import failed",
             "summary_footer": footer,
@@ -573,6 +582,7 @@ def run_import_claude_code(args: SimpleNamespace, env: CommandEnv) -> None:
                 "registrar": env.registrar,
                 "attachment_ocr": getattr(args, "attachment_ocr", False),
                 "sanitize_html": getattr(args, "sanitize_html", False),
+                "meta": getattr(args, "meta", None),
                 **kwargs,
             },
             "import_error_message": "Import failed",

--- a/polylogue/cli/imports.py
+++ b/polylogue/cli/imports.py
@@ -112,7 +112,7 @@ def _emit_import_json(results: List[ImportResult]) -> None:
             for res in results
         ],
     }
-    print(json.dumps(stamp_payload(payload), indent=2))
+    print(json.dumps(stamp_payload(payload), indent=2, sort_keys=True))
 
 
 def _emit_print_paths(results: List[ImportResult], ui) -> None:

--- a/polylogue/cli/inbox.py
+++ b/polylogue/cli/inbox.py
@@ -253,7 +253,7 @@ def run_inbox_cli(args: SimpleNamespace, env: CommandEnv) -> None:
                 "totals": totals,
             }
         )
-        print(json.dumps(payload, indent=2))
+        print(json.dumps(payload, indent=2, sort_keys=True))
         return
 
     if missing_roots == len(roots):

--- a/polylogue/cli/index_cli.py
+++ b/polylogue/cli/index_cli.py
@@ -38,7 +38,7 @@ def run_index_check(args: SimpleNamespace, env: CommandEnv) -> None:
 
     if getattr(args, "json", False):
         payload = stamp_payload(report)
-        print(json.dumps(payload, indent=2))
+        print(json.dumps(payload, indent=2, sort_keys=True))
         return
 
     ui = env.ui

--- a/polylogue/cli/json_output.py
+++ b/polylogue/cli/json_output.py
@@ -87,7 +87,7 @@ def emit_json_or_error(payload: Optional[Dict], error: Optional[Exception], ui: 
         else:
             output = payload or {}
 
-        print(json.dumps(output, indent=2))
+        print(json.dumps(output, indent=2, sort_keys=True))
     elif error:
         ui.console.print(f"[red]Error: {error}")
 

--- a/polylogue/cli/maintain.py
+++ b/polylogue/cli/maintain.py
@@ -51,7 +51,7 @@ def run_maintain_cli(args: SimpleNamespace, env: CommandEnv) -> None:
             payload = stamp_payload({"from": str(src), "to": str(dest), "bytes": total_bytes})
             import json
 
-            print(json.dumps(payload, indent=2))
+            print(json.dumps(payload, indent=2, sort_keys=True))
             return
         env.ui.summary(
             "Restore",

--- a/polylogue/cli/metrics.py
+++ b/polylogue/cli/metrics.py
@@ -1,0 +1,272 @@
+from __future__ import annotations
+
+import json
+import time
+from collections import defaultdict
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from types import SimpleNamespace
+from typing import Any, Dict, Iterable, Optional, Tuple
+
+from ..commands import CommandEnv, _provider_from_cmd, status_command
+from ..db import open_connection
+from ..schema import stamp_payload
+from ..util import parse_rfc3339_to_epoch
+from ..version import POLYLOGUE_VERSION, SCHEMA_VERSION
+
+
+def run_metrics_cli(args: SimpleNamespace, env: CommandEnv) -> None:
+    provider_filter = _normalize_filter(getattr(args, "providers", None))
+    runs_limit = getattr(args, "runs_limit", 0)
+    if isinstance(runs_limit, int) and runs_limit <= 0:
+        runs_limit = None
+    json_mode = bool(getattr(args, "json", False))
+    serve = bool(getattr(args, "serve", False))
+    host = getattr(args, "host", "127.0.0.1")
+    port = int(getattr(args, "port", 8000))
+
+    if json_mode and serve:
+        raise SystemExit("--json cannot be used with --serve")
+
+    def build_payload() -> Dict[str, Any]:
+        status = status_command(env, runs_limit=runs_limit, provider_filter=provider_filter)
+        db_counts = _query_db_counts(provider_filter=provider_filter)
+        run_metrics = _aggregate_run_metrics(status.runs, provider_filter=provider_filter)
+        payload = {
+            "generated_at": time.time(),
+            "build": {"polylogue_version": POLYLOGUE_VERSION, "schema_version": SCHEMA_VERSION},
+            "db": db_counts,
+            "runs": run_metrics,
+        }
+        return stamp_payload(payload)
+
+    if serve:
+        _serve_metrics(
+            env,
+            host=host,
+            port=port,
+            build_prometheus_text=lambda: _format_prometheus(build_payload()),
+        )
+        return
+
+    payload = build_payload()
+    if json_mode:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return
+
+    print(_format_prometheus(payload).rstrip())
+
+
+def _normalize_filter(raw: Optional[str]) -> Optional[set[str]]:
+    if not raw:
+        return None
+    values = {chunk.strip().lower() for chunk in raw.split(",") if chunk.strip()}
+    return values or None
+
+
+def _query_db_counts(*, provider_filter: Optional[set[str]]) -> Dict[str, Any]:
+    counts: Dict[str, Any] = {"by_provider": {}}
+    with open_connection(None) as conn:
+        for table in ("conversations", "branches", "messages", "attachments", "raw_imports"):
+            if provider_filter:
+                rows = conn.execute(
+                    f"SELECT provider, COUNT(*) AS n FROM {table} WHERE provider IN ({','.join(['?'] * len(provider_filter))}) GROUP BY provider",
+                    tuple(sorted(provider_filter)),
+                ).fetchall()
+            else:
+                rows = conn.execute(
+                    f"SELECT provider, COUNT(*) AS n FROM {table} GROUP BY provider",
+                ).fetchall()
+            counts["by_provider"][table] = {row["provider"]: int(row["n"] or 0) for row in rows}
+
+        if provider_filter:
+            rows = conn.execute(
+                f"SELECT provider, COALESCE(SUM(size_bytes), 0) AS total FROM attachments WHERE provider IN ({','.join(['?'] * len(provider_filter))}) GROUP BY provider",
+                tuple(sorted(provider_filter)),
+            ).fetchall()
+        else:
+            rows = conn.execute(
+                "SELECT provider, COALESCE(SUM(size_bytes), 0) AS total FROM attachments GROUP BY provider",
+            ).fetchall()
+        counts["by_provider"]["attachment_bytes"] = {row["provider"]: int(row["total"] or 0) for row in rows}
+    return counts
+
+
+def _aggregate_run_metrics(runs: Iterable[dict], *, provider_filter: Optional[set[str]]) -> Dict[str, Any]:
+    run_records: Dict[Tuple[str, str], int] = defaultdict(int)
+    items: Dict[Tuple[str, str], int] = defaultdict(int)
+    attachments: Dict[Tuple[str, str], int] = defaultdict(int)
+    attachment_bytes: Dict[Tuple[str, str], int] = defaultdict(int)
+    skipped: Dict[Tuple[str, str], int] = defaultdict(int)
+    pruned: Dict[Tuple[str, str], int] = defaultdict(int)
+    diffs: Dict[Tuple[str, str], int] = defaultdict(int)
+    duration: Dict[Tuple[str, str], float] = defaultdict(float)
+    retries: Dict[Tuple[str, str], int] = defaultdict(int)
+    failures: Dict[Tuple[str, str], int] = defaultdict(int)
+    last_ts: Dict[Tuple[str, str], float] = {}
+
+    for record in runs:
+        cmd = (record.get("cmd") or "unknown").strip()
+        provider = (record.get("provider") or _provider_from_cmd(cmd) or "unknown").strip()
+        provider_norm = provider.lower()
+        if provider_filter and provider_norm not in provider_filter:
+            continue
+        key = (cmd, provider_norm)
+        run_records[key] += 1
+        items[key] += int(record.get("count", 0) or 0)
+        attachments[key] += int(record.get("attachments", 0) or 0)
+        attachment_bytes[key] += int(record.get("attachmentBytes", record.get("attachment_bytes", 0)) or 0)
+        skipped[key] += int(record.get("skipped", 0) or 0)
+        pruned[key] += int(record.get("pruned", 0) or 0)
+        diffs[key] += int(record.get("diffs", 0) or 0)
+        duration[key] += float(record.get("duration", 0.0) or 0.0)
+        retries[key] += int(record.get("driveRetries", record.get("retries", 0)) or 0)
+        failures[key] += int(record.get("driveFailures", record.get("failures", 0)) or 0)
+        ts = record.get("timestamp")
+        epoch = parse_rfc3339_to_epoch(ts) if isinstance(ts, str) else None
+        if epoch is not None:
+            prev = last_ts.get(key)
+            if prev is None or epoch > prev:
+                last_ts[key] = epoch
+
+    def as_rows(metric: Dict[Tuple[str, str], Any]) -> list[dict]:
+        rows = []
+        for (cmd, provider), value in sorted(metric.items()):
+            rows.append({"cmd": cmd, "provider": provider, "value": value})
+        return rows
+
+    return {
+        "run_records_total": as_rows(run_records),
+        "items_processed_total": as_rows(items),
+        "attachments_processed_total": as_rows(attachments),
+        "attachment_bytes_processed_total": as_rows(attachment_bytes),
+        "skipped_total": as_rows(skipped),
+        "pruned_total": as_rows(pruned),
+        "diffs_total": as_rows(diffs),
+        "duration_seconds_total": as_rows(duration),
+        "retries_total": as_rows(retries),
+        "failures_total": as_rows(failures),
+        "last_run_timestamp_seconds": as_rows(last_ts),
+    }
+
+
+def _prom_escape(value: str) -> str:
+    return (
+        value.replace("\\", "\\\\")
+        .replace("\n", "\\n")
+        .replace('"', '\\"')
+    )
+
+
+def _prom_labels(labels: Dict[str, str]) -> str:
+    if not labels:
+        return ""
+    parts = [f'{name}="{_prom_escape(value)}"' for name, value in labels.items()]
+    return "{" + ",".join(parts) + "}"
+
+
+def _format_prometheus(payload: Dict[str, Any]) -> str:
+    lines: list[str] = []
+    generated = payload.get("generated_at") or payload.get("generatedAt")
+    try:
+        generated_value = float(generated)
+    except Exception:
+        generated_value = time.time()
+    lines.append("# HELP polylogue_metrics_generated_timestamp_seconds Time the metrics payload was generated.")
+    lines.append("# TYPE polylogue_metrics_generated_timestamp_seconds gauge")
+    lines.append(f"polylogue_metrics_generated_timestamp_seconds {generated_value:.6f}")
+    lines.append("# HELP polylogue_build_info Polylogue build and schema version information.")
+    lines.append("# TYPE polylogue_build_info gauge")
+    build = payload.get("build") or {}
+    labels = {
+        "version": str(build.get("polylogue_version") or build.get("polylogueVersion") or POLYLOGUE_VERSION),
+        "schema_version": str(build.get("schema_version") or build.get("schemaVersion") or SCHEMA_VERSION),
+    }
+    lines.append(f"polylogue_build_info{_prom_labels(labels)} 1")
+
+    db = payload.get("db") or {}
+    by_provider = (db.get("by_provider") or db.get("byProvider") or {}) if isinstance(db, dict) else {}
+    for table in ("conversations", "branches", "messages", "attachments", "raw_imports"):
+        series = by_provider.get(table) or {}
+        lines.append(f"# HELP polylogue_db_{table}_total Rows in {table} table.")
+        lines.append(f"# TYPE polylogue_db_{table}_total gauge")
+        for provider, value in sorted(series.items()):
+            lines.append(f"polylogue_db_{table}_total{_prom_labels({'provider': str(provider)})} {int(value)}")
+    bytes_series = by_provider.get("attachment_bytes") or by_provider.get("attachmentBytes") or {}
+    lines.append("# HELP polylogue_db_attachment_bytes_total Sum of attachment bytes in attachments table.")
+    lines.append("# TYPE polylogue_db_attachment_bytes_total gauge")
+    for provider, value in sorted(bytes_series.items()):
+        lines.append(f"polylogue_db_attachment_bytes_total{_prom_labels({'provider': str(provider)})} {int(value)}")
+
+    runs = payload.get("runs") or {}
+    mapping = {
+        "run_records_total": ("polylogue_run_records_total", "Total recorded runs."),
+        "items_processed_total": ("polylogue_items_processed_total", "Total processed items reported by runs."),
+        "attachments_processed_total": ("polylogue_attachments_processed_total", "Total attachments processed in runs."),
+        "attachment_bytes_processed_total": ("polylogue_attachment_bytes_processed_total", "Total attachment bytes processed in runs."),
+        "skipped_total": ("polylogue_skipped_total", "Total skipped count recorded in runs."),
+        "pruned_total": ("polylogue_pruned_total", "Total pruned count recorded in runs."),
+        "diffs_total": ("polylogue_diffs_total", "Total diffs recorded in runs."),
+        "duration_seconds_total": ("polylogue_duration_seconds_total", "Total duration seconds recorded in runs."),
+        "retries_total": ("polylogue_retries_total", "Total retries recorded in runs."),
+        "failures_total": ("polylogue_failures_total", "Total failures recorded in runs."),
+        "last_run_timestamp_seconds": ("polylogue_last_run_timestamp_seconds", "Timestamp of most recent run per cmd/provider."),
+    }
+    for key, (metric_name, help_text) in mapping.items():
+        series = runs.get(key) or runs.get(_camel(key)) or []
+        lines.append(f"# HELP {metric_name} {help_text}")
+        lines.append(f"# TYPE {metric_name} gauge")
+        if not isinstance(series, list):
+            continue
+        for row in series:
+            if not isinstance(row, dict):
+                continue
+            cmd = str(row.get("cmd") or "")
+            provider = str(row.get("provider") or "")
+            value = row.get("value")
+            try:
+                num = float(value)
+            except Exception:
+                continue
+            if num.is_integer():
+                rendered = str(int(num))
+            else:
+                rendered = str(num)
+            lines.append(f"{metric_name}{_prom_labels({'cmd': cmd, 'provider': provider})} {rendered}")
+    return "\n".join(lines) + "\n"
+
+
+def _camel(s: str) -> str:
+    if "_" not in s:
+        return s
+    head, *rest = s.split("_")
+    return head + "".join(part.capitalize() for part in rest)
+
+
+def _serve_metrics(env: CommandEnv, *, host: str, port: int, build_prometheus_text) -> None:
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):  # noqa: N802
+            if self.path not in ("/", "/metrics"):
+                self.send_response(404)
+                self.end_headers()
+                return
+            body = build_prometheus_text().encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *_args, **_kwargs):  # noqa: N802
+            return
+
+    server = HTTPServer((host, port), Handler)
+    env.ui.console.print(f"[green]Serving metrics on http://{host}:{port}/metrics (Ctrl-C to stop)")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        return
+    finally:
+        server.server_close()
+
+
+__all__ = ["run_metrics_cli"]

--- a/polylogue/cli/open_helper.py
+++ b/polylogue/cli/open_helper.py
@@ -19,7 +19,7 @@ def run_open_cli(args: SimpleNamespace, env: CommandEnv) -> None:
     if not entry and fallback:
         path = Path(fallback)
         if getattr(args, "json", False):
-            print(json.dumps(stamp_payload({"path": str(path), "source": "fallback"})))
+            print(json.dumps(stamp_payload({"path": str(path), "source": "fallback"}), sort_keys=True))
             return
         ui.console.print(str(path))
         return
@@ -35,7 +35,7 @@ def run_open_cli(args: SimpleNamespace, env: CommandEnv) -> None:
         "path": str(path_value) if path_value else None,
     }
     if getattr(args, "json", False):
-        print(json.dumps(stamp_payload(payload), indent=2))
+        print(json.dumps(stamp_payload(payload), indent=2, sort_keys=True))
         return
     if not path_value:
         ui.console.print("[yellow]No path recorded for last run.")

--- a/polylogue/cli/prefs.py
+++ b/polylogue/cli/prefs.py
@@ -22,7 +22,7 @@ def _load_prefs() -> Dict[str, Dict[str, str]]:
 
 def _save_prefs(prefs: Dict[str, Dict[str, str]]) -> None:
     PREFS_PATH.parent.mkdir(parents=True, exist_ok=True)
-    PREFS_PATH.write_text(json.dumps(prefs, indent=2), encoding="utf-8")
+    PREFS_PATH.write_text(json.dumps(prefs, indent=2, sort_keys=True), encoding="utf-8")
 
 
 def run_prefs_cli(args: SimpleNamespace, env: CommandEnv) -> None:
@@ -32,7 +32,7 @@ def run_prefs_cli(args: SimpleNamespace, env: CommandEnv) -> None:
 
     if sub == "list":
         if getattr(args, "json", False):
-            print(json.dumps(prefs, indent=2))
+            print(json.dumps(prefs, indent=2, sort_keys=True))
             return
         lines = []
         for cmd, values in sorted(prefs.items()):
@@ -52,7 +52,7 @@ def run_prefs_cli(args: SimpleNamespace, env: CommandEnv) -> None:
         cmd_prefs[flag] = value
         _save_prefs(prefs)
         if getattr(args, "json", False):
-            print(json.dumps({"command": command, "flag": flag, "value": value}))
+            print(json.dumps({"command": command, "flag": flag, "value": value}, sort_keys=True))
             return
         ui.console.print(f"[green]Saved preference: {command} {flag}={value}")
         return
@@ -65,7 +65,7 @@ def run_prefs_cli(args: SimpleNamespace, env: CommandEnv) -> None:
             prefs = {}
         _save_prefs(prefs)
         if getattr(args, "json", False):
-            print(json.dumps({"cleared": target or "all"}))
+            print(json.dumps({"cleared": target or "all"}, sort_keys=True))
             return
         ui.console.print(f"[green]Cleared preferences for {target or 'all commands'}")
         return

--- a/polylogue/cli/render.py
+++ b/polylogue/cli/render.py
@@ -118,7 +118,7 @@ def run_render_cli(args: object, env: CommandEnv, json_output: bool) -> None:
         }
         if getattr(args, "sanitize_html", False):
             payload["redacted"] = True
-        print(json.dumps(stamp_payload(payload), indent=2))
+        print(json.dumps(stamp_payload(payload), indent=2, sort_keys=True))
         return
     extra_lines: List[str] = []
     if getattr(args, "print_paths", False):

--- a/polylogue/cli/render.py
+++ b/polylogue/cli/render.py
@@ -19,6 +19,7 @@ from .failure_logging import record_failure
 from .context import (
     DEFAULT_COLLAPSE,
     DEFAULT_RENDER_OUT,
+    parse_meta_items,
     resolve_collapse_thresholds,
     resolve_collapse_value,
     resolve_html_enabled,
@@ -61,6 +62,7 @@ def run_render_cli(args: object, env: CommandEnv, json_output: bool) -> None:
     if render_prefs.get("--html") is not None and args.html_mode == "auto":
         html_enabled = render_prefs.get("--html") == "on"
     html_theme = settings.html_theme
+    meta = parse_meta_items(getattr(args, "meta", None)) or None
     options = RenderOptions(
         inputs=inputs,
         output_dir=output,
@@ -74,6 +76,7 @@ def run_render_cli(args: object, env: CommandEnv, json_output: bool) -> None:
         diff=getattr(args, "diff", False),
         attachment_ocr=getattr(args, "attachment_ocr", False) or _truthy(render_prefs.get("--attachment-ocr", "false")) if render_prefs else getattr(args, "attachment_ocr", False),
         sanitize_html=getattr(args, "sanitize_html", False),
+        meta=meta,
     )
     if getattr(args, "max_disk", None):
         projected = len(inputs) * 5 * 1024 * 1024  # rough 5MiB per file heuristic

--- a/polylogue/cli/runs.py
+++ b/polylogue/cli/runs.py
@@ -45,6 +45,7 @@ def run_runs_cli(args: SimpleNamespace, env: CommandEnv) -> None:
         return
 
     table = Table(title=f"Recent Runs (n={len(runs)})")
+    table.add_column("ID", justify="right")
     table.add_column("Timestamp")
     table.add_column("Command")
     table.add_column("Provider")
@@ -54,6 +55,7 @@ def run_runs_cli(args: SimpleNamespace, env: CommandEnv) -> None:
     table.add_column("Failures", justify="right")
     for entry in runs:
         table.add_row(
+            str(entry.get("id") or ""),
             entry.get("timestamp", "-"),
             entry.get("cmd", "-"),
             entry.get("provider", "-"),
@@ -79,7 +81,7 @@ def _print_plain(env: CommandEnv, runs: List[dict]) -> None:
         return
     for entry in runs:
         console.print(
-            f"{entry.get('timestamp','-')} :: {entry.get('cmd','-')} provider={entry.get('provider','-')} count={entry.get('count',0)} duration={entry.get('duration',0)}"
+            f"#{entry.get('id','-')} {entry.get('timestamp','-')} :: {entry.get('cmd','-')} provider={entry.get('provider','-')} count={entry.get('count',0)} duration={entry.get('duration',0)}"
         )
 
 

--- a/polylogue/cli/runs.py
+++ b/polylogue/cli/runs.py
@@ -18,6 +18,7 @@ def run_runs_cli(args: SimpleNamespace, env: CommandEnv) -> None:
     cmd_filter = _normalize_filter(getattr(args, "commands", None))
     since_epoch = parse_input_time_to_epoch(getattr(args, "since", None))
     until_epoch = parse_input_time_to_epoch(getattr(args, "until", None))
+    json_lines = bool(getattr(args, "json_lines", False))
     runs = load_runs(limit=limit)
     if provider_filter:
         runs = [run for run in runs if (run.get("provider") or "").lower() in provider_filter]
@@ -25,6 +26,11 @@ def run_runs_cli(args: SimpleNamespace, env: CommandEnv) -> None:
         runs = [run for run in runs if (run.get("cmd") or "").lower() in cmd_filter]
     if since_epoch is not None or until_epoch is not None:
         runs = [run for run in runs if _timestamp_in_range(run.get("timestamp"), since_epoch, until_epoch)]
+
+    if json_lines:
+        for row in runs:
+            print(json.dumps(row, separators=(",", ":"), sort_keys=True))
+        return
 
     if getattr(args, "json", False):
         if getattr(args, "json_verbose", False):

--- a/polylogue/cli/runs.py
+++ b/polylogue/cli/runs.py
@@ -29,9 +29,9 @@ def run_runs_cli(args: SimpleNamespace, env: CommandEnv) -> None:
     if getattr(args, "json", False):
         if getattr(args, "json_verbose", False):
             payload = stamp_payload({"runs": runs, "count": len(runs)})
-            print(json.dumps(payload, indent=2))
+            print(json.dumps(payload, indent=2, sort_keys=True))
         else:
-            print(json.dumps(runs, indent=2))
+            print(json.dumps(runs, indent=2, sort_keys=True))
         return
 
     if env.ui.plain:

--- a/polylogue/cli/search_cli.py
+++ b/polylogue/cli/search_cli.py
@@ -191,7 +191,7 @@ def run_search_cli(args: object, env: CommandEnv) -> None:
                 "hits": payload_hits,
             }
         )
-        print(json.dumps(payload, indent=2, ensure_ascii=False))
+        print(json.dumps(payload, indent=2, ensure_ascii=False, sort_keys=True))
         return
 
     if csv_target:
@@ -472,4 +472,3 @@ def run_search_preview(args: object) -> None:
 
 
 __all__ = ["run_search_cli", "run_search_preview", "find_anchor_line"]
-

--- a/polylogue/cli/settings_cli.py
+++ b/polylogue/cli/settings_cli.py
@@ -103,7 +103,7 @@ def run_settings_cli(args: SimpleNamespace, env: CommandEnv) -> None:
 
     payload = _settings_snapshot(settings)
     if getattr(args, "json", False):
-        print(json.dumps(stamp_payload(payload), indent=2))
+        print(json.dumps(stamp_payload(payload), indent=2, sort_keys=True))
         return
 
     summary_lines = [

--- a/polylogue/cli/status.py
+++ b/polylogue/cli/status.py
@@ -20,7 +20,7 @@ from .context import DEFAULT_OUTPUT_ROOTS, DEFAULT_RENDER_OUT
 
 
 def _dump_runs(ui, records: List[dict], destination: str, *, quiet: bool = False) -> None:
-    payload = json.dumps(records, indent=2)
+    payload = json.dumps(records, indent=2, sort_keys=True)
     if destination == "-":
         print(payload)
         return
@@ -32,7 +32,7 @@ def _dump_runs(ui, records: List[dict], destination: str, *, quiet: bool = False
 
 
 def _dump_summary(ui, payload: Dict[str, Any], destination: str, *, quiet: bool = False) -> None:
-    body = json.dumps(payload, indent=2)
+    body = json.dumps(payload, indent=2, sort_keys=True)
     if destination == "-":
         print(body)
         return
@@ -157,9 +157,9 @@ def run_status_cli(args: SimpleNamespace, env: CommandEnv) -> None:
                 }
             )
             if json_lines:
-                print(json.dumps(payload, separators=(",", ":")), flush=True)
+                print(json.dumps(payload, separators=(",", ":"), sort_keys=True), flush=True)
             else:
-                print(json.dumps(payload, indent=2))
+                print(json.dumps(payload, indent=2, sort_keys=True))
             return
 
         if ui.plain:
@@ -334,7 +334,11 @@ def run_stats_cli(args: SimpleNamespace, env: CommandEnv) -> None:
         if warnings:
             payload["warnings"] = warnings
         if json_mode:
-            encoded = json.dumps(payload, separators=(",", ":")) if json_lines else json.dumps(payload, indent=2)
+            encoded = (
+                json.dumps(payload, separators=(",", ":"), sort_keys=True)
+                if json_lines
+                else json.dumps(payload, indent=2, sort_keys=True)
+            )
             print(encoded)
         else:
             ui.summary("Stats", [message])
@@ -530,7 +534,7 @@ def run_stats_cli(args: SimpleNamespace, env: CommandEnv) -> None:
 
     if json_lines:
         for row in display_rows:
-            print(json.dumps(row, separators=(",", ":")))
+            print(json.dumps(row, separators=(",", ":"), sort_keys=True))
         if warnings and quiet_json:
             print("\n".join(warnings), file=sys.stderr)
         return
@@ -549,7 +553,7 @@ def run_stats_cli(args: SimpleNamespace, env: CommandEnv) -> None:
             "filtered_out": filtered_out,
             "warnings": warnings,
         }
-        print(json.dumps(payload, indent=2))
+        print(json.dumps(payload, indent=2, sort_keys=True))
         return
 
     if csv_destination:

--- a/polylogue/cli/sync.py
+++ b/polylogue/cli/sync.py
@@ -523,6 +523,7 @@ def _run_local_sync(provider_name: str, args: SimpleNamespace, env: CommandEnv) 
     prune = args.prune
     diff_enabled = getattr(args, "diff", False)
     meta = parse_meta_items(getattr(args, "meta", None)) or None
+    jobs = max(1, int(getattr(args, "jobs", 1) or 1))
 
     if not base_dir.exists():
         if provider.create_base_dir and args.base_dir is None:
@@ -591,6 +592,7 @@ def _run_local_sync(provider_name: str, args: SimpleNamespace, env: CommandEnv) 
             attachment_ocr=getattr(args, "attachment_ocr", False),
             sanitize_html=getattr(args, "sanitize_html", False),
             meta=meta,
+            jobs=jobs,
         )
     except Exception as exc:
         ui.console.print(f"[red]{provider.title} sync failed: {exc}")

--- a/polylogue/cli/sync.py
+++ b/polylogue/cli/sync.py
@@ -123,7 +123,7 @@ def run_list_cli(args: SimpleNamespace, env: CommandEnv, json_output: bool) -> N
                 "files": result.files,
             }
         )
-        print(json.dumps(payload, indent=2))
+        print(json.dumps(payload, indent=2, sort_keys=True))
         return
     console = env.ui.console
     console.print(f"{len(result.files)} chat(s) in {result.folder_name}:")
@@ -362,7 +362,7 @@ def _run_sync_drive(args: SimpleNamespace, env: CommandEnv) -> None:
             payload["redacted"] = True
         if previous_run_note:
             payload["previousRun"] = previous_run_note
-        print(json.dumps(stamp_payload(payload), indent=2))
+        print(json.dumps(stamp_payload(payload), indent=2, sort_keys=True))
         return
 
     lines = [f"Synced {result.count} chat(s) → {result.output_dir}"]
@@ -558,7 +558,7 @@ def _run_local_sync(provider_name: str, args: SimpleNamespace, env: CommandEnv) 
             payload["redacted"] = True
         if previous_run_note:
             payload["previousRun"] = previous_run_note
-        print(json.dumps(stamp_payload(payload), indent=2))
+        print(json.dumps(stamp_payload(payload), indent=2, sort_keys=True))
     else:
         summarize_import(ui, f"{provider.title} Sync", result.written, extra_lines=footer_lines)
         console = ui.console

--- a/polylogue/cli/verify.py
+++ b/polylogue/cli/verify.py
@@ -1,0 +1,330 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+from ..archive import Archive
+from ..commands import CommandEnv
+from ..document_store import read_existing_document
+from ..schema import stamp_payload
+
+
+@dataclass
+class VerifyIssue:
+    provider: str
+    conversation_id: str
+    path: Optional[Path]
+    message: str
+    severity: str = "error"  # error|warning|info
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "provider": self.provider,
+            "conversationId": self.conversation_id,
+            "path": str(self.path) if self.path else None,
+            "message": self.message,
+            "severity": self.severity,
+        }
+
+
+_PROVIDER_ALIASES = {
+    "drive-sync": "drive",
+    "claude.ai": "claude",
+}
+
+
+def _parse_csv_set(raw: Optional[str]) -> Optional[Set[str]]:
+    if not raw:
+        return None
+    values = {chunk.strip().lower() for chunk in str(raw).split(",") if chunk.strip()}
+    return values or None
+
+
+def _safe_json(raw: Optional[str]) -> Dict[str, Any]:
+    if not raw:
+        return {}
+    try:
+        payload = json.loads(raw)
+        return payload if isinstance(payload, dict) else {}
+    except Exception:
+        return {}
+
+
+def _resolve_archive_root(archive: Archive, provider: str) -> Optional[Path]:
+    canonical = _PROVIDER_ALIASES.get(provider, provider)
+    try:
+        return archive.provider_root(canonical)
+    except Exception:
+        return None
+
+
+def _resolve_conversation_paths(
+    *,
+    archive: Archive,
+    provider: str,
+    slug: str,
+    state_entry: Dict[str, Any],
+) -> Tuple[Optional[Path], Optional[Path]]:
+    output_path = state_entry.get("outputPath")
+    if isinstance(output_path, str) and output_path.strip():
+        path = Path(output_path)
+        return path, path.parent
+    root = _resolve_archive_root(archive, provider)
+    if root is None:
+        return None, None
+    md_path = root / slug / "conversation.md"
+    return md_path, md_path.parent
+
+
+def run_verify_cli(args: SimpleNamespace, env: CommandEnv) -> None:
+    ui = env.ui
+    provider_filter = _parse_csv_set(getattr(args, "provider", None))
+    slug_filter = str(getattr(args, "slug", "") or "").strip() or None
+    conversation_ids = [cid.strip() for cid in getattr(args, "conversation_ids", []) if cid and str(cid).strip()]
+    conversation_id_filter = set(conversation_ids) if conversation_ids else None
+    limit = getattr(args, "limit", None)
+    json_mode = bool(getattr(args, "json", False))
+
+    rows_raw = env.database.query(
+        "SELECT provider, conversation_id, slug, content_hash, metadata_json FROM conversations"
+    )
+    rows: List[Dict[str, Any]] = [dict(row) for row in rows_raw]
+    if provider_filter:
+        rows = [row for row in rows if str(row.get("provider") or "").lower() in provider_filter]
+    if slug_filter:
+        rows = [row for row in rows if str(row.get("slug") or "") == slug_filter]
+    if conversation_id_filter:
+        rows = [row for row in rows if str(row.get("conversation_id") or "") in conversation_id_filter]
+    if isinstance(limit, int) and limit > 0:
+        rows = rows[:limit]
+
+    issues: List[VerifyIssue] = []
+    verified = 0
+    for row in rows:
+        provider = str(row.get("provider") or "")
+        conversation_id = str(row.get("conversation_id") or "")
+        slug = str(row.get("slug") or "")
+        stored_content_hash = row.get("content_hash")
+        state_entry = _safe_json(row.get("metadata_json"))
+        md_path, conversation_dir = _resolve_conversation_paths(
+            archive=env.archive,
+            provider=provider,
+            slug=slug,
+            state_entry=state_entry,
+        )
+        if md_path is None:
+            issues.append(
+                VerifyIssue(
+                    provider=provider,
+                    conversation_id=conversation_id,
+                    path=None,
+                    message="Unable to resolve conversation path (missing state entry outputPath and archive root).",
+                )
+            )
+            continue
+        if not md_path.exists():
+            issues.append(
+                VerifyIssue(
+                    provider=provider,
+                    conversation_id=conversation_id,
+                    path=md_path,
+                    message="Missing conversation.md",
+                )
+            )
+            continue
+
+        existing = read_existing_document(md_path)
+        if existing is None:
+            issues.append(
+                VerifyIssue(
+                    provider=provider,
+                    conversation_id=conversation_id,
+                    path=md_path,
+                    message="Failed to parse front matter.",
+                )
+            )
+            continue
+
+        polylogue_meta = existing.metadata.get("polylogue")
+        if not isinstance(polylogue_meta, dict):
+            issues.append(
+                VerifyIssue(
+                    provider=provider,
+                    conversation_id=conversation_id,
+                    path=md_path,
+                    message="Missing polylogue front matter metadata.",
+                )
+            )
+            continue
+
+        fm_provider = polylogue_meta.get("provider")
+        fm_conversation_id = polylogue_meta.get("conversationId")
+        fm_slug = polylogue_meta.get("slug")
+        fm_content_hash = polylogue_meta.get("contentHash")
+        computed_hash = existing.content_hash
+
+        if fm_provider != provider:
+            issues.append(
+                VerifyIssue(
+                    provider=provider,
+                    conversation_id=conversation_id,
+                    path=md_path,
+                    message=f"Front matter provider mismatch: {fm_provider!r} != {provider!r}",
+                )
+            )
+        if fm_conversation_id != conversation_id:
+            issues.append(
+                VerifyIssue(
+                    provider=provider,
+                    conversation_id=conversation_id,
+                    path=md_path,
+                    message=f"Front matter conversationId mismatch: {fm_conversation_id!r} != {conversation_id!r}",
+                )
+            )
+        if fm_slug != slug:
+            issues.append(
+                VerifyIssue(
+                    provider=provider,
+                    conversation_id=conversation_id,
+                    path=md_path,
+                    message=f"Front matter slug mismatch: {fm_slug!r} != {slug!r}",
+                    severity="warning",
+                )
+            )
+        if fm_content_hash != computed_hash:
+            issues.append(
+                VerifyIssue(
+                    provider=provider,
+                    conversation_id=conversation_id,
+                    path=md_path,
+                    message="Front matter contentHash mismatch (re-render recommended).",
+                )
+            )
+        if stored_content_hash and stored_content_hash != computed_hash:
+            issues.append(
+                VerifyIssue(
+                    provider=provider,
+                    conversation_id=conversation_id,
+                    path=md_path,
+                    message="DB content_hash mismatch (re-render or repair DB).",
+                )
+            )
+        state_hash = state_entry.get("contentHash")
+        if state_hash and state_hash != computed_hash:
+            issues.append(
+                VerifyIssue(
+                    provider=provider,
+                    conversation_id=conversation_id,
+                    path=md_path,
+                    message="State entry contentHash mismatch (re-render recommended).",
+                    severity="warning",
+                )
+            )
+        state_output = state_entry.get("outputPath")
+        if isinstance(state_output, str) and state_output and str(md_path) != state_output:
+            issues.append(
+                VerifyIssue(
+                    provider=provider,
+                    conversation_id=conversation_id,
+                    path=md_path,
+                    message=f"State entry outputPath mismatch: {state_output!r}",
+                    severity="warning",
+                )
+            )
+
+        conv_dir = conversation_dir or md_path.parent
+        # Verify attachments referenced by the index.
+        att_rows = env.database.query(
+            """
+            SELECT attachment_path
+              FROM attachments
+             WHERE provider = ?
+               AND conversation_id = ?
+               AND attachment_path IS NOT NULL
+            """,
+            (provider, conversation_id),
+        )
+        for att in att_rows:
+            raw = att.get("attachment_path") if isinstance(att, dict) else att["attachment_path"]
+            if not isinstance(raw, str) or not raw:
+                continue
+            path = Path(raw)
+            if not path.is_absolute():
+                path = conv_dir / path
+            if not path.exists():
+                issues.append(
+                    VerifyIssue(
+                        provider=provider,
+                        conversation_id=conversation_id,
+                        path=path,
+                        message="Missing attachment file referenced by DB.",
+                    )
+                )
+
+        # Verify branch documents.
+        branch_rows = env.database.query(
+            "SELECT branch_id FROM branches WHERE provider = ? AND conversation_id = ?",
+            (provider, conversation_id),
+        )
+        for branch_row in branch_rows:
+            branch_id = branch_row.get("branch_id") if isinstance(branch_row, dict) else branch_row["branch_id"]
+            branch_id = str(branch_id or "")
+            if not branch_id:
+                continue
+            branch_dir = conv_dir / "branches" / branch_id
+            branch_path = branch_dir / f"{branch_id}.md"
+            overlay_path = branch_dir / "overlay.md"
+            if not branch_path.exists():
+                issues.append(
+                    VerifyIssue(
+                        provider=provider,
+                        conversation_id=conversation_id,
+                        path=branch_path,
+                        message="Missing branch markdown file.",
+                    )
+                )
+            if not overlay_path.exists():
+                issues.append(
+                    VerifyIssue(
+                        provider=provider,
+                        conversation_id=conversation_id,
+                        path=overlay_path,
+                        message="Missing branch overlay.md file.",
+                        severity="warning",
+                    )
+                )
+
+        verified += 1
+
+    error_count = sum(1 for issue in issues if issue.severity == "error")
+    warning_count = sum(1 for issue in issues if issue.severity == "warning")
+    info_count = sum(1 for issue in issues if issue.severity == "info")
+
+    if json_mode:
+        payload = stamp_payload(
+            {
+                "verified": verified,
+                "candidateCount": len(rows),
+                "errors": error_count,
+                "warnings": warning_count,
+                "info": info_count,
+                "issues": [issue.as_dict() for issue in issues],
+            }
+        )
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        ui.console.print(f"Verified {verified} conversation(s).")
+        if issues:
+            ui.console.print(f"[red]Errors:[/red] {error_count}  [yellow]Warnings:[/yellow] {warning_count}")
+            for issue in issues[:50]:
+                prefix = "ERROR" if issue.severity == "error" else "WARN" if issue.severity == "warning" else "INFO"
+                location = f" ({issue.path})" if issue.path else ""
+                ui.console.print(f"[{prefix}] {issue.provider}/{issue.conversation_id}: {issue.message}{location}")
+            if len(issues) > 50:
+                ui.console.print(f"... and {len(issues) - 50} more issue(s)")
+
+    if error_count:
+        raise SystemExit(1)

--- a/polylogue/cli_common.py
+++ b/polylogue/cli_common.py
@@ -43,6 +43,13 @@ def filter_chats(
                 f"Skipped {dropped_missing_modified} chat(s) missing modifiedTime; unable to apply --since/--until.",
                 file=sys.stderr,
             )
+    out.sort(
+        key=lambda c: (
+            -(parse_rfc3339_to_epoch(c.get("modifiedTime")) or 0.0),
+            (c.get("name") or "").lower(),
+            str(c.get("id") or ""),
+        )
+    )
     return out
 
 

--- a/polylogue/commands.py
+++ b/polylogue/commands.py
@@ -703,21 +703,29 @@ def sync_command(options: SyncOptions, env: CommandEnv) -> SyncResult:
             try:
                 pipeline.run(ctx)
             except Exception as exc:
+                stage = None
+                if ctx.history:
+                    stage = ctx.history[-1].get("name")
                 failures.append(
                     {
                         "id": meta.get("id"),
                         "name": meta.get("name"),
                         "error": str(exc),
+                        "stage": stage,
                     }
                 )
                 tracker.advance()
                 continue
             if ctx.aborted:
+                stage = None
+                if ctx.history:
+                    stage = ctx.history[-1].get("name")
                 failures.append(
                     {
                         "id": meta.get("id"),
                         "name": meta.get("name"),
                         "error": "aborted",
+                        "stage": stage,
                     }
                 )
                 tracker.advance()

--- a/polylogue/conversation.py
+++ b/polylogue/conversation.py
@@ -49,7 +49,7 @@ def _compute_branch_stats(
     return stats
 
 
-def _branch_map_snippet(branch_dir: Path, branch_ids: List[str]) -> Optional[str]:
+def _branch_map_snippet(_branch_dir: Path, branch_ids: List[str]) -> Optional[str]:
     if not branch_ids:
         return None
     lines: List[str] = []
@@ -469,6 +469,14 @@ def process_conversation(
         per_chunk_links=per_chunk_links,
         citations=citations,
     )
+
+    if len(plan.branches) > 1:
+        snippet = _branch_map_snippet(
+            (output_dir / slug) / "branches",
+            list(plan.branches.keys()),
+        )
+        if snippet:
+            document.body = f"{snippet}\n{document.body}"
 
     from .document_store import persist_document
 

--- a/polylogue/drive_async.py
+++ b/polylogue/drive_async.py
@@ -24,6 +24,7 @@ from typing import Any, Dict, List, Optional
 import sys
 
 from .util import colorize, get_cached_folder_id, set_cached_folder_id
+from tenacity import AsyncRetrying, retry_if_exception_type, stop_after_attempt, wait_exponential
 
 try:
     import httpx
@@ -111,31 +112,41 @@ async def _retry_async(
     notifier=None,
 ):
     """Async retry wrapper with exponential backoff."""
+    max_attempts = max(1, retries)
     base_delay = max(0.0, base_delay)
-    retries = max(1, retries)
-    last_err = None
+
     attempts = 0
-    for i in range(retries):
-        attempts += 1
-        try:
-            result = await fn()
-            _record_drive_completion(operation, attempts)
-            return result
-        except Exception as e:
-            last_err = e
-            delay = base_delay * (2 ** i)
-            if notifier:
-                try:
-                    notifier(operation=operation, attempt=attempts, total=retries, error=e, delay=delay)
-                except Exception:
-                    pass
-            if i == retries - 1:
-                _record_drive_completion(operation, attempts, error=e)
-                raise
-            await asyncio.sleep(delay)
-    if last_err:
-        raise last_err
-    return None
+
+    def _before(retry_state) -> None:
+        nonlocal attempts
+        attempts = retry_state.attempt_number
+
+    def _after(retry_state) -> None:
+        if notifier and retry_state.outcome.failed:
+            exc = retry_state.outcome.exception()
+            delay = base_delay * (2 ** (attempts - 1))
+            try:
+                notifier(operation=operation, attempt=attempts, total=max_attempts, error=exc, delay=delay)
+            except Exception:
+                pass
+
+    retrying = AsyncRetrying(
+        stop=stop_after_attempt(max_attempts),
+        wait=wait_exponential(multiplier=base_delay, exp_base=2, min=0),
+        retry=retry_if_exception_type(Exception),
+        reraise=True,
+        sleep=asyncio.sleep,
+        before=_before,
+        after=_after,
+    )
+
+    try:
+        result = await retrying(fn)
+        _record_drive_completion(operation, attempts or 1)
+        return result
+    except Exception as exc:
+        _record_drive_completion(operation, attempts or max_attempts, error=exc)
+        raise
 
 
 def _raise_for_status(resp: httpx.Response) -> None:

--- a/polylogue/frontmatter_canonical.py
+++ b/polylogue/frontmatter_canonical.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import frontmatter
+
+
+_PATH_KEYS = {
+    "outputPath",
+    "htmlPath",
+    "attachmentsDir",
+    "sourceExportPath",
+    "sessionPath",
+    "sessionFile",
+    "bundle_path",
+    "export_root",
+}
+
+_ALWAYS_SCRUB = {"outputPath", "htmlPath", "attachmentsDir"}
+
+
+def _deep_sort(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: _deep_sort(value[key]) for key in sorted(value)}
+    if isinstance(value, list):
+        return [_deep_sort(item) for item in value]
+    return value
+
+
+def _scrub_paths(value: Any, *, repo_root: Path) -> Any:
+    if isinstance(value, dict):
+        scrubbed: Dict[str, Any] = {}
+        for key, item in value.items():
+            if key in _PATH_KEYS and isinstance(item, str):
+                if key in _ALWAYS_SCRUB:
+                    scrubbed[key] = "<path>"
+                else:
+                    scrubbed[key] = _scrub_path_string(item, repo_root=repo_root)
+            else:
+                scrubbed[key] = _scrub_paths(item, repo_root=repo_root)
+        return scrubbed
+    if isinstance(value, list):
+        return [_scrub_paths(item, repo_root=repo_root) for item in value]
+    if isinstance(value, str):
+        return value
+    return value
+
+
+def _scrub_path_string(value: str, *, repo_root: Path) -> str:
+    text = value.strip()
+    if not text:
+        return value
+    try:
+        path = Path(text)
+    except Exception:
+        return value
+    if not path.is_absolute():
+        return text
+    try:
+        rel = path.relative_to(repo_root)
+        return str(rel)
+    except Exception:
+        return "<abs>"
+
+
+def canonicalize_markdown(
+    text: str,
+    *,
+    repo_root: Optional[Path] = None,
+    scrub_paths: bool = False,
+    sort_keys: bool = True,
+) -> str:
+    post = frontmatter.loads(text)
+    metadata: Dict[str, Any] = dict(post.metadata)
+    if scrub_paths and repo_root is not None:
+        metadata = _scrub_paths(metadata, repo_root=repo_root)
+    if sort_keys:
+        metadata = _deep_sort(metadata)
+    return frontmatter.dumps(frontmatter.Post(post.content, **metadata))
+
+
+def canonicalize_file(
+    path: Path,
+    *,
+    repo_root: Optional[Path] = None,
+    scrub_paths: bool = False,
+    sort_keys: bool = True,
+) -> bool:
+    text = path.read_text(encoding="utf-8")
+    out = canonicalize_markdown(text, repo_root=repo_root, scrub_paths=scrub_paths, sort_keys=sort_keys)
+    if out == text:
+        return False
+    path.write_text(out, encoding="utf-8")
+    return True

--- a/polylogue/importers/chatgpt.py
+++ b/polylogue/importers/chatgpt.py
@@ -177,6 +177,7 @@ def import_chatgpt_export(
     registrar: Optional[ConversationRegistrar] = None,
     attachment_ocr: bool = False,
     sanitize_html: bool = False,
+    meta: Optional[Dict[str, str]] = None,
 ) -> List[ImportResult]:
     """Import ChatGPT export to database.
 
@@ -235,6 +236,7 @@ def import_chatgpt_export(
                                 registrar=registrar,
                                 attachment_ocr=attachment_ocr,
                                 sanitize_html=sanitize_html,
+                                meta=meta,
                             )
                         )
                         if raw_hash:
@@ -304,6 +306,7 @@ def _render_chatgpt_conversation(
     registrar: Optional[ConversationRegistrar],
     attachment_ocr: bool = False,
     sanitize_html: bool = False,
+    meta: Optional[Dict[str, str]] = None,
 ) -> ImportResult:
     title = conv.get("title") or "chatgpt-conversation"
     conv_id = conv.get("id") or conv.get("conversation_id") or "chat"
@@ -440,6 +443,7 @@ def _render_chatgpt_conversation(
         extra_state={
             "sourceModel": model_slug,
             "sourceExportPath": str(export_root),
+            "cliMeta": dict(meta) if meta else None,
         },
         source_file_id=conversation_id,
         modified_time=conv.get("update_time") or conv.get("modified_time"),

--- a/polylogue/importers/claude_ai.py
+++ b/polylogue/importers/claude_ai.py
@@ -75,6 +75,7 @@ def import_claude_export(
     registrar: Optional[ConversationRegistrar] = None,
     attachment_ocr: bool = False,
     sanitize_html: bool = False,
+    meta: Optional[Dict[str, str]] = None,
 ) -> List[ImportResult]:
     registrar = registrar or create_default_registrar()
     root, tmp = _load_bundle(export_path)
@@ -125,6 +126,7 @@ def import_claude_export(
                         registrar=registrar,
                         attachment_ocr=attachment_ocr,
                         sanitize_html=sanitize_html,
+                        meta=meta,
                     )
                 )
                 if raw_hash:
@@ -185,6 +187,7 @@ def _render_claude_conversation(
     registrar: Optional[ConversationRegistrar],
     attachment_ocr: bool = False,
     sanitize_html: bool = False,
+    meta: Optional[Dict[str, str]] = None,
 ) -> ImportResult:
     title = conv.get("name") or conv.get("title") or "claude-chat"
     conv_id = conv.get("uuid") or conv.get("id") or "claude"
@@ -311,6 +314,7 @@ def _render_claude_conversation(
         extra_state={
             "sourceModel": model_id,
             "sourceExportPath": str(export_root),
+            "cliMeta": dict(meta) if meta else None,
         },
         source_file_id=conv_id,
         modified_time=conv.get("updated_at") or conv.get("modified_at"),

--- a/polylogue/importers/codex.py
+++ b/polylogue/importers/codex.py
@@ -37,9 +37,11 @@ def import_codex_session(
     registrar: Optional[ConversationRegistrar] = None,
     attachment_ocr: bool = False,
     sanitize_html: bool = False,
+    meta: Optional[Dict[str, str]] = None,
 ) -> ImportResult:
     from .raw_storage import store_raw_import, mark_parse_success, mark_parse_failed
 
+    cli_meta = dict(meta) if meta else None
     registrar = registrar or create_default_registrar()
     base_dir = base_dir.expanduser()
     candidate = Path(session_id)
@@ -240,8 +242,8 @@ def import_codex_session(
                     if parent_id and "parentId" not in chunks[idx]:
                         chunks[idx]["parentId"] = parent_id
                         chunks[idx]["branchParent"] = parent_id
-                    meta = chunk_metadata[idx]
-                    calls = meta.setdefault("tool_calls", [])
+                    chunk_meta = chunk_metadata[idx]
+                    calls = chunk_meta.setdefault("tool_calls", [])
                     if calls:
                         calls[0]["output"] = output_text
                     else:
@@ -292,7 +294,7 @@ def import_codex_session(
         if parent_id and "parentId" not in chunk:
             chunk["parentId"] = parent_id
             chunk["branchParent"] = parent_id
-        meta = chunk_metadata[idx] if idx < len(chunk_metadata) else {}
+        chunk_meta = chunk_metadata[idx] if idx < len(chunk_metadata) else {}
         links = list(per_chunk_links.get(idx, []))
         message_records.append(
             build_message_record(
@@ -300,9 +302,9 @@ def import_codex_session(
                 conversation_id=session_id,
                 chunk_index=idx,
                 chunk=chunk,
-                raw_metadata=meta.get("raw") if isinstance(meta, dict) else None,
+                raw_metadata=chunk_meta.get("raw") if isinstance(chunk_meta, dict) else None,
                 attachments=links,
-                tool_calls=meta.get("tool_calls") if isinstance(meta, dict) else None,
+                tool_calls=chunk_meta.get("tool_calls") if isinstance(chunk_meta, dict) else None,
                 seen_ids=seen_message_ids,
                 fallback_prefix=slug,
             )
@@ -331,6 +333,7 @@ def import_codex_session(
             extra_yaml=extra_yaml,
             extra_state={
                 "sessionPath": str(session_path),
+                "cliMeta": cli_meta,
             },
             source_file_id=session_id,
             modified_time=None,

--- a/polylogue/importers/utils.py
+++ b/polylogue/importers/utils.py
@@ -79,12 +79,21 @@ def store_large_text(
     attachments: List[AttachmentInfo],
     per_chunk_links: Dict[int, List[Tuple[str, Path]]],
     prefix: str = "chunk",
+    routing_stats: Optional[Dict[str, int]] = None,
 ) -> str:
     """Persist oversized text to an attachment and return a preview."""
 
+    if not text:
+        return text
+
     lines = text.splitlines()
     if len(lines) <= LINE_THRESHOLD and len(text) <= CHAR_THRESHOLD:
+        if routing_stats is not None:
+            routing_stats["skipped"] = routing_stats.get("skipped", 0) + 1
         return text
+
+    if routing_stats is not None:
+        routing_stats["routed"] = routing_stats.get("routed", 0) + 1
 
     attachments_dir.mkdir(parents=True, exist_ok=True)
     attachment_name = f"{prefix}{chunk_index:03d}.txt"

--- a/polylogue/local_sync.py
+++ b/polylogue/local_sync.py
@@ -130,6 +130,7 @@ def _sync_sessions(
     ui: Optional[UI] = None,
     attachment_ocr: bool = False,
     sanitize_html: bool = False,
+    meta: Optional[Dict[str, str]] = None,
 ) -> LocalSyncResult:
     if registrar is None:
         state_dir = output_dir / ".polylogue-state"
@@ -145,6 +146,8 @@ def _sync_sessions(
     importer_kwargs.setdefault("registrar", registrar)
     importer_kwargs.setdefault("attachment_ocr", attachment_ocr)
     importer_kwargs.setdefault("sanitize_html", sanitize_html)
+    if meta:
+        importer_kwargs.setdefault("meta", dict(meta))
     attachments_total = 0
     attachment_bytes_total = 0
     tokens_total = 0
@@ -491,6 +494,7 @@ def _sync_export_bundles(
     ui: Optional[UI] = None,
     attachment_ocr: bool = False,
     sanitize_html: bool = False,
+    meta: Optional[Dict[str, str]] = None,
 ) -> LocalSyncResult:
     registrar = registrar or create_default_registrar()
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -557,6 +561,7 @@ def _sync_export_bundles(
                 registrar=registrar,
                 attachment_ocr=attachment_ocr,
                 sanitize_html=sanitize_html,
+                meta=dict(meta) if meta else None,
             )
             if bundle_hash:
                 from .util import current_utc_timestamp
@@ -644,6 +649,7 @@ def sync_codex_sessions(
     ui: Optional[UI] = None,
     attachment_ocr: bool = False,
     sanitize_html: bool = False,
+    meta: Optional[Dict[str, str]] = None,
 ) -> LocalSyncResult:
     base_dir = base_dir.expanduser()
     if sessions is None:
@@ -669,6 +675,7 @@ def sync_codex_sessions(
         ui=ui,
         attachment_ocr=attachment_ocr,
         sanitize_html=sanitize_html,
+        meta=meta,
     )
 
 
@@ -688,6 +695,7 @@ def sync_claude_code_sessions(
     ui: Optional[UI] = None,
     attachment_ocr: bool = False,
     sanitize_html: bool = False,
+    meta: Optional[Dict[str, str]] = None,
 ) -> LocalSyncResult:
     base_dir = base_dir.expanduser()
     if sessions is None:
@@ -713,6 +721,7 @@ def sync_claude_code_sessions(
         ui=ui,
         attachment_ocr=attachment_ocr,
         sanitize_html=sanitize_html,
+        meta=meta,
     )
 
 
@@ -754,6 +763,7 @@ def sync_chatgpt_exports(
     ui: Optional[UI] = None,
     attachment_ocr: bool = False,
     sanitize_html: bool = False,
+    meta: Optional[Dict[str, str]] = None,
 ) -> LocalSyncResult:
     base_dir = base_dir.expanduser()
     base_dir.mkdir(parents=True, exist_ok=True)
@@ -789,6 +799,7 @@ def sync_chatgpt_exports(
         ui=ui,
         attachment_ocr=attachment_ocr,
         sanitize_html=sanitize_html,
+        meta=meta,
     )
 
 
@@ -808,6 +819,7 @@ def sync_claude_exports(
     ui: Optional[UI] = None,
     attachment_ocr: bool = False,
     sanitize_html: bool = False,
+    meta: Optional[Dict[str, str]] = None,
 ) -> LocalSyncResult:
     base_dir = base_dir.expanduser()
     base_dir.mkdir(parents=True, exist_ok=True)
@@ -843,6 +855,7 @@ def sync_claude_exports(
         ui=ui,
         attachment_ocr=attachment_ocr,
         sanitize_html=sanitize_html,
+        meta=meta,
     )
 
 

--- a/polylogue/options.py
+++ b/polylogue/options.py
@@ -19,6 +19,7 @@ class RenderOptions:
     diff: bool = False
     attachment_ocr: bool = False
     sanitize_html: bool = False
+    meta: Optional[Dict[str, str]] = None
 
 
 @dataclass
@@ -42,6 +43,7 @@ class SyncOptions:
     prefetched_chats: Optional[List[Dict[str, Any]]] = None
     attachment_ocr: bool = False
     sanitize_html: bool = False
+    meta: Optional[Dict[str, str]] = None
 
 
 @dataclass

--- a/polylogue/render.py
+++ b/polylogue/render.py
@@ -593,6 +593,15 @@ def build_markdown_from_chunks(
 
     attachments_list = attachments or []
     if attachments_list:
+        attachments_list = sorted(
+            attachments_list,
+            key=lambda info: (
+                (info.name or "").lower(),
+                (info.link or ""),
+                info.local_path.as_posix() if info.local_path else "",
+            ),
+        )
+    if attachments_list:
         parts.append("## Attachments\n\n")
         for info in attachments_list:
             size = _human_size(info.size_bytes)

--- a/polylogue/util.py
+++ b/polylogue/util.py
@@ -535,6 +535,11 @@ def snapshot_for_diff(path: Path) -> Optional[Path]:
 
 
 def current_utc_timestamp() -> str:
+    fixed = os.environ.get("POLYLOGUE_FIXED_NOW")
+    if fixed:
+        fixed = fixed.strip()
+        if fixed:
+            return fixed
     return (
         datetime.datetime.now(datetime.timezone.utc)
         .replace(microsecond=0)

--- a/polylogue/util.py
+++ b/polylogue/util.py
@@ -178,6 +178,7 @@ def load_runs(limit: Optional[int] = None) -> list[dict]:
             "count": row["count"],
             "attachments": row["attachments"],
             "attachment_bytes": row["attachment_bytes"],
+            "attachmentBytes": row["attachment_bytes"],
             "tokens": row["tokens"],
             "skipped": row["skipped"],
             "pruned": row["pruned"],
@@ -213,6 +214,7 @@ def get_run_by_id(run_id: int) -> Optional[dict]:
         "count": row["count"],
         "attachments": row["attachments"],
         "attachment_bytes": row["attachment_bytes"],
+        "attachmentBytes": row["attachment_bytes"],
         "tokens": row["tokens"],
         "skipped": row["skipped"],
         "pruned": row["pruned"],
@@ -439,7 +441,7 @@ def add_run(record: Dict[str, Any]) -> None:
     cmd = payload.get("cmd") or "unknown"
     count = int(payload.get("count") or 0)
     attachments = int(payload.get("attachments") or 0)
-    attachment_bytes = int(payload.get("attachment_bytes") or 0)
+    attachment_bytes = int(payload.get("attachment_bytes") or payload.get("attachmentBytes") or 0)
     tokens = int(payload.get("tokens") or 0)
     skipped = int(payload.get("skipped") or 0)
     pruned = int(payload.get("pruned") or 0)
@@ -460,6 +462,7 @@ def add_run(record: Dict[str, Any]) -> None:
             "count",
             "attachments",
             "attachment_bytes",
+            "attachmentBytes",
             "tokens",
             "skipped",
             "pruned",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,11 +39,13 @@ def _build_tiktoken_stub() -> types.ModuleType:
     core_module = types.ModuleType("tiktoken.core")
     core_module.Encoding = _SimpleEncoding  # type: ignore[attr-defined]
     module.core = core_module  # type: ignore[attr-defined]
-    sys.modules.setdefault("tiktoken.core", core_module)
+    sys.modules["tiktoken.core"] = core_module
     return module
 
 
-sys.modules.setdefault("tiktoken", _build_tiktoken_stub())
+_tiktoken_stub = _build_tiktoken_stub()
+# Force deterministic tokenization in tests even when `tiktoken` is installed.
+sys.modules["tiktoken"] = _tiktoken_stub
 
 def _configure_state(monkeypatch, root: Path) -> Path:
     state_root = root / "state"

--- a/tests/golden/chatgpt-basic.md
+++ b/tests/golden/chatgpt-basic.md
@@ -1,0 +1,51 @@
+---
+attachmentPolicy:
+  charThreshold: 4000
+  extractedCount: 0
+  lineThreshold: 40
+  previewLines: 5
+  routing:
+    routed: 0
+    skipped: 2
+attachment_bytes: 0
+attachmentsDir: null
+collapseThreshold: 10
+contentHash: 0e389ee88a35ed7ab13edee24abd8e7867cb0046e183a0f1e39139007d30f1c9
+currentBranch: branch-000
+dirty: false
+html: false
+htmlPath: null
+lastImported: '2000-01-01T00:00:00Z'
+lastUpdated: 4
+outputPath: <path>
+polylogue:
+  contentHash: 0e389ee88a35ed7ab13edee24abd8e7867cb0046e183a0f1e39139007d30f1c9
+  conversationId: golden-chatgpt-1
+  lastUpdated: '4'
+  provider: chatgpt
+  slug: golden-chatgpt
+  title: Golden ChatGPT
+slug: golden-chatgpt
+sourceExportPath: tests/fixtures/golden/chatgpt
+title: Golden ChatGPT
+token_count: 19
+tokens: 19
+word_count: 19
+words: 19
+---
+
+## User
+
+Hello, ChatGPT.
+
+Here is code:
+
+```python
+print('hi')
+```
+
+And a link: https://example.com
+
+## Model
+
+Reply with an inline footnote: [7] works.

--- a/tests/golden/claude-basic.md
+++ b/tests/golden/claude-basic.md
@@ -1,0 +1,43 @@
+---
+attachmentPolicy:
+  charThreshold: 4000
+  extractedCount: 0
+  lineThreshold: 40
+  previewLines: 5
+  routing:
+    routed: 0
+    skipped: 2
+attachment_bytes: 0
+attachmentsDir: null
+collapseThreshold: 10
+contentHash: 03bee25aeb24d3008c8f09f69d67e6c740a5d26efbd1faf2a592cd29221255fc
+currentBranch: branch-000
+dirty: false
+html: false
+htmlPath: null
+lastImported: '2000-01-01T00:00:00Z'
+lastUpdated: null
+outputPath: <path>
+polylogue:
+  contentHash: 03bee25aeb24d3008c8f09f69d67e6c740a5d26efbd1faf2a592cd29221255fc
+  conversationId: golden-claude-1
+  lastUpdated: null
+  provider: claude.ai
+  slug: golden-claude
+  title: Golden Claude
+slug: golden-claude
+sourceExportPath: tests/fixtures/golden/claude
+title: Golden Claude
+token_count: 6
+tokens: 6
+word_count: 6
+words: 6
+---
+
+## User
+
+Hello, Claude.
+
+## Model
+
+Inline footnote: [3] ok.

--- a/tests/golden/claude-code-basic.md
+++ b/tests/golden/claude-code-basic.md
@@ -1,0 +1,56 @@
+---
+attachmentPolicy:
+  charThreshold: 4000
+  extractedCount: 0
+  lineThreshold: 40
+  previewLines: 5
+  routing:
+    routed: 0
+    skipped: 3
+attachment_bytes: 0
+attachmentsDir: null
+collapseThreshold: 10
+contentHash: c958013174df7a51a0e6a91df74991861f8f5742ca279b32661e54381235ba63
+currentBranch: branch-000
+dirty: false
+html: false
+htmlPath: null
+lastImported: '2000-01-01T00:00:00Z'
+lastUpdated: null
+outputPath: <path>
+polylogue:
+  contentHash: c958013174df7a51a0e6a91df74991861f8f5742ca279b32661e54381235ba63
+  conversationId: tests/fixtures/golden/claude_code/claude-code-golden.jsonl
+  lastUpdated: null
+  provider: claude-code
+  slug: claude-code-golden
+  title: claude-code-golden
+sessionFile: tests/fixtures/golden/claude_code/claude-code-golden.jsonl
+slug: claude-code-golden
+title: claude-code-golden
+token_count: 22
+tokens: 22
+word_count: 22
+words: 22
+workspace: claude_code
+---
+
+## User
+
+Hello from Claude Code.
+
+## Model
+
+Footnote: [7] ok.
+
+## Model
+
+Tool call `bash`
+```json
+{
+  "cmd": "echo hi"
+}
+```
+
+Result:
+[2] tool output footnote

--- a/tests/golden/codex-basic.md
+++ b/tests/golden/codex-basic.md
@@ -1,0 +1,55 @@
+---
+attachmentPolicy:
+  charThreshold: 4000
+  extractedCount: 0
+  lineThreshold: 40
+  previewLines: 5
+  routing:
+    routed: 0
+    skipped: 3
+attachment_bytes: 0
+attachmentsDir: null
+collapseThreshold: 10
+contentHash: 866414d75a1892d89263f4c3cce6b6be71f71ce2b7407b9ffa6d1114726d95c1
+currentBranch: branch-000
+dirty: false
+html: false
+htmlPath: null
+lastImported: '2000-01-01T00:00:00Z'
+lastUpdated: null
+outputPath: <path>
+polylogue:
+  contentHash: 866414d75a1892d89263f4c3cce6b6be71f71ce2b7407b9ffa6d1114726d95c1
+  conversationId: tests/fixtures/golden/codex/codex-golden.jsonl
+  lastUpdated: null
+  provider: codex
+  slug: codex-golden
+  title: codex-golden
+sessionPath: tests/fixtures/golden/codex/codex-golden.jsonl
+slug: codex-golden
+title: codex-golden
+token_count: 20
+tokens: 20
+word_count: 20
+words: 20
+---
+
+## User
+
+Hello from Codex.
+
+## Model
+
+Footnote: [9] ok.
+
+## Model
+
+Tool call `bash`
+```json
+{
+  "cmd": "echo hi"
+}
+```
+
+Output:
+[1] output footnote

--- a/tests/golden_html/chatgpt-basic.html
+++ b/tests/golden_html/chatgpt-basic.html
@@ -1,0 +1,333 @@
+
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Golden ChatGPT</title>
+    <style>
+      :root {
+        --bg: #ffffff;
+        --fg: #222222;
+        --accent: #2563eb;
+        --border: #3b82f644;
+      }
+      * { box-sizing: border-box; }
+      body {
+        background: var(--bg);
+        color: var(--fg);
+        font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        margin: 0;
+        line-height: 1.6;
+      }
+      header {
+        position: sticky;
+        top: 0;
+        z-index: 10;
+        backdrop-filter: blur(6px);
+        background: color-mix(in srgb, var(--bg) 88%, transparent);
+        border-bottom: 1px solid var(--border);
+        padding: 0.75rem 1.5rem;
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+      }
+      main {
+        max-width: 980px;
+        margin: 0 auto;
+        padding: 1.5rem;
+      }
+      h1 { margin: 0; font-size: 1.5rem; }
+      a { color: var(--accent); }
+      .pill {
+        border: 1px solid var(--border);
+        padding: 0.35rem 0.6rem;
+        border-radius: 999px;
+        font-size: 0.9rem;
+      }
+      .toolbar { display: flex; gap: 0.75rem; align-items: center; }
+      .search-input {
+        flex: 1;
+        padding: 0.45rem 0.75rem;
+        border-radius: 8px;
+        border: 1px solid var(--border);
+        background: color-mix(in srgb, var(--bg) 96%, #00000008);
+        color: var(--fg);
+      }
+      .layout { display: grid; grid-template-columns: 260px 1fr; gap: 1.25rem; align-items: start; }
+      .card {
+        border: 1px solid var(--border);
+        border-radius: 12px;
+        padding: 1rem;
+        background: color-mix(in srgb, var(--bg) 96%, #00000006);
+      }
+      .metadata table {
+        width: 100%;
+        border-collapse: collapse;
+        margin-bottom: 0.5rem;
+      }
+      .metadata th, .metadata td {
+        border: 1px solid var(--border);
+        padding: 0.35rem 0.5rem;
+        text-align: left;
+        font-size: 0.9rem;
+      }
+      .toc ul { list-style: none; padding-left: 0; margin: 0; }
+      .toc li { margin: 0.2rem 0; }
+      .toc a { text-decoration: none; }
+      .attachments { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 0.75rem; }
+      .attachment {
+        border: 1px solid var(--border);
+        border-radius: 10px;
+        padding: 0.6rem 0.75rem;
+        background: color-mix(in srgb, var(--bg) 94%, #00000008);
+      }
+      .content blockquote {
+        border-left: 4px solid #3b82f6;
+        padding-left: 1rem;
+        margin-left: 0;
+        background: #3b82f611;
+      }
+      details.callout {
+        margin: 1rem 0;
+        border-left: 4px solid #3b82f6;
+        padding-left: 1rem;
+        background: #3b82f611;
+      }
+      details.callout summary {
+        cursor: pointer;
+        font-weight: 600;
+        list-style: none;
+      }
+      details.callout summary::-webkit-details-marker { display: none; }
+      details.callout summary::before {
+        content: '▶';
+        display: inline-block;
+        margin-right: 0.5rem;
+        transform: rotate(0deg);
+        transition: transform 0.2s ease;
+      }
+      details.callout[open] summary::before { transform: rotate(90deg); }
+      pre {
+        background: #22222211;
+        padding: 0.75rem;
+        overflow-x: auto;
+      }
+      code { font-family: "JetBrains Mono", "Fira Code", monospace; }
+      h2 { margin-top: 2rem; }
+      .hidden { display: none !important; }
+      .anchor-btn {
+        margin-left: 0.4rem;
+        font-size: 0.85rem;
+        color: var(--accent);
+        text-decoration: none;
+        opacity: 0.7;
+      }
+      .anchor-btn:hover { opacity: 1; }
+    </style>
+  </head>
+  <body>
+    <header>
+      <div class="pill">Golden ChatGPT</div>
+      <input class="search-input" id="client-search" type="search" placeholder="Filter text (press / to focus)" />
+      <div class="toolbar"><span class="pill" id="match-count"></span></div>
+    </header>
+    <main>
+      <div class="layout">
+        <div class="card toc">
+          <h3>Contents</h3>
+          <ul id="toc"></ul>
+          
+        </div>
+        <div>
+          <div class="card metadata">
+            <table>
+              <tbody>
+                
+                <tr>
+                  <th>attachmentPolicy</th>
+                  <td>{&#34;charThreshold&#34;: 4000, &#34;extractedCount&#34;: 0, &#34;lineThreshold&#34;: 40, &#34;previewLines&#34;: 5, &#34;routing&#34;: {&#34;routed&#34;: 0, &#34;skipped&#34;: 2}}</td>
+                </tr>
+                
+                <tr>
+                  <th>attachment_bytes</th>
+                  <td>0</td>
+                </tr>
+                
+                <tr>
+                  <th>attachments</th>
+                  <td>0</td>
+                </tr>
+                
+                <tr>
+                  <th>attachmentsDir</th>
+                  <td>None</td>
+                </tr>
+                
+                <tr>
+                  <th>collapseThreshold</th>
+                  <td>10</td>
+                </tr>
+                
+                <tr>
+                  <th>contentHash</th>
+                  <td>0e389ee88a35ed7ab13edee24abd8e7867cb0046e183a0f1e39139007d30f1c9</td>
+                </tr>
+                
+                <tr>
+                  <th>currentBranch</th>
+                  <td>branch-000</td>
+                </tr>
+                
+                <tr>
+                  <th>dirty</th>
+                  <td>False</td>
+                </tr>
+                
+                <tr>
+                  <th>html</th>
+                  <td>False</td>
+                </tr>
+                
+                <tr>
+                  <th>htmlPath</th>
+                  <td>None</td>
+                </tr>
+                
+                <tr>
+                  <th>lastImported</th>
+                  <td>2000-01-01T00:00:00Z</td>
+                </tr>
+                
+                <tr>
+                  <th>lastUpdated</th>
+                  <td>4</td>
+                </tr>
+                
+                <tr>
+                  <th>outputPath</th>
+                  <td>&lt;path&gt;</td>
+                </tr>
+                
+                <tr>
+                  <th>polylogue</th>
+                  <td>{&#34;contentHash&#34;: &#34;0e389ee88a35ed7ab13edee24abd8e7867cb0046e183a0f1e39139007d30f1c9&#34;, &#34;conversationId&#34;: &#34;golden-chatgpt-1&#34;, &#34;lastUpdated&#34;: &#34;4&#34;, &#34;provider&#34;: &#34;chatgpt&#34;, &#34;slug&#34;: &#34;golden-chatgpt&#34;, &#34;title&#34;: &#34;Golden ChatGPT&#34;}</td>
+                </tr>
+                
+                <tr>
+                  <th>slug</th>
+                  <td>golden-chatgpt</td>
+                </tr>
+                
+                <tr>
+                  <th>sourceExportPath</th>
+                  <td>tests/fixtures/golden/chatgpt</td>
+                </tr>
+                
+                <tr>
+                  <th>title</th>
+                  <td>Golden ChatGPT</td>
+                </tr>
+                
+                <tr>
+                  <th>token_count</th>
+                  <td>19</td>
+                </tr>
+                
+                <tr>
+                  <th>tokens</th>
+                  <td>19</td>
+                </tr>
+                
+                <tr>
+                  <th>word_count</th>
+                  <td>19</td>
+                </tr>
+                
+                <tr>
+                  <th>words</th>
+                  <td>19</td>
+                </tr>
+                
+              </tbody>
+            </table>
+          </div>
+          <div class="content" id="content"><h2 id="user">User</h2>
+<p>Hello, ChatGPT.</p>
+<p>Here is code:</p>
+<pre><code class="language-python">print('hi')
+</code></pre>
+<p>And a link: https://example.com</p>
+<h2 id="model">Model</h2>
+<p>Reply with an inline footnote: [7] works.</p>
+</div>
+        </div>
+      </div>
+    </main>
+    <script>
+      const tocEl = document.getElementById('toc');
+      const headings = document.querySelectorAll('#content h1, #content h2, #content h3');
+      headings.forEach(h => {
+        if (!h.id) return;
+        const anchor = document.createElement('a');
+        anchor.href = `#${h.id}`;
+        anchor.textContent = '🔗';
+        anchor.className = 'anchor-btn';
+        anchor.title = 'Copy link';
+        anchor.addEventListener('click', evt => {
+          evt.preventDefault();
+          const url = `${window.location.origin}${window.location.pathname}#${h.id}`;
+          navigator.clipboard?.writeText(url).catch(() => {});
+          window.location.hash = h.id;
+        });
+        h.appendChild(anchor);
+        const li = document.createElement('li');
+        const a = document.createElement('a');
+        a.href = `#${h.id}`;
+        a.textContent = h.textContent;
+        li.appendChild(a);
+        tocEl.appendChild(li);
+      });
+      const searchInput = document.getElementById('client-search');
+      const content = document.getElementById('content');
+      const blocks = Array.from(content.querySelectorAll('p, li, blockquote, details'));
+      const matchCount = document.getElementById('match-count');
+      function applyFilter(term) {
+        const q = term.trim().toLowerCase();
+        let matches = 0;
+        blocks.forEach(el => {
+          const text = el.textContent.toLowerCase();
+          const hit = q && text.includes(q);
+          el.classList.toggle('hidden', q && !hit);
+          if (hit) matches += 1;
+        });
+        matchCount.textContent = q ? `${matches} match(es)` : '';
+      }
+      searchInput.addEventListener('input', (e) => applyFilter(e.target.value));
+      window.addEventListener('keydown', (e) => {
+        if (e.key === '/' && document.activeElement !== searchInput) {
+          e.preventDefault();
+          searchInput.focus();
+        }
+      });
+
+      // Add copy-link buttons for message anchors (msg-N)
+      const msgAnchors = content.querySelectorAll('a[id^="msg-"]');
+      msgAnchors.forEach(anchor => {
+        const id = anchor.getAttribute('id');
+        if (!id) return;
+        const btn = document.createElement('a');
+        btn.href = `#${id}`;
+        btn.textContent = '🔗';
+        btn.className = 'anchor-btn';
+        btn.title = 'Copy link to message';
+        btn.addEventListener('click', evt => {
+          evt.preventDefault();
+          const url = `${window.location.origin}${window.location.pathname}#${id}`;
+          navigator.clipboard?.writeText(url).catch(() => {});
+          window.location.hash = id;
+        });
+        anchor.insertAdjacentElement('afterend', btn);
+      });
+    </script>
+  </body>
+</html>

--- a/tests/golden_html/claude-basic.html
+++ b/tests/golden_html/claude-basic.html
@@ -1,0 +1,329 @@
+
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Golden Claude</title>
+    <style>
+      :root {
+        --bg: #ffffff;
+        --fg: #222222;
+        --accent: #2563eb;
+        --border: #3b82f644;
+      }
+      * { box-sizing: border-box; }
+      body {
+        background: var(--bg);
+        color: var(--fg);
+        font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        margin: 0;
+        line-height: 1.6;
+      }
+      header {
+        position: sticky;
+        top: 0;
+        z-index: 10;
+        backdrop-filter: blur(6px);
+        background: color-mix(in srgb, var(--bg) 88%, transparent);
+        border-bottom: 1px solid var(--border);
+        padding: 0.75rem 1.5rem;
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+      }
+      main {
+        max-width: 980px;
+        margin: 0 auto;
+        padding: 1.5rem;
+      }
+      h1 { margin: 0; font-size: 1.5rem; }
+      a { color: var(--accent); }
+      .pill {
+        border: 1px solid var(--border);
+        padding: 0.35rem 0.6rem;
+        border-radius: 999px;
+        font-size: 0.9rem;
+      }
+      .toolbar { display: flex; gap: 0.75rem; align-items: center; }
+      .search-input {
+        flex: 1;
+        padding: 0.45rem 0.75rem;
+        border-radius: 8px;
+        border: 1px solid var(--border);
+        background: color-mix(in srgb, var(--bg) 96%, #00000008);
+        color: var(--fg);
+      }
+      .layout { display: grid; grid-template-columns: 260px 1fr; gap: 1.25rem; align-items: start; }
+      .card {
+        border: 1px solid var(--border);
+        border-radius: 12px;
+        padding: 1rem;
+        background: color-mix(in srgb, var(--bg) 96%, #00000006);
+      }
+      .metadata table {
+        width: 100%;
+        border-collapse: collapse;
+        margin-bottom: 0.5rem;
+      }
+      .metadata th, .metadata td {
+        border: 1px solid var(--border);
+        padding: 0.35rem 0.5rem;
+        text-align: left;
+        font-size: 0.9rem;
+      }
+      .toc ul { list-style: none; padding-left: 0; margin: 0; }
+      .toc li { margin: 0.2rem 0; }
+      .toc a { text-decoration: none; }
+      .attachments { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 0.75rem; }
+      .attachment {
+        border: 1px solid var(--border);
+        border-radius: 10px;
+        padding: 0.6rem 0.75rem;
+        background: color-mix(in srgb, var(--bg) 94%, #00000008);
+      }
+      .content blockquote {
+        border-left: 4px solid #3b82f6;
+        padding-left: 1rem;
+        margin-left: 0;
+        background: #3b82f611;
+      }
+      details.callout {
+        margin: 1rem 0;
+        border-left: 4px solid #3b82f6;
+        padding-left: 1rem;
+        background: #3b82f611;
+      }
+      details.callout summary {
+        cursor: pointer;
+        font-weight: 600;
+        list-style: none;
+      }
+      details.callout summary::-webkit-details-marker { display: none; }
+      details.callout summary::before {
+        content: '▶';
+        display: inline-block;
+        margin-right: 0.5rem;
+        transform: rotate(0deg);
+        transition: transform 0.2s ease;
+      }
+      details.callout[open] summary::before { transform: rotate(90deg); }
+      pre {
+        background: #22222211;
+        padding: 0.75rem;
+        overflow-x: auto;
+      }
+      code { font-family: "JetBrains Mono", "Fira Code", monospace; }
+      h2 { margin-top: 2rem; }
+      .hidden { display: none !important; }
+      .anchor-btn {
+        margin-left: 0.4rem;
+        font-size: 0.85rem;
+        color: var(--accent);
+        text-decoration: none;
+        opacity: 0.7;
+      }
+      .anchor-btn:hover { opacity: 1; }
+    </style>
+  </head>
+  <body>
+    <header>
+      <div class="pill">Golden Claude</div>
+      <input class="search-input" id="client-search" type="search" placeholder="Filter text (press / to focus)" />
+      <div class="toolbar"><span class="pill" id="match-count"></span></div>
+    </header>
+    <main>
+      <div class="layout">
+        <div class="card toc">
+          <h3>Contents</h3>
+          <ul id="toc"></ul>
+          
+        </div>
+        <div>
+          <div class="card metadata">
+            <table>
+              <tbody>
+                
+                <tr>
+                  <th>attachmentPolicy</th>
+                  <td>{&#34;charThreshold&#34;: 4000, &#34;extractedCount&#34;: 0, &#34;lineThreshold&#34;: 40, &#34;previewLines&#34;: 5, &#34;routing&#34;: {&#34;routed&#34;: 0, &#34;skipped&#34;: 2}}</td>
+                </tr>
+                
+                <tr>
+                  <th>attachment_bytes</th>
+                  <td>0</td>
+                </tr>
+                
+                <tr>
+                  <th>attachments</th>
+                  <td>0</td>
+                </tr>
+                
+                <tr>
+                  <th>attachmentsDir</th>
+                  <td>None</td>
+                </tr>
+                
+                <tr>
+                  <th>collapseThreshold</th>
+                  <td>10</td>
+                </tr>
+                
+                <tr>
+                  <th>contentHash</th>
+                  <td>03bee25aeb24d3008c8f09f69d67e6c740a5d26efbd1faf2a592cd29221255fc</td>
+                </tr>
+                
+                <tr>
+                  <th>currentBranch</th>
+                  <td>branch-000</td>
+                </tr>
+                
+                <tr>
+                  <th>dirty</th>
+                  <td>False</td>
+                </tr>
+                
+                <tr>
+                  <th>html</th>
+                  <td>False</td>
+                </tr>
+                
+                <tr>
+                  <th>htmlPath</th>
+                  <td>None</td>
+                </tr>
+                
+                <tr>
+                  <th>lastImported</th>
+                  <td>2000-01-01T00:00:00Z</td>
+                </tr>
+                
+                <tr>
+                  <th>lastUpdated</th>
+                  <td>None</td>
+                </tr>
+                
+                <tr>
+                  <th>outputPath</th>
+                  <td>&lt;path&gt;</td>
+                </tr>
+                
+                <tr>
+                  <th>polylogue</th>
+                  <td>{&#34;contentHash&#34;: &#34;03bee25aeb24d3008c8f09f69d67e6c740a5d26efbd1faf2a592cd29221255fc&#34;, &#34;conversationId&#34;: &#34;golden-claude-1&#34;, &#34;lastUpdated&#34;: null, &#34;provider&#34;: &#34;claude.ai&#34;, &#34;slug&#34;: &#34;golden-claude&#34;, &#34;title&#34;: &#34;Golden Claude&#34;}</td>
+                </tr>
+                
+                <tr>
+                  <th>slug</th>
+                  <td>golden-claude</td>
+                </tr>
+                
+                <tr>
+                  <th>sourceExportPath</th>
+                  <td>tests/fixtures/golden/claude</td>
+                </tr>
+                
+                <tr>
+                  <th>title</th>
+                  <td>Golden Claude</td>
+                </tr>
+                
+                <tr>
+                  <th>token_count</th>
+                  <td>6</td>
+                </tr>
+                
+                <tr>
+                  <th>tokens</th>
+                  <td>6</td>
+                </tr>
+                
+                <tr>
+                  <th>word_count</th>
+                  <td>6</td>
+                </tr>
+                
+                <tr>
+                  <th>words</th>
+                  <td>6</td>
+                </tr>
+                
+              </tbody>
+            </table>
+          </div>
+          <div class="content" id="content"><h2 id="user">User</h2>
+<p>Hello, Claude.</p>
+<h2 id="model">Model</h2>
+<p>Inline footnote: [3] ok.</p>
+</div>
+        </div>
+      </div>
+    </main>
+    <script>
+      const tocEl = document.getElementById('toc');
+      const headings = document.querySelectorAll('#content h1, #content h2, #content h3');
+      headings.forEach(h => {
+        if (!h.id) return;
+        const anchor = document.createElement('a');
+        anchor.href = `#${h.id}`;
+        anchor.textContent = '🔗';
+        anchor.className = 'anchor-btn';
+        anchor.title = 'Copy link';
+        anchor.addEventListener('click', evt => {
+          evt.preventDefault();
+          const url = `${window.location.origin}${window.location.pathname}#${h.id}`;
+          navigator.clipboard?.writeText(url).catch(() => {});
+          window.location.hash = h.id;
+        });
+        h.appendChild(anchor);
+        const li = document.createElement('li');
+        const a = document.createElement('a');
+        a.href = `#${h.id}`;
+        a.textContent = h.textContent;
+        li.appendChild(a);
+        tocEl.appendChild(li);
+      });
+      const searchInput = document.getElementById('client-search');
+      const content = document.getElementById('content');
+      const blocks = Array.from(content.querySelectorAll('p, li, blockquote, details'));
+      const matchCount = document.getElementById('match-count');
+      function applyFilter(term) {
+        const q = term.trim().toLowerCase();
+        let matches = 0;
+        blocks.forEach(el => {
+          const text = el.textContent.toLowerCase();
+          const hit = q && text.includes(q);
+          el.classList.toggle('hidden', q && !hit);
+          if (hit) matches += 1;
+        });
+        matchCount.textContent = q ? `${matches} match(es)` : '';
+      }
+      searchInput.addEventListener('input', (e) => applyFilter(e.target.value));
+      window.addEventListener('keydown', (e) => {
+        if (e.key === '/' && document.activeElement !== searchInput) {
+          e.preventDefault();
+          searchInput.focus();
+        }
+      });
+
+      // Add copy-link buttons for message anchors (msg-N)
+      const msgAnchors = content.querySelectorAll('a[id^="msg-"]');
+      msgAnchors.forEach(anchor => {
+        const id = anchor.getAttribute('id');
+        if (!id) return;
+        const btn = document.createElement('a');
+        btn.href = `#${id}`;
+        btn.textContent = '🔗';
+        btn.className = 'anchor-btn';
+        btn.title = 'Copy link to message';
+        btn.addEventListener('click', evt => {
+          evt.preventDefault();
+          const url = `${window.location.origin}${window.location.pathname}#${id}`;
+          navigator.clipboard?.writeText(url).catch(() => {});
+          window.location.hash = id;
+        });
+        anchor.insertAdjacentElement('afterend', btn);
+      });
+    </script>
+  </body>
+</html>

--- a/tests/golden_html/claude-code-basic.html
+++ b/tests/golden_html/claude-code-basic.html
@@ -1,0 +1,342 @@
+
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>claude-code-golden</title>
+    <style>
+      :root {
+        --bg: #ffffff;
+        --fg: #222222;
+        --accent: #2563eb;
+        --border: #3b82f644;
+      }
+      * { box-sizing: border-box; }
+      body {
+        background: var(--bg);
+        color: var(--fg);
+        font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        margin: 0;
+        line-height: 1.6;
+      }
+      header {
+        position: sticky;
+        top: 0;
+        z-index: 10;
+        backdrop-filter: blur(6px);
+        background: color-mix(in srgb, var(--bg) 88%, transparent);
+        border-bottom: 1px solid var(--border);
+        padding: 0.75rem 1.5rem;
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+      }
+      main {
+        max-width: 980px;
+        margin: 0 auto;
+        padding: 1.5rem;
+      }
+      h1 { margin: 0; font-size: 1.5rem; }
+      a { color: var(--accent); }
+      .pill {
+        border: 1px solid var(--border);
+        padding: 0.35rem 0.6rem;
+        border-radius: 999px;
+        font-size: 0.9rem;
+      }
+      .toolbar { display: flex; gap: 0.75rem; align-items: center; }
+      .search-input {
+        flex: 1;
+        padding: 0.45rem 0.75rem;
+        border-radius: 8px;
+        border: 1px solid var(--border);
+        background: color-mix(in srgb, var(--bg) 96%, #00000008);
+        color: var(--fg);
+      }
+      .layout { display: grid; grid-template-columns: 260px 1fr; gap: 1.25rem; align-items: start; }
+      .card {
+        border: 1px solid var(--border);
+        border-radius: 12px;
+        padding: 1rem;
+        background: color-mix(in srgb, var(--bg) 96%, #00000006);
+      }
+      .metadata table {
+        width: 100%;
+        border-collapse: collapse;
+        margin-bottom: 0.5rem;
+      }
+      .metadata th, .metadata td {
+        border: 1px solid var(--border);
+        padding: 0.35rem 0.5rem;
+        text-align: left;
+        font-size: 0.9rem;
+      }
+      .toc ul { list-style: none; padding-left: 0; margin: 0; }
+      .toc li { margin: 0.2rem 0; }
+      .toc a { text-decoration: none; }
+      .attachments { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 0.75rem; }
+      .attachment {
+        border: 1px solid var(--border);
+        border-radius: 10px;
+        padding: 0.6rem 0.75rem;
+        background: color-mix(in srgb, var(--bg) 94%, #00000008);
+      }
+      .content blockquote {
+        border-left: 4px solid #3b82f6;
+        padding-left: 1rem;
+        margin-left: 0;
+        background: #3b82f611;
+      }
+      details.callout {
+        margin: 1rem 0;
+        border-left: 4px solid #3b82f6;
+        padding-left: 1rem;
+        background: #3b82f611;
+      }
+      details.callout summary {
+        cursor: pointer;
+        font-weight: 600;
+        list-style: none;
+      }
+      details.callout summary::-webkit-details-marker { display: none; }
+      details.callout summary::before {
+        content: '▶';
+        display: inline-block;
+        margin-right: 0.5rem;
+        transform: rotate(0deg);
+        transition: transform 0.2s ease;
+      }
+      details.callout[open] summary::before { transform: rotate(90deg); }
+      pre {
+        background: #22222211;
+        padding: 0.75rem;
+        overflow-x: auto;
+      }
+      code { font-family: "JetBrains Mono", "Fira Code", monospace; }
+      h2 { margin-top: 2rem; }
+      .hidden { display: none !important; }
+      .anchor-btn {
+        margin-left: 0.4rem;
+        font-size: 0.85rem;
+        color: var(--accent);
+        text-decoration: none;
+        opacity: 0.7;
+      }
+      .anchor-btn:hover { opacity: 1; }
+    </style>
+  </head>
+  <body>
+    <header>
+      <div class="pill">claude-code-golden</div>
+      <input class="search-input" id="client-search" type="search" placeholder="Filter text (press / to focus)" />
+      <div class="toolbar"><span class="pill" id="match-count"></span></div>
+    </header>
+    <main>
+      <div class="layout">
+        <div class="card toc">
+          <h3>Contents</h3>
+          <ul id="toc"></ul>
+          
+        </div>
+        <div>
+          <div class="card metadata">
+            <table>
+              <tbody>
+                
+                <tr>
+                  <th>attachmentPolicy</th>
+                  <td>{&#34;charThreshold&#34;: 4000, &#34;extractedCount&#34;: 0, &#34;lineThreshold&#34;: 40, &#34;previewLines&#34;: 5, &#34;routing&#34;: {&#34;routed&#34;: 0, &#34;skipped&#34;: 3}}</td>
+                </tr>
+                
+                <tr>
+                  <th>attachment_bytes</th>
+                  <td>0</td>
+                </tr>
+                
+                <tr>
+                  <th>attachments</th>
+                  <td>0</td>
+                </tr>
+                
+                <tr>
+                  <th>attachmentsDir</th>
+                  <td>None</td>
+                </tr>
+                
+                <tr>
+                  <th>collapseThreshold</th>
+                  <td>10</td>
+                </tr>
+                
+                <tr>
+                  <th>contentHash</th>
+                  <td>c958013174df7a51a0e6a91df74991861f8f5742ca279b32661e54381235ba63</td>
+                </tr>
+                
+                <tr>
+                  <th>currentBranch</th>
+                  <td>branch-000</td>
+                </tr>
+                
+                <tr>
+                  <th>dirty</th>
+                  <td>False</td>
+                </tr>
+                
+                <tr>
+                  <th>html</th>
+                  <td>False</td>
+                </tr>
+                
+                <tr>
+                  <th>htmlPath</th>
+                  <td>None</td>
+                </tr>
+                
+                <tr>
+                  <th>lastImported</th>
+                  <td>2000-01-01T00:00:00Z</td>
+                </tr>
+                
+                <tr>
+                  <th>lastUpdated</th>
+                  <td>None</td>
+                </tr>
+                
+                <tr>
+                  <th>outputPath</th>
+                  <td>&lt;path&gt;</td>
+                </tr>
+                
+                <tr>
+                  <th>polylogue</th>
+                  <td>{&#34;contentHash&#34;: &#34;c958013174df7a51a0e6a91df74991861f8f5742ca279b32661e54381235ba63&#34;, &#34;conversationId&#34;: &#34;tests/fixtures/golden/claude_code/claude-code-golden.jsonl&#34;, &#34;lastUpdated&#34;: null, &#34;provider&#34;: &#34;claude-code&#34;, &#34;slug&#34;: &#34;claude-code-golden&#34;, &#34;title&#34;: &#34;claude-code-golden&#34;}</td>
+                </tr>
+                
+                <tr>
+                  <th>sessionFile</th>
+                  <td>tests/fixtures/golden/claude_code/claude-code-golden.jsonl</td>
+                </tr>
+                
+                <tr>
+                  <th>slug</th>
+                  <td>claude-code-golden</td>
+                </tr>
+                
+                <tr>
+                  <th>title</th>
+                  <td>claude-code-golden</td>
+                </tr>
+                
+                <tr>
+                  <th>token_count</th>
+                  <td>22</td>
+                </tr>
+                
+                <tr>
+                  <th>tokens</th>
+                  <td>22</td>
+                </tr>
+                
+                <tr>
+                  <th>word_count</th>
+                  <td>22</td>
+                </tr>
+                
+                <tr>
+                  <th>words</th>
+                  <td>22</td>
+                </tr>
+                
+                <tr>
+                  <th>workspace</th>
+                  <td>claude_code</td>
+                </tr>
+                
+              </tbody>
+            </table>
+          </div>
+          <div class="content" id="content"><h2 id="user">User</h2>
+<p>Hello from Claude Code.</p>
+<h2 id="model">Model</h2>
+<p>Footnote: [7] ok.</p>
+<h2 id="model">Model</h2>
+<p>Tool call <code>bash</code></p>
+<pre><code class="language-json">{
+  &quot;cmd&quot;: &quot;echo hi&quot;
+}
+</code></pre>
+<p>Result:
+[2] tool output footnote</p>
+</div>
+        </div>
+      </div>
+    </main>
+    <script>
+      const tocEl = document.getElementById('toc');
+      const headings = document.querySelectorAll('#content h1, #content h2, #content h3');
+      headings.forEach(h => {
+        if (!h.id) return;
+        const anchor = document.createElement('a');
+        anchor.href = `#${h.id}`;
+        anchor.textContent = '🔗';
+        anchor.className = 'anchor-btn';
+        anchor.title = 'Copy link';
+        anchor.addEventListener('click', evt => {
+          evt.preventDefault();
+          const url = `${window.location.origin}${window.location.pathname}#${h.id}`;
+          navigator.clipboard?.writeText(url).catch(() => {});
+          window.location.hash = h.id;
+        });
+        h.appendChild(anchor);
+        const li = document.createElement('li');
+        const a = document.createElement('a');
+        a.href = `#${h.id}`;
+        a.textContent = h.textContent;
+        li.appendChild(a);
+        tocEl.appendChild(li);
+      });
+      const searchInput = document.getElementById('client-search');
+      const content = document.getElementById('content');
+      const blocks = Array.from(content.querySelectorAll('p, li, blockquote, details'));
+      const matchCount = document.getElementById('match-count');
+      function applyFilter(term) {
+        const q = term.trim().toLowerCase();
+        let matches = 0;
+        blocks.forEach(el => {
+          const text = el.textContent.toLowerCase();
+          const hit = q && text.includes(q);
+          el.classList.toggle('hidden', q && !hit);
+          if (hit) matches += 1;
+        });
+        matchCount.textContent = q ? `${matches} match(es)` : '';
+      }
+      searchInput.addEventListener('input', (e) => applyFilter(e.target.value));
+      window.addEventListener('keydown', (e) => {
+        if (e.key === '/' && document.activeElement !== searchInput) {
+          e.preventDefault();
+          searchInput.focus();
+        }
+      });
+
+      // Add copy-link buttons for message anchors (msg-N)
+      const msgAnchors = content.querySelectorAll('a[id^="msg-"]');
+      msgAnchors.forEach(anchor => {
+        const id = anchor.getAttribute('id');
+        if (!id) return;
+        const btn = document.createElement('a');
+        btn.href = `#${id}`;
+        btn.textContent = '🔗';
+        btn.className = 'anchor-btn';
+        btn.title = 'Copy link to message';
+        btn.addEventListener('click', evt => {
+          evt.preventDefault();
+          const url = `${window.location.origin}${window.location.pathname}#${id}`;
+          navigator.clipboard?.writeText(url).catch(() => {});
+          window.location.hash = id;
+        });
+        anchor.insertAdjacentElement('afterend', btn);
+      });
+    </script>
+  </body>
+</html>

--- a/tests/golden_html/codex-basic.html
+++ b/tests/golden_html/codex-basic.html
@@ -1,0 +1,337 @@
+
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>codex-golden</title>
+    <style>
+      :root {
+        --bg: #ffffff;
+        --fg: #222222;
+        --accent: #2563eb;
+        --border: #3b82f644;
+      }
+      * { box-sizing: border-box; }
+      body {
+        background: var(--bg);
+        color: var(--fg);
+        font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        margin: 0;
+        line-height: 1.6;
+      }
+      header {
+        position: sticky;
+        top: 0;
+        z-index: 10;
+        backdrop-filter: blur(6px);
+        background: color-mix(in srgb, var(--bg) 88%, transparent);
+        border-bottom: 1px solid var(--border);
+        padding: 0.75rem 1.5rem;
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+      }
+      main {
+        max-width: 980px;
+        margin: 0 auto;
+        padding: 1.5rem;
+      }
+      h1 { margin: 0; font-size: 1.5rem; }
+      a { color: var(--accent); }
+      .pill {
+        border: 1px solid var(--border);
+        padding: 0.35rem 0.6rem;
+        border-radius: 999px;
+        font-size: 0.9rem;
+      }
+      .toolbar { display: flex; gap: 0.75rem; align-items: center; }
+      .search-input {
+        flex: 1;
+        padding: 0.45rem 0.75rem;
+        border-radius: 8px;
+        border: 1px solid var(--border);
+        background: color-mix(in srgb, var(--bg) 96%, #00000008);
+        color: var(--fg);
+      }
+      .layout { display: grid; grid-template-columns: 260px 1fr; gap: 1.25rem; align-items: start; }
+      .card {
+        border: 1px solid var(--border);
+        border-radius: 12px;
+        padding: 1rem;
+        background: color-mix(in srgb, var(--bg) 96%, #00000006);
+      }
+      .metadata table {
+        width: 100%;
+        border-collapse: collapse;
+        margin-bottom: 0.5rem;
+      }
+      .metadata th, .metadata td {
+        border: 1px solid var(--border);
+        padding: 0.35rem 0.5rem;
+        text-align: left;
+        font-size: 0.9rem;
+      }
+      .toc ul { list-style: none; padding-left: 0; margin: 0; }
+      .toc li { margin: 0.2rem 0; }
+      .toc a { text-decoration: none; }
+      .attachments { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 0.75rem; }
+      .attachment {
+        border: 1px solid var(--border);
+        border-radius: 10px;
+        padding: 0.6rem 0.75rem;
+        background: color-mix(in srgb, var(--bg) 94%, #00000008);
+      }
+      .content blockquote {
+        border-left: 4px solid #3b82f6;
+        padding-left: 1rem;
+        margin-left: 0;
+        background: #3b82f611;
+      }
+      details.callout {
+        margin: 1rem 0;
+        border-left: 4px solid #3b82f6;
+        padding-left: 1rem;
+        background: #3b82f611;
+      }
+      details.callout summary {
+        cursor: pointer;
+        font-weight: 600;
+        list-style: none;
+      }
+      details.callout summary::-webkit-details-marker { display: none; }
+      details.callout summary::before {
+        content: '▶';
+        display: inline-block;
+        margin-right: 0.5rem;
+        transform: rotate(0deg);
+        transition: transform 0.2s ease;
+      }
+      details.callout[open] summary::before { transform: rotate(90deg); }
+      pre {
+        background: #22222211;
+        padding: 0.75rem;
+        overflow-x: auto;
+      }
+      code { font-family: "JetBrains Mono", "Fira Code", monospace; }
+      h2 { margin-top: 2rem; }
+      .hidden { display: none !important; }
+      .anchor-btn {
+        margin-left: 0.4rem;
+        font-size: 0.85rem;
+        color: var(--accent);
+        text-decoration: none;
+        opacity: 0.7;
+      }
+      .anchor-btn:hover { opacity: 1; }
+    </style>
+  </head>
+  <body>
+    <header>
+      <div class="pill">codex-golden</div>
+      <input class="search-input" id="client-search" type="search" placeholder="Filter text (press / to focus)" />
+      <div class="toolbar"><span class="pill" id="match-count"></span></div>
+    </header>
+    <main>
+      <div class="layout">
+        <div class="card toc">
+          <h3>Contents</h3>
+          <ul id="toc"></ul>
+          
+        </div>
+        <div>
+          <div class="card metadata">
+            <table>
+              <tbody>
+                
+                <tr>
+                  <th>attachmentPolicy</th>
+                  <td>{&#34;charThreshold&#34;: 4000, &#34;extractedCount&#34;: 0, &#34;lineThreshold&#34;: 40, &#34;previewLines&#34;: 5, &#34;routing&#34;: {&#34;routed&#34;: 0, &#34;skipped&#34;: 3}}</td>
+                </tr>
+                
+                <tr>
+                  <th>attachment_bytes</th>
+                  <td>0</td>
+                </tr>
+                
+                <tr>
+                  <th>attachments</th>
+                  <td>0</td>
+                </tr>
+                
+                <tr>
+                  <th>attachmentsDir</th>
+                  <td>None</td>
+                </tr>
+                
+                <tr>
+                  <th>collapseThreshold</th>
+                  <td>10</td>
+                </tr>
+                
+                <tr>
+                  <th>contentHash</th>
+                  <td>866414d75a1892d89263f4c3cce6b6be71f71ce2b7407b9ffa6d1114726d95c1</td>
+                </tr>
+                
+                <tr>
+                  <th>currentBranch</th>
+                  <td>branch-000</td>
+                </tr>
+                
+                <tr>
+                  <th>dirty</th>
+                  <td>False</td>
+                </tr>
+                
+                <tr>
+                  <th>html</th>
+                  <td>False</td>
+                </tr>
+                
+                <tr>
+                  <th>htmlPath</th>
+                  <td>None</td>
+                </tr>
+                
+                <tr>
+                  <th>lastImported</th>
+                  <td>2000-01-01T00:00:00Z</td>
+                </tr>
+                
+                <tr>
+                  <th>lastUpdated</th>
+                  <td>None</td>
+                </tr>
+                
+                <tr>
+                  <th>outputPath</th>
+                  <td>&lt;path&gt;</td>
+                </tr>
+                
+                <tr>
+                  <th>polylogue</th>
+                  <td>{&#34;contentHash&#34;: &#34;866414d75a1892d89263f4c3cce6b6be71f71ce2b7407b9ffa6d1114726d95c1&#34;, &#34;conversationId&#34;: &#34;tests/fixtures/golden/codex/codex-golden.jsonl&#34;, &#34;lastUpdated&#34;: null, &#34;provider&#34;: &#34;codex&#34;, &#34;slug&#34;: &#34;codex-golden&#34;, &#34;title&#34;: &#34;codex-golden&#34;}</td>
+                </tr>
+                
+                <tr>
+                  <th>sessionPath</th>
+                  <td>tests/fixtures/golden/codex/codex-golden.jsonl</td>
+                </tr>
+                
+                <tr>
+                  <th>slug</th>
+                  <td>codex-golden</td>
+                </tr>
+                
+                <tr>
+                  <th>title</th>
+                  <td>codex-golden</td>
+                </tr>
+                
+                <tr>
+                  <th>token_count</th>
+                  <td>20</td>
+                </tr>
+                
+                <tr>
+                  <th>tokens</th>
+                  <td>20</td>
+                </tr>
+                
+                <tr>
+                  <th>word_count</th>
+                  <td>20</td>
+                </tr>
+                
+                <tr>
+                  <th>words</th>
+                  <td>20</td>
+                </tr>
+                
+              </tbody>
+            </table>
+          </div>
+          <div class="content" id="content"><h2 id="user">User</h2>
+<p>Hello from Codex.</p>
+<h2 id="model">Model</h2>
+<p>Footnote: [9] ok.</p>
+<h2 id="model">Model</h2>
+<p>Tool call <code>bash</code></p>
+<pre><code class="language-json">{
+  &quot;cmd&quot;: &quot;echo hi&quot;
+}
+</code></pre>
+<p>Output:
+[1] output footnote</p>
+</div>
+        </div>
+      </div>
+    </main>
+    <script>
+      const tocEl = document.getElementById('toc');
+      const headings = document.querySelectorAll('#content h1, #content h2, #content h3');
+      headings.forEach(h => {
+        if (!h.id) return;
+        const anchor = document.createElement('a');
+        anchor.href = `#${h.id}`;
+        anchor.textContent = '🔗';
+        anchor.className = 'anchor-btn';
+        anchor.title = 'Copy link';
+        anchor.addEventListener('click', evt => {
+          evt.preventDefault();
+          const url = `${window.location.origin}${window.location.pathname}#${h.id}`;
+          navigator.clipboard?.writeText(url).catch(() => {});
+          window.location.hash = h.id;
+        });
+        h.appendChild(anchor);
+        const li = document.createElement('li');
+        const a = document.createElement('a');
+        a.href = `#${h.id}`;
+        a.textContent = h.textContent;
+        li.appendChild(a);
+        tocEl.appendChild(li);
+      });
+      const searchInput = document.getElementById('client-search');
+      const content = document.getElementById('content');
+      const blocks = Array.from(content.querySelectorAll('p, li, blockquote, details'));
+      const matchCount = document.getElementById('match-count');
+      function applyFilter(term) {
+        const q = term.trim().toLowerCase();
+        let matches = 0;
+        blocks.forEach(el => {
+          const text = el.textContent.toLowerCase();
+          const hit = q && text.includes(q);
+          el.classList.toggle('hidden', q && !hit);
+          if (hit) matches += 1;
+        });
+        matchCount.textContent = q ? `${matches} match(es)` : '';
+      }
+      searchInput.addEventListener('input', (e) => applyFilter(e.target.value));
+      window.addEventListener('keydown', (e) => {
+        if (e.key === '/' && document.activeElement !== searchInput) {
+          e.preventDefault();
+          searchInput.focus();
+        }
+      });
+
+      // Add copy-link buttons for message anchors (msg-N)
+      const msgAnchors = content.querySelectorAll('a[id^="msg-"]');
+      msgAnchors.forEach(anchor => {
+        const id = anchor.getAttribute('id');
+        if (!id) return;
+        const btn = document.createElement('a');
+        btn.href = `#${id}`;
+        btn.textContent = '🔗';
+        btn.className = 'anchor-btn';
+        btn.title = 'Copy link to message';
+        btn.addEventListener('click', evt => {
+          evt.preventDefault();
+          const url = `${window.location.origin}${window.location.pathname}#${id}`;
+          navigator.clipboard?.writeText(url).catch(() => {});
+          window.location.hash = id;
+        });
+        anchor.insertAdjacentElement('afterend', btn);
+      });
+    </script>
+  </body>
+</html>

--- a/tests/test_attachment_routing.py
+++ b/tests/test_attachment_routing.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+
+from polylogue.importers.utils import LINE_THRESHOLD, store_large_text
+from polylogue.render import AttachmentInfo
+
+
+def test_store_large_text_updates_routing_stats_skipped(tmp_path: Path) -> None:
+    attachments: list[AttachmentInfo] = []
+    per_chunk_links: dict[int, list[tuple[str, Path]]] = {}
+    stats = {"routed": 0, "skipped": 0}
+
+    out = store_large_text(
+        "hello",
+        chunk_index=0,
+        attachments_dir=tmp_path / "attachments",
+        markdown_dir=tmp_path,
+        attachments=attachments,
+        per_chunk_links=per_chunk_links,
+        routing_stats=stats,
+    )
+
+    assert out == "hello"
+    assert stats["skipped"] == 1
+    assert stats["routed"] == 0
+    assert not attachments
+
+
+def test_store_large_text_updates_routing_stats_routed(tmp_path: Path) -> None:
+    attachments: list[AttachmentInfo] = []
+    per_chunk_links: dict[int, list[tuple[str, Path]]] = {}
+    stats = {"routed": 0, "skipped": 0}
+    text = "\n".join(f"line {i}" for i in range(LINE_THRESHOLD + 1))
+
+    out = store_large_text(
+        text,
+        chunk_index=0,
+        attachments_dir=tmp_path / "attachments",
+        markdown_dir=tmp_path,
+        attachments=attachments,
+        per_chunk_links=per_chunk_links,
+        routing_stats=stats,
+    )
+
+    assert "Full content saved to" in out
+    assert stats["routed"] == 1
+    assert stats["skipped"] == 0
+    assert len(attachments) == 1
+    assert (tmp_path / "attachments" / "chunk000.txt").exists()

--- a/tests/test_attachments_cli.py
+++ b/tests/test_attachments_cli.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+from polylogue.cli.attachments import run_attachments_cli
+from polylogue.commands import CommandEnv
+from polylogue.db import open_connection
+from polylogue.ui import UI
+
+
+def _seed_attachment(
+    db_path: Path,
+    *,
+    provider: str,
+    conversation_id: str,
+    branch_id: str,
+    message_id: str,
+    timestamp: str,
+    attachment_name: str,
+    attachment_path: Path,
+    size_bytes: int = 100,
+    content_hash: str = "hash-1",
+) -> None:
+    with open_connection(db_path) as conn:
+        conn.execute(
+            """
+            INSERT OR REPLACE INTO conversations(provider, conversation_id, slug, title)
+            VALUES (?, ?, ?, ?)
+            """,
+            (provider, conversation_id, conversation_id, conversation_id),
+        )
+        conn.execute(
+            """
+            INSERT OR REPLACE INTO branches(provider, conversation_id, branch_id, is_current)
+            VALUES (?, ?, ?, 1)
+            """,
+            (provider, conversation_id, branch_id),
+        )
+        conn.execute(
+            """
+            INSERT OR REPLACE INTO messages(provider, conversation_id, branch_id, message_id, position, timestamp, role)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (provider, conversation_id, branch_id, message_id, 0, timestamp, "user"),
+        )
+        conn.execute(
+            """
+            INSERT OR REPLACE INTO attachments(
+                provider, conversation_id, branch_id, message_id,
+                attachment_name, attachment_path, size_bytes, content_hash, mime_type, text_bytes, ocr_used
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                provider,
+                conversation_id,
+                branch_id,
+                message_id,
+                attachment_name,
+                str(attachment_path),
+                size_bytes,
+                content_hash,
+                "text/plain",
+                0,
+                0,
+            ),
+        )
+
+
+def test_attachments_stats_filters_provider_and_time(state_env, tmp_path, capsys):
+    env = CommandEnv(ui=UI(plain=True))
+    db_path = env.database.resolve_path()
+    assert db_path is not None
+
+    a = tmp_path / "a.txt"
+    a.write_text("a", encoding="utf-8")
+    b = tmp_path / "b.txt"
+    b.write_text("b", encoding="utf-8")
+
+    _seed_attachment(
+        db_path,
+        provider="codex",
+        conversation_id="conv-1",
+        branch_id="main",
+        message_id="m1",
+        timestamp="2024-01-01T00:00:00Z",
+        attachment_name="a.txt",
+        attachment_path=a.resolve(),
+        size_bytes=10,
+        content_hash="hash-a",
+    )
+    _seed_attachment(
+        db_path,
+        provider="claude-code",
+        conversation_id="conv-2",
+        branch_id="main",
+        message_id="m2",
+        timestamp="2024-02-01T00:00:00Z",
+        attachment_name="b.txt",
+        attachment_path=b.resolve(),
+        size_bytes=20,
+        content_hash="hash-b",
+    )
+
+    args = SimpleNamespace(
+        attachments_cmd="stats",
+        from_index=True,
+        json=True,
+        json_lines=False,
+        dir=None,
+        provider="claude-code",
+        since="2024-01-15",
+        until=None,
+        ext=None,
+        hash=True,
+        sort="size",
+        limit=10,
+        csv=None,
+        clean_orphans=False,
+        dry_run=False,
+    )
+    run_attachments_cli(args, env)
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["count"] == 1
+    assert payload["top"][0]["provider"] == "claude-code"
+
+
+def test_attachments_clean_orphans_dry_run_and_apply(state_env, tmp_path, capsys):
+    env = CommandEnv(ui=UI(plain=True))
+    db_path = env.database.resolve_path()
+    assert db_path is not None
+
+    archive_root = tmp_path / "archive"
+    attachment_dir = archive_root / "codex" / "conv-1" / "attachments"
+    attachment_dir.mkdir(parents=True)
+    referenced = attachment_dir / "keep.txt"
+    referenced.write_text("keep", encoding="utf-8")
+    orphan = attachment_dir / "orphan.txt"
+    orphan.write_text("orphan", encoding="utf-8")
+
+    _seed_attachment(
+        db_path,
+        provider="codex",
+        conversation_id="conv-1",
+        branch_id="main",
+        message_id="m1",
+        timestamp="2024-01-01T00:00:00Z",
+        attachment_name="keep.txt",
+        attachment_path=referenced.resolve(),
+        size_bytes=4,
+        content_hash="hash-keep",
+    )
+
+    args = SimpleNamespace(
+        attachments_cmd="stats",
+        from_index=True,
+        json=True,
+        json_lines=False,
+        dir=archive_root,
+        provider="codex",
+        since=None,
+        until=None,
+        ext=None,
+        hash=False,
+        sort="size",
+        limit=10,
+        csv=None,
+        clean_orphans=True,
+        dry_run=True,
+    )
+    run_attachments_cli(args, env)
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["orphans"]["count"] == 1
+    assert payload["orphans"]["removed"] == 0
+    assert orphan.exists()
+
+    args.dry_run = False
+    run_attachments_cli(args, env)
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["orphans"]["count"] == 1
+    assert payload["orphans"]["removed"] == 1
+    assert not orphan.exists()

--- a/tests/test_cli_common.py
+++ b/tests/test_cli_common.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sys
+from types import SimpleNamespace
 
 from polylogue.cli_common import filter_chats
 from polylogue.cli_common import choose_single_entry
@@ -45,3 +46,41 @@ def test_choose_single_entry_non_tty_skips(monkeypatch):
     assert selection is None
     assert cancelled is True
     assert any("cannot prompt" in line for line in ui.console.lines)
+
+
+def test_choose_single_entry_interactive_uses_sk(monkeypatch):
+    import subprocess
+
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        return subprocess.CompletedProcess(cmd, 0, stdout=b"0\tAlpha\n", stderr=b"")
+
+    monkeypatch.setattr("polylogue.cli_common.subprocess.run", fake_run)
+
+    ui = SimpleNamespace(plain=False)
+    selection, cancelled = choose_single_entry(ui, ["alpha", "bravo"], format_line=lambda v, _: v, prompt="pick")
+
+    assert cancelled is False
+    assert selection == "alpha"
+    assert calls
+    assert calls[0][0][:2] == ["sk", "--ansi"]
+
+
+def test_choose_single_entry_interactive_cancelled(monkeypatch):
+    import subprocess
+
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+
+    def fake_run(cmd, **kwargs):
+        raise subprocess.CalledProcessError(130, cmd, output=b"", stderr=b"cancelled")
+
+    monkeypatch.setattr("polylogue.cli_common.subprocess.run", fake_run)
+
+    ui = SimpleNamespace(plain=False)
+    selection, cancelled = choose_single_entry(ui, ["alpha"], format_line=lambda v, _: v)
+    assert selection is None
+    assert cancelled is True

--- a/tests/test_cli_meta.py
+++ b/tests/test_cli_meta.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import json
+from contextlib import contextmanager
+
+from polylogue import util
+from polylogue.commands import CommandEnv, RenderOptions, SyncOptions, render_command, sync_command
+from polylogue.document_store import read_existing_document
+
+
+class DummyUI:
+    plain = True
+
+    def __init__(self):
+        self.console = self
+
+    def print(self, *_args, **_kwargs):  # pragma: no cover - diagnostics only
+        pass
+
+    def summary(self, *_args, **_kwargs):  # pragma: no cover
+        pass
+
+    def banner(self, *_args, **_kwargs):  # pragma: no cover
+        pass
+
+    @contextmanager
+    def progress(self, *_args, **_kwargs):  # pragma: no cover
+        class DummyProgressTracker:
+            def advance(self, *args, **kwargs):
+                pass
+
+            def update(self, *args, **kwargs):
+                pass
+
+        yield DummyProgressTracker()
+
+
+def test_render_meta_in_frontmatter_and_runs(tmp_path, state_env):
+    src = tmp_path / "render.json"
+    payload = {
+        "id": "conv-render-meta",
+        "title": "Snapshot Render Meta",
+        "chunkedPrompt": {
+            "chunks": [
+                {"role": "user", "text": "Hello", "timestamp": "2024-01-01T00:00:00Z"},
+                {"role": "model", "text": "Hi there", "timestamp": "2024-01-01T00:01:00Z"},
+            ]
+        },
+        "metadata": {"createTime": "2024-01-01T00:00:00Z"},
+    }
+    src.write_text(json.dumps(payload), encoding="utf-8")
+    out_dir = tmp_path / "out"
+
+    options = RenderOptions(
+        inputs=[src],
+        output_dir=out_dir,
+        collapse_threshold=12,
+        download_attachments=False,
+        dry_run=False,
+        force=False,
+        html=False,
+        html_theme=None,
+        diff=False,
+        meta={"suite": "tests"},
+    )
+
+    env = CommandEnv(ui=DummyUI())
+    render_command(options, env)
+    output_md = out_dir / "render" / "conversation.md"
+    existing = read_existing_document(output_md)
+    assert existing is not None
+    assert existing.metadata["polylogue"]["cliMeta"] == {"suite": "tests"}
+
+    runs = util.load_runs()
+    assert runs
+    last = runs[-1]
+    assert last["cmd"] == "render"
+    assert last["meta"] == {"suite": "tests"}
+
+
+def test_sync_drive_meta_in_frontmatter(tmp_path, state_env, monkeypatch):
+    class SnapshotDrive:
+        def __init__(self, ui):
+            self.ui = ui
+
+        def resolve_folder_id(self, *_args, **_kwargs):
+            return "folder-demo"
+
+        def list_chats(self, *_args, **_kwargs):
+            return [
+                {
+                    "id": "drive-meta",
+                    "name": "Drive Meta",
+                    "modifiedTime": "2024-01-02T00:00:00Z",
+                }
+            ]
+
+        def download_chat_bytes(self, *_args, **_kwargs):
+            payload = {
+                "chunkedPrompt": {
+                    "chunks": [
+                        {
+                            "role": "user",
+                            "text": "Sync question",
+                            "timestamp": "2024-01-02T00:00:00Z",
+                        },
+                        {
+                            "role": "model",
+                            "text": "Sync answer",
+                            "timestamp": "2024-01-02T00:01:00Z",
+                        },
+                    ]
+                }
+            }
+            return json.dumps(payload).encode("utf-8")
+
+    monkeypatch.setattr("polylogue.commands.DriveClient", SnapshotDrive)
+
+    options = SyncOptions(
+        folder_name="Demo",
+        folder_id=None,
+        output_dir=tmp_path / "drive",
+        collapse_threshold=16,
+        download_attachments=False,
+        dry_run=False,
+        force=False,
+        prune=False,
+        since=None,
+        until=None,
+        name_filter=None,
+        html=False,
+        html_theme="dark",
+        diff=False,
+        meta={"from": "tests"},
+    )
+
+    env = CommandEnv(ui=DummyUI())
+    result = sync_command(options, env)
+    assert result.count == 1
+    existing = read_existing_document(result.items[0].output)
+    assert existing is not None
+    assert existing.metadata["polylogue"]["cliMeta"] == {"from": "tests"}
+

--- a/tests/test_golden_html_snapshots.py
+++ b/tests/test_golden_html_snapshots.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import frontmatter
+
+from polylogue.frontmatter_canonical import canonicalize_markdown
+from polylogue.html import HtmlRenderOptions, render_html
+from polylogue.importers.chatgpt import import_chatgpt_export
+from polylogue.importers.claude_ai import import_claude_export
+from polylogue.importers.claude_code import import_claude_code_session
+from polylogue.importers.codex import import_codex_session
+from polylogue.render import MarkdownDocument
+from polylogue.renderers.db_renderer import DatabaseRenderer
+
+
+FIXED_NOW = "2000-01-01T00:00:00Z"
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _rel(path: Path) -> Path:
+    root = _repo_root()
+    return path.relative_to(root)
+
+
+def _render_slug(db_path: Path, output_dir: Path, slug: str) -> None:
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.row_factory = sqlite3.Row
+        row = conn.execute(
+            "SELECT provider, conversation_id FROM conversations WHERE slug = ?",
+            (slug,),
+        ).fetchone()
+        assert row, f"slug not found in db: {slug}"
+        provider = row["provider"]
+        conversation_id = row["conversation_id"]
+    finally:
+        conn.close()
+    renderer = DatabaseRenderer(db_path)
+    renderer.render_conversation(provider, conversation_id, output_dir)
+
+
+def _assert_golden_html(markdown_path: Path, golden_html_path: Path) -> None:
+    assert markdown_path.exists()
+    assert golden_html_path.exists()
+    repo_root = _repo_root()
+    canonical_md = canonicalize_markdown(markdown_path.read_text(encoding="utf-8"), repo_root=repo_root, scrub_paths=True)
+    post = frontmatter.loads(canonical_md)
+    doc = MarkdownDocument(body=post.content, metadata=dict(post.metadata), attachments=[], stats={})
+    actual = render_html(doc, HtmlRenderOptions(theme="light")).replace("\r\n", "\n").strip()
+    expected = golden_html_path.read_text(encoding="utf-8").replace("\r\n", "\n").strip()
+    assert actual == expected
+
+
+def test_golden_chatgpt_basic_html(tmp_path, state_env, monkeypatch):
+    monkeypatch.setenv("POLYLOGUE_FIXED_NOW", FIXED_NOW)
+    fixtures = _repo_root() / "tests" / "fixtures" / "golden"
+    golden_dir = _repo_root() / "tests" / "golden_html"
+    out_dir = tmp_path / "out"
+
+    results = import_chatgpt_export(
+        _rel(fixtures / "chatgpt"),
+        output_dir=out_dir,
+        collapse_threshold=10,
+        html=False,
+        html_theme="light",
+        force=True,
+    )
+    assert results
+    slug = results[0].slug
+    db_path = Path(state_env) / "polylogue.db"
+    _render_slug(db_path, out_dir, slug)
+    _assert_golden_html(out_dir / slug / "conversation.md", golden_dir / "chatgpt-basic.html")
+
+
+def test_golden_claude_basic_html(tmp_path, state_env, monkeypatch):
+    monkeypatch.setenv("POLYLOGUE_FIXED_NOW", FIXED_NOW)
+    fixtures = _repo_root() / "tests" / "fixtures" / "golden"
+    golden_dir = _repo_root() / "tests" / "golden_html"
+    out_dir = tmp_path / "out"
+
+    results = import_claude_export(
+        _rel(fixtures / "claude"),
+        output_dir=out_dir,
+        collapse_threshold=10,
+        html=False,
+        html_theme="light",
+        force=True,
+    )
+    assert results
+    slug = results[0].slug
+    db_path = Path(state_env) / "polylogue.db"
+    _render_slug(db_path, out_dir, slug)
+    _assert_golden_html(out_dir / slug / "conversation.md", golden_dir / "claude-basic.html")
+
+
+def test_golden_codex_basic_html(tmp_path, state_env, monkeypatch):
+    monkeypatch.setenv("POLYLOGUE_FIXED_NOW", FIXED_NOW)
+    fixtures = _repo_root() / "tests" / "fixtures" / "golden"
+    golden_dir = _repo_root() / "tests" / "golden_html"
+    out_dir = tmp_path / "out"
+
+    result = import_codex_session(
+        str(_rel(fixtures / "codex" / "codex-golden.jsonl")),
+        base_dir=_repo_root(),
+        output_dir=out_dir,
+        collapse_threshold=10,
+        html=False,
+        force=True,
+    )
+    slug = result.slug
+    db_path = Path(state_env) / "polylogue.db"
+    _render_slug(db_path, out_dir, slug)
+    _assert_golden_html(out_dir / slug / "conversation.md", golden_dir / "codex-basic.html")
+
+
+def test_golden_claude_code_basic_html(tmp_path, state_env, monkeypatch):
+    monkeypatch.setenv("POLYLOGUE_FIXED_NOW", FIXED_NOW)
+    fixtures = _repo_root() / "tests" / "fixtures" / "golden"
+    golden_dir = _repo_root() / "tests" / "golden_html"
+    out_dir = tmp_path / "out"
+
+    result = import_claude_code_session(
+        str(_rel(fixtures / "claude_code" / "claude-code-golden.jsonl")),
+        base_dir=Path("."),
+        output_dir=out_dir,
+        collapse_threshold=10,
+        html=False,
+        html_theme="light",
+        force=True,
+    )
+    slug = result.slug
+    db_path = Path(state_env) / "polylogue.db"
+    _render_slug(db_path, out_dir, slug)
+    _assert_golden_html(out_dir / slug / "conversation.md", golden_dir / "claude-code-basic.html")
+

--- a/tests/test_golden_snapshots.py
+++ b/tests/test_golden_snapshots.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from polylogue.frontmatter_canonical import canonicalize_markdown
+from polylogue.importers.chatgpt import import_chatgpt_export
+from polylogue.importers.claude_ai import import_claude_export
+from polylogue.importers.claude_code import import_claude_code_session
+from polylogue.importers.codex import import_codex_session
+from polylogue.renderers.db_renderer import DatabaseRenderer
+
+
+FIXED_NOW = "2000-01-01T00:00:00Z"
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _rel(path: Path) -> Path:
+    root = _repo_root()
+    return path.relative_to(root)
+
+
+def _render_slug(db_path: Path, output_dir: Path, slug: str) -> None:
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.row_factory = sqlite3.Row
+        row = conn.execute(
+            "SELECT provider, conversation_id FROM conversations WHERE slug = ?",
+            (slug,),
+        ).fetchone()
+        assert row, f"slug not found in db: {slug}"
+        provider = row["provider"]
+        conversation_id = row["conversation_id"]
+    finally:
+        conn.close()
+    renderer = DatabaseRenderer(db_path)
+    renderer.render_conversation(provider, conversation_id, output_dir)
+
+
+def _assert_golden(markdown_path: Path, golden_path: Path) -> None:
+    assert markdown_path.exists()
+    assert golden_path.exists()
+    repo_root = _repo_root()
+    actual = canonicalize_markdown(markdown_path.read_text(encoding="utf-8"), repo_root=repo_root, scrub_paths=True)
+    expected = canonicalize_markdown(golden_path.read_text(encoding="utf-8"), repo_root=repo_root, scrub_paths=True)
+    assert actual == expected
+
+
+def test_golden_chatgpt_basic(tmp_path, state_env, monkeypatch):
+    monkeypatch.setenv("POLYLOGUE_FIXED_NOW", FIXED_NOW)
+    fixtures = _repo_root() / "tests" / "fixtures" / "golden"
+    golden_dir = _repo_root() / "tests" / "golden"
+    out_dir = tmp_path / "out"
+
+    results = import_chatgpt_export(
+        _rel(fixtures / "chatgpt"),
+        output_dir=out_dir,
+        collapse_threshold=10,
+        html=False,
+        html_theme="light",
+        force=True,
+    )
+    assert results
+    slug = results[0].slug
+    db_path = Path(state_env) / "polylogue.db"
+    _render_slug(db_path, out_dir, slug)
+    _assert_golden(out_dir / slug / "conversation.md", golden_dir / "chatgpt-basic.md")
+
+
+def test_golden_claude_basic(tmp_path, state_env, monkeypatch):
+    monkeypatch.setenv("POLYLOGUE_FIXED_NOW", FIXED_NOW)
+    fixtures = _repo_root() / "tests" / "fixtures" / "golden"
+    golden_dir = _repo_root() / "tests" / "golden"
+    out_dir = tmp_path / "out"
+
+    results = import_claude_export(
+        _rel(fixtures / "claude"),
+        output_dir=out_dir,
+        collapse_threshold=10,
+        html=False,
+        html_theme="light",
+        force=True,
+    )
+    assert results
+    slug = results[0].slug
+    db_path = Path(state_env) / "polylogue.db"
+    _render_slug(db_path, out_dir, slug)
+    _assert_golden(out_dir / slug / "conversation.md", golden_dir / "claude-basic.md")
+
+
+def test_golden_codex_basic(tmp_path, state_env, monkeypatch):
+    monkeypatch.setenv("POLYLOGUE_FIXED_NOW", FIXED_NOW)
+    fixtures = _repo_root() / "tests" / "fixtures" / "golden"
+    golden_dir = _repo_root() / "tests" / "golden"
+    out_dir = tmp_path / "out"
+
+    result = import_codex_session(
+        str(_rel(fixtures / "codex" / "codex-golden.jsonl")),
+        base_dir=_repo_root(),
+        output_dir=out_dir,
+        collapse_threshold=10,
+        html=False,
+        force=True,
+    )
+    slug = result.slug
+    db_path = Path(state_env) / "polylogue.db"
+    _render_slug(db_path, out_dir, slug)
+    _assert_golden(out_dir / slug / "conversation.md", golden_dir / "codex-basic.md")
+
+
+def test_golden_claude_code_basic(tmp_path, state_env, monkeypatch):
+    monkeypatch.setenv("POLYLOGUE_FIXED_NOW", FIXED_NOW)
+    fixtures = _repo_root() / "tests" / "fixtures" / "golden"
+    golden_dir = _repo_root() / "tests" / "golden"
+    out_dir = tmp_path / "out"
+
+    result = import_claude_code_session(
+        str(_rel(fixtures / "claude_code" / "claude-code-golden.jsonl")),
+        base_dir=Path("."),
+        output_dir=out_dir,
+        collapse_threshold=10,
+        html=False,
+        html_theme="light",
+        force=True,
+    )
+    slug = result.slug
+    db_path = Path(state_env) / "polylogue.db"
+    _render_slug(db_path, out_dir, slug)
+    _assert_golden(out_dir / slug / "conversation.md", golden_dir / "claude-code-basic.md")

--- a/tests/test_inbox_cli.py
+++ b/tests/test_inbox_cli.py
@@ -18,6 +18,10 @@ def test_inbox_cli_lists_and_quarantines(tmp_path: Path, capsys) -> None:
     bad = inbox / "bad.zip"
     bad.write_bytes(b"junk")
 
+    ignored = inbox / "ignored.zip"
+    ignored.write_bytes(b"junk")
+    (inbox / ".polylogueignore").write_text("ignored.zip\n", encoding="utf-8")
+
     args = SimpleNamespace(
         providers="chatgpt,claude",
         dir=inbox,
@@ -33,5 +37,6 @@ def test_inbox_cli_lists_and_quarantines(tmp_path: Path, capsys) -> None:
     providers = {entry["provider"] for entry in output.get("entries", [])}
     assert "chatgpt" in providers
     assert output.get("quarantined"), "expected bad.zip to be quarantined"
+    assert output.get("ignoredByRule", 0) == 1
     assert output.get("totals", {}).get("pending", 0) >= 1
     assert (inbox / "quarantine" / "bad.zip").exists()

--- a/tests/test_inbox_cli.py
+++ b/tests/test_inbox_cli.py
@@ -38,5 +38,7 @@ def test_inbox_cli_lists_and_quarantines(tmp_path: Path, capsys) -> None:
     assert "chatgpt" in providers
     assert output.get("quarantined"), "expected bad.zip to be quarantined"
     assert output.get("ignoredByRule", 0) == 1
+    assert output.get("malformed", 0) == 1
+    assert output.get("malformedByReason", {}).get("not-a-zip") == 1
     assert output.get("totals", {}).get("pending", 0) >= 1
     assert (inbox / "quarantine" / "bad.zip").exists()

--- a/tests/test_local_sync_jobs.py
+++ b/tests/test_local_sync_jobs.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from polylogue.importers.base import ImportResult
+from polylogue.local_sync import _sync_sessions
+from polylogue.render import MarkdownDocument
+from polylogue.ui import UI
+
+
+def test_local_sync_jobs_preserves_deterministic_order(tmp_path):
+    base = tmp_path / "sessions"
+    base.mkdir(parents=True, exist_ok=True)
+    sessions = []
+    for idx in range(5):
+        p = base / f"{idx:02d}.jsonl"
+        p.write_text("{}", encoding="utf-8")
+        sessions.append(p)
+
+    out_dir = tmp_path / "out"
+
+    def import_fn(session_id: str, *, output_dir: Path, **_kwargs):
+        slug = Path(session_id).stem
+        conv_dir = output_dir / slug
+        conv_dir.mkdir(parents=True, exist_ok=True)
+        md_path = conv_dir / "conversation.md"
+        md_path.write_text("---\n---\n\nHello\n", encoding="utf-8")
+        doc = MarkdownDocument(
+            body="Hello",
+            metadata={"attachmentBytes": 0},
+            attachments=[],
+            stats={"totalTokensApprox": 0, "totalWordsApprox": 0},
+        )
+        return ImportResult(markdown_path=md_path, html_path=None, attachments_dir=None, document=doc, slug=slug)
+
+    ui = UI(plain=True)
+    result = _sync_sessions(
+        sessions,
+        output_dir=out_dir,
+        collapse_threshold=10,
+        collapse_thresholds={"message": 10, "tool": 10},
+        base_dir=base,
+        html=False,
+        html_theme="light",
+        force=True,
+        prune=False,
+        diff=False,
+        provider="codex",
+        import_fn=import_fn,
+        ui=ui,
+        jobs=3,
+    )
+
+    assert [r.slug for r in result.written] == [f"{idx:02d}" for idx in range(5)]
+    assert result.failures == 0
+

--- a/tests/test_metrics_cli.py
+++ b/tests/test_metrics_cli.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+from click.testing import CliRunner
+
+from polylogue.cli.click_app import cli as click_cli
+from polylogue.cli.metrics import run_metrics_cli
+from polylogue.commands import CommandEnv
+from polylogue.db import open_connection
+from polylogue import util
+
+
+class DummyConsole:
+    def __init__(self):
+        self.lines = []
+
+    def print(self, *args, **kwargs):
+        self.lines.append(" ".join(str(a) for a in args))
+
+
+class DummyUI:
+    plain = True
+
+    def __init__(self):
+        self.console = DummyConsole()
+
+
+def test_metrics_cli_prometheus_output(state_env, capsys):
+    with open_connection(None) as conn:
+        conn.execute(
+            """
+            INSERT INTO conversations (
+                provider, conversation_id, slug, title, current_branch,
+                root_message_id, last_updated, content_hash, metadata_json
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            ("chatgpt", "conv-1", "conv-1", "Test Conversation", None, None, None, None, None),
+        )
+        conn.commit()
+
+    util.add_run({"cmd": "render", "provider": "render", "count": 1, "attachments": 2, "attachmentBytes": 2048})
+    env = CommandEnv(ui=DummyUI())
+    run_metrics_cli(SimpleNamespace(providers=None, runs_limit=0, json=False, serve=False, host="127.0.0.1", port=0), env)
+    out = capsys.readouterr().out
+
+    assert "polylogue_build_info" in out
+    assert 'polylogue_db_conversations_total{provider="chatgpt"} 1' in out
+    assert 'polylogue_run_records_total{cmd="render",provider="render"} 1' in out
+    assert 'polylogue_attachments_processed_total{cmd="render",provider="render"} 2' in out
+
+
+def test_click_browse_metrics_json(state_env):
+    runner = CliRunner()
+    result = runner.invoke(click_cli, ["--plain", "browse", "metrics", "--json"])
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert "db" in payload
+    assert "runs" in payload
+

--- a/tests/test_render_branch.py
+++ b/tests/test_render_branch.py
@@ -33,6 +33,21 @@ def _write_render_input(path: Path) -> None:
     path.write_text(json.dumps(payload), encoding="utf-8")
 
 
+def _write_render_input_branched(path: Path) -> None:
+    payload = {
+        "chunkedPrompt": {
+            "chunks": [
+                {"role": "user", "text": "Hello", "messageId": "m1", "timestamp": "2024-01-01T00:00:00Z"},
+                {"role": "model", "text": "Hi", "messageId": "m2", "parentId": "m1", "timestamp": "2024-01-01T00:01:00Z"},
+                {"role": "user", "text": "Question", "messageId": "m3", "parentId": "m2", "timestamp": "2024-01-01T00:02:00Z"},
+                {"role": "model", "text": "Answer A", "messageId": "m4", "parentId": "m3", "timestamp": "2024-01-01T00:03:00Z"},
+                {"role": "model", "text": "Answer B", "messageId": "m5", "parentId": "m3", "timestamp": "2024-01-01T00:04:00Z"},
+            ]
+        }
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
 def _run_render(tmp_path: Path, state_env) -> Path:
     _ = state_env  # ensure fixture applies environment paths
     src = tmp_path / "sample.json"
@@ -59,3 +74,32 @@ def test_render_branch_full_writes_branch_tree(tmp_path, state_env):
     branch_dir = conversation_dir / "branches" / "branch-000"
     assert branch_dir.exists()
     assert (branch_dir / "branch-000.md").exists()
+
+
+def test_render_branch_full_includes_branch_map_in_conversation_md(tmp_path, state_env):
+    _ = state_env  # ensure fixture applies environment paths
+    src = tmp_path / "branched.json"
+    _write_render_input_branched(src)
+    out_dir = tmp_path / "render"
+    options = RenderOptions(
+        inputs=[src],
+        output_dir=out_dir,
+        collapse_threshold=16,
+        download_attachments=False,
+        dry_run=False,
+        force=False,
+        html=False,
+        html_theme="light",
+        diff=False,
+    )
+    env = CommandEnv(ui=_SilentUI())
+    render_command(options, env)
+
+    conversation_dir = out_dir / "branched"
+    conversation_md = conversation_dir / "conversation.md"
+    assert conversation_md.exists()
+    rendered = conversation_md.read_text(encoding="utf-8")
+    assert "## Branch map" in rendered
+    assert "- [branch-000](./branches/branch-000/branch-000.md)" in rendered
+    assert "- [branch-001](./branches/branch-001/branch-001.md)" in rendered
+    assert (conversation_dir / "branches" / "branch-001" / "branch-001.md").exists()

--- a/tests/test_resume_from.py
+++ b/tests/test_resume_from.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from polylogue import util
+from polylogue.cli.sync import _apply_resume_from
+from polylogue.commands import CommandEnv
+
+
+class DummyConsole:
+    def print(self, *_args, **_kwargs):
+        return None
+
+
+class DummyUI:
+    plain = True
+
+    def __init__(self):
+        self.console = DummyConsole()
+
+
+def test_resume_from_drive_selects_failed_chat_ids(state_env):
+    util.add_run(
+        {
+            "cmd": "sync drive",
+            "provider": "drive",
+            "failedChats": [{"id": "abc", "name": "A", "error": "nope"}, {"id": "def", "name": "B", "error": "nope"}],
+        }
+    )
+    run_id = util.load_runs(limit=1)[0]["id"]
+    env = CommandEnv(ui=DummyUI())
+    args = SimpleNamespace(provider="drive", chat_ids=None, sessions=None, all=False, prune=True, resume_from=None)
+    _apply_resume_from(args, env, run_id=run_id)
+    assert args.chat_ids == ["abc", "def"]
+    assert args.all is True
+    assert args.prune is False
+    assert args.resume_from == run_id
+
+
+def test_resume_from_local_selects_failed_paths(state_env):
+    util.add_run(
+        {
+            "cmd": "sync codex",
+            "provider": "codex",
+            "failedPaths": [{"path": "/tmp/demo.jsonl", "error": "bad json"}],
+        }
+    )
+    run_id = util.load_runs(limit=1)[0]["id"]
+    env = CommandEnv(ui=DummyUI())
+    args = SimpleNamespace(provider="codex", chat_ids=None, sessions=None, all=False, prune=True, resume_from=None)
+    _apply_resume_from(args, env, run_id=run_id)
+    assert args.sessions == ["/tmp/demo.jsonl"]
+    assert args.all is True
+    assert args.prune is False
+    assert args.resume_from == run_id
+

--- a/tests/test_runs_cli.py
+++ b/tests/test_runs_cli.py
@@ -52,3 +52,17 @@ def test_runs_cli_since_until(state_env):
     output = "\n".join(env.ui.console.lines)
     assert "codex" in output
     assert "drive" not in output
+
+
+def test_runs_cli_json_lines(state_env, capsys):
+    util.add_run({"cmd": "sync drive", "provider": "drive", "count": 1})
+    util.add_run({"cmd": "sync codex", "provider": "codex", "count": 2})
+    env = CommandEnv(ui=DummyUI())
+    run_runs_cli(
+        SimpleNamespace(limit=10, providers=None, commands=None, since=None, until=None, json=False, json_lines=True),
+        env,
+    )
+    out = capsys.readouterr().out.strip().splitlines()
+    assert len(out) == 2
+    decoded = [json.loads(line) for line in out]
+    assert {row["cmd"] for row in decoded} == {"sync drive", "sync codex"}

--- a/tests/test_verify_canonical.py
+++ b/tests/test_verify_canonical.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import json
+from contextlib import contextmanager
+from pathlib import Path
+from types import SimpleNamespace
+
+import frontmatter
+import pytest
+
+from polylogue.cli.verify import run_verify_cli
+from polylogue.commands import CommandEnv, RenderOptions, render_command
+
+
+class DummyUI:
+    plain = True
+
+    def __init__(self):
+        self.console = self
+
+    def print(self, *_args, **_kwargs):  # pragma: no cover
+        pass
+
+    def summary(self, *_args, **_kwargs):  # pragma: no cover
+        pass
+
+    def banner(self, *_args, **_kwargs):  # pragma: no cover
+        pass
+
+    @contextmanager
+    def progress(self, *_args, **_kwargs):  # pragma: no cover
+        class DummyProgressTracker:
+            def advance(self, *args, **kwargs):
+                pass
+
+            def update(self, *args, **kwargs):
+                pass
+
+        yield DummyProgressTracker()
+
+
+def test_verify_flags_noncanonical_and_unknown_keys(tmp_path, state_env, capsys):
+    src = tmp_path / "render.json"
+    payload = {
+        "id": "conv-verify-canon",
+        "title": "Verify Canon",
+        "chunkedPrompt": {
+            "chunks": [
+                {"role": "user", "text": "Hello", "timestamp": "2024-01-01T00:00:00Z"},
+                {"role": "model", "text": "Hi", "timestamp": "2024-01-01T00:01:00Z"},
+            ]
+        },
+    }
+    src.write_text(json.dumps(payload), encoding="utf-8")
+    out_dir = tmp_path / "out"
+
+    env = CommandEnv(ui=DummyUI())
+    render_command(
+        RenderOptions(
+            inputs=[src],
+            output_dir=out_dir,
+            collapse_threshold=12,
+            download_attachments=False,
+            dry_run=False,
+            force=False,
+            html=False,
+            html_theme=None,
+            diff=False,
+        ),
+        env,
+    )
+
+    md_path = out_dir / "render" / "conversation.md"
+    post = frontmatter.loads(md_path.read_text(encoding="utf-8"))
+    polylogue_meta = dict(post.metadata.get("polylogue") or {})
+    polylogue_meta["mysteryKey"] = "x"
+    post.metadata["polylogue"] = polylogue_meta
+    # Write without sorting/canonicalization.
+    md_path.write_text(frontmatter.dumps(post), encoding="utf-8")
+
+    with pytest.raises(SystemExit):
+        run_verify_cli(
+            SimpleNamespace(
+                provider="render",
+                slug="render",
+                conversation_ids=(),
+                limit=None,
+                json=True,
+                fix=False,
+                strict=False,
+                unknown_policy="error",
+                allow_polylogue_keys=(),
+            ),
+            env,
+        )
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["errors"] >= 1
+    messages = [issue["message"] for issue in payload["issues"]]
+    assert any("Unknown polylogue metadata keys" in msg for msg in messages)
+
+
+def test_verify_fix_rewrites_frontmatter(tmp_path, state_env):
+    src = tmp_path / "render.json"
+    payload = {
+        "id": "conv-verify-fix",
+        "title": "Verify Fix",
+        "chunkedPrompt": {"chunks": [{"role": "user", "text": "Hello"}]},
+    }
+    src.write_text(json.dumps(payload), encoding="utf-8")
+    out_dir = tmp_path / "out"
+
+    env = CommandEnv(ui=DummyUI())
+    render_command(
+        RenderOptions(
+            inputs=[src],
+            output_dir=out_dir,
+            collapse_threshold=12,
+            download_attachments=False,
+            dry_run=False,
+            force=False,
+            html=False,
+            html_theme=None,
+            diff=False,
+        ),
+        env,
+    )
+
+    md_path = out_dir / "render" / "conversation.md"
+    # Make the YAML order non-canonical by reversing keys at top-level.
+    post = frontmatter.loads(md_path.read_text(encoding="utf-8"))
+    meta = dict(post.metadata)
+    post.metadata = dict(reversed(list(meta.items())))
+    md_path.write_text(frontmatter.dumps(post), encoding="utf-8")
+
+    run_verify_cli(
+        SimpleNamespace(
+            provider="render",
+            slug="render",
+            conversation_ids=(),
+            limit=None,
+            json=True,
+            fix=True,
+            strict=False,
+            unknown_policy="ignore",
+            allow_polylogue_keys=(),
+        ),
+        env,
+    )
+    # second pass should not need to rewrite and should exit cleanly.
+    run_verify_cli(
+        SimpleNamespace(
+            provider="render",
+            slug="render",
+            conversation_ids=(),
+            limit=None,
+            json=True,
+            fix=False,
+            strict=True,
+            unknown_policy="ignore",
+            allow_polylogue_keys=(),
+        ),
+        env,
+    )
+

--- a/tests/test_verify_cli.py
+++ b/tests/test_verify_cli.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import json
+from contextlib import contextmanager
+from types import SimpleNamespace
+
+from polylogue.cli.verify import run_verify_cli
+from polylogue.commands import CommandEnv, RenderOptions, render_command
+
+
+class DummyUI:
+    plain = True
+
+    def __init__(self):
+        self.console = self
+
+    def print(self, *_args, **_kwargs):  # pragma: no cover - diagnostics only
+        pass
+
+    def summary(self, *_args, **_kwargs):  # pragma: no cover
+        pass
+
+    def banner(self, *_args, **_kwargs):  # pragma: no cover
+        pass
+
+    @contextmanager
+    def progress(self, *_args, **_kwargs):  # pragma: no cover
+        class DummyProgressTracker:
+            def advance(self, *args, **kwargs):
+                pass
+
+            def update(self, *args, **kwargs):
+                pass
+
+        yield DummyProgressTracker()
+
+
+def test_verify_cli_reports_ok(tmp_path, state_env, capsys):
+    src = tmp_path / "render.json"
+    payload = {
+        "id": "conv-verify",
+        "title": "Verify",
+        "chunkedPrompt": {
+            "chunks": [
+                {"role": "user", "text": "Hello", "timestamp": "2024-01-01T00:00:00Z"},
+                {"role": "model", "text": "Hi", "timestamp": "2024-01-01T00:01:00Z"},
+            ]
+        },
+    }
+    src.write_text(json.dumps(payload), encoding="utf-8")
+    out_dir = tmp_path / "out"
+
+    options = RenderOptions(
+        inputs=[src],
+        output_dir=out_dir,
+        collapse_threshold=12,
+        download_attachments=False,
+        dry_run=False,
+        force=False,
+        html=False,
+        html_theme=None,
+        diff=False,
+    )
+    env = CommandEnv(ui=DummyUI())
+    render_command(options, env)
+
+    run_verify_cli(SimpleNamespace(provider="render", slug="render", conversation_ids=(), limit=None, json=True), env)
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["errors"] == 0
+    assert payload["verified"] == 1
+


### PR DESCRIPTION
## Summary

I added three missing operational loops around the archive: a verifier that can prove rendered output still matches the database, a metrics surface that makes run history and provider counts observable without ad hoc SQL, and a resume path that can turn the metadata from a failed run into the input set for the next one. While wiring those pieces, I also added `--jobs` parallelism for local Codex / Claude Code sync, broadened attachment and inbox inspection, and made JSON / snapshot output much more deterministic. The common thread is run metadata: once runs record stable IDs, failure manifests, retry counters, and custom metadata, they become useful for verification, observability, and recovery instead of just being historical log rows. I intentionally let these features land together because each one depended on the same deterministic output work and the same richer run records. The branch also uses that determinism work to improve branch explorers, transcript rendering, and golden tests, so the new commands are backed by outputs that do not drift for incidental ordering reasons.

## Motivation

There were four practical gaps in the archive workflow.

The first was **drift detection**. A rendered `conversation.md` file could diverge from the database, front matter, or attachment index and there was no first-class way to notice short of opening the file and comparing it by hand. That becomes a real problem once the archive is used for search, export, or CI snapshots.

The second was **failed-run recovery**. When a Drive or local sync partially failed, the information about what went wrong existed only indirectly in console output or in inconsistent metadata blobs. Operators had to re-run broad syncs or manually reconstruct the failed subset.

The third was **observability**. We had rich state in SQLite and in the runs table, but nothing that could be scraped, dumped, or graphed without custom SQL. That made it hard to answer basic questions like “how many conversations are indexed per provider?” or “when did the last successful sync happen?”

The fourth was **throughput without determinism loss**. Local sync had obvious concurrency opportunities, but naively parallelizing it would have destabilized slug ordering and snapshot output, which would then undermine the verifier and golden tests.

The solution that kept recurring in the branch was: make run and render output deterministic first, then build verify/metrics/resume on top of that stable substrate.

## Changes by concern

### 1. Add a verifier that reasons about the whole archive surface

`polylogue/cli/verify.py` is the new user-facing entrypoint, but the real foundation is `polylogue/frontmatter_canonical.py`. I wanted `verify --fix` to do more than just “rewrite some YAML”; it needed to normalize key ordering and optionally scrub absolute paths so the same canonicalizer could also support portable snapshot tests.

The verifier checks several different drift vectors:

- front matter keys vs the conversation row
- content-hash agreement across rendered file, DB state, and recomputed body
- branch document existence
- attachment path existence
- unknown `polylogue.*` keys, with policy control

That last point matters because schema drift is often subtle. If someone adds or renames metadata keys, I want the archive to be able to treat that as ignored noise, a warning, or a hard error depending on the context. `--strict` and `--unknown` make the same command usable both for operator spot checks and for CI gating.

### 2. Turn run history into a real recovery mechanism

The key enabling change is richer run metadata. `polylogue/util.py` gains `get_run_by_id()`, but more importantly sync/render/import runs now record failure manifests and custom metadata in a consistent shape. Once the run row contains `failedChats`, `failedPaths`, failure counters, and retry settings, `--resume-from <id>` can build the next invocation mechanically instead of heuristically.

The recovery rules are conservative on purpose:

- limit the resumed run to the previously failed subset
- force `--all` so there is no picker ambiguity
- disable `--prune` so a recovery run cannot delete unrelated good output

That gives a focused rerun without making the operator remember the exact failed IDs or file paths.

Threaded `--meta key=value` through sync/import/render because the same mechanism is useful both for dashboards and for recovery bookkeeping. It lets external orchestration attach deployment IDs, batch IDs, or environment tags without inventing a separate side channel.

### 3. Add metrics without inventing a separate service

`polylogue/cli/metrics.py` exports a Prometheus-style text format and a structured JSON form from the existing DB plus run history. I kept it in-process and optionally served via a tiny HTTP server because the underlying data is already local and cheap to aggregate.

The metrics break down counts by provider and command, and they surface:

- items processed
- attachments / bytes
- duration
- retries / failures
- last-run timestamps

This is intentionally close to the run payload model. I do not want two parallel telemetry schemas. The same run records that power `--resume-from` should also power `/metrics`.

### 4. Parallelize local sync without destabilizing output

The `--jobs` work in `polylogue/local_sync.py` uses `ThreadPoolExecutor`, but the detail that matters is result collection order. Workers can finish whenever they want; output ordering still follows the original input index. That preserves deterministic slug ordering and keeps branch/render snapshots stable even when the work is concurrent.

I paired that with plain-mode ETA/progress reporting so the same code path remains usable in environments without Rich. Parallelism is only worth it if operators can still understand what the command is doing.

### 5. Pay down the incidental nondeterminism

A lot of smaller changes exist solely because the new verify / metrics / golden tooling would have been noisy without them:

- sorted JSON output via `sort_keys=True`
- sorted rendered attachments
- consistent Drive chat ordering by `modifiedTime`
- run IDs in the runs table output
- inline branch diffs and branch map snippets in rendered output
- attachment routing counts exposed in metadata
- inbox reason codes for malformed exports and ignored items

These are individually modest, but together they make the archive much easier to reason about mechanically.

## Testing

I added fixed-time Markdown and HTML golden snapshots for all four providers so ordering and metadata regressions show up immediately. The command-specific coverage includes:

- `tests/test_metrics_cli.py`
- verify CLI coverage for canonical rewrites and unknown-key handling
- resume-from tests for Drive and local provider paths
- attachment stats tests for provider filters, time windows, and orphan cleanup
- local sync ordering tests for `--jobs`
- inbox tests for malformed export detection and `.polylogueignore` handling

Those tests matter because the branch intentionally touches rendering, CLI metadata, retry logic, and concurrency at the same time. The snapshots and targeted unit tests are what keep that scope safe.

## Notes

I did not try to make `verify` a full schema-migration tool. It canonicalizes and flags drift, but it is still operating on top of the existing archive model. Likewise, the metrics server is intentionally minimal: it is a thin export surface over current state, not a long-running daemon with its own persistence story. The branch’s main value is that verification, observability, and recovery now all speak the same language: stable rendered output plus richer run metadata.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `verify` command to validate conversation integrity and frontmatter consistency.
  * Added `metrics` command to monitor system health and view run statistics.
  * Added resume-from functionality to retry failed syncs from the last failure point.
  * Added attachment filtering (by provider, date range) and orphan cleanup capabilities.
  * Added metadata tagging support for imports and renders.

* **Improvements**
  * Enhanced inbox detection with `.polylogueignore` support.
  * Added branch map visualization in rendered conversations.
  * Improved diff display for non-canonical branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->