### PR TITLE
refactor: renew archive search result-shape contracts

### DIFF
--- a/devtools/pipeline_probe.py
+++ b/devtools/pipeline_probe.py
@@ -15,7 +15,9 @@ import tempfile
 from collections.abc import Iterator
 from contextlib import contextmanager, redirect_stdout
 from pathlib import Path
-from typing import NotRequired, TypeAlias, TypedDict
+from typing import NotRequired, TypeAlias
+
+from typing_extensions import TypedDict
 
 from polylogue.config import Config, Source
 from polylogue.paths import blob_store_root, db_path

--- a/devtools/project_motd.py
+++ b/devtools/project_motd.py
@@ -11,7 +11,9 @@ import re
 import subprocess
 import sys
 from pathlib import Path
-from typing import TextIO, TypedDict
+from typing import TextIO
+
+from typing_extensions import TypedDict
 
 from devtools.command_catalog import control_plane_command
 from devtools.generated_surfaces import GENERATED_SURFACES, GeneratedSurface

--- a/polylogue/cli/embed_stats.py
+++ b/polylogue/cli/embed_stats.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Protocol, TypedDict
+from typing import TYPE_CHECKING, Protocol
 
 import click
+from typing_extensions import TypedDict
 
 if TYPE_CHECKING:
     from polylogue.config import Config

--- a/polylogue/pipeline/run_finalization.py
+++ b/polylogue/pipeline/run_finalization.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import time
-from typing import TYPE_CHECKING, TypedDict, cast
+from typing import TYPE_CHECKING, cast
 from uuid import uuid4
+
+from typing_extensions import TypedDict
 
 from polylogue.pipeline.run_support import write_run_json
 from polylogue.storage.backends import create_backend

--- a/polylogue/pipeline/run_stages.py
+++ b/polylogue/pipeline/run_stages.py
@@ -4,7 +4,9 @@ import asyncio
 from collections.abc import AsyncIterator, Iterable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, TypedDict
+from typing import TYPE_CHECKING
+
+from typing_extensions import TypedDict
 
 from polylogue.config import Config
 from polylogue.pipeline.run_support import PARSE_STAGES

--- a/polylogue/pipeline/semantic_capture.py
+++ b/polylogue/pipeline/semantic_capture.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from typing import NotRequired, TypedDict, cast
+from typing import NotRequired, cast
+
+from typing_extensions import TypedDict
 
 from polylogue.lib.payload_coercion import is_payload_mapping, mapping_or_empty, optional_string
 from polylogue.lib.raw_payload_decode import JSONRecord, JSONValue

--- a/polylogue/pipeline/services/indexing.py
+++ b/polylogue/pipeline/services/indexing.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import sqlite3
 from collections.abc import AsyncIterable, AsyncIterator, Callable, Iterable
-from typing import TYPE_CHECKING, TypedDict
+from typing import TYPE_CHECKING
 
 import aiosqlite
+from typing_extensions import TypedDict
 
 from polylogue.logging import get_logger
 from polylogue.storage.action_event_rebuild_runtime import (

--- a/polylogue/pipeline/services/ingest_worker.py
+++ b/polylogue/pipeline/services/ingest_worker.py
@@ -14,7 +14,9 @@ import re
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, TypeAlias, TypedDict, cast
+from typing import TYPE_CHECKING, TypeAlias, cast
+
+from typing_extensions import TypedDict
 
 from polylogue.lib.artifact_taxonomy import classify_artifact
 from polylogue.lib.branch_type import BranchType

--- a/polylogue/sources/assembly.py
+++ b/polylogue/sources/assembly.py
@@ -9,7 +9,9 @@ from __future__ import annotations
 from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Protocol, TypeAlias, TypedDict
+from typing import TYPE_CHECKING, Any, Protocol, TypeAlias
+
+from typing_extensions import TypedDict
 
 from polylogue.types import Provider
 

--- a/polylogue/storage/backends/async_sqlite_archive.py
+++ b/polylogue/storage/backends/async_sqlite_archive.py
@@ -10,6 +10,7 @@ from polylogue.storage.backends.queries import attachments as attachments_q
 from polylogue.storage.backends.queries import conversations as conversations_q
 from polylogue.storage.backends.queries import messages as messages_q
 from polylogue.storage.backends.queries.stats import AggregateMessageStats
+from polylogue.storage.search_models import ConversationSearchResult
 from polylogue.storage.session_product_runtime import SessionProductStatusSnapshot
 from polylogue.storage.store import AttachmentRecord, ContentBlockRecord, ConversationRecord, MessageRecord
 
@@ -146,6 +147,15 @@ class SQLiteArchiveMixin:
     async def search_conversations(self, query: str, limit: int = 100, providers: list[str] | None = None) -> list[str]:
         """Search conversations using the canonical ranked FTS conversation query."""
         return await self.queries.search_conversations(query, limit, providers)
+
+    async def search_conversation_hits(
+        self,
+        query: str,
+        limit: int = 100,
+        providers: list[str] | None = None,
+    ) -> ConversationSearchResult:
+        """Search conversations while preserving ordered conversation-hit metadata."""
+        return await self.queries.search_conversation_hits(query, limit, providers)
 
     async def iter_messages(
         self,

--- a/polylogue/storage/backends/queries/conversations.py
+++ b/polylogue/storage/backends/queries/conversations.py
@@ -22,7 +22,9 @@ from polylogue.storage.backends.queries.conversations_reads import (
     list_conversations_by_parent,
 )
 from polylogue.storage.backends.queries.conversations_search import (
+    search_action_conversation_hits,
     search_action_conversations,
+    search_conversation_hits,
     search_conversations,
 )
 from polylogue.storage.backends.queries.conversations_writes import (
@@ -48,7 +50,9 @@ __all__ = [
     "list_tags",
     "resolve_id",
     "save_conversation_record",
+    "search_action_conversation_hits",
     "search_action_conversations",
+    "search_conversation_hits",
     "search_conversations",
     "set_metadata",
     "update_metadata_raw",

--- a/polylogue/storage/backends/queries/conversations_search.py
+++ b/polylogue/storage/backends/queries/conversations_search.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import aiosqlite
 
 from polylogue.maintenance_targets import build_maintenance_target_catalog
+from polylogue.storage.search_models import ConversationSearchResult
 
 _MAINTENANCE_TARGET_CATALOG = build_maintenance_target_catalog()
 _MESSAGE_SEARCH_REPAIR_HINT = _MAINTENANCE_TARGET_CATALOG.repair_hint(("dangling_fts",), include_run_all=True)
@@ -14,12 +15,12 @@ _ACTION_SEARCH_REPAIR_HINT = _MAINTENANCE_TARGET_CATALOG.repair_hint(
 )
 
 
-async def search_conversations(
+async def search_conversation_hits(
     conn: aiosqlite.Connection,
     query: str,
     limit: int = 100,
     providers: list[str] | None = None,
-) -> list[str]:
+) -> ConversationSearchResult:
     from polylogue.errors import DatabaseError
     from polylogue.storage.fts_lifecycle import message_fts_readiness_async
 
@@ -37,20 +38,29 @@ async def search_conversations(
         scope_names=providers,
     )
     if query_spec is None:
-        return []
+        return ConversationSearchResult(hits=[])
 
     sql, params = query_spec
     cursor = await conn.execute(sql, params)
     rows = await cursor.fetchall()
-    return [str(row["conversation_id"]) for row in rows]
+    return ConversationSearchResult.from_ids([str(row["conversation_id"]) for row in rows])
 
 
-async def search_action_conversations(
+async def search_conversations(
     conn: aiosqlite.Connection,
     query: str,
     limit: int = 100,
     providers: list[str] | None = None,
 ) -> list[str]:
+    return (await search_conversation_hits(conn, query, limit, providers)).conversation_ids()
+
+
+async def search_action_conversation_hits(
+    conn: aiosqlite.Connection,
+    query: str,
+    limit: int = 100,
+    providers: list[str] | None = None,
+) -> ConversationSearchResult:
     from polylogue.errors import DatabaseError
     from polylogue.storage.action_event_status import action_event_read_model_status_async
     from polylogue.storage.search import build_ranked_action_search_query
@@ -67,12 +77,26 @@ async def search_action_conversations(
         scope_names=providers,
     )
     if query_spec is None:
-        return []
+        return ConversationSearchResult(hits=[])
 
     sql, params = query_spec
     cursor = await conn.execute(sql, params)
     rows = await cursor.fetchall()
-    return [str(row["conversation_id"]) for row in rows]
+    return ConversationSearchResult.from_ids([str(row["conversation_id"]) for row in rows])
 
 
-__all__ = ["search_action_conversations", "search_conversations"]
+async def search_action_conversations(
+    conn: aiosqlite.Connection,
+    query: str,
+    limit: int = 100,
+    providers: list[str] | None = None,
+) -> list[str]:
+    return (await search_action_conversation_hits(conn, query, limit, providers)).conversation_ids()
+
+
+__all__ = [
+    "search_action_conversation_hits",
+    "search_action_conversations",
+    "search_conversation_hits",
+    "search_conversations",
+]

--- a/polylogue/storage/backends/queries/stats.py
+++ b/polylogue/storage/backends/queries/stats.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-from typing import TypedDict
-
 import aiosqlite
+from typing_extensions import TypedDict
 
 from polylogue.storage.store import MessageRecord
 

--- a/polylogue/storage/backends/query_store_archive.py
+++ b/polylogue/storage/backends/query_store_archive.py
@@ -14,6 +14,7 @@ from polylogue.storage.backends.queries import messages as messages_q
 from polylogue.storage.backends.queries import stats as stats_q
 from polylogue.storage.backends.queries.stats import AggregateMessageStats
 from polylogue.storage.query_models import ConversationRecordQuery
+from polylogue.storage.search_models import ConversationSearchResult
 from polylogue.storage.store import (
     AttachmentRecord,
     ContentBlockRecord,
@@ -64,14 +65,30 @@ class SQLiteQueryStoreArchiveMixin:
             return await conversations_q.resolve_id(conn, id_prefix)
 
     async def search_conversations(self, query: str, limit: int = 100, providers: list[str] | None = None) -> list[str]:
-        async with self._connection_factory() as conn:
-            return await conversations_q.search_conversations(conn, query, limit, providers)
+        return (await self.search_conversation_hits(query, limit=limit, providers=providers)).conversation_ids()
 
     async def search_action_conversations(
         self, query: str, limit: int = 100, providers: list[str] | None = None
     ) -> list[str]:
+        return (await self.search_action_conversation_hits(query, limit=limit, providers=providers)).conversation_ids()
+
+    async def search_conversation_hits(
+        self,
+        query: str,
+        limit: int = 100,
+        providers: list[str] | None = None,
+    ) -> ConversationSearchResult:
         async with self._connection_factory() as conn:
-            return await conversations_q.search_action_conversations(conn, query, limit, providers)
+            return await conversations_q.search_conversation_hits(conn, query, limit, providers)
+
+    async def search_action_conversation_hits(
+        self,
+        query: str,
+        limit: int = 100,
+        providers: list[str] | None = None,
+    ) -> ConversationSearchResult:
+        async with self._connection_factory() as conn:
+            return await conversations_q.search_action_conversation_hits(conn, query, limit, providers)
 
     async def get_messages(self, conversation_id: str) -> list[MessageRecord]:
         async with self._connection_factory() as conn:

--- a/polylogue/storage/query_models.py
+++ b/polylogue/storage/query_models.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, replace
-from typing import TypedDict
+
+from typing_extensions import TypedDict
 
 
 class ConversationListQueryKwargs(TypedDict):

--- a/polylogue/storage/repository_archive_search.py
+++ b/polylogue/storage/repository_archive_search.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from polylogue.lib.conversation_models import Conversation, ConversationSummary
     from polylogue.storage.backends.query_store import SQLiteQueryStore
+    from polylogue.storage.search_models import ConversationSearchResult
     from polylogue.storage.store import ConversationRecord
 
 
@@ -30,8 +31,8 @@ class RepositoryArchiveSearchMixin:
     ) -> builtins.list[ConversationSummary]:
         from polylogue.storage.hydrators import conversation_summary_from_record
 
-        ids, records = await self._search_records(query, limit=limit, providers=providers)
-        if not ids:
+        hits, records = await self._search_records(query, limit=limit, providers=providers)
+        if not hits.hits:
             return []
         return [conversation_summary_from_record(record) for record in records]
 
@@ -41,8 +42,8 @@ class RepositoryArchiveSearchMixin:
         limit: int = 20,
         providers: builtins.list[str] | None = None,
     ) -> builtins.list[Conversation]:
-        ids, records = await self._search_records(query, limit=limit, providers=providers)
-        return await self._hydrate_conversations(records, ordered_ids=ids)
+        hits, records = await self._search_records(query, limit=limit, providers=providers)
+        return await self._hydrate_conversations(records, ordered_ids=hits.conversation_ids())
 
     async def search_actions(
         self,
@@ -50,8 +51,8 @@ class RepositoryArchiveSearchMixin:
         limit: int = 20,
         providers: builtins.list[str] | None = None,
     ) -> builtins.list[Conversation]:
-        ids, records = await self._search_action_records(query, limit=limit, providers=providers)
-        return await self._hydrate_conversations(records, ordered_ids=ids)
+        hits, records = await self._search_action_records(query, limit=limit, providers=providers)
+        return await self._hydrate_conversations(records, ordered_ids=hits.conversation_ids())
 
     async def _search_records(
         self,
@@ -59,13 +60,12 @@ class RepositoryArchiveSearchMixin:
         *,
         limit: int,
         providers: builtins.list[str] | None,
-    ) -> tuple[builtins.list[str], builtins.list[ConversationRecord]]:
-        ids = await self.queries.search_conversations(query, limit=limit, providers=providers)
-        if not ids:
-            return [], []
-        records = await self.queries.get_conversations_batch(ids)
-        by_id = {str(record.conversation_id): record for record in records}
-        return ids, [by_id[conversation_id] for conversation_id in ids if conversation_id in by_id]
+    ) -> tuple[ConversationSearchResult, builtins.list[ConversationRecord]]:
+        hits = await self.queries.search_conversation_hits(query, limit=limit, providers=providers)
+        if not hits.hits:
+            return hits, []
+        records = await self.queries.get_conversations_batch(hits.conversation_ids())
+        return hits, records
 
     async def _search_action_records(
         self,
@@ -73,13 +73,12 @@ class RepositoryArchiveSearchMixin:
         *,
         limit: int,
         providers: builtins.list[str] | None,
-    ) -> tuple[builtins.list[str], builtins.list[ConversationRecord]]:
-        ids = await self.queries.search_action_conversations(query, limit=limit, providers=providers)
-        if not ids:
-            return [], []
-        records = await self.queries.get_conversations_batch(ids)
-        by_id = {str(record.conversation_id): record for record in records}
-        return ids, [by_id[conversation_id] for conversation_id in ids if conversation_id in by_id]
+    ) -> tuple[ConversationSearchResult, builtins.list[ConversationRecord]]:
+        hits = await self.queries.search_action_conversation_hits(query, limit=limit, providers=providers)
+        if not hits.hits:
+            return hits, []
+        records = await self.queries.get_conversations_batch(hits.conversation_ids())
+        return hits, records
 
 
 __all__ = ["RepositoryArchiveSearchMixin"]

--- a/polylogue/storage/search_models.py
+++ b/polylogue/storage/search_models.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -23,4 +24,33 @@ class SearchResult:
     hits: list[SearchHit]
 
 
-__all__ = ["SearchHit", "SearchResult"]
+@dataclass(frozen=True)
+class ConversationSearchHit:
+    conversation_id: str
+    rank: int
+    score: float | None = None
+
+
+@dataclass(frozen=True)
+class ConversationSearchResult:
+    hits: list[ConversationSearchHit]
+
+    @classmethod
+    def from_ids(cls, conversation_ids: Sequence[str]) -> ConversationSearchResult:
+        return cls(
+            hits=[
+                ConversationSearchHit(conversation_id=conversation_id, rank=rank)
+                for rank, conversation_id in enumerate(conversation_ids, start=1)
+            ]
+        )
+
+    def conversation_ids(self) -> list[str]:
+        return [hit.conversation_id for hit in self.hits]
+
+
+__all__ = [
+    "ConversationSearchHit",
+    "ConversationSearchResult",
+    "SearchHit",
+    "SearchResult",
+]

--- a/polylogue/storage/search_providers/hybrid.py
+++ b/polylogue/storage/search_providers/hybrid.py
@@ -17,7 +17,11 @@ from polylogue.storage.backends.connection import (
 from polylogue.storage.backends.connection import (
     open_read_connection,
 )
-from polylogue.storage.search_providers.hybrid_conversations import _resolve_ranked_conversation_ids
+from polylogue.storage.search_models import ConversationSearchResult
+from polylogue.storage.search_providers.hybrid_conversations import (
+    _resolve_ranked_conversation_hits,
+    _resolve_ranked_conversation_ids,
+)
 from polylogue.storage.search_providers.hybrid_factory import create_hybrid_provider
 
 if TYPE_CHECKING:
@@ -165,17 +169,26 @@ class HybridSearchProvider:
         Returns:
             List of conversation IDs, ordered by best-matching message score.
         """
+        return self.search_conversation_hits(query, limit=limit, providers=providers).conversation_ids()
+
+    def search_conversation_hits(
+        self,
+        query: str,
+        limit: int = 20,
+        providers: list[str] | None = None,
+    ) -> ConversationSearchResult:
+        """Search and return ordered conversation hits."""
         if limit <= 0:
-            return []
+            return ConversationSearchResult(hits=[])
 
         # Get message-level results (scored for ranking)
         message_results = self.search_scored(query, limit=limit * 3)
 
         if not message_results:
-            return []
+            return ConversationSearchResult(hits=[])
 
         with open_connection(self.fts_provider.db_path) as conn:
-            return _resolve_ranked_conversation_ids(
+            return _resolve_ranked_conversation_hits(
                 conn,
                 message_results=message_results,
                 limit=limit,
@@ -185,6 +198,7 @@ class HybridSearchProvider:
 
 __all__ = [
     "HybridSearchProvider",
+    "_resolve_ranked_conversation_hits",
     "_resolve_ranked_conversation_ids",
     "create_hybrid_provider",
     "reciprocal_rank_fusion",

--- a/polylogue/storage/search_providers/hybrid_conversations.py
+++ b/polylogue/storage/search_providers/hybrid_conversations.py
@@ -5,18 +5,19 @@ from __future__ import annotations
 from sqlite3 import Connection
 
 from polylogue.storage.backends.connection import _build_provider_scope_filter
+from polylogue.storage.search_models import ConversationSearchResult
 
 
-def _resolve_ranked_conversation_ids(
+def _resolve_ranked_conversation_hits(
     conn: Connection,
     *,
     message_results: list[tuple[str, float]],
     limit: int,
     scope_names: list[str] | None,
-) -> list[str]:
+) -> ConversationSearchResult:
     """Resolve ranked message hits into unique conversation IDs in SQL."""
     if not message_results or limit <= 0:
-        return []
+        return ConversationSearchResult(hits=[])
 
     values_sql = ", ".join("(?, ?)" for _ in message_results)
     params: list[object] = []
@@ -65,7 +66,22 @@ def _resolve_ranked_conversation_ids(
         """,
         tuple(params),
     ).fetchall()
-    return [row["conversation_id"] for row in rows]
+    return ConversationSearchResult.from_ids([row["conversation_id"] for row in rows])
 
 
-__all__ = ["_resolve_ranked_conversation_ids"]
+def _resolve_ranked_conversation_ids(
+    conn: Connection,
+    *,
+    message_results: list[tuple[str, float]],
+    limit: int,
+    scope_names: list[str] | None,
+) -> list[str]:
+    return _resolve_ranked_conversation_hits(
+        conn,
+        message_results=message_results,
+        limit=limit,
+        scope_names=scope_names,
+    ).conversation_ids()
+
+
+__all__ = ["_resolve_ranked_conversation_hits", "_resolve_ranked_conversation_ids"]

--- a/polylogue/storage/session_product_runtime.py
+++ b/polylogue/storage/session_product_runtime.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal, TypeAlias, TypedDict
+from typing import Literal, TypeAlias
+
+from typing_extensions import TypedDict
 
 ProviderDayGroup: TypeAlias = tuple[str, str]
 SessionProductReadyFlag: TypeAlias = Literal[

--- a/polylogue/storage/state_views.py
+++ b/polylogue/storage/state_views.py
@@ -9,9 +9,10 @@ from __future__ import annotations
 
 from collections.abc import ItemsView, KeysView, Mapping, ValuesView
 from dataclasses import dataclass
-from typing import TypedDict, cast
+from typing import cast
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
+from typing_extensions import TypedDict
 
 from polylogue.storage.store import AttachmentRecord, ConversationRecord, MessageRecord
 from polylogue.types import (

--- a/polylogue/surface_payloads.py
+++ b/polylogue/surface_payloads.py
@@ -7,9 +7,10 @@ import sys
 from collections.abc import Mapping, Sequence
 from datetime import datetime
 from enum import Enum
-from typing import TYPE_CHECKING, Literal, NotRequired, TypedDict, cast
+from typing import TYPE_CHECKING, Literal, NotRequired, cast
 
 from pydantic import BaseModel, ConfigDict, Field
+from typing_extensions import TypedDict
 
 from polylogue.schemas.json_types import JSONDocument, JSONValue
 

--- a/tests/infra/cli_subprocess.py
+++ b/tests/infra/cli_subprocess.py
@@ -16,7 +16,9 @@ import subprocess
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal, TypedDict
+from typing import Literal
+
+from typing_extensions import TypedDict
 
 
 @dataclass

--- a/tests/unit/cli/test_source_selection_helpers.py
+++ b/tests/unit/cli/test_source_selection_helpers.py
@@ -7,11 +7,12 @@ from collections.abc import Iterable
 from io import StringIO
 from pathlib import Path
 from types import SimpleNamespace
-from typing import TypedDict, cast
+from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import click
 import pytest
+from typing_extensions import TypedDict
 
 from polylogue.cli import helpers
 from polylogue.cli.types import AppEnv

--- a/tests/unit/core/test_filters_props.py
+++ b/tests/unit/core/test_filters_props.py
@@ -19,12 +19,13 @@ from __future__ import annotations
 from collections.abc import Callable
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Literal, NotRequired, TypeAlias, TypedDict
+from typing import Literal, NotRequired, TypeAlias
 from unittest.mock import patch
 
 import pytest
 from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
+from typing_extensions import TypedDict
 
 from polylogue.cli.filter_picker import pick_filter
 from polylogue.lib.conversation_models import Conversation

--- a/tests/unit/pipeline/test_resilience.py
+++ b/tests/unit/pipeline/test_resilience.py
@@ -12,11 +12,12 @@ from collections.abc import Sequence
 from datetime import datetime, timezone
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Literal, TypedDict
+from typing import Literal
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from hypothesis import HealthCheck, given, settings
+from typing_extensions import TypedDict
 
 from polylogue.config import Source
 from polylogue.lib.raw_payload_decode import JSONValue

--- a/tests/unit/sources/test_drive_source_client.py
+++ b/tests/unit/sources/test_drive_source_client.py
@@ -11,7 +11,7 @@ from typing import cast
 from unittest.mock import MagicMock
 
 import pytest
-from hypothesis import given, settings
+from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 
 from polylogue.sources.drive_gateway import DriveServiceGateway
@@ -169,7 +169,7 @@ def test_needs_download_contract(tmp_path: Path) -> None:
     st.lists(json_document_strategy(), min_size=0, max_size=8),
     st.sampled_from(("session.jsonl", "session.jsonl.txt", "session.ndjson", "SESSION.JSONL")),
 )
-@settings(max_examples=35)
+@settings(max_examples=35, suppress_health_check=[HealthCheck.too_slow])
 def test_parse_downloaded_json_payload_preserves_newline_delimited_documents(
     documents: list[dict[str, object]], name: str
 ) -> None:

--- a/tests/unit/sources/test_parser_crashlessness.py
+++ b/tests/unit/sources/test_parser_crashlessness.py
@@ -11,11 +11,12 @@ Unacceptable: AttributeError, IndexError, RecursionError (bugs).
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import TypedDict, cast
+from typing import cast
 
 import pytest
 from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
+from typing_extensions import TypedDict
 
 from polylogue.sources.parsers import chatgpt, claude, codex, drive
 from tests.infra.strategies.schema_driven import schema_conformant_payload

--- a/tests/unit/sources/test_source_laws.py
+++ b/tests/unit/sources/test_source_laws.py
@@ -9,13 +9,14 @@ import zipfile
 from collections.abc import Iterable, Mapping
 from io import BytesIO
 from pathlib import Path
-from typing import IO, BinaryIO, TypedDict
+from typing import IO, BinaryIO
 from unittest.mock import MagicMock
 
 import ijson
 import pytest
 from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
+from typing_extensions import TypedDict
 
 from polylogue.config import Source
 from polylogue.lib.roles import Role, normalize_role

--- a/tests/unit/storage/test_archive_search_contracts.py
+++ b/tests/unit/storage/test_archive_search_contracts.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from polylogue.lib.conversation_models import Conversation
+from polylogue.lib.messages import MessageCollection
+from polylogue.storage.repository_archive_search import RepositoryArchiveSearchMixin
+from polylogue.storage.search_models import ConversationSearchResult
+from polylogue.storage.search_providers.hybrid_conversations import (
+    _resolve_ranked_conversation_hits,
+)
+from polylogue.storage.store import ConversationRecord
+from polylogue.types import ContentHash, ConversationId, Provider
+
+
+def _conversation_record(conversation_id: str, *, title: str, provider_name: str = "chatgpt") -> ConversationRecord:
+    return ConversationRecord(
+        conversation_id=ConversationId(conversation_id),
+        provider_name=provider_name,
+        provider_conversation_id=f"provider-{conversation_id}",
+        title=title,
+        content_hash=ContentHash(f"hash-{conversation_id}"),
+    )
+
+
+@dataclass
+class _FakeQueries:
+    hits: ConversationSearchResult
+    records_by_id: dict[str, ConversationRecord]
+    last_batch_ids: list[str] | None = None
+
+    async def search_conversation_hits(
+        self,
+        query: str,
+        *,
+        limit: int,
+        providers: list[str] | None,
+    ) -> ConversationSearchResult:
+        return self.hits
+
+    async def search_action_conversation_hits(
+        self,
+        query: str,
+        *,
+        limit: int,
+        providers: list[str] | None,
+    ) -> ConversationSearchResult:
+        return self.hits
+
+    async def get_conversations_batch(self, ids: list[str]) -> list[ConversationRecord]:
+        self.last_batch_ids = ids
+        return [self.records_by_id[conversation_id] for conversation_id in ids]
+
+
+class _FakeRepo(RepositoryArchiveSearchMixin):
+    queries: Any
+
+    def __init__(self, queries: _FakeQueries) -> None:
+        self.queries = queries
+        self.ordered_ids_seen: list[str] | None = None
+
+    async def _hydrate_conversations(
+        self,
+        conversation_records: list[ConversationRecord],
+        *,
+        ordered_ids: list[str] | None = None,
+    ) -> list[Conversation]:
+        self.ordered_ids_seen = ordered_ids
+        return [
+            Conversation(
+                id=ConversationId(str(record.conversation_id)),
+                provider=Provider.from_string(record.provider_name),
+                messages=MessageCollection.empty(),
+                title=record.title,
+            )
+            for record in conversation_records
+        ]
+
+
+def _memory_conn() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute("CREATE TABLE conversations (conversation_id TEXT PRIMARY KEY, provider_name TEXT NOT NULL)")
+    conn.execute("CREATE TABLE messages (message_id TEXT PRIMARY KEY, conversation_id TEXT NOT NULL)")
+    return conn
+
+
+def test_resolve_ranked_conversation_hits_preserves_order_and_provider_scope() -> None:
+    conn = _memory_conn()
+    conn.executemany(
+        "INSERT INTO conversations(conversation_id, provider_name) VALUES (?, ?)",
+        [
+            ("conv-a", "chatgpt"),
+            ("conv-b", "claude"),
+        ],
+    )
+    conn.executemany(
+        "INSERT INTO messages(message_id, conversation_id) VALUES (?, ?)",
+        [
+            ("msg-a1", "conv-a"),
+            ("msg-a2", "conv-a"),
+            ("msg-b1", "conv-b"),
+        ],
+    )
+
+    hits = _resolve_ranked_conversation_hits(
+        conn,
+        message_results=[("msg-b1", 0.9), ("msg-a1", 0.8), ("msg-a2", 0.7)],
+        limit=10,
+        scope_names=None,
+    )
+    assert hits.conversation_ids() == ["conv-b", "conv-a"]
+    assert [hit.rank for hit in hits.hits] == [1, 2]
+
+    scoped_hits = _resolve_ranked_conversation_hits(
+        conn,
+        message_results=[("msg-b1", 0.9), ("msg-a1", 0.8), ("msg-a2", 0.7)],
+        limit=10,
+        scope_names=["chatgpt"],
+    )
+    assert scoped_hits.conversation_ids() == ["conv-a"]
+    assert [hit.rank for hit in scoped_hits.hits] == [1]
+
+
+@pytest.mark.asyncio
+async def test_repository_search_summaries_follow_conversation_hit_order() -> None:
+    hits = ConversationSearchResult.from_ids(["conv-b", "conv-a"])
+    queries = _FakeQueries(
+        hits=hits,
+        records_by_id={
+            "conv-a": _conversation_record("conv-a", title="First"),
+            "conv-b": _conversation_record("conv-b", title="Second"),
+        },
+    )
+    repo = _FakeRepo(queries)
+
+    summaries = await repo.search_summaries("storage", limit=5)
+
+    assert queries.last_batch_ids == ["conv-b", "conv-a"]
+    assert [summary.id for summary in summaries] == [ConversationId("conv-b"), ConversationId("conv-a")]
+    assert [summary.title for summary in summaries] == ["Second", "First"]
+
+
+@pytest.mark.asyncio
+async def test_repository_search_and_action_search_pass_ordered_ids_to_hydration() -> None:
+    hits = ConversationSearchResult.from_ids(["conv-b", "conv-a"])
+    queries = _FakeQueries(
+        hits=hits,
+        records_by_id={
+            "conv-a": _conversation_record("conv-a", title="First"),
+            "conv-b": _conversation_record("conv-b", title="Second"),
+        },
+    )
+    repo = _FakeRepo(queries)
+
+    search_result = await repo.search("storage", limit=5)
+    assert [str(conversation.id) for conversation in search_result] == ["conv-b", "conv-a"]
+    assert repo.ordered_ids_seen == ["conv-b", "conv-a"]
+
+    action_result = await repo.search_actions("storage", limit=5)
+    assert [str(conversation.id) for conversation in action_result] == ["conv-b", "conv-a"]
+    assert repo.ordered_ids_seen == ["conv-b", "conv-a"]

--- a/tests/unit/storage/test_store_ops.py
+++ b/tests/unit/storage/test_store_ops.py
@@ -12,13 +12,14 @@ from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any, TypedDict, cast
+from typing import Any, cast
 from unittest.mock import AsyncMock
 
 import pytest
 from hypothesis import given, settings
 from hypothesis import strategies as st
 from pydantic import ValidationError
+from typing_extensions import TypedDict
 
 from polylogue.lib.conversation_models import Conversation
 from polylogue.lib.messages import MessageCollection


### PR DESCRIPTION
Ref #239
Ref #222

## Summary
- introduce explicit conversation-hit result carriers for archive search instead of flattening ranked results to raw ID lists too early
- thread those carriers through the query helpers, query store, async archive backend, and repository search mixin
- add focused contract tests covering provider scoping, rank preservation, and repository hydration order

## Problem
The archive search seam still collapsed ranked search output into raw conversation ID lists too early. The lower search helpers knew about ranking and provider-scoped candidate resolution, but `query_store_archive`, `repository_archive_search`, and the hybrid conversation resolver bounced between ad hoc tuples, reordered ID batches, and manual by-id reconstruction. That left the result shape path-dependent and duplicated the “search IDs -> batch fetch -> restore order” logic.

## Solution
- added `ConversationSearchHit` and `ConversationSearchResult` in `polylogue/storage/search_models.py` as the typed carrier for ranked conversation hits
- introduced `search_conversation_hits(...)` and `search_action_conversation_hits(...)` in the SQL query helpers and propagated them through `query_store_archive` and `async_sqlite_archive`, while preserving the legacy ID-returning wrappers for existing call sites
- rewired `repository_archive_search.py` to consume ordered hit carriers directly and rely on `get_conversations_batch(...)` for stable hydration order instead of rebuilding `by_id` maps locally
- taught the hybrid search provider and `hybrid_conversations.py` to resolve ranked conversation hits once, with provider scoping preserved before limit trimming, and keep the old ID-oriented helpers as thin wrappers
- added `tests/unit/storage/test_archive_search_contracts.py` to lock the new seam contract around provider scoping, rank preservation, ordered batch hydration, and action-search parity

## Verification
- `ruff check polylogue/storage/search_models.py polylogue/storage/backends/queries/conversations_search.py polylogue/storage/backends/queries/conversations.py polylogue/storage/backends/query_store_archive.py polylogue/storage/backends/async_sqlite_archive.py polylogue/storage/repository_archive_search.py polylogue/storage/search_providers/hybrid_conversations.py polylogue/storage/search_providers/hybrid.py tests/unit/storage/test_archive_search_contracts.py`
- `mypy polylogue/storage/search_models.py polylogue/storage/backends/queries/conversations_search.py polylogue/storage/backends/queries/conversations.py polylogue/storage/backends/query_store_archive.py polylogue/storage/backends/async_sqlite_archive.py polylogue/storage/repository_archive_search.py polylogue/storage/search_providers/hybrid_conversations.py polylogue/storage/search_providers/hybrid.py tests/unit/storage/test_archive_search_contracts.py`
- `pytest -q tests/unit/storage/test_archive_search_contracts.py tests/unit/storage/test_hybrid.py tests/unit/storage/test_hybrid_laws.py -k 'conversation_hits or search_conversations or provider_scope or orphan or providers'`
- `devtools verify`
