### PR TITLE
refactor: rebuild schema extraction and synthetic boundary contracts

### DIFF
--- a/polylogue/schemas/extraction.py
+++ b/polylogue/schemas/extraction.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Mapping
+from dataclasses import dataclass
 from typing import TypeAlias
 
 from polylogue.lib.json import JSONDocument, json_document
@@ -53,6 +55,25 @@ _WELL_KNOWN_TIMESTAMP_NAMES = frozenset(
         "date",
     }
 )
+
+
+@dataclass(frozen=True)
+class ResolvedSchemaBody:
+    raw: object | None
+    text: str
+    block_payloads: SchemaBlockPayload
+
+
+@dataclass(frozen=True)
+class ResolvedSchemaMessageFields:
+    message_id: str | None
+    role_raw: object | None
+    body: ResolvedSchemaBody
+    timestamp_raw: str | int | float | None
+    model: str | None
+    usage: JSONDocument | None
+    cost: CostInfo | None
+    duration_ms: int | None
 
 
 def _resolve_json_path(raw: SchemaPayload, path: str) -> object | None:
@@ -245,6 +266,68 @@ def _extract_duration_ms(raw: SchemaPayload) -> int | None:
 # -------------------------------------------------------------------
 
 
+def _resolve_role_raw(raw: SchemaPayload, paths: Mapping[str, str | None]) -> object | None:
+    role_path = paths.get("message_role")
+    role_raw = _resolve_json_path(raw, role_path) if role_path is not None else None
+    return role_raw if role_raw is not None else _find_by_well_known_names(raw, _WELL_KNOWN_ROLE_NAMES)
+
+
+def _resolve_body_raw(raw: SchemaPayload, paths: Mapping[str, str | None]) -> object | None:
+    body_path = paths.get("message_body")
+    body_raw = _resolve_json_path(raw, body_path) if body_path is not None else None
+    if body_raw is not None:
+        return body_raw
+    message_payload = _resolve_message_meta_payload(raw)
+    nested_body = _find_by_well_known_names(message_payload, _WELL_KNOWN_BODY_NAMES)
+    return nested_body if nested_body is not None else _find_by_well_known_names(raw, _WELL_KNOWN_BODY_NAMES)
+
+
+def _resolve_timestamp_raw(raw: SchemaPayload, paths: Mapping[str, str | None]) -> str | int | float | None:
+    timestamp_path = paths.get("message_timestamp")
+    ts_raw = _resolve_json_path(raw, timestamp_path) if timestamp_path is not None else None
+    if ts_raw is None:
+        ts_raw = _find_by_well_known_names(raw, _WELL_KNOWN_TIMESTAMP_NAMES)
+    return _timestamp_candidate(ts_raw)
+
+
+def _resolve_message_meta_payload(raw: SchemaPayload) -> SchemaPayload:
+    message_payload = json_document(raw.get("message"))
+    return message_payload if message_payload else raw
+
+
+def _resolve_body(body_raw: object | None) -> ResolvedSchemaBody:
+    block_payloads = _extract_content_block_list(body_raw)
+    return ResolvedSchemaBody(
+        raw=body_raw,
+        text=_extract_text_from_body(body_raw),
+        block_payloads=block_payloads,
+    )
+
+
+def _resolve_message_fields(
+    raw: SchemaPayload,
+    *,
+    schema: SchemaPayload,
+    provider: Provider,
+) -> ResolvedSchemaMessageFields:
+    pins = load_pins(provider)
+    paths = resolve_pinned_paths(schema, pins)
+    message_meta = _resolve_message_meta_payload(raw)
+    usage = json_document(message_meta.get("usage")) or None
+    model = message_meta.get("model")
+
+    return ResolvedSchemaMessageFields(
+        message_id=_extract_message_id(raw),
+        role_raw=_resolve_role_raw(raw, paths),
+        body=_resolve_body(_resolve_body_raw(raw, paths)),
+        timestamp_raw=_resolve_timestamp_raw(raw, paths),
+        model=model if isinstance(model, str) else None,
+        usage=usage,
+        cost=_extract_cost(raw),
+        duration_ms=_extract_duration_ms(raw),
+    )
+
+
 def extract_message_from_schema(
     raw: SchemaPayload,
     *,
@@ -252,51 +335,23 @@ def extract_message_from_schema(
     provider: Provider,
 ) -> HarmonizedMessage:
     """Extract a harmonized message using schema semantic annotations."""
-    pins = load_pins(provider)
-    paths = resolve_pinned_paths(schema, pins)
-
-    role_path = paths.get("message_role")
-    role_raw = _resolve_json_path(raw, role_path) if role_path is not None else None
-    if role_raw is None:
-        role_raw = _find_by_well_known_names(raw, _WELL_KNOWN_ROLE_NAMES)
-    role = Role.normalize(str(role_raw) if role_raw else "unknown")
-
-    body_path = paths.get("message_body")
-    body_raw = _resolve_json_path(raw, body_path) if body_path is not None else None
-    if body_raw is None:
-        body_raw = _find_by_well_known_names(raw, _WELL_KNOWN_BODY_NAMES)
-    text = _extract_text_from_body(body_raw)
-
-    block_dicts = _extract_content_block_list(body_raw)
-    content_blocks = extract_content_blocks(block_dicts) if block_dicts else []
-    reasoning_traces = extract_reasoning_traces(block_dicts, provider) if block_dicts else []
-    tool_calls = extract_tool_calls(block_dicts, provider) if block_dicts else []
-
-    timestamp_path = paths.get("message_timestamp")
-    ts_raw = _resolve_json_path(raw, timestamp_path) if timestamp_path is not None else None
-    if ts_raw is None:
-        ts_raw = _find_by_well_known_names(raw, _WELL_KNOWN_TIMESTAMP_NAMES)
-    timestamp = parse_timestamp(_timestamp_candidate(ts_raw))
-
-    msg_data = raw.get("message")
-    if not isinstance(msg_data, dict):
-        msg_data = raw
-    usage_raw = msg_data.get("usage")
-    tokens = extract_token_usage(usage_raw) if isinstance(usage_raw, dict) else None
-    model = msg_data.get("model")
+    resolved = _resolve_message_fields(raw, schema=schema, provider=provider)
+    block_dicts = resolved.body.block_payloads
+    role = Role.normalize(str(resolved.role_raw) if resolved.role_raw else "unknown")
+    timestamp = parse_timestamp(resolved.timestamp_raw)
 
     return HarmonizedMessage(
-        id=_extract_message_id(raw),
+        id=resolved.message_id,
         role=role,
-        text=text,
+        text=resolved.body.text,
         timestamp=timestamp,
-        reasoning_traces=reasoning_traces,
-        tool_calls=tool_calls,
-        content_blocks=content_blocks,
-        model=model if isinstance(model, str) else None,
-        tokens=tokens,
-        cost=_extract_cost(raw),
-        duration_ms=_extract_duration_ms(raw),
+        reasoning_traces=extract_reasoning_traces(block_dicts, provider) if block_dicts else [],
+        tool_calls=extract_tool_calls(block_dicts, provider) if block_dicts else [],
+        content_blocks=extract_content_blocks(block_dicts) if block_dicts else [],
+        model=resolved.model,
+        tokens=extract_token_usage(resolved.usage),
+        cost=resolved.cost,
+        duration_ms=resolved.duration_ms,
         provider=provider,
         raw=_object_record(raw),
     )

--- a/polylogue/schemas/observation_identity.py
+++ b/polylogue/schemas/observation_identity.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import hashlib
 from pathlib import Path
 
-from polylogue.schemas.observation_models import PROVIDERS, ProviderConfig
+from polylogue.schemas.observation_models import PROVIDERS, ProviderConfig, SchemaClusterPayload
 from polylogue.types import Provider
 
 
@@ -32,7 +32,7 @@ def fingerprint_hash(fingerprint: object) -> str:
     return hashlib.sha256(raw).hexdigest()[:16]
 
 
-def schema_cluster_id(cluster_payload: object, artifact_kind: str) -> str:
+def schema_cluster_id(cluster_payload: SchemaClusterPayload, artifact_kind: str) -> str:
     """Compute a stable cluster identifier for a schema unit."""
     from polylogue.schemas.shape_fingerprint import _structure_fingerprint
 

--- a/polylogue/schemas/observation_models.py
+++ b/polylogue/schemas/observation_models.py
@@ -4,9 +4,13 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Literal, TypeAlias
 
+from polylogue.lib.json import JSONDocumentList, JSONValue
 from polylogue.types import Provider
+
+SchemaSampleGranularity: TypeAlias = Literal["document", "record"]
+SchemaClusterPayload: TypeAlias = JSONValue
 
 
 @dataclass
@@ -18,7 +22,7 @@ class ProviderConfig:
     db_provider_name: Provider | None = None
     session_dir: Path | None = None
     max_sessions: int | None = None
-    sample_granularity: str = "document"
+    sample_granularity: SchemaSampleGranularity = "document"
     record_type_key: str | None = None
     schema_sample_cap: int | None = None
 
@@ -27,8 +31,8 @@ class ProviderConfig:
 class SchemaUnit:
     """Clusterable schema-observation input."""
 
-    cluster_payload: Any
-    schema_samples: list[dict[str, Any]]
+    cluster_payload: SchemaClusterPayload
+    schema_samples: JSONDocumentList
     artifact_kind: str
     conversation_id: str | None = None
     raw_id: str | None = None
@@ -77,3 +81,12 @@ PROVIDERS: dict[Provider, ProviderConfig] = {
         schema_sample_cap=128,
     ),
 }
+
+
+__all__ = [
+    "PROVIDERS",
+    "ProviderConfig",
+    "SchemaClusterPayload",
+    "SchemaSampleGranularity",
+    "SchemaUnit",
+]

--- a/polylogue/schemas/observation_runtime.py
+++ b/polylogue/schemas/observation_runtime.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TypeAlias
 
@@ -9,12 +10,144 @@ from polylogue.lib.artifact_taxonomy import classify_artifact
 from polylogue.lib.json import JSONDocument, JSONValue, is_json_value, json_document
 from polylogue.lib.raw_payload import extract_payload_samples, record_bucket_key
 from polylogue.schemas.observation_identity import derive_bundle_scope, schema_cluster_id
-from polylogue.schemas.observation_models import ProviderConfig, SchemaUnit
+from polylogue.schemas.observation_models import ProviderConfig, SchemaClusterPayload, SchemaUnit
 from polylogue.types import Provider
 
 SchemaSample: TypeAlias = JSONDocument
 
 _SCHEMA_SAMPLE_STRING_LIMIT = 1024
+
+
+@dataclass(frozen=True)
+class _ObservationContext:
+    provider_name: Provider
+    source_path: Path | None
+    source_path_text: str | None
+    raw_id: str | None
+    observed_at: str | None
+    bundle_scope: str | None
+    effective_max_samples: int | None
+
+
+@dataclass(frozen=True)
+class _ObservedSchemaUnit:
+    cluster_payload: SchemaClusterPayload
+    schema_samples: list[SchemaSample]
+    artifact_kind: str
+    conversation_id: str | None
+    profile_tokens: tuple[str, ...]
+
+
+def _build_observation_context(
+    *,
+    provider_name: Provider,
+    source_path: str | Path | None,
+    raw_id: str | None,
+    observed_at: str | None,
+    config: ProviderConfig,
+    max_samples: int | None,
+) -> _ObservationContext:
+    provider_token = Provider.from_string(provider_name)
+    source_path_obj = Path(source_path) if source_path is not None else None
+    return _ObservationContext(
+        provider_name=provider_token,
+        source_path=source_path_obj,
+        source_path_text=str(source_path_obj) if source_path_obj is not None else None,
+        raw_id=raw_id,
+        observed_at=observed_at,
+        bundle_scope=derive_bundle_scope(provider_token, source_path_obj),
+        effective_max_samples=max_samples if max_samples is not None else config.schema_sample_cap,
+    )
+
+
+def _to_schema_unit(observed: _ObservedSchemaUnit, context: _ObservationContext) -> SchemaUnit:
+    return SchemaUnit(
+        cluster_payload=observed.cluster_payload,
+        schema_samples=observed.schema_samples,
+        artifact_kind=observed.artifact_kind,
+        conversation_id=observed.conversation_id,
+        raw_id=context.raw_id,
+        source_path=context.source_path_text,
+        bundle_scope=context.bundle_scope,
+        observed_at=context.observed_at,
+        exact_structure_id=schema_cluster_id(observed.cluster_payload, observed.artifact_kind),
+        profile_tokens=observed.profile_tokens,
+    )
+
+
+def _eligible_artifact_kind(
+    payload: SchemaClusterPayload,
+    *,
+    context: _ObservationContext,
+) -> str | None:
+    artifact = classify_artifact(
+        payload,
+        provider=context.provider_name,
+        source_path=context.source_path,
+    )
+    return artifact.cohort if artifact.schema_eligible else None
+
+
+def _extract_record_observation(
+    normalized_payload: JSONValue,
+    *,
+    context: _ObservationContext,
+    config: ProviderConfig,
+) -> _ObservedSchemaUnit | None:
+    artifact_kind = _eligible_artifact_kind(normalized_payload, context=context)
+    if artifact_kind is None:
+        return None
+
+    samples = _compact_schema_samples(
+        extract_payload_samples(
+            normalized_payload,
+            sample_granularity="record",
+            max_samples=context.effective_max_samples,
+            record_type_key=config.record_type_key,
+        )
+    )
+    if not samples:
+        return None
+
+    return _ObservedSchemaUnit(
+        cluster_payload=normalized_payload,
+        schema_samples=samples,
+        artifact_kind=artifact_kind,
+        conversation_id=context.raw_id,
+        profile_tokens=_record_profile_tokens(
+            samples,
+            record_type_key=config.record_type_key,
+        ),
+    )
+
+
+def _extract_document_observations(
+    normalized_payload: JSONValue,
+    *,
+    context: _ObservationContext,
+) -> list[_ObservedSchemaUnit]:
+    documents = _compact_schema_samples(
+        extract_payload_samples(
+            normalized_payload,
+            sample_granularity="document",
+            max_samples=context.effective_max_samples,
+        )
+    )
+    units: list[_ObservedSchemaUnit] = []
+    for sample in documents:
+        artifact_kind = _eligible_artifact_kind(sample, context=context)
+        if artifact_kind is None:
+            continue
+        units.append(
+            _ObservedSchemaUnit(
+                cluster_payload=sample,
+                schema_samples=[sample],
+                artifact_kind=artifact_kind,
+                conversation_id=_document_conversation_id(sample, context.raw_id),
+                profile_tokens=_document_profile_tokens(sample),
+            )
+        )
+    return units
 
 
 def extract_schema_units_from_payload(
@@ -31,80 +164,32 @@ def extract_schema_units_from_payload(
     if not is_json_value(payload):
         return []
     normalized_payload: JSONValue = payload
-    provider_token = Provider.from_string(provider_name)
-    effective_max_samples = max_samples if max_samples is not None else config.schema_sample_cap
-    bundle_scope = derive_bundle_scope(provider_token, source_path)
-    source_path_text = str(source_path) if source_path is not None else None
+    context = _build_observation_context(
+        provider_name=provider_name,
+        source_path=source_path,
+        raw_id=raw_id,
+        observed_at=observed_at,
+        config=config,
+        max_samples=max_samples,
+    )
 
     if config.sample_granularity == "record":
-        artifact = classify_artifact(
+        observed = _extract_record_observation(
             normalized_payload,
-            provider=provider_token,
-            source_path=source_path,
+            context=context,
+            config=config,
         )
-        if not artifact.schema_eligible:
+        if observed is None:
             return []
+        return [_to_schema_unit(observed, context)]
 
-        samples = _compact_schema_samples(
-            extract_payload_samples(
-                normalized_payload,
-                sample_granularity="record",
-                max_samples=effective_max_samples,
-                record_type_key=config.record_type_key,
-            )
-        )
-        if not samples:
-            return []
-
-        return [
-            SchemaUnit(
-                cluster_payload=normalized_payload,
-                schema_samples=samples,
-                artifact_kind=artifact.cohort,
-                conversation_id=raw_id,
-                raw_id=raw_id,
-                source_path=source_path_text,
-                bundle_scope=bundle_scope,
-                observed_at=observed_at,
-                exact_structure_id=schema_cluster_id(normalized_payload, artifact.cohort),
-                profile_tokens=_record_profile_tokens(
-                    samples,
-                    record_type_key=config.record_type_key,
-                ),
-            )
-        ]
-
-    documents = _compact_schema_samples(
-        extract_payload_samples(
+    return [
+        _to_schema_unit(observed, context)
+        for observed in _extract_document_observations(
             normalized_payload,
-            sample_granularity="document",
-            max_samples=effective_max_samples,
+            context=context,
         )
-    )
-    units: list[SchemaUnit] = []
-    for sample in documents:
-        artifact = classify_artifact(
-            sample,
-            provider=provider_token,
-            source_path=source_path,
-        )
-        if not artifact.schema_eligible:
-            continue
-        units.append(
-            SchemaUnit(
-                cluster_payload=sample,
-                schema_samples=[sample],
-                artifact_kind=artifact.cohort,
-                conversation_id=_document_conversation_id(sample, raw_id),
-                raw_id=raw_id,
-                source_path=source_path_text,
-                bundle_scope=bundle_scope,
-                observed_at=observed_at,
-                exact_structure_id=schema_cluster_id(sample, artifact.cohort),
-                profile_tokens=_document_profile_tokens(sample),
-            )
-        )
-    return units
+    ]
 
 
 def _compact_schema_value(value: JSONValue) -> JSONValue:

--- a/polylogue/schemas/sampling_db.py
+++ b/polylogue/schemas/sampling_db.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import sqlite3
 from collections.abc import Iterator
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal, TypeAlias, overload
 
@@ -14,6 +15,7 @@ from polylogue.lib.provider_identity import (
     canonical_schema_provider,
 )
 from polylogue.lib.raw_payload import extract_record_samples_from_raw_content
+from polylogue.lib.raw_payload_decode import RawPayloadEnvelope
 from polylogue.logging import get_logger
 from polylogue.paths import db_path as archive_db_path
 from polylogue.schemas.observation import (
@@ -27,8 +29,21 @@ from polylogue.types import Provider
 
 logger = get_logger(__name__)
 
-SchemaRow = tuple[str | None, str | None, str | None, str, str | None, str | None]
 SchemaSample: TypeAlias = JSONDocument
+
+
+@dataclass(frozen=True)
+class _RawConversationRow:
+    source_path: str | None
+    provider_name: str | None
+    payload_provider: str | None
+    raw_id: str
+    file_mtime: str | None
+    acquired_at: str | None
+
+    @property
+    def observed_at(self) -> str | None:
+        return self.file_mtime or self.acquired_at
 
 
 def _sample_provider_where_clause(provider_name: str | Provider) -> tuple[str, tuple[str, ...]]:
@@ -47,15 +62,89 @@ def _sample_provider_where_clause(provider_name: str | Provider) -> tuple[str, t
     return clause, params
 
 
-def _coerce_schema_row(row: sqlite3.Row) -> SchemaRow:
-    return (
-        row[0],
-        row[1],
-        row[2],
-        row[3],
-        row[4],
-        row[5],
+def _coerce_schema_row(row: sqlite3.Row) -> _RawConversationRow:
+    return _RawConversationRow(
+        source_path=row[0],
+        provider_name=row[1],
+        payload_provider=row[2],
+        raw_id=row[3],
+        file_mtime=row[4],
+        acquired_at=row[5],
     )
+
+
+def _record_sample_limit(
+    *,
+    config: ProviderConfig,
+    max_samples: int | None,
+    full_corpus: bool,
+) -> int | None:
+    if full_corpus:
+        return None
+    if max_samples is not None:
+        return max_samples
+    return config.schema_sample_cap or 128
+
+
+def _iter_record_stream_units(
+    *,
+    row: _RawConversationRow,
+    provider_name: Provider,
+    raw_content: Path,
+    config: ProviderConfig,
+    max_samples: int | None,
+    full_corpus: bool,
+) -> Iterator[SchemaUnit]:
+    runtime_provider = canonical_runtime_provider(row.payload_provider or row.provider_name)
+    if canonical_schema_provider(runtime_provider) != str(provider_name):
+        return
+
+    try:
+        samples = extract_record_samples_from_raw_content(
+            raw_content,
+            max_samples=_record_sample_limit(
+                config=config,
+                max_samples=max_samples,
+                full_corpus=full_corpus,
+            ),
+            record_type_key=config.record_type_key,
+        )
+    except Exception:
+        samples = []
+
+    if not samples:
+        return
+
+    yield from extract_schema_units_from_payload(
+        samples,
+        provider_name=provider_name,
+        source_path=row.source_path,
+        raw_id=row.raw_id,
+        observed_at=row.observed_at,
+        config=config,
+        max_samples=max_samples,
+    )
+
+
+def _build_raw_payload_envelope_for_row(
+    row: _RawConversationRow,
+    *,
+    provider_name: Provider,
+    raw_content: Path,
+    config: ProviderConfig,
+) -> RawPayloadEnvelope | None:
+    try:
+        from polylogue.schemas import sampling as sampling_root
+
+        return sampling_root.build_raw_payload_envelope(
+            raw_content,
+            source_path=row.source_path,
+            fallback_provider=row.provider_name or str(provider_name),
+            payload_provider=row.payload_provider,
+            jsonl_dict_only=config.sample_granularity == "record",
+        )
+    except Exception:
+        return None
 
 
 def _iter_schema_units_from_db(
@@ -83,67 +172,43 @@ def _iter_schema_units_from_db(
         )
         batch_size = 1 if config.sample_granularity == "record" else 100
         while True:
-            rows = cursor.fetchmany(batch_size)
-            if not rows:
+            batch = tuple(_coerce_schema_row(row) for row in cursor.fetchmany(batch_size))
+            if not batch:
                 break
-            for row in rows:
-                source_path, provider_name_col, payload_provider_col, raw_id, file_mtime, acquired_at = (
-                    _coerce_schema_row(row)
-                )
-                raw_content = blob_store.blob_path(raw_id)
+            for row in batch:
+                raw_content = blob_store.blob_path(row.raw_id)
 
                 if config.sample_granularity == "record":
-                    runtime_provider = canonical_runtime_provider(payload_provider_col or provider_name_col)
-                    if canonical_schema_provider(runtime_provider) != str(provider_name):
+                    yielded_record_units = False
+                    for unit in _iter_record_stream_units(
+                        row=row,
+                        provider_name=provider_name,
+                        raw_content=raw_content,
+                        config=config,
+                        max_samples=max_samples,
+                        full_corpus=full_corpus,
+                    ):
+                        yielded_record_units = True
+                        yield unit
+                    if yielded_record_units:
                         continue
 
-                    sample_limit = max_samples
-                    if full_corpus:
-                        sample_limit = None
-                    elif sample_limit is None:
-                        sample_limit = config.schema_sample_cap or 128
-
-                    try:
-                        samples = extract_record_samples_from_raw_content(
-                            raw_content,
-                            max_samples=sample_limit,
-                            record_type_key=config.record_type_key,
-                        )
-                    except Exception:
-                        samples = []
-
-                    if samples:
-                        yield from extract_schema_units_from_payload(
-                            samples,
-                            provider_name=provider_name,
-                            source_path=source_path,
-                            raw_id=raw_id,
-                            observed_at=file_mtime or acquired_at,
-                            config=config,
-                            max_samples=max_samples,
-                        )
-                        continue
-
-                try:
-                    from polylogue.schemas import sampling as sampling_root
-
-                    envelope = sampling_root.build_raw_payload_envelope(
-                        raw_content,
-                        source_path=source_path,
-                        fallback_provider=provider_name_col or str(provider_name),
-                        payload_provider=payload_provider_col,
-                        jsonl_dict_only=config.sample_granularity == "record",
-                    )
-                except Exception:
+                envelope = _build_raw_payload_envelope_for_row(
+                    row,
+                    provider_name=provider_name,
+                    raw_content=raw_content,
+                    config=config,
+                )
+                if envelope is None:
                     continue
                 if canonical_schema_provider(envelope.provider) != str(provider_name):
                     continue
                 yield from extract_schema_units_from_payload(
                     envelope.payload,
                     provider_name=provider_name,
-                    source_path=source_path,
-                    raw_id=raw_id,
-                    observed_at=file_mtime or acquired_at,
+                    source_path=row.source_path,
+                    raw_id=row.raw_id,
+                    observed_at=row.observed_at,
                     config=config,
                     max_samples=max_samples,
                 )

--- a/polylogue/schemas/sampling_sessions.py
+++ b/polylogue/schemas/sampling_sessions.py
@@ -13,16 +13,7 @@ from polylogue.schemas.observation_models import SchemaUnit
 from polylogue.types import Provider
 
 
-def _iter_schema_units_from_sessions(
-    provider_name: Provider,
-    session_dir: Path,
-    *,
-    max_sessions: int | None,
-    config: ProviderConfig,
-    max_samples: int | None = None,
-) -> Iterator[SchemaUnit]:
-    """Yield clusterable schema units from filesystem session files."""
-    provider_name = Provider.from_string(provider_name)
+def _iter_session_json_documents(session_dir: Path, *, max_sessions: int | None) -> Iterator[tuple[Path, JSONDocument]]:
     if not session_dir.exists():
         return
 
@@ -36,7 +27,6 @@ def _iter_schema_units_from_sessions(
         jsonl_files = jsonl_files[::step][:max_sessions]
 
     for path in jsonl_files:
-        records: list[JSONDocument] = []
         try:
             with path.open(encoding="utf-8") as handle:
                 for line in handle:
@@ -44,10 +34,26 @@ def _iter_schema_units_from_sessions(
                         continue
                     with contextlib.suppress(ValueError):
                         if record := json_document(loads(line)):
-                            records.append(record)
+                            yield path, record
         except OSError:
             continue
 
+
+def _iter_schema_units_from_sessions(
+    provider_name: Provider,
+    session_dir: Path,
+    *,
+    max_sessions: int | None,
+    config: ProviderConfig,
+    max_samples: int | None = None,
+) -> Iterator[SchemaUnit]:
+    """Yield clusterable schema units from filesystem session files."""
+    provider_name = Provider.from_string(provider_name)
+    records_by_path: dict[Path, list[JSONDocument]] = {}
+    for path, record in _iter_session_json_documents(session_dir, max_sessions=max_sessions):
+        records_by_path.setdefault(path, []).append(record)
+
+    for path, records in records_by_path.items():
         if not records:
             continue
 
@@ -68,29 +74,8 @@ def _iter_samples_from_sessions(
     max_sessions: int | None,
 ) -> Iterator[JSONDocument]:
     """Yield individual sample dicts from session files."""
-    if not session_dir.exists():
-        return
-
-    jsonl_files = sorted(
-        session_dir.rglob("*.jsonl"),
-        key=lambda p: p.stat().st_mtime,
-        reverse=True,
-    )
-    if max_sessions and len(jsonl_files) > max_sessions:
-        step = max(1, len(jsonl_files) // max_sessions)
-        jsonl_files = jsonl_files[::step][:max_sessions]
-
-    for path in jsonl_files:
-        try:
-            with path.open(encoding="utf-8") as handle:
-                for line in handle:
-                    if not line.strip():
-                        continue
-                    with contextlib.suppress(ValueError):
-                        if record := json_document(loads(line)):
-                            yield record
-        except OSError:
-            continue
+    for _path, record in _iter_session_json_documents(session_dir, max_sessions=max_sessions):
+        yield record
 
 
 __all__ = [

--- a/polylogue/schemas/synthetic/build_batch.py
+++ b/polylogue/schemas/synthetic/build_batch.py
@@ -14,6 +14,7 @@ from polylogue.schemas.synthetic.models import (
     SyntheticStyle,
 )
 from polylogue.schemas.synthetic.relations import RelationConstraintSolver
+from polylogue.schemas.synthetic.semantic_values import SemanticValueGenerator
 from polylogue.schemas.synthetic.showcase import _SHOWCASE_THEMES, ConversationTheme
 from polylogue.schemas.synthetic.wire_formats import WireFormat
 
@@ -25,7 +26,7 @@ class _SyntheticBatchContext(Protocol):
     package_version: str
     element_kind: str | None
     _relation_solver: RelationConstraintSolver
-    _semantic_gen: object | None
+    _semantic_gen: SemanticValueGenerator | None
 
     def _generate_jsonl_records(
         self,
@@ -33,7 +34,7 @@ class _SyntheticBatchContext(Protocol):
         rng: random.Random,
         *,
         theme: ConversationTheme | None = None,
-    ) -> object: ...
+    ) -> list[dict[str, JSONValue]]: ...
 
     def _generate_tree_json(
         self,
@@ -41,7 +42,7 @@ class _SyntheticBatchContext(Protocol):
         rng: random.Random,
         *,
         theme: ConversationTheme | None = None,
-    ) -> object: ...
+    ) -> dict[str, JSONValue]: ...
 
     def _generate_linear_json(
         self,
@@ -49,9 +50,9 @@ class _SyntheticBatchContext(Protocol):
         rng: random.Random,
         *,
         theme: ConversationTheme | None = None,
-    ) -> object: ...
+    ) -> dict[str, JSONValue]: ...
 
-    def _generate_from_schema(self, schema: SchemaRecord, rng: random.Random) -> object: ...
+    def _generate_from_schema(self, schema: SchemaRecord, rng: random.Random) -> JSONValue: ...
 
     def _serialize(self, data: JSONValue) -> bytes: ...
 

--- a/polylogue/schemas/synthetic/build_records.py
+++ b/polylogue/schemas/synthetic/build_records.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 import random
 import uuid
+from collections.abc import Sequence
 from typing import Protocol, TypeAlias
 
 from polylogue.lib.raw_payload_decode import JSONValue
-from polylogue.schemas.synthetic.models import SchemaRecord
+from polylogue.schemas.synthetic.models import SchemaRecord, SchemaValue
 from polylogue.schemas.synthetic.semantic_values import SemanticValueGenerator
 from polylogue.schemas.synthetic.showcase import ConversationTheme
 from polylogue.schemas.synthetic.wire_formats import WireFormat
@@ -49,7 +50,7 @@ def _coerce_record(value: JSONValue) -> SyntheticRecord:
     return value if isinstance(value, dict) else {}
 
 
-def _coerce_schema(value: JSONValue) -> SchemaRecord:
+def _coerce_schema(value: SchemaValue | object) -> SchemaRecord:
     return value if isinstance(value, dict) else {}
 
 
@@ -66,7 +67,18 @@ def _message_payloads(records: list[SyntheticRecord]) -> list[JSONValue]:
     return list(records)
 
 
-def _has_messages_path(parts: list[str], schema: SchemaRecord) -> tuple[bool, SchemaRecord]:
+def _reset_semantic_generator(
+    self: _WireFormatContext,
+    *,
+    rng: random.Random,
+    theme: ConversationTheme | None,
+    base_ts: float,
+    roles: Sequence[str],
+) -> None:
+    self._semantic_gen = SemanticValueGenerator(rng, theme=theme, base_ts=base_ts, role_cycle=list(roles))
+
+
+def _has_messages_path(parts: Sequence[str], schema: SchemaRecord) -> tuple[bool, SchemaRecord]:
     cursor = schema
     for part in parts:
         props = _coerce_schema(cursor.get("properties"))
@@ -77,6 +89,12 @@ def _has_messages_path(parts: list[str], schema: SchemaRecord) -> tuple[bool, Sc
     return True, cursor
 
 
+def _advance_semantic_turn(self: _WireFormatContext) -> None:
+    semantic_generator = self._semantic_gen
+    if semantic_generator is not None:
+        semantic_generator.advance_turn()
+
+
 def _generate_tree_json(
     self: _WireFormatContext, n_messages: int, rng: random.Random, *, theme: ConversationTheme | None = None
 ) -> SyntheticRecord:
@@ -85,7 +103,7 @@ def _generate_tree_json(
 
     roles = self._role_cycle()
     base_ts = rng.uniform(1670000000, 1760000000)
-    self._semantic_gen = SemanticValueGenerator(rng, theme=theme, base_ts=base_ts, role_cycle=roles)
+    _reset_semantic_generator(self, rng=rng, theme=theme, base_ts=base_ts, roles=roles)
 
     top = self._generate_from_schema(self.schema, rng, skip_keys={tree_cfg.container_path})
     if not isinstance(top, dict):
@@ -117,17 +135,16 @@ def _generate_tree_json(
 
         role = roles[i % len(roles)]
         self._ensure_wire_format(node, role, rng, i, base_ts=base_ts, theme=theme)
-        self._semantic_gen.advance_turn()
+        _advance_semantic_turn(self)
         nodes.append(node)
 
-    properties_map = _coerce_schema(self.schema.get("properties"))
     children_by_id: SyntheticRecord = {}
     for node in nodes:
         node_id_value = node.get(tree_cfg.key_field)
         if isinstance(node_id_value, str):
             children_by_id[node_id_value] = node
     top_record[tree_cfg.container_path] = children_by_id
-    if "current_node" in properties_map:
+    if "current_node" in properties:
         top_record["current_node"] = nodes[-1][tree_cfg.key_field]
     if self.provider == "chatgpt":
         top_record["id"] = str(uuid.UUID(int=rng.getrandbits(128), version=4))
@@ -147,7 +164,7 @@ def _generate_linear_json(
 
     roles = self._role_cycle()
     base_ts = rng.uniform(1670000000, 1760000000)
-    self._semantic_gen = SemanticValueGenerator(rng, theme=theme, base_ts=base_ts, role_cycle=roles)
+    _reset_semantic_generator(self, rng=rng, theme=theme, base_ts=base_ts, roles=roles)
 
     schema_has_path, msgs_schema = _has_messages_path(msgs_parts, self.schema)
 
@@ -167,7 +184,7 @@ def _generate_linear_json(
         msg = _coerce_record(self._generate_from_schema(item_schema, rng))
         role = roles[i % len(roles)]
         self._ensure_wire_format(msg, role, rng, i, base_ts=base_ts, theme=theme)
-        self._semantic_gen.advance_turn()
+        _advance_semantic_turn(self)
         messages.append(msg)
 
     target: SyntheticRecord = top_record
@@ -192,14 +209,14 @@ def _generate_jsonl_records(
     roles = self._role_cycle()
     session_id = str(uuid.UUID(int=rng.getrandbits(128), version=4))
     base_ts = rng.uniform(1670000000, 1760000000)
-    self._semantic_gen = SemanticValueGenerator(rng, theme=theme, base_ts=base_ts, role_cycle=roles)
+    _reset_semantic_generator(self, rng=rng, theme=theme, base_ts=base_ts, roles=roles)
 
     for i in range(n_messages):
         record = _coerce_record(self._generate_from_schema(self.schema, rng))
 
         role = roles[i % len(roles)]
         self._ensure_wire_format(record, role, rng, i, base_ts=base_ts, theme=theme)
-        self._semantic_gen.advance_turn()
+        _advance_semantic_turn(self)
 
         if tree_cfg:
             node_id = str(uuid.UUID(int=rng.getrandbits(128), version=4))

--- a/polylogue/schemas/synthetic/build_wire_formats.py
+++ b/polylogue/schemas/synthetic/build_wire_formats.py
@@ -14,8 +14,14 @@ from polylogue.schemas.synthetic.showcase import ConversationTheme
 SyntheticRecord: TypeAlias = dict[str, JSONValue]
 
 
-def _as_record(value: JSONValue) -> SyntheticRecord:
+def _as_record(value: object) -> SyntheticRecord:
     return value if isinstance(value, dict) else {}
+
+
+def _record_field(record: SyntheticRecord, field_name: str) -> SyntheticRecord:
+    nested = _as_record(record.get(field_name))
+    record[field_name] = nested
+    return nested
 
 
 class _WireFormatContext(Protocol):
@@ -109,21 +115,17 @@ def _ensure_wire_chatgpt(
     index: int,
     theme: ConversationTheme | None,
 ) -> None:
-    msg = data.get("message")
-    if not isinstance(msg, dict):
-        msg = {"id": str(uuid.UUID(int=rng.getrandbits(128), version=4))}
-        data["message"] = msg
-    author = msg.setdefault("author", {})
-    if isinstance(author, dict):
-        author.setdefault("role", role)
-    if not isinstance(msg.get("content"), dict):
-        msg["content"] = {}
-    content = msg.setdefault("content", {})
-    assert isinstance(content, dict)
-    if isinstance(content, dict):
-        if "parts" not in content or not content["parts"]:
-            content["parts"] = [_text_for_role(rng, role, turn_index=index, theme=theme)]
-        content.setdefault("content_type", "text")
+    msg = _record_field(data, "message")
+    msg.setdefault("id", str(uuid.UUID(int=rng.getrandbits(128), version=4)))
+
+    author = _record_field(msg, "author")
+    author.setdefault("role", role)
+
+    content = _record_field(msg, "content")
+    if "parts" not in content or not content["parts"]:
+        content["parts"] = [_text_for_role(rng, role, turn_index=index, theme=theme)]
+    content.setdefault("content_type", "text")
+
     msg.setdefault("create_time", ts)
     msg.setdefault("id", str(uuid.UUID(int=rng.getrandbits(128), version=4)))
 
@@ -157,10 +159,7 @@ def _ensure_wire_claude_code(
     theme: ConversationTheme | None,
 ) -> None:
     data.setdefault("type", role)
-    message = data.get("message")
-    if not isinstance(message, dict):
-        data["message"] = {}
-    msg = _as_record(data["message"])
+    msg = _record_field(data, "message")
     msg.setdefault("role", role)
     if "content" not in msg:
         msg["content"] = [{"type": "text", "text": _text_for_role(rng, role, turn_index=index, theme=theme)}]

--- a/polylogue/schemas/synthetic/core.py
+++ b/polylogue/schemas/synthetic/core.py
@@ -2,43 +2,31 @@
 
 from __future__ import annotations
 
+import random
 from collections import Counter
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from polylogue.scenarios import CorpusSpec
 from polylogue.schemas.runtime_registry import SchemaRegistry, canonical_schema_provider
-from polylogue.schemas.synthetic.builders import (
-    _ensure_wire_chatgpt,
-    _ensure_wire_claude_ai,
-    _ensure_wire_claude_code,
-    _ensure_wire_codex,
-    _ensure_wire_format,
-    _ensure_wire_gemini,
-    _generate_conversation,
-    _generate_jsonl_records,
-    _generate_linear_json,
-    _generate_tree_json,
-    _role_cycle,
-    generate_batch,
-)
+from polylogue.schemas.synthetic import builders as synthetic_builders
+from polylogue.schemas.synthetic import runtime as synthetic_runtime
 from polylogue.schemas.synthetic.models import (
     SchemaRecord,
     SyntheticGenerationBatch,
     SyntheticGenerationReport,
+    SyntheticGenerationState,
     SyntheticSchemaSelection,
     SyntheticWrittenBatch,
 )
 from polylogue.schemas.synthetic.relations import RelationConstraintSolver
-from polylogue.schemas.synthetic.runtime import (
-    _generate_array,
-    _generate_from_schema,
-    _generate_number,
-    _generate_object,
-    _generate_string,
-    _serialize,
-)
 from polylogue.schemas.synthetic.selection import available_synthetic_providers, select_synthetic_schema
+from polylogue.schemas.synthetic.semantic_values import SemanticValueGenerator
 from polylogue.schemas.synthetic.wire_formats import WireFormat
+
+if TYPE_CHECKING:
+    from polylogue.lib.raw_payload_decode import JSONValue
+    from polylogue.schemas.synthetic.showcase import ConversationTheme
 
 
 class SyntheticCorpus:
@@ -58,8 +46,10 @@ class SyntheticCorpus:
         self.provider = provider
         self.package_version = package_version
         self.element_kind = element_kind
-        self._relation_solver = RelationConstraintSolver(schema)
-        self._semantic_gen: object | None = None
+        self._generation_state = SyntheticGenerationState(
+            relation_solver=RelationConstraintSolver(schema),
+            semantic_generator=None,
+        )
 
     @classmethod
     def for_provider(
@@ -161,7 +151,7 @@ class SyntheticCorpus:
         seed: int | None = None,
         style: str = "default",
     ) -> SyntheticGenerationBatch:
-        return generate_batch(
+        return synthetic_builders.generate_batch(
             self,
             count=count,
             messages_per_conversation=messages_per_conversation,
@@ -183,23 +173,197 @@ class SyntheticCorpus:
             style=style,
         ).raw_items
 
-    _ensure_wire_chatgpt = _ensure_wire_chatgpt
-    _ensure_wire_claude_ai = _ensure_wire_claude_ai
-    _ensure_wire_claude_code = _ensure_wire_claude_code
-    _ensure_wire_codex = _ensure_wire_codex
-    _ensure_wire_format = _ensure_wire_format
-    _ensure_wire_gemini = _ensure_wire_gemini
-    _generate_array = _generate_array
-    _generate_conversation = _generate_conversation
-    _generate_from_schema = _generate_from_schema
-    _generate_jsonl_records = _generate_jsonl_records
-    _generate_linear_json = _generate_linear_json
-    _generate_number = _generate_number
-    _generate_object = _generate_object
-    _generate_string = _generate_string
-    _generate_tree_json = _generate_tree_json
-    _role_cycle = _role_cycle
-    _serialize = _serialize
+    @property
+    def _relation_solver(self) -> RelationConstraintSolver:
+        return self._generation_state.relation_solver
+
+    @_relation_solver.setter
+    def _relation_solver(self, value: RelationConstraintSolver) -> None:
+        self._generation_state.relation_solver = value
+
+    @property
+    def _semantic_gen(self) -> SemanticValueGenerator | None:
+        semantic_generator = self._generation_state.semantic_generator
+        return semantic_generator if isinstance(semantic_generator, SemanticValueGenerator) else None
+
+    @_semantic_gen.setter
+    def _semantic_gen(self, value: SemanticValueGenerator | None) -> None:
+        self._generation_state.semantic_generator = value
+
+    def _ensure_wire_chatgpt(
+        self,
+        data: dict[str, JSONValue],
+        role: str,
+        rng: random.Random,
+        ts: float,
+        *,
+        index: int,
+        theme: ConversationTheme | None,
+    ) -> None:
+        synthetic_builders._ensure_wire_chatgpt(self, data, role, rng, ts, index=index, theme=theme)
+
+    def _ensure_wire_claude_ai(
+        self,
+        data: dict[str, JSONValue],
+        role: str,
+        rng: random.Random,
+        ts: float,
+        *,
+        index: int,
+        theme: ConversationTheme | None,
+    ) -> None:
+        synthetic_builders._ensure_wire_claude_ai(self, data, role, rng, ts, index=index, theme=theme)
+
+    def _ensure_wire_claude_code(
+        self,
+        data: dict[str, JSONValue],
+        role: str,
+        rng: random.Random,
+        ts: float,
+        *,
+        index: int,
+        theme: ConversationTheme | None,
+    ) -> None:
+        synthetic_builders._ensure_wire_claude_code(self, data, role, rng, ts, index=index, theme=theme)
+
+    def _ensure_wire_codex(
+        self,
+        data: dict[str, JSONValue],
+        role: str,
+        rng: random.Random,
+        ts: float,
+        *,
+        index: int,
+        theme: ConversationTheme | None,
+    ) -> None:
+        synthetic_builders._ensure_wire_codex(self, data, role, rng, ts, index=index, theme=theme)
+
+    def _ensure_wire_format(
+        self,
+        data: dict[str, JSONValue],
+        role: str,
+        rng: random.Random,
+        index: int,
+        base_ts: float = 1700000000.0,
+        theme: ConversationTheme | None = None,
+    ) -> None:
+        synthetic_builders._ensure_wire_format(self, data, role, rng, index, base_ts=base_ts, theme=theme)
+
+    def _ensure_wire_gemini(
+        self,
+        data: dict[str, JSONValue],
+        role: str,
+        rng: random.Random,
+        *,
+        index: int,
+        theme: ConversationTheme | None,
+    ) -> None:
+        synthetic_builders._ensure_wire_gemini(self, data, role, rng, index=index, theme=theme)
+
+    def _generate_array(
+        self,
+        schema: SchemaRecord,
+        rng: random.Random,
+        *,
+        depth: int = 0,
+        max_depth: int = 6,
+        path: str = "$",
+    ) -> list[JSONValue]:
+        return synthetic_runtime._generate_array(self, schema, rng, depth=depth, max_depth=max_depth, path=path)
+
+    def _generate_conversation(
+        self,
+        n_messages: int,
+        rng: random.Random,
+        *,
+        theme: ConversationTheme | None = None,
+    ) -> JSONValue:
+        return synthetic_builders._generate_conversation(self, n_messages, rng, theme=theme)
+
+    def _generate_from_schema(
+        self,
+        schema: SchemaRecord,
+        rng: random.Random,
+        *,
+        skip_keys: set[str] | None = None,
+        depth: int = 0,
+        max_depth: int = 6,
+        path: str = "$",
+    ) -> JSONValue:
+        return synthetic_runtime._generate_from_schema(
+            self,
+            schema,
+            rng,
+            skip_keys=skip_keys,
+            depth=depth,
+            max_depth=max_depth,
+            path=path,
+        )
+
+    def _generate_jsonl_records(
+        self,
+        n_messages: int,
+        rng: random.Random,
+        *,
+        theme: ConversationTheme | None = None,
+    ) -> list[dict[str, JSONValue]]:
+        return synthetic_builders._generate_jsonl_records(self, n_messages, rng, theme=theme)
+
+    def _generate_linear_json(
+        self,
+        n_messages: int,
+        rng: random.Random,
+        *,
+        theme: ConversationTheme | None = None,
+    ) -> dict[str, JSONValue]:
+        return synthetic_builders._generate_linear_json(self, n_messages, rng, theme=theme)
+
+    def _generate_number(
+        self,
+        schema: SchemaRecord,
+        rng: random.Random,
+        *,
+        is_int: bool = False,
+    ) -> float | int:
+        return synthetic_runtime._generate_number(self, schema, rng, is_int=is_int)
+
+    def _generate_object(
+        self,
+        schema: SchemaRecord,
+        rng: random.Random,
+        *,
+        skip_keys: set[str] | None = None,
+        depth: int = 0,
+        max_depth: int = 6,
+        path: str = "$",
+    ) -> dict[str, JSONValue]:
+        return synthetic_runtime._generate_object(
+            self,
+            schema,
+            rng,
+            skip_keys=skip_keys,
+            depth=depth,
+            max_depth=max_depth,
+            path=path,
+        )
+
+    def _generate_string(self, schema: SchemaRecord, rng: random.Random) -> str:
+        return synthetic_runtime._generate_string(self, schema, rng)
+
+    def _generate_tree_json(
+        self,
+        n_messages: int,
+        rng: random.Random,
+        *,
+        theme: ConversationTheme | None = None,
+    ) -> dict[str, JSONValue]:
+        return synthetic_builders._generate_tree_json(self, n_messages, rng, theme=theme)
+
+    def _role_cycle(self) -> list[str]:
+        return synthetic_builders._role_cycle(self)
+
+    def _serialize(self, data: JSONValue) -> bytes:
+        return synthetic_runtime._serialize(self, data)
 
 
 __all__ = [

--- a/polylogue/schemas/synthetic/models.py
+++ b/polylogue/schemas/synthetic/models.py
@@ -4,9 +4,13 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal, TypeAlias
+from typing import TYPE_CHECKING, Literal, TypeAlias
 
 from polylogue.schemas.synthetic.wire_formats import WireEncoding, WireFormat
+
+if TYPE_CHECKING:
+    from polylogue.schemas.synthetic.relations import RelationConstraintSolver
+    from polylogue.schemas.synthetic.semantic_values import SemanticValueGenerator
 
 SchemaScalar: TypeAlias = str | int | float | bool | None
 SchemaValue: TypeAlias = SchemaScalar | list["SchemaValue"] | dict[str, "SchemaValue"]
@@ -58,12 +62,19 @@ class SyntheticWrittenBatch:
     files: tuple[Path, ...]
 
 
+@dataclass
+class SyntheticGenerationState:
+    relation_solver: RelationConstraintSolver
+    semantic_generator: SemanticValueGenerator | None = None
+
+
 __all__ = [
     "SchemaRecord",
     "SchemaScalar",
     "SchemaValue",
     "SyntheticArtifact",
     "SyntheticGenerationBatch",
+    "SyntheticGenerationState",
     "SyntheticGenerationReport",
     "SyntheticSchemaSelection",
     "SyntheticStyle",

--- a/polylogue/schemas/synthetic/relation_solver_runtime.py
+++ b/polylogue/schemas/synthetic/relation_solver_runtime.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import random
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
+
+from polylogue.schemas.synthetic.models import SchemaRecord
 
 if TYPE_CHECKING:
     from polylogue.schemas.synthetic.relations import (
@@ -14,15 +17,45 @@ if TYPE_CHECKING:
     )
 
 
-def _mapping_items(schema: dict[str, object], key: str) -> tuple[dict[str, object], ...]:
+@dataclass(frozen=True)
+class _ForeignKeyAnnotation:
+    source: str
+    target: str
+
+
+@dataclass(frozen=True)
+class _TimeDeltaAnnotation:
+    field_a: str
+    field_b: str
+    min_delta: float
+    max_delta: float
+    avg_delta: float
+
+
+@dataclass(frozen=True)
+class _MutualExclusionAnnotation:
+    parent: str
+    fields: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class _StringLengthAnnotation:
+    path: str
+    min_length: int
+    max_length: int
+    avg_length: float
+    stddev: float
+
+
+def _annotation_records(schema: SchemaRecord, key: str) -> tuple[SchemaRecord, ...]:
     value = schema.get(key)
-    if not isinstance(value, list | tuple):
+    if not isinstance(value, list):
         return ()
     return tuple(item for item in value if isinstance(item, dict))
 
 
 def _string_tuple(value: object) -> tuple[str, ...]:
-    if not isinstance(value, list | tuple):
+    if not isinstance(value, list):
         return ()
     return tuple(str(item) for item in value)
 
@@ -47,6 +80,59 @@ def _float_value(value: object, default: float) -> float:
     return default
 
 
+def _foreign_key_annotations(schema: SchemaRecord) -> tuple[_ForeignKeyAnnotation, ...]:
+    annotations: list[_ForeignKeyAnnotation] = []
+    for record in _annotation_records(schema, "x-polylogue-foreign-keys"):
+        source = str(record.get("source", "")).strip()
+        target = str(record.get("target", "")).strip()
+        if source and target:
+            annotations.append(_ForeignKeyAnnotation(source=source, target=target))
+    return tuple(annotations)
+
+
+def _time_delta_annotations(schema: SchemaRecord) -> tuple[_TimeDeltaAnnotation, ...]:
+    annotations: list[_TimeDeltaAnnotation] = []
+    for record in _annotation_records(schema, "x-polylogue-time-deltas"):
+        annotations.append(
+            _TimeDeltaAnnotation(
+                field_a=str(record.get("field_a", "")).strip(),
+                field_b=str(record.get("field_b", "")).strip(),
+                min_delta=_float_value(record.get("min_delta"), 0.0),
+                max_delta=_float_value(record.get("max_delta"), 0.0),
+                avg_delta=_float_value(record.get("avg_delta"), 0.0),
+            )
+        )
+    return tuple(annotation for annotation in annotations if annotation.field_a and annotation.field_b)
+
+
+def _mutual_exclusion_annotations(schema: SchemaRecord) -> tuple[_MutualExclusionAnnotation, ...]:
+    annotations: list[_MutualExclusionAnnotation] = []
+    for record in _annotation_records(schema, "x-polylogue-mutually-exclusive"):
+        parent = str(record.get("parent", "")).strip()
+        fields = _string_tuple(record.get("fields"))
+        if parent and len(fields) >= 2:
+            annotations.append(_MutualExclusionAnnotation(parent=parent, fields=fields))
+    return tuple(annotations)
+
+
+def _string_length_annotations(schema: SchemaRecord) -> tuple[_StringLengthAnnotation, ...]:
+    annotations: list[_StringLengthAnnotation] = []
+    for record in _annotation_records(schema, "x-polylogue-string-lengths"):
+        path = str(record.get("path", "")).strip()
+        if not path:
+            continue
+        annotations.append(
+            _StringLengthAnnotation(
+                path=path,
+                min_length=_int_value(record.get("min"), 0),
+                max_length=_int_value(record.get("max"), 100),
+                avg_length=_float_value(record.get("avg"), 50.0),
+                stddev=_float_value(record.get("stddev"), 10.0),
+            )
+        )
+    return tuple(annotations)
+
+
 class RelationConstraintSolverRuntimeMixin:
     fk_graph: ForeignKeyGraph
     time_deltas: list[TimeDeltaConstraint]
@@ -56,48 +142,40 @@ class RelationConstraintSolverRuntimeMixin:
     _mutual_exclusion_cls: type[MutualExclusionGroup]
     _string_length_cls: type[StringLengthConstraint]
 
-    def _parse_foreign_keys(self, schema: dict[str, object]) -> None:
-        for fk in _mapping_items(schema, "x-polylogue-foreign-keys"):
-            source = str(fk.get("source", "")).strip()
-            target = str(fk.get("target", "")).strip()
-            if source and target:
-                self.fk_graph.references[source] = target
+    def _parse_foreign_keys(self, schema: SchemaRecord) -> None:
+        for annotation in _foreign_key_annotations(schema):
+            self.fk_graph.references[annotation.source] = annotation.target
 
-    def _parse_time_deltas(self, schema: dict[str, object]) -> None:
-        for td in _mapping_items(schema, "x-polylogue-time-deltas"):
+    def _parse_time_deltas(self, schema: SchemaRecord) -> None:
+        for annotation in _time_delta_annotations(schema):
             self.time_deltas.append(
                 self._time_delta_cls(
-                    field_a=str(td.get("field_a", "")),
-                    field_b=str(td.get("field_b", "")),
-                    min_delta=_float_value(td.get("min_delta"), 0.0),
-                    max_delta=_float_value(td.get("max_delta"), 0.0),
-                    avg_delta=_float_value(td.get("avg_delta"), 0.0),
+                    field_a=annotation.field_a,
+                    field_b=annotation.field_b,
+                    min_delta=annotation.min_delta,
+                    max_delta=annotation.max_delta,
+                    avg_delta=annotation.avg_delta,
                 )
             )
 
-    def _parse_mutual_exclusions(self, schema: dict[str, object]) -> None:
-        for me in _mapping_items(schema, "x-polylogue-mutually-exclusive"):
-            parent = str(me.get("parent", "")).strip()
-            fields = _string_tuple(me.get("fields"))
-            if parent and len(fields) >= 2:
-                self.mutual_exclusions.append(
-                    self._mutual_exclusion_cls(
-                        parent_path=parent,
-                        field_names=frozenset(fields),
-                    )
+    def _parse_mutual_exclusions(self, schema: SchemaRecord) -> None:
+        for annotation in _mutual_exclusion_annotations(schema):
+            self.mutual_exclusions.append(
+                self._mutual_exclusion_cls(
+                    parent_path=annotation.parent,
+                    field_names=frozenset(annotation.fields),
                 )
+            )
 
-    def _parse_string_lengths(self, schema: dict[str, object]) -> None:
-        for sl in _mapping_items(schema, "x-polylogue-string-lengths"):
-            path = str(sl.get("path", "")).strip()
-            if path:
-                self.string_lengths[path] = self._string_length_cls(
-                    path=path,
-                    min_length=_int_value(sl.get("min"), 0),
-                    max_length=_int_value(sl.get("max"), 100),
-                    avg_length=_float_value(sl.get("avg"), 50.0),
-                    stddev=_float_value(sl.get("stddev"), 10.0),
-                )
+    def _parse_string_lengths(self, schema: SchemaRecord) -> None:
+        for annotation in _string_length_annotations(schema):
+            self.string_lengths[annotation.path] = self._string_length_cls(
+                path=annotation.path,
+                min_length=annotation.min_length,
+                max_length=annotation.max_length,
+                avg_length=annotation.avg_length,
+                stddev=annotation.stddev,
+            )
 
     def register_generated_id(self, path: str, value: str) -> None:
         self.fk_graph.register_id(path, value)

--- a/polylogue/schemas/synthetic/relations.py
+++ b/polylogue/schemas/synthetic/relations.py
@@ -12,8 +12,8 @@ from __future__ import annotations
 
 import random
 from dataclasses import dataclass, field
-from typing import Any
 
+from polylogue.schemas.synthetic.models import SchemaRecord
 from polylogue.schemas.synthetic.relation_solver_runtime import RelationConstraintSolverRuntimeMixin
 
 
@@ -88,7 +88,7 @@ class RelationConstraintSolver(RelationConstraintSolverRuntimeMixin):
     consistency.
     """
 
-    def __init__(self, schema: dict[str, Any]) -> None:
+    def __init__(self, schema: SchemaRecord) -> None:
         self.fk_graph = ForeignKeyGraph()
         self.time_deltas: list[TimeDeltaConstraint] = []
         self.mutual_exclusions: list[MutualExclusionGroup] = []

--- a/polylogue/schemas/synthetic/runtime.py
+++ b/polylogue/schemas/synthetic/runtime.py
@@ -5,47 +5,24 @@ from __future__ import annotations
 import json
 import random
 import uuid
-from collections.abc import Mapping, Sequence
 from datetime import datetime, timezone
-from typing import Protocol, TypeAlias, cast
+from typing import TYPE_CHECKING, Protocol, TypeAlias
 
 from polylogue.lib.raw_payload_decode import JSONValue
 from polylogue.schemas.synthetic.models import SchemaRecord, SchemaValue
-from polylogue.schemas.synthetic.semantic_values import _text_for_role
-from polylogue.schemas.synthetic.wire_formats import WireEncoding
+from polylogue.schemas.synthetic.semantic_values import SemanticValueGenerator, _text_for_role
+from polylogue.schemas.synthetic.wire_formats import WireFormat
+
+if TYPE_CHECKING:
+    from polylogue.schemas.synthetic.relations import RelationConstraintSolver
 
 SyntheticRecord: TypeAlias = dict[str, JSONValue]
 
 
-class _SemanticGenerator(Protocol):
-    def try_generate(self, schema: Mapping[str, object]) -> tuple[bool, JSONValue]: ...
-
-
-class _RelationSolver(Protocol):
-    mutual_exclusions: Sequence[object]
-
-    def generate_string_with_length(self, path: str, rng: random.Random, value: str) -> str: ...
-
-    def register_generated_id(self, path: str, value: str) -> None: ...
-
-    def filter_mutually_exclusive(
-        self,
-        path: str,
-        candidate_keys: set[str],
-        rng: random.Random,
-    ) -> set[str]: ...
-
-    def resolve_foreign_key(self, path: str, rng: random.Random) -> JSONValue | None: ...
-
-
-class _WireFormat(Protocol):
-    encoding: WireEncoding
-
-
 class _SyntheticRuntimeContext(Protocol):
-    wire_format: _WireFormat
-    _semantic_gen: _SemanticGenerator | None
-    _relation_solver: _RelationSolver
+    wire_format: WireFormat
+    _semantic_gen: SemanticValueGenerator | None
+    _relation_solver: RelationConstraintSolver
 
     def _generate_from_schema(
         self,
@@ -90,11 +67,11 @@ class _SyntheticRuntimeContext(Protocol):
     ) -> float | int: ...
 
 
-def _schema_record(value: object) -> SchemaRecord:
-    return cast(SchemaRecord, value) if isinstance(value, dict) else {}
+def _schema_record(value: SchemaValue | object) -> SchemaRecord:
+    return value if isinstance(value, dict) else {}
 
 
-def _schema_records(value: object) -> list[SchemaRecord]:
+def _schema_records(value: SchemaValue | object) -> list[SchemaRecord]:
     if not isinstance(value, list):
         return []
     return [record for item in value if (record := _schema_record(item))]

--- a/polylogue/schemas/synthetic/selection.py
+++ b/polylogue/schemas/synthetic/selection.py
@@ -3,22 +3,20 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Protocol, TypeAlias, cast
+from typing import Protocol, TypeAlias
 
+from polylogue.schemas.packages import SchemaVersionPackage
 from polylogue.schemas.runtime_registry import SchemaRegistry, canonical_schema_provider
 from polylogue.schemas.synthetic.models import SchemaRecord, SyntheticSchemaSelection
 from polylogue.schemas.synthetic.wire_formats import PROVIDER_WIRE_FORMATS
 
 
-class _SchemaVersionPackageLike(Protocol):
-    version: str
-    default_element_kind: str | None
-
-    def element(self, element_kind: str | None) -> object | None: ...
-
-
 class _SchemaRegistryLike(Protocol):
-    def get_package(self, provider: str, version: str = "default") -> object | None: ...
+    def get_package(
+        self,
+        provider: str,
+        version: str = "default",
+    ) -> SchemaVersionPackage | None: ...
 
     def get_element_schema(
         self,
@@ -26,9 +24,9 @@ class _SchemaRegistryLike(Protocol):
         *,
         version: str = "default",
         element_kind: str | None = None,
-    ) -> object | None: ...
+    ) -> SchemaRecord | None: ...
 
-    def get_schema(self, provider: str, version: str = "default") -> object | None: ...
+    def get_schema(self, provider: str, version: str = "default") -> SchemaRecord | None: ...
 
     def list_providers(self) -> list[str]: ...
 
@@ -41,14 +39,6 @@ def _default_registry_factory() -> _SchemaRegistryLike:
     return SchemaRegistry()
 
 
-def _schema_package(value: object) -> _SchemaVersionPackageLike | None:
-    return cast(_SchemaVersionPackageLike, value) if value is not None else None
-
-
-def _schema_record(value: object) -> SchemaRecord | None:
-    return cast(SchemaRecord, value) if isinstance(value, dict) else None
-
-
 def select_synthetic_schema(
     provider: str,
     *,
@@ -59,7 +49,7 @@ def select_synthetic_schema(
 ) -> SyntheticSchemaSelection:
     canonical_provider = canonical_provider_resolver(provider)
     registry = registry_factory()
-    package = _schema_package(registry.get_package(canonical_provider, version=version))
+    package = registry.get_package(canonical_provider, version=version)
     resolved_element_kind = element_kind
 
     schema: SchemaRecord | None
@@ -72,12 +62,10 @@ def select_synthetic_schema(
                 f"{resolved_element_kind!r} in package {package.version} for provider "
                 f"{canonical_provider}"
             )
-        schema = _schema_record(
-            registry.get_element_schema(
-                canonical_provider,
-                version=version,
-                element_kind=resolved_element_kind,
-            )
+        schema = registry.get_element_schema(
+            canonical_provider,
+            version=version,
+            element_kind=resolved_element_kind,
         )
         canonical_version = package.version
     else:
@@ -86,7 +74,7 @@ def select_synthetic_schema(
                 f"Element schemas are not available for provider {canonical_provider}; "
                 f"cannot request element_kind={element_kind!r}"
             )
-        schema = _schema_record(registry.get_schema(canonical_provider, version=version))
+        schema = registry.get_schema(canonical_provider, version=version)
         canonical_version = version
         resolved_element_kind = None if element_kind is None else element_kind
 

--- a/polylogue/schemas/tooling_registry.py
+++ b/polylogue/schemas/tooling_registry.py
@@ -6,10 +6,11 @@ import json
 from collections.abc import Mapping, Sequence
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, TypeAlias
+from typing import TYPE_CHECKING, TypeAlias, cast
 
 from polylogue.schemas.json_types import json_document, json_document_list
 from polylogue.schemas.observation import schema_cluster_id
+from polylogue.schemas.observation_models import SchemaClusterPayload
 from polylogue.schemas.packages import SchemaPackageCatalog, SchemaVersionPackage
 from polylogue.schemas.runtime_registry import (
     ElementSchemaMap,
@@ -33,6 +34,18 @@ def _dominant_keys(sample: object) -> list[str]:
     if documents:
         return sorted(documents[0])
     return []
+
+
+def _cluster_payload(sample: object) -> SchemaClusterPayload:
+    document = json_document(sample)
+    if document:
+        return document
+    documents = json_document_list(sample)
+    if documents:
+        return cast(SchemaClusterPayload, documents)
+    if sample is None or isinstance(sample, (str, int, float, bool)):
+        return sample
+    return None
 
 
 class SchemaRegistryToolingMixin:
@@ -134,7 +147,7 @@ class SchemaRegistryToolingMixin:
             artifact_kind = (
                 artifact_kinds[index] if artifact_kinds is not None and index < len(artifact_kinds) else "unspecified"
             )
-            cluster_id = schema_cluster_id(sample, artifact_kind)
+            cluster_id = schema_cluster_id(_cluster_payload(sample), artifact_kind)
             groups.setdefault(cluster_id, []).append(index)
             artifact_by_cluster[cluster_id] = artifact_kind
 

--- a/tests/unit/core/test_schema_extraction_runtime.py
+++ b/tests/unit/core/test_schema_extraction_runtime.py
@@ -1,0 +1,131 @@
+"""Focused tests for schema extraction and observation runtime helpers."""
+
+from __future__ import annotations
+
+from polylogue.lib.json import JSONDocument
+from polylogue.schemas.extraction import extract_message_from_schema
+from polylogue.schemas.observation import ProviderConfig, extract_schema_units_from_payload
+from polylogue.types import Provider
+
+
+class TestExtractMessageFromSchema:
+    def test_falls_back_to_well_known_fields_without_pins(self) -> None:
+        raw: JSONDocument = {
+            "uuid": "msg-1",
+            "sender": "user",
+            "text": "Hello there",
+            "created_at": "2026-01-01T00:00:00Z",
+            "costUSD": "0.02",
+            "durationMs": "15",
+            "message": {
+                "model": "claude-3.7-sonnet",
+                "usage": {
+                    "input_tokens": 10,
+                    "output_tokens": 4,
+                    "total_tokens": 14,
+                },
+            },
+        }
+
+        message = extract_message_from_schema(raw, schema={}, provider=Provider.CLAUDE_AI)
+
+        assert message.id == "msg-1"
+        assert str(message.role) == "user"
+        assert message.text == "Hello there"
+        assert message.model == "claude-3.7-sonnet"
+        assert message.tokens is not None
+        assert message.tokens.total_tokens == 14
+        assert message.cost is not None
+        assert message.cost.total_usd == 0.02
+        assert message.duration_ms == 15
+
+    def test_extracts_text_and_blocks_from_structured_body(self) -> None:
+        raw: JSONDocument = {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "First block"},
+                    {"type": "thinking", "thinking": "Reasoning trace"},
+                    {"type": "tool_use", "name": "write_file", "input": {"path": "a.txt"}},
+                ],
+            },
+            "timestamp": "2026-01-01T00:01:00Z",
+        }
+        schema: JSONDocument = {
+            "properties": {
+                "message": {
+                    "properties": {
+                        "content": {"x-polylogue-semantic-role": "message_body"},
+                    }
+                }
+            }
+        }
+
+        message = extract_message_from_schema(raw, schema=schema, provider=Provider.CLAUDE_CODE)
+
+        assert message.text == "First block"
+        assert len(message.content_blocks) == 3
+        assert len(message.reasoning_traces) == 1
+        assert len(message.tool_calls) == 1
+
+
+class TestExtractSchemaUnitsFromPayload:
+    def test_record_granularity_compacts_and_profiles_samples(self) -> None:
+        config = ProviderConfig(
+            name=Provider.CLAUDE_CODE,
+            description="Claude Code",
+            sample_granularity="record",
+            record_type_key="type",
+            schema_sample_cap=8,
+        )
+        payload = [
+            {"type": "session_meta", "id": "sess-1"},
+            {"type": "message", "role": "user", "content": [{"type": "text", "text": "x" * 2048}]},
+            {"type": "message", "role": "assistant", "content": [{"type": "text", "text": "reply"}]},
+        ]
+
+        units = extract_schema_units_from_payload(
+            payload,
+            provider_name=Provider.CLAUDE_CODE,
+            source_path="/tmp/session.jsonl",
+            raw_id="raw-1",
+            observed_at="2026-01-01T00:00:00Z",
+            config=config,
+        )
+
+        assert len(units) == 1
+        unit = units[0]
+        assert unit.conversation_id == "raw-1"
+        assert unit.bundle_scope == "session"
+        assert any(token.startswith("bucket:") for token in unit.profile_tokens)
+        content = unit.schema_samples[1]["content"]
+        assert isinstance(content, list)
+        first_block = content[0]
+        assert isinstance(first_block, dict)
+        text = first_block.get("text")
+        assert isinstance(text, str)
+        assert len(text) == 1024
+
+    def test_document_granularity_emits_one_unit_per_document(self) -> None:
+        config = ProviderConfig(
+            name=Provider.CHATGPT,
+            description="ChatGPT",
+            sample_granularity="document",
+        )
+        payload = [
+            {"id": "conv-1", "mapping": {"node-1": {"message": {"id": "m1"}}}},
+            {"id": "conv-2", "mapping": {"node-9": {"message": {"author": {"role": "user"}}}}},
+        ]
+
+        units = extract_schema_units_from_payload(
+            payload,
+            provider_name=Provider.CHATGPT,
+            source_path="/tmp/conversations.json",
+            raw_id="raw-docs",
+            config=config,
+        )
+
+        assert len(units) == 2
+        assert {unit.conversation_id for unit in units} == {"conv-1", "conv-2"}
+        assert all(unit.artifact_kind == "conversation_document" for unit in units)


### PR DESCRIPTION
Ref #261

## Summary
- rebuild schema extraction around explicit resolved-message records instead of loose body/usage/timestamp plumbing
- renew synthetic generation so `SyntheticCorpus` owns real runtime state and explicit methods rather than rebinding imported helpers
- tighten schema observation and sampling feed paths so record-stream and document sampling flow through cleaner typed boundaries

## Problem
The schema-side core was strict-type-clean, but several high-churn seams were still path-dependent and weakly modeled. Extraction mixed JSON-path walking, body fallback, timestamp/model/usage resolution, and harmonization through broad `object` values. Synthetic generation centered on a `SyntheticCorpus` shell that rebound imported helper functions and spread runtime state across loose helper protocols. DB/session sampling still duplicated record-stream versus envelope logic instead of owning an explicit raw-row boundary.

That left the code semantically underspecified even though mypy was green.

## Solution
- introduced explicit extraction and observation records in:
  - `polylogue/schemas/extraction.py`
  - `polylogue/schemas/observation_models.py`
  - `polylogue/schemas/observation_runtime.py`
- renewed the synthetic center of gravity in:
  - `polylogue/schemas/synthetic/core.py`
  - `polylogue/schemas/synthetic/runtime.py`
  - `polylogue/schemas/synthetic/relation_solver_runtime.py`
  - `polylogue/schemas/synthetic/relations.py`
- followed the new contracts through the mechanical helper surfaces in:
  - `polylogue/schemas/synthetic/build_batch.py`
  - `polylogue/schemas/synthetic/build_records.py`
  - `polylogue/schemas/synthetic/build_wire_formats.py`
  - `polylogue/schemas/synthetic/selection.py`
- normalized schema sampling and cluster-payload handling in:
  - `polylogue/schemas/sampling_db.py`
  - `polylogue/schemas/sampling_sessions.py`
  - `polylogue/schemas/observation_identity.py`
  - `polylogue/schemas/tooling_registry.py`
- added focused extraction/observation tests in `tests/unit/core/test_schema_extraction_runtime.py`

## Verification
- `mypy polylogue/schemas/extraction.py polylogue/schemas/observation_models.py polylogue/schemas/observation_runtime.py polylogue/schemas/synthetic/core.py polylogue/schemas/synthetic/models.py polylogue/schemas/synthetic/relations.py polylogue/schemas/synthetic/relation_solver_runtime.py polylogue/schemas/synthetic/runtime.py polylogue/schemas/synthetic/build_batch.py tests/unit/core/test_schema_extraction_runtime.py`
- `pytest -q tests/unit/core/test_schema_extraction_runtime.py tests/unit/core/test_sampling.py tests/unit/core/test_schema_generation.py tests/unit/core/test_synthetic_relations.py tests/unit/core/test_synthetic_semantics.py tests/unit/core/test_synthetic_semantic_wiring.py`
- `mypy polylogue/schemas/observation_identity.py polylogue/schemas/sampling_db.py polylogue/schemas/sampling_sessions.py`
- `pytest -q tests/unit/core/test_sampling.py tests/unit/core/test_schema_generation.py -k 'sampling or schema_generation'`
- `mypy polylogue/schemas/tooling_registry.py tests/unit/core/test_schema_registry.py tests/unit/core/test_schema_cluster_assignment.py tests/integration/test_schema_operator_workflow.py`
- `devtools verify`
- push hook: `devtools verify --quick`
