### PR TITLE
refactor: renew run and acquisition boundary contracts

### DIFF
--- a/polylogue/cli/commands/run.py
+++ b/polylogue/cli/commands/run.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
 
 import click
 
@@ -41,6 +40,7 @@ from polylogue.pipeline.observers import (
     RunObserver,
     WebhookObserver,
 )
+from polylogue.pipeline.payload_types import SiteBuildOptions
 from polylogue.pipeline.run_support import RUN_STAGE_CHOICES, expand_requested_stage, normalize_stage_sequence
 from polylogue.pipeline.runner import plan_sources
 from polylogue.sources import DriveError
@@ -77,7 +77,7 @@ class RunStageRequest:
     name: str
     stage_sequence: tuple[str, ...]
     render_format: str | None = None
-    site_options: dict[str, Any] | None = None
+    site_options: SiteBuildOptions | None = None
     embed_options: EmbedOptions | None = None
 
 
@@ -100,7 +100,7 @@ def _make_stage_request(
     name: str,
     *,
     render_format: str | None = None,
-    site_options: dict[str, Any] | None = None,
+    site_options: SiteBuildOptions | None = None,
 ) -> RunStageRequest:
     return RunStageRequest(
         name=name,
@@ -152,7 +152,7 @@ def _resolve_embed_options(stage_requests: list[RunStageRequest]) -> EmbedOption
     return options[0]
 
 
-def _resolve_site_options(stage_requests: list[RunStageRequest]) -> dict[str, Any] | None:
+def _resolve_site_options(stage_requests: list[RunStageRequest]) -> SiteBuildOptions | None:
     options = [request.site_options for request in stage_requests if request.site_options is not None]
     if not options:
         return None
@@ -447,15 +447,17 @@ def run_site_stage(
     dashboard: bool,
 ) -> RunStageRequest:
     """Generate a static HTML site from the archive."""
+    site_options: SiteBuildOptions = {
+        "title": title,
+        "search": search,
+        "search_provider": search_provider,
+        "dashboard": dashboard,
+    }
+    if output is not None:
+        site_options["output"] = output
     return _make_stage_request(
         "site",
-        site_options={
-            "output": output,
-            "title": title,
-            "search": search,
-            "search_provider": search_provider,
-            "dashboard": dashboard,
-        },
+        site_options=site_options,
     )
 
 

--- a/polylogue/cli/run_workflow.py
+++ b/polylogue/cli/run_workflow.py
@@ -22,6 +22,7 @@ from polylogue.cli.run_watch_workflow import WatchDisplayObserver, WatchStatusOb
 from polylogue.config import Config
 from polylogue.lib.timestamps import format_timestamp
 from polylogue.pipeline.observers import CompositeObserver, RunObserver
+from polylogue.pipeline.payload_types import SiteBuildOptions
 from polylogue.pipeline.run_support import expand_requested_stage
 from polylogue.pipeline.runner import run_sources
 from polylogue.protocols import ProgressCallback
@@ -39,7 +40,7 @@ def execute_sync_once(
     render_format: str,
     plan_snapshot: PlanResult | None = None,
     progress_callback: ProgressCallback | None = None,
-    site_options: dict[str, object] | None = None,
+    site_options: SiteBuildOptions | None = None,
 ) -> RunResult:
     return run_coroutine_sync(
         run_sources(
@@ -67,7 +68,7 @@ def run_with_progress(
     render_format: str,
     plan_snapshot: PlanResult | None = None,
     observer: RunObserver | None = None,
-    site_options: dict[str, object] | None = None,
+    site_options: SiteBuildOptions | None = None,
 ) -> RunResult:
     with progress_observer(env) as progress_observer_handle:
         progress_bridge = (
@@ -99,7 +100,7 @@ def run_sync_once(
     render_format: str,
     plan_snapshot: PlanResult | None = None,
     observer: RunObserver | None = None,
-    site_options: dict[str, object] | None = None,
+    site_options: SiteBuildOptions | None = None,
 ) -> RunResult:
     try:
         result = run_with_progress(

--- a/polylogue/lib/metrics.py
+++ b/polylogue/lib/metrics.py
@@ -11,7 +11,9 @@ import sys
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import cast
+
+from polylogue.lib.json import JSONDocument, JSONValue, is_json_value
 
 
 def _read_proc_status_kb(field_name: str) -> int | None:
@@ -58,6 +60,11 @@ def read_peak_rss_children_mb() -> float | None:
     return _read_rusage_peak_rss_mb(resource.RUSAGE_CHILDREN)
 
 
+def _slow_item_elapsed(item: JSONDocument) -> float:
+    elapsed = item.get("elapsed_s")
+    return float(elapsed) if isinstance(elapsed, int | float) else 0.0
+
+
 @dataclass
 class StageMetrics:
     """Per-stage timing and throughput metrics."""
@@ -67,7 +74,7 @@ class StageMetrics:
     start_time: float = field(default_factory=time.perf_counter)
     end_time: float | None = None
     sub_timings: dict[str, float] = field(default_factory=dict)
-    details: dict[str, Any] = field(default_factory=dict)
+    details: JSONDocument = field(default_factory=dict)
     rss_start_mb: float | None = None
     rss_end_mb: float | None = None
     peak_rss_self_mb: float | None = None
@@ -107,8 +114,8 @@ class StageMetrics:
         )
         return self
 
-    def to_dict(self) -> dict[str, Any]:
-        result = {
+    def to_dict(self) -> JSONDocument:
+        result: JSONDocument = {
             "stage": self.name,
             "items": self.items_processed,
             "elapsed_ms": round(self.elapsed_ms, 1),
@@ -140,21 +147,22 @@ class SlowItemTracker:
     def __init__(self, threshold_s: float = 5.0, max_items: int = 50) -> None:
         self.threshold_s = threshold_s
         self.max_items = max_items
-        self.items: list[dict[str, Any]] = []
+        self.items: list[JSONDocument] = []
 
-    def record(self, item_id: str, stage: str, elapsed_s: float, **extra: Any) -> None:
+    def record(self, item_id: str, stage: str, elapsed_s: float, **extra: object) -> None:
         if elapsed_s >= self.threshold_s and len(self.items) < self.max_items:
-            self.items.append(
-                {
-                    "id": item_id,
-                    "stage": stage,
-                    "elapsed_s": round(elapsed_s, 2),
-                    **extra,
-                }
-            )
+            payload: JSONDocument = {
+                "id": item_id,
+                "stage": stage,
+                "elapsed_s": round(elapsed_s, 2),
+            }
+            for key, value in extra.items():
+                if is_json_value(value):
+                    payload[key] = value
+            self.items.append(payload)
 
-    def to_list(self) -> list[dict[str, Any]]:
-        return sorted(self.items, key=lambda x: x["elapsed_s"], reverse=True)
+    def to_list(self) -> list[JSONDocument]:
+        return sorted(self.items, key=_slow_item_elapsed, reverse=True)
 
 
 class PipelineMetrics:
@@ -175,15 +183,16 @@ class PipelineMetrics:
     def total_elapsed_s(self) -> float:
         return time.perf_counter() - self._pipeline_start
 
-    def to_summary(self) -> dict[str, Any]:
+    def to_summary(self) -> JSONDocument:
         """Export full metrics for logging/persistence."""
+        slow_items = cast(list[JSONValue], list(self.slow_items.to_list()))
         return {
             "total_duration_ms": round(self.total_elapsed_s * 1000, 1),
             "current_rss_mb": read_current_rss_mb(),
             "peak_rss_self_mb": read_peak_rss_self_mb(),
             "peak_rss_children_mb": read_peak_rss_children_mb(),
             "stages": {name: m.to_dict() for name, m in self.stages.items()},
-            "slow_items": self.slow_items.to_list(),
+            "slow_items": slow_items,
         }
 
 

--- a/polylogue/pipeline/payload_types.py
+++ b/polylogue/pipeline/payload_types.py
@@ -1,0 +1,137 @@
+"""Typed payload contracts for run/acquisition telemetry surfaces."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from typing_extensions import TypedDict
+
+from polylogue.lib.json import JSONDocument
+from polylogue.storage.session_product_runtime import SessionProductRefreshChunkPayload
+from polylogue.types import SearchProvider
+
+
+class SiteBuildOptions(TypedDict, total=False):
+    output: Path
+    title: str
+    search: bool
+    search_provider: str | SearchProvider
+    dashboard: bool
+
+
+class AcquireSplitPayloadSummary(TypedDict):
+    count: int
+    total_blob_mb: float
+    max_blob_mb: float
+    total_detect_provider_ms: float
+    total_classify_ms: float
+    total_serialize_ms: float
+    max_detect_provider_ms: float
+    max_classify_ms: float
+    max_serialize_ms: float
+
+
+class AcquireDiagnostics(TypedDict, total=False):
+    peak_observation: JSONDocument
+    observation_count: int
+    split_payload_summary: AcquireSplitPayloadSummary
+
+
+class ParseBatchObservation(TypedDict, total=False):
+    records: int
+    blob_mb: float
+    result_mb: float
+    max_result_mb: float
+    conversations: int
+    messages: int
+    changed_conversations: int
+    workers: int
+    failed_raw_count: int
+    skipped_raw_count: int
+    elapsed_ms: float
+    sync_ingest_elapsed_ms: float
+    sync_setup_elapsed_ms: float
+    result_wait_elapsed_ms: float
+    drain_elapsed_ms: float
+    write_elapsed_ms: float
+    max_write_elapsed_ms: float
+    flush_elapsed_ms: float
+    commit_elapsed_ms: float
+    executor_teardown_elapsed_ms: float
+    raw_state_update_elapsed_ms: float
+    unattributed_elapsed_ms: float
+    rss_start_mb: float
+    rss_end_mb: float
+    rss_delta_mb: float
+    process_peak_rss_self_mb: float
+    peak_rss_growth_mb: float
+    peak_rss_children_mb: float
+    max_current_rss_mb: float
+    max_result_raw_id: str
+    batch: int
+    processed_raw: int
+
+
+class ParseBatchObservationSummary(TypedDict, total=False):
+    batch_count: int
+    slow_batch_count: int
+    max_elapsed_ms: float
+    max_blob_mb: float
+    max_result_mb: float
+    max_current_rss_mb: float
+    max_rss_end_mb: float
+    max_rss_delta_mb: float
+    max_peak_rss_growth_mb: float
+    batches: list[ParseBatchObservation]
+
+
+class IngestDiagnostics(TypedDict, total=False):
+    acquisition: AcquireDiagnostics
+    batch_observations: ParseBatchObservationSummary
+
+
+class RenderStageObservation(TypedDict, total=False):
+    workers: int
+    rss_start_mb: float
+    rss_end_mb: float
+    rss_delta_mb: float
+    max_current_rss_mb: float
+
+
+class MaterializeStageObservation(TypedDict, total=False):
+    mode: str
+    profiles: int
+    work_events: int
+    phases: int
+    threads: int
+    tag_rollups: int
+    day_summaries: int
+    conversations: int
+    unique_thread_roots: int
+    unique_provider_days: int
+    elapsed_ms: float
+    update_ms: float
+    thread_refresh_ms: float
+    aggregate_refresh_ms: float
+    update_chunk_count: int
+    update_slow_chunk_count: int
+    update_max_chunk_ms: float
+    update_max_chunk_load_ms: float
+    update_max_chunk_hydrate_ms: float
+    update_max_chunk_build_ms: float
+    update_max_chunk_write_ms: float
+    update_chunks: list[SessionProductRefreshChunkPayload]
+    failed: bool
+    error: str
+
+
+__all__ = [
+    "AcquireDiagnostics",
+    "AcquireSplitPayloadSummary",
+    "IngestDiagnostics",
+    "MaterializeStageObservation",
+    "ParseBatchObservation",
+    "ParseBatchObservationSummary",
+    "RenderStageObservation",
+    "SiteBuildOptions",
+]

--- a/polylogue/pipeline/run_execution.py
+++ b/polylogue/pipeline/run_execution.py
@@ -6,8 +6,10 @@ import time
 from typing import TYPE_CHECKING
 
 from polylogue.config import Config
+from polylogue.lib.json import JSONDocument, JSONValue, json_document
 from polylogue.lib.metrics import PipelineMetrics
 from polylogue.logging import get_logger
+from polylogue.pipeline.payload_types import SiteBuildOptions
 from polylogue.pipeline.run_finalization import persist_run_result
 from polylogue.pipeline.run_stages import (
     IndexStageOutcome,
@@ -38,9 +40,15 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 
-def _compact_log_details(value: object) -> object:
+def _json_detail_payload(payload: object) -> JSONDocument:
+    if isinstance(payload, dict):
+        return json_document(dict(payload))
+    return {}
+
+
+def _compact_log_details(value: JSONValue) -> JSONValue:
     if isinstance(value, dict):
-        compact: dict[str, object] = {}
+        compact: JSONDocument = {}
         for key, nested in value.items():
             if isinstance(nested, list):
                 count_key = f"{key}_count"
@@ -52,7 +60,7 @@ def _compact_log_details(value: object) -> object:
     return value
 
 
-def _compact_stage_log_payload(payload: dict[str, object]) -> dict[str, object]:
+def _compact_stage_log_payload(payload: JSONDocument) -> JSONDocument:
     """Trim oversized telemetry from normal stage-complete log lines."""
     compact = dict(payload)
     details = compact.get("details")
@@ -71,7 +79,7 @@ async def run_sources(
     source_names: Sequence[str] | None = None,
     progress_callback: ProgressCallback | None = None,
     render_format: str = "html",
-    site_options: dict[str, object] | None = None,
+    site_options: SiteBuildOptions | None = None,
     raw_batch_size: int = 50,
     ingest_workers: int | None = None,
     measure_ingest_result_size: bool = False,
@@ -103,7 +111,7 @@ async def run_sources(
                 ui=ui,
                 progress_callback=progress_callback,
             )
-            sm.details.update(acquire_result.diagnostics)
+            sm.details.update(_json_detail_payload(acquire_result.diagnostics))
             sm.stop(items=acquire_result.counts["acquired"])
             state.record_acquire(acquire_result)
             logger.info("Acquire stage complete", **sm.to_dict(), **acquire_result.counts)
@@ -141,7 +149,7 @@ async def run_sources(
                 measure_ingest_result_size=measure_ingest_result_size,
             )
             sm.sub_timings.update({f"{k}_s": v for k, v in ingest_result.timings.items()})
-            sm.details.update(ingest_result.diagnostics)
+            sm.details.update(_json_detail_payload(ingest_result.diagnostics))
             sm.stop(items=len(ingest_result.parse_raw_ids))
             if "acquire" not in executed_stages:
                 state.record_acquire(ingest_result.acquire_result)
@@ -174,7 +182,7 @@ async def run_sources(
                 progress_callback=progress_callback,
             )
             if materialize_outcome.observation:
-                sm.details.update(materialize_outcome.observation)
+                sm.details.update(_json_detail_payload(materialize_outcome.observation))
             state.record_materialize(materialized=materialize_outcome.item_count)
             sm.stop(items=materialize_outcome.item_count)
             materialize_log_payload = _compact_stage_log_payload(sm.to_dict())
@@ -201,7 +209,7 @@ async def run_sources(
                 failures=render_outcome.failures,
             )
             if render_outcome.observation:
-                sm.details.update(render_outcome.observation)
+                sm.details.update(_json_detail_payload(render_outcome.observation))
             sm.stop(items=state.counts.get("rendered", 0))
             logger.info(
                 "Render stage complete",

--- a/polylogue/pipeline/run_finalization.py
+++ b/polylogue/pipeline/run_finalization.py
@@ -3,15 +3,16 @@
 from __future__ import annotations
 
 import time
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 from uuid import uuid4
 
 from typing_extensions import TypedDict
 
+from polylogue.lib.json import JSONDocument
 from polylogue.pipeline.run_support import write_run_json
 from polylogue.storage.backends import create_backend
 from polylogue.storage.backends.queries import runs as runs_q
-from polylogue.storage.run_state import RunCountsPayload, RunDrift, RunDriftPayload, RunResult
+from polylogue.storage.run_state import DriftBucketPayload, RunCountsPayload, RunDrift, RunDriftPayload, RunResult
 from polylogue.storage.store import RunRecord
 
 if TYPE_CHECKING:
@@ -32,7 +33,44 @@ class RunPayload(TypedDict):
     indexed: bool
     index_error: str | None
     duration_ms: int
-    metrics: dict[str, object]
+    metrics: JSONDocument
+
+
+def _counts_document(payload: RunCountsPayload) -> JSONDocument:
+    document: JSONDocument = {}
+    for key, value in payload.items():
+        if isinstance(value, int):
+            document[key] = value
+    return document
+
+
+def _drift_bucket_document(payload: DriftBucketPayload) -> JSONDocument:
+    return {
+        "conversations": payload["conversations"],
+        "messages": payload["messages"],
+        "attachments": payload["attachments"],
+    }
+
+
+def _drift_document(payload: RunDriftPayload) -> JSONDocument:
+    return {
+        "new": _drift_bucket_document(payload["new"]),
+        "removed": _drift_bucket_document(payload["removed"]),
+        "changed": _drift_bucket_document(payload["changed"]),
+    }
+
+
+def _run_payload_document(payload: RunPayload) -> JSONDocument:
+    return {
+        "run_id": payload["run_id"],
+        "timestamp": payload["timestamp"],
+        "counts": _counts_document(payload["counts"]),
+        "drift": _drift_document(payload["drift"]),
+        "indexed": payload["indexed"],
+        "index_error": payload["index_error"],
+        "duration_ms": payload["duration_ms"],
+        "metrics": payload["metrics"],
+    }
 
 
 def build_run_payload(
@@ -44,12 +82,11 @@ def build_run_payload(
 ) -> RunPayload:
     """Create the canonical persisted payload for a completed pipeline run."""
     drift = state.finalize()
-    counts = cast(RunCountsPayload, state.counts.to_dict())
     return {
         "run_id": uuid4().hex,
         "timestamp": int(time.time()),
-        "counts": counts,
-        "drift": drift.to_dict(),
+        "counts": state.counts.to_payload(),
+        "drift": drift.to_payload(),
         "indexed": index_outcome.indexed,
         "index_error": index_outcome.error,
         "duration_ms": duration_ms,
@@ -79,13 +116,13 @@ async def persist_run_result(
             run_id=str(run_payload["run_id"]),
             timestamp=str(run_payload["timestamp"]),
             plan_snapshot=plan.model_dump(mode="json") if plan else None,
-            counts=cast(dict[str, object], dict(run_payload["counts"])),
-            drift=cast(dict[str, object], dict(run_payload["drift"])),
+            counts=dict(run_payload["counts"]),
+            drift=dict(run_payload["drift"]),
             indexed=index_outcome.indexed,
             duration_ms=duration_ms,
         ),
     )
-    run_path = write_run_json(config.archive_root, cast(dict[str, object], dict(run_payload)))
+    run_path = write_run_json(config.archive_root, _run_payload_document(run_payload))
     return RunResult(
         run_id=str(run_payload["run_id"]),
         counts=state.counts.model_copy(deep=True),

--- a/polylogue/pipeline/run_stages.py
+++ b/polylogue/pipeline/run_stages.py
@@ -6,9 +6,12 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from typing_extensions import TypedDict
-
 from polylogue.config import Config
+from polylogue.pipeline.payload_types import (
+    MaterializeStageObservation,
+    RenderStageObservation,
+    SiteBuildOptions,
+)
 from polylogue.pipeline.run_support import PARSE_STAGES
 from polylogue.storage.run_state import RenderFailurePayload
 from polylogue.types import SearchProvider
@@ -22,6 +25,7 @@ if TYPE_CHECKING:
     from polylogue.protocols import ProgressCallback
     from polylogue.storage.backends.async_sqlite import SQLiteBackend
     from polylogue.storage.repository import ConversationRepository
+    from polylogue.storage.session_product_runtime import SessionProductCounts
 
 
 @dataclass(slots=True)
@@ -29,7 +33,7 @@ class RenderStageOutcome:
     rendered_count: int
     failures: list[RenderFailurePayload]
     total: int
-    observation: dict[str, object] | None = None
+    observation: RenderStageObservation | None = None
 
 
 @dataclass(slots=True)
@@ -42,7 +46,7 @@ class SchemaGenerationOutcome:
 class MaterializeStageOutcome:
     item_count: int
     rebuilt: bool
-    observation: dict[str, object] | None = None
+    observation: MaterializeStageObservation | None = None
 
 
 @dataclass(slots=True)
@@ -67,15 +71,7 @@ class EmbedStageOutcome:
     stats_only: bool = False
 
 
-class _SiteOptions(TypedDict, total=False):
-    output: Path
-    title: str
-    search: bool
-    search_provider: str | SearchProvider
-    dashboard: bool
-
-
-def _site_option_path(options: dict[str, object], key: str, *, default: Path) -> Path:
+def _site_option_path(options: SiteBuildOptions, key: str, *, default: Path) -> Path:
     value = options.get(key)
     if isinstance(value, Path):
         return value
@@ -84,18 +80,18 @@ def _site_option_path(options: dict[str, object], key: str, *, default: Path) ->
     return default
 
 
-def _site_option_str(options: dict[str, object], key: str, *, default: str) -> str:
+def _site_option_str(options: SiteBuildOptions, key: str, *, default: str) -> str:
     value = options.get(key)
     return value if isinstance(value, str) and value.strip() else default
 
 
-def _site_option_bool(options: dict[str, object], key: str, *, default: bool) -> bool:
+def _site_option_bool(options: SiteBuildOptions, key: str, *, default: bool) -> bool:
     value = options.get(key)
     return value if isinstance(value, bool) else default
 
 
 def _site_option_search_provider(
-    options: dict[str, object],
+    options: SiteBuildOptions,
     *,
     default: SearchProvider,
 ) -> SearchProvider:
@@ -105,6 +101,22 @@ def _site_option_search_provider(
     if isinstance(value, str) and value.strip():
         return SearchProvider.from_string(value)
     return default
+
+
+def _materialize_rebuild_observation(
+    *,
+    mode: str,
+    counts: SessionProductCounts,
+) -> MaterializeStageObservation:
+    return {
+        "mode": mode,
+        "profiles": counts.profiles,
+        "work_events": counts.work_events,
+        "phases": counts.phases,
+        "threads": counts.threads,
+        "tag_rollups": counts.tag_rollups,
+        "day_summaries": counts.day_summaries,
+    }
 
 
 async def execute_acquire_stage(
@@ -211,7 +223,7 @@ async def execute_materialize_stage(
             return MaterializeStageOutcome(
                 item_count=len(conversation_ids),
                 rebuilt=True,
-                observation={"mode": "rebuild-from-empty", **counts.to_dict()},
+                observation=_materialize_rebuild_observation(mode="rebuild-from-empty", counts=counts),
             )
 
         observation = await refresh_session_products_bulk(backend, conversation_ids)
@@ -255,7 +267,7 @@ async def execute_materialize_stage(
     return MaterializeStageOutcome(
         item_count=counts.profiles,
         rebuilt=True,
-        observation={"mode": "rebuild", **counts.to_dict()},
+        observation=_materialize_rebuild_observation(mode="rebuild", counts=counts),
     )
 
 
@@ -300,7 +312,7 @@ async def execute_render_stage(
         total=render_total,
         progress_callback=progress_callback,
     )
-    observation: dict[str, object] = {"workers": render_result.worker_count}
+    observation: RenderStageObservation = {"workers": render_result.worker_count}
     if render_result.rss_start_mb is not None:
         observation["rss_start_mb"] = render_result.rss_start_mb
     if render_result.rss_end_mb is not None:
@@ -383,14 +395,14 @@ async def execute_site_stage(
     *,
     backend: SQLiteBackend,
     repository: ConversationRepository,
-    site_options: dict[str, object] | None = None,
+    site_options: SiteBuildOptions | None = None,
     progress_callback: ProgressCallback | None = None,
 ) -> SiteStageOutcome:
     """Build a static HTML site from the archive."""
     from polylogue.paths import data_home
     from polylogue.site.builder import SiteBuilder, SiteConfig
 
-    opts = site_options or {}
+    opts: SiteBuildOptions = site_options or {}
     output_path = _site_option_path(opts, "output", default=data_home() / "site")
     config = SiteConfig(
         title=_site_option_str(opts, "title", default="Polylogue Archive"),

--- a/polylogue/pipeline/run_support.py
+++ b/polylogue/pipeline/run_support.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import TypeVar
 
 from polylogue.config import Config, Source
-from polylogue.lib.json import dumps
+from polylogue.lib.json import JSONDocument, dumps
 from polylogue.sync_bridge import run_coroutine_sync
 
 T = TypeVar("T")
@@ -80,12 +80,15 @@ def normalize_stage_sequence(
     return normalized
 
 
-def write_run_json(archive_root: Path, payload: dict[str, object]) -> Path:
+def write_run_json(archive_root: Path, payload: JSONDocument) -> Path:
     """Write run result JSON to the runs directory."""
     runs_dir = archive_root / "runs"
     runs_dir.mkdir(parents=True, exist_ok=True)
-    run_id = payload.get("run_id", "unknown")
-    run_path = runs_dir / f"run-{payload['timestamp']}-{run_id}.json"
+    run_id_value = payload.get("run_id")
+    run_id = run_id_value if isinstance(run_id_value, str) and run_id_value else "unknown"
+    timestamp_value = payload.get("timestamp")
+    timestamp = int(timestamp_value) if isinstance(timestamp_value, int) else 0
+    run_path = runs_dir / f"run-{timestamp}-{run_id}.json"
     run_path.write_text(dumps(payload, option=None), encoding="utf-8")
     return run_path
 

--- a/polylogue/pipeline/services/__init__.py
+++ b/polylogue/pipeline/services/__init__.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from .acquisition import AcquireResult, AcquisitionService
     from .indexing import IndexService
-    from .parsing import IngestPhase, IngestState, ParseResult, ParsingService
+    from .parsing import IngestPhase, IngestResult, IngestState, ParseResult, ParsingService
     from .planning import IngestPlan, PlanningService
     from .rendering import RenderResult, RenderService
     from .validation import ValidateResult, ValidationService
@@ -20,6 +20,7 @@ def __getattr__(name: str) -> object:
         "IndexService": ("polylogue.pipeline.services.indexing", "IndexService"),
         "IngestPlan": ("polylogue.pipeline.services.planning", "IngestPlan"),
         "IngestPhase": ("polylogue.pipeline.services.parsing", "IngestPhase"),
+        "IngestResult": ("polylogue.pipeline.services.parsing", "IngestResult"),
         "IngestState": ("polylogue.pipeline.services.parsing", "IngestState"),
         "ParseResult": ("polylogue.pipeline.services.parsing", "ParseResult"),
         "ParsingService": ("polylogue.pipeline.services.parsing", "ParsingService"),
@@ -43,6 +44,7 @@ __all__ = [
     "IndexService",
     "IngestPlan",
     "IngestPhase",
+    "IngestResult",
     "IngestState",
     "ParseResult",
     "ParsingService",

--- a/polylogue/pipeline/services/acquisition.py
+++ b/polylogue/pipeline/services/acquisition.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, cast
 
+from polylogue.lib.json import JSONDocument
 from polylogue.lib.metrics import read_peak_rss_self_mb
 from polylogue.logging import get_logger
+from polylogue.pipeline.payload_types import AcquireSplitPayloadSummary
 from polylogue.pipeline.services.acquisition_persistence import persist_raw_record
 from polylogue.pipeline.services.acquisition_records import ScanResult
 from polylogue.pipeline.services.acquisition_streams import iter_raw_record_stream
@@ -67,7 +69,7 @@ class AcquisitionService:
         drive_config: DriveConfig | None = None,
         progress_label: str = "Scanning",
         on_record: Callable[[RawConversationRecord], Awaitable[None]] | None = None,
-        observation_callback: Callable[[dict[str, object]], None] | None = None,
+        observation_callback: Callable[[JSONDocument], None] | None = None,
     ) -> ScanResult:
         """Visit source raw payloads incrementally without forcing list materialization."""
         result = ScanResult()
@@ -136,10 +138,10 @@ class AcquisitionService:
         # reduce commit frequency and async thread-crossing overhead.
         flush_interval = 500
         items_since_flush = 0
-        peak_observation: dict[str, object] | None = None
+        peak_observation: JSONDocument | None = None
         observation_count = 0
         peak_baseline = read_peak_rss_self_mb() or 0.0
-        split_payload_summary = {
+        split_payload_totals = {
             "count": 0,
             "total_blob_mb": 0.0,
             "max_blob_mb": 0.0,
@@ -151,15 +153,15 @@ class AcquisitionService:
             "max_serialize_ms": 0.0,
         }
 
-        def _observe(observation: dict[str, object]) -> None:
+        def _observe(observation: JSONDocument) -> None:
             nonlocal peak_observation, observation_count, peak_baseline
             observation_count += 1
             if observation.get("phase") == "zip-entry-split-payload-serialized":
-                split_payload_summary["count"] += 1
+                split_payload_totals["count"] += 1
                 blob_mb = observation.get("blob_mb")
                 if isinstance(blob_mb, int | float):
-                    split_payload_summary["total_blob_mb"] += float(blob_mb)
-                    split_payload_summary["max_blob_mb"] = max(split_payload_summary["max_blob_mb"], float(blob_mb))
+                    split_payload_totals["total_blob_mb"] += float(blob_mb)
+                    split_payload_totals["max_blob_mb"] = max(split_payload_totals["max_blob_mb"], float(blob_mb))
                 for field, total_key, max_key in (
                     ("detect_provider_ms", "total_detect_provider_ms", "max_detect_provider_ms"),
                     ("classify_ms", "total_classify_ms", "max_classify_ms"),
@@ -167,8 +169,8 @@ class AcquisitionService:
                 ):
                     value = observation.get(field)
                     if isinstance(value, int | float):
-                        split_payload_summary[total_key] += float(value)
-                        split_payload_summary[max_key] = max(split_payload_summary[max_key], float(value))
+                        split_payload_totals[total_key] += float(value)
+                        split_payload_totals[max_key] = max(split_payload_totals[max_key], float(value))
             peak_rss_self_mb = observation.get("peak_rss_self_mb")
             if not isinstance(peak_rss_self_mb, int | float):
                 return
@@ -205,10 +207,17 @@ class AcquisitionService:
         if peak_observation is not None:
             result.diagnostics["peak_observation"] = peak_observation
             result.diagnostics["observation_count"] = observation_count
-        if split_payload_summary["count"]:
-            result.diagnostics["split_payload_summary"] = {
-                key: round(value, 3) if isinstance(value, float) else value
-                for key, value in split_payload_summary.items()
-            }
+        if split_payload_totals["count"]:
+            result.diagnostics["split_payload_summary"] = AcquireSplitPayloadSummary(
+                count=int(split_payload_totals["count"]),
+                total_blob_mb=round(split_payload_totals["total_blob_mb"], 3),
+                max_blob_mb=round(split_payload_totals["max_blob_mb"], 3),
+                total_detect_provider_ms=round(split_payload_totals["total_detect_provider_ms"], 3),
+                total_classify_ms=round(split_payload_totals["total_classify_ms"], 3),
+                total_serialize_ms=round(split_payload_totals["total_serialize_ms"], 3),
+                max_detect_provider_ms=round(split_payload_totals["max_detect_provider_ms"], 3),
+                max_classify_ms=round(split_payload_totals["max_classify_ms"], 3),
+                max_serialize_ms=round(split_payload_totals["max_serialize_ms"], 3),
+            )
 
         return result

--- a/polylogue/pipeline/services/acquisition_records.py
+++ b/polylogue/pipeline/services/acquisition_records.py
@@ -4,17 +4,24 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
+from typing_extensions import TypedDict
+
 from polylogue.lib.provider_identity import canonical_acquisition_provider
 from polylogue.sources.parsers.base import RawConversationData
 from polylogue.storage.cursor_state import CursorStatePayload
 from polylogue.storage.store import RawConversationRecord
 
 
+class ScanCounts(TypedDict):
+    scanned: int
+    errors: int
+
+
 class ScanResult:
     """Result of scanning raw payloads from sources without persisting them."""
 
     def __init__(self) -> None:
-        self.counts: dict[str, int] = {
+        self.counts: ScanCounts = {
             "scanned": 0,
             "errors": 0,
         }
@@ -60,4 +67,4 @@ def make_raw_record(
     )
 
 
-__all__ = ["ScanResult", "make_raw_record"]
+__all__ = ["ScanCounts", "ScanResult", "make_raw_record"]

--- a/polylogue/pipeline/services/acquisition_streams.py
+++ b/polylogue/pipeline/services/acquisition_streams.py
@@ -9,6 +9,7 @@ from functools import partial
 from itertools import islice
 from typing import TYPE_CHECKING
 
+from polylogue.lib.json import JSONDocument
 from polylogue.logging import get_logger
 from polylogue.pipeline.services.acquisition_records import make_raw_record
 from polylogue.sources.parsers.base import RawConversationData
@@ -20,7 +21,7 @@ if TYPE_CHECKING:
     from polylogue.sources.drive_types import DriveConfigLike, DriveUILike
 
 logger = get_logger(__name__)
-ObservationCallback = Callable[[dict[str, object]], None]
+ObservationCallback = Callable[[JSONDocument], None]
 
 
 def _drain_batch(

--- a/polylogue/pipeline/services/ingest_batch.py
+++ b/polylogue/pipeline/services/ingest_batch.py
@@ -19,7 +19,7 @@ from concurrent.futures import Future, as_completed
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, TypeAlias
+from typing import TYPE_CHECKING
 
 from polylogue.lib.metrics import (
     read_current_rss_mb,
@@ -28,6 +28,7 @@ from polylogue.lib.metrics import (
 )
 from polylogue.logging import get_logger
 from polylogue.paths import blob_store_root
+from polylogue.pipeline.payload_types import MaterializeStageObservation, ParseBatchObservation
 from polylogue.pipeline.services.ingest_worker import (
     ConversationData,
     ConversationTuple,
@@ -60,8 +61,6 @@ _DEFAULT_INGEST_WORKER_LIMIT = 8
 _INGEST_SOFT_BLOB_LIMIT_BYTES = 48 * 1024 * 1024
 _INGEST_HIGH_BLOB_LIMIT_BYTES = 96 * 1024 * 1024
 _INGEST_EXTREME_BLOB_LIMIT_BYTES = 256 * 1024 * 1024
-
-BatchObservation: TypeAlias = dict[str, object]
 
 
 @dataclass(slots=True)
@@ -783,8 +782,8 @@ def _build_batch_memory_observation(
     peak_rss_self_end_mb: float | None,
     peak_rss_children_mb: float | None,
     max_current_rss_mb: float | None,
-) -> BatchObservation:
-    observation: BatchObservation = {}
+) -> ParseBatchObservation:
+    observation: ParseBatchObservation = {}
     if rss_start_mb is not None:
         observation["rss_start_mb"] = rss_start_mb
     if rss_end_mb is not None:
@@ -813,7 +812,7 @@ async def process_ingest_batch(
     batch_ids: list[str],
     result: ParseResult,
     progress_callback: ProgressCallback | None,
-) -> BatchObservation | None:
+) -> ParseBatchObservation | None:
     """Process a batch of raw records through the unified ingest pipeline.
 
     1. Submit all records to ProcessPool (decode + validate + parse + transform)
@@ -896,7 +895,7 @@ async def process_ingest_batch(
     rss_end_mb = read_current_rss_mb()
     peak_rss_self_end_mb = read_peak_rss_self_mb()
     peak_rss_children_mb = read_peak_rss_children_mb()
-    observation: BatchObservation = {
+    observation: ParseBatchObservation = {
         "records": batch_summary.raw_record_count,
         "blob_mb": round(batch_summary.total_blob_mb, 1),
         "result_mb": round(batch_summary.total_result_bytes / (1024 * 1024), 3),
@@ -1028,7 +1027,7 @@ async def _persist_batch_raw_state_updates(
 async def refresh_session_products_bulk(
     backend: SQLiteBackend,
     changed_conversation_ids: list[str],
-) -> BatchObservation | None:
+) -> MaterializeStageObservation | None:
     """Bulk session product refresh — once after all batches, not per-batch."""
     if not changed_conversation_ids:
         return None
@@ -1078,7 +1077,7 @@ async def refresh_session_products_bulk(
         chunk_hydrate_values = [chunk.hydrate_ms for chunk in chunk_observations]
         chunk_build_values = [chunk.build_ms for chunk in chunk_observations]
         chunk_write_values = [chunk.write_ms for chunk in chunk_observations]
-        observation: BatchObservation = {
+        observation: MaterializeStageObservation = {
             "conversations": len(changed_conversation_ids),
             "unique_thread_roots": len(thread_root_ids),
             "unique_provider_days": len(affected_groups),

--- a/polylogue/pipeline/services/parsing_models.py
+++ b/polylogue/pipeline/services/parsing_models.py
@@ -4,10 +4,16 @@ import asyncio
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
+
+from polylogue.pipeline.payload_types import IngestDiagnostics, ParseBatchObservation
 
 if TYPE_CHECKING:
     from polylogue.pipeline.stage_models import AcquireResult, ValidateResult
+
+
+def _empty_ingest_diagnostics() -> IngestDiagnostics:
+    return {}
 
 
 class IngestPhase(str, Enum):
@@ -104,7 +110,7 @@ class ParseResult:
         # Tracks conversation IDs whose content changed so downstream
         # materialization can refresh derived session-product rows explicitly.
         self._changed_conversation_ids: list[str] = []
-        self.batch_observations: list[dict[str, Any]] = []
+        self.batch_observations: list[ParseBatchObservation] = []
 
     async def merge_result(
         self,
@@ -138,7 +144,7 @@ class IngestResult:
     parse_result: ParseResult
     parse_raw_ids: list[str]
     timings: dict[str, float] = field(default_factory=dict)
-    diagnostics: dict[str, Any] = field(default_factory=dict)
+    diagnostics: IngestDiagnostics = field(default_factory=_empty_ingest_diagnostics)
 
 
 __all__ = ["IngestPhase", "IngestResult", "IngestState", "ParseResult"]

--- a/polylogue/pipeline/services/parsing_workflow.py
+++ b/polylogue/pipeline/services/parsing_workflow.py
@@ -13,6 +13,7 @@ from collections.abc import AsyncIterator, Iterable, Iterator
 from typing import TYPE_CHECKING
 
 from polylogue.logging import get_logger
+from polylogue.pipeline.payload_types import ParseBatchObservation, ParseBatchObservationSummary
 from polylogue.pipeline.run_support import PARSE_STAGES
 from polylogue.pipeline.services.parsing_models import IngestResult, IngestState, ParseResult
 
@@ -94,12 +95,12 @@ def _append_unique_raw_ids(
 
 
 def _summarize_batch_observations(
-    batch_observations: list[dict[str, object]],
-) -> dict[str, object]:
+    batch_observations: list[ParseBatchObservation],
+) -> ParseBatchObservationSummary:
     if not batch_observations:
         return {}
 
-    def _observation_float(observation: dict[str, object], field: str) -> float | None:
+    def _observation_float(observation: ParseBatchObservation, field: str) -> float | None:
         value = observation.get(field)
         if value is None:
             return None
@@ -126,18 +127,26 @@ def _summarize_batch_observations(
         if elapsed_ms is not None and elapsed_ms >= 2000.0:
             slow_batch_count += 1
 
-    return {
+    summary: ParseBatchObservationSummary = {
         "batch_count": len(batch_observations),
         "slow_batch_count": slow_batch_count,
-        "max_elapsed_ms": _max_float("elapsed_ms"),
-        "max_blob_mb": _max_float("blob_mb"),
-        "max_result_mb": _max_float("max_result_mb"),
-        "max_current_rss_mb": _max_float("max_current_rss_mb"),
-        "max_rss_end_mb": _max_float("rss_end_mb"),
-        "max_rss_delta_mb": _max_float("rss_delta_mb"),
-        "max_peak_rss_growth_mb": _max_float("peak_rss_growth_mb"),
         "batches": batch_observations,
     }
+    if (value := _max_float("elapsed_ms")) is not None:
+        summary["max_elapsed_ms"] = value
+    if (value := _max_float("blob_mb")) is not None:
+        summary["max_blob_mb"] = value
+    if (value := _max_float("max_result_mb")) is not None:
+        summary["max_result_mb"] = value
+    if (value := _max_float("max_current_rss_mb")) is not None:
+        summary["max_current_rss_mb"] = value
+    if (value := _max_float("rss_end_mb")) is not None:
+        summary["max_rss_end_mb"] = value
+    if (value := _max_float("rss_delta_mb")) is not None:
+        summary["max_rss_delta_mb"] = value
+    if (value := _max_float("peak_rss_growth_mb")) is not None:
+        summary["max_peak_rss_growth_mb"] = value
+    return summary
 
 
 async def ingest_sources(

--- a/polylogue/pipeline/stage_models.py
+++ b/polylogue/pipeline/stage_models.py
@@ -5,10 +5,15 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
+from polylogue.pipeline.payload_types import AcquireDiagnostics
 from polylogue.types import Provider, ValidationStatus
 
 if TYPE_CHECKING:
     from polylogue.sources.parsers.base import ParsedConversation
+
+
+def _empty_acquire_diagnostics() -> AcquireDiagnostics:
+    return {}
 
 
 @dataclass(slots=True)
@@ -19,7 +24,7 @@ class AcquireResult:
     skipped: int = 0
     errors: int = 0
     raw_ids: list[str] = field(default_factory=list)
-    diagnostics: dict[str, object] = field(default_factory=dict)
+    diagnostics: AcquireDiagnostics = field(default_factory=_empty_acquire_diagnostics)
 
     @property
     def counts(self) -> dict[str, int]:

--- a/polylogue/sources/assembly.py
+++ b/polylogue/sources/assembly.py
@@ -6,10 +6,9 @@ can implement for sidecar discovery and post-parse enrichment.
 
 from __future__ import annotations
 
-from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Protocol, TypeAlias
+from typing import TYPE_CHECKING, Protocol, TypeAlias
 
 from typing_extensions import TypedDict
 
@@ -20,15 +19,20 @@ from .parsers.base import ParsedConversation
 if TYPE_CHECKING:
     from .parsers.claude_index import SessionIndexEntry
 
-SidecarData: TypeAlias = dict[str, Any]
+ClaudeCodeSessionIndex: TypeAlias = dict[str, "SessionIndexEntry"]
+CodexThreadNames: TypeAlias = dict[str, str]
 
 
 class _ClaudeCodeSidecarData(TypedDict, total=False):
-    session_index: dict[str, SessionIndexEntry]
+    session_index: ClaudeCodeSessionIndex
 
 
 class _CodexSidecarData(TypedDict, total=False):
-    thread_names: dict[str, str]
+    thread_names: CodexThreadNames
+
+
+class SidecarData(_ClaudeCodeSidecarData, _CodexSidecarData, total=False):
+    pass
 
 
 @dataclass(frozen=True, slots=True)
@@ -52,7 +56,7 @@ class ProviderAssemblySpec(Protocol):
     def enrich_conversation(
         self,
         conv: ParsedConversation,
-        sidecar_data: Mapping[str, Any],
+        sidecar_data: SidecarData,
     ) -> ParsedConversation:
         """Enrich a parsed conversation using discovered sidecar data."""
         ...
@@ -72,6 +76,8 @@ def get_assembly_spec(provider: Provider) -> ProviderAssemblySpec | None:
 
 
 __all__ = [
+    "ClaudeCodeSessionIndex",
+    "CodexThreadNames",
     "ProviderAssemblySpec",
     "SidecarData",
     "_CodexSidecarData",

--- a/polylogue/sources/assembly_claude_code.py
+++ b/polylogue/sources/assembly_claude_code.py
@@ -2,11 +2,9 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
 from pathlib import Path
-from typing import Any
 
-from .assembly import SidecarData
+from .assembly import ClaudeCodeSessionIndex, SidecarData
 from .parsers.base import ParsedConversation
 from .parsers.claude_index import (
     SessionIndexEntry,
@@ -38,30 +36,15 @@ class ClaudeCodeAssemblySpec:
     def enrich_conversation(
         self,
         conv: ParsedConversation,
-        sidecar_data: Mapping[str, Any],
+        sidecar_data: SidecarData,
     ) -> ParsedConversation:
         """Enrich a Claude Code conversation from the sessions-index sidecar."""
-        data = sidecar_data.get("session_index")
-        idx = _coerce_claude_code_session_index(data)
+        idx: ClaudeCodeSessionIndex = sidecar_data.get("session_index", {})
         if conv.provider_conversation_id in idx:
             return enrich_conversation_from_index(conv, idx[conv.provider_conversation_id])
         return conv
 
 
-def _coerce_claude_code_session_index(
-    value: object | None,
-) -> dict[str, SessionIndexEntry]:
-    """Best-effort coercion from dynamic sidecar data to session-index mapping."""
-    if not isinstance(value, dict):
-        return {}
-    result: dict[str, SessionIndexEntry] = {}
-    for session_id, entry in value.items():
-        if isinstance(session_id, str) and isinstance(entry, SessionIndexEntry):
-            result[session_id] = entry
-    return result
-
-
 __all__ = [
     "ClaudeCodeAssemblySpec",
-    "_coerce_claude_code_session_index",
 ]

--- a/polylogue/sources/assembly_codex.py
+++ b/polylogue/sources/assembly_codex.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 import json
 from collections.abc import Mapping
 from pathlib import Path
-from typing import Any, cast
 
+from polylogue.lib.json import json_document
 from polylogue.logging import get_logger
 
-from .assembly import SidecarData
+from .assembly import CodexThreadNames, SidecarData
 from .parsers.base import ParsedConversation
 
 logger = get_logger(__name__)
@@ -38,7 +38,7 @@ def _parse_codex_session_index(sessions_root: Path) -> dict[str, str]:
                 parsed = json.loads(line)
                 if not isinstance(parsed, dict):
                     continue
-                entry = cast(Mapping[str, object], parsed)
+                entry = json_document(parsed)
                 tid = _coerce_codex_session_id(entry)
                 name = _coerce_codex_thread_name(entry)
                 if tid and name:
@@ -72,10 +72,10 @@ class CodexAssemblySpec:
     def enrich_conversation(
         self,
         conv: ParsedConversation,
-        sidecar_data: Mapping[str, Any],
+        sidecar_data: SidecarData,
     ) -> ParsedConversation:
         """Enrich a Codex conversation with thread name or first-user-message title."""
-        thread_names = _coerce_thread_names(sidecar_data.get("thread_names"))
+        thread_names: CodexThreadNames = sidecar_data.get("thread_names", {})
         cid = conv.provider_conversation_id
 
         # Try thread name from side index
@@ -120,17 +120,6 @@ class CodexAssemblySpec:
                     )
 
         return conv
-
-
-def _coerce_thread_names(value: object | None) -> dict[str, str]:
-    """Best-effort coercion to a thread-name sidecar map."""
-    if not isinstance(value, dict):
-        return {}
-    result: dict[str, str] = {}
-    for thread_id, thread_name in value.items():
-        if isinstance(thread_id, str) and isinstance(thread_name, str):
-            result[thread_id] = thread_name
-    return result
 
 
 def _coerce_codex_session_id(entry: Mapping[str, object]) -> str | None:

--- a/polylogue/sources/cursor.py
+++ b/polylogue/sources/cursor.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from polylogue.logging import get_logger
+from polylogue.sources.assembly import SidecarData
 from polylogue.storage.cursor_state import CursorFailurePayload, CursorStatePayload
 from polylogue.types import Provider
 
@@ -128,7 +129,7 @@ class _ParseContext:
     fallback_id: str  # path.stem, used as fallback conversation ID
     file_mtime: str | None
     capture_raw: bool
-    sidecar_data: dict[str, object]
+    sidecar_data: SidecarData
 
 
 __all__ = [

--- a/polylogue/sources/source_acquisition.py
+++ b/polylogue/sources/source_acquisition.py
@@ -10,7 +10,7 @@ from typing import IO, BinaryIO, TypeAlias, cast
 
 from polylogue.config import Source
 from polylogue.lib.artifact_taxonomy import classify_artifact
-from polylogue.lib.json import JSONValue, is_json_value
+from polylogue.lib.json import JSONDocument, JSONValue, is_json_value
 from polylogue.lib.json import dumps_bytes as json_dumps_bytes
 from polylogue.lib.metrics import read_current_rss_mb, read_peak_rss_self_mb
 from polylogue.logging import get_logger
@@ -32,7 +32,7 @@ _decoders.logger = logger
 
 _DETECTION_PREFIX_SIZE = 8192  # 8 KB — enough for provider detection
 _HEARTBEAT_INTERVAL_S = 5.0
-AcquisitionObservation: TypeAlias = dict[str, object]
+AcquisitionObservation: TypeAlias = JSONDocument
 ObservationCallback: TypeAlias = Callable[[AcquisitionObservation], None]
 StatusCallback: TypeAlias = Callable[[str], None]
 CursorState: TypeAlias = CursorStatePayload
@@ -97,8 +97,10 @@ def _observe_acquisition(
         "source_index": source_index,
         "current_rss_mb": current_rss_mb,
         "peak_rss_self_mb": peak_rss_self_mb,
-        **extra,
     }
+    for key, value in extra.items():
+        if is_json_value(value):
+            payload[key] = value
     observation_callback(payload)
 
 

--- a/polylogue/sources/source_walk.py
+++ b/polylogue/sources/source_walk.py
@@ -18,6 +18,10 @@ _SUPPORTED_DOUBLE_EXTENSIONS = frozenset({".jsonl.txt"})
 _SKIP_DIRS = frozenset({"analysis", "__pycache__", ".git", "node_modules"})
 
 
+def _empty_sidecar_data() -> SidecarData:
+    return {}
+
+
 def _has_supported_extension(path: Path) -> bool:
     name_lower = path.name.lower()
     for ext in _SUPPORTED_DOUBLE_EXTENSIONS:
@@ -53,7 +57,7 @@ class _SourceWalkSetup:
     paths: list[Path]
     paths_to_process: list[tuple[Path, str | None]]
     skipped_mtime: int
-    sidecar_data: SidecarData = field(default_factory=dict)
+    sidecar_data: SidecarData = field(default_factory=_empty_sidecar_data)
 
 
 def _setup_source_walk(
@@ -73,7 +77,7 @@ def _setup_source_walk(
         include_file_mtime=include_mtime,
         known_mtimes=known_mtimes,
     )
-    sidecar_data: SidecarData = {}
+    sidecar_data = _empty_sidecar_data()
     if discover_sidecars:
         provider = Provider.from_string(source.name)
         spec = get_assembly_spec(provider)

--- a/polylogue/storage/run_state.py
+++ b/polylogue/storage/run_state.py
@@ -153,6 +153,24 @@ class PlanCounts(_SparseIntMap):
     render: int | None = None
     index: int | None = None
 
+    def to_payload(self) -> PlanCountsPayload:
+        payload: PlanCountsPayload = {}
+        if self.scan is not None:
+            payload["scan"] = self.scan
+        if self.store_raw is not None:
+            payload["store_raw"] = self.store_raw
+        if self.validate_count is not None:
+            payload["validate"] = self.validate_count
+        if self.parse is not None:
+            payload["parse"] = self.parse
+        if self.materialize is not None:
+            payload["materialize"] = self.materialize
+        if self.render is not None:
+            payload["render"] = self.render
+        if self.index is not None:
+            payload["index"] = self.index
+        return payload
+
 
 class PlanDetails(_SparseIntMap):
     new_raw: int | None = None
@@ -162,6 +180,24 @@ class PlanDetails(_SparseIntMap):
     backlog_parse: int | None = None
     preview_invalid: int | None = None
     preview_skipped_no_schema: int | None = None
+
+    def to_payload(self) -> PlanDetailsPayload:
+        payload: PlanDetailsPayload = {}
+        if self.new_raw is not None:
+            payload["new_raw"] = self.new_raw
+        if self.existing_raw is not None:
+            payload["existing_raw"] = self.existing_raw
+        if self.duplicate_raw is not None:
+            payload["duplicate_raw"] = self.duplicate_raw
+        if self.backlog_validate is not None:
+            payload["backlog_validate"] = self.backlog_validate
+        if self.backlog_parse is not None:
+            payload["backlog_parse"] = self.backlog_parse
+        if self.preview_invalid is not None:
+            payload["preview_invalid"] = self.preview_invalid
+        if self.preview_skipped_no_schema is not None:
+            payload["preview_skipped_no_schema"] = self.preview_skipped_no_schema
+        return payload
 
 
 class RunCounts(_SparseIntMap):
@@ -188,11 +224,49 @@ class RunCounts(_SparseIntMap):
     new_conversations: int | None = None
     changed_conversations: int | None = None
 
+    def to_payload(self) -> RunCountsPayload:
+        payload: RunCountsPayload = {}
+        for field_name in (
+            "conversations",
+            "messages",
+            "attachments",
+            "skipped_conversations",
+            "skipped_messages",
+            "skipped_attachments",
+            "acquired",
+            "skipped",
+            "acquire_errors",
+            "validated",
+            "validation_invalid",
+            "validation_drift",
+            "validation_skipped_no_schema",
+            "validation_errors",
+            "materialized",
+            "rendered",
+            "render_failures",
+            "parse_failures",
+            "schemas_generated",
+            "schemas_failed",
+            "new_conversations",
+            "changed_conversations",
+        ):
+            value = getattr(self, field_name)
+            if value is not None:
+                payload[field_name] = value
+        return payload
+
 
 class DriftBucket(_DenseIntMap):
     conversations: int = 0
     messages: int = 0
     attachments: int = 0
+
+    def to_payload(self) -> DriftBucketPayload:
+        return {
+            "conversations": self.conversations,
+            "messages": self.messages,
+            "attachments": self.attachments,
+        }
 
 
 class RunDrift(BaseModel):
@@ -203,10 +277,13 @@ class RunDrift(BaseModel):
     changed: DriftBucket = Field(default_factory=DriftBucket)
 
     def to_dict(self) -> RunDriftPayload:
+        return self.to_payload()
+
+    def to_payload(self) -> RunDriftPayload:
         return {
-            "new": cast(DriftBucketPayload, self.new.to_dict()),
-            "removed": cast(DriftBucketPayload, self.removed.to_dict()),
-            "changed": cast(DriftBucketPayload, self.changed.to_dict()),
+            "new": self.new.to_payload(),
+            "removed": self.removed.to_payload(),
+            "changed": self.changed.to_payload(),
         }
 
     def __getitem__(self, key: str) -> DriftBucket:

--- a/tests/unit/pipeline/test_parsing_service.py
+++ b/tests/unit/pipeline/test_parsing_service.py
@@ -13,6 +13,7 @@ import pytest
 
 from polylogue.config import Config, Source
 from polylogue.lib.raw_payload_decode import JSONValue
+from polylogue.pipeline.payload_types import ParseBatchObservation
 from polylogue.pipeline.services.acquisition import AcquireResult, AcquisitionService
 from polylogue.pipeline.services.acquisition_records import ScanResult
 from polylogue.pipeline.services.parsing import ParseResult, ParsingService
@@ -27,6 +28,21 @@ from polylogue.types import Provider
 WorkspacePaths = dict[str, Path]
 ConversationPayload = dict[str, JSONValue]
 VisitSourcesCallback = Callable[[RawConversationRecord], Awaitable[None]]
+
+
+def _parse_batch_observation(
+    *,
+    elapsed_ms: float,
+    blob_mb: float,
+    rss_end_mb: float,
+    peak_rss_growth_mb: float,
+) -> ParseBatchObservation:
+    return {
+        "elapsed_ms": elapsed_ms,
+        "blob_mb": blob_mb,
+        "rss_end_mb": rss_end_mb,
+        "peak_rss_growth_mb": peak_rss_growth_mb,
+    }
 
 
 class TestParseResultMerge:
@@ -99,7 +115,7 @@ class TestParsingServiceParseSources:
 
         acquire_result = AcquireResult()
         acquire_result.raw_ids = ["raw-1", "raw-2"]
-        acquire_result.counts["acquired"] = 2
+        acquire_result.acquired = 2
 
         with patch(
             "polylogue.pipeline.services.acquisition.AcquisitionService.acquire_sources",
@@ -149,12 +165,12 @@ class TestParsingServiceParseSources:
 
         parse_result = ParseResult()
         parse_result.batch_observations = [
-            {
-                "elapsed_ms": 123.4,
-                "blob_mb": 1.5,
-                "rss_end_mb": 42.0,
-                "peak_rss_growth_mb": 12.5,
-            }
+            _parse_batch_observation(
+                elapsed_ms=123.4,
+                blob_mb=1.5,
+                rss_end_mb=42.0,
+                peak_rss_growth_mb=12.5,
+            )
         ]
 
         with patch(
@@ -188,7 +204,7 @@ class TestParsingServiceParseSources:
 
         acquire_result = AcquireResult()
         acquire_result.raw_ids = ["raw-1", "raw-2", "raw-1"]
-        acquire_result.counts["acquired"] = 3
+        acquire_result.acquired = 3
 
         parse_backlog_calls: list[list[str]] = []
         validation_backlog_calls: list[list[str]] = []
@@ -237,7 +253,7 @@ class TestParsingServiceParseSources:
         service = ParsingService(repository=mock_repository, archive_root=Path("/tmp/archive"), config=mock_config)
 
         acquire_result = AcquireResult()
-        acquire_result.counts["skipped"] = 5
+        acquire_result.skipped = 5
         with patch(
             "polylogue.pipeline.services.acquisition.AcquisitionService.acquire_sources",
             new=AsyncMock(return_value=acquire_result),

--- a/tests/unit/pipeline/test_run_sources.py
+++ b/tests/unit/pipeline/test_run_sources.py
@@ -11,6 +11,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from polylogue.config import Config, Source
+from polylogue.pipeline.payload_types import IngestDiagnostics, MaterializeStageObservation
 from polylogue.pipeline.run_stages import (
     IndexStageOutcome,
     MaterializeStageOutcome,
@@ -21,6 +22,7 @@ from polylogue.pipeline.run_support import expand_requested_stage, normalize_sta
 from polylogue.pipeline.runner import _select_sources, latest_run, plan_sources, run_sources
 from polylogue.pipeline.services.parsing_models import IngestResult, ParseResult
 from polylogue.pipeline.stage_models import AcquireResult
+from polylogue.schemas.json_types import JSONDocument, JSONValue
 from polylogue.sources.parsers.base import RawConversationData
 from polylogue.storage.backends import create_backend
 from polylogue.storage.backends.async_sqlite import SQLiteBackend
@@ -31,6 +33,36 @@ from polylogue.types import PlanStage
 from tests.infra.storage_records import make_conversation, make_message, store_records
 
 WorkspaceEnv = Mapping[str, Path]
+
+
+def _run_json_payload(**payload: JSONValue) -> JSONDocument:
+    return payload
+
+
+def _ingest_diagnostics_with_batch_summary(
+    *,
+    batch_count: int,
+    slow_batch_count: int,
+) -> IngestDiagnostics:
+    return {
+        "batch_observations": {
+            "batch_count": batch_count,
+            "slow_batch_count": slow_batch_count,
+        }
+    }
+
+
+def _materialize_stage_observation(
+    *,
+    conversations: int,
+    chunk_count: int,
+    slow_chunk_count: int,
+) -> MaterializeStageObservation:
+    return {
+        "conversations": conversations,
+        "update_chunk_count": chunk_count,
+        "update_slow_chunk_count": slow_chunk_count,
+    }
 
 
 def _seed_conversations(workspace_env: WorkspaceEnv, *conversation_ids: str, with_message: bool = False) -> None:
@@ -212,16 +244,7 @@ def test_ingest_stage_log_omits_full_batch_telemetry(workspace_env: WorkspaceEnv
         parse_result=parse_result,
         parse_raw_ids=["raw-log"],
         timings={"acquire": 0.0, "ingest": 0.02},
-        diagnostics={
-            "batch_observations": {
-                "batch_count": 2,
-                "slow_batch_count": 1,
-                "batches": [
-                    {"elapsed_ms": 123.4, "blob_mb": 12.3},
-                    {"elapsed_ms": 456.7, "blob_mb": 45.6},
-                ],
-            }
-        },
+        diagnostics=_ingest_diagnostics_with_batch_summary(batch_count=2, slow_batch_count=1),
     )
     persisted_result = RunResult(
         run_id="test-run",
@@ -281,15 +304,7 @@ def test_materialize_stage_log_omits_full_chunk_telemetry(
     materialize_outcome = MaterializeStageOutcome(
         item_count=12,
         rebuilt=False,
-        observation={
-            "conversations": 12,
-            "update_chunk_count": 2,
-            "update_slow_chunk_count": 1,
-            "update_chunks": [
-                {"total_ms": 123.4, "conversation_count": 10},
-                {"total_ms": 456.7, "conversation_count": 2},
-            ],
-        },
+        observation=_materialize_stage_observation(conversations=12, chunk_count=2, slow_chunk_count=1),
     )
     persisted_result = RunResult(
         run_id="test-run",
@@ -1155,7 +1170,11 @@ class TestWriteRunJson:
 
         archive_root = tmp_path / "archive"
         archive_root.mkdir()
-        payload = {"run_id": "test-run-1", "timestamp": int(time.time()), "counts": {"conversations": 1}}
+        payload = _run_json_payload(
+            run_id="test-run-1",
+            timestamp=int(time.time()),
+            counts={"conversations": 1},
+        )
 
         result = _write_run_json(archive_root, payload)
         assert (archive_root / "runs").exists()
@@ -1169,12 +1188,12 @@ class TestWriteRunJson:
         archive_root = tmp_path / "archive"
         archive_root.mkdir()
         timestamp = int(time.time())
-        payload = {
-            "run_id": "abc123",
-            "timestamp": timestamp,
-            "counts": {"conversations": 10, "messages": 50},
-            "indexed": True,
-        }
+        payload = _run_json_payload(
+            run_id="abc123",
+            timestamp=timestamp,
+            counts={"conversations": 10, "messages": 50},
+            indexed=True,
+        )
 
         result_path = _write_run_json(archive_root, payload)
         content = json.loads(result_path.read_text())
@@ -1188,7 +1207,10 @@ class TestWriteRunJson:
 
         archive_root = tmp_path / "archive"
         archive_root.mkdir()
-        result = _write_run_json(archive_root, {"run_id": "myrun", "timestamp": 1704067200})
+        result = _write_run_json(
+            archive_root,
+            _run_json_payload(run_id="myrun", timestamp=1704067200),
+        )
         assert result.name == "run-1704067200-myrun.json"
 
 

--- a/tests/unit/sources/test_assembly.py
+++ b/tests/unit/sources/test_assembly.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import pytest
 
 from polylogue.lib.roles import Role
-from polylogue.sources.assembly import get_assembly_spec
+from polylogue.sources.assembly import SidecarData, get_assembly_spec
 from polylogue.sources.assembly_claude_code import ClaudeCodeAssemblySpec
 from polylogue.sources.assembly_codex import CodexAssemblySpec, _parse_codex_session_index
 from polylogue.sources.parsers.base import ParsedConversation, ParsedMessage
@@ -48,13 +48,13 @@ def _provider_meta(conversation: ParsedConversation) -> dict[str, object]:
     return conversation.provider_meta
 
 
-def _thread_sidecars(thread_names: dict[str, str] | None = None) -> dict[str, dict[str, str]]:
+def _thread_sidecars(thread_names: dict[str, str] | None = None) -> SidecarData:
     return {"thread_names": {} if thread_names is None else thread_names}
 
 
 def _session_sidecars(
     session_index: dict[str, SessionIndexEntry] | None = None,
-) -> dict[str, dict[str, SessionIndexEntry]]:
+) -> SidecarData:
     return {"session_index": {} if session_index is None else session_index}
 
 

--- a/tests/unit/sources/test_source_laws.py
+++ b/tests/unit/sources/test_source_laws.py
@@ -24,6 +24,7 @@ from polylogue.schemas.json_types import JSONDocument
 from polylogue.sources import decoders as decoders_module
 from polylogue.sources import dispatch as dispatch_module
 from polylogue.sources import source_acquisition
+from polylogue.sources.assembly import SidecarData
 from polylogue.sources.cursor import (
     _get_file_mtime,
     _initialize_cursor_state,
@@ -1201,7 +1202,7 @@ def _parse_context(
     source_path: str,
     fallback_id: str,
     capture_raw: bool = True,
-    sidecar_data: dict[str, object] | None = None,
+    sidecar_data: SidecarData | None = None,
 ) -> _ParseContext:
     return _ParseContext(
         provider_hint=Provider.from_string(provider_hint),
@@ -1926,7 +1927,7 @@ def test_iter_source_raw_data_reports_split_payload_observations(tmp_path: Path)
             ).encode("utf-8"),
         )
 
-    observations: list[dict[str, object]] = []
+    observations: list[JSONDocument] = []
 
     items = list(
         iter_source_raw_data(


### PR DESCRIPTION
## Summary
- tighten run/acquisition telemetry and stage payloads around explicit JSON and TypedDict contracts
- carry those contracts through source assembly sidecars and the affected pipeline/source tests
- keep the slice stacked on the schema/lib payload-boundary renewal

## Problem
The run and acquisition flow still relied on loosely shaped dictionaries and ad hoc payload coercion at key boundaries. Stage observations, run-state payload emission, sidecar enrichment, and a chunk of the downstream tests were all depending on inferred `dict[str, object]` shapes rather than stable typed contracts, which left the code path-dependent and brittle at both runtime and verification time.

## Solution
- add `polylogue/pipeline/payload_types.py` and thread its typed payload contracts through run execution, finalization, acquisition, parsing, ingest batching, source acquisition, and the run CLI
- tighten `run_state`, `metrics`, and stage outcome models so emitted run payloads and observation summaries are explicit JSON-shaped values instead of generic dict/cast plumbing
- replace loose source sidecar maps with typed Claude Code and Codex sidecar contracts, then align the pipeline/source tests with the new observation and run-json helpers

## Verification
- `ruff check polylogue/pipeline/payload_types.py polylogue/pipeline/stage_models.py polylogue/pipeline/services/parsing_models.py polylogue/lib/metrics.py polylogue/pipeline/run_support.py polylogue/pipeline/run_finalization.py polylogue/pipeline/run_stages.py polylogue/pipeline/run_execution.py polylogue/pipeline/services/acquisition.py polylogue/pipeline/services/acquisition_streams.py polylogue/pipeline/services/parsing_workflow.py polylogue/pipeline/services/ingest_batch.py polylogue/sources/source_acquisition.py polylogue/cli/run_workflow.py polylogue/cli/commands/run.py`
- `mypy polylogue/pipeline/payload_types.py polylogue/pipeline/stage_models.py polylogue/pipeline/services/parsing_models.py polylogue/lib/metrics.py polylogue/pipeline/run_support.py polylogue/pipeline/run_finalization.py polylogue/pipeline/run_stages.py polylogue/pipeline/run_execution.py polylogue/pipeline/services/acquisition.py polylogue/pipeline/services/acquisition_streams.py polylogue/pipeline/services/parsing_workflow.py polylogue/pipeline/services/ingest_batch.py polylogue/sources/source_acquisition.py polylogue/cli/run_workflow.py polylogue/cli/commands/run.py`
- `ruff check polylogue/pipeline/services/__init__.py polylogue/pipeline/services/acquisition_records.py polylogue/sources/assembly.py polylogue/sources/assembly_claude_code.py polylogue/sources/assembly_codex.py polylogue/sources/cursor.py polylogue/sources/source_walk.py tests/unit/pipeline/test_parsing_service.py tests/unit/pipeline/test_run_sources.py tests/unit/sources/test_assembly.py tests/unit/sources/test_source_laws.py`
- `mypy polylogue/pipeline/services/__init__.py polylogue/pipeline/services/acquisition_records.py polylogue/sources/assembly.py polylogue/sources/assembly_claude_code.py polylogue/sources/assembly_codex.py polylogue/sources/cursor.py polylogue/sources/source_walk.py tests/unit/pipeline/test_parsing_service.py tests/unit/pipeline/test_run_sources.py tests/unit/sources/test_assembly.py tests/unit/sources/test_source_laws.py`
- `pytest -q tests/unit/pipeline/test_parsing_service.py tests/unit/pipeline/test_run_sources.py tests/unit/sources/test_assembly.py tests/unit/sources/test_source_laws.py tests/unit/devtools/test_pipeline_probe.py`
- `devtools verify`

Ref #252
