### PR TITLE
fix: tighten None/Optional narrowing in 3 mypy-excluded files

### DIFF
--- a/polylogue/lib/action_event_parsing.py
+++ b/polylogue/lib/action_event_parsing.py
@@ -82,7 +82,10 @@ def build_tool_calls_from_content_blocks(
         normalized_input = _normalized_mapping(block.get("tool_input"))
         semantic_category = _tool_category_from_semantic(block.get("semantic_type"))
         classified_category = classify_tool(name, normalized_input)
-        category = classified_category if semantic_category in (None, ToolCategory.OTHER) else semantic_category
+        if semantic_category is None or semantic_category is ToolCategory.OTHER:
+            category = classified_category
+        else:
+            category = semantic_category
         raw = {
             "block_id": block.get("block_id"),
             "block_index": block.get("block_index"),

--- a/polylogue/lib/phase_extraction.py
+++ b/polylogue/lib/phase_extraction.py
@@ -60,10 +60,11 @@ def _build_phase(
     if start_time and end_time:
         duration_ms = max(int((end_time - start_time).total_seconds() * 1000), 0)
 
+    ref_time = start_time or end_time
     return SessionPhase(
         start_time=start_time,
         end_time=end_time,
-        canonical_session_date=(start_time or end_time).date() if (start_time or end_time) else None,
+        canonical_session_date=ref_time.date() if ref_time else None,
         message_range=(start_idx, end_idx),
         duration_ms=duration_ms,
         tool_counts=dict(tool_counts),

--- a/polylogue/ui/facade_prompts.py
+++ b/polylogue/ui/facade_prompts.py
@@ -6,12 +6,16 @@ import json
 import sys
 from collections import deque
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from polylogue.ui.facade import UIError
 
 _NO_STUB_RESPONSE = object()
 
 
 def load_prompt_responses(
-    ui_error_cls: type[Exception],
+    ui_error_cls: type[UIError],
     *,
     prompt_stub_path: Path | None = None,
 ) -> deque[dict[str, object]]:
@@ -34,7 +38,7 @@ def load_prompt_responses(
 def pop_prompt_response(
     prompt_responses: deque[dict[str, object]],
     kind: str,
-    ui_error_cls: type[Exception],
+    ui_error_cls: type[UIError],
 ) -> dict[str, object] | None:
     if not prompt_responses:
         return None
@@ -45,7 +49,7 @@ def pop_prompt_response(
     return entry
 
 
-def require_plain_prompt_tty(prompt_topic: str, ui_error_cls: type[Exception]) -> None:
+def require_plain_prompt_tty(prompt_topic: str, ui_error_cls: type[UIError]) -> None:
     if not sys.stdin.isatty():
         raise ui_error_cls(
             f"Plain mode cannot prompt for {prompt_topic}",
@@ -57,7 +61,7 @@ def consume_confirm_stub(
     prompt_responses: deque[dict[str, object]],
     *,
     default: bool,
-    ui_error_cls: type[Exception],
+    ui_error_cls: type[UIError],
 ) -> bool | object:
     response = pop_prompt_response(prompt_responses, "confirm", ui_error_cls)
     if response is None:
@@ -79,7 +83,7 @@ def consume_confirm_stub(
 def consume_choose_stub(
     prompt_responses: deque[dict[str, object]],
     options: list[str],
-    ui_error_cls: type[Exception],
+    ui_error_cls: type[UIError],
 ) -> str | None | object:
     response = pop_prompt_response(prompt_responses, "choose", ui_error_cls)
     if response is None:
@@ -109,7 +113,7 @@ def consume_input_stub(
     prompt_responses: deque[dict[str, object]],
     *,
     default: str | None,
-    ui_error_cls: type[Exception],
+    ui_error_cls: type[UIError],
 ) -> str | None | object:
     response = pop_prompt_response(prompt_responses, "input", ui_error_cls)
     if response is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,13 +184,11 @@ exclude = [
   "polylogue/facade_archive\\.py$",
   "polylogue/facade_ingest\\.py$",
   "polylogue/facade_products\\.py$",
-  "polylogue/lib/action_event_parsing\\.py$",
   "polylogue/lib/attribution\\.py$",
   "polylogue/lib/conversation_runtime\\.py$",
   "polylogue/lib/conversation_summary_runtime\\.py$",
   "polylogue/lib/filter_builder\\.py$",
   "polylogue/lib/message_model_runtime\\.py$",
-  "polylogue/lib/phase_extraction\\.py$",
   "polylogue/lib/projection_filter_mixin\\.py$",
   "polylogue/lib/projection_terminal_mixin\\.py$",
   "polylogue/lib/projection_transform_mixin\\.py$",
@@ -332,7 +330,6 @@ exclude = [
   "polylogue/sync_product_queries\\.py$",
   "polylogue/ui/__init__\\.py$",
   "polylogue/ui/facade\\.py$",
-  "polylogue/ui/facade_prompts\\.py$",
   "polylogue/ui/facade_rendering\\.py$",
 ]
 files = [


### PR DESCRIPTION
## Summary

Three excluded files, each carrying a single mypy error that exposed a real narrowing defect (not a missing annotation). All three are now clean and promoted into the gate. Gate grows from 392 → 395 files under \`mypy --strict\`.

## Problem

- **\`polylogue/lib/phase_extraction.py:66\`** — \`(start_time or end_time).date() if (start_time or end_time) else None\`. Mypy evaluates the method call first and cannot tie the \`if\`-guard to the \`or\`-chain; \`.date()\` resolves on \`datetime | None\`.
- **\`polylogue/lib/action_event_parsing.py:106\`** — \`category = classified if semantic_category in (None, ToolCategory.OTHER) else semantic_category\`. In the else branch mypy still sees \`ToolCategory | None\` because \`x in (...)\` is not a narrowing form; but \`ToolCall.category\` is non-Optional.
- **\`polylogue/ui/facade_prompts.py:50\`** — \`ui_error_cls: type[Exception]\` with \`raise ui_error_cls(..., prompt_topic=prompt_topic)\`. \`Exception\` does not accept \`prompt_topic=\`; the real constructor signature is \`UIError\`'s.

## Solution

- **phase_extraction**: bind \`ref_time = start_time or end_time\` before the dataclass construction; use \`ref_time.date() if ref_time else None\`. Same runtime behavior, mypy-legible narrowing.
- **action_event_parsing**: rewrite as \`if semantic_category is None or semantic_category is ToolCategory.OTHER\` so mypy narrows \`semantic_category\` to \`ToolCategory\` in the else branch.
- **facade_prompts**: narrow every \`ui_error_cls\` in the module to \`type[UIError]\`. UIError is imported under \`TYPE_CHECKING\` to avoid the runtime cycle with \`polylogue.ui.facade\`. Every caller already passes UIError.

## Verification

- \`nix develop -c mypy --config-file pyproject.toml polylogue/ui/facade_prompts.py polylogue/lib/phase_extraction.py polylogue/lib/action_event_parsing.py\` — \`Success: no issues found in 3 source files\`
- \`nix develop -c devtools verify --quick\` — format, lint, mypy, render-all --check all passed
- Pre-push hook (\`devtools verify --quick\`) passed

Full \`devtools verify\` (with pytest) deferred to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
