### PR TITLE
refactor: tighten source provider and ingestion emission seams

### DIFF
--- a/polylogue/pipeline/services/ingest_worker.py
+++ b/polylogue/pipeline/services/ingest_worker.py
@@ -13,13 +13,14 @@ import pickle
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from typing_extensions import TypedDict
 
-from polylogue.lib.artifact_taxonomy import classify_artifact
+from polylogue.lib.artifact_taxonomy import ArtifactClassification, classify_artifact
 from polylogue.lib.branch_type import BranchType
 from polylogue.lib.json import dumps as json_dumps
+from polylogue.lib.raw_payload_decode import RawPayloadEnvelope
 from polylogue.lib.roles import Role
 from polylogue.pipeline.materialization_runtime import (
     MaterializedConversation,
@@ -42,6 +43,7 @@ from polylogue.types import (
 )
 
 if TYPE_CHECKING:
+    from polylogue.schemas.packages import SchemaResolution
     from polylogue.schemas.runtime_registry import SchemaRegistry
     from polylogue.sources.parsers.base import ParsedConversation
 
@@ -189,6 +191,41 @@ class IngestRecordResult:
     serialized_size_bytes: int | None = None
 
 
+ParsePlanMode = Literal["payload", "stream"]
+
+
+@dataclass(frozen=True, slots=True)
+class _IngestContext:
+    raw_record: RawConversationRecord
+    raw_source: Path
+    archive_root: Path
+    validation_mode: ValidationMode
+    measure_serialized_size: bool
+    source_name: str
+    fallback_timestamp: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class _ParsePlan:
+    provider: Provider
+    payload_provider: str
+    artifact: ArtifactClassification
+    mode: ParsePlanMode
+    schema_payload: object | None
+    payload: object | None = None
+    stream_name: str | None = None
+    malformed_jsonl_lines: int = 0
+    malformed_jsonl_detail: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class _PlanValidation:
+    status: ValidationStatus
+    schema_resolution: SchemaResolution | None = None
+    validation_error: str | None = None
+    parse_error: str | None = None
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -257,31 +294,67 @@ def _is_stream_record_provider(source_path: str | None, provider: str | Provider
     return Provider.from_string(provider) in STREAM_RECORD_PROVIDERS
 
 
-def _stream_grouped_jsonl_record(
-    raw_record: RawConversationRecord,
-    *,
-    raw_source: Path,
-    archive_root: Path,
+def _record_result(
+    context: _IngestContext,
     payload_provider: str | None,
-    validation_mode: ValidationMode,
-    measure_serialized_size: bool,
-) -> IngestRecordResult | None:
-    from polylogue.lib.raw_payload_decode import _sample_jsonl_payload_with_detail
-    from polylogue.schemas.validator import SchemaValidator
-    from polylogue.sources.dispatch import detect_provider, parse_stream_payload
+    *,
+    validation_status: ValidationStatus,
+    validation_error: str | None = None,
+    parse_error: str | None = None,
+    error: str | None = None,
+    conversations: list[ConversationData] | None = None,
+    include_source_name: bool = False,
+) -> IngestRecordResult:
+    return _finalize_result(
+        IngestRecordResult(
+            raw_id=context.raw_record.raw_id,
+            payload_provider=payload_provider,
+            validation_status=validation_status.value,
+            validation_error=validation_error,
+            parse_error=parse_error,
+            error=error,
+            conversations=conversations or [],
+            source_name=context.source_name if include_source_name else None,
+        ),
+        measure_serialized_size=context.measure_serialized_size,
+    )
 
-    stream_name = raw_record.source_path or raw_record.raw_id
+
+def _resolve_schema_resolution(
+    provider: Provider,
+    payload: object,
+    *,
+    source_path: str | None,
+) -> SchemaResolution | None:
+    if payload is None:
+        return None
+    return _runtime_schema_registry().resolve_payload(
+        provider,
+        payload,
+        source_path=source_path,
+    )
+
+
+def _build_stream_parse_plan(
+    context: _IngestContext,
+    *,
+    payload_provider: str | None,
+) -> _ParsePlan | None:
+    from polylogue.lib.raw_payload_decode import _sample_jsonl_payload_with_detail
+    from polylogue.sources.dispatch import detect_provider
+
+    stream_name = context.raw_record.source_path or context.raw_record.raw_id
 
     try:
         sample_payloads, malformed_lines, malformed_detail = _sample_jsonl_payload_with_detail(
-            raw_source,
+            context.raw_source,
             max_samples=64,
             jsonl_dict_only=True,
         )
     except Exception:
         return None
 
-    runtime_provider = Provider.from_string(payload_provider or raw_record.provider_name)
+    runtime_provider = Provider.from_string(payload_provider or context.raw_record.provider_name)
     detected_provider = Provider.from_string(payload_provider or runtime_provider)
     sniffed_provider = runtime_provider
     if sample_payloads:
@@ -294,140 +367,210 @@ def _stream_grouped_jsonl_record(
     artifact = classify_artifact(
         sample_payloads,
         provider=detected_provider,
-        source_path=raw_record.source_path,
+        source_path=context.raw_record.source_path,
     )
-    if not artifact.parse_as_conversation:
-        return _finalize_result(
-            IngestRecordResult(
-                raw_id=raw_record.raw_id,
-                payload_provider=str(detected_provider),
-                validation_status=ValidationStatus.SKIPPED.value,
-            ),
-            measure_serialized_size=measure_serialized_size,
+    return _ParsePlan(
+        provider=detected_provider,
+        payload_provider=str(detected_provider),
+        artifact=artifact,
+        mode="stream",
+        schema_payload=sample_payloads if artifact.schema_eligible else None,
+        stream_name=stream_name,
+        malformed_jsonl_lines=malformed_lines,
+        malformed_jsonl_detail=malformed_detail,
+    )
+
+
+def _build_envelope_parse_plan(
+    envelope: RawPayloadEnvelope,
+) -> _ParsePlan:
+    return _ParsePlan(
+        provider=envelope.provider,
+        payload_provider=str(envelope.provider),
+        artifact=envelope.artifact,
+        mode="payload",
+        schema_payload=envelope.payload if envelope.artifact.schema_eligible else None,
+        payload=envelope.payload,
+        malformed_jsonl_lines=envelope.malformed_jsonl_lines,
+        malformed_jsonl_detail=envelope.malformed_jsonl_detail,
+    )
+
+
+def _validate_parse_plan(
+    context: _IngestContext,
+    plan: _ParsePlan,
+) -> _PlanValidation:
+    from polylogue.schemas.validator import SchemaValidator
+
+    if context.validation_mode is ValidationMode.OFF:
+        return _PlanValidation(status=ValidationStatus.SKIPPED)
+    if not plan.artifact.schema_eligible or plan.schema_payload is None:
+        return _PlanValidation(status=ValidationStatus.PASSED)
+    if plan.malformed_jsonl_lines and context.validation_mode is ValidationMode.STRICT:
+        malformed_error = _format_malformed_jsonl_error(
+            malformed_lines=plan.malformed_jsonl_lines,
+            malformed_detail=plan.malformed_jsonl_detail,
+        )
+        return _PlanValidation(
+            status=ValidationStatus.FAILED,
+            validation_error=malformed_error,
+            parse_error=malformed_error,
         )
 
-    v_status = ValidationStatus.PASSED
-    v_error: str | None = None
-    schema_resolution = None
-
-    if validation_mode is not ValidationMode.OFF and artifact.schema_eligible:
-        if malformed_lines and validation_mode is ValidationMode.STRICT:
-            malformed_error = _format_malformed_jsonl_error(
-                malformed_lines=malformed_lines,
-                malformed_detail=malformed_detail,
-            )
-            return _finalize_result(
-                IngestRecordResult(
-                    raw_id=raw_record.raw_id,
-                    payload_provider=str(detected_provider),
-                    validation_status=ValidationStatus.FAILED.value,
-                    validation_error=malformed_error,
-                    parse_error=malformed_error,
-                    error=malformed_error,
-                ),
-                measure_serialized_size=measure_serialized_size,
-            )
-
-        schema_resolution = _runtime_schema_registry().resolve_payload(
-            detected_provider,
-            sample_payloads,
-            source_path=raw_record.source_path,
-        )
-
-        try:
-            validator = SchemaValidator.for_payload(
-                detected_provider,
-                sample_payloads,
-                source_path=raw_record.source_path,
-                schema_resolution=schema_resolution,
-            )
-        except (FileNotFoundError, ImportError):
-            validator = None
-            v_status = ValidationStatus.SKIPPED
-
-        if validator is not None:
-            validation_samples = validator.validation_samples(sample_payloads)
-            if validation_samples:
-                collected_errors: list[str] = []
-                for sample in validation_samples:
-                    sample_result = validator.validate(sample, include_drift=False)
-                    if not sample_result.is_valid:
-                        collected_errors.extend(sample_result.errors[:2])
-                if collected_errors and validation_mode is ValidationMode.STRICT:
-                    first_error = collected_errors[0]
-                    return _finalize_result(
-                        IngestRecordResult(
-                            raw_id=raw_record.raw_id,
-                            payload_provider=str(detected_provider),
-                            validation_status=ValidationStatus.FAILED.value,
-                            validation_error=f"Schema validation failed: {first_error}",
-                            error=f"Schema validation failed: {first_error}",
-                        ),
-                        measure_serialized_size=measure_serialized_size,
-                    )
-    elif validation_mode is ValidationMode.OFF:
-        v_status = ValidationStatus.SKIPPED
-
-    del sample_payloads
-    schema_resolution = None
+    schema_resolution = _resolve_schema_resolution(
+        plan.provider,
+        plan.schema_payload,
+        source_path=context.raw_record.source_path,
+    )
 
     try:
-        with raw_source.open("rb") as handle:
-            parsed_conversations = parse_stream_payload(
-                detected_provider,
-                _iter_json_stream(handle, stream_name),
-                _fallback_id(raw_record.source_path, raw_record.raw_id),
-            )
-    except Exception as exc:
-        return _finalize_result(
-            IngestRecordResult(
-                raw_id=raw_record.raw_id,
-                payload_provider=str(detected_provider),
-                validation_status=v_status.value,
-                parse_error=f"parse: {exc}",
-                error=f"parse: {exc}",
-            ),
-            measure_serialized_size=measure_serialized_size,
+        validator = SchemaValidator.for_payload(
+            plan.provider,
+            plan.schema_payload,
+            source_path=context.raw_record.source_path,
+            schema_resolution=schema_resolution,
+        )
+    except (FileNotFoundError, ImportError):
+        return _PlanValidation(
+            status=ValidationStatus.SKIPPED,
+            schema_resolution=schema_resolution,
         )
 
-    fallback_timestamp = raw_record.file_mtime
-    source_name = raw_record.source_name or raw_record.source_path or ""
+    validation_samples = validator.validation_samples(plan.schema_payload)
+    if validation_samples:
+        collected_errors: list[str] = []
+        for sample in validation_samples:
+            sample_result = validator.validate(sample, include_drift=False)
+            if not sample_result.is_valid:
+                collected_errors.extend(sample_result.errors[:2])
+        if collected_errors and context.validation_mode is ValidationMode.STRICT:
+            return _PlanValidation(
+                status=ValidationStatus.FAILED,
+                schema_resolution=schema_resolution,
+                validation_error=f"Schema validation failed: {collected_errors[0]}",
+            )
+
+    return _PlanValidation(
+        status=ValidationStatus.PASSED,
+        schema_resolution=schema_resolution,
+    )
+
+
+def _parse_plan_conversations(
+    context: _IngestContext,
+    plan: _ParsePlan,
+    *,
+    schema_resolution: SchemaResolution | None,
+) -> list[ParsedConversation]:
+    from polylogue.sources.dispatch import parse_payload, parse_stream_payload
+
+    resolved_schema = schema_resolution
+    if resolved_schema is None and plan.artifact.schema_eligible:
+        resolved_schema = _resolve_schema_resolution(
+            plan.provider,
+            plan.schema_payload,
+            source_path=context.raw_record.source_path,
+        )
+    fallback_id = _fallback_id(context.raw_record.source_path, context.raw_record.raw_id)
+    if plan.mode == "stream":
+        assert plan.stream_name is not None
+        with context.raw_source.open("rb") as handle:
+            return parse_stream_payload(
+                plan.provider,
+                _iter_json_stream(handle, plan.stream_name),
+                fallback_id,
+            )
+
+    return parse_payload(
+        plan.provider,
+        plan.payload,
+        fallback_id,
+        schema_resolution=resolved_schema,
+    )
+
+
+def _materialize_parsed_conversations(
+    context: _IngestContext,
+    plan: _ParsePlan,
+    *,
+    validation: _PlanValidation,
+    parsed_conversations: list[ParsedConversation],
+) -> IngestRecordResult:
     result_convos: list[ConversationData] = []
     for convo in parsed_conversations:
         normalized_convo = _normalized_conversation(
             convo,
-            fallback_timestamp=fallback_timestamp,
+            fallback_timestamp=context.fallback_timestamp,
         )
         try:
             cdata = _transform_to_tuples(
                 normalized_convo,
-                source_name=source_name,
-                archive_root=archive_root,
-                raw_id=raw_record.raw_id,
+                source_name=context.source_name,
+                archive_root=context.archive_root,
+                raw_id=context.raw_record.raw_id,
             )
             result_convos.append(cdata)
         except Exception as exc:
-            return _finalize_result(
-                IngestRecordResult(
-                    raw_id=raw_record.raw_id,
-                    payload_provider=str(detected_provider),
-                    validation_status=v_status.value,
-                    parse_error=f"transform: {exc}",
-                    error=f"transform: {exc}",
-                ),
-                measure_serialized_size=measure_serialized_size,
+            return _record_result(
+                context,
+                plan.payload_provider,
+                validation_status=validation.status,
+                parse_error=f"transform: {exc}",
+                error=f"transform: {exc}",
             )
 
-    return _finalize_result(
-        IngestRecordResult(
-            raw_id=raw_record.raw_id,
-            payload_provider=str(detected_provider),
-            validation_status=v_status.value,
-            validation_error=v_error,
-            conversations=result_convos,
-            source_name=source_name,
-        ),
-        measure_serialized_size=measure_serialized_size,
+    return _record_result(
+        context,
+        plan.payload_provider,
+        validation_status=validation.status,
+        validation_error=validation.validation_error,
+        conversations=result_convos,
+        include_source_name=True,
+    )
+
+
+def _run_parse_plan(
+    context: _IngestContext,
+    plan: _ParsePlan,
+) -> IngestRecordResult:
+    if not plan.artifact.parse_as_conversation:
+        return _record_result(
+            context,
+            plan.payload_provider,
+            validation_status=ValidationStatus.SKIPPED,
+        )
+
+    validation = _validate_parse_plan(context, plan)
+    if validation.validation_error is not None:
+        return _record_result(
+            context,
+            plan.payload_provider,
+            validation_status=validation.status,
+            validation_error=validation.validation_error,
+            parse_error=validation.parse_error,
+            error=validation.validation_error,
+        )
+
+    try:
+        parsed_conversations = _parse_plan_conversations(
+            context,
+            plan,
+            schema_resolution=validation.schema_resolution,
+        )
+    except Exception as exc:
+        return _record_result(
+            context,
+            plan.payload_provider,
+            validation_status=validation.status,
+            parse_error=f"parse: {exc}",
+            error=f"parse: {exc}",
+        )
+
+    return _materialize_parsed_conversations(
+        context,
+        plan,
+        validation=validation,
+        parsed_conversations=parsed_conversations,
     )
 
 
@@ -452,8 +595,6 @@ def ingest_record(
     """
     from polylogue.lib.raw_payload import build_raw_payload_envelope
     from polylogue.paths import blob_store_root
-    from polylogue.schemas.validator import SchemaValidator
-    from polylogue.sources.dispatch import parse_payload
 
     archive_root = Path(archive_root_str)
     validation_mode = ValidationMode.from_string(validation_mode_value)
@@ -465,191 +606,40 @@ def ingest_record(
     resolved_blob_root = Path(blob_root_str) if blob_root_str is not None else blob_store_root()
     blob_store = BlobStore(resolved_blob_root)
     raw_source = blob_store.blob_path(raw_record.raw_id)
+    context = _IngestContext(
+        raw_record=raw_record,
+        raw_source=raw_source,
+        archive_root=archive_root,
+        validation_mode=validation_mode,
+        measure_serialized_size=measure_serialized_size,
+        source_name=raw_record.source_name or raw_record.source_path or "",
+        fallback_timestamp=raw_record.file_mtime,
+    )
 
-    if _is_stream_record_provider(raw_record.source_path, stored_payload_provider or raw_record.provider_name):
-        streamed = _stream_grouped_jsonl_record(
-            raw_record,
-            raw_source=raw_source,
-            archive_root=archive_root,
-            payload_provider=stored_payload_provider,
-            validation_mode=validation_mode,
-            measure_serialized_size=measure_serialized_size,
-        )
-        if streamed is not None:
-            return streamed
+    if _is_stream_record_provider(raw_record.source_path, stored_payload_provider or raw_record.provider_name) and (
+        stream_plan := _build_stream_parse_plan(context, payload_provider=stored_payload_provider)
+    ):
+        return _run_parse_plan(context, stream_plan)
 
     # ── Phase 1: Decode blob (ONE decode, not two) ────────────────────
     try:
         envelope = build_raw_payload_envelope(
-            raw_source,
+            context.raw_source,
             source_path=raw_record.source_path,
             fallback_provider=raw_record.provider_name,
             payload_provider=stored_payload_provider,
         )
     except Exception as exc:
-        return _finalize_result(
-            IngestRecordResult(
-                raw_id=raw_record.raw_id,
-                payload_provider=stored_payload_provider,
-                validation_status=ValidationStatus.FAILED.value,
-                validation_error=f"decode: {exc}",
-                parse_error=f"decode: {exc}",
-                error=f"decode: {exc}",
-            ),
-            measure_serialized_size=measure_serialized_size,
+        return _record_result(
+            context,
+            stored_payload_provider,
+            validation_status=ValidationStatus.FAILED,
+            validation_error=f"decode: {exc}",
+            parse_error=f"decode: {exc}",
+            error=f"decode: {exc}",
         )
 
-    payload_provider = str(envelope.provider)
-
-    if not envelope.artifact.parse_as_conversation:
-        return _finalize_result(
-            IngestRecordResult(
-                raw_id=raw_record.raw_id,
-                payload_provider=payload_provider,
-                validation_status=ValidationStatus.SKIPPED.value,
-            ),
-            measure_serialized_size=measure_serialized_size,
-        )
-
-    # ── Phase 2: Validate schema (inline, reuses decoded payload) ─────
-    v_status = ValidationStatus.PASSED
-    v_error: str | None = None
-    schema_resolution = None
-
-    if validation_mode is not ValidationMode.OFF and envelope.artifact.schema_eligible:
-        malformed_lines = envelope.malformed_jsonl_lines
-        malformed_detail = envelope.malformed_jsonl_detail
-        if malformed_lines and validation_mode is ValidationMode.STRICT:
-            malformed_error = _format_malformed_jsonl_error(
-                malformed_lines=malformed_lines,
-                malformed_detail=malformed_detail,
-            )
-            return _finalize_result(
-                IngestRecordResult(
-                    raw_id=raw_record.raw_id,
-                    payload_provider=payload_provider,
-                    validation_status=ValidationStatus.FAILED.value,
-                    validation_error=malformed_error,
-                    parse_error=malformed_error,
-                    error=malformed_error,
-                ),
-                measure_serialized_size=measure_serialized_size,
-            )
-
-        schema_resolution = _runtime_schema_registry().resolve_payload(
-            envelope.provider,
-            envelope.payload,
-            source_path=raw_record.source_path,
-        )
-
-        try:
-            validator = SchemaValidator.for_payload(
-                envelope.provider,
-                envelope.payload,
-                source_path=raw_record.source_path,
-                schema_resolution=schema_resolution,
-            )
-        except (FileNotFoundError, ImportError):
-            validator = None
-            v_status = ValidationStatus.SKIPPED
-
-        if validator is not None:
-            samples = validator.validation_samples(envelope.payload)
-            if samples:
-                collected_errors: list[str] = []
-                for sample in samples:
-                    sample_result = validator.validate(sample, include_drift=False)
-                    if not sample_result.is_valid:
-                        collected_errors.extend(sample_result.errors[:2])
-
-                if collected_errors and validation_mode is ValidationMode.STRICT:
-                    first_error = collected_errors[0]
-                    return _finalize_result(
-                        IngestRecordResult(
-                            raw_id=raw_record.raw_id,
-                            payload_provider=payload_provider,
-                            validation_status=ValidationStatus.FAILED.value,
-                            validation_error=f"Schema validation failed: {first_error}",
-                            error=f"Schema validation failed: {first_error}",
-                        ),
-                        measure_serialized_size=measure_serialized_size,
-                    )
-    elif validation_mode is ValidationMode.OFF:
-        v_status = ValidationStatus.SKIPPED
-
-    # ── Phase 3: Parse (provider-specific conversation extraction) ─────
-    if schema_resolution is None and envelope.artifact.schema_eligible:
-        schema_resolution = _runtime_schema_registry().resolve_payload(
-            envelope.provider,
-            envelope.payload,
-            source_path=raw_record.source_path,
-        )
-
-    try:
-        parsed_conversations = parse_payload(
-            envelope.provider,
-            envelope.payload,
-            _fallback_id(raw_record.source_path, raw_record.raw_id),
-            schema_resolution=schema_resolution,
-        )
-    except Exception as exc:
-        return _finalize_result(
-            IngestRecordResult(
-                raw_id=raw_record.raw_id,
-                payload_provider=payload_provider,
-                validation_status=v_status.value,
-                parse_error=f"parse: {exc}",
-                error=f"parse: {exc}",
-            ),
-            measure_serialized_size=measure_serialized_size,
-        )
-
-    # The decoded payload can be much larger than the normalized conversation
-    # objects; drop it before tuple transformation to avoid overlapping heaps.
-    del envelope
-    schema_resolution = None
-
-    # Apply raw record defaults (timestamps) and transform immediately.
-    fallback_timestamp = raw_record.file_mtime
-    source_name = raw_record.source_name or raw_record.source_path or ""
-    result_convos: list[ConversationData] = []
-    for convo in parsed_conversations:
-        normalized_convo = _normalized_conversation(
-            convo,
-            fallback_timestamp=fallback_timestamp,
-        )
-        try:
-            cdata = _transform_to_tuples(
-                normalized_convo,
-                source_name=source_name,
-                archive_root=archive_root,
-                raw_id=raw_record.raw_id,
-            )
-            result_convos.append(cdata)
-        except Exception as exc:
-            return _finalize_result(
-                IngestRecordResult(
-                    raw_id=raw_record.raw_id,
-                    payload_provider=payload_provider,
-                    validation_status=v_status.value,
-                    parse_error=f"transform: {exc}",
-                    error=f"transform: {exc}",
-                ),
-                measure_serialized_size=measure_serialized_size,
-            )
-    del parsed_conversations
-
-    return _finalize_result(
-        IngestRecordResult(
-            raw_id=raw_record.raw_id,
-            payload_provider=payload_provider,
-            validation_status=v_status.value,
-            validation_error=v_error,
-            conversations=result_convos,
-            source_name=source_name,
-        ),
-        measure_serialized_size=measure_serialized_size,
-    )
+    return _run_parse_plan(context, _build_envelope_parse_plan(envelope))
 
 
 # ---------------------------------------------------------------------------

--- a/polylogue/sources/emitter.py
+++ b/polylogue/sources/emitter.py
@@ -8,7 +8,7 @@ from io import BytesIO
 from itertools import chain
 from typing import TYPE_CHECKING, BinaryIO
 
-from polylogue.lib.artifact_taxonomy import classify_artifact
+from polylogue.lib.artifact_taxonomy import ArtifactClassification, classify_artifact
 from polylogue.lib.json import dumps_bytes as json_dumps_bytes
 from polylogue.logging import get_logger
 from polylogue.types import Provider
@@ -38,6 +38,24 @@ class _SniffResult:
     provider: Provider
     payloads: Iterable[JsonValue]
     grouped_payloads: list[JsonValue] | None = None
+
+    @property
+    def is_grouped(self) -> bool:
+        return self.grouped_payloads is not None
+
+
+@dataclass(frozen=True, slots=True)
+class _PreparedJsonlState:
+    sniff_handle: BinaryIO
+    pre_read_bytes: bytes | None
+    stream_start: int | None
+
+
+@dataclass(frozen=True, slots=True)
+class _ResolvedPayload:
+    provider: Provider
+    artifact: ArtifactClassification
+    schema_resolution: SchemaResolution | None
 
 
 class _ConversationEmitter:
@@ -87,56 +105,11 @@ class _ConversationEmitter:
             return
 
         if is_jsonl:
-            stream_start = self._capture_stream_start(handle) if pre_read_bytes is None else None
-            if pre_read_bytes is None and stream_start is None and self._ctx.capture_raw and precomputed_raw is None:
-                sniff_bytes = handle.read()
-                sniffed = self._sniff_jsonl_payloads(
-                    BytesIO(sniff_bytes),
-                    stream_name,
-                )
-                if sniffed.provider in GROUP_PROVIDERS:
-                    yield from self._emit_grouped(
-                        BytesIO(sniff_bytes),
-                        stream_name,
-                        sniff_bytes,
-                        precomputed_raw=precomputed_raw,
-                        precomputed_payloads=sniffed.grouped_payloads,
-                    )
-                    return
-                yield from self._emit_individual_payloads(
-                    sniffed.payloads,
-                    stream_name=stream_name,
-                )
-                return
-
-            sniff_handle = BytesIO(pre_read_bytes) if pre_read_bytes is not None else handle
-            sniffed = self._sniff_jsonl_payloads(
-                sniff_handle,
+            yield from self._emit_jsonl(
+                handle,
                 stream_name,
-            )
-            if sniffed.provider in GROUP_PROVIDERS:
-                grouped_bytes = pre_read_bytes
-                grouped_handle = sniff_handle
-                if (
-                    grouped_bytes is None
-                    and self._ctx.capture_raw
-                    and precomputed_raw is None
-                    and stream_start is not None
-                ):
-                    self._restore_stream_start(handle, stream_start)
-                    grouped_bytes = handle.read()
-                    grouped_handle = BytesIO(grouped_bytes)
-                yield from self._emit_grouped(
-                    grouped_handle,
-                    stream_name,
-                    grouped_bytes,
-                    precomputed_raw=precomputed_raw,
-                    precomputed_payloads=sniffed.grouped_payloads,
-                )
-                return
-            yield from self._emit_individual_payloads(
-                sniffed.payloads,
-                stream_name=stream_name,
+                pre_read_bytes=pre_read_bytes,
+                precomputed_raw=precomputed_raw,
             )
             return
 
@@ -169,20 +142,14 @@ class _ConversationEmitter:
             return
 
         raw_data = precomputed_raw or (self._make_raw(raw_bytes) if raw_bytes else None)
-        provider = detect_provider(payloads) or self._ctx.provider_hint
-        artifact = classify_artifact(
-            payloads,
-            provider=provider,
-            source_path=self._ctx.source_path_str,
-        )
-        if not artifact.parse_as_conversation:
+        resolved = self._resolve_payload(payloads)
+        if not resolved.artifact.parse_as_conversation:
             return
-        schema_resolution = self._resolve_schema(provider, payloads)
         for conv in parse_payload(
-            provider,
+            resolved.provider,
             payloads,
             self._ctx.fallback_id,
-            schema_resolution=schema_resolution,
+            schema_resolution=resolved.schema_resolution,
         ):
             yield (raw_data, self._maybe_enrich(conv))
 
@@ -216,31 +183,29 @@ class _ConversationEmitter:
         source_index = 0
         for payload in payloads:
             try:
-                provider = detect_provider(payload) or self._ctx.provider_hint
-                artifact = classify_artifact(
-                    payload,
-                    provider=provider,
-                    source_path=self._ctx.source_path_str,
-                )
-                if not artifact.parse_as_conversation:
+                resolved = self._resolve_payload(payload)
+                if not resolved.artifact.parse_as_conversation:
                     continue
-                schema_resolution = self._resolve_schema(provider, payload)
 
                 if whole_file_raw is not None:
                     raw_data: RawConversationData | None = whole_file_raw
                 elif self._ctx.capture_raw:
                     raw_bytes = json_dumps_bytes(payload)
-                    raw_data = self._make_raw(raw_bytes, source_index=source_index, provider_override=provider)
+                    raw_data = self._make_raw(
+                        raw_bytes,
+                        source_index=source_index,
+                        provider_override=resolved.provider,
+                    )
                 else:
                     raw_data = None
 
                 for conv in parse_payload(
-                    provider,
+                    resolved.provider,
                     payload,
                     self._ctx.fallback_id,
-                    schema_resolution=schema_resolution,
+                    schema_resolution=resolved.schema_resolution,
                 ):
-                    yield (raw_data, self._maybe_enrich(conv, provider))
+                    yield (raw_data, self._maybe_enrich(conv, resolved.provider))
                 source_index += 1
             except Exception:
                 logger.exception("Error processing payload from %s", stream_name)
@@ -275,6 +240,103 @@ class _ConversationEmitter:
                 grouped_payloads=buffered_payloads,
             )
         return _SniffResult(provider=detected_provider, payloads=iter(buffered_payloads))
+
+    def _prepare_jsonl_state(
+        self,
+        handle: BinaryIO,
+        *,
+        pre_read_bytes: bytes | None,
+    ) -> _PreparedJsonlState:
+        if pre_read_bytes is not None:
+            return _PreparedJsonlState(
+                sniff_handle=BytesIO(pre_read_bytes),
+                pre_read_bytes=pre_read_bytes,
+                stream_start=None,
+            )
+        return _PreparedJsonlState(
+            sniff_handle=handle,
+            pre_read_bytes=None,
+            stream_start=self._capture_stream_start(handle),
+        )
+
+    def _non_seekable_jsonl_sniff(
+        self,
+        handle: BinaryIO,
+        stream_name: str,
+    ) -> tuple[bytes, _SniffResult]:
+        sniff_bytes = handle.read()
+        return sniff_bytes, self._sniff_jsonl_payloads(BytesIO(sniff_bytes), stream_name)
+
+    def _grouped_jsonl_source(
+        self,
+        handle: BinaryIO,
+        state: _PreparedJsonlState,
+        *,
+        precomputed_raw: RawConversationData | None,
+    ) -> tuple[BinaryIO, bytes | None]:
+        grouped_bytes = state.pre_read_bytes
+        grouped_handle: BinaryIO = state.sniff_handle
+        if (
+            grouped_bytes is None
+            and self._ctx.capture_raw
+            and precomputed_raw is None
+            and state.stream_start is not None
+        ):
+            self._restore_stream_start(handle, state.stream_start)
+            grouped_bytes = handle.read()
+            grouped_handle = BytesIO(grouped_bytes)
+        return grouped_handle, grouped_bytes
+
+    def _emit_jsonl(
+        self,
+        handle: BinaryIO,
+        stream_name: str,
+        *,
+        pre_read_bytes: bytes | None,
+        precomputed_raw: RawConversationData | None,
+    ) -> Iterable[tuple[RawConversationData | None, ParsedConversation]]:
+        state = self._prepare_jsonl_state(handle, pre_read_bytes=pre_read_bytes)
+        if (
+            state.pre_read_bytes is None
+            and state.stream_start is None
+            and self._ctx.capture_raw
+            and precomputed_raw is None
+        ):
+            sniff_bytes, sniffed = self._non_seekable_jsonl_sniff(handle, stream_name)
+            if sniffed.is_grouped:
+                yield from self._emit_grouped(
+                    BytesIO(sniff_bytes),
+                    stream_name,
+                    sniff_bytes,
+                    precomputed_raw=precomputed_raw,
+                    precomputed_payloads=sniffed.grouped_payloads,
+                )
+                return
+            yield from self._emit_individual_payloads(
+                sniffed.payloads,
+                stream_name=stream_name,
+            )
+            return
+
+        sniffed = self._sniff_jsonl_payloads(state.sniff_handle, stream_name)
+        if sniffed.is_grouped:
+            grouped_handle, grouped_bytes = self._grouped_jsonl_source(
+                handle,
+                state,
+                precomputed_raw=precomputed_raw,
+            )
+            yield from self._emit_grouped(
+                grouped_handle,
+                stream_name,
+                grouped_bytes,
+                precomputed_raw=precomputed_raw,
+                precomputed_payloads=sniffed.grouped_payloads,
+            )
+            return
+        yield from self._emit_individual_payloads(
+            sniffed.payloads,
+            stream_name=stream_name,
+        )
 
     def _capture_stream_start(self, handle: BinaryIO) -> int | None:
         seekable = getattr(handle, "seekable", None)
@@ -314,6 +376,19 @@ class _ConversationEmitter:
                 exc,
             )
             return None
+
+    def _resolve_payload(self, payload: JsonValue) -> _ResolvedPayload:
+        provider = detect_provider(payload) or self._ctx.provider_hint
+        artifact = classify_artifact(
+            payload,
+            provider=provider,
+            source_path=self._ctx.source_path_str,
+        )
+        return _ResolvedPayload(
+            provider=provider,
+            artifact=artifact,
+            schema_resolution=self._resolve_schema(provider, payload),
+        )
 
     def _make_raw(
         self,

--- a/polylogue/sources/parsers/codex.py
+++ b/polylogue/sources/parsers/codex.py
@@ -47,6 +47,46 @@ def _latest_timestamp(*values: str | None) -> str | None:
     return candidates[-1][1]
 
 
+def _validate_record(item: object, *, index: int, context: str = "record") -> CodexRecord | None:
+    if not isinstance(item, dict):
+        return None
+    try:
+        return CodexRecord.model_validate(item)
+    except ValidationError as exc:
+        logger.debug("Skipping invalid %s at index %d: %s", context, index, exc)
+        return None
+
+
+def _payload_record(record: CodexRecord, *, index: int, context: str) -> CodexRecord | None:
+    payload = record.payload
+    if not isinstance(payload, dict):
+        return None
+    return _validate_record(payload, index=index, context=context)
+
+
+def _session_meta_record(record: CodexRecord, *, index: int) -> CodexRecord | None:
+    if record.type == "session_meta":
+        return _payload_record(record, index=index, context="session_meta payload")
+    if record.id and record.timestamp and not record.type:
+        return record
+    return None
+
+
+def _message_record(record: CodexRecord, *, index: int) -> CodexRecord | None:
+    if record.format_type == "state":
+        return None
+    if record.type == "response_item":
+        inner = _payload_record(record, index=index, context="response_item payload")
+        return inner if inner is not None and inner.is_message else None
+    return record if record.is_message else None
+
+
+def _git_context(record: CodexRecord) -> dict[str, object] | None:
+    if record.git is None:
+        return None
+    return record.git.model_dump(exclude_none=True) or None
+
+
 def looks_like(payload: Sequence[object]) -> bool:
     """Detect Codex JSONL format using typed validation.
 
@@ -62,20 +102,14 @@ def looks_like(payload: Sequence[object]) -> bool:
     if not isinstance(payload, list):
         return False
 
-    for item in payload:
-        if not isinstance(item, dict):
+    for idx, item in enumerate(payload, start=1):
+        record = _validate_record(item, index=idx)
+        if record is None:
             continue
-
-        try:
-            record = CodexRecord.model_validate(item)
-            # Check for known Codex format indicators
-            if record.format_type in ("envelope", "direct", "state"):
-                return True
-            # Session metadata (first line of intermediate format)
-            if record.id and record.timestamp:
-                return True
-        except ValidationError:
-            continue
+        if record.format_type in ("envelope", "direct", "state"):
+            return True
+        if record.id and record.timestamp:
+            return True
 
     return False
 
@@ -104,13 +138,8 @@ def _parse_records(records: Iterable[object], fallback_id: str) -> ParsedConvers
     session_instructions: str | None = None  # System instructions from session metadata
 
     for idx, item in enumerate(records, start=1):
-        if not isinstance(item, dict):
-            continue
-
-        try:
-            record = CodexRecord.model_validate(item)
-        except ValidationError as exc:
-            logger.debug("Skipping invalid record at index %d: %s", idx, exc)
+        record = _validate_record(item, index=idx)
+        if record is None:
             continue
 
         # Handle compaction events (before message check so they don't fall through)
@@ -147,72 +176,33 @@ def _parse_records(records: Iterable[object], fallback_id: str) -> ParsedConvers
             )
             continue
 
-        # Handle session metadata (envelope format)
-        if record.type == "session_meta" and record.payload:
-            meta_id = record.payload.get("id")
+        session_meta = _session_meta_record(record, index=idx)
+        if session_meta is not None:
+            meta_id = session_meta.id
             if meta_id and meta_id not in session_metas_seen:
                 session_metas_seen.append(meta_id)
-                # First session_meta sets the conversation ID and captures session-level data
                 if len(session_metas_seen) == 1:
-                    session_id = str(meta_id)
-                    session_timestamp = _normalize_timestamp(record.payload.get("timestamp"))
-            # Capture git/instructions from envelope payload (may appear in inner record)
-            inner = CodexRecord.model_validate(record.payload) if isinstance(record.payload, dict) else None
-            if inner and inner.git and not session_git:
-                session_git = inner.git.model_dump(exclude_none=True) or None
-            if inner and inner.instructions and not session_instructions:
-                session_instructions = inner.instructions
+                    session_id = meta_id
+                    session_timestamp = _normalize_timestamp(session_meta.timestamp)
+            git_context = _git_context(session_meta)
+            if git_context and not session_git:
+                session_git = git_context
+            if session_meta.instructions and not session_instructions:
+                session_instructions = session_meta.instructions
             continue
 
-        # Handle session metadata (intermediate format - first line with id+timestamp)
-        if record.id and record.timestamp and not record.type:
-            if record.id not in session_metas_seen:
-                session_metas_seen.append(record.id)
-                if len(session_metas_seen) == 1:
-                    session_id = record.id
-                    session_timestamp = _normalize_timestamp(record.timestamp)
-            # Capture git/instructions from top-level record
-            if record.git and not session_git:
-                session_git = record.git.model_dump(exclude_none=True) or None
-            if record.instructions and not session_instructions:
-                session_instructions = record.instructions
-            continue
-
-        # Skip state markers
-        if record.format_type == "state":
-            continue
-
-        # Handle messages - either from envelope or direct format
-        if record.type == "response_item" and record.payload:
-            # Envelope format: unwrap payload and create new record for message
-            inner_payload = record.payload
-            if inner_payload.get("type") == "message":
-                try:
-                    record = CodexRecord.model_validate(inner_payload)
-                except ValidationError as exc:
-                    logger.debug("Skipping invalid envelope payload at index %d: %s", idx, exc)
-                    continue
-
-        # Parse message records using typed properties
-        if record.is_message:
-            raw_role = record.effective_role
-            text = record.text_content
-            timestamp = _normalize_timestamp(record.timestamp)
+        message_record = _message_record(record, index=idx)
+        if message_record is not None:
+            raw_role = message_record.effective_role
+            text = message_record.text_content
+            timestamp = _normalize_timestamp(message_record.timestamp)
 
             if not raw_role or raw_role == "unknown" or not text:
                 continue
             role = Role.normalize(raw_role)
 
-            # Get message ID from the record
-            msg_id = record.id or f"msg-{idx}"
-
-            # Build content blocks from the raw content field
-            raw_content = None
-            if record.content:
-                raw_content = record.content
-            elif record.payload and isinstance(record.payload, dict):
-                raw_content = record.payload.get("content")
-            content_blocks = content_blocks_from_segments(raw_content) if raw_content else []
+            msg_id = message_record.id or f"msg-{idx}"
+            content_blocks = content_blocks_from_segments(message_record.effective_content)
             if not content_blocks and text:
                 from .base import ParsedContentBlock
 

--- a/polylogue/sources/parsers/drive.py
+++ b/polylogue/sources/parsers/drive.py
@@ -50,6 +50,109 @@ def _attachment_from_doc(doc: JSONDocument | str, message_id: str | None) -> Par
     return _attachment_from_doc_impl(doc, message_id)
 
 
+def _gemini_content_block_payloads(message: GeminiMessage, text: str | None) -> list[JSONDocument]:
+    content_block_payloads = [
+        block_payload
+        for content_block in message.extract_content_blocks()
+        if (block_payload := _viewport_block_payload(content_block)) is not None
+    ]
+    if content_block_payloads:
+        return content_block_payloads
+    if not text:
+        return []
+    return [{"type": "thinking" if message.isThought else "text", "text": text}]
+
+
+def _typed_gemini_meta(chunk_obj: JSONDocument, message: GeminiMessage, text: str | None) -> dict[str, object]:
+    meta: dict[str, object] = {"raw": chunk_obj}
+
+    if message.isThought:
+        meta["isThought"] = True
+    if message.tokenCount is not None:
+        meta["tokenCount"] = message.tokenCount
+    if message.finishReason:
+        meta["finishReason"] = message.finishReason
+    if message.thinkingBudget is not None:
+        meta["thinkingBudget"] = message.thinkingBudget
+    if message.safetyRatings:
+        meta["safetyRatings"] = list(message.safetyRatings)
+    if message.grounding:
+        meta["grounding"] = (
+            message.grounding.model_dump() if hasattr(message.grounding, "model_dump") else message.grounding
+        )
+    if message.branchParent:
+        meta["branchParent"] = (
+            message.branchParent.model_dump() if hasattr(message.branchParent, "model_dump") else message.branchParent
+        )
+    if message.branchChildren:
+        meta["branchChildren"] = message.branchChildren
+    if message.executableCode:
+        meta["executableCode"] = message.executableCode
+    if message.codeExecutionResult:
+        meta["codeExecutionResult"] = message.codeExecutionResult
+    if message.errorMessage:
+        meta["errorMessage"] = message.errorMessage
+    if message.isEdited:
+        meta["isEdited"] = True
+
+    meta["content_blocks"] = _gemini_content_block_payloads(message, text)
+
+    reasoning_traces = message.extract_reasoning_traces()
+    if reasoning_traces:
+        meta["reasoning_traces"] = [
+            {"text": trace.text, "token_count": trace.token_count, "provider": trace.provider}
+            for trace in reasoning_traces
+        ]
+    return meta
+
+
+def _fallback_gemini_meta(chunk_obj: JSONDocument, text: str | None) -> dict[str, object]:
+    meta: dict[str, object] = {"raw": chunk_obj}
+    if chunk_obj.get("isThought"):
+        meta["isThought"] = True
+    token_count = chunk_obj.get("tokenCount")
+    if token_count:
+        meta["tokenCount"] = token_count
+
+    fallback_content_blocks: list[JSONDocument] = []
+    if text:
+        block_type = "thinking" if chunk_obj.get("isThought") else "text"
+        fallback_content_blocks.append({"type": block_type, "text": text})
+
+    exec_code = chunk_obj.get("executableCode")
+    if isinstance(exec_code, dict) and exec_code:
+        meta["executableCode"] = exec_code
+        code = exec_code.get("code")
+        if isinstance(code, str) and code:
+            fallback_content_blocks.append({"type": "code", "text": code})
+
+    exec_result = chunk_obj.get("codeExecutionResult")
+    if isinstance(exec_result, dict) and exec_result:
+        meta["codeExecutionResult"] = exec_result
+        output = exec_result.get("output")
+        outcome = exec_result.get("outcome")
+        if isinstance(output, str) and output:
+            fallback_content_blocks.append({"type": "tool_result", "text": output})
+        elif isinstance(outcome, str) and outcome:
+            fallback_content_blocks.append({"type": "tool_result", "text": f"[{outcome}]"})
+
+    error_msg = chunk_obj.get("errorMessage")
+    if isinstance(error_msg, str) and error_msg:
+        meta["errorMessage"] = error_msg
+
+    meta["content_blocks"] = fallback_content_blocks
+    return meta
+
+
+def _append_attachment_blocks(meta: dict[str, object], chunk_attachments: list[ParsedAttachment]) -> None:
+    meta_blocks = meta.get("content_blocks")
+    attachment_blocks = _attachment_block_payloads(chunk_attachments)
+    if isinstance(meta_blocks, list):
+        meta_blocks.extend(attachment_blocks)
+        return
+    meta["content_blocks"] = attachment_blocks
+
+
 def parse_chunked_prompt(provider: Provider | str, payload: JSONDocument, fallback_id: str) -> ParsedConversation:
     runtime_provider = Provider.from_string(provider)
     prompt = json_document(payload.get("chunkedPrompt"))
@@ -88,98 +191,16 @@ def parse_chunked_prompt(provider: Provider | str, payload: JSONDocument, fallba
         observed_timestamps.append(message_timestamp)
         used_typed_model = False
 
-        # Try to parse via the rich GeminiMessage typed model for structured extraction
-        meta: dict[str, object] = {"raw": chunk_obj}
+        # Try to parse via the rich GeminiMessage typed model for structured extraction.
         try:
-            gem = GeminiMessage.model_validate(chunk_obj)
+            gemini_message = GeminiMessage.model_validate(chunk_obj)
             used_typed_model = True
-            # Extract rich metadata from the typed model
-            if gem.isThought:
-                meta["isThought"] = True
-            if gem.tokenCount is not None:
-                meta["tokenCount"] = gem.tokenCount
-            if gem.finishReason:
-                meta["finishReason"] = gem.finishReason
-            if gem.thinkingBudget is not None:
-                meta["thinkingBudget"] = gem.thinkingBudget
-            if gem.safetyRatings:
-                meta["safetyRatings"] = list(gem.safetyRatings)
-            if gem.grounding:
-                meta["grounding"] = (
-                    gem.grounding.model_dump() if hasattr(gem.grounding, "model_dump") else gem.grounding
-                )
-            if gem.branchParent:
-                meta["branchParent"] = (
-                    gem.branchParent.model_dump() if hasattr(gem.branchParent, "model_dump") else gem.branchParent
-                )
-            if gem.branchChildren:
-                meta["branchChildren"] = gem.branchChildren
-            if gem.executableCode:
-                meta["executableCode"] = gem.executableCode
-            if gem.codeExecutionResult:
-                meta["codeExecutionResult"] = gem.codeExecutionResult
-            if gem.errorMessage:
-                meta["errorMessage"] = gem.errorMessage
-            if gem.isEdited:
-                meta["isEdited"] = True
-
-            # Extract structured content blocks via the typed model
-            content_block_payloads: list[JSONDocument] = [
-                block_payload
-                for cb in gem.extract_content_blocks()
-                if (block_payload := _viewport_block_payload(cb)) is not None
-            ]
-            if not content_block_payloads:
-                # Fallback: basic block from text
-                content_block_payloads = (
-                    [{"type": "thinking" if gem.isThought else "text", "text": text}] if text else []
-                )
-            meta["content_blocks"] = content_block_payloads
-
-            # Extract reasoning traces if present
-            traces = gem.extract_reasoning_traces()
-            if traces:
-                meta["reasoning_traces"] = [
-                    {"text": t.text, "token_count": t.token_count, "provider": t.provider} for t in traces
-                ]
+            meta = _typed_gemini_meta(chunk_obj, gemini_message, text)
         except (ValidationError, Exception):
-            # Fallback: basic extraction for non-conforming chunks
-            if chunk_obj.get("isThought"):
-                meta["isThought"] = True
-            token_count = chunk_obj.get("tokenCount")
-            if token_count:
-                meta["tokenCount"] = token_count
-            fallback_content_blocks: list[JSONDocument] = []
-            if text:
-                block_type = "thinking" if chunk_obj.get("isThought") else "text"
-                fallback_content_blocks.append({"type": block_type, "text": text})
-            exec_code = chunk_obj.get("executableCode")
-            if isinstance(exec_code, dict) and exec_code:
-                meta["executableCode"] = exec_code
-                code = exec_code.get("code")
-                if isinstance(code, str) and code:
-                    fallback_content_blocks.append({"type": "code", "text": code})
-            exec_result = chunk_obj.get("codeExecutionResult")
-            if isinstance(exec_result, dict) and exec_result:
-                meta["codeExecutionResult"] = exec_result
-                output = exec_result.get("output")
-                outcome = exec_result.get("outcome")
-                if isinstance(output, str) and output:
-                    fallback_content_blocks.append({"type": "tool_result", "text": output})
-                elif isinstance(outcome, str) and outcome:
-                    fallback_content_blocks.append({"type": "tool_result", "text": f"[{outcome}]"})
-            error_msg = chunk_obj.get("errorMessage")
-            if isinstance(error_msg, str) and error_msg:
-                meta["errorMessage"] = error_msg
-            meta["content_blocks"] = fallback_content_blocks
+            meta = _fallback_gemini_meta(chunk_obj, text)
 
         if chunk_attachments and not used_typed_model:
-            meta_blocks = meta.get("content_blocks")
-            attachment_blocks = _attachment_block_payloads(chunk_attachments)
-            if isinstance(meta_blocks, list):
-                meta_blocks.extend(attachment_blocks)
-            else:
-                meta["content_blocks"] = attachment_blocks
+            _append_attachment_blocks(meta, chunk_attachments)
 
         if not text and not chunk_attachments and not meta.get("content_blocks"):
             continue

--- a/polylogue/sources/providers/claude_code_models.py
+++ b/polylogue/sources/providers/claude_code_models.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
-from typing import Any, Literal
+from typing import Literal, TypeAlias
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from polylogue.lib.json import json_document
 from polylogue.lib.viewports import ReasoningTrace, TokenUsage, ToolCall, classify_tool
 from polylogue.types import Provider
+
+ClaudeCodeContentBlockRecord: TypeAlias = dict[str, object]
+ClaudeCodeContentBlocks: TypeAlias = list[ClaudeCodeContentBlockRecord]
 
 
 class ClaudeCodeToolUse(BaseModel):
@@ -18,14 +22,14 @@ class ClaudeCodeToolUse(BaseModel):
     type: Literal["tool_use"] = "tool_use"
     id: str
     name: str
-    input: dict[str, Any] = Field(default_factory=dict)
+    input: ClaudeCodeContentBlockRecord = Field(default_factory=dict)
 
     def to_tool_call(self) -> ToolCall:
         return ToolCall(
             name=self.name,
             id=self.id,
             input=self.input,
-            category=classify_tool(self.name, self.input),
+            category=classify_tool(self.name, json_document(self.input)),
             provider=Provider.CLAUDE_CODE,
             raw=self.model_dump(),
         )
@@ -38,7 +42,7 @@ class ClaudeCodeToolResult(BaseModel):
 
     type: Literal["tool_result"] = "tool_result"
     tool_use_id: str
-    content: str | list[Any] = ""
+    content: str | list[object] = ""
     is_error: bool = False
 
 
@@ -95,7 +99,7 @@ class ClaudeCodeMessageContent(BaseModel):
     type: str = "message"
     role: str
     model: str | None = None
-    content: list[dict[str, Any]] = Field(default_factory=list)
+    content: ClaudeCodeContentBlocks = Field(default_factory=list)
     stop_reason: str | None = None
     stop_sequence: str | None = None
     usage: ClaudeCodeUsage | None = None
@@ -107,4 +111,4 @@ class ClaudeCodeUserMessage(BaseModel):
     model_config = ConfigDict(extra="allow")
 
     role: Literal["user"] = "user"
-    content: str | list[dict[str, Any]] = ""
+    content: str | ClaudeCodeContentBlocks = ""

--- a/polylogue/sources/providers/claude_code_record.py
+++ b/polylogue/sources/providers/claude_code_record.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any
+from typing import TypeAlias
 
 from pydantic import BaseModel, ConfigDict
 
+from polylogue.lib.json import JSONDocument, JSONDocumentList, json_document, json_document_list
 from polylogue.lib.provider_semantics import (
     extract_claude_code_text,
     extract_content_blocks,
@@ -25,7 +26,50 @@ from polylogue.lib.viewports import (
 )
 from polylogue.types import Provider
 
-from .claude_code_models import ClaudeCodeMessageContent, ClaudeCodeUserMessage
+from .claude_code_models import ClaudeCodeMessageContent, ClaudeCodeUsage, ClaudeCodeUserMessage
+
+ClaudeCodeMessagePayload: TypeAlias = ClaudeCodeMessageContent | ClaudeCodeUserMessage | dict[str, object] | None
+
+
+def _usage_int(record: JSONDocument, key: str) -> int | None:
+    value = record.get(key)
+    return value if isinstance(value, int) else None
+
+
+def _message_record(message: ClaudeCodeMessagePayload) -> JSONDocument:
+    if isinstance(message, BaseModel):
+        return json_document(message.model_dump())
+    return json_document(message)
+
+
+def _message_role(message: ClaudeCodeMessagePayload) -> str | None:
+    role = _message_record(message).get("role")
+    return role if isinstance(role, str) else None
+
+
+def _message_content_value(message: ClaudeCodeMessagePayload) -> object:
+    if isinstance(message, BaseModel):
+        return getattr(message, "content", None)
+    return _message_record(message).get("content")
+
+
+def _message_content_blocks(message: ClaudeCodeMessagePayload) -> JSONDocumentList:
+    return json_document_list(_message_content_value(message))
+
+
+def _message_usage(message: ClaudeCodeMessagePayload) -> ClaudeCodeUsage | JSONDocument | None:
+    if isinstance(message, ClaudeCodeMessageContent):
+        return message.usage
+    if isinstance(message, BaseModel):
+        usage = _message_record(message).get("usage")
+        return usage if isinstance(usage, dict) else None
+    usage = _message_record(message).get("usage")
+    return usage if isinstance(usage, dict) else None
+
+
+def _message_model(message: ClaudeCodeMessagePayload) -> str | None:
+    value = _message_record(message).get("model")
+    return value if isinstance(value, str) else None
 
 
 class ClaudeCodeRecord(BaseModel):
@@ -39,7 +83,7 @@ class ClaudeCodeRecord(BaseModel):
     parentUuid: str | None = None
     timestamp: str | int | float | None = None
     sessionId: str | None = None
-    message: ClaudeCodeMessageContent | ClaudeCodeUserMessage | dict[str, Any] | None = None
+    message: ClaudeCodeMessagePayload = None
     cwd: str | None = None
     gitBranch: str | None = None
     version: str | None = None
@@ -58,11 +102,7 @@ class ClaudeCodeRecord(BaseModel):
 
     @property
     def role(self) -> str:
-        message_role = None
-        if isinstance(self.message, dict):
-            message_role = self.message.get("role")
-        elif self.message is not None:
-            message_role = getattr(self.message, "role", None)
+        message_role = _message_role(self.message)
         if isinstance(message_role, str) and message_role:
             try:
                 normalized_role = normalize_role(message_role)
@@ -92,32 +132,18 @@ class ClaudeCodeRecord(BaseModel):
             top_content = getattr(self, "content", None)
             return top_content if isinstance(top_content, str) else ""
 
-        msg = self.message
-        content = msg.get("content", "") if isinstance(msg, dict) else getattr(msg, "content", None)
+        content = _message_content_value(self.message)
 
         if isinstance(content, str):
             return content
-        if isinstance(content, list):
-            return extract_claude_code_text(content)
+        blocks = json_document_list(content)
+        if blocks:
+            return extract_claude_code_text(blocks)
         return ""
 
     @property
-    def content_blocks_raw(self) -> list[dict[str, Any]]:
-        if not self.message:
-            return []
-
-        if isinstance(self.message, dict):
-            content = self.message.get("content", [])
-            if isinstance(content, list):
-                return content
-            return []
-
-        if hasattr(self.message, "content"):
-            content = self.message.content
-            if isinstance(content, list):
-                return content
-
-        return []
+    def content_blocks_raw(self) -> JSONDocumentList:
+        return _message_content_blocks(self.message)
 
     def extract_reasoning_traces(self) -> list[ReasoningTrace]:
         return extract_reasoning_traces(self.content_blocks_raw, "claude-code")
@@ -130,27 +156,22 @@ class ClaudeCodeRecord(BaseModel):
 
     def to_meta(self) -> MessageMeta:
         tokens = None
-        if isinstance(self.message, ClaudeCodeMessageContent) and self.message.usage:
-            tokens = self.message.usage.to_token_usage()
-        elif isinstance(self.message, dict):
-            usage_raw = self.message.get("usage", {})
-            if usage_raw:
-                tokens = TokenUsage(
-                    input_tokens=usage_raw.get("input_tokens"),
-                    output_tokens=usage_raw.get("output_tokens"),
-                    cache_read_tokens=usage_raw.get("cache_read_input_tokens"),
-                    cache_write_tokens=usage_raw.get("cache_creation_input_tokens"),
-                )
+        usage = _message_usage(self.message)
+        if isinstance(usage, ClaudeCodeUsage):
+            tokens = usage.to_token_usage()
+        elif isinstance(usage, dict):
+            tokens = TokenUsage(
+                input_tokens=_usage_int(usage, "input_tokens"),
+                output_tokens=_usage_int(usage, "output_tokens"),
+                cache_read_tokens=_usage_int(usage, "cache_read_input_tokens"),
+                cache_write_tokens=_usage_int(usage, "cache_creation_input_tokens"),
+            )
 
         cost = None
         if self.costUSD is not None:
             cost = CostInfo(total_usd=self.costUSD)
 
-        model = None
-        if isinstance(self.message, ClaudeCodeMessageContent):
-            model = self.message.model
-        elif isinstance(self.message, dict):
-            model = self.message.get("model")
+        model = _message_model(self.message)
 
         return MessageMeta(
             id=self.uuid,

--- a/polylogue/sources/providers/codex.py
+++ b/polylogue/sources/providers/codex.py
@@ -12,10 +12,11 @@ Codex sessions can have multiple format generations:
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, Literal
+from typing import Literal
 
 from pydantic import BaseModel, ConfigDict
 
+from polylogue.lib.json import JSONDocument, JSONDocumentList, json_document, json_document_list
 from polylogue.lib.provider_semantics import extract_codex_text
 from polylogue.lib.roles import Role, normalize_role
 from polylogue.lib.timestamps import parse_timestamp
@@ -51,6 +52,22 @@ class CodexGitInfo(BaseModel):
     repository_url: str | None = None
 
 
+CodexPayloadRecord = dict[str, object]
+
+
+def _content_text(record: JSONDocument) -> str | None:
+    for key in ("text", "input_text", "output_text", "code"):
+        value = record.get(key)
+        if isinstance(value, str):
+            return value
+    return None
+
+
+def _content_language(record: JSONDocument) -> str | None:
+    value = record.get("language")
+    return value if isinstance(value, str) else None
+
+
 class CodexRecord(BaseModel):
     """A single record from a Codex JSONL session.
 
@@ -66,7 +83,7 @@ class CodexRecord(BaseModel):
     type: str | None = None
     """Record type: session_meta, response_item, message, etc."""
 
-    payload: dict[str, Any] | None = None
+    payload: CodexPayloadRecord | None = None
     """Payload for envelope format."""
 
     # Direct format fields
@@ -76,7 +93,7 @@ class CodexRecord(BaseModel):
     role: str | None = None
     """Role for direct message format."""
 
-    content: list[CodexContentBlock | dict[str, Any]] | None = None
+    content: list[CodexContentBlock | CodexPayloadRecord] | None = None
     """Content blocks for direct message format."""
 
     # Session metadata
@@ -152,7 +169,8 @@ class CodexRecord(BaseModel):
     def effective_role(self) -> str:
         """Get normalized role from any format."""
         if self.format_type == "envelope" and self.payload:
-            return str(self.payload.get("role", "unknown"))
+            value = self.payload.get("role")
+            return value if isinstance(value, str) else "unknown"
         if self.role:
             return self.role
         return "unknown"
@@ -166,15 +184,19 @@ class CodexRecord(BaseModel):
             return "unknown"
 
     @property
-    def effective_content(self) -> list[dict[str, Any]]:
+    def effective_content(self) -> JSONDocumentList:
         """Get content blocks from any format."""
         if self.format_type == "envelope" and self.payload:
-            content = self.payload.get("content", [])
-            if isinstance(content, list):
-                return content
-            return []
+            return json_document_list(self.payload.get("content"))
         if self.content:
-            return [c.model_dump() if isinstance(c, CodexContentBlock) else c for c in self.content]
+            records: JSONDocumentList = []
+            for item in self.content:
+                record = (
+                    json_document(item.model_dump()) if isinstance(item, CodexContentBlock) else json_document(item)
+                )
+                if record:
+                    records.append(record)
+            return records
         return []
 
     @property
@@ -210,16 +232,14 @@ class CodexRecord(BaseModel):
         """Extract harmonized content blocks."""
         blocks = []
         for raw in self.effective_content:
-            if not isinstance(raw, dict):
-                continue
-
-            block_type = raw.get("type", "")
+            block_type_value = raw.get("type")
+            block_type = block_type_value if isinstance(block_type_value, str) else ""
 
             if block_type in ("input_text", "output_text", "text"):
                 blocks.append(
                     ContentBlock(
                         type=ContentType.TEXT,
-                        text=raw.get("text") or raw.get("input_text") or raw.get("output_text"),
+                        text=_content_text(raw),
                         raw=raw,
                     )
                 )
@@ -227,8 +247,8 @@ class CodexRecord(BaseModel):
                 blocks.append(
                     ContentBlock(
                         type=ContentType.CODE,
-                        text=raw.get("text") or raw.get("code"),
-                        language=raw.get("language"),
+                        text=_content_text(raw),
+                        language=_content_language(raw),
                         raw=raw,
                     )
                 )
@@ -236,7 +256,7 @@ class CodexRecord(BaseModel):
                 blocks.append(
                     ContentBlock(
                         type=ContentType.UNKNOWN,
-                        text=raw.get("text"),
+                        text=_content_text(raw),
                         raw=raw,
                     )
                 )

--- a/polylogue/sources/providers/gemini_message.py
+++ b/polylogue/sources/providers/gemini_message.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import TypeAlias
+from typing import TypeAlias, cast
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from polylogue.lib.json import json_document
 from polylogue.lib.roles import Role
 from polylogue.lib.timestamps import parse_timestamp
 from polylogue.lib.viewports import (
@@ -29,7 +30,7 @@ GeminiBranchChildren: TypeAlias = list[GeminiDictValue]
 
 def _normalize_mapping(payload: BaseModel | GeminiDictValue) -> GeminiDictValue:
     if isinstance(payload, BaseModel):
-        return payload.model_dump()
+        return cast(GeminiDictValue, json_document(payload.model_dump()))
     return payload
 
 
@@ -58,7 +59,21 @@ def _get_str_or_none(value: object) -> str | None:
 
 
 def _string_or_empty_dict(value: object) -> GeminiDictValue:
-    return value if isinstance(value, dict) else {}
+    return cast(GeminiDictValue, json_document(value))
+
+
+def _part_record(part: GeminiPartValue) -> GeminiDictValue:
+    if isinstance(part, GeminiPart):
+        return cast(GeminiDictValue, json_document(part.model_dump()))
+    return part
+
+
+def _drive_document_record(value: GeminiDictValue | str | None) -> GeminiDictValue | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return {"id": value}
+    return value
 
 
 class GeminiMessage(BaseModel):
@@ -169,7 +184,7 @@ class GeminiMessage(BaseModel):
             )
 
         for part in self.parts:
-            raw_part = _normalize_mapping(part) if not isinstance(part, GeminiPart) else part.model_dump()
+            raw_part = _part_record(part)
             part_text = _part_text(part)
             if part_text:
                 blocks.append(
@@ -217,13 +232,14 @@ class GeminiMessage(BaseModel):
                 )
 
         if self.driveDocument:
-            raw_doc = self.driveDocument if isinstance(self.driveDocument, dict) else {"id": self.driveDocument}
-            blocks.append(
-                ContentBlock(
-                    type=ContentType.FILE,
-                    raw={"driveDocument": raw_doc},
+            raw_doc = _drive_document_record(self.driveDocument)
+            if raw_doc is not None:
+                blocks.append(
+                    ContentBlock(
+                        type=ContentType.FILE,
+                        raw={"driveDocument": raw_doc},
+                    )
                 )
-            )
 
         if self.inlineFile:
             mime_type = _get_str_or_none(self.inlineFile.get("mimeType"))


### PR DESCRIPTION
## Summary
- tighten provider-facing message adapters for Claude Code, Codex, and Gemini payloads
- unify ingest parsing around explicit parse-plan helpers instead of duplicated stream/envelope control flow
- normalize JSONL emission and provider-specific parser follow-through over the renewed ingestion contracts

## Problem
The remaining source/provider seam was still carrying path-dependent payload branching across three adjacent layers:
- provider message adapters mixed open dict plumbing with ad hoc normalization
- `ingest_worker` duplicated grouped-stream versus envelope parsing control flow
- the JSONL emitter and Codex/Drive parsers repeated provider detection and metadata shaping in slightly different forms

That code was strict-mypy-cleanable, but it still hid runtime meaning behind loosely shaped containers and repeated branches.

## Solution
- rebuild the provider message adapters in `polylogue/sources/providers/claude_code_models.py`, `polylogue/sources/providers/claude_code_record.py`, `polylogue/sources/providers/codex.py`, and `polylogue/sources/providers/gemini_message.py` around explicit helper aliases and normalization helpers
- refactor `polylogue/pipeline/services/ingest_worker.py` to use typed parse-plan/context records so grouped stream parsing and envelope parsing share one orchestration path
- restructure `polylogue/sources/emitter.py` so grouped JSONL, individual payload, and raw-capture handling all flow through one resolved payload path
- carry the contract shape through `polylogue/sources/parsers/codex.py` and `polylogue/sources/parsers/drive.py`

Ref #262

## Verification
- `ruff check polylogue/sources/providers/claude_code_models.py polylogue/sources/providers/claude_code_record.py polylogue/sources/providers/codex.py polylogue/sources/providers/gemini_message.py`
- `mypy polylogue/sources/providers/claude_code_models.py polylogue/sources/providers/claude_code_record.py polylogue/sources/providers/codex.py polylogue/sources/providers/gemini_message.py`
- `pytest -q tests/unit/sources/test_models.py -k 'Gemini or ClaudeCode or Codex'`
- `ruff check polylogue/sources/parsers/codex.py polylogue/sources/parsers/drive.py polylogue/sources/emitter.py polylogue/pipeline/services/ingest_worker.py`
- `mypy polylogue/sources/parsers/codex.py polylogue/sources/parsers/drive.py polylogue/sources/emitter.py polylogue/pipeline/services/ingest_worker.py`
- `pytest -q tests/unit/pipeline/test_quarantine_fixtures.py tests/unit/pipeline/test_resilience.py tests/unit/pipeline/test_ingest_batch.py -k 'ingest_record or malformed_jsonl or zero_length_blob or schema_resolution or streams_codex_jsonl or iter_ingest_results_sync'`
- `pytest -q tests/unit/sources/test_models.py tests/unit/sources/test_source_laws.py tests/unit/pipeline/test_quarantine_fixtures.py tests/unit/pipeline/test_resilience.py tests/unit/pipeline/test_ingest_batch.py -k 'Gemini or ClaudeCode or Codex or conversation_emitter or ingest_record or malformed_jsonl or zero_length_blob or schema_resolution or streams_codex_jsonl or iter_ingest_results_sync'`
- `devtools verify`
