### PR TITLE
refactor: unify CLI and MCP surface payload contracts

### DIFF
--- a/polylogue/cli/machine_errors.py
+++ b/polylogue/cli/machine_errors.py
@@ -1,17 +1,14 @@
-"""Machine-consumable CLI error and success envelopes.
-
-When ``--json`` is passed, all CLI output — including failures — must be
-valid JSON on stdout.  This module provides the stable envelope shapes
-and a top-level exception handler that Click's default error path cannot
-satisfy (Click writes plain text to stderr before command logic runs).
-"""
+"""Machine-consumable CLI error and success envelopes."""
 
 from __future__ import annotations
 
-import json
 import sys
-from dataclasses import dataclass, field
-from typing import Any
+from collections.abc import Mapping
+
+from polylogue.surface_payloads import (
+    MachineErrorPayload,
+    MachineSuccessPayload,
+)
 
 # ---------------------------------------------------------------------------
 # Error codes
@@ -25,48 +22,22 @@ UNSUPPORTED_ENVIRONMENT = "unsupported_environment"
 NO_RESULTS = "no_results"
 
 
-# ---------------------------------------------------------------------------
-# Envelope dataclasses
-# ---------------------------------------------------------------------------
+class MachineError(MachineErrorPayload):
+    """CLI-visible machine-error envelope."""
 
 
-@dataclass(frozen=True, slots=True)
-class MachineError:
-    """Structured error envelope emitted when ``--json`` is active."""
-
-    code: str
-    message: str
-    command: list[str] = field(default_factory=list)
-    details: dict[str, Any] = field(default_factory=dict)
-
-    def to_dict(self) -> dict[str, Any]:
-        out: dict[str, Any] = {
-            "status": "error",
-            "code": self.code,
-            "message": self.message,
-        }
-        if self.command:
-            out["command"] = self.command
-        if self.details:
-            out["details"] = self.details
-        return out
-
-    def emit(self, *, exit_code: int = 1) -> None:
-        """Write JSON to stdout and exit."""
-        sys.stdout.write(json.dumps(self.to_dict(), indent=2))
-        sys.stdout.write("\n")
-        sys.stdout.flush()
-        raise SystemExit(exit_code)
+class MachineSuccess(MachineSuccessPayload):
+    """CLI-visible machine-success envelope."""
 
 
-@dataclass(frozen=True, slots=True)
-class MachineSuccess:
-    """Structured success envelope."""
-
-    result: dict[str, Any] = field(default_factory=dict)
-
-    def to_dict(self) -> dict[str, Any]:
-        return {"status": "ok", "result": self.result}
+def _normalize_result_payload(
+    result: Mapping[str, object] | MachineSuccessPayload | None,
+) -> dict[str, object]:
+    if result is None:
+        return {}
+    if isinstance(result, MachineSuccessPayload):
+        return result.result
+    return {str(key): value for key, value in result.items()}
 
 
 # ---------------------------------------------------------------------------
@@ -80,13 +51,13 @@ def error_invalid_arguments(
     command: list[str] | None = None,
     option: str | None = None,
 ) -> MachineError:
-    details: dict[str, Any] = {}
+    details: dict[str, object] = {}
     if option:
         details["option"] = option
     return MachineError(
         code=INVALID_ARGUMENTS,
         message=message,
-        command=command or [],
+        command=tuple(command or ()),
         details=details,
     )
 
@@ -97,13 +68,13 @@ def error_invalid_path(
     command: list[str] | None = None,
     path: str | None = None,
 ) -> MachineError:
-    details: dict[str, Any] = {}
+    details: dict[str, object] = {}
     if path:
         details["path"] = path
     return MachineError(
         code=INVALID_PATH,
         message=message,
-        command=command or [],
+        command=tuple(command or ()),
         details=details,
     )
 
@@ -114,13 +85,13 @@ def error_runtime(
     command: list[str] | None = None,
     exception_type: str | None = None,
 ) -> MachineError:
-    details: dict[str, Any] = {}
+    details: dict[str, object] = {}
     if exception_type:
         details["exception_type"] = exception_type
     return MachineError(
         code=RUNTIME_ERROR,
         message=message,
-        command=command or [],
+        command=tuple(command or ()),
         details=details,
     )
 
@@ -131,13 +102,13 @@ def error_dependency_missing(
     command: list[str] | None = None,
     dependency: str | None = None,
 ) -> MachineError:
-    details: dict[str, Any] = {}
+    details: dict[str, object] = {}
     if dependency:
         details["dependency"] = dependency
     return MachineError(
         code=DEPENDENCY_MISSING,
         message=message,
-        command=command or [],
+        command=tuple(command or ()),
         details=details,
     )
 
@@ -150,7 +121,7 @@ def error_unsupported_environment(
     return MachineError(
         code=UNSUPPORTED_ENVIRONMENT,
         message=message,
-        command=command or [],
+        command=tuple(command or ()),
     )
 
 
@@ -160,26 +131,24 @@ def error_no_results(
     command: list[str] | None = None,
     filters: list[str] | None = None,
 ) -> MachineError:
-    details: dict[str, Any] = {}
+    details: dict[str, object] = {}
     if filters:
-        details["filters"] = filters
+        details["filters"] = list(filters)
     return MachineError(
         code=NO_RESULTS,
         message=message,
-        command=command or [],
+        command=tuple(command or ()),
         details=details,
     )
 
 
-def success(result: dict[str, Any] | None = None) -> MachineSuccess:
-    return MachineSuccess(result=result or {})
+def success(result: Mapping[str, object] | MachineSuccess | None = None) -> MachineSuccess:
+    return MachineSuccess(result=_normalize_result_payload(result))
 
 
-def emit_success(result: dict[str, Any] | None = None) -> None:
-    """Write a ``{"status": "ok", "result": …}`` envelope to stdout."""
-    import json as _json
-
-    sys.stdout.write(_json.dumps(success(result).to_dict(), indent=2))
+def emit_success(result: Mapping[str, object] | MachineSuccess | None = None) -> None:
+    """Write a ``{\"status\": \"ok\", \"result\": …}`` envelope to stdout."""
+    sys.stdout.write(success(result).to_json(exclude_none=True))
     sys.stdout.write("\n")
     sys.stdout.flush()
 

--- a/polylogue/cli/products_rendering.py
+++ b/polylogue/cli/products_rendering.py
@@ -7,12 +7,14 @@ the ``summarize_archive_debt`` helper.
 
 from __future__ import annotations
 
+from pydantic import BaseModel
+
 from polylogue.cli.machine_errors import emit_success
 from polylogue.products.registry import render_product_items
 
 
 def model_payload(item: object) -> object:
-    return item.model_dump(mode="json") if hasattr(item, "model_dump") else item
+    return item.model_dump(mode="json") if isinstance(item, BaseModel) else item
 
 
 def emit_product_list(*, key: str, items: list[object]) -> None:

--- a/polylogue/cli/query.py
+++ b/polylogue/cli/query.py
@@ -16,6 +16,8 @@ from polylogue.cli.root_request import RootModeRequest
 from polylogue.cli.types import AppEnv
 from polylogue.lib.query_spec import ConversationQuerySpec, QuerySpecError
 from polylogue.logging import get_logger
+from polylogue.schemas.json_types import JSONDocument
+from polylogue.surface_payloads import ConversationListRowPayload
 from polylogue.sync_bridge import run_coroutine_sync
 
 logger = get_logger(__name__)
@@ -90,16 +92,11 @@ def result_date(result: Conversation | ConversationSummary) -> datetime | None:
     return None
 
 
-def summary_to_dict(summary: ConversationSummary, message_count: int) -> dict[str, object]:
-    return {
-        "id": str(summary.id),
-        "provider": str(summary.provider),
-        "title": summary.display_title,
-        "date": summary.display_date.isoformat() if summary.display_date else None,
-        "tags": summary.tags,
-        "summary": summary.summary,
-        "messages": message_count,
-    }
+def summary_to_dict(summary: ConversationSummary, message_count: int) -> JSONDocument:
+    return ConversationListRowPayload.from_summary(
+        summary,
+        message_count=message_count,
+    ).selected()
 
 
 # ---------------------------------------------------------------------------

--- a/polylogue/cli/query_output.py
+++ b/polylogue/cli/query_output.py
@@ -35,6 +35,8 @@ from polylogue.cli.query_stats import (
 )
 from polylogue.logging import get_logger
 from polylogue.rendering.formatting import format_conversation
+from polylogue.schemas.json_types import JSONDocument
+from polylogue.surface_payloads import ConversationListRowPayload
 
 logger = get_logger(__name__)
 
@@ -268,16 +270,11 @@ def open_result(
 # ---------------------------------------------------------------------------
 
 
-def summary_to_dict(summary: ConversationSummary, message_count: int) -> dict[str, object]:
-    return {
-        "id": str(summary.id),
-        "provider": str(summary.provider),
-        "title": summary.display_title,
-        "date": summary.display_date.isoformat() if summary.display_date else None,
-        "tags": summary.tags,
-        "summary": summary.summary,
-        "messages": message_count,
-    }
+def summary_to_dict(summary: ConversationSummary, message_count: int) -> JSONDocument:
+    return ConversationListRowPayload.from_summary(
+        summary,
+        message_count=message_count,
+    ).selected()
 
 
 def format_summary_list(

--- a/polylogue/mcp/payloads.py
+++ b/polylogue/mcp/payloads.py
@@ -2,113 +2,61 @@
 
 from __future__ import annotations
 
-from datetime import datetime
-from typing import Any
+from typing import TYPE_CHECKING, Generic, TypeVar
 
-from pydantic import BaseModel, ConfigDict, RootModel
+from pydantic import RootModel
 
-from polylogue.lib.models import Conversation, ConversationSummary
+from polylogue.surface_payloads import (
+    ConversationDetailPayload as MCPConversationDetailPayload,
+)
+from polylogue.surface_payloads import (
+    ConversationMessagePayload as MCPMessagePayload,
+)
+from polylogue.surface_payloads import (
+    ConversationSummaryPayload as MCPConversationSummaryPayload,
+)
+from polylogue.surface_payloads import (
+    SurfacePayloadModel,
+    model_json_document,
+    normalize_role,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from polylogue.health import HealthCheck, HealthReport
+    from polylogue.lib.models import Conversation
+    from polylogue.lib.stats import ArchiveStats
+
+TRoot = TypeVar("TRoot")
 
 
-def normalize_role(role: object) -> str:
-    if not role:
-        return "unknown"
-    if hasattr(role, "value"):
-        role = role.value
-    return str(role)
-
-
-class MCPPayload(BaseModel):
-    """Base model for JSON payloads returned by MCP surfaces."""
-
-    model_config = ConfigDict(extra="forbid", frozen=True)
-
-    def to_json(self, *, exclude_none: bool = False) -> str:
-        return self.model_dump_json(indent=2, exclude_none=exclude_none)
-
-
-class MCPRootPayload(RootModel[Any]):
+class MCPRootPayload(RootModel[TRoot], Generic[TRoot]):
     """Root-model variant for list/map payloads."""
 
     def to_json(self, *, exclude_none: bool = False) -> str:
         return self.model_dump_json(indent=2, exclude_none=exclude_none)
 
 
-class MCPErrorPayload(MCPPayload):
+class MCPErrorPayload(SurfacePayloadModel):
     error: str
     tool: str | None = None
     conversation_id: str | None = None
 
 
-class MCPMessagePayload(MCPPayload):
-    id: str
-    role: str
-    text: str
-    timestamp: datetime | None = None
-
-    @classmethod
-    def from_message(cls, message: Any) -> MCPMessagePayload:
-        return cls(
-            id=str(message.id),
-            role=normalize_role(message.role),
-            text=message.text or "",
-            timestamp=message.timestamp,
-        )
-
-
-class MCPConversationSummaryPayload(MCPPayload):
-    id: str
-    provider: str
-    title: str
-    message_count: int
-    created_at: datetime | None = None
-    updated_at: datetime | None = None
-
-    @classmethod
-    def from_conversation(cls, conversation: Conversation) -> MCPConversationSummaryPayload:
-        return cls(
-            id=str(conversation.id),
-            provider=conversation.provider,
-            title=conversation.display_title,
-            message_count=len(conversation.messages),
-            created_at=conversation.created_at,
-            updated_at=conversation.updated_at,
-        )
-
-    @classmethod
-    def from_summary(
-        cls,
-        summary: ConversationSummary,
-        *,
-        message_count: int | None = None,
-    ) -> MCPConversationSummaryPayload:
-        return cls(
-            id=str(summary.id),
-            provider=summary.provider,
-            title=summary.display_title,
-            message_count=summary.message_count or 0 if message_count is None else message_count,
-            created_at=summary.created_at,
-            updated_at=summary.updated_at,
-        )
-
-
-class MCPConversationDetailPayload(MCPConversationSummaryPayload):
-    messages: list[MCPMessagePayload]
-
-    @classmethod
-    def from_conversation(cls, conversation: Conversation) -> MCPConversationDetailPayload:
-        summary = MCPConversationSummaryPayload.from_conversation(conversation)
-        return cls(
-            **summary.model_dump(),
-            messages=[MCPMessagePayload.from_message(msg) for msg in conversation.messages],
-        )
-
-
-class MCPConversationSummaryListPayload(MCPRootPayload):
+class MCPConversationSummaryListPayload(MCPRootPayload[list[MCPConversationSummaryPayload]]):
     root: list[MCPConversationSummaryPayload]
 
 
-class MCPArchiveStatsPayload(MCPPayload):
+def conversation_summary_list_payload(
+    conversations: Sequence[Conversation],
+) -> MCPConversationSummaryListPayload:
+    return MCPConversationSummaryListPayload(
+        root=[MCPConversationSummaryPayload.from_conversation(conv) for conv in conversations]
+    )
+
+
+class MCPArchiveStatsPayload(SurfacePayloadModel):
     total_conversations: int
     total_messages: int
     providers: dict[str, int]
@@ -128,7 +76,7 @@ class MCPArchiveStatsPayload(MCPPayload):
     @classmethod
     def from_archive_stats(
         cls,
-        archive_stats: Any,
+        archive_stats: ArchiveStats,
         *,
         include_embedded: bool,
         include_db_size: bool,
@@ -164,7 +112,7 @@ class MCPArchiveStatsPayload(MCPPayload):
         )
 
 
-class MCPMutationStatusPayload(MCPPayload):
+class MCPMutationStatusPayload(SurfacePayloadModel):
     status: str
     conversation_id: str | None = None
     tag: str | None = None
@@ -174,53 +122,56 @@ class MCPMutationStatusPayload(MCPPayload):
     conversation_count: int | None = None
 
 
-class MCPTagCountsPayload(MCPRootPayload):
+class MCPTagCountsPayload(MCPRootPayload[dict[str, int]]):
     root: dict[str, int]
 
 
-class MCPMetadataPayload(MCPRootPayload):
-    root: dict[str, Any]
+class MCPMetadataPayload(MCPRootPayload[dict[str, object]]):
+    root: dict[str, object]
 
 
-class MCPStatsByPayload(MCPRootPayload):
+class MCPStatsByPayload(MCPRootPayload[dict[str, int]]):
     root: dict[str, int]
 
 
-class MCPHealthCheckPayload(MCPPayload):
+class MCPHealthCheckPayload(SurfacePayloadModel):
     name: str
     status: str
     count: int | None = None
     detail: str | None = None
 
     @classmethod
-    def from_check(cls, check: Any, *, include_counts: bool, include_detail: bool) -> MCPHealthCheckPayload:
+    def from_check(
+        cls,
+        check: HealthCheck,
+        *,
+        include_counts: bool,
+        include_detail: bool,
+    ) -> MCPHealthCheckPayload:
         return cls(
             name=check.name,
-            status=check.status.value if hasattr(check.status, "value") else str(check.status),
+            status=check.status.value,
             count=check.count if include_counts else None,
             detail=check.detail if include_detail else None,
         )
 
 
-def _extract_health_source(report: Any) -> str | None:
-    provenance = getattr(report, "provenance", None)
-    if provenance is None:
+def _extract_health_source(report: HealthReport) -> str | None:
+    provenance = report.provenance
+    if provenance is None or provenance.source is None:
         return None
-    source = getattr(provenance, "source", None)
-    if source is None:
-        return None
-    return getattr(source, "value", str(source))
+    return provenance.source
 
 
-class MCPHealthReportPayload(MCPPayload):
+class MCPHealthReportPayload(SurfacePayloadModel):
     checks: list[MCPHealthCheckPayload]
-    summary: str
+    summary: str | dict[str, int]
     source: str | None = None
 
     @classmethod
     def from_report(
         cls,
-        report: Any,
+        report: HealthReport,
         *,
         include_counts: bool,
         include_detail: bool,
@@ -251,9 +202,10 @@ __all__ = [
     "MCPMessagePayload",
     "MCPMetadataPayload",
     "MCPRootPayload",
-    "MCPPayload",
     "MCPMutationStatusPayload",
     "MCPStatsByPayload",
     "MCPTagCountsPayload",
+    "conversation_summary_list_payload",
+    "model_json_document",
     "normalize_role",
 ]

--- a/polylogue/mcp/server_product_tools.py
+++ b/polylogue/mcp/server_product_tools.py
@@ -7,7 +7,6 @@ lookups) are registered directly.
 
 from __future__ import annotations
 
-import json
 from typing import TYPE_CHECKING
 
 from polylogue.mcp.payloads import MCPRootPayload
@@ -151,32 +150,33 @@ def register_product_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
 
             summaries = await hooks.get_repo().list_summaries()
             coverage = analyze_coverage(summaries)
-            return json.dumps(
-                {
-                    "total_conversations": coverage.total_conversations,
-                    "total_messages": coverage.total_messages,
-                    "provider_counts": coverage.provider_counts,
-                    "provider_ranges": [
-                        {
-                            "provider": r.provider,
-                            "first_date": r.first_date.isoformat(),
-                            "last_date": r.last_date.isoformat(),
-                            "count": r.count,
-                        }
-                        for r in coverage.provider_ranges
-                    ],
-                    "gaps": [
-                        {
-                            "start_date": g.start_date.isoformat(),
-                            "end_date": g.end_date.isoformat(),
-                            "days": g.days,
-                        }
-                        for g in coverage.gaps
-                    ],
-                    "truncated_sessions": coverage.truncated_sessions,
-                    "date_range": [d.isoformat() if d else None for d in coverage.date_range],
-                },
-                indent=2,
+            return hooks.json_payload(
+                MCPRootPayload(
+                    root={
+                        "total_conversations": coverage.total_conversations,
+                        "total_messages": coverage.total_messages,
+                        "provider_counts": coverage.provider_counts,
+                        "provider_ranges": [
+                            {
+                                "provider": r.provider,
+                                "first_date": r.first_date.isoformat(),
+                                "last_date": r.last_date.isoformat(),
+                                "count": r.count,
+                            }
+                            for r in coverage.provider_ranges
+                        ],
+                        "gaps": [
+                            {
+                                "start_date": g.start_date.isoformat(),
+                                "end_date": g.end_date.isoformat(),
+                                "days": g.days,
+                            }
+                            for g in coverage.gaps
+                        ],
+                        "truncated_sessions": coverage.truncated_sessions,
+                        "date_range": [d.isoformat() if d else None for d in coverage.date_range],
+                    }
+                )
             )
 
         return await hooks.async_safe_call("archive_coverage", run)

--- a/polylogue/mcp/server_resources.py
+++ b/polylogue/mcp/server_resources.py
@@ -7,11 +7,10 @@ from typing import TYPE_CHECKING
 from polylogue.mcp.payloads import (
     MCPArchiveStatsPayload,
     MCPConversationDetailPayload,
-    MCPConversationSummaryListPayload,
-    MCPConversationSummaryPayload,
     MCPErrorPayload,
     MCPHealthReportPayload,
     MCPTagCountsPayload,
+    conversation_summary_list_payload,
 )
 from polylogue.mcp.server_tools import build_query_spec
 
@@ -39,11 +38,7 @@ def register_resources(mcp: FastMCP, hooks: ServerCallbacks) -> None:
     @mcp.resource("polylogue://conversations")
     async def conversations_resource() -> str:
         convs = await build_query_spec().list(hooks.get_repo())
-        return hooks.json_payload(
-            MCPConversationSummaryListPayload(
-                root=[MCPConversationSummaryPayload.from_conversation(conv) for conv in convs]
-            )
-        )
+        return hooks.json_payload(conversation_summary_list_payload(convs))
 
     @mcp.resource("polylogue://conversation/{conv_id}")
     async def conversation_resource(conv_id: str) -> str:

--- a/polylogue/mcp/server_support.py
+++ b/polylogue/mcp/server_support.py
@@ -2,30 +2,41 @@
 
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Protocol, TypeVar, overload
+
+from pydantic import BaseModel
 
 from polylogue.logging import get_logger
 from polylogue.mcp.payloads import MCPErrorPayload
+from polylogue.operations import ArchiveOperations
 from polylogue.services import RuntimeServices, build_runtime_services
+from polylogue.surface_payloads import serialize_surface_payload
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable
+    from polylogue.config import Config
+    from polylogue.storage.repository import ConversationRepository
 
 logger = get_logger(__name__)
 _runtime_services: RuntimeServices | None = None
+TResult = TypeVar("TResult")
+
+
+class JSONPayloadSerializer(Protocol):
+    def __call__(self, payload: BaseModel, *, exclude_none: bool = False) -> str: ...
 
 
 @dataclass(frozen=True)
 class ServerCallbacks:
-    json_payload: Callable[..., str]
-    clamp_limit: Callable[[int | Any], int]
-    safe_call: Callable[[str, Any], str]
-    async_safe_call: Callable[[str, Any], Awaitable[str]]
+    json_payload: JSONPayloadSerializer
+    clamp_limit: Callable[[int | object], int]
+    safe_call: Callable[[str, Callable[[], str]], str]
+    async_safe_call: Callable[[str, Callable[[], Awaitable[str]]], Awaitable[str]]
     error_json: Callable[..., str]
-    get_repo: Callable[[], Any]
-    get_config: Callable[[], Any]
-    get_archive_ops: Callable[[], Any]
+    get_repo: Callable[[], ConversationRepository]
+    get_config: Callable[[], Config]
+    get_archive_ops: Callable[[], ArchiveOperations]
     extract_fenced_code: Callable[[str, str], list[dict[str, str]]]
 
 
@@ -45,38 +56,70 @@ def _extract_fenced_code(text: str, language: str = "") -> list[dict[str, str]]:
     return results
 
 
-def _json_payload(payload: Any, *, exclude_none: bool = False) -> str:
+def _json_payload(payload: BaseModel, *, exclude_none: bool = False) -> str:
     """Serialize a typed MCP payload with canonical JSON formatting."""
-    return str(payload.to_json(exclude_none=exclude_none))
+    return serialize_surface_payload(payload, exclude_none=exclude_none)
 
 
-def _clamp_limit(limit: int | Any) -> int:
+def _clamp_limit(limit: int | object) -> int:
     """Ensure limit is a positive integer, defaulting to 10 on bad input."""
     try:
-        return max(1, int(limit))
+        if isinstance(limit, bool):
+            raise TypeError
+        if isinstance(limit, int):
+            return max(1, limit)
+        if isinstance(limit, float):
+            return max(1, int(limit))
+        if isinstance(limit, str | bytes | bytearray):
+            return max(1, int(limit))
+        return max(1, int(str(limit)))
     except (TypeError, ValueError):
         return 10
 
 
-def _safe_call(fn_name: str, fn: Any) -> str:
+@overload
+def _safe_call(fn_name: str, fn: Callable[[], str]) -> str: ...
+
+
+@overload
+def _safe_call(fn_name: str, fn: Callable[[], None]) -> str: ...
+
+
+@overload
+def _safe_call(fn_name: str, fn: Callable[[], TResult]) -> TResult | str: ...
+
+
+def _safe_call(fn_name: str, fn: Callable[[], TResult]) -> TResult | str:
     """Call fn() and return its result, or a JSON error dict on exception."""
     try:
-        return str(fn())
+        return fn()
     except Exception as exc:
         logger.exception("MCP tool %s failed", fn_name)
         return _json_payload(MCPErrorPayload(error=str(exc), tool=fn_name), exclude_none=True)
 
 
-async def _async_safe_call(fn_name: str, fn: Any) -> str:
+@overload
+async def _async_safe_call(fn_name: str, fn: Callable[[], Awaitable[str]]) -> str: ...
+
+
+@overload
+async def _async_safe_call(fn_name: str, fn: Callable[[], Awaitable[None]]) -> str: ...
+
+
+@overload
+async def _async_safe_call(fn_name: str, fn: Callable[[], Awaitable[TResult]]) -> TResult | str: ...
+
+
+async def _async_safe_call(fn_name: str, fn: Callable[[], Awaitable[TResult]]) -> TResult | str:
     """Async version of _safe_call for async tool handlers."""
     try:
-        return str(await fn())
+        return await fn()
     except Exception as exc:
         logger.exception("MCP tool %s failed", fn_name)
         return _json_payload(MCPErrorPayload(error=str(exc), tool=fn_name), exclude_none=True)
 
 
-def _error_json(message: str, **extra: Any) -> str:
+def _error_json(message: str, **extra: str) -> str:
     """Return a JSON-encoded error dict."""
     return _json_payload(MCPErrorPayload(error=message, **extra), exclude_none=True)
 
@@ -95,12 +138,12 @@ def _get_runtime_services() -> RuntimeServices:
     return _runtime_services
 
 
-def _get_repo() -> Any:
+def _get_repo() -> ConversationRepository:
     """Return the MCP repository from the configured runtime services."""
     return _get_runtime_services().get_repository()
 
 
-def _get_config() -> Any:
+def _get_config() -> Config:
     """Return the MCP config from the configured runtime services."""
     return _get_runtime_services().get_config()
 

--- a/polylogue/mcp/server_tools.py
+++ b/polylogue/mcp/server_tools.py
@@ -2,16 +2,16 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from polylogue.lib.query_spec import ConversationQuerySpec
 from polylogue.mcp.payloads import (
     MCPArchiveStatsPayload,
     MCPConversationDetailPayload,
-    MCPConversationSummaryListPayload,
     MCPConversationSummaryPayload,
     MCPHealthReportPayload,
     MCPStatsByPayload,
+    conversation_summary_list_payload,
 )
 from polylogue.mcp.server_maintenance_tools import register_maintenance_tools
 from polylogue.mcp.server_mutation_tools import register_mutation_tools
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
     from polylogue.mcp.server_support import ServerCallbacks
 
 
-def build_query_spec(**params: Any) -> ConversationQuerySpec:
+def build_query_spec(**params: object) -> ConversationQuerySpec:
     normalized = dict(params)
     if "has_tool_use" in normalized:
         normalized["filter_has_tool_use"] = normalized.pop("has_tool_use")
@@ -73,11 +73,7 @@ def register_query_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
                 min_words=min_words,
             )
             results = await ops.query_conversations(spec)
-            return hooks.json_payload(
-                MCPConversationSummaryListPayload(
-                    root=[MCPConversationSummaryPayload.from_conversation(result) for result in results]
-                )
-            )
+            return hooks.json_payload(conversation_summary_list_payload(results))
 
         return await hooks.async_safe_call("search", run)
 
@@ -125,11 +121,7 @@ def register_query_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
                 min_words=min_words,
             )
             conversations = await ops.query_conversations(spec)
-            return hooks.json_payload(
-                MCPConversationSummaryListPayload(
-                    root=[MCPConversationSummaryPayload.from_conversation(conv) for conv in conversations]
-                )
-            )
+            return hooks.json_payload(conversation_summary_list_payload(conversations))
 
         return await hooks.async_safe_call("list_conversations", run)
 
@@ -181,11 +173,7 @@ def register_read_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
     async def get_session_tree(conversation_id: str) -> str:
         async def run() -> str:
             tree = await hooks.get_repo().get_session_tree(conversation_id)
-            return hooks.json_payload(
-                MCPConversationSummaryListPayload(
-                    root=[MCPConversationSummaryPayload.from_conversation(conv) for conv in tree]
-                )
-            )
+            return hooks.json_payload(conversation_summary_list_payload(tree))
 
         return await hooks.async_safe_call("get_session_tree", run)
 

--- a/polylogue/rendering/formatting.py
+++ b/polylogue/rendering/formatting.py
@@ -16,17 +16,17 @@ from __future__ import annotations
 import csv
 import io
 import json
-from typing import TYPE_CHECKING, Any, TypedDict
+from typing import TYPE_CHECKING
+
+from polylogue.surface_payloads import (
+    ConversationDetailPayload,
+    ConversationListRowPayload,
+    JSONDocument,
+    model_json_document,
+)
 
 if TYPE_CHECKING:
     from polylogue.lib.models import Conversation
-
-
-class ConversationMessagePayload(TypedDict):
-    id: str
-    role: str
-    text: str | None
-    timestamp: str | None
 
 
 def format_conversation(
@@ -62,34 +62,24 @@ def format_conversation(
         return _conv_to_markdown(conv)
 
 
-def _conv_to_dict(conv: Conversation, fields: str | None) -> dict[str, object]:
+def _conv_to_dict(conv: Conversation, fields: str | None) -> JSONDocument:
     """Convert conversation to summary dict (message count, not content).
 
     Used for list-mode output where loading all message text is unnecessary.
     For full-content output, use _conv_to_json() instead.
     """
-    full: dict[str, object] = {
-        "id": str(conv.id),
-        "provider": str(conv.provider),
-        "title": conv.display_title,
-        "date": conv.display_date.isoformat() if conv.display_date else None,
-        "messages": len(conv.messages),
-        "words": sum(m.word_count for m in conv.messages),
-        "tags": conv.tags,
-        "summary": conv.summary,
-    }
-    if not fields:
-        return full
-    selected = [f.strip() for f in fields.split(",")]
-    return {key: value for key, value in full.items() if key in selected}
+    selected = {field.strip() for field in fields.split(",")} if fields else None
+    return ConversationListRowPayload.from_conversation(conv).selected(selected)
 
 
 def _conv_to_json(conv: Conversation, fields: str | None) -> str:
     """Convert a single conversation to full JSON with message content."""
     data = _conv_to_dict(conv, fields)
-    # Override message count with full message content
-    if fields is None or "messages" in (fields or "").split(","):
-        data["messages"] = [_serialize_message(msg) for msg in conv.messages]
+    if fields is None or "messages" in {field.strip() for field in fields.split(",")}:
+        detail_payload = ConversationDetailPayload.from_conversation(conv)
+        data["messages"] = [
+            model_json_document(message_payload, exclude_none=True) for message_payload in detail_payload.messages
+        ]
     return json.dumps(data, indent=2)
 
 
@@ -106,9 +96,11 @@ def _conv_to_yaml(conv: Conversation, fields: str | None) -> str:
     import yaml
 
     data = _conv_to_dict(conv, fields)
-    # For single conversation, also include full message content
-    if fields is None or "messages" in fields.split(","):
-        data["messages"] = [_serialize_message(msg) for msg in conv.messages]
+    if fields is None or "messages" in {field.strip() for field in fields.split(",")}:
+        detail_payload = ConversationDetailPayload.from_conversation(conv)
+        data["messages"] = [
+            model_json_document(message_payload, exclude_none=True) for message_payload in detail_payload.messages
+        ]
 
     return str(yaml.dump(data, default_flow_style=False, allow_unicode=True, sort_keys=False))
 
@@ -173,17 +165,6 @@ def _conv_to_plaintext(conv: Conversation) -> str:
             lines.append("")
 
     return "\n".join(lines).strip()
-
-
-def _serialize_message(message: Any) -> ConversationMessagePayload:
-    timestamp = message.timestamp
-    isoformat = getattr(timestamp, "isoformat", None)
-    return {
-        "id": str(message.id),
-        "role": str(message.role),
-        "text": message.text,
-        "timestamp": isoformat() if callable(isoformat) else None,
-    }
 
 
 def _yaml_safe(value: str) -> str:

--- a/polylogue/surface_payloads.py
+++ b/polylogue/surface_payloads.py
@@ -1,0 +1,246 @@
+"""Shared surface payload models for CLI, MCP, and presentation adapters."""
+
+from __future__ import annotations
+
+import json
+import sys
+from collections.abc import Mapping, Sequence
+from datetime import datetime
+from enum import Enum
+from typing import TYPE_CHECKING, Literal, NotRequired, TypedDict, cast
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from polylogue.schemas.json_types import JSONDocument, JSONValue
+
+if TYPE_CHECKING:
+    from collections.abc import Container
+
+    from polylogue.lib.models import Conversation, ConversationSummary, Message
+
+
+def serialize_surface_payload(payload: BaseModel, *, exclude_none: bool = False) -> str:
+    """Serialize a surface payload model with stable JSON formatting."""
+    return payload.model_dump_json(indent=2, exclude_none=exclude_none)
+
+
+def model_json_document(payload: BaseModel, *, exclude_none: bool = False) -> JSONDocument:
+    """Return a model dump constrained to the shared JSON document type."""
+    return cast(JSONDocument, payload.model_dump(mode="json", exclude_none=exclude_none))
+
+
+class SurfacePayloadModel(BaseModel):
+    """Shared base for immutable JSON payload models exposed by surfaces."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    def to_json(self, *, exclude_none: bool = False) -> str:
+        return serialize_surface_payload(self, exclude_none=exclude_none)
+
+
+class MachineErrorEnvelope(TypedDict):
+    """Serialized machine-error envelope with sparse optional keys."""
+
+    status: Literal["error"]
+    code: str
+    message: str
+    command: NotRequired[list[str]]
+    details: NotRequired[JSONDocument]
+
+
+class MachineSuccessEnvelope(TypedDict):
+    """Serialized machine-success envelope."""
+
+    status: Literal["ok"]
+    result: JSONDocument
+
+
+class MachineErrorPayload(SurfacePayloadModel):
+    """Structured error payload for machine-readable CLI surfaces."""
+
+    status: Literal["error"] = "error"
+    code: str
+    message: str
+    command: Sequence[str] = ()
+    details: Mapping[str, object] = Field(default_factory=dict)
+
+    def to_dict(self) -> MachineErrorEnvelope:
+        payload: MachineErrorEnvelope = {
+            "status": self.status,
+            "code": self.code,
+            "message": self.message,
+        }
+        if self.command:
+            payload["command"] = list(self.command)
+        if self.details:
+            payload["details"] = cast(JSONDocument, dict(self.details))
+        return payload
+
+    def to_json(self, *, exclude_none: bool = False) -> str:
+        del exclude_none
+        return json.dumps(self.to_dict(), indent=2)
+
+    def emit(self, *, exit_code: int = 1) -> None:
+        """Write the payload to stdout and exit."""
+        sys.stdout.write(self.to_json(exclude_none=True))
+        sys.stdout.write("\n")
+        sys.stdout.flush()
+        raise SystemExit(exit_code)
+
+
+class MachineSuccessPayload(SurfacePayloadModel):
+    """Structured success payload for machine-readable CLI surfaces."""
+
+    status: Literal["ok"] = "ok"
+    result: dict[str, object] = Field(default_factory=dict)
+
+    def to_dict(self) -> MachineSuccessEnvelope:
+        return {
+            "status": self.status,
+            "result": cast(JSONDocument, dict(self.result)),
+        }
+
+
+def normalize_role(role: object) -> str:
+    if not role:
+        return "unknown"
+    if isinstance(role, Enum):
+        role = role.value
+    return str(role)
+
+
+class ConversationMessagePayload(SurfacePayloadModel):
+    """Machine-readable message payload shared across CLI and MCP surfaces."""
+
+    id: str
+    role: str
+    text: str
+    timestamp: datetime | None = None
+
+    @classmethod
+    def from_message(cls, message: Message) -> ConversationMessagePayload:
+        return cls(
+            id=str(message.id),
+            role=normalize_role(message.role),
+            text=message.text or "",
+            timestamp=message.timestamp,
+        )
+
+
+class ConversationSummaryPayload(SurfacePayloadModel):
+    """Compact conversation summary payload used by MCP/search surfaces."""
+
+    id: str
+    provider: str
+    title: str
+    message_count: int
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+    @classmethod
+    def from_conversation(cls, conversation: Conversation) -> ConversationSummaryPayload:
+        return cls(
+            id=str(conversation.id),
+            provider=str(conversation.provider),
+            title=conversation.display_title,
+            message_count=len(conversation.messages),
+            created_at=conversation.created_at,
+            updated_at=conversation.updated_at,
+        )
+
+    @classmethod
+    def from_summary(
+        cls,
+        summary: ConversationSummary,
+        *,
+        message_count: int | None = None,
+    ) -> ConversationSummaryPayload:
+        return cls(
+            id=str(summary.id),
+            provider=str(summary.provider),
+            title=summary.display_title,
+            message_count=summary.message_count or 0 if message_count is None else message_count,
+            created_at=summary.created_at,
+            updated_at=summary.updated_at,
+        )
+
+
+class ConversationDetailPayload(ConversationSummaryPayload):
+    """Full conversation detail payload with serialized messages."""
+
+    messages: tuple[ConversationMessagePayload, ...]
+
+    @classmethod
+    def from_conversation(cls, conversation: Conversation) -> ConversationDetailPayload:
+        summary = ConversationSummaryPayload.from_conversation(conversation)
+        return cls(
+            **summary.model_dump(),
+            messages=tuple(ConversationMessagePayload.from_message(msg) for msg in conversation.messages),
+        )
+
+
+class ConversationListRowPayload(SurfacePayloadModel):
+    """Conversation row payload used by CLI list, JSON, and YAML surfaces."""
+
+    id: str
+    provider: str
+    title: str
+    date: str | None = None
+    messages: int
+    tags: tuple[str, ...] = ()
+    summary: str | None = None
+    words: int | None = None
+
+    @classmethod
+    def from_conversation(cls, conversation: Conversation) -> ConversationListRowPayload:
+        return cls(
+            id=str(conversation.id),
+            provider=str(conversation.provider),
+            title=conversation.display_title,
+            date=conversation.display_date.isoformat() if conversation.display_date else None,
+            messages=len(conversation.messages),
+            tags=tuple(conversation.tags),
+            summary=conversation.summary,
+            words=sum(message.word_count for message in conversation.messages),
+        )
+
+    @classmethod
+    def from_summary(
+        cls,
+        summary: ConversationSummary,
+        *,
+        message_count: int,
+    ) -> ConversationListRowPayload:
+        return cls(
+            id=str(summary.id),
+            provider=str(summary.provider),
+            title=summary.display_title,
+            date=summary.display_date.isoformat() if summary.display_date else None,
+            messages=message_count,
+            tags=tuple(summary.tags),
+            summary=summary.summary,
+        )
+
+    def selected(self, fields: Container[str] | None = None) -> JSONDocument:
+        data = model_json_document(self, exclude_none=True)
+        if fields is None:
+            return data
+        return {key: value for key, value in data.items() if key in fields}
+
+
+__all__ = [
+    "ConversationDetailPayload",
+    "ConversationListRowPayload",
+    "ConversationMessagePayload",
+    "ConversationSummaryPayload",
+    "MachineErrorPayload",
+    "MachineErrorEnvelope",
+    "MachineSuccessEnvelope",
+    "MachineSuccessPayload",
+    "SurfacePayloadModel",
+    "JSONDocument",
+    "JSONValue",
+    "model_json_document",
+    "normalize_role",
+    "serialize_surface_payload",
+]

--- a/tests/unit/cli/test_json_envelope_contract.py
+++ b/tests/unit/cli/test_json_envelope_contract.py
@@ -213,4 +213,4 @@ class TestStatusFieldInvariant:
         """Error and success envelopes have distinct status values."""
         err_status = MachineError(code="x", message="y").to_dict()["status"]
         ok_status = success().to_dict()["status"]
-        assert err_status != ok_status
+        assert (err_status, ok_status) == ("error", "ok")

--- a/tests/unit/cli/test_query_exec_laws.py
+++ b/tests/unit/cli/test_query_exec_laws.py
@@ -48,6 +48,7 @@ from polylogue.cli.types import AppEnv
 from polylogue.lib.models import Conversation
 from polylogue.lib.query_spec import ConversationQuerySpec, QuerySpecError
 from polylogue.lib.roles import Role
+from polylogue.schemas.json_types import JSONDocument
 from polylogue.services import build_runtime_services
 from polylogue.storage.store import ContentBlockRecord, ConversationRecord, MessageRecord
 from polylogue.types import ContentBlockType, ContentHash, ConversationId, MessageId, Provider, SemanticBlockType
@@ -109,7 +110,7 @@ def _fields_arg(fields: tuple[str, ...] | None) -> str | None:
     return None if not fields else ",".join(fields)
 
 
-def _structured_rows(case: Any) -> list[dict[str, object]]:
+def _structured_rows(case: Any) -> list[JSONDocument]:
     rows = [summary_to_dict(build_conversation_summary(spec), spec.message_count) for spec in case.summaries]
     if case.selected_fields:
         selected = set(case.selected_fields)


### PR DESCRIPTION
Ref #226

## Summary
- add a shared `surface_payloads` layer for machine envelopes and conversation/list/detail payloads
- route CLI query/list JSON shaping and MCP list/detail payloads through those shared contracts
- tighten MCP server support typing and keep the affected contract tests aligned with the new surface models

## Problem
The CLI and MCP surfaces were still carrying duplicated conversation serialization, machine-envelope assembly, and ad hoc JSON shaping even after the substrate and product layers had been renewed. That left the public surfaces thin in name only: they were still compensating for historical ambiguity with their own parallel payload logic.

## Solution
- add `polylogue/surface_payloads.py` as the shared surface-contract module for machine error/success envelopes plus conversation summary/detail/list payload models
- rebuild `polylogue/cli/machine_errors.py`, `polylogue/cli/query.py`, `polylogue/cli/query_output.py`, and `polylogue/rendering/formatting.py` to consume those shared payload models instead of hand-assembling dicts
- simplify `polylogue/mcp/payloads.py`, `polylogue/mcp/server_tools.py`, `polylogue/mcp/server_resources.py`, and `polylogue/mcp/server_product_tools.py` around the same surface contracts and strengthen `polylogue/mcp/server_support.py` with explicit serializer and safe-call typing
- absorb the direct typing/test fallout in the affected CLI law tests so the new contracts are exercised through the repo baseline

## Verification
- `python -m mypy polylogue/mcp/server_support.py polylogue/surface_payloads.py tests/unit/security/test_mcp_security.py tests/unit/mcp/test_mcp_edge_cases.py tests/unit/cli/test_json_envelope_contract.py tests/unit/cli/test_query_exec_laws.py`
- `pytest -q tests/unit/security/test_mcp_security.py tests/unit/mcp/test_mcp_edge_cases.py tests/unit/cli/test_json_envelope_contract.py tests/unit/cli/test_query_exec_laws.py`
- `devtools verify`
