### PR TITLE
test: cover attachment recovery and bulk-export skip paths

### DIFF
--- a/nix/python-deps.nix
+++ b/nix/python-deps.nix
@@ -27,6 +27,7 @@ let
     pytest-cov
     coverage
     mypy
+    pexpect
   ];
 in {
   inherit commonDeps devDeps;

--- a/polylogue/cli/analytics.py
+++ b/polylogue/cli/analytics.py
@@ -1,0 +1,326 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Dict, List, Optional
+
+from jinja2 import BaseLoader, Environment
+
+from ..commands import CommandEnv
+from ..db import open_connection
+from ..schema import stamp_payload
+from .editor import open_in_editor
+
+
+_TEMPLATE = """
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Polylogue Analytics</title>
+  <style>
+    :root {
+      --bg: {{ '#ffffff' if theme == 'light' else '#111827' }};
+      --fg: {{ '#111827' if theme == 'light' else '#e5e7eb' }};
+      --muted: {{ '#6b7280' if theme == 'light' else '#9ca3af' }};
+      --border: {{ '#e5e7eb' if theme == 'light' else '#374151' }};
+      --accent: {{ '#2563eb' if theme == 'light' else '#93c5fd' }};
+      --row: {{ '#f9fafb' if theme == 'light' else '#0b1220' }};
+    }
+    * { box-sizing: border-box; }
+    body { margin: 0; background: var(--bg); color: var(--fg); font-family: system-ui, -apple-system, Segoe UI, sans-serif; }
+    header { position: sticky; top: 0; z-index: 10; border-bottom: 1px solid var(--border); padding: 0.75rem 1rem; background: color-mix(in srgb, var(--bg) 92%, transparent); backdrop-filter: blur(6px); display: flex; gap: 0.75rem; align-items: center; }
+    h1 { font-size: 1.1rem; margin: 0; }
+    main { padding: 1rem; max-width: 1200px; margin: 0 auto; }
+    h2 { font-size: 1rem; margin: 1.25rem 0 0.5rem; }
+    .muted { color: var(--muted); font-size: 0.85rem; }
+    table { width: 100%; border-collapse: collapse; border: 1px solid var(--border); border-radius: 12px; overflow: hidden; }
+    thead th { text-align: left; font-size: 0.85rem; color: var(--muted); padding: 0.6rem 0.75rem; border-bottom: 1px solid var(--border); background: color-mix(in srgb, var(--bg) 94%, #00000006); }
+    tbody td { padding: 0.55rem 0.75rem; border-bottom: 1px solid var(--border); vertical-align: top; }
+    tbody tr:nth-child(even) { background: var(--row); }
+    .num { text-align: right; font-variant-numeric: tabular-nums; }
+    a { color: var(--accent); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Polylogue Analytics</h1>
+    <span class="muted">generated {{ generated_at }}</span>
+  </header>
+  <main>
+    <h2>Providers</h2>
+    <table>
+      <thead><tr>
+        <th>Provider</th>
+        <th class="num">Conversations</th>
+        <th class="num">Branches</th>
+        <th class="num">Messages</th>
+        <th class="num">Attachments</th>
+        <th class="num">Attachment MiB</th>
+      </tr></thead>
+      <tbody>
+        {% for row in provider_rows %}
+        <tr>
+          <td>{{ row.provider }}</td>
+          <td class="num">{{ row.conversations }}</td>
+          <td class="num">{{ row.branches }}</td>
+          <td class="num">{{ row.messages }}</td>
+          <td class="num">{{ row.attachments }}</td>
+          <td class="num">{{ '%.2f'|format(row.attachment_bytes / (1024*1024)) }}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+
+    <h2>Top Models</h2>
+    <table>
+      <thead><tr>
+        <th>Provider</th>
+        <th>Model</th>
+        <th class="num">Messages</th>
+        <th class="num">Tokens</th>
+      </tr></thead>
+      <tbody>
+        {% for row in model_rows %}
+        <tr>
+          <td>{{ row.provider }}</td>
+          <td><code>{{ row.model }}</code></td>
+          <td class="num">{{ row.messages }}</td>
+          <td class="num">{{ row.tokens }}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+
+    <h2>Roles</h2>
+    <table>
+      <thead><tr>
+        <th>Provider</th>
+        <th>Role</th>
+        <th class="num">Messages</th>
+        <th class="num">Tokens</th>
+      </tr></thead>
+      <tbody>
+        {% for row in role_rows %}
+        <tr>
+          <td>{{ row.provider }}</td>
+          <td><code>{{ row.role }}</code></td>
+          <td class="num">{{ row.messages }}</td>
+          <td class="num">{{ row.tokens }}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+
+    <h2>Branch Hotspots</h2>
+    <div class="muted">Conversations with most branches</div>
+    <div style="height: 0.5rem"></div>
+    <table>
+      <thead><tr>
+        <th>Provider</th>
+        <th>Slug</th>
+        <th>Title</th>
+        <th class="num">Branches</th>
+      </tr></thead>
+      <tbody>
+        {% for row in branch_hotspots %}
+        <tr>
+          <td>{{ row.provider }}</td>
+          <td><code>{{ row.slug }}</code></td>
+          <td>{{ row.title or '-' }}</td>
+          <td class="num">{{ row.branch_count }}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </main>
+</body>
+</html>
+"""
+
+
+def run_analytics_cli(args: SimpleNamespace, env: CommandEnv) -> None:
+    providers = _normalize_filter(getattr(args, "providers", None))
+    model_limit = max(1, int(getattr(args, "model_limit", 25) or 25))
+    hotspot_limit = max(1, int(getattr(args, "hotspot_limit", 25) or 25))
+    json_mode = bool(getattr(args, "json", False))
+    out_path = getattr(args, "out", None)
+    theme = getattr(args, "theme", "light") or "light"
+    open_result = bool(getattr(args, "open", False))
+
+    payload = _build_payload(providers=providers, model_limit=model_limit, hotspot_limit=hotspot_limit)
+
+    if json_mode:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return
+
+    if out_path is None:
+        out_path = Path.cwd() / "analytics.html"
+    out = Path(out_path).expanduser()
+    out.parent.mkdir(parents=True, exist_ok=True)
+
+    html = Environment(loader=BaseLoader(), autoescape=True).from_string(_TEMPLATE).render(
+        generated_at=datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        theme=theme,
+        provider_rows=payload["providerRows"],
+        model_rows=payload["modelRows"],
+        role_rows=payload["roleRows"],
+        branch_hotspots=payload["branchHotspots"],
+    )
+    out.write_text(html, encoding="utf-8")
+    if open_result:
+        open_in_editor(out)
+    else:
+        env.ui.console.print(f"[green]Wrote analytics → {out}[/green]")
+
+
+def _normalize_filter(raw: Optional[str]) -> Optional[set[str]]:
+    if not raw:
+        return None
+    values = {chunk.strip().lower() for chunk in raw.split(",") if chunk.strip()}
+    return values or None
+
+
+def _placeholders(n: int) -> str:
+    return ",".join("?" for _ in range(n))
+
+
+def _build_payload(*, providers: Optional[set[str]], model_limit: int, hotspot_limit: int) -> Dict[str, Any]:
+    provider_rows: List[Dict[str, Any]] = []
+    model_rows: List[Dict[str, Any]] = []
+    role_rows: List[Dict[str, Any]] = []
+    branch_hotspots: List[Dict[str, Any]] = []
+
+    params: List[object] = []
+    provider_where = ""
+    if providers:
+        provider_where = f"WHERE provider IN ({_placeholders(len(providers))})"
+        params.extend(sorted(providers))
+
+    with open_connection(None) as conn:
+        conv_rows = conn.execute(
+            f"SELECT provider, COUNT(*) AS n FROM conversations {provider_where} GROUP BY provider",
+            params,
+        ).fetchall()
+        branch_rows = conn.execute(
+            f"SELECT provider, COUNT(*) AS n FROM branches {provider_where} GROUP BY provider",
+            params,
+        ).fetchall()
+        msg_rows = conn.execute(
+            f"SELECT provider, COUNT(*) AS n, COALESCE(SUM(token_count), 0) AS tokens FROM messages {provider_where} GROUP BY provider",
+            params,
+        ).fetchall()
+        att_rows = conn.execute(
+            f"SELECT provider, COUNT(*) AS n, COALESCE(SUM(size_bytes), 0) AS bytes FROM attachments {provider_where} GROUP BY provider",
+            params,
+        ).fetchall()
+
+        conv_counts = {row["provider"]: int(row["n"] or 0) for row in conv_rows}
+        branch_counts = {row["provider"]: int(row["n"] or 0) for row in branch_rows}
+        msg_counts = {row["provider"]: (int(row["n"] or 0), int(row["tokens"] or 0)) for row in msg_rows}
+        att_counts = {row["provider"]: (int(row["n"] or 0), int(row["bytes"] or 0)) for row in att_rows}
+
+        all_providers = sorted(set(conv_counts) | set(branch_counts) | set(msg_counts) | set(att_counts))
+        for provider in all_providers:
+            messages_n, messages_tokens = msg_counts.get(provider, (0, 0))
+            attachments_n, attachments_bytes = att_counts.get(provider, (0, 0))
+            provider_rows.append(
+                {
+                    "provider": provider,
+                    "conversations": conv_counts.get(provider, 0),
+                    "branches": branch_counts.get(provider, 0),
+                    "messages": messages_n,
+                    "messageTokens": messages_tokens,
+                    "attachments": attachments_n,
+                    "attachment_bytes": attachments_bytes,
+                }
+            )
+
+        role_params = list(params)
+        role_rows_raw = conn.execute(
+            f"""
+            SELECT provider, COALESCE(role, 'unknown') AS role, COUNT(*) AS n, COALESCE(SUM(token_count), 0) AS tokens
+              FROM messages
+              {provider_where}
+             GROUP BY provider, role
+             ORDER BY provider, n DESC, role
+            """,
+            role_params,
+        ).fetchall()
+        for row in role_rows_raw:
+            role_rows.append({"provider": row["provider"], "role": row["role"], "messages": int(row["n"] or 0), "tokens": int(row["tokens"] or 0)})
+
+        model_params = list(params)
+        model_where = provider_where
+        if model_where:
+            model_where += " AND model IS NOT NULL AND model != ''"
+        else:
+            model_where = "WHERE model IS NOT NULL AND model != ''"
+        model_rows_raw = conn.execute(
+            f"""
+            SELECT provider, model, COUNT(*) AS n, COALESCE(SUM(token_count), 0) AS tokens
+              FROM messages
+              {model_where}
+             GROUP BY provider, model
+             ORDER BY n DESC, tokens DESC
+             LIMIT ?
+            """,
+            [*model_params, model_limit],
+        ).fetchall()
+        for row in model_rows_raw:
+            model_rows.append(
+                {
+                    "provider": row["provider"],
+                    "model": row["model"],
+                    "messages": int(row["n"] or 0),
+                    "tokens": int(row["tokens"] or 0),
+                }
+            )
+
+        hotspot_params = list(params)
+        hotspot_where = ""
+        if providers:
+            hotspot_where = f"WHERE b.provider IN ({_placeholders(len(providers))})"
+        hotspot_rows = conn.execute(
+            f"""
+            SELECT b.provider, b.conversation_id, COUNT(*) AS n,
+                   c.slug AS slug, c.title AS title
+              FROM branches AS b
+              JOIN conversations AS c
+                ON c.provider = b.provider AND c.conversation_id = b.conversation_id
+              {hotspot_where}
+             GROUP BY b.provider, b.conversation_id
+             ORDER BY n DESC, b.provider, c.slug
+             LIMIT ?
+            """,
+            [*hotspot_params, hotspot_limit],
+        ).fetchall()
+        for row in hotspot_rows:
+            branch_hotspots.append(
+                {
+                    "provider": row["provider"],
+                    "conversation_id": row["conversation_id"],
+                    "slug": row["slug"],
+                    "title": row["title"],
+                    "branch_count": int(row["n"] or 0),
+                }
+            )
+
+    return stamp_payload(
+        {
+            "generated_at": datetime.now(timezone.utc).timestamp(),
+            "provider_rows": provider_rows,
+            "role_rows": role_rows,
+            "model_rows": model_rows,
+            "branch_hotspots": branch_hotspots,
+        }
+    )
+
+
+__all__ = ["run_analytics_cli"]
+

--- a/polylogue/cli/browse.py
+++ b/polylogue/cli/browse.py
@@ -13,6 +13,7 @@ def run_browse_cli(args: SimpleNamespace, env: CommandEnv) -> None:
     from .metrics import run_metrics_cli
     from .runs import run_runs_cli
     from .status import run_stats_cli, run_status_cli
+    from .timeline import run_timeline_cli
 
     browse_cmd = args.browse_cmd
 
@@ -31,6 +32,8 @@ def run_browse_cli(args: SimpleNamespace, env: CommandEnv) -> None:
         run_inbox_cli(args, env)
     elif browse_cmd == "metrics":
         run_metrics_cli(args, env)
+    elif browse_cmd == "timeline":
+        run_timeline_cli(args, env)
     else:
         raise SystemExit(f"Unknown browse sub-command: {browse_cmd}")
 

--- a/polylogue/cli/browse.py
+++ b/polylogue/cli/browse.py
@@ -8,6 +8,7 @@ from ..commands import CommandEnv
 
 def run_browse_cli(args: SimpleNamespace, env: CommandEnv) -> None:
     """Dispatch to appropriate browse subcommand."""
+    from .analytics import run_analytics_cli
     from .branches_cli import run_branches_cli
     from .inbox import run_inbox_cli
     from .metrics import run_metrics_cli
@@ -34,6 +35,8 @@ def run_browse_cli(args: SimpleNamespace, env: CommandEnv) -> None:
         run_metrics_cli(args, env)
     elif browse_cmd == "timeline":
         run_timeline_cli(args, env)
+    elif browse_cmd == "analytics":
+        run_analytics_cli(args, env)
     else:
         raise SystemExit(f"Unknown browse sub-command: {browse_cmd}")
 

--- a/polylogue/cli/click_app.py
+++ b/polylogue/cli/click_app.py
@@ -187,6 +187,7 @@ def cli(ctx: click.Context, plain: bool, interactive: bool) -> None:
 @click.option("--resume-from", type=int, help="Resume a previous run by run ID (reprocess failed items only)")
 @click.option("--meta", multiple=True, help="Attach custom metadata key=value (repeatable)")
 @click.option("--root", type=str, help="Named root label to use when configs support multi-root archives")
+@click.option("--disk-estimate", is_flag=True, help="Print projected disk usage before running")
 @click.option("--max-disk", type=float, help="Abort if projected disk use exceeds this many GiB (approx)")
 @click.pass_obj
 def sync(env: CommandEnv, **kwargs) -> None:
@@ -259,6 +260,7 @@ def import_cmd_click(env: CommandEnv, **kwargs) -> None:
 @click.option("--to-clipboard", is_flag=True, help="Copy a single rendered file to the clipboard")
 @click.option("--dry-run", is_flag=True, help="Report actions without writing files")
 @click.option("--attachment-ocr", is_flag=True, help="Attempt OCR on image attachments when indexing attachment text")
+@click.option("--disk-estimate", is_flag=True, help="Print projected disk usage before running")
 @click.option("--max-disk", type=float, help="Abort if projected disk use exceeds this many GiB (approx)")
 @click.option("--sanitize-html", is_flag=True, help="Mask emails/keys/tokens in rendered Markdown/HTML outputs")
 @click.option("--meta", multiple=True, help="Attach custom metadata key=value (repeatable)")

--- a/polylogue/cli/click_app.py
+++ b/polylogue/cli/click_app.py
@@ -490,6 +490,22 @@ def browse_timeline(env: CommandEnv, **kwargs) -> None:
     browse_cmd.run_browse_cli(args, env)
 
 
+@browse_group.command(name="analytics")
+@click.option("--providers", type=str, help="Comma-separated provider filter")
+@click.option("--model-limit", type=int, default=25, show_default=True, help="Top-N models to include")
+@click.option("--hotspot-limit", type=int, default=25, show_default=True, help="Top-N branch hotspots to include")
+@click.option("--out", type=click.Path(path_type=Path), help="Write HTML analytics to this path (default: ./analytics.html)")
+@click.option("--theme", type=click.Choice(["light", "dark"]), default="light", show_default=True, help="HTML theme")
+@click.option("--open", "open_result", is_flag=True, help="Open result in $EDITOR after command completes")
+@click.option("--json", is_flag=True, help="Emit machine-readable summary instead of writing HTML")
+@click.pass_obj
+def browse_analytics(env: CommandEnv, **kwargs) -> None:
+    """Role/model/branch analytics from the SQLite state DB."""
+    kwargs["open"] = kwargs.pop("open_result")
+    args = SimpleNamespace(browse_cmd="analytics", **kwargs)
+    browse_cmd.run_browse_cli(args, env)
+
+
 @browse_group.command(name="inbox")
 @click.option("--providers", type=str, default="chatgpt,claude", show_default=True, help="Comma-separated provider filter")
 @click.option("--dir", type=click.Path(path_type=Path), help="Override inbox root for a generic scan")

--- a/polylogue/cli/click_app.py
+++ b/polylogue/cli/click_app.py
@@ -475,6 +475,21 @@ def browse_metrics(env: CommandEnv, **kwargs) -> None:
     browse_cmd.run_browse_cli(args, env)
 
 
+@browse_group.command(name="timeline")
+@click.option("--providers", type=str, help="Comma-separated provider filter")
+@click.option("--limit", type=int, default=500, show_default=True, help="Maximum rows to include")
+@click.option("--out", type=click.Path(path_type=Path), help="Write HTML timeline to this path (default: ./timeline.html)")
+@click.option("--theme", type=click.Choice(["light", "dark"]), default="light", show_default=True, help="HTML theme")
+@click.option("--open", "open_result", is_flag=True, help="Open result in $EDITOR after command completes")
+@click.option("--json", is_flag=True, help="Emit machine-readable rows instead of writing HTML")
+@click.pass_obj
+def browse_timeline(env: CommandEnv, **kwargs) -> None:
+    """Render a global conversation timeline (HTML) from the SQLite state DB."""
+    kwargs["open"] = kwargs.pop("open_result")
+    args = SimpleNamespace(browse_cmd="timeline", **kwargs)
+    browse_cmd.run_browse_cli(args, env)
+
+
 @browse_group.command(name="inbox")
 @click.option("--providers", type=str, default="chatgpt,claude", show_default=True, help="Comma-separated provider filter")
 @click.option("--dir", type=click.Path(path_type=Path), help="Override inbox root for a generic scan")

--- a/polylogue/cli/click_app.py
+++ b/polylogue/cli/click_app.py
@@ -140,6 +140,7 @@ def cli(ctx: click.Context, plain: bool, interactive: bool) -> None:
 @click.argument("provider", type=click.Choice(["drive", "codex", "claude-code", "chatgpt", "claude"]))
 @click.option("--out", type=click.Path(path_type=Path), help="Override output directory")
 @click.option("--links-only", is_flag=True, help="Link attachments instead of downloading (Drive only)")
+@click.option("--attachments-only", is_flag=True, help="Retry/download Drive attachments only (requires --resume-from; no re-render)")
 @click.option("--attachment-ocr", is_flag=True, help="Attempt OCR on image attachments when indexing attachment text")
 @click.option("--sanitize-html", is_flag=True, help="Mask emails/keys/tokens in synced Markdown/HTML outputs")
 @click.option("--dry-run", is_flag=True, help="Report actions without writing files")

--- a/polylogue/cli/timeline.py
+++ b/polylogue/cli/timeline.py
@@ -1,0 +1,255 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Dict, List, Optional
+
+from jinja2 import BaseLoader, Environment
+
+from ..commands import CommandEnv
+from ..db import open_connection
+from ..schema import stamp_payload
+from .editor import open_in_editor
+
+
+@dataclass(frozen=True)
+class TimelineRow:
+    provider: str
+    conversation_id: str
+    slug: str
+    title: Optional[str]
+    last_updated: Optional[str]
+    tokens: int
+    words: int
+    attachments: int
+    attachment_bytes: int
+    branch_count: int
+    output_path: Optional[str]
+    html_path: Optional[str]
+
+
+_TEMPLATE = """
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Polylogue Timeline</title>
+  <style>
+    :root {
+      --bg: {{ '#ffffff' if theme == 'light' else '#111827' }};
+      --fg: {{ '#111827' if theme == 'light' else '#e5e7eb' }};
+      --muted: {{ '#6b7280' if theme == 'light' else '#9ca3af' }};
+      --border: {{ '#e5e7eb' if theme == 'light' else '#374151' }};
+      --accent: {{ '#2563eb' if theme == 'light' else '#93c5fd' }};
+      --row: {{ '#f9fafb' if theme == 'light' else '#0b1220' }};
+    }
+    * { box-sizing: border-box; }
+    body { margin: 0; background: var(--bg); color: var(--fg); font-family: system-ui, -apple-system, Segoe UI, sans-serif; }
+    header { position: sticky; top: 0; z-index: 10; border-bottom: 1px solid var(--border); padding: 0.75rem 1rem; background: color-mix(in srgb, var(--bg) 92%, transparent); backdrop-filter: blur(6px); display: flex; gap: 0.75rem; align-items: center; }
+    h1 { font-size: 1.1rem; margin: 0; }
+    .pill { border: 1px solid var(--border); padding: 0.25rem 0.6rem; border-radius: 999px; color: var(--muted); font-size: 0.85rem; }
+    .search { flex: 1; padding: 0.5rem 0.75rem; border-radius: 10px; border: 1px solid var(--border); background: color-mix(in srgb, var(--bg) 96%, #00000008); color: var(--fg); }
+    main { padding: 1rem; max-width: 1200px; margin: 0 auto; }
+    table { width: 100%; border-collapse: collapse; border: 1px solid var(--border); border-radius: 12px; overflow: hidden; }
+    thead th { text-align: left; font-size: 0.85rem; color: var(--muted); padding: 0.6rem 0.75rem; border-bottom: 1px solid var(--border); background: color-mix(in srgb, var(--bg) 94%, #00000006); position: sticky; top: 56px; }
+    tbody td { padding: 0.55rem 0.75rem; border-bottom: 1px solid var(--border); vertical-align: top; }
+    tbody tr:nth-child(even) { background: var(--row); }
+    a { color: var(--accent); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    .muted { color: var(--muted); font-size: 0.85rem; }
+    .num { text-align: right; font-variant-numeric: tabular-nums; }
+    .links a { margin-right: 0.6rem; }
+    .hidden { display: none; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Polylogue Timeline</h1>
+    <input id="q" class="search" type="search" placeholder="Filter (provider/title/slug) — press /" />
+    <span class="pill" id="count"></span>
+  </header>
+  <main>
+    <div class="muted">Generated at {{ generated_at }} (rows={{ rows|length }})</div>
+    <div style="height: 0.75rem"></div>
+    <table>
+      <thead>
+        <tr>
+          <th>Updated</th>
+          <th>Provider</th>
+          <th>Title</th>
+          <th>Slug</th>
+          <th class="num">Branches</th>
+          <th class="num">Tokens</th>
+          <th class="num">Words</th>
+          <th class="num">Attachments</th>
+          <th class="num">Attachment MiB</th>
+          <th>Links</th>
+        </tr>
+      </thead>
+      <tbody id="rows">
+        {% for row in rows %}
+        <tr data-filter="{{ (row.provider ~ ' ' ~ (row.title or '') ~ ' ' ~ row.slug)|lower }}">
+          <td class="muted">{{ row.last_updated or '-' }}</td>
+          <td>{{ row.provider }}</td>
+          <td>{{ row.title or '-' }}</td>
+          <td><code>{{ row.slug }}</code></td>
+          <td class="num">{{ row.branch_count }}</td>
+          <td class="num">{{ row.tokens }}</td>
+          <td class="num">{{ row.words }}</td>
+          <td class="num">{{ row.attachments }}</td>
+          <td class="num">{{ '%.2f'|format((row.attachment_bytes or 0) / (1024*1024)) }}</td>
+          <td class="links">
+            {% if row.output_path %}<a href="{{ row.output_path }}">md</a>{% endif %}
+            {% if row.html_path %}<a href="{{ row.html_path }}">html</a>{% endif %}
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </main>
+  <script>
+    const q = document.getElementById('q');
+    const count = document.getElementById('count');
+    const rows = Array.from(document.querySelectorAll('#rows tr'));
+    function apply() {
+      const term = (q.value || '').trim().toLowerCase();
+      let visible = 0;
+      for (const tr of rows) {
+        const hay = tr.getAttribute('data-filter') || '';
+        const hit = !term || hay.includes(term);
+        tr.classList.toggle('hidden', !hit);
+        if (hit) visible += 1;
+      }
+      count.textContent = term ? `${visible} match(es)` : '';
+    }
+    q.addEventListener('input', apply);
+    window.addEventListener('keydown', (e) => {
+      if (e.key === '/' && document.activeElement !== q) {
+        e.preventDefault();
+        q.focus();
+      }
+    });
+  </script>
+</body>
+</html>
+"""
+
+
+def run_timeline_cli(args: SimpleNamespace, env: CommandEnv) -> None:
+    providers = _normalize_filter(getattr(args, "providers", None))
+    limit = getattr(args, "limit", 500)
+    limit = int(limit) if isinstance(limit, int) else 500
+    if limit <= 0:
+        limit = 500
+    json_mode = bool(getattr(args, "json", False))
+    out_path = getattr(args, "out", None)
+    theme = getattr(args, "theme", "light") or "light"
+    open_result = bool(getattr(args, "open", False))
+
+    rows = _load_rows(limit=limit, providers=providers)
+
+    if json_mode:
+        payload = stamp_payload(
+            {
+                "generated_at": datetime.now(timezone.utc).timestamp(),
+                "count": len(rows),
+                "rows": [row.__dict__ for row in rows],
+            }
+        )
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return
+
+    if out_path is None:
+        out_path = Path.cwd() / "timeline.html"
+    out = Path(out_path).expanduser()
+    out.parent.mkdir(parents=True, exist_ok=True)
+
+    html = Environment(loader=BaseLoader(), autoescape=True).from_string(_TEMPLATE).render(
+        rows=rows,
+        generated_at=datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        theme=theme,
+    )
+    out.write_text(html, encoding="utf-8")
+    if open_result:
+        open_in_editor(out)
+    else:
+        env.ui.console.print(f"[green]Wrote timeline → {out}[/green]")
+
+
+def _normalize_filter(raw: Optional[str]) -> Optional[set[str]]:
+    if not raw:
+        return None
+    values = {chunk.strip().lower() for chunk in raw.split(",") if chunk.strip()}
+    return values or None
+
+
+def _decode_meta(raw: Optional[str]) -> Dict[str, Any]:
+    if not raw:
+        return {}
+    try:
+        value = json.loads(raw)
+        return value if isinstance(value, dict) else {}
+    except Exception:
+        return {}
+
+
+def _load_rows(*, limit: int, providers: Optional[set[str]]) -> List[TimelineRow]:
+    with open_connection(None) as conn:
+        rows = conn.execute(
+            """
+            SELECT provider, conversation_id, slug, title, last_updated, metadata_json
+              FROM conversations
+            """
+        ).fetchall()
+        branch_rows = conn.execute(
+            """
+            SELECT provider, conversation_id, COUNT(*) AS n
+              FROM branches
+             GROUP BY provider, conversation_id
+            """
+        ).fetchall()
+
+    branch_counts: Dict[tuple[str, str], int] = {(r["provider"], r["conversation_id"]): int(r["n"] or 0) for r in branch_rows}
+    out: List[TimelineRow] = []
+    for row in rows:
+        provider = (row["provider"] or "").lower()
+        if providers and provider not in providers:
+            continue
+        conversation_id = row["conversation_id"]
+        slug = row["slug"]
+        title = row["title"]
+        last_updated = row["last_updated"]
+        meta = _decode_meta(row["metadata_json"])
+        tokens = int(meta.get("token_count", meta.get("tokens", 0)) or 0)
+        words = int(meta.get("word_count", meta.get("words", 0)) or 0)
+        attachments = int(meta.get("attachments", 0) or 0)
+        attachment_bytes = int(meta.get("attachment_bytes", meta.get("attachmentBytes", 0)) or 0)
+        output_path = meta.get("outputPath")
+        html_path = meta.get("htmlPath")
+        bc = branch_counts.get((row["provider"], conversation_id), 0)
+        out.append(
+            TimelineRow(
+                provider=provider,
+                conversation_id=conversation_id,
+                slug=slug,
+                title=title,
+                last_updated=last_updated,
+                tokens=tokens,
+                words=words,
+                attachments=attachments,
+                attachment_bytes=attachment_bytes,
+                branch_count=bc,
+                output_path=str(output_path) if isinstance(output_path, str) else None,
+                html_path=str(html_path) if isinstance(html_path, str) else None,
+            )
+        )
+    out.sort(key=lambda r: (r.last_updated or "", r.provider, r.slug), reverse=True)
+    return out[:limit]
+
+
+__all__ = ["run_timeline_cli"]
+

--- a/polylogue/cli/watch.py
+++ b/polylogue/cli/watch.py
@@ -183,12 +183,8 @@ def _run_watch_sessions(
                 console.print("[dim]Changes:[/dim]")
                 for path in relevant:
                     console.print(f"  {path}")
-            if now - last_run < debounce:
-                skipped_events.extend(relevant)
-                skipped_total += len(relevant)
-                continue
             elapsed = now - last_progress
-            if stall_seconds and elapsed > stall_seconds:
+            if stall_seconds and elapsed > stall_seconds and not stalled:
                 console.print(
                     f"[yellow]No sync progress for {stall_seconds}s; check watcher input or increase --stall-seconds."
                 )
@@ -198,9 +194,14 @@ def _run_watch_sessions(
 
                     os.environ["POLYLOGUE_EXIT_REASON"] = "partial"
                     raise SystemExit(2)
+            if now - last_run < debounce:
+                skipped_events.extend(relevant)
+                skipped_total += len(relevant)
+                continue
             sync_once(relevant)
             last_run = now
             last_progress = now
+            stalled = False
             if skipped_events:
                 total_skipped = len(skipped_events)
                 console.print(

--- a/polylogue/document_store.py
+++ b/polylogue/document_store.py
@@ -110,6 +110,9 @@ def _metadata_without_content_hash(metadata: Dict[str, Any]) -> Dict[str, Any]:
         polylogue.pop("sourceFile", None)
         polylogue.pop("sessionPath", None)
         polylogue.pop("sessionFile", None)
+        polylogue.pop("sourceRawHash", None)
+        polylogue.pop("renderConfigHash", None)
+        polylogue.pop("sourceBundleHash", None)
     return serialised
 
 

--- a/polylogue/document_store.py
+++ b/polylogue/document_store.py
@@ -85,11 +85,31 @@ def _metadata_without_content_hash(metadata: Dict[str, Any]) -> Dict[str, Any]:
         serialised = json.loads(json.dumps(metadata, default=str))
     except Exception:
         serialised = json.loads(json.dumps({}, default=str))
+    # Content hashes should be stable across machines/paths; strip path-like
+    # metadata that depends on where the archive lives.
+    for key in (
+        "outputPath",
+        "htmlPath",
+        "attachmentsDir",
+        "sourceExportPath",
+        "sourceFile",
+        "sessionPath",
+        "sessionFile",
+        "bundle_path",
+        "export_root",
+    ):
+        serialised.pop(key, None)
     polylogue = serialised.get("polylogue")
     if isinstance(polylogue, dict):
         polylogue.pop("contentHash", None)
         polylogue.pop("lastImported", None)
         polylogue.pop("dirty", None)
+        polylogue.pop("attachmentsDir", None)
+        polylogue.pop("htmlPath", None)
+        polylogue.pop("sourceExportPath", None)
+        polylogue.pop("sourceFile", None)
+        polylogue.pop("sessionPath", None)
+        polylogue.pop("sessionFile", None)
     return serialised
 
 

--- a/polylogue/html.py
+++ b/polylogue/html.py
@@ -461,6 +461,13 @@ def render_html(document: MarkdownDocument, options: HtmlRenderOptions) -> str:
     metadata_rows_raw["attachments"] = len(document.attachments)
     metadata_rows = {k: metadata_rows_raw[k] for k in sorted(metadata_rows_raw)}
     attachment_total_bytes = 0
+    attachments_sorted = sorted(
+        document.attachments,
+        key=lambda att: (
+            (att.name or "").lower(),
+            (att.local_path.as_posix() if getattr(att, "local_path", None) else (att.link or "")).lower(),
+        ),
+    )
     attachments = [
         {
             "name": att.name,
@@ -471,9 +478,9 @@ def render_html(document: MarkdownDocument, options: HtmlRenderOptions) -> str:
             "kind": "image" if _attachment_preview_src(att) else "file",
             "icon": _attachment_icon(att),
         }
-        for att in document.attachments
+        for att in attachments_sorted
     ]
-    for att in document.attachments:
+    for att in attachments_sorted:
         if getattr(att, "size_bytes", None):
             try:
                 attachment_total_bytes += int(att.size_bytes or 0)

--- a/polylogue/importers/chatgpt.py
+++ b/polylogue/importers/chatgpt.py
@@ -10,8 +10,15 @@ from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
 
 import ijson
 
+from ..db import get_raw_import_by_conversation, open_connection
 from ..render import AttachmentInfo
-from ..util import assign_conversation_slug, sanitize_filename
+from ..util import (
+    assign_conversation_slug,
+    current_utc_timestamp,
+    get_import_sync_state,
+    sanitize_filename,
+    set_import_sync_state,
+)
 from ..conversation import process_conversation
 from ..branching import MessageRecord
 from ..services.conversation_registrar import ConversationRegistrar, create_default_registrar
@@ -27,6 +34,26 @@ from .utils import (
     store_large_text,
 )
 from .raw_storage import compute_hash, store_raw_import, mark_parse_success, mark_parse_failed
+
+
+def _render_config_hash(
+    *,
+    collapse_threshold: int,
+    collapse_thresholds: Optional[Dict[str, int]],
+    html: bool,
+    html_theme: str,
+    attachment_ocr: bool,
+    sanitize_html: bool,
+) -> str:
+    payload = {
+        "collapse_threshold": int(collapse_threshold),
+        "collapse_thresholds": dict(collapse_thresholds) if collapse_thresholds else None,
+        "html": bool(html),
+        "html_theme": str(html_theme),
+        "attachment_ocr": bool(attachment_ocr),
+        "sanitize_html": bool(sanitize_html),
+    }
+    return compute_hash(json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8"))
 
 
 def _load_export(path: Path) -> Tuple[Path, Optional[TemporaryDirectory]]:
@@ -188,6 +215,14 @@ def import_chatgpt_export(
     registrar = registrar or create_default_registrar()
     base_path, tmp = _load_export(export_path)
     bundle_hash: Optional[str] = None
+    render_hash = _render_config_hash(
+        collapse_threshold=collapse_threshold,
+        collapse_thresholds=collapse_thresholds,
+        html=html,
+        html_theme=html_theme,
+        attachment_ocr=attachment_ocr,
+        sanitize_html=sanitize_html,
+    )
     try:
         convo_path = base_path / "conversations.json"
         if not convo_path.exists():
@@ -200,58 +235,111 @@ def import_chatgpt_export(
 
         output_dir.mkdir(parents=True, exist_ok=True)
         results: List[ImportResult] = []
-        with convo_path.open("rb") as fh:
-            try:
-                for conv in ijson.items(fh, "item"):
-                    if not isinstance(conv, dict):
-                        raise ValueError
-                    conv_id = conv.get("id") or conv.get("conversation_id")
-                    if selected_ids and conv_id not in selected_ids:
-                        continue
-                    # Store per-conversation raw snapshot (deduped by hash/version)
-                    raw_bytes = json.dumps(conv, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
-                    raw_hash = store_raw_import(
-                        data=raw_bytes,
-                        provider="chatgpt",
-                        conversation_id=conv_id or "conversation",
-                        source_path=export_path,
-                        metadata={
-                            "bundle_hash": bundle_hash,
-                            "bundle_path": str(export_path),
-                            "export_root": str(base_path),
-                        },
-                    )
-                    try:
-                        results.append(
-                            _render_chatgpt_conversation(
-                                conv,
-                                base_path,
-                                output_dir,
-                                collapse_threshold=collapse_threshold,
-                                collapse_thresholds=collapse_thresholds,
-                                html=html,
-                                html_theme=html_theme,
-                                force=force,
-                                allow_dirty=allow_dirty,
-                                registrar=registrar,
-                                attachment_ocr=attachment_ocr,
-                                sanitize_html=sanitize_html,
-                                meta=meta,
-                            )
-                        )
-                        if raw_hash:
-                            mark_parse_success(raw_hash)
-                    except Exception:
-                        if raw_hash:
-                            import traceback
+        db_path = registrar.database.resolve_path()
+        with open_connection(db_path) as conn:
+            with convo_path.open("rb") as fh:
+                try:
+                    for conv in ijson.items(fh, "item"):
+                        if not isinstance(conv, dict):
+                            raise ValueError
+                        conv_id = conv.get("id") or conv.get("conversation_id")
+                        if selected_ids and conv_id not in selected_ids:
+                            continue
+                        title = conv.get("title") or "chatgpt-conversation"
+                        conv_id_str = conv_id or "conversation"
+                        slug = assign_conversation_slug("chatgpt", conv_id_str, title, id_hint=(conv_id_str or "")[:8])
+                        conversation_dir = output_dir / slug
+                        markdown_path = conversation_dir / "conversation.md"
+                        html_path = conversation_dir / "conversation.html" if html else None
+                        attachments_dir = conversation_dir / "attachments"
+                        # Store per-conversation raw snapshot (deduped by hash/version)
+                        raw_bytes = json.dumps(conv, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+                        raw_hash = compute_hash(raw_bytes)
 
-                            mark_parse_failed(raw_hash, traceback.format_exc())
-                        raise
-            except Exception as exc:
-                raise ValueError(
-                    "Unexpected ChatGPT export format: conversations.json must contain a list. "
-                    "Make sure you're using a valid ChatGPT export from the official export feature."
-                ) from exc
+                        state_entry = registrar.get_state("chatgpt", conv_id_str)
+                        raw_row = get_raw_import_by_conversation(conn, "chatgpt", conv_id_str)
+                        raw_ok = False
+                        if raw_row is not None:
+                            try:
+                                raw_ok = raw_row["hash"] == raw_hash and (raw_row["parse_status"] or "") == "success"
+                            except Exception:
+                                raw_ok = False
+                        sync_state = get_import_sync_state("chatgpt", conv_id_str) or {}
+                        sync_ok = sync_state.get("rawHash") == raw_hash and sync_state.get("renderConfigHash") == render_hash
+                        if (
+                            not force
+                            and raw_ok
+                            and isinstance(state_entry, dict)
+                            and not bool(state_entry.get("dirty"))
+                            and sync_ok
+                            and markdown_path.exists()
+                            and (not html_path or html_path.exists())
+                        ):
+                            results.append(
+                                ImportResult(
+                                    markdown_path=markdown_path,
+                                    html_path=html_path,
+                                    attachments_dir=attachments_dir if attachments_dir.exists() else None,
+                                    document=None,
+                                    slug=slug,
+                                    skipped=True,
+                                    skip_reason="raw+render config unchanged",
+                                )
+                            )
+                            continue
+
+                        raw_hash = store_raw_import(
+                            data=raw_bytes,
+                            provider="chatgpt",
+                            conversation_id=conv_id_str,
+                            source_path=export_path,
+                            metadata={
+                                "bundle_hash": bundle_hash,
+                                "bundle_path": str(export_path),
+                                "export_root": str(base_path),
+                            },
+                        )
+                        try:
+                            rendered = _render_chatgpt_conversation(
+                                    conv,
+                                    base_path,
+                                    output_dir,
+                                    collapse_threshold=collapse_threshold,
+                                    collapse_thresholds=collapse_thresholds,
+                                    html=html,
+                                    html_theme=html_theme,
+                                    force=force,
+                                    allow_dirty=allow_dirty,
+                                    registrar=registrar,
+                                    attachment_ocr=attachment_ocr,
+                                    sanitize_html=sanitize_html,
+                                    meta=meta,
+                                )
+                            results.append(rendered)
+                            if raw_hash:
+                                mark_parse_success(raw_hash)
+                            if conv_id_str:
+                                set_import_sync_state(
+                                    "chatgpt",
+                                    conv_id_str,
+                                    {
+                                        "rawHash": raw_hash,
+                                        "renderConfigHash": render_hash,
+                                        "bundleHash": bundle_hash,
+                                        "lastImported": current_utc_timestamp(),
+                                    },
+                                )
+                        except Exception:
+                            if raw_hash:
+                                import traceback
+
+                                mark_parse_failed(raw_hash, traceback.format_exc())
+                            raise
+                except Exception as exc:
+                    raise ValueError(
+                        "Unexpected ChatGPT export format: conversations.json must contain a list. "
+                        "Make sure you're using a valid ChatGPT export from the official export feature."
+                    ) from exc
 
         return results
     finally:

--- a/polylogue/pipeline.py
+++ b/polylogue/pipeline.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union, cast
 
 from .drive_client import DriveClient
+from .drive import snapshot_drive_metrics
 from .render import (
     AttachmentInfo,
     MarkdownDocument,
@@ -152,7 +153,11 @@ def collect_attachments(
                             rel = str(local_path.relative_to(collector.markdown_root))
                         except Exception:
                             rel = str(local_path)
-                        failures.append({"id": att_id, "filename": fname, "path": rel})
+                        err = snapshot_drive_metrics(reset=False).get("lastError")
+                        failure = {"id": att_id, "filename": fname, "path": rel}
+                        if isinstance(err, str) and err.strip():
+                            failure["error"] = err.strip()
+                        failures.append(failure)
                         collector.add_local(idx, fname, att_id, local_path)
                         continue
                 drive.touch_mtime(local_path, meta_att.get("modifiedTime"))

--- a/polylogue/util.py
+++ b/polylogue/util.py
@@ -100,6 +100,19 @@ def parse_rfc3339_to_epoch(ts: Optional[str]) -> Optional[float]:
         return None
 
 
+def format_duration(seconds: Optional[float]) -> str:
+    if seconds is None:
+        return "?"
+    seconds = max(0.0, float(seconds))
+    mins, sec = divmod(int(seconds + 0.5), 60)
+    hrs, mins = divmod(mins, 60)
+    if hrs:
+        return f"{hrs}h{mins:02d}m{sec:02d}s"
+    if mins:
+        return f"{mins}m{sec:02d}s"
+    return f"{sec}s"
+
+
 def parse_input_time_to_epoch(s: Optional[Union[str, float, int, datetime.date, datetime.datetime]]) -> Optional[float]:
     if s is None:
         return None

--- a/tests/golden/chatgpt-basic.md
+++ b/tests/golden/chatgpt-basic.md
@@ -10,7 +10,7 @@ attachmentPolicy:
 attachment_bytes: 0
 attachmentsDir: null
 collapseThreshold: 10
-contentHash: 0e389ee88a35ed7ab13edee24abd8e7867cb0046e183a0f1e39139007d30f1c9
+contentHash: ba13482a4969c45bff3bf35e90070ba2422b9676f1d7f6bbdf13ea229408b59f
 currentBranch: branch-000
 dirty: false
 html: false
@@ -19,7 +19,7 @@ lastImported: '2000-01-01T00:00:00Z'
 lastUpdated: 4
 outputPath: <path>
 polylogue:
-  contentHash: 0e389ee88a35ed7ab13edee24abd8e7867cb0046e183a0f1e39139007d30f1c9
+  contentHash: ba13482a4969c45bff3bf35e90070ba2422b9676f1d7f6bbdf13ea229408b59f
   conversationId: golden-chatgpt-1
   lastUpdated: '4'
   provider: chatgpt

--- a/tests/golden/chatgpt-tool.md
+++ b/tests/golden/chatgpt-tool.md
@@ -1,0 +1,39 @@
+---
+attachmentPolicy:
+  charThreshold: 4000
+  extractedCount: 2
+  lineThreshold: 40
+  previewLines: 5
+  routing:
+    routed: 0
+    skipped: 4
+attachment_bytes: 296
+attachmentsDir: <path>
+collapseThreshold: 10
+contentHash: 8973bd2c8438ac0e240f20676ba42406f38bb7880298f3e8e4e70b0f9c1f2e55
+currentBranch: branch-000
+dirty: false
+html: false
+htmlPath: null
+lastImported: '2000-01-01T00:00:00Z'
+lastUpdated: 1700000004
+outputPath: <path>
+polylogue:
+  contentHash: 8973bd2c8438ac0e240f20676ba42406f38bb7880298f3e8e4e70b0f9c1f2e55
+  conversationId: golden-chatgpt-tool-1
+  lastUpdated: '1700000004'
+  provider: chatgpt
+  slug: golden-chatgpt-tool-attachments
+  title: Golden ChatGPT Tool + Attachments
+slug: golden-chatgpt-tool-attachments
+sourceExportPath: tests/fixtures/golden/chatgpt_tool
+title: Golden ChatGPT Tool + Attachments
+token_count: 28
+tokens: 28
+word_count: 28
+words: 28
+---
+
+## Model
+
+Done.

--- a/tests/golden/claude-basic.md
+++ b/tests/golden/claude-basic.md
@@ -10,7 +10,7 @@ attachmentPolicy:
 attachment_bytes: 0
 attachmentsDir: null
 collapseThreshold: 10
-contentHash: 03bee25aeb24d3008c8f09f69d67e6c740a5d26efbd1faf2a592cd29221255fc
+contentHash: 1debf6fbfc81e761794797e3cb74a40e31f5066c76e1316459bacb6b96d1320c
 currentBranch: branch-000
 dirty: false
 html: false
@@ -19,7 +19,7 @@ lastImported: '2000-01-01T00:00:00Z'
 lastUpdated: null
 outputPath: <path>
 polylogue:
-  contentHash: 03bee25aeb24d3008c8f09f69d67e6c740a5d26efbd1faf2a592cd29221255fc
+  contentHash: 1debf6fbfc81e761794797e3cb74a40e31f5066c76e1316459bacb6b96d1320c
   conversationId: golden-claude-1
   lastUpdated: null
   provider: claude.ai

--- a/tests/golden/claude-code-basic.md
+++ b/tests/golden/claude-code-basic.md
@@ -10,7 +10,7 @@ attachmentPolicy:
 attachment_bytes: 0
 attachmentsDir: null
 collapseThreshold: 10
-contentHash: c958013174df7a51a0e6a91df74991861f8f5742ca279b32661e54381235ba63
+contentHash: 1b6a5882d2e967ac2738d3bdfbfe4d4cba0aaa884e4956ba6eb1854e77f1e73c
 currentBranch: branch-000
 dirty: false
 html: false
@@ -19,7 +19,7 @@ lastImported: '2000-01-01T00:00:00Z'
 lastUpdated: null
 outputPath: <path>
 polylogue:
-  contentHash: c958013174df7a51a0e6a91df74991861f8f5742ca279b32661e54381235ba63
+  contentHash: 1b6a5882d2e967ac2738d3bdfbfe4d4cba0aaa884e4956ba6eb1854e77f1e73c
   conversationId: tests/fixtures/golden/claude_code/claude-code-golden.jsonl
   lastUpdated: null
   provider: claude-code

--- a/tests/golden/claude-tool.md
+++ b/tests/golden/claude-tool.md
@@ -1,0 +1,56 @@
+---
+attachmentPolicy:
+  charThreshold: 4000
+  extractedCount: 2
+  lineThreshold: 40
+  previewLines: 5
+  routing:
+    routed: 0
+    skipped: 2
+attachment_bytes: 295
+attachmentsDir: <path>
+collapseThreshold: 10
+contentHash: 419d733be8531e4ca97dfc8a943a0f7c70af11804f4d0cafecb5c311d502ec6f
+currentBranch: branch-000
+dirty: false
+html: false
+htmlPath: null
+lastImported: '2000-01-01T00:00:00Z'
+lastUpdated: '2024-01-01T00:00:03Z'
+outputPath: <path>
+polylogue:
+  contentHash: 419d733be8531e4ca97dfc8a943a0f7c70af11804f4d0cafecb5c311d502ec6f
+  conversationId: golden-claude-tool-1
+  lastUpdated: '2024-01-01T00:00:03Z'
+  provider: claude.ai
+  slug: golden-claude-tool-attachments
+  title: Golden Claude Tool + Attachments
+slug: golden-claude-tool-attachments
+sourceExportPath: tests/fixtures/golden/claude_tool
+sourceModel: claude-3.5-sonnet
+title: Golden Claude Tool + Attachments
+token_count: 28
+tokens: 28
+word_count: 28
+words: 28
+---
+
+## User
+
+Hello. Please run a command and show the result. Also see attachments.
+
+## Model
+
+Tool call `bash`
+```json
+{
+  "cmd": "echo hi"
+}
+```
+
+Tool result
+````
+hi
+````
+
+Done.

--- a/tests/golden/codex-basic.md
+++ b/tests/golden/codex-basic.md
@@ -10,7 +10,7 @@ attachmentPolicy:
 attachment_bytes: 0
 attachmentsDir: null
 collapseThreshold: 10
-contentHash: 866414d75a1892d89263f4c3cce6b6be71f71ce2b7407b9ffa6d1114726d95c1
+contentHash: 23449ecb7e9d11274b853f9afe072fb54be5c725dd245bce7ddfe6e6863d7b68
 currentBranch: branch-000
 dirty: false
 html: false
@@ -19,7 +19,7 @@ lastImported: '2000-01-01T00:00:00Z'
 lastUpdated: null
 outputPath: <path>
 polylogue:
-  contentHash: 866414d75a1892d89263f4c3cce6b6be71f71ce2b7407b9ffa6d1114726d95c1
+  contentHash: 23449ecb7e9d11274b853f9afe072fb54be5c725dd245bce7ddfe6e6863d7b68
   conversationId: tests/fixtures/golden/codex/codex-golden.jsonl
   lastUpdated: null
   provider: codex

--- a/tests/golden_html/chatgpt-basic.html
+++ b/tests/golden_html/chatgpt-basic.html
@@ -44,6 +44,7 @@
         border-radius: 999px;
         font-size: 0.9rem;
       }
+      .muted { opacity: 0.8; font-size: 0.85rem; }
       .toolbar { display: flex; gap: 0.75rem; align-items: center; }
       .search-input {
         flex: 1;
@@ -53,12 +54,25 @@
         background: color-mix(in srgb, var(--bg) 96%, #00000008);
         color: var(--fg);
       }
+      .sidebar-input {
+        width: 100%;
+        padding: 0.4rem 0.6rem;
+        border-radius: 10px;
+        border: 1px solid var(--border);
+        background: color-mix(in srgb, var(--bg) 96%, #00000008);
+        color: var(--fg);
+        margin: 0.4rem 0 0.75rem;
+      }
       .layout { display: grid; grid-template-columns: 260px 1fr; gap: 1.25rem; align-items: start; }
       .card {
         border: 1px solid var(--border);
         border-radius: 12px;
         padding: 1rem;
         background: color-mix(in srgb, var(--bg) 96%, #00000006);
+      }
+      @media (max-width: 860px) {
+        header { flex-wrap: wrap; }
+        .layout { grid-template-columns: 1fr; }
       }
       .metadata table {
         width: 100%;
@@ -74,6 +88,7 @@
       .toc ul { list-style: none; padding-left: 0; margin: 0; }
       .toc li { margin: 0.2rem 0; }
       .toc a { text-decoration: none; }
+      .toc a:hover { text-decoration: underline; }
       .attachments { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 0.75rem; }
       .attachment {
         border: 1px solid var(--border);
@@ -81,6 +96,9 @@
         padding: 0.6rem 0.75rem;
         background: color-mix(in srgb, var(--bg) 94%, #00000008);
       }
+      .attachment .att-meta { display: flex; gap: 0.5rem; align-items: baseline; flex-wrap: wrap; }
+      .attachment .att-name { font-weight: 600; }
+      .attachment .att-sub { font-size: 0.85rem; opacity: 0.8; }
       .attachment img {
         width: 100%;
         max-height: 160px;
@@ -88,6 +106,51 @@
         border-radius: 8px;
         border: 1px solid var(--border);
         margin-top: 0.5rem;
+      }
+      .lightbox {
+        position: fixed;
+        inset: 0;
+        display: none;
+        align-items: center;
+        justify-content: center;
+        background: color-mix(in srgb, #000 75%, transparent);
+        z-index: 30;
+        padding: 1.25rem;
+      }
+      .lightbox[open] { display: flex; }
+      .lightbox-card {
+        max-width: 1100px;
+        width: 100%;
+        max-height: 92vh;
+        border-radius: 14px;
+        border: 1px solid var(--border);
+        background: var(--bg);
+        overflow: hidden;
+        display: grid;
+        grid-template-rows: auto 1fr;
+      }
+      .lightbox-header {
+        display: flex;
+        gap: 0.75rem;
+        align-items: center;
+        justify-content: space-between;
+        padding: 0.65rem 0.85rem;
+        border-bottom: 1px solid var(--border);
+      }
+      .lightbox-header a { text-decoration: none; }
+      .lightbox-body {
+        padding: 0.75rem;
+        overflow: auto;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+      .lightbox-body img {
+        max-width: 100%;
+        max-height: 80vh;
+        object-fit: contain;
+        border-radius: 10px;
+        border: 1px solid var(--border);
       }
       .content blockquote {
         border-left: 4px solid #3b82f6;
@@ -178,7 +241,7 @@
                 
                 <tr>
                   <th>contentHash</th>
-                  <td>0e389ee88a35ed7ab13edee24abd8e7867cb0046e183a0f1e39139007d30f1c9</td>
+                  <td>ba13482a4969c45bff3bf35e90070ba2422b9676f1d7f6bbdf13ea229408b59f</td>
                 </tr>
                 
                 <tr>
@@ -218,7 +281,7 @@
                 
                 <tr>
                   <th>polylogue</th>
-                  <td>{&#34;contentHash&#34;: &#34;0e389ee88a35ed7ab13edee24abd8e7867cb0046e183a0f1e39139007d30f1c9&#34;, &#34;conversationId&#34;: &#34;golden-chatgpt-1&#34;, &#34;lastUpdated&#34;: &#34;4&#34;, &#34;provider&#34;: &#34;chatgpt&#34;, &#34;slug&#34;: &#34;golden-chatgpt&#34;, &#34;title&#34;: &#34;Golden ChatGPT&#34;}</td>
+                  <td>{&#34;contentHash&#34;: &#34;ba13482a4969c45bff3bf35e90070ba2422b9676f1d7f6bbdf13ea229408b59f&#34;, &#34;conversationId&#34;: &#34;golden-chatgpt-1&#34;, &#34;lastUpdated&#34;: &#34;4&#34;, &#34;provider&#34;: &#34;chatgpt&#34;, &#34;slug&#34;: &#34;golden-chatgpt&#34;, &#34;title&#34;: &#34;Golden ChatGPT&#34;}</td>
                 </tr>
                 
                 <tr>
@@ -271,11 +334,31 @@
         </div>
       </div>
     </main>
+    <div class="lightbox" id="lightbox" role="dialog" aria-modal="true" aria-label="Attachment preview">
+      <div class="lightbox-card">
+        <div class="lightbox-header">
+          <div>
+            <strong id="lightbox-title"></strong>
+            <span class="muted" id="lightbox-hint"></span>
+          </div>
+          <div class="toolbar">
+            <a id="lightbox-open" href="#" target="_blank" class="pill">open</a>
+            <a href="#" id="lightbox-close" class="pill">close</a>
+          </div>
+        </div>
+        <div class="lightbox-body">
+          <img id="lightbox-img" alt="" />
+        </div>
+      </div>
+    </div>
     <script>
       const tocEl = document.getElementById('toc');
       const headings = document.querySelectorAll('#content h1, #content h2, #content h3');
       headings.forEach(h => {
         if (!h.id) return;
+        const clone = h.cloneNode(true);
+        clone.querySelectorAll('.anchor-btn').forEach(n => n.remove());
+        const headingText = (clone.textContent || '').trim();
         const anchor = document.createElement('a');
         anchor.href = `#${h.id}`;
         anchor.textContent = '🔗';
@@ -291,7 +374,7 @@
         const li = document.createElement('li');
         const a = document.createElement('a');
         a.href = `#${h.id}`;
-        a.textContent = h.textContent;
+        a.textContent = headingText || h.id;
         li.appendChild(a);
         tocEl.appendChild(li);
       });
@@ -336,6 +419,51 @@
         });
         anchor.insertAdjacentElement('afterend', btn);
       });
+
+      // Attachments: filter + lightbox previews.
+      const attFilter = document.getElementById('att-filter');
+      const attCards = Array.from(document.querySelectorAll('.attachment'));
+      function applyAttFilter(term) {
+        const q = (term || '').trim().toLowerCase();
+        for (const card of attCards) {
+          const hay = card.getAttribute('data-att') || '';
+          card.classList.toggle('hidden', q && !hay.includes(q));
+        }
+      }
+      if (attFilter) attFilter.addEventListener('input', (e) => applyAttFilter(e.target.value));
+
+      const lightbox = document.getElementById('lightbox');
+      const lightboxImg = document.getElementById('lightbox-img');
+      const lightboxTitle = document.getElementById('lightbox-title');
+      const lightboxOpen = document.getElementById('lightbox-open');
+      const lightboxHint = document.getElementById('lightbox-hint');
+      const lightboxClose = document.getElementById('lightbox-close');
+
+      function closeLightbox() {
+        if (!lightbox) return;
+        lightbox.removeAttribute('open');
+        if (lightboxImg) lightboxImg.src = '';
+      }
+      function openLightbox(src, name) {
+        if (!lightbox) return;
+        lightbox.setAttribute('open', 'true');
+        if (lightboxImg) lightboxImg.src = src;
+        if (lightboxImg) lightboxImg.alt = name || '';
+        if (lightboxTitle) lightboxTitle.textContent = name || '';
+        if (lightboxHint) lightboxHint.textContent = ' (Esc to close)';
+        if (lightboxOpen) lightboxOpen.href = src;
+      }
+      document.querySelectorAll('.att-preview').forEach(img => {
+        img.addEventListener('click', (e) => {
+          e.preventDefault();
+          const src = img.getAttribute('data-full') || img.getAttribute('src');
+          const name = img.getAttribute('data-name') || '';
+          openLightbox(src, name);
+        });
+      });
+      if (lightboxClose) lightboxClose.addEventListener('click', (e) => { e.preventDefault(); closeLightbox(); });
+      if (lightbox) lightbox.addEventListener('click', (e) => { if (e.target === lightbox) closeLightbox(); });
+      window.addEventListener('keydown', (e) => { if (e.key === 'Escape') closeLightbox(); });
     </script>
   </body>
 </html>

--- a/tests/golden_html/chatgpt-basic.html
+++ b/tests/golden_html/chatgpt-basic.html
@@ -81,6 +81,14 @@
         padding: 0.6rem 0.75rem;
         background: color-mix(in srgb, var(--bg) 94%, #00000008);
       }
+      .attachment img {
+        width: 100%;
+        max-height: 160px;
+        object-fit: cover;
+        border-radius: 8px;
+        border: 1px solid var(--border);
+        margin-top: 0.5rem;
+      }
       .content blockquote {
         border-left: 4px solid #3b82f6;
         padding-left: 1rem;

--- a/tests/golden_html/chatgpt-tool.html
+++ b/tests/golden_html/chatgpt-tool.html
@@ -1,57 +1,15 @@
-from __future__ import annotations
 
-from dataclasses import dataclass
-from pathlib import Path
-from typing import Dict
-import re
-import math
-import json
-import urllib.parse
-
-from jinja2 import Environment, BaseLoader
-from markupsafe import escape
-from markdown_it import MarkdownIt
-
-from .render import AttachmentInfo, MarkdownDocument
-
-
-def _human_size(num: float | int | None) -> str | None:
-    if num is None or num <= 0:
-        return None
-    units = ["B", "KB", "MB", "GB", "TB"]
-    idx = min(int(math.log(num, 1024)) if num > 0 else 0, len(units) - 1)
-    value = num / (1024 ** idx)
-    return f"{value:.2f} {units[idx]}"
-
-
-THEMES: Dict[str, Dict[str, str]] = {
-    "light": {
-        "background": "#ffffff",
-        "foreground": "#222222",
-        "callout_border": "#3b82f6",
-        "link": "#2563eb",
-    },
-    "dark": {
-        "background": "#111827",
-        "foreground": "#e5e7eb",
-        "callout_border": "#60a5fa",
-        "link": "#93c5fd",
-    },
-}
-
-
-HTML_TEMPLATE = """
 <!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>{{ title }}</title>
+    <title>Golden ChatGPT Tool + Attachments</title>
     <style>
       :root {
-        --bg: {{ theme.background }};
-        --fg: {{ theme.foreground }};
-        --accent: {{ theme.link }};
-        --border: {{ theme.callout_border }}44;
+        --bg: #ffffff;
+        --fg: #222222;
+        --accent: #2563eb;
+        --border: #3b82f644;
       }
       * { box-sizing: border-box; }
       body {
@@ -195,16 +153,16 @@ HTML_TEMPLATE = """
         border: 1px solid var(--border);
       }
       .content blockquote {
-        border-left: 4px solid {{ theme.callout_border }};
+        border-left: 4px solid #3b82f6;
         padding-left: 1rem;
         margin-left: 0;
-        background: {{ theme.callout_border }}11;
+        background: #3b82f611;
       }
       details.callout {
         margin: 1rem 0;
-        border-left: 4px solid {{ theme.callout_border }};
+        border-left: 4px solid #3b82f6;
         padding-left: 1rem;
-        background: {{ theme.callout_border }}11;
+        background: #3b82f611;
       }
       details.callout summary {
         cursor: pointer;
@@ -221,7 +179,7 @@ HTML_TEMPLATE = """
       }
       details.callout[open] summary::before { transform: rotate(90deg); }
       pre {
-        background: {{ theme.foreground }}11;
+        background: #22222211;
         padding: 0.75rem;
         overflow-x: auto;
       }
@@ -240,7 +198,7 @@ HTML_TEMPLATE = """
   </head>
   <body>
     <header>
-      <div class="pill">{{ title }}</div>
+      <div class="pill">Golden ChatGPT Tool + Attachments</div>
       <input class="search-input" id="client-search" type="search" placeholder="Filter text (press / to focus)" />
       <div class="toolbar"><span class="pill" id="match-count"></span></div>
     </header>
@@ -249,40 +207,124 @@ HTML_TEMPLATE = """
         <div class="card toc">
           <h3>Contents</h3>
           <ul id="toc"></ul>
-          {% if attachments %}
-          <h4>Attachments</h4>
-          <input class="sidebar-input" id="att-filter" type="search" placeholder="Filter attachments" />
-          <div class="attachments">
-            {% for att in attachments %}
-              <div class="attachment" data-att="{{ (att.name ~ ' ' ~ (att.kind or '') ~ ' ' ~ (att.ext or ''))|lower }}">
-                <div class="att-meta">
-                  <span class="att-name">{{ att.icon }} <a href="{{ att.link }}" target="_blank">{{ att.name }}</a></span>
-                  {% if att.size %}<span class="att-sub">{{ att.size }}</span>{% endif %}
-                </div>
-                {% if att.preview_src %}
-                  <a href="{{ att.link }}" target="_blank">
-                    <img class="att-preview" data-full="{{ att.link }}" data-name="{{ att.name }}" src="{{ att.preview_src }}" alt="{{ att.name }}" />
-                  </a>
-                {% endif %}
-              </div>
-            {% endfor %}
-          </div>
-          {% endif %}
+          
         </div>
         <div>
           <div class="card metadata">
             <table>
               <tbody>
-                {% for key, value in metadata.items() %}
+                
                 <tr>
-                  <th>{{ key }}</th>
-                  <td>{{ value }}</td>
+                  <th>attachmentPolicy</th>
+                  <td>{&#34;charThreshold&#34;: 4000, &#34;extractedCount&#34;: 2, &#34;lineThreshold&#34;: 40, &#34;previewLines&#34;: 5, &#34;routing&#34;: {&#34;routed&#34;: 0, &#34;skipped&#34;: 4}}</td>
                 </tr>
-                {% endfor %}
+                
+                <tr>
+                  <th>attachment_bytes</th>
+                  <td>296</td>
+                </tr>
+                
+                <tr>
+                  <th>attachments</th>
+                  <td>0</td>
+                </tr>
+                
+                <tr>
+                  <th>attachmentsDir</th>
+                  <td>&lt;path&gt;</td>
+                </tr>
+                
+                <tr>
+                  <th>collapseThreshold</th>
+                  <td>10</td>
+                </tr>
+                
+                <tr>
+                  <th>contentHash</th>
+                  <td>8973bd2c8438ac0e240f20676ba42406f38bb7880298f3e8e4e70b0f9c1f2e55</td>
+                </tr>
+                
+                <tr>
+                  <th>currentBranch</th>
+                  <td>branch-000</td>
+                </tr>
+                
+                <tr>
+                  <th>dirty</th>
+                  <td>False</td>
+                </tr>
+                
+                <tr>
+                  <th>html</th>
+                  <td>False</td>
+                </tr>
+                
+                <tr>
+                  <th>htmlPath</th>
+                  <td>None</td>
+                </tr>
+                
+                <tr>
+                  <th>lastImported</th>
+                  <td>2000-01-01T00:00:00Z</td>
+                </tr>
+                
+                <tr>
+                  <th>lastUpdated</th>
+                  <td>1700000004</td>
+                </tr>
+                
+                <tr>
+                  <th>outputPath</th>
+                  <td>&lt;path&gt;</td>
+                </tr>
+                
+                <tr>
+                  <th>polylogue</th>
+                  <td>{&#34;contentHash&#34;: &#34;8973bd2c8438ac0e240f20676ba42406f38bb7880298f3e8e4e70b0f9c1f2e55&#34;, &#34;conversationId&#34;: &#34;golden-chatgpt-tool-1&#34;, &#34;lastUpdated&#34;: &#34;1700000004&#34;, &#34;provider&#34;: &#34;chatgpt&#34;, &#34;slug&#34;: &#34;golden-chatgpt-tool-attachments&#34;, &#34;title&#34;: &#34;Golden ChatGPT Tool + Attachments&#34;}</td>
+                </tr>
+                
+                <tr>
+                  <th>slug</th>
+                  <td>golden-chatgpt-tool-attachments</td>
+                </tr>
+                
+                <tr>
+                  <th>sourceExportPath</th>
+                  <td>tests/fixtures/golden/chatgpt_tool</td>
+                </tr>
+                
+                <tr>
+                  <th>title</th>
+                  <td>Golden ChatGPT Tool + Attachments</td>
+                </tr>
+                
+                <tr>
+                  <th>token_count</th>
+                  <td>28</td>
+                </tr>
+                
+                <tr>
+                  <th>tokens</th>
+                  <td>28</td>
+                </tr>
+                
+                <tr>
+                  <th>word_count</th>
+                  <td>28</td>
+                </tr>
+                
+                <tr>
+                  <th>words</th>
+                  <td>28</td>
+                </tr>
+                
               </tbody>
             </table>
           </div>
-          <div class="content" id="content">{{ body_html | safe }}</div>
+          <div class="content" id="content"><h2 id="model">Model</h2>
+<p>Done.</p>
+</div>
         </div>
       </div>
     </main>
@@ -419,169 +461,3 @@ HTML_TEMPLATE = """
     </script>
   </body>
 </html>
-"""
-
-
-@dataclass
-class HtmlRenderOptions:
-    theme: str = "light"
-
-
-def _anchorize(text: str) -> str:
-    """Create a URL-safe anchor id from text."""
-    safe = re.sub(r"<[^>]+>", "", text or "")
-    safe = re.sub(r"[^a-zA-Z0-9\\-_]+", "-", safe).strip("-").lower()
-    return safe or "section"
-
-
-_MD_RENDERER = MarkdownIt("commonmark", {"html": True}).enable("table").enable("strikethrough")
-_JINJA_ENV = Environment(loader=BaseLoader(), autoescape=True) if Environment is not None else None
-_JINJA_TEMPLATE = _JINJA_ENV.from_string(HTML_TEMPLATE) if _JINJA_ENV is not None else None
-
-
-def render_html(document: MarkdownDocument, options: HtmlRenderOptions) -> str:
-    theme = THEMES.get(options.theme, THEMES["light"])
-    body_html = _MD_RENDERER.render(document.body)
-    # Inject anchors for headings to support deep links from search/open.
-    body_html = re.sub(
-        r"<h([1-6])>(.*?)</h\1>",
-        lambda m: f'<h{m.group(1)} id="{_anchorize(m.group(2))}">{m.group(2)}</h{m.group(1)}>',
-        body_html,
-    )
-    body_html = _transform_callouts(body_html)
-    def _fmt(value: object) -> object:
-        if isinstance(value, (dict, list)):
-            try:
-                return json.dumps(value, sort_keys=True, ensure_ascii=False)
-            except Exception:
-                return str(value)
-        return value
-
-    metadata_rows_raw = {k: _fmt(v) for k, v in document.metadata.items() if k != "attachments"}
-    metadata_rows_raw["attachments"] = len(document.attachments)
-    metadata_rows = {k: metadata_rows_raw[k] for k in sorted(metadata_rows_raw)}
-    attachment_total_bytes = 0
-    attachments = [
-        {
-            "name": att.name,
-            "link": urllib.parse.quote(att.local_path.as_posix()) if getattr(att, "local_path", None) else att.link,
-            "size": _human_size(att.size_bytes) if hasattr(att, "size_bytes") else None,
-            "preview_src": _attachment_preview_src(att),
-            "ext": getattr(att.local_path, "suffix", "") if getattr(att, "local_path", None) else Path(att.link).suffix,
-            "kind": "image" if _attachment_preview_src(att) else "file",
-            "icon": _attachment_icon(att),
-        }
-        for att in document.attachments
-    ]
-    for att in document.attachments:
-        if getattr(att, "size_bytes", None):
-            try:
-                attachment_total_bytes += int(att.size_bytes or 0)
-            except Exception:
-                pass
-    if attachment_total_bytes:
-        metadata_rows["attachmentBytes"] = int(attachment_total_bytes)
-
-    if _JINJA_TEMPLATE is None:
-        rows = "".join(
-            f"<tr><th>{escape(str(k))}</th><td>{escape(str(v))}</td></tr>" for k, v in metadata_rows.items()
-        )
-        return f"""
-<!DOCTYPE html>
-<html lang=\"en\">
-  <head>
-    <meta charset=\"utf-8\" />
-    <title>{document.metadata.get('title', 'Conversation')}</title>
-    <style>
-      body {{ background: {theme['background']}; color: {theme['foreground']}; font-family: system-ui, sans-serif; margin: 2rem auto; max-width: 820px; line-height: 1.6; }}
-      a {{ color: {theme['link']}; }}
-      table {{ width: 100%; border-collapse: collapse; margin-bottom: 1.5rem; }}
-      th, td {{ border: 1px solid {theme['callout_border']}44; padding: 0.4rem 0.6rem; text-align: left; font-size: 0.9rem; }}
-      blockquote {{ border-left: 4px solid {theme['callout_border']}; padding-left: 1rem; margin-left: 0; background: {theme['callout_border']}11; }}
-      pre {{ background: {theme['foreground']}11; padding: 0.75rem; overflow-x: auto; }}
-      code {{ font-family: "JetBrains Mono", monospace; }}
-    </style>
-  </head>
-  <body>
-    <h1>{escape(str(document.metadata.get('title', 'Conversation')))}</h1>
-    <div class=\"metadata\">
-      <table><tbody>{rows}</tbody></table>
-    </div>
-    <div class=\"content\">{body_html}</div>
-  </body>
-</html>
-"""
-
-    return _JINJA_TEMPLATE.render(
-        title=document.metadata.get("title", "Conversation"),
-        metadata=metadata_rows,
-        body_html=body_html,
-        theme=theme,
-        attachments=attachments,
-    )
-
-
-def write_html(document: MarkdownDocument, path: Path, theme: str) -> None:
-    options = HtmlRenderOptions(theme=theme)
-    html_text = render_html(document, options)
-    path.write_text(html_text, encoding="utf-8")
-
-
-def _transform_callouts(html: str) -> str:
-    import re
-
-    pattern = re.compile(
-        r"<blockquote>\s*<p>\[!([A-Z]+)\]([+-])\s+(.*?)</p>(.*?)</blockquote>",
-        flags=re.DOTALL,
-    )
-
-    def repl(match: re.Match[str]) -> str:
-        kind, fold, header, body = match.groups()
-        open_attr = " open" if fold == "+" else ""
-        summary = header.strip()
-        body_html = body.strip()
-        if body_html and not body_html.startswith("<"):
-            body_html = f"<p>{body_html}</p>"
-        parts = [
-            f"<details class=\"callout\" data-kind=\"{kind.lower()}\"{open_attr}>",
-            f"<summary>{summary}</summary>",
-        ]
-        if body_html:
-            parts.append(body_html)
-        parts.append("</details>")
-        return "\n".join(parts)
-
-    return pattern.sub(repl, html)
-
-
-_IMAGE_SUFFIXES = {".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".svg"}
-
-
-def _attachment_preview_src(att: AttachmentInfo) -> Optional[str]:
-    local = getattr(att, "local_path", None)
-    if local is None:
-        return None
-    suffix = local.suffix.lower()
-    if suffix not in _IMAGE_SUFFIXES:
-        return None
-    return urllib.parse.quote(local.as_posix())
-
-
-def _attachment_icon(att: AttachmentInfo) -> str:
-    local = getattr(att, "local_path", None)
-    suffix = ""
-    if local is not None:
-        suffix = local.suffix.lower()
-    elif isinstance(getattr(att, "link", None), str):
-        suffix = Path(att.link).suffix.lower()
-    if suffix in _IMAGE_SUFFIXES:
-        return "🖼"
-    if suffix in {".pdf"}:
-        return "📄"
-    if suffix in {".md", ".txt"}:
-        return "📝"
-    if suffix in {".json", ".jsonl", ".yaml", ".yml"}:
-        return "🧾"
-    if suffix in {".zip", ".tar", ".gz", ".bz2", ".xz"}:
-        return "🗜"
-    return "📎"

--- a/tests/golden_html/claude-basic.html
+++ b/tests/golden_html/claude-basic.html
@@ -81,6 +81,14 @@
         padding: 0.6rem 0.75rem;
         background: color-mix(in srgb, var(--bg) 94%, #00000008);
       }
+      .attachment img {
+        width: 100%;
+        max-height: 160px;
+        object-fit: cover;
+        border-radius: 8px;
+        border: 1px solid var(--border);
+        margin-top: 0.5rem;
+      }
       .content blockquote {
         border-left: 4px solid #3b82f6;
         padding-left: 1rem;

--- a/tests/golden_html/claude-basic.html
+++ b/tests/golden_html/claude-basic.html
@@ -44,6 +44,7 @@
         border-radius: 999px;
         font-size: 0.9rem;
       }
+      .muted { opacity: 0.8; font-size: 0.85rem; }
       .toolbar { display: flex; gap: 0.75rem; align-items: center; }
       .search-input {
         flex: 1;
@@ -53,12 +54,25 @@
         background: color-mix(in srgb, var(--bg) 96%, #00000008);
         color: var(--fg);
       }
+      .sidebar-input {
+        width: 100%;
+        padding: 0.4rem 0.6rem;
+        border-radius: 10px;
+        border: 1px solid var(--border);
+        background: color-mix(in srgb, var(--bg) 96%, #00000008);
+        color: var(--fg);
+        margin: 0.4rem 0 0.75rem;
+      }
       .layout { display: grid; grid-template-columns: 260px 1fr; gap: 1.25rem; align-items: start; }
       .card {
         border: 1px solid var(--border);
         border-radius: 12px;
         padding: 1rem;
         background: color-mix(in srgb, var(--bg) 96%, #00000006);
+      }
+      @media (max-width: 860px) {
+        header { flex-wrap: wrap; }
+        .layout { grid-template-columns: 1fr; }
       }
       .metadata table {
         width: 100%;
@@ -74,6 +88,7 @@
       .toc ul { list-style: none; padding-left: 0; margin: 0; }
       .toc li { margin: 0.2rem 0; }
       .toc a { text-decoration: none; }
+      .toc a:hover { text-decoration: underline; }
       .attachments { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 0.75rem; }
       .attachment {
         border: 1px solid var(--border);
@@ -81,6 +96,9 @@
         padding: 0.6rem 0.75rem;
         background: color-mix(in srgb, var(--bg) 94%, #00000008);
       }
+      .attachment .att-meta { display: flex; gap: 0.5rem; align-items: baseline; flex-wrap: wrap; }
+      .attachment .att-name { font-weight: 600; }
+      .attachment .att-sub { font-size: 0.85rem; opacity: 0.8; }
       .attachment img {
         width: 100%;
         max-height: 160px;
@@ -88,6 +106,51 @@
         border-radius: 8px;
         border: 1px solid var(--border);
         margin-top: 0.5rem;
+      }
+      .lightbox {
+        position: fixed;
+        inset: 0;
+        display: none;
+        align-items: center;
+        justify-content: center;
+        background: color-mix(in srgb, #000 75%, transparent);
+        z-index: 30;
+        padding: 1.25rem;
+      }
+      .lightbox[open] { display: flex; }
+      .lightbox-card {
+        max-width: 1100px;
+        width: 100%;
+        max-height: 92vh;
+        border-radius: 14px;
+        border: 1px solid var(--border);
+        background: var(--bg);
+        overflow: hidden;
+        display: grid;
+        grid-template-rows: auto 1fr;
+      }
+      .lightbox-header {
+        display: flex;
+        gap: 0.75rem;
+        align-items: center;
+        justify-content: space-between;
+        padding: 0.65rem 0.85rem;
+        border-bottom: 1px solid var(--border);
+      }
+      .lightbox-header a { text-decoration: none; }
+      .lightbox-body {
+        padding: 0.75rem;
+        overflow: auto;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+      .lightbox-body img {
+        max-width: 100%;
+        max-height: 80vh;
+        object-fit: contain;
+        border-radius: 10px;
+        border: 1px solid var(--border);
       }
       .content blockquote {
         border-left: 4px solid #3b82f6;
@@ -178,7 +241,7 @@
                 
                 <tr>
                   <th>contentHash</th>
-                  <td>03bee25aeb24d3008c8f09f69d67e6c740a5d26efbd1faf2a592cd29221255fc</td>
+                  <td>1debf6fbfc81e761794797e3cb74a40e31f5066c76e1316459bacb6b96d1320c</td>
                 </tr>
                 
                 <tr>
@@ -218,7 +281,7 @@
                 
                 <tr>
                   <th>polylogue</th>
-                  <td>{&#34;contentHash&#34;: &#34;03bee25aeb24d3008c8f09f69d67e6c740a5d26efbd1faf2a592cd29221255fc&#34;, &#34;conversationId&#34;: &#34;golden-claude-1&#34;, &#34;lastUpdated&#34;: null, &#34;provider&#34;: &#34;claude.ai&#34;, &#34;slug&#34;: &#34;golden-claude&#34;, &#34;title&#34;: &#34;Golden Claude&#34;}</td>
+                  <td>{&#34;contentHash&#34;: &#34;1debf6fbfc81e761794797e3cb74a40e31f5066c76e1316459bacb6b96d1320c&#34;, &#34;conversationId&#34;: &#34;golden-claude-1&#34;, &#34;lastUpdated&#34;: null, &#34;provider&#34;: &#34;claude.ai&#34;, &#34;slug&#34;: &#34;golden-claude&#34;, &#34;title&#34;: &#34;Golden Claude&#34;}</td>
                 </tr>
                 
                 <tr>
@@ -267,11 +330,31 @@
         </div>
       </div>
     </main>
+    <div class="lightbox" id="lightbox" role="dialog" aria-modal="true" aria-label="Attachment preview">
+      <div class="lightbox-card">
+        <div class="lightbox-header">
+          <div>
+            <strong id="lightbox-title"></strong>
+            <span class="muted" id="lightbox-hint"></span>
+          </div>
+          <div class="toolbar">
+            <a id="lightbox-open" href="#" target="_blank" class="pill">open</a>
+            <a href="#" id="lightbox-close" class="pill">close</a>
+          </div>
+        </div>
+        <div class="lightbox-body">
+          <img id="lightbox-img" alt="" />
+        </div>
+      </div>
+    </div>
     <script>
       const tocEl = document.getElementById('toc');
       const headings = document.querySelectorAll('#content h1, #content h2, #content h3');
       headings.forEach(h => {
         if (!h.id) return;
+        const clone = h.cloneNode(true);
+        clone.querySelectorAll('.anchor-btn').forEach(n => n.remove());
+        const headingText = (clone.textContent || '').trim();
         const anchor = document.createElement('a');
         anchor.href = `#${h.id}`;
         anchor.textContent = '🔗';
@@ -287,7 +370,7 @@
         const li = document.createElement('li');
         const a = document.createElement('a');
         a.href = `#${h.id}`;
-        a.textContent = h.textContent;
+        a.textContent = headingText || h.id;
         li.appendChild(a);
         tocEl.appendChild(li);
       });
@@ -332,6 +415,51 @@
         });
         anchor.insertAdjacentElement('afterend', btn);
       });
+
+      // Attachments: filter + lightbox previews.
+      const attFilter = document.getElementById('att-filter');
+      const attCards = Array.from(document.querySelectorAll('.attachment'));
+      function applyAttFilter(term) {
+        const q = (term || '').trim().toLowerCase();
+        for (const card of attCards) {
+          const hay = card.getAttribute('data-att') || '';
+          card.classList.toggle('hidden', q && !hay.includes(q));
+        }
+      }
+      if (attFilter) attFilter.addEventListener('input', (e) => applyAttFilter(e.target.value));
+
+      const lightbox = document.getElementById('lightbox');
+      const lightboxImg = document.getElementById('lightbox-img');
+      const lightboxTitle = document.getElementById('lightbox-title');
+      const lightboxOpen = document.getElementById('lightbox-open');
+      const lightboxHint = document.getElementById('lightbox-hint');
+      const lightboxClose = document.getElementById('lightbox-close');
+
+      function closeLightbox() {
+        if (!lightbox) return;
+        lightbox.removeAttribute('open');
+        if (lightboxImg) lightboxImg.src = '';
+      }
+      function openLightbox(src, name) {
+        if (!lightbox) return;
+        lightbox.setAttribute('open', 'true');
+        if (lightboxImg) lightboxImg.src = src;
+        if (lightboxImg) lightboxImg.alt = name || '';
+        if (lightboxTitle) lightboxTitle.textContent = name || '';
+        if (lightboxHint) lightboxHint.textContent = ' (Esc to close)';
+        if (lightboxOpen) lightboxOpen.href = src;
+      }
+      document.querySelectorAll('.att-preview').forEach(img => {
+        img.addEventListener('click', (e) => {
+          e.preventDefault();
+          const src = img.getAttribute('data-full') || img.getAttribute('src');
+          const name = img.getAttribute('data-name') || '';
+          openLightbox(src, name);
+        });
+      });
+      if (lightboxClose) lightboxClose.addEventListener('click', (e) => { e.preventDefault(); closeLightbox(); });
+      if (lightbox) lightbox.addEventListener('click', (e) => { if (e.target === lightbox) closeLightbox(); });
+      window.addEventListener('keydown', (e) => { if (e.key === 'Escape') closeLightbox(); });
     </script>
   </body>
 </html>

--- a/tests/golden_html/claude-code-basic.html
+++ b/tests/golden_html/claude-code-basic.html
@@ -44,6 +44,7 @@
         border-radius: 999px;
         font-size: 0.9rem;
       }
+      .muted { opacity: 0.8; font-size: 0.85rem; }
       .toolbar { display: flex; gap: 0.75rem; align-items: center; }
       .search-input {
         flex: 1;
@@ -53,12 +54,25 @@
         background: color-mix(in srgb, var(--bg) 96%, #00000008);
         color: var(--fg);
       }
+      .sidebar-input {
+        width: 100%;
+        padding: 0.4rem 0.6rem;
+        border-radius: 10px;
+        border: 1px solid var(--border);
+        background: color-mix(in srgb, var(--bg) 96%, #00000008);
+        color: var(--fg);
+        margin: 0.4rem 0 0.75rem;
+      }
       .layout { display: grid; grid-template-columns: 260px 1fr; gap: 1.25rem; align-items: start; }
       .card {
         border: 1px solid var(--border);
         border-radius: 12px;
         padding: 1rem;
         background: color-mix(in srgb, var(--bg) 96%, #00000006);
+      }
+      @media (max-width: 860px) {
+        header { flex-wrap: wrap; }
+        .layout { grid-template-columns: 1fr; }
       }
       .metadata table {
         width: 100%;
@@ -74,6 +88,7 @@
       .toc ul { list-style: none; padding-left: 0; margin: 0; }
       .toc li { margin: 0.2rem 0; }
       .toc a { text-decoration: none; }
+      .toc a:hover { text-decoration: underline; }
       .attachments { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 0.75rem; }
       .attachment {
         border: 1px solid var(--border);
@@ -81,6 +96,9 @@
         padding: 0.6rem 0.75rem;
         background: color-mix(in srgb, var(--bg) 94%, #00000008);
       }
+      .attachment .att-meta { display: flex; gap: 0.5rem; align-items: baseline; flex-wrap: wrap; }
+      .attachment .att-name { font-weight: 600; }
+      .attachment .att-sub { font-size: 0.85rem; opacity: 0.8; }
       .attachment img {
         width: 100%;
         max-height: 160px;
@@ -88,6 +106,51 @@
         border-radius: 8px;
         border: 1px solid var(--border);
         margin-top: 0.5rem;
+      }
+      .lightbox {
+        position: fixed;
+        inset: 0;
+        display: none;
+        align-items: center;
+        justify-content: center;
+        background: color-mix(in srgb, #000 75%, transparent);
+        z-index: 30;
+        padding: 1.25rem;
+      }
+      .lightbox[open] { display: flex; }
+      .lightbox-card {
+        max-width: 1100px;
+        width: 100%;
+        max-height: 92vh;
+        border-radius: 14px;
+        border: 1px solid var(--border);
+        background: var(--bg);
+        overflow: hidden;
+        display: grid;
+        grid-template-rows: auto 1fr;
+      }
+      .lightbox-header {
+        display: flex;
+        gap: 0.75rem;
+        align-items: center;
+        justify-content: space-between;
+        padding: 0.65rem 0.85rem;
+        border-bottom: 1px solid var(--border);
+      }
+      .lightbox-header a { text-decoration: none; }
+      .lightbox-body {
+        padding: 0.75rem;
+        overflow: auto;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+      .lightbox-body img {
+        max-width: 100%;
+        max-height: 80vh;
+        object-fit: contain;
+        border-radius: 10px;
+        border: 1px solid var(--border);
       }
       .content blockquote {
         border-left: 4px solid #3b82f6;
@@ -178,7 +241,7 @@
                 
                 <tr>
                   <th>contentHash</th>
-                  <td>c958013174df7a51a0e6a91df74991861f8f5742ca279b32661e54381235ba63</td>
+                  <td>1b6a5882d2e967ac2738d3bdfbfe4d4cba0aaa884e4956ba6eb1854e77f1e73c</td>
                 </tr>
                 
                 <tr>
@@ -218,7 +281,7 @@
                 
                 <tr>
                   <th>polylogue</th>
-                  <td>{&#34;contentHash&#34;: &#34;c958013174df7a51a0e6a91df74991861f8f5742ca279b32661e54381235ba63&#34;, &#34;conversationId&#34;: &#34;tests/fixtures/golden/claude_code/claude-code-golden.jsonl&#34;, &#34;lastUpdated&#34;: null, &#34;provider&#34;: &#34;claude-code&#34;, &#34;slug&#34;: &#34;claude-code-golden&#34;, &#34;title&#34;: &#34;claude-code-golden&#34;}</td>
+                  <td>{&#34;contentHash&#34;: &#34;1b6a5882d2e967ac2738d3bdfbfe4d4cba0aaa884e4956ba6eb1854e77f1e73c&#34;, &#34;conversationId&#34;: &#34;tests/fixtures/golden/claude_code/claude-code-golden.jsonl&#34;, &#34;lastUpdated&#34;: null, &#34;provider&#34;: &#34;claude-code&#34;, &#34;slug&#34;: &#34;claude-code-golden&#34;, &#34;title&#34;: &#34;claude-code-golden&#34;}</td>
                 </tr>
                 
                 <tr>
@@ -280,11 +343,31 @@
         </div>
       </div>
     </main>
+    <div class="lightbox" id="lightbox" role="dialog" aria-modal="true" aria-label="Attachment preview">
+      <div class="lightbox-card">
+        <div class="lightbox-header">
+          <div>
+            <strong id="lightbox-title"></strong>
+            <span class="muted" id="lightbox-hint"></span>
+          </div>
+          <div class="toolbar">
+            <a id="lightbox-open" href="#" target="_blank" class="pill">open</a>
+            <a href="#" id="lightbox-close" class="pill">close</a>
+          </div>
+        </div>
+        <div class="lightbox-body">
+          <img id="lightbox-img" alt="" />
+        </div>
+      </div>
+    </div>
     <script>
       const tocEl = document.getElementById('toc');
       const headings = document.querySelectorAll('#content h1, #content h2, #content h3');
       headings.forEach(h => {
         if (!h.id) return;
+        const clone = h.cloneNode(true);
+        clone.querySelectorAll('.anchor-btn').forEach(n => n.remove());
+        const headingText = (clone.textContent || '').trim();
         const anchor = document.createElement('a');
         anchor.href = `#${h.id}`;
         anchor.textContent = '🔗';
@@ -300,7 +383,7 @@
         const li = document.createElement('li');
         const a = document.createElement('a');
         a.href = `#${h.id}`;
-        a.textContent = h.textContent;
+        a.textContent = headingText || h.id;
         li.appendChild(a);
         tocEl.appendChild(li);
       });
@@ -345,6 +428,51 @@
         });
         anchor.insertAdjacentElement('afterend', btn);
       });
+
+      // Attachments: filter + lightbox previews.
+      const attFilter = document.getElementById('att-filter');
+      const attCards = Array.from(document.querySelectorAll('.attachment'));
+      function applyAttFilter(term) {
+        const q = (term || '').trim().toLowerCase();
+        for (const card of attCards) {
+          const hay = card.getAttribute('data-att') || '';
+          card.classList.toggle('hidden', q && !hay.includes(q));
+        }
+      }
+      if (attFilter) attFilter.addEventListener('input', (e) => applyAttFilter(e.target.value));
+
+      const lightbox = document.getElementById('lightbox');
+      const lightboxImg = document.getElementById('lightbox-img');
+      const lightboxTitle = document.getElementById('lightbox-title');
+      const lightboxOpen = document.getElementById('lightbox-open');
+      const lightboxHint = document.getElementById('lightbox-hint');
+      const lightboxClose = document.getElementById('lightbox-close');
+
+      function closeLightbox() {
+        if (!lightbox) return;
+        lightbox.removeAttribute('open');
+        if (lightboxImg) lightboxImg.src = '';
+      }
+      function openLightbox(src, name) {
+        if (!lightbox) return;
+        lightbox.setAttribute('open', 'true');
+        if (lightboxImg) lightboxImg.src = src;
+        if (lightboxImg) lightboxImg.alt = name || '';
+        if (lightboxTitle) lightboxTitle.textContent = name || '';
+        if (lightboxHint) lightboxHint.textContent = ' (Esc to close)';
+        if (lightboxOpen) lightboxOpen.href = src;
+      }
+      document.querySelectorAll('.att-preview').forEach(img => {
+        img.addEventListener('click', (e) => {
+          e.preventDefault();
+          const src = img.getAttribute('data-full') || img.getAttribute('src');
+          const name = img.getAttribute('data-name') || '';
+          openLightbox(src, name);
+        });
+      });
+      if (lightboxClose) lightboxClose.addEventListener('click', (e) => { e.preventDefault(); closeLightbox(); });
+      if (lightbox) lightbox.addEventListener('click', (e) => { if (e.target === lightbox) closeLightbox(); });
+      window.addEventListener('keydown', (e) => { if (e.key === 'Escape') closeLightbox(); });
     </script>
   </body>
 </html>

--- a/tests/golden_html/claude-code-basic.html
+++ b/tests/golden_html/claude-code-basic.html
@@ -81,6 +81,14 @@
         padding: 0.6rem 0.75rem;
         background: color-mix(in srgb, var(--bg) 94%, #00000008);
       }
+      .attachment img {
+        width: 100%;
+        max-height: 160px;
+        object-fit: cover;
+        border-radius: 8px;
+        border: 1px solid var(--border);
+        margin-top: 0.5rem;
+      }
       .content blockquote {
         border-left: 4px solid #3b82f6;
         padding-left: 1rem;

--- a/tests/golden_html/claude-tool.html
+++ b/tests/golden_html/claude-tool.html
@@ -1,57 +1,15 @@
-from __future__ import annotations
 
-from dataclasses import dataclass
-from pathlib import Path
-from typing import Dict
-import re
-import math
-import json
-import urllib.parse
-
-from jinja2 import Environment, BaseLoader
-from markupsafe import escape
-from markdown_it import MarkdownIt
-
-from .render import AttachmentInfo, MarkdownDocument
-
-
-def _human_size(num: float | int | None) -> str | None:
-    if num is None or num <= 0:
-        return None
-    units = ["B", "KB", "MB", "GB", "TB"]
-    idx = min(int(math.log(num, 1024)) if num > 0 else 0, len(units) - 1)
-    value = num / (1024 ** idx)
-    return f"{value:.2f} {units[idx]}"
-
-
-THEMES: Dict[str, Dict[str, str]] = {
-    "light": {
-        "background": "#ffffff",
-        "foreground": "#222222",
-        "callout_border": "#3b82f6",
-        "link": "#2563eb",
-    },
-    "dark": {
-        "background": "#111827",
-        "foreground": "#e5e7eb",
-        "callout_border": "#60a5fa",
-        "link": "#93c5fd",
-    },
-}
-
-
-HTML_TEMPLATE = """
 <!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>{{ title }}</title>
+    <title>Golden Claude Tool + Attachments</title>
     <style>
       :root {
-        --bg: {{ theme.background }};
-        --fg: {{ theme.foreground }};
-        --accent: {{ theme.link }};
-        --border: {{ theme.callout_border }}44;
+        --bg: #ffffff;
+        --fg: #222222;
+        --accent: #2563eb;
+        --border: #3b82f644;
       }
       * { box-sizing: border-box; }
       body {
@@ -195,16 +153,16 @@ HTML_TEMPLATE = """
         border: 1px solid var(--border);
       }
       .content blockquote {
-        border-left: 4px solid {{ theme.callout_border }};
+        border-left: 4px solid #3b82f6;
         padding-left: 1rem;
         margin-left: 0;
-        background: {{ theme.callout_border }}11;
+        background: #3b82f611;
       }
       details.callout {
         margin: 1rem 0;
-        border-left: 4px solid {{ theme.callout_border }};
+        border-left: 4px solid #3b82f6;
         padding-left: 1rem;
-        background: {{ theme.callout_border }}11;
+        background: #3b82f611;
       }
       details.callout summary {
         cursor: pointer;
@@ -221,7 +179,7 @@ HTML_TEMPLATE = """
       }
       details.callout[open] summary::before { transform: rotate(90deg); }
       pre {
-        background: {{ theme.foreground }}11;
+        background: #22222211;
         padding: 0.75rem;
         overflow-x: auto;
       }
@@ -240,7 +198,7 @@ HTML_TEMPLATE = """
   </head>
   <body>
     <header>
-      <div class="pill">{{ title }}</div>
+      <div class="pill">Golden Claude Tool + Attachments</div>
       <input class="search-input" id="client-search" type="search" placeholder="Filter text (press / to focus)" />
       <div class="toolbar"><span class="pill" id="match-count"></span></div>
     </header>
@@ -249,40 +207,139 @@ HTML_TEMPLATE = """
         <div class="card toc">
           <h3>Contents</h3>
           <ul id="toc"></ul>
-          {% if attachments %}
-          <h4>Attachments</h4>
-          <input class="sidebar-input" id="att-filter" type="search" placeholder="Filter attachments" />
-          <div class="attachments">
-            {% for att in attachments %}
-              <div class="attachment" data-att="{{ (att.name ~ ' ' ~ (att.kind or '') ~ ' ' ~ (att.ext or ''))|lower }}">
-                <div class="att-meta">
-                  <span class="att-name">{{ att.icon }} <a href="{{ att.link }}" target="_blank">{{ att.name }}</a></span>
-                  {% if att.size %}<span class="att-sub">{{ att.size }}</span>{% endif %}
-                </div>
-                {% if att.preview_src %}
-                  <a href="{{ att.link }}" target="_blank">
-                    <img class="att-preview" data-full="{{ att.link }}" data-name="{{ att.name }}" src="{{ att.preview_src }}" alt="{{ att.name }}" />
-                  </a>
-                {% endif %}
-              </div>
-            {% endfor %}
-          </div>
-          {% endif %}
+          
         </div>
         <div>
           <div class="card metadata">
             <table>
               <tbody>
-                {% for key, value in metadata.items() %}
+                
                 <tr>
-                  <th>{{ key }}</th>
-                  <td>{{ value }}</td>
+                  <th>attachmentPolicy</th>
+                  <td>{&#34;charThreshold&#34;: 4000, &#34;extractedCount&#34;: 2, &#34;lineThreshold&#34;: 40, &#34;previewLines&#34;: 5, &#34;routing&#34;: {&#34;routed&#34;: 0, &#34;skipped&#34;: 2}}</td>
                 </tr>
-                {% endfor %}
+                
+                <tr>
+                  <th>attachment_bytes</th>
+                  <td>295</td>
+                </tr>
+                
+                <tr>
+                  <th>attachments</th>
+                  <td>0</td>
+                </tr>
+                
+                <tr>
+                  <th>attachmentsDir</th>
+                  <td>&lt;path&gt;</td>
+                </tr>
+                
+                <tr>
+                  <th>collapseThreshold</th>
+                  <td>10</td>
+                </tr>
+                
+                <tr>
+                  <th>contentHash</th>
+                  <td>419d733be8531e4ca97dfc8a943a0f7c70af11804f4d0cafecb5c311d502ec6f</td>
+                </tr>
+                
+                <tr>
+                  <th>currentBranch</th>
+                  <td>branch-000</td>
+                </tr>
+                
+                <tr>
+                  <th>dirty</th>
+                  <td>False</td>
+                </tr>
+                
+                <tr>
+                  <th>html</th>
+                  <td>False</td>
+                </tr>
+                
+                <tr>
+                  <th>htmlPath</th>
+                  <td>None</td>
+                </tr>
+                
+                <tr>
+                  <th>lastImported</th>
+                  <td>2000-01-01T00:00:00Z</td>
+                </tr>
+                
+                <tr>
+                  <th>lastUpdated</th>
+                  <td>2024-01-01T00:00:03Z</td>
+                </tr>
+                
+                <tr>
+                  <th>outputPath</th>
+                  <td>&lt;path&gt;</td>
+                </tr>
+                
+                <tr>
+                  <th>polylogue</th>
+                  <td>{&#34;contentHash&#34;: &#34;419d733be8531e4ca97dfc8a943a0f7c70af11804f4d0cafecb5c311d502ec6f&#34;, &#34;conversationId&#34;: &#34;golden-claude-tool-1&#34;, &#34;lastUpdated&#34;: &#34;2024-01-01T00:00:03Z&#34;, &#34;provider&#34;: &#34;claude.ai&#34;, &#34;slug&#34;: &#34;golden-claude-tool-attachments&#34;, &#34;title&#34;: &#34;Golden Claude Tool + Attachments&#34;}</td>
+                </tr>
+                
+                <tr>
+                  <th>slug</th>
+                  <td>golden-claude-tool-attachments</td>
+                </tr>
+                
+                <tr>
+                  <th>sourceExportPath</th>
+                  <td>tests/fixtures/golden/claude_tool</td>
+                </tr>
+                
+                <tr>
+                  <th>sourceModel</th>
+                  <td>claude-3.5-sonnet</td>
+                </tr>
+                
+                <tr>
+                  <th>title</th>
+                  <td>Golden Claude Tool + Attachments</td>
+                </tr>
+                
+                <tr>
+                  <th>token_count</th>
+                  <td>28</td>
+                </tr>
+                
+                <tr>
+                  <th>tokens</th>
+                  <td>28</td>
+                </tr>
+                
+                <tr>
+                  <th>word_count</th>
+                  <td>28</td>
+                </tr>
+                
+                <tr>
+                  <th>words</th>
+                  <td>28</td>
+                </tr>
+                
               </tbody>
             </table>
           </div>
-          <div class="content" id="content">{{ body_html | safe }}</div>
+          <div class="content" id="content"><h2 id="user">User</h2>
+<p>Hello. Please run a command and show the result. Also see attachments.</p>
+<h2 id="model">Model</h2>
+<p>Tool call <code>bash</code></p>
+<pre><code class="language-json">{
+  &quot;cmd&quot;: &quot;echo hi&quot;
+}
+</code></pre>
+<p>Tool result</p>
+<pre><code>hi
+</code></pre>
+<p>Done.</p>
+</div>
         </div>
       </div>
     </main>
@@ -419,169 +476,3 @@ HTML_TEMPLATE = """
     </script>
   </body>
 </html>
-"""
-
-
-@dataclass
-class HtmlRenderOptions:
-    theme: str = "light"
-
-
-def _anchorize(text: str) -> str:
-    """Create a URL-safe anchor id from text."""
-    safe = re.sub(r"<[^>]+>", "", text or "")
-    safe = re.sub(r"[^a-zA-Z0-9\\-_]+", "-", safe).strip("-").lower()
-    return safe or "section"
-
-
-_MD_RENDERER = MarkdownIt("commonmark", {"html": True}).enable("table").enable("strikethrough")
-_JINJA_ENV = Environment(loader=BaseLoader(), autoescape=True) if Environment is not None else None
-_JINJA_TEMPLATE = _JINJA_ENV.from_string(HTML_TEMPLATE) if _JINJA_ENV is not None else None
-
-
-def render_html(document: MarkdownDocument, options: HtmlRenderOptions) -> str:
-    theme = THEMES.get(options.theme, THEMES["light"])
-    body_html = _MD_RENDERER.render(document.body)
-    # Inject anchors for headings to support deep links from search/open.
-    body_html = re.sub(
-        r"<h([1-6])>(.*?)</h\1>",
-        lambda m: f'<h{m.group(1)} id="{_anchorize(m.group(2))}">{m.group(2)}</h{m.group(1)}>',
-        body_html,
-    )
-    body_html = _transform_callouts(body_html)
-    def _fmt(value: object) -> object:
-        if isinstance(value, (dict, list)):
-            try:
-                return json.dumps(value, sort_keys=True, ensure_ascii=False)
-            except Exception:
-                return str(value)
-        return value
-
-    metadata_rows_raw = {k: _fmt(v) for k, v in document.metadata.items() if k != "attachments"}
-    metadata_rows_raw["attachments"] = len(document.attachments)
-    metadata_rows = {k: metadata_rows_raw[k] for k in sorted(metadata_rows_raw)}
-    attachment_total_bytes = 0
-    attachments = [
-        {
-            "name": att.name,
-            "link": urllib.parse.quote(att.local_path.as_posix()) if getattr(att, "local_path", None) else att.link,
-            "size": _human_size(att.size_bytes) if hasattr(att, "size_bytes") else None,
-            "preview_src": _attachment_preview_src(att),
-            "ext": getattr(att.local_path, "suffix", "") if getattr(att, "local_path", None) else Path(att.link).suffix,
-            "kind": "image" if _attachment_preview_src(att) else "file",
-            "icon": _attachment_icon(att),
-        }
-        for att in document.attachments
-    ]
-    for att in document.attachments:
-        if getattr(att, "size_bytes", None):
-            try:
-                attachment_total_bytes += int(att.size_bytes or 0)
-            except Exception:
-                pass
-    if attachment_total_bytes:
-        metadata_rows["attachmentBytes"] = int(attachment_total_bytes)
-
-    if _JINJA_TEMPLATE is None:
-        rows = "".join(
-            f"<tr><th>{escape(str(k))}</th><td>{escape(str(v))}</td></tr>" for k, v in metadata_rows.items()
-        )
-        return f"""
-<!DOCTYPE html>
-<html lang=\"en\">
-  <head>
-    <meta charset=\"utf-8\" />
-    <title>{document.metadata.get('title', 'Conversation')}</title>
-    <style>
-      body {{ background: {theme['background']}; color: {theme['foreground']}; font-family: system-ui, sans-serif; margin: 2rem auto; max-width: 820px; line-height: 1.6; }}
-      a {{ color: {theme['link']}; }}
-      table {{ width: 100%; border-collapse: collapse; margin-bottom: 1.5rem; }}
-      th, td {{ border: 1px solid {theme['callout_border']}44; padding: 0.4rem 0.6rem; text-align: left; font-size: 0.9rem; }}
-      blockquote {{ border-left: 4px solid {theme['callout_border']}; padding-left: 1rem; margin-left: 0; background: {theme['callout_border']}11; }}
-      pre {{ background: {theme['foreground']}11; padding: 0.75rem; overflow-x: auto; }}
-      code {{ font-family: "JetBrains Mono", monospace; }}
-    </style>
-  </head>
-  <body>
-    <h1>{escape(str(document.metadata.get('title', 'Conversation')))}</h1>
-    <div class=\"metadata\">
-      <table><tbody>{rows}</tbody></table>
-    </div>
-    <div class=\"content\">{body_html}</div>
-  </body>
-</html>
-"""
-
-    return _JINJA_TEMPLATE.render(
-        title=document.metadata.get("title", "Conversation"),
-        metadata=metadata_rows,
-        body_html=body_html,
-        theme=theme,
-        attachments=attachments,
-    )
-
-
-def write_html(document: MarkdownDocument, path: Path, theme: str) -> None:
-    options = HtmlRenderOptions(theme=theme)
-    html_text = render_html(document, options)
-    path.write_text(html_text, encoding="utf-8")
-
-
-def _transform_callouts(html: str) -> str:
-    import re
-
-    pattern = re.compile(
-        r"<blockquote>\s*<p>\[!([A-Z]+)\]([+-])\s+(.*?)</p>(.*?)</blockquote>",
-        flags=re.DOTALL,
-    )
-
-    def repl(match: re.Match[str]) -> str:
-        kind, fold, header, body = match.groups()
-        open_attr = " open" if fold == "+" else ""
-        summary = header.strip()
-        body_html = body.strip()
-        if body_html and not body_html.startswith("<"):
-            body_html = f"<p>{body_html}</p>"
-        parts = [
-            f"<details class=\"callout\" data-kind=\"{kind.lower()}\"{open_attr}>",
-            f"<summary>{summary}</summary>",
-        ]
-        if body_html:
-            parts.append(body_html)
-        parts.append("</details>")
-        return "\n".join(parts)
-
-    return pattern.sub(repl, html)
-
-
-_IMAGE_SUFFIXES = {".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".svg"}
-
-
-def _attachment_preview_src(att: AttachmentInfo) -> Optional[str]:
-    local = getattr(att, "local_path", None)
-    if local is None:
-        return None
-    suffix = local.suffix.lower()
-    if suffix not in _IMAGE_SUFFIXES:
-        return None
-    return urllib.parse.quote(local.as_posix())
-
-
-def _attachment_icon(att: AttachmentInfo) -> str:
-    local = getattr(att, "local_path", None)
-    suffix = ""
-    if local is not None:
-        suffix = local.suffix.lower()
-    elif isinstance(getattr(att, "link", None), str):
-        suffix = Path(att.link).suffix.lower()
-    if suffix in _IMAGE_SUFFIXES:
-        return "🖼"
-    if suffix in {".pdf"}:
-        return "📄"
-    if suffix in {".md", ".txt"}:
-        return "📝"
-    if suffix in {".json", ".jsonl", ".yaml", ".yml"}:
-        return "🧾"
-    if suffix in {".zip", ".tar", ".gz", ".bz2", ".xz"}:
-        return "🗜"
-    return "📎"

--- a/tests/golden_html/codex-basic.html
+++ b/tests/golden_html/codex-basic.html
@@ -81,6 +81,14 @@
         padding: 0.6rem 0.75rem;
         background: color-mix(in srgb, var(--bg) 94%, #00000008);
       }
+      .attachment img {
+        width: 100%;
+        max-height: 160px;
+        object-fit: cover;
+        border-radius: 8px;
+        border: 1px solid var(--border);
+        margin-top: 0.5rem;
+      }
       .content blockquote {
         border-left: 4px solid #3b82f6;
         padding-left: 1rem;

--- a/tests/golden_html/codex-basic.html
+++ b/tests/golden_html/codex-basic.html
@@ -44,6 +44,7 @@
         border-radius: 999px;
         font-size: 0.9rem;
       }
+      .muted { opacity: 0.8; font-size: 0.85rem; }
       .toolbar { display: flex; gap: 0.75rem; align-items: center; }
       .search-input {
         flex: 1;
@@ -53,12 +54,25 @@
         background: color-mix(in srgb, var(--bg) 96%, #00000008);
         color: var(--fg);
       }
+      .sidebar-input {
+        width: 100%;
+        padding: 0.4rem 0.6rem;
+        border-radius: 10px;
+        border: 1px solid var(--border);
+        background: color-mix(in srgb, var(--bg) 96%, #00000008);
+        color: var(--fg);
+        margin: 0.4rem 0 0.75rem;
+      }
       .layout { display: grid; grid-template-columns: 260px 1fr; gap: 1.25rem; align-items: start; }
       .card {
         border: 1px solid var(--border);
         border-radius: 12px;
         padding: 1rem;
         background: color-mix(in srgb, var(--bg) 96%, #00000006);
+      }
+      @media (max-width: 860px) {
+        header { flex-wrap: wrap; }
+        .layout { grid-template-columns: 1fr; }
       }
       .metadata table {
         width: 100%;
@@ -74,6 +88,7 @@
       .toc ul { list-style: none; padding-left: 0; margin: 0; }
       .toc li { margin: 0.2rem 0; }
       .toc a { text-decoration: none; }
+      .toc a:hover { text-decoration: underline; }
       .attachments { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 0.75rem; }
       .attachment {
         border: 1px solid var(--border);
@@ -81,6 +96,9 @@
         padding: 0.6rem 0.75rem;
         background: color-mix(in srgb, var(--bg) 94%, #00000008);
       }
+      .attachment .att-meta { display: flex; gap: 0.5rem; align-items: baseline; flex-wrap: wrap; }
+      .attachment .att-name { font-weight: 600; }
+      .attachment .att-sub { font-size: 0.85rem; opacity: 0.8; }
       .attachment img {
         width: 100%;
         max-height: 160px;
@@ -88,6 +106,51 @@
         border-radius: 8px;
         border: 1px solid var(--border);
         margin-top: 0.5rem;
+      }
+      .lightbox {
+        position: fixed;
+        inset: 0;
+        display: none;
+        align-items: center;
+        justify-content: center;
+        background: color-mix(in srgb, #000 75%, transparent);
+        z-index: 30;
+        padding: 1.25rem;
+      }
+      .lightbox[open] { display: flex; }
+      .lightbox-card {
+        max-width: 1100px;
+        width: 100%;
+        max-height: 92vh;
+        border-radius: 14px;
+        border: 1px solid var(--border);
+        background: var(--bg);
+        overflow: hidden;
+        display: grid;
+        grid-template-rows: auto 1fr;
+      }
+      .lightbox-header {
+        display: flex;
+        gap: 0.75rem;
+        align-items: center;
+        justify-content: space-between;
+        padding: 0.65rem 0.85rem;
+        border-bottom: 1px solid var(--border);
+      }
+      .lightbox-header a { text-decoration: none; }
+      .lightbox-body {
+        padding: 0.75rem;
+        overflow: auto;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+      .lightbox-body img {
+        max-width: 100%;
+        max-height: 80vh;
+        object-fit: contain;
+        border-radius: 10px;
+        border: 1px solid var(--border);
       }
       .content blockquote {
         border-left: 4px solid #3b82f6;
@@ -178,7 +241,7 @@
                 
                 <tr>
                   <th>contentHash</th>
-                  <td>866414d75a1892d89263f4c3cce6b6be71f71ce2b7407b9ffa6d1114726d95c1</td>
+                  <td>23449ecb7e9d11274b853f9afe072fb54be5c725dd245bce7ddfe6e6863d7b68</td>
                 </tr>
                 
                 <tr>
@@ -218,7 +281,7 @@
                 
                 <tr>
                   <th>polylogue</th>
-                  <td>{&#34;contentHash&#34;: &#34;866414d75a1892d89263f4c3cce6b6be71f71ce2b7407b9ffa6d1114726d95c1&#34;, &#34;conversationId&#34;: &#34;tests/fixtures/golden/codex/codex-golden.jsonl&#34;, &#34;lastUpdated&#34;: null, &#34;provider&#34;: &#34;codex&#34;, &#34;slug&#34;: &#34;codex-golden&#34;, &#34;title&#34;: &#34;codex-golden&#34;}</td>
+                  <td>{&#34;contentHash&#34;: &#34;23449ecb7e9d11274b853f9afe072fb54be5c725dd245bce7ddfe6e6863d7b68&#34;, &#34;conversationId&#34;: &#34;tests/fixtures/golden/codex/codex-golden.jsonl&#34;, &#34;lastUpdated&#34;: null, &#34;provider&#34;: &#34;codex&#34;, &#34;slug&#34;: &#34;codex-golden&#34;, &#34;title&#34;: &#34;codex-golden&#34;}</td>
                 </tr>
                 
                 <tr>
@@ -275,11 +338,31 @@
         </div>
       </div>
     </main>
+    <div class="lightbox" id="lightbox" role="dialog" aria-modal="true" aria-label="Attachment preview">
+      <div class="lightbox-card">
+        <div class="lightbox-header">
+          <div>
+            <strong id="lightbox-title"></strong>
+            <span class="muted" id="lightbox-hint"></span>
+          </div>
+          <div class="toolbar">
+            <a id="lightbox-open" href="#" target="_blank" class="pill">open</a>
+            <a href="#" id="lightbox-close" class="pill">close</a>
+          </div>
+        </div>
+        <div class="lightbox-body">
+          <img id="lightbox-img" alt="" />
+        </div>
+      </div>
+    </div>
     <script>
       const tocEl = document.getElementById('toc');
       const headings = document.querySelectorAll('#content h1, #content h2, #content h3');
       headings.forEach(h => {
         if (!h.id) return;
+        const clone = h.cloneNode(true);
+        clone.querySelectorAll('.anchor-btn').forEach(n => n.remove());
+        const headingText = (clone.textContent || '').trim();
         const anchor = document.createElement('a');
         anchor.href = `#${h.id}`;
         anchor.textContent = '🔗';
@@ -295,7 +378,7 @@
         const li = document.createElement('li');
         const a = document.createElement('a');
         a.href = `#${h.id}`;
-        a.textContent = h.textContent;
+        a.textContent = headingText || h.id;
         li.appendChild(a);
         tocEl.appendChild(li);
       });
@@ -340,6 +423,51 @@
         });
         anchor.insertAdjacentElement('afterend', btn);
       });
+
+      // Attachments: filter + lightbox previews.
+      const attFilter = document.getElementById('att-filter');
+      const attCards = Array.from(document.querySelectorAll('.attachment'));
+      function applyAttFilter(term) {
+        const q = (term || '').trim().toLowerCase();
+        for (const card of attCards) {
+          const hay = card.getAttribute('data-att') || '';
+          card.classList.toggle('hidden', q && !hay.includes(q));
+        }
+      }
+      if (attFilter) attFilter.addEventListener('input', (e) => applyAttFilter(e.target.value));
+
+      const lightbox = document.getElementById('lightbox');
+      const lightboxImg = document.getElementById('lightbox-img');
+      const lightboxTitle = document.getElementById('lightbox-title');
+      const lightboxOpen = document.getElementById('lightbox-open');
+      const lightboxHint = document.getElementById('lightbox-hint');
+      const lightboxClose = document.getElementById('lightbox-close');
+
+      function closeLightbox() {
+        if (!lightbox) return;
+        lightbox.removeAttribute('open');
+        if (lightboxImg) lightboxImg.src = '';
+      }
+      function openLightbox(src, name) {
+        if (!lightbox) return;
+        lightbox.setAttribute('open', 'true');
+        if (lightboxImg) lightboxImg.src = src;
+        if (lightboxImg) lightboxImg.alt = name || '';
+        if (lightboxTitle) lightboxTitle.textContent = name || '';
+        if (lightboxHint) lightboxHint.textContent = ' (Esc to close)';
+        if (lightboxOpen) lightboxOpen.href = src;
+      }
+      document.querySelectorAll('.att-preview').forEach(img => {
+        img.addEventListener('click', (e) => {
+          e.preventDefault();
+          const src = img.getAttribute('data-full') || img.getAttribute('src');
+          const name = img.getAttribute('data-name') || '';
+          openLightbox(src, name);
+        });
+      });
+      if (lightboxClose) lightboxClose.addEventListener('click', (e) => { e.preventDefault(); closeLightbox(); });
+      if (lightbox) lightbox.addEventListener('click', (e) => { if (e.target === lightbox) closeLightbox(); });
+      window.addEventListener('keydown', (e) => { if (e.key === 'Escape') closeLightbox(); });
     </script>
   </body>
 </html>

--- a/tests/test_analytics_cli.py
+++ b/tests/test_analytics_cli.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+from click.testing import CliRunner
+
+from polylogue.cli.analytics import run_analytics_cli
+from polylogue.cli.click_app import cli as click_cli
+from polylogue.commands import CommandEnv
+from polylogue.db import open_connection, upsert_conversation
+
+
+class DummyConsole:
+    def print(self, *_args, **_kwargs):
+        return None
+
+
+class DummyUI:
+    plain = True
+    console = DummyConsole()
+
+
+def test_analytics_cli_json(state_env, capsys):
+    with open_connection(None) as conn:
+        upsert_conversation(
+            conn,
+            provider="codex",
+            conversation_id="conv-1",
+            slug="conv-1",
+            title="One",
+            current_branch="branch-000",
+            root_message_id=None,
+            last_updated="2024-01-01T00:00:00Z",
+            content_hash=None,
+            metadata={},
+        )
+        conn.execute(
+            "INSERT INTO branches(provider, conversation_id, branch_id, parent_branch_id, label, depth, is_current, metadata_json) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            ("codex", "conv-1", "branch-000", None, None, 0, 1, None),
+        )
+        conn.execute(
+            """
+            INSERT INTO messages(
+                provider, conversation_id, branch_id, message_id, parent_id, position, timestamp, role, model,
+                content_hash, content_text, content_json, rendered_text, raw_json, token_count, word_count,
+                attachment_count, attachment_names, is_leaf, metadata_json
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "codex",
+                "conv-1",
+                "branch-000",
+                "m-1",
+                None,
+                0,
+                "2024-01-01T00:00:00Z",
+                "assistant",
+                "gpt-4o",
+                None,
+                "hello",
+                None,
+                "hello",
+                "{}",
+                10,
+                2,
+                0,
+                None,
+                1,
+                None,
+            ),
+        )
+        conn.commit()
+
+    env = CommandEnv(ui=DummyUI())
+    run_analytics_cli(SimpleNamespace(providers=None, model_limit=25, hotspot_limit=25, out=None, theme="light", open=False, json=True), env)
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["providerRows"][0]["provider"] == "codex"
+    assert any(row["role"] == "assistant" for row in payload["roleRows"])
+    assert any(row["model"] == "gpt-4o" for row in payload["modelRows"])
+    assert payload["branchHotspots"][0]["branchCount"] == 1
+
+
+def test_click_browse_analytics_json(state_env):
+    runner = CliRunner()
+    result = runner.invoke(click_cli, ["--plain", "browse", "analytics", "--json"])
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert "providerRows" in payload
+

--- a/tests/test_cli_wrappers.py
+++ b/tests/test_cli_wrappers.py
@@ -60,6 +60,8 @@ def _build_render_args(input_path: Path, out_dir: Path, *, json_mode: bool = Fal
         diff=False,
         to_clipboard=False,
         json=json_mode,
+        disk_estimate=False,
+        max_disk=None,
     )
 
 
@@ -88,6 +90,19 @@ def test_run_render_cli_json_output(tmp_path, capsys):
     assert payload["cmd"] == "render"
     assert payload["count"] == 1
     assert payload["files"][0]["slug"] == "sample"
+
+
+def test_run_render_cli_json_output_includes_disk_estimate(tmp_path, capsys):
+    src = tmp_path / "sample.json"
+    _write_render_input(src)
+    args = _build_render_args(src, tmp_path / "out", json_mode=True)
+    args.disk_estimate = True
+    ui = RecordingUI()
+
+    run_render_cli(args, CommandEnv(ui=ui), json_output=True)
+
+    payload = json.loads(capsys.readouterr().out)
+    assert "diskEstimateBytes" in payload
 
 
 def test_run_render_cli_plain_summary(tmp_path):

--- a/tests/test_delta_diff.py
+++ b/tests/test_delta_diff.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from polylogue.util import write_delta_diff
+
+
+def test_write_delta_diff_uses_delta_output(monkeypatch, tmp_path: Path):
+    old_path = tmp_path / "old.txt"
+    new_path = tmp_path / "new.txt"
+    old_path.write_text("a\n", encoding="utf-8")
+    new_path.write_text("b\n", encoding="utf-8")
+
+    def fake_run(cmd, **_kwargs):  # noqa: ANN001
+        assert cmd[:1] == ["delta"]
+        return SimpleNamespace(returncode=0, stdout="delta\n", stderr="")
+
+    monkeypatch.setattr("polylogue.util.subprocess.run", fake_run)
+
+    diff_path = write_delta_diff(old_path, new_path)
+    assert diff_path is not None
+    assert diff_path.read_text(encoding="utf-8").strip() == "delta"
+
+
+def test_write_delta_diff_falls_back_to_unified_diff(monkeypatch, tmp_path: Path):
+    old_path = tmp_path / "old.txt"
+    new_path = tmp_path / "new.txt"
+    old_path.write_text("hello\n", encoding="utf-8")
+    new_path.write_text("hello world\n", encoding="utf-8")
+
+    def fake_run(_cmd, **_kwargs):  # noqa: ANN001
+        return SimpleNamespace(returncode=1, stdout="", stderr="boom")
+
+    monkeypatch.setattr("polylogue.util.subprocess.run", fake_run)
+
+    diff_path = write_delta_diff(old_path, new_path)
+    assert diff_path is not None
+    body = diff_path.read_text(encoding="utf-8")
+    assert "---" in body
+    assert "+hello world" in body
+

--- a/tests/test_drive_attachments_only.py
+++ b/tests/test_drive_attachments_only.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from polylogue import util
+from polylogue.cli.sync import _run_sync_drive
+from polylogue.commands import CommandEnv
+
+
+class DummyConsole:
+    def print(self, *_args, **_kwargs):
+        return None
+
+
+class DummyUI:
+    plain = True
+
+    def __init__(self):
+        self.console = DummyConsole()
+
+
+def test_sync_drive_attachments_only_retries_failed_items(tmp_path: Path, state_env, monkeypatch):
+    out_dir = tmp_path / "archive"
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    util.add_run(
+        {
+            "cmd": "sync drive",
+            "provider": "drive",
+            "out": str(out_dir),
+            "failedAttachments": [
+                {
+                    "id": "chat-1",
+                    "name": "Chat One",
+                    "slug": "chat-one",
+                    "attachments": [
+                        {"id": "att-1", "filename": "a.txt", "path": "attachments/a.txt"},
+                    ],
+                }
+            ],
+        }
+    )
+    run_id = util.load_runs(limit=1)[0]["id"]
+
+    class StubDrive:
+        def __init__(self):
+            self.ui = DummyUI()
+
+        def attachment_meta(self, file_id):  # noqa: ARG002
+            return {"name": "a.txt", "modifiedTime": "2024-01-01T00:00:00Z"}
+
+        def download_attachment(self, file_id, path: Path) -> bool:  # noqa: ARG002
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text("ok", encoding="utf-8")
+            return True
+
+        def touch_mtime(self, path: Path, _mt):  # noqa: ARG002
+            return None
+
+    captured = []
+    monkeypatch.setattr("polylogue.cli.sync.add_run", lambda payload: captured.append(payload))
+
+    env = CommandEnv(ui=DummyUI())
+    env.drive = StubDrive()
+
+    args = SimpleNamespace(
+        json=False,
+        list_only=False,
+        attachments_only=True,
+        resume_from=run_id,
+        out=None,
+        links_only=False,
+        offline=False,
+        drive_retries=None,
+        drive_retry_base=None,
+        dry_run=False,
+        force=False,
+        folder_name="AI Studio",
+        folder_id=None,
+        since=None,
+        until=None,
+        name_filter=None,
+    )
+    _run_sync_drive(args, env)
+
+    assert (out_dir / "chat-one" / "attachments" / "a.txt").exists()
+    assert captured
+    assert captured[0]["attachmentsOnly"] is True
+    assert captured[0]["attachmentDownloads"] == 1
+

--- a/tests/test_golden_html_snapshots.py
+++ b/tests/test_golden_html_snapshots.py
@@ -76,6 +76,26 @@ def test_golden_chatgpt_basic_html(tmp_path, state_env, monkeypatch):
     _render_slug(db_path, out_dir, slug)
     _assert_golden_html(out_dir / slug / "conversation.md", golden_dir / "chatgpt-basic.html")
 
+def test_golden_chatgpt_tool_html(tmp_path, state_env, monkeypatch):
+    monkeypatch.setenv("POLYLOGUE_FIXED_NOW", FIXED_NOW)
+    fixtures = _repo_root() / "tests" / "fixtures" / "golden"
+    golden_dir = _repo_root() / "tests" / "golden_html"
+    out_dir = tmp_path / "out"
+
+    results = import_chatgpt_export(
+        _rel(fixtures / "chatgpt_tool"),
+        output_dir=out_dir,
+        collapse_threshold=10,
+        html=False,
+        html_theme="light",
+        force=True,
+    )
+    assert results
+    slug = results[0].slug
+    db_path = Path(state_env) / "polylogue.db"
+    _render_slug(db_path, out_dir, slug)
+    _assert_golden_html(out_dir / slug / "conversation.md", golden_dir / "chatgpt-tool.html")
+
 
 def test_golden_claude_basic_html(tmp_path, state_env, monkeypatch):
     monkeypatch.setenv("POLYLOGUE_FIXED_NOW", FIXED_NOW)
@@ -96,6 +116,26 @@ def test_golden_claude_basic_html(tmp_path, state_env, monkeypatch):
     db_path = Path(state_env) / "polylogue.db"
     _render_slug(db_path, out_dir, slug)
     _assert_golden_html(out_dir / slug / "conversation.md", golden_dir / "claude-basic.html")
+
+def test_golden_claude_tool_html(tmp_path, state_env, monkeypatch):
+    monkeypatch.setenv("POLYLOGUE_FIXED_NOW", FIXED_NOW)
+    fixtures = _repo_root() / "tests" / "fixtures" / "golden"
+    golden_dir = _repo_root() / "tests" / "golden_html"
+    out_dir = tmp_path / "out"
+
+    results = import_claude_export(
+        _rel(fixtures / "claude_tool"),
+        output_dir=out_dir,
+        collapse_threshold=10,
+        html=False,
+        html_theme="light",
+        force=True,
+    )
+    assert results
+    slug = results[0].slug
+    db_path = Path(state_env) / "polylogue.db"
+    _render_slug(db_path, out_dir, slug)
+    _assert_golden_html(out_dir / slug / "conversation.md", golden_dir / "claude-tool.html")
 
 
 def test_golden_codex_basic_html(tmp_path, state_env, monkeypatch):
@@ -137,4 +177,3 @@ def test_golden_claude_code_basic_html(tmp_path, state_env, monkeypatch):
     db_path = Path(state_env) / "polylogue.db"
     _render_slug(db_path, out_dir, slug)
     _assert_golden_html(out_dir / slug / "conversation.md", golden_dir / "claude-code-basic.html")
-

--- a/tests/test_golden_snapshots.py
+++ b/tests/test_golden_snapshots.py
@@ -69,6 +69,26 @@ def test_golden_chatgpt_basic(tmp_path, state_env, monkeypatch):
     _render_slug(db_path, out_dir, slug)
     _assert_golden(out_dir / slug / "conversation.md", golden_dir / "chatgpt-basic.md")
 
+def test_golden_chatgpt_tool(tmp_path, state_env, monkeypatch):
+    monkeypatch.setenv("POLYLOGUE_FIXED_NOW", FIXED_NOW)
+    fixtures = _repo_root() / "tests" / "fixtures" / "golden"
+    golden_dir = _repo_root() / "tests" / "golden"
+    out_dir = tmp_path / "out"
+
+    results = import_chatgpt_export(
+        _rel(fixtures / "chatgpt_tool"),
+        output_dir=out_dir,
+        collapse_threshold=10,
+        html=False,
+        html_theme="light",
+        force=True,
+    )
+    assert results
+    slug = results[0].slug
+    db_path = Path(state_env) / "polylogue.db"
+    _render_slug(db_path, out_dir, slug)
+    _assert_golden(out_dir / slug / "conversation.md", golden_dir / "chatgpt-tool.md")
+
 
 def test_golden_claude_basic(tmp_path, state_env, monkeypatch):
     monkeypatch.setenv("POLYLOGUE_FIXED_NOW", FIXED_NOW)
@@ -89,6 +109,26 @@ def test_golden_claude_basic(tmp_path, state_env, monkeypatch):
     db_path = Path(state_env) / "polylogue.db"
     _render_slug(db_path, out_dir, slug)
     _assert_golden(out_dir / slug / "conversation.md", golden_dir / "claude-basic.md")
+
+def test_golden_claude_tool(tmp_path, state_env, monkeypatch):
+    monkeypatch.setenv("POLYLOGUE_FIXED_NOW", FIXED_NOW)
+    fixtures = _repo_root() / "tests" / "fixtures" / "golden"
+    golden_dir = _repo_root() / "tests" / "golden"
+    out_dir = tmp_path / "out"
+
+    results = import_claude_export(
+        _rel(fixtures / "claude_tool"),
+        output_dir=out_dir,
+        collapse_threshold=10,
+        html=False,
+        html_theme="light",
+        force=True,
+    )
+    assert results
+    slug = results[0].slug
+    db_path = Path(state_env) / "polylogue.db"
+    _render_slug(db_path, out_dir, slug)
+    _assert_golden(out_dir / slug / "conversation.md", golden_dir / "claude-tool.md")
 
 
 def test_golden_codex_basic(tmp_path, state_env, monkeypatch):

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -52,6 +52,23 @@ def test_render_html_metadata_escaped(tmp_path: Path):
     assert "&lt;script&gt;alert(&#39;x&#39;)&lt;/script&gt;" in output
 
 
+def test_render_html_uses_local_attachment_paths_and_previews(tmp_path: Path):
+    local_img = tmp_path / "attachments" / "image.png"
+    local_img.parent.mkdir(parents=True, exist_ok=True)
+    local_img.write_bytes(b"\x89PNG\r\n\x1a\n")
+    doc = MarkdownDocument(
+        body="Just text",
+        metadata={"title": "Safe"},
+        attachments=[AttachmentInfo(name="image.png", link="http://example.com/remote", local_path=local_img, size_bytes=9, remote=False)],
+        stats={},
+    )
+    output = render_html(doc, HtmlRenderOptions())
+    assert "http://example.com/remote" not in output
+    assert "image.png" in output
+    assert "<img" in output
+    assert "attachments/image.png" in output
+
+
 def test_branch_html_escapes_untrusted_content(tmp_path: Path):
     branch_path = Path("branch file.md")
     node = BranchNodeSummary(

--- a/tests/test_interactive_harness.py
+++ b/tests/test_interactive_harness.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import os
+import stat
+import sys
+from pathlib import Path
+
+import pexpect
+
+
+def _write_executable(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def _make_interactive_stubs(tmp_path: Path) -> Path:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(parents=True, exist_ok=True)
+
+    _write_executable(
+        bin_dir / "gum",
+        """#!/usr/bin/env python3
+import os
+import sys
+
+def _log(argv):
+    log_path = os.environ.get("POLYLOGUE_TEST_CMD_LOG")
+    if not log_path:
+        return
+    with open(log_path, "a", encoding="utf-8") as fh:
+        fh.write("gum " + " ".join(argv[1:]) + "\\n")
+
+def main():
+    _log(sys.argv)
+    if len(sys.argv) < 2:
+        sys.exit(1)
+    sub = sys.argv[1]
+    if sub == "format":
+        sys.stdout.write(sys.stdin.read())
+        return
+    if sub == "confirm":
+        # Heuristic: treat --default as "yes", otherwise "no".
+        sys.exit(0 if "--default" in sys.argv else 1)
+    if sub == "input":
+        out = ""
+        if "--value" in sys.argv:
+            idx = sys.argv.index("--value")
+            if idx + 1 < len(sys.argv):
+                out = sys.argv[idx + 1]
+        sys.stdout.write(out + "\\n")
+        return
+    sys.exit(0)
+
+if __name__ == "__main__":
+    main()
+""",
+    )
+
+    _write_executable(
+        bin_dir / "sk",
+        """#!/usr/bin/env python3
+import os
+import sys
+
+def _log(argv):
+    log_path = os.environ.get("POLYLOGUE_TEST_CMD_LOG")
+    if not log_path:
+        return
+    with open(log_path, "a", encoding="utf-8") as fh:
+        fh.write("sk " + " ".join(argv[1:]) + "\\n")
+
+def main():
+    _log(sys.argv)
+    if os.environ.get("POLYLOGUE_TEST_SK_CANCEL") in {"1", "true", "yes", "on"}:
+        sys.exit(130)
+    forced = os.environ.get("POLYLOGUE_TEST_SK_CHOICE")
+    if forced is not None:
+        sys.stdout.write(forced + "\\n")
+        return
+    options = [line for line in sys.stdin.read().splitlines() if line.strip()]
+    sys.stdout.write((options[0] if options else "") + "\\n")
+
+if __name__ == "__main__":
+    main()
+""",
+    )
+
+    passthrough = """#!/usr/bin/env python3
+import os
+import sys
+
+log_path = os.environ.get("POLYLOGUE_TEST_CMD_LOG")
+if log_path:
+    with open(log_path, "a", encoding="utf-8") as fh:
+        fh.write(os.path.basename(sys.argv[0]) + " " + " ".join(sys.argv[1:]) + "\\n")
+sys.stdout.write(sys.stdin.read())
+"""
+    for name in ("bat", "glow", "delta"):
+        _write_executable(bin_dir / name, passthrough)
+
+    return bin_dir
+
+
+def _spawn_polylogue(args: list[str], *, cwd: Path, env: dict[str, str]):
+    cmd = [sys.executable, str(cwd / "polylogue.py"), *args]
+    child = pexpect.spawn(cmd[0], cmd[1:], cwd=str(cwd), env=env, encoding="utf-8", timeout=30)
+    return child
+
+
+def test_interactive_config_init_runs_under_pty(tmp_path: Path):
+    repo_root = Path(__file__).resolve().parents[1]
+    stub_bin = _make_interactive_stubs(tmp_path)
+    log_path = tmp_path / "cmd.log"
+
+    env = os.environ.copy()
+    env["PATH"] = f"{stub_bin}{os.pathsep}{env.get('PATH', '')}"
+    env["XDG_CONFIG_HOME"] = str(tmp_path / "config")
+    env["XDG_DATA_HOME"] = str(tmp_path / "data")
+    env["XDG_CACHE_HOME"] = str(tmp_path / "cache")
+    env["XDG_STATE_HOME"] = str(tmp_path / "state")
+    env["POLYLOGUE_TEST_CMD_LOG"] = str(log_path)
+
+    child = _spawn_polylogue(["config", "init", "--force"], cwd=repo_root, env=env)
+    child.expect("Next steps", timeout=30)
+    child.expect(pexpect.EOF)
+    child.close()
+    assert child.exitstatus == 0
+
+    config_home = Path(env["XDG_CONFIG_HOME"]) / "polylogue"
+    assert (config_home / "settings.json").exists()
+    assert (config_home / "config.json").exists()
+
+    log = log_path.read_text(encoding="utf-8")
+    assert "gum input" in log
+    assert "gum confirm" in log
+    assert "sk --prompt" in log
+
+
+def test_interactive_config_init_cancelled_when_config_exists(tmp_path: Path):
+    repo_root = Path(__file__).resolve().parents[1]
+    stub_bin = _make_interactive_stubs(tmp_path)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{stub_bin}{os.pathsep}{env.get('PATH', '')}"
+    env["XDG_CONFIG_HOME"] = str(tmp_path / "config")
+    env["XDG_DATA_HOME"] = str(tmp_path / "data")
+    env["XDG_CACHE_HOME"] = str(tmp_path / "cache")
+    env["XDG_STATE_HOME"] = str(tmp_path / "state")
+
+    # Seed config via a forced init run.
+    first = _spawn_polylogue(["config", "init", "--force"], cwd=repo_root, env=env)
+    first.expect("Next steps", timeout=30)
+    first.expect(pexpect.EOF)
+    first.close()
+    assert first.exitstatus == 0
+
+    # Second run should prompt and then cancel (gum confirm default is "no").
+    second = _spawn_polylogue(["config", "init"], cwd=repo_root, env=env)
+    second.expect("Init cancelled", timeout=30)
+    second.expect(pexpect.EOF)
+    second.close()
+    assert second.exitstatus == 0

--- a/tests/test_resume_from.py
+++ b/tests/test_resume_from.py
@@ -37,6 +37,27 @@ def test_resume_from_drive_selects_failed_chat_ids(state_env):
     assert args.resume_from == run_id
 
 
+def test_resume_from_drive_includes_failed_attachments(state_env):
+    util.add_run(
+        {
+            "cmd": "sync drive",
+            "provider": "drive",
+            "failedAttachments": [
+                {"id": "abc", "name": "A", "attachments": ["file-1"]},
+                {"id": "def", "name": "B", "attachments": ["file-2", "file-3"]},
+            ],
+        }
+    )
+    run_id = util.load_runs(limit=1)[0]["id"]
+    env = CommandEnv(ui=DummyUI())
+    args = SimpleNamespace(provider="drive", chat_ids=None, sessions=None, all=False, prune=True, resume_from=None)
+    _apply_resume_from(args, env, run_id=run_id)
+    assert args.chat_ids == ["abc", "def"]
+    assert args.all is True
+    assert args.prune is False
+    assert args.resume_from == run_id
+
+
 def test_resume_from_local_selects_failed_paths(state_env):
     util.add_run(
         {
@@ -53,4 +74,3 @@ def test_resume_from_local_selects_failed_paths(state_env):
     assert args.all is True
     assert args.prune is False
     assert args.resume_from == run_id
-

--- a/tests/test_search_open.py
+++ b/tests/test_search_open.py
@@ -1,6 +1,13 @@
-from pathlib import Path
+from __future__ import annotations
 
-from polylogue.cli.search_cli import find_anchor_line
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from polylogue.cli.search_cli import _open_single_search_hit, find_anchor_line, run_search_cli
+from polylogue.commands import CommandEnv
+from polylogue.options import SearchHit, SearchResult
 
 
 def test_find_anchor_line(tmp_path: Path) -> None:
@@ -16,3 +23,110 @@ body
     assert find_anchor_line(target, "msg-2") == 2
     assert find_anchor_line(target, "#msg-2") == 2
     assert find_anchor_line(target, "msg-99") is None
+
+
+class _RecordingConsole:
+    def __init__(self) -> None:
+        self.lines: list[str] = []
+
+    def print(self, *args: object, **_kwargs: object) -> None:
+        self.lines.append(" ".join(str(a) for a in args))
+
+
+class _RecordingUI:
+    plain = True
+
+    def __init__(self) -> None:
+        self.console = _RecordingConsole()
+
+
+def _hit_for_path(path: Path, *, kind: str = "message", position: int = 2) -> SearchHit:
+    return SearchHit(
+        provider="codex",
+        conversation_id="c1",
+        slug="slug",
+        title="Title",
+        branch_id="main",
+        message_id="m1",
+        position=position,
+        timestamp="2024-01-01T00:00:00Z",
+        attachment_count=0,
+        score=0.5,
+        snippet="snippet",
+        body="body",
+        conversation_path=path,
+        branch_path=None,
+        model="model",
+        kind=kind,
+    )
+
+
+def test_open_single_search_hit_opens_html_in_browser(monkeypatch, tmp_path: Path) -> None:
+    target = tmp_path / "conversation.html"
+    target.write_text("<!doctype html><html></html>", encoding="utf-8")
+    ui = _RecordingUI()
+    hit = _hit_for_path(target)
+
+    opened: list[str] = []
+
+    monkeypatch.setattr("polylogue.cli.search_cli.webbrowser.open", lambda url: opened.append(url) or True)
+    monkeypatch.setattr("polylogue.cli.search_cli.open_in_editor", lambda *_a, **_k: pytest.fail("open_in_editor should not be called"))
+
+    _open_single_search_hit(ui, hit)
+
+    assert opened and opened[0].endswith("#msg-2")
+
+
+def test_open_single_search_hit_opens_markdown_in_editor(monkeypatch, tmp_path: Path) -> None:
+    target = tmp_path / "conversation.md"
+    target.write_text('line-one\n<a id="msg-2"></a>\nbody\n', encoding="utf-8")
+    ui = _RecordingUI()
+    hit = _hit_for_path(target)
+
+    called: dict[str, object] = {}
+
+    def fake_open_in_editor(path: Path, *, line=None):  # noqa: ANN001
+        called["path"] = path
+        called["line"] = line
+        return True
+
+    monkeypatch.setattr("polylogue.cli.search_cli.open_in_editor", fake_open_in_editor)
+    monkeypatch.setattr("polylogue.cli.search_cli.webbrowser.open", lambda *_a, **_k: pytest.fail("webbrowser.open should not be called"))
+
+    _open_single_search_hit(ui, hit)
+
+    assert called["path"] == target
+    assert called["line"] == 2
+
+
+def test_search_csv_stdout(monkeypatch, capsys) -> None:
+    hit = _hit_for_path(Path("/tmp/conversation.md"))
+    args = SimpleNamespace(
+        query="hello",
+        from_stdin=False,
+        limit=20,
+        provider=None,
+        slug=None,
+        conversation_id=None,
+        branch=None,
+        model=None,
+        since=None,
+        until=None,
+        with_attachments=False,
+        without_attachments=False,
+        in_attachments=False,
+        attachment_name=None,
+        fields="",
+        csv="-",
+        json=False,
+        json_lines=False,
+        no_picker=True,
+        open=False,
+    )
+
+    monkeypatch.setattr("polylogue.cli.search_cli.search_command", lambda *_a, **_k: SearchResult(hits=[hit]))
+
+    run_search_cli(args, CommandEnv(ui=_RecordingUI()))
+
+    out = capsys.readouterr().out
+    assert out.splitlines()[0].startswith("provider,conversationId")

--- a/tests/test_timeline_cli.py
+++ b/tests/test_timeline_cli.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+from click.testing import CliRunner
+
+from polylogue.cli.click_app import cli as click_cli
+from polylogue.cli.timeline import run_timeline_cli
+from polylogue.commands import CommandEnv
+from polylogue.db import open_connection, upsert_conversation
+
+
+class DummyConsole:
+    def __init__(self):
+        self.lines = []
+
+    def print(self, *args, **kwargs):  # noqa: ANN001, ARG002
+        self.lines.append(" ".join(str(a) for a in args))
+
+
+class DummyUI:
+    plain = True
+
+    def __init__(self):
+        self.console = DummyConsole()
+
+
+def test_timeline_cli_json(state_env, capsys):
+    with open_connection(None) as conn:
+        upsert_conversation(
+            conn,
+            provider="codex",
+            conversation_id="conv-1",
+            slug="conv-1",
+            title="One",
+            current_branch=None,
+            root_message_id=None,
+            last_updated="2024-01-01T00:00:00Z",
+            content_hash=None,
+            metadata={"token_count": 12, "word_count": 3, "attachments": 1, "attachment_bytes": 2048},
+        )
+        conn.commit()
+    env = CommandEnv(ui=DummyUI())
+    run_timeline_cli(SimpleNamespace(providers=None, limit=10, out=None, theme="light", open=False, json=True), env)
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["count"] == 1
+    assert payload["rows"][0]["provider"] == "codex"
+    assert payload["rows"][0]["tokens"] == 12
+
+
+def test_click_browse_timeline_json(state_env):
+    runner = CliRunner()
+    result = runner.invoke(click_cli, ["--plain", "browse", "timeline", "--json"])
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert "rows" in payload
+


### PR DESCRIPTION
## Summary

I expanded the test suite around the workflows that were still mostly “trust me” paths: partial attachment failures, interactive sync/config flows, HTML transcript rendering, and repeated imports of large ChatGPT / Claude exports. To make those behaviors testable, I also changed the production code in a few targeted places: attachment failures now carry partial results without exploding the pipeline, Drive sync can retry only failed attachments from a previous run, bulk export imports can skip unchanged conversations based on both raw bytes and render configuration, and the HTML/browse surfaces expose richer archive-wide views. The through-line is that I wanted the archive to be resilient under imperfect real-world inputs and to have automated coverage for the recovery path, not just the happy path. The branch also pays down a couple of correctness bugs that the new coverage made obvious, including the misplaced sync JSON block and the watch debounce/stall ordering issue. The result is a suite that exercises the operator workflows that were previously most likely to break silently.

## Motivation

Before this branch, the suite had good coverage for simple render and sync behavior, but it still had blind spots exactly where the archive is most operationally interesting.

**Attachment failure handling** was the biggest one. A failed Drive attachment download could collapse the whole render stage, which is the wrong failure mode for an archival tool. Losing one image or file reference should not prevent the rest of the conversation from being written and indexed.

**Interactive flows** were another gap. `config init` and interactive provider/session selection were still largely untested, which meant a regression in the prompt path or subprocess handling would not show up until a human tried it.

**Bulk export re-imports** were wasting time. ChatGPT and Claude bundle imports could be huge, but if the raw export bytes and render settings were unchanged, we still had to pay the parse/render cost because the importer had no reusable sync state keyed to render config.

**HTML output** also lagged behind the rest of the archive. Attachments were hard to scan, image-heavy transcripts were clumsy to inspect, and the sidebar/anchor behavior was noisy enough that HTML snapshots were less stable than they needed to be.

I treated those as one branch because the testing work kept uncovering small structural changes that were necessary to express the right behavior in the product code.

## Changes by concern

### 1. Let attachment failures degrade instead of aborting

The key production change is the move from a generic runtime failure to an explicit `AttachmentDownloadError` shape. That matters because the pipeline can distinguish:

- the conversation body, which is still renderable
- the successfully recovered attachments / links
- the failed attachment subset, which should be reported and retried later

`RenderDocumentStage` catches the partial-failure form and continues with the usable results. `sync_command` then records the failed items in run metadata as `failedAttachments`, including identifiers and error text, without collapsing the whole run into a generic failure.

That richer run metadata is what makes `--attachments-only` viable. Rather than re-rendering a whole conversation just to retry a couple of files, the next run can target the failed attachment subset directly.

This is the kind of change I wanted the tests to force: the pipeline should preserve as much archive value as possible even when the network or upstream data is imperfect.

### 2. Add archive-wide browse views that are snapshot-friendly

The new `timeline` and `analytics` browse commands are not just UI garnish. They provide structured archive-level views that make it much easier to reason about large datasets in tests and during manual inspection.

- `timeline` gives a sortable conversation list with recency, token, word, and attachment stats
- `analytics` summarizes provider/model/role/branch hotspots from SQLite
- both have JSON output for assertions and themed HTML for manual inspection

I paired those with improvements in `polylogue/html.py` because the HTML transcript view was the other obvious archive-inspection surface. The attachment cards, previews, filter input, lightbox, and anchor fixes make the rendered transcript usable for transcripts that mix text and media instead of treating attachments as an afterthought.

The stability work in HTML is just as important as the new UI. Sorting the attachment sidebar and stripping HTML noise out of generated anchors keeps HTML snapshots meaningful instead of brittle.

### 3. Skip unchanged bulk-export conversations

The import skip logic uses more than raw input bytes. I added a render-config hash covering the knobs that materially affect the rendered output:

- collapse threshold
- HTML mode/theme
- OCR setting
- sanitize/redaction setting

A conversation is only skipped when all three conditions hold:

1. raw content hash matches
2. render-config hash matches
3. expected output files already exist

That is a stronger and more correct condition than “same source bytes” alone. If the operator changes HTML mode or OCR, the conversation should re-render even if the underlying export JSON did not move.

Stripped path-dependent metadata keys out of content-hash inputs in `document_store.py`, because archive relocation should not invalidate content identity. That change helps both the import skip logic and the snapshot story.

### 4. Put the interactive path under PTY coverage

The PTY harness uses stub `gum`, `sk`, `bat`, and `delta` binaries so the tests can exercise real CLI control flow without depending on a full external environment. I used that harness to cover:

- `config init`
- interactive sync for Codex / ChatGPT / Claude / Claude Code
- cancel paths as well as success paths

This is intentionally closer to the user experience than a unit test over a helper function. The bugs I wanted to catch live at the boundary between CLI parsing, prompt selection, environment setup, and filesystem effects.

### 5. Fix the small bugs the new tests exposed

Two production bugs were worth fixing immediately because the new coverage surfaced them clearly.

The sync JSON success block was indented under an exception branch, so successful runs could not emit the JSON payload that callers expected.

The watch stall logic checked debounce before stall detection, which meant a rapid event stream could keep deferring the stall warning forever. Swapping that order makes `--fail-on-stall` meaningful even during noisy input bursts.

Split disk estimation into a standalone `--disk-estimate` preflight instead of making it an accidental side effect of `--max-disk`.

## Testing

This branch is deliberately test-heavy. The most important additions are:

- golden tool-use + attachment fixtures for ChatGPT and Claude, including HTML
- PTY interactive coverage for config init and sync flows
- attachment failure tracking and attachment-only retry tests
- import-skip coverage for unchanged raw bytes plus unchanged render config
- watch stall tests that specifically assert the debounce-ordering fix
- search output tests for `--open` and `--csv`
- analytics / timeline JSON path tests

That combination gives us much better confidence in both operator-facing flows and the recovery story around them.

## Notes

Kept the attachment-retry flow targeted at Drive because that is where the failure mode is most acute and where the run metadata already had the right granularity to make a focused rerun useful. The PTY harness also remains intentionally pragmatic rather than pretty; the goal is to exercise the real CLI boundary with enough fidelity to catch regressions, not to build a second interactive framework inside the tests.
