### PR TITLE
refactor: renew session-product runtime contracts

### DIFF
--- a/devtools/synthetic_benchmark_runtime.py
+++ b/devtools/synthetic_benchmark_runtime.py
@@ -330,12 +330,12 @@ def run_session_product_materialization_campaign(db_path: Path) -> CampaignResul
         scale_level="",
         metrics={
             "rebuild_wall_s": round(elapsed, 3),
-            "profiles_rebuilt": int(rebuilt["profiles"]),
-            "work_events_rebuilt": int(rebuilt["work_events"]),
-            "phases_rebuilt": int(rebuilt["phases"]),
-            "threads_rebuilt": int(rebuilt["threads"]),
-            "tag_rollups_rebuilt": int(rebuilt["tag_rollups"]),
-            "day_summaries_rebuilt": int(rebuilt["day_summaries"]),
+            "profiles_rebuilt": rebuilt.profiles,
+            "work_events_rebuilt": rebuilt.work_events,
+            "phases_rebuilt": rebuilt.phases,
+            "threads_rebuilt": rebuilt.threads,
+            "tag_rollups_rebuilt": rebuilt.tag_rollups,
+            "day_summaries_rebuilt": rebuilt.day_summaries,
         },
         db_stats={
             "session_profiles_before": stats_before.get("session_profiles_count", 0),

--- a/polylogue/facade_archive.py
+++ b/polylogue/facade_archive.py
@@ -11,6 +11,7 @@ from polylogue.archive_products import (
     SessionProfileProduct,
     SessionProfileProductQuery,
 )
+from polylogue.storage.session_product_runtime import SessionProductStatusSnapshot
 
 if TYPE_CHECKING:
     from polylogue.config import Config
@@ -41,7 +42,7 @@ if TYPE_CHECKING:
             since: str | None = None,
         ) -> SearchResult: ...
 
-        async def get_session_product_status(self) -> dict[str, int | bool]: ...
+        async def get_session_product_status(self) -> SessionProductStatusSnapshot: ...
 
         async def get_session_profile_product(
             self,
@@ -111,7 +112,7 @@ class PolylogueArchiveMixin:
             since=since,
         )
 
-    async def get_session_product_status(self) -> dict[str, int | bool]:
+    async def get_session_product_status(self) -> SessionProductStatusSnapshot:
         return await self.operations.get_session_product_status()
 
     async def get_session_profile_product(

--- a/polylogue/operations/archive.py
+++ b/polylogue/operations/archive.py
@@ -43,12 +43,16 @@ from polylogue.services import RuntimeServices, build_runtime_services
 from polylogue.storage.backends.connection import connection_context
 from polylogue.storage.repair import collect_archive_debt_statuses_sync
 from polylogue.storage.search import SearchHit, SearchResult
+from polylogue.storage.session_product_runtime import (
+    SessionProductReadyFlag,
+    SessionProductStatusSnapshot,
+)
 from polylogue.types import Provider
 
 logger = structlog.get_logger(__name__)
 _MAINTENANCE_TARGET_CATALOG = build_maintenance_target_catalog()
 _SESSION_PRODUCT_REPAIR_HINT = _MAINTENANCE_TARGET_CATALOG.repair_hint(("session_products",), include_run_all=True)
-_PROFILE_FTS_STATUS_BY_TIER = {
+_PROFILE_FTS_STATUS_BY_TIER: dict[str, SessionProductReadyFlag] = {
     "merged": "profile_merged_fts_ready",
     "evidence": "profile_evidence_fts_ready",
     "inference": "profile_inference_fts_ready",
@@ -167,16 +171,16 @@ def provider_analytics_product(row: Mapping[str, object]) -> ProviderAnalyticsPr
 
 
 def _require_ready_flag(
-    status: dict[str, int | bool],
-    flag: str,
+    status: SessionProductStatusSnapshot,
+    flag: SessionProductReadyFlag,
     detail: str,
 ) -> None:
-    if bool(status.get(flag, False)):
+    if status.ready_flag(flag):
         return
     raise ArchiveProductUnavailableError(f"{detail} {_SESSION_PRODUCT_REPAIR_HINT}")
 
 
-async def _read_session_product_status(backend: SQLiteBackend) -> dict[str, int | bool]:
+async def _read_session_product_status(backend: SQLiteBackend) -> SessionProductStatusSnapshot:
     return await backend.get_session_product_status()
 
 
@@ -313,7 +317,7 @@ class ArchiveStatsMixin:
             for row in rows
         ]
 
-    async def get_session_product_status(self) -> dict[str, int | bool]:
+    async def get_session_product_status(self) -> SessionProductStatusSnapshot:
         return await self.backend.get_session_product_status()
 
 
@@ -326,7 +330,7 @@ class ArchiveProductSessionMixin:
         @property
         def backend(self) -> SQLiteBackend: ...
 
-    async def _session_product_status(self) -> dict[str, int | bool]:
+    async def _session_product_status(self) -> SessionProductStatusSnapshot:
         return await _read_session_product_status(self.backend)
 
     async def get_session_profile_product(

--- a/polylogue/pipeline/run_stages.py
+++ b/polylogue/pipeline/run_stages.py
@@ -190,8 +190,8 @@ async def execute_materialize_stage(
             return MaterializeStageOutcome(item_count=0, rebuilt=False)
 
         status = await backend.get_session_product_status()
-        total_conversations = int(status.get("total_conversations", 0) or 0)
-        profile_row_count = int(status.get("profile_row_count", 0) or 0)
+        total_conversations = status.total_conversations
+        profile_row_count = status.profile_row_count
         use_bounded_rebuild = profile_row_count == 0 and total_conversations == len(conversation_ids)
         if progress_callback is not None:
             progress_callback(0, desc=f"Materializing: 0/{len(conversation_ids)}")
@@ -208,7 +208,7 @@ async def execute_materialize_stage(
             return MaterializeStageOutcome(
                 item_count=len(conversation_ids),
                 rebuilt=True,
-                observation={"mode": "rebuild-from-empty", **counts},
+                observation={"mode": "rebuild-from-empty", **counts.to_dict()},
             )
 
         observation = await refresh_session_products_bulk(backend, conversation_ids)
@@ -250,9 +250,9 @@ async def execute_materialize_stage(
         )
         await conn.commit()
     return MaterializeStageOutcome(
-        item_count=int(counts.get("profiles", 0)),
+        item_count=counts.profiles,
         rebuilt=True,
-        observation={"mode": "rebuild", **counts},
+        observation={"mode": "rebuild", **counts.to_dict()},
     )
 
 

--- a/polylogue/storage/backends/async_sqlite_archive.py
+++ b/polylogue/storage/backends/async_sqlite_archive.py
@@ -10,6 +10,7 @@ from polylogue.storage.backends.queries import attachments as attachments_q
 from polylogue.storage.backends.queries import conversations as conversations_q
 from polylogue.storage.backends.queries import messages as messages_q
 from polylogue.storage.backends.queries.stats import AggregateMessageStats
+from polylogue.storage.session_product_runtime import SessionProductStatusSnapshot
 from polylogue.storage.store import AttachmentRecord, ContentBlockRecord, ConversationRecord, MessageRecord
 
 if TYPE_CHECKING:
@@ -138,7 +139,7 @@ class SQLiteArchiveMixin:
         async for cid in self.queries.iter_conversation_ids(source_names=source_names, page_size=page_size):
             yield cid
 
-    async def get_session_product_status(self) -> dict[str, int | bool]:
+    async def get_session_product_status(self) -> SessionProductStatusSnapshot:
         """Return materialized session-product coverage counters."""
         return await self.queries.get_session_product_status()
 

--- a/polylogue/storage/backends/query_store.py
+++ b/polylogue/storage/backends/query_store.py
@@ -22,6 +22,7 @@ from polylogue.storage.backends.query_store_product_profiles import (
 from polylogue.storage.backends.query_store_product_timelines import (
     SQLiteQueryStoreProductTimelinesMixin,
 )
+from polylogue.storage.session_product_runtime import SessionProductStatusSnapshot
 from polylogue.storage.store import (
     ActionEventRecord,
     DaySessionSummaryRecord,
@@ -53,7 +54,7 @@ class SQLiteQueryStore(
         async with self._connection_factory() as conn:
             return await action_event_read_model_status_async(conn)
 
-    async def get_session_product_status(self) -> dict[str, int | bool]:
+    async def get_session_product_status(self) -> SessionProductStatusSnapshot:
         from polylogue.storage.session_product_status import session_product_status_async
 
         async with self._connection_factory() as conn:

--- a/polylogue/storage/derived_status.py
+++ b/polylogue/storage/derived_status.py
@@ -40,53 +40,53 @@ def collect_derived_model_statuses_sync(
         "action_fts_ready": bool(action_status["action_fts_ready"]),
         "action_stale_rows": int(action_status["stale_count"]),
         "action_matches_version": bool(action_status["matches_version"]),
-        "profile_rows": int(session_status["profile_row_count"]),
-        "profile_merged_fts_rows": int(session_status["profile_merged_fts_count"]),
-        "profile_merged_fts_duplicates": int(session_status["profile_merged_fts_duplicate_count"]),
-        "profile_evidence_fts_rows": int(session_status["profile_evidence_fts_count"]),
-        "profile_evidence_fts_duplicates": int(session_status["profile_evidence_fts_duplicate_count"]),
-        "profile_inference_fts_rows": int(session_status["profile_inference_fts_count"]),
-        "profile_inference_fts_duplicates": int(session_status["profile_inference_fts_duplicate_count"]),
-        "profile_enrichment_fts_rows": int(session_status["profile_enrichment_fts_count"]),
-        "profile_enrichment_fts_duplicates": int(session_status["profile_enrichment_fts_duplicate_count"]),
-        "work_event_rows": int(session_status["work_event_inference_count"]),
-        "work_event_fts_rows": int(session_status["work_event_inference_fts_count"]),
-        "work_event_fts_duplicates": int(session_status["work_event_inference_fts_duplicate_count"]),
-        "phase_rows": int(session_status["phase_inference_count"]),
-        "work_thread_rows": int(session_status["thread_count"]),
-        "work_thread_fts_rows": int(session_status["thread_fts_count"]),
-        "work_thread_fts_duplicates": int(session_status["thread_fts_duplicate_count"]),
-        "total_thread_roots": int(session_status["root_threads"]),
-        "tag_rollup_rows": int(session_status["tag_rollup_count"]),
-        "expected_tag_rollup_rows": int(session_status["expected_tag_rollup_count"]),
-        "day_summary_rows": int(session_status["day_summary_count"]),
-        "expected_day_summary_rows": int(session_status["expected_day_summary_count"]),
-        "missing_profile_rows": int(session_status["missing_profile_row_count"]),
-        "stale_profile_rows": int(session_status["stale_profile_row_count"]),
-        "orphan_profile_rows": int(session_status["orphan_profile_row_count"]),
-        "expected_work_event_rows": int(session_status["expected_work_event_inference_count"]),
-        "stale_work_event_rows": int(session_status["stale_work_event_inference_count"]),
-        "orphan_work_event_rows": int(session_status["orphan_work_event_inference_count"]),
-        "expected_phase_rows": int(session_status["expected_phase_inference_count"]),
-        "stale_phase_rows": int(session_status["stale_phase_inference_count"]),
-        "orphan_phase_rows": int(session_status["orphan_phase_inference_count"]),
-        "stale_thread_rows": int(session_status["stale_thread_count"]),
-        "orphan_thread_rows": int(session_status["orphan_thread_count"]),
-        "stale_tag_rollup_rows": int(session_status["stale_tag_rollup_count"]),
-        "stale_day_summary_rows": int(session_status["stale_day_summary_count"]),
-        "profile_rows_ready": bool(session_status["profile_rows_ready"]),
-        "profile_merged_fts_ready": bool(session_status["profile_merged_fts_ready"]),
-        "profile_evidence_fts_ready": bool(session_status["profile_evidence_fts_ready"]),
-        "profile_inference_fts_ready": bool(session_status["profile_inference_fts_ready"]),
-        "profile_enrichment_fts_ready": bool(session_status["profile_enrichment_fts_ready"]),
-        "work_event_rows_ready": bool(session_status["work_event_inference_rows_ready"]),
-        "work_event_fts_ready": bool(session_status["work_event_inference_fts_ready"]),
-        "phase_rows_ready": bool(session_status["phase_inference_rows_ready"]),
-        "threads_ready": bool(session_status["threads_ready"]),
-        "thread_fts_ready": bool(session_status["threads_fts_ready"]),
-        "tag_rollups_ready": bool(session_status["tag_rollups_ready"]),
-        "day_summaries_ready": bool(session_status["day_summaries_ready"]),
-        "week_summaries_ready": bool(session_status["week_summaries_ready"]),
+        "profile_rows": session_status.profile_row_count,
+        "profile_merged_fts_rows": session_status.profile_merged_fts_count,
+        "profile_merged_fts_duplicates": session_status.profile_merged_fts_duplicate_count,
+        "profile_evidence_fts_rows": session_status.profile_evidence_fts_count,
+        "profile_evidence_fts_duplicates": session_status.profile_evidence_fts_duplicate_count,
+        "profile_inference_fts_rows": session_status.profile_inference_fts_count,
+        "profile_inference_fts_duplicates": session_status.profile_inference_fts_duplicate_count,
+        "profile_enrichment_fts_rows": session_status.profile_enrichment_fts_count,
+        "profile_enrichment_fts_duplicates": session_status.profile_enrichment_fts_duplicate_count,
+        "work_event_rows": session_status.work_event_inference_count,
+        "work_event_fts_rows": session_status.work_event_inference_fts_count,
+        "work_event_fts_duplicates": session_status.work_event_inference_fts_duplicate_count,
+        "phase_rows": session_status.phase_inference_count,
+        "work_thread_rows": session_status.thread_count,
+        "work_thread_fts_rows": session_status.thread_fts_count,
+        "work_thread_fts_duplicates": session_status.thread_fts_duplicate_count,
+        "total_thread_roots": session_status.root_threads,
+        "tag_rollup_rows": session_status.tag_rollup_count,
+        "expected_tag_rollup_rows": session_status.expected_tag_rollup_count,
+        "day_summary_rows": session_status.day_summary_count,
+        "expected_day_summary_rows": session_status.expected_day_summary_count,
+        "missing_profile_rows": session_status.missing_profile_row_count,
+        "stale_profile_rows": session_status.stale_profile_row_count,
+        "orphan_profile_rows": session_status.orphan_profile_row_count,
+        "expected_work_event_rows": session_status.expected_work_event_inference_count,
+        "stale_work_event_rows": session_status.stale_work_event_inference_count,
+        "orphan_work_event_rows": session_status.orphan_work_event_inference_count,
+        "expected_phase_rows": session_status.expected_phase_inference_count,
+        "stale_phase_rows": session_status.stale_phase_inference_count,
+        "orphan_phase_rows": session_status.orphan_phase_inference_count,
+        "stale_thread_rows": session_status.stale_thread_count,
+        "orphan_thread_rows": session_status.orphan_thread_count,
+        "stale_tag_rollup_rows": session_status.stale_tag_rollup_count,
+        "stale_day_summary_rows": session_status.stale_day_summary_count,
+        "profile_rows_ready": session_status.profile_rows_ready,
+        "profile_merged_fts_ready": session_status.profile_merged_fts_ready,
+        "profile_evidence_fts_ready": session_status.profile_evidence_fts_ready,
+        "profile_inference_fts_ready": session_status.profile_inference_fts_ready,
+        "profile_enrichment_fts_ready": session_status.profile_enrichment_fts_ready,
+        "work_event_rows_ready": session_status.work_event_inference_rows_ready,
+        "work_event_fts_ready": session_status.work_event_inference_fts_ready,
+        "phase_rows_ready": session_status.phase_inference_rows_ready,
+        "threads_ready": session_status.threads_ready,
+        "thread_fts_ready": session_status.threads_fts_ready,
+        "tag_rollups_ready": session_status.tag_rollups_ready,
+        "day_summaries_ready": session_status.day_summaries_ready,
+        "week_summaries_ready": session_status.week_summaries_ready,
         "embedded_conversations": embedding_stats.embedded_conversations,
         "embedded_messages": embedding_stats.embedded_messages,
         "pending_conversations": embedding_stats.pending_conversations,
@@ -101,7 +101,7 @@ def collect_derived_model_statuses_sync(
     )
     metrics["evidence_retrieval_rows"] = int(metrics["profile_evidence_fts_rows"]) + int(metrics["action_fts_rows"])
     metrics["expected_evidence_retrieval_rows"] = int(metrics["profile_rows"]) + int(metrics["action_rows"])
-    metrics["evidence_retrieval_ready"] = bool(session_status["profile_evidence_fts_ready"]) and bool(
+    metrics["evidence_retrieval_ready"] = session_status.profile_evidence_fts_ready and bool(
         action_status["action_fts_ready"]
     )
     metrics["inference_retrieval_rows"] = (
@@ -111,13 +111,13 @@ def collect_derived_model_statuses_sync(
         int(metrics["profile_rows"]) + int(metrics["work_event_rows"]) + int(metrics["phase_rows"])
     )
     metrics["inference_retrieval_ready"] = (
-        bool(session_status["profile_inference_fts_ready"])
-        and bool(session_status["work_event_inference_fts_ready"])
-        and bool(session_status["phase_inference_rows_ready"])
+        session_status.profile_inference_fts_ready
+        and session_status.work_event_inference_fts_ready
+        and session_status.phase_inference_rows_ready
     )
     metrics["enrichment_retrieval_rows"] = int(metrics["profile_enrichment_fts_rows"])
     metrics["expected_enrichment_retrieval_rows"] = int(metrics["profile_rows"])
-    metrics["enrichment_retrieval_ready"] = bool(session_status["profile_enrichment_fts_ready"])
+    metrics["enrichment_retrieval_ready"] = session_status.profile_enrichment_fts_ready
 
     return {
         **build_archive_product_statuses(metrics),

--- a/polylogue/storage/embedding_stats_support.py
+++ b/polylogue/storage/embedding_stats_support.py
@@ -8,6 +8,8 @@ from typing import cast
 
 import aiosqlite
 
+from polylogue.storage.session_product_runtime import SessionProductStatusSnapshot
+
 StatsRow = sqlite3.Row | tuple[object, ...]
 
 
@@ -40,7 +42,7 @@ def build_retrieval_bands_from_status(
     stale_messages: int,
     missing_provenance: int,
     action_status: Mapping[str, object],
-    session_status: Mapping[str, object],
+    session_status: SessionProductStatusSnapshot,
 ) -> dict[str, dict[str, object]]:
     transcript_ready = total_conversations == 0 or (
         embedded_conversations == total_conversations
@@ -50,30 +52,30 @@ def build_retrieval_bands_from_status(
     )
     transcript_status = "empty" if total_conversations == 0 else ("ready" if transcript_ready else "pending")
 
-    evidence_source_rows = _coerce_int(action_status["count"]) + _coerce_int(session_status["profile_row_count"])
-    evidence_materialized_rows = _coerce_int(action_status["action_fts_count"]) + _coerce_int(
-        session_status["profile_evidence_fts_count"]
+    evidence_source_rows = _coerce_int(action_status["count"]) + session_status.profile_row_count
+    evidence_materialized_rows = (
+        _coerce_int(action_status["action_fts_count"]) + session_status.profile_evidence_fts_count
     )
-    evidence_ready = bool(action_status["action_fts_ready"]) and bool(session_status["profile_evidence_fts_ready"])
+    evidence_ready = bool(action_status["action_fts_ready"]) and session_status.profile_evidence_fts_ready
 
     inference_source_rows = (
-        _coerce_int(session_status["profile_row_count"])
-        + _coerce_int(session_status["work_event_inference_count"])
-        + _coerce_int(session_status["phase_inference_count"])
+        session_status.profile_row_count
+        + session_status.work_event_inference_count
+        + session_status.phase_inference_count
     )
     inference_materialized_rows = (
-        _coerce_int(session_status["profile_inference_fts_count"])
-        + _coerce_int(session_status["work_event_inference_fts_count"])
-        + _coerce_int(session_status["phase_inference_count"])
+        session_status.profile_inference_fts_count
+        + session_status.work_event_inference_fts_count
+        + session_status.phase_inference_count
     )
     inference_ready = (
-        bool(session_status["profile_inference_fts_ready"])
-        and bool(session_status["work_event_inference_fts_ready"])
-        and bool(session_status["phase_inference_rows_ready"])
+        session_status.profile_inference_fts_ready
+        and session_status.work_event_inference_fts_ready
+        and session_status.phase_inference_rows_ready
     )
-    enrichment_source_rows = _coerce_int(session_status["profile_row_count"])
-    enrichment_materialized_rows = _coerce_int(session_status["profile_enrichment_fts_count"])
-    enrichment_ready = bool(session_status["profile_enrichment_fts_ready"])
+    enrichment_source_rows = session_status.profile_row_count
+    enrichment_materialized_rows = session_status.profile_enrichment_fts_count
+    enrichment_ready = session_status.profile_enrichment_fts_ready
 
     return {
         "transcript_embeddings": {
@@ -100,7 +102,7 @@ def build_retrieval_bands_from_status(
             "source_rows": evidence_source_rows,
             "materialized_rows": evidence_materialized_rows,
             "pending_rows": max(0, evidence_source_rows - evidence_materialized_rows),
-            "stale_rows": _coerce_int(session_status["profile_evidence_fts_duplicate_count"])
+            "stale_rows": session_status.profile_evidence_fts_duplicate_count
             + _coerce_int(action_status["stale_count"])
             + _coerce_int(action_status.get("action_fts_stale_rows", 0)),
             "detail": (
@@ -108,7 +110,7 @@ def build_retrieval_bands_from_status(
                 if evidence_ready
                 else (
                     f"Evidence retrieval pending ({evidence_materialized_rows:,}/{evidence_source_rows:,} supporting rows; "
-                    f"profile_evidence_fts={_coerce_int(session_status['profile_evidence_fts_count']):,}/{_coerce_int(session_status['profile_row_count']):,}, "
+                    f"profile_evidence_fts={session_status.profile_evidence_fts_count:,}/{session_status.profile_row_count:,}, "
                     f"action_event_fts={_coerce_int(action_status['action_fts_count']):,}/{_coerce_int(action_status['count']):,})"
                 )
             ),
@@ -120,19 +122,19 @@ def build_retrieval_bands_from_status(
             "materialized_rows": inference_materialized_rows,
             "pending_rows": max(0, inference_source_rows - inference_materialized_rows),
             "stale_rows": (
-                _coerce_int(session_status["profile_inference_fts_duplicate_count"])
-                + _coerce_int(session_status["work_event_inference_fts_duplicate_count"])
-                + _coerce_int(session_status["stale_work_event_inference_count"])
-                + _coerce_int(session_status["stale_phase_inference_count"])
+                session_status.profile_inference_fts_duplicate_count
+                + session_status.work_event_inference_fts_duplicate_count
+                + session_status.stale_work_event_inference_count
+                + session_status.stale_phase_inference_count
             ),
             "detail": (
                 f"Inference retrieval ready ({inference_materialized_rows:,}/{inference_source_rows:,} supporting rows)"
                 if inference_ready
                 else (
                     f"Inference retrieval pending ({inference_materialized_rows:,}/{inference_source_rows:,} supporting rows; "
-                    f"profile_inference_fts={_coerce_int(session_status['profile_inference_fts_count']):,}/{_coerce_int(session_status['profile_row_count']):,}, "
-                    f"work_event_inference_fts={_coerce_int(session_status['work_event_inference_fts_count']):,}/{_coerce_int(session_status['work_event_inference_count']):,}, "
-                    f"phase_inference={_coerce_int(session_status['phase_inference_count']):,}/{_coerce_int(session_status['expected_phase_inference_count']):,})"
+                    f"profile_inference_fts={session_status.profile_inference_fts_count:,}/{session_status.profile_row_count:,}, "
+                    f"work_event_inference_fts={session_status.work_event_inference_fts_count:,}/{session_status.work_event_inference_count:,}, "
+                    f"phase_inference={session_status.phase_inference_count:,}/{session_status.expected_phase_inference_count:,})"
                 )
             ),
         },
@@ -142,13 +144,13 @@ def build_retrieval_bands_from_status(
             "source_rows": enrichment_source_rows,
             "materialized_rows": enrichment_materialized_rows,
             "pending_rows": max(0, enrichment_source_rows - enrichment_materialized_rows),
-            "stale_rows": _coerce_int(session_status["profile_enrichment_fts_duplicate_count"]),
+            "stale_rows": session_status.profile_enrichment_fts_duplicate_count,
             "detail": (
                 f"Enrichment retrieval ready ({enrichment_materialized_rows:,}/{enrichment_source_rows:,} supporting rows)"
                 if enrichment_ready
                 else (
                     f"Enrichment retrieval pending ({enrichment_materialized_rows:,}/{enrichment_source_rows:,} supporting rows; "
-                    f"profile_enrichment_fts={_coerce_int(session_status['profile_enrichment_fts_count']):,}/{_coerce_int(session_status['profile_row_count']):,})"
+                    f"profile_enrichment_fts={session_status.profile_enrichment_fts_count:,}/{session_status.profile_row_count:,})"
                 )
             ),
         },

--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -608,40 +608,30 @@ def repair_session_products(
     try:
         with connection_context(None) as conn:
             status = session_product_status_sync(conn)
-            profile_merged_fts_pending = max(
-                0, int(status["profile_row_count"]) - int(status["profile_merged_fts_count"])
-            )
-            profile_merged_fts_duplicates = max(0, int(status.get("profile_merged_fts_duplicate_count", 0)))
-            profile_evidence_fts_pending = max(
-                0, int(status["profile_row_count"]) - int(status["profile_evidence_fts_count"])
-            )
-            profile_evidence_fts_duplicates = max(0, int(status.get("profile_evidence_fts_duplicate_count", 0)))
-            profile_inference_fts_pending = max(
-                0, int(status["profile_row_count"]) - int(status["profile_inference_fts_count"])
-            )
-            profile_inference_fts_duplicates = max(0, int(status.get("profile_inference_fts_duplicate_count", 0)))
-            profile_enrichment_fts_pending = max(
-                0, int(status["profile_row_count"]) - int(status["profile_enrichment_fts_count"])
-            )
-            profile_enrichment_fts_duplicates = max(0, int(status.get("profile_enrichment_fts_duplicate_count", 0)))
-            work_event_fts_pending = max(
-                0, int(status["work_event_inference_count"]) - int(status["work_event_inference_fts_count"])
-            )
-            work_event_fts_duplicates = max(0, int(status.get("work_event_inference_fts_duplicate_count", 0)))
-            thread_fts_pending = max(0, int(status["thread_count"]) - int(status["thread_fts_count"]))
-            thread_fts_duplicates = max(0, int(status.get("thread_fts_duplicate_count", 0)))
+            profile_merged_fts_pending = max(0, status.profile_row_count - status.profile_merged_fts_count)
+            profile_merged_fts_duplicates = max(0, status.profile_merged_fts_duplicate_count)
+            profile_evidence_fts_pending = max(0, status.profile_row_count - status.profile_evidence_fts_count)
+            profile_evidence_fts_duplicates = max(0, status.profile_evidence_fts_duplicate_count)
+            profile_inference_fts_pending = max(0, status.profile_row_count - status.profile_inference_fts_count)
+            profile_inference_fts_duplicates = max(0, status.profile_inference_fts_duplicate_count)
+            profile_enrichment_fts_pending = max(0, status.profile_row_count - status.profile_enrichment_fts_count)
+            profile_enrichment_fts_duplicates = max(0, status.profile_enrichment_fts_duplicate_count)
+            work_event_fts_pending = max(0, status.work_event_inference_count - status.work_event_inference_fts_count)
+            work_event_fts_duplicates = max(0, status.work_event_inference_fts_duplicate_count)
+            thread_fts_pending = max(0, status.thread_count - status.thread_fts_count)
+            thread_fts_duplicates = max(0, status.thread_fts_duplicate_count)
             pending = (
-                int(status["missing_profile_row_count"])
-                + int(status["stale_profile_row_count"])
-                + int(status["orphan_profile_row_count"])
-                + int(status["stale_work_event_inference_count"])
-                + int(status["orphan_work_event_inference_count"])
-                + int(status["stale_phase_inference_count"])
-                + int(status["orphan_phase_inference_count"])
-                + int(status["stale_thread_count"])
-                + int(status["orphan_thread_count"])
-                + int(status["stale_tag_rollup_count"])
-                + int(status["stale_day_summary_count"])
+                status.missing_profile_row_count
+                + status.stale_profile_row_count
+                + status.orphan_profile_row_count
+                + status.stale_work_event_inference_count
+                + status.orphan_work_event_inference_count
+                + status.stale_phase_inference_count
+                + status.orphan_phase_inference_count
+                + status.stale_thread_count
+                + status.orphan_thread_count
+                + status.stale_tag_rollup_count
+                + status.stale_day_summary_count
                 + profile_merged_fts_pending
                 + profile_merged_fts_duplicates
                 + profile_evidence_fts_pending
@@ -674,30 +664,23 @@ def repair_session_products(
             conn.commit()
             refreshed = session_product_status_sync(conn)
             success = (
-                bool(refreshed["profile_rows_ready"])
-                and bool(refreshed["profile_merged_fts_ready"])
-                and bool(refreshed["profile_evidence_fts_ready"])
-                and bool(refreshed["profile_inference_fts_ready"])
-                and bool(refreshed["profile_enrichment_fts_ready"])
-                and bool(refreshed["work_event_inference_rows_ready"])
-                and bool(refreshed["work_event_inference_fts_ready"])
-                and bool(refreshed["phase_inference_rows_ready"])
-                and bool(refreshed["threads_ready"])
-                and bool(refreshed["threads_fts_ready"])
-                and bool(refreshed["tag_rollups_ready"])
-                and bool(refreshed["day_summaries_ready"])
-                and bool(refreshed["week_summaries_ready"])
+                refreshed.profile_rows_ready
+                and refreshed.profile_merged_fts_ready
+                and refreshed.profile_evidence_fts_ready
+                and refreshed.profile_inference_fts_ready
+                and refreshed.profile_enrichment_fts_ready
+                and refreshed.work_event_inference_rows_ready
+                and refreshed.work_event_inference_fts_ready
+                and refreshed.phase_inference_rows_ready
+                and refreshed.threads_ready
+                and refreshed.threads_fts_ready
+                and refreshed.tag_rollups_ready
+                and refreshed.day_summaries_ready
+                and refreshed.week_summaries_ready
             )
             return _repair_result(
                 "session_products",
-                repaired_count=(
-                    int(rebuilt["profiles"])
-                    + int(rebuilt["work_events"])
-                    + int(rebuilt["phases"])
-                    + int(rebuilt["threads"])
-                    + int(rebuilt["tag_rollups"])
-                    + int(rebuilt["day_summaries"])
-                ),
+                repaired_count=rebuilt.total(),
                 success=success,
                 detail="Session products ready" if success else "Session products still incomplete",
             )

--- a/polylogue/storage/session_product_rebuild.py
+++ b/polylogue/storage/session_product_rebuild.py
@@ -33,6 +33,7 @@ from polylogue.storage.session_product_profiles import (
     hydrate_session_profile,
     now_iso,
 )
+from polylogue.storage.session_product_runtime import SessionProductCounts
 from polylogue.storage.session_product_storage import (
     replace_session_phases_sync,
     replace_session_profile_sync,
@@ -407,15 +408,8 @@ def _materialize_progress_desc(
     return f"Materializing: {profile_count}"
 
 
-def _empty_rebuild_counts() -> dict[str, int]:
-    return {
-        "profiles": 0,
-        "work_events": 0,
-        "phases": 0,
-        "threads": 0,
-        "tag_rollups": 0,
-        "day_summaries": 0,
-    }
+def _empty_rebuild_counts() -> SessionProductCounts:
+    return SessionProductCounts()
 
 
 def _finalize_rebuild_counts(
@@ -426,15 +420,15 @@ def _finalize_rebuild_counts(
     threads: int,
     tag_rollups: int,
     day_summaries: int,
-) -> dict[str, int]:
-    return {
-        "profiles": profiles,
-        "work_events": work_events,
-        "phases": phases,
-        "threads": threads,
-        "tag_rollups": tag_rollups,
-        "day_summaries": day_summaries,
-    }
+) -> SessionProductCounts:
+    return SessionProductCounts(
+        profiles=profiles,
+        work_events=work_events,
+        phases=phases,
+        threads=threads,
+        tag_rollups=tag_rollups,
+        day_summaries=day_summaries,
+    )
 
 
 def rebuild_session_products_sync(
@@ -444,7 +438,7 @@ def rebuild_session_products_sync(
     page_size: int = _SESSION_PRODUCT_REBUILD_PAGE_SIZE,
     progress_callback: ProgressCallback | None = None,
     progress_total: int | None = None,
-) -> dict[str, int]:
+) -> SessionProductCounts:
     conversation_chunks: Iterable[Sequence[str]]
     if conversation_ids is None:
         conn.execute("DELETE FROM session_work_events")
@@ -538,7 +532,7 @@ async def rebuild_session_products_async(
     transaction_depth: int = 0,
     progress_callback: ProgressCallback | None = None,
     progress_total: int | None = None,
-) -> dict[str, int]:
+) -> SessionProductCounts:
     from polylogue.storage.backends.queries.session_product_profile_writes import (
         replace_session_profile,
     )

--- a/polylogue/storage/session_product_refresh.py
+++ b/polylogue/storage/session_product_refresh.py
@@ -19,6 +19,11 @@ from polylogue.storage.session_product_rebuild import (
     hydrate_conversations,
     load_async_batch,
 )
+from polylogue.storage.session_product_runtime import (
+    ProviderDayGroup,
+    SessionProductCounts,
+    SessionProductRefreshChunkPayload,
+)
 from polylogue.storage.session_product_threads import (
     build_thread_records_for_roots_async,
     thread_root_id_async,
@@ -34,16 +39,16 @@ _SESSION_PRODUCT_REFRESH_MESSAGE_BUDGET = 5_000
 
 @dataclass(slots=True)
 class _SessionProductRefreshUpdate:
-    counts: dict[str, int]
+    counts: SessionProductCounts
     thread_root_id: str | None
-    affected_groups: set[tuple[str, str]]
+    affected_groups: set[ProviderDayGroup]
 
 
 @dataclass(slots=True)
 class _SessionProductBulkRefreshUpdate:
-    counts: dict[str, int]
+    counts: SessionProductCounts
     thread_root_ids: set[str]
-    affected_groups: set[tuple[str, str]]
+    affected_groups: set[ProviderDayGroup]
     chunk_observations: list[SessionProductRefreshChunkObservation]
 
 
@@ -70,8 +75,8 @@ class SessionProductRefreshChunkObservation:
     total_ms: float
     slow: bool = False
 
-    def to_observation(self) -> dict[str, object]:
-        observation: dict[str, object] = {
+    def to_observation(self) -> SessionProductRefreshChunkPayload:
+        observation: SessionProductRefreshChunkPayload = {
             "conversation_count": self.conversation_count,
             "estimated_message_count": self.estimated_message_count,
             "max_estimated_conversation_messages": self.max_estimated_conversation_messages,
@@ -84,21 +89,13 @@ class SessionProductRefreshChunkObservation:
             "build_ms": self.build_ms,
             "write_ms": self.write_ms,
             "total_ms": self.total_ms,
+            "slow": self.slow,
         }
-        if self.slow:
-            observation["slow"] = True
         return observation
 
 
-def _empty_refresh_counts() -> dict[str, int]:
-    return {
-        "profiles": 0,
-        "work_events": 0,
-        "phases": 0,
-        "threads": 0,
-        "tag_rollups": 0,
-        "day_summaries": 0,
-    }
+def _empty_refresh_counts() -> SessionProductCounts:
+    return SessionProductCounts()
 
 
 async def _refresh_thread_root_async(
@@ -156,7 +153,7 @@ async def delete_session_products_for_conversation_async(
     conversation_id: str,
     *,
     transaction_depth: int = 0,
-) -> dict[str, int]:
+) -> SessionProductCounts:
     from polylogue.storage.backends.queries.session_product_timeline_writes import (
         replace_session_phases,
         replace_session_work_events,
@@ -186,14 +183,13 @@ async def delete_session_products_for_conversation_async(
             {old_group},
             transaction_depth=transaction_depth,
         )
-    return {
-        "profiles": 1 if row is not None else 0,
-        "work_events": 0,
-        "phases": 0,
-        "threads": 0,
-        "tag_rollups": 1 if old_group is not None else 0,
-        "day_summaries": 1 if old_group is not None else 0,
-    }
+    counts = _empty_refresh_counts()
+    counts.add(
+        profiles=1 if row is not None else 0,
+        tag_rollups=1 if old_group is not None else 0,
+        day_summaries=1 if old_group is not None else 0,
+    )
+    return counts
 
 
 async def refresh_session_products_for_conversation_async(
@@ -201,7 +197,7 @@ async def refresh_session_products_for_conversation_async(
     conversation_id: str,
     *,
     transaction_depth: int = 0,
-) -> dict[str, int]:
+) -> SessionProductCounts:
     update = await _apply_session_product_conversation_update_async(
         conn,
         conversation_id,
@@ -217,11 +213,12 @@ async def refresh_session_products_for_conversation_async(
         update.affected_groups,
         transaction_depth=transaction_depth,
     )
-    result = dict(update.counts)
-    result["threads"] = thread_count
-    result["tag_rollups"] = len(update.affected_groups)
-    result["day_summaries"] = len(update.affected_groups)
-    return result
+    update.counts.add(
+        threads=thread_count,
+        tag_rollups=len(update.affected_groups),
+        day_summaries=len(update.affected_groups),
+    )
+    return update.counts
 
 
 async def _apply_session_product_conversation_update_async(
@@ -283,14 +280,11 @@ async def _apply_session_product_conversation_update_async(
         if group is not None
     }
     return _SessionProductRefreshUpdate(
-        counts={
-            "profiles": 1,
-            "work_events": record_bundle.work_event_count,
-            "phases": record_bundle.phase_count,
-            "threads": 0,
-            "tag_rollups": 0,
-            "day_summaries": 0,
-        },
+        counts=SessionProductCounts(
+            profiles=1,
+            work_events=record_bundle.work_event_count,
+            phases=record_bundle.phase_count,
+        ),
         thread_root_id=await thread_root_id_async(conn, conversation_id),
         affected_groups=affected_groups,
     )
@@ -434,7 +428,7 @@ async def _apply_session_product_conversation_updates_async(
 
     counts = _empty_refresh_counts()
     thread_root_ids: set[str] = set()
-    affected_groups: set[tuple[str, str]] = set()
+    affected_groups: set[ProviderDayGroup] = set()
     chunk_observations: list[SessionProductRefreshChunkObservation] = []
     conversation_id_list = list(conversation_ids)
     message_counts = await _load_message_counts_async(conn, conversation_id_list)
@@ -470,9 +464,11 @@ async def _apply_session_product_conversation_updates_async(
             record_bundle = build_session_product_records(hydrated_conversation)
             record_bundles.append(record_bundle)
 
-            counts["profiles"] += 1
-            counts["work_events"] += record_bundle.work_event_count
-            counts["phases"] += record_bundle.phase_count
+            counts.add(
+                profiles=1,
+                work_events=record_bundle.work_event_count,
+                phases=record_bundle.phase_count,
+            )
             affected_groups.update(
                 group
                 for group in (

--- a/polylogue/storage/session_product_runtime.py
+++ b/polylogue/storage/session_product_runtime.py
@@ -1,0 +1,134 @@
+"""Shared runtime contracts for session-product rebuild and refresh flows."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, TypeAlias, TypedDict
+
+ProviderDayGroup: TypeAlias = tuple[str, str]
+SessionProductReadyFlag: TypeAlias = Literal[
+    "profile_rows_ready",
+    "profile_merged_fts_ready",
+    "profile_evidence_fts_ready",
+    "profile_inference_fts_ready",
+    "profile_enrichment_fts_ready",
+    "work_event_inference_rows_ready",
+    "work_event_inference_fts_ready",
+    "phase_inference_rows_ready",
+    "threads_ready",
+    "threads_fts_ready",
+    "tag_rollups_ready",
+    "day_summaries_ready",
+    "week_summaries_ready",
+]
+
+
+class SessionProductRefreshChunkPayload(TypedDict):
+    conversation_count: int
+    estimated_message_count: int
+    max_estimated_conversation_messages: int
+    hydrated_count: int
+    profiles_written: int
+    work_events_written: int
+    phases_written: int
+    load_ms: float
+    hydrate_ms: float
+    build_ms: float
+    write_ms: float
+    total_ms: float
+    slow: bool
+
+
+@dataclass(slots=True)
+class SessionProductCounts:
+    profiles: int = 0
+    work_events: int = 0
+    phases: int = 0
+    threads: int = 0
+    tag_rollups: int = 0
+    day_summaries: int = 0
+
+    def add(
+        self,
+        *,
+        profiles: int = 0,
+        work_events: int = 0,
+        phases: int = 0,
+        threads: int = 0,
+        tag_rollups: int = 0,
+        day_summaries: int = 0,
+    ) -> None:
+        self.profiles += profiles
+        self.work_events += work_events
+        self.phases += phases
+        self.threads += threads
+        self.tag_rollups += tag_rollups
+        self.day_summaries += day_summaries
+
+    def to_dict(self) -> dict[str, int]:
+        return {
+            "profiles": self.profiles,
+            "work_events": self.work_events,
+            "phases": self.phases,
+            "threads": self.threads,
+            "tag_rollups": self.tag_rollups,
+            "day_summaries": self.day_summaries,
+        }
+
+    def total(self) -> int:
+        return sum(self.to_dict().values())
+
+
+@dataclass(slots=True, frozen=True)
+class SessionProductStatusSnapshot:
+    total_conversations: int = 0
+    root_threads: int = 0
+    profile_row_count: int = 0
+    profile_merged_fts_count: int = 0
+    profile_merged_fts_duplicate_count: int = 0
+    profile_evidence_fts_count: int = 0
+    profile_evidence_fts_duplicate_count: int = 0
+    profile_inference_fts_count: int = 0
+    profile_inference_fts_duplicate_count: int = 0
+    profile_enrichment_fts_count: int = 0
+    profile_enrichment_fts_duplicate_count: int = 0
+    work_event_inference_count: int = 0
+    work_event_inference_fts_count: int = 0
+    work_event_inference_fts_duplicate_count: int = 0
+    phase_inference_count: int = 0
+    thread_count: int = 0
+    thread_fts_count: int = 0
+    thread_fts_duplicate_count: int = 0
+    tag_rollup_count: int = 0
+    day_summary_count: int = 0
+    missing_profile_row_count: int = 0
+    stale_profile_row_count: int = 0
+    orphan_profile_row_count: int = 0
+    expected_work_event_inference_count: int = 0
+    stale_work_event_inference_count: int = 0
+    orphan_work_event_inference_count: int = 0
+    expected_phase_inference_count: int = 0
+    stale_phase_inference_count: int = 0
+    orphan_phase_inference_count: int = 0
+    stale_thread_count: int = 0
+    orphan_thread_count: int = 0
+    expected_tag_rollup_count: int = 0
+    stale_tag_rollup_count: int = 0
+    expected_day_summary_count: int = 0
+    stale_day_summary_count: int = 0
+    profile_rows_ready: bool = False
+    profile_merged_fts_ready: bool = False
+    profile_evidence_fts_ready: bool = False
+    profile_inference_fts_ready: bool = False
+    profile_enrichment_fts_ready: bool = False
+    work_event_inference_rows_ready: bool = False
+    work_event_inference_fts_ready: bool = False
+    phase_inference_rows_ready: bool = False
+    threads_ready: bool = False
+    threads_fts_ready: bool = False
+    tag_rollups_ready: bool = False
+    day_summaries_ready: bool = False
+    week_summaries_ready: bool = False
+
+    def ready_flag(self, key: SessionProductReadyFlag) -> bool:
+        return bool(getattr(self, key))

--- a/polylogue/storage/session_product_status.py
+++ b/polylogue/storage/session_product_status.py
@@ -7,6 +7,7 @@ import sqlite3
 import aiosqlite
 
 from polylogue.storage.session_product_aggregates import _PROFILE_BUCKET_DAY_SQL
+from polylogue.storage.session_product_runtime import SessionProductStatusSnapshot
 from polylogue.storage.store import SESSION_PRODUCT_MATERIALIZER_VERSION
 
 # ---------------------------------------------------------------------------
@@ -262,7 +263,7 @@ def _to_int(row: tuple[object, ...] | sqlite3.Row | None) -> int:
 def _status_payload(
     tables: dict[str, bool],
     counts: dict[str, int],
-) -> dict[str, int | bool]:
+) -> SessionProductStatusSnapshot:
     profile_count = counts["profile_row_count"]
     work_event_count = counts["work_event_inference_count"]
     phase_count = counts["phase_inference_count"]
@@ -285,52 +286,52 @@ def _status_payload(
     expected_day_summary_count = counts["expected_day_summary_count"]
     stale_day_summary_count = counts["stale_day_summary_count"]
 
-    return {
+    return SessionProductStatusSnapshot(
         **counts,
-        "profile_rows_ready": tables["session_profiles"]
+        profile_rows_ready=tables["session_profiles"]
         and missing_profile_count == 0
         and stale_profile_count == 0
         and orphan_profile_count == 0,
-        "profile_merged_fts_ready": tables["session_profiles_fts"]
+        profile_merged_fts_ready=tables["session_profiles_fts"]
         and counts["profile_merged_fts_count"] == profile_count
         and counts["profile_merged_fts_duplicate_count"] == 0,
-        "profile_evidence_fts_ready": tables["session_profile_evidence_fts"]
+        profile_evidence_fts_ready=tables["session_profile_evidence_fts"]
         and counts["profile_evidence_fts_count"] == profile_count
         and counts["profile_evidence_fts_duplicate_count"] == 0,
-        "profile_inference_fts_ready": tables["session_profile_inference_fts"]
+        profile_inference_fts_ready=tables["session_profile_inference_fts"]
         and counts["profile_inference_fts_count"] == profile_count
         and counts["profile_inference_fts_duplicate_count"] == 0,
-        "profile_enrichment_fts_ready": tables["session_profile_enrichment_fts"]
+        profile_enrichment_fts_ready=tables["session_profile_enrichment_fts"]
         and counts["profile_enrichment_fts_count"] == profile_count
         and counts["profile_enrichment_fts_duplicate_count"] == 0,
-        "work_event_inference_rows_ready": tables["session_work_events"]
+        work_event_inference_rows_ready=tables["session_work_events"]
         and work_event_count == expected_work_event_count
         and stale_work_event_count == 0
         and orphan_work_event_count == 0,
-        "work_event_inference_fts_ready": tables["session_work_events_fts"]
+        work_event_inference_fts_ready=tables["session_work_events_fts"]
         and counts["work_event_inference_fts_count"] == work_event_count
         and counts["work_event_inference_fts_duplicate_count"] == 0,
-        "phase_inference_rows_ready": tables["session_phases"]
+        phase_inference_rows_ready=tables["session_phases"]
         and phase_count == expected_phase_count
         and stale_phase_count == 0
         and orphan_phase_count == 0,
-        "threads_ready": tables["work_threads"]
+        threads_ready=tables["work_threads"]
         and thread_count == counts["root_threads"]
         and stale_thread_count == 0
         and orphan_thread_count == 0,
-        "threads_fts_ready": tables["work_threads_fts"]
+        threads_fts_ready=tables["work_threads_fts"]
         and counts["thread_fts_count"] == thread_count
         and counts["thread_fts_duplicate_count"] == 0,
-        "tag_rollups_ready": tables["session_tag_rollups"]
+        tag_rollups_ready=tables["session_tag_rollups"]
         and tag_rollup_count == expected_tag_rollup_count
         and stale_tag_rollup_count == 0,
-        "day_summaries_ready": tables["day_session_summaries"]
+        day_summaries_ready=tables["day_session_summaries"]
         and day_summary_count == expected_day_summary_count
         and stale_day_summary_count == 0,
-        "week_summaries_ready": tables["day_session_summaries"]
+        week_summaries_ready=tables["day_session_summaries"]
         and day_summary_count == expected_day_summary_count
         and stale_day_summary_count == 0,
-    }
+    )
 
 
 def session_profile_repair_candidate_ids_sync(conn: sqlite3.Connection) -> list[str]:
@@ -355,7 +356,7 @@ def session_product_status_sync(
     conn: sqlite3.Connection,
     *,
     verify_freshness: bool = True,
-) -> dict[str, int | bool]:
+) -> SessionProductStatusSnapshot:
     tables = {key: bool(conn.execute(sql).fetchone()) for key, sql in _TABLE_SQLS.items()}
 
     def count(sql: str, *params: object) -> int:
@@ -511,7 +512,7 @@ def session_product_status_sync(
     return _status_payload(tables, counts)
 
 
-async def session_product_status_async(conn: aiosqlite.Connection) -> dict[str, int | bool]:
+async def session_product_status_async(conn: aiosqlite.Connection) -> SessionProductStatusSnapshot:
     tables = {}
     for key, sql in _TABLE_SQLS.items():
         tables[key] = bool(await (await conn.execute(sql)).fetchone())

--- a/polylogue/sync_product_queries.py
+++ b/polylogue/sync_product_queries.py
@@ -26,6 +26,7 @@ from polylogue.archive_products import (
     WorkThreadProduct,
     WorkThreadProductQuery,
 )
+from polylogue.storage.session_product_runtime import SessionProductStatusSnapshot
 from polylogue.sync_bridge import run_coroutine_sync
 
 if TYPE_CHECKING:
@@ -37,7 +38,7 @@ class SyncProductQueriesMixin:
 
     _facade: Polylogue
 
-    def get_session_product_status(self) -> dict[str, int | bool]:
+    def get_session_product_status(self) -> SessionProductStatusSnapshot:
         return run_coroutine_sync(self._facade.get_session_product_status())
 
     def get_session_profile_product(

--- a/tests/unit/cli/test_products.py
+++ b/tests/unit/cli/test_products.py
@@ -383,10 +383,10 @@ def test_session_product_rebuild_supports_legacy_payload_columns(cli_workspace: 
         rebuild_session_products_sync(conn)
         status = session_product_status_sync(conn)
 
-    assert _expect_int(status["profile_row_count"]) == 2
-    assert _expect_bool(status["profile_rows_ready"]) is True
-    assert _expect_bool(status["work_event_inference_rows_ready"]) is True
-    assert _expect_bool(status["phase_inference_rows_ready"]) is True
+    assert status.profile_row_count == 2
+    assert status.profile_rows_ready is True
+    assert status.work_event_inference_rows_ready is True
+    assert status.phase_inference_rows_ready is True
 
 
 def test_session_product_rebuild_pages_full_rebuild(cli_workspace: CliWorkspace) -> None:
@@ -396,13 +396,13 @@ def test_session_product_rebuild_pages_full_rebuild(cli_workspace: CliWorkspace)
         counts = rebuild_session_products_sync(conn, page_size=1)
         status = session_product_status_sync(conn)
 
-    assert _expect_int(counts["profiles"]) == 2
-    assert _expect_int(counts["work_events"]) >= 1
-    assert _expect_int(counts["phases"]) >= 1
-    assert _expect_int(status["profile_row_count"]) == 2
-    assert _expect_bool(status["profile_rows_ready"]) is True
-    assert _expect_bool(status["work_event_inference_rows_ready"]) is True
-    assert _expect_bool(status["phase_inference_rows_ready"]) is True
+    assert counts.profiles == 2
+    assert counts.work_events >= 1
+    assert counts.phases >= 1
+    assert status.profile_row_count == 2
+    assert status.profile_rows_ready is True
+    assert status.work_event_inference_rows_ready is True
+    assert status.phase_inference_rows_ready is True
 
 
 def test_session_product_rebuild_sync_reports_progress(cli_workspace: CliWorkspace) -> None:
@@ -468,7 +468,7 @@ def test_session_product_rebuild_preserves_profile_semantics_without_loading_ful
             ("conv-heavy",),
         ).fetchone()
 
-    assert _expect_int(counts["profiles"]) == 1
+    assert counts.profiles == 1
     assert row is not None
     repo_names = _expect_list(json.loads(row["repo_names_json"]))
     evidence_payload = _expect_object(json.loads(row["evidence_payload_json"]))
@@ -564,14 +564,14 @@ def test_session_product_status_accepts_epoch_backed_conversation_timestamps(cli
         rebuild_session_products_sync(conn)
         status = session_product_status_sync(conn)
 
-    assert _expect_int(status["profile_row_count"]) == 1
-    assert _expect_int(status["stale_profile_row_count"]) == 0
-    assert _expect_int(status["stale_work_event_inference_count"]) == 0
-    assert _expect_int(status["stale_phase_inference_count"]) == 0
-    assert _expect_bool(status["profile_rows_ready"]) is True
-    assert _expect_bool(status["work_event_inference_rows_ready"]) is True
-    assert _expect_bool(status["phase_inference_rows_ready"]) is True
-    assert _expect_int(status["profile_merged_fts_duplicate_count"]) == 0
+    assert status.profile_row_count == 1
+    assert status.stale_profile_row_count == 0
+    assert status.stale_work_event_inference_count == 0
+    assert status.stale_phase_inference_count == 0
+    assert status.profile_rows_ready is True
+    assert status.work_event_inference_rows_ready is True
+    assert status.phase_inference_rows_ready is True
+    assert status.profile_merged_fts_duplicate_count == 0
 
 
 def test_targeted_session_product_rebuild_does_not_duplicate_profile_fts(cli_workspace: CliWorkspace) -> None:
@@ -581,10 +581,10 @@ def test_targeted_session_product_rebuild_does_not_duplicate_profile_fts(cli_wor
         rebuild_session_products_sync(conn, conversation_ids=["conv-root"])
         status = session_product_status_sync(conn)
 
-    assert _expect_int(status["profile_row_count"]) == 2
-    assert _expect_int(status["profile_merged_fts_count"]) == 2
-    assert _expect_int(status["profile_merged_fts_duplicate_count"]) == 0
-    assert _expect_bool(status["profile_merged_fts_ready"]) is True
+    assert status.profile_row_count == 2
+    assert status.profile_merged_fts_count == 2
+    assert status.profile_merged_fts_duplicate_count == 0
+    assert status.profile_merged_fts_ready is True
 
 
 def test_session_product_status_marks_older_materializer_versions_stale(cli_workspace: CliWorkspace) -> None:
@@ -599,9 +599,9 @@ def test_session_product_status_marks_older_materializer_versions_stale(cli_work
         conn.commit()
         status = session_product_status_sync(conn)
 
-    assert _expect_int(status["profile_row_count"]) == 2
-    assert _expect_int(status["stale_profile_row_count"]) == 2
-    assert _expect_bool(status["profile_rows_ready"]) is False
+    assert status.profile_row_count == 2
+    assert status.stale_profile_row_count == 2
+    assert status.profile_rows_ready is False
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/devtools/test_benchmark_campaigns.py
+++ b/tests/unit/devtools/test_benchmark_campaigns.py
@@ -22,6 +22,7 @@ from devtools.synthetic_benchmark_runtime import (
     run_session_product_materialization_campaign,
 )
 from polylogue.scenarios import ExecutionKind
+from polylogue.storage.session_product_runtime import SessionProductCounts
 
 
 def test_synthetic_benchmark_registry_is_compiled_from_authored_scenarios() -> None:
@@ -204,14 +205,14 @@ def test_session_product_materialization_campaign_reports_rebuild_counts(monkeyp
     monkeypatch.setattr("polylogue.storage.backends.connection.open_connection", lambda _db_path: FakeContext())
     monkeypatch.setattr(
         "polylogue.storage.session_product_rebuild.rebuild_session_products_sync",
-        lambda conn: {
-            "profiles": 5,
-            "work_events": 8,
-            "phases": 3,
-            "threads": 2,
-            "tag_rollups": 4,
-            "day_summaries": 2,
-        },
+        lambda conn: SessionProductCounts(
+            profiles=5,
+            work_events=8,
+            phases=3,
+            threads=2,
+            tag_rollups=4,
+            day_summaries=2,
+        ),
     )
 
     result = run_session_product_materialization_campaign(tmp_path / "benchmark.db")

--- a/tests/unit/pipeline/test_run_sources.py
+++ b/tests/unit/pipeline/test_run_sources.py
@@ -25,6 +25,7 @@ from polylogue.sources.parsers.base import RawConversationData
 from polylogue.storage.backends import create_backend
 from polylogue.storage.backends.async_sqlite import SQLiteBackend
 from polylogue.storage.backends.connection import open_connection
+from polylogue.storage.session_product_runtime import SessionProductCounts
 from polylogue.storage.state_views import PlanResult, RunResult
 from tests.infra.storage_records import make_conversation, make_message, store_records
 
@@ -564,14 +565,14 @@ class TestRunSourcesIntegration:
             "polylogue.storage.session_product_rebuild.rebuild_session_products_async",
             new_callable=AsyncMock,
         ) as mock_rebuild:
-            mock_rebuild.return_value = {
-                "profiles": 1,
-                "work_events": 2,
-                "phases": 1,
-                "threads": 1,
-                "tag_rollups": 1,
-                "day_summaries": 1,
-            }
+            mock_rebuild.return_value = SessionProductCounts(
+                profiles=1,
+                work_events=2,
+                phases=1,
+                threads=1,
+                tag_rollups=1,
+                day_summaries=1,
+            )
             result = asyncio.run(run_sources(config=config, stage="materialize"))
 
         mock_rebuild.assert_awaited_once()

--- a/tests/unit/storage/test_derived_status.py
+++ b/tests/unit/storage/test_derived_status.py
@@ -7,6 +7,7 @@ import sqlite3
 import pytest
 
 from polylogue.storage.embedding_stats_models import EmbeddingStatsSnapshot
+from polylogue.storage.session_product_runtime import SessionProductStatusSnapshot
 
 
 def test_collect_derived_statuses_skips_retrieval_band_recomputation(
@@ -50,57 +51,23 @@ def test_collect_derived_statuses_skips_retrieval_band_recomputation(
             _conn: sqlite3.Connection,
             *,
             verify_freshness: bool = True,
-        ) -> dict[str, object]:
+        ) -> SessionProductStatusSnapshot:
             verify_calls.append(("session", verify_freshness))
-            return {
-                "profile_row_count": 0,
-                "profile_merged_fts_count": 0,
-                "profile_merged_fts_duplicate_count": 0,
-                "profile_evidence_fts_count": 0,
-                "profile_evidence_fts_duplicate_count": 0,
-                "profile_inference_fts_count": 0,
-                "profile_inference_fts_duplicate_count": 0,
-                "profile_enrichment_fts_count": 0,
-                "profile_enrichment_fts_duplicate_count": 0,
-                "work_event_inference_count": 0,
-                "work_event_inference_fts_count": 0,
-                "work_event_inference_fts_duplicate_count": 0,
-                "phase_inference_count": 0,
-                "thread_count": 0,
-                "thread_fts_count": 0,
-                "thread_fts_duplicate_count": 0,
-                "root_threads": 0,
-                "tag_rollup_count": 0,
-                "expected_tag_rollup_count": 0,
-                "day_summary_count": 0,
-                "expected_day_summary_count": 0,
-                "missing_profile_row_count": 0,
-                "stale_profile_row_count": 0,
-                "orphan_profile_row_count": 0,
-                "expected_work_event_inference_count": 0,
-                "stale_work_event_inference_count": 0,
-                "orphan_work_event_inference_count": 0,
-                "expected_phase_inference_count": 0,
-                "stale_phase_inference_count": 0,
-                "orphan_phase_inference_count": 0,
-                "stale_thread_count": 0,
-                "orphan_thread_count": 0,
-                "stale_tag_rollup_count": 0,
-                "stale_day_summary_count": 0,
-                "profile_rows_ready": True,
-                "profile_merged_fts_ready": True,
-                "profile_evidence_fts_ready": True,
-                "profile_inference_fts_ready": True,
-                "profile_enrichment_fts_ready": True,
-                "work_event_inference_rows_ready": True,
-                "work_event_inference_fts_ready": True,
-                "phase_inference_rows_ready": True,
-                "threads_ready": True,
-                "threads_fts_ready": True,
-                "tag_rollups_ready": True,
-                "day_summaries_ready": True,
-                "week_summaries_ready": True,
-            }
+            return SessionProductStatusSnapshot(
+                profile_rows_ready=True,
+                profile_merged_fts_ready=True,
+                profile_evidence_fts_ready=True,
+                profile_inference_fts_ready=True,
+                profile_enrichment_fts_ready=True,
+                work_event_inference_rows_ready=True,
+                work_event_inference_fts_ready=True,
+                phase_inference_rows_ready=True,
+                threads_ready=True,
+                threads_fts_ready=True,
+                tag_rollups_ready=True,
+                day_summaries_ready=True,
+                week_summaries_ready=True,
+            )
 
         monkeypatch.setattr(
             derived_status_mod,

--- a/tests/unit/storage/test_embedding_stats.py
+++ b/tests/unit/storage/test_embedding_stats.py
@@ -13,6 +13,7 @@ from polylogue.storage.embedding_stats import (
     read_embedding_stats_async,
     read_embedding_stats_sync,
 )
+from polylogue.storage.session_product_runtime import SessionProductStatusSnapshot
 
 
 def test_read_embedding_stats_sync_missing_tables_returns_zeroes() -> None:
@@ -99,27 +100,27 @@ def test_read_embedding_stats_sync_exposes_retrieval_bands_when_archive_tables_e
         monkeypatch.setattr(
             embedding_stats_mod,
             "session_product_status_sync",
-            lambda _conn: {
-                "profile_row_count": 2,
-                "profile_evidence_fts_count": 2,
-                "profile_evidence_fts_ready": True,
-                "profile_evidence_fts_duplicate_count": 0,
-                "work_event_inference_count": 2,
-                "work_event_inference_fts_count": 2,
-                "work_event_inference_fts_ready": True,
-                "work_event_inference_fts_duplicate_count": 0,
-                "phase_inference_count": 2,
-                "phase_inference_rows_ready": True,
-                "expected_phase_inference_count": 2,
-                "stale_work_event_inference_count": 0,
-                "stale_phase_inference_count": 0,
-                "profile_inference_fts_count": 2,
-                "profile_inference_fts_ready": True,
-                "profile_inference_fts_duplicate_count": 0,
-                "profile_enrichment_fts_count": 2,
-                "profile_enrichment_fts_ready": True,
-                "profile_enrichment_fts_duplicate_count": 0,
-            },
+            lambda _conn: SessionProductStatusSnapshot(
+                profile_row_count=2,
+                profile_evidence_fts_count=2,
+                profile_evidence_fts_ready=True,
+                profile_evidence_fts_duplicate_count=0,
+                work_event_inference_count=2,
+                work_event_inference_fts_count=2,
+                work_event_inference_fts_ready=True,
+                work_event_inference_fts_duplicate_count=0,
+                phase_inference_count=2,
+                phase_inference_rows_ready=True,
+                expected_phase_inference_count=2,
+                stale_work_event_inference_count=0,
+                stale_phase_inference_count=0,
+                profile_inference_fts_count=2,
+                profile_inference_fts_ready=True,
+                profile_inference_fts_duplicate_count=0,
+                profile_enrichment_fts_count=2,
+                profile_enrichment_fts_ready=True,
+                profile_enrichment_fts_duplicate_count=0,
+            ),
         )
 
         stats = read_embedding_stats_sync(conn)
@@ -214,27 +215,27 @@ async def test_read_embedding_stats_async_derives_pending_from_total_conversatio
         }
 
     async def fake_session_status(_conn: Any) -> Any:
-        return {
-            "profile_row_count": 0,
-            "profile_evidence_fts_count": 0,
-            "profile_evidence_fts_ready": True,
-            "profile_evidence_fts_duplicate_count": 0,
-            "work_event_inference_count": 0,
-            "work_event_inference_fts_count": 0,
-            "work_event_inference_fts_ready": True,
-            "work_event_inference_fts_duplicate_count": 0,
-            "phase_inference_count": 0,
-            "phase_inference_rows_ready": True,
-            "expected_phase_inference_count": 0,
-            "stale_work_event_inference_count": 0,
-            "stale_phase_inference_count": 0,
-            "profile_inference_fts_count": 0,
-            "profile_inference_fts_ready": True,
-            "profile_inference_fts_duplicate_count": 0,
-            "profile_enrichment_fts_count": 0,
-            "profile_enrichment_fts_ready": True,
-            "profile_enrichment_fts_duplicate_count": 0,
-        }
+        return SessionProductStatusSnapshot(
+            profile_row_count=0,
+            profile_evidence_fts_count=0,
+            profile_evidence_fts_ready=True,
+            profile_evidence_fts_duplicate_count=0,
+            work_event_inference_count=0,
+            work_event_inference_fts_count=0,
+            work_event_inference_fts_ready=True,
+            work_event_inference_fts_duplicate_count=0,
+            phase_inference_count=0,
+            phase_inference_rows_ready=True,
+            expected_phase_inference_count=0,
+            stale_work_event_inference_count=0,
+            stale_phase_inference_count=0,
+            profile_inference_fts_count=0,
+            profile_inference_fts_ready=True,
+            profile_inference_fts_duplicate_count=0,
+            profile_enrichment_fts_count=0,
+            profile_enrichment_fts_ready=True,
+            profile_enrichment_fts_duplicate_count=0,
+        )
 
     async with aiosqlite.connect(":memory:") as conn:
         await conn.execute("CREATE TABLE conversations (conversation_id TEXT)")

--- a/tests/unit/storage/test_session_product_refresh.py
+++ b/tests/unit/storage/test_session_product_refresh.py
@@ -51,7 +51,7 @@ async def test_apply_session_product_conversation_updates_async_batches_hydrated
             page_size=10,
         )
 
-    assert update.counts["profiles"] == 1
+    assert update.counts.profiles == 1
     assert update.thread_root_ids == {"conv-refresh"}
     assert update.affected_groups
     assert len(update.chunk_observations) == 1
@@ -94,7 +94,7 @@ async def test_apply_session_product_conversation_updates_async_preserves_thread
             page_size=10,
         )
 
-    assert update.counts["profiles"] == 2
+    assert update.counts.profiles == 2
     assert update.thread_root_ids == {"conv-root"}
     assert len(update.chunk_observations) == 1
 
@@ -131,7 +131,7 @@ async def test_apply_session_product_conversation_updates_async_uses_small_defau
             transaction_depth=1,
         )
 
-    assert update.counts["profiles"] == 11
+    assert update.counts.profiles == 11
     assert len(update.chunk_observations) == 2
     assert update.chunk_observations[0].conversation_count == 10
     assert update.chunk_observations[0].estimated_message_count == 10
@@ -188,7 +188,7 @@ async def test_apply_session_product_conversation_updates_async_splits_large_mes
             transaction_depth=1,
         )
 
-    assert update.counts["profiles"] == 3
+    assert update.counts.profiles == 3
     assert len(update.chunk_observations) == 2
     assert update.chunk_observations[0].conversation_count == 1
     assert update.chunk_observations[0].estimated_message_count == 4_000
@@ -220,7 +220,7 @@ async def test_apply_session_product_conversation_updates_async_clears_deleted_c
         )
         await conn.commit()
 
-    assert first_update.counts["profiles"] == 1
+    assert first_update.counts.profiles == 1
 
     with open_connection(db_path) as conn:
         conn.execute("DELETE FROM messages WHERE conversation_id = ?", ("conv-stale",))
@@ -236,7 +236,7 @@ async def test_apply_session_product_conversation_updates_async_clears_deleted_c
         )
         await conn.commit()
 
-    assert second_update.counts["profiles"] == 0
+    assert second_update.counts.profiles == 0
     assert len(second_update.chunk_observations) == 1
 
     with open_connection(db_path) as conn:


### PR DESCRIPTION
Ref #225
Ref #222

## Summary
- replace dict-shaped session-product rebuild counts with a typed runtime counter object
- replace dict-shaped session-product status snapshots with a typed runtime snapshot and ready-flag helper
- carry the new contracts through archive operations, repair, embedding stats, benchmark tooling, and the direct tests

## Problem
The session-product runtime still exposed broad dict payloads for rebuild counts and readiness snapshots. That kept storage, repair, and product surfaces stringly-typed even after the earlier substrate renewal work, and it forced tests plus benchmark tooling to keep patching and indexing anonymous containers.

## Solution
Added `SessionProductCounts` and `SessionProductStatusSnapshot` in `polylogue/storage/session_product_runtime.py`, then moved `session_product_refresh.py`, `session_product_rebuild.py`, and `session_product_status.py` onto those contracts. Updated the downstream storage/query/facade surfaces and the consumers that actually inspect the status data, especially `operations/archive.py`, `storage/repair.py`, `storage/derived_status.py`, `storage/embedding_stats_support.py`, and `devtools/synthetic_benchmark_runtime.py`.

## Verification
- `devtools verify`
