### PR TITLE
refactor: renew schema and ingestion boundary contracts

### DIFF
--- a/polylogue/lib/raw_payload_decode.py
+++ b/polylogue/lib/raw_payload_decode.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Mapping
 from dataclasses import dataclass
 from io import BytesIO, StringIO
 from pathlib import Path
@@ -17,7 +18,7 @@ from polylogue.types import Provider
 WireFormat = Literal["json", "jsonl"]
 JSONScalar: TypeAlias = str | int | float | bool | None
 JSONValue: TypeAlias = JSONScalar | list["JSONValue"] | dict[str, "JSONValue"]
-JSONRecord: TypeAlias = dict[str, JSONValue]
+JSONRecord: TypeAlias = Mapping[str, object]
 
 
 def _coerce_json_value(value: object) -> JSONValue:

--- a/polylogue/pipeline/prepare_transform.py
+++ b/polylogue/pipeline/prepare_transform.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import cast
 
 from polylogue.lib.json import dumps as json_dumps
 from polylogue.lib.viewports import ToolCategory, classify_tool
@@ -20,7 +21,7 @@ from polylogue.pipeline.prepare_models import (
     _timestamp_sort_key,
 )
 from polylogue.pipeline.prepare_transform_content import canonicalize_conversation_content
-from polylogue.pipeline.semantic_metadata import extract_tool_metadata
+from polylogue.pipeline.semantic_metadata import ToolInputPayload, extract_tool_metadata
 from polylogue.schemas.code_detection import detect_language
 from polylogue.sources.parsers.base import ParsedConversation
 from polylogue.storage.store import (
@@ -119,7 +120,10 @@ def transform_to_records(convo: ParsedConversation, source_name: str, *, archive
                 semantic_type = (
                     None if category is ToolCategory.OTHER else SemanticBlockType.from_string(category.value)
                 )
-                tool_meta = extract_tool_metadata(block.tool_name, dict(block.tool_input or {}))
+                tool_meta = extract_tool_metadata(
+                    block.tool_name,
+                    cast(ToolInputPayload, dict(block.tool_input or {})),
+                )
                 if tool_meta is not None:
                     base = dict(block.metadata) if isinstance(block.metadata, dict) else {}
                     base.update(tool_meta)

--- a/polylogue/pipeline/semantic_capture.py
+++ b/polylogue/pipeline/semantic_capture.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
-from typing import Any, NotRequired, TypedDict, cast
+from collections.abc import Sequence
+from typing import NotRequired, TypedDict, cast
 
 from polylogue.lib.payload_coercion import is_payload_mapping, mapping_or_empty, optional_string
-from polylogue.lib.raw_payload_decode import JSONValue
-from polylogue.pipeline.semantic_metadata import _parse_git_command, _parse_subagent_spawn
+from polylogue.lib.raw_payload_decode import JSONRecord, JSONValue
+from polylogue.pipeline.semantic_metadata import ToolMetadata, _parse_git_command, _parse_subagent_spawn
 
 
 class ContextCompactionSummary(TypedDict):
@@ -27,7 +27,7 @@ class ThinkingTraceSummary(TypedDict):
 class ToolInvocationSummary(TypedDict, total=False):
     tool_name: str | None
     tool_id: str | None
-    input: Mapping[str, Any]
+    input: JSONRecord
     is_file_operation: bool
     is_search_operation: bool
     is_subagent: bool
@@ -52,6 +52,10 @@ def _json_value(value: object) -> JSONValue | None:
     return cast(JSONValue | None, value)
 
 
+def _json_record(value: object) -> JSONRecord:
+    return cast(JSONRecord, value) if isinstance(value, dict) else {}
+
+
 def _text_from_message_content(content: object) -> str:
     if isinstance(content, str):
         return content
@@ -70,7 +74,7 @@ def _summary_text(item: object) -> str:
     return _text_from_message_content(message.get("content"))
 
 
-def detect_context_compaction(item: Mapping[str, Any]) -> ContextCompactionSummary | None:
+def detect_context_compaction(item: JSONRecord) -> ContextCompactionSummary | None:
     """Detect if a raw message item represents a context compaction event."""
     msg_type = item.get("type")
 
@@ -99,7 +103,7 @@ def detect_context_compaction(item: Mapping[str, Any]) -> ContextCompactionSumma
     return None
 
 
-def extract_thinking_traces(content_blocks: Sequence[Mapping[str, Any]]) -> list[ThinkingTraceSummary]:
+def extract_thinking_traces(content_blocks: Sequence[JSONRecord]) -> list[ThinkingTraceSummary]:
     traces: list[ThinkingTraceSummary] = []
     for block in content_blocks:
         if block.get("type") != "thinking":
@@ -110,12 +114,12 @@ def extract_thinking_traces(content_blocks: Sequence[Mapping[str, Any]]) -> list
     return traces
 
 
-def extract_tool_invocations(content_blocks: Sequence[Mapping[str, Any]]) -> list[ToolInvocationSummary]:
+def extract_tool_invocations(content_blocks: Sequence[JSONRecord]) -> list[ToolInvocationSummary]:
     invocations: list[ToolInvocationSummary] = []
     for block in content_blocks:
         if block.get("type") != "tool_use":
             continue
-        input_payload = mapping_or_empty(block.get("input"))
+        input_payload = _json_record(mapping_or_empty(block.get("input")))
         invocation: ToolInvocationSummary = {
             "tool_name": optional_string(block.get("name")),
             "tool_id": optional_string(block.get("id")),
@@ -133,7 +137,7 @@ def extract_tool_invocations(content_blocks: Sequence[Mapping[str, Any]]) -> lis
     return invocations
 
 
-def parse_git_operation(tool_invocation: Mapping[str, Any]) -> dict[str, Any] | None:
+def parse_git_operation(tool_invocation: ToolInvocationSummary) -> ToolMetadata | None:
     if tool_invocation.get("tool_name") != "Bash":
         return None
     command = optional_string(mapping_or_empty(tool_invocation.get("input")).get("command"))
@@ -142,7 +146,7 @@ def parse_git_operation(tool_invocation: Mapping[str, Any]) -> dict[str, Any] | 
     return _parse_git_command(command)
 
 
-def extract_file_changes(tool_invocations: Sequence[Mapping[str, Any]]) -> list[FileChangeSummary]:
+def extract_file_changes(tool_invocations: Sequence[ToolInvocationSummary]) -> list[FileChangeSummary]:
     changes: list[FileChangeSummary] = []
     for invocation in tool_invocations:
         tool_name = invocation.get("tool_name")
@@ -171,13 +175,13 @@ def extract_file_changes(tool_invocations: Sequence[Mapping[str, Any]]) -> list[
     return changes
 
 
-def extract_subagent_spawns(tool_invocations: Sequence[Mapping[str, Any]]) -> list[SubagentSpawnSummary]:
+def extract_subagent_spawns(tool_invocations: Sequence[ToolInvocationSummary]) -> list[SubagentSpawnSummary]:
     spawns: list[SubagentSpawnSummary] = []
     for invocation in tool_invocations:
         if invocation.get("tool_name") != "Task":
             continue
         input_data = mapping_or_empty(invocation.get("input"))
-        parsed = _parse_subagent_spawn(input_data)
+        parsed = _parse_subagent_spawn(_json_record(input_data))
         agent_type = parsed.get("agent_type")
         spawns.append(
             {
@@ -190,8 +194,8 @@ def extract_subagent_spawns(tool_invocations: Sequence[Mapping[str, Any]]) -> li
     return spawns
 
 
-def extract_git_operations(tool_invocations: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
-    operations: list[dict[str, Any]] = []
+def extract_git_operations(tool_invocations: Sequence[ToolInvocationSummary]) -> list[ToolMetadata]:
+    operations: list[ToolMetadata] = []
     for invocation in tool_invocations:
         if git_op := parse_git_operation(invocation):
             operations.append(git_op)

--- a/polylogue/pipeline/semantic_capture.py
+++ b/polylogue/pipeline/semantic_capture.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from typing import NotRequired, TypedDict, cast
 
 from polylogue.lib.payload_coercion import is_payload_mapping, mapping_or_empty, optional_string
 from polylogue.lib.raw_payload_decode import JSONRecord, JSONValue
 from polylogue.pipeline.semantic_metadata import ToolMetadata, _parse_git_command, _parse_subagent_spawn
+from polylogue.schemas.json_types import JSONValue as SchemaJSONValue
 
 
 class ContextCompactionSummary(TypedDict):
@@ -56,6 +57,10 @@ def _json_record(value: object) -> JSONRecord:
     return cast(JSONRecord, value) if isinstance(value, dict) else {}
 
 
+def _tool_input_payload(value: Mapping[str, object]) -> dict[str, SchemaJSONValue]:
+    return cast(dict[str, SchemaJSONValue], dict(value))
+
+
 def _text_from_message_content(content: object) -> str:
     if isinstance(content, str):
         return content
@@ -74,7 +79,7 @@ def _summary_text(item: object) -> str:
     return _text_from_message_content(message.get("content"))
 
 
-def detect_context_compaction(item: JSONRecord) -> ContextCompactionSummary | None:
+def detect_context_compaction(item: Mapping[str, object]) -> ContextCompactionSummary | None:
     """Detect if a raw message item represents a context compaction event."""
     msg_type = item.get("type")
 
@@ -103,7 +108,7 @@ def detect_context_compaction(item: JSONRecord) -> ContextCompactionSummary | No
     return None
 
 
-def extract_thinking_traces(content_blocks: Sequence[JSONRecord]) -> list[ThinkingTraceSummary]:
+def extract_thinking_traces(content_blocks: Sequence[Mapping[str, object]]) -> list[ThinkingTraceSummary]:
     traces: list[ThinkingTraceSummary] = []
     for block in content_blocks:
         if block.get("type") != "thinking":
@@ -114,7 +119,7 @@ def extract_thinking_traces(content_blocks: Sequence[JSONRecord]) -> list[Thinki
     return traces
 
 
-def extract_tool_invocations(content_blocks: Sequence[JSONRecord]) -> list[ToolInvocationSummary]:
+def extract_tool_invocations(content_blocks: Sequence[Mapping[str, object]]) -> list[ToolInvocationSummary]:
     invocations: list[ToolInvocationSummary] = []
     for block in content_blocks:
         if block.get("type") != "tool_use":
@@ -137,7 +142,7 @@ def extract_tool_invocations(content_blocks: Sequence[JSONRecord]) -> list[ToolI
     return invocations
 
 
-def parse_git_operation(tool_invocation: ToolInvocationSummary) -> ToolMetadata | None:
+def parse_git_operation(tool_invocation: Mapping[str, object]) -> ToolMetadata | None:
     if tool_invocation.get("tool_name") != "Bash":
         return None
     command = optional_string(mapping_or_empty(tool_invocation.get("input")).get("command"))
@@ -146,7 +151,7 @@ def parse_git_operation(tool_invocation: ToolInvocationSummary) -> ToolMetadata 
     return _parse_git_command(command)
 
 
-def extract_file_changes(tool_invocations: Sequence[ToolInvocationSummary]) -> list[FileChangeSummary]:
+def extract_file_changes(tool_invocations: Sequence[Mapping[str, object]]) -> list[FileChangeSummary]:
     changes: list[FileChangeSummary] = []
     for invocation in tool_invocations:
         tool_name = invocation.get("tool_name")
@@ -175,13 +180,13 @@ def extract_file_changes(tool_invocations: Sequence[ToolInvocationSummary]) -> l
     return changes
 
 
-def extract_subagent_spawns(tool_invocations: Sequence[ToolInvocationSummary]) -> list[SubagentSpawnSummary]:
+def extract_subagent_spawns(tool_invocations: Sequence[Mapping[str, object]]) -> list[SubagentSpawnSummary]:
     spawns: list[SubagentSpawnSummary] = []
     for invocation in tool_invocations:
         if invocation.get("tool_name") != "Task":
             continue
         input_data = mapping_or_empty(invocation.get("input"))
-        parsed = _parse_subagent_spawn(_json_record(input_data))
+        parsed = _parse_subagent_spawn(_tool_input_payload(input_data))
         agent_type = parsed.get("agent_type")
         spawns.append(
             {
@@ -194,7 +199,7 @@ def extract_subagent_spawns(tool_invocations: Sequence[ToolInvocationSummary]) -
     return spawns
 
 
-def extract_git_operations(tool_invocations: Sequence[ToolInvocationSummary]) -> list[ToolMetadata]:
+def extract_git_operations(tool_invocations: Sequence[Mapping[str, object]]) -> list[ToolMetadata]:
     operations: list[ToolMetadata] = []
     for invocation in tool_invocations:
         if git_op := parse_git_operation(invocation):

--- a/polylogue/pipeline/semantic_metadata.py
+++ b/polylogue/pipeline/semantic_metadata.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeAlias
+from typing import TypeAlias
 
 from polylogue.lib.viewports import ToolCategory, classify_tool
+from polylogue.schemas.json_types import JSONDocument, JSONValue, json_document
 
-ToolInputScalar: TypeAlias = str | int | float | bool | None
-ToolInputPayload: TypeAlias = Mapping[str, Any]
-ToolMetadata: TypeAlias = dict[str, Any]
+ToolInputPayload: TypeAlias = Mapping[str, JSONValue]
+ToolMetadata: TypeAlias = JSONDocument
 
 
 def extract_tool_metadata(tool_name: str, tool_input: ToolInputPayload) -> ToolMetadata | None:
@@ -34,7 +34,7 @@ def _payload_string(tool_input: ToolInputPayload, key: str) -> str | None:
     return value if isinstance(value, str) and value else None
 
 
-def _payload_list(tool_input: ToolInputPayload, key: str) -> list[Any] | None:
+def _payload_list(tool_input: ToolInputPayload, key: str) -> list[JSONValue] | None:
     value = tool_input.get(key)
     return value if isinstance(value, list) else None
 
@@ -62,10 +62,7 @@ def _parse_git_command(command: str) -> ToolMetadata:
         return {"full_command": command}
 
     git_command = parts[1]
-    metadata: ToolMetadata = {
-        "command": git_command,
-        "full_command": command,
-    }
+    metadata: ToolMetadata = {"command": git_command, "full_command": command}
 
     if git_command == "commit":
         message = _quoted_flag_value(command, "-m")
@@ -162,7 +159,7 @@ def _extract_agent_metadata(tool_name: str, tool_input: ToolInputPayload) -> Too
     questions = _payload_list(tool_input, "questions")
     if questions is not None:
         metadata["question_count"] = len(questions)
-    return metadata
+    return json_document(metadata)
 
 
 __all__ = [

--- a/polylogue/schemas/generation_field_annotations.py
+++ b/polylogue/schemas/generation_field_annotations.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
-from typing import Any
+from collections.abc import Mapping, Sequence
+from typing import overload
 
 from polylogue.schemas.field_stats import FieldStats
+from polylogue.schemas.json_types import JSONDocument, JSONValue
 from polylogue.schemas.privacy import (
     _is_content_field,
     _is_safe_enum_value,
@@ -16,16 +18,71 @@ _ENUM_MIN_COUNT = 2
 _ENUM_MIN_FREQ = 0.03
 
 
+def _enum_values(
+    field_stats: FieldStats,
+    *,
+    path: str,
+    min_conversation_count: int,
+    privacy_config: object | None,
+) -> list[JSONValue]:
+    total = max(field_stats.value_count, 1)
+    min_count = _ENUM_MIN_COUNT if total >= 20 else 1
+    min_freq = _ENUM_MIN_FREQ if total >= 50 else 0.0
+    values: list[JSONValue] = []
+    for value, count in field_stats.observed_values.most_common(_ENUM_VALUE_CAP):
+        if not _is_safe_enum_value(value, path=path, config=privacy_config):
+            continue
+        if count < min_count:
+            continue
+        if min_freq and (count / total) < min_freq:
+            continue
+        if min_conversation_count > 1 and field_stats.value_conversation_ids:
+            conversation_count = len(field_stats.value_conversation_ids.get(value, set()))
+            if conversation_count < min_conversation_count:
+                continue
+        values.append(value)
+        if len(values) >= _ENUM_OUTPUT_CAP:
+            break
+    return values
+
+
+def _schema_node(value: JSONValue | object) -> JSONDocument | None:
+    return value if isinstance(value, dict) else None
+
+
+@overload
 def annotate_schema(
-    schema: dict[str, Any],
-    stats: dict[str, FieldStats],
+    schema: JSONDocument,
+    stats: Mapping[str, FieldStats],
     path: str = "$",
     *,
     min_conversation_count: int = 1,
-    privacy_config: Any | None = None,
-) -> dict[str, Any]:
+    privacy_config: object | None = None,
+) -> JSONDocument: ...
+
+
+@overload
+def annotate_schema(
+    schema: JSONValue,
+    stats: Mapping[str, FieldStats],
+    path: str = "$",
+    *,
+    min_conversation_count: int = 1,
+    privacy_config: object | None = None,
+) -> JSONValue: ...
+
+
+def annotate_schema(
+    schema: JSONValue,
+    stats: Mapping[str, FieldStats],
+    path: str = "$",
+    *,
+    min_conversation_count: int = 1,
+    privacy_config: object | None = None,
+) -> JSONValue:
     """Apply x-polylogue-* annotations to a schema from collected field stats."""
-    if not isinstance(schema, dict):
+    schema_node = _schema_node(schema)
+    if schema_node is None:
         return schema
 
     field_stats = stats.get(path)
@@ -33,11 +90,11 @@ def annotate_schema(
         if "[*]" not in path:
             freq = field_stats.frequency
             if 0.0 < freq < 0.95:
-                schema["x-polylogue-frequency"] = round(freq, 3)
+                schema_node["x-polylogue-frequency"] = round(freq, 3)
 
         fmt = field_stats.dominant_format
         if fmt:
-            schema["x-polylogue-format"] = fmt
+            schema_node["x-polylogue-format"] = fmt
 
         id_formats = {"uuid4", "uuid", "hex-id", "base64"}
         if (
@@ -46,33 +103,20 @@ def annotate_schema(
             and fmt not in id_formats
             and not _is_content_field(path)
         ):
-            total = max(field_stats.value_count, 1)
-            min_count = _ENUM_MIN_COUNT if total >= 20 else 1
-            min_freq = _ENUM_MIN_FREQ if total >= 50 else 0.0
-            sorted_vals: list[Any] = []
-            for value, count in field_stats.observed_values.most_common(_ENUM_VALUE_CAP):
-                if isinstance(value, str):
-                    if not _is_safe_enum_value(value, path=path, config=privacy_config):
-                        continue
-                    if count < min_count:
-                        continue
-                    if min_freq and (count / total) < min_freq:
-                        continue
-                    if min_conversation_count > 1 and field_stats.value_conversation_ids:
-                        conversation_count = len(field_stats.value_conversation_ids.get(value, set()))
-                        if conversation_count < min_conversation_count:
-                            continue
-                sorted_vals.append(value)
-                if len(sorted_vals) >= _ENUM_OUTPUT_CAP:
-                    break
-            if sorted_vals:
-                schema["x-polylogue-values"] = sorted_vals
+            enum_values = _enum_values(
+                field_stats,
+                path=path,
+                min_conversation_count=min_conversation_count,
+                privacy_config=privacy_config,
+            )
+            if enum_values:
+                schema_node["x-polylogue-values"] = enum_values
 
         if field_stats.num_min is not None and field_stats.num_max is not None:
-            schema["x-polylogue-range"] = [field_stats.num_min, field_stats.num_max]
+            schema_node["x-polylogue-range"] = [field_stats.num_min, field_stats.num_max]
 
         if field_stats.array_lengths:
-            schema["x-polylogue-array-lengths"] = [
+            schema_node["x-polylogue-array-lengths"] = [
                 min(field_stats.array_lengths),
                 max(field_stats.array_lengths),
             ]
@@ -82,15 +126,16 @@ def annotate_schema(
             and field_stats.value_count
             and field_stats.is_multiline / field_stats.value_count > 0.3
         ):
-            schema["x-polylogue-multiline"] = True
+            schema_node["x-polylogue-multiline"] = True
 
         ref_target = getattr(field_stats, "_ref_target", None)
         if ref_target:
-            schema["x-polylogue-ref"] = ref_target
+            schema_node["x-polylogue-ref"] = ref_target
 
-    if "properties" in schema:
-        for prop_name, prop_schema in schema["properties"].items():
-            schema["properties"][prop_name] = annotate_schema(
+    properties = _schema_node(schema_node.get("properties"))
+    if properties is not None:
+        for prop_name, prop_schema in properties.items():
+            properties[prop_name] = annotate_schema(
                 prop_schema,
                 stats,
                 f"{path}.{prop_name}",
@@ -98,18 +143,20 @@ def annotate_schema(
                 privacy_config=privacy_config,
             )
 
-    if isinstance(schema.get("additionalProperties"), dict):
-        schema["additionalProperties"] = annotate_schema(
-            schema["additionalProperties"],
+    additional_properties = _schema_node(schema_node.get("additionalProperties"))
+    if additional_properties is not None:
+        schema_node["additionalProperties"] = annotate_schema(
+            additional_properties,
             stats,
             f"{path}.*",
             min_conversation_count=min_conversation_count,
             privacy_config=privacy_config,
         )
 
-    if isinstance(schema.get("items"), dict):
-        schema["items"] = annotate_schema(
-            schema["items"],
+    items = _schema_node(schema_node.get("items"))
+    if items is not None:
+        schema_node["items"] = annotate_schema(
+            items,
             stats,
             f"{path}[*]",
             min_conversation_count=min_conversation_count,
@@ -117,8 +164,9 @@ def annotate_schema(
         )
 
     for keyword in ("anyOf", "oneOf", "allOf"):
-        if keyword in schema:
-            schema[keyword] = [
+        keyword_items = schema_node.get(keyword)
+        if isinstance(keyword_items, Sequence) and not isinstance(keyword_items, (str, bytes, bytearray)):
+            schema_node[keyword] = [
                 annotate_schema(
                     item,
                     stats,
@@ -126,36 +174,48 @@ def annotate_schema(
                     min_conversation_count=min_conversation_count,
                     privacy_config=privacy_config,
                 )
-                for item in schema[keyword]
+                for item in keyword_items
             ]
 
-    return schema
+    return schema_node
 
 
-def remove_nested_required(schema: dict[str, Any], depth: int = 0) -> dict[str, Any]:
+@overload
+def remove_nested_required(schema: JSONDocument, depth: int = 0) -> JSONDocument: ...
+
+
+@overload
+def remove_nested_required(schema: JSONValue, depth: int = 0) -> JSONValue: ...
+
+
+def remove_nested_required(schema: JSONValue, depth: int = 0) -> JSONValue:
     """Remove nested required declarations from generated schemas."""
-    if not isinstance(schema, dict):
+    schema_node = _schema_node(schema)
+    if schema_node is None:
         return schema
 
-    if depth > 0 and "required" in schema:
-        del schema["required"]
+    if depth > 0 and "required" in schema_node:
+        del schema_node["required"]
 
-    if "properties" in schema:
-        for key, prop in schema["properties"].items():
-            schema["properties"][key] = remove_nested_required(prop, depth + 1)
+    properties = _schema_node(schema_node.get("properties"))
+    if properties is not None:
+        for key, prop in properties.items():
+            properties[key] = remove_nested_required(prop, depth + 1)
 
-    additional_properties = schema.get("additionalProperties")
-    if isinstance(additional_properties, dict):
-        schema["additionalProperties"] = remove_nested_required(additional_properties, depth + 1)
+    additional_properties = _schema_node(schema_node.get("additionalProperties"))
+    if additional_properties is not None:
+        schema_node["additionalProperties"] = remove_nested_required(additional_properties, depth + 1)
 
-    if "items" in schema:
-        schema["items"] = remove_nested_required(schema["items"], depth + 1)
+    items = _schema_node(schema_node.get("items"))
+    if items is not None:
+        schema_node["items"] = remove_nested_required(items, depth + 1)
 
     for keyword in ("anyOf", "oneOf", "allOf"):
-        if keyword in schema:
-            schema[keyword] = [remove_nested_required(item, depth + 1) for item in schema[keyword]]
+        keyword_items = schema_node.get(keyword)
+        if isinstance(keyword_items, Sequence) and not isinstance(keyword_items, (str, bytes, bytearray)):
+            schema_node[keyword] = [remove_nested_required(item, depth + 1) for item in keyword_items]
 
-    return schema
+    return schema_node
 
 
 __all__ = [

--- a/polylogue/schemas/generation_schema_builder.py
+++ b/polylogue/schemas/generation_schema_builder.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
+from collections.abc import Sequence
 from datetime import datetime, timezone
-from typing import Any, Protocol, TypeAlias, cast
+from typing import Protocol, TypeAlias, cast
 
 from polylogue.schemas.field_stats import _collect_field_stats
 from polylogue.schemas.generation_support import (
@@ -16,12 +16,13 @@ from polylogue.schemas.generation_support import (
     _remove_nested_required,
     collapse_dynamic_keys,
 )
+from polylogue.schemas.json_types import JSONDocument
 from polylogue.schemas.observation import ProviderConfig
 from polylogue.schemas.redaction_report import SchemaReport
 from polylogue.schemas.shape_fingerprint import _structure_fingerprint
 
-SchemaPayload: TypeAlias = Mapping[str, Any]
-MutableSchemaPayload: TypeAlias = dict[str, Any]
+SchemaPayload: TypeAlias = JSONDocument
+MutableSchemaPayload: TypeAlias = JSONDocument
 
 
 class PrivacyConfigLike(Protocol):

--- a/polylogue/schemas/generation_schema_builder.py
+++ b/polylogue/schemas/generation_schema_builder.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from datetime import datetime, timezone
-from typing import Protocol, TypeAlias, cast
+from typing import Any, Protocol, TypeAlias, cast
 
 from polylogue.schemas.field_stats import _collect_field_stats
 from polylogue.schemas.generation_support import (
@@ -16,13 +16,13 @@ from polylogue.schemas.generation_support import (
     _remove_nested_required,
     collapse_dynamic_keys,
 )
-from polylogue.schemas.json_types import JSONDocument
 from polylogue.schemas.observation import ProviderConfig
 from polylogue.schemas.redaction_report import SchemaReport
 from polylogue.schemas.shape_fingerprint import _structure_fingerprint
 
-SchemaPayload: TypeAlias = JSONDocument
-MutableSchemaPayload: TypeAlias = JSONDocument
+SchemaInput: TypeAlias = Mapping[str, object]
+SchemaPayload: TypeAlias = dict[str, Any]
+MutableSchemaPayload: TypeAlias = dict[str, Any]
 
 
 class PrivacyConfigLike(Protocol):
@@ -35,7 +35,7 @@ _STRUCTURE_EXEMPLARS_PER_FINGERPRINT = 8
 def _generate_cluster_schema(
     provider: str,
     config: ProviderConfig,
-    samples: Sequence[SchemaPayload],
+    samples: Sequence[SchemaInput],
     conv_ids: Sequence[str | None],
     *,
     privacy_config: PrivacyConfigLike | None,
@@ -105,7 +105,7 @@ def _apply_schema_metadata(
 
 
 def generate_schema_from_samples(
-    samples: Sequence[SchemaPayload],
+    samples: Sequence[SchemaInput],
     *,
     annotate: bool = True,
     max_stats_samples: int = 500,
@@ -146,6 +146,7 @@ def generate_schema_from_samples(
 
 
 __all__ = [
+    "SchemaInput",
     "_apply_schema_metadata",
     "_generate_cluster_schema",
     "generate_schema_from_samples",

--- a/polylogue/schemas/generation_semantic_relations.py
+++ b/polylogue/schemas/generation_semantic_relations.py
@@ -2,71 +2,42 @@
 
 from __future__ import annotations
 
-from typing import Any
+from collections.abc import Mapping, Sequence
+from typing import cast, overload
 
 from polylogue.schemas.field_stats import FieldStats
+from polylogue.schemas.json_types import JSONDocument, JSONDocumentList, JSONValue
 from polylogue.schemas.relational_inference import infer_relations
+from polylogue.schemas.relational_inference_models import RelationalAnnotations
 from polylogue.schemas.semantic_inference import infer_semantic_roles, select_best_roles
 
 
-def annotate_semantic_and_relational(
-    schema: dict[str, Any],
-    field_stats: dict[str, FieldStats],
-    *,
-    artifact_kind: str | None = None,
-) -> dict[str, Any]:
-    """Attach semantic-role and relational annotations to a schema."""
-    candidates = infer_semantic_roles(field_stats, artifact_kind=artifact_kind)
-    best_roles = select_best_roles(candidates)
-    role_by_path: dict[str, tuple[str, float, dict[str, Any]]] = {}
-    for role, candidate in best_roles.items():
-        role_by_path[candidate.path] = (role, candidate.confidence, candidate.evidence)
-
-    _attach_semantic_roles(schema, role_by_path)
-    relations = infer_relations(field_stats)
-    _attach_relational_annotations(schema, relations)
-    return schema
+def _schema_node(value: JSONValue | object) -> JSONDocument | None:
+    return value if isinstance(value, dict) else None
 
 
-def _attach_semantic_roles(
-    schema: dict[str, Any],
-    role_by_path: dict[str, tuple[str, float, dict[str, Any]]],
-    *,
-    path: str = "$",
-) -> None:
-    if not isinstance(schema, dict):
-        return
-    if path in role_by_path:
-        role, confidence, evidence = role_by_path[path]
-        schema["x-polylogue-semantic-role"] = role
-        schema["x-polylogue-score"] = round(confidence, 3)
-        schema["x-polylogue-evidence"] = evidence
-
-    if "properties" in schema:
-        for prop_name, prop_schema in schema["properties"].items():
-            _attach_semantic_roles(prop_schema, role_by_path, path=f"{path}.{prop_name}")
-    if isinstance(schema.get("additionalProperties"), dict):
-        _attach_semantic_roles(schema["additionalProperties"], role_by_path, path=f"{path}.*")
-    if isinstance(schema.get("items"), dict):
-        _attach_semantic_roles(schema["items"], role_by_path, path=f"{path}[*]")
-    for keyword in ("anyOf", "oneOf", "allOf"):
-        for item in schema.get(keyword, []):
-            _attach_semantic_roles(item, role_by_path, path=path)
+def _json_value(value: object) -> JSONValue:
+    return cast(JSONValue, value)
 
 
-def _attach_relational_annotations(schema: dict[str, Any], relations: Any) -> None:
-    if relations.foreign_keys:
-        schema["x-polylogue-foreign-keys"] = [
+def _relation_payloads(
+    relations: RelationalAnnotations,
+) -> tuple[
+    JSONDocumentList,
+    JSONDocumentList,
+    JSONDocumentList,
+    JSONDocumentList,
+]:
+    return (
+        [
             {
                 "source": relation.source_path,
                 "target": relation.target_path,
                 "match_ratio": round(relation.match_ratio, 3),
             }
             for relation in relations.foreign_keys
-        ]
-
-    if relations.time_deltas:
-        schema["x-polylogue-time-deltas"] = [
+        ],
+        [
             {
                 "field_a": relation.field_a,
                 "field_b": relation.field_b,
@@ -75,19 +46,15 @@ def _attach_relational_annotations(schema: dict[str, Any], relations: Any) -> No
                 "avg_delta": round(relation.avg_delta, 1),
             }
             for relation in relations.time_deltas
-        ]
-
-    if relations.mutual_exclusions:
-        schema["x-polylogue-mutually-exclusive"] = [
+        ],
+        [
             {
                 "parent": relation.parent_path,
-                "fields": sorted(relation.field_names),
+                "fields": _json_value(sorted(relation.field_names)),
             }
             for relation in relations.mutual_exclusions
-        ]
-
-    if relations.string_lengths:
-        schema["x-polylogue-string-lengths"] = [
+        ],
+        [
             {
                 "path": relation.path,
                 "min": relation.min_length,
@@ -96,7 +63,94 @@ def _attach_relational_annotations(schema: dict[str, Any], relations: Any) -> No
                 "stddev": round(relation.stddev, 1),
             }
             for relation in relations.string_lengths
-        ]
+        ],
+    )
+
+
+@overload
+def annotate_semantic_and_relational(
+    schema: JSONDocument,
+    field_stats: Mapping[str, FieldStats],
+    *,
+    artifact_kind: str | None = None,
+) -> JSONDocument: ...
+
+
+@overload
+def annotate_semantic_and_relational(
+    schema: JSONValue,
+    field_stats: Mapping[str, FieldStats],
+    *,
+    artifact_kind: str | None = None,
+) -> JSONValue: ...
+
+
+def annotate_semantic_and_relational(
+    schema: JSONValue,
+    field_stats: Mapping[str, FieldStats],
+    *,
+    artifact_kind: str | None = None,
+) -> JSONValue:
+    """Attach semantic-role and relational annotations to a schema."""
+    schema_node = _schema_node(schema)
+    if schema_node is None:
+        return schema
+    stats_by_path = dict(field_stats)
+    candidates = infer_semantic_roles(stats_by_path, artifact_kind=artifact_kind)
+    best_roles = select_best_roles(candidates)
+    role_by_path: dict[str, tuple[str, float, JSONDocument]] = {}
+    for role, candidate in best_roles.items():
+        role_by_path[candidate.path] = (role, candidate.confidence, candidate.evidence)
+
+    _attach_semantic_roles(schema_node, role_by_path)
+    relations = infer_relations(stats_by_path)
+    _attach_relational_annotations(schema_node, relations)
+    return schema_node
+
+
+def _attach_semantic_roles(
+    schema: JSONDocument,
+    role_by_path: Mapping[str, tuple[str, float, JSONDocument]],
+    *,
+    path: str = "$",
+) -> None:
+    if path in role_by_path:
+        role, confidence, evidence = role_by_path[path]
+        schema["x-polylogue-semantic-role"] = role
+        schema["x-polylogue-score"] = round(confidence, 3)
+        schema["x-polylogue-evidence"] = evidence
+
+    properties = _schema_node(schema.get("properties"))
+    if properties is not None:
+        for prop_name, prop_schema in properties.items():
+            child_schema = _schema_node(prop_schema)
+            if child_schema is not None:
+                _attach_semantic_roles(child_schema, role_by_path, path=f"{path}.{prop_name}")
+    additional_properties = _schema_node(schema.get("additionalProperties"))
+    if additional_properties is not None:
+        _attach_semantic_roles(additional_properties, role_by_path, path=f"{path}.*")
+    items = _schema_node(schema.get("items"))
+    if items is not None:
+        _attach_semantic_roles(items, role_by_path, path=f"{path}[*]")
+    for keyword in ("anyOf", "oneOf", "allOf"):
+        keyword_items = schema.get(keyword)
+        if isinstance(keyword_items, Sequence) and not isinstance(keyword_items, (str, bytes, bytearray)):
+            for item in keyword_items:
+                child_schema = _schema_node(item)
+                if child_schema is not None:
+                    _attach_semantic_roles(child_schema, role_by_path, path=path)
+
+
+def _attach_relational_annotations(schema: JSONDocument, relations: RelationalAnnotations) -> None:
+    foreign_keys, time_deltas, mutual_exclusions, string_lengths = _relation_payloads(relations)
+    if foreign_keys:
+        schema["x-polylogue-foreign-keys"] = _json_value(foreign_keys)
+    if time_deltas:
+        schema["x-polylogue-time-deltas"] = _json_value(time_deltas)
+    if mutual_exclusions:
+        schema["x-polylogue-mutually-exclusive"] = _json_value(mutual_exclusions)
+    if string_lengths:
+        schema["x-polylogue-string-lengths"] = _json_value(string_lengths)
 
 
 __all__ = ["annotate_semantic_and_relational"]

--- a/polylogue/schemas/generation_semantic_relations.py
+++ b/polylogue/schemas/generation_semantic_relations.py
@@ -6,7 +6,7 @@ from collections.abc import Mapping, Sequence
 from typing import cast, overload
 
 from polylogue.schemas.field_stats import FieldStats
-from polylogue.schemas.json_types import JSONDocument, JSONDocumentList, JSONValue
+from polylogue.schemas.json_types import JSONDocument, JSONDocumentList, JSONValue, json_document
 from polylogue.schemas.relational_inference import infer_relations
 from polylogue.schemas.relational_inference_models import RelationalAnnotations
 from polylogue.schemas.semantic_inference import infer_semantic_roles, select_best_roles
@@ -100,7 +100,7 @@ def annotate_semantic_and_relational(
     best_roles = select_best_roles(candidates)
     role_by_path: dict[str, tuple[str, float, JSONDocument]] = {}
     for role, candidate in best_roles.items():
-        role_by_path[candidate.path] = (role, candidate.confidence, candidate.evidence)
+        role_by_path[candidate.path] = (role, candidate.confidence, json_document(candidate.evidence))
 
     _attach_semantic_roles(schema_node, role_by_path)
     relations = infer_relations(stats_by_path)

--- a/polylogue/schemas/generation_support.py
+++ b/polylogue/schemas/generation_support.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from typing import Any, Protocol, TypeAlias, overload
+from typing import Any, Protocol, TypeAlias, cast, overload
 
 from polylogue.schemas import generation_dynamic_keys as _dynamic_keys
 from polylogue.schemas.field_stats import FieldStats
@@ -38,12 +38,15 @@ def _annotate_schema(
     min_conversation_count: int = 1,
     privacy_config: PrivacyConfigLike | None = None,
 ) -> SchemaPayload:
-    return annotate_schema(
-        dict(schema),
-        dict(stats),
-        path,
-        min_conversation_count=min_conversation_count,
-        privacy_config=privacy_config,
+    return cast(
+        SchemaPayload,
+        annotate_schema(
+            dict(schema),
+            dict(stats),
+            path,
+            min_conversation_count=min_conversation_count,
+            privacy_config=privacy_config,
+        ),
     )
 
 
@@ -53,7 +56,10 @@ def _annotate_semantic_and_relational(
     *,
     artifact_kind: str | None = None,
 ) -> SchemaPayload:
-    return annotate_semantic_and_relational(dict(schema), dict(field_stats), artifact_kind=artifact_kind)
+    return cast(
+        SchemaPayload,
+        annotate_semantic_and_relational(dict(schema), dict(field_stats), artifact_kind=artifact_kind),
+    )
 
 
 @overload

--- a/polylogue/schemas/generation_workflow.py
+++ b/polylogue/schemas/generation_workflow.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from polylogue.paths import db_path as archive_db_path
 from polylogue.schemas.generation_models import _ProviderBundle
@@ -20,7 +21,11 @@ def persist_generated_provider_bundle(output_dir: Path, provider: str, bundle: _
         return
 
     registry = SchemaRegistry(storage_root=output_dir)
-    registry.replace_provider_packages(provider, bundle.catalog, bundle.package_schemas)
+    registry.replace_provider_packages(
+        provider,
+        bundle.catalog,
+        cast(Mapping[str, dict[str, Mapping[str, object]]], bundle.package_schemas),
+    )
     registry.save_cluster_manifest(bundle.manifest)
 
     for legacy_name in (f"{provider}.schema.json.gz", f"{provider}.schema.json"):

--- a/polylogue/schemas/json_types.py
+++ b/polylogue/schemas/json_types.py
@@ -1,0 +1,30 @@
+"""Shared JSON-shaped aliases for schema and tooling payloads."""
+
+from __future__ import annotations
+
+from typing import TypeAlias, cast
+
+JSONScalar: TypeAlias = str | int | float | bool | None
+JSONValue: TypeAlias = JSONScalar | list["JSONValue"] | dict[str, "JSONValue"]
+JSONDocument: TypeAlias = dict[str, JSONValue]
+JSONDocumentList: TypeAlias = list[JSONDocument]
+
+
+def json_document(value: object) -> JSONDocument:
+    return cast(JSONDocument, value) if isinstance(value, dict) else {}
+
+
+def json_document_list(value: object) -> JSONDocumentList:
+    if not isinstance(value, list):
+        return []
+    return [json_document(item) for item in value]
+
+
+__all__ = [
+    "JSONDocument",
+    "JSONDocumentList",
+    "JSONScalar",
+    "JSONValue",
+    "json_document",
+    "json_document_list",
+]

--- a/polylogue/schemas/operator_annotations.py
+++ b/polylogue/schemas/operator_annotations.py
@@ -2,8 +2,17 @@
 
 from __future__ import annotations
 
-from typing import Any
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import cast
 
+from polylogue.schemas.json_types import JSONDocument, JSONValue, json_document
+from polylogue.schemas.operator_models import (
+    JSONDocument as OperatorJSONDocument,
+)
+from polylogue.schemas.operator_models import (
+    JSONDocumentList as OperatorJSONDocumentList,
+)
 from polylogue.schemas.operator_models import (
     SchemaAnnotationSummary,
     SchemaCoverageSummary,
@@ -13,7 +22,46 @@ from polylogue.schemas.operator_models import (
 )
 
 
-def collect_annotation_summary(schema: dict[str, Any]) -> SchemaAnnotationSummary:
+@dataclass(frozen=True, slots=True)
+class _RoleCandidate:
+    path: str
+    score: float
+    evidence: OperatorJSONDocument
+
+    def to_payload(self) -> OperatorJSONDocument:
+        return {
+            "path": self.path,
+            "score": self.score,
+            "evidence": self.evidence,
+        }
+
+
+def _schema_node(value: JSONValue | object) -> JSONDocument | None:
+    return value if isinstance(value, dict) else None
+
+
+def _node_evidence(node: Mapping[str, object]) -> OperatorJSONDocument:
+    return cast(OperatorJSONDocument, json_document(node.get("x-polylogue-evidence")))
+
+
+def _score_value(value: object) -> float:
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError:
+            return 0.0
+    return 0.0
+
+
+def _string_list(value: object) -> list[str]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        return []
+    return [item for item in value if isinstance(item, str)]
+
+
+def collect_annotation_summary(schema: JSONDocument) -> SchemaAnnotationSummary:
     """Collect format/value/semantic coverage from a schema document."""
     format_count = 0
     values_count = 0
@@ -24,18 +72,16 @@ def collect_annotation_summary(schema: dict[str, Any]) -> SchemaAnnotationSummar
     with_values = 0
     with_role = 0
 
-    def visit(node: dict[str, Any], *, path: str) -> None:
+    def visit(node: JSONDocument, *, path: str) -> None:
         nonlocal format_count, values_count, total_enum_values
         nonlocal total_fields, with_format, with_values, with_role
-        if not isinstance(node, dict):
-            return
         role = node.get("x-polylogue-semantic-role")
         if role:
             assignment = SchemaRoleAssignment(
                 path=path,
                 role=str(role),
-                confidence=float(node.get("x-polylogue-score", 0.0) or 0.0),
-                evidence=dict(node.get("x-polylogue-evidence", {})),
+                confidence=_score_value(node.get("x-polylogue-score", 0.0)),
+                evidence=_node_evidence(node),
             )
             key = (assignment.path, assignment.role)
             current = role_by_key.get(key)
@@ -43,28 +89,39 @@ def collect_annotation_summary(schema: dict[str, Any]) -> SchemaAnnotationSummar
                 role_by_key[key] = assignment
         if "x-polylogue-format" in node:
             format_count += 1
-        if "x-polylogue-values" in node:
+        enum_values = node.get("x-polylogue-values")
+        enum_list = _string_list(enum_values)
+        if enum_list:
             values_count += 1
-            total_enum_values += len(node["x-polylogue-values"])
+            total_enum_values += len(enum_list)
 
-        for name, child in node.get("properties", {}).items():
-            if isinstance(child, dict):
+        properties = _schema_node(node.get("properties"))
+        if properties is not None:
+            for name, child in properties.items():
+                child_node = _schema_node(child)
+                if child_node is None:
+                    continue
                 total_fields += 1
-                if "x-polylogue-format" in child:
+                if "x-polylogue-format" in child_node:
                     with_format += 1
-                if "x-polylogue-values" in child:
+                if "x-polylogue-values" in child_node:
                     with_values += 1
-                if "x-polylogue-semantic-role" in child:
+                if "x-polylogue-semantic-role" in child_node:
                     with_role += 1
-                visit(child, path=f"{path}.{name}")
-        if isinstance(node.get("items"), dict):
-            visit(node["items"], path=f"{path}[*]")
-        if isinstance(node.get("additionalProperties"), dict):
-            visit(node["additionalProperties"], path=f"{path}.*")
+                visit(child_node, path=f"{path}.{name}")
+        items = _schema_node(node.get("items"))
+        if items is not None:
+            visit(items, path=f"{path}[*]")
+        additional_properties = _schema_node(node.get("additionalProperties"))
+        if additional_properties is not None:
+            visit(additional_properties, path=f"{path}.*")
         for keyword in ("anyOf", "oneOf", "allOf"):
-            for child in node.get(keyword, []):
-                if isinstance(child, dict):
-                    visit(child, path=path)
+            keyword_items = node.get(keyword)
+            if isinstance(keyword_items, Sequence) and not isinstance(keyword_items, (str, bytes, bytearray)):
+                for child in keyword_items:
+                    child_node = _schema_node(child)
+                    if child_node is not None:
+                        visit(child_node, path=path)
 
     visit(schema, path="$")
     roles = sorted(role_by_key.values(), key=lambda item: (-item.confidence, item.path, item.role))
@@ -83,7 +140,7 @@ def collect_annotation_summary(schema: dict[str, Any]) -> SchemaAnnotationSummar
     )
 
 
-def build_review_proof(schema: dict[str, Any]) -> SchemaReviewProof:
+def build_review_proof(schema: JSONDocument) -> SchemaReviewProof:
     """Build a proof surface from a schema's semantic annotations and field stats.
 
     Re-runs inference from the schema's own samples metadata to produce
@@ -95,7 +152,8 @@ def build_review_proof(schema: dict[str, Any]) -> SchemaReviewProof:
         RECORD_STREAM_KINDS,
     )
 
-    artifact_kind = schema.get("x-polylogue-artifact-kind")
+    artifact_kind_value = schema.get("x-polylogue-artifact-kind")
+    artifact_kind = artifact_kind_value if isinstance(artifact_kind_value, str) else None
     is_record_stream = artifact_kind in RECORD_STREAM_KINDS
 
     eligible_roles = list(SEMANTIC_ROLES)
@@ -105,7 +163,7 @@ def build_review_proof(schema: dict[str, Any]) -> SchemaReviewProof:
         ineligible_roles = [r for r in SEMANTIC_ROLES if r not in RECORD_STREAM_ELIGIBLE_ROLES]
 
     # Collect all role assignments from the schema itself
-    role_entries: dict[str, list[dict[str, Any]]] = {}  # role -> list of {path, score, evidence}
+    role_entries: dict[str, list[_RoleCandidate]] = {}
     _collect_role_candidates_from_schema(schema, "$", role_entries)
 
     # Build proof entries for each semantic role
@@ -141,14 +199,14 @@ def build_review_proof(schema: dict[str, Any]) -> SchemaReviewProof:
             continue
 
         chosen = candidates[0]
-        competing = [{"path": c["path"], "score": c["score"], "evidence": c["evidence"]} for c in candidates[1:]]
+        competing: OperatorJSONDocumentList = [candidate.to_payload() for candidate in candidates[1:]]
         proof_entries.append(
             SchemaRoleProofEntry(
                 role=role,
-                chosen_path=chosen["path"],
-                chosen_score=chosen["score"],
+                chosen_path=chosen.path,
+                chosen_score=chosen.score,
                 competing=competing,
-                evidence=chosen["evidence"],
+                evidence=chosen.evidence,
                 abstained=False,
             )
         )
@@ -162,40 +220,44 @@ def build_review_proof(schema: dict[str, Any]) -> SchemaReviewProof:
 
 
 def _collect_role_candidates_from_schema(
-    node: dict[str, Any],
+    node: JSONDocument,
     path: str,
-    role_entries: dict[str, list[dict[str, Any]]],
+    role_entries: dict[str, list[_RoleCandidate]],
 ) -> None:
     """Walk a schema and collect all semantic role annotations with scores."""
-    if not isinstance(node, dict):
-        return
     role = node.get("x-polylogue-semantic-role")
     if role:
-        score = float(node.get("x-polylogue-score", 0.0) or 0.0)
-        evidence = dict(node.get("x-polylogue-evidence", {}))
-        role_entries.setdefault(role, []).append(
-            {
-                "path": path,
-                "score": score,
-                "evidence": evidence,
-            }
+        role_entries.setdefault(str(role), []).append(
+            _RoleCandidate(
+                path=path,
+                score=_score_value(node.get("x-polylogue-score", 0.0)),
+                evidence=_node_evidence(node),
+            )
         )
 
-    for name, child in node.get("properties", {}).items():
-        if isinstance(child, dict):
-            _collect_role_candidates_from_schema(child, f"{path}.{name}", role_entries)
-    if isinstance(node.get("items"), dict):
-        _collect_role_candidates_from_schema(node["items"], f"{path}[*]", role_entries)
-    if isinstance(node.get("additionalProperties"), dict):
+    properties = _schema_node(node.get("properties"))
+    if properties is not None:
+        for name, child in properties.items():
+            child_node = _schema_node(child)
+            if child_node is not None:
+                _collect_role_candidates_from_schema(child_node, f"{path}.{name}", role_entries)
+    items = _schema_node(node.get("items"))
+    if items is not None:
+        _collect_role_candidates_from_schema(items, f"{path}[*]", role_entries)
+    additional_properties = _schema_node(node.get("additionalProperties"))
+    if additional_properties is not None:
         _collect_role_candidates_from_schema(
-            node["additionalProperties"],
+            additional_properties,
             f"{path}.*",
             role_entries,
         )
     for keyword in ("anyOf", "oneOf", "allOf"):
-        for child in node.get(keyword, []):
-            if isinstance(child, dict):
-                _collect_role_candidates_from_schema(child, path, role_entries)
+        keyword_items = node.get(keyword)
+        if isinstance(keyword_items, Sequence) and not isinstance(keyword_items, (str, bytes, bytearray)):
+            for child in keyword_items:
+                child_node = _schema_node(child)
+                if child_node is not None:
+                    _collect_role_candidates_from_schema(child_node, path, role_entries)
 
 
 __all__ = ["build_review_proof", "collect_annotation_summary"]

--- a/polylogue/schemas/operator_annotations.py
+++ b/polylogue/schemas/operator_annotations.py
@@ -61,8 +61,9 @@ def _string_list(value: object) -> list[str]:
     return [item for item in value if isinstance(item, str)]
 
 
-def collect_annotation_summary(schema: JSONDocument) -> SchemaAnnotationSummary:
+def collect_annotation_summary(schema: Mapping[str, object]) -> SchemaAnnotationSummary:
     """Collect format/value/semantic coverage from a schema document."""
+    schema_node = json_document(schema)
     format_count = 0
     values_count = 0
     total_enum_values = 0
@@ -123,7 +124,7 @@ def collect_annotation_summary(schema: JSONDocument) -> SchemaAnnotationSummary:
                     if child_node is not None:
                         visit(child_node, path=path)
 
-    visit(schema, path="$")
+    visit(schema_node, path="$")
     roles = sorted(role_by_key.values(), key=lambda item: (-item.confidence, item.path, item.role))
     return SchemaAnnotationSummary(
         semantic_count=len(roles),
@@ -140,7 +141,7 @@ def collect_annotation_summary(schema: JSONDocument) -> SchemaAnnotationSummary:
     )
 
 
-def build_review_proof(schema: JSONDocument) -> SchemaReviewProof:
+def build_review_proof(schema: Mapping[str, object]) -> SchemaReviewProof:
     """Build a proof surface from a schema's semantic annotations and field stats.
 
     Re-runs inference from the schema's own samples metadata to produce
@@ -152,7 +153,8 @@ def build_review_proof(schema: JSONDocument) -> SchemaReviewProof:
         RECORD_STREAM_KINDS,
     )
 
-    artifact_kind_value = schema.get("x-polylogue-artifact-kind")
+    schema_node = json_document(schema)
+    artifact_kind_value = schema_node.get("x-polylogue-artifact-kind")
     artifact_kind = artifact_kind_value if isinstance(artifact_kind_value, str) else None
     is_record_stream = artifact_kind in RECORD_STREAM_KINDS
 
@@ -164,7 +166,7 @@ def build_review_proof(schema: JSONDocument) -> SchemaReviewProof:
 
     # Collect all role assignments from the schema itself
     role_entries: dict[str, list[_RoleCandidate]] = {}
-    _collect_role_candidates_from_schema(schema, "$", role_entries)
+    _collect_role_candidates_from_schema(schema_node, "$", role_entries)
 
     # Build proof entries for each semantic role
     proof_entries: list[SchemaRoleProofEntry] = []

--- a/polylogue/schemas/operator_inference.py
+++ b/polylogue/schemas/operator_inference.py
@@ -2,10 +2,16 @@
 
 from __future__ import annotations
 
-from typing import Any, cast
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Protocol, cast
 
 from polylogue.scenarios import CorpusScenario, CorpusSpec, build_corpus_scenarios, build_inferred_corpus_specs
 from polylogue.schemas.audit_models import AuditReport
+from polylogue.schemas.json_types import JSONDocument
+from polylogue.schemas.operator_models import (
+    JSONDocument as OperatorJSONDocument,
+)
 from polylogue.schemas.operator_models import (
     SchemaAuditRequest,
     SchemaCompareRequest,
@@ -19,12 +25,53 @@ from polylogue.schemas.operator_models import (
     SchemaProviderSnapshot,
 )
 from polylogue.schemas.operator_registry import schema_registry
-from polylogue.schemas.packages import SchemaPackageCatalog
-from polylogue.schemas.registry import ClusterManifest
+from polylogue.schemas.packages import SchemaPackageCatalog, SchemaVersionPackage
+from polylogue.schemas.tooling_models import ClusterManifest, SchemaDiff
 from polylogue.types import Provider
 
 
-def _registry_catalog(registry: Any, provider: str) -> SchemaPackageCatalog | None:
+class _SchemaRegistryLike(Protocol):
+    def load_package_catalog(self, provider: str) -> SchemaPackageCatalog | None: ...
+
+    def cluster_samples(self, provider: str, samples: Sequence[JSONDocument]) -> ClusterManifest: ...
+
+    def save_cluster_manifest(self, manifest: ClusterManifest) -> Path: ...
+
+    def load_cluster_manifest(self, provider: str) -> ClusterManifest | None: ...
+
+    def list_providers(self) -> list[str]: ...
+
+    def list_versions(self, provider: str) -> list[str]: ...
+
+    def get_schema_age_days(self, provider: str) -> int | None: ...
+
+    def compare_versions(
+        self,
+        provider: str,
+        from_version: str,
+        to_version: str,
+        *,
+        element_kind: str | None = None,
+    ) -> SchemaDiff: ...
+
+    def promote_cluster(
+        self,
+        provider: str,
+        cluster_id: str,
+        *,
+        samples: Sequence[JSONDocument] | None = None,
+    ) -> str: ...
+
+    def get_package(self, provider: str, *, version: str) -> SchemaVersionPackage | None: ...
+
+    def get_element_schema(self, provider: str, *, version: str) -> JSONDocument | None: ...
+
+
+def _typed_registry() -> _SchemaRegistryLike:
+    return cast(_SchemaRegistryLike, schema_registry())
+
+
+def _registry_catalog(registry: object, provider: str) -> SchemaPackageCatalog | None:
     load_catalog = getattr(registry, "load_package_catalog", None)
     if load_catalog is None:
         return None
@@ -67,7 +114,7 @@ def infer_schema(request: SchemaInferRequest) -> SchemaInferResult:
         full_corpus=request.full_corpus,
     )
     package_version = result.default_version or "default"
-    registry = schema_registry()
+    registry = _typed_registry()
     if not request.cluster or not result.success:
         corpus_specs, corpus_scenarios = _build_inferred_outputs(
             provider=request.provider,
@@ -135,9 +182,9 @@ def infer_schema(request: SchemaInferRequest) -> SchemaInferResult:
 def list_inferred_corpus_specs(
     *,
     provider: str | None = None,
-    registry: Any | None = None,
+    registry: _SchemaRegistryLike | None = None,
 ) -> tuple[CorpusSpec, ...]:
-    registry = registry or schema_registry()
+    registry = registry or _typed_registry()
     providers = (provider,) if provider is not None else tuple(registry.list_providers())
     specs: list[CorpusSpec] = []
     for provider_name in providers:
@@ -169,7 +216,7 @@ def list_inferred_corpus_specs(
 def list_inferred_corpus_scenarios(
     *,
     provider: str | None = None,
-    registry: Any | None = None,
+    registry: _SchemaRegistryLike | None = None,
 ) -> tuple[CorpusScenario, ...]:
     return build_corpus_scenarios(
         list_inferred_corpus_specs(provider=provider, registry=registry),
@@ -179,7 +226,7 @@ def list_inferred_corpus_scenarios(
 
 
 def list_schemas(request: SchemaListRequest) -> SchemaListResult:
-    registry = schema_registry()
+    registry = _typed_registry()
     if request.provider is not None:
         provider = request.provider
         return SchemaListResult(
@@ -215,7 +262,7 @@ def list_schemas(request: SchemaListRequest) -> SchemaListResult:
 
 
 def compare_schema_versions(request: SchemaCompareRequest) -> SchemaCompareResult:
-    registry = schema_registry()
+    registry = _typed_registry()
     return SchemaCompareResult(
         diff=registry.compare_versions(
             request.provider,
@@ -231,8 +278,8 @@ def promote_schema_cluster(request: SchemaPromoteRequest) -> SchemaPromoteResult
     from polylogue.schemas.sampling import load_samples_from_db
     from polylogue.schemas.shape_fingerprint import _structure_fingerprint
 
-    registry = schema_registry()
-    samples: list[dict[str, Any]] | None = None
+    registry = _typed_registry()
+    samples: list[JSONDocument] | None = None
     if request.with_samples:
         provider_token = Provider.from_string(request.provider)
         config = PROVIDERS.get(provider_token)
@@ -263,7 +310,7 @@ def promote_schema_cluster(request: SchemaPromoteRequest) -> SchemaPromoteResult
         cluster_id=request.cluster_id,
         package_version=new_version,
         package=registry.get_package(request.provider, version=new_version),
-        schema=registry.get_element_schema(request.provider, version=new_version),
+        schema=cast(OperatorJSONDocument | None, registry.get_element_schema(request.provider, version=new_version)),
         versions=registry.list_versions(request.provider),
     )
 

--- a/polylogue/schemas/operator_models.py
+++ b/polylogue/schemas/operator_models.py
@@ -135,7 +135,7 @@ class SchemaCompareResult:
     diff: SchemaDiff
 
     def to_dict(self) -> JSONDocument:
-        return self.diff.to_dict()
+        return cast(JSONDocument, self.diff.to_dict())
 
 
 @dataclass(frozen=True)

--- a/polylogue/schemas/packages.py
+++ b/polylogue/schemas/packages.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
-from typing import Any
 
+from polylogue.schemas.json_types import JSONDocument, json_document, json_document_list
 from polylogue.types import Provider
 
 
@@ -14,6 +14,24 @@ def _provider_value(provider: str | Provider) -> str:
     if provider_token is Provider.UNKNOWN and isinstance(provider, str):
         return provider
     return str(provider_token)
+
+
+def _string_or_none(value: object) -> str | None:
+    return value if isinstance(value, str) else None
+
+
+def _string_list(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value]
+
+
+def _int_value(value: object, default: int = 0) -> int:
+    return int(value) if isinstance(value, (str, int, float)) else default
+
+
+def _string_int_dict(value: object) -> dict[str, int]:
+    return {str(key): _int_value(item) for key, item in json_document(value).items()}
 
 
 @dataclass
@@ -33,26 +51,26 @@ class SchemaElementManifest:
     representative_paths: list[str] = field(default_factory=list)
     observed_artifact_count: int = 0
 
-    def to_dict(self) -> dict[str, Any]:
-        return asdict(self)
+    def to_dict(self) -> JSONDocument:
+        return json_document(asdict(self))
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> SchemaElementManifest:
+    def from_dict(cls, data: JSONDocument) -> SchemaElementManifest:
         return cls(
             element_kind=str(data["element_kind"]),
-            schema_file=data.get("schema_file"),
-            sample_count=int(data.get("sample_count", 0)),
-            artifact_count=int(data.get("artifact_count", 0)),
+            schema_file=_string_or_none(data.get("schema_file")),
+            sample_count=_int_value(data.get("sample_count")),
+            artifact_count=_int_value(data.get("artifact_count")),
             supported=bool(data.get("supported", True)),
             first_seen=str(data.get("first_seen", "")),
             last_seen=str(data.get("last_seen", "")),
-            bundle_scope_count=int(data.get("bundle_scope_count", 0)),
-            bundle_scopes=[str(item) for item in data.get("bundle_scopes", [])],
-            exact_structure_ids=[str(item) for item in data.get("exact_structure_ids", [])],
-            profile_family_ids=[str(item) for item in data.get("profile_family_ids", [])],
-            profile_tokens=[str(item) for item in data.get("profile_tokens", [])],
-            representative_paths=[str(item) for item in data.get("representative_paths", [])],
-            observed_artifact_count=int(data.get("observed_artifact_count", 0)),
+            bundle_scope_count=_int_value(data.get("bundle_scope_count")),
+            bundle_scopes=_string_list(data.get("bundle_scopes")),
+            exact_structure_ids=_string_list(data.get("exact_structure_ids")),
+            profile_family_ids=_string_list(data.get("profile_family_ids")),
+            profile_tokens=_string_list(data.get("profile_tokens")),
+            representative_paths=_string_list(data.get("representative_paths")),
+            observed_artifact_count=_int_value(data.get("observed_artifact_count")),
         )
 
 
@@ -73,43 +91,43 @@ class SchemaVersionPackage:
     elements: list[SchemaElementManifest] = field(default_factory=list)
     orphan_adjunct_counts: dict[str, int] = field(default_factory=dict)
 
-    def to_dict(self) -> dict[str, Any]:
-        return {
-            "provider": _provider_value(self.provider),
-            "version": self.version,
-            "anchor_kind": self.anchor_kind,
-            "default_element_kind": self.default_element_kind,
-            "first_seen": self.first_seen,
-            "last_seen": self.last_seen,
-            "bundle_scope_count": self.bundle_scope_count,
-            "sample_count": self.sample_count,
-            "anchor_profile_family_id": self.anchor_profile_family_id,
-            "bundle_scopes": self.bundle_scopes,
-            "profile_family_ids": self.profile_family_ids,
-            "representative_paths": self.representative_paths,
-            "elements": [element.to_dict() for element in self.elements],
-            "orphan_adjunct_counts": self.orphan_adjunct_counts,
-        }
+    def to_dict(self) -> JSONDocument:
+        return json_document(
+            {
+                "provider": _provider_value(self.provider),
+                "version": self.version,
+                "anchor_kind": self.anchor_kind,
+                "default_element_kind": self.default_element_kind,
+                "first_seen": self.first_seen,
+                "last_seen": self.last_seen,
+                "bundle_scope_count": self.bundle_scope_count,
+                "sample_count": self.sample_count,
+                "anchor_profile_family_id": self.anchor_profile_family_id,
+                "bundle_scopes": self.bundle_scopes,
+                "profile_family_ids": self.profile_family_ids,
+                "representative_paths": self.representative_paths,
+                "elements": [element.to_dict() for element in self.elements],
+                "orphan_adjunct_counts": self.orphan_adjunct_counts,
+            }
+        )
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> SchemaVersionPackage:
+    def from_dict(cls, data: JSONDocument) -> SchemaVersionPackage:
         return cls(
-            provider=_provider_value(data["provider"]),
+            provider=_provider_value(str(data["provider"])),
             version=str(data["version"]),
             anchor_kind=str(data["anchor_kind"]),
             default_element_kind=str(data.get("default_element_kind", data["anchor_kind"])),
             first_seen=str(data["first_seen"]),
             last_seen=str(data["last_seen"]),
-            bundle_scope_count=int(data.get("bundle_scope_count", 0)),
-            sample_count=int(data.get("sample_count", 0)),
+            bundle_scope_count=_int_value(data.get("bundle_scope_count")),
+            sample_count=_int_value(data.get("sample_count")),
             anchor_profile_family_id=str(data.get("anchor_profile_family_id", "")),
-            bundle_scopes=[str(item) for item in data.get("bundle_scopes", [])],
-            profile_family_ids=[str(item) for item in data.get("profile_family_ids", [])],
-            representative_paths=[str(item) for item in data.get("representative_paths", [])],
-            elements=[SchemaElementManifest.from_dict(item) for item in data.get("elements", [])],
-            orphan_adjunct_counts={
-                str(key): int(value) for key, value in data.get("orphan_adjunct_counts", {}).items()
-            },
+            bundle_scopes=_string_list(data.get("bundle_scopes")),
+            profile_family_ids=_string_list(data.get("profile_family_ids")),
+            representative_paths=_string_list(data.get("representative_paths")),
+            elements=[SchemaElementManifest.from_dict(item) for item in json_document_list(data.get("elements"))],
+            orphan_adjunct_counts=_string_int_dict(data.get("orphan_adjunct_counts")),
         )
 
     def element(self, element_kind: str | None = None) -> SchemaElementManifest | None:
@@ -131,29 +149,29 @@ class SchemaPackageCatalog:
         if not self.generated_at:
             self.generated_at = datetime.now(tz=timezone.utc).isoformat()
 
-    def to_dict(self) -> dict[str, Any]:
-        return {
-            "provider": _provider_value(self.provider),
-            "generated_at": self.generated_at,
-            "latest_version": self.latest_version,
-            "default_version": self.default_version,
-            "recommended_version": self.recommended_version,
-            "orphan_adjunct_counts": self.orphan_adjunct_counts,
-            "packages": [package.to_dict() for package in self.packages],
-        }
+    def to_dict(self) -> JSONDocument:
+        return json_document(
+            {
+                "provider": _provider_value(self.provider),
+                "generated_at": self.generated_at,
+                "latest_version": self.latest_version,
+                "default_version": self.default_version,
+                "recommended_version": self.recommended_version,
+                "orphan_adjunct_counts": self.orphan_adjunct_counts,
+                "packages": [package.to_dict() for package in self.packages],
+            }
+        )
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> SchemaPackageCatalog:
+    def from_dict(cls, data: JSONDocument) -> SchemaPackageCatalog:
         return cls(
-            provider=_provider_value(data["provider"]),
+            provider=_provider_value(str(data["provider"])),
             generated_at=str(data.get("generated_at", "")),
-            latest_version=data.get("latest_version"),
-            default_version=data.get("default_version"),
-            recommended_version=data.get("recommended_version"),
-            orphan_adjunct_counts={
-                str(key): int(value) for key, value in data.get("orphan_adjunct_counts", {}).items()
-            },
-            packages=[SchemaVersionPackage.from_dict(item) for item in data.get("packages", [])],
+            latest_version=_string_or_none(data.get("latest_version")),
+            default_version=_string_or_none(data.get("default_version")),
+            recommended_version=_string_or_none(data.get("recommended_version")),
+            orphan_adjunct_counts=_string_int_dict(data.get("orphan_adjunct_counts")),
+            packages=[SchemaVersionPackage.from_dict(item) for item in json_document_list(data.get("packages"))],
         )
 
     def package(self, version: str) -> SchemaVersionPackage | None:

--- a/polylogue/schemas/pinning.py
+++ b/polylogue/schemas/pinning.py
@@ -21,14 +21,24 @@ import json
 import logging
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Literal, TypeAlias, cast
 
+from polylogue.schemas.json_types import JSONDocument, json_document, json_document_list
 from polylogue.types import Provider
 
 logger = logging.getLogger(__name__)
 
+PinAction: TypeAlias = Literal["confirm", "reject"]
+PinnableRole: TypeAlias = Literal[
+    "message_role",
+    "message_body",
+    "message_timestamp",
+    "message_container",
+    "conversation_title",
+]
+
 # Semantic roles that can be pinned
-PINNABLE_ROLES = frozenset(
+PINNABLE_ROLES: frozenset[PinnableRole] = frozenset(
     {
         "message_role",
         "message_body",
@@ -39,20 +49,55 @@ PINNABLE_ROLES = frozenset(
 )
 
 
+def _required_string(record: JSONDocument, key: str) -> str:
+    value = record.get(key)
+    if not isinstance(value, str):
+        raise ValueError(f"Pin field {key!r} must be a string")
+    return value
+
+
+def _optional_string(record: JSONDocument, key: str, default: str = "") -> str:
+    value = record.get(key)
+    return value if isinstance(value, str) else default
+
+
+def _pin_action(value: object) -> PinAction:
+    if value in ("confirm", "reject"):
+        return cast(PinAction, value)
+    raise ValueError(f"Pin action must be 'confirm' or 'reject', got {value!r}")
+
+
+def _pin_role(value: object) -> PinnableRole:
+    if value in PINNABLE_ROLES:
+        return cast(PinnableRole, value)
+    raise ValueError(f"Role {value!r} is not pinnable. Valid: {sorted(PINNABLE_ROLES)}")
+
+
 @dataclass(frozen=True, slots=True)
 class PinDecision:
     """A human review decision about a semantic annotation."""
 
     path: str
-    role: str
-    action: str  # "confirm" or "reject"
+    role: PinnableRole
+    action: PinAction
     reason: str = ""
 
     def __post_init__(self) -> None:
-        if self.action not in ("confirm", "reject"):
-            raise ValueError(f"Pin action must be 'confirm' or 'reject', got {self.action!r}")
-        if self.role not in PINNABLE_ROLES:
-            raise ValueError(f"Role {self.role!r} is not pinnable. Valid: {sorted(PINNABLE_ROLES)}")
+        _pin_action(self.action)
+        _pin_role(self.role)
+
+    def to_dict(self) -> JSONDocument:
+        return json_document(asdict(self))
+
+    @classmethod
+    def from_dict(cls, data: object) -> PinDecision:
+        record = json_document(data)
+        return cls(
+            path=_required_string(record, "path"),
+            role=_pin_role(record.get("role")),
+            action=_pin_action(record.get("action")),
+            reason=_optional_string(record, "reason"),
+        )
 
 
 @dataclass
@@ -73,24 +118,16 @@ class PinSet:
         """Check if a specific path+role combination was rejected."""
         return any(pin.path == path and pin.role == role and pin.action == "reject" for pin in self.pins)
 
-    def to_dict(self) -> dict[str, Any]:
-        return {
-            "provider": self.provider,
-            "pins": [asdict(pin) for pin in self.pins],
-        }
+    def to_dict(self) -> JSONDocument:
+        return json_document({"provider": self.provider, "pins": [pin.to_dict() for pin in self.pins]})
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> PinSet:
-        pins = [
-            PinDecision(
-                path=p["path"],
-                role=p["role"],
-                action=p["action"],
-                reason=p.get("reason", ""),
-            )
-            for p in data.get("pins", [])
-        ]
-        return cls(provider=data.get("provider", ""), pins=pins)
+    def from_dict(cls, data: object) -> PinSet:
+        payload = json_document(data)
+        return cls(
+            provider=_optional_string(payload, "provider"),
+            pins=[PinDecision.from_dict(pin) for pin in json_document_list(payload.get("pins"))],
+        )
 
 
 # -------------------------------------------------------------------
@@ -116,7 +153,7 @@ def load_pins(provider: Provider | str) -> PinSet:
         pin_set = PinSet.from_dict(data)
         pin_set.provider = str(provider)
         return pin_set
-    except (json.JSONDecodeError, KeyError, TypeError) as exc:
+    except (json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
         logger.warning("Failed to load pins from %s: %s", path, exc)
         return PinSet(provider=str(provider))
 
@@ -134,7 +171,7 @@ def save_pins(provider: Provider | str, pin_set: PinSet) -> None:
 
 
 def resolve_pinned_paths(
-    schema: dict[str, Any],
+    schema: JSONDocument,
     pins: PinSet,
 ) -> dict[str, str | None]:
     """Resolve which schema paths to use for each semantic role.
@@ -155,9 +192,9 @@ def resolve_pinned_paths(
 
 
 def apply_pins_to_schema(
-    schema: dict[str, Any],
+    schema: JSONDocument,
     pins: PinSet,
-) -> dict[str, Any]:
+) -> JSONDocument:
     """Apply pin decisions to a schema in-place (for re-inference).
 
     - Confirmed annotations get ``x-polylogue-pinned: true``
@@ -170,7 +207,7 @@ def apply_pins_to_schema(
 
 
 def _apply_pins_recursive(
-    node: Any,
+    node: object,
     path: str,
     pins: PinSet,
 ) -> None:
@@ -179,12 +216,12 @@ def _apply_pins_recursive(
         return
 
     role = node.get("x-polylogue-semantic-role")
-    if role and pins.is_rejected(path or "$", role):
+    if isinstance(role, str) and pins.is_rejected(path or "$", role):
         # Remove rejected annotation
         node.pop("x-polylogue-semantic-role", None)
         node.pop("x-polylogue-evidence", None)
         node["x-polylogue-rejected"] = True
-    elif role and pins.confirmed_path(role) == (path or "$"):
+    elif isinstance(role, str) and pins.confirmed_path(role) == (path or "$"):
         node["x-polylogue-pinned"] = True
 
     # Recurse into schema structure

--- a/polylogue/schemas/pinning.py
+++ b/polylogue/schemas/pinning.py
@@ -171,7 +171,7 @@ def save_pins(provider: Provider | str, pin_set: PinSet) -> None:
 
 
 def resolve_pinned_paths(
-    schema: JSONDocument,
+    schema: object,
     pins: PinSet,
 ) -> dict[str, str | None]:
     """Resolve which schema paths to use for each semantic role.
@@ -180,6 +180,7 @@ def resolve_pinned_paths(
     produce entries. If no pin exists for a role, it maps to None (and
     the extractor falls back to well-known-name heuristics).
     """
+    del schema
     result: dict[str, str | None] = dict.fromkeys(PINNABLE_ROLES)
 
     # First: apply confirmed pins directly

--- a/polylogue/schemas/runtime_registry.py
+++ b/polylogue/schemas/runtime_registry.py
@@ -344,7 +344,7 @@ class SchemaRegistry:
         for element in package.elements:
             if element.schema_file is None:
                 continue
-            schema = copy.deepcopy(element_schemas[element.element_kind])
+            schema = cast(dict[str, object], copy.deepcopy(element_schemas[element.element_kind]))
             schema["$id"] = f"polylogue://schemas/{provider_token}/{package.version}/{element.element_kind}"
             schema["x-polylogue-version"] = (
                 int(package.version[1:]) if package.version.startswith("v") else package.version

--- a/polylogue/schemas/semantic_inference_models.py
+++ b/polylogue/schemas/semantic_inference_models.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any
+
+from polylogue.schemas.json_types import JSONDocument
 
 KNOWN_ROLE_VALUES = frozenset(
     {
@@ -52,7 +53,7 @@ class SemanticCandidate:
     path: str
     role: str
     confidence: float
-    evidence: dict[str, Any] = field(default_factory=dict)
+    evidence: JSONDocument = field(default_factory=dict)
 
 
 __all__ = [

--- a/polylogue/schemas/semantic_inference_models.py
+++ b/polylogue/schemas/semantic_inference_models.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
-from polylogue.schemas.json_types import JSONDocument
-
 KNOWN_ROLE_VALUES = frozenset(
     {
         "user",
@@ -53,7 +51,7 @@ class SemanticCandidate:
     path: str
     role: str
     confidence: float
-    evidence: JSONDocument = field(default_factory=dict)
+    evidence: dict[str, object] = field(default_factory=dict)
 
 
 __all__ = [

--- a/polylogue/schemas/synthetic/build_records.py
+++ b/polylogue/schemas/synthetic/build_records.py
@@ -4,13 +4,15 @@ from __future__ import annotations
 
 import random
 import uuid
-from typing import Protocol
+from typing import Protocol, TypeAlias
 
-from polylogue.lib.raw_payload_decode import JSONRecord, JSONValue
+from polylogue.lib.raw_payload_decode import JSONValue
 from polylogue.schemas.synthetic.models import SchemaRecord
 from polylogue.schemas.synthetic.semantic_values import SemanticValueGenerator
 from polylogue.schemas.synthetic.showcase import ConversationTheme
 from polylogue.schemas.synthetic.wire_formats import WireFormat
+
+SyntheticRecord: TypeAlias = dict[str, JSONValue]
 
 
 class _WireFormatContext(Protocol):
@@ -32,7 +34,7 @@ class _WireFormatContext(Protocol):
 
     def _ensure_wire_format(
         self,
-        data: JSONRecord,
+        data: SyntheticRecord,
         role: str,
         rng: random.Random,
         index: int,
@@ -43,7 +45,7 @@ class _WireFormatContext(Protocol):
     def _role_cycle(self) -> list[str]: ...
 
 
-def _coerce_record(value: JSONValue) -> JSONRecord:
+def _coerce_record(value: JSONValue) -> SyntheticRecord:
     return value if isinstance(value, dict) else {}
 
 
@@ -51,7 +53,7 @@ def _coerce_schema(value: JSONValue) -> SchemaRecord:
     return value if isinstance(value, dict) else {}
 
 
-def _child_id_list(record: JSONRecord, field_name: str) -> list[JSONValue]:
+def _child_id_list(record: SyntheticRecord, field_name: str) -> list[JSONValue]:
     existing = record.get(field_name)
     if isinstance(existing, list) and all(isinstance(item, str) for item in existing):
         return existing
@@ -60,7 +62,7 @@ def _child_id_list(record: JSONRecord, field_name: str) -> list[JSONValue]:
     return children
 
 
-def _message_payloads(records: list[JSONRecord]) -> list[JSONValue]:
+def _message_payloads(records: list[SyntheticRecord]) -> list[JSONValue]:
     return list(records)
 
 
@@ -77,7 +79,7 @@ def _has_messages_path(parts: list[str], schema: SchemaRecord) -> tuple[bool, Sc
 
 def _generate_tree_json(
     self: _WireFormatContext, n_messages: int, rng: random.Random, *, theme: ConversationTheme | None = None
-) -> JSONRecord:
+) -> SyntheticRecord:
     tree_cfg = self.wire_format.tree
     assert tree_cfg is not None and tree_cfg.container_path is not None
 
@@ -93,7 +95,7 @@ def _generate_tree_json(
 
     container_schema = _coerce_schema(properties.get(tree_cfg.container_path))
     node_schema = _coerce_schema(container_schema.get("additionalProperties"))
-    nodes: list[JSONRecord] = []
+    nodes: list[SyntheticRecord] = []
 
     for i in range(n_messages):
         node = _coerce_record(self._generate_from_schema(node_schema, rng))
@@ -119,7 +121,7 @@ def _generate_tree_json(
         nodes.append(node)
 
     properties_map = _coerce_schema(self.schema.get("properties"))
-    children_by_id: JSONRecord = {}
+    children_by_id: SyntheticRecord = {}
     for node in nodes:
         node_id_value = node.get(tree_cfg.key_field)
         if isinstance(node_id_value, str):
@@ -138,7 +140,7 @@ def _generate_tree_json(
 
 def _generate_linear_json(
     self: _WireFormatContext, n_messages: int, rng: random.Random, *, theme: ConversationTheme | None = None
-) -> JSONRecord:
+) -> SyntheticRecord:
     msgs_path = self.wire_format.messages_path
     assert msgs_path is not None
     msgs_parts = msgs_path.split(".")
@@ -160,7 +162,7 @@ def _generate_linear_json(
         top = {}
     top_record = _coerce_record(top)
 
-    messages: list[JSONRecord] = []
+    messages: list[SyntheticRecord] = []
     for i in range(n_messages):
         msg = _coerce_record(self._generate_from_schema(item_schema, rng))
         role = roles[i % len(roles)]
@@ -168,7 +170,7 @@ def _generate_linear_json(
         self._semantic_gen.advance_turn()
         messages.append(msg)
 
-    target: JSONRecord = top_record
+    target: SyntheticRecord = top_record
     for index, part in enumerate(msgs_parts):
         if index == len(msgs_parts) - 1:
             target[part] = _message_payloads(messages)
@@ -184,9 +186,9 @@ def _generate_linear_json(
 
 def _generate_jsonl_records(
     self: _WireFormatContext, n_messages: int, rng: random.Random, *, theme: ConversationTheme | None = None
-) -> list[JSONRecord]:
+) -> list[SyntheticRecord]:
     tree_cfg = self.wire_format.tree
-    records: list[JSONRecord] = []
+    records: list[SyntheticRecord] = []
     roles = self._role_cycle()
     session_id = str(uuid.UUID(int=rng.getrandbits(128), version=4))
     base_ts = rng.uniform(1670000000, 1760000000)

--- a/polylogue/schemas/synthetic/build_wire_formats.py
+++ b/polylogue/schemas/synthetic/build_wire_formats.py
@@ -5,14 +5,16 @@ from __future__ import annotations
 import random
 import uuid
 from datetime import datetime, timezone
-from typing import Protocol
+from typing import Protocol, TypeAlias
 
-from polylogue.lib.raw_payload_decode import JSONRecord, JSONValue
+from polylogue.lib.raw_payload_decode import JSONValue
 from polylogue.schemas.synthetic.semantic_values import _text_for_role
 from polylogue.schemas.synthetic.showcase import ConversationTheme
 
+SyntheticRecord: TypeAlias = dict[str, JSONValue]
 
-def _as_record(value: JSONValue) -> JSONRecord:
+
+def _as_record(value: JSONValue) -> SyntheticRecord:
     return value if isinstance(value, dict) else {}
 
 
@@ -21,7 +23,7 @@ class _WireFormatContext(Protocol):
 
     def _ensure_wire_chatgpt(
         self,
-        data: JSONRecord,
+        data: SyntheticRecord,
         role: str,
         rng: random.Random,
         ts: float,
@@ -32,7 +34,7 @@ class _WireFormatContext(Protocol):
 
     def _ensure_wire_claude_ai(
         self,
-        data: JSONRecord,
+        data: SyntheticRecord,
         role: str,
         rng: random.Random,
         ts: float,
@@ -43,7 +45,7 @@ class _WireFormatContext(Protocol):
 
     def _ensure_wire_claude_code(
         self,
-        data: JSONRecord,
+        data: SyntheticRecord,
         role: str,
         rng: random.Random,
         ts: float,
@@ -54,7 +56,7 @@ class _WireFormatContext(Protocol):
 
     def _ensure_wire_codex(
         self,
-        data: JSONRecord,
+        data: SyntheticRecord,
         role: str,
         rng: random.Random,
         ts: float,
@@ -65,7 +67,7 @@ class _WireFormatContext(Protocol):
 
     def _ensure_wire_gemini(
         self,
-        data: JSONRecord,
+        data: SyntheticRecord,
         role: str,
         rng: random.Random,
         *,
@@ -76,7 +78,7 @@ class _WireFormatContext(Protocol):
 
 def _ensure_wire_format(
     self: _WireFormatContext,
-    data: JSONRecord,
+    data: SyntheticRecord,
     role: str,
     rng: random.Random,
     index: int,
@@ -99,7 +101,7 @@ def _ensure_wire_format(
 
 def _ensure_wire_chatgpt(
     self: _WireFormatContext,
-    data: JSONRecord,
+    data: SyntheticRecord,
     role: str,
     rng: random.Random,
     ts: float,
@@ -128,7 +130,7 @@ def _ensure_wire_chatgpt(
 
 def _ensure_wire_claude_ai(
     self: _WireFormatContext,
-    data: JSONRecord,
+    data: SyntheticRecord,
     role: str,
     rng: random.Random,
     ts: float,
@@ -146,7 +148,7 @@ def _ensure_wire_claude_ai(
 
 def _ensure_wire_claude_code(
     self: _WireFormatContext,
-    data: JSONRecord,
+    data: SyntheticRecord,
     role: str,
     rng: random.Random,
     ts: float,
@@ -168,7 +170,7 @@ def _ensure_wire_claude_code(
 
 def _ensure_wire_codex(
     self: _WireFormatContext,
-    data: JSONRecord,
+    data: SyntheticRecord,
     role: str,
     rng: random.Random,
     ts: float,
@@ -189,7 +191,7 @@ def _ensure_wire_codex(
 
 def _ensure_wire_gemini(
     self: _WireFormatContext,
-    data: JSONRecord,
+    data: SyntheticRecord,
     role: str,
     rng: random.Random,
     *,

--- a/polylogue/schemas/synthetic/runtime.py
+++ b/polylogue/schemas/synthetic/runtime.py
@@ -5,18 +5,20 @@ from __future__ import annotations
 import json
 import random
 import uuid
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from datetime import datetime, timezone
-from typing import Protocol, cast
+from typing import Protocol, TypeAlias, cast
 
-from polylogue.lib.raw_payload_decode import JSONRecord, JSONValue
+from polylogue.lib.raw_payload_decode import JSONValue
 from polylogue.schemas.synthetic.models import SchemaRecord, SchemaValue
 from polylogue.schemas.synthetic.semantic_values import _text_for_role
 from polylogue.schemas.synthetic.wire_formats import WireEncoding
 
+SyntheticRecord: TypeAlias = dict[str, JSONValue]
+
 
 class _SemanticGenerator(Protocol):
-    def try_generate(self, schema: SchemaRecord) -> tuple[bool, JSONValue]: ...
+    def try_generate(self, schema: Mapping[str, object]) -> tuple[bool, JSONValue]: ...
 
 
 class _RelationSolver(Protocol):
@@ -65,7 +67,7 @@ class _SyntheticRuntimeContext(Protocol):
         depth: int = 0,
         max_depth: int = 6,
         path: str = "$",
-    ) -> JSONRecord: ...
+    ) -> SyntheticRecord: ...
 
     def _generate_array(
         self,
@@ -218,8 +220,8 @@ def _generate_object(
     depth: int = 0,
     max_depth: int = 6,
     path: str = "$",
-) -> JSONRecord:
-    obj: JSONRecord = {}
+) -> SyntheticRecord:
+    obj: SyntheticRecord = {}
     properties = _schema_record(schema.get("properties"))
     candidate_keys = set(properties.keys())
     if skip_keys:

--- a/polylogue/schemas/synthetic/semantic_values.py
+++ b/polylogue/schemas/synthetic/semantic_values.py
@@ -14,8 +14,9 @@ Semantic roles handled:
 from __future__ import annotations
 
 import random
+from collections.abc import Mapping
 
-from polylogue.schemas.synthetic.models import SchemaRecord, SchemaValue
+from polylogue.schemas.synthetic.models import SchemaScalar
 from polylogue.schemas.synthetic.showcase import _SHOWCASE_THEMES, ConversationTheme
 
 # =============================================================================
@@ -42,7 +43,7 @@ _ROLE_TEXTS: dict[str, list[str]] = {
 }
 
 
-def _string_values(schema: SchemaRecord, key: str) -> list[str]:
+def _string_values(schema: Mapping[str, object], key: str) -> list[str]:
     values = schema.get(key)
     if not isinstance(values, list):
         return []
@@ -97,8 +98,8 @@ class SemanticValueGenerator:
 
     def try_generate(
         self,
-        schema: SchemaRecord,
-    ) -> tuple[bool, SchemaValue]:
+        schema: Mapping[str, object],
+    ) -> tuple[bool, SchemaScalar]:
         """Attempt semantic generation for a schema node.
 
         Returns:
@@ -137,7 +138,7 @@ class SemanticValueGenerator:
     def turn_index(self) -> int:
         return self._turn_index
 
-    def _generate_role(self, schema: SchemaRecord) -> str:
+    def _generate_role(self, schema: Mapping[str, object]) -> str:
         """Generate a role value from observed values or cycle."""
         # Prefer observed values from the schema
         if values := _string_values(schema, "x-polylogue-values"):
@@ -150,7 +151,7 @@ class SemanticValueGenerator:
             return str(self.rng.choice(values))
         return self.current_role
 
-    def _generate_body(self, schema: SchemaRecord) -> str:
+    def _generate_body(self, schema: Mapping[str, object]) -> str:
         """Generate message body content."""
         return _text_for_role(
             self.rng,
@@ -159,7 +160,7 @@ class SemanticValueGenerator:
             theme=self.theme,
         )
 
-    def _generate_timestamp(self, schema: SchemaRecord) -> SchemaValue:
+    def _generate_timestamp(self, schema: Mapping[str, object]) -> SchemaScalar:
         """Generate a sequential timestamp value.
 
         Respects the field's format annotation to produce the right
@@ -180,7 +181,7 @@ class SemanticValueGenerator:
             case _:
                 return ts
 
-    def _generate_title(self, schema: SchemaRecord) -> str:
+    def _generate_title(self, schema: Mapping[str, object]) -> str:
         """Generate a conversation title."""
         if self.theme is not None:
             return self.theme.title

--- a/polylogue/schemas/synthetic/semantic_values.py
+++ b/polylogue/schemas/synthetic/semantic_values.py
@@ -14,8 +14,8 @@ Semantic roles handled:
 from __future__ import annotations
 
 import random
-from typing import Any
 
+from polylogue.schemas.synthetic.models import SchemaRecord, SchemaValue
 from polylogue.schemas.synthetic.showcase import _SHOWCASE_THEMES, ConversationTheme
 
 # =============================================================================
@@ -40,6 +40,13 @@ _ROLE_TEXTS: dict[str, list[str]] = {
     "model": ["I'll explain step by step.", "Here's a breakdown of the architecture."],
     "tool": ["Function executed successfully.", "Error: resource not found."],
 }
+
+
+def _string_values(schema: SchemaRecord, key: str) -> list[str]:
+    values = schema.get(key)
+    if not isinstance(values, list):
+        return []
+    return [value for value in values if isinstance(value, str)]
 
 
 def _text_for_role(
@@ -90,8 +97,8 @@ class SemanticValueGenerator:
 
     def try_generate(
         self,
-        schema: dict[str, Any],
-    ) -> tuple[bool, Any]:
+        schema: SchemaRecord,
+    ) -> tuple[bool, SchemaValue]:
         """Attempt semantic generation for a schema node.
 
         Returns:
@@ -130,10 +137,10 @@ class SemanticValueGenerator:
     def turn_index(self) -> int:
         return self._turn_index
 
-    def _generate_role(self, schema: dict[str, Any]) -> str:
+    def _generate_role(self, schema: SchemaRecord) -> str:
         """Generate a role value from observed values or cycle."""
         # Prefer observed values from the schema
-        if values := schema.get("x-polylogue-values"):
+        if values := _string_values(schema, "x-polylogue-values"):
             # Filter to known conversational roles if present
             conversational = [v for v in values if v in {"user", "assistant", "human", "model", "system", "tool"}]
             if conversational:
@@ -143,7 +150,7 @@ class SemanticValueGenerator:
             return str(self.rng.choice(values))
         return self.current_role
 
-    def _generate_body(self, schema: dict[str, Any]) -> str:
+    def _generate_body(self, schema: SchemaRecord) -> str:
         """Generate message body content."""
         return _text_for_role(
             self.rng,
@@ -152,7 +159,7 @@ class SemanticValueGenerator:
             theme=self.theme,
         )
 
-    def _generate_timestamp(self, schema: dict[str, Any]) -> Any:
+    def _generate_timestamp(self, schema: SchemaRecord) -> SchemaValue:
         """Generate a sequential timestamp value.
 
         Respects the field's format annotation to produce the right
@@ -173,13 +180,13 @@ class SemanticValueGenerator:
             case _:
                 return ts
 
-    def _generate_title(self, schema: dict[str, Any]) -> str:
+    def _generate_title(self, schema: SchemaRecord) -> str:
         """Generate a conversation title."""
         if self.theme is not None:
             return self.theme.title
 
         # Use observed values if available
-        if values := schema.get("x-polylogue-values"):
+        if values := _string_values(schema, "x-polylogue-values"):
             return str(self.rng.choice(values))
 
         # Fallback: pick a theme title

--- a/polylogue/schemas/tooling_models.py
+++ b/polylogue/schemas/tooling_models.py
@@ -4,9 +4,27 @@ from __future__ import annotations
 
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
-from typing import Any
 
+from polylogue.schemas.json_types import JSONDocument, json_document, json_document_list
 from polylogue.schemas.runtime_registry import SchemaProvider, canonical_schema_provider
+
+
+def _string_list(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value]
+
+
+def _int_dict(value: object) -> dict[str, int]:
+    return {str(key): int(item) for key, item in json_document(value).items() if isinstance(item, (str, int, float))}
+
+
+def _int_scalar(value: object, default: int = 0) -> int:
+    return int(value) if isinstance(value, (str, int, float)) and not isinstance(value, bool) else default
+
+
+def _float_scalar(value: object, default: float = 1.0) -> float:
+    return float(value) if isinstance(value, (str, int, float)) and not isinstance(value, bool) else default
 
 
 @dataclass
@@ -15,7 +33,7 @@ class PropertyChange:
     kind: str
     detail: str
 
-    def to_dict(self) -> dict[str, Any]:
+    def to_dict(self) -> JSONDocument:
         return {"path": self.path, "kind": self.kind, "detail": self.detail}
 
 
@@ -43,18 +61,20 @@ class SchemaDiff:
             parts.append(f"~{len(self.changed_properties)} changed")
         return ", ".join(parts) if parts else "no changes"
 
-    def to_dict(self) -> dict[str, Any]:
-        return {
-            "provider": str(self.provider),
-            "version_a": self.version_a,
-            "version_b": self.version_b,
-            "summary": self.summary(),
-            "has_changes": self.has_changes,
-            "added_properties": self.added_properties,
-            "removed_properties": self.removed_properties,
-            "changed_properties": self.changed_properties,
-            "classified_changes": [change.to_dict() for change in self.classified_changes],
-        }
+    def to_dict(self) -> JSONDocument:
+        return json_document(
+            {
+                "provider": str(self.provider),
+                "version_a": self.version_a,
+                "version_b": self.version_b,
+                "summary": self.summary(),
+                "has_changes": self.has_changes,
+                "added_properties": self.added_properties,
+                "removed_properties": self.removed_properties,
+                "changed_properties": self.changed_properties,
+                "classified_changes": [change.to_dict() for change in self.classified_changes],
+            }
+        )
 
     def to_text(self) -> str:
         lines = [
@@ -170,10 +190,10 @@ class SchemaCluster:
     bundle_scope_count: int = 0
     promoted_package_version: str | None = None
 
-    def to_dict(self) -> dict[str, Any]:
+    def to_dict(self) -> JSONDocument:
         data = asdict(self)
         data["provider"] = str(self.provider)
-        return data
+        return json_document(data)
 
 
 @dataclass
@@ -188,41 +208,48 @@ class ClusterManifest:
         if not self.generated_at:
             self.generated_at = datetime.now(tz=timezone.utc).isoformat()
 
-    def to_dict(self) -> dict[str, Any]:
-        return {
-            "provider": str(self.provider),
-            "generated_at": self.generated_at,
-            "cluster_count": len(self.clusters),
-            "artifact_counts": self.artifact_counts,
-            "default_version": self.default_version,
-            "clusters": [cluster.to_dict() for cluster in self.clusters],
-        }
+    def to_dict(self) -> JSONDocument:
+        return json_document(
+            {
+                "provider": str(self.provider),
+                "generated_at": self.generated_at,
+                "cluster_count": len(self.clusters),
+                "artifact_counts": self.artifact_counts,
+                "default_version": self.default_version,
+                "clusters": [cluster.to_dict() for cluster in self.clusters],
+            }
+        )
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> ClusterManifest:
+    def from_dict(cls, data: JSONDocument) -> ClusterManifest:
+        cluster_payloads = json_document_list(data.get("clusters"))
         return cls(
-            provider=canonical_schema_provider(data["provider"]),
+            provider=canonical_schema_provider(str(data["provider"])),
             clusters=[
                 SchemaCluster(
-                    cluster_id=cluster["cluster_id"],
-                    provider=canonical_schema_provider(cluster["provider"]),
-                    sample_count=int(cluster["sample_count"]),
-                    first_seen=cluster["first_seen"],
-                    last_seen=cluster["last_seen"],
-                    representative_paths=list(cluster.get("representative_paths", [])),
-                    dominant_keys=list(cluster.get("dominant_keys", [])),
-                    confidence=float(cluster.get("confidence", 1.0)),
+                    cluster_id=str(cluster["cluster_id"]),
+                    provider=canonical_schema_provider(str(cluster["provider"])),
+                    sample_count=_int_scalar(cluster.get("sample_count")),
+                    first_seen=str(cluster["first_seen"]),
+                    last_seen=str(cluster["last_seen"]),
+                    representative_paths=_string_list(cluster.get("representative_paths")),
+                    dominant_keys=_string_list(cluster.get("dominant_keys")),
+                    confidence=_float_scalar(cluster.get("confidence")),
                     artifact_kind=str(cluster.get("artifact_kind", "unspecified")),
-                    profile_tokens=list(cluster.get("profile_tokens", [])),
-                    exact_structure_ids=list(cluster.get("exact_structure_ids", [])),
-                    bundle_scope_count=int(cluster.get("bundle_scope_count", 0)),
-                    promoted_package_version=cluster.get("promoted_package_version"),
+                    profile_tokens=_string_list(cluster.get("profile_tokens")),
+                    exact_structure_ids=_string_list(cluster.get("exact_structure_ids")),
+                    bundle_scope_count=_int_scalar(cluster.get("bundle_scope_count")),
+                    promoted_package_version=(
+                        str(cluster["promoted_package_version"])
+                        if isinstance(cluster.get("promoted_package_version"), str)
+                        else None
+                    ),
                 )
-                for cluster in data.get("clusters", [])
+                for cluster in cluster_payloads
             ],
-            generated_at=data.get("generated_at", ""),
-            artifact_counts={str(key): int(value) for key, value in data.get("artifact_counts", {}).items()},
-            default_version=data.get("default_version"),
+            generated_at=str(data.get("generated_at", "")),
+            artifact_counts=_int_dict(data.get("artifact_counts")),
+            default_version=str(data["default_version"]) if isinstance(data.get("default_version"), str) else None,
         )
 
 

--- a/polylogue/schemas/unified_adapters.py
+++ b/polylogue/schemas/unified_adapters.py
@@ -52,7 +52,7 @@ def _harmonize_viewport_message(
         cost=meta.cost,
         duration_ms=meta.duration_ms,
         provider=provider,
-        raw=raw,
+        raw=dict(raw),
     )
 
 

--- a/polylogue/schemas/unified_fallbacks.py
+++ b/polylogue/schemas/unified_fallbacks.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Any
+from collections.abc import Callable
+from typing import Any, cast
 
 from polylogue.lib.provider_semantics import (
     extract_chatgpt_text,
@@ -11,6 +12,7 @@ from polylogue.lib.provider_semantics import (
     extract_reasoning_traces,
     extract_tool_calls,
 )
+from polylogue.lib.raw_payload_decode import JSONRecord
 from polylogue.lib.roles import Role
 from polylogue.lib.timestamps import parse_timestamp
 from polylogue.lib.viewports import CostInfo, ReasoningTrace, TokenUsage
@@ -18,94 +20,118 @@ from polylogue.schemas.unified_models import HarmonizedMessage, _missing_role, e
 from polylogue.types import Provider
 
 
-def _fallback_extract_claude_code(raw: dict[str, Any]) -> HarmonizedMessage:
+def _record(value: object) -> JSONRecord:
+    return cast(JSONRecord, value) if isinstance(value, dict) else {}
+
+
+def _content_blocks(value: object) -> list[dict[str, Any]] | None:
+    if not isinstance(value, list):
+        return None
+    return [dict(item) for item in value if isinstance(item, dict)]
+
+
+def _payload_record(raw: JSONRecord) -> dict[str, Any]:
+    return dict(raw)
+
+
+FallbackExtractor = Callable[[JSONRecord], HarmonizedMessage]
+
+
+def _fallback_extract_claude_code(raw: JSONRecord) -> HarmonizedMessage:
     """Fallback extraction for malformed Claude Code records."""
-    msg = raw.get("message", {})
-    content = msg.get("content", []) if isinstance(msg, dict) else []
+    payload = _payload_record(raw)
+    if payload.get("message") == {}:
+        _missing_role()
+    msg = _payload_record(_record(payload.get("message")))
+    content = _content_blocks(msg.get("content"))
 
     return HarmonizedMessage(
-        id=raw.get("uuid"),
-        role=Role.normalize((msg.get("role") if isinstance(msg, dict) else raw.get("type")) or _missing_role()),
+        id=payload.get("uuid"),
+        role=Role.normalize((msg.get("role") or payload.get("type")) or _missing_role()),
         text=extract_claude_code_text(content),
-        timestamp=parse_timestamp(raw.get("timestamp")),
+        timestamp=parse_timestamp(payload.get("timestamp")),
         reasoning_traces=extract_reasoning_traces(content, Provider.CLAUDE_CODE),
         tool_calls=extract_tool_calls(content, Provider.CLAUDE_CODE),
         content_blocks=extract_content_blocks(content),
-        model=msg.get("model") if isinstance(msg, dict) else None,
-        tokens=extract_token_usage(msg.get("usage") if isinstance(msg, dict) else None),
-        cost=CostInfo(total_usd=raw.get("costUSD")) if raw.get("costUSD") else None,
-        duration_ms=raw.get("durationMs"),
+        model=msg.get("model"),
+        tokens=extract_token_usage(dict(usage) if (usage := _record(msg.get("usage"))) else None),
+        cost=CostInfo(total_usd=payload.get("costUSD")) if payload.get("costUSD") else None,
+        duration_ms=payload.get("durationMs"),
         provider=Provider.CLAUDE_CODE,
-        raw=raw,
+        raw=payload,
     )
 
 
-def _fallback_extract_claude_ai(raw: dict[str, Any]) -> HarmonizedMessage:
+def _fallback_extract_claude_ai(raw: JSONRecord) -> HarmonizedMessage:
     """Fallback extraction for malformed Claude AI records."""
+    payload = _payload_record(raw)
     return HarmonizedMessage(
-        id=raw.get("uuid"),
-        role=Role.normalize(raw.get("sender") or _missing_role()),
-        text=raw.get("text", ""),
-        timestamp=parse_timestamp(raw.get("created_at")),
+        id=payload.get("uuid"),
+        role=Role.normalize(payload.get("sender") or _missing_role()),
+        text=payload.get("text", ""),
+        timestamp=parse_timestamp(payload.get("created_at")),
         provider=Provider.CLAUDE_AI,
-        raw=raw,
+        raw=payload,
     )
 
 
-def _fallback_extract_chatgpt(raw: dict[str, Any]) -> HarmonizedMessage:
+def _fallback_extract_chatgpt(raw: JSONRecord) -> HarmonizedMessage:
     """Fallback extraction for malformed ChatGPT records."""
-    author = raw.get("author", {})
-    content = raw.get("content", {})
-    metadata = raw.get("metadata", {})
+    payload = _payload_record(raw)
+    author = _payload_record(_record(payload.get("author")))
+    content = _payload_record(_record(payload.get("content")))
+    metadata = _payload_record(_record(payload.get("metadata")))
 
     return HarmonizedMessage(
-        id=raw.get("id"),
-        role=Role.normalize((author.get("role") if isinstance(author, dict) else None) or _missing_role()),
-        text=extract_chatgpt_text(content) if isinstance(content, dict) else "",
-        timestamp=parse_timestamp(raw.get("create_time")),
-        model=metadata.get("model_slug") if isinstance(metadata, dict) else None,
+        id=payload.get("id"),
+        role=Role.normalize(author.get("role") or _missing_role()),
+        text=extract_chatgpt_text(content),
+        timestamp=parse_timestamp(payload.get("create_time")),
+        model=metadata.get("model_slug"),
         provider=Provider.CHATGPT,
-        raw=raw,
+        raw=payload,
     )
 
 
-def _fallback_extract_gemini(raw: dict[str, Any]) -> HarmonizedMessage:
+def _fallback_extract_gemini(raw: JSONRecord) -> HarmonizedMessage:
     """Fallback extraction for malformed Gemini records."""
-    is_thinking = raw.get("isThought", False)
-    thinking_budget = raw.get("thinkingBudget")
-    token_count = raw.get("tokenCount")
+    payload = _payload_record(raw)
+    is_thinking = payload.get("isThought", False)
+    thinking_budget = payload.get("thinkingBudget")
+    token_count = payload.get("tokenCount")
     output_tokens = token_count if isinstance(token_count, int) else None
 
     return HarmonizedMessage(
         id=None,
-        role=Role.normalize(raw.get("role") or _missing_role()),
-        text=raw.get("text", ""),
+        role=Role.normalize(payload.get("role") or _missing_role()),
+        text=payload.get("text", ""),
         timestamp=None,
         reasoning_traces=[
             ReasoningTrace(
-                text=raw.get("text", ""),
+                text=payload.get("text", ""),
                 token_count=thinking_budget if isinstance(thinking_budget, int) else None,
                 provider=Provider.GEMINI,
-                raw=raw,
+                raw=payload,
             )
         ]
         if is_thinking
         else [],
         tokens=TokenUsage(output_tokens=output_tokens) if output_tokens is not None else None,
         provider=Provider.GEMINI,
-        raw=raw,
+        raw=payload,
     )
 
 
-def _fallback_extract_codex(raw: dict[str, Any]) -> HarmonizedMessage:
+def _fallback_extract_codex(raw: JSONRecord) -> HarmonizedMessage:
     """Fallback extraction for malformed Codex records."""
-    if isinstance(raw.get("payload"), dict):
-        payload = raw["payload"]
+    raw_payload = _payload_record(raw)
+    payload = _payload_record(_record(raw_payload.get("payload")))
+    if payload:
         role = payload.get("role", "unknown")
         content = payload.get("content", [])
     else:
-        role = raw.get("role", "unknown")
-        content = raw.get("content", [])
+        role = raw_payload.get("role", "unknown")
+        content = raw_payload.get("content", [])
 
     text_parts = []
     for block in content if isinstance(content, list) else []:
@@ -116,16 +142,16 @@ def _fallback_extract_codex(raw: dict[str, Any]) -> HarmonizedMessage:
             text_parts.append(text)
 
     return HarmonizedMessage(
-        id=raw.get("id"),
+        id=raw_payload.get("id"),
         role=Role.normalize(role),
         text="\n".join(text_parts),
-        timestamp=parse_timestamp(raw.get("timestamp")),
+        timestamp=parse_timestamp(raw_payload.get("timestamp")),
         provider=Provider.CODEX,
-        raw=raw,
+        raw=raw_payload,
     )
 
 
-_FALLBACK_EXTRACTORS = {
+_FALLBACK_EXTRACTORS: dict[Provider, FallbackExtractor] = {
     Provider.CLAUDE_CODE: _fallback_extract_claude_code,
     Provider.CLAUDE_AI: _fallback_extract_claude_ai,
     Provider.CHATGPT: _fallback_extract_chatgpt,
@@ -134,7 +160,7 @@ _FALLBACK_EXTRACTORS = {
 }
 
 
-def extract_fallback_message(provider: Provider, raw: dict[str, Any]) -> HarmonizedMessage:
+def extract_fallback_message(provider: Provider, raw: JSONRecord) -> HarmonizedMessage:
     """Fallback harmonization for malformed raw provider payloads."""
     try:
         extractor = _FALLBACK_EXTRACTORS[provider]

--- a/polylogue/schemas/unified_provider_meta_coercion.py
+++ b/polylogue/schemas/unified_provider_meta_coercion.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from datetime import datetime
-from typing import Any
 
 from pydantic import ValidationError
 
@@ -11,6 +11,8 @@ from polylogue.lib.timestamps import parse_timestamp
 from polylogue.lib.viewports import ContentBlock, CostInfo, ReasoningTrace, TokenUsage, ToolCall
 from polylogue.schemas.unified_models import extract_token_usage
 from polylogue.types import Provider
+
+ProviderMetaPayload = Mapping[str, object]
 
 
 def _coerce_timestamp(value: datetime | str | float | int | None) -> datetime | None:
@@ -80,7 +82,7 @@ def _coerce_content_blocks(blocks: object) -> list[ContentBlock]:
     return coerced
 
 
-def _extract_generic_tokens(provider_meta: dict[str, Any]) -> TokenUsage | None:
+def _extract_generic_tokens(provider_meta: ProviderMetaPayload) -> TokenUsage | None:
     usage = provider_meta.get("usage")
     if isinstance(usage, dict):
         return extract_token_usage(usage)
@@ -100,7 +102,7 @@ def _extract_generic_tokens(provider_meta: dict[str, Any]) -> TokenUsage | None:
     return None
 
 
-def _extract_generic_cost(provider_meta: dict[str, Any]) -> CostInfo | None:
+def _extract_generic_cost(provider_meta: ProviderMetaPayload) -> CostInfo | None:
     cost = provider_meta.get("cost")
     if isinstance(cost, CostInfo):
         return cost
@@ -116,7 +118,7 @@ def _extract_generic_cost(provider_meta: dict[str, Any]) -> CostInfo | None:
     return None
 
 
-def _has_extracted_viewports(provider_meta: dict[str, Any]) -> bool:
+def _has_extracted_viewports(provider_meta: ProviderMetaPayload) -> bool:
     return any(
         key in provider_meta
         for key in (
@@ -140,4 +142,5 @@ __all__ = [
     "_extract_generic_cost",
     "_extract_generic_tokens",
     "_has_extracted_viewports",
+    "ProviderMetaPayload",
 ]

--- a/polylogue/schemas/unified_provider_meta_runtime.py
+++ b/polylogue/schemas/unified_provider_meta_runtime.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from datetime import datetime
-from typing import Any, Protocol, cast
+from typing import Any, cast
 
 from pydantic import ValidationError
 
@@ -12,7 +12,7 @@ from polylogue.lib.raw_payload_decode import JSONRecord
 from polylogue.schemas.unified_adapters import extract_with_adapter
 from polylogue.schemas.unified_fallbacks import extract_fallback_message
 from polylogue.schemas.unified_models import HarmonizedMessage
-from polylogue.schemas.unified_provider_meta_coercion import ProviderMetaPayload, _has_extracted_viewports
+from polylogue.schemas.unified_provider_meta_coercion import _has_extracted_viewports
 from polylogue.schemas.unified_provider_meta_harmonize import (
     _harmonize_extracted_provider_meta,
     _overlay_message_context,
@@ -20,25 +20,17 @@ from polylogue.schemas.unified_provider_meta_harmonize import (
 from polylogue.types import Provider
 
 
-class ParsedMessageLike(Protocol):
-    provider_meta: ProviderMetaPayload | None
-    provider_message_id: str | None
-    role: str | None
-    text: str | None
-    timestamp: datetime | str | float | int | None
-
-
 def _json_record(value: object) -> JSONRecord:
     return cast(JSONRecord, value) if isinstance(value, dict) else {}
 
 
-def _provider_meta_dict(value: ProviderMetaPayload) -> dict[str, Any]:
+def _provider_meta_dict(value: Mapping[str, object]) -> dict[str, Any]:
     return dict(value)
 
 
 def extract_from_provider_meta(
     provider: Provider | str,
-    provider_meta: ProviderMetaPayload,
+    provider_meta: Mapping[str, object],
     *,
     message_id: str | None = None,
     role: str | None = None,
@@ -62,7 +54,7 @@ def extract_from_provider_meta(
             timestamp=timestamp,
         )
 
-    if _has_extracted_viewports(provider_meta):
+    if _has_extracted_viewports(dict(provider_meta)):
         return _harmonize_extracted_provider_meta(
             resolved_provider,
             _provider_meta_dict(provider_meta),
@@ -93,7 +85,7 @@ def extract_from_provider_meta(
     )
 
 
-def is_message_record(provider: Provider | str, raw: JSONRecord) -> bool:
+def is_message_record(provider: Provider | str, raw: Mapping[str, object]) -> bool:
     """Check if a record is an actual message (vs metadata)."""
     resolved_provider = provider if isinstance(provider, Provider) else Provider.from_string(provider)
     if resolved_provider == Provider.CLAUDE_CODE:
@@ -106,7 +98,7 @@ def is_message_record(provider: Provider | str, raw: JSONRecord) -> bool:
 
 def harmonize_parsed_message(
     provider: str,
-    provider_meta: ProviderMetaPayload | None,
+    provider_meta: Mapping[str, object] | None,
     *,
     message_id: str | None = None,
     role: str | None = None,
@@ -133,13 +125,13 @@ def harmonize_parsed_message(
 
 def bulk_harmonize(
     provider: str,
-    parsed_messages: Iterable[ParsedMessageLike],
+    parsed_messages: Iterable[object],
 ) -> list[HarmonizedMessage]:
     """Bulk convert ParsedMessages to HarmonizedMessages."""
     results: list[HarmonizedMessage] = []
     for parsed_message in parsed_messages:
         meta = getattr(parsed_message, "provider_meta", None)
-        if not meta:
+        if not isinstance(meta, Mapping) or not meta:
             continue
         harmonized = harmonize_parsed_message(
             provider,

--- a/polylogue/schemas/unified_provider_meta_runtime.py
+++ b/polylogue/schemas/unified_provider_meta_runtime.py
@@ -2,15 +2,17 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from datetime import datetime
-from typing import Any
+from typing import Any, Protocol, cast
 
 from pydantic import ValidationError
 
+from polylogue.lib.raw_payload_decode import JSONRecord
 from polylogue.schemas.unified_adapters import extract_with_adapter
 from polylogue.schemas.unified_fallbacks import extract_fallback_message
 from polylogue.schemas.unified_models import HarmonizedMessage
-from polylogue.schemas.unified_provider_meta_coercion import _has_extracted_viewports
+from polylogue.schemas.unified_provider_meta_coercion import ProviderMetaPayload, _has_extracted_viewports
 from polylogue.schemas.unified_provider_meta_harmonize import (
     _harmonize_extracted_provider_meta,
     _overlay_message_context,
@@ -18,9 +20,25 @@ from polylogue.schemas.unified_provider_meta_harmonize import (
 from polylogue.types import Provider
 
 
+class ParsedMessageLike(Protocol):
+    provider_meta: ProviderMetaPayload | None
+    provider_message_id: str | None
+    role: str | None
+    text: str | None
+    timestamp: datetime | str | float | int | None
+
+
+def _json_record(value: object) -> JSONRecord:
+    return cast(JSONRecord, value) if isinstance(value, dict) else {}
+
+
+def _provider_meta_dict(value: ProviderMetaPayload) -> dict[str, Any]:
+    return dict(value)
+
+
 def extract_from_provider_meta(
     provider: Provider | str,
-    provider_meta: dict[str, Any],
+    provider_meta: ProviderMetaPayload,
     *,
     message_id: str | None = None,
     role: str | None = None,
@@ -31,10 +49,11 @@ def extract_from_provider_meta(
     resolved_provider = provider if isinstance(provider, Provider) else Provider.from_string(provider)
     raw = provider_meta.get("raw")
     if raw is not None:
+        raw_record = _json_record(raw)
         try:
-            harmonized = extract_with_adapter(resolved_provider, raw)
+            harmonized = extract_with_adapter(resolved_provider, raw_record)
         except (ValidationError, ValueError):
-            harmonized = extract_fallback_message(resolved_provider, raw)
+            harmonized = extract_fallback_message(resolved_provider, dict(raw_record))
         return _overlay_message_context(
             harmonized,
             message_id=message_id,
@@ -46,7 +65,7 @@ def extract_from_provider_meta(
     if _has_extracted_viewports(provider_meta):
         return _harmonize_extracted_provider_meta(
             resolved_provider,
-            provider_meta,
+            _provider_meta_dict(provider_meta),
             message_id=message_id,
             role=role,
             text=text,
@@ -54,11 +73,11 @@ def extract_from_provider_meta(
         )
 
     try:
-        harmonized = extract_with_adapter(resolved_provider, provider_meta)
+        harmonized = extract_with_adapter(resolved_provider, _json_record(provider_meta))
     except (ValidationError, ValueError, TypeError):
         return _harmonize_extracted_provider_meta(
             resolved_provider,
-            provider_meta,
+            _provider_meta_dict(provider_meta),
             message_id=message_id,
             role=role,
             text=text,
@@ -74,7 +93,7 @@ def extract_from_provider_meta(
     )
 
 
-def is_message_record(provider: Provider | str, raw: dict[str, Any]) -> bool:
+def is_message_record(provider: Provider | str, raw: JSONRecord) -> bool:
     """Check if a record is an actual message (vs metadata)."""
     resolved_provider = provider if isinstance(provider, Provider) else Provider.from_string(provider)
     if resolved_provider == Provider.CLAUDE_CODE:
@@ -87,7 +106,7 @@ def is_message_record(provider: Provider | str, raw: dict[str, Any]) -> bool:
 
 def harmonize_parsed_message(
     provider: str,
-    provider_meta: dict[str, Any] | None,
+    provider_meta: ProviderMetaPayload | None,
     *,
     message_id: str | None = None,
     role: str | None = None,
@@ -99,7 +118,7 @@ def harmonize_parsed_message(
         return None
 
     raw = provider_meta.get("raw", provider_meta)
-    if not is_message_record(provider, raw):
+    if not is_message_record(provider, _json_record(raw)):
         return None
 
     return extract_from_provider_meta(
@@ -114,7 +133,7 @@ def harmonize_parsed_message(
 
 def bulk_harmonize(
     provider: str,
-    parsed_messages: list[Any],
+    parsed_messages: Iterable[ParsedMessageLike],
 ) -> list[HarmonizedMessage]:
     """Bulk convert ParsedMessages to HarmonizedMessages."""
     results: list[HarmonizedMessage] = []

--- a/tests/unit/core/test_schema_cluster_assignment.py
+++ b/tests/unit/core/test_schema_cluster_assignment.py
@@ -16,12 +16,17 @@ from pathlib import Path
 
 import pytest
 
+from polylogue.schemas.json_types import JSONDocument, json_document_list
 from polylogue.schemas.registry import (
     ClusterManifest,
     SchemaRegistry,
     _fingerprint_hash,
 )
 from polylogue.schemas.shape_fingerprint import _structure_fingerprint
+
+
+def _document_list_field(document: JSONDocument, key: str) -> list[JSONDocument]:
+    return json_document_list(document.get(key))
 
 
 @pytest.fixture
@@ -285,7 +290,7 @@ class TestManifestMembership:
         manifest = registry.cluster_samples("cnt-prov", samples)
         d = manifest.to_dict()
         assert d["cluster_count"] == 2
-        assert len(d["clusters"]) == 2
+        assert len(_document_list_field(d, "clusters")) == 2
 
     def test_manifest_roundtrip(self, registry: SchemaRegistry) -> None:
         samples = [

--- a/tests/unit/core/test_schema_registry.py
+++ b/tests/unit/core/test_schema_registry.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 import gzip
 import json
 from pathlib import Path
-from typing import Any
 
 import pytest
 from jsonschema import Draft202012Validator
 
+from polylogue.schemas.json_types import JSONDocument, JSONDocumentList, json_document, json_document_list
 from polylogue.schemas.registry import (
     ClusterManifest,
     PropertyChange,
@@ -20,6 +20,14 @@ from polylogue.schemas.registry import (
 )
 
 
+def _document_list_field(document: JSONDocument, key: str) -> JSONDocumentList:
+    return json_document_list(document.get(key))
+
+
+def _document_field(document: JSONDocument, key: str) -> JSONDocument:
+    return json_document(document.get(key))
+
+
 @pytest.fixture
 def tmp_registry(tmp_path: Path) -> SchemaRegistry:
     """Registry with an isolated storage root."""
@@ -27,7 +35,7 @@ def tmp_registry(tmp_path: Path) -> SchemaRegistry:
 
 
 @pytest.fixture
-def sample_schema_a() -> dict[str, Any]:
+def sample_schema_a() -> JSONDocument:
     return {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "type": "object",
@@ -41,7 +49,7 @@ def sample_schema_a() -> dict[str, Any]:
 
 
 @pytest.fixture
-def sample_schema_b() -> dict[str, Any]:
+def sample_schema_b() -> JSONDocument:
     return {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "type": "object",
@@ -83,8 +91,9 @@ class TestSchemaDiffOutputs:
         )
         d = diff.to_dict()
         assert d["has_changes"] is True
-        assert len(d["classified_changes"]) == 3
-        assert d["classified_changes"][0]["kind"] == "added"
+        classified_changes = _document_list_field(d, "classified_changes")
+        assert len(classified_changes) == 3
+        assert classified_changes[0]["kind"] == "added"
 
     def test_to_text_renders(self) -> None:
         diff = SchemaDiff(
@@ -299,8 +308,9 @@ class TestRegistryPromotion:
         assert version == "v1"
         schema = tmp_registry.get_schema("stub-prov", version=version)
         assert schema is not None
-        assert "id" in schema["properties"]
-        assert "key" in schema["properties"]
+        properties = _document_field(schema, "properties")
+        assert "id" in properties
+        assert "key" in properties
 
     def test_promote_cluster_updates_manifest(self, tmp_registry: SchemaRegistry) -> None:
         samples = [{"a": 1}]
@@ -347,8 +357,8 @@ class TestEnhancedCompare:
     def test_classified_changes_additive(
         self,
         tmp_registry: SchemaRegistry,
-        sample_schema_a: dict[str, Any],
-        sample_schema_b: dict[str, Any],
+        sample_schema_a: JSONDocument,
+        sample_schema_b: JSONDocument,
     ) -> None:
         tmp_registry.register_schema("cmp-prov", sample_schema_a)
         tmp_registry.register_schema("cmp-prov", sample_schema_b)
@@ -362,8 +372,8 @@ class TestEnhancedCompare:
     def test_classified_changes_type_mutation(
         self,
         tmp_registry: SchemaRegistry,
-        sample_schema_a: dict[str, Any],
-        sample_schema_b: dict[str, Any],
+        sample_schema_a: JSONDocument,
+        sample_schema_b: JSONDocument,
     ) -> None:
         tmp_registry.register_schema("cmp-prov", sample_schema_a)
         tmp_registry.register_schema("cmp-prov", sample_schema_b)
@@ -376,8 +386,8 @@ class TestEnhancedCompare:
     def test_classified_changes_requiredness(
         self,
         tmp_registry: SchemaRegistry,
-        sample_schema_a: dict[str, Any],
-        sample_schema_b: dict[str, Any],
+        sample_schema_a: JSONDocument,
+        sample_schema_b: JSONDocument,
     ) -> None:
         tmp_registry.register_schema("cmp-prov", sample_schema_a)
         tmp_registry.register_schema("cmp-prov", sample_schema_b)

--- a/tests/unit/core/test_schema_semantic_inference.py
+++ b/tests/unit/core/test_schema_semantic_inference.py
@@ -10,10 +10,20 @@ Covers:
 from __future__ import annotations
 
 from collections import Counter
+from collections.abc import Mapping
 
 from polylogue.schemas.field_stats import FieldStats
 from polylogue.schemas.semantic_inference_models import SemanticCandidate
 from polylogue.schemas.semantic_inference_runtime import infer_semantic_roles, select_best_roles
+
+
+def _candidate_for_role(candidates: list[SemanticCandidate], role: str) -> SemanticCandidate | None:
+    return next((candidate for candidate in candidates if candidate.role == role), None)
+
+
+def _evidence_float(evidence: Mapping[str, object], key: str) -> float | None:
+    value = evidence.get(key)
+    return float(value) if isinstance(value, (int, float)) else None
 
 
 class TestInferSemanticRoles:
@@ -190,7 +200,7 @@ class TestScoreMessageContainer:
             "$.messages[*].created_at": FieldStats(path="$.messages[*].created_at"),
         }
         candidates = infer_semantic_roles(stats)
-        container = next((c for c in candidates if c.role == "message_container"), None)
+        container = _candidate_for_role(candidates, "message_container")
         assert container is not None
         assert container.path == "$.messages"
         assert container.confidence > 0.15
@@ -210,7 +220,7 @@ class TestScoreMessageContainer:
             ),
         }
         candidates = infer_semantic_roles(stats)
-        container = next((c for c in candidates if c.role == "message_container"), None)
+        container = _candidate_for_role(candidates, "message_container")
         assert container is not None
         assert "avg_object_fanout" in container.evidence
 
@@ -225,7 +235,7 @@ class TestScoreMessageContainer:
             "$.messages[*].id": FieldStats(path="$.messages[*].id"),
         }
         candidates_low = infer_semantic_roles(stats_low)
-        container_low = next((c for c in candidates_low if c.role == "message_container"), None)
+        container_low = _candidate_for_role(candidates_low, "message_container")
         # Same setup but with high frequency
         stats_high = {
             "$.messages": FieldStats(
@@ -237,7 +247,7 @@ class TestScoreMessageContainer:
             "$.messages[*].id": FieldStats(path="$.messages[*].id"),
         }
         candidates_high = infer_semantic_roles(stats_high)
-        container_high = next((c for c in candidates_high if c.role == "message_container"), None)
+        container_high = _candidate_for_role(candidates_high, "message_container")
         assert container_high is not None
         # High frequency should score better than low frequency
         if container_low is not None:
@@ -255,9 +265,11 @@ class TestScoreMessageContainer:
             "$.messages[*].id": FieldStats(path="$.messages[*].id"),
         }
         candidates = infer_semantic_roles(stats)
-        container = next((c for c in candidates if c.role == "message_container"), None)
+        container = _candidate_for_role(candidates, "message_container")
         assert container is not None
-        assert container.evidence.get("depth", 999) <= 3
+        depth = _evidence_float(container.evidence, "depth")
+        assert depth is not None
+        assert depth <= 3
 
 
 class TestScoreMessageRole:
@@ -275,7 +287,7 @@ class TestScoreMessageRole:
             ),
         }
         candidates = infer_semantic_roles(stats)
-        role = next((c for c in candidates if c.role == "message_role"), None)
+        role = _candidate_for_role(candidates, "message_role")
         assert role is not None
         assert role.confidence > 0.3
         assert "known_roles" in role.evidence
@@ -294,7 +306,7 @@ class TestScoreMessageRole:
             ),
         }
         candidates = infer_semantic_roles(stats)
-        role = next((c for c in candidates if c.role == "message_role"), None)
+        role = _candidate_for_role(candidates, "message_role")
         assert role is not None
         assert "name_signal" in role.evidence
 
@@ -312,7 +324,7 @@ class TestScoreMessageRole:
             ),
         }
         candidates = infer_semantic_roles(stats)
-        role = next((c for c in candidates if c.role == "message_role"), None)
+        role = _candidate_for_role(candidates, "message_role")
         assert role is None
 
     def test_multiline_content_penalizes(self) -> None:
@@ -330,7 +342,7 @@ class TestScoreMessageRole:
             ),
         }
         candidates_no_nl = infer_semantic_roles(stats_no_nl)
-        role_no_nl = next((c for c in candidates_no_nl if c.role == "message_role"), None)
+        role_no_nl = _candidate_for_role(candidates_no_nl, "message_role")
 
         stats_nl = {
             "$.type": FieldStats(
@@ -345,9 +357,9 @@ class TestScoreMessageRole:
             ),
         }
         candidates_nl = infer_semantic_roles(stats_nl)
-        role_nl = next((c for c in candidates_nl if c.role == "message_role"), None)
+        role_nl = _candidate_for_role(candidates_nl, "message_role")
         # Both should score, but multiline should be lower
-        if role_no_nl and role_nl:
+        if role_no_nl is not None and role_nl is not None:
             assert role_no_nl.confidence > role_nl.confidence
 
 
@@ -375,7 +387,7 @@ class TestScoreMessageBody:
             ),
         }
         candidates = infer_semantic_roles(stats)
-        body = next((c for c in candidates if c.role == "message_body"), None)
+        body = _candidate_for_role(candidates, "message_body")
         assert body is not None
         assert body.confidence > 0.3
         assert "avg_length" in body.evidence
@@ -396,7 +408,7 @@ class TestScoreMessageBody:
             ),
         }
         candidates = infer_semantic_roles(stats)
-        body = next((c for c in candidates if c.role == "message_body"), None)
+        body = _candidate_for_role(candidates, "message_body")
         assert body is not None
         assert "name_signal" in body.evidence
 
@@ -415,7 +427,7 @@ class TestScoreMessageBody:
             ),
         }
         candidates = infer_semantic_roles(stats)
-        body = next((c for c in candidates if c.role == "message_body"), None)
+        body = _candidate_for_role(candidates, "message_body")
         assert body is None
 
     def test_entropy_bonus(self) -> None:
@@ -439,7 +451,7 @@ class TestScoreMessageBody:
             ),
         }
         candidates = infer_semantic_roles(stats)
-        body = next((c for c in candidates if c.role == "message_body"), None)
+        body = _candidate_for_role(candidates, "message_body")
         assert body is not None
         assert "entropy" in body.evidence
 
@@ -461,7 +473,7 @@ class TestScoreMessageTimestamp:
             ),
         }
         candidates = infer_semantic_roles(stats)
-        ts = next((c for c in candidates if c.role == "message_timestamp"), None)
+        ts = _candidate_for_role(candidates, "message_timestamp")
         assert ts is not None
         assert ts.confidence > 0.3
         assert "format" in ts.evidence
@@ -480,7 +492,7 @@ class TestScoreMessageTimestamp:
             ),
         }
         candidates = infer_semantic_roles(stats)
-        ts = next((c for c in candidates if c.role == "message_timestamp"), None)
+        ts = _candidate_for_role(candidates, "message_timestamp")
         assert ts is not None
         assert ts.confidence > 0.3
 
@@ -499,7 +511,7 @@ class TestScoreMessageTimestamp:
             ),
         }
         candidates = infer_semantic_roles(stats)
-        ts = next((c for c in candidates if c.role == "message_timestamp"), None)
+        ts = _candidate_for_role(candidates, "message_timestamp")
         assert ts is not None
         # Monotonicity bonus requires _ordered_samples to be set (from array context)
         # Plain numeric_values don't trigger monotonicity checking
@@ -519,7 +531,7 @@ class TestScoreMessageTimestamp:
             ),
         }
         candidates = infer_semantic_roles(stats)
-        ts = next((c for c in candidates if c.role == "message_timestamp"), None)
+        ts = _candidate_for_role(candidates, "message_timestamp")
         assert ts is not None
         assert "name_signal" in ts.evidence
 
@@ -539,9 +551,9 @@ class TestScoreMessageTimestamp:
             ),
         }
         candidates = infer_semantic_roles(stats)
-        ts = next((c for c in candidates if c.role == "message_timestamp"), None)
+        ts = _candidate_for_role(candidates, "message_timestamp")
         # Should still exist but with reduced confidence due to multiline
-        if ts:
+        if ts is not None:
             assert ts.confidence < 0.6
 
 
@@ -562,7 +574,7 @@ class TestScoreConversationTitle:
             ),
         }
         candidates = infer_semantic_roles(stats)
-        title = next((c for c in candidates if c.role == "conversation_title"), None)
+        title = _candidate_for_role(candidates, "conversation_title")
         assert title is not None
         assert title.confidence > 0.2
         assert "avg_length" in title.evidence
@@ -583,7 +595,7 @@ class TestScoreConversationTitle:
             ),
         }
         candidates = infer_semantic_roles(stats)
-        title = next((c for c in candidates if c.role == "conversation_title"), None)
+        title = _candidate_for_role(candidates, "conversation_title")
         assert title is not None
         assert "name_signal" in title.evidence
 
@@ -602,7 +614,7 @@ class TestScoreConversationTitle:
             ),
         }
         candidates = infer_semantic_roles(stats)
-        title = next((c for c in candidates if c.role == "conversation_title"), None)
+        title = _candidate_for_role(candidates, "conversation_title")
         assert title is None
 
     def test_multiline_penalizes(self) -> None:
@@ -620,11 +632,13 @@ class TestScoreConversationTitle:
             ),
         }
         candidates = infer_semantic_roles(stats)
-        title = next((c for c in candidates if c.role == "conversation_title"), None)
+        title = _candidate_for_role(candidates, "conversation_title")
         # Title with multiline should exist but multiline is tracked in evidence
-        if title:
+        if title is not None:
             assert "newline_rate" in title.evidence
-            assert title.evidence["newline_rate"] > 0.0
+            newline_rate = _evidence_float(title.evidence, "newline_rate")
+            assert newline_rate is not None
+            assert newline_rate > 0.0
 
     def test_inside_array_penalizes(self) -> None:
         """Titles inside message arrays ([*]) are penalized."""
@@ -641,9 +655,9 @@ class TestScoreConversationTitle:
             ),
         }
         candidates = infer_semantic_roles(stats)
-        title = next((c for c in candidates if c.role == "conversation_title"), None)
+        title = _candidate_for_role(candidates, "conversation_title")
         # Array items are penalized but may still score if other factors strong
-        if title:
+        if title is not None:
             assert title.confidence < 0.5
 
     def test_deep_path_penalizes(self) -> None:
@@ -661,8 +675,10 @@ class TestScoreConversationTitle:
             ),
         }
         candidates = infer_semantic_roles(stats)
-        title = next((c for c in candidates if c.role == "conversation_title"), None)
+        title = _candidate_for_role(candidates, "conversation_title")
         # Deep paths are penalized via the scoring function
         # The 0.5x multiplier for depth > 4 should be applied
-        if title:
-            assert title.evidence.get("depth", 0) > 4
+        if title is not None:
+            depth = _evidence_float(title.evidence, "depth")
+            assert depth is not None
+            assert depth > 4

--- a/tests/unit/core/test_synthetic_semantics.py
+++ b/tests/unit/core/test_synthetic_semantics.py
@@ -19,17 +19,19 @@ from __future__ import annotations
 import json
 import random
 from datetime import datetime
-from typing import Any
-from unittest.mock import MagicMock
+from pathlib import Path
+from typing import Protocol, cast
 
 import pytest
 
+from polylogue.paths import Source
 from polylogue.scenarios import CorpusProfile, CorpusSpec
 from polylogue.schemas.synthetic import (
     PROVIDER_WIRE_FORMATS,
     SyntheticCorpus,
     WireFormat,
 )
+from polylogue.schemas.synthetic.models import SchemaRecord
 from polylogue.schemas.synthetic.semantic_values import (
     _ROLE_TEXTS,
     SemanticValueGenerator,
@@ -37,6 +39,81 @@ from polylogue.schemas.synthetic.semantic_values import (
 )
 from polylogue.schemas.synthetic.showcase import _SHOWCASE_THEMES
 from polylogue.sources.dispatch import parse_payload
+
+
+def _schema(value: object) -> SchemaRecord:
+    return cast(SchemaRecord, value)
+
+
+def _float_value(value: object) -> float:
+    assert isinstance(value, float)
+    return value
+
+
+class SyntheticSourceFactory(Protocol):
+    def __call__(
+        self,
+        provider: str,
+        count: int = 1,
+        messages_per_conversation: range = range(4, 12),
+        seed: int = 42,
+    ) -> Source: ...
+
+
+class _FakePackage:
+    def __init__(
+        self,
+        *,
+        version: str,
+        default_element_kind: str | None,
+        available_elements: set[str],
+    ) -> None:
+        self.version = version
+        self.default_element_kind = default_element_kind
+        self._available_elements = available_elements
+
+    def element(self, element_kind: str | None) -> object | None:
+        if element_kind in self._available_elements:
+            return {"element_kind": element_kind}
+        return None
+
+
+class _FakeRegistry:
+    def __init__(
+        self,
+        *,
+        package: _FakePackage | None,
+        element_schema: SchemaRecord | None = None,
+        schema: SchemaRecord | None = None,
+    ) -> None:
+        self._package = package
+        self._element_schema = element_schema
+        self._schema = schema
+        self.package_calls: list[tuple[str, str]] = []
+        self.element_schema_calls: list[tuple[str, str, str | None]] = []
+        self.schema_calls: list[tuple[str, str]] = []
+
+    def get_package(self, provider: str, version: str = "default") -> _FakePackage | None:
+        self.package_calls.append((provider, version))
+        return self._package
+
+    def get_element_schema(
+        self,
+        provider: str,
+        *,
+        version: str = "default",
+        element_kind: str | None = None,
+    ) -> SchemaRecord | None:
+        self.element_schema_calls.append((provider, version, element_kind))
+        return self._element_schema
+
+    def get_schema(self, provider: str, version: str = "default") -> SchemaRecord | None:
+        self.schema_calls.append((provider, version))
+        return self._schema
+
+    def list_providers(self) -> list[str]:
+        return ["chatgpt"]
+
 
 # ---------------------------------------------------------------------------
 # _text_for_role
@@ -150,7 +227,7 @@ class TestSyntheticConversationEnvelope:
         assert batch.report.provider == "chatgpt"
         assert batch.report.generated_count == 2
 
-    def test_write_spec_artifacts_returns_written_paths(self, tmp_path: Any) -> None:
+    def test_write_spec_artifacts_returns_written_paths(self, tmp_path: Path) -> None:
         spec = CorpusSpec.for_provider(
             "chatgpt",
             count=1,
@@ -165,7 +242,7 @@ class TestSyntheticConversationEnvelope:
         assert written.files[0].exists()
         assert written.batch.report.generated_count == 1
 
-    def test_write_specs_artifacts_avoids_same_provider_name_collisions(self, tmp_path: Any) -> None:
+    def test_write_specs_artifacts_avoids_same_provider_name_collisions(self, tmp_path: Path) -> None:
         specs = (
             CorpusSpec(
                 provider="chatgpt",
@@ -204,17 +281,19 @@ class TestSyntheticConversationEnvelope:
 class TestSemanticRole:
     def test_generates_role_from_cycle(self) -> None:
         gen = SemanticValueGenerator(random.Random(0))
-        schema = {"x-polylogue-semantic-role": "message_role"}
+        schema = _schema({"x-polylogue-semantic-role": "message_role"})
         handled, value = gen.try_generate(schema)
         assert handled is True
         assert value == "user"
 
     def test_role_respects_observed_values(self) -> None:
         gen = SemanticValueGenerator(random.Random(42))
-        schema = {
-            "x-polylogue-semantic-role": "message_role",
-            "x-polylogue-values": ["user", "assistant", "system"],
-        }
+        schema = _schema(
+            {
+                "x-polylogue-semantic-role": "message_role",
+                "x-polylogue-values": ["user", "assistant", "system"],
+            }
+        )
         handled, value = gen.try_generate(schema)
         assert handled is True
         assert value in {"user", "assistant", "system"}
@@ -224,10 +303,12 @@ class TestSemanticRole:
             random.Random(0),
             role_cycle=["human", "assistant"],
         )
-        schema = {
-            "x-polylogue-semantic-role": "message_role",
-            "x-polylogue-values": ["human", "assistant"],
-        }
+        schema = _schema(
+            {
+                "x-polylogue-semantic-role": "message_role",
+                "x-polylogue-values": ["human", "assistant"],
+            }
+        )
         handled, value = gen.try_generate(schema)
         assert handled is True
         assert value == "human"  # current_role is "human"
@@ -241,7 +322,7 @@ class TestSemanticRole:
 class TestSemanticBody:
     def test_generates_nonempty_body_text(self) -> None:
         gen = SemanticValueGenerator(random.Random(0))
-        schema = {"x-polylogue-semantic-role": "message_body"}
+        schema = _schema({"x-polylogue-semantic-role": "message_body"})
         handled, value = gen.try_generate(schema)
         assert handled is True
         assert isinstance(value, str)
@@ -249,7 +330,7 @@ class TestSemanticBody:
 
     def test_body_text_matches_current_role(self) -> None:
         gen = SemanticValueGenerator(random.Random(42))
-        schema = {"x-polylogue-semantic-role": "message_body"}
+        schema = _schema({"x-polylogue-semantic-role": "message_body"})
 
         # Turn 0 = user
         _, user_text = gen.try_generate(schema)
@@ -263,7 +344,7 @@ class TestSemanticBody:
     def test_body_with_theme_uses_themed_content(self) -> None:
         theme = _SHOWCASE_THEMES[0]
         gen = SemanticValueGenerator(random.Random(0), theme=theme)
-        schema = {"x-polylogue-semantic-role": "message_body"}
+        schema = _schema({"x-polylogue-semantic-role": "message_body"})
         handled, value = gen.try_generate(schema)
         assert handled is True
         assert value in theme.user_turns  # turn 0 = user
@@ -277,7 +358,7 @@ class TestSemanticBody:
 class TestSemanticTimestamp:
     def test_generates_epoch_by_default(self) -> None:
         gen = SemanticValueGenerator(random.Random(0), base_ts=1700000000.0)
-        schema = {"x-polylogue-semantic-role": "message_timestamp"}
+        schema = _schema({"x-polylogue-semantic-role": "message_timestamp"})
         handled, value = gen.try_generate(schema)
         assert handled is True
         assert isinstance(value, float)
@@ -285,7 +366,7 @@ class TestSemanticTimestamp:
 
     def test_sequential_timestamps_increase(self) -> None:
         gen = SemanticValueGenerator(random.Random(0), base_ts=1700000000.0)
-        schema = {"x-polylogue-semantic-role": "message_timestamp"}
+        schema = _schema({"x-polylogue-semantic-role": "message_timestamp"})
 
         _, ts0 = gen.try_generate(schema)
         gen.advance_turn()
@@ -293,14 +374,16 @@ class TestSemanticTimestamp:
         gen.advance_turn()
         _, ts2 = gen.try_generate(schema)
 
-        assert ts0 < ts1 < ts2
+        assert _float_value(ts0) < _float_value(ts1) < _float_value(ts2)
 
     def test_iso8601_format(self) -> None:
         gen = SemanticValueGenerator(random.Random(0), base_ts=1700000000.0)
-        schema = {
-            "x-polylogue-semantic-role": "message_timestamp",
-            "x-polylogue-format": "iso8601",
-        }
+        schema = _schema(
+            {
+                "x-polylogue-semantic-role": "message_timestamp",
+                "x-polylogue-format": "iso8601",
+            }
+        )
         handled, value = gen.try_generate(schema)
         assert handled is True
         assert isinstance(value, str)
@@ -310,10 +393,12 @@ class TestSemanticTimestamp:
 
     def test_unix_epoch_str_format(self) -> None:
         gen = SemanticValueGenerator(random.Random(0), base_ts=1700000000.0)
-        schema = {
-            "x-polylogue-semantic-role": "message_timestamp",
-            "x-polylogue-format": "unix-epoch-str",
-        }
+        schema = _schema(
+            {
+                "x-polylogue-semantic-role": "message_timestamp",
+                "x-polylogue-format": "unix-epoch-str",
+            }
+        )
         handled, value = gen.try_generate(schema)
         assert handled is True
         assert isinstance(value, str)
@@ -321,10 +406,12 @@ class TestSemanticTimestamp:
 
     def test_unix_epoch_format(self) -> None:
         gen = SemanticValueGenerator(random.Random(0), base_ts=1700000000.0)
-        schema = {
-            "x-polylogue-semantic-role": "message_timestamp",
-            "x-polylogue-format": "unix-epoch",
-        }
+        schema = _schema(
+            {
+                "x-polylogue-semantic-role": "message_timestamp",
+                "x-polylogue-format": "unix-epoch",
+            }
+        )
         handled, value = gen.try_generate(schema)
         assert handled is True
         assert isinstance(value, float)
@@ -338,7 +425,7 @@ class TestSemanticTimestamp:
 class TestSemanticTitle:
     def test_generates_title_string(self) -> None:
         gen = SemanticValueGenerator(random.Random(0))
-        schema = {"x-polylogue-semantic-role": "conversation_title"}
+        schema = _schema({"x-polylogue-semantic-role": "conversation_title"})
         handled, value = gen.try_generate(schema)
         assert handled is True
         assert isinstance(value, str)
@@ -347,24 +434,26 @@ class TestSemanticTitle:
     def test_themed_title_uses_theme(self) -> None:
         theme = _SHOWCASE_THEMES[0]
         gen = SemanticValueGenerator(random.Random(0), theme=theme)
-        schema = {"x-polylogue-semantic-role": "conversation_title"}
+        schema = _schema({"x-polylogue-semantic-role": "conversation_title"})
         handled, value = gen.try_generate(schema)
         assert handled is True
         assert value == theme.title
 
     def test_title_with_observed_values(self) -> None:
         gen = SemanticValueGenerator(random.Random(42))
-        schema = {
-            "x-polylogue-semantic-role": "conversation_title",
-            "x-polylogue-values": ["Alpha", "Beta", "Gamma"],
-        }
+        schema = _schema(
+            {
+                "x-polylogue-semantic-role": "conversation_title",
+                "x-polylogue-values": ["Alpha", "Beta", "Gamma"],
+            }
+        )
         handled, value = gen.try_generate(schema)
         assert handled is True
         assert value in {"Alpha", "Beta", "Gamma"}
 
     def test_title_without_theme_or_values_picks_showcase_theme(self) -> None:
         gen = SemanticValueGenerator(random.Random(42))
-        schema = {"x-polylogue-semantic-role": "conversation_title"}
+        schema = _schema({"x-polylogue-semantic-role": "conversation_title"})
         handled, value = gen.try_generate(schema)
         assert handled is True
         known_titles = {t.title for t in _SHOWCASE_THEMES}
@@ -379,14 +468,14 @@ class TestSemanticTitle:
 class TestSemanticFallback:
     def test_no_semantic_role_returns_not_handled(self) -> None:
         gen = SemanticValueGenerator(random.Random(0))
-        schema = {"type": "string"}
+        schema = _schema({"type": "string"})
         handled, value = gen.try_generate(schema)
         assert handled is False
         assert value is None
 
     def test_unknown_semantic_role_returns_not_handled(self) -> None:
         gen = SemanticValueGenerator(random.Random(0))
-        schema = {"x-polylogue-semantic-role": "completely_unknown_role"}
+        schema = _schema({"x-polylogue-semantic-role": "completely_unknown_role"})
         handled, value = gen.try_generate(schema)
         assert handled is False
         assert value is None
@@ -394,7 +483,7 @@ class TestSemanticFallback:
     def test_message_container_role_returns_not_handled(self) -> None:
         """message_container is structural and defers to normal generation."""
         gen = SemanticValueGenerator(random.Random(0))
-        schema = {"x-polylogue-semantic-role": "message_container"}
+        schema = _schema({"x-polylogue-semantic-role": "message_container"})
         handled, value = gen.try_generate(schema)
         assert handled is False
 
@@ -414,7 +503,7 @@ class TestWireFormatShape:
         assert set(PROVIDER_WIRE_FORMATS.keys()) == self.EXPECTED_PROVIDERS
 
     @pytest.mark.parametrize("provider", sorted(EXPECTED_PROVIDERS))
-    def test_encoding_is_valid(self, provider: Any) -> None:
+    def test_encoding_is_valid(self, provider: str) -> None:
         """Each wire format has a valid encoding value."""
         wf = PROVIDER_WIRE_FORMATS[provider]
         assert isinstance(wf, WireFormat)
@@ -471,7 +560,7 @@ class TestCorpusParseRoundtrip:
     """Generated corpus parses successfully through source iterators."""
 
     @pytest.mark.parametrize("provider", sorted(PROVIDER_WIRE_FORMATS.keys()))
-    def test_generated_data_parses(self, provider: Any, synthetic_source: Any) -> None:
+    def test_generated_data_parses(self, provider: str, synthetic_source: SyntheticSourceFactory) -> None:
         """Synthetic data for each provider round-trips through parser."""
         from polylogue.sources import iter_source_conversations
 
@@ -495,7 +584,7 @@ class TestSeedDeterminism:
     """Corpus generation is deterministic given the same seed."""
 
     @pytest.mark.parametrize("provider", sorted(SyntheticCorpus.available_providers() or ["chatgpt"]))
-    def test_same_seed_produces_identical_output(self, provider: Any) -> None:
+    def test_same_seed_produces_identical_output(self, provider: str) -> None:
         """Two generate() calls with same seed → identical byte output."""
         try:
             corpus = SyntheticCorpus.for_provider(provider)
@@ -522,7 +611,7 @@ class TestMessageCountContract:
     """Generated conversations respect the message count range."""
 
     @pytest.mark.parametrize("provider", sorted(SyntheticCorpus.available_providers() or ["chatgpt"]))
-    def test_generate_count_matches_requested(self, provider: Any) -> None:
+    def test_generate_count_matches_requested(self, provider: str) -> None:
         """generate(count=N) returns exactly N items."""
         try:
             corpus = SyntheticCorpus.for_provider(provider)
@@ -562,7 +651,7 @@ class TestParseRoundtrip:
     """Synthetic data round-trips through the actual provider parsers."""
 
     @pytest.mark.parametrize("provider", sorted(SyntheticCorpus.available_providers() or ["chatgpt"]))
-    def test_synthetic_parses_to_conversations(self, provider: Any, synthetic_source: Any) -> None:
+    def test_synthetic_parses_to_conversations(self, provider: str, synthetic_source: SyntheticSourceFactory) -> None:
         """Synthetic corpus for each provider parses into valid conversations."""
         from polylogue.sources import iter_source_conversations
 
@@ -736,17 +825,16 @@ class TestProviderAvailability:
     def test_for_provider_accepts_explicit_version_and_element(self, monkeypatch: pytest.MonkeyPatch) -> None:
         import polylogue.schemas.synthetic.core as synthetic_core
 
-        fake_registry = MagicMock()
-        fake_package = MagicMock(
+        fake_package = _FakePackage(
             version="v2",
             default_element_kind="conversation_record_stream",
+            available_elements={"conversation_record_stream"},
         )
-        fake_package.element.side_effect = lambda element_kind: (
-            {"element_kind": element_kind} if element_kind == "conversation_record_stream" else None
+        fake_schema = _schema({"type": "object"})
+        fake_registry = _FakeRegistry(
+            package=fake_package,
+            element_schema=fake_schema,
         )
-        fake_schema = {"type": "object"}
-        fake_registry.get_package.return_value = fake_package
-        fake_registry.get_element_schema.return_value = fake_schema
         monkeypatch.setattr(synthetic_core, "SchemaRegistry", lambda: fake_registry)
 
         corpus = SyntheticCorpus.for_provider(
@@ -756,38 +844,31 @@ class TestProviderAvailability:
         )
 
         assert isinstance(corpus, SyntheticCorpus)
-        fake_registry.get_package.assert_called_once_with("chatgpt", version="v2")
-        fake_registry.get_element_schema.assert_called_once_with(
-            "chatgpt",
-            version="v2",
-            element_kind="conversation_record_stream",
-        )
+        assert fake_registry.package_calls == [("chatgpt", "v2")]
+        assert fake_registry.element_schema_calls == [("chatgpt", "v2", "conversation_record_stream")]
         assert corpus.schema == fake_schema
 
     def test_for_provider_rejects_unknown_element_when_package_exists(self, monkeypatch: pytest.MonkeyPatch) -> None:
         import polylogue.schemas.synthetic.core as synthetic_core
 
-        fake_registry = MagicMock()
-        fake_package = MagicMock(
+        fake_package = _FakePackage(
             version="v2",
             default_element_kind="conversation_record_stream",
+            available_elements=set(),
         )
-        fake_package.element.return_value = None
-        fake_registry.get_package.return_value = fake_package
+        fake_registry = _FakeRegistry(package=fake_package)
         monkeypatch.setattr(synthetic_core, "SchemaRegistry", lambda: fake_registry)
 
         with pytest.raises(ValueError):
             SyntheticCorpus.for_provider("chatgpt", version="v2", element_kind="unknown_element")
 
-        fake_registry.get_package.assert_called_once_with("chatgpt", version="v2")
+        assert fake_registry.package_calls == [("chatgpt", "v2")]
 
     def test_for_provider_rejects_element_without_package(self, monkeypatch: pytest.MonkeyPatch) -> None:
         import polylogue.schemas.synthetic.core as synthetic_core
 
-        fake_registry = MagicMock()
-        fake_registry.get_package.return_value = None
-        fake_schema = {"type": "object"}
-        fake_registry.get_schema.return_value = fake_schema
+        fake_schema = _schema({"type": "object"})
+        fake_registry = _FakeRegistry(package=None, schema=fake_schema)
         monkeypatch.setattr(synthetic_core, "SchemaRegistry", lambda: fake_registry)
 
         with pytest.raises(ValueError):

--- a/tests/unit/pipeline/test_prepare_semantic.py
+++ b/tests/unit/pipeline/test_prepare_semantic.py
@@ -14,6 +14,16 @@ from __future__ import annotations
 from polylogue.lib.viewports import ToolCategory, classify_tool
 from polylogue.pipeline.semantic_capture import extract_subagent_spawns, parse_git_operation
 from polylogue.pipeline.semantic_metadata import extract_tool_metadata
+from polylogue.schemas.json_types import JSONDocument, json_document
+
+
+def _payload(data: object) -> JSONDocument:
+    return json_document(data)
+
+
+def _string_list(value: object) -> list[str]:
+    return [entry for entry in value if isinstance(entry, str)] if isinstance(value, list) else []
+
 
 # =============================================================================
 # Tests for classify_tool
@@ -80,35 +90,38 @@ class TestClassifyTool:
 
 class TestExtractToolMetadata:
     def test_git_status_returns_metadata(self) -> None:
-        meta = extract_tool_metadata("Bash", {"command": "git status"})
+        meta = extract_tool_metadata("Bash", _payload({"command": "git status"}))
         assert meta is not None
         assert meta["command"] == "status"
         assert "full_command" in meta
 
     def test_git_commit_extracts_message(self) -> None:
-        meta = extract_tool_metadata("Bash", {"command": 'git commit -m "fix: bug"'})
+        meta = extract_tool_metadata("Bash", _payload({"command": 'git commit -m "fix: bug"'}))
         assert meta is not None
         assert meta["command"] == "commit"
         assert meta.get("message") == "fix: bug"
 
     def test_git_push_extracts_remote_branch(self) -> None:
-        meta = extract_tool_metadata("Bash", {"command": "git push origin main"})
+        meta = extract_tool_metadata("Bash", _payload({"command": "git push origin main"}))
         assert meta is not None
         assert meta.get("remote") == "origin"
         assert meta.get("branch") == "main"
 
     def test_git_checkout_extracts_branch(self) -> None:
-        meta = extract_tool_metadata("Bash", {"command": "git checkout feature-x"})
+        meta = extract_tool_metadata("Bash", _payload({"command": "git checkout feature-x"}))
         assert meta is not None
         assert meta.get("branch") == "feature-x"
 
     def test_read_returns_file_path(self) -> None:
-        meta = extract_tool_metadata("Read", {"file_path": "/path/to/file.py"})
+        meta = extract_tool_metadata("Read", _payload({"file_path": "/path/to/file.py"}))
         assert meta is not None
         assert meta["path"] == "/path/to/file.py"
 
     def test_write_returns_file_path_and_snippet(self) -> None:
-        meta = extract_tool_metadata("Write", {"file_path": "/path/to/file.py", "content": "hello world"})
+        meta = extract_tool_metadata(
+            "Write",
+            _payload({"file_path": "/path/to/file.py", "content": "hello world"}),
+        )
         assert meta is not None
         assert meta["path"] == "/path/to/file.py"
         assert "new_content_snippet" in meta
@@ -116,11 +129,13 @@ class TestExtractToolMetadata:
     def test_edit_returns_path_and_snippets(self) -> None:
         meta = extract_tool_metadata(
             "Edit",
-            {
-                "file_path": "/path/to/file.py",
-                "old_string": "old code",
-                "new_string": "new code",
-            },
+            _payload(
+                {
+                    "file_path": "/path/to/file.py",
+                    "old_string": "old code",
+                    "new_string": "new code",
+                }
+            ),
         )
         assert meta is not None
         assert meta["path"] == "/path/to/file.py"
@@ -130,34 +145,39 @@ class TestExtractToolMetadata:
     def test_task_returns_agent_type(self) -> None:
         meta = extract_tool_metadata(
             "Task",
-            {
-                "subagent_type": "general-purpose",
-                "description": "Do something",
-                "prompt": "Please do X",
-            },
+            _payload(
+                {
+                    "subagent_type": "general-purpose",
+                    "description": "Do something",
+                    "prompt": "Please do X",
+                }
+            ),
         )
         assert meta is not None
         assert meta["agent_type"] == "general-purpose"
         assert "prompt_snippet" in meta
 
     def test_shell_returns_none(self) -> None:
-        meta = extract_tool_metadata("Bash", {"command": "ls -la"})
+        meta = extract_tool_metadata("Bash", _payload({"command": "ls -la"}))
         assert meta is None
 
     def test_search_returns_path_and_pattern(self) -> None:
-        meta = extract_tool_metadata("Grep", {"path": "/workspace/polylogue", "pattern": "build_session_profile"})
+        meta = extract_tool_metadata(
+            "Grep",
+            _payload({"path": "/workspace/polylogue", "pattern": "build_session_profile"}),
+        )
         assert meta is not None
         assert meta["path"] == "/workspace/polylogue"
         assert meta["pattern"] == "build_session_profile"
 
     def test_agent_todo_metadata_summarizes_todos(self) -> None:
-        meta = extract_tool_metadata("TodoWrite", {"todos": [{"id": "1"}, {"id": "2"}]})
+        meta = extract_tool_metadata("TodoWrite", _payload({"todos": [{"id": "1"}, {"id": "2"}]}))
         assert meta is not None
         assert meta["tool"] == "TodoWrite"
         assert meta["todo_count"] == 2
 
     def test_other_tool_returns_none(self) -> None:
-        meta = extract_tool_metadata("UnknownTool", {})
+        meta = extract_tool_metadata("UnknownTool", _payload({}))
         assert meta is None
 
 
@@ -212,7 +232,7 @@ class TestParseGitOperation:
     def test_git_add(self) -> None:
         result = parse_git_operation({"tool_name": "Bash", "input": {"command": "git add file1.py file2.py"}})
         assert result is not None
-        assert "file1.py" in result.get("files", [])
+        assert "file1.py" in _string_list(result.get("files"))
 
 
 # =============================================================================


### PR DESCRIPTION
Closes #224

## Summary
- renew schema/provider metadata, generation annotation, fallback, and ingestion boundary contracts
- tighten the schema/source renewal tranche to fully green repo-wide type and verification gates
- absorb the remaining test-side fallout so the tranche lands as a clean baseline

## Problem
The older schema/source ingestion layer was still shaped by path-dependent agent-written glue: loosely typed provider metadata, dict-shaped schema walkers, and fallback/runtime seams that were technically accepted by strict mypy but still ambiguous at the contract boundaries. Tightening those source files exposed downstream test helpers and semantic assertions that were still depending on broader, weaker payload shapes.

## Solution
- introduce and propagate shared JSON document aliases across provider-meta, package, and semantic inference surfaces
- rewrite the generation annotation and relation helpers so schema walking, operator inference, and package replacement use explicit typed boundaries instead of loose object plumbing
- tighten fallback, pinning, and synthetic runtime helpers so provider-specific extraction and generated-schema paths share the same contract shape
- relax the over-tight seams revealed by the rewrite where read-only mappings were the right boundary, and keep mutable/generated paths as concrete dict surfaces
- finish the tranche by narrowing the affected test helpers and assertions for schema registry, semantic inference, synthetic semantics, cluster assignment, and prepare-semantic coverage

## Verification
- `ruff check tests/unit/core/test_schema_semantic_inference.py tests/unit/core/test_schema_registry.py tests/unit/core/test_schema_cluster_assignment.py tests/unit/core/test_synthetic_semantics.py tests/unit/pipeline/test_prepare_semantic.py`
- `python -m mypy polylogue tests devtools`
- `pytest -q tests/unit/core/test_schema_semantic_inference.py tests/unit/core/test_schema_registry.py tests/unit/core/test_schema_cluster_assignment.py tests/unit/core/test_synthetic_semantics.py tests/unit/pipeline/test_prepare_semantic.py`
- `devtools verify`
