### PR TITLE
fix: split raw parse/validation semantics and tighten quarantine accounting

### DIFF
--- a/polylogue/pipeline/services/ingest_batch.py
+++ b/polylogue/pipeline/services/ingest_batch.py
@@ -65,6 +65,7 @@ class _RawIngestOutcome:
     payload_provider: str | None
     validation_status: str
     validation_error: str | None
+    parse_error: str | None
     error: str | None
     had_conversations: bool
 
@@ -437,6 +438,7 @@ def _record_outcome(summary: _IngestBatchSummary, ir: IngestRecordResult) -> Non
         payload_provider=ir.payload_provider,
         validation_status=ir.validation_status,
         validation_error=ir.validation_error,
+        parse_error=ir.parse_error,
         error=ir.error,
         had_conversations=bool(ir.conversations),
     )
@@ -945,7 +947,7 @@ def _failed_raw_state_update(
             parse_error=error,
         )
     return RawConversationStateUpdate(
-        parse_error=error,
+        parse_error=outcome.parse_error,
         payload_provider=outcome.payload_provider,
         validation_status=outcome.validation_status,
         validation_error=outcome.validation_error or error,

--- a/polylogue/pipeline/services/ingest_worker.py
+++ b/polylogue/pipeline/services/ingest_worker.py
@@ -90,6 +90,7 @@ class IngestRecordResult:
     payload_provider: str | None = None
     validation_status: str = "skipped"  # ValidationStatus value
     validation_error: str | None = None
+    parse_error: str | None = None
     error: str | None = None
     conversations: list[ConversationData] = field(default_factory=list)
     source_name: str | None = None
@@ -236,6 +237,7 @@ def _stream_grouped_jsonl_record(
                     payload_provider=str(detected_provider),
                     validation_status=ValidationStatus.FAILED.value,
                     validation_error=malformed_error,
+                    parse_error=malformed_error,
                     error=malformed_error,
                 ),
                 measure_serialized_size=measure_serialized_size,
@@ -293,14 +295,15 @@ def _stream_grouped_jsonl_record(
             )
     except Exception as exc:
         return _finalize_result(
-            IngestRecordResult(
-                raw_id=raw_record.raw_id,
-                payload_provider=str(detected_provider),
-                validation_status=v_status.value,
-                error=f"parse: {exc}",
-            ),
-            measure_serialized_size=measure_serialized_size,
-        )
+                IngestRecordResult(
+                    raw_id=raw_record.raw_id,
+                    payload_provider=str(detected_provider),
+                    validation_status=v_status.value,
+                    parse_error=f"parse: {exc}",
+                    error=f"parse: {exc}",
+                ),
+                measure_serialized_size=measure_serialized_size,
+            )
 
     fallback_timestamp = raw_record.file_mtime
     source_name = raw_record.source_name or raw_record.source_path or ""
@@ -327,6 +330,7 @@ def _stream_grouped_jsonl_record(
                     raw_id=raw_record.raw_id,
                     payload_provider=str(detected_provider),
                     validation_status=v_status.value,
+                    parse_error=f"transform: {exc}",
                     error=f"transform: {exc}",
                 ),
                 measure_serialized_size=measure_serialized_size,
@@ -402,15 +406,16 @@ def ingest_record(
         )
     except Exception as exc:
         return _finalize_result(
-            IngestRecordResult(
-                raw_id=raw_record.raw_id,
-                payload_provider=stored_payload_provider,
-                validation_status=ValidationStatus.FAILED.value,
-                validation_error=f"decode: {exc}",
-                error=f"decode: {exc}",
-            ),
-            measure_serialized_size=measure_serialized_size,
-        )
+                IngestRecordResult(
+                    raw_id=raw_record.raw_id,
+                    payload_provider=stored_payload_provider,
+                    validation_status=ValidationStatus.FAILED.value,
+                    validation_error=f"decode: {exc}",
+                    parse_error=f"decode: {exc}",
+                    error=f"decode: {exc}",
+                ),
+                measure_serialized_size=measure_serialized_size,
+            )
 
     payload_provider = str(envelope.provider)
 
@@ -443,6 +448,7 @@ def ingest_record(
                     payload_provider=payload_provider,
                     validation_status=ValidationStatus.FAILED.value,
                     validation_error=malformed_error,
+                    parse_error=malformed_error,
                     error=malformed_error,
                 ),
                 measure_serialized_size=measure_serialized_size,
@@ -506,14 +512,15 @@ def ingest_record(
         )
     except Exception as exc:
         return _finalize_result(
-            IngestRecordResult(
-                raw_id=raw_record.raw_id,
-                payload_provider=payload_provider,
-                validation_status=v_status.value,
-                error=f"parse: {exc}",
-            ),
-            measure_serialized_size=measure_serialized_size,
-        )
+                IngestRecordResult(
+                    raw_id=raw_record.raw_id,
+                    payload_provider=payload_provider,
+                    validation_status=v_status.value,
+                    parse_error=f"parse: {exc}",
+                    error=f"parse: {exc}",
+                ),
+                measure_serialized_size=measure_serialized_size,
+            )
 
     # The decoded payload can be much larger than the normalized conversation
     # objects; drop it before tuple transformation to avoid overlapping heaps.
@@ -546,6 +553,7 @@ def ingest_record(
                     raw_id=raw_record.raw_id,
                     payload_provider=payload_provider,
                     validation_status=v_status.value,
+                    parse_error=f"transform: {exc}",
                     error=f"transform: {exc}",
                 ),
                 measure_serialized_size=measure_serialized_size,

--- a/polylogue/pipeline/services/ingest_worker.py
+++ b/polylogue/pipeline/services/ingest_worker.py
@@ -295,15 +295,15 @@ def _stream_grouped_jsonl_record(
             )
     except Exception as exc:
         return _finalize_result(
-                IngestRecordResult(
-                    raw_id=raw_record.raw_id,
-                    payload_provider=str(detected_provider),
-                    validation_status=v_status.value,
-                    parse_error=f"parse: {exc}",
-                    error=f"parse: {exc}",
-                ),
-                measure_serialized_size=measure_serialized_size,
-            )
+            IngestRecordResult(
+                raw_id=raw_record.raw_id,
+                payload_provider=str(detected_provider),
+                validation_status=v_status.value,
+                parse_error=f"parse: {exc}",
+                error=f"parse: {exc}",
+            ),
+            measure_serialized_size=measure_serialized_size,
+        )
 
     fallback_timestamp = raw_record.file_mtime
     source_name = raw_record.source_name or raw_record.source_path or ""
@@ -406,16 +406,16 @@ def ingest_record(
         )
     except Exception as exc:
         return _finalize_result(
-                IngestRecordResult(
-                    raw_id=raw_record.raw_id,
-                    payload_provider=stored_payload_provider,
-                    validation_status=ValidationStatus.FAILED.value,
-                    validation_error=f"decode: {exc}",
-                    parse_error=f"decode: {exc}",
-                    error=f"decode: {exc}",
-                ),
-                measure_serialized_size=measure_serialized_size,
-            )
+            IngestRecordResult(
+                raw_id=raw_record.raw_id,
+                payload_provider=stored_payload_provider,
+                validation_status=ValidationStatus.FAILED.value,
+                validation_error=f"decode: {exc}",
+                parse_error=f"decode: {exc}",
+                error=f"decode: {exc}",
+            ),
+            measure_serialized_size=measure_serialized_size,
+        )
 
     payload_provider = str(envelope.provider)
 
@@ -512,15 +512,15 @@ def ingest_record(
         )
     except Exception as exc:
         return _finalize_result(
-                IngestRecordResult(
-                    raw_id=raw_record.raw_id,
-                    payload_provider=payload_provider,
-                    validation_status=v_status.value,
-                    parse_error=f"parse: {exc}",
-                    error=f"parse: {exc}",
-                ),
-                measure_serialized_size=measure_serialized_size,
-            )
+            IngestRecordResult(
+                raw_id=raw_record.raw_id,
+                payload_provider=payload_provider,
+                validation_status=v_status.value,
+                parse_error=f"parse: {exc}",
+                error=f"parse: {exc}",
+            ),
+            measure_serialized_size=measure_serialized_size,
+        )
 
     # The decoded payload can be much larger than the normalized conversation
     # objects; drop it before tuple transformation to avoid overlapping heaps.

--- a/polylogue/pipeline/services/validation_flow.py
+++ b/polylogue/pipeline/services/validation_flow.py
@@ -216,17 +216,17 @@ async def evaluate_raw_records(
             result.drift_counts[prov] = result.drift_counts.get(prov, 0) + cnt
 
         result.records.append(
-                ValidatedRawRecord(
-                    raw_id=raw_record.raw_id,
-                    parseable=outcome.parseable,
-                    validation_status=outcome.validation_status,
-                    validation_error=outcome.validation_error,
-                    parse_error=outcome.parse_error,
-                    canonical_provider=outcome.canonical_provider,
-                    payload_provider=outcome.payload_provider,
-                    drift_count=outcome.drift_count,
-                )
+            ValidatedRawRecord(
+                raw_id=raw_record.raw_id,
+                parseable=outcome.parseable,
+                validation_status=outcome.validation_status,
+                validation_error=outcome.validation_error,
+                parse_error=outcome.parse_error,
+                canonical_provider=outcome.canonical_provider,
+                payload_provider=outcome.payload_provider,
+                drift_count=outcome.drift_count,
             )
+        )
 
         if persist:
             await repository.mark_raw_validated(

--- a/polylogue/pipeline/services/validation_flow.py
+++ b/polylogue/pipeline/services/validation_flow.py
@@ -73,6 +73,7 @@ async def validate_raw_ids(
                     parseable=True,
                     validation_status=ValidationStatus.SKIPPED,
                     validation_error=None,
+                    parse_error=None,
                     canonical_provider=Provider.UNKNOWN,
                     payload_provider=None,
                 )
@@ -106,6 +107,7 @@ async def validate_raw_ids(
                     parseable=False,
                     validation_status=ValidationStatus.FAILED,
                     validation_error="Missing raw conversation record",
+                    parse_error="Missing raw conversation record",
                     canonical_provider=Provider.UNKNOWN,
                     payload_provider=None,
                 )
@@ -150,6 +152,7 @@ async def evaluate_raw_records(
                     parseable=True,
                     validation_status=ValidationStatus.SKIPPED,
                     validation_error=None,
+                    parse_error=None,
                     canonical_provider=Provider.from_string(raw_record.provider_name),
                     payload_provider=raw_record.payload_provider,
                 )
@@ -213,16 +216,17 @@ async def evaluate_raw_records(
             result.drift_counts[prov] = result.drift_counts.get(prov, 0) + cnt
 
         result.records.append(
-            ValidatedRawRecord(
-                raw_id=raw_record.raw_id,
-                parseable=outcome.parseable,
-                validation_status=outcome.validation_status,
-                validation_error=outcome.validation_error,
-                canonical_provider=outcome.canonical_provider,
-                payload_provider=outcome.payload_provider,
-                drift_count=outcome.drift_count,
+                ValidatedRawRecord(
+                    raw_id=raw_record.raw_id,
+                    parseable=outcome.parseable,
+                    validation_status=outcome.validation_status,
+                    validation_error=outcome.validation_error,
+                    parse_error=outcome.parse_error,
+                    canonical_provider=outcome.canonical_provider,
+                    payload_provider=outcome.payload_provider,
+                    drift_count=outcome.drift_count,
+                )
             )
-        )
 
         if persist:
             await repository.mark_raw_validated(
@@ -234,10 +238,10 @@ async def evaluate_raw_records(
                 mode=mode,
                 payload_provider=outcome.payload_provider,
             )
-            if not outcome.parseable and outcome.validation_error is not None:
+            if outcome.parse_error is not None:
                 await repository.mark_raw_parsed(
                     raw_record.raw_id,
-                    error=outcome.validation_error,
+                    error=outcome.parse_error,
                     payload_provider=outcome.payload_provider,
                 )
 

--- a/polylogue/pipeline/services/validation_runtime.py
+++ b/polylogue/pipeline/services/validation_runtime.py
@@ -28,6 +28,7 @@ class _ValidationOutcome:
 
     validation_status: ValidationStatus
     validation_error: str | None
+    parse_error: str | None
     parseable: bool
     canonical_provider: Provider
     payload_provider: Provider | None
@@ -79,6 +80,7 @@ def _validate_record_sync(
         return _ValidationOutcome(
             validation_status=ValidationStatus.FAILED,
             validation_error=f"Unable to decode payload: {exc}",
+            parse_error=f"Unable to decode payload: {exc}",
             parseable=False,
             canonical_provider=canonical_provider,
             payload_provider=payload_provider,
@@ -95,6 +97,7 @@ def _validate_record_sync(
         return _ValidationOutcome(
             validation_status=ValidationStatus.SKIPPED,
             validation_error=f"Artifact excluded from conversation schema inference: {envelope.artifact.kind.value}",
+            parse_error=None,
             parseable=False,
             canonical_provider=canonical_provider,
             payload_provider=payload_provider,
@@ -112,6 +115,7 @@ def _validate_record_sync(
             return _ValidationOutcome(
                 validation_status=ValidationStatus.FAILED,
                 validation_error=malformed_error,
+                parse_error=malformed_error,
                 parseable=False,
                 canonical_provider=canonical_provider,
                 payload_provider=payload_provider,
@@ -197,6 +201,7 @@ def _validate_record_sync(
     return _ValidationOutcome(
         validation_status=validation_status,
         validation_error=validation_error,
+        parse_error=None,
         parseable=parseable,
         canonical_provider=canonical_provider,
         payload_provider=payload_provider,

--- a/polylogue/pipeline/stage_models.py
+++ b/polylogue/pipeline/stage_models.py
@@ -38,6 +38,7 @@ class ValidatedRawRecord:
     parseable: bool
     validation_status: ValidationStatus
     validation_error: str | None
+    parse_error: str | None
     canonical_provider: Provider
     payload_provider: Provider | None
     drift_count: int = 0

--- a/polylogue/schemas/verification_corpus.py
+++ b/polylogue/schemas/verification_corpus.py
@@ -202,7 +202,7 @@ def verify_raw_corpus(
                 provider_stats.decode_errors += 1
                 if request.quarantine_malformed:
                     raw_id = str(row["raw_id"])
-                    reason = f"Unable to decode payload: {type(exc).__name__}"
+                    reason = f"Unable to decode payload: {exc}"
                     quarantine_updates.append((raw_id, reason, candidate_provider, stored_payload_provider))
                     provider_stats.quarantined_records += 1
                 if request.progress_callback is not None:

--- a/polylogue/storage/action_event_artifacts.py
+++ b/polylogue/storage/action_event_artifacts.py
@@ -64,7 +64,9 @@ class ActionEventArtifactState:
 
     @property
     def rows_ready(self) -> bool:
-        return self.source_conversations == 0 or (self.missing_conversations == 0 and self.stale_rows == 0)
+        return self.source_conversations == 0 or (
+            self.missing_conversations == 0 and self.stale_rows == 0 and self.orphan_rows == 0
+        )
 
     @property
     def fts_ready(self) -> bool:
@@ -76,7 +78,13 @@ class ActionEventArtifactState:
 
     @property
     def repair_item_count(self) -> int:
-        return self.missing_conversations + self.stale_rows + self.pending_fts_rows + self.excess_fts_rows
+        return (
+            self.missing_conversations
+            + self.stale_rows
+            + self.orphan_rows
+            + self.pending_fts_rows
+            + self.excess_fts_rows
+        )
 
     def repair_detail(self) -> str:
         if self.repair_item_count == 0:
@@ -87,6 +95,8 @@ class ActionEventArtifactState:
             parts.append(f"{self.missing_conversations:,} missing conversations")
         if self.stale_rows:
             parts.append(f"{self.stale_rows:,} stale action-event rows")
+        if self.orphan_rows:
+            parts.append(f"{self.orphan_rows:,} orphan action-event rows")
         if self.pending_fts_rows:
             parts.append(f"{self.pending_fts_rows:,} pending action-event FTS rows")
         if self.excess_fts_rows:

--- a/polylogue/storage/raw_ingest_artifacts.py
+++ b/polylogue/storage/raw_ingest_artifacts.py
@@ -27,6 +27,7 @@ class RawIngestArtifactState:
     """Canonical persisted raw-state semantics for validation and parse planning."""
 
     parsed_at: str | None = None
+    parse_error: str | None = None
     validation_status: ValidationStatus | None = None
 
     @classmethod
@@ -35,6 +36,7 @@ class RawIngestArtifactState:
             return cls()
         return cls(
             parsed_at=state.parsed_at,
+            parse_error=state.parse_error,
             validation_status=state.validation_status,
         )
 
@@ -48,7 +50,7 @@ class RawIngestArtifactState:
 
     @property
     def quarantined(self) -> bool:
-        return not self.parsed and self.validation_status is ValidationStatus.FAILED
+        return not self.parsed and self.parse_error is not None
 
     def needs_validation_backlog(self, *, force_reparse: bool = False) -> bool:
         return self.validation_status is None and (force_reparse or not self.parsed)

--- a/tests/infra/strategies/pipeline.py
+++ b/tests/infra/strategies/pipeline.py
@@ -143,7 +143,7 @@ def expected_validation_contract(case: ValidationCase) -> dict[str, Any]:
         "parseable": not blocked,
         "status": "failed" if blocked else "passed",
         "invalid_count": invalid_count,
-        "mark_raw_parsed": blocked,
+        "mark_raw_parsed": malformed_blocks,
         "validation_samples_called": not malformed_blocks,
     }
 

--- a/tests/unit/core/test_schema_validation.py
+++ b/tests/unit/core/test_schema_validation.py
@@ -754,6 +754,51 @@ def test_verify_raw_corpus_quarantine_malformed_updates_validation_state(db_path
     assert isinstance(row[6], str) and "Malformed JSONL lines" in row[6]
 
 
+def test_verify_raw_corpus_quarantine_empty_payload_updates_validation_state(db_path):
+    raw_id = _insert_raw_record(
+        db_path=db_path,
+        raw_id="raw-codex-empty",
+        provider_name="codex",
+        source_name="codex",
+        source_path="/tmp/empty-session.jsonl",
+        raw_content=b"",
+    )
+
+    report = verify_raw_corpus(
+        db_path=db_path,
+        request=SchemaVerificationRequest(
+            providers=["codex"],
+            max_samples=16,
+            quarantine_malformed=True,
+        ),
+    )
+    stats = report.providers["codex"]
+
+    assert report.total_records == 1
+    assert stats.decode_errors == 1
+    assert stats.quarantined_records == 1
+
+    with open_connection(db_path) as conn:
+        row = conn.execute(
+            """
+            SELECT validation_status, validation_error, validation_mode, validation_provider,
+                   payload_provider,
+                   validated_at, parse_error
+            FROM raw_conversations
+            WHERE raw_id = ?
+            """,
+            (raw_id,),
+        ).fetchone()
+    assert row is not None
+    assert row[0] == "failed"
+    assert isinstance(row[1], str) and "zero-length" in row[1]
+    assert row[2] == "strict"
+    assert row[3] == "codex"
+    assert row[4] is None
+    assert row[5] is not None
+    assert isinstance(row[6], str) and "zero-length" in row[6]
+
+
 def test_verify_raw_corpus_honors_record_limit_and_offset(db_path, monkeypatch):
     class _AlwaysValidValidator:
         provider = "chatgpt"

--- a/tests/unit/pipeline/test_ingest_batch.py
+++ b/tests/unit/pipeline/test_ingest_batch.py
@@ -541,6 +541,7 @@ def test_successful_raw_state_update_combines_parse_and_validation_fields() -> N
         payload_provider="chatgpt",
         validation_status="passed",
         validation_error=None,
+        parse_error=None,
         error=None,
         had_conversations=True,
     )
@@ -567,6 +568,7 @@ def test_failed_raw_state_update_combines_parse_and_validation_fields() -> None:
         payload_provider="chatgpt",
         validation_status="failed",
         validation_error="schema mismatch",
+        parse_error="parse failed",
         error="parse failed",
         had_conversations=False,
     )
@@ -579,6 +581,32 @@ def test_failed_raw_state_update_combines_parse_and_validation_fields() -> None:
 
     assert state == RawConversationStateUpdate(
         parse_error="parse failed",
+        payload_provider="chatgpt",
+        validation_status="failed",
+        validation_error="schema mismatch",
+        validation_mode="strict",
+    )
+
+
+def test_failed_raw_state_update_keeps_validation_only_failure_out_of_parse_error() -> None:
+    outcome = _RawIngestOutcome(
+        raw_id="raw-1",
+        payload_provider="chatgpt",
+        validation_status="failed",
+        validation_error="schema mismatch",
+        parse_error=None,
+        error="schema mismatch",
+        had_conversations=False,
+    )
+
+    state = _failed_raw_state_update(
+        outcome=outcome,
+        error="schema mismatch",
+        validation_mode="strict",
+    )
+
+    assert state == RawConversationStateUpdate(
+        parse_error=None,
         payload_provider="chatgpt",
         validation_status="failed",
         validation_error="schema mismatch",
@@ -643,6 +671,7 @@ async def test_persist_batch_raw_state_updates_uses_one_typed_update_per_raw() -
             payload_provider="chatgpt",
             validation_status="passed",
             validation_error=None,
+            parse_error=None,
             error=None,
             had_conversations=True,
         ),
@@ -651,6 +680,7 @@ async def test_persist_batch_raw_state_updates_uses_one_typed_update_per_raw() -
             payload_provider="codex",
             validation_status="failed",
             validation_error="bad schema",
+            parse_error="parse failed",
             error="parse failed",
             had_conversations=False,
         ),
@@ -675,3 +705,44 @@ async def test_persist_batch_raw_state_updates_uses_one_typed_update_per_raw() -
     assert failed_call.args == ("raw-failed",)
     assert failed_call.kwargs["state"].parse_error == "parse failed"
     assert failed_call.kwargs["state"].validation_error == "bad schema"
+
+
+@pytest.mark.asyncio
+async def test_persist_batch_raw_state_updates_preserves_validation_only_failure_without_quarantine() -> None:
+    update_raw_state = AsyncMock()
+    repository = SimpleNamespace(update_raw_state=update_raw_state)
+    service = SimpleNamespace(repository=repository)
+
+    @asynccontextmanager
+    async def _bulk_connection():
+        yield
+
+    backend = SimpleNamespace(bulk_connection=_bulk_connection)
+    outcomes = {
+        "raw-schema-invalid": _RawIngestOutcome(
+            raw_id="raw-schema-invalid",
+            payload_provider="chatgpt",
+            validation_status="failed",
+            validation_error="bad schema",
+            parse_error=None,
+            error="bad schema",
+            had_conversations=False,
+        ),
+    }
+
+    elapsed_s = await _persist_batch_raw_state_updates(
+        service,
+        backend,
+        outcomes=outcomes,
+        succeeded_raw_ids=set(),
+        skipped_raw_ids=set(),
+        failed_raw_ids={"raw-schema-invalid": "bad schema"},
+        validation_mode="strict",
+    )
+
+    assert elapsed_s >= 0.0
+    update_raw_state.assert_awaited_once()
+    state = update_raw_state.await_args.kwargs["state"]
+    assert state.parse_error is None
+    assert state.validation_error == "bad schema"
+    assert state.validation_status == "failed"

--- a/tests/unit/storage/test_action_event_artifacts.py
+++ b/tests/unit/storage/test_action_event_artifacts.py
@@ -61,9 +61,7 @@ def test_action_event_artifact_state_treats_orphan_rows_as_unready_and_repairabl
     assert state.rows_ready is False
     assert state.fts_ready is True
     assert state.repair_item_count == 2
-    assert state.repair_detail() == (
-        "Action-event read model pending (2 orphan action-event rows)"
-    )
+    assert state.repair_detail() == ("Action-event read model pending (2 orphan action-event rows)")
     assert row_status.ready is False
     assert row_status.orphan_rows == 2
     assert "orphan rows 2" in row_status.detail

--- a/tests/unit/storage/test_action_event_artifacts.py
+++ b/tests/unit/storage/test_action_event_artifacts.py
@@ -47,6 +47,28 @@ def test_action_event_artifact_state_reports_missing_and_stale_rows() -> None:
     assert "4 pending rows" in fts_status.detail
 
 
+def test_action_event_artifact_state_treats_orphan_rows_as_unready_and_repairable() -> None:
+    state = ActionEventArtifactState(
+        source_conversations=4,
+        materialized_conversations=4,
+        materialized_rows=10,
+        fts_rows=10,
+        orphan_rows=2,
+    )
+
+    row_status = state.row_status()
+
+    assert state.rows_ready is False
+    assert state.fts_ready is True
+    assert state.repair_item_count == 2
+    assert state.repair_detail() == (
+        "Action-event read model pending (2 orphan action-event rows)"
+    )
+    assert row_status.ready is False
+    assert row_status.orphan_rows == 2
+    assert "orphan rows 2" in row_status.detail
+
+
 def test_build_action_statuses_marks_extra_fts_rows_as_stale() -> None:
     statuses = build_action_statuses(
         {

--- a/tests/unit/storage/test_raw_ingest_artifacts.py
+++ b/tests/unit/storage/test_raw_ingest_artifacts.py
@@ -18,16 +18,24 @@ from polylogue.types import ValidationStatus
 
 def test_raw_ingest_artifact_state_classifies_quarantine_and_backlogs() -> None:
     passed_unparsed = RawIngestArtifactState(validation_status=ValidationStatus.PASSED)
-    failed_unparsed = RawIngestArtifactState(validation_status=ValidationStatus.FAILED)
+    failed_schema_unparsed = RawIngestArtifactState(validation_status=ValidationStatus.FAILED)
+    failed_parse_unparsed = RawIngestArtifactState(
+        validation_status=ValidationStatus.FAILED,
+        parse_error="Malformed JSONL lines: 1",
+    )
     unvalidated_parsed = RawIngestArtifactState(parsed_at="2026-04-13T00:00:00Z")
 
     assert passed_unparsed.needs_validation_backlog() is False
     assert passed_unparsed.needs_parse_backlog() is True
     assert passed_unparsed.quarantined is False
 
-    assert failed_unparsed.needs_validation_backlog() is False
-    assert failed_unparsed.needs_parse_backlog() is False
-    assert failed_unparsed.quarantined is True
+    assert failed_schema_unparsed.needs_validation_backlog() is False
+    assert failed_schema_unparsed.needs_parse_backlog() is False
+    assert failed_schema_unparsed.quarantined is False
+
+    assert failed_parse_unparsed.needs_validation_backlog() is False
+    assert failed_parse_unparsed.needs_parse_backlog() is False
+    assert failed_parse_unparsed.quarantined is True
 
     assert unvalidated_parsed.needs_validation_backlog() is False
     assert unvalidated_parsed.needs_parse_backlog() is False

--- a/tests/unit/storage/test_repair.py
+++ b/tests/unit/storage/test_repair.py
@@ -12,10 +12,11 @@ def _status(
     pending_documents: int = 0,
     pending_rows: int = 0,
     stale_rows: int = 0,
+    orphan_rows: int = 0,
 ) -> DerivedModelStatus:
     return DerivedModelStatus(
         name="test",
-        ready=pending_documents == 0 and pending_rows == 0 and stale_rows == 0,
+        ready=pending_documents == 0 and pending_rows == 0 and stale_rows == 0 and orphan_rows == 0,
         detail="",
         source_documents=source_documents,
         materialized_documents=materialized_documents,
@@ -23,6 +24,7 @@ def _status(
         pending_documents=pending_documents,
         pending_rows=pending_rows,
         stale_rows=stale_rows,
+        orphan_rows=orphan_rows,
     )
 
 
@@ -53,6 +55,23 @@ def test_action_event_repair_detail_reports_missing_and_stale_rows() -> None:
     assert repair_mod.action_event_repair_count(statuses) == 26
     assert repair_mod._action_event_repair_detail(statuses) == (
         "Action-event read model pending (12 missing conversations, 5 stale action-event rows, 9 pending action-event FTS rows)"
+    )
+
+
+def test_action_event_repair_detail_reports_orphan_rows() -> None:
+    statuses = {
+        "action_events": _status(
+            source_documents=4,
+            materialized_documents=4,
+            materialized_rows=10,
+            orphan_rows=2,
+        ),
+        "action_events_fts": _status(materialized_rows=10),
+    }
+
+    assert repair_mod.action_event_repair_count(statuses) == 2
+    assert repair_mod._action_event_repair_detail(statuses) == (
+        "Action-event read model pending (2 orphan action-event rows)"
     )
 
 


### PR DESCRIPTION
## Summary

PR 9/9. Stacked on `feature/refactor/stack-08-final-unification`.

Trailing runtime semantic fixes discovered after the substrate wave landed. Three fixes that share one semantic unit: raw records have two distinct failure modes (decode vs validation), and every writer/reader honors the split.

## Problem

Three tangled defects surfaced when the live archive was revalidated against the new semantics:

- **Stale validation state for parseable raws.** Strict schema-invalid raws were being persisted as `parse_error` / quarantine failures. The validation runtime was conflating "payload cannot be decoded" with "payload decoded but failed strict schema checks". Parseable raws that happened to fail strict schema validation showed up as permanently unparsed and unreachable to force-reparse planning.
- **Action-event orphan rows not counted.** Orphan rows were already measured and surfaced, but they did not participate in repair readiness, debt accounting, or repair detail. The readiness derived from row counts could report `ok` while repair would still report work.
- **Verifier decode-error detail lost.** `verify_raw_corpus` flattened decode errors to generic exception class names, while the live validation service preserved the real decode error text. The two surfaces disagreed on what "malformed JSONL" looked like.

Live state before the fixes: 12,524 total raws, 3 unparsed (2 parseable-but-validation-failed, 1 genuinely malformed, plus 1 hidden zero-byte Codex session exposed once the stale pair was resolved).

## Solution

- **Split raw parse failure from validation failure** (`polylogue/pipeline/services/validation_runtime.py`, `validation_flow.py`, `ingest_worker.py`, `ingest_batch.py`, `stage_models.py`, `polylogue/storage/raw_ingest_artifacts.py`). Only real decode/parse/transform failures now set `parse_error` and quarantine a raw; schema-invalid-but-decodable payloads stay in `validation_status = failed` without becoming parse failures. `_ValidationOutcome` dataclass and persisted batch outcomes carry the split explicitly.
- **Count action-event orphan rows in repair readiness** (`polylogue/storage/action_event_artifacts.py`, `tests/unit/storage/test_action_event_artifacts.py`, `tests/unit/storage/test_repair.py`). Orphan rows now participate in derived readiness, debt totals, and repair detail.
- **Preserve decode error detail in schema quarantine** (`polylogue/schemas/verification_corpus.py`, `tests/unit/core/test_schema_validation.py`). The verifier now carries the real decode error text from the live validation service instead of flattening to exception class names. Adds the missing direct regression test for empty-raw quarantine.

## Verification

- `pytest -q tests/unit/pipeline/test_ingest_batch.py tests/unit/storage/test_raw_ingest_artifacts.py tests/unit/storage/test_action_event_artifacts.py tests/unit/storage/test_repair.py tests/unit/storage/test_derived_status.py tests/unit/pipeline/test_parsing_service.py tests/unit/pipeline/test_run_sources.py tests/unit/core/test_schema_validation.py tests/unit/pipeline/test_prepare_records.py tests/unit/pipeline/test_resilience.py` → 170 passed
- `ruff check polylogue/pipeline/services/validation_runtime.py polylogue/pipeline/services/validation_flow.py polylogue/pipeline/services/ingest_worker.py polylogue/pipeline/services/ingest_batch.py polylogue/pipeline/stage_models.py polylogue/storage/raw_ingest_artifacts.py polylogue/storage/action_event_artifacts.py polylogue/schemas/verification_corpus.py`
- Live repair pass: 2 stale raws rewritten to `parsed`, 1 malformed raw quarantined with detailed decode error, 1 zero-byte Codex session explicitly quarantined. Final live state: 12,524 raws / 12,522 parsed / 2 intentional quarantines.

Commits on this branch: 3 (delta against `feature/refactor/stack-08-final-unification`).

## Stack

Base: `feature/refactor/stack-08-final-unification`. This is the last PR in the stacked series.
