### PR TITLE
test: renew verification law and probe contracts

### DIFF
--- a/devtools/pipeline_probe.py
+++ b/devtools/pipeline_probe.py
@@ -15,7 +15,7 @@ import tempfile
 from collections.abc import Iterator
 from contextlib import contextmanager, redirect_stdout
 from pathlib import Path
-from typing import Any, cast
+from typing import NotRequired, TypeAlias, TypedDict
 
 from polylogue.config import Config, Source
 from polylogue.paths import blob_store_root, db_path
@@ -31,6 +31,7 @@ from polylogue.storage.backends.connection import (
 from polylogue.storage.backends.queries.raw_state import EFFECTIVE_RAW_PROVIDER_SQL
 from polylogue.storage.blob_store import BlobStore, reset_blob_store
 from polylogue.storage.repository import ConversationRepository
+from polylogue.storage.state_views import RunResult
 from polylogue.storage.store import RawConversationRecord
 from polylogue.types import Provider
 
@@ -53,6 +54,90 @@ _SOURCE_BACKED_PROBE_STAGE_SEQUENCES: dict[str, tuple[str, ...]] = {
     "reprocess": ("acquire", "parse", "materialize", "render", "index"),
     "all": ("acquire", "parse", "materialize", "render", "index"),
 }
+
+JsonScalar: TypeAlias = str | int | float | bool | None
+JsonValue: TypeAlias = JsonScalar | dict[str, "JsonValue"] | list["JsonValue"]
+JsonObject: TypeAlias = dict[str, JsonValue]
+ProbeSummary: TypeAlias = dict[str, object]
+
+
+class RawFanoutEntry(TypedDict):
+    raw_id: str
+    payload_provider: str | None
+    source_name: str | None
+    blob_size_bytes: int
+    conversation_count: int
+    message_count: int
+    parse_error: str | None
+
+
+class PathFingerprint(TypedDict):
+    path: str
+    kind: str
+    sha256: str
+    file_count: int
+    total_bytes: int
+
+
+class StagedSourceEntry(TypedDict):
+    input_path: str
+    staged_path: str
+    kind: str
+    file_count: int
+    bytes: int
+
+
+class SourceInputsSummary(TypedDict):
+    input_count: int
+    staged_entry_count: int
+    staged_file_count: int
+    total_bytes: int
+    entries: list[StagedSourceEntry]
+
+
+class ProbeProvenance(TypedDict):
+    git_commit: str | None
+    worktree_dirty: bool | None
+    manifest_sha256: NotRequired[str]
+    source_input_fingerprints: NotRequired[list[PathFingerprint]]
+    source_inputs_sha256: NotRequired[str]
+
+
+class ArchiveManifest(TypedDict):
+    input_mode: str
+    source_db: str
+    source_blob_root: str
+    seed: int
+    sample_per_provider: int
+    provider_filters: list[str]
+    source_filters: list[str]
+    candidate_count: int
+    missing_blob_count: int
+    available_by_provider: dict[str, int]
+    sampled_by_provider: dict[str, int]
+    records: list[JsonObject]
+
+
+class ArchiveSubsetSampleSummary(TypedDict):
+    selected_count: int
+    copied_records: int
+    copied_blob_bytes: int
+    provider_counts: dict[str, int]
+    source_counts: dict[str, int]
+    sample_per_provider: int
+    candidate_count: int
+    missing_blob_count: int
+    available_by_provider: dict[str, int]
+    sampled_by_provider: dict[str, int]
+
+
+class BudgetReport(TypedDict):
+    ok: bool
+    max_total_ms: float | None
+    observed_total_ms: JsonValue
+    max_peak_rss_mb: float | None
+    observed_peak_rss_mb: JsonValue
+    violations: list[str]
 
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -264,7 +349,7 @@ def _db_row_counts(db_path: Path) -> dict[str, int]:
     return stats
 
 
-def _db_raw_fanout(db_path: Path) -> list[dict[str, Any]]:
+def _db_raw_fanout(db_path: Path) -> list[RawFanoutEntry]:
     if not db_path.exists():
         return []
     with open_connection(db_path) as conn:
@@ -315,7 +400,7 @@ def _sha256_file(path: Path) -> str:
     return digest.hexdigest()
 
 
-def _fingerprint_path(path: Path) -> dict[str, Any]:
+def _fingerprint_path(path: Path) -> PathFingerprint:
     if path.is_file():
         return {
             "path": str(path),
@@ -379,18 +464,16 @@ def _safe_git_worktree_dirty() -> bool | None:
 def _build_probe_provenance(
     *,
     manifest_path: Path | None = None,
-    source_inputs: dict[str, Any] | None = None,
-) -> dict[str, Any]:
-    provenance: dict[str, Any] = {
+    source_inputs: SourceInputsSummary | None = None,
+) -> ProbeProvenance:
+    provenance: ProbeProvenance = {
         "git_commit": _safe_git_commit(),
         "worktree_dirty": _safe_git_worktree_dirty(),
     }
     if manifest_path is not None and manifest_path.exists():
         provenance["manifest_sha256"] = _sha256_file(manifest_path)
     if source_inputs is not None:
-        fingerprints = [
-            _fingerprint_path(Path(str(entry["staged_path"]))) for entry in source_inputs.get("entries", [])
-        ]
+        fingerprints = [_fingerprint_path(Path(entry["staged_path"])) for entry in source_inputs["entries"]]
         provenance["source_input_fingerprints"] = fingerprints
         digest = hashlib.sha256()
         for entry in fingerprints:
@@ -596,14 +679,15 @@ def _source_counts(records: list[RawConversationRecord]) -> dict[str, int]:
     return dict(sorted(counts.items()))
 
 
-def _persist_manifest(manifest: dict[str, Any], destination: Path) -> Path:
+def _persist_manifest(manifest: ArchiveManifest, destination: Path) -> Path:
     destination.parent.mkdir(parents=True, exist_ok=True)
     destination.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     return destination
 
 
-def _load_manifest(manifest_path: Path) -> dict[str, Any]:
-    return cast(dict[str, Any], json.loads(manifest_path.read_text(encoding="utf-8")))
+def _load_manifest(manifest_path: Path) -> ArchiveManifest:
+    manifest: ArchiveManifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    return manifest
 
 
 def _build_archive_manifest(
@@ -614,7 +698,7 @@ def _build_archive_manifest(
     source_filters: list[str],
     sample_per_provider: int,
     seed: int,
-) -> dict[str, Any]:
+) -> ArchiveManifest:
     source_blob_store = BlobStore(source_blob_root)
     candidate_records = _fetch_archive_candidates(
         db_path=source_db,
@@ -689,7 +773,7 @@ def _resolve_archive_manifest(
     source_filters: list[str],
     sample_per_provider: int,
     seed: int,
-) -> dict[str, Any]:
+) -> ArchiveManifest:
     if manifest_in is not None:
         manifest = _load_manifest(manifest_in)
         if source_blob_root is not None:
@@ -712,11 +796,11 @@ def _resolve_archive_manifest(
 
 async def _seed_archive_subset(
     *,
-    manifest: dict[str, Any],
+    manifest: ArchiveManifest,
     repository: ConversationRepository,
     target_blob_store: BlobStore,
-) -> dict[str, Any]:
-    records = [RawConversationRecord.model_validate(record_payload) for record_payload in manifest.get("records", [])]
+) -> ArchiveSubsetSampleSummary:
+    records = [RawConversationRecord.model_validate(record_payload) for record_payload in manifest["records"]]
     source_blob_root = Path(str(manifest["source_blob_root"])).resolve()
     source_blob_store = BlobStore(source_blob_root)
     copied_records = 0
@@ -740,11 +824,11 @@ async def _seed_archive_subset(
         "copied_blob_bytes": copied_blob_bytes,
         "provider_counts": _provider_counts(records),
         "source_counts": _source_counts(records),
-        "sample_per_provider": manifest.get("sample_per_provider"),
-        "candidate_count": manifest.get("candidate_count"),
-        "missing_blob_count": manifest.get("missing_blob_count", 0),
-        "available_by_provider": manifest.get("available_by_provider", {}),
-        "sampled_by_provider": manifest.get("sampled_by_provider", {}),
+        "sample_per_provider": manifest["sample_per_provider"],
+        "candidate_count": manifest["candidate_count"],
+        "missing_blob_count": manifest["missing_blob_count"],
+        "available_by_provider": manifest["available_by_provider"],
+        "sampled_by_provider": manifest["sampled_by_provider"],
     }
 
 
@@ -763,10 +847,11 @@ def _probe_mode(args: argparse.Namespace) -> str:
     return str(getattr(args, "input_mode", "synthetic"))
 
 
-def _load_run_payload(run_path: str | None) -> dict[str, Any]:
+def _load_run_payload(run_path: str | None) -> JsonObject:
     if not run_path:
         return {}
-    return cast(dict[str, Any], json.loads(Path(run_path).read_text(encoding="utf-8")))
+    payload: JsonObject = json.loads(Path(run_path).read_text(encoding="utf-8"))
+    return payload
 
 
 def _path_size_bytes(path: Path) -> int:
@@ -793,9 +878,9 @@ def _stage_source_subset(
     *,
     source_paths: list[Path],
     source_root: Path,
-) -> dict[str, Any]:
+) -> SourceInputsSummary:
     source_root.mkdir(parents=True, exist_ok=True)
-    entries: list[dict[str, Any]] = []
+    entries: list[StagedSourceEntry] = []
     staged_file_count = 0
     total_bytes = 0
 
@@ -839,7 +924,7 @@ async def _run_probe_pipeline(
     measure_ingest_result_size: bool,
     backend: SQLiteBackend | None = None,
     repository: ConversationRepository | None = None,
-) -> tuple[Any, dict[str, Any]]:
+) -> tuple[RunResult, JsonObject]:
     result = await run_sources(
         config=config,
         stage=stage,
@@ -860,7 +945,27 @@ def _probe_stage_sequence(probe_mode: str, stage: str) -> list[str] | None:
     return list(_SOURCE_BACKED_PROBE_STAGE_SEQUENCES[stage])
 
 
-async def run_probe(args: argparse.Namespace) -> dict[str, Any]:
+def _json_object_or_empty(value: object | None) -> JsonObject:
+    if isinstance(value, dict):
+        payload: JsonObject = value
+        return payload
+    return {}
+
+
+def _json_float_or_none(value: object | None) -> float | None:
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError:
+            return None
+    return None
+
+
+async def run_probe(args: argparse.Namespace) -> ProbeSummary:
     probe_mode = _probe_mode(args)
     if probe_mode not in _INPUT_MODES:
         raise ValueError(f"--input-mode must be one of {_INPUT_MODES}")
@@ -875,7 +980,7 @@ async def run_probe(args: argparse.Namespace) -> dict[str, Any]:
     archive_root = workdir / "archive"
     render_root = workdir / "render"
     db_path: Path | None = None
-    summary: dict[str, Any]
+    summary: ProbeSummary
 
     if probe_mode == "synthetic":
         if args.count <= 0:
@@ -915,6 +1020,7 @@ async def run_probe(args: argparse.Namespace) -> dict[str, Any]:
                 ingest_workers=ingest_workers,
                 measure_ingest_result_size=args.measure_ingest_result_size,
             )
+        result_payload = result.model_dump()
 
         summary = {
             "probe": {
@@ -946,7 +1052,7 @@ async def run_probe(args: argparse.Namespace) -> dict[str, Any]:
                 "total_bytes": total_bytes,
             },
             "provenance": _build_probe_provenance(),
-            "result": result.model_dump(),
+            "result": result_payload,
             "run_payload": run_payload,
             "db_stats": _db_row_counts(db_path) if db_path is not None else {},
             "raw_fanout": _db_raw_fanout(db_path) if db_path is not None else [],
@@ -980,6 +1086,7 @@ async def run_probe(args: argparse.Namespace) -> dict[str, Any]:
                 ingest_workers=ingest_workers,
                 measure_ingest_result_size=args.measure_ingest_result_size,
             )
+        result_payload = result.model_dump()
 
         summary = {
             "probe": {
@@ -1001,7 +1108,7 @@ async def run_probe(args: argparse.Namespace) -> dict[str, Any]:
             },
             "source_inputs": source_inputs,
             "provenance": _build_probe_provenance(source_inputs=source_inputs),
-            "result": result.model_dump(),
+            "result": result_payload,
             "run_payload": run_payload,
             "db_stats": _db_row_counts(db_path) if db_path is not None else {},
             "raw_fanout": _db_raw_fanout(db_path) if db_path is not None else [],
@@ -1054,6 +1161,7 @@ async def run_probe(args: argparse.Namespace) -> dict[str, Any]:
                 )
             finally:
                 await repository.close()
+        result_payload = result.model_dump()
 
         summary = {
             "probe": {
@@ -1079,7 +1187,7 @@ async def run_probe(args: argparse.Namespace) -> dict[str, Any]:
             },
             "sample": sample_summary,
             "provenance": _build_probe_provenance(manifest_path=manifest_path),
-            "result": result.model_dump(),
+            "result": result_payload,
             "run_payload": run_payload,
             "db_stats": _db_row_counts(db_path) if db_path is not None else {},
             "raw_fanout": _db_raw_fanout(db_path) if db_path is not None else [],
@@ -1088,29 +1196,35 @@ async def run_probe(args: argparse.Namespace) -> dict[str, Any]:
     return summary
 
 
-def _build_budget_report(summary: dict[str, Any], args: argparse.Namespace) -> dict[str, Any] | None:
+def _build_budget_report(summary: ProbeSummary, args: argparse.Namespace) -> BudgetReport | None:
     if args.max_total_ms is None and args.max_peak_rss_mb is None:
         return None
 
-    metrics = summary.get("run_payload", {}).get("metrics", {})
-    observed_total_ms = metrics.get("total_duration_ms", summary.get("result", {}).get("duration_ms"))
+    run_payload = _json_object_or_empty(summary.get("run_payload"))
+    metrics = _json_object_or_empty(run_payload.get("metrics"))
+    result_payload = _json_object_or_empty(summary.get("result"))
+    observed_total_ms = metrics.get("total_duration_ms", result_payload.get("duration_ms"))
     observed_peak_rss_mb = metrics.get("peak_rss_self_mb")
     violations: list[str] = []
 
     if args.max_total_ms is not None:
         if observed_total_ms is None:
             violations.append("missing total runtime metric")
-        elif float(observed_total_ms) > args.max_total_ms:
+        elif (observed_total_ms_value := _json_float_or_none(observed_total_ms)) is None:
+            violations.append("non-numeric total runtime metric")
+        elif observed_total_ms_value > args.max_total_ms:
             violations.append(
-                f"total runtime {float(observed_total_ms):.1f} ms exceeded budget {args.max_total_ms:.1f} ms"
+                f"total runtime {observed_total_ms_value:.1f} ms exceeded budget {args.max_total_ms:.1f} ms"
             )
 
     if args.max_peak_rss_mb is not None:
         if observed_peak_rss_mb is None:
             violations.append("missing peak RSS metric")
-        elif float(observed_peak_rss_mb) > args.max_peak_rss_mb:
+        elif (observed_peak_rss_mb_value := _json_float_or_none(observed_peak_rss_mb)) is None:
+            violations.append("non-numeric peak RSS metric")
+        elif observed_peak_rss_mb_value > args.max_peak_rss_mb:
             violations.append(
-                f"peak RSS {float(observed_peak_rss_mb):.1f} MiB exceeded budget {args.max_peak_rss_mb:.1f} MiB"
+                f"peak RSS {observed_peak_rss_mb_value:.1f} MiB exceeded budget {args.max_peak_rss_mb:.1f} MiB"
             )
 
     return {

--- a/tests/infra/storage_records.py
+++ b/tests/infra/storage_records.py
@@ -9,7 +9,7 @@ import threading
 from collections.abc import Mapping
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Final, cast
+from typing import TYPE_CHECKING, Final, TypeAlias
 from uuid import uuid4
 
 from polylogue.lib.branch_type import BranchType
@@ -38,10 +38,25 @@ from polylogue.types import (
     ValidationStatus,
 )
 
+if TYPE_CHECKING:
+    from polylogue.lib.conversation_models import Conversation
+
+JSONRecord: TypeAlias = dict[str, object]
+MessageMapping: TypeAlias = Mapping[str, object]
+
+
+class _AutoTimestampSentinel:
+    """Marker for builders that should synthesize a fresh timestamp."""
+
+
+class _AutoMessageIdSentinel:
+    """Marker for builders that should target the most recent message."""
+
+
 # Thread-safety lock for writes (matches store.py pattern)
 _WRITE_LOCK = threading.Lock()
-_AUTO_TIMESTAMP: Final[object] = object()
-_AUTO_MESSAGE_ID: Final[object] = object()
+_AUTO_TIMESTAMP: Final = _AutoTimestampSentinel()
+_AUTO_MESSAGE_ID: Final = _AutoMessageIdSentinel()
 
 
 def _conversation_id(value: str) -> ConversationId:
@@ -68,8 +83,62 @@ def _optional_int(value: object) -> int | None:
     return value if isinstance(value, int) else None
 
 
-def _optional_dict(value: object) -> dict[str, object] | None:
-    return cast(dict[str, object], value) if isinstance(value, dict) else None
+def _optional_dict(value: object) -> JSONRecord | None:
+    if not isinstance(value, Mapping):
+        return None
+    result: JSONRecord = {}
+    for key, item in value.items():
+        if not isinstance(key, str):
+            return None
+        result[key] = item
+    return result
+
+
+def _coerce_str(value: object, default: str) -> str:
+    return value if isinstance(value, str) else default
+
+
+def _coerce_int(value: object, default: int) -> int:
+    return value if isinstance(value, int) else default
+
+
+def _coerce_sort_key(value: object, default: float | None) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return default
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError:
+            return default
+    return default
+
+
+def _coerce_content_hash(value: object, default: str) -> ContentHash:
+    return _content_hash(_coerce_str(value, default))
+
+
+def _resolve_timestamp(value: str | None | _AutoTimestampSentinel) -> str | None:
+    return datetime.now(timezone.utc).isoformat() if isinstance(value, _AutoTimestampSentinel) else value
+
+
+def _resolve_attachment_message_id(
+    *,
+    value: str | None | _AutoMessageIdSentinel,
+    messages: list[MessageRecord],
+) -> str | None:
+    if isinstance(value, _AutoMessageIdSentinel):
+        return str(messages[-1].message_id) if messages else None
+    return value
+
+
+def _coerce_builder_timestamp(value: object) -> str | None | _AutoTimestampSentinel:
+    if isinstance(value, str) or value is None:
+        return value
+    return _AUTO_TIMESTAMP
 
 
 def _content_block_record(
@@ -104,7 +173,7 @@ def _content_block_record(
 
 def _content_block_from_mapping(
     *,
-    block: Mapping[str, object],
+    block: MessageMapping,
     message_id: str,
     conversation_id: str,
     block_index: int,
@@ -586,7 +655,7 @@ class ConversationBuilder:
         self.conv = self.conv.model_copy(update={"updated_at": updated_at, "sort_key": _timestamp_sort_key(updated_at)})
         return self
 
-    def metadata(self, metadata: dict[str, object] | None) -> ConversationBuilder:
+    def metadata(self, metadata: JSONRecord | None) -> ConversationBuilder:
         self.conv = self.conv.model_copy(update={"metadata": metadata})
         return self
 
@@ -603,11 +672,11 @@ class ConversationBuilder:
         message_id: str | None = None,
         role: str | None = "user",
         text: str = "Test message",
-        timestamp: str | None | object = _AUTO_TIMESTAMP,
-        **kwargs: Any,
+        timestamp: str | None | _AutoTimestampSentinel = _AUTO_TIMESTAMP,
+        **kwargs: object,
     ) -> ConversationBuilder:
         msg_id = f"m{len(self.messages) + 1}" if message_id is None else message_id
-        ts = datetime.now(timezone.utc).isoformat() if timestamp is _AUTO_TIMESTAMP else cast(str | None, timestamp)
+        ts = _resolve_timestamp(timestamp)
 
         provider_meta = _optional_dict(kwargs.pop("provider_meta", None))
         extra_blocks = _normalize_content_blocks(
@@ -631,38 +700,42 @@ class ConversationBuilder:
             else 0
         )
         has_thinking = 1 if ContentBlockType.THINKING in block_types else 0
+        default_sort_key = _timestamp_sort_key(ts) if ts is not None else None
+        default_content_hash = uuid4().hex[:16]
 
-        msg = MessageRecord(
-            message_id=_message_id(msg_id),
-            conversation_id=self.conv.conversation_id,
-            role=role_value,
-            text=text,
-            sort_key=kwargs.pop("sort_key", _timestamp_sort_key(ts) if ts is not None else None),
-            content_hash=_content_hash(cast(str, kwargs.pop("content_hash", uuid4().hex[:16]))),
-            content_blocks=all_blocks,
-            word_count=cast(int, kwargs.pop("word_count", word_count)),
-            has_tool_use=cast(int, kwargs.pop("has_tool_use", has_tool_use)),
-            has_thinking=cast(int, kwargs.pop("has_thinking", has_thinking)),
-            **kwargs,
-        )
+        payload: JSONRecord = {
+            "message_id": _message_id(msg_id),
+            "conversation_id": self.conv.conversation_id,
+            "role": role_value,
+            "text": text,
+            "sort_key": _coerce_sort_key(
+                kwargs.pop("sort_key", default_sort_key),
+                default_sort_key,
+            ),
+            "content_hash": _coerce_content_hash(
+                kwargs.pop("content_hash", default_content_hash), default_content_hash
+            ),
+            "content_blocks": all_blocks,
+            "word_count": _coerce_int(kwargs.pop("word_count", word_count), word_count),
+            "has_tool_use": _coerce_int(kwargs.pop("has_tool_use", has_tool_use), has_tool_use),
+            "has_thinking": _coerce_int(kwargs.pop("has_thinking", has_thinking), has_thinking),
+        }
+        payload.update(kwargs)
+        msg = MessageRecord.model_validate(payload)
         self.messages.append(msg)
         return self
 
     def add_attachment(
         self,
         attachment_id: str | None = None,
-        message_id: str | None | object = _AUTO_MESSAGE_ID,
+        message_id: str | None | _AutoMessageIdSentinel = _AUTO_MESSAGE_ID,
         mime_type: str = "application/octet-stream",
         size_bytes: int = 1024,
         path: str | None = None,
-        provider_meta: dict[str, object] | None = None,
+        provider_meta: JSONRecord | None = None,
     ) -> ConversationBuilder:
         att_id = f"att{len(self.attachments) + 1}" if attachment_id is None else attachment_id
-        resolved_message_id = (
-            str(self.messages[-1].message_id)
-            if self.messages and message_id is _AUTO_MESSAGE_ID
-            else cast(str | None, message_id)
-        )
+        resolved_message_id = _resolve_attachment_message_id(value=message_id, messages=self.messages)
         att = AttachmentRecord(
             attachment_id=_attachment_id(att_id),
             conversation_id=self.conv.conversation_id,
@@ -685,7 +758,7 @@ class ConversationBuilder:
             )
         return self.conv
 
-    async def build(self) -> object:
+    async def build(self) -> Conversation | None:
         from polylogue.storage.backends.async_sqlite import SQLiteBackend
         from polylogue.storage.repository import ConversationRepository
 
@@ -710,19 +783,24 @@ def make_conversation(
     title: str = "Test Conversation",
     created_at: str | None = None,
     updated_at: str | None = None,
-    **kwargs: Any,
+    **kwargs: object,
 ) -> ConversationRecord:
     now = datetime.now(timezone.utc).isoformat()
-    return ConversationRecord(
-        conversation_id=_conversation_id(conversation_id),
-        provider_name=provider_name,
-        provider_conversation_id=cast(str, kwargs.pop("provider_conversation_id", f"ext-{conversation_id}")),
-        title=title,
-        created_at=created_at or now,
-        updated_at=updated_at or now,
-        content_hash=_content_hash(cast(str, kwargs.pop("content_hash", uuid4().hex))),
-        **kwargs,
-    )
+    default_content_hash = uuid4().hex
+    payload: JSONRecord = {
+        "conversation_id": _conversation_id(conversation_id),
+        "provider_name": provider_name,
+        "provider_conversation_id": _coerce_str(
+            kwargs.pop("provider_conversation_id", f"ext-{conversation_id}"),
+            f"ext-{conversation_id}",
+        ),
+        "title": title,
+        "created_at": created_at or now,
+        "updated_at": updated_at or now,
+        "content_hash": _coerce_content_hash(kwargs.pop("content_hash", default_content_hash), default_content_hash),
+    }
+    payload.update(kwargs)
+    return ConversationRecord.model_validate(payload)
 
 
 def make_message(
@@ -731,7 +809,7 @@ def make_message(
     role: str = "user",
     text: str | None = "Test message",
     timestamp: str | None = None,
-    **kwargs: Any,
+    **kwargs: object,
 ) -> MessageRecord:
     ts = timestamp or datetime.now(timezone.utc).isoformat()
     provider_meta = _optional_dict(kwargs.pop("provider_meta", None))
@@ -754,20 +832,26 @@ def make_message(
         1 if (block_types & {ContentBlockType.TOOL_USE, ContentBlockType.TOOL_RESULT}) or role_value is Role.TOOL else 0
     )
     has_thinking = 1 if ContentBlockType.THINKING in block_types else 0
+    default_sort_key = _timestamp_sort_key(ts) if ts is not None else None
+    default_content_hash = uuid4().hex[:16]
 
-    return MessageRecord(
-        message_id=_message_id(message_id),
-        conversation_id=_conversation_id(conversation_id),
-        role=role_value,
-        text=text,
-        sort_key=kwargs.pop("sort_key", _timestamp_sort_key(ts) if ts is not None else None),
-        content_hash=_content_hash(cast(str, kwargs.pop("content_hash", uuid4().hex[:16]))),
-        content_blocks=all_blocks,
-        word_count=cast(int, kwargs.pop("word_count", word_count)),
-        has_tool_use=cast(int, kwargs.pop("has_tool_use", has_tool_use)),
-        has_thinking=cast(int, kwargs.pop("has_thinking", has_thinking)),
-        **kwargs,
-    )
+    payload: JSONRecord = {
+        "message_id": _message_id(message_id),
+        "conversation_id": _conversation_id(conversation_id),
+        "role": role_value,
+        "text": text,
+        "sort_key": _coerce_sort_key(
+            kwargs.pop("sort_key", default_sort_key),
+            default_sort_key,
+        ),
+        "content_hash": _coerce_content_hash(kwargs.pop("content_hash", default_content_hash), default_content_hash),
+        "content_blocks": all_blocks,
+        "word_count": _coerce_int(kwargs.pop("word_count", word_count), word_count),
+        "has_tool_use": _coerce_int(kwargs.pop("has_tool_use", has_tool_use), has_tool_use),
+        "has_thinking": _coerce_int(kwargs.pop("has_thinking", has_thinking), has_thinking),
+    }
+    payload.update(kwargs)
+    return MessageRecord.model_validate(payload)
 
 
 def make_attachment(
@@ -777,21 +861,22 @@ def make_attachment(
     mime_type: str = "application/octet-stream",
     size_bytes: int = 1024,
     name: str | None = None,
-    **kwargs: Any,
+    **kwargs: object,
 ) -> AttachmentRecord:
     provider_meta = _optional_dict(kwargs.pop("provider_meta", None))
     if name and provider_meta is None:
         provider_meta = {"name": name}
 
-    return AttachmentRecord(
-        attachment_id=_attachment_id(attachment_id),
-        conversation_id=_conversation_id(conversation_id),
-        message_id=None if message_id is None else _message_id(message_id),
-        mime_type=mime_type,
-        size_bytes=size_bytes,
-        provider_meta=provider_meta,
-        **kwargs,
-    )
+    payload: JSONRecord = {
+        "attachment_id": _attachment_id(attachment_id),
+        "conversation_id": _conversation_id(conversation_id),
+        "message_id": None if message_id is None else _message_id(message_id),
+        "mime_type": mime_type,
+        "size_bytes": size_bytes,
+        "provider_meta": provider_meta,
+    }
+    payload.update(kwargs)
+    return AttachmentRecord.model_validate(payload)
 
 
 def make_raw_conversation(
@@ -805,37 +890,38 @@ def make_raw_conversation(
     validation_status: str | ValidationStatus | None = None,
     validation_provider: str | Provider | None = None,
     validation_mode: str | ValidationMode | None = None,
-    **kwargs: Any,
+    **kwargs: object,
 ) -> RawConversationRecord:
     timestamp = acquired_at or datetime.now(timezone.utc).isoformat()
-    return RawConversationRecord(
-        raw_id=raw_id,
-        provider_name=provider_name,
-        source_path=source_path,
-        blob_size=blob_size,
-        acquired_at=timestamp,
-        payload_provider=(
+    payload: JSONRecord = {
+        "raw_id": raw_id,
+        "provider_name": provider_name,
+        "source_path": source_path,
+        "blob_size": blob_size,
+        "acquired_at": timestamp,
+        "payload_provider": (
             payload_provider
             if isinstance(payload_provider, Provider) or payload_provider is None
             else Provider.from_string(payload_provider)
         ),
-        validation_status=(
+        "validation_status": (
             validation_status
             if isinstance(validation_status, ValidationStatus) or validation_status is None
             else ValidationStatus.from_string(validation_status)
         ),
-        validation_provider=(
+        "validation_provider": (
             validation_provider
             if isinstance(validation_provider, Provider) or validation_provider is None
             else Provider.from_string(validation_provider)
         ),
-        validation_mode=(
+        "validation_mode": (
             validation_mode
             if isinstance(validation_mode, ValidationMode) or validation_mode is None
             else ValidationMode.from_string(validation_mode)
         ),
-        **kwargs,
-    )
+    }
+    payload.update(kwargs)
+    return RawConversationRecord.model_validate(payload)
 
 
 class DbFactory:
@@ -850,10 +936,10 @@ class DbFactory:
         id: str | None = None,
         provider: str = "test",
         title: str = "Test Conversation",
-        messages: list[dict[str, object]] | None = None,
+        messages: list[JSONRecord] | None = None,
         created_at: datetime | None = None,
         updated_at: datetime | None = None,
-        metadata: dict[str, object] | None = None,
+        metadata: JSONRecord | None = None,
     ) -> str:
         cid = id or str(uuid4())
         created_iso = (created_at or datetime.now(timezone.utc)).isoformat()
@@ -893,7 +979,7 @@ class DbFactory:
                 message_id=message_id,
                 role=_optional_str(msg.get("role")) or "user",
                 text=text_value,
-                timestamp=msg.get("timestamp", _AUTO_TIMESTAMP),
+                timestamp=_coerce_builder_timestamp(msg.get("timestamp", _AUTO_TIMESTAMP)),
                 **message_kwargs,
             )
 

--- a/tests/unit/cli/test_check.py
+++ b/tests/unit/cli/test_check.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from typing import Any, cast
+from pathlib import Path
 from unittest.mock import ANY, patch
 
 import pytest
@@ -13,6 +13,7 @@ from polylogue.cli import cli
 from polylogue.cli.check_workflow import CheckCommandOptions, run_check_workflow
 from polylogue.cli.types import AppEnv
 from polylogue.health import HealthCheck, HealthReport, VerifyStatus
+from polylogue.lib.raw_payload_decode import JSONValue
 from polylogue.schemas.operator_models import (
     ArtifactCohortListResult,
     ArtifactObservationListResult,
@@ -31,14 +32,53 @@ from polylogue.types import ArtifactSupportStatus, Provider
 from polylogue.ui import create_ui
 from tests.infra.storage_records import ConversationBuilder, DbFactory
 
+WorkspacePaths = dict[str, Path]
+JsonObject = dict[str, JSONValue]
+JsonArray = list[JSONValue]
+
 
 @pytest.fixture
-def cli_runner() -> Any:
+def cli_runner() -> CliRunner:
     """Provide a Click CLI test runner."""
     return CliRunner()
 
 
-def _extract_json(output: str) -> dict[str, Any]:
+def _require_json_object(value: object, *, context: str) -> JsonObject:
+    if not isinstance(value, dict):
+        raise ValueError(f"Expected {context} object, got {type(value).__name__}")
+    if not all(isinstance(key, str) for key in value):
+        raise ValueError(f"Expected {context} keys to be strings")
+    return {str(key): item for key, item in value.items()}
+
+
+def _require_json_array(value: object, *, context: str) -> JsonArray:
+    if not isinstance(value, list):
+        raise ValueError(f"Expected {context} array, got {type(value).__name__}")
+    return list(value)
+
+
+def _json_object_field(payload: JsonObject, key: str, *, context: str) -> JsonObject:
+    return _require_json_object(payload.get(key), context=f"{context}.{key}")
+
+
+def _json_array_field(payload: JsonObject, key: str, *, context: str) -> JsonArray:
+    return _require_json_array(payload.get(key), context=f"{context}.{key}")
+
+
+def _json_array_item(items: JsonArray, index: int, *, context: str) -> JsonObject:
+    return _require_json_object(items[index], context=f"{context}[{index}]")
+
+
+def _find_named_check(payload: JsonObject, name: str) -> JsonObject:
+    checks = _json_array_field(payload, "checks", context="check payload")
+    for check in checks:
+        check_payload = _require_json_object(check, context=f"check {name}")
+        if check_payload.get("name") == name:
+            return check_payload
+    raise AssertionError(f"Missing check named {name}")
+
+
+def _extract_json(output: str) -> JsonObject:
     """Extract JSON from CLI output, unwrapping the success envelope."""
     lines = output.strip().split("\n")
     # Find first line that starts with { and join all subsequent lines
@@ -47,21 +87,17 @@ def _extract_json(output: str) -> dict[str, Any]:
         raise ValueError(f"No JSON found in output: {output}")
     json_str = "\n".join(lines[json_start:])
     data = json.loads(json_str)
-    if not isinstance(data, dict):
-        raise ValueError(f"Expected JSON object, got {type(data).__name__}")
+    data_object = _require_json_object(data, context="JSON")
     # Unwrap success envelope
-    if isinstance(data, dict) and data.get("status") == "ok" and "result" in data:
-        result = data["result"]
-        if not isinstance(result, dict):
-            raise ValueError(f"Expected result object, got {type(result).__name__}")
-        return cast(dict[str, Any], result)
-    return cast(dict[str, Any], data)
+    if data_object.get("status") == "ok" and "result" in data_object:
+        return _require_json_object(data_object["result"], context="result")
+    return data_object
 
 
 class TestHealthReportConstruction:
     """Tests for proper HealthReport instantiation."""
 
-    def test_health_report_requires_summary(self: Any) -> None:
+    def test_health_report_requires_summary(self) -> None:
         """HealthReport derives summary dict from check statuses."""
         checks = [
             HealthCheck("database", VerifyStatus.OK, summary="DB reachable"),
@@ -73,7 +109,7 @@ class TestHealthReportConstruction:
         assert len(report.checks) == 2
         assert report.summary == {"ok": 1, "warning": 1, "error": 0}
 
-    def test_health_report_summary_counts(self: Any) -> None:
+    def test_health_report_summary_counts(self) -> None:
         """Summary should accurately reflect check status counts."""
         checks = [
             HealthCheck("check1", VerifyStatus.OK),
@@ -89,7 +125,7 @@ class TestHealthReportConstruction:
         assert report.summary["warning"] == 1
         assert report.summary["error"] == 1
 
-    def test_health_report_to_dict_serialization(self: Any) -> None:
+    def test_health_report_to_dict_serialization(self) -> None:
         """HealthReport should serialize to dict with all required fields."""
         checks = [HealthCheck("test", VerifyStatus.OK, summary="OK")]
         report = HealthReport(checks=checks)
@@ -101,7 +137,7 @@ class TestHealthReportConstruction:
         assert "timestamp" in data
         assert data["summary"] == {"ok": 1, "warning": 0, "error": 0}
 
-    def test_health_report_empty_checks(self: Any) -> None:
+    def test_health_report_empty_checks(self) -> None:
         """HealthReport with no checks should still have summary."""
         report = HealthReport(checks=[])
 
@@ -109,7 +145,7 @@ class TestHealthReportConstruction:
         assert report.summary == {"ok": 0, "warning": 0, "error": 0}
 
 
-def test_check_records_scoped_maintenance_preview(cli_workspace: Any, cli_runner: Any) -> None:
+def test_check_records_scoped_maintenance_preview(cli_workspace: WorkspacePaths, cli_runner: CliRunner) -> None:
     from polylogue.storage.session_product_rebuild import rebuild_session_products_sync
 
     db_path = cli_workspace["db_path"]
@@ -140,12 +176,16 @@ def test_check_records_scoped_maintenance_preview(cli_workspace: Any, cli_runner
 
     assert result.exit_code == 0
     payload = _extract_json(result.output)
-    assert payload["maintenance"]["targets"] == ["session_products"]
-    assert payload["maintenance"]["items"][0]["name"] == "session_products"
-    assert payload["maintenance"]["items"][0]["repaired_count"] > 0
+    maintenance = _json_object_field(payload, "maintenance", context="check payload")
+    assert maintenance.get("targets") == ["session_products"]
+    maintenance_item = _json_array_item(
+        _json_array_field(maintenance, "items", context="maintenance"), 0, context="maintenance.items"
+    )
+    assert maintenance_item.get("name") == "session_products"
+    assert maintenance_item.get("repaired_count") == 1
 
 
-def test_check_records_scoped_maintenance_apply(cli_workspace: Any, cli_runner: Any) -> None:
+def test_check_records_scoped_maintenance_apply(cli_workspace: WorkspacePaths, cli_runner: CliRunner) -> None:
     from polylogue.storage.session_product_rebuild import rebuild_session_products_sync
 
     db_path = cli_workspace["db_path"]
@@ -176,12 +216,18 @@ def test_check_records_scoped_maintenance_apply(cli_workspace: Any, cli_runner: 
 
     assert result.exit_code == 0
     payload = _extract_json(result.output)
-    assert payload["maintenance"]["targets"] == ["session_products"]
-    assert payload["maintenance"]["items"][0]["name"] == "session_products"
-    assert payload["maintenance"]["items"][0]["success"] is True
+    maintenance = _json_object_field(payload, "maintenance", context="check payload")
+    assert maintenance.get("targets") == ["session_products"]
+    maintenance_item = _json_array_item(
+        _json_array_field(maintenance, "items", context="maintenance"), 0, context="maintenance.items"
+    )
+    assert maintenance_item.get("name") == "session_products"
+    assert maintenance_item.get("success") is True
 
 
-def test_check_plain_preview_summarizes_changes_not_issues(cli_workspace: Any, cli_runner: Any) -> None:
+def test_check_plain_preview_summarizes_changes_not_issues(
+    cli_workspace: WorkspacePaths, cli_runner: CliRunner
+) -> None:
     from polylogue.storage.session_product_rebuild import rebuild_session_products_sync
 
     db_path = cli_workspace["db_path"]
@@ -216,7 +262,7 @@ def test_check_plain_preview_summarizes_changes_not_issues(cli_workspace: Any, c
     assert "issue(s)" not in result.output
 
 
-def test_check_warns_when_message_index_is_incomplete(cli_workspace: Any, cli_runner: Any) -> None:
+def test_check_warns_when_message_index_is_incomplete(cli_workspace: WorkspacePaths, cli_runner: CliRunner) -> None:
     db_path = cli_workspace["db_path"]
     factory = DbFactory(db_path)
     factory.create_conversation(
@@ -235,12 +281,14 @@ def test_check_warns_when_message_index_is_incomplete(cli_workspace: Any, cli_ru
 
     assert result.exit_code == 0
     payload = _extract_json(result.output)
-    index_check = next(check for check in payload["checks"] if check["name"] == "index")
+    index_check = _find_named_check(payload, "index")
     assert index_check["status"] == "warning"
     assert index_check["detail"] == "messages FTS missing or empty; use --deep to verify full coverage"
 
 
-def test_check_ignores_null_text_messages_in_fts_readiness(cli_workspace: Any, cli_runner: Any) -> None:
+def test_check_ignores_null_text_messages_in_fts_readiness(
+    cli_workspace: WorkspacePaths, cli_runner: CliRunner
+) -> None:
     db_path = cli_workspace["db_path"]
     factory = DbFactory(db_path)
     factory.create_conversation(
@@ -259,8 +307,8 @@ def test_check_ignores_null_text_messages_in_fts_readiness(cli_workspace: Any, c
     assert result.exit_code == 0
 
     data = _extract_json(result.output)
-    index_check = next(c for c in data["checks"] if c["name"] == "index")
-    fts_check = next(c for c in data["checks"] if c["name"] == "fts_sync")
+    index_check = _find_named_check(data, "index")
+    fts_check = _find_named_check(data, "fts_sync")
 
     assert index_check["status"] == "ok"
     assert index_check["detail"] == "messages FTS present"
@@ -271,7 +319,7 @@ def test_check_ignores_null_text_messages_in_fts_readiness(cli_workspace: Any, c
 class TestCheckCommand:
     """Tests for polylogue check command."""
 
-    def test_check_clean_database(self: Any, db_path: Any, cli_runner: Any) -> None:
+    def test_check_clean_database(self, db_path: Path, cli_runner: CliRunner) -> None:
         """Check command succeeds on clean database with valid data."""
         factory = DbFactory(db_path)
 
@@ -290,7 +338,7 @@ class TestCheckCommand:
         assert result.exit_code == 0
         assert "ok" in result.output.lower() or "✓" in result.output
 
-    def test_check_json_output(self: Any, db_path: Any, cli_runner: Any) -> None:
+    def test_check_json_output(self, db_path: Path, cli_runner: CliRunner) -> None:
         """Check --json flag produces valid JSON."""
         factory = DbFactory(db_path)
 
@@ -307,15 +355,17 @@ class TestCheckCommand:
         data = _extract_json(result.output)
         assert "checks" in data
         assert "summary" in data
-        assert isinstance(data["checks"], list)
-        assert isinstance(data["summary"], dict)
+        checks = _json_array_field(data, "checks", context="check payload")
+        summary = _json_object_field(data, "summary", context="check payload")
+        assert isinstance(checks, list)
+        assert isinstance(summary, dict)
 
         # Check summary has expected keys
-        assert "ok" in data["summary"]
-        assert "warning" in data["summary"]
-        assert "error" in data["summary"]
+        assert "ok" in summary
+        assert "warning" in summary
+        assert "error" in summary
 
-    def test_check_runtime_only_skips_archive_health(self: Any, monkeypatch: Any) -> None:
+    def test_check_runtime_only_skips_archive_health(self, monkeypatch: pytest.MonkeyPatch) -> None:
         runtime_report = HealthReport(checks=[HealthCheck("runtime_only", VerifyStatus.OK, summary="runtime ok")])
         env = AppEnv(ui=create_ui(True))
         options = CheckCommandOptions(
@@ -356,7 +406,7 @@ class TestCheckCommand:
         assert result.report is runtime_report
         assert result.runtime_report is None
 
-    def test_check_detects_orphan_messages(self: Any, db_path: Any, cli_runner: Any) -> None:
+    def test_check_detects_orphan_messages(self, db_path: Path, cli_runner: CliRunner) -> None:
         """Check detects messages without conversations."""
 
         # Disable foreign key constraints temporarily to insert orphan message
@@ -388,18 +438,15 @@ class TestCheckCommand:
         data = _extract_json(result.output)
 
         # Find the orphaned_messages check
-        orphan_check = next(
-            (c for c in data["checks"] if c["name"] == "orphaned_messages"),
-            None,
-        )
-        assert orphan_check is not None
+        orphan_check = _find_named_check(data, "orphaned_messages")
         assert orphan_check["status"] == "error"
         assert orphan_check["count"] == 1
 
         # Summary should show at least one error
-        assert data["summary"]["error"] >= 1
+        summary = _json_object_field(data, "summary", context="check payload")
+        assert summary.get("error") == 1
 
-    def test_check_verbose_output(self: Any, db_path: Any, cli_runner: Any) -> None:
+    def test_check_verbose_output(self, db_path: Path, cli_runner: CliRunner) -> None:
         """Check -v flag increases detail with provider breakdown."""
         factory = DbFactory(db_path)
 
@@ -427,7 +474,7 @@ class TestCheckCommand:
         # (provider_distribution check always has breakdown)
         assert "chatgpt" in result_verbose.output or "claude-ai" in result_verbose.output
 
-    def test_check_detects_empty_conversations(self: Any, db_path: Any, cli_runner: Any) -> None:
+    def test_check_detects_empty_conversations(self, db_path: Path, cli_runner: CliRunner) -> None:
         """Check detects conversations with no messages (warning status)."""
 
         # Create a conversation with no messages
@@ -459,15 +506,11 @@ class TestCheckCommand:
         data = _extract_json(result.output)
 
         # Find the empty_conversations check
-        empty_check = next(
-            (c for c in data["checks"] if c["name"] == "empty_conversations"),
-            None,
-        )
-        assert empty_check is not None
+        empty_check = _find_named_check(data, "empty_conversations")
         assert empty_check["status"] == "warning"
         assert empty_check["count"] == 1
 
-    def test_check_no_duplicate_conversation_ids(self: Any, db_path: Any, cli_runner: Any) -> None:
+    def test_check_no_duplicate_conversation_ids(self, db_path: Path, cli_runner: CliRunner) -> None:
         """Check duplicate_conversations check passes when there are no duplicates."""
         factory = DbFactory(db_path)
 
@@ -489,15 +532,11 @@ class TestCheckCommand:
         data = _extract_json(result.output)
 
         # Find the duplicate_conversations check
-        dup_check = next(
-            (c for c in data["checks"] if c["name"] == "duplicate_conversations"),
-            None,
-        )
-        assert dup_check is not None
+        dup_check = _find_named_check(data, "duplicate_conversations")
         assert dup_check["status"] == "ok"
         assert dup_check["count"] == 0  # No duplicates found
 
-    def test_check_detects_fts_sync_issues(self: Any, db_path: Any, cli_runner: Any) -> None:
+    def test_check_detects_fts_sync_issues(self, db_path: Path, cli_runner: CliRunner) -> None:
         """Check detects FTS sync issues when FTS table is missing."""
         factory = DbFactory(db_path)
 
@@ -519,15 +558,11 @@ class TestCheckCommand:
         data = _extract_json(result.output)
 
         # Find the fts_sync check
-        fts_check = next(
-            (c for c in data["checks"] if c["name"] == "fts_sync"),
-            None,
-        )
-        assert fts_check is not None
+        fts_check = _find_named_check(data, "fts_sync")
         # Should be warning due to missing FTS table
         assert fts_check["status"] == "warning"
 
-    def test_check_plain_output_format(self: Any, db_path: Any, cli_runner: Any) -> None:
+    def test_check_plain_output_format(self, db_path: Path, cli_runner: CliRunner) -> None:
         """Check --plain flag produces plain text output without colors."""
         factory = DbFactory(db_path)
 
@@ -546,7 +581,7 @@ class TestCheckCommand:
         assert "[green]" not in result.output
         assert "[red]" not in result.output
 
-    def test_check_summary_counts(self: Any, db_path: Any, cli_runner: Any) -> None:
+    def test_check_summary_counts(self, db_path: Path, cli_runner: CliRunner) -> None:
         """Check summary shows correct counts of ok/warning/error checks."""
         factory = DbFactory(db_path)
 
@@ -566,7 +601,7 @@ class TestCheckCommand:
         assert "warnings" in result.output or "warning" in result.output
         assert "errors" in result.output or "error" in result.output
 
-    def test_check_empty_database(self: Any, db_path: Any, cli_runner: Any) -> None:
+    def test_check_empty_database(self, db_path: Path, cli_runner: CliRunner) -> None:
         """Check command succeeds on empty database."""
         # Don't create any data - just verify empty DB (db_path fixture ensures DB exists)
 
@@ -576,7 +611,7 @@ class TestCheckCommand:
         # Should show healthy status checks (no integrity_check without --deep)
         assert "OK database" in result.output
 
-    def test_check_sqlite_integrity_check(self: Any, db_path: Any, cli_runner: Any) -> None:
+    def test_check_sqlite_integrity_check(self, db_path: Path, cli_runner: CliRunner) -> None:
         """Check includes SQLite integrity check when --deep is passed."""
         factory = DbFactory(db_path)
 
@@ -592,11 +627,7 @@ class TestCheckCommand:
         data = _extract_json(result.output)
 
         # Find the sqlite_integrity check
-        integrity_check = next(
-            (c for c in data["checks"] if c["name"] == "sqlite_integrity"),
-            None,
-        )
-        assert integrity_check is not None
+        integrity_check = _find_named_check(data, "sqlite_integrity")
         assert integrity_check["status"] == "ok"
         assert integrity_check["detail"] == "ok"
 
@@ -622,7 +653,9 @@ class TestCheckCommandSupplementary:
     ]
 
     @pytest.mark.parametrize("args,expected_error", INVALID_FLAG_COMBOS)
-    def test_invalid_flag_combinations_rejected(self: Any, cli_workspace: Any, args: Any, expected_error: Any) -> None:
+    def test_invalid_flag_combinations_rejected(
+        self, cli_workspace: WorkspacePaths, args: list[str], expected_error: str
+    ) -> None:
         """Flag dependencies and value constraints are enforced."""
         from click.testing import CliRunner
 
@@ -635,7 +668,7 @@ class TestCheckCommandSupplementary:
 
     # --- Remaining non-repetitive tests ---
 
-    def test_json_output_with_repair(self: Any, cli_workspace: Any) -> None:
+    def test_json_output_with_repair(self, cli_workspace: WorkspacePaths) -> None:
         """--json with --repair includes maintenance results."""
         from click.testing import CliRunner
 
@@ -645,10 +678,10 @@ class TestCheckCommandSupplementary:
         result = runner.invoke(cli, ["doctor", "--json", "--repair", "--preview"])
         assert result.exit_code == 0
         envelope = json.loads(result.output.split("\n", 1)[-1] if "Plain" in result.output else result.output)
-        data = envelope.get("result", envelope)
+        data = _require_json_object(envelope.get("result", envelope), context="repair preview payload")
         assert "maintenance" in data
 
-    def test_repair_with_no_issues_shows_message(self: Any, cli_workspace: Any) -> None:
+    def test_repair_with_no_issues_shows_message(self, cli_workspace: WorkspacePaths) -> None:
         """When repair finds no issues, should show a maintenance status message."""
         from click.testing import CliRunner
 
@@ -663,7 +696,7 @@ class TestCheckCommandSupplementary:
             or "maintenance" in result.output.lower()
         )
 
-    def test_vacuum_with_repair(self: Any, cli_workspace: Any) -> None:
+    def test_vacuum_with_repair(self, cli_workspace: WorkspacePaths) -> None:
         """--vacuum with --repair should attempt VACUUM."""
         from click.testing import CliRunner
 
@@ -674,7 +707,7 @@ class TestCheckCommandSupplementary:
         assert result.exit_code == 0
         assert "VACUUM" in result.output
 
-    def test_json_output_with_repair_and_vacuum_is_machine_safe(self: Any, cli_workspace: Any) -> None:
+    def test_json_output_with_repair_and_vacuum_is_machine_safe(self, cli_workspace: WorkspacePaths) -> None:
         """`--json --repair --vacuum` should stay valid JSON."""
         from click.testing import CliRunner
 
@@ -685,12 +718,13 @@ class TestCheckCommandSupplementary:
 
         assert result.exit_code == 0
         envelope = json.loads(result.output)
-        data = envelope.get("result", envelope)
+        data = _require_json_object(envelope.get("result", envelope), context="repair vacuum payload")
         assert "maintenance" in data
-        assert data["vacuum"]["ok"] is True
-        assert data["vacuum"]["preview"] is True
+        vacuum = _json_object_field(data, "vacuum", context="repair vacuum payload")
+        assert vacuum.get("ok") is True
+        assert vacuum.get("preview") is True
 
-    def test_check_schemas_json_output(self: Any, cli_workspace: Any) -> None:
+    def test_check_schemas_json_output(self, cli_workspace: WorkspacePaths) -> None:
         """--schemas adds schema_verification block to JSON output."""
         from click.testing import CliRunner
 
@@ -718,12 +752,13 @@ class TestCheckCommandSupplementary:
         assert result.exit_code == 0
         data = _extract_json(result.output)
         assert "schema_verification" in data
-        assert data["schema_verification"]["total_records"] == 3
-        assert data["schema_verification"]["max_samples"] == "all"
-        assert data["schema_verification"]["record_limit"] == "all"
-        assert data["schema_verification"]["record_offset"] == 0
+        schema_verification = _json_object_field(data, "schema_verification", context="schema verification payload")
+        assert schema_verification.get("total_records") == 3
+        assert schema_verification.get("max_samples") == "all"
+        assert schema_verification.get("record_limit") == "all"
+        assert schema_verification.get("record_offset") == 0
 
-    def test_check_schemas_forwards_record_chunk_options(self: Any, cli_workspace: Any) -> None:
+    def test_check_schemas_forwards_record_chunk_options(self, cli_workspace: WorkspacePaths) -> None:
         """Chunking options are forwarded to verify_raw_corpus."""
         from click.testing import CliRunner
 
@@ -770,7 +805,7 @@ class TestCheckCommandSupplementary:
         assert request.progress_callback is not None
         assert mock_verify.call_args.kwargs["db_path"] == ANY
 
-    def test_check_schemas_forwards_quarantine_flag(self: Any, cli_workspace: Any) -> None:
+    def test_check_schemas_forwards_quarantine_flag(self, cli_workspace: WorkspacePaths) -> None:
         """Quarantine option is forwarded to verify_raw_corpus."""
         from click.testing import CliRunner
 
@@ -801,7 +836,7 @@ class TestCheckCommandSupplementary:
         assert request.quarantine_malformed is True
         assert request.progress_callback is not None
 
-    def test_check_proof_json_output(self: Any, cli_workspace: Any) -> None:
+    def test_check_proof_json_output(self, cli_workspace: WorkspacePaths) -> None:
         """--proof adds artifact_proof block to JSON output."""
         from click.testing import CliRunner
 
@@ -835,12 +870,14 @@ class TestCheckCommandSupplementary:
         assert result.exit_code == 0
         data = _extract_json(result.output)
         assert "artifact_proof" in data
-        assert data["artifact_proof"]["total_records"] == 2
-        assert data["artifact_proof"]["summary"]["linked_sidecars"] == 1
-        assert data["artifact_proof"]["summary"]["unsupported_parseable_records"] == 1
-        assert data["artifact_proof"]["summary"]["package_versions"] == {"v7": 1}
+        artifact_proof = _json_object_field(data, "artifact_proof", context="artifact proof payload")
+        artifact_summary = _json_object_field(artifact_proof, "summary", context="artifact proof payload")
+        assert artifact_proof.get("total_records") == 2
+        assert artifact_summary.get("linked_sidecars") == 1
+        assert artifact_summary.get("unsupported_parseable_records") == 1
+        assert artifact_summary.get("package_versions") == {"v7": 1}
 
-    def test_check_proof_plain_output(self: Any, cli_workspace: Any) -> None:
+    def test_check_proof_plain_output(self, cli_workspace: WorkspacePaths) -> None:
         """--proof renders the artifact proof summary in plain output."""
         from click.testing import CliRunner
 
@@ -875,7 +912,7 @@ class TestCheckCommandSupplementary:
         assert "chatgpt: contract_backed=1" in result.output
         assert "packages: v1=1" in result.output
 
-    def test_check_proof_forwards_artifact_scope(self: Any, cli_workspace: Any) -> None:
+    def test_check_proof_forwards_artifact_scope(self, cli_workspace: WorkspacePaths) -> None:
         """Artifact provider/limit/offset are forwarded to the proof workflow."""
         from click.testing import CliRunner
 
@@ -910,7 +947,7 @@ class TestCheckCommandSupplementary:
         assert request.record_limit == 25
         assert request.record_offset == 50
 
-    def test_check_artifacts_json_output(self: Any, cli_workspace: Any) -> None:
+    def test_check_artifacts_json_output(self, cli_workspace: WorkspacePaths) -> None:
         """--artifacts adds artifact_observations rows to JSON output."""
         from click.testing import CliRunner
 
@@ -969,10 +1006,18 @@ class TestCheckCommandSupplementary:
 
         assert result.exit_code == 0
         data = _extract_json(result.output)
-        assert data["artifact_observations"]["count"] == 1
-        assert data["artifact_observations"]["items"][0]["support_status"] == "supported_parseable"
+        artifact_observations = _json_object_field(
+            data, "artifact_observations", context="artifact observations payload"
+        )
+        assert artifact_observations.get("count") == 1
+        observation = _json_array_item(
+            _json_array_field(artifact_observations, "items", context="artifact observations payload"),
+            0,
+            context="artifact_observations.items",
+        )
+        assert observation.get("support_status") == "supported_parseable"
 
-    def test_check_cohorts_plain_output(self: Any, cli_workspace: Any) -> None:
+    def test_check_cohorts_plain_output(self, cli_workspace: WorkspacePaths) -> None:
         """--cohorts renders durable cohort summaries in plain output."""
         from click.testing import CliRunner
 

--- a/tests/unit/core/test_filters_props.py
+++ b/tests/unit/core/test_filters_props.py
@@ -18,7 +18,8 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from datetime import datetime, timedelta, timezone
-from typing import Any
+from pathlib import Path
+from typing import Literal, NotRequired, TypeAlias, TypedDict
 from unittest.mock import patch
 
 import pytest
@@ -26,6 +27,8 @@ from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 
 from polylogue.cli.filter_picker import pick_filter
+from polylogue.lib.conversation_models import Conversation
+from polylogue.lib.filter_types import SortField
 from polylogue.lib.filters import ConversationFilter
 from polylogue.lib.models import ConversationSummary
 from polylogue.storage.backends.async_sqlite import SQLiteBackend
@@ -43,8 +46,35 @@ from tests.infra.strategies.filters import (
 # =============================================================================
 
 
+class MessageSeed(TypedDict):
+    id: str
+    role: NotRequired[str]
+    text: NotRequired[str]
+
+
+class ConversationSeed(TypedDict):
+    id: str
+    provider: str
+    title: NotRequired[str]
+    messages: NotRequired[list[MessageSeed]]
+
+
+class FilterSpec(TypedDict):
+    type: str
+    value: NotRequired[object]
+    field: NotRequired[str]
+    direction: NotRequired[str]
+
+
+FilterRepoFactory: TypeAlias = Callable[[list[ConversationSeed]], ConversationRepository]
+TerminalMethod: TypeAlias = Literal["list", "first", "count", "delete", "pick"]
+TerminalResult: TypeAlias = list[Conversation] | Conversation | None | int
+DateMethodName: TypeAlias = Literal["since", "until"]
+BranchPredicateName: TypeAlias = Literal["is_continuation", "is_sidechain", "has_branches"]
+
+
 @pytest.fixture
-def filter_db(tmp_path: Any) -> Any:
+def filter_db(tmp_path: Path) -> Path:
     """Create database with test conversations for filter tests."""
     db_path = tmp_path / "filter_test.db"
 
@@ -85,14 +115,14 @@ def filter_db(tmp_path: Any) -> Any:
 
 
 @pytest.fixture
-def filter_repo(filter_db: Any) -> Any:
+def filter_repo(filter_db: Path) -> ConversationRepository:
     """Create repository for filter tests."""
     backend = SQLiteBackend(db_path=filter_db)
     return ConversationRepository(backend=backend)
 
 
 @pytest.fixture
-def filter_db_empty(tmp_path: Any) -> Any:
+def filter_db_empty(tmp_path: Path) -> Path:
     """Create empty database for testing empty repository edge cases."""
     db_path = tmp_path / "filter_empty.db"
     with open_connection(db_path) as conn:
@@ -101,14 +131,14 @@ def filter_db_empty(tmp_path: Any) -> Any:
 
 
 @pytest.fixture
-def filter_repo_empty(filter_db_empty: Any) -> Any:
+def filter_repo_empty(filter_db_empty: Path) -> ConversationRepository:
     """Create repository for empty database tests."""
     backend = SQLiteBackend(db_path=filter_db_empty)
     return ConversationRepository(backend=backend)
 
 
 @pytest.fixture
-def filter_db_advanced(tmp_path: Any) -> Any:
+def filter_db_advanced(tmp_path: Path) -> Path:
     """Create database with conversations for advanced filter tests.
 
     Includes thinking blocks, tool use, attachments, summaries,
@@ -217,7 +247,7 @@ def filter_db_advanced(tmp_path: Any) -> Any:
 
 
 @pytest.fixture
-def filter_repo_advanced(filter_db_advanced: Any) -> Any:
+def filter_repo_advanced(filter_db_advanced: Path) -> ConversationRepository:
     """Create repository for advanced filter tests."""
     backend = SQLiteBackend(db_path=filter_db_advanced)
     return ConversationRepository(backend=backend)
@@ -228,19 +258,26 @@ def filter_repo_advanced(filter_db_advanced: Any) -> Any:
 # =============================================================================
 
 
-def _apply_filter_spec(f: ConversationFilter, spec: dict[str, Any]) -> ConversationFilter:
+def _apply_filter_spec(f: ConversationFilter, spec: FilterSpec) -> ConversationFilter:
     """Apply a single filter spec dict to a ConversationFilter."""
     ftype = spec["type"]
     if ftype == "provider":
-        return f.provider(spec["value"])
+        return f.provider(str(spec["value"]))
     elif ftype == "contains":
-        return f.contains(spec["value"])
+        return f.contains(str(spec["value"]))
     elif ftype == "since":
-        return f.since(spec["value"])
+        return f.since(str(spec["value"]))
     elif ftype == "until":
-        return f.until(spec["value"])
+        return f.until(str(spec["value"]))
     elif ftype == "limit":
-        return f.limit(spec["value"])
+        raw_value = spec["value"]
+        if isinstance(raw_value, bool):
+            return f.limit(int(raw_value))
+        if isinstance(raw_value, int):
+            return f.limit(raw_value)
+        if isinstance(raw_value, (float, str)):
+            return f.limit(int(raw_value))
+        return f.limit(0)
     elif ftype == "offset":
         # ConversationFilter does not have .offset(), skip
         return f
@@ -258,7 +295,7 @@ def _apply_filter_spec(f: ConversationFilter, spec: dict[str, Any]) -> Conversat
 
 @given(filter_chain_strategy(min_filters=1, max_filters=4))
 @settings(max_examples=30, suppress_health_check=[HealthCheck.too_slow])
-def test_filter_chain_never_crashes_on_build(chain: list[dict[str, Any]]) -> None:
+def test_filter_chain_never_crashes_on_build(chain: list[FilterSpec]) -> None:
     """Building a filter chain from arbitrary filter specs never crashes.
 
     We can't call .list() here (needs async + DB), but we verify the
@@ -275,7 +312,7 @@ def test_filter_chain_never_crashes_on_build(chain: list[dict[str, Any]]) -> Non
 
 
 @pytest.mark.asyncio
-async def test_filter_chain_never_crashes_on_execution(make_filter_repo: Any) -> None:
+async def test_filter_chain_never_crashes_on_execution(make_filter_repo: FilterRepoFactory) -> None:
     """Composed filters never crash when executed against a real DB.
 
     Uses explicit examples rather than @given to avoid fixture-scope issues.
@@ -299,7 +336,7 @@ async def test_filter_chain_never_crashes_on_execution(make_filter_repo: Any) ->
     )
 
     # Test a variety of filter chain combos
-    chains: list[list[dict[str, Any]]] = [
+    chains: list[list[FilterSpec]] = [
         [{"type": "provider", "value": "claude-ai"}],
         [{"type": "limit", "value": 1}],
         [{"type": "provider", "value": "chatgpt"}, {"type": "limit", "value": 5}],
@@ -320,7 +357,7 @@ async def test_filter_chain_never_crashes_on_execution(make_filter_repo: Any) ->
 
 
 @pytest.mark.asyncio
-async def test_filter_monotonicity_provider(filter_repo: Any) -> None:
+async def test_filter_monotonicity_provider(filter_repo: ConversationRepository) -> None:
     """Adding a provider filter never increases result count."""
     all_count = await ConversationFilter(filter_repo).count()
     filtered_count = await ConversationFilter(filter_repo).provider("claude-ai").count()
@@ -328,7 +365,7 @@ async def test_filter_monotonicity_provider(filter_repo: Any) -> None:
 
 
 @pytest.mark.asyncio
-async def test_filter_monotonicity_limit(filter_repo: Any) -> None:
+async def test_filter_monotonicity_limit(filter_repo: ConversationRepository) -> None:
     """Adding a limit filter never increases result count."""
     all_count = await ConversationFilter(filter_repo).count()
     limited_count = len(await ConversationFilter(filter_repo).limit(1).list())
@@ -336,7 +373,7 @@ async def test_filter_monotonicity_limit(filter_repo: Any) -> None:
 
 
 @pytest.mark.asyncio
-async def test_filter_monotonicity_exclude(filter_repo: Any) -> None:
+async def test_filter_monotonicity_exclude(filter_repo: ConversationRepository) -> None:
     """Adding an exclude filter never increases result count."""
     all_count = await ConversationFilter(filter_repo).count()
     excluded = await ConversationFilter(filter_repo).exclude_provider("claude-ai").list()
@@ -344,7 +381,7 @@ async def test_filter_monotonicity_exclude(filter_repo: Any) -> None:
 
 
 @pytest.mark.asyncio
-async def test_filter_monotonicity_chained(filter_repo_advanced: Any) -> None:
+async def test_filter_monotonicity_chained(filter_repo_advanced: ConversationRepository) -> None:
     """Stacking filters monotonically decreases results."""
     c0 = await ConversationFilter(filter_repo_advanced).count()
     c1 = len(await ConversationFilter(filter_repo_advanced).provider("claude-ai").list())
@@ -358,7 +395,7 @@ async def test_filter_monotonicity_chained(filter_repo_advanced: Any) -> None:
 
 
 @pytest.mark.asyncio
-async def test_filter_idempotence_provider(filter_repo: Any) -> None:
+async def test_filter_idempotence_provider(filter_repo: ConversationRepository) -> None:
     """Applying provider("claude-ai") twice yields same results as once."""
     once = await ConversationFilter(filter_repo).provider("claude-ai").list()
     twice = await ConversationFilter(filter_repo).provider("claude-ai").provider("claude-ai").list()
@@ -366,7 +403,7 @@ async def test_filter_idempotence_provider(filter_repo: Any) -> None:
 
 
 @pytest.mark.asyncio
-async def test_filter_idempotence_exclude(filter_repo: Any) -> None:
+async def test_filter_idempotence_exclude(filter_repo: ConversationRepository) -> None:
     """Applying exclude_provider("claude-ai") twice yields same results as once."""
     once = await ConversationFilter(filter_repo).exclude_provider("claude-ai").list()
     twice = await ConversationFilter(filter_repo).exclude_provider("claude-ai").exclude_provider("claude-ai").list()
@@ -531,7 +568,7 @@ def test_filter_order_independent(items: list[int], threshold1: int, threshold2:
 class TestConversationFilterChaining:
     """Chainability and multi-method filter tests (key regressions)."""
 
-    def test_filter_returns_self(self: Any, filter_repo: Any) -> None:
+    def test_filter_returns_self(self, filter_repo: ConversationRepository) -> None:
         """Every fluent filter method must return self."""
         chainable_methods: tuple[Callable[[ConversationFilter], ConversationFilter], ...] = (
             lambda f: f.provider("claude-ai"),
@@ -555,7 +592,7 @@ class TestConversationFilterChaining:
             assert method_fn(fresh) is fresh
 
     @pytest.mark.asyncio
-    async def test_filter_chain_multiple_methods(self: Any, filter_repo: Any) -> None:
+    async def test_filter_chain_multiple_methods(self, filter_repo: ConversationRepository) -> None:
         """Chain must apply ALL filters — provider, limit both take effect."""
         result = await ConversationFilter(filter_repo).provider("claude-ai").limit(1).sort("date").list()
         assert isinstance(result, list)
@@ -567,28 +604,28 @@ class TestConversationFilterTerminal:
     """Terminal methods: first, count, delete."""
 
     @pytest.mark.asyncio
-    async def test_filter_first(self: Any, filter_repo: Any) -> None:
+    async def test_filter_first(self, filter_repo: ConversationRepository) -> None:
         result = await ConversationFilter(filter_repo).first()
         assert result is not None
         assert hasattr(result, "id")
 
     @pytest.mark.asyncio
-    async def test_filter_first_empty(self: Any, filter_repo: Any) -> None:
+    async def test_filter_first_empty(self, filter_repo: ConversationRepository) -> None:
         result = await ConversationFilter(filter_repo).provider("nonexistent").first()
         assert result is None
 
     @pytest.mark.asyncio
-    async def test_filter_count(self: Any, filter_repo: Any) -> None:
+    async def test_filter_count(self, filter_repo: ConversationRepository) -> None:
         count = await ConversationFilter(filter_repo).count()
         assert count == 3
 
     @pytest.mark.asyncio
-    async def test_filter_count_with_filter(self: Any, filter_repo: Any) -> None:
+    async def test_filter_count_with_filter(self, filter_repo: ConversationRepository) -> None:
         count = await ConversationFilter(filter_repo).provider("claude-ai").count()
         assert count == 2
 
     @pytest.mark.asyncio
-    async def test_filter_delete_removes_conversations(self: Any, filter_repo: Any) -> None:
+    async def test_filter_delete_removes_conversations(self, filter_repo: ConversationRepository) -> None:
         initial_count = await ConversationFilter(filter_repo).count()
         assert initial_count > 0
         deleted = await ConversationFilter(filter_repo).limit(1).delete()
@@ -601,7 +638,11 @@ class TestFilterDateParsing:
     """Date parsing for since/until — key regressions."""
 
     @pytest.mark.parametrize("method_name", ["since", "until"])
-    def test_date_method_raises_on_invalid(self: Any, filter_repo: Any, method_name: Any) -> None:
+    def test_date_method_raises_on_invalid(
+        self,
+        filter_repo: ConversationRepository,
+        method_name: DateMethodName,
+    ) -> None:
         f = ConversationFilter(filter_repo)
         with pytest.raises(ValueError, match="Cannot parse date"):
             getattr(f, method_name)("not-a-date")
@@ -615,14 +656,19 @@ class TestFilterDateParsing:
             ("until", "today"),
         ],
     )
-    def test_date_method_accepts_string_formats(self: Any, filter_repo: Any, method_name: Any, date_str: Any) -> None:
+    def test_date_method_accepts_string_formats(
+        self,
+        filter_repo: ConversationRepository,
+        method_name: DateMethodName,
+        date_str: str,
+    ) -> None:
         f = ConversationFilter(filter_repo)
         getattr(f, method_name)(date_str)
         field_name = "_since_date" if method_name == "since" else "_until_date"
         assert getattr(f, field_name) is not None
         assert isinstance(getattr(f, field_name), datetime)
 
-    def test_since_and_until_together_datetime(self: Any, filter_repo: Any) -> None:
+    def test_since_and_until_together_datetime(self, filter_repo: ConversationRepository) -> None:
         start = datetime(2024, 1, 1, tzinfo=timezone.utc)
         end = datetime(2024, 12, 31, tzinfo=timezone.utc)
         filter_obj = ConversationFilter(filter_repo).since(start).until(end)
@@ -635,12 +681,12 @@ class TestConversationFilterSort:
 
     @pytest.mark.parametrize("sort_key", ["date", "messages", "random"])
     @pytest.mark.asyncio
-    async def test_filter_sort(self: Any, filter_repo: Any, sort_key: Any) -> None:
+    async def test_filter_sort(self, filter_repo: ConversationRepository, sort_key: SortField) -> None:
         result = await ConversationFilter(filter_repo).sort(sort_key).list()
         assert len(result) > 0
 
     @pytest.mark.asyncio
-    async def test_filter_sort_reverse(self: Any, filter_repo: Any) -> None:
+    async def test_filter_sort_reverse(self, filter_repo: ConversationRepository) -> None:
         normal = await ConversationFilter(filter_repo).sort("date").list()
         reversed_list = await ConversationFilter(filter_repo).sort("date").reverse().list()
         if len(normal) > 1:
@@ -649,7 +695,11 @@ class TestConversationFilterSort:
 
     @pytest.mark.parametrize("sort_field", ["tokens", "words", "longest", "messages"])
     @pytest.mark.asyncio
-    async def test_sort_field_produces_results(self: Any, filter_repo_advanced: Any, sort_field: Any) -> None:
+    async def test_sort_field_produces_results(
+        self,
+        filter_repo_advanced: ConversationRepository,
+        sort_field: SortField,
+    ) -> None:
         result = await ConversationFilter(filter_repo_advanced).sort(sort_field).list()
         assert len(result) > 0
 
@@ -659,12 +709,16 @@ class TestConversationFilterHasTypes:
 
     @pytest.mark.parametrize("content_type", ["thinking", "tools", "attachments", "summary"])
     @pytest.mark.asyncio
-    async def test_has_content_type_returns_list(self: Any, filter_repo_advanced: Any, content_type: Any) -> None:
+    async def test_has_content_type_returns_list(
+        self,
+        filter_repo_advanced: ConversationRepository,
+        content_type: str,
+    ) -> None:
         result = await ConversationFilter(filter_repo_advanced).has(content_type).list()
         assert isinstance(result, list)
 
     @pytest.mark.asyncio
-    async def test_has_thinking_with_provider(self: Any, filter_repo_advanced: Any) -> None:
+    async def test_has_thinking_with_provider(self, filter_repo_advanced: ConversationRepository) -> None:
         result = await ConversationFilter(filter_repo_advanced).provider("claude-ai").has("thinking").list()
         assert len(result) >= 1
         for conv in result:
@@ -678,13 +732,16 @@ class TestConversationFilterSample:
     @pytest.mark.parametrize("sample_size,expected", [(2, 2), (0, 0), (1, 1)])
     @pytest.mark.asyncio
     async def test_sample_returns_correct_count(
-        self: Any, filter_repo_advanced: Any, sample_size: Any, expected: Any
+        self,
+        filter_repo_advanced: ConversationRepository,
+        sample_size: int,
+        expected: int,
     ) -> None:
         result = await ConversationFilter(filter_repo_advanced).sample(sample_size).list()
         assert len(result) == expected
 
     @pytest.mark.asyncio
-    async def test_sample_with_filter_respects_filters(self: Any, filter_repo_advanced: Any) -> None:
+    async def test_sample_with_filter_respects_filters(self, filter_repo_advanced: ConversationRepository) -> None:
         result = await ConversationFilter(filter_repo_advanced).provider("claude-ai").sample(2).list()
         assert all(c.provider == "claude-ai" for c in result)
 
@@ -693,7 +750,7 @@ class TestConversationFilterCombinedFilters:
     """Combined positive + negative filters — key regressions."""
 
     @pytest.mark.asyncio
-    async def test_exclude_provider_and_exclude_tag(self: Any, filter_repo_advanced: Any) -> None:
+    async def test_exclude_provider_and_exclude_tag(self, filter_repo_advanced: ConversationRepository) -> None:
         result = await (
             ConversationFilter(filter_repo_advanced).exclude_provider("claude-ai").exclude_tag("quantum").list()
         )
@@ -702,14 +759,14 @@ class TestConversationFilterCombinedFilters:
             assert "quantum" not in conv.tags
 
     @pytest.mark.asyncio
-    async def test_provider_with_exclude_tag(self: Any, filter_repo_advanced: Any) -> None:
+    async def test_provider_with_exclude_tag(self, filter_repo_advanced: ConversationRepository) -> None:
         result = await ConversationFilter(filter_repo_advanced).provider("claude-ai").exclude_tag("simple").list()
         assert all(c.provider == "claude-ai" for c in result)
         for conv in result:
             assert "simple" not in conv.tags
 
     @pytest.mark.asyncio
-    async def test_multiple_exclude_providers(self: Any, filter_repo_advanced: Any) -> None:
+    async def test_multiple_exclude_providers(self, filter_repo_advanced: ConversationRepository) -> None:
         result = await ConversationFilter(filter_repo_advanced).exclude_provider("claude-ai", "chatgpt").list()
         for conv in result:
             assert conv.provider not in ("claude-ai", "chatgpt")
@@ -719,23 +776,23 @@ class TestConversationFilterListSummaries:
     """list_summaries() terminal method — key regressions."""
 
     @pytest.mark.asyncio
-    async def test_list_summaries_returns_summary_objects(self: Any, filter_repo_advanced: Any) -> None:
+    async def test_list_summaries_returns_summary_objects(self, filter_repo_advanced: ConversationRepository) -> None:
         result = await ConversationFilter(filter_repo_advanced).list_summaries()
         assert len(result) > 0
         for summary in result:
             assert isinstance(summary, ConversationSummary)
 
     @pytest.mark.asyncio
-    async def test_list_summaries_rejects_content_filters(self: Any, filter_repo_advanced: Any) -> None:
+    async def test_list_summaries_rejects_content_filters(self, filter_repo_advanced: ConversationRepository) -> None:
         with pytest.raises(ValueError, match="Cannot use list_summaries"):
             await ConversationFilter(filter_repo_advanced).has("thinking").list_summaries()
 
     @pytest.mark.asyncio
-    async def test_list_summaries_allows_summary_has_filter(self: Any, filter_repo_advanced: Any) -> None:
+    async def test_list_summaries_allows_summary_has_filter(self, filter_repo_advanced: ConversationRepository) -> None:
         result = await ConversationFilter(filter_repo_advanced).has("summary").list_summaries()
         assert all(s.summary for s in result)
 
-    def test_can_use_summaries_check(self: Any, filter_repo_advanced: Any) -> None:
+    def test_can_use_summaries_check(self, filter_repo_advanced: ConversationRepository) -> None:
         simple = ConversationFilter(filter_repo_advanced).provider("claude-ai")
         assert simple.can_use_summaries() is True
         with_content = ConversationFilter(filter_repo_advanced).has("thinking")
@@ -757,10 +814,13 @@ class TestConversationFilterEmptyRepository:
     )
     @pytest.mark.asyncio
     async def test_empty_repo_terminal_operations(
-        self: Any, filter_repo_empty: Any, terminal_method: Any, expected_result: Any
+        self,
+        filter_repo_empty: ConversationRepository,
+        terminal_method: TerminalMethod,
+        expected_result: TerminalResult,
     ) -> None:
         filter_obj = ConversationFilter(filter_repo_empty)
-        result: object
+        result: TerminalResult
         if terminal_method == "list":
             result = await filter_obj.list()
         elif terminal_method == "first":
@@ -778,7 +838,7 @@ class TestConversationFilterBranching:
     """Branch predicate and pick regression tests."""
 
     @pytest.fixture
-    def filter_repo_branches(self: Any, tmp_path: Any) -> Any:
+    def filter_repo_branches(self, tmp_path: Path) -> ConversationRepository:
         db_path = tmp_path / "filter_branches.db"
         with open_connection(db_path) as conn:
             rebuild_index(conn)
@@ -813,7 +873,12 @@ class TestConversationFilterBranching:
             ("has_branches", False),
         ],
     )
-    def test_branch_predicates(self: Any, filter_repo_branches: Any, method: Any, value: Any) -> None:
+    def test_branch_predicates(
+        self,
+        filter_repo_branches: ConversationRepository,
+        method: BranchPredicateName,
+        value: bool,
+    ) -> None:
         filter_obj = ConversationFilter(filter_repo_branches)
         getattr(filter_obj, method)(value)
         if method == "is_continuation":
@@ -824,7 +889,7 @@ class TestConversationFilterBranching:
             assert filter_obj._has_branches is value
 
     @pytest.mark.asyncio
-    async def test_parent_filters_by_parent_id(self: Any, filter_repo_branches: Any) -> None:
+    async def test_parent_filters_by_parent_id(self, filter_repo_branches: ConversationRepository) -> None:
         result = await ConversationFilter(filter_repo_branches).parent("root").list()
         for conv in result:
             assert conv.parent_id == "root"
@@ -834,7 +899,7 @@ class TestFiltersPick:
     """pick() interactive picker regression tests."""
 
     @pytest.fixture
-    def filter_repo_pick(self: Any, tmp_path: Any) -> Any:
+    def filter_repo_pick(self, tmp_path: Path) -> ConversationRepository:
         db_path = tmp_path / "filter_pick.db"
         with open_connection(db_path) as conn:
             rebuild_index(conn)
@@ -844,12 +909,12 @@ class TestFiltersPick:
         return ConversationRepository(backend)
 
     @pytest.mark.asyncio
-    async def test_pick_no_results(self: Any, filter_repo_pick: Any) -> None:
+    async def test_pick_no_results(self, filter_repo_pick: ConversationRepository) -> None:
         result = await pick_filter(ConversationFilter(filter_repo_pick).provider("nonexistent"))
         assert result is None
 
     @pytest.mark.asyncio
-    async def test_pick_non_tty(self: Any, filter_repo_pick: Any) -> None:
+    async def test_pick_non_tty(self, filter_repo_pick: ConversationRepository) -> None:
         with patch("sys.stdout.isatty", return_value=False):
             result = await pick_filter(ConversationFilter(filter_repo_pick))
             assert result is not None
@@ -859,13 +924,13 @@ class TestFtsWithProviderFilter:
     """FTS + provider combined filter regression."""
 
     @pytest.mark.asyncio
-    async def test_fts_with_provider_match(self: Any, filter_repo: Any) -> None:
+    async def test_fts_with_provider_match(self, filter_repo: ConversationRepository) -> None:
         result = await ConversationFilter(filter_repo).contains("errors").provider("claude-ai").list()
         assert len(result) > 0
         assert all(c.provider == "claude-ai" for c in result)
 
     @pytest.mark.asyncio
-    async def test_fts_with_provider_mismatch(self: Any, filter_repo: Any) -> None:
+    async def test_fts_with_provider_mismatch(self, filter_repo: ConversationRepository) -> None:
         result = await ConversationFilter(filter_repo).contains("schema").provider("chatgpt").list()
         assert len(result) == 0
 
@@ -874,7 +939,7 @@ class TestDeleteCascade:
     """Delete cascade behavior."""
 
     @pytest.fixture
-    async def populated_db(self: Any, tmp_path: Any) -> Any:
+    async def populated_db(self, tmp_path: Path) -> tuple[Path, SQLiteBackend, ConversationRepository]:
         db_path = tmp_path / "cascade.db"
         backend = SQLiteBackend(db_path=db_path)
         repo = ConversationRepository(backend=backend)
@@ -892,7 +957,10 @@ class TestDeleteCascade:
         return db_path, backend, repo
 
     @pytest.mark.asyncio
-    async def test_delete_cascades_to_messages(self: Any, populated_db: Any) -> None:
+    async def test_delete_cascades_to_messages(
+        self,
+        populated_db: tuple[Path, SQLiteBackend, ConversationRepository],
+    ) -> None:
         db_path, backend, repo = populated_db
         f = ConversationFilter(repo).id("cascade-conv")
         deleted = await f.delete()
@@ -914,7 +982,11 @@ class TestFilterLimitZeroEdgeCases:
         ],
     )
     @pytest.mark.asyncio
-    async def test_limit_zero_returns_empty(self: Any, filter_repo_advanced: Any, setup_fn: Any) -> None:
+    async def test_limit_zero_returns_empty(
+        self,
+        filter_repo_advanced: ConversationRepository,
+        setup_fn: Callable[[ConversationFilter], ConversationFilter],
+    ) -> None:
         result = await setup_fn(ConversationFilter(filter_repo_advanced)).list()
         assert len(result) == 0
 

--- a/tests/unit/core/test_filters_schemas.py
+++ b/tests/unit/core/test_filters_schemas.py
@@ -7,11 +7,13 @@ filter logic.
 
 from __future__ import annotations
 
-from typing import Any
+from collections.abc import Callable
+from typing import Any, Literal, TypeAlias
 from unittest.mock import patch
 
 import pytest
 
+from polylogue.schemas.json_types import JSONDocument
 from polylogue.schemas.unified import (
     HarmonizedMessage,
     bulk_harmonize,
@@ -35,7 +37,20 @@ from polylogue.schemas.validator import (
 # =============================================================================
 
 
-REASONING_TRACES_CASES: list[tuple[Any, str, int, str | None, str]] = [
+ProviderName: TypeAlias = Literal["claude-code", "claude-ai", "chatgpt", "gemini", "codex"]
+ProviderPayload: TypeAlias = dict[str, Any]
+ProviderContent: TypeAlias = Any
+UsagePayload: TypeAlias = dict[str, Any] | None
+ExtractTextFn: TypeAlias = Callable[[Any], str]
+ReasoningTraceCase: TypeAlias = tuple[ProviderContent, str, int, str | None, str]
+ContentBlocksCase: TypeAlias = tuple[ProviderContent, int, list[str], str]
+ExtractTextCase: TypeAlias = tuple[ExtractTextFn, ProviderContent | UsagePayload, str, str]
+MessageRecordTypeCase: TypeAlias = tuple[str, str, bool, str]
+TokenUsageExpectation: TypeAlias = Literal["partial"] | None
+TokenUsageCase: TypeAlias = tuple[UsagePayload, TokenUsageExpectation, str]
+
+
+REASONING_TRACES_CASES: list[ReasoningTraceCase] = [
     (None, "claude-ai", 0, None, "empty_none_content"),
     (["string", 123], "claude-ai", 0, None, "non_dict_block"),
     ([{"type": "thinking", "thinking": "Let me think..."}], "claude-ai", 1, "Let me think...", "thinking_block"),
@@ -43,7 +58,7 @@ REASONING_TRACES_CASES: list[tuple[Any, str, int, str | None, str]] = [
     ([{"type": "thinking", "text": "Fallback text"}], "claude-ai", 1, "Fallback text", "thinking_fallback"),
 ]
 
-CONTENT_BLOCKS_CASES: list[tuple[Any, int, list[str], str]] = [
+CONTENT_BLOCKS_CASES: list[ContentBlocksCase] = [
     (None, 0, [], "empty_none"),
     (["string", 123, None], 0, [], "non_dict_items"),
     ([{"type": "text", "text": "Hello"}], 1, ["text"], "text_block"),
@@ -61,7 +76,7 @@ CONTENT_BLOCKS_CASES: list[tuple[Any, int, list[str], str]] = [
     ([{"type": "unknown", "data": "something"}], 0, [], "unknown_block_type"),
 ]
 
-EXTRACT_TEXT_CASES: list[tuple[Any, Any, str, str]] = [
+EXTRACT_TEXT_CASES: list[ExtractTextCase] = [
     (extract_claude_code_text, None, "", "claude_code_none"),
     (extract_claude_code_text, ["string", 123], "", "claude_code_non_dict"),
     (extract_chatgpt_text, None, "", "chatgpt_none"),
@@ -70,7 +85,7 @@ EXTRACT_TEXT_CASES: list[tuple[Any, Any, str, str]] = [
     (extract_chatgpt_text, {"parts": [123, "text", {"key": "val"}]}, "text", "chatgpt_non_string_parts"),
 ]
 
-HARMONIZED_MESSAGE_PROVIDER_CASES: list[tuple[str, str, str]] = [
+HARMONIZED_MESSAGE_PROVIDER_CASES: list[tuple[ProviderName, str, str]] = [
     ("claude-code", "claude_code_msg", "Claude Code extraction"),
     ("claude-ai", "claude_ai_msg", "Claude AI extraction"),
     ("chatgpt", "chatgpt_msg", "ChatGPT extraction"),
@@ -78,14 +93,14 @@ HARMONIZED_MESSAGE_PROVIDER_CASES: list[tuple[str, str, str]] = [
     ("codex", "codex_msg", "Codex extraction"),
 ]
 
-MESSAGE_RECORD_TYPE_CASES: list[tuple[str, str, bool, str]] = [
+MESSAGE_RECORD_TYPE_CASES: list[MessageRecordTypeCase] = [
     ("claude-code", "user", True, "Claude Code user"),
     ("claude-code", "assistant", True, "Claude Code assistant"),
     ("claude-code", "metadata", False, "Claude Code metadata"),
     ("chatgpt", "anything", True, "Other providers always True"),
 ]
 
-TOKEN_USAGE_CASES: list[tuple[Any, str | None, str]] = [
+TOKEN_USAGE_CASES: list[TokenUsageCase] = [
     (None, None, "None usage"),
     ({}, None, "Empty dict (no tokens)"),
     ({"input_tokens": 100}, "partial", "Partial token fields"),
@@ -93,7 +108,7 @@ TOKEN_USAGE_CASES: list[tuple[Any, str | None, str]] = [
 
 
 class TestUnifiedMissingRole:
-    def test_missing_role_raises_error(self: Any) -> None:
+    def test_missing_role_raises_error(self) -> None:
         from polylogue.schemas.unified import _missing_role
 
         with pytest.raises(ValueError, match="Message has no role"):
@@ -103,7 +118,12 @@ class TestUnifiedMissingRole:
 class TestUnifiedExtractReasoningTraces:
     @pytest.mark.parametrize("content,provider,expected_len,expected_text,description", REASONING_TRACES_CASES)
     def test_extract_reasoning_traces(
-        self: Any, content: Any, provider: Any, expected_len: Any, expected_text: Any, description: Any
+        self,
+        content: ProviderContent,
+        provider: str,
+        expected_len: int,
+        expected_text: str | None,
+        description: str,
     ) -> None:
         result = extract_reasoning_traces(content, provider)
         assert len(result) == expected_len
@@ -114,7 +134,11 @@ class TestUnifiedExtractReasoningTraces:
 class TestUnifiedExtractContentBlocks:
     @pytest.mark.parametrize("content,expected_len,expected_types,description", CONTENT_BLOCKS_CASES)
     def test_extract_content_blocks(
-        self: Any, content: Any, expected_len: Any, expected_types: Any, description: Any
+        self,
+        content: ProviderContent,
+        expected_len: int,
+        expected_types: list[str],
+        description: str,
     ) -> None:
         result = extract_content_blocks(content)
         assert len(result) == expected_len
@@ -125,7 +149,12 @@ class TestUnifiedExtractContentBlocks:
 
 class TestUnifiedExtractTokenUsage:
     @pytest.mark.parametrize("usage,expected_type,description", TOKEN_USAGE_CASES)
-    def test_extract_token_usage(self: Any, usage: Any, expected_type: Any, description: Any) -> None:
+    def test_extract_token_usage(
+        self,
+        usage: UsagePayload,
+        expected_type: TokenUsageExpectation,
+        description: str,
+    ) -> None:
         result = extract_token_usage(usage)
         if expected_type is None:
             assert result is None
@@ -136,19 +165,30 @@ class TestUnifiedExtractTokenUsage:
 
 class TestUnifiedExtractTextHelpers:
     @pytest.mark.parametrize("extract_fn,content,expected,description", EXTRACT_TEXT_CASES)
-    def test_extract_text(self: Any, extract_fn: Any, content: Any, expected: Any, description: Any) -> None:
+    def test_extract_text(
+        self,
+        extract_fn: ExtractTextFn,
+        content: ProviderContent | UsagePayload,
+        expected: str,
+        description: str,
+    ) -> None:
         result = extract_fn(content)
         assert result == expected or expected in result
 
 
 class TestUnifiedExtractHarmonizedMessage:
-    def test_extract_harmonized_message_invalid_provider(self: Any) -> None:
+    def test_extract_harmonized_message_invalid_provider(self) -> None:
         with pytest.raises(ValueError, match="Unknown provider"):
             extract_harmonized_message("unknown_provider", {})
 
     @pytest.mark.parametrize("provider,msg_key,description", HARMONIZED_MESSAGE_PROVIDER_CASES)
-    def test_extract_harmonized_message_by_provider(self: Any, provider: Any, msg_key: Any, description: Any) -> None:
-        raw: dict[str, Any]
+    def test_extract_harmonized_message_by_provider(
+        self,
+        provider: ProviderName,
+        msg_key: str,
+        description: str,
+    ) -> None:
+        raw: JSONDocument
         if provider == "claude-code":
             raw = {
                 "uuid": "msg1",
@@ -168,29 +208,31 @@ class TestUnifiedExtractHarmonizedMessage:
 
 
 class TestUnifiedHarmonizeParsedMessage:
-    def test_harmonize_parsed_message_none_meta(self: Any) -> None:
+    def test_harmonize_parsed_message_none_meta(self) -> None:
         assert harmonize_parsed_message("claude-ai", None) is None
 
-    def test_harmonize_parsed_message_not_message_record(self: Any) -> None:
+    def test_harmonize_parsed_message_not_message_record(self) -> None:
         assert harmonize_parsed_message("claude-code", {"type": "metadata"}) is None
 
-    def test_harmonize_parsed_message_valid(self: Any) -> None:
+    def test_harmonize_parsed_message_valid(self) -> None:
         meta = {"raw": {"uuid": "msg1", "sender": "user", "text": "Hello"}}
         result = harmonize_parsed_message("claude-ai", meta)
         assert isinstance(result, HarmonizedMessage)
 
 
 class TestUnifiedBulkHarmonize:
-    def test_bulk_harmonize_no_provider_meta(self: Any) -> None:
+    def test_bulk_harmonize_no_provider_meta(self) -> None:
         class MockParsedMessage:
+            provider_meta: JSONDocument | None = None
+
             pass
 
         result = bulk_harmonize("claude-ai", [MockParsedMessage()])
         assert result == []
 
-    def test_bulk_harmonize_mixed_valid_invalid(self: Any) -> None:
+    def test_bulk_harmonize_mixed_valid_invalid(self) -> None:
         class MockParsedMessage:
-            def __init__(self: Any, meta: Any = None) -> None:
+            def __init__(self, meta: JSONDocument | None = None) -> None:
                 self.provider_meta = meta
 
         messages = [
@@ -211,7 +253,13 @@ class TestUnifiedBulkHarmonize:
 
 class TestUnifiedIsMessageRecord:
     @pytest.mark.parametrize("provider,record_type,expected,description", MESSAGE_RECORD_TYPE_CASES)
-    def test_is_message_record(self: Any, provider: Any, record_type: Any, expected: Any, description: Any) -> None:
+    def test_is_message_record(
+        self,
+        provider: str,
+        record_type: str,
+        expected: bool,
+        description: str,
+    ) -> None:
         result = is_message_record(provider, {"type": record_type})
         assert result == expected
 
@@ -222,33 +270,33 @@ class TestUnifiedIsMessageRecord:
 
 
 class TestValidatorImportErrorHandling:
-    def test_validator_jsonschema_not_installed(self: Any) -> None:
+    def test_validator_jsonschema_not_installed(self) -> None:
         with patch("polylogue.schemas.validator.jsonschema", None):
             with pytest.raises(ImportError, match="jsonschema not installed"):
                 SchemaValidator({})
 
 
 class TestValidatorAvailableProviders:
-    def test_available_providers_returns_list(self: Any) -> None:
+    def test_available_providers_returns_list(self) -> None:
         result = SchemaValidator.available_providers()
         assert isinstance(result, list)
 
 
 class TestValidatorDetectDrift:
-    def test_validate_detects_unexpected_field(self: Any) -> None:
+    def test_validate_detects_unexpected_field(self) -> None:
         schema = {"type": "object", "properties": {"name": {"type": "string"}}, "additionalProperties": False}
         validator = SchemaValidator(schema, strict=True)
         result = validator.validate({"name": "test", "extra": "field"})
         assert result.has_drift
         assert any("Unexpected field" in w for w in result.drift_warnings)
 
-    def test_validate_additional_properties_true(self: Any) -> None:
+    def test_validate_additional_properties_true(self) -> None:
         schema = {"type": "object", "properties": {"name": {"type": "string"}}, "additionalProperties": True}
         validator = SchemaValidator(schema, strict=True)
         result = validator.validate({"name": "test", "extra": "field"})
         assert not result.has_drift
 
-    def test_validate_additional_properties_schema(self: Any) -> None:
+    def test_validate_additional_properties_schema(self) -> None:
         schema = {
             "type": "object",
             "properties": {"name": {"type": "string"}},
@@ -257,7 +305,7 @@ class TestValidatorDetectDrift:
         validator = SchemaValidator(schema, strict=True)
         validator.validate({"name": "test", "extra": "value"})
 
-    def test_validate_nested_object_drift(self: Any) -> None:
+    def test_validate_nested_object_drift(self) -> None:
         schema = {
             "type": "object",
             "properties": {"user": {"type": "object", "properties": {"name": {"type": "string"}}}},
@@ -267,7 +315,7 @@ class TestValidatorDetectDrift:
         result = validator.validate(data)
         assert isinstance(result, ValidationResult)
 
-    def test_validate_list_items_drift(self: Any) -> None:
+    def test_validate_list_items_drift(self) -> None:
         schema = {
             "type": "object",
             "properties": {
@@ -281,7 +329,7 @@ class TestValidatorDetectDrift:
 
 
 class TestValidatorFormatError:
-    def test_validate_multiple_errors(self: Any) -> None:
+    def test_validate_multiple_errors(self) -> None:
         schema = {
             "type": "object",
             "required": ["name"],
@@ -293,25 +341,25 @@ class TestValidatorFormatError:
 
 
 class TestValidatorConvenienceFunction:
-    def test_validate_provider_export_raises_on_missing_schema(self: Any) -> None:
+    def test_validate_provider_export_raises_on_missing_schema(self) -> None:
         with pytest.raises(FileNotFoundError):
             validate_provider_export({}, "invalid_provider", strict=True)
 
 
 class TestValidationResult:
-    def test_validation_result_has_drift_property(self: Any) -> None:
+    def test_validation_result_has_drift_property(self) -> None:
         result = ValidationResult(is_valid=True, drift_warnings=["Field X is new"])
         assert result.has_drift is True
 
-    def test_validation_result_no_drift(self: Any) -> None:
+    def test_validation_result_no_drift(self) -> None:
         result = ValidationResult(is_valid=True)
         assert result.has_drift is False
 
-    def test_validation_result_raise_if_invalid(self: Any) -> None:
+    def test_validation_result_raise_if_invalid(self) -> None:
         result = ValidationResult(is_valid=False, errors=["Error 1", "Error 2"])
         with pytest.raises(ValueError, match="Schema validation failed"):
             result.raise_if_invalid()
 
-    def test_validation_result_raise_if_valid(self: Any) -> None:
+    def test_validation_result_raise_if_valid(self) -> None:
         result = ValidationResult(is_valid=True)
         result.raise_if_invalid()

--- a/tests/unit/devtools/test_pipeline_probe.py
+++ b/tests/unit/devtools/test_pipeline_probe.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
+from typing import TypeAlias
 
 import pytest
 
@@ -17,6 +18,52 @@ from polylogue.storage.blob_store import BlobStore
 from polylogue.storage.repository import ConversationRepository
 from polylogue.storage.store import RawConversationRecord
 from polylogue.types import Provider, ValidationStatus
+
+JsonScalar: TypeAlias = str | int | float | bool | None
+JsonValue: TypeAlias = JsonScalar | dict[str, "JsonValue"] | list["JsonValue"]
+JsonObject: TypeAlias = dict[str, JsonValue]
+JsonArray: TypeAlias = list[JsonValue]
+
+
+def _require_json_object(value: object) -> JsonObject:
+    assert isinstance(value, dict)
+    return value
+
+
+def _require_json_array(value: object) -> JsonArray:
+    assert isinstance(value, list)
+    return value
+
+
+def _require_int(value: object) -> int:
+    assert isinstance(value, int)
+    return value
+
+
+def _require_str(value: object) -> str:
+    assert isinstance(value, str)
+    return value
+
+
+def _require_bool(value: object) -> bool:
+    assert isinstance(value, bool)
+    return value
+
+
+def _require_number(value: object) -> int | float:
+    assert isinstance(value, int | float)
+    return value
+
+
+def _json_path(value: object, *keys: str) -> object:
+    current: object = value
+    for key in keys:
+        current = _require_json_object(current)[key]
+    return current
+
+
+def _load_json_object(text: str) -> JsonObject:
+    return _require_json_object(json.loads(text))
 
 
 class _Args(argparse.Namespace):
@@ -209,28 +256,36 @@ async def _seed_archive_source(tmp_path: Path) -> tuple[Path, Path]:
 
 async def test_run_probe_emits_real_pipeline_summary(tmp_path: Path) -> None:
     summary = await run_probe(_Args(tmp_path / "probe"))
-    acquisition_details = summary["run_payload"]["metrics"]["stages"]["ingest"]["details"]["acquisition"]
-    ingest_details = summary["run_payload"]["metrics"]["stages"]["ingest"]["details"]["batch_observations"]
+    run_payload = _require_json_object(summary["run_payload"])
+    metrics = _require_json_object(run_payload["metrics"])
+    stages = _require_json_object(metrics["stages"])
+    ingest = _require_json_object(stages["ingest"])
+    details = _require_json_object(ingest["details"])
+    acquisition_details = _require_json_object(details["acquisition"])
+    ingest_details = _require_json_object(details["batch_observations"])
 
-    assert summary["probe"]["provider"] == "chatgpt"
-    assert summary["probe"]["corpus_source"] == "default"
-    assert summary["probe"]["stage_sequence"] == ["acquire", "parse"]
-    assert summary["result"]["run_path"] is not None
-    assert summary["run_payload"]["metrics"]["total_duration_ms"] is not None
-    assert summary["run_payload"]["metrics"]["peak_rss_self_mb"] is not None
-    assert summary["run_payload"]["metrics"]["peak_rss_children_mb"] is not None
-    assert "index" not in summary["run_payload"]["metrics"]["stages"]
+    assert _json_path(summary, "probe", "provider") == "chatgpt"
+    assert _json_path(summary, "probe", "corpus_source") == "default"
+    assert _json_path(summary, "probe", "stage_sequence") == ["acquire", "parse"]
+    assert _json_path(summary, "result", "run_path") is not None
+    assert metrics["total_duration_ms"] is not None
+    assert metrics["peak_rss_self_mb"] is not None
+    assert metrics["peak_rss_children_mb"] is not None
+    assert "index" not in stages
     assert isinstance(acquisition_details, dict)
-    assert ingest_details["batch_count"] == 1
+    assert _require_int(ingest_details["batch_count"]) == 1
     assert ingest_details["max_current_rss_mb"] is not None
-    assert len(ingest_details["batches"]) == 1
-    assert ingest_details["batches"][0]["max_current_rss_mb"] is not None
-    assert ingest_details["batches"][0]["result_wait_elapsed_ms"] >= 0
-    assert ingest_details["batches"][0]["write_elapsed_ms"] >= 0
-    assert ingest_details["batches"][0]["commit_elapsed_ms"] >= 0
-    assert ingest_details["batches"][0]["raw_state_update_elapsed_ms"] >= 0
-    assert summary["db_stats"]["raw_conversations_count"] >= 1
-    assert len(summary["raw_fanout"]) == summary["db_stats"]["raw_conversations_count"]
+    batches = _require_json_array(ingest_details["batches"])
+    assert len(batches) == 1
+    first_batch = _require_json_object(batches[0])
+    assert first_batch["max_current_rss_mb"] is not None
+    assert _require_number(first_batch["result_wait_elapsed_ms"]) >= 0
+    assert _require_number(first_batch["write_elapsed_ms"]) >= 0
+    assert _require_number(first_batch["commit_elapsed_ms"]) >= 0
+    assert _require_number(first_batch["raw_state_update_elapsed_ms"]) >= 0
+    raw_count = _require_int(_json_path(summary, "db_stats", "raw_conversations_count"))
+    assert raw_count >= 1
+    assert len(_require_json_array(summary["raw_fanout"])) == raw_count
 
 
 async def test_run_probe_can_stage_real_source_subset(tmp_path: Path) -> None:
@@ -255,17 +310,21 @@ async def test_run_probe_can_stage_real_source_subset(tmp_path: Path) -> None:
 
     summary = await run_probe(args)
 
-    assert summary["probe"]["input_mode"] == "source-subset"
-    assert summary["probe"]["source_name"] == "inbox"
-    assert summary["probe"]["stage_sequence"] == ["acquire", "parse"]
-    assert summary["source_inputs"]["input_count"] == 2
-    assert summary["source_inputs"]["staged_file_count"] == 2
-    assert summary["source_inputs"]["total_bytes"] == total_bytes
-    assert summary["provenance"]["git_commit"] is not None
-    assert isinstance(summary["provenance"]["worktree_dirty"], bool)
-    assert len(summary["provenance"]["source_inputs_sha256"]) == 64
-    assert len(summary["provenance"]["source_input_fingerprints"]) == 2
-    assert all(len(entry["sha256"]) == 64 for entry in summary["provenance"]["source_input_fingerprints"])
+    source_inputs = _require_json_object(summary["source_inputs"])
+    provenance = _require_json_object(summary["provenance"])
+
+    assert _json_path(summary, "probe", "input_mode") == "source-subset"
+    assert _json_path(summary, "probe", "source_name") == "inbox"
+    assert _json_path(summary, "probe", "stage_sequence") == ["acquire", "parse"]
+    assert _require_int(source_inputs["input_count"]) == 2
+    assert _require_int(source_inputs["staged_file_count"]) == 2
+    assert _require_int(source_inputs["total_bytes"]) == total_bytes
+    assert provenance["git_commit"] is not None
+    assert isinstance(_require_bool(provenance["worktree_dirty"]), bool)
+    assert len(_require_str(provenance["source_inputs_sha256"])) == 64
+    fingerprints = _require_json_array(provenance["source_input_fingerprints"])
+    assert len(fingerprints) == 2
+    assert all(len(_require_str(_require_json_object(entry)["sha256"])) == 64 for entry in fingerprints)
 
 
 def test_write_probe_sources_threads_through_corpus_source(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
@@ -340,12 +399,14 @@ async def test_run_probe_applies_ingest_tuning_overrides(tmp_path: Path) -> None
     args.ingest_workers = 1
 
     summary = await run_probe(args)
-    ingest_details = summary["run_payload"]["metrics"]["stages"]["ingest"]["details"]["batch_observations"]
+    ingest_details = _require_json_object(
+        _json_path(summary, "run_payload", "metrics", "stages", "ingest", "details", "batch_observations")
+    )
 
-    assert summary["probe"]["raw_batch_size"] == 1
-    assert summary["probe"]["ingest_workers"] == 1
-    assert ingest_details["batch_count"] == 2
-    assert all(batch["workers"] == 1 for batch in ingest_details["batches"])
+    assert _json_path(summary, "probe", "raw_batch_size") == 1
+    assert _json_path(summary, "probe", "ingest_workers") == 1
+    assert _require_int(ingest_details["batch_count"]) == 2
+    assert all(_require_json_object(batch)["workers"] == 1 for batch in _require_json_array(ingest_details["batches"]))
 
 
 async def test_run_probe_can_measure_ingest_result_sizes(tmp_path: Path) -> None:
@@ -369,12 +430,15 @@ async def test_run_probe_can_measure_ingest_result_sizes(tmp_path: Path) -> None
     args.measure_ingest_result_size = True
 
     summary = await run_probe(args)
-    batch = summary["run_payload"]["metrics"]["stages"]["ingest"]["details"]["batch_observations"]
+    batch = _require_json_object(
+        _json_path(summary, "run_payload", "metrics", "stages", "ingest", "details", "batch_observations")
+    )
 
-    assert summary["probe"]["measure_ingest_result_size"] is True
+    assert _json_path(summary, "probe", "measure_ingest_result_size") is True
     assert batch["max_result_mb"] is not None
-    assert batch["batches"][0]["result_mb"] > 0
-    assert batch["batches"][0]["max_result_mb"] > 0
+    first_batch = _require_json_object(_require_json_array(batch["batches"])[0])
+    assert _require_number(first_batch["result_mb"]) > 0
+    assert _require_number(first_batch["max_result_mb"]) > 0
 
 
 async def test_run_probe_rejects_source_subset_without_source_paths(tmp_path: Path) -> None:
@@ -410,12 +474,12 @@ def test_main_writes_json_summary(tmp_path: Path, capsys: pytest.CaptureFixture[
         ]
     )
 
-    printed = json.loads(capsys.readouterr().out)
-    written = json.loads(json_out.read_text())
+    printed = _load_json_object(capsys.readouterr().out)
+    written = _load_json_object(json_out.read_text())
 
     assert exit_code == 0
-    assert printed["paths"]["workdir"] == str(workdir.resolve())
-    assert written["result"]["run_path"] is not None
+    assert _json_path(printed, "paths", "workdir") == str(workdir.resolve())
+    assert _json_path(written, "result", "run_path") is not None
 
 
 def test_main_runs_source_subset_mode(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
@@ -446,11 +510,11 @@ def test_main_runs_source_subset_mode(tmp_path: Path, capsys: pytest.CaptureFixt
         ]
     )
 
-    printed = json.loads(capsys.readouterr().out)
+    printed = _load_json_object(capsys.readouterr().out)
 
     assert exit_code == 0
-    assert printed["probe"]["input_mode"] == "source-subset"
-    assert printed["db_stats"]["raw_conversations_count"] == 1
+    assert _json_path(printed, "probe", "input_mode") == "source-subset"
+    assert _json_path(printed, "db_stats", "raw_conversations_count") == 1
 
 
 def test_main_uses_ephemeral_workdir_when_omitted(capsys: pytest.CaptureFixture[str]) -> None:
@@ -469,11 +533,11 @@ def test_main_uses_ephemeral_workdir_when_omitted(capsys: pytest.CaptureFixture[
         ]
     )
 
-    printed = json.loads(capsys.readouterr().out)
+    printed = _load_json_object(capsys.readouterr().out)
 
     assert exit_code == 0
-    assert "polylogue-pipeline-probe-" in printed["paths"]["workdir"]
-    assert printed["result"]["run_path"] is not None
+    assert "polylogue-pipeline-probe-" in _require_str(_json_path(printed, "paths", "workdir"))
+    assert _json_path(printed, "result", "run_path") is not None
 
 
 def test_main_returns_nonzero_when_budget_is_exceeded(capsys: pytest.CaptureFixture[str]) -> None:
@@ -496,11 +560,11 @@ def test_main_returns_nonzero_when_budget_is_exceeded(capsys: pytest.CaptureFixt
         ]
     )
 
-    printed = json.loads(capsys.readouterr().out)
+    printed = _load_json_object(capsys.readouterr().out)
 
     assert exit_code == 1
-    assert printed["budgets"]["ok"] is False
-    assert len(printed["budgets"]["violations"]) >= 1
+    assert _json_path(printed, "budgets", "ok") is False
+    assert len(_require_json_array(_json_path(printed, "budgets", "violations"))) >= 1
 
 
 async def test_run_probe_can_sample_archive_subset_and_persist_manifest(tmp_path: Path) -> None:
@@ -514,19 +578,20 @@ async def test_run_probe_can_sample_archive_subset_and_persist_manifest(tmp_path
     )
 
     summary = await run_probe(args)
-    manifest = json.loads(manifest_out.read_text(encoding="utf-8"))
+    manifest = _load_json_object(manifest_out.read_text(encoding="utf-8"))
 
-    assert summary["probe"]["input_mode"] == "archive-subset"
-    assert summary["sample"]["selected_count"] == 2
-    assert summary["sample"]["provider_counts"] == {"chatgpt": 1, "codex": 1}
-    assert summary["db_stats"]["raw_conversations_count"] == 2
-    assert summary["db_stats"]["conversations_count"] == 2
-    assert len(summary["raw_fanout"]) == 2
-    assert sum(item["conversation_count"] for item in summary["raw_fanout"]) == 2
-    assert summary["paths"]["manifest_path"].endswith("archive-subset-manifest.json")
-    assert len(summary["provenance"]["manifest_sha256"]) == 64
+    assert _json_path(summary, "probe", "input_mode") == "archive-subset"
+    assert _json_path(summary, "sample", "selected_count") == 2
+    assert _json_path(summary, "sample", "provider_counts") == {"chatgpt": 1, "codex": 1}
+    assert _json_path(summary, "db_stats", "raw_conversations_count") == 2
+    assert _json_path(summary, "db_stats", "conversations_count") == 2
+    raw_fanout = _require_json_array(summary["raw_fanout"])
+    assert len(raw_fanout) == 2
+    assert sum(_require_int(_require_json_object(item)["conversation_count"]) for item in raw_fanout) == 2
+    assert _require_str(_json_path(summary, "paths", "manifest_path")).endswith("archive-subset-manifest.json")
+    assert len(_require_str(_json_path(summary, "provenance", "manifest_sha256"))) == 64
     assert manifest["sample_per_provider"] == 1
-    assert len(manifest["records"]) == 2
+    assert len(_require_json_array(manifest["records"])) == 2
 
 
 async def test_run_probe_can_replay_archive_subset_manifest(tmp_path: Path) -> None:
@@ -551,9 +616,9 @@ async def test_run_probe_can_replay_archive_subset_manifest(tmp_path: Path) -> N
 
     summary = await run_probe(replay_args)
 
-    assert summary["sample"]["selected_count"] == 2
-    assert summary["sample"]["sample_per_provider"] == 1
-    assert summary["sample"]["provider_counts"] == {"chatgpt": 1, "codex": 1}
+    assert _json_path(summary, "sample", "selected_count") == 2
+    assert _json_path(summary, "sample", "sample_per_provider") == 1
+    assert _json_path(summary, "sample", "provider_counts") == {"chatgpt": 1, "codex": 1}
 
 
 async def test_run_probe_rejects_empty_archive_subset(tmp_path: Path) -> None:

--- a/tests/unit/devtools/test_validation_lanes.py
+++ b/tests/unit/devtools/test_validation_lanes.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 import pytest
 
 from devtools.lane_models import LaneEntry
@@ -19,30 +17,30 @@ from polylogue.scenarios import AssertionSpec, ExecutionKind, polylogue_executio
 
 
 class TestValidationLanesImportable:
-    def test_module_imports(self: Any) -> None:
+    def test_module_imports(self) -> None:
         import devtools.run_validation_lanes  # noqa: F401
 
-    def test_main_callable(self: Any) -> None:
+    def test_main_callable(self) -> None:
         assert callable(main)
 
 
 class TestLaneParsing:
     @pytest.mark.parametrize("lane_name", sorted(VALID_LANES))
-    def test_valid_lane_returns_config(self: Any, lane_name: Any) -> None:
+    def test_valid_lane_returns_config(self, lane_name: str) -> None:
         lane = parse_lane(lane_name)
         assert isinstance(lane, LaneEntry)
         assert lane.name == lane_name
 
-    def test_invalid_lane_raises_value_error(self: Any) -> None:
+    def test_invalid_lane_raises_value_error(self) -> None:
         with pytest.raises(ValueError, match="Invalid lane"):
             parse_lane("nope")
 
-    def test_all_lanes_have_description_and_timeout(self: Any) -> None:
+    def test_all_lanes_have_description_and_timeout(self) -> None:
         for lane in LANES.values():
             assert lane.description
             assert lane.timeout_s > 0
 
-    def test_machine_contract_lane_carries_shared_operation_metadata(self: Any) -> None:
+    def test_machine_contract_lane_carries_shared_operation_metadata(self) -> None:
         lane = LANES["machine-contract"]
 
         assert lane.execution is not None
@@ -50,7 +48,7 @@ class TestLaneParsing:
         assert lane.operation_targets == ("cli.json-contract",)
         assert lane.tags == ("contract", "json", "cli")
 
-    def test_retrieval_checks_lane_carries_runtime_query_and_health_metadata(self: Any) -> None:
+    def test_retrieval_checks_lane_carries_runtime_query_and_health_metadata(self) -> None:
         lane = LANES["retrieval-checks"]
 
         assert lane.path_targets == ("conversation-query-loop", "message-fts-health-loop")
@@ -58,7 +56,7 @@ class TestLaneParsing:
         assert lane.operation_targets == ("query-conversations", "project-archive-health")
         assert lane.tags == ("contract", "retrieval", "health")
 
-    def test_composite_lane_inherits_metadata_through_catalog_entries(self: Any) -> None:
+    def test_composite_lane_inherits_metadata_through_catalog_entries(self) -> None:
         from devtools.validation_catalog import build_composite_lane_entries
 
         frontier_local = next(entry for entry in build_composite_lane_entries() if entry.name == "frontier-local")
@@ -75,21 +73,21 @@ class TestLaneParsing:
         assert "project-archive-health" in archive_intelligence.operation_targets
         assert runtime_substrate.family == "runtime-substrate"
 
-    def test_live_health_json_lane_carries_archive_health_metadata(self: Any) -> None:
+    def test_live_health_json_lane_carries_archive_health_metadata(self) -> None:
         lane = LANES["live-health-json"]
 
         assert "message-fts-health-loop" in lane.path_targets
         assert "archive_health" in lane.artifact_targets
         assert "project-archive-health" in lane.operation_targets
 
-    def test_live_products_status_lane_infers_status_query_metadata(self: Any) -> None:
+    def test_live_products_status_lane_infers_status_query_metadata(self) -> None:
         lane = LANES["live-products-status"]
 
         assert lane.path_targets == ("session-product-status-query-loop",)
         assert lane.artifact_targets == ("session_product_health", "session_product_status_results")
         assert lane.operation_targets == ("query-session-product-status",)
 
-    def test_live_products_debt_lane_infers_archive_debt_metadata(self: Any) -> None:
+    def test_live_products_debt_lane_infers_archive_debt_metadata(self) -> None:
         lane = LANES["live-products-debt"]
 
         assert lane.path_targets == ("archive-debt-query-loop",)
@@ -101,7 +99,7 @@ class TestLaneParsing:
         )
         assert lane.operation_targets == ("query-archive-debt",)
 
-    def test_live_embed_stats_lane_infers_embedding_status_metadata(self: Any) -> None:
+    def test_live_embed_stats_lane_infers_embedding_status_metadata(self) -> None:
         lane = LANES["live-embed-stats"]
 
         assert lane.path_targets == ("retrieval-band-health-loop", "embedding-status-query-loop")
@@ -120,7 +118,7 @@ class TestLaneParsing:
             "cli.json-contract",
         )
 
-    def test_pipeline_probe_chatgpt_lane_infers_parse_stage_runtime_metadata(self: Any) -> None:
+    def test_pipeline_probe_chatgpt_lane_infers_parse_stage_runtime_metadata(self) -> None:
         lane = LANES["pipeline-probe-chatgpt"]
 
         assert lane.execution is not None
@@ -147,7 +145,7 @@ class TestLaneParsing:
             "ingest-archive-runtime",
         )
 
-    def test_memory_budget_lane_preserves_wrapped_runtime_metadata(self: Any) -> None:
+    def test_memory_budget_lane_preserves_wrapped_runtime_metadata(self) -> None:
         lane = LANES["memory-budget"]
 
         assert lane.path_targets == ("conversation-query-loop",)
@@ -156,20 +154,20 @@ class TestLaneParsing:
 
 
 class TestCommandConstruction:
-    def test_machine_contract_lane_uses_pytest_marker(self: Any) -> None:
+    def test_machine_contract_lane_uses_pytest_marker(self) -> None:
         cmd = build_lane_command(LANES["machine-contract"])
         assert cmd[0] == "pytest"
         assert "machine_contract" in cmd
 
-    def test_query_routing_lane_uses_pytest_marker(self: Any) -> None:
+    def test_query_routing_lane_uses_pytest_marker(self) -> None:
         cmd = build_lane_command(LANES["query-routing"])
         assert "query_routing" in cmd
 
-    def test_showcase_baselines_lane_uses_verify_showcase_module(self: Any) -> None:
+    def test_showcase_baselines_lane_uses_verify_showcase_module(self) -> None:
         cmd = build_lane_command(LANES["showcase-baselines"])
         assert cmd[:2] == ["devtools", "verify-showcase"]
 
-    def test_pipeline_probe_chatgpt_lane_uses_probe_budgets(self: Any) -> None:
+    def test_pipeline_probe_chatgpt_lane_uses_probe_budgets(self) -> None:
         cmd = build_lane_command(LANES["pipeline-probe-chatgpt"])
         assert cmd[:2] == ["devtools", "pipeline-probe"]
         assert "--provider" in cmd
@@ -177,7 +175,7 @@ class TestCommandConstruction:
         assert "--max-total-ms" in cmd
         assert "--max-peak-rss-mb" in cmd
 
-    def test_live_archive_subset_parse_probe_lane_uses_medium_archive_subset_probe(self: Any) -> None:
+    def test_live_archive_subset_parse_probe_lane_uses_medium_archive_subset_probe(self) -> None:
         lane = LANES["live-archive-subset-parse-probe"]
         assert lane.execution is not None
         cmd = build_lane_command(lane)
@@ -192,20 +190,20 @@ class TestCommandConstruction:
         assert "--workdir" in cmd
         assert "--json-out" in cmd
 
-    def test_semantic_stack_lane_uses_explicit_semantic_suite(self: Any) -> None:
+    def test_semantic_stack_lane_uses_explicit_semantic_suite(self) -> None:
         cmd = build_lane_command(LANES["semantic-stack"])
         assert cmd[0] == "pytest"
         assert "tests/unit/core/test_semantic_facts.py" in cmd
         assert "tests/unit/sources/test_unified_semantic_laws.py" in cmd
 
-    def test_source_provider_fidelity_lane_uses_source_governance_suite(self: Any) -> None:
+    def test_source_provider_fidelity_lane_uses_source_governance_suite(self) -> None:
         cmd = build_lane_command(LANES["source-provider-fidelity"])
         assert cmd[0] == "pytest"
         assert "tests/unit/sources/test_source_laws.py" in cmd
         assert "tests/unit/sources/test_drive_ops.py" in cmd
         assert "tests/integration/test_security.py" in cmd
 
-    def test_source_provider_fidelity_lane_carries_source_acquisition_metadata(self: Any) -> None:
+    def test_source_provider_fidelity_lane_carries_source_acquisition_metadata(self) -> None:
         lane = LANES["source-provider-fidelity"]
 
         assert lane.path_targets == ("source-acquisition-loop",)
@@ -218,14 +216,14 @@ class TestCommandConstruction:
         assert lane.operation_targets == ("acquire-raw-conversations",)
         assert lane.tags == ("contract", "sources", "acquisition")
 
-    def test_maintenance_workflows_lane_uses_health_and_check_suite(self: Any) -> None:
+    def test_maintenance_workflows_lane_uses_health_and_check_suite(self) -> None:
         cmd = build_lane_command(LANES["maintenance-workflows"])
         assert cmd[0] == "pytest"
         assert "tests/unit/core/test_health_core.py" in cmd
         assert "tests/unit/cli/test_check.py" in cmd
         assert "tests/integration/test_health.py" in cmd
 
-    def test_maintenance_workflows_lane_carries_publication_runtime_metadata(self: Any) -> None:
+    def test_maintenance_workflows_lane_carries_publication_runtime_metadata(self) -> None:
         lane = LANES["maintenance-workflows"]
 
         assert lane.path_targets == ("site-publication-loop",)
@@ -238,7 +236,7 @@ class TestCommandConstruction:
         assert lane.operation_targets == ("publish-site",)
         assert lane.tags == ("contract", "maintenance", "publication")
 
-    def test_archive_data_products_lane_uses_product_and_consumer_suite(self: Any) -> None:
+    def test_archive_data_products_lane_uses_product_and_consumer_suite(self) -> None:
         cmd = build_lane_command(LANES["archive-data-products"])
         assert cmd[0] == "pytest"
         assert "tests/unit/cli/test_products.py" in cmd
@@ -246,7 +244,7 @@ class TestCommandConstruction:
         assert "tests/unit/mcp/test_tool_contracts.py" in cmd
         assert "tests/integration/test_health.py" in cmd
 
-    def test_semantic_product_normalization_lane_uses_normalization_toolchain_suite(self: Any) -> None:
+    def test_semantic_product_normalization_lane_uses_normalization_toolchain_suite(self) -> None:
         cmd = build_lane_command(LANES["semantic-product-normalization"])
         assert cmd[0] == "pytest"
         assert "tests/unit/core/test_repo_identity.py" in cmd
@@ -254,19 +252,19 @@ class TestCommandConstruction:
         assert "tests/integration/test_schema_operator_workflow.py" in cmd
         assert "tests/unit/sources/test_parsers_drive.py" in cmd
 
-    def test_retrieval_checks_lane_uses_retrieval_suite(self: Any) -> None:
+    def test_retrieval_checks_lane_uses_retrieval_suite(self) -> None:
         cmd = build_lane_command(LANES["retrieval-checks"])
         assert cmd[0] == "pytest"
         assert "tests/unit/cli/test_query_exec.py" in cmd
         assert "tests/unit/core/test_health_core.py" in cmd
 
-    def test_embeddings_coverage_lane_uses_embed_suite(self: Any) -> None:
+    def test_embeddings_coverage_lane_uses_embed_suite(self) -> None:
         cmd = build_lane_command(LANES["embeddings-coverage"])
         assert cmd[0] == "pytest"
         assert "tests/unit/cli/test_embed.py" in cmd
         assert "tests/unit/storage/test_embedding_stats.py" in cmd
 
-    def test_embeddings_coverage_lane_carries_embedding_runtime_metadata(self: Any) -> None:
+    def test_embeddings_coverage_lane_carries_embedding_runtime_metadata(self) -> None:
         lane = LANES["embeddings-coverage"]
 
         assert lane.path_targets == (
@@ -289,34 +287,34 @@ class TestCommandConstruction:
         )
         assert lane.tags == ("contract", "embeddings", "retrieval")
 
-    def test_evidence_tier_contracts_lane_uses_evidence_suite(self: Any) -> None:
+    def test_evidence_tier_contracts_lane_uses_evidence_suite(self) -> None:
         cmd = build_lane_command(LANES["evidence-tier-contracts"])
         assert cmd[0] == "pytest"
         assert "tests/unit/cli/test_products.py" in cmd
         assert "tests/unit/storage/test_backend.py" in cmd
         assert "tests/unit/pipeline/test_prepare_semantic.py" in cmd
 
-    def test_inference_tier_contracts_lane_uses_inference_suite(self: Any) -> None:
+    def test_inference_tier_contracts_lane_uses_inference_suite(self) -> None:
         cmd = build_lane_command(LANES["inference-tier-contracts"])
         assert cmd[0] == "pytest"
         assert "tests/unit/mcp/test_tool_contracts.py" in cmd
         assert "tests/unit/pipeline/test_prepare_semantic.py" in cmd
 
-    def test_mixed_consumer_contracts_lane_uses_consumer_suite(self: Any) -> None:
+    def test_mixed_consumer_contracts_lane_uses_consumer_suite(self) -> None:
         cmd = build_lane_command(LANES["mixed-consumer-contracts"])
         assert cmd[0] == "pytest"
         assert "tests/unit/cli/test_products.py" in cmd
         assert "tests/unit/core/test_facade_api.py" in cmd
         assert "tests/integration/test_health.py" in cmd
 
-    def test_retrieval_band_readiness_lane_uses_embed_health_suite(self: Any) -> None:
+    def test_retrieval_band_readiness_lane_uses_embed_health_suite(self) -> None:
         cmd = build_lane_command(LANES["retrieval-band-readiness"])
         assert cmd[0] == "pytest"
         assert "tests/unit/cli/test_embed.py" in cmd
         assert "tests/unit/storage/test_embedding_stats.py" in cmd
         assert "tests/unit/core/test_health_core.py" in cmd
 
-    def test_retrieval_band_readiness_lane_carries_retrieval_health_metadata(self: Any) -> None:
+    def test_retrieval_band_readiness_lane_carries_retrieval_health_metadata(self) -> None:
         lane = LANES["retrieval-band-readiness"]
 
         assert lane.path_targets == (
@@ -339,44 +337,44 @@ class TestCommandConstruction:
         )
         assert lane.tags == ("contract", "retrieval", "embeddings", "health")
 
-    def test_heuristic_inference_contracts_lane_uses_semantic_product_suite(self: Any) -> None:
+    def test_heuristic_inference_contracts_lane_uses_semantic_product_suite(self) -> None:
         cmd = build_lane_command(LANES["heuristic-inference-contracts"])
         assert cmd[0] == "pytest"
         assert "tests/unit/cli/test_products.py" in cmd
         assert "tests/unit/pipeline/test_prepare_semantic.py" in cmd
 
-    def test_probabilistic_enrichment_contracts_lane_uses_enrichment_suite(self: Any) -> None:
+    def test_probabilistic_enrichment_contracts_lane_uses_enrichment_suite(self) -> None:
         cmd = build_lane_command(LANES["probabilistic-enrichment-contracts"])
         assert cmd[0] == "pytest"
         assert "tests/unit/storage/test_embedding_stats.py" in cmd
         assert "tests/unit/mcp/test_tool_contracts.py" in cmd
 
-    def test_cleanup_contracts_lane_uses_health_and_check_suite(self: Any) -> None:
+    def test_cleanup_contracts_lane_uses_health_and_check_suite(self) -> None:
         cmd = build_lane_command(LANES["cleanup-contracts"])
         assert cmd[0] == "pytest"
         assert "tests/unit/cli/test_check.py" in cmd
         assert "tests/integration/test_health.py" in cmd
 
-    def test_memory_budget_lane_uses_budget_runner(self: Any) -> None:
+    def test_memory_budget_lane_uses_budget_runner(self) -> None:
         cmd = build_lane_command(LANES["memory-budget"])
         assert cmd[:2] == ["devtools", "query-memory-budget"]
         assert "--max-rss-mb" in cmd
         assert "polylogue" in cmd
 
-    def test_maintenance_memory_budget_lane_uses_check_preview(self: Any) -> None:
+    def test_maintenance_memory_budget_lane_uses_check_preview(self) -> None:
         cmd = build_lane_command(LANES["maintenance-memory-budget"])
         assert cmd[:2] == ["devtools", "query-memory-budget"]
         assert "--repair" in cmd
         assert "--cleanup" in cmd
         assert "--preview" in cmd
 
-    def test_scale_fast_lane_uses_direct_pytest_execution(self: Any) -> None:
+    def test_scale_fast_lane_uses_direct_pytest_execution(self) -> None:
         cmd = build_lane_command(LANES["scale-fast"])
         assert cmd[:2] == ["pytest", "-v"]
         assert "tests/unit/storage/test_scale.py" in cmd
         assert "--timeout=30" in cmd
 
-    def test_scale_slow_lane_uses_direct_pytest_marker_filter(self: Any) -> None:
+    def test_scale_slow_lane_uses_direct_pytest_marker_filter(self) -> None:
         cmd = build_lane_command(LANES["scale-slow"])
         assert cmd[:2] == ["pytest", "-v"]
         assert "tests/unit/storage/" in cmd
@@ -388,24 +386,24 @@ class TestCommandConstruction:
                 break
         assert found, f"-m slow not found in command: {cmd}"
 
-    def test_scale_stretch_lane_is_composite(self: Any) -> None:
+    def test_scale_stretch_lane_is_composite(self) -> None:
         lane = LANES["scale-stretch"]
         assert lane.is_composite
         assert lane.sub_lanes == ("scale-fast", "scale-slow")
 
-    def test_long_haul_lane_uses_campaign_runner(self: Any) -> None:
+    def test_long_haul_lane_uses_campaign_runner(self) -> None:
         cmd = build_lane_command(LANES["long-haul-small"])
         assert cmd[:2] == ["devtools", "run-benchmark-campaigns"]
         assert "--scale" in cmd
         assert "small" in cmd
 
-    def test_live_lane_uses_module_entrypoint(self: Any) -> None:
+    def test_live_lane_uses_module_entrypoint(self) -> None:
         cmd = build_lane_command(LANES["live-exercises"])
         assert cmd[:1] == ["polylogue"]
         assert "audit" in cmd
         assert "--live" in cmd
 
-    def test_live_maintenance_preview_lane_uses_doctor_preview(self: Any) -> None:
+    def test_live_maintenance_preview_lane_uses_doctor_preview(self) -> None:
         cmd = build_lane_command(LANES["live-maintenance-preview"])
         assert cmd[:1] == ["polylogue"]
         assert "doctor" in cmd
@@ -413,14 +411,14 @@ class TestCommandConstruction:
         assert "--cleanup" in cmd
         assert "--preview" in cmd
 
-    def test_live_products_tags_lane_uses_products_entrypoint(self: Any) -> None:
+    def test_live_products_tags_lane_uses_products_entrypoint(self) -> None:
         cmd = build_lane_command(LANES["live-products-tags"])
         assert cmd[:1] == ["polylogue"]
         assert "products" in cmd
         assert "tags" in cmd
         assert "--json" in cmd
 
-    def test_live_products_day_summaries_lane_uses_products_entrypoint(self: Any) -> None:
+    def test_live_products_day_summaries_lane_uses_products_entrypoint(self) -> None:
         cmd = build_lane_command(LANES["live-products-day-summaries"])
         assert cmd[:1] == ["polylogue"]
         assert "products" in cmd
@@ -429,7 +427,11 @@ class TestCommandConstruction:
 
 
 class TestLaneAssertions:
-    def test_run_lane_enforces_shared_assertion_spec(self: Any, monkeypatch: Any, capsys: Any) -> None:
+    def test_run_lane_enforces_shared_assertion_spec(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
         lane = LaneEntry(
             name="json-contract",
             description="JSON contract lane",
@@ -453,21 +455,21 @@ class TestLaneAssertions:
         assert exit_code == 1
         assert "failed assertion" in captured.out
 
-    def test_live_products_analytics_lane_uses_products_entrypoint(self: Any) -> None:
+    def test_live_products_analytics_lane_uses_products_entrypoint(self) -> None:
         cmd = build_lane_command(LANES["live-products-analytics"])
         assert cmd[:1] == ["polylogue"]
         assert "products" in cmd
         assert "analytics" in cmd
         assert "--json" in cmd
 
-    def test_live_products_debt_lane_uses_products_entrypoint(self: Any) -> None:
+    def test_live_products_debt_lane_uses_products_entrypoint(self) -> None:
         cmd = build_lane_command(LANES["live-products-debt"])
         assert cmd[:1] == ["polylogue"]
         assert "products" in cmd
         assert "debt" in cmd
         assert "--json" in cmd
 
-    def test_live_products_profiles_evidence_lane_uses_tiered_products_entrypoint(self: Any) -> None:
+    def test_live_products_profiles_evidence_lane_uses_tiered_products_entrypoint(self) -> None:
         cmd = build_lane_command(LANES["live-products-profiles-evidence"])
         assert cmd[:1] == ["polylogue"]
         assert "products" in cmd
@@ -475,7 +477,7 @@ class TestLaneAssertions:
         assert "evidence" in cmd
         assert "--json" in cmd
 
-    def test_live_products_profiles_inference_lane_uses_tiered_products_entrypoint(self: Any) -> None:
+    def test_live_products_profiles_inference_lane_uses_tiered_products_entrypoint(self) -> None:
         cmd = build_lane_command(LANES["live-products-profiles-inference"])
         assert cmd[:1] == ["polylogue"]
         assert "products" in cmd
@@ -483,14 +485,14 @@ class TestLaneAssertions:
         assert "inference" in cmd
         assert "--json" in cmd
 
-    def test_live_products_enrichments_lane_uses_enrichment_entrypoint(self: Any) -> None:
+    def test_live_products_enrichments_lane_uses_enrichment_entrypoint(self) -> None:
         cmd = build_lane_command(LANES["live-products-enrichments"])
         assert cmd[:1] == ["polylogue"]
         assert "products" in cmd
         assert "enrichments" in cmd
         assert "--json" in cmd
 
-    def test_live_session_product_repair_lane_uses_doctor_repair_target(self: Any) -> None:
+    def test_live_session_product_repair_lane_uses_doctor_repair_target(self) -> None:
         cmd = build_lane_command(LANES["live-session-product-repair"])
         assert cmd[:1] == ["polylogue"]
         assert "doctor" in cmd
@@ -498,11 +500,11 @@ class TestLaneAssertions:
         assert "--target" in cmd
         assert "session_products" in cmd
 
-    def test_composite_lane_has_no_direct_command(self: Any) -> None:
+    def test_composite_lane_has_no_direct_command(self) -> None:
         with pytest.raises(ValueError, match="composite"):
             build_lane_command(LANES["frontier-local"])
 
-    def test_dry_run_returns_zero(self: Any, capsys: Any) -> None:
+    def test_dry_run_returns_zero(self, capsys: pytest.CaptureFixture[str]) -> None:
         exit_code = main(["--lane", "frontier-local", "--dry-run"])
         captured = capsys.readouterr()
 
@@ -512,7 +514,7 @@ class TestLaneAssertions:
         assert "showcase-baselines" in captured.out
         assert "semantic-stack" in captured.out
 
-    def test_archive_intelligence_dry_run_includes_new_lanes(self: Any, capsys: Any) -> None:
+    def test_archive_intelligence_dry_run_includes_new_lanes(self, capsys: pytest.CaptureFixture[str]) -> None:
         exit_code = main(["--lane", "archive-intelligence", "--dry-run"])
         captured = capsys.readouterr()
 
@@ -520,14 +522,20 @@ class TestLaneAssertions:
         assert "retrieval-checks" in captured.out
         assert "embeddings-coverage" in captured.out
 
-    def test_frontier_extended_dry_run_includes_pipeline_probe_lane(self: Any, capsys: Any) -> None:
+    def test_frontier_extended_dry_run_includes_pipeline_probe_lane(
+        self,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
         exit_code = main(["--lane", "frontier-extended", "--dry-run"])
         captured = capsys.readouterr()
 
         assert exit_code == 0
         assert "pipeline-probe-chatgpt" in captured.out
 
-    def test_source_runtime_alignment_dry_run_includes_new_lanes(self: Any, capsys: Any) -> None:
+    def test_source_runtime_alignment_dry_run_includes_new_lanes(
+        self,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
         exit_code = main(["--lane", "source-runtime-alignment", "--dry-run"])
         captured = capsys.readouterr()
 
@@ -535,7 +543,10 @@ class TestLaneAssertions:
         assert "source-provider-fidelity" in captured.out
         assert "maintenance-workflows" in captured.out
 
-    def test_live_maintenance_small_dry_run_includes_preview_and_budget(self: Any, capsys: Any) -> None:
+    def test_live_maintenance_small_dry_run_includes_preview_and_budget(
+        self,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
         exit_code = main(["--lane", "live-maintenance-small", "--dry-run"])
         captured = capsys.readouterr()
 
@@ -543,7 +554,10 @@ class TestLaneAssertions:
         assert "live-maintenance-preview" in captured.out
         assert "maintenance-memory-budget" in captured.out
 
-    def test_archive_data_products_live_dry_run_includes_local_and_live_product_lanes(self: Any, capsys: Any) -> None:
+    def test_archive_data_products_live_dry_run_includes_local_and_live_product_lanes(
+        self,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
         exit_code = main(["--lane", "archive-data-products-live", "--dry-run"])
         captured = capsys.readouterr()
 
@@ -551,7 +565,10 @@ class TestLaneAssertions:
         assert "archive-data-products" in captured.out
         assert "live-products-small" in captured.out
 
-    def test_domain_read_model_live_dry_run_includes_new_product_and_maintenance_lanes(self: Any, capsys: Any) -> None:
+    def test_domain_read_model_live_dry_run_includes_new_product_and_maintenance_lanes(
+        self,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
         exit_code = main(["--lane", "domain-read-model-live", "--dry-run"])
         captured = capsys.readouterr()
 
@@ -561,7 +578,10 @@ class TestLaneAssertions:
         assert "live-products-debt" in captured.out
         assert "live-maintenance-small" in captured.out
 
-    def test_domain_read_model_hardening_dry_run_expands_both_subtrees(self: Any, capsys: Any) -> None:
+    def test_domain_read_model_hardening_dry_run_expands_both_subtrees(
+        self,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
         exit_code = main(["--lane", "domain-read-model-hardening", "--dry-run"])
         captured = capsys.readouterr()
 
@@ -569,7 +589,10 @@ class TestLaneAssertions:
         assert "domain-read-model-contracts" in captured.out
         assert "domain-read-model-live" in captured.out
 
-    def test_runtime_substrate_contracts_dry_run_includes_contract_lanes(self: Any, capsys: Any) -> None:
+    def test_runtime_substrate_contracts_dry_run_includes_contract_lanes(
+        self,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
         exit_code = main(["--lane", "runtime-substrate-contracts", "--dry-run"])
         captured = capsys.readouterr()
 
@@ -579,7 +602,10 @@ class TestLaneAssertions:
         assert "maintenance-workflows" in captured.out
         assert "archive-data-products" in captured.out
 
-    def test_runtime_substrate_live_dry_run_includes_live_and_budget_lanes(self: Any, capsys: Any) -> None:
+    def test_runtime_substrate_live_dry_run_includes_live_and_budget_lanes(
+        self,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
         exit_code = main(["--lane", "runtime-substrate-live", "--dry-run"])
         captured = capsys.readouterr()
 
@@ -588,7 +614,10 @@ class TestLaneAssertions:
         assert "live-maintenance-small" in captured.out
         assert "memory-budget" in captured.out
 
-    def test_runtime_substrate_hardening_dry_run_expands_both_subtrees(self: Any, capsys: Any) -> None:
+    def test_runtime_substrate_hardening_dry_run_expands_both_subtrees(
+        self,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
         exit_code = main(["--lane", "runtime-substrate-hardening", "--dry-run"])
         captured = capsys.readouterr()
 
@@ -597,7 +626,8 @@ class TestLaneAssertions:
         assert "runtime-substrate-live" in captured.out
 
     def test_semantic_product_live_dry_run_includes_normalized_product_and_maintenance_lanes(
-        self: Any, capsys: Any
+        self,
+        capsys: pytest.CaptureFixture[str],
     ) -> None:
         exit_code = main(["--lane", "semantic-product-live", "--dry-run"])
         captured = capsys.readouterr()
@@ -608,7 +638,10 @@ class TestLaneAssertions:
         assert "live-products-debt" in captured.out
         assert "live-maintenance-small" in captured.out
 
-    def test_semantic_product_hardening_dry_run_expands_both_subtrees(self: Any, capsys: Any) -> None:
+    def test_semantic_product_hardening_dry_run_expands_both_subtrees(
+        self,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
         exit_code = main(["--lane", "semantic-product-hardening", "--dry-run"])
         captured = capsys.readouterr()
 
@@ -616,7 +649,10 @@ class TestLaneAssertions:
         assert "semantic-product-normalization" in captured.out
         assert "semantic-product-live" in captured.out
 
-    def test_evidence_contracts_dry_run_includes_tier_and_retrieval_lanes(self: Any, capsys: Any) -> None:
+    def test_evidence_contracts_dry_run_includes_tier_and_retrieval_lanes(
+        self,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
         exit_code = main(["--lane", "evidence-contracts", "--dry-run"])
         captured = capsys.readouterr()
 
@@ -626,7 +662,10 @@ class TestLaneAssertions:
         assert "mixed-consumer-contracts" in captured.out
         assert "retrieval-band-readiness" in captured.out
 
-    def test_evidence_live_dry_run_includes_tiered_and_repair_lanes(self: Any, capsys: Any) -> None:
+    def test_evidence_live_dry_run_includes_tiered_and_repair_lanes(
+        self,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
         exit_code = main(["--lane", "evidence-live", "--dry-run"])
         captured = capsys.readouterr()
 
@@ -638,7 +677,10 @@ class TestLaneAssertions:
         assert "live-session-product-repair" in captured.out
         assert "maintenance-memory-budget" in captured.out
 
-    def test_evidence_hardening_dry_run_expands_both_subtrees(self: Any, capsys: Any) -> None:
+    def test_evidence_hardening_dry_run_expands_both_subtrees(
+        self,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
         exit_code = main(["--lane", "evidence-hardening", "--dry-run"])
         captured = capsys.readouterr()
 

--- a/tests/unit/pipeline/test_parsing_service.py
+++ b/tests/unit/pipeline/test_parsing_service.py
@@ -4,15 +4,15 @@ from __future__ import annotations
 
 import asyncio
 import json
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Awaitable, Callable
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from polylogue.config import Config, Source
+from polylogue.lib.raw_payload_decode import JSONValue
 from polylogue.pipeline.services.acquisition import AcquireResult, AcquisitionService
 from polylogue.pipeline.services.acquisition_records import ScanResult
 from polylogue.pipeline.services.parsing import ParseResult, ParsingService
@@ -24,9 +24,13 @@ from polylogue.storage.repository import ConversationRepository
 from polylogue.storage.store import RawConversationRecord
 from polylogue.types import Provider
 
+WorkspacePaths = dict[str, Path]
+ConversationPayload = dict[str, JSONValue]
+VisitSourcesCallback = Callable[[RawConversationRecord], Awaitable[None]]
+
 
 class TestParseResultMerge:
-    async def test_merge_thread_safe(self: Any) -> None:
+    async def test_merge_thread_safe(self) -> None:
         result = ParseResult()
 
         async def merge_batch(start_id: int) -> None:
@@ -53,7 +57,7 @@ class TestParseResultMerge:
 
 
 class TestParsingServiceParseSources:
-    async def test_ingest_empty_sources_returns_empty_result(self: Any) -> None:
+    async def test_ingest_empty_sources_returns_empty_result(self) -> None:
         mock_repository = MagicMock()
         mock_backend = MagicMock()
         mock_repository.backend = mock_backend
@@ -86,7 +90,7 @@ class TestParsingServiceParseSources:
         assert result.counts["messages"] == 0
         assert len(result.processed_ids) == 0
 
-    async def test_ingest_calls_acquire_then_parse(self: Any) -> None:
+    async def test_ingest_calls_acquire_then_parse(self) -> None:
         mock_repository = MagicMock()
         mock_backend = MagicMock()
         mock_repository.backend = mock_backend
@@ -133,7 +137,7 @@ class TestParsingServiceParseSources:
         assert result.counts["messages"] == 5
         assert result.processed_ids == {"conv-1", "conv-2"}
 
-    async def test_ingest_sources_surfaces_batch_diagnostics_only(self: Any) -> None:
+    async def test_ingest_sources_surfaces_batch_diagnostics_only(self) -> None:
         mock_repository = MagicMock()
         mock_backend = MagicMock()
         mock_repository.backend = mock_backend
@@ -175,7 +179,7 @@ class TestParsingServiceParseSources:
         assert result.diagnostics["batch_observations"]["max_peak_rss_growth_mb"] == 12.5
         assert "session_product_refresh" not in result.diagnostics
 
-    async def test_ingest_dedupes_backlog_without_rebuilding_raw_id_list(self: Any) -> Any:
+    async def test_ingest_dedupes_backlog_without_rebuilding_raw_id_list(self) -> None:
         mock_repository = MagicMock()
         mock_backend = MagicMock()
         mock_repository.backend = mock_backend
@@ -189,12 +193,12 @@ class TestParsingServiceParseSources:
         parse_backlog_calls: list[list[str]] = []
         validation_backlog_calls: list[list[str]] = []
 
-        async def _parse_backlog(*, source_names: Any, exclude_raw_ids: Any) -> Any:
+        async def _parse_backlog(*, source_names: list[str] | None, exclude_raw_ids: list[str]) -> list[str]:
             assert source_names == ["test-source"]
             parse_backlog_calls.append(list(exclude_raw_ids))
             return ["raw-2", "raw-3", "raw-3"]
 
-        async def _validation_backlog(*, source_names: Any, exclude_raw_ids: Any) -> Any:
+        async def _validation_backlog(*, source_names: list[str] | None, exclude_raw_ids: list[str]) -> list[str]:
             assert source_names == ["test-source"]
             validation_backlog_calls.append(list(exclude_raw_ids))
             return ["raw-3", "raw-4", "raw-1"]
@@ -225,7 +229,7 @@ class TestParsingServiceParseSources:
             progress_callback=None,
         )
 
-    async def test_ingest_skips_parse_when_nothing_acquired(self: Any) -> None:
+    async def test_ingest_skips_parse_when_nothing_acquired(self) -> None:
         mock_repository = MagicMock()
         mock_backend = MagicMock()
         mock_repository.backend = mock_backend
@@ -256,7 +260,7 @@ class TestParsingServiceParseSources:
         mock_parse.assert_not_called()
         assert result.counts["conversations"] == 0
 
-    async def test_progress_callback_passed_to_both_stages(self: Any) -> None:
+    async def test_progress_callback_passed_to_both_stages(self) -> None:
         mock_repository = MagicMock()
         mock_backend = MagicMock()
         mock_repository.backend = mock_backend
@@ -295,7 +299,7 @@ class TestParsingServiceParseSources:
         # In unified ingest, validation is inline — callback passed to parse_from_raw
         mock_parse.assert_awaited_once_with(raw_ids=["raw-1"], progress_callback=callback)
 
-    async def test_backend_not_initialized_raises(self: Any) -> None:
+    async def test_backend_not_initialized_raises(self) -> None:
         mock_repository = MagicMock()
         mock_repository.backend = None
         mock_config = MagicMock(spec=Config)
@@ -307,7 +311,7 @@ class TestParsingServiceParseSources:
 
 
 class TestParsingServiceIntegration:
-    def _conversation_json(self: Any, conversation_id: str, title: str, message: str) -> dict[str, Any]:
+    def _conversation_json(self, conversation_id: str, title: str, message: str) -> ConversationPayload:
         return {
             "id": conversation_id,
             "title": title,
@@ -329,7 +333,9 @@ class TestParsingServiceIntegration:
             },
         }
 
-    async def test_ingest_with_real_database(self: Any, cli_workspace: Any, monkeypatch: Any) -> None:
+    async def test_ingest_with_real_database(
+        self, cli_workspace: WorkspacePaths, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         monkeypatch.setenv("POLYLOGUE_SCHEMA_VALIDATION", "off")
         inbox = cli_workspace["inbox_dir"]
         (inbox / "conversations.json").write_text(
@@ -349,7 +355,7 @@ class TestParsingServiceIntegration:
         assert result.counts["conversations"] >= 1
         assert result.processed_ids
 
-    async def test_parse_from_raw_parses_stored_conversations(self: Any, cli_workspace: Any) -> None:
+    async def test_parse_from_raw_parses_stored_conversations(self, cli_workspace: WorkspacePaths) -> None:
         inbox = cli_workspace["inbox_dir"]
         (inbox / "conversations.json").write_text(
             json.dumps([self._conversation_json("test-conv-raw", "Test Raw Conversation", "Hello from raw!")])
@@ -383,7 +389,7 @@ class TestParsingServiceIntegration:
 
 
 class TestParsingServiceStreaming:
-    async def test_parse_from_raw_uses_raw_headers_without_prefetching_full_records(self: Any, tmp_path: Any) -> None:
+    async def test_parse_from_raw_uses_raw_headers_without_prefetching_full_records(self, tmp_path: Path) -> None:
         backend = MagicMock()
         backend.iter_raw_conversations.side_effect = AssertionError("iter_raw_conversations should not be used")
 
@@ -405,7 +411,7 @@ class TestParsingServiceStreaming:
         repository.iter_raw_headers.assert_called_once_with(provider_name="chatgpt")
         assert mock_process.await_count == 1
 
-    async def test_parse_from_raw_splits_explicit_raw_ids_by_blob_budget(self: Any, tmp_path: Any) -> None:
+    async def test_parse_from_raw_splits_explicit_raw_ids_by_blob_budget(self, tmp_path: Path) -> None:
         backend = MagicMock()
         repository = MagicMock()
         repository.backend = backend
@@ -429,7 +435,7 @@ class TestParsingServiceStreaming:
         assert mock_process.await_args_list[0].args[2] == ["raw-1"]
         assert mock_process.await_args_list[1].args[2] == ["raw-2", "raw-3"]
 
-    async def test_parse_from_raw_splits_streamed_backlog_by_blob_budget(self: Any, tmp_path: Any) -> None:
+    async def test_parse_from_raw_splits_streamed_backlog_by_blob_budget(self, tmp_path: Path) -> None:
         backend = MagicMock()
 
         async def raw_headers() -> AsyncGenerator[tuple[str, int], None]:
@@ -465,7 +471,7 @@ class TestParsingServiceStreaming:
 class TestPlanningService:
     @patch("polylogue.pipeline.services.acquisition.iter_source_raw_data")
     async def test_parse_plan_uses_existing_raw_scope_without_scanning_sources(
-        self: Any, mock_iter: Any, tmp_path: Path
+        self, mock_iter: MagicMock, tmp_path: Path
     ) -> None:
         backend = SQLiteBackend(db_path=tmp_path / "test.db")
         config = Config(sources=[], archive_root=tmp_path / "archive", render_root=tmp_path / "render")
@@ -493,7 +499,7 @@ class TestPlanningService:
         assert set(plan.parse_ready_raw_ids) == {"raw-scoped"}
         mock_iter.assert_not_called()
 
-    async def test_planning_includes_scoped_validation_backlog(self: Any, tmp_path: Path) -> None:
+    async def test_planning_includes_scoped_validation_backlog(self, tmp_path: Path) -> None:
         backend = SQLiteBackend(db_path=tmp_path / "test.db")
         config = Config(sources=[], archive_root=tmp_path / "archive", render_root=tmp_path / "render")
         planner = PlanningService(backend=backend, config=config)
@@ -523,7 +529,7 @@ class TestPlanningService:
         assert set(plan.validate_raw_ids) == {"raw-scoped"}
 
     @patch("polylogue.pipeline.services.acquisition.iter_source_raw_data")
-    async def test_build_plan_dedupes_duplicate_scanned_raw_ids(self: Any, mock_iter: Any, tmp_path: Path) -> None:
+    async def test_build_plan_dedupes_duplicate_scanned_raw_ids(self, mock_iter: MagicMock, tmp_path: Path) -> None:
         backend = SQLiteBackend(db_path=tmp_path / "test.db")
         config = Config(sources=[], archive_root=tmp_path / "archive", render_root=tmp_path / "render")
         planner = PlanningService(backend=backend, config=config)
@@ -550,8 +556,8 @@ class TestPlanningService:
         assert plan.summary.details["duplicate_raw"] == 1
 
     async def test_build_plan_execution_does_not_load_backlog_content(
-        self: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> Any:
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         backend = SQLiteBackend(db_path=tmp_path / "test.db")
         config = Config(sources=[], archive_root=tmp_path / "archive", render_root=tmp_path / "render")
         planner = PlanningService(backend=backend, config=config)
@@ -575,9 +581,14 @@ class TestPlanningService:
 
         original = ConversationRepository.get_raw_conversations_batch
 
-        async def spy_batch(self: Any, ids: Any, *args: Any, **kwargs: Any) -> Any:
+        async def spy_batch(
+            repository: ConversationRepository,
+            ids: list[str],
+            *args: object,
+            **kwargs: object,
+        ) -> list[RawConversationRecord]:
             call_count[0] += 1
-            return await original(self, ids, *args, **kwargs)
+            return await original(repository, ids, *args, **kwargs)
 
         monkeypatch.setattr(ConversationRepository, "get_raw_conversations_batch", spy_batch)
         plan = await planner.build_plan(sources=[Source(name="inbox-a", path=source_dir)], stage="all", preview=False)
@@ -586,8 +597,8 @@ class TestPlanningService:
         assert call_count[0] == 0
 
     async def test_build_plan_preview_validates_backlog_in_batches(
-        self: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> Any:
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         backend = SQLiteBackend(db_path=tmp_path / "test.db")
         config = Config(sources=[], archive_root=tmp_path / "archive", render_root=tmp_path / "render")
         planner = PlanningService(backend=backend, config=config)
@@ -613,10 +624,15 @@ class TestPlanningService:
 
         original = ConversationRepository.get_raw_conversations_batch
 
-        async def spy_batch(self: Any, ids: Any, *args: Any, **kwargs: Any) -> Any:
+        async def spy_batch(
+            repository: ConversationRepository,
+            ids: list[str],
+            *args: object,
+            **kwargs: object,
+        ) -> list[RawConversationRecord]:
             call_count[0] += 1
             batch_sizes.append(len(ids))
-            return await original(self, ids, *args, **kwargs)
+            return await original(repository, ids, *args, **kwargs)
 
         monkeypatch.setattr(ConversationRepository, "get_raw_conversations_batch", spy_batch)
         plan = await planner.build_plan(sources=[Source(name="inbox-a", path=source_dir)], stage="all", preview=True)
@@ -625,7 +641,7 @@ class TestPlanningService:
         assert call_count[0] >= 2
         assert max(batch_sizes) <= ValidationService.RAW_BATCH_SIZE
 
-    async def test_planning_includes_only_parseable_backlog_statuses(self: Any, tmp_path: Path) -> None:
+    async def test_planning_includes_only_parseable_backlog_statuses(self, tmp_path: Path) -> None:
         backend = SQLiteBackend(db_path=tmp_path / "test.db")
         config = Config(sources=[], archive_root=tmp_path / "archive", render_root=tmp_path / "render")
         planner = PlanningService(backend=backend, config=config)
@@ -651,7 +667,7 @@ class TestPlanningService:
         assert plan.summary.details["backlog_parse"] == 2
         assert set(plan.parse_ready_raw_ids) == {"raw-passed", "raw-skipped"}
 
-    async def test_build_plan_force_reparse_simulates_reset_for_parse_backlog(self: Any, tmp_path: Path) -> None:
+    async def test_build_plan_force_reparse_simulates_reset_for_parse_backlog(self, tmp_path: Path) -> None:
         backend = SQLiteBackend(db_path=tmp_path / "test.db")
         config = Config(sources=[], archive_root=tmp_path / "archive", render_root=tmp_path / "render")
         planner = PlanningService(backend=backend, config=config)
@@ -724,10 +740,10 @@ class TestPlanningService:
 
     @patch("polylogue.pipeline.services.acquisition.AcquisitionService.visit_sources")
     async def test_build_plan_force_reparse_counts_scanned_existing_records(
-        self: Any,
-        mock_visit_sources: Any,
+        self,
+        mock_visit_sources: MagicMock,
         tmp_path: Path,
-    ) -> Any:
+    ) -> None:
         backend = SQLiteBackend(db_path=tmp_path / "test.db")
         config = Config(sources=[], archive_root=tmp_path / "archive", render_root=tmp_path / "render")
         planner = PlanningService(backend=backend, config=config)
@@ -747,11 +763,11 @@ class TestPlanningService:
         await backend.mark_raw_parsed("raw-existing", payload_provider="chatgpt")
 
         async def _visit_sources(
-            _sources: Any,
+            _sources: list[Source],
             *,
-            on_record: Any = None,
-            **_kwargs: Any,
-        ) -> Any:
+            on_record: VisitSourcesCallback | None = None,
+            **_kwargs: object,
+        ) -> ScanResult:
             assert on_record is not None
             await on_record(record)
             result = ScanResult()
@@ -780,10 +796,10 @@ class TestPlanningService:
 
     @patch("polylogue.pipeline.services.acquisition.AcquisitionService.visit_sources")
     async def test_build_plan_force_reparse_reuses_shared_backlog_semantics_for_scanned_records(
-        self: Any,
-        mock_visit_sources: Any,
+        self,
+        mock_visit_sources: MagicMock,
         tmp_path: Path,
-    ) -> Any:
+    ) -> None:
         backend = SQLiteBackend(db_path=tmp_path / "test.db")
         config = Config(sources=[], archive_root=tmp_path / "archive", render_root=tmp_path / "render")
         planner = PlanningService(backend=backend, config=config)
@@ -831,11 +847,11 @@ class TestPlanningService:
         )
 
         async def _visit_sources(
-            _sources: Any,
+            _sources: list[Source],
             *,
-            on_record: Any = None,
-            **_kwargs: Any,
-        ) -> Any:
+            on_record: VisitSourcesCallback | None = None,
+            **_kwargs: object,
+        ) -> ScanResult:
             assert on_record is not None
             for record in records:
                 await on_record(record)
@@ -865,7 +881,7 @@ class TestPlanningService:
 
     @pytest.mark.parametrize(("stage", "count_key"), [("render", "render"), ("index", "index")])
     async def test_build_plan_uses_count_query_for_render_and_index(
-        self: Any, tmp_path: Path, stage: str, count_key: str
+        self, tmp_path: Path, stage: str, count_key: str
     ) -> None:
         backend = MagicMock(spec=SQLiteBackend)
         backend.queries = MagicMock()

--- a/tests/unit/pipeline/test_resilience.py
+++ b/tests/unit/pipeline/test_resilience.py
@@ -8,18 +8,21 @@ verifies the pipeline recovers, logs, or surfaces the error cleanly.
 from __future__ import annotations
 
 import json
+from collections.abc import Sequence
 from datetime import datetime, timezone
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Any
+from typing import Literal, TypedDict
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 from hypothesis import HealthCheck, given, settings
 
 from polylogue.config import Source
+from polylogue.lib.raw_payload_decode import JSONValue
 from polylogue.lib.roles import Role
 from polylogue.pipeline.services.acquisition import AcquisitionService
-from polylogue.pipeline.services.parsing import ParseResult
+from polylogue.pipeline.services.parsing import ParseResult, ParsingService
 from polylogue.pipeline.services.validation import ValidationService
 from polylogue.sources.parsers.base import (
     ParsedContentBlock,
@@ -31,6 +34,9 @@ from polylogue.storage.backends.async_sqlite import SQLiteBackend
 from polylogue.storage.store import RawConversationRecord
 from polylogue.types import ContentBlockType, Provider, ValidationStatus
 from tests.infra.strategies import (
+    AcquisitionInputSpec,
+    ParseMergeEvent,
+    ValidationCase,
     acquisition_input_batch_strategy,
     build_acquisition_raw_bytes,
     build_validation_payload,
@@ -39,6 +45,14 @@ from tests.infra.strategies import (
     parse_merge_events_strategy,
     validation_case_strategy,
 )
+
+ConversationJson = dict[str, JSONValue]
+
+
+class ConversationNode(TypedDict):
+    message: dict[str, JSONValue]
+    parent: str | None
+    children: list[str]
 
 
 def _make_raw_record(
@@ -66,10 +80,9 @@ def _make_raw_record(
     )
 
 
-def _make_parsing_service(tmp_path: Path) -> Any:
+def _make_parsing_service(tmp_path: Path) -> ParsingService:
     """Shared factory to avoid boilerplate in each test."""
     from polylogue.config import Config
-    from polylogue.pipeline.services.parsing import ParsingService
     from polylogue.storage.backends.async_sqlite import SQLiteBackend
     from polylogue.storage.repository import ConversationRepository
 
@@ -86,12 +99,16 @@ def _make_parsing_service(tmp_path: Path) -> Any:
     )
 
 
+def _provider_hint(value: str | None) -> Provider | None:
+    return None if value is None else Provider.from_string(value)
+
+
 # ---------------------------------------------------------------------------
 # Fault 1: Parsing service handles valid JSON with unknown chatgpt structure
 # ---------------------------------------------------------------------------
 
 
-def test_parse_unknown_chatgpt_structure_returns_empty(tmp_path: Any) -> None:
+def test_parse_unknown_chatgpt_structure_returns_empty(tmp_path: Path) -> None:
     """Valid JSON but missing chatgpt mapping field returns empty, not an exception."""
     from polylogue.pipeline.services.ingest_worker import ingest_record
 
@@ -106,7 +123,7 @@ def test_parse_unknown_chatgpt_structure_returns_empty(tmp_path: Any) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_parse_chatgpt_no_messages_returns_empty(tmp_path: Any) -> None:
+def test_parse_chatgpt_no_messages_returns_empty(tmp_path: Path) -> None:
     """ChatGPT payload with empty mapping returns empty list."""
     from polylogue.pipeline.services.ingest_worker import ingest_record
 
@@ -128,7 +145,7 @@ def test_parse_chatgpt_no_messages_returns_empty(tmp_path: Any) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_parse_jsonl_all_invalid_lines_surfaces_error(tmp_path: Any) -> None:
+def test_parse_jsonl_all_invalid_lines_surfaces_error(tmp_path: Path) -> None:
     """JSONL where every line is invalid surfaces an error (by design).
 
     ingest_worker catches all exceptions and returns them in result.error.
@@ -147,7 +164,7 @@ def test_parse_jsonl_all_invalid_lines_surfaces_error(tmp_path: Any) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_parse_mixed_valid_invalid_jsonl_lines(tmp_path: Any) -> None:
+def test_parse_mixed_valid_invalid_jsonl_lines(tmp_path: Path) -> None:
     """JSONL with some valid lines: valid lines parsed, invalid lines skipped."""
     from polylogue.pipeline.services.ingest_worker import ingest_record
 
@@ -171,7 +188,7 @@ def test_parse_mixed_valid_invalid_jsonl_lines(tmp_path: Any) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_parse_unknown_provider_name(tmp_path: Any) -> None:
+def test_parse_unknown_provider_name(tmp_path: Path) -> None:
     """Unknown provider name falls back gracefully."""
     from polylogue.pipeline.services.ingest_worker import ingest_record
 
@@ -189,7 +206,7 @@ def test_parse_unknown_provider_name(tmp_path: Any) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_parse_claude_code_jsonl_with_null_fields(tmp_path: Any) -> None:
+def test_parse_claude_code_jsonl_with_null_fields(tmp_path: Path) -> None:
     """Claude-code JSONL with null fields in messages is handled gracefully."""
     from polylogue.pipeline.services.ingest_worker import ingest_record
 
@@ -207,11 +224,11 @@ def test_parse_claude_code_jsonl_with_null_fields(tmp_path: Any) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_parse_very_large_conversation_does_not_crash(tmp_path: Any) -> None:
+def test_parse_very_large_conversation_does_not_crash(tmp_path: Path) -> None:
     """Very large valid chatgpt payload is handled without crashing."""
     from polylogue.pipeline.services.ingest_worker import ingest_record
 
-    messages: dict[str, Any] = {}
+    messages: dict[str, ConversationNode] = {}
     prev_id: str | None = None
     for i in range(50):
         node_id = f"node-{i}"
@@ -249,7 +266,7 @@ def test_parse_very_large_conversation_does_not_crash(tmp_path: Any) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_parse_chatgpt_deeply_nested_malformed_nodes(tmp_path: Any) -> None:
+def test_parse_chatgpt_deeply_nested_malformed_nodes(tmp_path: Path) -> None:
     """ChatGPT payload with malformed node structure returns empty, not exception."""
     from polylogue.pipeline.services.ingest_worker import ingest_record
 
@@ -275,7 +292,7 @@ def test_parse_chatgpt_deeply_nested_malformed_nodes(tmp_path: Any) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_parse_chatgpt_bundle_with_one_invalid_item(tmp_path: Any) -> None:
+def test_parse_chatgpt_bundle_with_one_invalid_item(tmp_path: Path) -> None:
     """ChatGPT bundle list with one invalid item: valid items parsed, invalid skipped."""
     from polylogue.pipeline.services.ingest_worker import ingest_record
 
@@ -312,7 +329,7 @@ def test_parse_chatgpt_bundle_with_one_invalid_item(tmp_path: Any) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_parse_gemini_missing_text_fields(tmp_path: Any) -> None:
+def test_parse_gemini_missing_text_fields(tmp_path: Path) -> None:
     """Gemini payload with messages missing text fields is handled gracefully."""
     from polylogue.pipeline.services.ingest_worker import ingest_record
 
@@ -340,7 +357,9 @@ def test_parse_gemini_missing_text_fields(tmp_path: Any) -> None:
 
 @settings(max_examples=25, deadline=None, suppress_health_check=[HealthCheck.too_slow])
 @given(acquisition_input_batch_strategy())
-async def test_acquisition_law_counts_unique_raws_and_normalizes_provider_hints(batch: Any) -> None:
+async def test_acquisition_law_counts_unique_raws_and_normalizes_provider_hints(
+    batch: tuple[AcquisitionInputSpec, ...],
+) -> None:
     """Acquisition should store each unique raw payload once and keep raw provider hints canonical."""
     with TemporaryDirectory() as tempdir:
         backend = SQLiteBackend(db_path=Path(tempdir) / "acquire.db")
@@ -351,7 +370,7 @@ async def test_acquisition_law_counts_unique_raws_and_normalizes_provider_hints(
                 raw_bytes=build_acquisition_raw_bytes(spec),
                 source_path=f"/tmp/{index}.json",
                 source_index=index,
-                provider_hint=spec.provider_hint,
+                provider_hint=_provider_hint(spec.provider_hint),
             )
             for index, spec in enumerate(batch)
         ]
@@ -386,7 +405,7 @@ async def test_acquisition_law_counts_unique_raws_and_normalizes_provider_hints(
 
 @settings(max_examples=30, deadline=None)
 @given(validation_case_strategy())
-async def test_validation_law_matches_mode_and_payload_contract(case: Any) -> None:
+async def test_validation_law_matches_mode_and_payload_contract(case: ValidationCase) -> None:
     """Validation mode, malformed JSONL, and schema verdicts must produce one stable persisted contract."""
     from polylogue.schemas import ValidationResult
     from polylogue.storage.blob_store import get_blob_store
@@ -413,16 +432,16 @@ async def test_validation_law_matches_mode_and_payload_contract(case: Any) -> No
     class _SyntheticValidator:
         provider = provider_name
 
-        def __init__(self: Any) -> None:
-            self.max_samples_seen = "unset"
+        def __init__(self) -> None:
+            self.max_samples_seen: int | None | Literal["unset"] = "unset"
 
-        def validation_samples(self: Any, payload: Any, max_samples: Any = None) -> Any:
+        def validation_samples(self, payload: JSONValue, max_samples: int | None = None) -> list[JSONValue]:
             self.max_samples_seen = max_samples
             if isinstance(payload, list):
                 return [item for item in payload if isinstance(item, dict)]
             return [payload]
 
-        def validate(self: Any, _sample: Any) -> Any:
+        def validate(self, _sample: object) -> ValidationResult:
             return ValidationResult(
                 is_valid=case.invalid_sample_count == 0,
                 errors=["schema error"] if case.invalid_sample_count else [],
@@ -463,7 +482,7 @@ async def test_validation_law_matches_mode_and_payload_contract(case: Any) -> No
 
 @settings(max_examples=30, deadline=None, suppress_health_check=[HealthCheck.too_slow])
 @given(parse_merge_events_strategy())
-async def test_parse_result_merge_law_accumulates_counts_and_processed_ids(events: Any) -> None:
+async def test_parse_result_merge_law_accumulates_counts_and_processed_ids(events: list[ParseMergeEvent]) -> None:
     """ParseResult.merge_result should be componentwise additive with processed-id union semantics."""
     result = ParseResult()
     for event in events:
@@ -513,7 +532,9 @@ def test_ingest_worker_decodes_and_dispatches_provider(tmp_path: Path) -> None:
     assert result.error is None
 
 
-def test_ingest_worker_reuses_schema_resolution_and_skips_drift_walk(tmp_path: Path, monkeypatch: Any) -> None:
+def test_ingest_worker_reuses_schema_resolution_and_skips_drift_walk(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Parse-path validation should reuse one schema resolution and avoid unused drift traversal."""
     from polylogue.pipeline.services.ingest_worker import ingest_record
     from polylogue.schemas import ValidationResult
@@ -546,10 +567,16 @@ def test_ingest_worker_reuses_schema_resolution_and_skips_drift_walk(tmp_path: P
     observed: dict[str, object] = {}
 
     class _CapturingRegistry:
-        def __init__(self: Any) -> None:
+        def __init__(self) -> None:
             self.calls = 0
 
-        def resolve_payload(self: Any, provider: Any, payload: Any, *, source_path: Any = None) -> Any:
+        def resolve_payload(
+            self,
+            provider: str | Provider,
+            payload: JSONValue,
+            *,
+            source_path: str | None = None,
+        ) -> SchemaResolution:
             self.calls += 1
             observed["registry_provider"] = provider
             observed["registry_source_path"] = source_path
@@ -562,16 +589,21 @@ def test_ingest_worker_reuses_schema_resolution_and_skips_drift_walk(tmp_path: P
     class _CapturingValidator:
         provider = "chatgpt"
 
-        def validation_samples(self: Any, payload: Any, max_samples: Any = None) -> Any:
+        def validation_samples(self, payload: JSONValue, max_samples: int | None = None) -> list[JSONValue]:
             return [payload]
 
-        def validate(self: Any, _sample: Any, *, include_drift: Any = None) -> Any:
+        def validate(self, _sample: object, *, include_drift: bool | None = None) -> ValidationResult:
             observed["include_drift"] = include_drift
             return ValidationResult(is_valid=True)
 
     def _fake_for_payload(
-        provider: Any, payload: Any, *, source_path: Any = None, schema_resolution: Any = None, strict: Any = True
-    ) -> Any:
+        provider: str | Provider,
+        payload: JSONValue,
+        *,
+        source_path: str | None = None,
+        schema_resolution: SchemaResolution | None = None,
+        strict: bool = True,
+    ) -> _CapturingValidator:
         observed["validator_provider"] = provider
         observed["validator_source_path"] = source_path
         observed["validator_payload"] = payload
@@ -580,8 +612,13 @@ def test_ingest_worker_reuses_schema_resolution_and_skips_drift_walk(tmp_path: P
         return _CapturingValidator()
 
     def _fake_parse_payload(
-        provider: Any, payload: Any, fallback_id: Any, _depth: Any = 0, *, schema_resolution: Any = None
-    ) -> Any:
+        provider: str | Provider,
+        payload: JSONValue,
+        fallback_id: str,
+        _depth: int = 0,
+        *,
+        schema_resolution: SchemaResolution | None = None,
+    ) -> Sequence[ParsedConversation]:
         observed["parse_provider"] = provider
         observed["parse_schema_resolution"] = schema_resolution
         observed["parse_fallback_id"] = fallback_id

--- a/tests/unit/pipeline/test_run_sources.py
+++ b/tests/unit/pipeline/test_run_sources.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import asyncio
 import json
+from collections.abc import Mapping
 from pathlib import Path
-from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -28,8 +28,10 @@ from polylogue.storage.backends.connection import open_connection
 from polylogue.storage.state_views import PlanResult, RunResult
 from tests.infra.storage_records import make_conversation, make_message, store_records
 
+WorkspaceEnv = Mapping[str, Path]
 
-def _seed_conversations(workspace_env: Any, *conversation_ids: str, with_message: bool = False) -> None:
+
+def _seed_conversations(workspace_env: WorkspaceEnv, *conversation_ids: str, with_message: bool = False) -> None:
     db_path = workspace_env["data_root"] / "polylogue" / "polylogue.db"
     db_path.parent.mkdir(parents=True, exist_ok=True)
     with open_connection(db_path) as conn:
@@ -81,7 +83,7 @@ def test_normalize_stage_sequence_rejects_duplicates() -> None:
         normalize_stage_sequence(stage="all", stage_sequence=("parse", "parse"))
 
 
-def test_run_sources_accepts_explicit_leaf_stage_sequence(workspace_env: Any, tmp_path: Path) -> None:
+def test_run_sources_accepts_explicit_leaf_stage_sequence(workspace_env: WorkspaceEnv, tmp_path: Path) -> None:
     inbox = tmp_path / "explicit-sequence"
     inbox.mkdir(parents=True, exist_ok=True)
     _write_chatgpt_export(inbox / "conversations.json", "conv-explicit-sequence")
@@ -105,7 +107,10 @@ def test_run_sources_accepts_explicit_leaf_stage_sequence(workspace_env: Any, tm
     assert result.indexed is False
 
 
-def test_explicit_leaf_stage_sequence_uses_order_sensitive_leaf_semantics(workspace_env: Any, tmp_path: Path) -> None:
+def test_explicit_leaf_stage_sequence_uses_order_sensitive_leaf_semantics(
+    workspace_env: WorkspaceEnv,
+    tmp_path: Path,
+) -> None:
     config = Config(
         sources=[Source(name="explicit", path=tmp_path / "explicit")],
         archive_root=workspace_env["archive_root"],
@@ -181,7 +186,7 @@ def test_explicit_leaf_stage_sequence_uses_order_sensitive_leaf_semantics(worksp
     assert mock_index.await_args.kwargs["stage"] == "all"
 
 
-def test_ingest_stage_log_omits_full_batch_telemetry(workspace_env: Any, tmp_path: Path) -> None:
+def test_ingest_stage_log_omits_full_batch_telemetry(workspace_env: WorkspaceEnv, tmp_path: Path) -> None:
     config = Config(
         sources=[Source(name="explicit", path=tmp_path / "explicit")],
         archive_root=workspace_env["archive_root"],
@@ -246,7 +251,10 @@ def test_ingest_stage_log_omits_full_batch_telemetry(workspace_env: Any, tmp_pat
     assert "batches" not in details["batch_observations"]
 
 
-def test_materialize_stage_log_omits_full_chunk_telemetry(workspace_env: Any, tmp_path: Path) -> None:
+def test_materialize_stage_log_omits_full_chunk_telemetry(
+    workspace_env: WorkspaceEnv,
+    tmp_path: Path,
+) -> None:
     config = Config(
         sources=[Source(name="explicit", path=tmp_path / "explicit")],
         archive_root=workspace_env["archive_root"],
@@ -306,7 +314,7 @@ def test_materialize_stage_log_omits_full_chunk_telemetry(workspace_env: Any, tm
 
 
 class TestRunSourcesRenderFailures:
-    def test_render_failure_tracked_in_result(self: Any, workspace_env: Any) -> Any:
+    def test_render_failure_tracked_in_result(self, workspace_env: WorkspaceEnv) -> None:
         from polylogue.storage.state_views import RunResult
 
         archive_root = workspace_env["archive_root"]
@@ -316,7 +324,8 @@ class TestRunSourcesRenderFailures:
 
         with patch("polylogue.rendering.renderers.html.HTMLRenderer.render", new_callable=AsyncMock) as mock_render:
 
-            def render_side_effect(conversation_id: Any, output_path: Any) -> Any:
+            def render_side_effect(conversation_id: str, output_path: Path) -> MagicMock:
+                del output_path
                 if "fail-conv" in conversation_id:
                     raise ValueError("Render failed for testing")
                 return MagicMock()
@@ -331,7 +340,7 @@ class TestRunSourcesRenderFailures:
         assert failure["conversation_id"] == "test:fail-conv"
         assert "error" in failure
 
-    def test_render_continues_after_failure(self: Any, workspace_env: Any) -> Any:
+    def test_render_continues_after_failure(self, workspace_env: WorkspaceEnv) -> None:
         archive_root = workspace_env["archive_root"]
         archive_root.mkdir(parents=True, exist_ok=True)
         _seed_conversations(workspace_env, "test:first", "test:second", "test:third")
@@ -340,7 +349,8 @@ class TestRunSourcesRenderFailures:
 
         with patch("polylogue.rendering.renderers.html.HTMLRenderer.render", new_callable=AsyncMock) as mock_render:
 
-            def render_side_effect(conversation_id: Any, output_path: Any) -> Any:
+            def render_side_effect(conversation_id: str, output_path: Path) -> MagicMock:
+                del output_path
                 render_attempts.append(conversation_id)
                 if "second" in conversation_id:
                     raise ValueError("Failed on purpose")
@@ -351,7 +361,7 @@ class TestRunSourcesRenderFailures:
 
         assert set(render_attempts) >= {"test:first", "test:second", "test:third"}
 
-    def test_render_failure_count_in_counts(self: Any, workspace_env: Any) -> Any:
+    def test_render_failure_count_in_counts(self, workspace_env: WorkspaceEnv) -> None:
         archive_root = workspace_env["archive_root"]
         archive_root.mkdir(parents=True, exist_ok=True)
         _seed_conversations(workspace_env, "test:success", "test:fail1", "test:fail2")
@@ -359,7 +369,8 @@ class TestRunSourcesRenderFailures:
 
         with patch("polylogue.rendering.renderers.html.HTMLRenderer.render", new_callable=AsyncMock) as mock_render:
 
-            def render_side_effect(conversation_id: Any, output_path: Any) -> Any:
+            def render_side_effect(conversation_id: str, output_path: Path) -> MagicMock:
+                del output_path
                 if conversation_id in ["test:fail1", "test:fail2"]:
                     raise ValueError("Render failed")
                 return MagicMock()
@@ -370,7 +381,7 @@ class TestRunSourcesRenderFailures:
         assert result.counts["render_failures"] == 2
         assert result.counts["rendered"] == 1
 
-    def test_render_stage_uses_configured_render_root(self: Any, workspace_env: Any, tmp_path: Path) -> None:
+    def test_render_stage_uses_configured_render_root(self, workspace_env: WorkspaceEnv, tmp_path: Path) -> None:
         custom_render_root = tmp_path / "custom-render-root"
         _seed_conversations(workspace_env, "test:custom-render-root", with_message=True)
         config = Config(sources=[], archive_root=workspace_env["archive_root"], render_root=custom_render_root)
@@ -394,7 +405,12 @@ class TestRunSourcesIntegration:
         ],
     )
     def test_stage_matrix(
-        self: Any, workspace_env: Any, tmp_path: Path, stage: str, with_source_data: bool, monkeypatch: Any
+        self,
+        workspace_env: WorkspaceEnv,
+        tmp_path: Path,
+        stage: str,
+        with_source_data: bool,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         monkeypatch.setenv("POLYLOGUE_SCHEMA_VALIDATION", "strict")
         sources = []
@@ -458,7 +474,7 @@ class TestRunSourcesIntegration:
             else:
                 assert result.index_error is not None
 
-    def test_plan_snapshot_is_persisted_without_affecting_drift(self: Any, workspace_env: Any) -> None:
+    def test_plan_snapshot_is_persisted_without_affecting_drift(self, workspace_env: Mapping[str, Path]) -> None:
         config = Config(
             sources=[],
             archive_root=workspace_env["archive_root"],
@@ -480,7 +496,7 @@ class TestRunSourcesIntegration:
         assert result.drift["new"]["conversations"] == 0
         assert result.drift["removed"]["conversations"] == 0
 
-    def test_drift_calculation_without_plan(self: Any, workspace_env: Any, tmp_path: Path) -> None:
+    def test_drift_calculation_without_plan(self, workspace_env: Mapping[str, Path], tmp_path: Path) -> None:
         inbox = tmp_path / "inbox"
         inbox.mkdir()
         _write_chatgpt_export(inbox / "conversations.json", "conv-new")
@@ -498,7 +514,9 @@ class TestRunSourcesIntegration:
             result.counts["new_conversations"] + result.counts["changed_conversations"]
         )
 
-    def test_changed_conversation_is_not_reported_as_new(self: Any, workspace_env: Any, tmp_path: Path) -> None:
+    def test_changed_conversation_is_not_reported_as_new(
+        self, workspace_env: Mapping[str, Path], tmp_path: Path
+    ) -> None:
         inbox = tmp_path / "inbox"
         inbox.mkdir()
         export_path = inbox / "conversations.json"
@@ -523,7 +541,7 @@ class TestRunSourcesIntegration:
         assert second.drift["new"]["conversations"] == 0
         assert second.drift["changed"]["conversations"] == 1
 
-    def test_run_result_has_run_id(self: Any, workspace_env: Any) -> None:
+    def test_run_result_has_run_id(self, workspace_env: Mapping[str, Path]) -> None:
         config = Config(
             sources=[],
             archive_root=workspace_env["archive_root"],
@@ -534,7 +552,7 @@ class TestRunSourcesIntegration:
         assert isinstance(result.run_id, str)
         assert len(result.run_id) > 0
 
-    def test_materialize_stage_rebuilds_all_when_unscoped(self: Any, workspace_env: Any) -> None:
+    def test_materialize_stage_rebuilds_all_when_unscoped(self, workspace_env: Mapping[str, Path]) -> None:
         _seed_conversations(workspace_env, "test:materialize-rebuild", with_message=True)
         config = Config(
             sources=[],
@@ -563,7 +581,7 @@ class TestRunSourcesIntegration:
         assert result.counts["materialized"] == 1
         assert result.indexed is False
 
-    def test_index_error_captured(self: Any, workspace_env: Any) -> None:
+    def test_index_error_captured(self, workspace_env: Mapping[str, Path]) -> None:
         config = Config(
             sources=[],
             archive_root=workspace_env["archive_root"],
@@ -579,7 +597,7 @@ class TestRunSourcesIntegration:
         assert result.index_error is not None
         assert "Index rebuild failed" in result.index_error
 
-    def test_parse_stage_reuses_persisted_validation_status(self: Any, workspace_env: Any) -> None:
+    def test_parse_stage_reuses_persisted_validation_status(self, workspace_env: Mapping[str, Path]) -> None:
         from polylogue.storage.blob_store import get_blob_store
         from polylogue.storage.store import RawConversationRecord
 
@@ -634,7 +652,9 @@ class TestRunSourcesIntegration:
         asyncio.run(backend.close())
         assert result.counts["conversations"] >= 1
 
-    def test_materialize_stage_rebuild_progress_advances_by_processed_chunk(self: Any, workspace_env: Any) -> None:
+    def test_materialize_stage_rebuild_progress_advances_by_processed_chunk(
+        self, workspace_env: Mapping[str, Path]
+    ) -> None:
         _seed_conversations(workspace_env, "test:materialize-a", "test:materialize-b", with_message=True)
         backend = create_backend(workspace_env["data_root"] / "polylogue" / "polylogue.db")
         callback = MagicMock()
@@ -660,7 +680,7 @@ class TestRunSourcesIntegration:
             "Materializing: 2/2",
         ]
 
-    def test_all_stage_uses_bounded_rebuild_when_products_are_empty(self: Any, workspace_env: Any) -> None:
+    def test_all_stage_uses_bounded_rebuild_when_products_are_empty(self, workspace_env: Mapping[str, Path]) -> None:
         _seed_conversations(workspace_env, "test:all-a", "test:all-b", with_message=True)
         backend = create_backend(workspace_env["data_root"] / "polylogue" / "polylogue.db")
         callback = MagicMock()
@@ -688,7 +708,9 @@ class TestRunSourcesIntegration:
             "Materializing: 2/2",
         ]
 
-    def test_parse_with_explicit_source_filter_skips_acquire(self: Any, workspace_env: Any, tmp_path: Path) -> None:
+    def test_parse_with_explicit_source_filter_skips_acquire(
+        self, workspace_env: Mapping[str, Path], tmp_path: Path
+    ) -> None:
         scoped_source = tmp_path / "scoped"
         scoped_source.mkdir()
         config = Config(
@@ -734,10 +756,10 @@ class TestRunSourcesIntegration:
 
 class TestAcquisitionServiceAcquireSources:
     @pytest.fixture
-    def backend(self: Any, tmp_path: Path) -> SQLiteBackend:
+    def backend(self, tmp_path: Path) -> SQLiteBackend:
         return SQLiteBackend(db_path=tmp_path / "test.db")
 
-    async def test_acquire_empty_sources(self: Any, backend: SQLiteBackend) -> None:
+    async def test_acquire_empty_sources(self, backend: SQLiteBackend) -> None:
         from polylogue.pipeline.services.acquisition import AcquisitionService
 
         result = await AcquisitionService(backend=backend).acquire_sources([])
@@ -745,7 +767,7 @@ class TestAcquisitionServiceAcquireSources:
         assert result.raw_ids == []
 
     @patch("polylogue.pipeline.services.acquisition.iter_source_raw_data")
-    async def test_progress_callback_called(self: Any, mock_iter: Any, backend: SQLiteBackend) -> None:
+    async def test_progress_callback_called(self, mock_iter: MagicMock, backend: SQLiteBackend) -> None:
         from polylogue.pipeline.services.acquisition import AcquisitionService
 
         raw_data = RawConversationData(
@@ -768,7 +790,10 @@ class TestAcquisitionServiceAcquireSources:
     @pytest.mark.parametrize("error_scenario", ["iteration_error", "none_raw_data"])
     @patch("polylogue.pipeline.services.acquisition.iter_source_raw_data")
     async def test_acquire_handles_errors(
-        self: Any, mock_iter: Any, backend: SQLiteBackend, error_scenario: str
+        self,
+        mock_iter: MagicMock,
+        backend: SQLiteBackend,
+        error_scenario: str,
     ) -> None:
         from polylogue.pipeline.services.acquisition import AcquisitionService
 
@@ -786,7 +811,7 @@ class TestAcquisitionServiceAcquireSources:
 
 
 class TestAcquisitionServiceIntegration:
-    def _make_conv(self: Any, conversation_id: str, title: str, timestamp: int, message: str) -> dict[str, object]:
+    def _make_conv(self, conversation_id: str, title: str, timestamp: int, message: str) -> dict[str, object]:
         return {
             "id": conversation_id,
             "title": title,
@@ -808,7 +833,7 @@ class TestAcquisitionServiceIntegration:
             },
         }
 
-    async def test_acquire_real_chatgpt_file(self: Any, tmp_path: Path) -> None:
+    async def test_acquire_real_chatgpt_file(self, tmp_path: Path) -> None:
         from polylogue.pipeline.services.acquisition import AcquisitionService
 
         inbox = tmp_path / "inbox"
@@ -834,7 +859,7 @@ class TestAcquisitionServiceIntegration:
         assert data[0]["id"] == "conv-1"
         assert data[0]["title"] == "Test Chat"
 
-    async def test_acquire_multiple_json_files(self: Any, tmp_path: Path) -> None:
+    async def test_acquire_multiple_json_files(self, tmp_path: Path) -> None:
         from polylogue.pipeline.services.acquisition import AcquisitionService
 
         inbox = tmp_path / "inbox"
@@ -851,7 +876,7 @@ class TestAcquisitionServiceIntegration:
         assert result.counts["acquired"] == 1
         assert len(result.raw_ids) == 1
 
-    async def test_acquire_claude_code_sidecars_into_artifact_ledger(self: Any, tmp_path: Path) -> None:
+    async def test_acquire_claude_code_sidecars_into_artifact_ledger(self, tmp_path: Path) -> None:
         from polylogue.pipeline.services.acquisition import AcquisitionService
         from polylogue.schemas.verification_artifacts import list_artifact_observation_rows
         from polylogue.schemas.verification_requests import ArtifactObservationQuery
@@ -948,7 +973,7 @@ def _write_chatgpt_preview_export(path: Path, conversation_id: str) -> None:
 
 
 class TestSelectSources:
-    def test_select_all_sources_when_no_filter(self: Any, tmp_path: Path) -> None:
+    def test_select_all_sources_when_no_filter(self, tmp_path: Path) -> None:
         sources = [
             Source(name="source-a", path=tmp_path / "a"),
             Source(name="source-b", path=tmp_path / "b"),
@@ -959,7 +984,7 @@ class TestSelectSources:
         assert _select_sources(config, None) == sources
         assert _select_sources(config, []) == sources
 
-    def test_select_filtered_sources(self: Any, tmp_path: Path) -> None:
+    def test_select_filtered_sources(self, tmp_path: Path) -> None:
         sources = [
             Source(name="chatgpt-export", path=tmp_path / "a"),
             Source(name="claude-export", path=tmp_path / "b"),
@@ -973,7 +998,7 @@ class TestSelectSources:
             "codex-export",
         }
 
-    def test_select_empty_when_no_match(self: Any, tmp_path: Path) -> None:
+    def test_select_empty_when_no_match(self, tmp_path: Path) -> None:
         config = Config(
             sources=[Source(name="source-a", path=tmp_path / "a")],
             archive_root=tmp_path / "archive",
@@ -983,7 +1008,7 @@ class TestSelectSources:
 
 
 class TestPlanSources:
-    def test_plan_empty_config(self: Any, tmp_path: Path) -> None:
+    def test_plan_empty_config(self, tmp_path: Path) -> None:
         config = Config(sources=[], archive_root=tmp_path / "archive", render_root=tmp_path / "render")
         backend = SQLiteBackend(db_path=tmp_path / "preview.db")
         try:
@@ -998,7 +1023,7 @@ class TestPlanSources:
         assert result.sources == []
         assert result.cursors == {}
 
-    def test_plan_single_source(self: Any, tmp_path: Path) -> None:
+    def test_plan_single_source(self, tmp_path: Path) -> None:
         inbox = tmp_path / "inbox"
         inbox.mkdir()
         _write_chatgpt_preview_export(inbox / "conversations.json", "conv-1")
@@ -1024,7 +1049,7 @@ class TestPlanSources:
         assert result.sources == ["test-source"]
         assert result.stage_sequence == ["acquire", "parse", "materialize", "render", "site", "index"]
 
-    async def test_plan_inside_running_event_loop(self: Any, tmp_path: Path) -> None:
+    async def test_plan_inside_running_event_loop(self, tmp_path: Path) -> None:
         config = Config(sources=[], archive_root=tmp_path / "archive", render_root=tmp_path / "render")
         backend = SQLiteBackend(db_path=tmp_path / "preview.db")
         try:
@@ -1033,7 +1058,7 @@ class TestPlanSources:
             await backend.close()
         assert result.counts == {}
 
-    async def test_plan_accepts_explicit_leaf_stage_sequence(self: Any, tmp_path: Path) -> None:
+    async def test_plan_accepts_explicit_leaf_stage_sequence(self, tmp_path: Path) -> None:
         from polylogue.storage.blob_store import get_blob_store
         from polylogue.storage.store import RawConversationRecord
 
@@ -1101,7 +1126,7 @@ class TestPlanSources:
 
 
 class TestWriteRunJson:
-    def test_creates_runs_directory(self: Any, tmp_path: Any) -> None:
+    def test_creates_runs_directory(self, tmp_path: Path) -> None:
         import time
 
         from polylogue.pipeline.runner import _write_run_json
@@ -1114,7 +1139,7 @@ class TestWriteRunJson:
         assert (archive_root / "runs").exists()
         assert result.exists()
 
-    def test_writes_correct_content(self: Any, tmp_path: Any) -> None:
+    def test_writes_correct_content(self, tmp_path: Path) -> None:
         import time
 
         from polylogue.pipeline.runner import _write_run_json
@@ -1136,7 +1161,7 @@ class TestWriteRunJson:
         assert content["counts"] == {"conversations": 10, "messages": 50}
         assert content["indexed"] is True
 
-    def test_filename_contains_timestamp_and_id(self: Any, tmp_path: Any) -> None:
+    def test_filename_contains_timestamp_and_id(self, tmp_path: Path) -> None:
         from polylogue.pipeline.runner import _write_run_json
 
         archive_root = tmp_path / "archive"
@@ -1146,14 +1171,14 @@ class TestWriteRunJson:
 
 
 class TestLatestRun:
-    def test_no_runs_returns_none(self: Any, workspace_env: Any) -> None:
+    def test_no_runs_returns_none(self, workspace_env: Mapping[str, Path]) -> None:
         db_path = workspace_env["data_root"] / "polylogue" / "polylogue.db"
         db_path.parent.mkdir(parents=True, exist_ok=True)
         with open_connection(db_path):
             pass
         assert asyncio.run(latest_run()) is None
 
-    def test_returns_most_recent(self: Any, workspace_env: Any) -> None:
+    def test_returns_most_recent(self, workspace_env: Mapping[str, Path]) -> None:
         db_path = workspace_env["data_root"] / "polylogue" / "polylogue.db"
         db_path.parent.mkdir(parents=True, exist_ok=True)
         with open_connection(db_path) as conn:
@@ -1181,7 +1206,7 @@ class TestLatestRun:
         assert result.run_id == "run-1"
         assert result.timestamp == "3000"
 
-    def test_parses_json_columns(self: Any, workspace_env: Any) -> None:
+    def test_parses_json_columns(self, workspace_env: Mapping[str, Path]) -> None:
         db_path = workspace_env["data_root"] / "polylogue" / "polylogue.db"
         db_path.parent.mkdir(parents=True, exist_ok=True)
         plan = {"conversations": 5, "messages": 20}

--- a/tests/unit/sources/test_models.py
+++ b/tests/unit/sources/test_models.py
@@ -14,7 +14,7 @@ Coverage includes:
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any
+from typing import TypeAlias
 
 import pytest
 
@@ -62,6 +62,16 @@ CLAUDE_AI_ROLE_MAPPING = [
     ("", "unknown"),
 ]
 
+ChatGPTPartsInput: TypeAlias = list[object]
+GeminiPartsInput: TypeAlias = list[GeminiPart | dict[str, object]]
+GeminiThoughtSignatureInput: TypeAlias = list[GeminiThoughtSignature | dict[str, object] | str]
+ClaudeCodeMessageInput: TypeAlias = dict[str, object] | ClaudeCodeMessageContent | ClaudeCodeUserMessage | None
+RawRecordKwargs: TypeAlias = dict[str, object]
+ChatGPTConversationMessages: TypeAlias = list[tuple[str, str]]
+ProviderViewportRecord: TypeAlias = (
+    ClaudeCodeRecord | ClaudeAIChatMessage | ChatGPTMessage | GeminiMessage | CodexRecord
+)
+
 
 class TestChatGPTMessageTextContent:
     """Regression tests for ChatGPTMessage.text_content."""
@@ -77,7 +87,7 @@ class TestChatGPTMessageTextContent:
         ],
         ids=["string_parts", "none_parts", "dict_none_text", "dict_valid_text", "empty_parts"],
     )
-    def test_text_content_with_parts(self: Any, parts: Any, expected: Any) -> None:
+    def test_text_content_with_parts(self, parts: ChatGPTPartsInput, expected: str) -> None:
         msg = ChatGPTMessage(
             id="1",
             author=ChatGPTAuthor(role="user"),
@@ -85,11 +95,11 @@ class TestChatGPTMessageTextContent:
         )
         assert msg.text_content == expected
 
-    def test_text_content_no_content(self: Any) -> None:
+    def test_text_content_no_content(self) -> None:
         msg = ChatGPTMessage(id="1", author=ChatGPTAuthor(role="user"))
         assert msg.text_content == ""
 
-    def test_text_content_direct_text(self: Any) -> None:
+    def test_text_content_direct_text(self) -> None:
         msg = ChatGPTMessage(
             id="1",
             author=ChatGPTAuthor(role="user"),
@@ -98,55 +108,58 @@ class TestChatGPTMessageTextContent:
         assert msg.text_content == "Direct text"
 
     @pytest.mark.parametrize("role_in,expected", CHATGPT_ROLE_MAPPING)
-    def test_role_normalized(self: Any, role_in: Any, expected: Any) -> None:
-        msg = ChatGPTMessage(id="1", author=ChatGPTAuthor(role=role_in))
+    def test_role_normalized(self, role_in: str | None, expected: str) -> None:
+        msg = ChatGPTMessage(
+            id="1",
+            author=ChatGPTAuthor(role="user").model_copy(update={"role": role_in}),
+        )
         assert msg.role_normalized == expected
 
 
 class TestGeminiMessageTextContent:
     """Regression tests for GeminiMessage.text_content."""
 
-    def test_text_content_from_text_field(self: Any) -> None:
+    def test_text_content_from_text_field(self) -> None:
         msg = GeminiMessage(text="Hello", role="user")
         assert msg.text_content == "Hello"
 
-    def test_text_content_from_parts_dict_none_text(self: Any) -> None:
+    def test_text_content_from_parts_dict_none_text(self) -> None:
         """Regression: dict part with 'text' key but None value must not crash."""
         msg = GeminiMessage(text="", role="user", parts=[{"text": None}, {"text": "ok"}])
         assert msg.text_content == "ok"
 
-    def test_text_content_from_parts_typed(self: Any) -> None:
+    def test_text_content_from_parts_typed(self) -> None:
         from polylogue.sources.providers.gemini import GeminiPart
 
         msg = GeminiMessage(text="", role="model", parts=[GeminiPart(text="typed")])
         assert msg.text_content == "typed"
 
     @pytest.mark.parametrize("role_in,expected", GEMINI_ROLE_MAPPING)
-    def test_role_normalized(self: Any, role_in: Any, expected: Any) -> None:
-        msg = GeminiMessage(text="x", role=role_in)
+    def test_role_normalized(self, role_in: str | None, expected: str) -> None:
+        msg = GeminiMessage(text="x", role="user").model_copy(update={"role": role_in})
         assert msg.role_normalized == expected
 
-    def test_extract_content_blocks_dict_none_text(self: Any) -> None:
+    def test_extract_content_blocks_dict_none_text(self) -> None:
         """Regression: extract_content_blocks with None text in dict part must not crash."""
         msg = GeminiMessage(text="", role="user", parts=[{"text": None}, {"text": "ok"}])
         blocks = msg.extract_content_blocks()
         text_blocks = [b for b in blocks if b.text == "ok"]
         assert len(text_blocks) == 1
 
-    def test_extract_content_blocks_file_data(self: Any) -> None:
+    def test_extract_content_blocks_file_data(self) -> None:
         """File-only parts (inlineData) produce a FILE content block."""
         msg = GeminiMessage(text="", role="user", parts=[{"inlineData": {"mimeType": "image/png"}}])
         blocks = msg.extract_content_blocks()
         assert len(blocks) == 1
         assert blocks[0].type.value == "file"
 
-    def test_thinking_message(self: Any) -> None:
+    def test_thinking_message(self) -> None:
         msg = GeminiMessage(text="Thinking...", role="model", isThought=True)
         traces = msg.extract_reasoning_traces()
         assert len(traces) == 1
         assert traces[0].text == "Thinking..."
 
-    def test_role_none_defaults_to_unknown(self: Any) -> None:
+    def test_role_none_defaults_to_unknown(self) -> None:
         msg = GeminiMessage(text="hi", role="user").model_copy(update={"role": None})
         assert msg.role_normalized == "unknown"
 
@@ -160,7 +173,7 @@ class TestClaudeCodeRecordRole:
     """Test type→role mapping for all record types."""
 
     @pytest.mark.parametrize("record_type,expected_role", CLAUDE_CODE_TYPE_ROLE_MAPPING)
-    def test_type_role_mapping(self: Any, record_type: Any, expected_role: Any) -> None:
+    def test_type_role_mapping(self, record_type: str, expected_role: str) -> None:
         record = ClaudeCodeRecord(type=record_type)
         assert record.role == expected_role
 
@@ -169,7 +182,7 @@ class TestClaudeCodeRecordTimestamp:
     """Test timestamp parsing from various formats."""
 
     @pytest.mark.parametrize("timestamp,expected_year,test_id", CLAUDE_CODE_TIMESTAMP_PARSING)
-    def test_timestamp_parsing(self: Any, timestamp: Any, expected_year: Any, test_id: Any) -> None:
+    def test_timestamp_parsing(self, timestamp: str | float | None, expected_year: int | None, test_id: str) -> None:
         record = ClaudeCodeRecord(type="user", timestamp=timestamp)
         ts = record.parsed_timestamp
         if expected_year is None:
@@ -188,17 +201,17 @@ class TestClaudeCodeRecordBooleanFlags:
     """
 
     @pytest.mark.parametrize("record_type,expected", CLAUDE_CODE_IS_ACTUAL_MESSAGE)
-    def test_is_actual_message(self: Any, record_type: Any, expected: Any) -> None:
+    def test_is_actual_message(self, record_type: str, expected: bool) -> None:
         record = ClaudeCodeRecord(type=record_type)
         assert record.is_actual_message is expected
 
     @pytest.mark.parametrize("record_type,expected", CLAUDE_CODE_IS_CONTEXT_COMPACTION)
-    def test_is_context_compaction(self: Any, record_type: Any, expected: Any) -> None:
+    def test_is_context_compaction(self, record_type: str, expected: bool) -> None:
         record = ClaudeCodeRecord(type=record_type)
         assert record.is_context_compaction is expected
 
     @pytest.mark.parametrize("record_type,expected", CLAUDE_CODE_IS_TOOL_PROGRESS)
-    def test_is_tool_progress(self: Any, record_type: Any, expected: Any) -> None:
+    def test_is_tool_progress(self, record_type: str, expected: bool) -> None:
         record = ClaudeCodeRecord(type=record_type)
         assert record.is_tool_progress is expected
 
@@ -237,11 +250,11 @@ class TestClaudeCodeRecordTextContent2:
     ]
 
     @pytest.mark.parametrize("message,expected,test_id", CLAUDE_CODE_TEXT_CONTENT_CASES)
-    def test_text_content(self: Any, message: Any, expected: Any, test_id: Any) -> None:
+    def test_text_content(self, message: ClaudeCodeMessageInput, expected: str, test_id: str) -> None:
         record = ClaudeCodeRecord(type="user" if message is None else "assistant", message=message)
         assert record.text_content == expected
 
-    def test_top_level_content_field_for_summary_records(self: Any) -> None:
+    def test_top_level_content_field_for_summary_records(self) -> None:
         """Summary/system records with top-level content field return it as text."""
         record = ClaudeCodeRecord.model_validate({"type": "summary", "content": "Compacted conversation context"})
         assert record.text_content == "Compacted conversation context"
@@ -250,11 +263,11 @@ class TestClaudeCodeRecordTextContent2:
 class TestClaudeCodeRecordContentBlocksRaw2:
     """Test raw content block extraction."""
 
-    def test_no_message_returns_empty_list(self: Any) -> None:
+    def test_no_message_returns_empty_list(self) -> None:
         record = ClaudeCodeRecord(type="user", message=None)
         assert record.content_blocks_raw == []
 
-    def test_dict_message_with_list_content(self: Any) -> None:
+    def test_dict_message_with_list_content(self) -> None:
         blocks = [{"type": "text", "text": "hello"}, {"type": "tool_use", "name": "Read"}]
         record = ClaudeCodeRecord(
             type="assistant",
@@ -262,7 +275,7 @@ class TestClaudeCodeRecordContentBlocksRaw2:
         )
         assert record.content_blocks_raw == blocks
 
-    def test_dict_message_with_string_content(self: Any) -> None:
+    def test_dict_message_with_string_content(self) -> None:
         """String content is not a list, returns empty."""
         record = ClaudeCodeRecord(
             type="user",
@@ -270,7 +283,7 @@ class TestClaudeCodeRecordContentBlocksRaw2:
         )
         assert record.content_blocks_raw == []
 
-    def test_typed_message_with_list_content(self: Any) -> None:
+    def test_typed_message_with_list_content(self) -> None:
         msg = ClaudeCodeMessageContent(
             role="assistant",
             content=[{"type": "text", "text": "hello"}],
@@ -283,7 +296,7 @@ class TestClaudeCodeRecordContentBlocksRaw2:
 class TestClaudeCodeRecordToMeta2:
     """Test harmonized metadata generation."""
 
-    def test_basic_meta(self: Any) -> None:
+    def test_basic_meta(self) -> None:
         record = ClaudeCodeRecord(type="user", uuid="msg-1")
         meta = record.to_meta()
         assert meta.id == "msg-1"
@@ -292,18 +305,18 @@ class TestClaudeCodeRecordToMeta2:
         assert meta.tokens is None
         assert meta.cost is None
 
-    def test_meta_with_cost(self: Any) -> None:
+    def test_meta_with_cost(self) -> None:
         record = ClaudeCodeRecord(type="assistant", uuid="msg-2", costUSD=0.05)
         meta = record.to_meta()
         assert meta.cost is not None
         assert meta.cost.total_usd == 0.05
 
-    def test_meta_with_duration(self: Any) -> None:
+    def test_meta_with_duration(self) -> None:
         record = ClaudeCodeRecord(type="assistant", uuid="msg-3", durationMs=1500)
         meta = record.to_meta()
         assert meta.duration_ms == 1500
 
-    def test_meta_with_typed_message_usage(self: Any) -> None:
+    def test_meta_with_typed_message_usage(self) -> None:
         """Token usage from ClaudeCodeMessageContent is extracted."""
         usage = ClaudeCodeUsage(
             input_tokens=100,
@@ -325,7 +338,7 @@ class TestClaudeCodeRecordToMeta2:
         assert meta.tokens.cache_write_tokens == 20
         assert meta.model == "claude-sonnet-4-20250514"
 
-    def test_meta_with_dict_message_usage(self: Any) -> None:
+    def test_meta_with_dict_message_usage(self) -> None:
         """Token usage from dict message is extracted."""
         record = ClaudeCodeRecord(
             type="assistant",
@@ -346,7 +359,7 @@ class TestClaudeCodeRecordToMeta2:
         assert meta.tokens.output_tokens == 100
         assert meta.model == "claude-opus-4-20250514"
 
-    def test_meta_with_dict_message_no_usage(self: Any) -> None:
+    def test_meta_with_dict_message_no_usage(self) -> None:
         """Dict message without usage field returns None tokens."""
         record = ClaudeCodeRecord(
             type="assistant",
@@ -359,7 +372,7 @@ class TestClaudeCodeRecordToMeta2:
 class TestClaudeCodeToolUseConversion:
     """Test tool_use → ToolCall conversion."""
 
-    def test_to_tool_call(self: Any) -> None:
+    def test_to_tool_call(self) -> None:
         tool_use = ClaudeCodeToolUse(
             id="toolu_123",
             name="Read",
@@ -372,7 +385,7 @@ class TestClaudeCodeToolUseConversion:
         assert tc.provider == "claude-code"
         assert tc.category is not None
 
-    def test_to_tool_call_empty_input(self: Any) -> None:
+    def test_to_tool_call_empty_input(self) -> None:
         tool_use = ClaudeCodeToolUse(id="toolu_456", name="UnknownTool", input={})
         tc = tool_use.to_tool_call()
         assert tc.name == "UnknownTool"
@@ -382,14 +395,14 @@ class TestClaudeCodeToolUseConversion:
 class TestClaudeCodeThinkingBlockConversion:
     """Test thinking block → ReasoningTrace conversion."""
 
-    def test_to_reasoning_trace(self: Any) -> None:
+    def test_to_reasoning_trace(self) -> None:
         block = ClaudeCodeThinkingBlock(thinking="Let me think about this problem step by step.")
         trace = block.to_reasoning_trace()
         assert trace.text == "Let me think about this problem step by step."
         assert trace.provider == "claude-code"
         assert trace.raw is not None
 
-    def test_to_reasoning_trace_empty(self: Any) -> None:
+    def test_to_reasoning_trace_empty(self) -> None:
         block = ClaudeCodeThinkingBlock(thinking="")
         trace = block.to_reasoning_trace()
         assert trace.text == ""
@@ -398,7 +411,7 @@ class TestClaudeCodeThinkingBlockConversion:
 class TestClaudeCodeUsageConversion:
     """Test usage → TokenUsage conversion."""
 
-    def test_to_token_usage_full(self: Any) -> None:
+    def test_to_token_usage_full(self) -> None:
         usage = ClaudeCodeUsage(
             input_tokens=500,
             output_tokens=200,
@@ -411,7 +424,7 @@ class TestClaudeCodeUsageConversion:
         assert tu.cache_read_tokens == 100
         assert tu.cache_write_tokens == 50
 
-    def test_to_token_usage_partial(self: Any) -> None:
+    def test_to_token_usage_partial(self) -> None:
         """Missing fields are None, not 0."""
         usage = ClaudeCodeUsage(input_tokens=100, output_tokens=50)
         tu = usage.to_token_usage()
@@ -420,7 +433,7 @@ class TestClaudeCodeUsageConversion:
         assert tu.cache_read_tokens is None
         assert tu.cache_write_tokens is None
 
-    def test_to_token_usage_all_none(self: Any) -> None:
+    def test_to_token_usage_all_none(self) -> None:
         usage = ClaudeCodeUsage()
         tu = usage.to_token_usage()
         assert tu.input_tokens is None
@@ -430,7 +443,7 @@ class TestClaudeCodeUsageConversion:
 class TestClaudeCodeRecordViewportMethods:
     """Test extract_reasoning_traces, extract_tool_calls, extract_content_blocks."""
 
-    def test_extract_reasoning_traces_with_thinking(self: Any) -> None:
+    def test_extract_reasoning_traces_with_thinking(self) -> None:
         record = ClaudeCodeRecord(
             type="assistant",
             message={
@@ -445,7 +458,7 @@ class TestClaudeCodeRecordViewportMethods:
         assert len(traces) >= 1
         assert any("Analyzing" in t.text for t in traces)
 
-    def test_extract_reasoning_traces_none(self: Any) -> None:
+    def test_extract_reasoning_traces_none(self) -> None:
         record = ClaudeCodeRecord(
             type="assistant",
             message={
@@ -456,7 +469,7 @@ class TestClaudeCodeRecordViewportMethods:
         traces = record.extract_reasoning_traces()
         assert traces == []
 
-    def test_extract_tool_calls(self: Any) -> None:
+    def test_extract_tool_calls(self) -> None:
         record = ClaudeCodeRecord(
             type="assistant",
             message={
@@ -470,7 +483,7 @@ class TestClaudeCodeRecordViewportMethods:
         assert len(calls) == 1
         assert calls[0].name == "Bash"
 
-    def test_extract_tool_calls_empty(self: Any) -> None:
+    def test_extract_tool_calls_empty(self) -> None:
         record = ClaudeCodeRecord(
             type="user",
             message={"role": "user", "content": "just text"},
@@ -478,7 +491,7 @@ class TestClaudeCodeRecordViewportMethods:
         calls = record.extract_tool_calls()
         assert calls == []
 
-    def test_extract_content_blocks(self: Any) -> None:
+    def test_extract_content_blocks(self) -> None:
         record = ClaudeCodeRecord(
             type="assistant",
             message={
@@ -496,7 +509,7 @@ class TestClaudeCodeRecordViewportMethods:
 class TestGeminiTextContentExtra:
     """Test GeminiMessage.text_content with parts variations."""
 
-    def test_text_content_direct_text(self: Any) -> None:
+    def test_text_content_direct_text(self) -> None:
         msg = GeminiMessage(text="Direct text", role="user")
         assert msg.text_content == "Direct text"
 
@@ -511,11 +524,11 @@ class TestGeminiTextContentExtra:
         ],
         ids=["typed_parts", "dict_parts", "mixed_parts", "no_text_keys", "empty_list"],
     )
-    def test_text_content_from_parts(self: Any, parts: Any, expected: Any) -> None:
+    def test_text_content_from_parts(self, parts: GeminiPartsInput, expected: str) -> None:
         msg = GeminiMessage(text="", role="user", parts=parts)
         assert msg.text_content == expected
 
-    def test_text_content_parts_dict_with_non_string_text(self: Any) -> None:
+    def test_text_content_parts_dict_with_non_string_text(self) -> None:
         """Coverage for line 135: coerce non-string text to str."""
         msg = GeminiMessage(
             text="",
@@ -525,7 +538,7 @@ class TestGeminiTextContentExtra:
         content = msg.text_content
         assert isinstance(content, str)
 
-    def test_text_content_parts_dict_with_none_text(self: Any) -> None:
+    def test_text_content_parts_dict_with_none_text(self) -> None:
         msg = GeminiMessage(
             text="",
             role="user",
@@ -533,7 +546,7 @@ class TestGeminiTextContentExtra:
         )
         assert msg.text_content == "Valid"
 
-    def test_text_content_parts_typed_none_text(self: Any) -> None:
+    def test_text_content_parts_typed_none_text(self) -> None:
         msg = GeminiMessage(
             text="",
             role="user",
@@ -541,7 +554,7 @@ class TestGeminiTextContentExtra:
         )
         assert msg.text_content == "Valid"
 
-    def test_text_content_prefers_text_over_parts(self: Any) -> None:
+    def test_text_content_prefers_text_over_parts(self) -> None:
         msg = GeminiMessage(
             text="Direct",
             role="user",
@@ -553,7 +566,7 @@ class TestGeminiTextContentExtra:
 class TestGeminiToMetaExtra:
     """Test GeminiMessage.to_meta conversion."""
 
-    def test_to_meta_basic(self: Any) -> None:
+    def test_to_meta_basic(self) -> None:
         msg = GeminiMessage(text="hello", role="user")
         meta = msg.to_meta()
         assert meta.role == "user"
@@ -569,7 +582,7 @@ class TestGeminiToMetaExtra:
         ],
         ids=["with_count", "zero_count", "none_count"],
     )
-    def test_to_meta_token_count(self: Any, tokenCount: Any, has_tokens: Any, expected_output: Any) -> None:
+    def test_to_meta_token_count(self, tokenCount: int | None, has_tokens: bool, expected_output: int | None) -> None:
         msg = GeminiMessage(text="hello", role="user", tokenCount=tokenCount)
         meta = msg.to_meta()
         if has_tokens:
@@ -578,7 +591,7 @@ class TestGeminiToMetaExtra:
         else:
             assert meta.tokens is None
 
-    def test_to_meta_uses_chunk_timestamp_when_present(self: Any) -> None:
+    def test_to_meta_uses_chunk_timestamp_when_present(self) -> None:
         msg = GeminiMessage(text="", role="user", createTime="2024-06-15T10:30:00Z")
         meta = msg.to_meta()
         assert meta.timestamp is not None
@@ -588,12 +601,12 @@ class TestGeminiToMetaExtra:
 class TestGeminiExtractReasoningTracesExtra:
     """Test GeminiMessage.extract_reasoning_traces."""
 
-    def test_extract_reasoning_traces_no_thought(self: Any) -> None:
+    def test_extract_reasoning_traces_no_thought(self) -> None:
         msg = GeminiMessage(text="Regular response", role="user", isThought=False)
         traces = msg.extract_reasoning_traces()
         assert len(traces) == 0
 
-    def test_extract_reasoning_traces_thought_with_text(self: Any) -> None:
+    def test_extract_reasoning_traces_thought_with_text(self) -> None:
         msg = GeminiMessage(
             text="Thinking...",
             role="model",
@@ -606,7 +619,7 @@ class TestGeminiExtractReasoningTracesExtra:
         assert traces[0].token_count == 1000
         assert traces[0].provider == "gemini"
 
-    def test_extract_reasoning_traces_thought_without_text(self: Any) -> None:
+    def test_extract_reasoning_traces_thought_without_text(self) -> None:
         """Regression: isThought=True but no text should not create trace."""
         msg = GeminiMessage(text="", role="model", isThought=True)
         traces = msg.extract_reasoning_traces()
@@ -620,7 +633,9 @@ class TestGeminiExtractReasoningTracesExtra:
         ],
         ids=["string_sigs", "dict_sigs"],
     )
-    def test_extract_reasoning_traces_with_signatures(self: Any, signatures: Any, expected_in_raw: Any) -> None:
+    def test_extract_reasoning_traces_with_signatures(
+        self, signatures: GeminiThoughtSignatureInput, expected_in_raw: list[object]
+    ) -> None:
         """Coverage for line 157-162: various signature types."""
         msg = GeminiMessage(
             text="Thought",
@@ -632,7 +647,7 @@ class TestGeminiExtractReasoningTracesExtra:
         assert len(traces) == 1
         assert traces[0].raw["thoughtSignatures"] == expected_in_raw
 
-    def test_extract_reasoning_traces_with_model_signatures(self: Any) -> None:
+    def test_extract_reasoning_traces_with_model_signatures(self) -> None:
         """Coverage for line 159-160: BaseModel signature handling."""
         sig = GeminiThoughtSignature()
         msg = GeminiMessage(
@@ -645,7 +660,7 @@ class TestGeminiExtractReasoningTracesExtra:
         assert len(traces) == 1
         assert len(traces[0].raw["thoughtSignatures"]) == 1
 
-    def test_extract_reasoning_traces_budget_none(self: Any) -> None:
+    def test_extract_reasoning_traces_budget_none(self) -> None:
         msg = GeminiMessage(
             text="Thought",
             role="model",
@@ -709,11 +724,11 @@ class TestGeminiExtractContentBlocksExtra:
 
     @pytest.mark.parametrize("kwargs,expected_len,expected_type,test_id", GEMINI_EXTRACT_CONTENT_BLOCKS_CASES)
     def test_extract_content_blocks(
-        self: Any, kwargs: Any, expected_len: Any, expected_type: Any, test_id: Any
+        self, kwargs: RawRecordKwargs, expected_len: int | None, expected_type: str | None, test_id: str
     ) -> None:
         from polylogue.lib.viewports import ContentType
 
-        msg = GeminiMessage(**kwargs)
+        msg = GeminiMessage.model_validate(kwargs)
         blocks = msg.extract_content_blocks()
         if expected_len is not None:
             assert len(blocks) == expected_len
@@ -723,7 +738,7 @@ class TestGeminiExtractContentBlocksExtra:
         elif expected_type == "thinking":
             assert blocks[0].type == ContentType.THINKING
 
-    def test_extract_content_blocks_drive_inline_and_youtube(self: Any) -> None:
+    def test_extract_content_blocks_drive_inline_and_youtube(self) -> None:
         from polylogue.lib.viewports import ContentType
 
         msg = GeminiMessage(
@@ -750,8 +765,8 @@ class TestClaudeAIChatMessageRoleNormalizedAndTimestamp:
     """Test ClaudeAIChatMessage role_normalized and parsed_timestamp."""
 
     @pytest.mark.parametrize("sender,expected", CLAUDE_AI_ROLE_MAPPING, ids=["human", "assistant", "system", "empty"])
-    def test_role_normalized(self: Any, sender: Any, expected: Any) -> None:
-        msg = ClaudeAIChatMessage(uuid="1", text="hi", sender=sender)
+    def test_role_normalized(self, sender: str | None, expected: str) -> None:
+        msg = ClaudeAIChatMessage(uuid="1", text="hi", sender="human").model_copy(update={"sender": sender})
         assert msg.role_normalized == expected
 
     @pytest.mark.parametrize(
@@ -765,7 +780,7 @@ class TestClaudeAIChatMessageRoleNormalizedAndTimestamp:
             ("2024-06-15 10:30:00", None, "malformed_iso"),
         ],
     )
-    def test_parsed_timestamp(self: Any, created_at: Any, expect_datetime: Any, test_id: Any) -> None:
+    def test_parsed_timestamp(self, created_at: str | None, expect_datetime: bool | None, test_id: str) -> None:
         msg = ClaudeAIChatMessage(
             uuid="1",
             text="hi",
@@ -792,7 +807,9 @@ class TestClaudeAIChatMessageToMeta:
             ("msg-3", "human", "bad-date", False, "invalid_timestamp"),
         ],
     )
-    def test_to_meta(self: Any, uuid_: Any, sender: Any, created_at: Any, expect_timestamp: Any, test_id: Any) -> None:
+    def test_to_meta(
+        self, uuid_: str, sender: str, created_at: str | None, expect_timestamp: bool, test_id: str
+    ) -> None:
         msg = ClaudeAIChatMessage(uuid=uuid_, text="hi", sender=sender, created_at=created_at)
         meta = msg.to_meta()
         assert meta.id == uuid_
@@ -819,7 +836,7 @@ class TestClaudeAIChatMessageToContentBlocks:
             ("", "human", "empty_text"),
         ],
     )
-    def test_to_content_blocks(self: Any, text: Any, sender: Any, test_id: Any) -> None:
+    def test_to_content_blocks(self, text: str, sender: str, test_id: str) -> None:
         from polylogue.lib.viewports import ContentType
 
         msg = ClaudeAIChatMessage(uuid="1", text=text, sender=sender)
@@ -839,7 +856,7 @@ class TestClaudeAIConversationProperties:
             ("", "", "title_empty_name"),
         ],
     )
-    def test_title(self: Any, name: Any, expected_title: Any, test_id: Any) -> None:
+    def test_title(self, name: str, expected_title: str, test_id: str) -> None:
         conv = ClaudeAIConversation(
             uuid="c-1",
             name=name,
@@ -856,13 +873,13 @@ class TestClaudeAIConversationProperties:
             ("not-a-date", False, "invalid"),
         ],
     )
-    def test_created_datetime(self: Any, date_str: Any, expect_valid: Any, test_id: Any) -> None:
+    def test_created_datetime(self, date_str: str | None, expect_valid: bool, test_id: str) -> None:
         conv = ClaudeAIConversation(
             uuid="c-1",
             name="Test",
-            created_at=date_str,
+            created_at="2024-01-01T00:00:00Z",
             updated_at="2024-06-15T10:30:00Z",
-        )
+        ).model_copy(update={"created_at": date_str})
         dt = conv.created_datetime
         if expect_valid:
             assert dt is not None
@@ -877,13 +894,13 @@ class TestClaudeAIConversationProperties:
             ("bad-date", False, "invalid"),
         ],
     )
-    def test_updated_datetime(self: Any, updated_date: Any, expect_valid: Any, test_id: Any) -> None:
+    def test_updated_datetime(self, updated_date: str | None, expect_valid: bool, test_id: str) -> None:
         conv = ClaudeAIConversation(
             uuid="c-1",
             name="Test",
             created_at="2024-01-01T00:00:00Z",
-            updated_at=updated_date,
-        )
+            updated_at="2024-06-15T10:30:00Z",
+        ).model_copy(update={"updated_at": updated_date})
         dt = conv.updated_datetime
         if expect_valid:
             assert dt is not None
@@ -895,7 +912,7 @@ class TestClaudeAIConversationProperties:
 class TestClaudeAIConversationMessages:
     """Test ClaudeAIConversation.messages property."""
 
-    def test_messages_alias(self: Any) -> None:
+    def test_messages_alias(self) -> None:
         """Coverage for line 125: messages alias returns chat_messages."""
         conv = ClaudeAIConversation(
             uuid="c-1",
@@ -912,7 +929,7 @@ class TestClaudeAIConversationMessages:
         assert messages[0].text == "hi"
         assert messages[1].text == "hello"
 
-    def test_messages_empty(self: Any) -> None:
+    def test_messages_empty(self) -> None:
         conv = ClaudeAIConversation(
             uuid="c-1",
             name="Test",
@@ -926,7 +943,7 @@ class TestClaudeAIConversationMessages:
 class TestClaudeAIConversationIntegration:
     """Integration tests for full conversation workflow."""
 
-    def test_full_conversation_workflow(self: Any) -> None:
+    def test_full_conversation_workflow(self) -> None:
         """Test a complete conversation with all features."""
         conv = ClaudeAIConversation(
             uuid="conv-full",
@@ -960,7 +977,7 @@ class TestClaudeAIConversationIntegration:
             blocks = msg.to_content_blocks()
             assert len(blocks) > 0
 
-    def test_conversation_with_invalid_timestamps(self: Any) -> None:
+    def test_conversation_with_invalid_timestamps(self) -> None:
         """Test conversation with unparseable timestamps."""
         conv = ClaudeAIConversation(
             uuid="conv-bad",
@@ -995,31 +1012,31 @@ class TestNormalizeRole:
     """
 
     @pytest.mark.parametrize("input_role,expected,description", NORMALIZE_ROLE_CANONICAL)
-    def test_canonical_mapping(self: Any, input_role: Any, expected: Any, description: Any) -> None:
+    def test_canonical_mapping(self, input_role: str, expected: str, description: str) -> None:
         from polylogue.lib.roles import normalize_role
 
         assert normalize_role(input_role) == expected
 
-    def test_empty_raises(self: Any) -> None:
+    def test_empty_raises(self) -> None:
         from polylogue.lib.roles import normalize_role
 
         with pytest.raises(ValueError, match="cannot be empty"):
             normalize_role("")
 
-    def test_whitespace_raises(self: Any) -> None:
+    def test_whitespace_raises(self) -> None:
         from polylogue.lib.roles import normalize_role
 
         with pytest.raises(ValueError, match="cannot be empty"):
             normalize_role("   ")
 
-    def test_role_enum_normalize_unknown(self: Any) -> None:
+    def test_role_enum_normalize_unknown(self) -> None:
         from polylogue.lib.roles import Role
 
         result = Role.normalize("unrecognized")
         assert result == Role.UNKNOWN
         assert result.value == "unknown"
 
-    def test_parsed_message_uses_normalized_role(self: Any) -> None:
+    def test_parsed_message_uses_normalized_role(self) -> None:
         """ParsedMessage from parsers should have normalized roles."""
         from polylogue.lib.roles import Role
         from polylogue.sources.parsers.base import ParsedMessage
@@ -1037,7 +1054,7 @@ class TestNormalizeRole:
 # =============================================================================
 
 
-def _make_provider_record_with_role(provider: str, raw_role: str) -> Any:
+def _make_provider_record_with_role(provider: str, raw_role: str) -> ProviderViewportRecord:
     """Construct the canonical record type for each provider with the given role."""
     if provider == "claude-code":
         # ClaudeCodeRecord.role_normalized delegates to .role which is derived from .type
@@ -1063,7 +1080,7 @@ class TestUnifiedRoleNormalization:
         UNIFIED_ROLE_NORMALIZATION,
         ids=[row[3] for row in UNIFIED_ROLE_NORMALIZATION],
     )
-    def test_unified_role_normalization(self: Any, provider: Any, raw_role: Any, expected: Any, desc: Any) -> None:
+    def test_unified_role_normalization(self, provider: str, raw_role: str, expected: str, desc: str) -> None:
         """All providers map roles correctly."""
         record = _make_provider_record_with_role(provider, raw_role)
         assert record.role_normalized == expected
@@ -1078,9 +1095,9 @@ class TestUnifiedRoleNormalization:
 class TestChatGPTIterUserAssistantPairs:
     """Tests for ChatGPTConversation.iter_user_assistant_pairs()."""
 
-    def _make_conv(self: Any, messages: Any) -> Any:
+    def _make_conv(self, messages: ChatGPTConversationMessages) -> ChatGPTConversation:
         """Helper to build a ChatGPTConversation with given messages inline."""
-        mapping = {}
+        mapping: dict[str, ChatGPTNode] = {}
         prev_id = None
         for i, (role, text) in enumerate(messages):
             node_id = f"node-{i}"
@@ -1146,7 +1163,11 @@ class TestChatGPTIterUserAssistantPairs:
         ],
     )
     def test_pair_scenarios(
-        self: Any, messages: Any, expected_count: Any, expected_user_text: Any, expected_assistant_text: Any
+        self,
+        messages: ChatGPTConversationMessages,
+        expected_count: int,
+        expected_user_text: str | None,
+        expected_assistant_text: str | None,
     ) -> None:
         """Test various message pairing scenarios."""
         conv = self._make_conv(messages)
@@ -1157,13 +1178,13 @@ class TestChatGPTIterUserAssistantPairs:
         if expected_assistant_text is not None:
             assert pairs[0][1].text_content == expected_assistant_text
 
-    def test_empty_conversation(self: Any) -> None:
+    def test_empty_conversation(self) -> None:
         """No messages yields no pairs."""
         conv = self._make_conv([])
         pairs = list(conv.iter_user_assistant_pairs())
         assert len(pairs) == 0
 
-    def test_single_message_no_pair(self: Any) -> None:
+    def test_single_message_no_pair(self) -> None:
         """Single message yields no pairs."""
         conv = self._make_conv([("user", "alone")])
         pairs = list(conv.iter_user_assistant_pairs())
@@ -1182,7 +1203,9 @@ class TestChatGPTContentBlocks:
             ("multimodal_image", [], None, ContentType.UNKNOWN),
         ],
     )
-    def test_content_type_mapping(self: Any, content_type: Any, parts: Any, language: Any, expected_type: Any) -> None:
+    def test_content_type_mapping(
+        self, content_type: str, parts: ChatGPTPartsInput, language: str | None, expected_type: ContentType
+    ) -> None:
         """Test various content types map to expected ContentType."""
         msg = ChatGPTMessage(
             id="m1",
@@ -1195,7 +1218,7 @@ class TestChatGPTContentBlocks:
         if language:
             assert blocks[0].language == language
 
-    def test_no_content_returns_empty(self: Any) -> None:
+    def test_no_content_returns_empty(self) -> None:
         """No content returns empty list."""
         msg = ChatGPTMessage(id="m1", author=ChatGPTAuthor(role="user"), content=None)
         blocks = msg.to_content_blocks()
@@ -1215,7 +1238,9 @@ class TestChatGPTTextExtractionEdge:
             (None, [{"other": "value"}, "text"], "text"),
         ],
     )
-    def test_text_extraction_scenarios(self: Any, text_field: Any, parts: Any, expected_text: Any) -> None:
+    def test_text_extraction_scenarios(
+        self, text_field: str | None, parts: ChatGPTPartsInput | None, expected_text: str | None
+    ) -> None:
         """Test various text extraction scenarios."""
         msg = ChatGPTMessage(
             id="m1",
@@ -1229,7 +1254,7 @@ class TestChatGPTTextExtractionEdge:
         else:
             assert text == expected_text
 
-    def test_no_content(self: Any) -> None:
+    def test_no_content(self) -> None:
         """No content returns empty string."""
         msg = ChatGPTMessage(id="m1", author=ChatGPTAuthor(role="user"), content=None)
         assert msg.text_content == ""
@@ -1238,7 +1263,7 @@ class TestChatGPTTextExtractionEdge:
 class TestChatGPTTreeTraversal:
     """Tests for ChatGPTConversation.messages tree traversal."""
 
-    def test_branching_follows_first_child(self: Any) -> None:
+    def test_branching_follows_first_child(self) -> None:
         """Branching tree follows first child path."""
         mapping = {
             "root": ChatGPTNode(id="root", parent=None, children=["a", "b"]),
@@ -1288,7 +1313,7 @@ class TestChatGPTTreeTraversal:
         assert "response" in texts
         assert "branch B" not in texts
 
-    def test_cycle_detection(self: Any) -> None:
+    def test_cycle_detection(self) -> None:
         """Cycle in tree doesn't cause infinite loop."""
         mapping = {
             "a": ChatGPTNode(
@@ -1324,7 +1349,7 @@ class TestChatGPTTreeTraversal:
         msgs = conv.messages
         assert len(msgs) == 2
 
-    def test_no_root_node(self: Any) -> None:
+    def test_no_root_node(self) -> None:
         """All nodes have parents -- no root found."""
         mapping = {
             "a": ChatGPTNode(id="a", parent="b", children=[]),
@@ -1341,7 +1366,7 @@ class TestChatGPTTreeTraversal:
         )
         assert conv.messages == []
 
-    def test_root_only(self: Any) -> None:
+    def test_root_only(self) -> None:
         """Root node with no message and no children."""
         mapping = {
             "root": ChatGPTNode(id="root", parent=None, children=[]),
@@ -1357,7 +1382,7 @@ class TestChatGPTTreeTraversal:
         )
         assert conv.messages == []
 
-    def test_client_created_root_detection(self: Any) -> None:
+    def test_client_created_root_detection(self) -> None:
         """Parent 'client-created-root' is recognized as root."""
         mapping = {
             "node1": ChatGPTNode(
@@ -1388,7 +1413,7 @@ class TestChatGPTTreeTraversal:
 class TestChatGPTTimestampEdgeCases:
     """Tests for timestamp edge cases."""
 
-    def test_invalid_create_time(self: Any) -> None:
+    def test_invalid_create_time(self) -> None:
         """Invalid timestamp returns None."""
         msg = ChatGPTMessage(
             id="m1",
@@ -1397,7 +1422,7 @@ class TestChatGPTTimestampEdgeCases:
         )
         assert msg.timestamp is None
 
-    def test_conversation_invalid_create_time(self: Any) -> None:
+    def test_conversation_invalid_create_time(self) -> None:
         """Conversation with invalid timestamp returns None."""
         conv = ChatGPTConversation(
             id="c1",
@@ -1411,7 +1436,7 @@ class TestChatGPTTimestampEdgeCases:
         assert conv.created_at is None
         assert conv.updated_at is None
 
-    def test_valid_timestamp_conversion(self: Any) -> None:
+    def test_valid_timestamp_conversion(self) -> None:
         """Valid timestamp converts correctly."""
         msg = ChatGPTMessage(
             id="m1",
@@ -1442,9 +1467,9 @@ class TestCodexRecordEdgeCases:
             ({}, "unknown"),
         ],
     )
-    def test_format_detection(self: Any, record_kwargs: Any, expected_format: Any) -> None:
+    def test_format_detection(self, record_kwargs: RawRecordKwargs, expected_format: str) -> None:
         """Test format_type detection for various record configurations."""
-        rec = CodexRecord(**record_kwargs)
+        rec = CodexRecord.model_validate(record_kwargs)
         assert rec.format_type == expected_format
 
     @pytest.mark.parametrize(
@@ -1458,24 +1483,24 @@ class TestCodexRecordEdgeCases:
             ({}, False),
         ],
     )
-    def test_is_message_detection(self: Any, record_kwargs: Any, expected_is_message: Any) -> None:
+    def test_is_message_detection(self, record_kwargs: RawRecordKwargs, expected_is_message: bool) -> None:
         """Test is_message detection for various record types."""
-        rec = CodexRecord(**record_kwargs)
+        rec = CodexRecord.model_validate(record_kwargs)
         assert rec.is_message is expected_is_message
 
-    def test_envelope_content(self: Any) -> None:
+    def test_envelope_content(self) -> None:
         """Content from envelope payload."""
         rec = CodexRecord(type="response_item", payload={"content": [{"type": "output_text", "text": "hello"}]})
         content = rec.effective_content
         assert len(content) == 1
         assert content[0]["text"] == "hello"
 
-    def test_envelope_non_list_content(self: Any) -> None:
+    def test_envelope_non_list_content(self) -> None:
         """Envelope payload content that's not a list returns empty."""
         rec = CodexRecord(type="response_item", payload={"content": "just a string"})
         assert rec.effective_content == []
 
-    def test_direct_content_blocks(self: Any) -> None:
+    def test_direct_content_blocks(self) -> None:
         """Content from direct format CodexContentBlock."""
         rec = CodexRecord(
             type="message",
@@ -1487,7 +1512,7 @@ class TestCodexRecordEdgeCases:
         assert content[0]["type"] == "output_text"
         assert content[0]["text"] == "hi"
 
-    def test_direct_content_dicts(self: Any) -> None:
+    def test_direct_content_dicts(self) -> None:
         """Content from direct format raw dicts."""
         rec = CodexRecord(
             type="message",
@@ -1497,7 +1522,7 @@ class TestCodexRecordEdgeCases:
         content = rec.effective_content
         assert content[0]["text"] == "question"
 
-    def test_no_content(self: Any) -> None:
+    def test_no_content(self) -> None:
         """Record with no content returns empty list."""
         rec = CodexRecord(type="session_meta", payload={})
         assert rec.effective_content == []
@@ -1509,7 +1534,7 @@ class TestCodexRecordEdgeCases:
             ("2024-06-15T10:30:00Z", 2024),
         ],
     )
-    def test_valid_timestamp_parsing(self: Any, timestamp: Any, expected_year: Any) -> None:
+    def test_valid_timestamp_parsing(self, timestamp: str, expected_year: int) -> None:
         """Test parsing of valid timestamp formats."""
         rec = CodexRecord(timestamp=timestamp)
         ts = rec.parsed_timestamp
@@ -1524,7 +1549,7 @@ class TestCodexRecordEdgeCases:
             ("", "empty"),
         ],
     )
-    def test_invalid_timestamp_parsing(self: Any, timestamp: Any, description: Any) -> None:
+    def test_invalid_timestamp_parsing(self, timestamp: str | None, description: str) -> None:
         """Test that invalid timestamps return None."""
         rec = CodexRecord(timestamp=timestamp) if timestamp is not None else CodexRecord()
         assert rec.parsed_timestamp is None
@@ -1537,12 +1562,12 @@ class TestCodexRecordEdgeCases:
             ([{"type": "text", "text": "plain"}], "plain"),
         ],
     )
-    def test_text_extraction_by_type(self: Any, payload_content: Any, expected_text: Any) -> None:
+    def test_text_extraction_by_type(self, payload_content: list[dict[str, str]], expected_text: str) -> None:
         """Test text extraction from various content field names."""
         rec = CodexRecord(type="response_item", payload={"content": payload_content})
         assert rec.text_content == expected_text
 
-    def test_multiple_blocks_joined(self: Any) -> None:
+    def test_multiple_blocks_joined(self) -> None:
         """Multiple content blocks joined with newline."""
         rec = CodexRecord(
             type="response_item",
@@ -1556,7 +1581,7 @@ class TestCodexRecordEdgeCases:
         assert "line1" in rec.text_content
         assert "line2" in rec.text_content
 
-    def test_empty_content_text(self: Any) -> None:
+    def test_empty_content_text(self) -> None:
         """No content returns empty string."""
         rec = CodexRecord()
         assert rec.text_content == ""
@@ -1570,7 +1595,7 @@ class TestCodexRecordEdgeCases:
         ],
     )
     def test_content_block_extraction(
-        self: Any, payload_content: Any, expected_type: Any, expected_language: Any
+        self, payload_content: list[dict[str, str]], expected_type: ContentType, expected_language: str | None
     ) -> None:
         """Test extraction and type mapping of content blocks."""
         rec = CodexRecord(type="response_item", payload={"content": payload_content})
@@ -1580,7 +1605,7 @@ class TestCodexRecordEdgeCases:
         if expected_language:
             assert blocks[0].language == expected_language
 
-    def test_non_dict_block_skipped(self: Any) -> None:
+    def test_non_dict_block_skipped(self) -> None:
         """Non-dict content items are skipped."""
         rec = CodexRecord(
             type="response_item", payload={"content": ["just a string", {"type": "text", "text": "real"}]}
@@ -1597,18 +1622,18 @@ class TestCodexRecordEdgeCases:
             ({"type": "response_item", "payload": {}}, "unknown"),
         ],
     )
-    def test_effective_role(self: Any, record_kwargs: Any, expected_effective_role: Any) -> None:
+    def test_effective_role(self, record_kwargs: RawRecordKwargs, expected_effective_role: str) -> None:
         """Test effective_role extraction from various record formats."""
-        rec = CodexRecord(**record_kwargs)
+        rec = CodexRecord.model_validate(record_kwargs)
         assert rec.effective_role == expected_effective_role
 
-    def test_to_meta_unknown_role_normalized(self: Any) -> None:
+    def test_to_meta_unknown_role_normalized(self) -> None:
         """Unknown roles map to 'unknown' in MessageMeta."""
         rec = CodexRecord(type="response_item", payload={"role": "admin"})
         meta = rec.to_meta()
         assert meta.role == "unknown"
 
-    def test_to_meta_system_role(self: Any) -> None:
+    def test_to_meta_system_role(self) -> None:
         """System role preserved."""
         rec = CodexRecord(role="system")
         meta = rec.to_meta()

--- a/tests/unit/sources/test_source_laws.py
+++ b/tests/unit/sources/test_source_laws.py
@@ -6,10 +6,10 @@ import json
 import os
 import tempfile
 import zipfile
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from io import BytesIO
 from pathlib import Path
-from typing import IO, Any, BinaryIO, TypedDict, cast
+from typing import IO, BinaryIO, TypedDict
 from unittest.mock import MagicMock
 
 import ijson
@@ -19,6 +19,7 @@ from hypothesis import strategies as st
 
 from polylogue.config import Source
 from polylogue.lib.roles import Role, normalize_role
+from polylogue.schemas.json_types import JSONDocument
 from polylogue.sources import decoders as decoders_module
 from polylogue.sources import dispatch as dispatch_module
 from polylogue.sources import source_acquisition
@@ -76,6 +77,7 @@ from polylogue.sources.source_parsing import (
     iter_source_conversations_with_raw,
 )
 from polylogue.sources.source_walk import _has_supported_extension
+from polylogue.storage.blob_store import BlobStore, Heartbeat
 from polylogue.types import Provider
 from tests.infra.source_builders import GenericConversationBuilder, make_claude_chat_message
 from tests.infra.strategies import (
@@ -94,6 +96,26 @@ class GeneratedSourceCase(TypedDict):
     path: Path
     raw: bytes
     provider: str
+
+
+class FailedFile(TypedDict):
+    path: str
+    error: str
+
+
+def _require_generated_source_case(value: object) -> GeneratedSourceCase:
+    if not isinstance(value, dict):
+        raise AssertionError(f"expected generated source case, got {type(value).__name__}")
+    path = value.get("path")
+    raw = value.get("raw")
+    provider = value.get("provider")
+    if not isinstance(path, Path):
+        raise AssertionError(f"expected generated path, got {type(path).__name__}")
+    if not isinstance(raw, bytes):
+        raise AssertionError(f"expected generated raw bytes, got {type(raw).__name__}")
+    if not isinstance(provider, str):
+        raise AssertionError(f"expected generated provider, got {type(provider).__name__}")
+    return GeneratedSourceCase(path=path, raw=raw, provider=provider)
 
 
 def _parsed_message(
@@ -130,8 +152,22 @@ def _parsed_conversation(
     )
 
 
-def _failed_files(cursor_state: dict[str, object]) -> list[dict[str, object]]:
-    return cast(list[dict[str, object]], cursor_state.get("failed_files", []))
+def _failed_files(cursor_state: Mapping[str, object]) -> list[FailedFile]:
+    failed_files = cursor_state.get("failed_files", [])
+    if not isinstance(failed_files, list):
+        return []
+    return [
+        FailedFile(path=str(item["path"]), error=str(item["error"]))
+        for item in failed_files
+        if isinstance(item, dict) and "path" in item and "error" in item
+    ]
+
+
+def _numeric_observation_value(observation: Mapping[str, object], key: str) -> float:
+    value = observation.get(key)
+    if not isinstance(value, (int, float, str)):
+        raise AssertionError(f"expected numeric observation field {key}, got {type(value).__name__}")
+    return float(value)
 
 
 _CANONICAL_PROVIDERS = (
@@ -365,9 +401,9 @@ def _write_generic_conversation(path: Path, conversation_id: str, text: str = "h
     st.booleans(),
 )
 @settings(max_examples=30, deadline=None)
-def test_iter_source_conversations_round_trips_generated_exports(case: dict[str, object], use_zip: bool) -> None:
+def test_iter_source_conversations_round_trips_generated_exports(case: object, use_zip: bool) -> None:
     """Generated provider exports should stay discoverable through file and ZIP iteration."""
-    generated = cast(GeneratedSourceCase, case)
+    generated = _require_generated_source_case(case)
     with tempfile.TemporaryDirectory() as tmp:
         source = _materialize_generated_source(
             Path(tmp),
@@ -396,12 +432,12 @@ def test_iter_source_conversations_round_trips_generated_exports(case: dict[str,
 )
 @settings(max_examples=30, deadline=None)
 def test_iter_source_conversations_with_raw_capture_contract(
-    case: dict[str, object],
+    case: object,
     use_zip: bool,
     capture_raw: bool,
 ) -> None:
     """Raw iteration must preserve provider parsing while toggling raw payload capture cleanly."""
-    generated = cast(GeneratedSourceCase, case)
+    generated = _require_generated_source_case(case)
     with tempfile.TemporaryDirectory() as tmp:
         source = _materialize_generated_source(
             Path(tmp),
@@ -518,7 +554,7 @@ def test_iter_source_conversations_tracks_file_disappearance_contract(
         encoding: str | None = None,
         errors: str | None = None,
         newline: str | None = None,
-    ) -> Any:
+    ) -> IO[str] | BinaryIO:
         if path == second:
             raise FileNotFoundError("deleted")
         return original_open(
@@ -1165,7 +1201,7 @@ def _parse_context(
     source_path: str,
     fallback_id: str,
     capture_raw: bool = True,
-    sidecar_data: dict[str, Any] | None = None,
+    sidecar_data: JSONDocument | None = None,
 ) -> _ParseContext:
     return _ParseContext(
         provider_hint=Provider.from_string(provider_hint),
@@ -1901,24 +1937,24 @@ def test_iter_source_raw_data_reports_split_payload_observations(tmp_path: Path)
 
     assert len(items) == 2
     assert observations
-    peak = max(observations, key=lambda observation: float(cast(str | int | float, observation["peak_rss_self_mb"])))
+    peak = max(observations, key=lambda observation: _numeric_observation_value(observation, "peak_rss_self_mb"))
     assert peak["phase"] == "zip-entry-split-payload-serialized"
     assert peak["source_path"] == f"{archive_path}:nested/conversations.json"
     assert peak["provider_hint"] == Provider.CHATGPT.value
     assert peak["source_index"] in {0, 1}
-    assert int(cast(str | int, peak["blob_size"])) > 0
+    assert _numeric_observation_value(peak, "blob_size") > 0
     assert peak["artifact_kind"]
-    assert float(cast(str | int | float, peak["detect_provider_ms"])) >= 0.0
-    assert float(cast(str | int | float, peak["classify_ms"])) >= 0.0
-    assert float(cast(str | int | float, peak["serialize_ms"])) >= 0.0
-    assert float(cast(str | int | float, peak["peak_rss_self_mb"])) > 0.0
+    assert _numeric_observation_value(peak, "detect_provider_ms") >= 0.0
+    assert _numeric_observation_value(peak, "classify_ms") >= 0.0
+    assert _numeric_observation_value(peak, "serialize_ms") >= 0.0
+    assert _numeric_observation_value(peak, "peak_rss_self_mb") > 0.0
 
 
 def test_iter_source_raw_data_streams_preserved_zip_entries_into_blob_store(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    from polylogue.storage.blob_store import BlobStore, get_blob_store
+    from polylogue.storage.blob_store import get_blob_store
 
     entry_bytes = json.dumps({"id": "chatgpt-1", "mapping": {}}).encode("utf-8")
     archive_path = tmp_path / "bundle.zip"
@@ -1946,7 +1982,7 @@ def test_iter_entry_payloads_locks_provider_after_first_detected_payload(
         {"id": "chatgpt-2", "mapping": {}},
         {"id": "chatgpt-3", "mapping": {}},
     ]
-    detect_calls: list[dict[str, object]] = []
+    detect_calls: list[JSONDocument] = []
     original_detect_provider = dispatch_module.detect_provider
 
     def tracking_detect_provider(payload: object, path: object | None = None) -> Provider | None:
@@ -2000,7 +2036,7 @@ def test_iter_source_raw_data_skips_known_mtimes_without_reading_file(tmp_path: 
     items = list(
         iter_source_raw_data(
             Source(name="chatgpt", path=tmp_path),
-            known_mtimes={str(skipped): cast(str, _get_file_mtime(skipped))},
+            known_mtimes={str(skipped): str(_get_file_mtime(skipped))},
         )
     )
 
@@ -2101,15 +2137,13 @@ def test_iter_source_raw_data_tracks_read_failures_without_stopping(
     bad.write_text('{"mapping": {}, "id": "bad"}', encoding="utf-8")
 
     # Patch blob_store.write_from_path to fail for the bad file
-    from polylogue.storage.blob_store import BlobStore
-
     original_write = BlobStore.write_from_path
 
     def flaky_write(
         self: BlobStore,
         source: Path,
         *,
-        heartbeat: Any = None,
+        heartbeat: Heartbeat | None = None,
     ) -> tuple[str, int]:
         del heartbeat
         if source == bad:

--- a/tests/unit/sources/test_unified_semantic_laws.py
+++ b/tests/unit/sources/test_unified_semantic_laws.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from datetime import datetime
 from types import SimpleNamespace
-from typing import Any, Protocol, cast
+from typing import Protocol, TypeAlias, cast
 
 import pytest
 from hypothesis import given, settings
@@ -70,7 +70,11 @@ from tests.infra.strategies import (
 _VALID_VIEWPORT_ROLES = {"user", "assistant", "system", "tool", "unknown", "model"}
 
 
-RawPayload = dict[str, object]
+JsonScalar: TypeAlias = str | int | float | bool | None
+JsonValue: TypeAlias = JsonScalar | dict[str, "JsonValue"] | list["JsonValue"]
+RawPayload: TypeAlias = dict[str, JsonValue]
+RawContent: TypeAlias = list[RawPayload]
+SemanticCase: TypeAlias = tuple[str, RawPayload]
 
 
 class ViewportRecord(Protocol):
@@ -92,15 +96,17 @@ def _provider(value: str | Provider) -> Provider:
 
 
 def _as_dict(value: object) -> RawPayload:
-    return cast(RawPayload, value) if isinstance(value, dict) else {}
+    if not isinstance(value, dict):
+        return {}
+    return {key: value for key, value in value.items() if isinstance(key, str)}
 
 
 def _as_list(value: object) -> list[object]:
-    return cast(list[object], value) if isinstance(value, list) else []
+    return list(value) if isinstance(value, list) else []
 
 
-def _typed_content(value: list[object]) -> list[dict[str, Any]]:
-    return cast(list[dict[str, Any]], value)
+def _content_blocks(value: list[object]) -> RawContent:
+    return [_as_dict(item) for item in value if isinstance(item, dict)]
 
 
 def _build_viewport_record(provider: str, raw: RawPayload) -> ViewportRecord:
@@ -117,9 +123,9 @@ def _build_viewport_record(provider: str, raw: RawPayload) -> ViewportRecord:
     raise AssertionError(f"unexpected provider {provider}")
 
 
-def _structured_provider_meta(record: ViewportRecord) -> dict[str, object]:
+def _structured_provider_meta(record: ViewportRecord) -> RawPayload:
     meta = record.to_meta()
-    provider_meta: dict[str, object] = {
+    provider_meta: RawPayload = {
         "content_blocks": [block.model_dump(mode="json") for block in record.extract_content_blocks()],
         "reasoning_traces": [trace.model_dump(mode="json") for trace in record.extract_reasoning_traces()],
         "tool_calls": [call.model_dump(mode="json") for call in record.extract_tool_calls()],
@@ -210,7 +216,7 @@ def _expected_reasoning_texts(content: list[object]) -> list[str]:
     return texts
 
 
-def _expected_tool_blocks(content: list[object]) -> list[dict[str, object]]:
+def _expected_tool_blocks(content: list[object]) -> RawContent:
     return [block for block in content if isinstance(block, dict) and block.get("type") == "tool_use"]
 
 
@@ -236,7 +242,7 @@ def _expected_content_types(content: list[object]) -> list[ContentType]:
 
 @given(provider_semantic_case_strategy())
 @settings(max_examples=40, deadline=None)
-def test_unified_semantic_equivalence_for_rich_provider_cases(case: tuple[str, dict[str, object]]) -> None:
+def test_unified_semantic_equivalence_for_rich_provider_cases(case: SemanticCase) -> None:
     provider, raw = case
     record = _build_viewport_record(provider, raw)
     meta = record.to_meta()
@@ -268,7 +274,7 @@ def test_unified_semantic_equivalence_for_rich_provider_cases(case: tuple[str, d
 
 @given(provider_semantic_case_strategy())
 @settings(max_examples=30, deadline=None)
-def test_harmonize_parsed_message_matches_bulk_harmonize(case: tuple[str, dict[str, object]]) -> None:
+def test_harmonize_parsed_message_matches_bulk_harmonize(case: SemanticCase) -> None:
     provider, raw = case
     record = _build_viewport_record(provider, raw)
     meta = record.to_meta()
@@ -321,7 +327,7 @@ def test_harmonized_message_provider_coercion_contract(provider_str: str) -> Non
     st.sampled_from(["claude-code", "claude-ai", "chatgpt", "gemini", "codex"]),
 )
 def test_typed_content_blocks_extract_without_crash(
-    content: list[dict[str, object]],
+    content: RawContent,
     provider: str,
 ) -> None:
     """Typed content block strategies always produce extractable blocks."""
@@ -349,7 +355,7 @@ def test_extract_reasoning_traces_preserve_reasoning_blocks_contract(
     content: list[object],
     provider: str,
 ) -> None:
-    traces = extract_reasoning_traces(_typed_content(content), provider)
+    traces = extract_reasoning_traces(_content_blocks(content), provider)
     assert [trace.text for trace in traces] == _expected_reasoning_texts(content)
     assert all(str(trace.provider) == provider for trace in traces)
 
@@ -369,7 +375,7 @@ def test_extract_tool_calls_preserve_tool_use_blocks_contract(
     content: list[object],
     provider: str,
 ) -> None:
-    calls = extract_tool_calls(_typed_content(content), provider)
+    calls = extract_tool_calls(_content_blocks(content), provider)
     expected = _expected_tool_blocks(content)
     assert [call.name for call in calls] == [str(block.get("name", "")) for block in expected]
     assert [call.id for call in calls] == [block.get("id") for block in expected]
@@ -392,7 +398,7 @@ def test_extract_tool_calls_preserve_tool_use_blocks_contract(
 def test_extract_content_blocks_preserve_recognized_block_order_contract(
     content: list[object],
 ) -> None:
-    blocks = extract_content_blocks(_typed_content(content))
+    blocks = extract_content_blocks(_content_blocks(content))
     assert [block.type for block in blocks] == _expected_content_types(content)
 
 
@@ -420,7 +426,7 @@ def test_extract_codex_text_prefers_first_available_text_field_contract(content:
         text = block.get("text", "") or block.get("input_text", "") or block.get("output_text", "")
         if isinstance(text, str) and text:
             expected.append(text)
-    assert extract_codex_text(_typed_content(content)) == "\n".join(expected)
+    assert extract_codex_text(_content_blocks(content)) == "\n".join(expected)
 
 
 @given(
@@ -432,11 +438,11 @@ def test_extract_codex_text_prefers_first_available_text_field_contract(content:
 )
 @settings(max_examples=20, deadline=None)
 def test_rich_semantic_cases_are_message_records(
-    chatgpt_raw: dict[str, object],
-    claude_ai_raw: dict[str, object],
-    claude_code_raw: dict[str, object],
-    codex_raw: dict[str, object],
-    gemini_raw: dict[str, object],
+    chatgpt_raw: RawPayload,
+    claude_ai_raw: RawPayload,
+    claude_code_raw: RawPayload,
+    codex_raw: RawPayload,
+    gemini_raw: RawPayload,
 ) -> None:
     assert is_message_record("chatgpt", chatgpt_raw)
     assert is_message_record("claude-ai", claude_ai_raw)
@@ -447,7 +453,7 @@ def test_rich_semantic_cases_are_message_records(
 
 @given(provider_semantic_case_strategy())
 @settings(max_examples=40, deadline=None)
-def test_rich_provider_block_classification_contract(case: tuple[str, dict[str, object]]) -> None:
+def test_rich_provider_block_classification_contract(case: SemanticCase) -> None:
     provider, raw = case
     record = _build_viewport_record(provider, raw)
 
@@ -456,7 +462,7 @@ def test_rich_provider_block_classification_contract(case: tuple[str, dict[str, 
 
 @given(provider_semantic_case_strategy())
 @settings(max_examples=40, deadline=None)
-def test_provider_adapter_viewport_contract(case: tuple[str, dict[str, object]]) -> None:
+def test_provider_adapter_viewport_contract(case: SemanticCase) -> None:
     provider, raw = case
     record = _build_viewport_record(provider, raw)
     meta = record.to_meta()
@@ -523,7 +529,7 @@ def test_provider_adapter_viewport_contract(case: tuple[str, dict[str, object]])
 
 @given(provider_semantic_case_strategy())
 @settings(max_examples=40, deadline=None)
-def test_rich_provider_meta_contract(case: tuple[str, dict[str, object]]) -> None:
+def test_rich_provider_meta_contract(case: SemanticCase) -> None:
     provider, raw = case
     record = _build_viewport_record(provider, raw)
     meta = record.to_meta()
@@ -563,7 +569,7 @@ def test_rich_provider_meta_contract(case: tuple[str, dict[str, object]]) -> Non
 
 @given(provider_semantic_case_strategy())
 @settings(max_examples=30, deadline=None)
-def test_structured_provider_meta_overlay_contract(case: tuple[str, dict[str, object]]) -> None:
+def test_structured_provider_meta_overlay_contract(case: SemanticCase) -> None:
     provider, raw = case
     record = _build_viewport_record(provider, raw)
     meta = record.to_meta()
@@ -605,7 +611,7 @@ def test_structured_provider_meta_overlay_contract(case: tuple[str, dict[str, ob
         ("gemini", {"role": "model"}, True),
     ],
 )
-def test_is_message_record_contract(provider: str, raw: dict[str, object], expected: bool) -> None:
+def test_is_message_record_contract(provider: str, raw: RawPayload, expected: bool) -> None:
     assert is_message_record(provider, raw) is expected
 
 
@@ -831,9 +837,9 @@ def test_generic_content_extraction_contract() -> None:
         {"type": "code", "code": "print('ok')", "language": "python"},
     ]
 
-    blocks = extract_content_blocks(_typed_content(content))
-    traces = extract_reasoning_traces(_typed_content(content), Provider.CLAUDE_CODE)
-    calls = extract_tool_calls(_typed_content(content), Provider.CLAUDE_CODE)
+    blocks = extract_content_blocks(_content_blocks(content))
+    traces = extract_reasoning_traces(_content_blocks(content), Provider.CLAUDE_CODE)
+    calls = extract_tool_calls(_content_blocks(content), Provider.CLAUDE_CODE)
 
     assert [block.type for block in blocks] == [
         ContentType.TEXT,
@@ -856,7 +862,7 @@ def test_generic_content_extraction_contract() -> None:
         {"type": "text", "text": "world"},
         "ignored",
     ]
-    assert extract_claude_code_text(_typed_content(cc_content)) == "hello\nworld"
+    assert extract_claude_code_text(_content_blocks(cc_content)) == "hello\nworld"
 
 
 def test_extract_from_provider_meta_integration_contract() -> None:
@@ -922,7 +928,7 @@ def test_extract_from_provider_meta_integration_contract() -> None:
     ]
 
     # --- Multi-provider overlay: DB fields fill in when provider_meta lacks them ---
-    overlay_cases: list[tuple[str, dict[str, object], str, str, str, str]] = [
+    overlay_cases: list[tuple[str, RawPayload, str, str, str, str]] = [
         ("claude-ai", {"sender": "human", "text": ""}, "db-message-id", "user", "DB fallback text", "claude-ai"),
         (
             "gemini",
@@ -1043,7 +1049,7 @@ def test_extract_harmonized_message_fallback_contract() -> None:
     assert msg_cc.tool_calls[0].input == {"path": "README.md"}
 
     # --- Claude Code: type field fallback for role ---
-    claude_code_role_fallbacks: list[tuple[dict[str, object], str]] = [
+    claude_code_role_fallbacks: list[tuple[RawPayload, str]] = [
         ({"uuid": "m1", "type": "human", "message": "not-a-dict"}, "user"),
         ({"uuid": "m1", "type": "assistant", "message": "not-a-dict"}, "assistant"),
     ]
@@ -1053,7 +1059,7 @@ def test_extract_harmonized_message_fallback_contract() -> None:
         assert msg.id == "m1"
 
     # --- Malformed payloads across providers ---
-    malformed_cases: list[tuple[str, dict[str, object], str, str, str, str | None]] = [
+    malformed_cases: list[tuple[str, RawPayload, str, str, str, str | None]] = [
         (
             "claude-ai",
             {"sender": "human", "text": "Fallback Claude AI text", "created_at": "2024-01-15T10:30:00Z"},


### PR DESCRIPTION
Closes #232
Ref #227

## Summary

- renew verification-law fixtures and probe/runtime assertions over the current substrate

## Problem

- the previous substrate renewal tightened production contracts, but several test and devtools surfaces were still leaning on loose object indexing, dict splats, and untyped builder/runtime helpers
- that left full-repo strict mypy and verification fragile even though the core source layers were clean

## Solution

- rebuild the affected verification surfaces around explicit JSON/object helpers, validated model construction, and typed fixture/runtime adapters
- clean the probe summary assertions, storage-record builders, filter/schema law tests, and source-law/model tests so they match the stricter runtime contracts

## Verification

- `devtools verify`
