### PR TITLE
docs: add agent workflow rules and verification gate documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,61 @@ AI chat export archiver — ingests Claude, ChatGPT, Codex, Gemini exports into 
 - Archive writes are idempotent by content hash. User metadata (tags, summaries)
   is excluded from the hash — changing it does not trigger re-import.
 
+## Agent Workflow
+
+Rules for AI agents working on this repository. These override default
+agent behavior.
+
+### Issue-first for non-trivial work
+
+Open an issue before starting work that is non-trivial, spans multiple
+PRs, or introduces architectural decisions. The issue defines scope and
+acceptance criteria. Reference it from the PR with `Ref #NNN` or
+`Closes #NNN`.
+
+### Verification before push
+
+Run `devtools verify` (full, with pytest) before creating any PR. The
+git hooks enforce format and lint on commit and `devtools verify --quick`
+on push, but the full baseline must pass before the PR is opened.
+
+Do not treat CI as the first verification pass. Anticipate failures
+locally.
+
+### PR body discipline
+
+The PR template requires sections: Summary, Problem, Solution,
+Verification. Fill all of them. The PR title becomes the squash-merge
+commit subject on `master` — write it as the permanent history line.
+
+Rules for the squash-merge subject:
+
+- Under 72 characters.
+- Conventional prefix (`feat:`, `fix:`, `refactor:`, `test:`, `chore:`,
+  `perf:`, `docs:`).
+- Describes what changed, not what was worked on.
+- Accurate — do not claim alignment, unification, or convergence unless
+  the code actually achieves it.
+
+Rules for the squash-merge body (PR description):
+
+- Problem: why the work was necessary.
+- Solution: what was done, key modules and contracts touched.
+- Verification: exact commands run, not "tests pass."
+
+### Claim verification
+
+Before writing a commit message or PR body that claims something is
+aligned, unified, converged, or complete — verify the claim against the
+code. Grep for duplicated logic, check both paths, read the diff. A
+claim that doesn't match the code is worse than no claim.
+
+### Issue and PR writing quality
+
+Issues and PR bodies are durable artifacts. Write them for a reader who
+has no conversation context — they should stand alone. Include file
+paths, acceptance criteria, and design references where applicable.
+
 @CONTRIBUTING.md
 @TESTING.md
 @docs/architecture.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,9 +34,16 @@ devtools render-all
 All code changes land through feature branches and squash-merged pull requests
 targeting `master`.
 
-1. Create a branch from `origin/master`.
-2. Push the branch and open a pull request.
-3. Squash-merge the pull request into `master`.
+1. Open an issue first when the work is non-trivial, spans multiple PRs,
+   or introduces architectural decisions. Skip for self-contained fixes.
+2. Create a branch from `origin/master`.
+3. Work on the branch. Git hooks enforce format and lint on commit, and
+   run `devtools verify --quick` on push.
+4. Run `devtools verify` (full, with pytest) before creating the PR.
+5. Open a pull request. The template has required sections — fill them
+   all in. The PR title becomes the squash-merge subject on `master`.
+6. CI must pass. Fix failures on the branch, do not merge with red CI.
+7. Squash-merge the pull request into `master`.
 
 ## Branch Naming
 
@@ -160,12 +167,24 @@ The repository should stay aligned with the workflow above:
 
 ## Verification Baseline
 
-For most code changes:
+The devshell installs git hooks automatically (`core.hooksPath .githooks`):
+
+- **pre-commit**: `ruff format --check` + `ruff check` on staged files.
+- **pre-push**: `devtools verify --quick` (format + lint + render-all --check).
+
+Before creating a PR, run the full baseline:
 
 ```bash
-pytest -q --ignore=tests/integration
-ruff check polylogue tests devtools
+devtools verify            # format + lint + render-all --check + pytest
+```
+
+Or manually:
+
+```bash
+ruff format --check polylogue/ tests/ devtools/
+ruff check polylogue/ tests/ devtools/
 devtools render-all --check
+pytest -q --ignore=tests/integration
 ```
 
 Add `devtools build-package` or `nix flake check` when touching packaging or


### PR DESCRIPTION
## Summary

Codify the workflow discipline rules learned in this session into
CLAUDE.md and CONTRIBUTING.md so they survive across sessions.

## Problem

Agent workflow failures (unformatted code pushed, PR bodies missing
required sections, claims not matching code) kept recurring because
the rules existed only in conversation feedback, not in the project's
governance documents. Each new session starts without that context.

## Solution

**CLAUDE.md** — new "Agent Workflow" section with rules that override
default agent behavior:

- Issue-first for non-trivial work
- `devtools verify` before any PR (not after CI fails)
- PR body must fill all template sections (Summary, Problem, Solution,
  Verification)
- Squash-merge subject rules (under 72 chars, conventional, accurate)
- Claim verification: grep for duplicated logic before claiming
  alignment/unification
- Issues and PRs are durable artifacts, write them standalone

**CONTRIBUTING.md** — updated to reflect the full lifecycle:

- Workflow section: issue → branch → hooks → verify → PR → CI → merge
  (was just branch → push → merge)
- Verification baseline: documents git hooks and `devtools verify`

## Verification

```
devtools verify --quick    # format + lint + render-all --check
```

No code changes, only documentation.
