### PR TITLE
fix: split shellHook chatter from stdout and honor --id

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -110,7 +110,7 @@
 
             # Create venv if it doesn't exist
             if [ ! -d .venv ]; then
-              echo "Creating virtual environment..."
+              echo "Creating virtual environment..." >&2
               uv venv
             fi
 
@@ -119,13 +119,13 @@
 
             # Install dependencies if needed
             if [ ! -f .venv/.synced ]; then
-              echo "Installing dependencies..."
+              echo "Installing dependencies..." >&2
               uv pip install -e ".[dev]"
               touch .venv/.synced
             fi
 
-            echo "Polylogue development environment ready"
-            echo "Run: polylogue --help"
+            echo "Polylogue development environment ready" >&2
+            echo "Run: polylogue --help" >&2
           '';
         };
 

--- a/polylogue/cli/query.py
+++ b/polylogue/cli/query.py
@@ -226,6 +226,12 @@ def execute_query(env: AppEnv, params: dict[str, Any]) -> None:
                 env.ui.console.print("No conversations in archive.")
                 raise SystemExit(2)
             full_id = str(summaries[0].id)
+        elif params.get("conv_id"):
+            resolved = conv_repo.resolve_id(params["conv_id"])
+            if not resolved:
+                click.echo(f"No conversation found matching: {params['conv_id']}", err=True)
+                raise SystemExit(2)
+            full_id = str(resolved)
         else:
             # Try to resolve first query term as ID
             if query_terms:


### PR DESCRIPTION
## Summary

This branch fixes two command-boundary bugs that have the same failure shape: output or intent is sent down the wrong channel. In `flake.nix` the devshell bootstrap messages were being written to stdout, which is fine for an interactive terminal but wrong as soon as someone pipes that output into another command or uses it from automation. In `polylogue/cli/query.py` the explicit conversation-id parameter was missing its own resolution branch, so an `--id` lookup could fall through into the more general query-term logic instead of going straight through `conv_repo.resolve_id()`. I kept them together because both bugs live at the edge between "what the user typed" and "what the command actually emitted or resolved." The fixes are small, but they remove a class of subtle behavior that is disproportionately annoying in scripts.

## Motivation

The shellHook bug is easy to dismiss if you only test `nix develop` interactively. The status lines are useful there: creating the virtualenv, installing dependencies, printing a ready banner. The problem is that stdout is also the channel people rely on for machine-consumable output. Once those banners are mixed into stdout, the shell environment stops behaving like a clean command in pipelines.

The query bug is similar in spirit. Polylogue already has a dedicated ID-resolution path via `conv_repo.resolve_id()`, but the `conv_id` parameter was not taking it early enough. That means the CLI could accept a specific id-like input and still treat it as a generic query term. In a conversation archive that is exactly the wrong ambiguity: explicit IDs should be deterministic, and misses should fail loudly on stderr rather than silently broadening into another selection mode.

## Changes grouped by concern

### Devshell output discipline

The `flake.nix` change is literally just routing the shellHook chatter to stderr:

```bash
echo "Creating virtual environment..." >&2
echo "Installing dependencies..." >&2
echo "Polylogue development environment ready" >&2
echo "Run: polylogue --help" >&2
```

I am not changing the messages or suppressing them. I still want those lines in an interactive session. The fix is simply to put them on the right stream so stdout remains available for actual command output when the shell is used in a scripted context.

### Explicit ID resolution in query mode

The `execute_query()` change is similarly small but important. The resolution order has a dedicated `conv_id` branch before the code falls back to positional query terms:

```python
elif params.get("conv_id"):
    resolved = conv_repo.resolve_id(params["conv_id"])
    if not resolved:
        click.echo(..., err=True)
        raise SystemExit(2)
    full_id = str(resolved)
```

That gives explicit IDs the behavior users already expect:
- resolve through the ID-prefix resolver, not through free-text matching
- emit the miss on stderr
- stop the command with the same exit semantics as other no-result paths

I intentionally did not broaden the change into a bigger routing refactor. The bug here was not that the query command needed a new architecture; it was that one explicit parameter was missing the obvious dedicated branch.

## Testing

No dedicated new tests land with this branch. That is a gap, and I do not want to pretend otherwise.

The shellHook fix is best validated manually because the observable behavior is stream routing during environment activation. The query fix leans on the surrounding CLI/query coverage that already exists in the suite, but the exact `conv_id` branch would still benefit from a direct regression test in later work.

## Notes

This is a deliberately tiny fix. I did not touch broader CLI routing, output formatting, or shell startup behavior beyond the two incorrect branches above. The main review question is simply whether both outputs now go to the channel users would naturally expect: status chatter to stderr, explicit ids through explicit id resolution.