### PR TITLE
chore: clean 3 single-error mypy files, add types-PyYAML stubs

### DIFF
--- a/polylogue/cli/commands/check.py
+++ b/polylogue/cli/commands/check.py
@@ -93,7 +93,7 @@ def check_command(
     render_plain_output(env, result, options)
 
 
-def _make_schema_progress_callback():
+def _make_schema_progress_callback() -> Any:
     return _make_schema_progress_callback_impl()
 
 

--- a/polylogue/mcp/server.py
+++ b/polylogue/mcp/server.py
@@ -60,7 +60,7 @@ def build_server() -> FastMCP:
         get_repo=lambda: _get_repo(),
         get_config=lambda: _get_config(),
         get_archive_ops=lambda: _get_archive_ops(),
-        extract_fenced_code=lambda text, language="": _extract_fenced_code(text, language),
+        extract_fenced_code=_extract_fenced_code,
     )
     register_tools(mcp, hooks)
     register_resources(mcp, hooks)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ dev = [
   "pyte>=0.8.0",  # Terminal emulator for deterministic output snapshot tests
   "mutmut>=3.0.0",  # Mutation testing for coverage verification
   "mypy>=1.17,<1.18",
+  "types-PyYAML>=6.0",  # yaml library stubs for mypy
   "ruff>=0.1.0",
   "pre-commit>=3.5.0",
 ]
@@ -164,7 +165,6 @@ exclude = [
   "polylogue/archive_product_rollups\\.py$",
   "polylogue/archive_product_summaries\\.py$",
   "polylogue/archive_products\\.py$",
-  "polylogue/cli/commands/check\\.py$",
   "polylogue/cli/commands/generate\\.py$",
   "polylogue/cli/commands/products\\.py$",
   "polylogue/cli/commands/run\\.py$",
@@ -206,7 +206,6 @@ exclude = [
   "polylogue/lib/session_profile_models\\.py$",
   "polylogue/lib/threads\\.py$",
   "polylogue/lib/work_event_extraction\\.py$",
-  "polylogue/mcp/server\\.py$",
   "polylogue/mcp/server_maintenance_tools\\.py$",
   "polylogue/mcp/server_product_tools\\.py$",
   "polylogue/mcp/server_prompts\\.py$",
@@ -233,7 +232,6 @@ exclude = [
   "polylogue/products/registry\\.py$",
   "polylogue/protocols\\.py$",
   "polylogue/rendering/core_formatter\\.py$",
-  "polylogue/rendering/formatting\\.py$",
   "polylogue/rendering/renderers/html\\.py$",
   "polylogue/scenarios/assertions\\.py$",
   "polylogue/scenarios/execution\\.py$",

--- a/uv.lock
+++ b/uv.lock
@@ -1384,6 +1384,7 @@ dev = [
     { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "syrupy" },
+    { name = "types-pyyaml" },
 ]
 fuzz = [
     { name = "atheris" },
@@ -1470,6 +1471,7 @@ requires-dist = [
     { name = "tree-sitter-rust", marker = "extra == 'tree-sitter'", specifier = ">=0.21.0" },
     { name = "tree-sitter-typescript", marker = "extra == 'tree-sitter'", specifier = ">=0.21.0" },
     { name = "tree-sitter-yaml", marker = "extra == 'tree-sitter'", specifier = ">=0.6.0" },
+    { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
 ]
 provides-extras = ["dev", "ocr", "fuzz", "tree-sitter"]
 
@@ -2749,6 +2751,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6c/e7/9525defa7b30792623f56b1fba9bbba361752348875b165b8975b87398fd/tree_sitter_yaml-0.7.2-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:74ca712c50fc9d7dbc68cb36b4a7811d6e67a5466b5a789f19bf8dd6084ef752", size = 90455, upload-time = "2025-10-07T14:40:33.778Z" },
     { url = "https://files.pythonhosted.org/packages/4a/d6/8d1e1ace03db3b02e64e91daf21d1347941d1bbecc606a5473a1a605250d/tree_sitter_yaml-0.7.2-cp310-abi3-win_amd64.whl", hash = "sha256:7587b5ca00fc4f9a548eff649697a3b395370b2304b399ceefa2087d8a6c9186", size = 45514, upload-time = "2025-10-07T14:40:34.562Z" },
     { url = "https://files.pythonhosted.org/packages/d8/c7/dcf3ea1c4f5da9b10353b9af4455d756c92d728a8f58f03c480d3ef0ead5/tree_sitter_yaml-0.7.2-cp310-abi3-win_arm64.whl", hash = "sha256:f63c227b18e7ce7587bce124578f0bbf1f890ac63d3e3cd027417574273642c4", size = 44065, upload-time = "2025-10-07T14:40:35.337Z" },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20260408"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/73/b759b1e413c31034cc01ecdfb96b38115d0ab4db55a752a3929f0cd449fd/types_pyyaml-6.0.12.20260408.tar.gz", hash = "sha256:92a73f2b8d7f39ef392a38131f76b970f8c66e4c42b3125ae872b7c93b556307", size = 17735, upload-time = "2026-04-08T04:30:50.974Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/f0/c391068b86abb708882c6d75a08cd7d25b2c7227dab527b3a3685a3c635b/types_pyyaml-6.0.12.20260408-py3-none-any.whl", hash = "sha256:fbc42037d12159d9c801ebfcc79ebd28335a7c13b08a4cfbc6916df78fee9384", size = 20339, upload-time = "2026-04-08T04:30:50.113Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Three excluded files each carrying a single mypy error — cleaned and promoted into the gate. Gate grows from 389 → 392 files under `mypy --strict`.

## Problem

From running mypy against the full exclude list, 29 files had exactly one reported error. These three resolved without cascade work:

1. `polylogue/cli/commands/check.py:96` — `_make_schema_progress_callback()` wrapper missing return annotation, but the underlying impl in `check_support.py` explicitly returns `Any`.
2. `polylogue/mcp/server.py:63` — `extract_fenced_code=lambda text, language="": _extract_fenced_code(text, language)`. Mypy could not infer the lambda against `Callable[[str, str], list[dict[str, str]]]` when a default argument was involved.
3. `polylogue/rendering/formatting.py:107` — `import yaml` raised `import-untyped` because PyYAML stubs were never declared.

## Solution

- `check.py`: annotate the wrapper as `-> Any` to propagate the impl's declared return.
- `server.py`: drop the forwarding lambda and pass `_extract_fenced_code` directly — signatures match exactly.
- `pyproject.toml`: add `types-PyYAML>=6.0` to the `dev` extra. Re-lock `uv.lock`. The source file needed no change.

## Verification

- `nix develop -c mypy --config-file pyproject.toml polylogue/` — `Success: no issues found in 392 source files`
- `nix develop -c devtools verify --quick` — all checks passed (format, lint, mypy, render-all --check)
- Pre-push hook (`devtools verify --quick`) passed

Full `devtools verify` (with pytest) deferred to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
