### PR TITLE
refactor: rebuild schema generation and audit boundary contracts

### DIFF
--- a/polylogue/schemas/audit_checks.py
+++ b/polylogue/schemas/audit_checks.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+
 from polylogue.lib.outcomes import OutcomeCheck as CheckResult
 from polylogue.lib.outcomes import OutcomeStatus
 from polylogue.schemas.audit_walkers import _HEX_RE, _UUID_RE, SchemaNode, _walk_semantic_roles, _walk_values
@@ -9,11 +11,12 @@ from polylogue.schemas.json_types import json_document, json_document_list
 from polylogue.schemas.privacy import _is_safe_enum_value, _looks_high_entropy_token
 
 
-def check_privacy_guards(schema: SchemaNode) -> CheckResult:
+def check_privacy_guards(schema: Mapping[str, object] | SchemaNode) -> CheckResult:
     """Check that no UUIDs, hashes, or PII leak through enum values."""
     violations: list[str] = []
+    root = json_document(schema)
 
-    for path, values in _walk_values(schema):
+    for path, values in _walk_values(root):
         for v in values:
             if _UUID_RE.match(v):
                 violations.append(f"{path}: UUID leak {v!r}")
@@ -38,8 +41,8 @@ def check_privacy_guards(schema: SchemaNode) -> CheckResult:
     )
 
 
-def _schema_node_at_path(schema: SchemaNode, path: str) -> SchemaNode:
-    current = schema
+def _schema_node_at_path(schema: Mapping[str, object] | SchemaNode, path: str) -> SchemaNode:
+    current = json_document(schema)
     for part in path.split(".")[1:]:
         if part == "*":
             current = json_document(current.get("additionalProperties"))
@@ -54,14 +57,15 @@ def _schema_node_at_path(schema: SchemaNode, path: str) -> SchemaNode:
     return current
 
 
-def check_semantic_roles(schema: SchemaNode) -> CheckResult:
+def check_semantic_roles(schema: Mapping[str, object] | SchemaNode) -> CheckResult:
     """Check semantic role assignments for sanity."""
     issues: list[str] = []
-    roles = _walk_semantic_roles(schema)
+    root = json_document(schema)
+    roles = _walk_semantic_roles(root)
 
     for path, role, _confidence in roles:
         if role == "conversation_title":
-            current = _schema_node_at_path(schema, path)
+            current = _schema_node_at_path(root, path)
             fmt = current.get("x-polylogue-format")
 
             if fmt in ("uuid4", "uuid", "hex-id"):
@@ -93,7 +97,7 @@ def check_semantic_roles(schema: SchemaNode) -> CheckResult:
     )
 
 
-def check_annotation_coverage(schema: SchemaNode) -> CheckResult:
+def check_annotation_coverage(schema: Mapping[str, object] | SchemaNode) -> CheckResult:
     """Check that schema has adequate annotation coverage."""
     total_fields = 0
     annotated_fields = 0
@@ -127,7 +131,7 @@ def check_annotation_coverage(schema: SchemaNode) -> CheckResult:
             for child in json_document_list(node.get(keyword)):
                 _count(child)
 
-    _count(schema)
+    _count(json_document(schema))
 
     if total_fields == 0:
         return CheckResult(
@@ -155,16 +159,17 @@ def check_annotation_coverage(schema: SchemaNode) -> CheckResult:
     )
 
 
-def check_cross_provider_consistency(schemas: dict[str, SchemaNode]) -> CheckResult:
+def check_cross_provider_consistency(schemas: Mapping[str, Mapping[str, object] | SchemaNode]) -> CheckResult:
     """Check consistency across all provider schemas."""
     issues: list[str] = []
 
     for provider, schema in schemas.items():
-        roles = _walk_semantic_roles(schema)
+        root = json_document(schema)
+        roles = _walk_semantic_roles(root)
         if not roles:
             issues.append(f"{provider}: no semantic roles")
 
-        if not schema.get("x-polylogue-sample-count"):
+        if not root.get("x-polylogue-sample-count"):
             issues.append(f"{provider}: missing sample count")
 
     if issues:

--- a/polylogue/schemas/audit_checks.py
+++ b/polylogue/schemas/audit_checks.py
@@ -2,15 +2,14 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from polylogue.lib.outcomes import OutcomeCheck as CheckResult
 from polylogue.lib.outcomes import OutcomeStatus
-from polylogue.schemas.audit_walkers import _HEX_RE, _UUID_RE, _walk_semantic_roles, _walk_values
+from polylogue.schemas.audit_walkers import _HEX_RE, _UUID_RE, SchemaNode, _walk_semantic_roles, _walk_values
+from polylogue.schemas.json_types import json_document, json_document_list
 from polylogue.schemas.privacy import _is_safe_enum_value, _looks_high_entropy_token
 
 
-def check_privacy_guards(schema: dict[str, Any]) -> CheckResult:
+def check_privacy_guards(schema: SchemaNode) -> CheckResult:
     """Check that no UUIDs, hashes, or PII leak through enum values."""
     violations: list[str] = []
 
@@ -39,28 +38,31 @@ def check_privacy_guards(schema: dict[str, Any]) -> CheckResult:
     )
 
 
-def check_semantic_roles(schema: dict[str, Any]) -> CheckResult:
+def _schema_node_at_path(schema: SchemaNode, path: str) -> SchemaNode:
+    current = schema
+    for part in path.split(".")[1:]:
+        if part == "*":
+            current = json_document(current.get("additionalProperties"))
+            continue
+        if part.endswith("[*]"):
+            name = part[:-3]
+            if name:
+                current = json_document(json_document(current.get("properties")).get(name))
+            current = json_document(current.get("items"))
+            continue
+        current = json_document(json_document(current.get("properties")).get(part))
+    return current
+
+
+def check_semantic_roles(schema: SchemaNode) -> CheckResult:
     """Check semantic role assignments for sanity."""
     issues: list[str] = []
     roles = _walk_semantic_roles(schema)
 
     for path, role, _confidence in roles:
         if role == "conversation_title":
-            fmt = None
-            parts = path.split(".")
-            current = schema
-            for part in parts[1:]:
-                if part == "*":
-                    current = current.get("additionalProperties", {})
-                elif "[*]" in part:
-                    name = part.replace("[*]", "")
-                    if name:
-                        current = current.get("properties", {}).get(name, {})
-                    current = current.get("items", {})
-                else:
-                    current = current.get("properties", {}).get(part, {})
-            if isinstance(current, dict):
-                fmt = current.get("x-polylogue-format")
+            current = _schema_node_at_path(schema, path)
+            fmt = current.get("x-polylogue-format")
 
             if fmt in ("uuid4", "uuid", "hex-id"):
                 issues.append(f"{path}: {fmt}-format field assigned as {role}")
@@ -91,7 +93,7 @@ def check_semantic_roles(schema: dict[str, Any]) -> CheckResult:
     )
 
 
-def check_annotation_coverage(schema: dict[str, Any]) -> CheckResult:
+def check_annotation_coverage(schema: SchemaNode) -> CheckResult:
     """Check that schema has adequate annotation coverage."""
     total_fields = 0
     annotated_fields = 0
@@ -104,26 +106,26 @@ def check_annotation_coverage(schema: dict[str, Any]) -> CheckResult:
         "x-polylogue-multiline",
     }
 
-    def _count(s: dict[str, Any]) -> None:
+    def _count(node: SchemaNode) -> None:
         nonlocal total_fields, annotated_fields
-        if not isinstance(s, dict):
-            return
-        if "properties" in s:
-            for prop in s["properties"].values():
-                if isinstance(prop, dict):
-                    total_fields += 1
-                    if any(k in prop for k in annotation_keys):
-                        annotated_fields += 1
-                    _count(prop)
-        if isinstance(s.get("items"), dict):
-            _count(s["items"])
-        if isinstance(s.get("additionalProperties"), dict):
-            _count(s["additionalProperties"])
-        for kw in ("anyOf", "oneOf", "allOf"):
-            if kw in s:
-                for sub in s[kw]:
-                    if isinstance(sub, dict):
-                        _count(sub)
+        properties = json_document(node.get("properties"))
+        for prop in properties.values():
+            child = json_document(prop)
+            if not child:
+                continue
+            total_fields += 1
+            if any(key in child for key in annotation_keys):
+                annotated_fields += 1
+            _count(child)
+        items = json_document(node.get("items"))
+        if items:
+            _count(items)
+        additional_properties = json_document(node.get("additionalProperties"))
+        if additional_properties:
+            _count(additional_properties)
+        for keyword in ("anyOf", "oneOf", "allOf"):
+            for child in json_document_list(node.get(keyword)):
+                _count(child)
 
     _count(schema)
 
@@ -153,7 +155,7 @@ def check_annotation_coverage(schema: dict[str, Any]) -> CheckResult:
     )
 
 
-def check_cross_provider_consistency(schemas: dict[str, dict[str, Any]]) -> CheckResult:
+def check_cross_provider_consistency(schemas: dict[str, SchemaNode]) -> CheckResult:
     """Check consistency across all provider schemas."""
     issues: list[str] = []
 

--- a/polylogue/schemas/audit_walkers.py
+++ b/polylogue/schemas/audit_walkers.py
@@ -3,74 +3,81 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Any
+from typing import TypeAlias
 
+from polylogue.schemas.json_types import JSONDocument, JSONValue, json_document, json_document_list
 from polylogue.schemas.runtime_registry import SchemaRegistry
+
+SchemaPath = str
+SchemaStringValues = list[str]
+SchemaRoleRecord = tuple[SchemaPath, str, float]
+SchemaValueRecord = tuple[SchemaPath, SchemaStringValues]
+SchemaNode: TypeAlias = JSONDocument
 
 _UUID_RE = re.compile(
     r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
     re.IGNORECASE,
 )
 _HEX_RE = re.compile(r"^[0-9a-f]{16,}$", re.IGNORECASE)
+_SCHEMA_COMPOSITE_KEYWORDS = ("anyOf", "oneOf", "allOf")
 
 
-def _load_committed_schema(provider: str) -> dict[str, Any] | None:
+def _load_committed_schema(provider: str) -> SchemaNode | None:
     """Load a committed provider schema."""
     schema_root = Path(__file__).resolve().parent / "providers"
     return SchemaRegistry(storage_root=schema_root).get_schema(provider, version="default")
 
 
-def _walk_values(schema: dict[str, Any], path: str = "$") -> list[tuple[str, list[str]]]:
+def _string_values(value: JSONValue | None) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, str)]
+
+
+def _child_schema_nodes(schema: SchemaNode, path: SchemaPath) -> Iterable[tuple[SchemaPath, SchemaNode]]:
+    properties = json_document(schema.get("properties"))
+    for name, prop in properties.items():
+        child = json_document(prop)
+        if child:
+            yield f"{path}.{name}", child
+
+    additional_properties = json_document(schema.get("additionalProperties"))
+    if additional_properties:
+        yield f"{path}.*", additional_properties
+
+    items = json_document(schema.get("items"))
+    if items:
+        yield f"{path}[*]", items
+
+    for keyword in _SCHEMA_COMPOSITE_KEYWORDS:
+        for child in json_document_list(schema.get(keyword)):
+            yield path, child
+
+
+def _walk_values(schema: SchemaNode, path: SchemaPath = "$") -> list[SchemaValueRecord]:
     """Walk schema tree and collect all x-polylogue-values entries."""
-    results: list[tuple[str, list[str]]] = []
-    if not isinstance(schema, dict):
-        return results
+    results: list[SchemaValueRecord] = []
+    values = _string_values(schema.get("x-polylogue-values"))
+    if values:
+        results.append((path, values))
 
-    values = schema.get("x-polylogue-values")
-    if isinstance(values, list):
-        results.append((path, [str(v) for v in values]))
-
-    if "properties" in schema:
-        for name, prop in schema["properties"].items():
-            results.extend(_walk_values(prop, f"{path}.{name}"))
-    if isinstance(schema.get("additionalProperties"), dict):
-        results.extend(_walk_values(schema["additionalProperties"], f"{path}.*"))
-    if isinstance(schema.get("items"), dict):
-        results.extend(_walk_values(schema["items"], f"{path}[*]"))
-    for kw in ("anyOf", "oneOf", "allOf"):
-        if kw in schema:
-            for sub in schema[kw]:
-                if isinstance(sub, dict):
-                    results.extend(_walk_values(sub, path))
-
+    for child_path, child in _child_schema_nodes(schema, path):
+        results.extend(_walk_values(child, child_path))
     return results
 
 
-def _walk_semantic_roles(schema: dict[str, Any], path: str = "$") -> list[tuple[str, str, float]]:
+def _walk_semantic_roles(schema: SchemaNode, path: SchemaPath = "$") -> list[SchemaRoleRecord]:
     """Walk schema and collect (path, role, confidence) tuples."""
-    results: list[tuple[str, str, float]] = []
-    if not isinstance(schema, dict):
-        return results
-
+    results: list[SchemaRoleRecord] = []
     role = schema.get("x-polylogue-semantic-role")
     confidence = schema.get("x-polylogue-score", 0.0)
-    if role:
-        results.append((path, role, confidence))
+    if isinstance(role, str):
+        results.append((path, role, float(confidence) if isinstance(confidence, int | float) else 0.0))
 
-    if "properties" in schema:
-        for name, prop in schema["properties"].items():
-            results.extend(_walk_semantic_roles(prop, f"{path}.{name}"))
-    if isinstance(schema.get("additionalProperties"), dict):
-        results.extend(_walk_semantic_roles(schema["additionalProperties"], f"{path}.*"))
-    if isinstance(schema.get("items"), dict):
-        results.extend(_walk_semantic_roles(schema["items"], f"{path}[*]"))
-    for kw in ("anyOf", "oneOf", "allOf"):
-        if kw in schema:
-            for sub in schema[kw]:
-                if isinstance(sub, dict):
-                    results.extend(_walk_semantic_roles(sub, path))
-
+    for child_path, child in _child_schema_nodes(schema, path):
+        results.extend(_walk_semantic_roles(child, child_path))
     return results
 
 

--- a/polylogue/schemas/generation_cluster_support.py
+++ b/polylogue/schemas/generation_cluster_support.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from datetime import datetime, timezone
 
 from polylogue.schemas.generation_models import _ClusterAccumulator, _ProfileSummary
@@ -193,7 +194,7 @@ def _refine_coarse_clusters(
 
 def _update_cluster_reservoir(
     acc: _ClusterAccumulator,
-    sample: dict[str, object],
+    sample: Mapping[str, object],
     conversation_id: str | None,
     *,
     reservoir_size: int,

--- a/polylogue/schemas/generation_dynamic_keys.py
+++ b/polylogue/schemas/generation_dynamic_keys.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 try:
     from genson import SchemaBuilder
 
@@ -13,6 +11,7 @@ except ImportError:
     GENSON_AVAILABLE = False
 
 from polylogue.schemas.field_stats import is_dynamic_key
+from polylogue.schemas.json_types import JSONDocument, json_document, json_document_list
 
 _HIGH_CARDINALITY_KEY_THRESHOLD = 128
 _PATHLIKE_KEY_RATIO_THRESHOLD = 0.35
@@ -35,36 +34,33 @@ def _should_collapse_high_cardinality_keys(keys: list[str]) -> bool:
     return (pathlike / len(keys)) >= _PATHLIKE_KEY_RATIO_THRESHOLD
 
 
-def merge_schemas(schemas: list[dict[str, Any]]) -> dict[str, Any]:
+def merge_schemas(schemas: list[JSONDocument]) -> JSONDocument:
     """Merge multiple schemas into one using genson when available."""
     if not GENSON_AVAILABLE:
         return schemas[0] if schemas else {}
     builder = SchemaBuilder()
     for schema in schemas:
         builder.add_schema(schema)
-    return dict(builder.to_schema())
+    return json_document(builder.to_schema())
 
 
-def collapse_dynamic_keys(schema: dict[str, Any]) -> dict[str, Any]:
+def collapse_dynamic_keys(schema: JSONDocument) -> JSONDocument:
     """Collapse dynamic key properties into additionalProperties."""
-    if not isinstance(schema, dict):
-        return schema
+    properties = json_document(schema.get("properties"))
+    if properties:
+        static_props: JSONDocument = {}
+        dynamic_schemas: list[JSONDocument] = []
+        key_names = list(properties.keys())
 
-    if "properties" in schema:
-        props = schema["properties"]
-        static_props: dict[str, Any] = {}
-        dynamic_schemas: list[dict[str, Any]] = []
-        key_names = list(props.keys())
-
-        for key, value in props.items():
-            collapsed_value = collapse_dynamic_keys(value)
+        for key, value in properties.items():
+            collapsed_value = collapse_dynamic_keys(json_document(value))
             if is_dynamic_key(key):
                 dynamic_schemas.append(collapsed_value)
             else:
                 static_props[key] = collapsed_value
 
         if _should_collapse_high_cardinality_keys(key_names):
-            dynamic_schemas.extend(static_props.values())
+            dynamic_schemas.extend(json_document(value) for value in static_props.values() if json_document(value))
             static_props = {}
             schema["x-polylogue-high-cardinality-keys"] = True
 
@@ -72,20 +68,24 @@ def collapse_dynamic_keys(schema: dict[str, Any]) -> dict[str, Any]:
             schema["properties"] = static_props
             schema["additionalProperties"] = merge_schemas(dynamic_schemas)
             schema["x-polylogue-dynamic-keys"] = True
-            if "required" in schema:
-                schema["required"] = [required for required in schema["required"] if required in static_props]
+            required = schema.get("required")
+            if isinstance(required, list):
+                schema["required"] = [item for item in required if isinstance(item, str) and item in static_props]
         else:
             schema["properties"] = static_props
 
-    if "items" in schema:
-        schema["items"] = collapse_dynamic_keys(schema["items"])
+    items = json_document(schema.get("items"))
+    if items:
+        schema["items"] = collapse_dynamic_keys(items)
 
     for keyword in ("anyOf", "oneOf", "allOf"):
-        if keyword in schema:
-            schema[keyword] = [collapse_dynamic_keys(item) for item in schema[keyword]]
+        variants = json_document_list(schema.get(keyword))
+        if variants:
+            schema[keyword] = [collapse_dynamic_keys(item) for item in variants]
 
-    if "additionalProperties" in schema and isinstance(schema["additionalProperties"], dict):
-        schema["additionalProperties"] = collapse_dynamic_keys(schema["additionalProperties"])
+    additional_properties = json_document(schema.get("additionalProperties"))
+    if additional_properties:
+        schema["additionalProperties"] = collapse_dynamic_keys(additional_properties)
 
     return schema
 

--- a/polylogue/schemas/generation_models.py
+++ b/polylogue/schemas/generation_models.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import random
-from collections.abc import Mapping
 from collections import Counter
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 

--- a/polylogue/schemas/generation_models.py
+++ b/polylogue/schemas/generation_models.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import random
+from collections.abc import Mapping
 from collections import Counter
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
@@ -63,7 +64,7 @@ class _ClusterAccumulator:
     representative_paths: list[str] = field(default_factory=list)
     profile_token_counts: Counter[str] = field(default_factory=Counter)
     member_profiles: set[tuple[str, ...]] = field(default_factory=set)
-    reservoir_samples: list[JSONDocument] = field(default_factory=list)
+    reservoir_samples: list[Mapping[str, object]] = field(default_factory=list)
     reservoir_conv_ids: list[str | None] = field(default_factory=list)
     rng: random.Random = field(default_factory=lambda: random.Random(42))
     exact_structure_ids: set[str] = field(default_factory=set)

--- a/polylogue/schemas/generation_models.py
+++ b/polylogue/schemas/generation_models.py
@@ -5,11 +5,15 @@ from __future__ import annotations
 import random
 from collections import Counter
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING
 
+from polylogue.schemas.json_types import JSONDocument
 from polylogue.schemas.observation import SchemaUnit
 from polylogue.schemas.packages import SchemaPackageCatalog
 from polylogue.schemas.registry import ClusterManifest
+
+if TYPE_CHECKING:
+    from polylogue.schemas.redaction_report import SchemaReport
 
 
 @dataclass
@@ -17,10 +21,10 @@ class GenerationResult:
     """Result of schema generation."""
 
     provider: str
-    schema: dict[str, Any] | None
+    schema: JSONDocument | None
     sample_count: int
     error: str | None = None
-    redaction_report: Any | None = None
+    redaction_report: SchemaReport | None = None
     versions: list[str] = field(default_factory=list)
     default_version: str | None = None
     cluster_count: int = 0
@@ -36,7 +40,7 @@ class GenerationResult:
 class _ProviderBundle:
     result: GenerationResult
     catalog: SchemaPackageCatalog | None = None
-    package_schemas: dict[str, dict[str, dict[str, Any]]] = field(default_factory=dict)
+    package_schemas: dict[str, dict[str, JSONDocument]] = field(default_factory=dict)
     manifest: ClusterManifest | None = None
 
 
@@ -59,7 +63,7 @@ class _ClusterAccumulator:
     representative_paths: list[str] = field(default_factory=list)
     profile_token_counts: Counter[str] = field(default_factory=Counter)
     member_profiles: set[tuple[str, ...]] = field(default_factory=set)
-    reservoir_samples: list[dict[str, Any]] = field(default_factory=list)
+    reservoir_samples: list[JSONDocument] = field(default_factory=list)
     reservoir_conv_ids: list[str | None] = field(default_factory=list)
     rng: random.Random = field(default_factory=lambda: random.Random(42))
     exact_structure_ids: set[str] = field(default_factory=set)

--- a/polylogue/schemas/generation_provider_bundle.py
+++ b/polylogue/schemas/generation_provider_bundle.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
 
 from polylogue.paths import db_path as archive_db_path
 from polylogue.schemas.generation_cluster_collection import (
@@ -22,7 +21,7 @@ from polylogue.schemas.generation_provider_bundle_packages import (
     build_provider_catalog_artifacts,
     build_success_provider_bundle,
 )
-from polylogue.schemas.generation_support import GENSON_AVAILABLE
+from polylogue.schemas.generation_support import GENSON_AVAILABLE, PrivacyConfigLike
 from polylogue.schemas.observation import PROVIDERS, ProviderConfig, resolve_provider_config
 from polylogue.schemas.registry import ClusterManifest, SchemaCluster
 from polylogue.types import Provider
@@ -56,7 +55,7 @@ def _build_provider_bundle(
     *,
     db_path: Path | None,
     max_samples: int | None,
-    privacy_config: Any | None,
+    privacy_config: PrivacyConfigLike | None,
     full_corpus: bool = False,
 ) -> _ProviderBundle:
     """Generate all inferred schema versions plus the default result for a provider."""

--- a/polylogue/schemas/generation_provider_bundle_packages.py
+++ b/polylogue/schemas/generation_provider_bundle_packages.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any
+from typing import cast
 
 from polylogue.schemas.generation_cluster_support import (
     _artifact_priority,
@@ -27,6 +27,8 @@ from polylogue.schemas.generation_schema_builder import (
     _apply_schema_metadata,
     _generate_cluster_schema,
 )
+from polylogue.schemas.generation_support import PrivacyConfigLike
+from polylogue.schemas.json_types import JSONDocument, JSONValue
 from polylogue.schemas.observation import ProviderConfig
 from polylogue.schemas.packages import (
     SchemaElementManifest,
@@ -43,7 +45,7 @@ class ProviderCatalogArtifacts:
     """Fully assembled provider package artifacts."""
 
     catalog: SchemaPackageCatalog
-    package_schemas: dict[str, dict[str, dict[str, Any]]]
+    package_schemas: dict[str, dict[str, JSONDocument]]
     package_reports: dict[str, dict[str, SchemaReport | None]]
     manifest: ClusterManifest
 
@@ -59,11 +61,11 @@ def build_provider_catalog_artifacts(
     sample_count: int,
     artifact_counts: dict[str, int],
     orphan_adjunct_counts: dict[str, int],
-    privacy_config: Any | None,
+    privacy_config: PrivacyConfigLike | None,
 ) -> ProviderCatalogArtifacts:
     """Build package schemas, catalog metadata, and manifest for a provider."""
     total_units = max(sum(acc.sample_count for acc in clusters.values()), 1)
-    package_schemas: dict[str, dict[str, dict[str, Any]]] = {}
+    package_schemas: dict[str, dict[str, JSONDocument]] = {}
     package_reports: dict[str, dict[str, SchemaReport | None]] = {}
     catalog_packages: list[SchemaVersionPackage] = []
     cluster_to_package_version: dict[str, str] = {}
@@ -84,7 +86,7 @@ def build_provider_catalog_artifacts(
             key=lambda item: (_artifact_priority(item[0]), item[0]),
             reverse=True,
         ):
-            schema_samples: list[dict[str, Any]] = []
+            schema_samples: list[JSONDocument] = []
             conv_ids: list[str | None] = []
             representative_paths: list[str] = []
             exact_structure_ids = sorted({membership.unit.exact_structure_id for membership in kind_memberships})
@@ -117,16 +119,21 @@ def build_provider_catalog_artifacts(
                 artifact_kind=element_kind,
                 observed_artifact_count=len(kind_memberships),
             )
+            profile_family_ids_json = [cast(JSONValue, profile_id) for profile_id in profile_family_ids]
+            exact_structure_ids_json = [cast(JSONValue, structure_id) for structure_id in exact_structure_ids]
+            package_profile_family_ids_json = [
+                cast(JSONValue, profile_id) for profile_id in sorted(package_acc.profile_family_ids)
+            ]
             schema["x-polylogue-package-version"] = version
-            schema["x-polylogue-profile-family-ids"] = profile_family_ids
-            schema["x-polylogue-exact-structure-ids"] = exact_structure_ids
+            schema["x-polylogue-profile-family-ids"] = profile_family_ids_json
+            schema["x-polylogue-exact-structure-ids"] = exact_structure_ids_json
             if element_first_seen:
                 schema["x-polylogue-element-first-seen"] = element_first_seen
             if element_last_seen:
                 schema["x-polylogue-element-last-seen"] = element_last_seen
             schema["x-polylogue-element-bundle-scope-count"] = len(element_bundle_scopes)
             schema["x-polylogue-anchor-profile-family-id"] = package_acc.anchor_family_id
-            schema["x-polylogue-package-profile-family-ids"] = sorted(package_acc.profile_family_ids)
+            schema["x-polylogue-package-profile-family-ids"] = package_profile_family_ids_json
             package_schemas[version][element_kind] = schema
             package_reports[version][element_kind] = redaction_report
             elements.append(

--- a/polylogue/schemas/generation_redaction.py
+++ b/polylogue/schemas/generation_redaction.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
-
+from polylogue.schemas.audit_walkers import SchemaNode, _walk_values
 from polylogue.schemas.field_stats import FieldStats
 from polylogue.schemas.privacy import (
     _is_content_field,
@@ -20,33 +19,13 @@ from polylogue.schemas.redaction_report import (
 def _build_redaction_report(
     provider: str,
     stats: dict[str, FieldStats],
-    schema: dict[str, Any],
+    schema: SchemaNode,
     *,
-    privacy_config: Any | None = None,
+    privacy_config: object | None = None,
     privacy_level: str = "standard",
 ) -> SchemaReport:
     report = SchemaReport(provider=provider, privacy_level=privacy_level)
-    schema_values: dict[str, set[str]] = {}
-
-    def _collect_schema_values(s: dict[str, Any], path: str = "$") -> None:
-        if not isinstance(s, dict):
-            return
-        vals = s.get("x-polylogue-values")
-        if isinstance(vals, list):
-            schema_values[path] = {str(v) for v in vals}
-        if "properties" in s:
-            for name, prop in s["properties"].items():
-                _collect_schema_values(prop, f"{path}.{name}")
-        if isinstance(s.get("additionalProperties"), dict):
-            _collect_schema_values(s["additionalProperties"], f"{path}.*")
-        if isinstance(s.get("items"), dict):
-            _collect_schema_values(s["items"], f"{path}[*]")
-        for kw in ("anyOf", "oneOf", "allOf"):
-            for sub in s.get(kw, []):
-                if isinstance(sub, dict):
-                    _collect_schema_values(sub, path)
-
-    _collect_schema_values(schema)
+    schema_values = {path: set(values) for path, values in _walk_values(schema)}
 
     for path, fs in stats.items():
         if not fs.is_enum_like or not fs.observed_values:

--- a/polylogue/schemas/generation_schema_builder.py
+++ b/polylogue/schemas/generation_schema_builder.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from datetime import datetime, timezone
-from typing import Any, Protocol, TypeAlias, cast
+from typing import Protocol, TypeAlias
 
 from polylogue.schemas.field_stats import _collect_field_stats
 from polylogue.schemas.generation_support import (
@@ -16,13 +16,14 @@ from polylogue.schemas.generation_support import (
     _remove_nested_required,
     collapse_dynamic_keys,
 )
+from polylogue.schemas.json_types import JSONDocument, JSONValue, json_document
 from polylogue.schemas.observation import ProviderConfig
 from polylogue.schemas.redaction_report import SchemaReport
 from polylogue.schemas.shape_fingerprint import _structure_fingerprint
 
-SchemaInput: TypeAlias = Mapping[str, object]
-SchemaPayload: TypeAlias = dict[str, Any]
-MutableSchemaPayload: TypeAlias = dict[str, Any]
+SchemaInput: TypeAlias = Mapping[str, JSONValue]
+SchemaPayload: TypeAlias = JSONDocument
+MutableSchemaPayload: TypeAlias = JSONDocument
 
 
 class PrivacyConfigLike(Protocol):
@@ -55,8 +56,8 @@ def _generate_cluster_schema(
             builder.add_object(dict(sample))
             fingerprint_counts[fingerprint] = seen + 1
 
-    schema = collapse_dynamic_keys(builder.to_schema())
-    schema = cast(MutableSchemaPayload, _remove_nested_required(schema))
+    schema = collapse_dynamic_keys(json_document(builder.to_schema()))
+    schema = _remove_nested_required(schema)
     if config.sample_granularity == "record":
         schema.pop("required", None)
 
@@ -127,8 +128,8 @@ def generate_schema_from_samples(
     for sample in genson_samples:
         builder.add_object(dict(sample))
 
-    schema = collapse_dynamic_keys(builder.to_schema())
-    schema = cast(MutableSchemaPayload, _remove_nested_required(schema))
+    schema = collapse_dynamic_keys(json_document(builder.to_schema()))
+    schema = _remove_nested_required(schema)
 
     if annotate:
         stats_samples = list(samples)
@@ -142,7 +143,7 @@ def generate_schema_from_samples(
         schema = _annotate_semantic_and_relational(schema, field_stats)
 
     schema["$schema"] = "https://json-schema.org/draft/2020-12/schema"
-    return dict(schema)
+    return schema
 
 
 __all__ = [

--- a/polylogue/schemas/generation_schema_builder.py
+++ b/polylogue/schemas/generation_schema_builder.py
@@ -16,18 +16,19 @@ from polylogue.schemas.generation_support import (
     _remove_nested_required,
     collapse_dynamic_keys,
 )
-from polylogue.schemas.json_types import JSONDocument, JSONValue, json_document
+from polylogue.schemas.json_types import JSONDocument, json_document
 from polylogue.schemas.observation import ProviderConfig
 from polylogue.schemas.redaction_report import SchemaReport
 from polylogue.schemas.shape_fingerprint import _structure_fingerprint
 
-SchemaInput: TypeAlias = Mapping[str, JSONValue]
+SchemaInput: TypeAlias = Mapping[str, object]
 SchemaPayload: TypeAlias = JSONDocument
 MutableSchemaPayload: TypeAlias = JSONDocument
 
 
 class PrivacyConfigLike(Protocol):
-    level: str
+    @property
+    def level(self) -> str: ...
 
 
 _STRUCTURE_EXEMPLARS_PER_FINGERPRINT = 8

--- a/polylogue/schemas/generation_support.py
+++ b/polylogue/schemas/generation_support.py
@@ -3,16 +3,17 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from typing import Any, Protocol, TypeAlias, cast, overload
+from typing import Protocol, TypeAlias, overload
 
 from polylogue.schemas import generation_dynamic_keys as _dynamic_keys
 from polylogue.schemas.field_stats import FieldStats
 from polylogue.schemas.generation_field_annotations import annotate_schema, remove_nested_required
 from polylogue.schemas.generation_redaction import _build_redaction_report
 from polylogue.schemas.generation_semantic_relations import annotate_semantic_and_relational
+from polylogue.schemas.json_types import JSONDocument, JSONValue, json_document
 
-SchemaPayload: TypeAlias = dict[str, Any]
-SchemaMapping: TypeAlias = Mapping[str, Any]
+SchemaPayload: TypeAlias = JSONDocument
+SchemaMapping: TypeAlias = Mapping[str, JSONValue]
 SchemaCollection: TypeAlias = Sequence[SchemaMapping]
 FieldStatsMapping: TypeAlias = Mapping[str, FieldStats]
 
@@ -27,7 +28,7 @@ collapse_dynamic_keys = _dynamic_keys.collapse_dynamic_keys
 
 
 def _merge_schemas(schemas: SchemaCollection) -> SchemaPayload:
-    return _dynamic_keys.merge_schemas([dict(schema) for schema in schemas])
+    return _dynamic_keys.merge_schemas([json_document(dict(schema)) for schema in schemas])
 
 
 def _annotate_schema(
@@ -38,15 +39,12 @@ def _annotate_schema(
     min_conversation_count: int = 1,
     privacy_config: PrivacyConfigLike | None = None,
 ) -> SchemaPayload:
-    return cast(
-        SchemaPayload,
-        annotate_schema(
-            dict(schema),
-            dict(stats),
-            path,
-            min_conversation_count=min_conversation_count,
-            privacy_config=privacy_config,
-        ),
+    return annotate_schema(
+        json_document(dict(schema)),
+        dict(stats),
+        path,
+        min_conversation_count=min_conversation_count,
+        privacy_config=privacy_config,
     )
 
 
@@ -56,9 +54,10 @@ def _annotate_semantic_and_relational(
     *,
     artifact_kind: str | None = None,
 ) -> SchemaPayload:
-    return cast(
-        SchemaPayload,
-        annotate_semantic_and_relational(dict(schema), dict(field_stats), artifact_kind=artifact_kind),
+    return annotate_semantic_and_relational(
+        json_document(dict(schema)),
+        dict(field_stats),
+        artifact_kind=artifact_kind,
     )
 
 
@@ -72,7 +71,7 @@ def _remove_nested_required(schema: object, depth: int = 0) -> object: ...
 
 def _remove_nested_required(schema: object, depth: int = 0) -> object:
     if isinstance(schema, Mapping):
-        return remove_nested_required(dict(schema), depth=depth)
+        return remove_nested_required(json_document(dict(schema)), depth=depth)
     return schema
 
 

--- a/polylogue/schemas/generation_support.py
+++ b/polylogue/schemas/generation_support.py
@@ -10,16 +10,17 @@ from polylogue.schemas.field_stats import FieldStats
 from polylogue.schemas.generation_field_annotations import annotate_schema, remove_nested_required
 from polylogue.schemas.generation_redaction import _build_redaction_report
 from polylogue.schemas.generation_semantic_relations import annotate_semantic_and_relational
-from polylogue.schemas.json_types import JSONDocument, JSONValue, json_document
+from polylogue.schemas.json_types import JSONDocument, json_document
 
 SchemaPayload: TypeAlias = JSONDocument
-SchemaMapping: TypeAlias = Mapping[str, JSONValue]
+SchemaMapping: TypeAlias = Mapping[str, object]
 SchemaCollection: TypeAlias = Sequence[SchemaMapping]
 FieldStatsMapping: TypeAlias = Mapping[str, FieldStats]
 
 
 class PrivacyConfigLike(Protocol):
-    level: str
+    @property
+    def level(self) -> str: ...
 
 
 GENSON_AVAILABLE = _dynamic_keys.GENSON_AVAILABLE

--- a/polylogue/schemas/generation_workflow.py
+++ b/polylogue/schemas/generation_workflow.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
 
 from polylogue.paths import db_path as archive_db_path
-from polylogue.schemas.generation_models import _ProviderBundle
+from polylogue.schemas.generation_models import GenerationResult, _ProviderBundle
 from polylogue.schemas.generation_provider_bundle import _build_provider_bundle
 from polylogue.schemas.generation_schema_builder import generate_schema_from_samples
+from polylogue.schemas.generation_support import PrivacyConfigLike
 from polylogue.schemas.observation import PROVIDERS
 from polylogue.schemas.registry import SchemaRegistry
 from polylogue.schemas.runtime_registry import ElementSchemaMap
@@ -45,9 +45,9 @@ def generate_provider_schema(
     provider: str,
     db_path: Path | None = None,
     max_samples: int | None = None,
-    privacy_config: Any | None = None,
+    privacy_config: PrivacyConfigLike | None = None,
     full_corpus: bool = False,
-) -> Any:
+) -> GenerationResult:
     """Generate the default inferred schema for a provider."""
     return _build_provider_bundle(
         provider,
@@ -63,8 +63,8 @@ def generate_all_schemas(
     db_path: Path | None = None,
     providers: list[str] | None = None,
     max_samples: int | None = None,
-    privacy_config: Any | None = None,
-) -> Any:
+    privacy_config: PrivacyConfigLike | None = None,
+) -> list[GenerationResult]:
     """Generate versioned schemas for all providers."""
     if db_path is None:
         db_path = archive_db_path()

--- a/polylogue/schemas/observation_identity.py
+++ b/polylogue/schemas/observation_identity.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import hashlib
 from pathlib import Path
-from typing import Any
 
+from polylogue.schemas.json_types import JSONValue
 from polylogue.schemas.observation_models import PROVIDERS, ProviderConfig
 from polylogue.types import Provider
 
@@ -27,13 +27,13 @@ def resolve_provider_config(provider_name: str | Provider) -> ProviderConfig:
     )
 
 
-def fingerprint_hash(fingerprint: Any) -> str:
+def fingerprint_hash(fingerprint: object) -> str:
     """Compute a stable short hash for a structural fingerprint."""
     raw = repr(fingerprint).encode("utf-8")
     return hashlib.sha256(raw).hexdigest()[:16]
 
 
-def schema_cluster_id(cluster_payload: Any, artifact_kind: str) -> str:
+def schema_cluster_id(cluster_payload: JSONValue, artifact_kind: str) -> str:
     """Compute a stable cluster identifier for a schema unit."""
     from polylogue.schemas.shape_fingerprint import _structure_fingerprint
 

--- a/polylogue/schemas/observation_identity.py
+++ b/polylogue/schemas/observation_identity.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import hashlib
 from pathlib import Path
 
-from polylogue.schemas.json_types import JSONValue
 from polylogue.schemas.observation_models import PROVIDERS, ProviderConfig
 from polylogue.types import Provider
 
@@ -33,7 +32,7 @@ def fingerprint_hash(fingerprint: object) -> str:
     return hashlib.sha256(raw).hexdigest()[:16]
 
 
-def schema_cluster_id(cluster_payload: JSONValue, artifact_kind: str) -> str:
+def schema_cluster_id(cluster_payload: object, artifact_kind: str) -> str:
     """Compute a stable cluster identifier for a schema unit."""
     from polylogue.schemas.shape_fingerprint import _structure_fingerprint
 

--- a/polylogue/schemas/operator_inference.py
+++ b/polylogue/schemas/operator_inference.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from pathlib import Path
-from typing import Protocol, cast
+from typing import Literal, Protocol, cast
 
 from polylogue.scenarios import CorpusScenario, CorpusSpec, build_corpus_scenarios, build_inferred_corpus_specs
 from polylogue.schemas.audit_models import AuditReport
@@ -26,6 +26,7 @@ from polylogue.schemas.operator_models import (
 )
 from polylogue.schemas.operator_registry import schema_registry
 from polylogue.schemas.packages import SchemaPackageCatalog, SchemaVersionPackage
+from polylogue.schemas.privacy_config import PrivacyConfig
 from polylogue.schemas.tooling_models import ClusterManifest, SchemaDiff
 from polylogue.types import Provider
 
@@ -33,7 +34,7 @@ from polylogue.types import Provider
 class _SchemaRegistryLike(Protocol):
     def load_package_catalog(self, provider: str) -> SchemaPackageCatalog | None: ...
 
-    def cluster_samples(self, provider: str, samples: Sequence[JSONDocument]) -> ClusterManifest: ...
+    def cluster_samples(self, provider: str, samples: Sequence[object]) -> ClusterManifest: ...
 
     def save_cluster_manifest(self, manifest: ClusterManifest) -> Path: ...
 
@@ -59,7 +60,7 @@ class _SchemaRegistryLike(Protocol):
         provider: str,
         cluster_id: str,
         *,
-        samples: Sequence[JSONDocument] | None = None,
+        samples: Sequence[object] | None = None,
     ) -> str: ...
 
     def get_package(self, provider: str, *, version: str) -> SchemaVersionPackage | None: ...
@@ -101,6 +102,41 @@ def _build_inferred_outputs(
     return corpus_specs, corpus_scenarios
 
 
+def _privacy_config(payload: JSONDocument | None) -> PrivacyConfig | None:
+    if payload is None:
+        return None
+    field_overrides = payload.get("field_overrides")
+    allow_patterns = payload.get("allow_value_patterns")
+    deny_patterns = payload.get("deny_value_patterns")
+    level = payload.get("level")
+    safe_enum_max_length = payload.get("safe_enum_max_length", 50)
+    high_entropy_min_length = payload.get("high_entropy_min_length", 10)
+    cross_conv_min_count = payload.get("cross_conv_min_count", 3)
+    config_level: Literal["strict", "standard", "permissive"]
+    if level in {"strict", "standard", "permissive"}:
+        config_level = cast(Literal["strict", "standard", "permissive"], level)
+    else:
+        config_level = "standard"
+    return PrivacyConfig(
+        level=config_level,
+        safe_enum_max_length=safe_enum_max_length if isinstance(safe_enum_max_length, int) else 50,
+        high_entropy_min_length=high_entropy_min_length if isinstance(high_entropy_min_length, int) else 10,
+        cross_conv_min_count=cross_conv_min_count if isinstance(cross_conv_min_count, int) else 3,
+        cross_conv_proportional=bool(payload.get("cross_conv_proportional", False)),
+        field_overrides=(
+            {key: value for key, value in field_overrides.items() if isinstance(key, str) and isinstance(value, str)}
+            if isinstance(field_overrides, dict)
+            else {}
+        ),
+        allow_value_patterns=[value for value in allow_patterns if isinstance(value, str)]
+        if isinstance(allow_patterns, list)
+        else [],
+        deny_value_patterns=[value for value in deny_patterns if isinstance(value, str)]
+        if isinstance(deny_patterns, list)
+        else [],
+    )
+
+
 def infer_schema(request: SchemaInferRequest) -> SchemaInferResult:
     from polylogue.schemas.generation_workflow import generate_provider_schema
     from polylogue.schemas.observation import PROVIDERS
@@ -110,7 +146,7 @@ def infer_schema(request: SchemaInferRequest) -> SchemaInferResult:
         request.provider,
         db_path=request.db_path,
         max_samples=request.max_samples,
-        privacy_config=request.privacy_config,
+        privacy_config=_privacy_config(cast(JSONDocument | None, request.privacy_config)),
         full_corpus=request.full_corpus,
     )
     package_version = result.default_version or "default"

--- a/polylogue/schemas/sampling.py
+++ b/polylogue/schemas/sampling.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from pathlib import Path
-from typing import Any
 
 from polylogue.lib.raw_payload import build_raw_payload_envelope, collect_limited_samples
 from polylogue.paths import db_path as archive_db_path
+from polylogue.schemas.json_types import JSONDocument
 from polylogue.schemas.observation import resolve_provider_config
+from polylogue.schemas.observation_models import SchemaUnit
 from polylogue.schemas.sampling_db import (
     _iter_samples_from_db,
     _iter_schema_units_from_db,
@@ -27,7 +29,7 @@ def iter_schema_units(
     db_path: Path | None = None,
     max_samples: int | None = None,
     full_corpus: bool = False,
-) -> Any:
+) -> Iterator[SchemaUnit]:
     """Yield schema units for a provider from DB, with session fallback."""
     provider_name = Provider.from_string(provider_name)
     if db_path is None:
@@ -63,7 +65,7 @@ def load_samples_from_db(
     provider_name: str | Provider,
     db_path: Path | None = None,
     max_samples: int | None = None,
-) -> list[dict[str, Any]]:
+) -> list[JSONDocument]:
     """Load raw samples from the polylogue database."""
     provider_name = Provider.from_string(provider_name)
     if db_path is None:
@@ -87,7 +89,7 @@ def load_samples_from_sessions(
     max_sessions: int | None = None,
     max_samples: int | None = None,
     record_type_key: str | None = None,
-) -> list[dict[str, Any]]:
+) -> list[JSONDocument]:
     """Load samples from JSONL session files."""
     if max_samples is None:
         return list(_iter_samples_from_sessions(session_dir, max_sessions=max_sessions))

--- a/polylogue/schemas/sampling_db.py
+++ b/polylogue/schemas/sampling_db.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 import sqlite3
 from collections.abc import Iterator
 from pathlib import Path
-from typing import Any, Literal, overload
+from typing import Literal, TypeAlias, overload
 
+from polylogue.lib.json import JSONDocument
 from polylogue.lib.provider_identity import (
     CORE_RUNTIME_PROVIDERS,
     canonical_runtime_provider,
@@ -27,7 +28,7 @@ from polylogue.types import Provider
 logger = get_logger(__name__)
 
 SchemaRow = tuple[str | None, str | None, str | None, str, str | None, str | None]
-SchemaSample = dict[str, Any]
+SchemaSample: TypeAlias = JSONDocument
 
 
 def _sample_provider_where_clause(provider_name: str | Provider) -> tuple[str, tuple[str, ...]]:

--- a/polylogue/schemas/sampling_sessions.py
+++ b/polylogue/schemas/sampling_sessions.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 import contextlib
-import json
+from collections.abc import Iterator
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
 
+from polylogue.lib.json import JSONDocument, json_document, loads
 from polylogue.schemas.observation import ProviderConfig, extract_schema_units_from_payload
+from polylogue.schemas.observation_models import SchemaUnit
 from polylogue.types import Provider
 
 
@@ -19,7 +20,7 @@ def _iter_schema_units_from_sessions(
     max_sessions: int | None,
     config: ProviderConfig,
     max_samples: int | None = None,
-) -> Any:
+) -> Iterator[SchemaUnit]:
     """Yield clusterable schema units from filesystem session files."""
     provider_name = Provider.from_string(provider_name)
     if not session_dir.exists():
@@ -35,16 +36,15 @@ def _iter_schema_units_from_sessions(
         jsonl_files = jsonl_files[::step][:max_sessions]
 
     for path in jsonl_files:
-        records: list[dict[str, Any]] = []
+        records: list[JSONDocument] = []
         try:
             with path.open(encoding="utf-8") as handle:
                 for line in handle:
                     if not line.strip():
                         continue
-                    with contextlib.suppress(json.JSONDecodeError):
-                        parsed = json.loads(line)
-                        if isinstance(parsed, dict):
-                            records.append(parsed)
+                    with contextlib.suppress(ValueError):
+                        if record := json_document(loads(line)):
+                            records.append(record)
         except OSError:
             continue
 
@@ -66,7 +66,7 @@ def _iter_samples_from_sessions(
     session_dir: Path,
     *,
     max_sessions: int | None,
-) -> Any:
+) -> Iterator[JSONDocument]:
     """Yield individual sample dicts from session files."""
     if not session_dir.exists():
         return
@@ -86,10 +86,9 @@ def _iter_samples_from_sessions(
                 for line in handle:
                     if not line.strip():
                         continue
-                    with contextlib.suppress(json.JSONDecodeError):
-                        parsed = json.loads(line)
-                        if isinstance(parsed, dict):
-                            yield parsed
+                    with contextlib.suppress(ValueError):
+                        if record := json_document(loads(line)):
+                            yield record
         except OSError:
             continue
 

--- a/polylogue/schemas/tooling_diff.py
+++ b/polylogue/schemas/tooling_diff.py
@@ -2,13 +2,23 @@
 
 from __future__ import annotations
 
-from typing import Any
-
+from polylogue.schemas.json_types import JSONDocument, json_document
 from polylogue.schemas.runtime_registry import SchemaProvider
 from polylogue.schemas.tooling_models import PropertyChange, SchemaDiff
 
 
-def _type_label(schema: dict[str, Any]) -> str:
+def _schema_properties(schema: JSONDocument) -> JSONDocument:
+    return json_document(schema.get("properties"))
+
+
+def _required_properties(schema: JSONDocument) -> set[str]:
+    required = schema.get("required")
+    if not isinstance(required, list):
+        return set()
+    return {item for item in required if isinstance(item, str)}
+
+
+def _type_label(schema: JSONDocument) -> str:
     schema_type = schema.get("type")
     if isinstance(schema_type, list):
         return " | ".join(str(item) for item in schema_type)
@@ -19,11 +29,13 @@ def diff_schemas(
     provider: SchemaProvider,
     v1: str,
     v2: str,
-    schema_a: dict[str, Any],
-    schema_b: dict[str, Any],
+    schema_a: JSONDocument,
+    schema_b: JSONDocument,
 ) -> SchemaDiff:
-    props_a = set(schema_a.get("properties", {}).keys())
-    props_b = set(schema_b.get("properties", {}).keys())
+    properties_a = _schema_properties(schema_a)
+    properties_b = _schema_properties(schema_b)
+    props_a = set(properties_a)
+    props_b = set(properties_b)
     added = sorted(props_b - props_a)
     removed = sorted(props_a - props_b)
     changed: list[str] = []
@@ -32,7 +44,7 @@ def diff_schemas(
     for prop in added:
         classified.append(
             PropertyChange(
-                path=prop, kind="added", detail=f"new property (type: {_type_label(schema_b['properties'][prop])})"
+                path=prop, kind="added", detail=f"new property (type: {_type_label(json_document(properties_b[prop]))})"
             )
         )
     for prop in removed:
@@ -40,15 +52,15 @@ def diff_schemas(
             PropertyChange(
                 path=prop,
                 kind="removed",
-                detail=f"removed property (was type: {_type_label(schema_a['properties'][prop])})",
+                detail=f"removed property (was type: {_type_label(json_document(properties_a[prop]))})",
             )
         )
 
-    req_a = set(schema_a.get("required", []))
-    req_b = set(schema_b.get("required", []))
+    req_a = _required_properties(schema_a)
+    req_b = _required_properties(schema_b)
     for prop in sorted(props_a & props_b):
-        prop_a = schema_a["properties"][prop]
-        prop_b = schema_b["properties"][prop]
+        prop_a = json_document(properties_a[prop])
+        prop_b = json_document(properties_b[prop])
         if prop_a.get("type") != prop_b.get("type"):
             changed.append(prop)
             classified.append(

--- a/polylogue/schemas/tooling_registry.py
+++ b/polylogue/schemas/tooling_registry.py
@@ -8,7 +8,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, TypeAlias
 
-from polylogue.schemas.json_types import JSONDocument, JSONValue, json_document, json_document_list
+from polylogue.schemas.json_types import json_document, json_document_list
 from polylogue.schemas.observation import schema_cluster_id
 from polylogue.schemas.packages import SchemaPackageCatalog, SchemaVersionPackage
 from polylogue.schemas.runtime_registry import (

--- a/polylogue/schemas/tooling_registry.py
+++ b/polylogue/schemas/tooling_registry.py
@@ -11,16 +11,21 @@ from typing import TYPE_CHECKING, TypeAlias
 from polylogue.schemas.json_types import JSONDocument, JSONValue, json_document, json_document_list
 from polylogue.schemas.observation import schema_cluster_id
 from polylogue.schemas.packages import SchemaPackageCatalog, SchemaVersionPackage
-from polylogue.schemas.runtime_registry import ElementSchemaMap, PublicSchemaDocument, canonical_schema_provider
+from polylogue.schemas.runtime_registry import (
+    ElementSchemaMap,
+    PublicSchemaDocument,
+    SchemaInputDocument,
+    canonical_schema_provider,
+)
 from polylogue.schemas.tooling_diff import diff_schemas
 from polylogue.schemas.tooling_models import ClusterManifest, PropertyChange, SchemaCluster, SchemaDiff
 from polylogue.types import Provider
 
-SchemaPayload: TypeAlias = JSONDocument
-ObservedSchemaSample: TypeAlias = JSONValue
+SchemaPayload: TypeAlias = SchemaInputDocument
+ObservedSchemaSample: TypeAlias = object
 
 
-def _dominant_keys(sample: ObservedSchemaSample) -> list[str]:
+def _dominant_keys(sample: object) -> list[str]:
     document = json_document(sample)
     if document:
         return sorted(document)
@@ -42,7 +47,7 @@ class SchemaRegistryToolingMixin:
             provider: str,
             *,
             version: str,
-            schema: SchemaPayload,
+            schema: SchemaInputDocument,
             element_kind: str = "conversation_document",
             first_seen: str | None = None,
             last_seen: str | None = None,
@@ -65,7 +70,7 @@ class SchemaRegistryToolingMixin:
             element_kind: str | None = None,
         ) -> PublicSchemaDocument | None: ...
 
-        def register_schema(self, provider: str, schema: SchemaPayload) -> str: ...
+        def register_schema(self, provider: str, schema: SchemaInputDocument) -> str: ...
 
     def replace_provider_schemas(
         self,

--- a/polylogue/schemas/tooling_registry.py
+++ b/polylogue/schemas/tooling_registry.py
@@ -6,8 +6,9 @@ import json
 from collections.abc import Mapping, Sequence
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, TypeAlias
+from typing import TYPE_CHECKING, TypeAlias
 
+from polylogue.schemas.json_types import JSONDocument, JSONValue, json_document, json_document_list
 from polylogue.schemas.observation import schema_cluster_id
 from polylogue.schemas.packages import SchemaPackageCatalog, SchemaVersionPackage
 from polylogue.schemas.runtime_registry import ElementSchemaMap, PublicSchemaDocument, canonical_schema_provider
@@ -15,17 +16,17 @@ from polylogue.schemas.tooling_diff import diff_schemas
 from polylogue.schemas.tooling_models import ClusterManifest, PropertyChange, SchemaCluster, SchemaDiff
 from polylogue.types import Provider
 
-SchemaPayload: TypeAlias = Mapping[str, Any]
-ObservedSchemaSample: TypeAlias = object
+SchemaPayload: TypeAlias = JSONDocument
+ObservedSchemaSample: TypeAlias = JSONValue
 
 
-def _dominant_keys(sample: object) -> list[str]:
-    if isinstance(sample, dict):
-        return sorted(str(key) for key in sample)
-    if isinstance(sample, list):
-        first_dict = next((item for item in sample if isinstance(item, dict)), None)
-        if first_dict is not None:
-            return sorted(str(key) for key in first_dict)
+def _dominant_keys(sample: ObservedSchemaSample) -> list[str]:
+    document = json_document(sample)
+    if document:
+        return sorted(document)
+    documents = json_document_list(sample)
+    if documents:
+        return sorted(documents[0])
     return []
 
 
@@ -77,7 +78,7 @@ class SchemaRegistryToolingMixin:
         packages: list[SchemaVersionPackage] = []
         package_schemas: dict[str, ElementSchemaMap] = {}
         for version, schema in versioned_schemas:
-            package, schemas = self._single_element_package(provider_token, version=version, schema=dict(schema))
+            package, schemas = self._single_element_package(provider_token, version=version, schema=schema)
             packages.append(package)
             package_schemas[version] = schemas
         latest_version = packages[-1].version if packages else None
@@ -204,7 +205,7 @@ class SchemaRegistryToolingMixin:
         if samples:
             from polylogue.schemas.generation_workflow import generate_schema_from_samples
 
-            schema = generate_schema_from_samples(samples)
+            schema = json_document(generate_schema_from_samples(samples))
         else:
             schema = {
                 "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/polylogue/schemas/validator_resolution.py
+++ b/polylogue/schemas/validator_resolution.py
@@ -62,7 +62,7 @@ def resolve_provider_schema(
 
 def resolve_payload_schema(
     provider: str | Provider,
-    payload: JSONValue,
+    payload: object,
     *,
     source_path: str | None = None,
     schema_resolution: SchemaResolution | None = None,

--- a/polylogue/schemas/validator_resolution.py
+++ b/polylogue/schemas/validator_resolution.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 from functools import lru_cache
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from polylogue.paths import data_home
+from polylogue.schemas.json_types import JSONDocument, JSONValue
 from polylogue.schemas.runtime_registry import SchemaRegistry, canonical_schema_provider
 from polylogue.types import Provider
 
@@ -39,7 +40,7 @@ def resolve_provider_schema(
     provider: str | Provider,
     *,
     registry_cls: type[SchemaRegistry] = SchemaRegistry,
-) -> tuple[Provider, dict[str, Any], tuple[str, str, str]]:
+) -> tuple[Provider, JSONDocument, tuple[str, str, str]]:
     canonical = canonical_provider(provider)
     registry = _registry_for(registry_cls)
     package = registry.get_package(str(canonical), version="default") if hasattr(registry, "get_package") else None
@@ -61,12 +62,12 @@ def resolve_provider_schema(
 
 def resolve_payload_schema(
     provider: str | Provider,
-    payload: Any,
+    payload: JSONValue,
     *,
     source_path: str | None = None,
     schema_resolution: SchemaResolution | None = None,
     registry_cls: type[SchemaRegistry] = SchemaRegistry,
-) -> tuple[Provider, dict[str, Any], tuple[str, str, str]]:
+) -> tuple[Provider, JSONDocument, tuple[str, str, str]]:
     canonical = canonical_provider(provider)
     registry = _registry_for(registry_cls)
     resolution = schema_resolution

--- a/polylogue/schemas/validator_resolution.py
+++ b/polylogue/schemas/validator_resolution.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from polylogue.paths import data_home
-from polylogue.schemas.json_types import JSONDocument, JSONValue
+from polylogue.schemas.json_types import JSONDocument
 from polylogue.schemas.runtime_registry import SchemaRegistry, canonical_schema_provider
 from polylogue.types import Provider
 

--- a/tests/infra/schema_access.py
+++ b/tests/infra/schema_access.py
@@ -1,0 +1,35 @@
+"""Test helpers for narrowing generated schema payloads."""
+
+from __future__ import annotations
+
+from polylogue.schemas.json_types import JSONDocument, JSONValue, json_document
+
+
+def schema_node(value: object) -> JSONDocument:
+    return json_document(value)
+
+
+def schema_properties(schema: object) -> JSONDocument:
+    return json_document(schema_node(schema).get("properties"))
+
+
+def schema_property(schema: object, name: str) -> JSONDocument:
+    return json_document(schema_properties(schema).get(name))
+
+
+def schema_items(schema: object) -> JSONDocument:
+    return json_document(schema_node(schema).get("items"))
+
+
+def schema_values(schema: object) -> list[JSONValue]:
+    values = schema_node(schema).get("x-polylogue-values")
+    return list(values) if isinstance(values, list) else []
+
+
+__all__ = [
+    "schema_items",
+    "schema_node",
+    "schema_properties",
+    "schema_property",
+    "schema_values",
+]

--- a/tests/property/test_rendering_preservation.py
+++ b/tests/property/test_rendering_preservation.py
@@ -12,7 +12,7 @@ import json
 from collections import Counter
 from typing import Any
 
-from hypothesis import given, settings
+from hypothesis import HealthCheck, given, settings
 
 from tests.infra.strategies.messages import conversation_strategy
 
@@ -274,7 +274,7 @@ def test_json_yaml_agree_on_message_count(conv_data: dict[str, Any]) -> None:
 
 
 @given(conv_data=conversation_strategy(min_messages=1, max_messages=5))
-@settings(max_examples=20, deadline=5000)
+@settings(max_examples=20, deadline=5000, suppress_health_check=[HealthCheck.filter_too_much])
 def test_json_yaml_agree_on_identity(conv_data: dict[str, Any]) -> None:
     """JSON and YAML agree on conversation_id, provider, title."""
     import yaml

--- a/tests/unit/core/test_privacy_guards.py
+++ b/tests/unit/core/test_privacy_guards.py
@@ -18,6 +18,7 @@ from polylogue.schemas.schema_inference import (
     _is_content_field,
     _is_safe_enum_value,
 )
+from tests.infra.schema_access import schema_property, schema_values
 
 LETTER_CATEGORIES: tuple[Literal["L"], ...] = ("L",)
 
@@ -119,7 +120,7 @@ class TestAnnotationPrivacyIntegration:
         annotated = _annotate_schema(schema, stats, path="$")
 
         # High cardinality → not enum-like → no values annotation
-        assert "x-polylogue-values" not in annotated["properties"]["status"]
+        assert not schema_values(schema_property(annotated, "status"))
 
     def test_content_field_values_excluded(self: Any) -> None:
         """Known content fields never get x-polylogue-values even if low cardinality."""
@@ -130,4 +131,4 @@ class TestAnnotationPrivacyIntegration:
         annotated = _annotate_schema(schema, stats, path="$")
 
         # "title" is in _CONTENT_FIELD_NAMES → values suppressed
-        assert "x-polylogue-values" not in annotated["properties"]["title"]
+        assert not schema_values(schema_property(annotated, "title"))

--- a/tests/unit/core/test_sampling.py
+++ b/tests/unit/core/test_sampling.py
@@ -15,6 +15,7 @@ import pytest
 from polylogue.schemas.observation import PROVIDERS, ProviderConfig
 from polylogue.schemas.sampling import load_samples_from_db, load_samples_from_sessions
 from polylogue.types import Provider
+from tests.infra.schema_access import schema_node
 
 
 class TestProviderConfig:
@@ -219,7 +220,12 @@ class TestLoadSamplesFromDb:
         assert len(result) == 2
         assert {sample["type"] for sample in result} == {"session_meta", "message"}
         message_sample = next(sample for sample in result if sample["type"] == "message")
-        assert len(message_sample["content"][0]["text"]) == 1024
+        content = message_sample.get("content")
+        assert isinstance(content, list)
+        first_block = schema_node(content[0]) if content else {}
+        text = first_block.get("text")
+        assert isinstance(text, str)
+        assert len(text) == 1024
 
 
 class TestLoadSamplesFromSessions:

--- a/tests/unit/core/test_schema_annotation_contracts.py
+++ b/tests/unit/core/test_schema_annotation_contracts.py
@@ -28,8 +28,16 @@ from polylogue.schemas.generation_support import (
 from polylogue.schemas.generation_workflow import (
     generate_schema_from_samples,
 )
+from polylogue.schemas.json_types import JSONDocument
 from polylogue.schemas.semantic_inference_runtime import (
     infer_semantic_roles,
+)
+from tests.infra.schema_access import (
+    schema_items,
+    schema_node,
+    schema_properties,
+    schema_property,
+    schema_values,
 )
 
 
@@ -96,13 +104,12 @@ class TestAnnotateSemanticAndRelational:
         result_schema = _annotate_semantic_and_relational(schema, field_stats)
 
         # If role was detected, check confidence/evidence
-        if "role" in result_schema.get("properties", {}):
-            role_schema = result_schema["properties"]["role"]
-            if "x-polylogue-semantic-role" in role_schema:
-                assert "x-polylogue-score" in role_schema
-                assert isinstance(role_schema["x-polylogue-score"], (int, float))
-                assert "x-polylogue-evidence" in role_schema
-                assert isinstance(role_schema["x-polylogue-evidence"], dict)
+        role_schema = schema_property(result_schema, "role")
+        if role_schema and "x-polylogue-semantic-role" in role_schema:
+            assert "x-polylogue-score" in role_schema
+            assert isinstance(role_schema["x-polylogue-score"], (int, float))
+            assert "x-polylogue-evidence" in role_schema
+            assert isinstance(role_schema["x-polylogue-evidence"], dict)
 
     def test_foreign_key_annotation_at_root(self) -> None:
         """x-polylogue-foreign-keys annotation at schema root."""
@@ -305,9 +312,10 @@ class TestGenerateSchemaFromSamples:
         ]
         result_schema = generate_schema_from_samples(samples)
         assert result_schema is not None
-        assert "properties" in result_schema
-        assert "messages" in result_schema["properties"]
-        assert "title" in result_schema["properties"]
+        properties = schema_properties(result_schema)
+        assert properties
+        assert "messages" in properties
+        assert "title" in properties
 
     def test_semantic_annotations_in_generated_schema(self) -> None:
         """Generated schema includes semantic role annotations."""
@@ -326,17 +334,16 @@ class TestGenerateSchemaFromSamples:
         # Check for at least some semantic annotations
         has_semantic = False
 
-        def check_schema(s: dict[str, object], depth: int = 0) -> bool:
+        def check_schema(s: object, depth: int = 0) -> bool:
             nonlocal has_semantic
-            if "x-polylogue-semantic-role" in s:
+            node = schema_node(s)
+            if "x-polylogue-semantic-role" in node:
                 has_semantic = True
-            properties = s.get("properties")
-            if isinstance(properties, dict):
-                for prop_schema in properties.values():
-                    if isinstance(prop_schema, dict):
-                        check_schema(prop_schema, depth + 1)
-            if "items" in s and isinstance(s["items"], dict):
-                check_schema(s["items"], depth + 1)
+            for prop_schema in schema_properties(node).values():
+                check_schema(prop_schema, depth + 1)
+            items = schema_items(node)
+            if items:
+                check_schema(items, depth + 1)
             return has_semantic
 
         check_schema(result_schema)
@@ -406,7 +413,7 @@ class TestGenerateSchemaFromSamples:
         ]
         result_schema = generate_schema_from_samples(samples)
         assert result_schema is not None
-        props = result_schema.get("properties", {})
+        props = schema_properties(result_schema)
         assert "id" in props or "title" in props or "message_count" in props
 
     def test_empty_samples_returns_base_object_schema(self) -> None:
@@ -650,29 +657,30 @@ def _find_annotations(
     return result
 
 
-def _get_nested(schema: dict[str, object], dotpath: str) -> dict[str, object] | None:
+def _get_nested(schema: object, dotpath: str) -> JSONDocument | None:
     """Navigate a schema by dot-separated property path."""
-    current = schema
+    current = schema_node(schema)
     for part in dotpath.split("."):
         if part == "additionalProperties":
-            candidate = current.get("additionalProperties", {})
+            candidate = schema_node(current.get("additionalProperties"))
         else:
-            properties = current.get("properties", {})
-            if not isinstance(properties, dict):
-                return None
-            candidate = properties.get(part, {})
-        if not isinstance(candidate, dict):
-            return None
-        current = candidate
+            candidate = schema_property(current, part)
+        current = schema_node(candidate)
         if not current:
             return None
         any_of = current.get("anyOf")
         if isinstance(any_of, list):
             for variant in any_of:
-                if isinstance(variant, dict) and variant.get("type") == "object" and "properties" in variant:
-                    current = variant
+                variant_node = schema_node(variant)
+                if variant_node.get("type") == "object" and schema_properties(variant_node):
+                    current = variant_node
                     break
     return current or None
+
+
+def _schema_any_of_variants(schema: object) -> list[JSONDocument]:
+    any_of = schema_node(schema).get("anyOf")
+    return [variant for variant in any_of if isinstance(variant, dict)] if isinstance(any_of, list) else []
 
 
 class TestSchemaAnnotations:
@@ -694,10 +702,8 @@ class TestSchemaAnnotations:
         if schema is None:
             pytest.skip("ChatGPT schema not available")
 
-        properties = schema.get("properties")
-        assert isinstance(properties, dict)
-        current_node = properties.get("current_node")
-        assert isinstance(current_node, dict)
+        current_node = schema_property(schema, "current_node")
+        assert current_node
         assert current_node.get("x-polylogue-format") == "uuid4"
         node_id = _get_nested(schema, "mapping.additionalProperties.id")
         assert node_id is not None
@@ -708,10 +714,8 @@ class TestSchemaAnnotations:
         if schema is None:
             pytest.skip("ChatGPT schema not available")
 
-        properties = schema.get("properties")
-        assert isinstance(properties, dict)
-        create_time = properties.get("create_time", {})
-        assert isinstance(create_time, dict)
+        create_time = schema_property(schema, "create_time")
+        assert create_time
         fmt = create_time.get("x-polylogue-format")
         rng = create_time.get("x-polylogue-range")
         assert fmt == "unix-epoch" or rng is not None
@@ -721,10 +725,8 @@ class TestSchemaAnnotations:
         if schema is None:
             pytest.skip("ChatGPT schema not available")
 
-        properties = schema.get("properties")
-        assert isinstance(properties, dict)
-        current_node = properties.get("current_node")
-        assert isinstance(current_node, dict)
+        current_node = schema_property(schema, "current_node")
+        assert current_node
         assert current_node.get("x-polylogue-ref") == "$.mapping"
 
     def test_claude_code_has_annotations(self) -> None:
@@ -744,12 +746,9 @@ class TestSchemaAnnotations:
         if schema is None:
             pytest.skip("Claude Code schema not available")
 
-        properties = schema.get("properties")
-        assert isinstance(properties, dict)
-        type_schema = properties.get("type")
-        assert isinstance(type_schema, dict)
-        type_values = type_schema.get("x-polylogue-values", [])
-        assert isinstance(type_values, list)
+        type_schema = schema_property(schema, "type")
+        assert type_schema
+        type_values = schema_values(type_schema)
         assert any(value in type_values for value in ("user", "assistant", "human"))
 
     def test_claude_ai_sender_semantic(self) -> None:
@@ -757,24 +756,19 @@ class TestSchemaAnnotations:
         if schema is None:
             pytest.skip("Claude AI schema not available")
 
-        properties = schema.get("properties")
-        assert isinstance(properties, dict)
-        messages = properties.get("chat_messages", {})
-        assert isinstance(messages, dict)
-        item = messages.get("items", {})
-        assert isinstance(item, dict)
+        messages = schema_property(schema, "chat_messages")
+        assert messages
+        item = schema_items(messages)
+        assert item
         # Navigate anyOf if present
-        if "anyOf" in item:
-            any_of = item["anyOf"]
-            assert isinstance(any_of, list)
-            for variant in any_of:
-                assert isinstance(variant, dict)
-                sender = variant.get("properties", {}).get("sender", {})
-                assert isinstance(sender, dict)
+        variants = _schema_any_of_variants(item)
+        if variants:
+            for variant in variants:
+                sender = schema_property(variant, "sender")
                 if "x-polylogue-semantic-role" in sender:
                     assert sender["x-polylogue-semantic-role"] == "message_role"
                     return
-        sender = item.get("properties", {}).get("sender", {})
+        sender = schema_property(item, "sender")
         assert sender.get("x-polylogue-semantic-role") == "message_role"
 
     @pytest.mark.parametrize("provider", ["chatgpt", "claude-code", "claude-ai", "codex"])

--- a/tests/unit/core/test_schema_generation.py
+++ b/tests/unit/core/test_schema_generation.py
@@ -26,6 +26,7 @@ from polylogue.schemas.schema_inference import (
     load_samples_from_db,
     load_samples_from_sessions,
 )
+from tests.infra.schema_access import schema_properties, schema_property, schema_values
 
 
 class TestProviderSchemaGeneration:
@@ -212,8 +213,9 @@ class TestGenerateSchemaFromSamples:
         result = generate_schema_from_samples([{"id": "abc", "count": 42}])
         assert result["type"] == "object"
         assert "properties" in result
-        assert "id" in result["properties"]
-        assert "count" in result["properties"]
+        properties = schema_properties(result)
+        assert "id" in properties
+        assert "count" in properties
 
     def test_identifier_fields_do_not_emit_value_enums(self) -> None:
         result = generate_schema_from_samples(
@@ -222,8 +224,8 @@ class TestGenerateSchemaFromSamples:
                 {"resourceId": "12q0eVTU-RR-IMCjN0peXXKVg3LPwbmVW", "category": "HARM_CATEGORY_HARASSMENT"},
             ]
         )
-        assert "x-polylogue-values" not in result["properties"]["resourceId"]
-        assert "x-polylogue-values" in result["properties"]["category"]
+        assert not schema_values(schema_property(result, "resourceId"))
+        assert schema_values(schema_property(result, "category"))
 
     def test_high_entropy_tail_segments_are_filtered(self) -> None:
         result = generate_schema_from_samples(
@@ -232,8 +234,8 @@ class TestGenerateSchemaFromSamples:
                 {"promptId": "prompts/26CInJFZ16cELIshzl5Xf30JVJoaLr1q", "model": "models/gemini-2.5-pro"},
             ]
         )
-        assert "x-polylogue-values" not in result["properties"]["promptId"]
-        assert result["properties"]["model"].get("x-polylogue-values") == ["models/gemini-2.5-pro"]
+        assert not schema_values(schema_property(result, "promptId"))
+        assert schema_values(schema_property(result, "model")) == ["models/gemini-2.5-pro"]
 
     def test_high_entropy_values_filtered_even_without_identifier_field_name(self) -> None:
         result = generate_schema_from_samples(
@@ -242,8 +244,8 @@ class TestGenerateSchemaFromSamples:
                 {"channel": "12q0eVTU-RR-IMCjN0peXXKVg3LPwbmVW", "role": "assistant"},
             ]
         )
-        assert "x-polylogue-values" not in result["properties"]["channel"]
-        assert result["properties"]["role"].get("x-polylogue-values") == ["assistant"]
+        assert not schema_values(schema_property(result, "channel"))
+        assert schema_values(schema_property(result, "role")) == ["assistant"]
 
 
 class TestGenerateAllSchemas:

--- a/tests/unit/core/test_schema_laws.py
+++ b/tests/unit/core/test_schema_laws.py
@@ -12,6 +12,7 @@ import pytest
 from hypothesis import HealthCheck, assume, given, settings
 from hypothesis import strategies as st
 
+from polylogue.schemas.json_types import json_document
 from polylogue.schemas.schema_inference import (
     _remove_nested_required,
     _structure_fingerprint,
@@ -22,6 +23,7 @@ from polylogue.schemas.schema_inference import (
 )
 from polylogue.schemas.validator import SchemaValidator
 from polylogue.types import Provider
+from tests.infra.schema_access import schema_node, schema_properties
 from tests.infra.strategies import (
     SessionJsonlFileSpec,
     dynamic_key_strategy,
@@ -33,6 +35,18 @@ from tests.infra.strategies import (
     session_jsonl_tree_strategy,
     static_key_strategy,
 )
+
+
+def _required_fields(schema: object) -> list[str]:
+    required = schema_node(schema).get("required")
+    if not isinstance(required, list):
+        return []
+    return [value for value in required if isinstance(value, str)]
+
+
+def _schema_string(schema: object, key: str) -> str | None:
+    value = schema_node(schema).get(key)
+    return value if isinstance(value, str) else None
 
 
 def _nested_required_paths(schema: object, *, depth: int = 0, path: str = "$") -> list[str]:
@@ -108,7 +122,7 @@ def test_collapse_dynamic_keys_preserves_static_fields_and_rehomes_dynamic_maps(
     dynamic_type: str,
 ) -> None:
     """Collapsing dynamic maps must keep static fields explicit and merge dynamic ones."""
-    schema = {
+    schema: dict[str, object] = {
         "type": "object",
         "required": static_keys + dynamic_keys,
         "properties": {
@@ -117,29 +131,31 @@ def test_collapse_dynamic_keys_preserves_static_fields_and_rehomes_dynamic_maps(
         },
     }
 
-    collapsed = collapse_dynamic_keys(copy.deepcopy(schema))
+    collapsed = collapse_dynamic_keys(json_document(copy.deepcopy(schema)))
+    properties = schema_properties(collapsed)
 
-    assert set(collapsed["properties"].keys()) == set(static_keys)
-    assert all(key not in collapsed["properties"] for key in dynamic_keys)
-    assert collapsed.get("x-polylogue-dynamic-keys") is True
-    assert "additionalProperties" in collapsed
-    assert set(collapsed.get("required", [])) == set(static_keys)
+    assert set(properties.keys()) == set(static_keys)
+    assert all(key not in properties for key in dynamic_keys)
+    assert schema_node(collapsed).get("x-polylogue-dynamic-keys") is True
+    assert "additionalProperties" in schema_node(collapsed)
+    assert set(_required_fields(collapsed)) == set(static_keys)
 
 
 @settings(max_examples=30)
 @given(st.lists(static_key_strategy(), min_size=1, max_size=4, unique=True))
 def test_collapse_dynamic_keys_leaves_static_only_objects_explicit(static_keys: list[str]) -> None:
     """Static-only schemas should not gain additionalProperties noise."""
-    schema = {
+    schema: dict[str, object] = {
         "type": "object",
         "properties": {key: {"type": "string"} for key in static_keys},
     }
 
-    collapsed = collapse_dynamic_keys(copy.deepcopy(schema))
+    collapsed = collapse_dynamic_keys(json_document(copy.deepcopy(schema)))
+    properties = schema_properties(collapsed)
 
-    assert set(collapsed["properties"].keys()) == set(static_keys)
-    assert "additionalProperties" not in collapsed
-    assert "x-polylogue-dynamic-keys" not in collapsed
+    assert set(properties.keys()) == set(static_keys)
+    assert "additionalProperties" not in schema_node(collapsed)
+    assert "x-polylogue-dynamic-keys" not in schema_node(collapsed)
 
 
 @settings(max_examples=35, deadline=None)
@@ -272,6 +288,6 @@ def test_generate_schema_from_samples_exposes_union_of_observed_top_level_fields
     schema = generate_schema_from_samples(samples)
     observed_keys = {key for sample in samples for key in sample}
 
-    assert observed_keys.issubset(schema.get("properties", {}).keys())
-    assert schema["type"] == "object"
-    assert schema["$schema"] == "https://json-schema.org/draft/2020-12/schema"
+    assert observed_keys.issubset(schema_properties(schema).keys())
+    assert _schema_string(schema, "type") == "object"
+    assert _schema_string(schema, "$schema") == "https://json-schema.org/draft/2020-12/schema"

--- a/tests/unit/core/test_schema_privacy.py
+++ b/tests/unit/core/test_schema_privacy.py
@@ -11,7 +11,7 @@ Tests are grouped by guard type so failures pinpoint which heuristic regressed.
 
 from __future__ import annotations
 
-from typing import Any, cast
+from collections.abc import Mapping
 
 import pytest
 from hypothesis import given, settings
@@ -23,6 +23,7 @@ from polylogue.schemas.schema_inference import (
     _is_content_field,
     _is_safe_enum_value,
 )
+from tests.infra.schema_access import schema_property, schema_values
 
 # =============================================================================
 # _is_safe_enum_value — existing heuristics (regression guard)
@@ -211,7 +212,7 @@ class TestCrossConversationThreshold:
         values_by_conv: dict[str, list[str]],
         *,
         min_conversation_count: int = 3,
-    ) -> dict[str, Any]:
+    ) -> Mapping[str, object]:
         """Build schema annotations from samples grouped by conversation ID."""
         samples = []
         conv_ids = []
@@ -226,9 +227,9 @@ class TestCrossConversationThreshold:
         flat_conv_ids: list[str | None] = [cid for cid, vals in values_by_conv.items() for _ in vals]
 
         stats = _collect_field_stats(flat_samples, conversation_ids=flat_conv_ids)
-        schema: dict[str, Any] = {"type": "object", "properties": {"status": {"type": "string"}}}
+        schema: dict[str, object] = {"type": "object", "properties": {"status": {"type": "string"}}}
         annotated = _annotate_schema(schema, stats, min_conversation_count=min_conversation_count)
-        return cast(dict[str, Any], annotated.get("properties", {}).get("status", {}))
+        return schema_property(annotated, "status")
 
     def test_value_in_one_conv_excluded_at_threshold_3(self) -> None:
         """A value seen in only 1 conversation is excluded when threshold=3."""
@@ -239,7 +240,7 @@ class TestCrossConversationThreshold:
             "conv_D": ["common"],
         }
         status_schema = self._make_schema_with_samples(values_by_conv, min_conversation_count=3)
-        enum_vals = status_schema.get("x-polylogue-values", [])
+        enum_vals = schema_values(status_schema)
         assert "rare_status" not in enum_vals, "Single-conversation value should be excluded"
 
     def test_value_in_three_convs_included_at_threshold_3(self) -> None:
@@ -250,14 +251,14 @@ class TestCrossConversationThreshold:
             "conv_C": ["stable_role"],
         }
         status_schema = self._make_schema_with_samples(values_by_conv, min_conversation_count=3)
-        enum_vals = status_schema.get("x-polylogue-values", [])
+        enum_vals = schema_values(status_schema)
         assert "stable_role" in enum_vals, "Value in 3 conversations should pass threshold=3"
 
     def test_threshold_1_includes_single_conv_values(self) -> None:
         """Default threshold=1 preserves existing behaviour (no cross-conv filtering)."""
         values_by_conv = {"conv_A": ["only_here", "only_here"]}
         status_schema = self._make_schema_with_samples(values_by_conv, min_conversation_count=1)
-        enum_vals = status_schema.get("x-polylogue-values", [])
+        enum_vals = schema_values(status_schema)
         assert "only_here" in enum_vals, "threshold=1 should not filter single-conv values"
 
     def test_no_conversation_ids_skips_threshold(self) -> None:
@@ -266,7 +267,7 @@ class TestCrossConversationThreshold:
         stats = _collect_field_stats(samples)  # no conversation_ids
         schema = {"type": "object", "properties": {"status": {"type": "string"}}}
         annotated = _annotate_schema(schema, stats, min_conversation_count=3)
-        enum_vals = annotated.get("properties", {}).get("status", {}).get("x-polylogue-values", [])
+        enum_vals = schema_values(schema_property(annotated, "status"))
         # No conversation tracking → no filtering
         assert "solo_value" in enum_vals
 
@@ -312,7 +313,7 @@ class TestKeyDenylist:
         stats = _collect_field_stats(samples)
         schema = {"type": "object", "properties": {field_name: {"type": "string"}}}
         annotated = _annotate_schema(schema, stats)
-        field_schema = annotated["properties"][field_name]
+        field_schema = schema_property(annotated, field_name)
         assert "x-polylogue-values" not in field_schema, f"Field '{field_name}' should suppress enum extraction"
 
     def test_non_denylist_field_gets_enums(self) -> None:
@@ -321,7 +322,7 @@ class TestKeyDenylist:
         stats = _collect_field_stats(samples)
         schema = {"type": "object", "properties": {"status": {"type": "string"}}}
         annotated = _annotate_schema(schema, stats)
-        assert "x-polylogue-values" in annotated["properties"]["status"]
+        assert "x-polylogue-values" in schema_property(annotated, "status")
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
Renew the schema generation, audit, and tooling boundary layer around explicit JSON/document contracts instead of loose schema-payload traversal.

## Problem
The schema authoring and audit surface was still one of the remaining path-dependent strata in the renewal program. Audit walkers/checks, generation helpers, sampling utilities, validator resolution, and tooling registry seams still mixed runtime meaning with broad mapping/object payload flow, while the surrounding tests relied on repeated deep indexing into JSON unions.

Closes #257
Ref #250

## Solution
- rebuilt schema audit walkers/checks around explicit JSON normalization and typed traversal helpers
- tightened generation, sampling, redaction, observation-identity, tooling-diff, validator-resolution, and operator-inference contracts so internal flow stays on modeled payload/document shapes
- widened selected source-side entry contracts only where callers naturally provide schema-like mappings, instead of forcing spurious narrowing at the public edge
- added shared schema-access helpers for tests and aligned the schema contract/property tests around those helpers
- suppressed the known Hypothesis filter-too-much false negative in rendering preservation so the verification baseline stays honest and green

## Verification
- `mypy tests/unit/core/test_schema_generation.py tests/unit/core/test_privacy_guards.py tests/unit/core/test_schema_privacy.py tests/unit/core/test_sampling.py tests/unit/core/test_schema_laws.py tests/unit/core/test_schema_annotation_contracts.py tests/unit/core/test_audit.py polylogue/schemas/audit_checks.py polylogue/schemas/operator_inference.py polylogue/schemas/generation_models.py polylogue/schemas/tooling_registry.py polylogue/schemas/validator_resolution.py tests/infra/schema_access.py`
- `pytest -q tests/unit/core/test_audit.py tests/unit/core/test_sampling.py tests/unit/core/test_schema_generation.py tests/unit/core/test_schema_privacy.py tests/unit/core/test_privacy_guards.py tests/unit/core/test_schema_laws.py tests/unit/core/test_schema_annotation_contracts.py`
- `pytest -q tests/property/test_rendering_preservation.py -k json_yaml_agree_on_identity`
- `devtools verify`
