### PR TITLE
feat: add provider events for compaction records

### DIFF
--- a/polylogue/archive_products.py
+++ b/polylogue/archive_products.py
@@ -64,6 +64,8 @@ class SessionEvidencePayload(ArchiveProductModel):
     total_duration_ms: int = 0
     wall_duration_ms: int = 0
     cost_is_estimated: bool = False
+    compaction_count: int = 0
+    has_compaction: bool = False
     tool_categories: dict[str, int] = Field(default_factory=dict)
     repo_paths: tuple[str, ...] = ()
     cwd_paths: tuple[str, ...] = ()

--- a/polylogue/lib/session_profile_models.py
+++ b/polylogue/lib/session_profile_models.py
@@ -46,6 +46,7 @@ class SessionProfile:
     cost_is_estimated: bool = False
     thread_id: str | None = None
     continuation_depth: int = 0
+    compaction_count: int = 0
     tags: tuple[str, ...] = ()
     auto_tags: tuple[str, ...] = ()
     is_continuation: bool = False
@@ -103,6 +104,7 @@ class SessionProfile:
             "engaged_minutes": round(self.engaged_duration_ms / 60_000.0, 4),
             "wall_duration_ms": self.wall_duration_ms,
             "cost_is_estimated": self.cost_is_estimated,
+            "compaction_count": self.compaction_count,
             "thread_id": self.thread_id,
             "continuation_depth": self.continuation_depth,
             "tags": list(self.tags),
@@ -184,6 +186,7 @@ class SessionProfile:
             engaged_duration_ms=int(payload.get("engaged_duration_ms", 0) or 0),
             wall_duration_ms=int(payload.get("wall_duration_ms", 0) or 0),
             cost_is_estimated=bool(payload.get("cost_is_estimated", False)),
+            compaction_count=int(payload.get("compaction_count", 0) or 0),
             thread_id=str(payload["thread_id"]) if payload.get("thread_id") is not None else None,
             continuation_depth=int(payload.get("continuation_depth", 0) or 0),
             tags=tuple(str(item) for item in payload.get("tags", []) or []),

--- a/polylogue/lib/session_profile_runtime.py
+++ b/polylogue/lib/session_profile_runtime.py
@@ -57,6 +57,11 @@ def build_session_profile(
     facts = session_analysis.facts
     attribution = session_analysis.attribution
     cost_usd, cost_is_estimated = harmonize_session_cost(conversation)
+    compaction_count = 0
+    if conversation.provider_meta:
+        compactions = conversation.provider_meta.get("context_compactions")
+        if isinstance(compactions, list):
+            compaction_count = len(compactions)
     engaged_duration_ms = sum(int(phase.duration_ms or 0) for phase in session_analysis.phases)
     if engaged_duration_ms <= 0:
         engaged_duration_ms = max(int(conversation.total_duration_ms or 0), 0)
@@ -95,6 +100,7 @@ def build_session_profile(
         engaged_duration_ms=engaged_duration_ms,
         wall_duration_ms=facts.wall_duration_ms,
         cost_is_estimated=cost_is_estimated,
+        compaction_count=compaction_count,
         tags=tuple(conversation.tags),
         is_continuation=conversation.is_continuation,
         parent_id=str(conversation.parent_id) if conversation.parent_id else None,

--- a/polylogue/pipeline/semantic_capture.py
+++ b/polylogue/pipeline/semantic_capture.py
@@ -8,9 +8,21 @@ from polylogue.pipeline.semantic_metadata import _parse_git_command, _parse_suba
 
 
 def detect_context_compaction(item: dict[str, Any]) -> dict[str, Any] | None:
-    """Detect if a raw message item represents a context compaction event."""
+    """Detect if a raw message item represents a context compaction event.
+
+    Recognises two record shapes:
+    - **Legacy**: ``{"type": "summary", "message": {"content": "..."}, ...}``
+    - **Modern**: ``{"type": "system", "subtype": "compact_boundary",
+      "compact_metadata": {...}, ...}``
+
+    Returns a normalised dict with ``summary``, ``timestamp``, ``trigger``,
+    ``pre_tokens``, ``preserved_segment_id``, and ``is_modern``.
+    """
     msg_type = item.get("type")
 
+    # ------------------------------------------------------------------
+    # Legacy format: type == "summary"
+    # ------------------------------------------------------------------
     if msg_type == "summary":
         message = item.get("message", {})
         content = ""
@@ -27,6 +39,44 @@ def detect_context_compaction(item: dict[str, Any]) -> dict[str, Any] | None:
         return {
             "summary": content,
             "timestamp": item.get("timestamp"),
+            "trigger": None,
+            "pre_tokens": None,
+            "preserved_segment_id": None,
+            "is_modern": False,
+        }
+
+    # ------------------------------------------------------------------
+    # Modern format: type == "system", subtype == "compact_boundary"
+    # ------------------------------------------------------------------
+    if msg_type == "system" and item.get("subtype") == "compact_boundary":
+        meta = item.get("compact_metadata") or {}
+        # Extract summary text from message.content (same structure as legacy)
+        message = item.get("message", {})
+        content = ""
+        if isinstance(message, dict):
+            content_raw = message.get("content")
+            if isinstance(content_raw, str):
+                content = content_raw
+            elif isinstance(content_raw, list):
+                for block in content_raw:
+                    if isinstance(block, dict) and block.get("type") == "text":
+                        content = block.get("text", "")
+                        break
+
+        # pre_tokens: accept both camelCase and snake_case
+        pre_tokens = meta.get("preTokens") or meta.get("pre_tokens")
+
+        # preserved_segment → anchor_uuid
+        preserved = meta.get("preserved_segment") or {}
+        anchor_uuid = preserved.get("anchor_uuid") if isinstance(preserved, dict) else None
+
+        return {
+            "summary": content,
+            "timestamp": item.get("timestamp"),
+            "trigger": meta.get("trigger"),
+            "pre_tokens": pre_tokens,
+            "preserved_segment_id": anchor_uuid,
+            "is_modern": True,
         }
 
     return None

--- a/polylogue/sources/parsers/base.py
+++ b/polylogue/sources/parsers/base.py
@@ -9,6 +9,7 @@ from .base_models import (
     ParsedContentBlock,
     ParsedConversation,
     ParsedMessage,
+    ParsedProviderEvent,
     RawConversationData,
 )
 from .base_support import (
@@ -22,6 +23,7 @@ __all__ = [
     "ParsedMessage",
     "ParsedAttachment",
     "ParsedConversation",
+    "ParsedProviderEvent",
     "RawConversationData",
     "normalize_role",
     "content_blocks_from_segments",

--- a/polylogue/sources/parsers/base_models.py
+++ b/polylogue/sources/parsers/base_models.py
@@ -88,6 +88,14 @@ class ParsedAttachment(BaseModel):
         return v if v else None
 
 
+class ParsedProviderEvent(BaseModel):
+    """Non-message semantic artifact from a provider (compaction, turn context, etc.)."""
+
+    event_type: str  # "compaction", "turn_context", etc.
+    timestamp: str | None = None
+    payload: dict[str, object] = Field(default_factory=dict)
+
+
 class ParsedConversation(BaseModel):
     provider_name: Provider
     provider_conversation_id: str
@@ -97,6 +105,7 @@ class ParsedConversation(BaseModel):
     messages: list[ParsedMessage]
     attachments: list[ParsedAttachment] = Field(default_factory=list)
     provider_meta: dict[str, object] | None = None
+    provider_events: list[ParsedProviderEvent] = Field(default_factory=list)
     parent_conversation_provider_id: str | None = None
     branch_type: BranchType | None = None
 

--- a/polylogue/sources/parsers/claude_code_parser.py
+++ b/polylogue/sources/parsers/claude_code_parser.py
@@ -12,7 +12,7 @@ from polylogue.logging import get_logger
 from polylogue.sources.providers.claude_code import ClaudeCodeRecord
 from polylogue.types import Provider
 
-from .base import ParsedContentBlock, ParsedConversation, ParsedMessage, content_blocks_from_segments
+from .base import ParsedContentBlock, ParsedConversation, ParsedMessage, ParsedProviderEvent, content_blocks_from_segments
 from .claude_common import extract_message_text, normalize_timestamp
 
 _TAG_RE = re.compile(r"<[^>]+>")
@@ -72,6 +72,7 @@ def parse_code(payload: list[object], fallback_id: str) -> ParsedConversation:
     timestamps: list[str] = []
     session_id: str | None = None
     context_compactions: list[dict[str, Any]] = []
+    provider_events: list[ParsedProviderEvent] = []
     total_cost = 0.0
     total_duration = 0
     saw_cost_field = False
@@ -90,6 +91,11 @@ def parse_code(payload: list[object], fallback_id: str) -> ParsedConversation:
         compaction = detect_context_compaction(item)
         if compaction:
             context_compactions.append(compaction)
+            provider_events.append(ParsedProviderEvent(
+                event_type="compaction",
+                timestamp=compaction.get("timestamp"),
+                payload=compaction,
+            ))
             continue
 
         try:
@@ -187,6 +193,7 @@ def parse_code(payload: list[object], fallback_id: str) -> ParsedConversation:
         updated_at=updated_at,
         messages=messages,
         provider_meta=provider_meta if provider_meta else None,
+        provider_events=provider_events,
         parent_conversation_provider_id=parent_session_id,
         branch_type=branch_type,
     )

--- a/polylogue/sources/parsers/codex.py
+++ b/polylogue/sources/parsers/codex.py
@@ -15,7 +15,7 @@ from polylogue.logging import get_logger
 from polylogue.sources.providers.codex import CodexRecord
 from polylogue.types import Provider
 
-from .base import ParsedConversation, ParsedMessage, content_blocks_from_segments
+from .base import ParsedConversation, ParsedMessage, ParsedProviderEvent, content_blocks_from_segments
 
 logger = get_logger(__name__)
 
@@ -82,6 +82,8 @@ def parse(payload: list[object], fallback_id: str) -> ParsedConversation:
     - format_type: Detected format generation
     """
     messages: list[ParsedMessage] = []
+    provider_events: list[ParsedProviderEvent] = []
+    context_compactions: list[dict[str, object]] = []
     session_id = fallback_id
     session_timestamp: str | None = None
     latest_message_timestamp: str | None = None
@@ -97,6 +99,34 @@ def parse(payload: list[object], fallback_id: str) -> ParsedConversation:
             record = CodexRecord.model_validate(item)
         except ValidationError as exc:
             logger.debug("Skipping invalid record at index %d: %s", idx, exc)
+            continue
+
+        # Handle compaction events (before message check so they don't fall through)
+        if record.is_compaction:
+            event_payload: dict[str, object] = {
+                "summary": record.compacted_message,
+                "has_replacement_history": record.has_replacement_history,
+            }
+            if record.payload:
+                event_payload["raw"] = record.payload
+            provider_events.append(ParsedProviderEvent(
+                event_type="compaction",
+                timestamp=record.timestamp,
+                payload=event_payload,
+            ))
+            context_compactions.append(event_payload)
+            continue
+
+        # Handle turn-context events
+        if record.is_turn_context:
+            tc_payload: dict[str, object] = {}
+            if record.payload:
+                tc_payload["raw"] = record.payload
+            provider_events.append(ParsedProviderEvent(
+                event_type="turn_context",
+                timestamp=record.timestamp,
+                payload=tc_payload,
+            ))
             continue
 
         # Handle session metadata (envelope format)
@@ -195,12 +225,14 @@ def parse(payload: list[object], fallback_id: str) -> ParsedConversation:
 
     # Build conversation-level provider_meta with session context
     conv_meta: dict[str, object] | None = None
-    if session_git or session_instructions:
+    if session_git or session_instructions or context_compactions:
         conv_meta = {}
         if session_git:
             conv_meta["git"] = session_git
         if session_instructions:
             conv_meta["instructions"] = session_instructions
+        if context_compactions:
+            conv_meta["context_compactions"] = context_compactions
 
     return ParsedConversation(
         provider_name=Provider.CODEX,
@@ -210,6 +242,7 @@ def parse(payload: list[object], fallback_id: str) -> ParsedConversation:
         updated_at=_latest_timestamp(latest_message_timestamp, session_timestamp),
         messages=messages,
         provider_meta=conv_meta,
+        provider_events=provider_events,
         parent_conversation_provider_id=parent_id,
         branch_type=branch_type,
     )

--- a/polylogue/sources/providers/claude_code_record.py
+++ b/polylogue/sources/providers/claude_code_record.py
@@ -33,6 +33,7 @@ class ClaudeCodeRecord(BaseModel):
     model_config = ConfigDict(extra="allow")
 
     type: str
+    subtype: str | None = None
     uuid: str | None = None
     parentUuid: str | None = None
     timestamp: str | int | float | None = None
@@ -163,7 +164,9 @@ class ClaudeCodeRecord(BaseModel):
 
     @property
     def is_context_compaction(self) -> bool:
-        return self.type == "summary"
+        return self.type == "summary" or (
+            self.type == "system" and self.subtype == "compact_boundary"
+        )
 
     @property
     def is_tool_progress(self) -> bool:

--- a/polylogue/sources/providers/codex.py
+++ b/polylogue/sources/providers/codex.py
@@ -107,6 +107,38 @@ class CodexRecord(BaseModel):
         return "unknown"
 
     @property
+    def is_compaction(self) -> bool:
+        """Check if this record represents a compaction event.
+
+        Envelope format: ``{"type": "compacted", "payload": {"message": "...", ...}}``
+        """
+        return self.type == "compacted"
+
+    @property
+    def is_turn_context(self) -> bool:
+        """Check if this record represents a turn-context event.
+
+        Envelope format: ``{"type": "turn_context", "payload": {...}}``
+        """
+        return self.type == "turn_context"
+
+    @property
+    def compacted_message(self) -> str:
+        """Extract the summary/message text from a compaction record."""
+        if not self.is_compaction or not self.payload:
+            return ""
+        msg = self.payload.get("message", "")
+        return str(msg) if msg else ""
+
+    @property
+    def has_replacement_history(self) -> bool:
+        """Check if a compaction record includes replacement_history."""
+        if not self.is_compaction or not self.payload:
+            return False
+        history = self.payload.get("replacement_history")
+        return isinstance(history, list) and len(history) > 0
+
+    @property
     def is_message(self) -> bool:
         """Check if this record contains an actual message."""
         if self.format_type == "envelope":

--- a/polylogue/storage/session_product_profiles.py
+++ b/polylogue/storage/session_product_profiles.py
@@ -144,6 +144,8 @@ def profile_evidence_payload(profile: SessionProfile) -> dict[str, object]:
         "total_duration_ms": profile.total_duration_ms,
         "wall_duration_ms": profile.wall_duration_ms,
         "cost_is_estimated": profile.cost_is_estimated,
+        "compaction_count": profile.compaction_count,
+        "has_compaction": profile.compaction_count > 0,
         "tool_categories": dict(profile.tool_categories),
         "repo_paths": list(profile.repo_paths),
         "cwd_paths": list(profile.cwd_paths),

--- a/tests/unit/sources/test_compaction.py
+++ b/tests/unit/sources/test_compaction.py
@@ -1,0 +1,434 @@
+"""Tests for first-class provider event support for compaction.
+
+Covers:
+- Legacy and modern compaction detection in semantic_capture
+- Claude Code parser emitting provider_events
+- Codex provider model compaction/turn_context recognition
+- Codex parser emitting provider_events
+- Profile builder counting compaction events
+"""
+from __future__ import annotations
+
+from polylogue.pipeline.semantic_capture import detect_context_compaction
+from polylogue.sources.parsers.claude_code_parser import parse_code
+from polylogue.sources.parsers.codex import parse as parse_codex
+from polylogue.sources.providers.claude_code import ClaudeCodeRecord
+from polylogue.sources.providers.codex import CodexRecord
+
+
+# =============================================================================
+# detect_context_compaction — legacy format
+# =============================================================================
+
+class TestLegacyCompactionDetection:
+    def test_summary_type_detected(self) -> None:
+        item = {"type": "summary", "message": {"content": "Session summary text"}, "timestamp": "2024-01-01T10:00:00Z"}
+        result = detect_context_compaction(item)
+        assert result is not None
+        assert result["summary"] == "Session summary text"
+        assert result["timestamp"] == "2024-01-01T10:00:00Z"
+        assert result["is_modern"] is False
+
+    def test_summary_with_content_blocks(self) -> None:
+        item = {
+            "type": "summary",
+            "message": {"content": [{"type": "text", "text": "Block summary"}]},
+            "timestamp": "2024-01-01",
+        }
+        result = detect_context_compaction(item)
+        assert result is not None
+        assert result["summary"] == "Block summary"
+        assert result["is_modern"] is False
+
+    def test_summary_with_empty_message(self) -> None:
+        item = {"type": "summary", "message": {}}
+        result = detect_context_compaction(item)
+        assert result is not None
+        assert result["summary"] == ""
+        assert result["trigger"] is None
+        assert result["pre_tokens"] is None
+        assert result["preserved_segment_id"] is None
+
+    def test_non_compaction_returns_none(self) -> None:
+        assert detect_context_compaction({"type": "user"}) is None
+        assert detect_context_compaction({"type": "assistant"}) is None
+        assert detect_context_compaction({}) is None
+
+
+# =============================================================================
+# detect_context_compaction — modern format
+# =============================================================================
+
+class TestModernCompactionDetection:
+    def test_system_compact_boundary_detected(self) -> None:
+        item = {
+            "type": "system",
+            "subtype": "compact_boundary",
+            "message": {"content": "Compacted summary"},
+            "timestamp": "2024-06-01T12:00:00Z",
+            "compact_metadata": {
+                "trigger": "token_limit",
+                "preTokens": 128000,
+                "preserved_segment": {
+                    "head_uuid": "h1",
+                    "anchor_uuid": "a1",
+                    "tail_uuid": "t1",
+                },
+            },
+        }
+        result = detect_context_compaction(item)
+        assert result is not None
+        assert result["summary"] == "Compacted summary"
+        assert result["timestamp"] == "2024-06-01T12:00:00Z"
+        assert result["is_modern"] is True
+        assert result["trigger"] == "token_limit"
+        assert result["pre_tokens"] == 128000
+        assert result["preserved_segment_id"] == "a1"
+
+    def test_modern_snake_case_pre_tokens(self) -> None:
+        item = {
+            "type": "system",
+            "subtype": "compact_boundary",
+            "message": {"content": "summary"},
+            "compact_metadata": {"pre_tokens": 50000},
+        }
+        result = detect_context_compaction(item)
+        assert result is not None
+        assert result["pre_tokens"] == 50000
+
+    def test_modern_with_content_blocks(self) -> None:
+        item = {
+            "type": "system",
+            "subtype": "compact_boundary",
+            "message": {"content": [{"type": "text", "text": "Modern block"}]},
+            "compact_metadata": {},
+        }
+        result = detect_context_compaction(item)
+        assert result is not None
+        assert result["summary"] == "Modern block"
+        assert result["is_modern"] is True
+
+    def test_system_without_compact_boundary_not_detected(self) -> None:
+        """system records without subtype == compact_boundary are not compaction."""
+        assert detect_context_compaction({"type": "system"}) is None
+        assert detect_context_compaction({"type": "system", "subtype": "other"}) is None
+
+    def test_modern_no_preserved_segment(self) -> None:
+        item = {
+            "type": "system",
+            "subtype": "compact_boundary",
+            "message": {"content": "No segment"},
+            "compact_metadata": {"trigger": "manual"},
+        }
+        result = detect_context_compaction(item)
+        assert result is not None
+        assert result["preserved_segment_id"] is None
+
+
+# =============================================================================
+# ClaudeCodeRecord.is_context_compaction
+# =============================================================================
+
+class TestClaudeCodeRecordCompaction:
+    def test_legacy_summary(self) -> None:
+        record = ClaudeCodeRecord(type="summary")
+        assert record.is_context_compaction is True
+
+    def test_modern_compact_boundary(self) -> None:
+        record = ClaudeCodeRecord(type="system", subtype="compact_boundary")
+        assert record.is_context_compaction is True
+
+    def test_system_without_subtype(self) -> None:
+        record = ClaudeCodeRecord(type="system")
+        assert record.is_context_compaction is False
+
+    def test_user_not_compaction(self) -> None:
+        record = ClaudeCodeRecord(type="user")
+        assert record.is_context_compaction is False
+
+
+# =============================================================================
+# Claude Code parser — provider_events emission
+# =============================================================================
+
+class TestClaudeCodeParserProviderEvents:
+    def test_legacy_compaction_emits_provider_event(self) -> None:
+        payload = [
+            {"type": "user", "uuid": "u1", "timestamp": "2024-01-01T10:00:00Z",
+             "message": {"role": "user", "content": "hello"}},
+            {"type": "summary", "uuid": "s1", "timestamp": "2024-01-01T10:05:00Z",
+             "message": {"content": "Summary of conversation"}},
+            {"type": "assistant", "uuid": "a1", "timestamp": "2024-01-01T10:10:00Z",
+             "message": {"role": "assistant", "content": "response"}},
+        ]
+        result = parse_code(payload, "test-session")
+        assert len(result.provider_events) == 1
+        event = result.provider_events[0]
+        assert event.event_type == "compaction"
+        assert event.payload["summary"] == "Summary of conversation"
+        assert event.payload["is_modern"] is False
+
+    def test_modern_compaction_emits_provider_event(self) -> None:
+        payload = [
+            {"type": "user", "uuid": "u1", "timestamp": "2024-01-01T10:00:00Z",
+             "message": {"role": "user", "content": "hello"}},
+            {"type": "system", "subtype": "compact_boundary", "uuid": "c1",
+             "timestamp": "2024-01-01T10:05:00Z",
+             "message": {"content": "Modern compacted summary"},
+             "compact_metadata": {"trigger": "auto", "preTokens": 100000}},
+        ]
+        result = parse_code(payload, "test-session")
+        assert len(result.provider_events) == 1
+        event = result.provider_events[0]
+        assert event.event_type == "compaction"
+        assert event.payload["is_modern"] is True
+        assert event.payload["trigger"] == "auto"
+        assert event.payload["pre_tokens"] == 100000
+
+    def test_compaction_backward_compat_provider_meta(self) -> None:
+        """provider_meta['context_compactions'] still populated for backward compat."""
+        payload = [
+            {"type": "summary", "uuid": "s1", "message": {"content": "sum"}},
+        ]
+        result = parse_code(payload, "test-session")
+        assert result.provider_meta is not None
+        compactions = result.provider_meta["context_compactions"]
+        assert len(compactions) == 1
+        assert compactions[0]["summary"] == "sum"
+
+    def test_no_compaction_no_provider_events(self) -> None:
+        payload = [
+            {"type": "user", "uuid": "u1", "timestamp": "2024-01-01T10:00:00Z",
+             "message": {"role": "user", "content": "hello"}},
+        ]
+        result = parse_code(payload, "test-session")
+        assert result.provider_events == []
+
+    def test_compaction_not_counted_as_message(self) -> None:
+        """Compaction records should not appear in messages list."""
+        payload = [
+            {"type": "user", "uuid": "u1", "message": {"role": "user", "content": "hello"}},
+            {"type": "summary", "uuid": "s1", "message": {"content": "summary"}},
+            {"type": "assistant", "uuid": "a1", "message": {"role": "assistant", "content": "world"}},
+        ]
+        result = parse_code(payload, "test-session")
+        assert len(result.messages) == 2
+        roles = [m.role for m in result.messages]
+        assert "system" not in roles or all(r in ("user", "assistant") for r in roles)
+
+
+# =============================================================================
+# CodexRecord — compaction and turn_context recognition
+# =============================================================================
+
+class TestCodexRecordCompaction:
+    def test_compacted_type_recognized(self) -> None:
+        record = CodexRecord(type="compacted", payload={"message": "Compacted text", "replacement_history": [{"role": "user"}]})
+        assert record.is_compaction is True
+        assert record.is_message is False
+        assert record.compacted_message == "Compacted text"
+        assert record.has_replacement_history is True
+
+    def test_compacted_no_replacement_history(self) -> None:
+        record = CodexRecord(type="compacted", payload={"message": "Short"})
+        assert record.is_compaction is True
+        assert record.has_replacement_history is False
+
+    def test_turn_context_recognized(self) -> None:
+        record = CodexRecord(type="turn_context", payload={"context": "data"})
+        assert record.is_turn_context is True
+        assert record.is_message is False
+        assert record.is_compaction is False
+
+    def test_response_item_not_compaction(self) -> None:
+        record = CodexRecord(type="response_item", payload={"type": "message", "role": "user", "content": []})
+        assert record.is_compaction is False
+        assert record.is_turn_context is False
+
+    def test_compacted_message_empty_payload(self) -> None:
+        record = CodexRecord(type="compacted", payload=None)
+        assert record.compacted_message == ""
+        assert record.has_replacement_history is False
+
+
+# =============================================================================
+# Codex parser — provider_events emission
+# =============================================================================
+
+class TestCodexParserProviderEvents:
+    def test_compaction_emits_provider_event(self) -> None:
+        payload = [
+            {"type": "session_meta", "payload": {"id": "s1", "timestamp": "2024-01-01"}},
+            {"type": "compacted", "payload": {"message": "Context was compacted", "replacement_history": []}},
+            {"type": "response_item", "payload": {
+                "type": "message", "role": "user",
+                "content": [{"type": "input_text", "text": "hello"}],
+            }},
+        ]
+        result = parse_codex(payload, "fallback")
+        assert len(result.provider_events) == 1
+        event = result.provider_events[0]
+        assert event.event_type == "compaction"
+        assert event.payload["summary"] == "Context was compacted"
+
+    def test_turn_context_emits_provider_event(self) -> None:
+        payload = [
+            {"type": "session_meta", "payload": {"id": "s1", "timestamp": "2024-01-01"}},
+            {"type": "turn_context", "payload": {"context": "previous turn data"}},
+            {"type": "response_item", "payload": {
+                "type": "message", "role": "user",
+                "content": [{"type": "input_text", "text": "hello"}],
+            }},
+        ]
+        result = parse_codex(payload, "fallback")
+        assert len(result.provider_events) == 1
+        event = result.provider_events[0]
+        assert event.event_type == "turn_context"
+
+    def test_messages_still_extracted_alongside_compaction(self) -> None:
+        """Compaction records must not break normal message extraction."""
+        payload = [
+            {"type": "session_meta", "payload": {"id": "s1", "timestamp": "2024-01-01"}},
+            {"type": "response_item", "payload": {
+                "type": "message", "role": "user",
+                "content": [{"type": "input_text", "text": "first message"}],
+            }},
+            {"type": "compacted", "payload": {"message": "compacted"}},
+            {"type": "response_item", "payload": {
+                "type": "message", "role": "assistant",
+                "content": [{"type": "output_text", "text": "second message"}],
+            }},
+            {"type": "turn_context", "payload": {}},
+            {"type": "response_item", "payload": {
+                "type": "message", "role": "user",
+                "content": [{"type": "input_text", "text": "third message"}],
+            }},
+        ]
+        result = parse_codex(payload, "fallback")
+        assert len(result.messages) == 3
+        assert result.messages[0].text == "first message"
+        assert result.messages[1].text == "second message"
+        assert result.messages[2].text == "third message"
+        assert len(result.provider_events) == 2
+        assert result.provider_events[0].event_type == "compaction"
+        assert result.provider_events[1].event_type == "turn_context"
+
+    def test_compaction_backward_compat_provider_meta(self) -> None:
+        """provider_meta['context_compactions'] still populated for backward compat."""
+        payload = [
+            {"type": "compacted", "payload": {"message": "compact text"}},
+            {"type": "response_item", "payload": {
+                "type": "message", "role": "user",
+                "content": [{"type": "input_text", "text": "hi"}],
+            }},
+        ]
+        result = parse_codex(payload, "fallback")
+        assert result.provider_meta is not None
+        assert "context_compactions" in result.provider_meta
+        compactions = result.provider_meta["context_compactions"]
+        assert len(compactions) == 1
+        assert compactions[0]["summary"] == "compact text"
+
+    def test_no_compaction_no_provider_events(self) -> None:
+        payload = [
+            {"type": "session_meta", "payload": {"id": "s1", "timestamp": "2024-01-01"}},
+            {"type": "response_item", "payload": {
+                "type": "message", "role": "user",
+                "content": [{"type": "input_text", "text": "hello"}],
+            }},
+        ]
+        result = parse_codex(payload, "fallback")
+        assert result.provider_events == []
+
+
+# =============================================================================
+# Profile builder — compaction counting
+# =============================================================================
+
+class TestProfileCompactionCounting:
+    def test_evidence_payload_includes_compaction_fields(self) -> None:
+        from polylogue.archive_products import SessionEvidencePayload
+
+        # Default values
+        payload = SessionEvidencePayload()
+        assert payload.compaction_count == 0
+        assert payload.has_compaction is False
+
+        # With compaction
+        payload = SessionEvidencePayload(compaction_count=3, has_compaction=True)
+        assert payload.compaction_count == 3
+        assert payload.has_compaction is True
+
+    def test_evidence_payload_roundtrips(self) -> None:
+        from polylogue.archive_products import SessionEvidencePayload
+
+        payload = SessionEvidencePayload(compaction_count=2, has_compaction=True)
+        dumped = payload.model_dump()
+        restored = SessionEvidencePayload.model_validate(dumped)
+        assert restored.compaction_count == 2
+        assert restored.has_compaction is True
+
+    def test_profile_evidence_payload_populates_compaction(self) -> None:
+        from polylogue.lib.session_profile_models import SessionProfile
+        from polylogue.storage.session_product_profiles import profile_evidence_payload
+
+        profile = SessionProfile(
+            conversation_id="test",
+            provider="claude-code",
+            title="Test",
+            created_at=None,
+            updated_at=None,
+            message_count=10,
+            substantive_count=5,
+            tool_use_count=2,
+            thinking_count=1,
+            attachment_count=0,
+            word_count=100,
+            total_cost_usd=0.0,
+            total_duration_ms=0,
+            tool_categories={},
+            repo_paths=(),
+            cwd_paths=(),
+            branch_names=(),
+            file_paths_touched=(),
+            languages_detected=(),
+            canonical_projects=(),
+            work_events=(),
+            phases=(),
+            compaction_count=3,
+        )
+        evidence = profile_evidence_payload(profile)
+        assert evidence["compaction_count"] == 3
+        assert evidence["has_compaction"] is True
+
+    def test_profile_evidence_payload_zero_compaction(self) -> None:
+        from polylogue.lib.session_profile_models import SessionProfile
+        from polylogue.storage.session_product_profiles import profile_evidence_payload
+
+        profile = SessionProfile(
+            conversation_id="test",
+            provider="codex",
+            title="Test",
+            created_at=None,
+            updated_at=None,
+            message_count=5,
+            substantive_count=3,
+            tool_use_count=0,
+            thinking_count=0,
+            attachment_count=0,
+            word_count=50,
+            total_cost_usd=0.0,
+            total_duration_ms=0,
+            tool_categories={},
+            repo_paths=(),
+            cwd_paths=(),
+            branch_names=(),
+            file_paths_touched=(),
+            languages_detected=(),
+            canonical_projects=(),
+            work_events=(),
+            phases=(),
+        )
+        evidence = profile_evidence_payload(profile)
+        assert evidence["compaction_count"] == 0
+        assert evidence["has_compaction"] is False


### PR DESCRIPTION
## Summary

I introduced a first-class provider-event surface for compaction and turn-context records so parser outputs can represent non-message provider artifacts without smuggling them through normal message structures. The main target is compaction: both Claude Code and Codex emit records that materially change session interpretation, but those records were either buried in provider-specific message streams or reduced to ad hoc metadata. This change normalizes those records, adds `ParsedProviderEvent` to the parser model, and wires compaction counts into session profiles and evidence products. I kept `provider_meta["context_compactions"]` populated for now so downstream profile code stays stable while the new event surface lands.

## Motivation

Compaction is semantically important. It tells us that a long-running session crossed a context boundary and gives us information about what was preserved or summarized. That is useful for analytics, evidence products, and session interpretation, but the parser layer did not have a proper place to represent it. Claude Code had legacy `summary` records and a newer `system` / `compact_boundary` shape. Codex has `compacted` records and `turn_context` envelopes. None of those are normal messages, and forcing them through message parsing is the wrong model.

At the same time, session products already benefit from knowing whether compaction happened. Rather than waiting for every downstream consumer to migrate to the new provider-event surface before shipping anything, I wanted a transitional change that:
1. normalizes the provider-specific record shapes,
2. exposes them as first-class parser output, and
3. keeps the existing metadata path alive long enough for session products to consume the new information immediately.

## Changes grouped by concern

### Normalized compaction detection

`polylogue/pipeline/semantic_capture.py` now normalizes two Claude Code shapes inside `detect_context_compaction()`:
- legacy `{"type": "summary",...}`
- modern `{"type": "system", "subtype": "compact_boundary",...}`

The returned structure is consistent across both shapes:

```python
{
    "summary": ...,
    "timestamp": ...,
    "trigger": ...,
    "pre_tokens": ...,
    "preserved_segment_id": ...,
    "is_modern": ...,
}
```

I made the extractor tolerant of string or block-based message content and of both `preTokens` and `pre_tokens` because the point of the helper is to hide provider/version differences from the parser.

### First-class provider events

The core parser-model addition is:

```python
class ParsedProviderEvent(BaseModel):
    event_type: str
    timestamp: str | None = None
    payload: dict[str, object] = Field(default_factory=dict)
```

and `ParsedConversation` carries:

```python
provider_events: list[ParsedProviderEvent] = Field(default_factory=list)
```

This gives the parser layer a clean place to store compaction and turn-context records without pretending they are assistant/user/system messages.

### Provider-specific parser changes

For Claude Code:
- `ClaudeCodeRecord` now treats both `summary` and `system` / `compact_boundary` as context-compaction records.
- `parse_code()` appends a `ParsedProviderEvent(event_type="compaction",...)` whenever compaction is detected and skips those records in normal message handling.

For Codex:
- `CodexRecord` gained `is_compaction`, `is_turn_context`, `compacted_message`, and `has_replacement_history`.
- `parse()` handles `compacted` envelopes before message parsing, emits `compaction` events, emits `turn_context` events, and continues to parse adjacent response items as normal messages.

The key behavior here is that provider events are additive; they do not reduce message extraction fidelity.

### Backward-compatible metadata and session products

Kept `provider_meta["context_compactions"]` populated for both parsers so existing downstream code continues to work. Session profile generation still reads compaction information from conversation metadata for now:

```python
compactions = conversation.provider_meta.get("context_compactions")
if isinstance(compactions, list):
    compaction_count = len(compactions)
```

That let me wire the new product-facing fields immediately:
- `SessionProfile.compaction_count`
- `SessionEvidencePayload.compaction_count`
- `SessionEvidencePayload.has_compaction`

and the storage serializer writes both `compaction_count` and `has_compaction` into the evidence payload.

### Exported parser surface

`polylogue/sources/parsers/base.py` now re-exports `ParsedProviderEvent`, so code importing parser model types from the base module can access the new event class without reaching into `base_models.py` directly.

## Testing

The new `tests/unit/sources/test_compaction.py` file covers:
- legacy and modern Claude Code compaction detection
- `ClaudeCodeRecord.is_context_compaction`
- provider-event emission from the Claude Code parser
- `CodexRecord` helpers for compaction and turn-context envelopes
- provider-event emission from the Codex parser
- preservation of `provider_meta["context_compactions"]`
- session-profile and evidence-payload compaction fields

The tests also explicitly check that compaction records do not get counted as normal messages.

## Notes

This is intentionally a transitional design. `provider_events` is the long-term clean surface, but session products still populate `compaction_count` from backward-compatible metadata in this commit. That minimizes migration risk while making the new event model available immediately.

I scoped the change to compaction and turn-context events because those are the clearest non-message provider artifacts in the current providers. The `ParsedProviderEvent` surface is broader than that, but I did not want to invent consumers for hypothetical future event types in the same patch.