### PR TITLE
fix: restore Python 3.11 TypedDict compatibility

### DIFF
--- a/devtools/pipeline_probe.py
+++ b/devtools/pipeline_probe.py
@@ -15,7 +15,9 @@ import tempfile
 from collections.abc import Iterator
 from contextlib import contextmanager, redirect_stdout
 from pathlib import Path
-from typing import NotRequired, TypeAlias, TypedDict
+from typing import NotRequired, TypeAlias
+
+from typing_extensions import TypedDict
 
 from polylogue.config import Config, Source
 from polylogue.paths import blob_store_root, db_path

--- a/devtools/project_motd.py
+++ b/devtools/project_motd.py
@@ -11,7 +11,9 @@ import re
 import subprocess
 import sys
 from pathlib import Path
-from typing import TextIO, TypedDict
+from typing import TextIO
+
+from typing_extensions import TypedDict
 
 from devtools.command_catalog import control_plane_command
 from devtools.generated_surfaces import GENERATED_SURFACES, GeneratedSurface

--- a/polylogue/cli/embed_stats.py
+++ b/polylogue/cli/embed_stats.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Protocol, TypedDict
+from typing import TYPE_CHECKING, Protocol
 
 import click
+from typing_extensions import TypedDict
 
 if TYPE_CHECKING:
     from polylogue.config import Config

--- a/polylogue/pipeline/run_finalization.py
+++ b/polylogue/pipeline/run_finalization.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import time
-from typing import TYPE_CHECKING, TypedDict, cast
+from typing import TYPE_CHECKING, cast
 from uuid import uuid4
+
+from typing_extensions import TypedDict
 
 from polylogue.pipeline.run_support import write_run_json
 from polylogue.storage.backends import create_backend

--- a/polylogue/pipeline/run_stages.py
+++ b/polylogue/pipeline/run_stages.py
@@ -4,7 +4,9 @@ import asyncio
 from collections.abc import AsyncIterator, Iterable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, TypedDict
+from typing import TYPE_CHECKING
+
+from typing_extensions import TypedDict
 
 from polylogue.config import Config
 from polylogue.pipeline.run_support import PARSE_STAGES

--- a/polylogue/pipeline/semantic_capture.py
+++ b/polylogue/pipeline/semantic_capture.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from typing import NotRequired, TypedDict, cast
+from typing import NotRequired, cast
+
+from typing_extensions import TypedDict
 
 from polylogue.lib.payload_coercion import is_payload_mapping, mapping_or_empty, optional_string
 from polylogue.lib.raw_payload_decode import JSONRecord, JSONValue

--- a/polylogue/pipeline/services/indexing.py
+++ b/polylogue/pipeline/services/indexing.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import sqlite3
 from collections.abc import AsyncIterable, AsyncIterator, Callable, Iterable
-from typing import TYPE_CHECKING, TypedDict
+from typing import TYPE_CHECKING
 
 import aiosqlite
+from typing_extensions import TypedDict
 
 from polylogue.logging import get_logger
 from polylogue.storage.action_event_rebuild_runtime import (

--- a/polylogue/pipeline/services/ingest_worker.py
+++ b/polylogue/pipeline/services/ingest_worker.py
@@ -14,7 +14,9 @@ import re
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, TypeAlias, TypedDict, cast
+from typing import TYPE_CHECKING, TypeAlias, cast
+
+from typing_extensions import TypedDict
 
 from polylogue.lib.artifact_taxonomy import classify_artifact
 from polylogue.lib.branch_type import BranchType

--- a/polylogue/sources/assembly.py
+++ b/polylogue/sources/assembly.py
@@ -9,7 +9,9 @@ from __future__ import annotations
 from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Protocol, TypeAlias, TypedDict
+from typing import TYPE_CHECKING, Any, Protocol, TypeAlias
+
+from typing_extensions import TypedDict
 
 from polylogue.types import Provider
 

--- a/polylogue/storage/backends/queries/stats.py
+++ b/polylogue/storage/backends/queries/stats.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-from typing import TypedDict
-
 import aiosqlite
+from typing_extensions import TypedDict
 
 from polylogue.storage.store import MessageRecord
 

--- a/polylogue/storage/query_models.py
+++ b/polylogue/storage/query_models.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, replace
-from typing import TypedDict
+
+from typing_extensions import TypedDict
 
 
 class ConversationListQueryKwargs(TypedDict):

--- a/polylogue/storage/session_product_runtime.py
+++ b/polylogue/storage/session_product_runtime.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal, TypeAlias, TypedDict
+from typing import Literal, TypeAlias
+
+from typing_extensions import TypedDict
 
 ProviderDayGroup: TypeAlias = tuple[str, str]
 SessionProductReadyFlag: TypeAlias = Literal[

--- a/polylogue/storage/state_views.py
+++ b/polylogue/storage/state_views.py
@@ -9,9 +9,10 @@ from __future__ import annotations
 
 from collections.abc import ItemsView, KeysView, Mapping, ValuesView
 from dataclasses import dataclass
-from typing import TypedDict, cast
+from typing import cast
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
+from typing_extensions import TypedDict
 
 from polylogue.storage.store import AttachmentRecord, ConversationRecord, MessageRecord
 from polylogue.types import (

--- a/polylogue/surface_payloads.py
+++ b/polylogue/surface_payloads.py
@@ -7,9 +7,10 @@ import sys
 from collections.abc import Mapping, Sequence
 from datetime import datetime
 from enum import Enum
-from typing import TYPE_CHECKING, Literal, NotRequired, TypedDict, cast
+from typing import TYPE_CHECKING, Literal, NotRequired, cast
 
 from pydantic import BaseModel, ConfigDict, Field
+from typing_extensions import TypedDict
 
 from polylogue.schemas.json_types import JSONDocument, JSONValue
 

--- a/tests/infra/cli_subprocess.py
+++ b/tests/infra/cli_subprocess.py
@@ -16,7 +16,9 @@ import subprocess
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal, TypedDict
+from typing import Literal
+
+from typing_extensions import TypedDict
 
 
 @dataclass

--- a/tests/unit/cli/test_source_selection_helpers.py
+++ b/tests/unit/cli/test_source_selection_helpers.py
@@ -7,11 +7,12 @@ from collections.abc import Iterable
 from io import StringIO
 from pathlib import Path
 from types import SimpleNamespace
-from typing import TypedDict, cast
+from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import click
 import pytest
+from typing_extensions import TypedDict
 
 from polylogue.cli import helpers
 from polylogue.cli.types import AppEnv

--- a/tests/unit/core/test_filters_props.py
+++ b/tests/unit/core/test_filters_props.py
@@ -19,12 +19,13 @@ from __future__ import annotations
 from collections.abc import Callable
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Literal, NotRequired, TypeAlias, TypedDict
+from typing import Literal, NotRequired, TypeAlias
 from unittest.mock import patch
 
 import pytest
 from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
+from typing_extensions import TypedDict
 
 from polylogue.cli.filter_picker import pick_filter
 from polylogue.lib.conversation_models import Conversation

--- a/tests/unit/pipeline/test_resilience.py
+++ b/tests/unit/pipeline/test_resilience.py
@@ -12,11 +12,12 @@ from collections.abc import Sequence
 from datetime import datetime, timezone
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Literal, TypedDict
+from typing import Literal
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from hypothesis import HealthCheck, given, settings
+from typing_extensions import TypedDict
 
 from polylogue.config import Source
 from polylogue.lib.raw_payload_decode import JSONValue

--- a/tests/unit/sources/test_drive_source_client.py
+++ b/tests/unit/sources/test_drive_source_client.py
@@ -11,7 +11,7 @@ from typing import cast
 from unittest.mock import MagicMock
 
 import pytest
-from hypothesis import given, settings
+from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 
 from polylogue.sources.drive_gateway import DriveServiceGateway
@@ -169,7 +169,7 @@ def test_needs_download_contract(tmp_path: Path) -> None:
     st.lists(json_document_strategy(), min_size=0, max_size=8),
     st.sampled_from(("session.jsonl", "session.jsonl.txt", "session.ndjson", "SESSION.JSONL")),
 )
-@settings(max_examples=35)
+@settings(max_examples=35, suppress_health_check=[HealthCheck.too_slow])
 def test_parse_downloaded_json_payload_preserves_newline_delimited_documents(
     documents: list[dict[str, object]], name: str
 ) -> None:

--- a/tests/unit/sources/test_parser_crashlessness.py
+++ b/tests/unit/sources/test_parser_crashlessness.py
@@ -11,11 +11,12 @@ Unacceptable: AttributeError, IndexError, RecursionError (bugs).
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import TypedDict, cast
+from typing import cast
 
 import pytest
 from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
+from typing_extensions import TypedDict
 
 from polylogue.sources.parsers import chatgpt, claude, codex, drive
 from tests.infra.strategies.schema_driven import schema_conformant_payload

--- a/tests/unit/sources/test_source_laws.py
+++ b/tests/unit/sources/test_source_laws.py
@@ -9,13 +9,14 @@ import zipfile
 from collections.abc import Iterable, Mapping
 from io import BytesIO
 from pathlib import Path
-from typing import IO, BinaryIO, TypedDict
+from typing import IO, BinaryIO
 from unittest.mock import MagicMock
 
 import ijson
 import pytest
 from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
+from typing_extensions import TypedDict
 
 from polylogue.config import Source
 from polylogue.lib.roles import Role, normalize_role

--- a/tests/unit/storage/test_store_ops.py
+++ b/tests/unit/storage/test_store_ops.py
@@ -12,13 +12,14 @@ from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any, TypedDict, cast
+from typing import Any, cast
 from unittest.mock import AsyncMock
 
 import pytest
 from hypothesis import given, settings
 from hypothesis import strategies as st
 from pydantic import ValidationError
+from typing_extensions import TypedDict
 
 from polylogue.lib.conversation_models import Conversation
 from polylogue.lib.messages import MessageCollection


### PR DESCRIPTION
Ref #241
Ref #222

## Summary
- switch runtime-loaded `TypedDict` payload surfaces to `typing_extensions.TypedDict` so Pydantic stays compatible with Python 3.11
- carry the same import boundary through adjacent devtool and test helper surfaces for consistency
- stabilize one slow Hypothesis Drive payload property test that started flaking once the suite was exercised under 3.11

## Problem
Open refactor PRs were failing the `test (3.11)` GitHub Actions leg with `pydantic.errors.PydanticUserError: Please use typing_extensions.TypedDict instead of typing.TypedDict on Python < 3.12.` The repo verified locally on newer interpreters, but several runtime-loaded payload and state models still imported `TypedDict` from `typing`, which Pydantic v2 rejects under Python 3.11.

## Solution
- rewired the affected runtime payload surfaces in `polylogue/` to import `TypedDict` from `typing_extensions`, including state, pipeline, surface-payload, source-assembly, and query-model helpers
- mirrored the same import boundary in adjacent devtool and test/helper modules so the repo uses one consistent `TypedDict` contract across supported Python versions
- updated `tests/unit/sources/test_drive_source_client.py` to suppress the `HealthCheck.too_slow` warning for the newline-delimited payload property test, which became flaky when the suite was actually run under Python 3.11

## Verification
- `ruff check devtools/pipeline_probe.py devtools/project_motd.py polylogue/cli/embed_stats.py polylogue/pipeline/run_finalization.py polylogue/pipeline/run_stages.py polylogue/pipeline/semantic_capture.py polylogue/pipeline/services/indexing.py polylogue/pipeline/services/ingest_worker.py polylogue/sources/assembly.py polylogue/storage/backends/queries/stats.py polylogue/storage/query_models.py polylogue/storage/session_product_runtime.py polylogue/storage/state_views.py polylogue/surface_payloads.py tests/infra/cli_subprocess.py tests/unit/cli/test_source_selection_helpers.py tests/unit/core/test_filters_props.py tests/unit/pipeline/test_resilience.py tests/unit/sources/test_drive_source_client.py tests/unit/sources/test_parser_crashlessness.py tests/unit/sources/test_source_laws.py tests/unit/storage/test_store_ops.py`
- `uv run --python 3.11 --extra dev pytest -q -n 0 tests/unit/ui/test_ui.py tests/unit/scenarios/test_scenario_specs.py tests/integration/test_cli_machine_contract.py tests/unit/showcase/test_scenario_models.py`
- `uv run --python 3.11 --extra dev pytest -q -n 0 tests/unit/sources/test_drive_source_client.py`
- `devtools verify`
