### PR TITLE
refactor: renew transient run-state and storage view contracts

### DIFF
--- a/polylogue/cli/formatting.py
+++ b/polylogue/cli/formatting.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from polylogue.config import Source
 from polylogue.lib.run_activity import conversation_activity_counts
 from polylogue.lib.timestamps import format_timestamp
+from polylogue.storage.state_views import CursorStatePayload, PlanCounts, PlanDetails, RunCounts
 
 _FALSEY_ENV_VALUES = frozenset({"0", "false", "no"})
 
@@ -31,7 +32,7 @@ def announce_plain_mode() -> None:
     sys.stderr.write("Plain output active (non-TTY).\n")
 
 
-def format_cursors(cursors: Mapping[str, object]) -> str | None:
+def format_cursors(cursors: Mapping[str, object] | dict[str, CursorStatePayload]) -> str | None:
     if not cursors:
         return None
     parts: list[str] = []
@@ -62,7 +63,7 @@ def format_cursors(cursors: Mapping[str, object]) -> str | None:
     return "; ".join(parts)
 
 
-def format_counts(counts: Mapping[str, object]) -> str:
+def format_counts(counts: Mapping[str, object] | RunCounts) -> str:
     ordered_labels = [
         ("acquired", "acquired"),
         ("skipped", "skipped"),
@@ -102,7 +103,7 @@ def format_counts(counts: Mapping[str, object]) -> str:
     return ", ".join(parts)
 
 
-def format_run_details(counts: Mapping[str, object]) -> list[str]:
+def format_run_details(counts: Mapping[str, object] | RunCounts) -> list[str]:
     lines: list[str] = []
     total_conv, new_conv, changed_conv = conversation_activity_counts(counts)
 
@@ -163,7 +164,7 @@ def format_run_details(counts: Mapping[str, object]) -> list[str]:
     return lines
 
 
-def format_plan_counts(counts: Mapping[str, object]) -> str:
+def format_plan_counts(counts: Mapping[str, object] | PlanCounts) -> str:
     labels = [
         ("scan", "scan"),
         ("store_raw", "store"),
@@ -183,7 +184,7 @@ def format_plan_counts(counts: Mapping[str, object]) -> str:
     return ", ".join(parts)
 
 
-def format_plan_details(details: Mapping[str, object]) -> str | None:
+def format_plan_details(details: Mapping[str, object] | PlanDetails) -> str | None:
     labels = [
         ("new_raw", "new raw"),
         ("existing_raw", "existing raw"),

--- a/polylogue/cli/run_display_workflow.py
+++ b/polylogue/cli/run_display_workflow.py
@@ -19,12 +19,13 @@ from polylogue.cli.helpers import fail
 from polylogue.lib.timestamps import format_timestamp
 from polylogue.pipeline.run_support import expand_requested_stage
 from polylogue.sources import DriveError
+from polylogue.storage.state_views import PlanResult, RunResult
 
 
 def display_result(
     env: Any,
     cfg: Any,
-    result: Any,
+    result: RunResult,
     stage: str,
     selected_sources: list[str] | None,
     *,
@@ -120,7 +121,7 @@ def render_preview_summary(
     env: Any,
     *,
     selected_sources: list[str] | None,
-    plan_snapshot: Any,
+    plan_snapshot: PlanResult | None,
 ) -> None:
     plan_lines = []
     if selected_sources:

--- a/polylogue/cli/run_workflow.py
+++ b/polylogue/cli/run_workflow.py
@@ -125,8 +125,8 @@ def run_sync_once(
 
 def display_result(
     env: Any,
-    cfg: Any,
-    result: Any,
+    cfg: Config,
+    result: RunResult,
     stage: str,
     selected_sources: list[str] | None,
     *,
@@ -195,7 +195,7 @@ def render_preview_summary(
     env: Any,
     *,
     selected_sources: list[str] | None,
-    plan_snapshot: Any,
+    plan_snapshot: PlanResult | None,
 ) -> None:
     plan_lines = []
     if selected_sources:

--- a/polylogue/lib/run_activity.py
+++ b/polylogue/lib/run_activity.py
@@ -4,14 +4,16 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 
+from polylogue.storage.state_views import RunCounts, RunDrift
 
-def _int_value(mapping: Mapping[str, object], key: str) -> int:
+
+def _int_value(mapping: Mapping[str, object] | RunCounts, key: str) -> int:
     value = mapping.get(key)
     return value if isinstance(value, int) else 0
 
 
 def _drift_value(
-    drift: Mapping[str, Mapping[str, object]] | None,
+    drift: Mapping[str, Mapping[str, object]] | RunDrift | None,
     bucket: str,
     key: str,
 ) -> int:
@@ -25,8 +27,8 @@ def _drift_value(
 
 
 def conversation_activity_counts(
-    counts: Mapping[str, object],
-    drift: Mapping[str, Mapping[str, object]] | None = None,
+    counts: Mapping[str, object] | RunCounts,
+    drift: Mapping[str, Mapping[str, object]] | RunDrift | None = None,
 ) -> tuple[int, int, int]:
     """Return total, new, and changed conversation counts for one run."""
 

--- a/polylogue/pipeline/run_finalization.py
+++ b/polylogue/pipeline/run_finalization.py
@@ -9,7 +9,7 @@ from uuid import uuid4
 from polylogue.pipeline.run_support import write_run_json
 from polylogue.storage.backends import create_backend
 from polylogue.storage.backends.queries import runs as runs_q
-from polylogue.storage.state_views import RunResult
+from polylogue.storage.state_views import RunCountsPayload, RunDrift, RunDriftPayload, RunResult
 from polylogue.storage.store import RunRecord
 
 if TYPE_CHECKING:
@@ -25,8 +25,8 @@ if TYPE_CHECKING:
 class RunPayload(TypedDict):
     run_id: str
     timestamp: int
-    counts: dict[str, int]
-    drift: dict[str, dict[str, int]]
+    counts: RunCountsPayload
+    drift: RunDriftPayload
     indexed: bool
     index_error: str | None
     duration_ms: int
@@ -42,11 +42,12 @@ def build_run_payload(
 ) -> RunPayload:
     """Create the canonical persisted payload for a completed pipeline run."""
     drift = state.finalize()
+    counts = cast(RunCountsPayload, state.counts.to_dict())
     return {
         "run_id": uuid4().hex,
         "timestamp": int(time.time()),
-        "counts": state.counts,
-        "drift": drift,
+        "counts": counts,
+        "drift": drift.to_dict(),
         "indexed": index_outcome.indexed,
         "index_error": index_outcome.error,
         "duration_ms": duration_ms,
@@ -75,9 +76,9 @@ async def persist_run_result(
         RunRecord(
             run_id=str(run_payload["run_id"]),
             timestamp=str(run_payload["timestamp"]),
-            plan_snapshot=plan.model_dump() if plan else None,
-            counts=state.counts,
-            drift=run_payload["drift"],
+            plan_snapshot=plan.model_dump(mode="json") if plan else None,
+            counts=cast(dict[str, object], dict(run_payload["counts"])),
+            drift=cast(dict[str, object], dict(run_payload["drift"])),
             indexed=index_outcome.indexed,
             duration_ms=duration_ms,
         ),
@@ -85,8 +86,8 @@ async def persist_run_result(
     run_path = write_run_json(config.archive_root, cast(dict[str, object], dict(run_payload)))
     return RunResult(
         run_id=str(run_payload["run_id"]),
-        counts=state.counts,
-        drift=run_payload["drift"],
+        counts=state.counts.model_copy(deep=True),
+        drift=RunDrift.model_validate(run_payload["drift"]),
         indexed=index_outcome.indexed,
         index_error=index_outcome.error,
         duration_ms=duration_ms,

--- a/polylogue/pipeline/run_stages.py
+++ b/polylogue/pipeline/run_stages.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, TypedDict
 
 from polylogue.config import Config
 from polylogue.pipeline.run_support import PARSE_STAGES
+from polylogue.storage.state_views import RenderFailurePayload
 from polylogue.types import SearchProvider
 
 if TYPE_CHECKING:
@@ -24,7 +25,7 @@ if TYPE_CHECKING:
 @dataclass(slots=True)
 class RenderStageOutcome:
     rendered_count: int
-    failures: list[dict[str, str]]
+    failures: list[RenderFailurePayload]
     total: int
     observation: dict[str, object] | None = None
 

--- a/polylogue/pipeline/run_state.py
+++ b/polylogue/pipeline/run_state.py
@@ -1,96 +1,89 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any
 
 from polylogue.pipeline.services.parsing import ParseResult
+from polylogue.pipeline.stage_models import AcquireResult, ValidateResult
+from polylogue.storage.state_views import DriftBucket, RenderFailurePayload, RunCounts, RunDrift
 
 
-def _initial_counts() -> dict[str, int]:
-    return {
-        "conversations": 0,
-        "messages": 0,
-        "attachments": 0,
-        "skipped_conversations": 0,
-        "skipped_messages": 0,
-        "skipped_attachments": 0,
-        "materialized": 0,
-        "rendered": 0,
-    }
+def _initial_counts() -> RunCounts:
+    return RunCounts(
+        conversations=0,
+        messages=0,
+        attachments=0,
+        skipped_conversations=0,
+        skipped_messages=0,
+        skipped_attachments=0,
+        materialized=0,
+        rendered=0,
+    )
 
 
-def _initial_changed_counts() -> dict[str, int]:
-    return {
-        "conversations": 0,
-        "messages": 0,
-        "attachments": 0,
-    }
+def _initial_changed_counts() -> DriftBucket:
+    return DriftBucket()
 
 
 @dataclass(slots=True)
 class RunExecutionState:
     """Mutable run bookkeeping shared across pipeline stages."""
 
-    counts: dict[str, int] = field(default_factory=_initial_counts)
-    changed_counts: dict[str, int] = field(default_factory=_initial_changed_counts)
+    counts: RunCounts = field(default_factory=_initial_counts)
+    changed_counts: DriftBucket = field(default_factory=_initial_changed_counts)
     processed_ids: set[str] = field(default_factory=set)
-    render_failures: list[dict[str, str]] = field(default_factory=list)
+    render_failures: list[RenderFailurePayload] = field(default_factory=list)
 
-    def record_acquire(self, acquire_result: Any) -> None:
-        self.counts["acquired"] = acquire_result.counts["acquired"]
-        self.counts["skipped"] = acquire_result.counts["skipped"]
-        self.counts["acquire_errors"] = acquire_result.counts["errors"]
+    def record_acquire(self, acquire_result: AcquireResult) -> None:
+        self.counts.acquired = acquire_result.acquired
+        self.counts.skipped = acquire_result.skipped
+        self.counts.acquire_errors = acquire_result.errors
 
-    def record_validation(self, validation_result: Any) -> None:
+    def record_validation(self, validation_result: ValidateResult | None) -> None:
         if validation_result is None:
             return
-        self.counts["validated"] = validation_result.counts["validated"]
-        self.counts["validation_invalid"] = validation_result.counts["invalid"]
-        self.counts["validation_drift"] = validation_result.counts["drift"]
-        self.counts["validation_skipped_no_schema"] = validation_result.counts["skipped_no_schema"]
-        self.counts["validation_errors"] = validation_result.counts["errors"]
+        self.counts.validated = validation_result.validated
+        self.counts.validation_invalid = validation_result.invalid
+        self.counts.validation_drift = validation_result.drift
+        self.counts.validation_skipped_no_schema = validation_result.skipped_no_schema
+        self.counts.validation_errors = validation_result.errors
 
     def record_parse(self, parse_result: ParseResult) -> None:
         for key, value in parse_result.counts.items():
-            self.counts[key] = value
+            setattr(self.counts, key, value)
         if parse_result.parse_failures:
-            self.counts["parse_failures"] = parse_result.parse_failures
-        self.changed_counts.update(parse_result.changed_counts)
+            self.counts.parse_failures = parse_result.parse_failures
+        for key, value in parse_result.changed_counts.items():
+            current = getattr(self.changed_counts, key)
+            setattr(self.changed_counts, key, current + value)
         self.processed_ids = parse_result.processed_ids
-        self.counts["conversations"] = len(self.processed_ids)
+        self.counts.conversations = len(self.processed_ids)
 
     def record_schema_generation(self, *, generated: int, failed: int) -> None:
-        self.counts["schemas_generated"] = generated
-        self.counts["schemas_failed"] = failed
+        self.counts.schemas_generated = generated
+        self.counts.schemas_failed = failed
 
     def record_materialize(self, *, materialized: int) -> None:
-        self.counts["materialized"] = materialized
+        self.counts.materialized = materialized
 
-    def record_render(self, *, rendered: int, failures: list[dict[str, str]]) -> None:
-        self.counts["rendered"] = rendered
+    def record_render(self, *, rendered: int, failures: list[RenderFailurePayload]) -> None:
+        self.counts.rendered = rendered
         self.render_failures = failures
         if failures:
-            self.counts["render_failures"] = len(failures)
+            self.counts.render_failures = len(failures)
 
-    def finalize(self) -> dict[str, dict[str, int]]:
-        new_counts = {
-            "conversations": max(
-                self.counts["conversations"] - self.changed_counts["conversations"],
-                0,
-            ),
-            "messages": max(self.counts["messages"] - self.changed_counts["messages"], 0),
-            "attachments": max(
-                self.counts["attachments"] - self.changed_counts["attachments"],
-                0,
-            ),
-        }
-        self.counts["new_conversations"] = new_counts["conversations"]
-        self.counts["changed_conversations"] = self.changed_counts["conversations"]
-        return {
-            "new": new_counts,
-            "removed": {"conversations": 0, "messages": 0, "attachments": 0},
-            "changed": dict(self.changed_counts),
-        }
+    def finalize(self) -> RunDrift:
+        new_counts = DriftBucket(
+            conversations=max(self.counts.int_value("conversations") - self.changed_counts.conversations, 0),
+            messages=max(self.counts.int_value("messages") - self.changed_counts.messages, 0),
+            attachments=max(self.counts.int_value("attachments") - self.changed_counts.attachments, 0),
+        )
+        self.counts.new_conversations = new_counts.conversations
+        self.counts.changed_conversations = self.changed_counts.conversations
+        return RunDrift(
+            new=new_counts,
+            removed=DriftBucket(),
+            changed=self.changed_counts.model_copy(deep=True),
+        )
 
 
 __all__ = ["RunExecutionState"]

--- a/polylogue/pipeline/services/acquisition.py
+++ b/polylogue/pipeline/services/acquisition.py
@@ -13,6 +13,7 @@ from polylogue.pipeline.services.acquisition_streams import iter_raw_record_stre
 from polylogue.pipeline.stage_models import AcquireResult
 from polylogue.protocols import ProgressCallback
 from polylogue.sources.source_acquisition import iter_source_raw_data
+from polylogue.storage.state_views import CursorStatePayload
 from polylogue.storage.store import RawConversationRecord
 
 if TYPE_CHECKING:
@@ -80,7 +81,7 @@ class AcquisitionService:
 
         for source in sources:
             logger.debug("Scanning source", source=source.name)
-            cursor_state: dict[str, object] = {}
+            cursor_state: CursorStatePayload = {}
             try:
                 async for record in iter_raw_record_stream(
                     source,

--- a/polylogue/pipeline/services/acquisition_records.py
+++ b/polylogue/pipeline/services/acquisition_records.py
@@ -6,6 +6,7 @@ from datetime import datetime, timezone
 
 from polylogue.lib.provider_identity import canonical_acquisition_provider
 from polylogue.sources.parsers.base import RawConversationData
+from polylogue.storage.state_views import CursorStatePayload
 from polylogue.storage.store import RawConversationRecord
 
 
@@ -17,7 +18,7 @@ class ScanResult:
             "scanned": 0,
             "errors": 0,
         }
-        self.cursors: dict[str, dict[str, object]] = {}
+        self.cursors: dict[str, CursorStatePayload] = {}
 
 
 def make_raw_record(

--- a/polylogue/pipeline/services/acquisition_streams.py
+++ b/polylogue/pipeline/services/acquisition_streams.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING
 from polylogue.logging import get_logger
 from polylogue.pipeline.services.acquisition_records import make_raw_record
 from polylogue.sources.parsers.base import RawConversationData
+from polylogue.storage.state_views import CursorStatePayload
 from polylogue.storage.store import RawConversationRecord
 
 if TYPE_CHECKING:
@@ -76,7 +77,7 @@ async def iter_drive_raw_stream(
     *,
     known_mtimes: dict[str, str] | None = None,
     ui: DriveUILike | None = None,
-    cursor_state: dict[str, object] | None = None,
+    cursor_state: CursorStatePayload | None = None,
     drive_config: DriveConfigLike | None = None,
 ) -> AsyncIterator[RawConversationData]:
     """Stream Drive payloads as raw records without touching the local cache."""
@@ -111,7 +112,7 @@ async def iter_raw_record_stream(
     *,
     known_mtimes: dict[str, str] | None = None,
     ui: DriveUILike | None = None,
-    cursor_state: dict[str, object] | None = None,
+    cursor_state: CursorStatePayload | None = None,
     drive_config: DriveConfigLike | None = None,
     observation_callback: ObservationCallback | None = None,
     progress_callback: Callable[[int, str | None], None] | None = None,

--- a/polylogue/pipeline/services/planning_runtime.py
+++ b/polylogue/pipeline/services/planning_runtime.py
@@ -11,7 +11,7 @@ from polylogue.pipeline.run_support import expand_requested_stage, normalize_sta
 from polylogue.pipeline.stage_models import ValidateResult
 from polylogue.protocols import ProgressCallback
 from polylogue.storage.raw_ingest_artifacts import RawIngestArtifactState
-from polylogue.storage.state_views import PlanResult
+from polylogue.storage.state_views import PlanCounts, PlanDetails, PlanResult
 from polylogue.storage.store import RawConversationRecord
 from polylogue.types import PlanStage
 
@@ -75,13 +75,13 @@ async def build_ingest_plan(
         conversation_count = 0
         if has_materialize or has_render or has_index:
             conversation_count = await service.backend.count_conversation_ids(source_names=db_scope_names)
-        stage_counts: dict[str, int] = {}
+        stage_counts = PlanCounts()
         if has_materialize and conversation_count:
-            stage_counts["materialize"] = conversation_count
+            stage_counts.materialize = conversation_count
         if has_render and conversation_count:
-            stage_counts["render"] = conversation_count
+            stage_counts.render = conversation_count
         if has_index and conversation_count:
-            stage_counts["index"] = conversation_count
+            stage_counts.index = conversation_count
         return IngestPlan(
             summary=PlanResult(
                 timestamp=int(time.time()),
@@ -109,20 +109,20 @@ async def build_ingest_plan(
             force_reparse=force_reparse,
         )
         reprocess_raw_ids = dedupe_ids([*validate_backlog_ids, *parse_backlog_ids])
-        backlog_counts: dict[str, int] = {}
-        backlog_details: dict[str, int] = {}
+        backlog_counts = PlanCounts()
+        backlog_details = PlanDetails()
         if validate_backlog_ids:
-            backlog_counts["validate"] = len(validate_backlog_ids)
-            backlog_details["backlog_validate"] = len(validate_backlog_ids)
+            backlog_counts.validate_count = len(validate_backlog_ids)
+            backlog_details.backlog_validate = len(validate_backlog_ids)
         if reprocess_raw_ids:
-            backlog_counts["parse"] = len(reprocess_raw_ids)
-            backlog_details["backlog_parse"] = len(parse_backlog_ids)
+            backlog_counts.parse = len(reprocess_raw_ids)
+            backlog_details.backlog_parse = len(parse_backlog_ids)
             if has_materialize:
-                backlog_counts["materialize"] = len(reprocess_raw_ids)
+                backlog_counts.materialize = len(reprocess_raw_ids)
             if has_render:
-                backlog_counts["render"] = len(reprocess_raw_ids)
+                backlog_counts.render = len(reprocess_raw_ids)
             if has_index:
-                backlog_counts["index"] = len(reprocess_raw_ids)
+                backlog_counts.index = len(reprocess_raw_ids)
         return IngestPlan(
             summary=PlanResult(
                 timestamp=int(time.time()),
@@ -142,13 +142,13 @@ async def build_ingest_plan(
     scanned_count = 0
     validate_raw_ids: list[str] = []
     parse_ready_raw_ids: list[str] = []
-    plan_details: dict[str, int] = {
-        "new_raw": 0,
-        "existing_raw": 0,
-        "duplicate_raw": 0,
-        "backlog_validate": 0,
-        "backlog_parse": 0,
-    }
+    plan_details = PlanDetails(
+        new_raw=0,
+        existing_raw=0,
+        duplicate_raw=0,
+        backlog_validate=0,
+        backlog_parse=0,
+    )
     pending_records: list[RawConversationRecord] = []
     preview_validation = ValidateResult() if preview and has_parse else None
     seen_scanned_raw_ids: set[str] = set()
@@ -166,12 +166,12 @@ async def build_ingest_plan(
 
         for record in pending_records:
             if record.raw_id in seen_scanned_raw_ids:
-                plan_details["duplicate_raw"] += 1
+                plan_details.duplicate_raw = plan_details.int_value("duplicate_raw") + 1
                 continue
             seen_scanned_raw_ids.add(record.raw_id)
             state = scanned_states.get(record.raw_id)
             if state is None:
-                plan_details["new_raw"] += 1
+                plan_details.new_raw = plan_details.int_value("new_raw") + 1
                 if has_parse:
                     validate_raw_ids.append(record.raw_id)
                     if (
@@ -182,7 +182,7 @@ async def build_ingest_plan(
                         preview_records.append(record)
                 continue
 
-            plan_details["existing_raw"] += 1
+            plan_details.existing_raw = plan_details.int_value("existing_raw") + 1
             if not has_parse:
                 continue
 
@@ -226,7 +226,7 @@ async def build_ingest_plan(
             force_reparse=force_reparse,
         )
         if backlog_validate_ids:
-            plan_details["backlog_validate"] = len(backlog_validate_ids)
+            plan_details.backlog_validate = len(backlog_validate_ids)
             validate_raw_ids.extend(backlog_validate_ids)
 
         if preview:
@@ -237,9 +237,9 @@ async def build_ingest_plan(
                 )
                 preview_validation.merge(backlog_preview_validation)
             if preview_validation is not None and preview_validation.counts["invalid"]:
-                plan_details["preview_invalid"] = preview_validation.counts["invalid"]
+                plan_details.preview_invalid = preview_validation.counts["invalid"]
             if preview_validation is not None and preview_validation.counts["skipped_no_schema"]:
-                plan_details["preview_skipped_no_schema"] = preview_validation.counts["skipped_no_schema"]
+                plan_details.preview_skipped_no_schema = preview_validation.counts["skipped_no_schema"]
 
     if has_parse:
         backlog_parse_ids = await collect_parse_backlog(
@@ -248,43 +248,43 @@ async def build_ingest_plan(
             exclude_raw_ids=validate_raw_ids,
             force_reparse=force_reparse,
         )
-        plan_details["backlog_parse"] = len(backlog_parse_ids)
+        plan_details.backlog_parse = len(backlog_parse_ids)
         parse_ready_raw_ids.extend(backlog_parse_ids)
         if preview_validation is not None:
             parse_ready_raw_ids.extend(preview_validation.parseable_raw_ids)
         parse_ready_raw_ids = dedupe_ids(parse_ready_raw_ids)
         validate_raw_ids = dedupe_ids(validate_raw_ids)
 
-    final_counts: dict[str, int] = {}
+    final_counts = PlanCounts()
     if scanned_count:
-        final_counts["scan"] = scanned_count
-    if plan_details["new_raw"] and has_acquire:
-        final_counts["store_raw"] = plan_details["new_raw"]
+        final_counts.scan = scanned_count
+    if plan_details.int_value("new_raw") and has_acquire:
+        final_counts.store_raw = plan_details.int_value("new_raw")
     if has_parse and validate_raw_ids:
-        final_counts["validate"] = len(validate_raw_ids)
+        final_counts.validate_count = len(validate_raw_ids)
     if has_parse and parse_ready_raw_ids:
-        final_counts["parse"] = len(parse_ready_raw_ids)
+        final_counts.parse = len(parse_ready_raw_ids)
         if has_materialize:
-            final_counts["materialize"] = len(parse_ready_raw_ids)
+            final_counts.materialize = len(parse_ready_raw_ids)
         if has_render:
-            final_counts["render"] = len(parse_ready_raw_ids)
+            final_counts.render = len(parse_ready_raw_ids)
         if has_index:
-            final_counts["index"] = len(parse_ready_raw_ids)
+            final_counts.index = len(parse_ready_raw_ids)
     elif not has_parse and (has_materialize or has_render or has_index):
         conversation_count = await service.backend.count_conversation_ids(source_names=db_scope_names)
         if has_materialize and conversation_count:
-            final_counts["materialize"] = conversation_count
+            final_counts.materialize = conversation_count
         if has_render and conversation_count:
-            final_counts["render"] = conversation_count
+            final_counts.render = conversation_count
         if has_index and conversation_count:
-            final_counts["index"] = conversation_count
+            final_counts.index = conversation_count
 
     summary = PlanResult(
         timestamp=int(time.time()),
         stage=summary_stage,
         stage_sequence=normalized_plan_stage_sequence,
         counts=final_counts,
-        details={key: value for key, value in plan_details.items() if value},
+        details=plan_details,
         sources=source_names,
         cursors=scan_result.cursors,
     )

--- a/polylogue/pipeline/services/rendering.py
+++ b/polylogue/pipeline/services/rendering.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING
 from polylogue.lib.metrics import read_current_rss_mb
 from polylogue.logging import get_logger
 from polylogue.protocols import OutputRenderer, ProgressCallback
+from polylogue.storage.state_views import RenderFailurePayload
 
 if TYPE_CHECKING:
     from polylogue.storage.backends.async_sqlite import SQLiteBackend
@@ -36,7 +37,7 @@ class RenderResult:
 
     def __init__(self) -> None:
         self.rendered_count: int = 0
-        self.failures: list[dict[str, str]] = []
+        self.failures: list[RenderFailurePayload] = []
         self.worker_count: int = 0
         self.rss_start_mb: float | None = None
         self.rss_end_mb: float | None = None

--- a/polylogue/pipeline/watch.py
+++ b/polylogue/pipeline/watch.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from typing import TYPE_CHECKING
 
 from polylogue.pipeline.observers import RunObserver
@@ -35,7 +35,7 @@ class WatchRunner:
             while self._running:
                 try:
                     result = self._sync_fn()
-                    new_count = result.counts.get("conversations", 0)
+                    new_count = _conversation_count(result)
                     self._observer.on_completed(result)
                     if new_count <= 0:
                         self._observer.on_idle(result)
@@ -53,3 +53,15 @@ class WatchRunner:
 
 
 __all__ = ["WatchRunner"]
+
+
+def _conversation_count(result: object) -> int:
+    counts = getattr(result, "counts", None)
+    int_value = getattr(counts, "int_value", None)
+    if callable(int_value):
+        value = int_value("conversations")
+        return value if isinstance(value, int) else 0
+    if isinstance(counts, Mapping):
+        value = counts.get("conversations", 0)
+        return value if isinstance(value, int) else 0
+    return 0

--- a/polylogue/sources/cursor.py
+++ b/polylogue/sources/cursor.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
 
 from polylogue.logging import get_logger
+from polylogue.storage.state_views import CursorFailurePayload, CursorStatePayload
 from polylogue.types import Provider
 
 logger = get_logger(__name__)
@@ -23,18 +23,19 @@ def _get_file_mtime(path: Path) -> str | None:
 
 
 def _record_cursor_failure(
-    cursor_state: dict[str, Any] | None,
+    cursor_state: CursorStatePayload | None,
     path: str,
     error: str,
 ) -> None:
     """Record a file processing failure in cursor_state."""
     if cursor_state is not None:
-        cursor_state["failed_files"].append({"path": path, "error": error})
-        cursor_state["failed_count"] = cursor_state.get("failed_count", 0) + 1
+        failed_files = cursor_state.setdefault("failed_files", [])
+        failed_files.append(CursorFailurePayload(path=path, error=error))
+        cursor_state["failed_count"] = int(cursor_state.get("failed_count", 0) or 0) + 1
 
 
 def _initialize_cursor_state(
-    cursor_state: dict[str, Any] | None,
+    cursor_state: CursorStatePayload | None,
     paths: list[Path],
 ) -> None:
     """Populate cursor bookkeeping for a source iteration pass."""
@@ -127,7 +128,7 @@ class _ParseContext:
     fallback_id: str  # path.stem, used as fallback conversation ID
     file_mtime: str | None
     capture_raw: bool
-    sidecar_data: dict[str, Any]
+    sidecar_data: dict[str, object]
 
 
 __all__ = [

--- a/polylogue/sources/decoder_zip.py
+++ b/polylogue/sources/decoder_zip.py
@@ -5,11 +5,12 @@ from __future__ import annotations
 import zipfile
 from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, BinaryIO, cast
+from typing import BinaryIO, cast
 
 from polylogue.lib.artifact_taxonomy import classify_artifact_path
 from polylogue.logging import get_logger
 from polylogue.storage.blob_store import get_blob_store
+from polylogue.storage.state_views import CursorStatePayload
 from polylogue.types import Provider
 
 from .cursor import _record_cursor_failure
@@ -30,7 +31,7 @@ class ZipEntryValidator:
         self,
         provider_hint: str | Provider,
         *,
-        cursor_state: dict[str, Any] | None,
+        cursor_state: CursorStatePayload | None,
         zip_path: Path,
         conversation_only: bool = False,
     ) -> None:
@@ -100,7 +101,7 @@ def process_zip(
     should_group: bool,
     file_mtime: str | None,
     capture_raw: bool,
-    cursor_state: dict[str, Any] | None,
+    cursor_state: CursorStatePayload | None,
 ) -> Iterable[tuple[RawConversationData | None, ParsedConversation]]:
     """Process a ZIP file, yielding conversations from its entries."""
     del should_group

--- a/polylogue/sources/drive.py
+++ b/polylogue/sources/drive.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
 
 from polylogue.logging import get_logger
+from polylogue.storage.state_views import CursorStatePayload
 from polylogue.types import Provider
 
 from ..assets import asset_path
@@ -122,7 +122,7 @@ def iter_drive_conversations(
     ui: DriveUILike | None = None,
     client: DriveSourceAPI | None = None,
     download_assets: bool = True,
-    cursor_state: dict[str, Any] | None = None,
+    cursor_state: CursorStatePayload | None = None,
     drive_config: DriveConfigLike | None = None,
 ) -> Iterable[ParsedConversation]:
     if not source.folder:
@@ -172,7 +172,7 @@ def iter_drive_raw_data(
     source: Source,
     ui: DriveUILike | None = None,
     client: DriveSourceAPI | None = None,
-    cursor_state: dict[str, Any] | None = None,
+    cursor_state: CursorStatePayload | None = None,
     drive_config: DriveConfigLike | None = None,
     known_mtimes: dict[str, str] | None = None,
 ) -> Iterable[RawConversationData]:

--- a/polylogue/sources/source_acquisition.py
+++ b/polylogue/sources/source_acquisition.py
@@ -14,6 +14,7 @@ from polylogue.lib.json import dumps_bytes as json_dumps_bytes
 from polylogue.lib.metrics import read_current_rss_mb, read_peak_rss_self_mb
 from polylogue.logging import get_logger
 from polylogue.storage.blob_store import BlobStore, get_blob_store
+from polylogue.storage.state_views import CursorStatePayload
 from polylogue.types import Provider
 
 from . import cursor as _cursor
@@ -33,7 +34,7 @@ _HEARTBEAT_INTERVAL_S = 5.0
 AcquisitionObservation: TypeAlias = dict[str, object]
 ObservationCallback: TypeAlias = Callable[[AcquisitionObservation], None]
 StatusCallback: TypeAlias = Callable[[str], None]
-CursorState: TypeAlias = dict[str, object]
+CursorState: TypeAlias = CursorStatePayload
 DetectedEntryPayload: TypeAlias = tuple[Provider, object, float]
 
 

--- a/polylogue/sources/source_parsing.py
+++ b/polylogue/sources/source_parsing.py
@@ -10,6 +10,7 @@ from polylogue.config import Source
 from polylogue.lib.artifact_taxonomy import classify_artifact_path
 from polylogue.logging import get_logger
 from polylogue.storage.blob_store import get_blob_store
+from polylogue.storage.state_views import CursorStatePayload
 from polylogue.types import Provider
 
 from . import cursor as _cursor
@@ -29,7 +30,7 @@ _decoders.logger = logger
 def iter_source_conversations(
     source: Source,
     *,
-    cursor_state: dict[str, object] | None = None,
+    cursor_state: CursorStatePayload | None = None,
 ) -> Iterable[ParsedConversation]:
     """Iterate parsed conversations from one configured source."""
     for _raw, conversation in iter_source_conversations_with_raw(
@@ -43,7 +44,7 @@ def iter_source_conversations(
 def iter_source_conversations_with_raw(
     source: Source,
     *,
-    cursor_state: dict[str, object] | None = None,
+    cursor_state: CursorStatePayload | None = None,
     capture_raw: bool = True,
     known_mtimes: dict[str, str] | None = None,
 ) -> Iterable[tuple[RawConversationData | None, ParsedConversation]]:

--- a/polylogue/sources/source_walk.py
+++ b/polylogue/sources/source_walk.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from polylogue.config import Source
+from polylogue.storage.state_views import CursorStatePayload
 from polylogue.types import Provider
 
 from . import cursor as _cursor
@@ -58,7 +59,7 @@ class _SourceWalkSetup:
 def _setup_source_walk(
     source: Source,
     *,
-    cursor_state: dict[str, object] | None,
+    cursor_state: CursorStatePayload | None,
     include_mtime: bool,
     known_mtimes: dict[str, str] | None,
     discover_sidecars: bool,

--- a/polylogue/storage/state_views.py
+++ b/polylogue/storage/state_views.py
@@ -7,10 +7,11 @@ durable storage records in ``store.py``.
 
 from __future__ import annotations
 
+from collections.abc import ItemsView, KeysView, Mapping, ValuesView
 from dataclasses import dataclass
-from typing import Any
+from typing import TypedDict, cast
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from polylogue.storage.store import AttachmentRecord, ConversationRecord, MessageRecord
 from polylogue.types import (
@@ -20,6 +21,249 @@ from polylogue.types import (
     ValidationMode,
     ValidationStatus,
 )
+
+
+class CursorFailurePayload(TypedDict):
+    path: str
+    error: str
+
+
+class CursorStatePayload(TypedDict, total=False):
+    file_count: int
+    error_count: int
+    latest_mtime: float
+    latest_file_name: str
+    latest_path: str
+    latest_file_id: str
+    latest_error: str
+    latest_error_file: str
+    failed_count: int
+    failed_files: list[CursorFailurePayload]
+
+
+class PlanCountsPayload(TypedDict, total=False):
+    scan: int
+    store_raw: int
+    validate: int
+    parse: int
+    materialize: int
+    render: int
+    index: int
+
+
+class PlanDetailsPayload(TypedDict, total=False):
+    new_raw: int
+    existing_raw: int
+    duplicate_raw: int
+    backlog_validate: int
+    backlog_parse: int
+    preview_invalid: int
+    preview_skipped_no_schema: int
+
+
+class RunCountsPayload(TypedDict, total=False):
+    conversations: int
+    messages: int
+    attachments: int
+    skipped_conversations: int
+    skipped_messages: int
+    skipped_attachments: int
+    acquired: int
+    skipped: int
+    acquire_errors: int
+    validated: int
+    validation_invalid: int
+    validation_drift: int
+    validation_skipped_no_schema: int
+    validation_errors: int
+    materialized: int
+    rendered: int
+    render_failures: int
+    parse_failures: int
+    schemas_generated: int
+    schemas_failed: int
+    new_conversations: int
+    changed_conversations: int
+
+
+class DriftBucketPayload(TypedDict):
+    conversations: int
+    messages: int
+    attachments: int
+
+
+class RunDriftPayload(TypedDict):
+    new: DriftBucketPayload
+    removed: DriftBucketPayload
+    changed: DriftBucketPayload
+
+
+class RenderFailurePayload(TypedDict):
+    conversation_id: str
+    error: str
+
+
+class _SparseIntMap(BaseModel):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    def to_dict(self) -> dict[str, int]:
+        return cast(dict[str, int], self.model_dump(by_alias=True, exclude_none=True))
+
+    def int_value(self, field_name: str) -> int:
+        value = getattr(self, field_name)
+        return value if isinstance(value, int) else 0
+
+    def __getitem__(self, key: str) -> int:
+        payload = self.to_dict()
+        if key not in payload:
+            raise KeyError(key)
+        return payload[key]
+
+    def get(self, key: str, default: int | None = None) -> int | None:
+        return self.to_dict().get(key, default)
+
+    def items(self) -> ItemsView[str, int]:
+        return self.to_dict().items()
+
+    def keys(self) -> KeysView[str]:
+        return self.to_dict().keys()
+
+    def values(self) -> ValuesView[int]:
+        return self.to_dict().values()
+
+    def __contains__(self, key: object) -> bool:
+        return key in self.to_dict()
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, Mapping):
+            return self.to_dict() == dict(other)
+        return super().__eq__(other)
+
+
+class _DenseIntMap(BaseModel):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    def to_dict(self) -> dict[str, int]:
+        return cast(dict[str, int], self.model_dump(by_alias=True))
+
+    def __getitem__(self, key: str) -> int:
+        payload = self.to_dict()
+        if key not in payload:
+            raise KeyError(key)
+        return payload[key]
+
+    def get(self, key: str, default: int | None = None) -> int | None:
+        return self.to_dict().get(key, default)
+
+    def items(self) -> ItemsView[str, int]:
+        return self.to_dict().items()
+
+    def keys(self) -> KeysView[str]:
+        return self.to_dict().keys()
+
+    def values(self) -> ValuesView[int]:
+        return self.to_dict().values()
+
+    def __contains__(self, key: object) -> bool:
+        return key in self.to_dict()
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, Mapping):
+            return self.to_dict() == dict(other)
+        return super().__eq__(other)
+
+
+class PlanCounts(_SparseIntMap):
+    scan: int | None = None
+    store_raw: int | None = None
+    validate_count: int | None = Field(default=None, alias="validate")
+    parse: int | None = None
+    materialize: int | None = None
+    render: int | None = None
+    index: int | None = None
+
+
+class PlanDetails(_SparseIntMap):
+    new_raw: int | None = None
+    existing_raw: int | None = None
+    duplicate_raw: int | None = None
+    backlog_validate: int | None = None
+    backlog_parse: int | None = None
+    preview_invalid: int | None = None
+    preview_skipped_no_schema: int | None = None
+
+
+class RunCounts(_SparseIntMap):
+    conversations: int | None = None
+    messages: int | None = None
+    attachments: int | None = None
+    skipped_conversations: int | None = None
+    skipped_messages: int | None = None
+    skipped_attachments: int | None = None
+    acquired: int | None = None
+    skipped: int | None = None
+    acquire_errors: int | None = None
+    validated: int | None = None
+    validation_invalid: int | None = None
+    validation_drift: int | None = None
+    validation_skipped_no_schema: int | None = None
+    validation_errors: int | None = None
+    materialized: int | None = None
+    rendered: int | None = None
+    render_failures: int | None = None
+    parse_failures: int | None = None
+    schemas_generated: int | None = None
+    schemas_failed: int | None = None
+    new_conversations: int | None = None
+    changed_conversations: int | None = None
+
+
+class DriftBucket(_DenseIntMap):
+    conversations: int = 0
+    messages: int = 0
+    attachments: int = 0
+
+
+class RunDrift(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    new: DriftBucket = Field(default_factory=DriftBucket)
+    removed: DriftBucket = Field(default_factory=DriftBucket)
+    changed: DriftBucket = Field(default_factory=DriftBucket)
+
+    def to_dict(self) -> RunDriftPayload:
+        return {
+            "new": cast(DriftBucketPayload, self.new.to_dict()),
+            "removed": cast(DriftBucketPayload, self.removed.to_dict()),
+            "changed": cast(DriftBucketPayload, self.changed.to_dict()),
+        }
+
+    def __getitem__(self, key: str) -> DriftBucket:
+        if key not in {"new", "removed", "changed"}:
+            raise KeyError(key)
+        return cast(DriftBucket, getattr(self, key))
+
+    def get(self, key: str, default: DriftBucket | None = None) -> DriftBucket | None:
+        if key in {"new", "removed", "changed"}:
+            return cast(DriftBucket, getattr(self, key))
+        return default
+
+    def items(self) -> ItemsView[str, DriftBucket]:
+        return {"new": self.new, "removed": self.removed, "changed": self.changed}.items()
+
+    def keys(self) -> KeysView[str]:
+        return {"new": self.new, "removed": self.removed, "changed": self.changed}.keys()
+
+    def values(self) -> ValuesView[DriftBucket]:
+        return {"new": self.new, "removed": self.removed, "changed": self.changed}.values()
+
+    def __contains__(self, key: object) -> bool:
+        return key in {"new", "removed", "changed"}
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, Mapping):
+            return self.to_dict() == dict(other)
+        return super().__eq__(other)
 
 
 class ArtifactCohortSummary(BaseModel):
@@ -61,10 +305,10 @@ class PlanResult(BaseModel):
     timestamp: int
     stage: PlanStage = PlanStage.ALL
     stage_sequence: list[PlanStage] = Field(default_factory=list)
-    counts: dict[str, int]
-    details: dict[str, int] = Field(default_factory=dict)
+    counts: PlanCounts = Field(default_factory=lambda: PlanCounts())
+    details: PlanDetails = Field(default_factory=lambda: PlanDetails())
     sources: list[str]
-    cursors: dict[str, dict[str, Any]]
+    cursors: dict[str, CursorStatePayload] = Field(default_factory=dict)
 
     @field_validator("stage", mode="before")
     @classmethod
@@ -78,6 +322,31 @@ class PlanResult(BaseModel):
             return []
         values = v if isinstance(v, list) else list(v) if isinstance(v, tuple) else [v]
         return [PlanStage.from_string(str(item)) for item in values]
+
+    @field_validator("counts", mode="before")
+    @classmethod
+    def coerce_plan_counts(cls, v: object) -> PlanCounts:
+        if isinstance(v, PlanCounts):
+            return v
+        return PlanCounts.model_validate(v or {})
+
+    @field_validator("details", mode="before")
+    @classmethod
+    def coerce_plan_details(cls, v: object) -> PlanDetails:
+        if isinstance(v, PlanDetails):
+            return v
+        return PlanDetails.model_validate(v or {})
+
+    @field_validator("cursors", mode="before")
+    @classmethod
+    def coerce_cursors(cls, v: object) -> dict[str, CursorStatePayload]:
+        if not isinstance(v, dict):
+            return {}
+        payload: dict[str, CursorStatePayload] = {}
+        for name, cursor in v.items():
+            if isinstance(name, str) and isinstance(cursor, dict):
+                payload[name] = cast(CursorStatePayload, cursor)
+        return payload
 
 
 class RawConversationState(BaseModel):
@@ -152,13 +421,42 @@ class RawConversationStateUpdate:
 
 class RunResult(BaseModel):
     run_id: str
-    counts: dict[str, int]
-    drift: dict[str, dict[str, int]]
+    counts: RunCounts = Field(default_factory=lambda: RunCounts())
+    drift: RunDrift = Field(default_factory=lambda: RunDrift())
     indexed: bool
     index_error: str | None
     duration_ms: int
-    render_failures: list[dict[str, str]] = Field(default_factory=list)
+    render_failures: list[RenderFailurePayload] = Field(default_factory=list)
     run_path: str | None = None
+
+    @field_validator("counts", mode="before")
+    @classmethod
+    def coerce_run_counts(cls, v: object) -> RunCounts:
+        if isinstance(v, RunCounts):
+            return v
+        return RunCounts.model_validate(v or {})
+
+    @field_validator("drift", mode="before")
+    @classmethod
+    def coerce_run_drift(cls, v: object) -> RunDrift:
+        if isinstance(v, RunDrift):
+            return v
+        return RunDrift.model_validate(v or {})
+
+    @field_validator("render_failures", mode="before")
+    @classmethod
+    def coerce_render_failures(cls, v: object) -> list[RenderFailurePayload]:
+        if not isinstance(v, list):
+            return []
+        failures: list[RenderFailurePayload] = []
+        for item in v:
+            if not isinstance(item, dict):
+                continue
+            conversation_id = item.get("conversation_id")
+            error = item.get("error")
+            if isinstance(conversation_id, str) and isinstance(error, str):
+                failures.append({"conversation_id": conversation_id, "error": error})
+        return failures
 
 
 class ExistingConversation(BaseModel):
@@ -178,9 +476,22 @@ class ConversationRenderProjection:
 __all__ = [
     "ArtifactCohortSummary",
     "ConversationRenderProjection",
+    "CursorFailurePayload",
+    "CursorStatePayload",
+    "DriftBucket",
+    "DriftBucketPayload",
     "ExistingConversation",
+    "PlanCounts",
+    "PlanCountsPayload",
+    "PlanDetails",
+    "PlanDetailsPayload",
     "PlanResult",
     "RawConversationState",
     "RawConversationStateUpdate",
+    "RenderFailurePayload",
+    "RunCounts",
+    "RunCountsPayload",
+    "RunDrift",
+    "RunDriftPayload",
     "RunResult",
 ]

--- a/tests/integration/test_security.py
+++ b/tests/integration/test_security.py
@@ -5,13 +5,25 @@ from __future__ import annotations
 import tempfile
 import zipfile
 from pathlib import Path
-from typing import cast
 
 import pytest
 
 from polylogue.paths import Source
 from polylogue.sources.decoders import MAX_UNCOMPRESSED_SIZE
 from polylogue.sources.source_parsing import iter_source_conversations
+from polylogue.storage.state_views import CursorFailurePayload, CursorStatePayload
+
+
+def _empty_cursor_state() -> CursorStatePayload:
+    return {}
+
+
+def _failed_files(cursor_state: CursorStatePayload) -> list[CursorFailurePayload]:
+    return cursor_state.get("failed_files", [])
+
+
+def _failed_count(cursor_state: CursorStatePayload) -> int:
+    return cursor_state.get("failed_count", 0)
 
 
 def test_symlink_traversal_blocked_in_directory() -> None:
@@ -71,10 +83,10 @@ def test_zip_bomb_compression_ratio_blocked(tmp_path: Path) -> None:
         zf.writestr("valid.json", json_content)
 
     source = Source(name="test", path=tmp_path)
-    cursor_state: dict[str, object] = {}
+    cursor_state: CursorStatePayload = _empty_cursor_state()
     list(iter_source_conversations(source, cursor_state=cursor_state))
-    failed = cast(list[dict[str, object]], cursor_state.get("failed_files", []))
-    failed_count = cast(int, cursor_state.get("failed_count", 0))
+    failed = _failed_files(cursor_state)
+    failed_count = _failed_count(cursor_state)
     assert failed_count >= 1 or not failed
     if failed:
         has_expected_error = any(
@@ -96,6 +108,6 @@ def test_zip_path_traversal_filenames_handled(tmp_path: Path) -> None:
         zf.writestr("normal.json", json_content)
 
     source = Source(name="test", path=tmp_path)
-    cursor_state: dict[str, object] = {}
+    cursor_state: CursorStatePayload = _empty_cursor_state()
     payloads = list(iter_source_conversations(source, cursor_state=cursor_state))
     assert len(payloads) >= 1

--- a/tests/integration/test_workflows.py
+++ b/tests/integration/test_workflows.py
@@ -675,6 +675,6 @@ async def test_pipeline_runner_stage_matrix(workspace_env: Any, chatgpt_sample_s
     assert result is not None
     assert result.counts["conversations"] > 0
     if stage == "parse":
-        assert result.counts.get("rendered", 0) == 0
+        assert result.counts.int_value("rendered") == 0
     else:
-        assert result.counts.get("rendered", 0) >= 1
+        assert result.counts.int_value("rendered") >= 1

--- a/tests/unit/cli/test_run.py
+++ b/tests/unit/cli/test_run.py
@@ -33,10 +33,10 @@ def runner() -> CliRunner:
 def mock_plan_result() -> PlanResult:
     return PlanResult(
         timestamp=1234567890,
-        counts={"conversations": 5, "messages": 50, "attachments": 2},
+        counts={"scan": 5, "store_raw": 5, "validate": 5, "parse": 5, "materialize": 5},
         sources=["test-inbox"],
         cursors={"test-inbox": {"path": "/tmp/inbox"}},
-        details={"new": 2, "existing": 3},
+        details={"new_raw": 2, "existing_raw": 3},
     )
 
 
@@ -45,7 +45,7 @@ def mock_run_result() -> RunResult:
     return RunResult(
         run_id="run-123",
         counts={"conversations": 3, "messages": 30, "attachments": 1},
-        drift={"conversations": {"new": 2, "updated": 1, "unchanged": 5}},
+        drift={"new": {"conversations": 2}, "changed": {"conversations": 1}, "removed": {}},
         indexed=True,
         index_error=None,
         duration_ms=1500,

--- a/tests/unit/cli/test_run.py
+++ b/tests/unit/cli/test_run.py
@@ -18,7 +18,16 @@ from polylogue.cli.types import AppEnv
 from polylogue.sources import DriveError
 from polylogue.storage.backends.async_sqlite import SQLiteBackend
 from polylogue.storage.repository import ConversationRepository
-from polylogue.storage.state_views import PlanResult, RunResult
+from polylogue.storage.state_views import (
+    DriftBucket,
+    PlanCounts,
+    PlanDetails,
+    PlanResult,
+    RenderFailurePayload,
+    RunCounts,
+    RunDrift,
+    RunResult,
+)
 from tests.infra.storage_records import DbFactory
 
 PatchMap = dict[str, MagicMock]
@@ -33,10 +42,10 @@ def runner() -> CliRunner:
 def mock_plan_result() -> PlanResult:
     return PlanResult(
         timestamp=1234567890,
-        counts={"scan": 5, "store_raw": 5, "validate": 5, "parse": 5, "materialize": 5},
+        counts=PlanCounts(scan=5, store_raw=5, validate=5, parse=5, materialize=5),
         sources=["test-inbox"],
-        cursors={"test-inbox": {"path": "/tmp/inbox"}},
-        details={"new_raw": 2, "existing_raw": 3},
+        cursors={"test-inbox": {"latest_path": "/tmp/inbox"}},
+        details=PlanDetails(new_raw=2, existing_raw=3),
     )
 
 
@@ -44,8 +53,11 @@ def mock_plan_result() -> PlanResult:
 def mock_run_result() -> RunResult:
     return RunResult(
         run_id="run-123",
-        counts={"conversations": 3, "messages": 30, "attachments": 1},
-        drift={"new": {"conversations": 2}, "changed": {"conversations": 1}, "removed": {}},
+        counts=RunCounts(conversations=3, messages=30, attachments=1),
+        drift=RunDrift(
+            new=DriftBucket(conversations=2),
+            changed=DriftBucket(conversations=1),
+        ),
         indexed=True,
         index_error=None,
         duration_ms=1500,
@@ -315,7 +327,14 @@ class TestRunCommand:
             runner,
             ["run", "--preview", "--source", "test-inbox"],
             plan_result=mock_plan_result,
-            run_result=RunResult(run_id="unused", counts={}, drift={}, indexed=False, index_error=None, duration_ms=0),
+            run_result=RunResult(
+                run_id="unused",
+                counts=RunCounts(),
+                drift=RunDrift(),
+                indexed=False,
+                index_error=None,
+                duration_ms=0,
+            ),
             selected_sources=["test-inbox"],
             prompted_stage="all",
         )
@@ -336,8 +355,8 @@ class TestRunCommand:
                 "index",
                 RunResult(
                     run_id="run-idx",
-                    counts={"conversations": 0},
-                    drift={},
+                    counts=RunCounts(conversations=0),
+                    drift=RunDrift(),
                     indexed=True,
                     index_error=None,
                     duration_ms=800,
@@ -351,8 +370,8 @@ class TestRunCommand:
                 "render",
                 RunResult(
                     run_id="run-render",
-                    counts={"conversations": 3},
-                    drift={},
+                    counts=RunCounts(conversations=3),
+                    drift=RunDrift(),
                     indexed=True,
                     index_error=None,
                     duration_ms=1200,
@@ -366,12 +385,15 @@ class TestRunCommand:
                 "all",
                 RunResult(
                     run_id="run-all",
-                    counts={"conversations": 2},
-                    drift={},
+                    counts=RunCounts(conversations=2),
+                    drift=RunDrift(),
                     indexed=False,
                     index_error="Vector database unavailable",
                     duration_ms=900,
-                    render_failures=[{"conversation_id": "conv-1", "error": "boom"}],
+                    render_failures=cast(
+                        list[RenderFailurePayload],
+                        [{"conversation_id": "conv-1", "error": "boom"}],
+                    ),
                 ),
                 ["Sync", "Render failures (1)", "Index error: Vector database unavailable"],
                 True,

--- a/tests/unit/cli/test_run_int.py
+++ b/tests/unit/cli/test_run_int.py
@@ -13,10 +13,40 @@ from polylogue.config import Source, get_config
 from polylogue.pipeline.observers import ExecObserver, NotificationObserver, WebhookObserver
 from polylogue.pipeline.runner import latest_run, plan_sources, run_sources
 from polylogue.storage.backends.connection import open_connection
-from polylogue.storage.state_views import RunResult
+from polylogue.storage.state_views import (
+    DriftBucket,
+    RenderFailurePayload,
+    RunCounts,
+    RunDrift,
+    RunResult,
+)
 from tests.infra.source_builders import ChatGPTExportBuilder, GenericConversationBuilder, InboxBuilder
 
 run_command = cast(Any, import_module("polylogue.cli.commands.run"))
+
+
+def _observer_result(
+    *,
+    conversations: int,
+    new_conversations: int = 0,
+    changed_conversations: int = 0,
+) -> RunResult:
+    return RunResult(
+        run_id="observer-run",
+        counts=RunCounts(
+            conversations=conversations,
+            new_conversations=new_conversations,
+            changed_conversations=changed_conversations,
+        ),
+        drift=RunDrift(
+            new=DriftBucket(conversations=new_conversations),
+            changed=DriftBucket(conversations=changed_conversations),
+        ),
+        indexed=True,
+        index_error=None,
+        duration_ms=0,
+        render_failures=[],
+    )
 
 
 @pytest.fixture
@@ -206,11 +236,13 @@ async def test_latest_run_parsing(workspace_env: Any, tmp_path: Any, setup_type:
 
 def test_display_result_reports_render_failures(mock_env: Any, capsys: Any) -> None:
     mock_config = MagicMock(render_root=Path("/tmp/render"))
-    failures = [{"conversation_id": f"conv-{index}", "error": f"error {index}"} for index in range(15)]
+    failures: list[RenderFailurePayload] = [
+        {"conversation_id": f"conv-{index}", "error": f"error {index}"} for index in range(15)
+    ]
     result = RunResult(
         run_id="run-123",
-        counts={"conversations": 0},
-        drift={},
+        counts=RunCounts(conversations=0),
+        drift=RunDrift(),
         indexed=True,
         index_error=None,
         duration_ms=0,
@@ -230,8 +262,8 @@ def test_display_result_reports_index_error_hint(mock_env: Any, capsys: Any) -> 
     mock_config = MagicMock(render_root=Path("/tmp/render"))
     result = RunResult(
         run_id="run-123",
-        counts={"conversations": 0},
-        drift={},
+        counts=RunCounts(conversations=0),
+        drift=RunDrift(),
         indexed=False,
         index_error="Database locked",
         duration_ms=0,
@@ -248,36 +280,23 @@ def test_display_result_reports_index_error_hint(mock_env: Any, capsys: Any) -> 
 class TestWatchModeCallbacks:
     def test_notify_callback_executes_with_count(self) -> None:
         with patch("subprocess.run") as mock_run:
-            NotificationObserver().on_completed(
-                MagicMock(
-                    counts={"conversations": 5, "new_conversations": 5, "changed_conversations": 0},
-                    drift={"new": {"conversations": 5}, "changed": {"conversations": 0}},
-                )
-            )
+            NotificationObserver().on_completed(_observer_result(conversations=5, new_conversations=5))
         assert "notify-send" in mock_run.call_args[0][0]
         assert "5" in str(mock_run.call_args[0][0])
 
     def test_notify_zero_is_noop(self) -> None:
         with patch("subprocess.run") as mock_run:
-            NotificationObserver().on_completed(MagicMock(counts={"conversations": 0}, drift={}))
+            NotificationObserver().on_completed(_observer_result(conversations=0))
         mock_run.assert_not_called()
 
     def test_notify_missing_binary_is_ignored(self) -> None:
         with patch("subprocess.run", side_effect=FileNotFoundError()):
-            NotificationObserver().on_completed(
-                MagicMock(
-                    counts={"conversations": 1, "new_conversations": 1, "changed_conversations": 0},
-                    drift={"new": {"conversations": 1}, "changed": {"conversations": 0}},
-                )
-            )
+            NotificationObserver().on_completed(_observer_result(conversations=1, new_conversations=1))
 
     def test_exec_callback_executes_with_count(self) -> None:
         with patch("subprocess.run") as mock_run:
             ExecObserver("echo $POLYLOGUE_ACTIVITY_COUNT").on_completed(
-                MagicMock(
-                    counts={"conversations": 3, "new_conversations": 3, "changed_conversations": 0},
-                    drift={"new": {"conversations": 3}, "changed": {"conversations": 0}},
-                )
+                _observer_result(conversations=3, new_conversations=3)
             )
         assert mock_run.call_args.kwargs["env"]["POLYLOGUE_ACTIVITY_COUNT"] == "3"
         assert mock_run.call_args.kwargs["env"]["POLYLOGUE_NEW_CONVERSATION_COUNT"] == "3"
@@ -304,10 +323,7 @@ class TestWatchModeCallbacks:
             patch("urllib.request.urlopen") as mock_urlopen,
         ):
             WebhookObserver("http://example.com/webhook").on_completed(
-                MagicMock(
-                    counts={"conversations": 2, "new_conversations": 2, "changed_conversations": 0},
-                    drift={"new": {"conversations": 2}, "changed": {"conversations": 0}},
-                )
+                _observer_result(conversations=2, new_conversations=2)
             )
         call_args = mock_urlopen.call_args[0][0]
         assert call_args.get_full_url() == "http://example.com/webhook"
@@ -322,10 +338,7 @@ class TestWatchModeCallbacks:
             patch("urllib.request.Request") as mock_request,
         ):
             WebhookObserver("http://example.com/webhook").on_completed(
-                MagicMock(
-                    counts={"conversations": 7, "new_conversations": 7, "changed_conversations": 0},
-                    drift={"new": {"conversations": 7}, "changed": {"conversations": 0}},
-                )
+                _observer_result(conversations=7, new_conversations=7)
             )
         payload = json.loads(mock_request.call_args.kwargs["data"].decode())
         assert payload == {
@@ -342,8 +355,5 @@ class TestWatchModeCallbacks:
             patch("urllib.request.urlopen", side_effect=ConnectionError("Connection failed")),
         ):
             WebhookObserver("http://example.com/webhook").on_completed(
-                MagicMock(
-                    counts={"conversations": 1, "new_conversations": 1, "changed_conversations": 0},
-                    drift={"new": {"conversations": 1}, "changed": {"conversations": 0}},
-                )
+                _observer_result(conversations=1, new_conversations=1)
             )

--- a/tests/unit/cli/test_run_laws.py
+++ b/tests/unit/cli/test_run_laws.py
@@ -30,7 +30,14 @@ from polylogue.cli.run_observers import (
 from polylogue.cli.run_workflow import display_result as _display_result
 from polylogue.cli.run_workflow import run_sync_once as _run_sync_once
 from polylogue.config import Config, get_config
-from polylogue.storage.state_views import RunResult
+from polylogue.storage.state_views import (
+    PlanCounts,
+    PlanDetails,
+    PlanResult,
+    RunCounts,
+    RunDrift,
+    RunResult,
+)
 
 
 def _make_env(*, plain: bool) -> MagicMock:
@@ -58,8 +65,8 @@ def _make_env(*, plain: bool) -> MagicMock:
 def _run_result(*, conversations: int = 1, index_error: str | None = None) -> RunResult:
     return RunResult(
         run_id="run-123",
-        counts={"conversations": conversations},
-        drift={},
+        counts=RunCounts(conversations=conversations),
+        drift=RunDrift(),
         indexed=index_error is None,
         index_error=index_error,
         duration_ms=150,
@@ -144,7 +151,13 @@ def test_run_sync_once_forwards_plan_snapshot_contract() -> None:
             None,
             None,
             "html",
-            plan_snapshot=MagicMock(timestamp=123, counts={"scan": 1}, sources=[], cursors={}),
+            plan_snapshot=PlanResult(
+                timestamp=123,
+                counts=PlanCounts(scan=1),
+                details=PlanDetails(),
+                sources=[],
+                cursors={},
+            ),
         )
 
     assert observed == result

--- a/tests/unit/pipeline/test_run_sources.py
+++ b/tests/unit/pipeline/test_run_sources.py
@@ -26,7 +26,7 @@ from polylogue.storage.backends import create_backend
 from polylogue.storage.backends.async_sqlite import SQLiteBackend
 from polylogue.storage.backends.connection import open_connection
 from polylogue.storage.session_product_runtime import SessionProductCounts
-from polylogue.storage.state_views import PlanResult, RunResult
+from polylogue.storage.state_views import PlanCounts, PlanResult, RunResult
 from tests.infra.storage_records import make_conversation, make_message, store_records
 
 WorkspaceEnv = Mapping[str, Path]
@@ -483,7 +483,7 @@ class TestRunSourcesIntegration:
         )
         plan = PlanResult(
             timestamp=123,
-            counts={"conversations": 10, "messages": 50, "attachments": 5},
+            counts={"scan": 10, "store_raw": 10, "validate": 10, "parse": 10, "materialize": 10},
             sources=["test"],
             cursors={},
         )
@@ -493,7 +493,7 @@ class TestRunSourcesIntegration:
 
         assert latest is not None
         assert latest.plan_snapshot is not None
-        assert latest.plan_snapshot["counts"] == plan.counts
+        assert PlanCounts.model_validate(latest.plan_snapshot["counts"]) == plan.counts
         assert result.drift["new"]["conversations"] == 0
         assert result.drift["removed"]["conversations"] == 0
 
@@ -1020,7 +1020,7 @@ class TestPlanSources:
         assert isinstance(result, PlanResult)
         assert result.stage == "all"
         assert result.counts == {}
-        assert result.details == {}
+        assert all(value == 0 for value in result.details.to_dict().values())
         assert result.sources == []
         assert result.cursors == {}
 

--- a/tests/unit/pipeline/test_run_sources.py
+++ b/tests/unit/pipeline/test_run_sources.py
@@ -26,7 +26,8 @@ from polylogue.storage.backends import create_backend
 from polylogue.storage.backends.async_sqlite import SQLiteBackend
 from polylogue.storage.backends.connection import open_connection
 from polylogue.storage.session_product_runtime import SessionProductCounts
-from polylogue.storage.state_views import PlanCounts, PlanResult, RunResult
+from polylogue.storage.state_views import PlanCounts, PlanResult, RunCounts, RunDrift, RunResult
+from polylogue.types import PlanStage
 from tests.infra.storage_records import make_conversation, make_message, store_records
 
 WorkspaceEnv = Mapping[str, Path]
@@ -103,8 +104,8 @@ def test_run_sources_accepts_explicit_leaf_stage_sequence(workspace_env: Workspa
     )
 
     assert result.counts["conversations"] >= 1
-    assert result.counts.get("materialized", 0) == 0
-    assert result.counts.get("rendered", 0) == 0
+    assert result.counts.int_value("materialized") == 0
+    assert result.counts.int_value("rendered") == 0
     assert result.indexed is False
 
 
@@ -132,8 +133,14 @@ def test_explicit_leaf_stage_sequence_uses_order_sensitive_leaf_semantics(
     )
     persisted_result = RunResult(
         run_id="test-run",
-        counts={"conversations": 1, "rendered": 1},
-        drift={"new": {"conversations": 1}, "changed": {"conversations": 0}, "removed": {"conversations": 0}},
+        counts=RunCounts(conversations=1, rendered=1),
+        drift=RunDrift.model_validate(
+            {
+                "new": {"conversations": 1},
+                "changed": {"conversations": 0},
+                "removed": {"conversations": 0},
+            }
+        ),
         indexed=True,
         index_error=None,
         duration_ms=1,
@@ -218,8 +225,14 @@ def test_ingest_stage_log_omits_full_batch_telemetry(workspace_env: WorkspaceEnv
     )
     persisted_result = RunResult(
         run_id="test-run",
-        counts={"conversations": 1},
-        drift={"new": {"conversations": 1}, "changed": {"conversations": 0}, "removed": {"conversations": 0}},
+        counts=RunCounts(conversations=1),
+        drift=RunDrift.model_validate(
+            {
+                "new": {"conversations": 1},
+                "changed": {"conversations": 0},
+                "removed": {"conversations": 0},
+            }
+        ),
         indexed=False,
         index_error=None,
         duration_ms=1,
@@ -280,8 +293,14 @@ def test_materialize_stage_log_omits_full_chunk_telemetry(
     )
     persisted_result = RunResult(
         run_id="test-run",
-        counts={"conversations": 1, "materialized": 12},
-        drift={"new": {"conversations": 1}, "changed": {"conversations": 0}, "removed": {"conversations": 0}},
+        counts=RunCounts(conversations=1, materialized=12),
+        drift=RunDrift.model_validate(
+            {
+                "new": {"conversations": 1},
+                "changed": {"conversations": 0},
+                "removed": {"conversations": 0},
+            }
+        ),
         indexed=False,
         index_error=None,
         duration_ms=1,
@@ -441,18 +460,18 @@ class TestRunSourcesIntegration:
 
         if stage == "parse":
             assert result.counts["conversations"] >= 1
-            assert result.counts.get("materialized", 0) == 0
-            assert result.counts.get("rendered", 0) == 0
+            assert result.counts.int_value("materialized") == 0
+            assert result.counts.int_value("rendered") == 0
             assert result.indexed is False
         elif stage == "materialize":
             assert result.counts["conversations"] == 0
-            assert result.counts.get("materialized", 0) >= 1
-            assert result.counts.get("rendered", 0) == 0
+            assert result.counts.int_value("materialized") >= 1
+            assert result.counts.int_value("rendered") == 0
             assert result.indexed is False
         elif stage == "render":
             assert result.counts["conversations"] == 0
             assert result.counts["messages"] == 0
-            assert result.counts.get("rendered", 0) == 0
+            assert result.counts.int_value("rendered") == 0
             assert result.indexed is False
         elif stage == "index":
             assert result.counts["conversations"] == 0
@@ -460,16 +479,16 @@ class TestRunSourcesIntegration:
             assert result.index_error is None
         elif stage == "reprocess":
             assert result.counts["conversations"] >= 1
-            assert result.counts.get("materialized", 0) >= 1
-            assert result.counts.get("rendered", 0) >= 1
+            assert result.counts.int_value("materialized") >= 1
+            assert result.counts.int_value("rendered") >= 1
             if result.indexed:
                 assert result.index_error is None
             else:
                 assert result.index_error is not None
         else:
             assert result.counts["conversations"] >= 1
-            assert result.counts.get("materialized", 0) >= 1
-            assert result.counts.get("rendered", 0) >= 1
+            assert result.counts.int_value("materialized") >= 1
+            assert result.counts.int_value("rendered") >= 1
             if result.indexed:
                 assert result.index_error is None
             else:
@@ -483,7 +502,9 @@ class TestRunSourcesIntegration:
         )
         plan = PlanResult(
             timestamp=123,
-            counts={"scan": 10, "store_raw": 10, "validate": 10, "parse": 10, "materialize": 10},
+            stage=PlanStage.PARSE,
+            stage_sequence=[PlanStage.PARSE],
+            counts=PlanCounts(scan=10, store_raw=10, validate=10, parse=10, materialize=10),
             sources=["test"],
             cursors={},
         )
@@ -1019,7 +1040,7 @@ class TestPlanSources:
 
         assert isinstance(result, PlanResult)
         assert result.stage == "all"
-        assert result.counts == {}
+        assert result.counts == PlanCounts()
         assert all(value == 0 for value in result.details.to_dict().values())
         assert result.sources == []
         assert result.cursors == {}
@@ -1057,7 +1078,7 @@ class TestPlanSources:
             result = plan_sources(config, backend=backend)
         finally:
             await backend.close()
-        assert result.counts == {}
+        assert result.counts == PlanCounts()
 
     async def test_plan_accepts_explicit_leaf_stage_sequence(self, tmp_path: Path) -> None:
         from polylogue.storage.blob_store import get_blob_store
@@ -1228,7 +1249,7 @@ class TestLatestRun:
         result = asyncio.run(latest_run())
         assert result is not None
         assert result.plan_snapshot == plan
-        assert result.counts == counts
-        assert result.drift == drift
+        assert result.counts == RunCounts.model_validate(counts)
+        assert RunDrift.model_validate(result.drift) == RunDrift.model_validate(drift)
         assert result.indexed is True
         assert result.duration_ms == 500

--- a/tests/unit/sources/test_acquisition_encoding.py
+++ b/tests/unit/sources/test_acquisition_encoding.py
@@ -9,10 +9,10 @@ iter_source_raw_data (acquisition path).
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
 
 from polylogue.config import Source
 from polylogue.sources.parsers.base import ParsedConversation, RawConversationData
+from polylogue.storage.state_views import CursorFailurePayload, CursorStatePayload
 from tests.infra.encoding_fixtures import EncodingFixtureBuilder
 
 
@@ -33,7 +33,7 @@ def _collect_conversations_with_raw(
     source_path: Path,
     provider: str = "codex",
     *,
-    cursor_state: dict[str, Any] | None = None,
+    cursor_state: CursorStatePayload | None = None,
 ) -> list[tuple[RawConversationData | None, ParsedConversation]]:
     """Run iter_source_conversations_with_raw and collect results."""
     from polylogue.sources.source_parsing import iter_source_conversations_with_raw
@@ -46,13 +46,21 @@ def _collect_raw_data(
     source_path: Path,
     provider: str = "codex",
     *,
-    cursor_state: dict[str, Any] | None = None,
+    cursor_state: CursorStatePayload | None = None,
 ) -> list[RawConversationData]:
     """Run iter_source_raw_data and collect results."""
     from polylogue.sources.source_acquisition import iter_source_raw_data
 
     source = _make_source(source_path, name=provider)
     return list(iter_source_raw_data(source, cursor_state=cursor_state))
+
+
+def _empty_cursor_state() -> CursorStatePayload:
+    return {}
+
+
+def _failed_files(cursor_state: CursorStatePayload) -> list[CursorFailurePayload]:
+    return cursor_state.get("failed_files", [])
 
 
 class TestZipBomHandling:
@@ -110,7 +118,7 @@ class TestZipPartialCorruption:
     def test_valid_entries_survive_corrupt_siblings(self, tmp_path: Path) -> None:
         """Valid JSON entries are parsed even when other entries are corrupt."""
         EncodingFixtureBuilder.partial_corruption_zip(tmp_path)
-        cursor_state: dict[str, Any] = {}
+        cursor_state: CursorStatePayload = _empty_cursor_state()
         results = _collect_conversations_with_raw(tmp_path, provider="chatgpt", cursor_state=cursor_state)
         # At least the valid.json entry should produce a conversation
         # (it's added to the ZIP first, so it's yielded before corrupt.json fails)
@@ -121,11 +129,11 @@ class TestZipPartialCorruption:
     def test_cursor_state_records_corrupt_entries(self, tmp_path: Path) -> None:
         """cursor_state tracks failures for corrupt ZIP entries."""
         EncodingFixtureBuilder.partial_corruption_zip(tmp_path)
-        cursor_state: dict[str, Any] = {}
+        cursor_state: CursorStatePayload = _empty_cursor_state()
         _results = _collect_conversations_with_raw(tmp_path, provider="chatgpt", cursor_state=cursor_state)
         # The corrupt entry should cause a recorded failure
         # _initialize_cursor_state creates failed_files as a list
-        failed = cursor_state.get("failed_files", [])
+        failed = _failed_files(cursor_state)
         assert len(failed) >= 1, f"Expected at least 1 failure recorded, got cursor_state={cursor_state}"
 
 

--- a/tests/unit/sources/test_decoders.py
+++ b/tests/unit/sources/test_decoders.py
@@ -10,7 +10,6 @@ import io
 import json
 import zipfile
 from pathlib import Path
-from typing import Any, cast
 
 from hypothesis import given, settings
 from hypothesis import strategies as st
@@ -21,10 +20,15 @@ from polylogue.sources.decoders import (
     _iter_json_stream,
     _ZipEntryValidator,
 )
+from polylogue.storage.state_views import CursorFailurePayload, CursorStatePayload
 
 # =============================================================================
 # _decode_json_bytes
 # =============================================================================
+
+
+def _seeded_cursor_state() -> CursorStatePayload:
+    return {"failed_files": [], "failed_count": 0}
 
 
 class TestDecodeJsonBytesBasic:
@@ -209,7 +213,7 @@ class TestZipEntryValidator:
         """Entries with compression ratio > MAX_COMPRESSION_RATIO are rejected."""
         validator = _ZipEntryValidator(
             "chatgpt",
-            cursor_state={"failed_files": [], "failed_count": 0},
+            cursor_state=_seeded_cursor_state(),
             zip_path=Path("test.zip"),
         )
         # Ratio = 200000 / 1 = 200000, well above MAX_COMPRESSION_RATIO
@@ -221,7 +225,7 @@ class TestZipEntryValidator:
         """Entries with uncompressed size > MAX_UNCOMPRESSED_SIZE are rejected."""
         validator = _ZipEntryValidator(
             "chatgpt",
-            cursor_state={"failed_files": [], "failed_count": 0},
+            cursor_state=_seeded_cursor_state(),
             zip_path=Path("test.zip"),
         )
         huge_entry = self._make_zip_info(
@@ -293,7 +297,7 @@ class TestZipEntryValidator:
 
     def test_cursor_state_records_failures(self) -> None:
         """Rejected entries record failures in cursor_state."""
-        cursor_state: dict[str, Any] = {"failed_files": [], "failed_count": 0}
+        cursor_state = _seeded_cursor_state()
         validator = _ZipEntryValidator(
             "chatgpt",
             cursor_state=cursor_state,
@@ -301,5 +305,6 @@ class TestZipEntryValidator:
         )
         bomb_entry = self._make_zip_info("bomb.json", file_size=500000, compress_size=1)
         list(validator.filter_entries([bomb_entry]))
-        assert int(cursor_state["failed_count"]) >= 1
-        assert len(cast(list[object], cursor_state["failed_files"])) >= 1
+        failed_files: list[CursorFailurePayload] = cursor_state.get("failed_files", [])
+        assert cursor_state["failed_count"] >= 1
+        assert len(failed_files) >= 1

--- a/tests/unit/sources/test_drive_ops.py
+++ b/tests/unit/sources/test_drive_ops.py
@@ -11,6 +11,7 @@ from polylogue.config import Source
 from polylogue.sources import DriveFile, download_drive_files, iter_drive_conversations
 from polylogue.sources.drive import _apply_drive_attachments
 from polylogue.sources.parsers.base import ParsedAttachment, ParsedConversation
+from polylogue.storage.state_views import CursorStatePayload
 from polylogue.types import Provider
 
 
@@ -80,6 +81,10 @@ class _DriveConversationClient:
 
     def download_bytes(self, file_id: str) -> bytes:
         return f"bytes:{file_id}".encode()
+
+
+def _empty_cursor_state() -> CursorStatePayload:
+    return {}
 
 
 def test_download_drive_files_contract(tmp_path: Path) -> None:
@@ -213,7 +218,7 @@ def test_iter_drive_conversations_tracks_cursor_and_attachment_downloads(tmp_pat
             "att-1": DriveFile("att-1", "doc.txt", "text/plain", None, 7),
         },
     )
-    cursor_state: dict[str, object] = {}
+    cursor_state: CursorStatePayload = _empty_cursor_state()
 
     conversations = list(
         iter_drive_conversations(
@@ -244,7 +249,7 @@ def test_iter_drive_conversations_tracks_payload_failures_and_continues(tmp_path
         payloads={"good": good_payload},
         payload_failures={"bad": RuntimeError("download failed")},
     )
-    cursor_state: dict[str, object] = {}
+    cursor_state: CursorStatePayload = _empty_cursor_state()
 
     conversations = list(
         iter_drive_conversations(

--- a/tests/unit/sources/test_source_laws.py
+++ b/tests/unit/sources/test_source_laws.py
@@ -78,6 +78,7 @@ from polylogue.sources.source_parsing import (
 )
 from polylogue.sources.source_walk import _has_supported_extension
 from polylogue.storage.blob_store import BlobStore, Heartbeat
+from polylogue.storage.state_views import CursorFailurePayload, CursorStatePayload
 from polylogue.types import Provider
 from tests.infra.source_builders import GenericConversationBuilder, make_claude_chat_message
 from tests.infra.strategies import (
@@ -152,15 +153,9 @@ def _parsed_conversation(
     )
 
 
-def _failed_files(cursor_state: Mapping[str, object]) -> list[FailedFile]:
-    failed_files = cursor_state.get("failed_files", [])
-    if not isinstance(failed_files, list):
-        return []
-    return [
-        FailedFile(path=str(item["path"]), error=str(item["error"]))
-        for item in failed_files
-        if isinstance(item, dict) and "path" in item and "error" in item
-    ]
+def _failed_files(cursor_state: CursorStatePayload) -> list[FailedFile]:
+    failed_files: list[CursorFailurePayload] = cursor_state.get("failed_files", [])
+    return [FailedFile(path=str(item["path"]), error=str(item["error"])) for item in failed_files]
 
 
 def _numeric_observation_value(observation: Mapping[str, object], key: str) -> float:
@@ -177,6 +172,10 @@ _CANONICAL_PROVIDERS = (
     Provider.CODEX.value,
     Provider.GEMINI.value,
 )
+
+
+def _empty_cursor_state() -> CursorStatePayload:
+    return {}
 
 
 @given(
@@ -506,7 +505,7 @@ def test_source_iteration_preserves_claude_attachment_metadata_contract(tmp_path
 
 
 def test_iter_source_conversations_handles_empty_directories_contract(tmp_path: Path) -> None:
-    cursor_state: dict[str, object] = {}
+    cursor_state: CursorStatePayload = _empty_cursor_state()
 
     assert list(iter_source_conversations(Source(name="test", path=tmp_path), cursor_state=cursor_state)) == []
     assert cursor_state["file_count"] == 0
@@ -519,7 +518,7 @@ def test_source_iteration_continues_after_invalid_json_contract(tmp_path: Path, 
     (tmp_path / "invalid.json").write_text("{ broken json", encoding="utf-8")
     _write_generic_conversation(tmp_path / "valid2.json", "valid2", "bye")
 
-    cursor_state: dict[str, object] = {}
+    cursor_state: CursorStatePayload = _empty_cursor_state()
     if iterator == "parsed":
         results = list(iter_source_conversations(Source(name="test", path=tmp_path), cursor_state=cursor_state))
         conversation_ids = [conversation.provider_conversation_id for conversation in results]
@@ -544,7 +543,7 @@ def test_iter_source_conversations_tracks_file_disappearance_contract(
 ) -> None:
     first = _write_generic_conversation(tmp_path / "first.json", "first")
     second = _write_generic_conversation(tmp_path / "second.json", "second")
-    cursor_state: dict[str, object] = {}
+    cursor_state: CursorStatePayload = _empty_cursor_state()
     original_open = Path.open
 
     def flaky_open(
@@ -755,7 +754,7 @@ def test_iter_source_conversations_with_raw_tracks_unicode_decode_failures_contr
     bad_file = tmp_path / "bad_encoding.json"
     bad_file.write_bytes(b"\xff\xfe invalid utf-8 { bad json")
 
-    cursor_state: dict[str, object] = {}
+    cursor_state: CursorStatePayload = _empty_cursor_state()
     results = list(iter_source_conversations_with_raw(Source(name="test", path=tmp_path), cursor_state=cursor_state))
 
     assert results == []
@@ -779,7 +778,7 @@ def test_source_iteration_ignores_stat_failures_for_optional_mtime_contract(
 
     monkeypatch.setattr(Path, "stat", flaky_stat)
 
-    parsed_cursor: dict[str, object] = {}
+    parsed_cursor: CursorStatePayload = _empty_cursor_state()
     raw_items = list(iter_source_conversations_with_raw(Source(name="test", path=source_dir), capture_raw=True))
     parsed_items = list(iter_source_conversations(Source(name="test", path=source_dir), cursor_state=parsed_cursor))
 
@@ -978,7 +977,7 @@ def test_has_supported_extension_contract(filename: str, expected: bool) -> None
 
 
 def test_record_cursor_failure_updates_state_exactly() -> None:
-    cursor_state = {"failed_files": [], "failed_count": 0}
+    cursor_state: CursorStatePayload = {"failed_files": [], "failed_count": 0}
 
     _record_cursor_failure(cursor_state, "/tmp/data.json", "broken")
 
@@ -1000,7 +999,7 @@ def test_initialize_cursor_state_tracks_latest_path_and_mtime(tmp_path: Path) ->
     os.utime(older, (1000, 1000))
     os.utime(newer, (2000, 2000))
 
-    cursor_state: dict[str, object] = {}
+    cursor_state: CursorStatePayload = _empty_cursor_state()
     _initialize_cursor_state(cursor_state, [older, newer])
 
     assert cursor_state["file_count"] == 2
@@ -1201,7 +1200,7 @@ def _parse_context(
     source_path: str,
     fallback_id: str,
     capture_raw: bool = True,
-    sidecar_data: JSONDocument | None = None,
+    sidecar_data: dict[str, object] | None = None,
 ) -> _ParseContext:
     return _ParseContext(
         provider_hint=Provider.from_string(provider_hint),
@@ -1643,7 +1642,7 @@ def test_zip_entry_validator_policy_contract(
     expected_failed_count: int,
     expected_failed_fragment: str | None,
 ) -> None:
-    cursor_state = {"failed_files": [], "failed_count": 0}
+    cursor_state: CursorStatePayload = {"failed_files": [], "failed_count": 0}
     validator = _ZipEntryValidator(
         source_name,
         cursor_state=cursor_state,
@@ -1707,7 +1706,7 @@ def test_iter_drive_raw_data_contract() -> None:
         files,
         raw_bytes={"chatgpt-1": b'{"id":"chatgpt-1"}', "gemini-1": b'{"role":"model"}'},
     )
-    cursor_state: dict[str, object] = {}
+    cursor_state: CursorStatePayload = _empty_cursor_state()
 
     items = list(iter_drive_raw_data(source=source, client=client, cursor_state=cursor_state))
 
@@ -1734,7 +1733,7 @@ def test_iter_drive_raw_data_skips_known_mtimes_and_tracks_failures() -> None:
         raw_bytes={"old": b"{}", "new": b'{"id":"new"}'},
         failures={"bad": RuntimeError("download failed")},
     )
-    cursor_state: dict[str, object] = {}
+    cursor_state: CursorStatePayload = _empty_cursor_state()
 
     items = list(
         iter_drive_raw_data(
@@ -2047,7 +2046,7 @@ def test_iter_source_raw_data_skips_zero_byte_plain_files_and_tracks_failure(tmp
     empty = tmp_path / "empty.jsonl"
     empty.write_bytes(b"")
 
-    cursor_state: dict[str, object] = {}
+    cursor_state: CursorStatePayload = _empty_cursor_state()
     items = list(iter_source_raw_data(Source(name="codex", path=empty), cursor_state=cursor_state))
 
     assert items == []
@@ -2090,7 +2089,7 @@ def test_iter_source_raw_data_skips_zero_byte_zip_entries_and_tracks_failure(tmp
     with zipfile.ZipFile(archive_path, "w") as zf:
         zf.writestr("nested/empty.jsonl", b"")
 
-    cursor_state: dict[str, object] = {}
+    cursor_state: CursorStatePayload = _empty_cursor_state()
     items = list(iter_source_raw_data(Source(name="codex", path=archive_path), cursor_state=cursor_state))
 
     assert items == []
@@ -2152,7 +2151,7 @@ def test_iter_source_raw_data_tracks_read_failures_without_stopping(
 
     monkeypatch.setattr(BlobStore, "write_from_path", flaky_write)
 
-    cursor_state: dict[str, object] = {}
+    cursor_state: CursorStatePayload = _empty_cursor_state()
     items = list(iter_source_raw_data(Source(name="chatgpt", path=tmp_path), cursor_state=cursor_state))
 
     assert [item.source_path for item in items] == [str(good)]


### PR DESCRIPTION
Ref #235
Ref #222

## Summary
- renew transient run-state and plan-state contracts around `PlanResult`, `RunResult`, cursor payloads, and run drift/count snapshots
- propagate those typed contracts through planning, acquisition, render/watch helpers, and the affected test surfaces
- keep persisted `RunRecord` JSON boundaries broad while making the transient pipeline/runtime layer explicit and typed

## Problem
The run-state seam was still path-dependent and loosely modeled. Planning counts/details, cursor snapshots, run counts, drift, and render failures moved through broad dicts, which made the pipeline runtime ambiguous and forced repeated coercion at the CLI/test boundaries.

## Solution
- introduced explicit transient state models and payload aliases in `polylogue/storage/state_views.py` for plan counts/details, run counts, drift buckets, cursor state, and render failures
- rewired planning and execution state in `polylogue/pipeline/services/planning_runtime.py`, `polylogue/pipeline/run_state.py`, and `polylogue/pipeline/run_finalization.py` to use those models directly
- propagated the tighter cursor and render-failure contracts through source acquisition/decoding helpers plus `watch.py`, `run_stages.py`, and `pipeline/services/rendering.py`
- updated the affected CLI, pipeline, source, and integration tests to construct typed run/plan fixtures explicitly instead of raw dict payloads

## Verification
- `pytest -q tests/unit/cli/test_run.py tests/unit/cli/test_run_laws.py tests/unit/cli/test_run_int.py tests/unit/cli/test_deterministic_output.py tests/unit/pipeline/test_run_sources.py tests/unit/pipeline/test_parsing_service.py tests/unit/pipeline/test_observers.py tests/unit/pipeline/test_watch.py`
- `mypy polylogue/pipeline/watch.py polylogue/pipeline/run_stages.py polylogue/pipeline/services/rendering.py tests/unit/cli/test_run.py tests/unit/cli/test_run_int.py tests/unit/cli/test_run_laws.py tests/unit/sources/test_drive_ops.py tests/unit/sources/test_decoders.py tests/unit/sources/test_acquisition_encoding.py tests/unit/sources/test_source_laws.py tests/integration/test_security.py tests/unit/pipeline/test_run_sources.py tests/integration/test_workflows.py`
- `devtools verify`
