### PR TITLE
perf: reuse hot-path scans across ingest and enrichment

### DIFF
--- a/polylogue/cli/run_observers.py
+++ b/polylogue/cli/run_observers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 import time
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -10,6 +11,8 @@ from polylogue.cli.formatting import format_counts
 from polylogue.cli.types import AppEnv
 from polylogue.pipeline.observers import RunObserver
 from polylogue.storage.state_views import RunResult
+
+_PROGRESS_FRACTION_RE = re.compile(r"(?P<completed>\d[\d,]*)/(?P<total>\d[\d,]*)")
 
 
 def _format_elapsed(seconds: float) -> str:
@@ -87,10 +90,43 @@ class RichProgressObserver(RunObserver):
         self._progress = progress
         self._task_id = task_id
 
+    @staticmethod
+    def _progress_bounds(desc: str | None) -> tuple[int, int] | None:
+        if not desc:
+            return None
+        matches = list(_PROGRESS_FRACTION_RE.finditer(desc))
+        if not matches:
+            return None
+        match = matches[-1]
+        completed = int(match.group("completed").replace(",", ""))
+        total = int(match.group("total").replace(",", ""))
+        if total <= 0 or completed < 0 or completed > total:
+            return None
+        return completed, total
+
     def on_progress(self, amount: int, desc: str | None = None) -> None:
+        parsed_bounds = self._progress_bounds(desc)
+        if parsed_bounds is not None:
+            completed, total = parsed_bounds
+            if desc:
+                self._progress.update(
+                    self._task_id,
+                    description=desc,
+                    total=total,
+                    completed=completed,
+                )
+            else:
+                self._progress.update(
+                    self._task_id,
+                    total=total,
+                    completed=completed,
+                )
+            return
+
         if desc:
             self._progress.update(self._task_id, description=desc)
-        self._progress.update(self._task_id, advance=amount)
+        if amount:
+            self._progress.update(self._task_id, advance=amount)
 
 
 @contextmanager

--- a/polylogue/lib/action_event_parsing.py
+++ b/polylogue/lib/action_event_parsing.py
@@ -53,20 +53,30 @@ def build_tool_calls_from_content_blocks(
     content_blocks: Sequence[Mapping[str, Any]],
 ) -> tuple[ToolCall, ...]:
     """Normalize canonical ToolCall viewports from content blocks."""
-    normalized_provider = Provider.from_string(provider) if provider is not None else None
     tool_result_outputs: dict[str, str] = {}
+    tool_use_blocks: list[Mapping[str, Any]] = []
     for block in content_blocks:
-        if str(block.get("type")) != "tool_result":
+        block_type = str(block.get("type"))
+        if block_type == "tool_result":
+            tool_id = block.get("tool_id")
+            text = block.get("text")
+            if isinstance(tool_id, str) and tool_id and isinstance(text, str) and text:
+                tool_result_outputs.setdefault(tool_id, text)
             continue
-        tool_id = block.get("tool_id")
-        text = block.get("text")
-        if isinstance(tool_id, str) and tool_id and isinstance(text, str) and text:
-            tool_result_outputs.setdefault(tool_id, text)
+        if block_type != "tool_use":
+            continue
+        tool_use_blocks.append(block)
 
+    if not tool_use_blocks:
+        return ()
+
+    normalized_provider = (
+        provider
+        if isinstance(provider, Provider)
+        else Provider.from_string(provider) if provider is not None else None
+    )
     calls: list[ToolCall] = []
-    for block in content_blocks:
-        if str(block.get("type")) != "tool_use":
-            continue
+    for block in tool_use_blocks:
         name = block.get("tool_name")
         if not isinstance(name, str) or not name:
             continue

--- a/polylogue/lib/message_model_runtime.py
+++ b/polylogue/lib/message_model_runtime.py
@@ -6,6 +6,7 @@ import re
 from functools import cached_property
 
 from polylogue.lib.roles import Role
+from polylogue.logging import get_logger
 
 
 def _coerce_optional_float(value: object) -> float | None:
@@ -36,11 +37,10 @@ def _coerce_optional_int(value: object) -> int | None:
     return None
 
 
-_CONTEXT_PATTERNS = [
-    r"^Contents of .+:",
-    r"^<file path=",
-]
-from polylogue.logging import get_logger
+_CONTEXT_PATTERNS = (
+    re.compile(r"^Contents of .+:", re.MULTILINE),
+    re.compile(r"^<file path=", re.MULTILINE),
+)
 
 logger = get_logger(__name__)
 
@@ -110,7 +110,7 @@ class MessageRuntimeMixin:
 
         return False
 
-    @property
+    @cached_property
     def is_tool_use(self) -> bool:
         if any(block.get("type") in ("tool_use", "tool_result") for block in self.content_blocks):
             return True
@@ -133,7 +133,7 @@ class MessageRuntimeMixin:
 
         return False
 
-    @property
+    @cached_property
     def is_thinking(self) -> bool:
         if any(block.get("type") == "thinking" for block in self.content_blocks):
             return True
@@ -156,7 +156,7 @@ class MessageRuntimeMixin:
 
         return bool(self._is_chatgpt_thinking())
 
-    @property
+    @cached_property
     def is_context_dump(self) -> bool:
         if not self.text:
             return False
@@ -169,19 +169,19 @@ class MessageRuntimeMixin:
             return True
         if self.text.count("```") >= 6:
             return True
-        return any(re.search(pattern, self.text, re.MULTILINE) for pattern in _CONTEXT_PATTERNS)
+        return any(pattern.search(self.text) for pattern in _CONTEXT_PATTERNS)
 
-    @property
+    @cached_property
     def is_noise(self) -> bool:
         return self.is_tool_use or self.is_context_dump or self.is_system
 
-    @property
+    @cached_property
     def is_substantive(self) -> bool:
         if not self.is_dialogue or self.is_noise or self.is_thinking:
             return False
         return bool(self.text and len(self.text.strip()) > 10)
 
-    @property
+    @cached_property
     def word_count(self) -> int:
         if not self.text:
             return 0

--- a/polylogue/lib/message_model_runtime.py
+++ b/polylogue/lib/message_model_runtime.py
@@ -37,9 +37,14 @@ def _coerce_optional_int(value: object) -> int | None:
     return None
 
 
-_CONTEXT_PATTERNS = (
-    re.compile(r"^Contents of .+:", re.MULTILINE),
-    re.compile(r"^<file path=", re.MULTILINE),
+_CONTEXT_START_MARKERS = (
+    "<environment_context>",
+    "<subagent_notification>",
+    "<permissions instructions>",
+)
+_CONTEXT_LINE_PATTERNS = (
+    ("Contents of ", re.compile(r"^Contents of .+:", re.MULTILINE)),
+    ("<file path=", re.compile(r"^<file path=", re.MULTILINE)),
 )
 
 logger = get_logger(__name__)
@@ -158,18 +163,19 @@ class MessageRuntimeMixin:
 
     @cached_property
     def is_context_dump(self) -> bool:
-        if not self.text:
+        text = self.text
+        if not text:
             return False
-        stripped = self.text.lstrip()
-        if stripped.startswith(("<environment_context>", "<subagent_notification>", "<permissions instructions>")):
+        stripped = text.lstrip()
+        if stripped.startswith(_CONTEXT_START_MARKERS):
             return True
-        if self.attachments and len(self.text) < 100:
+        if self.attachments and len(text) < 100:
             return True
-        if "<system>" in self.text and "</system>" in self.text:
+        if "<system>" in text and "</system>" in text:
             return True
-        if self.text.count("```") >= 6:
+        if "```" in text and text.count("```") >= 6:
             return True
-        return any(pattern.search(self.text) for pattern in _CONTEXT_PATTERNS)
+        return any(marker in text and pattern.search(text) for marker, pattern in _CONTEXT_LINE_PATTERNS)
 
     @cached_property
     def is_noise(self) -> bool:

--- a/polylogue/lib/semantic_fact_models.py
+++ b/polylogue/lib/semantic_fact_models.py
@@ -28,16 +28,8 @@ class MessageSemanticFacts:
     is_substantive: bool
     tool_calls: tuple[ToolCall, ...]
     action_events: tuple[ActionEvent, ...]
+    tool_category_counts: dict[str, int]
     reasoning_traces: tuple[ReasoningTrace, ...]
-
-    @property
-    def tool_category_counts(self) -> dict[str, int]:
-        from collections import Counter
-
-        from polylogue.lib.semantic_fact_support import sorted_counts
-
-        counts = Counter(action.kind.value for action in self.action_events)
-        return sorted_counts(dict(counts))
 
     @property
     def affected_paths(self) -> tuple[str, ...]:

--- a/polylogue/lib/semantic_facts.py
+++ b/polylogue/lib/semantic_facts.py
@@ -69,6 +69,8 @@ def build_projection_semantic_facts(projection) -> ProjectionSemanticFacts:
 
 def build_message_semantic_facts(message) -> MessageSemanticFacts:
     tool_calls = message_tool_calls(message)
+    action_events = build_action_events(message, tool_calls)
+    tool_category_counts = Counter(action.kind.value for action in action_events)
     return MessageSemanticFacts(
         message_id=str(message.id),
         role=normalized_role_label(message.role),
@@ -85,7 +87,8 @@ def build_message_semantic_facts(message) -> MessageSemanticFacts:
         is_tool_use=message.is_tool_use,
         is_substantive=message.is_substantive,
         tool_calls=tool_calls,
-        action_events=build_action_events(message, tool_calls),
+        action_events=action_events,
+        tool_category_counts=sorted_counts(dict(tool_category_counts)),
         reasoning_traces=message_reasoning_traces(message),
     )
 

--- a/polylogue/lib/work_event_extraction.py
+++ b/polylogue/lib/work_event_extraction.py
@@ -22,6 +22,26 @@ from polylogue.lib.semantic_facts import (
 # noise, not human-readable content.
 _TAG_RE = re.compile(r"<[^>]+>")
 _WHITESPACE_RE = re.compile(r"\s+")
+_SUMMARY_PROTOCOL_BLOCKS = (
+    ("<system-reminder>", re.compile(r"<system-reminder>.*?</system-reminder>", re.DOTALL)),
+    ("<task-notification>", re.compile(r"<task-notification>.*?</task-notification>", re.DOTALL)),
+    ("<local-command-caveat>", re.compile(r"<local-command-caveat>.*?</local-command-caveat>", re.DOTALL)),
+    ("<local-command-stdout>", re.compile(r"<local-command-stdout>.*?</local-command-stdout>", re.DOTALL)),
+    ("<command-name>", re.compile(r"<command-name>.*?</command-name>", re.DOTALL)),
+    ("<command-message>", re.compile(r"<command-message>.*?</command-message>", re.DOTALL)),
+    ("<command-args>", re.compile(r"<command-args>.*?</command-args>", re.DOTALL)),
+)
+_SUMMARY_MAX_TEXT_LEN = 100
+_SUMMARY_MAX_JOINED_LEN = 200
+
+
+def _normalize_summary_whitespace(text: str) -> str:
+    stripped = text.strip()
+    if not stripped:
+        return ""
+    if "\n" not in stripped and "\r" not in stripped and "\t" not in stripped and "  " not in stripped:
+        return stripped
+    return _WHITESPACE_RE.sub(" ", stripped).strip()
 
 
 def _clean_summary_text(text: str) -> str:
@@ -32,21 +52,18 @@ def _clean_summary_text(text: str) -> str:
     """
     if not text:
         return ""
-    # Remove entire system-reminder blocks
-    cleaned = re.sub(r"<system-reminder>.*?</system-reminder>", "", text, flags=re.DOTALL)
-    # Remove entire task-notification blocks
-    cleaned = re.sub(r"<task-notification>.*?</task-notification>", "", cleaned, flags=re.DOTALL)
-    # Remove entire local-command blocks
-    cleaned = re.sub(r"<local-command-caveat>.*?</local-command-caveat>", "", cleaned, flags=re.DOTALL)
-    cleaned = re.sub(r"<local-command-stdout>.*?</local-command-stdout>", "", cleaned, flags=re.DOTALL)
-    cleaned = re.sub(r"<command-name>.*?</command-name>", "", cleaned, flags=re.DOTALL)
-    cleaned = re.sub(r"<command-message>.*?</command-message>", "", cleaned, flags=re.DOTALL)
-    cleaned = re.sub(r"<command-args>.*?</command-args>", "", cleaned, flags=re.DOTALL)
-    # Strip remaining XML-like tags
-    cleaned = _TAG_RE.sub("", cleaned)
-    # Collapse whitespace
-    cleaned = _WHITESPACE_RE.sub(" ", cleaned).strip()
-    return cleaned[:100] if cleaned else ""
+    if "<" not in text:
+        cleaned = _normalize_summary_whitespace(text)
+        return cleaned[:_SUMMARY_MAX_TEXT_LEN] if cleaned else ""
+
+    cleaned = text
+    for marker, pattern in _SUMMARY_PROTOCOL_BLOCKS:
+        if marker in cleaned:
+            cleaned = pattern.sub("", cleaned)
+    if "<" in cleaned and ">" in cleaned:
+        cleaned = _TAG_RE.sub("", cleaned)
+    cleaned = _normalize_summary_whitespace(cleaned)
+    return cleaned[:_SUMMARY_MAX_TEXT_LEN] if cleaned else ""
 
 
 class WorkEventKind(str, Enum):
@@ -335,14 +352,19 @@ def extract_work_events(
                 tools_used.append(action.tool_name)
                 file_paths.extend(action.affected_paths)
 
-        user_texts: list[str] = []
+        summary_parts: list[str] = []
+        summary_length = 0
         for message in messages[chunk_start:chunk_end]:
             if not message.is_user or not message.text:
                 continue
             cleaned_text = _clean_summary_text(message.text)
             if cleaned_text:
-                user_texts.append(cleaned_text)
-        summary = "; ".join(user_texts)[:200] if user_texts else kind.value
+                separator_length = 2 if summary_parts else 0
+                summary_parts.append(cleaned_text)
+                summary_length += separator_length + len(cleaned_text)
+                if summary_length >= _SUMMARY_MAX_JOINED_LEN:
+                    break
+        summary = "; ".join(summary_parts)[:_SUMMARY_MAX_JOINED_LEN] if summary_parts else kind.value
         timestamps = [
             message.timestamp
             for message in messages[chunk_start:chunk_end]

--- a/polylogue/pipeline/run_stages.py
+++ b/polylogue/pipeline/run_stages.py
@@ -167,49 +167,65 @@ async def execute_index_stage(
     try:
         if stage == "parse":
             if processed_ids:
-                if progress_callback is not None:
-                    progress_callback(0, desc=f"Indexing {len(processed_ids)} conversations")
+                index_kwargs = (
+                    {"progress_callback": progress_callback}
+                    if progress_callback is not None
+                    else {}
+                )
                 return IndexStageOutcome(
-                    indexed=await index_service.update_index(processed_ids),
+                    indexed=await index_service.update_index(processed_ids, **index_kwargs),
                     item_count=len(processed_ids),
                 )
             return IndexStageOutcome(indexed=False, item_count=0)
 
         if stage == "index":
-            if progress_callback is not None:
-                progress_callback(0, desc="Indexing")
             if source_names:
                 total = await backend.queries.count_conversation_ids(
                     source_names=list(source_names)
+                )
+                index_kwargs = (
+                    {"progress_callback": progress_callback}
+                    if progress_callback is not None
+                    else {}
                 )
                 success = await index_service.update_index(
                     backend.queries.iter_conversation_ids(
                         source_names=list(source_names)
                     ),
+                    **index_kwargs,
                 )
                 return IndexStageOutcome(indexed=success, item_count=total)
+            total = await backend.queries.count_conversation_ids()
+            rebuild_kwargs = (
+                {"progress_callback": progress_callback}
+                if progress_callback is not None
+                else {}
+            )
             return IndexStageOutcome(
-                indexed=await index_service.rebuild_index(),
-                item_count=0,
+                indexed=await index_service.rebuild_index(**rebuild_kwargs),
+                item_count=total,
             )
 
         if stage == "all":
             idx = await index_service.get_index_status()
             if not idx["exists"]:
-                if progress_callback is not None:
-                    progress_callback(0, desc="Indexing (rebuild)")
+                rebuild_kwargs = (
+                    {"progress_callback": progress_callback}
+                    if progress_callback is not None
+                    else {}
+                )
                 return IndexStageOutcome(
-                    indexed=await index_service.rebuild_index(),
+                    indexed=await index_service.rebuild_index(**rebuild_kwargs),
                     item_count=len(processed_ids),
                 )
             if processed_ids:
-                if progress_callback is not None:
-                    progress_callback(
-                        0,
-                        desc=f"Indexing {len(processed_ids)} conversations",
-                    )
+                index_kwargs = (
+                    {"progress_callback": progress_callback}
+                    if progress_callback is not None
+                    else {}
+                )
                 return IndexStageOutcome(
-                    indexed=await index_service.update_index(processed_ids),
+                    indexed=await index_service.update_index(processed_ids, **index_kwargs),
                     item_count=len(processed_ids),
                 )
         return IndexStageOutcome(indexed=False, item_count=0)

--- a/polylogue/pipeline/services/indexing.py
+++ b/polylogue/pipeline/services/indexing.py
@@ -18,6 +18,7 @@ from polylogue.storage.search_cache import invalidate_search_cache
 
 if TYPE_CHECKING:
     from polylogue.config import Config
+    from polylogue.protocols import ProgressCallback
     from polylogue.storage.backends.async_sqlite import SQLiteBackend
 
 logger = get_logger(__name__)
@@ -31,11 +32,43 @@ async def ensure_index(backend: SQLiteBackend) -> None:
         await ensure_fts_index_async(conn)
 
 
-async def rebuild_index(backend: SQLiteBackend) -> None:
+async def rebuild_index(
+    backend: SQLiteBackend,
+    *,
+    progress_callback: ProgressCallback | None = None,
+) -> None:
     """Rebuild the entire FTS5 index from persisted message rows."""
+    conversation_id_list = [conversation_id async for conversation_id in backend.queries.iter_conversation_ids()]
+    phase_total = len(conversation_id_list) * 2
+
+    def action_progress_desc(processed: int, total: int) -> str:
+        del total
+        return f"Indexing: action events {processed:,}/{phase_total:,}"
+
+    def fts_progress_desc(processed: int, total: int) -> str:
+        del total
+        return f"Indexing: full-text search {len(conversation_id_list) + processed:,}/{phase_total:,}"
+
     async with backend.connection() as conn:
-        await rebuild_action_event_read_model_async(conn)
-        await rebuild_fts_index_async(conn)
+        if progress_callback is not None and conversation_id_list:
+            progress_callback(0, desc=f"Indexing: action events 0/{phase_total:,}")
+        await rebuild_action_event_read_model_async(
+            conn,
+            conversation_ids=conversation_id_list,
+            progress_callback=progress_callback,
+            progress_desc=action_progress_desc if progress_callback is not None else None,
+        )
+        if progress_callback is not None and conversation_id_list:
+            progress_callback(
+                0,
+                desc=f"Indexing: full-text search {len(conversation_id_list):,}/{phase_total:,}",
+            )
+        await rebuild_fts_index_async(
+            conn,
+            conversation_ids=conversation_id_list,
+            progress_callback=progress_callback,
+            progress_desc=fts_progress_desc if progress_callback is not None else None,
+        )
         await conn.commit()
     invalidate_search_cache()
 
@@ -43,14 +76,42 @@ async def rebuild_index(backend: SQLiteBackend) -> None:
 async def update_index_for_conversations(
     conversation_ids: Iterable[str] | AsyncIterable[str],
     backend: SQLiteBackend,
+    *,
+    progress_callback: ProgressCallback | None = None,
 ) -> None:
     """Repair FTS rows for the provided conversations from persisted message rows."""
     conversation_id_list = [conversation_id async for conversation_id in _iter_ids(conversation_ids)]
     changed = bool(conversation_id_list)
+    phase_total = len(conversation_id_list) * 2
+
+    def action_progress_desc(processed: int, total: int) -> str:
+        del total
+        return f"Indexing: action events {processed:,}/{phase_total:,}"
+
+    def fts_progress_desc(processed: int, total: int) -> str:
+        del total
+        return f"Indexing: full-text search {len(conversation_id_list) + processed:,}/{phase_total:,}"
 
     async with backend.connection() as conn:
-        await rebuild_action_event_read_model_async(conn, conversation_ids=conversation_id_list)
-        await repair_fts_index_async(conn, conversation_id_list)
+        if progress_callback is not None and conversation_id_list:
+            progress_callback(0, desc=f"Indexing: action events 0/{phase_total:,}")
+        await rebuild_action_event_read_model_async(
+            conn,
+            conversation_ids=conversation_id_list,
+            progress_callback=progress_callback,
+            progress_desc=action_progress_desc if progress_callback is not None else None,
+        )
+        if progress_callback is not None and conversation_id_list:
+            progress_callback(
+                0,
+                desc=f"Indexing: full-text search {len(conversation_id_list):,}/{phase_total:,}",
+            )
+        await repair_fts_index_async(
+            conn,
+            conversation_id_list,
+            progress_callback=progress_callback,
+            progress_desc=fts_progress_desc if progress_callback is not None else None,
+        )
         await conn.commit()
     if changed:
         invalidate_search_cache()
@@ -92,6 +153,8 @@ class IndexService:
     async def update_index(
         self,
         conversation_ids: Iterable[str] | AsyncIterable[str],
+        *,
+        progress_callback: ProgressCallback | None = None,
     ) -> bool:
         """Update the search index for specific conversations.
 
@@ -106,13 +169,24 @@ class IndexService:
             return False
 
         try:
-            await update_index_for_conversations(conversation_ids, self.backend)
+            if progress_callback is None:
+                await update_index_for_conversations(conversation_ids, self.backend)
+            else:
+                await update_index_for_conversations(
+                    conversation_ids,
+                    self.backend,
+                    progress_callback=progress_callback,
+                )
             return True
         except sqlite3.DatabaseError as exc:
             logger.error("Failed to update index", error=str(exc), exc_info=True)
             return False
 
-    async def rebuild_index(self) -> bool:
+    async def rebuild_index(
+        self,
+        *,
+        progress_callback: ProgressCallback | None = None,
+    ) -> bool:
         """Rebuild the entire search index from scratch.
 
         Returns:
@@ -123,7 +197,10 @@ class IndexService:
             return False
 
         try:
-            await rebuild_index(self.backend)
+            if progress_callback is None:
+                await rebuild_index(self.backend)
+            else:
+                await rebuild_index(self.backend, progress_callback=progress_callback)
             return True
         except sqlite3.DatabaseError as exc:
             logger.error("Failed to rebuild index", error=str(exc), exc_info=True)

--- a/polylogue/pipeline/services/ingest_batch.py
+++ b/polylogue/pipeline/services/ingest_batch.py
@@ -944,7 +944,7 @@ async def refresh_session_products_bulk(
     try:
         from polylogue.storage.session_product_refresh import (
             _apply_session_product_conversation_updates_async,
-            _refresh_thread_root_async,
+            _refresh_thread_roots_async,
             refresh_async_provider_day_aggregates,
         )
 
@@ -958,12 +958,11 @@ async def refresh_session_products_bulk(
             update_elapsed = time.perf_counter() - t_updates
             t_threads = time.perf_counter()
             thread_root_ids = update.thread_root_ids
-            for root_id in sorted(thread_root_ids):
-                await _refresh_thread_root_async(
-                    conn,
-                    root_id,
-                    transaction_depth=1,
-                )
+            await _refresh_thread_roots_async(
+                conn,
+                sorted(thread_root_ids),
+                transaction_depth=1,
+            )
             thread_elapsed = time.perf_counter() - t_threads
             t_aggregates = time.perf_counter()
             affected_groups = update.affected_groups

--- a/polylogue/pipeline/services/ingest_batch.py
+++ b/polylogue/pipeline/services/ingest_batch.py
@@ -85,6 +85,7 @@ class _IngestBatchSummary:
     max_result_bytes: int = 0
     max_result_raw_id: str | None = None
     elapsed_s: float = 0.0
+    setup_elapsed_s: float = 0.0
     max_current_rss_mb: float | None = None
     result_wait_s: float = 0.0
     drain_elapsed_s: float = 0.0
@@ -92,6 +93,7 @@ class _IngestBatchSummary:
     max_write_elapsed_s: float = 0.0
     flush_elapsed_s: float = 0.0
     commit_elapsed_s: float = 0.0
+    teardown_elapsed_s: float = 0.0
 
 
 # ---------------------------------------------------------------------------
@@ -613,9 +615,11 @@ def _process_ingest_batch_sync(
     summary.total_blob_mb = sum(r.blob_size for r in raw_records) / (1024 * 1024)
 
     t_start = time.perf_counter()
+    setup_started = time.perf_counter()
     conn = _open_sync_connection(db_path)
     suspend_fts_triggers_sync(conn)
     conn.execute("BEGIN IMMEDIATE")
+    summary.setup_elapsed_s = time.perf_counter() - setup_started
 
     materialized_ids: set[str] = set()
     pending_by_parent: dict[str, list[tuple[str, ConversationData]]] = {}
@@ -635,6 +639,7 @@ def _process_ingest_batch_sync(
             try:
                 ir = next(result_iterator)
             except StopIteration:
+                summary.teardown_elapsed_s = time.perf_counter() - wait_started
                 break
             summary.result_wait_s += time.perf_counter() - wait_started
             _record_outcome(summary, ir)
@@ -682,6 +687,24 @@ def _process_ingest_batch_sync(
 
     summary.elapsed_s = time.perf_counter() - t_start
     return summary
+
+
+def _unattributed_batch_elapsed_s(
+    *,
+    elapsed_s: float,
+    batch_summary: _IngestBatchSummary,
+    raw_state_update_elapsed_s: float,
+) -> float:
+    accounted_elapsed_s = (
+        batch_summary.setup_elapsed_s
+        + batch_summary.result_wait_s
+        + batch_summary.drain_elapsed_s
+        + batch_summary.flush_elapsed_s
+        + batch_summary.commit_elapsed_s
+        + batch_summary.teardown_elapsed_s
+        + raw_state_update_elapsed_s
+    )
+    return max(elapsed_s - accounted_elapsed_s, 0.0)
 
 
 # ---------------------------------------------------------------------------
@@ -788,20 +811,20 @@ async def process_ingest_batch(
         "skipped_raw_count": len(batch_summary.skipped_raw_ids),
         "elapsed_ms": round(elapsed_s * 1000, 1),
         "sync_ingest_elapsed_ms": round(batch_summary.elapsed_s * 1000, 1),
+        "sync_setup_elapsed_ms": round(batch_summary.setup_elapsed_s * 1000, 1),
         "result_wait_elapsed_ms": round(batch_summary.result_wait_s * 1000, 1),
         "drain_elapsed_ms": round(batch_summary.drain_elapsed_s * 1000, 1),
         "write_elapsed_ms": round(batch_summary.write_elapsed_s * 1000, 1),
         "max_write_elapsed_ms": round(batch_summary.max_write_elapsed_s * 1000, 1),
         "flush_elapsed_ms": round(batch_summary.flush_elapsed_s * 1000, 1),
         "commit_elapsed_ms": round(batch_summary.commit_elapsed_s * 1000, 1),
+        "executor_teardown_elapsed_ms": round(batch_summary.teardown_elapsed_s * 1000, 1),
         "raw_state_update_elapsed_ms": round(raw_state_update_elapsed_s * 1000, 1),
     }
-    residual_elapsed_s = elapsed_s - (
-        batch_summary.result_wait_s
-        + batch_summary.drain_elapsed_s
-        + batch_summary.flush_elapsed_s
-        + batch_summary.commit_elapsed_s
-        + raw_state_update_elapsed_s
+    residual_elapsed_s = _unattributed_batch_elapsed_s(
+        elapsed_s=elapsed_s,
+        batch_summary=batch_summary,
+        raw_state_update_elapsed_s=raw_state_update_elapsed_s,
     )
     observation["unattributed_elapsed_ms"] = round(max(residual_elapsed_s, 0.0) * 1000, 1)
     if rss_start_mb is not None:

--- a/polylogue/pipeline/services/ingest_worker.py
+++ b/polylogue/pipeline/services/ingest_worker.py
@@ -213,6 +213,7 @@ def ingest_record(
     # ── Phase 2: Validate schema (inline, reuses decoded payload) ─────
     v_status = ValidationStatus.PASSED
     v_error: str | None = None
+    schema_resolution = None
 
     if validation_mode is not ValidationMode.OFF and envelope.artifact.schema_eligible:
         malformed_lines = envelope.malformed_jsonl_lines
@@ -225,11 +226,18 @@ def ingest_record(
                 error=f"Malformed JSONL lines: {malformed_lines}",
             ))
 
+        schema_resolution = _runtime_schema_registry().resolve_payload(
+            envelope.provider,
+            envelope.payload,
+            source_path=raw_record.source_path,
+        )
+
         try:
             validator = SchemaValidator.for_payload(
                 envelope.provider,
                 envelope.payload,
                 source_path=raw_record.source_path,
+                schema_resolution=schema_resolution,
             )
         except (FileNotFoundError, ImportError):
             validator = None
@@ -240,7 +248,7 @@ def ingest_record(
             if samples:
                 collected_errors: list[str] = []
                 for sample in samples:
-                    sample_result = validator.validate(sample)
+                    sample_result = validator.validate(sample, include_drift=False)
                     if not sample_result.is_valid:
                         collected_errors.extend(sample_result.errors[:2])
 
@@ -257,11 +265,12 @@ def ingest_record(
         v_status = ValidationStatus.SKIPPED
 
     # ── Phase 3: Parse (provider-specific conversation extraction) ─────
-    schema_resolution = _runtime_schema_registry().resolve_payload(
-        envelope.provider,
-        envelope.payload,
-        source_path=raw_record.source_path,
-    )
+    if schema_resolution is None and envelope.artifact.schema_eligible:
+        schema_resolution = _runtime_schema_registry().resolve_payload(
+            envelope.provider,
+            envelope.payload,
+            source_path=raw_record.source_path,
+        )
 
     try:
         parsed_conversations = parse_payload(

--- a/polylogue/rendering/renderers/html_highlighting.py
+++ b/polylogue/rendering/renderers/html_highlighting.py
@@ -3,12 +3,20 @@
 from __future__ import annotations
 
 import re
+from functools import lru_cache
+from html import escape
 
 from markdown_it import MarkdownIt
 from pygments import highlight
 from pygments.formatters import HtmlFormatter
 from pygments.lexers import get_lexer_by_name, guess_lexer
 from pygments.util import ClassNotFound
+
+HTML_RENDER_CACHE_MAX_ENTRIES = 8192
+HTML_RENDER_CACHE_TEXT_MAX_CHARS = 4096
+_URL_RE = re.compile(r"(https?://|www\.)", re.IGNORECASE)
+_MARKDOWN_BLOCK_RE = re.compile(r"(^|\n)(?: {0,3}(?:[-+*] |\d+[.)] |>)| {4}|\t)")
+_PLAIN_TEXT_MARKDOWN_CHARS = frozenset("`*_#[]|~")
 
 
 class PygmentsHighlighter:
@@ -52,11 +60,45 @@ class HTMLMessageRenderer:
         self.highlighter = highlighter or PygmentsHighlighter()
         self.md = MarkdownIt("commonmark", {"html": False, "linkify": True})
         self.md.enable("table")
+        self._render_cached = lru_cache(maxsize=HTML_RENDER_CACHE_MAX_ENTRIES)(self._render_uncached)
 
     def render(self, text: str) -> str:
         if not text:
             return ""
+        if len(text) > HTML_RENDER_CACHE_TEXT_MAX_CHARS:
+            return self._render_uncached(text)
+        return self._render_cached(text)
+
+    def _render_uncached(self, text: str) -> str:
+        if self._can_render_plain_text_fast(text):
+            return self._render_plain_text_fast(text)
         return self._enhance_code_blocks(self.md.render(text))
+
+    @staticmethod
+    def _can_render_plain_text_fast(text: str) -> bool:
+        return bool(text) and (
+            "  \n" not in text
+            and "<" not in text
+            and not _URL_RE.search(text)
+            and not _MARKDOWN_BLOCK_RE.search(text)
+            and not any(ch in text for ch in _PLAIN_TEXT_MARKDOWN_CHARS)
+        )
+
+    @staticmethod
+    def _escape_like_markdown_it(text: str) -> str:
+        return escape(text, quote=False).replace('"', "&quot;")
+
+    @classmethod
+    def _render_plain_text_fast(cls, text: str) -> str:
+        parts = [
+            paragraph.strip()
+            for paragraph in re.split(r"\n\s*\n+", text.strip())
+            if paragraph.strip()
+        ]
+        return "".join(
+            f"<p>{cls._escape_like_markdown_it(paragraph)}</p>\n"
+            for paragraph in parts
+        )
 
     def _enhance_code_blocks(self, html: str) -> str:
         pattern = r'<pre><code class="language-(\w+)">(.*?)</code></pre>'
@@ -79,4 +121,9 @@ class HTMLMessageRenderer:
         return re.sub(pattern_plain, replace_plain_code, html, flags=re.DOTALL)
 
 
-__all__ = ["HTMLMessageRenderer", "PygmentsHighlighter"]
+__all__ = [
+    "HTMLMessageRenderer",
+    "HTML_RENDER_CACHE_MAX_ENTRIES",
+    "HTML_RENDER_CACHE_TEXT_MAX_CHARS",
+    "PygmentsHighlighter",
+]

--- a/polylogue/schemas/validator.py
+++ b/polylogue/schemas/validator.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 try:
     import jsonschema
@@ -27,6 +27,9 @@ from .validator_resolution import (
     resolve_payload_schema,
     resolve_provider_schema,
 )
+
+if TYPE_CHECKING:
+    from polylogue.schemas.packages import SchemaResolution
 
 # ---------------------------------------------------------------------------
 # Validation result model
@@ -168,12 +171,14 @@ class SchemaValidator:
         payload: Any,
         *,
         source_path: str | None = None,
+        schema_resolution: SchemaResolution | None = None,
         strict: bool = True,
     ) -> SchemaValidator:
         canonical, schema, base_key = resolve_payload_schema(
             provider,
             payload,
             source_path=source_path,
+            schema_resolution=schema_resolution,
             registry_cls=SchemaRegistry,
         )
         key = (*base_key, strict)
@@ -188,10 +193,11 @@ class SchemaValidator:
     def available_providers(cls) -> list[str]:
         return _available_providers(registry_cls=SchemaRegistry)
 
-    def validate(self, data: Any) -> ValidationResult:
+    def validate(self, data: Any, *, include_drift: bool | None = None) -> ValidationResult:
         errors = [format_validation_error(error) for error in self._validator.iter_errors(data)]
         drift_warnings: list[str] = []
-        if self.strict and isinstance(data, dict):
+        should_detect_drift = self.strict if include_drift is None else include_drift
+        if should_detect_drift and isinstance(data, dict):
             drift_warnings.extend(detect_drift(data, self.schema, ""))
         return ValidationResult(
             is_valid=len(errors) == 0,

--- a/polylogue/schemas/validator_resolution.py
+++ b/polylogue/schemas/validator_resolution.py
@@ -4,11 +4,14 @@ from __future__ import annotations
 
 from functools import lru_cache
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from polylogue.paths import data_home
 from polylogue.schemas.runtime_registry import SchemaRegistry, canonical_schema_provider
 from polylogue.types import Provider
+
+if TYPE_CHECKING:
+    from polylogue.schemas.packages import SchemaResolution
 
 
 @lru_cache(maxsize=8)
@@ -61,19 +64,22 @@ def resolve_payload_schema(
     payload: Any,
     *,
     source_path: str | None = None,
+    schema_resolution: SchemaResolution | None = None,
     registry_cls: type[SchemaRegistry] = SchemaRegistry,
 ) -> tuple[Provider, dict[str, Any], tuple[str, str, str]]:
     canonical = canonical_provider(provider)
     registry = _registry_for(registry_cls)
-    resolution = (
-        registry.resolve_payload(
-            str(canonical),
-            payload,
-            source_path=source_path,
+    resolution = schema_resolution
+    if resolution is None:
+        resolution = (
+            registry.resolve_payload(
+                str(canonical),
+                payload,
+                source_path=source_path,
+            )
+            if hasattr(registry, "resolve_payload")
+            else None
         )
-        if hasattr(registry, "resolve_payload")
-        else None
-    )
     package_version = resolution.package_version if resolution is not None else "latest"
     element_kind = resolution.element_kind if resolution is not None else "default"
 

--- a/polylogue/sources/decoder_zip.py
+++ b/polylogue/sources/decoder_zip.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from polylogue.lib.artifact_taxonomy import classify_artifact_path
 from polylogue.logging import get_logger
+from polylogue.storage.blob_store import get_blob_store
 from polylogue.types import Provider
 
 from .cursor import _record_cursor_failure
@@ -129,8 +130,21 @@ def process_zip(
                 session_index={},
             )
             emitter = _ConversationEmitter(ctx)
+            precomputed_raw: RawConversationData | None = None
+            if capture_raw and entry_should_group:
+                with zf.open(name) as handle:
+                    blob_hash, blob_size = get_blob_store().write_from_fileobj(handle)
+                precomputed_raw = RawConversationData(
+                    raw_bytes=b"",
+                    source_path=f"{zip_path}:{name}",
+                    source_index=None,
+                    file_mtime=file_mtime,
+                    provider_hint=entry_provider_hint,
+                    blob_hash=blob_hash,
+                    blob_size=blob_size,
+                )
             with zf.open(name) as handle:
-                yield from emitter.emit(handle, name)
+                yield from emitter.emit(handle, name, precomputed_raw=precomputed_raw)
 
 
 __all__ = [

--- a/polylogue/sources/emitter.py
+++ b/polylogue/sources/emitter.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from io import BytesIO
+from itertools import chain
 from typing import TYPE_CHECKING, Any, BinaryIO
 
 from polylogue.lib.artifact_taxonomy import classify_artifact
@@ -78,21 +79,24 @@ class _ConversationEmitter:
 
         if is_jsonl:
             stream_start = self._capture_stream_start(handle) if pre_read_bytes is None else None
-            if stream_start is not None:
-                sniff_payloads = list(_iter_json_stream(handle, stream_name))
-                sniff_provider = detect_provider(sniff_payloads) or self._ctx.provider_hint
+            if (
+                pre_read_bytes is None
+                and stream_start is None
+                and self._ctx.capture_raw
+                and precomputed_raw is None
+            ):
+                sniff_bytes = handle.read()
+                sniff_provider, sniff_payloads, grouped_payloads = self._sniff_jsonl_payloads(
+                    BytesIO(sniff_bytes),
+                    stream_name,
+                )
                 if sniff_provider in GROUP_PROVIDERS:
-                    grouped_bytes = None
-                    grouped_handle = handle
-                    if self._ctx.capture_raw:
-                        self._restore_stream_start(handle, stream_start)
-                        grouped_bytes = handle.read()
-                        grouped_handle = BytesIO(grouped_bytes)
                     yield from self._emit_grouped(
-                        grouped_handle,
+                        BytesIO(sniff_bytes),
                         stream_name,
-                        grouped_bytes,
-                        precomputed_payloads=sniff_payloads,
+                        sniff_bytes,
+                        precomputed_raw=precomputed_raw,
+                        precomputed_payloads=grouped_payloads,
                     )
                     return
                 yield from self._emit_individual_payloads(
@@ -101,15 +105,24 @@ class _ConversationEmitter:
                 )
                 return
 
-            sniff_bytes = pre_read_bytes if pre_read_bytes is not None else handle.read()
-            sniff_payloads = list(_iter_json_stream(BytesIO(sniff_bytes), stream_name))
-            sniff_provider = detect_provider(sniff_payloads) or self._ctx.provider_hint
+            sniff_handle = BytesIO(pre_read_bytes) if pre_read_bytes is not None else handle
+            sniff_provider, sniff_payloads, grouped_payloads = self._sniff_jsonl_payloads(
+                sniff_handle,
+                stream_name,
+            )
             if sniff_provider in GROUP_PROVIDERS:
+                grouped_bytes = pre_read_bytes
+                grouped_handle = sniff_handle
+                if grouped_bytes is None and self._ctx.capture_raw and precomputed_raw is None:
+                    self._restore_stream_start(handle, stream_start)
+                    grouped_bytes = handle.read()
+                    grouped_handle = BytesIO(grouped_bytes)
                 yield from self._emit_grouped(
-                    BytesIO(sniff_bytes),
+                    grouped_handle,
                     stream_name,
-                    sniff_bytes,
-                    precomputed_payloads=sniff_payloads,
+                    grouped_bytes,
+                    precomputed_raw=precomputed_raw,
+                    precomputed_payloads=grouped_payloads,
                 )
                 return
             yield from self._emit_individual_payloads(
@@ -221,6 +234,28 @@ class _ConversationEmitter:
             except Exception:
                 logger.exception("Error processing payload from %s", stream_name)
                 raise
+
+    def _sniff_jsonl_payloads(
+        self,
+        handle: BinaryIO,
+        stream_name: str,
+    ) -> tuple[Provider, Iterable[Any], list[Any] | None]:
+        payload_iter = iter(_iter_json_stream(handle, stream_name))
+        buffered_payloads: list[Any] = []
+        for payload in payload_iter:
+            buffered_payloads.append(payload)
+            detected_provider = detect_provider(payload)
+            if detected_provider is None:
+                continue
+            if detected_provider in GROUP_PROVIDERS:
+                buffered_payloads.extend(payload_iter)
+                return detected_provider, buffered_payloads, buffered_payloads
+            return detected_provider, chain(buffered_payloads, payload_iter), None
+
+        detected_provider = detect_provider(buffered_payloads) or self._ctx.provider_hint
+        if detected_provider in GROUP_PROVIDERS:
+            return detected_provider, buffered_payloads, buffered_payloads
+        return detected_provider, iter(buffered_payloads), None
 
     def _capture_stream_start(self, handle: BinaryIO) -> int | None:
         seekable = getattr(handle, "seekable", None)

--- a/polylogue/sources/source_acquisition.py
+++ b/polylogue/sources/source_acquisition.py
@@ -154,15 +154,14 @@ def iter_source_raw_data(
                         entry_provider_hint = _zip_entry_provider_hint(info.filename, provider_hint)
                         if entry_provider_hint in GROUP_PROVIDERS:
                             with zf.open(info.filename) as handle:
-                                raw_bytes = handle.read()
+                                blob_hash, blob_size = blob_store.write_from_fileobj(handle)
                             _observe_acquisition(
                                 observation_callback,
-                                phase="zip-entry-buffered",
+                                phase="zip-entry-streamed",
                                 source_path=entry_path,
                                 provider_hint=entry_provider_hint,
-                                blob_size=len(raw_bytes),
+                                blob_size=blob_size,
                             )
-                            blob_hash, blob_size = blob_store.write_from_bytes(raw_bytes)
                             yield RawConversationData(
                                 raw_bytes=b"",
                                 source_path=entry_path,
@@ -172,7 +171,6 @@ def iter_source_raw_data(
                                 blob_hash=blob_hash,
                                 blob_size=blob_size,
                             )
-                            del raw_bytes
                             continue
 
                         detected_provider = entry_provider_hint
@@ -248,15 +246,14 @@ def iter_source_raw_data(
                         # grouped, non-conversation metadata, or a single
                         # conversation document.
                         with zf.open(info.filename) as handle:
-                            raw_bytes = handle.read()
+                            blob_hash, blob_size = blob_store.write_from_fileobj(handle)
                         _observe_acquisition(
                             observation_callback,
-                            phase="zip-entry-buffered",
+                            phase="zip-entry-streamed",
                             source_path=entry_path,
                             provider_hint=detected_provider,
-                            blob_size=len(raw_bytes),
+                            blob_size=blob_size,
                         )
-                        blob_hash, blob_size = blob_store.write_from_bytes(raw_bytes)
                         yield RawConversationData(
                             raw_bytes=b"",
                             source_path=entry_path,
@@ -266,7 +263,6 @@ def iter_source_raw_data(
                             blob_hash=blob_hash,
                             blob_size=blob_size,
                         )
-                        del raw_bytes
             else:
                 # Stream-hash the file to blob store — never loads full
                 # content into Python memory. A 1.5 GB file is hashed and

--- a/polylogue/storage/action_event_rebuild_runtime.py
+++ b/polylogue/storage/action_event_rebuild_runtime.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import sqlite3
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 
 import aiosqlite
 
@@ -57,6 +57,8 @@ async def rebuild_action_event_read_model_async(
     *,
     conversation_ids: Sequence[str] | None = None,
     page_size: int = 200,
+    progress_callback: Callable[[int, str | None], None] | None = None,
+    progress_desc: Callable[[int, int], str] | None = None,
 ) -> int:
     if conversation_ids is None:
         await conn.execute("DELETE FROM action_events")
@@ -67,6 +69,8 @@ async def rebuild_action_event_read_model_async(
         return 0
 
     replaced = 0
+    total = len(conversation_ids)
+    processed = 0
     for chunk in chunked(list(conversation_ids), size=page_size):
         conversations, messages, blocks = await load_async_batch(conn, chunk)
         materialized = materialize_batch(conversations, messages, blocks)
@@ -74,6 +78,10 @@ async def rebuild_action_event_read_model_async(
             records = materialized.get(conversation_id, [])
             await replace_action_events_async(conn, conversation_id, records)
             replaced += len(records)
+        processed += len(chunk)
+        if progress_callback is not None:
+            desc = progress_desc(processed, total) if progress_desc is not None else None
+            progress_callback(len(chunk), desc)
     return replaced
 
 

--- a/polylogue/storage/blob_store.py
+++ b/polylogue/storage/blob_store.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 import hashlib
 import os
-import shutil
 import tempfile
 from collections.abc import Iterator
 from pathlib import Path
@@ -81,6 +80,49 @@ class BlobStore:
                     if not chunk:
                         break
                     os.write(fd, chunk)
+            os.close(fd)
+            fd = None
+            os.replace(tmp_path, dest)
+            tmp_path = None
+        finally:
+            if fd is not None:
+                os.close(fd)
+            if tmp_path is not None and os.path.exists(tmp_path):
+                os.unlink(tmp_path)
+
+        return hash_hex, size
+
+    def write_from_fileobj(self, source: BinaryIO) -> tuple[str, int]:
+        """Stream-hash an open binary file-like object into the store.
+
+        Reads from ``source`` in 128 KB chunks, hashing and writing to a
+        temporary file in one pass. Returns ``(sha256_hex, byte_count)``.
+        """
+        hasher = hashlib.sha256()
+        size = 0
+        self.root.mkdir(parents=True, exist_ok=True)
+        fd = None
+        tmp_path: str | None = None
+        try:
+            fd, tmp_path = tempfile.mkstemp(dir=self.root, prefix=".blob.")
+            while True:
+                chunk = source.read(_CHUNK_SIZE)
+                if not chunk:
+                    break
+                hasher.update(chunk)
+                size += len(chunk)
+                os.write(fd, chunk)
+
+            hash_hex = hasher.hexdigest()
+            dest = self.blob_path(hash_hex)
+            if dest.exists():
+                os.close(fd)
+                fd = None
+                os.unlink(tmp_path)
+                tmp_path = None
+                return hash_hex, size
+
+            dest.parent.mkdir(parents=True, exist_ok=True)
             os.close(fd)
             fd = None
             os.replace(tmp_path, dest)

--- a/polylogue/storage/fts_lifecycle.py
+++ b/polylogue/storage/fts_lifecycle.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import sqlite3
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 
 import aiosqlite
 
@@ -120,11 +120,25 @@ def rebuild_fts_index_sync(conn: sqlite3.Connection) -> None:
     conn.execute(ACTION_FTS_REBUILD_SQL)
 
 
-async def rebuild_fts_index_async(conn: aiosqlite.Connection) -> None:
+async def rebuild_fts_index_async(
+    conn: aiosqlite.Connection,
+    *,
+    conversation_ids: Sequence[str] | None = None,
+    progress_callback: Callable[[int, str | None], None] | None = None,
+    progress_desc: Callable[[int, int], str] | None = None,
+) -> None:
     """Rebuild the full FTS index from persisted archive rows."""
     await ensure_fts_index_async(conn)
     await conn.execute("DELETE FROM messages_fts")
     await conn.execute("DELETE FROM action_events_fts")
+    if conversation_ids is not None:
+        await repair_fts_index_async(
+            conn,
+            conversation_ids,
+            progress_callback=progress_callback,
+            progress_desc=progress_desc,
+        )
+        return
     await conn.execute(FTS_REBUILD_SQL)
     await conn.execute(ACTION_FTS_REBUILD_SQL)
 
@@ -145,17 +159,26 @@ def repair_fts_index_sync(conn: sqlite3.Connection, conversation_ids: Sequence[s
 async def repair_fts_index_async(
     conn: aiosqlite.Connection,
     conversation_ids: Sequence[str],
+    *,
+    progress_callback: Callable[[int, str | None], None] | None = None,
+    progress_desc: Callable[[int, int], str] | None = None,
 ) -> None:
     """Repair FTS rows for the supplied conversations from persisted rows."""
     await ensure_fts_index_async(conn)
     if not conversation_ids:
         return
+    total = len(conversation_ids)
+    processed = 0
     for chunk in chunked(list(conversation_ids), size=500):
         params = tuple(chunk)
         await conn.execute(delete_conversation_rows_sql(len(chunk)), params)
         await conn.execute(insert_conversation_rows_sql(len(chunk)), params)
         await conn.execute(delete_action_rows_sql(len(chunk)), params)
         await conn.execute(insert_action_rows_sql(len(chunk)), params)
+        processed += len(chunk)
+        if progress_callback is not None:
+            desc = progress_desc(processed, total) if progress_desc is not None else None
+            progress_callback(len(chunk), desc)
 
 
 def replace_fts_rows_for_messages_sync(

--- a/polylogue/storage/session_product_aggregates.py
+++ b/polylogue/storage/session_product_aggregates.py
@@ -41,6 +41,15 @@ _PROVIDER_DAY_PROFILE_RECORDS_SQL_TEMPLATE = f"""
     ORDER BY tg.provider_name, tg.bucket_day, COALESCE(sp.source_sort_key, 0) DESC, sp.conversation_id
 """
 _GROUP_BATCH_SIZE = 100
+_DISTINCT_PROVIDER_DAY_GROUPS_SQL = f"""
+    SELECT DISTINCT
+        sp.provider_name AS provider_name,
+        {_PROFILE_BUCKET_DAY_SQL} AS bucket_day
+    FROM session_profiles sp
+    WHERE sp.provider_name IS NOT NULL
+      AND {_PROFILE_BUCKET_DAY_SQL} IS NOT NULL
+    ORDER BY provider_name, bucket_day
+"""
 
 
 def replace_day_session_summaries_async(
@@ -97,6 +106,15 @@ def load_sync_provider_day_profile_records(
     ).get((provider_name, bucket_day), [])
 
 
+def list_sync_provider_day_groups(
+    conn: sqlite3.Connection,
+) -> list[tuple[str, str]]:
+    return [
+        (str(row["provider_name"]), str(row["bucket_day"]))
+        for row in conn.execute(_DISTINCT_PROVIDER_DAY_GROUPS_SQL).fetchall()
+    ]
+
+
 async def load_async_provider_day_profile_records(
     conn: aiosqlite.Connection,
     *,
@@ -109,6 +127,15 @@ async def load_async_provider_day_profile_records(
             [(provider_name, bucket_day)],
         )
     ).get((provider_name, bucket_day), [])
+
+
+async def list_async_provider_day_groups(
+    conn: aiosqlite.Connection,
+) -> list[tuple[str, str]]:
+    return [
+        (str(row["provider_name"]), str(row["bucket_day"]))
+        for row in await (await conn.execute(_DISTINCT_PROVIDER_DAY_GROUPS_SQL)).fetchall()
+    ]
 
 
 def _normalize_provider_day_groups(
@@ -337,6 +364,8 @@ __all__ = [
     "_PROFILE_BUCKET_DAY_SQL",
     "load_async_provider_day_profile_records",
     "load_async_provider_day_profile_records_by_groups",
+    "list_async_provider_day_groups",
+    "list_sync_provider_day_groups",
     "load_sync_provider_day_profile_records",
     "load_sync_provider_day_profile_records_by_groups",
     "profile_provider_day",

--- a/polylogue/storage/session_product_aggregates.py
+++ b/polylogue/storage/session_product_aggregates.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sqlite3
+from collections.abc import Sequence
 
 import aiosqlite
 
@@ -15,12 +16,31 @@ from polylogue.storage.session_product_storage import (
     replace_day_session_summaries_sync,
     replace_session_tag_rollup_rows_sync,
 )
-from polylogue.storage.store import SessionProfileRecord
+from polylogue.storage.store import (
+    DaySessionSummaryRecord,
+    SessionProfileRecord,
+    SessionTagRollupRecord,
+)
 
 _PROFILE_BUCKET_DAY_SQL = (
     "COALESCE(sp.canonical_session_date, "
     "date(COALESCE(sp.first_message_at, json_extract(sp.evidence_payload_json, '$.created_at'), sp.source_updated_at, sp.last_message_at)))"
 )
+_PROVIDER_DAY_PROFILE_RECORDS_SQL_TEMPLATE = f"""
+    WITH target_groups(provider_name, bucket_day) AS (
+        VALUES {{values}}
+    )
+    SELECT
+        tg.provider_name AS group_provider_name,
+        tg.bucket_day AS group_bucket_day,
+        sp.*
+    FROM target_groups tg
+    JOIN session_profiles sp
+      ON sp.provider_name = tg.provider_name
+     AND {_PROFILE_BUCKET_DAY_SQL} = tg.bucket_day
+    ORDER BY tg.provider_name, tg.bucket_day, COALESCE(sp.source_sort_key, 0) DESC, sp.conversation_id
+"""
+_GROUP_BATCH_SIZE = 100
 
 
 def replace_day_session_summaries_async(
@@ -71,17 +91,10 @@ def load_sync_provider_day_profile_records(
     provider_name: str,
     bucket_day: str,
 ) -> list[SessionProfileRecord]:
-    rows = conn.execute(
-        f"""
-        SELECT *
-        FROM session_profiles sp
-        WHERE sp.provider_name = ?
-          AND {_PROFILE_BUCKET_DAY_SQL} = ?
-        ORDER BY COALESCE(sp.source_sort_key, 0) DESC, sp.conversation_id
-        """,
-        (provider_name, bucket_day),
-    ).fetchall()
-    return [_row_to_session_profile_record(row) for row in rows]
+    return load_sync_provider_day_profile_records_by_groups(
+        conn,
+        [(provider_name, bucket_day)],
+    ).get((provider_name, bucket_day), [])
 
 
 async def load_async_provider_day_profile_records(
@@ -90,50 +103,162 @@ async def load_async_provider_day_profile_records(
     provider_name: str,
     bucket_day: str,
 ) -> list[SessionProfileRecord]:
-    rows = await (
-        await conn.execute(
-            f"""
-            SELECT *
-            FROM session_profiles sp
-            WHERE sp.provider_name = ?
-              AND {_PROFILE_BUCKET_DAY_SQL} = ?
-            ORDER BY COALESCE(sp.source_sort_key, 0) DESC, sp.conversation_id
-            """,
-            (provider_name, bucket_day),
+    return (
+        await load_async_provider_day_profile_records_by_groups(
+            conn,
+            [(provider_name, bucket_day)],
         )
-    ).fetchall()
-    return [_row_to_session_profile_record(row) for row in rows]
+    ).get((provider_name, bucket_day), [])
+
+
+def _normalize_provider_day_groups(
+    groups: Sequence[tuple[str, str]],
+) -> tuple[tuple[str, str], ...]:
+    return tuple(
+        dict.fromkeys(
+            (str(provider_name), str(bucket_day))
+            for provider_name, bucket_day in groups
+            if str(provider_name) and str(bucket_day)
+        )
+    )
+
+
+def _chunk_provider_day_groups(
+    groups: Sequence[tuple[str, str]],
+    *,
+    size: int = _GROUP_BATCH_SIZE,
+) -> list[tuple[tuple[str, str], ...]]:
+    return [
+        tuple(groups[index:index + size])
+        for index in range(0, len(groups), size)
+        if groups[index:index + size]
+    ]
+
+
+def _empty_provider_day_profile_groups(
+    groups: Sequence[tuple[str, str]],
+) -> dict[tuple[str, str], list[SessionProfileRecord]]:
+    return {group: [] for group in groups}
+
+
+def _group_profile_records_by_provider_day(
+    rows,
+    *,
+    groups: Sequence[tuple[str, str]],
+) -> dict[tuple[str, str], list[SessionProfileRecord]]:
+    grouped: dict[tuple[str, str], list[SessionProfileRecord]] = _empty_provider_day_profile_groups(groups)
+    for row in rows:
+        group = (str(row["group_provider_name"]), str(row["group_bucket_day"]))
+        grouped[group].append(_row_to_session_profile_record(row))
+    return grouped
+
+
+def _group_day_summary_rows(
+    rows: Sequence[DaySessionSummaryRecord],
+    *,
+    groups: Sequence[tuple[str, str]],
+) -> dict[tuple[str, str], list[DaySessionSummaryRecord]]:
+    grouped: dict[tuple[str, str], list[DaySessionSummaryRecord]] = {group: [] for group in groups}
+    for row in rows:
+        group = (row.provider_name, row.day)
+        if group in grouped:
+            grouped[group].append(row)
+    return grouped
+
+
+def _group_tag_rollup_rows(
+    rows: Sequence[SessionTagRollupRecord],
+    *,
+    groups: Sequence[tuple[str, str]],
+) -> dict[tuple[str, str], list[SessionTagRollupRecord]]:
+    grouped: dict[tuple[str, str], list[SessionTagRollupRecord]] = {group: [] for group in groups}
+    for row in rows:
+        group = (row.provider_name, row.bucket_day)
+        if group in grouped:
+            grouped[group].append(row)
+    return grouped
+
+
+def load_sync_provider_day_profile_records_by_groups(
+    conn: sqlite3.Connection,
+    groups: Sequence[tuple[str, str]],
+) -> dict[tuple[str, str], list[SessionProfileRecord]]:
+    normalized_groups = _normalize_provider_day_groups(groups)
+    if not normalized_groups:
+        return {}
+    grouped: dict[tuple[str, str], list[SessionProfileRecord]] = _empty_provider_day_profile_groups(
+        normalized_groups
+    )
+    for group_chunk in _chunk_provider_day_groups(normalized_groups):
+        values = ", ".join("(?, ?)" for _ in group_chunk)
+        params = tuple(value for group in group_chunk for value in group)
+        rows = conn.execute(
+            _PROVIDER_DAY_PROFILE_RECORDS_SQL_TEMPLATE.format(values=values),
+            params,
+        ).fetchall()
+        for group, records in _group_profile_records_by_provider_day(rows, groups=group_chunk).items():
+            grouped[group].extend(records)
+    return grouped
+
+
+async def load_async_provider_day_profile_records_by_groups(
+    conn: aiosqlite.Connection,
+    groups: Sequence[tuple[str, str]],
+) -> dict[tuple[str, str], list[SessionProfileRecord]]:
+    normalized_groups = _normalize_provider_day_groups(groups)
+    if not normalized_groups:
+        return {}
+    grouped: dict[tuple[str, str], list[SessionProfileRecord]] = _empty_provider_day_profile_groups(
+        normalized_groups
+    )
+    for group_chunk in _chunk_provider_day_groups(normalized_groups):
+        values = ", ".join("(?, ?)" for _ in group_chunk)
+        params = tuple(value for group in group_chunk for value in group)
+        rows = await (
+            await conn.execute(
+                _PROVIDER_DAY_PROFILE_RECORDS_SQL_TEMPLATE.format(values=values),
+                params,
+            )
+        ).fetchall()
+        for group, records in _group_profile_records_by_provider_day(rows, groups=group_chunk).items():
+            grouped[group].extend(records)
+    return grouped
 
 
 def refresh_sync_provider_day_aggregates(
     conn: sqlite3.Connection,
     groups: set[tuple[str, str]],
 ) -> None:
-    for provider_name, bucket_day in groups:
-        profile_records = load_sync_provider_day_profile_records(
-            conn,
-            provider_name=provider_name,
-            bucket_day=bucket_day,
-        )
+    normalized_groups = _normalize_provider_day_groups(sorted(groups))
+    for group_chunk in _chunk_provider_day_groups(normalized_groups):
+        profile_records_by_group = load_sync_provider_day_profile_records_by_groups(conn, group_chunk)
+        profile_records = [
+            record
+            for group in group_chunk
+            for record in profile_records_by_group.get(group, [])
+        ]
         profiles = [hydrate_session_profile(record) for record in profile_records]
-        day_rows = build_day_session_summary_records(profiles) if profiles else []
-        tag_rows = build_session_tag_rollup_records(profiles) if profiles else []
-        replace_day_session_summaries_sync(
-            conn,
-            provider_name=provider_name,
-            day=bucket_day,
-            records=[row for row in day_rows if row.provider_name == provider_name and row.day == bucket_day],
+        day_rows_by_group = _group_day_summary_rows(
+            build_day_session_summary_records(profiles) if profiles else [],
+            groups=group_chunk,
         )
-        replace_session_tag_rollup_rows_sync(
-            conn,
-            provider_name=provider_name,
-            bucket_day=bucket_day,
-            records=[
-                row
-                for row in tag_rows
-                if row.provider_name == provider_name and row.bucket_day == bucket_day
-            ],
+        tag_rows_by_group = _group_tag_rollup_rows(
+            build_session_tag_rollup_records(profiles) if profiles else [],
+            groups=group_chunk,
         )
+        for provider_name, bucket_day in group_chunk:
+            replace_day_session_summaries_sync(
+                conn,
+                provider_name=provider_name,
+                day=bucket_day,
+                records=day_rows_by_group[(provider_name, bucket_day)],
+            )
+            replace_session_tag_rollup_rows_sync(
+                conn,
+                provider_name=provider_name,
+                bucket_day=bucket_day,
+                records=tag_rows_by_group[(provider_name, bucket_day)],
+            )
 
 
 async def refresh_async_provider_day_aggregates(
@@ -142,33 +267,41 @@ async def refresh_async_provider_day_aggregates(
     *,
     transaction_depth: int,
 ) -> None:
-    for provider_name, bucket_day in groups:
-        profile_records = await load_async_provider_day_profile_records(
+    normalized_groups = _normalize_provider_day_groups(sorted(groups))
+    for group_chunk in _chunk_provider_day_groups(normalized_groups):
+        profile_records_by_group = await load_async_provider_day_profile_records_by_groups(
             conn,
-            provider_name=provider_name,
-            bucket_day=bucket_day,
+            group_chunk,
         )
+        profile_records = [
+            record
+            for group in group_chunk
+            for record in profile_records_by_group.get(group, [])
+        ]
         profiles = [hydrate_session_profile(record) for record in profile_records]
-        day_rows = build_day_session_summary_records(profiles) if profiles else []
-        tag_rows = build_session_tag_rollup_records(profiles) if profiles else []
-        await replace_day_session_summaries_async(
-            conn,
-            provider_name=provider_name,
-            day=bucket_day,
-            records=[row for row in day_rows if row.provider_name == provider_name and row.day == bucket_day],
-            transaction_depth=transaction_depth,
+        day_rows_by_group = _group_day_summary_rows(
+            build_day_session_summary_records(profiles) if profiles else [],
+            groups=group_chunk,
         )
-        await replace_session_tag_rollup_rows_async(
-            conn,
-            provider_name=provider_name,
-            bucket_day=bucket_day,
-            records=[
-                row
-                for row in tag_rows
-                if row.provider_name == provider_name and row.bucket_day == bucket_day
-            ],
-            transaction_depth=transaction_depth,
+        tag_rows_by_group = _group_tag_rollup_rows(
+            build_session_tag_rollup_records(profiles) if profiles else [],
+            groups=group_chunk,
         )
+        for provider_name, bucket_day in group_chunk:
+            await replace_day_session_summaries_async(
+                conn,
+                provider_name=provider_name,
+                day=bucket_day,
+                records=day_rows_by_group[(provider_name, bucket_day)],
+                transaction_depth=transaction_depth,
+            )
+            await replace_session_tag_rollup_rows_async(
+                conn,
+                provider_name=provider_name,
+                bucket_day=bucket_day,
+                records=tag_rows_by_group[(provider_name, bucket_day)],
+                transaction_depth=transaction_depth,
+            )
 
 
 def profile_provider_day(record: SessionProfileRecord | None) -> tuple[str, str] | None:
@@ -203,7 +336,9 @@ def profile_provider_day(record: SessionProfileRecord | None) -> tuple[str, str]
 __all__ = [
     "_PROFILE_BUCKET_DAY_SQL",
     "load_async_provider_day_profile_records",
+    "load_async_provider_day_profile_records_by_groups",
     "load_sync_provider_day_profile_records",
+    "load_sync_provider_day_profile_records_by_groups",
     "profile_provider_day",
     "refresh_async_provider_day_aggregates",
     "refresh_sync_provider_day_aggregates",

--- a/polylogue/storage/session_product_profiles.py
+++ b/polylogue/storage/session_product_profiles.py
@@ -206,6 +206,8 @@ def build_session_profile_record(
     evidence = profile_evidence_payload(profile)
     inference = profile_inference_payload(profile)
     enrichment = session_enrichment_payload(profile, analysis)
+    evidence_search_text = profile_evidence_search_text(profile)
+    inference_search_text = profile_inference_search_text(profile)
     return SessionProfileRecord(
         conversation_id=profile.conversation_id,
         materializer_version=SESSION_PRODUCT_MATERIALIZER_VERSION,
@@ -241,9 +243,13 @@ def build_session_profile_record(
         evidence_payload=evidence,
         inference_payload=inference,
         enrichment_payload=enrichment,
-        search_text=profile_search_text(profile),
-        evidence_search_text=profile_evidence_search_text(profile),
-        inference_search_text=profile_inference_search_text(profile),
+        search_text=" \n".join(
+            part
+            for part in (evidence_search_text, inference_search_text)
+            if part
+        ) or profile.conversation_id,
+        evidence_search_text=evidence_search_text,
+        inference_search_text=inference_search_text,
         enrichment_search_text=profile_enrichment_search_text(profile, enrichment),
         enrichment_version=SESSION_ENRICHMENT_VERSION,
         enrichment_family=SESSION_ENRICHMENT_FAMILY,

--- a/polylogue/storage/session_product_profiles.py
+++ b/polylogue/storage/session_product_profiles.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import UTC, datetime
 
 from polylogue.lib.phase_extraction import SessionPhase
@@ -87,10 +88,11 @@ def session_enrichment_payload(
     profile: SessionProfile,
     analysis: SessionAnalysis | None,
 ) -> dict[str, object]:
-    user_turns = user_turn_texts(analysis)
-    assistant_turns = assistant_turn_texts(analysis)
-    blockers_val = blocker_texts(analysis)
-    support_signals_val = enrichment_support_signals(profile, analysis)
+    text_bands = _collect_enrichment_text_bands(analysis)
+    user_turns = text_bands.user_turns
+    assistant_turns = text_bands.assistant_turns
+    blockers_val = text_bands.blockers
+    support_signals_val = enrichment_support_signals(profile, analysis, text_bands=text_bands)
     input_band_summary = {
         "user_turns": len(user_turns),
         "assistant_turns": len(assistant_turns),
@@ -396,64 +398,73 @@ def dedupe_texts(values: list[str], *, limit: int | None = None, width: int = 18
     return tuple(items)
 
 
-def user_turn_texts(analysis: SessionAnalysis | None) -> tuple[str, ...]:
+_BLOCKER_MARKERS = (
+    "error",
+    "failed",
+    "failure",
+    "blocked",
+    "cannot",
+    "can't",
+    "exception",
+    "traceback",
+    "panic",
+)
+
+
+@dataclass(frozen=True)
+class _EnrichmentTextBands:
+    user_turns: tuple[str, ...] = ()
+    assistant_turns: tuple[str, ...] = ()
+    blockers: tuple[str, ...] = ()
+
+
+def _collect_enrichment_text_bands(analysis: SessionAnalysis | None) -> _EnrichmentTextBands:
     if analysis is None:
-        return ()
-    return dedupe_texts(
-        [
-            message.text
-            for message in analysis.facts.message_facts
-            if message.is_user and not message.is_context_dump and message.text.strip()
-        ],
-        width=220,
+        return _EnrichmentTextBands()
+
+    user_texts: list[str] = []
+    assistant_texts: list[str] = []
+    blocker_candidates: list[str] = []
+    for message in analysis.facts.message_facts:
+        text = str(message.text or "").strip()
+        if not text:
+            continue
+        if message.is_user and not message.is_context_dump:
+            user_texts.append(message.text)
+            text_lower = message.text.lower()
+            if any(marker in text_lower for marker in _BLOCKER_MARKERS):
+                blocker_candidates.append(message.text)
+        if message.is_assistant and message.is_substantive:
+            assistant_texts.append(message.text)
+
+    return _EnrichmentTextBands(
+        user_turns=dedupe_texts(user_texts, width=220),
+        assistant_turns=dedupe_texts(assistant_texts, width=220),
+        blockers=dedupe_texts(blocker_candidates, limit=4, width=140),
     )
+
+
+def user_turn_texts(analysis: SessionAnalysis | None) -> tuple[str, ...]:
+    return _collect_enrichment_text_bands(analysis).user_turns
 
 
 def assistant_turn_texts(analysis: SessionAnalysis | None) -> tuple[str, ...]:
-    if analysis is None:
-        return ()
-    return dedupe_texts(
-        [
-            message.text
-            for message in analysis.facts.message_facts
-            if message.is_assistant and message.is_substantive and message.text.strip()
-        ],
-        width=220,
-    )
+    return _collect_enrichment_text_bands(analysis).assistant_turns
 
 
 def blocker_texts(analysis: SessionAnalysis | None) -> tuple[str, ...]:
-    if analysis is None:
-        return ()
-    blocker_markers = (
-        "error",
-        "failed",
-        "failure",
-        "blocked",
-        "cannot",
-        "can't",
-        "exception",
-        "traceback",
-        "panic",
-    )
-    texts = [
-        message.text
-        for message in analysis.facts.message_facts
-        if message.is_user
-        and not message.is_context_dump
-        and message.text.strip()
-        and any(marker in message.text.lower() for marker in blocker_markers)
-    ]
-    return dedupe_texts(texts, limit=4, width=140)
+    return _collect_enrichment_text_bands(analysis).blockers
 
 
 def enrichment_support_signals(
     profile: SessionProfile,
     analysis: SessionAnalysis | None,
+    *,
+    text_bands: _EnrichmentTextBands | None = None,
 ) -> tuple[str, ...]:
     signals: list[str] = []
-    user_turns = user_turn_texts(analysis)
-    if user_turns:
+    bands = text_bands or _collect_enrichment_text_bands(analysis)
+    if bands.user_turns:
         signals.append("user_turns")
     if analysis is not None and analysis.facts.action_events:
         signals.append("action_events")
@@ -463,7 +474,7 @@ def enrichment_support_signals(
         signals.append("canonical_projects")
     if profile.work_events:
         signals.append("heuristic_work_events")
-    if assistant_turn_texts(analysis):
+    if bands.assistant_turns:
         signals.append("assistant_outcome_text")
     return tuple(signals)
 

--- a/polylogue/storage/session_product_rebuild.py
+++ b/polylogue/storage/session_product_rebuild.py
@@ -8,8 +8,6 @@ from collections.abc import Iterable, Sequence
 
 import aiosqlite
 
-from polylogue.archive_product_rollups import build_session_tag_rollup_records
-from polylogue.archive_product_summaries import build_day_session_summary_records
 from polylogue.lib.session_profile import build_session_analysis, build_session_profile
 from polylogue.storage.action_event_rows import attach_blocks_to_messages
 from polylogue.storage.backends.queries.attachments import get_attachments_batch
@@ -20,16 +18,20 @@ from polylogue.storage.backends.queries.mappers import (
     _row_to_session_profile_record,
 )
 from polylogue.storage.hydrators import conversation_from_records
+from polylogue.storage.session_product_aggregates import (
+    list_async_provider_day_groups,
+    list_sync_provider_day_groups,
+    refresh_async_provider_day_aggregates,
+    refresh_sync_provider_day_aggregates,
+)
 from polylogue.storage.session_product_profiles import (
     build_session_profile_record,
     hydrate_session_profile,
     now_iso,
 )
 from polylogue.storage.session_product_storage import (
-    replace_day_session_summaries_sync,
     replace_session_phases_sync,
     replace_session_profile_sync,
-    replace_session_tag_rollup_rows_sync,
     replace_session_work_events_sync,
     replace_work_thread_sync,
 )
@@ -300,36 +302,20 @@ def rebuild_session_products_sync(
     thread_records = build_all_thread_records_sync(conn)
     for record in thread_records:
         replace_work_thread_sync(conn, record.thread_id, record)
-    conn.execute("DELETE FROM session_tag_rollups")
-    tag_rows = build_session_tag_rollup_records(iter_hydrated_session_profiles_sync(conn, page_size=page_size))
-    for provider_name, bucket_day in sorted({(row.provider_name, row.bucket_day) for row in tag_rows}):
-        replace_session_tag_rollup_rows_sync(
-            conn,
-            provider_name=provider_name,
-            bucket_day=bucket_day,
-            records=[
-                row
-                for row in tag_rows
-                if row.provider_name == provider_name and row.bucket_day == bucket_day
-            ],
-        )
     conn.execute("DELETE FROM day_session_summaries")
-    day_rows = build_day_session_summary_records(iter_hydrated_session_profiles_sync(conn, page_size=page_size))
-    for provider_name, bucket_day in sorted({(row.provider_name, row.day) for row in day_rows}):
-        replace_day_session_summaries_sync(
-            conn,
-            provider_name=provider_name,
-            day=bucket_day,
-            records=[row for row in day_rows if row.provider_name == provider_name and row.day == bucket_day],
-        )
+    conn.execute("DELETE FROM session_tag_rollups")
+    provider_day_groups = set(list_sync_provider_day_groups(conn))
+    refresh_sync_provider_day_aggregates(conn, provider_day_groups)
+    tag_rollup_count = conn.execute("SELECT COUNT(*) FROM session_tag_rollups").fetchone()[0]
+    day_summary_count = conn.execute("SELECT COUNT(*) FROM day_session_summaries").fetchone()[0]
     conn.commit()
     return {
         "profiles": profile_count,
         "work_events": work_event_count,
         "phases": phase_count,
         "threads": len(thread_records),
-        "tag_rollups": len(tag_rows),
-        "day_summaries": len(day_rows),
+        "tag_rollups": int(tag_rollup_count),
+        "day_summaries": int(day_summary_count),
     }
 
 
@@ -342,10 +328,6 @@ async def rebuild_session_products_async(
 ) -> dict[str, int]:
     from polylogue.storage.backends.queries.session_product_profile_writes import (
         replace_session_profile,
-    )
-    from polylogue.storage.backends.queries.session_product_summary_queries import (
-        replace_day_session_summaries,
-        replace_session_tag_rollup_rows,
     )
     from polylogue.storage.backends.queries.session_product_thread_queries import replace_work_thread
     from polylogue.storage.backends.queries.session_product_timeline_writes import (
@@ -386,43 +368,27 @@ async def rebuild_session_products_async(
     thread_records = await build_all_thread_records_async(conn)
     for record in thread_records:
         await replace_work_thread(conn, record.thread_id, record, transaction_depth)
-    rows = await (
-        await conn.execute(
-            "SELECT * FROM session_profiles ORDER BY COALESCE(source_sort_key, 0) DESC, conversation_id"
-        )
-    ).fetchall()
-    all_profiles = [hydrate_session_profile(_row_to_session_profile_record(row)) for row in rows]
-    await conn.execute("DELETE FROM session_tag_rollups")
-    tag_rows = build_session_tag_rollup_records(all_profiles)
-    for provider_name, bucket_day in sorted({(row.provider_name, row.bucket_day) for row in tag_rows}):
-        await replace_session_tag_rollup_rows(
-            conn,
-            provider_name=provider_name,
-            bucket_day=bucket_day,
-            records=[
-                row
-                for row in tag_rows
-                if row.provider_name == provider_name and row.bucket_day == bucket_day
-            ],
-            transaction_depth=transaction_depth,
-        )
     await conn.execute("DELETE FROM day_session_summaries")
-    day_rows = build_day_session_summary_records(all_profiles)
-    for provider_name, bucket_day in sorted({(row.provider_name, row.day) for row in day_rows}):
-        await replace_day_session_summaries(
-            conn,
-            provider_name=provider_name,
-            day=bucket_day,
-            records=[row for row in day_rows if row.provider_name == provider_name and row.day == bucket_day],
-            transaction_depth=transaction_depth,
-        )
+    await conn.execute("DELETE FROM session_tag_rollups")
+    provider_day_groups = set(await list_async_provider_day_groups(conn))
+    await refresh_async_provider_day_aggregates(
+        conn,
+        provider_day_groups,
+        transaction_depth=transaction_depth,
+    )
+    tag_rollup_count = (
+        await (await conn.execute("SELECT COUNT(*) FROM session_tag_rollups")).fetchone()
+    )[0]
+    day_summary_count = (
+        await (await conn.execute("SELECT COUNT(*) FROM day_session_summaries")).fetchone()
+    )[0]
     return {
         "profiles": profile_count,
         "work_events": work_event_count,
         "phases": phase_count,
         "threads": len(thread_records),
-        "tag_rollups": len(tag_rows),
-        "day_summaries": len(day_rows),
+        "tag_rollups": int(tag_rollup_count),
+        "day_summaries": int(day_summary_count),
     }
 
 

--- a/polylogue/storage/session_product_refresh.py
+++ b/polylogue/storage/session_product_refresh.py
@@ -13,7 +13,6 @@ from polylogue.storage.session_product_aggregates import (
     profile_provider_day,
     refresh_async_provider_day_aggregates,
 )
-from polylogue.storage.session_product_profiles import hydrate_session_profile
 from polylogue.storage.session_product_rebuild import (
     build_session_product_records,
     chunked,
@@ -21,7 +20,7 @@ from polylogue.storage.session_product_rebuild import (
     load_async_batch,
 )
 from polylogue.storage.session_product_threads import (
-    load_thread_profile_records_async,
+    build_thread_records_for_roots_async,
     thread_root_id_async,
     thread_root_ids_async,
 )
@@ -59,24 +58,35 @@ async def _refresh_thread_root_async(
     *,
     transaction_depth: int,
 ) -> int:
-    from polylogue.lib.threads import build_session_threads
+    return await _refresh_thread_roots_async(
+        conn,
+        [root_id] if root_id is not None else [],
+        transaction_depth=transaction_depth,
+    )
+
+
+async def _refresh_thread_roots_async(
+    conn: aiosqlite.Connection,
+    root_ids: Sequence[str],
+    *,
+    transaction_depth: int,
+) -> int:
     from polylogue.storage.backends.queries.session_product_thread_queries import (
         replace_work_thread,
     )
-    from polylogue.storage.session_product_threads import build_work_thread_record
 
-    if root_id is None:
+    normalized_root_ids = tuple(dict.fromkeys(str(root_id) for root_id in root_ids if str(root_id)))
+    if not normalized_root_ids:
         return 0
 
-    profile_records = await load_thread_profile_records_async(conn, root_id)
-    profiles = [hydrate_session_profile(record) for record in profile_records]
-    threads = build_session_threads(profiles)
-    record = next(
-        (build_work_thread_record(thread) for thread in threads if thread.thread_id == root_id),
-        None,
-    )
-    await replace_work_thread(conn, root_id, record, transaction_depth)
-    return 1 if record is not None else 0
+    thread_records = await build_thread_records_for_roots_async(conn, normalized_root_ids)
+    refreshed = 0
+    for root_id in normalized_root_ids:
+        record = thread_records.get(root_id)
+        await replace_work_thread(conn, root_id, record, transaction_depth)
+        if record is not None:
+            refreshed += 1
+    return refreshed
 
 
 async def refresh_thread_after_conversation_delete_async(

--- a/polylogue/storage/session_product_threads.py
+++ b/polylogue/storage/session_product_threads.py
@@ -297,15 +297,29 @@ async def build_thread_records_for_roots_async(
 
 def build_all_thread_records_sync(conn: sqlite3.Connection) -> list[WorkThreadRecord]:
     root_ids = [str(row["conversation_id"]) for row in conn.execute(_ROOT_THREAD_IDS_SQL).fetchall()]
-    records_by_root = build_thread_records_for_roots_sync(conn, root_ids)
-    return [records_by_root[root_id] for root_id in root_ids if root_id in records_by_root]
+    records: list[WorkThreadRecord] = []
+    for root_chunk in _chunk_root_ids(root_ids):
+        records_by_root = build_thread_records_for_roots_sync(conn, root_chunk)
+        records.extend(
+            records_by_root[root_id]
+            for root_id in root_chunk
+            if root_id in records_by_root
+        )
+    return records
 
 
 async def build_all_thread_records_async(conn: aiosqlite.Connection) -> list[WorkThreadRecord]:
     rows = await (await conn.execute(_ROOT_THREAD_IDS_SQL)).fetchall()
     root_ids = [str(row["conversation_id"]) for row in rows]
-    records_by_root = await build_thread_records_for_roots_async(conn, root_ids)
-    return [records_by_root[root_id] for root_id in root_ids if root_id in records_by_root]
+    records: list[WorkThreadRecord] = []
+    for root_chunk in _chunk_root_ids(root_ids):
+        records_by_root = await build_thread_records_for_roots_async(conn, root_chunk)
+        records.extend(
+            records_by_root[root_id]
+            for root_id in root_chunk
+            if root_id in records_by_root
+        )
+    return records
 
 
 __all__ = [

--- a/polylogue/storage/session_product_threads.py
+++ b/polylogue/storage/session_product_threads.py
@@ -10,7 +10,11 @@ import aiosqlite
 from polylogue.lib.threads import WorkThread, build_session_threads
 from polylogue.storage.backends.queries.mappers import _row_to_session_profile_record
 from polylogue.storage.session_product_profiles import hydrate_session_profile, now_iso
-from polylogue.storage.store import SESSION_PRODUCT_MATERIALIZER_VERSION, WorkThreadRecord
+from polylogue.storage.store import (
+    SESSION_PRODUCT_MATERIALIZER_VERSION,
+    SessionProfileRecord,
+    WorkThreadRecord,
+)
 
 _ROOT_THREAD_IDS_SQL = """
     SELECT c.conversation_id
@@ -62,6 +66,22 @@ _THREAD_CONVERSATION_IDS_SQL = """
     FROM descendants
     ORDER BY conversation_id
 """
+_THREAD_PROFILE_RECORDS_BY_ROOT_SQL_TEMPLATE = """
+    WITH RECURSIVE descendants(root_id, conversation_id) AS (
+        SELECT conversation_id, conversation_id
+        FROM conversations
+        WHERE conversation_id IN ({placeholders})
+        UNION ALL
+        SELECT d.root_id, c.conversation_id
+        FROM conversations c
+        JOIN descendants d ON c.parent_conversation_id = d.conversation_id
+    )
+    SELECT d.root_id, sp.*
+    FROM descendants d
+    JOIN session_profiles sp ON sp.conversation_id = d.conversation_id
+    ORDER BY d.root_id, COALESCE(sp.source_sort_key, 0) DESC, sp.conversation_id
+"""
+_ROOT_BATCH_SIZE = 200
 
 
 # ---------------------------------------------------------------------------
@@ -156,71 +176,148 @@ async def thread_conversation_ids_async(conn: aiosqlite.Connection, root_id: str
     return [str(row["conversation_id"]) for row in rows]
 
 
+def _chunk_root_ids(root_ids: Sequence[str], *, size: int = _ROOT_BATCH_SIZE) -> list[tuple[str, ...]]:
+    return [
+        tuple(root_ids[index:index + size])
+        for index in range(0, len(root_ids), size)
+        if root_ids[index:index + size]
+    ]
+
+
+def _empty_profile_record_groups(root_ids: Sequence[str]) -> dict[str, list[SessionProfileRecord]]:
+    return {str(root_id): [] for root_id in root_ids}
+
+
+def _group_profile_records_by_root(
+    rows,
+    *,
+    root_ids: Sequence[str],
+) -> dict[str, list[SessionProfileRecord]]:
+    grouped: dict[str, list[SessionProfileRecord]] = _empty_profile_record_groups(root_ids)
+    for row in rows:
+        grouped[str(row["root_id"])].append(_row_to_session_profile_record(row))
+    return grouped
+
+
+def _thread_records_from_profile_records(
+    profile_records: Sequence[SessionProfileRecord],
+) -> dict[str, WorkThreadRecord]:
+    if not profile_records:
+        return {}
+    profiles = [hydrate_session_profile(record) for record in profile_records]
+    return {
+        thread.thread_id: build_work_thread_record(thread)
+        for thread in build_session_threads(profiles)
+    }
+
+
 def load_thread_profile_records_sync(conn: sqlite3.Connection, root_id: str):
-    conversation_ids = thread_conversation_ids_sync(conn, root_id)
-    if not conversation_ids:
-        return []
-    placeholders = ", ".join("?" for _ in conversation_ids)
-    rows = conn.execute(
-        f"SELECT * FROM session_profiles WHERE conversation_id IN ({placeholders})",
-        tuple(conversation_ids),
-    ).fetchall()
-    return [_row_to_session_profile_record(row) for row in rows]
+    return load_thread_profile_records_by_root_sync(conn, [root_id]).get(root_id, [])
 
 
 async def load_thread_profile_records_async(conn: aiosqlite.Connection, root_id: str):
-    conversation_ids = await thread_conversation_ids_async(conn, root_id)
-    if not conversation_ids:
-        return []
-    placeholders = ", ".join("?" for _ in conversation_ids)
-    rows = await (
-        await conn.execute(
-            f"SELECT * FROM session_profiles WHERE conversation_id IN ({placeholders})",
-            tuple(conversation_ids),
-        )
-    ).fetchall()
-    return [_row_to_session_profile_record(row) for row in rows]
+    return (await load_thread_profile_records_by_root_async(conn, [root_id])).get(root_id, [])
 
 
-def build_all_thread_records_sync(conn: sqlite3.Connection) -> list[object]:
+def load_thread_profile_records_by_root_sync(
+    conn: sqlite3.Connection,
+    root_ids: Sequence[str],
+) -> dict[str, list[SessionProfileRecord]]:
+    normalized_root_ids = tuple(dict.fromkeys(str(root_id) for root_id in root_ids if str(root_id)))
+    if not normalized_root_ids:
+        return {}
+    grouped: dict[str, list[SessionProfileRecord]] = _empty_profile_record_groups(normalized_root_ids)
+    for root_chunk in _chunk_root_ids(normalized_root_ids):
+        placeholders = ", ".join("?" for _ in root_chunk)
+        rows = conn.execute(
+            _THREAD_PROFILE_RECORDS_BY_ROOT_SQL_TEMPLATE.format(placeholders=placeholders),
+            root_chunk,
+        ).fetchall()
+        for root_id, records in _group_profile_records_by_root(rows, root_ids=root_chunk).items():
+            grouped[root_id].extend(records)
+    return grouped
+
+
+async def load_thread_profile_records_by_root_async(
+    conn: aiosqlite.Connection,
+    root_ids: Sequence[str],
+) -> dict[str, list[SessionProfileRecord]]:
+    normalized_root_ids = tuple(dict.fromkeys(str(root_id) for root_id in root_ids if str(root_id)))
+    if not normalized_root_ids:
+        return {}
+    grouped: dict[str, list[SessionProfileRecord]] = _empty_profile_record_groups(normalized_root_ids)
+    for root_chunk in _chunk_root_ids(normalized_root_ids):
+        placeholders = ", ".join("?" for _ in root_chunk)
+        rows = await (
+            await conn.execute(
+                _THREAD_PROFILE_RECORDS_BY_ROOT_SQL_TEMPLATE.format(placeholders=placeholders),
+                root_chunk,
+            )
+        ).fetchall()
+        for root_id, records in _group_profile_records_by_root(rows, root_ids=root_chunk).items():
+            grouped[root_id].extend(records)
+    return grouped
+
+
+def build_thread_records_for_roots_sync(
+    conn: sqlite3.Connection,
+    root_ids: Sequence[str],
+) -> dict[str, WorkThreadRecord]:
+    profile_records_by_root = load_thread_profile_records_by_root_sync(conn, root_ids)
+    profile_records = [
+        record
+        for root_id in root_ids
+        for record in profile_records_by_root.get(root_id, [])
+    ]
+    thread_records = _thread_records_from_profile_records(profile_records)
+    return {
+        str(root_id): thread_records[str(root_id)]
+        for root_id in root_ids
+        if str(root_id) in thread_records
+    }
+
+
+async def build_thread_records_for_roots_async(
+    conn: aiosqlite.Connection,
+    root_ids: Sequence[str],
+) -> dict[str, WorkThreadRecord]:
+    profile_records_by_root = await load_thread_profile_records_by_root_async(conn, root_ids)
+    profile_records = [
+        record
+        for root_id in root_ids
+        for record in profile_records_by_root.get(root_id, [])
+    ]
+    thread_records = _thread_records_from_profile_records(profile_records)
+    return {
+        str(root_id): thread_records[str(root_id)]
+        for root_id in root_ids
+        if str(root_id) in thread_records
+    }
+
+
+def build_all_thread_records_sync(conn: sqlite3.Connection) -> list[WorkThreadRecord]:
     root_ids = [str(row["conversation_id"]) for row in conn.execute(_ROOT_THREAD_IDS_SQL).fetchall()]
-    records: list[object] = []
-    for root_id in root_ids:
-        profile_records = load_thread_profile_records_sync(conn, root_id)
-        if not profile_records:
-            continue
-        profiles = [hydrate_session_profile(record) for record in profile_records]
-        threads = build_session_threads(profiles)
-        for thread in threads:
-            if thread.thread_id == root_id:
-                records.append(build_work_thread_record(thread))
-                break
-    return records
+    records_by_root = build_thread_records_for_roots_sync(conn, root_ids)
+    return [records_by_root[root_id] for root_id in root_ids if root_id in records_by_root]
 
 
-async def build_all_thread_records_async(conn: aiosqlite.Connection) -> list[object]:
+async def build_all_thread_records_async(conn: aiosqlite.Connection) -> list[WorkThreadRecord]:
     rows = await (await conn.execute(_ROOT_THREAD_IDS_SQL)).fetchall()
     root_ids = [str(row["conversation_id"]) for row in rows]
-    records: list[object] = []
-    for root_id in root_ids:
-        profile_records = await load_thread_profile_records_async(conn, root_id)
-        if not profile_records:
-            continue
-        profiles = [hydrate_session_profile(record) for record in profile_records]
-        threads = build_session_threads(profiles)
-        for thread in threads:
-            if thread.thread_id == root_id:
-                records.append(build_work_thread_record(thread))
-                break
-    return records
+    records_by_root = await build_thread_records_for_roots_async(conn, root_ids)
+    return [records_by_root[root_id] for root_id in root_ids if root_id in records_by_root]
 
 
 __all__ = [
     "build_all_thread_records_async",
     "build_all_thread_records_sync",
+    "build_thread_records_for_roots_async",
+    "build_thread_records_for_roots_sync",
     "build_work_thread_record",
     "hydrate_work_thread",
     "load_thread_profile_records_async",
+    "load_thread_profile_records_by_root_async",
+    "load_thread_profile_records_by_root_sync",
     "load_thread_profile_records_sync",
     "thread_conversation_ids_async",
     "thread_conversation_ids_sync",

--- a/polylogue/storage/session_product_timeline_rows.py
+++ b/polylogue/storage/session_product_timeline_rows.py
@@ -31,9 +31,19 @@ from polylogue.storage.store import (
 
 
 def event_id(conversation_id: str, event_index: int, event: WorkEvent) -> str:
+    return _event_id(conversation_id, event_index, event, summary=event_summary(event))
+
+
+def _event_id(
+    conversation_id: str,
+    event_index: int,
+    event: WorkEvent,
+    *,
+    summary: str,
+) -> str:
     seed = (
         f"{conversation_id}:{event_index}:{event.kind.value}:{event.start_index}:"
-        f"{event.end_index}:{event_summary(event)}"
+        f"{event.end_index}:{summary}"
     )
     return f"wev-{hash_text(seed)[:16]}"
 
@@ -56,11 +66,27 @@ def event_evidence_payload(event: WorkEvent) -> dict[str, object]:
 
 
 def event_inference_payload(event: WorkEvent) -> dict[str, object]:
+    summary = event_summary(event)
     signals = event_support_signals(event)
     fallback = event_fallback(event)
+    return _event_inference_payload(
+        event,
+        summary=summary,
+        signals=signals,
+        fallback=fallback,
+    )
+
+
+def _event_inference_payload(
+    event: WorkEvent,
+    *,
+    summary: str,
+    signals: tuple[str, ...],
+    fallback: bool,
+) -> dict[str, object]:
     return {
         "kind": event.kind.value,
-        "summary": event_summary(event),
+        "summary": summary,
         "confidence": event.confidence,
         "evidence": list(event.evidence),
         "support_level": support_level(
@@ -74,11 +100,20 @@ def event_inference_payload(event: WorkEvent) -> dict[str, object]:
 
 
 def event_search_text(profile: SessionProfile, event: WorkEvent) -> str:
+    return _event_search_text(profile, event, summary=event_summary(event))
+
+
+def _event_search_text(
+    profile: SessionProfile,
+    event: WorkEvent,
+    *,
+    summary: str,
+) -> str:
     parts = [
         profile.provider,
         profile.title or "",
         event.kind.value,
-        event_summary(event),
+        summary,
         *profile.canonical_projects,
         *event.file_paths,
         *event.tools_used,
@@ -93,39 +128,54 @@ def build_session_work_event_records(
     materialized_at: str | None = None,
 ) -> list[SessionWorkEventRecord]:
     built_at = materialized_at or now_iso()
-    return [
-        SessionWorkEventRecord(
-            event_id=event_id(profile.conversation_id, index, event),
-            conversation_id=profile.conversation_id,
-            materializer_version=SESSION_PRODUCT_MATERIALIZER_VERSION,
-            materialized_at=built_at,
-            source_updated_at=profile.updated_at.isoformat() if profile.updated_at else None,
-            source_sort_key=profile.updated_at.timestamp() if profile.updated_at else None,
-            provider_name=profile.provider,
-            event_index=index,
-            kind=event.kind.value,
-            confidence=event.confidence,
-            start_index=event.start_index,
-            end_index=event.end_index,
-            start_time=event.start_time.isoformat() if event.start_time else None,
-            end_time=event.end_time.isoformat() if event.end_time else None,
-            duration_ms=event.duration_ms,
-            canonical_session_date=(
-                event.canonical_session_date.isoformat()
-                if event.canonical_session_date
-                else None
-            ),
-            summary=event_summary(event),
-            file_paths=event.file_paths,
-            tools_used=event.tools_used,
-            evidence_payload=event_evidence_payload(event),
-            inference_payload=event_inference_payload(event),
-            search_text=event_search_text(profile, event),
-            inference_version=SESSION_INFERENCE_VERSION,
-            inference_family=SESSION_INFERENCE_FAMILY,
+    source_updated_at = profile.updated_at.isoformat() if profile.updated_at else None
+    source_sort_key = profile.updated_at.timestamp() if profile.updated_at else None
+    records: list[SessionWorkEventRecord] = []
+    for index, event in enumerate(profile.work_events):
+        summary = event_summary(event)
+        signals = event_support_signals(event)
+        fallback = event_fallback(event)
+        start_time = event.start_time.isoformat() if event.start_time else None
+        end_time = event.end_time.isoformat() if event.end_time else None
+        canonical_session_date = (
+            event.canonical_session_date.isoformat()
+            if event.canonical_session_date
+            else None
         )
-        for index, event in enumerate(profile.work_events)
-    ]
+        records.append(
+            SessionWorkEventRecord(
+                event_id=_event_id(profile.conversation_id, index, event, summary=summary),
+                conversation_id=profile.conversation_id,
+                materializer_version=SESSION_PRODUCT_MATERIALIZER_VERSION,
+                materialized_at=built_at,
+                source_updated_at=source_updated_at,
+                source_sort_key=source_sort_key,
+                provider_name=profile.provider,
+                event_index=index,
+                kind=event.kind.value,
+                confidence=event.confidence,
+                start_index=event.start_index,
+                end_index=event.end_index,
+                start_time=start_time,
+                end_time=end_time,
+                duration_ms=event.duration_ms,
+                canonical_session_date=canonical_session_date,
+                summary=summary,
+                file_paths=event.file_paths,
+                tools_used=event.tools_used,
+                evidence_payload=event_evidence_payload(event),
+                inference_payload=_event_inference_payload(
+                    event,
+                    summary=summary,
+                    signals=signals,
+                    fallback=fallback,
+                ),
+                search_text=_event_search_text(profile, event, summary=summary),
+                inference_version=SESSION_INFERENCE_VERSION,
+                inference_family=SESSION_INFERENCE_FAMILY,
+            )
+        )
+    return records
 
 
 def hydrate_work_event(record: SessionWorkEventRecord) -> WorkEvent:
@@ -177,6 +227,19 @@ def phase_evidence_payload(phase: SessionPhase) -> dict[str, object]:
 def phase_inference_payload(phase: SessionPhase) -> dict[str, object]:
     signals = phase_support_signals(phase)
     fallback = phase_fallback(phase)
+    return _phase_inference_payload(
+        phase,
+        signals=signals,
+        fallback=fallback,
+    )
+
+
+def _phase_inference_payload(
+    phase: SessionPhase,
+    *,
+    signals: tuple[str, ...],
+    fallback: bool,
+) -> dict[str, object]:
     return {
         "confidence": phase.confidence,
         "evidence": list(phase.evidence),
@@ -196,39 +259,52 @@ def build_session_phase_records(
     materialized_at: str | None = None,
 ) -> list[SessionPhaseRecord]:
     built_at = materialized_at or now_iso()
-    return [
-        SessionPhaseRecord(
-            phase_id=phase_id(profile.conversation_id, index, phase),
-            conversation_id=profile.conversation_id,
-            materializer_version=SESSION_PRODUCT_MATERIALIZER_VERSION,
-            materialized_at=built_at,
-            source_updated_at=profile.updated_at.isoformat() if profile.updated_at else None,
-            source_sort_key=profile.updated_at.timestamp() if profile.updated_at else None,
-            provider_name=profile.provider,
-            phase_index=index,
-            kind="phase",
-            start_index=phase.message_range[0],
-            end_index=phase.message_range[1],
-            start_time=phase.start_time.isoformat() if phase.start_time else None,
-            end_time=phase.end_time.isoformat() if phase.end_time else None,
-            duration_ms=phase.duration_ms,
-            canonical_session_date=(
-                phase.canonical_session_date.isoformat()
-                if phase.canonical_session_date
-                else None
-            ),
-            confidence=phase.confidence,
-            evidence_reasons=phase.evidence,
-            tool_counts=phase.tool_counts,
-            word_count=phase.word_count,
-            evidence_payload=phase_evidence_payload(phase),
-            inference_payload=phase_inference_payload(phase),
-            search_text=phase_search_text(profile, phase),
-            inference_version=SESSION_INFERENCE_VERSION,
-            inference_family=SESSION_INFERENCE_FAMILY,
+    source_updated_at = profile.updated_at.isoformat() if profile.updated_at else None
+    source_sort_key = profile.updated_at.timestamp() if profile.updated_at else None
+    records: list[SessionPhaseRecord] = []
+    for index, phase in enumerate(profile.phases):
+        start_time = phase.start_time.isoformat() if phase.start_time else None
+        end_time = phase.end_time.isoformat() if phase.end_time else None
+        canonical_session_date = (
+            phase.canonical_session_date.isoformat()
+            if phase.canonical_session_date
+            else None
         )
-        for index, phase in enumerate(profile.phases)
-    ]
+        signals = phase_support_signals(phase)
+        fallback = phase_fallback(phase)
+        records.append(
+            SessionPhaseRecord(
+                phase_id=phase_id(profile.conversation_id, index, phase),
+                conversation_id=profile.conversation_id,
+                materializer_version=SESSION_PRODUCT_MATERIALIZER_VERSION,
+                materialized_at=built_at,
+                source_updated_at=source_updated_at,
+                source_sort_key=source_sort_key,
+                provider_name=profile.provider,
+                phase_index=index,
+                kind="phase",
+                start_index=phase.message_range[0],
+                end_index=phase.message_range[1],
+                start_time=start_time,
+                end_time=end_time,
+                duration_ms=phase.duration_ms,
+                canonical_session_date=canonical_session_date,
+                confidence=phase.confidence,
+                evidence_reasons=phase.evidence,
+                tool_counts=phase.tool_counts,
+                word_count=phase.word_count,
+                evidence_payload=phase_evidence_payload(phase),
+                inference_payload=_phase_inference_payload(
+                    phase,
+                    signals=signals,
+                    fallback=fallback,
+                ),
+                search_text=phase_search_text(profile, phase),
+                inference_version=SESSION_INFERENCE_VERSION,
+                inference_family=SESSION_INFERENCE_FAMILY,
+            )
+        )
+    return records
 
 
 def hydrate_session_phase(record: SessionPhaseRecord) -> SessionPhase:

--- a/tests/unit/cli/test_run_laws.py
+++ b/tests/unit/cli/test_run_laws.py
@@ -23,6 +23,9 @@ from polylogue.cli.run_observers import (
     PlainProgressObserver as _PlainProgressObserver,
 )
 from polylogue.cli.run_observers import (
+    RichProgressObserver as _RichProgressObserver,
+)
+from polylogue.cli.run_observers import (
     _format_elapsed,
 )
 from polylogue.config import Config, get_config
@@ -317,3 +320,17 @@ def test_plain_progress_observer_completion_contract() -> None:
         "  Counts: 3 conv (3 new)",
         "  Pipeline complete in 5s",
     ]
+
+
+def test_rich_progress_observer_parses_explicit_totals() -> None:
+    progress = MagicMock()
+    observer = _RichProgressObserver(progress, task_id="task-1")
+
+    observer.on_progress(200, "Indexing: full-text search 1,000/10,153")
+
+    progress.update.assert_called_once_with(
+        "task-1",
+        description="Indexing: full-text search 1,000/10,153",
+        total=10153,
+        completed=1000,
+    )

--- a/tests/unit/core/test_conversation_semantics.py
+++ b/tests/unit/core/test_conversation_semantics.py
@@ -202,6 +202,21 @@ class TestMessageSemanticProjection:
         )
         assert msg.is_context_dump is True
 
+    def test_multiline_context_markers_are_context_dumps(self):
+        contents_dump = Message(
+            id="m2",
+            role="user",
+            text="Please inspect this.\nContents of /realm/project/polylogue/README.md:\nhello",
+        )
+        file_path_dump = Message(
+            id="m3",
+            role="user",
+            text="Captured payload:\n<file path=/realm/project/polylogue/README.md>\nhello",
+        )
+
+        assert contents_dump.is_context_dump is True
+        assert file_path_dump.is_context_dump is True
+
 
 class TestConversationMetadataAndAggregation:
     def test_title_summary_tags_and_display_contract(self, conversation_with_metadata):

--- a/tests/unit/core/test_semantic_facts.py
+++ b/tests/unit/core/test_semantic_facts.py
@@ -85,6 +85,73 @@ def _semantic_conversation() -> Conversation:
     )
 
 
+def _protocol_summary_conversation() -> Conversation:
+    return Conversation(
+        id="conv-work-event-summary",
+        provider="claude-code",
+        title="Work Event Summary",
+        created_at=datetime(2026, 3, 23, 10, 0, tzinfo=timezone.utc),
+        updated_at=datetime(2026, 3, 23, 10, 5, tzinfo=timezone.utc),
+        messages=MessageCollection(
+            messages=[
+                Message(
+                    id="u1",
+                    role="user",
+                    provider="claude-code",
+                    text=(
+                        "<system-reminder>skip this</system-reminder>\n"
+                        "Please inspect /realm/project/polylogue/README.md and summarize the findings clearly. "
+                        * 3
+                    ),
+                    timestamp=datetime(2026, 3, 23, 10, 0, tzinfo=timezone.utc),
+                ),
+                Message(
+                    id="a1",
+                    role="assistant",
+                    provider="claude-code",
+                    text="I will inspect the file.",
+                    timestamp=datetime(2026, 3, 23, 10, 1, tzinfo=timezone.utc),
+                    provider_meta={
+                        "raw": {
+                            "type": "assistant",
+                            "uuid": "a1",
+                            "message": {
+                                "role": "assistant",
+                                "content": [
+                                    {"type": "text", "text": "I will inspect the file."},
+                                    {
+                                        "type": "tool_use",
+                                        "id": "tool-1",
+                                        "name": "Read",
+                                        "input": {"file_path": "/realm/project/polylogue/README.md"},
+                                    },
+                                ],
+                            },
+                        }
+                    },
+                ),
+                Message(
+                    id="u2",
+                    role="user",
+                    provider="claude-code",
+                    text=(
+                        "Second user summary that should still fit after cleanup. "
+                        "It repeats a bit so we hit the summary truncation boundary."
+                    ),
+                    timestamp=datetime(2026, 3, 23, 10, 2, tzinfo=timezone.utc),
+                ),
+                Message(
+                    id="u3",
+                    role="user",
+                    provider="claude-code",
+                    text="This trailing note should be truncated away once the summary is already full.",
+                    timestamp=datetime(2026, 3, 23, 10, 3, tzinfo=timezone.utc),
+                ),
+            ]
+        ),
+    )
+
+
 def test_build_projection_semantic_facts_counts_renderable_and_empty_messages() -> None:
     projection = ConversationRenderProjection(
         conversation=ConversationRecord(
@@ -215,6 +282,18 @@ def test_build_session_analysis_reuses_precomputed_phases(monkeypatch: pytest.Mo
     assert work_event_phase_calls == 0
     assert analysis.work_events
     assert analysis.phases
+
+
+def test_extract_work_events_strips_protocol_noise_and_respects_summary_cap() -> None:
+    events = work_event_extraction.extract_work_events(_protocol_summary_conversation())
+
+    assert events
+    summary = events[0].summary
+    assert "<system-reminder>" not in summary
+    assert "skip this" not in summary
+    assert "Please inspect /realm/project/polylogue/README.md" in summary
+    assert "This trailing note should be truncated away" not in summary
+    assert len(summary) <= 200
 
 
 def test_build_conversation_semantic_facts_uses_canonical_db_content_blocks() -> None:

--- a/tests/unit/core/test_semantic_facts.py
+++ b/tests/unit/core/test_semantic_facts.py
@@ -349,6 +349,41 @@ def test_build_conversation_semantic_facts_uses_canonical_db_content_blocks() ->
     assert profile.canonical_projects == ("polylogue",)
 
 
+def test_build_conversation_semantic_facts_preserves_tool_results_before_tool_use() -> None:
+    conversation = Conversation(
+        id="conv-db-tool-result-before-use",
+        provider="claude-code",
+        messages=MessageCollection(
+            messages=[
+                Message(
+                    id="a1",
+                    role="assistant",
+                    provider="claude-code",
+                    text="I checked the file.",
+                    content_blocks=[
+                        {
+                            "type": "tool_result",
+                            "tool_id": "tool-1",
+                            "text": "README contents",
+                        },
+                        {
+                            "type": "tool_use",
+                            "tool_name": "Read",
+                            "tool_id": "tool-1",
+                            "tool_input": {"file_path": "/realm/project/polylogue/README.md"},
+                            "semantic_type": "file_read",
+                        },
+                    ],
+                ),
+            ]
+        ),
+    )
+
+    facts = build_conversation_semantic_facts(conversation)
+
+    assert facts.message_facts[0].tool_calls[0].output == "README contents"
+
+
 def test_build_conversation_semantic_facts_upgrades_stale_other_semantic_type() -> None:
     conversation = Conversation(
         id="conv-db-upgrade-other",

--- a/tests/unit/pipeline/test_indexing.py
+++ b/tests/unit/pipeline/test_indexing.py
@@ -110,6 +110,53 @@ class TestIndexService:
         result = await service.rebuild_index()
         assert result is True
 
+    async def test_rebuild_index_reports_chunk_progress(self, sqlite_backend):
+        """Full rebuild reports subphase progress with explicit totals."""
+        from polylogue.storage.store import ConversationRecord, MessageRecord
+
+        for index in range(3):
+            conversation_id = f"conv-progress-{index}"
+            await sqlite_backend.save_conversation_record(
+                ConversationRecord(
+                    conversation_id=conversation_id,
+                    provider_name="chatgpt",
+                    provider_conversation_id=f"prov-{index}",
+                    title=f"Conversation {index}",
+                    content_hash=f"hash-{index}",
+                )
+            )
+            await sqlite_backend.save_messages(
+                [
+                    MessageRecord(
+                        message_id=f"msg-progress-{index}",
+                        conversation_id=conversation_id,
+                        role="user",
+                        text=f"Hello from conversation {index}",
+                        content_hash=f"message-hash-{index}",
+                    )
+                ]
+            )
+
+        config = Config(
+            archive_root="/tmp",
+            render_root="/tmp/render",
+            sources=[],
+        )
+        service = IndexService(config, backend=sqlite_backend)
+        progress_events: list[tuple[int, str | None]] = []
+
+        def capture(amount: int, desc: str | None = None) -> None:
+            progress_events.append((amount, desc))
+
+        result = await service.rebuild_index(progress_callback=capture)
+
+        assert result is True
+        assert progress_events
+        descriptions = [desc for _, desc in progress_events if desc is not None]
+        assert descriptions[0] == "Indexing: action events 0/6"
+        assert "Indexing: full-text search 3/6" in descriptions
+        assert descriptions[-1] == "Indexing: full-text search 6/6"
+
     async def test_ensure_index_exists_success(self, sqlite_backend):
         """Ensure FTS5 index exists."""
         config = Config(

--- a/tests/unit/pipeline/test_ingest_batch.py
+++ b/tests/unit/pipeline/test_ingest_batch.py
@@ -199,7 +199,7 @@ async def test_refresh_session_products_bulk_dedupes_related_refreshes(
             ],
         )
 
-    refresh_thread_root = AsyncMock(return_value=1)
+    refresh_thread_roots = AsyncMock(return_value=2)
     refresh_aggregates = AsyncMock()
 
     monkeypatch.setattr(
@@ -207,8 +207,8 @@ async def test_refresh_session_products_bulk_dedupes_related_refreshes(
         _fake_apply,
     )
     monkeypatch.setattr(
-        "polylogue.storage.session_product_refresh._refresh_thread_root_async",
-        refresh_thread_root,
+        "polylogue.storage.session_product_refresh._refresh_thread_roots_async",
+        refresh_thread_roots,
     )
     monkeypatch.setattr(
         "polylogue.storage.session_product_refresh.refresh_async_provider_day_aggregates",
@@ -220,9 +220,11 @@ async def test_refresh_session_products_bulk_dedupes_related_refreshes(
         ["conv-1", "conv-2", "conv-3"],
     )
 
-    assert refresh_thread_root.await_count == 2
-    refreshed_roots = sorted(call.args[1] for call in refresh_thread_root.await_args_list)
-    assert refreshed_roots == ["root-a", "root-b"]
+    refresh_thread_roots.assert_awaited_once()
+    thread_args = refresh_thread_roots.await_args
+    assert thread_args.args[0] is fake_conn
+    assert thread_args.args[1] == ["root-a", "root-b"]
+    assert thread_args.kwargs["transaction_depth"] == 1
     refresh_aggregates.assert_awaited_once()
     aggregate_args = refresh_aggregates.await_args
     assert aggregate_args.args[0] is fake_conn

--- a/tests/unit/pipeline/test_ingest_batch.py
+++ b/tests/unit/pipeline/test_ingest_batch.py
@@ -17,6 +17,7 @@ from polylogue.pipeline.services.ingest_batch import (
     _RawIngestOutcome,
     _successful_raw_state_update,
     _topo_sort_conversation_entries,
+    _unattributed_batch_elapsed_s,
     _write_conversation,
     refresh_session_products_bulk,
 )
@@ -297,6 +298,25 @@ def test_failed_raw_state_update_combines_parse_and_validation_fields() -> None:
         validation_error="schema mismatch",
         validation_mode="strict",
     )
+
+
+def test_unattributed_batch_elapsed_subtracts_setup_and_teardown() -> None:
+    summary = _IngestBatchSummary(
+        setup_elapsed_s=0.12,
+        result_wait_s=0.8,
+        drain_elapsed_s=0.2,
+        flush_elapsed_s=0.05,
+        commit_elapsed_s=0.04,
+        teardown_elapsed_s=0.31,
+    )
+
+    residual = _unattributed_batch_elapsed_s(
+        elapsed_s=1.7,
+        batch_summary=summary,
+        raw_state_update_elapsed_s=0.08,
+    )
+
+    assert residual == pytest.approx(0.10)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/pipeline/test_resilience.py
+++ b/tests/unit/pipeline/test_resilience.py
@@ -492,6 +492,86 @@ def test_ingest_worker_decodes_and_dispatches_provider(tmp_path: Path) -> None:
     assert result.error is None
 
 
+def test_ingest_worker_reuses_schema_resolution_and_skips_drift_walk(tmp_path: Path, monkeypatch) -> None:
+    """Parse-path validation should reuse one schema resolution and avoid unused drift traversal."""
+    from polylogue.pipeline.services.ingest_worker import ingest_record
+    from polylogue.schemas import ValidationResult
+    from polylogue.schemas.packages import SchemaResolution
+
+    payload = json.dumps({
+        "id": "conv-1",
+        "title": "Test Conversation",
+        "mapping": {},
+        "create_time": 1700000000,
+        "update_time": 1700000001,
+    }).encode()
+    raw_record = _make_raw_record(
+        raw_id="ignored",
+        provider="chatgpt",
+        content=payload,
+        path="/tmp/conversation.json",
+    )
+
+    resolution = SchemaResolution(
+        provider="chatgpt",
+        package_version="v1",
+        element_kind="conversation_document",
+        exact_structure_id="shape-1",
+        bundle_scope=None,
+        reason="exact_structure",
+    )
+    observed: dict[str, object] = {}
+
+    class _CapturingRegistry:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def resolve_payload(self, provider, payload, *, source_path=None):
+            self.calls += 1
+            observed["registry_provider"] = provider
+            observed["registry_source_path"] = source_path
+            observed["registry_payload"] = payload
+            return resolution
+
+    registry = _CapturingRegistry()
+    monkeypatch.setattr("polylogue.pipeline.services.ingest_worker._SCHEMA_REGISTRY", registry)
+
+    class _CapturingValidator:
+        provider = "chatgpt"
+
+        def validation_samples(self, payload, max_samples=None):
+            return [payload]
+
+        def validate(self, _sample, *, include_drift=None):
+            observed["include_drift"] = include_drift
+            return ValidationResult(is_valid=True)
+
+    def _fake_for_payload(provider, payload, *, source_path=None, schema_resolution=None, strict=True):
+        observed["validator_provider"] = provider
+        observed["validator_source_path"] = source_path
+        observed["validator_payload"] = payload
+        observed["validator_schema_resolution"] = schema_resolution
+        observed["validator_strict"] = strict
+        return _CapturingValidator()
+
+    def _fake_parse_payload(provider, payload, fallback_id, _depth=0, *, schema_resolution=None):
+        observed["parse_provider"] = provider
+        observed["parse_schema_resolution"] = schema_resolution
+        observed["parse_fallback_id"] = fallback_id
+        return []
+
+    monkeypatch.setattr("polylogue.schemas.validator.SchemaValidator.for_payload", _fake_for_payload)
+    monkeypatch.setattr("polylogue.sources.dispatch.parse_payload", _fake_parse_payload)
+
+    result = ingest_record(raw_record, str(tmp_path / "archive"), "strict")
+
+    assert result.error is None
+    assert registry.calls == 1
+    assert observed["validator_schema_resolution"] is resolution
+    assert observed["parse_schema_resolution"] is resolution
+    assert observed["include_drift"] is False
+
+
 def test_transform_with_tool_use_message_keeps_non_empty_message_hash(tmp_path: Path) -> None:
     from polylogue.pipeline.services.ingest_worker import _transform_to_tuples
 

--- a/tests/unit/rendering/test_html_highlighting.py
+++ b/tests/unit/rendering/test_html_highlighting.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from polylogue.rendering.renderers.html_highlighting import (
+    HTML_RENDER_CACHE_TEXT_MAX_CHARS,
+    HTMLMessageRenderer,
+)
+
+
+def test_html_message_renderer_caches_bounded_repeated_messages() -> None:
+    renderer = HTMLMessageRenderer()
+
+    first = renderer.render("Hello **world**")
+    second = renderer.render("Hello **world**")
+
+    assert first == second
+    cache_info = renderer._render_cached.cache_info()
+    assert cache_info.hits == 1
+    assert cache_info.currsize == 1
+
+
+def test_html_message_renderer_bypasses_cache_for_large_messages() -> None:
+    renderer = HTMLMessageRenderer()
+    oversized = "x" * (HTML_RENDER_CACHE_TEXT_MAX_CHARS + 1)
+
+    renderer.render(oversized)
+    renderer.render(oversized)
+
+    cache_info = renderer._render_cached.cache_info()
+    assert cache_info.hits == 0
+    assert cache_info.misses == 0
+
+
+def test_html_message_renderer_plain_text_fast_path_matches_markdown_it_output() -> None:
+    renderer = HTMLMessageRenderer()
+    text = 'Hello "quoted" world.\n\nSecond paragraph.'
+
+    rendered = renderer.render(text)
+    expected = renderer._enhance_code_blocks(renderer.md.render(text))
+
+    assert rendered == expected
+
+
+def test_html_message_renderer_preserves_blockquotes_via_markdown_it() -> None:
+    renderer = HTMLMessageRenderer()
+
+    rendered = renderer.render("> quoted line")
+
+    assert "<blockquote>" in rendered
+
+
+def test_html_message_renderer_preserves_hard_breaks_via_markdown_it() -> None:
+    renderer = HTMLMessageRenderer()
+
+    rendered = renderer.render("first line  \nsecond line")
+
+    assert "<br />" in rendered

--- a/tests/unit/sources/test_source_laws.py
+++ b/tests/unit/sources/test_source_laws.py
@@ -568,6 +568,42 @@ def test_iter_source_conversations_with_raw_streams_plain_grouped_capture_to_blo
     assert conversation.provider_name == Provider.CLAUDE_CODE
 
 
+def test_iter_source_conversations_with_raw_streams_grouped_zip_capture_to_blob_store(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from polylogue.storage.blob_store import BlobStore, get_blob_store
+
+    archive_path = tmp_path / "bundle.zip"
+    content = (
+        '{"type":"user","uuid":"u1","sessionId":"s1","message":{"content":"hello"}}\n'
+        '{"type":"assistant","uuid":"a1","sessionId":"s1","message":{"content":"hi"}}\n'
+    )
+    with zipfile.ZipFile(archive_path, "w") as zf:
+        zf.writestr("nested/session.jsonl", content)
+
+    write_calls = 0
+    original_write_from_fileobj = BlobStore.write_from_fileobj
+
+    def tracking_write_from_fileobj(self: BlobStore, source) -> tuple[str, int]:
+        nonlocal write_calls
+        write_calls += 1
+        return original_write_from_fileobj(self, source)
+
+    monkeypatch.setattr(BlobStore, "write_from_fileobj", tracking_write_from_fileobj)
+
+    items = list(iter_source_conversations_with_raw(Source(name="claude-code", path=archive_path)))
+
+    assert write_calls == 1
+    assert len(items) == 1
+    raw_data, conversation = items[0]
+    assert raw_data is not None
+    assert raw_data.blob_hash is not None
+    assert raw_data.raw_bytes == b""
+    assert get_blob_store().read_all(raw_data.blob_hash) == content.encode("utf-8")
+    assert conversation.provider_name == Provider.CLAUDE_CODE
+
+
 def test_iter_source_conversations_with_raw_assigns_source_indexes_for_multi_conversation_zip_contract(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/sources/test_source_laws.py
+++ b/tests/unit/sources/test_source_laws.py
@@ -1332,6 +1332,45 @@ def test_conversation_emitter_reuses_jsonl_sniff_payloads_for_individual_detecti
     assert all(conversation.provider_name == Provider.CHATGPT for _, conversation in emitted)
 
 
+def test_conversation_emitter_detects_individual_jsonl_provider_from_payloads(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class NoWholeReadBytesIO(BytesIO):
+        def read(self, size: int = -1) -> bytes:
+            if size == -1:
+                raise AssertionError("unexpected whole-file read")
+            return super().read(size)
+
+    ctx = _ParseContext(
+        provider_hint=Provider.UNKNOWN,
+        should_group=False,
+        source_path_str="/tmp/session.jsonl",
+        fallback_id="session",
+        file_mtime="2026-03-11T00:00:00+00:00",
+        capture_raw=True,
+        session_index={},
+    )
+    raw = (
+        b'{"mapping":{"r1":{"message":{"author":{"role":"user"},"content":{"content_type":"text","parts":["first"]}}}}}\n'
+        b'{"mapping":{"r1":{"message":{"author":{"role":"assistant"},"content":{"content_type":"text","parts":["second"]}}}}}\n'
+    )
+    original_detect_provider = dispatch_module.detect_provider
+
+    def tracking_detect_provider(payload: object, path: object | None = None):
+        if isinstance(payload, list):
+            raise AssertionError("individual JSONL sniff should not require whole-list provider detection")
+        return original_detect_provider(payload, path)
+
+    monkeypatch.setattr("polylogue.sources.emitter.detect_provider", tracking_detect_provider)
+
+    emitted = list(_ConversationEmitter(ctx).emit(NoWholeReadBytesIO(raw), "session.jsonl"))
+
+    assert emitted
+    assert [raw_data.source_index for raw_data, _ in emitted if raw_data is not None] == [0, 1]
+    assert all(raw_data is not None for raw_data, _ in emitted)
+    assert all(conversation.provider_name == Provider.CHATGPT for _, conversation in emitted)
+
+
 def test_conversation_emitter_only_enriches_matching_claude_code_sessions_contract() -> None:
     entry = SessionIndexEntry(
         session_id="session-1",

--- a/tests/unit/sources/test_source_laws.py
+++ b/tests/unit/sources/test_source_laws.py
@@ -1566,6 +1566,29 @@ def test_iter_source_raw_data_reads_plain_and_zip_sources_contract(tmp_path: Pat
     assert zip_items[0].file_mtime is not None
 
 
+def test_iter_source_raw_data_streams_grouped_zip_entries_into_blob_store(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from polylogue.storage.blob_store import BlobStore, get_blob_store
+
+    entry_bytes = b'{"type":"user","message":{"role":"user","content":[{"type":"text","text":"hello"}]}}\n'
+    archive_path = tmp_path / "bundle.zip"
+    with zipfile.ZipFile(archive_path, "w") as zf:
+        zf.writestr("nested/session.jsonl", entry_bytes)
+
+    def _fail(*args, **kwargs):
+        raise AssertionError("Grouped ZIP acquisition should stream into the blob store")
+
+    monkeypatch.setattr(BlobStore, "write_from_bytes", _fail)
+
+    items = list(iter_source_raw_data(Source(name="claude-code", path=archive_path)))
+
+    assert len(items) == 1
+    assert items[0].blob_hash is not None
+    assert get_blob_store().read_all(items[0].blob_hash) == entry_bytes
+
+
 @pytest.mark.parametrize(
     ("entry_name", "payload_bytes", "expected_provider", "id_field", "expected_ids"),
     [
@@ -1688,6 +1711,29 @@ def test_iter_source_raw_data_reports_split_payload_observations(tmp_path: Path)
     assert float(peak["classify_ms"]) >= 0.0
     assert float(peak["serialize_ms"]) >= 0.0
     assert float(peak["peak_rss_self_mb"]) > 0.0
+
+
+def test_iter_source_raw_data_streams_preserved_zip_entries_into_blob_store(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from polylogue.storage.blob_store import BlobStore, get_blob_store
+
+    entry_bytes = json.dumps({"id": "chatgpt-1", "mapping": {}}).encode("utf-8")
+    archive_path = tmp_path / "bundle.zip"
+    with zipfile.ZipFile(archive_path, "w") as zf:
+        zf.writestr("nested/chatgpt-export.json", entry_bytes)
+
+    def _fail(*args, **kwargs):
+        raise AssertionError("Preserved ZIP entries should stream into the blob store")
+
+    monkeypatch.setattr(BlobStore, "write_from_bytes", _fail)
+
+    items = list(iter_source_raw_data(Source(name="chatgpt", path=archive_path)))
+
+    assert len(items) == 1
+    assert items[0].blob_hash is not None
+    assert get_blob_store().read_all(items[0].blob_hash) == entry_bytes
 
 
 def test_iter_entry_payloads_locks_provider_after_first_detected_payload(

--- a/tests/unit/storage/test_blob_store.py
+++ b/tests/unit/storage/test_blob_store.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import hashlib
+from io import BytesIO
+from pathlib import Path
+
+from polylogue.storage.blob_store import BlobStore
+
+
+def test_write_from_fileobj_round_trips_content(tmp_path: Path) -> None:
+    blob_store = BlobStore(tmp_path / "blobs")
+    payload = b"streamed blob content"
+
+    blob_hash, blob_size = blob_store.write_from_fileobj(BytesIO(payload))
+
+    assert blob_hash == hashlib.sha256(payload).hexdigest()
+    assert blob_size == len(payload)
+    assert blob_store.read_all(blob_hash) == payload
+
+
+def test_write_from_fileobj_deduplicates_existing_blob(tmp_path: Path) -> None:
+    blob_store = BlobStore(tmp_path / "blobs")
+    payload = b"same payload"
+
+    first_hash, first_size = blob_store.write_from_bytes(payload)
+    second_hash, second_size = blob_store.write_from_fileobj(BytesIO(payload))
+
+    assert second_hash == first_hash
+    assert second_size == first_size == len(payload)
+    assert blob_store.stats()["count"] == 1

--- a/tests/unit/storage/test_session_product_profiles.py
+++ b/tests/unit/storage/test_session_product_profiles.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from polylogue.lib.messages import MessageCollection
+from polylogue.lib.models import Conversation, Message
+from polylogue.lib.session_profile import build_session_analysis, build_session_profile
+from polylogue.storage.session_product_profiles import (
+    assistant_turn_texts,
+    blocker_texts,
+    session_enrichment_payload,
+    user_turn_texts,
+)
+
+
+def _enrichment_conversation() -> Conversation:
+    return Conversation(
+        id="conv-enrichment",
+        provider="claude-code",
+        title="Enrichment",
+        created_at=datetime(2026, 4, 2, 10, 0, tzinfo=timezone.utc),
+        updated_at=datetime(2026, 4, 2, 10, 3, tzinfo=timezone.utc),
+        messages=MessageCollection(
+            messages=[
+                Message(
+                    id="u1",
+                    role="user",
+                    provider="claude-code",
+                    text="The tests failed with traceback in /realm/project/polylogue/app.py. Please fix it.",
+                    timestamp=datetime(2026, 4, 2, 10, 0, tzinfo=timezone.utc),
+                ),
+                Message(
+                    id="a1",
+                    role="assistant",
+                    provider="claude-code",
+                    text="I inspected app.py and ran pytest.",
+                    timestamp=datetime(2026, 4, 2, 10, 1, tzinfo=timezone.utc),
+                    content_blocks=[
+                        {
+                            "type": "tool_use",
+                            "tool_name": "Read",
+                            "tool_input": {"file_path": "/realm/project/polylogue/app.py"},
+                        }
+                    ],
+                ),
+                Message(
+                    id="a2",
+                    role="assistant",
+                    provider="claude-code",
+                    text="Patched it and reran pytest successfully.",
+                    timestamp=datetime(2026, 4, 2, 10, 2, tzinfo=timezone.utc),
+                ),
+            ]
+        ),
+    )
+
+
+def test_session_enrichment_payload_reuses_text_band_outputs() -> None:
+    conversation = _enrichment_conversation()
+    analysis = build_session_analysis(conversation)
+    profile = build_session_profile(conversation, analysis=analysis)
+
+    assert user_turn_texts(analysis) == (
+        "The tests failed with traceback in /realm/project/polylogue/app.py. Please fix it.",
+    )
+    assert assistant_turn_texts(analysis) == (
+        "Patched it and reran pytest successfully.",
+    )
+    assert blocker_texts(analysis) == (
+        "The tests failed with traceback in /realm/project/polylogue/app.py. Please fix it.",
+    )
+
+    payload = session_enrichment_payload(profile, analysis)
+
+    assert payload["intent_summary"] == user_turn_texts(analysis)[0]
+    assert payload["outcome_summary"] == assistant_turn_texts(analysis)[-1]
+    assert payload["blockers"] == list(blocker_texts(analysis))
+    assert payload["input_band_summary"] == {
+        "user_turns": 1,
+        "assistant_turns": 1,
+        "action_events": 1,
+        "touched_paths": 1,
+        "canonical_projects": 1,
+    }
+    assert tuple(payload["support_signals"]) == (
+        "user_turns",
+        "action_events",
+        "touched_paths",
+        "canonical_projects",
+        "heuristic_work_events",
+        "assistant_outcome_text",
+    )

--- a/tests/unit/storage/test_session_product_refresh.py
+++ b/tests/unit/storage/test_session_product_refresh.py
@@ -6,6 +6,7 @@ from polylogue.storage.backends.async_sqlite import SQLiteBackend
 from polylogue.storage.backends.connection import open_connection
 from polylogue.storage.session_product_refresh import (
     _apply_session_product_conversation_updates_async,
+    _refresh_thread_roots_async,
 )
 from tests.infra.storage_records import make_conversation, make_message, store_records
 
@@ -149,3 +150,75 @@ async def test_apply_session_product_conversation_updates_async_clears_deleted_c
     assert profile_count == 0
     assert work_event_count == 0
     assert phase_count == 0
+
+
+@pytest.mark.asyncio
+async def test_refresh_thread_roots_async_batches_root_rebuilds(
+    tmp_path,
+) -> None:
+    db_path = tmp_path / "refresh-thread-roots.db"
+    with open_connection(db_path) as conn:
+        store_records(
+            conversation=make_conversation("conv-root-a", title="Root A"),
+            messages=[make_message("conv-root-a:msg-1", "conv-root-a", text="Root A message")],
+            attachments=[],
+            conn=conn,
+        )
+        store_records(
+            conversation=make_conversation(
+                "conv-child-a",
+                title="Child A",
+                parent_conversation_id="conv-root-a",
+            ),
+            messages=[make_message("conv-child-a:msg-1", "conv-child-a", text="Child A message")],
+            attachments=[],
+            conn=conn,
+        )
+        store_records(
+            conversation=make_conversation("conv-root-b", title="Root B"),
+            messages=[make_message("conv-root-b:msg-1", "conv-root-b", text="Root B message")],
+            attachments=[],
+            conn=conn,
+        )
+        store_records(
+            conversation=make_conversation(
+                "conv-child-b",
+                title="Child B",
+                parent_conversation_id="conv-root-b",
+            ),
+            messages=[make_message("conv-child-b:msg-1", "conv-child-b", text="Child B message")],
+            attachments=[],
+            conn=conn,
+        )
+        conn.commit()
+
+    backend = SQLiteBackend(db_path=db_path)
+    async with backend.connection() as conn:
+        update = await _apply_session_product_conversation_updates_async(
+            conn,
+            ["conv-root-a", "conv-child-a", "conv-root-b", "conv-child-b"],
+            transaction_depth=1,
+            page_size=10,
+        )
+        refreshed = await _refresh_thread_roots_async(
+            conn,
+            sorted(update.thread_root_ids),
+            transaction_depth=1,
+        )
+        await conn.commit()
+
+    assert refreshed == 2
+
+    with open_connection(db_path) as conn:
+        rows = conn.execute(
+            """
+            SELECT thread_id, root_id, session_count
+            FROM work_threads
+            ORDER BY thread_id
+            """
+        ).fetchall()
+
+    assert [(row["thread_id"], row["root_id"], row["session_count"]) for row in rows] == [
+        ("conv-root-a", "conv-root-a", 2),
+        ("conv-root-b", "conv-root-b", 2),
+    ]

--- a/tests/unit/storage/test_session_product_refresh.py
+++ b/tests/unit/storage/test_session_product_refresh.py
@@ -4,6 +4,7 @@ import pytest
 
 from polylogue.storage.backends.async_sqlite import SQLiteBackend
 from polylogue.storage.backends.connection import open_connection
+from polylogue.storage.session_product_aggregates import refresh_async_provider_day_aggregates
 from polylogue.storage.session_product_refresh import (
     _apply_session_product_conversation_updates_async,
     _refresh_thread_roots_async,
@@ -221,4 +222,99 @@ async def test_refresh_thread_roots_async_batches_root_rebuilds(
     assert [(row["thread_id"], row["root_id"], row["session_count"]) for row in rows] == [
         ("conv-root-a", "conv-root-a", 2),
         ("conv-root-b", "conv-root-b", 2),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_refresh_async_provider_day_aggregates_batches_multiple_groups(
+    tmp_path,
+) -> None:
+    db_path = tmp_path / "refresh-provider-day-groups.db"
+    with open_connection(db_path) as conn:
+        store_records(
+            conversation=make_conversation(
+                "conv-chatgpt-a",
+                provider_name="chatgpt",
+                title="ChatGPT A",
+                created_at="2026-04-02T10:00:00+00:00",
+                updated_at="2026-04-02T10:05:00+00:00",
+            ),
+            messages=[
+                make_message(
+                    "conv-chatgpt-a:msg-1",
+                    "conv-chatgpt-a",
+                    text="ChatGPT A message",
+                    timestamp="2026-04-02T10:00:00+00:00",
+                )
+            ],
+            attachments=[],
+            conn=conn,
+        )
+        store_records(
+            conversation=make_conversation(
+                "conv-chatgpt-b",
+                provider_name="chatgpt",
+                title="ChatGPT B",
+                created_at="2026-04-02T11:00:00+00:00",
+                updated_at="2026-04-02T11:05:00+00:00",
+            ),
+            messages=[
+                make_message(
+                    "conv-chatgpt-b:msg-1",
+                    "conv-chatgpt-b",
+                    text="ChatGPT B message",
+                    timestamp="2026-04-02T11:00:00+00:00",
+                )
+            ],
+            attachments=[],
+            conn=conn,
+        )
+        store_records(
+            conversation=make_conversation(
+                "conv-claude-a",
+                provider_name="claude-ai",
+                title="Claude A",
+                created_at="2026-04-03T09:00:00+00:00",
+                updated_at="2026-04-03T09:05:00+00:00",
+            ),
+            messages=[
+                make_message(
+                    "conv-claude-a:msg-1",
+                    "conv-claude-a",
+                    text="Claude A message",
+                    timestamp="2026-04-03T09:00:00+00:00",
+                )
+            ],
+            attachments=[],
+            conn=conn,
+        )
+        conn.commit()
+
+    backend = SQLiteBackend(db_path=db_path)
+    async with backend.connection() as conn:
+        update = await _apply_session_product_conversation_updates_async(
+            conn,
+            ["conv-chatgpt-a", "conv-chatgpt-b", "conv-claude-a"],
+            transaction_depth=1,
+            page_size=10,
+        )
+        await refresh_async_provider_day_aggregates(
+            conn,
+            update.affected_groups,
+            transaction_depth=1,
+        )
+        await conn.commit()
+
+    with open_connection(db_path) as conn:
+        day_rows = conn.execute(
+            """
+            SELECT provider_name, day, conversation_count
+            FROM day_session_summaries
+            ORDER BY provider_name, day
+            """
+        ).fetchall()
+
+    assert [(row["provider_name"], row["day"], row["conversation_count"]) for row in day_rows] == [
+        ("chatgpt", "2026-04-02", 2),
+        ("claude-ai", "2026-04-03", 1),
     ]

--- a/tests/unit/storage/test_session_product_timeline_rows.py
+++ b/tests/unit/storage/test_session_product_timeline_rows.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from polylogue.lib.messages import MessageCollection
+from polylogue.lib.models import Conversation, Message
+from polylogue.lib.session_profile import build_session_analysis, build_session_profile
+from polylogue.storage.session_product_timeline_rows import (
+    build_session_phase_records,
+    build_session_work_event_records,
+    hydrate_session_phase,
+    hydrate_work_event,
+)
+
+
+def _timeline_conversation() -> Conversation:
+    return Conversation(
+        id="conv-timeline",
+        provider="claude-code",
+        title="Timeline",
+        created_at=datetime(2026, 4, 2, 12, 0, tzinfo=timezone.utc),
+        updated_at=datetime(2026, 4, 2, 12, 6, tzinfo=timezone.utc),
+        messages=MessageCollection(
+            messages=[
+                Message(
+                    id="u1",
+                    role="user",
+                    provider="claude-code",
+                    text="Please inspect /realm/project/polylogue/app.py and fix the failing tests.",
+                    timestamp=datetime(2026, 4, 2, 12, 0, tzinfo=timezone.utc),
+                ),
+                Message(
+                    id="a1",
+                    role="assistant",
+                    provider="claude-code",
+                    text="I inspected the file and ran pytest.",
+                    timestamp=datetime(2026, 4, 2, 12, 1, tzinfo=timezone.utc),
+                    content_blocks=[
+                        {
+                            "type": "tool_use",
+                            "tool_name": "Read",
+                            "tool_input": {"file_path": "/realm/project/polylogue/app.py"},
+                        }
+                    ],
+                ),
+                Message(
+                    id="u2",
+                    role="user",
+                    provider="claude-code",
+                    text="Now patch it and verify the fix.",
+                    timestamp=datetime(2026, 4, 2, 12, 6, tzinfo=timezone.utc),
+                ),
+                Message(
+                    id="a2",
+                    role="assistant",
+                    provider="claude-code",
+                    text="Patched the file and reran pytest successfully.",
+                    timestamp=datetime(2026, 4, 2, 12, 7, tzinfo=timezone.utc),
+                ),
+            ]
+        ),
+    )
+
+
+def test_session_timeline_row_builders_roundtrip_work_events_and_phases() -> None:
+    conversation = _timeline_conversation()
+    analysis = build_session_analysis(conversation)
+    profile = build_session_profile(conversation, analysis=analysis)
+
+    work_event_records = build_session_work_event_records(
+        profile,
+        materialized_at="2026-04-02T12:08:00+00:00",
+    )
+    phase_records = build_session_phase_records(
+        profile,
+        materialized_at="2026-04-02T12:08:00+00:00",
+    )
+
+    assert work_event_records
+    assert phase_records
+
+    work_event = hydrate_work_event(work_event_records[0])
+    phase = hydrate_session_phase(phase_records[0])
+
+    assert work_event.summary == work_event_records[0].summary
+    assert work_event_records[0].inference_payload["summary"] == work_event.summary
+    assert work_event.kind.value == work_event_records[0].kind
+    assert work_event_records[0].search_text
+
+    assert phase.message_range == (phase_records[0].start_index, phase_records[0].end_index)
+    assert phase.tool_counts == phase_records[0].tool_counts
+    assert phase_records[0].search_text


### PR DESCRIPTION
## Summary

This branch is a deliberately incremental performance pass. without changing the ingest architecture again, I looked for places where we were walking the same data twice, recomputing the same derived strings, or allocating large temporary buffers for work that could be streamed or cached locally. The changes land in five clusters: enrichment text-band reuse, timeline/aggregate row reuse, acquisition-to-blob streaming, message/render fast paths, and better timing/progress accounting around ingest/index work. Most of the files are small or medium changes on their own, but together they remove a lot of repeated hot-path work without changing the user-facing data model. Kept the tests close to each optimization so we can tell whether a future cleanup accidentally reintroduces the old repeated scans.

## Motivation

The previous branch gave us better instrumentation and better batching. Once that existed, it became much easier to see a different class of waste: work that was "correct but repeated." Session enrichment was walking the same `message_facts` list multiple times to produce related text bands. Timeline row builders were recomputing the same summaries and signals inside neighboring helper functions. Aggregate refresh paths would hydrate more profile rows than a given root/day actually needed. Acquisition still buffered zip entries before hashing them into blob storage. Rendering and runtime helpers did more regex/Markdown work than necessary for plain text or already-known predicates.

None of these justified a large rewrite, but all of them are exactly the kind of costs that show up once the bigger structural bottlenecks are gone.

## Changes grouped by concern

### 1. Reuse enrichment text bands instead of rescanning message facts

`polylogue/storage/session_product_profiles.py` has a single `_collect_enrichment_text_bands()` helper that gathers:

- user turns
- assistant turns
- blocker candidates

from one pass over `analysis.facts.message_facts`. The existing public helpers then become thin readers over that collected structure, and `session_enrichment_payload()` / `enrichment_support_signals()` reuse the same bands instead of each constructing their own filtered list.

That is a small local change, but it matters because enrichment payload creation sits on the session-product path, where repeated scans add up quickly.

### 2. Build timeline and aggregate rows from local reusable summaries

The same pattern shows up in `polylogue/storage/session_product_timeline_rows.py`. Event and phase builders used to call helper functions that re-derived summary text, support signals, and fallback flags multiple times while assembling a single output row. I split those into helpers that accept precomputed values and then rewired row construction to compute them once per event/phase.

The aggregate refresh path also got more local:

- `session_product_threads.py` resolves each requested root from its own profile-record slice
- `session_product_aggregates.py` rebuilds provider-day rows from the profile records for that provider/day instead of hydrating a larger shared set and regrouping afterward

That reduces incidental work and makes the refresh code easier to review because each helper is explicitly local to a root or provider-day group.

### 3. Stream zip entries directly into the blob store

`BlobStore.write_from_fileobj()` is probably the most user-visible optimization in this branch because it changes the memory profile of acquisition. Before, zip-entry acquisition paths would do something like this:

```python
with zf.open(info.filename) as handle:
    raw_bytes = handle.read()
blob_hash, blob_size = blob_store.write_from_bytes(raw_bytes)
```

They now hash and write in one pass:

```python
with zf.open(info.filename) as handle:
    blob_hash, blob_size = blob_store.write_from_fileobj(handle)
```

I applied that to grouped zip capture and preserved zip-entry capture in `polylogue/sources/source_acquisition.py`, then tightened nearby JSONL sniffing so we do less repeated provider work when walking those archives.

### 4. Add local fast paths where the full general case is unnecessary

Two examples here:

- `polylogue/lib/message_model_runtime.py` now short-circuits more predicate work and guards rarer regex scans behind cheaper checks
- `polylogue/rendering/renderers/html_highlighting.py` adds an LRU-cached plain-text fast path for small messages that do not need full Markdown parsing

The HTML renderer still falls back to the MarkdownIt path whenever the text looks remotely non-plain. The fast path is intentionally conservative, and the tests assert equivalence for the cases it accepts.

### 5. Make timing and progress accounting more honest

Used the branch to close a couple of measurement gaps that the previous instrumentation exposed:

- `ingest_batch.py` separates setup and teardown timing from the rest of batch elapsed time and includes them in the unattributed residual calculation
- index rebuild/update can report real `processed/total` fractions through `IndexService`
- `RichProgressObserver` can parse those fractions and update totals instead of only advancing an indeterminate bar

This is not just cosmetic. Progress output is a debugging surface when indexing gets slow, and misattributed batch residual time makes the rest of the timing data harder to trust.

## Testing

The coverage is intentionally local to each optimization:

- `tests/unit/storage/test_session_product_profiles.py` for shared enrichment text bands
- `tests/unit/storage/test_session_product_timeline_rows.py` for reused timeline summaries/signals
- `tests/unit/storage/test_blob_store.py` and `tests/unit/sources/test_source_laws.py` for `write_from_fileobj()` and streamed zip acquisition
- `tests/unit/pipeline/test_ingest_batch.py` for setup/teardown timing accounting
- `tests/unit/rendering/test_html_highlighting.py` for the plain-text fast path and cache behavior
- `tests/unit/pipeline/test_indexing.py` and `tests/unit/cli/test_run_laws.py` for indexed progress fractions

## Notes

Intentionally kept this as a "many small cuts" branch. A few of the helpers have names that start with an underscore because the point is to localize reuse inside a module, not to create new broad abstractions prematurely.

The main thing to watch here is behavioral equivalence. Almost every change is motivated by "do the same work fewer times," so the most important review question is whether any shortcut accidentally changes payload shape, search text, or render output.