### PR TITLE
feat: resolve Drive settings from config and stream export detection

### DIFF
--- a/docs/providers/claude-code.md
+++ b/docs/providers/claude-code.md
@@ -1,6 +1,6 @@
 # Claude Code Session Imports
 
-Claude Code stores IDE transcripts beneath `~/.claude/projects/`. Polylogue mirrors those JSONL streams into Markdown while preserving workspace context, shell snapshots, and tool outputs.
+Claude Code stores IDE transcripts beneath `~/.claude/projects/` (or `~/.config/claude/projects/` on some systems). Set `POLYLOGUE_CLAUDE_CODE_PROJECTS` if you need to override the default. Polylogue mirrors those JSONL streams into Markdown while preserving workspace context, shell snapshots, and tool outputs.
 
 ## Project Layout
 

--- a/polylogue/cli/attachments.py
+++ b/polylogue/cli/attachments.py
@@ -9,7 +9,7 @@ from types import SimpleNamespace
 from typing import Dict, List, Optional, Set, Tuple
 
 from ..commands import CommandEnv
-from .context import DEFAULT_OUTPUT_ROOTS
+from .context import resolve_output_roots
 from ..schema import stamp_payload
 from ..util import parse_input_time_to_epoch
 
@@ -65,11 +65,11 @@ def _iter_attachment_files(root: Path) -> List[Path]:
     return files
 
 
-def _collect_roots(args_dir) -> List[Path]:
+def _collect_roots(args_dir, env: CommandEnv) -> List[Path]:
     if args_dir:
         root = Path(args_dir).expanduser()
         return [root]
-    return [path for path in DEFAULT_OUTPUT_ROOTS if path.exists()]
+    return [path for path in resolve_output_roots(env.config) if path.exists()]
 
 
 def run_attachments_cli(args: SimpleNamespace, env: CommandEnv) -> None:
@@ -102,7 +102,7 @@ def _run_attachment_stats(args: SimpleNamespace, env: CommandEnv) -> None:
 
     orphan_summary: Dict[str, object] = {"requested": clean_orphans, "count": 0, "removed": 0, "bytes": 0, "errors": 0}
     if clean_orphans:
-        roots = _collect_roots(getattr(args, "dir", None))
+        roots = _collect_roots(getattr(args, "dir", None), env)
         if not roots:
             ui.console.print("[red]No output roots found for orphan cleanup.")
             raise SystemExit(1)

--- a/polylogue/cli/click_app.py
+++ b/polylogue/cli/click_app.py
@@ -610,6 +610,8 @@ def doctor() -> None:
 @click.option("--codex-dir", type=click.Path(path_type=Path), help="Override Codex sessions directory")
 @click.option("--claude-code-dir", type=click.Path(path_type=Path), help="Override Claude Code projects directory")
 @click.option("--limit", type=int, help="Limit number of files inspected per provider")
+@click.option("--skip-index", is_flag=True, help="Skip SQLite index validation (can speed up large archives)")
+@click.option("--skip-qdrant", is_flag=True, help="Skip Qdrant validation even when configured")
 @click.option("--json", is_flag=True, help="Emit machine-readable report")
 @click.option("--json-verbose", is_flag=True, help="Emit JSON with verbose details")
 @click.pass_obj

--- a/polylogue/cli/click_app.py
+++ b/polylogue/cli/click_app.py
@@ -39,7 +39,9 @@ from .env_cli import run_env_cli
 
 
 def _build_env(plain: bool) -> CommandEnv:
-    return CommandEnv(ui=create_ui(plain))
+    env = CommandEnv(ui=create_ui(plain))
+    env.prefs = prefs_cmd.load_prefs()
+    return env
 
 _FORCE_PLAIN_VALUES = {"1", "true", "yes", "on"}
 _PLAIN_REASON_FLAG = "requested via --plain"

--- a/polylogue/cli/config_cli.py
+++ b/polylogue/cli/config_cli.py
@@ -28,6 +28,10 @@ def run_config_show(args: object, env: CommandEnv) -> None:
 
     if getattr(args, "json", False):
         roots_map = getattr(env.config.defaults, "roots", {}) or {}
+        roots_payload = {
+            label: {key: str(value) for key, value in vars(paths).items()}
+            for label, paths in roots_map.items()
+        }
         payload = stamp_payload(
             {
                 "configPath": str(CONFIG_PATH) if CONFIG_PATH else None,
@@ -55,7 +59,7 @@ def run_config_show(args: object, env: CommandEnv) -> None:
                     "claude_code": str(defaults.output_dirs.sync_claude_code),
                     "chatgpt": str(defaults.output_dirs.import_chatgpt),
                     "claude": str(defaults.output_dirs.import_claude),
-                    "roots": {label: vars(paths) for label, paths in roots_map.items()},
+                    "roots": roots_payload,
                 },
                 "inputs": {
                     "chatgpt": str(exports.chatgpt),

--- a/polylogue/cli/config_cli.py
+++ b/polylogue/cli/config_cli.py
@@ -8,14 +8,16 @@ from ..commands import CommandEnv
 
 def run_config_show(args: object, env: CommandEnv) -> None:
     """Show current configuration (combines env + settings)."""
-    from ..config import CONFIG, CONFIG_PATH, DEFAULT_CREDENTIALS, DEFAULT_TOKEN
+    from ..config import CONFIG_PATH, DEFAULT_CREDENTIALS, DEFAULT_TOKEN
     from ..config import is_config_declarative
     from ..schema import stamp_payload
     from ..settings import SETTINGS_PATH
 
     ui = env.ui
     settings = env.settings
-    defaults = CONFIG.defaults
+    defaults = env.config.defaults
+    exports = env.config.exports
+    index_cfg = env.config.index
     declarative, decl_reason, decl_target = is_config_declarative(CONFIG_PATH)
 
     credential_env = os.environ.get("POLYLOGUE_CREDENTIAL_PATH")
@@ -56,16 +58,16 @@ def run_config_show(args: object, env: CommandEnv) -> None:
                     "roots": {label: vars(paths) for label, paths in roots_map.items()},
                 },
                 "inputs": {
-                    "chatgpt": str(CONFIG.exports.chatgpt),
-                    "claude": str(CONFIG.exports.claude),
+                    "chatgpt": str(exports.chatgpt),
+                    "claude": str(exports.claude),
                 },
                 "index": {
-                    "backend": CONFIG.index.backend if CONFIG.index else "sqlite",
+                    "backend": index_cfg.backend if index_cfg else "sqlite",
                     "qdrant": {
-                        "url": CONFIG.index.qdrant_url if CONFIG.index else None,
-                        "api_key": CONFIG.index.qdrant_api_key if CONFIG.index else None,
-                        "collection": CONFIG.index.qdrant_collection if CONFIG.index else None,
-                        "vector_size": CONFIG.index.qdrant_vector_size if CONFIG.index else None,
+                        "url": index_cfg.qdrant_url if index_cfg else None,
+                        "api_key": index_cfg.qdrant_api_key if index_cfg else None,
+                        "collection": index_cfg.qdrant_collection if index_cfg else None,
+                        "vector_size": index_cfg.qdrant_vector_size if index_cfg else None,
                     },
                 },
                 "statePath": str(env.conversations.state_path),

--- a/polylogue/cli/config_cli.py
+++ b/polylogue/cli/config_cli.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+from pathlib import Path
 
 from ..commands import CommandEnv
 
@@ -23,8 +24,16 @@ def run_config_show(args: object, env: CommandEnv) -> None:
     credential_env = os.environ.get("POLYLOGUE_CREDENTIAL_PATH")
     token_env = os.environ.get("POLYLOGUE_TOKEN_PATH")
     drive_cfg = getattr(env, "config", None).drive if hasattr(env, "config") else None
-    credential_path = drive_cfg.credentials_path if drive_cfg else DEFAULT_CREDENTIALS
-    token_path = drive_cfg.token_path if drive_cfg else DEFAULT_TOKEN
+    credential_path = (
+        Path(credential_env).expanduser()
+        if credential_env
+        else (drive_cfg.credentials_path if drive_cfg else DEFAULT_CREDENTIALS)
+    )
+    token_path = (
+        Path(token_env).expanduser()
+        if token_env
+        else (drive_cfg.token_path if drive_cfg else DEFAULT_TOKEN)
+    )
 
     if getattr(args, "json", False):
         roots_map = getattr(env.config.defaults, "roots", {}) or {}

--- a/polylogue/cli/config_cli.py
+++ b/polylogue/cli/config_cli.py
@@ -125,7 +125,11 @@ def run_config_show(args: object, env: CommandEnv) -> None:
     if roots_map:
         summary_lines.append("  labeled roots:")
         for label, paths in roots_map.items():
-            summary_lines.append(f"    {label}: render={paths.render} codex={paths.sync_codex}")
+            summary_lines.append(
+                "    "
+                f"{label}: render={paths.render} gemini={paths.sync_drive} codex={paths.sync_codex} "
+                f"claude-code={paths.sync_claude_code} chatgpt={paths.import_chatgpt} claude={paths.import_claude}"
+            )
     summary_lines.extend(
         [
             "",

--- a/polylogue/cli/config_editor.py
+++ b/polylogue/cli/config_editor.py
@@ -35,6 +35,7 @@ def _persist_all(env: CommandEnv) -> None:
         html_theme=settings.html_theme,
         index=config_obj.index,
         roots=config_obj.defaults.roots if getattr(config_obj.defaults, "roots", None) else None,
+        drive=config_obj.drive if hasattr(config_obj, "drive") else None,
         path=CONFIG_PATH,
     )
 

--- a/polylogue/cli/context.py
+++ b/polylogue/cli/context.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import Dict, Optional, Sequence, Tuple
 
-from ..config import CONFIG
+from ..config import CONFIG, Config
 from ..settings import SETTINGS, Settings, ensure_settings_defaults
 from ..drive_client import DEFAULT_FOLDER_NAME
 
@@ -91,12 +91,15 @@ def _collect_output_dirs(dirs) -> list[Path]:
     ]
 
 
-_base_output_dirs = _collect_output_dirs(CONFIG.defaults.output_dirs)
-_labeled_output_dirs: list[Path] = []
-for paths in getattr(CONFIG.defaults, "roots", {}).values():
-    _labeled_output_dirs.extend(_collect_output_dirs(paths))
+def resolve_output_roots(config: Optional[Config] = None) -> list[Path]:
+    active = config or CONFIG
+    roots = list(_collect_output_dirs(active.defaults.output_dirs))
+    for paths in getattr(active.defaults, "roots", {}).values():
+        roots.extend(_collect_output_dirs(paths))
+    return list(dict.fromkeys(roots))
 
-DEFAULT_OUTPUT_ROOTS = list(dict.fromkeys(_base_output_dirs + _labeled_output_dirs))
+
+DEFAULT_OUTPUT_ROOTS = resolve_output_roots()
 
 
 ensure_settings_defaults()

--- a/polylogue/cli/env_cli.py
+++ b/polylogue/cli/env_cli.py
@@ -35,8 +35,17 @@ def run_env_cli(args: SimpleNamespace, env: CommandEnv) -> None:
     credential_env = os.environ.get("POLYLOGUE_CREDENTIAL_PATH")
     token_env = os.environ.get("POLYLOGUE_TOKEN_PATH")
 
-    credential_path = Path(credential_env).expanduser() if credential_env else DEFAULT_CREDENTIALS
-    token_path = Path(token_env).expanduser() if token_env else DEFAULT_TOKEN
+    drive_cfg = getattr(env.config, "drive", None)
+    credential_path = (
+        Path(credential_env).expanduser()
+        if credential_env
+        else (drive_cfg.credentials_path if drive_cfg else DEFAULT_CREDENTIALS)
+    )
+    token_path = (
+        Path(token_env).expanduser()
+        if token_env
+        else (drive_cfg.token_path if drive_cfg else DEFAULT_TOKEN)
+    )
 
     checks.append(_path_status(paths_module.CONFIG_HOME, required=True, label="Config home"))
     checks.append(_path_status(paths_module.DATA_HOME, required=True, label="Data home"))

--- a/polylogue/cli/env_cli.py
+++ b/polylogue/cli/env_cli.py
@@ -63,14 +63,19 @@ def run_env_cli(args: SimpleNamespace, env: CommandEnv) -> None:
     if cfg_path.exists():
         try:
             cfg_raw: Dict[str, Any] = json.loads(cfg_path.read_text(encoding="utf-8"))
-            allowed_top = {"defaults", "index", "exports", "drive"}
+            allowed_top = {"paths", "ui", "defaults", "index", "exports", "drive"}
             extra_keys = sorted(set(cfg_raw.keys()) - allowed_top)
             if extra_keys:
                 drift_warnings.append(f"config contains unknown keys: {', '.join(extra_keys)}")
-            defaults = cfg_raw.get("defaults") or {}
+            defaults = cfg_raw.get("defaults") or cfg_raw.get("ui") or {}
+            paths = cfg_raw.get("paths") or {}
+            roots = {}
             if isinstance(defaults, dict):
-                if "roots" in defaults and not isinstance(defaults.get("roots"), dict):
-                    drift_warnings.append("defaults.roots should be a mapping of labels to output paths")
+                roots = defaults.get("roots") or roots
+            if isinstance(paths, dict):
+                roots = paths.get("roots") or roots
+            if roots and not isinstance(roots, dict):
+                drift_warnings.append("roots should be a mapping of labels to output paths")
         except Exception as exc:
             drift_warnings.append(f"config parse failed: {exc}")
 

--- a/polylogue/cli/inbox.py
+++ b/polylogue/cli/inbox.py
@@ -12,7 +12,6 @@ from types import SimpleNamespace
 from typing import Dict, List, Optional, Tuple
 
 from ..commands import CommandEnv
-from ..config import CONFIG
 from ..local_sync import _detect_export_provider
 from ..schema import stamp_payload
 
@@ -153,8 +152,8 @@ def run_inbox_cli(args: SimpleNamespace, env: CommandEnv) -> None:
     if override_root:
         roots.append((None, Path(override_root).expanduser()))
     else:
-        roots.append(("chatgpt", CONFIG.exports.chatgpt))
-        roots.append(("claude", CONFIG.exports.claude))
+        roots.append(("chatgpt", env.config.exports.chatgpt))
+        roots.append(("claude", env.config.exports.claude))
 
     entries: List[Dict[str, object]] = []
     quarantined: List[str] = []

--- a/polylogue/cli/init.py
+++ b/polylogue/cli/init.py
@@ -7,8 +7,7 @@ from types import SimpleNamespace
 from typing import Optional
 
 from ..settings import Settings, persist_settings, SETTINGS_PATH
-from ..commands import CommandEnv
-from ..drive_client import DriveClient
+from ..commands import CommandEnv, build_drive_client
 from ..config import persist_config, IndexConfig, is_config_declarative
 
 
@@ -175,7 +174,7 @@ def run_init_cli(args: SimpleNamespace, env: CommandEnv) -> None:
 
     if drive_setup:
         try:
-            drive_client = DriveClient(ui)
+            drive_client = build_drive_client(env)
             drive_client.ensure_credentials()
             console.print("[green]✓ Drive credentials configured")
         except (SystemExit, KeyboardInterrupt):

--- a/polylogue/cli/init.py
+++ b/polylogue/cli/init.py
@@ -9,7 +9,7 @@ from typing import Optional
 from ..settings import Settings, persist_settings, SETTINGS_PATH
 from ..commands import CommandEnv
 from ..drive_client import DriveClient
-from ..config import CONFIG, persist_config, IndexConfig, is_config_declarative
+from ..config import persist_config, IndexConfig, is_config_declarative
 
 
 def run_init_cli(args: SimpleNamespace, env: CommandEnv) -> None:
@@ -56,8 +56,8 @@ def run_init_cli(args: SimpleNamespace, env: CommandEnv) -> None:
     console.print("Let's set up your configuration.\n")
 
     # Step 1: Roots
-    default_output_root = CONFIG.defaults.output_dirs.render.parent
-    default_input_root = CONFIG.exports.chatgpt
+    default_output_root = env.config.defaults.output_dirs.render.parent
+    default_input_root = env.config.exports.chatgpt
     console.print(f"[bold]Output Directory[/bold]")
     console.print(f"Where should rendered conversations be saved (root for all providers)?")
 
@@ -123,10 +123,11 @@ def run_init_cli(args: SimpleNamespace, env: CommandEnv) -> None:
     console.print(f"\n[bold]Index Backend[/bold]")
     console.print("Choose index backend (sqlite is default; qdrant enables vector search).")
     backend = "sqlite"
-    qdrant_url: Optional[str] = CONFIG.index.qdrant_url if CONFIG.index else None
-    qdrant_key: Optional[str] = CONFIG.index.qdrant_api_key if CONFIG.index else None
-    qdrant_collection: Optional[str] = CONFIG.index.qdrant_collection if CONFIG.index else None
-    qdrant_vector: Optional[int] = CONFIG.index.qdrant_vector_size if CONFIG.index else None
+    index_cfg = env.config.index
+    qdrant_url: Optional[str] = index_cfg.qdrant_url if index_cfg else None
+    qdrant_key: Optional[str] = index_cfg.qdrant_api_key if index_cfg else None
+    qdrant_collection: Optional[str] = index_cfg.qdrant_collection if index_cfg else None
+    qdrant_vector: Optional[int] = index_cfg.qdrant_vector_size if index_cfg else None
     if not ui.plain:
         backend_choice = ui.choose("  Backend (sqlite/qdrant/none)", ["sqlite", "qdrant", "none"])
         backend = backend_choice or "sqlite"

--- a/polylogue/cli/prefs.py
+++ b/polylogue/cli/prefs.py
@@ -5,29 +5,33 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import Dict
 
-from ..paths import STATE_HOME
+from .. import paths as paths_module
 from ..commands import CommandEnv
 
-PREFS_PATH = STATE_HOME / "prefs.json"
+
+def prefs_path() -> Path:
+    return paths_module.STATE_HOME / "prefs.json"
 
 
-def _load_prefs() -> Dict[str, Dict[str, str]]:
-    if not PREFS_PATH.exists():
+def load_prefs() -> Dict[str, Dict[str, str]]:
+    path = prefs_path()
+    if not path.exists():
         return {}
     try:
-        return json.loads(PREFS_PATH.read_text(encoding="utf-8"))
+        return json.loads(path.read_text(encoding="utf-8"))
     except Exception:
         return {}
 
 
 def _save_prefs(prefs: Dict[str, Dict[str, str]]) -> None:
-    PREFS_PATH.parent.mkdir(parents=True, exist_ok=True)
-    PREFS_PATH.write_text(json.dumps(prefs, indent=2, sort_keys=True), encoding="utf-8")
+    path = prefs_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(prefs, indent=2, sort_keys=True), encoding="utf-8")
 
 
 def run_prefs_cli(args: SimpleNamespace, env: CommandEnv) -> None:
     ui = env.ui
-    prefs = _load_prefs()
+    prefs = load_prefs()
     sub = getattr(args, "prefs_cmd", None)
 
     if sub == "list":
@@ -74,4 +78,4 @@ def run_prefs_cli(args: SimpleNamespace, env: CommandEnv) -> None:
     raise SystemExit(1)
 
 
-__all__ = ["run_prefs_cli", "PREFS_PATH"]
+__all__ = ["run_prefs_cli", "prefs_path", "load_prefs"]

--- a/polylogue/cli/prune_cli.py
+++ b/polylogue/cli/prune_cli.py
@@ -8,7 +8,7 @@ from typing import List, Tuple
 from ..commands import CommandEnv
 from ..paths import STATE_HOME
 from ..util import preflight_disk_requirement
-from .context import DEFAULT_OUTPUT_ROOTS
+from .context import resolve_output_roots
 
 
 def _legacy_candidates(root: Path) -> List[Path]:
@@ -27,7 +27,7 @@ def run_prune_cli(args: object, env: CommandEnv) -> None:
     if raw_dirs:
         roots = [Path(path).expanduser() for path in raw_dirs]
     else:
-        roots = list(DEFAULT_OUTPUT_ROOTS)
+        roots = resolve_output_roots(env.config)
     seen: set[Path] = set()
     unique_roots: List[Path] = []
     for root in roots:
@@ -107,4 +107,3 @@ def run_prune_cli(args: object, env: CommandEnv) -> None:
 
 
 __all__ = ["run_prune_cli"]
-

--- a/polylogue/cli/render.py
+++ b/polylogue/cli/render.py
@@ -6,8 +6,7 @@ from typing import List, Optional, Sequence
 import shutil
 
 from ..cli_common import resolve_inputs, sk_select
-from ..commands import CommandEnv, render_command
-from ..drive_client import DriveClient
+from ..commands import CommandEnv, build_drive_client, render_command
 from ..importers import ImportResult
 from ..options import RenderOptions
 from ..version import POLYLOGUE_VERSION, SCHEMA_VERSION
@@ -97,7 +96,7 @@ def run_render_cli(args: object, env: CommandEnv, json_output: bool) -> None:
 
             preflight_disk_requirement(projected_bytes=projected, limit_gib=max_disk, ui=ui)
     if download_attachments and env.drive is None:
-        env.drive = DriveClient(ui)
+        env.drive = build_drive_client(env)
     try:
         result = render_command(options, env)
     except Exception as exc:

--- a/polylogue/cli/settings_cli.py
+++ b/polylogue/cli/settings_cli.py
@@ -99,6 +99,7 @@ def run_settings_cli(args: SimpleNamespace, env: CommandEnv) -> None:
             index=config_obj.index,
             path=CONFIG_PATH,
             roots=config_obj.defaults.roots if getattr(config_obj.defaults, "roots", None) else None,
+            drive=config_obj.drive if hasattr(config_obj, "drive") else None,
         )
 
     payload = _settings_snapshot(settings)

--- a/polylogue/cli/status.py
+++ b/polylogue/cli/status.py
@@ -14,9 +14,8 @@ from typing import Any, Dict, List, Optional, Set, cast
 from ..commands import CommandEnv, status_command
 from ..version import POLYLOGUE_VERSION, SCHEMA_VERSION
 from ..schema import stamp_payload
-from ..config import CONFIG_ENV, CONFIG_PATH, DEFAULT_PATHS
 from ..util import parse_input_time_to_epoch
-from .context import DEFAULT_OUTPUT_ROOTS, DEFAULT_RENDER_OUT
+from .context import resolve_output_roots
 
 
 def _dump_runs(ui, records: List[dict], destination: str, *, quiet: bool = False) -> None:
@@ -354,7 +353,7 @@ def run_stats_cli(args: SimpleNamespace, env: CommandEnv) -> None:
             return _fail("No Markdown files found (stats directory missing).", directory=directory_input, directories=[directory_input])
         roots = [directory]
     else:
-        roots = [path for path in DEFAULT_OUTPUT_ROOTS if path.exists()]
+        roots = [path for path in resolve_output_roots(env.config) if path.exists()]
         if not roots:
             return _fail("No Markdown files found across configured output roots.")
 

--- a/polylogue/cli/sync.py
+++ b/polylogue/cli/sync.py
@@ -8,8 +8,7 @@ from typing import Dict, List, Optional
 import shutil
 
 from ..cli_common import filter_chats, sk_select
-from ..commands import CommandEnv, list_command, sync_command
-from ..drive_client import DriveClient
+from ..commands import CommandEnv, build_drive_client, list_command, sync_command
 from ..drive import snapshot_drive_metrics
 from ..local_sync import (
     LocalSyncResult,
@@ -137,7 +136,7 @@ def _retry_drive_attachments_only(
     force: bool,
 ) -> dict:
     ui = env.ui
-    drive = env.drive or DriveClient(ui)
+    drive = env.drive or build_drive_client(env)
     env.drive = drive
 
     failed_attachments = run.get("failedAttachments")
@@ -470,7 +469,7 @@ def _run_sync_drive(args: SimpleNamespace, env: CommandEnv) -> None:
         drive_retries = retries_override if retries_override is not None else getattr(drive_cfg, "retries", None)
         drive_retry_base = retry_base_override if retry_base_override is not None else getattr(drive_cfg, "retry_base", None)
 
-        env.drive = env.drive or DriveClient(ui, retries=drive_retries, retry_base=drive_retry_base)
+        env.drive = env.drive or build_drive_client(env, retries=drive_retries, retry_base=drive_retry_base)
         result_payload = _retry_drive_attachments_only(
             run=run,
             env=env,
@@ -499,7 +498,7 @@ def _run_sync_drive(args: SimpleNamespace, env: CommandEnv) -> None:
     drive_retries = retries_override if retries_override is not None else getattr(drive_cfg, "retries", None)
     drive_retry_base = retry_base_override if retry_base_override is not None else getattr(drive_cfg, "retry_base", None)
 
-    drive = env.drive or DriveClient(ui, retries=drive_retries, retry_base=drive_retry_base)
+    drive = env.drive or build_drive_client(env, retries=drive_retries, retry_base=drive_retry_base)
     env.drive = drive
     folder_id = drive.resolve_folder_id(args.folder_name, args.folder_id)
     raw_chats = drive.list_chats(args.folder_name, folder_id)

--- a/polylogue/cli/sync.py
+++ b/polylogue/cli/sync.py
@@ -392,9 +392,10 @@ def run_sync_cli(args: SimpleNamespace, env: CommandEnv) -> None:
         from ..drive_client import DEFAULT_CREDENTIALS
 
         cred_env = os.environ.get("POLYLOGUE_CREDENTIAL_PATH")
-        cred_path = Path(cred_env).expanduser() if cred_env else DEFAULT_CREDENTIALS
-        if env.config.drive and env.config.drive.credentials_path:
-            cred_path = env.config.drive.credentials_path
+        if cred_env:
+            cred_path = Path(cred_env).expanduser()
+        else:
+            cred_path = env.config.drive.credentials_path if env.config.drive else DEFAULT_CREDENTIALS
         if not cred_path.exists():
             raise SystemExit(
                 f"Drive sync requires credentials.json at {cred_path} "

--- a/polylogue/cli/sync.py
+++ b/polylogue/cli/sync.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import time
+import os
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Dict, List, Optional
@@ -390,13 +391,14 @@ def run_sync_cli(args: SimpleNamespace, env: CommandEnv) -> None:
     if provider == "drive":
         from ..drive_client import DEFAULT_CREDENTIALS
 
-        cred_path = DEFAULT_CREDENTIALS
+        cred_env = os.environ.get("POLYLOGUE_CREDENTIAL_PATH")
+        cred_path = Path(cred_env).expanduser() if cred_env else DEFAULT_CREDENTIALS
         if env.config.drive and env.config.drive.credentials_path:
             cred_path = env.config.drive.credentials_path
         if not cred_path.exists():
             raise SystemExit(
                 f"Drive sync requires credentials.json at {cred_path} "
-                f"(set drive.credentials_path in config)."
+                " (set POLYLOGUE_CREDENTIAL_PATH or drive.credentials_path in config)."
             )
 
     if provider in {"chatgpt", "claude"}:

--- a/polylogue/cli/sync.py
+++ b/polylogue/cli/sync.py
@@ -292,7 +292,7 @@ def _log_local_sync(
     if getattr(result, "ignored", 0):
         console.print(f"[yellow]{title}: skipped {result.ignored} path(s) via .polylogueignore.")
     run_payload = {
-        "cmd": title.lower().replace(" ", "-"),
+        "cmd": f"sync {provider}",
         "provider": provider,
         "count": len(result.written),
         "out": str(result.output_dir),
@@ -712,7 +712,12 @@ def _collect_session_selection(ui, sessions: List[Path], header: str) -> Optiona
 def _run_local_sync(provider_name: str, args: SimpleNamespace, env: CommandEnv) -> None:
     provider = get_local_provider(provider_name)
     ui = env.ui
-    previous_run_note = format_run_brief(latest_run(provider=provider.name, cmd=f"sync {provider.name}"))
+    cmd_name = f"sync {provider.name}"
+    previous = latest_run(provider=provider.name, cmd=cmd_name)
+    if previous is None:
+        legacy_cmd = provider.title.lower().replace(" ", "-")
+        previous = latest_run(provider=provider.name, cmd=legacy_cmd)
+    previous_run_note = format_run_brief(previous)
     if getattr(args, "diff", False) and not provider.supports_diff:
         ui.console.print(f"[red]{provider.title} does not support --diff output")
         raise SystemExit(1)

--- a/polylogue/cli/sync.py
+++ b/polylogue/cli/sync.py
@@ -887,6 +887,8 @@ def _run_local_sync(provider_name: str, args: SimpleNamespace, env: CommandEnv) 
         footer_lines: List[str] = []
         if not result.written:
             footer_lines.append(f"Output dir: {result.output_dir}")
+            if result.failures:
+                footer_lines.append(f"Failures: {result.failures}")
         if previous_run_note:
             footer_lines.append(f"Previous run: {previous_run_note}")
         summarize_import(ui, f"{provider.title} Sync", result.written, extra_lines=footer_lines or None)

--- a/polylogue/cli/sync.py
+++ b/polylogue/cli/sync.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json
 import time
-import os
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Dict, List, Optional
@@ -387,20 +386,6 @@ def run_sync_cli(args: SimpleNamespace, env: CommandEnv) -> None:
         if not paths:
             raise SystemExit(f"Unknown root label '{label}'. Define it in config or use a known label.")
         env.config.defaults.output_dirs = paths
-
-    if provider == "drive":
-        from ..drive_client import DEFAULT_CREDENTIALS
-
-        cred_env = os.environ.get("POLYLOGUE_CREDENTIAL_PATH")
-        if cred_env:
-            cred_path = Path(cred_env).expanduser()
-        else:
-            cred_path = env.config.drive.credentials_path if env.config.drive else DEFAULT_CREDENTIALS
-        if not cred_path.exists():
-            raise SystemExit(
-                f"Drive sync requires credentials.json at {cred_path} "
-                " (set POLYLOGUE_CREDENTIAL_PATH or drive.credentials_path in config)."
-            )
 
     if provider in {"chatgpt", "claude"}:
         if getattr(args, "base_dir", None):

--- a/polylogue/cli/sync.py
+++ b/polylogue/cli/sync.py
@@ -717,7 +717,14 @@ def _run_local_sync(provider_name: str, args: SimpleNamespace, env: CommandEnv) 
     if getattr(args, "diff", False) and not provider.supports_diff:
         ui.console.print(f"[red]{provider.title} does not support --diff output")
         raise SystemExit(1)
-    base_dir = Path(args.base_dir).expanduser() if args.base_dir else provider.default_base.expanduser()
+    if args.base_dir:
+        base_dir = Path(args.base_dir).expanduser()
+    elif provider.name == "chatgpt":
+        base_dir = env.config.exports.chatgpt
+    elif provider.name == "claude":
+        base_dir = env.config.exports.claude
+    else:
+        base_dir = provider.default_base.expanduser()
     out_dir = resolve_output_path(args.out, _resolve_default_output(provider.name, env))
     settings = env.settings
     collapse_thresholds = resolve_collapse_thresholds(args, settings)

--- a/polylogue/cli/watch.py
+++ b/polylogue/cli/watch.py
@@ -63,7 +63,14 @@ def _run_watch_sessions(
 ) -> None:
     watch_fn = _watch_directory
     ui = env.ui
-    base_dir = Path(args.base_dir).expanduser() if args.base_dir else provider.default_base
+    if args.base_dir:
+        base_dir = Path(args.base_dir).expanduser()
+    elif provider.name == "chatgpt":
+        base_dir = env.config.exports.chatgpt
+    elif provider.name == "claude":
+        base_dir = env.config.exports.claude
+    else:
+        base_dir = provider.default_base.expanduser()
     if getattr(args, "offline", False):
         ui.console.print("[yellow]Offline mode enabled; network-dependent steps will be skipped.")
     base_exists = base_dir.exists()

--- a/polylogue/commands.py
+++ b/polylogue/commands.py
@@ -102,6 +102,7 @@ class CommandEnv:
     config: Config = field(default_factory=lambda: CONFIG)
     repository: ConversationRepository = field(default_factory=ConversationRepository)
     settings: Settings = field(default_factory=Settings)
+    prefs: Dict[str, Dict[str, str]] = field(default_factory=dict)
     state_repo: ConversationStateRepository = field(default_factory=ConversationStateRepository)
     database: ConversationDatabase = field(default_factory=ConversationDatabase)
     archive: Archive = field(default_factory=lambda: Archive(CONFIG))

--- a/polylogue/commands.py
+++ b/polylogue/commands.py
@@ -765,7 +765,7 @@ def sync_command(options: SyncOptions, env: CommandEnv) -> SyncResult:
         eta = ((total - done) / rate) if rate > 0 else None
         pct = (done / total) * 100.0
         env.ui.console.print(
-            f"[dim]drive progress: {done}/{total} ({pct:.1f}%) elapsed={format_duration(elapsed)} eta={format_duration(eta)}[/dim]"
+            f"[dim]drive progress: {done}/{total} ({pct:.0f}%) elapsed={format_duration(elapsed)} eta={format_duration(eta)}[/dim]"
         )
     with env.ui.progress(description, total=len(chats)) as tracker:
         for idx, meta in enumerate(chats, start=1):

--- a/polylogue/core/configuration.py
+++ b/polylogue/core/configuration.py
@@ -193,6 +193,11 @@ class AppConfig(BaseSettings):
                         index_data["qdrant_vector_size"] = qdrant["vector_size"]
                 config_dict["index"] = IndexConfig(**index_data)
 
+            if "exports" in data:
+                exports_data = data.get("exports") or {}
+                if isinstance(exports_data, dict):
+                    config_dict["exports"] = ExportsConfig(**exports_data)
+
             # Store raw data for compatibility
             config_dict["raw"] = data
             config_dict["config_path"] = path

--- a/polylogue/doctor.py
+++ b/polylogue/doctor.py
@@ -516,9 +516,9 @@ def run_doctor(
     issues.extend(_credential_issues(credential_path, token_path))
     issues.extend(_drive_failure_issues())
     if not skip_index:
-        _status("Checking SQLite index health (may take a while on large archives)")
+        _status("Checking SQLite index health (quick check; use `polylogue doctor index check` for full scan)")
         try:
-            sqlite_notes = verify_sqlite_indexes(default_db_path())
+            sqlite_notes = verify_sqlite_indexes(default_db_path(), full=False)
             if sqlite_notes:
                 counts["indexes"] = counts.get("indexes", 0) + len(sqlite_notes)
                 for note in sqlite_notes:

--- a/polylogue/drive.py
+++ b/polylogue/drive.py
@@ -215,7 +215,7 @@ def _run_console_flow(flow: InstalledAppFlow, *, verbose: bool) -> Credentials:
     if session is not None and getattr(session, "redirect_uri", None) != flow.redirect_uri:
         session.redirect_uri = flow.redirect_uri
 
-    auth_url, _ = flow.authorization_url(prompt="consent")
+    auth_url, _ = flow.authorization_url(prompt="consent", redirect_uri=flow.redirect_uri)
     prompt = (
         "Open this link in your browser to authorize Polylogue:\n"
         f"  {auth_url}\n"

--- a/polylogue/drive_client.py
+++ b/polylogue/drive_client.py
@@ -25,7 +25,6 @@ DEFAULT_CREDENTIALS = CONFIG_DIR / "credentials.json"
 _ENV_TOKEN_PATH = os.environ.get("POLYLOGUE_TOKEN_PATH")
 DEFAULT_TOKEN = Path(_ENV_TOKEN_PATH).expanduser() if _ENV_TOKEN_PATH else CONFIG_DIR / "token.json"
 DEFAULT_FOLDER_NAME = "Google AI Studio"
-FALLBACK_FOLDER_NAMES = ("AI Studio",)
 
 
 class DriveClient:
@@ -168,21 +167,8 @@ class DriveClient:
             return folder_id
         name = folder_name or DEFAULT_FOLDER_NAME
         svc = self.service()
-        candidates = [name]
-        if folder_name is None:
-            candidates.extend([c for c in FALLBACK_FOLDER_NAMES if c != name])
-
-        for candidate in candidates:
-            resolved = find_folder_id(svc, candidate, notifier=self._notify_retry)
-            if not resolved:
-                continue
-            if candidate != name:
-                prefix = "Default Drive folder" if folder_name is None else "Drive folder"
-                message = f"{prefix} '{name}' not found; using '{candidate}'."
-                if self.ui.plain:
-                    self.ui.console.print(message)
-                else:
-                    self.ui.console.print(f"[yellow]{message}[/yellow]")
+        resolved = find_folder_id(svc, name, notifier=self._notify_retry)
+        if resolved:
             return resolved
         raise SystemExit(f"Folder not found: {name}")
 

--- a/polylogue/drive_client.py
+++ b/polylogue/drive_client.py
@@ -31,12 +31,26 @@ FALLBACK_FOLDER_NAMES = ("AI Studio",)
 class DriveClient:
     """Wrapper that manages credentials and Drive service access."""
 
-    def __init__(self, ui: UI, *, retries: Optional[int] = None, retry_base: Optional[float] = None):
+    def __init__(
+        self,
+        ui: UI,
+        *,
+        retries: Optional[int] = None,
+        retry_base: Optional[float] = None,
+        credentials_path: Optional[Path] = None,
+        token_path: Optional[Path] = None,
+    ):
         self.ui = ui
-        env_path = os.environ.get("POLYLOGUE_CREDENTIAL_PATH")
-        self._credentials_path: Path = Path(env_path).expanduser() if env_path else DEFAULT_CREDENTIALS
-        token_env = os.environ.get("POLYLOGUE_TOKEN_PATH")
-        self._token_path: Path = Path(token_env).expanduser() if token_env else DEFAULT_TOKEN
+        if credentials_path is None:
+            env_path = os.environ.get("POLYLOGUE_CREDENTIAL_PATH")
+            self._credentials_path = Path(env_path).expanduser() if env_path else DEFAULT_CREDENTIALS
+        else:
+            self._credentials_path = Path(credentials_path).expanduser()
+        if token_path is None:
+            token_env = os.environ.get("POLYLOGUE_TOKEN_PATH")
+            self._token_path = Path(token_env).expanduser() if token_env else DEFAULT_TOKEN
+        else:
+            self._token_path = Path(token_path).expanduser()
         self._service = None
         if retries is not None or retry_base is not None:
             set_retry_defaults(retries=retries, base_delay=retry_base)

--- a/polylogue/drive_client.py
+++ b/polylogue/drive_client.py
@@ -171,12 +171,6 @@ class DriveClient:
         candidates = [name]
         if folder_name is None:
             candidates.extend([c for c in FALLBACK_FOLDER_NAMES if c != name])
-        elif name in FALLBACK_FOLDER_NAMES:
-            if DEFAULT_FOLDER_NAME != name:
-                candidates.append(DEFAULT_FOLDER_NAME)
-            candidates.extend([c for c in FALLBACK_FOLDER_NAMES if c != name])
-        elif name == DEFAULT_FOLDER_NAME:
-            candidates.extend([c for c in FALLBACK_FOLDER_NAMES if c != name])
 
         for candidate in candidates:
             resolved = find_folder_id(svc, candidate, notifier=self._notify_retry)

--- a/polylogue/importers/chatgpt.py
+++ b/polylogue/importers/chatgpt.py
@@ -49,6 +49,7 @@ from .utils import (
     LINE_THRESHOLD,
     PREVIEW_LINES,
     estimate_token_count,
+    find_conversations_json,
     normalise_inline_footnotes,
     safe_extractall,
     store_large_text,
@@ -78,13 +79,21 @@ def _render_config_hash(
 
 def _load_export(path: Path) -> Tuple[Path, Optional[TemporaryDirectory]]:
     if path.is_dir():
-        return path, None
+        root = path
+        conv_path = find_conversations_json(root)
+        if conv_path is not None:
+            return conv_path.parent, None
+        return root, None
     if path.suffix.lower() != ".zip":
         raise FileNotFoundError(f"Unsupported ChatGPT export: {path}")
     tmp = TemporaryDirectory(prefix="chatgpt-export-")
     with zipfile.ZipFile(path) as zf:
         safe_extractall(zf, Path(tmp.name))
-    return Path(tmp.name), tmp
+    root = Path(tmp.name)
+    conv_path = find_conversations_json(root)
+    if conv_path is not None:
+        return conv_path.parent, tmp
+    return root, tmp
 
 
 def _render_parts(parts: Iterable) -> str:

--- a/polylogue/importers/utils.py
+++ b/polylogue/importers/utils.py
@@ -155,3 +155,18 @@ def safe_extractall(archive, target: Path) -> None:
     """Safely extract the entire archive to ``target``."""
 
     safe_extract(archive, archive.namelist(), target)
+
+
+def find_conversations_json(root: Path) -> Optional[Path]:
+    """Locate conversations.json within a directory (preferring shallow paths)."""
+
+    candidate = root / "conversations.json"
+    if candidate.exists():
+        return candidate
+    try:
+        matches = list(root.rglob("conversations.json"))
+    except OSError:
+        return None
+    if not matches:
+        return None
+    return min(matches, key=lambda path: (len(path.relative_to(root).parts), str(path)))

--- a/polylogue/local_sync.py
+++ b/polylogue/local_sync.py
@@ -335,6 +335,11 @@ def _sync_sessions(
             except Exception:
                 existing_dirty = False
 
+        if not force and not existing_dirty and _is_up_to_date_multi(source_paths, md_path):
+            entry["skipped"] = True
+            entry["skip_reason"] = "up-to-date"
+            return entry
+
         if not force and not existing_dirty and provider != "claude-code":
             try:
                 from .importers.raw_storage import compute_hash
@@ -349,11 +354,6 @@ def _sync_sessions(
                     return entry
             except Exception:
                 pass
-
-        if not force and _is_up_to_date_multi(source_paths, md_path):
-            entry["skipped"] = True
-            entry["skip_reason"] = "up-to-date"
-            return entry
 
         diff_tracker = DiffTracker(md_path, diff)
         try:

--- a/polylogue/local_sync.py
+++ b/polylogue/local_sync.py
@@ -946,11 +946,11 @@ def _list_claude_code_paths(base_dir: Path) -> List[Path]:
 
 
 def _list_chatgpt_exports(base_dir: Path) -> List[Path]:
-    return _discover_export_targets(base_dir)
+    return _discover_export_targets(base_dir, provider="chatgpt")
 
 
 def _list_claude_exports(base_dir: Path) -> List[Path]:
-    return _discover_export_targets(base_dir)
+    return _discover_export_targets(base_dir, provider="claude")
 
 
 def sync_chatgpt_exports(

--- a/polylogue/local_sync.py
+++ b/polylogue/local_sync.py
@@ -909,7 +909,7 @@ def sync_claude_code_sessions(
 ) -> LocalSyncResult:
     base_dir = base_dir.expanduser()
     if sessions is None:
-        sessions = base_dir.rglob("*.jsonl")
+        sessions = _list_claude_code_paths(base_dir)
     return _sync_sessions(
         sessions,
         output_dir=output_dir,

--- a/polylogue/local_sync.py
+++ b/polylogue/local_sync.py
@@ -550,6 +550,8 @@ def _classify_conversation_entry(entry: object) -> Optional[str]:
         return "claude"
     if "create_time" in entry or "update_time" in entry:
         return "chatgpt"
+    if "uuid" in entry and any(key in entry for key in ("name", "title", "created_at", "updated_at")):
+        return "claude"
     if "uuid" in entry and "model" in entry:
         return "claude"
     messages = entry.get("messages")
@@ -579,6 +581,8 @@ def _classify_conversations_snippet(data: bytes) -> Optional[str]:
         return "claude"
     if b'"author"' in lowered or b'"role"' in lowered:
         return "chatgpt"
+    if b'"uuid"' in lowered and (b'"created_at"' in lowered or b'"updated_at"' in lowered):
+        return "claude"
     if b'"uuid"' in lowered and b'"model"' in lowered:
         return "claude"
     return None

--- a/polylogue/local_sync.py
+++ b/polylogue/local_sync.py
@@ -856,7 +856,7 @@ def sync_codex_sessions(
 ) -> LocalSyncResult:
     base_dir = base_dir.expanduser()
     if sessions is None:
-        sessions = _list_claude_code_paths(base_dir)
+        sessions = _list_codex_paths(base_dir)
     return _sync_sessions(
         sessions,
         output_dir=output_dir,

--- a/polylogue/providers/drive.py
+++ b/polylogue/providers/drive.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Dict, List, Optional
-
-from typing import Callable
+from typing import Callable, Dict, List, Optional
 
 from ..drive_client import DriveClient
 from ..ui import UI
@@ -15,8 +13,8 @@ class DriveProviderSession:
     name = "drive"
     title = "Google Drive"
 
-    def __init__(self, ui: UI, client_factory: Callable[[UI], DriveClient] = DriveClient):
-        self._client = client_factory(ui)
+    def __init__(self, ui: UI, client_factory: Callable[..., DriveClient] = DriveClient, **client_kwargs: object):
+        self._client = client_factory(ui, **client_kwargs)
 
     @property
     def ui(self) -> UI:

--- a/polylogue/ui/__init__.py
+++ b/polylogue/ui/__init__.py
@@ -199,16 +199,20 @@ class _PlainProgressTracker:
     def _coerce_int(value: Optional[float]) -> Optional[int]:
         if isinstance(value, int):
             return value
-        if isinstance(value, float) and value.is_integer():
-            return int(value)
+        if isinstance(value, float):
+            rounded = round(value)
+            if abs(value - rounded) < 1e-6:
+                return int(rounded)
         return None
 
     @staticmethod
     def _format_value(value: float | int) -> str:
         if isinstance(value, int):
             return str(value)
-        if isinstance(value, float) and value.is_integer():
-            return str(int(value))
+        if isinstance(value, float):
+            rounded = round(value)
+            if abs(value - rounded) < 1e-6:
+                return str(int(rounded))
         return f"{float(value):.2f}".rstrip("0").rstrip(".")
 
 

--- a/polylogue/ui/__init__.py
+++ b/polylogue/ui/__init__.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from typing import Iterable, List, Optional, Set
+import math
 import sys
+from typing import Iterable, List, Optional, Set
 from rich.progress import (
     BarColumn,
     Progress,
@@ -168,7 +169,7 @@ class _PlainProgressTracker:
     def __enter__(self):
         return self
 
-    def advance(self, advance: float = 1.0) -> None:
+    def advance(self, advance: float = 1) -> None:
         as_int = self._coerce_int(advance)
         if as_int is not None and not self._use_float:
             self._completed += as_int
@@ -201,7 +202,7 @@ class _PlainProgressTracker:
             return value
         if isinstance(value, float):
             rounded = round(value)
-            if abs(value - rounded) < 1e-6:
+            if math.isclose(value, rounded, abs_tol=1e-4):
                 return int(rounded)
         return None
 
@@ -211,7 +212,7 @@ class _PlainProgressTracker:
             return str(value)
         if isinstance(value, float):
             rounded = round(value)
-            if abs(value - rounded) < 1e-6:
+            if math.isclose(value, rounded, abs_tol=1e-4):
                 return str(int(rounded))
         return f"{float(value):.2f}".rstrip("0").rstrip(".")
 
@@ -225,7 +226,7 @@ class _RichProgressTracker:
         self._progress.__enter__()
         return self
 
-    def advance(self, advance: float = 1.0) -> None:
+    def advance(self, advance: float = 1) -> None:
         self._progress.advance(self._task_id, advance)
 
     def update(self, *, total: Optional[int] = None, description: Optional[str] = None) -> None:

--- a/polylogue/util.py
+++ b/polylogue/util.py
@@ -32,6 +32,20 @@ def _resolve_path(env_var: str, home_default: Path, xdg_default: Path) -> Path:
 
 DEFAULT_CODEX_HOME = Path.home() / ".codex" / "sessions"
 DEFAULT_CLAUDE_CODE_HOME = Path.home() / ".claude" / "projects"
+DEFAULT_CLAUDE_CODE_CONFIG_HOME = Path.home() / ".config" / "claude" / "projects"
+
+
+def resolve_claude_code_project_root() -> Path:
+    env_value = os.environ.get("POLYLOGUE_CLAUDE_CODE_PROJECTS")
+    if env_value:
+        return Path(env_value).expanduser()
+    for candidate in (
+        Path.home() / ".claude" / "projects",
+        Path.home() / ".config" / "claude" / "projects",
+    ):
+        if candidate.exists():
+            return candidate
+    return DATA_HOME / "claude" / "projects"
 
 
 CODEX_SESSIONS_ROOT = _resolve_path(
@@ -41,11 +55,7 @@ CODEX_SESSIONS_ROOT = _resolve_path(
 )
 
 
-CLAUDE_CODE_PROJECT_ROOT = _resolve_path(
-    "POLYLOGUE_CLAUDE_CODE_PROJECTS",
-    DEFAULT_CLAUDE_CODE_HOME,
-    DATA_HOME / "claude" / "projects",
-)
+CLAUDE_CODE_PROJECT_ROOT = resolve_claude_code_project_root()
 
 
 def colorize(text: str, color: str) -> str:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -126,3 +126,10 @@ if __name__ == "__main__":
 
 
 _install_tool_shims()
+
+
+@pytest.fixture(autouse=True)
+def _disable_browser_launch(monkeypatch):
+    monkeypatch.delenv("POLYLOGUE_BROWSER", raising=False)
+    monkeypatch.delenv("BROWSER", raising=False)
+    monkeypatch.setattr("polylogue.cli.editor.webbrowser.open", lambda *_a, **_k: False)

--- a/tests/test_cli_plain_smoke.py
+++ b/tests/test_cli_plain_smoke.py
@@ -14,7 +14,7 @@ def _run_polylogue(args: list[str], *, cwd: Path, env: dict[str, str]) -> subpro
 
 
 def _common_env(tmp_path: Path, force_plain: bool = True) -> dict[str, str]:
-    env = os.environ.copy()
+    env = {key: value for key, value in os.environ.items() if not key.startswith("POLYLOGUE_")}
     if force_plain:
         env["POLYLOGUE_FORCE_PLAIN"] = "1"
     else:

--- a/tests/test_config_roots.py
+++ b/tests/test_config_roots.py
@@ -1,7 +1,7 @@
 import json
 from pathlib import Path
 
-from polylogue.config import IndexConfig, persist_config, load_config
+from polylogue.config import DriveConfig, IndexConfig, load_config, persist_config
 
 
 def test_persist_config_includes_roots(tmp_path: Path) -> None:
@@ -51,3 +51,57 @@ def test_load_config_populates_labeled_roots(tmp_path: Path, monkeypatch) -> Non
     assert "work" in cfg.defaults.roots
     assert cfg.defaults.roots["work"].render == work_root / "render"
     assert cfg.defaults.roots["work"].import_claude == work_root / "claude"
+
+
+def test_persist_config_includes_drive_settings(tmp_path: Path) -> None:
+    input_root = tmp_path / "inbox"
+    output_root = tmp_path / "archive"
+    drive_cfg = DriveConfig(
+        credentials_path=tmp_path / "creds.json",
+        token_path=tmp_path / "token.json",
+        retries=5,
+        retry_base=1.25,
+        from_config=True,
+    )
+
+    config_path = persist_config(
+        input_root=input_root,
+        output_root=output_root,
+        collapse_threshold=10,
+        html_previews=True,
+        html_theme="dark",
+        index=IndexConfig(),
+        path=tmp_path / "config.json",
+        drive=drive_cfg,
+    )
+
+    data = json.loads(config_path.read_text(encoding="utf-8"))
+    assert data["drive"]["credentials_path"] == str(drive_cfg.credentials_path)
+    assert data["drive"]["token_path"] == str(drive_cfg.token_path)
+    assert data["drive"]["retries"] == 5
+    assert data["drive"]["retry_base"] == 1.25
+
+
+def test_load_config_populates_drive_settings(tmp_path: Path, monkeypatch) -> None:
+    payload = {
+        "paths": {
+            "input_root": str(tmp_path / "inbox"),
+            "output_root": str(tmp_path / "archive"),
+        },
+        "drive": {
+            "credentials_path": str(tmp_path / "creds.json"),
+            "token_path": str(tmp_path / "token.json"),
+            "retries": 4,
+            "retry_base": 0.75,
+        },
+    }
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps(payload), encoding="utf-8")
+    monkeypatch.setenv("POLYLOGUE_CONFIG", str(config_path))
+
+    cfg = load_config()
+    assert cfg.drive.credentials_path == tmp_path / "creds.json"
+    assert cfg.drive.token_path == tmp_path / "token.json"
+    assert cfg.drive.retries == 4
+    assert cfg.drive.retry_base == 0.75
+    assert cfg.drive.from_config is True

--- a/tests/test_config_roots.py
+++ b/tests/test_config_roots.py
@@ -53,6 +53,25 @@ def test_load_config_populates_labeled_roots(tmp_path: Path, monkeypatch) -> Non
     assert cfg.defaults.roots["work"].import_claude == work_root / "claude"
 
 
+def test_load_config_defaults_exports_to_input_root(tmp_path: Path, monkeypatch) -> None:
+    inbox = tmp_path / "inbox"
+    payload = {
+        "paths": {
+            "input_root": str(inbox),
+            "output_root": str(tmp_path / "archive"),
+        }
+    }
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps(payload), encoding="utf-8")
+    monkeypatch.setenv("POLYLOGUE_CONFIG", str(config_path))
+    monkeypatch.delenv("POLYLOGUE_EXPORTS_CHATGPT", raising=False)
+    monkeypatch.delenv("POLYLOGUE_EXPORTS_CLAUDE", raising=False)
+
+    cfg = load_config()
+    assert cfg.exports.chatgpt == inbox
+    assert cfg.exports.claude == inbox
+
+
 def test_persist_config_includes_drive_settings(tmp_path: Path) -> None:
     input_root = tmp_path / "inbox"
     output_root = tmp_path / "archive"

--- a/tests/test_consolidated_commands.py
+++ b/tests/test_consolidated_commands.py
@@ -289,6 +289,33 @@ def test_config_dispatcher_handles_show(monkeypatch, tmp_path, capsys):
     assert "outputs" in parsed
 
 
+def test_config_show_serializes_labeled_roots(monkeypatch, tmp_path, capsys):
+    _configure_isolated_state(monkeypatch, tmp_path)
+    from polylogue.config import OutputDirs
+
+    ui = DummyUI()
+    env = CommandEnv(ui=ui)
+    alt_root = tmp_path / "alt"
+    env.config.defaults.roots = {
+        "alt": OutputDirs(
+            render=alt_root / "render",
+            sync_drive=alt_root / "gemini",
+            sync_codex=alt_root / "codex",
+            sync_claude_code=alt_root / "claude-code",
+            import_chatgpt=alt_root / "chatgpt",
+            import_claude=alt_root / "claude",
+        )
+    }
+    args = SimpleNamespace(json=True)
+    from polylogue.cli.config_cli import run_config_show
+
+    run_config_show(args, env)
+
+    parsed = json.loads(capsys.readouterr().out)
+    roots = parsed["outputs"]["roots"]
+    assert roots["alt"]["render"] == str(alt_root / "render")
+
+
 # ===== Integration Tests =====
 
 def test_browse_branches_integration(monkeypatch, tmp_path, capsys):

--- a/tests/test_drive_client.py
+++ b/tests/test_drive_client.py
@@ -97,6 +97,23 @@ def test_drive_client_uses_default_folder_name(monkeypatch):
     assert seen == ["Google AI Studio"]
 
 
+def test_drive_client_uses_explicit_folder_name(monkeypatch):
+    client = DriveClient(DummyUI())
+    monkeypatch.setattr(client, "service", lambda: object())
+    seen: list[str] = []
+
+    def fake_find(_svc, name, notifier=None):
+        seen.append(name)
+        return "folder-456"
+
+    monkeypatch.setattr("polylogue.drive_client.find_folder_id", fake_find)
+
+    resolved = client.resolve_folder_id("AI Studio", None)
+
+    assert resolved == "folder-456"
+    assert seen == ["AI Studio"]
+
+
 def test_run_console_flow_assigns_redirect(monkeypatch):
     class DummySession:
         def __init__(self):

--- a/tests/test_drive_client.py
+++ b/tests/test_drive_client.py
@@ -80,6 +80,25 @@ def test_drive_client_explicit_paths_override_env(tmp_path, monkeypatch):
     assert client.token_path == explicit_token
 
 
+def test_drive_client_falls_back_from_legacy_folder_name(monkeypatch):
+    client = DriveClient(DummyUI())
+    monkeypatch.setattr(client, "service", lambda: object())
+    seen: list[str] = []
+
+    def fake_find(_svc, name, notifier=None):
+        seen.append(name)
+        if name == "Google AI Studio":
+            return "folder-123"
+        return None
+
+    monkeypatch.setattr("polylogue.drive_client.find_folder_id", fake_find)
+
+    resolved = client.resolve_folder_id("AI Studio", None)
+
+    assert resolved == "folder-123"
+    assert seen == ["AI Studio", "Google AI Studio"]
+
+
 def test_run_console_flow_assigns_redirect(monkeypatch):
     class DummySession:
         def __init__(self):

--- a/tests/test_drive_client.py
+++ b/tests/test_drive_client.py
@@ -80,23 +80,23 @@ def test_drive_client_explicit_paths_override_env(tmp_path, monkeypatch):
     assert client.token_path == explicit_token
 
 
-def test_drive_client_falls_back_from_legacy_folder_name(monkeypatch):
+def test_drive_client_falls_back_from_default_folder_name(monkeypatch):
     client = DriveClient(DummyUI())
     monkeypatch.setattr(client, "service", lambda: object())
     seen: list[str] = []
 
     def fake_find(_svc, name, notifier=None):
         seen.append(name)
-        if name == "Google AI Studio":
+        if name == "AI Studio":
             return "folder-123"
         return None
 
     monkeypatch.setattr("polylogue.drive_client.find_folder_id", fake_find)
 
-    resolved = client.resolve_folder_id("AI Studio", None)
+    resolved = client.resolve_folder_id(None, None)
 
     assert resolved == "folder-123"
-    assert seen == ["AI Studio", "Google AI Studio"]
+    assert seen == ["Google AI Studio", "AI Studio"]
 
 
 def test_run_console_flow_assigns_redirect(monkeypatch):

--- a/tests/test_drive_client.py
+++ b/tests/test_drive_client.py
@@ -80,23 +80,21 @@ def test_drive_client_explicit_paths_override_env(tmp_path, monkeypatch):
     assert client.token_path == explicit_token
 
 
-def test_drive_client_falls_back_from_default_folder_name(monkeypatch):
+def test_drive_client_uses_default_folder_name(monkeypatch):
     client = DriveClient(DummyUI())
     monkeypatch.setattr(client, "service", lambda: object())
     seen: list[str] = []
 
     def fake_find(_svc, name, notifier=None):
         seen.append(name)
-        if name == "AI Studio":
-            return "folder-123"
-        return None
+        return "folder-123"
 
     monkeypatch.setattr("polylogue.drive_client.find_folder_id", fake_find)
 
     resolved = client.resolve_folder_id(None, None)
 
     assert resolved == "folder-123"
-    assert seen == ["Google AI Studio", "AI Studio"]
+    assert seen == ["Google AI Studio"]
 
 
 def test_run_console_flow_assigns_redirect(monkeypatch):

--- a/tests/test_drive_client.py
+++ b/tests/test_drive_client.py
@@ -61,6 +61,25 @@ def test_drive_client_respects_env_path(tmp_path, monkeypatch):
     assert client.token_path == tmp_path / "env-creds" / "token.json"
 
 
+def test_drive_client_explicit_paths_override_env(tmp_path, monkeypatch):
+    env_creds = tmp_path / "env-creds" / "credentials.json"
+    env_creds.parent.mkdir(parents=True, exist_ok=True)
+    env_creds.write_text(json.dumps({"installed": {"client_id": "env"}}), encoding="utf-8")
+    monkeypatch.setenv("POLYLOGUE_CREDENTIAL_PATH", str(env_creds))
+    monkeypatch.setenv("POLYLOGUE_TOKEN_PATH", str(tmp_path / "env-creds" / "token.json"))
+
+    explicit_creds = tmp_path / "explicit" / "credentials.json"
+    explicit_token = tmp_path / "explicit" / "token.json"
+    explicit_creds.parent.mkdir(parents=True, exist_ok=True)
+    explicit_creds.write_text(json.dumps({"installed": {"client_id": "explicit"}}), encoding="utf-8")
+    explicit_token.write_text(json.dumps({"token": "explicit"}), encoding="utf-8")
+
+    client = DriveClient(DummyUI(), credentials_path=explicit_creds, token_path=explicit_token)
+
+    assert client.credentials_path == explicit_creds
+    assert client.token_path == explicit_token
+
+
 def test_run_console_flow_assigns_redirect(monkeypatch):
     class DummySession:
         def __init__(self):

--- a/tests/test_local_sync.py
+++ b/tests/test_local_sync.py
@@ -4,6 +4,8 @@ from pathlib import Path
 
 from polylogue.importers.base import ImportResult
 from polylogue.local_sync import (
+    _list_chatgpt_exports,
+    _list_claude_exports,
     sync_chatgpt_exports,
     sync_claude_code_sessions,
     sync_claude_exports,
@@ -271,6 +273,25 @@ def test_sync_chatgpt_exports(monkeypatch, tmp_path):
     )
     assert not calls
     assert result_skip.skipped >= 2
+
+
+def test_list_export_targets_filters_provider(tmp_path):
+    base_dir = tmp_path / "exports"
+    chatgpt_dir = base_dir / "chatgpt"
+    claude_dir = base_dir / "claude"
+    chatgpt_dir.mkdir(parents=True, exist_ok=True)
+    claude_dir.mkdir(parents=True, exist_ok=True)
+    (chatgpt_dir / "conversations.json").write_text(
+        json.dumps({"conversations": [{"mapping": {"root": {}}}]}),
+        encoding="utf-8",
+    )
+    (claude_dir / "conversations.json").write_text(json.dumps([{"title": "Claude"}]), encoding="utf-8")
+
+    chatgpt_targets = _list_chatgpt_exports(base_dir)
+    claude_targets = _list_claude_exports(base_dir)
+
+    assert chatgpt_targets == [chatgpt_dir]
+    assert claude_targets == [claude_dir]
 
 
 def test_sync_chatgpt_exports_normalizes_sessions(monkeypatch, tmp_path):

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1,11 +1,28 @@
 from __future__ import annotations
 
 import re
+from contextlib import contextmanager
 
 import pytest
 
 from polylogue import ui as ui_module
 from polylogue.ui import UI
+from polylogue.ui.facade import ConsoleFacade
+
+
+class _RecordingConsole:
+    def __init__(self) -> None:
+        self.lines: list[str] = []
+
+    def print(self, *args: object, **_kwargs: object) -> None:
+        self.lines.append(" ".join(str(arg) for arg in args))
+
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*[mK]")
+
+
+def _strip_ansi(text: str) -> str:
+    return _ANSI_RE.sub("", text)
 
 
 def test_ui_summary_handles_brackets_without_markup():
@@ -13,7 +30,18 @@ def test_ui_summary_handles_brackets_without_markup():
     lines = ["Copy config to [/tmp/example.json, /tmp/fallback.json]"]
     with view.console.capture() as capture:
         view.summary("Doctor", lines)
-    assert "/tmp/example.json" in capture.get()
+    assert "/tmp/example.json" in _strip_ansi(capture.get())
+
+
+def test_ui_summary_plain_mode_prints_body():
+    view = UI(plain=True)
+    console = _RecordingConsole()
+    view.console = console
+
+    view.summary("Summary", ["Line one", "Line two"])
+
+    assert console.lines[0] == "-- Summary --"
+    assert console.lines[1] == "Line one\nLine two"
 
 
 def test_ui_confirm_interactive_uses_questionary(monkeypatch):
@@ -124,3 +152,175 @@ def test_plain_progress_formats_integerish_values():
     assert tracker._coerce_int(5.0000001) == 5
     assert tracker._format_value(12.0000001) == "12"
     assert tracker._format_value(12.5) == "12.5"
+
+
+def test_ui_banner_plain_mode_prints_lines():
+    view = UI(plain=True)
+    console = _RecordingConsole()
+    view.console = console
+
+    view.banner("Title", "Subtitle")
+
+    assert console.lines[0] == "== Title =="
+    assert console.lines[1] == "Subtitle"
+
+
+def test_ui_banner_rich_mode_includes_title():
+    view = UI(plain=False)
+    with view.console.capture() as capture:
+        view.banner("Title", "Subtitle")
+    output = _strip_ansi(capture.get())
+    assert "Title" in output
+    assert "Subtitle" in output
+
+
+def test_ui_render_markdown_plain_mode_prints_body():
+    view = UI(plain=True)
+    console = _RecordingConsole()
+    view.console = console
+
+    view.render_markdown("**Hello**")
+
+    assert console.lines == ["**Hello**"]
+
+
+def test_ui_render_markdown_rich_mode_includes_body():
+    view = UI(plain=False)
+    with view.console.capture() as capture:
+        view.render_markdown("**Hello**")
+    assert "Hello" in _strip_ansi(capture.get())
+
+
+def test_ui_render_code_plain_mode_prints_body():
+    view = UI(plain=True)
+    console = _RecordingConsole()
+    view.console = console
+
+    view.render_code("print('ok')", language="python")
+
+    assert console.lines == ["print('ok')"]
+
+
+def test_ui_render_code_rich_mode_includes_source():
+    view = UI(plain=False)
+    with view.console.capture() as capture:
+        view.render_code("print('ok')", language="python")
+    assert "print('ok')" in _strip_ansi(capture.get())
+
+
+def test_ui_render_diff_plain_mode_prints_unified_diff():
+    view = UI(plain=True)
+    console = _RecordingConsole()
+    view.console = console
+
+    view.render_diff("old\n", "new\n", filename="sample.txt")
+
+    assert console.lines
+    diff_text = "\n".join(console.lines)
+    assert "a/sample.txt" in diff_text
+    assert "b/sample.txt" in diff_text
+    assert "-old" in diff_text
+    assert "+new" in diff_text
+
+
+def test_ui_render_diff_rich_mode_includes_filenames(monkeypatch):
+    view = UI(plain=False)
+
+    @contextmanager
+    def _pager(*_args, **_kwargs):
+        yield None
+
+    monkeypatch.setattr(view.console, "pager", _pager)
+    with view.console.capture() as capture:
+        view.render_diff("old\n", "new\n", filename="sample.txt")
+    output = _strip_ansi(capture.get())
+    assert "sample.txt" in output
+
+
+def test_ui_progress_plain_emits_completion_line():
+    view = UI(plain=True)
+    console = _RecordingConsole()
+    view.console = console
+
+    with view.progress("Syncing items", total=2) as tracker:
+        tracker.advance()
+        tracker.advance()
+
+    assert console.lines[0] == "Syncing items..."
+    assert any("complete" in line and "(2/2)" in line for line in console.lines)
+
+
+def test_ui_progress_rich_uses_integer_format(monkeypatch):
+    captured = {}
+
+    class DummyProgress:
+        def __init__(self, *columns, **_kwargs):
+            captured["columns"] = columns
+
+        def add_task(self, description, total=None):
+            captured["description"] = description
+            captured["total"] = total
+            return 1
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def advance(self, _task_id, advance):
+            captured["advance"] = advance
+
+        def update(self, _task_id, **kwargs):
+            captured["update"] = kwargs
+
+    monkeypatch.setattr(ui_module, "Progress", DummyProgress)
+
+    view = UI(plain=False)
+    tracker = view.progress("Syncing items", total=3)
+
+    count_column = next(
+        column
+        for column in captured["columns"]
+        if isinstance(column, ui_module.TextColumn) and "task.completed" in column.text_format
+    )
+    assert count_column.text_format == "{task.completed:.0f}/{task.total:.0f}"
+
+    with tracker:
+        tracker.advance(1)
+        tracker.update(description="Next", total=4)
+
+    assert captured["description"] == "Syncing items"
+    assert captured["total"] == 3
+    assert captured["advance"] == 1
+    assert captured["update"] == {"description": "Next", "total": 4}
+
+
+def test_console_facade_status_plain_outputs_message_only():
+    facade = ConsoleFacade(plain=True)
+    console = _RecordingConsole()
+    facade.console = console
+
+    facade.error("error")
+    facade.warning("warn")
+    facade.success("ok")
+    facade.info("info")
+
+    assert console.lines[0].split(" ", 1)[1] == "error"
+    assert console.lines[1].split(" ", 1)[1] == "warn"
+    assert console.lines[2].split(" ", 1)[1] == "ok"
+    assert console.lines[3] == "info"
+
+
+def test_console_facade_status_rich_includes_messages():
+    facade = ConsoleFacade(plain=False)
+    with facade.console.capture() as capture:
+        facade.error("error")
+        facade.warning("warn")
+        facade.success("ok")
+        facade.info("info")
+    output = _strip_ansi(capture.get())
+    assert "error" in output
+    assert "warn" in output
+    assert "ok" in output
+    assert "info" in output

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -117,3 +117,10 @@ def test_ui_input_interactive_uses_questionary(monkeypatch):
     view = UI(plain=False)
     assert view.input("Enter", default="fallback") == "value"
     assert calls and calls[0] == ("Enter", "fallback")
+
+
+def test_plain_progress_formats_integerish_values():
+    tracker = ui_module._PlainProgressTracker
+    assert tracker._coerce_int(5.0000001) == 5
+    assert tracker._format_value(12.0000001) == "12"
+    assert tracker._format_value(12.5) == "12.5"

--- a/tests/test_util_paths.py
+++ b/tests/test_util_paths.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from polylogue import util
+
+
+def test_resolve_claude_code_project_root_prefers_config_dir(tmp_path, monkeypatch):
+    monkeypatch.delenv("POLYLOGUE_CLAUDE_CODE_PROJECTS", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    config_root = tmp_path / ".config" / "claude" / "projects"
+    config_root.mkdir(parents=True, exist_ok=True)
+
+    resolved = util.resolve_claude_code_project_root()
+
+    assert resolved == config_root
+
+
+def test_resolve_claude_code_project_root_env_override(tmp_path, monkeypatch):
+    custom = tmp_path / "custom-projects"
+    custom.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("POLYLOGUE_CLAUDE_CODE_PROJECTS", str(custom))
+
+    resolved = util.resolve_claude_code_project_root()
+
+    assert resolved == custom


### PR DESCRIPTION
## Summary

I centralized path and credential resolution for Drive sync, replaced several import-time root globals with config-aware helpers, and rebuilt export detection so ChatGPT / Claude bundles can be found and classified reliably even when they are nested or too large for eager parsing. The practical outcome is that `config.json` can drive more of the real sync behavior without acting like documentation for a partially env-driven runtime. At the same time, the archive utilities that scan outputs (`attachments`, `prune`, `stats`, `status`) respect the active config object not whatever roots happened to be baked into module state at import time. The export-detection work is equally important because repeated sync of local exports only works well if the system can find the right `conversations.json` and classify provider data without pulling a giant archive into memory. Used the same pass to tighten doctor output, Claude Code path discovery, and the Nix module’s Drive-related settings so the effective runtime surface is more coherent end to end.

## Motivation

This branch came out of a cluster of bugs that all pointed to the same architectural weakness: path and config resolution was happening in too many places and at too many times.

Drive credentials are the clearest example. Users could declare credential paths in config or through Nix-managed settings, but parts of the runtime still looked directly at env vars or built-in defaults. That meant `config.json` was not actually the source of truth for the full sync path.

Output roots had a similar issue. `DEFAULT_OUTPUT_ROOTS` was computed at import time from the module-level config, which meant later changes to `env.config` or labeled roots were invisible to commands that should have been scanning the active archive layout. Tests had to patch globals, which is always a warning sign.

Export discovery was the third pain point. The archive scanner worked fine for shallow, conventional exports, but it was much less trustworthy for nested bundles or very large `conversations.json` files. Loading a massive export just to decide whether it looked like ChatGPT or Claude is unnecessary work, and it becomes fragile when the schema is slightly irregular.

The fix was not “patch one bug at a time.” The fix was to make config resolution explicit and pass the active config object all the way through the places that need it.

## Changes by concern

### 1. Make Drive client construction deterministic

The most important product change is the introduction of a single construction path for Drive access. `build_drive_client()` in `polylogue/commands.py` resolves:

- credentials path
- token path
- retry count
- retry base delay

using the same precedence chain everywhere:

1. explicit env overrides
2. config values
3. built-in defaults

Updated `DriveClient.__init__()` so callers can pass explicit credential/token paths instead of hoping the right environment variables are present. That makes the client much easier to reason about in CLI code, tests, and the Nix service layer.

The config side mirrors that change. `DriveConfig` is a first-class part of config parsing/persistence, and it accepts both snake_case and camelCase keys so the runtime is tolerant of how the value got there while still writing back a stable config shape.

### 2. Stop baking output roots at import time

`resolve_output_roots(config)` is the small helper with outsized impact in this branch. Instead of treating output roots as a static module-level constant, commands now ask for the roots from the active config object when they actually need them.

That affects:

- attachments stats / extraction
- prune
- archive stats
- status-like scans

The benefit is simple: these utilities now follow `env.config` and labeled roots correctly. It also makes tests much cleaner because they can modify the config object under test instead of monkeypatching imported globals.

I paired that with a prefs cleanup (`load_prefs()` as a public helper and `CommandEnv.prefs` populated at startup) so both config and per-command preference state now enter the CLI through explicit initialization rather than accidental module state.

### 3. Rebuild export detection around layered strategies

The detection pipeline now tries the cheapest dependable thing first and only escalates when necessary. The important pieces are:

- `find_conversations_json()` for recursive discovery
- streaming classification for large files
- full parse when the file is small enough or the stream path is insufficient
- snippet heuristics as a fallback for oversized or awkward cases
- provider filtering at discovery time so the sync path does less speculative work

That layered approach is what makes the change valuable. I did not want to replace one fragile classifier with another fragile classifier. The scanner has a progressive strategy that can handle both conventional exports and nested/unusual ones without assuming everything should be slurped into memory.

### 4. Tighten sync and doctor behavior around the new config model

Once paths were explicit, a few sync/doctor mismatches became obvious.

In local sync:

- ChatGPT / Claude export base dirs now come from config unless overridden
- output directories are checked for writability up front
- mtime checks run before content hashing for the fast path
- hash-based skips require the markdown output to exist, which avoids over-trusting partially written state

In doctor:

- expensive checks can be skipped explicitly
- progress callbacks surface long-running phases
- output directories are checked for existence/writability
- credential resolution uses the same config-aware path as sync

Claude Code path discovery also gets a needed update by checking both `~/.claude/projects/` and `~/.config/claude/projects/`, with `POLYLOGUE_CLAUDE_CODE_PROJECTS` still available as an escape hatch.

### 5. Carry the same rules into Nix

The Nix module changes are not incidental. Once Drive settings became explicit config, it made sense to expose:

- `credentialsPath`
- `tokenPath`
- `retries`
- `retryBase`

at the module level and to wire the right environment into the service units. That gives declarative installs a credible story for the same behavior the CLI uses locally.

## Testing

The branch broadens tests around the exact resolution rules it changes:

- Drive client tests for credential/token precedence and auth prompting
- config-root and stats tests for active-root resolution
- local sync tests for export detection and skip behavior
- doctor tests for output-path checks and progress/reporting
- interactive/plain config coverage for the updated initialization path

This is important because precedence bugs are usually subtle. The tests are there to pin down which layer wins rather than leaving that behavior implicit.

## Notes

Kept the env → config → default ordering instead of trying to outlaw env overrides. That is still the most practical model for CLI tools, tests, and Nix-managed services. The goal of the branch is not to eliminate env overrides; it is to make them deliberate and consistent. Intentionally left export classification layered rather than “one true parser,” because the source data is diverse enough that a progressive strategy is easier to keep reliable.
