### PR TITLE
feat: add provider assembly layer for sidecar title resolution

### DIFF
--- a/polylogue/sources/assembly.py
+++ b/polylogue/sources/assembly.py
@@ -1,0 +1,62 @@
+"""Provider assembly layer — generic sidecar discovery and conversation enrichment.
+
+Replaces Claude-specific session index logic with a protocol that any provider
+can implement for sidecar discovery and post-parse enrichment.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Protocol
+
+from polylogue.types import Provider
+
+from .parsers.base import ParsedConversation
+
+
+@dataclass(frozen=True, slots=True)
+class TitleResolution:
+    """Result of provider-specific title resolution."""
+
+    title: str
+    source: str  # e.g. "session-index:summary", "first-user-message", "session-id"
+
+
+class ProviderAssemblySpec(Protocol):
+    """Provider-specific sidecar discovery and conversation enrichment."""
+
+    def discover_sidecars(self, source_paths: list[Path]) -> dict[str, Any]:
+        """Discover provider-specific sidecars from source paths.
+
+        Returns opaque provider data keyed by parent directory or similar.
+        """
+        ...
+
+    def enrich_conversation(
+        self,
+        conv: ParsedConversation,
+        sidecar_data: dict[str, Any],
+    ) -> ParsedConversation:
+        """Enrich a parsed conversation using discovered sidecar data."""
+        ...
+
+
+def get_assembly_spec(provider: Provider) -> ProviderAssemblySpec | None:
+    """Return the assembly spec for a provider, or None if no enrichment needed."""
+    if provider is Provider.CLAUDE_CODE:
+        from .assembly_claude_code import ClaudeCodeAssemblySpec
+
+        return ClaudeCodeAssemblySpec()
+    if provider is Provider.CODEX:
+        from .assembly_codex import CodexAssemblySpec
+
+        return CodexAssemblySpec()
+    return None
+
+
+__all__ = [
+    "ProviderAssemblySpec",
+    "TitleResolution",
+    "get_assembly_spec",
+]

--- a/polylogue/sources/assembly_claude_code.py
+++ b/polylogue/sources/assembly_claude_code.py
@@ -1,0 +1,50 @@
+"""Claude Code provider assembly — sessions-index.json sidecar discovery and enrichment."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from .parsers.base import ParsedConversation
+from .parsers.claude_index import (
+    SessionIndexEntry,
+    enrich_conversation_from_index,
+    parse_sessions_index,
+)
+
+
+class ClaudeCodeAssemblySpec:
+    """Claude Code provider assembly — sessions-index.json sidecar."""
+
+    def discover_sidecars(self, source_paths: list[Path]) -> dict[str, Any]:
+        """Discover Claude Code sessions-index.json sidecars.
+
+        Returns ``{"session_index": {session_id: SessionIndexEntry, ...}}``.
+        """
+        indices: dict[Path, dict[str, SessionIndexEntry]] = {}
+        for path in source_paths:
+            parent = path.parent
+            if parent not in indices:
+                index_path = parent / "sessions-index.json"
+                indices[parent] = parse_sessions_index(index_path)
+        # Flatten to {session_id: SessionIndexEntry}
+        flat: dict[str, SessionIndexEntry] = {}
+        for entries in indices.values():
+            flat.update(entries)
+        return {"session_index": flat}
+
+    def enrich_conversation(
+        self,
+        conv: ParsedConversation,
+        sidecar_data: dict[str, Any],
+    ) -> ParsedConversation:
+        """Enrich a Claude Code conversation from the sessions-index sidecar."""
+        idx: dict[str, SessionIndexEntry] = sidecar_data.get("session_index", {})
+        if conv.provider_conversation_id in idx:
+            return enrich_conversation_from_index(conv, idx[conv.provider_conversation_id])
+        return conv
+
+
+__all__ = [
+    "ClaudeCodeAssemblySpec",
+]

--- a/polylogue/sources/assembly_codex.py
+++ b/polylogue/sources/assembly_codex.py
@@ -1,0 +1,123 @@
+"""Codex provider assembly — session_index.jsonl thread name sidecar."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from polylogue.logging import get_logger
+
+from .parsers.base import ParsedConversation
+
+logger = get_logger(__name__)
+
+
+def _parse_codex_session_index(sessions_root: Path) -> dict[str, str]:
+    """Parse ~/.codex/session_index.jsonl — append-only, newest entry wins per thread_id.
+
+    Args:
+        sessions_root: The ``sessions/`` directory. The index file lives at
+            ``sessions_root.parent / "session_index.jsonl"``.
+
+    Returns:
+        Mapping of thread ID to thread name (latest entry wins).
+    """
+    index_path = sessions_root.parent / "session_index.jsonl"
+    if not index_path.exists():
+        return {}
+    names: dict[str, str] = {}
+    try:
+        for line in index_path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+                tid = entry.get("id") or entry.get("thread_id")
+                name = entry.get("thread_name") or entry.get("name")
+                if tid and name:
+                    names[tid] = name  # Latest wins (append-only)
+            except (json.JSONDecodeError, TypeError):
+                continue
+    except OSError as exc:
+        logger.debug("Failed to read Codex session_index.jsonl: %s", exc)
+    return names
+
+
+class CodexAssemblySpec:
+    """Codex provider assembly — session_index.jsonl thread name sidecar."""
+
+    def discover_sidecars(self, source_paths: list[Path]) -> dict[str, Any]:
+        """Discover Codex thread names from session_index.jsonl.
+
+        Returns ``{"thread_names": {thread_id: thread_name, ...}}``.
+        """
+        thread_names: dict[str, str] = {}
+        seen_roots: set[Path] = set()
+        for path in source_paths:
+            # Walk up to find the sessions root
+            for parent in path.parents:
+                if parent.name == "sessions" and parent not in seen_roots:
+                    seen_roots.add(parent)
+                    thread_names.update(_parse_codex_session_index(parent))
+                    break
+        return {"thread_names": thread_names}
+
+    def enrich_conversation(
+        self,
+        conv: ParsedConversation,
+        sidecar_data: dict[str, Any],
+    ) -> ParsedConversation:
+        """Enrich a Codex conversation with thread name or first-user-message title."""
+        thread_names: dict[str, str] = sidecar_data.get("thread_names", {})
+        cid = conv.provider_conversation_id
+
+        # Try thread name from side index
+        name = thread_names.get(cid)
+        if name and name != conv.title:
+            provider_meta = dict(conv.provider_meta) if conv.provider_meta else {}
+            provider_meta["thread_name"] = name
+            provider_meta["title_source"] = "session-index:thread-name"
+            return ParsedConversation(
+                provider_name=conv.provider_name,
+                provider_conversation_id=conv.provider_conversation_id,
+                title=name,
+                created_at=conv.created_at,
+                updated_at=conv.updated_at,
+                messages=conv.messages,
+                attachments=conv.attachments,
+                provider_meta=provider_meta,
+                parent_conversation_provider_id=conv.parent_conversation_provider_id,
+                branch_type=conv.branch_type,
+            )
+
+        # Fallback: use first user message as title if current title is just the session_id
+        if conv.title == cid and conv.messages:
+            for msg in conv.messages:
+                if msg.role == "user" and msg.text and msg.text.strip():
+                    preview = msg.text.strip()[:80]
+                    if len(msg.text.strip()) > 80:
+                        preview += "..."
+                    provider_meta = dict(conv.provider_meta) if conv.provider_meta else {}
+                    provider_meta["title_source"] = "first-user-message"
+                    return ParsedConversation(
+                        provider_name=conv.provider_name,
+                        provider_conversation_id=conv.provider_conversation_id,
+                        title=preview,
+                        created_at=conv.created_at,
+                        updated_at=conv.updated_at,
+                        messages=conv.messages,
+                        attachments=conv.attachments,
+                        provider_meta=provider_meta,
+                        parent_conversation_provider_id=conv.parent_conversation_provider_id,
+                        branch_type=conv.branch_type,
+                    )
+
+        return conv
+
+
+__all__ = [
+    "CodexAssemblySpec",
+    "_parse_codex_session_index",
+]

--- a/polylogue/sources/cursor.py
+++ b/polylogue/sources/cursor.py
@@ -10,8 +10,6 @@ from typing import Any
 from polylogue.logging import get_logger
 from polylogue.types import Provider
 
-from .parsers.claude import SessionIndexEntry
-
 logger = get_logger(__name__)
 
 
@@ -130,7 +128,7 @@ class _ParseContext:
     fallback_id: str  # path.stem, used as fallback conversation ID
     file_mtime: str | None
     capture_raw: bool
-    session_index: dict[str, SessionIndexEntry]
+    sidecar_data: dict[str, Any]
 
 
 __all__ = [

--- a/polylogue/sources/decoder_zip.py
+++ b/polylogue/sources/decoder_zip.py
@@ -127,7 +127,7 @@ def process_zip(
                 fallback_id=zip_path.stem,
                 file_mtime=file_mtime,
                 capture_raw=capture_raw,
-                session_index={},
+                sidecar_data={},
             )
             emitter = _ConversationEmitter(ctx)
             precomputed_raw: RawConversationData | None = None

--- a/polylogue/sources/emitter.py
+++ b/polylogue/sources/emitter.py
@@ -12,11 +12,11 @@ from polylogue.lib.json import dumps_bytes as json_dumps_bytes
 from polylogue.logging import get_logger
 from polylogue.types import Provider
 
+from .assembly import get_assembly_spec
 from .cursor import _ParseContext
 from .decoders import _iter_json_stream
 from .dispatch import GROUP_PROVIDERS, detect_provider, parse_payload
 from .parsers.base import ParsedConversation, RawConversationData
-from .parsers.claude import enrich_conversation_from_index
 
 if TYPE_CHECKING:
     from polylogue.schemas.packages import SchemaResolution
@@ -319,11 +319,11 @@ class _ConversationEmitter:
         conv: ParsedConversation,
         provider: Provider | None = None,
     ) -> ParsedConversation:
-        """Apply Claude Code session index enrichment if applicable."""
+        """Apply provider-specific enrichment via assembly layer."""
         p = provider or self._ctx.provider_hint
-        idx = self._ctx.session_index
-        if p is Provider.CLAUDE_CODE and conv.provider_conversation_id in idx:
-            return enrich_conversation_from_index(conv, idx[conv.provider_conversation_id])
+        spec = get_assembly_spec(p)
+        if spec is not None:
+            return spec.enrich_conversation(conv, self._ctx.sidecar_data)
         return conv
 
 

--- a/polylogue/sources/parsers/claude_index.py
+++ b/polylogue/sources/parsers/claude_index.py
@@ -68,17 +68,46 @@ def find_sessions_index(session_path: Path) -> Path | None:
     return index_path if index_path.exists() else None
 
 
+_GIT_BRANCH_PREFIXES = frozenset({
+    "feature/", "fix/", "bugfix/", "hotfix/", "release/",
+    "chore/", "refactor/", "test/", "docs/", "ci/", "perf/",
+})
+
+_GIT_BRANCH_EXACT = frozenset({
+    "main", "master", "develop", "dev", "staging", "production",
+    "HEAD", "head",
+})
+
+
+def _looks_like_git_branch(value: str) -> bool:
+    """Return True if value looks like a git branch name rather than a title."""
+    stripped = value.strip()
+    if stripped in _GIT_BRANCH_EXACT:
+        return True
+    for prefix in _GIT_BRANCH_PREFIXES:
+        if stripped.startswith(prefix):
+            return True
+    return False
+
+
 def enrich_conversation_from_index(
     conv: ParsedConversation,
     index_entry: SessionIndexEntry,
 ) -> ParsedConversation:
     title = conv.title
-    if index_entry.summary and index_entry.summary != "User Exits CLI Session":
+    title_source = "original"
+    if (
+        index_entry.summary
+        and index_entry.summary != "User Exits CLI Session"
+        and not _looks_like_git_branch(index_entry.summary)
+    ):
         title = index_entry.summary
+        title_source = "session-index:summary"
     elif index_entry.first_prompt and index_entry.first_prompt != "No prompt":
         title = index_entry.first_prompt[:80]
         if len(index_entry.first_prompt) > 80:
             title += "..."
+        title_source = "session-index:first-prompt"
 
     provider_meta = dict(conv.provider_meta) if conv.provider_meta else {}
     provider_meta.update({
@@ -87,6 +116,7 @@ def enrich_conversation_from_index(
         "isSidechain": index_entry.is_sidechain,
         "summary": index_entry.summary,
         "firstPrompt": index_entry.first_prompt,
+        "title_source": title_source,
     })
 
     return ParsedConversation(
@@ -103,6 +133,7 @@ def enrich_conversation_from_index(
 
 __all__ = [
     "SessionIndexEntry",
+    "_looks_like_git_branch",
     "enrich_conversation_from_index",
     "find_sessions_index",
     "parse_sessions_index",

--- a/polylogue/sources/source_acquisition.py
+++ b/polylogue/sources/source_acquisition.py
@@ -130,7 +130,7 @@ def iter_source_raw_data(
         cursor_state=cursor_state,
         include_mtime=True,
         known_mtimes=known_mtimes,
-        build_session_indices=False,
+        discover_sidecars=False,
     )
     if walk is None:
         return

--- a/polylogue/sources/source_parsing.py
+++ b/polylogue/sources/source_parsing.py
@@ -57,7 +57,7 @@ def iter_source_conversations_with_raw(
         cursor_state=cursor_state,
         include_mtime=capture_raw,
         known_mtimes=known_mtimes,
-        build_session_indices=True,
+        discover_sidecars=True,
     )
     if walk is None:
         return
@@ -88,7 +88,7 @@ def iter_source_conversations_with_raw(
                     fallback_id=path.stem,
                     file_mtime=file_mtime,
                     capture_raw=capture_raw,
-                    session_index=walk.session_indices.get(path.parent, {}),
+                    sidecar_data=walk.sidecar_data,
                 )
                 emitter = _ConversationEmitter(ctx)
 

--- a/polylogue/sources/source_walk.py
+++ b/polylogue/sources/source_walk.py
@@ -3,14 +3,15 @@
 from __future__ import annotations
 
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
 from polylogue.config import Source
+from polylogue.types import Provider
 
 from . import cursor as _cursor
-from .parsers.claude import SessionIndexEntry, parse_sessions_index
+from .assembly import get_assembly_spec
 
 _SUPPORTED_EXTENSIONS = frozenset({".json", ".jsonl", ".ndjson", ".zip"})
 _SUPPORTED_DOUBLE_EXTENSIONS = frozenset({".jsonl.txt"})
@@ -36,16 +37,6 @@ def _walk_source_paths(base: Path) -> list[Path]:
     return sorted(paths)
 
 
-def _build_session_indices(paths: list[Path]) -> dict[Path, dict[str, SessionIndexEntry]]:
-    indices: dict[Path, dict[str, SessionIndexEntry]] = {}
-    for path in paths:
-        parent = path.parent
-        if parent not in indices:
-            index_path = parent / "sessions-index.json"
-            indices[parent] = parse_sessions_index(index_path)
-    return indices
-
-
 def _resolve_source_paths(source: Source) -> list[Path]:
     if not source.path:
         return []
@@ -62,7 +53,7 @@ class _SourceWalkSetup:
     paths: list[Path]
     paths_to_process: list[tuple[Path, str | None]]
     skipped_mtime: int
-    session_indices: dict[Path, dict[str, SessionIndexEntry]]
+    sidecar_data: dict[str, Any] = field(default_factory=dict)
 
 
 def _setup_source_walk(
@@ -71,7 +62,7 @@ def _setup_source_walk(
     cursor_state: dict[str, Any] | None,
     include_mtime: bool,
     known_mtimes: dict[str, str] | None,
-    build_session_indices: bool,
+    discover_sidecars: bool,
 ) -> _SourceWalkSetup | None:
     paths = _resolve_source_paths(source)
     _cursor._initialize_cursor_state(cursor_state, paths)
@@ -82,12 +73,17 @@ def _setup_source_walk(
         include_file_mtime=include_mtime,
         known_mtimes=known_mtimes,
     )
-    session_indices = _build_session_indices(paths) if build_session_indices else {}
+    sidecar_data: dict[str, Any] = {}
+    if discover_sidecars:
+        provider = Provider.from_string(source.name)
+        spec = get_assembly_spec(provider)
+        if spec is not None:
+            sidecar_data = spec.discover_sidecars(paths)
     return _SourceWalkSetup(
         paths=paths,
         paths_to_process=paths_to_process,
         skipped_mtime=skipped_mtime,
-        session_indices=session_indices,
+        sidecar_data=sidecar_data,
     )
 
 
@@ -96,7 +92,6 @@ __all__ = [
     "_SUPPORTED_DOUBLE_EXTENSIONS",
     "_SUPPORTED_EXTENSIONS",
     "_SKIP_DIRS",
-    "_build_session_indices",
     "_has_supported_extension",
     "_resolve_source_paths",
     "_setup_source_walk",

--- a/tests/unit/sources/test_assembly.py
+++ b/tests/unit/sources/test_assembly.py
@@ -1,0 +1,476 @@
+"""Tests for provider assembly layer — sidecar discovery and conversation enrichment."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from polylogue.sources.assembly import get_assembly_spec
+from polylogue.sources.assembly_claude_code import ClaudeCodeAssemblySpec
+from polylogue.sources.assembly_codex import CodexAssemblySpec, _parse_codex_session_index
+from polylogue.sources.parsers.base import ParsedConversation, ParsedMessage
+from polylogue.sources.parsers.claude_index import (
+    SessionIndexEntry,
+    _looks_like_git_branch,
+)
+from polylogue.types import Provider
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+class TestGetAssemblySpec:
+    def test_claude_code_returns_spec(self) -> None:
+        spec = get_assembly_spec(Provider.CLAUDE_CODE)
+        assert isinstance(spec, ClaudeCodeAssemblySpec)
+
+    def test_codex_returns_spec(self) -> None:
+        spec = get_assembly_spec(Provider.CODEX)
+        assert isinstance(spec, CodexAssemblySpec)
+
+    @pytest.mark.parametrize("provider", [Provider.CHATGPT, Provider.CLAUDE_AI, Provider.GEMINI, Provider.UNKNOWN])
+    def test_no_spec_for_other_providers(self, provider: Provider) -> None:
+        assert get_assembly_spec(provider) is None
+
+
+# ---------------------------------------------------------------------------
+# Claude Code Assembly
+# ---------------------------------------------------------------------------
+
+
+class TestClaudeCodeAssemblySpec:
+    def test_discover_sidecars_parses_sessions_index(self, tmp_path: Path) -> None:
+        """Discovers sessions-index.json and returns session_index dict."""
+        index_data = {
+            "entries": [
+                {
+                    "sessionId": "sess-1",
+                    "fullPath": str(tmp_path / "sess-1.jsonl"),
+                    "firstPrompt": "Hello",
+                    "summary": "Greeting session",
+                    "messageCount": 5,
+                    "created": "2025-01-01T00:00:00Z",
+                    "modified": "2025-01-02T00:00:00Z",
+                    "gitBranch": "main",
+                    "projectPath": "/project",
+                    "isSidechain": False,
+                },
+                {
+                    "sessionId": "sess-2",
+                    "fullPath": str(tmp_path / "sess-2.jsonl"),
+                    "summary": "Second session",
+                    "messageCount": 3,
+                },
+            ]
+        }
+        (tmp_path / "sessions-index.json").write_text(json.dumps(index_data), encoding="utf-8")
+        session_file = tmp_path / "sess-1.jsonl"
+        session_file.touch()
+
+        spec = ClaudeCodeAssemblySpec()
+        sidecar_data = spec.discover_sidecars([session_file])
+
+        assert "session_index" in sidecar_data
+        idx = sidecar_data["session_index"]
+        assert "sess-1" in idx
+        assert "sess-2" in idx
+        assert isinstance(idx["sess-1"], SessionIndexEntry)
+        assert idx["sess-1"].summary == "Greeting session"
+
+    def test_discover_sidecars_handles_missing_index(self, tmp_path: Path) -> None:
+        """Returns empty session_index when no sessions-index.json exists."""
+        session_file = tmp_path / "sess-1.jsonl"
+        session_file.touch()
+
+        spec = ClaudeCodeAssemblySpec()
+        sidecar_data = spec.discover_sidecars([session_file])
+
+        assert sidecar_data["session_index"] == {}
+
+    def test_enrich_conversation_updates_title_from_summary(self) -> None:
+        """Enriches conversation title from session index summary."""
+        spec = ClaudeCodeAssemblySpec()
+        conv = ParsedConversation(
+            provider_name="claude-code",
+            provider_conversation_id="sess-1",
+            title="sess-1",
+            created_at=None,
+            updated_at=None,
+            messages=[ParsedMessage(provider_message_id="m1", role="user", text="hello")],
+        )
+        entry = SessionIndexEntry(
+            session_id="sess-1",
+            full_path="/tmp/sess-1.jsonl",
+            first_prompt="Hello",
+            summary="Build the parser",
+            message_count=5,
+            created="2025-01-01T00:00:00Z",
+            modified="2025-01-02T00:00:00Z",
+            git_branch="main",
+            project_path="/project",
+            is_sidechain=False,
+        )
+        sidecar_data = {"session_index": {"sess-1": entry}}
+
+        enriched = spec.enrich_conversation(conv, sidecar_data)
+
+        assert enriched.title == "Build the parser"
+        assert enriched.provider_meta["title_source"] == "session-index:summary"
+
+    def test_enrich_conversation_no_match_returns_original(self) -> None:
+        """Returns original conversation when no session index match."""
+        spec = ClaudeCodeAssemblySpec()
+        conv = ParsedConversation(
+            provider_name="claude-code",
+            provider_conversation_id="sess-99",
+            title="original",
+            created_at=None,
+            updated_at=None,
+            messages=[],
+        )
+        sidecar_data = {"session_index": {}}
+
+        result = spec.enrich_conversation(conv, sidecar_data)
+
+        assert result is conv
+        assert result.title == "original"
+
+
+# ---------------------------------------------------------------------------
+# Codex Assembly
+# ---------------------------------------------------------------------------
+
+
+class TestCodexAssemblySpec:
+    def test_discover_sidecars_parses_session_index_jsonl(self, tmp_path: Path) -> None:
+        """Discovers session_index.jsonl and returns thread_names dict."""
+        codex_dir = tmp_path / ".codex"
+        sessions_dir = codex_dir / "sessions"
+        sessions_dir.mkdir(parents=True)
+        index_path = codex_dir / "session_index.jsonl"
+        index_path.write_text(
+            '{"id": "thread-1", "thread_name": "Build API client", "updated_at": "2025-01-01T00:00:00Z"}\n'
+            '{"id": "thread-2", "thread_name": "Fix auth bug", "updated_at": "2025-01-02T00:00:00Z"}\n',
+            encoding="utf-8",
+        )
+        session_file = sessions_dir / "thread-1" / "session.jsonl"
+        session_file.parent.mkdir()
+        session_file.touch()
+
+        spec = CodexAssemblySpec()
+        sidecar_data = spec.discover_sidecars([session_file])
+
+        assert "thread_names" in sidecar_data
+        names = sidecar_data["thread_names"]
+        assert names["thread-1"] == "Build API client"
+        assert names["thread-2"] == "Fix auth bug"
+
+    def test_discover_sidecars_handles_missing_index(self, tmp_path: Path) -> None:
+        """Returns empty thread_names when no session_index.jsonl exists."""
+        codex_dir = tmp_path / ".codex"
+        sessions_dir = codex_dir / "sessions"
+        sessions_dir.mkdir(parents=True)
+        session_file = sessions_dir / "thread-1" / "session.jsonl"
+        session_file.parent.mkdir()
+        session_file.touch()
+
+        spec = CodexAssemblySpec()
+        sidecar_data = spec.discover_sidecars([session_file])
+
+        assert sidecar_data["thread_names"] == {}
+
+    def test_enrich_conversation_uses_thread_name(self) -> None:
+        """Enriches conversation title from thread name in sidecar data."""
+        spec = CodexAssemblySpec()
+        conv = ParsedConversation(
+            provider_name="codex",
+            provider_conversation_id="thread-1",
+            title="thread-1",
+            created_at=None,
+            updated_at=None,
+            messages=[ParsedMessage(provider_message_id="m1", role="user", text="build client")],
+        )
+        sidecar_data = {"thread_names": {"thread-1": "Build API client"}}
+
+        enriched = spec.enrich_conversation(conv, sidecar_data)
+
+        assert enriched.title == "Build API client"
+        assert enriched.provider_meta["title_source"] == "session-index:thread-name"
+        assert enriched.provider_meta["thread_name"] == "Build API client"
+
+    def test_enrich_conversation_falls_back_to_first_user_message(self) -> None:
+        """Falls back to first user message when no thread name available."""
+        spec = CodexAssemblySpec()
+        conv = ParsedConversation(
+            provider_name="codex",
+            provider_conversation_id="thread-1",
+            title="thread-1",
+            created_at=None,
+            updated_at=None,
+            messages=[
+                ParsedMessage(provider_message_id="m1", role="user", text="Implement the payment gateway"),
+                ParsedMessage(provider_message_id="m2", role="assistant", text="Sure, here is the code"),
+            ],
+        )
+        sidecar_data = {"thread_names": {}}
+
+        enriched = spec.enrich_conversation(conv, sidecar_data)
+
+        assert enriched.title == "Implement the payment gateway"
+        assert enriched.provider_meta["title_source"] == "first-user-message"
+
+    def test_enrich_conversation_truncates_long_first_message(self) -> None:
+        """Truncates first user message to 80 chars + ellipsis."""
+        spec = CodexAssemblySpec()
+        long_text = "A" * 100
+        conv = ParsedConversation(
+            provider_name="codex",
+            provider_conversation_id="thread-1",
+            title="thread-1",
+            created_at=None,
+            updated_at=None,
+            messages=[ParsedMessage(provider_message_id="m1", role="user", text=long_text)],
+        )
+        sidecar_data = {"thread_names": {}}
+
+        enriched = spec.enrich_conversation(conv, sidecar_data)
+
+        assert enriched.title == "A" * 80 + "..."
+        assert len(enriched.title) == 83
+
+    def test_enrich_conversation_no_match_no_user_messages(self) -> None:
+        """Returns original conversation when no enrichment possible."""
+        spec = CodexAssemblySpec()
+        conv = ParsedConversation(
+            provider_name="codex",
+            provider_conversation_id="thread-1",
+            title="thread-1",
+            created_at=None,
+            updated_at=None,
+            messages=[ParsedMessage(provider_message_id="m1", role="assistant", text="response")],
+        )
+        sidecar_data = {"thread_names": {}}
+
+        result = spec.enrich_conversation(conv, sidecar_data)
+
+        assert result is conv
+
+    def test_enrich_conversation_skips_empty_user_messages(self) -> None:
+        """Skips empty user messages when looking for first-user-message fallback."""
+        spec = CodexAssemblySpec()
+        conv = ParsedConversation(
+            provider_name="codex",
+            provider_conversation_id="thread-1",
+            title="thread-1",
+            created_at=None,
+            updated_at=None,
+            messages=[
+                ParsedMessage(provider_message_id="m1", role="user", text=""),
+                ParsedMessage(provider_message_id="m2", role="user", text="   "),
+                ParsedMessage(provider_message_id="m3", role="user", text="Real message here"),
+            ],
+        )
+        sidecar_data = {"thread_names": {}}
+
+        enriched = spec.enrich_conversation(conv, sidecar_data)
+
+        assert enriched.title == "Real message here"
+
+    def test_enrich_conversation_does_not_override_different_title(self) -> None:
+        """Does not fall back to first-user-message when title differs from conv ID."""
+        spec = CodexAssemblySpec()
+        conv = ParsedConversation(
+            provider_name="codex",
+            provider_conversation_id="thread-1",
+            title="Already has a title",
+            created_at=None,
+            updated_at=None,
+            messages=[ParsedMessage(provider_message_id="m1", role="user", text="some message")],
+        )
+        sidecar_data = {"thread_names": {}}
+
+        result = spec.enrich_conversation(conv, sidecar_data)
+
+        assert result is conv
+        assert result.title == "Already has a title"
+
+
+class TestParseCodexSessionIndex:
+    def test_parses_valid_jsonl(self, tmp_path: Path) -> None:
+        codex_dir = tmp_path / ".codex"
+        sessions_dir = codex_dir / "sessions"
+        sessions_dir.mkdir(parents=True)
+        (codex_dir / "session_index.jsonl").write_text(
+            '{"id": "t1", "thread_name": "Alpha"}\n'
+            '{"id": "t2", "thread_name": "Beta"}\n',
+            encoding="utf-8",
+        )
+
+        result = _parse_codex_session_index(sessions_dir)
+
+        assert result == {"t1": "Alpha", "t2": "Beta"}
+
+    def test_latest_entry_wins(self, tmp_path: Path) -> None:
+        codex_dir = tmp_path / ".codex"
+        sessions_dir = codex_dir / "sessions"
+        sessions_dir.mkdir(parents=True)
+        (codex_dir / "session_index.jsonl").write_text(
+            '{"id": "t1", "thread_name": "Old Name"}\n'
+            '{"id": "t1", "thread_name": "New Name"}\n',
+            encoding="utf-8",
+        )
+
+        result = _parse_codex_session_index(sessions_dir)
+
+        assert result == {"t1": "New Name"}
+
+    def test_handles_malformed_lines(self, tmp_path: Path) -> None:
+        codex_dir = tmp_path / ".codex"
+        sessions_dir = codex_dir / "sessions"
+        sessions_dir.mkdir(parents=True)
+        (codex_dir / "session_index.jsonl").write_text(
+            '{"id": "t1", "thread_name": "Good"}\n'
+            "not-json\n"
+            '{"id": "t2"}\n'  # Missing thread_name
+            '{"id": "t3", "thread_name": "Also Good"}\n',
+            encoding="utf-8",
+        )
+
+        result = _parse_codex_session_index(sessions_dir)
+
+        assert result == {"t1": "Good", "t3": "Also Good"}
+
+    def test_supports_alternative_field_names(self, tmp_path: Path) -> None:
+        """Supports thread_id/name as alternative to id/thread_name."""
+        codex_dir = tmp_path / ".codex"
+        sessions_dir = codex_dir / "sessions"
+        sessions_dir.mkdir(parents=True)
+        (codex_dir / "session_index.jsonl").write_text(
+            '{"thread_id": "t1", "name": "Alt Names"}\n',
+            encoding="utf-8",
+        )
+
+        result = _parse_codex_session_index(sessions_dir)
+
+        assert result == {"t1": "Alt Names"}
+
+    def test_handles_missing_file(self, tmp_path: Path) -> None:
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+
+        result = _parse_codex_session_index(sessions_dir)
+
+        assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# Anti-title heuristics (git branch rejection)
+# ---------------------------------------------------------------------------
+
+
+class TestLooksLikeGitBranch:
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "main",
+            "master",
+            "develop",
+            "dev",
+            "staging",
+            "production",
+            "HEAD",
+            "feature/auth-fix",
+            "fix/login-bug",
+            "bugfix/cors-headers",
+            "hotfix/prod-crash",
+            "release/v2.0",
+            "chore/deps-update",
+            "refactor/cleanup",
+            "test/add-coverage",
+            "docs/readme",
+            "ci/pipeline",
+            "perf/query-optimization",
+        ],
+    )
+    def test_rejects_git_branch_names(self, value: str) -> None:
+        assert _looks_like_git_branch(value) is True
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "Fixed authentication bug in login flow",
+            "Build the parser module",
+            "Investigate memory leak",
+            "User Exits CLI Session",
+            "Set up CI/CD pipeline",
+            "Update the feature flags documentation",
+            "",
+        ],
+    )
+    def test_accepts_real_titles(self, value: str) -> None:
+        assert _looks_like_git_branch(value) is False
+
+    def test_git_branch_summary_skipped_in_enrichment(self) -> None:
+        """enrich_conversation_from_index skips summary that looks like a git branch."""
+        from polylogue.sources.parsers.claude_index import enrich_conversation_from_index
+
+        conv = ParsedConversation(
+            provider_name="claude-code",
+            provider_conversation_id="sess-1",
+            title="sess-1",
+            created_at=None,
+            updated_at=None,
+            messages=[ParsedMessage(provider_message_id="m1", role="user", text="hello")],
+        )
+        entry = SessionIndexEntry(
+            session_id="sess-1",
+            full_path="/tmp/sess-1.jsonl",
+            first_prompt="Fix the bug",
+            summary="feature/auth-fix",  # Git branch — should be rejected
+            message_count=5,
+            created=None,
+            modified=None,
+            git_branch="feature/auth-fix",
+            project_path="/project",
+            is_sidechain=False,
+        )
+
+        enriched = enrich_conversation_from_index(conv, entry)
+
+        # Should fall back to first_prompt since summary looks like a git branch
+        assert enriched.title == "Fix the bug"
+        assert enriched.provider_meta["title_source"] == "session-index:first-prompt"
+
+    def test_git_branch_exact_match_skipped(self) -> None:
+        """Exact branch names like 'main' are rejected as summaries."""
+        from polylogue.sources.parsers.claude_index import enrich_conversation_from_index
+
+        conv = ParsedConversation(
+            provider_name="claude-code",
+            provider_conversation_id="sess-1",
+            title="sess-1",
+            created_at=None,
+            updated_at=None,
+            messages=[ParsedMessage(provider_message_id="m1", role="user", text="hello")],
+        )
+        entry = SessionIndexEntry(
+            session_id="sess-1",
+            full_path="/tmp/sess-1.jsonl",
+            first_prompt="Hello world",
+            summary="main",
+            message_count=1,
+            created=None,
+            modified=None,
+            git_branch="main",
+            project_path="/project",
+            is_sidechain=False,
+        )
+
+        enriched = enrich_conversation_from_index(conv, entry)
+
+        assert enriched.title == "Hello world"
+        assert enriched.provider_meta["title_source"] == "session-index:first-prompt"

--- a/tests/unit/sources/test_source_laws.py
+++ b/tests/unit/sources/test_source_laws.py
@@ -8,6 +8,7 @@ import tempfile
 import zipfile
 from io import BytesIO
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -992,6 +993,7 @@ def test_find_sessions_index_and_enrichment_contract(tmp_path: Path) -> None:
         "isSidechain": True,
         "summary": "Investigate parser contracts",
         "firstPrompt": "Summarize this repo",
+        "title_source": "session-index:summary",
     }
 
 
@@ -1071,7 +1073,7 @@ def _parse_context(
     source_path: str,
     fallback_id: str,
     capture_raw: bool = True,
-    session_index: dict[str, SessionIndexEntry] | None = None,
+    sidecar_data: dict[str, Any] | None = None,
 ) -> _ParseContext:
     return _ParseContext(
         provider_hint=provider_hint,
@@ -1080,7 +1082,7 @@ def _parse_context(
         fallback_id=fallback_id,
         file_mtime="2026-03-11T00:00:00+00:00",
         capture_raw=capture_raw,
-        session_index=session_index or {},
+        sidecar_data=sidecar_data or {},
     )
 
 
@@ -1266,7 +1268,7 @@ def test_conversation_emitter_reuses_jsonl_sniff_payloads_for_grouped_detection(
         fallback_id="session",
         file_mtime="2026-03-11T00:00:00+00:00",
         capture_raw=True,
-        session_index={},
+        sidecar_data={},
     )
     raw = (
         b'{"role":"user","content":[{"type":"input_text","text":"hello"}]}\n'
@@ -1307,7 +1309,7 @@ def test_conversation_emitter_reuses_jsonl_sniff_payloads_for_individual_detecti
         fallback_id="session",
         file_mtime="2026-03-11T00:00:00+00:00",
         capture_raw=True,
-        session_index={},
+        sidecar_data={},
     )
     raw = (
         b'{"mapping":{"r1":{"message":{"author":{"role":"user"},"content":{"content_type":"text","parts":["first"]}}}}}\n'
@@ -1348,7 +1350,7 @@ def test_conversation_emitter_detects_individual_jsonl_provider_from_payloads(
         fallback_id="session",
         file_mtime="2026-03-11T00:00:00+00:00",
         capture_raw=True,
-        session_index={},
+        sidecar_data={},
     )
     raw = (
         b'{"mapping":{"r1":{"message":{"author":{"role":"user"},"content":{"content_type":"text","parts":["first"]}}}}}\n'
@@ -1391,7 +1393,7 @@ def test_conversation_emitter_only_enriches_matching_claude_code_sessions_contra
         fallback_id="session",
         file_mtime="2026-03-11T00:00:00+00:00",
         capture_raw=False,
-        session_index={"session-1": entry},
+        sidecar_data={"session_index": {"session-1": entry}},
     )
     emitter = _ConversationEmitter(ctx)
     matching = ParsedConversation(


### PR DESCRIPTION
## Summary

I extracted sidecar discovery and post-parse enrichment into a provider-level assembly protocol so title correction is no longer a Claude Code special case embedded in the source walk. The new assembly layer lets each provider discover its own sidecars and enrich parsed conversations in one place, which allowed me to add Codex thread-name resolution without teaching `source_walk.py` or `_ConversationEmitter` about Codex-specific files. Tightened title correctness for Claude Code by refusing to treat obvious git branch names as human titles, and I now record `title_source` in provider metadata so downstream consumers can understand where a title came from. The parse pipeline remains content-driven; the new abstraction only runs on parse paths, not on raw-data acquisition.

## Motivation

Before this change, the source-walk and emitter path knew a very specific fact about Claude Code: some directories contain a `sessions-index.json` sidecar, and parsed conversations should be enriched from it. That coupling was already awkward on its own, but it became an obvious blocker once Codex needed similar treatment. Codex stores thread names in `session_index.jsonl`, which is the same architectural shape—a provider-owned sidecar that should improve parsed conversations after raw payload parsing.

I wanted the abstraction boundary to follow that shape instead of branching inside the generic pipeline. Rather than adding a second bespoke sidecar path for Codex, I moved the concept into a provider protocol with two responsibilities: discover sidecars from source paths, and enrich a `ParsedConversation` from the discovered data.

Title correctness was part of the same problem. Claude Code summaries from the side index can contain branch names like `feature/auth-fix`, and those should not outrank a real prompt-derived title. Once title enrichment became provider-owned, it made sense to fix that heuristic at the same time and expose the decision as metadata.

## Changes grouped by concern

### Provider assembly protocol

The new core surface lives in `polylogue/sources/assembly.py`:

```python
class ProviderAssemblySpec(Protocol):
    def discover_sidecars(self, source_paths: list[Path]) -> dict[str, Any]: ...
    def enrich_conversation(
        self,
        conv: ParsedConversation,
        sidecar_data: dict[str, Any],
    ) -> ParsedConversation: ...
```

and a simple registry:

```python
def get_assembly_spec(provider: Provider) -> ProviderAssemblySpec | None:
    if provider is Provider.CLAUDE_CODE:
        return ClaudeCodeAssemblySpec()
    if provider is Provider.CODEX:
        return CodexAssemblySpec()
    return None
```

That gives the generic pipeline exactly one place to ask, “does this provider have sidecars and enrichment rules?”

### Claude Code assembly and title-source metadata

`ClaudeCodeAssemblySpec` mostly wraps existing behavior, but it moves it behind the new boundary. `discover_sidecars()` walks the relevant parents, parses `sessions-index.json` once per directory, and flattens the entries by session id so lookup stays cheap during enrichment.

Improved `polylogue/sources/parsers/claude_index.py` so branch-shaped summaries are rejected:

```python
if index_entry.summary and not _looks_like_git_branch(index_entry.summary):
    title = index_entry.summary
    title_source = "session-index:summary"
elif index_entry.first_prompt and index_entry.first_prompt != "No prompt":
    title = index_entry.first_prompt[:80]
    title_source = "session-index:first-prompt"
```

That keeps the existing summary-first behavior for real summaries but avoids titles like `main` or `feature/refactor/cleanup`.

### Codex sidecar support and fallback titles

The new `polylogue/sources/assembly_codex.py` module reads `~/.codex/session_index.jsonl` relative to any discovered `sessions/` root. I intentionally made the parser tolerant of append-only history and slightly different field names (`id`/`thread_id`, `thread_name`/`name`). The last name for a thread wins, which matches the append-only file semantics.

When a parsed Codex conversation still has the raw session id as its title, enrichment now follows a two-step strategy:
1. prefer the thread name from `session_index.jsonl`, and
2. otherwise, use the first non-empty user message preview.

That fallback matters because Codex session payloads often carry usable conversational openings even when no side index is present.

### Parse-path plumbing

To support the new abstraction, I generalized the parse context:
- `_ParseContext.session_index` became `_ParseContext.sidecar_data`
- `_setup_source_walk(..., build_session_indices=...)` became `_setup_source_walk(..., discover_sidecars=...)`
- `iter_source_conversations_with_raw()` now asks the provider assembly to discover sidecars, while `iter_source_raw_data()` explicitly does not

`_ConversationEmitter._apply_provider_enrichment()` is the only place that calls the registry:

```python
spec = get_assembly_spec(p)
if spec is not None:
    return spec.enrich_conversation(conv, self._ctx.sidecar_data)
```

That change removes Claude-specific imports from the emitter and makes unsupported providers a clean no-op.

## Testing

I added `tests/unit/sources/test_assembly.py` to cover:
- provider registry resolution
- Claude Code sidecar discovery and summary/first-prompt enrichment
- Codex `session_index.jsonl` parsing, including malformed lines and newest-entry-wins behavior
- first-user-message fallback for Codex
- git-branch rejection for Claude Code summaries

Updated `tests/unit/sources/test_source_laws.py` so the helper context passes `sidecar_data` instead of `session_index`, and so the enrichment contract asserts the new `title_source` metadata.

## Notes

This change is intentionally additive for providers without sidecars. `get_assembly_spec()` returns `None` for everyone else, so ChatGPT, Claude web, Gemini, and unknown providers stay on the old parse path.

I did not try to generalize sidecars beyond title enrichment in this pass. The new protocol is broad enough for richer provider-owned enrichment later, but right now I kept it scoped to sidecar discovery and post-parse conversation mutation.