### PR TITLE
feat: expose tag inventory and make metadata edits atomic

### DIFF
--- a/polylogue/cli/click_app.py
+++ b/polylogue/cli/click_app.py
@@ -117,6 +117,7 @@ def _handle_query_mode(ctx: click.Context) -> None:
     has_filters = any(
         params.get(k)
         for k in (
+            "conv_id",
             "contains",
             "exclude_text",
             "provider",
@@ -144,8 +145,18 @@ def _handle_query_mode(ctx: click.Context) -> None:
         )
     )
 
-    # Stats mode: no query terms, no filters, and no explicit output mode
-    if not query_terms and not has_filters and not has_output_mode:
+    # Modifier flags that require query execution
+    has_modifiers = any(
+        params.get(k)
+        for k in (
+            "add_tag",
+            "set_meta",
+            "delete_matched",
+        )
+    )
+
+    # Stats mode: no query terms, no filters, no output mode, and no modifiers
+    if not query_terms and not has_filters and not has_output_mode and not has_modifiers:
         _show_stats(env, verbose=params.get("verbose", False))
         return
 

--- a/polylogue/cli/click_app.py
+++ b/polylogue/cli/click_app.py
@@ -138,6 +138,7 @@ def _handle_query_mode(ctx: click.Context) -> None:
             "list_mode",
             "limit",
             "stats_only",
+            "count_only",
             "stream",
             "dialogue_only",
         )
@@ -207,6 +208,7 @@ def _show_stats(env: AppEnv, *, verbose: bool = False) -> None:
 @click.option("--fields", help="Fields for list/json: id, title, provider, date, messages, words, tags, summary")
 @click.option("--list", "list_mode", is_flag=True, help="Force list format")
 @click.option("--stats", "stats_only", is_flag=True, help="Only statistics, no content")
+@click.option("--count", "count_only", is_flag=True, help="Print matched count and exit")
 @click.option(
     "--stats-by",
     "stats_by",
@@ -260,6 +262,7 @@ def cli(
     fields: str | None,
     list_mode: bool,
     stats_only: bool,
+    count_only: bool,
     stats_by: str | None,
     open_result: bool,
     transform: str | None,

--- a/polylogue/cli/click_app.py
+++ b/polylogue/cli/click_app.py
@@ -22,6 +22,7 @@ from polylogue.cli.commands.mcp import mcp_command
 from polylogue.cli.commands.reset import reset_command
 from polylogue.cli.commands.run import run_command, sources_command
 from polylogue.cli.commands.site import site_command
+from polylogue.cli.commands.tags import tags_command
 from polylogue.cli.formatting import announce_plain_mode, should_use_plain
 from polylogue.cli.types import AppEnv
 from polylogue.ui import create_ui
@@ -299,6 +300,7 @@ def cli(
         polylogue run       Ingest/render/index pipeline
         polylogue check     Health check and repair
         polylogue embed     Generate vector embeddings
+        polylogue tags      List tags with counts
         polylogue site      Build static HTML archive
         polylogue sources   List configured sources
         polylogue mcp       Start MCP server
@@ -328,6 +330,7 @@ cli.add_command(completions_command)
 cli.add_command(dashboard_command)
 cli.add_command(embed_command)
 cli.add_command(site_command)
+cli.add_command(tags_command)
 
 
 def main() -> None:

--- a/polylogue/cli/click_app.py
+++ b/polylogue/cli/click_app.py
@@ -203,7 +203,7 @@ def _show_stats(env: AppEnv, *, verbose: bool = False) -> None:
     type=click.Choice(["markdown", "json", "html", "obsidian", "org", "yaml", "plaintext", "csv"]),
     help="Output format",
 )
-@click.option("--fields", help="Select fields for list/json output (comma-separated)")
+@click.option("--fields", help="Fields for list/json: id, title, provider, date, messages, words, tags, summary")
 @click.option("--list", "list_mode", is_flag=True, help="Force list format")
 @click.option("--stats", "stats_only", is_flag=True, help="Only statistics, no content")
 @click.option(
@@ -219,7 +219,7 @@ def _show_stats(env: AppEnv, *, verbose: bool = False) -> None:
     help="Transform output: strip-tools, strip-thinking, or strip-all",
 )
 # --- Streaming options (memory-efficient for large conversations) ---
-@click.option("--stream", is_flag=True, help="Stream output (low memory, no buffering)")
+@click.option("--stream", is_flag=True, help="Stream output (low memory). Requires --latest or -i ID")
 @click.option("--dialogue-only", "-d", is_flag=True, help="Show only user/assistant messages")
 # --- Modifier options (write operations) ---
 @click.option("--set", "set_meta", nargs=2, multiple=True, help="Set metadata key value")
@@ -284,12 +284,24 @@ def cli(
         polylogue --latest --output browser
 
     \b
+    Combined filters:
+        polylogue "error" -p claude --since 2025-01 --list
+        polylogue --has thinking --sort tokens --limit 10
+        polylogue -t important --stats-by provider
+
+    \b
+    Modifiers (write operations):
+        polylogue "urgent" --add-tag review --dry-run
+        polylogue -p old --delete --dry-run
+
+    \b
     Subcommands:
-        polylogue run     Run pipeline stages (acquire, parse, render, index)
-        polylogue check   Health check and repair
-        polylogue mcp     Start MCP server
-        polylogue reset   Reset database
-        polylogue auth    Google Drive OAuth
+        polylogue run       Ingest/render/index pipeline
+        polylogue check     Health check and repair
+        polylogue embed     Generate vector embeddings
+        polylogue site      Build static HTML archive
+        polylogue sources   List configured sources
+        polylogue mcp       Start MCP server
 
     Run `polylogue <command> --help` for subcommand details.
     """

--- a/polylogue/cli/commands/auth.py
+++ b/polylogue/cli/commands/auth.py
@@ -129,3 +129,6 @@ def _revoke_drive_credentials(env: AppEnv) -> None:
 
     click.echo("Credentials revoked.")
     click.echo("Run `polylogue auth` to re-authenticate.")
+
+
+__all__ = ["auth_command"]

--- a/polylogue/cli/commands/check.py
+++ b/polylogue/cli/commands/check.py
@@ -111,3 +111,6 @@ def _run_vacuum(env: AppEnv) -> None:
         env.ui.console.print("  VACUUM complete.")
     except Exception as exc:
         env.ui.console.print(f"  VACUUM failed: {exc}")
+
+
+__all__ = ["check_command"]

--- a/polylogue/cli/commands/check.py
+++ b/polylogue/cli/commands/check.py
@@ -17,8 +17,9 @@ from polylogue.health import VerifyStatus, get_health, run_all_repairs
 @click.option("--repair", is_flag=True, help="Attempt to repair detected issues")
 @click.option("--preview", is_flag=True, help="Show what would be repaired without making changes")
 @click.option("--vacuum", is_flag=True, help="Reclaim unused space after repair")
+@click.option("--deep", is_flag=True, help="Run SQLite integrity check (slow on large databases)")
 @click.pass_obj
-def check_command(env: AppEnv, json_output: bool, verbose: bool, repair: bool, preview: bool, vacuum: bool) -> None:
+def check_command(env: AppEnv, json_output: bool, verbose: bool, repair: bool, preview: bool, vacuum: bool, deep: bool) -> None:
     """Health check with optional repair."""
     if vacuum and not repair:
         fail("check", "--vacuum requires --repair")
@@ -26,7 +27,7 @@ def check_command(env: AppEnv, json_output: bool, verbose: bool, repair: bool, p
         fail("check", "--preview requires --repair")
 
     config = load_effective_config(env)
-    report = get_health(config)
+    report = get_health(config, deep=deep)
 
     # Run repairs before output so JSON mode includes repair results
     repair_results: list | None = None

--- a/polylogue/cli/commands/completions.py
+++ b/polylogue/cli/commands/completions.py
@@ -27,3 +27,6 @@ def completions_command(ctx: click.Context, shell: str) -> None:
 
     comp = comp_cls(root_cmd, {}, prog_name, "_POLYLOGUE_COMPLETE")
     click.echo(comp.source())
+
+
+__all__ = ["completions_command"]

--- a/polylogue/cli/commands/dashboard.py
+++ b/polylogue/cli/commands/dashboard.py
@@ -15,3 +15,6 @@ def dashboard_command(env: AppEnv) -> None:
     config = get_config()
     app = PolylogueApp(config=config)
     app.run()
+
+
+__all__ = ["dashboard_command"]

--- a/polylogue/cli/commands/mcp.py
+++ b/polylogue/cli/commands/mcp.py
@@ -29,3 +29,6 @@ def mcp_command(env: AppEnv, transport: str) -> None:
         raise SystemExit(1) from None
 
     serve_stdio()
+
+
+__all__ = ["mcp_command"]

--- a/polylogue/cli/commands/reset.py
+++ b/polylogue/cli/commands/reset.py
@@ -107,3 +107,6 @@ def reset_command(
             env.ui.console.print(f"  Failed to delete {name}: {exc}")
 
     env.ui.console.print(f"\nReset complete: {deleted} item(s) deleted.")
+
+
+__all__ = ["reset_command"]

--- a/polylogue/cli/commands/run.py
+++ b/polylogue/cli/commands/run.py
@@ -286,6 +286,8 @@ def run_command(
                         click.echo(f"No new conversations at {time.strftime('%H:%M:%S')}")
                 except DriveError as exc:
                     click.echo(f"Sync error: {exc}", err=True)
+                except Exception as exc:
+                    click.echo(f"Unexpected error during sync: {exc}", err=True)
                 time.sleep(poll_interval)
         except KeyboardInterrupt:
             env.ui.console.print("\nWatch mode stopped.")

--- a/polylogue/cli/commands/run.py
+++ b/polylogue/cli/commands/run.py
@@ -330,3 +330,6 @@ def sources_command(env: AppEnv, json_output: bool) -> None:
         else:
             lines.append(f"{source.name}: (missing path)")
     env.ui.summary("Sources", lines)
+
+
+__all__ = ["run_command", "sources_command"]

--- a/polylogue/cli/commands/run.py
+++ b/polylogue/cli/commands/run.py
@@ -319,7 +319,7 @@ def sources_command(env: AppEnv, json_output: bool) -> None:
             }
             for source in cfg.sources
         ]
-        env.ui.console.print(json.dumps(payload, indent=2))
+        click.echo(json.dumps(payload, indent=2))
         return
     lines = []
     for source in cfg.sources:

--- a/polylogue/cli/commands/run.py
+++ b/polylogue/cli/commands/run.py
@@ -216,7 +216,6 @@ def _webhook_on_new(webhook_url: str, count: int) -> None:
 @click.option("--notify", is_flag=True, help="Desktop notification on new conversations (requires --watch)")
 @click.option("--exec", "exec_cmd", help="Execute command on new conversations (requires --watch)")
 @click.option("--webhook", help="Call webhook URL on new conversations (requires --watch)")
-@click.option("-p", "--provider", help="Limit to specific provider")
 @click.pass_obj
 def run_command(
     env: AppEnv,
@@ -228,7 +227,6 @@ def run_command(
     notify: bool,
     exec_cmd: str | None,
     webhook: str | None,
-    provider: str | None,
 ) -> None:
     """Run pipeline stages on configured sources."""
     # Validate watch-related flags

--- a/polylogue/cli/commands/tags.py
+++ b/polylogue/cli/commands/tags.py
@@ -1,0 +1,63 @@
+"""Tags command for listing and discovering tags."""
+
+from __future__ import annotations
+
+import json
+
+import click
+
+from polylogue.cli.types import AppEnv
+
+
+@click.command("tags")
+@click.option("--provider", "-p", default=None, help="Filter tags by provider")
+@click.option("--json", "json_mode", is_flag=True, help="Output as JSON")
+@click.option("--count", "-n", type=int, default=None, help="Show top N tags")
+@click.pass_obj
+def tags_command(
+    env: AppEnv,
+    provider: str | None,
+    json_mode: bool,
+    count: int | None,
+) -> None:
+    """List all tags with conversation counts.
+
+    \b
+    Examples:
+        polylogue tags                  # List all tags
+        polylogue tags -p claude        # Tags for Claude conversations only
+        polylogue tags --json           # Machine-readable output
+        polylogue tags -n 10            # Top 10 tags
+    """
+    from polylogue.storage.backends.sqlite import SQLiteBackend
+    from polylogue.storage.repository import ConversationRepository
+
+    backend = SQLiteBackend()
+    repo = ConversationRepository(backend=backend)
+
+    tags = repo.list_tags(provider=provider)
+
+    if count is not None:
+        # Truncate to top N (already sorted by count desc from SQL)
+        tags = dict(list(tags.items())[:count])
+
+    if json_mode:
+        click.echo(json.dumps(tags, indent=2))
+        return
+
+    if not tags:
+        if provider:
+            click.echo(f"No tags found for provider '{provider}'.")
+        else:
+            click.echo("No tags found.")
+        click.echo("Hint: use --add-tag to tag conversations, e.g.: polylogue --latest --add-tag important")
+        return
+
+    # Calculate column widths
+    max_tag_len = max(len(t) for t in tags)
+    max_count_len = max(len(str(c)) for c in tags.values())
+
+    header = provider or "all providers"
+    click.echo(f"Tags ({header}, {len(tags)} total):\n")
+    for tag, tag_count in tags.items():
+        click.echo(f"  {tag:<{max_tag_len}}  {tag_count:>{max_count_len}}")

--- a/polylogue/cli/commands/tags.py
+++ b/polylogue/cli/commands/tags.py
@@ -61,3 +61,6 @@ def tags_command(
     click.echo(f"Tags ({header}, {len(tags)} total):\n")
     for tag, tag_count in tags.items():
         click.echo(f"  {tag:<{max_tag_len}}  {tag_count:>{max_count_len}}")
+
+
+__all__ = ["tags_command"]

--- a/polylogue/cli/query.py
+++ b/polylogue/cli/query.py
@@ -1023,12 +1023,11 @@ def _write_message_streaming(msg: Message, output_format: str) -> None:
         sys.stdout.flush()
 
     elif output_format == "markdown":
-        # Markdown format with headers
-        role_label = msg.role.capitalize() if msg.role else "Unknown"
-        sys.stdout.write(f"## {role_label}\n\n")
+        # Markdown format with headers — skip empty-text messages (tool progress, etc.)
         if msg.text:
-            sys.stdout.write(f"{msg.text}\n\n")
-        sys.stdout.flush()
+            role_label = msg.role.capitalize() if msg.role else "Unknown"
+            sys.stdout.write(f"## {role_label}\n\n{msg.text}\n\n")
+            sys.stdout.flush()
 
     elif output_format == "json-lines":
         # JSONL format - one JSON object per line

--- a/polylogue/cli/query.py
+++ b/polylogue/cli/query.py
@@ -766,11 +766,12 @@ def _conv_to_markdown(conv: Conversation) -> str:
     lines.append("")
 
     for msg in conv.messages:
+        if not msg.text:
+            continue
         role_label = (msg.role or "unknown").capitalize()
         lines.append(f"## {role_label}")
         lines.append("")
-        if msg.text:
-            lines.append(msg.text)
+        lines.append(msg.text)
         lines.append("")
 
     return "\n".join(lines)
@@ -794,11 +795,13 @@ def _conv_to_html(conv: Conversation) -> str:
     title_safe = html_escape(title)
     messages_html = []
     for msg in conv.messages:
+        if not msg.text:
+            continue
         role = msg.role or "message"
         role_safe = html_escape(role, quote=True)
         # CSS class names: only allow lowercase alphanumeric and hyphens
         role_class = "message-" + re.sub(r"[^a-z0-9-]", "-", role.lower())
-        html_content = md_renderer.render(msg.text or "")
+        html_content = md_renderer.render(msg.text)
         messages_html.append(
             f'<div class="{role_class}"><strong>{role_safe}:</strong>{html_content}</div>'
         )
@@ -863,10 +866,11 @@ def _conv_to_org(conv: Conversation) -> str:
     ]
 
     for msg in conv.messages:
+        if not msg.text:
+            continue
         role_label = (msg.role or "unknown").upper()
         lines.append(f"* {role_label}")
-        if msg.text:
-            lines.append(msg.text)
+        lines.append(msg.text)
         lines.append("")
 
     return "\n".join(lines)

--- a/polylogue/cli/query.py
+++ b/polylogue/cli/query.py
@@ -428,7 +428,7 @@ def _delete_conversations(
             return
 
     # Individual confirmation if not bulk but not forced
-    if not force:
+    elif not force:
         click.echo(f"About to delete {count} conversation(s):")
         _print_breakdown()
         if not env.ui.confirm("Proceed?", default=False):

--- a/polylogue/cli/query.py
+++ b/polylogue/cli/query.py
@@ -114,7 +114,8 @@ def execute_query(env: AppEnv, params: dict[str, Any]) -> None:
         try:
             filter_chain = filter_chain.since(params["since"])
         except ValueError as exc:
-            click.echo(f"Error: {exc}", err=True)
+            click.echo(f"Error: Cannot parse date: '{params['since']}'", err=True)
+            click.echo("Hint: use ISO format (2025-01-15), relative ('yesterday', 'last week'), or month (2025-01)", err=True)
             raise SystemExit(1) from exc
 
     # Apply --until
@@ -122,7 +123,8 @@ def execute_query(env: AppEnv, params: dict[str, Any]) -> None:
         try:
             filter_chain = filter_chain.until(params["until"])
         except ValueError as exc:
-            click.echo(f"Error: {exc}", err=True)
+            click.echo(f"Error: Cannot parse date: '{params['until']}'", err=True)
+            click.echo("Hint: use ISO format (2025-01-15), relative ('yesterday', 'last week'), or month (2025-01)", err=True)
             raise SystemExit(1) from exc
 
     # Apply --latest (= --sort date --limit 1)
@@ -181,6 +183,7 @@ def execute_query(env: AppEnv, params: dict[str, Any]) -> None:
                 resolved = conv_repo.resolve_id(query_terms[0])
                 if not resolved:
                     click.echo(f"No conversation found matching: {query_terms[0]}", err=True)
+                    click.echo("Hint: use --list to browse conversations, or --latest for most recent", err=True)
                     raise SystemExit(2)
                 full_id = str(resolved)
             else:

--- a/polylogue/cli/query.py
+++ b/polylogue/cli/query.py
@@ -1029,7 +1029,7 @@ def _write_message_streaming(msg: Message, output_format: str) -> None:
     elif output_format == "markdown":
         # Markdown format with headers — skip empty-text messages (tool progress, etc.)
         if msg.text:
-            role_label = msg.role.capitalize() if msg.role else "Unknown"
+            role_label = (msg.role or "unknown").capitalize()
             sys.stdout.write(f"## {role_label}\n\n{msg.text}\n\n")
             sys.stdout.flush()
 

--- a/polylogue/cli/query.py
+++ b/polylogue/cli/query.py
@@ -766,7 +766,7 @@ def _conv_to_markdown(conv: Conversation) -> str:
     lines.append("")
 
     for msg in conv.messages:
-        role_label = msg.role.capitalize()
+        role_label = (msg.role or "unknown").capitalize()
         lines.append(f"## {role_label}")
         lines.append("")
         if msg.text:
@@ -863,7 +863,7 @@ def _conv_to_org(conv: Conversation) -> str:
     ]
 
     for msg in conv.messages:
-        role_label = msg.role.upper()
+        role_label = (msg.role or "unknown").upper()
         lines.append(f"* {role_label}")
         if msg.text:
             lines.append(msg.text)

--- a/polylogue/cli/query.py
+++ b/polylogue/cli/query.py
@@ -679,6 +679,26 @@ def _output_summary_list(
             for s in summaries
         ]
         env.ui.console.print(yaml.dump(data, default_flow_style=False, allow_unicode=True))
+    elif output_format == "csv":
+        import csv
+        import io
+
+        buf = io.StringIO()
+        writer = csv.writer(buf)
+        writer.writerow(["id", "date", "provider", "title", "messages", "tags", "summary"])
+        for s in summaries:
+            date = s.updated_at.strftime("%Y-%m-%d") if s.updated_at else ""
+            tags_str = ",".join(s.tags) if s.tags else ""
+            writer.writerow([
+                str(s.id),
+                date,
+                s.provider,
+                s.display_title or "",
+                msg_counts.get(str(s.id), 0),
+                tags_str,
+                s.summary or "",
+            ])
+        env.ui.console.print(buf.getvalue().rstrip())
     else:
         # Plain text format (default) — now with message counts
         lines = []
@@ -698,10 +718,11 @@ def _conv_to_csv(results: list[Conversation]) -> str:
 
     output = io.StringIO()
     writer = csv.writer(output)
-    writer.writerow(["id", "date", "provider", "title", "messages", "words"])
+    writer.writerow(["id", "date", "provider", "title", "messages", "words", "tags", "summary"])
 
     for conv in results:
         date = conv.updated_at.strftime("%Y-%m-%d") if conv.updated_at else ""
+        tags_str = ",".join(conv.tags) if conv.tags else ""
         writer.writerow(
             [
                 str(conv.id),
@@ -710,6 +731,8 @@ def _conv_to_csv(results: list[Conversation]) -> str:
                 conv.display_title or "",
                 len(conv.messages),
                 sum(m.word_count for m in conv.messages),
+                tags_str,
+                conv.summary or "",
             ]
         )
 

--- a/polylogue/lib/models.py
+++ b/polylogue/lib/models.py
@@ -362,7 +362,7 @@ class Message(BaseModel):
         """Message is primarily context/file content, not dialogue."""
         if not self.text:
             return False
-        if len(self.attachments) > 0 and (not self.text or len(self.text) < 100):
+        if len(self.attachments) > 0 and len(self.text) < 100:
             return True
         # System prompt content
         if "<system>" in self.text and "</system>" in self.text:
@@ -437,7 +437,7 @@ class DialoguePair(BaseModel):
     @property
     def exchange(self) -> str:
         """Render as text exchange."""
-        return f"User: {self.user.text}\n\nAssistant: {self.assistant.text}"
+        return f"User: {self.user.text or ''}\n\nAssistant: {self.assistant.text or ''}"
 
 
 class ConversationSummary(BaseModel):

--- a/polylogue/paths.py
+++ b/polylogue/paths.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 
 def _xdg_path(env_var: str, fallback: Path) -> Path:
-    raw = os.environ.get(env_var)
+    raw = os.environ.get(env_var, "").strip()
     if raw:
         return Path(raw).expanduser()
     return fallback

--- a/polylogue/pipeline/ingest.py
+++ b/polylogue/pipeline/ingest.py
@@ -19,25 +19,11 @@ from polylogue.pipeline.ids import (
     message_id as make_message_id,
 )
 from polylogue.sources import IngestBundle, ParsedConversation, ingest_bundle
-from polylogue.storage.backends.sqlite import connection_context
 from polylogue.storage.store import AttachmentRecord, ConversationRecord, ExistingConversation, MessageRecord
 from polylogue.types import AttachmentId, ConversationId, MessageId
 
 if TYPE_CHECKING:
     from polylogue.storage.repository import ConversationRepository
-
-
-def _existing_message_map(conversation_id: str) -> dict[str, str]:
-    with connection_context(None) as conn:
-        rows = conn.execute(
-            """
-            SELECT provider_message_id, message_id
-            FROM messages
-            WHERE conversation_id = ? AND provider_message_id IS NOT NULL
-            """,
-            (conversation_id,),
-        ).fetchall()
-    return {str(row["provider_message_id"]): row["message_id"] for row in rows if row["provider_message_id"]}
 
 
 def prepare_ingest(

--- a/polylogue/pipeline/runner.py
+++ b/polylogue/pipeline/runner.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import contextlib
 import time
 from collections.abc import Iterable, Sequence
 from pathlib import Path
@@ -350,18 +349,24 @@ def latest_run() -> RunRecord | None:
 
     raw_plan = row["plan_snapshot"]
     if isinstance(raw_plan, str) and raw_plan:
-        with contextlib.suppress(ValueError, TypeError):
+        try:
             plan_snapshot = loads(raw_plan)
+        except (ValueError, TypeError) as exc:
+            logger.debug("Corrupt plan_snapshot JSON in run %s: %s", row["run_id"], exc)
 
     raw_counts = row["counts_json"]
     if isinstance(raw_counts, str) and raw_counts:
-        with contextlib.suppress(ValueError, TypeError):
+        try:
             counts = loads(raw_counts)
+        except (ValueError, TypeError) as exc:
+            logger.debug("Corrupt counts_json in run %s: %s", row["run_id"], exc)
 
     raw_drift = row["drift_json"]
     if isinstance(raw_drift, str) and raw_drift:
-        with contextlib.suppress(ValueError, TypeError):
+        try:
             drift = loads(raw_drift)
+        except (ValueError, TypeError) as exc:
+            logger.debug("Corrupt drift_json in run %s: %s", row["run_id"], exc)
 
     return RunRecord(
         run_id=row["run_id"],

--- a/polylogue/pipeline/services/indexing.py
+++ b/polylogue/pipeline/services/indexing.py
@@ -86,7 +86,7 @@ class IndexService:
             Dictionary with 'exists' (bool) and 'count' (int) keys
         """
         try:
-            return index_status()
+            return index_status(self.conn)
         except Exception as exc:
             logger.error("Failed to get index status", error=str(exc))
             return {"exists": False, "count": 0}

--- a/polylogue/pipeline/services/ingestion.py
+++ b/polylogue/pipeline/services/ingestion.py
@@ -307,6 +307,8 @@ class IngestionService:
                             conv_id = futures.get(fut, "?")
                             logger.error("Error processing conversation %s: %s", conv_id, exc)
                             result.parse_failures += 1
+                            if progress_callback:
+                                progress_callback(1, desc="Parsing")
                         finally:
                             del futures[fut]
 
@@ -320,6 +322,8 @@ class IngestionService:
                     conv_id = futures.get(fut, "?")
                     logger.error("Error processing conversation %s: %s", conv_id, exc)
                     result.parse_failures += 1
+                    if progress_callback:
+                        progress_callback(1, desc="Parsing")
 
     def _parse_raw_record(self, raw_record: RawConversationRecord) -> list[ParsedConversation]:
         """Parse a raw conversation record into ParsedConversation(s).

--- a/polylogue/pipeline/services/ingestion.py
+++ b/polylogue/pipeline/services/ingestion.py
@@ -303,6 +303,10 @@ class IngestionService:
                     for fut in done:
                         try:
                             _handle_future(fut)
+                        except Exception as exc:
+                            conv_id = futures.get(fut, "?")
+                            logger.error("Error processing conversation %s: %s", conv_id, exc)
+                            result.parse_failures += 1
                         finally:
                             del futures[fut]
 
@@ -313,8 +317,9 @@ class IngestionService:
                 try:
                     _handle_future(fut)
                 except Exception as exc:
-                    logger.error("Error processing conversation", error=str(exc))
-                    raise
+                    conv_id = futures.get(fut, "?")
+                    logger.error("Error processing conversation %s: %s", conv_id, exc)
+                    result.parse_failures += 1
 
     def _parse_raw_record(self, raw_record: RawConversationRecord) -> list[ParsedConversation]:
         """Parse a raw conversation record into ParsedConversation(s).

--- a/polylogue/pipeline/services/ingestion.py
+++ b/polylogue/pipeline/services/ingestion.py
@@ -324,6 +324,8 @@ class IngestionService:
                     result.parse_failures += 1
                     if progress_callback:
                         progress_callback(1, desc="Parsing")
+                finally:
+                    del futures[fut]
 
     def _parse_raw_record(self, raw_record: RawConversationRecord) -> list[ParsedConversation]:
         """Parse a raw conversation record into ParsedConversation(s).

--- a/polylogue/rendering/renderers/html.py
+++ b/polylogue/rendering/renderers/html.py
@@ -457,7 +457,7 @@ DEFAULT_HTML_TEMPLATE = """<!DOCTYPE html>
 
         <div class="messages">
             {% for msg in messages %}
-            <article class="message message-{{ msg.role }}" id="msg-{{ loop.index }}">
+            <article class="message message-{{ msg.role or 'unknown' }}" id="msg-{{ loop.index }}">
                 <div class="message-avatar">
                     <span class="avatar-icon">{{ (msg.role or 'msg')[:2] | upper }}</span>
                 </div>
@@ -483,7 +483,7 @@ DEFAULT_HTML_TEMPLATE = """<!DOCTYPE html>
             {% for msg in messages %}
             <li>
                 <a href="#msg-{{ loop.index }}">
-                    {{ msg.role }}: {{ (msg.text or "")[:30] }}{% if msg.text|length > 30 %}...{% endif %}
+                    {{ msg.role or 'unknown' }}: {{ (msg.text or "")[:30] }}{% if msg.text|length > 30 %}...{% endif %}
                 </a>
             </li>
             {% endfor %}

--- a/polylogue/rendering/renderers/html.py
+++ b/polylogue/rendering/renderers/html.py
@@ -483,7 +483,7 @@ DEFAULT_HTML_TEMPLATE = """<!DOCTYPE html>
             {% for msg in messages %}
             <li>
                 <a href="#msg-{{ loop.index }}">
-                    {{ msg.role or 'unknown' }}: {{ (msg.text or "")[:30] }}{% if msg.text|length > 30 %}...{% endif %}
+                    {{ msg.role or 'unknown' }}: {{ (msg.text or "")[:30] }}{% if (msg.text or "")|length > 30 %}...{% endif %}
                 </a>
             </li>
             {% endfor %}

--- a/polylogue/site/builder.py
+++ b/polylogue/site/builder.py
@@ -411,8 +411,8 @@ CONVERSATION_TEMPLATE = """<!DOCTYPE html>
         </div>
 
         {% for msg in messages %}
-        <div class="message message-{{ msg.role }}">
-            <div class="message-role">{{ msg.role }}</div>
+        <div class="message message-{{ msg.role or 'unknown' }}">
+            <div class="message-role">{{ msg.role or 'unknown' }}</div>
             <div class="message-text">{{ msg.text }}</div>
         </div>
         {% endfor %}
@@ -777,7 +777,9 @@ class SiteBuilder:
             # Stream messages without loading full conversation
             messages = []
             for msg in repo.iter_messages(conv_idx.id, limit=500):
-                text = msg.text or ""
+                if not msg.text:
+                    continue
+                text = msg.text
                 # Truncate very long messages for the static site
                 if len(text) > 5000:
                     text = text[:5000] + "\n\n[... truncated ...]"

--- a/polylogue/sources/parsers/chatgpt.py
+++ b/polylogue/sources/parsers/chatgpt.py
@@ -33,6 +33,8 @@ def extract_messages_from_mapping(mapping: dict[str, object]) -> tuple[list[Pars
         if not isinstance(parts, list):
             continue
         text = "\n".join(str(part) for part in parts if part)
+        if not text:
+            continue
         # Role is required - skip messages without one
         author = msg.get("author")
         raw_role = author.get("role") if isinstance(author, dict) else None

--- a/polylogue/sources/parsers/claude.py
+++ b/polylogue/sources/parsers/claude.py
@@ -175,19 +175,29 @@ def extract_text_from_segments(segments: list[object]) -> str | None:
 
 
 def normalize_timestamp(ts: int | float | str | None) -> str | None:
+    """Normalize a timestamp to epoch seconds string.
+
+    Handles numeric epochs (int/float/str), millisecond epochs, and ISO 8601 strings.
+    """
     if ts is None:
         return None
+    # Try numeric first
     try:
         val = float(ts)
         # If timestamp is > 1e11 (year 5138), assume milliseconds and convert to seconds
-        # 1e11 seconds is roughly year 5138.
-        # 1700000000000 (current ms) is 1.7e12.
         if val > 1e11:
             val = val / 1000.0
         return str(val)
     except (ValueError, TypeError):
-        logger.debug("Non-numeric timestamp value: %r", ts)
-        return None
+        pass
+    # Try ISO 8601 string
+    if isinstance(ts, str):
+        from polylogue.lib.timestamps import parse_timestamp
+
+        dt = parse_timestamp(ts)
+        if dt is not None:
+            return str(dt.timestamp())
+    return None
 
 
 def extract_messages_from_chat_messages(chat_messages: list[object]) -> tuple[list[ParsedMessage], list[ParsedAttachment]]:

--- a/polylogue/sources/providers/chatgpt.py
+++ b/polylogue/sources/providers/chatgpt.py
@@ -105,7 +105,7 @@ class ChatGPTMessage(BaseModel):
             for part in self.content.parts:
                 if isinstance(part, str):
                     texts.append(part)
-                elif isinstance(part, dict) and "text" in part:
+                elif isinstance(part, dict) and part.get("text"):
                     texts.append(part["text"])
             return "\n".join(texts)
 

--- a/polylogue/sources/providers/gemini.py
+++ b/polylogue/sources/providers/gemini.py
@@ -131,7 +131,8 @@ class GeminiMessage(BaseModel):
             if isinstance(part, GeminiPart) and part.text:
                 texts.append(part.text)
             elif isinstance(part, dict) and part.get("text"):
-                texts.append(part["text"])
+                val = part["text"]
+                texts.append(val if isinstance(val, str) else str(val))
         return "\n".join(texts)
 
     def to_meta(self) -> MessageMeta:
@@ -149,7 +150,7 @@ class GeminiMessage(BaseModel):
     def extract_reasoning_traces(self) -> list[ReasoningTrace]:
         """Extract thinking/reasoning traces."""
         traces = []
-        if self.isThought:
+        if self.isThought and self.text:
             # Normalize signatures (can be strings, dicts, or models)
             sigs: list[str | dict[str, Any]] = []
             for s in self.thoughtSignatures:

--- a/polylogue/sources/providers/gemini.py
+++ b/polylogue/sources/providers/gemini.py
@@ -130,7 +130,7 @@ class GeminiMessage(BaseModel):
         for part in self.parts:
             if isinstance(part, GeminiPart) and part.text:
                 texts.append(part.text)
-            elif isinstance(part, dict) and "text" in part:
+            elif isinstance(part, dict) and part.get("text"):
                 texts.append(part["text"])
         return "\n".join(texts)
 
@@ -199,7 +199,7 @@ class GeminiMessage(BaseModel):
                         raw=part.model_dump(),
                     ))
             elif isinstance(part, dict):
-                if "text" in part:
+                if part.get("text"):
                     blocks.append(ContentBlock(
                         type=ContentType.TEXT,
                         text=part["text"],

--- a/polylogue/storage/backends/sqlite.py
+++ b/polylogue/storage/backends/sqlite.py
@@ -1082,6 +1082,9 @@ class SQLiteBackend:
         if limit is not None:
             query += " LIMIT ?"
             params.append(limit)
+        elif offset > 0:
+            # SQLite requires LIMIT before OFFSET; use -1 for unlimited
+            query += " LIMIT -1"
 
         if offset > 0:
             query += " OFFSET ?"

--- a/polylogue/storage/repository.py
+++ b/polylogue/storage/repository.py
@@ -398,6 +398,10 @@ class ConversationRepository:
         with self._write_lock:
             self._backend.remove_tag(conversation_id, tag)
 
+    def list_tags(self, *, provider: str | None = None) -> dict[str, int]:
+        """List all tags with counts. Read-only, no write lock needed."""
+        return self._backend.list_tags(provider=provider)
+
     def set_metadata(self, conversation_id: str, metadata: dict[str, object]) -> None:
         with self._write_lock:
             self._backend.set_metadata(conversation_id, metadata)

--- a/polylogue/storage/repository.py
+++ b/polylogue/storage/repository.py
@@ -100,7 +100,7 @@ class ConversationRepository:
 
     def list_summaries(
         self,
-        limit: int = 50,
+        limit: int | None = 50,
         offset: int = 0,
         provider: str | None = None,
         providers: builtins.list[str] | None = None,
@@ -124,7 +124,7 @@ class ConversationRepository:
 
     def list(
         self,
-        limit: int = 50,
+        limit: int | None = 50,
         offset: int = 0,
         provider: str | None = None,
         providers: builtins.list[str] | None = None,

--- a/polylogue/storage/repository.py
+++ b/polylogue/storage/repository.py
@@ -286,7 +286,7 @@ class ConversationRepository:
     def _get_message_conversation_mapping(self, message_ids: builtins.list[str]) -> dict[str, str]:
         from polylogue.storage.backends.sqlite import open_connection
 
-        with open_connection(None) as conn:
+        with open_connection(self._db_path) as conn:
             placeholders = ",".join("?" * len(message_ids))
             query = f"SELECT message_id, conversation_id FROM messages WHERE message_id IN ({placeholders})"
             rows = conn.execute(query, message_ids).fetchall()

--- a/polylogue/storage/search_providers/sqlite_vec.py
+++ b/polylogue/storage/search_providers/sqlite_vec.py
@@ -311,9 +311,7 @@ class SqliteVecProvider:
                     ),
                 )
 
-            conn.commit()
-
-            # Update embedding status
+            # Update embedding status (single atomic commit with the inserts above)
             conn.execute(
                 """
                 INSERT INTO embedding_status (

--- a/polylogue/storage/search_providers/sqlite_vec.py
+++ b/polylogue/storage/search_providers/sqlite_vec.py
@@ -125,7 +125,10 @@ class SqliteVecProvider:
                 finally:
                     conn.enable_load_extension(False)
             except Exception as exc:
-                logger.warning("sqlite-vec extension load failed on connection: %s", exc)
+                conn.close()
+                raise SqliteVecError(
+                    f"sqlite-vec extension failed to load on connection: {exc}"
+                ) from exc
 
         return conn
 

--- a/polylogue/storage/search_providers/sqlite_vec.py
+++ b/polylogue/storage/search_providers/sqlite_vec.py
@@ -201,7 +201,10 @@ class SqliteVecProvider:
                     time.sleep(0.1)
 
             except httpx.HTTPError as exc:
-                raise SqliteVecError(f"Embedding generation failed: {exc}") from exc
+                # Sanitize: don't leak API keys or full URLs in error messages
+                status = getattr(exc.response, "status_code", None) if hasattr(exc, "response") else None
+                detail = f"HTTP {status}" if status else type(exc).__name__
+                raise SqliteVecError(f"Embedding generation failed: {detail}") from exc
 
         return all_embeddings
 

--- a/polylogue/storage/search_providers/sqlite_vec.py
+++ b/polylogue/storage/search_providers/sqlite_vec.py
@@ -8,7 +8,6 @@ No external server required - vectors stored directly in SQLite.
 
 from __future__ import annotations
 
-import contextlib
 import logging
 import struct
 from pathlib import Path
@@ -428,15 +427,19 @@ class SqliteVecProvider:
             msg_count = 0
             pending = 0
 
-            with contextlib.suppress(Exception):
+            try:
                 msg_count = conn.execute(
                     "SELECT COUNT(*) FROM message_embeddings"
                 ).fetchone()[0]
+            except Exception as exc:
+                logger.debug("message_embeddings count failed (table may not exist): %s", exc)
 
-            with contextlib.suppress(Exception):
+            try:
                 pending = conn.execute(
                     "SELECT COUNT(*) FROM embedding_status WHERE needs_reindex = 1"
                 ).fetchone()[0]
+            except Exception as exc:
+                logger.debug("embedding_status count failed (table may not exist): %s", exc)
 
             return {
                 "embedded_messages": msg_count,

--- a/polylogue/ui/facade.py
+++ b/polylogue/ui/facade.py
@@ -45,7 +45,12 @@ class PlainConsole:
         pass
 
     def print(self, *objects: object, **_: object) -> None:
-        text = " ".join(str(obj) for obj in objects)
+        raw = " ".join(str(obj) for obj in objects)
+        # Strip Rich markup (e.g. [bold], [green], [/#d97757]) for plain output
+        try:
+            text = Text.from_markup(raw).plain
+        except Exception:
+            text = raw
         print(text)
 
 

--- a/polylogue/ui/tui/screens/browser.py
+++ b/polylogue/ui/tui/screens/browser.py
@@ -77,7 +77,7 @@ class Browser(Container):
 
         for msg in conv.messages:
             role_icon = "👤" if msg.role == "user" else "🤖"
-            md_lines.append(f"### {role_icon} {msg.role.upper()}")
+            md_lines.append(f"### {role_icon} {(msg.role or 'unknown').upper()}")
             md_lines.append(msg.text or "*[No content]*")
             md_lines.append("")
 

--- a/polylogue/ui/tui/screens/search.py
+++ b/polylogue/ui/tui/screens/search.py
@@ -77,7 +77,7 @@ class Search(Container):
 
         for msg in conv.messages:
             role_icon = "👤" if msg.role == "user" else "🤖"
-            md_lines.append(f"### {role_icon} {msg.role.upper()}")
+            md_lines.append(f"### {role_icon} {(msg.role or 'unknown').upper()}")
             md_lines.append(msg.text or "*[No content]*")
             md_lines.append("")
 

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -294,12 +294,11 @@ class TestCheckCommand:
         result = cli_runner.invoke(cli, ["check"])
         assert result.exit_code == 0
 
-        # Should show healthy status checks
+        # Should show healthy status checks (no integrity_check without --deep)
         assert "OK database" in result.output
-        assert "OK sqlite_integrity" in result.output
 
     def test_check_sqlite_integrity_check(self, db_path, cli_runner):
-        """Check includes SQLite integrity check in results."""
+        """Check includes SQLite integrity check when --deep is passed."""
         factory = DbFactory(db_path)
 
         factory.create_conversation(
@@ -308,7 +307,7 @@ class TestCheckCommand:
             messages=[{"id": "m1", "role": "user", "text": "test"}],
         )
 
-        result = cli_runner.invoke(cli, ["--plain", "check", "--json"])
+        result = cli_runner.invoke(cli, ["--plain", "check", "--deep", "--json"])
         assert result.exit_code == 0
 
         data = _extract_json(result.output)

--- a/tests/test_cli_run.py
+++ b/tests/test_cli_run.py
@@ -786,8 +786,8 @@ class TestDeleteConversationPreview:
         captured = capsys.readouterr()
         assert "Date range: 2023-06-01 → 2024-02-15" in captured.out
 
-    def test_delete_bulk_shows_breakdown_before_exit(self, capsys):
-        """Bulk deletion (>10 items) without force shows breakdown and exits."""
+    def test_delete_bulk_shows_breakdown_and_prompts(self, capsys):
+        """Bulk deletion (>10 items) without force shows breakdown and prompts."""
         from unittest.mock import MagicMock
         from datetime import datetime
 
@@ -815,12 +815,9 @@ class TestDeleteConversationPreview:
         env.ui.console.print = MagicMock()
         env.ui.confirm = MagicMock(return_value=False)
 
-        # Should raise SystemExit for bulk without force
-        try:
-            _delete_conversations(env, convs, {"force": False})
-            assert False, "Expected SystemExit"
-        except SystemExit as e:
-            assert e.code == 1
+        # Should prompt for confirmation and abort when declined
+        _delete_conversations(env, convs, {"force": False})
+        env.ui.confirm.assert_called_once()
 
         captured = capsys.readouterr()
         assert "About to DELETE 15 conversations" in captured.err

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import stat
@@ -581,3 +582,701 @@ class TestCachePath:
 
         assert result == tmp_path / "health.json"
         assert result.name == "health.json"
+
+
+def _insert_conversation(conn, conversation_id: str, provider_name: str = "test", title: str = "Test"):
+    """Helper to insert a conversation with all required fields."""
+    content_hash = hashlib.sha256(f"{provider_name}:{conversation_id}".encode()).hexdigest()
+    conn.execute(
+        "INSERT INTO conversations (conversation_id, provider_name, provider_conversation_id, title, content_hash, version) VALUES (?, ?, ?, ?, ?, ?)",
+        (conversation_id, provider_name, f"{provider_name}-id", title, content_hash, 1),
+    )
+
+
+def _insert_message(conn, message_id: str, conversation_id: str, role: str = "user", text: str = "Text", provider_meta: dict | None = None, allow_orphaned: bool = False):
+    """Helper to insert a message with all required fields."""
+    content_hash = hashlib.sha256(f"{message_id}:{text}".encode()).hexdigest()
+    meta = json.dumps(provider_meta) if provider_meta else None
+    if allow_orphaned:
+        # Temporarily disable foreign keys to insert orphaned message
+        conn.execute("PRAGMA foreign_keys = OFF")
+        try:
+            conn.execute(
+                "INSERT INTO messages (message_id, conversation_id, role, text, content_hash, version, provider_meta) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (message_id, conversation_id, role, text, content_hash, 1, meta),
+            )
+        finally:
+            conn.execute("PRAGMA foreign_keys = ON")
+    else:
+        conn.execute(
+            "INSERT INTO messages (message_id, conversation_id, role, text, content_hash, version, provider_meta) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (message_id, conversation_id, role, text, content_hash, 1, meta),
+        )
+
+
+class TestRepairOrphanedMessages:
+    """Tests for repair_orphaned_messages function."""
+
+    def test_clean_state_no_orphaned_messages(self, cli_workspace):
+        """repair_orphaned_messages should return 0 when no orphans exist."""
+        from polylogue.config import get_config
+        from polylogue.health import repair_orphaned_messages
+        from polylogue.storage.backends.sqlite import connection_context
+
+        # Setup: create a valid conversation and message
+        config = get_config()
+        with connection_context(None) as conn:
+            _insert_conversation(conn, "conv-1")
+            _insert_message(conn, "msg-1", "conv-1")
+            conn.commit()
+
+        # Act
+        result = repair_orphaned_messages(config, dry_run=False)
+
+        # Assert
+        assert result.name == "orphaned_messages"
+        assert result.repaired_count == 0
+        assert result.success is True
+        assert "No orphaned" in result.detail
+
+    def test_orphaned_messages_found_and_deleted(self, cli_workspace):
+        """repair_orphaned_messages should find and delete orphaned messages."""
+        from polylogue.config import get_config
+        from polylogue.health import repair_orphaned_messages
+        from polylogue.storage.backends.sqlite import connection_context
+
+        config = get_config()
+        with connection_context(None) as conn:
+            # Insert orphaned message (references non-existent conversation)
+            _insert_message(conn, "orphan-1", "nonexistent-conv", "user", "I am orphaned", allow_orphaned=True)
+            _insert_message(conn, "orphan-2", "nonexistent-conv", "assistant", "Also orphaned", allow_orphaned=True)
+            conn.commit()
+
+        # Act
+        result = repair_orphaned_messages(config, dry_run=False)
+
+        # Assert
+        assert result.name == "orphaned_messages"
+        assert result.repaired_count == 2
+        assert result.success is True
+
+        # Verify they were actually deleted
+        with connection_context(None) as conn:
+            remaining = conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0]
+            assert remaining == 0
+
+    def test_orphaned_messages_dry_run_counts_but_doesnt_delete(self, cli_workspace):
+        """repair_orphaned_messages with dry_run=True should count but not delete."""
+        from polylogue.config import get_config
+        from polylogue.health import repair_orphaned_messages
+        from polylogue.storage.backends.sqlite import connection_context
+
+        config = get_config()
+        with connection_context(None) as conn:
+            _insert_message(conn, "orphan-1", "nonexistent-conv", "user", "I am orphaned", allow_orphaned=True)
+            conn.commit()
+
+        # Act
+        result = repair_orphaned_messages(config, dry_run=True)
+
+        # Assert
+        assert result.repaired_count == 1
+        assert result.success is True
+        assert "Would:" in result.detail
+
+        # Verify data was NOT deleted
+        with connection_context(None) as conn:
+            remaining = conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0]
+            assert remaining == 1
+
+    def test_orphaned_messages_idempotency(self, cli_workspace):
+        """Running repair twice should find 0 on second run."""
+        from polylogue.config import get_config
+        from polylogue.health import repair_orphaned_messages
+        from polylogue.storage.backends.sqlite import connection_context
+
+        config = get_config()
+        with connection_context(None) as conn:
+            _insert_message(conn, "orphan-1", "nonexistent-conv", "user", "I am orphaned", allow_orphaned=True)
+            conn.commit()
+
+        # First repair
+        result1 = repair_orphaned_messages(config, dry_run=False)
+        assert result1.repaired_count == 1
+
+        # Second repair should find nothing
+        result2 = repair_orphaned_messages(config, dry_run=False)
+        assert result2.repaired_count == 0
+        assert result2.success is True
+
+
+class TestRepairEmptyConversations:
+    """Tests for repair_empty_conversations function."""
+
+    def test_clean_state_no_empty_conversations(self, cli_workspace):
+        """repair_empty_conversations should return 0 when no empty convos exist."""
+        from polylogue.config import get_config
+        from polylogue.health import repair_empty_conversations
+        from polylogue.storage.backends.sqlite import connection_context
+
+        config = get_config()
+        with connection_context(None) as conn:
+            # Create conversation with message
+            _insert_conversation(conn, "conv-1")
+            _insert_message(conn, "msg-1", "conv-1", "user", "Hello")
+            conn.commit()
+
+        # Act
+        result = repair_empty_conversations(config, dry_run=False)
+
+        # Assert
+        assert result.name == "empty_conversations"
+        assert result.repaired_count == 0
+        assert result.success is True
+
+    def test_empty_conversations_found_and_deleted(self, cli_workspace):
+        """repair_empty_conversations should find and delete empty conversations."""
+        from polylogue.config import get_config
+        from polylogue.health import repair_empty_conversations
+        from polylogue.storage.backends.sqlite import connection_context
+
+        config = get_config()
+        with connection_context(None) as conn:
+            # Create empty conversations (no messages)
+            _insert_conversation(conn, "empty-1")
+            _insert_conversation(conn, "empty-2")
+            conn.commit()
+
+        # Act
+        result = repair_empty_conversations(config, dry_run=False)
+
+        # Assert
+        assert result.name == "empty_conversations"
+        assert result.repaired_count == 2
+        assert result.success is True
+
+        # Verify they were deleted
+        with connection_context(None) as conn:
+            remaining = conn.execute("SELECT COUNT(*) FROM conversations").fetchone()[0]
+            assert remaining == 0
+
+    def test_empty_conversations_dry_run_counts_but_doesnt_delete(self, cli_workspace):
+        """repair_empty_conversations with dry_run=True should count but not delete."""
+        from polylogue.config import get_config
+        from polylogue.health import repair_empty_conversations
+        from polylogue.storage.backends.sqlite import connection_context
+
+        config = get_config()
+        with connection_context(None) as conn:
+            _insert_conversation(conn, "empty-1")
+            conn.commit()
+
+        # Act
+        result = repair_empty_conversations(config, dry_run=True)
+
+        # Assert
+        assert result.repaired_count == 1
+        assert "Would:" in result.detail
+
+        # Verify not deleted
+        with connection_context(None) as conn:
+            remaining = conn.execute("SELECT COUNT(*) FROM conversations").fetchone()[0]
+            assert remaining == 1
+
+    def test_empty_conversations_idempotency(self, cli_workspace):
+        """Running repair twice should find 0 on second run."""
+        from polylogue.config import get_config
+        from polylogue.health import repair_empty_conversations
+        from polylogue.storage.backends.sqlite import connection_context
+
+        config = get_config()
+        with connection_context(None) as conn:
+            _insert_conversation(conn, "empty-1")
+            conn.commit()
+
+        # First repair
+        result1 = repair_empty_conversations(config, dry_run=False)
+        assert result1.repaired_count == 1
+
+        # Second repair should find nothing
+        result2 = repair_empty_conversations(config, dry_run=False)
+        assert result2.repaired_count == 0
+
+
+class TestRepairDanglingFts:
+    """Tests for repair_dangling_fts function."""
+
+    def test_clean_fts_state(self, cli_workspace):
+        """repair_dangling_fts should return 0 when FTS is in sync."""
+        from polylogue.config import get_config
+        from polylogue.health import repair_dangling_fts
+        from polylogue.storage.backends.sqlite import connection_context
+
+        config = get_config()
+        with connection_context(None) as conn:
+            # Create conversation and message (FTS auto-syncs)
+            _insert_conversation(conn, "conv-1")
+            _insert_message(conn, "msg-1", "conv-1", "user", "Searchable text")
+            conn.commit()
+
+        # Act
+        result = repair_dangling_fts(config, dry_run=False)
+
+        # Assert
+        assert result.name == "dangling_fts"
+        assert result.repaired_count == 0
+        assert result.success is True
+
+    def test_dangling_fts_orphaned_entry(self, cli_workspace):
+        """repair_dangling_fts should find and delete FTS entries without messages."""
+        from polylogue.config import get_config
+        from polylogue.health import repair_dangling_fts
+        from polylogue.storage.backends.sqlite import connection_context
+
+        config = get_config()
+        with connection_context(None) as conn:
+            # Insert a message first (creates FTS entry via trigger)
+            _insert_conversation(conn, "conv-1")
+            _insert_message(conn, "msg-1", "conv-1", "user", "Text")
+            conn.commit()
+
+            # Get the rowid that was assigned
+            rowid = conn.execute("SELECT rowid FROM messages WHERE message_id = ?", ("msg-1",)).fetchone()[0]
+
+            # Now manually delete the message but manually insert FTS entry to simulate orphaned state
+            conn.execute("DELETE FROM messages WHERE message_id = ?", ("msg-1",))
+
+            # Manually insert a dangling FTS entry (rowid won't match any message)
+            conn.execute(
+                "INSERT INTO messages_fts (rowid, message_id, conversation_id, content) VALUES (?, ?, ?, ?)",
+                (rowid + 999, "orphan-fts", "conv-1", "dangling entry"),
+            )
+            conn.commit()
+
+        # Act
+        result = repair_dangling_fts(config, dry_run=False)
+
+        # Assert
+        assert result.name == "dangling_fts"
+        assert result.repaired_count == 1
+        assert result.success is True
+
+    def test_dangling_fts_missing_entry(self, cli_workspace):
+        """repair_dangling_fts should insert missing FTS entries for messages."""
+        from polylogue.config import get_config
+        from polylogue.health import repair_dangling_fts
+        from polylogue.storage.backends.sqlite import connection_context
+
+        config = get_config()
+        with connection_context(None) as conn:
+            # Insert conversation and message
+            _insert_conversation(conn, "conv-1")
+            _insert_message(conn, "msg-1", "conv-1", "user", "Text1")
+            conn.commit()
+
+            # Disable triggers temporarily and delete FTS entry
+            conn.execute("DROP TRIGGER IF EXISTS messages_fts_delete")
+            conn.execute("DELETE FROM messages_fts WHERE message_id = ?", ("msg-1",))
+            conn.commit()
+
+            # Re-create the trigger
+            conn.execute(
+                """CREATE TRIGGER messages_fts_delete AFTER DELETE ON messages BEGIN
+                   DELETE FROM messages_fts WHERE rowid = OLD.rowid;
+                END"""
+            )
+            conn.commit()
+
+        # Act
+        result = repair_dangling_fts(config, dry_run=False)
+
+        # Assert
+        assert result.name == "dangling_fts"
+        assert result.repaired_count == 1
+        assert result.success is True
+
+    def test_dangling_fts_dry_run_counts_but_doesnt_modify(self, cli_workspace):
+        """repair_dangling_fts with dry_run=True should count but not modify."""
+        from polylogue.config import get_config
+        from polylogue.health import repair_dangling_fts
+        from polylogue.storage.backends.sqlite import connection_context
+
+        config = get_config()
+        with connection_context(None) as conn:
+            _insert_conversation(conn, "conv-1")
+            _insert_message(conn, "msg-1", "conv-1", "user", "Text")
+            _insert_message(conn, "msg-2", "conv-1", "user", "Text2")
+            conn.commit()
+
+            msg_count = conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0]
+            fts_count = conn.execute("SELECT COUNT(*) FROM messages_fts").fetchone()[0]
+            initial_diff = abs(msg_count - fts_count)
+
+        # Act
+        result = repair_dangling_fts(config, dry_run=True)
+
+        # Assert - dry_run returns count estimate even if FTS is in sync
+        assert result.success is True
+
+        # Verify no actual change
+        with connection_context(None) as conn:
+            msg_count = conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0]
+            fts_count = conn.execute("SELECT COUNT(*) FROM messages_fts").fetchone()[0]
+            assert abs(msg_count - fts_count) == initial_diff
+
+
+class TestRepairOrphanedAttachments:
+    """Tests for repair_orphaned_attachments function."""
+
+    def test_clean_attachments_state(self, cli_workspace):
+        """repair_orphaned_attachments should return 0 when all attachments are referenced."""
+        from polylogue.config import get_config
+        from polylogue.health import repair_orphaned_attachments
+        from polylogue.storage.backends.sqlite import connection_context
+
+        config = get_config()
+        with connection_context(None) as conn:
+            # Create conversation, message, attachment, and reference
+            _insert_conversation(conn, "conv-1")
+            _insert_message(conn, "msg-1", "conv-1", "user", "Text")
+            conn.execute(
+                "INSERT INTO attachments (attachment_id, mime_type) VALUES (?, ?)",
+                ("att-1", "text/plain"),
+            )
+            conn.execute(
+                "INSERT INTO attachment_refs (ref_id, attachment_id, conversation_id, message_id) VALUES (?, ?, ?, ?)",
+                ("ref-1", "att-1", "conv-1", "msg-1"),
+            )
+            conn.commit()
+
+        # Act
+        result = repair_orphaned_attachments(config, dry_run=False)
+
+        # Assert
+        assert result.name == "orphaned_attachments"
+        assert result.repaired_count == 0
+        assert result.success is True
+
+    def test_orphaned_attachments_orphaned_refs(self, cli_workspace):
+        """repair_orphaned_attachments should detect orphaned attachment refs in dry-run."""
+        from polylogue.config import get_config
+        from polylogue.health import repair_orphaned_attachments
+        from polylogue.storage.backends.sqlite import connection_context
+
+        config = get_config()
+        with connection_context(None) as conn:
+            # Create attachment with no references
+            conn.execute(
+                "INSERT INTO attachments (attachment_id, mime_type) VALUES (?, ?)",
+                ("att-1", "text/plain"),
+            )
+            _insert_conversation(conn, "conv-1")
+            # Insert a proper ref
+            conn.execute(
+                "INSERT INTO attachment_refs (ref_id, attachment_id, conversation_id, message_id) VALUES (?, ?, ?, ?)",
+                ("ref-1", "att-1", "conv-1", None),
+            )
+            conn.commit()
+
+        # Act - create another attachment that's unreferenced
+        with connection_context(None) as conn:
+            conn.execute("INSERT INTO attachments (attachment_id, mime_type) VALUES (?, ?)", ("att-2", "image/png"))
+            conn.commit()
+
+        # Now run repair
+        result = repair_orphaned_attachments(config, dry_run=False)
+
+        # Assert
+        assert result.name == "orphaned_attachments"
+        # Should delete at least the unreferenced attachment
+        assert result.repaired_count >= 1
+
+    def test_orphaned_attachments_unreferenced_attachment(self, cli_workspace):
+        """repair_orphaned_attachments should delete unreferenced attachments."""
+        from polylogue.config import get_config
+        from polylogue.health import repair_orphaned_attachments
+        from polylogue.storage.backends.sqlite import connection_context
+
+        config = get_config()
+        with connection_context(None) as conn:
+            # Create attachment with no references
+            conn.execute(
+                "INSERT INTO attachments (attachment_id, mime_type) VALUES (?, ?)",
+                ("att-1", "text/plain"),
+            )
+            conn.commit()
+
+        # Act
+        result = repair_orphaned_attachments(config, dry_run=False)
+
+        # Assert
+        assert result.name == "orphaned_attachments"
+        assert result.repaired_count >= 1  # Should delete the unreferenced attachment
+
+    def test_orphaned_attachments_dry_run(self, cli_workspace):
+        """repair_orphaned_attachments with dry_run=True should count but not delete."""
+        from polylogue.config import get_config
+        from polylogue.health import repair_orphaned_attachments
+        from polylogue.storage.backends.sqlite import connection_context
+
+        config = get_config()
+        with connection_context(None) as conn:
+            conn.execute(
+                "INSERT INTO attachments (attachment_id, mime_type) VALUES (?, ?)",
+                ("att-1", "text/plain"),
+            )
+            conn.commit()
+
+        # Act
+        result = repair_orphaned_attachments(config, dry_run=True)
+
+        # Assert
+        assert "Would:" in result.detail
+
+        # Verify not deleted
+        with connection_context(None) as conn:
+            remaining = conn.execute("SELECT COUNT(*) FROM attachments").fetchone()[0]
+            assert remaining == 1
+
+
+class TestRepairUnknownRoles:
+    """Tests for repair_unknown_roles function."""
+
+    def test_clean_roles_state(self, cli_workspace):
+        """repair_unknown_roles should return 0 when no unknown roles in claude-code."""
+        from polylogue.config import get_config
+        from polylogue.health import repair_unknown_roles
+        from polylogue.storage.backends.sqlite import connection_context
+
+        config = get_config()
+        with connection_context(None) as conn:
+            # Create claude-code conversation with properly-typed messages
+            _insert_conversation(conn, "cc-conv-1", provider_name="claude-code")
+            _insert_message(conn, "cc-msg-1", "cc-conv-1", "user", "code", {"raw": {"type": "user"}})
+            conn.commit()
+
+        # Act
+        result = repair_unknown_roles(config, dry_run=False)
+
+        # Assert
+        assert result.name == "unknown_roles"
+        assert result.repaired_count == 0
+        assert result.success is True
+
+    def test_unknown_roles_progress_to_tool(self, cli_workspace):
+        """repair_unknown_roles should map progress → tool role."""
+        from polylogue.config import get_config
+        from polylogue.health import repair_unknown_roles
+        from polylogue.storage.backends.sqlite import connection_context
+
+        config = get_config()
+        with connection_context(None) as conn:
+            _insert_conversation(conn, "cc-conv-1", provider_name="claude-code")
+            _insert_message(conn, "cc-msg-1", "cc-conv-1", "unknown", "progress text", {"raw": {"type": "progress"}})
+            _insert_message(conn, "cc-msg-2", "cc-conv-1", "unknown", "result text", {"raw": {"type": "result"}})
+            conn.commit()
+
+        # Act
+        result = repair_unknown_roles(config, dry_run=False)
+
+        # Assert
+        assert result.name == "unknown_roles"
+        assert result.repaired_count == 2
+        assert result.success is True
+
+        # Verify roles were updated to 'tool'
+        with connection_context(None) as conn:
+            roles = conn.execute("SELECT role FROM messages WHERE message_id IN (?, ?)", ("cc-msg-1", "cc-msg-2")).fetchall()
+            assert all(r[0] == "tool" for r in roles)
+
+    def test_unknown_roles_system_types(self, cli_workspace):
+        """repair_unknown_roles should map system types to system role."""
+        from polylogue.config import get_config
+        from polylogue.health import repair_unknown_roles
+        from polylogue.storage.backends.sqlite import connection_context
+
+        config = get_config()
+        with connection_context(None) as conn:
+            _insert_conversation(conn, "cc-conv-1", provider_name="claude-code")
+            _insert_message(conn, "cc-msg-1", "cc-conv-1", "unknown", "summary", {"raw": {"type": "summary"}})
+            _insert_message(conn, "cc-msg-2", "cc-conv-1", "unknown", "system", {"raw": {"type": "system"}})
+            conn.commit()
+
+        # Act
+        result = repair_unknown_roles(config, dry_run=False)
+
+        # Assert
+        assert result.repaired_count == 2
+
+        # Verify roles were updated to 'system'
+        with connection_context(None) as conn:
+            roles = conn.execute("SELECT role FROM messages WHERE message_id IN (?, ?)", ("cc-msg-1", "cc-msg-2")).fetchall()
+            assert all(r[0] == "system" for r in roles)
+
+    def test_unknown_roles_dry_run(self, cli_workspace):
+        """repair_unknown_roles with dry_run=True should count but not modify."""
+        from polylogue.config import get_config
+        from polylogue.health import repair_unknown_roles
+        from polylogue.storage.backends.sqlite import connection_context
+
+        config = get_config()
+        with connection_context(None) as conn:
+            _insert_conversation(conn, "cc-conv-1", provider_name="claude-code")
+            _insert_message(conn, "cc-msg-1", "cc-conv-1", "unknown", "progress", {"raw": {"type": "progress"}})
+            conn.commit()
+
+        # Act
+        result = repair_unknown_roles(config, dry_run=True)
+
+        # Assert
+        assert result.repaired_count == 1
+        assert "Would:" in result.detail
+
+        # Verify role was NOT changed
+        with connection_context(None) as conn:
+            role = conn.execute("SELECT role FROM messages WHERE message_id = ?", ("cc-msg-1",)).fetchone()[0]
+            assert role == "unknown"
+
+    def test_unknown_roles_non_claude_code_ignored(self, cli_workspace):
+        """repair_unknown_roles should only affect claude-code conversations."""
+        from polylogue.config import get_config
+        from polylogue.health import repair_unknown_roles
+        from polylogue.storage.backends.sqlite import connection_context
+
+        config = get_config()
+        with connection_context(None) as conn:
+            # Create non-claude-code conversation with unknown role
+            _insert_conversation(conn, "conv-1", provider_name="chatgpt")
+            _insert_message(conn, "msg-1", "conv-1", "unknown", "text", {"raw": {"type": "progress"}})
+            conn.commit()
+
+        # Act
+        result = repair_unknown_roles(config, dry_run=False)
+
+        # Assert
+        assert result.repaired_count == 0
+
+        # Verify role was NOT changed
+        with connection_context(None) as conn:
+            role = conn.execute("SELECT role FROM messages WHERE message_id = ?", ("msg-1",)).fetchone()[0]
+            assert role == "unknown"
+
+
+class TestRepairWalCheckpoint:
+    """Tests for repair_wal_checkpoint function."""
+
+    def test_wal_checkpoint_succeeds(self, cli_workspace):
+        """repair_wal_checkpoint should execute without crashing."""
+        from polylogue.config import get_config
+        from polylogue.health import repair_wal_checkpoint
+
+        config = get_config()
+
+        # Act
+        result = repair_wal_checkpoint(config, dry_run=False)
+
+        # Assert
+        assert result.name == "wal_checkpoint"
+        assert result.success is True
+        # repaired_count and detail depend on WAL file state; just verify no crash
+
+    def test_wal_checkpoint_dry_run(self, cli_workspace):
+        """repair_wal_checkpoint with dry_run=True should inspect WAL without modifying."""
+        from polylogue.config import get_config
+        from polylogue.health import repair_wal_checkpoint
+
+        config = get_config()
+
+        # Act
+        result = repair_wal_checkpoint(config, dry_run=True)
+
+        # Assert
+        assert result.name == "wal_checkpoint"
+        assert result.success is True
+        assert "Would:" in result.detail or "nothing to checkpoint" in result.detail
+
+
+class TestRunAllRepairs:
+    """Tests for run_all_repairs orchestration."""
+
+    def test_run_all_repairs_returns_all_results(self, cli_workspace):
+        """run_all_repairs should return results for all repair functions."""
+        from polylogue.config import get_config
+        from polylogue.health import run_all_repairs
+
+        config = get_config()
+
+        # Act
+        results = run_all_repairs(config, dry_run=False)
+
+        # Assert
+        assert isinstance(results, list)
+        assert len(results) == 6  # All 6 repair functions
+
+        # Verify we got each repair type
+        repair_names = {r.name for r in results}
+        expected = {
+            "orphaned_messages",
+            "empty_conversations",
+            "dangling_fts",
+            "orphaned_attachments",
+            "unknown_roles",
+            "wal_checkpoint",
+        }
+        assert repair_names == expected
+
+    def test_run_all_repairs_all_success(self, cli_workspace):
+        """run_all_repairs should have all successful on clean database."""
+        from polylogue.config import get_config
+        from polylogue.health import run_all_repairs
+
+        config = get_config()
+
+        # Act
+        results = run_all_repairs(config, dry_run=False)
+
+        # Assert
+        assert all(r.success for r in results), f"Some repairs failed: {results}"
+
+    def test_run_all_repairs_dry_run_all_have_would(self, cli_workspace):
+        """run_all_repairs with dry_run=True should have 'Would:' in details."""
+        from polylogue.config import get_config
+        from polylogue.health import run_all_repairs
+        from polylogue.storage.backends.sqlite import connection_context
+
+        config = get_config()
+
+        # Setup: add some issues
+        with connection_context(None) as conn:
+            _insert_message(conn, "orphan-1", "nonexistent-conv", "user", "Orphaned", allow_orphaned=True)
+            conn.commit()
+
+        # Act
+        results = run_all_repairs(config, dry_run=True)
+
+        # Assert
+        # Some should have "Would:" when issues are found
+        assert any("Would:" in r.detail for r in results), "Expected at least one 'Would:' in dry-run results"
+
+    def test_run_all_repairs_idempotency_after_full_run(self, cli_workspace):
+        """run_all_repairs twice should find 0 issues on second run."""
+        from polylogue.config import get_config
+        from polylogue.health import run_all_repairs
+        from polylogue.storage.backends.sqlite import connection_context
+
+        config = get_config()
+
+        # Setup: add issues
+        with connection_context(None) as conn:
+            _insert_conversation(conn, "empty-1")
+            conn.commit()
+
+        # First repair run
+        results1 = run_all_repairs(config, dry_run=False)
+        total_repaired_1 = sum(r.repaired_count for r in results1)
+        assert total_repaired_1 > 0
+
+        # Second repair run should find nothing
+        results2 = run_all_repairs(config, dry_run=False)
+        total_repaired_2 = sum(r.repaired_count for r in results2)
+        assert total_repaired_2 == 0

--- a/tests/test_importers_unit.py
+++ b/tests/test_importers_unit.py
@@ -129,7 +129,7 @@ CHATGPT_EXTRACT_MESSAGES_CASES = [
     # Content variants
     ({"node1": make_chatgpt_node("msg1", "user", ["Part1", "Part2"])}, 1, "multiple parts"),
     ({"node1": make_chatgpt_node("msg1", "user", [None, "Valid"])}, 1, "parts with None"),
-    ({"node1": {"message": {"id": "1", "author": {"role": "user"}, "content": {"parts": []}}}}, 1, "empty parts"),
+    ({"node1": {"message": {"id": "1", "author": {"role": "user"}, "content": {"parts": []}}}}, 0, "empty parts"),
 
     # Role normalization
     ({"node1": make_chatgpt_node("msg1", "human", ["Hi"])}, 1, "human role alias"),

--- a/tests/test_indexing_service.py
+++ b/tests/test_indexing_service.py
@@ -116,3 +116,21 @@ class TestIndexService:
             assert isinstance(status, dict)
             assert "exists" in status
             assert "count" in status
+
+    def test_get_index_status_uses_service_connection(self, workspace_env):
+        """Regression: get_index_status must use the service's connection, not open_connection(None)."""
+        with open_connection(None) as conn:
+            config = Config(
+                archive_root=workspace_env["archive_root"],
+                render_root=workspace_env["archive_root"] / "render",
+                sources=[],
+            )
+            service = IndexService(config, conn)
+
+            # Ensure FTS table exists via this connection
+            service.ensure_index_exists()
+
+            # get_index_status should use the same connection and find the table
+            status = service.get_index_status()
+            assert status["exists"] is True
+            assert isinstance(status["count"], int)

--- a/tests/test_provider_models.py
+++ b/tests/test_provider_models.py
@@ -1,0 +1,108 @@
+"""Tests for provider-specific model viewport methods."""
+
+import pytest
+
+from polylogue.sources.providers.chatgpt import ChatGPTMessage, ChatGPTAuthor, ChatGPTContent
+from polylogue.sources.providers.gemini import GeminiMessage
+
+
+class TestChatGPTMessageTextContent:
+    """Regression tests for ChatGPTMessage.text_content."""
+
+    def test_text_content_with_string_parts(self):
+        msg = ChatGPTMessage(
+            id="1", author=ChatGPTAuthor(role="user"),
+            content=ChatGPTContent(content_type="text", parts=["Hello", "World"]),
+        )
+        assert msg.text_content == "Hello\nWorld"
+
+    def test_text_content_with_none_parts(self):
+        """Regression: parts list can contain None values."""
+        msg = ChatGPTMessage(
+            id="1", author=ChatGPTAuthor(role="user"),
+            content=ChatGPTContent(content_type="text", parts=[None, "Valid"]),
+        )
+        assert msg.text_content == "Valid"
+
+    def test_text_content_with_dict_none_text(self):
+        """Regression: dict part with 'text' key but None value must not crash join()."""
+        msg = ChatGPTMessage(
+            id="1", author=ChatGPTAuthor(role="user"),
+            content=ChatGPTContent(content_type="text", parts=[{"text": None}, {"text": "ok"}]),
+        )
+        assert msg.text_content == "ok"
+
+    def test_text_content_with_dict_valid_text(self):
+        msg = ChatGPTMessage(
+            id="1", author=ChatGPTAuthor(role="user"),
+            content=ChatGPTContent(content_type="text", parts=[{"text": "hello"}]),
+        )
+        assert msg.text_content == "hello"
+
+    def test_text_content_empty_parts(self):
+        msg = ChatGPTMessage(
+            id="1", author=ChatGPTAuthor(role="user"),
+            content=ChatGPTContent(content_type="text", parts=[]),
+        )
+        assert msg.text_content == ""
+
+    def test_text_content_no_content(self):
+        msg = ChatGPTMessage(id="1", author=ChatGPTAuthor(role="user"))
+        assert msg.text_content == ""
+
+    def test_text_content_direct_text(self):
+        msg = ChatGPTMessage(
+            id="1", author=ChatGPTAuthor(role="user"),
+            content=ChatGPTContent(content_type="text", text="Direct text"),
+        )
+        assert msg.text_content == "Direct text"
+
+    def test_role_normalized(self):
+        for role_in, expected in [("user", "user"), ("assistant", "assistant"), ("tool", "tool"), ("custom", "unknown")]:
+            msg = ChatGPTMessage(id="1", author=ChatGPTAuthor(role=role_in))
+            assert msg.role_normalized == expected
+
+
+class TestGeminiMessageTextContent:
+    """Regression tests for GeminiMessage.text_content."""
+
+    def test_text_content_from_text_field(self):
+        msg = GeminiMessage(text="Hello", role="user")
+        assert msg.text_content == "Hello"
+
+    def test_text_content_from_parts_dict_none_text(self):
+        """Regression: dict part with 'text' key but None value must not crash."""
+        msg = GeminiMessage(text="", role="user", parts=[{"text": None}, {"text": "ok"}])
+        assert msg.text_content == "ok"
+
+    def test_text_content_from_parts_typed(self):
+        from polylogue.sources.providers.gemini import GeminiPart
+        msg = GeminiMessage(text="", role="model", parts=[GeminiPart(text="typed")])
+        assert msg.text_content == "typed"
+
+    def test_role_normalized(self):
+        for role_in, expected in [("user", "user"), ("model", "assistant"), ("assistant", "assistant"), ("custom", "unknown")]:
+            msg = GeminiMessage(text="x", role=role_in)
+            assert msg.role_normalized == expected
+
+    def test_extract_content_blocks_dict_none_text(self):
+        """Regression: extract_content_blocks with None text in dict part must not crash."""
+        msg = GeminiMessage(text="", role="user", parts=[{"text": None}, {"text": "ok"}])
+        blocks = msg.extract_content_blocks()
+        text_blocks = [b for b in blocks if b.text == "ok"]
+        assert len(text_blocks) == 1
+
+    def test_extract_content_blocks_file_data(self):
+        """Pydantic coerces dict parts to GeminiPart (extra=allow), so inlineData
+        ends up as a GeminiPart attribute. The GeminiPart branch only checks .text,
+        so file-only parts produce no content blocks — this is current behavior."""
+        msg = GeminiMessage(text="", role="user", parts=[{"inlineData": {"mimeType": "image/png"}}])
+        blocks = msg.extract_content_blocks()
+        # No text in the part → no content blocks extracted
+        assert len(blocks) == 0
+
+    def test_thinking_message(self):
+        msg = GeminiMessage(text="Thinking...", role="model", isThought=True)
+        traces = msg.extract_reasoning_traces()
+        assert len(traces) == 1
+        assert traces[0].text == "Thinking..."

--- a/tests/test_ui_wrapper.py
+++ b/tests/test_ui_wrapper.py
@@ -160,6 +160,53 @@ def test_plain_progress_tracker():
     tracker.__exit__(None, None, None)
 
 
+class TestPlainConsoleMarkupStripping:
+    """Regression tests: PlainConsole must strip Rich markup for CI/plain output."""
+
+    def test_strips_bold_markup(self, capsys):
+        from polylogue.ui.facade import PlainConsole
+
+        console = PlainConsole()
+        console.print("[bold]Archive:[/bold] 1,234 conversations")
+        captured = capsys.readouterr()
+        assert "[bold]" not in captured.out
+        assert "Archive: 1,234 conversations" in captured.out
+
+    def test_strips_color_markup(self, capsys):
+        from polylogue.ui.facade import PlainConsole
+
+        console = PlainConsole()
+        console.print("[green]✓[/green] All ok")
+        captured = capsys.readouterr()
+        assert "[green]" not in captured.out
+        assert "✓ All ok" in captured.out
+
+    def test_strips_hex_color_markup(self, capsys):
+        from polylogue.ui.facade import PlainConsole
+
+        console = PlainConsole()
+        console.print("[#d97757]████████[/#d97757]")
+        captured = capsys.readouterr()
+        assert "#d97757" not in captured.out
+        assert "████████" in captured.out
+
+    def test_preserves_plain_text(self, capsys):
+        from polylogue.ui.facade import PlainConsole
+
+        console = PlainConsole()
+        console.print("No markup at all")
+        captured = capsys.readouterr()
+        assert captured.out.strip() == "No markup at all"
+
+    def test_handles_empty_string(self, capsys):
+        from polylogue.ui.facade import PlainConsole
+
+        console = PlainConsole()
+        console.print("")
+        captured = capsys.readouterr()
+        assert captured.out.strip() == ""
+
+
 def test_rich_progress_tracker():
     progress_mock = MagicMock()
     task_id = "task1"


### PR DESCRIPTION
## Summary

I wanted tag management to be discoverable instead of only writable. At the start of this branch Polylogue could add and remove tags on conversations, but there was no cheap way to ask "what tags already exist?" and the storage path behind those edits was still a plain JSON read/modify/write cycle with no explicit protection against competing writers. I fixed that by pushing tag aggregation into SQLite with `json_each(...)` and by routing metadata/tag mutations through a transactional helper that uses `BEGIN IMMEDIATE` at the outer boundary and `SAVEPOINT` when the caller is already inside a write. Once that work was in place, I used the same branch to harden the other archive surfaces that depend on sparse message records: query output, repair commands, renderers, provider parsers, concurrent ingestion, and sqlite-vec error paths. The diff looks broad, but the work is actually pretty coherent: the new tag surface forced me to tighten the places where missing role/text fields or non-atomic metadata could still produce misleading or fragile behavior.

## Motivation

I considered landing `polylogue tags` as a very small CLI feature and leaving the rest for later, but that would have put a nicer read surface on top of metadata writes I still did not trust. `add_tag()`, `remove_tag()`, `update_metadata()`, and `delete_metadata()` all revolved around the same pattern: fetch the JSON blob, mutate it in Python, and write it back. That is tolerable when there is exactly one writer and no nesting, but it gets shakier once the archive supports concurrent ingestion, batch mutation, repair commands, and repository helpers that may already be inside a transaction.

The later commits kept reinforcing the same theme. Every time I wrote or expanded a regression, I ran into one of two classes of bug:

1. sparse provider data: `role=None`, `text=None`, empty content blocks, or odd timestamp fallbacks
2. archive-scale operations that were still written in the convenient but expensive SQL shape

Did not want tag discovery to materialize the entire archive just to answer a count question. If the command is going to be useful in the CLI, it should be backed by SQL aggregation, not a Python loop over conversations.

## Changes grouped by concern

### Tag discovery and metadata mutation

I added a dedicated `polylogue tags` command in `polylogue/cli/commands/tags.py` and wired it into `polylogue/cli/click_app.py`. The command stays intentionally narrow: list tags with counts, optionally scope by provider, optionally emit JSON, optionally truncate to the top `N`.

The backing query lives in `SQLiteBackend.list_tags()` and uses SQLite's JSON1 support:

```sql
SELECT tag.value AS tag_name, COUNT(*) AS cnt
FROM conversations,
     json_each(json_extract(metadata, '$.tags')) AS tag
WHERE metadata IS NOT NULL
  AND json_extract(metadata, '$.tags') IS NOT NULL
GROUP BY tag.value
ORDER BY cnt DESC
```

That gave me a cheap read path, but the more important work is underneath it. Metadata mutation runs through an explicit transaction boundary in `_metadata_read_modify_write()`. The helper takes the outer write lock when necessary and falls back to a savepoint if a caller is already inside a transaction:

```python
BEGIN IMMEDIATE  # outer metadata write
...
SAVEPOINT metadata_rmw  # nested metadata write
...
RELEASE / ROLLBACK TO SAVEPOINT
```

That is what makes tag and metadata changes safe to expose more aggressively from the CLI. It also gives the storage tests a single place to pin the semantics without scattering the same correctness expectation across `add_tag()`, `remove_tag()`, and key-value metadata updates.

### Query UX and machine-readable output

A lot of the user-visible polish here is individually small, but the cumulative effect matters. `cli/query.py` has a lightweight `--count` path, clearer no-results output through `_describe_filters()` and `_no_results()`, full-content JSON for single conversations via `_conv_to_json()`, and cleaner CSV behavior for list mode.

Switched the stdout path to `click.echo()` so machine-readable output is not coupled to the Rich console implementation. That interacts with another branch fix: `PlainConsole` now strips markup before printing, so CI logs and plain-mode output do not leak `[bold]`, `[green]`, or other Rich tags.

Bulk operations changed in a deliberate way as well. Instead of requiring callers to know ahead of time that they need `--force`, the delete and modifier flows now present an interactive confirmation path. That is safer in interactive use and also made the code easier to reason about because preview and confirmation sit on the same branch.

### Repair paths and archive-scale operations

`health.py` had two separate weaknesses. Some repair queries were written with `NOT IN`, which becomes the wrong shape once the tables get large or `NULL`s become relevant, and the dry-run logic for FTS synchronization was doing more work than needed. I replaced those with correlated `NOT EXISTS` forms and a row-count-based dry-run comparison.

Tightened the role repair logic. The previous path could collapse any unknown role into `tool`, which is too blunt for Claude Code archives that have progress or system-like records with incomplete chat-role information. The new repair path inspects provider metadata through `json_extract(...)` and maps more precisely based on the source record type.

The branch also makes sqlite-vec failure modes explicit. Extension-load problems are no longer silently swallowed, and `httpx` exception text is sanitized so caller-visible errors do not echo full URLs or credentials.

### Sparse record handling across renderers, parsers, and ingestion

By the middle of the branch I had fixed essentially the same null-handling bug in markdown, org, HTML, the static site, the MCP server, and the TUI. I made the policy explicit everywhere: missing roles serialize as `"unknown"`, missing text is skipped rather than rendered as an empty section, and empty stream headers are suppressed.

On the parser side I tightened several provider-specific cases:
- ChatGPT/Gemini text extraction now tolerates `None` and structured parts more defensively.
- ISO timestamp fallback runs through the shared parser instead of assuming a single shape.
- expected provider validation skips get logged at DEBUG not surfacing as noisy warnings.

In `pipeline/services/ingestion.py` I also stopped one failed future from poisoning the rest of the concurrent batch. That bug is easy to miss until you run parallel imports across mixed-quality data, but once it appears the failure mode is bad: a single parse error silently prevents the rest of the futures from being observed.

## Testing

This branch is very regression-driven. The main additions are concentrated in:

- `tests/test_cli_run.py` for the new `tags` command and embed-path regressions
- `tests/test_storage.py` for tag aggregation, metadata atomicity, DB path handling, and SQL edge cases
- `tests/test_health.py` for repair functions and dry-run behavior
- `tests/test_pipeline_concurrent.py` for failed-future isolation
- `tests/test_provider_models.py` and related parser tests for sparse provider payloads
- `tests/test_ui_wrapper.py` for plain-console markup stripping

Where possible I tested the seam where the bug actually lived instead of only driving it through the public CLI. For example, the metadata work is primarily pinned at the storage helper boundary because that is where correctness lives.

## Notes

A few things are intentionally out of scope. I did not add tag normalization or hierarchy semantics; the new command reports exactly what is stored. `PRAGMA integrity_check` remains opt-in behind `--deep` because it is still the right tool, just not the right default. And while the renderers now agree on missing role/text handling, there is still room to reduce duplication further by pushing more of that policy into shared helpers later.