### PR TITLE
refactor: rebuild schema, source, and ingestion boundary contracts

### DIFF
--- a/polylogue/pipeline/services/ingest_batch.py
+++ b/polylogue/pipeline/services/ingest_batch.py
@@ -119,6 +119,14 @@ class _IngestBatchSummary:
     teardown_elapsed_s: float = 0.0
 
 
+@dataclass(frozen=True, slots=True)
+class _IngestWorkerRequest:
+    archive_root_str: str
+    blob_root_str: str
+    validation_mode: str
+    measure_ingest_result_size: bool
+
+
 # ---------------------------------------------------------------------------
 # SQL statements (copied from async query modules — sync versions)
 # ---------------------------------------------------------------------------
@@ -578,38 +586,35 @@ def _flush_pending_conversation_entries(
             materialized_ids.add(cdata.conversation_id)
 
 
+def _run_ingest_record(
+    raw_record: RawConversationRecord,
+    request: _IngestWorkerRequest,
+) -> IngestRecordResult:
+    return ingest_record(
+        raw_record,
+        request.archive_root_str,
+        request.validation_mode,
+        request.measure_ingest_result_size,
+        blob_root_str=request.blob_root_str,
+    )
+
+
 def _iter_ingest_results_sync(
     raw_records: list[RawConversationRecord],
     *,
-    archive_root_str: str,
-    blob_root_str: str,
-    validation_mode: str,
+    request: _IngestWorkerRequest,
     worker_count: int,
-    measure_ingest_result_size: bool,
 ) -> Iterable[IngestRecordResult]:
     if worker_count <= 1:
         for raw_record in raw_records:
-            yield ingest_record(
-                raw_record,
-                archive_root_str,
-                validation_mode,
-                measure_ingest_result_size,
-                blob_root_str=blob_root_str,
-            )
+            yield _run_ingest_record(raw_record, request)
         return
 
     try:
         with process_pool_executor(max_workers=worker_count) as executor:
             futures: dict[Future[IngestRecordResult], str] = {}
             for raw_record in raw_records:
-                future = executor.submit(
-                    ingest_record,
-                    raw_record,
-                    archive_root_str,
-                    validation_mode,
-                    measure_ingest_result_size,
-                    blob_root_str=blob_root_str,
-                )
+                future = executor.submit(_run_ingest_record, raw_record, request)
                 futures[future] = raw_record.raw_id
 
             for future in as_completed(futures):
@@ -623,13 +628,7 @@ def _iter_ingest_results_sync(
                     )
     except (TypeError, pickle.PicklingError):
         for raw_record in raw_records:
-            yield ingest_record(
-                raw_record,
-                archive_root_str,
-                validation_mode,
-                measure_ingest_result_size,
-                blob_root_str=blob_root_str,
-            )
+            yield _run_ingest_record(raw_record, request)
 
 
 def _resolved_ingest_worker_limit(value: int | None) -> int:
@@ -678,6 +677,12 @@ def _process_ingest_batch_sync(
     summary.raw_record_count = len(raw_records)
     summary.worker_count = _select_ingest_worker_count(raw_records, ingest_workers)
     summary.total_blob_mb = sum(r.blob_size for r in raw_records) / (1024 * 1024)
+    worker_request = _IngestWorkerRequest(
+        archive_root_str=archive_root_str,
+        blob_root_str=blob_root_str,
+        validation_mode=validation_mode,
+        measure_ingest_result_size=measure_ingest_result_size,
+    )
 
     t_start = time.perf_counter()
     setup_started = time.perf_counter()
@@ -694,11 +699,8 @@ def _process_ingest_batch_sync(
         result_iterator = iter(
             _iter_ingest_results_sync(
                 raw_records,
-                archive_root_str=archive_root_str,
-                blob_root_str=blob_root_str,
-                validation_mode=validation_mode,
+                request=worker_request,
                 worker_count=summary.worker_count,
-                measure_ingest_result_size=measure_ingest_result_size,
             )
         )
         while True:

--- a/polylogue/pipeline/services/ingest_worker.py
+++ b/polylogue/pipeline/services/ingest_worker.py
@@ -212,6 +212,7 @@ class _ParsePlan:
     artifact: ArtifactClassification
     mode: ParsePlanMode
     schema_payload: object | None
+    schema_resolution: SchemaResolution | None = None
     payload: object | None = None
     stream_name: str | None = None
     malformed_jsonl_lines: int = 0
@@ -221,7 +222,6 @@ class _ParsePlan:
 @dataclass(frozen=True, slots=True)
 class _PlanValidation:
     status: ValidationStatus
-    schema_resolution: SchemaResolution | None = None
     validation_error: str | None = None
     parse_error: str | None = None
 
@@ -320,18 +320,61 @@ def _record_result(
     )
 
 
-def _resolve_schema_resolution(
-    provider: Provider,
-    payload: object,
+def _schema_payload_for_artifact(
     *,
+    artifact: ArtifactClassification,
+    payload: object,
+) -> object | None:
+    return payload if artifact.schema_eligible else None
+
+
+def _resolve_plan_schema(
+    *,
+    provider: Provider,
+    schema_payload: object | None,
     source_path: str | None,
 ) -> SchemaResolution | None:
-    if payload is None:
+    if schema_payload is None:
         return None
     return _runtime_schema_registry().resolve_payload(
         provider,
-        payload,
+        schema_payload,
         source_path=source_path,
+    )
+
+
+def _build_parse_plan(
+    *,
+    provider: Provider,
+    payload_provider: str,
+    artifact: ArtifactClassification,
+    source_path: str | None,
+    mode: ParsePlanMode,
+    payload: object | None = None,
+    schema_payload_source: object,
+    stream_name: str | None = None,
+    malformed_jsonl_lines: int = 0,
+    malformed_jsonl_detail: str | None = None,
+) -> _ParsePlan:
+    schema_payload = _schema_payload_for_artifact(
+        artifact=artifact,
+        payload=schema_payload_source,
+    )
+    return _ParsePlan(
+        provider=provider,
+        payload_provider=payload_provider,
+        artifact=artifact,
+        mode=mode,
+        schema_payload=schema_payload,
+        schema_resolution=_resolve_plan_schema(
+            provider=provider,
+            schema_payload=schema_payload,
+            source_path=source_path,
+        ),
+        payload=payload,
+        stream_name=stream_name,
+        malformed_jsonl_lines=malformed_jsonl_lines,
+        malformed_jsonl_detail=malformed_jsonl_detail,
     )
 
 
@@ -369,12 +412,13 @@ def _build_stream_parse_plan(
         provider=detected_provider,
         source_path=context.raw_record.source_path,
     )
-    return _ParsePlan(
+    return _build_parse_plan(
         provider=detected_provider,
         payload_provider=str(detected_provider),
         artifact=artifact,
+        source_path=context.raw_record.source_path,
         mode="stream",
-        schema_payload=sample_payloads if artifact.schema_eligible else None,
+        schema_payload_source=sample_payloads,
         stream_name=stream_name,
         malformed_jsonl_lines=malformed_lines,
         malformed_jsonl_detail=malformed_detail,
@@ -382,15 +426,17 @@ def _build_stream_parse_plan(
 
 
 def _build_envelope_parse_plan(
+    context: _IngestContext,
     envelope: RawPayloadEnvelope,
 ) -> _ParsePlan:
-    return _ParsePlan(
+    return _build_parse_plan(
         provider=envelope.provider,
         payload_provider=str(envelope.provider),
         artifact=envelope.artifact,
+        source_path=context.raw_record.source_path,
         mode="payload",
-        schema_payload=envelope.payload if envelope.artifact.schema_eligible else None,
         payload=envelope.payload,
+        schema_payload_source=envelope.payload,
         malformed_jsonl_lines=envelope.malformed_jsonl_lines,
         malformed_jsonl_detail=envelope.malformed_jsonl_detail,
     )
@@ -417,23 +463,16 @@ def _validate_parse_plan(
             parse_error=malformed_error,
         )
 
-    schema_resolution = _resolve_schema_resolution(
-        plan.provider,
-        plan.schema_payload,
-        source_path=context.raw_record.source_path,
-    )
-
     try:
         validator = SchemaValidator.for_payload(
             plan.provider,
             plan.schema_payload,
             source_path=context.raw_record.source_path,
-            schema_resolution=schema_resolution,
+            schema_resolution=plan.schema_resolution,
         )
     except (FileNotFoundError, ImportError):
         return _PlanValidation(
             status=ValidationStatus.SKIPPED,
-            schema_resolution=schema_resolution,
         )
 
     validation_samples = validator.validation_samples(plan.schema_payload)
@@ -446,31 +485,20 @@ def _validate_parse_plan(
         if collected_errors and context.validation_mode is ValidationMode.STRICT:
             return _PlanValidation(
                 status=ValidationStatus.FAILED,
-                schema_resolution=schema_resolution,
                 validation_error=f"Schema validation failed: {collected_errors[0]}",
             )
 
     return _PlanValidation(
         status=ValidationStatus.PASSED,
-        schema_resolution=schema_resolution,
     )
 
 
 def _parse_plan_conversations(
     context: _IngestContext,
     plan: _ParsePlan,
-    *,
-    schema_resolution: SchemaResolution | None,
 ) -> list[ParsedConversation]:
     from polylogue.sources.dispatch import parse_payload, parse_stream_payload
 
-    resolved_schema = schema_resolution
-    if resolved_schema is None and plan.artifact.schema_eligible:
-        resolved_schema = _resolve_schema_resolution(
-            plan.provider,
-            plan.schema_payload,
-            source_path=context.raw_record.source_path,
-        )
     fallback_id = _fallback_id(context.raw_record.source_path, context.raw_record.raw_id)
     if plan.mode == "stream":
         assert plan.stream_name is not None
@@ -485,7 +513,7 @@ def _parse_plan_conversations(
         plan.provider,
         plan.payload,
         fallback_id,
-        schema_resolution=resolved_schema,
+        schema_resolution=plan.schema_resolution,
     )
 
 
@@ -555,7 +583,6 @@ def _run_parse_plan(
         parsed_conversations = _parse_plan_conversations(
             context,
             plan,
-            schema_resolution=validation.schema_resolution,
         )
     except Exception as exc:
         return _record_result(
@@ -639,7 +666,7 @@ def ingest_record(
             error=f"decode: {exc}",
         )
 
-    return _run_parse_plan(context, _build_envelope_parse_plan(envelope))
+    return _run_parse_plan(context, _build_envelope_parse_plan(context, envelope))
 
 
 # ---------------------------------------------------------------------------

--- a/polylogue/schemas/observation_runtime.py
+++ b/polylogue/schemas/observation_runtime.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TypeAlias
@@ -16,6 +17,8 @@ from polylogue.types import Provider
 SchemaSample: TypeAlias = JSONDocument
 
 _SCHEMA_SAMPLE_STRING_LIMIT = 1024
+_MAX_PROFILE_TOKENS = 160
+_MAX_NESTED_PROFILE_TOKENS = 8
 
 
 @dataclass(frozen=True)
@@ -227,16 +230,55 @@ def _coarse_type(value: object) -> str:
     return type(value).__name__
 
 
+def _nested_object_keys(value: object) -> tuple[str, ...]:
+    if not isinstance(value, dict):
+        return ()
+    return tuple(sorted(str(key) for key in value)[:_MAX_NESTED_PROFILE_TOKENS])
+
+
+def _nested_list_object_keys(value: object) -> tuple[str, ...]:
+    if not isinstance(value, list):
+        return ()
+    keys: set[str] = set()
+    for item in value[:_MAX_NESTED_PROFILE_TOKENS]:
+        if not isinstance(item, dict):
+            continue
+        keys.update(str(key) for key in item)
+        if len(keys) >= _MAX_NESTED_PROFILE_TOKENS:
+            break
+    return tuple(sorted(keys)[:_MAX_NESTED_PROFILE_TOKENS])
+
+
+def _append_tokens(tokens: list[str], values: Iterable[str]) -> None:
+    for value in values:
+        if value not in tokens:
+            tokens.append(value)
+        if len(tokens) >= _MAX_PROFILE_TOKENS:
+            return
+
+
 def _document_profile_tokens(sample: SchemaSample) -> tuple[str, ...]:
     tokens: list[str] = []
     for key, value in sorted(sample.items()):
-        tokens.append(f"field:{key}")
         value_type = _coarse_type(value)
-        if value_type in {"array", "object"}:
-            tokens.append(f"shape:{key}:{value_type}")
+        _append_tokens(
+            tokens,
+            (
+                f"field:{key}",
+                f"type:{key}:{value_type}",
+            ),
+        )
+        if value_type == "object":
+            _append_tokens(tokens, (f"shape:{key}:object",))
+            _append_tokens(tokens, (f"child:{key}:{child}" for child in _nested_object_keys(value)))
+        elif value_type == "array":
+            _append_tokens(tokens, (f"shape:{key}:array",))
+            _append_tokens(tokens, (f"item:{key}:{child}" for child in _nested_list_object_keys(value)))
         if key in {"mapping", "chat_messages", "chunkedPrompt", "chunks", "messages"}:
-            tokens.append(f"anchor:{key}")
-    return tuple(tokens[:96])
+            _append_tokens(tokens, (f"anchor:{key}",))
+        if len(tokens) >= _MAX_PROFILE_TOKENS:
+            break
+    return tuple(tokens[:_MAX_PROFILE_TOKENS])
 
 
 def _record_profile_tokens(
@@ -245,17 +287,27 @@ def _record_profile_tokens(
     record_type_key: str | None,
 ) -> tuple[str, ...]:
     bucket_keys: dict[str, set[str]] = {}
+    bucket_value_types: dict[str, dict[str, set[str]]] = {}
     for sample in samples[:512]:
         bucket = record_bucket_key(sample, record_type_key)
         keys = bucket_keys.setdefault(bucket, set())
+        value_types = bucket_value_types.setdefault(bucket, {})
         keys.update(str(key) for key in sample)
+        for key, value in sample.items():
+            value_types.setdefault(str(key), set()).add(_coarse_type(value))
 
     tokens: list[str] = []
     for bucket, keys in sorted(bucket_keys.items()):
-        tokens.append(f"bucket:{bucket}")
+        _append_tokens(tokens, (f"bucket:{bucket}",))
         for key in sorted(keys)[:24]:
-            tokens.append(f"field:{bucket}:{key}")
-    return tuple(tokens[:160])
+            _append_tokens(tokens, (f"field:{bucket}:{key}",))
+            for value_type in sorted(bucket_value_types.get(bucket, {}).get(key, ())):
+                _append_tokens(tokens, (f"type:{bucket}:{key}:{value_type}",))
+            if len(tokens) >= _MAX_PROFILE_TOKENS:
+                break
+        if len(tokens) >= _MAX_PROFILE_TOKENS:
+            break
+    return tuple(tokens[:_MAX_PROFILE_TOKENS])
 
 
 def _document_conversation_id(sample: SchemaSample, raw_id: str | None) -> str | None:

--- a/polylogue/schemas/packages.py
+++ b/polylogue/schemas/packages.py
@@ -1,9 +1,10 @@
-"""Package-aware schema manifest models."""
+"""Package-aware schema manifest and resolution models."""
 
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
+from typing import Literal, TypeAlias
 
 from polylogue.schemas.json_types import JSONDocument, json_document, json_document_list
 from polylogue.types import Provider
@@ -32,6 +33,14 @@ def _int_value(value: object, default: int = 0) -> int:
 
 def _string_int_dict(value: object) -> dict[str, int]:
     return {str(key): _int_value(item) for key, item in json_document(value).items()}
+
+
+SchemaResolutionReason: TypeAlias = Literal[
+    "bundle_scope",
+    "exact_structure",
+    "package_default",
+    "profile_family",
+]
 
 
 @dataclass
@@ -134,6 +143,14 @@ class SchemaVersionPackage:
         target = element_kind or self.default_element_kind
         return next((item for item in self.elements if item.element_kind == target), None)
 
+    def element_bundle_scopes(self, element_kind: str | None = None) -> set[str]:
+        element = self.element(element_kind)
+        if element is None:
+            return set(self.bundle_scopes)
+        scopes = set(self.bundle_scopes)
+        scopes.update(element.bundle_scopes)
+        return scopes
+
 
 @dataclass
 class SchemaPackageCatalog:
@@ -185,12 +202,14 @@ class SchemaResolution:
     element_kind: str
     exact_structure_id: str | None
     bundle_scope: str | None
-    reason: str
+    reason: SchemaResolutionReason
+    profile_score: float | None = None
 
 
 __all__ = [
     "SchemaElementManifest",
     "SchemaPackageCatalog",
     "SchemaResolution",
+    "SchemaResolutionReason",
     "SchemaVersionPackage",
 ]

--- a/polylogue/schemas/runtime_registry.py
+++ b/polylogue/schemas/runtime_registry.py
@@ -9,12 +9,12 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, cast
 
 from polylogue.lib.provider_identity import canonical_schema_provider as _canonical_schema_provider
 from polylogue.lib.provider_identity import normalize_provider_token
 from polylogue.lib.raw_payload_decode import JSONRecord
 from polylogue.paths import data_home
+from polylogue.schemas.json_types import json_document
 from polylogue.schemas.observation import (
     derive_bundle_scope,
     extract_schema_units_from_payload,
@@ -25,6 +25,7 @@ from polylogue.schemas.packages import (
     SchemaElementManifest,
     SchemaPackageCatalog,
     SchemaResolution,
+    SchemaResolutionReason,
     SchemaVersionPackage,
 )
 from polylogue.types import Provider
@@ -32,10 +33,17 @@ from polylogue.types import Provider
 SCHEMA_DIR = Path(__file__).parent / "providers"
 SchemaProvider = Provider | str
 SchemaCacheKey = tuple[str, str, str | None]
-SchemaInputDocument = Mapping[str, Any]
-PublicSchemaDocument = dict[str, Any]
-SchemaDocument = JSONRecord
-ElementSchemaMap = dict[str, SchemaDocument]
+SchemaInputDocument = Mapping[str, object]
+PublicSchemaDocument = JSONRecord
+ElementSchemaMap = dict[str, PublicSchemaDocument]
+
+_PROFILE_SAMPLE_LIMIT = 64
+_RESOLUTION_PRIORITY: dict[SchemaResolutionReason, int] = {
+    "exact_structure": 3,
+    "bundle_scope": 2,
+    "profile_family": 1,
+    "package_default": 0,
+}
 
 
 def _provider_token(provider: str | Provider) -> str:
@@ -78,14 +86,14 @@ def _read_json_dict(path: Path) -> PublicSchemaDocument:
     loaded = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(loaded, dict):
         raise ValueError(f"Expected JSON object in {path}")
-    return loaded
+    return {str(key): value for key, value in loaded.items()}
 
 
 def _read_gzip_json_dict(path: Path) -> PublicSchemaDocument:
     loaded = json.loads(gzip.decompress(path.read_bytes()).decode("utf-8"))
     if not isinstance(loaded, dict):
         raise ValueError(f"Expected gzipped JSON object in {path}")
-    return loaded
+    return {str(key): value for key, value in loaded.items()}
 
 
 def _catalog_path(provider_dir: Path) -> Path:
@@ -125,6 +133,30 @@ class _SchemaEvidence:
     exact_structure_ids: list[str]
     profile_tokens: list[str]
     representative_paths: list[str]
+
+
+@dataclass(frozen=True)
+class _ObservedPayload:
+    artifact_kind: str
+    bundle_scope: str | None
+    exact_structure_id: str | None
+    profile_tokens: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class _ResolvedElement:
+    package: SchemaVersionPackage
+    element: SchemaElementManifest
+
+
+@dataclass(frozen=True)
+class _ResolutionCandidate:
+    reason: SchemaResolutionReason
+    resolved: _ResolvedElement
+    exact_structure_id: str | None
+    bundle_scope: str | None
+    observation_index: int
+    profile_score: float | None = None
 
 
 def _schema_evidence(schema: SchemaInputDocument) -> _SchemaEvidence:
@@ -174,8 +206,33 @@ def _resolved_package_version(catalog: SchemaPackageCatalog, version: str) -> st
     return version
 
 
-def _schema_document(schema: SchemaInputDocument) -> SchemaDocument:
-    return cast(SchemaDocument, dict(schema))
+def _package_rank_key(
+    catalog: SchemaPackageCatalog,
+    package: SchemaVersionPackage,
+) -> tuple[bool, bool, bool, int, str]:
+    version_score, version_text = _version_sort_key(package.version)
+    return (
+        package.version != (catalog.recommended_version or ""),
+        package.version != (catalog.default_version or ""),
+        package.version != (catalog.latest_version or ""),
+        -version_score,
+        version_text,
+    )
+
+
+def _candidate_sort_key(
+    candidate: _ResolutionCandidate,
+    *,
+    package_rank: Mapping[str, int],
+) -> tuple[int, int, float, int, str, str]:
+    return (
+        -_RESOLUTION_PRIORITY[candidate.reason],
+        package_rank[candidate.resolved.package.version],
+        -(candidate.profile_score or 0.0),
+        candidate.observation_index,
+        candidate.resolved.element.element_kind,
+        candidate.resolved.package.version,
+    )
 
 
 class SchemaRegistry:
@@ -344,7 +401,7 @@ class SchemaRegistry:
         for element in package.elements:
             if element.schema_file is None:
                 continue
-            schema = cast(dict[str, object], copy.deepcopy(element_schemas[element.element_kind]))
+            schema = copy.deepcopy(element_schemas[element.element_kind])
             schema["$id"] = f"polylogue://schemas/{provider_token}/{package.version}/{element.element_kind}"
             schema["x-polylogue-version"] = (
                 int(package.version[1:]) if package.version.startswith("v") else package.version
@@ -424,7 +481,7 @@ class SchemaRegistry:
                 )
             ],
         )
-        return package, {element_kind: _schema_document(schema)}
+        return package, {element_kind: json_document(copy.deepcopy(dict(schema)))}
 
     def register_schema(self, provider: str, schema: SchemaInputDocument) -> str:
         provider_token = _provider_token(provider)
@@ -438,7 +495,7 @@ class SchemaRegistry:
         package, schemas = self._single_element_package(
             provider_token,
             version=version,
-            schema=_schema_document(copy.deepcopy(schema)),
+            schema=copy.deepcopy(dict(schema)),
         )
         catalog = self.load_package_catalog(provider_token) or SchemaPackageCatalog(provider=provider_token)
         existing_packages = [item for item in catalog.packages if item.version != version]
@@ -454,6 +511,143 @@ class SchemaRegistry:
             self._package_dir(provider_token, version) / "elements" / f"{package.default_element_kind}.schema.json.gz"
         )
 
+    def _package_rank(self, catalog: SchemaPackageCatalog) -> dict[str, int]:
+        ranked = sorted(catalog.packages, key=lambda package: _package_rank_key(catalog, package))
+        return {package.version: index for index, package in enumerate(ranked)}
+
+    def _ranked_packages(self, catalog: SchemaPackageCatalog) -> list[SchemaVersionPackage]:
+        return sorted(catalog.packages, key=lambda package: _package_rank_key(catalog, package))
+
+    def _observed_payloads(
+        self,
+        provider: str,
+        payload: object,
+        *,
+        source_path: str | None,
+    ) -> list[_ObservedPayload]:
+        provider_token = _provider_token(provider)
+        config = resolve_provider_config(provider_token)
+        fallback_bundle_scope = derive_bundle_scope(provider_token, source_path)
+        units = extract_schema_units_from_payload(
+            payload,
+            provider_name=Provider.from_string(provider_token),
+            source_path=source_path,
+            raw_id=None,
+            observed_at=None,
+            config=config,
+            max_samples=_PROFILE_SAMPLE_LIMIT,
+        )
+        return [
+            _ObservedPayload(
+                artifact_kind=unit.artifact_kind,
+                bundle_scope=unit.bundle_scope or fallback_bundle_scope,
+                exact_structure_id=unit.exact_structure_id or None,
+                profile_tokens=unit.profile_tokens,
+            )
+            for unit in units
+        ]
+
+    def _resolve_observation(
+        self,
+        packages: Sequence[SchemaVersionPackage],
+        observation: _ObservedPayload,
+        *,
+        package_rank: Mapping[str, int],
+        observation_index: int,
+    ) -> _ResolutionCandidate | None:
+        candidates: list[_ResolutionCandidate] = []
+        observed_profile_tokens = set(observation.profile_tokens)
+        for package in packages:
+            element = package.element(observation.artifact_kind)
+            if element is None:
+                continue
+            resolved = _ResolvedElement(package=package, element=element)
+
+            if observation.exact_structure_id and observation.exact_structure_id in element.exact_structure_ids:
+                candidates.append(
+                    _ResolutionCandidate(
+                        reason="exact_structure",
+                        resolved=resolved,
+                        exact_structure_id=observation.exact_structure_id,
+                        bundle_scope=observation.bundle_scope,
+                        observation_index=observation_index,
+                    )
+                )
+            if observation.bundle_scope and observation.bundle_scope in package.element_bundle_scopes(
+                element.element_kind
+            ):
+                candidates.append(
+                    _ResolutionCandidate(
+                        reason="bundle_scope",
+                        resolved=resolved,
+                        exact_structure_id=observation.exact_structure_id,
+                        bundle_scope=observation.bundle_scope,
+                        observation_index=observation_index,
+                    )
+                )
+            if observed_profile_tokens and element.profile_tokens:
+                score = profile_similarity(set(element.profile_tokens), observed_profile_tokens)
+                if score > 0.0:
+                    candidates.append(
+                        _ResolutionCandidate(
+                            reason="profile_family",
+                            resolved=resolved,
+                            exact_structure_id=observation.exact_structure_id,
+                            bundle_scope=observation.bundle_scope,
+                            observation_index=observation_index,
+                            profile_score=score,
+                        )
+                    )
+
+        if not candidates:
+            return None
+
+        winner = min(
+            candidates,
+            key=lambda candidate: _candidate_sort_key(candidate, package_rank=package_rank),
+        )
+        return winner
+
+    def _default_resolution(
+        self,
+        provider: str,
+        *,
+        observations: Sequence[_ObservedPayload],
+        source_path: str | None,
+    ) -> SchemaResolution | None:
+        default_package = self.get_package(provider, version="default")
+        if default_package is None:
+            return None
+
+        matching_observation = next(
+            (
+                observation
+                for observation in observations
+                if default_package.element(observation.artifact_kind) is not None
+            ),
+            None,
+        )
+        if matching_observation is not None:
+            element = default_package.element(matching_observation.artifact_kind)
+            if element is not None:
+                return SchemaResolution(
+                    provider=provider,
+                    package_version=default_package.version,
+                    element_kind=element.element_kind,
+                    exact_structure_id=matching_observation.exact_structure_id,
+                    bundle_scope=matching_observation.bundle_scope,
+                    reason="package_default",
+                )
+
+        return SchemaResolution(
+            provider=provider,
+            package_version=default_package.version,
+            element_kind=default_package.default_element_kind,
+            exact_structure_id=None,
+            bundle_scope=derive_bundle_scope(provider, source_path),
+            reason="package_default",
+        )
+
     def resolve_payload(
         self,
         provider: str,
@@ -466,152 +660,42 @@ class SchemaRegistry:
         if catalog is None or not catalog.packages:
             return None
 
-        config = resolve_provider_config(provider_token)
-        units = extract_schema_units_from_payload(
-            payload,
-            provider_name=Provider.from_string(provider_token),
-            source_path=source_path,
-            raw_id=None,
-            observed_at=None,
-            config=config,
-            max_samples=64,
-        )
-        if not units:
-            default_package = self.get_package(provider_token, version="default")
-            if default_package is None:
-                return None
+        observations = self._observed_payloads(provider_token, payload, source_path=source_path)
+        ranked_packages = self._ranked_packages(catalog)
+        package_rank = self._package_rank(catalog)
+        best_candidate: _ResolutionCandidate | None = None
+        for index, observation in enumerate(observations):
+            candidate = self._resolve_observation(
+                ranked_packages,
+                observation,
+                package_rank=package_rank,
+                observation_index=index,
+            )
+            if candidate is None:
+                continue
+            if best_candidate is None:
+                best_candidate = candidate
+                continue
+            if _candidate_sort_key(candidate, package_rank=package_rank) < _candidate_sort_key(
+                best_candidate,
+                package_rank=package_rank,
+            ):
+                best_candidate = candidate
+
+        if best_candidate is not None:
             return SchemaResolution(
                 provider=provider_token,
-                package_version=default_package.version,
-                element_kind=default_package.default_element_kind,
-                exact_structure_id=None,
-                bundle_scope=derive_bundle_scope(provider_token, source_path),
-                reason="package_default",
+                package_version=best_candidate.resolved.package.version,
+                element_kind=best_candidate.resolved.element.element_kind,
+                exact_structure_id=best_candidate.exact_structure_id,
+                bundle_scope=best_candidate.bundle_scope,
+                reason=best_candidate.reason,
+                profile_score=best_candidate.profile_score,
             )
-
-        unit = units[0]
-        bundle_scope = unit.bundle_scope or derive_bundle_scope(provider_token, source_path)
-
-        bundle_resolution = self._resolve_by_bundle_scope(
-            catalog.packages,
-            unit.artifact_kind,
-            bundle_scope,
+        return self._default_resolution(
             provider_token,
-            unit.exact_structure_id,
-        )
-        if bundle_resolution is not None:
-            return bundle_resolution
-
-        exact_resolution = self._resolve_by_exact_structure(
-            catalog.packages,
-            unit.artifact_kind,
-            unit.exact_structure_id,
-            bundle_scope,
-            provider_token,
-        )
-        if exact_resolution is not None:
-            return exact_resolution
-
-        profile_resolution = self._resolve_by_profile_similarity(
-            catalog.packages,
-            unit.artifact_kind,
-            unit.profile_tokens,
-            unit.exact_structure_id,
-            bundle_scope,
-            provider_token,
-        )
-        if profile_resolution is not None:
-            return profile_resolution
-
-        default_package = self.get_package(provider_token, version="default")
-        if default_package is None:
-            return None
-        return SchemaResolution(
-            provider=provider_token,
-            package_version=default_package.version,
-            element_kind=default_package.default_element_kind,
-            exact_structure_id=unit.exact_structure_id,
-            bundle_scope=bundle_scope,
-            reason="package_default",
-        )
-
-    def _resolve_by_bundle_scope(
-        self,
-        packages: list[SchemaVersionPackage],
-        artifact_kind: str,
-        bundle_scope: str | None,
-        provider: str,
-        exact_structure_id: str | None,
-    ) -> SchemaResolution | None:
-        if bundle_scope is None:
-            return None
-        for package in packages:
-            if bundle_scope not in package.bundle_scopes:
-                continue
-            element = package.element(artifact_kind)
-            if element is None:
-                continue
-            return SchemaResolution(
-                provider=provider,
-                package_version=package.version,
-                element_kind=element.element_kind,
-                exact_structure_id=exact_structure_id,
-                bundle_scope=bundle_scope,
-                reason="bundle_scope",
-            )
-        return None
-
-    def _resolve_by_exact_structure(
-        self,
-        packages: list[SchemaVersionPackage],
-        artifact_kind: str,
-        exact_structure_id: str | None,
-        bundle_scope: str | None,
-        provider: str,
-    ) -> SchemaResolution | None:
-        for package in packages:
-            element = package.element(artifact_kind)
-            if element is None:
-                continue
-            if exact_structure_id in element.exact_structure_ids:
-                return SchemaResolution(
-                    provider=provider,
-                    package_version=package.version,
-                    element_kind=element.element_kind,
-                    exact_structure_id=exact_structure_id,
-                    bundle_scope=bundle_scope,
-                    reason="exact_structure",
-                )
-        return None
-
-    def _resolve_by_profile_similarity(
-        self,
-        packages: list[SchemaVersionPackage],
-        artifact_kind: str,
-        profile_tokens: Sequence[str],
-        exact_structure_id: str | None,
-        bundle_scope: str | None,
-        provider: str,
-    ) -> SchemaResolution | None:
-        best_match: tuple[float, SchemaVersionPackage, SchemaElementManifest] | None = None
-        observed_profile_tokens = set(profile_tokens)
-        for package in packages:
-            element = package.element(artifact_kind)
-            if element is None or not element.profile_tokens:
-                continue
-            score = profile_similarity(set(element.profile_tokens), observed_profile_tokens)
-            if best_match is None or score > best_match[0]:
-                best_match = (score, package, element)
-        if best_match is None or best_match[0] <= 0.0:
-            return None
-        _score, package, element = best_match
-        return SchemaResolution(
-            provider=provider,
-            package_version=package.version,
-            element_kind=element.element_kind,
-            exact_structure_id=exact_structure_id,
-            bundle_scope=bundle_scope,
-            reason="profile_family",
+            observations=observations,
+            source_path=source_path,
         )
 
     def match_payload_version(

--- a/polylogue/schemas/unified.py
+++ b/polylogue/schemas/unified.py
@@ -47,6 +47,7 @@ from polylogue.schemas.unified_provider_meta import (
     harmonize_parsed_message,
     is_message_record,
 )
+from polylogue.schemas.validator_resolution import resolve_payload_schema
 from polylogue.types import Provider
 
 logger = logging.getLogger(__name__)
@@ -76,20 +77,11 @@ def try_schema_extraction(provider: Provider | str, raw: JSONDocument) -> Harmon
     p = provider if isinstance(provider, Provider) else Provider.from_string(provider)
     try:
         from polylogue.schemas.extraction import extract_message_from_schema
-        from polylogue.schemas.runtime_registry import SchemaRegistry
 
-        registry = SchemaRegistry()
-        resolution = registry.resolve_payload(str(p), raw)
-        if resolution is None:
-            return None
-        schema = registry.get_element_schema(
-            resolution.provider,
-            version=resolution.package_version,
-            element_kind=resolution.element_kind,
-        )
-        if schema is None:
-            return None
+        _, schema, _ = resolve_payload_schema(p, raw)
         return extract_message_from_schema(raw, schema=schema, provider=p)
+    except FileNotFoundError:
+        return None
     except Exception:
         return None
 

--- a/polylogue/schemas/validator_resolution.py
+++ b/polylogue/schemas/validator_resolution.py
@@ -34,7 +34,7 @@ def _load_package(
 ) -> SchemaVersionPackage:
     package = registry.get_package(str(provider), version=version)
     if package is None:
-        raise FileNotFoundError(f"No schema package found for provider: {provider} (version: {version})")
+        raise FileNotFoundError(f"No schema found for provider: {provider} (version: {version})")
     return package
 
 
@@ -57,6 +57,20 @@ def _load_schema(
     return schema
 
 
+def _load_latest_schema(
+    registry: object,
+    provider: Provider,
+) -> JSONDocument | None:
+    get_schema = getattr(registry, "get_schema", None)
+    if not callable(get_schema):
+        return None
+    latest_schema = get_schema(str(provider), version="latest")
+    if isinstance(latest_schema, dict):
+        return latest_schema
+    default_schema = get_schema(str(provider), version="default")
+    return default_schema if isinstance(default_schema, dict) else None
+
+
 def reset_registry_cache() -> None:
     """Clear shared runtime-registry instances used by schema validation."""
     _shared_registry.cache_clear()
@@ -74,6 +88,11 @@ def resolve_provider_schema(
 ) -> tuple[Provider, JSONDocument, tuple[str, str, str]]:
     canonical = canonical_provider(provider)
     registry = _registry_for(registry_cls)
+    if not hasattr(registry, "get_package"):
+        schema = _load_latest_schema(registry, canonical)
+        if schema is None:
+            raise FileNotFoundError(f"No schema found for provider: {canonical}")
+        return canonical, schema, (str(canonical), "latest", "conversation_document")
     package = _load_package(registry, canonical, version="default")
     package_version = package.version
     element_kind = package.default_element_kind

--- a/polylogue/schemas/validator_resolution.py
+++ b/polylogue/schemas/validator_resolution.py
@@ -12,7 +12,7 @@ from polylogue.schemas.runtime_registry import SchemaRegistry, canonical_schema_
 from polylogue.types import Provider
 
 if TYPE_CHECKING:
-    from polylogue.schemas.packages import SchemaResolution
+    from polylogue.schemas.packages import SchemaResolution, SchemaVersionPackage
 
 
 @lru_cache(maxsize=8)
@@ -24,6 +24,37 @@ def _registry_for(registry_cls: type[SchemaRegistry]) -> SchemaRegistry:
     if registry_cls is SchemaRegistry:
         return _shared_registry(str(data_home() / "schemas"))
     return registry_cls()
+
+
+def _load_package(
+    registry: SchemaRegistry,
+    provider: Provider,
+    *,
+    version: str,
+) -> SchemaVersionPackage:
+    package = registry.get_package(str(provider), version=version)
+    if package is None:
+        raise FileNotFoundError(f"No schema package found for provider: {provider} (version: {version})")
+    return package
+
+
+def _load_schema(
+    registry: SchemaRegistry,
+    provider: Provider,
+    *,
+    package_version: str,
+    element_kind: str,
+) -> JSONDocument:
+    schema = registry.get_element_schema(
+        str(provider),
+        version=package_version,
+        element_kind=element_kind,
+    )
+    if schema is None:
+        raise FileNotFoundError(
+            f"No schema found for provider: {provider} (package: {package_version}, element: {element_kind})"
+        )
+    return schema
 
 
 def reset_registry_cache() -> None:
@@ -43,20 +74,15 @@ def resolve_provider_schema(
 ) -> tuple[Provider, JSONDocument, tuple[str, str, str]]:
     canonical = canonical_provider(provider)
     registry = _registry_for(registry_cls)
-    package = registry.get_package(str(canonical), version="default") if hasattr(registry, "get_package") else None
-    package_version = package.version if package is not None else "latest"
-    element_kind = package.default_element_kind if package is not None else "default"
-
-    if package is not None and hasattr(registry, "get_element_schema"):
-        schema = registry.get_element_schema(
-            str(canonical),
-            version=package.version,
-            element_kind=package.default_element_kind,
-        )
-    else:
-        schema = registry.get_schema(str(canonical), version="latest")
-    if schema is None:
-        raise FileNotFoundError(f"No schema found for provider: {provider} (canonical: {canonical})")
+    package = _load_package(registry, canonical, version="default")
+    package_version = package.version
+    element_kind = package.default_element_kind
+    schema = _load_schema(
+        registry,
+        canonical,
+        package_version=package_version,
+        element_kind=element_kind,
+    )
     return canonical, schema, (str(canonical), package_version, element_kind)
 
 
@@ -72,31 +98,26 @@ def resolve_payload_schema(
     registry = _registry_for(registry_cls)
     resolution = schema_resolution
     if resolution is None:
-        resolution = (
-            registry.resolve_payload(
-                str(canonical),
-                payload,
-                source_path=source_path,
-            )
-            if hasattr(registry, "resolve_payload")
-            else None
-        )
-    package_version = resolution.package_version if resolution is not None else "latest"
-    element_kind = resolution.element_kind if resolution is not None else "default"
-
-    if hasattr(registry, "get_element_schema"):
-        schema = registry.get_element_schema(
+        resolution = registry.resolve_payload(
             str(canonical),
-            version=package_version,
-            element_kind=None if element_kind == "default" else element_kind,
+            payload,
+            source_path=source_path,
         )
+
+    if resolution is None:
+        package = _load_package(registry, canonical, version="default")
+        package_version = package.version
+        element_kind = package.default_element_kind
     else:
-        schema = registry.get_schema(str(canonical), version=package_version)
-    if schema is None:
-        raise FileNotFoundError(
-            "No schema found for provider: "
-            f"{provider} (canonical: {canonical}, package: {package_version}, element: {element_kind})"
-        )
+        package_version = resolution.package_version
+        element_kind = resolution.element_kind
+
+    schema = _load_schema(
+        registry,
+        canonical,
+        package_version=package_version,
+        element_kind=element_kind,
+    )
     return canonical, schema, (str(canonical), package_version, element_kind)
 
 

--- a/polylogue/sources/dispatch.py
+++ b/polylogue/sources/dispatch.py
@@ -22,18 +22,20 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
+BUNDLE_PROVIDERS = frozenset({Provider.CHATGPT, Provider.CLAUDE_AI})
 GROUP_PROVIDERS = frozenset({Provider.CLAUDE_CODE, Provider.CODEX, Provider.GEMINI, Provider.DRIVE})
 STREAM_RECORD_PROVIDERS = frozenset({Provider.CLAUDE_CODE, Provider.CODEX})
+DRIVE_LIKE_PROVIDERS = frozenset({Provider.GEMINI, Provider.DRIVE})
 _MAX_PARSE_DEPTH = 10
 
 PayloadRecord: TypeAlias = JSONDocument
 PayloadSequence: TypeAlias = list[JSONValue]
 LoweredPayloadMode: TypeAlias = Literal[
-    "single_record",
     "bundle_record",
-    "grouped_records",
     "chunked_prompt",
     "generic_messages",
+    "grouped_records",
+    "single_record",
 ]
 
 
@@ -49,7 +51,7 @@ def _payload_record(value: object) -> PayloadRecord | None:
     return value if is_json_document(value) else None
 
 
-def _payload_list(value: object) -> PayloadSequence | None:
+def _payload_sequence(value: object) -> PayloadSequence | None:
     if not isinstance(value, list):
         return None
     payloads: list[JSONValue] = []
@@ -60,12 +62,12 @@ def _payload_list(value: object) -> PayloadSequence | None:
     return payloads
 
 
-def _payload_messages(record: PayloadRecord) -> list[JSONValue] | None:
+def _record_messages(record: PayloadRecord) -> list[JSONValue] | None:
     messages = record.get("messages")
     return messages if isinstance(messages, list) else None
 
 
-def _payload_conversations(record: PayloadRecord) -> list[JSONValue] | None:
+def _record_conversations(record: PayloadRecord) -> list[JSONValue] | None:
     conversations = record.get("conversations")
     return conversations if isinstance(conversations, list) else None
 
@@ -74,7 +76,7 @@ def _looks_like_gemini_mapping(record: PayloadRecord) -> bool:
     return "chunkedPrompt" in record or isinstance(record.get("chunks"), list)
 
 
-def _detect_provider_from_mapping(record: PayloadRecord) -> Provider | None:
+def _detect_provider_from_record(record: PayloadRecord) -> Provider | None:
     if chatgpt.looks_like(record):
         return Provider.CHATGPT
     if claude.looks_like_ai(record):
@@ -100,9 +102,10 @@ def _detect_provider_from_sequence(payloads: PayloadSequence) -> Provider | None
             return Provider.CLAUDE_AI
         if _looks_like_gemini_mapping(first_record):
             return Provider.GEMINI
-    if claude.looks_like_code(payloads):
+
+    if claude.looks_like_code(cast(list[object], payloads)):
         return Provider.CLAUDE_CODE
-    if codex.looks_like(payloads):
+    if codex.looks_like(cast(list[object], payloads)):
         return Provider.CODEX
     return None
 
@@ -112,8 +115,8 @@ def detect_provider(payload: object, path: object | None = None) -> Provider | N
     del path
 
     if record := _payload_record(payload):
-        return _detect_provider_from_mapping(record)
-    payloads = _payload_list(payload)
+        return _detect_provider_from_record(record)
+    payloads = _payload_sequence(payload)
     return _detect_provider_from_sequence(payloads) if payloads is not None else None
 
 
@@ -141,15 +144,6 @@ def _detect_provider_from_raw_bytes(
     return detect_provider(payloads) or fallback_provider
 
 
-def _looks_like_chunked_conversation(payload: object) -> bool:
-    record = _payload_record(payload)
-    return record is not None and (drive.looks_like(record) or isinstance(record.get("chunks"), list))
-
-
-def _looks_like_chunked_conversation_list(payload: PayloadSequence) -> bool:
-    return bool(payload) and all(_looks_like_chunked_conversation(item) for item in payload)
-
-
 def _schema_guided_payload(
     provider: Provider,
     payload: object,
@@ -160,71 +154,139 @@ def _schema_guided_payload(
         return payload
     if schema_resolution.element_kind not in {"conversation_record_stream", "subagent_conversation_stream"}:
         return payload
-    if provider in (Provider.CLAUDE_CODE, Provider.CODEX) and (record := _payload_record(payload)):
-        messages = _payload_messages(record)
-        if messages is not None:
-            return messages
-        return [record]
-    return payload
+    if provider not in {Provider.CLAUDE_CODE, Provider.CODEX}:
+        return payload
+
+    record = _payload_record(payload)
+    if record is None:
+        return payload
+
+    messages = _record_messages(record)
+    if messages is not None:
+        return messages
+    return [record]
 
 
-def _lower_bundle_specs(
+def _looks_like_chunked_conversation(payload: object) -> bool:
+    record = _payload_record(payload)
+    return record is not None and (drive.looks_like(record) or isinstance(record.get("chunks"), list))
+
+
+def _looks_like_chunked_conversation_list(payloads: PayloadSequence) -> bool:
+    return bool(payloads) and all(_looks_like_chunked_conversation(item) for item in payloads)
+
+
+def _single_record_spec(provider: Provider, payload: PayloadRecord, fallback_id: str) -> LoweredPayloadSpec:
+    return LoweredPayloadSpec(
+        provider=provider,
+        fallback_id=fallback_id,
+        mode="single_record",
+        payload=payload,
+    )
+
+
+def _chunked_prompt_spec(
+    provider: Provider,
+    payload: PayloadRecord | PayloadSequence,
+    fallback_id: str,
+) -> LoweredPayloadSpec:
+    return LoweredPayloadSpec(
+        provider=provider,
+        fallback_id=fallback_id,
+        mode="chunked_prompt",
+        payload=payload,
+    )
+
+
+def _generic_messages_spec(
+    provider: Provider,
+    payload: PayloadRecord,
+    fallback_id: str,
+) -> LoweredPayloadSpec:
+    return LoweredPayloadSpec(
+        provider=provider,
+        fallback_id=fallback_id,
+        mode="generic_messages",
+        payload=payload,
+    )
+
+
+def _grouped_records_spec(
+    provider: Provider,
+    payload: PayloadRecord | PayloadSequence,
+    fallback_id: str,
+) -> LoweredPayloadSpec:
+    return LoweredPayloadSpec(
+        provider=provider,
+        fallback_id=fallback_id,
+        mode="grouped_records",
+        payload=payload,
+    )
+
+
+def _bundle_record_specs(
     provider: Provider,
     payloads: PayloadSequence,
     fallback_id: str,
 ) -> list[LoweredPayloadSpec]:
-    specs: list[LoweredPayloadSpec] = []
-    for index, item in enumerate(payloads):
-        if record := _payload_record(item):
-            specs.append(
-                LoweredPayloadSpec(
-                    provider=provider,
-                    fallback_id=f"{fallback_id}-{index}",
-                    mode="bundle_record",
-                    payload=record,
-                )
-            )
-    return specs
-
-
-def _lower_grouped_spec(
-    provider: Provider,
-    payload: object,
-    fallback_id: str,
-) -> list[LoweredPayloadSpec]:
-    payloads = _payload_list(payload)
-    if payloads is not None:
-        return [
-            LoweredPayloadSpec(provider=provider, fallback_id=fallback_id, mode="grouped_records", payload=payloads)
-        ]
-
-    record = _payload_record(payload)
-    if record is None:
-        return []
-
-    messages = _payload_messages(record)
-    grouped_payload = messages if messages is not None else [record]
     return [
-        LoweredPayloadSpec(provider=provider, fallback_id=fallback_id, mode="grouped_records", payload=grouped_payload)
+        LoweredPayloadSpec(
+            provider=provider,
+            fallback_id=f"{fallback_id}-{index}",
+            mode="bundle_record",
+            payload=record,
+        )
+        for index, item in enumerate(payloads)
+        if (record := _payload_record(item)) is not None
     ]
 
 
-def _lower_drive_like_specs(
-    runtime_provider: Provider,
-    payload: object,
+def _lower_bundle_payload(
+    provider: Provider,
+    shaped_payload: object,
+    fallback_id: str,
+) -> list[LoweredPayloadSpec]:
+    payloads = _payload_sequence(shaped_payload)
+    if payloads is not None:
+        return _bundle_record_specs(provider, payloads, fallback_id)
+    record = _payload_record(shaped_payload)
+    return [_single_record_spec(provider, record, fallback_id)] if record is not None else []
+
+
+def _lower_grouped_payload(
+    provider: Provider,
+    shaped_payload: object,
+    fallback_id: str,
+) -> list[LoweredPayloadSpec]:
+    payloads = _payload_sequence(shaped_payload)
+    if payloads is not None:
+        return [_grouped_records_spec(provider, payloads, fallback_id)]
+
+    record = _payload_record(shaped_payload)
+    if record is None:
+        return []
+
+    messages = _record_messages(record)
+    grouped_payload = messages if messages is not None else [record]
+    return [_grouped_records_spec(provider, grouped_payload, fallback_id)]
+
+
+def _lower_drive_like_payload(
+    provider: Provider,
+    shaped_payload: object,
     fallback_id: str,
     *,
     depth: int,
     schema_resolution: SchemaResolution | None,
 ) -> list[LoweredPayloadSpec]:
-    payloads = _payload_list(payload)
+    payloads = _payload_sequence(shaped_payload)
     if payloads is not None:
         if _looks_like_chunked_conversation_list(payloads):
             nested_specs: list[LoweredPayloadSpec] = []
             for index, item in enumerate(payloads):
                 nested_specs.extend(
                     _lower_payload_specs(
-                        runtime_provider,
+                        provider,
                         item,
                         f"{fallback_id}-{index}",
                         depth=depth + 1,
@@ -232,46 +294,34 @@ def _lower_drive_like_specs(
                     )
                 )
             return nested_specs
-        return [
-            LoweredPayloadSpec(
-                provider=runtime_provider,
-                fallback_id=fallback_id,
-                mode="chunked_prompt",
-                payload=payloads,
-            )
-        ]
+        return [_chunked_prompt_spec(provider, payloads, fallback_id)]
 
-    record = _payload_record(payload)
+    record = _payload_record(shaped_payload)
     if record is None:
         return []
-
-    if _payload_messages(record) is not None:
-        return [
-            LoweredPayloadSpec(
-                provider=runtime_provider,
-                fallback_id=fallback_id,
-                mode="generic_messages",
-                payload=record,
-            )
-        ]
+    if _record_messages(record) is not None:
+        return [_generic_messages_spec(provider, record, fallback_id)]
     if chatgpt.looks_like(record):
-        return [
-            LoweredPayloadSpec(
-                provider=Provider.CHATGPT,
-                fallback_id=fallback_id,
-                mode="single_record",
-                payload=record,
-            )
-        ]
+        return [_single_record_spec(Provider.CHATGPT, record, fallback_id)]
     if _looks_like_chunked_conversation(record):
-        return [
-            LoweredPayloadSpec(
-                provider=runtime_provider,
-                fallback_id=fallback_id,
-                mode="chunked_prompt",
-                payload=record,
-            )
-        ]
+        return [_chunked_prompt_spec(provider, record, fallback_id)]
+    return []
+
+
+def _lower_fallback_payload(
+    provider: Provider,
+    shaped_payload: object,
+    fallback_id: str,
+) -> list[LoweredPayloadSpec]:
+    record = _payload_record(shaped_payload)
+    if record is None:
+        return []
+    if _record_messages(record) is not None:
+        return [_generic_messages_spec(provider, record, fallback_id)]
+    if chatgpt.looks_like(record):
+        return [_single_record_spec(Provider.CHATGPT, record, fallback_id)]
+    if _looks_like_chunked_conversation(record):
+        return [_chunked_prompt_spec(provider, record, fallback_id)]
     return []
 
 
@@ -290,7 +340,7 @@ def _lower_payload_specs(
 
     shaped_payload = _schema_guided_payload(runtime_provider, payload, schema_resolution)
     record = _payload_record(shaped_payload)
-    if record is not None and (conversations := _payload_conversations(record)):
+    if record is not None and (conversations := _record_conversations(record)):
         lowered_specs: list[LoweredPayloadSpec] = []
         for index, item in enumerate(conversations):
             if item_record := _payload_record(item):
@@ -305,77 +355,19 @@ def _lower_payload_specs(
                 )
         return lowered_specs
 
-    payloads = _payload_list(shaped_payload)
-
-    if runtime_provider is Provider.CHATGPT:
-        if payloads is not None:
-            return _lower_bundle_specs(runtime_provider, payloads, fallback_id)
-        return (
-            [
-                LoweredPayloadSpec(
-                    provider=runtime_provider, fallback_id=fallback_id, mode="single_record", payload=record
-                )
-            ]
-            if record is not None
-            else []
-        )
-
-    if runtime_provider is Provider.CLAUDE_AI:
-        if payloads is not None:
-            return _lower_bundle_specs(runtime_provider, payloads, fallback_id)
-        return (
-            [
-                LoweredPayloadSpec(
-                    provider=runtime_provider, fallback_id=fallback_id, mode="single_record", payload=record
-                )
-            ]
-            if record is not None
-            else []
-        )
-
-    if runtime_provider is Provider.CLAUDE_CODE:
-        return _lower_grouped_spec(runtime_provider, shaped_payload, fallback_id)
-
-    if runtime_provider is Provider.CODEX:
-        return _lower_grouped_spec(runtime_provider, shaped_payload, fallback_id)
-
-    if runtime_provider in (Provider.GEMINI, Provider.DRIVE):
-        return _lower_drive_like_specs(
+    if runtime_provider in BUNDLE_PROVIDERS:
+        return _lower_bundle_payload(runtime_provider, shaped_payload, fallback_id)
+    if runtime_provider in {Provider.CLAUDE_CODE, Provider.CODEX}:
+        return _lower_grouped_payload(runtime_provider, shaped_payload, fallback_id)
+    if runtime_provider in DRIVE_LIKE_PROVIDERS:
+        return _lower_drive_like_payload(
             runtime_provider,
             shaped_payload,
             fallback_id,
             depth=depth,
             schema_resolution=schema_resolution,
         )
-
-    if record is not None and _payload_messages(record) is not None:
-        return [
-            LoweredPayloadSpec(
-                provider=runtime_provider,
-                fallback_id=fallback_id,
-                mode="generic_messages",
-                payload=record,
-            )
-        ]
-    if record is not None and chatgpt.looks_like(record):
-        return [
-            LoweredPayloadSpec(
-                provider=Provider.CHATGPT,
-                fallback_id=fallback_id,
-                mode="single_record",
-                payload=record,
-            )
-        ]
-    if record is not None and _looks_like_chunked_conversation(record):
-        return [
-            LoweredPayloadSpec(
-                provider=runtime_provider,
-                fallback_id=fallback_id,
-                mode="chunked_prompt",
-                payload=record,
-            )
-        ]
-    return []
+    return _lower_fallback_payload(runtime_provider, shaped_payload, fallback_id)
 
 
 def _generic_messages_conversation(
@@ -383,7 +375,7 @@ def _generic_messages_conversation(
     payload: PayloadRecord,
     fallback_id: str,
 ) -> ParsedConversation | None:
-    messages_payload = _payload_messages(payload)
+    messages_payload = _record_messages(payload)
     if messages_payload is None:
         return None
 
@@ -410,16 +402,16 @@ def _parse_lowered_spec(spec: LoweredPayloadSpec) -> list[ParsedConversation]:
         return [claude.parse_ai(record, spec.fallback_id)] if record is not None else []
 
     if spec.provider is Provider.CLAUDE_CODE:
-        payloads = _payload_list(spec.payload)
+        payloads = _payload_sequence(spec.payload)
         return [claude.parse_code(cast(list[object], payloads), spec.fallback_id)] if payloads is not None else []
 
     if spec.provider is Provider.CODEX:
-        payloads = _payload_list(spec.payload)
+        payloads = _payload_sequence(spec.payload)
         return [codex.parse(cast(list[object], payloads), spec.fallback_id)] if payloads is not None else []
 
     if spec.mode == "chunked_prompt":
         record = _payload_record(spec.payload)
-        payload = record if record is not None else {"chunks": _payload_list(spec.payload) or []}
+        payload = record if record is not None else {"chunks": _payload_sequence(spec.payload) or []}
         return [drive.parse_chunked_prompt(spec.provider, payload, spec.fallback_id)]
 
     if spec.mode == "generic_messages":
@@ -474,29 +466,36 @@ def parse_drive_payload(
     fallback_id: str,
     _depth: int = 0,
 ) -> list[ParsedConversation]:
+    """Compatibility wrapper for Drive/Gemini payload parsing."""
     runtime_provider = Provider.from_string(provider)
     if _depth > _MAX_PARSE_DEPTH:
         logger.warning("Recursion depth exceeded parsing drive payload %s", fallback_id)
         return []
 
-    payloads = _payload_list(payload)
+    payloads = _payload_sequence(payload)
     if payloads is not None:
         if payloads and all(isinstance(item, str) or _payload_record(item) is not None for item in payloads):
             first_record = _payload_record(payloads[0]) if payloads else None
             if first_record is None or "role" in first_record or "text" in first_record:
-                spec = LoweredPayloadSpec(
-                    provider=runtime_provider,
-                    fallback_id=fallback_id,
-                    mode="chunked_prompt",
-                    payload=payloads,
-                )
+                spec = _chunked_prompt_spec(runtime_provider, payloads, fallback_id)
                 return _parse_lowered_spec(spec)
 
         nested_conversations: list[ParsedConversation] = []
         for index, item in enumerate(payloads):
+            if _looks_like_chunked_conversation(item):
+                nested_conversations.extend(
+                    parse_drive_payload(
+                        runtime_provider,
+                        item,
+                        f"{fallback_id}-{index}",
+                        _depth + 1,
+                    )
+                )
+                continue
+            detected = detect_provider(item) or runtime_provider
             nested_conversations.extend(
-                parse_drive_payload(
-                    runtime_provider,
+                parse_payload(
+                    detected,
                     item,
                     f"{fallback_id}-{index}",
                     _depth + 1,
@@ -504,25 +503,21 @@ def parse_drive_payload(
             )
         return nested_conversations
 
-    if record := _payload_record(payload):
-        if "chunkedPrompt" in record or "chunks" in record:
-            spec = LoweredPayloadSpec(
-                provider=runtime_provider,
-                fallback_id=fallback_id,
-                mode="chunked_prompt",
-                payload=record,
-            )
-            return _parse_lowered_spec(spec)
+    record = _payload_record(payload)
+    if record is None:
+        return []
+    if "chunkedPrompt" in record or "chunks" in record:
+        spec = _chunked_prompt_spec(runtime_provider, record, fallback_id)
+        return _parse_lowered_spec(spec)
 
-        detected = detect_provider(record) or runtime_provider
-        return parse_payload(detected, record, fallback_id, _depth + 1)
-
-    return []
+    detected = detect_provider(record) or runtime_provider
+    return parse_payload(detected, record, fallback_id, _depth + 1)
 
 
 __all__ = [
     "GROUP_PROVIDERS",
     "STREAM_RECORD_PROVIDERS",
+    "LoweredPayloadSpec",
     "_detect_provider_from_raw_bytes",
     "detect_provider",
     "parse_drive_payload",

--- a/polylogue/sources/drive.py
+++ b/polylogue/sources/drive.py
@@ -13,7 +13,7 @@ from ..config import Source
 from ..paths import safe_path_component
 from .dispatch import parse_drive_payload
 from .drive_source import DriveSourceAPI, _parse_modified_time, build_drive_source_client
-from .drive_types import DriveConfigLike, DriveUILike
+from .drive_types import DriveConfigLike, DriveFile, DriveUILike
 from .parsers.base import ParsedConversation, RawConversationData
 
 logger = get_logger(__name__)
@@ -26,6 +26,50 @@ class DriveDownloadResult:
     downloaded_files: list[Path]
     failed_files: list[dict[str, str | int]]
     total_files: int
+
+
+@dataclass(slots=True)
+class _DriveCursorTracker:
+    cursor_state: CursorStatePayload | None
+
+    def _record_latest_file(self, file_meta: DriveFile) -> None:
+        if self.cursor_state is None or not file_meta.modified_time:
+            return
+        modified_timestamp = _parse_modified_time(file_meta.modified_time)
+        last_timestamp = self.cursor_state.get("latest_mtime")
+        if modified_timestamp is None or (last_timestamp is not None and modified_timestamp <= last_timestamp):
+            return
+        self.cursor_state["latest_mtime"] = modified_timestamp
+        self.cursor_state["latest_file_id"] = file_meta.file_id
+        self.cursor_state["latest_file_name"] = file_meta.name
+
+    def observe_file(self, file_meta: DriveFile) -> None:
+        if self.cursor_state is None:
+            return
+        self.cursor_state["file_count"] = self.cursor_state.get("file_count", 0) + 1
+        self._record_latest_file(file_meta)
+
+    def record_failure(self, *, file_name: str, error: Exception) -> None:
+        if self.cursor_state is None:
+            return
+        self.cursor_state["error_count"] = self.cursor_state.get("error_count", 0) + 1
+        self.cursor_state["latest_error"] = str(error)
+        self.cursor_state["latest_error_file"] = file_name
+
+
+def _cursor_tracker(cursor_state: CursorStatePayload | None) -> _DriveCursorTracker:
+    if cursor_state is not None:
+        cursor_state.setdefault("file_count", 0)
+    return _DriveCursorTracker(cursor_state)
+
+
+def _resolved_drive_client(
+    *,
+    ui: DriveUILike | None,
+    client: DriveSourceAPI | None,
+    drive_config: DriveConfigLike | None,
+) -> DriveSourceAPI:
+    return client or build_drive_source_client(ui=ui, config=drive_config)
 
 
 def drive_cache_file_path(dest_dir: Path, name: str) -> Path:
@@ -127,27 +171,15 @@ def iter_drive_conversations(
 ) -> Iterable[ParsedConversation]:
     if not source.folder:
         return
-    drive_client = client or build_drive_source_client(ui=ui, config=drive_config)
+    drive_client = _resolved_drive_client(ui=ui, client=client, drive_config=drive_config)
     folder_id = drive_client.resolve_folder_id(source.folder)
-    if cursor_state is not None:
-        cursor_state.setdefault("file_count", 0)
+    tracker = _cursor_tracker(cursor_state)
     for file_meta in drive_client.iter_json_files(folder_id):
-        if cursor_state is not None:
-            cursor_state["file_count"] = cursor_state.get("file_count", 0) + 1
-            if file_meta.modified_time:
-                ts = _parse_modified_time(file_meta.modified_time)
-                last_ts = cursor_state.get("latest_mtime")
-                if ts is not None and (last_ts is None or ts > last_ts):
-                    cursor_state["latest_mtime"] = ts
-                    cursor_state["latest_file_id"] = file_meta.file_id
-                    cursor_state["latest_file_name"] = file_meta.name
+        tracker.observe_file(file_meta)
         try:
             payload = drive_client.download_json_payload(file_meta.file_id, name=file_meta.name)
         except Exception as exc:
-            if cursor_state is not None:
-                cursor_state["error_count"] = cursor_state.get("error_count", 0) + 1
-                cursor_state["latest_error"] = str(exc)
-                cursor_state["latest_error_file"] = file_meta.name
+            tracker.record_failure(file_name=file_meta.name, error=exc)
             logger.warning(
                 "Failed to download Drive payload for %s (%s): %s",
                 file_meta.name,
@@ -185,23 +217,14 @@ def iter_drive_raw_data(
     if not source.folder:
         return
 
-    drive_client = client or build_drive_source_client(ui=ui, config=drive_config)
+    drive_client = _resolved_drive_client(ui=ui, client=client, drive_config=drive_config)
     folder_id = drive_client.resolve_folder_id(source.folder)
-    if cursor_state is not None:
-        cursor_state.setdefault("file_count", 0)
+    tracker = _cursor_tracker(cursor_state)
 
     for file_meta in drive_client.iter_json_files(folder_id):
         dest_path = drive_cache_file_path(source.path or Path(source.name), file_meta.name)
         source_path = str(dest_path)
-        if cursor_state is not None:
-            cursor_state["file_count"] = cursor_state.get("file_count", 0) + 1
-            if file_meta.modified_time:
-                ts = _parse_modified_time(file_meta.modified_time)
-                last_ts = cursor_state.get("latest_mtime")
-                if ts is not None and (last_ts is None or ts > last_ts):
-                    cursor_state["latest_mtime"] = ts
-                    cursor_state["latest_file_id"] = file_meta.file_id
-                    cursor_state["latest_file_name"] = file_meta.name
+        tracker.observe_file(file_meta)
 
         if (
             known_mtimes is not None
@@ -226,10 +249,7 @@ def iter_drive_raw_data(
             try:
                 raw_bytes = drive_client.download_bytes(file_meta.file_id)
             except Exception as exc:
-                if cursor_state is not None:
-                    cursor_state["error_count"] = cursor_state.get("error_count", 0) + 1
-                    cursor_state["latest_error"] = str(exc)
-                    cursor_state["latest_error_file"] = file_meta.name
+                tracker.record_failure(file_name=file_meta.name, error=exc)
                 logger.warning(
                     "Failed to download Drive payload for %s (%s): %s",
                     file_meta.name,

--- a/polylogue/sources/drive_gateway.py
+++ b/polylogue/sources/drive_gateway.py
@@ -21,6 +21,7 @@ from .drive_types import (
     DriveConfigLike,
     DriveCredentialLike,
     DriveNotFoundError,
+    DriveRetryPolicy,
 )
 from .drive_types import DriveError as DriveServiceError
 
@@ -121,6 +122,18 @@ def _resolve_retry_base(value: float | None) -> float:
     return DEFAULT_DRIVE_RETRY_BASE
 
 
+def resolve_drive_retry_policy(
+    *,
+    retries: int | None,
+    retry_base: float | None,
+    config: DriveConfigLike | None = None,
+) -> DriveRetryPolicy:
+    return DriveRetryPolicy(
+        retries=_resolve_retries(retries, config),
+        retry_base=_resolve_retry_base(retry_base),
+    )
+
+
 class DriveServiceGateway:
     """Owns Google API imports, service construction, raw Drive calls, and retry policy."""
 
@@ -128,20 +141,22 @@ class DriveServiceGateway:
         self,
         *,
         auth_manager: _DriveAuthManagerLike,
-        retries: int,
-        retry_base: float,
+        retry_policy: DriveRetryPolicy,
     ) -> None:
         self._auth_manager = auth_manager
-        self._retries = retries
-        self._retry_base = retry_base
+        self._retry_policy = retry_policy
         self._service: _DriveService | None = None
 
     def call_with_retry(self, func: Callable[P, T], *args: P.args, **kwargs: P.kwargs) -> T:
         from tenacity import Retrying
 
         retryer = Retrying(
-            stop=stop_after_attempt(max(self._retries, 0) + 1),
-            wait=wait_exponential(multiplier=self._retry_base, min=self._retry_base, max=10),
+            stop=stop_after_attempt(max(self._retry_policy.retries, 0) + 1),
+            wait=wait_exponential(
+                multiplier=self._retry_policy.retry_base,
+                min=self._retry_policy.retry_base,
+                max=10,
+            ),
             retry=retry_if_exception_type(Exception)
             & retry_if_not_exception_type((DriveAuthError, DriveNotFoundError)),
             reraise=True,
@@ -223,4 +238,5 @@ __all__ = [
     "_import_module",
     "_resolve_retries",
     "_resolve_retry_base",
+    "resolve_drive_retry_policy",
 ]

--- a/polylogue/sources/drive_source.py
+++ b/polylogue/sources/drive_source.py
@@ -5,8 +5,7 @@ from .drive_gateway import (
     DEFAULT_DRIVE_RETRIES,
     DEFAULT_DRIVE_RETRY_BASE,
     _import_module,
-    _resolve_retries,
-    _resolve_retry_base,
+    resolve_drive_retry_policy,
 )
 from .drive_source_client import DriveSourceClient
 from .drive_source_factory import build_drive_source_client
@@ -39,6 +38,5 @@ __all__ = [
     "_parse_downloaded_json_payload",
     "_parse_modified_time",
     "_parse_size",
-    "_resolve_retries",
-    "_resolve_retry_base",
+    "resolve_drive_retry_policy",
 ]

--- a/polylogue/sources/drive_source_client.py
+++ b/polylogue/sources/drive_source_client.py
@@ -11,16 +11,18 @@ from typing import BinaryIO, cast
 from polylogue.lib.json import JSONDocument, JSONValue
 from polylogue.logging import get_logger
 
-from .drive_gateway import DriveListFilesResponse, DrivePayloadRecord, DriveServiceGateway
+from .drive_gateway import DriveServiceGateway
 from .drive_source_support import (
     _build_drive_file,
     _build_folder_lookup_query,
     _is_supported_drive_payload,
-    _json_sequence,
     _looks_like_id,
     _needs_download,
     _parse_downloaded_json_payload,
     _parse_modified_time,
+    _record_string,
+    _response_files,
+    _response_page_token,
 )
 from .drive_types import (
     FOLDER_MIME_TYPE,
@@ -34,28 +36,14 @@ logger = get_logger(__name__)
 class DriveSourceClient:
     """Owns Polylogue-specific Drive source semantics."""
 
-    @staticmethod
-    def _record_string(record: DrivePayloadRecord, key: str, *, default: str = "") -> str:
-        value = record.get(key)
-        return value if isinstance(value, str) else default
-
-    @staticmethod
-    def _response_files(response: DriveListFilesResponse) -> list[JSONValue]:
-        return _json_sequence(response.get("files"))
-
-    @staticmethod
-    def _response_page_token(response: DriveListFilesResponse) -> str | None:
-        token = response.get("nextPageToken")
-        return token if isinstance(token, str) else None
-
     def __init__(self, *, gateway: DriveServiceGateway) -> None:
         self._gateway = gateway
         self._meta_cache: dict[str, DriveFile] = {}
 
     def _resolve_folder_by_id(self, folder_ref: str) -> str | None:
         meta = self._gateway.get_file(folder_ref, "id,name,mimeType")
-        if self._record_string(meta, "mimeType") == FOLDER_MIME_TYPE:
-            file_id = self._record_string(meta, "id")
+        if _record_string(meta, "mimeType") == FOLDER_MIME_TYPE:
+            file_id = _record_string(meta, "id")
             return file_id or None
         return None
 
@@ -66,13 +54,13 @@ class DriveSourceClient:
             page_token=None,
             page_size=1000,
         )
-        matches = self._response_files(response)
+        matches = _response_files(response)
         if not matches:
             raise DriveNotFoundError(f"Folder not found: {folder_ref}")
         first = matches[0]
         if not isinstance(first, dict):
             return folder_ref
-        file_id = self._record_string(first, "id", default=folder_ref)
+        file_id = _record_string(first, "id", default=folder_ref)
         return file_id or folder_ref
 
     def resolve_folder_id(self, folder_ref: str) -> str:
@@ -104,19 +92,19 @@ class DriveSourceClient:
                 page_token=page_token,
                 page_size=1000,
             )
-            for item in self._response_files(response):
+            for item in _response_files(response):
                 if not isinstance(item, dict):
                     continue
                 item_payload: JSONDocument = item
-                name = self._record_string(item_payload, "name")
-                mime_type = self._record_string(item_payload, "mimeType")
+                name = _record_string(item_payload, "name")
+                mime_type = _record_string(item_payload, "mimeType")
                 if not _is_supported_drive_payload(name, mime_type):
                     continue
                 file_obj = _build_drive_file(item_payload)
                 if file_obj.file_id:
                     self._meta_cache[file_obj.file_id] = file_obj
                     yield file_obj
-            page_token = self._response_page_token(response)
+            page_token = _response_page_token(response)
             if not page_token:
                 break
 

--- a/polylogue/sources/drive_source_factory.py
+++ b/polylogue/sources/drive_source_factory.py
@@ -5,8 +5,7 @@ from pathlib import Path
 from .drive_auth import DriveAuthManager
 from .drive_gateway import (
     DriveServiceGateway,
-    _resolve_retries,
-    _resolve_retry_base,
+    resolve_drive_retry_policy,
 )
 from .drive_source_client import DriveSourceClient
 from .drive_types import DriveConfigLike, DriveUILike
@@ -22,6 +21,11 @@ def build_drive_source_client(
     config: DriveConfigLike | None = None,
 ) -> DriveSourceClient:
     """Build the canonical Drive source client from auth and gateway primitives."""
+    retry_policy = resolve_drive_retry_policy(
+        retries=retries,
+        retry_base=retry_base,
+        config=config,
+    )
     auth_manager = DriveAuthManager(
         ui=ui,
         credentials_path=credentials_path,
@@ -30,7 +34,6 @@ def build_drive_source_client(
     )
     gateway = DriveServiceGateway(
         auth_manager=auth_manager,
-        retries=_resolve_retries(retries, config),
-        retry_base=_resolve_retry_base(retry_base),
+        retry_policy=retry_policy,
     )
     return DriveSourceClient(gateway=gateway)

--- a/polylogue/sources/drive_source_support.py
+++ b/polylogue/sources/drive_source_support.py
@@ -7,7 +7,7 @@ from typing import TypeAlias
 from polylogue.lib.json import JSONValue, is_json_value, loads
 from polylogue.logging import get_logger
 
-from .drive_gateway import DrivePayloadRecord
+from .drive_gateway import DriveListFilesResponse, DrivePayloadRecord
 from .drive_types import (
     FOLDER_MIME_TYPE,
     GEMINI_PROMPT_MIME_TYPE,
@@ -29,6 +29,20 @@ def _json_sequence(value: object) -> DriveJSONSequence:
         if is_json_value(item):
             items.append(item)
     return items
+
+
+def _response_files(response: DriveListFilesResponse) -> list[JSONValue]:
+    return _json_sequence(response.get("files"))
+
+
+def _response_page_token(response: DriveListFilesResponse) -> str | None:
+    token = response.get("nextPageToken")
+    return token if isinstance(token, str) else None
+
+
+def _record_string(record: DrivePayloadRecord, key: str, *, default: str = "") -> str:
+    value = record.get(key)
+    return value if isinstance(value, str) else default
 
 
 def _parse_modified_time(raw: str | None) -> float | None:
@@ -110,10 +124,7 @@ def _needs_download(meta: DriveFile, dest: Path) -> bool:
 
 
 def _extract_meta_string(meta: DriveJSONRecord, key: str, *, file_id_fallback: str = "") -> str:
-    value = meta.get(key)
-    if isinstance(value, str):
-        return value
-    return file_id_fallback
+    return _record_string(meta, key, default=file_id_fallback)
 
 
 def _build_drive_file(meta: DriveJSONRecord, *, file_id_fallback: str = "") -> DriveFile:
@@ -136,8 +147,11 @@ __all__ = [
     "DriveJSONPayload",
     "DriveJSONRecord",
     "DriveJSONSequence",
+    "_record_string",
     "_build_drive_file",
     "_build_folder_lookup_query",
+    "_response_files",
+    "_response_page_token",
     "_is_supported_drive_payload",
     "_json_sequence",
     "_looks_like_id",

--- a/polylogue/sources/drive_types.py
+++ b/polylogue/sources/drive_types.py
@@ -33,6 +33,12 @@ class DriveFile:
     size_bytes: int | None
 
 
+@dataclass(frozen=True, slots=True)
+class DriveRetryPolicy:
+    retries: int
+    retry_base: float
+
+
 class DriveConfigLike(Protocol):
     @property
     def credentials_path(self) -> str | PathLike[str] | None: ...
@@ -135,6 +141,7 @@ __all__ = [
     "DriveError",
     "DriveFile",
     "DriveNotFoundError",
+    "DriveRetryPolicy",
     "DriveTokenStoreLike",
     "DriveUILike",
 ]

--- a/polylogue/storage/artifact_inspection.py
+++ b/polylogue/storage/artifact_inspection.py
@@ -8,6 +8,7 @@ from datetime import datetime, timezone
 from polylogue.lib.artifact_taxonomy import ArtifactKind, classify_artifact_path
 from polylogue.lib.raw_payload import JSONValue, RawPayloadEnvelope, build_raw_payload_envelope
 from polylogue.schemas.observation import derive_bundle_scope, schema_cluster_id
+from polylogue.schemas.packages import SchemaResolution
 from polylogue.schemas.runtime_registry import SchemaRegistry
 from polylogue.storage.blob_store import get_blob_store
 from polylogue.storage.store import ArtifactObservationRecord, RawConversationRecord
@@ -66,26 +67,21 @@ def _resolve_payload_support(
     payload_provider: Provider,
     payload: JSONValue,
     source_path: str | None,
-) -> tuple[str | None, str | None, str | None, bool]:
+) -> tuple[SchemaResolution | None, bool]:
     resolution = registry.resolve_payload(
         payload_provider,
         payload,
         source_path=source_path,
     )
     if resolution is None:
-        return None, None, None, False
+        return None, False
 
     package = registry.get_package(payload_provider, version=resolution.package_version)
     element = package.element(resolution.element_kind) if package is not None else None
     if package is None or element is None or not element.supported:
-        return None, None, resolution.reason, False
+        return resolution, False
 
-    return (
-        resolution.package_version,
-        resolution.element_kind,
-        resolution.reason,
-        True,
-    )
+    return resolution, True
 
 
 def _inspect_payload_envelope(record: RawConversationRecord) -> RawPayloadEnvelope:
@@ -206,9 +202,7 @@ def inspect_raw_artifact(record: RawConversationRecord) -> ArtifactObservationRe
     try:
         envelope = _inspect_payload_envelope(record)
         payload_provider = envelope.provider
-        resolved_package_version: str | None = None
-        resolved_element_kind: str | None = None
-        resolution_reason: str | None = None
+        resolution: SchemaResolution | None = None
         has_supported_resolution = False
 
         if (
@@ -216,17 +210,15 @@ def inspect_raw_artifact(record: RawConversationRecord) -> ArtifactObservationRe
             and envelope.artifact.schema_eligible
             and envelope.malformed_jsonl_lines == 0
         ):
-            (
-                resolved_package_version,
-                resolved_element_kind,
-                resolution_reason,
-                has_supported_resolution,
-            ) = _resolve_payload_support(
+            resolution, has_supported_resolution = _resolve_payload_support(
                 registry=registry,
                 payload_provider=payload_provider,
                 payload=envelope.payload,
                 source_path=record.source_path,
             )
+        resolved_package_version = resolution.package_version if resolution is not None else None
+        resolved_element_kind = resolution.element_kind if resolution is not None else None
+        resolution_reason = resolution.reason if resolution is not None else None
 
         support_status = _support_status(
             parse_as_conversation=envelope.artifact.parse_as_conversation,

--- a/tests/unit/core/test_schema_annotation_contracts.py
+++ b/tests/unit/core/test_schema_annotation_contracts.py
@@ -17,6 +17,7 @@ Ensures:
 from __future__ import annotations
 
 from collections import Counter
+from collections.abc import Mapping
 from typing import Any
 
 import pytest
@@ -615,7 +616,7 @@ class TestFieldStatsCollection:
 # =============================================================================
 
 
-def _load_schema(provider: str) -> dict[str, object] | None:
+def _load_schema(provider: str) -> JSONDocument | None:
     """Load a packaged provider schema, returning None if absent."""
     try:
         from polylogue.schemas.registry import SCHEMA_DIR, SchemaRegistry
@@ -634,14 +635,14 @@ def _load_schema(provider: str) -> dict[str, object] | None:
 
 
 def _find_annotations(
-    schema: dict[str, object],
+    schema: Mapping[str, object],
     prefix: str = "x-polylogue-",
 ) -> dict[str, list[tuple[str, Any]]]:
     """Walk the schema tree and collect all x-polylogue-* annotations by key."""
     result: dict[str, list[tuple[str, Any]]] = {}
 
     def _walk(obj: Any, path: str) -> None:
-        if not isinstance(obj, dict):
+        if not isinstance(obj, Mapping):
             return
         for key, value in obj.items():
             if key.startswith(prefix):

--- a/tests/unit/core/test_schema_registry_versions.py
+++ b/tests/unit/core/test_schema_registry_versions.py
@@ -100,9 +100,11 @@ class TestGetSchema:
 
         retrieved = registry.get_schema("get-prov", version="v1")
         assert retrieved is not None
-        assert "a" in retrieved["properties"]
+        retrieved_properties = retrieved.get("properties")
+        assert isinstance(retrieved_properties, dict)
+        assert "a" in retrieved_properties
         # v1 should NOT have "b"
-        assert "b" not in retrieved["properties"]
+        assert "b" not in retrieved_properties
 
     def test_get_latest_returns_most_recent(self, registry: SchemaRegistry) -> None:
         schema_v1 = {"type": "object", "properties": {"old": {"type": "string"}}}
@@ -112,7 +114,9 @@ class TestGetSchema:
 
         latest = registry.get_schema("lat-prov", version="latest")
         assert latest is not None
-        assert "new" in latest["properties"]
+        latest_properties = latest.get("properties")
+        assert isinstance(latest_properties, dict)
+        assert "new" in latest_properties
 
     def test_get_nonexistent_version_returns_none(self, registry: SchemaRegistry) -> None:
         schema = {"type": "object", "properties": {"x": {"type": "string"}}}
@@ -154,7 +158,9 @@ class TestMetadataInjection:
         # Should be a valid ISO timestamp
         from datetime import datetime
 
-        datetime.fromisoformat(stored["x-polylogue-registered-at"])
+        registered_at = stored.get("x-polylogue-registered-at")
+        assert isinstance(registered_at, str)
+        datetime.fromisoformat(registered_at)
 
     def test_register_does_not_mutate_input(self, registry: SchemaRegistry) -> None:
         """The original dict passed in should not be modified."""

--- a/tests/unit/pipeline/test_ingest_batch.py
+++ b/tests/unit/pipeline/test_ingest_batch.py
@@ -17,6 +17,7 @@ from polylogue.pipeline.services.ingest_batch import (
     _drain_ready_conversation_entries,
     _failed_raw_state_update,
     _IngestBatchSummary,
+    _IngestWorkerRequest,
     _iter_ingest_results_sync,
     _persist_batch_raw_state_updates,
     _RawIngestOutcome,
@@ -389,11 +390,13 @@ def test_iter_ingest_results_sync_runs_inline_for_single_worker(
     results = list(
         _iter_ingest_results_sync(
             raw_records,
-            archive_root_str="/tmp/archive",
-            blob_root_str="/tmp/blob-store",
-            validation_mode="strict",
+            request=_IngestWorkerRequest(
+                archive_root_str="/tmp/archive",
+                blob_root_str="/tmp/blob-store",
+                validation_mode="strict",
+                measure_ingest_result_size=False,
+            ),
             worker_count=1,
-            measure_ingest_result_size=False,
         )
     )
 

--- a/tests/unit/sources/test_drive_gateway.py
+++ b/tests/unit/sources/test_drive_gateway.py
@@ -14,8 +14,9 @@ from polylogue.sources.drive_gateway import (
     _import_module,
     _resolve_retries,
     _resolve_retry_base,
+    resolve_drive_retry_policy,
 )
-from polylogue.sources.drive_types import DriveAuthError, DriveNotFoundError
+from polylogue.sources.drive_types import DriveAuthError, DriveNotFoundError, DriveRetryPolicy
 from tests.infra.drive_mocks import MockDriveService, MockMediaIoBaseDownload
 
 
@@ -23,7 +24,10 @@ def _gateway(*, retries: int = 0, retry_base: float = 0.0) -> DriveServiceGatewa
     """Build a gateway with a mock auth manager."""
     auth_manager = MagicMock()
     auth_manager.load_credentials.return_value = object()
-    return DriveServiceGateway(auth_manager=auth_manager, retries=retries, retry_base=retry_base)
+    return DriveServiceGateway(
+        auth_manager=auth_manager,
+        retry_policy=DriveRetryPolicy(retries=retries, retry_base=retry_base),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -81,6 +85,14 @@ def test_resolve_retry_base_contract(
     expected: float,
 ) -> None:
     assert _resolve_retry_base(explicit) == expected
+
+
+def test_resolve_drive_retry_policy_contract() -> None:
+    config = MagicMock(retry_count=7)
+    assert resolve_drive_retry_policy(retries=None, retry_base=None, config=config) == DriveRetryPolicy(
+        retries=7,
+        retry_base=DEFAULT_DRIVE_RETRY_BASE,
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- centralize runtime schema resolution around package catalogs and payload observations
- rebuild source dispatch and Drive ingestion boundaries around shared typed helpers
- collapse ingest worker and batch runtime argument threading into explicit plan/request contracts

## Problem
The oldest schema/source/ingestion stratum still carried the strongest path dependence in the archive substrate: dict-shaped payload flow, duplicated source helper logic, repeated schema resolution across validation and parsing, and loose runtime seams around Drive and ingest-worker dispatch. That made the code harder to reason about and left behavior spread across too many small branches.

Closes #271.

## Solution
- rebuilt `polylogue/schemas/runtime_registry.py` to resolve payloads across observed schema units instead of whichever element happened to be first, with explicit candidate ranking and richer resolution metadata
- strengthened `polylogue/schemas/observation_runtime.py`, `polylogue/schemas/packages.py`, `polylogue/schemas/unified.py`, `polylogue/schemas/validator_resolution.py`, and `polylogue/storage/artifact_inspection.py` so schema loading, payload extraction, and artifact inspection all consume the same runtime resolution contract
- rewrote `polylogue/sources/dispatch.py` as an explicit lowering pipeline for bundle, grouped, stream, and Drive-like payloads instead of a path-dependent chain of special cases
- introduced an explicit retry-policy boundary for Drive runtime construction in `polylogue/sources/drive_gateway.py`, `polylogue/sources/drive_types.py`, and `polylogue/sources/drive_source_factory.py`
- collapsed repeated Drive cursor/failure bookkeeping into shared helpers in `polylogue/sources/drive.py`, `polylogue/sources/drive_source_client.py`, and `polylogue/sources/drive_source_support.py`
- moved the ingest runtime onto explicit parse-plan and worker-request contracts in `polylogue/pipeline/services/ingest_worker.py` and `polylogue/pipeline/services/ingest_batch.py`, so schema resolution is computed once and reused instead of being rediscovered deeper in the parse path
- restored validator fallback compatibility for lightweight/latest-only registries while keeping the new package-backed resolution path in place

## Verification
- `pytest -q tests/unit/core/test_schema_extraction_runtime.py tests/unit/core/test_schema_validation.py tests/unit/core/test_schema_registry.py`
- `mypy polylogue/schemas/packages.py polylogue/schemas/observation_runtime.py polylogue/schemas/runtime_registry.py`
- `ruff check polylogue/schemas/packages.py polylogue/schemas/observation_runtime.py polylogue/schemas/runtime_registry.py`
- `pytest -q tests/unit/sources/test_source_laws.py -k 'parse_payload or parse_drive_payload or detect_provider or conversation_emitter_resolves_schema_for_payloads'`
- `mypy polylogue/sources/dispatch.py polylogue/schemas/validator_resolution.py polylogue/storage/artifact_inspection.py polylogue/schemas/unified.py`
- `pytest -q tests/unit/sources/test_source_laws.py tests/unit/core/test_synthetic_semantics.py tests/unit/core/test_verification.py`
- `mypy polylogue/pipeline/services/ingest_worker.py polylogue/sources/drive_types.py polylogue/sources/drive_gateway.py polylogue/sources/drive_source_factory.py polylogue/sources/drive.py`
- `pytest -q tests/unit/pipeline/test_resilience.py -k 'schema_resolution or streams_codex_jsonl or ingest_worker'`
- `pytest -q tests/unit/sources/test_drive_gateway.py tests/unit/sources/test_drive_source_client.py tests/unit/sources/test_drive_ops.py tests/unit/sources/test_source_laws.py -k 'iter_drive_conversations or iter_drive_raw_data or download_drive_files or resolve_retries or retry_base or retry_policy or call_with_retry or service_handle or download_file or resolve_folder_id or download_json_payload or download_to_path'`
- `pytest -q tests/unit/pipeline/test_ingest_batch.py -k 'iter_ingest_results_sync or select_ingest_worker_count'`
- `pytest -q tests/unit/core/test_schema_validation.py -k 'missing_provider_raises or prefers_registry_latest'`
- `devtools verify`
- `git push -u origin feature/refactor/schema-source-ingestion-boundaries` (pre-push hook runs `devtools verify --quick`)
