### PR TITLE
refactor: reduce weak payload plumbing across lib and storage runtime

### DIFF
--- a/polylogue/archive_product_models.py
+++ b/polylogue/archive_product_models.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from polylogue.lib.session_payload_documents import SessionPhaseDocument, WorkEventDocument
+
 ARCHIVE_PRODUCT_CONTRACT_VERSION = 4
 
 
@@ -75,8 +77,8 @@ class SessionInferencePayload(ArchiveProductModel):
     engaged_duration_source: str = "session_total_fallback"
     repo_inference_strength: str = "weak"
     auto_tags: tuple[str, ...] = ()
-    work_events: tuple[dict[str, object], ...] = ()
-    phases: tuple[dict[str, object], ...] = ()
+    work_events: tuple[WorkEventDocument, ...] = ()
+    phases: tuple[SessionPhaseDocument, ...] = ()
 
 
 class WorkEventEvidencePayload(ArchiveProductModel):

--- a/polylogue/lib/query_retrieval_candidates.py
+++ b/polylogue/lib/query_retrieval_candidates.py
@@ -2,9 +2,7 @@
 
 from __future__ import annotations
 
-import inspect
-from collections.abc import Awaitable
-from typing import TYPE_CHECKING, Literal, TypeVar, cast, overload
+from typing import TYPE_CHECKING, Literal, overload
 
 from polylogue.lib.query_support import provider_values
 
@@ -12,16 +10,8 @@ if TYPE_CHECKING:
     from polylogue.lib.models import Conversation, ConversationSummary
     from polylogue.lib.query_plan import ConversationQueryPlan
     from polylogue.protocols import ConversationQueryRuntimeStore
+    from polylogue.storage.action_event_artifacts import ActionEventArtifactState
     from polylogue.storage.query_models import ConversationRecordQuery
-
-
-_T = TypeVar("_T")
-
-
-async def _resolve_maybe_awaitable(value: _T | object) -> _T:
-    if inspect.isawaitable(value):
-        return await cast(Awaitable[_T], value)
-    return cast(_T, value)
 
 
 def candidate_record_query(plan: ConversationQueryPlan) -> tuple[ConversationRecordQuery, bool]:
@@ -50,26 +40,29 @@ def uses_action_read_model(plan: ConversationQueryPlan) -> bool:
     )
 
 
+async def _action_event_state(
+    plan: ConversationQueryPlan,
+    repository: ConversationQueryRuntimeStore,
+) -> ActionEventArtifactState | None:
+    if not uses_action_read_model(plan):
+        return None
+    return await repository.get_action_event_artifact_state()
+
+
 async def action_event_rows_ready(
     plan: ConversationQueryPlan,
     repository: ConversationQueryRuntimeStore,
 ) -> bool:
-    if not uses_action_read_model(plan):
-        return True
-    state: object = await _resolve_maybe_awaitable(repository.get_action_event_artifact_state())
-    rows_ready = getattr(state, "rows_ready", False)
-    return rows_ready if isinstance(rows_ready, bool) else False
+    state = await _action_event_state(plan, repository)
+    return True if state is None else state.rows_ready
 
 
 async def action_search_ready(
     plan: ConversationQueryPlan,
     repository: ConversationQueryRuntimeStore,
 ) -> bool:
-    if not uses_action_read_model(plan):
-        return True
-    state: object = await _resolve_maybe_awaitable(repository.get_action_event_artifact_state())
-    ready = getattr(state, "ready", False)
-    return ready if isinstance(ready, bool) else False
+    state = await _action_event_state(plan, repository)
+    return True if state is None else state.ready
 
 
 async def can_use_action_event_stats_with(

--- a/polylogue/lib/session_payload_documents.py
+++ b/polylogue/lib/session_payload_documents.py
@@ -1,0 +1,96 @@
+"""Shared typed document payloads for session-derived runtime surfaces."""
+
+from __future__ import annotations
+
+from typing_extensions import TypedDict
+
+
+class WorkEventDocument(TypedDict):
+    kind: str
+    start_index: int
+    end_index: int
+    start_time: str | None
+    end_time: str | None
+    canonical_session_date: str | None
+    duration_ms: int
+    confidence: float
+    evidence: list[str]
+    file_paths: list[str]
+    tools_used: list[str]
+    summary: str
+
+
+class SessionPhaseDocument(TypedDict):
+    start_time: str | None
+    end_time: str | None
+    canonical_session_date: str | None
+    message_range: list[int]
+    duration_ms: int
+    tool_counts: dict[str, int]
+    word_count: int
+    confidence: float
+    evidence: list[str]
+
+
+class SessionProfileDocument(TypedDict):
+    conversation_id: str
+    provider: str
+    title: str | None
+    created_at: str | None
+    updated_at: str | None
+    message_count: int
+    substantive_count: int
+    tool_use_count: int
+    thinking_count: int
+    attachment_count: int
+    word_count: int
+    total_cost_usd: float
+    total_duration_ms: int
+    tool_categories: dict[str, int]
+    repo_paths: list[str]
+    cwd_paths: list[str]
+    branch_names: list[str]
+    file_paths_touched: list[str]
+    languages_detected: list[str]
+    repo_names: list[str]
+    work_events: list[WorkEventDocument]
+    phases: list[SessionPhaseDocument]
+    first_message_at: str | None
+    last_message_at: str | None
+    canonical_session_date: str | None
+    engaged_duration_ms: int
+    engaged_minutes: float
+    wall_duration_ms: int
+    cost_is_estimated: bool
+    compaction_count: int
+    thread_id: str | None
+    continuation_depth: int
+    tags: list[str]
+    auto_tags: list[str]
+    is_continuation: bool
+    parent_id: str | None
+
+
+class WorkThreadDocument(TypedDict):
+    thread_id: str
+    root_id: str
+    session_ids: list[str]
+    session_count: int
+    depth: int
+    branch_count: int
+    start_time: str | None
+    end_time: str | None
+    wall_duration_ms: int
+    total_messages: int
+    total_cost_usd: float
+    dominant_repo: str | None
+    provider_breakdown: dict[str, int]
+    work_event_breakdown: dict[str, int]
+
+
+__all__ = [
+    "SessionPhaseDocument",
+    "SessionProfileDocument",
+    "WorkEventDocument",
+    "WorkThreadDocument",
+]

--- a/polylogue/lib/session_profile_models.py
+++ b/polylogue/lib/session_profile_models.py
@@ -6,8 +6,6 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import date, datetime
 
-from typing_extensions import TypedDict
-
 from polylogue.lib.attribution import ConversationAttribution
 from polylogue.lib.payload_coercion import (
     coerce_float,
@@ -23,58 +21,14 @@ from polylogue.lib.payload_coercion import (
 from polylogue.lib.phase_extraction import SessionPhase
 from polylogue.lib.repo_identity import normalize_repo_names, normalize_repo_paths
 from polylogue.lib.semantic_facts import ConversationSemanticFacts
-from polylogue.lib.work_event_extraction import WorkEvent, WorkEventPayload
+from polylogue.lib.session_payload_documents import (
+    SessionPhaseDocument,
+    SessionProfileDocument,
+)
+from polylogue.lib.work_event_extraction import WorkEvent
 
-
-class SessionPhasePayload(TypedDict):
-    start_time: str | None
-    end_time: str | None
-    canonical_session_date: str | None
-    message_range: list[int]
-    duration_ms: int
-    tool_counts: dict[str, int]
-    word_count: int
-    confidence: float
-    evidence: list[str]
-
-
-class SessionProfilePayload(TypedDict):
-    conversation_id: str
-    provider: str
-    title: str | None
-    created_at: str | None
-    updated_at: str | None
-    message_count: int
-    substantive_count: int
-    tool_use_count: int
-    thinking_count: int
-    attachment_count: int
-    word_count: int
-    total_cost_usd: float
-    total_duration_ms: int
-    tool_categories: dict[str, int]
-    repo_paths: list[str]
-    cwd_paths: list[str]
-    branch_names: list[str]
-    file_paths_touched: list[str]
-    languages_detected: list[str]
-    repo_names: list[str]
-    work_events: list[WorkEventPayload]
-    phases: list[SessionPhasePayload]
-    first_message_at: str | None
-    last_message_at: str | None
-    canonical_session_date: str | None
-    engaged_duration_ms: int
-    engaged_minutes: float
-    wall_duration_ms: int
-    cost_is_estimated: bool
-    compaction_count: int
-    thread_id: str | None
-    continuation_depth: int
-    tags: list[str]
-    auto_tags: list[str]
-    is_continuation: bool
-    parent_id: str | None
+SessionPhasePayload = SessionPhaseDocument
+SessionProfilePayload = SessionProfileDocument
 
 
 def _phase_to_dict(phase: SessionPhase) -> SessionPhasePayload:
@@ -91,7 +45,7 @@ def _phase_to_dict(phase: SessionPhase) -> SessionPhasePayload:
     }
 
 
-def _phase_from_mapping(payload: Mapping[str, object]) -> SessionPhase:
+def _phase_from_mapping(payload: SessionPhasePayload | Mapping[str, object]) -> SessionPhase:
     return SessionPhase(
         start_time=optional_datetime(payload.get("start_time")),
         end_time=optional_datetime(payload.get("end_time")),
@@ -186,7 +140,7 @@ class SessionProfile:
         }
 
     @classmethod
-    def from_dict(cls, payload: Mapping[str, object]) -> SessionProfile:
+    def from_dict(cls, payload: SessionProfilePayload | Mapping[str, object]) -> SessionProfile:
         repo_paths = normalize_repo_paths(string_sequence(payload.get("repo_paths")))
         explicit_repo_names = tuple(
             sorted({item.strip() for item in string_sequence(payload.get("repo_names")) if item.strip()})

--- a/polylogue/lib/threads.py
+++ b/polylogue/lib/threads.py
@@ -6,8 +6,7 @@ from collections import Counter, defaultdict
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from datetime import datetime
-
-from typing_extensions import TypedDict
+from typing import TypeAlias
 
 from polylogue.lib.payload_coercion import (
     coerce_float,
@@ -18,24 +17,47 @@ from polylogue.lib.payload_coercion import (
     string_sequence,
 )
 from polylogue.lib.repo_identity import normalize_repo_names
+from polylogue.lib.session_payload_documents import WorkThreadDocument
 from polylogue.lib.session_profile import SessionProfile
 
+WorkThreadPayload: TypeAlias = WorkThreadDocument
 
-class WorkThreadPayload(TypedDict):
-    thread_id: str
-    root_id: str
-    session_ids: list[str]
-    session_count: int
-    depth: int
-    branch_count: int
-    start_time: str | None
-    end_time: str | None
-    wall_duration_ms: int
-    total_messages: int
-    total_cost_usd: float
-    dominant_repo: str | None
-    provider_breakdown: dict[str, int]
-    work_event_breakdown: dict[str, int]
+
+def _work_thread_payload(thread: WorkThread) -> WorkThreadPayload:
+    return {
+        "thread_id": thread.thread_id,
+        "root_id": thread.root_id,
+        "session_ids": list(thread.session_ids),
+        "session_count": len(thread.session_ids),
+        "depth": thread.depth,
+        "branch_count": thread.branch_count,
+        "start_time": thread.start_time.isoformat() if thread.start_time else None,
+        "end_time": thread.end_time.isoformat() if thread.end_time else None,
+        "wall_duration_ms": thread.wall_duration_ms,
+        "total_messages": thread.total_messages,
+        "total_cost_usd": thread.total_cost_usd,
+        "dominant_repo": thread.dominant_repo,
+        "provider_breakdown": dict(thread.provider_breakdown),
+        "work_event_breakdown": dict(thread.work_event_breakdown),
+    }
+
+
+def _work_thread_from_mapping(payload: Mapping[str, object]) -> WorkThread:
+    return WorkThread(
+        thread_id=str(payload["thread_id"]),
+        root_id=str(payload["root_id"]),
+        session_ids=string_sequence(payload.get("session_ids")),
+        depth=coerce_int(payload.get("depth"), 0),
+        branch_count=coerce_int(payload.get("branch_count"), 0),
+        start_time=optional_datetime(payload.get("start_time")),
+        end_time=optional_datetime(payload.get("end_time")),
+        wall_duration_ms=coerce_int(payload.get("wall_duration_ms"), 0),
+        total_messages=coerce_int(payload.get("total_messages"), 0),
+        total_cost_usd=coerce_float(payload.get("total_cost_usd"), 0.0),
+        dominant_repo=optional_string(payload.get("dominant_repo")),
+        provider_breakdown=string_int_mapping(payload.get("provider_breakdown")),
+        work_event_breakdown=string_int_mapping(payload.get("work_event_breakdown")),
+    )
 
 
 @dataclass(frozen=True)
@@ -55,40 +77,15 @@ class WorkThread:
     work_event_breakdown: dict[str, int]
 
     def to_dict(self) -> WorkThreadPayload:
-        return {
-            "thread_id": self.thread_id,
-            "root_id": self.root_id,
-            "session_ids": list(self.session_ids),
-            "session_count": len(self.session_ids),
-            "depth": self.depth,
-            "branch_count": self.branch_count,
-            "start_time": self.start_time.isoformat() if self.start_time else None,
-            "end_time": self.end_time.isoformat() if self.end_time else None,
-            "wall_duration_ms": self.wall_duration_ms,
-            "total_messages": self.total_messages,
-            "total_cost_usd": self.total_cost_usd,
-            "dominant_repo": self.dominant_repo,
-            "provider_breakdown": self.provider_breakdown,
-            "work_event_breakdown": self.work_event_breakdown,
-        }
+        return _work_thread_payload(self)
+
+    @classmethod
+    def from_payload(cls, payload: WorkThreadPayload) -> WorkThread:
+        return _work_thread_from_mapping(payload)
 
     @classmethod
     def from_dict(cls, payload: Mapping[str, object]) -> WorkThread:
-        return cls(
-            thread_id=str(payload["thread_id"]),
-            root_id=str(payload["root_id"]),
-            session_ids=string_sequence(payload.get("session_ids")),
-            depth=coerce_int(payload.get("depth"), 0),
-            branch_count=coerce_int(payload.get("branch_count"), 0),
-            start_time=optional_datetime(payload.get("start_time")),
-            end_time=optional_datetime(payload.get("end_time")),
-            wall_duration_ms=coerce_int(payload.get("wall_duration_ms"), 0),
-            total_messages=coerce_int(payload.get("total_messages"), 0),
-            total_cost_usd=coerce_float(payload.get("total_cost_usd"), 0.0),
-            dominant_repo=optional_string(payload.get("dominant_repo")),
-            provider_breakdown=string_int_mapping(payload.get("provider_breakdown")),
-            work_event_breakdown=string_int_mapping(payload.get("work_event_breakdown")),
-        )
+        return _work_thread_from_mapping(payload)
 
 
 def _bfs_depth(adjacency: dict[str, list[str]], root: str) -> int:

--- a/polylogue/lib/work_event_extraction.py
+++ b/polylogue/lib/work_event_extraction.py
@@ -9,8 +9,6 @@ from datetime import date, datetime
 from enum import Enum
 from typing import TYPE_CHECKING, TypeAlias
 
-from typing_extensions import TypedDict
-
 from polylogue.lib.payload_coercion import (
     coerce_float,
     coerce_int,
@@ -24,6 +22,7 @@ from polylogue.lib.semantic_facts import (
     MessageSemanticFacts,
     build_conversation_semantic_facts,
 )
+from polylogue.lib.session_payload_documents import WorkEventDocument
 
 # Strip XML-like protocol artifacts from user messages before summarizing.
 # Claude Code sessions contain <command-name>, <task-notification>,
@@ -102,19 +101,7 @@ class WorkEventKind(str, Enum):
     CONVERSATION = "conversation"
 
 
-class WorkEventPayload(TypedDict):
-    kind: str
-    start_index: int
-    end_index: int
-    start_time: str | None
-    end_time: str | None
-    canonical_session_date: str | None
-    duration_ms: int
-    confidence: float
-    evidence: list[str]
-    file_paths: list[str]
-    tools_used: list[str]
-    summary: str
+WorkEventPayload: TypeAlias = WorkEventDocument
 
 
 @dataclass(frozen=True)
@@ -191,7 +178,7 @@ class WorkEvent:
         }
 
     @classmethod
-    def from_dict(cls, payload: Mapping[str, object]) -> WorkEvent:
+    def from_dict(cls, payload: WorkEventPayload | Mapping[str, object]) -> WorkEvent:
         return cls(
             kind=WorkEventKind(str(payload["kind"])),
             start_index=coerce_int(payload.get("start_index"), 0),

--- a/polylogue/mcp/payloads.py
+++ b/polylogue/mcp/payloads.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Generic, TypeVar
 from pydantic import RootModel
 from typing_extensions import TypedDict
 
+from polylogue.schemas.json_types import JSONDocument
 from polylogue.surface_payloads import (
     ConversationDetailPayload as MCPConversationDetailPayload,
 )
@@ -135,6 +136,10 @@ class MCPTagCountsPayload(MCPRootPayload[dict[str, int]]):
 
 class MCPMetadataPayload(SurfacePayloadModel):
     root: dict[str, object]
+
+    @classmethod
+    def from_document(cls, document: JSONDocument) -> MCPMetadataPayload:
+        return cls(root=dict(document))
 
     def to_json(self, *, exclude_none: bool = False) -> str:
         del exclude_none

--- a/polylogue/mcp/server_mutation_tools.py
+++ b/polylogue/mcp/server_mutation_tools.py
@@ -56,7 +56,7 @@ def register_mutation_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
     async def get_metadata(conversation_id: str) -> str:
         async def run() -> str:
             metadata = await hooks.get_tag_store().get_metadata(conversation_id)
-            return hooks.json_payload(MCPMetadataPayload(root=metadata))
+            return hooks.json_payload(MCPMetadataPayload.from_document(metadata))
 
         return await hooks.async_safe_call("get_metadata", run)
 

--- a/polylogue/operations/archive.py
+++ b/polylogue/operations/archive.py
@@ -42,6 +42,7 @@ from polylogue.maintenance_targets import build_maintenance_target_catalog
 from polylogue.paths import conversation_render_root
 from polylogue.services import RuntimeServices, build_runtime_services
 from polylogue.storage.backends.connection import connection_context
+from polylogue.storage.backends.queries.stats import ProviderMetricsRow
 from polylogue.storage.repair import collect_archive_debt_statuses_sync
 from polylogue.storage.search import SearchHit, SearchResult
 from polylogue.storage.session_product_runtime import (
@@ -165,21 +166,21 @@ def _slice_products(
     return products
 
 
-def provider_analytics_product(row: Mapping[str, object]) -> ProviderAnalyticsProduct:
-    conversation_count = _row_int(row, "conversation_count")
-    user_message_count = _row_int(row, "user_message_count")
-    assistant_message_count = _row_int(row, "assistant_message_count")
-    message_count = _row_int(row, "message_count")
-    user_word_sum = _row_int(row, "user_word_sum")
-    assistant_word_sum = _row_int(row, "assistant_word_sum")
-    tool_use_count = _row_int(row, "tool_use_count")
-    thinking_count = _row_int(row, "thinking_count")
-    conversations_with_tools = _row_int(row, "conversations_with_tools")
-    conversations_with_thinking = _row_int(row, "conversations_with_thinking")
+def provider_analytics_product(row: ProviderMetricsRow) -> ProviderAnalyticsProduct:
+    conversation_count = row["conversation_count"]
+    user_message_count = row["user_message_count"]
+    assistant_message_count = row["assistant_message_count"]
+    message_count = row["message_count"]
+    user_word_sum = row["user_word_sum"]
+    assistant_word_sum = row["assistant_word_sum"]
+    tool_use_count = row["tool_use_count"]
+    thinking_count = row["thinking_count"]
+    conversations_with_tools = row["conversations_with_tools"]
+    conversations_with_thinking = row["conversations_with_thinking"]
     tool_use_percentage = (conversations_with_tools / conversation_count) * 100 if conversation_count > 0 else 0.0
     thinking_percentage = (conversations_with_thinking / conversation_count) * 100 if conversation_count > 0 else 0.0
     return ProviderAnalyticsProduct(
-        provider_name=_row_str(row, "provider_name", default="unknown") or "unknown",
+        provider_name=row["provider_name"] or "unknown",
         conversation_count=conversation_count,
         message_count=message_count,
         user_message_count=user_message_count,
@@ -355,10 +356,7 @@ class ArchiveStatsMixin:
 
     async def provider_counts(self) -> list[tuple[str, int]]:
         rows = await self.backend.get_provider_conversation_counts()
-        return [
-            (_row_str(row, "provider_name", default="unknown") or "unknown", _row_int(row, "conversation_count"))
-            for row in rows
-        ]
+        return [(row["provider_name"] or "unknown", row["conversation_count"]) for row in rows]
 
     async def get_session_product_status(self) -> SessionProductStatusSnapshot:
         return await self.backend.get_session_product_status()

--- a/polylogue/protocols.py
+++ b/polylogue/protocols.py
@@ -13,6 +13,7 @@ from collections.abc import AsyncIterator
 from pathlib import Path
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
+from polylogue.lib.json import JSONDocument, JSONValue
 from polylogue.storage.store import (
     ArtifactObservationRecord,
     AttachmentRecord,
@@ -355,9 +356,9 @@ class TagStore(Protocol):
 
     async def list_tags(self, *, provider: str | None = None) -> dict[str, int]: ...
 
-    async def get_metadata(self, conversation_id: str) -> dict[str, object]: ...
+    async def get_metadata(self, conversation_id: str) -> JSONDocument: ...
 
-    async def update_metadata(self, conversation_id: str, key: str, value: object) -> None: ...
+    async def update_metadata(self, conversation_id: str, key: str, value: JSONValue) -> None: ...
 
     async def delete_metadata(self, conversation_id: str, key: str) -> None: ...
 

--- a/polylogue/storage/backends/async_sqlite_archive.py
+++ b/polylogue/storage/backends/async_sqlite_archive.py
@@ -9,7 +9,11 @@ from typing import TYPE_CHECKING
 from polylogue.storage.backends.queries import attachments as attachments_q
 from polylogue.storage.backends.queries import conversations as conversations_q
 from polylogue.storage.backends.queries import messages as messages_q
-from polylogue.storage.backends.queries.stats import AggregateMessageStats
+from polylogue.storage.backends.queries.stats import (
+    AggregateMessageStats,
+    ProviderConversationCountRow,
+    ProviderMetricsRow,
+)
 from polylogue.storage.search_models import ConversationSearchResult
 from polylogue.storage.session_product_runtime import SessionProductStatusSnapshot
 from polylogue.storage.store import AttachmentRecord, ContentBlockRecord, ConversationRecord, MessageRecord
@@ -196,11 +200,11 @@ class SQLiteArchiveMixin:
         """Get conversation counts grouped by provider, month, or year."""
         return await self.queries.get_stats_by(group_by)
 
-    async def get_provider_conversation_counts(self) -> list[dict[str, object]]:
+    async def get_provider_conversation_counts(self) -> list[ProviderConversationCountRow]:
         """Return conversation counts per provider."""
         return await self.queries.get_provider_conversation_counts()
 
-    async def get_provider_metrics_rows(self) -> list[dict[str, object]]:
+    async def get_provider_metrics_rows(self) -> list[ProviderMetricsRow]:
         """Return raw provider aggregation rows for analytics reporting."""
         return await self.queries.get_provider_metrics_rows()
 

--- a/polylogue/storage/backends/queries/conversations_identity.py
+++ b/polylogue/storage/backends/queries/conversations_identity.py
@@ -6,6 +6,7 @@ from collections.abc import AsyncIterator
 
 import aiosqlite
 
+from polylogue.lib.json import JSONDocument, json_document
 from polylogue.lib.json import dumps as json_dumps
 from polylogue.storage.backends.connection import _build_source_scope_filter
 from polylogue.storage.backends.queries.mappers import _parse_json
@@ -84,7 +85,7 @@ async def iter_conversation_ids(
             yield str(row["conversation_id"])
 
 
-async def get_metadata(conn: aiosqlite.Connection, conversation_id: str) -> dict[str, object]:
+async def get_metadata(conn: aiosqlite.Connection, conversation_id: str) -> JSONDocument:
     cursor = await conn.execute(
         "SELECT metadata FROM conversations WHERE conversation_id = ?",
         (conversation_id,),
@@ -92,13 +93,13 @@ async def get_metadata(conn: aiosqlite.Connection, conversation_id: str) -> dict
     row = await cursor.fetchone()
     if row is None:
         return {}
-    return _parse_json(row["metadata"], field="metadata", record_id=conversation_id) or {}
+    return json_document(_parse_json(row["metadata"], field="metadata", record_id=conversation_id))
 
 
 async def update_metadata_raw(
     conn: aiosqlite.Connection,
     conversation_id: str,
-    metadata: dict[str, object],
+    metadata: JSONDocument,
 ) -> None:
     await conn.execute(
         "UPDATE conversations SET metadata = ? WHERE conversation_id = ?",
@@ -109,7 +110,7 @@ async def update_metadata_raw(
 async def set_metadata(
     conn: aiosqlite.Connection,
     conversation_id: str,
-    metadata: dict[str, object],
+    metadata: JSONDocument,
     transaction_depth: int,
 ) -> None:
     await conn.execute(

--- a/polylogue/storage/backends/queries/mappers_product_legacy.py
+++ b/polylogue/storage/backends/queries/mappers_product_legacy.py
@@ -17,6 +17,7 @@ from polylogue.archive_product_models import (
     WorkEventEvidencePayload,
     WorkEventInferencePayload,
 )
+from polylogue.lib.session_payload_documents import SessionPhaseDocument, WorkEventDocument
 from polylogue.storage.backends.queries.mappers import _parse_json, _row_get
 
 PayloadModel = TypeVar("PayloadModel", bound=BaseModel)
@@ -109,8 +110,8 @@ def session_profile_inference_from_legacy(
             or "session_total_fallback",
             "repo_inference_strength": _legacy_text(legacy_payload.get("repo_inference_strength")) or "weak",
             "auto_tags": _row_text_tuple(row, "auto_tags_json", legacy_payload, legacy_key="auto_tags"),
-            "work_events": _legacy_dict_tuple(legacy_payload.get("work_events")),
-            "phases": _legacy_dict_tuple(legacy_payload.get("phases")),
+            "work_events": _legacy_work_event_documents(legacy_payload.get("work_events")),
+            "phases": _legacy_phase_documents(legacy_payload.get("phases")),
         }
     )
 
@@ -304,6 +305,14 @@ def _legacy_float(value: object, default: float = 0.0) -> float:
     return default
 
 
+def _legacy_int(value: object, default: int = 0) -> int:
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, str | int | float):
+        return int(value or default)
+    return default
+
+
 def _legacy_text_tuple(value: object) -> tuple[str, ...]:
     if not isinstance(value, Iterable) or isinstance(value, str | bytes | Mapping):
         return ()
@@ -324,6 +333,49 @@ def _legacy_int_dict(value: object) -> dict[str, int]:
     if not isinstance(value, Mapping):
         return {}
     return {str(key): int(item) for key, item in value.items() if item is not None}
+
+
+def _legacy_work_event_documents(value: object) -> tuple[WorkEventDocument, ...]:
+    documents: list[WorkEventDocument] = []
+    for item in _legacy_dict_tuple(value):
+        documents.append(
+            {
+                "kind": _legacy_text(item.get("kind")) or "conversation",
+                "start_index": _legacy_int(item.get("start_index")),
+                "end_index": _legacy_int(item.get("end_index")),
+                "start_time": _legacy_text(item.get("start_time")),
+                "end_time": _legacy_text(item.get("end_time")),
+                "canonical_session_date": _legacy_text(item.get("canonical_session_date")),
+                "duration_ms": _legacy_int(item.get("duration_ms")),
+                "confidence": _legacy_float(item.get("confidence")),
+                "evidence": list(_legacy_text_tuple(item.get("evidence"))),
+                "file_paths": list(_legacy_text_tuple(item.get("file_paths"))),
+                "tools_used": list(_legacy_text_tuple(item.get("tools_used"))),
+                "summary": _legacy_text(item.get("summary")) or "",
+            }
+        )
+    return tuple(documents)
+
+
+def _legacy_phase_documents(value: object) -> tuple[SessionPhaseDocument, ...]:
+    documents: list[SessionPhaseDocument] = []
+    for item in _legacy_dict_tuple(value):
+        start_index = _legacy_int(item.get("start_index"))
+        end_index = _legacy_int(item.get("end_index"))
+        documents.append(
+            {
+                "start_time": _legacy_text(item.get("start_time")),
+                "end_time": _legacy_text(item.get("end_time")),
+                "canonical_session_date": _legacy_text(item.get("canonical_session_date")),
+                "message_range": [start_index, end_index],
+                "duration_ms": _legacy_int(item.get("duration_ms")),
+                "tool_counts": _legacy_int_dict(item.get("tool_counts")),
+                "word_count": _legacy_int(item.get("word_count")),
+                "confidence": _legacy_float(item.get("confidence")),
+                "evidence": list(_legacy_text_tuple(item.get("evidence"))),
+            }
+        )
+    return tuple(documents)
 
 
 __all__ = [

--- a/polylogue/storage/backends/queries/stats.py
+++ b/polylogue/storage/backends/queries/stats.py
@@ -29,8 +29,29 @@ class _MessageAggregate(TypedDict):
     words_approx: int
 
 
+class ProviderConversationCountRow(TypedDict):
+    provider_name: str
+    conversation_count: int
+
+
+class ProviderMetricsRow(TypedDict):
+    provider_name: str
+    conversation_count: int
+    message_count: int
+    user_message_count: int
+    assistant_message_count: int
+    user_word_sum: int
+    assistant_word_sum: int
+    tool_use_count: int
+    thinking_count: int
+    conversations_with_tools: int
+    conversations_with_thinking: int
+
+
 __all__ = [
     "AggregateMessageStats",
+    "ProviderConversationCountRow",
+    "ProviderMetricsRow",
     "aggregate_message_stats",
     "upsert_conversation_stats",
     "get_stats_by",
@@ -232,7 +253,7 @@ async def get_stats_by(conn: aiosqlite.Connection, group_by: str = "provider") -
 
 async def get_provider_conversation_counts(
     conn: aiosqlite.Connection,
-) -> list[dict[str, object]]:
+) -> list[ProviderConversationCountRow]:
     """Return conversation counts per provider — fast, conversations-table-only query."""
     cursor = await conn.execute(
         """
@@ -243,12 +264,18 @@ async def get_provider_conversation_counts(
         """
     )
     rows = await cursor.fetchall()
-    return [dict(row) for row in rows]
+    return [
+        {
+            "provider_name": str(row["provider_name"] or "unknown"),
+            "conversation_count": int(row["conversation_count"] or 0),
+        }
+        for row in rows
+    ]
 
 
 async def get_provider_metrics_rows(
     conn: aiosqlite.Connection,
-) -> list[dict[str, object]]:
+) -> list[ProviderMetricsRow]:
     """Return raw provider aggregation rows for analytics reporting."""
     cursor = await conn.execute(
         """
@@ -271,4 +298,19 @@ async def get_provider_metrics_rows(
         """
     )
     rows = await cursor.fetchall()
-    return [dict(row) for row in rows]
+    return [
+        {
+            "provider_name": str(row["provider_name"] or "unknown"),
+            "conversation_count": int(row["conversation_count"] or 0),
+            "message_count": int(row["message_count"] or 0),
+            "user_message_count": int(row["user_message_count"] or 0),
+            "assistant_message_count": int(row["assistant_message_count"] or 0),
+            "user_word_sum": int(row["user_word_sum"] or 0),
+            "assistant_word_sum": int(row["assistant_word_sum"] or 0),
+            "tool_use_count": int(row["tool_use_count"] or 0),
+            "thinking_count": int(row["thinking_count"] or 0),
+            "conversations_with_tools": int(row["conversations_with_tools"] or 0),
+            "conversations_with_thinking": int(row["conversations_with_thinking"] or 0),
+        }
+        for row in rows
+    ]

--- a/polylogue/storage/backends/query_store_archive.py
+++ b/polylogue/storage/backends/query_store_archive.py
@@ -12,7 +12,11 @@ from polylogue.storage.backends.queries import attachments as attachments_q
 from polylogue.storage.backends.queries import conversations as conversations_q
 from polylogue.storage.backends.queries import messages as messages_q
 from polylogue.storage.backends.queries import stats as stats_q
-from polylogue.storage.backends.queries.stats import AggregateMessageStats
+from polylogue.storage.backends.queries.stats import (
+    AggregateMessageStats,
+    ProviderConversationCountRow,
+    ProviderMetricsRow,
+)
 from polylogue.storage.query_models import ConversationRecordQuery
 from polylogue.storage.search_models import ConversationSearchResult
 from polylogue.storage.store import (
@@ -164,11 +168,11 @@ class SQLiteQueryStoreArchiveMixin:
         async with self._connection_factory() as conn:
             return await stats_q.get_stats_by(conn, group_by)
 
-    async def get_provider_conversation_counts(self) -> list[dict[str, object]]:
+    async def get_provider_conversation_counts(self) -> list[ProviderConversationCountRow]:
         async with self._connection_factory() as conn:
             return await stats_q.get_provider_conversation_counts(conn)
 
-    async def get_provider_metrics_rows(self) -> list[dict[str, object]]:
+    async def get_provider_metrics_rows(self) -> list[ProviderMetricsRow]:
         async with self._connection_factory() as conn:
             return await stats_q.get_provider_metrics_rows(conn)
 

--- a/polylogue/storage/repository_write_conversations.py
+++ b/polylogue/storage/repository_write_conversations.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import builtins
+from typing import cast
 
 from polylogue.lib.conversation_models import Conversation
+from polylogue.lib.json import json_document
 from polylogue.storage.action_event_rows import attach_blocks_to_messages, build_action_event_records
 from polylogue.storage.backends.queries import action_events as action_events_q
 from polylogue.storage.backends.queries import attachments as attachments_q
@@ -39,12 +41,15 @@ def provider_conversation_id(conversation_id: str, provider: str | None) -> str:
 
 
 def conversation_to_record(conversation: Conversation) -> ConversationRecord:
-    from typing import cast
-
     from polylogue.types import ContentHash, ConversationId
 
     created_at_str = conversation.created_at.isoformat() if conversation.created_at else None
     updated_at_str = conversation.updated_at.isoformat() if conversation.updated_at else (created_at_str or None)
+    metadata = json_document(conversation.metadata)
+    metadata_record: dict[str, object] = {}
+    metadata_record.update(metadata)
+    provider_meta: dict[str, object] = {}
+    provider_meta.update(json_document(metadata.get("provider_meta")))
 
     return ConversationRecord(
         conversation_id=cast(ConversationId, str(conversation.id)),
@@ -56,9 +61,9 @@ def conversation_to_record(conversation: Conversation) -> ConversationRecord:
         title=conversation.title or "",
         created_at=created_at_str,
         updated_at=updated_at_str,
-        content_hash=cast(ContentHash, conversation.metadata.get("content_hash", "")),
-        provider_meta=cast(dict[str, object], conversation.metadata.get("provider_meta", {})),
-        metadata=conversation.metadata,
+        content_hash=cast(ContentHash, metadata_record.get("content_hash", "")),
+        provider_meta=provider_meta,
+        metadata=metadata_record,
     )
 
 

--- a/polylogue/storage/repository_write_metadata.py
+++ b/polylogue/storage/repository_write_metadata.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 
+from polylogue.lib.json import JSONDocument
 from polylogue.storage.backends.queries import conversations as conversations_q
 from polylogue.storage.repository_contracts import RepositoryBackendProtocol
 
@@ -11,7 +12,7 @@ from polylogue.storage.repository_contracts import RepositoryBackendProtocol
 async def metadata_read_modify_write(
     backend: RepositoryBackendProtocol,
     conversation_id: str,
-    mutator: Callable[[dict[str, object]], bool],
+    mutator: Callable[[JSONDocument], bool],
 ) -> None:
     async with backend.transaction(), backend.connection() as conn:
         current = await conversations_q.get_metadata(conn, conversation_id)

--- a/polylogue/storage/repository_writes.py
+++ b/polylogue/storage/repository_writes.py
@@ -7,6 +7,8 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from polylogue.lib.conversation_models import Conversation
+from polylogue.lib.json import JSONDocument, JSONValue
+from polylogue.lib.payload_coercion import string_sequence
 from polylogue.storage.backends.queries import conversations as conversations_q
 from polylogue.storage.backends.queries import publications as publications_q
 from polylogue.storage.backends.queries import runs as runs_q
@@ -87,26 +89,26 @@ class RepositoryWriteMixin:
         async with self._backend.connection() as conn:
             return await publications_q.get_latest_publication(conn, publication_kind)
 
-    async def get_metadata(self, conversation_id: str) -> dict[str, object]:
+    async def get_metadata(self, conversation_id: str) -> JSONDocument:
         async with self._backend.connection() as conn:
             return await conversations_q.get_metadata(conn, conversation_id)
 
     async def _metadata_read_modify_write(
         self,
         conversation_id: str,
-        mutator: Callable[[dict[str, object]], bool],
+        mutator: Callable[[JSONDocument], bool],
     ) -> None:
         await metadata_read_modify_write(self._backend, conversation_id, mutator)
 
-    async def update_metadata(self, conversation_id: str, key: str, value: object) -> None:
-        def _set(meta: dict[str, object]) -> bool:
+    async def update_metadata(self, conversation_id: str, key: str, value: JSONValue) -> None:
+        def _set(meta: JSONDocument) -> bool:
             meta[key] = value
             return True
 
         await self._metadata_read_modify_write(conversation_id, _set)
 
     async def delete_metadata(self, conversation_id: str, key: str) -> None:
-        def _delete(meta: dict[str, object]) -> bool:
+        def _delete(meta: JSONDocument) -> bool:
             if key in meta:
                 del meta[key]
                 return True
@@ -115,24 +117,24 @@ class RepositoryWriteMixin:
         await self._metadata_read_modify_write(conversation_id, _delete)
 
     async def add_tag(self, conversation_id: str, tag: str) -> None:
-        def _add(meta: dict[str, object]) -> bool:
-            tags = meta.get("tags", [])
-            if not isinstance(tags, list):
-                tags = []
+        def _add(meta: JSONDocument) -> bool:
+            tags = list(string_sequence(meta.get("tags")))
             if tag not in tags:
                 tags.append(tag)
-                meta["tags"] = tags
+                tag_payload: list[JSONValue] = list(tags)
+                meta["tags"] = tag_payload
                 return True
             return False
 
         await self._metadata_read_modify_write(conversation_id, _add)
 
     async def remove_tag(self, conversation_id: str, tag: str) -> None:
-        def _remove(meta: dict[str, object]) -> bool:
-            tags = meta.get("tags", [])
-            if isinstance(tags, list) and tag in tags:
+        def _remove(meta: JSONDocument) -> bool:
+            tags = list(string_sequence(meta.get("tags")))
+            if tag in tags:
                 tags.remove(tag)
-                meta["tags"] = tags
+                tag_payload: list[JSONValue] = list(tags)
+                meta["tags"] = tag_payload
                 return True
             return False
 
@@ -142,7 +144,7 @@ class RepositoryWriteMixin:
         async with self._backend.connection() as conn:
             return await conversations_q.list_tags(conn, provider=provider)
 
-    async def set_metadata(self, conversation_id: str, metadata: dict[str, object]) -> None:
+    async def set_metadata(self, conversation_id: str, metadata: JSONDocument) -> None:
         async with self._backend.connection() as conn:
             await conversations_q.set_metadata(
                 conn,

--- a/polylogue/storage/session_product_profiles.py
+++ b/polylogue/storage/session_product_profiles.py
@@ -20,11 +20,13 @@ from polylogue.lib.payload_coercion import (
     string_sequence,
 )
 from polylogue.lib.phase_extraction import SessionPhase
-from polylogue.lib.session_profile import SessionAnalysis, SessionProfile
-from polylogue.lib.session_profile_models import (
-    SessionPhasePayload,
-    SessionProfilePayload,
+from polylogue.lib.session_payload_documents import (
+    SessionPhaseDocument,
+    SessionProfileDocument,
+    WorkEventDocument,
 )
+from polylogue.lib.session_profile import SessionAnalysis, SessionProfile
+from polylogue.lib.session_profile_models import SessionPhasePayload
 from polylogue.lib.work_event_extraction import WorkEvent, WorkEventPayload
 from polylogue.storage.store import (
     SESSION_ENRICHMENT_FAMILY,
@@ -257,7 +259,7 @@ def build_session_profile_record(
 
 
 def hydrate_session_profile(record: SessionProfileRecord) -> SessionProfile:
-    merged_payload: SessionProfilePayload = {
+    merged_payload: SessionProfileDocument = {
         "conversation_id": str(record.conversation_id),
         "provider": record.provider_name,
         "title": record.title,
@@ -298,7 +300,7 @@ def hydrate_session_profile(record: SessionProfileRecord) -> SessionProfile:
     return SessionProfile.from_dict(merged_payload)
 
 
-def _phase_document(payload: SessionPhasePayload) -> dict[str, object]:
+def _phase_document(payload: SessionPhasePayload) -> SessionPhaseDocument:
     return {
         "start_time": payload["start_time"],
         "end_time": payload["end_time"],
@@ -326,7 +328,7 @@ def _phase_payload_from_phase(phase: SessionPhase) -> SessionPhasePayload:
     }
 
 
-def _phase_from_payload_mapping(payload: dict[str, object]) -> SessionPhase:
+def _phase_from_payload_mapping(payload: SessionPhaseDocument | dict[str, object]) -> SessionPhase:
     return SessionPhase(
         start_time=optional_datetime(payload.get("start_time")),
         end_time=optional_datetime(payload.get("end_time")),
@@ -340,7 +342,7 @@ def _phase_from_payload_mapping(payload: dict[str, object]) -> SessionPhase:
     )
 
 
-def _work_event_document(payload: WorkEventPayload) -> dict[str, object]:
+def _work_event_document(payload: WorkEventPayload) -> WorkEventDocument:
     return {
         "kind": payload["kind"],
         "start_index": payload["start_index"],
@@ -357,11 +359,11 @@ def _work_event_document(payload: WorkEventPayload) -> dict[str, object]:
     }
 
 
-def _phase_payload(payload: dict[str, object]) -> SessionPhasePayload:
+def _phase_payload(payload: SessionPhaseDocument | dict[str, object]) -> SessionPhasePayload:
     return _phase_payload_from_phase(_phase_from_payload_mapping(payload))
 
 
-def _work_event_payload(payload: dict[str, object]) -> WorkEventPayload:
+def _work_event_payload(payload: WorkEventDocument | dict[str, object]) -> WorkEventPayload:
     event = WorkEvent.from_dict(payload)
     return event.to_dict()
 

--- a/polylogue/storage/session_product_threads.py
+++ b/polylogue/storage/session_product_threads.py
@@ -8,6 +8,7 @@ from collections.abc import AsyncIterator, Iterable, Iterator, Sequence
 import aiosqlite
 
 from polylogue.archive_product_models import WorkThreadPayload as ArchivedWorkThreadPayload
+from polylogue.lib.session_payload_documents import WorkThreadDocument
 from polylogue.lib.threads import WorkThread, WorkThreadPayload, build_session_threads
 from polylogue.storage.backends.queries.mappers import _row_to_session_profile_record
 from polylogue.storage.session_product_profiles import hydrate_session_profile, now_iso
@@ -132,14 +133,14 @@ def build_work_thread_record(
 
 
 def hydrate_work_thread(record: WorkThreadRecord) -> WorkThread:
-    return WorkThread.from_dict(_thread_payload_document(record))
+    return WorkThread.from_payload(_thread_payload_document(record))
 
 
 def _thread_payload(thread: WorkThread) -> WorkThreadPayload:
     return thread.to_dict()
 
 
-def _thread_payload_document(record: WorkThreadRecord) -> dict[str, object]:
+def _thread_payload_document(record: WorkThreadRecord) -> WorkThreadDocument:
     payload = record.payload
     return {
         "thread_id": record.thread_id,
@@ -154,6 +155,7 @@ def _thread_payload_document(record: WorkThreadRecord) -> dict[str, object]:
         "total_messages": payload.total_messages,
         "total_cost_usd": payload.total_cost_usd,
         "dominant_repo": payload.dominant_repo,
+        "provider_breakdown": {},
         "work_event_breakdown": dict(payload.work_event_breakdown),
     }
 

--- a/polylogue/storage/session_product_timeline_rows.py
+++ b/polylogue/storage/session_product_timeline_rows.py
@@ -12,6 +12,7 @@ from polylogue.archive_product_models import (
 )
 from polylogue.lib.hashing import hash_text
 from polylogue.lib.phase_extraction import SessionPhase
+from polylogue.lib.session_payload_documents import WorkEventDocument
 from polylogue.lib.session_profile import SessionProfile
 from polylogue.lib.work_event_extraction import WorkEvent
 from polylogue.storage.session_product_profiles import (
@@ -175,12 +176,21 @@ def build_session_work_event_records(
 
 
 def hydrate_work_event(record: SessionWorkEventRecord) -> WorkEvent:
-    return WorkEvent.from_dict(
-        {
-            **record.evidence_payload.model_dump(mode="json"),
-            **record.inference_payload.model_dump(mode="json"),
-        }
-    )
+    payload: WorkEventDocument = {
+        "kind": record.inference_payload.kind,
+        "start_index": record.evidence_payload.start_index,
+        "end_index": record.evidence_payload.end_index,
+        "start_time": record.evidence_payload.start_time,
+        "end_time": record.evidence_payload.end_time,
+        "canonical_session_date": record.evidence_payload.canonical_session_date,
+        "duration_ms": record.evidence_payload.duration_ms,
+        "confidence": record.inference_payload.confidence,
+        "evidence": list(record.inference_payload.evidence),
+        "file_paths": list(record.evidence_payload.file_paths),
+        "tools_used": list(record.evidence_payload.tools_used),
+        "summary": record.inference_payload.summary,
+    }
+    return WorkEvent.from_dict(payload)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Ref #263

## Summary
- reduce weak metadata and analytics payload plumbing across repository write and archive analytics seams
- route action-readiness checks through the typed action-event artifact state contract
- share typed session payload documents across session profiles, work events, and work threads
- normalize legacy session-product fallback payloads and MCP metadata adapters around those tightened contracts

## Problem
Recent substrate renewal tightened JSON and session-product contracts, but the lib/storage runtime still had several weak seams:
- metadata/tag operations still widened through loose dict/object shapes
- provider analytics rows and action-readiness checks were not consistently using their typed runtime contracts
- session profile, work event, and thread payloads duplicated near-identical dict schemas in multiple modules
- legacy fallback hydration and MCP metadata surfaces still depended on ad hoc adapter logic that became brittle once payload shapes were made explicit

## Solution
- updated repository metadata/tag protocols and write paths to use shared JSON document/value contracts
- introduced typed provider analytics rows and consumed them through archive operations instead of untyped row dicts
- replaced awaitable probing in retrieval readiness with direct `ActionEventArtifactState` consumption
- added `polylogue/lib/session_payload_documents.py` and rewired session profile, work event, and thread runtime/storage helpers to share those document contracts
- localized compatibility work in the legacy mapper and MCP metadata wrapper so stricter runtime payloads do not leak regressions into old rows or surface serialization

## Verification
- `devtools verify`
- `pytest -q tests/unit/storage/test_session_product_refresh.py tests/unit/storage/test_product_materialization_laws.py tests/unit/mcp/test_tool_contracts.py -k 'thread or profile or work_event or phase or enrichment'`
- `pytest -q tests/unit/storage/test_session_product_mapper_fallbacks.py tests/unit/storage/test_session_product_refresh.py tests/unit/mcp/test_tool_contracts.py -k 'metadata or timeline or work_event or session_profile_record_falls_back'`
