### PR TITLE
refactor: contract CLI and MCP read surfaces

### DIFF
--- a/polylogue/cli/embed_runtime.py
+++ b/polylogue/cli/embed_runtime.py
@@ -9,7 +9,7 @@ import click
 if TYPE_CHECKING:
     from polylogue.lib.models import Conversation
     from polylogue.protocols import VectorProvider
-    from polylogue.storage.repository import ConversationRepository
+    from polylogue.storage.repository_contracts import RepositoryBackendProtocol
     from polylogue.storage.store import MessageRecord
 
 
@@ -38,9 +38,18 @@ class _HasUI(Protocol):
     ui: _EmbedUI
 
 
+class _EmbedConversationStore(Protocol):
+    @property
+    def backend(self) -> RepositoryBackendProtocol: ...
+
+    async def get_messages(self, conversation_id: str) -> list[MessageRecord]: ...
+
+    async def view(self, conversation_id: str) -> Conversation | None: ...
+
+
 def embed_single(
     env: object,
-    repo: ConversationRepository,
+    repo: _EmbedConversationStore,
     vec_provider: VectorProvider,
     conversation_id: str,
 ) -> None:
@@ -51,7 +60,7 @@ def embed_single(
         conv = await repo.view(conversation_id)
         if conv is None:
             return None
-        messages = await repo.queries.get_messages(str(conv.id))
+        messages = await repo.get_messages(str(conv.id))
         return conv, messages
 
     result = run_coroutine_sync(_fetch())
@@ -77,7 +86,7 @@ def embed_single(
 
 def embed_batch(
     env: object,
-    repo: ConversationRepository,
+    repo: _EmbedConversationStore,
     vec_provider: VectorProvider,
     *,
     rebuild: bool = False,
@@ -124,7 +133,7 @@ def embed_batch(
     error_count = 0
 
     def _embed_one(conversation_id: str) -> bool:
-        messages = run_coroutine_sync(repo.queries.get_messages(conversation_id))
+        messages = run_coroutine_sync(repo.get_messages(conversation_id))
         if messages:
             vec_provider.upsert(conversation_id, messages)
             return True

--- a/polylogue/cli/query.py
+++ b/polylogue/cli/query.py
@@ -574,7 +574,7 @@ async def async_execute_query(env: AppEnv, params: dict[str, Any]) -> None:
 
     if route == QueryRoute.SUMMARY_STATS:
         summaries = await filter_chain.list_summaries()
-        msg_counts = await repo.queries.get_message_counts_batch([str(summary.id) for summary in summaries])
+        msg_counts = await repo.get_message_counts_batch([str(summary.id) for summary in summaries])
         _query_output.output_stats_by_summaries(
             env,
             summaries,
@@ -599,18 +599,16 @@ async def async_execute_query(env: AppEnv, params: dict[str, Any]) -> None:
             )
             return
         if await _await_if_needed(query_plan.can_use_action_event_stats_with(repo)) is True:
-            records_result = repo.queries.list_conversations(query_plan.record_query.with_limit(query_plan.limit))
-            if inspect.isawaitable(records_result):
-                records = await records_result
-                await _query_output.output_stats_by_semantic_query(
-                    env,
-                    [record.conversation_id for record in records],
-                    repo,
-                    plan.stats_dimension or "all",
-                    selection=plan.selection,
-                    output_format=plan.output.output_format,
-                )
-                return
+            summaries = await repo.list_summaries_by_query(query_plan.record_query.with_limit(query_plan.limit))
+            await _query_output.output_stats_by_semantic_summaries(
+                env,
+                summaries,
+                repo,
+                plan.stats_dimension or "all",
+                selection=plan.selection,
+                output_format=plan.output.output_format,
+            )
+            return
 
     if route == QueryRoute.STATS_BY and plan.stats_dimension in {"repo", "work-kind"}:
         if filter_chain.can_use_summaries():
@@ -625,10 +623,10 @@ async def async_execute_query(env: AppEnv, params: dict[str, Any]) -> None:
             )
             return
         query_plan = filter_chain.build_query_plan()
-        records = await repo.queries.list_conversations(query_plan.record_query.with_limit(query_plan.limit))
-        await _query_output.output_stats_by_profile_query(
+        summaries = await repo.list_summaries_by_query(query_plan.record_query.with_limit(query_plan.limit))
+        await _query_output.output_stats_by_profile_summaries(
             env,
-            [record.conversation_id for record in records],
+            summaries,
             repo,
             plan.stats_dimension or "all",
             selection=plan.selection,

--- a/polylogue/cli/query_actions.py
+++ b/polylogue/cli/query_actions.py
@@ -14,8 +14,7 @@ if TYPE_CHECKING:
     from polylogue.lib.filters import ConversationFilter
     from polylogue.lib.models import Conversation, ConversationSummary
     from polylogue.lib.query_spec import ConversationQuerySpec
-    from polylogue.protocols import ConversationQueryRuntimeStore
-    from polylogue.storage.repository import ConversationRepository
+    from polylogue.protocols import ConversationQueryRuntimeStore, TagStore
 
 
 async def resolve_stream_target(
@@ -62,7 +61,7 @@ async def apply_modifiers(
     env: AppEnv,
     results: Sequence[Conversation | ConversationSummary],
     params: dict[str, Any],
-    repo: ConversationRepository | None = None,
+    repo: TagStore | None = None,
 ) -> None:
     """Apply metadata modifiers to matched conversations."""
     repo = repo or env.repository

--- a/polylogue/cli/query_output.py
+++ b/polylogue/cli/query_output.py
@@ -347,7 +347,7 @@ async def output_summary_list(
     msg_counts: dict[str, int] = {}
     if repo:
         ids = [str(summary.id) for summary in summaries]
-        msg_counts = await repo.queries.get_message_counts_batch(ids)
+        msg_counts = await repo.get_message_counts_batch(ids)
 
     fields = params.get("fields")
     fields_value = str(fields) if isinstance(fields, str) else None
@@ -556,12 +556,13 @@ async def stream_conversation(
     message_limit: int | None = None,
 ) -> int:
     """Stream conversation messages to stdout without buffering."""
-    conv_record = await repo.queries.get_conversation(conversation_id)
-    if not conv_record:
+    projection = await repo.get_render_projection(conversation_id)
+    if projection is None:
         click.echo(f"Conversation not found: {conversation_id}", err=True)
         raise SystemExit(1)
+    conv_record = projection.conversation
 
-    stats = await repo.queries.get_conversation_stats(conversation_id)
+    stats = await repo.get_conversation_stats(conversation_id)
     sys.stdout.write(
         render_stream_header(
             conversation_id=conversation_id,

--- a/polylogue/cli/query_semantic.py
+++ b/polylogue/cli/query_semantic.py
@@ -142,13 +142,12 @@ async def _load_semantic_stats_conversations(
 
     from polylogue.storage.hydrators import conversation_from_records
 
-    queries = repo.queries
-    records = await queries.get_conversations_batch(conversation_ids)
-    messages_by_conversation = await queries.get_messages_batch(conversation_ids)
+    records = await repo.get_conversations_batch(conversation_ids)
+    messages_by_conversation = await repo.get_messages_batch(conversation_ids)
 
     attachments_by_conversation: dict[str, list[AttachmentRecord]] = {}
     attachments_result: Awaitable[dict[str, list[AttachmentRecord]]] | dict[str, list[AttachmentRecord]] | object
-    attachments_result = queries.get_attachments_batch(conversation_ids)
+    attachments_result = repo.get_attachments_batch(conversation_ids)
     if isinstance(attachments_result, Awaitable):
         attachments_by_conversation = await attachments_result
     elif isinstance(attachments_result, dict):

--- a/polylogue/cli/query_stats.py
+++ b/polylogue/cli/query_stats.py
@@ -10,7 +10,6 @@ from typing import TYPE_CHECKING
 import click
 
 from polylogue.cli.machine_errors import error_no_results
-from polylogue.storage.backends.queries import stats as stats_q
 
 if TYPE_CHECKING:
     from polylogue.cli.types import AppEnv
@@ -137,23 +136,17 @@ async def output_stats_sql(
             conv_ids = None
     else:
         conv_ids = None
-        async with repo.backend.read_connection() as conn:
-            await conn.execute("BEGIN")
-            try:
-                archive_stats = await repo.get_archive_stats(conn=conn)
-                conv_count = archive_stats.total_conversations
-                if conv_count == 0:
-                    if output_format == "json":
-                        error_no_results("No conversations in archive.").emit(exit_code=2)
-                    env.ui.console.print("No conversations in archive.")
-                    return
-                stats = await stats_q.aggregate_message_stats(conn, None)
-            finally:
-                if conn.in_transaction:
-                    await conn.rollback()
+        archive_stats = await repo.get_archive_stats()
+        conv_count = archive_stats.total_conversations
+        if conv_count == 0:
+            if output_format == "json":
+                error_no_results("No conversations in archive.").emit(exit_code=2)
+            env.ui.console.print("No conversations in archive.")
+            return
+        stats = await repo.aggregate_message_stats()
 
     if has_filters:
-        stats = await repo.queries.aggregate_message_stats(conv_ids)
+        stats = await repo.aggregate_message_stats(conv_ids)
 
     date_range = ""
     if stats["min_sort_key"] and stats["max_sort_key"]:

--- a/polylogue/mcp/server.py
+++ b/polylogue/mcp/server.py
@@ -13,7 +13,6 @@ from polylogue.mcp.server_support import (
     _error_json,
     _extract_fenced_code,
     _get_config,
-    _get_repo,
     _get_runtime_services,
     _json_payload,
     _safe_call,
@@ -21,20 +20,45 @@ from polylogue.mcp.server_support import (
 )
 from polylogue.mcp.server_tools import register_tools
 from polylogue.operations import ArchiveOperations
+from polylogue.protocols import ConversationQueryRuntimeStore, TagStore
 from polylogue.services import RuntimeServices
+from polylogue.storage.backends.async_sqlite import SQLiteBackend
+from polylogue.storage.repository import ConversationRepository
 
 if TYPE_CHECKING:
     from mcp.server.fastmcp import FastMCP
 
 
+def _get_repo() -> ConversationRepository:
+    """Return the canonical server-level repository injection seam."""
+    return _get_runtime_services().get_repository()
+
+
+def _get_query_store() -> ConversationQueryRuntimeStore:
+    """Return the query/runtime store used by read-heavy MCP surfaces."""
+    return _get_repo()
+
+
+def _get_tag_store() -> TagStore:
+    """Return the tag/metadata store used by mutation/resource surfaces."""
+    return _get_repo()
+
+
+def _get_backend() -> SQLiteBackend:
+    """Return the backend bound to the injected repository when available."""
+    backend = getattr(_get_repo(), "backend", None)
+    if isinstance(backend, SQLiteBackend):
+        return backend
+    return _get_runtime_services().get_backend()
+
+
 def _get_archive_ops() -> ArchiveOperations:
     """Return canonical archive operations for MCP read surfaces."""
-    repo = _get_repo()
     services = _get_runtime_services()
     return ArchiveOperations(
         config=services.config if services is not None else None,
-        repository=repo,
-        backend=getattr(repo, "backend", None),
+        repository=_get_repo(),
+        backend=_get_backend(),
     )
 
 
@@ -57,7 +81,9 @@ def build_server() -> FastMCP:
         safe_call=lambda fn_name, fn: _safe_call(fn_name, fn),
         async_safe_call=lambda fn_name, fn: _async_safe_call(fn_name, fn),
         error_json=lambda message, **extra: _error_json(message, **extra),
-        get_repo=lambda: _get_repo(),
+        get_query_store=lambda: _get_query_store(),
+        get_tag_store=lambda: _get_tag_store(),
+        get_backend=lambda: _get_backend(),
         get_config=lambda: _get_config(),
         get_archive_ops=lambda: _get_archive_ops(),
         extract_fenced_code=_extract_fenced_code,

--- a/polylogue/mcp/server_maintenance_tools.py
+++ b/polylogue/mcp/server_maintenance_tools.py
@@ -18,8 +18,7 @@ def register_maintenance_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
         async def run() -> str:
             from polylogue.pipeline.services.indexing import IndexService
 
-            repo = hooks.get_repo()
-            service = IndexService(config=hooks.get_config(), backend=repo.backend)
+            service = IndexService(config=hooks.get_config(), backend=hooks.get_backend())
             success = await service.rebuild_index()
             status_info = await service.get_index_status()
             index_exists_value = status_info.get("exists", False)
@@ -40,8 +39,7 @@ def register_maintenance_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
         async def run() -> str:
             from polylogue.pipeline.services.indexing import IndexService
 
-            repo = hooks.get_repo()
-            service = IndexService(config=hooks.get_config(), backend=repo.backend)
+            service = IndexService(config=hooks.get_config(), backend=hooks.get_backend())
             success = await service.update_index(conversation_ids)
             return hooks.json_payload(
                 MCPMutationStatusPayload(
@@ -58,7 +56,7 @@ def register_maintenance_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
         async def run() -> str:
             from polylogue.rendering.formatting import format_conversation
 
-            conv = await hooks.get_repo().view(id)
+            conv = await hooks.get_archive_ops().get_conversation(id)
             if conv is None:
                 return hooks.error_json(f"Conversation not found: {id}")
             valid_formats = {

--- a/polylogue/mcp/server_mutation_tools.py
+++ b/polylogue/mcp/server_mutation_tools.py
@@ -17,8 +17,7 @@ def register_mutation_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
     @mcp.tool()
     async def add_tag(conversation_id: str, tag: str) -> str:
         async def run() -> str:
-            repo = hooks.get_repo()
-            await repo.add_tag(conversation_id, tag)
+            await hooks.get_tag_store().add_tag(conversation_id, tag)
             return hooks.json_payload(
                 MCPMutationStatusPayload(
                     status="ok",
@@ -33,8 +32,7 @@ def register_mutation_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
     @mcp.tool()
     async def remove_tag(conversation_id: str, tag: str) -> str:
         async def run() -> str:
-            repo = hooks.get_repo()
-            await repo.remove_tag(conversation_id, tag)
+            await hooks.get_tag_store().remove_tag(conversation_id, tag)
             return hooks.json_payload(
                 MCPMutationStatusPayload(
                     status="ok",
@@ -49,7 +47,7 @@ def register_mutation_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
     @mcp.tool()
     async def list_tags(provider: str | None = None) -> str:
         async def run() -> str:
-            tags = await hooks.get_repo().list_tags(provider=provider)
+            tags = await hooks.get_tag_store().list_tags(provider=provider)
             return hooks.json_payload(MCPTagCountsPayload(root=tags))
 
         return await hooks.async_safe_call("list_tags", run)
@@ -57,7 +55,7 @@ def register_mutation_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
     @mcp.tool()
     async def get_metadata(conversation_id: str) -> str:
         async def run() -> str:
-            metadata = await hooks.get_repo().get_metadata(conversation_id)
+            metadata = await hooks.get_tag_store().get_metadata(conversation_id)
             return hooks.json_payload(MCPMetadataPayload(root=metadata))
 
         return await hooks.async_safe_call("get_metadata", run)
@@ -65,12 +63,11 @@ def register_mutation_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
     @mcp.tool()
     async def set_metadata(conversation_id: str, key: str, value: str) -> str:
         async def run() -> str:
-            repo = hooks.get_repo()
             try:
                 parsed_value = json.loads(value)
             except (json.JSONDecodeError, TypeError):
                 parsed_value = value
-            await repo.update_metadata(conversation_id, key, parsed_value)
+            await hooks.get_tag_store().update_metadata(conversation_id, key, parsed_value)
             return hooks.json_payload(
                 MCPMutationStatusPayload(
                     status="ok",
@@ -85,7 +82,7 @@ def register_mutation_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
     @mcp.tool()
     async def delete_metadata(conversation_id: str, key: str) -> str:
         async def run() -> str:
-            await hooks.get_repo().delete_metadata(conversation_id, key)
+            await hooks.get_tag_store().delete_metadata(conversation_id, key)
             return hooks.json_payload(
                 MCPMutationStatusPayload(
                     status="ok",
@@ -105,7 +102,7 @@ def register_mutation_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
                     "Safety guard: set confirm=true to delete",
                     conversation_id=conversation_id,
                 )
-            deleted = await hooks.get_repo().delete_conversation(conversation_id)
+            deleted = await hooks.get_query_store().delete_conversation(conversation_id)
             return hooks.json_payload(
                 MCPMutationStatusPayload(
                     status="deleted" if deleted else "not_found",

--- a/polylogue/mcp/server_product_tools.py
+++ b/polylogue/mcp/server_product_tools.py
@@ -148,7 +148,7 @@ def register_product_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
         async def run() -> str:
             from polylogue.lib.coverage import analyze_coverage
 
-            summaries = await hooks.get_repo().list_summaries()
+            summaries = await hooks.get_query_store().list_summaries()
             coverage = analyze_coverage(summaries)
             return hooks.json_payload(
                 MCPRootPayload(

--- a/polylogue/mcp/server_prompts.py
+++ b/polylogue/mcp/server_prompts.py
@@ -23,14 +23,14 @@ def register_prompts(mcp: FastMCP, hooks: ServerCallbacks) -> None:
         since: str | None = None,
         limit: int = 50,
     ) -> str:
-        repo = hooks.get_repo()
+        store = hooks.get_query_store()
         spec = build_query_spec(
             query="error",
             provider=provider,
             since=since,
             limit=hooks.clamp_limit(limit),
         )
-        convs = await spec.list(repo)
+        convs = await spec.list(store)
 
         error_contexts = []
         for conv in convs:
@@ -65,13 +65,13 @@ Error contexts:
 
     @mcp.prompt()
     async def summarize_week(limit: int = 100) -> str:
-        repo = hooks.get_repo()
+        store = hooks.get_query_store()
         week_ago = (datetime.now(tz=timezone.utc) - timedelta(days=7)).isoformat()
         spec = build_query_spec(
             since=week_ago,
             limit=hooks.clamp_limit(limit),
         )
-        convs = await spec.list(repo)
+        convs = await spec.list(store)
 
         by_provider: dict[str, int] = {}
         total_messages = 0
@@ -97,8 +97,8 @@ Focus on actionable insights and patterns, not exhaustive summaries.
 
     @mcp.prompt()
     async def extract_code(language: str = "", limit: int = 50) -> str:
-        repo = hooks.get_repo()
-        convs = await build_query_spec(limit=hooks.clamp_limit(limit)).list(repo)
+        store = hooks.get_query_store()
+        convs = await build_query_spec(limit=hooks.clamp_limit(limit)).list(store)
 
         code_snippets: list[dict[str, str]] = []
         for conv in convs:
@@ -128,9 +128,9 @@ Code snippets:
 
     @mcp.prompt()
     async def compare_conversations(id1: str, id2: str) -> str:
-        repo = hooks.get_repo()
-        conv1 = await repo.view(id1)
-        conv2 = await repo.view(id2)
+        store = hooks.get_query_store()
+        conv1 = await store.get_eager(id1)
+        conv2 = await store.get_eager(id2)
 
         def _summarize(conv: Any) -> dict[str, Any]:
             if conv is None:
@@ -165,12 +165,12 @@ Conversation 2:
 
     @mcp.prompt()
     async def extract_patterns(provider: str | None = None, limit: int = 30) -> str:
-        repo = hooks.get_repo()
+        store = hooks.get_query_store()
         spec = build_query_spec(
             provider=provider,
             limit=hooks.clamp_limit(limit),
         )
-        convs = await spec.list(repo)
+        convs = await spec.list(store)
 
         summaries = []
         for conv in convs:

--- a/polylogue/mcp/server_resources.py
+++ b/polylogue/mcp/server_resources.py
@@ -25,7 +25,7 @@ def register_resources(mcp: FastMCP, hooks: ServerCallbacks) -> None:
 
     @mcp.resource("polylogue://stats")
     async def stats_resource() -> str:
-        archive_stats = await hooks.get_repo().get_archive_stats()
+        archive_stats = await hooks.get_archive_ops().storage_stats()
         return hooks.json_payload(
             MCPArchiveStatsPayload.from_archive_stats(
                 archive_stats,
@@ -37,19 +37,19 @@ def register_resources(mcp: FastMCP, hooks: ServerCallbacks) -> None:
 
     @mcp.resource("polylogue://conversations")
     async def conversations_resource() -> str:
-        convs = await build_query_spec().list(hooks.get_repo())
+        convs = await build_query_spec().list(hooks.get_query_store())
         return hooks.json_payload(conversation_summary_list_payload(convs))
 
     @mcp.resource("polylogue://conversation/{conv_id}")
     async def conversation_resource(conv_id: str) -> str:
-        conv = await hooks.get_repo().get(conv_id)
+        conv = await hooks.get_archive_ops().get_conversation(conv_id)
         if not conv:
             return hooks.error_json(f"Conversation not found: {conv_id}")
         return hooks.json_payload(MCPConversationDetailPayload.from_conversation(conv))
 
     @mcp.resource("polylogue://tags")
     async def tags_resource() -> str:
-        tags = await hooks.get_repo().list_tags()
+        tags = await hooks.get_tag_store().list_tags()
         return hooks.json_payload(MCPTagCountsPayload(root=tags))
 
     @mcp.resource("polylogue://health")

--- a/polylogue/mcp/server_support.py
+++ b/polylogue/mcp/server_support.py
@@ -11,12 +11,13 @@ from pydantic import BaseModel
 from polylogue.logging import get_logger
 from polylogue.mcp.payloads import MCPErrorPayload
 from polylogue.operations import ArchiveOperations
+from polylogue.protocols import ConversationQueryRuntimeStore, TagStore
 from polylogue.services import RuntimeServices, build_runtime_services
 from polylogue.surface_payloads import serialize_surface_payload
 
 if TYPE_CHECKING:
     from polylogue.config import Config
-    from polylogue.storage.repository import ConversationRepository
+    from polylogue.storage.backends.async_sqlite import SQLiteBackend
 
 logger = get_logger(__name__)
 _runtime_services: RuntimeServices | None = None
@@ -34,7 +35,9 @@ class ServerCallbacks:
     safe_call: Callable[[str, Callable[[], str]], str]
     async_safe_call: Callable[[str, Callable[[], Awaitable[str]]], Awaitable[str]]
     error_json: Callable[..., str]
-    get_repo: Callable[[], ConversationRepository]
+    get_query_store: Callable[[], ConversationQueryRuntimeStore]
+    get_tag_store: Callable[[], TagStore]
+    get_backend: Callable[[], SQLiteBackend]
     get_config: Callable[[], Config]
     get_archive_ops: Callable[[], ArchiveOperations]
     extract_fenced_code: Callable[[str, str], list[dict[str, str]]]
@@ -138,9 +141,19 @@ def _get_runtime_services() -> RuntimeServices:
     return _runtime_services
 
 
-def _get_repo() -> ConversationRepository:
-    """Return the MCP repository from the configured runtime services."""
+def _get_query_store() -> ConversationQueryRuntimeStore:
+    """Return the MCP query/runtime store from the configured runtime services."""
     return _get_runtime_services().get_repository()
+
+
+def _get_tag_store() -> TagStore:
+    """Return the MCP tag/metadata store from the configured runtime services."""
+    return _get_runtime_services().get_repository()
+
+
+def _get_backend() -> SQLiteBackend:
+    """Return the configured backend for maintenance surfaces."""
+    return _get_runtime_services().get_backend()
 
 
 def _get_config() -> Config:
@@ -154,9 +167,11 @@ __all__ = [
     "_clamp_limit",
     "_error_json",
     "_extract_fenced_code",
+    "_get_backend",
     "_get_config",
-    "_get_repo",
+    "_get_query_store",
     "_get_runtime_services",
+    "_get_tag_store",
     "_json_payload",
     "_safe_call",
     "_set_runtime_services",

--- a/polylogue/mcp/server_tools.py
+++ b/polylogue/mcp/server_tools.py
@@ -154,12 +154,11 @@ def register_read_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
     @mcp.tool()
     async def get_conversation_summary(id: str) -> str:
         async def run() -> str:
-            repo = hooks.get_repo()
-            full_id = await repo.resolve_id(id) or id
-            summary = await repo.get_summary(full_id)
+            ops = hooks.get_archive_ops()
+            summary = await ops.get_conversation_summary(id)
             if summary is None:
                 return hooks.error_json(f"Conversation not found: {id}")
-            stats = await repo.queries.get_conversation_stats(str(full_id))
+            stats = await ops.get_conversation_stats(id)
             return hooks.json_payload(
                 MCPConversationSummaryPayload.from_summary(
                     summary,
@@ -172,7 +171,7 @@ def register_read_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
     @mcp.tool()
     async def get_session_tree(conversation_id: str) -> str:
         async def run() -> str:
-            tree = await hooks.get_repo().get_session_tree(conversation_id)
+            tree = await hooks.get_archive_ops().get_session_tree(conversation_id)
             return hooks.json_payload(conversation_summary_list_payload(tree))
 
         return await hooks.async_safe_call("get_session_tree", run)
@@ -180,7 +179,7 @@ def register_read_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
     @mcp.tool()
     async def get_stats_by(group_by: str = "provider") -> str:
         async def run() -> str:
-            root = await hooks.get_repo().queries.get_stats_by(group_by)
+            root = await hooks.get_archive_ops().get_stats_by(group_by)
             return hooks.json_payload(MCPStatsByPayload(root=root))
 
         return await hooks.async_safe_call("get_stats_by", run)

--- a/polylogue/operations/archive.py
+++ b/polylogue/operations/archive.py
@@ -36,6 +36,7 @@ from polylogue.archive_products import (
     WorkThreadProduct,
     WorkThreadProductQuery,
 )
+from polylogue.lib.conversation_models import ConversationSummary
 from polylogue.lib.query_spec import ConversationQuerySpec
 from polylogue.maintenance_targets import build_maintenance_target_catalog
 from polylogue.paths import conversation_render_root
@@ -198,6 +199,14 @@ class ArchiveSearchMixin:
     async def get_conversation(self, conversation_id: str) -> Conversation | None:
         return await self.repository.view(conversation_id)
 
+    async def get_conversation_summary(self, conversation_id: str) -> ConversationSummary | None:
+        full_id = await self.repository.resolve_id(conversation_id) or conversation_id
+        return await self.repository.get_summary(str(full_id))
+
+    async def get_conversation_stats(self, conversation_id: str) -> dict[str, int]:
+        full_id = await self.repository.resolve_id(conversation_id) or conversation_id
+        return await self.repository.get_conversation_stats(str(full_id))
+
     async def get_conversations(self, conversation_ids: list[str]) -> list[Conversation]:
         return await self.repository.get_many(conversation_ids)
 
@@ -211,6 +220,15 @@ class ArchiveSearchMixin:
 
     async def query_conversations(self, spec: ConversationQuerySpec) -> list[Conversation]:
         return await spec.list(self.repository)
+
+    async def get_session_tree(self, conversation_id: str) -> list[Conversation]:
+        return await self.repository.get_session_tree(conversation_id)
+
+    async def get_stats_by(self, group_by: str = "provider") -> dict[str, int]:
+        return await self.repository.get_stats_by(group_by)
+
+    async def list_tags(self, *, provider: str | None = None) -> dict[str, int]:
+        return await self.repository.list_tags(provider=provider)
 
     async def search(
         self,
@@ -290,7 +308,7 @@ class ArchiveStatsMixin:
 
     async def summary_stats(self) -> ArchiveStats:
         storage_snapshot = await self.storage_stats()
-        aggregate_stats = await self.repository.queries.aggregate_message_stats()
+        aggregate_stats = await self.repository.aggregate_message_stats()
         tags = await self.repository.list_tags()
         recent = await self.list_conversations(limit=5)
 

--- a/polylogue/protocols.py
+++ b/polylogue/protocols.py
@@ -31,9 +31,10 @@ if TYPE_CHECKING:
     from polylogue.lib.session_profile import SessionProfile
     from polylogue.lib.stats import ArchiveStats
     from polylogue.storage.action_event_artifacts import ActionEventArtifactState
+    from polylogue.storage.archive_views import ConversationRenderProjection
     from polylogue.storage.backends.queries.stats import AggregateMessageStats
     from polylogue.storage.query_models import ConversationRecordQuery
-    from polylogue.storage.repository_contracts import RepositoryBackendProtocol
+    from polylogue.storage.store import ConversationRecord
     from polylogue.types import ConversationId
 
 
@@ -252,8 +253,6 @@ class ConversationQueryRuntimeStore(
 class ArchiveMessageQueryStore(Protocol):
     """Low-level archive/message query band used by CLI output and stats helpers."""
 
-    async def get_conversation(self, conversation_id: str) -> ConversationRecord | None: ...
-
     async def get_messages(self, conversation_id: str) -> list[MessageRecord]: ...
 
     async def get_conversation_stats(self, conversation_id: str) -> dict[str, int]: ...
@@ -264,6 +263,8 @@ class ArchiveMessageQueryStore(Protocol):
         self,
         conversation_ids: list[str] | None = None,
     ) -> AggregateMessageStats: ...
+
+    async def get_stats_by(self, group_by: str = "provider") -> dict[str, int]: ...
 
 
 @runtime_checkable
@@ -287,16 +288,31 @@ class SemanticArchiveQueryStore(ArchiveMessageQueryStore, Protocol):
 class ConversationOutputStore(ConversationReader, Protocol):
     """Conversation output surface used by streaming and summary display helpers."""
 
-    @property
-    def queries(self) -> SemanticArchiveQueryStore: ...
+    async def get_render_projection(
+        self,
+        conversation_id: str,
+    ) -> ConversationRenderProjection | None: ...
+
+    async def get_conversation_stats(self, conversation_id: str) -> dict[str, int]: ...
+
+    async def get_message_counts_batch(self, conversation_ids: list[str]) -> dict[str, int]: ...
 
 
 @runtime_checkable
 class ConversationSemanticStatsStore(ActionEventArtifactReader, Protocol):
     """Semantic stats surface for action-event-backed grouped output."""
 
-    @property
-    def queries(self) -> SemanticArchiveQueryStore: ...
+    async def get_conversations_batch(self, ids: list[str]) -> list[ConversationRecord]: ...
+
+    async def get_messages_batch(
+        self,
+        conversation_ids: list[str],
+    ) -> dict[str, list[MessageRecord]]: ...
+
+    async def get_attachments_batch(
+        self,
+        conversation_ids: list[str],
+    ) -> dict[str, list[AttachmentRecord]]: ...
 
     async def get_action_events_batch(
         self,
@@ -312,14 +328,18 @@ class ConversationArchiveStatsStore(
 ):
     """Archive stats/profile surface consumed by grouped CLI output helpers."""
 
-    @property
-    def backend(self) -> RepositoryBackendProtocol: ...
+    async def aggregate_message_stats(
+        self,
+        conversation_ids: list[str] | None = None,
+    ) -> AggregateMessageStats: ...
 
     async def get_archive_stats(
         self,
         *,
         conn: aiosqlite.Connection | None = None,
     ) -> ArchiveStats: ...
+
+    async def get_stats_by(self, group_by: str = "provider") -> dict[str, int]: ...
 
     async def get_session_profiles_batch(
         self,
@@ -340,6 +360,21 @@ class TagStore(Protocol):
     async def update_metadata(self, conversation_id: str, key: str, value: object) -> None: ...
 
     async def delete_metadata(self, conversation_id: str, key: str) -> None: ...
+
+    async def add_tag(self, conversation_id: str, tag: str) -> None: ...
+
+    async def remove_tag(self, conversation_id: str, tag: str) -> None: ...
+
+
+@runtime_checkable
+class ConversationArchiveReadStore(ConversationReader, SearchStore, Protocol):
+    """Small read-side surface used by UI and resource adapters."""
+
+    async def get_archive_stats(
+        self,
+        *,
+        conn: aiosqlite.Connection | None = None,
+    ) -> ArchiveStats: ...
 
 
 @runtime_checkable

--- a/polylogue/storage/repository_archive_conversations.py
+++ b/polylogue/storage/repository_archive_conversations.py
@@ -16,7 +16,7 @@ from polylogue.storage.hydrators import (
 )
 from polylogue.storage.query_models import ConversationRecordQuery
 from polylogue.storage.repository_contracts import RepositoryBackendProtocol
-from polylogue.storage.store import ConversationRecord
+from polylogue.storage.store import AttachmentRecord, ConversationRecord, MessageRecord
 
 if TYPE_CHECKING:
     from polylogue.storage.backends.query_store import SQLiteQueryStore
@@ -66,6 +66,24 @@ class RepositoryArchiveConversationMixin:
 
     async def get_eager(self, conversation_id: str) -> Conversation | None:
         return await self.get(conversation_id)
+
+    async def get_messages(self, conversation_id: str) -> list[MessageRecord]:
+        return await self.queries.get_messages(conversation_id)
+
+    async def get_conversations_batch(self, ids: list[str]) -> list[ConversationRecord]:
+        return await self.queries.get_conversations_batch(ids)
+
+    async def get_messages_batch(
+        self,
+        conversation_ids: list[str],
+    ) -> dict[str, list[MessageRecord]]:
+        return await self.queries.get_messages_batch(conversation_ids)
+
+    async def get_attachments_batch(
+        self,
+        conversation_ids: list[str],
+    ) -> dict[str, list[AttachmentRecord]]:
+        return await self.queries.get_attachments_batch(conversation_ids)
 
     async def _hydrate_conversations(
         self,

--- a/polylogue/storage/repository_archive_queries.py
+++ b/polylogue/storage/repository_archive_queries.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, cast
 
 from polylogue.lib.conversation_models import Conversation, ConversationSummary
 from polylogue.protocols import ConversationQueryRuntimeStore
+from polylogue.storage.backends.queries.stats import AggregateMessageStats
 from polylogue.storage.query_models import ConversationRecordQuery
 
 if TYPE_CHECKING:
@@ -167,6 +168,21 @@ class RepositoryArchiveQueryMixin:
 
     async def count_by_query(self, query: ConversationRecordQuery) -> int:
         return await self.queries.count_conversations(query)
+
+    async def get_conversation_stats(self, conversation_id: str) -> dict[str, int]:
+        return await self.queries.get_conversation_stats(conversation_id)
+
+    async def get_message_counts_batch(self, conversation_ids: builtins.list[str]) -> dict[str, int]:
+        return await self.queries.get_message_counts_batch(conversation_ids)
+
+    async def aggregate_message_stats(
+        self,
+        conversation_ids: builtins.list[str] | None = None,
+    ) -> AggregateMessageStats:
+        return await self.queries.aggregate_message_stats(conversation_ids)
+
+    async def get_stats_by(self, group_by: str = "provider") -> dict[str, int]:
+        return await self.queries.get_stats_by(group_by)
 
     async def count(
         self,

--- a/polylogue/ui/tui/app.py
+++ b/polylogue/ui/tui/app.py
@@ -6,7 +6,7 @@ from textual.app import App, ComposeResult
 from textual.widgets import Footer, Header
 
 if TYPE_CHECKING:
-    from polylogue.storage.repository import ConversationRepository
+    from polylogue.protocols import ConversationArchiveReadStore
 
 
 class PolylogueApp(App[None]):
@@ -20,7 +20,7 @@ class PolylogueApp(App[None]):
 
     def __init__(
         self,
-        repository: ConversationRepository | None = None,
+        repository: ConversationArchiveReadStore | None = None,
     ) -> None:
         super().__init__()
         self._repository = repository

--- a/polylogue/ui/tui/screens/base.py
+++ b/polylogue/ui/tui/screens/base.py
@@ -6,11 +6,11 @@ from typing import TYPE_CHECKING
 from textual.containers import Container
 from textual.widgets import Markdown as MarkdownWidget
 
+from polylogue.protocols import ConversationArchiveReadStore
 from polylogue.rendering.core import format_conversation_markdown
 
 if TYPE_CHECKING:
     from polylogue.lib.conversation_models import Conversation
-    from polylogue.storage.repository import ConversationRepository
 
 
 ConversationMarkdownFormatter = Callable[["Conversation"], str]
@@ -21,12 +21,12 @@ class RepositoryBoundContainer(Container):
 
     def __init__(
         self,
-        repository: ConversationRepository | None = None,
+        repository: ConversationArchiveReadStore | None = None,
     ) -> None:
         super().__init__()
         self._repository = repository
 
-    def _get_repo(self, owner_name: str) -> ConversationRepository:
+    def _get_repo(self, owner_name: str) -> ConversationArchiveReadStore:
         """Return the injected repository or fail with a screen-specific message."""
         if self._repository is None:
             raise RuntimeError(f"{owner_name} widget requires an injected repository")

--- a/tests/unit/cli/test_embed.py
+++ b/tests/unit/cli/test_embed.py
@@ -81,8 +81,7 @@ def mock_repository() -> Any:
 def mock_repository_async(mock_conversation: Any) -> Any:
     repo = MagicMock()
     repo.view = AsyncMock(return_value=mock_conversation)
-    repo.queries = MagicMock()
-    repo.queries.get_messages = AsyncMock(return_value=_MOCK_MESSAGES)
+    repo.get_messages = AsyncMock(return_value=_MOCK_MESSAGES)
     return repo
 
 
@@ -177,9 +176,7 @@ class TestEmbedSingle:
     def test_embed_single_success(self, mock_env: Any, mock_repository_async: Any, capsys: Any) -> None:
         mock_vec_provider = MagicMock()
         _embed_single(mock_env, mock_repository_async, mock_vec_provider, "conv-123")
-        mock_vec_provider.upsert.assert_called_once_with(
-            "conv-123", mock_repository_async.queries.get_messages.return_value
-        )
+        mock_vec_provider.upsert.assert_called_once_with("conv-123", mock_repository_async.get_messages.return_value)
         captured = capsys.readouterr()
         assert "Embedding 2 messages" in captured.out
         assert "✓ Embedded" in captured.out
@@ -190,7 +187,7 @@ class TestEmbedSingle:
             _embed_single(mock_env, mock_repository_async, MagicMock(), "nonexistent")
 
     def test_embed_single_no_messages(self, mock_env: Any, mock_repository_async: Any, capsys: Any) -> None:
-        mock_repository_async.queries.get_messages = AsyncMock(return_value=[])
+        mock_repository_async.get_messages = AsyncMock(return_value=[])
         mock_vec_provider = MagicMock()
         _embed_single(mock_env, mock_repository_async, mock_vec_provider, "conv-123")
         mock_vec_provider.upsert.assert_not_called()

--- a/tests/unit/cli/test_query_exec.py
+++ b/tests/unit/cli/test_query_exec.py
@@ -83,15 +83,16 @@ def _make_env(*, repo: MagicMock | None = None, config: MagicMock | None = None)
     ui.console = MagicMock()
     ui.confirm = MagicMock(return_value=True)
     if repo is not None:
-        queries = repo.queries
-        if not isinstance(queries.get_conversation, AsyncMock):
-            queries.get_conversation = AsyncMock(return_value=None)
-        if not isinstance(queries.get_conversation_stats, AsyncMock):
-            queries.get_conversation_stats = AsyncMock(return_value={})
-        if not isinstance(queries.get_message_counts_batch, AsyncMock):
-            queries.get_message_counts_batch = AsyncMock(return_value={})
-        if not isinstance(queries.aggregate_message_stats, AsyncMock):
-            queries.aggregate_message_stats = AsyncMock(return_value={})
+        if not isinstance(repo.get_render_projection, AsyncMock):
+            repo.get_render_projection = AsyncMock(return_value=None)
+        if not isinstance(repo.get_conversation_stats, AsyncMock):
+            repo.get_conversation_stats = AsyncMock(return_value={})
+        if not isinstance(repo.get_message_counts_batch, AsyncMock):
+            repo.get_message_counts_batch = AsyncMock(return_value={})
+        if not isinstance(repo.aggregate_message_stats, AsyncMock):
+            repo.aggregate_message_stats = AsyncMock(return_value={})
+        if not isinstance(repo.list_summaries_by_query, AsyncMock):
+            repo.list_summaries_by_query = AsyncMock(return_value=[])
         if not isinstance(repo.get_action_event_artifact_state, AsyncMock):
             repo.get_action_event_artifact_state = AsyncMock(return_value=_ready_action_event_state())
     return AppEnv(ui=ui, services=build_runtime_services(config=config, repository=repo))
@@ -666,13 +667,13 @@ async def test_async_execute_query_uses_action_event_stats_lane_for_semantic_sta
             fts_rows=1,
         )
     )
-    repo.queries.list_conversations = AsyncMock(return_value=[SimpleNamespace(conversation_id="conv-semantic-1")])
+    repo.list_summaries_by_query = AsyncMock(return_value=[_make_summary("conv-semantic-1")])
     env = _make_env(repo=repo, config=MagicMock())
 
     with (
         patch("polylogue.cli.helpers.load_effective_config", return_value=MagicMock()),
         patch("polylogue.storage.search_providers.create_vector_provider", return_value=None),
-        patch("polylogue.cli.query_output.output_stats_by_semantic_query", new_callable=AsyncMock) as mock_output,
+        patch("polylogue.cli.query_output.output_stats_by_semantic_summaries", new_callable=AsyncMock) as mock_output,
         patch("polylogue.cli.query_output._output_stats_by") as mock_fallback,
     ):
         await async_execute_query(
@@ -686,7 +687,7 @@ async def test_async_execute_query_uses_action_event_stats_lane_for_semantic_sta
             ),
         )
 
-    repo.queries.list_conversations.assert_awaited_once()
+    repo.list_summaries_by_query.assert_awaited_once()
     mock_output.assert_awaited_once()
     mock_fallback.assert_not_called()
 
@@ -750,8 +751,17 @@ async def test_stream_conversation_output_contract(
     from polylogue.cli.query_output import stream_conversation
 
     repo = MagicMock()
-    repo.queries.get_conversation = AsyncMock(return_value=SimpleNamespace(title="Test Title"))
-    repo.queries.get_conversation_stats = AsyncMock(return_value={"dialogue_messages": 1, "total_messages": 2})
+    repo.get_render_projection = AsyncMock(
+        return_value=SimpleNamespace(
+            conversation=SimpleNamespace(
+                title="Test Title",
+                provider_name=None,
+                updated_at=None,
+                created_at=None,
+            )
+        )
+    )
+    repo.get_conversation_stats = AsyncMock(return_value={"dialogue_messages": 1, "total_messages": 2})
 
     async def _iter_messages(*_args: object, **_kwargs: object) -> AsyncIterator[MessageModel]:
         messages = [_make_msg("m1", "user", "Hello"), _make_msg("m2", "assistant", "Hi")]
@@ -780,7 +790,7 @@ async def test_stream_conversation_errors_for_missing_conversation() -> None:
     from polylogue.cli.query_output import stream_conversation
 
     repo = MagicMock()
-    repo.queries.get_conversation = AsyncMock(return_value=None)
+    repo.get_render_projection = AsyncMock(return_value=None)
     env = _make_env(repo=repo, config=MagicMock())
 
     with patch("click.echo") as mock_echo, pytest.raises(SystemExit) as exc_info:

--- a/tests/unit/cli/test_query_exec_laws.py
+++ b/tests/unit/cli/test_query_exec_laws.py
@@ -7,8 +7,6 @@ import csv
 import io
 import json
 import tempfile
-from collections.abc import AsyncIterator
-from contextlib import asynccontextmanager
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
@@ -84,38 +82,25 @@ def _make_env(*, repo: MagicMock | None = None, config: MagicMock | None = None)
     ui.console = MagicMock()
     ui.confirm = MagicMock(return_value=True)
     if repo is not None:
-        queries = repo.queries
-        if not isinstance(queries.get_conversation, AsyncMock):
-            queries.get_conversation = AsyncMock(return_value=None)
-        if not isinstance(queries.get_conversation_stats, AsyncMock):
-            queries.get_conversation_stats = AsyncMock(return_value={})
-        if not isinstance(queries.get_message_counts_batch, AsyncMock):
-            queries.get_message_counts_batch = AsyncMock(return_value={})
-        if not isinstance(queries.aggregate_message_stats, AsyncMock):
-            queries.aggregate_message_stats = AsyncMock(return_value={})
+        if not isinstance(repo.get_render_projection, AsyncMock):
+            repo.get_render_projection = AsyncMock(return_value=None)
+        if not isinstance(repo.get_conversation_stats, AsyncMock):
+            repo.get_conversation_stats = AsyncMock(return_value={})
+        if not isinstance(repo.get_message_counts_batch, AsyncMock):
+            repo.get_message_counts_batch = AsyncMock(return_value={})
+        if not isinstance(repo.aggregate_message_stats, AsyncMock):
+            repo.aggregate_message_stats = AsyncMock(return_value={})
+        if not isinstance(repo.get_conversations_batch, AsyncMock):
+            repo.get_conversations_batch = AsyncMock(return_value=[])
+        if not isinstance(repo.get_messages_batch, AsyncMock):
+            repo.get_messages_batch = AsyncMock(return_value={})
+        if not isinstance(repo.get_attachments_batch, AsyncMock):
+            repo.get_attachments_batch = AsyncMock(return_value={})
+        if not isinstance(repo.list_summaries_by_query, AsyncMock):
+            repo.list_summaries_by_query = AsyncMock(return_value=[])
         if not isinstance(repo.get_action_event_artifact_state, AsyncMock):
             repo.get_action_event_artifact_state = AsyncMock(return_value=_ready_action_event_state())
     return AppEnv(ui=ui, services=build_runtime_services(config=config, repository=repo))
-
-
-@asynccontextmanager
-async def _async_connection(conn: object) -> AsyncIterator[object]:
-    yield conn
-
-
-class _SnapshotConn:
-    def __init__(self) -> None:
-        self.in_transaction = False
-        self.execute = AsyncMock(side_effect=self._execute)
-        self.rollback = AsyncMock(side_effect=self._rollback)
-
-    async def _execute(self, sql: str, *args: object, **kwargs: object) -> None:
-        del args, kwargs
-        if sql == "BEGIN":
-            self.in_transaction = True
-
-    async def _rollback(self) -> None:
-        self.in_transaction = False
 
 
 def _fields_arg(fields: tuple[str, ...] | None) -> str | None:
@@ -476,7 +461,7 @@ def test_delete_conversations_contract(case: Any) -> None:
 @pytest.mark.parametrize("output_format", ["json", "yaml", "csv", "text"])
 def test_output_summary_list_contract(case: Any, output_format: str) -> None:
     repo = MagicMock()
-    repo.queries.get_message_counts_batch = AsyncMock(return_value=build_message_counts(case.summaries))
+    repo.get_message_counts_batch = AsyncMock(return_value=build_message_counts(case.summaries))
     env = _make_env(repo=repo)
     summaries = [build_conversation_summary(spec) for spec in case.summaries]
     params: dict[str, object] = {"output_format": output_format}
@@ -697,7 +682,7 @@ async def test_output_stats_by_semantic_summaries_json_contract() -> None:
             fts_rows=0,
         )
     )
-    repo.queries.get_conversations_batch = AsyncMock(
+    repo.get_conversations_batch = AsyncMock(
         side_effect=[
             [
                 ConversationRecord(
@@ -725,7 +710,7 @@ async def test_output_stats_by_semantic_summaries_json_contract() -> None:
             ],
         ]
     )
-    repo.queries.get_messages_batch = AsyncMock(
+    repo.get_messages_batch = AsyncMock(
         side_effect=[
             {
                 "conv-law-1": [
@@ -814,8 +799,8 @@ async def test_output_stats_by_semantic_summaries_json_contract() -> None:
         ],
         "summary": {"group": "MATCHED", "conversations": 2, "facts": 2, "messages": 2},
     }
-    assert repo.queries.get_conversations_batch.await_count == 2
-    assert repo.queries.get_messages_batch.await_count == 2
+    assert repo.get_conversations_batch.await_count == 2
+    assert repo.get_messages_batch.await_count == 2
 
 
 @pytest.mark.asyncio
@@ -1129,7 +1114,7 @@ def test_async_execute_query_action_routing_contract(case: str, expected_helper:
         mock_output_stats_by = cast(MagicMock, mock_output_stats_by)
         mock_open_result = cast(MagicMock, mock_open_result)
         mock_output_results = cast(MagicMock, mock_output_results)
-        repo.queries.get_message_counts_batch = AsyncMock(return_value={str(summary.id): 2})
+        repo.get_message_counts_batch = AsyncMock(return_value={str(summary.id): 2})
         asyncio.run(async_execute_query(env, {"limit": 7}))
 
     selection.build_filter.assert_called_once_with(repo, vector_provider=None)
@@ -1146,7 +1131,7 @@ def test_async_execute_query_action_routing_contract(case: str, expected_helper:
     elif expected_helper == "stats_by_summaries":
         filter_chain.list.assert_not_called()
         filter_chain.list_summaries.assert_awaited_once()
-        repo.queries.get_message_counts_batch.assert_awaited_once_with([str(summary.id)])
+        repo.get_message_counts_batch.assert_awaited_once_with([str(summary.id)])
         mock_output_stats_by_summaries.assert_called_once()
         mock_output_stats_by_semantic_summaries.assert_not_called()
         mock_output_stats_by_profile_summaries.assert_not_called()
@@ -1473,7 +1458,7 @@ def test_apply_transform_contract(transform: str, expected_ids: list[str]) -> No
 async def test_output_stats_sql_uses_summary_pushdown_contract() -> None:
     env = _make_env()
     repo = MagicMock()
-    repo.queries.aggregate_message_stats = AsyncMock(
+    repo.aggregate_message_stats = AsyncMock(
         return_value={
             "total": 9,
             "user": 4,
@@ -1518,7 +1503,7 @@ async def test_output_stats_sql_uses_summary_pushdown_contract() -> None:
 
     filter_chain.list_summaries.assert_awaited_once()
     filter_chain.count.assert_not_called()
-    repo.queries.aggregate_message_stats.assert_awaited_once_with(["conv-a", "conv-b"])
+    repo.aggregate_message_stats.assert_awaited_once_with(["conv-a", "conv-b"])
     printed = [call.args[0] for call in cast(MagicMock, env.ui.console.print).call_args_list if call.args]
     assert printed == [
         "\nConversations: 2\n",
@@ -1544,9 +1529,7 @@ async def test_output_stats_sql_empty_paths_contract(
 ) -> None:
     env = _make_env()
     repo = MagicMock()
-    repo.queries.aggregate_message_stats = AsyncMock()
-    conn = _SnapshotConn()
-    repo.backend.read_connection.return_value = _async_connection(conn)
+    repo.aggregate_message_stats = AsyncMock()
     repo.get_archive_stats = AsyncMock(return_value=SimpleNamespace(total_conversations=0))
 
     filter_chain = MagicMock()
@@ -1577,9 +1560,7 @@ async def test_output_stats_sql_empty_paths_json_contract(
 ) -> None:
     env = _make_env()
     repo = MagicMock()
-    repo.queries.aggregate_message_stats = AsyncMock()
-    conn = _SnapshotConn()
-    repo.backend.read_connection.return_value = _async_connection(conn)
+    repo.aggregate_message_stats = AsyncMock()
     repo.get_archive_stats = AsyncMock(return_value=SimpleNamespace(total_conversations=0))
 
     filter_chain = MagicMock()
@@ -1606,8 +1587,6 @@ async def test_output_stats_sql_empty_paths_json_contract(
 async def test_output_stats_sql_archive_scope_includes_embedding_state() -> None:
     env = _make_env()
     repo = MagicMock()
-    conn = _SnapshotConn()
-    repo.backend.read_connection.return_value = _async_connection(conn)
     repo.get_archive_stats = AsyncMock(
         return_value=SimpleNamespace(
             total_conversations=2,
@@ -1623,28 +1602,24 @@ async def test_output_stats_sql_archive_scope_includes_embedding_state() -> None
     filter_chain.can_use_summaries.return_value = False
     filter_chain.count = AsyncMock(side_effect=AssertionError("archive-scope stats should reuse archive snapshot"))
 
-    with patch(
-        "polylogue.cli.query_stats.stats_q.aggregate_message_stats",
-        new=AsyncMock(
-            return_value={
-                "total": 9,
-                "user": 4,
-                "assistant": 5,
-                "words_approx": 42,
-                "providers": {"claude-ai": 2, "chatgpt": 1},
-                "attachment_refs": 2,
-                "distinct_attachments": 1,
-                "min_sort_key": 1704067200,
-                "max_sort_key": 1704153600,
-            }
-        ),
-    ) as mock_aggregate:
-        await output_stats_sql(env, filter_chain, repo)
+    repo.aggregate_message_stats = AsyncMock(
+        return_value={
+            "total": 9,
+            "user": 4,
+            "assistant": 5,
+            "words_approx": 42,
+            "providers": {"claude-ai": 2, "chatgpt": 1},
+            "attachment_refs": 2,
+            "distinct_attachments": 1,
+            "min_sort_key": 1704067200,
+            "max_sort_key": 1704153600,
+        }
+    )
 
-    repo.get_archive_stats.assert_awaited_once_with(conn=conn)
-    mock_aggregate.assert_awaited_once_with(conn, None)
-    conn.execute.assert_awaited_once_with("BEGIN")
-    conn.rollback.assert_awaited_once()
+    await output_stats_sql(env, filter_chain, repo)
+
+    repo.get_archive_stats.assert_awaited_once_with()
+    repo.aggregate_message_stats.assert_awaited_once_with()
     printed = [call.args[0] for call in cast(MagicMock, env.ui.console.print).call_args_list if call.args]
     assert printed == [
         "\nConversations: 2\n",
@@ -1662,8 +1637,6 @@ async def test_output_stats_sql_archive_scope_includes_embedding_state() -> None
 async def test_output_stats_sql_json_contract() -> None:
     env = _make_env()
     repo = MagicMock()
-    conn = _SnapshotConn()
-    repo.backend.read_connection.return_value = _async_connection(conn)
     repo.get_archive_stats = AsyncMock(
         return_value=SimpleNamespace(
             total_conversations=2,
@@ -1679,34 +1652,27 @@ async def test_output_stats_sql_json_contract() -> None:
     filter_chain.describe.return_value = []
     filter_chain.can_use_summaries.return_value = False
     filter_chain.count = AsyncMock(side_effect=AssertionError("archive-scope stats should reuse archive snapshot"))
+    repo.aggregate_message_stats = AsyncMock(
+        return_value={
+            "total": 9,
+            "user": 4,
+            "assistant": 5,
+            "words_approx": 42,
+            "attachment_refs": 2,
+            "distinct_attachments": 1,
+            "min_sort_key": 1704067200,
+            "max_sort_key": 1704153600,
+            "providers": {"claude-ai": 2, "chatgpt": 1},
+        }
+    )
 
-    with (
-        patch(
-            "polylogue.cli.query_stats.stats_q.aggregate_message_stats",
-            new=AsyncMock(
-                return_value={
-                    "total": 9,
-                    "user": 4,
-                    "assistant": 5,
-                    "words_approx": 42,
-                    "attachment_refs": 2,
-                    "distinct_attachments": 1,
-                    "min_sort_key": 1704067200,
-                    "max_sort_key": 1704153600,
-                    "providers": {"claude-ai": 2, "chatgpt": 1},
-                }
-            ),
-        ) as mock_aggregate,
-        patch("click.echo") as mock_echo,
-    ):
+    with patch("click.echo") as mock_echo:
         mock_echo = cast(MagicMock, mock_echo)
         await output_stats_sql(env, filter_chain, repo, output_format="json")
 
     cast(MagicMock, env.ui.console.print).assert_not_called()
-    repo.get_archive_stats.assert_awaited_once_with(conn=conn)
-    mock_aggregate.assert_awaited_once_with(conn, None)
-    conn.execute.assert_awaited_once_with("BEGIN")
-    conn.rollback.assert_awaited_once()
+    repo.get_archive_stats.assert_awaited_once_with()
+    repo.aggregate_message_stats.assert_awaited_once_with()
     payload = json.loads(mock_echo.call_args.args[0])
     assert payload["dimension"] == "archive"
     assert payload["rows"] == []

--- a/tests/unit/mcp/test_server_surfaces.py
+++ b/tests/unit/mcp/test_server_surfaces.py
@@ -131,16 +131,16 @@ class TestResourceSurfaces:
     def test_stats_returns_archive_statistics(self: object, mcp_server: Any) -> None:
         from polylogue.lib.stats import ArchiveStats
 
-        with patch("polylogue.mcp.server._get_repo") as mock_get_repo:
-            mock_repo = MagicMock()
-            mock_repo.get_archive_stats = AsyncMock(
+        with patch("polylogue.mcp.server._get_archive_ops") as mock_get_archive_ops:
+            mock_ops = MagicMock()
+            mock_ops.storage_stats = AsyncMock(
                 return_value=ArchiveStats(
                     total_conversations=2,
                     total_messages=4,
                     providers={"chatgpt": 2},
                 )
             )
-            mock_get_repo.return_value = mock_repo
+            mock_get_archive_ops.return_value = mock_ops
 
             result = invoke_surface(mcp_server._resource_manager._resources["polylogue://stats"].fn)
 
@@ -154,11 +154,8 @@ class TestResourceSurfaces:
         simple_conversation: Conversation,
         mcp_server: Any,
     ) -> None:
-        with patch("polylogue.mcp.server._get_repo") as mock_get_repo:
-            mock_repo = MagicMock()
-            mock_repo.list.return_value = [simple_conversation]
-            mock_get_repo.return_value = mock_repo
-
+        with patch("polylogue.mcp.server._get_query_store") as mock_get_query_store:
+            mock_get_query_store.return_value = MagicMock()
             with patch("polylogue.lib.filters.ConversationFilter") as mock_filter_cls:
                 mock_filter_cls.return_value = make_mock_filter(results=[simple_conversation])
 
@@ -175,10 +172,10 @@ class TestResourceSurfaces:
         simple_conversation: Conversation,
         mcp_server: Any,
     ) -> None:
-        with patch("polylogue.mcp.server._get_repo") as mock_get_repo:
-            mock_repo = MagicMock()
-            mock_repo.get = AsyncMock(return_value=simple_conversation)
-            mock_get_repo.return_value = mock_repo
+        with patch("polylogue.mcp.server._get_archive_ops") as mock_get_archive_ops:
+            mock_ops = MagicMock()
+            mock_ops.get_conversation = AsyncMock(return_value=simple_conversation)
+            mock_get_archive_ops.return_value = mock_ops
 
             result = invoke_surface(
                 mcp_server._resource_manager._templates["polylogue://conversation/{conv_id}"].fn,
@@ -190,10 +187,10 @@ class TestResourceSurfaces:
         assert "messages" in conv
 
     def test_conversation_resource_not_found(self: object, mcp_server: Any) -> None:
-        with patch("polylogue.mcp.server._get_repo") as mock_get_repo:
-            mock_repo = MagicMock()
-            mock_repo.get = AsyncMock(return_value=None)
-            mock_get_repo.return_value = mock_repo
+        with patch("polylogue.mcp.server._get_archive_ops") as mock_get_archive_ops:
+            mock_ops = MagicMock()
+            mock_ops.get_conversation = AsyncMock(return_value=None)
+            mock_get_archive_ops.return_value = mock_ops
 
             result = invoke_surface(
                 mcp_server._resource_manager._templates["polylogue://conversation/{conv_id}"].fn,
@@ -204,10 +201,10 @@ class TestResourceSurfaces:
         assert "error" in result_dict
 
     def test_tags_resource(self: object, mcp_server: Any) -> None:
-        with patch("polylogue.mcp.server._get_repo") as mock_get_repo:
-            mock_repo = make_repo_mock()
-            mock_repo.list_tags.return_value = {"feature": 10, "bug": 5}
-            mock_get_repo.return_value = mock_repo
+        with patch("polylogue.mcp.server._get_tag_store") as mock_get_tag_store:
+            mock_tag_store = make_repo_mock()
+            mock_tag_store.list_tags.return_value = {"feature": 10, "bug": 5}
+            mock_get_tag_store.return_value = mock_tag_store
 
             result = invoke_surface(mcp_server._resource_manager._resources["polylogue://tags"].fn)
 
@@ -246,11 +243,8 @@ class TestPromptSurfaces:
     ) -> None:
         simple_conversation.messages.to_list()[0].text = "Got an error while running"
 
-        with patch("polylogue.mcp.server._get_repo") as mock_get_repo:
-            mock_repo = MagicMock()
-            mock_repo.list.return_value = [simple_conversation]
-            mock_get_repo.return_value = mock_repo
-
+        with patch("polylogue.mcp.server._get_query_store") as mock_get_query_store:
+            mock_get_query_store.return_value = MagicMock()
             with patch("polylogue.lib.filters.ConversationFilter") as mock_filter_cls:
                 mock_filter_cls.return_value = make_mock_filter(results=[simple_conversation])
 
@@ -272,11 +266,8 @@ class TestPromptSurfaces:
         ]
         big_conv = make_conv(id="big", provider=Provider.UNKNOWN, title="Errors", messages=msgs)
 
-        with patch("polylogue.mcp.server._get_repo") as mock_get_repo:
-            mock_repo = MagicMock()
-            mock_repo.list.return_value = [big_conv]
-            mock_get_repo.return_value = mock_repo
-
+        with patch("polylogue.mcp.server._get_query_store") as mock_get_query_store:
+            mock_get_query_store.return_value = MagicMock()
             with patch("polylogue.lib.filters.ConversationFilter") as mock_filter_cls:
                 mock_filter_cls.return_value = make_mock_filter(results=[big_conv])
 
@@ -286,11 +277,8 @@ class TestPromptSurfaces:
 
     @pytest.mark.asyncio
     async def test_analyze_errors_no_matches(self: object, mcp_server: Any) -> None:
-        with patch("polylogue.mcp.server._get_repo") as mock_get_repo:
-            mock_repo = MagicMock()
-            mock_repo.list.return_value = []
-            mock_get_repo.return_value = mock_repo
-
+        with patch("polylogue.mcp.server._get_query_store") as mock_get_query_store:
+            mock_get_query_store.return_value = MagicMock()
             with patch("polylogue.lib.filters.ConversationFilter") as mock_filter_cls:
                 mock_filter_cls.return_value = make_mock_filter(results=[])
 
@@ -300,11 +288,8 @@ class TestPromptSurfaces:
 
     @pytest.mark.asyncio
     async def test_summarize_week_empty(self: object, mcp_server: Any) -> None:
-        with patch("polylogue.mcp.server._get_repo") as mock_get_repo:
-            mock_repo = MagicMock()
-            mock_repo.list.return_value = []
-            mock_get_repo.return_value = mock_repo
-
+        with patch("polylogue.mcp.server._get_query_store") as mock_get_query_store:
+            mock_get_query_store.return_value = MagicMock()
             with patch("polylogue.lib.filters.ConversationFilter") as mock_filter_cls:
                 mock_filter_cls.return_value = make_mock_filter(results=[])
 
@@ -322,11 +307,8 @@ class TestPromptSurfaces:
             messages=[make_msg(id="m1", role=Role.USER, text="Just text, no code")],
         )
 
-        with patch("polylogue.mcp.server._get_repo") as mock_get_repo:
-            mock_repo = MagicMock()
-            mock_repo.list.return_value = [conv]
-            mock_get_repo.return_value = mock_repo
-
+        with patch("polylogue.mcp.server._get_query_store") as mock_get_query_store:
+            mock_get_query_store.return_value = MagicMock()
             with patch("polylogue.lib.filters.ConversationFilter") as mock_filter_cls:
                 mock_filter_cls.return_value = make_mock_filter(results=[conv])
 
@@ -349,11 +331,8 @@ class TestPromptSurfaces:
             ],
         )
 
-        with patch("polylogue.mcp.server._get_repo") as mock_get_repo:
-            mock_repo = MagicMock()
-            mock_repo.list.return_value = [conv]
-            mock_get_repo.return_value = mock_repo
-
+        with patch("polylogue.mcp.server._get_query_store") as mock_get_query_store:
+            mock_get_query_store.return_value = MagicMock()
             with patch("polylogue.lib.filters.ConversationFilter") as mock_filter_cls:
                 mock_filter_cls.return_value = make_mock_filter(results=[conv])
 
@@ -370,11 +349,8 @@ class TestPromptSurfaces:
             messages=[make_msg(id="m1", role=Role.ASSISTANT, text=None)],
         )
 
-        with patch("polylogue.mcp.server._get_repo") as mock_get_repo:
-            mock_repo = MagicMock()
-            mock_repo.list.return_value = [conv]
-            mock_get_repo.return_value = mock_repo
-
+        with patch("polylogue.mcp.server._get_query_store") as mock_get_query_store:
+            mock_get_query_store.return_value = MagicMock()
             with patch("polylogue.lib.filters.ConversationFilter") as mock_filter_cls:
                 mock_filter_cls.return_value = make_mock_filter(results=[conv])
 
@@ -387,10 +363,10 @@ class TestPromptSurfaces:
         simple_conversation: Conversation,
         mcp_server: Any,
     ) -> None:
-        with patch("polylogue.mcp.server._get_repo") as mock_get_repo:
-            mock_repo = make_repo_mock()
-            mock_repo.view.side_effect = [simple_conversation, simple_conversation]
-            mock_get_repo.return_value = mock_repo
+        with patch("polylogue.mcp.server._get_query_store") as mock_get_query_store:
+            mock_query_store = make_repo_mock()
+            mock_query_store.get_eager = AsyncMock(side_effect=[simple_conversation, simple_conversation])
+            mock_get_query_store.return_value = mock_query_store
 
             result = invoke_surface(
                 mcp_server._prompt_manager._prompts["compare_conversations"].fn,
@@ -409,11 +385,10 @@ class TestPromptSurfaces:
         mcp_server: Any,
     ) -> None:
         with (
-            patch("polylogue.mcp.server._get_repo") as mock_get_repo,
+            patch("polylogue.mcp.server._get_query_store") as mock_get_query_store,
             patch("polylogue.lib.filters.ConversationFilter") as mock_filter_cls,
         ):
-            mock_repo = make_repo_mock()
-            mock_get_repo.return_value = mock_repo
+            mock_get_query_store.return_value = MagicMock()
             mock_filter_cls.return_value = make_mock_filter(results=[simple_conversation])
 
             result = await invoke_surface_async(mcp_server._prompt_manager._prompts["extract_patterns"].fn)
@@ -425,12 +400,12 @@ class TestPromptSurfaces:
 class TestExportConversationTool:
     def test_export_markdown(self: object, simple_conversation: Conversation, mcp_server: Any) -> None:
         with (
-            patch("polylogue.mcp.server._get_repo") as mock_get_repo,
+            patch("polylogue.mcp.server._get_archive_ops") as mock_get_archive_ops,
             patch("polylogue.rendering.formatting.format_conversation") as mock_format,
         ):
-            mock_repo = make_repo_mock()
-            mock_repo.view.return_value = simple_conversation
-            mock_get_repo.return_value = mock_repo
+            mock_ops = MagicMock()
+            mock_ops.get_conversation = AsyncMock(return_value=simple_conversation)
+            mock_get_archive_ops.return_value = mock_ops
             mock_format.return_value = "# Test Conversation\n\nFormatted content"
 
             result = invoke_surface(
@@ -446,10 +421,10 @@ class TestExportConversationTool:
         assert call_args[0][1] == "markdown"
 
     def test_export_not_found(self: object, mcp_server: Any) -> None:
-        with patch("polylogue.mcp.server._get_repo") as mock_get_repo:
-            mock_repo = make_repo_mock()
-            mock_repo.view.return_value = None
-            mock_get_repo.return_value = mock_repo
+        with patch("polylogue.mcp.server._get_archive_ops") as mock_get_archive_ops:
+            mock_ops = MagicMock()
+            mock_ops.get_conversation = AsyncMock(return_value=None)
+            mock_get_archive_ops.return_value = mock_ops
 
             result = invoke_surface(mcp_server._tool_manager._tools["export_conversation"].fn, id="nonexistent")
 
@@ -463,12 +438,12 @@ class TestExportConversationTool:
         mcp_server: Any,
     ) -> None:
         with (
-            patch("polylogue.mcp.server._get_repo") as mock_get_repo,
+            patch("polylogue.mcp.server._get_archive_ops") as mock_get_archive_ops,
             patch("polylogue.rendering.formatting.format_conversation") as mock_format,
         ):
-            mock_repo = make_repo_mock()
-            mock_repo.view.return_value = simple_conversation
-            mock_get_repo.return_value = mock_repo
+            mock_ops = MagicMock()
+            mock_ops.get_conversation = AsyncMock(return_value=simple_conversation)
+            mock_get_archive_ops.return_value = mock_ops
             mock_format.return_value = "# Content"
 
             invoke_surface(

--- a/tests/unit/mcp/test_tool_contracts.py
+++ b/tests/unit/mcp/test_tool_contracts.py
@@ -318,10 +318,10 @@ class TestQueryTools:
 
 class TestGetConversationTool:
     def test_get_returns_conversation(self, simple_conversation: Conversation, mcp_server: Any) -> None:
-        with patch("polylogue.mcp.server._get_repo") as mock_get_repo:
-            mock_repo = make_repo_mock()
-            mock_repo.view.return_value = simple_conversation
-            mock_get_repo.return_value = mock_repo
+        with patch("polylogue.mcp.server._get_archive_ops") as mock_get_archive_ops:
+            mock_ops = MagicMock()
+            mock_ops.get_conversation = AsyncMock(return_value=simple_conversation)
+            mock_get_archive_ops.return_value = mock_ops
 
             result = invoke_surface(mcp_server._tool_manager._tools["get_conversation"].fn, id="test:conv-123")
 
@@ -330,10 +330,10 @@ class TestGetConversationTool:
         assert len(conv["messages"]) == 2
 
     def test_get_not_found(self, mcp_server: Any) -> None:
-        with patch("polylogue.mcp.server._get_repo") as mock_get_repo:
-            mock_repo = make_repo_mock()
-            mock_repo.view.return_value = None
-            mock_get_repo.return_value = mock_repo
+        with patch("polylogue.mcp.server._get_archive_ops") as mock_get_archive_ops:
+            mock_ops = MagicMock()
+            mock_ops.get_conversation = AsyncMock(return_value=None)
+            mock_get_archive_ops.return_value = mock_ops
 
             result = invoke_surface(mcp_server._tool_manager._tools["get_conversation"].fn, id="nonexistent")
 
@@ -350,10 +350,10 @@ class TestGetConversationTool:
             messages=[make_msg(id="m1", role="assistant", text=long_text)],
         )
 
-        with patch("polylogue.mcp.server._get_repo") as mock_get_repo:
-            mock_repo = make_repo_mock()
-            mock_repo.view.return_value = conv
-            mock_get_repo.return_value = mock_repo
+        with patch("polylogue.mcp.server._get_archive_ops") as mock_get_archive_ops:
+            mock_ops = MagicMock()
+            mock_ops.get_conversation = AsyncMock(return_value=conv)
+            mock_get_archive_ops.return_value = mock_ops
 
             result = invoke_surface(mcp_server._tool_manager._tools["get_conversation"].fn, id="test:long")
 
@@ -361,10 +361,10 @@ class TestGetConversationTool:
 
     @pytest.mark.asyncio
     async def test_get_with_nonexistent_id(self, mcp_server: Any) -> None:
-        with patch("polylogue.mcp.server._get_repo") as mock_get_repo:
-            mock_repo = make_repo_mock()
-            mock_repo.view.return_value = None
-            mock_get_repo.return_value = mock_repo
+        with patch("polylogue.mcp.server._get_archive_ops") as mock_get_archive_ops:
+            mock_ops = MagicMock()
+            mock_ops.get_conversation = AsyncMock(return_value=None)
+            mock_get_archive_ops.return_value = mock_ops
 
             result = await invoke_surface_async(
                 mcp_server._tool_manager._tools["get_conversation"].fn, id="nonexistent-id-xyz"
@@ -621,18 +621,20 @@ class TestStatsTool:
         expected_mb: float | int,
         mcp_server: Any,
     ) -> None:
-        with patch("polylogue.mcp.server._get_repo") as mock_get_repo:
-            mock_repo = make_repo_mock()
-            mock_repo.get_archive_stats.return_value = ArchiveStats(
-                total_conversations=total_conversations,
-                total_messages=total_messages,
-                providers=providers,
-                embedded_conversations=embedded_convs,
-                embedded_messages=embedded_msgs,
-                pending_embedding_conversations=pending_convs,
-                db_size_bytes=db_size,
+        with patch("polylogue.mcp.server._get_archive_ops") as mock_get_archive_ops:
+            mock_ops = MagicMock()
+            mock_ops.storage_stats = AsyncMock(
+                return_value=ArchiveStats(
+                    total_conversations=total_conversations,
+                    total_messages=total_messages,
+                    providers=providers,
+                    embedded_conversations=embedded_convs,
+                    embedded_messages=embedded_msgs,
+                    pending_embedding_conversations=pending_convs,
+                    db_size_bytes=db_size,
+                )
             )
-            mock_get_repo.return_value = mock_repo
+            mock_get_archive_ops.return_value = mock_ops
 
             result = invoke_surface(mcp_server._tool_manager._tools["stats"].fn)
 
@@ -646,10 +648,10 @@ class TestStatsTool:
 
 class TestMutationTools:
     def test_add_tag_success(self, mcp_server: Any) -> None:
-        with patch("polylogue.mcp.server._get_repo") as mock_get_repo:
-            mock_repo = make_repo_mock()
-            mock_repo.add_tag.return_value = None
-            mock_get_repo.return_value = mock_repo
+        with patch("polylogue.mcp.server._get_tag_store") as mock_get_tag_store:
+            mock_tag_store = make_repo_mock()
+            mock_tag_store.add_tag.return_value = None
+            mock_get_tag_store.return_value = mock_tag_store
 
             result = invoke_surface(
                 mcp_server._tool_manager._tools["add_tag"].fn, conversation_id="test:conv-123", tag="important"
@@ -657,13 +659,13 @@ class TestMutationTools:
 
         parsed = json.loads(result)
         assert parsed == {"status": "ok", "conversation_id": "test:conv-123", "tag": "important"}
-        mock_repo.add_tag.assert_called_once_with("test:conv-123", "important")
+        mock_tag_store.add_tag.assert_called_once_with("test:conv-123", "important")
 
     def test_add_tag_error(self, mcp_server: Any) -> None:
-        with patch("polylogue.mcp.server._get_repo") as mock_get_repo:
-            mock_repo = make_repo_mock()
-            mock_repo.add_tag.side_effect = ValueError("Invalid tag")
-            mock_get_repo.return_value = mock_repo
+        with patch("polylogue.mcp.server._get_tag_store") as mock_get_tag_store:
+            mock_tag_store = make_repo_mock()
+            mock_tag_store.add_tag.side_effect = ValueError("Invalid tag")
+            mock_get_tag_store.return_value = mock_tag_store
 
             result = invoke_surface(
                 mcp_server._tool_manager._tools["add_tag"].fn, conversation_id="test:conv-123", tag="invalid"
@@ -673,10 +675,10 @@ class TestMutationTools:
         assert "Invalid tag" in parsed["error"]
 
     def test_remove_tag_success(self, mcp_server: Any) -> None:
-        with patch("polylogue.mcp.server._get_repo") as mock_get_repo:
-            mock_repo = make_repo_mock()
-            mock_repo.remove_tag.return_value = None
-            mock_get_repo.return_value = mock_repo
+        with patch("polylogue.mcp.server._get_tag_store") as mock_get_tag_store:
+            mock_tag_store = make_repo_mock()
+            mock_tag_store.remove_tag.return_value = None
+            mock_get_tag_store.return_value = mock_tag_store
 
             result = invoke_surface(
                 mcp_server._tool_manager._tools["remove_tag"].fn, conversation_id="test:conv-123", tag="important"
@@ -684,13 +686,13 @@ class TestMutationTools:
 
         parsed = json.loads(result)
         assert parsed == {"status": "ok", "conversation_id": "test:conv-123", "tag": "important"}
-        mock_repo.remove_tag.assert_called_once_with("test:conv-123", "important")
+        mock_tag_store.remove_tag.assert_called_once_with("test:conv-123", "important")
 
     def test_remove_tag_error(self, mcp_server: Any) -> None:
-        with patch("polylogue.mcp.server._get_repo") as mock_get_repo:
-            mock_repo = make_repo_mock()
-            mock_repo.remove_tag.side_effect = RuntimeError("Backend error")
-            mock_get_repo.return_value = mock_repo
+        with patch("polylogue.mcp.server._get_tag_store") as mock_get_tag_store:
+            mock_tag_store = make_repo_mock()
+            mock_tag_store.remove_tag.side_effect = RuntimeError("Backend error")
+            mock_get_tag_store.return_value = mock_tag_store
 
             result = invoke_surface(
                 mcp_server._tool_manager._tools["remove_tag"].fn, conversation_id="test:conv-123", tag="important"
@@ -699,41 +701,41 @@ class TestMutationTools:
         assert "error" in json.loads(result)
 
     def test_list_tags_returns_counts(self, mcp_server: Any) -> None:
-        with patch("polylogue.mcp.server._get_repo") as mock_get_repo:
-            mock_repo = make_repo_mock()
-            mock_repo.list_tags.return_value = {"bug": 3, "feature": 5, "urgent": 1}
-            mock_get_repo.return_value = mock_repo
+        with patch("polylogue.mcp.server._get_tag_store") as mock_get_tag_store:
+            mock_tag_store = make_repo_mock()
+            mock_tag_store.list_tags.return_value = {"bug": 3, "feature": 5, "urgent": 1}
+            mock_get_tag_store.return_value = mock_tag_store
 
             result = invoke_surface(mcp_server._tool_manager._tools["list_tags"].fn)
 
         assert json.loads(result) == {"bug": 3, "feature": 5, "urgent": 1}
 
     def test_list_tags_with_provider(self, mcp_server: Any) -> None:
-        with patch("polylogue.mcp.server._get_repo") as mock_get_repo:
-            mock_repo = make_repo_mock()
-            mock_repo.list_tags.return_value = {"claude-ai": 2}
-            mock_get_repo.return_value = mock_repo
+        with patch("polylogue.mcp.server._get_tag_store") as mock_get_tag_store:
+            mock_tag_store = make_repo_mock()
+            mock_tag_store.list_tags.return_value = {"claude-ai": 2}
+            mock_get_tag_store.return_value = mock_tag_store
 
             result = invoke_surface(mcp_server._tool_manager._tools["list_tags"].fn, provider="claude-ai")
 
         assert json.loads(result) == {"claude-ai": 2}
-        mock_repo.list_tags.assert_called_once_with(provider="claude-ai")
+        mock_tag_store.list_tags.assert_called_once_with(provider="claude-ai")
 
     def test_get_metadata_success(self, mcp_server: Any) -> None:
-        with patch("polylogue.mcp.server._get_repo") as mock_get_repo:
-            mock_repo = make_repo_mock()
-            mock_repo.get_metadata.return_value = {"key": "value", "count": 42}
-            mock_get_repo.return_value = mock_repo
+        with patch("polylogue.mcp.server._get_tag_store") as mock_get_tag_store:
+            mock_tag_store = make_repo_mock()
+            mock_tag_store.get_metadata.return_value = {"key": "value", "count": 42}
+            mock_get_tag_store.return_value = mock_tag_store
 
             result = invoke_surface(mcp_server._tool_manager._tools["get_metadata"].fn, conversation_id="test:conv-123")
 
         assert json.loads(result) == {"key": "value", "count": 42}
 
     def test_set_metadata_string_value(self, mcp_server: Any) -> None:
-        with patch("polylogue.mcp.server._get_repo") as mock_get_repo:
-            mock_repo = make_repo_mock()
-            mock_repo.update_metadata.return_value = None
-            mock_get_repo.return_value = mock_repo
+        with patch("polylogue.mcp.server._get_tag_store") as mock_get_tag_store:
+            mock_tag_store = make_repo_mock()
+            mock_tag_store.update_metadata.return_value = None
+            mock_get_tag_store.return_value = mock_tag_store
 
             result = invoke_surface(
                 mcp_server._tool_manager._tools["set_metadata"].fn,
@@ -743,13 +745,13 @@ class TestMutationTools:
             )
 
         assert json.loads(result)["status"] == "ok"
-        mock_repo.update_metadata.assert_called_once_with("test:conv-123", "author", "john")
+        mock_tag_store.update_metadata.assert_called_once_with("test:conv-123", "author", "john")
 
     def test_set_metadata_json_value(self, mcp_server: Any) -> None:
-        with patch("polylogue.mcp.server._get_repo") as mock_get_repo:
-            mock_repo = make_repo_mock()
-            mock_repo.update_metadata.return_value = None
-            mock_get_repo.return_value = mock_repo
+        with patch("polylogue.mcp.server._get_tag_store") as mock_get_tag_store:
+            mock_tag_store = make_repo_mock()
+            mock_tag_store.update_metadata.return_value = None
+            mock_get_tag_store.return_value = mock_tag_store
 
             result = invoke_surface(
                 mcp_server._tool_manager._tools["set_metadata"].fn,
@@ -759,13 +761,13 @@ class TestMutationTools:
             )
 
         assert json.loads(result)["status"] == "ok"
-        mock_repo.update_metadata.assert_called_once_with("test:conv-123", "config", {"nested": True})
+        mock_tag_store.update_metadata.assert_called_once_with("test:conv-123", "config", {"nested": True})
 
     def test_delete_metadata_success(self, mcp_server: Any) -> None:
-        with patch("polylogue.mcp.server._get_repo") as mock_get_repo:
-            mock_repo = make_repo_mock()
-            mock_repo.delete_metadata.return_value = None
-            mock_get_repo.return_value = mock_repo
+        with patch("polylogue.mcp.server._get_tag_store") as mock_get_tag_store:
+            mock_tag_store = make_repo_mock()
+            mock_tag_store.delete_metadata.return_value = None
+            mock_get_tag_store.return_value = mock_tag_store
 
             result = invoke_surface(
                 mcp_server._tool_manager._tools["delete_metadata"].fn,
@@ -776,12 +778,12 @@ class TestMutationTools:
         parsed = json.loads(result)
         assert parsed["status"] == "ok"
         assert parsed["key"] == "author"
-        mock_repo.delete_metadata.assert_called_once_with("test:conv-123", "author")
+        mock_tag_store.delete_metadata.assert_called_once_with("test:conv-123", "author")
 
     def test_delete_requires_confirm(self, mcp_server: Any) -> None:
-        with patch("polylogue.mcp.server._get_repo") as mock_get_repo:
-            mock_repo = make_repo_mock()
-            mock_get_repo.return_value = mock_repo
+        with patch("polylogue.mcp.server._get_query_store") as mock_get_query_store:
+            mock_query_store = make_repo_mock()
+            mock_get_query_store.return_value = mock_query_store
 
             result = invoke_surface(
                 mcp_server._tool_manager._tools["delete_conversation"].fn,
@@ -791,13 +793,13 @@ class TestMutationTools:
 
         parsed = json.loads(result)
         assert "confirm=true" in parsed["error"]
-        mock_repo.delete_conversation.assert_not_called()
+        mock_query_store.delete_conversation.assert_not_called()
 
     def test_delete_with_confirm(self, mcp_server: Any) -> None:
-        with patch("polylogue.mcp.server._get_repo") as mock_get_repo:
-            mock_repo = make_repo_mock()
-            mock_repo.delete_conversation.return_value = True
-            mock_get_repo.return_value = mock_repo
+        with patch("polylogue.mcp.server._get_query_store") as mock_get_query_store:
+            mock_query_store = make_repo_mock()
+            mock_query_store.delete_conversation.return_value = True
+            mock_get_query_store.return_value = mock_query_store
 
             result = invoke_surface(
                 mcp_server._tool_manager._tools["delete_conversation"].fn,
@@ -806,13 +808,13 @@ class TestMutationTools:
             )
 
         assert json.loads(result)["status"] == "deleted"
-        mock_repo.delete_conversation.assert_called_once_with("test:conv-123")
+        mock_query_store.delete_conversation.assert_called_once_with("test:conv-123")
 
     def test_delete_not_found(self, mcp_server: Any) -> None:
-        with patch("polylogue.mcp.server._get_repo") as mock_get_repo:
-            mock_repo = make_repo_mock()
-            mock_repo.delete_conversation.return_value = False
-            mock_get_repo.return_value = mock_repo
+        with patch("polylogue.mcp.server._get_query_store") as mock_get_query_store:
+            mock_query_store = make_repo_mock()
+            mock_query_store.delete_conversation.return_value = False
+            mock_get_query_store.return_value = mock_query_store
 
             result = invoke_surface(
                 mcp_server._tool_manager._tools["delete_conversation"].fn,
@@ -823,8 +825,8 @@ class TestMutationTools:
         assert json.loads(result)["status"] == "not_found"
 
     def test_summary_returns_metadata(self, mcp_server: Any) -> None:
-        with patch("polylogue.mcp.server._get_repo") as mock_get_repo:
-            mock_repo = make_repo_mock()
+        with patch("polylogue.mcp.server._get_archive_ops") as mock_get_archive_ops:
+            mock_ops = MagicMock()
             mock_summary = _make_summary(
                 "test:conv-123",
                 provider=Provider.CHATGPT,
@@ -832,10 +834,9 @@ class TestMutationTools:
                 created_at=datetime(2024, 1, 15, tzinfo=timezone.utc),
                 updated_at=datetime(2024, 1, 15, 11, 0, 0, tzinfo=timezone.utc),
             )
-            mock_repo.resolve_id.return_value = "test:conv-123"
-            mock_repo.get_summary.return_value = mock_summary
-            mock_repo.queries.get_conversation_stats.return_value = {"total_messages": 5}
-            mock_get_repo.return_value = mock_repo
+            mock_ops.get_conversation_summary = AsyncMock(return_value=mock_summary)
+            mock_ops.get_conversation_stats = AsyncMock(return_value={"total_messages": 5})
+            mock_get_archive_ops.return_value = mock_ops
 
             result = invoke_surface(mcp_server._tool_manager._tools["get_conversation_summary"].fn, id="test:conv-123")
 
@@ -846,21 +847,20 @@ class TestMutationTools:
         assert parsed["message_count"] == 5
 
     def test_summary_not_found(self, mcp_server: Any) -> None:
-        with patch("polylogue.mcp.server._get_repo") as mock_get_repo:
-            mock_repo = make_repo_mock()
-            mock_repo.resolve_id.return_value = None
-            mock_repo.get_summary.return_value = None
-            mock_get_repo.return_value = mock_repo
+        with patch("polylogue.mcp.server._get_archive_ops") as mock_get_archive_ops:
+            mock_ops = MagicMock()
+            mock_ops.get_conversation_summary = AsyncMock(return_value=None)
+            mock_get_archive_ops.return_value = mock_ops
 
             result = invoke_surface(mcp_server._tool_manager._tools["get_conversation_summary"].fn, id="nonexistent")
 
         assert "not found" in json.loads(result)["error"].lower()
 
     def test_session_tree_returns_list(self, simple_conversation: Conversation, mcp_server: Any) -> None:
-        with patch("polylogue.mcp.server._get_repo") as mock_get_repo:
-            mock_repo = make_repo_mock()
-            mock_repo.get_session_tree.return_value = [simple_conversation]
-            mock_get_repo.return_value = mock_repo
+        with patch("polylogue.mcp.server._get_archive_ops") as mock_get_archive_ops:
+            mock_ops = MagicMock()
+            mock_ops.get_session_tree = AsyncMock(return_value=[simple_conversation])
+            mock_get_archive_ops.return_value = mock_ops
 
             result = invoke_surface(
                 mcp_server._tool_manager._tools["get_session_tree"].fn, conversation_id="test:conv-123"
@@ -878,10 +878,10 @@ class TestMutationTools:
         ],
     )
     def test_stats_by_group(self, group_by: str, expected: dict[str, int], mcp_server: Any) -> None:
-        with patch("polylogue.mcp.server._get_repo") as mock_get_repo:
-            mock_repo = make_repo_mock()
-            mock_repo.queries.get_stats_by.return_value = expected
-            mock_get_repo.return_value = mock_repo
+        with patch("polylogue.mcp.server._get_archive_ops") as mock_get_archive_ops:
+            mock_ops = MagicMock()
+            mock_ops.get_stats_by = AsyncMock(return_value=expected)
+            mock_get_archive_ops.return_value = mock_ops
 
             result = invoke_surface(mcp_server._tool_manager._tools["get_stats_by"].fn, group_by=group_by)
 
@@ -915,11 +915,11 @@ class TestMutationTools:
     def test_rebuild_index_success(self, mcp_server: Any) -> None:
         with (
             patch("polylogue.mcp.server._get_config") as mock_get_config,
-            patch("polylogue.mcp.server._get_repo") as mock_get_repo,
+            patch("polylogue.mcp.server._get_backend") as mock_get_backend,
             patch("polylogue.pipeline.services.indexing.IndexService") as mock_service_cls,
         ):
             mock_get_config.return_value = MagicMock()
-            mock_get_repo.return_value = make_repo_mock()
+            mock_get_backend.return_value = MagicMock()
             mock_service = MagicMock()
             mock_service.rebuild_index = AsyncMock(return_value=True)
             mock_service.get_index_status = AsyncMock(return_value={"exists": True, "count": 500})
@@ -935,11 +935,11 @@ class TestMutationTools:
     def test_update_index_success(self, mcp_server: Any) -> None:
         with (
             patch("polylogue.mcp.server._get_config") as mock_get_config,
-            patch("polylogue.mcp.server._get_repo") as mock_get_repo,
+            patch("polylogue.mcp.server._get_backend") as mock_get_backend,
             patch("polylogue.pipeline.services.indexing.IndexService") as mock_service_cls,
         ):
             mock_get_config.return_value = MagicMock()
-            mock_get_repo.return_value = make_repo_mock()
+            mock_get_backend.return_value = MagicMock()
             mock_service = MagicMock()
             mock_service.update_index = AsyncMock(return_value=True)
             mock_service_cls.return_value = mock_service


### PR DESCRIPTION
## Summary
- contract CLI, MCP, and TUI read paths around explicit repository and archive-operation surfaces
- remove direct `.queries` and backend reach-through from the affected surfaces
- align CLI and MCP tests with the narrowed injection seams

## Problem
The renewed substrate was still leaking implementation details into higher-level surfaces. CLI helpers, MCP resources/tools, and the TUI were reaching through `repo.queries` and backend connections instead of depending on explicit read-side contracts. That kept surface code coupled to repository internals and made the MCP seam brittle in tests.

Ref #245

## Solution
- flatten the relevant protocols in `polylogue/protocols.py` so surface code depends on direct read/query methods instead of nested `.queries`
- add repository and `ArchiveOperations` delegates for the surfaced read/stat methods
- rewire CLI query helpers, MCP resources/prompts/tools, and the TUI base app to use those narrower contracts
- keep a stable `_get_repo()` seam in `polylogue.mcp.server` while exposing narrower callbacks for query, tag, backend, and archive-operation access
- update CLI embed/query tests and MCP server-surface/tool-contract tests to match the new seams

## Verification
- `pytest -q tests/unit/cli/test_query_exec.py tests/unit/cli/test_query_exec_laws.py tests/unit/cli/test_query_fmt.py tests/unit/cli/test_run.py -k 'query or embed'`
- `pytest -q tests/unit/mcp tests/unit/ui -k 'tool or resource or prompt or mutation or maintenance or browser or dashboard or search or app'`
- `pytest -q tests/unit/cli/test_embed.py tests/unit/cli/test_query_exec.py tests/unit/cli/test_query_exec_laws.py tests/unit/mcp/test_server_surfaces.py tests/unit/mcp/test_tool_contracts.py`
- `devtools verify`
