### PR TITLE
refactor: renew verification and test surfaces

### DIFF
--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -141,7 +141,7 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
     CommandSpec(
         "pipeline-probe",
         "verification",
-        "Run synthetic pipeline probes against generated archives.",
+        "Run typed pipeline probes against synthetic, staged, or archive-subset inputs.",
         "devtools.pipeline_probe",
     ),
     CommandSpec(

--- a/devtools/pipeline_probe.py
+++ b/devtools/pipeline_probe.py
@@ -14,16 +14,23 @@ import sys
 import tempfile
 from collections.abc import Iterator
 from contextlib import contextmanager, redirect_stdout
+from dataclasses import replace
 from pathlib import Path
-from typing import NotRequired, TypeAlias
+from typing import NotRequired, Protocol, TypeAlias
 
 from typing_extensions import TypedDict
 
 from polylogue.config import Config, Source
 from polylogue.paths import blob_store_root, db_path
 from polylogue.pipeline.runner import RUN_STAGE_CHOICES, run_sources
-from polylogue.scenarios import CorpusRequest, CorpusSourceKind
+from polylogue.scenarios import (
+    CorpusRequest,
+    CorpusSourceKind,
+    PipelineProbeInputMode,
+    PipelineProbeRequest,
+)
 from polylogue.schemas.synthetic import SyntheticCorpus
+from polylogue.showcase.workspace import VerificationWorkspace, create_verification_workspace
 from polylogue.storage.backends import SQLiteBackend, create_backend
 from polylogue.storage.backends.connection import (
     _build_provider_scope_filter,
@@ -44,7 +51,7 @@ _EXT_MAP = {
     "claude-code": ".jsonl",
     "codex": ".jsonl",
 }
-_INPUT_MODES = ("synthetic", "archive-subset", "source-subset")
+_INPUT_MODES = tuple(mode.value for mode in PipelineProbeInputMode)
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 _SOURCE_BACKED_PROBE_STAGE_SEQUENCES: dict[str, tuple[str, ...]] = {
     "acquire": ("acquire",),
@@ -61,6 +68,10 @@ JsonScalar: TypeAlias = str | int | float | bool | None
 JsonValue: TypeAlias = JsonScalar | dict[str, "JsonValue"] | list["JsonValue"]
 JsonObject: TypeAlias = dict[str, JsonValue]
 ProbeSummary: TypeAlias = dict[str, object]
+
+
+class _RawConversationStore(Protocol):
+    async def save_raw_conversation(self, record: RawConversationRecord) -> bool: ...
 
 
 class RawFanoutEntry(TypedDict):
@@ -308,24 +319,58 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
+def _request_from_args(args: argparse.Namespace) -> PipelineProbeRequest:
+    """Project argparse input onto the authored pipeline-probe request contract."""
+    provider_names = tuple(_names(getattr(args, "provider", None)))
+    corpus_request: CorpusRequest | None = None
+    input_mode = PipelineProbeInputMode(_probe_mode(args))
+    if input_mode is PipelineProbeInputMode.SYNTHETIC:
+        corpus_request = CorpusRequest(
+            providers=provider_names or ("chatgpt",),
+            source=CorpusSourceKind(getattr(args, "corpus_source", CorpusSourceKind.DEFAULT.value)),
+            count=args.count,
+            messages_min=args.messages_min,
+            messages_max=args.messages_max,
+            seed=args.seed,
+            style=getattr(args, "style", "default"),
+            package_version=getattr(args, "package_version", "default"),
+        )
+    return PipelineProbeRequest(
+        stage=args.stage,
+        input_mode=input_mode,
+        corpus_request=corpus_request,
+        sample_per_provider=args.sample_per_provider,
+        source_filters=tuple(_names(getattr(args, "source_filters", None))),
+        source_paths=tuple(str(path) for path in _paths(getattr(args, "source_paths", None))),
+        source_name=str(getattr(args, "source_name", "inbox") or "inbox"),
+        source_db=str(args.source_db) if args.source_db is not None else None,
+        source_blob_root=str(args.source_blob_root) if args.source_blob_root is not None else None,
+        manifest_out=str(args.manifest_out) if args.manifest_out is not None else None,
+        manifest_in=str(args.manifest_in) if args.manifest_in is not None else None,
+        raw_batch_size=args.raw_batch_size,
+        ingest_workers=args.ingest_workers,
+        measure_ingest_result_size=bool(args.measure_ingest_result_size),
+        workdir=str(args.workdir) if args.workdir is not None else None,
+        json_out=str(args.json_out) if args.json_out is not None else None,
+        max_total_ms=args.max_total_ms,
+        max_peak_rss_mb=args.max_peak_rss_mb,
+    )
+
+
 @contextmanager
-def _isolated_env(workdir: Path) -> Iterator[None]:
+def _isolated_env(workspace: VerificationWorkspace) -> Iterator[None]:
     previous = {
         key: os.environ.get(key)
         for key in (
+            "HOME",
+            "XDG_CACHE_HOME",
             "XDG_DATA_HOME",
             "XDG_STATE_HOME",
             "XDG_CONFIG_HOME",
             "POLYLOGUE_ARCHIVE_ROOT",
         )
     }
-    env_updates = {
-        "XDG_DATA_HOME": str(workdir / "xdg-data"),
-        "XDG_STATE_HOME": str(workdir / "xdg-state"),
-        "XDG_CONFIG_HOME": str(workdir / "xdg-config"),
-        "POLYLOGUE_ARCHIVE_ROOT": str(workdir / "archive"),
-    }
-    for key, value in env_updates.items():
+    for key, value in workspace.env_vars.items():
         os.environ[key] = value
     reset_blob_store()
     try:
@@ -337,6 +382,11 @@ def _isolated_env(workdir: Path) -> Iterator[None]:
                 os.environ.pop(key, None)
             else:
                 os.environ[key] = previous_value
+
+
+def _workspace_for_request(request: PipelineProbeRequest) -> VerificationWorkspace:
+    workdir = Path(request.workdir).resolve() if request.workdir is not None else None
+    return create_verification_workspace(workdir, prefix="polylogue-pipeline-probe-")
 
 
 def _db_row_counts(db_path: Path) -> dict[str, int]:
@@ -799,7 +849,7 @@ def _resolve_archive_manifest(
 async def _seed_archive_subset(
     *,
     manifest: ArchiveManifest,
-    repository: ConversationRepository,
+    repository: _RawConversationStore,
     target_blob_store: BlobStore,
 ) -> ArchiveSubsetSampleSummary:
     records = [RawConversationRecord.model_validate(record_payload) for record_payload in manifest["records"]]
@@ -834,8 +884,23 @@ async def _seed_archive_subset(
     }
 
 
-def _resolve_synthetic_provider(args: argparse.Namespace) -> str:
-    provider_names = _names(getattr(args, "provider", None))
+def _resolved_corpus_request(request: PipelineProbeRequest) -> CorpusRequest:
+    if request.corpus_request is not None:
+        return request.corpus_request
+    return CorpusRequest(
+        providers=("chatgpt",),
+        source=CorpusSourceKind.DEFAULT,
+        count=5,
+        messages_min=4,
+        messages_max=12,
+        seed=42,
+        style="default",
+        package_version="default",
+    )
+
+
+def _resolve_synthetic_provider(request: PipelineProbeRequest) -> str:
+    provider_names = tuple(_resolved_corpus_request(request).providers or ("chatgpt",))
     provider_name = provider_names[0] if provider_names else "chatgpt"
     available = set(SyntheticCorpus.available_providers())
     if provider_name not in available:
@@ -845,7 +910,9 @@ def _resolve_synthetic_provider(args: argparse.Namespace) -> str:
     return provider_name
 
 
-def _probe_mode(args: argparse.Namespace) -> str:
+def _probe_mode(args: argparse.Namespace | PipelineProbeRequest) -> str:
+    if isinstance(args, PipelineProbeRequest):
+        return args.input_mode_kind.value
     return str(getattr(args, "input_mode", "synthetic"))
 
 
@@ -918,23 +985,20 @@ def _stage_source_subset(
 async def _run_probe_pipeline(
     *,
     config: Config,
-    stage: str,
+    request: PipelineProbeRequest,
     stage_sequence: list[str] | None,
     source_names: list[str] | None,
-    raw_batch_size: int | None,
-    ingest_workers: int | None,
-    measure_ingest_result_size: bool,
     backend: SQLiteBackend | None = None,
     repository: ConversationRepository | None = None,
 ) -> tuple[RunResult, JsonObject]:
     result = await run_sources(
         config=config,
-        stage=stage,
+        stage=request.stage,
         stage_sequence=stage_sequence,
         source_names=source_names,
-        raw_batch_size=raw_batch_size or 50,
-        ingest_workers=ingest_workers,
-        measure_ingest_result_size=measure_ingest_result_size,
+        raw_batch_size=request.raw_batch_size or 50,
+        ingest_workers=request.ingest_workers,
+        measure_ingest_result_size=request.measure_ingest_result_size,
         backend=backend,
         repository=repository,
     )
@@ -967,44 +1031,37 @@ def _json_float_or_none(value: object | None) -> float | None:
     return None
 
 
-async def run_probe(args: argparse.Namespace) -> ProbeSummary:
-    probe_mode = _probe_mode(args)
+async def run_probe(request: PipelineProbeRequest) -> ProbeSummary:
+    probe_mode = _probe_mode(request)
     if probe_mode not in _INPUT_MODES:
         raise ValueError(f"--input-mode must be one of {_INPUT_MODES}")
 
-    workdir = args.workdir.resolve()
-    raw_batch_size = getattr(args, "raw_batch_size", None)
+    workspace = _workspace_for_request(request)
+    workdir = workspace.root
+    raw_batch_size = request.raw_batch_size
     if raw_batch_size is not None and raw_batch_size <= 0:
         raise ValueError("--raw-batch-size must be positive")
-    ingest_workers = getattr(args, "ingest_workers", None)
+    ingest_workers = request.ingest_workers
     if ingest_workers is not None and ingest_workers <= 0:
         raise ValueError("--ingest-workers must be positive")
-    archive_root = workdir / "archive"
-    render_root = workdir / "render"
+    archive_root = workspace.archive_root
+    render_root = workspace.render_root
     db_path: Path | None = None
     summary: ProbeSummary
 
-    if probe_mode == "synthetic":
-        if args.count <= 0:
+    if probe_mode == PipelineProbeInputMode.SYNTHETIC.value:
+        corpus_request = _resolved_corpus_request(request)
+        if corpus_request.count <= 0:
             raise ValueError("--count must be positive")
-        if args.messages_min <= 0 or args.messages_max < args.messages_min:
+        if corpus_request.messages_min <= 0 or corpus_request.messages_max < corpus_request.messages_min:
             raise ValueError("--messages-min/--messages-max must define a positive inclusive range")
-        provider_name = _resolve_synthetic_provider(args)
+        provider_name = _resolve_synthetic_provider(request)
         source_root = workdir / "sources" / provider_name
 
-        stage_sequence = _probe_stage_sequence(probe_mode, args.stage)
-        with _isolated_env(workdir):
+        stage_sequence = _probe_stage_sequence(probe_mode, request.stage)
+        with _isolated_env(workspace):
             files, total_bytes = _write_probe_sources(
-                request=CorpusRequest(
-                    providers=(provider_name,),
-                    source=CorpusSourceKind(args.corpus_source),
-                    count=args.count,
-                    messages_min=args.messages_min,
-                    messages_max=args.messages_max,
-                    seed=args.seed,
-                    style=getattr(args, "style", "default"),
-                    package_version=getattr(args, "package_version", "default"),
-                ),
+                request=corpus_request,
                 source_root=source_root,
             )
             config = Config(
@@ -1015,12 +1072,9 @@ async def run_probe(args: argparse.Namespace) -> ProbeSummary:
             db_path = config.db_path
             result, run_payload = await _run_probe_pipeline(
                 config=config,
-                stage=args.stage,
+                request=request,
                 stage_sequence=stage_sequence,
                 source_names=[provider_name],
-                raw_batch_size=raw_batch_size,
-                ingest_workers=ingest_workers,
-                measure_ingest_result_size=args.measure_ingest_result_size,
             )
         result_payload = result.model_dump()
 
@@ -1028,18 +1082,18 @@ async def run_probe(args: argparse.Namespace) -> ProbeSummary:
             "probe": {
                 "input_mode": "synthetic",
                 "provider": provider_name,
-                "corpus_source": args.corpus_source,
-                "stage": args.stage,
+                "corpus_source": corpus_request.source_kind.value,
+                "stage": request.stage,
                 "stage_sequence": stage_sequence,
-                "count": args.count,
-                "messages_min": args.messages_min,
-                "messages_max": args.messages_max,
-                "seed": args.seed,
-                "style": getattr(args, "style", "default"),
-                "package_version": getattr(args, "package_version", "default"),
-                "raw_batch_size": args.raw_batch_size,
-                "ingest_workers": args.ingest_workers,
-                "measure_ingest_result_size": args.measure_ingest_result_size,
+                "count": corpus_request.count,
+                "messages_min": corpus_request.messages_min,
+                "messages_max": corpus_request.messages_max,
+                "seed": corpus_request.seed,
+                "style": corpus_request.style,
+                "package_version": corpus_request.package_version,
+                "raw_batch_size": request.raw_batch_size,
+                "ingest_workers": request.ingest_workers,
+                "measure_ingest_result_size": request.measure_ingest_result_size,
             },
             "paths": {
                 "workdir": str(workdir),
@@ -1059,16 +1113,16 @@ async def run_probe(args: argparse.Namespace) -> ProbeSummary:
             "db_stats": _db_row_counts(db_path) if db_path is not None else {},
             "raw_fanout": _db_raw_fanout(db_path) if db_path is not None else [],
         }
-    elif probe_mode == "source-subset":
-        source_paths = _paths(getattr(args, "source_paths", None))
+    elif probe_mode == PipelineProbeInputMode.SOURCE_SUBSET.value:
+        source_paths = _paths(request.source_paths)
         if not source_paths:
             raise ValueError("--source-path is required in source-subset mode")
 
-        source_name = str(getattr(args, "source_name", "inbox")).strip() or "inbox"
+        source_name = request.source_name.strip() or "inbox"
         source_root = workdir / "sources" / source_name
-        stage_sequence = _probe_stage_sequence(probe_mode, args.stage)
+        stage_sequence = _probe_stage_sequence(probe_mode, request.stage)
 
-        with _isolated_env(workdir):
+        with _isolated_env(workspace):
             source_inputs = _stage_source_subset(
                 source_paths=source_paths,
                 source_root=source_root,
@@ -1081,12 +1135,9 @@ async def run_probe(args: argparse.Namespace) -> ProbeSummary:
             db_path = config.db_path
             result, run_payload = await _run_probe_pipeline(
                 config=config,
-                stage=args.stage,
+                request=request,
                 stage_sequence=stage_sequence,
                 source_names=[source_name],
-                raw_batch_size=raw_batch_size,
-                ingest_workers=ingest_workers,
-                measure_ingest_result_size=args.measure_ingest_result_size,
             )
         result_payload = result.model_dump()
 
@@ -1094,11 +1145,11 @@ async def run_probe(args: argparse.Namespace) -> ProbeSummary:
             "probe": {
                 "input_mode": "source-subset",
                 "source_name": source_name,
-                "stage": args.stage,
+                "stage": request.stage,
                 "stage_sequence": stage_sequence,
-                "raw_batch_size": args.raw_batch_size,
-                "ingest_workers": args.ingest_workers,
-                "measure_ingest_result_size": args.measure_ingest_result_size,
+                "raw_batch_size": request.raw_batch_size,
+                "ingest_workers": request.ingest_workers,
+                "measure_ingest_result_size": request.measure_ingest_result_size,
             },
             "paths": {
                 "workdir": str(workdir),
@@ -1116,30 +1167,32 @@ async def run_probe(args: argparse.Namespace) -> ProbeSummary:
             "raw_fanout": _db_raw_fanout(db_path) if db_path is not None else [],
         }
     else:
-        if args.sample_per_provider <= 0:
+        sample_per_provider = request.sample_per_provider or 50
+        if sample_per_provider <= 0:
             raise ValueError("--sample-per-provider must be positive")
-        provider_filters = _names(getattr(args, "provider", None))
-        source_filters = _names(getattr(args, "source_filters", None))
+        provider_filters = list(_resolved_corpus_request(request).providers or ())
+        source_filters = list(request.source_filters)
+        resolved_corpus_request = _resolved_corpus_request(request)
         manifest = _resolve_archive_manifest(
-            manifest_in=getattr(args, "manifest_in", None),
-            source_db=getattr(args, "source_db", None),
-            source_blob_root=getattr(args, "source_blob_root", None),
+            manifest_in=Path(request.manifest_in) if request.manifest_in is not None else None,
+            source_db=Path(request.source_db) if request.source_db is not None else None,
+            source_blob_root=Path(request.source_blob_root) if request.source_blob_root is not None else None,
             provider_filters=provider_filters,
             source_filters=source_filters,
-            sample_per_provider=args.sample_per_provider,
-            seed=args.seed,
+            sample_per_provider=sample_per_provider,
+            seed=resolved_corpus_request.seed or 42,
         )
         manifest_path = workdir / "archive-subset-manifest.json"
         _persist_manifest(manifest, manifest_path)
-        if args.manifest_out is not None:
-            _persist_manifest(manifest, args.manifest_out)
+        if request.manifest_out is not None:
+            _persist_manifest(manifest, Path(request.manifest_out))
 
         config = Config(
             sources=[],
             archive_root=archive_root,
             render_root=render_root,
         )
-        with _isolated_env(workdir):
+        with _isolated_env(workspace):
             db_path = config.db_path
             backend = create_backend(db_path=db_path)
             repository = ConversationRepository(backend=backend)
@@ -1152,12 +1205,9 @@ async def run_probe(args: argparse.Namespace) -> ProbeSummary:
                 )
                 result, run_payload = await _run_probe_pipeline(
                     config=config,
-                    stage=args.stage,
+                    request=request,
                     stage_sequence=None,
                     source_names=None,
-                    raw_batch_size=raw_batch_size,
-                    ingest_workers=ingest_workers,
-                    measure_ingest_result_size=args.measure_ingest_result_size,
                     backend=backend,
                     repository=repository,
                 )
@@ -1168,14 +1218,14 @@ async def run_probe(args: argparse.Namespace) -> ProbeSummary:
         summary = {
             "probe": {
                 "input_mode": "archive-subset",
-                "stage": args.stage,
-                "seed": args.seed,
-                "sample_per_provider": args.sample_per_provider,
+                "stage": request.stage,
+                "seed": resolved_corpus_request.seed,
+                "sample_per_provider": sample_per_provider,
                 "provider_filters": provider_filters,
                 "source_filters": source_filters,
-                "raw_batch_size": args.raw_batch_size,
-                "ingest_workers": args.ingest_workers,
-                "measure_ingest_result_size": args.measure_ingest_result_size,
+                "raw_batch_size": request.raw_batch_size,
+                "ingest_workers": request.ingest_workers,
+                "measure_ingest_result_size": request.measure_ingest_result_size,
             },
             "paths": {
                 "workdir": str(workdir),
@@ -1198,8 +1248,8 @@ async def run_probe(args: argparse.Namespace) -> ProbeSummary:
     return summary
 
 
-def _build_budget_report(summary: ProbeSummary, args: argparse.Namespace) -> BudgetReport | None:
-    if args.max_total_ms is None and args.max_peak_rss_mb is None:
+def _build_budget_report(summary: ProbeSummary, request: PipelineProbeRequest) -> BudgetReport | None:
+    if request.max_total_ms is None and request.max_peak_rss_mb is None:
         return None
 
     run_payload = _json_object_or_empty(summary.get("run_payload"))
@@ -1209,53 +1259,55 @@ def _build_budget_report(summary: ProbeSummary, args: argparse.Namespace) -> Bud
     observed_peak_rss_mb = metrics.get("peak_rss_self_mb")
     violations: list[str] = []
 
-    if args.max_total_ms is not None:
+    if request.max_total_ms is not None:
         if observed_total_ms is None:
             violations.append("missing total runtime metric")
         elif (observed_total_ms_value := _json_float_or_none(observed_total_ms)) is None:
             violations.append("non-numeric total runtime metric")
-        elif observed_total_ms_value > args.max_total_ms:
+        elif observed_total_ms_value > request.max_total_ms:
             violations.append(
-                f"total runtime {observed_total_ms_value:.1f} ms exceeded budget {args.max_total_ms:.1f} ms"
+                f"total runtime {observed_total_ms_value:.1f} ms exceeded budget {request.max_total_ms:.1f} ms"
             )
 
-    if args.max_peak_rss_mb is not None:
+    if request.max_peak_rss_mb is not None:
         if observed_peak_rss_mb is None:
             violations.append("missing peak RSS metric")
         elif (observed_peak_rss_mb_value := _json_float_or_none(observed_peak_rss_mb)) is None:
             violations.append("non-numeric peak RSS metric")
-        elif observed_peak_rss_mb_value > args.max_peak_rss_mb:
+        elif observed_peak_rss_mb_value > request.max_peak_rss_mb:
             violations.append(
-                f"peak RSS {observed_peak_rss_mb_value:.1f} MiB exceeded budget {args.max_peak_rss_mb:.1f} MiB"
+                f"peak RSS {observed_peak_rss_mb_value:.1f} MiB exceeded budget {request.max_peak_rss_mb:.1f} MiB"
             )
 
     return {
         "ok": not violations,
-        "max_total_ms": args.max_total_ms,
+        "max_total_ms": request.max_total_ms,
         "observed_total_ms": observed_total_ms,
-        "max_peak_rss_mb": args.max_peak_rss_mb,
+        "max_peak_rss_mb": request.max_peak_rss_mb,
         "observed_peak_rss_mb": observed_peak_rss_mb,
         "violations": violations,
     }
 
 
 def main(argv: list[str] | None = None) -> int:
-    args = _parse_args(argv)
-    if args.workdir is None:
+    request = _request_from_args(_parse_args(argv))
+    active_request = request
+    if request.workdir is None:
         with tempfile.TemporaryDirectory(prefix="polylogue-pipeline-probe-") as tempdir:
-            args.workdir = Path(tempdir)
+            active_request = replace(request, workdir=str(Path(tempdir)))
             with redirect_stdout(sys.stderr):
-                summary = asyncio.run(run_probe(args))
+                summary = asyncio.run(run_probe(active_request))
     else:
         with redirect_stdout(sys.stderr):
-            summary = asyncio.run(run_probe(args))
-    budget_report = _build_budget_report(summary, args)
+            summary = asyncio.run(run_probe(active_request))
+    budget_report = _build_budget_report(summary, active_request)
     if budget_report is not None:
         summary["budgets"] = budget_report
     encoded = json.dumps(summary, indent=2, sort_keys=True)
-    if args.json_out is not None:
-        args.json_out.parent.mkdir(parents=True, exist_ok=True)
-        args.json_out.write_text(encoded + "\n", encoding="utf-8")
+    if active_request.json_out is not None:
+        json_out = Path(active_request.json_out)
+        json_out.parent.mkdir(parents=True, exist_ok=True)
+        json_out.write_text(encoded + "\n", encoding="utf-8")
     print(encoded)
     return 1 if budget_report is not None and not budget_report["ok"] else 0
 

--- a/devtools/verify_showcase.py
+++ b/devtools/verify_showcase.py
@@ -14,8 +14,9 @@ import difflib
 import sys
 from pathlib import Path
 
+from polylogue.showcase.cli_boundary import invoke_showcase_cli
 from polylogue.showcase.exercises import EXERCISES, Exercise
-from polylogue.showcase.runner import ShowcaseRunner
+from polylogue.showcase.showcase_runner_support import run_exercise
 
 BASELINE_DIR = Path(__file__).resolve().parent.parent / "tests" / "baselines" / "showcase"
 
@@ -38,10 +39,6 @@ def get_tier_0_exercises() -> list[Exercise]:
 
 def run_tier_0() -> dict[str, str]:
     """Run tier 0 exercises and return {exercise_name: output} mapping."""
-    runner = ShowcaseRunner(live=False, fail_fast=False, verbose=False)
-
-    # We only need to run the structural exercises — no seeding needed.
-    # Use the runner's _run_exercise directly to avoid full workspace setup.
     from polylogue.showcase.exercises import topological_order
 
     exercises = get_tier_0_exercises()
@@ -49,7 +46,11 @@ def run_tier_0() -> dict[str, str]:
 
     results: dict[str, str] = {}
     for ex in exercises:
-        er = runner._run_exercise(ex)
+        er = run_exercise(
+            ex,
+            env_vars={},
+            invoke_showcase_cli_fn=invoke_showcase_cli,
+        )
         results[ex.name] = er.output or ""
 
     return results

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -57,7 +57,7 @@ These are the commands worth remembering during normal repo work:
 | Command | Description |
 | --- | --- |
 | `devtools artifact-graph` | Render the runtime artifact, operation, and scenario-coverage map. |
-| `devtools pipeline-probe` | Run synthetic pipeline probes against generated archives. |
+| `devtools pipeline-probe` | Run typed pipeline probes against synthetic, staged, or archive-subset inputs. |
 | `devtools query-memory-budget` | Measure query-memory envelopes on generated fixtures. |
 | `devtools run-validation-lanes` | Run named validation lanes. |
 | `devtools scenario-projections` | Render the authored scenario-bearing verification projections. |

--- a/tests/infra/mcp.py
+++ b/tests/infra/mcp.py
@@ -91,29 +91,44 @@ async def invoke_surface_async(
     return result
 
 
-def make_repo_mock() -> MagicMock:
-    """Create a repository mock with async methods used by MCP surfaces."""
-    repo = MagicMock()
-    repo.list = AsyncMock(return_value=[])
-    repo.search = AsyncMock(return_value=[])
-    repo.view = AsyncMock(return_value=None)
-    repo.get = AsyncMock(return_value=None)
-    repo.resolve_id = AsyncMock(return_value=None)
-    repo.get_archive_stats = AsyncMock(return_value=MagicMock())
-    repo.get_summary = AsyncMock(return_value=None)
-    repo.get_session_tree = AsyncMock(return_value=[])
-    repo.add_tag = AsyncMock(return_value=None)
-    repo.remove_tag = AsyncMock(return_value=None)
-    repo.list_tags = AsyncMock(return_value={})
-    repo.get_metadata = AsyncMock(return_value={})
-    repo.update_metadata = AsyncMock(return_value=None)
-    repo.delete_metadata = AsyncMock(return_value=None)
-    repo.delete_conversation = AsyncMock(return_value=False)
-    repo.backend = MagicMock()
-    repo.queries = MagicMock()
-    repo.queries.get_conversation_stats = AsyncMock(return_value={})
-    repo.queries.get_stats_by = AsyncMock(return_value={})
-    return repo
+def make_query_store_mock() -> MagicMock:
+    """Create a query-store mock matching the current MCP read/query seam."""
+    store = MagicMock()
+    store.list = AsyncMock(return_value=[])
+    store.list_summaries = AsyncMock(return_value=[])
+    store.list_summaries_by_query = AsyncMock(return_value=[])
+    store.search = AsyncMock(return_value=[])
+    store.search_summaries = AsyncMock(return_value=[])
+    store.view = AsyncMock(return_value=None)
+    store.get = AsyncMock(return_value=None)
+    store.get_eager = AsyncMock(return_value=None)
+    store.resolve_id = AsyncMock(return_value=None)
+    store.delete_conversation = AsyncMock(return_value=False)
+    return store
+
+
+def make_tag_store_mock() -> MagicMock:
+    """Create a tag/metadata store mock matching the current MCP mutation seam."""
+    store = MagicMock()
+    store.add_tag = AsyncMock(return_value=None)
+    store.remove_tag = AsyncMock(return_value=None)
+    store.list_tags = AsyncMock(return_value={})
+    store.get_metadata = AsyncMock(return_value={})
+    store.update_metadata = AsyncMock(return_value=None)
+    store.delete_metadata = AsyncMock(return_value=None)
+    return store
+
+
+def make_archive_ops_mock() -> MagicMock:
+    """Create an archive-operations mock matching the current MCP read seam."""
+    operations = MagicMock()
+    operations.get_conversation = AsyncMock(return_value=None)
+    operations.get_conversation_summary = AsyncMock(return_value=None)
+    operations.get_conversation_stats = AsyncMock(return_value={})
+    operations.get_session_tree = AsyncMock(return_value=[])
+    operations.get_stats_by = AsyncMock(return_value={})
+    operations.storage_stats = AsyncMock(return_value=MagicMock())
+    return operations
 
 
 def make_mock_filter(results: Sequence[object] | None = None, **method_overrides: object) -> MagicMock:

--- a/tests/unit/devtools/test_pipeline_probe.py
+++ b/tests/unit/devtools/test_pipeline_probe.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import argparse
 import json
 from pathlib import Path
 from typing import TypeAlias
@@ -10,7 +9,7 @@ from typing import TypeAlias
 import pytest
 
 from devtools.pipeline_probe import _write_probe_sources, main, run_probe
-from polylogue.scenarios import CorpusRequest, CorpusScenario, CorpusSpec
+from polylogue.scenarios import CorpusRequest, CorpusScenario, CorpusSpec, PipelineProbeRequest
 from polylogue.schemas.synthetic import SyntheticCorpus
 from polylogue.storage.backends import create_backend
 from polylogue.storage.backends.connection import open_connection
@@ -66,99 +65,77 @@ def _load_json_object(text: str) -> JsonObject:
     return _require_json_object(json.loads(text))
 
 
-class _Args(argparse.Namespace):
-    def __init__(self, workdir: Path) -> None:
-        super().__init__(
-            input_mode="synthetic",
-            provider="chatgpt",
-            corpus_source="default",
+def _synthetic_request(workdir: Path) -> PipelineProbeRequest:
+    return PipelineProbeRequest(
+        stage="parse",
+        workdir=str(workdir),
+        corpus_request=CorpusRequest(
+            providers=("chatgpt",),
+            source="default",
             count=1,
             messages_min=3,
             messages_max=4,
             seed=7,
-            sample_per_provider=50,
-            source_filters=None,
-            source_db=None,
-            source_blob_root=None,
-            manifest_out=None,
-            manifest_in=None,
-            stage="parse",
-            raw_batch_size=None,
-            ingest_workers=None,
-            measure_ingest_result_size=False,
-            json_out=None,
-            max_total_ms=None,
-            max_peak_rss_mb=None,
-            workdir=workdir,
-        )
+            style="default",
+        ),
+    )
 
 
-class _ArchiveArgs(argparse.Namespace):
-    def __init__(
-        self,
-        *,
-        workdir: Path,
-        source_db: Path,
-        source_blob_root: Path,
-        manifest_out: Path | None = None,
-        manifest_in: Path | None = None,
-    ) -> None:
-        super().__init__(
-            input_mode="archive-subset",
-            provider=None,
+def _archive_request(
+    *,
+    workdir: Path,
+    source_db: Path,
+    source_blob_root: Path,
+    manifest_out: Path | None = None,
+    manifest_in: Path | None = None,
+    sample_per_provider: int = 1,
+    seed: int = 11,
+) -> PipelineProbeRequest:
+    return PipelineProbeRequest(
+        stage="parse",
+        input_mode="archive-subset",
+        workdir=str(workdir),
+        source_db=str(source_db),
+        source_blob_root=str(source_blob_root),
+        manifest_out=str(manifest_out) if manifest_out is not None else None,
+        manifest_in=str(manifest_in) if manifest_in is not None else None,
+        sample_per_provider=sample_per_provider,
+        corpus_request=CorpusRequest(
             count=1,
             messages_min=3,
             messages_max=4,
-            seed=11,
-            sample_per_provider=1,
-            source_filters=None,
-            manifest_out=manifest_out,
-            manifest_in=manifest_in,
-            stage="parse",
-            raw_batch_size=None,
-            ingest_workers=None,
-            measure_ingest_result_size=False,
-            json_out=None,
-            max_total_ms=None,
-            max_peak_rss_mb=None,
-            workdir=workdir,
-            source_db=source_db,
-            source_blob_root=source_blob_root,
-        )
+            seed=seed,
+            style="default",
+        ),
+    )
 
 
-class _SourceSubsetArgs(argparse.Namespace):
-    def __init__(
-        self,
-        *,
-        workdir: Path,
-        source_paths: list[Path],
-        source_name: str = "inbox",
-    ) -> None:
-        super().__init__(
-            input_mode="source-subset",
-            provider=None,
+def _source_subset_request(
+    *,
+    workdir: Path,
+    source_paths: list[Path],
+    source_name: str = "inbox",
+    raw_batch_size: int | None = None,
+    ingest_workers: int | None = None,
+    measure_ingest_result_size: bool = False,
+) -> PipelineProbeRequest:
+    return PipelineProbeRequest(
+        stage="parse",
+        input_mode="source-subset",
+        workdir=str(workdir),
+        source_paths=tuple(str(path) for path in source_paths),
+        source_name=source_name,
+        raw_batch_size=raw_batch_size,
+        ingest_workers=ingest_workers,
+        measure_ingest_result_size=measure_ingest_result_size,
+        corpus_request=CorpusRequest(
             count=1,
             messages_min=3,
             messages_max=4,
             seed=13,
-            sample_per_provider=50,
-            source_filters=None,
-            source_db=None,
-            source_blob_root=None,
-            manifest_out=None,
-            manifest_in=None,
-            stage="parse",
-            raw_batch_size=None,
-            ingest_workers=None,
-            measure_ingest_result_size=False,
-            json_out=None,
-            max_total_ms=None,
-            max_peak_rss_mb=None,
-            workdir=workdir,
-            source_paths=source_paths,
-            source_name=source_name,
-        )
+            style="default",
+        ),
+    )
 
 
 async def _seed_archive_source(tmp_path: Path) -> tuple[Path, Path]:
@@ -255,7 +232,7 @@ async def _seed_archive_source(tmp_path: Path) -> tuple[Path, Path]:
 
 
 async def test_run_probe_emits_real_pipeline_summary(tmp_path: Path) -> None:
-    summary = await run_probe(_Args(tmp_path / "probe"))
+    summary = await run_probe(_synthetic_request(tmp_path / "probe"))
     run_payload = _require_json_object(summary["run_payload"])
     metrics = _require_json_object(run_payload["metrics"])
     stages = _require_json_object(metrics["stages"])
@@ -302,13 +279,13 @@ async def test_run_probe_can_stage_real_source_subset(tmp_path: Path) -> None:
         ),
         source_root=source_input_root,
     )
-    args = _SourceSubsetArgs(
+    request = _source_subset_request(
         workdir=tmp_path / "source-subset-probe",
         source_paths=files,
         source_name="inbox",
     )
 
-    summary = await run_probe(args)
+    summary = await run_probe(request)
 
     source_inputs = _require_json_object(summary["source_inputs"])
     provenance = _require_json_object(summary["provenance"])
@@ -391,14 +368,14 @@ async def test_run_probe_applies_ingest_tuning_overrides(tmp_path: Path) -> None
         ),
         source_root=source_input_root,
     )
-    args = _SourceSubsetArgs(
+    request = _source_subset_request(
         workdir=tmp_path / "source-subset-overrides",
         source_paths=files,
+        raw_batch_size=1,
+        ingest_workers=1,
     )
-    args.raw_batch_size = 1
-    args.ingest_workers = 1
 
-    summary = await run_probe(args)
+    summary = await run_probe(request)
     ingest_details = _require_json_object(
         _json_path(summary, "run_payload", "metrics", "stages", "ingest", "details", "batch_observations")
     )
@@ -423,13 +400,13 @@ async def test_run_probe_can_measure_ingest_result_sizes(tmp_path: Path) -> None
         ),
         source_root=source_input_root,
     )
-    args = _SourceSubsetArgs(
+    request = _source_subset_request(
         workdir=tmp_path / "source-subset-size-probe",
         source_paths=files,
+        measure_ingest_result_size=True,
     )
-    args.measure_ingest_result_size = True
 
-    summary = await run_probe(args)
+    summary = await run_probe(request)
     batch = _require_json_object(
         _json_path(summary, "run_payload", "metrics", "stages", "ingest", "details", "batch_observations")
     )
@@ -442,13 +419,13 @@ async def test_run_probe_can_measure_ingest_result_sizes(tmp_path: Path) -> None
 
 
 async def test_run_probe_rejects_source_subset_without_source_paths(tmp_path: Path) -> None:
-    args = _SourceSubsetArgs(
+    request = _source_subset_request(
         workdir=tmp_path / "missing-source-paths",
         source_paths=[],
     )
 
     with pytest.raises(ValueError, match="--source-path is required"):
-        await run_probe(args)
+        await run_probe(request)
 
 
 def test_main_writes_json_summary(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
@@ -570,14 +547,14 @@ def test_main_returns_nonzero_when_budget_is_exceeded(capsys: pytest.CaptureFixt
 async def test_run_probe_can_sample_archive_subset_and_persist_manifest(tmp_path: Path) -> None:
     source_db, source_blob_root = await _seed_archive_source(tmp_path)
     manifest_out = tmp_path / "subset-manifest.json"
-    args = _ArchiveArgs(
+    request = _archive_request(
         workdir=tmp_path / "archive-probe",
         source_db=source_db,
         source_blob_root=source_blob_root,
         manifest_out=manifest_out,
     )
 
-    summary = await run_probe(args)
+    summary = await run_probe(request)
     manifest = _load_json_object(manifest_out.read_text(encoding="utf-8"))
 
     assert _json_path(summary, "probe", "input_mode") == "archive-subset"
@@ -597,24 +574,24 @@ async def test_run_probe_can_sample_archive_subset_and_persist_manifest(tmp_path
 async def test_run_probe_can_replay_archive_subset_manifest(tmp_path: Path) -> None:
     source_db, source_blob_root = await _seed_archive_source(tmp_path)
     manifest_out = tmp_path / "subset-manifest.json"
-    first_args = _ArchiveArgs(
+    first_request = _archive_request(
         workdir=tmp_path / "archive-probe-first",
         source_db=source_db,
         source_blob_root=source_blob_root,
         manifest_out=manifest_out,
     )
-    await run_probe(first_args)
+    await run_probe(first_request)
 
-    replay_args = _ArchiveArgs(
+    replay_request = _archive_request(
         workdir=tmp_path / "archive-probe-replay",
         source_db=source_db,
         source_blob_root=source_blob_root,
         manifest_in=manifest_out,
+        sample_per_provider=99,
+        seed=999,
     )
-    replay_args.sample_per_provider = 99
-    replay_args.seed = 999
 
-    summary = await run_probe(replay_args)
+    summary = await run_probe(replay_request)
 
     assert _json_path(summary, "sample", "selected_count") == 2
     assert _json_path(summary, "sample", "sample_per_provider") == 1
@@ -626,11 +603,11 @@ async def test_run_probe_rejects_empty_archive_subset(tmp_path: Path) -> None:
     with open_connection(empty_db):
         pass
     empty_blob_root = tmp_path / "empty-blobs"
-    args = _ArchiveArgs(
+    request = _archive_request(
         workdir=tmp_path / "archive-probe-empty",
         source_db=empty_db,
         source_blob_root=empty_blob_root,
     )
 
     with pytest.raises(ValueError, match="found no raw conversations"):
-        await run_probe(args)
+        await run_probe(request)

--- a/tests/unit/mcp/test_mcp_edge_cases.py
+++ b/tests/unit/mcp/test_mcp_edge_cases.py
@@ -91,12 +91,12 @@ class TestUnicodeHandling:
     @pytest.mark.asyncio
     async def test_unicode_tag(self, mcp_server: Any) -> None:
         """Unicode characters in tag names don't crash the server."""
-        from tests.infra.mcp import make_repo_mock
+        from tests.infra.mcp import make_tag_store_mock
 
-        with patch("polylogue.mcp.server._get_repo") as mock_get_repo:
-            mock_repo = make_repo_mock()
-            mock_repo.add_tag = AsyncMock(return_value=True)
-            mock_get_repo.return_value = mock_repo
+        with patch("polylogue.mcp.server._get_tag_store") as mock_get_tag_store:
+            mock_tag_store = make_tag_store_mock()
+            mock_tag_store.add_tag = AsyncMock(return_value=True)
+            mock_get_tag_store.return_value = mock_tag_store
 
             # This should not crash even with emoji/CJK/RTL
             for tag in ["bug-fix", "重要", "مهم", "critical"]:
@@ -111,15 +111,15 @@ class TestUnicodeHandling:
     @pytest.mark.asyncio
     async def test_empty_query(self, mcp_server: Any) -> None:
         """Empty query string doesn't crash search."""
-        from tests.infra.mcp import make_mock_filter, make_repo_mock
+        from tests.infra.mcp import make_mock_filter, make_query_store_mock
 
         with (
-            patch("polylogue.mcp.server._get_repo") as mock_get_repo,
+            patch("polylogue.mcp.server._get_query_store") as mock_get_query_store,
             patch("polylogue.lib.filters.ConversationFilter") as mock_filter_cls,
         ):
-            mock_repo = make_repo_mock()
-            mock_repo.search = AsyncMock(return_value=[])
-            mock_get_repo.return_value = mock_repo
+            mock_query_store = make_query_store_mock()
+            mock_query_store.search = AsyncMock(return_value=[])
+            mock_get_query_store.return_value = mock_query_store
             mock_filter_cls.return_value = make_mock_filter(results=[])
 
             result = await _invoke_tool(
@@ -140,15 +140,15 @@ class TestBoundaryParameters:
     @pytest.mark.asyncio
     async def test_limit_zero(self, mcp_server: Any) -> None:
         """limit=0 is clamped to 1 (returns minimal results)."""
-        from tests.infra.mcp import make_mock_filter, make_repo_mock
+        from tests.infra.mcp import make_mock_filter, make_query_store_mock
 
         with (
-            patch("polylogue.mcp.server._get_repo") as mock_get_repo,
+            patch("polylogue.mcp.server._get_query_store") as mock_get_query_store,
             patch("polylogue.lib.filters.ConversationFilter") as mock_filter_cls,
         ):
-            mock_repo = make_repo_mock()
-            mock_repo.list = AsyncMock(return_value=[])
-            mock_get_repo.return_value = mock_repo
+            mock_query_store = make_query_store_mock()
+            mock_query_store.list = AsyncMock(return_value=[])
+            mock_get_query_store.return_value = mock_query_store
             mock_filter_cls.return_value = make_mock_filter(results=[])
 
             result = await _invoke_tool(
@@ -161,15 +161,15 @@ class TestBoundaryParameters:
     @pytest.mark.asyncio
     async def test_limit_negative(self, mcp_server: Any) -> None:
         """Negative limit is clamped to 1."""
-        from tests.infra.mcp import make_mock_filter, make_repo_mock
+        from tests.infra.mcp import make_mock_filter, make_query_store_mock
 
         with (
-            patch("polylogue.mcp.server._get_repo") as mock_get_repo,
+            patch("polylogue.mcp.server._get_query_store") as mock_get_query_store,
             patch("polylogue.lib.filters.ConversationFilter") as mock_filter_cls,
         ):
-            mock_repo = make_repo_mock()
-            mock_repo.list = AsyncMock(return_value=[])
-            mock_get_repo.return_value = mock_repo
+            mock_query_store = make_query_store_mock()
+            mock_query_store.list = AsyncMock(return_value=[])
+            mock_get_query_store.return_value = mock_query_store
             mock_filter_cls.return_value = make_mock_filter(results=[])
 
             result = await _invoke_tool(

--- a/tests/unit/mcp/test_server_surfaces.py
+++ b/tests/unit/mcp/test_server_surfaces.py
@@ -22,8 +22,9 @@ from tests.infra.mcp import (
     invoke_surface,
     invoke_surface_async,
     make_mock_filter,
-    make_repo_mock,
+    make_query_store_mock,
     make_simple_conversation,
+    make_tag_store_mock,
 )
 
 SerializationCase = tuple[str, Conversation, dict[str, object], str]
@@ -202,7 +203,7 @@ class TestResourceSurfaces:
 
     def test_tags_resource(self: object, mcp_server: Any) -> None:
         with patch("polylogue.mcp.server._get_tag_store") as mock_get_tag_store:
-            mock_tag_store = make_repo_mock()
+            mock_tag_store = make_tag_store_mock()
             mock_tag_store.list_tags.return_value = {"feature": 10, "bug": 5}
             mock_get_tag_store.return_value = mock_tag_store
 
@@ -364,7 +365,7 @@ class TestPromptSurfaces:
         mcp_server: Any,
     ) -> None:
         with patch("polylogue.mcp.server._get_query_store") as mock_get_query_store:
-            mock_query_store = make_repo_mock()
+            mock_query_store = make_query_store_mock()
             mock_query_store.get_eager = AsyncMock(side_effect=[simple_conversation, simple_conversation])
             mock_get_query_store.return_value = mock_query_store
 

--- a/tests/unit/mcp/test_tool_contracts.py
+++ b/tests/unit/mcp/test_tool_contracts.py
@@ -43,8 +43,9 @@ from tests.infra.builders import make_conv, make_msg
 from tests.infra.mcp import (
     invoke_surface,
     invoke_surface_async,
-    make_repo_mock,
+    make_query_store_mock,
     make_simple_conversation,
+    make_tag_store_mock,
 )
 
 STATS_CONFIGS = [
@@ -649,7 +650,7 @@ class TestStatsTool:
 class TestMutationTools:
     def test_add_tag_success(self, mcp_server: Any) -> None:
         with patch("polylogue.mcp.server._get_tag_store") as mock_get_tag_store:
-            mock_tag_store = make_repo_mock()
+            mock_tag_store = make_tag_store_mock()
             mock_tag_store.add_tag.return_value = None
             mock_get_tag_store.return_value = mock_tag_store
 
@@ -663,7 +664,7 @@ class TestMutationTools:
 
     def test_add_tag_error(self, mcp_server: Any) -> None:
         with patch("polylogue.mcp.server._get_tag_store") as mock_get_tag_store:
-            mock_tag_store = make_repo_mock()
+            mock_tag_store = make_tag_store_mock()
             mock_tag_store.add_tag.side_effect = ValueError("Invalid tag")
             mock_get_tag_store.return_value = mock_tag_store
 
@@ -676,7 +677,7 @@ class TestMutationTools:
 
     def test_remove_tag_success(self, mcp_server: Any) -> None:
         with patch("polylogue.mcp.server._get_tag_store") as mock_get_tag_store:
-            mock_tag_store = make_repo_mock()
+            mock_tag_store = make_tag_store_mock()
             mock_tag_store.remove_tag.return_value = None
             mock_get_tag_store.return_value = mock_tag_store
 
@@ -690,7 +691,7 @@ class TestMutationTools:
 
     def test_remove_tag_error(self, mcp_server: Any) -> None:
         with patch("polylogue.mcp.server._get_tag_store") as mock_get_tag_store:
-            mock_tag_store = make_repo_mock()
+            mock_tag_store = make_tag_store_mock()
             mock_tag_store.remove_tag.side_effect = RuntimeError("Backend error")
             mock_get_tag_store.return_value = mock_tag_store
 
@@ -702,7 +703,7 @@ class TestMutationTools:
 
     def test_list_tags_returns_counts(self, mcp_server: Any) -> None:
         with patch("polylogue.mcp.server._get_tag_store") as mock_get_tag_store:
-            mock_tag_store = make_repo_mock()
+            mock_tag_store = make_tag_store_mock()
             mock_tag_store.list_tags.return_value = {"bug": 3, "feature": 5, "urgent": 1}
             mock_get_tag_store.return_value = mock_tag_store
 
@@ -712,7 +713,7 @@ class TestMutationTools:
 
     def test_list_tags_with_provider(self, mcp_server: Any) -> None:
         with patch("polylogue.mcp.server._get_tag_store") as mock_get_tag_store:
-            mock_tag_store = make_repo_mock()
+            mock_tag_store = make_tag_store_mock()
             mock_tag_store.list_tags.return_value = {"claude-ai": 2}
             mock_get_tag_store.return_value = mock_tag_store
 
@@ -723,7 +724,7 @@ class TestMutationTools:
 
     def test_get_metadata_success(self, mcp_server: Any) -> None:
         with patch("polylogue.mcp.server._get_tag_store") as mock_get_tag_store:
-            mock_tag_store = make_repo_mock()
+            mock_tag_store = make_tag_store_mock()
             mock_tag_store.get_metadata.return_value = {"key": "value", "count": 42}
             mock_get_tag_store.return_value = mock_tag_store
 
@@ -733,7 +734,7 @@ class TestMutationTools:
 
     def test_set_metadata_string_value(self, mcp_server: Any) -> None:
         with patch("polylogue.mcp.server._get_tag_store") as mock_get_tag_store:
-            mock_tag_store = make_repo_mock()
+            mock_tag_store = make_tag_store_mock()
             mock_tag_store.update_metadata.return_value = None
             mock_get_tag_store.return_value = mock_tag_store
 
@@ -749,7 +750,7 @@ class TestMutationTools:
 
     def test_set_metadata_json_value(self, mcp_server: Any) -> None:
         with patch("polylogue.mcp.server._get_tag_store") as mock_get_tag_store:
-            mock_tag_store = make_repo_mock()
+            mock_tag_store = make_tag_store_mock()
             mock_tag_store.update_metadata.return_value = None
             mock_get_tag_store.return_value = mock_tag_store
 
@@ -765,7 +766,7 @@ class TestMutationTools:
 
     def test_delete_metadata_success(self, mcp_server: Any) -> None:
         with patch("polylogue.mcp.server._get_tag_store") as mock_get_tag_store:
-            mock_tag_store = make_repo_mock()
+            mock_tag_store = make_tag_store_mock()
             mock_tag_store.delete_metadata.return_value = None
             mock_get_tag_store.return_value = mock_tag_store
 
@@ -782,7 +783,7 @@ class TestMutationTools:
 
     def test_delete_requires_confirm(self, mcp_server: Any) -> None:
         with patch("polylogue.mcp.server._get_query_store") as mock_get_query_store:
-            mock_query_store = make_repo_mock()
+            mock_query_store = make_query_store_mock()
             mock_get_query_store.return_value = mock_query_store
 
             result = invoke_surface(
@@ -797,7 +798,7 @@ class TestMutationTools:
 
     def test_delete_with_confirm(self, mcp_server: Any) -> None:
         with patch("polylogue.mcp.server._get_query_store") as mock_get_query_store:
-            mock_query_store = make_repo_mock()
+            mock_query_store = make_query_store_mock()
             mock_query_store.delete_conversation.return_value = True
             mock_get_query_store.return_value = mock_query_store
 
@@ -812,7 +813,7 @@ class TestMutationTools:
 
     def test_delete_not_found(self, mcp_server: Any) -> None:
         with patch("polylogue.mcp.server._get_query_store") as mock_get_query_store:
-            mock_query_store = make_repo_mock()
+            mock_query_store = make_query_store_mock()
             mock_query_store.delete_conversation.return_value = False
             mock_get_query_store.return_value = mock_query_store
 


### PR DESCRIPTION
Closes #246

## Summary
- migrate `devtools pipeline-probe` onto the authored `PipelineProbeRequest` and workspace contracts
- split MCP verification helpers/tests across query, tag, and archive-ops seams instead of monolithic repo mocks
- remove the remaining verification-time private API reach-through in `verify-showcase` and refresh generated devtools references

## Problem
The substrate and surface renewal work had already tightened repository, archive-ops, and workspace contracts, but the verification layer was still asserting older shapes. `pipeline_probe` still projected an ad hoc `argparse.Namespace` world, MCP tests still modeled a monolithic repo surface, and `verify_showcase` still reached through a private runner method.

## Solution
The probe path now projects CLI input onto `PipelineProbeRequest`, uses `VerificationWorkspace`, and replays archive subsets through a typed raw-conversation store seam. MCP test helpers were rebuilt around separate query/tag/archive-ops mocks so tool and resource tests assert the renewed boundaries directly. `verify_showcase` now uses the public `run_exercise()` helper, and the devtools command catalog/docs were updated to reflect the broadened probe contract.

## Verification
- `ruff check devtools/pipeline_probe.py devtools/verify_showcase.py devtools/command_catalog.py tests/unit/devtools/test_pipeline_probe.py tests/infra/mcp.py tests/unit/mcp/test_mcp_edge_cases.py tests/unit/mcp/test_server_surfaces.py tests/unit/mcp/test_tool_contracts.py`
- `mypy devtools/pipeline_probe.py devtools/verify_showcase.py devtools/command_catalog.py tests/unit/devtools/test_pipeline_probe.py tests/infra/mcp.py tests/unit/mcp/test_mcp_edge_cases.py tests/unit/mcp/test_server_surfaces.py tests/unit/mcp/test_tool_contracts.py`
- `pytest -q tests/unit/devtools/test_pipeline_probe.py tests/unit/mcp/test_mcp_edge_cases.py tests/unit/mcp/test_server_surfaces.py tests/unit/mcp/test_tool_contracts.py`
- `devtools render-devtools-reference`
- `devtools render-agents`
- `devtools render-all --check`
- `devtools verify`
