### PR TITLE
refactor: renew session product runtime and storage seams

### DIFF
--- a/polylogue/archive_product_models.py
+++ b/polylogue/archive_product_models.py
@@ -1,0 +1,183 @@
+"""Shared archive product base and typed payload contracts."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+ARCHIVE_PRODUCT_CONTRACT_VERSION = 4
+
+
+class ArchiveProductModel(BaseModel):
+    """Shared base for public archive data product payloads."""
+
+    # extra="ignore" tolerates legacy fields from older materialized records
+    # (e.g. primary_work_kind, decisions removed in the March 2026 cleanup)
+    model_config = ConfigDict(extra="ignore", frozen=True)
+
+    def to_json(self, *, exclude_none: bool = False) -> str:
+        return self.model_dump_json(indent=2, exclude_none=exclude_none)
+
+
+class ArchiveProductProvenance(ArchiveProductModel):
+    materializer_version: int
+    materialized_at: str
+    source_updated_at: str | None = None
+    source_sort_key: float | None = None
+
+
+class ArchiveInferenceProvenance(ArchiveProductProvenance):
+    inference_version: int
+    inference_family: str
+
+
+class ArchiveEnrichmentProvenance(ArchiveProductProvenance):
+    enrichment_version: int
+    enrichment_family: str
+
+
+class SessionEvidencePayload(ArchiveProductModel):
+    created_at: str | None = None
+    updated_at: str | None = None
+    first_message_at: str | None = None
+    last_message_at: str | None = None
+    canonical_session_date: str | None = None
+    message_count: int = 0
+    substantive_count: int = 0
+    attachment_count: int = 0
+    tool_use_count: int = 0
+    thinking_count: int = 0
+    word_count: int = 0
+    total_cost_usd: float = 0.0
+    total_duration_ms: int = 0
+    wall_duration_ms: int = 0
+    cost_is_estimated: bool = False
+    compaction_count: int = 0
+    has_compaction: bool = False
+    tool_categories: dict[str, int] = Field(default_factory=dict)
+    repo_paths: tuple[str, ...] = ()
+    cwd_paths: tuple[str, ...] = ()
+    branch_names: tuple[str, ...] = ()
+    file_paths_touched: tuple[str, ...] = ()
+    languages_detected: tuple[str, ...] = ()
+    tags: tuple[str, ...] = ()
+    is_continuation: bool = False
+    parent_id: str | None = None
+
+
+class SessionInferencePayload(ArchiveProductModel):
+    repo_names: tuple[str, ...] = ()
+    work_event_count: int = 0
+    phase_count: int = 0
+    engaged_duration_ms: int = 0
+    engaged_minutes: float = 0.0
+    support_level: str = "weak"
+    support_signals: tuple[str, ...] = ()
+    engaged_duration_source: str = "session_total_fallback"
+    repo_inference_strength: str = "weak"
+    auto_tags: tuple[str, ...] = ()
+    work_events: tuple[dict[str, object], ...] = ()
+    phases: tuple[dict[str, object], ...] = ()
+
+
+class WorkEventEvidencePayload(ArchiveProductModel):
+    start_index: int
+    end_index: int
+    start_time: str | None = None
+    end_time: str | None = None
+    canonical_session_date: str | None = None
+    duration_ms: int = 0
+    file_paths: tuple[str, ...] = ()
+    tools_used: tuple[str, ...] = ()
+
+
+class WorkEventInferencePayload(ArchiveProductModel):
+    kind: str
+    summary: str
+    confidence: float
+    evidence: tuple[str, ...] = ()
+    support_level: str = "weak"
+    support_signals: tuple[str, ...] = ()
+    fallback_inference: bool = False
+
+
+class SessionPhaseEvidencePayload(ArchiveProductModel):
+    start_time: str | None = None
+    end_time: str | None = None
+    canonical_session_date: str | None = None
+    message_range: tuple[int, int] = (0, 0)
+    duration_ms: int = 0
+    tool_counts: dict[str, int] = Field(default_factory=dict)
+    word_count: int = 0
+
+
+class SessionPhaseInferencePayload(ArchiveProductModel):
+    confidence: float = 0.0
+    evidence: tuple[str, ...] = ()
+    support_level: str = "weak"
+    support_signals: tuple[str, ...] = ()
+    fallback_inference: bool = False
+
+
+class SessionEnrichmentPayload(ArchiveProductModel):
+    intent_summary: str | None = None
+    outcome_summary: str | None = None
+    blockers: tuple[str, ...] = ()
+    confidence: float = 0.0
+    support_level: str = "weak"
+    support_signals: tuple[str, ...] = ()
+    input_band_summary: dict[str, int] = Field(default_factory=dict)
+
+
+class WorkThreadPayload(ArchiveProductModel):
+    start_time: str | None = None
+    end_time: str | None = None
+    dominant_repo: str | None = None
+    session_ids: tuple[str, ...] = ()
+    session_count: int = 0
+    depth: int = 0
+    branch_count: int = 0
+    total_messages: int = 0
+    total_cost_usd: float = 0.0
+    wall_duration_ms: int = 0
+    work_event_breakdown: dict[str, int] = Field(default_factory=dict)
+
+
+class DaySessionSummaryPayload(ArchiveProductModel):
+    date: str
+    session_count: int = 0
+    total_cost_usd: float = 0.0
+    total_duration_ms: int = 0
+    total_wall_duration_ms: int = 0
+    total_messages: int = 0
+    total_words: int = 0
+    work_event_breakdown: dict[str, int] = Field(default_factory=dict)
+    repos_active: tuple[str, ...] = ()
+    providers: dict[str, int] = Field(default_factory=dict)
+
+
+class WeekSessionSummaryPayload(ArchiveProductModel):
+    iso_week: str
+    day_summaries: tuple[DaySessionSummaryPayload, ...] = ()
+    session_count: int = 0
+    total_cost_usd: float = 0.0
+    total_duration_ms: int = 0
+    total_messages: int = 0
+
+
+__all__ = [
+    "ARCHIVE_PRODUCT_CONTRACT_VERSION",
+    "ArchiveEnrichmentProvenance",
+    "ArchiveInferenceProvenance",
+    "ArchiveProductModel",
+    "ArchiveProductProvenance",
+    "DaySessionSummaryPayload",
+    "SessionEnrichmentPayload",
+    "SessionEvidencePayload",
+    "SessionInferencePayload",
+    "SessionPhaseEvidencePayload",
+    "SessionPhaseInferencePayload",
+    "WeekSessionSummaryPayload",
+    "WorkEventEvidencePayload",
+    "WorkEventInferencePayload",
+    "WorkThreadPayload",
+]

--- a/polylogue/archive_product_summaries.py
+++ b/polylogue/archive_product_summaries.py
@@ -7,6 +7,7 @@ from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
 from datetime import UTC, date, datetime
 
+from polylogue.archive_product_models import DaySessionSummaryPayload, WeekSessionSummaryPayload
 from polylogue.archive_products import (
     DaySessionSummaryProduct,
     WeekSessionSummaryProduct,
@@ -84,7 +85,7 @@ def build_day_session_summary_records(
                 total_words=summary.total_words,
                 work_event_breakdown=summary.work_event_breakdown,
                 repos_active=summary.repos_active,
-                payload=summary.to_dict(),
+                payload=DaySessionSummaryPayload.model_validate(summary.to_dict()),
                 search_text=search_text or bucket_day.isoformat(),
             )
         )
@@ -140,7 +141,7 @@ def aggregate_day_session_summary_products(
         DaySessionSummaryProduct(
             date=day,
             provenance=records_provenance(record_rows),
-            summary=summary.to_dict(),
+            summary=DaySessionSummaryPayload.model_validate(summary.to_dict()),
         )
         for day, summary, record_rows in _aggregate_day_summaries(rows)
     ]
@@ -165,7 +166,7 @@ def aggregate_week_session_summary_products(
             WeekSessionSummaryProduct(
                 iso_week=iso_week,
                 provenance=records_provenance(provenance_rows[iso_week]),
-                summary=week_summary.to_dict(),
+                summary=WeekSessionSummaryPayload.model_validate(week_summary.to_dict()),
             )
         )
     return products

--- a/polylogue/archive_products.py
+++ b/polylogue/archive_products.py
@@ -4,10 +4,24 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from datetime import date, datetime, timedelta
-from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field
-
+from polylogue.archive_product_models import (
+    ARCHIVE_PRODUCT_CONTRACT_VERSION,
+    ArchiveEnrichmentProvenance,
+    ArchiveInferenceProvenance,
+    ArchiveProductModel,
+    ArchiveProductProvenance,
+    DaySessionSummaryPayload,
+    SessionEnrichmentPayload,
+    SessionEvidencePayload,
+    SessionInferencePayload,
+    SessionPhaseEvidencePayload,
+    SessionPhaseInferencePayload,
+    WeekSessionSummaryPayload,
+    WorkEventEvidencePayload,
+    WorkEventInferencePayload,
+    WorkThreadPayload,
+)
 from polylogue.lib.session_profile import SessionProfile
 from polylogue.storage.repair import ArchiveDebtStatus
 from polylogue.storage.store import (
@@ -18,132 +32,9 @@ from polylogue.storage.store import (
     WorkThreadRecord,
 )
 
-ARCHIVE_PRODUCT_CONTRACT_VERSION = 4
-
-
-class ArchiveProductModel(BaseModel):
-    """Shared base for public archive data product payloads."""
-
-    # extra="ignore" tolerates legacy fields from older materialized records
-    # (e.g. primary_work_kind, decisions removed in the March 2026 cleanup)
-    model_config = ConfigDict(extra="ignore", frozen=True)
-
-    def to_json(self, *, exclude_none: bool = False) -> str:
-        return self.model_dump_json(indent=2, exclude_none=exclude_none)
-
 
 class ArchiveProductUnavailableError(RuntimeError):
     """Raised when a durable archive-product surface is not ready to read."""
-
-
-class ArchiveProductProvenance(ArchiveProductModel):
-    materializer_version: int
-    materialized_at: str
-    source_updated_at: str | None = None
-    source_sort_key: float | None = None
-
-
-class ArchiveInferenceProvenance(ArchiveProductProvenance):
-    inference_version: int
-    inference_family: str
-
-
-class ArchiveEnrichmentProvenance(ArchiveProductProvenance):
-    enrichment_version: int
-    enrichment_family: str
-
-
-class SessionEvidencePayload(ArchiveProductModel):
-    created_at: str | None = None
-    updated_at: str | None = None
-    first_message_at: str | None = None
-    last_message_at: str | None = None
-    canonical_session_date: str | None = None
-    message_count: int = 0
-    substantive_count: int = 0
-    attachment_count: int = 0
-    tool_use_count: int = 0
-    thinking_count: int = 0
-    word_count: int = 0
-    total_cost_usd: float = 0.0
-    total_duration_ms: int = 0
-    wall_duration_ms: int = 0
-    cost_is_estimated: bool = False
-    compaction_count: int = 0
-    has_compaction: bool = False
-    tool_categories: dict[str, int] = Field(default_factory=dict)
-    repo_paths: tuple[str, ...] = ()
-    cwd_paths: tuple[str, ...] = ()
-    branch_names: tuple[str, ...] = ()
-    file_paths_touched: tuple[str, ...] = ()
-    languages_detected: tuple[str, ...] = ()
-    tags: tuple[str, ...] = ()
-    is_continuation: bool = False
-    parent_id: str | None = None
-
-
-class SessionInferencePayload(ArchiveProductModel):
-    repo_names: tuple[str, ...] = ()
-    work_event_count: int = 0
-    phase_count: int = 0
-    engaged_duration_ms: int = 0
-    engaged_minutes: float = 0.0
-    support_level: str = "weak"
-    support_signals: tuple[str, ...] = ()
-    engaged_duration_source: str = "session_total_fallback"
-    repo_inference_strength: str = "weak"
-    auto_tags: tuple[str, ...] = ()
-    work_events: tuple[dict[str, Any], ...] = ()
-    phases: tuple[dict[str, Any], ...] = ()
-
-
-class WorkEventEvidencePayload(ArchiveProductModel):
-    start_index: int
-    end_index: int
-    start_time: str | None = None
-    end_time: str | None = None
-    canonical_session_date: str | None = None
-    duration_ms: int = 0
-    file_paths: tuple[str, ...] = ()
-    tools_used: tuple[str, ...] = ()
-
-
-class WorkEventInferencePayload(ArchiveProductModel):
-    kind: str
-    summary: str
-    confidence: float
-    evidence: tuple[str, ...] = ()
-    support_level: str = "weak"
-    support_signals: tuple[str, ...] = ()
-    fallback_inference: bool = False
-
-
-class SessionPhaseEvidencePayload(ArchiveProductModel):
-    start_time: str | None = None
-    end_time: str | None = None
-    canonical_session_date: str | None = None
-    message_range: tuple[int, int] = (0, 0)
-    duration_ms: int = 0
-    tool_counts: dict[str, int] = Field(default_factory=dict)
-    word_count: int = 0
-
-
-class SessionPhaseInferencePayload(ArchiveProductModel):
-    confidence: float = 0.0
-    evidence: tuple[str, ...] = ()
-    support_level: str = "weak"
-    support_signals: tuple[str, ...] = ()
-    fallback_inference: bool = False
-
-
-class SessionEnrichmentPayload(ArchiveProductModel):
-    intent_summary: str | None = None
-    outcome_summary: str | None = None
-    blockers: tuple[str, ...] = ()
-    confidence: float = 0.0
-    support_level: str = "weak"
-    support_signals: tuple[str, ...] = ()
-    input_band_summary: dict[str, int] = Field(default_factory=dict)
 
 
 class SessionProfileProductQuery(ArchiveProductModel):
@@ -272,7 +163,7 @@ class SessionProfileProduct(ArchiveProductModel):
                 source_updated_at=record.source_updated_at,
                 source_sort_key=record.source_sort_key,
             ),
-            evidence=(SessionEvidencePayload.model_validate(record.evidence_payload) if include_evidence else None),
+            evidence=(record.evidence_payload if include_evidence else None),
             inference_provenance=(
                 ArchiveInferenceProvenance(
                     materializer_version=record.materializer_version,
@@ -285,7 +176,7 @@ class SessionProfileProduct(ArchiveProductModel):
                 if include_inference
                 else None
             ),
-            inference=(SessionInferencePayload.model_validate(record.inference_payload) if include_inference else None),
+            inference=(record.inference_payload if include_inference else None),
         )
 
 
@@ -320,7 +211,7 @@ class SessionEnrichmentProduct(ArchiveProductModel):
                 enrichment_version=record.enrichment_version,
                 enrichment_family=record.enrichment_family,
             ),
-            enrichment=SessionEnrichmentPayload.model_validate(record.enrichment_payload),
+            enrichment=record.enrichment_payload,
         )
 
 
@@ -358,8 +249,8 @@ class SessionWorkEventProduct(ArchiveProductModel):
                 inference_version=record.inference_version,
                 inference_family=record.inference_family,
             ),
-            evidence=WorkEventEvidencePayload.model_validate(record.evidence_payload),
-            inference=WorkEventInferencePayload.model_validate(record.inference_payload),
+            evidence=record.evidence_payload,
+            inference=record.inference_payload,
         )
 
 
@@ -397,8 +288,8 @@ class SessionPhaseProduct(ArchiveProductModel):
                 inference_version=record.inference_version,
                 inference_family=record.inference_family,
             ),
-            evidence=SessionPhaseEvidencePayload.model_validate(record.evidence_payload),
-            inference=SessionPhaseInferencePayload.model_validate(record.inference_payload),
+            evidence=record.evidence_payload,
+            inference=record.inference_payload,
         )
 
 
@@ -409,7 +300,7 @@ class WorkThreadProduct(ArchiveProductModel):
     root_id: str
     dominant_repo: str | None = None
     provenance: ArchiveProductProvenance
-    thread: dict[str, Any]
+    thread: WorkThreadPayload
 
     @classmethod
     def from_record(cls, record: WorkThreadRecord) -> WorkThreadProduct:
@@ -423,7 +314,7 @@ class WorkThreadProduct(ArchiveProductModel):
                 source_updated_at=record.end_time or record.start_time,
                 source_sort_key=None,
             ),
-            thread=dict(record.payload),
+            thread=record.payload,
         )
 
 
@@ -444,7 +335,7 @@ class DaySessionSummaryProduct(ArchiveProductModel):
     product_kind: str = "day_session_summary"
     date: str
     provenance: ArchiveProductProvenance
-    summary: dict[str, Any]
+    summary: DaySessionSummaryPayload
 
 
 class WeekSessionSummaryProduct(ArchiveProductModel):
@@ -452,7 +343,7 @@ class WeekSessionSummaryProduct(ArchiveProductModel):
     product_kind: str = "week_session_summary"
     iso_week: str
     provenance: ArchiveProductProvenance
-    summary: dict[str, Any]
+    summary: WeekSessionSummaryPayload
 
 
 class ProviderAnalyticsProduct(ArchiveProductModel):

--- a/polylogue/cli/commands/products.py
+++ b/polylogue/cli/commands/products.py
@@ -8,7 +8,6 @@ works without re-specifying the filter on the subcommand.
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Any
 
 import click
 
@@ -19,7 +18,6 @@ from polylogue.products.registry import (
     PRODUCT_REGISTRY,
     ProductQueryError,
     ProductType,
-    _resolve_query_class,
     fetch_products,
     render_product_items,
 )
@@ -33,22 +31,14 @@ def _build_click_params(pt: ProductType) -> list[click.Parameter]:
     params: list[click.Parameter] = []
 
     for opt in pt.cli_options:
-        kwargs: dict[str, Any] = {"help": opt.help}
-        if opt.type is not None:
-            kwargs["type"] = opt.type
-        if opt.default is not None:
-            kwargs["default"] = opt.default
-        else:
-            kwargs["default"] = None
-        if opt.show_default:
-            kwargs["show_default"] = True
-        if opt.is_flag:
-            kwargs["is_flag"] = True
-
         params.append(
             click.Option(
                 opt.flags,
-                **kwargs,
+                help=opt.help,
+                type=opt.type,
+                default=opt.default,
+                show_default=opt.show_default,
+                is_flag=opt.is_flag,
             )
         )
 
@@ -90,7 +80,7 @@ def _build_click_params(pt: ProductType) -> list[click.Parameter]:
     return params
 
 
-def _find_root_params(ctx: click.Context) -> dict[str, Any]:
+def _find_root_params(ctx: click.Context) -> dict[str, object]:
     """Walk up the context chain to find the root CLI group's params."""
     cur = ctx
     while cur.parent is not None:
@@ -105,8 +95,10 @@ def _make_callback(pt: ProductType) -> Callable[..., None]:
     context when the product's query class accepts them.
     """
     # Pre-resolve accepted fields so we only inject keys the query class understands.
-    query_cls = _resolve_query_class(pt.query_class_path)
-    accepted_root_keys = frozenset(k for k in _ROOT_FILTER_KEYS if k in query_cls.model_fields)
+    query_model = pt.query_model
+    accepted_root_keys = frozenset(
+        key for key in _ROOT_FILTER_KEYS if query_model is not None and key in query_model.model_fields
+    )
 
     @click.pass_context
     def callback(
@@ -114,7 +106,7 @@ def _make_callback(pt: ProductType) -> Callable[..., None]:
         /,
         json_mode: bool = False,
         output_format: str | None = None,
-        **kwargs: Any,
+        **kwargs: object,
     ) -> None:
         env: AppEnv = ctx.obj
 
@@ -157,7 +149,7 @@ def products_command() -> None:
 
 # Register all product types as subcommands
 for _pt in PRODUCT_REGISTRY.values():
-    if _pt.query_class_path and _pt.operations_method:
+    if _pt.query_model is not None and _pt.operations_method_name:
         products_command.add_command(_build_product_command(_pt))
 
 

--- a/polylogue/mcp/server_product_tools.py
+++ b/polylogue/mcp/server_product_tools.py
@@ -8,9 +8,7 @@ lookups) are registered directly.
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Any, cast
-
-from pydantic import BaseModel
+from typing import TYPE_CHECKING
 
 from polylogue.mcp.payloads import MCPRootPayload
 from polylogue.products.registry import (
@@ -32,34 +30,41 @@ def _register_list_tool(
 ) -> None:
     """Register one list-style MCP tool for a product type."""
 
-    # Build the set of accepted query field names from the query class
-    from polylogue.products.registry import _resolve_query_class
-
-    query_cls = cast(type[BaseModel], _resolve_query_class(pt.query_class_path))
-    query_fields = set(query_cls.model_fields)
+    query_model = pt.query_model
+    if query_model is None:
+        raise ValueError(f"Product type {pt.name} does not declare a query model")
+    query_fields = set(query_model.model_fields)
 
     # Determine parameter defaults from the query class
-    field_defaults: dict[str, Any] = {}
-    for fname, finfo in query_cls.model_fields.items():
+    field_defaults: dict[str, object | None] = {}
+    field_annotations: dict[str, object] = {}
+    for fname, finfo in query_model.model_fields.items():
         if finfo.default is not None:
             field_defaults[fname] = finfo.default
         else:
             field_defaults[fname] = None
+        field_annotations[fname] = finfo.annotation if finfo.annotation is not None else object
 
-    async def tool_fn(**kwargs: Any) -> str:
+    async def tool_fn(**kwargs: object) -> str:
         async def run() -> str:
             ops = hooks.get_archive_ops()
             # Apply limit clamping and offset sanitization
             if "limit" in kwargs:
                 kwargs["limit"] = hooks.clamp_limit(kwargs["limit"])
             if "offset" in kwargs:
-                kwargs["offset"] = max(0, int(kwargs["offset"]))
+                offset_value = kwargs["offset"]
+                if isinstance(offset_value, bool):
+                    kwargs["offset"] = 0
+                elif isinstance(offset_value, (int, str, bytes, bytearray)):
+                    kwargs["offset"] = max(0, int(offset_value))
+                else:
+                    kwargs["offset"] = 0
             products = await fetch_products_async(pt, ops, **kwargs)
             return hooks.json_payload(
                 MCPRootPayload(
                     root={
                         "count": len(products),
-                        "items": [p.model_dump(mode="json") if hasattr(p, "model_dump") else p for p in products],
+                        "items": [product.model_dump(mode="json") for product in products],
                     }
                 )
             )
@@ -75,27 +80,23 @@ def _register_list_tool(
     ]
     for fname in sorted(query_fields):
         default = field_defaults.get(fname)
-        # FastMCP reads annotations from __annotations__, so we build them
+        annotation = field_annotations[fname]
         if fname == "limit":
             params.append(
                 inspect.Parameter(fname, inspect.Parameter.KEYWORD_ONLY, default=pt.mcp_default_limit, annotation=int)
             )
         elif fname == "offset":
             params.append(inspect.Parameter(fname, inspect.Parameter.KEYWORD_ONLY, default=0, annotation=int))
-        elif isinstance(default, str):
-            params.append(inspect.Parameter(fname, inspect.Parameter.KEYWORD_ONLY, default=default, annotation=str))
-        elif isinstance(default, int):
-            params.append(inspect.Parameter(fname, inspect.Parameter.KEYWORD_ONLY, default=default, annotation=int))
         else:
             params.append(
-                inspect.Parameter(fname, inspect.Parameter.KEYWORD_ONLY, default=None, annotation="str | None")
+                inspect.Parameter(fname, inspect.Parameter.KEYWORD_ONLY, default=default, annotation=annotation)
             )
 
     # Remove the placeholder — FastMCP doesn't need it
     params = params[1:]
 
     # Create a properly-signed wrapper
-    async def wrapper(**kw: Any) -> str:
+    async def wrapper(**kw: object) -> str:
         return await tool_fn(**kw)
 
     wrapper.__name__ = pt.name
@@ -103,7 +104,7 @@ def _register_list_tool(
     wrapper.__doc__ = f"List {pt.display_name.lower()} from the archive."
 
     # Set annotations for FastMCP introspection
-    annotations: dict[str, Any] = {}
+    annotations: dict[str, object] = {}
     for p in params:
         annotations[p.name] = p.annotation
     annotations["return"] = str
@@ -121,7 +122,7 @@ def register_product_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
 
     # Register generic list tools from the registry
     for pt in PRODUCT_REGISTRY.values():
-        if pt.query_class_path and pt.operations_method:
+        if pt.query_model is not None and pt.operations_method_name:
             _register_list_tool(mcp, hooks, pt)
 
     # --- Special tools ---

--- a/polylogue/pipeline/services/ingest_batch.py
+++ b/polylogue/pipeline/services/ingest_batch.py
@@ -1072,12 +1072,12 @@ async def refresh_session_products_bulk(
             await conn.commit()
 
         elapsed = time.perf_counter() - t_start
-        chunk_observations = getattr(update, "chunk_observations", [])
-        chunk_total_values = [float(chunk["total_ms"]) for chunk in chunk_observations]
-        chunk_load_values = [float(chunk["load_ms"]) for chunk in chunk_observations]
-        chunk_hydrate_values = [float(chunk["hydrate_ms"]) for chunk in chunk_observations]
-        chunk_build_values = [float(chunk["build_ms"]) for chunk in chunk_observations]
-        chunk_write_values = [float(chunk["write_ms"]) for chunk in chunk_observations]
+        chunk_observations = update.chunk_observations
+        chunk_total_values = [chunk.total_ms for chunk in chunk_observations]
+        chunk_load_values = [chunk.load_ms for chunk in chunk_observations]
+        chunk_hydrate_values = [chunk.hydrate_ms for chunk in chunk_observations]
+        chunk_build_values = [chunk.build_ms for chunk in chunk_observations]
+        chunk_write_values = [chunk.write_ms for chunk in chunk_observations]
         observation: BatchObservation = {
             "conversations": len(changed_conversation_ids),
             "unique_thread_roots": len(thread_root_ids),
@@ -1087,7 +1087,7 @@ async def refresh_session_products_bulk(
             "thread_refresh_ms": round(thread_elapsed * 1000.0, 1),
             "aggregate_refresh_ms": round(aggregate_elapsed * 1000.0, 1),
             "update_chunk_count": len(chunk_observations),
-            "update_slow_chunk_count": sum(1 for chunk in chunk_observations if bool(chunk.get("slow"))),
+            "update_slow_chunk_count": sum(1 for chunk in chunk_observations if chunk.slow),
         }
         if chunk_total_values:
             observation["update_max_chunk_ms"] = round(max(chunk_total_values), 1)
@@ -1100,7 +1100,7 @@ async def refresh_session_products_bulk(
         if chunk_write_values:
             observation["update_max_chunk_write_ms"] = round(max(chunk_write_values), 1)
         if chunk_observations:
-            observation["update_chunks"] = chunk_observations
+            observation["update_chunks"] = [chunk.to_observation() for chunk in chunk_observations]
         if elapsed > 2.0:
             logger.info(
                 "session_product_refresh",

--- a/polylogue/products/registry.py
+++ b/polylogue/products/registry.py
@@ -1,35 +1,41 @@
-"""Product type registry — data-driven derived product descriptors.
+"""Product type registry — typed descriptors for durable product surfaces.
 
 Each product type is a ``ProductType`` descriptor that defines:
 - how to display items in plain text (via ``fields``)
 - what the JSON key is for API responses
 - what display name to use in CLI output
-- how to fetch data (query class + operations method name)
-- CLI command configuration (name, help, options)
+- how to build a typed query model
+- which archive-operations method provides the items
+- CLI command metadata (name, help, options)
 
 The rendering is generic: ``render_product_items()`` handles JSON mode
-(all types) and plain-text mode (using field descriptors). Adding a new
-product type requires only a new ``ProductType`` registration — no new
-rendering, workflow, command, or MCP tool files.
-
-Product *semantics* (row builders, lifecycle, storage) remain in code;
-only the *transport/presentation* layer is generic.
+(all types) and plain-text mode (using field descriptors). Product
+semantics stay in the archive/storage layers; the registry owns only the
+transport and presentation contract.
 """
 
 from __future__ import annotations
 
-from collections.abc import Callable
-from dataclasses import dataclass, field
-from typing import Any, cast
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
 
 import click
 from pydantic import BaseModel
 
-from polylogue.archive_products import ArchiveProductModel
+from polylogue.archive_products import (
+    ArchiveProductModel,
+    DaySessionSummaryProductQuery,
+    ProviderAnalyticsProductQuery,
+    SessionEnrichmentProductQuery,
+    SessionPhaseProductQuery,
+    SessionProfileProductQuery,
+    SessionTagRollupQuery,
+    SessionWorkEventProductQuery,
+    WeekSessionSummaryProductQuery,
+    WorkThreadProductQuery,
+)
 
-# -------------------------------------------------------------------
-# Field descriptors
-# -------------------------------------------------------------------
+ProductAccessor = Callable[[object], str]
 
 
 @dataclass(frozen=True, slots=True)
@@ -37,15 +43,8 @@ class ProductField:
     """Describes one displayable field of a product item."""
 
     label: str
-    accessor: Callable[[Any], str]
-    """Function that takes an item and returns a display string."""
+    accessor: ProductAccessor
     group: int = 0
-    """Fields with the same group number are displayed on the same line."""
-
-
-# -------------------------------------------------------------------
-# CLI option descriptor
-# -------------------------------------------------------------------
 
 
 @dataclass(frozen=True, slots=True)
@@ -53,90 +52,60 @@ class CliOption:
     """Describes one Click option for a product command."""
 
     param_name: str
-    """Python parameter name (snake_case)."""
     flags: tuple[str, ...]
-    """Click flags, e.g. ('--provider',)."""
     help: str = ""
-    type: type | click.ParamType | None = None
-    default: Any = None
+    type: click.ParamType | type[object] | None = None
+    default: object | None = None
     show_default: bool = False
     is_flag: bool = False
     expose_value_as: str | None = None
-    """If set, Click will expose the value under this name instead of param_name."""
 
 
-# -------------------------------------------------------------------
-# Product type descriptor
-# -------------------------------------------------------------------
-
-
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class ProductType:
     """Descriptor for one kind of derived product."""
 
     name: str
-    """Registry key, e.g. 'session_profiles'."""
-
     display_name: str
-    """Human-readable name, e.g. 'Session Profiles'."""
-
     json_key: str
-    """Key used in JSON API responses."""
-
-    fields: list[ProductField] = field(default_factory=list)
-    """Fields to display in plain-text mode, grouped by ``group`` number."""
-
+    fields: tuple[ProductField, ...] = ()
     empty_message: str = "No items matched."
-    """Message shown when no items match the query."""
-
-    # --- Dispatch metadata ---
-
-    query_class_path: str = ""
-    """Dotted import path to the query class, e.g.
-    'polylogue.archive_products.SessionProfileProductQuery'."""
-
-    operations_method: str = ""
-    """Name of the async method on ArchiveOperations, e.g.
-    'list_session_profile_products'."""
-
+    query_model: type[ArchiveProductModel] | None = None
+    operations_method_name: str = ""
     cli_command_name: str = ""
-    """Click command name, e.g. 'profiles'. Defaults to name with _ -> -."""
-
     cli_help: str = ""
-    """Help string for the Click command."""
-
-    cli_options: list[CliOption] = field(default_factory=list)
-    """Extra Click options beyond the standard --json, --limit, --offset."""
-
+    cli_options: tuple[CliOption, ...] = ()
     mcp_default_limit: int = 50
-    """Default limit for MCP tool calls."""
 
     @property
     def resolved_cli_command_name(self) -> str:
         return self.cli_command_name or self.name.replace("_", "-")
 
 
-# -------------------------------------------------------------------
-# Generic rendering
-# -------------------------------------------------------------------
-
-
 def _model_payload(item: object) -> object:
     """Convert a product item to a JSON-serializable payload."""
-    return item.model_dump(mode="json") if hasattr(item, "model_dump") else item
+
+    if isinstance(item, BaseModel):
+        return item.model_dump(mode="json")
+    return item
+
+
+def _stringify(value: object | None, default: str = "-") -> str:
+    if value is None:
+        return default
+    if isinstance(value, str) and not value:
+        return default
+    return str(value)
 
 
 def render_product_items(
-    items: list[Any],
+    items: Sequence[object],
     product_type: ProductType,
     *,
     json_mode: bool = False,
 ) -> None:
-    """Render product items to stdout using the product type descriptor.
+    """Render product items using the product type descriptor."""
 
-    JSON mode: emit structured JSON via the machine-error envelope.
-    Plain mode: format using field descriptors.
-    """
     if json_mode:
         from polylogue.cli.machine_errors import emit_success
 
@@ -155,99 +124,117 @@ def render_product_items(
     click.echo(f"{product_type.display_name}: {len(items)}\n")
 
     for item in items:
-        # Group fields by group number, render each group as one line
         groups: dict[int, list[str]] = {}
-        for f in product_type.fields:
+        for field in product_type.fields:
             try:
-                value = f.accessor(item)
+                value = field.accessor(item)
             except (AttributeError, KeyError, TypeError):
                 value = "-"
-            groups.setdefault(f.group, []).append(f"{f.label}={value}" if f.label else str(value))
+            groups.setdefault(field.group, []).append(f"{field.label}={value}" if field.label else str(value))
 
         for group_num in sorted(groups):
             prefix = "  " if group_num == 0 else "    "
             click.echo(f"{prefix}{' '.join(groups[group_num])}")
 
 
-# -------------------------------------------------------------------
-# Helper for building accessors
-# -------------------------------------------------------------------
-
-
-def _attr(name: str, default: str = "-") -> Callable[[Any], str]:
+def _attr(name: str, default: str = "-") -> ProductAccessor:
     """Create an accessor that gets an attribute by name."""
 
-    def accessor(item: Any) -> str:
-        value = getattr(item, name, None)
-        if value is None:
-            return default
-        return str(value)
+    def accessor(item: object) -> str:
+        return _stringify(getattr(item, name, None), default)
 
     return accessor
 
 
-def _nested(outer: str, inner: str, default: str = "-") -> Callable[[Any], str]:
-    """Create an accessor that gets a nested dict value from a model_dump."""
+def _nested(outer: str, inner: str, default: str = "-") -> ProductAccessor:
+    """Create an accessor that gets a nested attribute."""
 
-    def accessor(item: Any) -> str:
-        obj = getattr(item, outer, None)
-        if obj is None:
+    def accessor(item: object) -> str:
+        nested = getattr(item, outer, None)
+        if nested is None:
             return default
-        if hasattr(obj, "model_dump"):
-            obj = obj.model_dump(mode="json")
-        if isinstance(obj, dict):
-            value = obj.get(inner)
-            return str(value) if value is not None else default
-        return default
+        return _stringify(getattr(nested, inner, None), default)
 
     return accessor
 
 
-def _list_preview(name: str, limit: int = 3) -> Callable[[Any], str]:
-    """Accessor showing first N items of a list attribute."""
+def _id_with_provider(identifier_attr: str) -> ProductAccessor:
+    """Accessor rendering an identifier together with the provider name."""
 
-    def accessor(item: Any) -> str:
+    def accessor(item: object) -> str:
+        identifier = _stringify(getattr(item, identifier_attr, None))
+        provider = _stringify(getattr(item, "provider_name", None))
+        return f"{identifier} [{provider}]"
+
+    return accessor
+
+
+def _list_preview(name: str, limit: int = 3) -> ProductAccessor:
+    """Accessor showing the first N items of a tuple/list attribute."""
+
+    def accessor(item: object) -> str:
         values = getattr(item, name, None)
-        if not values:
-            return "-"
         if isinstance(values, (list, tuple)):
-            return ", ".join(str(v) for v in values[:limit]) or "-"
-        return str(values)
+            preview = ", ".join(str(value) for value in values[:limit])
+            return preview or "-"
+        return _stringify(values)
 
     return accessor
 
 
-# -------------------------------------------------------------------
-# Registry
-# -------------------------------------------------------------------
+def _formatted_float(name: str, *, precision: int = 1, default: str = "-") -> ProductAccessor:
+    """Accessor rendering a numeric attribute with fixed precision."""
+
+    def accessor(item: object) -> str:
+        value = getattr(item, name, None)
+        if not isinstance(value, (int, float)) or isinstance(value, bool):
+            return default
+        return f"{float(value):.{precision}f}"
+
+    return accessor
+
+
+def _count_with_percentage(count_attr: str, percentage_attr: str) -> ProductAccessor:
+    """Accessor rendering ``count (pct%)`` pairs from sibling attributes."""
+
+    def accessor(item: object) -> str:
+        count = getattr(item, count_attr, None)
+        percentage = getattr(item, percentage_attr, None)
+        if not isinstance(count, int) or isinstance(count, bool):
+            return "-"
+        if not isinstance(percentage, (int, float)) or isinstance(percentage, bool):
+            return str(count)
+        return f"{count} ({float(percentage):.1f}%)"
+
+    return accessor
+
 
 PRODUCT_REGISTRY: dict[str, ProductType] = {}
 
 
-def register(pt: ProductType) -> ProductType:
+def register(product_type: ProductType) -> ProductType:
     """Register a product type and return it."""
-    PRODUCT_REGISTRY[pt.name] = pt
-    return pt
+
+    PRODUCT_REGISTRY[product_type.name] = product_type
+    return product_type
 
 
 def get_product_type(name: str) -> ProductType:
     """Look up a registered product type by name."""
-    pt = PRODUCT_REGISTRY.get(name)
-    if pt is None:
+
+    product_type = PRODUCT_REGISTRY.get(name)
+    if product_type is None:
         raise KeyError(f"Unknown product type: {name!r}. Available: {sorted(PRODUCT_REGISTRY)}")
-    return pt
+    return product_type
 
 
 def list_product_types() -> list[str]:
-    """Return sorted list of registered product type names."""
+    """Return the sorted registered product type names."""
+
     return sorted(PRODUCT_REGISTRY)
 
 
-# -------------------------------------------------------------------
-# Shared option sets
-# -------------------------------------------------------------------
-
-_SESSION_TIME_OPTIONS: list[CliOption] = [
+_SESSION_TIME_OPTIONS = (
     CliOption(
         "first_message_since",
         ("--first-message-since",),
@@ -268,14 +255,10 @@ _SESSION_TIME_OPTIONS: list[CliOption] = [
         ("--session-date-until",),
         help="Only sessions whose canonical session date is on/before this date",
     ),
-]
+)
 
 _QUERY_OPTION = CliOption("query", ("--query",), help="FTS query against product search text")
 
-
-# -------------------------------------------------------------------
-# Product type registrations
-# -------------------------------------------------------------------
 
 register(
     ProductType(
@@ -283,11 +266,11 @@ register(
         display_name="Session Profiles",
         json_key="session_profiles",
         empty_message="No session profiles matched.",
-        query_class_path="polylogue.archive_products.SessionProfileProductQuery",
-        operations_method="list_session_profile_products",
+        query_model=SessionProfileProductQuery,
+        operations_method_name="list_session_profile_products",
         cli_command_name="profiles",
         cli_help="List durable session-profile products.",
-        cli_options=[
+        cli_options=(
             *_SESSION_TIME_OPTIONS,
             CliOption(
                 "tier",
@@ -298,15 +281,15 @@ register(
                 help="Return merged, evidence-only, or inference-only profile products",
             ),
             _QUERY_OPTION,
-        ],
-        fields=[
-            ProductField("", lambda i: f"{i.conversation_id} [{i.provider_name}]", group=0),
+        ),
+        fields=(
+            ProductField("", _id_with_provider("conversation_id"), group=0),
             ProductField("tier", _attr("semantic_tier"), group=0),
             ProductField("", _attr("title", "(untitled)"), group=0),
             ProductField("session_date", _nested("evidence", "canonical_session_date"), group=1),
             ProductField("messages", _nested("evidence", "message_count", "0"), group=1),
             ProductField("engaged_min", _nested("inference", "engaged_minutes", "0"), group=1),
-        ],
+        ),
     )
 )
 
@@ -316,24 +299,20 @@ register(
         display_name="Session Enrichments",
         json_key="session_enrichments",
         empty_message="No session enrichments matched.",
-        query_class_path="polylogue.archive_products.SessionEnrichmentProductQuery",
-        operations_method="list_session_enrichment_products",
+        query_model=SessionEnrichmentProductQuery,
+        operations_method_name="list_session_enrichment_products",
         cli_command_name="enrichments",
         cli_help="List durable probabilistic session-enrichment products.",
-        cli_options=[
+        cli_options=(
             *_SESSION_TIME_OPTIONS,
             _QUERY_OPTION,
-        ],
-        fields=[
-            ProductField("", lambda i: f"{i.conversation_id} [{i.provider_name}]", group=0),
+        ),
+        fields=(
+            ProductField("", _id_with_provider("conversation_id"), group=0),
             ProductField("", _attr("title", "(untitled)"), group=0),
             ProductField("support", _nested("enrichment", "support_level"), group=1),
-            ProductField(
-                "family",
-                lambda i: i.enrichment_provenance.enrichment_family if hasattr(i, "enrichment_provenance") else "-",
-                group=1,
-            ),
-        ],
+            ProductField("family", _nested("enrichment_provenance", "enrichment_family"), group=1),
+        ),
     )
 )
 
@@ -343,23 +322,23 @@ register(
         display_name="Work Events",
         json_key="session_work_events",
         empty_message="No work events matched.",
-        query_class_path="polylogue.archive_products.SessionWorkEventProductQuery",
-        operations_method="list_session_work_event_products",
+        query_model=SessionWorkEventProductQuery,
+        operations_method_name="list_session_work_event_products",
         cli_command_name="work-events",
         cli_help="List durable work-event products.",
-        cli_options=[
+        cli_options=(
             CliOption("conversation_id", ("--conversation-id",), help="Only events from one conversation"),
             CliOption("kind", ("--kind",), help="Only this work-event kind"),
             _QUERY_OPTION,
-        ],
-        fields=[
-            ProductField("", lambda i: f"{i.event_id} [{i.provider_name}]", group=0),
+        ),
+        fields=(
+            ProductField("", _id_with_provider("event_id"), group=0),
             ProductField("kind", _nested("inference", "kind"), group=0),
             ProductField("conv", _attr("conversation_id"), group=0),
             ProductField("start", _nested("evidence", "start_time"), group=1),
             ProductField("end", _nested("evidence", "end_time"), group=1),
             ProductField("duration_ms", _nested("evidence", "duration_ms", "0"), group=1),
-        ],
+        ),
     )
 )
 
@@ -369,21 +348,21 @@ register(
         display_name="Session Phases",
         json_key="session_phases",
         empty_message="No session phases matched.",
-        query_class_path="polylogue.archive_products.SessionPhaseProductQuery",
-        operations_method="list_session_phase_products",
+        query_model=SessionPhaseProductQuery,
+        operations_method_name="list_session_phase_products",
         cli_command_name="phases",
         cli_help="List durable session-phase products.",
-        cli_options=[
+        cli_options=(
             CliOption("conversation_id", ("--conversation-id",), help="Only phases from one conversation"),
             CliOption("kind", ("--kind",), help="Only this session phase kind"),
-        ],
-        fields=[
-            ProductField("", lambda i: f"{i.phase_id} [{i.provider_name}]", group=0),
+        ),
+        fields=(
+            ProductField("", _id_with_provider("phase_id"), group=0),
             ProductField("kind", _nested("inference", "kind"), group=0),
             ProductField("conv", _attr("conversation_id"), group=0),
             ProductField("start", _nested("evidence", "start_time"), group=1),
             ProductField("words", _nested("evidence", "word_count", "0"), group=1),
-        ],
+        ),
     )
 )
 
@@ -393,24 +372,18 @@ register(
         display_name="Work Threads",
         json_key="work_threads",
         empty_message="No work threads matched.",
-        query_class_path="polylogue.archive_products.WorkThreadProductQuery",
-        operations_method="list_work_thread_products",
+        query_model=WorkThreadProductQuery,
+        operations_method_name="list_work_thread_products",
         cli_command_name="threads",
         cli_help="List durable work-thread products.",
-        cli_options=[
-            _QUERY_OPTION,
-        ],
-        fields=[
+        cli_options=(_QUERY_OPTION,),
+        fields=(
             ProductField("", _attr("thread_id"), group=0),
             ProductField("repo", _attr("dominant_repo", "-"), group=0),
-            ProductField(
-                "sessions", lambda i: str(i.thread.get("session_count", 0)) if hasattr(i, "thread") else "0", group=0
-            ),
-            ProductField(
-                "messages", lambda i: str(i.thread.get("total_messages", 0)) if hasattr(i, "thread") else "0", group=1
-            ),
-            ProductField("depth", lambda i: str(i.thread.get("depth", 0)) if hasattr(i, "thread") else "0", group=1),
-        ],
+            ProductField("sessions", _nested("thread", "session_count", "0"), group=0),
+            ProductField("messages", _nested("thread", "total_messages", "0"), group=1),
+            ProductField("depth", _nested("thread", "depth", "0"), group=1),
+        ),
     )
 )
 
@@ -420,20 +393,18 @@ register(
         display_name="Session Tag Rollups",
         json_key="session_tag_rollups",
         empty_message="No session tag rollups matched.",
-        query_class_path="polylogue.archive_products.SessionTagRollupQuery",
-        operations_method="list_session_tag_rollup_products",
+        query_model=SessionTagRollupQuery,
+        operations_method_name="list_session_tag_rollup_products",
         cli_command_name="tags",
         cli_help="List durable session-tag rollup products.",
-        cli_options=[
-            CliOption("query", ("--query",), help="Substring match against the tag name"),
-        ],
+        cli_options=(CliOption("query", ("--query",), help="Substring match against the tag name"),),
         mcp_default_limit=100,
-        fields=[
+        fields=(
             ProductField("", _attr("tag"), group=0),
             ProductField("conversations", _attr("conversation_count", "0"), group=0),
             ProductField("explicit", _attr("explicit_count", "0"), group=0),
             ProductField("auto", _attr("auto_count", "0"), group=0),
-        ],
+        ),
     )
 )
 
@@ -443,21 +414,16 @@ register(
         display_name="Day Session Summaries",
         json_key="day_session_summaries",
         empty_message="No day summaries matched.",
-        query_class_path="polylogue.archive_products.DaySessionSummaryProductQuery",
-        operations_method="list_day_session_summary_products",
+        query_model=DaySessionSummaryProductQuery,
+        operations_method_name="list_day_session_summary_products",
         cli_command_name="day-summaries",
         cli_help="List durable day-level session summary products.",
-        cli_options=[],
         mcp_default_limit=90,
-        fields=[
+        fields=(
             ProductField("", _attr("date"), group=0),
-            ProductField(
-                "sessions", lambda i: str(i.summary.get("session_count", 0)) if hasattr(i, "summary") else "0", group=0
-            ),
-            ProductField(
-                "messages", lambda i: str(i.summary.get("total_messages", 0)) if hasattr(i, "summary") else "0", group=0
-            ),
-        ],
+            ProductField("sessions", _nested("summary", "session_count", "0"), group=0),
+            ProductField("messages", _nested("summary", "total_messages", "0"), group=0),
+        ),
     )
 )
 
@@ -467,21 +433,16 @@ register(
         display_name="Week Session Summaries",
         json_key="week_session_summaries",
         empty_message="No week summaries matched.",
-        query_class_path="polylogue.archive_products.WeekSessionSummaryProductQuery",
-        operations_method="list_week_session_summary_products",
+        query_model=WeekSessionSummaryProductQuery,
+        operations_method_name="list_week_session_summary_products",
         cli_command_name="week-summaries",
         cli_help="List durable week-level session summary products.",
-        cli_options=[],
         mcp_default_limit=52,
-        fields=[
+        fields=(
             ProductField("", _attr("iso_week"), group=0),
-            ProductField(
-                "sessions", lambda i: str(i.summary.get("session_count", 0)) if hasattr(i, "summary") else "0", group=0
-            ),
-            ProductField(
-                "messages", lambda i: str(i.summary.get("total_messages", 0)) if hasattr(i, "summary") else "0", group=0
-            ),
-        ],
+            ProductField("sessions", _nested("summary", "session_count", "0"), group=0),
+            ProductField("messages", _nested("summary", "total_messages", "0"), group=0),
+        ),
     )
 )
 
@@ -491,52 +452,20 @@ register(
         display_name="Provider Analytics",
         json_key="provider_analytics",
         empty_message="No provider analytics matched.",
-        query_class_path="polylogue.archive_products.ProviderAnalyticsProductQuery",
-        operations_method="list_provider_analytics_products",
+        query_model=ProviderAnalyticsProductQuery,
+        operations_method_name="list_provider_analytics_products",
         cli_command_name="analytics",
         cli_help="List provider-level analytics products.",
-        cli_options=[],
-        fields=[
+        fields=(
             ProductField("", _attr("provider_name"), group=0),
             ProductField("conversations", _attr("conversation_count", "0"), group=0),
             ProductField("messages", _attr("message_count", "0"), group=0),
-            ProductField(
-                "avg_messages",
-                lambda i: (
-                    f"{i.avg_messages_per_conversation:.1f}" if hasattr(i, "avg_messages_per_conversation") else "-"
-                ),
-                group=0,
-            ),
-            ProductField(
-                "tools",
-                lambda i: f"{i.tool_use_count} ({i.tool_use_percentage:.1f}%)" if hasattr(i, "tool_use_count") else "-",
-                group=1,
-            ),
-            ProductField(
-                "thinking",
-                lambda i: f"{i.thinking_count} ({i.thinking_percentage:.1f}%)" if hasattr(i, "thinking_count") else "-",
-                group=1,
-            ),
-        ],
+            ProductField("avg_messages", _formatted_float("avg_messages_per_conversation"), group=0),
+            ProductField("tools", _count_with_percentage("tool_use_count", "tool_use_percentage"), group=1),
+            ProductField("thinking", _count_with_percentage("thinking_count", "thinking_percentage"), group=1),
+        ),
     )
 )
-
-
-# -------------------------------------------------------------------
-# Generic data fetching
-# -------------------------------------------------------------------
-
-
-def _resolve_query_class(dotted_path: str) -> type[ArchiveProductModel]:
-    """Import and return a class from a dotted path."""
-    module_path, class_name = dotted_path.rsplit(".", 1)
-    import importlib
-
-    mod = importlib.import_module(module_path)
-    resolved = getattr(mod, class_name)
-    if not isinstance(resolved, type) or not issubclass(resolved, BaseModel):
-        raise TypeError(f"{dotted_path} is not a Pydantic model class")
-    return cast(type[ArchiveProductModel], resolved)
 
 
 class ProductQueryError(ValueError):
@@ -545,11 +474,14 @@ class ProductQueryError(ValueError):
 
 def _build_query(
     product_type: ProductType,
-    **kwargs: Any,
-) -> Any:
+    **kwargs: object,
+) -> ArchiveProductModel:
     """Build and validate the typed query object for a product fetch."""
-    query_cls = _resolve_query_class(product_type.query_class_path)
-    accepted = set(query_cls.model_fields)
+
+    query_model = product_type.query_model
+    if query_model is None:
+        raise ProductQueryError(f"Product type {product_type.name} does not declare a query model")
+    accepted = set(query_model.model_fields)
     unknown = sorted(set(kwargs) - accepted)
     if unknown:
         unknown_list = ", ".join(unknown)
@@ -557,35 +489,33 @@ def _build_query(
         raise ProductQueryError(
             f"Unknown query field(s) for {product_type.name}: {unknown_list}. Accepted fields: {accepted_list}"
         )
-    return query_cls(**kwargs)
+    return query_model(**kwargs)
 
 
 def fetch_products(
     product_type: ProductType,
     operations: object,
-    **kwargs: Any,
-) -> list[Any]:
-    """Fetch product items using the registry dispatch metadata.
+    **kwargs: object,
+) -> list[ArchiveProductModel]:
+    """Fetch product items using the registry dispatch metadata."""
 
-    Constructs the query object from ``product_type.query_class_path``
-    using **kwargs, then calls the async operations method synchronously.
-    """
     from polylogue.sync_bridge import run_coroutine_sync
 
     query = _build_query(product_type, **kwargs)
-    method = getattr(operations, product_type.operations_method)
-    return cast(list[Any], run_coroutine_sync(method(query)))
+    method = getattr(operations, product_type.operations_method_name)
+    return list(run_coroutine_sync(method(query)))
 
 
 async def fetch_products_async(
     product_type: ProductType,
     operations: object,
-    **kwargs: Any,
-) -> list[Any]:
+    **kwargs: object,
+) -> list[ArchiveProductModel]:
     """Async variant of ``fetch_products()``."""
+
     query = _build_query(product_type, **kwargs)
-    method = getattr(operations, product_type.operations_method)
-    return cast(list[Any], await method(query))
+    method = getattr(operations, product_type.operations_method_name)
+    return list(await method(query))
 
 
 __all__ = [

--- a/polylogue/scenarios/execution.py
+++ b/polylogue/scenarios/execution.py
@@ -120,10 +120,10 @@ def _metadata_for_polylogue_products(argv: tuple[str, ...]) -> ScenarioMetadata:
         return _metadata_for_operations(direct_operation)
     operation_name = next(
         (
-            _PRODUCT_OPERATION_BY_METHOD[product.operations_method]
+            _PRODUCT_OPERATION_BY_METHOD[product.operations_method_name]
             for product in PRODUCT_REGISTRY.values()
             if product.resolved_cli_command_name == subcommand
-            and product.operations_method in _PRODUCT_OPERATION_BY_METHOD
+            and product.operations_method_name in _PRODUCT_OPERATION_BY_METHOD
         ),
         "",
     )

--- a/polylogue/storage/backends/queries/mappers_product_aggregates.py
+++ b/polylogue/storage/backends/queries/mappers_product_aggregates.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import sqlite3
 
+from polylogue.archive_product_models import DaySessionSummaryPayload
 from polylogue.storage.backends.queries.mappers import _parse_json, _row_get
 from polylogue.storage.store import (
     DaySessionSummaryRecord,
@@ -54,12 +55,14 @@ def _row_to_day_session_summary_record(row: sqlite3.Row) -> DaySessionSummaryRec
         )
         or {},
         repos_active=tuple(_parse_json(_row_get(row, "repos_active_json")) or []),
-        payload=_parse_json(
-            row["payload_json"],
-            field="payload_json",
-            record_id=f"{row['provider_name']}:{row['day']}",
-        )
-        or {},
+        payload=DaySessionSummaryPayload.model_validate(
+            _parse_json(
+                row["payload_json"],
+                field="payload_json",
+                record_id=f"{row['provider_name']}:{row['day']}",
+            )
+            or {}
+        ),
         search_text=row["search_text"],
     )
 

--- a/polylogue/storage/backends/queries/mappers_product_profiles.py
+++ b/polylogue/storage/backends/queries/mappers_product_profiles.py
@@ -4,6 +4,11 @@ from __future__ import annotations
 
 import sqlite3
 
+from polylogue.archive_product_models import (
+    SessionEnrichmentPayload,
+    SessionEvidencePayload,
+    SessionInferencePayload,
+)
 from polylogue.storage.backends.queries.mappers import _parse_json, _row_get
 from polylogue.storage.store import SessionProfileRecord
 from polylogue.types import ConversationId
@@ -22,109 +27,116 @@ def _row_to_session_profile_record(row: sqlite3.Row) -> SessionProfileRecord:
         )
         or {}
     )
-    evidence_payload = (
-        _parse_json(
-            _row_get(row, "evidence_payload_json"),
-            field="evidence_payload_json",
-            record_id=row["conversation_id"],
-        )
-        or {}
+    raw_evidence_payload = _parse_json(
+        _row_get(row, "evidence_payload_json"),
+        field="evidence_payload_json",
+        record_id=row["conversation_id"],
     )
-    if not evidence_payload:
-        evidence_payload = {
-            "created_at": legacy_payload.get("created_at"),
-            "updated_at": legacy_payload.get("updated_at") or _row_get(row, "source_updated_at"),
-            "first_message_at": _row_get(row, "first_message_at") or legacy_payload.get("first_message_at"),
-            "last_message_at": _row_get(row, "last_message_at") or legacy_payload.get("last_message_at"),
-            "canonical_session_date": _row_get(row, "canonical_session_date")
-            or legacy_payload.get("canonical_session_date"),
-            "message_count": int(_row_get(row, "message_count", 0) or legacy_payload.get("message_count") or 0),
-            "substantive_count": int(
-                _row_get(row, "substantive_count", 0) or legacy_payload.get("substantive_count") or 0
-            ),
-            "attachment_count": int(
-                _row_get(row, "attachment_count", 0) or legacy_payload.get("attachment_count") or 0
-            ),
-            "tool_use_count": int(_row_get(row, "tool_use_count", 0) or legacy_payload.get("tool_use_count") or 0),
-            "thinking_count": int(_row_get(row, "thinking_count", 0) or legacy_payload.get("thinking_count") or 0),
-            "word_count": int(_row_get(row, "word_count", 0) or legacy_payload.get("word_count") or 0),
-            "total_cost_usd": float(
-                _row_get(row, "total_cost_usd", 0.0) or legacy_payload.get("total_cost_usd") or 0.0
-            ),
-            "total_duration_ms": int(
-                _row_get(row, "total_duration_ms", 0) or legacy_payload.get("total_duration_ms") or 0
-            ),
-            "wall_duration_ms": int(
-                _row_get(row, "wall_duration_ms", 0) or legacy_payload.get("wall_duration_ms") or 0
-            ),
-            "cost_is_estimated": bool(
-                int(_row_get(row, "cost_is_estimated", 0) or 0) or legacy_payload.get("cost_is_estimated")
-            ),
-            "tool_categories": legacy_payload.get("tool_categories") or {},
-            "repo_paths": tuple(
-                _parse_json(_row_get(row, "repo_paths_json")) or legacy_payload.get("repo_paths") or []
-            ),
-            "cwd_paths": tuple(legacy_payload.get("cwd_paths") or ()),
-            "branch_names": tuple(legacy_payload.get("branch_names") or ()),
-            "file_paths_touched": tuple(legacy_payload.get("file_paths_touched") or ()),
-            "languages_detected": tuple(legacy_payload.get("languages_detected") or ()),
-            "tags": tuple(_parse_json(_row_get(row, "tags_json")) or legacy_payload.get("tags") or []),
-            "is_continuation": bool(legacy_payload.get("is_continuation", False)),
-            "parent_id": legacy_payload.get("parent_id"),
-        }
-    inference_payload = (
-        _parse_json(
-            _row_get(row, "inference_payload_json"),
-            field="inference_payload_json",
-            record_id=row["conversation_id"],
+    if raw_evidence_payload:
+        evidence_payload = SessionEvidencePayload.model_validate(raw_evidence_payload)
+    else:
+        evidence_payload = SessionEvidencePayload.model_validate(
+            {
+                "created_at": legacy_payload.get("created_at"),
+                "updated_at": legacy_payload.get("updated_at") or _row_get(row, "source_updated_at"),
+                "first_message_at": _row_get(row, "first_message_at") or legacy_payload.get("first_message_at"),
+                "last_message_at": _row_get(row, "last_message_at") or legacy_payload.get("last_message_at"),
+                "canonical_session_date": _row_get(row, "canonical_session_date")
+                or legacy_payload.get("canonical_session_date"),
+                "message_count": int(_row_get(row, "message_count", 0) or legacy_payload.get("message_count") or 0),
+                "substantive_count": int(
+                    _row_get(row, "substantive_count", 0) or legacy_payload.get("substantive_count") or 0
+                ),
+                "attachment_count": int(
+                    _row_get(row, "attachment_count", 0) or legacy_payload.get("attachment_count") or 0
+                ),
+                "tool_use_count": int(_row_get(row, "tool_use_count", 0) or legacy_payload.get("tool_use_count") or 0),
+                "thinking_count": int(_row_get(row, "thinking_count", 0) or legacy_payload.get("thinking_count") or 0),
+                "word_count": int(_row_get(row, "word_count", 0) or legacy_payload.get("word_count") or 0),
+                "total_cost_usd": float(
+                    _row_get(row, "total_cost_usd", 0.0) or legacy_payload.get("total_cost_usd") or 0.0
+                ),
+                "total_duration_ms": int(
+                    _row_get(row, "total_duration_ms", 0) or legacy_payload.get("total_duration_ms") or 0
+                ),
+                "wall_duration_ms": int(
+                    _row_get(row, "wall_duration_ms", 0) or legacy_payload.get("wall_duration_ms") or 0
+                ),
+                "cost_is_estimated": bool(
+                    int(_row_get(row, "cost_is_estimated", 0) or 0) or legacy_payload.get("cost_is_estimated")
+                ),
+                "tool_categories": legacy_payload.get("tool_categories") or {},
+                "repo_paths": tuple(
+                    _parse_json(_row_get(row, "repo_paths_json")) or legacy_payload.get("repo_paths") or []
+                ),
+                "cwd_paths": tuple(legacy_payload.get("cwd_paths") or ()),
+                "branch_names": tuple(legacy_payload.get("branch_names") or ()),
+                "file_paths_touched": tuple(legacy_payload.get("file_paths_touched") or ()),
+                "languages_detected": tuple(legacy_payload.get("languages_detected") or ()),
+                "tags": tuple(_parse_json(_row_get(row, "tags_json")) or legacy_payload.get("tags") or []),
+                "is_continuation": bool(legacy_payload.get("is_continuation", False)),
+                "parent_id": legacy_payload.get("parent_id"),
+            }
         )
-        or {}
+    raw_inference_payload = _parse_json(
+        _row_get(row, "inference_payload_json"),
+        field="inference_payload_json",
+        record_id=row["conversation_id"],
     )
-    if not inference_payload:
-        inference_payload = {
-            "repo_names": tuple(
-                _parse_json(_row_get(row, "repo_names_json")) or legacy_payload.get("repo_names") or []
-            ),
-            "work_event_count": int(
-                _row_get(row, "work_event_count", 0) or legacy_payload.get("work_event_count") or 0
-            ),
-            "phase_count": int(_row_get(row, "phase_count", 0) or legacy_payload.get("phase_count") or 0),
-            "engaged_duration_ms": int(
-                _row_get(row, "engaged_duration_ms", 0) or legacy_payload.get("engaged_duration_ms") or 0
-            ),
-            "engaged_minutes": float(legacy_payload.get("engaged_minutes") or 0.0),
-            "support_level": str(legacy_payload.get("support_level") or "weak"),
-            "support_signals": tuple(legacy_payload.get("support_signals") or ()),
-            "engaged_duration_source": str(legacy_payload.get("engaged_duration_source") or "session_total_fallback"),
-            "repo_inference_strength": str(legacy_payload.get("repo_inference_strength") or "weak"),
-            "auto_tags": tuple(_parse_json(_row_get(row, "auto_tags_json")) or legacy_payload.get("auto_tags") or []),
-            "work_events": tuple(legacy_payload.get("work_events") or ()),
-            "phases": tuple(legacy_payload.get("phases") or ()),
-        }
-    enrichment_payload = (
-        _parse_json(
-            _row_get(row, "enrichment_payload_json"),
-            field="enrichment_payload_json",
-            record_id=row["conversation_id"],
+    if raw_inference_payload:
+        inference_payload = SessionInferencePayload.model_validate(raw_inference_payload)
+    else:
+        inference_payload = SessionInferencePayload.model_validate(
+            {
+                "repo_names": tuple(
+                    _parse_json(_row_get(row, "repo_names_json")) or legacy_payload.get("repo_names") or []
+                ),
+                "work_event_count": int(
+                    _row_get(row, "work_event_count", 0) or legacy_payload.get("work_event_count") or 0
+                ),
+                "phase_count": int(_row_get(row, "phase_count", 0) or legacy_payload.get("phase_count") or 0),
+                "engaged_duration_ms": int(
+                    _row_get(row, "engaged_duration_ms", 0) or legacy_payload.get("engaged_duration_ms") or 0
+                ),
+                "engaged_minutes": float(legacy_payload.get("engaged_minutes") or 0.0),
+                "support_level": str(legacy_payload.get("support_level") or "weak"),
+                "support_signals": tuple(legacy_payload.get("support_signals") or ()),
+                "engaged_duration_source": str(
+                    legacy_payload.get("engaged_duration_source") or "session_total_fallback"
+                ),
+                "repo_inference_strength": str(legacy_payload.get("repo_inference_strength") or "weak"),
+                "auto_tags": tuple(
+                    _parse_json(_row_get(row, "auto_tags_json")) or legacy_payload.get("auto_tags") or []
+                ),
+                "work_events": tuple(legacy_payload.get("work_events") or ()),
+                "phases": tuple(legacy_payload.get("phases") or ()),
+            }
         )
-        or {}
+    raw_enrichment_payload = _parse_json(
+        _row_get(row, "enrichment_payload_json"),
+        field="enrichment_payload_json",
+        record_id=row["conversation_id"],
     )
-    if not enrichment_payload:
-        enrichment_payload = {
-            "intent_summary": row["title"] or legacy_payload.get("title"),
-            "outcome_summary": None,
-            "blockers": (),
-            "confidence": 0.0,
-            "support_level": "weak",
-            "support_signals": tuple(inference_payload.get("support_signals") or ()),
-            "input_band_summary": {
-                "user_turns": 0,
-                "assistant_turns": 0,
-                "action_events": 0,
-                "touched_paths": len(_parse_json(_row_get(row, "repo_paths_json")) or []),
-                "repo_names": len(_parse_json(_row_get(row, "repo_names_json")) or []),
-            },
-        }
+    if raw_enrichment_payload:
+        enrichment_payload = SessionEnrichmentPayload.model_validate(raw_enrichment_payload)
+    else:
+        enrichment_payload = SessionEnrichmentPayload.model_validate(
+            {
+                "intent_summary": row["title"] or legacy_payload.get("title"),
+                "outcome_summary": None,
+                "blockers": (),
+                "confidence": 0.0,
+                "support_level": "weak",
+                "support_signals": inference_payload.support_signals,
+                "input_band_summary": {
+                    "user_turns": 0,
+                    "assistant_turns": 0,
+                    "action_events": 0,
+                    "touched_paths": len(_parse_json(_row_get(row, "repo_paths_json")) or []),
+                    "repo_names": len(_parse_json(_row_get(row, "repo_names_json")) or []),
+                },
+            }
+        )
     return SessionProfileRecord(
         conversation_id=ConversationId(row["conversation_id"]),
         materializer_version=int(_row_get(row, "materializer_version", 1) or 1),

--- a/polylogue/storage/backends/queries/mappers_product_timelines.py
+++ b/polylogue/storage/backends/queries/mappers_product_timelines.py
@@ -4,6 +4,13 @@ from __future__ import annotations
 
 import sqlite3
 
+from polylogue.archive_product_models import (
+    SessionPhaseEvidencePayload,
+    SessionPhaseInferencePayload,
+    WorkEventEvidencePayload,
+    WorkEventInferencePayload,
+    WorkThreadPayload,
+)
 from polylogue.storage.backends.queries.mappers import _parse_json, _row_get
 from polylogue.storage.store import SessionPhaseRecord, SessionWorkEventRecord, WorkThreadRecord
 from polylogue.types import ConversationId
@@ -18,45 +25,47 @@ def _row_to_session_work_event_record(row: sqlite3.Row) -> SessionWorkEventRecor
         )
         or {}
     )
-    evidence_payload = (
-        _parse_json(
-            _row_get(row, "evidence_payload_json"),
-            field="evidence_payload_json",
-            record_id=row["event_id"],
-        )
-        or {}
+    raw_evidence_payload = _parse_json(
+        _row_get(row, "evidence_payload_json"),
+        field="evidence_payload_json",
+        record_id=row["event_id"],
     )
-    if not evidence_payload:
-        evidence_payload = {
-            "start_index": int(_row_get(row, "start_index", 0) or legacy_payload.get("start_index") or 0),
-            "end_index": int(_row_get(row, "end_index", 0) or legacy_payload.get("end_index") or 0),
-            "start_time": _row_get(row, "start_time") or legacy_payload.get("start_time"),
-            "end_time": _row_get(row, "end_time") or legacy_payload.get("end_time"),
-            "canonical_session_date": _row_get(row, "canonical_session_date")
-            or legacy_payload.get("canonical_session_date"),
-            "duration_ms": int(_row_get(row, "duration_ms", 0) or legacy_payload.get("duration_ms") or 0),
-            "file_paths": tuple(
-                _parse_json(_row_get(row, "file_paths_json")) or legacy_payload.get("file_paths") or []
-            ),
-            "tools_used": tuple(
-                _parse_json(_row_get(row, "tools_used_json")) or legacy_payload.get("tools_used") or []
-            ),
-        }
-    inference_payload = (
-        _parse_json(
-            _row_get(row, "inference_payload_json"),
-            field="inference_payload_json",
-            record_id=row["event_id"],
+    if raw_evidence_payload:
+        evidence_payload = WorkEventEvidencePayload.model_validate(raw_evidence_payload)
+    else:
+        evidence_payload = WorkEventEvidencePayload.model_validate(
+            {
+                "start_index": int(_row_get(row, "start_index", 0) or legacy_payload.get("start_index") or 0),
+                "end_index": int(_row_get(row, "end_index", 0) or legacy_payload.get("end_index") or 0),
+                "start_time": _row_get(row, "start_time") or legacy_payload.get("start_time"),
+                "end_time": _row_get(row, "end_time") or legacy_payload.get("end_time"),
+                "canonical_session_date": _row_get(row, "canonical_session_date")
+                or legacy_payload.get("canonical_session_date"),
+                "duration_ms": int(_row_get(row, "duration_ms", 0) or legacy_payload.get("duration_ms") or 0),
+                "file_paths": tuple(
+                    _parse_json(_row_get(row, "file_paths_json")) or legacy_payload.get("file_paths") or []
+                ),
+                "tools_used": tuple(
+                    _parse_json(_row_get(row, "tools_used_json")) or legacy_payload.get("tools_used") or []
+                ),
+            }
         )
-        or {}
+    raw_inference_payload = _parse_json(
+        _row_get(row, "inference_payload_json"),
+        field="inference_payload_json",
+        record_id=row["event_id"],
     )
-    if not inference_payload:
-        inference_payload = {
-            "kind": row["kind"],
-            "summary": row["summary"],
-            "confidence": float(_row_get(row, "confidence", 0.0) or legacy_payload.get("confidence") or 0.0),
-            "evidence": tuple(legacy_payload.get("evidence") or ()),
-        }
+    if raw_inference_payload:
+        inference_payload = WorkEventInferencePayload.model_validate(raw_inference_payload)
+    else:
+        inference_payload = WorkEventInferencePayload.model_validate(
+            {
+                "kind": row["kind"],
+                "summary": row["summary"],
+                "confidence": float(_row_get(row, "confidence", 0.0) or legacy_payload.get("confidence") or 0.0),
+                "evidence": tuple(legacy_payload.get("evidence") or ()),
+            }
+        )
     return SessionWorkEventRecord(
         event_id=row["event_id"],
         conversation_id=ConversationId(row["conversation_id"]),
@@ -94,43 +103,47 @@ def _row_to_session_phase_record(row: sqlite3.Row) -> SessionPhaseRecord:
         )
         or {}
     )
-    evidence_payload = (
-        _parse_json(
-            _row_get(row, "evidence_payload_json"),
-            field="evidence_payload_json",
-            record_id=row["phase_id"],
-        )
-        or {}
+    raw_evidence_payload = _parse_json(
+        _row_get(row, "evidence_payload_json"),
+        field="evidence_payload_json",
+        record_id=row["phase_id"],
     )
-    if not evidence_payload:
-        evidence_payload = {
-            "start_time": _row_get(row, "start_time") or legacy_payload.get("start_time"),
-            "end_time": _row_get(row, "end_time") or legacy_payload.get("end_time"),
-            "canonical_session_date": _row_get(row, "canonical_session_date")
-            or legacy_payload.get("canonical_session_date"),
-            "message_range": (
-                int(_row_get(row, "start_index", 0) or legacy_payload.get("start_index") or 0),
-                int(_row_get(row, "end_index", 0) or legacy_payload.get("end_index") or 0),
-            ),
-            "duration_ms": int(_row_get(row, "duration_ms", 0) or legacy_payload.get("duration_ms") or 0),
-            "tool_counts": _parse_json(_row_get(row, "tool_counts_json")) or legacy_payload.get("tool_counts") or {},
-            "word_count": int(_row_get(row, "word_count", 0) or legacy_payload.get("word_count") or 0),
-        }
-    inference_payload = (
-        _parse_json(
-            _row_get(row, "inference_payload_json"),
-            field="inference_payload_json",
-            record_id=row["phase_id"],
+    if raw_evidence_payload:
+        evidence_payload = SessionPhaseEvidencePayload.model_validate(raw_evidence_payload)
+    else:
+        evidence_payload = SessionPhaseEvidencePayload.model_validate(
+            {
+                "start_time": _row_get(row, "start_time") or legacy_payload.get("start_time"),
+                "end_time": _row_get(row, "end_time") or legacy_payload.get("end_time"),
+                "canonical_session_date": _row_get(row, "canonical_session_date")
+                or legacy_payload.get("canonical_session_date"),
+                "message_range": (
+                    int(_row_get(row, "start_index", 0) or legacy_payload.get("start_index") or 0),
+                    int(_row_get(row, "end_index", 0) or legacy_payload.get("end_index") or 0),
+                ),
+                "duration_ms": int(_row_get(row, "duration_ms", 0) or legacy_payload.get("duration_ms") or 0),
+                "tool_counts": _parse_json(_row_get(row, "tool_counts_json"))
+                or legacy_payload.get("tool_counts")
+                or {},
+                "word_count": int(_row_get(row, "word_count", 0) or legacy_payload.get("word_count") or 0),
+            }
         )
-        or {}
+    raw_inference_payload = _parse_json(
+        _row_get(row, "inference_payload_json"),
+        field="inference_payload_json",
+        record_id=row["phase_id"],
     )
-    if not inference_payload:
-        inference_payload = {
-            "confidence": float(_row_get(row, "confidence", 0.0) or legacy_payload.get("confidence") or 0.0),
-            "evidence": tuple(
-                _parse_json(_row_get(row, "evidence_reasons_json")) or legacy_payload.get("evidence") or []
-            ),
-        }
+    if raw_inference_payload:
+        inference_payload = SessionPhaseInferencePayload.model_validate(raw_inference_payload)
+    else:
+        inference_payload = SessionPhaseInferencePayload.model_validate(
+            {
+                "confidence": float(_row_get(row, "confidence", 0.0) or legacy_payload.get("confidence") or 0.0),
+                "evidence": tuple(
+                    _parse_json(_row_get(row, "evidence_reasons_json")) or legacy_payload.get("evidence") or []
+                ),
+            }
+        )
     return SessionPhaseRecord(
         phase_id=row["phase_id"],
         conversation_id=ConversationId(row["conversation_id"]),
@@ -181,7 +194,9 @@ def _row_to_work_thread_record(row: sqlite3.Row) -> WorkThreadRecord:
         total_cost_usd=float(_row_get(row, "total_cost_usd", 0.0) or 0.0),
         wall_duration_ms=int(_row_get(row, "wall_duration_ms", 0) or 0),
         work_event_breakdown=_parse_json(_row_get(row, "work_event_breakdown_json")) or {},
-        payload=_parse_json(row["payload_json"], field="payload_json", record_id=row["thread_id"]) or {},
+        payload=WorkThreadPayload.model_validate(
+            _parse_json(row["payload_json"], field="payload_json", record_id=row["thread_id"]) or {}
+        ),
         search_text=row["search_text"],
     )
 

--- a/polylogue/storage/backends/queries/session_product_profile_writes.py
+++ b/polylogue/storage/backends/queries/session_product_profile_writes.py
@@ -6,7 +6,11 @@ from collections.abc import Sequence
 
 import aiosqlite
 
-from polylogue.storage.store import SessionProfileRecord, _json_array_or_none, _json_or_none
+from polylogue.storage.session_product_storage import (
+    session_profile_insert_columns,
+    session_profile_insert_values,
+)
+from polylogue.storage.store import SessionProfileRecord
 
 _ASYNC_COLUMN_CACHE: dict[tuple[int, str], bool] = {}
 
@@ -21,122 +25,6 @@ async def _table_has_column(conn: aiosqlite.Connection, table: str, column: str)
     found = any(str(row["name"] if "name" in row else row[1]) == column for row in rows)
     _ASYNC_COLUMN_CACHE[key] = found
     return found
-
-
-def _session_profile_insert_columns(
-    *,
-    has_legacy_payload: bool,
-) -> list[str]:
-    columns = [
-        "conversation_id",
-        "materializer_version",
-        "materialized_at",
-        "source_updated_at",
-        "source_sort_key",
-        "provider_name",
-        "title",
-        "first_message_at",
-        "last_message_at",
-        "canonical_session_date",
-        "repo_paths_json",
-        "repo_names_json",
-        "tags_json",
-        "auto_tags_json",
-        "message_count",
-        "substantive_count",
-        "attachment_count",
-        "work_event_count",
-        "phase_count",
-        "word_count",
-        "tool_use_count",
-        "thinking_count",
-        "total_cost_usd",
-        "total_duration_ms",
-        "engaged_duration_ms",
-        "wall_duration_ms",
-        "cost_is_estimated",
-    ]
-    if has_legacy_payload:
-        columns.append("payload_json")
-    columns.extend(
-        [
-            "evidence_payload_json",
-            "inference_payload_json",
-            "enrichment_payload_json",
-            "search_text",
-            "evidence_search_text",
-            "inference_search_text",
-            "enrichment_search_text",
-            "enrichment_version",
-            "enrichment_family",
-            "inference_version",
-            "inference_family",
-        ]
-    )
-    return columns
-
-
-def _session_profile_insert_values(
-    record: SessionProfileRecord,
-    *,
-    has_legacy_payload: bool,
-) -> tuple[object, ...]:
-    payload_json = _json_or_none(
-        {
-            **record.evidence_payload.model_dump(mode="json"),
-            **record.inference_payload.model_dump(mode="json"),
-            "conversation_id": str(record.conversation_id),
-            "provider": record.provider_name,
-            "title": record.title,
-        }
-    )
-    values: list[object] = [
-        record.conversation_id,
-        record.materializer_version,
-        record.materialized_at,
-        record.source_updated_at,
-        record.source_sort_key,
-        record.provider_name,
-        record.title,
-        record.first_message_at,
-        record.last_message_at,
-        record.canonical_session_date,
-        _json_array_or_none(record.repo_paths),
-        _json_array_or_none(record.repo_names),
-        _json_array_or_none(record.tags),
-        _json_array_or_none(record.auto_tags),
-        record.message_count,
-        record.substantive_count,
-        record.attachment_count,
-        record.work_event_count,
-        record.phase_count,
-        record.word_count,
-        record.tool_use_count,
-        record.thinking_count,
-        record.total_cost_usd,
-        record.total_duration_ms,
-        record.engaged_duration_ms,
-        record.wall_duration_ms,
-        int(record.cost_is_estimated),
-    ]
-    if has_legacy_payload:
-        values.append(payload_json)
-    values.extend(
-        [
-            _json_or_none(record.evidence_payload),
-            _json_or_none(record.inference_payload),
-            _json_or_none(record.enrichment_payload),
-            record.search_text,
-            record.evidence_search_text,
-            record.inference_search_text,
-            record.enrichment_search_text,
-            record.enrichment_version,
-            record.enrichment_family,
-            record.inference_version,
-            record.inference_family,
-        ]
-    )
-    return tuple(values)
 
 
 __all__ = ["replace_session_profile", "replace_session_profiles_bulk"]
@@ -156,7 +44,7 @@ async def replace_session_profiles_bulk(
         )
     if records:
         has_legacy_payload = await _table_has_column(conn, "session_profiles", "payload_json")
-        columns = _session_profile_insert_columns(has_legacy_payload=has_legacy_payload)
+        columns = session_profile_insert_columns(has_legacy_payload=has_legacy_payload)
         placeholders = ", ".join("?" for _ in columns)
         await conn.executemany(
             f"""
@@ -165,7 +53,7 @@ async def replace_session_profiles_bulk(
             ) VALUES ({placeholders})
             """,
             [
-                _session_profile_insert_values(
+                session_profile_insert_values(
                     record,
                     has_legacy_payload=has_legacy_payload,
                 )

--- a/polylogue/storage/backends/queries/session_product_profile_writes.py
+++ b/polylogue/storage/backends/queries/session_product_profile_writes.py
@@ -83,8 +83,8 @@ def _session_profile_insert_values(
 ) -> tuple[object, ...]:
     payload_json = _json_or_none(
         {
-            **record.evidence_payload,
-            **record.inference_payload,
+            **record.evidence_payload.model_dump(mode="json"),
+            **record.inference_payload.model_dump(mode="json"),
             "conversation_id": str(record.conversation_id),
             "provider": record.provider_name,
             "title": record.title,

--- a/polylogue/storage/backends/queries/session_product_summary_queries.py
+++ b/polylogue/storage/backends/queries/session_product_summary_queries.py
@@ -133,7 +133,7 @@ async def replace_session_tag_rollup_rows(
                     record.conversation_count,
                     record.explicit_count,
                     record.auto_count,
-                    _json_or_none(dict[str, object](record.repo_breakdown)),
+                    _json_or_none(record.repo_breakdown),
                     record.search_text,
                 )
                 for record in records
@@ -191,7 +191,7 @@ async def replace_day_session_summaries(
                     record.total_wall_duration_ms,
                     record.total_messages,
                     record.total_words,
-                    _json_or_none(dict[str, object](record.work_event_breakdown)),
+                    _json_or_none(record.work_event_breakdown),
                     _json_array_or_none(record.repos_active),
                     _json_or_none(record.payload),
                     record.search_text,

--- a/polylogue/storage/backends/queries/session_product_summary_queries.py
+++ b/polylogue/storage/backends/queries/session_product_summary_queries.py
@@ -8,12 +8,11 @@ from polylogue.storage.backends.queries.mappers import (
     _row_to_day_session_summary_record,
     _row_to_session_tag_rollup_record,
 )
-from polylogue.storage.store import (
-    DaySessionSummaryRecord,
-    SessionTagRollupRecord,
-    _json_array_or_none,
-    _json_or_none,
+from polylogue.storage.session_product_storage import (
+    day_session_summary_insert_values,
+    session_tag_rollup_insert_values,
 )
+from polylogue.storage.store import DaySessionSummaryRecord, SessionTagRollupRecord
 
 __all__ = [
     "list_day_session_summaries",
@@ -121,23 +120,7 @@ async def replace_session_tag_rollup_rows(
                 search_text
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
-            [
-                (
-                    record.tag,
-                    record.bucket_day,
-                    record.provider_name,
-                    record.materializer_version,
-                    record.materialized_at,
-                    record.source_updated_at,
-                    record.source_sort_key,
-                    record.conversation_count,
-                    record.explicit_count,
-                    record.auto_count,
-                    _json_or_none(record.repo_breakdown),
-                    record.search_text,
-                )
-                for record in records
-            ],
+            [session_tag_rollup_insert_values(record) for record in records],
         )
     if transaction_depth == 0:
         await conn.commit()
@@ -177,27 +160,7 @@ async def replace_day_session_summaries(
                 search_text
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
-            [
-                (
-                    record.day,
-                    record.provider_name,
-                    record.materializer_version,
-                    record.materialized_at,
-                    record.source_updated_at,
-                    record.source_sort_key,
-                    record.conversation_count,
-                    record.total_cost_usd,
-                    record.total_duration_ms,
-                    record.total_wall_duration_ms,
-                    record.total_messages,
-                    record.total_words,
-                    _json_or_none(record.work_event_breakdown),
-                    _json_array_or_none(record.repos_active),
-                    _json_or_none(record.payload),
-                    record.search_text,
-                )
-                for record in records
-            ],
+            [day_session_summary_insert_values(record) for record in records],
         )
     if transaction_depth == 0:
         await conn.commit()

--- a/polylogue/storage/backends/queries/session_product_thread_queries.py
+++ b/polylogue/storage/backends/queries/session_product_thread_queries.py
@@ -112,7 +112,7 @@ async def replace_work_thread(
                 record.total_messages,
                 record.total_cost_usd,
                 record.wall_duration_ms,
-                _json_or_none(dict[str, object](record.work_event_breakdown or {})),
+                _json_or_none(record.work_event_breakdown or {}),
                 _json_or_none(record.payload),
                 record.search_text,
             ),

--- a/polylogue/storage/backends/queries/session_product_thread_queries.py
+++ b/polylogue/storage/backends/queries/session_product_thread_queries.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import aiosqlite
 
 from polylogue.storage.backends.queries.mappers import _row_to_work_thread_record
-from polylogue.storage.store import WorkThreadRecord, _json_array_or_none, _json_or_none
+from polylogue.storage.session_product_storage import work_thread_insert_values
+from polylogue.storage.store import WorkThreadRecord
 
 __all__ = [
     "get_work_thread",
@@ -97,25 +98,7 @@ async def replace_work_thread(
                 search_text
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
-            (
-                record.thread_id,
-                record.root_id,
-                record.materializer_version,
-                record.materialized_at,
-                record.start_time,
-                record.end_time,
-                record.dominant_repo,
-                _json_array_or_none(record.session_ids),
-                record.session_count,
-                record.depth,
-                record.branch_count,
-                record.total_messages,
-                record.total_cost_usd,
-                record.wall_duration_ms,
-                _json_or_none(record.work_event_breakdown or {}),
-                _json_or_none(record.payload),
-                record.search_text,
-            ),
+            work_thread_insert_values(record),
         )
     if transaction_depth == 0:
         await conn.commit()

--- a/polylogue/storage/backends/queries/session_product_timeline_writes.py
+++ b/polylogue/storage/backends/queries/session_product_timeline_writes.py
@@ -6,12 +6,13 @@ from collections.abc import Sequence
 
 import aiosqlite
 
-from polylogue.storage.store import (
-    SessionPhaseRecord,
-    SessionWorkEventRecord,
-    _json_array_or_none,
-    _json_or_none,
+from polylogue.storage.session_product_storage import (
+    session_phase_insert_columns,
+    session_phase_insert_values,
+    session_work_event_insert_columns,
+    session_work_event_insert_values,
 )
+from polylogue.storage.store import SessionPhaseRecord, SessionWorkEventRecord
 
 __all__ = [
     "replace_session_phases",
@@ -63,38 +64,7 @@ async def replace_session_work_events_bulk(
         )
     if records:
         has_legacy_payload = await _table_has_column(conn, "session_work_events", "payload_json")
-        columns = [
-            "event_id",
-            "conversation_id",
-            "materializer_version",
-            "materialized_at",
-            "source_updated_at",
-            "source_sort_key",
-            "provider_name",
-            "event_index",
-            "kind",
-            "confidence",
-            "start_index",
-            "end_index",
-            "start_time",
-            "end_time",
-            "duration_ms",
-            "canonical_session_date",
-            "summary",
-            "file_paths_json",
-            "tools_used_json",
-        ]
-        if has_legacy_payload:
-            columns.append("payload_json")
-        columns.extend(
-            [
-                "evidence_payload_json",
-                "inference_payload_json",
-                "search_text",
-                "inference_version",
-                "inference_family",
-            ]
-        )
+        columns = session_work_event_insert_columns(has_legacy_payload=has_legacy_payload)
         placeholders = ", ".join("?" for _ in columns)
         await conn.executemany(
             f"""
@@ -103,47 +73,9 @@ async def replace_session_work_events_bulk(
             ) VALUES ({placeholders})
             """,
             [
-                tuple(
-                    [
-                        record.event_id,
-                        record.conversation_id,
-                        record.materializer_version,
-                        record.materialized_at,
-                        record.source_updated_at,
-                        record.source_sort_key,
-                        record.provider_name,
-                        record.event_index,
-                        record.kind,
-                        record.confidence,
-                        record.start_index,
-                        record.end_index,
-                        record.start_time,
-                        record.end_time,
-                        record.duration_ms,
-                        record.canonical_session_date,
-                        record.summary,
-                        _json_array_or_none(record.file_paths),
-                        _json_array_or_none(record.tools_used),
-                    ]
-                    + (
-                        [
-                            _json_or_none(
-                                {
-                                    **record.evidence_payload.model_dump(mode="json"),
-                                    **record.inference_payload.model_dump(mode="json"),
-                                }
-                            )
-                        ]
-                        if has_legacy_payload
-                        else []
-                    )
-                    + [
-                        _json_or_none(record.evidence_payload),
-                        _json_or_none(record.inference_payload),
-                        record.search_text,
-                        record.inference_version,
-                        record.inference_family,
-                    ]
+                session_work_event_insert_values(
+                    record,
+                    has_legacy_payload=has_legacy_payload,
                 )
                 for record in records
             ],
@@ -180,38 +112,7 @@ async def replace_session_phases_bulk(
         )
     if records:
         has_legacy_payload = await _table_has_column(conn, "session_phases", "payload_json")
-        columns = [
-            "phase_id",
-            "conversation_id",
-            "materializer_version",
-            "materialized_at",
-            "source_updated_at",
-            "source_sort_key",
-            "provider_name",
-            "phase_index",
-            "kind",
-            "start_index",
-            "end_index",
-            "start_time",
-            "end_time",
-            "duration_ms",
-            "canonical_session_date",
-            "confidence",
-            "evidence_reasons_json",
-            "tool_counts_json",
-            "word_count",
-        ]
-        if has_legacy_payload:
-            columns.append("payload_json")
-        columns.extend(
-            [
-                "evidence_payload_json",
-                "inference_payload_json",
-                "search_text",
-                "inference_version",
-                "inference_family",
-            ]
-        )
+        columns = session_phase_insert_columns(has_legacy_payload=has_legacy_payload)
         placeholders = ", ".join("?" for _ in columns)
         await conn.executemany(
             f"""
@@ -220,47 +121,9 @@ async def replace_session_phases_bulk(
             ) VALUES ({placeholders})
             """,
             [
-                tuple(
-                    [
-                        record.phase_id,
-                        record.conversation_id,
-                        record.materializer_version,
-                        record.materialized_at,
-                        record.source_updated_at,
-                        record.source_sort_key,
-                        record.provider_name,
-                        record.phase_index,
-                        record.kind,
-                        record.start_index,
-                        record.end_index,
-                        record.start_time,
-                        record.end_time,
-                        record.duration_ms,
-                        record.canonical_session_date,
-                        record.confidence,
-                        _json_array_or_none(record.evidence_reasons) or "[]",
-                        _json_or_none(record.tool_counts),
-                        record.word_count,
-                    ]
-                    + (
-                        [
-                            _json_or_none(
-                                {
-                                    **record.evidence_payload.model_dump(mode="json"),
-                                    **record.inference_payload.model_dump(mode="json"),
-                                }
-                            )
-                        ]
-                        if has_legacy_payload
-                        else []
-                    )
-                    + [
-                        _json_or_none(record.evidence_payload),
-                        _json_or_none(record.inference_payload),
-                        record.search_text,
-                        record.inference_version,
-                        record.inference_family,
-                    ]
+                session_phase_insert_values(
+                    record,
+                    has_legacy_payload=has_legacy_payload,
                 )
                 for record in records
             ],

--- a/polylogue/storage/backends/queries/session_product_timeline_writes.py
+++ b/polylogue/storage/backends/queries/session_product_timeline_writes.py
@@ -129,8 +129,8 @@ async def replace_session_work_events_bulk(
                         [
                             _json_or_none(
                                 {
-                                    **record.evidence_payload,
-                                    **record.inference_payload,
+                                    **record.evidence_payload.model_dump(mode="json"),
+                                    **record.inference_payload.model_dump(mode="json"),
                                 }
                             )
                         ]
@@ -246,8 +246,8 @@ async def replace_session_phases_bulk(
                         [
                             _json_or_none(
                                 {
-                                    **record.evidence_payload,
-                                    **record.inference_payload,
+                                    **record.evidence_payload.model_dump(mode="json"),
+                                    **record.inference_payload.model_dump(mode="json"),
                                 }
                             )
                         ]

--- a/polylogue/storage/session_product_aggregates.py
+++ b/polylogue/storage/session_product_aggregates.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import sqlite3
-from collections.abc import Coroutine, Iterable, Sequence
-from typing import Any
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
 
 import aiosqlite
 
@@ -12,6 +12,12 @@ from polylogue.archive_product_rollups import build_session_tag_rollup_records
 from polylogue.archive_product_summaries import build_day_session_summary_records
 from polylogue.archive_products import date_from_iso
 from polylogue.storage.backends.queries.mappers import _row_to_session_profile_record
+from polylogue.storage.backends.queries.session_product_summary_queries import (
+    replace_day_session_summaries as replace_day_session_summaries_async,
+)
+from polylogue.storage.backends.queries.session_product_summary_queries import (
+    replace_session_tag_rollup_rows as replace_session_tag_rollup_rows_async,
+)
 from polylogue.storage.session_product_profiles import hydrate_session_profile
 from polylogue.storage.session_product_storage import (
     replace_day_session_summaries_sync,
@@ -53,46 +59,12 @@ _DISTINCT_PROVIDER_DAY_GROUPS_SQL = f"""
 """
 
 
-def replace_day_session_summaries_async(
-    conn: aiosqlite.Connection,
-    *,
-    provider_name: str,
-    day: str,
-    records: list[DaySessionSummaryRecord],
-    transaction_depth: int,
-) -> Coroutine[Any, Any, None]:
-    from polylogue.storage.backends.queries.session_product_summary_queries import (
-        replace_day_session_summaries as replace_day_session_summaries_async_query,
-    )
-
-    return replace_day_session_summaries_async_query(
-        conn,
-        provider_name=provider_name,
-        day=day,
-        records=records,
-        transaction_depth=transaction_depth,
-    )
-
-
-def replace_session_tag_rollup_rows_async(
-    conn: aiosqlite.Connection,
-    *,
-    provider_name: str,
-    bucket_day: str,
-    records: list[SessionTagRollupRecord],
-    transaction_depth: int,
-) -> Coroutine[Any, Any, None]:
-    from polylogue.storage.backends.queries.session_product_summary_queries import (
-        replace_session_tag_rollup_rows as replace_session_tag_rollup_rows_async_query,
-    )
-
-    return replace_session_tag_rollup_rows_async_query(
-        conn,
-        provider_name=provider_name,
-        bucket_day=bucket_day,
-        records=records,
-        transaction_depth=transaction_depth,
-    )
+@dataclass(slots=True, frozen=True)
+class ProviderDayAggregateWrite:
+    provider_name: str
+    bucket_day: str
+    day_rows: list[DaySessionSummaryRecord]
+    tag_rows: list[SessionTagRollupRecord]
 
 
 def load_sync_provider_day_profile_records(
@@ -179,6 +151,14 @@ def _group_profile_records_by_provider_day(
     return grouped
 
 
+def _provider_day_group_query(
+    groups: Sequence[tuple[str, str]],
+) -> tuple[str, tuple[str, ...]]:
+    values = ", ".join("(?, ?)" for _ in groups)
+    params = tuple(value for group in groups for value in group)
+    return values, params
+
+
 def _aggregate_rows_for_profile_records(
     profile_records: Sequence[SessionProfileRecord],
 ) -> tuple[list[DaySessionSummaryRecord], list[SessionTagRollupRecord]]:
@@ -191,6 +171,26 @@ def _aggregate_rows_for_profile_records(
     )
 
 
+def _aggregate_writes_for_groups(
+    profile_records_by_group: dict[tuple[str, str], list[SessionProfileRecord]],
+    groups: Sequence[tuple[str, str]],
+) -> list[ProviderDayAggregateWrite]:
+    writes: list[ProviderDayAggregateWrite] = []
+    for provider_name, bucket_day in groups:
+        day_rows, tag_rows = _aggregate_rows_for_profile_records(
+            profile_records_by_group.get((provider_name, bucket_day), []),
+        )
+        writes.append(
+            ProviderDayAggregateWrite(
+                provider_name=provider_name,
+                bucket_day=bucket_day,
+                day_rows=day_rows,
+                tag_rows=tag_rows,
+            )
+        )
+    return writes
+
+
 def load_sync_provider_day_profile_records_by_groups(
     conn: sqlite3.Connection,
     groups: Sequence[tuple[str, str]],
@@ -200,8 +200,7 @@ def load_sync_provider_day_profile_records_by_groups(
         return {}
     grouped: dict[tuple[str, str], list[SessionProfileRecord]] = _empty_provider_day_profile_groups(normalized_groups)
     for group_chunk in _chunk_provider_day_groups(normalized_groups):
-        values = ", ".join("(?, ?)" for _ in group_chunk)
-        params = tuple(value for group in group_chunk for value in group)
+        values, params = _provider_day_group_query(group_chunk)
         rows = conn.execute(
             _PROVIDER_DAY_PROFILE_RECORDS_SQL_TEMPLATE.format(values=values),
             params,
@@ -220,8 +219,7 @@ async def load_async_provider_day_profile_records_by_groups(
         return {}
     grouped: dict[tuple[str, str], list[SessionProfileRecord]] = _empty_provider_day_profile_groups(normalized_groups)
     for group_chunk in _chunk_provider_day_groups(normalized_groups):
-        values = ", ".join("(?, ?)" for _ in group_chunk)
-        params = tuple(value for group in group_chunk for value in group)
+        values, params = _provider_day_group_query(group_chunk)
         rows = await (
             await conn.execute(
                 _PROVIDER_DAY_PROFILE_RECORDS_SQL_TEMPLATE.format(values=values),
@@ -240,21 +238,18 @@ def refresh_sync_provider_day_aggregates(
     normalized_groups = _normalize_provider_day_groups(sorted(groups))
     for group_chunk in _chunk_provider_day_groups(normalized_groups):
         profile_records_by_group = load_sync_provider_day_profile_records_by_groups(conn, group_chunk)
-        for provider_name, bucket_day in group_chunk:
-            day_rows, tag_rows = _aggregate_rows_for_profile_records(
-                profile_records_by_group.get((provider_name, bucket_day), []),
-            )
+        for write in _aggregate_writes_for_groups(profile_records_by_group, group_chunk):
             replace_day_session_summaries_sync(
                 conn,
-                provider_name=provider_name,
-                day=bucket_day,
-                records=day_rows,
+                provider_name=write.provider_name,
+                day=write.bucket_day,
+                records=write.day_rows,
             )
             replace_session_tag_rollup_rows_sync(
                 conn,
-                provider_name=provider_name,
-                bucket_day=bucket_day,
-                records=tag_rows,
+                provider_name=write.provider_name,
+                bucket_day=write.bucket_day,
+                records=write.tag_rows,
             )
 
 
@@ -270,22 +265,19 @@ async def refresh_async_provider_day_aggregates(
             conn,
             group_chunk,
         )
-        for provider_name, bucket_day in group_chunk:
-            day_rows, tag_rows = _aggregate_rows_for_profile_records(
-                profile_records_by_group.get((provider_name, bucket_day), []),
-            )
+        for write in _aggregate_writes_for_groups(profile_records_by_group, group_chunk):
             await replace_day_session_summaries_async(
                 conn,
-                provider_name=provider_name,
-                day=bucket_day,
-                records=day_rows,
+                provider_name=write.provider_name,
+                day=write.bucket_day,
+                records=write.day_rows,
                 transaction_depth=transaction_depth,
             )
             await replace_session_tag_rollup_rows_async(
                 conn,
-                provider_name=provider_name,
-                bucket_day=bucket_day,
-                records=tag_rows,
+                provider_name=write.provider_name,
+                bucket_day=write.bucket_day,
+                records=write.tag_rows,
                 transaction_depth=transaction_depth,
             )
 

--- a/polylogue/storage/session_product_profiles.py
+++ b/polylogue/storage/session_product_profiles.py
@@ -5,6 +5,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import UTC, datetime
 
+from polylogue.archive_product_models import (
+    SessionEnrichmentPayload,
+    SessionEvidencePayload,
+    SessionInferencePayload,
+)
 from polylogue.lib.phase_extraction import SessionPhase
 from polylogue.lib.session_profile import SessionAnalysis, SessionProfile
 from polylogue.lib.work_event_extraction import WorkEvent
@@ -65,21 +70,17 @@ def profile_search_text(profile: SessionProfile) -> str:
     )
 
 
-def _payload_strings(value: object) -> tuple[str, ...]:
-    if not isinstance(value, list):
-        return ()
-    return tuple(str(item) for item in value)
-
-
-def profile_enrichment_search_text(profile: SessionProfile, enrichment_payload: dict[str, object]) -> str:
-    blockers = _payload_strings(enrichment_payload.get("blockers"))
-    support_signals_list = _payload_strings(enrichment_payload.get("support_signals"))
+def profile_enrichment_search_text(
+    profile: SessionProfile,
+    enrichment_payload: SessionEnrichmentPayload,
+) -> str:
+    blockers = enrichment_payload.blockers
+    support_signals_list = enrichment_payload.support_signals
     parts = [
         profile.provider,
         profile.title or "",
-        str(enrichment_payload.get("refined_work_kind") or ""),
-        str(enrichment_payload.get("intent_summary") or ""),
-        str(enrichment_payload.get("outcome_summary") or ""),
+        enrichment_payload.intent_summary or "",
+        enrichment_payload.outcome_summary or "",
         *profile.repo_names,
         *profile.repo_paths,
         *blockers,
@@ -97,7 +98,7 @@ def profile_enrichment_search_text(profile: SessionProfile, enrichment_payload: 
 def session_enrichment_payload(
     profile: SessionProfile,
     analysis: SessionAnalysis | None,
-) -> dict[str, object]:
+) -> SessionEnrichmentPayload:
     text_bands = _collect_enrichment_text_bands(analysis)
     user_turns = text_bands.user_turns
     assistant_turns = text_bands.assistant_turns
@@ -122,65 +123,63 @@ def session_enrichment_payload(
     )
     intent_summary = user_turns[0] if user_turns else (profile.title or None)
     outcome_summary = assistant_turns[-1] if assistant_turns else (user_turns[-1] if user_turns else None)
-    return {
-        "intent_summary": intent_summary,
-        "outcome_summary": outcome_summary,
-        "blockers": list(blockers_val),
-        "confidence": round(confidence, 3),
-        "support_level": support_level(confidence, support_signals=support_signals_val),
-        "support_signals": list(support_signals_val),
-        "input_band_summary": input_band_summary,
-    }
+    return SessionEnrichmentPayload(
+        intent_summary=intent_summary,
+        outcome_summary=outcome_summary,
+        blockers=blockers_val,
+        confidence=round(confidence, 3),
+        support_level=support_level(confidence, support_signals=support_signals_val),
+        support_signals=support_signals_val,
+        input_band_summary=input_band_summary,
+    )
 
 
-def profile_evidence_payload(profile: SessionProfile) -> dict[str, object]:
-    return {
-        "created_at": profile.created_at.isoformat() if profile.created_at else None,
-        "updated_at": profile.updated_at.isoformat() if profile.updated_at else None,
-        "first_message_at": profile.first_message_at.isoformat() if profile.first_message_at else None,
-        "last_message_at": profile.last_message_at.isoformat() if profile.last_message_at else None,
-        "canonical_session_date": (
-            profile.canonical_session_date.isoformat() if profile.canonical_session_date else None
-        ),
-        "message_count": profile.message_count,
-        "substantive_count": profile.substantive_count,
-        "attachment_count": profile.attachment_count,
-        "tool_use_count": profile.tool_use_count,
-        "thinking_count": profile.thinking_count,
-        "word_count": profile.word_count,
-        "total_cost_usd": profile.total_cost_usd,
-        "total_duration_ms": profile.total_duration_ms,
-        "wall_duration_ms": profile.wall_duration_ms,
-        "cost_is_estimated": profile.cost_is_estimated,
-        "compaction_count": profile.compaction_count,
-        "has_compaction": profile.compaction_count > 0,
-        "tool_categories": dict(profile.tool_categories),
-        "repo_paths": list(profile.repo_paths),
-        "cwd_paths": list(profile.cwd_paths),
-        "branch_names": list(profile.branch_names),
-        "file_paths_touched": list(profile.file_paths_touched),
-        "languages_detected": list(profile.languages_detected),
-        "tags": list(profile.tags),
-        "is_continuation": profile.is_continuation,
-        "parent_id": profile.parent_id,
-    }
+def profile_evidence_payload(profile: SessionProfile) -> SessionEvidencePayload:
+    return SessionEvidencePayload(
+        created_at=profile.created_at.isoformat() if profile.created_at else None,
+        updated_at=profile.updated_at.isoformat() if profile.updated_at else None,
+        first_message_at=profile.first_message_at.isoformat() if profile.first_message_at else None,
+        last_message_at=profile.last_message_at.isoformat() if profile.last_message_at else None,
+        canonical_session_date=profile.canonical_session_date.isoformat() if profile.canonical_session_date else None,
+        message_count=profile.message_count,
+        substantive_count=profile.substantive_count,
+        attachment_count=profile.attachment_count,
+        tool_use_count=profile.tool_use_count,
+        thinking_count=profile.thinking_count,
+        word_count=profile.word_count,
+        total_cost_usd=profile.total_cost_usd,
+        total_duration_ms=profile.total_duration_ms,
+        wall_duration_ms=profile.wall_duration_ms,
+        cost_is_estimated=profile.cost_is_estimated,
+        compaction_count=profile.compaction_count,
+        has_compaction=profile.compaction_count > 0,
+        tool_categories=dict(profile.tool_categories),
+        repo_paths=profile.repo_paths,
+        cwd_paths=profile.cwd_paths,
+        branch_names=profile.branch_names,
+        file_paths_touched=profile.file_paths_touched,
+        languages_detected=profile.languages_detected,
+        tags=profile.tags,
+        is_continuation=profile.is_continuation,
+        parent_id=profile.parent_id,
+    )
 
 
-def profile_inference_payload(profile: SessionProfile) -> dict[str, object]:
+def profile_inference_payload(profile: SessionProfile) -> SessionInferencePayload:
     signals = profile_support_signals(profile)
-    return {
-        "repo_names": list(profile.repo_names),
-        "work_event_count": len(profile.work_events),
-        "phase_count": len(profile.phases),
-        "engaged_duration_ms": profile.engaged_duration_ms,
-        "engaged_minutes": round(profile.engaged_duration_ms / 60_000.0, 4),
-        "support_level": profile_support_level(profile),
-        "support_signals": list(signals),
-        "engaged_duration_source": engaged_duration_source(profile),
-        "repo_inference_strength": repo_inference_strength(profile),
-        "auto_tags": list(profile.auto_tags),
-        "work_events": [event.to_dict() for event in profile.work_events],
-        "phases": [
+    return SessionInferencePayload(
+        repo_names=profile.repo_names,
+        work_event_count=len(profile.work_events),
+        phase_count=len(profile.phases),
+        engaged_duration_ms=profile.engaged_duration_ms,
+        engaged_minutes=round(profile.engaged_duration_ms / 60_000.0, 4),
+        support_level=profile_support_level(profile),
+        support_signals=signals,
+        engaged_duration_source=engaged_duration_source(profile),
+        repo_inference_strength=repo_inference_strength(profile),
+        auto_tags=profile.auto_tags,
+        work_events=tuple(event.to_dict() for event in profile.work_events),
+        phases=tuple(
             {
                 "start_time": phase.start_time.isoformat() if phase.start_time else None,
                 "end_time": phase.end_time.isoformat() if phase.end_time else None,
@@ -195,8 +194,8 @@ def profile_inference_payload(profile: SessionProfile) -> dict[str, object]:
                 "evidence": list(phase.evidence),
             }
             for phase in profile.phases
-        ],
-    }
+        ),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -261,8 +260,8 @@ def build_session_profile_record(
 
 def hydrate_session_profile(record: SessionProfileRecord) -> SessionProfile:
     merged_payload = {
-        **record.evidence_payload,
-        **record.inference_payload,
+        **record.evidence_payload.model_dump(mode="json"),
+        **record.inference_payload.model_dump(mode="json"),
         "conversation_id": str(record.conversation_id),
         "provider": record.provider_name,
         "title": record.title,

--- a/polylogue/storage/session_product_rebuild.py
+++ b/polylogue/storage/session_product_rebuild.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import sqlite3
 from collections import defaultdict
 from collections.abc import AsyncIterator, Iterable, Iterator, Sequence
+from dataclasses import dataclass
 
 import aiosqlite
 
@@ -93,6 +94,33 @@ SELECT
 FROM conversations
 WHERE conversation_id IN ({placeholders})
 """
+
+
+@dataclass(slots=True)
+class SessionProductArchiveBatch:
+    conversations: list[ConversationRecord]
+    messages: list[MessageRecord]
+    attachments_by_conversation: dict[str, list[AttachmentRecord]]
+    blocks: list[ContentBlockRecord]
+
+
+@dataclass(slots=True)
+class SessionProductRecordBundle:
+    profile_record: SessionProfileRecord
+    work_event_records: list[SessionWorkEventRecord]
+    phase_records: list[SessionPhaseRecord]
+
+    @property
+    def conversation_id(self) -> ConversationId:
+        return self.profile_record.conversation_id
+
+    @property
+    def work_event_count(self) -> int:
+        return len(self.work_event_records)
+
+    @property
+    def phase_count(self) -> int:
+        return len(self.phase_records)
 
 
 def chunked(items: Sequence[str], *, size: int) -> Iterable[Sequence[str]]:
@@ -217,7 +245,7 @@ def sync_attachment_batch(
 def load_sync_batch(
     conn: sqlite3.Connection,
     conversation_ids: Sequence[str],
-) -> tuple[list[ConversationRecord], list[MessageRecord], dict[str, list[AttachmentRecord]], list[ContentBlockRecord]]:
+) -> SessionProductArchiveBatch:
     placeholders = ", ".join("?" for _ in conversation_ids)
     conversations = [
         _row_to_session_product_conversation(row)
@@ -250,13 +278,18 @@ def load_sync_batch(
             tuple(conversation_ids),
         ).fetchall()
     ]
-    return conversations, messages, sync_attachment_batch(conn, conversation_ids), blocks
+    return SessionProductArchiveBatch(
+        conversations=conversations,
+        messages=messages,
+        attachments_by_conversation=sync_attachment_batch(conn, conversation_ids),
+        blocks=blocks,
+    )
 
 
 async def load_async_batch(
     conn: aiosqlite.Connection,
     conversation_ids: Sequence[str],
-) -> tuple[list[ConversationRecord], list[MessageRecord], dict[str, list[AttachmentRecord]], list[ContentBlockRecord]]:
+) -> SessionProductArchiveBatch:
     placeholders = ", ".join("?" for _ in conversation_ids)
     conversations = [
         _row_to_session_product_conversation(row)
@@ -296,24 +329,26 @@ async def load_async_batch(
         ).fetchall()
     ]
     attachments = await get_attachments_batch(conn, list(conversation_ids))
-    return conversations, messages, attachments, blocks
+    return SessionProductArchiveBatch(
+        conversations=conversations,
+        messages=messages,
+        attachments_by_conversation=attachments,
+        blocks=blocks,
+    )
 
 
 def hydrate_conversations(
-    conversations: list[ConversationRecord],
-    messages: list[MessageRecord],
-    attachments_by_conversation: dict[str, list[AttachmentRecord]],
-    blocks: list[ContentBlockRecord],
+    batch: SessionProductArchiveBatch,
 ) -> list[Conversation]:
     messages_by_conversation: dict[str, list[MessageRecord]] = defaultdict(list)
     blocks_by_conversation: dict[str, list[ContentBlockRecord]] = defaultdict(list)
-    for message in messages:
+    for message in batch.messages:
         messages_by_conversation[str(message.conversation_id)].append(message)
-    for block in blocks:
+    for block in batch.blocks:
         blocks_by_conversation[str(block.conversation_id)].append(block)
 
     hydrated: list[Conversation] = []
-    for conversation in conversations:
+    for conversation in batch.conversations:
         conversation_id = str(conversation.conversation_id)
         attached_messages = attach_blocks_to_messages(
             messages_by_conversation.get(conversation_id, []),
@@ -323,7 +358,7 @@ def hydrate_conversations(
             conversation_from_records(
                 conversation,
                 attached_messages,
-                attachments_by_conversation.get(conversation_id, []),
+                batch.attachments_by_conversation.get(conversation_id, []),
             )
         )
     return hydrated
@@ -331,15 +366,75 @@ def hydrate_conversations(
 
 def build_session_product_records(
     conversation: Conversation,
-) -> tuple[SessionProfileRecord, list[SessionWorkEventRecord], list[SessionPhaseRecord]]:
+) -> SessionProductRecordBundle:
     analysis = build_session_analysis(conversation)
     profile = build_session_profile(conversation, analysis=analysis)
     materialized_at = now_iso()
-    return (
-        build_session_profile_record(profile, analysis=analysis, materialized_at=materialized_at),
-        build_session_work_event_records(profile, materialized_at=materialized_at),
-        build_session_phase_records(profile, materialized_at=materialized_at),
+    return SessionProductRecordBundle(
+        profile_record=build_session_profile_record(
+            profile,
+            analysis=analysis,
+            materialized_at=materialized_at,
+        ),
+        work_event_records=build_session_work_event_records(profile, materialized_at=materialized_at),
+        phase_records=build_session_phase_records(profile, materialized_at=materialized_at),
     )
+
+
+def build_session_product_record_bundles(
+    conversations: Iterable[Conversation],
+) -> list[SessionProductRecordBundle]:
+    return [build_session_product_records(conversation) for conversation in conversations]
+
+
+def _count_record_bundles(
+    bundles: Sequence[SessionProductRecordBundle],
+) -> tuple[int, int, int]:
+    return (
+        len(bundles),
+        sum(bundle.work_event_count for bundle in bundles),
+        sum(bundle.phase_count for bundle in bundles),
+    )
+
+
+def _materialize_progress_desc(
+    *,
+    profile_count: int,
+    progress_total: int | None,
+) -> str:
+    if progress_total is not None:
+        return f"Materializing: {profile_count}/{progress_total}"
+    return f"Materializing: {profile_count}"
+
+
+def _empty_rebuild_counts() -> dict[str, int]:
+    return {
+        "profiles": 0,
+        "work_events": 0,
+        "phases": 0,
+        "threads": 0,
+        "tag_rollups": 0,
+        "day_summaries": 0,
+    }
+
+
+def _finalize_rebuild_counts(
+    *,
+    profiles: int,
+    work_events: int,
+    phases: int,
+    threads: int,
+    tag_rollups: int,
+    day_summaries: int,
+) -> dict[str, int]:
+    return {
+        "profiles": profiles,
+        "work_events": work_events,
+        "phases": phases,
+        "threads": threads,
+        "tag_rollups": tag_rollups,
+        "day_summaries": day_summaries,
+    }
 
 
 def rebuild_session_products_sync(
@@ -366,7 +461,7 @@ def rebuild_session_products_sync(
         conn.execute("DELETE FROM session_tag_rollups")
         conn.execute("DELETE FROM day_session_summaries")
         conn.commit()
-        return {"profiles": 0, "work_events": 0, "phases": 0, "threads": 0, "tag_rollups": 0, "day_summaries": 0}
+        return _empty_rebuild_counts()
 
     profile_count = 0
     work_event_count = 0
@@ -374,31 +469,39 @@ def rebuild_session_products_sync(
     saw_conversation_ids = False
     for chunk in conversation_chunks:
         saw_conversation_ids = True
-        conversations, messages, attachments, blocks = load_sync_batch(conn, chunk)
-        chunk_profiles = 0
-        for conversation in hydrate_conversations(conversations, messages, attachments, blocks):
-            profile_record, event_records, phase_records = build_session_product_records(conversation)
-            replace_session_profile_sync(conn, profile_record)
-            replace_session_work_events_sync(conn, profile_record.conversation_id, event_records)
-            replace_session_phases_sync(conn, profile_record.conversation_id, phase_records)
-            profile_count += 1
-            chunk_profiles += 1
-            work_event_count += len(event_records)
-            phase_count += len(phase_records)
-        if progress_callback is not None and chunk_profiles:
-            desc = (
-                f"Materializing: {profile_count}/{progress_total}"
-                if progress_total is not None
-                else f"Materializing: {profile_count}"
+        batch = load_sync_batch(conn, chunk)
+        record_bundles = build_session_product_record_bundles(hydrate_conversations(batch))
+        chunk_profiles, chunk_work_events, chunk_phases = _count_record_bundles(record_bundles)
+        for bundle in record_bundles:
+            replace_session_profile_sync(conn, bundle.profile_record)
+            replace_session_work_events_sync(
+                conn,
+                bundle.conversation_id,
+                bundle.work_event_records,
             )
-            progress_callback(chunk_profiles, desc=desc)
+            replace_session_phases_sync(
+                conn,
+                bundle.conversation_id,
+                bundle.phase_records,
+            )
+        profile_count += chunk_profiles
+        work_event_count += chunk_work_events
+        phase_count += chunk_phases
+        if progress_callback is not None and chunk_profiles:
+            progress_callback(
+                chunk_profiles,
+                desc=_materialize_progress_desc(
+                    profile_count=profile_count,
+                    progress_total=progress_total,
+                ),
+            )
     if not saw_conversation_ids:
         conn.execute("DELETE FROM work_threads")
         conn.execute("DELETE FROM session_phases")
         conn.execute("DELETE FROM session_tag_rollups")
         conn.execute("DELETE FROM day_session_summaries")
         conn.commit()
-        return {"profiles": 0, "work_events": 0, "phases": 0, "threads": 0, "tag_rollups": 0, "day_summaries": 0}
+        return _empty_rebuild_counts()
 
     conn.execute("DELETE FROM work_threads")
     thread_count = 0
@@ -417,14 +520,14 @@ def rebuild_session_products_sync(
     tag_rollup_count = conn.execute("SELECT COUNT(*) FROM session_tag_rollups").fetchone()[0]
     day_summary_count = conn.execute("SELECT COUNT(*) FROM day_session_summaries").fetchone()[0]
     conn.commit()
-    return {
-        "profiles": profile_count,
-        "work_events": work_event_count,
-        "phases": phase_count,
-        "threads": thread_count,
-        "tag_rollups": int(tag_rollup_count),
-        "day_summaries": int(day_summary_count),
-    }
+    return _finalize_rebuild_counts(
+        profiles=profile_count,
+        work_events=work_event_count,
+        phases=phase_count,
+        threads=thread_count,
+        tag_rollups=int(tag_rollup_count),
+        day_summaries=int(day_summary_count),
+    )
 
 
 async def rebuild_session_products_async(
@@ -456,55 +559,71 @@ async def rebuild_session_products_async(
         await conn.execute("DELETE FROM session_phases")
         await conn.execute("DELETE FROM session_tag_rollups")
         await conn.execute("DELETE FROM day_session_summaries")
-        return {"profiles": 0, "work_events": 0, "phases": 0, "threads": 0, "tag_rollups": 0, "day_summaries": 0}
+        return _empty_rebuild_counts()
 
     profile_count = 0
     work_event_count = 0
     phase_count = 0
     if conversation_ids is None:
         async for chunk in iter_conversation_id_pages_async(conn, page_size=page_size):
-            conversations, messages, attachments, blocks = await load_async_batch(conn, chunk)
-            chunk_profiles = 0
-            for conversation in hydrate_conversations(conversations, messages, attachments, blocks):
-                profile_record, event_records, phase_records = build_session_product_records(conversation)
-                await replace_session_profile(conn, profile_record, transaction_depth)
+            batch = await load_async_batch(conn, chunk)
+            record_bundles = build_session_product_record_bundles(hydrate_conversations(batch))
+            chunk_profiles, chunk_work_events, chunk_phases = _count_record_bundles(record_bundles)
+            for bundle in record_bundles:
+                await replace_session_profile(conn, bundle.profile_record, transaction_depth)
                 await replace_session_work_events(
-                    conn, profile_record.conversation_id, event_records, transaction_depth
+                    conn,
+                    bundle.conversation_id,
+                    bundle.work_event_records,
+                    transaction_depth,
                 )
-                await replace_session_phases(conn, profile_record.conversation_id, phase_records, transaction_depth)
-                profile_count += 1
-                chunk_profiles += 1
-                work_event_count += len(event_records)
-                phase_count += len(phase_records)
+                await replace_session_phases(
+                    conn,
+                    bundle.conversation_id,
+                    bundle.phase_records,
+                    transaction_depth,
+                )
+            profile_count += chunk_profiles
+            work_event_count += chunk_work_events
+            phase_count += chunk_phases
             if progress_callback is not None and chunk_profiles:
-                desc = (
-                    f"Materializing: {profile_count}/{progress_total}"
-                    if progress_total is not None
-                    else f"Materializing: {profile_count}"
+                progress_callback(
+                    chunk_profiles,
+                    desc=_materialize_progress_desc(
+                        profile_count=profile_count,
+                        progress_total=progress_total,
+                    ),
                 )
-                progress_callback(chunk_profiles, desc=desc)
     else:
         for chunk_ids in chunked(list(conversation_ids), size=page_size):
-            conversations, messages, attachments, blocks = await load_async_batch(conn, chunk_ids)
-            chunk_profiles = 0
-            for conversation in hydrate_conversations(conversations, messages, attachments, blocks):
-                profile_record, event_records, phase_records = build_session_product_records(conversation)
-                await replace_session_profile(conn, profile_record, transaction_depth)
+            batch = await load_async_batch(conn, chunk_ids)
+            record_bundles = build_session_product_record_bundles(hydrate_conversations(batch))
+            chunk_profiles, chunk_work_events, chunk_phases = _count_record_bundles(record_bundles)
+            for bundle in record_bundles:
+                await replace_session_profile(conn, bundle.profile_record, transaction_depth)
                 await replace_session_work_events(
-                    conn, profile_record.conversation_id, event_records, transaction_depth
+                    conn,
+                    bundle.conversation_id,
+                    bundle.work_event_records,
+                    transaction_depth,
                 )
-                await replace_session_phases(conn, profile_record.conversation_id, phase_records, transaction_depth)
-                profile_count += 1
-                chunk_profiles += 1
-                work_event_count += len(event_records)
-                phase_count += len(phase_records)
+                await replace_session_phases(
+                    conn,
+                    bundle.conversation_id,
+                    bundle.phase_records,
+                    transaction_depth,
+                )
+            profile_count += chunk_profiles
+            work_event_count += chunk_work_events
+            phase_count += chunk_phases
             if progress_callback is not None and chunk_profiles:
-                desc = (
-                    f"Materializing: {profile_count}/{progress_total}"
-                    if progress_total is not None
-                    else f"Materializing: {profile_count}"
+                progress_callback(
+                    chunk_profiles,
+                    desc=_materialize_progress_desc(
+                        profile_count=profile_count,
+                        progress_total=progress_total,
+                    ),
                 )
-                progress_callback(chunk_profiles, desc=desc)
 
     await conn.execute("DELETE FROM work_threads")
     thread_count = 0
@@ -528,19 +647,22 @@ async def rebuild_session_products_async(
     day_summary_row = await (await conn.execute("SELECT COUNT(*) FROM day_session_summaries")).fetchone()
     tag_rollup_count = int(tag_rollup_row[0]) if tag_rollup_row is not None else 0
     day_summary_count = int(day_summary_row[0]) if day_summary_row is not None else 0
-    return {
-        "profiles": profile_count,
-        "work_events": work_event_count,
-        "phases": phase_count,
-        "threads": thread_count,
-        "tag_rollups": int(tag_rollup_count),
-        "day_summaries": int(day_summary_count),
-    }
+    return _finalize_rebuild_counts(
+        profiles=profile_count,
+        work_events=work_event_count,
+        phases=phase_count,
+        threads=thread_count,
+        tag_rollups=int(tag_rollup_count),
+        day_summaries=int(day_summary_count),
+    )
 
 
 __all__ = [
     "_ALL_CONVERSATION_IDS_SQL",
     "_ALL_SESSION_PROFILE_ROWS_SQL",
+    "SessionProductArchiveBatch",
+    "SessionProductRecordBundle",
+    "build_session_product_record_bundles",
     "build_session_product_records",
     "chunked",
     "hydrate_conversations",

--- a/polylogue/storage/session_product_refresh.py
+++ b/polylogue/storage/session_product_refresh.py
@@ -14,6 +14,7 @@ from polylogue.storage.session_product_aggregates import (
     refresh_async_provider_day_aggregates,
 )
 from polylogue.storage.session_product_rebuild import (
+    SessionProductRecordBundle,
     build_session_product_records,
     hydrate_conversations,
     load_async_batch,
@@ -43,7 +44,50 @@ class _SessionProductBulkRefreshUpdate:
     counts: dict[str, int]
     thread_root_ids: set[str]
     affected_groups: set[tuple[str, str]]
-    chunk_observations: list[dict[str, object]]
+    chunk_observations: list[SessionProductRefreshChunkObservation]
+
+
+@dataclass(slots=True, frozen=True)
+class _SessionProductRefreshChunk:
+    conversation_ids: tuple[str, ...]
+    estimated_message_count: int
+    max_estimated_conversation_messages: int
+
+
+@dataclass(slots=True, frozen=True)
+class SessionProductRefreshChunkObservation:
+    conversation_count: int
+    estimated_message_count: int
+    max_estimated_conversation_messages: int
+    hydrated_count: int
+    profiles_written: int
+    work_events_written: int
+    phases_written: int
+    load_ms: float
+    hydrate_ms: float
+    build_ms: float
+    write_ms: float
+    total_ms: float
+    slow: bool = False
+
+    def to_observation(self) -> dict[str, object]:
+        observation: dict[str, object] = {
+            "conversation_count": self.conversation_count,
+            "estimated_message_count": self.estimated_message_count,
+            "max_estimated_conversation_messages": self.max_estimated_conversation_messages,
+            "hydrated_count": self.hydrated_count,
+            "profiles_written": self.profiles_written,
+            "work_events_written": self.work_events_written,
+            "phases_written": self.phases_written,
+            "load_ms": self.load_ms,
+            "hydrate_ms": self.hydrate_ms,
+            "build_ms": self.build_ms,
+            "write_ms": self.write_ms,
+            "total_ms": self.total_ms,
+        }
+        if self.slow:
+            observation["slow"] = True
+        return observation
 
 
 def _empty_refresh_counts() -> dict[str, int]:
@@ -200,8 +244,8 @@ async def _apply_session_product_conversation_update_async(
             (conversation_id,),
         )
     ).fetchone()
-    conversations, messages, attachments, blocks = await load_async_batch(conn, [conversation_id])
-    hydrated = hydrate_conversations(conversations, messages, attachments, blocks)
+    batch = await load_async_batch(conn, [conversation_id])
+    hydrated = hydrate_conversations(batch)
     if not hydrated:
         await conn.execute("DELETE FROM session_profiles WHERE conversation_id = ?", (conversation_id,))
         await replace_session_work_events(conn, conversation_id, [], transaction_depth)
@@ -215,24 +259,34 @@ async def _apply_session_product_conversation_update_async(
             affected_groups={old_group} if old_group is not None else set(),
         )
 
-    profile_record, event_records, phase_records = build_session_product_records(hydrated[0])
-    await replace_session_profile(conn, profile_record, transaction_depth)
-    await replace_session_work_events(conn, conversation_id, event_records, transaction_depth)
-    await replace_session_phases(conn, conversation_id, phase_records, transaction_depth)
+    record_bundle = build_session_product_records(hydrated[0])
+    await replace_session_profile(conn, record_bundle.profile_record, transaction_depth)
+    await replace_session_work_events(
+        conn,
+        conversation_id,
+        record_bundle.work_event_records,
+        transaction_depth,
+    )
+    await replace_session_phases(
+        conn,
+        conversation_id,
+        record_bundle.phase_records,
+        transaction_depth,
+    )
 
     affected_groups = {
         group
         for group in (
             profile_provider_day(_row_to_session_profile_record(old_profile_record)) if old_profile_record else None,
-            profile_provider_day(profile_record),
+            profile_provider_day(record_bundle.profile_record),
         )
         if group is not None
     }
     return _SessionProductRefreshUpdate(
         counts={
             "profiles": 1,
-            "work_events": len(event_records),
-            "phases": len(phase_records),
+            "work_events": record_bundle.work_event_count,
+            "phases": record_bundle.phase_count,
             "threads": 0,
             "tag_rollups": 0,
             "day_summaries": 0,
@@ -284,25 +338,83 @@ def _chunk_conversation_ids_by_message_budget(
     message_counts: dict[str, int],
     page_size: int,
     message_budget: int,
-) -> list[list[str]]:
-    chunks: list[list[str]] = []
+) -> list[_SessionProductRefreshChunk]:
+    chunks: list[_SessionProductRefreshChunk] = []
     current_chunk: list[str] = []
     current_messages = 0
+    current_max_messages = 0
 
     for conversation_id in conversation_ids:
         estimated_messages = max(int(message_counts.get(conversation_id, 0) or 0), 1)
         if current_chunk and (
             len(current_chunk) >= page_size or current_messages + estimated_messages > message_budget
         ):
-            chunks.append(current_chunk)
+            chunks.append(
+                _SessionProductRefreshChunk(
+                    conversation_ids=tuple(current_chunk),
+                    estimated_message_count=current_messages,
+                    max_estimated_conversation_messages=current_max_messages,
+                )
+            )
             current_chunk = []
             current_messages = 0
+            current_max_messages = 0
         current_chunk.append(conversation_id)
         current_messages += estimated_messages
+        current_max_messages = max(current_max_messages, estimated_messages)
 
     if current_chunk:
-        chunks.append(current_chunk)
+        chunks.append(
+            _SessionProductRefreshChunk(
+                conversation_ids=tuple(current_chunk),
+                estimated_message_count=current_messages,
+                max_estimated_conversation_messages=current_max_messages,
+            )
+        )
     return chunks
+
+
+def _flatten_record_bundles(
+    bundles: Sequence[SessionProductRecordBundle],
+) -> tuple[list[SessionProfileRecord], list[SessionWorkEventRecord], list[SessionPhaseRecord]]:
+    profile_records: list[SessionProfileRecord] = []
+    work_event_records: list[SessionWorkEventRecord] = []
+    phase_records: list[SessionPhaseRecord] = []
+    for bundle in bundles:
+        profile_records.append(bundle.profile_record)
+        work_event_records.extend(bundle.work_event_records)
+        phase_records.extend(bundle.phase_records)
+    return profile_records, work_event_records, phase_records
+
+
+def _refresh_chunk_observation(
+    *,
+    chunk: _SessionProductRefreshChunk,
+    hydrated_count: int,
+    profiles_written: int,
+    work_events_written: int,
+    phases_written: int,
+    load_ms: float,
+    hydrate_ms: float,
+    build_ms: float,
+    write_ms: float,
+    total_ms: float,
+) -> SessionProductRefreshChunkObservation:
+    return SessionProductRefreshChunkObservation(
+        conversation_count=len(chunk.conversation_ids),
+        estimated_message_count=chunk.estimated_message_count,
+        max_estimated_conversation_messages=chunk.max_estimated_conversation_messages,
+        hydrated_count=hydrated_count,
+        profiles_written=profiles_written,
+        work_events_written=work_events_written,
+        phases_written=phases_written,
+        load_ms=load_ms,
+        hydrate_ms=hydrate_ms,
+        build_ms=build_ms,
+        write_ms=write_ms,
+        total_ms=total_ms,
+        slow=total_ms >= 500.0,
+    )
 
 
 async def _apply_session_product_conversation_updates_async(
@@ -323,7 +435,7 @@ async def _apply_session_product_conversation_updates_async(
     counts = _empty_refresh_counts()
     thread_root_ids: set[str] = set()
     affected_groups: set[tuple[str, str]] = set()
-    chunk_observations: list[dict[str, object]] = []
+    chunk_observations: list[SessionProductRefreshChunkObservation] = []
     conversation_id_list = list(conversation_ids)
     message_counts = await _load_message_counts_async(conn, conversation_id_list)
     conversation_chunks = _chunk_conversation_ids_by_message_budget(
@@ -336,22 +448,17 @@ async def _apply_session_product_conversation_updates_async(
     for chunk in conversation_chunks:
         chunk_started = time.perf_counter()
         load_started = time.perf_counter()
-        old_profile_records = await _load_existing_session_profile_records_async(conn, chunk)
-        conversations, messages, attachments, blocks = await load_async_batch(conn, chunk)
-        root_ids_by_conversation = await thread_root_ids_async(conn, chunk)
+        old_profile_records = await _load_existing_session_profile_records_async(conn, chunk.conversation_ids)
+        batch = await load_async_batch(conn, chunk.conversation_ids)
+        root_ids_by_conversation = await thread_root_ids_async(conn, chunk.conversation_ids)
         load_elapsed_ms = round((time.perf_counter() - load_started) * 1000.0, 1)
-        profile_records_to_write: list[SessionProfileRecord] = []
-        work_event_records_to_write: list[SessionWorkEventRecord] = []
-        phase_records_to_write: list[SessionPhaseRecord] = []
         hydrate_started = time.perf_counter()
-        hydrated_by_id = {
-            str(conversation.id): conversation
-            for conversation in hydrate_conversations(conversations, messages, attachments, blocks)
-        }
+        hydrated_by_id = {str(conversation.id): conversation for conversation in hydrate_conversations(batch)}
         hydrate_elapsed_ms = round((time.perf_counter() - hydrate_started) * 1000.0, 1)
 
         build_started = time.perf_counter()
-        for conversation_id in chunk:
+        record_bundles: list[SessionProductRecordBundle] = []
+        for conversation_id in chunk.conversation_ids:
             old_profile_record = old_profile_records.get(conversation_id)
             hydrated_conversation = hydrated_by_id.get(conversation_id)
             if hydrated_conversation is None:
@@ -360,19 +467,17 @@ async def _apply_session_product_conversation_updates_async(
                     affected_groups.add(old_group)
                 continue
 
-            profile_record, event_records, phase_records = build_session_product_records(hydrated_conversation)
-            profile_records_to_write.append(profile_record)
-            work_event_records_to_write.extend(event_records)
-            phase_records_to_write.extend(phase_records)
+            record_bundle = build_session_product_records(hydrated_conversation)
+            record_bundles.append(record_bundle)
 
             counts["profiles"] += 1
-            counts["work_events"] += len(event_records)
-            counts["phases"] += len(phase_records)
+            counts["work_events"] += record_bundle.work_event_count
+            counts["phases"] += record_bundle.phase_count
             affected_groups.update(
                 group
                 for group in (
                     profile_provider_day(old_profile_record),
-                    profile_provider_day(profile_record),
+                    profile_provider_day(record_bundle.profile_record),
                 )
                 if group is not None
             )
@@ -382,47 +487,43 @@ async def _apply_session_product_conversation_updates_async(
         build_elapsed_ms = round((time.perf_counter() - build_started) * 1000.0, 1)
 
         write_started = time.perf_counter()
+        profile_records_to_write, work_event_records_to_write, phase_records_to_write = _flatten_record_bundles(
+            record_bundles
+        )
         await replace_session_profiles_bulk(
             conn,
-            chunk,
+            chunk.conversation_ids,
             profile_records_to_write,
             transaction_depth,
         )
         await replace_session_work_events_bulk(
             conn,
-            chunk,
+            chunk.conversation_ids,
             work_event_records_to_write,
             transaction_depth,
         )
         await replace_session_phases_bulk(
             conn,
-            chunk,
+            chunk.conversation_ids,
             phase_records_to_write,
             transaction_depth,
         )
         write_elapsed_ms = round((time.perf_counter() - write_started) * 1000.0, 1)
         chunk_total_ms = round((time.perf_counter() - chunk_started) * 1000.0, 1)
-        chunk_observation: dict[str, object] = {
-            "conversation_count": len(chunk),
-            "estimated_message_count": sum(
-                max(int(message_counts.get(conversation_id, 0) or 0), 1) for conversation_id in chunk
-            ),
-            "max_estimated_conversation_messages": max(
-                max(int(message_counts.get(conversation_id, 0) or 0), 1) for conversation_id in chunk
-            ),
-            "hydrated_count": len(hydrated_by_id),
-            "profiles_written": len(profile_records_to_write),
-            "work_events_written": len(work_event_records_to_write),
-            "phases_written": len(phase_records_to_write),
-            "load_ms": load_elapsed_ms,
-            "hydrate_ms": hydrate_elapsed_ms,
-            "build_ms": build_elapsed_ms,
-            "write_ms": write_elapsed_ms,
-            "total_ms": chunk_total_ms,
-        }
-        if chunk_total_ms >= 500.0:
-            chunk_observation["slow"] = True
-        chunk_observations.append(chunk_observation)
+        chunk_observations.append(
+            _refresh_chunk_observation(
+                chunk=chunk,
+                hydrated_count=len(hydrated_by_id),
+                profiles_written=len(profile_records_to_write),
+                work_events_written=len(work_event_records_to_write),
+                phases_written=len(phase_records_to_write),
+                load_ms=load_elapsed_ms,
+                hydrate_ms=hydrate_elapsed_ms,
+                build_ms=build_elapsed_ms,
+                write_ms=write_elapsed_ms,
+                total_ms=chunk_total_ms,
+            )
+        )
 
     return _SessionProductBulkRefreshUpdate(
         counts=counts,
@@ -433,6 +534,7 @@ async def _apply_session_product_conversation_updates_async(
 
 
 __all__ = [
+    "SessionProductRefreshChunkObservation",
     "delete_session_products_for_conversation_async",
     "refresh_async_provider_day_aggregates",
     "refresh_session_products_for_conversation_async",

--- a/polylogue/storage/session_product_storage.py
+++ b/polylogue/storage/session_product_storage.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import sqlite3
 from collections.abc import Sequence
 
+from pydantic import BaseModel
+
 from polylogue.storage.store import (
     DaySessionSummaryRecord,
     SessionPhaseRecord,
@@ -34,14 +36,12 @@ def table_has_column(conn: sqlite3.Connection, table: str, column: str) -> bool:
     return found
 
 
-# ---------------------------------------------------------------------------
-# Profile writes
-# ---------------------------------------------------------------------------
+def _placeholders(columns: Sequence[str]) -> str:
+    return ", ".join("?" for _ in columns)
 
 
-def replace_session_profile_sync(conn: sqlite3.Connection, record: SessionProfileRecord) -> None:
-    conn.execute("DELETE FROM session_profiles WHERE conversation_id = ?", (record.conversation_id,))
-    payload_json = _json_or_none(
+def _legacy_profile_payload_json(record: SessionProfileRecord) -> str | None:
+    return _json_or_none(
         {
             **record.evidence_payload.model_dump(mode="json"),
             **record.inference_payload.model_dump(mode="json"),
@@ -50,6 +50,12 @@ def replace_session_profile_sync(conn: sqlite3.Connection, record: SessionProfil
             "title": record.title,
         }
     )
+
+
+def session_profile_insert_columns(
+    *,
+    has_legacy_payload: bool,
+) -> tuple[str, ...]:
     columns = [
         "conversation_id",
         "materializer_version",
@@ -79,6 +85,31 @@ def replace_session_profile_sync(conn: sqlite3.Connection, record: SessionProfil
         "wall_duration_ms",
         "cost_is_estimated",
     ]
+    if has_legacy_payload:
+        columns.append("payload_json")
+    columns.extend(
+        [
+            "evidence_payload_json",
+            "inference_payload_json",
+            "enrichment_payload_json",
+            "search_text",
+            "evidence_search_text",
+            "inference_search_text",
+            "enrichment_search_text",
+            "enrichment_version",
+            "enrichment_family",
+            "inference_version",
+            "inference_family",
+        ]
+    )
+    return tuple(columns)
+
+
+def session_profile_insert_values(
+    record: SessionProfileRecord,
+    *,
+    has_legacy_payload: bool,
+) -> tuple[object, ...]:
     values: list[object] = [
         record.conversation_id,
         record.materializer_version,
@@ -108,24 +139,8 @@ def replace_session_profile_sync(conn: sqlite3.Connection, record: SessionProfil
         record.wall_duration_ms,
         int(record.cost_is_estimated),
     ]
-    if table_has_column(conn, "session_profiles", "payload_json"):
-        columns.append("payload_json")
-        values.append(payload_json)
-    columns.extend(
-        [
-            "evidence_payload_json",
-            "inference_payload_json",
-            "enrichment_payload_json",
-            "search_text",
-            "evidence_search_text",
-            "inference_search_text",
-            "enrichment_search_text",
-            "enrichment_version",
-            "enrichment_family",
-            "inference_version",
-            "inference_family",
-        ]
-    )
+    if has_legacy_payload:
+        values.append(_legacy_profile_payload_json(record))
     values.extend(
         [
             _json_or_none(record.evidence_payload),
@@ -141,14 +156,252 @@ def replace_session_profile_sync(conn: sqlite3.Connection, record: SessionProfil
             record.inference_family,
         ]
     )
-    placeholders = ", ".join("?" for _ in columns)
+    return tuple(values)
+
+
+def _legacy_timeline_payload_json(
+    evidence_payload: object,
+    inference_payload: object,
+) -> str | None:
+    evidence = evidence_payload.model_dump(mode="json") if isinstance(evidence_payload, BaseModel) else {}
+    inference = inference_payload.model_dump(mode="json") if isinstance(inference_payload, BaseModel) else {}
+    return _json_or_none({**evidence, **inference})
+
+
+def session_work_event_insert_columns(
+    *,
+    has_legacy_payload: bool,
+) -> tuple[str, ...]:
+    columns = [
+        "event_id",
+        "conversation_id",
+        "materializer_version",
+        "materialized_at",
+        "source_updated_at",
+        "source_sort_key",
+        "provider_name",
+        "event_index",
+        "kind",
+        "confidence",
+        "start_index",
+        "end_index",
+        "start_time",
+        "end_time",
+        "duration_ms",
+        "canonical_session_date",
+        "summary",
+        "file_paths_json",
+        "tools_used_json",
+    ]
+    if has_legacy_payload:
+        columns.append("payload_json")
+    columns.extend(
+        [
+            "evidence_payload_json",
+            "inference_payload_json",
+            "search_text",
+            "inference_version",
+            "inference_family",
+        ]
+    )
+    return tuple(columns)
+
+
+def session_work_event_insert_values(
+    record: SessionWorkEventRecord,
+    *,
+    has_legacy_payload: bool,
+) -> tuple[object, ...]:
+    values: list[object] = [
+        record.event_id,
+        record.conversation_id,
+        record.materializer_version,
+        record.materialized_at,
+        record.source_updated_at,
+        record.source_sort_key,
+        record.provider_name,
+        record.event_index,
+        record.kind,
+        record.confidence,
+        record.start_index,
+        record.end_index,
+        record.start_time,
+        record.end_time,
+        record.duration_ms,
+        record.canonical_session_date,
+        record.summary,
+        _json_array_or_none(record.file_paths),
+        _json_array_or_none(record.tools_used),
+    ]
+    if has_legacy_payload:
+        values.append(_legacy_timeline_payload_json(record.evidence_payload, record.inference_payload))
+    values.extend(
+        [
+            _json_or_none(record.evidence_payload),
+            _json_or_none(record.inference_payload),
+            record.search_text,
+            record.inference_version,
+            record.inference_family,
+        ]
+    )
+    return tuple(values)
+
+
+def session_phase_insert_columns(
+    *,
+    has_legacy_payload: bool,
+) -> tuple[str, ...]:
+    columns = [
+        "phase_id",
+        "conversation_id",
+        "materializer_version",
+        "materialized_at",
+        "source_updated_at",
+        "source_sort_key",
+        "provider_name",
+        "phase_index",
+        "kind",
+        "start_index",
+        "end_index",
+        "start_time",
+        "end_time",
+        "duration_ms",
+        "canonical_session_date",
+        "confidence",
+        "evidence_reasons_json",
+        "tool_counts_json",
+        "word_count",
+    ]
+    if has_legacy_payload:
+        columns.append("payload_json")
+    columns.extend(
+        [
+            "evidence_payload_json",
+            "inference_payload_json",
+            "search_text",
+            "inference_version",
+            "inference_family",
+        ]
+    )
+    return tuple(columns)
+
+
+def session_phase_insert_values(
+    record: SessionPhaseRecord,
+    *,
+    has_legacy_payload: bool,
+) -> tuple[object, ...]:
+    values: list[object] = [
+        record.phase_id,
+        record.conversation_id,
+        record.materializer_version,
+        record.materialized_at,
+        record.source_updated_at,
+        record.source_sort_key,
+        record.provider_name,
+        record.phase_index,
+        record.kind,
+        record.start_index,
+        record.end_index,
+        record.start_time,
+        record.end_time,
+        record.duration_ms,
+        record.canonical_session_date,
+        record.confidence,
+        _json_array_or_none(record.evidence_reasons) or "[]",
+        _json_or_none(record.tool_counts),
+        record.word_count,
+    ]
+    if has_legacy_payload:
+        values.append(_legacy_timeline_payload_json(record.evidence_payload, record.inference_payload))
+    values.extend(
+        [
+            _json_or_none(record.evidence_payload),
+            _json_or_none(record.inference_payload),
+            record.search_text,
+            record.inference_version,
+            record.inference_family,
+        ]
+    )
+    return tuple(values)
+
+
+def work_thread_insert_values(record: WorkThreadRecord) -> tuple[object, ...]:
+    return (
+        record.thread_id,
+        record.root_id,
+        record.materializer_version,
+        record.materialized_at,
+        record.start_time,
+        record.end_time,
+        record.dominant_repo,
+        _json_array_or_none(record.session_ids),
+        record.session_count,
+        record.depth,
+        record.branch_count,
+        record.total_messages,
+        record.total_cost_usd,
+        record.wall_duration_ms,
+        _json_or_none(record.work_event_breakdown or {}),
+        _json_or_none(record.payload),
+        record.search_text,
+    )
+
+
+def session_tag_rollup_insert_values(record: SessionTagRollupRecord) -> tuple[object, ...]:
+    return (
+        record.tag,
+        record.bucket_day,
+        record.provider_name,
+        record.materializer_version,
+        record.materialized_at,
+        record.source_updated_at,
+        record.source_sort_key,
+        record.conversation_count,
+        record.explicit_count,
+        record.auto_count,
+        _json_or_none(record.repo_breakdown),
+        record.search_text,
+    )
+
+
+def day_session_summary_insert_values(record: DaySessionSummaryRecord) -> tuple[object, ...]:
+    return (
+        record.day,
+        record.provider_name,
+        record.materializer_version,
+        record.materialized_at,
+        record.source_updated_at,
+        record.source_sort_key,
+        record.conversation_count,
+        record.total_cost_usd,
+        record.total_duration_ms,
+        record.total_wall_duration_ms,
+        record.total_messages,
+        record.total_words,
+        _json_or_none(record.work_event_breakdown),
+        _json_array_or_none(record.repos_active),
+        _json_or_none(record.payload),
+        record.search_text,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Profile writes
+# ---------------------------------------------------------------------------
+
+
+def replace_session_profile_sync(conn: sqlite3.Connection, record: SessionProfileRecord) -> None:
+    conn.execute("DELETE FROM session_profiles WHERE conversation_id = ?", (record.conversation_id,))
+    has_legacy_payload = table_has_column(conn, "session_profiles", "payload_json")
+    columns = session_profile_insert_columns(has_legacy_payload=has_legacy_payload)
     conn.execute(
         f"""
         INSERT INTO session_profiles (
             {", ".join(columns)}
-        ) VALUES ({placeholders})
+        ) VALUES ({_placeholders(columns)})
         """,
-        tuple(values),
+        session_profile_insert_values(record, has_legacy_payload=has_legacy_payload),
     )
 
 
@@ -165,90 +418,14 @@ def replace_session_work_events_sync(
     conn.execute("DELETE FROM session_work_events WHERE conversation_id = ?", (conversation_id,))
     if records:
         has_legacy_payload = table_has_column(conn, "session_work_events", "payload_json")
-        columns = [
-            "event_id",
-            "conversation_id",
-            "materializer_version",
-            "materialized_at",
-            "source_updated_at",
-            "source_sort_key",
-            "provider_name",
-            "event_index",
-            "kind",
-            "confidence",
-            "start_index",
-            "end_index",
-            "start_time",
-            "end_time",
-            "duration_ms",
-            "canonical_session_date",
-            "summary",
-            "file_paths_json",
-            "tools_used_json",
-        ]
-        if has_legacy_payload:
-            columns.append("payload_json")
-        columns.extend(
-            [
-                "evidence_payload_json",
-                "inference_payload_json",
-                "search_text",
-                "inference_version",
-                "inference_family",
-            ]
-        )
-        placeholders = ", ".join("?" for _ in columns)
+        columns = session_work_event_insert_columns(has_legacy_payload=has_legacy_payload)
         conn.executemany(
             f"""
             INSERT INTO session_work_events (
                 {", ".join(columns)}
-            ) VALUES ({placeholders})
+            ) VALUES ({_placeholders(columns)})
             """,
-            [
-                tuple(
-                    [
-                        record.event_id,
-                        record.conversation_id,
-                        record.materializer_version,
-                        record.materialized_at,
-                        record.source_updated_at,
-                        record.source_sort_key,
-                        record.provider_name,
-                        record.event_index,
-                        record.kind,
-                        record.confidence,
-                        record.start_index,
-                        record.end_index,
-                        record.start_time,
-                        record.end_time,
-                        record.duration_ms,
-                        record.canonical_session_date,
-                        record.summary,
-                        _json_array_or_none(record.file_paths),
-                        _json_array_or_none(record.tools_used),
-                    ]
-                    + (
-                        [
-                            _json_or_none(
-                                {
-                                    **record.evidence_payload.model_dump(mode="json"),
-                                    **record.inference_payload.model_dump(mode="json"),
-                                }
-                            )
-                        ]
-                        if has_legacy_payload
-                        else []
-                    )
-                    + [
-                        _json_or_none(record.evidence_payload),
-                        _json_or_none(record.inference_payload),
-                        record.search_text,
-                        record.inference_version,
-                        record.inference_family,
-                    ]
-                )
-                for record in records
-            ],
+            [session_work_event_insert_values(record, has_legacy_payload=has_legacy_payload) for record in records],
         )
 
 
@@ -260,90 +437,14 @@ def replace_session_phases_sync(
     conn.execute("DELETE FROM session_phases WHERE conversation_id = ?", (conversation_id,))
     if records:
         has_legacy_payload = table_has_column(conn, "session_phases", "payload_json")
-        columns = [
-            "phase_id",
-            "conversation_id",
-            "materializer_version",
-            "materialized_at",
-            "source_updated_at",
-            "source_sort_key",
-            "provider_name",
-            "phase_index",
-            "kind",
-            "start_index",
-            "end_index",
-            "start_time",
-            "end_time",
-            "duration_ms",
-            "canonical_session_date",
-            "confidence",
-            "evidence_reasons_json",
-            "tool_counts_json",
-            "word_count",
-        ]
-        if has_legacy_payload:
-            columns.append("payload_json")
-        columns.extend(
-            [
-                "evidence_payload_json",
-                "inference_payload_json",
-                "search_text",
-                "inference_version",
-                "inference_family",
-            ]
-        )
-        placeholders = ", ".join("?" for _ in columns)
+        columns = session_phase_insert_columns(has_legacy_payload=has_legacy_payload)
         conn.executemany(
             f"""
             INSERT INTO session_phases (
                 {", ".join(columns)}
-            ) VALUES ({placeholders})
+            ) VALUES ({_placeholders(columns)})
             """,
-            [
-                tuple(
-                    [
-                        record.phase_id,
-                        record.conversation_id,
-                        record.materializer_version,
-                        record.materialized_at,
-                        record.source_updated_at,
-                        record.source_sort_key,
-                        record.provider_name,
-                        record.phase_index,
-                        record.kind,
-                        record.start_index,
-                        record.end_index,
-                        record.start_time,
-                        record.end_time,
-                        record.duration_ms,
-                        record.canonical_session_date,
-                        record.confidence,
-                        _json_array_or_none(record.evidence_reasons) or "[]",
-                        _json_or_none(record.tool_counts),
-                        record.word_count,
-                    ]
-                    + (
-                        [
-                            _json_or_none(
-                                {
-                                    **record.evidence_payload.model_dump(mode="json"),
-                                    **record.inference_payload.model_dump(mode="json"),
-                                }
-                            )
-                        ]
-                        if has_legacy_payload
-                        else []
-                    )
-                    + [
-                        _json_or_none(record.evidence_payload),
-                        _json_or_none(record.inference_payload),
-                        record.search_text,
-                        record.inference_version,
-                        record.inference_family,
-                    ]
-                )
-                for record in records
-            ],
+            [session_phase_insert_values(record, has_legacy_payload=has_legacy_payload) for record in records],
         )
 
 
@@ -381,25 +482,7 @@ def replace_work_thread_sync(
                 search_text
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
-            (
-                record.thread_id,
-                record.root_id,
-                record.materializer_version,
-                record.materialized_at,
-                record.start_time,
-                record.end_time,
-                record.dominant_repo,
-                _json_array_or_none(record.session_ids),
-                record.session_count,
-                record.depth,
-                record.branch_count,
-                record.total_messages,
-                record.total_cost_usd,
-                record.wall_duration_ms,
-                _json_or_none(record.work_event_breakdown or {}),
-                _json_or_none(record.payload),
-                record.search_text,
-            ),
+            work_thread_insert_values(record),
         )
 
 
@@ -432,23 +515,7 @@ def replace_session_tag_rollup_rows_sync(
                 search_text
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
-            [
-                (
-                    record.tag,
-                    record.bucket_day,
-                    record.provider_name,
-                    record.materializer_version,
-                    record.materialized_at,
-                    record.source_updated_at,
-                    record.source_sort_key,
-                    record.conversation_count,
-                    record.explicit_count,
-                    record.auto_count,
-                    _json_or_none(record.repo_breakdown),
-                    record.search_text,
-                )
-                for record in records
-            ],
+            [session_tag_rollup_insert_values(record) for record in records],
         )
 
 
@@ -485,36 +552,25 @@ def replace_day_session_summaries_sync(
                 search_text
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
-            [
-                (
-                    record.day,
-                    record.provider_name,
-                    record.materializer_version,
-                    record.materialized_at,
-                    record.source_updated_at,
-                    record.source_sort_key,
-                    record.conversation_count,
-                    record.total_cost_usd,
-                    record.total_duration_ms,
-                    record.total_wall_duration_ms,
-                    record.total_messages,
-                    record.total_words,
-                    _json_or_none(record.work_event_breakdown),
-                    _json_array_or_none(record.repos_active),
-                    _json_or_none(record.payload),
-                    record.search_text,
-                )
-                for record in records
-            ],
+            [day_session_summary_insert_values(record) for record in records],
         )
 
 
 __all__ = [
+    "day_session_summary_insert_values",
     "replace_day_session_summaries_sync",
     "replace_session_phases_sync",
     "replace_session_profile_sync",
     "replace_session_tag_rollup_rows_sync",
     "replace_session_work_events_sync",
     "replace_work_thread_sync",
+    "session_phase_insert_columns",
+    "session_phase_insert_values",
+    "session_profile_insert_columns",
+    "session_profile_insert_values",
+    "session_tag_rollup_insert_values",
+    "session_work_event_insert_columns",
+    "session_work_event_insert_values",
     "table_has_column",
+    "work_thread_insert_values",
 ]

--- a/polylogue/storage/session_product_storage.py
+++ b/polylogue/storage/session_product_storage.py
@@ -43,8 +43,8 @@ def replace_session_profile_sync(conn: sqlite3.Connection, record: SessionProfil
     conn.execute("DELETE FROM session_profiles WHERE conversation_id = ?", (record.conversation_id,))
     payload_json = _json_or_none(
         {
-            **record.evidence_payload,
-            **record.inference_payload,
+            **record.evidence_payload.model_dump(mode="json"),
+            **record.inference_payload.model_dump(mode="json"),
             "conversation_id": str(record.conversation_id),
             "provider": record.provider_name,
             "title": record.title,
@@ -231,8 +231,8 @@ def replace_session_work_events_sync(
                         [
                             _json_or_none(
                                 {
-                                    **record.evidence_payload,
-                                    **record.inference_payload,
+                                    **record.evidence_payload.model_dump(mode="json"),
+                                    **record.inference_payload.model_dump(mode="json"),
                                 }
                             )
                         ]
@@ -319,15 +319,15 @@ def replace_session_phases_sync(
                         record.canonical_session_date,
                         record.confidence,
                         _json_array_or_none(record.evidence_reasons) or "[]",
-                        _json_or_none(dict[str, object](record.tool_counts)),
+                        _json_or_none(record.tool_counts),
                         record.word_count,
                     ]
                     + (
                         [
                             _json_or_none(
                                 {
-                                    **record.evidence_payload,
-                                    **record.inference_payload,
+                                    **record.evidence_payload.model_dump(mode="json"),
+                                    **record.inference_payload.model_dump(mode="json"),
                                 }
                             )
                         ]
@@ -396,7 +396,7 @@ def replace_work_thread_sync(
                 record.total_messages,
                 record.total_cost_usd,
                 record.wall_duration_ms,
-                _json_or_none(dict[str, object](record.work_event_breakdown or {})),
+                _json_or_none(record.work_event_breakdown or {}),
                 _json_or_none(record.payload),
                 record.search_text,
             ),
@@ -444,7 +444,7 @@ def replace_session_tag_rollup_rows_sync(
                     record.conversation_count,
                     record.explicit_count,
                     record.auto_count,
-                    _json_or_none(dict[str, object](record.repo_breakdown)),
+                    _json_or_none(record.repo_breakdown),
                     record.search_text,
                 )
                 for record in records
@@ -499,7 +499,7 @@ def replace_day_session_summaries_sync(
                     record.total_wall_duration_ms,
                     record.total_messages,
                     record.total_words,
-                    _json_or_none(dict[str, object](record.work_event_breakdown)),
+                    _json_or_none(record.work_event_breakdown),
                     _json_array_or_none(record.repos_active),
                     _json_or_none(record.payload),
                     record.search_text,

--- a/polylogue/storage/session_product_threads.py
+++ b/polylogue/storage/session_product_threads.py
@@ -7,6 +7,7 @@ from collections.abc import AsyncIterator, Iterable, Iterator, Sequence
 
 import aiosqlite
 
+from polylogue.archive_product_models import WorkThreadPayload
 from polylogue.lib.threads import WorkThread, build_session_threads
 from polylogue.storage.backends.queries.mappers import _row_to_session_profile_record
 from polylogue.storage.session_product_profiles import hydrate_session_profile, now_iso
@@ -124,13 +125,13 @@ def build_work_thread_record(
         total_cost_usd=thread.total_cost_usd,
         wall_duration_ms=thread.wall_duration_ms,
         work_event_breakdown=thread.work_event_breakdown,
-        payload=thread.to_dict(),
+        payload=WorkThreadPayload.model_validate(thread.to_dict()),
         search_text=thread_search_text(thread),
     )
 
 
 def hydrate_work_thread(record: WorkThreadRecord) -> WorkThread:
-    return WorkThread.from_dict(record.payload)
+    return WorkThread.from_dict(record.payload.model_dump(mode="json"))
 
 
 # ---------------------------------------------------------------------------

--- a/polylogue/storage/session_product_timeline_rows.py
+++ b/polylogue/storage/session_product_timeline_rows.py
@@ -4,6 +4,12 @@ from __future__ import annotations
 
 from datetime import datetime
 
+from polylogue.archive_product_models import (
+    SessionPhaseEvidencePayload,
+    SessionPhaseInferencePayload,
+    WorkEventEvidencePayload,
+    WorkEventInferencePayload,
+)
 from polylogue.lib.hashing import hash_text
 from polylogue.lib.phase_extraction import SessionPhase
 from polylogue.lib.session_profile import SessionProfile
@@ -46,20 +52,20 @@ def _event_id(
     return f"wev-{hash_text(seed)[:16]}"
 
 
-def event_evidence_payload(event: WorkEvent) -> dict[str, object]:
-    return {
-        "start_index": event.start_index,
-        "end_index": event.end_index,
-        "start_time": event.start_time.isoformat() if event.start_time else None,
-        "end_time": event.end_time.isoformat() if event.end_time else None,
-        "canonical_session_date": (event.canonical_session_date.isoformat() if event.canonical_session_date else None),
-        "duration_ms": event.duration_ms,
-        "file_paths": list(event.file_paths),
-        "tools_used": list(event.tools_used),
-    }
+def event_evidence_payload(event: WorkEvent) -> WorkEventEvidencePayload:
+    return WorkEventEvidencePayload(
+        start_index=event.start_index,
+        end_index=event.end_index,
+        start_time=event.start_time.isoformat() if event.start_time else None,
+        end_time=event.end_time.isoformat() if event.end_time else None,
+        canonical_session_date=event.canonical_session_date.isoformat() if event.canonical_session_date else None,
+        duration_ms=event.duration_ms,
+        file_paths=event.file_paths,
+        tools_used=event.tools_used,
+    )
 
 
-def event_inference_payload(event: WorkEvent) -> dict[str, object]:
+def event_inference_payload(event: WorkEvent) -> WorkEventInferencePayload:
     summary = event_summary(event)
     signals = event_support_signals(event)
     fallback = event_fallback(event)
@@ -77,20 +83,20 @@ def _event_inference_payload(
     summary: str,
     signals: tuple[str, ...],
     fallback: bool,
-) -> dict[str, object]:
-    return {
-        "kind": event.kind.value,
-        "summary": summary,
-        "confidence": event.confidence,
-        "evidence": list(event.evidence),
-        "support_level": support_level(
+) -> WorkEventInferencePayload:
+    return WorkEventInferencePayload(
+        kind=event.kind.value,
+        summary=summary,
+        confidence=event.confidence,
+        evidence=event.evidence,
+        support_level=support_level(
             float(event.confidence or 0.0),
             support_signals=signals,
             fallback=fallback,
         ),
-        "support_signals": list(signals),
-        "fallback_inference": fallback,
-    }
+        support_signals=signals,
+        fallback_inference=fallback,
+    )
 
 
 def event_search_text(profile: SessionProfile, event: WorkEvent) -> str:
@@ -169,7 +175,12 @@ def build_session_work_event_records(
 
 
 def hydrate_work_event(record: SessionWorkEventRecord) -> WorkEvent:
-    return WorkEvent.from_dict({**record.evidence_payload, **record.inference_payload})
+    return WorkEvent.from_dict(
+        {
+            **record.evidence_payload.model_dump(mode="json"),
+            **record.inference_payload.model_dump(mode="json"),
+        }
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -198,19 +209,19 @@ def phase_search_text(profile: SessionProfile, phase: SessionPhase) -> str:
     return search_text or profile.conversation_id
 
 
-def phase_evidence_payload(phase: SessionPhase) -> dict[str, object]:
-    return {
-        "start_time": phase.start_time.isoformat() if phase.start_time else None,
-        "end_time": phase.end_time.isoformat() if phase.end_time else None,
-        "canonical_session_date": (phase.canonical_session_date.isoformat() if phase.canonical_session_date else None),
-        "message_range": list(phase.message_range),
-        "duration_ms": phase.duration_ms,
-        "tool_counts": dict(phase.tool_counts),
-        "word_count": phase.word_count,
-    }
+def phase_evidence_payload(phase: SessionPhase) -> SessionPhaseEvidencePayload:
+    return SessionPhaseEvidencePayload(
+        start_time=phase.start_time.isoformat() if phase.start_time else None,
+        end_time=phase.end_time.isoformat() if phase.end_time else None,
+        canonical_session_date=phase.canonical_session_date.isoformat() if phase.canonical_session_date else None,
+        message_range=phase.message_range,
+        duration_ms=phase.duration_ms,
+        tool_counts=dict(phase.tool_counts),
+        word_count=phase.word_count,
+    )
 
 
-def phase_inference_payload(phase: SessionPhase) -> dict[str, object]:
+def phase_inference_payload(phase: SessionPhase) -> SessionPhaseInferencePayload:
     signals = phase_support_signals(phase)
     fallback = phase_fallback(phase)
     return _phase_inference_payload(
@@ -225,18 +236,18 @@ def _phase_inference_payload(
     *,
     signals: tuple[str, ...],
     fallback: bool,
-) -> dict[str, object]:
-    return {
-        "confidence": phase.confidence,
-        "evidence": list(phase.evidence),
-        "support_level": support_level(
+) -> SessionPhaseInferencePayload:
+    return SessionPhaseInferencePayload(
+        confidence=phase.confidence,
+        evidence=phase.evidence,
+        support_level=support_level(
             float(phase.confidence or 0.0),
             support_signals=signals,
             fallback=fallback,
         ),
-        "support_signals": list(signals),
-        "fallback_inference": fallback,
-    }
+        support_signals=signals,
+        fallback_inference=fallback,
+    )
 
 
 def build_session_phase_records(
@@ -290,7 +301,10 @@ def build_session_phase_records(
 
 
 def hydrate_session_phase(record: SessionPhaseRecord) -> SessionPhase:
-    payload = {**record.evidence_payload, **record.inference_payload}
+    payload = {
+        **record.evidence_payload.model_dump(mode="json"),
+        **record.inference_payload.model_dump(mode="json"),
+    }
     return SessionPhase(
         start_time=(datetime.fromisoformat(str(payload["start_time"])) if payload.get("start_time") else None),
         end_time=(datetime.fromisoformat(str(payload["end_time"])) if payload.get("end_time") else None),

--- a/polylogue/storage/store.py
+++ b/polylogue/storage/store.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import hashlib
+from collections.abc import Mapping
+
+from pydantic import BaseModel
 
 from polylogue.lib.json import dumps as json_dumps
 from polylogue.storage.store_constants import (
@@ -35,10 +38,12 @@ from polylogue.storage.store_runtime_raw_records import (
 from polylogue.types import AttachmentId, ConversationId, MessageId
 
 
-def _json_or_none(value: dict[str, object] | None) -> str | None:
+def _json_or_none(value: BaseModel | Mapping[str, object] | None) -> str | None:
     if value is None:
         return None
-    return json_dumps(value)
+    if isinstance(value, BaseModel):
+        return json_dumps(value.model_dump(mode="json"))
+    return json_dumps(dict(value))
 
 
 def _json_array_or_none(value: tuple[str, ...] | list[str] | None) -> str | None:

--- a/polylogue/storage/store_product_aggregate_records.py
+++ b/polylogue/storage/store_product_aggregate_records.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from pydantic import BaseModel, field_validator
+
+from polylogue.archive_product_models import DaySessionSummaryPayload
 
 from .store_constants import SESSION_PRODUCT_MATERIALIZER_VERSION
 
@@ -46,7 +46,7 @@ class DaySessionSummaryRecord(BaseModel):
     total_words: int = 0
     work_event_breakdown: dict[str, int]
     repos_active: tuple[str, ...] = ()
-    payload: dict[str, Any]
+    payload: DaySessionSummaryPayload
     search_text: str
 
     @field_validator("day", "provider_name", "materialized_at", "search_text")

--- a/polylogue/storage/store_product_session_records.py
+++ b/polylogue/storage/store_product_session_records.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from pydantic import BaseModel, field_validator
 
+from polylogue.archive_product_models import (
+    SessionEnrichmentPayload,
+    SessionEvidencePayload,
+    SessionInferencePayload,
+    WorkThreadPayload,
+)
 from polylogue.types import ConversationId
 
 from .store_constants import (
@@ -45,12 +49,12 @@ class SessionProfileRecord(BaseModel):
     engaged_duration_ms: int = 0
     wall_duration_ms: int = 0
     cost_is_estimated: bool = False
-    evidence_payload: dict[str, Any]
-    inference_payload: dict[str, Any]
+    evidence_payload: SessionEvidencePayload
+    inference_payload: SessionInferencePayload
     search_text: str
     evidence_search_text: str
     inference_search_text: str
-    enrichment_payload: dict[str, Any]
+    enrichment_payload: SessionEnrichmentPayload
     enrichment_search_text: str
     enrichment_version: int = SESSION_ENRICHMENT_VERSION
     enrichment_family: str = SESSION_ENRICHMENT_FAMILY
@@ -91,7 +95,7 @@ class WorkThreadRecord(BaseModel):
     total_cost_usd: float = 0.0
     wall_duration_ms: int = 0
     work_event_breakdown: dict[str, int] | None = None
-    payload: dict[str, Any]
+    payload: WorkThreadPayload
     search_text: str
 
     @field_validator("thread_id", "root_id", "materialized_at", "search_text")

--- a/polylogue/storage/store_product_timeline_records.py
+++ b/polylogue/storage/store_product_timeline_records.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from pydantic import BaseModel, field_validator
 
+from polylogue.archive_product_models import (
+    SessionPhaseEvidencePayload,
+    SessionPhaseInferencePayload,
+    WorkEventEvidencePayload,
+    WorkEventInferencePayload,
+)
 from polylogue.types import ConversationId
 
 from .store_constants import (
@@ -35,8 +39,8 @@ class SessionWorkEventRecord(BaseModel):
     summary: str
     file_paths: tuple[str, ...] = ()
     tools_used: tuple[str, ...] = ()
-    evidence_payload: dict[str, Any]
-    inference_payload: dict[str, Any]
+    evidence_payload: WorkEventEvidencePayload
+    inference_payload: WorkEventInferencePayload
     search_text: str
     inference_version: int = SESSION_INFERENCE_VERSION
     inference_family: str = SESSION_INFERENCE_FAMILY
@@ -78,8 +82,8 @@ class SessionPhaseRecord(BaseModel):
     evidence_reasons: tuple[str, ...] = ()
     tool_counts: dict[str, int]
     word_count: int = 0
-    evidence_payload: dict[str, Any]
-    inference_payload: dict[str, Any]
+    evidence_payload: SessionPhaseEvidencePayload
+    inference_payload: SessionPhaseInferencePayload
     search_text: str
     inference_version: int = SESSION_INFERENCE_VERSION
     inference_family: str = SESSION_INFERENCE_FAMILY

--- a/tests/unit/core/test_facade_api.py
+++ b/tests/unit/core/test_facade_api.py
@@ -353,7 +353,7 @@ class TestPolylogueArchiveProducts:
         assert enrichments[0].enrichment.confidence >= 0.0
         assert any(item.conversation_id == "conv-root" for item in phases)
         assert len(threads) == 1
-        assert threads[0].thread["session_count"] == 2
+        assert threads[0].thread.session_count == 2
 
         tag_rollups = await archive.list_session_tag_rollup_products(SessionTagRollupQuery(provider="claude-code"))
         day_summaries = await archive.list_day_session_summary_products(
@@ -365,9 +365,9 @@ class TestPolylogueArchiveProducts:
 
         assert any(item.tag == "provider:claude-code" for item in tag_rollups)
         assert len(day_summaries) == 1
-        assert day_summaries[0].summary["session_count"] == 2
+        assert day_summaries[0].summary.session_count == 2
         assert len(week_summaries) == 1
-        assert week_summaries[0].summary["session_count"] == 2
+        assert week_summaries[0].summary.session_count == 2
 
 
 class TestPolylogueListConversations:

--- a/tests/unit/core/test_repo_identity.py
+++ b/tests/unit/core/test_repo_identity.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 
+from polylogue.archive_product_models import DaySessionSummaryPayload
 from polylogue.archive_product_summaries import aggregate_day_session_summary_products
 from polylogue.lib.action_events import ActionEvent
 from polylogue.lib.attribution import extract_attribution, extract_attribution_from_action_events
@@ -349,10 +350,10 @@ def test_day_summary_and_aggregate_products_preserve_repo_names() -> None:
                 materialized_at="2026-03-24T10:10:00+00:00",
                 work_event_breakdown={},
                 repos_active=("polylogue",),
-                payload=summary.to_dict(),
+                payload=DaySessionSummaryPayload.model_validate(summary.to_dict()),
                 search_text="claude-code",
             )
         ]
     )[0]
 
-    assert product.summary["repos_active"] == ["polylogue"]
+    assert product.summary.repos_active == ("polylogue",)

--- a/tests/unit/mcp/test_tool_contracts.py
+++ b/tests/unit/mcp/test_tool_contracts.py
@@ -9,6 +9,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from polylogue.archive_product_models import (
+    DaySessionSummaryPayload,
+    WeekSessionSummaryPayload,
+    WorkThreadPayload,
+)
 from polylogue.archive_products import (
     ArchiveEnrichmentProvenance,
     ArchiveInferenceProvenance,
@@ -447,7 +452,7 @@ class TestProductTools:
             root_id="conv-1",
             dominant_repo="polylogue",
             provenance=_provenance(),
-            thread={"session_count": 2},
+            thread=WorkThreadPayload(session_count=2),
         )
         tag_rollup = SessionTagRollupProduct(
             tag="provider:claude-code",
@@ -461,12 +466,12 @@ class TestProductTools:
         day_summary = DaySessionSummaryProduct(
             date="2026-03-24",
             provenance=_provenance(),
-            summary={"session_count": 1, "total_messages": 2},
+            summary=DaySessionSummaryPayload(date="2026-03-24", session_count=1, total_messages=2),
         )
         week_summary = WeekSessionSummaryProduct(
             iso_week="2026-W13",
             provenance=_provenance(),
-            summary={"session_count": 1, "total_messages": 2, "day_summaries": []},
+            summary=WeekSessionSummaryPayload(iso_week="2026-W13", session_count=1, total_messages=2),
         )
         analytics = ProviderAnalyticsProduct(
             provider_name="claude-code",

--- a/tests/unit/pipeline/test_ingest_batch.py
+++ b/tests/unit/pipeline/test_ingest_batch.py
@@ -39,6 +39,7 @@ from polylogue.pipeline.services.ingest_worker import (
     _make_ref_id,
 )
 from polylogue.storage.backends.connection import open_connection
+from polylogue.storage.session_product_refresh import SessionProductRefreshChunkObservation
 from polylogue.storage.state_views import RawConversationStateUpdate
 from polylogue.types import AttachmentId, ContentBlockType, ContentHash, ConversationId, MessageId
 
@@ -489,18 +490,20 @@ async def test_refresh_session_products_bulk_dedupes_related_refreshes(
             },
             thread_root_ids={"root-a", "root-b"},
             chunk_observations=[
-                {
-                    "conversation_count": 3,
-                    "hydrated_count": 3,
-                    "profiles_written": 3,
-                    "work_events_written": 0,
-                    "phases_written": 0,
-                    "load_ms": 12.5,
-                    "hydrate_ms": 3.1,
-                    "build_ms": 9.9,
-                    "write_ms": 7.7,
-                    "total_ms": 33.2,
-                },
+                SessionProductRefreshChunkObservation(
+                    conversation_count=3,
+                    estimated_message_count=3,
+                    max_estimated_conversation_messages=1,
+                    hydrated_count=3,
+                    profiles_written=3,
+                    work_events_written=0,
+                    phases_written=0,
+                    load_ms=12.5,
+                    hydrate_ms=3.1,
+                    build_ms=9.9,
+                    write_ms=7.7,
+                    total_ms=33.2,
+                ),
             ],
         )
 

--- a/tests/unit/sources/test_compaction.py
+++ b/tests/unit/sources/test_compaction.py
@@ -466,8 +466,8 @@ class TestProfileCompactionCounting:
             compaction_count=3,
         )
         evidence = profile_evidence_payload(profile)
-        assert evidence["compaction_count"] == 3
-        assert evidence["has_compaction"] is True
+        assert evidence.compaction_count == 3
+        assert evidence.has_compaction is True
 
     def test_profile_evidence_payload_zero_compaction(self) -> None:
         from polylogue.lib.session_profile_models import SessionProfile
@@ -498,5 +498,5 @@ class TestProfileCompactionCounting:
             phases=(),
         )
         evidence = profile_evidence_payload(profile)
-        assert evidence["compaction_count"] == 0
-        assert evidence["has_compaction"] is False
+        assert evidence.compaction_count == 0
+        assert evidence.has_compaction is False

--- a/tests/unit/storage/test_session_product_profiles.py
+++ b/tests/unit/storage/test_session_product_profiles.py
@@ -69,19 +69,19 @@ def test_session_enrichment_payload_reuses_text_band_outputs() -> None:
 
     payload = session_enrichment_payload(profile, analysis)
 
-    assert payload["intent_summary"] == user_turn_texts(analysis)[0]
-    assert payload["outcome_summary"] == assistant_turn_texts(analysis)[-1]
-    assert payload["blockers"] == list(blocker_texts(analysis))
-    assert payload["input_band_summary"] == {
+    assert payload.intent_summary == user_turn_texts(analysis)[0]
+    assert payload.outcome_summary == assistant_turn_texts(analysis)[-1]
+    assert payload.blockers == blocker_texts(analysis)
+    assert payload.input_band_summary == {
         "user_turns": 1,
         "assistant_turns": 1,
         "action_events": 1,
         "touched_paths": 1,
         "repo_names": 1,
     }
-    support_signals = payload["support_signals"]
-    assert isinstance(support_signals, list)
-    assert tuple(support_signals) == (
+    support_signals = payload.support_signals
+    assert isinstance(support_signals, tuple)
+    assert support_signals == (
         "user_turns",
         "action_events",
         "touched_paths",

--- a/tests/unit/storage/test_session_product_refresh.py
+++ b/tests/unit/storage/test_session_product_refresh.py
@@ -14,8 +14,8 @@ from polylogue.storage.session_product_refresh import (
 from tests.infra.storage_records import make_conversation, make_message, store_records
 
 
-def _chunk_metric(chunk_observation: dict[str, object], key: str) -> float:
-    value = chunk_observation[key]
+def _chunk_metric(chunk_observation: object, key: str) -> float:
+    value = getattr(chunk_observation, key)
     assert isinstance(value, int | float)
     return float(value)
 
@@ -133,10 +133,10 @@ async def test_apply_session_product_conversation_updates_async_uses_small_defau
 
     assert update.counts["profiles"] == 11
     assert len(update.chunk_observations) == 2
-    assert update.chunk_observations[0]["conversation_count"] == 10
-    assert update.chunk_observations[0]["estimated_message_count"] == 10
-    assert update.chunk_observations[1]["conversation_count"] == 1
-    assert update.chunk_observations[1]["estimated_message_count"] == 1
+    assert update.chunk_observations[0].conversation_count == 10
+    assert update.chunk_observations[0].estimated_message_count == 10
+    assert update.chunk_observations[1].conversation_count == 1
+    assert update.chunk_observations[1].estimated_message_count == 1
 
 
 @pytest.mark.asyncio
@@ -190,10 +190,10 @@ async def test_apply_session_product_conversation_updates_async_splits_large_mes
 
     assert update.counts["profiles"] == 3
     assert len(update.chunk_observations) == 2
-    assert update.chunk_observations[0]["conversation_count"] == 1
-    assert update.chunk_observations[0]["estimated_message_count"] == 4_000
-    assert update.chunk_observations[1]["conversation_count"] == 2
-    assert update.chunk_observations[1]["estimated_message_count"] == 4_100
+    assert update.chunk_observations[0].conversation_count == 1
+    assert update.chunk_observations[0].estimated_message_count == 4_000
+    assert update.chunk_observations[1].conversation_count == 2
+    assert update.chunk_observations[1].estimated_message_count == 4_100
 
 
 @pytest.mark.asyncio

--- a/tests/unit/storage/test_session_product_timeline_rows.py
+++ b/tests/unit/storage/test_session_product_timeline_rows.py
@@ -86,7 +86,7 @@ def test_session_timeline_row_builders_roundtrip_work_events_and_phases() -> Non
     phase = hydrate_session_phase(phase_records[0])
 
     assert work_event.summary == work_event_records[0].summary
-    assert work_event_records[0].inference_payload["summary"] == work_event.summary
+    assert work_event_records[0].inference_payload.summary == work_event.summary
     assert work_event.kind.value == work_event_records[0].kind
     assert work_event_records[0].search_text
 


### PR DESCRIPTION
Ref #225

## Summary
- move session-product payload surfaces onto shared typed models and direct query-model registry wiring
- rewrite the session-product materialization runtime around typed batch, bundle, and refresh-observation contracts
- collapse duplicated session-product sync/async write assembly and tighten provider-day aggregate refresh on top of the unified writer seam

## Problem
The session-product layer was still split across path-dependent seams: archive product payloads were drifting between dict-shaped records and model-backed products, product registry dispatch still relied on dynamic query resolution, refresh/rebuild used tuple- and dict-shaped runtime plumbing, and the async writer/query modules were cloning the sync storage layer’s insert assembly. That left the storage/product runtime technically type-checked but still ambiguous and duplicated at the exact points where the archive materializes durable products.

## Solution
- extract shared archive product payload/base models into `polylogue/archive_product_models.py` and propagate those typed payloads through archive products, mappers, records, writers, and affected tests
- rewrite `polylogue/products/registry.py` to use direct query-model references, immutable descriptor tuples, and typed nested field access, then adapt the CLI, MCP, and scenario surfaces to that contract
- rebuild `polylogue/storage/session_product_rebuild.py` and `polylogue/storage/session_product_refresh.py` around `SessionProductArchiveBatch`, `SessionProductRecordBundle`, and `SessionProductRefreshChunkObservation`, and update `polylogue/pipeline/services/ingest_batch.py` to consume that typed refresh telemetry instead of dict-key probing
- extract shared insert-column/value builders into `polylogue/storage/session_product_storage.py`, route the async profile/timeline/thread/summary writers through those helpers, and simplify `polylogue/storage/session_product_aggregates.py` so sync and async provider-day refresh paths apply the same prepared aggregate writes
- absorb the direct fallout in affected tests, including the small compaction assertion update revealed by the repo-wide verify pass

## Verification
- `ruff check polylogue/storage/session_product_rebuild.py polylogue/storage/session_product_refresh.py polylogue/pipeline/services/ingest_batch.py tests/unit/storage/test_session_product_refresh.py tests/unit/pipeline/test_ingest_batch.py`
- `python -m mypy polylogue/storage/session_product_rebuild.py polylogue/storage/session_product_refresh.py polylogue/pipeline/services/ingest_batch.py tests/unit/storage/test_session_product_refresh.py tests/unit/pipeline/test_ingest_batch.py tests/unit/pipeline/test_run_sources.py tests/unit/storage/test_product_materialization_laws.py tests/unit/cli/test_products.py tests/unit/core/test_facade_api.py tests/unit/cli/test_check.py tests/unit/storage/test_backend.py tests/unit/sources/test_compaction.py`
- `pytest -q tests/unit/storage/test_session_product_refresh.py tests/unit/pipeline/test_ingest_batch.py tests/unit/pipeline/test_run_sources.py`
- `pytest -q tests/unit/storage/test_product_materialization_laws.py tests/unit/cli/test_products.py tests/unit/core/test_facade_api.py tests/unit/cli/test_check.py tests/unit/storage/test_backend.py tests/unit/sources/test_compaction.py`
- `devtools verify`
