### PR TITLE
feat: add semantic preservation proofs across read surfaces

### DIFF
--- a/devtools/run_validation_lanes.py
+++ b/devtools/run_validation_lanes.py
@@ -1,0 +1,204 @@
+"""Run named validation lanes for the remaining operator frontier.
+
+Usage:
+    python -m devtools.run_validation_lanes --list
+    python -m devtools.run_validation_lanes --lane machine-contract
+    python -m devtools.run_validation_lanes --lane frontier-local --dry-run
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class LaneConfig:
+    """Configuration for a validation lane."""
+
+    name: str
+    description: str
+    timeout_s: int
+    command: list[str] | None = None
+    sub_lanes: tuple[str, ...] = ()
+
+    @property
+    def is_composite(self) -> bool:
+        return bool(self.sub_lanes)
+
+
+LANES: dict[str, LaneConfig] = {
+    "machine-contract": LaneConfig(
+        name="machine-contract",
+        description="Root CLI JSON success/failure envelopes and runtime-health machine surfaces",
+        timeout_s=180,
+        command=[sys.executable, "-m", "pytest", "-q", "-n", "0", "-m", "machine_contract"],
+    ),
+    "query-routing": LaneConfig(
+        name="query-routing",
+        description="Query-first CLI route planning, integration, and streamed read-surface proofs",
+        timeout_s=240,
+        command=[sys.executable, "-m", "pytest", "-q", "-n", "0", "-m", "query_routing"],
+    ),
+    "tui": LaneConfig(
+        name="tui",
+        description="Textual Mission Control screens and interaction-state coverage",
+        timeout_s=240,
+        command=[sys.executable, "-m", "pytest", "-q", "-n", "0", "-m", "tui"],
+    ),
+    "chaos": LaneConfig(
+        name="chaos",
+        description="Hostility, interruption, and chronology integration coverage",
+        timeout_s=900,
+        command=[sys.executable, "-m", "pytest", "-q", "-n", "0", "-m", "chaos"],
+    ),
+    "scale-fast": LaneConfig(
+        name="scale-fast",
+        description="Fast storage scale budgets",
+        timeout_s=120,
+        command=[sys.executable, "-m", "devtools.run_scale_lanes", "--lane", "fast"],
+    ),
+    "scale-slow": LaneConfig(
+        name="scale-slow",
+        description="Slow local storage scale budgets",
+        timeout_s=360,
+        command=[sys.executable, "-m", "devtools.run_scale_lanes", "--lane", "slow"],
+    ),
+    "long-haul-small": LaneConfig(
+        name="long-haul-small",
+        description="Small reproducible benchmark/long-haul campaign",
+        timeout_s=1800,
+        command=[sys.executable, "-m", "devtools.run_campaign", "--scale", "small"],
+    ),
+    "live-exercises": LaneConfig(
+        name="live-exercises",
+        description="Operator-run live archive showcase/QA exercise lane",
+        timeout_s=1800,
+        command=[
+            sys.executable,
+            "-m",
+            "polylogue",
+            "--plain",
+            "qa",
+            "--live",
+            "--only",
+            "exercises",
+            "--tier",
+            "0",
+            "--json",
+        ],
+    ),
+    "frontier-local": LaneConfig(
+        name="frontier-local",
+        description="Non-live local closure lane for machine/query/TUI/chaos validation",
+        timeout_s=1500,
+        sub_lanes=("machine-contract", "query-routing", "tui", "chaos"),
+    ),
+    "frontier-extended": LaneConfig(
+        name="frontier-extended",
+        description="Local closure lane plus fast scale and small long-haul campaign",
+        timeout_s=3600,
+        sub_lanes=("frontier-local", "scale-fast", "long-haul-small"),
+    ),
+}
+
+VALID_LANES = frozenset(LANES)
+
+
+def parse_lane(lane_name: str) -> LaneConfig:
+    """Parse and validate a lane name."""
+    if lane_name not in LANES:
+        raise ValueError(
+            f"Invalid lane: {lane_name!r}. Valid lanes: {', '.join(sorted(VALID_LANES))}"
+        )
+    return LANES[lane_name]
+
+
+def build_lane_command(lane: LaneConfig) -> list[str]:
+    """Build the concrete subprocess command for a non-composite lane."""
+    if lane.command is None:
+        raise ValueError(f"Lane {lane.name!r} is composite and has no direct command")
+    return lane.command
+
+
+def _print_lane(lane: LaneConfig, *, indent: str = "") -> None:
+    print(f"{indent}{lane.name}: {lane.description}")
+    if lane.is_composite:
+        for child_name in lane.sub_lanes:
+            _print_lane(parse_lane(child_name), indent=indent + "  ")
+    else:
+        print(f"{indent}  command: {' '.join(build_lane_command(lane))}")
+        print(f"{indent}  timeout: {lane.timeout_s}s")
+
+
+def run_lane(lane: LaneConfig) -> int:
+    """Execute a validation lane."""
+    if lane.is_composite:
+        print(f"Validation lane: {lane.name} — {lane.description}")
+        for child_name in lane.sub_lanes:
+            exit_code = run_lane(parse_lane(child_name))
+            if exit_code != 0:
+                return exit_code
+        return 0
+
+    cmd = build_lane_command(lane)
+    print(f"Validation lane: {lane.name} — {lane.description}")
+    print(f"Command: {' '.join(cmd)}")
+    print(f"Timeout: {lane.timeout_s}s")
+    print()
+
+    try:
+        result = subprocess.run(cmd, timeout=lane.timeout_s)
+        return result.returncode
+    except subprocess.TimeoutExpired:
+        print(f"\nLane {lane.name!r} timed out after {lane.timeout_s}s")
+        return 2
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Main entry point."""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--lane",
+        choices=sorted(VALID_LANES),
+        help="Validation lane to run",
+    )
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        dest="list_lanes",
+        help="List available lanes and exit",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the selected lane command(s) without running them",
+    )
+    args = parser.parse_args(argv)
+
+    if args.list_lanes:
+        print("Available validation lanes:")
+        for lane_name in sorted(VALID_LANES):
+            lane = parse_lane(lane_name)
+            print(f"  {lane.name}: {lane.description}")
+        return 0
+
+    if not args.lane:
+        parser.error("--lane is required unless --list is used")
+
+    lane = parse_lane(args.lane)
+    if args.dry_run:
+        _print_lane(lane)
+        return 0
+
+    return run_lane(lane)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/test-quality-workflows.md
+++ b/docs/test-quality-workflows.md
@@ -26,6 +26,30 @@ benchmarks.
 nix develop -c pytest -q -n 0 -m "not slow and not benchmark"
 ```
 
+### Validation lanes
+
+Use the validation-lane runner when you want named operator surfaces instead of
+remembering individual test files or campaign commands.
+
+```bash
+python -m devtools.run_validation_lanes --list
+python -m devtools.run_validation_lanes --lane machine-contract
+python -m devtools.run_validation_lanes --lane query-routing
+python -m devtools.run_validation_lanes --lane frontier-local
+python -m devtools.run_validation_lanes --lane frontier-extended
+python -m devtools.run_validation_lanes --lane live-exercises --dry-run
+```
+
+Lane intent:
+
+- `machine-contract`: root CLI JSON success/failure and runtime-health machine surfaces
+- `query-routing`: query-first integration plus route-planning/unit proofs
+- `tui`: Textual Mission Control interaction/state coverage
+- `chaos`: ingestion hostility, interruption, and chronology suites
+- `frontier-local`: machine + query + TUI + chaos
+- `frontier-extended`: `frontier-local` plus fast scale and the small long-haul campaign
+- `live-exercises`: explicit operator lane for read-only live archive QA exercises
+
 ### Focused mutation checkpoints
 
 ```bash

--- a/polylogue/__main__.py
+++ b/polylogue/__main__.py
@@ -1,11 +1,11 @@
 """Main entry point for Polylogue CLI."""
 
-from polylogue.cli.click_app import cli
+from polylogue.cli.click_app import main as cli_main
 
 
 def main() -> None:
     """Main entry point."""
-    cli()
+    cli_main()
 
 
 if __name__ == "__main__":

--- a/polylogue/cli/click_app.py
+++ b/polylogue/cli/click_app.py
@@ -15,8 +15,8 @@ from click.shell_completion import get_completion_class
 
 from polylogue.cli.commands.auth import auth_command
 from polylogue.cli.commands.check import check_command
-from polylogue.cli.commands.generate import generate_command
 from polylogue.cli.commands.embed import embed_command
+from polylogue.cli.commands.generate import generate_command
 from polylogue.cli.commands.qa import qa_command
 from polylogue.cli.commands.reset import reset_command
 from polylogue.cli.commands.run import run_command, sources_command
@@ -167,7 +167,7 @@ def dashboard_command(env: AppEnv) -> None:
     """Launch the Mission Control TUI dashboard."""
     from polylogue.ui.tui.app import PolylogueApp
 
-    app = PolylogueApp(config=env.config, repository=env.repository)
+    app = PolylogueApp(repository=env.repository)
     app.run()
 
 

--- a/polylogue/cli/commands/check.py
+++ b/polylogue/cli/commands/check.py
@@ -42,7 +42,12 @@ def _format_semantic_metric_summary(metric_summary: dict[str, dict[str, int]]) -
 @click.option("--proof", "check_proof", is_flag=True, help="Run durable artifact support proof")
 @click.option("--artifacts", "check_artifacts", is_flag=True, help="List durable artifact observations")
 @click.option("--cohorts", "check_cohorts", is_flag=True, help="Summarize durable artifact cohorts")
-@click.option("--semantic-proof", "check_semantic_proof", is_flag=True, help="Run semantic preservation proof over canonical markdown rendering")
+@click.option(
+    "--semantic-proof",
+    "check_semantic_proof",
+    is_flag=True,
+    help="Run semantic preservation proof across canonical render and export surfaces",
+)
 @click.option("--schema-provider", "schema_providers", multiple=True, help="Limit schema verification to DB provider name (repeatable)")
 @click.option(
     "--artifact-provider",
@@ -80,6 +85,12 @@ def _format_semantic_metric_summary(metric_summary: dict[str, dict[str, int]]) -
     "semantic_providers",
     multiple=True,
     help="Limit semantic proof to conversation providers (repeatable)",
+)
+@click.option(
+    "--semantic-surface",
+    "semantic_surfaces",
+    multiple=True,
+    help="Limit semantic proof to surfaces such as canonical, json, yaml, csv, markdown, html, obsidian, org, or all",
 )
 @click.option(
     "--semantic-limit",
@@ -140,6 +151,7 @@ def check_command(
     artifact_limit: int | None,
     artifact_offset: int,
     semantic_providers: tuple[str, ...],
+    semantic_surfaces: tuple[str, ...],
     semantic_limit: int | None,
     semantic_offset: int,
     schema_samples: str,
@@ -174,6 +186,8 @@ def check_command(
         fail("check", "--artifact-offset requires --proof, --artifacts, or --cohorts")
     if semantic_providers and not check_semantic_proof:
         fail("check", "--semantic-provider requires --semantic-proof")
+    if semantic_surfaces and not check_semantic_proof:
+        fail("check", "--semantic-surface requires --semantic-proof")
     if semantic_limit is not None and not check_semantic_proof:
         fail("check", "--semantic-limit requires --semantic-proof")
     if semantic_offset != 0 and not check_semantic_proof:
@@ -243,13 +257,17 @@ def check_command(
             record_offset=artifact_offset,
         )
     if check_semantic_proof:
-        from polylogue.rendering.semantic_proof import prove_markdown_render_semantics
+        from polylogue.rendering.semantic_proof import prove_semantic_surface_suite
 
-        semantic_report = prove_markdown_render_semantics(
-            providers=list(semantic_providers) if semantic_providers else None,
-            record_limit=semantic_limit,
-            record_offset=semantic_offset,
-        )
+        try:
+            semantic_report = prove_semantic_surface_suite(
+                providers=list(semantic_providers) if semantic_providers else None,
+                surfaces=list(semantic_surfaces) if semantic_surfaces else None,
+                record_limit=semantic_limit,
+                record_offset=semantic_offset,
+            )
+        except ValueError as exc:
+            fail("check", str(exc))
 
     # Run repairs before output so JSON mode includes repair results
     repair_results: list | None = None
@@ -409,24 +427,35 @@ def check_command(
         semantic_summary = semantic_report.to_dict()["summary"]
         lines.append("")
         lines.append(
-            f"Semantic proof: {semantic_summary['total_conversations']:,} conversations "
-            f"(clean={semantic_summary['clean_conversations']:,}, "
-            f"critical={semantic_summary['critical_conversations']:,}, "
+            f"Semantic proof: {semantic_summary['surface_count']:,} surfaces "
+            f"(clean={semantic_summary['clean_surfaces']:,}, "
+            f"critical={semantic_summary['critical_surfaces']:,}, "
+            f"total_conversations={semantic_summary['total_conversations']:,}, "
             f"preserved_checks={semantic_summary['preserved_checks']:,}, "
             f"declared_loss_checks={semantic_summary['declared_loss_checks']:,}, "
             f"critical_loss_checks={semantic_summary['critical_loss_checks']:,})"
         )
         if semantic_summary["metric_summary"]:
             lines.append(f"  Metrics: {_format_semantic_metric_summary(semantic_summary['metric_summary'])}")
-        for provider, stats in sorted(semantic_report.provider_reports.items()):
+        for surface, surface_report in sorted(semantic_report.surfaces.items()):
+            surface_summary = surface_report.to_dict()["summary"]
             lines.append(
-                f"  {provider}: conversations={stats.total_conversations:,} "
-                f"clean={stats.clean_conversations:,} "
-                f"critical={stats.critical_conversations:,} "
-                f"preserved_checks={stats.preserved_checks:,} "
-                f"declared_loss_checks={stats.declared_loss_checks:,} "
-                f"critical_loss_checks={stats.critical_loss_checks:,}"
+                f"  {surface}: conversations={surface_summary['total_conversations']:,} "
+                f"clean={surface_summary['clean_conversations']:,} "
+                f"critical={surface_summary['critical_conversations']:,} "
+                f"preserved_checks={surface_summary['preserved_checks']:,} "
+                f"declared_loss_checks={surface_summary['declared_loss_checks']:,} "
+                f"critical_loss_checks={surface_summary['critical_loss_checks']:,}"
             )
+            for provider, stats in sorted(surface_report.providers.items()):
+                lines.append(
+                    f"    {provider}: conversations={stats.total_conversations:,} "
+                    f"clean={stats.clean_conversations:,} "
+                    f"critical={stats.critical_conversations:,} "
+                    f"preserved_checks={stats.preserved_checks:,} "
+                    f"declared_loss_checks={stats.declared_loss_checks:,} "
+                    f"critical_loss_checks={stats.critical_loss_checks:,}"
+                )
 
     if runtime_report is not None:
         lines.append("")

--- a/polylogue/cli/commands/check.py
+++ b/polylogue/cli/commands/check.py
@@ -46,7 +46,7 @@ def _format_semantic_metric_summary(metric_summary: dict[str, dict[str, int]]) -
     "--semantic-proof",
     "check_semantic_proof",
     is_flag=True,
-    help="Run semantic preservation proof across canonical render and export surfaces",
+    help="Run semantic preservation proof across canonical, export, query, stream, and MCP read surfaces",
 )
 @click.option("--schema-provider", "schema_providers", multiple=True, help="Limit schema verification to DB provider name (repeatable)")
 @click.option(
@@ -90,7 +90,7 @@ def _format_semantic_metric_summary(metric_summary: dict[str, dict[str, int]]) -
     "--semantic-surface",
     "semantic_surfaces",
     multiple=True,
-    help="Limit semantic proof to surfaces such as canonical, json, yaml, csv, markdown, html, obsidian, org, or all",
+    help="Limit semantic proof to canonical/export/query/stream/MCP surfaces such as canonical, export_all, query_all, stream_all, mcp_all, read_all, or all",
 )
 @click.option(
     "--semantic-limit",

--- a/polylogue/cli/commands/check.py
+++ b/polylogue/cli/commands/check.py
@@ -19,6 +19,17 @@ def _format_count_mapping(counts: dict[str, int]) -> str:
     return ", ".join(f"{key}={value:,}" for key, value in sorted(counts.items()))
 
 
+def _format_semantic_metric_summary(metric_summary: dict[str, dict[str, int]]) -> str:
+    return ", ".join(
+        (
+            f"{metric}(preserved={counts.get('preserved', 0):,}, "
+            f"declared_loss={counts.get('declared_loss', 0):,}, "
+            f"critical_loss={counts.get('critical_loss', 0):,})"
+        )
+        for metric, counts in sorted(metric_summary.items())
+    )
+
+
 @click.command("check")
 @click.option("--json", "json_output", is_flag=True, help="Output as JSON")
 @click.option("--verbose", "-v", is_flag=True, help="Show breakdown by provider")
@@ -31,6 +42,7 @@ def _format_count_mapping(counts: dict[str, int]) -> str:
 @click.option("--proof", "check_proof", is_flag=True, help="Run durable artifact support proof")
 @click.option("--artifacts", "check_artifacts", is_flag=True, help="List durable artifact observations")
 @click.option("--cohorts", "check_cohorts", is_flag=True, help="Summarize durable artifact cohorts")
+@click.option("--semantic-proof", "check_semantic_proof", is_flag=True, help="Run semantic preservation proof over canonical markdown rendering")
 @click.option("--schema-provider", "schema_providers", multiple=True, help="Limit schema verification to DB provider name (repeatable)")
 @click.option(
     "--artifact-provider",
@@ -62,6 +74,25 @@ def _format_count_mapping(counts: dict[str, int]) -> str:
     default=0,
     show_default=True,
     help="Start offset for artifact proof/listing/cohorting",
+)
+@click.option(
+    "--semantic-provider",
+    "semantic_providers",
+    multiple=True,
+    help="Limit semantic proof to conversation providers (repeatable)",
+)
+@click.option(
+    "--semantic-limit",
+    type=int,
+    default=None,
+    help="Limit semantic proof to N conversations",
+)
+@click.option(
+    "--semantic-offset",
+    type=int,
+    default=0,
+    show_default=True,
+    help="Start offset for semantic proof",
 )
 @click.option(
     "--schema-samples",
@@ -101,12 +132,16 @@ def check_command(
     check_proof: bool,
     check_artifacts: bool,
     check_cohorts: bool,
+    check_semantic_proof: bool,
     schema_providers: tuple[str, ...],
     artifact_providers: tuple[str, ...],
     artifact_statuses: tuple[str, ...],
     artifact_kinds: tuple[str, ...],
     artifact_limit: int | None,
     artifact_offset: int,
+    semantic_providers: tuple[str, ...],
+    semantic_limit: int | None,
+    semantic_offset: int,
     schema_samples: str,
     schema_record_limit: int | None,
     schema_record_offset: int,
@@ -137,6 +172,12 @@ def check_command(
         fail("check", "--artifact-limit requires --proof, --artifacts, or --cohorts")
     if artifact_offset != 0 and not (check_proof or check_artifacts or check_cohorts):
         fail("check", "--artifact-offset requires --proof, --artifacts, or --cohorts")
+    if semantic_providers and not check_semantic_proof:
+        fail("check", "--semantic-provider requires --semantic-proof")
+    if semantic_limit is not None and not check_semantic_proof:
+        fail("check", "--semantic-limit requires --semantic-proof")
+    if semantic_offset != 0 and not check_semantic_proof:
+        fail("check", "--semantic-offset requires --semantic-proof")
     if schema_record_limit is not None and schema_record_limit <= 0:
         fail("check", "--schema-record-limit must be a positive integer")
     if schema_record_offset < 0:
@@ -145,6 +186,10 @@ def check_command(
         fail("check", "--artifact-limit must be a positive integer")
     if artifact_offset < 0:
         fail("check", "--artifact-offset must be >= 0")
+    if semantic_limit is not None and semantic_limit <= 0:
+        fail("check", "--semantic-limit must be a positive integer")
+    if semantic_offset < 0:
+        fail("check", "--semantic-offset must be >= 0")
 
     config = load_effective_config(env)
     report = get_health(config, deep=deep)
@@ -155,6 +200,7 @@ def check_command(
     proof_report = None
     artifact_rows = None
     cohort_rows = None
+    semantic_report = None
     if check_schemas:
         from polylogue.schemas.verification import verify_raw_corpus
 
@@ -196,6 +242,14 @@ def check_command(
             record_limit=artifact_limit,
             record_offset=artifact_offset,
         )
+    if check_semantic_proof:
+        from polylogue.rendering.semantic_proof import prove_markdown_render_semantics
+
+        semantic_report = prove_markdown_render_semantics(
+            providers=list(semantic_providers) if semantic_providers else None,
+            record_limit=semantic_limit,
+            record_offset=semantic_offset,
+        )
 
     # Run repairs before output so JSON mode includes repair results
     repair_results: list | None = None
@@ -235,6 +289,8 @@ def check_command(
                 "count": len(cohort_rows),
                 "items": [row.model_dump(mode="json") for row in cohort_rows],
             }
+        if semantic_report is not None:
+            out["semantic_proof"] = semantic_report.to_dict()
         if repair_results is not None:
             out["repairs"] = [r.to_dict() for r in repair_results]
         if vacuum_result is not None:
@@ -347,6 +403,29 @@ def check_command(
                 f"count={row.observation_count:,} cohort={row.cohort_id or '-'} "
                 f"version={row.resolved_package_version or '-'} "
                 f"element={row.resolved_element_kind or '-'}"
+            )
+
+    if semantic_report is not None:
+        semantic_summary = semantic_report.to_dict()["summary"]
+        lines.append("")
+        lines.append(
+            f"Semantic proof: {semantic_summary['total_conversations']:,} conversations "
+            f"(clean={semantic_summary['clean_conversations']:,}, "
+            f"critical={semantic_summary['critical_conversations']:,}, "
+            f"preserved_checks={semantic_summary['preserved_checks']:,}, "
+            f"declared_loss_checks={semantic_summary['declared_loss_checks']:,}, "
+            f"critical_loss_checks={semantic_summary['critical_loss_checks']:,})"
+        )
+        if semantic_summary["metric_summary"]:
+            lines.append(f"  Metrics: {_format_semantic_metric_summary(semantic_summary['metric_summary'])}")
+        for provider, stats in sorted(semantic_report.provider_reports.items()):
+            lines.append(
+                f"  {provider}: conversations={stats.total_conversations:,} "
+                f"clean={stats.clean_conversations:,} "
+                f"critical={stats.critical_conversations:,} "
+                f"preserved_checks={stats.preserved_checks:,} "
+                f"declared_loss_checks={stats.declared_loss_checks:,} "
+                f"critical_loss_checks={stats.critical_loss_checks:,}"
             )
 
     if runtime_report is not None:

--- a/polylogue/cli/query_output.py
+++ b/polylogue/cli/query_output.py
@@ -10,8 +10,8 @@ from typing import TYPE_CHECKING, Any
 import click
 
 from polylogue.cli.query_helpers import no_results, summary_to_dict
-from polylogue.rendering.formatting import format_conversation
 from polylogue.logging import get_logger
+from polylogue.rendering.formatting import format_conversation
 
 logger = get_logger(__name__)
 
@@ -20,6 +20,191 @@ if TYPE_CHECKING:
     from polylogue.lib.filters import ConversationFilter
     from polylogue.lib.models import Conversation, ConversationSummary, Message
     from polylogue.storage.repository import ConversationRepository
+
+
+def format_summary_list(
+    summaries: list[ConversationSummary],
+    output_format: str,
+    fields: str | None,
+    *,
+    message_counts: dict[str, int] | None = None,
+) -> str:
+    """Format summary-list output for deterministic machine/plain surfaces."""
+    message_counts = message_counts or {}
+
+    selected: set[str] | None = None
+    if fields:
+        selected = {f.strip() for f in fields.split(",")}
+
+    if output_format == "json":
+        data = [summary_to_dict(s, message_counts.get(str(s.id), 0)) for s in summaries]
+        if selected:
+            data = [{k: v for k, v in d.items() if k in selected} for d in data]
+        return json.dumps(data, indent=2)
+
+    if output_format == "yaml":
+        import yaml
+
+        data = [summary_to_dict(s, message_counts.get(str(s.id), 0)) for s in summaries]
+        if selected:
+            data = [{k: v for k, v in d.items() if k in selected} for d in data]
+        return yaml.dump(data, default_flow_style=False, allow_unicode=True)
+
+    if output_format == "csv":
+        import csv
+        import io
+
+        buf = io.StringIO()
+        writer = csv.writer(buf)
+        writer.writerow(["id", "date", "provider", "title", "messages", "tags", "summary"])
+        for s in summaries:
+            date = s.display_date.strftime("%Y-%m-%d") if s.display_date else ""
+            tags_str = ",".join(s.tags) if s.tags else ""
+            writer.writerow([
+                str(s.id),
+                date,
+                s.provider,
+                s.display_title or "",
+                message_counts.get(str(s.id), 0),
+                tags_str,
+                s.summary or "",
+            ])
+        return buf.getvalue().rstrip("\r\n")
+
+    lines = []
+    for s in summaries:
+        date = s.display_date.strftime("%Y-%m-%d") if s.display_date else ""
+        raw_title = s.display_title or str(s.id)[:20]
+        title = (raw_title[:47] + "...") if len(raw_title) > 50 else raw_title
+        count = message_counts.get(str(s.id), 0)
+        lines.append(f"{str(s.id)[:24]:24s}  {date:10s}  {s.provider:12s}  {title} ({count} msgs)")
+    return "\n".join(lines)
+
+
+def render_stream_message(message: Message, output_format: str) -> str:
+    """Render a single streamed message chunk."""
+    if output_format == "plaintext":
+        if not message.text:
+            return ""
+        role_label = (message.role or "unknown").upper().replace("[", "").replace("]", "")
+        return f"[{role_label}]\n{message.text}\n\n"
+
+    if output_format == "markdown":
+        if not message.text:
+            return ""
+        role_label = (message.role or "unknown").capitalize()
+        return f"## {role_label}\n\n{message.text}\n\n"
+
+    if output_format == "json-lines":
+        record = {
+            "type": "message",
+            "id": message.id,
+            "role": message.role,
+            "timestamp": message.timestamp.isoformat() if message.timestamp else None,
+            "text": message.text,
+            "word_count": message.word_count,
+        }
+        return json.dumps(record, ensure_ascii=False) + "\n"
+
+    return ""
+
+
+def render_stream_header(
+    *,
+    conversation_id: str,
+    title: str | None,
+    provider: str | None,
+    display_date: object | None,
+    output_format: str,
+    dialogue_only: bool,
+    message_limit: int | None,
+    stats: dict[str, Any] | None,
+) -> str:
+    """Render any stream prelude/header for the selected output format."""
+    if hasattr(display_date, "strftime"):
+        display_date_text = display_date.strftime("%Y-%m-%d %H:%M")
+        display_date_value = display_date.isoformat() if hasattr(display_date, "isoformat") else str(display_date)
+    elif display_date:
+        display_date_text = str(display_date)
+        display_date_value = str(display_date)
+    else:
+        display_date_text = None
+        display_date_value = None
+
+    if output_format == "markdown":
+        lines = [f"# {title or conversation_id[:24]}", ""]
+        if display_date_text is not None:
+            lines.append(f"**Date**: {display_date_text}")
+        if provider:
+            lines.append(f"**Provider**: {provider}")
+        if display_date_text is not None or provider:
+            lines.append("")
+        if dialogue_only and stats:
+            line = f"_Showing {stats['dialogue_messages']} dialogue messages"
+            if message_limit:
+                line += f" (limit: {message_limit})"
+            line += f" of {stats['total_messages']} total_"
+            lines.extend([line, ""])
+        return "\n".join(lines)
+
+    if output_format == "json-lines":
+        header = {
+            "type": "header",
+            "conversation_id": conversation_id,
+            "title": title,
+            "provider": provider,
+            "date": display_date_value,
+            "dialogue_only": dialogue_only,
+            "message_limit": message_limit,
+            "stats": stats,
+        }
+        return json.dumps(header) + "\n"
+
+    return ""
+
+
+def render_stream_footer(*, output_format: str, emitted_messages: int) -> str:
+    """Render any stream closing/footer fragment."""
+    if output_format == "markdown":
+        return f"\n---\n_Streamed {emitted_messages} messages_\n"
+    if output_format == "json-lines":
+        return json.dumps({"type": "footer", "message_count": emitted_messages}) + "\n"
+    return ""
+
+
+def render_stream_transcript(
+    *,
+    conversation_id: str,
+    title: str | None,
+    provider: str | None,
+    display_date: object | None,
+    messages: list[Message],
+    output_format: str,
+    dialogue_only: bool = False,
+    message_limit: int | None = None,
+    stats: dict[str, Any] | None = None,
+) -> tuple[str, int]:
+    """Render the full stream transcript deterministically for proof/tests."""
+    parts = [
+        render_stream_header(
+            conversation_id=conversation_id,
+            title=title,
+            provider=provider,
+            display_date=display_date,
+            output_format=output_format,
+            dialogue_only=dialogue_only,
+            message_limit=message_limit,
+            stats=stats,
+        )
+    ]
+    emitted = 0
+    for message in messages[: message_limit if message_limit is not None else None]:
+        chunk = render_stream_message(message, output_format)
+        if chunk:
+            parts.append(chunk)
+            emitted += 1
+    parts.append(render_stream_footer(output_format=output_format, emitted_messages=emitted))
+    return "".join(parts), emitted
 
 
 async def output_stats_sql(
@@ -273,55 +458,15 @@ async def _output_summary_list(
         msg_counts = await repo.queries.get_message_counts_batch(ids)
 
     fields = params.get("fields")
-    selected: set[str] | None = None
-    if fields:
-        selected = {f.strip() for f in fields.split(",")}
-
-    if output_format == "json":
-        data = [summary_to_dict(s, msg_counts.get(str(s.id), 0)) for s in summaries]
-        if selected:
-            data = [{k: v for k, v in d.items() if k in selected} for d in data]
-        click.echo(json.dumps(data, indent=2))
-        return
-
-    if output_format == "yaml":
-        import yaml
-
-        data = [summary_to_dict(s, msg_counts.get(str(s.id), 0)) for s in summaries]
-        if selected:
-            data = [{k: v for k, v in d.items() if k in selected} for d in data]
-        click.echo(yaml.dump(data, default_flow_style=False, allow_unicode=True))
-        return
-
-    if output_format == "csv":
-        import csv
-        import io
-
-        buf = io.StringIO()
-        writer = csv.writer(buf)
-        writer.writerow(["id", "date", "provider", "title", "messages", "tags", "summary"])
-        for s in summaries:
-            date = s.display_date.strftime("%Y-%m-%d") if s.display_date else ""
-            tags_str = ",".join(s.tags) if s.tags else ""
-            writer.writerow([
-                str(s.id),
-                date,
-                s.provider,
-                s.display_title or "",
-                msg_counts.get(str(s.id), 0),
-                tags_str,
-                s.summary or "",
-            ])
-        click.echo(buf.getvalue().rstrip("\r\n"))
-        return
-
-    if env.ui.plain:
-        for s in summaries:
-            date = s.display_date.strftime("%Y-%m-%d") if s.display_date else ""
-            raw_title = s.display_title or str(s.id)[:20]
-            title = (raw_title[:47] + "...") if len(raw_title) > 50 else raw_title
-            count = msg_counts.get(str(s.id), 0)
-            click.echo(f"{str(s.id)[:24]:24s}  {date:10s}  {s.provider:12s}  {title} ({count} msgs)")
+    if output_format in {"json", "yaml", "csv"} or env.ui.plain:
+        click.echo(
+            format_summary_list(
+                summaries,
+                "text" if env.ui.plain and output_format not in {"json", "yaml", "csv"} else output_format,
+                fields,
+                message_counts=msg_counts,
+            )
+        )
         return
 
     from rich.table import Table
@@ -446,27 +591,19 @@ async def stream_conversation(
         raise SystemExit(1)
 
     stats = await repo.queries.get_conversation_stats(conversation_id)
-
-    if output_format == "markdown":
-        title = conv_record.title or conversation_id[:24]
-        sys.stdout.write(f"# {title}\n\n")
-        if dialogue_only and stats:
-            sys.stdout.write(f"_Showing {stats['dialogue_messages']} dialogue messages")
-            if message_limit:
-                sys.stdout.write(f" (limit: {message_limit})")
-            sys.stdout.write(f" of {stats['total_messages']} total_\n\n")
-        sys.stdout.flush()
-    elif output_format == "json-lines":
-        header = {
-            "type": "header",
-            "conversation_id": conversation_id,
-            "title": conv_record.title,
-            "dialogue_only": dialogue_only,
-            "message_limit": message_limit,
-            "stats": stats,
-        }
-        sys.stdout.write(json.dumps(header) + "\n")
-        sys.stdout.flush()
+    sys.stdout.write(
+        render_stream_header(
+            conversation_id=conversation_id,
+            title=conv_record.title,
+            provider=getattr(conv_record, "provider_name", None),
+            display_date=(getattr(conv_record, "updated_at", None) or getattr(conv_record, "created_at", None)),
+            output_format=output_format,
+            dialogue_only=dialogue_only,
+            message_limit=message_limit,
+            stats=stats,
+        )
+    )
+    sys.stdout.flush()
 
     count = 0
     async for msg in repo.iter_messages(
@@ -474,46 +611,23 @@ async def stream_conversation(
         dialogue_only=dialogue_only,
         limit=message_limit,
     ):
-        _write_message_streaming(msg, output_format)
-        count += 1
+        chunk = render_stream_message(msg, output_format)
+        if chunk:
+            sys.stdout.write(chunk)
+            count += 1
+        sys.stdout.flush()
 
-    if output_format == "markdown":
-        sys.stdout.write(f"\n---\n_Streamed {count} messages_\n")
-        sys.stdout.flush()
-    elif output_format == "json-lines":
-        footer = {"type": "footer", "message_count": count}
-        sys.stdout.write(json.dumps(footer) + "\n")
-        sys.stdout.flush()
+    sys.stdout.write(render_stream_footer(output_format=output_format, emitted_messages=count))
+    sys.stdout.flush()
 
     return count
 
 
 def _write_message_streaming(msg: Message, output_format: str) -> None:
     """Write a single message to stdout in streaming mode."""
-    if output_format == "plaintext":
-        role_label = (msg.role or "unknown").upper().replace("[", "").replace("]", "")
-        if msg.text:
-            sys.stdout.write(f"[{role_label}]\n{msg.text}\n\n")
-        sys.stdout.flush()
-        return
-
-    if output_format == "markdown":
-        if msg.text:
-            role_label = (msg.role or "unknown").capitalize()
-            sys.stdout.write(f"## {role_label}\n\n{msg.text}\n\n")
-            sys.stdout.flush()
-        return
-
-    if output_format == "json-lines":
-        record = {
-            "type": "message",
-            "id": msg.id,
-            "role": msg.role,
-            "timestamp": msg.timestamp.isoformat() if msg.timestamp else None,
-            "text": msg.text,
-            "word_count": msg.word_count,
-        }
-        sys.stdout.write(json.dumps(record, ensure_ascii=False) + "\n")
+    chunk = render_stream_message(msg, output_format)
+    if chunk:
+        sys.stdout.write(chunk)
         sys.stdout.flush()
 
 

--- a/polylogue/publication.py
+++ b/polylogue/publication.py
@@ -97,6 +97,21 @@ class ArtifactProofSummary(BaseModel):
     clean: bool
 
 
+class SemanticProofSummary(BaseModel):
+    """Compact semantic-preservation proof summary embedded in publication manifests."""
+
+    surface: str
+    total_conversations: int
+    provider_count: int
+    clean_conversations: int
+    critical_conversations: int
+    preserved_checks: int
+    declared_loss_checks: int
+    critical_loss_checks: int
+    metric_summary: dict[str, dict[str, int]] = Field(default_factory=dict)
+    clean: bool
+
+
 class ArchivePublicationSummary(BaseModel):
     """Archive-scale summary embedded in publication manifests."""
 
@@ -139,4 +154,5 @@ class SitePublicationManifest(BaseModel):
     outputs: SiteOutputSummary
     latest_run: PublicationRunSummary | None = None
     artifact_proof: ArtifactProofSummary | None = None
+    semantic_proof: SemanticProofSummary | None = None
     artifacts: OutputManifest

--- a/polylogue/publication.py
+++ b/polylogue/publication.py
@@ -98,7 +98,7 @@ class ArtifactProofSummary(BaseModel):
 
 
 class SemanticProofSummary(BaseModel):
-    """Compact semantic-preservation proof summary embedded in publication manifests."""
+    """Per-surface semantic-preservation proof summary embedded in publication manifests."""
 
     surface: str
     total_conversations: int
@@ -109,6 +109,21 @@ class SemanticProofSummary(BaseModel):
     declared_loss_checks: int
     critical_loss_checks: int
     metric_summary: dict[str, dict[str, int]] = Field(default_factory=dict)
+    clean: bool
+
+
+class SemanticProofSuiteSummary(BaseModel):
+    """Compact multi-surface semantic-proof summary embedded in publication manifests."""
+
+    surface_count: int
+    clean_surfaces: int
+    critical_surfaces: int
+    total_conversations: int
+    preserved_checks: int
+    declared_loss_checks: int
+    critical_loss_checks: int
+    metric_summary: dict[str, dict[str, int]] = Field(default_factory=dict)
+    surfaces: dict[str, SemanticProofSummary] = Field(default_factory=dict)
     clean: bool
 
 
@@ -154,5 +169,5 @@ class SitePublicationManifest(BaseModel):
     outputs: SiteOutputSummary
     latest_run: PublicationRunSummary | None = None
     artifact_proof: ArtifactProofSummary | None = None
-    semantic_proof: SemanticProofSummary | None = None
+    semantic_proof: SemanticProofSuiteSummary | None = None
     artifacts: OutputManifest

--- a/polylogue/rendering/renderers/html.py
+++ b/polylogue/rendering/renderers/html.py
@@ -407,7 +407,7 @@ def render_conversation_html(conv: Conversation, theme: str = "dark") -> str:
         conversation_id=str(conv.id),
         messages=messages,
         message_count=len(messages),
-        created_at=str(conv.created_at) if conv.created_at else None,
+        created_at=str(conv.display_date) if conv.display_date else None,
         highlight_css=highlighter.get_css(),
         theme=theme,
     )

--- a/polylogue/rendering/semantic_proof.py
+++ b/polylogue/rendering/semantic_proof.py
@@ -1,20 +1,73 @@
-"""Semantic preservation proofing for rendered output surfaces."""
+"""Semantic preservation proofing for canonical render and export surfaces."""
 
 from __future__ import annotations
 
 import asyncio
+import csv
+import io
+import json
+import re
 from collections import Counter
 from dataclasses import dataclass, field
+from html import unescape as html_unescape
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from polylogue.lib.roles import Role
 from polylogue.paths import archive_root as default_archive_root
 from polylogue.paths import db_path as default_db_path
 from polylogue.rendering.core import ConversationFormatter
+from polylogue.rendering.formatting import format_conversation
 from polylogue.storage.backends.async_sqlite import SQLiteBackend
 from polylogue.storage.repository import ConversationRepository
 from polylogue.storage.store import ConversationRenderProjection, MessageRecord
+
+if TYPE_CHECKING:
+    from polylogue.lib.models import Conversation, Message
+
+
+DEFAULT_SEMANTIC_SURFACES: tuple[str, ...] = (
+    "canonical_markdown_v1",
+    "export_json_v1",
+    "export_yaml_v1",
+    "export_csv_v1",
+    "export_markdown_v1",
+    "export_html_v1",
+    "export_obsidian_v1",
+    "export_org_v1",
+)
+
+_SURFACE_ALIASES: dict[str, tuple[str, ...]] = {
+    "all": DEFAULT_SEMANTIC_SURFACES,
+    "canonical": ("canonical_markdown_v1",),
+    "canonical_markdown": ("canonical_markdown_v1",),
+    "canonical_markdown_v1": ("canonical_markdown_v1",),
+    "json": ("export_json_v1",),
+    "yaml": ("export_yaml_v1",),
+    "csv": ("export_csv_v1",),
+    "markdown": ("export_markdown_v1",),
+    "html": ("export_html_v1",),
+    "obsidian": ("export_obsidian_v1",),
+    "org": ("export_org_v1",),
+    "export_all": tuple(surface for surface in DEFAULT_SEMANTIC_SURFACES if surface != "canonical_markdown_v1"),
+}
+
+_EXPORT_SURFACE_FORMATS: dict[str, str] = {
+    "export_json_v1": "json",
+    "export_yaml_v1": "yaml",
+    "export_csv_v1": "csv",
+    "export_markdown_v1": "markdown",
+    "export_html_v1": "html",
+    "export_obsidian_v1": "obsidian",
+    "export_org_v1": "org",
+}
+
+_HTML_ROLE_RE = re.compile(r'class="role-label">([^<]+)</span>')
+_HTML_TIMESTAMP_RE = re.compile(r'class="timestamp">[^<]+</time>')
+_HTML_BRANCH_RE = re.compile(r'class="branch-label">Branch\s+\d+</div>')
+_HTML_TITLE_RE = re.compile(r"<h1>(.*?)</h1>", re.DOTALL)
+_HTML_BADGE_RE = re.compile(r'class="badge">([^<]+)</span>')
+_HTML_META_RE = re.compile(r'class="meta-item">([^<]+)</span>')
 
 
 def _sorted_counts(counts: dict[str, int]) -> dict[str, int]:
@@ -25,13 +78,53 @@ def _empty_metric_counts() -> dict[str, int]:
     return {"preserved": 0, "declared_loss": 0, "critical_loss": 0}
 
 
-def _normalized_role(message: MessageRecord) -> str:
-    role = message.role
-    if isinstance(role, Role):
-        return str(role)
-    if role:
-        return str(Role.normalize(str(role)))
+def _normalized_role_label(value: object) -> str:
+    if isinstance(value, Role):
+        return str(value)
+    if value:
+        return str(Role.normalize(str(value)))
     return "message"
+
+
+def _is_text_message(message: Message | MessageRecord) -> bool:
+    return bool((message.text or "").strip())
+
+
+def _critical_or_preserved(*, metric: str, policy: str, input_value: Any, output_value: Any) -> SemanticMetricCheck:
+    return SemanticMetricCheck(
+        metric=metric,
+        status="preserved" if input_value == output_value else "critical_loss",
+        policy=policy,
+        input_value=input_value,
+        output_value=output_value,
+    )
+
+
+def _declared_loss_or_preserved(*, metric: str, policy: str, input_value: int, output_value: Any = 0) -> SemanticMetricCheck:
+    return SemanticMetricCheck(
+        metric=metric,
+        status="declared_loss" if input_value else "preserved",
+        policy=policy,
+        input_value=input_value,
+        output_value=output_value,
+    )
+
+
+def _presence_check(
+    *,
+    metric: str,
+    policy: str,
+    input_value: object,
+    output_present: bool,
+) -> SemanticMetricCheck:
+    expected_present = input_value is not None
+    return SemanticMetricCheck(
+        metric=metric,
+        status="preserved" if expected_present == output_present else "critical_loss",
+        policy=policy,
+        input_value=input_value,
+        output_value=output_present,
+    )
 
 
 def _input_facts(projection: ConversationRenderProjection) -> dict[str, Any]:
@@ -47,10 +140,10 @@ def _input_facts(projection: ConversationRenderProjection) -> dict[str, Any]:
 
     for message in projection.messages:
         has_attachments = attachment_counts.get(message.message_id, 0) > 0
-        has_text = bool((message.text or "").strip())
+        has_text = _is_text_message(message)
         if has_text or has_attachments:
             renderable_messages += 1
-            role_counts[_normalized_role(message)] += 1
+            role_counts[_normalized_role_label(message.role)] += 1
             if message.sort_key is not None:
                 timestamped_renderable_messages += 1
         else:
@@ -72,7 +165,7 @@ def _input_facts(projection: ConversationRenderProjection) -> dict[str, Any]:
     }
 
 
-def _output_facts(markdown_text: str) -> dict[str, Any]:
+def _canonical_markdown_output_facts(markdown_text: str) -> dict[str, Any]:
     message_sections = 0
     timestamp_lines = 0
     attachment_lines = 0
@@ -83,7 +176,7 @@ def _output_facts(markdown_text: str) -> dict[str, Any]:
             section = line[3:].strip()
             if section.lower() != "attachments":
                 message_sections += 1
-                role_section_counts[section] += 1
+                role_section_counts[_normalized_role_label(section)] += 1
         elif line.startswith("_Timestamp: "):
             timestamp_lines += 1
         elif line.startswith("- Attachment: "):
@@ -96,6 +189,207 @@ def _output_facts(markdown_text: str) -> dict[str, Any]:
         "typed_thinking_markers": 0,
         "typed_tool_markers": 0,
         "role_section_counts": _sorted_counts(dict(role_section_counts)),
+    }
+
+
+def _conversation_input_facts(conversation: Conversation) -> dict[str, Any]:
+    role_counts: Counter[str] = Counter()
+    message_ids: list[str] = []
+    text_message_ids: list[str] = []
+    timestamped_text_messages = 0
+    attachment_count = 0
+    thinking_messages = 0
+    tool_messages = 0
+    branch_messages = 0
+
+    for message in conversation.messages:
+        message_ids.append(str(message.id))
+        attachment_count += len(message.attachments)
+        if message.is_thinking:
+            thinking_messages += 1
+        if message.is_tool_use:
+            tool_messages += 1
+        if message.branch_index > 0:
+            branch_messages += 1
+        if _is_text_message(message):
+            text_message_ids.append(str(message.id))
+            role_counts[_normalized_role_label(message.role)] += 1
+            if message.timestamp is not None:
+                timestamped_text_messages += 1
+
+    display_date = conversation.display_date.isoformat() if conversation.display_date else None
+    return {
+        "conversation_id": str(conversation.id),
+        "provider": str(conversation.provider),
+        "title": conversation.display_title,
+        "date": display_date,
+        "total_messages": len(conversation.messages),
+        "text_messages": len(text_message_ids),
+        "message_ids": message_ids,
+        "text_message_ids": text_message_ids,
+        "text_role_counts": _sorted_counts(dict(role_counts)),
+        "timestamped_text_messages": timestamped_text_messages,
+        "attachment_count": attachment_count,
+        "thinking_messages": thinking_messages,
+        "tool_messages": tool_messages,
+        "branch_messages": branch_messages,
+    }
+
+
+def _json_like_output_facts(payload: dict[str, Any]) -> dict[str, Any]:
+    messages = payload.get("messages")
+    if not isinstance(messages, list):
+        messages = []
+    role_counts: Counter[str] = Counter()
+    message_ids: list[str] = []
+    timestamped_messages = 0
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        message_ids.append(str(message.get("id", "")))
+        role_counts[_normalized_role_label(message.get("role"))] += 1
+        if message.get("timestamp"):
+            timestamped_messages += 1
+    return {
+        "conversation_id": str(payload.get("id") or ""),
+        "provider": str(payload.get("provider") or ""),
+        "title": payload.get("title"),
+        "date": payload.get("date"),
+        "messages": len(message_ids),
+        "message_ids": message_ids,
+        "role_counts": _sorted_counts(dict(role_counts)),
+        "timestamped_messages": timestamped_messages,
+    }
+
+
+def _csv_output_facts(csv_text: str) -> dict[str, Any]:
+    reader = csv.DictReader(io.StringIO(csv_text))
+    message_ids: list[str] = []
+    role_counts: Counter[str] = Counter()
+    timestamped_messages = 0
+    conversation_ids: Counter[str] = Counter()
+    for row in reader:
+        conversation_id = str(row.get("conversation_id") or "")
+        if conversation_id:
+            conversation_ids[conversation_id] += 1
+        message_ids.append(str(row.get("message_id") or ""))
+        role_counts[_normalized_role_label(row.get("role"))] += 1
+        if row.get("timestamp"):
+            timestamped_messages += 1
+    conversation_id = ""
+    if conversation_ids:
+        conversation_id = conversation_ids.most_common(1)[0][0]
+    return {
+        "conversation_id": conversation_id,
+        "messages": len(message_ids),
+        "message_ids": message_ids,
+        "role_counts": _sorted_counts(dict(role_counts)),
+        "timestamped_messages": timestamped_messages,
+        "provider": None,
+        "title": None,
+        "date": None,
+    }
+
+
+def _markdown_doc_output_facts(text: str) -> dict[str, Any]:
+    title: str | None = None
+    provider: str | None = None
+    has_date = False
+    message_sections = 0
+    role_counts: Counter[str] = Counter()
+    for line in text.splitlines():
+        if title is None and line.startswith("# "):
+            title = line[2:].strip()
+        elif line.startswith("**Provider**: "):
+            provider = line.split(": ", 1)[1].strip()
+        elif line.startswith("**Date**: "):
+            has_date = True
+        elif line.startswith("## "):
+            role = line[3:].strip()
+            message_sections += 1
+            role_counts[_normalized_role_label(role)] += 1
+    return {
+        "title": title,
+        "provider": provider,
+        "has_date": has_date,
+        "message_sections": message_sections,
+        "role_counts": _sorted_counts(dict(role_counts)),
+        "timestamp_lines": 0,
+        "branch_labels": 0,
+        "conversation_id": None,
+    }
+
+
+def _obsidian_output_facts(text: str) -> dict[str, Any]:
+    frontmatter: dict[str, Any] = {}
+    body = text
+    if text.startswith("---\n"):
+        parts = text.split("\n---\n", 1)
+        if len(parts) == 2:
+            _, body = parts
+            try:
+                import yaml
+
+                parsed = yaml.safe_load(parts[0].replace("---\n", "", 1))
+                if isinstance(parsed, dict):
+                    frontmatter = parsed
+            except Exception:
+                frontmatter = {}
+    body_facts = _markdown_doc_output_facts(body)
+    body_facts["conversation_id"] = str(frontmatter.get("id") or "")
+    body_facts["provider"] = str(frontmatter.get("provider") or "")
+    body_facts["has_date"] = frontmatter.get("date") is not None
+    return body_facts
+
+
+def _org_output_facts(text: str) -> dict[str, Any]:
+    title: str | None = None
+    provider: str | None = None
+    has_date = False
+    message_sections = 0
+    role_counts: Counter[str] = Counter()
+    for line in text.splitlines():
+        if line.startswith("#+TITLE: "):
+            title = line.split(": ", 1)[1].strip()
+        elif line.startswith("#+DATE: "):
+            has_date = True
+        elif line.startswith("#+PROPERTY: provider "):
+            provider = line.split("#+PROPERTY: provider ", 1)[1].strip()
+        elif line.startswith("* "):
+            role = line[2:].strip()
+            message_sections += 1
+            role_counts[_normalized_role_label(role)] += 1
+    return {
+        "title": title,
+        "provider": provider,
+        "has_date": has_date,
+        "message_sections": message_sections,
+        "role_counts": _sorted_counts(dict(role_counts)),
+        "timestamp_lines": 0,
+        "branch_labels": 0,
+        "conversation_id": None,
+    }
+
+
+def _html_output_facts(text: str) -> dict[str, Any]:
+    title_match = _HTML_TITLE_RE.search(text)
+    title = html_unescape(title_match.group(1).strip()) if title_match else None
+    badge_match = _HTML_BADGE_RE.search(text)
+    provider = badge_match.group(1).strip() if badge_match else None
+    meta_items = [html_unescape(item).strip() for item in _HTML_META_RE.findall(text)]
+    has_date = len(meta_items) >= 2
+    role_counts: Counter[str] = Counter(
+        _normalized_role_label(role.strip()) for role in _HTML_ROLE_RE.findall(text)
+    )
+    return {
+        "title": title,
+        "provider": provider,
+        "has_date": has_date,
+        "message_sections": sum(role_counts.values()),
+        "role_counts": _sorted_counts(dict(role_counts)),
+        "timestamp_lines": len(_HTML_TIMESTAMP_RE.findall(text)),
+        "branch_labels": len(_HTML_BRANCH_RE.findall(text)),
+        "conversation_id": None,
     }
 
 
@@ -121,7 +415,7 @@ class SemanticMetricCheck:
 
 @dataclass(frozen=True)
 class SemanticConversationProof:
-    """Semantic proof result for one rendered conversation surface."""
+    """Semantic proof result for one rendered/exported conversation surface."""
 
     conversation_id: str
     provider: str
@@ -332,76 +626,154 @@ class SemanticProofReport:
         }
 
 
+@dataclass(frozen=True)
+class SemanticProofSuiteReport:
+    """Aggregate semantic proof report spanning multiple output surfaces."""
+
+    surface_reports: dict[str, SemanticProofReport]
+    record_limit: int | None = None
+    record_offset: int = 0
+    provider_filters: list[str] = field(default_factory=list)
+    surface_filters: list[str] = field(default_factory=list)
+
+    @property
+    def surfaces(self) -> dict[str, SemanticProofReport]:
+        return self.surface_reports
+
+    @property
+    def surface_count(self) -> int:
+        return len(self.surface_reports)
+
+    @property
+    def clean_surfaces(self) -> int:
+        return sum(1 for report in self.surface_reports.values() if report.is_clean)
+
+    @property
+    def critical_surfaces(self) -> int:
+        return sum(1 for report in self.surface_reports.values() if not report.is_clean)
+
+    @property
+    def total_conversations(self) -> int:
+        return sum(report.total_conversations for report in self.surface_reports.values())
+
+    @property
+    def preserved_checks(self) -> int:
+        return sum(report.preserved_checks for report in self.surface_reports.values())
+
+    @property
+    def declared_loss_checks(self) -> int:
+        return sum(report.declared_loss_checks for report in self.surface_reports.values())
+
+    @property
+    def critical_loss_checks(self) -> int:
+        return sum(report.critical_loss_checks for report in self.surface_reports.values())
+
+    @property
+    def metric_summary(self) -> dict[str, dict[str, int]]:
+        summary: dict[str, dict[str, int]] = {}
+        for report in self.surface_reports.values():
+            for metric, counts in report.metric_summary.items():
+                metric_counts = summary.setdefault(metric, _empty_metric_counts())
+                for status, count in counts.items():
+                    metric_counts[status] += count
+        return dict(sorted(summary.items()))
+
+    @property
+    def is_clean(self) -> bool:
+        return self.critical_surfaces == 0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "record_limit": self.record_limit if self.record_limit is not None else "all",
+            "record_offset": self.record_offset,
+            "provider_filters": list(self.provider_filters),
+            "surface_filters": list(self.surface_filters),
+            "summary": {
+                "surface_count": self.surface_count,
+                "clean_surfaces": self.clean_surfaces,
+                "critical_surfaces": self.critical_surfaces,
+                "total_conversations": self.total_conversations,
+                "preserved_checks": self.preserved_checks,
+                "declared_loss_checks": self.declared_loss_checks,
+                "critical_loss_checks": self.critical_loss_checks,
+                "metric_summary": self.metric_summary,
+                "clean": self.is_clean,
+            },
+            "surfaces": {
+                surface: report.to_dict()
+                for surface, report in sorted(self.surface_reports.items())
+            },
+        }
+
+
+def resolve_semantic_surfaces(surfaces: list[str] | tuple[str, ...] | None) -> list[str]:
+    """Normalize semantic-proof surface filters to canonical surface names."""
+    if not surfaces:
+        return list(DEFAULT_SEMANTIC_SURFACES)
+
+    resolved: list[str] = []
+    seen: set[str] = set()
+    for surface in surfaces:
+        token = str(surface).strip().lower().replace("-", "_")
+        aliases = _SURFACE_ALIASES.get(token)
+        if aliases is None:
+            raise ValueError(
+                "Unknown semantic surface "
+                f"{surface!r}. Valid values: {', '.join(sorted(_SURFACE_ALIASES))}"
+            )
+        for alias in aliases:
+            if alias not in seen:
+                seen.add(alias)
+                resolved.append(alias)
+    return resolved
+
+
 def prove_markdown_projection_semantics(
     projection: ConversationRenderProjection,
     markdown_text: str,
 ) -> SemanticConversationProof:
     """Compare a repository render projection to canonical markdown output."""
     input_facts = _input_facts(projection)
-    output_facts = _output_facts(markdown_text)
+    output_facts = _canonical_markdown_output_facts(markdown_text)
 
     checks = [
-        SemanticMetricCheck(
+        _critical_or_preserved(
             metric="renderable_messages",
-            status=(
-                "preserved"
-                if input_facts["renderable_messages"] == output_facts["message_sections"]
-                else "critical_loss"
-            ),
             policy="canonical markdown must preserve every renderable message section",
             input_value=input_facts["renderable_messages"],
             output_value=output_facts["message_sections"],
         ),
-        SemanticMetricCheck(
+        _critical_or_preserved(
             metric="attachment_lines",
-            status=(
-                "preserved"
-                if input_facts["attachment_count"] == output_facts["attachment_lines"]
-                else "critical_loss"
-            ),
             policy="canonical markdown must preserve attachment presence as attachment lines",
             input_value=input_facts["attachment_count"],
             output_value=output_facts["attachment_lines"],
         ),
-        SemanticMetricCheck(
+        _critical_or_preserved(
             metric="timestamp_lines",
-            status=(
-                "preserved"
-                if input_facts["timestamped_renderable_messages"] == output_facts["timestamp_lines"]
-                else "critical_loss"
-            ),
             policy="canonical markdown must preserve timestamps for renderable messages that have them",
             input_value=input_facts["timestamped_renderable_messages"],
             output_value=output_facts["timestamp_lines"],
         ),
-        SemanticMetricCheck(
+        _critical_or_preserved(
             metric="role_sections",
-            status=(
-                "preserved"
-                if input_facts["renderable_role_counts"] == output_facts["role_section_counts"]
-                else "critical_loss"
-            ),
             policy="canonical markdown must preserve renderable message role sections",
             input_value=input_facts["renderable_role_counts"],
             output_value=output_facts["role_section_counts"],
         ),
-        SemanticMetricCheck(
+        _declared_loss_or_preserved(
             metric="empty_messages",
-            status="declared_loss" if input_facts["empty_messages"] else "preserved",
             policy="canonical markdown intentionally omits messages with no text and no attachments",
             input_value=input_facts["empty_messages"],
-            output_value=0,
         ),
-        SemanticMetricCheck(
+        _declared_loss_or_preserved(
             metric="thinking_semantics",
-            status="declared_loss" if input_facts["thinking_messages"] else "preserved",
             policy="canonical markdown preserves display text but not typed thinking markers",
             input_value=input_facts["thinking_messages"],
             output_value=output_facts["typed_thinking_markers"],
         ),
-        SemanticMetricCheck(
+        _declared_loss_or_preserved(
             metric="tool_semantics",
-            status="declared_loss" if input_facts["tool_messages"] else "preserved",
             policy="canonical markdown preserves display text but not typed tool markers",
             input_value=input_facts["tool_messages"],
             output_value=output_facts["typed_tool_markers"],
@@ -418,14 +790,558 @@ def prove_markdown_projection_semantics(
     )
 
 
-async def _prove_markdown_render_semantics_async(
+def _prove_export_json_like_surface(
+    *,
+    conversation: Conversation,
+    rendered_text: str,
+    surface: str,
+) -> SemanticConversationProof:
+    try:
+        if surface == "export_yaml_v1":
+            import yaml
+
+            parsed = yaml.safe_load(rendered_text)
+        else:
+            parsed = json.loads(rendered_text)
+    except Exception:
+        parsed = {}
+    payload = parsed if isinstance(parsed, dict) else {}
+    input_facts = _conversation_input_facts(conversation)
+    output_facts = _json_like_output_facts(payload)
+    checks = [
+        _critical_or_preserved(
+            metric="conversation_id",
+            policy=f"{surface} must preserve the conversation identifier",
+            input_value=input_facts["conversation_id"],
+            output_value=output_facts["conversation_id"],
+        ),
+        _critical_or_preserved(
+            metric="provider_identity",
+            policy=f"{surface} must preserve provider identity",
+            input_value=input_facts["provider"],
+            output_value=output_facts["provider"],
+        ),
+        _critical_or_preserved(
+            metric="title_metadata",
+            policy=f"{surface} must preserve the display title",
+            input_value=input_facts["title"],
+            output_value=output_facts["title"],
+        ),
+        _critical_or_preserved(
+            metric="date_metadata",
+            policy=f"{surface} must preserve the display date value when present",
+            input_value=input_facts["date"],
+            output_value=output_facts["date"],
+        ),
+        _critical_or_preserved(
+            metric="message_entries",
+            policy=f"{surface} must preserve every message entry",
+            input_value=input_facts["total_messages"],
+            output_value=output_facts["messages"],
+        ),
+        _critical_or_preserved(
+            metric="message_ids",
+            policy=f"{surface} must preserve message identifiers",
+            input_value=input_facts["message_ids"],
+            output_value=output_facts["message_ids"],
+        ),
+        _critical_or_preserved(
+            metric="role_entries",
+            policy=f"{surface} must preserve message role distribution",
+            input_value=input_facts["text_role_counts"],
+            output_value=output_facts["role_counts"],
+        ),
+        _critical_or_preserved(
+            metric="timestamp_values",
+            policy=f"{surface} must preserve message timestamps",
+            input_value=input_facts["timestamped_text_messages"],
+            output_value=output_facts["timestamped_messages"],
+        ),
+        _declared_loss_or_preserved(
+            metric="attachment_semantics",
+            policy=f"{surface} intentionally omits attachment payload semantics",
+            input_value=input_facts["attachment_count"],
+        ),
+        _declared_loss_or_preserved(
+            metric="thinking_semantics",
+            policy=f"{surface} preserves display text but not typed thinking markers",
+            input_value=input_facts["thinking_messages"],
+        ),
+        _declared_loss_or_preserved(
+            metric="tool_semantics",
+            policy=f"{surface} preserves display text but not typed tool markers",
+            input_value=input_facts["tool_messages"],
+        ),
+        _declared_loss_or_preserved(
+            metric="branch_structure",
+            policy=f"{surface} intentionally omits explicit branch topology",
+            input_value=input_facts["branch_messages"],
+        ),
+    ]
+    return SemanticConversationProof(
+        conversation_id=input_facts["conversation_id"],
+        provider=input_facts["provider"],
+        surface=surface,
+        input_facts=input_facts,
+        output_facts=output_facts,
+        checks=checks,
+    )
+
+
+def _prove_export_csv_surface(
+    *,
+    conversation: Conversation,
+    rendered_text: str,
+) -> SemanticConversationProof:
+    input_facts = _conversation_input_facts(conversation)
+    output_facts = _csv_output_facts(rendered_text)
+    checks = [
+        _critical_or_preserved(
+            metric="conversation_id",
+            policy="export_csv_v1 must preserve the conversation identifier per row",
+            input_value=input_facts["conversation_id"],
+            output_value=output_facts["conversation_id"],
+        ),
+        _critical_or_preserved(
+            metric="text_messages",
+            policy="export_csv_v1 must preserve one row per text-bearing message",
+            input_value=input_facts["text_messages"],
+            output_value=output_facts["messages"],
+        ),
+        _critical_or_preserved(
+            metric="text_message_ids",
+            policy="export_csv_v1 must preserve identifiers for text-bearing messages",
+            input_value=input_facts["text_message_ids"],
+            output_value=output_facts["message_ids"],
+        ),
+        _critical_or_preserved(
+            metric="role_entries",
+            policy="export_csv_v1 must preserve roles for text-bearing messages",
+            input_value=input_facts["text_role_counts"],
+            output_value=output_facts["role_counts"],
+        ),
+        _critical_or_preserved(
+            metric="timestamp_values",
+            policy="export_csv_v1 must preserve timestamps for text-bearing messages",
+            input_value=input_facts["timestamped_text_messages"],
+            output_value=output_facts["timestamped_messages"],
+        ),
+        _declared_loss_or_preserved(
+            metric="provider_identity",
+            policy="export_csv_v1 intentionally omits conversation-level provider metadata",
+            input_value=1 if input_facts["provider"] else 0,
+            output_value=0,
+        ),
+        _declared_loss_or_preserved(
+            metric="title_metadata",
+            policy="export_csv_v1 intentionally omits conversation-level title metadata",
+            input_value=1 if input_facts["title"] else 0,
+            output_value=0,
+        ),
+        _declared_loss_or_preserved(
+            metric="date_metadata",
+            policy="export_csv_v1 intentionally omits conversation-level date metadata",
+            input_value=1 if input_facts["date"] else 0,
+            output_value=0,
+        ),
+        _declared_loss_or_preserved(
+            metric="attachment_semantics",
+            policy="export_csv_v1 intentionally omits attachment payload semantics",
+            input_value=input_facts["attachment_count"],
+        ),
+        _declared_loss_or_preserved(
+            metric="thinking_semantics",
+            policy="export_csv_v1 preserves display text but not typed thinking markers",
+            input_value=input_facts["thinking_messages"],
+        ),
+        _declared_loss_or_preserved(
+            metric="tool_semantics",
+            policy="export_csv_v1 preserves display text but not typed tool markers",
+            input_value=input_facts["tool_messages"],
+        ),
+        _declared_loss_or_preserved(
+            metric="branch_structure",
+            policy="export_csv_v1 intentionally omits explicit branch topology",
+            input_value=input_facts["branch_messages"],
+        ),
+    ]
+    return SemanticConversationProof(
+        conversation_id=input_facts["conversation_id"],
+        provider=input_facts["provider"],
+        surface="export_csv_v1",
+        input_facts=input_facts,
+        output_facts=output_facts,
+        checks=checks,
+    )
+
+
+def _prove_export_markdown_surface(
+    *,
+    conversation: Conversation,
+    rendered_text: str,
+) -> SemanticConversationProof:
+    input_facts = _conversation_input_facts(conversation)
+    output_facts = _markdown_doc_output_facts(rendered_text)
+    checks = [
+        _critical_or_preserved(
+            metric="title_metadata",
+            policy="export_markdown_v1 must preserve the display title",
+            input_value=input_facts["title"],
+            output_value=output_facts["title"],
+        ),
+        _critical_or_preserved(
+            metric="provider_identity",
+            policy="export_markdown_v1 must preserve provider identity at document level",
+            input_value=input_facts["provider"],
+            output_value=output_facts["provider"],
+        ),
+        _presence_check(
+            metric="date_metadata",
+            policy="export_markdown_v1 must preserve conversation date presence at document level",
+            input_value=input_facts["date"],
+            output_present=bool(output_facts["has_date"]),
+        ),
+        _critical_or_preserved(
+            metric="text_messages",
+            policy="export_markdown_v1 must preserve one section per text-bearing message",
+            input_value=input_facts["text_messages"],
+            output_value=output_facts["message_sections"],
+        ),
+        _critical_or_preserved(
+            metric="role_sections",
+            policy="export_markdown_v1 must preserve role sections for text-bearing messages",
+            input_value=input_facts["text_role_counts"],
+            output_value=output_facts["role_counts"],
+        ),
+        _declared_loss_or_preserved(
+            metric="timestamp_values",
+            policy="export_markdown_v1 intentionally omits per-message timestamps",
+            input_value=input_facts["timestamped_text_messages"],
+            output_value=output_facts["timestamp_lines"],
+        ),
+        _declared_loss_or_preserved(
+            metric="attachment_semantics",
+            policy="export_markdown_v1 intentionally omits attachment payload semantics",
+            input_value=input_facts["attachment_count"],
+        ),
+        _declared_loss_or_preserved(
+            metric="thinking_semantics",
+            policy="export_markdown_v1 preserves display text but not typed thinking markers",
+            input_value=input_facts["thinking_messages"],
+        ),
+        _declared_loss_or_preserved(
+            metric="tool_semantics",
+            policy="export_markdown_v1 preserves display text but not typed tool markers",
+            input_value=input_facts["tool_messages"],
+        ),
+        _declared_loss_or_preserved(
+            metric="branch_structure",
+            policy="export_markdown_v1 intentionally omits explicit branch topology",
+            input_value=input_facts["branch_messages"],
+            output_value=output_facts["branch_labels"],
+        ),
+    ]
+    return SemanticConversationProof(
+        conversation_id=input_facts["conversation_id"],
+        provider=input_facts["provider"],
+        surface="export_markdown_v1",
+        input_facts=input_facts,
+        output_facts=output_facts,
+        checks=checks,
+    )
+
+
+def _prove_export_obsidian_surface(
+    *,
+    conversation: Conversation,
+    rendered_text: str,
+) -> SemanticConversationProof:
+    input_facts = _conversation_input_facts(conversation)
+    output_facts = _obsidian_output_facts(rendered_text)
+    checks = [
+        _critical_or_preserved(
+            metric="conversation_id",
+            policy="export_obsidian_v1 must preserve conversation identity in frontmatter",
+            input_value=input_facts["conversation_id"],
+            output_value=output_facts["conversation_id"],
+        ),
+        _critical_or_preserved(
+            metric="title_metadata",
+            policy="export_obsidian_v1 must preserve the display title",
+            input_value=input_facts["title"],
+            output_value=output_facts["title"],
+        ),
+        _critical_or_preserved(
+            metric="provider_identity",
+            policy="export_obsidian_v1 must preserve provider identity in frontmatter",
+            input_value=input_facts["provider"],
+            output_value=output_facts["provider"],
+        ),
+        _presence_check(
+            metric="date_metadata",
+            policy="export_obsidian_v1 must preserve conversation date presence in frontmatter",
+            input_value=input_facts["date"],
+            output_present=bool(output_facts["has_date"]),
+        ),
+        _critical_or_preserved(
+            metric="text_messages",
+            policy="export_obsidian_v1 must preserve one section per text-bearing message",
+            input_value=input_facts["text_messages"],
+            output_value=output_facts["message_sections"],
+        ),
+        _critical_or_preserved(
+            metric="role_sections",
+            policy="export_obsidian_v1 must preserve role sections for text-bearing messages",
+            input_value=input_facts["text_role_counts"],
+            output_value=output_facts["role_counts"],
+        ),
+        _declared_loss_or_preserved(
+            metric="timestamp_values",
+            policy="export_obsidian_v1 intentionally omits per-message timestamps",
+            input_value=input_facts["timestamped_text_messages"],
+            output_value=output_facts["timestamp_lines"],
+        ),
+        _declared_loss_or_preserved(
+            metric="attachment_semantics",
+            policy="export_obsidian_v1 intentionally omits attachment payload semantics",
+            input_value=input_facts["attachment_count"],
+        ),
+        _declared_loss_or_preserved(
+            metric="thinking_semantics",
+            policy="export_obsidian_v1 preserves display text but not typed thinking markers",
+            input_value=input_facts["thinking_messages"],
+        ),
+        _declared_loss_or_preserved(
+            metric="tool_semantics",
+            policy="export_obsidian_v1 preserves display text but not typed tool markers",
+            input_value=input_facts["tool_messages"],
+        ),
+        _declared_loss_or_preserved(
+            metric="branch_structure",
+            policy="export_obsidian_v1 intentionally omits explicit branch topology",
+            input_value=input_facts["branch_messages"],
+            output_value=output_facts["branch_labels"],
+        ),
+    ]
+    return SemanticConversationProof(
+        conversation_id=input_facts["conversation_id"],
+        provider=input_facts["provider"],
+        surface="export_obsidian_v1",
+        input_facts=input_facts,
+        output_facts=output_facts,
+        checks=checks,
+    )
+
+
+def _prove_export_org_surface(
+    *,
+    conversation: Conversation,
+    rendered_text: str,
+) -> SemanticConversationProof:
+    input_facts = _conversation_input_facts(conversation)
+    output_facts = _org_output_facts(rendered_text)
+    checks = [
+        _critical_or_preserved(
+            metric="title_metadata",
+            policy="export_org_v1 must preserve the display title",
+            input_value=input_facts["title"],
+            output_value=output_facts["title"],
+        ),
+        _critical_or_preserved(
+            metric="provider_identity",
+            policy="export_org_v1 must preserve provider identity at document level",
+            input_value=input_facts["provider"],
+            output_value=output_facts["provider"],
+        ),
+        _presence_check(
+            metric="date_metadata",
+            policy="export_org_v1 must preserve conversation date presence at document level",
+            input_value=input_facts["date"],
+            output_present=bool(output_facts["has_date"]),
+        ),
+        _critical_or_preserved(
+            metric="text_messages",
+            policy="export_org_v1 must preserve one heading per text-bearing message",
+            input_value=input_facts["text_messages"],
+            output_value=output_facts["message_sections"],
+        ),
+        _critical_or_preserved(
+            metric="role_sections",
+            policy="export_org_v1 must preserve role headings for text-bearing messages",
+            input_value=input_facts["text_role_counts"],
+            output_value=output_facts["role_counts"],
+        ),
+        _declared_loss_or_preserved(
+            metric="timestamp_values",
+            policy="export_org_v1 intentionally omits per-message timestamps",
+            input_value=input_facts["timestamped_text_messages"],
+            output_value=output_facts["timestamp_lines"],
+        ),
+        _declared_loss_or_preserved(
+            metric="attachment_semantics",
+            policy="export_org_v1 intentionally omits attachment payload semantics",
+            input_value=input_facts["attachment_count"],
+        ),
+        _declared_loss_or_preserved(
+            metric="thinking_semantics",
+            policy="export_org_v1 preserves display text but not typed thinking markers",
+            input_value=input_facts["thinking_messages"],
+        ),
+        _declared_loss_or_preserved(
+            metric="tool_semantics",
+            policy="export_org_v1 preserves display text but not typed tool markers",
+            input_value=input_facts["tool_messages"],
+        ),
+        _declared_loss_or_preserved(
+            metric="branch_structure",
+            policy="export_org_v1 intentionally omits explicit branch topology",
+            input_value=input_facts["branch_messages"],
+            output_value=output_facts["branch_labels"],
+        ),
+    ]
+    return SemanticConversationProof(
+        conversation_id=input_facts["conversation_id"],
+        provider=input_facts["provider"],
+        surface="export_org_v1",
+        input_facts=input_facts,
+        output_facts=output_facts,
+        checks=checks,
+    )
+
+
+def _prove_export_html_surface(
+    *,
+    conversation: Conversation,
+    rendered_text: str,
+) -> SemanticConversationProof:
+    input_facts = _conversation_input_facts(conversation)
+    output_facts = _html_output_facts(rendered_text)
+    checks = [
+        _critical_or_preserved(
+            metric="title_metadata",
+            policy="export_html_v1 must preserve the display title",
+            input_value=input_facts["title"],
+            output_value=output_facts["title"],
+        ),
+        _critical_or_preserved(
+            metric="provider_identity",
+            policy="export_html_v1 must preserve provider identity at document level",
+            input_value=input_facts["provider"],
+            output_value=output_facts["provider"],
+        ),
+        _presence_check(
+            metric="date_metadata",
+            policy="export_html_v1 must preserve conversation date presence at document level",
+            input_value=input_facts["date"],
+            output_present=bool(output_facts["has_date"]),
+        ),
+        _critical_or_preserved(
+            metric="text_messages",
+            policy="export_html_v1 must preserve visible message sections for text-bearing messages",
+            input_value=input_facts["text_messages"],
+            output_value=output_facts["message_sections"],
+        ),
+        _critical_or_preserved(
+            metric="role_sections",
+            policy="export_html_v1 must preserve visible role labels for text-bearing messages",
+            input_value=input_facts["text_role_counts"],
+            output_value=output_facts["role_counts"],
+        ),
+        _critical_or_preserved(
+            metric="timestamp_values",
+            policy="export_html_v1 must preserve visible message timestamps",
+            input_value=input_facts["timestamped_text_messages"],
+            output_value=output_facts["timestamp_lines"],
+        ),
+        _critical_or_preserved(
+            metric="branch_structure",
+            policy="export_html_v1 must preserve visible branch groupings for branched messages",
+            input_value=input_facts["branch_messages"],
+            output_value=output_facts["branch_labels"],
+        ),
+        _declared_loss_or_preserved(
+            metric="attachment_semantics",
+            policy="export_html_v1 intentionally omits attachment payload semantics",
+            input_value=input_facts["attachment_count"],
+        ),
+        _declared_loss_or_preserved(
+            metric="thinking_semantics",
+            policy="export_html_v1 preserves display text but not typed thinking markers",
+            input_value=input_facts["thinking_messages"],
+        ),
+        _declared_loss_or_preserved(
+            metric="tool_semantics",
+            policy="export_html_v1 preserves display text but not typed tool markers",
+            input_value=input_facts["tool_messages"],
+        ),
+    ]
+    return SemanticConversationProof(
+        conversation_id=input_facts["conversation_id"],
+        provider=input_facts["provider"],
+        surface="export_html_v1",
+        input_facts=input_facts,
+        output_facts=output_facts,
+        checks=checks,
+    )
+
+
+def prove_export_surface_semantics(
+    conversation: Conversation,
+    surface: str,
+    rendered_text: str,
+) -> SemanticConversationProof:
+    """Compare a conversation export surface to the canonical conversation semantics."""
+    if surface == "export_json_v1":
+        return _prove_export_json_like_surface(
+            conversation=conversation,
+            rendered_text=rendered_text,
+            surface=surface,
+        )
+    if surface == "export_yaml_v1":
+        return _prove_export_json_like_surface(
+            conversation=conversation,
+            rendered_text=rendered_text,
+            surface=surface,
+        )
+    if surface == "export_csv_v1":
+        return _prove_export_csv_surface(conversation=conversation, rendered_text=rendered_text)
+    if surface == "export_markdown_v1":
+        return _prove_export_markdown_surface(conversation=conversation, rendered_text=rendered_text)
+    if surface == "export_obsidian_v1":
+        return _prove_export_obsidian_surface(conversation=conversation, rendered_text=rendered_text)
+    if surface == "export_org_v1":
+        return _prove_export_org_surface(conversation=conversation, rendered_text=rendered_text)
+    if surface == "export_html_v1":
+        return _prove_export_html_surface(conversation=conversation, rendered_text=rendered_text)
+    raise ValueError(f"Unsupported semantic surface: {surface}")
+
+
+def _empty_surface_report(
+    surface: str,
+    *,
+    record_limit: int | None,
+    record_offset: int,
+    provider_filters: list[str],
+) -> SemanticProofReport:
+    return SemanticProofReport(
+        surface=surface,
+        conversations=[],
+        provider_reports={},
+        record_limit=record_limit,
+        record_offset=record_offset,
+        provider_filters=provider_filters,
+    )
+
+
+async def _prove_semantic_surface_suite_async(
     *,
     db_path: Path,
     archive_root: Path,
     providers: list[str] | None,
+    surfaces: list[str],
     record_limit: int | None,
     record_offset: int,
-) -> SemanticProofReport:
+) -> SemanticProofSuiteReport:
     backend = SQLiteBackend(db_path=db_path)
     repository = ConversationRepository(backend=backend)
     formatter = ConversationFormatter(archive_root=archive_root, db_path=db_path, backend=backend)
@@ -435,23 +1351,97 @@ async def _prove_markdown_render_semantics_async(
             offset=record_offset,
             providers=providers,
         )
-        proofs: list[SemanticConversationProof] = []
+        proofs_by_surface: dict[str, list[SemanticConversationProof]] = {surface: [] for surface in surfaces}
+        need_export_surfaces = any(surface != "canonical_markdown_v1" for surface in surfaces)
+
         for summary in summaries:
-            projection = await repository.get_render_projection(str(summary.id))
-            if projection is None:
-                continue
-            formatted = formatter.format_projection(projection)
-            proofs.append(prove_markdown_projection_semantics(projection, formatted.markdown_text))
-        return SemanticProofReport(
-            surface="canonical_markdown_v1",
-            conversations=proofs,
-            provider_reports=_build_provider_reports(proofs),
+            conversation_id = str(summary.id)
+            conversation = await repository.view(conversation_id) if need_export_surfaces else None
+            projection = None
+            for surface in surfaces:
+                if surface == "canonical_markdown_v1":
+                    if projection is None:
+                        projection = await repository.get_render_projection(conversation_id)
+                    if projection is None:
+                        continue
+                    formatted = formatter.format_projection(projection)
+                    proofs_by_surface[surface].append(
+                        prove_markdown_projection_semantics(projection, formatted.markdown_text)
+                    )
+                    continue
+
+                if conversation is None:
+                    continue
+                rendered_text = format_conversation(conversation, _EXPORT_SURFACE_FORMATS[surface], None)
+                proofs_by_surface[surface].append(
+                    prove_export_surface_semantics(conversation, surface, rendered_text)
+                )
+
+        provider_filters = list(providers or [])
+        return SemanticProofSuiteReport(
+            surface_reports={
+                surface: SemanticProofReport(
+                    surface=surface,
+                    conversations=proofs_by_surface[surface],
+                    provider_reports=_build_provider_reports(proofs_by_surface[surface]),
+                    record_limit=record_limit,
+                    record_offset=record_offset,
+                    provider_filters=provider_filters,
+                )
+                for surface in surfaces
+            },
             record_limit=record_limit,
             record_offset=record_offset,
-            provider_filters=list(providers or []),
+            provider_filters=provider_filters,
+            surface_filters=list(surfaces),
         )
     finally:
         await backend.close()
+
+
+def prove_semantic_surface_suite(
+    *,
+    db_path: Path | None = None,
+    archive_root: Path | None = None,
+    providers: list[str] | None = None,
+    surfaces: list[str] | tuple[str, ...] | None = None,
+    record_limit: int | None = None,
+    record_offset: int = 0,
+) -> SemanticProofSuiteReport:
+    """Run semantic preservation proof across canonical render and export surfaces."""
+    effective_db_path = db_path or default_db_path()
+    bounded_limit = max(1, int(record_limit)) if record_limit is not None else None
+    bounded_offset = max(0, int(record_offset))
+    resolved_surfaces = resolve_semantic_surfaces(surfaces)
+    provider_filters = list(providers or [])
+
+    if not effective_db_path.exists():
+        return SemanticProofSuiteReport(
+            surface_reports={
+                surface: _empty_surface_report(
+                    surface,
+                    record_limit=bounded_limit,
+                    record_offset=bounded_offset,
+                    provider_filters=provider_filters,
+                )
+                for surface in resolved_surfaces
+            },
+            record_limit=bounded_limit,
+            record_offset=bounded_offset,
+            provider_filters=provider_filters,
+            surface_filters=list(resolved_surfaces),
+        )
+
+    return asyncio.run(
+        _prove_semantic_surface_suite_async(
+            db_path=effective_db_path,
+            archive_root=archive_root or default_archive_root(),
+            providers=providers,
+            surfaces=resolved_surfaces,
+            record_limit=bounded_limit,
+            record_offset=bounded_offset,
+        )
+    )
 
 
 def prove_markdown_render_semantics(
@@ -463,34 +1453,27 @@ def prove_markdown_render_semantics(
     record_offset: int = 0,
 ) -> SemanticProofReport:
     """Run semantic preservation proof over canonical markdown rendering."""
-    effective_db_path = db_path or default_db_path()
-    bounded_limit = max(1, int(record_limit)) if record_limit is not None else None
-    bounded_offset = max(0, int(record_offset))
-    if not effective_db_path.exists():
-        return SemanticProofReport(
-            surface="canonical_markdown_v1",
-            conversations=[],
-            provider_reports={},
-            record_limit=bounded_limit,
-            record_offset=bounded_offset,
-            provider_filters=list(providers or []),
-        )
-    return asyncio.run(
-        _prove_markdown_render_semantics_async(
-            db_path=effective_db_path,
-            archive_root=archive_root or default_archive_root(),
-            providers=providers,
-            record_limit=bounded_limit,
-            record_offset=bounded_offset,
-        )
+    suite = prove_semantic_surface_suite(
+        db_path=db_path,
+        archive_root=archive_root,
+        providers=providers,
+        surfaces=["canonical_markdown_v1"],
+        record_limit=record_limit,
+        record_offset=record_offset,
     )
+    return suite.surfaces["canonical_markdown_v1"]
 
 
 __all__ = [
+    "DEFAULT_SEMANTIC_SURFACES",
     "ProviderSemanticProof",
     "SemanticConversationProof",
     "SemanticMetricCheck",
     "SemanticProofReport",
+    "SemanticProofSuiteReport",
+    "prove_export_surface_semantics",
     "prove_markdown_projection_semantics",
     "prove_markdown_render_semantics",
+    "prove_semantic_surface_suite",
+    "resolve_semantic_surfaces",
 ]

--- a/polylogue/rendering/semantic_proof.py
+++ b/polylogue/rendering/semantic_proof.py
@@ -1,4 +1,4 @@
-"""Semantic preservation proofing for canonical render and export surfaces."""
+"""Semantic preservation proofing for render, export, query, stream, and MCP surfaces."""
 
 from __future__ import annotations
 
@@ -13,7 +13,14 @@ from html import unescape as html_unescape
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from polylogue.cli.query_output import format_summary_list, render_stream_transcript
+from polylogue.lib.models import ConversationSummary
 from polylogue.lib.roles import Role
+from polylogue.mcp.payloads import (
+    MCPConversationDetailPayload,
+    MCPConversationSummaryListPayload,
+    MCPConversationSummaryPayload,
+)
 from polylogue.paths import archive_root as default_archive_root
 from polylogue.paths import db_path as default_db_path
 from polylogue.rendering.core import ConversationFormatter
@@ -35,6 +42,15 @@ DEFAULT_SEMANTIC_SURFACES: tuple[str, ...] = (
     "export_html_v1",
     "export_obsidian_v1",
     "export_org_v1",
+    "query_summary_json_v1",
+    "query_summary_yaml_v1",
+    "query_summary_csv_v1",
+    "query_summary_text_v1",
+    "query_stream_plaintext_v1",
+    "query_stream_markdown_v1",
+    "query_stream_json_lines_v1",
+    "mcp_summary_json_v1",
+    "mcp_detail_json_v1",
 )
 
 _SURFACE_ALIASES: dict[str, tuple[str, ...]] = {
@@ -49,7 +65,56 @@ _SURFACE_ALIASES: dict[str, tuple[str, ...]] = {
     "html": ("export_html_v1",),
     "obsidian": ("export_obsidian_v1",),
     "org": ("export_org_v1",),
-    "export_all": tuple(surface for surface in DEFAULT_SEMANTIC_SURFACES if surface != "canonical_markdown_v1"),
+    "query_summary_json": ("query_summary_json_v1",),
+    "query_summary_yaml": ("query_summary_yaml_v1",),
+    "query_summary_csv": ("query_summary_csv_v1",),
+    "query_summary_text": ("query_summary_text_v1",),
+    "query_summary_all": (
+        "query_summary_json_v1",
+        "query_summary_yaml_v1",
+        "query_summary_csv_v1",
+        "query_summary_text_v1",
+    ),
+    "stream_plaintext": ("query_stream_plaintext_v1",),
+    "stream_markdown": ("query_stream_markdown_v1",),
+    "stream_json_lines": ("query_stream_json_lines_v1",),
+    "stream_all": (
+        "query_stream_plaintext_v1",
+        "query_stream_markdown_v1",
+        "query_stream_json_lines_v1",
+    ),
+    "query_all": (
+        "query_summary_json_v1",
+        "query_summary_yaml_v1",
+        "query_summary_csv_v1",
+        "query_summary_text_v1",
+        "query_stream_plaintext_v1",
+        "query_stream_markdown_v1",
+        "query_stream_json_lines_v1",
+    ),
+    "mcp_summary": ("mcp_summary_json_v1",),
+    "mcp_detail": ("mcp_detail_json_v1",),
+    "mcp_all": ("mcp_summary_json_v1", "mcp_detail_json_v1"),
+    "read_all": (
+        "query_summary_json_v1",
+        "query_summary_yaml_v1",
+        "query_summary_csv_v1",
+        "query_summary_text_v1",
+        "query_stream_plaintext_v1",
+        "query_stream_markdown_v1",
+        "query_stream_json_lines_v1",
+        "mcp_summary_json_v1",
+        "mcp_detail_json_v1",
+    ),
+    "export_all": (
+        "export_json_v1",
+        "export_yaml_v1",
+        "export_csv_v1",
+        "export_markdown_v1",
+        "export_html_v1",
+        "export_obsidian_v1",
+        "export_org_v1",
+    ),
 }
 
 _EXPORT_SURFACE_FORMATS: dict[str, str] = {
@@ -233,6 +298,252 @@ def _conversation_input_facts(conversation: Conversation) -> dict[str, Any]:
         "thinking_messages": thinking_messages,
         "tool_messages": tool_messages,
         "branch_messages": branch_messages,
+    }
+
+
+def _summary_input_facts(summary: ConversationSummary, message_count: int) -> dict[str, Any]:
+    return {
+        "conversation_id": str(summary.id),
+        "provider": str(summary.provider),
+        "title": summary.display_title,
+        "date": summary.display_date.isoformat() if summary.display_date else None,
+        "messages": message_count,
+        "tags": list(summary.tags),
+        "summary": summary.summary,
+    }
+
+
+def _summary_output_facts(payload: dict[str, Any]) -> dict[str, Any]:
+    tags = payload.get("tags")
+    if not isinstance(tags, list):
+        tags = []
+    return {
+        "conversation_id": str(payload.get("id") or ""),
+        "provider": str(payload.get("provider") or ""),
+        "title": payload.get("title"),
+        "date": payload.get("date"),
+        "messages": int(payload.get("messages") or 0),
+        "tags": [str(tag) for tag in tags],
+        "summary": payload.get("summary"),
+    }
+
+
+def _summary_csv_output_facts(csv_text: str) -> list[dict[str, Any]]:
+    reader = csv.DictReader(io.StringIO(csv_text))
+    rows: list[dict[str, Any]] = []
+    for row in reader:
+        tags_text = str(row.get("tags") or "")
+        rows.append(
+            {
+                "conversation_id": str(row.get("id") or ""),
+                "provider": str(row.get("provider") or ""),
+                "title": row.get("title"),
+                "date": row.get("date") or None,
+                "messages": int(row.get("messages") or 0),
+                "tags": [tag for tag in tags_text.split(",") if tag],
+                "summary": row.get("summary") or None,
+            }
+        )
+    return rows
+
+
+_SUMMARY_TEXT_RE = re.compile(
+    r"^(?P<id>.{1,24})\s{2,}(?P<date>\S*)\s{2,}(?P<provider>\S+)\s{2,}(?P<title>.*) \((?P<messages>\d+) msgs\)$"
+)
+
+
+def _summary_text_output_facts(text: str) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for line in text.splitlines():
+        match = _SUMMARY_TEXT_RE.match(line.rstrip())
+        if match is None:
+            continue
+        rows.append(
+            {
+                "conversation_id_prefix": match.group("id").strip(),
+                "provider": match.group("provider").strip(),
+                "date": match.group("date").strip() or None,
+                "title": match.group("title").strip(),
+                "messages": int(match.group("messages")),
+            }
+        )
+    return rows
+
+
+def _stream_input_facts(
+    conversation: Conversation,
+    *,
+    dialogue_only: bool = False,
+    message_limit: int | None = None,
+) -> dict[str, Any]:
+    filtered_messages = [
+        message
+        for message in conversation.messages
+        if (not dialogue_only or message.is_dialogue)
+    ]
+    if message_limit is not None:
+        filtered_messages = filtered_messages[:message_limit]
+
+    visible_messages = [message for message in filtered_messages if _is_text_message(message)]
+    role_counts: Counter[str] = Counter(_normalized_role_label(message.role) for message in visible_messages)
+    timestamped_messages = sum(1 for message in visible_messages if message.timestamp is not None)
+
+    return {
+        "conversation_id": str(conversation.id),
+        "provider": str(conversation.provider),
+        "title": conversation.display_title,
+        "date": conversation.display_date.isoformat() if conversation.display_date else None,
+        "text_messages": len(visible_messages),
+        "text_message_ids": [str(message.id) for message in visible_messages],
+        "text_role_counts": _sorted_counts(dict(role_counts)),
+        "timestamped_text_messages": timestamped_messages,
+        "attachment_count": sum(len(message.attachments) for message in filtered_messages),
+        "thinking_messages": sum(1 for message in filtered_messages if message.is_thinking),
+        "tool_messages": sum(1 for message in filtered_messages if message.is_tool_use),
+        "branch_messages": sum(1 for message in filtered_messages if message.branch_index > 0),
+        "dialogue_only": dialogue_only,
+        "message_limit": message_limit,
+    }
+
+
+def _stream_markdown_output_facts(text: str) -> dict[str, Any]:
+    title: str | None = None
+    provider: str | None = None
+    has_date = False
+    message_sections = 0
+    role_counts: Counter[str] = Counter()
+    for line in text.splitlines():
+        if title is None and line.startswith("# "):
+            title = line[2:].strip()
+        elif line.startswith("**Provider**: "):
+            provider = line.split(": ", 1)[1].strip()
+        elif line.startswith("**Date**: "):
+            has_date = True
+        elif line.startswith("## "):
+            role = line[3:].strip()
+            message_sections += 1
+            role_counts[_normalized_role_label(role)] += 1
+    footer_match = re.search(r"_Streamed (\d+) messages_", text)
+    return {
+        "title": title,
+        "provider": provider,
+        "has_date": has_date,
+        "message_sections": message_sections,
+        "role_counts": _sorted_counts(dict(role_counts)),
+        "footer_count": int(footer_match.group(1)) if footer_match else 0,
+    }
+
+
+def _stream_plaintext_output_facts(text: str) -> dict[str, Any]:
+    role_counts: Counter[str] = Counter()
+    message_sections = 0
+    for line in text.splitlines():
+        if line.startswith("[") and line.endswith("]"):
+            role = line[1:-1].strip()
+            message_sections += 1
+            role_counts[_normalized_role_label(role)] += 1
+    return {
+        "message_sections": message_sections,
+        "role_counts": _sorted_counts(dict(role_counts)),
+        "title": None,
+        "provider": None,
+        "has_date": False,
+    }
+
+
+def _stream_json_lines_output_facts(text: str) -> dict[str, Any]:
+    header: dict[str, Any] = {}
+    footer: dict[str, Any] = {}
+    message_ids: list[str] = []
+    role_counts: Counter[str] = Counter()
+    timestamped_messages = 0
+
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        try:
+            payload = json.loads(stripped)
+        except json.JSONDecodeError:
+            continue
+        record_type = payload.get("type")
+        if record_type == "header":
+            header = payload
+        elif record_type == "footer":
+            footer = payload
+        elif record_type == "message":
+            message_ids.append(str(payload.get("id") or ""))
+            role_counts[_normalized_role_label(payload.get("role"))] += 1
+            if payload.get("timestamp"):
+                timestamped_messages += 1
+
+    return {
+        "conversation_id": str(header.get("conversation_id") or ""),
+        "title": header.get("title"),
+        "provider": str(header.get("provider") or ""),
+        "date": header.get("date"),
+        "message_ids": message_ids,
+        "message_sections": len(message_ids),
+        "role_counts": _sorted_counts(dict(role_counts)),
+        "timestamped_messages": timestamped_messages,
+        "footer_count": int(footer.get("message_count") or 0),
+    }
+
+
+def _mcp_summary_output_facts(payload: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "conversation_id": str(payload.get("id") or ""),
+        "provider": str(payload.get("provider") or ""),
+        "title": payload.get("title"),
+        "messages": int(payload.get("message_count") or 0),
+        "created_at": payload.get("created_at"),
+        "updated_at": payload.get("updated_at"),
+    }
+
+
+def _mcp_detail_input_facts(conversation: Conversation) -> dict[str, Any]:
+    input_facts = _conversation_input_facts(conversation)
+    return {
+        "conversation_id": input_facts["conversation_id"],
+        "provider": input_facts["provider"],
+        "title": input_facts["title"],
+        "created_at": conversation.created_at.isoformat() if conversation.created_at else None,
+        "updated_at": conversation.updated_at.isoformat() if conversation.updated_at else None,
+        "messages": input_facts["total_messages"],
+        "message_ids": input_facts["message_ids"],
+        "role_counts": input_facts["text_role_counts"],
+        "timestamped_messages": input_facts["timestamped_text_messages"],
+        "attachment_count": input_facts["attachment_count"],
+        "thinking_messages": input_facts["thinking_messages"],
+        "tool_messages": input_facts["tool_messages"],
+        "branch_messages": input_facts["branch_messages"],
+    }
+
+
+def _mcp_detail_output_facts(payload: dict[str, Any]) -> dict[str, Any]:
+    messages = payload.get("messages")
+    if not isinstance(messages, list):
+        messages = []
+    role_counts: Counter[str] = Counter()
+    message_ids: list[str] = []
+    timestamped_messages = 0
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        message_ids.append(str(message.get("id") or ""))
+        role_counts[_normalized_role_label(message.get("role"))] += 1
+        if message.get("timestamp"):
+            timestamped_messages += 1
+    return {
+        "conversation_id": str(payload.get("id") or ""),
+        "provider": str(payload.get("provider") or ""),
+        "title": payload.get("title"),
+        "created_at": payload.get("created_at"),
+        "updated_at": payload.get("updated_at"),
+        "messages": len(message_ids),
+        "message_ids": message_ids,
+        "role_counts": _sorted_counts(dict(role_counts)),
+        "timestamped_messages": timestamped_messages,
     }
 
 
@@ -1316,6 +1627,639 @@ def prove_export_surface_semantics(
     raise ValueError(f"Unsupported semantic surface: {surface}")
 
 
+def _summary_record_from_conversation(conversation: Conversation) -> ConversationSummary:
+    return ConversationSummary(
+        id=conversation.id,
+        provider=conversation.provider,
+        title=conversation.title,
+        created_at=conversation.created_at,
+        updated_at=conversation.updated_at,
+        provider_meta=conversation.provider_meta,
+        metadata=conversation.metadata,
+        parent_id=conversation.parent_id,
+        branch_type=conversation.branch_type,
+        message_count=len(conversation.messages),
+    )
+
+
+def _prove_query_summary_json_like_surface(
+    *,
+    summary: ConversationSummary,
+    message_count: int,
+    rendered_text: str,
+    surface: str,
+) -> SemanticConversationProof:
+    try:
+        if surface == "query_summary_yaml_v1":
+            import yaml
+
+            parsed = yaml.safe_load(rendered_text)
+        else:
+            parsed = json.loads(rendered_text)
+    except Exception:
+        parsed = []
+
+    row = parsed[0] if isinstance(parsed, list) and parsed else {}
+    payload = row if isinstance(row, dict) else {}
+    input_facts = _summary_input_facts(summary, message_count)
+    output_facts = _summary_output_facts(payload)
+    checks = [
+        _critical_or_preserved(
+            metric="conversation_id",
+            policy=f"{surface} must preserve the conversation identifier",
+            input_value=input_facts["conversation_id"],
+            output_value=output_facts["conversation_id"],
+        ),
+        _critical_or_preserved(
+            metric="provider_identity",
+            policy=f"{surface} must preserve provider identity",
+            input_value=input_facts["provider"],
+            output_value=output_facts["provider"],
+        ),
+        _critical_or_preserved(
+            metric="title_metadata",
+            policy=f"{surface} must preserve the display title",
+            input_value=input_facts["title"],
+            output_value=output_facts["title"],
+        ),
+        _critical_or_preserved(
+            metric="date_metadata",
+            policy=f"{surface} must preserve the summary display date",
+            input_value=input_facts["date"],
+            output_value=output_facts["date"],
+        ),
+        _critical_or_preserved(
+            metric="message_count",
+            policy=f"{surface} must preserve summary message counts",
+            input_value=input_facts["messages"],
+            output_value=output_facts["messages"],
+        ),
+        _critical_or_preserved(
+            metric="tag_values",
+            policy=f"{surface} must preserve summary tag values",
+            input_value=input_facts["tags"],
+            output_value=output_facts["tags"],
+        ),
+        _critical_or_preserved(
+            metric="summary_text",
+            policy=f"{surface} must preserve summary text",
+            input_value=input_facts["summary"],
+            output_value=output_facts["summary"],
+        ),
+    ]
+    return SemanticConversationProof(
+        conversation_id=input_facts["conversation_id"],
+        provider=input_facts["provider"],
+        surface=surface,
+        input_facts=input_facts,
+        output_facts=output_facts,
+        checks=checks,
+    )
+
+
+def _prove_query_summary_csv_surface(
+    *,
+    summary: ConversationSummary,
+    message_count: int,
+    rendered_text: str,
+) -> SemanticConversationProof:
+    rows = _summary_csv_output_facts(rendered_text)
+    output_facts = rows[0] if rows else {}
+    input_facts = _summary_input_facts(summary, message_count)
+    checks = [
+        _critical_or_preserved(
+            metric="conversation_id",
+            policy="query_summary_csv_v1 must preserve the conversation identifier",
+            input_value=input_facts["conversation_id"],
+            output_value=output_facts.get("conversation_id", ""),
+        ),
+        _critical_or_preserved(
+            metric="provider_identity",
+            policy="query_summary_csv_v1 must preserve provider identity",
+            input_value=input_facts["provider"],
+            output_value=output_facts.get("provider", ""),
+        ),
+        _critical_or_preserved(
+            metric="title_metadata",
+            policy="query_summary_csv_v1 must preserve the display title",
+            input_value=input_facts["title"],
+            output_value=output_facts.get("title"),
+        ),
+        _critical_or_preserved(
+            metric="date_metadata",
+            policy="query_summary_csv_v1 must preserve the summary display date",
+            input_value=input_facts["date"][:10] if input_facts["date"] else None,
+            output_value=output_facts.get("date"),
+        ),
+        _critical_or_preserved(
+            metric="message_count",
+            policy="query_summary_csv_v1 must preserve summary message counts",
+            input_value=input_facts["messages"],
+            output_value=output_facts.get("messages", 0),
+        ),
+        _critical_or_preserved(
+            metric="tag_values",
+            policy="query_summary_csv_v1 must preserve summary tag values",
+            input_value=input_facts["tags"],
+            output_value=output_facts.get("tags", []),
+        ),
+        _critical_or_preserved(
+            metric="summary_text",
+            policy="query_summary_csv_v1 must preserve summary text",
+            input_value=input_facts["summary"],
+            output_value=output_facts.get("summary"),
+        ),
+    ]
+    return SemanticConversationProof(
+        conversation_id=input_facts["conversation_id"],
+        provider=input_facts["provider"],
+        surface="query_summary_csv_v1",
+        input_facts=input_facts,
+        output_facts=output_facts,
+        checks=checks,
+    )
+
+
+def _prove_query_summary_text_surface(
+    *,
+    summary: ConversationSummary,
+    message_count: int,
+    rendered_text: str,
+) -> SemanticConversationProof:
+    rows = _summary_text_output_facts(rendered_text)
+    output_facts = rows[0] if rows else {}
+    input_facts = _summary_input_facts(summary, message_count)
+    raw_title = input_facts["title"] or input_facts["conversation_id"][:20]
+    expected_title = (raw_title[:47] + "...") if len(raw_title) > 50 else raw_title
+    checks = [
+        _critical_or_preserved(
+            metric="conversation_id_prefix",
+            policy="query_summary_text_v1 must preserve the visible conversation id prefix",
+            input_value=input_facts["conversation_id"][:24],
+            output_value=output_facts.get("conversation_id_prefix", ""),
+        ),
+        _critical_or_preserved(
+            metric="provider_identity",
+            policy="query_summary_text_v1 must preserve provider identity",
+            input_value=input_facts["provider"],
+            output_value=output_facts.get("provider", ""),
+        ),
+        _critical_or_preserved(
+            metric="date_metadata",
+            policy="query_summary_text_v1 must preserve the visible summary date",
+            input_value=input_facts["date"][:10] if input_facts["date"] else None,
+            output_value=output_facts.get("date"),
+        ),
+        _critical_or_preserved(
+            metric="title_projection",
+            policy="query_summary_text_v1 must preserve the deterministic visible title projection",
+            input_value=expected_title,
+            output_value=output_facts.get("title", ""),
+        ),
+        _critical_or_preserved(
+            metric="message_count",
+            policy="query_summary_text_v1 must preserve summary message counts",
+            input_value=input_facts["messages"],
+            output_value=output_facts.get("messages", 0),
+        ),
+        _declared_loss_or_preserved(
+            metric="tag_values",
+            policy="query_summary_text_v1 intentionally omits tag values",
+            input_value=len(input_facts["tags"]),
+        ),
+        _declared_loss_or_preserved(
+            metric="summary_text",
+            policy="query_summary_text_v1 intentionally omits summary text",
+            input_value=1 if input_facts["summary"] else 0,
+        ),
+    ]
+    return SemanticConversationProof(
+        conversation_id=input_facts["conversation_id"],
+        provider=input_facts["provider"],
+        surface="query_summary_text_v1",
+        input_facts=input_facts,
+        output_facts=output_facts,
+        checks=checks,
+    )
+
+
+def _prove_query_stream_plaintext_surface(
+    *,
+    conversation: Conversation,
+    rendered_text: str,
+) -> SemanticConversationProof:
+    input_facts = _stream_input_facts(conversation)
+    output_facts = _stream_plaintext_output_facts(rendered_text)
+    checks = [
+        _critical_or_preserved(
+            metric="text_messages",
+            policy="query_stream_plaintext_v1 must preserve one visible block per text-bearing message",
+            input_value=input_facts["text_messages"],
+            output_value=output_facts["message_sections"],
+        ),
+        _critical_or_preserved(
+            metric="role_sections",
+            policy="query_stream_plaintext_v1 must preserve visible role labels for streamed messages",
+            input_value=input_facts["text_role_counts"],
+            output_value=output_facts["role_counts"],
+        ),
+        _declared_loss_or_preserved(
+            metric="title_metadata",
+            policy="query_stream_plaintext_v1 intentionally omits title metadata",
+            input_value=1 if input_facts["title"] else 0,
+        ),
+        _declared_loss_or_preserved(
+            metric="provider_identity",
+            policy="query_stream_plaintext_v1 intentionally omits provider metadata",
+            input_value=1 if input_facts["provider"] else 0,
+        ),
+        _declared_loss_or_preserved(
+            metric="date_metadata",
+            policy="query_stream_plaintext_v1 intentionally omits date metadata",
+            input_value=1 if input_facts["date"] else 0,
+        ),
+        _declared_loss_or_preserved(
+            metric="timestamp_values",
+            policy="query_stream_plaintext_v1 intentionally omits per-message timestamps",
+            input_value=input_facts["timestamped_text_messages"],
+        ),
+        _declared_loss_or_preserved(
+            metric="attachment_semantics",
+            policy="query_stream_plaintext_v1 intentionally omits attachment semantics",
+            input_value=input_facts["attachment_count"],
+        ),
+        _declared_loss_or_preserved(
+            metric="thinking_semantics",
+            policy="query_stream_plaintext_v1 preserves display text but not typed thinking markers",
+            input_value=input_facts["thinking_messages"],
+        ),
+        _declared_loss_or_preserved(
+            metric="tool_semantics",
+            policy="query_stream_plaintext_v1 preserves display text but not typed tool markers",
+            input_value=input_facts["tool_messages"],
+        ),
+        _declared_loss_or_preserved(
+            metric="branch_structure",
+            policy="query_stream_plaintext_v1 intentionally omits explicit branch topology",
+            input_value=input_facts["branch_messages"],
+        ),
+    ]
+    return SemanticConversationProof(
+        conversation_id=str(conversation.id),
+        provider=str(conversation.provider),
+        surface="query_stream_plaintext_v1",
+        input_facts=input_facts,
+        output_facts=output_facts,
+        checks=checks,
+    )
+
+
+def _prove_query_stream_markdown_surface(
+    *,
+    conversation: Conversation,
+    rendered_text: str,
+) -> SemanticConversationProof:
+    input_facts = _stream_input_facts(conversation)
+    output_facts = _stream_markdown_output_facts(rendered_text)
+    checks = [
+        _critical_or_preserved(
+            metric="title_metadata",
+            policy="query_stream_markdown_v1 must preserve the conversation title",
+            input_value=input_facts["title"],
+            output_value=output_facts["title"],
+        ),
+        _critical_or_preserved(
+            metric="provider_identity",
+            policy="query_stream_markdown_v1 must preserve provider identity in the stream header",
+            input_value=input_facts["provider"],
+            output_value=output_facts["provider"],
+        ),
+        _presence_check(
+            metric="date_metadata",
+            policy="query_stream_markdown_v1 must preserve conversation date presence in the stream header",
+            input_value=input_facts["date"],
+            output_present=bool(output_facts["has_date"]),
+        ),
+        _critical_or_preserved(
+            metric="text_messages",
+            policy="query_stream_markdown_v1 must preserve one visible section per text-bearing message",
+            input_value=input_facts["text_messages"],
+            output_value=output_facts["message_sections"],
+        ),
+        _critical_or_preserved(
+            metric="role_sections",
+            policy="query_stream_markdown_v1 must preserve visible role headings for streamed messages",
+            input_value=input_facts["text_role_counts"],
+            output_value=output_facts["role_counts"],
+        ),
+        _critical_or_preserved(
+            metric="footer_count",
+            policy="query_stream_markdown_v1 must report the number of emitted messages honestly",
+            input_value=input_facts["text_messages"],
+            output_value=output_facts["footer_count"],
+        ),
+        _declared_loss_or_preserved(
+            metric="timestamp_values",
+            policy="query_stream_markdown_v1 intentionally omits per-message timestamps",
+            input_value=input_facts["timestamped_text_messages"],
+        ),
+        _declared_loss_or_preserved(
+            metric="attachment_semantics",
+            policy="query_stream_markdown_v1 intentionally omits attachment semantics",
+            input_value=input_facts["attachment_count"],
+        ),
+        _declared_loss_or_preserved(
+            metric="thinking_semantics",
+            policy="query_stream_markdown_v1 preserves display text but not typed thinking markers",
+            input_value=input_facts["thinking_messages"],
+        ),
+        _declared_loss_or_preserved(
+            metric="tool_semantics",
+            policy="query_stream_markdown_v1 preserves display text but not typed tool markers",
+            input_value=input_facts["tool_messages"],
+        ),
+        _declared_loss_or_preserved(
+            metric="branch_structure",
+            policy="query_stream_markdown_v1 intentionally omits explicit branch topology",
+            input_value=input_facts["branch_messages"],
+        ),
+    ]
+    return SemanticConversationProof(
+        conversation_id=str(conversation.id),
+        provider=str(conversation.provider),
+        surface="query_stream_markdown_v1",
+        input_facts=input_facts,
+        output_facts=output_facts,
+        checks=checks,
+    )
+
+
+def _prove_query_stream_json_lines_surface(
+    *,
+    conversation: Conversation,
+    rendered_text: str,
+) -> SemanticConversationProof:
+    input_facts = _stream_input_facts(conversation)
+    output_facts = _stream_json_lines_output_facts(rendered_text)
+    checks = [
+        _critical_or_preserved(
+            metric="conversation_id",
+            policy="query_stream_json_lines_v1 must preserve the conversation identifier in the header",
+            input_value=input_facts["conversation_id"],
+            output_value=output_facts["conversation_id"],
+        ),
+        _critical_or_preserved(
+            metric="title_metadata",
+            policy="query_stream_json_lines_v1 must preserve the title in the header",
+            input_value=input_facts["title"],
+            output_value=output_facts["title"],
+        ),
+        _critical_or_preserved(
+            metric="provider_identity",
+            policy="query_stream_json_lines_v1 must preserve provider identity in the header",
+            input_value=input_facts["provider"],
+            output_value=output_facts["provider"],
+        ),
+        _critical_or_preserved(
+            metric="date_metadata",
+            policy="query_stream_json_lines_v1 must preserve the conversation date in the header",
+            input_value=input_facts["date"],
+            output_value=output_facts["date"],
+        ),
+        _critical_or_preserved(
+            metric="text_message_ids",
+            policy="query_stream_json_lines_v1 must preserve identifiers for emitted messages",
+            input_value=input_facts["text_message_ids"],
+            output_value=output_facts["message_ids"],
+        ),
+        _critical_or_preserved(
+            metric="role_sections",
+            policy="query_stream_json_lines_v1 must preserve role distribution for emitted messages",
+            input_value=input_facts["text_role_counts"],
+            output_value=output_facts["role_counts"],
+        ),
+        _critical_or_preserved(
+            metric="timestamp_values",
+            policy="query_stream_json_lines_v1 must preserve timestamps for emitted messages",
+            input_value=input_facts["timestamped_text_messages"],
+            output_value=output_facts["timestamped_messages"],
+        ),
+        _critical_or_preserved(
+            metric="footer_count",
+            policy="query_stream_json_lines_v1 must report the number of emitted messages honestly",
+            input_value=input_facts["text_messages"],
+            output_value=output_facts["footer_count"],
+        ),
+        _declared_loss_or_preserved(
+            metric="attachment_semantics",
+            policy="query_stream_json_lines_v1 intentionally omits attachment semantics",
+            input_value=input_facts["attachment_count"],
+        ),
+        _declared_loss_or_preserved(
+            metric="thinking_semantics",
+            policy="query_stream_json_lines_v1 preserves display text but not typed thinking markers",
+            input_value=input_facts["thinking_messages"],
+        ),
+        _declared_loss_or_preserved(
+            metric="tool_semantics",
+            policy="query_stream_json_lines_v1 preserves display text but not typed tool markers",
+            input_value=input_facts["tool_messages"],
+        ),
+        _declared_loss_or_preserved(
+            metric="branch_structure",
+            policy="query_stream_json_lines_v1 intentionally omits explicit branch topology",
+            input_value=input_facts["branch_messages"],
+        ),
+    ]
+    return SemanticConversationProof(
+        conversation_id=str(conversation.id),
+        provider=str(conversation.provider),
+        surface="query_stream_json_lines_v1",
+        input_facts=input_facts,
+        output_facts=output_facts,
+        checks=checks,
+    )
+
+
+def _prove_mcp_summary_surface(
+    *,
+    summary: ConversationSummary,
+    message_count: int,
+    rendered_text: str,
+) -> SemanticConversationProof:
+    try:
+        parsed = json.loads(rendered_text)
+    except Exception:
+        parsed = []
+    row = parsed[0] if isinstance(parsed, list) and parsed else {}
+    payload = row if isinstance(row, dict) else {}
+    input_facts = {
+        "conversation_id": str(summary.id),
+        "provider": str(summary.provider),
+        "title": summary.display_title,
+        "messages": message_count,
+        "created_at": summary.created_at.isoformat() if summary.created_at else None,
+        "updated_at": summary.updated_at.isoformat() if summary.updated_at else None,
+        "tags": list(summary.tags),
+        "summary": summary.summary,
+    }
+    output_facts = _mcp_summary_output_facts(payload)
+    checks = [
+        _critical_or_preserved(
+            metric="conversation_id",
+            policy="mcp_summary_json_v1 must preserve the conversation identifier",
+            input_value=input_facts["conversation_id"],
+            output_value=output_facts["conversation_id"],
+        ),
+        _critical_or_preserved(
+            metric="provider_identity",
+            policy="mcp_summary_json_v1 must preserve provider identity",
+            input_value=input_facts["provider"],
+            output_value=output_facts["provider"],
+        ),
+        _critical_or_preserved(
+            metric="title_metadata",
+            policy="mcp_summary_json_v1 must preserve the display title",
+            input_value=input_facts["title"],
+            output_value=output_facts["title"],
+        ),
+        _critical_or_preserved(
+            metric="message_count",
+            policy="mcp_summary_json_v1 must preserve summary message counts",
+            input_value=input_facts["messages"],
+            output_value=output_facts["messages"],
+        ),
+        _critical_or_preserved(
+            metric="created_at",
+            policy="mcp_summary_json_v1 must preserve the created_at timestamp when present",
+            input_value=input_facts["created_at"],
+            output_value=output_facts["created_at"],
+        ),
+        _critical_or_preserved(
+            metric="updated_at",
+            policy="mcp_summary_json_v1 must preserve the updated_at timestamp when present",
+            input_value=input_facts["updated_at"],
+            output_value=output_facts["updated_at"],
+        ),
+        _declared_loss_or_preserved(
+            metric="tag_values",
+            policy="mcp_summary_json_v1 intentionally omits tags",
+            input_value=len(input_facts["tags"]),
+        ),
+        _declared_loss_or_preserved(
+            metric="summary_text",
+            policy="mcp_summary_json_v1 intentionally omits summary text",
+            input_value=1 if input_facts["summary"] else 0,
+        ),
+    ]
+    return SemanticConversationProof(
+        conversation_id=input_facts["conversation_id"],
+        provider=input_facts["provider"],
+        surface="mcp_summary_json_v1",
+        input_facts=input_facts,
+        output_facts=output_facts,
+        checks=checks,
+    )
+
+
+def _prove_mcp_detail_surface(
+    *,
+    conversation: Conversation,
+    rendered_text: str,
+) -> SemanticConversationProof:
+    try:
+        parsed = json.loads(rendered_text)
+    except Exception:
+        parsed = {}
+    payload = parsed if isinstance(parsed, dict) else {}
+    input_facts = _mcp_detail_input_facts(conversation)
+    output_facts = _mcp_detail_output_facts(payload)
+    checks = [
+        _critical_or_preserved(
+            metric="conversation_id",
+            policy="mcp_detail_json_v1 must preserve the conversation identifier",
+            input_value=input_facts["conversation_id"],
+            output_value=output_facts["conversation_id"],
+        ),
+        _critical_or_preserved(
+            metric="provider_identity",
+            policy="mcp_detail_json_v1 must preserve provider identity",
+            input_value=input_facts["provider"],
+            output_value=output_facts["provider"],
+        ),
+        _critical_or_preserved(
+            metric="title_metadata",
+            policy="mcp_detail_json_v1 must preserve the display title",
+            input_value=input_facts["title"],
+            output_value=output_facts["title"],
+        ),
+        _critical_or_preserved(
+            metric="created_at",
+            policy="mcp_detail_json_v1 must preserve the created_at timestamp when present",
+            input_value=input_facts["created_at"],
+            output_value=output_facts["created_at"],
+        ),
+        _critical_or_preserved(
+            metric="updated_at",
+            policy="mcp_detail_json_v1 must preserve the updated_at timestamp when present",
+            input_value=input_facts["updated_at"],
+            output_value=output_facts["updated_at"],
+        ),
+        _critical_or_preserved(
+            metric="message_entries",
+            policy="mcp_detail_json_v1 must preserve every message entry",
+            input_value=input_facts["messages"],
+            output_value=output_facts["messages"],
+        ),
+        _critical_or_preserved(
+            metric="message_ids",
+            policy="mcp_detail_json_v1 must preserve message identifiers",
+            input_value=input_facts["message_ids"],
+            output_value=output_facts["message_ids"],
+        ),
+        _critical_or_preserved(
+            metric="role_entries",
+            policy="mcp_detail_json_v1 must preserve message role distribution",
+            input_value=input_facts["role_counts"],
+            output_value=output_facts["role_counts"],
+        ),
+        _critical_or_preserved(
+            metric="timestamp_values",
+            policy="mcp_detail_json_v1 must preserve message timestamps",
+            input_value=input_facts["timestamped_messages"],
+            output_value=output_facts["timestamped_messages"],
+        ),
+        _declared_loss_or_preserved(
+            metric="attachment_semantics",
+            policy="mcp_detail_json_v1 intentionally omits attachment payload semantics",
+            input_value=input_facts["attachment_count"],
+        ),
+        _declared_loss_or_preserved(
+            metric="thinking_semantics",
+            policy="mcp_detail_json_v1 preserves display text but not typed thinking markers",
+            input_value=input_facts["thinking_messages"],
+        ),
+        _declared_loss_or_preserved(
+            metric="tool_semantics",
+            policy="mcp_detail_json_v1 preserves display text but not typed tool markers",
+            input_value=input_facts["tool_messages"],
+        ),
+        _declared_loss_or_preserved(
+            metric="branch_structure",
+            policy="mcp_detail_json_v1 intentionally omits explicit branch topology",
+            input_value=input_facts["branch_messages"],
+        ),
+    ]
+    return SemanticConversationProof(
+        conversation_id=input_facts["conversation_id"],
+        provider=input_facts["provider"],
+        surface="mcp_detail_json_v1",
+        input_facts=input_facts,
+        output_facts=output_facts,
+        checks=checks,
+    )
+
+
 def _empty_surface_report(
     surface: str,
     *,
@@ -1352,11 +2296,112 @@ async def _prove_semantic_surface_suite_async(
             providers=providers,
         )
         proofs_by_surface: dict[str, list[SemanticConversationProof]] = {surface: [] for surface in surfaces}
-        need_export_surfaces = any(surface != "canonical_markdown_v1" for surface in surfaces)
+        summary_surfaces = {
+            "query_summary_json_v1",
+            "query_summary_yaml_v1",
+            "query_summary_csv_v1",
+            "query_summary_text_v1",
+        }
+        stream_surfaces = {
+            "query_stream_plaintext_v1",
+            "query_stream_markdown_v1",
+            "query_stream_json_lines_v1",
+        }
+        export_surfaces = set(_EXPORT_SURFACE_FORMATS)
+        summary_json_surfaces = {
+            "query_summary_json_v1",
+            "query_summary_yaml_v1",
+        }
+        need_message_counts = any(surface in summary_surfaces or surface == "mcp_summary_json_v1" for surface in surfaces)
+        need_full_conversations = any(
+            surface in export_surfaces
+            or surface in stream_surfaces
+            or surface == "mcp_detail_json_v1"
+            for surface in surfaces
+        )
+
+        summary_ids = [str(summary.id) for summary in summaries]
+        message_counts = (
+            await repository.queries.get_message_counts_batch(summary_ids)
+            if summary_ids and need_message_counts
+            else {}
+        )
+        conversations_by_id: dict[str, Conversation] = {}
+        if need_full_conversations and summary_ids:
+            conversations = await repository.get_many(summary_ids)
+            conversations_by_id = {str(conversation.id): conversation for conversation in conversations}
 
         for summary in summaries:
             conversation_id = str(summary.id)
-            conversation = await repository.view(conversation_id) if need_export_surfaces else None
+            conversation = conversations_by_id.get(conversation_id) if need_full_conversations else None
+            message_count = message_counts.get(
+                conversation_id,
+                len(conversation.messages) if conversation is not None else 0,
+            )
+            if summary_json_surfaces & set(surfaces):
+                for surface in sorted(summary_json_surfaces & set(surfaces)):
+                    rendered_text = format_summary_list(
+                        [summary],
+                        "json" if surface == "query_summary_json_v1" else "yaml",
+                        None,
+                        message_counts={conversation_id: message_count},
+                    )
+                    proofs_by_surface[surface].append(
+                        _prove_query_summary_json_like_surface(
+                            summary=summary,
+                            message_count=message_count,
+                            rendered_text=rendered_text,
+                            surface=surface,
+                        )
+                    )
+
+            if "query_summary_csv_v1" in surfaces:
+                rendered_text = format_summary_list(
+                    [summary],
+                    "csv",
+                    None,
+                    message_counts={conversation_id: message_count},
+                )
+                proofs_by_surface["query_summary_csv_v1"].append(
+                    _prove_query_summary_csv_surface(
+                        summary=summary,
+                        message_count=message_count,
+                        rendered_text=rendered_text,
+                    )
+                )
+
+            if "query_summary_text_v1" in surfaces:
+                rendered_text = format_summary_list(
+                    [summary],
+                    "text",
+                    None,
+                    message_counts={conversation_id: message_count},
+                )
+                proofs_by_surface["query_summary_text_v1"].append(
+                    _prove_query_summary_text_surface(
+                        summary=summary,
+                        message_count=message_count,
+                        rendered_text=rendered_text,
+                    )
+                )
+
+            if "mcp_summary_json_v1" in surfaces:
+                rendered_text = MCPConversationSummaryListPayload(
+                    root=[
+                        MCPConversationSummaryPayload.from_summary(
+                            summary,
+                            message_count=message_count,
+                        )
+                    ]
+                ).to_json()
+                proofs_by_surface["mcp_summary_json_v1"].append(
+                    _prove_mcp_summary_surface(
+                        summary=summary,
+                        message_count=message_count,
+                        rendered_text=rendered_text,
+                    )
+                )
+
             projection = None
             for surface in surfaces:
                 if surface == "canonical_markdown_v1":
@@ -1370,12 +2415,69 @@ async def _prove_semantic_surface_suite_async(
                     )
                     continue
 
-                if conversation is None:
+                if surface in export_surfaces:
+                    if conversation is None:
+                        continue
+                    rendered_text = format_conversation(conversation, _EXPORT_SURFACE_FORMATS[surface], None)
+                    proofs_by_surface[surface].append(
+                        prove_export_surface_semantics(conversation, surface, rendered_text)
+                    )
                     continue
-                rendered_text = format_conversation(conversation, _EXPORT_SURFACE_FORMATS[surface], None)
-                proofs_by_surface[surface].append(
-                    prove_export_surface_semantics(conversation, surface, rendered_text)
-                )
+
+                if surface in stream_surfaces:
+                    if conversation is None:
+                        continue
+                    rendered_text, _ = render_stream_transcript(
+                        conversation_id=conversation_id,
+                        title=conversation.display_title,
+                        provider=str(conversation.provider),
+                        display_date=conversation.display_date,
+                        messages=list(conversation.messages),
+                        output_format={
+                            "query_stream_plaintext_v1": "plaintext",
+                            "query_stream_markdown_v1": "markdown",
+                            "query_stream_json_lines_v1": "json-lines",
+                        }[surface],
+                        dialogue_only=False,
+                        message_limit=None,
+                        stats={
+                            "total_messages": len(conversation.messages),
+                            "dialogue_messages": sum(1 for message in conversation.messages if message.is_dialogue),
+                        },
+                    )
+                    if surface == "query_stream_plaintext_v1":
+                        proofs_by_surface[surface].append(
+                            _prove_query_stream_plaintext_surface(
+                                conversation=conversation,
+                                rendered_text=rendered_text,
+                            )
+                        )
+                    elif surface == "query_stream_markdown_v1":
+                        proofs_by_surface[surface].append(
+                            _prove_query_stream_markdown_surface(
+                                conversation=conversation,
+                                rendered_text=rendered_text,
+                            )
+                        )
+                    else:
+                        proofs_by_surface[surface].append(
+                            _prove_query_stream_json_lines_surface(
+                                conversation=conversation,
+                                rendered_text=rendered_text,
+                            )
+                        )
+                    continue
+
+                if surface == "mcp_detail_json_v1":
+                    if conversation is None:
+                        continue
+                    rendered_text = MCPConversationDetailPayload.from_conversation(conversation).to_json()
+                    proofs_by_surface[surface].append(
+                        _prove_mcp_detail_surface(
+                            conversation=conversation,
+                            rendered_text=rendered_text,
+                        )
+                    )
 
         provider_filters = list(providers or [])
         return SemanticProofSuiteReport(

--- a/polylogue/rendering/semantic_proof.py
+++ b/polylogue/rendering/semantic_proof.py
@@ -1,0 +1,496 @@
+"""Semantic preservation proofing for rendered output surfaces."""
+
+from __future__ import annotations
+
+import asyncio
+from collections import Counter
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from polylogue.lib.roles import Role
+from polylogue.paths import archive_root as default_archive_root
+from polylogue.paths import db_path as default_db_path
+from polylogue.rendering.core import ConversationFormatter
+from polylogue.storage.backends.async_sqlite import SQLiteBackend
+from polylogue.storage.repository import ConversationRepository
+from polylogue.storage.store import ConversationRenderProjection, MessageRecord
+
+
+def _sorted_counts(counts: dict[str, int]) -> dict[str, int]:
+    return dict(sorted(counts.items()))
+
+
+def _empty_metric_counts() -> dict[str, int]:
+    return {"preserved": 0, "declared_loss": 0, "critical_loss": 0}
+
+
+def _normalized_role(message: MessageRecord) -> str:
+    role = message.role
+    if isinstance(role, Role):
+        return str(role)
+    if role:
+        return str(Role.normalize(str(role)))
+    return "message"
+
+
+def _input_facts(projection: ConversationRenderProjection) -> dict[str, Any]:
+    attachment_counts: Counter[str] = Counter(
+        attachment.message_id for attachment in projection.attachments if attachment.message_id
+    )
+    renderable_messages = 0
+    timestamped_renderable_messages = 0
+    empty_messages = 0
+    thinking_messages = 0
+    tool_messages = 0
+    role_counts: Counter[str] = Counter()
+
+    for message in projection.messages:
+        has_attachments = attachment_counts.get(message.message_id, 0) > 0
+        has_text = bool((message.text or "").strip())
+        if has_text or has_attachments:
+            renderable_messages += 1
+            role_counts[_normalized_role(message)] += 1
+            if message.sort_key is not None:
+                timestamped_renderable_messages += 1
+        else:
+            empty_messages += 1
+        if int(message.has_thinking or 0) > 0:
+            thinking_messages += 1
+        if int(message.has_tool_use or 0) > 0:
+            tool_messages += 1
+
+    return {
+        "total_messages": len(projection.messages),
+        "renderable_messages": renderable_messages,
+        "timestamped_renderable_messages": timestamped_renderable_messages,
+        "attachment_count": len(projection.attachments),
+        "empty_messages": empty_messages,
+        "thinking_messages": thinking_messages,
+        "tool_messages": tool_messages,
+        "renderable_role_counts": _sorted_counts(dict(role_counts)),
+    }
+
+
+def _output_facts(markdown_text: str) -> dict[str, Any]:
+    message_sections = 0
+    timestamp_lines = 0
+    attachment_lines = 0
+    role_section_counts: Counter[str] = Counter()
+
+    for line in markdown_text.splitlines():
+        if line.startswith("## "):
+            section = line[3:].strip()
+            if section.lower() != "attachments":
+                message_sections += 1
+                role_section_counts[section] += 1
+        elif line.startswith("_Timestamp: "):
+            timestamp_lines += 1
+        elif line.startswith("- Attachment: "):
+            attachment_lines += 1
+
+    return {
+        "message_sections": message_sections,
+        "timestamp_lines": timestamp_lines,
+        "attachment_lines": attachment_lines,
+        "typed_thinking_markers": 0,
+        "typed_tool_markers": 0,
+        "role_section_counts": _sorted_counts(dict(role_section_counts)),
+    }
+
+
+@dataclass(frozen=True)
+class SemanticMetricCheck:
+    """One measurable preservation or declared-loss claim."""
+
+    metric: str
+    status: str
+    policy: str
+    input_value: Any
+    output_value: Any
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "metric": self.metric,
+            "status": self.status,
+            "policy": self.policy,
+            "input_value": self.input_value,
+            "output_value": self.output_value,
+        }
+
+
+@dataclass(frozen=True)
+class SemanticConversationProof:
+    """Semantic proof result for one rendered conversation surface."""
+
+    conversation_id: str
+    provider: str
+    surface: str
+    input_facts: dict[str, Any]
+    output_facts: dict[str, Any]
+    checks: list[SemanticMetricCheck] = field(default_factory=list)
+
+    @property
+    def critical_loss_checks(self) -> list[SemanticMetricCheck]:
+        return [check for check in self.checks if check.status == "critical_loss"]
+
+    @property
+    def declared_loss_checks(self) -> list[SemanticMetricCheck]:
+        return [check for check in self.checks if check.status == "declared_loss"]
+
+    @property
+    def preserved_checks(self) -> list[SemanticMetricCheck]:
+        return [check for check in self.checks if check.status == "preserved"]
+
+    @property
+    def metric_summary(self) -> dict[str, dict[str, int]]:
+        summary: dict[str, dict[str, int]] = {}
+        for check in self.checks:
+            counts = summary.setdefault(check.metric, _empty_metric_counts())
+            counts[check.status] += 1
+        return dict(sorted(summary.items()))
+
+    @property
+    def is_clean(self) -> bool:
+        return not self.critical_loss_checks
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "conversation_id": self.conversation_id,
+            "provider": self.provider,
+            "surface": self.surface,
+            "input_facts": self.input_facts,
+            "output_facts": self.output_facts,
+            "summary": {
+                "preserved_checks": len(self.preserved_checks),
+                "declared_loss_checks": len(self.declared_loss_checks),
+                "critical_loss_checks": len(self.critical_loss_checks),
+                "metric_summary": self.metric_summary,
+                "clean": self.is_clean,
+            },
+            "checks": [check.to_dict() for check in self.checks],
+        }
+
+
+@dataclass(frozen=True)
+class ProviderSemanticProof:
+    """Per-provider semantic-preservation proof summary."""
+
+    provider: str
+    total_conversations: int = 0
+    clean_conversations: int = 0
+    critical_conversations: int = 0
+    preserved_checks: int = 0
+    declared_loss_checks: int = 0
+    critical_loss_checks: int = 0
+    metric_summary: dict[str, dict[str, int]] = field(default_factory=dict)
+
+    @property
+    def is_clean(self) -> bool:
+        return self.critical_conversations == 0
+
+    @property
+    def clean(self) -> bool:
+        return self.is_clean
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "provider": self.provider,
+            "total_conversations": self.total_conversations,
+            "clean_conversations": self.clean_conversations,
+            "critical_conversations": self.critical_conversations,
+            "preserved_checks": self.preserved_checks,
+            "declared_loss_checks": self.declared_loss_checks,
+            "critical_loss_checks": self.critical_loss_checks,
+            "metric_summary": dict(sorted(self.metric_summary.items())),
+            "clean": self.clean,
+        }
+
+
+def _build_provider_reports(
+    conversations: list[SemanticConversationProof],
+) -> dict[str, ProviderSemanticProof]:
+    provider_totals: dict[str, dict[str, Any]] = {}
+    for proof in conversations:
+        state = provider_totals.setdefault(
+            proof.provider,
+            {
+                "total_conversations": 0,
+                "clean_conversations": 0,
+                "critical_conversations": 0,
+                "preserved_checks": 0,
+                "declared_loss_checks": 0,
+                "critical_loss_checks": 0,
+                "metric_summary": {},
+            },
+        )
+        state["total_conversations"] += 1
+        if proof.is_clean:
+            state["clean_conversations"] += 1
+        else:
+            state["critical_conversations"] += 1
+        state["preserved_checks"] += len(proof.preserved_checks)
+        state["declared_loss_checks"] += len(proof.declared_loss_checks)
+        state["critical_loss_checks"] += len(proof.critical_loss_checks)
+        for metric, counts in proof.metric_summary.items():
+            metric_counts = state["metric_summary"].setdefault(metric, _empty_metric_counts())
+            for status, count in counts.items():
+                metric_counts[status] += count
+
+    return {
+        provider: ProviderSemanticProof(
+            provider=provider,
+            total_conversations=state["total_conversations"],
+            clean_conversations=state["clean_conversations"],
+            critical_conversations=state["critical_conversations"],
+            preserved_checks=state["preserved_checks"],
+            declared_loss_checks=state["declared_loss_checks"],
+            critical_loss_checks=state["critical_loss_checks"],
+            metric_summary=dict(sorted(state["metric_summary"].items())),
+        )
+        for provider, state in sorted(provider_totals.items())
+    }
+
+
+@dataclass(frozen=True)
+class SemanticProofReport:
+    """Aggregate semantic proof report for one output surface."""
+
+    surface: str
+    conversations: list[SemanticConversationProof]
+    provider_reports: dict[str, ProviderSemanticProof]
+    record_limit: int | None = None
+    record_offset: int = 0
+    provider_filters: list[str] = field(default_factory=list)
+
+    @property
+    def total_conversations(self) -> int:
+        return len(self.conversations)
+
+    @property
+    def provider_count(self) -> int:
+        return len(self.provider_reports)
+
+    @property
+    def providers(self) -> dict[str, ProviderSemanticProof]:
+        return self.provider_reports
+
+    @property
+    def clean_conversations(self) -> int:
+        return sum(1 for proof in self.conversations if proof.is_clean)
+
+    @property
+    def critical_conversations(self) -> int:
+        return sum(1 for proof in self.conversations if not proof.is_clean)
+
+    @property
+    def preserved_checks(self) -> int:
+        return sum(len(proof.preserved_checks) for proof in self.conversations)
+
+    @property
+    def declared_loss_checks(self) -> int:
+        return sum(len(proof.declared_loss_checks) for proof in self.conversations)
+
+    @property
+    def critical_loss_checks(self) -> int:
+        return sum(len(proof.critical_loss_checks) for proof in self.conversations)
+
+    @property
+    def metric_summary(self) -> dict[str, dict[str, int]]:
+        summary: dict[str, dict[str, int]] = {}
+        for proof in self.conversations:
+            for check in proof.checks:
+                metric = summary.setdefault(check.metric, _empty_metric_counts())
+                metric[check.status] += 1
+        return dict(sorted(summary.items()))
+
+    @property
+    def is_clean(self) -> bool:
+        return self.critical_conversations == 0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "surface": self.surface,
+            "record_limit": self.record_limit if self.record_limit is not None else "all",
+            "record_offset": self.record_offset,
+            "provider_filters": list(self.provider_filters),
+            "summary": {
+                "total_conversations": self.total_conversations,
+                "provider_count": self.provider_count,
+                "clean_conversations": self.clean_conversations,
+                "critical_conversations": self.critical_conversations,
+                "preserved_checks": self.preserved_checks,
+                "declared_loss_checks": self.declared_loss_checks,
+                "critical_loss_checks": self.critical_loss_checks,
+                "metric_summary": self.metric_summary,
+                "clean": self.is_clean,
+            },
+            "providers": {
+                provider: stats.to_dict() for provider, stats in sorted(self.provider_reports.items())
+            },
+            "conversations": [proof.to_dict() for proof in self.conversations],
+        }
+
+
+def prove_markdown_projection_semantics(
+    projection: ConversationRenderProjection,
+    markdown_text: str,
+) -> SemanticConversationProof:
+    """Compare a repository render projection to canonical markdown output."""
+    input_facts = _input_facts(projection)
+    output_facts = _output_facts(markdown_text)
+
+    checks = [
+        SemanticMetricCheck(
+            metric="renderable_messages",
+            status=(
+                "preserved"
+                if input_facts["renderable_messages"] == output_facts["message_sections"]
+                else "critical_loss"
+            ),
+            policy="canonical markdown must preserve every renderable message section",
+            input_value=input_facts["renderable_messages"],
+            output_value=output_facts["message_sections"],
+        ),
+        SemanticMetricCheck(
+            metric="attachment_lines",
+            status=(
+                "preserved"
+                if input_facts["attachment_count"] == output_facts["attachment_lines"]
+                else "critical_loss"
+            ),
+            policy="canonical markdown must preserve attachment presence as attachment lines",
+            input_value=input_facts["attachment_count"],
+            output_value=output_facts["attachment_lines"],
+        ),
+        SemanticMetricCheck(
+            metric="timestamp_lines",
+            status=(
+                "preserved"
+                if input_facts["timestamped_renderable_messages"] == output_facts["timestamp_lines"]
+                else "critical_loss"
+            ),
+            policy="canonical markdown must preserve timestamps for renderable messages that have them",
+            input_value=input_facts["timestamped_renderable_messages"],
+            output_value=output_facts["timestamp_lines"],
+        ),
+        SemanticMetricCheck(
+            metric="role_sections",
+            status=(
+                "preserved"
+                if input_facts["renderable_role_counts"] == output_facts["role_section_counts"]
+                else "critical_loss"
+            ),
+            policy="canonical markdown must preserve renderable message role sections",
+            input_value=input_facts["renderable_role_counts"],
+            output_value=output_facts["role_section_counts"],
+        ),
+        SemanticMetricCheck(
+            metric="empty_messages",
+            status="declared_loss" if input_facts["empty_messages"] else "preserved",
+            policy="canonical markdown intentionally omits messages with no text and no attachments",
+            input_value=input_facts["empty_messages"],
+            output_value=0,
+        ),
+        SemanticMetricCheck(
+            metric="thinking_semantics",
+            status="declared_loss" if input_facts["thinking_messages"] else "preserved",
+            policy="canonical markdown preserves display text but not typed thinking markers",
+            input_value=input_facts["thinking_messages"],
+            output_value=output_facts["typed_thinking_markers"],
+        ),
+        SemanticMetricCheck(
+            metric="tool_semantics",
+            status="declared_loss" if input_facts["tool_messages"] else "preserved",
+            policy="canonical markdown preserves display text but not typed tool markers",
+            input_value=input_facts["tool_messages"],
+            output_value=output_facts["typed_tool_markers"],
+        ),
+    ]
+
+    return SemanticConversationProof(
+        conversation_id=projection.conversation.conversation_id,
+        provider=projection.conversation.provider_name or "unknown",
+        surface="canonical_markdown_v1",
+        input_facts=input_facts,
+        output_facts=output_facts,
+        checks=checks,
+    )
+
+
+async def _prove_markdown_render_semantics_async(
+    *,
+    db_path: Path,
+    archive_root: Path,
+    providers: list[str] | None,
+    record_limit: int | None,
+    record_offset: int,
+) -> SemanticProofReport:
+    backend = SQLiteBackend(db_path=db_path)
+    repository = ConversationRepository(backend=backend)
+    formatter = ConversationFormatter(archive_root=archive_root, db_path=db_path, backend=backend)
+    try:
+        summaries = await repository.list_summaries(
+            limit=record_limit,
+            offset=record_offset,
+            providers=providers,
+        )
+        proofs: list[SemanticConversationProof] = []
+        for summary in summaries:
+            projection = await repository.get_render_projection(str(summary.id))
+            if projection is None:
+                continue
+            formatted = formatter.format_projection(projection)
+            proofs.append(prove_markdown_projection_semantics(projection, formatted.markdown_text))
+        return SemanticProofReport(
+            surface="canonical_markdown_v1",
+            conversations=proofs,
+            provider_reports=_build_provider_reports(proofs),
+            record_limit=record_limit,
+            record_offset=record_offset,
+            provider_filters=list(providers or []),
+        )
+    finally:
+        await backend.close()
+
+
+def prove_markdown_render_semantics(
+    *,
+    db_path: Path | None = None,
+    archive_root: Path | None = None,
+    providers: list[str] | None = None,
+    record_limit: int | None = None,
+    record_offset: int = 0,
+) -> SemanticProofReport:
+    """Run semantic preservation proof over canonical markdown rendering."""
+    effective_db_path = db_path or default_db_path()
+    bounded_limit = max(1, int(record_limit)) if record_limit is not None else None
+    bounded_offset = max(0, int(record_offset))
+    if not effective_db_path.exists():
+        return SemanticProofReport(
+            surface="canonical_markdown_v1",
+            conversations=[],
+            provider_reports={},
+            record_limit=bounded_limit,
+            record_offset=bounded_offset,
+            provider_filters=list(providers or []),
+        )
+    return asyncio.run(
+        _prove_markdown_render_semantics_async(
+            db_path=effective_db_path,
+            archive_root=archive_root or default_archive_root(),
+            providers=providers,
+            record_limit=bounded_limit,
+            record_offset=bounded_offset,
+        )
+    )
+
+
+__all__ = [
+    "ProviderSemanticProof",
+    "SemanticConversationProof",
+    "SemanticMetricCheck",
+    "SemanticProofReport",
+    "prove_markdown_projection_semantics",
+    "prove_markdown_render_semantics",
+]

--- a/polylogue/schemas/verification.py
+++ b/polylogue/schemas/verification.py
@@ -382,7 +382,7 @@ def list_artifact_observation_rows(
 
     bounded_limit, bounded_offset = _bounded_window(record_limit, record_offset)
     with open_connection(db_path) as conn:
-        ensure_artifact_observations(conn, providers=providers)
+        ensure_artifact_observations(conn, providers=providers, refresh_resolutions=True)
         return list_durable_artifact_observations(
             conn,
             providers=providers,
@@ -409,7 +409,7 @@ def list_artifact_cohort_rows(
 
     bounded_limit, bounded_offset = _bounded_window(record_limit, record_offset)
     with open_connection(db_path) as conn:
-        ensure_artifact_observations(conn, providers=providers)
+        ensure_artifact_observations(conn, providers=providers, refresh_resolutions=True)
         return list_durable_artifact_cohorts(
             conn,
             providers=providers,

--- a/polylogue/showcase/exercises.py
+++ b/polylogue/showcase/exercises.py
@@ -266,7 +266,7 @@ EXERCISES: tuple[Exercise, ...] = (
        needs_data=True, writes=True, env="seeded", tier=2, depends_on="delete-one"),
 
     # =========================================================================
-    # subcommands (6) — tier 1: read-only health/stats; tier 2: site generation
+    # subcommands (10) — tier 1: read-only health/proof/stats; tier 2: site generation
     # =========================================================================
     _E("check-health", "subcommands", "Health check",
        ["check"], _V(stdout_contains=("ok",)), needs_data=True, tier=1, vhs_capture=True),
@@ -275,6 +275,18 @@ EXERCISES: tuple[Exercise, ...] = (
        needs_data=True, output_ext=".json", tier=1),
     _E("check-verbose", "subcommands", "Verbose health check",
        ["check", "-v"], needs_data=True, tier=1),
+    _E("check-proof-json", "subcommands", "Artifact proof as JSON",
+       ["check", "--json", "--proof"], _V(stdout_is_valid_json=True),
+       needs_data=True, output_ext=".json", tier=1),
+    _E("check-cohorts-json", "subcommands", "Artifact cohorts as JSON",
+       ["check", "--json", "--cohorts"], _V(stdout_is_valid_json=True),
+       needs_data=True, output_ext=".json", tier=1),
+    _E("check-semantic-proof", "subcommands", "Semantic preservation proof",
+       ["check", "--semantic-proof"], _V(stdout_contains=("Semantic proof:",)),
+       needs_data=True, tier=1),
+    _E("check-semantic-proof-json", "subcommands", "Semantic preservation proof as JSON",
+       ["check", "--json", "--semantic-proof"], _V(stdout_is_valid_json=True),
+       needs_data=True, output_ext=".json", tier=1),
     _E("embed-stats", "subcommands", "Embedding statistics",
        ["embed", "--stats"], needs_data=True, tier=1),
     _E("tags-json", "subcommands", "Tags as JSON",

--- a/polylogue/showcase/exercises.py
+++ b/polylogue/showcase/exercises.py
@@ -266,7 +266,7 @@ EXERCISES: tuple[Exercise, ...] = (
        needs_data=True, writes=True, env="seeded", tier=2, depends_on="delete-one"),
 
     # =========================================================================
-    # subcommands (10) — tier 1: read-only health/proof/stats; tier 2: site generation
+    # subcommands (12) — tier 1: read-only health/proof/stats; tier 2: site generation
     # =========================================================================
     _E("check-health", "subcommands", "Health check",
        ["check"], _V(stdout_contains=("ok",)), needs_data=True, tier=1, vhs_capture=True),
@@ -287,6 +287,13 @@ EXERCISES: tuple[Exercise, ...] = (
     _E("check-semantic-proof-json", "subcommands", "Semantic preservation proof as JSON",
        ["check", "--json", "--semantic-proof"], _V(stdout_is_valid_json=True),
        needs_data=True, output_ext=".json", tier=1),
+    _E("check-semantic-proof-read-surfaces", "subcommands", "Semantic proof for query, stream, and MCP read surfaces",
+       ["check", "--semantic-proof", "--semantic-surface", "read_all"],
+       _V(stdout_contains=("query_stream_json_lines_v1", "mcp_detail_json_v1")),
+       needs_data=True, tier=1),
+    _E("check-semantic-proof-read-surfaces-json", "subcommands", "Semantic proof for query, stream, and MCP read surfaces as JSON",
+       ["check", "--json", "--semantic-proof", "--semantic-surface", "read_all"],
+       _V(stdout_is_valid_json=True), needs_data=True, output_ext=".json", tier=1),
     _E("embed-stats", "subcommands", "Embedding statistics",
        ["embed", "--stats"], needs_data=True, tier=1),
     _E("tags-json", "subcommands", "Tags as JSON",

--- a/polylogue/showcase/qa_runner.py
+++ b/polylogue/showcase/qa_runner.py
@@ -28,7 +28,7 @@ from polylogue.showcase.workspace import (
 )
 
 if TYPE_CHECKING:
-    from polylogue.rendering.semantic_proof import SemanticProofReport
+    from polylogue.rendering.semantic_proof import SemanticProofSuiteReport
     from polylogue.schemas.audit import AuditReport
     from polylogue.schemas.verification import ArtifactProofReport
 
@@ -42,7 +42,7 @@ class QAResult:
     audit_skipped: bool = False
     proof_report: ArtifactProofReport | None = None
     proof_error: str | None = None
-    semantic_proof_report: SemanticProofReport | None = None
+    semantic_proof_report: SemanticProofSuiteReport | None = None
     semantic_proof_error: str | None = None
     showcase_result: ShowcaseResult | None = None
     exercises_skipped: bool = False
@@ -161,14 +161,14 @@ def _populate_semantic_proof(
     workspace_env: dict[str, str] | None,
 ) -> None:
     """Populate the semantic proof stage against the active archive."""
-    from polylogue.rendering.semantic_proof import prove_markdown_render_semantics
+    from polylogue.rendering.semantic_proof import prove_semantic_surface_suite
 
     try:
         if workspace_env:
             with override_workspace_env(workspace_env):
-                result.semantic_proof_report = prove_markdown_render_semantics()
+                result.semantic_proof_report = prove_semantic_surface_suite()
         else:
-            result.semantic_proof_report = prove_markdown_render_semantics()
+            result.semantic_proof_report = prove_semantic_surface_suite()
     except Exception as exc:
         result.semantic_proof_error = str(exc)
 

--- a/polylogue/showcase/qa_runner.py
+++ b/polylogue/showcase/qa_runner.py
@@ -28,6 +28,7 @@ from polylogue.showcase.workspace import (
 )
 
 if TYPE_CHECKING:
+    from polylogue.rendering.semantic_proof import SemanticProofReport
     from polylogue.schemas.audit import AuditReport
     from polylogue.schemas.verification import ArtifactProofReport
 
@@ -41,6 +42,8 @@ class QAResult:
     audit_skipped: bool = False
     proof_report: ArtifactProofReport | None = None
     proof_error: str | None = None
+    semantic_proof_report: SemanticProofReport | None = None
+    semantic_proof_error: str | None = None
     showcase_result: ShowcaseResult | None = None
     exercises_skipped: bool = False
     invariant_results: list[InvariantResult] = field(default_factory=list)
@@ -73,6 +76,15 @@ class QAResult:
         return OutcomeStatus.OK if self.proof_report.is_clean else OutcomeStatus.ERROR
 
     @property
+    def semantic_proof_status(self) -> OutcomeStatus:
+        """Status for the semantic proof stage."""
+        if self.semantic_proof_error is not None:
+            return OutcomeStatus.ERROR
+        if self.semantic_proof_report is None:
+            return OutcomeStatus.SKIP
+        return OutcomeStatus.OK if self.semantic_proof_report.is_clean else OutcomeStatus.ERROR
+
+    @property
     def showcase_status(self) -> OutcomeStatus:
         """Status for the exercise stage."""
         if self.exercises_skipped:
@@ -98,6 +110,7 @@ class QAResult:
             for stage in (
                 self.audit_status,
                 self.proof_status,
+                self.semantic_proof_status,
                 self.showcase_status,
                 self.invariant_status,
             )
@@ -142,6 +155,24 @@ def _populate_proof(
         result.proof_error = str(exc)
 
 
+def _populate_semantic_proof(
+    result: QAResult,
+    *,
+    workspace_env: dict[str, str] | None,
+) -> None:
+    """Populate the semantic proof stage against the active archive."""
+    from polylogue.rendering.semantic_proof import prove_markdown_render_semantics
+
+    try:
+        if workspace_env:
+            with override_workspace_env(workspace_env):
+                result.semantic_proof_report = prove_markdown_render_semantics()
+        else:
+            result.semantic_proof_report = prove_markdown_render_semantics()
+    except Exception as exc:
+        result.semantic_proof_error = str(exc)
+
+
 def run_qa_session(
     *,
     live: bool = False,
@@ -166,9 +197,10 @@ def run_qa_session(
     Stages (in order, each skippable):
       1. Schema audit
       2. Artifact proof
-      3. Exercises (showcase)
-      4. Invariant checks
-      5. Report generation
+      3. Semantic proof
+      4. Exercises (showcase)
+      5. Invariant checks
+      6. Report generation
     """
     result = QAResult(report_dir=report_dir)
     workspace_env_for_runner: dict[str, str] | None = workspace_env
@@ -240,6 +272,7 @@ def run_qa_session(
 
             if not audit_report.all_passed:
                 _populate_proof(result, workspace_env=workspace_env_for_runner)
+                _populate_semantic_proof(result, workspace_env=workspace_env_for_runner)
                 result.exercises_skipped = True
                 result.invariants_skipped = True
                 if verbose:
@@ -251,6 +284,7 @@ def run_qa_session(
         except Exception as e:
             result.audit_error = str(e)
             _populate_proof(result, workspace_env=workspace_env_for_runner)
+            _populate_semantic_proof(result, workspace_env=workspace_env_for_runner)
             result.exercises_skipped = True
             result.invariants_skipped = True
             if report_dir:
@@ -261,7 +295,10 @@ def run_qa_session(
     # --- Step 2: Artifact proof ---
     _populate_proof(result, workspace_env=workspace_env_for_runner)
 
-    # --- Step 3: Exercises ---
+    # --- Step 3: Semantic proof ---
+    _populate_semantic_proof(result, workspace_env=workspace_env_for_runner)
+
+    # --- Step 4: Exercises ---
     if skip_exercises:
         result.exercises_skipped = True
     else:
@@ -278,13 +315,13 @@ def run_qa_session(
         showcase_result = runner.run()
         result.showcase_result = showcase_result
 
-    # --- Step 4: Invariant checks ---
+    # --- Step 5: Invariant checks ---
     if skip_invariants:
         result.invariants_skipped = True
     elif result.showcase_result:
         result.invariant_results = check_invariants(result.showcase_result.results)
 
-    # --- Step 5: Save reports ---
+    # --- Step 6: Save reports ---
     if report_dir:
         result.report_dir = report_dir
         _save_qa_reports(result, report_dir)
@@ -314,6 +351,15 @@ def _save_qa_reports(result: QAResult, report_dir: Path) -> None:
     elif result.proof_error is not None:
         (report_dir / "artifact-proof.json").write_text(
             json.dumps({"error": result.proof_error}, indent=2, sort_keys=True)
+        )
+
+    if result.semantic_proof_report is not None:
+        (report_dir / "semantic-proof.json").write_text(
+            json.dumps(result.semantic_proof_report.to_dict(), indent=2, sort_keys=True)
+        )
+    elif result.semantic_proof_error is not None:
+        (report_dir / "semantic-proof.json").write_text(
+            json.dumps({"error": result.semantic_proof_error}, indent=2, sort_keys=True)
         )
 
     from polylogue.showcase.report import (

--- a/polylogue/showcase/report.py
+++ b/polylogue/showcase/report.py
@@ -399,14 +399,25 @@ def generate_qa_summary(result: QAResult) -> str:
     elif semantic_summary is not None:
         lines.append(
             "Semantic Proof: "
-            f"clean_conversations={semantic_summary['clean_conversations']}, "
-            f"critical_conversations={semantic_summary['critical_conversations']}, "
+            f"surfaces={semantic_summary['surface_count']}, "
+            f"clean_surfaces={semantic_summary['clean_surfaces']}, "
+            f"critical_surfaces={semantic_summary['critical_surfaces']}, "
+            f"total_conversations={semantic_summary['total_conversations']}, "
             f"preserved_checks={semantic_summary['preserved_checks']}, "
             f"declared_loss_checks={semantic_summary['declared_loss_checks']}, "
             f"critical_loss_checks={semantic_summary['critical_loss_checks']}"
         )
         if semantic_summary["metric_summary"]:
             lines.append(f"  Metrics: {_format_semantic_metric_summary(semantic_summary['metric_summary'])}")
+        for surface, surface_report in sorted(session["semantic_proof"].get("report", {}).get("surfaces", {}).items()):
+            surface_summary = surface_report["summary"]
+            lines.append(
+                f"  {surface}: clean={surface_summary['clean_conversations']}, "
+                f"critical={surface_summary['critical_conversations']}, "
+                f"preserved_checks={surface_summary['preserved_checks']}, "
+                f"declared_loss_checks={surface_summary['declared_loss_checks']}, "
+                f"critical_loss_checks={surface_summary['critical_loss_checks']}"
+            )
     elif result.semantic_proof_status is OutcomeStatus.SKIP:
         lines.append("Semantic Proof: SKIPPED")
     if result.audit_status is OutcomeStatus.ERROR:
@@ -556,10 +567,10 @@ def generate_qa_markdown(result: QAResult, *, git_sha: str | None = None) -> str
         lines.append("")
         lines.append("| Metric | Value |")
         lines.append("| --- | ---: |")
-        lines.append(f"| Surface | {semantic_proof_report['surface']} |")
+        lines.append(f"| Surface count | {semantic_summary['surface_count']} |")
+        lines.append(f"| Clean surfaces | {semantic_summary['clean_surfaces']} |")
+        lines.append(f"| Critical surfaces | {semantic_summary['critical_surfaces']} |")
         lines.append(f"| Total conversations | {semantic_summary['total_conversations']} |")
-        lines.append(f"| Clean conversations | {semantic_summary['clean_conversations']} |")
-        lines.append(f"| Critical conversations | {semantic_summary['critical_conversations']} |")
         lines.append(f"| Preserved checks | {semantic_summary['preserved_checks']} |")
         lines.append(f"| Declared loss checks | {semantic_summary['declared_loss_checks']} |")
         lines.append(f"| Critical loss checks | {semantic_summary['critical_loss_checks']} |")
@@ -574,17 +585,31 @@ def generate_qa_markdown(result: QAResult, *, git_sha: str | None = None) -> str
                     f"| {metric} | {counts['preserved']} | {counts['declared_loss']} | {counts['critical_loss']} |"
                 )
             lines.append("")
-        if semantic_proof_report["providers"]:
-            lines.append("### Providers")
+        if semantic_proof_report["surfaces"]:
+            lines.append("### Surfaces")
             lines.append("")
-            lines.append("| Provider | Conversations | Clean | Critical | Preserved checks | Declared loss | Critical loss |")
+            lines.append("| Surface | Conversations | Clean | Critical | Preserved checks | Declared loss | Critical loss |")
             lines.append("| --- | ---: | ---: | ---: | ---: | ---: | ---: |")
-            for provider, stats in semantic_proof_report["providers"].items():
+            for surface, surface_report in semantic_proof_report["surfaces"].items():
+                surface_summary = surface_report["summary"]
                 lines.append(
-                    f"| {provider} | {stats['total_conversations']} | {stats['clean_conversations']} | "
-                    f"{stats['critical_conversations']} | {stats['preserved_checks']} | "
-                    f"{stats['declared_loss_checks']} | {stats['critical_loss_checks']} |"
+                    f"| {surface} | {surface_summary['total_conversations']} | "
+                    f"{surface_summary['clean_conversations']} | {surface_summary['critical_conversations']} | "
+                    f"{surface_summary['preserved_checks']} | {surface_summary['declared_loss_checks']} | "
+                    f"{surface_summary['critical_loss_checks']} |"
                 )
+            lines.append("")
+            lines.append("### Surface Providers")
+            lines.append("")
+            lines.append("| Surface | Provider | Conversations | Clean | Critical | Preserved checks | Declared loss | Critical loss |")
+            lines.append("| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |")
+            for surface, surface_report in semantic_proof_report["surfaces"].items():
+                for provider, stats in surface_report["providers"].items():
+                    lines.append(
+                        f"| {surface} | {provider} | {stats['total_conversations']} | {stats['clean_conversations']} | "
+                        f"{stats['critical_conversations']} | {stats['preserved_checks']} | "
+                        f"{stats['declared_loss_checks']} | {stats['critical_loss_checks']} |"
+                    )
             lines.append("")
     elif result.semantic_proof_error:
         lines.append("## Semantic Proof")

--- a/polylogue/showcase/report.py
+++ b/polylogue/showcase/report.py
@@ -84,6 +84,17 @@ def _format_count_mapping(counts: dict[str, int]) -> str:
     return ", ".join(f"{key}={value}" for key, value in sorted(counts.items()))
 
 
+def _format_semantic_metric_summary(metric_summary: dict[str, dict[str, int]]) -> str:
+    parts = []
+    for metric, counts in sorted(metric_summary.items()):
+        parts.append(
+            f"{metric}(preserved={counts.get('preserved', 0)}, "
+            f"declared_loss={counts.get('declared_loss', 0)}, "
+            f"critical_loss={counts.get('critical_loss', 0)})"
+        )
+    return ", ".join(parts)
+
+
 def generate_summary(result: ShowcaseResult) -> str:
     """Generate a human-readable summary table."""
     lines: list[str] = []
@@ -323,6 +334,13 @@ def generate_qa_session(result: QAResult) -> dict[str, Any]:
         proof_payload["report"] = result.proof_report.to_dict()
     if result.proof_error is not None:
         proof_payload["error"] = result.proof_error
+    semantic_proof_payload: dict[str, Any] = {
+        "status": result.semantic_proof_status.value,
+    }
+    if result.semantic_proof_report is not None:
+        semantic_proof_payload["report"] = result.semantic_proof_report.to_dict()
+    if result.semantic_proof_error is not None:
+        semantic_proof_payload["error"] = result.semantic_proof_error
 
     showcase_payload: dict[str, Any] = {
         "status": result.showcase_status.value,
@@ -337,6 +355,7 @@ def generate_qa_session(result: QAResult) -> dict[str, Any]:
         "timestamp": datetime.now(timezone.utc).isoformat(),
         "audit": audit_payload,
         "proof": proof_payload,
+        "semantic_proof": semantic_proof_payload,
         "showcase": showcase_payload,
         "invariants": {
             "status": result.invariant_status.value,
@@ -355,6 +374,7 @@ def generate_qa_summary(result: QAResult) -> str:
     session = generate_qa_session(result)
     lines: list[str] = []
     proof_summary = session["proof"].get("report", {}).get("summary")
+    semantic_summary = session["semantic_proof"].get("report", {}).get("summary")
 
     lines.append(f"Schema Audit: {_status_label(result.audit_status)}")
     if result.proof_error:
@@ -374,6 +394,21 @@ def generate_qa_summary(result: QAResult) -> str:
             lines.append(f"  Elements: {_format_count_mapping(proof_summary['element_kinds'])}")
         if proof_summary["resolution_reasons"]:
             lines.append(f"  Reasons: {_format_count_mapping(proof_summary['resolution_reasons'])}")
+    if result.semantic_proof_error:
+        lines.append(f"Semantic Proof: FAIL ({result.semantic_proof_error})")
+    elif semantic_summary is not None:
+        lines.append(
+            "Semantic Proof: "
+            f"clean_conversations={semantic_summary['clean_conversations']}, "
+            f"critical_conversations={semantic_summary['critical_conversations']}, "
+            f"preserved_checks={semantic_summary['preserved_checks']}, "
+            f"declared_loss_checks={semantic_summary['declared_loss_checks']}, "
+            f"critical_loss_checks={semantic_summary['critical_loss_checks']}"
+        )
+        if semantic_summary["metric_summary"]:
+            lines.append(f"  Metrics: {_format_semantic_metric_summary(semantic_summary['metric_summary'])}")
+    elif result.semantic_proof_status is OutcomeStatus.SKIP:
+        lines.append("Semantic Proof: SKIPPED")
     if result.audit_status is OutcomeStatus.ERROR:
         if result.audit_error:
             lines.append(f"  Error: {result.audit_error}")
@@ -430,6 +465,7 @@ def generate_qa_markdown(result: QAResult, *, git_sha: str | None = None) -> str
     lines.append("| --- | --- |")
     lines.append(f"| Schema Audit | {_status_label(result.audit_status)} |")
     lines.append(f"| Artifact Proof | {_status_label(result.proof_status)} |")
+    lines.append(f"| Semantic Proof | {_status_label(result.semantic_proof_status)} |")
     lines.append(f"| Exercises | {_status_label(result.showcase_status)} |")
     lines.append(f"| Invariants | {_status_label(result.invariant_status)} |")
     lines.append(f"| Overall | {_status_label(result.overall_status)} |")
@@ -511,6 +547,49 @@ def generate_qa_markdown(result: QAResult, *, git_sha: str | None = None) -> str
         lines.append("## Artifact Proof")
         lines.append("")
         lines.append(f"- Error: {result.proof_error}")
+        lines.append("")
+
+    semantic_proof_report = session["semantic_proof"].get("report")
+    if semantic_proof_report is not None:
+        semantic_summary = semantic_proof_report["summary"]
+        lines.append("## Semantic Proof")
+        lines.append("")
+        lines.append("| Metric | Value |")
+        lines.append("| --- | ---: |")
+        lines.append(f"| Surface | {semantic_proof_report['surface']} |")
+        lines.append(f"| Total conversations | {semantic_summary['total_conversations']} |")
+        lines.append(f"| Clean conversations | {semantic_summary['clean_conversations']} |")
+        lines.append(f"| Critical conversations | {semantic_summary['critical_conversations']} |")
+        lines.append(f"| Preserved checks | {semantic_summary['preserved_checks']} |")
+        lines.append(f"| Declared loss checks | {semantic_summary['declared_loss_checks']} |")
+        lines.append(f"| Critical loss checks | {semantic_summary['critical_loss_checks']} |")
+        lines.append("")
+        if semantic_summary["metric_summary"]:
+            lines.append("### Semantic Metrics")
+            lines.append("")
+            lines.append("| Metric | Preserved | Declared loss | Critical loss |")
+            lines.append("| --- | ---: | ---: | ---: |")
+            for metric, counts in semantic_summary["metric_summary"].items():
+                lines.append(
+                    f"| {metric} | {counts['preserved']} | {counts['declared_loss']} | {counts['critical_loss']} |"
+                )
+            lines.append("")
+        if semantic_proof_report["providers"]:
+            lines.append("### Providers")
+            lines.append("")
+            lines.append("| Provider | Conversations | Clean | Critical | Preserved checks | Declared loss | Critical loss |")
+            lines.append("| --- | ---: | ---: | ---: | ---: | ---: | ---: |")
+            for provider, stats in semantic_proof_report["providers"].items():
+                lines.append(
+                    f"| {provider} | {stats['total_conversations']} | {stats['clean_conversations']} | "
+                    f"{stats['critical_conversations']} | {stats['preserved_checks']} | "
+                    f"{stats['declared_loss_checks']} | {stats['critical_loss_checks']} |"
+                )
+            lines.append("")
+    elif result.semantic_proof_error:
+        lines.append("## Semantic Proof")
+        lines.append("")
+        lines.append(f"- Error: {result.semantic_proof_error}")
         lines.append("")
 
     showcase_summary = session["showcase"]["summary"]

--- a/polylogue/site/builder.py
+++ b/polylogue/site/builder.py
@@ -27,6 +27,7 @@ from polylogue.site.models import (
 from polylogue.site.publication_support import (
     build_latest_run_summary,
     load_artifact_proof_summary,
+    load_semantic_proof_summary,
 )
 from polylogue.site.rendering import (
     build_template_environments,
@@ -120,6 +121,7 @@ class SiteBuilder:
                 search_status = "json_index_written"
 
             proof_summary = await self._artifact_proof_summary()
+            semantic_summary = await self._semantic_proof_summary()
             latest_run = await self._latest_run_summary()
             artifact_manifest = await asyncio.to_thread(
                 OutputManifest.scan,
@@ -169,6 +171,7 @@ class SiteBuilder:
                 ),
                 latest_run=latest_run,
                 artifact_proof=proof_summary,
+                semantic_proof=semantic_summary,
                 artifacts=artifact_manifest,
             )
             manifest_path = self.output_dir / "site-manifest.json"
@@ -317,6 +320,16 @@ class SiteBuilder:
         if not isinstance(getattr(backend, "db_path", None), Path):
             return None
         return await asyncio.to_thread(load_artifact_proof_summary, db_path=backend.db_path)
+
+    async def _semantic_proof_summary(self):
+        """Return semantic-preservation proof summary for manifest embedding."""
+        backend, _repository = self._open_storage()
+        if not isinstance(getattr(backend, "db_path", None), Path):
+            return None
+        return await asyncio.to_thread(
+            load_semantic_proof_summary,
+            db_path=backend.db_path,
+        )
 
     def _search_markup(self) -> str:
         return render_search_markup(self.config)

--- a/polylogue/site/publication_support.py
+++ b/polylogue/site/publication_support.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from polylogue.publication import ArtifactProofSummary, PublicationRunSummary
+from polylogue.paths import archive_root as default_archive_root
+from polylogue.publication import (
+    ArtifactProofSummary,
+    PublicationRunSummary,
+    SemanticProofSummary,
+)
 from polylogue.storage.store import RunRecord
 
 
@@ -49,5 +54,31 @@ def load_artifact_proof_summary(*, db_path: Path) -> ArtifactProofSummary:
         package_versions=report.package_versions,
         element_kinds=report.element_kinds,
         resolution_reasons=report.resolution_reasons,
+        clean=report.is_clean,
+    )
+
+
+def load_semantic_proof_summary(
+    *,
+    db_path: Path,
+    archive_root: Path | None = None,
+) -> SemanticProofSummary:
+    """Load the semantic-preservation proof summary for publication embedding."""
+    from polylogue.rendering.semantic_proof import prove_markdown_render_semantics
+
+    report = prove_markdown_render_semantics(
+        db_path=db_path,
+        archive_root=archive_root or default_archive_root(),
+    )
+    return SemanticProofSummary(
+        surface=report.surface,
+        total_conversations=report.total_conversations,
+        provider_count=report.provider_count,
+        clean_conversations=report.clean_conversations,
+        critical_conversations=report.critical_conversations,
+        preserved_checks=report.preserved_checks,
+        declared_loss_checks=report.declared_loss_checks,
+        critical_loss_checks=report.critical_loss_checks,
+        metric_summary=report.metric_summary,
         clean=report.is_clean,
     )

--- a/polylogue/site/publication_support.py
+++ b/polylogue/site/publication_support.py
@@ -8,6 +8,7 @@ from polylogue.paths import archive_root as default_archive_root
 from polylogue.publication import (
     ArtifactProofSummary,
     PublicationRunSummary,
+    SemanticProofSuiteSummary,
     SemanticProofSummary,
 )
 from polylogue.storage.store import RunRecord
@@ -62,23 +63,37 @@ def load_semantic_proof_summary(
     *,
     db_path: Path,
     archive_root: Path | None = None,
-) -> SemanticProofSummary:
+) -> SemanticProofSuiteSummary:
     """Load the semantic-preservation proof summary for publication embedding."""
-    from polylogue.rendering.semantic_proof import prove_markdown_render_semantics
+    from polylogue.rendering.semantic_proof import prove_semantic_surface_suite
 
-    report = prove_markdown_render_semantics(
+    report = prove_semantic_surface_suite(
         db_path=db_path,
         archive_root=archive_root or default_archive_root(),
     )
-    return SemanticProofSummary(
-        surface=report.surface,
+    return SemanticProofSuiteSummary(
+        surface_count=report.surface_count,
+        clean_surfaces=report.clean_surfaces,
+        critical_surfaces=report.critical_surfaces,
         total_conversations=report.total_conversations,
-        provider_count=report.provider_count,
-        clean_conversations=report.clean_conversations,
-        critical_conversations=report.critical_conversations,
         preserved_checks=report.preserved_checks,
         declared_loss_checks=report.declared_loss_checks,
         critical_loss_checks=report.critical_loss_checks,
         metric_summary=report.metric_summary,
+        surfaces={
+            surface: SemanticProofSummary(
+                surface=surface,
+                total_conversations=surface_report.total_conversations,
+                provider_count=surface_report.provider_count,
+                clean_conversations=surface_report.clean_conversations,
+                critical_conversations=surface_report.critical_conversations,
+                preserved_checks=surface_report.preserved_checks,
+                declared_loss_checks=surface_report.declared_loss_checks,
+                critical_loss_checks=surface_report.critical_loss_checks,
+                metric_summary=surface_report.metric_summary,
+                clean=surface_report.is_clean,
+            )
+            for surface, surface_report in sorted(report.surfaces.items())
+        },
         clean=report.is_clean,
     )

--- a/polylogue/storage/artifact_observations.py
+++ b/polylogue/storage/artifact_observations.py
@@ -339,12 +339,25 @@ def ensure_artifact_observations(
     conn: sqlite3.Connection,
     *,
     providers: list[str] | None = None,
+    refresh_resolutions: bool = False,
 ) -> int:
-    """Backfill missing artifact observations from existing raw records."""
+    """Backfill or refresh durable artifact observations from raw records."""
     inserted = 0
+    last_rowid = 0
     while True:
-        where_clauses = ["o.observation_id IS NULL"]
-        params: list[Any] = []
+        state_clauses = ["o.observation_id IS NULL"]
+        if refresh_resolutions:
+            state_clauses.append(
+                "("
+                "o.observation_id IS NOT NULL AND "
+                "o.parse_as_conversation = 1 AND "
+                "o.schema_eligible = 1 AND "
+                "o.malformed_jsonl_lines = 0 AND "
+                "o.decode_error IS NULL"
+                ")"
+            )
+        where_clauses = [f"({' OR '.join(state_clauses)})", "r.rowid > ?"]
+        params: list[Any] = [last_rowid]
         if providers:
             placeholders = ",".join("?" for _ in providers)
             where_clauses.append(
@@ -353,7 +366,7 @@ def ensure_artifact_observations(
             params.extend(providers)
         rows = conn.execute(
             f"""
-            SELECT r.*
+            SELECT r.rowid AS raw_rowid, r.*
             FROM raw_conversations r
             LEFT JOIN artifact_observations o
               ON COALESCE(o.source_name, '') = COALESCE(r.source_name, '')
@@ -372,6 +385,7 @@ def ensure_artifact_observations(
             observation = inspect_raw_artifact(record)
             if _upsert_artifact_observation(conn, observation):
                 inserted += 1
+            last_rowid = max(last_rowid, int(row["raw_rowid"]))
         conn.commit()
     return inserted
 

--- a/polylogue/ui/tui/app.py
+++ b/polylogue/ui/tui/app.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from textual.app import App, ComposeResult
@@ -8,14 +7,6 @@ from textual.widgets import Footer, Header
 
 if TYPE_CHECKING:
     from polylogue.storage.repository import ConversationRepository
-    from polylogue.ui.tui.screens.base import RepositoryBoundContainer
-
-
-@dataclass(frozen=True)
-class ScreenSpec:
-    tab_id: str
-    tab_label: str
-    screen_type: type[RepositoryBoundContainer]
 
 
 class PolylogueApp(App[None]):
@@ -26,8 +17,6 @@ class PolylogueApp(App[None]):
         ("d", "toggle_dark", "Toggle dark mode"),
         ("q", "quit", "Quit"),
     ]
-
-    _SCREEN_SPECS: tuple[ScreenSpec, ...] = ()
 
     def __init__(
         self,
@@ -40,23 +29,21 @@ class PolylogueApp(App[None]):
         """Create child widgets for the app."""
         from textual.widgets import TabbedContent, TabPane
 
-        if not self._SCREEN_SPECS:
-            from polylogue.ui.tui.screens.browser import Browser
-            from polylogue.ui.tui.screens.dashboard import Dashboard
-            from polylogue.ui.tui.screens.search import Search
-
-            type(self)._SCREEN_SPECS = (
-                ScreenSpec("dashboard", "Mission Control", Dashboard),
-                ScreenSpec("browser", "Browser", Browser),
-                ScreenSpec("search", "Search", Search),
-            )
+        from polylogue.ui.tui.screens.browser import Browser
+        from polylogue.ui.tui.screens.dashboard import Dashboard
+        from polylogue.ui.tui.screens.search import Search
 
         yield Header()
 
-        with TabbedContent(initial=self._SCREEN_SPECS[0].tab_id):
-            for spec in self._SCREEN_SPECS:
-                with TabPane(spec.tab_label, id=spec.tab_id):
-                    yield spec.screen_type(repository=self._repository)
+        with TabbedContent(initial="dashboard"):
+            with TabPane("Mission Control", id="dashboard"):
+                yield Dashboard(repository=self._repository)
+
+            with TabPane("Browser", id="browser"):
+                yield Browser(repository=self._repository)
+
+            with TabPane("Search", id="search"):
+                yield Search(repository=self._repository)
 
         yield Footer()
 

--- a/polylogue/ui/tui/app.py
+++ b/polylogue/ui/tui/app.py
@@ -1,14 +1,21 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from textual.app import App, ComposeResult
 from textual.widgets import Footer, Header
 
-from polylogue.config import Config
-
 if TYPE_CHECKING:
     from polylogue.storage.repository import ConversationRepository
+    from polylogue.ui.tui.screens.base import RepositoryBoundContainer
+
+
+@dataclass(frozen=True)
+class ScreenSpec:
+    tab_id: str
+    tab_label: str
+    screen_type: type[RepositoryBoundContainer]
 
 
 class PolylogueApp(App[None]):
@@ -20,36 +27,36 @@ class PolylogueApp(App[None]):
         ("q", "quit", "Quit"),
     ]
 
+    _SCREEN_SPECS: tuple[ScreenSpec, ...] = ()
+
     def __init__(
         self,
-        config: Config | None = None,
         repository: ConversationRepository | None = None,
     ) -> None:
         super().__init__()
-        self.config = config
         self._repository = repository
 
     def compose(self) -> ComposeResult:
         """Create child widgets for the app."""
         from textual.widgets import TabbedContent, TabPane
 
-        from polylogue.ui.tui.screens.dashboard import Dashboard
+        if not self._SCREEN_SPECS:
+            from polylogue.ui.tui.screens.browser import Browser
+            from polylogue.ui.tui.screens.dashboard import Dashboard
+            from polylogue.ui.tui.screens.search import Search
+
+            type(self)._SCREEN_SPECS = (
+                ScreenSpec("dashboard", "Mission Control", Dashboard),
+                ScreenSpec("browser", "Browser", Browser),
+                ScreenSpec("search", "Search", Search),
+            )
 
         yield Header()
 
-        with TabbedContent(initial="dashboard"):
-            with TabPane("Mission Control", id="dashboard"):
-                yield Dashboard(config=self.config, repository=self._repository)
-
-            with TabPane("Browser", id="browser"):
-                from polylogue.ui.tui.screens.browser import Browser
-
-                yield Browser(config=self.config, repository=self._repository)
-
-            with TabPane("Search", id="search"):
-                from polylogue.ui.tui.screens.search import Search
-
-                yield Search(config=self.config, repository=self._repository)
+        with TabbedContent(initial=self._SCREEN_SPECS[0].tab_id):
+            for spec in self._SCREEN_SPECS:
+                with TabPane(spec.tab_label, id=spec.tab_id):
+                    yield spec.screen_type(repository=self._repository)
 
         yield Footer()
 

--- a/polylogue/ui/tui/screens/base.py
+++ b/polylogue/ui/tui/screens/base.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+from textual.containers import Container
+from textual.widgets import Markdown as MarkdownWidget
+
+from polylogue.config import Config
+from polylogue.rendering.core import format_conversation_markdown
+
+if TYPE_CHECKING:
+    from polylogue.lib.models import Conversation
+    from polylogue.storage.repository import ConversationRepository
+
+
+ConversationMarkdownFormatter = Callable[["Conversation"], str]
+
+
+class RepositoryBoundContainer(Container):
+    """Shared base for TUI screens backed by an injected repository."""
+
+    def __init__(
+        self,
+        config: Config | None = None,
+        repository: ConversationRepository | None = None,
+    ) -> None:
+        super().__init__()
+        self.config = config
+        self._repository = repository
+
+    def _get_repo(self, owner_name: str) -> ConversationRepository:
+        """Return the injected repository or fail with a screen-specific message."""
+        if self._repository is None:
+            raise RuntimeError(f"{owner_name} widget requires an injected repository")
+        return self._repository
+
+    async def _load_conversation_markdown(
+        self,
+        conversation_id: str,
+        *,
+        viewer_selector: str,
+        formatter: ConversationMarkdownFormatter = format_conversation_markdown,
+    ) -> bool:
+        """Load a conversation and update the target Markdown widget."""
+        repo = self._get_repo(type(self).__name__)
+        viewer = self.query_one(viewer_selector, MarkdownWidget)
+
+        conv = await repo.get_eager(conversation_id)
+        if not conv:
+            viewer.update(f"Error: Could not load {conversation_id}")
+            return False
+
+        viewer.update(formatter(conv))
+        return True
+
+
+__all__ = ["RepositoryBoundContainer"]

--- a/polylogue/ui/tui/screens/base.py
+++ b/polylogue/ui/tui/screens/base.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING
 from textual.containers import Container
 from textual.widgets import Markdown as MarkdownWidget
 
-from polylogue.config import Config
 from polylogue.rendering.core import format_conversation_markdown
 
 if TYPE_CHECKING:
@@ -22,11 +21,9 @@ class RepositoryBoundContainer(Container):
 
     def __init__(
         self,
-        config: Config | None = None,
         repository: ConversationRepository | None = None,
     ) -> None:
         super().__init__()
-        self.config = config
         self._repository = repository
 
     def _get_repo(self, owner_name: str) -> ConversationRepository:

--- a/polylogue/ui/tui/screens/browser.py
+++ b/polylogue/ui/tui/screens/browser.py
@@ -1,36 +1,15 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from textual.app import ComposeResult
-from textual.containers import Container, Horizontal, VerticalScroll
+from textual.containers import Horizontal, VerticalScroll
 from textual.widgets import Markdown as MarkdownWidget
 from textual.widgets import Tree
 
-from polylogue.config import Config
-from polylogue.rendering.core import format_conversation_markdown
-
-if TYPE_CHECKING:
-    from polylogue.storage.repository import ConversationRepository
+from polylogue.ui.tui.screens.base import RepositoryBoundContainer
 
 
-class Browser(Container):
+class Browser(RepositoryBoundContainer):
     """Browser widget for navigating conversations."""
-
-    def __init__(
-        self,
-        config: Config | None = None,
-        repository: ConversationRepository | None = None,
-    ) -> None:
-        super().__init__()
-        self.config = config
-        self._repository = repository
-
-    def _get_repo(self) -> ConversationRepository:
-        """Get the injected repository."""
-        if self._repository is None:
-            raise RuntimeError("Browser widget requires an injected repository")
-        return self._repository
 
     def compose(self) -> ComposeResult:
         with Horizontal():
@@ -44,7 +23,7 @@ class Browser(Container):
     async def _fetch_tree(self) -> None:
         """Fetch tree data asynchronously, then update DOM."""
         try:
-            repo = self._get_repo()
+            repo = self._get_repo("Browser")
 
             stats = await repo.get_archive_stats()
             providers = sorted(stats.providers.keys()) if stats.providers else []
@@ -83,12 +62,4 @@ class Browser(Container):
 
     async def load_conversation(self, conversation_id: str) -> None:
         """Load and display conversation content."""
-        repo = self._get_repo()
-
-        conv = await repo.get_eager(conversation_id)
-        if not conv:
-            self.query_one("#markdown-viewer", MarkdownWidget).update(f"Error: Could not load {conversation_id}")
-            return
-
-        md_text = format_conversation_markdown(conv)
-        self.query_one("#markdown-viewer", MarkdownWidget).update(md_text)
+        await self._load_conversation_markdown(conversation_id, viewer_selector="#markdown-viewer")

--- a/polylogue/ui/tui/screens/dashboard.py
+++ b/polylogue/ui/tui/screens/dashboard.py
@@ -2,18 +2,13 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from textual.app import ComposeResult
 from textual.containers import Container, Grid
 from textual.widgets import Static
 
-from polylogue.config import Config
 from polylogue.logging import get_logger
+from polylogue.ui.tui.screens.base import RepositoryBoundContainer
 from polylogue.ui.tui.widgets.stats import StatCard
-
-if TYPE_CHECKING:
-    from polylogue.storage.repository import ConversationRepository
 
 logger = get_logger(__name__)
 
@@ -49,7 +44,7 @@ class ProviderBar(Static):
         return f"{self.provider[:16]:<16} {bar} {self.count:>6}"
 
 
-class Dashboard(Container):
+class Dashboard(RepositoryBoundContainer):
     """Enhanced dashboard widget with embedding stats and provider breakdown."""
 
     DEFAULT_CSS = """
@@ -79,21 +74,6 @@ class Dashboard(Container):
     }
     """
 
-    def __init__(
-        self,
-        config: Config | None = None,
-        repository: ConversationRepository | None = None,
-    ) -> None:
-        super().__init__()
-        self.config = config
-        self._repository = repository
-
-    def _get_repo(self) -> ConversationRepository:
-        """Get the injected repository."""
-        if self._repository is None:
-            raise RuntimeError("Dashboard widget requires an injected repository")
-        return self._repository
-
     def compose(self) -> ComposeResult:
         # Grid for stats
         with Grid(id="stats-grid"):
@@ -115,7 +95,7 @@ class Dashboard(Container):
     async def _fetch_stats(self) -> None:
         """Fetch stats asynchronously, then update DOM."""
         try:
-            repo = self._get_repo()
+            repo = self._get_repo("Dashboard")
             stats = await repo.get_archive_stats()
         except Exception as e:
             self.notify(f"Failed to load stats: {e}", severity="error")

--- a/polylogue/ui/tui/screens/search.py
+++ b/polylogue/ui/tui/screens/search.py
@@ -1,37 +1,18 @@
 from __future__ import annotations
 
 import sqlite3
-from typing import TYPE_CHECKING
 
 from textual.app import ComposeResult
 from textual.containers import Container, Horizontal, Vertical
 from textual.widgets import DataTable, Input
 from textual.widgets import Markdown as MarkdownWidget
 
-from polylogue.config import Config
 from polylogue.errors import DatabaseError
-
-if TYPE_CHECKING:
-    from polylogue.storage.repository import ConversationRepository
+from polylogue.ui.tui.screens.base import RepositoryBoundContainer
 
 
-class Search(Container):
+class Search(RepositoryBoundContainer):
     """Search widget for finding conversations."""
-
-    def __init__(
-        self,
-        config: Config | None = None,
-        repository: ConversationRepository | None = None,
-    ) -> None:
-        super().__init__()
-        self.config = config
-        self._repository = repository
-
-    def _get_repo(self) -> ConversationRepository:
-        """Get the injected repository."""
-        if self._repository is None:
-            raise RuntimeError("Search widget requires an injected repository")
-        return self._repository
 
     def compose(self) -> ComposeResult:
         with Vertical():
@@ -52,7 +33,7 @@ class Search(Container):
         if not query:
             return
 
-        repo = self._get_repo()
+        repo = self._get_repo("Search")
 
         # Perform search
         table = self.query_one("#search-results", DataTable)
@@ -85,20 +66,5 @@ class Search(Container):
         await self.load_conversation(conv_id)
 
     async def load_conversation(self, conversation_id: str) -> None:
-        """Load and display conversation content (duplicate logic from Browser)."""
-        repo = self._get_repo()
-
-        conv = await repo.get_eager(conversation_id)
-        if not conv:
-            self.query_one("#search-viewer", MarkdownWidget).update(f"Error: Could not load {conversation_id}")
-            return
-
-        md_lines = [f"# {conv.title or 'Untitled'}", f"*{conv.created_at}*", ""]
-
-        for msg in conv.messages:
-            role_icon = "👤" if msg.role == "user" else "🤖"
-            md_lines.append(f"### {role_icon} {(msg.role or 'unknown').upper()}")
-            md_lines.append(msg.text or "*[No content]*")
-            md_lines.append("")
-
-        self.query_one("#search-viewer", MarkdownWidget).update("\n".join(md_lines))
+        """Load and display conversation content."""
+        await self._load_conversation_markdown(conversation_id, viewer_selector="#search-viewer")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,11 @@ markers = [
     "integration: marks integration tests (pipeline, CLI end-to-end)",
     "benchmark: marks benchmark tests (run with --benchmark-enable -p no:xdist -p no:randomly)",
     "scale(level): parametric scale marker (small/medium/large/stretch)",
+    "machine_contract: marks root CLI JSON success/failure contract tests",
+    "query_routing: marks query-first CLI routing and read-surface tests",
+    "tui: marks Textual Mission Control interaction tests",
+    "chaos: marks ingestion hostility, interruption, and chronology tests",
+    "live: marks operator-run live archive validation lanes",
 ]
 filterwarnings = [
     "ignore::ResourceWarning",           # Unclosed sqlite3 connections in thread-local backend

--- a/tests/baselines/showcase/help-check.txt
+++ b/tests/baselines/showcase/help-check.txt
@@ -19,8 +19,8 @@ Options:
   --proof                         Run durable artifact support proof
   --artifacts                     List durable artifact observations
   --cohorts                       Summarize durable artifact cohorts
-  --semantic-proof                Run semantic preservation proof over
-                                  canonical markdown rendering
+  --semantic-proof                Run semantic preservation proof across
+                                  canonical render and export surfaces
   --schema-provider TEXT          Limit schema verification to DB provider name
                                   (repeatable)
   --artifact-provider TEXT        Limit artifact proof/listing/cohorting to
@@ -35,6 +35,9 @@ Options:
                                   proof/listing/cohorting  [default: 0]
   --semantic-provider TEXT        Limit semantic proof to conversation
                                   providers (repeatable)
+  --semantic-surface TEXT         Limit semantic proof to surfaces such as
+                                  canonical, json, yaml, csv, markdown, html,
+                                  obsidian, org, or all
   --semantic-limit INTEGER        Limit semantic proof to N conversations
   --semantic-offset INTEGER       Start offset for semantic proof  [default: 0]
   --schema-samples TEXT           Validation samples per raw payload: positive

--- a/tests/baselines/showcase/help-check.txt
+++ b/tests/baselines/showcase/help-check.txt
@@ -16,8 +16,27 @@ Options:
                                   checks
   --schemas                       Run raw-corpus schema verification (non-
                                   mutating)
+  --proof                         Run durable artifact support proof
+  --artifacts                     List durable artifact observations
+  --cohorts                       Summarize durable artifact cohorts
+  --semantic-proof                Run semantic preservation proof over
+                                  canonical markdown rendering
   --schema-provider TEXT          Limit schema verification to DB provider name
                                   (repeatable)
+  --artifact-provider TEXT        Limit artifact proof/listing/cohorting to
+                                  effective provider (repeatable)
+  --artifact-status TEXT          Limit artifact listing/cohorting to support
+                                  status (repeatable)
+  --artifact-kind TEXT            Limit artifact listing/cohorting to artifact
+                                  kind (repeatable)
+  --artifact-limit INTEGER        Limit artifact proof/listing/cohorting to N
+                                  observation rows
+  --artifact-offset INTEGER       Start offset for artifact
+                                  proof/listing/cohorting  [default: 0]
+  --semantic-provider TEXT        Limit semantic proof to conversation
+                                  providers (repeatable)
+  --semantic-limit INTEGER        Limit semantic proof to N conversations
+  --semantic-offset INTEGER       Start offset for semantic proof  [default: 0]
   --schema-samples TEXT           Validation samples per raw payload: positive
                                   integer or 'all'  [default: all]
   --schema-record-limit INTEGER   Limit schema verification to N raw records

--- a/tests/baselines/showcase/help-check.txt
+++ b/tests/baselines/showcase/help-check.txt
@@ -20,7 +20,8 @@ Options:
   --artifacts                     List durable artifact observations
   --cohorts                       Summarize durable artifact cohorts
   --semantic-proof                Run semantic preservation proof across
-                                  canonical render and export surfaces
+                                  canonical, export, query, stream, and MCP
+                                  read surfaces
   --schema-provider TEXT          Limit schema verification to DB provider name
                                   (repeatable)
   --artifact-provider TEXT        Limit artifact proof/listing/cohorting to
@@ -35,9 +36,10 @@ Options:
                                   proof/listing/cohorting  [default: 0]
   --semantic-provider TEXT        Limit semantic proof to conversation
                                   providers (repeatable)
-  --semantic-surface TEXT         Limit semantic proof to surfaces such as
-                                  canonical, json, yaml, csv, markdown, html,
-                                  obsidian, org, or all
+  --semantic-surface TEXT         Limit semantic proof to
+                                  canonical/export/query/stream/MCP surfaces
+                                  such as canonical, export_all, query_all,
+                                  stream_all, mcp_all, read_all, or all
   --semantic-limit INTEGER        Limit semantic proof to N conversations
   --semantic-offset INTEGER       Start offset for semantic proof  [default: 0]
   --schema-samples TEXT           Validation samples per raw payload: positive

--- a/tests/infra/cli_subprocess.py
+++ b/tests/infra/cli_subprocess.py
@@ -16,7 +16,7 @@ import subprocess
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 
 @dataclass
@@ -39,6 +39,7 @@ def run_cli(
     env: dict[str, str] | None = None,
     cwd: Path | None = None,
     timeout: float = 60.0,
+    entrypoint: Literal["script", "module"] = "script",
 ) -> CliResult:
     """Run polylogue CLI as subprocess with isolated environment.
 
@@ -47,6 +48,8 @@ def run_cli(
         env: Environment variables to set (merged with minimal clean env)
         cwd: Working directory for the command
         timeout: Maximum execution time in seconds
+        entrypoint: ``script`` for the installed ``polylogue`` entrypoint,
+            ``module`` for ``python -m polylogue`` semantics
 
     Returns:
         CliResult with exit_code, stdout, stderr, and combined output
@@ -80,25 +83,47 @@ def run_cli(
     # arbitrary working directories via `cwd`.
     project_root = Path(__file__).parent.parent.parent
 
-    command = ["uv", "run", "--project", str(project_root), "polylogue"] + args
+    if entrypoint == "script":
+        command = ["uv", "run", "--project", str(project_root), "polylogue"] + args
+    elif entrypoint == "module":
+        command = [sys.executable, "-m", "polylogue"] + args
+    else:  # pragma: no cover - Literal keeps callers honest
+        raise ValueError(f"Unsupported entrypoint: {entrypoint}")
+
     if "MUTANT_UNDER_TEST" in clean_env:
         # Mutated subprocess code imports mutmut's trampoline helpers and
         # expects mutmut.config to be initialized before any mutated imports.
         project_root_literal = repr(str(project_root))
-        command = [
-            sys.executable,
-            "-c",
-            (
-                "import os, runpy, sys; "
-                "import mutmut.__main__ as _mutmut_main; "
-                "_mutmut_cwd = os.getcwd(); "
-                f"os.chdir({project_root_literal}); "
-                "_mutmut_main.ensure_config_loaded(); "
-                "os.chdir(_mutmut_cwd); "
-                "sys.argv = ['polylogue', *sys.argv[1:]]; "
-                "runpy.run_module('polylogue', run_name='__main__')"
-            ),
-        ] + args
+        if entrypoint == "script":
+            command = [
+                sys.executable,
+                "-c",
+                (
+                    "import os, runpy, sys; "
+                    "import mutmut.__main__ as _mutmut_main; "
+                    "_mutmut_cwd = os.getcwd(); "
+                    f"os.chdir({project_root_literal}); "
+                    "_mutmut_main.ensure_config_loaded(); "
+                    "os.chdir(_mutmut_cwd); "
+                    "sys.argv = ['polylogue', *sys.argv[1:]]; "
+                    "runpy.run_module('polylogue', run_name='__main__')"
+                ),
+            ] + args
+        else:
+            command = [
+                sys.executable,
+                "-c",
+                (
+                    "import os, runpy, sys; "
+                    "import mutmut.__main__ as _mutmut_main; "
+                    "_mutmut_cwd = os.getcwd(); "
+                    f"os.chdir({project_root_literal}); "
+                    "_mutmut_main.ensure_config_loaded(); "
+                    "os.chdir(_mutmut_cwd); "
+                    "sys.argv = ['polylogue', *sys.argv[1:]]; "
+                    "runpy.run_module('polylogue', run_name='__main__')"
+                ),
+            ] + args
 
     result = subprocess.run(
         command,

--- a/tests/integration/test_chronology_extremes.py
+++ b/tests/integration/test_chronology_extremes.py
@@ -14,7 +14,7 @@ import pytest
 from tests.infra.cli_subprocess import run_cli, setup_isolated_workspace
 from tests.infra.large_batches import generate_timestamp_patterns, write_jsonl_file
 
-pytestmark = pytest.mark.integration
+pytestmark = [pytest.mark.integration, pytest.mark.chaos]
 
 
 # =============================================================================

--- a/tests/integration/test_cli_machine_contract.py
+++ b/tests/integration/test_cli_machine_contract.py
@@ -1,0 +1,77 @@
+"""Subprocess proofs for the root CLI machine-error contract."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tests.infra.cli_subprocess import run_cli, setup_isolated_workspace
+
+pytestmark = [pytest.mark.integration, pytest.mark.machine_contract]
+
+
+def _parse_json(stdout: str) -> dict[str, object]:
+    return json.loads(stdout)
+
+
+def test_script_entrypoint_invalid_flag_emits_json_error(tmp_path):
+    workspace = setup_isolated_workspace(tmp_path)
+
+    result = run_cli(["check", "--json", "--bad-flag"], env=workspace["env"], cwd=tmp_path)
+
+    assert result.exit_code != 0
+    payload = _parse_json(result.stdout)
+    assert payload["status"] == "error"
+    assert payload["code"] == "invalid_arguments"
+    assert payload["details"] == {"option": "--bad-flag"}
+    assert "No such option" in str(payload["message"])
+    assert "No such option" not in result.stderr
+
+
+def test_module_entrypoint_invalid_flag_emits_json_error(tmp_path):
+    workspace = setup_isolated_workspace(tmp_path)
+
+    result = run_cli(
+        ["check", "--json", "--bad-flag"],
+        env=workspace["env"],
+        cwd=tmp_path,
+        entrypoint="module",
+    )
+
+    assert result.exit_code != 0
+    payload = _parse_json(result.stdout)
+    assert payload["status"] == "error"
+    assert payload["code"] == "invalid_arguments"
+    assert payload["details"] == {"option": "--bad-flag"}
+    assert "No such option" in str(payload["message"])
+    assert "No such option" not in result.stderr
+
+
+def test_module_entrypoint_command_validation_emits_json_error(tmp_path):
+    workspace = setup_isolated_workspace(tmp_path)
+
+    result = run_cli(
+        ["check", "--json", "--semantic-proof", "--semantic-limit", "0"],
+        env=workspace["env"],
+        cwd=tmp_path,
+        entrypoint="module",
+    )
+
+    assert result.exit_code != 0
+    payload = _parse_json(result.stdout)
+    assert payload["status"] == "error"
+    assert payload["code"] == "invalid_arguments"
+    assert "--semantic-limit must be a positive integer" in str(payload["message"])
+    assert "Traceback" not in result.stderr
+
+
+def test_script_entrypoint_success_still_uses_success_envelope(tmp_path):
+    workspace = setup_isolated_workspace(tmp_path)
+
+    result = run_cli(["check", "--json"], env=workspace["env"], cwd=tmp_path)
+
+    assert result.exit_code == 0, result.output
+    payload = _parse_json(result.stdout)
+    assert payload["status"] == "ok"
+    assert "result" in payload

--- a/tests/integration/test_cli_query_mode.py
+++ b/tests/integration/test_cli_query_mode.py
@@ -1,4 +1,4 @@
-"""End-to-end subprocess tests for query-first CLI behavior."""
+"""End-to-end subprocess proofs for query-first CLI route selection."""
 
 from __future__ import annotations
 
@@ -7,142 +7,94 @@ import json
 import pytest
 
 from tests.infra.cli_subprocess import run_cli, setup_isolated_workspace
-from tests.infra.source_builders import GenericConversationBuilder
+from tests.infra.source_builders import GenericConversationBuilder, InboxBuilder
+
+pytestmark = [pytest.mark.integration, pytest.mark.query_routing]
 
 
-@pytest.mark.integration
-def test_cli_run_and_search(tmp_path):
-    workspace = setup_isolated_workspace(tmp_path)
-    env = workspace["env"]
-    paths = workspace["paths"]
-    inbox = paths["inbox"]
-
-    GenericConversationBuilder("conv1").add_user("hello").add_assistant("world").write_to(inbox / "conversation.json")
-
-    result = run_cli(["--plain", "run", "--stage", "all"], env=env, cwd=tmp_path)
+def _run_inbox(workspace, *, cwd) -> None:
+    result = run_cli(["--plain", "run", "--source", "inbox", "--stage", "all"], env=workspace["env"], cwd=cwd)
     assert result.exit_code == 0, result.output
-    assert any(paths["render_root"].rglob("*.html")) or any(paths["render_root"].rglob("*.md"))
-
-    latest_result = run_cli(["--plain", "--latest"], env=env, cwd=tmp_path)
-    assert latest_result.exit_code in (0, 2)
-
-    search_result = run_cli(["--plain", "hello", "--limit", "1", "-f", "json", "--list"], env=env, cwd=tmp_path)
-    assert search_result.exit_code in (0, 2)
-    if search_result.exit_code == 0:
-        payload = json.loads(search_result.stdout.strip())
-        assert payload and isinstance(payload, list)
 
 
-@pytest.mark.integration
-def test_cli_search_csv_header(tmp_path):
+def test_cli_query_count_route_returns_exact_count(tmp_path):
     workspace = setup_isolated_workspace(tmp_path)
-    env = workspace["env"]
-    output = tmp_path / "out.csv"
-    result = run_cli(["--plain", "missing", "--csv", str(output)], env=env, cwd=tmp_path)
-    assert result.exit_code in (0, 2)
-    if output.exists():
-        header = output.read_text(encoding="utf-8").splitlines()[0]
-        assert header.startswith("source,provider,conversation_id,message_id")
+    inbox = workspace["paths"]["inbox"]
 
-
-@pytest.mark.integration
-def test_cli_search_latest_missing_render(tmp_path):
-    workspace = setup_isolated_workspace(tmp_path)
-    env = workspace["env"]
-    result = run_cli(["--plain", "--latest", "--open"], env=env, cwd=tmp_path)
-    assert result.exit_code != 0
-    output_lower = result.output.lower()
-    assert (
-        "no rendered" in output_lower
-        or "no conversation" in output_lower
-        or "no results" in output_lower
-        or result.exit_code == 2
+    GenericConversationBuilder("conv-count").title("Count Route").add_user("alpha route").add_assistant("beta").write_to(
+        inbox / "conversation.json"
     )
+    _run_inbox(workspace, cwd=tmp_path)
 
+    result = run_cli(["--plain", "alpha", "--count"], env=workspace["env"], cwd=tmp_path)
 
-@pytest.mark.integration
-def test_cli_search_open_prefers_html(tmp_path):
-    workspace = setup_isolated_workspace(tmp_path)
-    env = workspace["env"]
-    paths = workspace["paths"]
-    inbox = paths["inbox"]
-
-    GenericConversationBuilder("conv-html").add_user("hello html").write_to(inbox / "conversation.json")
-
-    result = run_cli(["--plain", "run", "--stage", "all"], env=env, cwd=tmp_path)
     assert result.exit_code == 0, result.output
-    assert list(paths["render_root"].rglob("*.html"))
-
-    search_result = run_cli(["--plain", "hello", "--limit", "1"], env=env, cwd=tmp_path)
-    assert search_result.exit_code in (0, 2)
+    assert result.stdout.strip() == "1"
 
 
-@pytest.mark.integration
-def test_cli_config_set_invalid(tmp_path):
+def test_cli_query_summary_list_json_route_returns_structured_rows(tmp_path):
     workspace = setup_isolated_workspace(tmp_path)
-    env = workspace["env"]
-    result = run_cli(["config", "set", "unknown.key", "value"], env=env, cwd=tmp_path)
-    assert result.exit_code != 0
-    result = run_cli(["config", "set", "source.missing.type", "auto"], env=env, cwd=tmp_path)
-    assert result.exit_code != 0
+    inbox = workspace["paths"]["inbox"]
 
-
-@pytest.mark.integration
-def test_cli_search_latest_returns_path_without_open(tmp_path):
-    workspace = setup_isolated_workspace(tmp_path)
-    env = workspace["env"]
-    paths = workspace["paths"]
-    inbox = paths["inbox"]
-
-    GenericConversationBuilder("conv1-abc123").add_user("test content").write_to(inbox / "conversation.json")
-
-    run_result = run_cli(["--plain", "run", "--stage", "all"], env=env, cwd=tmp_path)
-    assert run_result.exit_code == 0, run_result.output
-
-    result = run_cli(["--plain", "--latest"], env=env, cwd=tmp_path)
-    assert result.exit_code in (0, 2)
-
-
-@pytest.mark.integration
-def test_cli_query_latest_with_query(tmp_path):
-    workspace = setup_isolated_workspace(tmp_path)
-    env = workspace["env"]
-    result = run_cli(["--plain", "some", "query", "--latest"], env=env, cwd=tmp_path)
-    assert result.exit_code in (0, 2)
-
-
-@pytest.mark.integration
-def test_cli_query_latest_with_json(tmp_path):
-    workspace = setup_isolated_workspace(tmp_path)
-    env = workspace["env"]
-    result = run_cli(["--plain", "--latest", "-f", "json"], env=env, cwd=tmp_path)
-    assert result.exit_code in (0, 2)
-
-
-@pytest.mark.integration
-def test_cli_no_args_shows_stats(tmp_path):
-    workspace = setup_isolated_workspace(tmp_path)
-    env = workspace["env"]
-    result = run_cli(["--plain"], env=env, cwd=tmp_path)
-    assert result.exit_code == 0
-
-
-@pytest.mark.integration
-def test_cli_search_open_missing_render_shows_hint(tmp_path):
-    workspace = setup_isolated_workspace(tmp_path)
-    env = workspace["env"]
-    paths = workspace["paths"]
-    inbox = paths["inbox"]
-
-    GenericConversationBuilder("conv-no-render").add_user("no render").write_to(inbox / "conversation.json")
-
-    result = run_cli(["--plain", "run", "--stage", "parse"], env=env, cwd=tmp_path)
-    assert result.exit_code == 0
-
-    search_result = run_cli(["--plain", "render", "--open"], env=env, cwd=tmp_path)
-    assert (
-        search_result.exit_code == 0
-        or search_result.exit_code == 2
-        or "render" in search_result.output.lower()
-        or "run" in search_result.output.lower()
+    GenericConversationBuilder("conv-list").title("List Route").add_user("searchable alpha").add_assistant("response").write_to(
+        inbox / "conversation.json"
     )
+    _run_inbox(workspace, cwd=tmp_path)
+
+    result = run_cli(["--plain", "searchable", "--list", "-f", "json"], env=workspace["env"], cwd=tmp_path)
+
+    assert result.exit_code == 0, result.output
+    rows = json.loads(result.stdout)
+    assert len(rows) == 1
+    assert str(rows[0]["id"]).endswith("conv-list")
+    assert rows[0]["title"] == "List Route"
+
+
+def test_cli_query_stream_route_emits_json_lines_header_messages_footer(tmp_path):
+    workspace = setup_isolated_workspace(tmp_path)
+    inbox = workspace["paths"]["inbox"]
+
+    GenericConversationBuilder("conv-stream").title("Stream Route").add_user("stream alpha").add_assistant("stream beta").write_to(
+        inbox / "conversation.json"
+    )
+    _run_inbox(workspace, cwd=tmp_path)
+
+    result = run_cli(["--plain", "--latest", "--stream", "-f", "json"], env=workspace["env"], cwd=tmp_path)
+
+    assert result.exit_code == 0, result.output
+    records = [json.loads(line) for line in result.stdout.splitlines() if line.strip()]
+    assert records[0]["type"] == "header"
+    assert str(records[0]["conversation_id"]).endswith("conv-stream")
+    assert [record["type"] for record in records[1:-1]] == ["message", "message"]
+    assert records[-1] == {"type": "footer", "message_count": 2}
+
+
+def test_cli_query_stats_by_provider_reports_provider_groups(tmp_path):
+    workspace = setup_isolated_workspace(tmp_path)
+    inbox = workspace["paths"]["inbox"]
+
+    (
+        InboxBuilder(inbox)
+        .add_chatgpt_export("conv-chatgpt", title="ChatGPT Route")
+        .add_codex_conversation("conv-codex", title="Codex Route")
+        .build()
+    )
+    _run_inbox(workspace, cwd=tmp_path)
+
+    result = run_cli(["--plain", "--stats-by", "provider"], env=workspace["env"], cwd=tmp_path)
+
+    assert result.exit_code == 0, result.output
+    output = result.output.lower()
+    assert "matched: 2 conversations" in output
+    assert "chatgpt" in output
+    assert "unknown" in output
+
+
+def test_cli_no_args_stats_surface_still_works(tmp_path):
+    workspace = setup_isolated_workspace(tmp_path)
+
+    result = run_cli(["--plain"], env=workspace["env"], cwd=tmp_path)
+
+    assert result.exit_code == 0, result.output
+    assert "archive:" in result.output.lower()
+    assert "sources:" in result.output.lower()

--- a/tests/integration/test_ingestion_chaos.py
+++ b/tests/integration/test_ingestion_chaos.py
@@ -18,7 +18,7 @@ from tests.infra.chaos_sources import (
 )
 from tests.infra.cli_subprocess import run_cli, setup_isolated_workspace
 
-pytestmark = pytest.mark.integration
+pytestmark = [pytest.mark.integration, pytest.mark.chaos]
 
 
 # =============================================================================

--- a/tests/integration/test_ingestion_interrupts.py
+++ b/tests/integration/test_ingestion_interrupts.py
@@ -17,7 +17,7 @@ import pytest
 from tests.infra.chaos_sources import ChaosInboxBuilder
 from tests.infra.cli_subprocess import setup_isolated_workspace
 
-pytestmark = pytest.mark.integration
+pytestmark = [pytest.mark.integration, pytest.mark.chaos]
 
 
 # =============================================================================

--- a/tests/unit/cli/__snapshots__/test_terminal_snapshots.ambr
+++ b/tests/unit/cli/__snapshots__/test_terminal_snapshots.ambr
@@ -19,8 +19,28 @@
                                     checks
     --schemas                       Run raw-corpus schema verification (non-
                                     mutating)
+    --proof                         Run durable artifact support proof
+    --artifacts                     List durable artifact observations
+    --cohorts                       Summarize durable artifact cohorts
+    --semantic-proof                Run semantic preservation proof over
+                                    canonical markdown rendering
     --schema-provider TEXT          Limit schema verification to DB provider
                                     name (repeatable)
+    --artifact-provider TEXT        Limit artifact proof<PATH> to
+                                    effective provider (repeatable)
+    --artifact-status TEXT          Limit artifact listing<PATH> to support
+                                    status (repeatable)
+    --artifact-kind TEXT            Limit artifact listing<PATH> to artifact
+                                    kind (repeatable)
+    --artifact-limit INTEGER        Limit artifact proof<PATH> to N
+                                    observation rows
+    --artifact-offset INTEGER       Start offset for artifact
+                                    proof<PATH>  [default: 0]
+    --semantic-provider TEXT        Limit semantic proof to conversation
+                                    providers (repeatable)
+    --semantic-limit INTEGER        Limit semantic proof to N conversations
+    --semantic-offset INTEGER       Start offset for semantic proof  [default:
+                                    0]
     --schema-samples TEXT           Validation samples per raw payload: positive
                                     integer or 'all'  [default: all]
     --schema-record-limit INTEGER   Limit schema verification to N raw records

--- a/tests/unit/cli/__snapshots__/test_terminal_snapshots.ambr
+++ b/tests/unit/cli/__snapshots__/test_terminal_snapshots.ambr
@@ -22,8 +22,8 @@
     --proof                         Run durable artifact support proof
     --artifacts                     List durable artifact observations
     --cohorts                       Summarize durable artifact cohorts
-    --semantic-proof                Run semantic preservation proof over
-                                    canonical markdown rendering
+    --semantic-proof                Run semantic preservation proof across
+                                    canonical render and export surfaces
     --schema-provider TEXT          Limit schema verification to DB provider
                                     name (repeatable)
     --artifact-provider TEXT        Limit artifact proof<PATH> to
@@ -38,6 +38,9 @@
                                     proof<PATH>  [default: 0]
     --semantic-provider TEXT        Limit semantic proof to conversation
                                     providers (repeatable)
+    --semantic-surface TEXT         Limit semantic proof to surfaces such as
+                                    canonical, json, yaml, csv, markdown, html,
+                                    obsidian, org, or all
     --semantic-limit INTEGER        Limit semantic proof to N conversations
     --semantic-offset INTEGER       Start offset for semantic proof  [default:
                                     0]

--- a/tests/unit/cli/__snapshots__/test_terminal_snapshots.ambr
+++ b/tests/unit/cli/__snapshots__/test_terminal_snapshots.ambr
@@ -23,7 +23,8 @@
     --artifacts                     List durable artifact observations
     --cohorts                       Summarize durable artifact cohorts
     --semantic-proof                Run semantic preservation proof across
-                                    canonical render and export surfaces
+                                    canonical, export, query, stream, and MCP
+                                    read surfaces
     --schema-provider TEXT          Limit schema verification to DB provider
                                     name (repeatable)
     --artifact-provider TEXT        Limit artifact proof<PATH> to
@@ -38,9 +39,10 @@
                                     proof<PATH>  [default: 0]
     --semantic-provider TEXT        Limit semantic proof to conversation
                                     providers (repeatable)
-    --semantic-surface TEXT         Limit semantic proof to surfaces such as
-                                    canonical, json, yaml, csv, markdown, html,
-                                    obsidian, org, or all
+    --semantic-surface TEXT         Limit semantic proof to
+                                    canonical<PATH> surfaces
+                                    such as canonical, export_all, query_all,
+                                    stream_all, mcp_all, read_all, or all
     --semantic-limit INTEGER        Limit semantic proof to N conversations
     --semantic-offset INTEGER       Start offset for semantic proof  [default:
                                     0]

--- a/tests/unit/cli/test_check.py
+++ b/tests/unit/cli/test_check.py
@@ -15,6 +15,7 @@ from polylogue.rendering.semantic_proof import (
     SemanticConversationProof,
     SemanticMetricCheck,
     SemanticProofReport,
+    SemanticProofSuiteReport,
 )
 from polylogue.schemas.verification import ArtifactProofReport, ProviderArtifactProof
 from polylogue.storage.backends.connection import open_connection
@@ -44,7 +45,7 @@ def _extract_json(output: str) -> dict:
     return data
 
 
-def _make_semantic_report(*, critical: bool = False) -> SemanticProofReport:
+def _make_semantic_report(*, critical: bool = False) -> SemanticProofSuiteReport:
     checks = [
         SemanticMetricCheck(
             metric="renderable_messages",
@@ -61,7 +62,7 @@ def _make_semantic_report(*, critical: bool = False) -> SemanticProofReport:
             output_value=0,
         ),
     ]
-    return SemanticProofReport(
+    canonical_report = SemanticProofReport(
         surface="canonical_markdown_v1",
         conversations=[
             SemanticConversationProof(
@@ -95,6 +96,63 @@ def _make_semantic_report(*, critical: bool = False) -> SemanticProofReport:
                     },
                 },
             )
+        },
+    )
+    html_report = SemanticProofReport(
+        surface="export_html_v1",
+        conversations=[
+            SemanticConversationProof(
+                conversation_id="conv-1",
+                provider="chatgpt",
+                surface="export_html_v1",
+                input_facts={"text_messages": 2},
+                output_facts={"message_sections": 1 if critical else 2},
+                checks=[
+                    SemanticMetricCheck(
+                        metric="text_messages",
+                        status="critical_loss" if critical else "preserved",
+                        policy="export_html_v1 must preserve visible message sections for text-bearing messages",
+                        input_value=2,
+                        output_value=1 if critical else 2,
+                    ),
+                    SemanticMetricCheck(
+                        metric="branch_structure",
+                        status="preserved",
+                        policy="export_html_v1 must preserve visible branch groupings for branched messages",
+                        input_value=0,
+                        output_value=0,
+                    ),
+                ],
+            )
+        ],
+        provider_reports={
+            "chatgpt": ProviderSemanticProof(
+                provider="chatgpt",
+                total_conversations=1,
+                clean_conversations=0 if critical else 1,
+                critical_conversations=1 if critical else 0,
+                preserved_checks=1 if critical else 2,
+                declared_loss_checks=0,
+                critical_loss_checks=1 if critical else 0,
+                metric_summary={
+                    "text_messages": {
+                        "preserved": 0 if critical else 1,
+                        "declared_loss": 0,
+                        "critical_loss": 1 if critical else 0,
+                    },
+                    "branch_structure": {
+                        "preserved": 1,
+                        "declared_loss": 0,
+                        "critical_loss": 0,
+                    },
+                },
+            )
+        },
+    )
+    return SemanticProofSuiteReport(
+        surface_reports={
+            "canonical_markdown_v1": canonical_report,
+            "export_html_v1": html_report,
         },
     )
 
@@ -458,6 +516,7 @@ class TestCheckCommandSupplementary:
         (["check", "--schema-record-offset", "10"], "--schema-record-offset requires --schemas"),
         (["check", "--schema-quarantine-malformed"], "--schema-quarantine-malformed requires --schemas"),
         (["check", "--semantic-provider", "chatgpt"], "--semantic-provider requires --semantic-proof"),
+        (["check", "--semantic-surface", "html"], "--semantic-surface requires --semantic-proof"),
         (["check", "--semantic-limit", "10"], "--semantic-limit requires --semantic-proof"),
         (["check", "--semantic-offset", "10"], "--semantic-offset requires --semantic-proof"),
         (["check", "--schemas", "--schema-samples", "0"], "--schema-samples must be a positive integer or 'all'"),
@@ -766,7 +825,7 @@ class TestCheckCommandSupplementary:
         fake_report = _make_semantic_report()
 
         with patch(
-            "polylogue.rendering.semantic_proof.prove_markdown_render_semantics",
+            "polylogue.rendering.semantic_proof.prove_semantic_surface_suite",
             return_value=fake_report,
         ):
             runner = CliRunner()
@@ -775,9 +834,10 @@ class TestCheckCommandSupplementary:
         assert result.exit_code == 0
         data = _extract_json(result.output)
         assert "semantic_proof" in data
-        assert data["semantic_proof"]["surface"] == "canonical_markdown_v1"
-        assert data["semantic_proof"]["summary"]["clean_conversations"] == 1
+        assert data["semantic_proof"]["summary"]["surface_count"] == 2
+        assert data["semantic_proof"]["summary"]["clean_surfaces"] == 2
         assert data["semantic_proof"]["summary"]["metric_summary"]["thinking_semantics"]["declared_loss"] == 1
+        assert "export_html_v1" in data["semantic_proof"]["surfaces"]
 
     def test_check_semantic_proof_plain_output(self, cli_workspace):
         """--semantic-proof renders the semantic proof summary in plain output."""
@@ -788,7 +848,7 @@ class TestCheckCommandSupplementary:
         fake_report = _make_semantic_report(critical=True)
 
         with patch(
-            "polylogue.rendering.semantic_proof.prove_markdown_render_semantics",
+            "polylogue.rendering.semantic_proof.prove_semantic_surface_suite",
             return_value=fake_report,
         ):
             runner = CliRunner()
@@ -796,12 +856,14 @@ class TestCheckCommandSupplementary:
 
         assert result.exit_code == 0
         assert "Semantic proof:" in result.output
-        assert "critical=1" in result.output
+        assert "critical=2" in result.output
         assert "renderable_messages(preserved=0, declared_loss=0, critical_loss=1)" in result.output
+        assert "canonical_markdown_v1: conversations=1 clean=0 critical=1" in result.output
+        assert "export_html_v1: conversations=1 clean=0 critical=1" in result.output
         assert "chatgpt: conversations=1 clean=0 critical=1" in result.output
 
     def test_check_semantic_proof_forwards_scope(self, cli_workspace):
-        """Semantic provider/limit/offset are forwarded to the proof workflow."""
+        """Semantic provider/surface/limit/offset are forwarded to the proof workflow."""
         from click.testing import CliRunner
 
         from polylogue.cli.click_app import cli
@@ -809,7 +871,7 @@ class TestCheckCommandSupplementary:
         fake_report = _make_semantic_report()
 
         with patch(
-            "polylogue.rendering.semantic_proof.prove_markdown_render_semantics",
+            "polylogue.rendering.semantic_proof.prove_semantic_surface_suite",
             return_value=fake_report,
         ) as mock_prove:
             runner = CliRunner()
@@ -822,6 +884,8 @@ class TestCheckCommandSupplementary:
                     "--semantic-proof",
                     "--semantic-provider",
                     "chatgpt",
+                    "--semantic-surface",
+                    "html",
                     "--semantic-limit",
                     "25",
                     "--semantic-offset",
@@ -832,6 +896,7 @@ class TestCheckCommandSupplementary:
         assert result.exit_code == 0
         mock_prove.assert_called_once_with(
             providers=["chatgpt"],
+            surfaces=["html"],
             record_limit=25,
             record_offset=50,
         )

--- a/tests/unit/cli/test_check.py
+++ b/tests/unit/cli/test_check.py
@@ -10,6 +10,12 @@ from click.testing import CliRunner
 
 from polylogue.cli import cli
 from polylogue.health import HealthCheck, HealthReport, VerifyStatus
+from polylogue.rendering.semantic_proof import (
+    ProviderSemanticProof,
+    SemanticConversationProof,
+    SemanticMetricCheck,
+    SemanticProofReport,
+)
 from polylogue.schemas.verification import ArtifactProofReport, ProviderArtifactProof
 from polylogue.storage.backends.connection import open_connection
 from polylogue.storage.store import ArtifactCohortSummary, ArtifactObservationRecord
@@ -36,6 +42,61 @@ def _extract_json(output: str) -> dict:
     if isinstance(data, dict) and data.get("status") == "ok" and "result" in data:
         return data["result"]
     return data
+
+
+def _make_semantic_report(*, critical: bool = False) -> SemanticProofReport:
+    checks = [
+        SemanticMetricCheck(
+            metric="renderable_messages",
+            status="critical_loss" if critical else "preserved",
+            policy="canonical markdown must preserve every renderable message section",
+            input_value=2,
+            output_value=1 if critical else 2,
+        ),
+        SemanticMetricCheck(
+            metric="thinking_semantics",
+            status="declared_loss",
+            policy="canonical markdown preserves display text but not typed thinking markers",
+            input_value=1,
+            output_value=0,
+        ),
+    ]
+    return SemanticProofReport(
+        surface="canonical_markdown_v1",
+        conversations=[
+            SemanticConversationProof(
+                conversation_id="conv-1",
+                provider="chatgpt",
+                surface="canonical_markdown_v1",
+                input_facts={"renderable_messages": 2},
+                output_facts={"message_sections": 1 if critical else 2},
+                checks=checks,
+            )
+        ],
+        provider_reports={
+            "chatgpt": ProviderSemanticProof(
+                provider="chatgpt",
+                total_conversations=1,
+                clean_conversations=0 if critical else 1,
+                critical_conversations=1 if critical else 0,
+                preserved_checks=0 if critical else 1,
+                declared_loss_checks=1,
+                critical_loss_checks=1 if critical else 0,
+                metric_summary={
+                    "renderable_messages": {
+                        "preserved": 0 if critical else 1,
+                        "declared_loss": 0,
+                        "critical_loss": 1 if critical else 0,
+                    },
+                    "thinking_semantics": {
+                        "preserved": 0,
+                        "declared_loss": 1,
+                        "critical_loss": 0,
+                    },
+                },
+            )
+        },
+    )
 
 
 class TestHealthReportConstruction:
@@ -396,9 +457,14 @@ class TestCheckCommandSupplementary:
         (["check", "--schema-record-limit", "100"], "--schema-record-limit requires --schemas"),
         (["check", "--schema-record-offset", "10"], "--schema-record-offset requires --schemas"),
         (["check", "--schema-quarantine-malformed"], "--schema-quarantine-malformed requires --schemas"),
+        (["check", "--semantic-provider", "chatgpt"], "--semantic-provider requires --semantic-proof"),
+        (["check", "--semantic-limit", "10"], "--semantic-limit requires --semantic-proof"),
+        (["check", "--semantic-offset", "10"], "--semantic-offset requires --semantic-proof"),
         (["check", "--schemas", "--schema-samples", "0"], "--schema-samples must be a positive integer or 'all'"),
         (["check", "--schemas", "--schema-record-limit", "0"], "--schema-record-limit must be a positive integer"),
         (["check", "--schemas", "--schema-record-offset", "-1"], "--schema-record-offset must be >= 0"),
+        (["check", "--semantic-proof", "--semantic-limit", "0"], "--semantic-limit must be a positive integer"),
+        (["check", "--semantic-proof", "--semantic-offset", "-1"], "--semantic-offset must be >= 0"),
     ]
 
     @pytest.mark.parametrize("args,expected_error", INVALID_FLAG_COMBOS)
@@ -687,6 +753,85 @@ class TestCheckCommandSupplementary:
         assert result.exit_code == 0
         mock_prove.assert_called_once_with(
             providers=["claude-code"],
+            record_limit=25,
+            record_offset=50,
+        )
+
+    def test_check_semantic_proof_json_output(self, cli_workspace):
+        """--semantic-proof adds semantic_proof block to JSON output."""
+        from click.testing import CliRunner
+
+        from polylogue.cli.click_app import cli
+
+        fake_report = _make_semantic_report()
+
+        with patch(
+            "polylogue.rendering.semantic_proof.prove_markdown_render_semantics",
+            return_value=fake_report,
+        ):
+            runner = CliRunner()
+            result = runner.invoke(cli, ["--plain", "check", "--json", "--semantic-proof"])
+
+        assert result.exit_code == 0
+        data = _extract_json(result.output)
+        assert "semantic_proof" in data
+        assert data["semantic_proof"]["surface"] == "canonical_markdown_v1"
+        assert data["semantic_proof"]["summary"]["clean_conversations"] == 1
+        assert data["semantic_proof"]["summary"]["metric_summary"]["thinking_semantics"]["declared_loss"] == 1
+
+    def test_check_semantic_proof_plain_output(self, cli_workspace):
+        """--semantic-proof renders the semantic proof summary in plain output."""
+        from click.testing import CliRunner
+
+        from polylogue.cli.click_app import cli
+
+        fake_report = _make_semantic_report(critical=True)
+
+        with patch(
+            "polylogue.rendering.semantic_proof.prove_markdown_render_semantics",
+            return_value=fake_report,
+        ):
+            runner = CliRunner()
+            result = runner.invoke(cli, ["--plain", "check", "--semantic-proof"])
+
+        assert result.exit_code == 0
+        assert "Semantic proof:" in result.output
+        assert "critical=1" in result.output
+        assert "renderable_messages(preserved=0, declared_loss=0, critical_loss=1)" in result.output
+        assert "chatgpt: conversations=1 clean=0 critical=1" in result.output
+
+    def test_check_semantic_proof_forwards_scope(self, cli_workspace):
+        """Semantic provider/limit/offset are forwarded to the proof workflow."""
+        from click.testing import CliRunner
+
+        from polylogue.cli.click_app import cli
+
+        fake_report = _make_semantic_report()
+
+        with patch(
+            "polylogue.rendering.semantic_proof.prove_markdown_render_semantics",
+            return_value=fake_report,
+        ) as mock_prove:
+            runner = CliRunner()
+            result = runner.invoke(
+                cli,
+                [
+                    "--plain",
+                    "check",
+                    "--json",
+                    "--semantic-proof",
+                    "--semantic-provider",
+                    "chatgpt",
+                    "--semantic-limit",
+                    "25",
+                    "--semantic-offset",
+                    "50",
+                ],
+            )
+
+        assert result.exit_code == 0
+        mock_prove.assert_called_once_with(
+            providers=["chatgpt"],
             record_limit=25,
             record_offset=50,
         )

--- a/tests/unit/cli/test_check_runtime.py
+++ b/tests/unit/cli/test_check_runtime.py
@@ -15,15 +15,14 @@ Validates health checks for the runtime environment, including:
 from __future__ import annotations
 
 import os
-import tempfile
-from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 
 from polylogue.config import Config
 from polylogue.health import HealthReport, VerifyStatus, run_runtime_health
 from polylogue.paths import Source
+
+pytestmark = pytest.mark.machine_contract
 
 
 class TestRuntimeHealthCheckNames:

--- a/tests/unit/cli/test_click_app.py
+++ b/tests/unit/cli/test_click_app.py
@@ -12,6 +12,7 @@ import pytest
 
 from polylogue.cli.click_app import cli as click_cli
 from polylogue.cli.click_app import mcp_command
+from polylogue.rendering.semantic_proof import SemanticProofReport
 from tests.infra.cli_subprocess import run_cli
 
 
@@ -465,6 +466,11 @@ class TestQaCommand:
                 },
                 total_records=1,
             ),
+            semantic_proof_report=SemanticProofReport(
+                surface="canonical_markdown_v1",
+                conversations=[],
+                provider_reports={},
+            ),
             exercises_skipped=True,
             invariants_skipped=True,
         )
@@ -475,6 +481,7 @@ class TestQaCommand:
         assert result.exit_code == 0
         payload = json.loads(result.output.split("\nPlain output active", 1)[0])
         assert payload["audit"]["status"] == "ok"
+        assert payload["semantic_proof"]["status"] == "ok"
         assert payload["showcase"]["status"] == "skip"
         assert payload["overall_status"] == "ok"
 

--- a/tests/unit/cli/test_click_app.py
+++ b/tests/unit/cli/test_click_app.py
@@ -12,7 +12,7 @@ import pytest
 
 from polylogue.cli.click_app import cli as click_cli
 from polylogue.cli.click_app import mcp_command
-from polylogue.rendering.semantic_proof import SemanticProofReport
+from polylogue.rendering.semantic_proof import SemanticProofReport, SemanticProofSuiteReport
 from tests.infra.cli_subprocess import run_cli
 
 
@@ -466,10 +466,14 @@ class TestQaCommand:
                 },
                 total_records=1,
             ),
-            semantic_proof_report=SemanticProofReport(
-                surface="canonical_markdown_v1",
-                conversations=[],
-                provider_reports={},
+            semantic_proof_report=SemanticProofSuiteReport(
+                surface_reports={
+                    "canonical_markdown_v1": SemanticProofReport(
+                        surface="canonical_markdown_v1",
+                        conversations=[],
+                        provider_reports={},
+                    )
+                },
             ),
             exercises_skipped=True,
             invariants_skipped=True,

--- a/tests/unit/cli/test_click_app_main.py
+++ b/tests/unit/cli/test_click_app_main.py
@@ -1,0 +1,87 @@
+"""Focused tests for the root CLI machine-error adapter."""
+
+from __future__ import annotations
+
+import json
+import sys
+from unittest.mock import patch
+
+import click
+import pytest
+
+from polylogue.cli.click_app import main
+
+pytestmark = pytest.mark.machine_contract
+
+
+def _run_main_with_error(monkeypatch: pytest.MonkeyPatch, argv: list[str], exc: BaseException, capsys) -> tuple[int, dict[str, object]]:
+    monkeypatch.setattr(sys, "argv", ["polylogue", *argv])
+    with patch("polylogue.cli.click_app.cli", side_effect=exc):
+        with pytest.raises(SystemExit) as exit_info:
+            main()
+    captured = capsys.readouterr()
+    return int(exit_info.value.code), json.loads(captured.out)
+
+
+def test_main_wraps_usage_error_as_json(monkeypatch, capsys):
+    exit_code, payload = _run_main_with_error(
+        monkeypatch,
+        ["check", "--json", "--bad-flag"],
+        click.NoSuchOption("--bad-flag"),
+        capsys,
+    )
+
+    assert exit_code == 2
+    assert payload["status"] == "error"
+    assert payload["code"] == "invalid_arguments"
+    assert payload["details"] == {"option": "--bad-flag"}
+
+
+def test_main_wraps_click_exception_as_runtime_json(monkeypatch, capsys):
+    exit_code, payload = _run_main_with_error(
+        monkeypatch,
+        ["check", "--json"],
+        click.ClickException("boom"),
+        capsys,
+    )
+
+    assert exit_code == 1
+    assert payload["status"] == "error"
+    assert payload["code"] == "runtime_error"
+    assert payload["message"] == "boom"
+
+
+def test_main_wraps_string_system_exit_as_invalid_arguments_json(monkeypatch, capsys):
+    exit_code, payload = _run_main_with_error(
+        monkeypatch,
+        ["check", "--json"],
+        SystemExit("check: --preview requires --repair"),
+        capsys,
+    )
+
+    assert exit_code == 1
+    assert payload["status"] == "error"
+    assert payload["code"] == "invalid_arguments"
+    assert payload["message"] == "check: --preview requires --repair"
+
+
+def test_main_wraps_unexpected_exception_as_runtime_json(monkeypatch, capsys):
+    exit_code, payload = _run_main_with_error(
+        monkeypatch,
+        ["check", "--json"],
+        RuntimeError("unexpected boom"),
+        capsys,
+    )
+
+    assert exit_code == 1
+    assert payload["status"] == "error"
+    assert payload["code"] == "runtime_error"
+    assert payload["message"] == "unexpected boom"
+    assert payload["details"] == {"exception_type": "RuntimeError"}
+
+
+def test_main_without_json_preserves_normal_click_failure(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["polylogue", "check", "--bad-flag"])
+    with patch("polylogue.cli.click_app.cli", side_effect=click.NoSuchOption("--bad-flag")):
+        with pytest.raises(click.NoSuchOption):
+            main()

--- a/tests/unit/cli/test_deterministic_output.py
+++ b/tests/unit/cli/test_deterministic_output.py
@@ -23,7 +23,7 @@ from click.testing import CliRunner
 
 from polylogue.cli.click_app import cli
 from polylogue.lib.outcomes import OutcomeCheck, OutcomeStatus
-from polylogue.rendering.semantic_proof import SemanticProofReport
+from polylogue.rendering.semantic_proof import SemanticProofReport, SemanticProofSuiteReport
 from polylogue.schemas.audit import AuditReport
 from polylogue.schemas.verification import ArtifactProofReport, ProviderArtifactProof
 from polylogue.showcase.exercises import Exercise
@@ -152,10 +152,14 @@ class TestFrozenClockShowcaseReport:
                 },
                 total_records=1,
             ),
-            semantic_proof_report=SemanticProofReport(
-                surface="canonical_markdown_v1",
-                conversations=[],
-                provider_reports={},
+            semantic_proof_report=SemanticProofSuiteReport(
+                surface_reports={
+                    "canonical_markdown_v1": SemanticProofReport(
+                        surface="canonical_markdown_v1",
+                        conversations=[],
+                        provider_reports={},
+                    )
+                },
             ),
             showcase_result=showcase_result,
             invariant_results=[

--- a/tests/unit/cli/test_deterministic_output.py
+++ b/tests/unit/cli/test_deterministic_output.py
@@ -23,6 +23,7 @@ from click.testing import CliRunner
 
 from polylogue.cli.click_app import cli
 from polylogue.lib.outcomes import OutcomeCheck, OutcomeStatus
+from polylogue.rendering.semantic_proof import SemanticProofReport
 from polylogue.schemas.audit import AuditReport
 from polylogue.schemas.verification import ArtifactProofReport, ProviderArtifactProof
 from polylogue.showcase.exercises import Exercise
@@ -150,6 +151,11 @@ class TestFrozenClockShowcaseReport:
                     )
                 },
                 total_records=1,
+            ),
+            semantic_proof_report=SemanticProofReport(
+                surface="canonical_markdown_v1",
+                conversations=[],
+                provider_reports={},
             ),
             showcase_result=showcase_result,
             invariant_results=[

--- a/tests/unit/cli/test_json_envelope_contract.py
+++ b/tests/unit/cli/test_json_envelope_contract.py
@@ -19,10 +19,11 @@ from click.testing import CliRunner
 from polylogue.cli.click_app import cli
 from polylogue.cli.machine_errors import (
     MachineError,
-    MachineSuccess,
     emit_success,
     success,
 )
+
+pytestmark = pytest.mark.machine_contract
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/cli/test_machine_contract.py
+++ b/tests/unit/cli/test_machine_contract.py
@@ -7,7 +7,8 @@ hand-enumerated cases.
 
 from __future__ import annotations
 
-from hypothesis import example, given, settings
+import pytest
+from hypothesis import example, given
 from hypothesis import strategies as st
 
 from polylogue.cli.machine_errors import (
@@ -27,6 +28,8 @@ from polylogue.cli.machine_errors import (
     success,
     wants_json,
 )
+
+pytestmark = pytest.mark.machine_contract
 
 
 class TestMachineErrorEnvelope:
@@ -208,4 +211,4 @@ class TestExtractCommand:
                     if candidate == item:
                         break
                 except StopIteration:
-                    raise AssertionError(f"Order violation: {item!r} not in expected position")
+                    raise AssertionError(f"Order violation: {item!r} not in expected position") from None

--- a/tests/unit/cli/test_query_exec.py
+++ b/tests/unit/cli/test_query_exec.py
@@ -7,24 +7,21 @@ clearest specification.
 
 from __future__ import annotations
 
-import subprocess
-import tempfile
-import webbrowser
 from datetime import datetime, timezone
 from io import StringIO
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import click
 import pytest
 
-from polylogue.cli.click_app import cli as click_cli
 from polylogue.cli.query_plan import QueryAction, QueryRoute
 from polylogue.cli.types import AppEnv
 from polylogue.lib.messages import MessageCollection
 from polylogue.lib.models import Conversation, ConversationSummary, Message
 from polylogue.services import build_runtime_services
+
+pytestmark = pytest.mark.query_routing
 
 
 def _make_msg(id: str, role: str, text: str, *, timestamp=None, provider_meta=None) -> Message:

--- a/tests/unit/cli/test_query_exec_laws.py
+++ b/tests/unit/cli/test_query_exec_laws.py
@@ -7,7 +7,6 @@ import csv
 import io
 import json
 import tempfile
-from datetime import datetime, timedelta
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -21,12 +20,12 @@ from polylogue.cli.query import async_execute_query, project_query_results
 from polylogue.cli.query_actions import apply_modifiers, apply_transform, delete_conversations
 from polylogue.cli.query_helpers import no_results, summary_to_dict
 from polylogue.cli.query_output import (
-    output_results,
-    output_stats_by_summaries,
-    output_stats_sql,
     _output_summary_list,
     _render_conversation_rich,
     _send_output,
+    output_results,
+    output_stats_by_summaries,
+    output_stats_sql,
 )
 from polylogue.cli.query_plan import (
     QueryAction,
@@ -50,6 +49,8 @@ from tests.infra.strategies import (
     summary_output_case_strategy,
     summary_stats_case_strategy,
 )
+
+pytestmark = pytest.mark.query_routing
 
 
 def _make_env(*, repo: MagicMock | None = None, config: MagicMock | None = None) -> AppEnv:
@@ -321,8 +322,8 @@ def test_output_summary_list_contract(case, output_format: str) -> None:
     elif output_format == "csv":
         assert list(csv.DictReader(io.StringIO(mock_echo.call_args[0][0]))) == _csv_rows(case)
     else:
-        assert mock_echo.call_count == len(case.summaries)
-        rendered = "\n".join(call.args[0] for call in mock_echo.call_args_list if call.args)
+        assert mock_echo.call_count == 1
+        rendered = mock_echo.call_args[0][0]
         for spec in case.summaries:
             assert spec.conversation_id[:24] in rendered
 
@@ -898,13 +899,14 @@ class TestSearchQueryContracts:
     )
     def test_filter_contract(self, search_workspace, case_id, args, expected_exit, error_hint):
         """Filter flags produce expected status codes and validation behavior."""
-        from datetime import datetime, timedelta
         from polylogue.cli import cli
 
         runner = CliRunner()
         resolved_args = list(args)
         if "__DYNAMIC_DATE__" in resolved_args:
             idx = resolved_args.index("__DYNAMIC_DATE__")
+            from datetime import datetime, timedelta
+
             resolved_args[idx] = (datetime.now() - timedelta(days=5)).strftime("%Y-%m-%d")
 
         result = runner.invoke(cli, ["--plain", *resolved_args])

--- a/tests/unit/cli/test_query_fmt.py
+++ b/tests/unit/cli/test_query_fmt.py
@@ -25,10 +25,16 @@ import yaml
 from rich.console import Console
 
 from polylogue.cli.query_helpers import describe_query_filters
-from polylogue.cli.query_output import _format_list, _output_stats_by, _write_message_streaming
-from polylogue.rendering.formatting import _conv_to_dict, _yaml_safe, format_conversation
+from polylogue.cli.query_output import (
+    _format_list,
+    _output_stats_by,
+    _write_message_streaming,
+    format_summary_list,
+    render_stream_transcript,
+)
 from polylogue.lib.messages import MessageCollection
-from polylogue.lib.models import Conversation, Message
+from polylogue.lib.models import Conversation, ConversationSummary, Message
+from polylogue.rendering.formatting import _conv_to_dict, _yaml_safe, format_conversation
 
 
 @dataclass(frozen=True)
@@ -360,6 +366,42 @@ class TestListFormatting:
             assert payload[0]["id"] == "conv-1234567890abcdef"
             assert payload[0]["provider"] == "claude-ai"
 
+    @pytest.mark.parametrize("output_format", ["json", "yaml", "csv", "text"])
+    def test_format_summary_list_contract(self, output_format: str) -> None:
+        summary = ConversationSummary(
+            id="conv-summary-1",
+            provider="claude-ai",
+            title="Summary Conversation",
+            created_at=datetime(2025, 6, 1, tzinfo=timezone.utc),
+            updated_at=datetime(2025, 6, 2, tzinfo=timezone.utc),
+            metadata={"tags": ["alpha", "beta"], "summary": "Summary text"},
+        )
+
+        rendered = format_summary_list(
+            [summary],
+            output_format,
+            None,
+            message_counts={"conv-summary-1": 7},
+        )
+
+        if output_format == "json":
+            payload = json.loads(rendered)
+            assert payload[0]["id"] == "conv-summary-1"
+            assert payload[0]["messages"] == 7
+            assert payload[0]["tags"] == ["alpha", "beta"]
+        elif output_format == "yaml":
+            payload = yaml.safe_load(rendered)
+            assert payload[0]["provider"] == "claude-ai"
+            assert payload[0]["summary"] == "Summary text"
+        elif output_format == "csv":
+            assert "id,date,provider,title,messages,tags,summary" in rendered
+            assert "conv-summary-1" in rendered
+            assert "alpha,beta" in rendered
+        else:
+            assert "conv-summary-1" in rendered
+            assert "claude-ai" in rendered
+            assert "(7 msgs)" in rendered
+
 
 class TestStreamingOutput:
     @pytest.mark.parametrize("output_format,expected_role,expected_text", STREAM_CASES)
@@ -380,6 +422,29 @@ class TestStreamingOutput:
             payload = json.loads(output)
             assert payload["id"] == "stream-1"
             assert payload["word_count"] == message.word_count
+
+    @pytest.mark.parametrize(
+        ("output_format", "expected_tokens"),
+        [
+            ("markdown", ("# Example Conversation", "**Provider**: claude-ai", "**Date**: 2025-06-15 12:30", "_Streamed 2 messages_")),
+            ("json-lines", ('"type": "header"', '"provider": "claude-ai"', '"date": "2025-06-15T12:30:00+00:00"', '"type": "footer"')),
+            ("plaintext", ("[USER]", "[ASSISTANT]")),
+        ],
+    )
+    def test_render_stream_transcript_contract(self, sample_conversation: Conversation, output_format: str, expected_tokens: tuple[str, ...]) -> None:
+        rendered, emitted = render_stream_transcript(
+            conversation_id=str(sample_conversation.id),
+            title=sample_conversation.display_title,
+            provider=str(sample_conversation.provider),
+            display_date=sample_conversation.display_date,
+            messages=list(sample_conversation.messages),
+            output_format=output_format,
+            stats={"total_messages": len(sample_conversation.messages), "dialogue_messages": len(list(sample_conversation.iter_dialogue()))},
+        )
+
+        assert emitted == 2
+        for token in expected_tokens:
+            assert token in rendered
 
 
 class TestGroupedStatsOutput:

--- a/tests/unit/cli/test_site.py
+++ b/tests/unit/cli/test_site.py
@@ -58,6 +58,8 @@ def test_site_command_json_emits_manifest(cli_workspace) -> None:
     assert payload["archive"]["total_conversations"] == 1
     assert payload["latest_run"]["run_id"] == "run-cli-001"
     assert payload["outputs"]["total_index_pages"] >= 1
+    assert payload["semantic_proof"]["surface"] == "canonical_markdown_v1"
+    assert payload["semantic_proof"]["total_conversations"] == 1
     assert payload["artifacts"]["entry_count"] >= 1
     assert "site-manifest.json" not in {
         entry["relative_path"] for entry in payload["artifacts"]["entries"]

--- a/tests/unit/cli/test_site.py
+++ b/tests/unit/cli/test_site.py
@@ -58,8 +58,8 @@ def test_site_command_json_emits_manifest(cli_workspace) -> None:
     assert payload["archive"]["total_conversations"] == 1
     assert payload["latest_run"]["run_id"] == "run-cli-001"
     assert payload["outputs"]["total_index_pages"] >= 1
-    assert payload["semantic_proof"]["surface"] == "canonical_markdown_v1"
-    assert payload["semantic_proof"]["total_conversations"] == 1
+    assert payload["semantic_proof"]["surface_count"] >= 1
+    assert payload["semantic_proof"]["surfaces"]["canonical_markdown_v1"]["total_conversations"] == 1
     assert payload["artifacts"]["entry_count"] >= 1
     assert "site-manifest.json" not in {
         entry["relative_path"] for entry in payload["artifacts"]["entries"]

--- a/tests/unit/core/test_semantic_proof.py
+++ b/tests/unit/core/test_semantic_proof.py
@@ -1,13 +1,19 @@
-"""Tests for semantic preservation proofing over canonical markdown rendering."""
+"""Tests for semantic preservation proofing across render and export surfaces."""
 
 from __future__ import annotations
 
 import asyncio
+import json
 
 from polylogue.rendering.core import ConversationFormatter
+from polylogue.rendering.formatting import format_conversation
 from polylogue.rendering.semantic_proof import (
+    DEFAULT_SEMANTIC_SURFACES,
+    prove_export_surface_semantics,
     prove_markdown_projection_semantics,
     prove_markdown_render_semantics,
+    prove_semantic_surface_suite,
+    resolve_semantic_surfaces,
 )
 from polylogue.storage.backends.async_sqlite import SQLiteBackend
 from polylogue.storage.repository import ConversationRepository
@@ -19,6 +25,15 @@ async def _load_projection(db_path, conversation_id: str):
     repository = ConversationRepository(backend=backend)
     try:
         return await repository.get_render_projection(conversation_id)
+    finally:
+        await backend.close()
+
+
+async def _load_conversation(db_path, conversation_id: str):
+    backend = SQLiteBackend(db_path=db_path)
+    repository = ConversationRepository(backend=backend)
+    try:
+        return await repository.view(conversation_id)
     finally:
         await backend.close()
 
@@ -90,23 +105,99 @@ def test_markdown_projection_semantics_detects_critical_loss(db_path, tmp_path):
     }
 
 
-def test_markdown_render_semantics_aggregates_provider_reports(db_path, tmp_path):
-    """Conversation-level proofs roll up into provider and report summaries."""
+def test_export_json_surface_detects_message_loss(db_path):
+    """Structured export proof flags silently dropped message rows as critical loss."""
     (
         ConversationBuilder(db_path, "conv-semantic-3")
         .provider("chatgpt")
-        .title("ChatGPT Semantic")
+        .title("JSON Semantic")
         .updated_at("2026-03-22T12:10:00+00:00")
-        .add_message("conv3-m1", role="user", text="hello")
+        .add_message("json-m1", role="user", text="hello")
+        .add_message("json-m2", role="assistant", text="world")
+        .save()
+    )
+
+    conversation = asyncio.run(_load_conversation(db_path, "conv-semantic-3"))
+    assert conversation is not None
+    payload = json.loads(format_conversation(conversation, "json", None))
+    payload["messages"] = payload["messages"][:-1]
+
+    report = prove_export_surface_semantics(
+        conversation,
+        "export_json_v1",
+        json.dumps(payload),
+    )
+
+    assert report.is_clean is False
+    assert {check.metric for check in report.critical_loss_checks} >= {
+        "message_entries",
+        "message_ids",
+        "role_entries",
+        "timestamp_values",
+    }
+
+
+def test_semantic_surface_suite_aggregates_export_and_canonical_surfaces(db_path, tmp_path):
+    """Suite proof aggregates canonical and export surfaces with explicit loss policies."""
+    (
+        ConversationBuilder(db_path, "conv-semantic-4")
+        .provider("chatgpt")
+        .title("ChatGPT Semantic")
+        .updated_at("2026-03-22T12:20:00+00:00")
+        .add_message("conv4-m1", role="user", text="hello")
+        .add_message("conv4-m2", role="assistant", text="branch-root")
+        .add_message(
+            "conv4-b1",
+            role="assistant",
+            text="branch alternative",
+            parent_message_id="conv4-m1",
+            branch_index=1,
+            provider_meta={"content_blocks": [{"type": "thinking", "text": "inner"}]},
+            has_thinking=1,
+        )
+        .add_attachment("att1", message_id="conv4-b1", path="/tmp/att1.txt")
         .save()
     )
     (
-        ConversationBuilder(db_path, "conv-semantic-4")
+        ConversationBuilder(db_path, "conv-semantic-5")
         .provider("claude-ai")
         .title("Claude Semantic")
-        .updated_at("2026-03-22T12:15:00+00:00")
+        .updated_at("2026-03-22T12:25:00+00:00")
+        .add_message("conv5-m1", role="assistant", text="tool output", has_tool_use=1)
+        .save()
+    )
+
+    suite = prove_semantic_surface_suite(
+        db_path=db_path,
+        archive_root=tmp_path,
+        surfaces=["canonical", "json", "html", "csv", "obsidian"],
+    )
+
+    assert suite.surface_count == 5
+    assert suite.total_conversations == 10
+    assert set(suite.surfaces) == {
+        "canonical_markdown_v1",
+        "export_json_v1",
+        "export_html_v1",
+        "export_csv_v1",
+        "export_obsidian_v1",
+    }
+    assert suite.surfaces["canonical_markdown_v1"].providers["chatgpt"].declared_loss_checks >= 1
+    assert suite.surfaces["export_json_v1"].providers["chatgpt"].declared_loss_checks >= 1
+    assert suite.surfaces["export_html_v1"].metric_summary["branch_structure"]["preserved"] == 1
+    assert suite.surfaces["export_csv_v1"].metric_summary["provider_identity"]["declared_loss"] == 2
+    assert suite.to_dict()["summary"]["surface_count"] == 5
+
+
+def test_markdown_render_semantics_returns_single_surface_report(db_path, tmp_path):
+    """Legacy single-surface helper remains a canonical-markdown projection of the suite."""
+    (
+        ConversationBuilder(db_path, "conv-semantic-6")
+        .provider("claude-ai")
+        .title("Single Surface")
+        .updated_at("2026-03-22T12:30:00+00:00")
         .add_message(
-            "conv4-m1",
+            "conv6-m1",
             role="assistant",
             text="thinking aloud",
             provider_meta={"content_blocks": [{"type": "thinking", "text": "inner"}]},
@@ -121,9 +212,11 @@ def test_markdown_render_semantics_aggregates_provider_reports(db_path, tmp_path
     )
 
     assert report.surface == "canonical_markdown_v1"
-    assert report.total_conversations == 2
-    assert report.provider_count == 2
-    assert report.providers["chatgpt"].clean is True
+    assert report.total_conversations == 1
+    assert report.provider_count == 1
     assert report.providers["claude-ai"].declared_loss_checks == 1
-    assert report.metric_summary["thinking_semantics"]["declared_loss"] == 1
-    assert report.to_dict()["summary"]["provider_count"] == 2
+
+
+def test_resolve_semantic_surfaces_expands_aliases():
+    """Surface aliases expand to canonical suite surface names."""
+    assert resolve_semantic_surfaces(["canonical", "json", "all"]) == list(DEFAULT_SEMANTIC_SURFACES)

--- a/tests/unit/core/test_semantic_proof.py
+++ b/tests/unit/core/test_semantic_proof.py
@@ -1,0 +1,129 @@
+"""Tests for semantic preservation proofing over canonical markdown rendering."""
+
+from __future__ import annotations
+
+import asyncio
+
+from polylogue.rendering.core import ConversationFormatter
+from polylogue.rendering.semantic_proof import (
+    prove_markdown_projection_semantics,
+    prove_markdown_render_semantics,
+)
+from polylogue.storage.backends.async_sqlite import SQLiteBackend
+from polylogue.storage.repository import ConversationRepository
+from tests.infra.storage_records import ConversationBuilder
+
+
+async def _load_projection(db_path, conversation_id: str):
+    backend = SQLiteBackend(db_path=db_path)
+    repository = ConversationRepository(backend=backend)
+    try:
+        return await repository.get_render_projection(conversation_id)
+    finally:
+        await backend.close()
+
+
+def test_markdown_projection_semantics_reports_declared_losses_without_critical_loss(db_path, tmp_path):
+    """Tool/thinking flattening is declared loss, not silent critical loss."""
+    (
+        ConversationBuilder(db_path, "conv-semantic-1")
+        .provider("chatgpt")
+        .title("Semantic Proof")
+        .updated_at("2026-03-22T12:00:00+00:00")
+        .add_message("m1", role="user", text="hello")
+        .add_message(
+            "m2",
+            role="assistant",
+            text="working on it",
+            provider_meta={"content_blocks": [{"type": "thinking", "text": "internal chain"}]},
+        )
+        .add_message(
+            "m3",
+            role="tool",
+            text="tool output",
+            provider_meta={"content_blocks": [{"type": "tool_result", "text": "tool output"}]},
+        )
+        .add_attachment("att1", message_id="m2", path="/tmp/att1.txt")
+        .save()
+    )
+
+    projection = asyncio.run(_load_projection(db_path, "conv-semantic-1"))
+    assert projection is not None
+    formatter = ConversationFormatter(archive_root=tmp_path, db_path=db_path)
+    markdown = formatter.format_projection(projection).markdown_text
+
+    report = prove_markdown_projection_semantics(projection, markdown)
+
+    assert report.is_clean is True
+    assert report.input_facts["attachment_count"] == 1
+    assert {check.metric for check in report.declared_loss_checks} == {
+        "thinking_semantics",
+        "tool_semantics",
+    }
+    assert report.metric_summary["renderable_messages"]["preserved"] == 1
+
+
+def test_markdown_projection_semantics_detects_critical_loss(db_path, tmp_path):
+    """Removing a rendered message section is reported as critical loss."""
+    (
+        ConversationBuilder(db_path, "conv-semantic-2")
+        .provider("chatgpt")
+        .title("Critical Semantic Loss")
+        .updated_at("2026-03-22T12:05:00+00:00")
+        .add_message("m1", role="user", text="hello")
+        .add_message("m2", role="assistant", text="world")
+        .save()
+    )
+
+    projection = asyncio.run(_load_projection(db_path, "conv-semantic-2"))
+    assert projection is not None
+    formatter = ConversationFormatter(archive_root=tmp_path, db_path=db_path)
+    markdown = formatter.format_projection(projection).markdown_text
+    broken_markdown = markdown.replace("## assistant", "### assistant", 1)
+
+    report = prove_markdown_projection_semantics(projection, broken_markdown)
+
+    assert report.is_clean is False
+    assert {check.metric for check in report.critical_loss_checks} == {
+        "renderable_messages",
+        "role_sections",
+    }
+
+
+def test_markdown_render_semantics_aggregates_provider_reports(db_path, tmp_path):
+    """Conversation-level proofs roll up into provider and report summaries."""
+    (
+        ConversationBuilder(db_path, "conv-semantic-3")
+        .provider("chatgpt")
+        .title("ChatGPT Semantic")
+        .updated_at("2026-03-22T12:10:00+00:00")
+        .add_message("conv3-m1", role="user", text="hello")
+        .save()
+    )
+    (
+        ConversationBuilder(db_path, "conv-semantic-4")
+        .provider("claude-ai")
+        .title("Claude Semantic")
+        .updated_at("2026-03-22T12:15:00+00:00")
+        .add_message(
+            "conv4-m1",
+            role="assistant",
+            text="thinking aloud",
+            provider_meta={"content_blocks": [{"type": "thinking", "text": "inner"}]},
+            has_thinking=1,
+        )
+        .save()
+    )
+
+    report = prove_markdown_render_semantics(
+        db_path=db_path,
+        archive_root=tmp_path,
+    )
+
+    assert report.surface == "canonical_markdown_v1"
+    assert report.total_conversations == 2
+    assert report.provider_count == 2
+    assert report.providers["chatgpt"].clean is True
+    assert report.providers["claude-ai"].declared_loss_checks == 1
+    assert report.metric_summary["thinking_semantics"]["declared_loss"] == 1
+    assert report.to_dict()["summary"]["provider_count"] == 2

--- a/tests/unit/core/test_semantic_proof.py
+++ b/tests/unit/core/test_semantic_proof.py
@@ -189,6 +189,69 @@ def test_semantic_surface_suite_aggregates_export_and_canonical_surfaces(db_path
     assert suite.to_dict()["summary"]["surface_count"] == 5
 
 
+def test_semantic_surface_suite_proves_query_summary_and_stream_surfaces(db_path, tmp_path):
+    """Query summary/stream read surfaces become first-class proof surfaces."""
+    (
+        ConversationBuilder(db_path, "conv-semantic-7")
+        .provider("claude-ai")
+        .title("Read Surface")
+        .updated_at("2026-03-22T13:00:00+00:00")
+        .metadata({"tags": ["alpha", "beta"], "summary": "Readable summary"})
+        .add_message("conv7-m1", role="user", text="")
+        .add_message("conv7-m2", role="assistant", text="visible answer")
+        .save()
+    )
+
+    suite = prove_semantic_surface_suite(
+        db_path=db_path,
+        archive_root=tmp_path,
+        surfaces=["query_all"],
+    )
+
+    assert set(suite.surfaces) == {
+        "query_summary_json_v1",
+        "query_summary_yaml_v1",
+        "query_summary_csv_v1",
+        "query_summary_text_v1",
+        "query_stream_plaintext_v1",
+        "query_stream_markdown_v1",
+        "query_stream_json_lines_v1",
+    }
+    assert suite.surfaces["query_summary_json_v1"].is_clean is True
+    assert suite.surfaces["query_summary_csv_v1"].metric_summary["tag_values"]["preserved"] == 1
+    assert suite.surfaces["query_summary_text_v1"].metric_summary["summary_text"]["declared_loss"] == 1
+    assert suite.surfaces["query_stream_plaintext_v1"].metric_summary["provider_identity"]["declared_loss"] == 1
+    assert suite.surfaces["query_stream_markdown_v1"].metric_summary["footer_count"]["preserved"] == 1
+    assert suite.surfaces["query_stream_json_lines_v1"].metric_summary["conversation_id"]["preserved"] == 1
+
+
+def test_semantic_surface_suite_proves_mcp_read_payloads(db_path, tmp_path):
+    """MCP summary/detail payloads participate in the same proof suite."""
+    (
+        ConversationBuilder(db_path, "conv-semantic-8")
+        .provider("chatgpt")
+        .title("MCP Surface")
+        .created_at("2026-03-20T12:00:00+00:00")
+        .updated_at("2026-03-22T13:05:00+00:00")
+        .metadata({"tags": ["ops"], "summary": "MCP summary"})
+        .add_message("conv8-m1", role="user", text="hello")
+        .add_message("conv8-m2", role="assistant", text="world")
+        .add_attachment("conv8-att1", message_id="conv8-m2", path="/tmp/mcp.txt")
+        .save()
+    )
+
+    suite = prove_semantic_surface_suite(
+        db_path=db_path,
+        archive_root=tmp_path,
+        surfaces=["mcp_all"],
+    )
+
+    assert set(suite.surfaces) == {"mcp_summary_json_v1", "mcp_detail_json_v1"}
+    assert suite.surfaces["mcp_summary_json_v1"].metric_summary["tag_values"]["declared_loss"] == 1
+    assert suite.surfaces["mcp_detail_json_v1"].metric_summary["message_entries"]["preserved"] == 1
+    assert suite.surfaces["mcp_detail_json_v1"].metric_summary["attachment_semantics"]["declared_loss"] == 1
+
+
 def test_markdown_render_semantics_returns_single_surface_report(db_path, tmp_path):
     """Legacy single-surface helper remains a canonical-markdown projection of the suite."""
     (
@@ -220,3 +283,14 @@ def test_markdown_render_semantics_returns_single_surface_report(db_path, tmp_pa
 def test_resolve_semantic_surfaces_expands_aliases():
     """Surface aliases expand to canonical suite surface names."""
     assert resolve_semantic_surfaces(["canonical", "json", "all"]) == list(DEFAULT_SEMANTIC_SURFACES)
+    assert resolve_semantic_surfaces(["read_all"]) == [
+        "query_summary_json_v1",
+        "query_summary_yaml_v1",
+        "query_summary_csv_v1",
+        "query_summary_text_v1",
+        "query_stream_plaintext_v1",
+        "query_stream_markdown_v1",
+        "query_stream_json_lines_v1",
+        "mcp_summary_json_v1",
+        "mcp_detail_json_v1",
+    ]

--- a/tests/unit/core/test_verification.py
+++ b/tests/unit/core/test_verification.py
@@ -21,6 +21,7 @@ from polylogue.schemas.verification import (
     prove_raw_artifact_coverage,
     verify_raw_corpus,
 )
+from polylogue.storage.artifact_observations import artifact_observation_id
 from polylogue.storage.backends.connection import open_connection
 
 
@@ -482,6 +483,151 @@ class TestProveRawArtifactCoverage:
                 "SELECT COUNT(*) FROM artifact_observations"
             ).fetchone()[0]
         assert observation_count == 5
+
+    def test_refreshes_stale_existing_observation_resolution(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        db_path = tmp_path / "stale-proof.db"
+        with open_connection(db_path):
+            pass
+
+        source_name = "chatgpt"
+        source_path = "/tmp/chatgpt-stale.json"
+        _insert_raw_record(
+            db_path=db_path,
+            raw_id="raw-chatgpt-stale-1",
+            provider_name="chatgpt",
+            source_name=source_name,
+            source_path=source_path,
+            raw_content=b'{"id":"one","mapping":{}}',
+        )
+
+        observation_id = artifact_observation_id(
+            source_name=source_name,
+            source_path=source_path,
+            source_index=0,
+        )
+        with open_connection(db_path) as conn:
+            conn.execute(
+                """
+                INSERT INTO artifact_observations (
+                    observation_id,
+                    raw_id,
+                    provider_name,
+                    payload_provider,
+                    source_name,
+                    source_path,
+                    source_index,
+                    file_mtime,
+                    wire_format,
+                    artifact_kind,
+                    classification_reason,
+                    parse_as_conversation,
+                    schema_eligible,
+                    support_status,
+                    malformed_jsonl_lines,
+                    decode_error,
+                    bundle_scope,
+                    cohort_id,
+                    resolved_package_version,
+                    resolved_element_kind,
+                    resolution_reason,
+                    link_group_key,
+                    sidecar_agent_type,
+                    first_observed_at,
+                    last_observed_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    observation_id,
+                    "raw-chatgpt-stale-1",
+                    "chatgpt",
+                    "chatgpt",
+                    source_name,
+                    source_path,
+                    0,
+                    None,
+                    "json",
+                    "conversation_document",
+                    "stale unsupported row",
+                    1,
+                    1,
+                    "unsupported_parseable",
+                    0,
+                    None,
+                    "chatgpt",
+                    "stale-cohort",
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    "2026-03-01T00:00:00+00:00",
+                    "2026-03-01T00:00:00+00:00",
+                ),
+            )
+            conn.commit()
+
+        package = SchemaVersionPackage(
+            provider="chatgpt",
+            version="v1",
+            anchor_kind="conversation_document",
+            default_element_kind="conversation_document",
+            first_seen="2026-03-01T00:00:00+00:00",
+            last_seen="2026-03-01T00:00:00+00:00",
+            bundle_scope_count=1,
+            sample_count=1,
+            elements=[
+                SchemaElementManifest(
+                    element_kind="conversation_document",
+                    schema_file="chatgpt-v1.json",
+                    sample_count=1,
+                    artifact_count=1,
+                )
+            ],
+        )
+
+        def _resolve_payload(self, provider, payload, *, source_path=None):
+            if str(provider) == "chatgpt":
+                return SchemaResolution(
+                    provider="chatgpt",
+                    package_version="v1",
+                    element_kind="conversation_document",
+                    exact_structure_id=None,
+                    bundle_scope=None,
+                    reason="exact_structure",
+                )
+            return None
+
+        def _get_package(self, provider, version="default"):
+            if str(provider) == "chatgpt" and version == "v1":
+                return package
+            return None
+
+        monkeypatch.setattr("polylogue.storage.artifact_observations.SchemaRegistry.resolve_payload", _resolve_payload)
+        monkeypatch.setattr("polylogue.storage.artifact_observations.SchemaRegistry.get_package", _get_package)
+
+        report = prove_raw_artifact_coverage(db_path=db_path)
+
+        assert report.total_records == 1
+        assert report.contract_backed_records == 1
+        assert report.providers["chatgpt"].package_versions == {"v1": 1}
+
+        with open_connection(db_path) as conn:
+            refreshed = conn.execute(
+                """
+                SELECT support_status, resolved_package_version, resolved_element_kind, resolution_reason
+                FROM artifact_observations
+                WHERE observation_id = ?
+                """,
+                (observation_id,),
+            ).fetchone()
+        assert refreshed["support_status"] == "supported_parseable"
+        assert refreshed["resolved_package_version"] == "v1"
+        assert refreshed["resolved_element_kind"] == "conversation_document"
+        assert refreshed["resolution_reason"] == "exact_structure"
 
     def test_lists_artifact_rows_and_cohorts_from_durable_control_plane(
         self,

--- a/tests/unit/devtools/test_validation_lanes.py
+++ b/tests/unit/devtools/test_validation_lanes.py
@@ -1,0 +1,76 @@
+"""Tests for devtools.run_validation_lanes."""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from devtools.run_validation_lanes import (
+    LANES,
+    VALID_LANES,
+    LaneConfig,
+    build_lane_command,
+    main,
+    parse_lane,
+)
+
+
+class TestValidationLanesImportable:
+    def test_module_imports(self):
+        import devtools.run_validation_lanes  # noqa: F401
+
+    def test_main_callable(self):
+        assert callable(main)
+
+
+class TestLaneParsing:
+    @pytest.mark.parametrize("lane_name", sorted(VALID_LANES))
+    def test_valid_lane_returns_config(self, lane_name):
+        lane = parse_lane(lane_name)
+        assert isinstance(lane, LaneConfig)
+        assert lane.name == lane_name
+
+    def test_invalid_lane_raises_value_error(self):
+        with pytest.raises(ValueError, match="Invalid lane"):
+            parse_lane("nope")
+
+    def test_all_lanes_have_description_and_timeout(self):
+        for lane in LANES.values():
+            assert lane.description
+            assert lane.timeout_s > 0
+
+
+class TestCommandConstruction:
+    def test_machine_contract_lane_uses_pytest_marker(self):
+        cmd = build_lane_command(LANES["machine-contract"])
+        assert cmd[:3] == [sys.executable, "-m", "pytest"]
+        assert "machine_contract" in cmd
+
+    def test_query_routing_lane_uses_pytest_marker(self):
+        cmd = build_lane_command(LANES["query-routing"])
+        assert "query_routing" in cmd
+
+    def test_long_haul_lane_uses_campaign_runner(self):
+        cmd = build_lane_command(LANES["long-haul-small"])
+        assert cmd[:3] == [sys.executable, "-m", "devtools.run_campaign"]
+        assert "--scale" in cmd
+        assert "small" in cmd
+
+    def test_live_lane_uses_module_entrypoint(self):
+        cmd = build_lane_command(LANES["live-exercises"])
+        assert cmd[:3] == [sys.executable, "-m", "polylogue"]
+        assert "qa" in cmd
+        assert "--live" in cmd
+
+    def test_composite_lane_has_no_direct_command(self):
+        with pytest.raises(ValueError, match="composite"):
+            build_lane_command(LANES["frontier-local"])
+
+    def test_dry_run_returns_zero(self, capsys):
+        exit_code = main(["--lane", "frontier-local", "--dry-run"])
+        captured = capsys.readouterr()
+
+        assert exit_code == 0
+        assert "machine-contract" in captured.out
+        assert "query-routing" in captured.out

--- a/tests/unit/showcase/test_exercise_catalog.py
+++ b/tests/unit/showcase/test_exercise_catalog.py
@@ -46,6 +46,15 @@ class TestExercisesByGroup:
         total = sum(len(exs) for exs in by_group.values())
         assert total == len(EXERCISES)
 
+    def test_proof_exercises_exist_in_subcommands_group(self):
+        names = {exercise.name for exercise in EXERCISES if exercise.group == "subcommands"}
+        assert {
+            "check-proof-json",
+            "check-cohorts-json",
+            "check-semantic-proof",
+            "check-semantic-proof-json",
+        } <= names
+
 
 class TestVhsExercises:
     """vhs_exercises returns only capturable exercises."""

--- a/tests/unit/showcase/test_exercise_catalog.py
+++ b/tests/unit/showcase/test_exercise_catalog.py
@@ -53,6 +53,8 @@ class TestExercisesByGroup:
             "check-cohorts-json",
             "check-semantic-proof",
             "check-semantic-proof-json",
+            "check-semantic-proof-read-surfaces",
+            "check-semantic-proof-read-surfaces-json",
         } <= names
 
 

--- a/tests/unit/showcase/test_qa_runner.py
+++ b/tests/unit/showcase/test_qa_runner.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 
 from polylogue.lib.outcomes import OutcomeCheck, OutcomeStatus
-from polylogue.rendering.semantic_proof import SemanticProofReport
+from polylogue.rendering.semantic_proof import SemanticProofReport, SemanticProofSuiteReport
 from polylogue.schemas.audit import AuditReport
 from polylogue.schemas.verification import ArtifactProofReport, ProviderArtifactProof
 from polylogue.showcase.exercises import Exercise, Validation
@@ -57,10 +57,14 @@ def test_save_qa_reports_writes_composed_session_artifacts(tmp_path):
             },
             total_records=1,
         ),
-        semantic_proof_report=SemanticProofReport(
-            surface="canonical_markdown_v1",
-            conversations=[],
-            provider_reports={},
+        semantic_proof_report=SemanticProofSuiteReport(
+            surface_reports={
+                "canonical_markdown_v1": SemanticProofReport(
+                    surface="canonical_markdown_v1",
+                    conversations=[],
+                    provider_reports={},
+                )
+            },
         ),
         showcase_result=_make_showcase_result(report_dir),
         invariant_results=[
@@ -85,6 +89,7 @@ def test_save_qa_reports_writes_composed_session_artifacts(tmp_path):
     assert proof_payload["summary"]["package_versions"] == {"v1": 1}
     assert proof_payload["summary"]["element_kinds"] == {"conversation_document": 1}
     assert semantic_payload["summary"]["clean"] is True
+    assert semantic_payload["summary"]["surface_count"] == 1
     assert invariant_checks == [
         {"exercise": "test-help", "invariant": "json_valid", "status": "ok"},
     ]

--- a/tests/unit/showcase/test_qa_runner.py
+++ b/tests/unit/showcase/test_qa_runner.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 
 from polylogue.lib.outcomes import OutcomeCheck, OutcomeStatus
+from polylogue.rendering.semantic_proof import SemanticProofReport
 from polylogue.schemas.audit import AuditReport
 from polylogue.schemas.verification import ArtifactProofReport, ProviderArtifactProof
 from polylogue.showcase.exercises import Exercise, Validation
@@ -56,6 +57,11 @@ def test_save_qa_reports_writes_composed_session_artifacts(tmp_path):
             },
             total_records=1,
         ),
+        semantic_proof_report=SemanticProofReport(
+            surface="canonical_markdown_v1",
+            conversations=[],
+            provider_reports={},
+        ),
         showcase_result=_make_showcase_result(report_dir),
         invariant_results=[
             InvariantResult("json_valid", "test-help", OutcomeStatus.OK),
@@ -67,19 +73,23 @@ def test_save_qa_reports_writes_composed_session_artifacts(tmp_path):
 
     qa_session = json.loads((report_dir / "qa-session.json").read_text())
     proof_payload = json.loads((report_dir / "artifact-proof.json").read_text())
+    semantic_payload = json.loads((report_dir / "semantic-proof.json").read_text())
     invariant_checks = json.loads((report_dir / "invariant-checks.json").read_text())
 
     assert qa_session["audit"]["status"] == "ok"
     assert qa_session["proof"]["status"] == "ok"
+    assert qa_session["semantic_proof"]["status"] == "ok"
     assert qa_session["showcase"]["summary"]["passed"] == 1
     assert qa_session["invariants"]["summary"] == {"failed": 0, "passed": 1, "skipped": 0}
     assert proof_payload["summary"]["contract_backed_records"] == 1
     assert proof_payload["summary"]["package_versions"] == {"v1": 1}
     assert proof_payload["summary"]["element_kinds"] == {"conversation_document": 1}
+    assert semantic_payload["summary"]["clean"] is True
     assert invariant_checks == [
         {"exercise": "test-help", "invariant": "json_valid", "status": "ok"},
     ]
     assert (report_dir / "artifact-proof.json").exists()
+    assert (report_dir / "semantic-proof.json").exists()
     assert (report_dir / "schema-audit.json").exists()
     assert (report_dir / "showcase-report.json").exists()
     assert (report_dir / "qa-session.md").exists()

--- a/tests/unit/showcase/test_report.py
+++ b/tests/unit/showcase/test_report.py
@@ -16,6 +16,12 @@ from hypothesis import given, settings
 from hypothesis import strategies as st
 
 from polylogue.lib.outcomes import OutcomeCheck, OutcomeStatus
+from polylogue.rendering.semantic_proof import (
+    ProviderSemanticProof,
+    SemanticConversationProof,
+    SemanticMetricCheck,
+    SemanticProofReport,
+)
 from polylogue.schemas.audit import AuditReport
 from polylogue.schemas.verification import ArtifactProofReport, ProviderArtifactProof
 from polylogue.showcase.invariants import InvariantResult
@@ -64,6 +70,60 @@ def _make_showcase(results: list[ExerciseResult]) -> ShowcaseResult:
     sr.results = results
     sr.total_duration_ms = sum(r.duration_ms for r in results)
     return sr
+
+
+def _make_semantic_report(*, critical: bool = False) -> SemanticProofReport:
+    checks = [
+        SemanticMetricCheck(
+            metric="renderable_messages",
+            status="critical_loss" if critical else "preserved",
+            policy="canonical markdown must preserve every renderable message section",
+            input_value=2,
+            output_value=1 if critical else 2,
+        ),
+        SemanticMetricCheck(
+            metric="thinking_semantics",
+            status="declared_loss",
+            policy="canonical markdown preserves display text but not typed thinking markers",
+            input_value=1,
+            output_value=0,
+        ),
+    ]
+    proof = SemanticConversationProof(
+        conversation_id="conv-1",
+        provider="chatgpt",
+        surface="canonical_markdown_v1",
+        input_facts={"renderable_messages": 2},
+        output_facts={"message_sections": 1 if critical else 2},
+        checks=checks,
+    )
+    return SemanticProofReport(
+        surface="canonical_markdown_v1",
+        conversations=[proof],
+        provider_reports={
+            "chatgpt": ProviderSemanticProof(
+                provider="chatgpt",
+                total_conversations=1,
+                clean_conversations=0 if critical else 1,
+                critical_conversations=1 if critical else 0,
+                preserved_checks=0 if critical else 1,
+                declared_loss_checks=1,
+                critical_loss_checks=1 if critical else 0,
+                metric_summary={
+                    "renderable_messages": {
+                        "preserved": 0 if critical else 1,
+                        "declared_loss": 0,
+                        "critical_loss": 1 if critical else 0,
+                    },
+                    "thinking_semantics": {
+                        "preserved": 0,
+                        "declared_loss": 1,
+                        "critical_loss": 0,
+                    },
+                },
+            )
+        },
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -239,6 +299,7 @@ def test_full_qa_session_contains_composed_stage_payloads():
             },
             total_records=2,
         ),
+        semantic_proof_report=_make_semantic_report(critical=True),
         showcase_result=showcase,
         invariant_results=[
             InvariantResult("json_valid", "ex", OutcomeStatus.OK),
@@ -255,6 +316,8 @@ def test_full_qa_session_contains_composed_stage_payloads():
     assert session["proof"]["report"]["summary"]["unsupported_parseable_records"] == 1
     assert session["proof"]["report"]["summary"]["package_versions"] == {"v1": 1}
     assert session["proof"]["report"]["summary"]["element_kinds"] == {"conversation_document": 1}
+    assert session["semantic_proof"]["status"] == "error"
+    assert session["semantic_proof"]["report"]["summary"]["critical_conversations"] == 1
     assert session["showcase"]["summary"] == {
         "total": 2,
         "passed": 1,
@@ -285,6 +348,7 @@ def test_generate_qa_summary_reports_stage_statuses():
             },
             total_records=1,
         ),
+        semantic_proof_report=_make_semantic_report(),
         exercises_skipped=True,
         invariants_skipped=True,
     )
@@ -295,6 +359,8 @@ def test_generate_qa_summary_reports_stage_statuses():
     assert "Artifact Proof: contract_backed=1" in summary
     assert "Packages: v1=1" in summary
     assert "Elements: conversation_document=1" in summary
+    assert "Semantic Proof: clean_conversations=1" in summary
+    assert "renderable_messages(preserved=1, declared_loss=0, critical_loss=0)" in summary
     assert "Exercises: SKIPPED" in summary
     assert "Invariants: SKIPPED" in summary
 
@@ -321,6 +387,7 @@ def test_generate_qa_markdown_includes_artifact_proof_section():
             },
             total_records=2,
         ),
+        semantic_proof_report=_make_semantic_report(),
         exercises_skipped=True,
         invariants_skipped=True,
     )
@@ -328,8 +395,11 @@ def test_generate_qa_markdown_includes_artifact_proof_section():
     markdown = generate_qa_markdown(qa_result)
 
     assert "## Artifact Proof" in markdown
+    assert "## Semantic Proof" in markdown
     assert "| Unsupported parseable | 1 |" in markdown
     assert "| v4 | 1 |" in markdown
     assert "| subagent_conversation_stream | 1 |" in markdown
     assert "| bundle_scope | 1 |" in markdown
     assert "| claude-code | 2 | 0 | 1 | 1 | 0 | 0 |" in markdown
+    assert "| Total conversations | 1 |" in markdown
+    assert "| renderable_messages | 1 | 0 | 0 |" in markdown

--- a/tests/unit/showcase/test_report.py
+++ b/tests/unit/showcase/test_report.py
@@ -21,6 +21,7 @@ from polylogue.rendering.semantic_proof import (
     SemanticConversationProof,
     SemanticMetricCheck,
     SemanticProofReport,
+    SemanticProofSuiteReport,
 )
 from polylogue.schemas.audit import AuditReport
 from polylogue.schemas.verification import ArtifactProofReport, ProviderArtifactProof
@@ -72,7 +73,7 @@ def _make_showcase(results: list[ExerciseResult]) -> ShowcaseResult:
     return sr
 
 
-def _make_semantic_report(*, critical: bool = False) -> SemanticProofReport:
+def _make_semantic_report(*, critical: bool = False) -> SemanticProofSuiteReport:
     checks = [
         SemanticMetricCheck(
             metric="renderable_messages",
@@ -97,7 +98,7 @@ def _make_semantic_report(*, critical: bool = False) -> SemanticProofReport:
         output_facts={"message_sections": 1 if critical else 2},
         checks=checks,
     )
-    return SemanticProofReport(
+    canonical_report = SemanticProofReport(
         surface="canonical_markdown_v1",
         conversations=[proof],
         provider_reports={
@@ -123,6 +124,51 @@ def _make_semantic_report(*, critical: bool = False) -> SemanticProofReport:
                 },
             )
         },
+    )
+    html_report = SemanticProofReport(
+        surface="export_html_v1",
+        conversations=[
+            SemanticConversationProof(
+                conversation_id="conv-1",
+                provider="chatgpt",
+                surface="export_html_v1",
+                input_facts={"text_messages": 2},
+                output_facts={"message_sections": 1 if critical else 2},
+                checks=[
+                    SemanticMetricCheck(
+                        metric="text_messages",
+                        status="critical_loss" if critical else "preserved",
+                        policy="export_html_v1 must preserve visible message sections for text-bearing messages",
+                        input_value=2,
+                        output_value=1 if critical else 2,
+                    ),
+                ],
+            )
+        ],
+        provider_reports={
+            "chatgpt": ProviderSemanticProof(
+                provider="chatgpt",
+                total_conversations=1,
+                clean_conversations=0 if critical else 1,
+                critical_conversations=1 if critical else 0,
+                preserved_checks=0 if critical else 1,
+                declared_loss_checks=0,
+                critical_loss_checks=1 if critical else 0,
+                metric_summary={
+                    "text_messages": {
+                        "preserved": 0 if critical else 1,
+                        "declared_loss": 0,
+                        "critical_loss": 1 if critical else 0,
+                    }
+                },
+            )
+        },
+    )
+    return SemanticProofSuiteReport(
+        surface_reports={
+            "canonical_markdown_v1": canonical_report,
+            "export_html_v1": html_report,
+        }
     )
 
 
@@ -317,7 +363,8 @@ def test_full_qa_session_contains_composed_stage_payloads():
     assert session["proof"]["report"]["summary"]["package_versions"] == {"v1": 1}
     assert session["proof"]["report"]["summary"]["element_kinds"] == {"conversation_document": 1}
     assert session["semantic_proof"]["status"] == "error"
-    assert session["semantic_proof"]["report"]["summary"]["critical_conversations"] == 1
+    assert session["semantic_proof"]["report"]["summary"]["critical_surfaces"] == 2
+    assert session["semantic_proof"]["report"]["surfaces"]["canonical_markdown_v1"]["summary"]["critical_conversations"] == 1
     assert session["showcase"]["summary"] == {
         "total": 2,
         "passed": 1,
@@ -359,7 +406,8 @@ def test_generate_qa_summary_reports_stage_statuses():
     assert "Artifact Proof: contract_backed=1" in summary
     assert "Packages: v1=1" in summary
     assert "Elements: conversation_document=1" in summary
-    assert "Semantic Proof: clean_conversations=1" in summary
+    assert "Semantic Proof: surfaces=2" in summary
+    assert "canonical_markdown_v1: clean=1" in summary
     assert "renderable_messages(preserved=1, declared_loss=0, critical_loss=0)" in summary
     assert "Exercises: SKIPPED" in summary
     assert "Invariants: SKIPPED" in summary
@@ -401,5 +449,6 @@ def test_generate_qa_markdown_includes_artifact_proof_section():
     assert "| subagent_conversation_stream | 1 |" in markdown
     assert "| bundle_scope | 1 |" in markdown
     assert "| claude-code | 2 | 0 | 1 | 1 | 0 | 0 |" in markdown
-    assert "| Total conversations | 1 |" in markdown
+    assert "| Surface count | 2 |" in markdown
+    assert "| canonical_markdown_v1 | 1 | 1 | 0 | 1 | 1 | 0 |" in markdown
     assert "| renderable_messages | 1 | 0 | 0 |" in markdown

--- a/tests/unit/site/test_builder.py
+++ b/tests/unit/site/test_builder.py
@@ -68,6 +68,9 @@ def test_site_builder_returns_typed_manifest_and_persists_it(db_path, tmp_path) 
     assert manifest.artifact_proof.package_versions == {}
     assert manifest.artifact_proof.element_kinds == {}
     assert manifest.artifact_proof.resolution_reasons == {}
+    assert manifest.semantic_proof is not None
+    assert manifest.semantic_proof.surface == "canonical_markdown_v1"
+    assert manifest.semantic_proof.total_conversations == 1
     assert (tmp_path / "site" / "site-manifest.json").exists()
     assert "site-manifest.json" not in {
         entry.relative_path for entry in manifest.artifacts.entries
@@ -75,6 +78,7 @@ def test_site_builder_returns_typed_manifest_and_persists_it(db_path, tmp_path) 
     assert persisted is not None
     assert persisted.publication_id == manifest.publication_id
     assert persisted.manifest["outputs"]["rendered_conversation_pages"] == 1
+    assert persisted.manifest["semantic_proof"]["total_conversations"] == 1
 
 
 def test_site_builder_reports_reused_pages_on_incremental_rebuild(db_path, tmp_path) -> None:

--- a/tests/unit/site/test_builder.py
+++ b/tests/unit/site/test_builder.py
@@ -69,8 +69,8 @@ def test_site_builder_returns_typed_manifest_and_persists_it(db_path, tmp_path) 
     assert manifest.artifact_proof.element_kinds == {}
     assert manifest.artifact_proof.resolution_reasons == {}
     assert manifest.semantic_proof is not None
-    assert manifest.semantic_proof.surface == "canonical_markdown_v1"
-    assert manifest.semantic_proof.total_conversations == 1
+    assert manifest.semantic_proof.surface_count >= 1
+    assert manifest.semantic_proof.surfaces["canonical_markdown_v1"].total_conversations == 1
     assert (tmp_path / "site" / "site-manifest.json").exists()
     assert "site-manifest.json" not in {
         entry.relative_path for entry in manifest.artifacts.entries
@@ -78,7 +78,7 @@ def test_site_builder_returns_typed_manifest_and_persists_it(db_path, tmp_path) 
     assert persisted is not None
     assert persisted.publication_id == manifest.publication_id
     assert persisted.manifest["outputs"]["rendered_conversation_pages"] == 1
-    assert persisted.manifest["semantic_proof"]["total_conversations"] == 1
+    assert persisted.manifest["semantic_proof"]["surfaces"]["canonical_markdown_v1"]["total_conversations"] == 1
 
 
 def test_site_builder_reports_reused_pages_on_incremental_rebuild(db_path, tmp_path) -> None:

--- a/tests/unit/ui/test_tui.py
+++ b/tests/unit/ui/test_tui.py
@@ -9,6 +9,7 @@ except ImportError:
     # Textual might not be installed in some envs
     PolylogueApp = None
 
+pytestmark = pytest.mark.tui
 _skip = pytest.mark.skipif(PolylogueApp is None, reason="Textual not installed")
 
 
@@ -316,14 +317,43 @@ async def test_dark_mode_toggle(storage_repository):
     """Press 'd' → assert dark mode toggles without crashing."""
     app = _make_app(storage_repository)
     async with app.run_test() as pilot:
-        # The 'd' key is bound to action_toggle_dark
-        # Just verify it doesn't crash — dark mode is a Textual theme feature
         await pilot.press("d")
         await pilot.pause()
+        assert pilot.app.theme == "textual-light"
         await pilot.press("d")
         await pilot.pause()
-        # If we reach here, the toggle didn't crash
+        assert pilot.app.theme == "textual-dark"
         assert pilot.app.query_one(Dashboard)
+
+
+@_skip
+@pytest.mark.asyncio
+async def test_search_missing_index_shows_rebuild_hint(storage_repository, conversation_builder):
+    """Dropping FTS tables yields a direct rebuild hint instead of a crash."""
+    from polylogue.storage.backends.connection import open_connection
+
+    conversation_builder("c1").add_message("m1", text="Reindex me").save()
+
+    with open_connection(storage_repository.backend.db_path) as conn:
+        conn.execute("DROP TABLE IF EXISTS messages_fts")
+        conn.commit()
+
+    app = _make_app(storage_repository)
+    async with app.run_test() as pilot:
+        tabs = pilot.app.query_one(TabbedContent)
+        tabs.active = "search"
+        await pilot.pause()
+
+        inp = pilot.app.query_one("#search-input", Input)
+        inp.focus()
+        inp.value = "Reindex"
+        await pilot.press("enter")
+        await pilot.pause()
+
+        table = pilot.app.query_one("#search-results", DataTable)
+        assert table.row_count == 1
+        row = table.get_row_at(0)
+        assert "Search index not built" in str(row[2])
 
 
 @_skip

--- a/tests/unit/ui/test_tui.py
+++ b/tests/unit/ui/test_tui.py
@@ -3,6 +3,7 @@ from textual.widgets import DataTable, Input, TabbedContent, Tree
 
 try:
     from polylogue.ui.tui.app import PolylogueApp
+    from polylogue.ui.tui.screens.base import RepositoryBoundContainer
     from polylogue.ui.tui.screens.dashboard import Dashboard, ProviderBar
     from polylogue.ui.tui.widgets.stats import StatCard
 except ImportError:
@@ -168,9 +169,9 @@ async def test_browser_node_selection(storage_repository, conversation_builder):
             from textual.widgets import Markdown as MarkdownWidget
 
             viewer = pilot.app.query_one("#markdown-viewer", MarkdownWidget)
-            # The viewer should have been updated (not the default empty)
-            # We can't easily read Markdown widget content, but we can check it mounted
             assert viewer is not None
+            assert "Test Chat" in viewer.source
+            assert "Hello World" in viewer.source
 
 
 @_skip
@@ -234,6 +235,15 @@ async def test_search_flow(storage_repository, conversation_builder):
         # Verify the found row key matches our conversation
         row_key = next(iter(table.rows))
         assert row_key.value == "c1"
+
+        from textual.widgets import Markdown as MarkdownWidget
+
+        table.move_cursor(row=0)
+        table.action_select_cursor()
+        await pilot.pause()
+
+        viewer = pilot.app.query_one("#search-viewer", MarkdownWidget)
+        assert "UniqueSearchTerm123" in viewer.source
 
 
 @_skip
@@ -354,6 +364,16 @@ async def test_search_missing_index_shows_rebuild_hint(storage_repository, conve
         assert table.row_count == 1
         row = table.get_row_at(0)
         assert "Search index not built" in str(row[2])
+
+
+def test_repository_bound_container_requires_injected_repo():
+    class DummyScreen(RepositoryBoundContainer):
+        pass
+
+    screen = DummyScreen()
+
+    with pytest.raises(RuntimeError, match="DummyScreen widget requires an injected repository"):
+        screen._get_repo("DummyScreen")
 
 
 @_skip


### PR DESCRIPTION
## Summary

This branch turns semantic proofing from a one-surface experiment into a first-class archive quality surface. I start by fixing a subtle correctness problem in the artifact proof path so stale durable observations can be refreshed against the current schema registry, then I add semantic proofs for canonical markdown, export surfaces, query summaries, query streams, and MCP read endpoints. Those proofs are surfaced in `polylogue check`, the showcase QA flow, and site publication manifests so they behave like an operator-facing gate instead of a private test helper. Add validation lanes that explicitly exercise the new read-surface contracts. The last few commits clean up the TUI read path so repository-bound screens share one base container and the screen composition remains explicit after dead config plumbing is removed.

## Motivation

The project already had strong snapshot and behavior tests around rendering and query output, but that still left a blind spot: we were asserting exact strings without explicitly stating which semantics a surface must preserve and which losses are intentional. That is fine for one renderer in isolation; it becomes brittle once the same conversation is exposed through canonical markdown, several export formats, streamed query output, and MCP detail/summary payloads. I wanted a single vocabulary that can say “message sections and attachments must survive”, “typed thinking markers are intentionally collapsed”, and “missing timestamps here is a real failure.”

The first proof correctness fix matters because semantic proofing is only useful if the underlying artifact proof is trustworthy. If a durable observation row can stay frozen in an older unsupported state even after the registry learns how to resolve it, the operator-facing surfaces will tell the wrong story. That is why the branch opens with a refresh path rather than jumping straight into new proof surfaces.

Did not want this to stay confined to unit tests. The check command, QA runner, and site publication manifest already carry other archive health signals. Semantic preservation belongs beside them.

## Changes

### Refresh artifact proof resolution before semantic proofing

`polylogue/storage/artifact_observations.py` now refreshes eligible existing rows when proofing runs, rather than only backfilling missing observations. `polylogue/schemas/verification.py` routes proof through that refreshed ledger, and `tests/unit/core/test_verification.py` covers the stale-resolution case directly.

That change is small in code size but important in effect: semantic proof summaries now rest on the same up-to-date support classification an operator would expect after registry changes.

### Add a semantic proof model layer

The bulk of the change lives in `polylogue/rendering/semantic_proof.py`. I added:

- `SemanticMetricCheck`
- `SemanticConversationProof`
- `ProviderSemanticProof`
- `SemanticProofReport`
- `SemanticProofSuiteReport`

Those types let each surface express metric-level outcomes as one of three states:

- preserved
- declared loss
- critical loss

That distinction is what lets me prove semantics without pretending every surface is lossless. Canonical markdown should preserve message sections, attachment presence, timestamps, and roles. It does not need to preserve typed thinking/tool markers if the loss is documented and intentional.

### Extend proofing beyond canonical markdown

After the canonical markdown pass was in place, I expanded the same contract model across the read stack:

- export JSON-like, CSV, Markdown, Obsidian, Org, and HTML surfaces
- query summary text / JSON / CSV surfaces
- query stream plaintext / Markdown / JSON-lines surfaces
- MCP summary and detail surfaces

That work stays centered in `polylogue/rendering/semantic_proof.py`, but it touches `polylogue/rendering/renderers/html.py`, `polylogue/cli/query_output.py`, and MCP read contracts so the proof evaluators line up with real outputs.

```python
report = prove_export_surface_semantics(conversation, "export_html_v1", rendered)
suite = prove_semantic_surface_suite(projection, formatter, surfaces=["canonical_markdown_v1", "export_html_v1"])
```

The important part is not the helper signature; it is that all of these surfaces now speak the same contract language.

### Surface proof results in operator workflows

`polylogue/cli/commands/check.py` supports `--semantic-proof` plus provider/limit/offset filters and JSON output. `polylogue/publication.py`, `polylogue/showcase/qa_runner.py`, `polylogue/showcase/report.py`, and `polylogue/site/publication_support.py` add semantic-proof summaries to QA and publication metadata.

That means the proof is visible where operators already look:

- local `check` output
- QA JSON and Markdown
- site publication manifests

### Add validation lanes and clean up TUI read screens

I added explicit validation lanes in `devtools/run_validation_lanes.py` and documented them in `docs/test-quality-workflows.md`. The new lanes make query-routing, machine-contract, TUI, chaos, and live read-surface checks visible as named regression targets rather than implicit collections of tests.

At the end of the branch I also cleaned up the TUI screen stack. `polylogue/ui/tui/screens/base.py` now provides `RepositoryBoundContainer` so browser/search/dashboard screens stop duplicating repository acquisition logic. I briefly removed too much tab/config wiring while simplifying that path, and the last commit restores explicit `ScreenSpec` composition in `polylogue/ui/tui/app.py`.

## Testing

Coverage for this work is intentionally wide rather than deep in one module:

- `tests/unit/core/test_semantic_proof.py` covers canonical markdown, export, query stream, query summary, and MCP proof surfaces.
- `tests/unit/cli/test_check.py`, `test_click_app.py`, `test_deterministic_output.py`, `test_query_fmt.py`, and `test_site.py` cover CLI and publication rendering.
- `tests/unit/showcase/test_exercise_catalog.py`, `test_qa_runner.py`, and `test_report.py` cover QA/report integration.
- `tests/unit/ui/test_tui.py` covers the repository-bound TUI screen path and explicit tab composition.
- `tests/integration/test_cli_machine_contract.py`, `test_cli_query_mode.py`, `test_ingestion_chaos.py`, and related validation-lane coverage make the new named lanes real.

## Notes

The branch clearly splits into two phases: semantic proof expansion first, TUI cleanup second. The TUI work is smaller, but it is still relevant because those screens are another read surface over repository data. I kept it in the same branch because the repository-bound container extraction was part of the same “make read surfaces explicit and testable” direction.

There are no intended breaking API changes here. The point is to add proof and validation coverage while keeping existing output surfaces intact.
