### PR TITLE
test: promote quarantine raws to regression fixtures

### DIFF
--- a/tests/unit/pipeline/test_quarantine_fixtures.py
+++ b/tests/unit/pipeline/test_quarantine_fixtures.py
@@ -1,0 +1,262 @@
+"""Synthetic regression fixtures for known quarantine shapes.
+
+The live archive has recurring quarantine cases that the operator brief
+documents but that were not previously captured as automated tests.
+Two patterns dominate:
+
+1. **Zero-length source file** — the export file exists but has 0 bytes.
+   Typical for interrupted Codex session writes. The decoder surfaces
+   ``Input is a zero-length, empty document``. The raw id for a real
+   zero-length blob is the SHA-256 of the empty string
+   (``e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855``).
+
+2. **Malformed JSONL mid-stream** — the JSONL export is mostly well-formed
+   but a single record has invalid JSON (missing comma, unbalanced brace,
+   etc.). In STRICT validation mode this surfaces as
+   ``Malformed JSONL lines: N (first bad line X: <detail>)``.
+
+These tests pin the quarantine contract: ``ingest_record`` must produce
+``error``/``parse_error`` in both cases, and when the result is
+persisted via ``mark_raw_parsed`` the raw conversation lands in a
+quarantined state (``parsed_at is None AND parse_error is not None``).
+
+If the quarantine policy ever shifts — say a future decoder starts
+tolerating empty blobs silently, or JSONL validation relaxes out of
+STRICT by default — these tests fail loudly so the regression is
+visible at PR time, not after a live archive run silently drops data.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from polylogue.pipeline.services.ingest_worker import ingest_record
+from polylogue.storage.blob_store import get_blob_store
+from polylogue.storage.raw_ingest_artifacts import RawIngestArtifactState
+from polylogue.storage.state_views import RawConversationState
+from polylogue.types import ValidationStatus
+
+EMPTY_SHA256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+
+def _make_raw_record(content: bytes, provider: str, path: str):
+    """Store ``content`` in the blob store and wrap a RawConversationRecord."""
+    from polylogue.storage.store import RawConversationRecord
+
+    raw_id, size = get_blob_store().write_from_bytes(content)
+    now = datetime.now(timezone.utc).isoformat()
+    return RawConversationRecord(
+        raw_id=raw_id,
+        provider_name=provider,
+        source_name="quarantine-fixture",
+        source_path=path,
+        source_index=None,
+        blob_size=size,
+        acquired_at=now,
+        file_mtime=now,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Synthetic fixtures — the shape, not the bytes, of real quarantine cases.
+# ---------------------------------------------------------------------------
+
+
+def zero_length_bytes() -> bytes:
+    """Zero-length export body. SHA-256 matches EMPTY_SHA256."""
+    return b""
+
+
+def claude_code_malformed_jsonl_bytes() -> bytes:
+    """Valid claude-code JSONL with one record that has a missing comma.
+
+    Structure: two well-formed records surrounding one bad record. The
+    bad record drops the comma between ``parentUuid`` and ``type``,
+    yielding ``unexpected character`` at the point the decoder expects
+    either a comma or the object's closing brace.
+    """
+    good_a = (
+        b'{"parentUuid":null,"type":"user",'
+        b'"message":{"role":"user","content":"hello"},'
+        b'"uuid":"m1","timestamp":"2025-01-01T00:00:00Z"}'
+    )
+    bad = (
+        b'{"parentUuid":null '  # <- missing comma here
+        b'"type":"user",'
+        b'"message":{"role":"user","content":"bad"},'
+        b'"uuid":"m2","timestamp":"2025-01-01T00:00:01Z"}'
+    )
+    good_b = (
+        b'{"parentUuid":"m1","type":"assistant",'
+        b'"message":{"role":"assistant","content":[{"type":"text","text":"hi"}]},'
+        b'"uuid":"m3","timestamp":"2025-01-01T00:00:02Z"}'
+    )
+    return good_a + b"\n" + bad + b"\n" + good_b + b"\n"
+
+
+def codex_malformed_jsonl_bytes() -> bytes:
+    """Valid codex JSONL with one record that is not valid JSON.
+
+    Codex sessions are JSONL with a ``session_meta`` envelope followed
+    by ``message`` records. A missing closing brace in a ``message``
+    record is a realistic corruption shape.
+    """
+    meta = b'{"type":"session_meta","payload":{"id":"session-x","timestamp":"2025-01-01T00:00:00Z"}}'
+    good = (
+        b'{"type":"message","id":"msg-1","role":"user",'
+        b'"timestamp":"2025-01-01T00:00:01Z",'
+        b'"content":[{"type":"input_text","text":"ping"}]}'
+    )
+    bad = (
+        b'{"type":"message","id":"msg-2","role":"assistant",'
+        b'"timestamp":"2025-01-01T00:00:02Z"'  # <- missing closing brace + comma
+        b'"content":[{"type":"output_text","text":"pong"}]'
+    )
+    return meta + b"\n" + good + b"\n" + bad + b"\n"
+
+
+# ---------------------------------------------------------------------------
+# Zero-length quarantine
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "provider,source_path",
+    [
+        ("codex", "/exports/codex-session.jsonl"),
+        ("claude-code", "/exports/claude-code-session.jsonl"),
+        ("chatgpt", "/exports/chatgpt.json"),
+        ("gemini", "/exports/gemini.json"),
+    ],
+)
+def test_zero_length_blob_quarantines_across_providers(tmp_path: Path, provider: str, source_path: str) -> None:
+    """Every provider produces a decoder-level quarantine on zero-length input.
+
+    The error originates in ``build_raw_payload_envelope`` and surfaces
+    identically regardless of provider — it's a pre-parser failure that
+    all provider paths share. Contract: ``error`` and ``parse_error``
+    set, ``validation_status == FAILED``, no conversations produced.
+    """
+    record = _make_raw_record(zero_length_bytes(), provider, source_path)
+    assert record.raw_id == EMPTY_SHA256
+
+    result = ingest_record(record, str(tmp_path / "archive"), "strict")
+
+    assert result.error is not None
+    assert result.parse_error is not None
+    assert "zero-length" in result.error
+    assert result.parse_error == result.error
+    assert result.validation_status == ValidationStatus.FAILED.value
+    assert result.conversations == []
+
+
+def test_zero_length_blob_quarantine_survives_non_strict_mode(tmp_path: Path) -> None:
+    """Zero-length input fails even with validation OFF — it's a decoder error.
+
+    The STRICT/OFF distinction governs schema validation, not blob
+    decoding. An empty document has no bytes to parse, so the error
+    fires before any validation step runs.
+    """
+    record = _make_raw_record(zero_length_bytes(), "codex", "/exports/codex.jsonl")
+    result = ingest_record(record, str(tmp_path / "archive"), "off")
+
+    assert result.error is not None
+    assert "zero-length" in result.error
+    assert result.parse_error is not None
+
+
+# ---------------------------------------------------------------------------
+# Malformed JSONL quarantine
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "provider,fixture",
+    [
+        ("claude-code", claude_code_malformed_jsonl_bytes),
+        ("codex", codex_malformed_jsonl_bytes),
+    ],
+)
+def test_malformed_jsonl_mid_stream_quarantines_in_strict_mode(tmp_path: Path, provider: str, fixture) -> None:
+    """Stream-record providers quarantine a single malformed JSONL record.
+
+    Under STRICT validation, even a single bad line triggers the
+    ``Malformed JSONL lines: N (first bad line X: ...)`` quarantine.
+    The envelope records ``malformed_jsonl_lines`` during sampling and
+    surfaces it as a parse error rather than silently dropping data.
+    """
+    record = _make_raw_record(fixture(), provider, f"/exports/{provider}.jsonl")
+    result = ingest_record(record, str(tmp_path / "archive"), "strict")
+
+    assert result.error is not None, "malformed JSONL must surface an error in STRICT mode"
+    assert result.error.startswith("Malformed JSONL lines:")
+    assert result.parse_error == result.error
+    assert result.validation_status == ValidationStatus.FAILED.value
+    assert result.conversations == []
+
+
+def test_malformed_jsonl_tolerated_in_validation_off_mode(tmp_path: Path) -> None:
+    """With validation disabled, well-formed records around a bad line still parse.
+
+    STRICT is the only mode that promotes malformed-line detection to a
+    fatal parse error. With validation OFF the bad line is silently
+    skipped and the surrounding records produce one conversation. This
+    test pins that asymmetry so a future "always strict" change would
+    fail here rather than silently break the OFF contract.
+    """
+    record = _make_raw_record(
+        claude_code_malformed_jsonl_bytes(),
+        "claude-code",
+        "/exports/claude-code.jsonl",
+    )
+    result = ingest_record(record, str(tmp_path / "archive"), "off")
+
+    assert result.error is None
+    assert result.conversations, "valid surrounding records should still parse"
+
+
+# ---------------------------------------------------------------------------
+# Persistence lifecycle — ingest_record → mark_raw_parsed → quarantined
+# ---------------------------------------------------------------------------
+
+
+async def test_quarantine_state_round_trip_through_mark_raw_parsed(tmp_path: Path) -> None:
+    """Persisting an ingest error leaves the raw row in a quarantined state.
+
+    Quarantine = ``parsed_at is None AND parse_error is not None`` (see
+    ``RawIngestArtifactState.quarantined``). Verifies the full lifecycle:
+    ``ingest_record`` surfaces the error, ``mark_raw_parsed`` persists it,
+    ``RawConversationState`` round-trips, and the derived artifact state
+    classifies the row as quarantined.
+    """
+    from polylogue.storage.backends.async_sqlite import SQLiteBackend
+
+    record = _make_raw_record(zero_length_bytes(), "codex", "/exports/codex.jsonl")
+
+    result = ingest_record(record, str(tmp_path / "archive"), "strict")
+    assert result.error is not None
+
+    backend = SQLiteBackend(db_path=tmp_path / "archive.db")
+    try:
+        await backend.save_raw_conversation(record)
+        await backend.mark_raw_parsed(record.raw_id, error=result.error)
+
+        stored = await backend.get_raw_conversation(record.raw_id)
+        assert stored is not None
+        assert stored.parse_error is not None
+        assert stored.parsed_at is None
+
+        state = RawIngestArtifactState.from_state(
+            RawConversationState(
+                raw_id=stored.raw_id,
+                parsed_at=stored.parsed_at,
+                parse_error=stored.parse_error,
+            )
+        )
+        assert state.quarantined is True
+        assert state.parsed is False
+    finally:
+        await backend.close()


### PR DESCRIPTION
## Summary

Add synthetic regression fixtures that pin the quarantine contract for two real-world failure shapes observed in the live archive.

## Problem

Two raw conversations in the live archive are durable quarantine cases observed in the live archive but not captured as automated tests:

- **Zero-length export** — raw id `e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855` (SHA-256 of empty string). An interrupted session write leaves a 0-byte file that fails decoding.
- **Malformed JSONL mid-stream** — raw id `57399b8676d88e84698827874e6f7cee6700f8138841ca058205af05cc73fd7e`. The JSONL file is mostly valid but one record contains invalid JSON (missing comma).

If quarantine policy ever shifts — decoder tolerates empty blobs silently, JSONL validation relaxes out of STRICT by default, or `mark_raw_parsed` changes how it records failures — these cases would regress silently on live archive runs.

Tracked as #201.

## Solution

New test file `tests/unit/pipeline/test_quarantine_fixtures.py` with synthetic fixtures matching the structural shape of the real failures (no real data copied, just the JSON shape that triggers the same code path).

### Fixtures

- `zero_length_bytes()` — empty bytes; raw id equals `EMPTY_SHA256` constant.
- `claude_code_malformed_jsonl_bytes()` — three claude-code JSONL records, the middle one missing a comma between `parentUuid` and `type`.
- `codex_malformed_jsonl_bytes()` — codex JSONL with session_meta, one good message, one message missing a closing brace.

### Tests

- **zero-length across all providers** (parametrized: chatgpt, claude-code, codex, gemini) — every provider's path surfaces `decode: Input is a zero-length, empty document` because the failure originates in the shared `build_raw_payload_envelope` before any provider-specific parsing.
- **zero-length survives validation OFF** — the decoder error fires before schema validation, so the STRICT/OFF mode distinction doesn't apply.
- **malformed JSONL under STRICT** (parametrized: claude-code, codex) — `Malformed JSONL lines: N (first bad line X: ...)` quarantine for stream-record providers.
- **malformed JSONL tolerated under OFF** — pins the asymmetry: OFF mode parses valid surrounding records, STRICT quarantines. A future "always strict" change would fail here visibly.
- **persistence round trip** — `ingest_record` error → `mark_raw_parsed` → `RawConversationState.parse_error` set, `parsed_at` null → `RawIngestArtifactState.quarantined is True`.

No production code change. The new tests only observe existing behavior.

## Verification

```
# New file in isolation
nix develop -c pytest tests/unit/pipeline/test_quarantine_fixtures.py -v
# 9 passed in 8.96s

# Full baseline
nix develop -c devtools verify
# format ok, lint ok, render-all ok, pytest ok
```

Closes #201
