### PR TITLE
refactor: renew session-product persistence seams

### DIFF
--- a/devtools/pipeline_probe.py
+++ b/devtools/pipeline_probe.py
@@ -15,7 +15,9 @@ import tempfile
 from collections.abc import Iterator
 from contextlib import contextmanager, redirect_stdout
 from pathlib import Path
-from typing import NotRequired, TypeAlias, TypedDict
+from typing import NotRequired, TypeAlias
+
+from typing_extensions import TypedDict
 
 from polylogue.config import Config, Source
 from polylogue.paths import blob_store_root, db_path

--- a/devtools/project_motd.py
+++ b/devtools/project_motd.py
@@ -11,7 +11,9 @@ import re
 import subprocess
 import sys
 from pathlib import Path
-from typing import TextIO, TypedDict
+from typing import TextIO
+
+from typing_extensions import TypedDict
 
 from devtools.command_catalog import control_plane_command
 from devtools.generated_surfaces import GENERATED_SURFACES, GeneratedSurface

--- a/polylogue/cli/embed_stats.py
+++ b/polylogue/cli/embed_stats.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Protocol, TypedDict
+from typing import TYPE_CHECKING, Protocol
 
 import click
+from typing_extensions import TypedDict
 
 if TYPE_CHECKING:
     from polylogue.config import Config

--- a/polylogue/pipeline/run_finalization.py
+++ b/polylogue/pipeline/run_finalization.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import time
-from typing import TYPE_CHECKING, TypedDict, cast
+from typing import TYPE_CHECKING, cast
 from uuid import uuid4
+
+from typing_extensions import TypedDict
 
 from polylogue.pipeline.run_support import write_run_json
 from polylogue.storage.backends import create_backend

--- a/polylogue/pipeline/run_stages.py
+++ b/polylogue/pipeline/run_stages.py
@@ -4,7 +4,9 @@ import asyncio
 from collections.abc import AsyncIterator, Iterable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, TypedDict
+from typing import TYPE_CHECKING
+
+from typing_extensions import TypedDict
 
 from polylogue.config import Config
 from polylogue.pipeline.run_support import PARSE_STAGES

--- a/polylogue/pipeline/semantic_capture.py
+++ b/polylogue/pipeline/semantic_capture.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from typing import NotRequired, TypedDict, cast
+from typing import NotRequired, cast
+
+from typing_extensions import TypedDict
 
 from polylogue.lib.payload_coercion import is_payload_mapping, mapping_or_empty, optional_string
 from polylogue.lib.raw_payload_decode import JSONRecord, JSONValue

--- a/polylogue/pipeline/services/indexing.py
+++ b/polylogue/pipeline/services/indexing.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import sqlite3
 from collections.abc import AsyncIterable, AsyncIterator, Callable, Iterable
-from typing import TYPE_CHECKING, TypedDict
+from typing import TYPE_CHECKING
 
 import aiosqlite
+from typing_extensions import TypedDict
 
 from polylogue.logging import get_logger
 from polylogue.storage.action_event_rebuild_runtime import (

--- a/polylogue/pipeline/services/ingest_worker.py
+++ b/polylogue/pipeline/services/ingest_worker.py
@@ -14,7 +14,9 @@ import re
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, TypeAlias, TypedDict, cast
+from typing import TYPE_CHECKING, TypeAlias, cast
+
+from typing_extensions import TypedDict
 
 from polylogue.lib.artifact_taxonomy import classify_artifact
 from polylogue.lib.branch_type import BranchType

--- a/polylogue/sources/assembly.py
+++ b/polylogue/sources/assembly.py
@@ -9,7 +9,9 @@ from __future__ import annotations
 from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Protocol, TypeAlias, TypedDict
+from typing import TYPE_CHECKING, Any, Protocol, TypeAlias
+
+from typing_extensions import TypedDict
 
 from polylogue.types import Provider
 

--- a/polylogue/storage/backends/queries/mappers_product_legacy.py
+++ b/polylogue/storage/backends/queries/mappers_product_legacy.py
@@ -1,0 +1,339 @@
+"""Typed legacy-payload hydrators for session-product row mappers."""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Iterable, Mapping
+from typing import TypeVar
+
+from pydantic import BaseModel
+
+from polylogue.archive_product_models import (
+    SessionEnrichmentPayload,
+    SessionEvidencePayload,
+    SessionInferencePayload,
+    SessionPhaseEvidencePayload,
+    SessionPhaseInferencePayload,
+    WorkEventEvidencePayload,
+    WorkEventInferencePayload,
+)
+from polylogue.storage.backends.queries.mappers import _parse_json, _row_get
+
+PayloadModel = TypeVar("PayloadModel", bound=BaseModel)
+LegacyPayload = dict[str, object]
+
+
+def parse_payload_model(
+    row: sqlite3.Row,
+    column: str,
+    *,
+    record_id: str,
+    model: type[PayloadModel],
+) -> PayloadModel | None:
+    raw_payload = _parse_json(
+        _row_get(row, column),
+        field=column,
+        record_id=record_id,
+    )
+    if not raw_payload:
+        return None
+    return model.model_validate(raw_payload)
+
+
+def parse_legacy_payload_dict(row: sqlite3.Row, *, record_id: str) -> LegacyPayload:
+    legacy_payload = _parse_json(
+        _row_get(row, "payload_json"),
+        field="payload_json",
+        record_id=record_id,
+    )
+    if isinstance(legacy_payload, dict):
+        return {str(key): value for key, value in legacy_payload.items()}
+    return {}
+
+
+def session_profile_evidence_from_legacy(
+    row: sqlite3.Row,
+    legacy_payload: LegacyPayload,
+) -> SessionEvidencePayload:
+    return SessionEvidencePayload.model_validate(
+        {
+            "created_at": _legacy_text(legacy_payload.get("created_at")),
+            "updated_at": _row_text(row, "source_updated_at") or _legacy_text(legacy_payload.get("updated_at")),
+            "first_message_at": _row_text(row, "first_message_at")
+            or _legacy_text(legacy_payload.get("first_message_at")),
+            "last_message_at": _row_text(row, "last_message_at") or _legacy_text(legacy_payload.get("last_message_at")),
+            "canonical_session_date": _row_text(row, "canonical_session_date")
+            or _legacy_text(legacy_payload.get("canonical_session_date")),
+            "message_count": _row_int(row, "message_count", legacy_payload, legacy_key="message_count"),
+            "substantive_count": _row_int(row, "substantive_count", legacy_payload, legacy_key="substantive_count"),
+            "attachment_count": _row_int(row, "attachment_count", legacy_payload, legacy_key="attachment_count"),
+            "tool_use_count": _row_int(row, "tool_use_count", legacy_payload, legacy_key="tool_use_count"),
+            "thinking_count": _row_int(row, "thinking_count", legacy_payload, legacy_key="thinking_count"),
+            "word_count": _row_int(row, "word_count", legacy_payload, legacy_key="word_count"),
+            "total_cost_usd": _row_float(row, "total_cost_usd", legacy_payload, legacy_key="total_cost_usd"),
+            "total_duration_ms": _row_int(row, "total_duration_ms", legacy_payload, legacy_key="total_duration_ms"),
+            "wall_duration_ms": _row_int(row, "wall_duration_ms", legacy_payload, legacy_key="wall_duration_ms"),
+            "cost_is_estimated": _row_bool(row, "cost_is_estimated", legacy_payload, legacy_key="cost_is_estimated"),
+            "tool_categories": _legacy_int_dict(legacy_payload.get("tool_categories")),
+            "repo_paths": _row_text_tuple(row, "repo_paths_json", legacy_payload, legacy_key="repo_paths"),
+            "cwd_paths": _legacy_text_tuple(legacy_payload.get("cwd_paths")),
+            "branch_names": _legacy_text_tuple(legacy_payload.get("branch_names")),
+            "file_paths_touched": _legacy_text_tuple(legacy_payload.get("file_paths_touched")),
+            "languages_detected": _legacy_text_tuple(legacy_payload.get("languages_detected")),
+            "tags": _row_text_tuple(row, "tags_json", legacy_payload, legacy_key="tags"),
+            "is_continuation": bool(legacy_payload.get("is_continuation", False)),
+            "parent_id": _legacy_text(legacy_payload.get("parent_id")),
+        }
+    )
+
+
+def session_profile_inference_from_legacy(
+    row: sqlite3.Row,
+    legacy_payload: LegacyPayload,
+) -> SessionInferencePayload:
+    return SessionInferencePayload.model_validate(
+        {
+            "repo_names": _row_text_tuple(row, "repo_names_json", legacy_payload, legacy_key="repo_names"),
+            "work_event_count": _row_int(row, "work_event_count", legacy_payload, legacy_key="work_event_count"),
+            "phase_count": _row_int(row, "phase_count", legacy_payload, legacy_key="phase_count"),
+            "engaged_duration_ms": _row_int(
+                row,
+                "engaged_duration_ms",
+                legacy_payload,
+                legacy_key="engaged_duration_ms",
+            ),
+            "engaged_minutes": _legacy_float(legacy_payload.get("engaged_minutes")),
+            "support_level": _legacy_text(legacy_payload.get("support_level")) or "weak",
+            "support_signals": _legacy_text_tuple(legacy_payload.get("support_signals")),
+            "engaged_duration_source": _legacy_text(legacy_payload.get("engaged_duration_source"))
+            or "session_total_fallback",
+            "repo_inference_strength": _legacy_text(legacy_payload.get("repo_inference_strength")) or "weak",
+            "auto_tags": _row_text_tuple(row, "auto_tags_json", legacy_payload, legacy_key="auto_tags"),
+            "work_events": _legacy_dict_tuple(legacy_payload.get("work_events")),
+            "phases": _legacy_dict_tuple(legacy_payload.get("phases")),
+        }
+    )
+
+
+def session_profile_enrichment_from_legacy(
+    row: sqlite3.Row,
+    legacy_payload: LegacyPayload,
+    *,
+    inference_payload: SessionInferencePayload,
+) -> SessionEnrichmentPayload:
+    repo_paths = _row_text_tuple(row, "repo_paths_json", legacy_payload, legacy_key="repo_paths")
+    repo_names = _row_text_tuple(row, "repo_names_json", legacy_payload, legacy_key="repo_names")
+    return SessionEnrichmentPayload.model_validate(
+        {
+            "intent_summary": _row_text(row, "title") or _legacy_text(legacy_payload.get("title")),
+            "outcome_summary": None,
+            "blockers": (),
+            "confidence": 0.0,
+            "support_level": "weak",
+            "support_signals": inference_payload.support_signals,
+            "input_band_summary": {
+                "user_turns": 0,
+                "assistant_turns": 0,
+                "action_events": 0,
+                "touched_paths": len(repo_paths),
+                "repo_names": len(repo_names),
+            },
+        }
+    )
+
+
+def session_work_event_evidence_from_legacy(
+    row: sqlite3.Row,
+    legacy_payload: LegacyPayload,
+) -> WorkEventEvidencePayload:
+    return WorkEventEvidencePayload.model_validate(
+        {
+            "start_index": _row_int(row, "start_index", legacy_payload, legacy_key="start_index"),
+            "end_index": _row_int(row, "end_index", legacy_payload, legacy_key="end_index"),
+            "start_time": _row_text(row, "start_time") or _legacy_text(legacy_payload.get("start_time")),
+            "end_time": _row_text(row, "end_time") or _legacy_text(legacy_payload.get("end_time")),
+            "canonical_session_date": _row_text(row, "canonical_session_date")
+            or _legacy_text(legacy_payload.get("canonical_session_date")),
+            "duration_ms": _row_int(row, "duration_ms", legacy_payload, legacy_key="duration_ms"),
+            "file_paths": _row_text_tuple(row, "file_paths_json", legacy_payload, legacy_key="file_paths"),
+            "tools_used": _row_text_tuple(row, "tools_used_json", legacy_payload, legacy_key="tools_used"),
+        }
+    )
+
+
+def session_work_event_inference_from_legacy(
+    row: sqlite3.Row,
+    legacy_payload: LegacyPayload,
+) -> WorkEventInferencePayload:
+    return WorkEventInferencePayload.model_validate(
+        {
+            "kind": _row_text(row, "kind") or "",
+            "summary": _row_text(row, "summary") or "",
+            "confidence": _row_float(row, "confidence", legacy_payload, legacy_key="confidence"),
+            "evidence": _legacy_text_tuple(legacy_payload.get("evidence")),
+        }
+    )
+
+
+def session_phase_evidence_from_legacy(
+    row: sqlite3.Row,
+    legacy_payload: LegacyPayload,
+) -> SessionPhaseEvidencePayload:
+    return SessionPhaseEvidencePayload.model_validate(
+        {
+            "start_time": _row_text(row, "start_time") or _legacy_text(legacy_payload.get("start_time")),
+            "end_time": _row_text(row, "end_time") or _legacy_text(legacy_payload.get("end_time")),
+            "canonical_session_date": _row_text(row, "canonical_session_date")
+            or _legacy_text(legacy_payload.get("canonical_session_date")),
+            "message_range": (
+                _row_int(row, "start_index", legacy_payload, legacy_key="start_index"),
+                _row_int(row, "end_index", legacy_payload, legacy_key="end_index"),
+            ),
+            "duration_ms": _row_int(row, "duration_ms", legacy_payload, legacy_key="duration_ms"),
+            "tool_counts": _row_int_dict(row, "tool_counts_json", legacy_payload, legacy_key="tool_counts"),
+            "word_count": _row_int(row, "word_count", legacy_payload, legacy_key="word_count"),
+        }
+    )
+
+
+def session_phase_inference_from_legacy(
+    row: sqlite3.Row,
+    legacy_payload: LegacyPayload,
+) -> SessionPhaseInferencePayload:
+    return SessionPhaseInferencePayload.model_validate(
+        {
+            "confidence": _row_float(row, "confidence", legacy_payload, legacy_key="confidence"),
+            "evidence": _row_text_tuple(
+                row,
+                "evidence_reasons_json",
+                legacy_payload,
+                legacy_key="evidence",
+            ),
+        }
+    )
+
+
+def _row_text(row: sqlite3.Row, column: str) -> str | None:
+    value = _row_get(row, column)
+    return None if value is None else str(value)
+
+
+def _row_int(
+    row: sqlite3.Row,
+    column: str,
+    legacy_payload: Mapping[str, object],
+    *,
+    legacy_key: str,
+    default: int = 0,
+) -> int:
+    raw_value = _row_get(row, column, None)
+    if raw_value is None:
+        raw_value = legacy_payload.get(legacy_key, default)
+    return int(raw_value or default)
+
+
+def _row_float(
+    row: sqlite3.Row,
+    column: str,
+    legacy_payload: Mapping[str, object],
+    *,
+    legacy_key: str,
+    default: float = 0.0,
+) -> float:
+    raw_value = _row_get(row, column, None)
+    if raw_value is None:
+        raw_value = legacy_payload.get(legacy_key, default)
+    return float(raw_value or default)
+
+
+def _row_bool(
+    row: sqlite3.Row,
+    column: str,
+    legacy_payload: Mapping[str, object],
+    *,
+    legacy_key: str,
+) -> bool:
+    raw_value = _row_get(row, column, None)
+    if raw_value is None:
+        raw_value = legacy_payload.get(legacy_key, False)
+    if isinstance(raw_value, bool):
+        return raw_value
+    if isinstance(raw_value, str | int | float):
+        return bool(int(raw_value or 0))
+    return bool(raw_value)
+
+
+def _row_text_tuple(
+    row: sqlite3.Row,
+    column: str,
+    legacy_payload: Mapping[str, object],
+    *,
+    legacy_key: str,
+) -> tuple[str, ...]:
+    parsed = _parse_json(_row_get(row, column))
+    if parsed is not None:
+        return _legacy_text_tuple(parsed)
+    return _legacy_text_tuple(legacy_payload.get(legacy_key))
+
+
+def _row_int_dict(
+    row: sqlite3.Row,
+    column: str,
+    legacy_payload: Mapping[str, object],
+    *,
+    legacy_key: str,
+) -> dict[str, int]:
+    parsed = _parse_json(_row_get(row, column))
+    if parsed is not None:
+        return _legacy_int_dict(parsed)
+    return _legacy_int_dict(legacy_payload.get(legacy_key))
+
+
+def _legacy_text(value: object) -> str | None:
+    if value is None:
+        return None
+    text = str(value)
+    return text if text else None
+
+
+def _legacy_float(value: object, default: float = 0.0) -> float:
+    if isinstance(value, bool):
+        return float(int(value))
+    if isinstance(value, str | int | float):
+        return float(value or default)
+    return default
+
+
+def _legacy_text_tuple(value: object) -> tuple[str, ...]:
+    if not isinstance(value, Iterable) or isinstance(value, str | bytes | Mapping):
+        return ()
+    return tuple(str(item) for item in value if item is not None)
+
+
+def _legacy_dict_tuple(value: object) -> tuple[dict[str, object], ...]:
+    if not isinstance(value, Iterable) or isinstance(value, str | bytes | Mapping):
+        return ()
+    items: list[dict[str, object]] = []
+    for item in value:
+        if isinstance(item, Mapping):
+            items.append({str(key): val for key, val in item.items()})
+    return tuple(items)
+
+
+def _legacy_int_dict(value: object) -> dict[str, int]:
+    if not isinstance(value, Mapping):
+        return {}
+    return {str(key): int(item) for key, item in value.items() if item is not None}
+
+
+__all__ = [
+    "parse_legacy_payload_dict",
+    "parse_payload_model",
+    "session_phase_evidence_from_legacy",
+    "session_phase_inference_from_legacy",
+    "session_profile_enrichment_from_legacy",
+    "session_profile_evidence_from_legacy",
+    "session_profile_inference_from_legacy",
+    "session_work_event_evidence_from_legacy",
+    "session_work_event_inference_from_legacy",
+]

--- a/polylogue/storage/backends/queries/mappers_product_profiles.py
+++ b/polylogue/storage/backends/queries/mappers_product_profiles.py
@@ -10,6 +10,13 @@ from polylogue.archive_product_models import (
     SessionInferencePayload,
 )
 from polylogue.storage.backends.queries.mappers import _parse_json, _row_get
+from polylogue.storage.backends.queries.mappers_product_legacy import (
+    parse_legacy_payload_dict,
+    parse_payload_model,
+    session_profile_enrichment_from_legacy,
+    session_profile_evidence_from_legacy,
+    session_profile_inference_from_legacy,
+)
 from polylogue.storage.store import SessionProfileRecord
 from polylogue.types import ConversationId
 
@@ -19,123 +26,37 @@ def _row_to_session_profile_record(row: sqlite3.Row) -> SessionProfileRecord:
     evidence_search_text = (_row_get(row, "evidence_search_text", "") or "").strip() or search_text
     inference_search_text = (_row_get(row, "inference_search_text", "") or "").strip() or search_text
     enrichment_search_text = (_row_get(row, "enrichment_search_text", "") or "").strip() or inference_search_text
-    legacy_payload = (
-        _parse_json(
-            _row_get(row, "payload_json"),
-            field="payload_json",
-            record_id=row["conversation_id"],
-        )
-        or {}
-    )
-    raw_evidence_payload = _parse_json(
-        _row_get(row, "evidence_payload_json"),
-        field="evidence_payload_json",
+    legacy_payload = parse_legacy_payload_dict(
+        row,
         record_id=row["conversation_id"],
     )
-    if raw_evidence_payload:
-        evidence_payload = SessionEvidencePayload.model_validate(raw_evidence_payload)
-    else:
-        evidence_payload = SessionEvidencePayload.model_validate(
-            {
-                "created_at": legacy_payload.get("created_at"),
-                "updated_at": legacy_payload.get("updated_at") or _row_get(row, "source_updated_at"),
-                "first_message_at": _row_get(row, "first_message_at") or legacy_payload.get("first_message_at"),
-                "last_message_at": _row_get(row, "last_message_at") or legacy_payload.get("last_message_at"),
-                "canonical_session_date": _row_get(row, "canonical_session_date")
-                or legacy_payload.get("canonical_session_date"),
-                "message_count": int(_row_get(row, "message_count", 0) or legacy_payload.get("message_count") or 0),
-                "substantive_count": int(
-                    _row_get(row, "substantive_count", 0) or legacy_payload.get("substantive_count") or 0
-                ),
-                "attachment_count": int(
-                    _row_get(row, "attachment_count", 0) or legacy_payload.get("attachment_count") or 0
-                ),
-                "tool_use_count": int(_row_get(row, "tool_use_count", 0) or legacy_payload.get("tool_use_count") or 0),
-                "thinking_count": int(_row_get(row, "thinking_count", 0) or legacy_payload.get("thinking_count") or 0),
-                "word_count": int(_row_get(row, "word_count", 0) or legacy_payload.get("word_count") or 0),
-                "total_cost_usd": float(
-                    _row_get(row, "total_cost_usd", 0.0) or legacy_payload.get("total_cost_usd") or 0.0
-                ),
-                "total_duration_ms": int(
-                    _row_get(row, "total_duration_ms", 0) or legacy_payload.get("total_duration_ms") or 0
-                ),
-                "wall_duration_ms": int(
-                    _row_get(row, "wall_duration_ms", 0) or legacy_payload.get("wall_duration_ms") or 0
-                ),
-                "cost_is_estimated": bool(
-                    int(_row_get(row, "cost_is_estimated", 0) or 0) or legacy_payload.get("cost_is_estimated")
-                ),
-                "tool_categories": legacy_payload.get("tool_categories") or {},
-                "repo_paths": tuple(
-                    _parse_json(_row_get(row, "repo_paths_json")) or legacy_payload.get("repo_paths") or []
-                ),
-                "cwd_paths": tuple(legacy_payload.get("cwd_paths") or ()),
-                "branch_names": tuple(legacy_payload.get("branch_names") or ()),
-                "file_paths_touched": tuple(legacy_payload.get("file_paths_touched") or ()),
-                "languages_detected": tuple(legacy_payload.get("languages_detected") or ()),
-                "tags": tuple(_parse_json(_row_get(row, "tags_json")) or legacy_payload.get("tags") or []),
-                "is_continuation": bool(legacy_payload.get("is_continuation", False)),
-                "parent_id": legacy_payload.get("parent_id"),
-            }
-        )
-    raw_inference_payload = _parse_json(
-        _row_get(row, "inference_payload_json"),
-        field="inference_payload_json",
+    evidence_payload = parse_payload_model(
+        row,
+        "evidence_payload_json",
         record_id=row["conversation_id"],
+        model=SessionEvidencePayload,
     )
-    if raw_inference_payload:
-        inference_payload = SessionInferencePayload.model_validate(raw_inference_payload)
-    else:
-        inference_payload = SessionInferencePayload.model_validate(
-            {
-                "repo_names": tuple(
-                    _parse_json(_row_get(row, "repo_names_json")) or legacy_payload.get("repo_names") or []
-                ),
-                "work_event_count": int(
-                    _row_get(row, "work_event_count", 0) or legacy_payload.get("work_event_count") or 0
-                ),
-                "phase_count": int(_row_get(row, "phase_count", 0) or legacy_payload.get("phase_count") or 0),
-                "engaged_duration_ms": int(
-                    _row_get(row, "engaged_duration_ms", 0) or legacy_payload.get("engaged_duration_ms") or 0
-                ),
-                "engaged_minutes": float(legacy_payload.get("engaged_minutes") or 0.0),
-                "support_level": str(legacy_payload.get("support_level") or "weak"),
-                "support_signals": tuple(legacy_payload.get("support_signals") or ()),
-                "engaged_duration_source": str(
-                    legacy_payload.get("engaged_duration_source") or "session_total_fallback"
-                ),
-                "repo_inference_strength": str(legacy_payload.get("repo_inference_strength") or "weak"),
-                "auto_tags": tuple(
-                    _parse_json(_row_get(row, "auto_tags_json")) or legacy_payload.get("auto_tags") or []
-                ),
-                "work_events": tuple(legacy_payload.get("work_events") or ()),
-                "phases": tuple(legacy_payload.get("phases") or ()),
-            }
-        )
-    raw_enrichment_payload = _parse_json(
-        _row_get(row, "enrichment_payload_json"),
-        field="enrichment_payload_json",
+    if evidence_payload is None:
+        evidence_payload = session_profile_evidence_from_legacy(row, legacy_payload)
+    inference_payload = parse_payload_model(
+        row,
+        "inference_payload_json",
         record_id=row["conversation_id"],
+        model=SessionInferencePayload,
     )
-    if raw_enrichment_payload:
-        enrichment_payload = SessionEnrichmentPayload.model_validate(raw_enrichment_payload)
-    else:
-        enrichment_payload = SessionEnrichmentPayload.model_validate(
-            {
-                "intent_summary": row["title"] or legacy_payload.get("title"),
-                "outcome_summary": None,
-                "blockers": (),
-                "confidence": 0.0,
-                "support_level": "weak",
-                "support_signals": inference_payload.support_signals,
-                "input_band_summary": {
-                    "user_turns": 0,
-                    "assistant_turns": 0,
-                    "action_events": 0,
-                    "touched_paths": len(_parse_json(_row_get(row, "repo_paths_json")) or []),
-                    "repo_names": len(_parse_json(_row_get(row, "repo_names_json")) or []),
-                },
-            }
+    if inference_payload is None:
+        inference_payload = session_profile_inference_from_legacy(row, legacy_payload)
+    enrichment_payload = parse_payload_model(
+        row,
+        "enrichment_payload_json",
+        record_id=row["conversation_id"],
+        model=SessionEnrichmentPayload,
+    )
+    if enrichment_payload is None:
+        enrichment_payload = session_profile_enrichment_from_legacy(
+            row,
+            legacy_payload,
+            inference_payload=inference_payload,
         )
     return SessionProfileRecord(
         conversation_id=ConversationId(row["conversation_id"]),

--- a/polylogue/storage/backends/queries/mappers_product_timelines.py
+++ b/polylogue/storage/backends/queries/mappers_product_timelines.py
@@ -12,60 +12,39 @@ from polylogue.archive_product_models import (
     WorkThreadPayload,
 )
 from polylogue.storage.backends.queries.mappers import _parse_json, _row_get
+from polylogue.storage.backends.queries.mappers_product_legacy import (
+    parse_legacy_payload_dict,
+    parse_payload_model,
+    session_phase_evidence_from_legacy,
+    session_phase_inference_from_legacy,
+    session_work_event_evidence_from_legacy,
+    session_work_event_inference_from_legacy,
+)
 from polylogue.storage.store import SessionPhaseRecord, SessionWorkEventRecord, WorkThreadRecord
 from polylogue.types import ConversationId
 
 
 def _row_to_session_work_event_record(row: sqlite3.Row) -> SessionWorkEventRecord:
-    legacy_payload = (
-        _parse_json(
-            _row_get(row, "payload_json"),
-            field="payload_json",
-            record_id=row["event_id"],
-        )
-        or {}
-    )
-    raw_evidence_payload = _parse_json(
-        _row_get(row, "evidence_payload_json"),
-        field="evidence_payload_json",
+    legacy_payload = parse_legacy_payload_dict(
+        row,
         record_id=row["event_id"],
     )
-    if raw_evidence_payload:
-        evidence_payload = WorkEventEvidencePayload.model_validate(raw_evidence_payload)
-    else:
-        evidence_payload = WorkEventEvidencePayload.model_validate(
-            {
-                "start_index": int(_row_get(row, "start_index", 0) or legacy_payload.get("start_index") or 0),
-                "end_index": int(_row_get(row, "end_index", 0) or legacy_payload.get("end_index") or 0),
-                "start_time": _row_get(row, "start_time") or legacy_payload.get("start_time"),
-                "end_time": _row_get(row, "end_time") or legacy_payload.get("end_time"),
-                "canonical_session_date": _row_get(row, "canonical_session_date")
-                or legacy_payload.get("canonical_session_date"),
-                "duration_ms": int(_row_get(row, "duration_ms", 0) or legacy_payload.get("duration_ms") or 0),
-                "file_paths": tuple(
-                    _parse_json(_row_get(row, "file_paths_json")) or legacy_payload.get("file_paths") or []
-                ),
-                "tools_used": tuple(
-                    _parse_json(_row_get(row, "tools_used_json")) or legacy_payload.get("tools_used") or []
-                ),
-            }
-        )
-    raw_inference_payload = _parse_json(
-        _row_get(row, "inference_payload_json"),
-        field="inference_payload_json",
+    evidence_payload = parse_payload_model(
+        row,
+        "evidence_payload_json",
         record_id=row["event_id"],
+        model=WorkEventEvidencePayload,
     )
-    if raw_inference_payload:
-        inference_payload = WorkEventInferencePayload.model_validate(raw_inference_payload)
-    else:
-        inference_payload = WorkEventInferencePayload.model_validate(
-            {
-                "kind": row["kind"],
-                "summary": row["summary"],
-                "confidence": float(_row_get(row, "confidence", 0.0) or legacy_payload.get("confidence") or 0.0),
-                "evidence": tuple(legacy_payload.get("evidence") or ()),
-            }
-        )
+    if evidence_payload is None:
+        evidence_payload = session_work_event_evidence_from_legacy(row, legacy_payload)
+    inference_payload = parse_payload_model(
+        row,
+        "inference_payload_json",
+        record_id=row["event_id"],
+        model=WorkEventInferencePayload,
+    )
+    if inference_payload is None:
+        inference_payload = session_work_event_inference_from_legacy(row, legacy_payload)
     return SessionWorkEventRecord(
         event_id=row["event_id"],
         conversation_id=ConversationId(row["conversation_id"]),
@@ -95,55 +74,26 @@ def _row_to_session_work_event_record(row: sqlite3.Row) -> SessionWorkEventRecor
 
 
 def _row_to_session_phase_record(row: sqlite3.Row) -> SessionPhaseRecord:
-    legacy_payload = (
-        _parse_json(
-            _row_get(row, "payload_json"),
-            field="payload_json",
-            record_id=row["phase_id"],
-        )
-        or {}
-    )
-    raw_evidence_payload = _parse_json(
-        _row_get(row, "evidence_payload_json"),
-        field="evidence_payload_json",
+    legacy_payload = parse_legacy_payload_dict(
+        row,
         record_id=row["phase_id"],
     )
-    if raw_evidence_payload:
-        evidence_payload = SessionPhaseEvidencePayload.model_validate(raw_evidence_payload)
-    else:
-        evidence_payload = SessionPhaseEvidencePayload.model_validate(
-            {
-                "start_time": _row_get(row, "start_time") or legacy_payload.get("start_time"),
-                "end_time": _row_get(row, "end_time") or legacy_payload.get("end_time"),
-                "canonical_session_date": _row_get(row, "canonical_session_date")
-                or legacy_payload.get("canonical_session_date"),
-                "message_range": (
-                    int(_row_get(row, "start_index", 0) or legacy_payload.get("start_index") or 0),
-                    int(_row_get(row, "end_index", 0) or legacy_payload.get("end_index") or 0),
-                ),
-                "duration_ms": int(_row_get(row, "duration_ms", 0) or legacy_payload.get("duration_ms") or 0),
-                "tool_counts": _parse_json(_row_get(row, "tool_counts_json"))
-                or legacy_payload.get("tool_counts")
-                or {},
-                "word_count": int(_row_get(row, "word_count", 0) or legacy_payload.get("word_count") or 0),
-            }
-        )
-    raw_inference_payload = _parse_json(
-        _row_get(row, "inference_payload_json"),
-        field="inference_payload_json",
+    evidence_payload = parse_payload_model(
+        row,
+        "evidence_payload_json",
         record_id=row["phase_id"],
+        model=SessionPhaseEvidencePayload,
     )
-    if raw_inference_payload:
-        inference_payload = SessionPhaseInferencePayload.model_validate(raw_inference_payload)
-    else:
-        inference_payload = SessionPhaseInferencePayload.model_validate(
-            {
-                "confidence": float(_row_get(row, "confidence", 0.0) or legacy_payload.get("confidence") or 0.0),
-                "evidence": tuple(
-                    _parse_json(_row_get(row, "evidence_reasons_json")) or legacy_payload.get("evidence") or []
-                ),
-            }
-        )
+    if evidence_payload is None:
+        evidence_payload = session_phase_evidence_from_legacy(row, legacy_payload)
+    inference_payload = parse_payload_model(
+        row,
+        "inference_payload_json",
+        record_id=row["phase_id"],
+        model=SessionPhaseInferencePayload,
+    )
+    if inference_payload is None:
+        inference_payload = session_phase_inference_from_legacy(row, legacy_payload)
     return SessionPhaseRecord(
         phase_id=row["phase_id"],
         conversation_id=ConversationId(row["conversation_id"]),

--- a/polylogue/storage/backends/queries/session_product_profile_writes.py
+++ b/polylogue/storage/backends/queries/session_product_profile_writes.py
@@ -7,6 +7,7 @@ from collections.abc import Sequence
 import aiosqlite
 
 from polylogue.storage.session_product_storage import (
+    build_insert_sql,
     session_profile_insert_columns,
     session_profile_insert_values,
 )
@@ -45,13 +46,8 @@ async def replace_session_profiles_bulk(
     if records:
         has_legacy_payload = await _table_has_column(conn, "session_profiles", "payload_json")
         columns = session_profile_insert_columns(has_legacy_payload=has_legacy_payload)
-        placeholders = ", ".join("?" for _ in columns)
         await conn.executemany(
-            f"""
-            INSERT INTO session_profiles (
-                {", ".join(columns)}
-            ) VALUES ({placeholders})
-            """,
+            build_insert_sql("session_profiles", columns),
             [
                 session_profile_insert_values(
                     record,

--- a/polylogue/storage/backends/queries/session_product_timeline_writes.py
+++ b/polylogue/storage/backends/queries/session_product_timeline_writes.py
@@ -7,6 +7,7 @@ from collections.abc import Sequence
 import aiosqlite
 
 from polylogue.storage.session_product_storage import (
+    build_insert_sql,
     session_phase_insert_columns,
     session_phase_insert_values,
     session_work_event_insert_columns,
@@ -65,13 +66,8 @@ async def replace_session_work_events_bulk(
     if records:
         has_legacy_payload = await _table_has_column(conn, "session_work_events", "payload_json")
         columns = session_work_event_insert_columns(has_legacy_payload=has_legacy_payload)
-        placeholders = ", ".join("?" for _ in columns)
         await conn.executemany(
-            f"""
-            INSERT INTO session_work_events (
-                {", ".join(columns)}
-            ) VALUES ({placeholders})
-            """,
+            build_insert_sql("session_work_events", columns),
             [
                 session_work_event_insert_values(
                     record,
@@ -113,13 +109,8 @@ async def replace_session_phases_bulk(
     if records:
         has_legacy_payload = await _table_has_column(conn, "session_phases", "payload_json")
         columns = session_phase_insert_columns(has_legacy_payload=has_legacy_payload)
-        placeholders = ", ".join("?" for _ in columns)
         await conn.executemany(
-            f"""
-            INSERT INTO session_phases (
-                {", ".join(columns)}
-            ) VALUES ({placeholders})
-            """,
+            build_insert_sql("session_phases", columns),
             [
                 session_phase_insert_values(
                     record,

--- a/polylogue/storage/backends/queries/stats.py
+++ b/polylogue/storage/backends/queries/stats.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-from typing import TypedDict
-
 import aiosqlite
+from typing_extensions import TypedDict
 
 from polylogue.storage.store import MessageRecord
 

--- a/polylogue/storage/query_models.py
+++ b/polylogue/storage/query_models.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, replace
-from typing import TypedDict
+
+from typing_extensions import TypedDict
 
 
 class ConversationListQueryKwargs(TypedDict):

--- a/polylogue/storage/session_product_runtime.py
+++ b/polylogue/storage/session_product_runtime.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal, TypeAlias, TypedDict
+from typing import Literal, TypeAlias
+
+from typing_extensions import TypedDict
 
 ProviderDayGroup: TypeAlias = tuple[str, str]
 SessionProductReadyFlag: TypeAlias = Literal[

--- a/polylogue/storage/session_product_storage.py
+++ b/polylogue/storage/session_product_storage.py
@@ -24,6 +24,100 @@ from polylogue.storage.store import (
 
 
 _SYNC_COLUMN_CACHE: dict[tuple[int, str], bool] = {}
+SqlValue = str | int | float | None
+SqlBindings = tuple[SqlValue, ...]
+
+_SESSION_PROFILE_BASE_COLUMNS = (
+    "conversation_id",
+    "materializer_version",
+    "materialized_at",
+    "source_updated_at",
+    "source_sort_key",
+    "provider_name",
+    "title",
+    "first_message_at",
+    "last_message_at",
+    "canonical_session_date",
+    "repo_paths_json",
+    "repo_names_json",
+    "tags_json",
+    "auto_tags_json",
+    "message_count",
+    "substantive_count",
+    "attachment_count",
+    "work_event_count",
+    "phase_count",
+    "word_count",
+    "tool_use_count",
+    "thinking_count",
+    "total_cost_usd",
+    "total_duration_ms",
+    "engaged_duration_ms",
+    "wall_duration_ms",
+    "cost_is_estimated",
+)
+_SESSION_PROFILE_PAYLOAD_COLUMNS = (
+    "evidence_payload_json",
+    "inference_payload_json",
+    "enrichment_payload_json",
+    "search_text",
+    "evidence_search_text",
+    "inference_search_text",
+    "enrichment_search_text",
+    "enrichment_version",
+    "enrichment_family",
+    "inference_version",
+    "inference_family",
+)
+_SESSION_WORK_EVENT_BASE_COLUMNS = (
+    "event_id",
+    "conversation_id",
+    "materializer_version",
+    "materialized_at",
+    "source_updated_at",
+    "source_sort_key",
+    "provider_name",
+    "event_index",
+    "kind",
+    "confidence",
+    "start_index",
+    "end_index",
+    "start_time",
+    "end_time",
+    "duration_ms",
+    "canonical_session_date",
+    "summary",
+    "file_paths_json",
+    "tools_used_json",
+)
+_TIMELINE_PAYLOAD_COLUMNS = (
+    "evidence_payload_json",
+    "inference_payload_json",
+    "search_text",
+    "inference_version",
+    "inference_family",
+)
+_SESSION_PHASE_BASE_COLUMNS = (
+    "phase_id",
+    "conversation_id",
+    "materializer_version",
+    "materialized_at",
+    "source_updated_at",
+    "source_sort_key",
+    "provider_name",
+    "phase_index",
+    "kind",
+    "start_index",
+    "end_index",
+    "start_time",
+    "end_time",
+    "duration_ms",
+    "canonical_session_date",
+    "confidence",
+    "evidence_reasons_json",
+    "tool_counts_json",
+    "word_count",
+)
 
 
 def table_has_column(conn: sqlite3.Connection, table: str, column: str) -> bool:
@@ -38,6 +132,39 @@ def table_has_column(conn: sqlite3.Connection, table: str, column: str) -> bool:
 
 def _placeholders(columns: Sequence[str]) -> str:
     return ", ".join("?" for _ in columns)
+
+
+def build_insert_sql(table: str, columns: Sequence[str]) -> str:
+    return f"""
+        INSERT INTO {table} (
+            {", ".join(columns)}
+        ) VALUES ({_placeholders(columns)})
+        """
+
+
+def _with_legacy_payload_column(
+    base_columns: tuple[str, ...],
+    payload_columns: tuple[str, ...],
+    *,
+    has_legacy_payload: bool,
+) -> tuple[str, ...]:
+    if has_legacy_payload:
+        return base_columns + ("payload_json",) + payload_columns
+    return base_columns + payload_columns
+
+
+def _compose_bindings(
+    base_values: Sequence[SqlValue],
+    payload_values: Sequence[SqlValue],
+    *,
+    has_legacy_payload: bool,
+    legacy_payload_json: str | None,
+) -> SqlBindings:
+    values = list(base_values)
+    if has_legacy_payload:
+        values.append(legacy_payload_json)
+    values.extend(payload_values)
+    return tuple(values)
 
 
 def _legacy_profile_payload_json(record: SessionProfileRecord) -> str | None:
@@ -56,61 +183,19 @@ def session_profile_insert_columns(
     *,
     has_legacy_payload: bool,
 ) -> tuple[str, ...]:
-    columns = [
-        "conversation_id",
-        "materializer_version",
-        "materialized_at",
-        "source_updated_at",
-        "source_sort_key",
-        "provider_name",
-        "title",
-        "first_message_at",
-        "last_message_at",
-        "canonical_session_date",
-        "repo_paths_json",
-        "repo_names_json",
-        "tags_json",
-        "auto_tags_json",
-        "message_count",
-        "substantive_count",
-        "attachment_count",
-        "work_event_count",
-        "phase_count",
-        "word_count",
-        "tool_use_count",
-        "thinking_count",
-        "total_cost_usd",
-        "total_duration_ms",
-        "engaged_duration_ms",
-        "wall_duration_ms",
-        "cost_is_estimated",
-    ]
-    if has_legacy_payload:
-        columns.append("payload_json")
-    columns.extend(
-        [
-            "evidence_payload_json",
-            "inference_payload_json",
-            "enrichment_payload_json",
-            "search_text",
-            "evidence_search_text",
-            "inference_search_text",
-            "enrichment_search_text",
-            "enrichment_version",
-            "enrichment_family",
-            "inference_version",
-            "inference_family",
-        ]
+    return _with_legacy_payload_column(
+        _SESSION_PROFILE_BASE_COLUMNS,
+        _SESSION_PROFILE_PAYLOAD_COLUMNS,
+        has_legacy_payload=has_legacy_payload,
     )
-    return tuple(columns)
 
 
 def session_profile_insert_values(
     record: SessionProfileRecord,
     *,
     has_legacy_payload: bool,
-) -> tuple[object, ...]:
-    values: list[object] = [
+) -> SqlBindings:
+    base_values: list[SqlValue] = [
         record.conversation_id,
         record.materializer_version,
         record.materialized_at,
@@ -139,80 +224,56 @@ def session_profile_insert_values(
         record.wall_duration_ms,
         int(record.cost_is_estimated),
     ]
-    if has_legacy_payload:
-        values.append(_legacy_profile_payload_json(record))
-    values.extend(
-        [
-            _json_or_none(record.evidence_payload),
-            _json_or_none(record.inference_payload),
-            _json_or_none(record.enrichment_payload),
-            record.search_text,
-            record.evidence_search_text,
-            record.inference_search_text,
-            record.enrichment_search_text,
-            record.enrichment_version,
-            record.enrichment_family,
-            record.inference_version,
-            record.inference_family,
-        ]
+    payload_values: tuple[SqlValue, ...] = (
+        _json_or_none(record.evidence_payload),
+        _json_or_none(record.inference_payload),
+        _json_or_none(record.enrichment_payload),
+        record.search_text,
+        record.evidence_search_text,
+        record.inference_search_text,
+        record.enrichment_search_text,
+        record.enrichment_version,
+        record.enrichment_family,
+        record.inference_version,
+        record.inference_family,
     )
-    return tuple(values)
+    return _compose_bindings(
+        base_values,
+        payload_values,
+        has_legacy_payload=has_legacy_payload,
+        legacy_payload_json=_legacy_profile_payload_json(record),
+    )
 
 
 def _legacy_timeline_payload_json(
-    evidence_payload: object,
-    inference_payload: object,
+    evidence_payload: BaseModel,
+    inference_payload: BaseModel,
 ) -> str | None:
-    evidence = evidence_payload.model_dump(mode="json") if isinstance(evidence_payload, BaseModel) else {}
-    inference = inference_payload.model_dump(mode="json") if isinstance(inference_payload, BaseModel) else {}
-    return _json_or_none({**evidence, **inference})
+    return _json_or_none(
+        {
+            **evidence_payload.model_dump(mode="json"),
+            **inference_payload.model_dump(mode="json"),
+        }
+    )
 
 
 def session_work_event_insert_columns(
     *,
     has_legacy_payload: bool,
 ) -> tuple[str, ...]:
-    columns = [
-        "event_id",
-        "conversation_id",
-        "materializer_version",
-        "materialized_at",
-        "source_updated_at",
-        "source_sort_key",
-        "provider_name",
-        "event_index",
-        "kind",
-        "confidence",
-        "start_index",
-        "end_index",
-        "start_time",
-        "end_time",
-        "duration_ms",
-        "canonical_session_date",
-        "summary",
-        "file_paths_json",
-        "tools_used_json",
-    ]
-    if has_legacy_payload:
-        columns.append("payload_json")
-    columns.extend(
-        [
-            "evidence_payload_json",
-            "inference_payload_json",
-            "search_text",
-            "inference_version",
-            "inference_family",
-        ]
+    return _with_legacy_payload_column(
+        _SESSION_WORK_EVENT_BASE_COLUMNS,
+        _TIMELINE_PAYLOAD_COLUMNS,
+        has_legacy_payload=has_legacy_payload,
     )
-    return tuple(columns)
 
 
 def session_work_event_insert_values(
     record: SessionWorkEventRecord,
     *,
     has_legacy_payload: bool,
-) -> tuple[object, ...]:
-    values: list[object] = [
+) -> SqlBindings:
+    base_values: list[SqlValue] = [
         record.event_id,
         record.conversation_id,
         record.materializer_version,
@@ -233,65 +294,38 @@ def session_work_event_insert_values(
         _json_array_or_none(record.file_paths),
         _json_array_or_none(record.tools_used),
     ]
-    if has_legacy_payload:
-        values.append(_legacy_timeline_payload_json(record.evidence_payload, record.inference_payload))
-    values.extend(
-        [
-            _json_or_none(record.evidence_payload),
-            _json_or_none(record.inference_payload),
-            record.search_text,
-            record.inference_version,
-            record.inference_family,
-        ]
+    payload_values: tuple[SqlValue, ...] = (
+        _json_or_none(record.evidence_payload),
+        _json_or_none(record.inference_payload),
+        record.search_text,
+        record.inference_version,
+        record.inference_family,
     )
-    return tuple(values)
+    return _compose_bindings(
+        base_values,
+        payload_values,
+        has_legacy_payload=has_legacy_payload,
+        legacy_payload_json=_legacy_timeline_payload_json(record.evidence_payload, record.inference_payload),
+    )
 
 
 def session_phase_insert_columns(
     *,
     has_legacy_payload: bool,
 ) -> tuple[str, ...]:
-    columns = [
-        "phase_id",
-        "conversation_id",
-        "materializer_version",
-        "materialized_at",
-        "source_updated_at",
-        "source_sort_key",
-        "provider_name",
-        "phase_index",
-        "kind",
-        "start_index",
-        "end_index",
-        "start_time",
-        "end_time",
-        "duration_ms",
-        "canonical_session_date",
-        "confidence",
-        "evidence_reasons_json",
-        "tool_counts_json",
-        "word_count",
-    ]
-    if has_legacy_payload:
-        columns.append("payload_json")
-    columns.extend(
-        [
-            "evidence_payload_json",
-            "inference_payload_json",
-            "search_text",
-            "inference_version",
-            "inference_family",
-        ]
+    return _with_legacy_payload_column(
+        _SESSION_PHASE_BASE_COLUMNS,
+        _TIMELINE_PAYLOAD_COLUMNS,
+        has_legacy_payload=has_legacy_payload,
     )
-    return tuple(columns)
 
 
 def session_phase_insert_values(
     record: SessionPhaseRecord,
     *,
     has_legacy_payload: bool,
-) -> tuple[object, ...]:
-    values: list[object] = [
+) -> SqlBindings:
+    base_values: list[SqlValue] = [
         record.phase_id,
         record.conversation_id,
         record.materializer_version,
@@ -312,21 +346,22 @@ def session_phase_insert_values(
         _json_or_none(record.tool_counts),
         record.word_count,
     ]
-    if has_legacy_payload:
-        values.append(_legacy_timeline_payload_json(record.evidence_payload, record.inference_payload))
-    values.extend(
-        [
-            _json_or_none(record.evidence_payload),
-            _json_or_none(record.inference_payload),
-            record.search_text,
-            record.inference_version,
-            record.inference_family,
-        ]
+    payload_values: tuple[SqlValue, ...] = (
+        _json_or_none(record.evidence_payload),
+        _json_or_none(record.inference_payload),
+        record.search_text,
+        record.inference_version,
+        record.inference_family,
     )
-    return tuple(values)
+    return _compose_bindings(
+        base_values,
+        payload_values,
+        has_legacy_payload=has_legacy_payload,
+        legacy_payload_json=_legacy_timeline_payload_json(record.evidence_payload, record.inference_payload),
+    )
 
 
-def work_thread_insert_values(record: WorkThreadRecord) -> tuple[object, ...]:
+def work_thread_insert_values(record: WorkThreadRecord) -> SqlBindings:
     return (
         record.thread_id,
         record.root_id,
@@ -348,7 +383,7 @@ def work_thread_insert_values(record: WorkThreadRecord) -> tuple[object, ...]:
     )
 
 
-def session_tag_rollup_insert_values(record: SessionTagRollupRecord) -> tuple[object, ...]:
+def session_tag_rollup_insert_values(record: SessionTagRollupRecord) -> SqlBindings:
     return (
         record.tag,
         record.bucket_day,
@@ -365,7 +400,7 @@ def session_tag_rollup_insert_values(record: SessionTagRollupRecord) -> tuple[ob
     )
 
 
-def day_session_summary_insert_values(record: DaySessionSummaryRecord) -> tuple[object, ...]:
+def day_session_summary_insert_values(record: DaySessionSummaryRecord) -> SqlBindings:
     return (
         record.day,
         record.provider_name,
@@ -396,11 +431,7 @@ def replace_session_profile_sync(conn: sqlite3.Connection, record: SessionProfil
     has_legacy_payload = table_has_column(conn, "session_profiles", "payload_json")
     columns = session_profile_insert_columns(has_legacy_payload=has_legacy_payload)
     conn.execute(
-        f"""
-        INSERT INTO session_profiles (
-            {", ".join(columns)}
-        ) VALUES ({_placeholders(columns)})
-        """,
+        build_insert_sql("session_profiles", columns),
         session_profile_insert_values(record, has_legacy_payload=has_legacy_payload),
     )
 
@@ -420,11 +451,7 @@ def replace_session_work_events_sync(
         has_legacy_payload = table_has_column(conn, "session_work_events", "payload_json")
         columns = session_work_event_insert_columns(has_legacy_payload=has_legacy_payload)
         conn.executemany(
-            f"""
-            INSERT INTO session_work_events (
-                {", ".join(columns)}
-            ) VALUES ({_placeholders(columns)})
-            """,
+            build_insert_sql("session_work_events", columns),
             [session_work_event_insert_values(record, has_legacy_payload=has_legacy_payload) for record in records],
         )
 
@@ -439,11 +466,7 @@ def replace_session_phases_sync(
         has_legacy_payload = table_has_column(conn, "session_phases", "payload_json")
         columns = session_phase_insert_columns(has_legacy_payload=has_legacy_payload)
         conn.executemany(
-            f"""
-            INSERT INTO session_phases (
-                {", ".join(columns)}
-            ) VALUES ({_placeholders(columns)})
-            """,
+            build_insert_sql("session_phases", columns),
             [session_phase_insert_values(record, has_legacy_payload=has_legacy_payload) for record in records],
         )
 
@@ -461,27 +484,28 @@ def replace_work_thread_sync(
     conn.execute("DELETE FROM work_threads WHERE thread_id = ?", (thread_id,))
     if record is not None:
         conn.execute(
-            """
-            INSERT INTO work_threads (
-                thread_id,
-                root_id,
-                materializer_version,
-                materialized_at,
-                start_time,
-                end_time,
-                dominant_repo,
-                session_ids_json,
-                session_count,
-                depth,
-                branch_count,
-                total_messages,
-                total_cost_usd,
-                wall_duration_ms,
-                work_event_breakdown_json,
-                payload_json,
-                search_text
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """,
+            build_insert_sql(
+                "work_threads",
+                (
+                    "thread_id",
+                    "root_id",
+                    "materializer_version",
+                    "materialized_at",
+                    "start_time",
+                    "end_time",
+                    "dominant_repo",
+                    "session_ids_json",
+                    "session_count",
+                    "depth",
+                    "branch_count",
+                    "total_messages",
+                    "total_cost_usd",
+                    "wall_duration_ms",
+                    "work_event_breakdown_json",
+                    "payload_json",
+                    "search_text",
+                ),
+            ),
             work_thread_insert_values(record),
         )
 
@@ -499,22 +523,23 @@ def replace_session_tag_rollup_rows_sync(
     )
     if records:
         conn.executemany(
-            """
-            INSERT INTO session_tag_rollups (
-                tag,
-                bucket_day,
-                provider_name,
-                materializer_version,
-                materialized_at,
-                source_updated_at,
-                source_sort_key,
-                conversation_count,
-                explicit_count,
-                auto_count,
-                repo_breakdown_json,
-                search_text
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """,
+            build_insert_sql(
+                "session_tag_rollups",
+                (
+                    "tag",
+                    "bucket_day",
+                    "provider_name",
+                    "materializer_version",
+                    "materialized_at",
+                    "source_updated_at",
+                    "source_sort_key",
+                    "conversation_count",
+                    "explicit_count",
+                    "auto_count",
+                    "repo_breakdown_json",
+                    "search_text",
+                ),
+            ),
             [session_tag_rollup_insert_values(record) for record in records],
         )
 
@@ -532,31 +557,33 @@ def replace_day_session_summaries_sync(
     )
     if records:
         conn.executemany(
-            """
-            INSERT INTO day_session_summaries (
-                day,
-                provider_name,
-                materializer_version,
-                materialized_at,
-                source_updated_at,
-                source_sort_key,
-                conversation_count,
-                total_cost_usd,
-                total_duration_ms,
-                total_wall_duration_ms,
-                total_messages,
-                total_words,
-                work_event_breakdown_json,
-                repos_active_json,
-                payload_json,
-                search_text
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """,
+            build_insert_sql(
+                "day_session_summaries",
+                (
+                    "day",
+                    "provider_name",
+                    "materializer_version",
+                    "materialized_at",
+                    "source_updated_at",
+                    "source_sort_key",
+                    "conversation_count",
+                    "total_cost_usd",
+                    "total_duration_ms",
+                    "total_wall_duration_ms",
+                    "total_messages",
+                    "total_words",
+                    "work_event_breakdown_json",
+                    "repos_active_json",
+                    "payload_json",
+                    "search_text",
+                ),
+            ),
             [day_session_summary_insert_values(record) for record in records],
         )
 
 
 __all__ = [
+    "build_insert_sql",
     "day_session_summary_insert_values",
     "replace_day_session_summaries_sync",
     "replace_session_phases_sync",

--- a/polylogue/storage/state_views.py
+++ b/polylogue/storage/state_views.py
@@ -9,9 +9,10 @@ from __future__ import annotations
 
 from collections.abc import ItemsView, KeysView, Mapping, ValuesView
 from dataclasses import dataclass
-from typing import TypedDict, cast
+from typing import cast
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
+from typing_extensions import TypedDict
 
 from polylogue.storage.store import AttachmentRecord, ConversationRecord, MessageRecord
 from polylogue.types import (

--- a/polylogue/surface_payloads.py
+++ b/polylogue/surface_payloads.py
@@ -7,9 +7,10 @@ import sys
 from collections.abc import Mapping, Sequence
 from datetime import datetime
 from enum import Enum
-from typing import TYPE_CHECKING, Literal, NotRequired, TypedDict, cast
+from typing import TYPE_CHECKING, Literal, NotRequired, cast
 
 from pydantic import BaseModel, ConfigDict, Field
+from typing_extensions import TypedDict
 
 from polylogue.schemas.json_types import JSONDocument, JSONValue
 

--- a/tests/infra/cli_subprocess.py
+++ b/tests/infra/cli_subprocess.py
@@ -16,7 +16,9 @@ import subprocess
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal, TypedDict
+from typing import Literal
+
+from typing_extensions import TypedDict
 
 
 @dataclass

--- a/tests/unit/cli/test_source_selection_helpers.py
+++ b/tests/unit/cli/test_source_selection_helpers.py
@@ -7,11 +7,12 @@ from collections.abc import Iterable
 from io import StringIO
 from pathlib import Path
 from types import SimpleNamespace
-from typing import TypedDict, cast
+from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import click
 import pytest
+from typing_extensions import TypedDict
 
 from polylogue.cli import helpers
 from polylogue.cli.types import AppEnv

--- a/tests/unit/core/test_filters_props.py
+++ b/tests/unit/core/test_filters_props.py
@@ -19,12 +19,13 @@ from __future__ import annotations
 from collections.abc import Callable
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Literal, NotRequired, TypeAlias, TypedDict
+from typing import Literal, NotRequired, TypeAlias
 from unittest.mock import patch
 
 import pytest
 from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
+from typing_extensions import TypedDict
 
 from polylogue.cli.filter_picker import pick_filter
 from polylogue.lib.conversation_models import Conversation

--- a/tests/unit/pipeline/test_resilience.py
+++ b/tests/unit/pipeline/test_resilience.py
@@ -12,11 +12,12 @@ from collections.abc import Sequence
 from datetime import datetime, timezone
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Literal, TypedDict
+from typing import Literal
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from hypothesis import HealthCheck, given, settings
+from typing_extensions import TypedDict
 
 from polylogue.config import Source
 from polylogue.lib.raw_payload_decode import JSONValue

--- a/tests/unit/sources/test_drive_source_client.py
+++ b/tests/unit/sources/test_drive_source_client.py
@@ -11,7 +11,7 @@ from typing import cast
 from unittest.mock import MagicMock
 
 import pytest
-from hypothesis import given, settings
+from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 
 from polylogue.sources.drive_gateway import DriveServiceGateway
@@ -169,7 +169,7 @@ def test_needs_download_contract(tmp_path: Path) -> None:
     st.lists(json_document_strategy(), min_size=0, max_size=8),
     st.sampled_from(("session.jsonl", "session.jsonl.txt", "session.ndjson", "SESSION.JSONL")),
 )
-@settings(max_examples=35)
+@settings(max_examples=35, suppress_health_check=[HealthCheck.too_slow])
 def test_parse_downloaded_json_payload_preserves_newline_delimited_documents(
     documents: list[dict[str, object]], name: str
 ) -> None:

--- a/tests/unit/sources/test_parser_crashlessness.py
+++ b/tests/unit/sources/test_parser_crashlessness.py
@@ -11,11 +11,12 @@ Unacceptable: AttributeError, IndexError, RecursionError (bugs).
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import TypedDict, cast
+from typing import cast
 
 import pytest
 from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
+from typing_extensions import TypedDict
 
 from polylogue.sources.parsers import chatgpt, claude, codex, drive
 from tests.infra.strategies.schema_driven import schema_conformant_payload

--- a/tests/unit/sources/test_source_laws.py
+++ b/tests/unit/sources/test_source_laws.py
@@ -9,13 +9,14 @@ import zipfile
 from collections.abc import Iterable, Mapping
 from io import BytesIO
 from pathlib import Path
-from typing import IO, BinaryIO, TypedDict
+from typing import IO, BinaryIO
 from unittest.mock import MagicMock
 
 import ijson
 import pytest
 from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
+from typing_extensions import TypedDict
 
 from polylogue.config import Source
 from polylogue.lib.roles import Role, normalize_role

--- a/tests/unit/storage/test_session_product_mapper_fallbacks.py
+++ b/tests/unit/storage/test_session_product_mapper_fallbacks.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from typing import cast
+
+import pytest
+
+from polylogue.storage.backends.queries.mappers_product_profiles import _row_to_session_profile_record
+from polylogue.storage.backends.queries.mappers_product_timelines import (
+    _row_to_session_phase_record,
+    _row_to_session_work_event_record,
+)
+
+
+def _make_row(columns: dict[str, object]) -> sqlite3.Row:
+    names = list(columns)
+    values = [columns[name] for name in names]
+
+    def _sqlite_type(value: object) -> str:
+        if isinstance(value, (bool, int)):
+            return "INTEGER"
+        if isinstance(value, float):
+            return "REAL"
+        return "TEXT"
+
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    column_defs = ", ".join(f'"{name}" {_sqlite_type(columns[name])}' for name in names)
+    placeholders = ", ".join("?" for _ in names)
+    conn.execute(f"CREATE TABLE t ({column_defs})")
+    conn.execute(f"INSERT INTO t VALUES ({placeholders})", values)
+    row = conn.execute("SELECT * FROM t").fetchone()
+    conn.close()
+    assert row is not None
+    return cast(sqlite3.Row, row)
+
+
+def _typed_payload_columns(mode: str, *names: str) -> dict[str, object]:
+    if mode == "missing":
+        return {}
+    return dict.fromkeys(names, "{}")
+
+
+@pytest.mark.parametrize("typed_payload_mode", ["missing", "empty"], ids=["missing-columns", "empty-columns"])
+def test_row_to_session_profile_record_falls_back_to_legacy_payloads(typed_payload_mode: str) -> None:
+    legacy_payload = {
+        "created_at": "2026-04-10T09:00:00+00:00",
+        "updated_at": "2026-04-10T09:05:00+00:00",
+        "first_message_at": "2026-04-10T09:00:00+00:00",
+        "last_message_at": "2026-04-10T09:05:00+00:00",
+        "canonical_session_date": "2026-04-10",
+        "message_count": 12,
+        "substantive_count": 9,
+        "attachment_count": 2,
+        "tool_use_count": 3,
+        "thinking_count": 1,
+        "word_count": 120,
+        "total_cost_usd": 1.25,
+        "total_duration_ms": 300000,
+        "wall_duration_ms": 305000,
+        "cost_is_estimated": True,
+        "tool_categories": {"read": 2, "edit": 1},
+        "repo_paths": ["/workspace/polylogue/app.py", "/workspace/polylogue/tests.py"],
+        "cwd_paths": ["/workspace/polylogue"],
+        "branch_names": ["feature/refactor/storage-lib-product-runtime-renewal"],
+        "file_paths_touched": ["/workspace/polylogue/app.py"],
+        "languages_detected": ["python"],
+        "tags": ["urgent"],
+        "is_continuation": True,
+        "parent_id": "conv-parent",
+        "repo_names": ["polylogue"],
+        "work_event_count": 4,
+        "phase_count": 2,
+        "engaged_duration_ms": 240000,
+        "engaged_minutes": 4.0,
+        "support_level": "strong",
+        "support_signals": ["user_turns", "action_events"],
+        "engaged_duration_source": "timeline",
+        "repo_inference_strength": "strong",
+        "auto_tags": ["bugfix"],
+        "work_events": [{"kind": "file_edit"}],
+        "phases": [{"kind": "implementation"}],
+    }
+    row = _make_row(
+        {
+            "conversation_id": "conv-profile-legacy",
+            "materialized_at": "2026-04-10T09:06:00+00:00",
+            "provider_name": "claude-code",
+            "title": "Legacy Profile",
+            "message_count": 12,
+            "repo_paths_json": json.dumps(["/workspace/polylogue/app.py", "/workspace/polylogue/tests.py"]),
+            "repo_names_json": json.dumps(["polylogue"]),
+            "tags_json": json.dumps(["urgent"]),
+            "auto_tags_json": json.dumps(["bugfix"]),
+            "search_text": "legacy profile search text",
+            "payload_json": json.dumps(legacy_payload),
+            **_typed_payload_columns(
+                typed_payload_mode,
+                "evidence_payload_json",
+                "inference_payload_json",
+                "enrichment_payload_json",
+            ),
+        }
+    )
+
+    record = _row_to_session_profile_record(row)
+
+    assert str(record.conversation_id) == "conv-profile-legacy"
+    assert record.provider_name == "claude-code"
+    assert record.title == "Legacy Profile"
+    assert record.repo_paths == ("/workspace/polylogue/app.py", "/workspace/polylogue/tests.py")
+    assert record.search_text == "legacy profile search text"
+
+    assert record.evidence_payload.created_at == "2026-04-10T09:00:00+00:00"
+    assert record.evidence_payload.tool_categories == {"read": 2, "edit": 1}
+    assert record.inference_payload.support_level == "strong"
+    assert record.inference_payload.auto_tags == ("bugfix",)
+    assert record.enrichment_payload.intent_summary == "Legacy Profile"
+    assert record.enrichment_payload.support_signals == ("user_turns", "action_events")
+    assert record.enrichment_payload.input_band_summary == {
+        "user_turns": 0,
+        "assistant_turns": 0,
+        "action_events": 0,
+        "touched_paths": 2,
+        "repo_names": 1,
+    }
+
+
+@pytest.mark.parametrize("typed_payload_mode", ["missing", "empty"], ids=["missing-columns", "empty-columns"])
+def test_row_to_session_work_event_record_falls_back_to_legacy_payloads(typed_payload_mode: str) -> None:
+    legacy_payload = {
+        "start_index": 3,
+        "end_index": 7,
+        "start_time": "2026-04-11T10:00:00+00:00",
+        "end_time": "2026-04-11T10:04:00+00:00",
+        "canonical_session_date": "2026-04-11",
+        "duration_ms": 240000,
+        "file_paths": ["/workspace/polylogue/app.py"],
+        "tools_used": ["read"],
+        "confidence": 0.91,
+        "evidence": ["read app.py before patching"],
+    }
+    row = _make_row(
+        {
+            "event_id": "event-legacy",
+            "conversation_id": "conv-event-legacy",
+            "materialized_at": "2026-04-11T10:05:00+00:00",
+            "provider_name": "claude-code",
+            "event_index": 1,
+            "kind": "file_edit",
+            "summary": "Patched the failing test path",
+            "search_text": "legacy work event search text",
+            "payload_json": json.dumps(legacy_payload),
+            **_typed_payload_columns(typed_payload_mode, "evidence_payload_json", "inference_payload_json"),
+        }
+    )
+
+    record = _row_to_session_work_event_record(row)
+
+    assert record.event_id == "event-legacy"
+    assert str(record.conversation_id) == "conv-event-legacy"
+    assert record.kind == "file_edit"
+    assert record.summary == "Patched the failing test path"
+    assert record.search_text == "legacy work event search text"
+
+    assert record.evidence_payload.start_index == 3
+    assert record.evidence_payload.duration_ms == 240000
+    assert record.evidence_payload.file_paths == ("/workspace/polylogue/app.py",)
+    assert record.inference_payload.kind == "file_edit"
+    assert record.inference_payload.summary == "Patched the failing test path"
+    assert record.inference_payload.confidence == pytest.approx(0.91)
+    assert record.inference_payload.evidence == ("read app.py before patching",)
+
+
+@pytest.mark.parametrize("typed_payload_mode", ["missing", "empty"], ids=["missing-columns", "empty-columns"])
+def test_row_to_session_phase_record_falls_back_to_legacy_payloads(typed_payload_mode: str) -> None:
+    legacy_payload = {
+        "start_time": "2026-04-12T11:00:00+00:00",
+        "end_time": "2026-04-12T11:06:00+00:00",
+        "canonical_session_date": "2026-04-12",
+        "start_index": 2,
+        "end_index": 8,
+        "duration_ms": 360000,
+        "tool_counts": {"read": 1, "edit": 1},
+        "word_count": 180,
+        "confidence": 0.73,
+        "evidence": ["tool-use burst", "assistant outcome"],
+    }
+    row = _make_row(
+        {
+            "phase_id": "phase-legacy",
+            "conversation_id": "conv-phase-legacy",
+            "materialized_at": "2026-04-12T11:07:00+00:00",
+            "provider_name": "claude-code",
+            "phase_index": 0,
+            "kind": "implementation",
+            "search_text": "legacy phase search text",
+            "payload_json": json.dumps(legacy_payload),
+            **_typed_payload_columns(typed_payload_mode, "evidence_payload_json", "inference_payload_json"),
+        }
+    )
+
+    record = _row_to_session_phase_record(row)
+
+    assert record.phase_id == "phase-legacy"
+    assert str(record.conversation_id) == "conv-phase-legacy"
+    assert record.kind == "implementation"
+    assert record.search_text == "legacy phase search text"
+
+    assert record.evidence_payload.message_range == (2, 8)
+    assert record.evidence_payload.tool_counts == {"read": 1, "edit": 1}
+    assert record.evidence_payload.word_count == 180
+    assert record.inference_payload.confidence == pytest.approx(0.73)
+    assert record.inference_payload.evidence == ("tool-use burst", "assistant outcome")

--- a/tests/unit/storage/test_store_ops.py
+++ b/tests/unit/storage/test_store_ops.py
@@ -12,13 +12,14 @@ from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any, TypedDict, cast
+from typing import Any, cast
 from unittest.mock import AsyncMock
 
 import pytest
 from hypothesis import given, settings
 from hypothesis import strategies as st
 from pydantic import ValidationError
+from typing_extensions import TypedDict
 
 from polylogue.lib.conversation_models import Conversation
 from polylogue.lib.messages import MessageCollection


### PR DESCRIPTION
Ref #237
Ref #225
Ref #222

## Summary
- rebuild session-product insert packing around shared typed SQL binding helpers instead of repeated `tuple[object, ...]` assembly
- extract shared legacy payload hydrators for session profile, work-event, and phase row mappers
- add focused mapper fallback tests covering both missing-column and empty-JSON typed-payload cases

## Problem
The session-product persistence seam still carried older path-dependent structure. On the write side, profile/work-event/phase rows each repeated their own insert column/value assembly with broad `object` tuples. On the read side, the profile and timeline mappers each reconstructed legacy `payload_json` fallbacks inline, duplicating row parsing and defaulting rules.

## Solution
- introduced explicit `SqlValue` / `SqlBindings` packing helpers plus shared insert SQL generation in `polylogue/storage/session_product_storage.py`
- rewired the async profile/timeline write queries to consume those shared insert builders instead of hand-assembling SQL placeholders locally
- added `polylogue/storage/backends/queries/mappers_product_legacy.py` as the single typed fallback surface for hydrating legacy session profile, work-event, and phase payloads
- slimmed `mappers_product_profiles.py` and `mappers_product_timelines.py` so they prefer modern payload columns when present and delegate legacy reconstruction to the shared helper otherwise
- added `tests/unit/storage/test_session_product_mapper_fallbacks.py` to lock the fallback contract for missing and empty typed payload columns

## Verification
- `ruff check polylogue/storage/session_product_storage.py polylogue/storage/backends/queries/mappers_product_legacy.py polylogue/storage/backends/queries/mappers_product_profiles.py polylogue/storage/backends/queries/mappers_product_timelines.py polylogue/storage/backends/queries/session_product_profile_writes.py polylogue/storage/backends/queries/session_product_timeline_writes.py tests/unit/storage/test_session_product_mapper_fallbacks.py`
- `mypy polylogue/storage/session_product_storage.py polylogue/storage/backends/queries/mappers_product_legacy.py polylogue/storage/backends/queries/mappers_product_profiles.py polylogue/storage/backends/queries/mappers_product_timelines.py polylogue/storage/backends/queries/session_product_profile_writes.py polylogue/storage/backends/queries/session_product_timeline_writes.py tests/unit/storage/test_session_product_mapper_fallbacks.py`
- `pytest -q tests/unit/storage/test_session_product_profiles.py tests/unit/storage/test_session_product_timeline_rows.py tests/unit/storage/test_session_product_mapper_fallbacks.py`
- `devtools verify`
