### PR TITLE
refactor: rewrite PR template and retire repo governance files

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,48 +1,43 @@
-## Intent
+## Summary
 
-What is this PR trying to achieve?
+<!-- 1-2 sentences: what this arc accomplishes -->
 
-## Source
+## Problem
 
-- Closes:
-- Related:
-- Derived from doc / report / note:
+<!-- What the codebase needed. Why this work was necessary. -->
 
-## Scope
+## Solution
 
-What is intentionally in scope here?
+<!-- What was done. Key code patterns, modules created/modified. -->
 
-## Why This Shape
+## Key Technical Decisions
 
-Why is this the right implementation or document shape instead of plausible alternatives?
+<!-- - **Decision**: Reasoning -->
 
-## Non-Goals / Deferred Work
+## What Was Omitted From Rewrite
 
-What is explicitly not being solved here?
+<!-- Files/commits excluded and why. -->
 
-## Verification
+## Dead Ends
 
-List the checks you ran and the exact commands when useful.
+<!-- Approaches tried and abandoned during original development. -->
 
-```bash
-# commands here
+<details>
+<summary>Diff Statistics</summary>
+
+```
+<!-- paste diffstat from commits.txt -->
 ```
 
-## Impact
+</details>
 
-- Archive / storage:
-- CLI / API / MCP:
-- Docs / site:
-- Security / privacy:
+## Attribution
 
-## Follow-Ups
+- **Primary tool**:
+- **Original commits**: N (YYYY-MM-DD → YYYY-MM-DD)
+- **Commits merged**: (fix chains folded)
+- **Commits deleted**: (mutation docs, etc.)
 
-Anything that should become a separate issue after this lands.
+---
 
-## Checklist
-
-- [ ] This branch is tied to an issue or an explicit source document/report.
-- [ ] The PR body explains scope and non-goals clearly.
-- [ ] Verification is recorded honestly.
-- [ ] Docs / operational impact is called out if relevant.
-- [ ] Remaining follow-up work is split out instead of hidden.
+<!-- Closes #NN  ← only on LAST PR of the era -->


### PR DESCRIPTION
## Summary

I rewrote the repository PR template around the information we actually need when a feature branch is squash-merged as a single narrative commit, and I removed governance files that were no longer doing useful work. The old template was optimized for a generic “what changed / what issue does this close” flow, but the repository had moved toward arc-shaped branches where the valuable context is the problem, the technical decisions, the dead ends, and what was intentionally omitted. In the same pass I deleted the CodeRabbit config, release categorization file, and CodeQL workflow, and I collapsed `.gitattributes` down to the one rule that still matters for the generated provider schemas. Updated the checked-in license text to MIT so the repository metadata is internally consistent.

## Motivation

The old PR template asked for “Intent”, “Source”, “Scope”, “Why This Shape”, and a verification checklist. That structure works for small changes, but it does not help when a branch contains a real development arc with folded fix commits, deleted experiments, and a final squash message that has to stand on its own. Reviewers need the architectural story much more than they need a generic checkbox saying that verification was recorded honestly.

At the same time, the repository still had several top-level governance files that were describing workflows we were not really using anymore. Keeping those files around increases the maintenance surface and makes it less obvious which controls are actually authoritative. This cleanup is intentionally narrow: it is about repository process and metadata, not runtime code.

## Changes grouped by concern

### PR authoring surface

The main change is the template rewrite in `.github/pull_request_template.md`. Instead of asking for broad, repetitive prose, the new template nudges authors toward the information that is hardest to recover later:

```md
## Summary
## Problem
## Solution
## Key Technical Decisions
## What Was Omitted From Rewrite
## Dead Ends
<details>
<summary>Diff Statistics</summary>
```

That is a better fit for squash-merged work because it captures both the final shape and the path taken to reach it. Added an `Attribution` section so the final PR body can explicitly record the primary tool, the original commit range, and which commits were folded or deleted.

### Retired governance files

I removed three files that were effectively stale policy:

- `.coderabbit.yaml`
- `.github/release.yml`
- `.github/workflows/codeql.yml`

None of these deletions changes the product surface, but they do reduce confusion about what actually governs the repository. The goal here is to stop advertising automation that the rest of the repo no longer depends on.

### Repository metadata cleanup

I simplified `.gitattributes` to the one remaining rule that still carries real signal:

```gitattributes
polylogue/schemas/providers/*.schema.json.gz binary linguist-generated=true
```

The previous file also carried generic diff, line-ending, export-ignore, and merge annotations. Those defaults were more historical sediment than active policy. Keeping only the generated-schema rule makes the remaining intent obvious.

### License normalization

I replaced the AGPL text in `LICENSE` with MIT. The README and badges already described the project as MIT-licensed, so leaving the older text in the checked-in file was an avoidable source of ambiguity. This change is administrative, but it is important that the repository say one thing consistently.

## Testing

There are no runtime code paths in this change, so there is no automated test delta to call out. The verification here is manual and repository-facing: checking the rendered PR template, confirming GitHub no longer sees the removed workflow/config files, and confirming the license file matches the repo metadata.

## Notes

I did not introduce a new release or review automation replacement in this branch. The purpose of this change is to remove stale surfaces and leave the repository with the minimum set of checked-in governance files that still reflect reality. If we later want new automation, it should be added explicitly instead of inheriting the shape of these retired files.
