### PR TITLE
refactor: contract CLI, MCP, and UI surfaces over renewed substrate

### DIFF
--- a/polylogue/cli/check_maintenance.py
+++ b/polylogue/cli/check_maintenance.py
@@ -2,18 +2,24 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING
 
+from polylogue.cli.check_models import VacuumResult
+from polylogue.cli.types import AppEnv
+from polylogue.health import HealthReport
 from polylogue.maintenance_targets import MaintenanceTargetMode, build_maintenance_target_catalog
-from polylogue.storage.repair import preview_counts_from_archive_debt
+from polylogue.storage.repair import RepairResult, preview_counts_from_archive_debt
+
+if TYPE_CHECKING:
+    from polylogue.cli.check_workflow import CheckCommandOptions
 
 
-def build_preview_counts(report: Any) -> dict[str, int]:
-    return preview_counts_from_archive_debt(getattr(report, "archive_debt", {}) or {})
+def build_preview_counts(report: HealthReport) -> dict[str, int]:
+    return preview_counts_from_archive_debt(report.archive_debt)
 
 
 def resolve_selected_maintenance_targets(
-    options: Any,
+    options: CheckCommandOptions,
 ) -> tuple[str, ...]:
     if options.maintenance_targets:
         return tuple(options.maintenance_targets)
@@ -27,13 +33,13 @@ def resolve_selected_maintenance_targets(
 
 
 def persist_maintenance_run(
-    env: Any,
+    env: AppEnv,
     *,
-    report: Any,
-    options: Any,
+    report: HealthReport,
+    options: CheckCommandOptions,
     targets: tuple[str, ...],
-    maintenance_results: list[Any],
-    vacuum_result: dict[str, Any] | None,
+    maintenance_results: list[RepairResult],
+    vacuum_result: VacuumResult | None,
     preview_counts: dict[str, int] | None,
 ) -> None:
     """No-op — maintenance run recording removed."""

--- a/polylogue/cli/check_models.py
+++ b/polylogue/cli/check_models.py
@@ -1,0 +1,44 @@
+"""Shared typed models for the check command surface."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from polylogue.health import HealthReport
+from polylogue.schemas.verification_models import ArtifactProofReport, SchemaVerificationReport
+from polylogue.storage.artifact_views import ArtifactCohortSummary
+from polylogue.storage.repair import RepairResult
+from polylogue.storage.store import ArtifactObservationRecord
+
+
+@dataclass(frozen=True)
+class VacuumResult:
+    """Machine-safe VACUUM result payload shared by workflow and renderers."""
+
+    ok: bool
+    detail: str
+    preview: bool = False
+
+    def to_dict(self) -> dict[str, str | bool]:
+        payload: dict[str, str | bool] = {"ok": self.ok, "detail": self.detail}
+        if self.preview:
+            payload["preview"] = True
+        return payload
+
+
+@dataclass
+class CheckCommandResult:
+    """Typed output surface for the check command workflow."""
+
+    report: HealthReport
+    runtime_report: HealthReport | None = None
+    schema_report: SchemaVerificationReport | None = None
+    proof_report: ArtifactProofReport | None = None
+    artifact_rows: list[ArtifactObservationRecord] | None = None
+    cohort_rows: list[ArtifactCohortSummary] | None = None
+    maintenance_results: list[RepairResult] | None = None
+    maintenance_targets: tuple[str, ...] = ()
+    vacuum_result: VacuumResult | None = None
+
+
+__all__ = ["CheckCommandResult", "VacuumResult"]

--- a/polylogue/cli/check_rendering_json.py
+++ b/polylogue/cli/check_rendering_json.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from polylogue.cli.machine_errors import emit_success
 
-from .check_workflow import CheckCommandOptions, CheckCommandResult
+from .check_models import CheckCommandResult
+from .check_workflow import CheckCommandOptions
 
 
 def emit_json_output(result: CheckCommandResult, options: CheckCommandOptions) -> None:
@@ -31,9 +32,9 @@ def emit_json_output(result: CheckCommandResult, options: CheckCommandOptions) -
         }
     if result.maintenance_results is not None:
         out["maintenance"] = {
-            "targets": list(options.maintenance_targets),
+            "targets": list(result.maintenance_targets),
             "items": [repair.to_dict() for repair in result.maintenance_results],
         }
     if result.vacuum_result is not None:
-        out["vacuum"] = result.vacuum_result
+        out["vacuum"] = result.vacuum_result.to_dict()
     emit_success(out)

--- a/polylogue/cli/check_rendering_plain.py
+++ b/polylogue/cli/check_rendering_plain.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import click
 
+from polylogue.cli.check_models import CheckCommandResult
 from polylogue.cli.check_support import format_count_mapping, run_vacuum
-from polylogue.cli.check_workflow import CheckCommandOptions, CheckCommandResult
+from polylogue.cli.check_workflow import CheckCommandOptions
 from polylogue.cli.types import AppEnv
 from polylogue.health import VerifyStatus
 
@@ -170,12 +171,12 @@ def append_artifact_observation_lines(lines: list[str], result: CheckCommandResu
 
     if result.cohort_rows is not None:
         lines.extend(["", f"Artifact cohorts: {len(result.cohort_rows):,} cohorts"])
-        for row in result.cohort_rows:
+        for cohort in result.cohort_rows:
             lines.append(
-                f"  {row.provider_name} {row.artifact_kind} {row.support_status} "
-                f"count={row.observation_count:,} cohort={row.cohort_id or '-'} "
-                f"version={row.resolved_package_version or '-'} "
-                f"element={row.resolved_element_kind or '-'}"
+                f"  {cohort.provider_name} {cohort.artifact_kind} {cohort.support_status} "
+                f"count={cohort.observation_count:,} cohort={cohort.cohort_id or '-'} "
+                f"version={cohort.resolved_package_version or '-'} "
+                f"element={cohort.resolved_element_kind or '-'}"
             )
 
 
@@ -214,8 +215,8 @@ def emit_maintenance_output(
         click.echo("")
         mode_label = "Preview of maintenance" if options.preview else "Running maintenance"
         click.echo(f"{mode_label}...")
-        if options.maintenance_targets:
-            click.echo(f"  Targets: {', '.join(options.maintenance_targets)}")
+        if result.maintenance_targets:
+            click.echo(f"  Targets: {', '.join(result.maintenance_targets)}")
         total_repaired = 0
         for repair in result.maintenance_results:
             if repair.repaired_count > 0 or not repair.success:

--- a/polylogue/cli/check_support.py
+++ b/polylogue/cli/check_support.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 import sys
 import time
-from typing import Any
 
+from polylogue.cli.check_models import VacuumResult
 from polylogue.cli.helpers import fail
 from polylogue.cli.types import AppEnv
+from polylogue.protocols import ProgressCallback
 
 
 def format_count_mapping(counts: dict[str, int]) -> str:
@@ -38,7 +39,7 @@ def parse_schema_samples(raw: str) -> int | None:
     return parsed
 
 
-def make_count_progress_callback(*, label: str, unit: str) -> Any:
+def make_count_progress_callback(*, label: str, unit: str) -> ProgressCallback:
     """Return a stderr progress reporter for monotonically increasing counters."""
     start = time.monotonic()
     count = 0
@@ -59,30 +60,30 @@ def make_count_progress_callback(*, label: str, unit: str) -> Any:
     return _cb
 
 
-def make_schema_progress_callback() -> Any:
+def make_schema_progress_callback() -> ProgressCallback:
     """Return a stderr progress reporter for schema verification."""
     return make_count_progress_callback(label="Verifying schemas", unit="raw records")
 
 
-def make_session_product_progress_callback() -> Any:
+def make_session_product_progress_callback() -> ProgressCallback:
     """Return a stderr progress reporter for session-product repairs."""
     return make_count_progress_callback(label="Repairing session products", unit="conversations")
 
 
-def vacuum_database(env: AppEnv) -> dict[str, Any]:
+def vacuum_database(env: AppEnv) -> VacuumResult:
     """Run VACUUM and return a machine-readable result."""
     from polylogue.storage.backends.connection import open_connection
 
     try:
         with open_connection(env.config.db_path) as conn:
             conn.execute("VACUUM")
-        return {"ok": True, "detail": "Running VACUUM to reclaim space...\n  VACUUM complete."}
+        return VacuumResult(ok=True, detail="Running VACUUM to reclaim space...\n  VACUUM complete.")
     except Exception as exc:
-        return {"ok": False, "detail": f"Running VACUUM to reclaim space...\n  VACUUM failed: {exc}"}
+        return VacuumResult(ok=False, detail=f"Running VACUUM to reclaim space...\n  VACUUM failed: {exc}")
 
 
 def run_vacuum(env: AppEnv) -> None:
     """Run VACUUM to reclaim unused space."""
     result = vacuum_database(env)
     env.ui.console.print("")
-    env.ui.console.print(result["detail"])
+    env.ui.console.print(result.detail)

--- a/polylogue/cli/check_workflow.py
+++ b/polylogue/cli/check_workflow.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import sys
 from dataclasses import dataclass
-from typing import Any
 
 from polylogue.cli.check_maintenance import (
     build_preview_counts as _build_preview_counts,
@@ -15,9 +14,8 @@ from polylogue.cli.check_maintenance import (
 from polylogue.cli.check_maintenance import (
     resolve_selected_maintenance_targets as _resolve_selected_maintenance_targets,
 )
-from polylogue.cli.check_validation import (
-    validate_check_options as _validate_check_options,
-)
+from polylogue.cli.check_models import CheckCommandResult, VacuumResult
+from polylogue.cli.check_validation import validate_check_options as _validate_check_options
 from polylogue.cli.helpers import load_effective_config
 from polylogue.cli.types import AppEnv
 from polylogue.health import get_health, run_runtime_health
@@ -69,18 +67,6 @@ class CheckCommandOptions:
     schema_record_offset: int
     schema_quarantine_malformed: bool
     maintenance_targets: tuple[str, ...]
-
-
-@dataclass
-class CheckCommandResult:
-    report: Any
-    runtime_report: Any | None = None
-    schema_report: Any | None = None
-    proof_report: Any | None = None
-    artifact_rows: list[Any] | None = None
-    cohort_rows: list[Any] | None = None
-    maintenance_results: list[Any] | None = None
-    vacuum_result: dict[str, Any] | None = None
 
 
 def validate_check_options(options: CheckCommandOptions) -> None:
@@ -189,6 +175,7 @@ def run_check_workflow(env: AppEnv, options: CheckCommandOptions) -> CheckComman
     if options.repair or options.cleanup:
         preview_counts = _build_preview_counts(report) if options.preview else None
         selected_targets = _resolve_selected_maintenance_targets(options)
+        result.maintenance_targets = selected_targets
         session_product_progress_callback = None
         if (
             options.repair
@@ -209,11 +196,7 @@ def run_check_workflow(env: AppEnv, options: CheckCommandOptions) -> CheckComman
 
     if (options.repair or options.cleanup) and options.vacuum:
         if options.preview:
-            result.vacuum_result = {
-                "ok": True,
-                "preview": True,
-                "detail": "Preview mode: VACUUM skipped.",
-            }
+            result.vacuum_result = VacuumResult(ok=True, preview=True, detail="Preview mode: VACUUM skipped.")
         elif options.json_output:
             result.vacuum_result = vacuum_database(env)
 

--- a/polylogue/cli/commands/check.py
+++ b/polylogue/cli/commands/check.py
@@ -2,10 +2,9 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 import click
 
+from polylogue.cli.check_models import VacuumResult
 from polylogue.cli.check_options import apply_check_command_options
 from polylogue.cli.check_rendering_json import emit_json_output
 from polylogue.cli.check_rendering_plain import render_plain_output
@@ -22,6 +21,7 @@ from polylogue.cli.check_support import run_vacuum as _run_vacuum_impl
 from polylogue.cli.check_support import vacuum_database as _vacuum_database_impl
 from polylogue.cli.check_workflow import CheckCommandOptions, run_check_workflow, validate_check_options
 from polylogue.cli.types import AppEnv
+from polylogue.protocols import ProgressCallback
 
 
 def _format_count_mapping(counts: dict[str, int]) -> str:
@@ -93,7 +93,7 @@ def check_command(
     render_plain_output(env, result, options)
 
 
-def _make_schema_progress_callback() -> Any:
+def _make_schema_progress_callback() -> ProgressCallback:
     return _make_schema_progress_callback_impl()
 
 
@@ -101,7 +101,7 @@ def _run_vacuum(env: AppEnv) -> None:
     _run_vacuum_impl(env)
 
 
-def _vacuum_database(env: AppEnv) -> dict[str, Any]:
+def _vacuum_database(env: AppEnv) -> VacuumResult:
     return _vacuum_database_impl(env)
 
 

--- a/polylogue/cli/query.py
+++ b/polylogue/cli/query.py
@@ -3,11 +3,11 @@
 from __future__ import annotations
 
 import inspect
-from collections.abc import Iterable, Mapping, Sequence
+from collections.abc import Awaitable, Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
-from typing import TYPE_CHECKING, Any, NoReturn
+from typing import TYPE_CHECKING, NoReturn, Protocol, TypeAlias, TypeVar, cast
 
 import click
 
@@ -27,26 +27,41 @@ if TYPE_CHECKING:
     from polylogue.lib.models import Conversation, ConversationSummary
     from polylogue.protocols import VectorProvider
 
+QueryParams: TypeAlias = dict[str, object]
+QueryParamSource: TypeAlias = Mapping[str, object] | ConversationQuerySpec
+QueryResult: TypeAlias = "Conversation | ConversationSummary"
+_T = TypeVar("_T")
+
+
+class ShowStatsCallback(Protocol):
+    def __call__(self, env: AppEnv, *, verbose: bool = False) -> None: ...
+
+
+async def _resolve_maybe_awaitable(value: _T | object) -> _T:
+    if inspect.isawaitable(value):
+        return await cast(Awaitable[_T], value)
+    return cast(_T, value)
+
 
 # ---------------------------------------------------------------------------
 # Query helpers (from query_helpers.py)
 # ---------------------------------------------------------------------------
 
 
-def coerce_query_spec(params: dict[str, Any] | ConversationQuerySpec) -> ConversationQuerySpec:
+def coerce_query_spec(params: QueryParamSource) -> ConversationQuerySpec:
     if isinstance(params, ConversationQuerySpec):
         return params
     return ConversationQuerySpec.from_params(params)
 
 
-def describe_query_filters(params: dict[str, Any] | ConversationQuerySpec) -> list[str]:
+def describe_query_filters(params: QueryParamSource) -> list[str]:
     """Build a human-readable list of active filters from params or spec."""
     return coerce_query_spec(params).describe()
 
 
 def no_results(
     env: AppEnv,
-    params: dict[str, Any] | ConversationQuerySpec,
+    params: QueryParamSource,
     *,
     exit_code: int = 2,
 ) -> NoReturn:
@@ -66,20 +81,20 @@ def no_results(
     raise SystemExit(exit_code)
 
 
-def result_id(result: Conversation | ConversationSummary) -> str:
+def result_id(result: QueryResult) -> str:
     return str(result.id)
 
 
-def result_provider(result: Conversation | ConversationSummary) -> str:
+def result_provider(result: QueryResult) -> str:
     return str(result.provider)
 
 
-def result_title(result: Conversation | ConversationSummary) -> str:
+def result_title(result: QueryResult) -> str:
     title = result.display_title
     return title if title else result_id(result)[:20]
 
 
-def result_date(result: Conversation | ConversationSummary) -> datetime | None:
+def result_date(result: QueryResult) -> datetime | None:
     display_date = getattr(result, "display_date", None)
     if isinstance(display_date, datetime):
         return display_date
@@ -398,7 +413,7 @@ def _split_query_mode_args(group: click.Group, args: list[str]) -> tuple[list[st
 def handle_query_mode(
     ctx: click.Context,
     *,
-    show_stats: Any,
+    show_stats: ShowStatsCallback,
 ) -> None:
     """Handle query mode: display stats or perform search."""
     env: AppEnv = ctx.obj
@@ -422,7 +437,7 @@ class QueryFirstGroupBase(click.Group):
             ctx.meta["polylogue_query_terms"] = query_terms
         return list(super().parse_args(ctx, parse_args))
 
-    def invoke(self, ctx: click.Context) -> Any:
+    def invoke(self, ctx: click.Context) -> object:
         """Invoke the group, dispatching to query or stats mode if no subcommand."""
         if ctx.meta.get("polylogue_has_subcommand", False):
             return super().invoke(ctx)
@@ -432,6 +447,7 @@ class QueryFirstGroupBase(click.Group):
             ctx.invoke(self.callback, **ctx.params)
 
         self.handle_default_mode(ctx)
+        return None
 
     def handle_default_mode(self, ctx: click.Context) -> None:
         """Dispatch no-subcommand mode for subclasses."""
@@ -455,7 +471,7 @@ def project_query_results(results: list[Conversation], plan: QueryExecutionPlan)
     return projected
 
 
-def execute_query(env: AppEnv, params: dict[str, Any]) -> None:
+def execute_query(env: AppEnv, params: QueryParams) -> None:
     """Execute a query-mode command."""
     run_coroutine_sync(async_execute_query(env, params))
 
@@ -473,13 +489,7 @@ def _create_query_vector_provider(config: Config) -> VectorProvider | None:
         return None
 
 
-async def _await_if_needed(value: Any) -> Any:
-    if inspect.isawaitable(value):
-        return await value
-    return value
-
-
-async def async_execute_query(env: AppEnv, params: dict[str, Any]) -> None:
+async def async_execute_query(env: AppEnv, params: QueryParams) -> None:
     """Async core of execute_query."""
     from polylogue.cli import query_actions as _query_actions
     from polylogue.cli import query_output as _query_output
@@ -558,13 +568,15 @@ async def async_execute_query(env: AppEnv, params: dict[str, Any]) -> None:
                 err=True,
             )
 
+        message_limit_param = params.get("limit")
+        message_limit = message_limit_param if isinstance(message_limit_param, int) else None
         await _query_output.stream_conversation(
             env,
             repo,
             full_id,
             output_format=plan.output.stream_format(),
             dialogue_only=plan.output.dialogue_only,
-            message_limit=params.get("limit"),
+            message_limit=message_limit,
         )
         return
 
@@ -598,7 +610,7 @@ async def async_execute_query(env: AppEnv, params: dict[str, Any]) -> None:
                 output_format=plan.output.output_format,
             )
             return
-        if await _await_if_needed(query_plan.can_use_action_event_stats_with(repo)) is True:
+        if await _resolve_maybe_awaitable(query_plan.can_use_action_event_stats_with(repo)) is True:
             summaries = await repo.list_summaries_by_query(query_plan.record_query.with_limit(query_plan.limit))
             await _query_output.output_stats_by_semantic_summaries(
                 env,

--- a/polylogue/cli/query_output.py
+++ b/polylogue/cli/query_output.py
@@ -11,7 +11,7 @@ from collections.abc import Sequence
 from datetime import datetime
 from html import escape as html_escape
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, TypeAlias
 
 import click
 
@@ -45,6 +45,9 @@ if TYPE_CHECKING:
     from polylogue.lib.models import Conversation, ConversationSummary, Message
     from polylogue.protocols import ConversationOutputStore
     from polylogue.storage.store import MessageRecord
+
+QueryParams: TypeAlias = dict[str, object]
+ConversationStats: TypeAlias = dict[str, int]
 
 
 # ---------------------------------------------------------------------------
@@ -339,11 +342,11 @@ def format_summary_list(
 async def output_summary_list(
     env: AppEnv,
     summaries: list[ConversationSummary],
-    params: dict[str, object],
+    params: QueryParams,
     repo: ConversationOutputStore | None = None,
 ) -> None:
     """Output a list of conversation summaries with optional rich table rendering."""
-    output_format = str(params.get("output_format", "text"))
+    output_format = str(params.get("output_format") or "text")
     msg_counts: dict[str, int] = {}
     if repo:
         ids = [str(summary.id) for summary in summaries]
@@ -457,7 +460,7 @@ def render_stream_header(
     output_format: str,
     dialogue_only: bool,
     message_limit: int | None,
-    stats: dict[str, Any] | None,
+    stats: ConversationStats | None,
 ) -> str:
     """Render any stream prelude/header for the selected output format."""
     if hasattr(display_date, "strftime"):
@@ -521,7 +524,7 @@ def render_stream_transcript(
     output_format: str,
     dialogue_only: bool = False,
     message_limit: int | None = None,
-    stats: dict[str, Any] | None = None,
+    stats: ConversationStats | None = None,
 ) -> tuple[str, int]:
     """Render the full stream transcript deterministically for proof/tests."""
     parts = [
@@ -603,7 +606,7 @@ def write_message_streaming(message: Message | MessageRecord, output_format: str
         sys.stdout.flush()
 
 
-def no_results(env: AppEnv, params: dict[str, Any], *, exit_code: int = 2) -> None:
+def no_results(env: AppEnv, params: QueryParams, *, exit_code: int = 2) -> None:
     """Delegate the no-results contract to the canonical query helper."""
     from polylogue.cli.query import no_results as query_no_results
 
@@ -618,16 +621,17 @@ def no_results(env: AppEnv, params: dict[str, Any], *, exit_code: int = 2) -> No
 def output_results(
     env: AppEnv,
     results: list[Conversation],
-    params: dict[str, Any],
+    params: QueryParams,
 ) -> None:
     """Output query results."""
     if not results:
         no_results(env, params)
 
-    output_format = params.get("output_format", "markdown")
-    output_dest = params.get("output", "stdout")
-    list_mode = params.get("list_mode", False)
+    output_format = str(params.get("output_format") or "markdown")
+    output_dest = str(params.get("output") or "stdout")
+    list_mode = bool(params.get("list_mode", False))
     fields = params.get("fields")
+    fields_value = fields if isinstance(fields, str) else None
     destinations = [d.strip() for d in output_dest.split(",")] if output_dest else ["stdout"]
 
     if len(results) == 1 and not list_mode:
@@ -635,11 +639,11 @@ def output_results(
         if output_format == "markdown" and destinations == ["stdout"] and not env.ui.plain:
             _render_conversation_rich(env, conv)
             return
-        content = format_conversation(conv, output_format, fields)
+        content = format_conversation(conv, output_format, fields_value)
         _send_output(env, content, destinations, output_format, conv)
         return
 
-    content = _format_list(results, output_format, fields)
+    content = _format_list(results, output_format, fields_value)
     _send_output(env, content, destinations, output_format, None)
 
 

--- a/polylogue/cli/query_verbs.py
+++ b/polylogue/cli/query_verbs.py
@@ -6,8 +6,6 @@ a specific action on the matched conversations.
 
 from __future__ import annotations
 
-from typing import Any
-
 import click
 
 from polylogue.cli.shell_completion_values import complete_open_targets
@@ -107,7 +105,7 @@ def delete_verb(ctx: click.Context, dry_run: bool, force: bool) -> None:
     _execute_query_verb(ctx, params)
 
 
-def _parent_params(ctx: click.Context) -> dict[str, Any]:
+def _parent_params(ctx: click.Context) -> dict[str, object]:
     """Extract params from parent context."""
     return dict(_require_parent_context(ctx).params)
 
@@ -128,7 +126,7 @@ def _require_parent_context(ctx: click.Context) -> click.Context:
 
 def _execute_query_verb(
     ctx: click.Context,
-    params: dict[str, Any],
+    params: dict[str, object],
     *,
     extra_query_terms: tuple[str, ...] = (),
 ) -> None:

--- a/polylogue/cli/root_request.py
+++ b/polylogue/cli/root_request.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from polylogue.lib.query_spec import ConversationQuerySpec
 
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 class RootModeRequest:
     """Canonical root request for stats-or-query dispatch."""
 
-    params: dict[str, Any]
+    params: dict[str, object]
     query_terms: tuple[str, ...]
 
     @classmethod
@@ -25,7 +25,7 @@ class RootModeRequest:
         )
         return cls(params=dict(ctx.params), query_terms=query_terms)
 
-    def query_params(self) -> dict[str, Any]:
+    def query_params(self) -> dict[str, object]:
         params = dict(self.params)
         params["query"] = self.query_terms
         return params

--- a/polylogue/lib/query_retrieval_candidates.py
+++ b/polylogue/lib/query_retrieval_candidates.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal, overload
+import inspect
+from collections.abc import Awaitable
+from typing import TYPE_CHECKING, Literal, TypeVar, cast, overload
 
 from polylogue.lib.query_support import provider_values
 
@@ -11,6 +13,15 @@ if TYPE_CHECKING:
     from polylogue.lib.query_plan import ConversationQueryPlan
     from polylogue.protocols import ConversationQueryRuntimeStore
     from polylogue.storage.query_models import ConversationRecordQuery
+
+
+_T = TypeVar("_T")
+
+
+async def _resolve_maybe_awaitable(value: _T | object) -> _T:
+    if inspect.isawaitable(value):
+        return await cast(Awaitable[_T], value)
+    return cast(_T, value)
 
 
 def candidate_record_query(plan: ConversationQueryPlan) -> tuple[ConversationRecordQuery, bool]:
@@ -45,7 +56,9 @@ async def action_event_rows_ready(
 ) -> bool:
     if not uses_action_read_model(plan):
         return True
-    return (await repository.get_action_event_artifact_state()).rows_ready
+    state: object = await _resolve_maybe_awaitable(repository.get_action_event_artifact_state())
+    rows_ready = getattr(state, "rows_ready", False)
+    return rows_ready if isinstance(rows_ready, bool) else False
 
 
 async def action_search_ready(
@@ -54,7 +67,9 @@ async def action_search_ready(
 ) -> bool:
     if not uses_action_read_model(plan):
         return True
-    return (await repository.get_action_event_artifact_state()).ready
+    state: object = await _resolve_maybe_awaitable(repository.get_action_event_artifact_state())
+    ready = getattr(state, "ready", False)
+    return ready if isinstance(ready, bool) else False
 
 
 async def can_use_action_event_stats_with(

--- a/polylogue/mcp/__init__.py
+++ b/polylogue/mcp/__init__.py
@@ -3,10 +3,14 @@
 from __future__ import annotations
 
 import importlib
-from typing import Any
+from types import ModuleType
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from polylogue.mcp import server as server
 
 
-def __getattr__(name: str) -> Any:
+def __getattr__(name: str) -> ModuleType:
     if name == "server":
         return importlib.import_module(f"{__name__}.server")
     raise AttributeError(name)

--- a/polylogue/mcp/payloads.py
+++ b/polylogue/mcp/payloads.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import json
 from typing import TYPE_CHECKING, Generic, TypeVar
 
 from pydantic import RootModel
+from typing_extensions import TypedDict
 
 from polylogue.surface_payloads import (
     ConversationDetailPayload as MCPConversationDetailPayload,
@@ -42,6 +44,11 @@ class MCPErrorPayload(SurfacePayloadModel):
     error: str
     tool: str | None = None
     conversation_id: str | None = None
+
+
+class MCPFencedCodeBlock(TypedDict):
+    language: str
+    code: str
 
 
 class MCPConversationSummaryListPayload(MCPRootPayload[list[MCPConversationSummaryPayload]]):
@@ -126,8 +133,12 @@ class MCPTagCountsPayload(MCPRootPayload[dict[str, int]]):
     root: dict[str, int]
 
 
-class MCPMetadataPayload(MCPRootPayload[dict[str, object]]):
+class MCPMetadataPayload(SurfacePayloadModel):
     root: dict[str, object]
+
+    def to_json(self, *, exclude_none: bool = False) -> str:
+        del exclude_none
+        return json.dumps(self.root, indent=2)
 
 
 class MCPStatsByPayload(MCPRootPayload[dict[str, int]]):
@@ -197,6 +208,7 @@ __all__ = [
     "MCPConversationSummaryListPayload",
     "MCPConversationSummaryPayload",
     "MCPErrorPayload",
+    "MCPFencedCodeBlock",
     "MCPHealthCheckPayload",
     "MCPHealthReportPayload",
     "MCPMessagePayload",

--- a/polylogue/mcp/server_product_tools.py
+++ b/polylogue/mcp/server_product_tools.py
@@ -7,6 +7,8 @@ lookups) are registered directly.
 
 from __future__ import annotations
 
+import inspect
+from collections.abc import Mapping
 from typing import TYPE_CHECKING
 
 from polylogue.mcp.payloads import MCPRootPayload
@@ -22,6 +24,84 @@ if TYPE_CHECKING:
     from polylogue.mcp.server_support import ServerCallbacks
 
 
+def _query_field_defaults(pt: ProductType) -> tuple[dict[str, object | None], dict[str, object]]:
+    query_model = pt.query_model
+    if query_model is None:
+        raise ValueError(f"Product type {pt.name} does not declare a query model")
+
+    defaults: dict[str, object | None] = {}
+    annotations: dict[str, object] = {}
+    for field_name, field_info in query_model.model_fields.items():
+        defaults[field_name] = None if field_info.is_required() else field_info.get_default(call_default_factory=True)
+        annotations[field_name] = field_info.annotation if field_info.annotation is not None else object
+    return defaults, annotations
+
+
+def _sanitize_offset(value: object) -> int:
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, (int, str, bytes, bytearray)):
+        return max(0, int(value))
+    return 0
+
+
+def _normalize_list_tool_kwargs(
+    hooks: ServerCallbacks,
+    kwargs: Mapping[str, object],
+) -> dict[str, object]:
+    normalized = dict(kwargs)
+    if "limit" in normalized:
+        normalized["limit"] = hooks.clamp_limit(normalized["limit"])
+    if "offset" in normalized:
+        normalized["offset"] = _sanitize_offset(normalized["offset"])
+    return normalized
+
+
+def _build_list_tool_parameters(
+    pt: ProductType,
+    *,
+    field_defaults: dict[str, object | None],
+    field_annotations: dict[str, object],
+) -> list[inspect.Parameter]:
+    params: list[inspect.Parameter] = []
+    for field_name in sorted(field_annotations):
+        if field_name == "limit":
+            params.append(
+                inspect.Parameter(
+                    field_name,
+                    inspect.Parameter.KEYWORD_ONLY,
+                    default=pt.mcp_default_limit,
+                    annotation=int,
+                )
+            )
+            continue
+        if field_name == "offset":
+            params.append(
+                inspect.Parameter(
+                    field_name,
+                    inspect.Parameter.KEYWORD_ONLY,
+                    default=0,
+                    annotation=int,
+                )
+            )
+            continue
+        params.append(
+            inspect.Parameter(
+                field_name,
+                inspect.Parameter.KEYWORD_ONLY,
+                default=field_defaults.get(field_name),
+                annotation=field_annotations[field_name],
+            )
+        )
+    return params
+
+
+def _wrapper_annotations(params: list[inspect.Parameter]) -> dict[str, object]:
+    annotations: dict[str, object] = {parameter.name: parameter.annotation for parameter in params}
+    annotations["return"] = str
+    return annotations
+
+
 def _register_list_tool(
     mcp: FastMCP,
     hooks: ServerCallbacks,
@@ -32,33 +112,18 @@ def _register_list_tool(
     query_model = pt.query_model
     if query_model is None:
         raise ValueError(f"Product type {pt.name} does not declare a query model")
-    query_fields = set(query_model.model_fields)
-
-    # Determine parameter defaults from the query class
-    field_defaults: dict[str, object | None] = {}
-    field_annotations: dict[str, object] = {}
-    for fname, finfo in query_model.model_fields.items():
-        if finfo.default is not None:
-            field_defaults[fname] = finfo.default
-        else:
-            field_defaults[fname] = None
-        field_annotations[fname] = finfo.annotation if finfo.annotation is not None else object
+    field_defaults, field_annotations = _query_field_defaults(pt)
+    params = _build_list_tool_parameters(
+        pt,
+        field_defaults=field_defaults,
+        field_annotations=field_annotations,
+    )
 
     async def tool_fn(**kwargs: object) -> str:
         async def run() -> str:
             ops = hooks.get_archive_ops()
-            # Apply limit clamping and offset sanitization
-            if "limit" in kwargs:
-                kwargs["limit"] = hooks.clamp_limit(kwargs["limit"])
-            if "offset" in kwargs:
-                offset_value = kwargs["offset"]
-                if isinstance(offset_value, bool):
-                    kwargs["offset"] = 0
-                elif isinstance(offset_value, (int, str, bytes, bytearray)):
-                    kwargs["offset"] = max(0, int(offset_value))
-                else:
-                    kwargs["offset"] = 0
-            products = await fetch_products_async(pt, ops, **kwargs)
+            normalized_kwargs = _normalize_list_tool_kwargs(hooks, kwargs)
+            products = await fetch_products_async(pt, ops, **normalized_kwargs)
             return hooks.json_payload(
                 MCPRootPayload(
                     root={
@@ -70,31 +135,6 @@ def _register_list_tool(
 
         return await hooks.async_safe_call(pt.name, run)
 
-    # Build a dynamic function signature so FastMCP can introspect parameters.
-    # We create a wrapper with explicit keyword arguments matching the query class.
-    import inspect
-
-    params = [
-        inspect.Parameter("self_placeholder", inspect.Parameter.POSITIONAL_OR_KEYWORD, default=None),
-    ]
-    for fname in sorted(query_fields):
-        default = field_defaults.get(fname)
-        annotation = field_annotations[fname]
-        if fname == "limit":
-            params.append(
-                inspect.Parameter(fname, inspect.Parameter.KEYWORD_ONLY, default=pt.mcp_default_limit, annotation=int)
-            )
-        elif fname == "offset":
-            params.append(inspect.Parameter(fname, inspect.Parameter.KEYWORD_ONLY, default=0, annotation=int))
-        else:
-            params.append(
-                inspect.Parameter(fname, inspect.Parameter.KEYWORD_ONLY, default=default, annotation=annotation)
-            )
-
-    # Remove the placeholder — FastMCP doesn't need it
-    params = params[1:]
-
-    # Create a properly-signed wrapper
     async def wrapper(**kw: object) -> str:
         return await tool_fn(**kw)
 
@@ -102,16 +142,8 @@ def _register_list_tool(
     wrapper.__qualname__ = pt.name
     wrapper.__doc__ = f"List {pt.display_name.lower()} from the archive."
 
-    # Set annotations for FastMCP introspection
-    annotations: dict[str, object] = {}
-    for p in params:
-        annotations[p.name] = p.annotation
-    annotations["return"] = str
-    wrapper.__annotations__ = annotations
-
-    # Set defaults
-    defaults_dict = {p.name: p.default for p in params}
-    wrapper.__kwdefaults__ = defaults_dict
+    wrapper.__annotations__ = _wrapper_annotations(params)
+    wrapper.__kwdefaults__ = {parameter.name: parameter.default for parameter in params}
 
     mcp.tool()(wrapper)
 

--- a/polylogue/mcp/server_prompts.py
+++ b/polylogue/mcp/server_prompts.py
@@ -4,14 +4,91 @@ from __future__ import annotations
 
 import json
 from datetime import datetime, timedelta, timezone
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, TypeAlias
 
+from typing_extensions import TypedDict
+
+from polylogue.mcp.payloads import MCPFencedCodeBlock
 from polylogue.mcp.server_tools import build_query_spec
+from polylogue.types import Provider
 
 if TYPE_CHECKING:
     from mcp.server.fastmcp import FastMCP
 
+    from polylogue.lib.conversation_models import Conversation
+    from polylogue.lib.message_models import Message
     from polylogue.mcp.server_support import ServerCallbacks
+
+
+class ErrorContextPayload(TypedDict):
+    conversation_id: str
+    provider: Provider
+    timestamp: str | None
+    snippet: str
+
+
+class ExtractedCodeSnippetPayload(TypedDict):
+    language: str
+    code: str
+    conversation: str
+
+
+class ComparedMessagePayload(TypedDict):
+    role: str
+    text: str
+
+
+class MissingConversationPayload(TypedDict):
+    error: str
+
+
+class ConversationSummaryPayload(TypedDict):
+    id: str
+    provider: Provider
+    title: str
+    message_count: int
+    messages: list[ComparedMessagePayload]
+
+
+class ConversationPatternPayload(TypedDict):
+    id: str
+    provider: Provider
+    title: str
+    opening: list[str]
+
+
+CompareConversationPayload: TypeAlias = ConversationSummaryPayload | MissingConversationPayload
+
+
+def _message_role(message: Message) -> str:
+    role = message.role
+    return role.value if hasattr(role, "value") else str(role)
+
+
+def _summarize_conversation(conv: Conversation | None) -> CompareConversationPayload:
+    if conv is None:
+        return {"error": "not found"}
+    return {
+        "id": str(conv.id),
+        "provider": conv.provider,
+        "title": conv.display_title,
+        "message_count": len(conv.messages),
+        "messages": [
+            {
+                "role": _message_role(message) if message.role else "unknown",
+                "text": (message.text or "")[:200],
+            }
+            for message in conv.messages.to_list()[:10]
+        ],
+    }
+
+
+def _code_snippet_payload(block: MCPFencedCodeBlock, conversation_id: str) -> ExtractedCodeSnippetPayload:
+    return {
+        "language": block.get("language", ""),
+        "code": block.get("code", ""),
+        "conversation": conversation_id[:20],
+    }
 
 
 def register_prompts(mcp: FastMCP, hooks: ServerCallbacks) -> None:
@@ -32,7 +109,7 @@ def register_prompts(mcp: FastMCP, hooks: ServerCallbacks) -> None:
         )
         convs = await spec.list(store)
 
-        error_contexts = []
+        error_contexts: list[ErrorContextPayload] = []
         for conv in convs:
             for msg in conv.messages:
                 if msg.text and ("error" in msg.text.lower() or "exception" in msg.text.lower()):
@@ -100,14 +177,13 @@ Focus on actionable insights and patterns, not exhaustive summaries.
         store = hooks.get_query_store()
         convs = await build_query_spec(limit=hooks.clamp_limit(limit)).list(store)
 
-        code_snippets: list[dict[str, str]] = []
+        code_snippets: list[ExtractedCodeSnippetPayload] = []
         for conv in convs:
             for msg in conv.messages:
                 if not msg.text:
                     continue
                 for block in hooks.extract_fenced_code(msg.text, language):
-                    block["conversation"] = str(conv.id)[:20]
-                    code_snippets.append(block)
+                    code_snippets.append(_code_snippet_payload(block, str(conv.id)))
                 if len(code_snippets) >= 15:
                     break
 
@@ -132,23 +208,6 @@ Code snippets:
         conv1 = await store.get_eager(id1)
         conv2 = await store.get_eager(id2)
 
-        def _summarize(conv: Any) -> dict[str, Any]:
-            if conv is None:
-                return {"error": "not found"}
-            return {
-                "id": str(conv.id),
-                "provider": conv.provider,
-                "title": conv.display_title,
-                "message_count": len(conv.messages),
-                "messages": [
-                    {
-                        "role": (m.role.value if hasattr(m.role, "value") else str(m.role)) if m.role else "unknown",
-                        "text": (m.text or "")[:200],
-                    }
-                    for m in conv.messages[:10]
-                ],
-            }
-
         return f"""Compare these two conversations and analyze:
 
 1. What topics/problems are discussed in each?
@@ -157,10 +216,10 @@ Code snippets:
 4. What can be learned from the differences?
 
 Conversation 1:
-{json.dumps(_summarize(conv1), indent=2)}
+{json.dumps(_summarize_conversation(conv1), indent=2)}
 
 Conversation 2:
-{json.dumps(_summarize(conv2), indent=2)}
+{json.dumps(_summarize_conversation(conv2), indent=2)}
 """
 
     @mcp.prompt()
@@ -172,7 +231,7 @@ Conversation 2:
         )
         convs = await spec.list(store)
 
-        summaries = []
+        summaries: list[ConversationPatternPayload] = []
         for conv in convs:
             first_msgs = [m.text[:150] for m in conv.messages.to_list()[:3] if m.text]
             summaries.append(

--- a/polylogue/mcp/server_support.py
+++ b/polylogue/mcp/server_support.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Protocol, TypeVar, overload
+from typing import TYPE_CHECKING, Protocol, TypeVar, cast, overload
 
 from pydantic import BaseModel
 
 from polylogue.logging import get_logger
-from polylogue.mcp.payloads import MCPErrorPayload
+from polylogue.mcp.payloads import MCPErrorPayload, MCPFencedCodeBlock
 from polylogue.operations import ArchiveOperations
 from polylogue.protocols import ConversationQueryRuntimeStore, TagStore
 from polylogue.services import RuntimeServices, build_runtime_services
@@ -28,27 +28,39 @@ class JSONPayloadSerializer(Protocol):
     def __call__(self, payload: BaseModel, *, exclude_none: bool = False) -> str: ...
 
 
+class ErrorJSONSerializer(Protocol):
+    def __call__(self, message: str, **extra: str) -> str: ...
+
+
+class FencedCodeExtractor(Protocol):
+    def __call__(self, text: str, language: str = "") -> list[MCPFencedCodeBlock]: ...
+
+
+class ToJSONPayload(Protocol):
+    def to_json(self, *, exclude_none: bool = False) -> str: ...
+
+
 @dataclass(frozen=True)
 class ServerCallbacks:
     json_payload: JSONPayloadSerializer
     clamp_limit: Callable[[int | object], int]
     safe_call: Callable[[str, Callable[[], str]], str]
     async_safe_call: Callable[[str, Callable[[], Awaitable[str]]], Awaitable[str]]
-    error_json: Callable[..., str]
+    error_json: ErrorJSONSerializer
     get_query_store: Callable[[], ConversationQueryRuntimeStore]
     get_tag_store: Callable[[], TagStore]
     get_backend: Callable[[], SQLiteBackend]
     get_config: Callable[[], Config]
     get_archive_ops: Callable[[], ArchiveOperations]
-    extract_fenced_code: Callable[[str, str], list[dict[str, str]]]
+    extract_fenced_code: FencedCodeExtractor
 
 
-def _extract_fenced_code(text: str, language: str = "") -> list[dict[str, str]]:
+def _extract_fenced_code(text: str, language: str = "") -> list[MCPFencedCodeBlock]:
     """Extract fenced code blocks from markdown text."""
     if "```" not in text:
         return []
     blocks = text.split("```")
-    results = []
+    results: list[MCPFencedCodeBlock] = []
     for i in range(1, len(blocks), 2):
         block = blocks[i]
         lines = block.split("\n", 1)
@@ -61,6 +73,9 @@ def _extract_fenced_code(text: str, language: str = "") -> list[dict[str, str]]:
 
 def _json_payload(payload: BaseModel, *, exclude_none: bool = False) -> str:
     """Serialize a typed MCP payload with canonical JSON formatting."""
+    to_json = getattr(payload, "to_json", None)
+    if callable(to_json):
+        return cast(ToJSONPayload, payload).to_json(exclude_none=exclude_none)
     return serialize_surface_payload(payload, exclude_none=exclude_none)
 
 

--- a/polylogue/ui/facade.py
+++ b/polylogue/ui/facade.py
@@ -16,6 +16,7 @@ from polylogue.errors import PolylogueError
 from polylogue.ui.facade_console import ConsoleLike, PlainConsole
 from polylogue.ui.facade_prompts import (
     _NO_STUB_RESPONSE,
+    PromptStubEntry,
     consume_choose_stub,
     consume_confirm_stub,
     consume_input_stub,
@@ -62,7 +63,7 @@ class ConsoleFacade:
     prompt_stub_path: Path | None = None
     console: ConsoleLike = field(init=False)
     theme: Theme = field(init=False, repr=False)
-    _prompt_responses: deque[dict[str, object]] = field(init=False, repr=False)
+    _prompt_responses: deque[PromptStubEntry] = field(init=False, repr=False)
 
     def __post_init__(self) -> None:
         self.theme = Theme(rich_theme_styles())
@@ -74,10 +75,10 @@ class ConsoleFacade:
         self._banner_box = box.DOUBLE
         self._prompt_responses = load_prompt_responses(UIError, prompt_stub_path=self.prompt_stub_path)
 
-    def _load_prompt_responses(self) -> object:
+    def _load_prompt_responses(self) -> deque[PromptStubEntry]:
         return load_prompt_responses(UIError, prompt_stub_path=self.prompt_stub_path)
 
-    def _pop_prompt_response(self, kind: str) -> object:
+    def _pop_prompt_response(self, kind: str) -> PromptStubEntry | None:
         return pop_prompt_response(self._prompt_responses, kind, UIError)
 
     def _require_plain_prompt_tty(self, prompt_topic: str) -> None:

--- a/polylogue/ui/facade_prompts.py
+++ b/polylogue/ui/facade_prompts.py
@@ -5,45 +5,96 @@ from __future__ import annotations
 import json
 import sys
 from collections import deque
+from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Final
 
 if TYPE_CHECKING:
     from polylogue.ui.facade import UIError
 
-_NO_STUB_RESPONSE = object()
+_PROMPT_STUB_SCALARS = (bool, int, float, str)
+
+
+@dataclass(frozen=True)
+class PromptStubEntry:
+    """Normalized prompt-stub entry loaded from a JSONL file."""
+
+    kind: str | None = None
+    use_default: bool = False
+    value: bool | int | float | str | None = None
+    has_value: bool = False
+    index: int | None = None
+
+    @classmethod
+    def from_json(cls, raw: object) -> PromptStubEntry | None:
+        if not isinstance(raw, dict):
+            return None
+        kind = raw.get("type")
+        entry_kind = kind if isinstance(kind, str) else None
+        use_default = bool(raw.get("use_default", False))
+        has_value = "value" in raw
+        raw_value = raw.get("value")
+        value: bool | int | float | str | None = (
+            raw_value if raw_value is None or isinstance(raw_value, _PROMPT_STUB_SCALARS) else str(raw_value)
+        )
+        return cls(
+            kind=entry_kind,
+            use_default=use_default,
+            value=value,
+            has_value=has_value,
+            index=_coerce_index(raw.get("index")),
+        )
+
+
+class _NoStubResponse:
+    __slots__ = ()
+
+
+_NO_STUB_RESPONSE: Final = _NoStubResponse()
+
+
+def _coerce_index(raw: object) -> int | None:
+    if isinstance(raw, int):
+        return raw
+    if isinstance(raw, str):
+        try:
+            return int(raw)
+        except ValueError:
+            return None
+    return None
 
 
 def load_prompt_responses(
     ui_error_cls: type[UIError],
     *,
     prompt_stub_path: Path | None = None,
-) -> deque[dict[str, object]]:
+) -> deque[PromptStubEntry]:
     if prompt_stub_path is None:
         return deque()
-    entries: deque[dict[str, object]] = deque()
+    entries: deque[PromptStubEntry] = deque()
     for line in prompt_stub_path.read_text(encoding="utf-8").splitlines():
         line = line.strip()
         if not line:
             continue
         try:
             data = json.loads(line)
-            if isinstance(data, dict):
-                entries.append(data)
+            entry = PromptStubEntry.from_json(data)
+            if entry is not None:
+                entries.append(entry)
         except json.JSONDecodeError as exc:
             raise ui_error_cls(f"Invalid prompt stub entry: {line}") from exc
     return entries
 
 
 def pop_prompt_response(
-    prompt_responses: deque[dict[str, object]],
+    prompt_responses: deque[PromptStubEntry],
     kind: str,
     ui_error_cls: type[UIError],
-) -> dict[str, object] | None:
+) -> PromptStubEntry | None:
     if not prompt_responses:
         return None
     entry = prompt_responses.popleft()
-    expected = entry.get("type")
+    expected = entry.kind
     if expected and expected != kind:
         raise ui_error_cls(f"Prompt stub expected '{expected}' but got '{kind}'")
     return entry
@@ -58,17 +109,17 @@ def require_plain_prompt_tty(prompt_topic: str, ui_error_cls: type[UIError]) -> 
 
 
 def consume_confirm_stub(
-    prompt_responses: deque[dict[str, object]],
+    prompt_responses: deque[PromptStubEntry],
     *,
     default: bool,
     ui_error_cls: type[UIError],
-) -> bool | object:
+) -> bool | _NoStubResponse:
     response = pop_prompt_response(prompt_responses, "confirm", ui_error_cls)
     if response is None:
         return _NO_STUB_RESPONSE
-    if response.get("use_default"):
+    if response.use_default:
         return default
-    value = response.get("value")
+    value = response.value
     if isinstance(value, bool):
         return value
     if isinstance(value, str):
@@ -81,46 +132,47 @@ def consume_confirm_stub(
 
 
 def consume_choose_stub(
-    prompt_responses: deque[dict[str, object]],
+    prompt_responses: deque[PromptStubEntry],
     options: list[str],
     ui_error_cls: type[UIError],
-) -> str | None | object:
+) -> str | None | _NoStubResponse:
     response = pop_prompt_response(prompt_responses, "choose", ui_error_cls)
     if response is None:
         return _NO_STUB_RESPONSE
-    if response.get("use_default"):
+    if response.use_default:
         return options[0] if options else None
-    if "value" in response:
-        value = response["value"]
-        if isinstance(value, str) and value in options:
-            return value
-    if "index" in response:
-        try:
-            index_val = response["index"]
-            idx: int | None = None
-            if isinstance(index_val, int):
-                idx = index_val
-            elif isinstance(index_val, str):
-                idx = int(index_val)
-            if idx is not None and 0 <= idx < len(options):
-                return options[idx]
-        except (KeyError, ValueError, TypeError):
-            pass
+    value = response.value
+    if isinstance(value, str) and value in options:
+        return value
+    if response.index is not None and 0 <= response.index < len(options):
+        return options[response.index]
     return _NO_STUB_RESPONSE
 
 
 def consume_input_stub(
-    prompt_responses: deque[dict[str, object]],
+    prompt_responses: deque[PromptStubEntry],
     *,
     default: str | None,
     ui_error_cls: type[UIError],
-) -> str | None | object:
+) -> str | None | _NoStubResponse:
     response = pop_prompt_response(prompt_responses, "input", ui_error_cls)
     if response is None:
         return _NO_STUB_RESPONSE
-    if response.get("use_default"):
+    if response.use_default:
         return default
-    if "value" in response:
-        value = response["value"]
+    if response.has_value:
+        value = response.value
         return None if value is None else str(value)
     return _NO_STUB_RESPONSE
+
+
+__all__ = [
+    "PromptStubEntry",
+    "_NO_STUB_RESPONSE",
+    "consume_choose_stub",
+    "consume_confirm_stub",
+    "consume_input_stub",
+    "load_prompt_responses",
+    "pop_prompt_response",
+    "require_plain_prompt_tty",
+]

--- a/tests/unit/ui/test_ui.py
+++ b/tests/unit/ui/test_ui.py
@@ -17,6 +17,7 @@ from rich.progress import TaskID
 
 from polylogue.ui import UI, _PlainProgressTracker, _RichProgressTracker, create_ui
 from polylogue.ui.facade import ConsoleFacade, PlainConsole, UIError, create_console_facade
+from polylogue.ui.facade_prompts import PromptStubEntry
 
 
 @pytest.fixture
@@ -127,7 +128,7 @@ class TestConsoleFacadePromptStubs:
 
         _write_stubs(mock_prompt_file, {"value": True})
         facade = ConsoleFacade(plain=True, prompt_stub_path=mock_prompt_file)
-        assert facade._pop_prompt_response("anything") == {"value": True}
+        assert facade._pop_prompt_response("anything") == PromptStubEntry(value=True, has_value=True)
 
         mock_prompt_file.write_text("")
         facade = ConsoleFacade(plain=True, prompt_stub_path=mock_prompt_file)


### PR DESCRIPTION
Ref #245

## Summary

Tighten the remaining CLI, MCP, and UI surface contracts so those entrypoints consume the renewed substrate through explicit typed request/result boundaries instead of weak parameter bags and ad hoc prompt or payload glue.

## Problem

The first half of this tranche tightened check-command and UI prompt surfaces, but query and MCP paths still carried a lot of broad `dict[str, object]` plumbing, dynamic registration glue, and prompt-side ad hoc payload shaping. That left the public surfaces technically type-clean in places while still underspecifying meaning and forcing compatibility workarounds deeper in the stack.

## Solution

- introduced typed CLI surface aliases and callback protocols in `polylogue/cli/query.py`, `polylogue/cli/query_output.py`, `polylogue/cli/query_verbs.py`, and `polylogue/cli/root_request.py`
- tightened semantic stats and action-read-model readiness compatibility in `polylogue/lib/query_retrieval_candidates.py`
- rebuilt MCP dynamic tool registration and prompt payload shaping in `polylogue/mcp/server_product_tools.py`, `polylogue/mcp/server_prompts.py`, `polylogue/mcp/server_support.py`, `polylogue/mcp/payloads.py`, and `polylogue/mcp/__init__.py`
- kept the machine-facing metadata payload raw while avoiding recursive Pydantic root-model traps
- the earlier branch commit also tightened the check-command/UI prompt surface with explicit result models and typed prompt stubs

## Verification

- `ruff check polylogue/cli/query.py polylogue/cli/query_output.py polylogue/cli/query_verbs.py polylogue/cli/root_request.py polylogue/mcp/__init__.py polylogue/mcp/payloads.py polylogue/mcp/server_product_tools.py polylogue/mcp/server_prompts.py polylogue/mcp/server_support.py polylogue/ui/facade_console.py`
- `mypy polylogue/cli/query.py polylogue/cli/query_output.py polylogue/cli/query_verbs.py polylogue/cli/root_request.py polylogue/mcp/payloads.py polylogue/mcp/server_support.py polylogue/mcp/server_prompts.py polylogue/mcp/server_product_tools.py polylogue/mcp/__init__.py polylogue/ui/facade_console.py`
- `pytest -q tests/unit/ui/test_ui.py tests/unit/cli/test_check.py`
- `pytest -q tests/unit/mcp/test_tool_contracts.py::TestMutationTools::test_get_metadata_success tests/unit/mcp/test_server_surfaces.py::TestClampLimit::test_clamp_limit_contract\[10-10_0\] tests/unit/cli/test_click_app.py::TestMcpServerImport::test_serve_stdio_can_be_imported`
- `pytest -q tests/unit/cli/test_query_exec_laws.py::test_async_execute_query_semantic_stats_by_falls_back_without_summaries_contract`
- `devtools verify`
