### PR TITLE
fix(test): stabilize flaky terminal snapshot error-consistency test

### DIFF
--- a/tests/unit/cli/test_terminal_snapshots.py
+++ b/tests/unit/cli/test_terminal_snapshots.py
@@ -139,9 +139,9 @@ class TestPlainModeConsistency:
         assert "Usage:" in pty_text or "usage:" in pty_text
 
     def test_error_consistency_across_modes(self):
-        """Verify error output is consistent."""
-        result = run_in_pty(["invalid-xyz"])
+        """Verify Click's unknown-subcommand error is rendered in the PTY."""
+        result = run_in_pty(["run", "invalid-xyz"])
         assert result.exit_code != 0
 
         error_text = grid_to_text(result.grid)
-        assert len(error_text) > 0
+        assert "No such command 'invalid-xyz'" in error_text


### PR DESCRIPTION
## Summary

Fix `tests/unit/cli/test_terminal_snapshots.py::TestPlainModeConsistency::test_error_consistency_across_modes`, which was intermittently timing out on CI and locally.

## Problem

The test invoked `polylogue invalid-xyz` expecting Click's immediate "unknown command" error. But the polylogue CLI is query-first — any bare token that isn't a known subcommand is interpreted as a search query. The call therefore routed through the full query-mode pipeline:

- Async archive init
- Aiosqlite worker thread spin-up
- Schema readiness check
- FTS consistency check
- Executing the search

On a fresh archive this takes ~9s (mostly Python import + cold SQLite init). On a stale FTS index it can take 60s+. The PTY harness has a 30s timeout, so the test would intermittently fail on slower CI runners or under contention.

The assertion was also weak: just `exit_code != 0` and non-empty output, which happens to be satisfied by query-mode's "no results" path too — masking the fact that the test was hitting an unintended code path.

Tracked as #200.

## Solution

Route the test through a known subcommand (`run`) whose children are the real target for Click's unknown-subcommand error:

```py
result = run_in_pty(["run", "invalid-xyz"])
assert result.exit_code != 0
assert "No such command 'invalid-xyz'" in error_text
```

`polylogue run invalid-xyz` triggers Click's standard error handler immediately — the entire PTY invocation completes in ~2s wall time (mostly Python startup), well under the 30s timeout. The new assertion checks the specific error string, so the test fails deterministically if query mode ever leaks back in.

No production-code change. This is a pure test correctness fix: the test now verifies what it always claimed to verify.

## Verification

```
# 5 consecutive runs of the previously flaky test
for i in 1..5; do
  nix develop -c pytest tests/unit/cli/test_terminal_snapshots.py::TestPlainModeConsistency::test_error_consistency_across_modes -v
done
# 5/5 PASSED in ~10s each

# Full terminal_snapshots suite
nix develop -c pytest tests/unit/cli/test_terminal_snapshots.py -v
# 10 passed in 10.71s

# Full verification baseline
nix develop -c devtools verify
# ruff format ok, ruff check ok, render-all ok, pytest ok (263s)
```

Closes #200
