### PR TITLE
refactor: introduce artifact graph and unify storage bootstrap

### DIFF
--- a/devtools/artifact_graph.py
+++ b/devtools/artifact_graph.py
@@ -1,0 +1,36 @@
+"""Render the runtime artifact graph for architectural inspection."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from polylogue.artifact_graph import build_artifact_graph
+
+
+def render_artifact_graph(*, as_json: bool) -> str:
+    graph = build_artifact_graph()
+    if as_json:
+        return json.dumps(graph.to_dict(), indent=2)
+
+    lines: list[str] = ["Artifact Paths:"]
+    for path in graph.paths:
+        lines.append(f"- {path.name}: {path.description}")
+        for node_name in path.nodes:
+            node = graph.by_name()[node_name]
+            dependencies = f" <- {', '.join(node.depends_on)}" if node.depends_on else ""
+            lines.append(f"  - {node.name} [{node.layer.value}]{dependencies}")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="Emit the artifact graph as JSON.")
+    args = parser.parse_args(argv)
+    sys.stdout.write(render_artifact_graph(as_json=args.json))
+    sys.stdout.write("\n")
+    return 0
+
+
+__all__ = ["main", "render_artifact_graph"]

--- a/polylogue/artifact_graph.py
+++ b/polylogue/artifact_graph.py
@@ -1,0 +1,179 @@
+"""Explicit artifact/dependency map for Polylogue runtime semantics."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from enum import Enum
+from typing import Any
+
+
+class ArtifactLayer(str, Enum):
+    SOURCE = "source"
+    DURABLE = "durable"
+    DERIVED = "derived"
+    INDEX = "index"
+    PROJECTION = "projection"
+
+
+@dataclass(frozen=True, slots=True)
+class ArtifactNode:
+    """One named artifact or projection in the Polylogue runtime graph."""
+
+    name: str
+    layer: ArtifactLayer
+    description: str
+    depends_on: tuple[str, ...] = ()
+    code_refs: tuple[str, ...] = ()
+    repair_targets: tuple[str, ...] = ()
+    health_surfaces: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data["layer"] = self.layer.value
+        return data
+
+
+@dataclass(frozen=True, slots=True)
+class ArtifactPath:
+    """One curated path through the artifact graph."""
+
+    name: str
+    description: str
+    nodes: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True, slots=True)
+class ArtifactGraph:
+    """Named artifact nodes plus curated high-value paths through them."""
+
+    nodes: tuple[ArtifactNode, ...]
+    paths: tuple[ArtifactPath, ...]
+
+    def by_name(self) -> dict[str, ArtifactNode]:
+        return {node.name: node for node in self.nodes}
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "nodes": [node.to_dict() for node in self.nodes],
+            "paths": [path.to_dict() for path in self.paths],
+        }
+
+
+def build_artifact_graph() -> ArtifactGraph:
+    nodes = (
+        ArtifactNode(
+            name="raw_validation_state",
+            layer=ArtifactLayer.DURABLE,
+            description="Persisted raw-conversation validation and parse state in raw_conversations.",
+            code_refs=(
+                "polylogue.storage.raw_ingest_artifacts.RawIngestArtifactState",
+                "polylogue.storage.backends.queries.raw_state",
+            ),
+        ),
+        ArtifactNode(
+            name="validation_backlog",
+            layer=ArtifactLayer.PROJECTION,
+            description="Raw records that still require validation before ordinary parse planning can trust them.",
+            depends_on=("raw_validation_state",),
+            code_refs=(
+                "polylogue.storage.raw_ingest_artifacts.validation_backlog_query_spec",
+                "polylogue.pipeline.services.planning_backlog.collect_validation_backlog",
+            ),
+        ),
+        ArtifactNode(
+            name="parse_backlog",
+            layer=ArtifactLayer.PROJECTION,
+            description="Raw records eligible for parse planning, including force-reparse simulation.",
+            depends_on=("raw_validation_state",),
+            code_refs=(
+                "polylogue.storage.raw_ingest_artifacts.parse_backlog_query_spec",
+                "polylogue.pipeline.services.planning_backlog.collect_parse_backlog",
+                "polylogue.pipeline.services.planning_runtime.build_ingest_plan",
+            ),
+        ),
+        ArtifactNode(
+            name="parse_quarantine",
+            layer=ArtifactLayer.PROJECTION,
+            description="Validation-failed unparsed raws that stay out of ordinary parse backlog but return under force-reparse.",
+            depends_on=("raw_validation_state",),
+            code_refs=("polylogue.storage.raw_ingest_artifacts.RawIngestArtifactState",),
+        ),
+        ArtifactNode(
+            name="tool_use_source_blocks",
+            layer=ArtifactLayer.SOURCE,
+            description="Tool-use content blocks anchored to valid conversations.",
+            code_refs=("polylogue.storage.action_event_status",),
+        ),
+        ArtifactNode(
+            name="action_event_rows",
+            layer=ArtifactLayer.DERIVED,
+            description="Materialized action-event read model derived from tool-use source blocks.",
+            depends_on=("tool_use_source_blocks",),
+            code_refs=(
+                "polylogue.storage.action_event_artifacts.ActionEventArtifactState",
+                "polylogue.storage.action_event_status",
+            ),
+            repair_targets=("action_event_read_model",),
+            health_surfaces=("doctor", "archive_debt"),
+        ),
+        ArtifactNode(
+            name="action_event_fts",
+            layer=ArtifactLayer.INDEX,
+            description="FTS projection over the action-event read model.",
+            depends_on=("action_event_rows",),
+            code_refs=(
+                "polylogue.storage.action_event_artifacts.ActionEventArtifactState",
+                "polylogue.storage.derived_status_products.build_action_statuses",
+            ),
+            repair_targets=("action_event_read_model",),
+            health_surfaces=("doctor", "archive_debt", "retrieval_evidence"),
+        ),
+        ArtifactNode(
+            name="action_event_health",
+            layer=ArtifactLayer.PROJECTION,
+            description="Projected health, debt, and repair semantics over action-event rows and FTS.",
+            depends_on=("action_event_rows", "action_event_fts"),
+            code_refs=(
+                "polylogue.storage.derived_status",
+                "polylogue.storage.repair",
+                "polylogue.storage.embedding_stats_support",
+            ),
+            repair_targets=("action_event_read_model",),
+            health_surfaces=("doctor", "archive_debt", "retrieval_evidence"),
+        ),
+    )
+    paths = (
+        ArtifactPath(
+            name="raw-reparse-loop",
+            description="Raw validation state to validation/parse backlog and quarantine projections.",
+            nodes=(
+                "raw_validation_state",
+                "validation_backlog",
+                "parse_backlog",
+                "parse_quarantine",
+            ),
+        ),
+        ArtifactPath(
+            name="action-event-repair-loop",
+            description="Tool-use source blocks through action-event rows, FTS, and projected repair semantics.",
+            nodes=(
+                "tool_use_source_blocks",
+                "action_event_rows",
+                "action_event_fts",
+                "action_event_health",
+            ),
+        ),
+    )
+    return ArtifactGraph(nodes=nodes, paths=paths)
+
+
+__all__ = [
+    "ArtifactGraph",
+    "ArtifactLayer",
+    "ArtifactNode",
+    "ArtifactPath",
+    "build_artifact_graph",
+]

--- a/polylogue/pipeline/services/planning_backlog.py
+++ b/polylogue/pipeline/services/planning_backlog.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from polylogue.storage.backends.async_sqlite import SQLiteBackend
+from polylogue.storage.raw_ingest_artifacts import parse_backlog_query_spec, validation_backlog_query_spec
 
 
 def dedupe_ids(raw_ids: list[str]) -> list[str]:
@@ -25,10 +26,12 @@ async def collect_validation_backlog(
 ) -> list[str]:
     exclude = set(exclude_raw_ids or [])
     backlog_validate_ids: list[str] = []
+    query_spec = validation_backlog_query_spec(force_reparse=force_reparse)
     async for raw_id in backend.queries.iter_raw_ids(
         source_names=source_names,
-        require_unparsed=not force_reparse,
-        require_unvalidated=True,
+        require_unparsed=query_spec.require_unparsed,
+        require_unvalidated=query_spec.require_unvalidated,
+        validation_statuses=list(query_spec.validation_statuses) if query_spec.validation_statuses is not None else None,
     ):
         if raw_id not in exclude:
             backlog_validate_ids.append(raw_id)
@@ -44,11 +47,11 @@ async def collect_parse_backlog(
 ) -> list[str]:
     exclude = set(exclude_raw_ids or [])
     backlog_parse_ids: list[str] = []
-    validation_statuses = None if force_reparse else ["passed", "skipped"]
+    query_spec = parse_backlog_query_spec(force_reparse=force_reparse)
     async for raw_id in backend.queries.iter_raw_ids(
         source_names=source_names,
-        require_unparsed=not force_reparse,
-        validation_statuses=validation_statuses,
+        require_unparsed=query_spec.require_unparsed,
+        validation_statuses=list(query_spec.validation_statuses) if query_spec.validation_statuses is not None else None,
     ):
         if raw_id not in exclude:
             backlog_parse_ids.append(raw_id)

--- a/polylogue/pipeline/services/planning_runtime.py
+++ b/polylogue/pipeline/services/planning_runtime.py
@@ -9,6 +9,7 @@ from polylogue.config import Source
 from polylogue.pipeline.run_support import expand_requested_stage, normalize_stage_sequence
 from polylogue.pipeline.stage_models import ValidateResult
 from polylogue.protocols import ProgressCallback
+from polylogue.storage.raw_ingest_artifacts import RawIngestArtifactState
 from polylogue.storage.state_views import PlanResult
 from polylogue.storage.store import RawConversationRecord
 from polylogue.types import PlanStage
@@ -162,14 +163,19 @@ async def build_ingest_plan(
             state = scanned_states.get(record.raw_id)
             if state is None:
                 details["new_raw"] += 1
+                if has_parse:
+                    validate_raw_ids.append(record.raw_id)
+                    if (
+                        preview
+                        and preview_validation is not None
+                        and len(preview_records) < max_preview_validation_records
+                    ):
+                        preview_records.append(record)
             else:
                 details["existing_raw"] += 1
-
-            if has_parse:
-                current_status = state.validation_status if state is not None else None
-                parsed_at = None if force_reparse else (state.parsed_at if state is not None else None)
-                if parsed_at is None:
-                    if current_status is None:
+                if has_parse:
+                    artifact_state = RawIngestArtifactState.from_state(state)
+                    if artifact_state.needs_validation_backlog(force_reparse=force_reparse):
                         validate_raw_ids.append(record.raw_id)
                         # Only accumulate a limited sample for preview validation
                         # to bound memory. Full validation happens during actual runs.
@@ -179,7 +185,7 @@ async def build_ingest_plan(
                             and len(preview_records) < max_preview_validation_records
                         ):
                             preview_records.append(record)
-                    elif current_status in {"passed", "skipped"}:
+                    if artifact_state.needs_parse_backlog(force_reparse=force_reparse):
                         parse_ready_raw_ids.append(record.raw_id)
 
         if preview_records and preview_validation is not None:

--- a/polylogue/storage/action_event_artifacts.py
+++ b/polylogue/storage/action_event_artifacts.py
@@ -1,0 +1,144 @@
+"""Shared action-event artifact semantics for status, debt, and repair."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+from polylogue.maintenance_models import DerivedModelStatus
+
+
+def _format_count_parts(parts: list[str]) -> str:
+    if not parts:
+        return ""
+    return ", ".join(parts)
+
+
+@dataclass(frozen=True, slots=True)
+class ActionEventArtifactState:
+    """Canonical state for the action-event read model and its FTS index."""
+
+    source_conversations: int
+    materialized_conversations: int
+    materialized_rows: int
+    fts_rows: int
+    stale_rows: int = 0
+    orphan_rows: int = 0
+    matches_version: bool = True
+
+    @classmethod
+    def from_metrics(cls, metrics: Mapping[str, int | bool]) -> ActionEventArtifactState:
+        return cls(
+            source_conversations=int(metrics["action_source_documents"]),
+            materialized_conversations=int(metrics["action_documents"]),
+            materialized_rows=int(metrics["action_rows"]),
+            fts_rows=int(metrics["action_fts_rows"]),
+            stale_rows=int(metrics["action_stale_rows"]),
+            orphan_rows=int(metrics["action_orphan_rows"]),
+            matches_version=bool(metrics["action_matches_version"]),
+        )
+
+    @classmethod
+    def from_status_snapshot(cls, status: Mapping[str, int | bool]) -> ActionEventArtifactState:
+        return cls(
+            source_conversations=int(status["valid_source_conversation_count"]),
+            materialized_conversations=int(status["materialized_conversation_count"]),
+            materialized_rows=int(status["count"]),
+            fts_rows=int(status["action_fts_count"]),
+            stale_rows=int(status["stale_count"]),
+            orphan_rows=int(status["orphan_tool_block_count"]),
+            matches_version=bool(status["matches_version"]),
+        )
+
+    @property
+    def missing_conversations(self) -> int:
+        return max(0, self.source_conversations - self.materialized_conversations)
+
+    @property
+    def pending_fts_rows(self) -> int:
+        return max(0, self.materialized_rows - self.fts_rows)
+
+    @property
+    def excess_fts_rows(self) -> int:
+        return max(0, self.fts_rows - self.materialized_rows)
+
+    @property
+    def rows_ready(self) -> bool:
+        return self.source_conversations == 0 or (
+            self.missing_conversations == 0 and self.stale_rows == 0
+        )
+
+    @property
+    def fts_ready(self) -> bool:
+        return self.pending_fts_rows == 0 and self.excess_fts_rows == 0
+
+    @property
+    def ready(self) -> bool:
+        return self.rows_ready and self.fts_ready
+
+    @property
+    def repair_item_count(self) -> int:
+        return self.missing_conversations + self.stale_rows + self.pending_fts_rows + self.excess_fts_rows
+
+    def repair_detail(self) -> str:
+        if self.repair_item_count == 0:
+            return "Action-event read model ready"
+
+        parts: list[str] = []
+        if self.missing_conversations:
+            parts.append(f"{self.missing_conversations:,} missing conversations")
+        if self.stale_rows:
+            parts.append(f"{self.stale_rows:,} stale action-event rows")
+        if self.pending_fts_rows:
+            parts.append(f"{self.pending_fts_rows:,} pending action-event FTS rows")
+        if self.excess_fts_rows:
+            parts.append(f"{self.excess_fts_rows:,} stale extra action-event FTS rows")
+        return f"Action-event read model pending ({_format_count_parts(parts)})"
+
+    def row_status(self) -> DerivedModelStatus:
+        return DerivedModelStatus(
+            name="action_events",
+            ready=self.rows_ready,
+            detail=(
+                f"Action-event rows ready ({self.materialized_conversations:,}/{self.source_conversations:,} conversations)"
+                if self.rows_ready
+                else (
+                    f"Action-event rows pending ({self.materialized_conversations:,}/{self.source_conversations:,} conversations; "
+                    f"stale rows {self.stale_rows:,}, orphan rows {self.orphan_rows:,})"
+                )
+            ),
+            source_documents=self.source_conversations,
+            materialized_documents=self.materialized_conversations,
+            materialized_rows=self.materialized_rows,
+            pending_documents=self.missing_conversations,
+            stale_rows=self.stale_rows,
+            orphan_rows=self.orphan_rows,
+            matches_version=self.matches_version,
+        )
+
+    def fts_status(self) -> DerivedModelStatus:
+        if self.fts_ready:
+            detail = f"Action-event FTS ready ({self.fts_rows:,}/{self.materialized_rows:,} rows)"
+        else:
+            parts: list[str] = []
+            if self.pending_fts_rows:
+                parts.append(f"{self.pending_fts_rows:,} pending")
+            if self.excess_fts_rows:
+                parts.append(f"{self.excess_fts_rows:,} stale extra")
+            detail = (
+                f"Action-event FTS pending ({self.fts_rows:,}/{self.materialized_rows:,} rows; "
+                f"{_format_count_parts(parts)} rows)"
+            )
+        return DerivedModelStatus(
+            name="action_events_fts",
+            ready=self.fts_ready,
+            detail=detail,
+            source_rows=self.materialized_rows,
+            materialized_rows=self.fts_rows,
+            pending_rows=self.pending_fts_rows,
+            stale_rows=self.excess_fts_rows,
+            orphan_rows=self.orphan_rows,
+        )
+
+
+__all__ = ["ActionEventArtifactState"]

--- a/polylogue/storage/action_event_status.py
+++ b/polylogue/storage/action_event_status.py
@@ -6,6 +6,7 @@ import sqlite3
 
 import aiosqlite
 
+from polylogue.storage.action_event_artifacts import ActionEventArtifactState
 from polylogue.storage.store import ACTION_EVENT_MATERIALIZER_VERSION
 
 _ACTION_EVENTS_EXISTS_SQL = "SELECT name FROM sqlite_master WHERE type='table' AND name='action_events'"
@@ -78,27 +79,32 @@ def action_event_read_model_status_sync(
         orphan_tool_block_count = 0
         source_conversation_count = materialized_conversation_count
     fts_status = fts_index_status_sync(conn)
-    action_fts_count = int(fts_status.get("action_count", 0))
-    action_fts_ready = count == action_fts_count
-    rows_ready = valid_source_conversation_count == 0 or (
-        valid_source_conversation_count == materialized_conversation_count and stale_count == 0
+    state = ActionEventArtifactState(
+        source_conversations=valid_source_conversation_count,
+        materialized_conversations=materialized_conversation_count,
+        materialized_rows=count,
+        fts_rows=int(fts_status.get("action_count", 0)),
+        stale_rows=stale_count,
+        orphan_rows=orphan_tool_block_count,
+        matches_version=stale_count == 0,
     )
-    ready = rows_ready and action_fts_ready
     return {
         "exists": exists,
         "count": count,
         "stale_count": stale_count,
-        "matches_version": stale_count == 0,
+        "matches_version": state.matches_version,
         "source_conversation_count": source_conversation_count,
         "valid_source_conversation_count": valid_source_conversation_count,
         "orphan_source_conversation_count": orphan_source_conversation_count,
         "orphan_tool_block_count": orphan_tool_block_count,
         "materialized_conversation_count": materialized_conversation_count,
-        "rows_ready": rows_ready,
+        "rows_ready": state.rows_ready,
         "action_fts_exists": bool(fts_status.get("exists", False)),
-        "action_fts_count": action_fts_count,
-        "action_fts_ready": action_fts_ready,
-        "ready": ready,
+        "action_fts_count": state.fts_rows,
+        "action_fts_pending_rows": state.pending_fts_rows,
+        "action_fts_stale_rows": state.excess_fts_rows,
+        "action_fts_ready": state.fts_ready,
+        "ready": state.ready,
     }
 
 
@@ -140,27 +146,32 @@ async def action_event_read_model_status_async(
         orphan_tool_block_count = 0
         source_conversation_count = materialized_conversation_count
     fts_status = await fts_index_status_async(conn)
-    action_fts_count = int(fts_status.get("action_count", 0))
-    action_fts_ready = count == action_fts_count
-    rows_ready = valid_source_conversation_count == 0 or (
-        valid_source_conversation_count == materialized_conversation_count and stale_count == 0
+    state = ActionEventArtifactState(
+        source_conversations=valid_source_conversation_count,
+        materialized_conversations=materialized_conversation_count,
+        materialized_rows=count,
+        fts_rows=int(fts_status.get("action_count", 0)),
+        stale_rows=stale_count,
+        orphan_rows=orphan_tool_block_count,
+        matches_version=stale_count == 0,
     )
-    ready = rows_ready and action_fts_ready
     return {
         "exists": exists,
         "count": count,
         "stale_count": stale_count,
-        "matches_version": stale_count == 0,
+        "matches_version": state.matches_version,
         "source_conversation_count": source_conversation_count,
         "valid_source_conversation_count": valid_source_conversation_count,
         "orphan_source_conversation_count": orphan_source_conversation_count,
         "orphan_tool_block_count": orphan_tool_block_count,
         "materialized_conversation_count": materialized_conversation_count,
-        "rows_ready": rows_ready,
+        "rows_ready": state.rows_ready,
         "action_fts_exists": bool(fts_status.get("exists", False)),
-        "action_fts_count": action_fts_count,
-        "action_fts_ready": action_fts_ready,
-        "ready": ready,
+        "action_fts_count": state.fts_rows,
+        "action_fts_pending_rows": state.pending_fts_rows,
+        "action_fts_stale_rows": state.excess_fts_rows,
+        "action_fts_ready": state.fts_ready,
+        "ready": state.ready,
     }
 
 

--- a/polylogue/storage/backends/async_sqlite_schema.py
+++ b/polylogue/storage/backends/async_sqlite_schema.py
@@ -4,182 +4,39 @@ from __future__ import annotations
 
 import aiosqlite
 
+from polylogue.errors import DatabaseError
+from polylogue.storage.backends.schema_bootstrap import (
+    SCHEMA_DDL,
+    SCHEMA_VERSION,
+    apply_schema_extension_plan_async,
+    assert_supported_archive_layout_snapshot,
+    build_current_schema_extension_plan,
+    capture_schema_snapshot_async,
+    ensure_vec0_table_async,
+    schema_version_mismatch_message,
+)
+
 
 async def ensure_schema(conn: aiosqlite.Connection) -> None:
     """Ensure database schema exists and is at the current schema version."""
-    from polylogue.storage.backends.schema_ddl import (
-        _ACTION_EVENT_DDL,
-        _ACTION_FTS_DDL,
-        _ARTIFACT_OBSERVATION_DDL,
-        _PUBLICATION_DDL,
-        _SESSION_PRODUCT_DDL,
-        _VEC0_DDL,
-        SCHEMA_DDL,
-        SCHEMA_VERSION,
-    )
+    snapshot = await capture_schema_snapshot_async(conn)
 
-    cursor = await conn.execute("PRAGMA user_version")
-    row = await cursor.fetchone()
-    current_version = row[0] if row else 0
-
-    if current_version == 0:
+    if snapshot.current_version == 0:
         await conn.execute("PRAGMA foreign_keys = ON")
         await conn.executescript(SCHEMA_DDL)
-        try:
-            await conn.execute("SELECT vec_version()")
-            await conn.execute(_VEC0_DDL)
-        except Exception:
-            pass
+        await ensure_vec0_table_async(conn)
         await conn.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
         await conn.commit()
         return
 
-    cursor = await conn.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='raw_conversations'")
-    raw_table_exists = await cursor.fetchone() is not None
-    if raw_table_exists:
-        cursor = await conn.execute("PRAGMA table_info(raw_conversations)")
-        raw_columns = {row[1] for row in await cursor.fetchall()}
-        if "raw_content" in raw_columns:
-            from polylogue.errors import DatabaseError
+    assert_supported_archive_layout_snapshot(snapshot)
 
-            raise DatabaseError(
-                "Database uses the legacy inline raw-content layout and is incompatible with the current blob-store "
-                "archive format. Move the database aside or run `polylogue reset --database` before re-importing."
-            )
-    else:
-        raw_columns = set()
+    if snapshot.current_version != SCHEMA_VERSION:
+        raise DatabaseError(schema_version_mismatch_message(snapshot.current_version))
 
-    if current_version != SCHEMA_VERSION:
-        from polylogue.errors import DatabaseError
-
-        raise DatabaseError(
-            f"Database schema version {current_version} is incompatible with expected version {SCHEMA_VERSION}. "
-            f"Delete the database file and re-run polylogue to create a fresh v{SCHEMA_VERSION} schema."
-        )
-
-    if "blob_size" not in raw_columns:
-        await conn.execute("ALTER TABLE raw_conversations ADD COLUMN blob_size INTEGER NOT NULL DEFAULT 0")
-
-    content_blocks_exists = bool(
-        await (await conn.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='content_blocks'")).fetchone()
-    )
-    if content_blocks_exists:
-        await conn.execute(
-            """
-            CREATE INDEX IF NOT EXISTS idx_content_blocks_tool_use_conversation
-            ON content_blocks(conversation_id)
-            WHERE type = 'tool_use'
-            """
-        )
-    await conn.executescript(_ARTIFACT_OBSERVATION_DDL)
-    await conn.executescript(_PUBLICATION_DDL)
-    await conn.executescript(_ACTION_EVENT_DDL)
-    cursor = await conn.execute("PRAGMA table_info(action_events)")
-    action_event_columns = {row[1] for row in await cursor.fetchall()}
-    if "materializer_version" not in action_event_columns:
-        await conn.execute("ALTER TABLE action_events ADD COLUMN materializer_version INTEGER NOT NULL DEFAULT 1")
-    await conn.executescript(_ACTION_FTS_DDL)
-
-    session_profiles_exists = bool(
-        await (
-            await conn.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='session_profiles'")
-        ).fetchone()
-    )
-    if session_profiles_exists:
-        cursor = await conn.execute("PRAGMA table_info(session_profiles)")
-        session_profile_columns = {row[1] for row in await cursor.fetchall()}
-        if "canonical_session_date" not in session_profile_columns:
-            await conn.execute("ALTER TABLE session_profiles ADD COLUMN canonical_session_date TEXT")
-        if "last_message_at" not in session_profile_columns:
-            await conn.execute("ALTER TABLE session_profiles ADD COLUMN last_message_at TEXT")
-        if "substantive_count" not in session_profile_columns:
-            await conn.execute("ALTER TABLE session_profiles ADD COLUMN substantive_count INTEGER NOT NULL DEFAULT 0")
-        if "attachment_count" not in session_profile_columns:
-            await conn.execute("ALTER TABLE session_profiles ADD COLUMN attachment_count INTEGER NOT NULL DEFAULT 0")
-        if "phase_count" not in session_profile_columns:
-            await conn.execute("ALTER TABLE session_profiles ADD COLUMN phase_count INTEGER NOT NULL DEFAULT 0")
-        if "engaged_duration_ms" not in session_profile_columns:
-            await conn.execute("ALTER TABLE session_profiles ADD COLUMN engaged_duration_ms INTEGER NOT NULL DEFAULT 0")
-        if "cost_is_estimated" not in session_profile_columns:
-            await conn.execute("ALTER TABLE session_profiles ADD COLUMN cost_is_estimated INTEGER NOT NULL DEFAULT 0")
-        if "evidence_payload_json" not in session_profile_columns:
-            await conn.execute(
-                "ALTER TABLE session_profiles ADD COLUMN evidence_payload_json TEXT NOT NULL DEFAULT '{}'"
-            )
-        if "inference_payload_json" not in session_profile_columns:
-            await conn.execute(
-                "ALTER TABLE session_profiles ADD COLUMN inference_payload_json TEXT NOT NULL DEFAULT '{}'"
-            )
-        if "evidence_search_text" not in session_profile_columns:
-            await conn.execute("ALTER TABLE session_profiles ADD COLUMN evidence_search_text TEXT NOT NULL DEFAULT ''")
-        if "inference_search_text" not in session_profile_columns:
-            await conn.execute("ALTER TABLE session_profiles ADD COLUMN inference_search_text TEXT NOT NULL DEFAULT ''")
-        if "inference_version" not in session_profile_columns:
-            await conn.execute("ALTER TABLE session_profiles ADD COLUMN inference_version INTEGER NOT NULL DEFAULT 1")
-        if "inference_family" not in session_profile_columns:
-            await conn.execute(
-                "ALTER TABLE session_profiles ADD COLUMN inference_family TEXT NOT NULL DEFAULT 'heuristic_session_semantics'"
-            )
-
-    session_work_events_exists = bool(
-        await (
-            await conn.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='session_work_events'")
-        ).fetchone()
-    )
-    if session_work_events_exists:
-        cursor = await conn.execute("PRAGMA table_info(session_work_events)")
-        session_work_event_columns = {row[1] for row in await cursor.fetchall()}
-        if "start_time" not in session_work_event_columns:
-            await conn.execute("ALTER TABLE session_work_events ADD COLUMN start_time TEXT")
-        if "end_time" not in session_work_event_columns:
-            await conn.execute("ALTER TABLE session_work_events ADD COLUMN end_time TEXT")
-        if "duration_ms" not in session_work_event_columns:
-            await conn.execute("ALTER TABLE session_work_events ADD COLUMN duration_ms INTEGER NOT NULL DEFAULT 0")
-        if "canonical_session_date" not in session_work_event_columns:
-            await conn.execute("ALTER TABLE session_work_events ADD COLUMN canonical_session_date TEXT")
-        if "evidence_payload_json" not in session_work_event_columns:
-            await conn.execute(
-                "ALTER TABLE session_work_events ADD COLUMN evidence_payload_json TEXT NOT NULL DEFAULT '{}'"
-            )
-        if "inference_payload_json" not in session_work_event_columns:
-            await conn.execute(
-                "ALTER TABLE session_work_events ADD COLUMN inference_payload_json TEXT NOT NULL DEFAULT '{}'"
-            )
-        if "inference_version" not in session_work_event_columns:
-            await conn.execute(
-                "ALTER TABLE session_work_events ADD COLUMN inference_version INTEGER NOT NULL DEFAULT 1"
-            )
-        if "inference_family" not in session_work_event_columns:
-            await conn.execute(
-                "ALTER TABLE session_work_events ADD COLUMN inference_family TEXT NOT NULL DEFAULT 'heuristic_session_semantics'"
-            )
-
-    session_phases_exists = bool(
-        await (
-            await conn.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='session_phases'")
-        ).fetchone()
-    )
-    if session_phases_exists:
-        cursor = await conn.execute("PRAGMA table_info(session_phases)")
-        session_phase_columns = {row[1] for row in await cursor.fetchall()}
-        if "confidence" not in session_phase_columns:
-            await conn.execute("ALTER TABLE session_phases ADD COLUMN confidence REAL NOT NULL DEFAULT 0")
-        if "evidence_reasons_json" not in session_phase_columns:
-            await conn.execute("ALTER TABLE session_phases ADD COLUMN evidence_reasons_json TEXT NOT NULL DEFAULT '[]'")
-        if "evidence_payload_json" not in session_phase_columns:
-            await conn.execute("ALTER TABLE session_phases ADD COLUMN evidence_payload_json TEXT NOT NULL DEFAULT '{}'")
-        if "inference_payload_json" not in session_phase_columns:
-            await conn.execute(
-                "ALTER TABLE session_phases ADD COLUMN inference_payload_json TEXT NOT NULL DEFAULT '{}'"
-            )
-        if "inference_version" not in session_phase_columns:
-            await conn.execute("ALTER TABLE session_phases ADD COLUMN inference_version INTEGER NOT NULL DEFAULT 1")
-        if "inference_family" not in session_phase_columns:
-            await conn.execute(
-                "ALTER TABLE session_phases ADD COLUMN inference_family TEXT NOT NULL DEFAULT 'heuristic_session_semantics'"
-            )
-
-    await conn.executescript(_SESSION_PRODUCT_DDL)
+    plan = build_current_schema_extension_plan(snapshot)
+    await apply_schema_extension_plan_async(conn, plan)
+    await ensure_vec0_table_async(conn)
     await conn.commit()
 
 

--- a/polylogue/storage/backends/schema_bootstrap.py
+++ b/polylogue/storage/backends/schema_bootstrap.py
@@ -1,0 +1,324 @@
+"""Shared schema bootstrap planning for sync and async SQLite backends."""
+
+from __future__ import annotations
+
+import re
+import sqlite3
+from contextlib import suppress
+from dataclasses import dataclass
+
+import aiosqlite
+
+from polylogue.errors import DatabaseError
+from polylogue.storage.backends.schema_ddl import (
+    _ACTION_EVENT_DDL,
+    _ACTION_FTS_DDL,
+    _ARTIFACT_OBSERVATION_DDL,
+    _PUBLICATION_DDL,
+    _SESSION_PRODUCT_DDL,
+    _VEC0_DDL,
+    SCHEMA_DDL,
+    SCHEMA_VERSION,
+)
+
+_RAW_SOURCE_MTIME_INDEX_SQL = (
+    "CREATE INDEX IF NOT EXISTS idx_raw_conv_source_mtime "
+    "ON raw_conversations(source_path, file_mtime) "
+    "WHERE file_mtime IS NOT NULL"
+)
+
+
+@dataclass(frozen=True)
+class SchemaSnapshot:
+    """Minimal database state needed to plan bootstrap extensions."""
+
+    current_version: int
+    table_columns: dict[str, frozenset[str]]
+    index_sql: dict[str, str | None]
+
+    def has_table(self, table_name: str) -> bool:
+        return table_name in self.table_columns
+
+    def columns(self, table_name: str) -> frozenset[str]:
+        return self.table_columns.get(table_name, frozenset())
+
+    def sql_for_index(self, index_name: str) -> str | None:
+        return self.index_sql.get(index_name)
+
+
+@dataclass(frozen=True)
+class SchemaExtensionPlan:
+    """Ordered SQL needed to bring a current-version DB up to current extensions."""
+
+    statements: tuple[str, ...]
+    scripts: tuple[str, ...]
+
+
+def _normalize_sql(sql: str) -> str:
+    normalized = " ".join(sql.replace(";", " ").split())
+    normalized = re.sub(r"\bIF\s+NOT\s+EXISTS\b", "", normalized, flags=re.IGNORECASE)
+    return " ".join(normalized.split())
+
+
+def schema_version_mismatch_message(current_version: int) -> str:
+    return (
+        f"Database schema version {current_version} is incompatible with expected version {SCHEMA_VERSION}. "
+        "Delete the database and re-import: `polylogue reset --database && polylogue run`."
+    )
+
+
+def assert_supported_archive_layout_snapshot(snapshot: SchemaSnapshot) -> None:
+    """Reject legacy archive layouts that the current runtime cannot write safely."""
+    if not snapshot.has_table("raw_conversations"):
+        return
+
+    if "raw_content" in snapshot.columns("raw_conversations"):
+        raise DatabaseError(
+            "Database uses the legacy inline raw-content layout and is incompatible with the current blob-store "
+            "archive format. Move the database aside or run `polylogue reset --database` before re-importing."
+        )
+
+
+def build_current_schema_extension_plan(snapshot: SchemaSnapshot) -> SchemaExtensionPlan:
+    """Build the canonical extension sequence for current-version databases."""
+    assert_supported_archive_layout_snapshot(snapshot)
+
+    statements: list[str] = []
+    scripts: list[str] = []
+
+    if snapshot.has_table("raw_conversations") and "blob_size" not in snapshot.columns("raw_conversations"):
+        statements.append("ALTER TABLE raw_conversations ADD COLUMN blob_size INTEGER NOT NULL DEFAULT 0")
+
+    if snapshot.has_table("raw_conversations"):
+        existing_index_sql = snapshot.sql_for_index("idx_raw_conv_source_mtime")
+        if existing_index_sql is None or _normalize_sql(existing_index_sql) != _normalize_sql(
+            _RAW_SOURCE_MTIME_INDEX_SQL
+        ):
+            if existing_index_sql is not None:
+                statements.append("DROP INDEX IF EXISTS idx_raw_conv_source_mtime")
+            statements.append(_RAW_SOURCE_MTIME_INDEX_SQL)
+
+    if snapshot.has_table("content_blocks"):
+        statements.append(
+            """
+            CREATE INDEX IF NOT EXISTS idx_content_blocks_tool_use_conversation
+            ON content_blocks(conversation_id)
+            WHERE type = 'tool_use'
+            """
+        )
+
+    scripts.extend((_ARTIFACT_OBSERVATION_DDL, _PUBLICATION_DDL, _ACTION_EVENT_DDL))
+    if snapshot.has_table("action_events") and "materializer_version" not in snapshot.columns("action_events"):
+        statements.append("ALTER TABLE action_events ADD COLUMN materializer_version INTEGER NOT NULL DEFAULT 1")
+    scripts.append(_ACTION_FTS_DDL)
+
+    if snapshot.has_table("session_profiles"):
+        session_profile_columns = snapshot.columns("session_profiles")
+        if "canonical_session_date" not in session_profile_columns:
+            statements.append("ALTER TABLE session_profiles ADD COLUMN canonical_session_date TEXT")
+        if "last_message_at" not in session_profile_columns:
+            statements.append("ALTER TABLE session_profiles ADD COLUMN last_message_at TEXT")
+        if "substantive_count" not in session_profile_columns:
+            statements.append("ALTER TABLE session_profiles ADD COLUMN substantive_count INTEGER NOT NULL DEFAULT 0")
+        if "attachment_count" not in session_profile_columns:
+            statements.append("ALTER TABLE session_profiles ADD COLUMN attachment_count INTEGER NOT NULL DEFAULT 0")
+        if "phase_count" not in session_profile_columns:
+            statements.append("ALTER TABLE session_profiles ADD COLUMN phase_count INTEGER NOT NULL DEFAULT 0")
+        if "engaged_duration_ms" not in session_profile_columns:
+            statements.append("ALTER TABLE session_profiles ADD COLUMN engaged_duration_ms INTEGER NOT NULL DEFAULT 0")
+        if "cost_is_estimated" not in session_profile_columns:
+            statements.append("ALTER TABLE session_profiles ADD COLUMN cost_is_estimated INTEGER NOT NULL DEFAULT 0")
+        if "evidence_payload_json" not in session_profile_columns:
+            statements.append("ALTER TABLE session_profiles ADD COLUMN evidence_payload_json TEXT NOT NULL DEFAULT '{}'")
+        if "inference_payload_json" not in session_profile_columns:
+            statements.append("ALTER TABLE session_profiles ADD COLUMN inference_payload_json TEXT NOT NULL DEFAULT '{}'")
+        if "evidence_search_text" not in session_profile_columns:
+            statements.append("ALTER TABLE session_profiles ADD COLUMN evidence_search_text TEXT NOT NULL DEFAULT ''")
+        if "inference_search_text" not in session_profile_columns:
+            statements.append("ALTER TABLE session_profiles ADD COLUMN inference_search_text TEXT NOT NULL DEFAULT ''")
+        if "enrichment_payload_json" not in session_profile_columns:
+            statements.append("ALTER TABLE session_profiles ADD COLUMN enrichment_payload_json TEXT NOT NULL DEFAULT '{}'")
+        if "enrichment_search_text" not in session_profile_columns:
+            statements.append("ALTER TABLE session_profiles ADD COLUMN enrichment_search_text TEXT NOT NULL DEFAULT ''")
+        if "enrichment_version" not in session_profile_columns:
+            statements.append("ALTER TABLE session_profiles ADD COLUMN enrichment_version INTEGER NOT NULL DEFAULT 1")
+        if "enrichment_family" not in session_profile_columns:
+            statements.append(
+                "ALTER TABLE session_profiles ADD COLUMN enrichment_family TEXT NOT NULL DEFAULT 'scored_session_enrichment'"
+            )
+        if "inference_version" not in session_profile_columns:
+            statements.append("ALTER TABLE session_profiles ADD COLUMN inference_version INTEGER NOT NULL DEFAULT 1")
+        if "inference_family" not in session_profile_columns:
+            statements.append(
+                "ALTER TABLE session_profiles ADD COLUMN inference_family TEXT NOT NULL DEFAULT 'heuristic_session_semantics'"
+            )
+        statements.extend(
+            (
+                """
+                UPDATE session_profiles
+                SET evidence_search_text = search_text
+                WHERE TRIM(COALESCE(evidence_search_text, '')) = ''
+                """,
+                """
+                UPDATE session_profiles
+                SET inference_search_text = search_text
+                WHERE TRIM(COALESCE(inference_search_text, '')) = ''
+                """,
+                """
+                UPDATE session_profiles
+                SET enrichment_search_text = inference_search_text
+                WHERE TRIM(COALESCE(enrichment_search_text, '')) = ''
+                """,
+            )
+        )
+
+    if snapshot.has_table("session_work_events"):
+        session_work_event_columns = snapshot.columns("session_work_events")
+        if "start_time" not in session_work_event_columns:
+            statements.append("ALTER TABLE session_work_events ADD COLUMN start_time TEXT")
+        if "end_time" not in session_work_event_columns:
+            statements.append("ALTER TABLE session_work_events ADD COLUMN end_time TEXT")
+        if "duration_ms" not in session_work_event_columns:
+            statements.append("ALTER TABLE session_work_events ADD COLUMN duration_ms INTEGER NOT NULL DEFAULT 0")
+        if "canonical_session_date" not in session_work_event_columns:
+            statements.append("ALTER TABLE session_work_events ADD COLUMN canonical_session_date TEXT")
+        if "evidence_payload_json" not in session_work_event_columns:
+            statements.append(
+                "ALTER TABLE session_work_events ADD COLUMN evidence_payload_json TEXT NOT NULL DEFAULT '{}'"
+            )
+        if "inference_payload_json" not in session_work_event_columns:
+            statements.append(
+                "ALTER TABLE session_work_events ADD COLUMN inference_payload_json TEXT NOT NULL DEFAULT '{}'"
+            )
+        if "inference_version" not in session_work_event_columns:
+            statements.append("ALTER TABLE session_work_events ADD COLUMN inference_version INTEGER NOT NULL DEFAULT 1")
+        if "inference_family" not in session_work_event_columns:
+            statements.append(
+                "ALTER TABLE session_work_events ADD COLUMN inference_family TEXT NOT NULL DEFAULT 'heuristic_session_semantics'"
+            )
+
+    if snapshot.has_table("session_phases"):
+        session_phase_columns = snapshot.columns("session_phases")
+        if "confidence" not in session_phase_columns:
+            statements.append("ALTER TABLE session_phases ADD COLUMN confidence REAL NOT NULL DEFAULT 0")
+        if "evidence_reasons_json" not in session_phase_columns:
+            statements.append("ALTER TABLE session_phases ADD COLUMN evidence_reasons_json TEXT NOT NULL DEFAULT '[]'")
+        if "evidence_payload_json" not in session_phase_columns:
+            statements.append("ALTER TABLE session_phases ADD COLUMN evidence_payload_json TEXT NOT NULL DEFAULT '{}'")
+        if "inference_payload_json" not in session_phase_columns:
+            statements.append("ALTER TABLE session_phases ADD COLUMN inference_payload_json TEXT NOT NULL DEFAULT '{}'")
+        if "inference_version" not in session_phase_columns:
+            statements.append("ALTER TABLE session_phases ADD COLUMN inference_version INTEGER NOT NULL DEFAULT 1")
+        if "inference_family" not in session_phase_columns:
+            statements.append(
+                "ALTER TABLE session_phases ADD COLUMN inference_family TEXT NOT NULL DEFAULT 'heuristic_session_semantics'"
+            )
+
+    scripts.append(_SESSION_PRODUCT_DDL)
+    return SchemaExtensionPlan(statements=tuple(statements), scripts=tuple(scripts))
+
+
+def capture_schema_snapshot(conn: sqlite3.Connection) -> SchemaSnapshot:
+    current_version = conn.execute("PRAGMA user_version").fetchone()[0]
+    table_columns: dict[str, frozenset[str]] = {}
+    index_sql: dict[str, str | None] = {}
+
+    for table_name in (
+        "raw_conversations",
+        "content_blocks",
+        "action_events",
+        "session_profiles",
+        "session_work_events",
+        "session_phases",
+    ):
+        row = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+            (table_name,),
+        ).fetchone()
+        if row is None:
+            continue
+        columns = {item[1] for item in conn.execute(f"PRAGMA table_info({table_name})").fetchall()}
+        table_columns[table_name] = frozenset(columns)
+
+    row = conn.execute(
+        "SELECT sql FROM sqlite_master WHERE type='index' AND name='idx_raw_conv_source_mtime'"
+    ).fetchone()
+    index_sql["idx_raw_conv_source_mtime"] = row[0] if row and isinstance(row[0], str) else None
+    return SchemaSnapshot(current_version=current_version, table_columns=table_columns, index_sql=index_sql)
+
+
+async def capture_schema_snapshot_async(conn: aiosqlite.Connection) -> SchemaSnapshot:
+    cursor = await conn.execute("PRAGMA user_version")
+    row = await cursor.fetchone()
+    current_version = row[0] if row else 0
+    table_columns: dict[str, frozenset[str]] = {}
+    index_sql: dict[str, str | None] = {}
+
+    for table_name in (
+        "raw_conversations",
+        "content_blocks",
+        "action_events",
+        "session_profiles",
+        "session_work_events",
+        "session_phases",
+    ):
+        cursor = await conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+            (table_name,),
+        )
+        row = await cursor.fetchone()
+        if row is None:
+            continue
+        cursor = await conn.execute(f"PRAGMA table_info({table_name})")
+        columns = {item[1] for item in await cursor.fetchall()}
+        table_columns[table_name] = frozenset(columns)
+
+    cursor = await conn.execute(
+        "SELECT sql FROM sqlite_master WHERE type='index' AND name='idx_raw_conv_source_mtime'"
+    )
+    row = await cursor.fetchone()
+    index_sql["idx_raw_conv_source_mtime"] = row[0] if row and isinstance(row[0], str) else None
+    return SchemaSnapshot(current_version=current_version, table_columns=table_columns, index_sql=index_sql)
+
+
+def apply_schema_extension_plan(conn: sqlite3.Connection, plan: SchemaExtensionPlan) -> None:
+    for statement in plan.statements:
+        conn.execute(statement)
+    for script in plan.scripts:
+        conn.executescript(script)
+
+
+async def apply_schema_extension_plan_async(conn: aiosqlite.Connection, plan: SchemaExtensionPlan) -> None:
+    for statement in plan.statements:
+        await conn.execute(statement)
+    for script in plan.scripts:
+        await conn.executescript(script)
+
+
+def ensure_vec0_table(conn: sqlite3.Connection) -> None:
+    with suppress(Exception):
+        conn.execute("SELECT vec_version()")
+        conn.execute(_VEC0_DDL)
+
+
+async def ensure_vec0_table_async(conn: aiosqlite.Connection) -> None:
+    with suppress(Exception):
+        await conn.execute("SELECT vec_version()")
+        await conn.execute(_VEC0_DDL)
+
+
+__all__ = [
+    "SCHEMA_DDL",
+    "SCHEMA_VERSION",
+    "SchemaExtensionPlan",
+    "SchemaSnapshot",
+    "apply_schema_extension_plan",
+    "apply_schema_extension_plan_async",
+    "assert_supported_archive_layout_snapshot",
+    "build_current_schema_extension_plan",
+    "capture_schema_snapshot",
+    "capture_schema_snapshot_async",
+    "ensure_vec0_table",
+    "ensure_vec0_table_async",
+    "schema_version_mismatch_message",
+]

--- a/polylogue/storage/backends/schema_upgrade.py
+++ b/polylogue/storage/backends/schema_upgrade.py
@@ -2,229 +2,54 @@
 
 from __future__ import annotations
 
-import re
 import sqlite3
-from contextlib import suppress
 
 from polylogue.errors import DatabaseError
 from polylogue.logging import get_logger
-from polylogue.storage.backends.schema_ddl import (
-    _ACTION_EVENT_DDL,
-    _ACTION_FTS_DDL,
-    _ARTIFACT_OBSERVATION_DDL,
-    _PUBLICATION_DDL,
-    _SESSION_PRODUCT_DDL,
-    _VEC0_DDL,
+from polylogue.storage.backends.schema_bootstrap import (
     SCHEMA_DDL,
     SCHEMA_VERSION,
+    apply_schema_extension_plan,
+    assert_supported_archive_layout_snapshot,
+    build_current_schema_extension_plan,
+    capture_schema_snapshot,
+    ensure_vec0_table,
+    schema_version_mismatch_message,
 )
 
 logger = get_logger(__name__)
 
 
-def ensure_vec0_table(conn: sqlite3.Connection) -> None:
-    with suppress(Exception):
-        conn.execute("SELECT vec_version()")
-        conn.execute(_VEC0_DDL)
-
-
-def _table_exists(conn: sqlite3.Connection, table_name: str) -> bool:
-    return bool(
-        conn.execute(
-            "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
-            (table_name,),
-        ).fetchone()
-    )
-
-
-def _table_columns(conn: sqlite3.Connection, table_name: str) -> set[str]:
-    return {row[1] for row in conn.execute(f"PRAGMA table_info({table_name})").fetchall()}
-
-
-def _index_sql(conn: sqlite3.Connection, index_name: str) -> str | None:
-    row = conn.execute(
-        "SELECT sql FROM sqlite_master WHERE type='index' AND name=?",
-        (index_name,),
-    ).fetchone()
-    if row is None:
-        return None
-    sql = row[0]
-    return sql if isinstance(sql, str) else None
-
-
-def _normalize_sql(sql: str) -> str:
-    normalized = " ".join(sql.replace(";", " ").split())
-    normalized = re.sub(r"\bIF\s+NOT\s+EXISTS\b", "", normalized, flags=re.IGNORECASE)
-    return " ".join(normalized.split())
-
-
 def _ensure_raw_source_mtime_index(conn: sqlite3.Connection) -> None:
-    desired_sql = (
-        "CREATE INDEX IF NOT EXISTS idx_raw_conv_source_mtime "
-        "ON raw_conversations(source_path, file_mtime) "
-        "WHERE file_mtime IS NOT NULL"
-    )
-    existing_sql = _index_sql(conn, "idx_raw_conv_source_mtime")
-    if existing_sql is not None and _normalize_sql(existing_sql) == _normalize_sql(desired_sql):
-        return
-    if existing_sql is not None:
-        logger.info("Replacing idx_raw_conv_source_mtime with partial covering definition")
-        conn.execute("DROP INDEX IF EXISTS idx_raw_conv_source_mtime")
-    conn.execute(desired_sql)
-
-
-def _ensure_tool_use_conversation_index(conn: sqlite3.Connection) -> None:
-    conn.execute(
-        """
-        CREATE INDEX IF NOT EXISTS idx_content_blocks_tool_use_conversation
-        ON content_blocks(conversation_id)
-        WHERE type = 'tool_use'
-        """
-    )
+    snapshot = capture_schema_snapshot(conn)
+    plan = build_current_schema_extension_plan(snapshot)
+    for statement in plan.statements:
+        if "idx_raw_conv_source_mtime" in statement:
+            conn.execute(statement)
 
 
 def assert_supported_archive_layout(conn: sqlite3.Connection) -> None:
     """Reject legacy archive layouts that the current runtime cannot write safely."""
-    if not _table_exists(conn, "raw_conversations"):
-        return
-
-    raw_columns = _table_columns(conn, "raw_conversations")
-    if "raw_content" in raw_columns:
-        raise DatabaseError(
-            "Database uses the legacy inline raw-content layout and is incompatible with the current blob-store "
-            "archive format. Move the database aside or run `polylogue reset --database` before re-importing."
-        )
+    assert_supported_archive_layout_snapshot(capture_schema_snapshot(conn))
 
 
 def apply_current_schema_extensions(conn: sqlite3.Connection) -> None:
-    assert_supported_archive_layout(conn)
-    if _table_exists(conn, "raw_conversations"):
-        raw_columns = _table_columns(conn, "raw_conversations")
-        if "blob_size" not in raw_columns:
-            conn.execute("ALTER TABLE raw_conversations ADD COLUMN blob_size INTEGER NOT NULL DEFAULT 0")
-
-    # Covering index for mtime-skip queries (avoids full table scan of raw payload storage)
-    _ensure_raw_source_mtime_index(conn)
-    if _table_exists(conn, "content_blocks"):
-        _ensure_tool_use_conversation_index(conn)
-    conn.executescript(_ARTIFACT_OBSERVATION_DDL)
-    conn.executescript(_PUBLICATION_DDL)
-    conn.executescript(_ACTION_EVENT_DDL)
-    action_event_columns = _table_columns(conn, "action_events")
-    if "materializer_version" not in action_event_columns:
-        conn.execute("ALTER TABLE action_events ADD COLUMN materializer_version INTEGER NOT NULL DEFAULT 1")
-    conn.executescript(_ACTION_FTS_DDL)
-
-    if _table_exists(conn, "session_profiles"):
-        session_profile_columns = _table_columns(conn, "session_profiles")
-        if "canonical_session_date" not in session_profile_columns:
-            conn.execute("ALTER TABLE session_profiles ADD COLUMN canonical_session_date TEXT")
-        if "last_message_at" not in session_profile_columns:
-            conn.execute("ALTER TABLE session_profiles ADD COLUMN last_message_at TEXT")
-        if "substantive_count" not in session_profile_columns:
-            conn.execute("ALTER TABLE session_profiles ADD COLUMN substantive_count INTEGER NOT NULL DEFAULT 0")
-        if "attachment_count" not in session_profile_columns:
-            conn.execute("ALTER TABLE session_profiles ADD COLUMN attachment_count INTEGER NOT NULL DEFAULT 0")
-        if "phase_count" not in session_profile_columns:
-            conn.execute("ALTER TABLE session_profiles ADD COLUMN phase_count INTEGER NOT NULL DEFAULT 0")
-        if "engaged_duration_ms" not in session_profile_columns:
-            conn.execute("ALTER TABLE session_profiles ADD COLUMN engaged_duration_ms INTEGER NOT NULL DEFAULT 0")
-        if "cost_is_estimated" not in session_profile_columns:
-            conn.execute("ALTER TABLE session_profiles ADD COLUMN cost_is_estimated INTEGER NOT NULL DEFAULT 0")
-        if "evidence_payload_json" not in session_profile_columns:
-            conn.execute("ALTER TABLE session_profiles ADD COLUMN evidence_payload_json TEXT NOT NULL DEFAULT '{}'")
-        if "inference_payload_json" not in session_profile_columns:
-            conn.execute("ALTER TABLE session_profiles ADD COLUMN inference_payload_json TEXT NOT NULL DEFAULT '{}'")
-        if "evidence_search_text" not in session_profile_columns:
-            conn.execute("ALTER TABLE session_profiles ADD COLUMN evidence_search_text TEXT NOT NULL DEFAULT ''")
-        if "inference_search_text" not in session_profile_columns:
-            conn.execute("ALTER TABLE session_profiles ADD COLUMN inference_search_text TEXT NOT NULL DEFAULT ''")
-        if "enrichment_payload_json" not in session_profile_columns:
-            conn.execute("ALTER TABLE session_profiles ADD COLUMN enrichment_payload_json TEXT NOT NULL DEFAULT '{}'")
-        if "enrichment_search_text" not in session_profile_columns:
-            conn.execute("ALTER TABLE session_profiles ADD COLUMN enrichment_search_text TEXT NOT NULL DEFAULT ''")
-        if "enrichment_version" not in session_profile_columns:
-            conn.execute("ALTER TABLE session_profiles ADD COLUMN enrichment_version INTEGER NOT NULL DEFAULT 1")
-        if "enrichment_family" not in session_profile_columns:
-            conn.execute(
-                "ALTER TABLE session_profiles ADD COLUMN enrichment_family TEXT NOT NULL DEFAULT 'scored_session_enrichment'"
-            )
-        if "inference_version" not in session_profile_columns:
-            conn.execute("ALTER TABLE session_profiles ADD COLUMN inference_version INTEGER NOT NULL DEFAULT 1")
-        if "inference_family" not in session_profile_columns:
-            conn.execute(
-                "ALTER TABLE session_profiles ADD COLUMN inference_family TEXT NOT NULL DEFAULT 'heuristic_session_semantics'"
-            )
-        conn.execute(
-            """
-            UPDATE session_profiles
-            SET evidence_search_text = search_text
-            WHERE TRIM(COALESCE(evidence_search_text, '')) = ''
-            """
-        )
-        conn.execute(
-            """
-            UPDATE session_profiles
-            SET inference_search_text = search_text
-            WHERE TRIM(COALESCE(inference_search_text, '')) = ''
-            """
-        )
-        conn.execute(
-            """
-            UPDATE session_profiles
-            SET enrichment_search_text = inference_search_text
-            WHERE TRIM(COALESCE(enrichment_search_text, '')) = ''
-            """
-        )
-
-    if _table_exists(conn, "session_work_events"):
-        session_work_event_columns = _table_columns(conn, "session_work_events")
-        if "start_time" not in session_work_event_columns:
-            conn.execute("ALTER TABLE session_work_events ADD COLUMN start_time TEXT")
-        if "end_time" not in session_work_event_columns:
-            conn.execute("ALTER TABLE session_work_events ADD COLUMN end_time TEXT")
-        if "duration_ms" not in session_work_event_columns:
-            conn.execute("ALTER TABLE session_work_events ADD COLUMN duration_ms INTEGER NOT NULL DEFAULT 0")
-        if "canonical_session_date" not in session_work_event_columns:
-            conn.execute("ALTER TABLE session_work_events ADD COLUMN canonical_session_date TEXT")
-        if "evidence_payload_json" not in session_work_event_columns:
-            conn.execute("ALTER TABLE session_work_events ADD COLUMN evidence_payload_json TEXT NOT NULL DEFAULT '{}'")
-        if "inference_payload_json" not in session_work_event_columns:
-            conn.execute("ALTER TABLE session_work_events ADD COLUMN inference_payload_json TEXT NOT NULL DEFAULT '{}'")
-        if "inference_version" not in session_work_event_columns:
-            conn.execute("ALTER TABLE session_work_events ADD COLUMN inference_version INTEGER NOT NULL DEFAULT 1")
-        if "inference_family" not in session_work_event_columns:
-            conn.execute(
-                "ALTER TABLE session_work_events ADD COLUMN inference_family TEXT NOT NULL DEFAULT 'heuristic_session_semantics'"
-            )
-
-    if _table_exists(conn, "session_phases"):
-        session_phase_columns = _table_columns(conn, "session_phases")
-        if "confidence" not in session_phase_columns:
-            conn.execute("ALTER TABLE session_phases ADD COLUMN confidence REAL NOT NULL DEFAULT 0")
-        if "evidence_reasons_json" not in session_phase_columns:
-            conn.execute("ALTER TABLE session_phases ADD COLUMN evidence_reasons_json TEXT NOT NULL DEFAULT '[]'")
-        if "evidence_payload_json" not in session_phase_columns:
-            conn.execute("ALTER TABLE session_phases ADD COLUMN evidence_payload_json TEXT NOT NULL DEFAULT '{}'")
-        if "inference_payload_json" not in session_phase_columns:
-            conn.execute("ALTER TABLE session_phases ADD COLUMN inference_payload_json TEXT NOT NULL DEFAULT '{}'")
-        if "inference_version" not in session_phase_columns:
-            conn.execute("ALTER TABLE session_phases ADD COLUMN inference_version INTEGER NOT NULL DEFAULT 1")
-        if "inference_family" not in session_phase_columns:
-            conn.execute(
-                "ALTER TABLE session_phases ADD COLUMN inference_family TEXT NOT NULL DEFAULT 'heuristic_session_semantics'"
-            )
-
-    conn.executescript(_SESSION_PRODUCT_DDL)
+    snapshot = capture_schema_snapshot(conn)
+    plan = build_current_schema_extension_plan(snapshot)
+    if snapshot.sql_for_index("idx_raw_conv_source_mtime") is not None and any(
+        statement == "DROP INDEX IF EXISTS idx_raw_conv_source_mtime" for statement in plan.statements
+    ):
+        logger.info("Replacing idx_raw_conv_source_mtime with partial covering definition")
+    apply_schema_extension_plan(conn, plan)
     ensure_vec0_table(conn)
     conn.commit()
 
 
 def ensure_schema(conn: sqlite3.Connection) -> None:
     """Ensure the database is at the current schema version."""
-    current_version = conn.execute("PRAGMA user_version").fetchone()[0]
+    snapshot = capture_schema_snapshot(conn)
 
-    if current_version == 0:
+    if snapshot.current_version == 0:
         conn.execute("PRAGMA foreign_keys = ON")
         conn.executescript(SCHEMA_DDL)
         ensure_vec0_table(conn)
@@ -233,15 +58,12 @@ def ensure_schema(conn: sqlite3.Connection) -> None:
         logger.debug("Created fresh schema v%s", SCHEMA_VERSION)
         return
 
-    assert_supported_archive_layout(conn)
+    assert_supported_archive_layout_snapshot(snapshot)
 
-    if current_version == SCHEMA_VERSION:
+    if snapshot.current_version == SCHEMA_VERSION:
         apply_current_schema_extensions(conn)
         return
 
-    raise DatabaseError(
-        f"Database schema version {current_version} is incompatible with expected version {SCHEMA_VERSION}. "
-        "Delete the database and re-import: `polylogue reset --database && polylogue run`."
-    )
+    raise DatabaseError(schema_version_mismatch_message(snapshot.current_version))
 
 __all__ = ["apply_current_schema_extensions", "assert_supported_archive_layout", "ensure_schema", "ensure_vec0_table"]

--- a/polylogue/storage/derived_status.py
+++ b/polylogue/storage/derived_status.py
@@ -35,6 +35,7 @@ def collect_derived_model_statuses_sync(
         "action_source_documents": int(action_status["valid_source_conversation_count"]),
         "action_orphan_rows": int(action_status["orphan_tool_block_count"]),
         "action_fts_rows": int(action_status["action_fts_count"]),
+        "action_fts_stale_rows": int(action_status.get("action_fts_stale_rows", 0)),
         "action_rows_ready": bool(action_status["rows_ready"]),
         "action_fts_ready": bool(action_status["action_fts_ready"]),
         "action_stale_rows": int(action_status["stale_count"]),
@@ -172,7 +173,11 @@ def build_retrieval_statuses(metrics: dict[str, int | bool]) -> dict[str, Derive
             pending_rows=pending_rows(
                 int(metrics["expected_evidence_retrieval_rows"]), int(metrics["evidence_retrieval_rows"])
             ),
-            stale_rows=int(metrics["profile_evidence_fts_duplicates"]) + int(metrics["action_stale_rows"]),
+            stale_rows=(
+                int(metrics["profile_evidence_fts_duplicates"])
+                + int(metrics["action_stale_rows"])
+                + int(metrics.get("action_fts_stale_rows", 0))
+            ),
             orphan_rows=int(metrics["action_orphan_rows"]) + int(metrics["orphan_profile_rows"]),
         ),
         "retrieval_inference": DerivedModelStatus(

--- a/polylogue/storage/derived_status_products.py
+++ b/polylogue/storage/derived_status_products.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from polylogue.maintenance_models import DerivedModelStatus
+from polylogue.storage.action_event_artifacts import ActionEventArtifactState
 from polylogue.storage.store import ACTION_EVENT_MATERIALIZER_VERSION, SESSION_PRODUCT_MATERIALIZER_VERSION
 
 
@@ -20,6 +21,10 @@ def pending_docs(source_docs: int, materialized_docs: int) -> int:
 
 
 def build_action_statuses(metrics: dict[str, int | bool]) -> dict[str, DerivedModelStatus]:
+    state = ActionEventArtifactState.from_metrics(metrics)
+    action_rows_status = state.row_status()
+    action_rows_payload = action_rows_status.to_dict()
+    action_rows_payload["materializer_version"] = ACTION_EVENT_MATERIALIZER_VERSION
     message_fts_exact_counts = bool(metrics.get("message_fts_exact_counts", True))
     return {
         "messages_fts": DerivedModelStatus(
@@ -42,36 +47,8 @@ def build_action_statuses(metrics: dict[str, int | bool]) -> dict[str, DerivedMo
             materialized_rows=int(metrics["message_fts_rows"]),
             pending_rows=pending_rows(int(metrics["message_source_rows"]), int(metrics["message_fts_rows"])),
         ),
-        "action_events": DerivedModelStatus(
-            name="action_events",
-            ready=bool(metrics["action_rows_ready"]),
-            detail=(
-                f"Action-event rows ready ({metrics['action_documents']:,}/{metrics['action_source_documents']:,} conversations)"
-                if bool(metrics["action_rows_ready"])
-                else f"Action-event rows pending ({metrics['action_documents']:,}/{metrics['action_source_documents']:,} conversations)"
-            ),
-            source_documents=int(metrics["action_source_documents"]),
-            materialized_documents=int(metrics["action_documents"]),
-            materialized_rows=int(metrics["action_rows"]),
-            pending_documents=pending_docs(int(metrics["action_source_documents"]), int(metrics["action_documents"])),
-            stale_rows=int(metrics["action_stale_rows"]),
-            orphan_rows=int(metrics["action_orphan_rows"]),
-            materializer_version=ACTION_EVENT_MATERIALIZER_VERSION,
-            matches_version=bool(metrics["action_matches_version"]),
-        ),
-        "action_events_fts": DerivedModelStatus(
-            name="action_events_fts",
-            ready=bool(metrics["action_fts_ready"]),
-            detail=(
-                f"Action-event FTS ready ({metrics['action_fts_rows']:,}/{metrics['action_rows']:,} rows)"
-                if bool(metrics["action_fts_ready"])
-                else f"Action-event FTS pending ({metrics['action_fts_rows']:,}/{metrics['action_rows']:,} rows)"
-            ),
-            source_rows=int(metrics["action_rows"]),
-            materialized_rows=int(metrics["action_fts_rows"]),
-            pending_rows=pending_rows(int(metrics["action_rows"]), int(metrics["action_fts_rows"])),
-            orphan_rows=int(metrics["action_orphan_rows"]),
-        ),
+        "action_events": DerivedModelStatus(**action_rows_payload),
+        "action_events_fts": state.fts_status(),
     }
 
 

--- a/polylogue/storage/embedding_stats_support.py
+++ b/polylogue/storage/embedding_stats_support.py
@@ -77,7 +77,8 @@ def build_retrieval_bands_from_status(
             "materialized_rows": evidence_materialized_rows,
             "pending_rows": max(0, evidence_source_rows - evidence_materialized_rows),
             "stale_rows": int(session_status["profile_evidence_fts_duplicate_count"])
-            + int(action_status["stale_count"]),
+            + int(action_status["stale_count"])
+            + int(action_status.get("action_fts_stale_rows", 0)),
             "detail": (
                 f"Evidence retrieval ready ({evidence_materialized_rows:,}/{evidence_source_rows:,} supporting rows)"
                 if evidence_ready

--- a/polylogue/storage/raw_ingest_artifacts.py
+++ b/polylogue/storage/raw_ingest_artifacts.py
@@ -1,0 +1,81 @@
+"""Shared raw-ingest backlog semantics for planning and reparse flows."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from polylogue.storage.state_views import RawConversationState
+from polylogue.types import ValidationStatus
+
+_PARSEABLE_VALIDATION_STATUSES = (
+    ValidationStatus.PASSED,
+    ValidationStatus.SKIPPED,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class RawBacklogQuerySpec:
+    """SQL selection contract for one persisted raw backlog view."""
+
+    require_unparsed: bool
+    require_unvalidated: bool = False
+    validation_statuses: tuple[str, ...] | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class RawIngestArtifactState:
+    """Canonical persisted raw-state semantics for validation and parse planning."""
+
+    parsed_at: str | None = None
+    validation_status: ValidationStatus | None = None
+
+    @classmethod
+    def from_state(cls, state: RawConversationState | None) -> RawIngestArtifactState:
+        if state is None:
+            return cls()
+        return cls(
+            parsed_at=state.parsed_at,
+            validation_status=state.validation_status,
+        )
+
+    @property
+    def parsed(self) -> bool:
+        return self.parsed_at is not None
+
+    @property
+    def validated(self) -> bool:
+        return self.validation_status is not None
+
+    @property
+    def quarantined(self) -> bool:
+        return not self.parsed and self.validation_status is ValidationStatus.FAILED
+
+    def needs_validation_backlog(self, *, force_reparse: bool = False) -> bool:
+        return self.validation_status is None and (force_reparse or not self.parsed)
+
+    def needs_parse_backlog(self, *, force_reparse: bool = False) -> bool:
+        if force_reparse:
+            return True
+        return (not self.parsed) and self.validation_status in _PARSEABLE_VALIDATION_STATUSES
+
+
+def validation_backlog_query_spec(*, force_reparse: bool = False) -> RawBacklogQuerySpec:
+    return RawBacklogQuerySpec(
+        require_unparsed=not force_reparse,
+        require_unvalidated=True,
+    )
+
+
+def parse_backlog_query_spec(*, force_reparse: bool = False) -> RawBacklogQuerySpec:
+    return RawBacklogQuerySpec(
+        require_unparsed=not force_reparse,
+        validation_statuses=None if force_reparse else tuple(status.value for status in _PARSEABLE_VALIDATION_STATUSES),
+    )
+
+
+__all__ = [
+    "RawBacklogQuerySpec",
+    "RawIngestArtifactState",
+    "parse_backlog_query_spec",
+    "validation_backlog_query_spec",
+]

--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from polylogue.logging import get_logger
 from polylogue.maintenance_models import DerivedModelStatus, MaintenanceCategory
+from polylogue.storage.action_event_artifacts import ActionEventArtifactState
 
 logger = get_logger(__name__)
 
@@ -176,38 +177,46 @@ def session_product_repair_count(derived_statuses: dict[str, DerivedModelStatus]
 
 
 def action_event_repair_count(derived_statuses: dict[str, DerivedModelStatus]) -> int:
-    missing_conversations, stale_rows, fts_pending_rows = _action_event_repair_components(derived_statuses)
-    return missing_conversations + stale_rows + fts_pending_rows
+    return _action_event_state_from_statuses(derived_statuses).repair_item_count
 
 
 def _action_event_repair_components(
     derived_statuses: dict[str, DerivedModelStatus],
-) -> tuple[int, int, int]:
+) -> tuple[int, int, int, int]:
+    state = _action_event_state_from_statuses(derived_statuses)
+    return (
+        state.missing_conversations,
+        state.stale_rows,
+        state.pending_fts_rows,
+        state.excess_fts_rows,
+    )
+
+
+def _action_event_state_from_statuses(
+    derived_statuses: dict[str, DerivedModelStatus],
+) -> ActionEventArtifactState:
     action_events = derived_statuses.get("action_events")
     action_events_fts = derived_statuses.get("action_events_fts")
     if action_events is None or action_events_fts is None:
-        return (0, 0, 0)
-    return (
-        max(0, int(action_events.pending_documents or 0)),
-        max(0, int(action_events.stale_rows or 0)),
-        max(0, int(action_events_fts.pending_rows or 0)),
+        return ActionEventArtifactState(
+            source_conversations=0,
+            materialized_conversations=0,
+            materialized_rows=0,
+            fts_rows=0,
+        )
+    return ActionEventArtifactState(
+        source_conversations=int(action_events.source_documents or 0),
+        materialized_conversations=int(action_events.materialized_documents or 0),
+        materialized_rows=int(action_events.materialized_rows or 0),
+        fts_rows=int(action_events_fts.materialized_rows or 0),
+        stale_rows=int(action_events.stale_rows or 0),
+        orphan_rows=int(action_events.orphan_rows or 0),
+        matches_version=bool(action_events.matches_version if action_events.matches_version is not None else True),
     )
 
 
 def _action_event_repair_detail(derived_statuses: dict[str, DerivedModelStatus]) -> str:
-    missing_conversations, stale_rows, fts_pending_rows = _action_event_repair_components(derived_statuses)
-    if missing_conversations == 0 and stale_rows == 0 and fts_pending_rows == 0:
-        return "Action-event read model ready"
-
-    detail_parts: list[str] = []
-    if missing_conversations:
-        detail_parts.append(f"{missing_conversations:,} missing conversations")
-    if stale_rows:
-        detail_parts.append(f"{stale_rows:,} stale action-event rows")
-    if fts_pending_rows:
-        detail_parts.append(f"{fts_pending_rows:,} pending action-event FTS rows")
-    joined = ", ".join(detail_parts)
-    return f"Action-event read model pending ({joined})"
+    return _action_event_state_from_statuses(derived_statuses).repair_detail()
 
 
 def dangling_fts_repair_count(derived_statuses: dict[str, DerivedModelStatus]) -> int:
@@ -753,13 +762,9 @@ def repair_action_event_read_model(config: Any, dry_run: bool = False) -> Repair
     try:
         with connection_context(None) as conn:
             status = action_event_read_model_status_sync(conn)
+            state = ActionEventArtifactState.from_status_snapshot(status)
             candidate_ids = action_event_repair_candidates_sync(conn)
-            missing_conversations = max(
-                0, int(status["valid_source_conversation_count"]) - int(status["materialized_conversation_count"])
-            )
-            stale_conversations = int(status["stale_count"])
-            action_fts_pending = max(0, int(status["count"]) - int(status["action_fts_count"]))
-            pending = max(len(candidate_ids), missing_conversations + stale_conversations) + action_fts_pending
+            pending = state.repair_item_count
 
             if dry_run:
                 return RepairResult(
@@ -770,13 +775,13 @@ def repair_action_event_read_model(config: Any, dry_run: bool = False) -> Repair
                     success=True,
                     detail="Would: action-event read model already ready"
                     if pending == 0
-                    else f"Would: repair action-event rows for {len(candidate_ids):,} conversations; action FTS pending {action_fts_pending:,}",
+                    else f"Would: {state.repair_detail()[0].lower() + state.repair_detail()[1:]}",
                 )
 
             repaired = 0
             if candidate_ids:
                 repaired = rebuild_action_event_read_model_sync(conn, conversation_ids=candidate_ids)
-            if not bool(status["action_fts_ready"]):
+            if not state.fts_ready:
                 repair_targets = candidate_ids or valid_action_event_source_ids_sync(conn)
                 if repair_targets:
                     repair_fts_index_sync(conn, repair_targets)
@@ -786,7 +791,7 @@ def repair_action_event_read_model(config: Any, dry_run: bool = False) -> Repair
                 name="action_event_read_model",
                 category=_CAT_DERIVED,
                 destructive=False,
-                repaired_count=repaired + action_fts_pending,
+                repaired_count=repaired + state.pending_fts_rows + state.excess_fts_rows,
                 success=bool(refreshed["ready"]),
                 detail="Action-event read model ready"
                 if refreshed["ready"]

--- a/tests/unit/core/test_artifact_graph.py
+++ b/tests/unit/core/test_artifact_graph.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from polylogue.artifact_graph import ArtifactLayer, build_artifact_graph
+
+
+def test_artifact_graph_contains_the_two_proven_vertical_paths() -> None:
+    graph = build_artifact_graph()
+    nodes = graph.by_name()
+
+    assert set(nodes) >= {
+        "raw_validation_state",
+        "validation_backlog",
+        "parse_backlog",
+        "parse_quarantine",
+        "tool_use_source_blocks",
+        "action_event_rows",
+        "action_event_fts",
+        "action_event_health",
+    }
+    assert nodes["raw_validation_state"].layer is ArtifactLayer.DURABLE
+    assert nodes["action_event_fts"].layer is ArtifactLayer.INDEX
+    assert nodes["action_event_fts"].depends_on == ("action_event_rows",)
+    assert nodes["action_event_health"].depends_on == ("action_event_rows", "action_event_fts")
+    assert nodes["parse_quarantine"].depends_on == ("raw_validation_state",)
+
+
+def test_artifact_graph_paths_reference_only_declared_nodes() -> None:
+    graph = build_artifact_graph()
+    node_names = set(graph.by_name())
+
+    assert {path.name for path in graph.paths} == {
+        "raw-reparse-loop",
+        "action-event-repair-loop",
+    }
+    for path in graph.paths:
+        assert path.nodes
+        assert set(path.nodes).issubset(node_names)
+
+
+def test_artifact_graph_serializes_layers_as_strings() -> None:
+    payload = build_artifact_graph().to_dict()
+
+    assert any(node["layer"] == "durable" for node in payload["nodes"])
+    assert any(path["name"] == "raw-reparse-loop" for path in payload["paths"])

--- a/tests/unit/devtools/test_artifact_graph.py
+++ b/tests/unit/devtools/test_artifact_graph.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import json
+
+from devtools import artifact_graph
+
+
+def test_render_artifact_graph_text_mentions_both_vertical_paths() -> None:
+    rendered = artifact_graph.render_artifact_graph(as_json=False)
+
+    assert "Artifact Paths:" in rendered
+    assert "raw-reparse-loop" in rendered
+    assert "action-event-repair-loop" in rendered
+    assert "action_event_fts [index] <- action_event_rows" in rendered
+
+
+def test_render_artifact_graph_json_is_machine_readable() -> None:
+    payload = json.loads(artifact_graph.render_artifact_graph(as_json=True))
+
+    assert {path["name"] for path in payload["paths"]} == {
+        "raw-reparse-loop",
+        "action-event-repair-loop",
+    }
+    assert any(node["name"] == "raw_validation_state" for node in payload["nodes"])

--- a/tests/unit/pipeline/test_parsing_service.py
+++ b/tests/unit/pipeline/test_parsing_service.py
@@ -773,6 +773,91 @@ class TestPlanningService:
         assert forced.summary.counts["parse"] == 1
         assert forced.summary.details["existing_raw"] == 1
 
+    @patch("polylogue.pipeline.services.acquisition.AcquisitionService.visit_sources")
+    async def test_build_plan_force_reparse_reuses_shared_backlog_semantics_for_scanned_records(
+        self,
+        mock_visit_sources,
+        tmp_path: Path,
+    ):
+        backend = SQLiteBackend(db_path=tmp_path / "test.db")
+        config = Config(sources=[], archive_root=tmp_path / "archive", render_root=tmp_path / "render")
+        planner = PlanningService(backend=backend, config=config)
+        source_dir = tmp_path / "inbox-a"
+        source_dir.mkdir()
+
+        records = [
+            RawConversationRecord(
+                raw_id="raw-existing-passed",
+                provider_name="chatgpt",
+                source_name="inbox-a",
+                source_path="/tmp/existing-passed.json",
+                blob_size=len(b'{"id":"x"}'),
+                acquired_at=datetime.now(tz=timezone.utc).isoformat(),
+            ),
+            RawConversationRecord(
+                raw_id="raw-existing-unvalidated",
+                provider_name="chatgpt",
+                source_name="inbox-a",
+                source_path="/tmp/existing-unvalidated.json",
+                blob_size=len(b'{"id":"x"}'),
+                acquired_at=datetime.now(tz=timezone.utc).isoformat(),
+            ),
+            RawConversationRecord(
+                raw_id="raw-existing-failed",
+                provider_name="chatgpt",
+                source_name="inbox-a",
+                source_path="/tmp/existing-failed.json",
+                blob_size=len(b'{"id":"x"}'),
+                acquired_at=datetime.now(tz=timezone.utc).isoformat(),
+            ),
+        ]
+        for record in records:
+            await backend.save_raw_conversation(record)
+
+        await backend.mark_raw_validated("raw-existing-passed", status="passed", provider="chatgpt", mode="strict")
+        await backend.mark_raw_parsed("raw-existing-passed", payload_provider="chatgpt")
+        await backend.mark_raw_parsed("raw-existing-unvalidated", payload_provider="chatgpt")
+        await backend.mark_raw_validated(
+            "raw-existing-failed",
+            status="failed",
+            error="Malformed JSONL lines: 1",
+            provider="chatgpt",
+            mode="strict",
+        )
+
+        async def _visit_sources(
+            _sources,
+            *,
+            on_record=None,
+            **_kwargs,
+        ):
+            assert on_record is not None
+            for record in records:
+                await on_record(record)
+            result = ScanResult()
+            result.counts["scanned"] = len(records)
+            return result
+
+        mock_visit_sources.side_effect = _visit_sources
+
+        forced = await planner.build_plan(
+            sources=[Source(name="inbox-a", path=source_dir)],
+            stage="all",
+            preview=True,
+            force_reparse=True,
+        )
+
+        assert forced.summary.counts["scan"] == 3
+        assert forced.summary.counts["validate"] == 1
+        assert forced.summary.counts["parse"] == 3
+        assert forced.summary.details["existing_raw"] == 3
+        assert set(forced.validate_raw_ids) == {"raw-existing-unvalidated"}
+        assert set(forced.parse_ready_raw_ids) == {
+            "raw-existing-passed",
+            "raw-existing-unvalidated",
+            "raw-existing-failed",
+        }
+
     @pytest.mark.parametrize(("stage", "count_key"), [("render", "render"), ("index", "index")])
     async def test_build_plan_uses_count_query_for_render_and_index(self, tmp_path: Path, stage: str, count_key: str):
         backend = MagicMock(spec=SQLiteBackend)

--- a/tests/unit/storage/test_action_event_artifacts.py
+++ b/tests/unit/storage/test_action_event_artifacts.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from polylogue.storage.action_event_artifacts import ActionEventArtifactState
+from polylogue.storage.derived_status_products import build_action_statuses
+
+
+def test_action_event_artifact_state_reports_pending_and_extra_fts_rows() -> None:
+    state = ActionEventArtifactState(
+        source_conversations=4,
+        materialized_conversations=4,
+        materialized_rows=10,
+        fts_rows=13,
+    )
+
+    assert state.rows_ready is True
+    assert state.fts_ready is False
+    assert state.pending_fts_rows == 0
+    assert state.excess_fts_rows == 3
+    assert state.repair_item_count == 3
+    assert state.repair_detail() == (
+        "Action-event read model pending (3 stale extra action-event FTS rows)"
+    )
+
+
+def test_action_event_artifact_state_reports_missing_and_stale_rows() -> None:
+    state = ActionEventArtifactState(
+        source_conversations=12,
+        materialized_conversations=9,
+        materialized_rows=21,
+        fts_rows=17,
+        stale_rows=5,
+        orphan_rows=2,
+        matches_version=False,
+    )
+
+    row_status = state.row_status()
+    fts_status = state.fts_status()
+
+    assert row_status.ready is False
+    assert row_status.pending_documents == 3
+    assert row_status.stale_rows == 5
+    assert row_status.orphan_rows == 2
+    assert "stale rows 5" in row_status.detail
+    assert "orphan rows 2" in row_status.detail
+
+    assert fts_status.ready is False
+    assert fts_status.pending_rows == 4
+    assert fts_status.stale_rows == 0
+    assert "4 pending rows" in fts_status.detail
+
+
+def test_build_action_statuses_marks_extra_fts_rows_as_stale() -> None:
+    statuses = build_action_statuses(
+        {
+            "message_fts_exact_counts": True,
+            "message_source_rows": 0,
+            "message_fts_rows": 0,
+            "message_fts_ready": True,
+            "action_source_documents": 4,
+            "action_documents": 4,
+            "action_rows": 10,
+            "action_fts_rows": 13,
+            "action_stale_rows": 0,
+            "action_orphan_rows": 0,
+            "action_matches_version": True,
+        }
+    )
+
+    action_fts = statuses["action_events_fts"]
+    assert action_fts.ready is False
+    assert action_fts.pending_rows == 0
+    assert action_fts.stale_rows == 3
+    assert action_fts.detail == "Action-event FTS pending (13/10 rows; 3 stale extra rows)"

--- a/tests/unit/storage/test_backend.py
+++ b/tests/unit/storage/test_backend.py
@@ -393,10 +393,127 @@ async def test_async_backend_extends_legacy_v1_raw_table(tmp_path: Path) -> None
             "SELECT blob_size FROM raw_conversations WHERE raw_id = ?",
             ("raw-legacy",),
         ).fetchone()
+        index_row = verify_conn.execute(
+            "SELECT sql FROM sqlite_master WHERE type='index' AND name='idx_raw_conv_source_mtime'"
+        ).fetchone()
 
     assert "blob_size" in columns
     assert row is not None
     assert row[0] == 123
+    assert index_row is not None
+    assert index_row[0] is not None
+    assert "WHERE file_mtime IS NOT NULL" in index_row[0]
+    await backend.close()
+
+
+async def test_async_backend_applies_current_session_profile_extensions(tmp_path: Path) -> None:
+    """Async schema ensure should apply the same current-version profile extensions as the sync backend."""
+    db_path = tmp_path / "legacy-profile-current.db"
+    conn = sqlite3.connect(db_path)
+    conn.executescript(
+        f"""
+        CREATE TABLE session_profiles (
+            conversation_id TEXT PRIMARY KEY,
+            materializer_version INTEGER NOT NULL DEFAULT 5,
+            materialized_at TEXT NOT NULL,
+            source_updated_at TEXT,
+            source_sort_key REAL,
+            provider_name TEXT NOT NULL,
+            title TEXT,
+            first_message_at TEXT,
+            repo_paths_json TEXT,
+            repo_names_json TEXT,
+            tags_json TEXT,
+            auto_tags_json TEXT,
+            message_count INTEGER NOT NULL DEFAULT 0,
+            work_event_count INTEGER NOT NULL DEFAULT 0,
+            word_count INTEGER NOT NULL DEFAULT 0,
+            tool_use_count INTEGER NOT NULL DEFAULT 0,
+            thinking_count INTEGER NOT NULL DEFAULT 0,
+            total_cost_usd REAL NOT NULL DEFAULT 0,
+            total_duration_ms INTEGER NOT NULL DEFAULT 0,
+            wall_duration_ms INTEGER NOT NULL DEFAULT 0,
+            search_text TEXT NOT NULL,
+            inference_search_text TEXT NOT NULL DEFAULT ''
+        );
+
+        INSERT INTO session_profiles (
+            conversation_id,
+            materializer_version,
+            materialized_at,
+            source_updated_at,
+            source_sort_key,
+            provider_name,
+            title,
+            first_message_at,
+            repo_paths_json,
+            repo_names_json,
+            tags_json,
+            auto_tags_json,
+            message_count,
+            work_event_count,
+            word_count,
+            tool_use_count,
+            thinking_count,
+            total_cost_usd,
+            total_duration_ms,
+            wall_duration_ms,
+            search_text,
+            inference_search_text
+        ) VALUES (
+            'conv-1',
+            5,
+            '2026-04-01T00:00:00Z',
+            '2026-04-01T00:00:00Z',
+            1.0,
+            'chatgpt',
+            'Legacy profile',
+            '2026-04-01T00:00:00Z',
+            '[]',
+            '[]',
+            '[]',
+            '[]',
+            1,
+            0,
+            2,
+            0,
+            0,
+            0.0,
+            0,
+            0,
+            'search baseline',
+            ''
+        );
+
+        PRAGMA user_version = {SCHEMA_VERSION};
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    backend = SQLiteBackend(db_path=db_path)
+    async with backend.connection():
+        pass
+
+    with sqlite3.connect(db_path) as verify_conn:
+        columns = {row[1] for row in verify_conn.execute("PRAGMA table_info(session_profiles)").fetchall()}
+        row = verify_conn.execute(
+            """
+            SELECT evidence_search_text, inference_search_text, enrichment_search_text, enrichment_family
+            FROM session_profiles
+            WHERE conversation_id = ?
+            """,
+            ("conv-1",),
+        ).fetchone()
+
+    assert {"evidence_search_text", "enrichment_payload_json", "enrichment_search_text", "enrichment_family"}.issubset(
+        columns
+    )
+    assert row is not None
+    assert row[0] == "search baseline"
+    assert row[1] == "search baseline"
+    assert row[2] == "search baseline"
+    assert row[3] == "scored_session_enrichment"
     await backend.close()
 
 

--- a/tests/unit/storage/test_derived_status.py
+++ b/tests/unit/storage/test_derived_status.py
@@ -120,3 +120,56 @@ def test_collect_derived_statuses_skips_retrieval_band_recomputation(
 
     assert calls == [False]
     assert verify_calls == [("fts", False), ("action", False), ("session", False)]
+
+
+def test_build_retrieval_statuses_counts_stale_action_event_fts_rows() -> None:
+    from polylogue.storage.derived_status import build_retrieval_statuses
+
+    statuses = build_retrieval_statuses(
+        {
+            "transcript_embeddings_ready": True,
+            "embedded_conversations": 0,
+            "embedded_messages": 0,
+            "pending_conversations": 0,
+            "stale_messages": 0,
+            "missing_provenance": 0,
+            "total_conversations": 0,
+            "evidence_retrieval_ready": False,
+            "evidence_retrieval_rows": 13,
+            "expected_evidence_retrieval_rows": 10,
+            "profile_evidence_fts_rows": 0,
+            "profile_evidence_fts_duplicates": 0,
+            "profile_rows": 0,
+            "action_fts_rows": 13,
+            "action_rows": 10,
+            "action_source_documents": 4,
+            "action_documents": 4,
+            "action_stale_rows": 0,
+            "action_fts_stale_rows": 3,
+            "action_orphan_rows": 0,
+            "orphan_profile_rows": 0,
+            "inference_retrieval_ready": True,
+            "inference_retrieval_rows": 0,
+            "expected_inference_retrieval_rows": 0,
+            "profile_inference_fts_rows": 0,
+            "profile_inference_fts_duplicates": 0,
+            "work_event_fts_rows": 0,
+            "work_event_fts_duplicates": 0,
+            "work_event_rows": 0,
+            "phase_rows": 0,
+            "stale_work_event_rows": 0,
+            "stale_phase_rows": 0,
+            "orphan_work_event_rows": 0,
+            "orphan_phase_rows": 0,
+            "enrichment_retrieval_ready": True,
+            "enrichment_retrieval_rows": 0,
+            "expected_enrichment_retrieval_rows": 0,
+            "profile_enrichment_fts_rows": 0,
+            "profile_enrichment_fts_duplicates": 0,
+        }
+    )
+
+    evidence = statuses["retrieval_evidence"]
+    assert evidence.ready is False
+    assert evidence.pending_rows == 0
+    assert evidence.stale_rows == 3

--- a/tests/unit/storage/test_raw_ingest_artifacts.py
+++ b/tests/unit/storage/test_raw_ingest_artifacts.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from polylogue.pipeline.services.planning_backlog import collect_parse_backlog, collect_validation_backlog
+from polylogue.storage.backends.async_sqlite import SQLiteBackend
+from polylogue.storage.raw_ingest_artifacts import (
+    RawIngestArtifactState,
+    parse_backlog_query_spec,
+    validation_backlog_query_spec,
+)
+from polylogue.storage.store import RawConversationRecord
+from polylogue.types import ValidationStatus
+
+
+def test_raw_ingest_artifact_state_classifies_quarantine_and_backlogs() -> None:
+    passed_unparsed = RawIngestArtifactState(validation_status=ValidationStatus.PASSED)
+    failed_unparsed = RawIngestArtifactState(validation_status=ValidationStatus.FAILED)
+    unvalidated_parsed = RawIngestArtifactState(parsed_at="2026-04-13T00:00:00Z")
+
+    assert passed_unparsed.needs_validation_backlog() is False
+    assert passed_unparsed.needs_parse_backlog() is True
+    assert passed_unparsed.quarantined is False
+
+    assert failed_unparsed.needs_validation_backlog() is False
+    assert failed_unparsed.needs_parse_backlog() is False
+    assert failed_unparsed.quarantined is True
+
+    assert unvalidated_parsed.needs_validation_backlog() is False
+    assert unvalidated_parsed.needs_parse_backlog() is False
+    assert unvalidated_parsed.needs_validation_backlog(force_reparse=True) is True
+    assert unvalidated_parsed.needs_parse_backlog(force_reparse=True) is True
+
+
+def test_raw_ingest_backlog_query_specs_match_force_reparse_contract() -> None:
+    ordinary_validate = validation_backlog_query_spec()
+    ordinary_parse = parse_backlog_query_spec()
+    forced_validate = validation_backlog_query_spec(force_reparse=True)
+    forced_parse = parse_backlog_query_spec(force_reparse=True)
+
+    assert ordinary_validate.require_unparsed is True
+    assert ordinary_validate.require_unvalidated is True
+    assert ordinary_validate.validation_statuses is None
+
+    assert ordinary_parse.require_unparsed is True
+    assert ordinary_parse.validation_statuses == ("passed", "skipped")
+
+    assert forced_validate.require_unparsed is False
+    assert forced_validate.require_unvalidated is True
+    assert forced_validate.validation_statuses is None
+
+    assert forced_parse.require_unparsed is False
+    assert forced_parse.validation_statuses is None
+
+
+@pytest.mark.asyncio
+async def test_collect_backlogs_match_shared_raw_ingest_state(tmp_path: Path) -> None:
+    backend = SQLiteBackend(db_path=tmp_path / "test.db")
+    try:
+        source_name = "inbox-a"
+        raw_ids = (
+            "raw-passed-unparsed",
+            "raw-skipped-unparsed",
+            "raw-failed-unparsed",
+            "raw-passed-parsed",
+            "raw-unvalidated-unparsed",
+            "raw-unvalidated-parsed",
+        )
+
+        for raw_id in raw_ids:
+            await backend.save_raw_conversation(
+                RawConversationRecord(
+                    raw_id=raw_id,
+                    provider_name="chatgpt",
+                    source_name=source_name,
+                    source_path=f"/tmp/{raw_id}.json",
+                    blob_size=len(b'{"id":"x"}'),
+                    acquired_at=datetime.now(tz=timezone.utc).isoformat(),
+                )
+            )
+
+        await backend.mark_raw_validated("raw-passed-unparsed", status="passed", provider="chatgpt", mode="strict")
+        await backend.mark_raw_validated("raw-skipped-unparsed", status="skipped", provider="chatgpt", mode="strict")
+        await backend.mark_raw_validated("raw-failed-unparsed", status="failed", provider="chatgpt", mode="strict")
+        await backend.mark_raw_validated("raw-passed-parsed", status="passed", provider="chatgpt", mode="strict")
+        await backend.mark_raw_parsed("raw-passed-parsed", payload_provider="chatgpt")
+        await backend.mark_raw_parsed("raw-unvalidated-parsed", payload_provider="chatgpt")
+
+        states = await backend.get_raw_conversation_states(list(raw_ids))
+
+        ordinary_validation = set(
+            await collect_validation_backlog(
+                backend,
+                source_names=[source_name],
+                force_reparse=False,
+            )
+        )
+        ordinary_parse = set(
+            await collect_parse_backlog(
+                backend,
+                source_names=[source_name],
+                force_reparse=False,
+            )
+        )
+        forced_validation = set(
+            await collect_validation_backlog(
+                backend,
+                source_names=[source_name],
+                force_reparse=True,
+            )
+        )
+        forced_parse = set(
+            await collect_parse_backlog(
+                backend,
+                source_names=[source_name],
+                force_reparse=True,
+            )
+        )
+
+        expected_ordinary_validation = {
+            raw_id
+            for raw_id in raw_ids
+            if RawIngestArtifactState.from_state(states[raw_id]).needs_validation_backlog(force_reparse=False)
+        }
+        expected_ordinary_parse = {
+            raw_id
+            for raw_id in raw_ids
+            if RawIngestArtifactState.from_state(states[raw_id]).needs_parse_backlog(force_reparse=False)
+        }
+        expected_forced_validation = {
+            raw_id
+            for raw_id in raw_ids
+            if RawIngestArtifactState.from_state(states[raw_id]).needs_validation_backlog(force_reparse=True)
+        }
+        expected_forced_parse = {
+            raw_id
+            for raw_id in raw_ids
+            if RawIngestArtifactState.from_state(states[raw_id]).needs_parse_backlog(force_reparse=True)
+        }
+
+        assert ordinary_validation == expected_ordinary_validation == {"raw-unvalidated-unparsed"}
+        assert ordinary_parse == expected_ordinary_parse == {"raw-passed-unparsed", "raw-skipped-unparsed"}
+        assert forced_validation == expected_forced_validation == {
+            "raw-unvalidated-parsed",
+            "raw-unvalidated-unparsed",
+        }
+        assert forced_parse == expected_forced_parse == set(raw_ids)
+    finally:
+        await backend.close()

--- a/tests/unit/storage/test_repair.py
+++ b/tests/unit/storage/test_repair.py
@@ -6,6 +6,9 @@ from polylogue.storage import repair as repair_mod
 
 def _status(
     *,
+    source_documents: int = 0,
+    materialized_documents: int = 0,
+    materialized_rows: int = 0,
     pending_documents: int = 0,
     pending_rows: int = 0,
     stale_rows: int = 0,
@@ -14,6 +17,9 @@ def _status(
         name="test",
         ready=pending_documents == 0 and pending_rows == 0 and stale_rows == 0,
         detail="",
+        source_documents=source_documents,
+        materialized_documents=materialized_documents,
+        materialized_rows=materialized_rows,
         pending_documents=pending_documents,
         pending_rows=pending_rows,
         stale_rows=stale_rows,
@@ -22,8 +28,8 @@ def _status(
 
 def test_action_event_repair_detail_reports_pending_fts_rows_only() -> None:
     statuses = {
-        "action_events": _status(),
-        "action_events_fts": _status(pending_rows=323048),
+        "action_events": _status(source_documents=0, materialized_documents=0, materialized_rows=323048),
+        "action_events_fts": _status(materialized_rows=0, pending_rows=323048),
     }
 
     assert repair_mod.action_event_repair_count(statuses) == 323048
@@ -34,11 +40,36 @@ def test_action_event_repair_detail_reports_pending_fts_rows_only() -> None:
 
 def test_action_event_repair_detail_reports_missing_and_stale_rows() -> None:
     statuses = {
-        "action_events": _status(pending_documents=12, stale_rows=5),
-        "action_events_fts": _status(pending_rows=9),
+        "action_events": _status(
+            source_documents=12,
+            materialized_documents=0,
+            materialized_rows=9,
+            pending_documents=12,
+            stale_rows=5,
+        ),
+        "action_events_fts": _status(materialized_rows=0, pending_rows=9),
     }
 
     assert repair_mod.action_event_repair_count(statuses) == 26
     assert repair_mod._action_event_repair_detail(statuses) == (
         "Action-event read model pending (12 missing conversations, 5 stale action-event rows, 9 pending action-event FTS rows)"
+    )
+
+
+def test_action_event_repair_detail_reports_stale_extra_fts_rows() -> None:
+    statuses = {
+        "action_events": _status(
+            source_documents=4,
+            materialized_documents=4,
+            materialized_rows=10,
+        ),
+        "action_events_fts": _status(
+            materialized_rows=13,
+            stale_rows=3,
+        ),
+    }
+
+    assert repair_mod.action_event_repair_count(statuses) == 3
+    assert repair_mod._action_event_repair_detail(statuses) == (
+        "Action-event read model pending (3 stale extra action-event FTS rows)"
     )


### PR DESCRIPTION
## Summary

PR 5/9. Stacked on PR 4 (`pr/04-perf-parse-hardening`).

The first shared semantic substrate: introduces an explicit runtime artifact graph and unifies storage/schema bootstrap across the sync and async paths. Small, focused PR that lays the foundation for PRs 6–8.

Highlights:

- **`polylogue/storage/action_event_artifacts.py`** — shared semantic model for action-event rows, FTS state, and repair accounting. Replaces the previous parallel definitions scattered across `action_event_status.py`, `derived_status_products.py`, `derived_status.py`, `embedding_stats_support.py`, and `repair.py`.
- **`polylogue/storage/raw_ingest_artifacts.py`** — shared semantic model for validation backlog eligibility, parse backlog eligibility, force-reparse, and quarantine classification. Replaces the previous drift-prone split between SQL backlog predicates and in-memory planning.
- **`polylogue/artifact_graph.py`** — first explicit runtime artifact/dependency graph covering the two proven vertical paths: `raw_validation_state → validation_backlog → parse_backlog → parse_quarantine` and `tool_use_source_blocks → action_event_rows → action_event_fts → action_event_health`. Also adds a `devtools/artifact_graph.py` projection.
- **`polylogue/storage/backends/schema_bootstrap.py`** — shared bootstrap planning for sync (`schema_upgrade.py`) and async (`async_sqlite_schema.py`) paths. Removes the previous drift where async carried weaker current-version extension coverage than sync.

Commits on this branch: 4 (commits 113–116 of the original branch).

## Test plan

- [x] `pytest -q tests/unit/storage/test_action_event_artifacts.py tests/unit/storage/test_raw_ingest_artifacts.py tests/unit/core/test_artifact_graph.py tests/unit/devtools/test_artifact_graph.py tests/unit/storage/test_backend.py`
- [x] `ruff check polylogue/storage/action_event_artifacts.py polylogue/storage/raw_ingest_artifacts.py polylogue/artifact_graph.py polylogue/storage/backends/schema_bootstrap.py`

## Stack

Base: `pr/04-perf-parse-hardening`. Next: `pr/06-scenario-substrate`.
