### PR TITLE
refactor: renew schema and source ingestion boundaries

### DIFF
--- a/polylogue/pipeline/materialization_runtime.py
+++ b/polylogue/pipeline/materialization_runtime.py
@@ -1,0 +1,341 @@
+"""Shared conversation materialization helpers for prepare and ingest paths."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TypeAlias, cast
+
+from polylogue.lib.branch_type import BranchType
+from polylogue.lib.json import dumps as json_dumps
+from polylogue.lib.roles import Role
+from polylogue.lib.viewports import ToolCategory, classify_tool
+from polylogue.pipeline.ids import (
+    attachment_content_id,
+    conversation_content_hash,
+    message_content_hash,
+)
+from polylogue.pipeline.ids import conversation_id as make_conversation_id
+from polylogue.pipeline.ids import message_id as make_message_id
+from polylogue.pipeline.prepare_transform_content import canonicalize_conversation_content
+from polylogue.pipeline.semantic_metadata import ToolInputPayload, extract_tool_metadata
+from polylogue.schemas.code_detection import detect_language
+from polylogue.sources.parsers.base import ParsedConversation
+from polylogue.types import (
+    AttachmentId,
+    ContentBlockType,
+    ContentHash,
+    ConversationId,
+    MessageId,
+    Provider,
+    SemanticBlockType,
+)
+
+ProviderMetadata: TypeAlias = dict[str, object]
+BlockMetadata: TypeAlias = dict[str, object]
+
+
+@dataclass(frozen=True, slots=True)
+class MaterializedContentBlock:
+    block_id: str
+    block_index: int
+    type: ContentBlockType
+    text: str | None
+    tool_name: str | None
+    tool_id: str | None
+    tool_input_json: str | None
+    media_type: str | None
+    metadata_json: str | None
+    semantic_type: SemanticBlockType | None
+
+
+@dataclass(frozen=True, slots=True)
+class MaterializedMessage:
+    message_id: MessageId
+    provider_message_id: str
+    role: Role
+    text: str | None
+    sort_key: float | None
+    content_hash: ContentHash
+    parent_message_id: MessageId | None
+    branch_index: int
+    word_count: int
+    has_tool_use: int
+    has_thinking: int
+    blocks: list[MaterializedContentBlock]
+
+
+@dataclass(frozen=True, slots=True)
+class MaterializedAttachment:
+    attachment_id: AttachmentId
+    message_id: MessageId | None
+    mime_type: str | None
+    size_bytes: int | None
+    source_path: str | None
+    path: str | None
+    provider_meta: ProviderMetadata
+
+
+@dataclass(frozen=True, slots=True)
+class MaterializedConversationStats:
+    message_count: int
+    word_count: int
+    tool_use_count: int
+    thinking_count: int
+
+
+@dataclass(frozen=True, slots=True)
+class MaterializedConversation:
+    conversation_id: ConversationId
+    provider_name: Provider
+    provider_conversation_id: str
+    title: str | None
+    created_at: str | None
+    updated_at: str | None
+    sort_key: float | None
+    content_hash: ContentHash
+    provider_meta: ProviderMetadata
+    parent_conversation_id: ConversationId | None
+    branch_type: BranchType | None
+    messages: list[MaterializedMessage]
+    attachments: list[MaterializedAttachment]
+    stats: MaterializedConversationStats
+
+
+def _timestamp_sort_key(ts: str | None) -> float | None:
+    """Convert a timestamp string to a numeric sort key."""
+    if ts is None:
+        return None
+    try:
+        value = float(ts)
+        if value > 32503680000:
+            value = value / 1000
+        return value
+    except (ValueError, TypeError):
+        pass
+
+    from datetime import datetime, timezone
+
+    try:
+        normalized = ts.replace("Z", "+00:00")
+        dt = datetime.fromisoformat(normalized)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt.timestamp()
+    except (ValueError, TypeError):
+        return None
+
+
+def _merged_conversation_provider_meta(
+    convo: ParsedConversation,
+    *,
+    source_name: str,
+) -> ProviderMetadata:
+    merged_provider_meta: ProviderMetadata = {"source": source_name}
+    if convo.provider_meta:
+        merged_provider_meta.update(convo.provider_meta)
+    return merged_provider_meta
+
+
+def _attachment_provider_meta(
+    base_meta: ProviderMetadata | None,
+    *,
+    provider_attachment_id: str | None,
+) -> ProviderMetadata:
+    meta: ProviderMetadata = dict(base_meta or {})
+    if provider_attachment_id:
+        meta.setdefault("provider_id", provider_attachment_id)
+    return meta
+
+
+def _tool_input_payload(tool_input: dict[str, object] | None) -> ToolInputPayload:
+    return cast(ToolInputPayload, dict(tool_input or {}))
+
+
+def _build_message_ids(convo: ParsedConversation, conversation_id: ConversationId) -> dict[str, MessageId]:
+    message_id_map: dict[str, MessageId] = {}
+    for idx, msg in enumerate(convo.messages, start=1):
+        provider_message_id = msg.provider_message_id or f"msg-{idx}"
+        message_id_map[str(provider_message_id)] = make_message_id(conversation_id, provider_message_id)
+    return message_id_map
+
+
+def _materialize_content_block(
+    message_id: MessageId,
+    block_index: int,
+    block: object,
+) -> MaterializedContentBlock:
+    parsed_block = cast("ParsedContentBlockLike", block)
+    tool_input_json = json_dumps(parsed_block.tool_input) if parsed_block.tool_input is not None else None
+    semantic_type: SemanticBlockType | None = None
+    semantic_metadata: BlockMetadata | None = dict(parsed_block.metadata) if parsed_block.metadata is not None else None
+
+    if parsed_block.type == "tool_use" and parsed_block.tool_name:
+        category = classify_tool(parsed_block.tool_name, parsed_block.tool_input or {})
+        semantic_type = None if category is ToolCategory.OTHER else SemanticBlockType.from_string(category.value)
+        tool_meta = extract_tool_metadata(
+            parsed_block.tool_name,
+            _tool_input_payload(parsed_block.tool_input),
+        )
+        if tool_meta is not None:
+            base = semantic_metadata or {}
+            base.update(tool_meta)
+            semantic_metadata = base
+    elif parsed_block.type == "thinking":
+        semantic_type = SemanticBlockType.THINKING
+    elif parsed_block.type == "code" and parsed_block.text and semantic_metadata is None:
+        detected_lang = detect_language(parsed_block.text)
+        if detected_lang:
+            semantic_metadata = {"language": detected_lang}
+
+    metadata_json = json_dumps(semantic_metadata) if semantic_metadata is not None else None
+
+    from polylogue.storage.store import ContentBlockRecord
+
+    return MaterializedContentBlock(
+        block_id=ContentBlockRecord.make_id(message_id, block_index),
+        block_index=block_index,
+        type=parsed_block.type,
+        text=parsed_block.text,
+        tool_name=parsed_block.tool_name,
+        tool_id=parsed_block.tool_id,
+        tool_input_json=tool_input_json,
+        media_type=parsed_block.media_type,
+        metadata_json=metadata_json,
+        semantic_type=semantic_type,
+    )
+
+
+def materialize_conversation(
+    convo: ParsedConversation,
+    *,
+    source_name: str,
+    archive_root: Path,
+) -> MaterializedConversation:
+    normalized_convo = canonicalize_conversation_content(convo)
+    content_hash = conversation_content_hash(normalized_convo)
+    conversation_id = make_conversation_id(
+        normalized_convo.provider_name,
+        normalized_convo.provider_conversation_id,
+    )
+    parent_conversation_id = (
+        make_conversation_id(normalized_convo.provider_name, normalized_convo.parent_conversation_provider_id)
+        if normalized_convo.parent_conversation_provider_id
+        else None
+    )
+    provider_meta = _merged_conversation_provider_meta(
+        normalized_convo,
+        source_name=source_name,
+    )
+    message_id_map = _build_message_ids(normalized_convo, conversation_id)
+
+    messages: list[MaterializedMessage] = []
+    total_word_count = 0
+    total_tool_use = 0
+    total_thinking = 0
+
+    for idx, msg in enumerate(normalized_convo.messages, start=1):
+        provider_message_id = msg.provider_message_id or f"msg-{idx}"
+        message_id = message_id_map[str(provider_message_id)]
+        parent_message_id = (
+            message_id_map.get(str(msg.parent_message_provider_id)) if msg.parent_message_provider_id else None
+        )
+        block_types = {block.type for block in msg.content_blocks}
+        word_count = len(msg.text.split()) if msg.text and msg.text.strip() else 0
+        has_tool_use = 1 if (block_types & {"tool_use", "tool_result"}) or msg.role == "tool" else 0
+        has_thinking = 1 if "thinking" in block_types else 0
+
+        total_word_count += word_count
+        total_tool_use += has_tool_use
+        total_thinking += has_thinking
+
+        blocks = [
+            _materialize_content_block(message_id, block_index, block)
+            for block_index, block in enumerate(msg.content_blocks)
+        ]
+
+        messages.append(
+            MaterializedMessage(
+                message_id=message_id,
+                provider_message_id=provider_message_id,
+                role=msg.role,
+                text=msg.text,
+                sort_key=_timestamp_sort_key(msg.timestamp),
+                content_hash=message_content_hash(msg, provider_message_id),
+                parent_message_id=parent_message_id,
+                branch_index=msg.branch_index,
+                word_count=word_count,
+                has_tool_use=has_tool_use,
+                has_thinking=has_thinking,
+                blocks=blocks,
+            )
+        )
+
+    attachments: list[MaterializedAttachment] = []
+    for attachment in normalized_convo.attachments:
+        raw_attachment_id, updated_meta, updated_path = attachment_content_id(
+            normalized_convo.provider_name,
+            attachment,
+            archive_root=archive_root,
+        )
+        attachments.append(
+            MaterializedAttachment(
+                attachment_id=AttachmentId(raw_attachment_id),
+                message_id=(
+                    message_id_map.get(attachment.message_provider_id or "") if attachment.message_provider_id else None
+                ),
+                mime_type=attachment.mime_type,
+                size_bytes=attachment.size_bytes,
+                source_path=attachment.path,
+                path=updated_path,
+                provider_meta=_attachment_provider_meta(
+                    dict(updated_meta or {}),
+                    provider_attachment_id=attachment.provider_attachment_id,
+                ),
+            )
+        )
+
+    return MaterializedConversation(
+        conversation_id=conversation_id,
+        provider_name=normalized_convo.provider_name,
+        provider_conversation_id=normalized_convo.provider_conversation_id,
+        title=normalized_convo.title,
+        created_at=normalized_convo.created_at,
+        updated_at=normalized_convo.updated_at,
+        sort_key=_timestamp_sort_key(normalized_convo.updated_at),
+        content_hash=content_hash,
+        provider_meta=provider_meta,
+        parent_conversation_id=parent_conversation_id,
+        branch_type=normalized_convo.branch_type,
+        messages=messages,
+        attachments=attachments,
+        stats=MaterializedConversationStats(
+            message_count=len(messages),
+            word_count=total_word_count,
+            tool_use_count=total_tool_use,
+            thinking_count=total_thinking,
+        ),
+    )
+
+
+class ParsedContentBlockLike:
+    type: ContentBlockType
+    text: str | None
+    tool_name: str | None
+    tool_id: str | None
+    tool_input: dict[str, object] | None
+    media_type: str | None
+    metadata: dict[str, object] | None
+
+
+__all__ = [
+    "BlockMetadata",
+    "MaterializedAttachment",
+    "MaterializedContentBlock",
+    "MaterializedConversation",
+    "MaterializedConversationStats",
+    "MaterializedMessage",
+    "ProviderMetadata",
+    "_timestamp_sort_key",
+    "materialize_conversation",
+]

--- a/polylogue/pipeline/prepare_models.py
+++ b/polylogue/pipeline/prepare_models.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 
 from pydantic import BaseModel, Field
 
+from polylogue.pipeline.materialization_runtime import _timestamp_sort_key
 from polylogue.storage.state_views import ExistingConversation
 from polylogue.storage.store import (
     AttachmentRecord,
@@ -35,30 +36,6 @@ class SaveResult(BaseModel):
     skipped_conversations: int
     skipped_messages: int
     skipped_attachments: int
-
-
-def _timestamp_sort_key(ts: str | None) -> float | None:
-    """Convert a timestamp string to a numeric sort key."""
-    if ts is None:
-        return None
-    try:
-        value = float(ts)
-        if value > 32503680000:
-            value = value / 1000
-        return value
-    except (ValueError, TypeError):
-        pass
-
-    from datetime import datetime, timezone
-
-    try:
-        normalized = ts.replace("Z", "+00:00")
-        dt = datetime.fromisoformat(normalized)
-        if dt.tzinfo is None:
-            dt = dt.replace(tzinfo=timezone.utc)
-        return dt.timestamp()
-    except (ValueError, TypeError):
-        return None
 
 
 @dataclass

--- a/polylogue/pipeline/prepare_transform.py
+++ b/polylogue/pipeline/prepare_transform.py
@@ -3,26 +3,13 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import cast
 
-from polylogue.lib.json import dumps as json_dumps
-from polylogue.lib.viewports import ToolCategory, classify_tool
-from polylogue.pipeline.ids import (
-    attachment_content_id,
-    conversation_content_hash,
-    message_content_hash,
-)
-from polylogue.pipeline.ids import conversation_id as make_conversation_id
-from polylogue.pipeline.ids import message_id as make_message_id
+from polylogue.pipeline.materialization_runtime import materialize_conversation
 from polylogue.pipeline.prepare_models import (
     AttachmentMaterializationPlan,
     RecordBundle,
     TransformResult,
-    _timestamp_sort_key,
 )
-from polylogue.pipeline.prepare_transform_content import canonicalize_conversation_content
-from polylogue.pipeline.semantic_metadata import ToolInputPayload, extract_tool_metadata
-from polylogue.schemas.code_detection import detect_language
 from polylogue.sources.parsers.base import ParsedConversation
 from polylogue.storage.store import (
     AttachmentRecord,
@@ -30,7 +17,7 @@ from polylogue.storage.store import (
     ConversationRecord,
     MessageRecord,
 )
-from polylogue.types import AttachmentId, MessageId, SemanticBlockType
+from polylogue.types import MessageId
 
 
 def plan_attachment_materialization(
@@ -50,131 +37,83 @@ def plan_attachment_materialization(
 
 
 def transform_to_records(convo: ParsedConversation, source_name: str, *, archive_root: Path) -> TransformResult:
-    convo = canonicalize_conversation_content(convo)
-    content_hash = conversation_content_hash(convo)
-    candidate_cid = make_conversation_id(convo.provider_name, convo.provider_conversation_id)
-
-    merged_provider_meta: dict[str, object] = {"source": source_name}
-    if convo.provider_meta:
-        merged_provider_meta.update(convo.provider_meta)
+    materialized = materialize_conversation(
+        convo,
+        source_name=source_name,
+        archive_root=archive_root,
+    )
 
     conversation_record = ConversationRecord(
-        conversation_id=candidate_cid,
-        provider_name=convo.provider_name,
-        provider_conversation_id=convo.provider_conversation_id,
-        title=convo.title,
-        created_at=convo.created_at,
-        updated_at=convo.updated_at,
-        sort_key=_timestamp_sort_key(convo.updated_at),
-        content_hash=content_hash,
-        provider_meta=merged_provider_meta,
-        parent_conversation_id=None,
-        branch_type=convo.branch_type,
+        conversation_id=materialized.conversation_id,
+        provider_name=materialized.provider_name,
+        provider_conversation_id=materialized.provider_conversation_id,
+        title=materialized.title,
+        created_at=materialized.created_at,
+        updated_at=materialized.updated_at,
+        sort_key=materialized.sort_key,
+        content_hash=materialized.content_hash,
+        provider_meta=materialized.provider_meta,
+        parent_conversation_id=materialized.parent_conversation_id,
+        branch_type=materialized.branch_type,
         raw_id=None,
     )
 
-    message_id_map: dict[str, MessageId] = {}
-    for idx, msg in enumerate(convo.messages, start=1):
-        provider_message_id = msg.provider_message_id or f"msg-{idx}"
-        message_id_map[str(provider_message_id)] = make_message_id(candidate_cid, provider_message_id)
-
-    messages: list[MessageRecord] = []
-    content_block_records: list[ContentBlockRecord] = []
-    for idx, msg in enumerate(convo.messages, start=1):
-        provider_message_id = msg.provider_message_id or f"msg-{idx}"
-        mid = message_id_map[str(provider_message_id)]
-        message_hash = message_content_hash(msg, provider_message_id)
-        parent_message_id: MessageId | None = None
-        if msg.parent_message_provider_id:
-            parent_message_id = message_id_map.get(str(msg.parent_message_provider_id))
-
-        block_types = {blk.type for blk in msg.content_blocks}
-        word_count = len(msg.text.split()) if msg.text and msg.text.strip() else 0
-        has_tool_use = 1 if (block_types & {"tool_use", "tool_result"}) or msg.role == "tool" else 0
-        has_thinking = 1 if "thinking" in block_types else 0
-        messages.append(
-            MessageRecord(
-                message_id=mid,
-                conversation_id=candidate_cid,
-                provider_message_id=provider_message_id,
-                role=msg.role,
-                text=msg.text,
-                sort_key=_timestamp_sort_key(msg.timestamp),
-                content_hash=message_hash,
-                parent_message_id=parent_message_id,
-                branch_index=msg.branch_index,
-                provider_name=convo.provider_name,
-                word_count=word_count,
-                has_tool_use=has_tool_use,
-                has_thinking=has_thinking,
-            )
+    messages: list[MessageRecord] = [
+        MessageRecord(
+            message_id=message.message_id,
+            conversation_id=materialized.conversation_id,
+            provider_message_id=message.provider_message_id,
+            role=message.role,
+            text=message.text,
+            sort_key=message.sort_key,
+            content_hash=message.content_hash,
+            parent_message_id=message.parent_message_id,
+            branch_index=message.branch_index,
+            provider_name=materialized.provider_name,
+            word_count=message.word_count,
+            has_tool_use=message.has_tool_use,
+            has_thinking=message.has_thinking,
         )
+        for message in materialized.messages
+    ]
 
-        for block_idx, block in enumerate(msg.content_blocks):
-            tool_input_json = json_dumps(block.tool_input) if block.tool_input is not None else None
-            semantic_type: SemanticBlockType | None = None
-            semantic_metadata: dict[str, object] | None = dict(block.metadata) if block.metadata is not None else None
-
-            if block.type == "tool_use" and block.tool_name:
-                category = classify_tool(block.tool_name, block.tool_input or {})
-                semantic_type = (
-                    None if category is ToolCategory.OTHER else SemanticBlockType.from_string(category.value)
-                )
-                tool_meta = extract_tool_metadata(
-                    block.tool_name,
-                    cast(ToolInputPayload, dict(block.tool_input or {})),
-                )
-                if tool_meta is not None:
-                    base = dict(block.metadata) if isinstance(block.metadata, dict) else {}
-                    base.update(tool_meta)
-                    semantic_metadata = base
-            elif block.type == "thinking":
-                semantic_type = SemanticBlockType.THINKING
-            elif block.type == "code" and block.text and semantic_metadata is None:
-                detected_lang = detect_language(block.text)
-                if detected_lang:
-                    semantic_metadata = {"language": detected_lang}
-
-            metadata_json = json_dumps(semantic_metadata) if semantic_metadata is not None else None
+    content_block_records: list[ContentBlockRecord] = []
+    message_id_map: dict[str, MessageId] = {}
+    for message in materialized.messages:
+        message_id_map[message.provider_message_id] = message.message_id
+        for block in message.blocks:
             content_block_records.append(
                 ContentBlockRecord(
-                    block_id=ContentBlockRecord.make_id(mid, block_idx),
-                    message_id=MessageId(mid),
-                    conversation_id=candidate_cid,
-                    block_index=block_idx,
+                    block_id=block.block_id,
+                    message_id=message.message_id,
+                    conversation_id=materialized.conversation_id,
+                    block_index=block.block_index,
                     type=block.type,
                     text=block.text,
                     tool_name=block.tool_name,
                     tool_id=block.tool_id,
-                    tool_input=tool_input_json,
+                    tool_input=block.tool_input_json,
                     media_type=block.media_type,
-                    metadata=metadata_json,
-                    semantic_type=semantic_type,
+                    metadata=block.metadata_json,
+                    semantic_type=block.semantic_type,
                 )
             )
 
     attachments: list[AttachmentRecord] = []
     materialization_plan = AttachmentMaterializationPlan()
-    for att in convo.attachments:
-        aid, updated_meta, updated_path = attachment_content_id(convo.provider_name, att, archive_root=archive_root)
-        meta: dict[str, object] = dict(updated_meta or {})
-        if att.provider_attachment_id:
-            meta.setdefault("provider_id", att.provider_attachment_id)
-        attachment_plan = plan_attachment_materialization(att.path, updated_path)
+    for attachment in materialized.attachments:
+        attachment_plan = plan_attachment_materialization(attachment.source_path, attachment.path)
         materialization_plan.move_before_save.extend(attachment_plan.move_before_save)
         materialization_plan.delete_after_save.extend(attachment_plan.delete_after_save)
-        message_id_val: MessageId | None = (
-            message_id_map.get(att.message_provider_id or "") if att.message_provider_id else None
-        )
         attachments.append(
             AttachmentRecord(
-                attachment_id=AttachmentId(aid),
-                conversation_id=candidate_cid,
-                message_id=message_id_val,
-                mime_type=att.mime_type,
-                size_bytes=att.size_bytes,
-                path=updated_path,
-                provider_meta=meta,
+                attachment_id=attachment.attachment_id,
+                conversation_id=materialized.conversation_id,
+                message_id=attachment.message_id,
+                mime_type=attachment.mime_type,
+                size_bytes=attachment.size_bytes,
+                path=attachment.path,
+                provider_meta=attachment.provider_meta,
             )
         )
 
@@ -187,8 +126,8 @@ def transform_to_records(convo: ParsedConversation, source_name: str, *, archive
     return TransformResult(
         bundle=bundle,
         materialization_plan=materialization_plan,
-        content_hash=content_hash,
-        candidate_cid=candidate_cid,
+        content_hash=materialized.content_hash,
+        candidate_cid=materialized.conversation_id,
         message_id_map=message_id_map,
     )
 

--- a/polylogue/pipeline/services/ingest_worker.py
+++ b/polylogue/pipeline/services/ingest_worker.py
@@ -11,10 +11,9 @@ from __future__ import annotations
 
 import pickle
 import re
-from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, TypeAlias, cast
+from typing import TYPE_CHECKING
 
 from typing_extensions import TypedDict
 
@@ -22,17 +21,10 @@ from polylogue.lib.artifact_taxonomy import classify_artifact
 from polylogue.lib.branch_type import BranchType
 from polylogue.lib.json import dumps as json_dumps
 from polylogue.lib.roles import Role
-from polylogue.lib.viewports import ToolCategory, classify_tool
-from polylogue.pipeline.ids import (
-    attachment_content_id,
-    conversation_content_hash,
-    message_content_hash,
+from polylogue.pipeline.materialization_runtime import (
+    MaterializedConversation,
+    materialize_conversation,
 )
-from polylogue.pipeline.ids import conversation_id as make_conversation_id
-from polylogue.pipeline.ids import message_id as make_message_id
-from polylogue.pipeline.prepare_transform_content import canonicalize_conversation_content
-from polylogue.pipeline.semantic_metadata import ToolInputPayload, ToolMetadata, extract_tool_metadata
-from polylogue.schemas.code_detection import detect_language
 from polylogue.sources.decoders import _iter_json_stream
 from polylogue.sources.dispatch import STREAM_RECORD_PROVIDERS
 from polylogue.storage.blob_store import BlobStore
@@ -51,13 +43,11 @@ from polylogue.types import (
 
 if TYPE_CHECKING:
     from polylogue.schemas.runtime_registry import SchemaRegistry
-    from polylogue.sources.parsers.base_models import ParsedConversation, ParsedMessage
+    from polylogue.sources.parsers.base import ParsedConversation
+
 
 _SOURCE_HASH_SUFFIX = re.compile(r"-(?:[0-9a-f]{16,64})$", re.IGNORECASE)
 _SCHEMA_REGISTRY: SchemaRegistry | None = None
-
-ProviderMetadata: TypeAlias = dict[str, object]
-BlockMetadata: TypeAlias = dict[str, object]
 
 
 class _TimestampUpdates(TypedDict, total=False):
@@ -216,28 +206,6 @@ def _fallback_id(source_path: str | None, raw_id: str) -> str:
     return cleaned or stem
 
 
-def _timestamp_sort_key(ts: str | None) -> float | None:
-    if ts is None:
-        return None
-    try:
-        value = float(ts)
-        if value > 32503680000:
-            value = value / 1000
-        return value
-    except (ValueError, TypeError):
-        pass
-    from datetime import datetime, timezone
-
-    try:
-        normalized = ts.replace("Z", "+00:00")
-        dt = datetime.fromisoformat(normalized)
-        if dt.tzinfo is None:
-            dt = dt.replace(tzinfo=timezone.utc)
-        return dt.timestamp()
-    except (ValueError, TypeError):
-        return None
-
-
 def _make_ref_id(
     attachment_id: str,
     conversation_id: str,
@@ -278,32 +246,6 @@ def _normalized_conversation(
     if convo.updated_at is None and isinstance(effective_created, str) and effective_created:
         updates["updated_at"] = effective_created
     return convo.model_copy(update=updates) if updates else convo
-
-
-def _merged_conversation_provider_meta(
-    convo: ParsedConversation,
-    *,
-    source_name: str,
-) -> ProviderMetadata:
-    merged_provider_meta: ProviderMetadata = {"source": source_name}
-    if convo.provider_meta:
-        merged_provider_meta.update(convo.provider_meta)
-    return merged_provider_meta
-
-
-def _attachment_provider_meta(
-    base_meta: ProviderMetadata | None,
-    *,
-    provider_attachment_id: str | None,
-) -> ProviderMetadata:
-    meta: ProviderMetadata = dict(base_meta or {})
-    if provider_attachment_id:
-        meta.setdefault("provider_id", provider_attachment_id)
-    return meta
-
-
-def _tool_input_payload(tool_input: Mapping[str, object] | None) -> ToolInputPayload:
-    return cast(ToolInputPayload, dict(tool_input or {}))
 
 
 def _is_stream_record_provider(source_path: str | None, provider: str | Provider | None) -> bool:
@@ -722,206 +664,113 @@ def _transform_to_tuples(
     archive_root: Path,
     raw_id: str | None,
 ) -> ConversationData:
-    """Convert a ParsedConversation to DB-ready tuples.
-
-    Equivalent to transform_to_records + enrich_bundle_from_db but produces
-    plain tuples instead of Pydantic models. Skips PrepareCache entirely
-    since conversation_id and message_id are deterministic hashes.
-    """
-    convo = canonicalize_conversation_content(convo)
-    content_hash = conversation_content_hash(convo)
-    cid = make_conversation_id(convo.provider_name, convo.provider_conversation_id)
-
-    merged_provider_meta = _merged_conversation_provider_meta(
+    """Convert a ParsedConversation to DB-ready tuples."""
+    materialized = materialize_conversation(
         convo,
         source_name=source_name,
+        archive_root=archive_root,
     )
 
-    # Parent conversation — always compute it (no PrepareCache needed).
-    # If parent doesn't exist in DB yet, that's fine — no FK constraint.
-    parent_conversation_id = None
-    if convo.parent_conversation_provider_id:
-        parent_conversation_id = make_conversation_id(
-            convo.provider_name,
-            convo.parent_conversation_provider_id,
+    conv_tuple: ConversationTuple = (
+        materialized.conversation_id,
+        materialized.provider_name,
+        materialized.provider_conversation_id,
+        materialized.title,
+        materialized.created_at,
+        materialized.updated_at,
+        materialized.sort_key,
+        materialized.content_hash,
+        _json_or_none(materialized.provider_meta),
+        "{}",
+        1,
+        materialized.parent_conversation_id,
+        materialized.branch_type,
+        raw_id,
+    )
+
+    msg_tuples: list[MessageTuple] = [
+        (
+            message.message_id,
+            materialized.conversation_id,
+            message.provider_message_id,
+            message.role,
+            message.text,
+            message.sort_key,
+            message.content_hash,
+            1,
+            message.parent_message_id,
+            message.branch_index,
+            materialized.provider_name,
+            message.word_count,
+            message.has_tool_use,
+            message.has_thinking,
         )
+        for message in materialized.messages
+    ]
 
-    sort_key = _timestamp_sort_key(convo.updated_at)
-
-    # Conversation tuple: matches INSERT INTO conversations column order
-    conv_tuple = (
-        cid,  # conversation_id
-        convo.provider_name,  # provider_name
-        convo.provider_conversation_id,  # provider_conversation_id
-        convo.title,  # title
-        convo.created_at,  # created_at
-        convo.updated_at,  # updated_at
-        sort_key,  # sort_key
-        content_hash,  # content_hash
-        _json_or_none(merged_provider_meta),  # provider_meta
-        "{}",  # metadata
-        1,  # version
-        parent_conversation_id,  # parent_conversation_id
-        convo.branch_type,  # branch_type
-        raw_id,  # raw_id
-    )
-
-    # Build message ID map
-    message_id_map: dict[str, MessageId] = {}
-    for idx, msg in enumerate(convo.messages, start=1):
-        provider_message_id = msg.provider_message_id or f"msg-{idx}"
-        message_id_map[str(provider_message_id)] = make_message_id(cid, provider_message_id)
-
-    # Message tuples + content block tuples
-    msg_tuples: list[MessageTuple] = []
     block_tuples: list[ContentBlockTuple] = []
-    total_word_count = 0
-    total_tool_use = 0
-    total_thinking = 0
-
-    for idx, msg in enumerate(convo.messages, start=1):
-        provider_message_id = msg.provider_message_id or f"msg-{idx}"
-        mid = message_id_map[str(provider_message_id)]
-        message_hash = message_content_hash(msg, provider_message_id)
-
-        parent_message_id: MessageId | None = None
-        if msg.parent_message_provider_id:
-            parent_message_id = message_id_map.get(str(msg.parent_message_provider_id))
-
-        block_types = {blk.type for blk in msg.content_blocks}
-        word_count = len(msg.text.split()) if msg.text and msg.text.strip() else 0
-        has_tool_use = 1 if (block_types & {"tool_use", "tool_result"}) or msg.role == "tool" else 0
-        has_thinking = 1 if "thinking" in block_types else 0
-
-        total_word_count += word_count
-        total_tool_use += has_tool_use
-        total_thinking += has_thinking
-
-        msg_tuples.append(
-            (
-                mid,  # message_id
-                cid,  # conversation_id
-                provider_message_id,  # provider_message_id
-                msg.role,  # role
-                msg.text,  # text
-                _timestamp_sort_key(msg.timestamp),  # sort_key
-                message_hash,  # content_hash
-                1,  # version
-                parent_message_id,  # parent_message_id
-                msg.branch_index,  # branch_index
-                convo.provider_name,  # provider_name
-                word_count,  # word_count
-                has_tool_use,  # has_tool_use
-                has_thinking,  # has_thinking
-            )
-        )
-
-        # Content blocks for this message
-        for block_idx, block in enumerate(msg.content_blocks):
-            tool_input_json = json_dumps(block.tool_input) if block.tool_input is not None else None
-            semantic_type: str | None = None
-            semantic_metadata: BlockMetadata | ToolMetadata | None = block.metadata
-
-            if block.type == "tool_use" and block.tool_name:
-                tool_input = _tool_input_payload(block.tool_input)
-                category = classify_tool(block.tool_name, tool_input)
-                semantic_type = None if category is ToolCategory.OTHER else category.value
-                tool_meta = extract_tool_metadata(block.tool_name, tool_input)
-                if tool_meta is not None:
-                    base = dict(block.metadata) if isinstance(block.metadata, dict) else {}
-                    base.update(tool_meta)
-                    semantic_metadata = base
-            elif block.type == "thinking":
-                semantic_type = "thinking"
-            elif block.type == "code" and block.text and semantic_metadata is None:
-                detected_lang = detect_language(block.text)
-                if detected_lang:
-                    language_metadata: BlockMetadata = {"language": detected_lang}
-                    semantic_metadata = language_metadata
-
-            metadata_json = json_dumps(semantic_metadata) if semantic_metadata is not None else None
-
-            from polylogue.storage.store import ContentBlockRecord
-
-            block_id = ContentBlockRecord.make_id(mid, block_idx)
+    for message in materialized.messages:
+        for block in message.blocks:
             block_tuples.append(
                 (
-                    block_id,  # block_id
-                    mid,  # message_id
-                    cid,  # conversation_id
-                    block_idx,  # block_index
-                    block.type,  # type
-                    block.text,  # text
-                    block.tool_name,  # tool_name
-                    block.tool_id,  # tool_id
-                    tool_input_json,  # tool_input
-                    block.media_type,  # media_type
-                    metadata_json,  # metadata
-                    semantic_type,  # semantic_type
+                    block.block_id,
+                    message.message_id,
+                    materialized.conversation_id,
+                    block.block_index,
+                    block.type,
+                    block.text,
+                    block.tool_name,
+                    block.tool_id,
+                    block.tool_input_json,
+                    block.media_type,
+                    block.metadata_json,
+                    block.semantic_type,
                 )
             )
 
-    # Conversation stats tuple
-    stats_tuple = (
-        cid,
-        convo.provider_name,
-        len(convo.messages),
-        total_word_count,
-        total_tool_use,
-        total_thinking,
+    stats_tuple: StatsTuple = (
+        materialized.conversation_id,
+        materialized.provider_name,
+        materialized.stats.message_count,
+        materialized.stats.word_count,
+        materialized.stats.tool_use_count,
+        materialized.stats.thinking_count,
     )
 
-    # Action events — build from content blocks
-    action_event_tuples = _build_action_event_tuples(
-        cid,
-        convo.provider_name,
-        convo.messages,
-        message_id_map,
-        msg_tuples,
-    )
+    action_event_tuples = _build_action_event_tuples(materialized)
 
-    # Attachments
     attachment_tuples: list[AttachmentTuple] = []
     attachment_ref_tuples: list[AttachmentRefTuple] = []
-    for att in convo.attachments:
-        raw_attachment_id, updated_meta, updated_path = attachment_content_id(
-            convo.provider_name,
-            att,
-            archive_root=archive_root,
-        )
-        aid = AttachmentId(raw_attachment_id)
-        meta = _attachment_provider_meta(
-            updated_meta,
-            provider_attachment_id=att.provider_attachment_id,
-        )
-        message_id_val = message_id_map.get(att.message_provider_id or "") if att.message_provider_id else None
-        meta_json = _json_or_none(meta)
-
+    for attachment in materialized.attachments:
+        meta_json = _json_or_none(attachment.provider_meta)
         attachment_tuples.append(
             (
-                aid,  # attachment_id
-                att.mime_type,  # mime_type
-                att.size_bytes,  # size_bytes
-                updated_path,  # path
-                0,  # ref_count (updated after ref insert)
-                meta_json,  # provider_meta
+                attachment.attachment_id,
+                attachment.mime_type,
+                attachment.size_bytes,
+                attachment.path,
+                0,
+                meta_json,
             )
         )
-        ref_id = _make_ref_id(aid, cid, message_id_val)
         attachment_ref_tuples.append(
             (
-                ref_id,  # ref_id
-                aid,  # attachment_id
-                cid,  # conversation_id
-                message_id_val,  # message_id
-                meta_json,  # provider_meta
+                _make_ref_id(
+                    attachment.attachment_id,
+                    materialized.conversation_id,
+                    attachment.message_id,
+                ),
+                attachment.attachment_id,
+                materialized.conversation_id,
+                attachment.message_id,
+                meta_json,
             )
         )
 
     return ConversationData(
-        conversation_id=cid,
-        content_hash=content_hash,
-        provider_name=convo.provider_name,
+        conversation_id=materialized.conversation_id,
+        content_hash=materialized.content_hash,
+        provider_name=materialized.provider_name,
         conversation_tuple=conv_tuple,
         message_tuples=msg_tuples,
         block_tuples=block_tuples,
@@ -935,11 +784,7 @@ def _transform_to_tuples(
 
 
 def _build_action_event_tuples(
-    conversation_id: str,
-    provider_name: str,
-    messages: list[ParsedMessage],
-    message_id_map: dict[str, MessageId],
-    msg_tuples: list[MessageTuple],
+    conversation: MaterializedConversation,
 ) -> list[ActionEventTuple]:
     """Build action event tuples for all messages in a conversation.
 
@@ -953,56 +798,44 @@ def _build_action_event_tuples(
         ContentBlockRecord,
         MessageRecord,
     )
-    from polylogue.types import MessageId, Provider
+    from polylogue.types import Provider
 
-    provider = Provider.from_string(provider_name)
+    provider = Provider.from_string(conversation.provider_name)
     action_tuples: list[ActionEventTuple] = []
-    conversation_id_token = ConversationId(conversation_id)
+    conversation_id_token = conversation.conversation_id
 
-    for idx, msg in enumerate(messages, start=1):
-        provider_message_id = msg.provider_message_id or f"msg-{idx}"
-        mid = message_id_map[str(provider_message_id)]
-        msg_tuple = msg_tuples[idx - 1]
-        msg_sort_key = msg_tuple[5] if isinstance(msg_tuple[5], float) else None  # sort_key is at index 5
-        msg_content_hash = ContentHash(str(msg_tuple[6]))
+    for message in conversation.messages:
+        if not message.has_tool_use:
+            continue
 
-        # Build lightweight domain message for action event extraction
-        block_types = {blk.type for blk in msg.content_blocks}
-        has_tool_use = 1 if (block_types & {"tool_use", "tool_result"}) or msg.role == "tool" else 0
-        if not has_tool_use:
-            continue  # Skip messages without tool use — no action events
-
-        # Reconstruct minimal MessageRecord for the hydrator
-        word_count = len(msg.text.split()) if msg.text and msg.text.strip() else 0
-        has_thinking = 1 if "thinking" in block_types else 0
         msg_record = MessageRecord(
-            message_id=MessageId(mid),
+            message_id=message.message_id,
             conversation_id=conversation_id_token,
-            provider_message_id=provider_message_id,
-            role=msg.role,
-            text=msg.text,
-            sort_key=msg_sort_key,
-            content_hash=msg_content_hash,
-            provider_name=provider_name,
-            word_count=word_count,
-            has_tool_use=has_tool_use,
-            has_thinking=has_thinking,
+            provider_message_id=message.provider_message_id,
+            role=message.role,
+            text=message.text,
+            sort_key=message.sort_key,
+            content_hash=message.content_hash,
+            provider_name=conversation.provider_name,
+            word_count=message.word_count,
+            has_tool_use=message.has_tool_use,
+            has_thinking=message.has_thinking,
             content_blocks=[
                 ContentBlockRecord(
-                    block_id=ContentBlockRecord.make_id(mid, bi),
-                    message_id=MessageId(mid),
+                    block_id=block.block_id,
+                    message_id=message.message_id,
                     conversation_id=conversation_id_token,
-                    block_index=bi,
-                    type=blk.type,
-                    text=blk.text,
-                    tool_name=blk.tool_name,
-                    tool_id=blk.tool_id,
-                    tool_input=json_dumps(blk.tool_input) if blk.tool_input is not None else None,
-                    media_type=blk.media_type,
-                    metadata=json_dumps(blk.metadata) if blk.metadata is not None else None,
-                    semantic_type=None,
+                    block_index=block.block_index,
+                    type=block.type,
+                    text=block.text,
+                    tool_name=block.tool_name,
+                    tool_id=block.tool_id,
+                    tool_input=block.tool_input_json,
+                    media_type=block.media_type,
+                    metadata=block.metadata_json,
+                    semantic_type=block.semantic_type,
                 )
-                for bi, blk in enumerate(msg.content_blocks)
+                for block in message.blocks
             ],
         )
 
@@ -1027,14 +860,14 @@ def _build_action_event_tuples(
             action_tuples.append(
                 (
                     event.event_id,  # event_id
-                    conversation_id,  # conversation_id
-                    mid,  # message_id
+                    conversation.conversation_id,  # conversation_id
+                    message.message_id,  # message_id
                     ACTION_EVENT_MATERIALIZER_VERSION,  # materializer_version
                     event.raw.get("block_id") if isinstance(event.raw, dict) else None,  # source_block_id
                     timestamp_iso,  # timestamp
-                    msg_sort_key,  # sort_key
+                    message.sort_key,  # sort_key
                     event.sequence_index,  # sequence_index
-                    provider_name,  # provider_name
+                    conversation.provider_name,  # provider_name
                     event.kind.value,  # action_kind
                     event.tool_name,  # tool_name
                     event.normalized_tool_name,  # normalized_tool_name

--- a/polylogue/sources/dispatch.py
+++ b/polylogue/sources/dispatch.py
@@ -1,11 +1,12 @@
-"""Provider detection and payload dispatch for source parsing."""
+"""Provider detection and payload lowering for source parsing."""
 
 from __future__ import annotations
 
 import json
 from collections.abc import Callable, Iterable
+from dataclasses import dataclass
 from io import BytesIO
-from typing import TYPE_CHECKING, TypeAlias
+from typing import TYPE_CHECKING, Literal, TypeAlias
 
 from polylogue.lib.payload_coercion import PayloadMapping, is_payload_mapping, optional_string
 from polylogue.logging import get_logger
@@ -26,6 +27,21 @@ _MAX_PARSE_DEPTH = 10
 
 PayloadRecord: TypeAlias = dict[str, object]
 ProviderParser: TypeAlias = Callable[[PayloadRecord, str], ParsedConversation]
+LoweredPayloadMode: TypeAlias = Literal[
+    "single_record",
+    "bundle_record",
+    "grouped_records",
+    "chunked_prompt",
+    "generic_messages",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class LoweredPayloadSpec:
+    provider: Provider
+    fallback_id: str
+    mode: LoweredPayloadMode
+    payload: PayloadRecord | list[object]
 
 
 def _payload_mapping(value: object) -> PayloadMapping | None:
@@ -86,33 +102,6 @@ def _detect_provider_from_sequence(payloads: list[object]) -> Provider | None:
     if codex.looks_like(payloads):
         return Provider.CODEX
     return None
-
-
-def _parse_bundle_items(
-    payloads: list[object],
-    fallback_id: str,
-    parser: ProviderParser,
-) -> list[ParsedConversation]:
-    results: list[ParsedConversation] = []
-    for index, item in enumerate(payloads):
-        if record := _payload_record(item):
-            results.append(parser(record, f"{fallback_id}-{index}"))
-    return results
-
-
-def _parse_grouped_records(
-    payload: object,
-    fallback_id: str,
-    parser: Callable[[list[object], str], ParsedConversation],
-) -> list[ParsedConversation]:
-    payloads = _payload_list(payload)
-    if payloads is not None:
-        return [parser(payloads, fallback_id)]
-
-    if record := _payload_record(payload):
-        messages = _payload_messages(record)
-        return [parser(messages if messages is not None else [record], fallback_id)]
-    return []
 
 
 def detect_provider(payload: object, path: object | None = None) -> Provider | None:
@@ -176,9 +165,219 @@ def _schema_guided_payload(
     return payload
 
 
+def _lower_bundle_specs(
+    provider: Provider,
+    payloads: list[object],
+    fallback_id: str,
+) -> list[LoweredPayloadSpec]:
+    specs: list[LoweredPayloadSpec] = []
+    for index, item in enumerate(payloads):
+        if record := _payload_record(item):
+            specs.append(
+                LoweredPayloadSpec(
+                    provider=provider,
+                    fallback_id=f"{fallback_id}-{index}",
+                    mode="bundle_record",
+                    payload=record,
+                )
+            )
+    return specs
+
+
+def _lower_grouped_spec(
+    provider: Provider,
+    payload: object,
+    fallback_id: str,
+) -> list[LoweredPayloadSpec]:
+    payloads = _payload_list(payload)
+    if payloads is not None:
+        return [
+            LoweredPayloadSpec(provider=provider, fallback_id=fallback_id, mode="grouped_records", payload=payloads)
+        ]
+
+    record = _payload_record(payload)
+    if record is None:
+        return []
+
+    messages = _payload_messages(record)
+    grouped_payload = messages if messages is not None else [record]
+    return [
+        LoweredPayloadSpec(provider=provider, fallback_id=fallback_id, mode="grouped_records", payload=grouped_payload)
+    ]
+
+
+def _lower_drive_like_specs(
+    runtime_provider: Provider,
+    payload: object,
+    fallback_id: str,
+    *,
+    depth: int,
+    schema_resolution: SchemaResolution | None,
+) -> list[LoweredPayloadSpec]:
+    payloads = _payload_list(payload)
+    if payloads is not None:
+        if _looks_like_chunked_conversation_list(payloads):
+            nested_specs: list[LoweredPayloadSpec] = []
+            for index, item in enumerate(payloads):
+                nested_specs.extend(
+                    _lower_payload_specs(
+                        runtime_provider,
+                        item,
+                        f"{fallback_id}-{index}",
+                        depth=depth + 1,
+                        schema_resolution=schema_resolution,
+                    )
+                )
+            return nested_specs
+        return [
+            LoweredPayloadSpec(
+                provider=runtime_provider,
+                fallback_id=fallback_id,
+                mode="chunked_prompt",
+                payload=payloads,
+            )
+        ]
+
+    record = _payload_record(payload)
+    if record is None:
+        return []
+
+    if _payload_messages(record) is not None:
+        return [
+            LoweredPayloadSpec(
+                provider=runtime_provider,
+                fallback_id=fallback_id,
+                mode="generic_messages",
+                payload=record,
+            )
+        ]
+    if chatgpt.looks_like(record):
+        return [
+            LoweredPayloadSpec(
+                provider=Provider.CHATGPT,
+                fallback_id=fallback_id,
+                mode="single_record",
+                payload=record,
+            )
+        ]
+    if _looks_like_chunked_conversation(record):
+        return [
+            LoweredPayloadSpec(
+                provider=runtime_provider,
+                fallback_id=fallback_id,
+                mode="chunked_prompt",
+                payload=record,
+            )
+        ]
+    return []
+
+
+def _lower_payload_specs(
+    provider: str | Provider,
+    payload: object,
+    fallback_id: str,
+    *,
+    depth: int = 0,
+    schema_resolution: SchemaResolution | None = None,
+) -> list[LoweredPayloadSpec]:
+    runtime_provider = Provider.from_string(provider)
+    if depth > _MAX_PARSE_DEPTH:
+        logger.warning("Recursion depth exceeded parsing %s (provider=%s)", fallback_id, provider)
+        return []
+
+    shaped_payload = _schema_guided_payload(runtime_provider, payload, schema_resolution)
+    record = _payload_record(shaped_payload)
+    if record is not None and (conversations := _payload_conversations(record)):
+        lowered_specs: list[LoweredPayloadSpec] = []
+        for index, item in enumerate(conversations):
+            if item_record := _payload_record(item):
+                lowered_specs.extend(
+                    _lower_payload_specs(
+                        runtime_provider,
+                        item_record,
+                        f"{fallback_id}-{index}",
+                        depth=depth + 1,
+                        schema_resolution=schema_resolution,
+                    )
+                )
+        return lowered_specs
+
+    payloads = _payload_list(shaped_payload)
+
+    if runtime_provider is Provider.CHATGPT:
+        if payloads is not None:
+            return _lower_bundle_specs(runtime_provider, payloads, fallback_id)
+        return (
+            [
+                LoweredPayloadSpec(
+                    provider=runtime_provider, fallback_id=fallback_id, mode="single_record", payload=record
+                )
+            ]
+            if record is not None
+            else []
+        )
+
+    if runtime_provider is Provider.CLAUDE_AI:
+        if payloads is not None:
+            return _lower_bundle_specs(runtime_provider, payloads, fallback_id)
+        return (
+            [
+                LoweredPayloadSpec(
+                    provider=runtime_provider, fallback_id=fallback_id, mode="single_record", payload=record
+                )
+            ]
+            if record is not None
+            else []
+        )
+
+    if runtime_provider is Provider.CLAUDE_CODE:
+        return _lower_grouped_spec(runtime_provider, shaped_payload, fallback_id)
+
+    if runtime_provider is Provider.CODEX:
+        return _lower_grouped_spec(runtime_provider, shaped_payload, fallback_id)
+
+    if runtime_provider in (Provider.GEMINI, Provider.DRIVE):
+        return _lower_drive_like_specs(
+            runtime_provider,
+            shaped_payload,
+            fallback_id,
+            depth=depth,
+            schema_resolution=schema_resolution,
+        )
+
+    if record is not None and _payload_messages(record) is not None:
+        return [
+            LoweredPayloadSpec(
+                provider=runtime_provider,
+                fallback_id=fallback_id,
+                mode="generic_messages",
+                payload=record,
+            )
+        ]
+    if record is not None and chatgpt.looks_like(record):
+        return [
+            LoweredPayloadSpec(
+                provider=Provider.CHATGPT,
+                fallback_id=fallback_id,
+                mode="single_record",
+                payload=record,
+            )
+        ]
+    if record is not None and _looks_like_chunked_conversation(record):
+        return [
+            LoweredPayloadSpec(
+                provider=runtime_provider,
+                fallback_id=fallback_id,
+                mode="chunked_prompt",
+                payload=record,
+            )
+        ]
+    return []
+
+
 def _generic_messages_conversation(
     provider: Provider,
-    payload: PayloadMapping,
+    payload: PayloadRecord,
     fallback_id: str,
 ) -> ParsedConversation | None:
     messages_payload = _payload_messages(payload)
@@ -198,6 +397,38 @@ def _generic_messages_conversation(
     )
 
 
+def _parse_lowered_spec(spec: LoweredPayloadSpec) -> list[ParsedConversation]:
+    if spec.provider is Provider.CHATGPT:
+        record = _payload_record(spec.payload)
+        return [chatgpt.parse(record, spec.fallback_id)] if record is not None else []
+
+    if spec.provider is Provider.CLAUDE_AI:
+        record = _payload_record(spec.payload)
+        return [claude.parse_ai(record, spec.fallback_id)] if record is not None else []
+
+    if spec.provider is Provider.CLAUDE_CODE:
+        payloads = _payload_list(spec.payload)
+        return [claude.parse_code(payloads, spec.fallback_id)] if payloads is not None else []
+
+    if spec.provider is Provider.CODEX:
+        payloads = _payload_list(spec.payload)
+        return [codex.parse(payloads, spec.fallback_id)] if payloads is not None else []
+
+    if spec.mode == "chunked_prompt":
+        record = _payload_record(spec.payload)
+        payload = record if record is not None else {"chunks": _payload_list(spec.payload) or []}
+        return [drive.parse_chunked_prompt(spec.provider, payload, spec.fallback_id)]
+
+    if spec.mode == "generic_messages":
+        record = _payload_record(spec.payload)
+        generic = (
+            _generic_messages_conversation(spec.provider, record, spec.fallback_id) if record is not None else None
+        )
+        return [generic] if generic is not None else []
+
+    return []
+
+
 def parse_payload(
     provider: str | Provider,
     payload: object,
@@ -207,77 +438,17 @@ def parse_payload(
     schema_resolution: SchemaResolution | None = None,
 ) -> list[ParsedConversation]:
     """Dispatch parsed payload to the appropriate provider parser."""
-    runtime_provider = Provider.from_string(provider)
-    if _depth > _MAX_PARSE_DEPTH:
-        logger.warning("Recursion depth exceeded parsing %s (provider=%s)", fallback_id, provider)
-        return []
-
-    shaped_payload = _schema_guided_payload(runtime_provider, payload, schema_resolution)
-
-    if record := _payload_mapping(shaped_payload):
-        if conversations := _payload_conversations(record):
-            results: list[ParsedConversation] = []
-            for index, item in enumerate(conversations):
-                if item_record := _payload_mapping(item):
-                    results.extend(
-                        parse_payload(
-                            runtime_provider,
-                            item_record,
-                            f"{fallback_id}-{index}",
-                            _depth + 1,
-                            schema_resolution=schema_resolution,
-                        )
-                    )
-            return results
-    else:
-        record = None
-
-    payloads = _payload_list(shaped_payload)
-
-    if runtime_provider is Provider.CHATGPT:
-        if payloads is not None:
-            return _parse_bundle_items(payloads, fallback_id, chatgpt.parse)
-        return [chatgpt.parse(dict(record), fallback_id)] if record is not None else []
-
-    if runtime_provider is Provider.CLAUDE_AI:
-        if payloads is not None:
-            return _parse_bundle_items(payloads, fallback_id, claude.parse_ai)
-        return [claude.parse_ai(dict(record), fallback_id)] if record is not None else []
-
-    if runtime_provider is Provider.CLAUDE_CODE:
-        return _parse_grouped_records(shaped_payload, fallback_id, claude.parse_code)
-
-    if runtime_provider is Provider.CODEX:
-        return _parse_grouped_records(shaped_payload, fallback_id, codex.parse)
-
-    if runtime_provider in (Provider.GEMINI, Provider.DRIVE) and payloads is not None:
-        if _looks_like_chunked_conversation_list(payloads):
-            chunked_results: list[ParsedConversation] = []
-            for index, item in enumerate(payloads):
-                chunked_results.extend(
-                    parse_payload(
-                        runtime_provider,
-                        item,
-                        f"{fallback_id}-{index}",
-                        _depth + 1,
-                        schema_resolution=schema_resolution,
-                    )
-                )
-            return chunked_results
-        return [drive.parse_chunked_prompt(runtime_provider, {"chunks": payloads}, fallback_id)]
-
-    if record is None:
-        return []
-
-    generic = _generic_messages_conversation(runtime_provider, record, fallback_id)
-    if generic is not None:
-        return [generic]
-
-    if chatgpt.looks_like(record):
-        return [chatgpt.parse(dict(record), fallback_id)]
-    if _looks_like_chunked_conversation(record):
-        return [drive.parse_chunked_prompt(runtime_provider, dict(record), fallback_id)]
-    return []
+    lowered_specs = _lower_payload_specs(
+        provider,
+        payload,
+        fallback_id,
+        depth=_depth,
+        schema_resolution=schema_resolution,
+    )
+    conversations: list[ParsedConversation] = []
+    for spec in lowered_specs:
+        conversations.extend(_parse_lowered_spec(spec))
+    return conversations
 
 
 def parse_stream_payload(
@@ -310,18 +481,39 @@ def parse_drive_payload(
         if payloads and all(isinstance(item, str) or _payload_record(item) is not None for item in payloads):
             first_record = _payload_mapping(payloads[0]) if payloads else None
             if first_record is None or "role" in first_record or "text" in first_record:
-                return [drive.parse_chunked_prompt(runtime_provider, {"chunks": payloads}, fallback_id)]
+                spec = LoweredPayloadSpec(
+                    provider=runtime_provider,
+                    fallback_id=fallback_id,
+                    mode="chunked_prompt",
+                    payload=payloads,
+                )
+                return _parse_lowered_spec(spec)
 
-        nested_results: list[ParsedConversation] = []
+        nested_conversations: list[ParsedConversation] = []
         for index, item in enumerate(payloads):
-            nested_results.extend(parse_drive_payload(runtime_provider, item, f"{fallback_id}-{index}", _depth + 1))
-        return nested_results
+            nested_conversations.extend(
+                parse_drive_payload(
+                    runtime_provider,
+                    item,
+                    f"{fallback_id}-{index}",
+                    _depth + 1,
+                )
+            )
+        return nested_conversations
 
-    if record := _payload_mapping(payload):
+    if record := _payload_record(payload):
         if "chunkedPrompt" in record or "chunks" in record:
-            return [drive.parse_chunked_prompt(runtime_provider, dict(record), fallback_id)]
+            spec = LoweredPayloadSpec(
+                provider=runtime_provider,
+                fallback_id=fallback_id,
+                mode="chunked_prompt",
+                payload=record,
+            )
+            return _parse_lowered_spec(spec)
+
         detected = detect_provider(record) or runtime_provider
-        return parse_payload(detected, record, fallback_id)
+        return parse_payload(detected, record, fallback_id, _depth + 1)
+
     return []
 
 


### PR DESCRIPTION
## Summary
Renew the source-ingestion boundary around two explicit seams: a shared conversation materializer for prepare/ingest record generation, and a lowered-payload dispatch layer that separates provider parser handoff from recursive payload normalization.

## Problem
The archive-renewal program had already tightened storage and search result contracts, but the upstream ingestion layer still carried older path-dependent glue:

- `prepare_transform.py` and `ingest_worker.py` both reimplemented the same conversation-to-record tuple lowering logic
- `sources/dispatch.py` mixed provider parser calls with recursion, schema-guided reshaping, and drive/generic fallback lowering in one large conditional path
- that kept the ingestion boundary harder to reason about than the substrate beneath it

## Solution
- Added `polylogue/pipeline/materialization_runtime.py` as the typed materialization seam for conversation/message/content-block/attachment lowering.
- Rewired `polylogue/pipeline/prepare_transform.py` and `polylogue/pipeline/services/ingest_worker.py` to consume that shared materialized conversation shape instead of maintaining separate transform pipelines.
- Moved `_timestamp_sort_key` to the shared materialization seam and re-used it from `prepare_models.py`.
- Rebuilt `polylogue/sources/dispatch.py` around a typed lowered-payload carrier so payload normalization, recursion, and provider parser invocation are separate concerns.
- Kept `parse_drive_payload()`'s recursive provider re-dispatch contract intact while still using the lowered carrier for chunked-drive payloads.

## Verification
- `ruff check polylogue/pipeline/materialization_runtime.py polylogue/pipeline/prepare_models.py polylogue/pipeline/prepare_transform.py polylogue/pipeline/services/ingest_worker.py`
- `mypy polylogue/pipeline/materialization_runtime.py polylogue/pipeline/prepare_models.py polylogue/pipeline/prepare_transform.py polylogue/pipeline/services/ingest_worker.py`
- `pytest -q -n 0 tests/unit/pipeline/test_ingest_batch.py tests/unit/pipeline/test_resilience.py`
- `pytest -q -n 0 tests/unit/pipeline/test_roundtrip_hydration_laws.py tests/unit/pipeline/test_prepare_records.py`
- `ruff check polylogue/sources/dispatch.py`
- `mypy polylogue/sources/dispatch.py`
- `pytest -q -n 0 tests/unit/sources/test_source_laws.py tests/unit/pipeline/test_resilience.py tests/unit/sources/test_assembly.py`
- `devtools verify`

## Risks and Follow-ups
- This PR intentionally stops short of rewriting `assembly.py` and the semantic-capture helper surface; those remain the next renewal tail once this source-ingestion slice is in CI.

Closes #243
Ref #222
