### PR TITLE
refactor: tighten schema and lib payload boundary contracts

### DIFF
--- a/polylogue/lib/action_event_parsing.py
+++ b/polylogue/lib/action_event_parsing.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import json
 from collections.abc import Mapping, Sequence
-from typing import Any
 
+from polylogue.lib.json import JSONDocument, json_document
 from polylogue.lib.viewports import ToolCall, ToolCategory, classify_tool
 from polylogue.types import Provider
 
@@ -17,7 +17,7 @@ def _clean_str(value: object) -> str | None:
     return candidate or None
 
 
-def _extract_first_string(mapping: dict[str, Any], fields: tuple[str, ...]) -> str | None:
+def _extract_first_string(mapping: Mapping[str, object], fields: tuple[str, ...]) -> str | None:
     for field in fields:
         value = _clean_str(mapping.get(field))
         if value is not None:
@@ -25,16 +25,16 @@ def _extract_first_string(mapping: dict[str, Any], fields: tuple[str, ...]) -> s
     return None
 
 
-def _normalized_mapping(value: object) -> dict[str, Any]:
+def _normalized_mapping(value: object) -> JSONDocument:
     if isinstance(value, Mapping):
-        return dict(value)
+        return json_document(dict(value))
     if isinstance(value, str) and value.strip():
         try:
             parsed = json.loads(value)
         except json.JSONDecodeError:
             return {}
         if isinstance(parsed, Mapping):
-            return dict(parsed)
+            return json_document(dict(parsed))
     return {}
 
 
@@ -50,11 +50,11 @@ def _tool_category_from_semantic(value: object) -> ToolCategory | None:
 def build_tool_calls_from_content_blocks(
     *,
     provider: Provider | str | None,
-    content_blocks: Sequence[Mapping[str, Any]],
+    content_blocks: Sequence[Mapping[str, object]],
 ) -> tuple[ToolCall, ...]:
     """Normalize canonical ToolCall viewports from content blocks."""
     tool_result_outputs: dict[str, str] = {}
-    tool_use_blocks: list[Mapping[str, Any]] = []
+    tool_use_blocks: list[Mapping[str, object]] = []
     for block in content_blocks:
         block_type = str(block.get("type"))
         if block_type == "tool_result":

--- a/polylogue/lib/action_events.py
+++ b/polylogue/lib/action_events.py
@@ -8,9 +8,9 @@ search/web targets, and message-scoped event identity.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any
 
 from polylogue.lib.action_event_fields import (
     build_search_text,
@@ -48,7 +48,7 @@ class ActionEvent:
     url: str | None
     output_text: str | None
     search_text: str
-    raw: dict[str, Any]
+    raw: Mapping[str, object]
 
     @property
     def normalized_tool_name(self) -> str:

--- a/polylogue/lib/artifact_taxonomy_runtime.py
+++ b/polylogue/lib/artifact_taxonomy_runtime.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
 
 from polylogue.lib.artifact_taxonomy_models import ArtifactClassification, ArtifactKind
 from polylogue.lib.artifact_taxonomy_support import (
@@ -16,6 +15,7 @@ from polylogue.lib.artifact_taxonomy_support import (
     normalize_source_path,
     path_only_sidecars,
 )
+from polylogue.lib.json import JSONDocument, JSONValue, json_document
 from polylogue.types import Provider
 
 
@@ -56,7 +56,7 @@ def classify_artifact_path(
 
 
 def classify_artifact(
-    payload: Any,
+    payload: JSONValue,
     *,
     provider: str | Provider,
     source_path: str | Path | None = None,
@@ -82,12 +82,13 @@ def classify_artifact(
 
 
 def _classify_list(
-    payload: list[Any],
+    payload: list[JSONValue],
     *,
     provider: Provider,
     source_path: str | Path | None,
 ) -> ArtifactClassification:
-    dict_items = [item for item in payload[:32] if isinstance(item, dict)]
+    dict_items = [json_document(item) for item in payload[:32]]
+    dict_items = [item for item in dict_items if item]
     if not payload:
         return ArtifactClassification(
             provider=provider,
@@ -141,7 +142,7 @@ def _classify_list(
 
 
 def _classify_dict(
-    payload: dict[str, Any],
+    payload: JSONDocument,
     *,
     provider: Provider,
     source_path: str | Path | None,

--- a/polylogue/lib/artifact_taxonomy_support.py
+++ b/polylogue/lib/artifact_taxonomy_support.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+
+from polylogue.lib.json import JSONDocument, JSONValue, json_document
 
 _PATH_ONLY_SIDECARS = {
     "bridge-pointer.json": "bridge pointer sidecar",
@@ -30,7 +31,7 @@ def path_only_sidecars() -> dict[str, str]:
     return _PATH_ONLY_SIDECARS
 
 
-def looks_like_conversation_document(payload: dict[str, Any]) -> bool:
+def looks_like_conversation_document(payload: JSONDocument) -> bool:
     if isinstance(payload.get("mapping"), dict):
         return True
     if isinstance(payload.get("chat_messages"), list):
@@ -44,27 +45,27 @@ def looks_like_conversation_document(payload: dict[str, Any]) -> bool:
     return isinstance(messages, list) and any(looks_like_message_entry(item) for item in messages[:12])
 
 
-def looks_like_record_stream(payload: list[dict[str, Any]]) -> bool:
+def looks_like_record_stream(payload: list[JSONDocument]) -> bool:
     if not payload:
         return False
     recordish = sum(1 for item in payload if looks_like_record_entry(item))
     return recordish / max(len(payload), 1) >= 0.5
 
 
-def looks_like_record_entry(payload: dict[str, Any]) -> bool:
+def looks_like_record_entry(payload: JSONDocument) -> bool:
     if any(key in payload for key in _RECORDISH_KEYS):
         return True
     if "role" in payload and any(key in payload for key in ("content", "text")) and len(payload) <= 16:
         return True
-    nested_message = payload.get("message")
-    return isinstance(nested_message, dict) and any(key in nested_message for key in _MESSAGE_KEYS)
+    nested_message = json_document(payload.get("message"))
+    return bool(nested_message) and any(key in nested_message for key in _MESSAGE_KEYS)
 
 
-def looks_like_message_entry(payload: Any) -> bool:
+def looks_like_message_entry(payload: object) -> bool:
     return isinstance(payload, dict) and any(key in payload for key in _MESSAGE_KEYS)
 
 
-def looks_metadataish_dict(payload: dict[str, Any]) -> bool:
+def looks_metadataish_dict(payload: JSONDocument) -> bool:
     if not payload:
         return True
     if len(payload) > 20:
@@ -76,7 +77,7 @@ def looks_metadataish_dict(payload: dict[str, Any]) -> bool:
     return all(is_scalarish(value) for value in payload.values())
 
 
-def looks_metadataish_list(payload: list[Any]) -> bool:
+def looks_metadataish_list(payload: list[JSONValue]) -> bool:
     if not payload:
         return True
     if len(payload) > 512:
@@ -87,7 +88,7 @@ def looks_metadataish_list(payload: list[Any]) -> bool:
     )
 
 
-def is_scalarish(value: Any, *, depth: int = 0) -> bool:
+def is_scalarish(value: object, *, depth: int = 0) -> bool:
     if isinstance(value, _SCALAR_TYPES):
         return True
     if depth >= 2:

--- a/polylogue/lib/json.py
+++ b/polylogue/lib/json.py
@@ -41,7 +41,11 @@ def json_document_list(value: object) -> JSONDocumentList:
     """Coerce a value into a list of string-keyed JSON objects."""
     if not isinstance(value, list):
         return []
-    return [json_document(item) for item in value]
+    return [document for item in value if (document := json_document(item))]
+
+
+def _reject_non_finite_token(token: str) -> JSONValue:
+    raise ValueError(f"invalid non-finite JSON token: {token}")
 
 
 def _default_encoder(user_default: JSONEncoder | None = None) -> JSONEncoder:
@@ -89,8 +93,8 @@ def loads(obj: str | bytes | bytearray) -> JSONValue:
         return cast(JSONValue, orjson.loads(obj))
     except (orjson.JSONDecodeError, ValueError) as exc:
         try:
-            return cast(JSONValue, json.loads(obj))
-        except json.JSONDecodeError:
+            return cast(JSONValue, json.loads(obj, parse_constant=_reject_non_finite_token))
+        except (json.JSONDecodeError, ValueError):
             raise exc from None
 
 

--- a/polylogue/lib/json.py
+++ b/polylogue/lib/json.py
@@ -1,18 +1,53 @@
-"""Central JSON utilities using orjson."""
+"""Central JSON utilities using orjson with typed JSON contracts."""
 
 from __future__ import annotations
 
+import json
 from collections.abc import Callable
 from decimal import Decimal
-from typing import Any
+from typing import TypeAlias, TypeGuard, cast
 
 import orjson
 
+JSONScalar: TypeAlias = str | int | float | bool | None
+JSONValue: TypeAlias = JSONScalar | list["JSONValue"] | dict[str, "JSONValue"]
+JSONDocument: TypeAlias = dict[str, JSONValue]
+JSONDocumentList: TypeAlias = list[JSONDocument]
+JSONEncoder: TypeAlias = Callable[[object], object]
 
-def _default_encoder(user_default: Callable[[Any], Any] | None = None) -> Callable[[Any], Any]:
+
+def is_json_value(value: object) -> TypeGuard[JSONValue]:
+    """Return whether *value* is representable as JSON."""
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return True
+    if isinstance(value, list):
+        return all(is_json_value(item) for item in value)
+    if isinstance(value, dict):
+        return all(isinstance(key, str) and is_json_value(item) for key, item in value.items())
+    return False
+
+
+def is_json_document(value: object) -> TypeGuard[JSONDocument]:
+    """Return whether *value* is a JSON object with string keys."""
+    return isinstance(value, dict) and all(isinstance(key, str) for key in value)
+
+
+def json_document(value: object) -> JSONDocument:
+    """Coerce a value into a string-keyed JSON object when possible."""
+    return value if is_json_document(value) else {}
+
+
+def json_document_list(value: object) -> JSONDocumentList:
+    """Coerce a value into a list of string-keyed JSON objects."""
+    if not isinstance(value, list):
+        return []
+    return [json_document(item) for item in value]
+
+
+def _default_encoder(user_default: JSONEncoder | None = None) -> JSONEncoder:
     """Create a JSON encoder that handles Decimal values."""
 
-    def _encoder(obj: Any) -> Any:
+    def _encoder(obj: object) -> object:
         if user_default is not None:
             try:
                 return user_default(obj)
@@ -26,30 +61,50 @@ def _default_encoder(user_default: Callable[[Any], Any] | None = None) -> Callab
 
 
 def dumps_bytes(
-    obj: Any,
+    obj: object,
     *,
-    default: Callable[[Any], Any] | None = None,
+    default: JSONEncoder | None = None,
     option: int | None = None,
 ) -> bytes:
     """Dump object to UTF-8 JSON bytes."""
     encoder = _default_encoder(default)
-    kwargs: dict[str, Any] = {"default": encoder}
-    if option is not None:
-        kwargs["option"] = option
     try:
-        return orjson.dumps(obj, **kwargs)
+        if option is None:
+            return orjson.dumps(obj, default=encoder)
+        return orjson.dumps(obj, default=encoder, option=option)
     except TypeError:
         pass
-    import json
 
     return json.dumps(obj, default=encoder).encode("utf-8")
 
 
-def dumps(obj: Any, *, default: Callable[[Any], Any] | None = None, option: int | None = None) -> str:
+def dumps(obj: object, *, default: JSONEncoder | None = None, option: int | None = None) -> str:
     """Dump object to JSON string."""
     return dumps_bytes(obj, default=default, option=option).decode("utf-8")
 
 
-def loads(obj: str | bytes) -> Any:
+def loads(obj: str | bytes | bytearray) -> JSONValue:
     """Load object from JSON string or bytes."""
-    return orjson.loads(obj)
+    try:
+        return cast(JSONValue, orjson.loads(obj))
+    except (orjson.JSONDecodeError, ValueError) as exc:
+        try:
+            return cast(JSONValue, json.loads(obj))
+        except json.JSONDecodeError:
+            raise exc from None
+
+
+__all__ = [
+    "JSONDocument",
+    "JSONDocumentList",
+    "JSONEncoder",
+    "JSONScalar",
+    "JSONValue",
+    "dumps",
+    "dumps_bytes",
+    "is_json_document",
+    "is_json_value",
+    "json_document",
+    "json_document_list",
+    "loads",
+]

--- a/polylogue/lib/message_model_runtime.py
+++ b/polylogue/lib/message_model_runtime.py
@@ -6,9 +6,10 @@ import re
 from collections.abc import Iterable, Mapping
 from datetime import datetime
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING
 
 from polylogue.lib.attachment_models import Attachment
+from polylogue.lib.json import JSONDocument, json_document, json_document_list
 from polylogue.lib.roles import Role
 from polylogue.logging import get_logger
 from polylogue.types import Provider
@@ -49,10 +50,12 @@ def _mapping(value: object) -> Mapping[str, object] | None:
     return value if isinstance(value, Mapping) else None
 
 
-def _content_block_mappings(value: object) -> list[Mapping[str, object]]:
-    if not isinstance(value, list):
-        return []
-    return [block for block in value if isinstance(block, Mapping)]
+def _provider_meta_record(provider_meta: dict[str, object] | None) -> JSONDocument:
+    return json_document(provider_meta)
+
+
+def _content_block_documents(value: object) -> list[JSONDocument]:
+    return json_document_list(value)
 
 
 def _block_texts(blocks: Iterable[Mapping[str, object]], *, block_type: str) -> list[str]:
@@ -120,7 +123,7 @@ class MessageRuntimeMixin:
 
             return extract_from_provider_meta(
                 self.provider,
-                cast(dict[str, Any], self.provider_meta),
+                _provider_meta_record(self.provider_meta),
                 message_id=self.id,
                 role=self.role,
                 text=self.text,
@@ -138,12 +141,13 @@ class MessageRuntimeMixin:
     def _is_chatgpt_thinking(self) -> bool:
         if self.provider_meta is None:
             return False
-        raw = _mapping(self.provider_meta.get("raw"))
-        if raw is None:
+        provider_meta = _provider_meta_record(self.provider_meta)
+        raw = json_document(provider_meta.get("raw"))
+        if not raw:
             return False
 
-        content = _mapping(raw.get("content"))
-        if content is not None:
+        content = json_document(raw.get("content"))
+        if content:
             content_type = content.get("content_type")
             if isinstance(content_type, str) and content_type in {"thoughts", "reasoning_recap"}:
                 return True
@@ -162,12 +166,13 @@ class MessageRuntimeMixin:
 
         provider_meta = self.provider_meta
         if provider_meta is not None:
+            provider_meta_record = _provider_meta_record(provider_meta)
             if any(
                 block.get("type") in {"tool_use", "tool_result"}
-                for block in _content_block_mappings(provider_meta.get("content_blocks"))
+                for block in _content_block_documents(provider_meta_record.get("content_blocks"))
             ):
                 return True
-            if bool(provider_meta.get("isSidechain")) or bool(provider_meta.get("isMeta")):
+            if bool(provider_meta_record.get("isSidechain")) or bool(provider_meta_record.get("isMeta")):
                 return True
             harmonized = self.harmonized
             if harmonized is not None and harmonized.tool_calls:
@@ -185,15 +190,16 @@ class MessageRuntimeMixin:
 
         provider_meta = self.provider_meta
         if provider_meta is not None:
+            provider_meta_record = _provider_meta_record(provider_meta)
             if any(
                 block.get("type") == "thinking"
-                for block in _content_block_mappings(provider_meta.get("content_blocks"))
+                for block in _content_block_documents(provider_meta_record.get("content_blocks"))
             ):
                 return True
-            if bool(provider_meta.get("isThought")):
+            if bool(provider_meta_record.get("isThought")):
                 return True
-            raw = _mapping(provider_meta.get("raw"))
-            if raw is not None and bool(raw.get("isThought")):
+            raw = json_document(provider_meta_record.get("raw"))
+            if raw and bool(raw.get("isThought")):
                 return True
             harmonized = self.harmonized
             if harmonized is not None and harmonized.reasoning_traces:
@@ -240,7 +246,8 @@ class MessageRuntimeMixin:
         provider_meta = self.provider_meta
         if provider_meta is None:
             return None
-        raw = _mapping(provider_meta.get("raw")) or provider_meta
+        provider_meta_record = _provider_meta_record(provider_meta)
+        raw = json_document(provider_meta_record.get("raw")) or provider_meta_record
         return _coerce_optional_float(raw.get("costUSD"))
 
     @property
@@ -248,7 +255,8 @@ class MessageRuntimeMixin:
         provider_meta = self.provider_meta
         if provider_meta is None:
             return None
-        raw = _mapping(provider_meta.get("raw")) or provider_meta
+        provider_meta_record = _provider_meta_record(provider_meta)
+        raw = json_document(provider_meta_record.get("raw")) or provider_meta_record
         return _coerce_optional_int(raw.get("durationMs"))
 
     def extract_thinking(self) -> str | None:
@@ -264,8 +272,9 @@ class MessageRuntimeMixin:
 
         provider_meta = self.provider_meta
         if provider_meta is not None:
+            provider_meta_record = _provider_meta_record(provider_meta)
             provider_texts = _block_texts(
-                _content_block_mappings(provider_meta.get("content_blocks")),
+                _content_block_documents(provider_meta_record.get("content_blocks")),
                 block_type="thinking",
             )
             if provider_texts:
@@ -278,7 +287,8 @@ class MessageRuntimeMixin:
                 return match.group(1).strip()
 
         if text and (
-            self._is_chatgpt_thinking() or (provider_meta is not None and bool(provider_meta.get("isThought")))
+            self._is_chatgpt_thinking()
+            or (provider_meta is not None and bool(_provider_meta_record(provider_meta).get("isThought")))
         ):
             return text.strip() or None
 

--- a/polylogue/lib/provider_semantics.py
+++ b/polylogue/lib/provider_semantics.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
-
+from polylogue.lib.json import JSONDocument, json_document
 from polylogue.lib.viewports import (
     ContentBlock,
     ContentType,
@@ -18,8 +17,9 @@ def content_text(value: object) -> str | None:
     """Extract text from string, dict, or list payloads used in content blocks."""
     if isinstance(value, str):
         return value
-    if isinstance(value, dict):
-        text = value.get("text")
+    record = json_document(value)
+    if record:
+        text = record.get("text")
         return text if isinstance(text, str) else None
     if isinstance(value, list):
         parts: list[str] = []
@@ -31,7 +31,12 @@ def content_text(value: object) -> str | None:
     return None
 
 
-def extract_reasoning_traces(content: list[dict[str, Any]] | None, provider: Provider | str) -> list[ReasoningTrace]:
+def _string_field(block: JSONDocument, key: str) -> str | None:
+    value = block.get(key)
+    return value if isinstance(value, str) else None
+
+
+def extract_reasoning_traces(content: list[JSONDocument] | None, provider: Provider | str) -> list[ReasoningTrace]:
     """Extract reasoning traces from provider content blocks."""
     if not content:
         return []
@@ -39,15 +44,12 @@ def extract_reasoning_traces(content: list[dict[str, Any]] | None, provider: Pro
     normalized_provider = provider if isinstance(provider, Provider) else Provider.from_string(provider)
     traces: list[ReasoningTrace] = []
     for block in content:
-        if not isinstance(block, dict):
-            continue
-
         block_type = block.get("type")
-        text = None
+        text: str | None = None
         if block_type == "thinking":
-            text = block.get("thinking") or block.get("text")
+            text = content_text(block.get("thinking")) or _string_field(block, "text")
         elif block.get("isThought"):
-            text = block.get("text")
+            text = _string_field(block, "text")
 
         if text:
             traces.append(ReasoningTrace(text=text, provider=normalized_provider, raw=block))
@@ -55,7 +57,7 @@ def extract_reasoning_traces(content: list[dict[str, Any]] | None, provider: Pro
     return traces
 
 
-def extract_tool_calls(content: list[dict[str, Any]] | None, provider: Provider | str) -> list[ToolCall]:
+def extract_tool_calls(content: list[JSONDocument] | None, provider: Provider | str) -> list[ToolCall]:
     """Extract tool calls from provider content blocks."""
     if not content:
         return []
@@ -63,16 +65,15 @@ def extract_tool_calls(content: list[dict[str, Any]] | None, provider: Provider 
     normalized_provider = provider if isinstance(provider, Provider) else Provider.from_string(provider)
     calls: list[ToolCall] = []
     for block in content:
-        if not isinstance(block, dict) or block.get("type") != "tool_use":
+        if block.get("type") != "tool_use":
             continue
 
-        name = block.get("name", "")
-        input_data = block.get("input", {})
-        normalized_input = input_data if isinstance(input_data, dict) else {}
+        name = _string_field(block, "name") or ""
+        normalized_input = json_document(block.get("input"))
         calls.append(
             ToolCall(
                 name=name,
-                id=block.get("id"),
+                id=_string_field(block, "id"),
                 input=normalized_input,
                 category=classify_tool(name, normalized_input),
                 provider=normalized_provider,
@@ -83,37 +84,33 @@ def extract_tool_calls(content: list[dict[str, Any]] | None, provider: Provider 
     return calls
 
 
-def extract_content_blocks(content: list[dict[str, Any]] | None) -> list[ContentBlock]:
+def extract_content_blocks(content: list[JSONDocument] | None) -> list[ContentBlock]:
     """Extract harmonized content blocks with type classification."""
     if not content:
         return []
 
     blocks: list[ContentBlock] = []
     for block in content:
-        if not isinstance(block, dict):
-            continue
-
         block_type = block.get("type", "text")
         if block_type == "text":
-            blocks.append(ContentBlock(type=ContentType.TEXT, text=block.get("text"), raw=block))
+            blocks.append(ContentBlock(type=ContentType.TEXT, text=_string_field(block, "text"), raw=block))
         elif block_type == "thinking":
             blocks.append(
                 ContentBlock(
                     type=ContentType.THINKING,
-                    text=block.get("thinking") or block.get("text"),
+                    text=content_text(block.get("thinking")) or _string_field(block, "text"),
                     raw=block,
                 )
             )
         elif block_type == "tool_use":
-            name = block.get("name", "")
-            input_data = block.get("input", {})
-            normalized_input = input_data if isinstance(input_data, dict) else {}
+            name = _string_field(block, "name") or ""
+            normalized_input = json_document(block.get("input"))
             blocks.append(
                 ContentBlock(
                     type=ContentType.TOOL_USE,
                     tool_call=ToolCall(
                         name=name,
-                        id=block.get("id"),
+                        id=_string_field(block, "id"),
                         input=normalized_input,
                         category=classify_tool(name, normalized_input),
                     ),
@@ -124,7 +121,7 @@ def extract_content_blocks(content: list[dict[str, Any]] | None) -> list[Content
             blocks.append(
                 ContentBlock(
                     type=ContentType.TOOL_RESULT,
-                    text=content_text(block.get("content")) or content_text(block.get("text")) or "",
+                    text=content_text(block.get("content")) or _string_field(block, "text") or "",
                     raw=block,
                 )
             )
@@ -132,8 +129,8 @@ def extract_content_blocks(content: list[dict[str, Any]] | None) -> list[Content
             blocks.append(
                 ContentBlock(
                     type=ContentType.CODE,
-                    text=block.get("text") or block.get("code"),
-                    language=block.get("language"),
+                    text=_string_field(block, "text") or _string_field(block, "code"),
+                    language=_string_field(block, "language"),
                     raw=block,
                 )
             )
@@ -141,41 +138,41 @@ def extract_content_blocks(content: list[dict[str, Any]] | None) -> list[Content
     return blocks
 
 
-def extract_display_text_from_content_blocks(content: list[dict[str, Any]] | None) -> str:
+def extract_display_text_from_content_blocks(content: list[JSONDocument] | None) -> str:
     """Rebuild human-readable text from stored structured content blocks."""
     if not content:
         return ""
 
     parts: list[str] = []
     for block in content:
-        if not isinstance(block, dict):
-            continue
         if block.get("type") not in {"text", "code", "tool_result", "thinking"}:
             continue
-        text = block.get("text")
-        if isinstance(text, str) and text:
+        text = _string_field(block, "text")
+        if text:
             parts.append(text)
     return "\n".join(parts)
 
 
-def extract_claude_code_text(content: list[dict[str, Any]] | None) -> str:
+def extract_claude_code_text(content: list[JSONDocument] | None) -> str:
     """Extract text from Claude Code content blocks, excluding non-text blocks."""
     if not content:
         return ""
 
     parts = []
     for block in content:
-        if isinstance(block, dict) and block.get("type") == "text":
-            parts.append(block.get("text", ""))
+        if block.get("type") == "text":
+            text = _string_field(block, "text")
+            if text:
+                parts.append(text)
     return "\n".join(filter(None, parts))
 
 
-def extract_chatgpt_text(content: dict[str, Any] | None) -> str:
+def extract_chatgpt_text(content: JSONDocument | None) -> str:
     """Extract text from ChatGPT content structures."""
     if not content:
         return ""
-    direct_text = content.get("text")
-    if isinstance(direct_text, str) and direct_text:
+    direct_text = _string_field(content, "text")
+    if direct_text:
         return direct_text
     parts = content.get("parts", [])
     if not isinstance(parts, list):
@@ -191,16 +188,14 @@ def extract_chatgpt_text(content: dict[str, Any] | None) -> str:
     return "\n".join(texts)
 
 
-def extract_codex_text(content: list[dict[str, Any]] | None) -> str:
+def extract_codex_text(content: list[JSONDocument] | None) -> str:
     """Extract text from Codex content blocks."""
     if not content or not isinstance(content, list):
         return ""
 
     parts = []
     for block in content:
-        if not isinstance(block, dict):
-            continue
-        text = block.get("text", "") or block.get("input_text", "") or block.get("output_text", "")
+        text = _string_field(block, "text") or _string_field(block, "input_text") or _string_field(block, "output_text")
         if text:
             parts.append(text)
     return "\n".join(parts)

--- a/polylogue/lib/provider_semantics.py
+++ b/polylogue/lib/provider_semantics.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+
 from polylogue.lib.json import JSONDocument, json_document
 from polylogue.lib.viewports import (
     ContentBlock,
@@ -36,6 +38,13 @@ def _string_field(block: JSONDocument, key: str) -> str | None:
     return value if isinstance(value, str) else None
 
 
+def _content_block_record(value: object) -> JSONDocument | None:
+    record = json_document(value)
+    if record or isinstance(value, Mapping):
+        return record
+    return None
+
+
 def extract_reasoning_traces(content: list[JSONDocument] | None, provider: Provider | str) -> list[ReasoningTrace]:
     """Extract reasoning traces from provider content blocks."""
     if not content:
@@ -43,7 +52,10 @@ def extract_reasoning_traces(content: list[JSONDocument] | None, provider: Provi
 
     normalized_provider = provider if isinstance(provider, Provider) else Provider.from_string(provider)
     traces: list[ReasoningTrace] = []
-    for block in content:
+    for raw_block in content:
+        block = _content_block_record(raw_block)
+        if block is None:
+            continue
         block_type = block.get("type")
         text: str | None = None
         if block_type == "thinking":
@@ -64,7 +76,10 @@ def extract_tool_calls(content: list[JSONDocument] | None, provider: Provider | 
 
     normalized_provider = provider if isinstance(provider, Provider) else Provider.from_string(provider)
     calls: list[ToolCall] = []
-    for block in content:
+    for raw_block in content:
+        block = _content_block_record(raw_block)
+        if block is None:
+            continue
         if block.get("type") != "tool_use":
             continue
 
@@ -90,7 +105,10 @@ def extract_content_blocks(content: list[JSONDocument] | None) -> list[ContentBl
         return []
 
     blocks: list[ContentBlock] = []
-    for block in content:
+    for raw_block in content:
+        block = _content_block_record(raw_block)
+        if block is None:
+            continue
         block_type = block.get("type", "text")
         if block_type == "text":
             blocks.append(ContentBlock(type=ContentType.TEXT, text=_string_field(block, "text"), raw=block))
@@ -144,7 +162,10 @@ def extract_display_text_from_content_blocks(content: list[JSONDocument] | None)
         return ""
 
     parts: list[str] = []
-    for block in content:
+    for raw_block in content:
+        block = _content_block_record(raw_block)
+        if block is None:
+            continue
         if block.get("type") not in {"text", "code", "tool_result", "thinking"}:
             continue
         text = _string_field(block, "text")
@@ -159,7 +180,10 @@ def extract_claude_code_text(content: list[JSONDocument] | None) -> str:
         return ""
 
     parts = []
-    for block in content:
+    for raw_block in content:
+        block = _content_block_record(raw_block)
+        if block is None:
+            continue
         if block.get("type") == "text":
             text = _string_field(block, "text")
             if text:
@@ -194,7 +218,10 @@ def extract_codex_text(content: list[JSONDocument] | None) -> str:
         return ""
 
     parts = []
-    for block in content:
+    for raw_block in content:
+        block = _content_block_record(raw_block)
+        if block is None:
+            continue
         text = _string_field(block, "text") or _string_field(block, "input_text") or _string_field(block, "output_text")
         if text:
             parts.append(text)

--- a/polylogue/lib/raw_payload.py
+++ b/polylogue/lib/raw_payload.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from polylogue.lib.json import JSONDocument, JSONDocumentList, JSONScalar, JSONValue
 from polylogue.lib.raw_payload_decode import (
     RawPayloadEnvelope,
     WireFormat,
@@ -17,6 +18,10 @@ from polylogue.lib.raw_payload_sampling_extract import (
 )
 
 __all__ = [
+    "JSONDocument",
+    "JSONDocumentList",
+    "JSONScalar",
+    "JSONValue",
     "RawPayloadEnvelope",
     "WireFormat",
     "build_raw_payload_envelope",

--- a/polylogue/lib/raw_payload_decode.py
+++ b/polylogue/lib/raw_payload_decode.py
@@ -2,37 +2,24 @@
 
 from __future__ import annotations
 
-import json
-from collections.abc import Mapping
 from dataclasses import dataclass
 from io import BytesIO, StringIO
 from pathlib import Path
-from typing import Literal, TypeAlias, cast
+from typing import Literal, TypeAlias
 
 import orjson
 
 from polylogue.lib.artifact_taxonomy import ArtifactClassification, classify_artifact
+from polylogue.lib.json import JSONDocument, JSONValue, is_json_value, loads
 from polylogue.sources.dispatch import detect_provider
 from polylogue.types import Provider
 
 WireFormat = Literal["json", "jsonl"]
-JSONScalar: TypeAlias = str | int | float | bool | None
-JSONValue: TypeAlias = JSONScalar | list["JSONValue"] | dict[str, "JSONValue"]
-JSONRecord: TypeAlias = Mapping[str, object]
-
-
-def _coerce_json_value(value: object) -> JSONValue:
-    return cast(JSONValue, value)
+JSONRecord: TypeAlias = JSONDocument
 
 
 def _load_json_record(line: str) -> JSONValue:
-    try:
-        return _coerce_json_value(orjson.loads(line))
-    except (orjson.JSONDecodeError, ValueError) as exc:
-        try:
-            return _coerce_json_value(json.loads(line))
-        except json.JSONDecodeError:
-            raise exc from None
+    return loads(line)
 
 
 @dataclass(frozen=True)
@@ -208,7 +195,7 @@ def _decode_raw_payload(
                 pass
         raw_bytes = raw_content.read_bytes()
         try:
-            return _coerce_json_value(orjson.loads(raw_bytes)), "json", 0, None
+            return loads(raw_bytes), "json", 0, None
         except (orjson.JSONDecodeError, ValueError) as exc:
             try:
                 payload, malformed_lines, malformed_detail = _decode_jsonl_payload(
@@ -218,6 +205,9 @@ def _decode_raw_payload(
             except (UnicodeDecodeError, ValueError):
                 raise exc from None
             return payload, "jsonl", malformed_lines, malformed_detail
+
+    if is_json_value(raw_content):
+        return raw_content, "json", 0, None
 
     raw = raw_content if isinstance(raw_content, (bytes, str)) else str(raw_content)
     if prefer_jsonl:
@@ -230,7 +220,7 @@ def _decode_raw_payload(
         except (UnicodeDecodeError, ValueError):
             pass
     try:
-        return _coerce_json_value(orjson.loads(raw)), "json", 0, None
+        return loads(raw), "json", 0, None
     except (orjson.JSONDecodeError, ValueError) as exc:
         try:
             payload, malformed_lines, malformed_detail = _decode_jsonl_payload(

--- a/polylogue/lib/raw_payload_sampling_buckets.py
+++ b/polylogue/lib/raw_payload_sampling_buckets.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from collections import Counter
-from typing import Any
+
+from polylogue.lib.json import JSONDocument, is_json_document, json_document
 
 RECORD_CANDIDATE_KEYS = frozenset(
     {
@@ -22,15 +23,14 @@ RECORD_CANDIDATE_KEYS = frozenset(
 )
 
 
-def is_record_candidate(item: dict[str, Any]) -> bool:
+def is_record_candidate(item: JSONDocument) -> bool:
     """Return whether a decoded object looks like a record-oriented payload item."""
     if any(key in item for key in RECORD_CANDIDATE_KEYS):
         return True
-    payload = item.get("payload")
-    return isinstance(payload, dict)
+    return is_json_document(item.get("payload"))
 
 
-def record_bucket_key(sample: dict[str, Any], record_type_key: str | None = None) -> str:
+def record_bucket_key(sample: JSONDocument, record_type_key: str | None = None) -> str:
     """Return a stratification key for record-oriented payload samples."""
     if record_type_key:
         value = sample.get(record_type_key)
@@ -40,8 +40,8 @@ def record_bucket_key(sample: dict[str, Any], record_type_key: str | None = None
         value = sample.get(key)
         if isinstance(value, str) and value:
             return f"{key}:{value}"
-    payload = sample.get("payload")
-    if isinstance(payload, dict):
+    payload = json_document(sample.get("payload"))
+    if payload:
         value = payload.get("type")
         if isinstance(value, str) and value:
             return f"payload.type:{value}"
@@ -80,12 +80,12 @@ def bucket_target_counts(bucket_counts: Counter[str], limit: int) -> Counter[str
 
 
 def take_bucketed_samples(
-    buckets: dict[str, list[dict[str, Any]]],
+    buckets: dict[str, list[JSONDocument]],
     limit: int,
-) -> list[dict[str, Any]]:
+) -> list[JSONDocument]:
     """Take a stratified sample across pre-bucketed payload records."""
     ordered_keys = sorted(buckets, key=lambda key: len(buckets[key]), reverse=True)
-    selected: list[dict[str, Any]] = []
+    selected: list[JSONDocument] = []
 
     for key in ordered_keys:
         if len(selected) >= limit:

--- a/polylogue/lib/raw_payload_sampling_extract.py
+++ b/polylogue/lib/raw_payload_sampling_extract.py
@@ -6,10 +6,9 @@ from collections import Counter
 from collections.abc import Callable, Iterable
 from io import BytesIO, StringIO
 from pathlib import Path
-from typing import IO, Any, Literal
+from typing import IO, Literal
 
-import orjson
-
+from polylogue.lib.json import JSONDocument, JSONValue, json_document, loads
 from polylogue.lib.raw_payload_sampling_buckets import (
     bucket_target_counts,
     is_record_candidate,
@@ -19,36 +18,36 @@ from polylogue.lib.raw_payload_sampling_buckets import (
 
 
 def limit_samples(
-    samples: list[dict[str, Any]],
+    samples: list[JSONDocument],
     *,
     limit: int,
     stratify: bool,
     record_type_key: str | None = None,
-) -> list[dict[str, Any]]:
+) -> list[JSONDocument]:
     """Limit extracted samples while preserving representative record variants."""
     if limit <= 0 or len(samples) <= limit:
         return samples
     if not stratify:
         return samples[:limit]
 
-    buckets: dict[str, list[dict[str, Any]]] = {}
+    buckets: dict[str, list[JSONDocument]] = {}
     for sample in samples:
         buckets.setdefault(record_bucket_key(sample, record_type_key), []).append(sample)
     return take_bucketed_samples(buckets, limit)
 
 
 def collect_limited_samples(
-    sample_factory: Callable[[], Iterable[dict[str, Any]]],
+    sample_factory: Callable[[], Iterable[JSONDocument]],
     *,
     limit: int,
     stratify: bool,
     record_type_key: str | None = None,
-) -> list[dict[str, Any]]:
+) -> list[JSONDocument]:
     """Collect bounded samples from a re-iterable source without full materialization."""
     if limit <= 0:
         return []
     if not stratify:
-        selected: list[dict[str, Any]] = []
+        selected: list[JSONDocument] = []
         for sample in sample_factory():
             selected.append(sample)
             if len(selected) >= limit:
@@ -61,7 +60,7 @@ def collect_limited_samples(
 
     target_counts = bucket_target_counts(bucket_counts, limit)
     collected_counts: Counter[str] = Counter()
-    stratified_selected: list[dict[str, Any]] = []
+    stratified_selected: list[JSONDocument] = []
 
     for sample in sample_factory():
         bucket = record_bucket_key(sample, record_type_key)
@@ -77,47 +76,50 @@ def collect_limited_samples(
 
 
 def extract_payload_samples(
-    payload: Any,
+    payload: JSONValue,
     *,
     sample_granularity: Literal["document", "record"],
     max_samples: int | None = None,
     record_type_key: str | None = None,
-) -> list[dict[str, Any]]:
+) -> list[JSONDocument]:
     """Extract representative validation/schema samples from a decoded payload."""
     if not isinstance(payload, (dict, list)):
         return []
 
     if sample_granularity == "document":
-        documents = [payload] if isinstance(payload, dict) else [item for item in payload if isinstance(item, dict)]
+        documents = [json_document(payload)] if isinstance(payload, dict) else [json_document(item) for item in payload]
+        documents = [document for document in documents if document]
         if max_samples is None:
             return documents
         return documents[:max_samples] if max_samples > 0 else []
 
     if isinstance(payload, dict):
-        return [payload] if is_record_candidate(payload) else []
+        payload_record = json_document(payload)
+        return [payload_record] if payload_record and is_record_candidate(payload_record) else []
 
     if max_samples is None:
-        return [item for item in payload if isinstance(item, dict) and is_record_candidate(item)]
+        return [record for item in payload if (record := json_document(item)) and is_record_candidate(record)]
 
     if max_samples <= 0:
         return []
 
     scan_cap: int = max(1024, max_samples * 64)
     per_bucket_cap: int = 8
-    buckets: dict[str, list[dict[str, Any]]] = {}
-    head_items: list[dict[str, Any]] = []
+    buckets: dict[str, list[JSONDocument]] = {}
+    head_items: list[JSONDocument] = []
     dict_count = 0
     truncated = False
 
     for item in payload:
-        if not isinstance(item, dict) or not is_record_candidate(item):
+        record = json_document(item)
+        if not record or not is_record_candidate(record):
             continue
         dict_count += 1
         if dict_count <= max_samples:
-            head_items.append(item)
-        bucket = buckets.setdefault(record_bucket_key(item, record_type_key), [])
+            head_items.append(record)
+        bucket = buckets.setdefault(record_bucket_key(record, record_type_key), [])
         if len(bucket) < per_bucket_cap:
-            bucket.append(item)
+            bucket.append(record)
         if dict_count >= scan_cap:
             truncated = True
             break
@@ -130,11 +132,11 @@ def extract_payload_samples(
 
 
 def extract_record_samples_from_raw_content(
-    raw_content: Path | bytes | str | Any,
+    raw_content: Path | bytes | str | JSONValue,
     *,
     max_samples: int | None,
     record_type_key: str | None = None,
-) -> list[dict[str, Any]]:
+) -> list[JSONDocument]:
     """Stream-record sample extraction for large JSONL payloads.
 
     When *raw_content* is a :class:`~pathlib.Path`, lines are streamed
@@ -147,7 +149,15 @@ def extract_record_samples_from_raw_content(
     if max_samples is not None and max_samples <= 0:
         return []
 
-    stream: IO[Any]
+    if not isinstance(raw_content, (Path, bytes, str)):
+        return extract_payload_samples(
+            raw_content,
+            sample_granularity="record",
+            max_samples=max_samples,
+            record_type_key=record_type_key,
+        )
+
+    stream: IO[bytes] | IO[str]
     if isinstance(raw_content, Path):
         stream = open(raw_content, "rb")  # noqa: SIM115 — caller-managed context
     else:
@@ -156,7 +166,7 @@ def extract_record_samples_from_raw_content(
 
     # Full-corpus mode: collect everything without caps.
     if max_samples is None:
-        all_records: list[dict[str, Any]] = []
+        all_records: list[JSONDocument] = []
         first_line = True
         try:
             for raw_line in stream:
@@ -168,18 +178,19 @@ def extract_record_samples_from_raw_content(
                 if not line:
                     continue
                 try:
-                    parsed = orjson.loads(line)
-                except (ValueError, orjson.JSONDecodeError):
+                    parsed = loads(line)
+                except ValueError:
                     continue
-                if isinstance(parsed, dict) and is_record_candidate(parsed):
-                    all_records.append(parsed)
+                record = json_document(parsed)
+                if record and is_record_candidate(record):
+                    all_records.append(record)
         finally:
             if isinstance(raw_content, Path):
                 stream.close()
         return all_records
 
-    lines: list[dict[str, Any]] = []
-    buckets: dict[str, list[dict[str, Any]]] = {}
+    lines: list[JSONDocument] = []
+    buckets: dict[str, list[JSONDocument]] = {}
     dict_count = 0
     scan_cap = max(1024, max_samples * 64)
     per_bucket_cap = 8
@@ -195,18 +206,19 @@ def extract_record_samples_from_raw_content(
             if not line:
                 continue
             try:
-                parsed = orjson.loads(line)
-            except (ValueError, orjson.JSONDecodeError):
+                parsed = loads(line)
+            except ValueError:
                 continue
-            if not isinstance(parsed, dict) or not is_record_candidate(parsed):
+            record = json_document(parsed)
+            if not record or not is_record_candidate(record):
                 continue
 
             dict_count += 1
             if dict_count <= max_samples:
-                lines.append(parsed)
-            bucket = buckets.setdefault(record_bucket_key(parsed, record_type_key), [])
+                lines.append(record)
+            bucket = buckets.setdefault(record_bucket_key(record, record_type_key), [])
             if len(bucket) < per_bucket_cap:
-                bucket.append(parsed)
+                bucket.append(record)
             if dict_count >= scan_cap:
                 break
     finally:

--- a/polylogue/lib/viewport_models.py
+++ b/polylogue/lib/viewport_models.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from datetime import datetime
-from typing import Any
 
 from pydantic import BaseModel, Field, field_validator
 
@@ -23,7 +23,7 @@ class ReasoningTrace(BaseModel):
     duration_ms: int | None = None
     token_count: int | None = None
     provider: Provider | None = None
-    raw: dict[str, Any] = Field(default_factory=dict)
+    raw: Mapping[str, object] = Field(default_factory=dict)
 
     @field_validator("provider", mode="before")
     @classmethod
@@ -38,12 +38,12 @@ class ReasoningTrace(BaseModel):
 class ToolCall(BaseModel):
     name: str
     id: str | None = None
-    input: dict[str, Any] = Field(default_factory=dict)
+    input: Mapping[str, object] = Field(default_factory=dict)
     output: str | None = None
     success: bool | None = None
     category: ToolCategory = ToolCategory.OTHER
     provider: Provider | None = None
-    raw: dict[str, Any] = Field(default_factory=dict)
+    raw: Mapping[str, object] = Field(default_factory=dict)
 
     @field_validator("provider", mode="before")
     @classmethod
@@ -108,7 +108,7 @@ class ContentBlock(BaseModel):
     url: str | None = None
     mime_type: str | None = None
     tool_call: ToolCall | None = None
-    raw: dict[str, Any] = Field(default_factory=dict)
+    raw: Mapping[str, object] = Field(default_factory=dict)
 
 
 class TokenUsage(BaseModel):

--- a/polylogue/lib/viewport_tools.py
+++ b/polylogue/lib/viewport_tools.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import re
 from collections.abc import Mapping
 from pathlib import PurePosixPath
-from typing import Any
 
+from polylogue.lib.json import JSONValue
 from polylogue.lib.viewport_enums import ToolCategory
 
 PATH_PATTERN = re.compile(r'(?:^|[\s"\'])(/[^\s"\']+|[./][^\s"\']+)')
@@ -14,7 +14,7 @@ NOISE_PATH_TOKENS = frozenset({"...", "//", "/dev/null", "|", "||", "&&", ";"})
 METADATA_FILE_BASENAME_ALLOWLIST = frozenset({"LICENSE", "COPYING", "NOTICE", "Makefile", "Dockerfile", "Justfile"})
 
 
-def classify_tool(name: str, input_data: Mapping[str, Any]) -> ToolCategory:
+def classify_tool(name: str, input_data: Mapping[str, JSONValue]) -> ToolCategory:
     name_lower = name.lower()
 
     if name_lower in ("read", "view", "cat"):

--- a/polylogue/pipeline/materialization_runtime.py
+++ b/polylogue/pipeline/materialization_runtime.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TypeAlias, cast
+from typing import Protocol, TypeAlias
 
 from polylogue.lib.branch_type import BranchType
+from polylogue.lib.json import JSONDocument, json_document
 from polylogue.lib.json import dumps as json_dumps
 from polylogue.lib.roles import Role
 from polylogue.lib.viewports import ToolCategory, classify_tool
@@ -32,7 +34,7 @@ from polylogue.types import (
 )
 
 ProviderMetadata: TypeAlias = dict[str, object]
-BlockMetadata: TypeAlias = dict[str, object]
+BlockMetadata: TypeAlias = JSONDocument
 
 
 @dataclass(frozen=True, slots=True)
@@ -148,8 +150,16 @@ def _attachment_provider_meta(
     return meta
 
 
-def _tool_input_payload(tool_input: dict[str, object] | None) -> ToolInputPayload:
-    return cast(ToolInputPayload, dict(tool_input or {}))
+def _tool_input_payload(tool_input: Mapping[str, object] | JSONDocument | None) -> ToolInputPayload:
+    if tool_input is None:
+        return {}
+    return json_document(tool_input if isinstance(tool_input, dict) else dict(tool_input))
+
+
+def _block_metadata(metadata: Mapping[str, object] | JSONDocument | None) -> BlockMetadata | None:
+    if metadata is None:
+        return None
+    return json_document(metadata if isinstance(metadata, dict) else dict(metadata))
 
 
 def _build_message_ids(convo: ParsedConversation, conversation_id: ConversationId) -> dict[str, MessageId]:
@@ -163,28 +173,28 @@ def _build_message_ids(convo: ParsedConversation, conversation_id: ConversationI
 def _materialize_content_block(
     message_id: MessageId,
     block_index: int,
-    block: object,
+    block: ParsedContentBlockLike,
 ) -> MaterializedContentBlock:
-    parsed_block = cast("ParsedContentBlockLike", block)
-    tool_input_json = json_dumps(parsed_block.tool_input) if parsed_block.tool_input is not None else None
+    tool_input = _tool_input_payload(block.tool_input)
+    tool_input_json = json_dumps(tool_input) if block.tool_input is not None else None
     semantic_type: SemanticBlockType | None = None
-    semantic_metadata: BlockMetadata | None = dict(parsed_block.metadata) if parsed_block.metadata is not None else None
+    semantic_metadata: BlockMetadata | None = _block_metadata(block.metadata)
 
-    if parsed_block.type == "tool_use" and parsed_block.tool_name:
-        category = classify_tool(parsed_block.tool_name, parsed_block.tool_input or {})
+    if block.type == "tool_use" and block.tool_name:
+        category = classify_tool(block.tool_name, tool_input)
         semantic_type = None if category is ToolCategory.OTHER else SemanticBlockType.from_string(category.value)
         tool_meta = extract_tool_metadata(
-            parsed_block.tool_name,
-            _tool_input_payload(parsed_block.tool_input),
+            block.tool_name,
+            tool_input,
         )
         if tool_meta is not None:
             base = semantic_metadata or {}
             base.update(tool_meta)
             semantic_metadata = base
-    elif parsed_block.type == "thinking":
+    elif block.type == "thinking":
         semantic_type = SemanticBlockType.THINKING
-    elif parsed_block.type == "code" and parsed_block.text and semantic_metadata is None:
-        detected_lang = detect_language(parsed_block.text)
+    elif block.type == "code" and block.text and semantic_metadata is None:
+        detected_lang = detect_language(block.text)
         if detected_lang:
             semantic_metadata = {"language": detected_lang}
 
@@ -195,12 +205,12 @@ def _materialize_content_block(
     return MaterializedContentBlock(
         block_id=ContentBlockRecord.make_id(message_id, block_index),
         block_index=block_index,
-        type=parsed_block.type,
-        text=parsed_block.text,
-        tool_name=parsed_block.tool_name,
-        tool_id=parsed_block.tool_id,
+        type=block.type,
+        text=block.text,
+        tool_name=block.tool_name,
+        tool_id=block.tool_id,
         tool_input_json=tool_input_json,
-        media_type=parsed_block.media_type,
+        media_type=block.media_type,
         metadata_json=metadata_json,
         semantic_type=semantic_type,
     )
@@ -318,14 +328,18 @@ def materialize_conversation(
     )
 
 
-class ParsedContentBlockLike:
+ParsedToolInput: TypeAlias = Mapping[str, object]
+ParsedBlockMetadata: TypeAlias = dict[str, object]
+
+
+class ParsedContentBlockLike(Protocol):
     type: ContentBlockType
     text: str | None
     tool_name: str | None
     tool_id: str | None
-    tool_input: dict[str, object] | None
+    tool_input: ParsedToolInput | None
     media_type: str | None
-    metadata: dict[str, object] | None
+    metadata: ParsedBlockMetadata | None
 
 
 __all__ = [

--- a/polylogue/pipeline/semantic_capture.py
+++ b/polylogue/pipeline/semantic_capture.py
@@ -3,14 +3,18 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from typing import NotRequired, cast
+from typing import NotRequired
 
 from typing_extensions import TypedDict
 
-from polylogue.lib.payload_coercion import is_payload_mapping, mapping_or_empty, optional_string
-from polylogue.lib.raw_payload_decode import JSONRecord, JSONValue
-from polylogue.pipeline.semantic_metadata import ToolMetadata, _parse_git_command, _parse_subagent_spawn
-from polylogue.schemas.json_types import JSONValue as SchemaJSONValue
+from polylogue.lib.json import JSONDocument, JSONValue, is_json_value, json_document, json_document_list
+from polylogue.lib.payload_coercion import mapping_or_empty, optional_string
+from polylogue.pipeline.semantic_metadata import (
+    ToolInputPayload,
+    ToolMetadata,
+    _parse_git_command,
+    _parse_subagent_spawn,
+)
 
 
 class ContextCompactionSummary(TypedDict):
@@ -30,7 +34,7 @@ class ThinkingTraceSummary(TypedDict):
 class ToolInvocationSummary(TypedDict, total=False):
     tool_name: str | None
     tool_id: str | None
-    input: JSONRecord
+    input: JSONDocument
     is_file_operation: bool
     is_search_operation: bool
     is_subagent: bool
@@ -52,24 +56,18 @@ class SubagentSpawnSummary(TypedDict):
 
 
 def _json_value(value: object) -> JSONValue | None:
-    return cast(JSONValue | None, value)
+    return value if is_json_value(value) else None
 
 
-def _json_record(value: object) -> JSONRecord:
-    return cast(JSONRecord, value) if isinstance(value, dict) else {}
-
-
-def _tool_input_payload(value: Mapping[str, object]) -> dict[str, SchemaJSONValue]:
-    return cast(dict[str, SchemaJSONValue], dict(value))
+def _tool_input_payload(value: object) -> ToolInputPayload:
+    return json_document(value)
 
 
 def _text_from_message_content(content: object) -> str:
     if isinstance(content, str):
         return content
-    if not isinstance(content, list):
-        return ""
-    for block in content:
-        if is_payload_mapping(block) and block.get("type") == "text":
+    for block in json_document_list(content):
+        if block.get("type") == "text":
             text = optional_string(block.get("text"))
             if text:
                 return text
@@ -112,7 +110,7 @@ def detect_context_compaction(item: Mapping[str, object]) -> ContextCompactionSu
 
 def extract_thinking_traces(content_blocks: Sequence[Mapping[str, object]]) -> list[ThinkingTraceSummary]:
     traces: list[ThinkingTraceSummary] = []
-    for block in content_blocks:
+    for block in (json_document(item) for item in content_blocks):
         if block.get("type") != "thinking":
             continue
         text = optional_string(block.get("thinking")) or optional_string(block.get("text")) or ""
@@ -123,10 +121,10 @@ def extract_thinking_traces(content_blocks: Sequence[Mapping[str, object]]) -> l
 
 def extract_tool_invocations(content_blocks: Sequence[Mapping[str, object]]) -> list[ToolInvocationSummary]:
     invocations: list[ToolInvocationSummary] = []
-    for block in content_blocks:
+    for block in (json_document(item) for item in content_blocks):
         if block.get("type") != "tool_use":
             continue
-        input_payload = _json_record(mapping_or_empty(block.get("input")))
+        input_payload = json_document(block.get("input"))
         invocation: ToolInvocationSummary = {
             "tool_name": optional_string(block.get("name")),
             "tool_id": optional_string(block.get("id")),
@@ -147,7 +145,7 @@ def extract_tool_invocations(content_blocks: Sequence[Mapping[str, object]]) -> 
 def parse_git_operation(tool_invocation: Mapping[str, object]) -> ToolMetadata | None:
     if tool_invocation.get("tool_name") != "Bash":
         return None
-    command = optional_string(mapping_or_empty(tool_invocation.get("input")).get("command"))
+    command = optional_string(json_document(tool_invocation.get("input")).get("command"))
     if not command or not command.strip().startswith("git "):
         return None
     return _parse_git_command(command)
@@ -157,7 +155,7 @@ def extract_file_changes(tool_invocations: Sequence[Mapping[str, object]]) -> li
     changes: list[FileChangeSummary] = []
     for invocation in tool_invocations:
         tool_name = invocation.get("tool_name")
-        input_data = mapping_or_empty(invocation.get("input"))
+        input_data = json_document(invocation.get("input"))
         path = optional_string(input_data.get("file_path")) or optional_string(input_data.get("path"))
         if not path:
             continue
@@ -187,7 +185,7 @@ def extract_subagent_spawns(tool_invocations: Sequence[Mapping[str, object]]) ->
     for invocation in tool_invocations:
         if invocation.get("tool_name") != "Task":
             continue
-        input_data = mapping_or_empty(invocation.get("input"))
+        input_data = json_document(invocation.get("input"))
         parsed = _parse_subagent_spawn(_tool_input_payload(input_data))
         agent_type = parsed.get("agent_type")
         spawns.append(

--- a/polylogue/pipeline/semantic_metadata.py
+++ b/polylogue/pipeline/semantic_metadata.py
@@ -2,13 +2,12 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
 from typing import TypeAlias
 
+from polylogue.lib.json import JSONDocument, JSONValue, json_document
 from polylogue.lib.viewports import ToolCategory, classify_tool
-from polylogue.schemas.json_types import JSONDocument, JSONValue, json_document
 
-ToolInputPayload: TypeAlias = Mapping[str, JSONValue]
+ToolInputPayload: TypeAlias = JSONDocument
 ToolMetadata: TypeAlias = JSONDocument
 
 

--- a/polylogue/pipeline/services/validation_runtime.py
+++ b/polylogue/pipeline/services/validation_runtime.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING
 
-from polylogue.lib.raw_payload import build_raw_payload_envelope
+from polylogue.lib.raw_payload import RawPayloadEnvelope, build_raw_payload_envelope
 from polylogue.logging import get_logger
 from polylogue.schemas.validator import SchemaValidator
 from polylogue.storage.blob_store import BlobStore
@@ -14,10 +13,6 @@ from polylogue.storage.store import RawConversationRecord
 from polylogue.types import Provider, ValidationMode, ValidationStatus
 
 logger = get_logger(__name__)
-
-
-if TYPE_CHECKING:
-    from polylogue.lib.raw_payload_decode import JSONValue, RawPayloadEnvelope
 
 
 ValidationCounts = dict[str, int]
@@ -120,7 +115,7 @@ def _validate_record_sync(
             raw_record=raw_record,
             payload_provider=stored_payload_provider,
         )
-        payload: JSONValue = envelope.payload
+        payload = envelope.payload
         malformed_lines = envelope.malformed_jsonl_lines
         malformed_detail = envelope.malformed_jsonl_detail
         payload_provider = envelope.provider

--- a/polylogue/schemas/extraction.py
+++ b/polylogue/schemas/extraction.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from typing import TypeAlias
 
+from polylogue.lib.json import JSONDocument, json_document
 from polylogue.lib.provider_semantics import (
     extract_content_blocks,
     extract_reasoning_traces,
@@ -19,7 +20,7 @@ from polylogue.types import Provider
 
 logger = logging.getLogger(__name__)
 
-SchemaPayload: TypeAlias = dict[str, object]
+SchemaPayload: TypeAlias = JSONDocument
 SchemaBlockPayload: TypeAlias = list[SchemaPayload]
 
 # -------------------------------------------------------------------
@@ -109,7 +110,11 @@ def _walk(obj: object | None, parts: list[str]) -> object | None:
 def _schema_payload(value: object) -> SchemaPayload | None:
     if not isinstance(value, dict):
         return None
-    return {str(key): child for key, child in value.items()}
+    return json_document(value)
+
+
+def _object_record(value: SchemaPayload) -> dict[str, object]:
+    return dict(value)
 
 
 def _find_by_well_known_names(raw: SchemaPayload, names: frozenset[str]) -> object | None:
@@ -293,7 +298,7 @@ def extract_message_from_schema(
         cost=_extract_cost(raw),
         duration_ms=_extract_duration_ms(raw),
         provider=provider,
-        raw=raw,
+        raw=_object_record(raw),
     )
 
 

--- a/polylogue/schemas/generation_workflow.py
+++ b/polylogue/schemas/generation_workflow.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
 from pathlib import Path
-from typing import Any, cast
+from typing import Any
 
 from polylogue.paths import db_path as archive_db_path
 from polylogue.schemas.generation_models import _ProviderBundle
@@ -12,6 +11,14 @@ from polylogue.schemas.generation_provider_bundle import _build_provider_bundle
 from polylogue.schemas.generation_schema_builder import generate_schema_from_samples
 from polylogue.schemas.observation import PROVIDERS
 from polylogue.schemas.registry import SchemaRegistry
+from polylogue.schemas.runtime_registry import ElementSchemaMap
+
+
+def _package_schemas(bundle: _ProviderBundle) -> dict[str, ElementSchemaMap]:
+    return {
+        version: {element_kind: dict(schema) for element_kind, schema in element_schemas.items()}
+        for version, element_schemas in bundle.package_schemas.items()
+    }
 
 
 def persist_generated_provider_bundle(output_dir: Path, provider: str, bundle: _ProviderBundle) -> None:
@@ -24,7 +31,7 @@ def persist_generated_provider_bundle(output_dir: Path, provider: str, bundle: _
     registry.replace_provider_packages(
         provider,
         bundle.catalog,
-        cast(Mapping[str, dict[str, Mapping[str, object]]], bundle.package_schemas),
+        _package_schemas(bundle),
     )
     registry.save_cluster_manifest(bundle.manifest)
 

--- a/polylogue/schemas/json_types.py
+++ b/polylogue/schemas/json_types.py
@@ -17,7 +17,7 @@ def json_document(value: object) -> JSONDocument:
 def json_document_list(value: object) -> JSONDocumentList:
     if not isinstance(value, list):
         return []
-    return [json_document(item) for item in value]
+    return [document for item in value if (document := json_document(item))]
 
 
 __all__ = [

--- a/polylogue/schemas/observation_runtime.py
+++ b/polylogue/schemas/observation_runtime.py
@@ -6,12 +6,13 @@ from pathlib import Path
 from typing import TypeAlias
 
 from polylogue.lib.artifact_taxonomy import classify_artifact
+from polylogue.lib.json import JSONDocument, JSONValue, is_json_value, json_document
 from polylogue.lib.raw_payload import extract_payload_samples, record_bucket_key
 from polylogue.schemas.observation_identity import derive_bundle_scope, schema_cluster_id
 from polylogue.schemas.observation_models import ProviderConfig, SchemaUnit
 from polylogue.types import Provider
 
-SchemaSample: TypeAlias = dict[str, object]
+SchemaSample: TypeAlias = JSONDocument
 
 _SCHEMA_SAMPLE_STRING_LIMIT = 1024
 
@@ -27,6 +28,9 @@ def extract_schema_units_from_payload(
     max_samples: int | None = None,
 ) -> list[SchemaUnit]:
     """Extract clusterable schema units from one decoded payload."""
+    if not is_json_value(payload):
+        return []
+    normalized_payload: JSONValue = payload
     provider_token = Provider.from_string(provider_name)
     effective_max_samples = max_samples if max_samples is not None else config.schema_sample_cap
     bundle_scope = derive_bundle_scope(provider_token, source_path)
@@ -34,7 +38,7 @@ def extract_schema_units_from_payload(
 
     if config.sample_granularity == "record":
         artifact = classify_artifact(
-            payload,
+            normalized_payload,
             provider=provider_token,
             source_path=source_path,
         )
@@ -43,7 +47,7 @@ def extract_schema_units_from_payload(
 
         samples = _compact_schema_samples(
             extract_payload_samples(
-                payload,
+                normalized_payload,
                 sample_granularity="record",
                 max_samples=effective_max_samples,
                 record_type_key=config.record_type_key,
@@ -54,7 +58,7 @@ def extract_schema_units_from_payload(
 
         return [
             SchemaUnit(
-                cluster_payload=payload,
+                cluster_payload=normalized_payload,
                 schema_samples=samples,
                 artifact_kind=artifact.cohort,
                 conversation_id=raw_id,
@@ -62,7 +66,7 @@ def extract_schema_units_from_payload(
                 source_path=source_path_text,
                 bundle_scope=bundle_scope,
                 observed_at=observed_at,
-                exact_structure_id=schema_cluster_id(payload, artifact.cohort),
+                exact_structure_id=schema_cluster_id(normalized_payload, artifact.cohort),
                 profile_tokens=_record_profile_tokens(
                     samples,
                     record_type_key=config.record_type_key,
@@ -72,7 +76,7 @@ def extract_schema_units_from_payload(
 
     documents = _compact_schema_samples(
         extract_payload_samples(
-            payload,
+            normalized_payload,
             sample_granularity="document",
             max_samples=effective_max_samples,
         )
@@ -103,7 +107,7 @@ def extract_schema_units_from_payload(
     return units
 
 
-def _compact_schema_value(value: object) -> object:
+def _compact_schema_value(value: JSONValue) -> JSONValue:
     if isinstance(value, str):
         return value[:_SCHEMA_SAMPLE_STRING_LIMIT] if len(value) > _SCHEMA_SAMPLE_STRING_LIMIT else value
     if isinstance(value, list):
@@ -118,7 +122,7 @@ def _compact_schema_samples(samples: list[SchemaSample]) -> list[SchemaSample]:
     for sample in samples:
         compacted_sample = _compact_schema_value(sample)
         if isinstance(compacted_sample, dict):
-            compacted.append(compacted_sample)
+            compacted.append(json_document(compacted_sample))
     return compacted
 
 

--- a/polylogue/schemas/unified.py
+++ b/polylogue/schemas/unified.py
@@ -19,10 +19,10 @@ extraction works on raw records (pre-parse or during parse).
 from __future__ import annotations
 
 import logging
-from typing import Any
 
 from pydantic import ValidationError
 
+from polylogue.lib.json import JSONDocument
 from polylogue.lib.provider_semantics import (
     extract_chatgpt_text,
     extract_claude_code_text,
@@ -52,7 +52,11 @@ from polylogue.types import Provider
 logger = logging.getLogger(__name__)
 
 
-def extract_harmonized_message(provider: Provider | str, raw: dict[str, Any]) -> HarmonizedMessage:
+def _object_record(value: JSONDocument) -> dict[str, object]:
+    return dict(value)
+
+
+def extract_harmonized_message(provider: Provider | str, raw: JSONDocument) -> HarmonizedMessage:
     """Extract ``HarmonizedMessage`` from a provider-native message payload.
 
     This operates on already-extracted message dicts (post-parse), not on
@@ -66,7 +70,7 @@ def extract_harmonized_message(provider: Provider | str, raw: dict[str, Any]) ->
         return extract_fallback_message(p, raw)
 
 
-def try_schema_extraction(provider: Provider | str, raw: dict[str, Any]) -> HarmonizedMessage | None:
+def try_schema_extraction(provider: Provider | str, raw: JSONDocument) -> HarmonizedMessage | None:
     """Record-level schema extraction. Returns None if unavailable.
 
     This is for raw wire-format records (pre-parse). Parsers can call
@@ -89,7 +93,7 @@ def try_schema_extraction(provider: Provider | str, raw: dict[str, Any]) -> Harm
         )
         if schema is None:
             return None
-        return extract_message_from_schema(raw, schema=schema, provider=p)
+        return extract_message_from_schema(_object_record(raw), schema=schema, provider=p)
     except Exception:
         return None
 

--- a/polylogue/schemas/unified.py
+++ b/polylogue/schemas/unified.py
@@ -52,10 +52,6 @@ from polylogue.types import Provider
 logger = logging.getLogger(__name__)
 
 
-def _object_record(value: JSONDocument) -> dict[str, object]:
-    return dict(value)
-
-
 def extract_harmonized_message(provider: Provider | str, raw: JSONDocument) -> HarmonizedMessage:
     """Extract ``HarmonizedMessage`` from a provider-native message payload.
 
@@ -93,7 +89,7 @@ def try_schema_extraction(provider: Provider | str, raw: JSONDocument) -> Harmon
         )
         if schema is None:
             return None
-        return extract_message_from_schema(_object_record(raw), schema=schema, provider=p)
+        return extract_message_from_schema(raw, schema=schema, provider=p)
     except Exception:
         return None
 

--- a/polylogue/schemas/unified_adapters.py
+++ b/polylogue/schemas/unified_adapters.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Protocol, TypeAlias, cast
+from typing import Protocol, TypeAlias
 
-from polylogue.lib.raw_payload_decode import JSONRecord
+from polylogue.lib.json import JSONDocument
 from polylogue.lib.viewports import ContentBlock, MessageMeta, ReasoningTrace, ToolCall
 from polylogue.schemas.unified_models import HarmonizedMessage, _missing_role
 from polylogue.types import Provider
@@ -24,17 +24,17 @@ class ViewportRecord(Protocol):
     def extract_content_blocks(self) -> list[ContentBlock]: ...
 
 
-AdapterBuilder: TypeAlias = Callable[[JSONRecord], ViewportRecord]
+AdapterBuilder: TypeAlias = Callable[[JSONDocument], ViewportRecord]
 
 
 class _ViewportModelType(Protocol):
     @classmethod
-    def model_validate(cls, obj: object) -> object: ...
+    def model_validate(cls, obj: object) -> ViewportRecord: ...
 
 
 def _harmonize_viewport_message(
     provider: Provider,
-    raw: JSONRecord,
+    raw: JSONDocument,
     message: ViewportRecord,
 ) -> HarmonizedMessage:
     """Build a harmonized message from a typed provider adapter."""
@@ -57,43 +57,43 @@ def _harmonize_viewport_message(
 
 
 def _validate_viewport(
-    raw: JSONRecord,
+    raw: JSONDocument,
     model_type: _ViewportModelType,
 ) -> ViewportRecord:
-    return cast(ViewportRecord, model_type.model_validate(raw))
+    return model_type.model_validate(raw)
 
 
-def _require_claude_code_message(raw: JSONRecord) -> None:
+def _require_claude_code_message(raw: JSONDocument) -> None:
     if raw.get("message") == {}:
         raise ValueError("Message has no role. Data should be validated at import time.")
 
 
-def _validate_claude_code_record(raw: JSONRecord) -> ViewportRecord:
+def _validate_claude_code_record(raw: JSONDocument) -> ViewportRecord:
     from polylogue.sources.providers.claude_code import ClaudeCodeRecord
 
     _require_claude_code_message(raw)
     return _validate_viewport(raw, ClaudeCodeRecord)
 
 
-def _validate_claude_ai_message(raw: JSONRecord) -> ViewportRecord:
+def _validate_claude_ai_message(raw: JSONDocument) -> ViewportRecord:
     from polylogue.sources.providers.claude_ai import ClaudeAIChatMessage
 
     return _validate_viewport(raw, ClaudeAIChatMessage)
 
 
-def _validate_chatgpt_message(raw: JSONRecord) -> ViewportRecord:
+def _validate_chatgpt_message(raw: JSONDocument) -> ViewportRecord:
     from polylogue.sources.providers.chatgpt import ChatGPTMessage
 
     return _validate_viewport(raw, ChatGPTMessage)
 
 
-def _validate_gemini_message(raw: JSONRecord) -> ViewportRecord:
+def _validate_gemini_message(raw: JSONDocument) -> ViewportRecord:
     from polylogue.sources.providers.gemini import GeminiMessage
 
     return _validate_viewport(raw, GeminiMessage)
 
 
-def _validate_codex_record(raw: JSONRecord) -> ViewportRecord:
+def _validate_codex_record(raw: JSONDocument) -> ViewportRecord:
     from polylogue.sources.providers.codex import CodexRecord
 
     return _validate_viewport(raw, CodexRecord)
@@ -108,7 +108,7 @@ _ADAPTER_BUILDERS: dict[Provider, AdapterBuilder] = {
 }
 
 
-def extract_with_adapter(provider: Provider, raw: JSONRecord) -> HarmonizedMessage:
+def extract_with_adapter(provider: Provider, raw: JSONDocument) -> HarmonizedMessage:
     """Extract via the canonical typed provider adapter for valid raw records."""
     try:
         builder = _ADAPTER_BUILDERS[provider]

--- a/polylogue/schemas/unified_fallbacks.py
+++ b/polylogue/schemas/unified_fallbacks.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Any, cast
 
+from polylogue.lib.json import JSONDocument, json_document, json_document_list
 from polylogue.lib.provider_semantics import (
     extract_chatgpt_text,
     extract_claude_code_text,
@@ -12,7 +12,6 @@ from polylogue.lib.provider_semantics import (
     extract_reasoning_traces,
     extract_tool_calls,
 )
-from polylogue.lib.raw_payload_decode import JSONRecord
 from polylogue.lib.roles import Role
 from polylogue.lib.timestamps import parse_timestamp
 from polylogue.lib.viewports import CostInfo, ReasoningTrace, TokenUsage
@@ -20,24 +19,57 @@ from polylogue.schemas.unified_models import HarmonizedMessage, _missing_role, e
 from polylogue.types import Provider
 
 
-def _record(value: object) -> JSONRecord:
-    return cast(JSONRecord, value) if isinstance(value, dict) else {}
+def _record(value: object) -> JSONDocument:
+    return json_document(value)
 
 
-def _content_blocks(value: object) -> list[dict[str, Any]] | None:
-    if not isinstance(value, list):
+def _content_blocks(value: object) -> list[JSONDocument] | None:
+    blocks = json_document_list(value)
+    return blocks or None
+
+
+def _payload_record(raw: JSONDocument) -> JSONDocument:
+    return json_document(dict(raw))
+
+
+def _object_record(value: JSONDocument) -> dict[str, object]:
+    return dict(value)
+
+
+def _string_value(value: object) -> str | None:
+    return value if isinstance(value, str) else None
+
+
+def _int_value(value: object) -> int | None:
+    if isinstance(value, bool):
         return None
-    return [dict(item) for item in value if isinstance(item, dict)]
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    return None
 
 
-def _payload_record(raw: JSONRecord) -> dict[str, Any]:
-    return dict(raw)
+def _float_value(value: object) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None
 
 
-FallbackExtractor = Callable[[JSONRecord], HarmonizedMessage]
+def _timestamp_candidate(value: object) -> str | int | float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (str, int, float)):
+        return value
+    return None
 
 
-def _fallback_extract_claude_code(raw: JSONRecord) -> HarmonizedMessage:
+FallbackExtractor = Callable[[JSONDocument], HarmonizedMessage]
+
+
+def _fallback_extract_claude_code(raw: JSONDocument) -> HarmonizedMessage:
     """Fallback extraction for malformed Claude Code records."""
     payload = _payload_record(raw)
     if payload.get("message") == {}:
@@ -46,36 +78,36 @@ def _fallback_extract_claude_code(raw: JSONRecord) -> HarmonizedMessage:
     content = _content_blocks(msg.get("content"))
 
     return HarmonizedMessage(
-        id=payload.get("uuid"),
-        role=Role.normalize((msg.get("role") or payload.get("type")) or _missing_role()),
+        id=_string_value(payload.get("uuid")),
+        role=Role.normalize(_string_value(msg.get("role")) or _string_value(payload.get("type")) or _missing_role()),
         text=extract_claude_code_text(content),
-        timestamp=parse_timestamp(payload.get("timestamp")),
+        timestamp=parse_timestamp(_timestamp_candidate(payload.get("timestamp"))),
         reasoning_traces=extract_reasoning_traces(content, Provider.CLAUDE_CODE),
         tool_calls=extract_tool_calls(content, Provider.CLAUDE_CODE),
         content_blocks=extract_content_blocks(content),
-        model=msg.get("model"),
+        model=_string_value(msg.get("model")),
         tokens=extract_token_usage(dict(usage) if (usage := _record(msg.get("usage"))) else None),
-        cost=CostInfo(total_usd=payload.get("costUSD")) if payload.get("costUSD") else None,
-        duration_ms=payload.get("durationMs"),
+        cost=CostInfo(total_usd=cost_usd) if (cost_usd := _float_value(payload.get("costUSD"))) is not None else None,
+        duration_ms=_int_value(payload.get("durationMs")),
         provider=Provider.CLAUDE_CODE,
-        raw=payload,
+        raw=_object_record(payload),
     )
 
 
-def _fallback_extract_claude_ai(raw: JSONRecord) -> HarmonizedMessage:
+def _fallback_extract_claude_ai(raw: JSONDocument) -> HarmonizedMessage:
     """Fallback extraction for malformed Claude AI records."""
     payload = _payload_record(raw)
     return HarmonizedMessage(
-        id=payload.get("uuid"),
-        role=Role.normalize(payload.get("sender") or _missing_role()),
-        text=payload.get("text", ""),
-        timestamp=parse_timestamp(payload.get("created_at")),
+        id=_string_value(payload.get("uuid")),
+        role=Role.normalize(_string_value(payload.get("sender")) or _missing_role()),
+        text=_string_value(payload.get("text")) or "",
+        timestamp=parse_timestamp(_timestamp_candidate(payload.get("created_at"))),
         provider=Provider.CLAUDE_AI,
-        raw=payload,
+        raw=_object_record(payload),
     )
 
 
-def _fallback_extract_chatgpt(raw: JSONRecord) -> HarmonizedMessage:
+def _fallback_extract_chatgpt(raw: JSONDocument) -> HarmonizedMessage:
     """Fallback extraction for malformed ChatGPT records."""
     payload = _payload_record(raw)
     author = _payload_record(_record(payload.get("author")))
@@ -83,17 +115,17 @@ def _fallback_extract_chatgpt(raw: JSONRecord) -> HarmonizedMessage:
     metadata = _payload_record(_record(payload.get("metadata")))
 
     return HarmonizedMessage(
-        id=payload.get("id"),
-        role=Role.normalize(author.get("role") or _missing_role()),
+        id=_string_value(payload.get("id")),
+        role=Role.normalize(_string_value(author.get("role")) or _missing_role()),
         text=extract_chatgpt_text(content),
-        timestamp=parse_timestamp(payload.get("create_time")),
-        model=metadata.get("model_slug"),
+        timestamp=parse_timestamp(_timestamp_candidate(payload.get("create_time"))),
+        model=_string_value(metadata.get("model_slug")),
         provider=Provider.CHATGPT,
-        raw=payload,
+        raw=_object_record(payload),
     )
 
 
-def _fallback_extract_gemini(raw: JSONRecord) -> HarmonizedMessage:
+def _fallback_extract_gemini(raw: JSONDocument) -> HarmonizedMessage:
     """Fallback extraction for malformed Gemini records."""
     payload = _payload_record(raw)
     is_thinking = payload.get("isThought", False)
@@ -103,51 +135,55 @@ def _fallback_extract_gemini(raw: JSONRecord) -> HarmonizedMessage:
 
     return HarmonizedMessage(
         id=None,
-        role=Role.normalize(payload.get("role") or _missing_role()),
-        text=payload.get("text", ""),
+        role=Role.normalize(_string_value(payload.get("role")) or _missing_role()),
+        text=_string_value(payload.get("text")) or "",
         timestamp=None,
         reasoning_traces=[
             ReasoningTrace(
-                text=payload.get("text", ""),
+                text=_string_value(payload.get("text")) or "",
                 token_count=thinking_budget if isinstance(thinking_budget, int) else None,
                 provider=Provider.GEMINI,
-                raw=payload,
+                raw=_object_record(payload),
             )
         ]
         if is_thinking
         else [],
         tokens=TokenUsage(output_tokens=output_tokens) if output_tokens is not None else None,
         provider=Provider.GEMINI,
-        raw=payload,
+        raw=_object_record(payload),
     )
 
 
-def _fallback_extract_codex(raw: JSONRecord) -> HarmonizedMessage:
+def _fallback_extract_codex(raw: JSONDocument) -> HarmonizedMessage:
     """Fallback extraction for malformed Codex records."""
     raw_payload = _payload_record(raw)
     payload = _payload_record(_record(raw_payload.get("payload")))
     if payload:
-        role = payload.get("role", "unknown")
+        role = _string_value(payload.get("role")) or "unknown"
         content = payload.get("content", [])
     else:
-        role = raw_payload.get("role", "unknown")
+        role = _string_value(raw_payload.get("role")) or "unknown"
         content = raw_payload.get("content", [])
 
     text_parts = []
     for block in content if isinstance(content, list) else []:
         if not isinstance(block, dict):
             continue
-        text = block.get("text", "") or block.get("input_text", "") or block.get("output_text", "")
+        text = (
+            _string_value(block.get("text"))
+            or _string_value(block.get("input_text"))
+            or _string_value(block.get("output_text"))
+        )
         if text:
             text_parts.append(text)
 
     return HarmonizedMessage(
-        id=raw_payload.get("id"),
+        id=_string_value(raw_payload.get("id")),
         role=Role.normalize(role),
         text="\n".join(text_parts),
-        timestamp=parse_timestamp(raw_payload.get("timestamp")),
+        timestamp=parse_timestamp(_timestamp_candidate(raw_payload.get("timestamp"))),
         provider=Provider.CODEX,
-        raw=raw_payload,
+        raw=_object_record(raw_payload),
     )
 
 
@@ -160,7 +196,7 @@ _FALLBACK_EXTRACTORS: dict[Provider, FallbackExtractor] = {
 }
 
 
-def extract_fallback_message(provider: Provider, raw: JSONRecord) -> HarmonizedMessage:
+def extract_fallback_message(provider: Provider, raw: JSONDocument) -> HarmonizedMessage:
     """Fallback harmonization for malformed raw provider payloads."""
     try:
         extractor = _FALLBACK_EXTRACTORS[provider]

--- a/polylogue/schemas/unified_models.py
+++ b/polylogue/schemas/unified_models.py
@@ -80,4 +80,7 @@ def extract_token_usage(usage: dict[str, Any] | None) -> TokenUsage | None:
     )
 
 
+HarmonizedMessage.model_rebuild()
+
+
 __all__ = ["HarmonizedMessage", "_missing_role", "extract_token_usage"]

--- a/polylogue/schemas/unified_models.py
+++ b/polylogue/schemas/unified_models.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, NoReturn
+from typing import NoReturn
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, ValidationError, field_validator
 
+from polylogue.lib.json import JSONDocument
 from polylogue.lib.roles import Role
 from polylogue.lib.viewports import ContentBlock, CostInfo, ReasoningTrace, TokenUsage, ToolCall
 from polylogue.types import Provider
@@ -32,7 +33,7 @@ class HarmonizedMessage(BaseModel):
     cost: CostInfo | None = None
     duration_ms: int | None = None
     provider: Provider
-    raw: dict[str, Any] = Field(default_factory=dict)
+    raw: dict[str, object] = Field(default_factory=dict)
 
     @field_validator("role", mode="before")
     @classmethod
@@ -66,18 +67,23 @@ class HarmonizedMessage(BaseModel):
         return [call for call in self.tool_calls if call.is_git_operation]
 
 
-def extract_token_usage(usage: dict[str, Any] | None) -> TokenUsage | None:
+def extract_token_usage(usage: JSONDocument | None) -> TokenUsage | None:
     """Extract token usage from usage dict."""
     if not usage:
         return None
 
-    return TokenUsage(
-        input_tokens=usage.get("input_tokens"),
-        output_tokens=usage.get("output_tokens"),
-        cache_read_tokens=usage.get("cache_read_input_tokens"),
-        cache_write_tokens=usage.get("cache_creation_input_tokens"),
-        total_tokens=usage.get("total_tokens"),
-    )
+    try:
+        return TokenUsage.model_validate(
+            {
+                "input_tokens": usage.get("input_tokens"),
+                "output_tokens": usage.get("output_tokens"),
+                "cache_read_tokens": usage.get("cache_read_input_tokens"),
+                "cache_write_tokens": usage.get("cache_creation_input_tokens"),
+                "total_tokens": usage.get("total_tokens"),
+            }
+        )
+    except ValidationError:
+        return None
 
 
 HarmonizedMessage.model_rebuild()

--- a/polylogue/schemas/unified_provider_meta_coercion.py
+++ b/polylogue/schemas/unified_provider_meta_coercion.py
@@ -2,17 +2,17 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
 from datetime import datetime
 
 from pydantic import ValidationError
 
+from polylogue.lib.json import JSONDocument, json_document
 from polylogue.lib.timestamps import parse_timestamp
 from polylogue.lib.viewports import ContentBlock, CostInfo, ReasoningTrace, TokenUsage, ToolCall
 from polylogue.schemas.unified_models import extract_token_usage
 from polylogue.types import Provider
 
-ProviderMetaPayload = Mapping[str, object]
+ProviderMetaPayload = JSONDocument
 
 
 def _coerce_timestamp(value: datetime | str | float | int | None) -> datetime | None:
@@ -34,7 +34,7 @@ def _coerce_reasoning_traces(
             continue
         if not isinstance(trace, dict):
             continue
-        raw_trace = dict(trace)
+        raw_trace = json_document(trace)
         raw_trace.setdefault("provider", provider)
         try:
             coerced.append(ReasoningTrace.model_validate(raw_trace))
@@ -56,7 +56,7 @@ def _coerce_tool_calls(
             continue
         if not isinstance(call, dict):
             continue
-        raw_call = dict(call)
+        raw_call = json_document(call)
         raw_call.setdefault("provider", provider)
         try:
             coerced.append(ToolCall.model_validate(raw_call))
@@ -76,7 +76,7 @@ def _coerce_content_blocks(blocks: object) -> list[ContentBlock]:
         if not isinstance(block, dict):
             continue
         try:
-            coerced.append(ContentBlock.model_validate(block))
+            coerced.append(ContentBlock.model_validate(json_document(block)))
         except ValidationError:
             continue
     return coerced
@@ -85,14 +85,14 @@ def _coerce_content_blocks(blocks: object) -> list[ContentBlock]:
 def _extract_generic_tokens(provider_meta: ProviderMetaPayload) -> TokenUsage | None:
     usage = provider_meta.get("usage")
     if isinstance(usage, dict):
-        return extract_token_usage(usage)
+        return extract_token_usage(json_document(usage))
 
     tokens = provider_meta.get("tokens")
     if isinstance(tokens, TokenUsage):
         return tokens
     if isinstance(tokens, dict):
         try:
-            return TokenUsage.model_validate(tokens)
+            return TokenUsage.model_validate(json_document(tokens))
         except ValidationError:
             return None
 
@@ -108,7 +108,7 @@ def _extract_generic_cost(provider_meta: ProviderMetaPayload) -> CostInfo | None
         return cost
     if isinstance(cost, dict):
         try:
-            return CostInfo.model_validate(cost)
+            return CostInfo.model_validate(json_document(cost))
         except ValidationError:
             return None
 

--- a/polylogue/schemas/unified_provider_meta_harmonize.py
+++ b/polylogue/schemas/unified_provider_meta_harmonize.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any
 
+from polylogue.lib.json import JSONDocument, json_document_list
 from polylogue.lib.provider_semantics import extract_display_text_from_content_blocks
 from polylogue.lib.roles import Role
 from polylogue.lib.viewports import ContentType, ReasoningTrace
@@ -20,9 +20,35 @@ from polylogue.schemas.unified_provider_meta_coercion import (
 from polylogue.types import Provider
 
 
+def _object_record(value: JSONDocument) -> dict[str, object]:
+    return dict(value)
+
+
+def _string_value(value: object) -> str | None:
+    return value if isinstance(value, str) else None
+
+
+def _int_value(value: object) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    return None
+
+
+def _timestamp_candidate(value: object) -> str | float | int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (str, float, int)):
+        return value
+    return None
+
+
 def _harmonize_extracted_provider_meta(
     provider: Provider,
-    provider_meta: dict[str, Any],
+    provider_meta: JSONDocument,
     *,
     message_id: str | None = None,
     role: str | None = None,
@@ -62,9 +88,8 @@ def _harmonize_extracted_provider_meta(
         if isinstance(provider_meta.get("text"), str):
             resolved_text = str(provider_meta["text"])
         else:
-            raw_content_blocks = provider_meta.get("content_blocks")
             resolved_text = extract_display_text_from_content_blocks(
-                raw_content_blocks if isinstance(raw_content_blocks, list) else None
+                json_document_list(provider_meta.get("content_blocks"))
             )
 
     resolved_timestamp = timestamp
@@ -75,24 +100,25 @@ def _harmonize_extracted_provider_meta(
             provider_meta.get("create_time"),
             provider_meta.get("updated_at"),
         ):
-            if candidate is not None:
-                resolved_timestamp = candidate
+            normalized_candidate = _timestamp_candidate(candidate)
+            if normalized_candidate is not None:
+                resolved_timestamp = normalized_candidate
                 break
 
     return HarmonizedMessage(
-        id=message_id or provider_meta.get("id") or provider_meta.get("uuid"),
+        id=message_id or _string_value(provider_meta.get("id")) or _string_value(provider_meta.get("uuid")),
         role=Role.normalize(resolved_role or _missing_role()),
         text=resolved_text or "",
         timestamp=_coerce_timestamp(resolved_timestamp),
         reasoning_traces=reasoning_traces,
         tool_calls=tool_calls,
         content_blocks=content_blocks,
-        model=provider_meta.get("model") or provider_meta.get("model_slug"),
+        model=_string_value(provider_meta.get("model")) or _string_value(provider_meta.get("model_slug")),
         tokens=_extract_generic_tokens(provider_meta),
         cost=_extract_generic_cost(provider_meta),
-        duration_ms=provider_meta.get("durationMs") or provider_meta.get("duration_ms"),
+        duration_ms=_int_value(provider_meta.get("durationMs")) or _int_value(provider_meta.get("duration_ms")),
         provider=provider,
-        raw=provider_meta,
+        raw=_object_record(provider_meta),
     )
 
 
@@ -104,7 +130,7 @@ def _overlay_message_context(
     text: str | None = None,
     timestamp: datetime | str | float | int | None = None,
 ) -> HarmonizedMessage:
-    updates: dict[str, Any] = {}
+    updates: dict[str, object] = {}
 
     if message.id is None and message_id is not None:
         updates["id"] = message_id

--- a/polylogue/schemas/unified_provider_meta_runtime.py
+++ b/polylogue/schemas/unified_provider_meta_runtime.py
@@ -4,11 +4,10 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Mapping
 from datetime import datetime
-from typing import Any, cast
 
 from pydantic import ValidationError
 
-from polylogue.lib.raw_payload_decode import JSONRecord
+from polylogue.lib.json import JSONDocument, json_document
 from polylogue.schemas.unified_adapters import extract_with_adapter
 from polylogue.schemas.unified_fallbacks import extract_fallback_message
 from polylogue.schemas.unified_models import HarmonizedMessage
@@ -20,12 +19,10 @@ from polylogue.schemas.unified_provider_meta_harmonize import (
 from polylogue.types import Provider
 
 
-def _json_record(value: object) -> JSONRecord:
-    return cast(JSONRecord, value) if isinstance(value, dict) else {}
-
-
-def _provider_meta_dict(value: Mapping[str, object]) -> dict[str, Any]:
-    return dict(value)
+def _provider_meta_record(value: Mapping[str, object]) -> JSONDocument:
+    if isinstance(value, dict):
+        return json_document(value)
+    return json_document(dict(value))
 
 
 def extract_from_provider_meta(
@@ -39,13 +36,13 @@ def extract_from_provider_meta(
 ) -> HarmonizedMessage:
     """Extract HarmonizedMessage from polylogue database format."""
     resolved_provider = provider if isinstance(provider, Provider) else Provider.from_string(provider)
-    raw = provider_meta.get("raw")
-    if raw is not None:
-        raw_record = _json_record(raw)
+    provider_meta_record = _provider_meta_record(provider_meta)
+    raw_record = json_document(provider_meta_record.get("raw"))
+    if raw_record:
         try:
             harmonized = extract_with_adapter(resolved_provider, raw_record)
         except (ValidationError, ValueError):
-            harmonized = extract_fallback_message(resolved_provider, dict(raw_record))
+            harmonized = extract_fallback_message(resolved_provider, raw_record)
         return _overlay_message_context(
             harmonized,
             message_id=message_id,
@@ -54,10 +51,10 @@ def extract_from_provider_meta(
             timestamp=timestamp,
         )
 
-    if _has_extracted_viewports(dict(provider_meta)):
+    if _has_extracted_viewports(provider_meta_record):
         return _harmonize_extracted_provider_meta(
             resolved_provider,
-            _provider_meta_dict(provider_meta),
+            provider_meta_record,
             message_id=message_id,
             role=role,
             text=text,
@@ -65,11 +62,11 @@ def extract_from_provider_meta(
         )
 
     try:
-        harmonized = extract_with_adapter(resolved_provider, _json_record(provider_meta))
+        harmonized = extract_with_adapter(resolved_provider, provider_meta_record)
     except (ValidationError, ValueError, TypeError):
         return _harmonize_extracted_provider_meta(
             resolved_provider,
-            _provider_meta_dict(provider_meta),
+            provider_meta_record,
             message_id=message_id,
             role=role,
             text=text,
@@ -109,13 +106,14 @@ def harmonize_parsed_message(
     if not provider_meta:
         return None
 
-    raw = provider_meta.get("raw", provider_meta)
-    if not is_message_record(provider, _json_record(raw)):
+    provider_meta_record = _provider_meta_record(provider_meta)
+    raw_record = json_document(provider_meta_record.get("raw")) or provider_meta_record
+    if not is_message_record(provider, raw_record):
         return None
 
     return extract_from_provider_meta(
         provider,
-        provider_meta,
+        provider_meta_record,
         message_id=message_id,
         role=role,
         text=text,

--- a/polylogue/schemas/validator.py
+++ b/polylogue/schemas/validator.py
@@ -14,6 +14,7 @@ except ImportError:
     jsonschema = None
     Draft202012Validator = None
 
+from polylogue.lib.json import JSONDocument, JSONValue, is_json_value, json_document
 from polylogue.lib.raw_payload import extract_payload_samples
 from polylogue.schemas.runtime_registry import SchemaRegistry
 from polylogue.types import Provider
@@ -33,7 +34,7 @@ if TYPE_CHECKING:
     from polylogue.schemas.packages import SchemaResolution
 
 ValidationSchema: TypeAlias = Mapping[str, Any]
-ValidationSample: TypeAlias = dict[str, Any]
+ValidationSample: TypeAlias = JSONDocument
 
 
 class ValidationErrorLike(Protocol):
@@ -78,7 +79,7 @@ _UUID_KEY_RE = re.compile(
 def _sample_payload(value: object) -> ValidationSample | None:
     if not isinstance(value, Mapping):
         return None
-    return {str(key): child for key, child in value.items()}
+    return json_document(dict(value))
 
 
 def _schema_mapping(value: object) -> ValidationSchema:
@@ -92,8 +93,11 @@ def _validation_samples(
     sample_granularity: Literal["document", "record"],
     max_samples: int | None,
 ) -> list[ValidationSample]:
+    if not is_json_value(payload):
+        return []
+    normalized_payload: JSONValue = payload
     raw_samples = extract_payload_samples(
-        payload,
+        normalized_payload,
         sample_granularity=sample_granularity,
         max_samples=max_samples,
     )

--- a/polylogue/sources/source_acquisition.py
+++ b/polylogue/sources/source_acquisition.py
@@ -10,6 +10,7 @@ from typing import IO, BinaryIO, TypeAlias, cast
 
 from polylogue.config import Source
 from polylogue.lib.artifact_taxonomy import classify_artifact
+from polylogue.lib.json import JSONValue, is_json_value
 from polylogue.lib.json import dumps_bytes as json_dumps_bytes
 from polylogue.lib.metrics import read_current_rss_mb, read_peak_rss_self_mb
 from polylogue.logging import get_logger
@@ -35,7 +36,11 @@ AcquisitionObservation: TypeAlias = dict[str, object]
 ObservationCallback: TypeAlias = Callable[[AcquisitionObservation], None]
 StatusCallback: TypeAlias = Callable[[str], None]
 CursorState: TypeAlias = CursorStatePayload
-DetectedEntryPayload: TypeAlias = tuple[Provider, object, float]
+DetectedEntryPayload: TypeAlias = tuple[Provider, JSONValue, float]
+
+
+def _artifact_payload(value: object) -> JSONValue:
+    return value if is_json_value(value) else {}
 
 
 def _heartbeat_label(source_path: str) -> str:
@@ -163,12 +168,13 @@ def _iter_entry_payloads(
     last_detected_provider: Provider | None = None
     provider_locked = False
     for payload in _decoders._iter_json_stream(handle, stream_name):
+        normalized_payload = _artifact_payload(payload)
         if provider_locked:
             provider = current_provider
             detect_provider_ms = 0.0
         else:
             detect_start = time.perf_counter()
-            detected_provider = detect_provider(payload)
+            detected_provider = detect_provider(normalized_payload)
             detect_provider_ms = (time.perf_counter() - detect_start) * 1000.0
             provider = detected_provider or current_provider
             if detected_provider is not None and detected_provider is not Provider.UNKNOWN:
@@ -177,7 +183,7 @@ def _iter_entry_payloads(
                     provider_locked = True
                 else:
                     last_detected_provider = detected_provider
-        yield (provider, payload, detect_provider_ms)
+        yield (provider, normalized_payload, detect_provider_ms)
 
 
 def _make_split_entry_raw_data(

--- a/polylogue/storage/artifact_inspection.py
+++ b/polylogue/storage/artifact_inspection.py
@@ -4,10 +4,9 @@ from __future__ import annotations
 
 import hashlib
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING
 
 from polylogue.lib.artifact_taxonomy import ArtifactKind, classify_artifact_path
-from polylogue.lib.raw_payload import build_raw_payload_envelope
+from polylogue.lib.raw_payload import JSONValue, RawPayloadEnvelope, build_raw_payload_envelope
 from polylogue.schemas.observation import derive_bundle_scope, schema_cluster_id
 from polylogue.schemas.runtime_registry import SchemaRegistry
 from polylogue.storage.blob_store import get_blob_store
@@ -15,9 +14,6 @@ from polylogue.storage.store import ArtifactObservationRecord, RawConversationRe
 from polylogue.types import ArtifactSupportStatus, Provider
 
 _SCHEMA_REGISTRY = SchemaRegistry()
-
-if TYPE_CHECKING:
-    from polylogue.lib.raw_payload_decode import JSONValue, RawPayloadEnvelope
 
 
 def artifact_observation_id(

--- a/tests/unit/core/test_json.py
+++ b/tests/unit/core/test_json.py
@@ -48,6 +48,12 @@ _json_value = st.recursive(
 )
 
 
+def _loaded_document(payload: str | bytes) -> core_json.JSONDocument:
+    result = core_json.loads(payload)
+    assert core_json.is_json_document(result)
+    return result
+
+
 # ---------------------------------------------------------------------------
 # Law 1: JSON roundtrip for basic serializable types
 # ---------------------------------------------------------------------------
@@ -78,7 +84,7 @@ def test_decimal_encodes_to_float(d: Decimal) -> None:
     """Decimal always encodes to float — never to string, never raises.
     The encoded value equals float(d)."""
     output = core_json.dumps({"v": d})
-    result = core_json.loads(output)
+    result = _loaded_document(output)
     assert isinstance(result["v"], float)
     assert result["v"] == float(d)
 
@@ -175,7 +181,7 @@ def test_dumps_custom_type_default_handler() -> Any:
 
     payload_obj = CustomType(42)
     output = core_json.dumps(payload_obj, default=custom_handler)
-    data = core_json.loads(output)
+    data = _loaded_document(output)
     assert data == {"custom": 42}
 
 
@@ -187,7 +193,7 @@ def test_dumps_custom_fallback_to_encoder() -> None:
 
     payload = {"decimal": Decimal("1.5")}
     output = core_json.dumps(payload, default=custom_handler)
-    data = core_json.loads(output)
+    data = _loaded_document(output)
     assert data["decimal"] == 1.5
 
 
@@ -200,7 +206,7 @@ def test_dumps_custom_handler_takes_precedence_for_decimal() -> Any:
         raise TypeError("Not handled")
 
     output = core_json.dumps({"decimal": Decimal("1.5")}, default=custom_handler)
-    data = core_json.loads(output)
+    data = _loaded_document(output)
     assert data["decimal"] == "decimal:1.5"
 
 
@@ -249,7 +255,7 @@ def test_dumps_fallback_uses_stdlib_encoder_when_orjson_option_rejects_object() 
         default=custom_handler,
         option=orjson.OPT_NON_STR_KEYS,
     )
-    data = core_json.loads(output)
+    data = _loaded_document(output)
     assert data == {"payload": {"custom": 7}}
 
 
@@ -308,7 +314,7 @@ def test_encoder_decimal_serialized_when_custom_fails() -> Any:
 
     payload = {"value": Decimal("1.5")}
     output = core_json.dumps(payload, default=custom_handler)
-    data = core_json.loads(output)
+    data = _loaded_document(output)
     assert data["value"] == 1.5
 
 

--- a/tests/unit/core/test_models.py
+++ b/tests/unit/core/test_models.py
@@ -12,6 +12,7 @@ from unittest.mock import Mock
 
 import pytest
 
+from polylogue.lib.json import JSONDocument, JSONValue, json_document
 from polylogue.lib.messages import MessageCollection
 from polylogue.lib.models import Message
 from polylogue.lib.provider_identity import (
@@ -43,7 +44,7 @@ TOOL_FILE_OPS = [
     ("MultiEdit", True),
     ("Bash", False),
 ]
-TOOL_GIT_OPS = [
+TOOL_GIT_OPS: list[tuple[str, JSONDocument, bool]] = [
     ("Bash", {"command": "git commit -m 'test'"}, True),
     ("Read", {"command": "git status"}, False),
     ("Bash", {"command": "ls -la"}, False),
@@ -51,7 +52,7 @@ TOOL_GIT_OPS = [
     ("Bash", {"command": "  git push  "}, True),
     ("Bash", {}, False),
 ]
-TOOL_AFFECTED_PATHS = [
+TOOL_AFFECTED_PATHS: list[tuple[str, JSONDocument, list[str]]] = [
     ("Read", {"file_path": "/tmp/test.txt"}, ["/tmp/test.txt"]),
     ("Write", {"file_path": "/tmp/output.txt"}, ["/tmp/output.txt"]),
     ("Edit", {"file_path": "/tmp/code.py"}, ["/tmp/code.py"]),
@@ -76,8 +77,12 @@ MESSAGE_ROLE_CASES = [
 
 
 def _make_tool(tool_name: str, input_data: dict[str, object] | None = None) -> ToolCall:
-    tool_input = input_data or {}
+    tool_input = json_document(input_data)
     return ToolCall(name=tool_name, id="t1", input=tool_input, category=classify_tool(tool_name, tool_input))
+
+
+def _json_input(payload: dict[str, JSONValue]) -> JSONDocument:
+    return json_document(payload)
 
 
 class TestToolCallProperties:
@@ -119,21 +124,25 @@ class TestToolCallProperties:
         assert "./fixtures/sample.txt" in tool.affected_paths
 
     def test_affected_paths_uses_structured_metadata_files(self: Any) -> None:
+        bash_input = _json_input({"command": "git add pyproject.toml README.md"})
         tool = ToolCall(
             name="Bash",
             id="t1",
-            input={"command": "git add pyproject.toml README.md"},
-            category=classify_tool("Bash", {"command": "git add pyproject.toml README.md"}),
+            input=bash_input,
+            category=classify_tool("Bash", bash_input),
             raw={"metadata": {"files": ["pyproject.toml", "/workspace/polylogue/README.md"]}},
         )
         assert tool.affected_paths == ["pyproject.toml", "/workspace/polylogue/README.md"]
 
     def test_affected_paths_filters_noisy_structured_metadata_files(self: Any) -> None:
+        bash_input = _json_input(
+            {"command": "git add modules/services/sinex/bridge.nix && git commit -m \"$(cat <<'EOF'\""}
+        )
         tool = ToolCall(
             name="Bash",
             id="t1",
-            input={"command": "git add modules/services/sinex/bridge.nix && git commit -m \"$(cat <<'EOF'\""},
-            category=classify_tool("Bash", {"command": "git add modules/services/sinex/bridge.nix"}),
+            input=bash_input,
+            category=classify_tool("Bash", bash_input),
             raw={
                 "metadata": {
                     "files": [
@@ -364,8 +373,9 @@ class TestConversationFromRecords:
 
         assert conversation.id == "c1"
         assert conversation.provider == Provider.CLAUDE_AI
-        assert len(conversation.messages) == 1
-        hydrated_message = conversation.messages.to_list()[0]
+        hydrated_messages = conversation.messages.to_list()
+        assert len(hydrated_messages) == 1
+        hydrated_message = hydrated_messages[0]
         assert hydrated_message.role == Role.USER
         assert [attachment.name for attachment in hydrated_message.attachments] == ["file.txt"]
 

--- a/tests/unit/core/test_schema_corpus_alignment.py
+++ b/tests/unit/core/test_schema_corpus_alignment.py
@@ -14,6 +14,7 @@ from typing import Any
 
 import pytest
 
+from polylogue.lib.json import JSONValue, json_document
 from polylogue.lib.raw_payload_sampling_extract import (
     extract_payload_samples,
     extract_record_samples_from_raw_content,
@@ -35,6 +36,11 @@ from polylogue.schemas.semantic_inference_runtime import (
     infer_semantic_roles,
 )
 from polylogue.types import Provider
+
+
+def _payload_documents(records: list[dict[str, str]]) -> list[JSONValue]:
+    return [json_document(record) for record in records]
+
 
 # ---------------------------------------------------------------------------
 # 1. Full-corpus mode bypasses sample caps
@@ -68,7 +74,7 @@ class TestFullCorpusMode:
 
     def test_extract_payload_samples_no_cap_returns_all(self) -> None:
         """extract_payload_samples with max_samples=None returns all records."""
-        records = [{"type": "assistant", "text": f"resp {i}"} for i in range(50)]
+        records = _payload_documents([{"type": "assistant", "text": f"resp {i}"} for i in range(50)])
         result = extract_payload_samples(
             records,
             sample_granularity="record",

--- a/tests/unit/sources/test_models.py
+++ b/tests/unit/sources/test_models.py
@@ -13,6 +13,7 @@ Coverage includes:
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from datetime import datetime
 from typing import TypeAlias
 
@@ -71,6 +72,15 @@ ChatGPTConversationMessages: TypeAlias = list[tuple[str, str]]
 ProviderViewportRecord: TypeAlias = (
     ClaudeCodeRecord | ClaudeAIChatMessage | ChatGPTMessage | GeminiMessage | CodexRecord
 )
+
+
+def _object_mapping(value: object) -> Mapping[str, object]:
+    return value if isinstance(value, dict) else {}
+
+
+def _object_list(mapping: Mapping[str, object], key: str) -> list[object]:
+    value = mapping.get(key)
+    return list(value) if isinstance(value, list) else []
 
 
 class TestChatGPTMessageTextContent:
@@ -290,7 +300,7 @@ class TestClaudeCodeRecordContentBlocksRaw2:
         )
         record = ClaudeCodeRecord(type="assistant", message=msg)
         assert len(record.content_blocks_raw) == 1
-        assert record.content_blocks_raw[0]["type"] == "text"
+        assert _object_mapping(record.content_blocks_raw[0]).get("type") == "text"
 
 
 class TestClaudeCodeRecordToMeta2:
@@ -645,7 +655,7 @@ class TestGeminiExtractReasoningTracesExtra:
         )
         traces = msg.extract_reasoning_traces()
         assert len(traces) == 1
-        assert traces[0].raw["thoughtSignatures"] == expected_in_raw
+        assert _object_list(traces[0].raw, "thoughtSignatures") == expected_in_raw
 
     def test_extract_reasoning_traces_with_model_signatures(self) -> None:
         """Coverage for line 159-160: BaseModel signature handling."""
@@ -658,7 +668,7 @@ class TestGeminiExtractReasoningTracesExtra:
         )
         traces = msg.extract_reasoning_traces()
         assert len(traces) == 1
-        assert len(traces[0].raw["thoughtSignatures"]) == 1
+        assert len(_object_list(traces[0].raw, "thoughtSignatures")) == 1
 
     def test_extract_reasoning_traces_budget_none(self) -> None:
         msg = GeminiMessage(

--- a/tests/unit/sources/test_unified_semantic_laws.py
+++ b/tests/unit/sources/test_unified_semantic_laws.py
@@ -11,6 +11,7 @@ import pytest
 from hypothesis import given, settings
 from hypothesis import strategies as st
 
+from polylogue.lib.json import JSONDocument, json_document, json_document_list
 from polylogue.lib.provider_semantics import (
     extract_chatgpt_text,
     extract_claude_code_text,
@@ -70,10 +71,8 @@ from tests.infra.strategies import (
 _VALID_VIEWPORT_ROLES = {"user", "assistant", "system", "tool", "unknown", "model"}
 
 
-JsonScalar: TypeAlias = str | int | float | bool | None
-JsonValue: TypeAlias = JsonScalar | dict[str, "JsonValue"] | list["JsonValue"]
-RawPayload: TypeAlias = dict[str, JsonValue]
-RawContent: TypeAlias = list[RawPayload]
+RawPayload: TypeAlias = JSONDocument
+RawContent: TypeAlias = list[JSONDocument]
 SemanticCase: TypeAlias = tuple[str, RawPayload]
 
 
@@ -96,9 +95,7 @@ def _provider(value: str | Provider) -> Provider:
 
 
 def _as_dict(value: object) -> RawPayload:
-    if not isinstance(value, dict):
-        return {}
-    return {key: value for key, value in value.items() if isinstance(key, str)}
+    return json_document(value)
 
 
 def _as_list(value: object) -> list[object]:
@@ -106,7 +103,11 @@ def _as_list(value: object) -> list[object]:
 
 
 def _content_blocks(value: list[object]) -> RawContent:
-    return [_as_dict(item) for item in value if isinstance(item, dict)]
+    return json_document_list(value)
+
+
+def _doc(value: object) -> JSONDocument:
+    return json_document(value)
 
 
 def _build_viewport_record(provider: str, raw: RawPayload) -> ViewportRecord:
@@ -126,16 +127,18 @@ def _build_viewport_record(provider: str, raw: RawPayload) -> ViewportRecord:
 def _structured_provider_meta(record: ViewportRecord) -> RawPayload:
     meta = record.to_meta()
     provider_meta: RawPayload = {
-        "content_blocks": [block.model_dump(mode="json") for block in record.extract_content_blocks()],
-        "reasoning_traces": [trace.model_dump(mode="json") for trace in record.extract_reasoning_traces()],
-        "tool_calls": [call.model_dump(mode="json") for call in record.extract_tool_calls()],
+        "content_blocks": [json_document(block.model_dump(mode="json")) for block in record.extract_content_blocks()],
+        "reasoning_traces": [
+            json_document(trace.model_dump(mode="json")) for trace in record.extract_reasoning_traces()
+        ],
+        "tool_calls": [json_document(call.model_dump(mode="json")) for call in record.extract_tool_calls()],
     }
     if meta.model is not None:
         provider_meta["model"] = meta.model
     if meta.tokens is not None:
-        provider_meta["tokens"] = meta.tokens.model_dump(mode="json")
+        provider_meta["tokens"] = json_document(meta.tokens.model_dump(mode="json"))
     if meta.cost is not None:
-        provider_meta["cost"] = meta.cost.model_dump(mode="json")
+        provider_meta["cost"] = json_document(meta.cost.model_dump(mode="json"))
     if meta.duration_ms is not None:
         provider_meta["duration_ms"] = meta.duration_ms
     return provider_meta
@@ -484,7 +487,7 @@ def test_provider_adapter_viewport_contract(case: SemanticCase) -> None:
 
     if isinstance(record, ChatGPTMessage):
         assert record.role_normalized in {"user", "assistant", "system", "tool", "unknown"}
-        assert record.text_content == extract_chatgpt_text(record.content.model_dump(mode="python"))
+        assert record.text_content == extract_chatgpt_text(_doc(record.content.model_dump(mode="python")))
         assert blocks == record.to_content_blocks()
         assert not traces
         assert not calls
@@ -619,10 +622,10 @@ def test_is_message_record_contract(provider: str, raw: RawPayload, expected: bo
     ("label", "action", "match"),
     [
         ("missing-role", lambda: _missing_role(), "Message has no role"),
-        ("unknown-provider", lambda: extract_harmonized_message("unknown_provider", {}), "Unknown provider"),
+        ("unknown-provider", lambda: extract_harmonized_message("unknown_provider", _doc({})), "Unknown provider"),
         (
             "claude-code-empty-message",
-            lambda: extract_harmonized_message("claude-code", {"uuid": "m1", "type": "human", "message": {}}),
+            lambda: extract_harmonized_message("claude-code", _doc({"uuid": "m1", "type": "human", "message": {}})),
             "no role",
         ),
     ],
@@ -723,13 +726,15 @@ def test_coercion_and_token_cost_internals_contract() -> None:
     assert [item.text for item in coerced_blocks] == ["kept-block", "dict-block", None]
 
     # --- extract_token_usage with cache fields ---
-    usage = {
-        "input_tokens": 10,
-        "output_tokens": 12,
-        "cache_read_input_tokens": 3,
-        "cache_creation_input_tokens": 4,
-        "total_tokens": 29,
-    }
+    usage = _doc(
+        {
+            "input_tokens": 10,
+            "output_tokens": 12,
+            "cache_read_input_tokens": 3,
+            "cache_creation_input_tokens": 4,
+            "total_tokens": 29,
+        }
+    )
     tokens = extract_token_usage(usage)
     assert tokens is not None
     assert tokens.input_tokens == 10
@@ -739,36 +744,38 @@ def test_coercion_and_token_cost_internals_contract() -> None:
     assert tokens.total_tokens == 29
 
     # --- _extract_generic_tokens ---
-    assert _extract_generic_tokens({"usage": usage}) == extract_token_usage(usage)
-    assert _extract_generic_tokens({"tokens": {"output_tokens": 7}}) == TokenUsage(output_tokens=7)
-    assert _extract_generic_tokens({"tokenCount": 9}) == TokenUsage(output_tokens=9)
-    assert _extract_generic_tokens({"tokens": {"output_tokens": "bad"}}) is None
+    assert _extract_generic_tokens(_doc({"usage": usage})) == extract_token_usage(usage)
+    assert _extract_generic_tokens(_doc({"tokens": _doc({"output_tokens": 7})})) == TokenUsage(output_tokens=7)
+    assert _extract_generic_tokens(_doc({"tokenCount": 9})) == TokenUsage(output_tokens=9)
+    assert _extract_generic_tokens(_doc({"tokens": _doc({"output_tokens": "bad"})})) is None
 
     # --- _extract_generic_cost ---
-    assert _extract_generic_cost({"cost": {"total_usd": 0.25}}) == CostInfo(total_usd=0.25)
-    assert _extract_generic_cost({"costUSD": 1.5}) == CostInfo(total_usd=1.5)
-    assert _extract_generic_cost({"cost": {"total_usd": "bad"}}) is None
+    assert _extract_generic_cost(_doc({"cost": _doc({"total_usd": 0.25})})) == CostInfo(total_usd=0.25)
+    assert _extract_generic_cost(_doc({"costUSD": 1.5})) == CostInfo(total_usd=1.5)
+    assert _extract_generic_cost(_doc({"cost": _doc({"total_usd": "bad"})})) is None
 
 
 def test_harmonization_pipeline_internals_contract() -> None:
     """Consolidated: _harmonize_extracted_provider_meta, _has_extracted_viewports, _overlay_message_context."""
     # --- _harmonize_extracted_provider_meta ---
-    provider_meta = {
-        "content_blocks": [
-            {"type": "text", "text": "plain text", "raw": {"text": "plain text"}},
-            {"type": "thinking", "text": "private reasoning", "raw": {"thinking": "private reasoning"}},
-            {
-                "type": "tool_use",
-                "tool_call": {"name": "Read", "id": "tool-1", "input": {"path": "README.md"}},
-                "raw": {"type": "tool_use"},
-            },
-        ],
-        "tokens": {"output_tokens": 5},
-        "costUSD": 0.25,
-        "durationMs": 12,
-        "sender": "assistant",
-        "created_at": "2025-01-01T00:00:00Z",
-    }
+    provider_meta = _doc(
+        {
+            "content_blocks": [
+                {"type": "text", "text": "plain text", "raw": {"text": "plain text"}},
+                {"type": "thinking", "text": "private reasoning", "raw": {"thinking": "private reasoning"}},
+                {
+                    "type": "tool_use",
+                    "tool_call": {"name": "Read", "id": "tool-1", "input": {"path": "README.md"}},
+                    "raw": {"type": "tool_use"},
+                },
+            ],
+            "tokens": {"output_tokens": 5},
+            "costUSD": 0.25,
+            "durationMs": 12,
+            "sender": "assistant",
+            "created_at": "2025-01-01T00:00:00Z",
+        }
+    )
 
     harmonized = _harmonize_extracted_provider_meta(
         Provider.CLAUDE_CODE,
@@ -790,13 +797,13 @@ def test_harmonization_pipeline_internals_contract() -> None:
     assert harmonized.timestamp is not None
 
     # --- _has_extracted_viewports ---
-    assert _has_extracted_viewports({"content_blocks": [], "duration_ms": 1}) is True
-    assert _has_extracted_viewports({"sender": "assistant", "text": "hello"}) is False
+    assert _has_extracted_viewports(_doc({"content_blocks": [], "duration_ms": 1})) is True
+    assert _has_extracted_viewports(_doc({"sender": "assistant", "text": "hello"})) is False
 
     # --- _overlay_message_context ---
     message = extract_harmonized_message(
         "claude-ai",
-        {"uuid": "m1", "sender": "assistant", "text": "hello", "created_at": "2025-01-01T00:00:00Z"},
+        _doc({"uuid": "m1", "sender": "assistant", "text": "hello", "created_at": "2025-01-01T00:00:00Z"}),
     )
     unknown = message.model_copy(update={"id": None, "role": "unknown", "text": "", "timestamp": None})
 
@@ -868,16 +875,18 @@ def test_generic_content_extraction_contract() -> None:
 def test_extract_from_provider_meta_integration_contract() -> None:
     """Consolidated: extract_from_provider_meta with plain blocks, structured blocks+tools, and multi-provider overlay."""
     # --- Plain content blocks with tokens/cost/duration ---
-    provider_meta_plain = {
-        "content_blocks": [
-            {"type": "text", "text": "plain text"},
-            {"type": "code", "text": "print('x')", "language": "python"},
-            {"type": "tool_result", "text": "tool output"},
-        ],
-        "tokens": {"output_tokens": 5},
-        "cost": {"total_usd": 0.25},
-        "duration_ms": 12,
-    }
+    provider_meta_plain = _doc(
+        {
+            "content_blocks": [
+                {"type": "text", "text": "plain text"},
+                {"type": "code", "text": "print('x')", "language": "python"},
+                {"type": "tool_result", "text": "tool output"},
+            ],
+            "tokens": {"output_tokens": 5},
+            "cost": {"total_usd": 0.25},
+            "duration_ms": 12,
+        }
+    )
 
     harmonized = extract_from_provider_meta(
         "claude-code",
@@ -895,19 +904,21 @@ def test_extract_from_provider_meta_integration_contract() -> None:
     assert harmonized.duration_ms == 12
 
     # --- Structured blocks with tool_calls and reasoning_traces ---
-    provider_meta_structured = {
-        "content_blocks": [
-            {"type": "text", "text": "plain text"},
-            {"type": "tool_use", "tool_call": {"name": "Read", "id": "tool-1", "input": {"path": "README.md"}}},
-            {"type": "tool_result", "text": "tool output"},
-            {"type": "code", "text": "print('x')", "language": "python"},
-        ],
-        "reasoning_traces": [{"text": "reason", "provider": "claude-code"}],
-        "tool_calls": [{"name": "Read", "id": "tool-1", "input": {"path": "README.md"}, "provider": "claude-code"}],
-        "tokens": {"output_tokens": 5},
-        "cost": {"total_usd": 0.25},
-        "duration_ms": 12,
-    }
+    provider_meta_structured = _doc(
+        {
+            "content_blocks": [
+                {"type": "text", "text": "plain text"},
+                {"type": "tool_use", "tool_call": {"name": "Read", "id": "tool-1", "input": {"path": "README.md"}}},
+                {"type": "tool_result", "text": "tool output"},
+                {"type": "code", "text": "print('x')", "language": "python"},
+            ],
+            "reasoning_traces": [{"text": "reason", "provider": "claude-code"}],
+            "tool_calls": [{"name": "Read", "id": "tool-1", "input": {"path": "README.md"}, "provider": "claude-code"}],
+            "tokens": {"output_tokens": 5},
+            "cost": {"total_usd": 0.25},
+            "duration_ms": 12,
+        }
+    )
 
     harmonized2 = extract_from_provider_meta(
         "claude-code",
@@ -986,7 +997,7 @@ def test_extract_harmonized_message_fallback_contract() -> None:
         "content": {"parts": ["hello", {"text": "world"}]},
         "metadata": {"model_slug": "gpt-4o"},
     }
-    msg_cg = extract_harmonized_message("chatgpt", chatgpt_raw)
+    msg_cg = extract_harmonized_message("chatgpt", _doc(chatgpt_raw))
     assert msg_cg.id == "chatgpt-fallback"
     assert msg_cg.role.value == "assistant"
     assert msg_cg.text == "hello\nworld"
@@ -997,7 +1008,7 @@ def test_extract_harmonized_message_fallback_contract() -> None:
         "text": "print('ok')",
         "parts": ["ignored", {"text": "still ignored"}],
     }
-    assert extract_chatgpt_text(content_direct) == "print('ok')"
+    assert extract_chatgpt_text(_doc(content_direct)) == "print('ok')"
 
     # --- Claude Code: full semantic fields preserved ---
     cc_raw = {
@@ -1024,7 +1035,7 @@ def test_extract_harmonized_message_fallback_contract() -> None:
             ],
         },
     }
-    msg_cc = extract_harmonized_message("claude-code", cc_raw)
+    msg_cc = extract_harmonized_message("claude-code", _doc(cc_raw))
     assert msg_cc.id == "claude-fallback"
     assert msg_cc.role.value == "assistant"
     assert msg_cc.text == "hello"
@@ -1054,7 +1065,7 @@ def test_extract_harmonized_message_fallback_contract() -> None:
         ({"uuid": "m1", "type": "assistant", "message": "not-a-dict"}, "assistant"),
     ]
     for raw, expected_role in claude_code_role_fallbacks:
-        msg = extract_harmonized_message("claude-code", raw)
+        msg = extract_harmonized_message("claude-code", _doc(raw))
         assert msg.role.value == expected_role
         assert msg.id == "m1"
 


### PR DESCRIPTION
## Summary
Tighten the shared JSON/payload contract that flows through raw payload decode, schema harmonization, provider semantic extractors, and adjacent schema/runtime helpers.

Ref #251
Ref #250

## Problem
Recent semantic-precision work established a stronger shared JSON/document contract, but the schema and lib boundary layer still had mixed assumptions:

- raw payload helpers, harmonization code, and runtime consumers were still split between loose `dict[str, object]` plumbing and newer JSON-shaped contracts
- schema fallback and provider-meta extraction paths still depended on cast-heavy or partially duplicated coercion logic
- adjacent schema utilities, action-event helpers, acquisition helpers, and tests still assumed the older, looser signatures
- the result was a type-clean local slice only after focused checks, while the full repo baseline still surfaced cross-module fallout

## Solution
This branch renews that boundary as one coherent slice:

- centralize shared JSON aliases and coercion helpers in `polylogue.lib.json`, including stricter fallback decoding behavior and filtered document-list coercion
- propagate JSON/document contracts through raw payload decode, provider semantics, viewport/runtime helpers, and schema harmonization entrypoints
- tighten schema fallback, unified extraction, observation, validator, and generation workflow helpers around explicit JSON-shaped payloads
- align acquisition and action-event helper seams with the same normalized payload contracts
- update the affected tests to narrow decoded JSON locally instead of widening production signatures back

Key modules touched include:
- `polylogue/lib/json.py`
- `polylogue/lib/raw_payload_decode.py`
- `polylogue/lib/provider_semantics.py`
- `polylogue/pipeline/materialization_runtime.py`
- `polylogue/pipeline/semantic_capture.py`
- `polylogue/schemas/unified*.py`
- `polylogue/schemas/extraction.py`
- `polylogue/schemas/observation_runtime.py`
- `polylogue/schemas/validator.py`
- `polylogue/sources/source_acquisition.py`

## Verification
- `ruff check polylogue/lib/provider_semantics.py polylogue/schemas/unified.py polylogue/schemas/unified_adapters.py polylogue/schemas/unified_fallbacks.py polylogue/schemas/unified_models.py polylogue/schemas/unified_provider_meta_coercion.py polylogue/schemas/unified_provider_meta_harmonize.py polylogue/schemas/unified_provider_meta_runtime.py`
- `mypy polylogue/lib/provider_semantics.py polylogue/schemas/unified.py polylogue/schemas/unified_adapters.py polylogue/schemas/unified_fallbacks.py polylogue/schemas/unified_models.py polylogue/schemas/unified_provider_meta_coercion.py polylogue/schemas/unified_provider_meta_harmonize.py polylogue/schemas/unified_provider_meta_runtime.py`
- `pytest -q tests/unit/sources/test_unified_semantic_laws.py tests/unit/core/test_filters_schemas.py tests/integration/test_extraction_db.py`
- `pytest -q tests/unit/core/test_json.py tests/unit/core/test_models.py tests/unit/core/test_schema_corpus_alignment.py tests/unit/core/test_filters_schemas.py tests/unit/core/test_schema_generation.py tests/unit/sources/test_unified_semantic_laws.py tests/unit/sources/test_models.py tests/unit/sources/test_source_laws.py tests/integration/test_extraction_db.py`
- `devtools verify`
