### PR TITLE
refactor: contract CLI, MCP, and UI surfaces over renewed substrate

### DIFF
--- a/polylogue/cli/check_options.py
+++ b/polylogue/cli/check_options.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Any
 
 import click
 
@@ -11,7 +10,9 @@ from polylogue.maintenance_targets import MAINTENANCE_TARGET_NAMES, build_mainte
 
 _MAINTENANCE_TARGET_HELP = build_maintenance_target_catalog().help_text()
 
-CHECK_COMMAND_OPTION_DECORATORS: tuple[Callable[[Callable[..., Any]], Callable[..., Any]], ...] = (
+CheckCommandDecorator = Callable[[Callable[..., object]], Callable[..., object]]
+
+CHECK_COMMAND_OPTION_DECORATORS: tuple[CheckCommandDecorator, ...] = (
     click.option("--json", "json_output", is_flag=True, help="Output as JSON"),
     click.option("--verbose", "-v", is_flag=True, help="Show breakdown by provider"),
     click.option("--repair", is_flag=True, help="Run safe derived-data and database maintenance repairs"),
@@ -103,7 +104,7 @@ CHECK_COMMAND_OPTION_DECORATORS: tuple[Callable[[Callable[..., Any]], Callable[.
 )
 
 
-def apply_check_command_options(func: Callable[..., Any]) -> Callable[..., Any]:
+def apply_check_command_options(func: Callable[..., object]) -> Callable[..., object]:
     for decorator in reversed(CHECK_COMMAND_OPTION_DECORATORS):
         func = decorator(func)
     return func

--- a/polylogue/cli/check_rendering_plain.py
+++ b/polylogue/cli/check_rendering_plain.py
@@ -117,31 +117,31 @@ def append_schema_lines(lines: list[str], result: CheckCommandResult) -> None:
 def append_artifact_proof_lines(lines: list[str], result: CheckCommandResult) -> None:
     if result.proof_report is None:
         return
-    proof_summary = result.proof_report.to_dict()["summary"]
+    proof_report = result.proof_report
     lines.extend(
         [
             "",
-            f"Artifact proof: {result.proof_report.total_records:,} artifact observations "
-            f"(contract_backed={proof_summary['contract_backed_records']:,}, "
-            f"unsupported={proof_summary['unsupported_parseable_records']:,}, "
-            f"non_parseable={proof_summary['recognized_non_parseable_records']:,}, "
-            f"unknown={proof_summary['unknown_records']:,}, "
-            f"decode_errors={proof_summary['decode_errors']:,})",
+            f"Artifact proof: {proof_report.total_records:,} artifact observations "
+            f"(contract_backed={proof_report.contract_backed_records:,}, "
+            f"unsupported={proof_report.unsupported_parseable_records:,}, "
+            f"non_parseable={proof_report.recognized_non_parseable_records:,}, "
+            f"unknown={proof_report.unknown_records:,}, "
+            f"decode_errors={proof_report.decode_errors:,})",
         ]
     )
-    if proof_summary["subagent_streams"]:
+    if proof_report.subagent_streams:
         lines.append(
-            f"  Claude subagents: linked_sidecars={proof_summary['linked_sidecars']:,} "
-            f"orphan_sidecars={proof_summary['orphan_sidecars']:,} "
-            f"streams={proof_summary['subagent_streams']:,}"
+            f"  Claude subagents: linked_sidecars={proof_report.linked_sidecars:,} "
+            f"orphan_sidecars={proof_report.orphan_sidecars:,} "
+            f"streams={proof_report.subagent_streams:,}"
         )
-    if proof_summary["package_versions"]:
-        lines.append(f"  Resolved packages: {format_count_mapping(proof_summary['package_versions'])}")
-    if proof_summary["element_kinds"]:
-        lines.append(f"  Resolved elements: {format_count_mapping(proof_summary['element_kinds'])}")
-    if proof_summary["resolution_reasons"]:
-        lines.append(f"  Resolution reasons: {format_count_mapping(proof_summary['resolution_reasons'])}")
-    for provider, stats in sorted(result.proof_report.providers.items()):
+    if proof_report.package_versions:
+        lines.append(f"  Resolved packages: {format_count_mapping(proof_report.package_versions)}")
+    if proof_report.element_kinds:
+        lines.append(f"  Resolved elements: {format_count_mapping(proof_report.element_kinds)}")
+    if proof_report.resolution_reasons:
+        lines.append(f"  Resolution reasons: {format_count_mapping(proof_report.resolution_reasons)}")
+    for provider, stats in sorted(proof_report.providers.items()):
         lines.append(
             f"  {provider}: contract_backed={stats.contract_backed_records:,} "
             f"unsupported={stats.unsupported_parseable_records:,} "

--- a/polylogue/cli/commands/products.py
+++ b/polylogue/cli/commands/products.py
@@ -13,6 +13,7 @@ import click
 
 from polylogue.archive_products import ArchiveProductUnavailableError
 from polylogue.cli.helper_support import fail
+from polylogue.cli.product_command_contracts import ProductCommandRequest, query_model_field_names
 from polylogue.cli.types import AppEnv
 from polylogue.products.registry import (
     PRODUCT_REGISTRY,
@@ -22,7 +23,6 @@ from polylogue.products.registry import (
     render_product_items,
 )
 
-# Root-level filter keys that product commands inherit from the parent context.
 _ROOT_FILTER_KEYS = ("provider", "since", "until")
 
 
@@ -80,14 +80,6 @@ def _build_click_params(pt: ProductType) -> list[click.Parameter]:
     return params
 
 
-def _find_root_params(ctx: click.Context) -> dict[str, object]:
-    """Walk up the context chain to find the root CLI group's params."""
-    cur = ctx
-    while cur.parent is not None:
-        cur = cur.parent
-    return cur.params
-
-
 def _make_callback(pt: ProductType) -> Callable[..., None]:
     """Create the Click callback for a product type command.
 
@@ -95,10 +87,7 @@ def _make_callback(pt: ProductType) -> Callable[..., None]:
     context when the product's query class accepts them.
     """
     # Pre-resolve accepted fields so we only inject keys the query class understands.
-    query_model = pt.query_model
-    accepted_root_keys = frozenset(
-        key for key in _ROOT_FILTER_KEYS if query_model is not None and key in query_model.model_fields
-    )
+    accepted_root_keys = tuple(key for key in _ROOT_FILTER_KEYS if key in query_model_field_names(pt))
 
     @click.pass_context
     def callback(
@@ -109,25 +98,20 @@ def _make_callback(pt: ProductType) -> Callable[..., None]:
         **kwargs: object,
     ) -> None:
         env: AppEnv = ctx.obj
-
-        # Inject root filter values the product query class can accept.
-        root_params = _find_root_params(ctx)
-        for key in accepted_root_keys:
-            if kwargs.get(key) is None:
-                root_val = root_params.get(key)
-                if root_val is not None:
-                    kwargs[key] = root_val
-
-        if output_format is None:
-            root_output_format = root_params.get("output_format")
-            if isinstance(root_output_format, str):
-                output_format = root_output_format
+        request = ProductCommandRequest.from_context(
+            ctx,
+            pt,
+            json_mode=json_mode,
+            output_format=output_format,
+            kwargs=kwargs,
+            inherited_root_keys=accepted_root_keys,
+        )
 
         try:
-            items = fetch_products(pt, env.operations, **kwargs)
+            items = fetch_products(pt, env.operations, **request.query_kwargs)
         except (ArchiveProductUnavailableError, ProductQueryError) as exc:
             fail(f"products {pt.resolved_cli_command_name}", str(exc))
-        render_product_items(items, pt, json_mode=(json_mode or output_format == "json"))
+        render_product_items(items, pt, json_mode=request.wants_json)
 
     return callback
 

--- a/polylogue/cli/commands/schema.py
+++ b/polylogue/cli/commands/schema.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from pathlib import Path
+from typing import TypeVar
 
 import click
 
@@ -33,6 +35,15 @@ from polylogue.schemas.operator_workflow import (
     list_schemas,
     promote_schema_cluster,
 )
+
+TResult = TypeVar("TResult")
+
+
+def _run_schema_action(command_name: str, action: Callable[[], TResult]) -> TResult:
+    try:
+        return action()
+    except ValueError as exc:
+        fail(command_name, str(exc))
 
 
 @click.group("schema")
@@ -134,17 +145,17 @@ def schema_compare(
 ) -> None:
     """Compare two schema package versions for a provider."""
     del env
-    try:
-        result = compare_schema_versions(
+    result = _run_schema_action(
+        "schema compare",
+        lambda: compare_schema_versions(
             SchemaCompareRequest(
                 provider=provider,
                 from_version=from_version,
                 to_version=to_version,
                 element_kind=element_kind,
             )
-        )
-    except ValueError as exc:
-        fail("schema compare", str(exc))
+        ),
+    )
 
     render_schema_compare_result(result=result, json_output=json_output, md_output=md_output)
 
@@ -165,8 +176,9 @@ def schema_promote(
     json_output: bool,
 ) -> None:
     """Promote an evidence cluster to a new registered package version."""
-    try:
-        result = promote_schema_cluster(
+    result = _run_schema_action(
+        "schema promote",
+        lambda: promote_schema_cluster(
             SchemaPromoteRequest(
                 provider=provider,
                 cluster_id=cluster_id,
@@ -174,9 +186,8 @@ def schema_promote(
                 with_samples=with_samples,
                 max_samples=max_samples,
             )
-        )
-    except ValueError as exc:
-        fail("schema promote", str(exc))
+        ),
+    )
 
     render_schema_promote_result(result=result, json_output=json_output)
 
@@ -200,17 +211,17 @@ def schema_explain(
 ) -> None:
     """Explain a package element schema with evidence and annotations."""
     del env
-    try:
-        result = explain_schema(
+    result = _run_schema_action(
+        "schema explain",
+        lambda: explain_schema(
             SchemaExplainRequest(
                 provider=provider,
                 version=version,
                 element_kind=element_kind,
                 proof=proof,
             )
-        )
-    except ValueError as exc:
-        fail("schema explain", str(exc))
+        ),
+    )
 
     render_schema_explain_result(result=result, json_output=json_output, verbose=verbose)
 

--- a/polylogue/cli/helper_summary.py
+++ b/polylogue/cli/helper_summary.py
@@ -3,27 +3,56 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
-from typing import Any
+from pathlib import Path
+from typing import Protocol
 
+from polylogue.archive_products import ProviderAnalyticsProduct
 from polylogue.cli.helper_support import load_effective_config
 from polylogue.cli.types import AppEnv
+from polylogue.config import Config, Source
 from polylogue.logging import get_logger
+from polylogue.readiness import ReadinessReport
+from polylogue.services import RuntimeServices
+from polylogue.storage.backends.async_sqlite import SQLiteBackend
+from polylogue.storage.store_runtime_archive_records import RunRecord
 from polylogue.sync_bridge import run_coroutine_sync
 from polylogue.ui.theme import provider_color
 
 logger = get_logger(__name__)
 
 
+class LatestRunFn(Protocol):
+    def __call__(self, backend: SQLiteBackend | None = None) -> Awaitable[RunRecord | None]: ...
+
+
+class GetProviderCountsFn(Protocol):
+    def __call__(
+        self,
+        *,
+        services: RuntimeServices | None = None,
+        db_path: Path | None = None,
+    ) -> Awaitable[list[tuple[str, int]]]: ...
+
+
+class ListProviderAnalyticsProductsFn(Protocol):
+    def __call__(
+        self,
+        *,
+        services: RuntimeServices | None = None,
+        db_path: Path | None = None,
+    ) -> Awaitable[list[ProviderAnalyticsProduct]]: ...
+
+
 def print_summary_impl(
     env: AppEnv,
     *,
     verbose: bool = False,
-    latest_run_fn: Callable[[Any], Awaitable[Any]],
-    format_sources_summary_fn: Callable[[Any], str],
-    quick_readiness_summary_fn: Callable[[Any], str],
-    get_readiness_fn: Callable[..., Any],
-    get_provider_counts_fn: Callable[..., Awaitable[list[tuple[str, int]]]],
-    list_provider_analytics_products_fn: Callable[..., Awaitable[list[Any]]],
+    latest_run_fn: LatestRunFn,
+    format_sources_summary_fn: Callable[[list[Source]], str],
+    quick_readiness_summary_fn: Callable[[Path], str],
+    get_readiness_fn: Callable[[Config], ReadinessReport],
+    get_provider_counts_fn: GetProviderCountsFn,
+    list_provider_analytics_products_fn: ListProviderAnalyticsProductsFn,
 ) -> None:
     ui = env.ui
     config = load_effective_config(env)

--- a/polylogue/cli/helpers.py
+++ b/polylogue/cli/helpers.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
 
 from polylogue.cli.formatting import format_sources_summary
 from polylogue.cli.helper_source_selection import (
@@ -15,6 +14,7 @@ from polylogue.cli.helper_source_selection import (
 from polylogue.cli.helper_source_state import load_last_source, save_last_source, source_state_path
 from polylogue.cli.helper_summary import print_summary_impl
 from polylogue.cli.helper_support import fail, load_effective_config
+from polylogue.cli.types import AppEnv
 from polylogue.operations import get_provider_counts, list_provider_analytics_products
 from polylogue.pipeline.runner import latest_run
 from polylogue.readiness import get_readiness, quick_readiness_summary
@@ -37,7 +37,7 @@ def latest_render_path(render_root: Path) -> Path | None:
     return latest
 
 
-def print_summary(env: Any, *, verbose: bool = False) -> None:
+def print_summary(env: AppEnv, *, verbose: bool = False) -> None:
     print_summary_impl(
         env,
         verbose=verbose,

--- a/polylogue/cli/product_command_contracts.py
+++ b/polylogue/cli/product_command_contracts.py
@@ -1,0 +1,84 @@
+"""Typed request helpers for archive-product CLI commands."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from polylogue.products.registry import ProductType
+
+if TYPE_CHECKING:
+    import click
+
+
+def find_root_params(ctx: click.Context) -> Mapping[str, object]:
+    """Walk up the Click context chain to the root query command params."""
+    current = ctx
+    while current.parent is not None:
+        current = current.parent
+    return current.params
+
+
+def query_model_field_names(product_type: ProductType) -> frozenset[str]:
+    """Return the accepted query-model fields for a product type."""
+    query_model = product_type.query_model
+    if query_model is None:
+        return frozenset()
+    return frozenset(query_model.model_fields)
+
+
+@dataclass(frozen=True, slots=True)
+class ProductCommandRequest:
+    """Normalized product command request shared by all product subcommands."""
+
+    query_kwargs: dict[str, object]
+    output_format: str | None
+    json_mode: bool
+
+    @classmethod
+    def from_context(
+        cls,
+        ctx: click.Context,
+        product_type: ProductType,
+        *,
+        json_mode: bool,
+        output_format: str | None,
+        kwargs: Mapping[str, object],
+        inherited_root_keys: tuple[str, ...],
+    ) -> ProductCommandRequest:
+        root_params = find_root_params(ctx)
+        accepted_root_keys = query_model_field_names(product_type)
+        normalized_kwargs = dict(kwargs)
+
+        for key in inherited_root_keys:
+            if key not in accepted_root_keys:
+                continue
+            if normalized_kwargs.get(key) is not None:
+                continue
+            inherited_value = root_params.get(key)
+            if inherited_value is not None:
+                normalized_kwargs[key] = inherited_value
+
+        resolved_output_format = output_format
+        if resolved_output_format is None:
+            root_output_format = root_params.get("output_format")
+            if isinstance(root_output_format, str):
+                resolved_output_format = root_output_format
+
+        return cls(
+            query_kwargs=normalized_kwargs,
+            output_format=resolved_output_format,
+            json_mode=json_mode,
+        )
+
+    @property
+    def wants_json(self) -> bool:
+        return self.json_mode or self.output_format == "json"
+
+
+__all__ = [
+    "find_root_params",
+    "ProductCommandRequest",
+    "query_model_field_names",
+]

--- a/polylogue/cli/products_rendering.py
+++ b/polylogue/cli/products_rendering.py
@@ -7,18 +7,28 @@ the ``summarize_archive_debt`` helper.
 
 from __future__ import annotations
 
-from pydantic import BaseModel
+from collections.abc import Sequence
+from typing import Protocol, runtime_checkable
 
 from polylogue.cli.machine_errors import emit_success
 from polylogue.products.registry import render_product_items
 
 
+@runtime_checkable
+class SupportsModelDump(Protocol):
+    def model_dump(self, *, mode: str) -> object: ...
+
+
 def model_payload(item: object) -> object:
-    return item.model_dump(mode="json") if isinstance(item, BaseModel) else item
+    return item.model_dump(mode="json") if isinstance(item, SupportsModelDump) else item
+
+
+def model_payloads(items: Sequence[object]) -> list[object]:
+    return [model_payload(item) for item in items]
 
 
 def emit_product_list(*, key: str, items: list[object]) -> None:
-    emit_success({"count": len(items), key: [model_payload(item) for item in items]})
+    emit_success({"count": len(items), key: model_payloads(items)})
 
 
 def summarize_archive_debt(items: list[object]) -> dict[str, int]:
@@ -33,6 +43,7 @@ def summarize_archive_debt(items: list[object]) -> dict[str, int]:
 __all__ = [
     "emit_product_list",
     "model_payload",
+    "model_payloads",
     "render_product_items",
     "summarize_archive_debt",
 ]

--- a/polylogue/cli/query.py
+++ b/polylogue/cli/query.py
@@ -3,18 +3,32 @@
 from __future__ import annotations
 
 import inspect
-from collections.abc import Awaitable, Iterable, Mapping, Sequence
-from dataclasses import dataclass
-from datetime import datetime
-from enum import Enum
-from typing import TYPE_CHECKING, NoReturn, Protocol, TypeAlias, TypeVar, cast
+from collections.abc import Awaitable, Iterable, Sequence
+from typing import TYPE_CHECKING, Protocol, TypeVar, cast
 
 import click
 
-from polylogue.cli.machine_errors import error_no_results
+from polylogue.cli.query_contracts import (
+    QueryAction,
+    QueryExecutionPlan,
+    QueryMutationSpec,
+    QueryOutputSpec,
+    QueryParams,
+    QueryPlanError,
+    QueryRoute,
+    build_query_execution_plan,
+    coerce_query_spec,
+    describe_query_filters,
+    resolve_query_route,
+    result_date,
+    result_id,
+    result_provider,
+    result_title,
+)
+from polylogue.cli.query_feedback import emit_no_results
 from polylogue.cli.root_request import RootModeRequest
 from polylogue.cli.types import AppEnv
-from polylogue.lib.query_spec import ConversationQuerySpec, QuerySpecError
+from polylogue.lib.query_spec import QuerySpecError
 from polylogue.logging import get_logger
 from polylogue.schemas.json_types import JSONDocument
 from polylogue.surface_payloads import ConversationListRowPayload
@@ -27,9 +41,6 @@ if TYPE_CHECKING:
     from polylogue.lib.models import Conversation, ConversationSummary
     from polylogue.protocols import VectorProvider
 
-QueryParams: TypeAlias = dict[str, object]
-QueryParamSource: TypeAlias = Mapping[str, object] | ConversationQuerySpec
-QueryResult: TypeAlias = "Conversation | ConversationSummary"
 _T = TypeVar("_T")
 
 
@@ -43,68 +54,19 @@ async def _resolve_maybe_awaitable(value: _T | object) -> _T:
     return cast(_T, value)
 
 
-# ---------------------------------------------------------------------------
-# Query helpers (from query_helpers.py)
-# ---------------------------------------------------------------------------
-
-
-def coerce_query_spec(params: QueryParamSource) -> ConversationQuerySpec:
-    if isinstance(params, ConversationQuerySpec):
-        return params
-    return ConversationQuerySpec.from_params(params)
-
-
-def describe_query_filters(params: QueryParamSource) -> list[str]:
-    """Build a human-readable list of active filters from params or spec."""
-    return coerce_query_spec(params).describe()
-
-
 def no_results(
     env: AppEnv,
-    params: QueryParamSource,
+    params: QueryParams,
     *,
-    exit_code: int = 2,
-) -> NoReturn:
-    """Print a helpful no-results message and exit."""
-    filters = describe_query_filters(params)
-    output_format = params.get("output_format") if isinstance(params, Mapping) else None
-    if output_format == "json":
-        message = "No conversations matched filters." if filters else "No conversations matched."
-        error_no_results(message, filters=filters).emit(exit_code=exit_code)
-    if filters:
-        click.echo("No conversations matched filters:", err=True)
-        for item in filters:
-            click.echo(f"  {item}", err=True)
-        click.echo("Hint: try broadening your filters or use `list` to browse", err=True)
-    else:
-        click.echo("No conversations matched.", err=True)
-    raise SystemExit(exit_code)
-
-
-def result_id(result: QueryResult) -> str:
-    return str(result.id)
-
-
-def result_provider(result: QueryResult) -> str:
-    return str(result.provider)
-
-
-def result_title(result: QueryResult) -> str:
-    title = result.display_title
-    return title if title else result_id(result)[:20]
-
-
-def result_date(result: QueryResult) -> datetime | None:
-    display_date = getattr(result, "display_date", None)
-    if isinstance(display_date, datetime):
-        return display_date
-    updated_at = getattr(result, "updated_at", None)
-    if isinstance(updated_at, datetime):
-        return updated_at
-    created_at = getattr(result, "created_at", None)
-    if isinstance(created_at, datetime):
-        return created_at
-    return None
+    exit_code: int | None = 2,
+) -> None:
+    """Emit the canonical query no-results message."""
+    emit_no_results(
+        env,
+        selection=coerce_query_spec(params),
+        output_format=str(params.get("output_format") or "text"),
+        exit_code=exit_code,
+    )
 
 
 def summary_to_dict(summary: ConversationSummary, message_count: int) -> JSONDocument:
@@ -112,202 +74,6 @@ def summary_to_dict(summary: ConversationSummary, message_count: int) -> JSONDoc
         summary,
         message_count=message_count,
     ).selected()
-
-
-# ---------------------------------------------------------------------------
-# Query plan (from query_plan.py)
-# ---------------------------------------------------------------------------
-
-
-class QueryPlanError(ValueError):
-    """Raised when CLI query parameters describe an invalid plan."""
-
-
-class QueryAction(str, Enum):
-    COUNT = "count"
-    STREAM = "stream"
-    STATS = "stats"
-    STATS_BY = "stats-by"
-    MODIFY = "modify"
-    DELETE = "delete"
-    OPEN = "open"
-    SHOW = "show"
-
-
-class QueryRoute(str, Enum):
-    COUNT = "count"
-    SUMMARY_LIST = "summary-list"
-    STREAM = "stream"
-    STATS_SQL = "stats-sql"
-    SUMMARY_STATS = "summary-stats"
-    STATS_BY = "stats-by"
-    SUMMARY_MODIFY = "summary-modify"
-    SUMMARY_DELETE = "summary-delete"
-    MODIFY = "modify"
-    DELETE = "delete"
-    OPEN = "open"
-    SHOW = "show"
-
-
-@dataclass(frozen=True)
-class QueryOutputSpec:
-    output_format: str
-    destinations: tuple[str, ...]
-    fields: str | None
-    dialogue_only: bool
-    transform: str | None
-    list_mode: bool
-
-    def stream_format(self) -> str:
-        if self.output_format == "json":
-            return "json-lines"
-        if self.output_format in {"plaintext", "markdown", "json-lines"}:
-            return self.output_format
-        return "plaintext"
-
-
-@dataclass(frozen=True)
-class QueryMutationSpec:
-    set_meta: tuple[tuple[str, str], ...]
-    add_tags: tuple[str, ...]
-    delete_matched: bool
-    dry_run: bool
-    force: bool
-
-    @property
-    def has_operations(self) -> bool:
-        return bool(self.set_meta or self.add_tags)
-
-
-@dataclass(frozen=True)
-class QueryExecutionPlan:
-    selection: ConversationQuerySpec
-    action: QueryAction
-    output: QueryOutputSpec
-    mutation: QueryMutationSpec
-    stats_dimension: str | None = None
-
-    def prefers_summary_list(self) -> bool:
-        return (
-            self.action == QueryAction.SHOW
-            and self.output.list_mode
-            and self.output.transform is None
-            and not self.output.dialogue_only
-        )
-
-    def prefers_summary_stats(self) -> bool:
-        return self.action == QueryAction.STATS_BY and self.stats_dimension in {"provider", "month", "year", "day"}
-
-    def prefers_summary_mutation(self) -> bool:
-        return self.action in {QueryAction.MODIFY, QueryAction.DELETE}
-
-
-def resolve_query_route(
-    plan: QueryExecutionPlan,
-    *,
-    can_use_summaries: bool,
-) -> QueryRoute:
-    if plan.action == QueryAction.COUNT:
-        return QueryRoute.COUNT
-    if plan.prefers_summary_list() and can_use_summaries:
-        return QueryRoute.SUMMARY_LIST
-    if plan.action == QueryAction.STREAM:
-        return QueryRoute.STREAM
-    if plan.action == QueryAction.STATS:
-        return QueryRoute.STATS_SQL
-    if plan.prefers_summary_stats() and can_use_summaries:
-        return QueryRoute.SUMMARY_STATS
-    if plan.action == QueryAction.STATS_BY:
-        return QueryRoute.STATS_BY
-    if plan.action == QueryAction.MODIFY:
-        return QueryRoute.SUMMARY_MODIFY if can_use_summaries else QueryRoute.MODIFY
-    if plan.action == QueryAction.DELETE:
-        return QueryRoute.SUMMARY_DELETE if can_use_summaries else QueryRoute.DELETE
-    if plan.action == QueryAction.OPEN:
-        return QueryRoute.OPEN
-    return QueryRoute.SHOW
-
-
-def build_query_execution_plan(params: Mapping[str, object]) -> QueryExecutionPlan:
-    selection = ConversationQuerySpec.from_params(dict(params))
-
-    output_dest = str(params.get("output") or "stdout")
-    destinations = tuple(part.strip() for part in output_dest.split(",") if part.strip()) or ("stdout",)
-    output = QueryOutputSpec(
-        output_format=str(params.get("output_format") or "markdown"),
-        destinations=destinations,
-        fields=str(params["fields"]) if params.get("fields") is not None else None,
-        dialogue_only=bool(params.get("dialogue_only", False)),
-        transform=str(params["transform"]) if params.get("transform") is not None else None,
-        list_mode=bool(params.get("list_mode", False)),
-    )
-
-    def _iter_param_values(value: object) -> Iterable[object] | None:
-        if isinstance(value, str | bytes):
-            return None
-        if isinstance(value, Iterable):
-            return value
-        return None
-
-    def _iter_set_meta_pairs(value: object) -> tuple[tuple[str, str], ...]:
-        if isinstance(value, str | bytes):
-            return ()
-        if not isinstance(value, Iterable):
-            return ()
-        pairs: list[tuple[str, str]] = []
-        for item in value:
-            if isinstance(item, str | bytes):
-                continue
-            if not isinstance(item, Sequence):
-                continue
-            if len(item) < 2:
-                continue
-            pairs.append((str(item[0]), str(item[1])))
-        return tuple(pairs)
-
-    raw_set_meta = params.get("set_meta")
-    set_meta = _iter_set_meta_pairs(raw_set_meta)
-    raw_add_tags = params.get("add_tag")
-    add_tags = tuple(str(tag) for tag in _iter_param_values(raw_add_tags) or ())
-    mutation = QueryMutationSpec(
-        set_meta=set_meta,
-        add_tags=add_tags,
-        delete_matched=bool(params.get("delete_matched", False)),
-        dry_run=bool(params.get("dry_run", False)),
-        force=bool(params.get("force", False)),
-    )
-
-    stats_dimension = str(params["stats_by"]) if params.get("stats_by") else None
-
-    if params.get("count_only"):
-        action = QueryAction.COUNT
-    elif params.get("stream"):
-        action = QueryAction.STREAM
-    elif params.get("stats_only"):
-        action = QueryAction.STATS
-    elif stats_dimension is not None:
-        action = QueryAction.STATS_BY
-    elif mutation.delete_matched:
-        action = QueryAction.DELETE
-    elif mutation.has_operations:
-        action = QueryAction.MODIFY
-    elif params.get("open_result"):
-        action = QueryAction.OPEN
-    else:
-        action = QueryAction.SHOW
-
-    if action == QueryAction.DELETE and not selection.has_filters():
-        raise QueryPlanError(
-            "delete requires at least one filter to prevent accidental deletion of the entire archive."
-        )
-
-    return QueryExecutionPlan(
-        selection=selection,
-        action=action,
-        output=output,
-        mutation=mutation,
-        stats_dimension=stats_dimension,
-    )
 
 
 # ---------------------------------------------------------------------------
@@ -420,10 +186,10 @@ def handle_query_mode(
     request = RootModeRequest.from_context(ctx)
 
     if request.should_show_stats():
-        show_stats(env, verbose=bool(request.params.get("verbose", False)))
+        show_stats(env, verbose=request.verbose)
         return
 
-    execute_query(env, request.query_params())
+    execute_query_request(env, request)
 
 
 class QueryFirstGroupBase(click.Group):
@@ -473,7 +239,12 @@ def project_query_results(results: list[Conversation], plan: QueryExecutionPlan)
 
 def execute_query(env: AppEnv, params: QueryParams) -> None:
     """Execute a query-mode command."""
-    run_coroutine_sync(async_execute_query(env, params))
+    execute_query_request(env, RootModeRequest.from_params(params))
+
+
+def execute_query_request(env: AppEnv, request: RootModeRequest) -> None:
+    """Execute a typed root-mode request."""
+    run_coroutine_sync(async_execute_query_request(env, request))
 
 
 def _create_query_vector_provider(config: Config) -> VectorProvider | None:
@@ -490,11 +261,18 @@ def _create_query_vector_provider(config: Config) -> VectorProvider | None:
 
 
 async def async_execute_query(env: AppEnv, params: QueryParams) -> None:
-    """Async core of execute_query."""
+    """Async compatibility wrapper for raw param execution."""
+    await async_execute_query_request(env, RootModeRequest.from_params(params))
+
+
+async def async_execute_query_request(env: AppEnv, request: RootModeRequest) -> None:
+    """Async core of query execution over a typed request."""
     from polylogue.cli import query_actions as _query_actions
     from polylogue.cli import query_output as _query_output
     from polylogue.cli.helpers import fail, load_effective_config
     from polylogue.config import ConfigError
+
+    params = request.query_params()
 
     try:
         config = load_effective_config(env)
@@ -552,7 +330,7 @@ async def async_execute_query(env: AppEnv, params: QueryParams) -> None:
         summary_results = await filter_chain.list_summaries()
         if not summary_results:
             no_results(env, params)
-        await _query_output._output_summary_list(env, summary_results, params, repo)
+        await _query_output._output_summary_list(env, summary_results, plan.output, repo)
         return
 
     if route == QueryRoute.STREAM:
@@ -562,9 +340,9 @@ async def async_execute_query(env: AppEnv, params: QueryParams) -> None:
                 "Warning: --transform is ignored in --stream mode (messages are streamed individually).",
                 err=True,
             )
-        if any(dest != "stdout" for dest in plan.output.destinations):
+        if any(target.kind != "stdout" for target in plan.output.destinations):
             click.echo(
-                f"Warning: --output {','.join(plan.output.destinations)} is ignored in --stream mode (output goes to stdout).",
+                f"Warning: --output {','.join(plan.output.destination_labels())} is ignored in --stream mode (output goes to stdout).",
                 err=True,
             )
 
@@ -581,7 +359,13 @@ async def async_execute_query(env: AppEnv, params: QueryParams) -> None:
         return
 
     if route == QueryRoute.STATS_SQL:
-        await _query_output.output_stats_sql(env, filter_chain, repo, output_format=plan.output.output_format)
+        await _query_output.output_stats_sql(
+            env,
+            filter_chain,
+            repo,
+            selection=plan.selection,
+            output_format=plan.output.output_format,
+        )
         return
 
     if route == QueryRoute.SUMMARY_STATS:
@@ -651,7 +435,7 @@ async def async_execute_query(env: AppEnv, params: QueryParams) -> None:
             open_results: Sequence[Conversation | ConversationSummary] = await filter_chain.list_summaries()
         else:
             open_results = await filter_chain.list()
-        _query_output._open_result(env, open_results, params)
+        _query_output._open_result(env, open_results, plan.output, selection=plan.selection)
         return
 
     if route in {QueryRoute.MODIFY, QueryRoute.SUMMARY_MODIFY}:
@@ -659,7 +443,7 @@ async def async_execute_query(env: AppEnv, params: QueryParams) -> None:
             matched_results: Sequence[Conversation | ConversationSummary] = await filter_chain.list_summaries()
         else:
             matched_results = await filter_chain.list()
-        await _query_actions.apply_modifiers(env, matched_results, params, repo)
+        await _query_actions.apply_modifiers(env, matched_results, plan.mutation, repo)
         return
 
     if route in {QueryRoute.DELETE, QueryRoute.SUMMARY_DELETE}:
@@ -667,7 +451,7 @@ async def async_execute_query(env: AppEnv, params: QueryParams) -> None:
             matched_results = await filter_chain.list_summaries()
         else:
             matched_results = await filter_chain.list()
-        await _query_actions.delete_conversations(env, matched_results, params, repo)
+        await _query_actions.delete_conversations(env, matched_results, plan.mutation, repo)
         return
 
     if route == QueryRoute.STATS_BY:
@@ -684,7 +468,7 @@ async def async_execute_query(env: AppEnv, params: QueryParams) -> None:
 
     conversation_results = await filter_chain.list()
     projected_results = project_query_results(conversation_results, plan)
-    _query_output.output_results(env, projected_results, params)
+    _query_output.output_results(env, projected_results, plan.output, selection=plan.selection)
 
 
 __all__ = [
@@ -699,6 +483,7 @@ __all__ = [
     "coerce_query_spec",
     "describe_query_filters",
     "execute_query",
+    "execute_query_request",
     "handle_query_mode",
     "no_results",
     "resolve_query_route",

--- a/polylogue/cli/query_actions.py
+++ b/polylogue/cli/query_actions.py
@@ -3,11 +3,11 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import click
 
-from polylogue.cli.query import result_date, result_id, result_provider, result_title
+from polylogue.cli.query_contracts import QueryMutationSpec, result_date, result_id, result_provider, result_title
 
 if TYPE_CHECKING:
     from polylogue.cli.types import AppEnv
@@ -60,7 +60,7 @@ async def resolve_stream_target(
 async def apply_modifiers(
     env: AppEnv,
     results: Sequence[Conversation | ConversationSummary],
-    params: dict[str, Any],
+    mutation: QueryMutationSpec,
     repo: TagStore | None = None,
 ) -> None:
     """Apply metadata modifiers to matched conversations."""
@@ -69,16 +69,16 @@ async def apply_modifiers(
         env.ui.console.print("No conversations matched.")
         return
 
-    dry_run = params.get("dry_run", False)
-    force = params.get("force", False)
+    dry_run = mutation.dry_run
+    force = mutation.force
     count = len(results)
 
     operations: list[str] = []
-    if params.get("set_meta"):
-        keys = [kv[0] for kv in params["set_meta"]]
+    if mutation.set_meta:
+        keys = [kv[0] for kv in mutation.set_meta]
         operations.append(f"set metadata: {', '.join(keys)}")
-    if params.get("add_tag"):
-        operations.append(f"add tags: {', '.join(params['add_tag'])}")
+    if mutation.add_tags:
+        operations.append(f"add tags: {', '.join(mutation.add_tags)}")
 
     op_desc = "; ".join(operations)
 
@@ -102,14 +102,14 @@ async def apply_modifiers(
     meta_set = 0
 
     for conv in results:
-        if params.get("set_meta"):
-            for kv in params["set_meta"]:
+        if mutation.set_meta:
+            for kv in mutation.set_meta:
                 key, value = kv[0], kv[1]
                 await repo.update_metadata(result_id(conv), key, value)
                 meta_set += 1
 
-        if params.get("add_tag"):
-            for tag in params["add_tag"]:
+        if mutation.add_tags:
+            for tag in mutation.add_tags:
                 await repo.add_tag(result_id(conv), tag)
                 tags_added += 1
 
@@ -126,7 +126,7 @@ async def apply_modifiers(
 async def delete_conversations(
     env: AppEnv,
     results: Sequence[Conversation | ConversationSummary],
-    params: dict[str, Any],
+    mutation: QueryMutationSpec,
     repo: ConversationQueryRuntimeStore | None = None,
 ) -> None:
     """Delete matched conversations."""
@@ -137,8 +137,8 @@ async def delete_conversations(
         env.ui.console.print("No conversations matched.")
         return
 
-    dry_run = params.get("dry_run", False)
-    force = params.get("force", False)
+    dry_run = mutation.dry_run
+    force = mutation.force
     count = len(results)
 
     provider_counts = Counter(result_provider(conv) for conv in results)

--- a/polylogue/cli/query_contracts.py
+++ b/polylogue/cli/query_contracts.py
@@ -1,0 +1,328 @@
+"""Typed query request and execution contracts for the CLI surface."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+from pathlib import Path
+from typing import TYPE_CHECKING, Literal, TypeAlias
+
+from polylogue.lib.query_spec import ConversationQuerySpec
+
+if TYPE_CHECKING:
+    from polylogue.lib.models import Conversation, ConversationSummary
+
+QueryParams: TypeAlias = dict[str, object]
+QueryParamSource: TypeAlias = Mapping[str, object] | ConversationQuerySpec
+QueryResult: TypeAlias = "Conversation | ConversationSummary"
+
+QueryOutputFormat: TypeAlias = str
+QueryTransform: TypeAlias = str | None
+QueryDeliveryName: TypeAlias = Literal["stdout", "browser", "clipboard"]
+
+
+def coerce_query_terms(value: object) -> tuple[str, ...]:
+    """Coerce a raw Click/query value into canonical query terms."""
+    if value is None:
+        return ()
+    if isinstance(value, str | bytes):
+        return (str(value),)
+    if isinstance(value, Iterable):
+        return tuple(str(term) for term in value)
+    return (str(value),)
+
+
+def coerce_query_spec(params: QueryParamSource) -> ConversationQuerySpec:
+    """Build a query spec from raw params or pass through an existing one."""
+    if isinstance(params, ConversationQuerySpec):
+        return params
+    return ConversationQuerySpec.from_params(params)
+
+
+def describe_query_filters(params: QueryParamSource) -> list[str]:
+    """Describe active query filters for CLI feedback."""
+    return coerce_query_spec(params).describe()
+
+
+@dataclass(frozen=True, slots=True)
+class QueryDeliveryTarget:
+    """Single parsed delivery target for query output."""
+
+    raw: str
+    kind: QueryDeliveryName | Literal["path"]
+    path: Path | None = None
+
+    @classmethod
+    def parse(cls, value: str) -> QueryDeliveryTarget:
+        normalized = value.strip() or "stdout"
+        if normalized == "stdout":
+            return cls(raw=normalized, kind="stdout")
+        if normalized == "browser":
+            return cls(raw=normalized, kind="browser")
+        if normalized == "clipboard":
+            return cls(raw=normalized, kind="clipboard")
+        return cls(raw=normalized, kind="path", path=Path(normalized))
+
+
+@dataclass(frozen=True, slots=True)
+class QueryOutputSpec:
+    """Surface output settings derived from raw CLI params."""
+
+    output_format: QueryOutputFormat
+    destinations: tuple[QueryDeliveryTarget, ...]
+    fields: str | None
+    dialogue_only: bool
+    transform: QueryTransform
+    list_mode: bool
+    print_path: bool
+
+    @classmethod
+    def from_params(cls, params: Mapping[str, object]) -> QueryOutputSpec:
+        output_dest = str(params.get("output") or "stdout")
+        destinations = tuple(QueryDeliveryTarget.parse(part) for part in output_dest.split(",") if part.strip()) or (
+            QueryDeliveryTarget.parse("stdout"),
+        )
+        return cls(
+            output_format=str(params.get("output_format") or "markdown"),
+            destinations=destinations,
+            fields=str(params["fields"]) if params.get("fields") is not None else None,
+            dialogue_only=bool(params.get("dialogue_only", False)),
+            transform=str(params["transform"]) if params.get("transform") is not None else None,
+            list_mode=bool(params.get("list_mode", False)),
+            print_path=bool(params.get("print_path", False)),
+        )
+
+    def stream_format(self) -> str:
+        if self.output_format == "json":
+            return "json-lines"
+        if self.output_format in {"plaintext", "markdown", "json-lines"}:
+            return self.output_format
+        return "plaintext"
+
+    def destination_labels(self) -> tuple[str, ...]:
+        return tuple(target.raw for target in self.destinations)
+
+
+@dataclass(frozen=True, slots=True)
+class QueryMutationSpec:
+    """Mutation-side execution settings derived from raw CLI params."""
+
+    set_meta: tuple[tuple[str, str], ...]
+    add_tags: tuple[str, ...]
+    delete_matched: bool
+    dry_run: bool
+    force: bool
+
+    @classmethod
+    def from_params(cls, params: Mapping[str, object]) -> QueryMutationSpec:
+        return cls(
+            set_meta=_iter_set_meta_pairs(params.get("set_meta")),
+            add_tags=tuple(str(tag) for tag in _iter_param_values(params.get("add_tag")) or ()),
+            delete_matched=bool(params.get("delete_matched", False)),
+            dry_run=bool(params.get("dry_run", False)),
+            force=bool(params.get("force", False)),
+        )
+
+    @property
+    def has_operations(self) -> bool:
+        return bool(self.set_meta or self.add_tags)
+
+
+class QueryPlanError(ValueError):
+    """Raised when CLI query parameters describe an invalid plan."""
+
+
+class QueryAction(str, Enum):
+    COUNT = "count"
+    STREAM = "stream"
+    STATS = "stats"
+    STATS_BY = "stats-by"
+    MODIFY = "modify"
+    DELETE = "delete"
+    OPEN = "open"
+    SHOW = "show"
+
+
+class QueryRoute(str, Enum):
+    COUNT = "count"
+    SUMMARY_LIST = "summary-list"
+    STREAM = "stream"
+    STATS_SQL = "stats-sql"
+    SUMMARY_STATS = "summary-stats"
+    STATS_BY = "stats-by"
+    SUMMARY_MODIFY = "summary-modify"
+    SUMMARY_DELETE = "summary-delete"
+    MODIFY = "modify"
+    DELETE = "delete"
+    OPEN = "open"
+    SHOW = "show"
+
+
+@dataclass(frozen=True, slots=True)
+class QueryExecutionPlan:
+    """Fully typed CLI execution plan for a query request."""
+
+    selection: ConversationQuerySpec
+    action: QueryAction
+    output: QueryOutputSpec
+    mutation: QueryMutationSpec
+    stats_dimension: str | None = None
+
+    @classmethod
+    def from_params(cls, params: Mapping[str, object]) -> QueryExecutionPlan:
+        selection = ConversationQuerySpec.from_params(dict(params))
+        output = QueryOutputSpec.from_params(params)
+        mutation = QueryMutationSpec.from_params(params)
+        stats_dimension = str(params["stats_by"]) if params.get("stats_by") else None
+
+        if params.get("count_only"):
+            action = QueryAction.COUNT
+        elif params.get("stream"):
+            action = QueryAction.STREAM
+        elif params.get("stats_only"):
+            action = QueryAction.STATS
+        elif stats_dimension is not None:
+            action = QueryAction.STATS_BY
+        elif mutation.delete_matched:
+            action = QueryAction.DELETE
+        elif mutation.has_operations:
+            action = QueryAction.MODIFY
+        elif params.get("open_result"):
+            action = QueryAction.OPEN
+        else:
+            action = QueryAction.SHOW
+
+        if action == QueryAction.DELETE and not selection.has_filters():
+            raise QueryPlanError(
+                "delete requires at least one filter to prevent accidental deletion of the entire archive."
+            )
+
+        return cls(
+            selection=selection,
+            action=action,
+            output=output,
+            mutation=mutation,
+            stats_dimension=stats_dimension,
+        )
+
+    def prefers_summary_list(self) -> bool:
+        return (
+            self.action == QueryAction.SHOW
+            and self.output.list_mode
+            and self.output.transform is None
+            and not self.output.dialogue_only
+        )
+
+    def prefers_summary_stats(self) -> bool:
+        return self.action == QueryAction.STATS_BY and self.stats_dimension in {"provider", "month", "year", "day"}
+
+    def prefers_summary_mutation(self) -> bool:
+        return self.action in {QueryAction.MODIFY, QueryAction.DELETE}
+
+
+def build_query_execution_plan(params: Mapping[str, object]) -> QueryExecutionPlan:
+    """Build a typed execution plan from raw CLI params."""
+    return QueryExecutionPlan.from_params(params)
+
+
+def resolve_query_route(
+    plan: QueryExecutionPlan,
+    *,
+    can_use_summaries: bool,
+) -> QueryRoute:
+    """Resolve the concrete runtime route for a query execution plan."""
+    if plan.action == QueryAction.COUNT:
+        return QueryRoute.COUNT
+    if plan.prefers_summary_list() and can_use_summaries:
+        return QueryRoute.SUMMARY_LIST
+    if plan.action == QueryAction.STREAM:
+        return QueryRoute.STREAM
+    if plan.action == QueryAction.STATS:
+        return QueryRoute.STATS_SQL
+    if plan.prefers_summary_stats() and can_use_summaries:
+        return QueryRoute.SUMMARY_STATS
+    if plan.action == QueryAction.STATS_BY:
+        return QueryRoute.STATS_BY
+    if plan.action == QueryAction.MODIFY:
+        return QueryRoute.SUMMARY_MODIFY if can_use_summaries else QueryRoute.MODIFY
+    if plan.action == QueryAction.DELETE:
+        return QueryRoute.SUMMARY_DELETE if can_use_summaries else QueryRoute.DELETE
+    if plan.action == QueryAction.OPEN:
+        return QueryRoute.OPEN
+    return QueryRoute.SHOW
+
+
+def result_id(result: QueryResult) -> str:
+    return str(result.id)
+
+
+def result_provider(result: QueryResult) -> str:
+    return str(result.provider)
+
+
+def result_title(result: QueryResult) -> str:
+    title = result.display_title
+    return title if title else result_id(result)[:20]
+
+
+def result_date(result: QueryResult) -> datetime | None:
+    display_date = getattr(result, "display_date", None)
+    if isinstance(display_date, datetime):
+        return display_date
+    updated_at = getattr(result, "updated_at", None)
+    if isinstance(updated_at, datetime):
+        return updated_at
+    created_at = getattr(result, "created_at", None)
+    if isinstance(created_at, datetime):
+        return created_at
+    return None
+
+
+def _iter_param_values(value: object) -> Iterable[object] | None:
+    if isinstance(value, str | bytes):
+        return None
+    if isinstance(value, Iterable):
+        return value
+    return None
+
+
+def _iter_set_meta_pairs(value: object) -> tuple[tuple[str, str], ...]:
+    if isinstance(value, str | bytes):
+        return ()
+    if not isinstance(value, Iterable):
+        return ()
+    pairs: list[tuple[str, str]] = []
+    for item in value:
+        if isinstance(item, str | bytes):
+            continue
+        if not isinstance(item, Sequence):
+            continue
+        if len(item) < 2:
+            continue
+        pairs.append((str(item[0]), str(item[1])))
+    return tuple(pairs)
+
+
+__all__ = [
+    "build_query_execution_plan",
+    "coerce_query_spec",
+    "coerce_query_terms",
+    "describe_query_filters",
+    "QueryAction",
+    "QueryDeliveryTarget",
+    "QueryExecutionPlan",
+    "QueryMutationSpec",
+    "QueryOutputSpec",
+    "QueryParamSource",
+    "QueryParams",
+    "QueryPlanError",
+    "QueryResult",
+    "QueryRoute",
+    "resolve_query_route",
+    "result_date",
+    "result_id",
+    "result_provider",
+    "result_title",
+]

--- a/polylogue/cli/query_feedback.py
+++ b/polylogue/cli/query_feedback.py
@@ -1,0 +1,41 @@
+"""Shared no-results feedback helpers for CLI query surfaces."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from polylogue.cli.machine_errors import error_no_results
+
+if TYPE_CHECKING:
+    from polylogue.cli.types import AppEnv
+    from polylogue.lib.query_spec import ConversationQuerySpec
+
+
+def emit_no_results(
+    env: AppEnv,
+    *,
+    selection: ConversationQuerySpec | None = None,
+    output_format: str = "text",
+    message: str | None = None,
+    hint: str | None = None,
+    exit_code: int | None = 2,
+) -> None:
+    """Render a canonical no-results message for human and machine surfaces."""
+    filters = selection.describe() if selection is not None else []
+    resolved_message = message or ("No conversations matched filters." if filters else "No conversations matched.")
+    if output_format == "json":
+        error_no_results(resolved_message, filters=filters or None).emit(exit_code=exit_code or 2)
+
+    if filters and message is None:
+        env.ui.console.print("No conversations matched filters:")
+        for item in filters:
+            env.ui.console.print(f"  {item}")
+        env.ui.console.print(hint or "Hint: try broadening your filters or use `list` to browse")
+    else:
+        env.ui.console.print(resolved_message)
+
+    if exit_code is not None:
+        raise SystemExit(exit_code)
+
+
+__all__ = ["emit_no_results"]

--- a/polylogue/cli/query_output.py
+++ b/polylogue/cli/query_output.py
@@ -15,6 +15,8 @@ from typing import TYPE_CHECKING, TypeAlias
 
 import click
 
+from polylogue.cli.query_contracts import QueryDeliveryTarget, QueryOutputSpec
+from polylogue.cli.query_feedback import emit_no_results
 from polylogue.cli.query_semantic import (
     SemanticStatsSlice,
     action_matches_slice,
@@ -43,10 +45,10 @@ logger = get_logger(__name__)
 if TYPE_CHECKING:
     from polylogue.cli.types import AppEnv
     from polylogue.lib.models import Conversation, ConversationSummary, Message
+    from polylogue.lib.query_spec import ConversationQuerySpec
     from polylogue.protocols import ConversationOutputStore
     from polylogue.storage.store import MessageRecord
 
-QueryParams: TypeAlias = dict[str, object]
 ConversationStats: TypeAlias = dict[str, int]
 
 
@@ -213,10 +215,12 @@ def copy_to_clipboard(env: AppEnv, content: str) -> None:
 def open_result(
     env: AppEnv,
     results: Sequence[Conversation | ConversationSummary],
-    params: dict[str, object],
+    output: QueryOutputSpec,
+    *,
+    selection: ConversationQuerySpec | None = None,
 ) -> None:
     if not results:
-        no_results(env, dict(params))
+        emit_no_results(env, selection=selection, output_format=output.output_format)
 
     conv = results[0]
 
@@ -256,9 +260,8 @@ def open_result(
         click.echo("Run 'polylogue run' to render conversations.", err=True)
         raise SystemExit(1)
 
-    if bool(params.get("print_path")):
-        output_format = str(params.get("output_format") or "markdown")
-        if output_format == "json":
+    if output.print_path:
+        if output.output_format == "json":
             click.echo(json.dumps({"path": str(render_file)}, indent=2))
         else:
             click.echo(str(render_file))
@@ -342,24 +345,23 @@ def format_summary_list(
 async def output_summary_list(
     env: AppEnv,
     summaries: list[ConversationSummary],
-    params: QueryParams,
+    output: QueryOutputSpec,
     repo: ConversationOutputStore | None = None,
 ) -> None:
     """Output a list of conversation summaries with optional rich table rendering."""
-    output_format = str(params.get("output_format") or "text")
     msg_counts: dict[str, int] = {}
     if repo:
         ids = [str(summary.id) for summary in summaries]
         msg_counts = await repo.get_message_counts_batch(ids)
 
-    fields = params.get("fields")
-    fields_value = str(fields) if isinstance(fields, str) else None
-    if output_format in {"json", "yaml", "csv"} or env.ui.plain:
+    if output.output_format in {"json", "yaml", "csv"} or env.ui.plain:
         click.echo(
             format_summary_list(
                 summaries,
-                "text" if env.ui.plain and output_format not in {"json", "yaml", "csv"} else output_format,
-                fields_value,
+                "text"
+                if env.ui.plain and output.output_format not in {"json", "yaml", "csv"}
+                else output.output_format,
+                output.fields,
                 message_counts=msg_counts,
             )
         )
@@ -606,11 +608,20 @@ def write_message_streaming(message: Message | MessageRecord, output_format: str
         sys.stdout.flush()
 
 
-def no_results(env: AppEnv, params: QueryParams, *, exit_code: int = 2) -> None:
-    """Delegate the no-results contract to the canonical query helper."""
-    from polylogue.cli.query import no_results as query_no_results
-
-    query_no_results(env, params, exit_code=exit_code)
+def no_results(
+    env: AppEnv,
+    output: QueryOutputSpec,
+    *,
+    selection: ConversationQuerySpec | None = None,
+    exit_code: int | None = 2,
+) -> None:
+    """Emit the canonical no-results contract for output surfaces."""
+    emit_no_results(
+        env,
+        selection=selection,
+        output_format=output.output_format,
+        exit_code=exit_code,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -621,30 +632,25 @@ def no_results(env: AppEnv, params: QueryParams, *, exit_code: int = 2) -> None:
 def output_results(
     env: AppEnv,
     results: list[Conversation],
-    params: QueryParams,
+    output: QueryOutputSpec,
+    *,
+    selection: ConversationQuerySpec | None = None,
 ) -> None:
     """Output query results."""
     if not results:
-        no_results(env, params)
+        no_results(env, output, selection=selection)
 
-    output_format = str(params.get("output_format") or "markdown")
-    output_dest = str(params.get("output") or "stdout")
-    list_mode = bool(params.get("list_mode", False))
-    fields = params.get("fields")
-    fields_value = fields if isinstance(fields, str) else None
-    destinations = [d.strip() for d in output_dest.split(",")] if output_dest else ["stdout"]
-
-    if len(results) == 1 and not list_mode:
+    if len(results) == 1 and not output.list_mode:
         conv = results[0]
-        if output_format == "markdown" and destinations == ["stdout"] and not env.ui.plain:
+        if output.output_format == "markdown" and output.destination_labels() == ("stdout",) and not env.ui.plain:
             _render_conversation_rich(env, conv)
             return
-        content = format_conversation(conv, output_format, fields_value)
-        _send_output(env, content, destinations, output_format, conv)
+        content = format_conversation(conv, output.output_format, output.fields)
+        _send_output(env, content, output.destinations, output.output_format, conv)
         return
 
-    content = _format_list(results, output_format, fields_value)
-    _send_output(env, content, destinations, output_format, None)
+    content = _format_list(results, output.output_format, output.fields)
+    _send_output(env, content, output.destinations, output.output_format, None)
 
 
 # Internal aliases used by query.py and tests
@@ -661,20 +667,21 @@ _render_conversation_rich = render_conversation_rich
 def _send_output(
     env: AppEnv,
     content: str,
-    destinations: list[str],
+    destinations: Sequence[QueryDeliveryTarget],
     output_format: str,
     conv: Conversation | None,
 ) -> None:
     """Send output to specified destinations."""
-    for dest in destinations:
-        if dest == "stdout":
+    for destination in destinations:
+        if destination.kind == "stdout":
             click.echo(content)
-        elif dest == "browser":
+        elif destination.kind == "browser":
             _open_in_browser(env, content, output_format, conv)
-        elif dest == "clipboard":
+        elif destination.kind == "clipboard":
             _copy_to_clipboard(env, content)
         else:
-            path = Path(dest)
+            assert destination.path is not None
+            path = destination.path
             path.parent.mkdir(parents=True, exist_ok=True)
             path.write_text(content, encoding="utf-8")
             env.ui.console.print(f"Wrote to {path}")

--- a/polylogue/cli/query_semantic.py
+++ b/polylogue/cli/query_semantic.py
@@ -6,7 +6,7 @@ from collections.abc import Awaitable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from polylogue.cli.machine_errors import error_no_results
+from polylogue.cli.query_feedback import emit_no_results
 from polylogue.cli.query_stats import emit_structured_stats
 
 if TYPE_CHECKING:
@@ -22,26 +22,6 @@ if TYPE_CHECKING:
 # ---------------------------------------------------------------------------
 # Semantic slice (from query_semantic_slice.py)
 # ---------------------------------------------------------------------------
-
-
-def _emit_grouped_no_results(
-    env: AppEnv,
-    *,
-    output_format: str = "text",
-    selection: ConversationQuerySpec | None = None,
-) -> None:
-    filters = selection.describe() if selection is not None else []
-    if output_format == "json":
-        message = "No conversations matched filters." if filters else "No conversations matched."
-        error_no_results(message, filters=filters or None).emit(exit_code=2)
-    if filters:
-        env.ui.console.print("No conversations matched filters:")
-        for item in filters:
-            env.ui.console.print(f"  {item}")
-        env.ui.console.print("Hint: try broadening your filters or use `list` to browse")
-    else:
-        env.ui.console.print("No conversations matched.")
-    raise SystemExit(2)
 
 
 @dataclass(frozen=True, slots=True)
@@ -228,7 +208,7 @@ async def output_stats_by_semantic_ids(
     if dimension not in {"action", "tool"}:
         raise ValueError(f"Unsupported semantic stats dimension: {dimension}")
     if not conversation_ids:
-        _emit_grouped_no_results(env, output_format=output_format, selection=selection)
+        emit_no_results(env, selection=selection, output_format=output_format)
 
     semantic_slice = SemanticStatsSlice.from_selection(selection)
     groups: dict[str, dict[str, int]] = defaultdict(lambda: {"convs": 0, "facts": 0, "msgs": 0})

--- a/polylogue/cli/query_stats.py
+++ b/polylogue/cli/query_stats.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 
 import click
 
-from polylogue.cli.machine_errors import error_no_results
+from polylogue.cli.query_feedback import emit_no_results
 
 if TYPE_CHECKING:
     from polylogue.cli.types import AppEnv
@@ -79,26 +79,6 @@ def emit_structured_stats(
     return False
 
 
-def _emit_grouped_no_results(
-    env: AppEnv,
-    *,
-    output_format: str = "text",
-    selection: ConversationQuerySpec | None = None,
-) -> None:
-    filters = selection.describe() if selection is not None else []
-    if output_format == "json":
-        message = "No conversations matched filters." if filters else "No conversations matched."
-        error_no_results(message, filters=filters or None).emit(exit_code=2)
-    if filters:
-        env.ui.console.print("No conversations matched filters:")
-        for item in filters:
-            env.ui.console.print(f"  {item}")
-        env.ui.console.print("Hint: try broadening your filters or use `list` to browse")
-    else:
-        env.ui.console.print("No conversations matched.")
-    raise SystemExit(2)
-
-
 # ---------------------------------------------------------------------------
 # SQL-backed archive stats (from query_sql_stats.py)
 # ---------------------------------------------------------------------------
@@ -109,6 +89,7 @@ async def output_stats_sql(
     filter_chain: ConversationFilter,
     repo: ConversationArchiveStatsStore,
     *,
+    selection: ConversationQuerySpec | None = None,
     output_format: str = "markdown",
 ) -> None:
     """Output statistics using SQL aggregation without full message loading."""
@@ -120,18 +101,24 @@ async def output_stats_sql(
         summaries = await filter_chain.list_summaries() if filter_chain.can_use_summaries() else None
         if summaries is not None:
             if not summaries:
-                if output_format == "json":
-                    error_no_results("No conversations matched.", filters=described_filters).emit(exit_code=2)
-                env.ui.console.print("No conversations matched.")
+                emit_no_results(
+                    env,
+                    selection=selection,
+                    output_format=output_format,
+                    exit_code=2 if output_format == "json" else None,
+                )
                 return
             conv_ids = [str(summary.id) for summary in summaries]
             conv_count = len(conv_ids)
         else:
             conv_count = await filter_chain.count()
             if conv_count == 0:
-                if output_format == "json":
-                    error_no_results("No conversations matched.", filters=described_filters).emit(exit_code=2)
-                env.ui.console.print("No conversations matched.")
+                emit_no_results(
+                    env,
+                    selection=selection,
+                    output_format=output_format,
+                    exit_code=2 if output_format == "json" else None,
+                )
                 return
             conv_ids = None
     else:
@@ -139,9 +126,12 @@ async def output_stats_sql(
         archive_stats = await repo.get_archive_stats()
         conv_count = archive_stats.total_conversations
         if conv_count == 0:
-            if output_format == "json":
-                error_no_results("No conversations in archive.").emit(exit_code=2)
-            env.ui.console.print("No conversations in archive.")
+            emit_no_results(
+                env,
+                output_format=output_format,
+                message="No conversations in archive.",
+                exit_code=2 if output_format == "json" else None,
+            )
             return
         stats = await repo.aggregate_message_stats()
 
@@ -249,7 +239,7 @@ def output_stats_by_summaries(
     from polylogue.ui.theme import provider_color
 
     if not summaries:
-        _emit_grouped_no_results(env, output_format=output_format, selection=selection)
+        emit_no_results(env, selection=selection, output_format=output_format)
 
     groups: dict[str, list[ConversationSummary]] = defaultdict(list)
     for summary in summaries:
@@ -581,7 +571,7 @@ def output_stats_by_conversations(
     output_format: str = "text",
 ) -> None:
     if not results:
-        _emit_grouped_no_results(env, output_format=output_format, selection=selection)
+        emit_no_results(env, selection=selection, output_format=output_format)
 
     if output_semantic_grouped_stats(
         env,
@@ -664,7 +654,7 @@ async def output_stats_by_profile_ids(
     if dimension not in {"repo", "work-kind"}:
         raise ValueError(f"Unsupported profile stats dimension: {dimension}")
     if not conversation_ids:
-        _emit_grouped_no_results(env, output_format=output_format, selection=selection)
+        emit_no_results(env, selection=selection, output_format=output_format)
 
     from polylogue.lib.session_profile import build_session_profile
 

--- a/polylogue/cli/query_verbs.py
+++ b/polylogue/cli/query_verbs.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import click
 
+from polylogue.cli.root_request import RootModeRequest
 from polylogue.cli.shell_completion_values import complete_open_targets
 from polylogue.cli.types import AppEnv
 
@@ -27,24 +28,21 @@ VERB_NAMES = frozenset({"list", "count", "stats", "open", "delete"})
 @click.pass_context
 def list_verb(ctx: click.Context, output_format: str | None, fields: str | None, limit: int | None) -> None:
     """List matched conversations."""
-    params = _parent_params(ctx)
-    params["list_mode"] = True
+    request = _parent_request(ctx).with_param_updates(list_mode=True)
     if output_format:
-        params["output_format"] = output_format
+        request = request.with_param_updates(output_format=output_format)
     if fields:
-        params["fields"] = fields
+        request = request.with_param_updates(fields=fields)
     if limit is not None:
-        params["limit"] = limit
-    _execute_query_verb(ctx, params)
+        request = request.with_param_updates(limit=limit)
+    _execute_query_verb(ctx, request)
 
 
 @click.command("count")
 @click.pass_context
 def count_verb(ctx: click.Context) -> None:
     """Print count of matched conversations."""
-    params = _parent_params(ctx)
-    params["count_only"] = True
-    _execute_query_verb(ctx, params)
+    _execute_query_verb(ctx, _parent_request(ctx).with_param_updates(count_only=True))
 
 
 @click.command("stats")
@@ -65,15 +63,14 @@ def count_verb(ctx: click.Context) -> None:
 @click.pass_context
 def stats_verb(ctx: click.Context, stats_by: str | None, output_format: str | None, limit: int | None) -> None:
     """Show statistics for matched conversations."""
-    params = _parent_params(ctx)
-    params["stats_only"] = stats_by is None
+    request = _parent_request(ctx).with_param_updates(stats_only=stats_by is None)
     if stats_by:
-        params["stats_by"] = stats_by
+        request = request.with_param_updates(stats_by=stats_by)
     if output_format:
-        params["output_format"] = output_format
+        request = request.with_param_updates(output_format=output_format)
     if limit is not None:
-        params["limit"] = limit
-    _execute_query_verb(ctx, params)
+        request = request.with_param_updates(limit=limit)
+    _execute_query_verb(ctx, request)
 
 
 @click.command("open")
@@ -82,14 +79,11 @@ def stats_verb(ctx: click.Context, stats_by: str | None, output_format: str | No
 @click.pass_context
 def open_verb(ctx: click.Context, print_path: bool, target_terms: tuple[str, ...]) -> None:
     """Open matched conversation in browser/editor."""
-    params = _parent_params(ctx)
-    params["open_result"] = True
-    params["print_path"] = print_path
+    request = _parent_request(ctx).with_param_updates(open_result=True, print_path=print_path)
     if not _parent_query_terms(ctx) and len(target_terms) == 1 and ":" in target_terms[0]:
-        params["conv_id"] = target_terms[0]
-        _execute_query_verb(ctx, params)
+        _execute_query_verb(ctx, request.with_param_updates(conv_id=target_terms[0]))
         return
-    _execute_query_verb(ctx, params, extra_query_terms=target_terms)
+    _execute_query_verb(ctx, request.append_query_terms(target_terms))
 
 
 @click.command("delete")
@@ -98,22 +92,21 @@ def open_verb(ctx: click.Context, print_path: bool, target_terms: tuple[str, ...
 @click.pass_context
 def delete_verb(ctx: click.Context, dry_run: bool, force: bool) -> None:
     """Delete matched conversations."""
-    params = _parent_params(ctx)
-    params["delete_matched"] = True
-    params["dry_run"] = dry_run
-    params["force"] = force
-    _execute_query_verb(ctx, params)
-
-
-def _parent_params(ctx: click.Context) -> dict[str, object]:
-    """Extract params from parent context."""
-    return dict(_require_parent_context(ctx).params)
+    _execute_query_verb(
+        ctx,
+        _parent_request(ctx).with_param_updates(delete_matched=True, dry_run=dry_run, force=force),
+    )
 
 
 def _parent_query_terms(ctx: click.Context) -> tuple[str, ...]:
     """Load query terms captured on the parent query context."""
     raw_terms = _require_parent_context(ctx).meta.get("polylogue_query_terms", ())
     return tuple(str(term) for term in raw_terms)
+
+
+def _parent_request(ctx: click.Context) -> RootModeRequest:
+    """Build the typed request from the parent query context."""
+    return RootModeRequest.from_context(_require_parent_context(ctx))
 
 
 def _require_parent_context(ctx: click.Context) -> click.Context:
@@ -126,16 +119,13 @@ def _require_parent_context(ctx: click.Context) -> click.Context:
 
 def _execute_query_verb(
     ctx: click.Context,
-    params: dict[str, object],
-    *,
-    extra_query_terms: tuple[str, ...] = (),
+    request: RootModeRequest,
 ) -> None:
     """Execute query with verb-modified params."""
-    from polylogue.cli.query import execute_query
+    from polylogue.cli.query import execute_query_request
 
     env: AppEnv = ctx.obj
-    params["query"] = _parent_query_terms(ctx) + extra_query_terms
-    execute_query(env, params)
+    execute_query_request(env, request)
 
 
 QUERY_VERBS = (list_verb, count_verb, stats_verb, open_verb, delete_verb)

--- a/polylogue/cli/root_request.py
+++ b/polylogue/cli/root_request.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING
 
+from polylogue.cli.query_contracts import coerce_query_terms
 from polylogue.lib.query_spec import ConversationQuerySpec
 
 if TYPE_CHECKING:
@@ -15,15 +17,19 @@ if TYPE_CHECKING:
 class RootModeRequest:
     """Canonical root request for stats-or-query dispatch."""
 
-    params: dict[str, object]
+    params: Mapping[str, object]
     query_terms: tuple[str, ...]
 
     @classmethod
     def from_context(cls, ctx: click.Context) -> RootModeRequest:
-        query_terms = tuple(
-            str(term) for term in (ctx.meta.get("polylogue_query_terms") or ctx.params.get("query_term") or ())
-        )
+        query_terms = coerce_query_terms(ctx.meta.get("polylogue_query_terms") or ctx.params.get("query_term"))
         return cls(params=dict(ctx.params), query_terms=query_terms)
+
+    @classmethod
+    def from_params(cls, params: Mapping[str, object]) -> RootModeRequest:
+        normalized_params = dict(params)
+        query_terms = coerce_query_terms(normalized_params.pop("query", ()))
+        return cls(params=normalized_params, query_terms=query_terms)
 
     def query_params(self) -> dict[str, object]:
         params = dict(self.params)
@@ -32,6 +38,10 @@ class RootModeRequest:
 
     def query_spec(self) -> ConversationQuerySpec:
         return ConversationQuerySpec.from_params(self.query_params())
+
+    @property
+    def verbose(self) -> bool:
+        return bool(self.params.get("verbose", False))
 
     def has_output_mode(self) -> bool:
         return any(
@@ -51,6 +61,17 @@ class RootModeRequest:
                 "set_meta",
             )
         )
+
+    def with_param_updates(self, **updates: object) -> RootModeRequest:
+        next_params = dict(self.params)
+        next_params.update(updates)
+        return replace(self, params=next_params)
+
+    def with_query_terms(self, query_terms: Sequence[str]) -> RootModeRequest:
+        return replace(self, query_terms=tuple(str(term) for term in query_terms))
+
+    def append_query_terms(self, extra_terms: Sequence[str]) -> RootModeRequest:
+        return self.with_query_terms(self.query_terms + tuple(str(term) for term in extra_terms))
 
     def should_show_stats(self) -> bool:
         query_spec = self.query_spec()

--- a/polylogue/cli/run_display_workflow.py
+++ b/polylogue/cli/run_display_workflow.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import Any
 
 import click
 
@@ -16,6 +15,8 @@ from polylogue.cli.formatting import (
     format_run_details,
 )
 from polylogue.cli.helpers import fail
+from polylogue.cli.types import AppEnv
+from polylogue.config import Config
 from polylogue.lib.timestamps import format_timestamp
 from polylogue.pipeline.run_support import expand_requested_stage
 from polylogue.sources import DriveError
@@ -23,8 +24,8 @@ from polylogue.storage.run_state import PlanResult, RunResult
 
 
 def display_result(
-    env: Any,
-    cfg: Any,
+    env: AppEnv,
+    cfg: Config,
     result: RunResult,
     stage: str,
     selected_sources: list[str] | None,
@@ -86,7 +87,7 @@ def display_result(
         )
 
 
-def render_sources(env: Any, *, json_output: bool) -> None:
+def render_sources(env: AppEnv, *, json_output: bool) -> None:
     from polylogue.cli.machine_errors import emit_success
 
     cfg = env.config
@@ -118,7 +119,7 @@ def handle_drive_error(exc: DriveError) -> None:
 
 
 def render_preview_summary(
-    env: Any,
+    env: AppEnv,
     *,
     selected_sources: list[str] | None,
     plan_snapshot: PlanResult | None,

--- a/polylogue/cli/run_watch_workflow.py
+++ b/polylogue/cli/run_watch_workflow.py
@@ -4,13 +4,15 @@ from __future__ import annotations
 
 import time
 from collections.abc import Sequence
-from typing import Any
 
 import click
 
+from polylogue.cli.types import AppEnv
+from polylogue.config import Config
 from polylogue.lib.run_activity import conversation_activity_counts
 from polylogue.pipeline.observers import RunObserver
 from polylogue.sources import DriveError
+from polylogue.storage.run_state import RunResult
 
 from .run_display_workflow import display_result
 
@@ -20,8 +22,8 @@ class WatchDisplayObserver(RunObserver):
 
     def __init__(
         self,
-        env: Any,
-        cfg: Any,
+        env: AppEnv,
+        cfg: Config,
         stage: str,
         selected_sources: list[str] | None,
         *,
@@ -35,7 +37,7 @@ class WatchDisplayObserver(RunObserver):
         self._display_stage = display_stage
         self._stage_sequence = stage_sequence
 
-    def on_completed(self, result: Any) -> None:
+    def on_completed(self, result: RunResult) -> None:
         activity_count, _, _ = conversation_activity_counts(result.counts, result.drift)
         if activity_count > 0:
             display_result(
@@ -52,7 +54,7 @@ class WatchDisplayObserver(RunObserver):
 class WatchStatusObserver(RunObserver):
     """Print idle and error status in watch mode."""
 
-    def on_idle(self, result: Any) -> None:
+    def on_idle(self, result: RunResult) -> None:
         click.echo(f"No conversation changes at {time.strftime('%H:%M:%S')}")
 
     def on_error(self, exc: Exception) -> None:

--- a/polylogue/cli/run_workflow.py
+++ b/polylogue/cli/run_workflow.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import Any
 
 import click
 
@@ -19,6 +18,7 @@ from polylogue.cli.helpers import fail
 from polylogue.cli.run_display_workflow import render_sources
 from polylogue.cli.run_observers import progress_observer
 from polylogue.cli.run_watch_workflow import WatchDisplayObserver, WatchStatusObserver
+from polylogue.cli.types import AppEnv
 from polylogue.config import Config
 from polylogue.lib.timestamps import format_timestamp
 from polylogue.pipeline.observers import CompositeObserver, RunObserver
@@ -33,7 +33,7 @@ from polylogue.sync_bridge import run_coroutine_sync
 
 def execute_sync_once(
     cfg: Config,
-    env: Any,
+    env: AppEnv,
     stage: str,
     stage_sequence: Sequence[str] | None,
     selected_sources: list[str] | None,
@@ -61,7 +61,7 @@ def execute_sync_once(
 
 def run_with_progress(
     cfg: Config,
-    env: Any,
+    env: AppEnv,
     stage: str,
     stage_sequence: Sequence[str] | None,
     selected_sources: list[str] | None,
@@ -93,7 +93,7 @@ def run_with_progress(
 
 def run_sync_once(
     cfg: Config,
-    env: Any,
+    env: AppEnv,
     stage: str,
     stage_sequence: Sequence[str] | None,
     selected_sources: list[str] | None,
@@ -125,7 +125,7 @@ def run_sync_once(
 
 
 def display_result(
-    env: Any,
+    env: AppEnv,
     cfg: Config,
     result: RunResult,
     stage: str,
@@ -193,7 +193,7 @@ def handle_drive_error(exc: DriveError) -> None:
 
 
 def render_preview_summary(
-    env: Any,
+    env: AppEnv,
     *,
     selected_sources: list[str] | None,
     plan_snapshot: PlanResult | None,

--- a/polylogue/cli/schema_command_support.py
+++ b/polylogue/cli/schema_command_support.py
@@ -3,27 +3,49 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import cast
+
+from polylogue.schemas.operator_models import JSONDocument
+from polylogue.schemas.privacy_config import PrivacyConfig, PrivacyConfigSection, PrivacyLevel
+
+
+def _privacy_config_payload(config: PrivacyConfig) -> JSONDocument:
+    payload: JSONDocument = {
+        "level": config.level,
+        "safe_enum_max_length": config.safe_enum_max_length,
+        "high_entropy_min_length": config.high_entropy_min_length,
+        "cross_conv_min_count": config.cross_conv_min_count,
+        "cross_conv_proportional": config.cross_conv_proportional,
+    }
+    if config.field_overrides:
+        payload["field_overrides"] = dict(config.field_overrides)
+    if config.allow_value_patterns:
+        payload["allow_value_patterns"] = list(config.allow_value_patterns)
+    if config.deny_value_patterns:
+        payload["deny_value_patterns"] = list(config.deny_value_patterns)
+    return payload
 
 
 def build_schema_privacy_config(
     *,
     privacy: str | None,
     privacy_config_path: Path | None,
-) -> Any:
+) -> JSONDocument | None:
     """Resolve schema-generation privacy config from CLI options."""
-    from polylogue.schemas.privacy_config import PrivacyConfig, load_privacy_config
+    from polylogue.schemas.privacy_config import load_privacy_config
 
-    cli_overrides: dict[str, Any] = {}
+    cli_overrides: PrivacyConfigSection = {}
     if privacy:
         cli_overrides["level"] = privacy
     if privacy_config_path:
-        return load_privacy_config(
-            cli_overrides=cli_overrides,
-            project_path=privacy_config_path.parent,
+        return _privacy_config_payload(
+            load_privacy_config(
+                cli_overrides=cli_overrides,
+                project_path=privacy_config_path.parent,
+            )
         )
     if cli_overrides:
-        return PrivacyConfig(**cli_overrides)
+        return _privacy_config_payload(PrivacyConfig(level=cast(PrivacyLevel, privacy)))
     return None
 
 

--- a/polylogue/cli/schema_rendering_explain.py
+++ b/polylogue/cli/schema_rendering_explain.py
@@ -3,14 +3,30 @@
 from __future__ import annotations
 
 import json
-from typing import Any
+from collections.abc import Mapping
 
 import click
 
 from polylogue.cli.machine_errors import emit_success
+from polylogue.schemas.operator_models import SchemaExplainResult
 
 
-def render_schema_explain_result(*, result: Any, json_output: bool, verbose: bool) -> None:
+def _schema_properties(schema: Mapping[str, object]) -> dict[str, Mapping[str, object]]:
+    properties = schema.get("properties")
+    if not isinstance(properties, Mapping):
+        return {}
+    return {name: value for name, value in properties.items() if isinstance(name, str) and isinstance(value, Mapping)}
+
+
+def _json_values(value: object) -> list[object]:
+    return value if isinstance(value, list) else []
+
+
+def _json_entries(value: object) -> list[object]:
+    return value if isinstance(value, list) else []
+
+
+def render_schema_explain_result(*, result: SchemaExplainResult, json_output: bool, verbose: bool) -> None:
     """Render schema explain output in JSON or human-readable form."""
     if json_output:
         emit_success(result.to_dict())
@@ -20,7 +36,7 @@ def render_schema_explain_result(*, result: Any, json_output: bool, verbose: boo
         _render_proof_surface(result)
         return
 
-    props = result.schema.get("properties", {})
+    props = _schema_properties(result.schema)
     resolved_element = result.element_kind or (
         result.package.default_element_kind
         if result.package is not None
@@ -68,7 +84,7 @@ def render_schema_explain_result(*, result: Any, json_output: bool, verbose: boo
 
     click.echo(f"\n  Properties ({len(props)}):")
     for name, prop_schema in sorted(props.items()):
-        type_str = prop_schema.get("type", "?")
+        type_str = str(prop_schema.get("type", "?"))
         annotations: list[str] = []
         if prop_schema.get("x-polylogue-semantic-role"):
             annotations.append(f"role={prop_schema['x-polylogue-semantic-role']}")
@@ -76,8 +92,8 @@ def render_schema_explain_result(*, result: Any, json_output: bool, verbose: boo
             annotations.append(f"fmt={prop_schema['x-polylogue-format']}")
         if prop_schema.get("x-polylogue-frequency") is not None:
             annotations.append(f"freq={prop_schema['x-polylogue-frequency']}")
-        if prop_schema.get("x-polylogue-values"):
-            values = prop_schema["x-polylogue-values"]
+        values = _json_values(prop_schema.get("x-polylogue-values"))
+        if values:
             preview = ", ".join(str(value) for value in values[:5])
             if len(values) > 5:
                 preview += f" (+{len(values) - 5} more)"
@@ -86,17 +102,17 @@ def render_schema_explain_result(*, result: Any, json_output: bool, verbose: boo
         click.echo(f"    {name}: {type_str}{ann_str}")
 
     for key in ("x-polylogue-foreign-keys", "x-polylogue-time-deltas", "x-polylogue-mutually-exclusive"):
-        value = result.schema.get(key)
-        if value:
+        values = _json_entries(result.schema.get(key))
+        if values:
             click.echo(f"\n  {key}:")
-            for entry in value:
+            for entry in values:
                 click.echo(f"    {json.dumps(entry)}")
 
     if verbose:
         render_explain_verbose(result)
 
 
-def render_explain_verbose(result: Any) -> None:
+def render_explain_verbose(result: SchemaExplainResult) -> None:
     """Render verbose schema explain coverage and role evidence."""
     click.echo()
     roles = result.annotations.roles
@@ -125,8 +141,10 @@ def render_explain_verbose(result: Any) -> None:
         )
 
 
-def _render_proof_surface(result: Any) -> None:
+def _render_proof_surface(result: SchemaExplainResult) -> None:
     """Render the proof surface for schema role assignment decisions."""
+    if result.review_proof is None:
+        return
     proof = result.review_proof
     click.echo(f"Schema Review Proof: {result.provider} {result.version}")
     click.echo(f"  Artifact kind: {proof.artifact_kind or 'unknown'}")

--- a/polylogue/cli/schema_rendering_results.py
+++ b/polylogue/cli/schema_rendering_results.py
@@ -3,14 +3,21 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
 
 import click
 
 from polylogue.cli.machine_errors import emit_success
+from polylogue.scenarios import CorpusScenario, CorpusSpec
+from polylogue.schemas.audit_models import AuditReport
+from polylogue.schemas.operator_models import (
+    SchemaCompareResult,
+    SchemaInferResult,
+    SchemaListResult,
+    SchemaPromoteResult,
+)
 
 
-def _render_corpus_spec_preview(*, corpus_specs: Any, header: str) -> None:
+def _render_corpus_spec_preview(*, corpus_specs: tuple[CorpusSpec, ...], header: str) -> None:
     if not corpus_specs:
         return
     click.echo(header)
@@ -24,7 +31,7 @@ def _render_corpus_spec_preview(*, corpus_specs: Any, header: str) -> None:
         click.echo(f"    … {len(corpus_specs) - 3} more")
 
 
-def _render_corpus_scenario_preview(*, corpus_scenarios: Any, header: str) -> None:
+def _render_corpus_scenario_preview(*, corpus_scenarios: tuple[CorpusScenario, ...], header: str) -> None:
     if not corpus_scenarios:
         return
     click.echo(header)
@@ -38,10 +45,21 @@ def _render_corpus_scenario_preview(*, corpus_scenarios: Any, header: str) -> No
         click.echo(f"    … {len(corpus_scenarios) - 3} more")
 
 
+def _corpus_scenario_payloads(corpus_scenarios: tuple[CorpusScenario, ...]) -> list[dict[str, object]]:
+    return [
+        {
+            "provider": scenario.provider,
+            "package_version": scenario.package_version,
+            "corpus_specs": [spec.to_payload() for spec in scenario.corpus_specs],
+        }
+        for scenario in corpus_scenarios
+    ]
+
+
 def render_schema_generate_result(
     *,
     provider: str,
-    result: Any,
+    result: SchemaInferResult,
     json_output: bool,
     report: bool,
 ) -> None:
@@ -51,11 +69,11 @@ def render_schema_generate_result(
         click.echo(generation.redaction_report.format_summary(), err=True)
         if not json_output:
             report_path = Path(f"{provider}-redaction-report.md")
-            report_path.write_text(generation.redaction_report.format_markdown())
+            report_path.write_text(generation.redaction_report.format_markdown(), encoding="utf-8")
             click.echo(f"  Redaction report: {report_path}", err=True)
 
     if json_output:
-        payload: dict[str, Any] = {
+        payload: dict[str, object] = {
             "provider": provider,
             "generation": {
                 "success": generation.success,
@@ -74,14 +92,7 @@ def render_schema_generate_result(
         if result.corpus_specs:
             payload["corpus_specs"] = [spec.to_payload() for spec in result.corpus_specs]
         if result.corpus_scenarios:
-            payload["corpus_scenarios"] = [
-                {
-                    "provider": scenario.provider,
-                    "package_version": scenario.package_version,
-                    "corpus_specs": [spec.to_payload() for spec in scenario.corpus_specs],
-                }
-                for scenario in result.corpus_scenarios
-            ]
+            payload["corpus_scenarios"] = _corpus_scenario_payloads(result.corpus_scenarios)
         emit_success(payload)
         return
 
@@ -107,14 +118,14 @@ def render_schema_generate_result(
 def render_schema_list_result(
     *,
     provider: str | None,
-    result: Any,
+    result: SchemaListResult,
     json_output: bool,
 ) -> None:
     """Render schema list output in JSON or text mode."""
     if provider:
         selected = result.selected
         if json_output:
-            emit_success(result.to_dict())
+            emit_success(selected.to_dict() if selected is not None else {"provider": provider, "versions": []})
             return
         if selected is None or (not selected.versions and selected.catalog is None):
             click.echo(f"No schemas found for provider: {provider}")
@@ -198,7 +209,7 @@ def render_schema_list_result(
         )
 
 
-def render_schema_compare_result(*, result: Any, json_output: bool, md_output: bool) -> None:
+def render_schema_compare_result(*, result: SchemaCompareResult, json_output: bool, md_output: bool) -> None:
     """Render schema comparison output."""
     if json_output:
         emit_success(result.to_dict())
@@ -208,7 +219,7 @@ def render_schema_compare_result(*, result: Any, json_output: bool, md_output: b
         click.echo(result.diff.to_text())
 
 
-def render_schema_promote_result(*, result: Any, json_output: bool) -> None:
+def render_schema_promote_result(*, result: SchemaPromoteResult, json_output: bool) -> None:
     """Render schema cluster promotion output."""
     if json_output:
         emit_success(result.to_dict())
@@ -218,7 +229,7 @@ def render_schema_promote_result(*, result: Any, json_output: bool) -> None:
     click.echo(f"Available versions: {', '.join(result.versions)}")
 
 
-def render_schema_audit_result(*, report: Any, json_output: bool) -> None:
+def render_schema_audit_result(*, report: AuditReport, json_output: bool) -> None:
     """Render schema audit output."""
     if json_output:
         emit_success(report.to_json())

--- a/polylogue/cli/shell_completion_values.py
+++ b/polylogue/cli/shell_completion_values.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sqlite3
+from collections.abc import Callable
 from typing import Final
 
 import click
@@ -21,6 +22,7 @@ _PROVIDER_DESCRIPTIONS: Final[dict[str, str]] = {
 
 _MAX_ID_COMPLETIONS = 24
 _MAX_VALUE_COMPLETIONS = 32
+CompletionHelpBuilder = Callable[[sqlite3.Row], str]
 
 
 def _split_csv_incomplete(incomplete: str) -> tuple[str, str]:
@@ -53,6 +55,19 @@ def _fetch_rows(sql: str, params: tuple[object, ...]) -> list[sqlite3.Row]:
             return list(cursor.fetchall())
     except sqlite3.Error:
         return []
+
+
+def _rows_to_completion_items(
+    rows: list[sqlite3.Row],
+    *,
+    value_column: str,
+    help_builder: CompletionHelpBuilder | None = None,
+) -> list[CompletionItem]:
+    items: list[CompletionItem] = []
+    for row in rows:
+        help_text = help_builder(row) if help_builder is not None else None
+        items.append(CompletionItem(str(row[value_column]), help=help_text))
+    return items
 
 
 def _trim_help(value: str, *, limit: int = 72) -> str:
@@ -114,13 +129,14 @@ def complete_conversation_ids(
             _MAX_ID_COMPLETIONS,
         ),
     )
-    items: list[CompletionItem] = []
-    for row in rows:
-        conv_id = str(row["conversation_id"])
-        provider = str(row["provider_name"] or "unknown")
-        title = _trim_help(str(row["display_title"] or conv_id))
-        items.append(CompletionItem(conv_id, help=f"{provider} · {title}"))
-    return items
+    return _rows_to_completion_items(
+        rows,
+        value_column="conversation_id",
+        help_builder=lambda row: (
+            f"{str(row['provider_name'] or 'unknown')} · "
+            f"{_trim_help(str(row['display_title'] or row['conversation_id']))}"
+        ),
+    )
 
 
 def complete_open_targets(
@@ -158,7 +174,11 @@ def complete_tag_values(
             _MAX_VALUE_COMPLETIONS,
         ),
     )
-    items = [CompletionItem(str(row["tag_name"]), help=f"{int(row['cnt'])} conversations") for row in rows]
+    items = _rows_to_completion_items(
+        rows,
+        value_column="tag_name",
+        help_builder=lambda row: f"{int(row['cnt'])} conversations",
+    )
     return _with_csv_prefix(items, prefix)
 
 
@@ -186,7 +206,11 @@ def complete_tool_values(
             _MAX_VALUE_COMPLETIONS,
         ),
     )
-    return [CompletionItem(str(row["normalized_tool_name"]), help=f"{int(row['cnt'])} actions") for row in rows]
+    return _rows_to_completion_items(
+        rows,
+        value_column="normalized_tool_name",
+        help_builder=lambda row: f"{int(row['cnt'])} actions",
+    )
 
 
 __all__ = [

--- a/polylogue/mcp/product_tool_contracts.py
+++ b/polylogue/mcp/product_tool_contracts.py
@@ -1,0 +1,101 @@
+"""Typed registration contracts for registry-driven MCP product tools."""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+
+from polylogue.products.registry import ProductType
+
+
+def _sanitize_offset(value: object) -> int:
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, (int, str, bytes, bytearray)):
+        return max(0, int(value))
+    return 0
+
+
+@dataclass(frozen=True, slots=True)
+class ProductToolSignature:
+    """Normalized dynamic signature for one product list MCP tool."""
+
+    parameters: tuple[inspect.Parameter, ...]
+    annotations: dict[str, object]
+    kwdefaults: dict[str, object]
+
+
+@dataclass(frozen=True, slots=True)
+class ProductListToolSpec:
+    """Registry-derived MCP list-tool contract for one product type."""
+
+    name: str
+    doc: str
+    signature: ProductToolSignature
+
+    @classmethod
+    def from_product_type(cls, product_type: ProductType) -> ProductListToolSpec:
+        query_model = product_type.query_model
+        if query_model is None:
+            raise ValueError(f"Product type {product_type.name} does not declare a query model")
+
+        parameters: list[inspect.Parameter] = []
+        for field_name in sorted(query_model.model_fields):
+            field_info = query_model.model_fields[field_name]
+            if field_name == "limit":
+                parameters.append(
+                    inspect.Parameter(
+                        field_name,
+                        inspect.Parameter.KEYWORD_ONLY,
+                        default=product_type.mcp_default_limit,
+                        annotation=int,
+                    )
+                )
+                continue
+            if field_name == "offset":
+                parameters.append(
+                    inspect.Parameter(
+                        field_name,
+                        inspect.Parameter.KEYWORD_ONLY,
+                        default=0,
+                        annotation=int,
+                    )
+                )
+                continue
+            parameters.append(
+                inspect.Parameter(
+                    field_name,
+                    inspect.Parameter.KEYWORD_ONLY,
+                    default=None if field_info.is_required() else field_info.get_default(call_default_factory=True),
+                    annotation=field_info.annotation if field_info.annotation is not None else object,
+                )
+            )
+
+        annotations = {parameter.name: parameter.annotation for parameter in parameters}
+        annotations["return"] = str
+        signature = ProductToolSignature(
+            parameters=tuple(parameters),
+            annotations=annotations,
+            kwdefaults={parameter.name: parameter.default for parameter in parameters},
+        )
+        return cls(
+            name=product_type.name,
+            doc=f"List {product_type.display_name.lower()} from the archive.",
+            signature=signature,
+        )
+
+    def normalize_kwargs(
+        self,
+        clamp_limit: Callable[[int | object], int],
+        kwargs: Mapping[str, object],
+    ) -> dict[str, object]:
+        normalized = dict(kwargs)
+        if "limit" in normalized:
+            normalized["limit"] = clamp_limit(normalized["limit"])
+        if "offset" in normalized:
+            normalized["offset"] = _sanitize_offset(normalized["offset"])
+        return normalized
+
+
+__all__ = ["ProductListToolSpec", "ProductToolSignature"]

--- a/polylogue/mcp/query_contracts.py
+++ b/polylogue/mcp/query_contracts.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
 
 from polylogue.lib.query_spec import ConversationQuerySpec
 
@@ -26,4 +27,53 @@ def build_query_spec(**params: object) -> ConversationQuerySpec:
     return ConversationQuerySpec.from_params(normalize_query_params(params))
 
 
-__all__ = ["build_query_spec", "normalize_query_params"]
+@dataclass(frozen=True, slots=True)
+class MCPConversationQueryRequest:
+    """Typed MCP query request shared across query/search tool surfaces."""
+
+    query: str | None = None
+    retrieval_lane: str | None = None
+    provider: str | None = None
+    since: str | None = None
+    tag: str | None = None
+    title: str | None = None
+    path: str | None = None
+    action: str | None = None
+    exclude_action: str | None = None
+    action_sequence: str | None = None
+    action_text: str | None = None
+    tool: str | None = None
+    exclude_tool: str | None = None
+    sort: str | None = None
+    has_tool_use: bool = False
+    has_thinking: bool = False
+    min_messages: int | None = None
+    min_words: int | None = None
+    limit: int = 10
+
+    def build_spec(self, clamp_limit: Callable[[int | object], int]) -> ConversationQuerySpec:
+        """Build a ConversationQuerySpec from this request using the given clamp helper."""
+        return build_query_spec(
+            query=self.query,
+            retrieval_lane=self.retrieval_lane or "auto",
+            provider=self.provider,
+            since=self.since,
+            tag=self.tag,
+            title=self.title,
+            path=self.path,
+            action=self.action,
+            exclude_action=self.exclude_action,
+            action_sequence=self.action_sequence,
+            action_text=self.action_text,
+            tool=self.tool,
+            exclude_tool=self.exclude_tool,
+            sort=self.sort,
+            limit=clamp_limit(self.limit),
+            has_tool_use=self.has_tool_use,
+            has_thinking=self.has_thinking,
+            min_messages=self.min_messages,
+            min_words=self.min_words,
+        )
+
+
+__all__ = ["build_query_spec", "MCPConversationQueryRequest", "normalize_query_params"]

--- a/polylogue/mcp/query_contracts.py
+++ b/polylogue/mcp/query_contracts.py
@@ -1,0 +1,29 @@
+"""Shared MCP-side query normalization helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from polylogue.lib.query_spec import ConversationQuerySpec
+
+_QUERY_PARAM_ALIASES = {
+    "has_tool_use": "filter_has_tool_use",
+    "has_thinking": "filter_has_thinking",
+}
+
+
+def normalize_query_params(params: Mapping[str, object]) -> dict[str, object]:
+    """Normalize MCP query kwargs into substrate query-spec parameter names."""
+    normalized = dict(params)
+    for source_key, target_key in _QUERY_PARAM_ALIASES.items():
+        if source_key in normalized:
+            normalized[target_key] = normalized.pop(source_key)
+    return normalized
+
+
+def build_query_spec(**params: object) -> ConversationQuerySpec:
+    """Build a ConversationQuerySpec from MCP-facing query kwargs."""
+    return ConversationQuerySpec.from_params(normalize_query_params(params))
+
+
+__all__ = ["build_query_spec", "normalize_query_params"]

--- a/polylogue/mcp/server_product_tools.py
+++ b/polylogue/mcp/server_product_tools.py
@@ -7,11 +7,10 @@ lookups) are registered directly.
 
 from __future__ import annotations
 
-import inspect
-from collections.abc import Mapping
 from typing import TYPE_CHECKING
 
 from polylogue.mcp.payloads import MCPRootPayload
+from polylogue.mcp.product_tool_contracts import ProductListToolSpec
 from polylogue.products.registry import (
     PRODUCT_REGISTRY,
     ProductType,
@@ -24,105 +23,18 @@ if TYPE_CHECKING:
     from polylogue.mcp.server_support import ServerCallbacks
 
 
-def _query_field_defaults(pt: ProductType) -> tuple[dict[str, object | None], dict[str, object]]:
-    query_model = pt.query_model
-    if query_model is None:
-        raise ValueError(f"Product type {pt.name} does not declare a query model")
-
-    defaults: dict[str, object | None] = {}
-    annotations: dict[str, object] = {}
-    for field_name, field_info in query_model.model_fields.items():
-        defaults[field_name] = None if field_info.is_required() else field_info.get_default(call_default_factory=True)
-        annotations[field_name] = field_info.annotation if field_info.annotation is not None else object
-    return defaults, annotations
-
-
-def _sanitize_offset(value: object) -> int:
-    if isinstance(value, bool):
-        return 0
-    if isinstance(value, (int, str, bytes, bytearray)):
-        return max(0, int(value))
-    return 0
-
-
-def _normalize_list_tool_kwargs(
-    hooks: ServerCallbacks,
-    kwargs: Mapping[str, object],
-) -> dict[str, object]:
-    normalized = dict(kwargs)
-    if "limit" in normalized:
-        normalized["limit"] = hooks.clamp_limit(normalized["limit"])
-    if "offset" in normalized:
-        normalized["offset"] = _sanitize_offset(normalized["offset"])
-    return normalized
-
-
-def _build_list_tool_parameters(
-    pt: ProductType,
-    *,
-    field_defaults: dict[str, object | None],
-    field_annotations: dict[str, object],
-) -> list[inspect.Parameter]:
-    params: list[inspect.Parameter] = []
-    for field_name in sorted(field_annotations):
-        if field_name == "limit":
-            params.append(
-                inspect.Parameter(
-                    field_name,
-                    inspect.Parameter.KEYWORD_ONLY,
-                    default=pt.mcp_default_limit,
-                    annotation=int,
-                )
-            )
-            continue
-        if field_name == "offset":
-            params.append(
-                inspect.Parameter(
-                    field_name,
-                    inspect.Parameter.KEYWORD_ONLY,
-                    default=0,
-                    annotation=int,
-                )
-            )
-            continue
-        params.append(
-            inspect.Parameter(
-                field_name,
-                inspect.Parameter.KEYWORD_ONLY,
-                default=field_defaults.get(field_name),
-                annotation=field_annotations[field_name],
-            )
-        )
-    return params
-
-
-def _wrapper_annotations(params: list[inspect.Parameter]) -> dict[str, object]:
-    annotations: dict[str, object] = {parameter.name: parameter.annotation for parameter in params}
-    annotations["return"] = str
-    return annotations
-
-
 def _register_list_tool(
     mcp: FastMCP,
     hooks: ServerCallbacks,
     pt: ProductType,
 ) -> None:
     """Register one list-style MCP tool for a product type."""
-
-    query_model = pt.query_model
-    if query_model is None:
-        raise ValueError(f"Product type {pt.name} does not declare a query model")
-    field_defaults, field_annotations = _query_field_defaults(pt)
-    params = _build_list_tool_parameters(
-        pt,
-        field_defaults=field_defaults,
-        field_annotations=field_annotations,
-    )
+    spec = ProductListToolSpec.from_product_type(pt)
 
     async def tool_fn(**kwargs: object) -> str:
         async def run() -> str:
             ops = hooks.get_archive_ops()
-            normalized_kwargs = _normalize_list_tool_kwargs(hooks, kwargs)
+            normalized_kwargs = spec.normalize_kwargs(hooks.clamp_limit, kwargs)
             products = await fetch_products_async(pt, ops, **normalized_kwargs)
             return hooks.json_payload(
                 MCPRootPayload(
@@ -138,12 +50,12 @@ def _register_list_tool(
     async def wrapper(**kw: object) -> str:
         return await tool_fn(**kw)
 
-    wrapper.__name__ = pt.name
-    wrapper.__qualname__ = pt.name
-    wrapper.__doc__ = f"List {pt.display_name.lower()} from the archive."
+    wrapper.__name__ = spec.name
+    wrapper.__qualname__ = spec.name
+    wrapper.__doc__ = spec.doc
 
-    wrapper.__annotations__ = _wrapper_annotations(params)
-    wrapper.__kwdefaults__ = {parameter.name: parameter.default for parameter in params}
+    wrapper.__annotations__ = spec.signature.annotations
+    wrapper.__kwdefaults__ = spec.signature.kwdefaults
 
     mcp.tool()(wrapper)
 

--- a/polylogue/mcp/server_prompts.py
+++ b/polylogue/mcp/server_prompts.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, TypeAlias
 from typing_extensions import TypedDict
 
 from polylogue.mcp.payloads import MCPFencedCodeBlock
-from polylogue.mcp.server_tools import build_query_spec
+from polylogue.mcp.query_contracts import build_query_spec
 from polylogue.types import Provider
 
 if TYPE_CHECKING:

--- a/polylogue/mcp/server_prompts.py
+++ b/polylogue/mcp/server_prompts.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, TypeAlias
 from typing_extensions import TypedDict
 
 from polylogue.mcp.payloads import MCPFencedCodeBlock
-from polylogue.mcp.query_contracts import build_query_spec
+from polylogue.mcp.query_contracts import MCPConversationQueryRequest
 from polylogue.types import Provider
 
 if TYPE_CHECKING:
@@ -101,12 +101,12 @@ def register_prompts(mcp: FastMCP, hooks: ServerCallbacks) -> None:
         limit: int = 50,
     ) -> str:
         store = hooks.get_query_store()
-        spec = build_query_spec(
+        spec = MCPConversationQueryRequest(
             query="error",
             provider=provider,
             since=since,
-            limit=hooks.clamp_limit(limit),
-        )
+            limit=limit,
+        ).build_spec(hooks.clamp_limit)
         convs = await spec.list(store)
 
         error_contexts: list[ErrorContextPayload] = []
@@ -144,10 +144,10 @@ Error contexts:
     async def summarize_week(limit: int = 100) -> str:
         store = hooks.get_query_store()
         week_ago = (datetime.now(tz=timezone.utc) - timedelta(days=7)).isoformat()
-        spec = build_query_spec(
+        spec = MCPConversationQueryRequest(
             since=week_ago,
-            limit=hooks.clamp_limit(limit),
-        )
+            limit=limit,
+        ).build_spec(hooks.clamp_limit)
         convs = await spec.list(store)
 
         by_provider: dict[str, int] = {}
@@ -175,7 +175,7 @@ Focus on actionable insights and patterns, not exhaustive summaries.
     @mcp.prompt()
     async def extract_code(language: str = "", limit: int = 50) -> str:
         store = hooks.get_query_store()
-        convs = await build_query_spec(limit=hooks.clamp_limit(limit)).list(store)
+        convs = await MCPConversationQueryRequest(limit=limit).build_spec(hooks.clamp_limit).list(store)
 
         code_snippets: list[ExtractedCodeSnippetPayload] = []
         for conv in convs:
@@ -225,10 +225,10 @@ Conversation 2:
     @mcp.prompt()
     async def extract_patterns(provider: str | None = None, limit: int = 30) -> str:
         store = hooks.get_query_store()
-        spec = build_query_spec(
+        spec = MCPConversationQueryRequest(
             provider=provider,
-            limit=hooks.clamp_limit(limit),
-        )
+            limit=limit,
+        ).build_spec(hooks.clamp_limit)
         convs = await spec.list(store)
 
         summaries: list[ConversationPatternPayload] = []

--- a/polylogue/mcp/server_resources.py
+++ b/polylogue/mcp/server_resources.py
@@ -12,7 +12,7 @@ from polylogue.mcp.payloads import (
     MCPTagCountsPayload,
     conversation_summary_list_payload,
 )
-from polylogue.mcp.query_contracts import build_query_spec
+from polylogue.mcp.query_contracts import MCPConversationQueryRequest
 
 if TYPE_CHECKING:
     from mcp.server.fastmcp import FastMCP
@@ -37,7 +37,7 @@ def register_resources(mcp: FastMCP, hooks: ServerCallbacks) -> None:
 
     @mcp.resource("polylogue://conversations")
     async def conversations_resource() -> str:
-        convs = await build_query_spec().list(hooks.get_query_store())
+        convs = await MCPConversationQueryRequest().build_spec(hooks.clamp_limit).list(hooks.get_query_store())
         return hooks.json_payload(conversation_summary_list_payload(convs))
 
     @mcp.resource("polylogue://conversation/{conv_id}")

--- a/polylogue/mcp/server_resources.py
+++ b/polylogue/mcp/server_resources.py
@@ -12,7 +12,7 @@ from polylogue.mcp.payloads import (
     MCPTagCountsPayload,
     conversation_summary_list_payload,
 )
-from polylogue.mcp.server_tools import build_query_spec
+from polylogue.mcp.query_contracts import build_query_spec
 
 if TYPE_CHECKING:
     from mcp.server.fastmcp import FastMCP

--- a/polylogue/mcp/server_tools.py
+++ b/polylogue/mcp/server_tools.py
@@ -12,7 +12,7 @@ from polylogue.mcp.payloads import (
     MCPStatsByPayload,
     conversation_summary_list_payload,
 )
-from polylogue.mcp.query_contracts import build_query_spec
+from polylogue.mcp.query_contracts import MCPConversationQueryRequest
 from polylogue.mcp.server_maintenance_tools import register_maintenance_tools
 from polylogue.mcp.server_mutation_tools import register_mutation_tools
 from polylogue.mcp.server_product_tools import register_product_tools
@@ -45,9 +45,9 @@ def register_query_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
     ) -> str:
         async def run() -> str:
             ops = hooks.get_archive_ops()
-            spec = build_query_spec(
+            spec = MCPConversationQueryRequest(
                 query=query,
-                retrieval_lane=retrieval_lane or "auto",
+                retrieval_lane=retrieval_lane,
                 provider=provider,
                 since=since,
                 path=path,
@@ -57,12 +57,12 @@ def register_query_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
                 action_text=action_text,
                 tool=tool,
                 exclude_tool=exclude_tool,
-                limit=hooks.clamp_limit(limit),
+                limit=limit,
                 has_tool_use=has_tool_use,
                 has_thinking=has_thinking,
                 min_messages=min_messages,
                 min_words=min_words,
-            )
+            ).build_spec(hooks.clamp_limit)
             results = await ops.query_conversations(spec)
             return hooks.json_payload(conversation_summary_list_payload(results))
 
@@ -91,9 +91,9 @@ def register_query_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
     ) -> str:
         async def run() -> str:
             ops = hooks.get_archive_ops()
-            spec = build_query_spec(
+            spec = MCPConversationQueryRequest(
                 provider=provider,
-                retrieval_lane=retrieval_lane or "auto",
+                retrieval_lane=retrieval_lane,
                 tag=tag,
                 title=title,
                 since=since,
@@ -105,12 +105,12 @@ def register_query_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
                 tool=tool,
                 exclude_tool=exclude_tool,
                 sort=sort,
-                limit=hooks.clamp_limit(limit),
+                limit=limit,
                 has_tool_use=has_tool_use,
                 has_thinking=has_thinking,
                 min_messages=min_messages,
                 min_words=min_words,
-            )
+            ).build_spec(hooks.clamp_limit)
             conversations = await ops.query_conversations(spec)
             return hooks.json_payload(conversation_summary_list_payload(conversations))
 

--- a/polylogue/mcp/server_tools.py
+++ b/polylogue/mcp/server_tools.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from polylogue.lib.query_spec import ConversationQuerySpec
 from polylogue.mcp.payloads import (
     MCPArchiveStatsPayload,
     MCPConversationDetailPayload,
@@ -13,6 +12,7 @@ from polylogue.mcp.payloads import (
     MCPStatsByPayload,
     conversation_summary_list_payload,
 )
+from polylogue.mcp.query_contracts import build_query_spec
 from polylogue.mcp.server_maintenance_tools import register_maintenance_tools
 from polylogue.mcp.server_mutation_tools import register_mutation_tools
 from polylogue.mcp.server_product_tools import register_product_tools
@@ -21,15 +21,6 @@ if TYPE_CHECKING:
     from mcp.server.fastmcp import FastMCP
 
     from polylogue.mcp.server_support import ServerCallbacks
-
-
-def build_query_spec(**params: object) -> ConversationQuerySpec:
-    normalized = dict(params)
-    if "has_tool_use" in normalized:
-        normalized["filter_has_tool_use"] = normalized.pop("has_tool_use")
-    if "has_thinking" in normalized:
-        normalized["filter_has_thinking"] = normalized.pop("has_thinking")
-    return ConversationQuerySpec.from_params(normalized)
 
 
 def register_query_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:

--- a/polylogue/rendering/blocks.py
+++ b/polylogue/rendering/blocks.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
+from html import escape
 
 from polylogue.rendering.block_models import RenderableBlock
+from polylogue.types import ContentBlockType
 
 # -------------------------------------------------------------------
 # Markdown rendering
@@ -32,53 +34,55 @@ def render_blocks_markdown(blocks: Sequence[RenderableBlock]) -> str:
 
 def _render_block_markdown(block: RenderableBlock) -> str:
     """Render a single content block to markdown."""
-    block_type = block.type
+    return _MARKDOWN_BLOCK_RENDERERS.get(block.type, _render_text_block_markdown)(block)
 
-    if block_type == "thinking":
-        text = block.text or ""
-        if not text.strip():
-            return ""
-        return f"<details><summary>Thinking</summary>\n\n{text.strip()}\n\n</details>"
 
-    if block_type == "tool_use":
-        name = block.tool_name or "unknown"
-        tool_input = block.tool_input
-        summary = _tool_input_summary(name, tool_input)
-        header = f"**Tool: {name}**"
-        if summary:
-            header += f" {summary}"
-        return header
+def _render_thinking_markdown(block: RenderableBlock) -> str:
+    text = _strip_text(block.text)
+    if not text:
+        return ""
+    return f"<details><summary>Thinking</summary>\n\n{text}\n\n</details>"
 
-    if block_type == "tool_result":
-        text = _extract_block_text(block)
-        if not text.strip():
-            return ""
-        # Short results inline, long results fenced
-        if len(text) < 200 and "\n" not in text:
-            return f"→ {text.strip()}"
-        return f"```\n{text.strip()}\n```"
 
-    if block_type == "code":
-        text = block.text or ""
-        lang = block.language or ""
-        if not text.strip():
-            return ""
-        return f"```{lang}\n{text.strip()}\n```"
+def _render_tool_use_markdown(block: RenderableBlock) -> str:
+    name = block.tool_name or "unknown"
+    summary = _tool_input_summary(name, block.tool_input)
+    header = f"**Tool: {name}**"
+    if summary:
+        header += f" {summary}"
+    return header
 
-    if block_type in ("image", "document", "file"):
-        url = block.url or ""
-        mime = block.mime_type or ""
-        name = block.name or block_type
-        parts = [f"[{name}]"]
-        if url:
-            parts[0] = f"[{name}]({url})"
-        if mime:
-            parts.append(f"({mime})")
-        return " ".join(parts)
 
-    # Default: text block
-    text = block.text or ""
-    return text.strip() if text else ""
+def _render_tool_result_markdown(block: RenderableBlock) -> str:
+    text = _extract_block_text(block).strip()
+    if not text:
+        return ""
+    if len(text) < 200 and "\n" not in text:
+        return f"→ {text}"
+    return f"```\n{text}\n```"
+
+
+def _render_code_markdown(block: RenderableBlock) -> str:
+    text = _strip_text(block.text)
+    if not text:
+        return ""
+    return f"```{block.language or ''}\n{text}\n```"
+
+
+def _render_media_markdown(block: RenderableBlock) -> str:
+    url = block.url or ""
+    mime = block.mime_type or ""
+    name = block.name or block.type
+    parts = [f"[{name}]"]
+    if url:
+        parts[0] = f"[{name}]({url})"
+    if mime:
+        parts.append(f"({mime})")
+    return " ".join(parts)
+
+
+def _render_text_block_markdown(block: RenderableBlock) -> str:
+    return _strip_text(block.text)
 
 
 def _tool_input_summary(name: str | None, tool_input: Mapping[str, object] | None) -> str:
@@ -114,7 +118,6 @@ def _tool_input_summary(name: str | None, tool_input: Mapping[str, object] | Non
     for key, value in tool_input.items():
         if isinstance(value, str) and len(value) < 60:
             return f"{key}={value}"
-        break
 
     return ""
 
@@ -136,57 +139,51 @@ def render_blocks_html(blocks: Sequence[RenderableBlock]) -> str:
 
 def _render_block_html(block: RenderableBlock) -> str:
     """Render a single content block to HTML."""
-    block_type = block.type
+    return _HTML_BLOCK_RENDERERS.get(block.type, _render_text_block_html)(block)
 
-    if block_type == "thinking":
-        text = block.text or ""
-        if not text.strip():
-            return ""
-        from html import escape
 
-        return (
-            '<details class="thinking-block">\n'
-            '  <summary class="thinking-label">Thinking</summary>\n'
-            f'  <div class="thinking-content">{escape(text.strip())}</div>\n'
-            "</details>"
-        )
-
-    if block_type == "tool_use":
-        from html import escape
-
-        name = escape(block.tool_name or "unknown")
-        summary = _tool_input_summary(block.tool_name, block.tool_input)
-        summary_html = ""
-        if summary:
-            summary_html = " <code>" + escape(summary.strip('`"')) + "</code>"
-        return f'<div class="tool-use-block"><span class="tool-name">{name}</span>{summary_html}</div>'
-
-    if block_type == "tool_result":
-        from html import escape
-
-        text = _extract_block_text(block)
-        if not text.strip():
-            return ""
-        return f'<pre class="tool-result-block">{escape(text.strip())}</pre>'
-
-    if block_type == "code":
-        from html import escape
-
-        text = block.text or ""
-        lang = block.language or ""
-        if not text.strip():
-            return ""
-        lang_attr = f' data-language="{escape(lang)}"' if lang else ""
-        return f'<pre class="code-block"{lang_attr}><code>{escape(text.strip())}</code></pre>'
-
-    # Default: text
-    text = block.text or ""
-    if not text.strip():
+def _render_thinking_html(block: RenderableBlock) -> str:
+    text = _strip_text(block.text)
+    if not text:
         return ""
-    from html import escape
+    return (
+        '<details class="thinking-block">\n'
+        '  <summary class="thinking-label">Thinking</summary>\n'
+        f'  <div class="thinking-content">{escape(text)}</div>\n'
+        "</details>"
+    )
 
+
+def _render_tool_use_html(block: RenderableBlock) -> str:
+    name = escape(block.tool_name or "unknown")
+    summary = _tool_input_summary(block.tool_name, block.tool_input)
+    summary_html = ""
+    if summary:
+        summary_html = " <code>" + escape(summary.strip('`"')) + "</code>"
+    return f'<div class="tool-use-block"><span class="tool-name">{name}</span>{summary_html}</div>'
+
+
+def _render_tool_result_html(block: RenderableBlock) -> str:
+    text = _strip_text(_extract_block_text(block))
+    if not text:
+        return ""
+    return f'<pre class="tool-result-block">{escape(text)}</pre>'
+
+
+def _render_code_html(block: RenderableBlock) -> str:
+    text = _strip_text(block.text)
+    if not text:
+        return ""
+    lang = block.language or ""
+    lang_attr = f' data-language="{escape(lang)}"' if lang else ""
+    return f'<pre class="code-block"{lang_attr}><code>{escape(text)}</code></pre>'
+
+
+def _render_text_block_html(block: RenderableBlock) -> str:
     # Simple paragraph wrapping for plain text
-    paragraphs = text.strip().split("\n\n")
+    if not block.text or not block.text.strip():
+        return ""
+    paragraphs = block.text.strip().split("\n\n")
     return "\n".join(f"<p>{escape(p.strip())}</p>" for p in paragraphs if p.strip())
 
 
@@ -199,27 +196,9 @@ def render_blocks_plaintext(blocks: Sequence[RenderableBlock]) -> str:
     """Render content blocks to plain text (no formatting)."""
     parts: list[str] = []
     for block in blocks:
-        block_type = block.type
-
-        if block_type == "thinking":
-            text = block.text or ""
-            if text.strip():
-                parts.append(f"[Thinking] {text.strip()}")
-
-        elif block_type == "tool_use":
-            name = block.tool_name or "unknown"
-            summary = _tool_input_summary(name, block.tool_input)
-            parts.append(f"[Tool: {name}] {summary}".strip())
-
-        elif block_type == "tool_result":
-            text = _extract_block_text(block)
-            if text.strip():
-                parts.append(text.strip())
-
-        else:
-            text = block.text or ""
-            if text.strip():
-                parts.append(text.strip())
+        rendered = _render_block_plaintext(block)
+        if rendered:
+            parts.append(rendered)
 
     return "\n\n".join(parts) if parts else ""
 
@@ -238,7 +217,83 @@ def has_structured_blocks(blocks: Sequence[RenderableBlock] | None) -> bool:
     """Check if a block list contains non-text typed blocks worth rendering structurally."""
     if not blocks:
         return False
-    return any(block.type in ("thinking", "tool_use", "tool_result", "code") for block in blocks)
+    return any(block.type in _STRUCTURED_BLOCK_TYPES for block in blocks)
+
+
+def _strip_text(value: str | None) -> str:
+    return (value or "").strip()
+
+
+def _noop_renderer(_block: RenderableBlock) -> str:
+    return ""
+
+
+def _render_block_plaintext(block: RenderableBlock) -> str:
+    """Render a single content block to plaintext."""
+    return _PLAIN_BLOCK_RENDERERS.get(block.type, _render_text_block_plaintext)(block)
+
+
+_MEDIA_BLOCK_TYPES = frozenset(
+    {
+        ContentBlockType.IMAGE.value,
+        ContentBlockType.DOCUMENT.value,
+        "file",
+    }
+)
+
+
+_MARKDOWN_BLOCK_RENDERERS: dict[str, Callable[[RenderableBlock], str]] = {
+    ContentBlockType.THINKING.value: _render_thinking_markdown,
+    ContentBlockType.TOOL_USE.value: _render_tool_use_markdown,
+    ContentBlockType.TOOL_RESULT.value: _render_tool_result_markdown,
+    ContentBlockType.CODE.value: _render_code_markdown,
+    **dict.fromkeys(_MEDIA_BLOCK_TYPES, _render_media_markdown),
+}
+
+
+_HTML_BLOCK_RENDERERS: dict[str, Callable[[RenderableBlock], str]] = {
+    ContentBlockType.THINKING.value: _render_thinking_html,
+    ContentBlockType.TOOL_USE.value: _render_tool_use_html,
+    ContentBlockType.TOOL_RESULT.value: _render_tool_result_html,
+    ContentBlockType.CODE.value: _render_code_html,
+    **dict.fromkeys(_MEDIA_BLOCK_TYPES, _noop_renderer),
+}
+
+
+def _render_text_block_plaintext(block: RenderableBlock) -> str:
+    return _strip_text(block.text)
+
+
+def _render_tool_use_plaintext(block: RenderableBlock) -> str:
+    name = block.tool_name or "unknown"
+    summary = _tool_input_summary(name, block.tool_input)
+    return f"[Tool: {name}] {summary}".strip()
+
+
+def _render_thinking_plaintext(block: RenderableBlock) -> str:
+    text = _strip_text(block.text)
+    if not text:
+        return ""
+    return f"[Thinking] {text}"
+
+
+def _render_tool_result_plaintext(block: RenderableBlock) -> str:
+    return _strip_text(_extract_block_text(block))
+
+
+_PLAIN_BLOCK_RENDERERS: dict[str, Callable[[RenderableBlock], str]] = {
+    ContentBlockType.THINKING.value: _render_thinking_plaintext,
+    ContentBlockType.TOOL_USE.value: _render_tool_use_plaintext,
+    ContentBlockType.TOOL_RESULT.value: _render_tool_result_plaintext,
+}
+
+
+_STRUCTURED_BLOCK_TYPES = {
+    ContentBlockType.THINKING.value,
+    ContentBlockType.TOOL_USE.value,
+    ContentBlockType.TOOL_RESULT.value,
+    ContentBlockType.CODE.value,
+}
 
 
 __all__ = [

--- a/polylogue/rendering/core_markdown.py
+++ b/polylogue/rendering/core_markdown.py
@@ -4,14 +4,14 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
-from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from polylogue.assets import asset_path
 from polylogue.lib.roles import Role
 from polylogue.rendering.block_models import RenderableBlock, coerce_renderable_blocks
 from polylogue.rendering.blocks import has_structured_blocks, render_blocks_markdown
+from polylogue.rendering.core_messages import normalize_render_timestamp
 
 if TYPE_CHECKING:
     from polylogue.lib.models import Conversation
@@ -125,19 +125,6 @@ def render_markdown_document(
     return "\n".join(lines).strip() + "\n"
 
 
-def _normalize_markdown_timestamp(timestamp: Any) -> str | None:
-    if timestamp is None:
-        return None
-    if isinstance(timestamp, datetime):
-        return timestamp.isoformat()
-    if isinstance(timestamp, (int, float)):
-        try:
-            return datetime.fromtimestamp(float(timestamp), tz=timezone.utc).isoformat().replace("+00:00", "Z")
-        except (ValueError, OSError):
-            return None
-    return str(timestamp)
-
-
 def _normalize_markdown_attachment(
     *,
     attachment_id: str,
@@ -165,7 +152,7 @@ def _normalize_markdown_message(
         message_id=message_id,
         role=str(normalized_role),
         text=text,
-        timestamp=_normalize_markdown_timestamp(timestamp),
+        timestamp=normalize_render_timestamp(timestamp),
         content_blocks=content_blocks,
     )
 

--- a/polylogue/rendering/core_messages.py
+++ b/polylogue/rendering/core_messages.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import re
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
+from typing import cast, overload
 
 from polylogue.rendering.block_models import RenderableBlock
 from polylogue.rendering.blocks import (
@@ -62,27 +63,85 @@ def role_css_class(role: str) -> str:
     return "message-" + _ROLE_CLASS_RE.sub("-", role.lower())
 
 
-def attach_rendered_message_branches(messages: Sequence[RenderedMessage]) -> list[RenderedMessage]:
-    """Attach branch messages to their mainline sibling in a typed message list."""
-    typed_messages = list(messages)
-    if not any(message.branch_index for message in typed_messages):
-        return typed_messages
+def _mapping_branch_index(message: Mapping[str, object]) -> int:
+    return normalize_render_branch_index(message.get("branch_index"))
 
-    mainline = [message for message in typed_messages if not message.branch_index]
+
+def _mapping_parent_message_id(message: Mapping[str, object]) -> str | None:
+    parent_message_id = message.get("parent_message_id")
+    if parent_message_id is None:
+        return None
+    return str(parent_message_id)
+
+
+def _attach_mapping_message_branches(messages: Sequence[Mapping[str, object]]) -> list[dict[str, object]]:
+    copied_messages = [dict(message) for message in messages]
+    if not any(_mapping_branch_index(message) for message in copied_messages):
+        return copied_messages
+
+    mainline = [message for message in copied_messages if not _mapping_branch_index(message)]
     mainline_by_parent = {
-        message.parent_message_id: message for message in mainline if message.parent_message_id is not None
+        parent_message_id: message
+        for message in mainline
+        if (parent_message_id := _mapping_parent_message_id(message)) is not None
     }
 
-    for message in typed_messages:
-        if not message.branch_index or message.parent_message_id is None:
+    for message in copied_messages:
+        branch_index = _mapping_branch_index(message)
+        parent_message_id = _mapping_parent_message_id(message)
+        if not branch_index or parent_message_id is None:
             continue
-        sibling = mainline_by_parent.get(message.parent_message_id)
+        sibling = mainline_by_parent.get(parent_message_id)
         if sibling is None:
             mainline.append(message)
             continue
-        sibling.branches.append(message)
+        sibling.setdefault("branches", [])
+        branches = sibling["branches"]
+        if isinstance(branches, list):
+            branches.append(message)
 
     return mainline
+
+
+@overload
+def attach_rendered_message_branches(messages: Sequence[RenderedMessage]) -> list[RenderedMessage]: ...
+
+
+@overload
+def attach_rendered_message_branches(messages: Sequence[Mapping[str, object]]) -> list[dict[str, object]]: ...
+
+
+def attach_rendered_message_branches(
+    messages: Sequence[RenderedMessage] | Sequence[Mapping[str, object]],
+) -> list[RenderedMessage] | list[dict[str, object]]:
+    """Attach branch messages to their mainline sibling for typed or mapping payloads."""
+    if not messages:
+        return []
+    if all(isinstance(message, RenderedMessage) for message in messages):
+        typed_messages = cast(list[RenderedMessage], list(messages))
+        if not any(message.branch_index for message in typed_messages):
+            return typed_messages
+
+        mainline = [message for message in typed_messages if not message.branch_index]
+        mainline_by_parent = {
+            message.parent_message_id: message for message in mainline if message.parent_message_id is not None
+        }
+
+        for message in typed_messages:
+            if not message.branch_index or message.parent_message_id is None:
+                continue
+            sibling = mainline_by_parent.get(message.parent_message_id)
+            if sibling is None:
+                mainline.append(message)
+                continue
+            sibling.branches.append(message)
+
+        return mainline
+
+    mapping_messages = cast(
+        list[Mapping[str, object]], [message for message in messages if isinstance(message, Mapping)]
+    )
+    return _attach_mapping_message_branches(mapping_messages)
 
 
 def build_rendered_message(

--- a/polylogue/rendering/core_messages.py
+++ b/polylogue/rendering/core_messages.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+import re
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 
@@ -12,6 +13,8 @@ from polylogue.rendering.blocks import (
     render_blocks_html,
     render_blocks_plaintext,
 )
+
+_ROLE_CLASS_RE = re.compile(r"[^a-z0-9-]")
 
 
 @dataclass(slots=True)
@@ -29,7 +32,7 @@ class RenderedMessage:
     branches: list[RenderedMessage] = field(default_factory=list)
 
 
-def _normalize_timestamp(timestamp: object) -> str | None:
+def normalize_render_timestamp(timestamp: object) -> str | None:
     if timestamp is None:
         return None
     if isinstance(timestamp, datetime):
@@ -42,7 +45,7 @@ def _normalize_timestamp(timestamp: object) -> str | None:
     return str(timestamp)
 
 
-def _normalize_branch_index(value: object) -> int:
+def normalize_render_branch_index(value: object) -> int:
     if value is None:
         return 0
     if isinstance(value, bool):
@@ -53,6 +56,33 @@ def _normalize_branch_index(value: object) -> int:
         return int(str(value))
     except ValueError:
         return 0
+
+
+def role_css_class(role: str) -> str:
+    return "message-" + _ROLE_CLASS_RE.sub("-", role.lower())
+
+
+def attach_rendered_message_branches(messages: Sequence[RenderedMessage]) -> list[RenderedMessage]:
+    """Attach branch messages to their mainline sibling in a typed message list."""
+    typed_messages = list(messages)
+    if not any(message.branch_index for message in typed_messages):
+        return typed_messages
+
+    mainline = [message for message in typed_messages if not message.branch_index]
+    mainline_by_parent = {
+        message.parent_message_id: message for message in mainline if message.parent_message_id is not None
+    }
+
+    for message in typed_messages:
+        if not message.branch_index or message.parent_message_id is None:
+            continue
+        sibling = mainline_by_parent.get(message.parent_message_id)
+        if sibling is None:
+            mainline.append(message)
+            continue
+        sibling.branches.append(message)
+
+    return mainline
 
 
 def build_rendered_message(
@@ -77,14 +107,16 @@ def build_rendered_message(
     html_content = render_blocks_html(content_blocks) if has_structured_blocks(content_blocks) else render_html(text)
     preview_text = display_text[:preview_limit] if preview_limit is not None else display_text
     normalized_parent = str(parent_message_id) if parent_message_id is not None else None
+    normalized_role_text = str(normalized_role)
     return RenderedMessage(
         id=str(message_id),
-        role=str(normalized_role),
+        role=normalized_role_text,
         text=preview_text,
         html_content=html_content,
-        timestamp=_normalize_timestamp(timestamp),
+        timestamp=normalize_render_timestamp(timestamp),
         parent_message_id=normalized_parent,
-        branch_index=_normalize_branch_index(branch_index),
+        branch_index=normalize_render_branch_index(branch_index),
+        role_class=role_css_class(normalized_role_text),
     )
 
 
@@ -115,7 +147,11 @@ def build_rendered_message_payload(
 
 
 __all__ = [
+    "attach_rendered_message_branches",
     "build_rendered_message",
     "build_rendered_message_payload",
+    "normalize_render_branch_index",
+    "normalize_render_timestamp",
+    "role_css_class",
     "RenderedMessage",
 ]

--- a/polylogue/rendering/renderers/html_messages.py
+++ b/polylogue/rendering/renderers/html_messages.py
@@ -2,75 +2,16 @@
 
 from __future__ import annotations
 
-import re
 from collections.abc import Callable
-from typing import TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING
 
 from polylogue.rendering.block_models import coerce_renderable_blocks
 from polylogue.rendering.core import build_rendered_message
-from polylogue.rendering.core_messages import RenderedMessage
+from polylogue.rendering.core_messages import RenderedMessage, attach_rendered_message_branches
 
 if TYPE_CHECKING:
     from polylogue.lib.models import Conversation
     from polylogue.storage.archive_views import ConversationRenderProjection
-
-_ROLE_CLASS_RE = re.compile(r"[^a-z0-9-]")
-TMessage = TypeVar("TMessage", RenderedMessage, dict[str, object])
-
-
-def _role_css_class(role: str) -> str:
-    return "message-" + _ROLE_CLASS_RE.sub("-", role.lower())
-
-
-def _branch_index(message: RenderedMessage | dict[str, object]) -> int:
-    if isinstance(message, RenderedMessage):
-        return message.branch_index
-    value = message.get("branch_index")
-    return value if isinstance(value, int) else 0
-
-
-def _parent_message_id(message: RenderedMessage | dict[str, object]) -> str | None:
-    if isinstance(message, RenderedMessage):
-        return message.parent_message_id
-    value = message.get("parent_message_id")
-    return value if isinstance(value, str) else None
-
-
-def _append_branch(message: RenderedMessage | dict[str, object], branch: RenderedMessage | dict[str, object]) -> None:
-    if isinstance(message, RenderedMessage):
-        if isinstance(branch, RenderedMessage):
-            message.branches.append(branch)
-        return
-    branches = message.setdefault("branches", [])
-    if isinstance(branches, list):
-        branches.append(branch)
-
-
-def _attach_branches(messages: list[TMessage]) -> list[TMessage]:
-    if not any(_branch_index(message) for message in messages):
-        return messages
-
-    mainline = [message for message in messages if not _branch_index(message)]
-
-    mainline_by_parent: dict[str, TMessage] = {}
-    for msg in mainline:
-        pid = _parent_message_id(msg)
-        if pid:
-            mainline_by_parent[pid] = msg
-
-    for msg in messages:
-        branch_idx = _branch_index(msg)
-        parent_id = _parent_message_id(msg)
-        if not branch_idx or not parent_id:
-            continue
-
-        sibling = mainline_by_parent.get(parent_id)
-        if sibling is not None:
-            _append_branch(sibling, msg)
-        else:
-            mainline.append(msg)
-
-    return mainline
 
 
 def build_projection_html_messages(
@@ -95,9 +36,8 @@ def build_projection_html_messages(
             render_html=render_html,
             preview_limit=preview_limit,
         )
-        payload.role_class = _role_css_class(payload.role)
         raw_messages.append(payload)
-    return _attach_branches(raw_messages)
+    return attach_rendered_message_branches(raw_messages)
 
 
 def build_conversation_html_messages(
@@ -121,9 +61,11 @@ def build_conversation_html_messages(
             render_html=render_html,
             preview_limit=preview_limit,
         )
-        payload.role_class = _role_css_class(payload.role)
         raw_messages.append(payload)
-    return _attach_branches(raw_messages)
+    return attach_rendered_message_branches(raw_messages)
+
+
+_attach_branches = attach_rendered_message_branches
 
 
 __all__ = [

--- a/polylogue/ui/facade.py
+++ b/polylogue/ui/facade.py
@@ -6,6 +6,7 @@ from collections import deque
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import cast
 
 import questionary
 from rich import box
@@ -17,6 +18,7 @@ from polylogue.ui.facade_console import ConsoleLike, PlainConsole
 from polylogue.ui.facade_prompts import (
     _NO_STUB_RESPONSE,
     PromptStubEntry,
+    _NoStubResponse,
     consume_choose_stub,
     consume_confirm_stub,
     consume_input_stub,
@@ -70,13 +72,10 @@ class ConsoleFacade:
         if self.plain:
             self.console = PlainConsole()
         else:
-            self.console = Console(no_color=False, force_terminal=True, theme=self.theme)
+            self.console = cast(ConsoleLike, Console(no_color=False, force_terminal=True, theme=self.theme))
         self._panel_box = box.ROUNDED
         self._banner_box = box.DOUBLE
         self._prompt_responses = load_prompt_responses(UIError, prompt_stub_path=self.prompt_stub_path)
-
-    def _load_prompt_responses(self) -> deque[PromptStubEntry]:
-        return load_prompt_responses(UIError, prompt_stub_path=self.prompt_stub_path)
 
     def _pop_prompt_response(self, kind: str) -> PromptStubEntry | None:
         return pop_prompt_response(self._prompt_responses, kind, UIError)
@@ -84,13 +83,13 @@ class ConsoleFacade:
     def _require_plain_prompt_tty(self, prompt_topic: str) -> None:
         require_plain_prompt_tty(prompt_topic, UIError)
 
-    def _consume_confirm_stub(self, *, default: bool) -> object:
+    def _consume_confirm_stub(self, *, default: bool) -> bool | _NoStubResponse:
         return consume_confirm_stub(self._prompt_responses, default=default, ui_error_cls=UIError)
 
-    def _consume_choose_stub(self, options: list[str]) -> object:
+    def _consume_choose_stub(self, options: list[str]) -> str | None | _NoStubResponse:
         return consume_choose_stub(self._prompt_responses, options, UIError)
 
-    def _consume_input_stub(self, *, default: str | None) -> object:
+    def _consume_input_stub(self, *, default: str | None) -> str | None | _NoStubResponse:
         return consume_input_stub(self._prompt_responses, default=default, ui_error_cls=UIError)
 
     def banner(self, title: str, subtitle: str | None = None) -> None:

--- a/polylogue/ui/facade_console.py
+++ b/polylogue/ui/facade_console.py
@@ -2,15 +2,40 @@
 
 from __future__ import annotations
 
+import io
 from contextlib import suppress
-from typing import Any, Protocol, runtime_checkable
+from typing import Protocol, runtime_checkable
 
+from rich.console import Console as RichConsole
+from rich.table import Table
 from rich.text import Text
 
 
 @runtime_checkable
 class ConsoleLike(Protocol):
-    def print(self, *objects: Any, **kwargs: Any) -> None: ...
+    def print(self, *objects: object, **kwargs: object) -> None: ...
+
+
+def _plain_text_from_markup(text: str) -> str:
+    with suppress(Exception):
+        return Text.from_markup(text).plain
+    return text
+
+
+def _render_plain_object(obj: object) -> str:
+    if isinstance(obj, Text):
+        return obj.plain
+    if isinstance(obj, str):
+        return _plain_text_from_markup(obj)
+
+    if isinstance(obj, Table):
+        buf = io.StringIO()
+        tmp = RichConsole(file=buf, highlight=False, no_color=True)
+        tmp.print(obj)
+        return buf.getvalue().rstrip()
+
+    raw = str(obj)
+    return _plain_text_from_markup(raw)
 
 
 class PlainConsole:
@@ -20,21 +45,8 @@ class PlainConsole:
         pass
 
     def print(self, *objects: object, **_: object) -> None:
-        import io
-
-        from rich.console import Console as RichConsole
-        from rich.table import Table
-
-        parts = []
-        for obj in objects:
-            if isinstance(obj, Table):
-                buf = io.StringIO()
-                tmp = RichConsole(file=buf, highlight=False, no_color=True)
-                tmp.print(obj)
-                parts.append(buf.getvalue().rstrip())
-            else:
-                raw = str(obj)
-                with suppress(Exception):
-                    raw = Text.from_markup(raw).plain
-                parts.append(raw)
+        parts = [_render_plain_object(obj) for obj in objects]
         print(" ".join(parts))
+
+
+__all__ = ["ConsoleLike", "PlainConsole"]

--- a/polylogue/ui/facade_rendering.py
+++ b/polylogue/ui/facade_rendering.py
@@ -3,13 +3,14 @@
 from __future__ import annotations
 
 import difflib
+from typing import Literal
 
 from pygments import highlight
 from pygments.formatters import TerminalFormatter
 from pygments.lexers import get_lexer_by_name
 from rich.align import Align
 from rich.box import Box
-from rich.console import Console
+from rich.console import Console, RenderableType
 from rich.markdown import Markdown
 from rich.panel import Panel
 from rich.syntax import Syntax
@@ -18,11 +19,37 @@ from rich.text import Text
 from polylogue.ui.facade_console import ConsoleLike
 
 
+def _print_plain_section(console: ConsoleLike, heading: str, content: str | None = None) -> None:
+    console.print(heading)
+    if content:
+        console.print(content)
+
+
+def _render_panel(
+    console: ConsoleLike,
+    body: RenderableType,
+    *,
+    border_style: str,
+    box: Box,
+    padding: tuple[int, int],
+    title: str | None = None,
+    title_align: Literal["left", "center", "right"] = "left",
+) -> None:
+    console.print(
+        Panel(
+            body,
+            border_style=border_style,
+            box=box,
+            padding=padding,
+            title=title,
+            title_align=title_align,
+        )
+    )
+
+
 def render_banner(console: ConsoleLike, *, plain: bool, banner_box: Box, title: str, subtitle: str | None) -> None:
     if plain:
-        console.print(f"== {title} ==")
-        if subtitle:
-            console.print(subtitle)
+        _print_plain_section(console, f"== {title} ==", subtitle)
         return
 
     title_text = Text(style="banner.title")
@@ -30,21 +57,19 @@ def render_banner(console: ConsoleLike, *, plain: bool, banner_box: Box, title: 
     title_text.append(title)
     if subtitle:
         title_text.append(f"\n{subtitle}", style="banner.subtitle")
-    panel = Panel(
+    _render_panel(
+        console,
         Align.left(title_text),
         border_style="banner.border",
         box=banner_box,
         padding=(1, 3),
     )
-    console.print(panel)
 
 
 def render_summary(console: ConsoleLike, *, plain: bool, panel_box: Box, title: str, lines: list[str]) -> None:
     text = "\n".join(lines)
     if plain:
-        console.print(f"-- {title} --")
-        if text:
-            console.print(text)
+        _print_plain_section(console, f"-- {title} --", text)
         return
 
     summary_text = Text()
@@ -53,7 +78,8 @@ def render_summary(console: ConsoleLike, *, plain: bool, panel_box: Box, title: 
         parsed = Text.from_markup(line, style="summary.text")
         summary_text.append_text(parsed)
         summary_text.append("\n")
-    panel = Panel(
+    _render_panel(
+        console,
         summary_text if summary_text.plain else Text(text, style="summary.text"),
         title=f"  {title}  ",
         title_align="left",
@@ -61,7 +87,6 @@ def render_summary(console: ConsoleLike, *, plain: bool, panel_box: Box, title: 
         box=panel_box,
         padding=(1, 2),
     )
-    console.print(panel)
 
 
 def render_markdown(console: ConsoleLike, *, plain: bool, panel_box: Box, content: str) -> None:
@@ -70,13 +95,13 @@ def render_markdown(console: ConsoleLike, *, plain: bool, panel_box: Box, conten
         return
 
     md = Markdown(content, style="summary.text")
-    panel = Panel(
+    _render_panel(
+        console,
         md,
         border_style="markdown.border",
         box=panel_box,
         padding=(1, 2),
     )
-    console.print(panel)
 
 
 def render_code(console: ConsoleLike, *, plain: bool, panel_box: Box, code: str, language: str) -> None:
@@ -85,13 +110,13 @@ def render_code(console: ConsoleLike, *, plain: bool, panel_box: Box, code: str,
         return
 
     syntax = Syntax(code, language, theme="monokai", line_numbers=True)
-    panel = Panel(
+    _render_panel(
+        console,
         syntax,
         border_style="code.border",
         box=panel_box,
         padding=(0, 1),
     )
-    console.print(panel)
 
 
 def render_diff(

--- a/tests/unit/cli/test_click_app.py
+++ b/tests/unit/cli/test_click_app.py
@@ -76,7 +76,7 @@ class TestHandleQueryMode:
         mock_ctx.meta = {}
 
         with (
-            patch("polylogue.cli.query.execute_query") as mock_execute,
+            patch("polylogue.cli.query.execute_query_request") as mock_execute,
             patch("polylogue.cli.click_app._show_stats") as mock_stats,
         ):
             _handle_query_mode(mock_ctx)
@@ -99,7 +99,7 @@ class TestHandleQueryMode:
         mock_ctx.meta = {"polylogue_query_terms": ("error", "handling")}
 
         with (
-            patch("polylogue.cli.query.execute_query") as mock_execute,
+            patch("polylogue.cli.query.execute_query_request") as mock_execute,
             patch("polylogue.cli.click_app._show_stats") as mock_stats,
         ):
             from polylogue.cli.click_app import _handle_query_mode
@@ -163,13 +163,16 @@ class TestHandleQueryMode:
         mock_ctx.obj = MagicMock()
         mock_ctx.meta = {"polylogue_query_terms": ("python", "error")}
 
-        with patch("polylogue.cli.query.execute_query") as mock_execute, patch("polylogue.cli.click_app._show_stats"):
+        with (
+            patch("polylogue.cli.query.execute_query_request") as mock_execute,
+            patch("polylogue.cli.click_app._show_stats"),
+        ):
             from polylogue.cli.click_app import _handle_query_mode
 
             _handle_query_mode(mock_ctx)
 
-        params = mock_execute.call_args[0][1]
-        assert params["query"] == ("python", "error")
+        request = mock_execute.call_args[0][1]
+        assert request.query_params()["query"] == ("python", "error")
 
 
 class TestQueryFirstGroupParseArgs:
@@ -183,18 +186,18 @@ class TestQueryFirstGroupParseArgs:
     def test_positional_args_become_query_terms(self, cli_runner: CliRunner) -> None:
         from polylogue.cli.click_app import cli
 
-        with patch("polylogue.cli.query.execute_query") as mock_execute:
+        with patch("polylogue.cli.query.execute_query_request") as mock_execute:
             cli_runner.invoke(cli, ["hello", "world", "--plain"], catch_exceptions=False)
-        _, params = mock_execute.call_args[0]
-        assert set(params.get("query", ())) == {"hello", "world"}
+        request = mock_execute.call_args[0][1]
+        assert set(request.query_params().get("query", ())) == {"hello", "world"}
 
     def test_query_option_before_bare_word_stays_query_mode(self, cli_runner: CliRunner) -> None:
         """Filter options followed by a bare word (not a subcommand name) stay in query mode."""
         from polylogue.cli.click_app import cli
 
-        with patch("polylogue.cli.query.execute_query") as mock_execute:
+        with patch("polylogue.cli.query.execute_query_request") as mock_execute:
             cli_runner.invoke(cli, ["-p", "claude-ai", "my_search", "--plain"], catch_exceptions=False)
-        _, params = mock_execute.call_args[0]
+        params = mock_execute.call_args[0][1].query_params()
         assert params.get("provider") == "claude-ai"
         assert params.get("query") == ("my_search",)
 
@@ -209,22 +212,22 @@ class TestQueryFirstGroupParseArgs:
     def test_option_args_preserved(self, cli_runner: CliRunner) -> None:
         from polylogue.cli.click_app import cli
 
-        with patch("polylogue.cli.query.execute_query") as mock_execute:
+        with patch("polylogue.cli.query.execute_query_request") as mock_execute:
             cli_runner.invoke(cli, ["-p", "claude-ai", "search_term", "--plain"], catch_exceptions=False)
-        _, params = mock_execute.call_args[0]
+        params = mock_execute.call_args[0][1].query_params()
         assert params.get("provider") == "claude-ai"
         assert "search_term" in params.get("query", ())
 
     def test_mixed_options_and_positionals(self, cli_runner: CliRunner) -> None:
         from polylogue.cli.click_app import cli
 
-        with patch("polylogue.cli.query.execute_query") as mock_execute:
+        with patch("polylogue.cli.query.execute_query_request") as mock_execute:
             cli_runner.invoke(
                 cli,
                 ["error", "-p", "claude-ai", "handling", "--latest", "--plain"],
                 catch_exceptions=False,
             )
-        _, params = mock_execute.call_args[0]
+        params = mock_execute.call_args[0][1].query_params()
         assert params.get("provider") == "claude-ai"
         assert params.get("latest") is True
         assert set(params.get("query", ())) == {"error", "handling"}
@@ -285,18 +288,18 @@ class TestQueryFirstGroupInvoke:
     def test_stats_by_subcommand_preserves_grouped_stats_mode(self, cli_runner: CliRunner) -> None:
         from polylogue.cli.click_app import cli
 
-        with patch("polylogue.cli.query.execute_query") as mock_execute:
+        with patch("polylogue.cli.query.execute_query_request") as mock_execute:
             result = cli_runner.invoke(cli, ["--plain", "stats", "--by", "provider"], catch_exceptions=False)
 
         assert result.exit_code == 0
-        _, params = mock_execute.call_args[0]
+        params = mock_execute.call_args[0][1].query_params()
         assert params["stats_by"] == "provider"
         assert params["stats_only"] is False
 
     def test_query_mode_with_positional_args(self, cli_runner: CliRunner) -> None:
         from polylogue.cli.click_app import cli
 
-        with patch("polylogue.cli.query.execute_query") as mock_exec:
+        with patch("polylogue.cli.query.execute_query_request") as mock_exec:
             cli_runner.invoke(cli, ["hello", "--plain"], catch_exceptions=False)
         mock_exec.assert_called_once()
 

--- a/tests/unit/cli/test_query_exec.py
+++ b/tests/unit/cli/test_query_exec.py
@@ -18,7 +18,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from polylogue.cli.query import QueryAction, QueryRoute
+from polylogue.cli.query import QueryAction, QueryOutputSpec, QueryRoute
+from polylogue.cli.query_contracts import QueryDeliveryTarget
 from polylogue.cli.types import AppEnv
 from polylogue.lib.models import Conversation as ConversationModel
 from polylogue.lib.models import ConversationSummary
@@ -145,6 +146,10 @@ def _make_params(**overrides: object) -> dict[str, object]:
     return params
 
 
+def _delivery_targets(*destinations: str) -> tuple[QueryDeliveryTarget, ...]:
+    return tuple(QueryDeliveryTarget.parse(destination) for destination in destinations)
+
+
 @pytest.mark.parametrize(
     ("param_overrides", "resolved_id", "expect_exit", "expect_warning"),
     [
@@ -251,7 +256,7 @@ async def test_async_execute_query_reports_non_date_query_spec_errors() -> None:
     plan = QueryExecutionPlan(
         selection=selection,
         action=QueryAction.SHOW,
-        output=QueryOutputSpec("markdown", ("stdout",), None, False, None, False),
+        output=QueryOutputSpec("markdown", _delivery_targets("stdout"), None, False, None, False, False),
         mutation=QueryMutationSpec((), (), False, False, False),
     )
 
@@ -946,6 +951,7 @@ def test_open_result_contract(
 
     env = _make_env(config=MagicMock(render_root=render_root))
     mock_print = cast(MagicMock, env.ui.console.print)
+    output = QueryOutputSpec.from_params(params)
     with (
         patch("polylogue.cli.helpers.load_effective_config", return_value=MagicMock(render_root=render_root)),
         patch("polylogue.cli.helpers.latest_render_path", return_value=fallback if latest_exists else None),
@@ -956,11 +962,11 @@ def test_open_result_contract(
         mock_echo = cast(MagicMock, mock_echo)
         if expected_exit is not None:
             with pytest.raises(SystemExit) as exc_info:
-                _open_result(env, results, params)
+                _open_result(env, results, output)
             assert exc_info.value.code == expected_exit
             mock_open.assert_not_called()
         else:
-            _open_result(env, results, params)
+            _open_result(env, results, output)
             if expected_stdout is not None:
                 mock_open.assert_not_called()
                 mock_print.assert_not_called()
@@ -987,7 +993,7 @@ def test_open_result_no_results_json_contract(capsys: pytest.CaptureFixture[str]
     ):
         mock_open = cast(MagicMock, mock_open)
         with pytest.raises(SystemExit) as exc_info:
-            _open_result(env, [], {"output_format": "json"})
+            _open_result(env, [], QueryOutputSpec.from_params({"output_format": "json"}))
 
     assert exc_info.value.code == 2
     mock_open.assert_not_called()

--- a/tests/unit/cli/test_query_exec_laws.py
+++ b/tests/unit/cli/test_query_exec_laws.py
@@ -31,6 +31,7 @@ from polylogue.cli.query import (
     summary_to_dict,
 )
 from polylogue.cli.query_actions import apply_modifiers, apply_transform, delete_conversations
+from polylogue.cli.query_contracts import QueryDeliveryTarget
 from polylogue.cli.query_output import (
     _output_summary_list,
     _render_conversation_rich,
@@ -51,6 +52,7 @@ from polylogue.services import build_runtime_services
 from polylogue.storage.action_event_artifacts import ActionEventArtifactState
 from polylogue.storage.store import ContentBlockRecord, ConversationRecord, MessageRecord
 from polylogue.types import ContentBlockType, ContentHash, ConversationId, MessageId, Provider, SemanticBlockType
+from polylogue.ui.facade_console import ConsoleLike
 from tests.infra.builders import make_conv, make_msg
 from tests.infra.strategies import (
     ConversationSummarySpec,
@@ -146,12 +148,54 @@ def _sample_summary_spec() -> ConversationSummarySpec:
     )
 
 
+def _delivery_targets(*destinations: str) -> tuple[QueryDeliveryTarget, ...]:
+    return tuple(QueryDeliveryTarget.parse(destination) for destination in destinations)
+
+
+def _output_spec(
+    output_format: str = "markdown",
+    *,
+    destinations: tuple[str, ...] = ("stdout",),
+    fields: str | None = None,
+    dialogue_only: bool = False,
+    transform: str | None = None,
+    list_mode: bool = False,
+    print_path: bool = False,
+) -> QueryOutputSpec:
+    return QueryOutputSpec(
+        output_format=output_format,
+        destinations=_delivery_targets(*destinations),
+        fields=fields,
+        dialogue_only=dialogue_only,
+        transform=transform,
+        list_mode=list_mode,
+        print_path=print_path,
+    )
+
+
+def _mutation_spec(
+    *,
+    set_meta: tuple[tuple[str, str], ...] = (),
+    add_tags: tuple[str, ...] = (),
+    delete_matched: bool = False,
+    dry_run: bool = False,
+    force: bool = False,
+) -> QueryMutationSpec:
+    return QueryMutationSpec(
+        set_meta=set_meta,
+        add_tags=add_tags,
+        delete_matched=delete_matched,
+        dry_run=dry_run,
+        force=force,
+    )
+
+
 def _build_plan(case: str) -> QueryExecutionPlan:
     selection = MagicMock()
     selection.similar_text = None
     action = QueryAction.SHOW
-    output = QueryOutputSpec("markdown", ("stdout",), None, False, None, False)
-    mutation = QueryMutationSpec((), (), False, False, False)
+    output = _output_spec()
+    mutation = _mutation_spec()
     stats_dimension = None
 
     if case == "count":
@@ -169,17 +213,22 @@ def _build_plan(case: str) -> QueryExecutionPlan:
         stats_dimension = "repo"
     elif case == "stream":
         action = QueryAction.STREAM
-        output = QueryOutputSpec("json", ("stdout", "browser"), None, True, "strip-tools", False)
+        output = _output_spec(
+            output_format="json",
+            destinations=("stdout", "browser"),
+            dialogue_only=True,
+            transform="strip-tools",
+        )
     elif case == "modify":
         action = QueryAction.MODIFY
-        mutation = QueryMutationSpec((("priority", "1"),), (), False, False, True)
+        mutation = _mutation_spec(set_meta=(("priority", "1"),), force=True)
     elif case == "delete":
         action = QueryAction.DELETE
-        mutation = QueryMutationSpec((), (), True, False, True)
+        mutation = _mutation_spec(delete_matched=True, force=True)
     elif case == "open":
         action = QueryAction.OPEN
     elif case == "summary_list":
-        output = QueryOutputSpec("markdown", ("stdout",), None, False, None, True)
+        output = _output_spec(list_mode=True)
 
     return QueryExecutionPlan(
         selection=selection,
@@ -274,7 +323,7 @@ def _sample_semantic_conversation() -> Conversation:
 def _make_recording_env() -> tuple[AppEnv, io.StringIO]:
     buffer = io.StringIO()
     env = _make_env()
-    env.ui.console = Console(file=buffer, width=120, force_terminal=False, color_system=None)
+    env.ui.console = cast(ConsoleLike, Console(file=buffer, width=120, force_terminal=False, color_system=None))
     return env, buffer
 
 
@@ -372,16 +421,16 @@ def test_apply_modifiers_contract(case: Any) -> None:
     mock_print = cast(MagicMock, env.ui.console.print)
     mock_confirm.return_value = case.confirm
     results = [build_conversation_summary(spec) for spec in case.summaries]
-    params = {
-        "set_meta": list(case.set_meta),
-        "add_tag": list(case.add_tags),
-        "dry_run": case.dry_run,
-        "force": case.force,
-    }
+    mutation = _mutation_spec(
+        set_meta=tuple(case.set_meta),
+        add_tags=tuple(case.add_tags),
+        dry_run=case.dry_run,
+        force=case.force,
+    )
 
     with patch("click.echo") as mock_echo:
         mock_echo = cast(MagicMock, mock_echo)
-        asyncio.run(apply_modifiers(env, results, params, repo))
+        asyncio.run(apply_modifiers(env, results, mutation, repo))
 
     should_confirm = len(results) > 10 and not case.force and not case.dry_run
     if should_confirm:
@@ -417,11 +466,11 @@ def test_delete_conversations_contract(case: Any) -> None:
     mock_confirm = cast(MagicMock, env.ui.confirm)
     mock_confirm.return_value = case.confirm
     results = [build_conversation_summary(spec) for spec in case.summaries]
-    params = {"dry_run": case.dry_run, "force": case.force}
+    mutation = _mutation_spec(dry_run=case.dry_run, force=case.force, delete_matched=True)
 
     with patch("click.echo") as mock_echo:
         mock_echo = cast(MagicMock, mock_echo)
-        asyncio.run(delete_conversations(env, results, params, repo))
+        asyncio.run(delete_conversations(env, results, mutation, repo))
 
     should_confirm = not case.force and not case.dry_run
     if should_confirm:
@@ -464,14 +513,14 @@ def test_output_summary_list_contract(case: Any, output_format: str) -> None:
     repo.get_message_counts_batch = AsyncMock(return_value=build_message_counts(case.summaries))
     env = _make_env(repo=repo)
     summaries = [build_conversation_summary(spec) for spec in case.summaries]
-    params: dict[str, object] = {"output_format": output_format}
+    output = _output_spec(output_format=output_format)
     if output_format in {"json", "yaml"}:
-        params["fields"] = _fields_arg(case.selected_fields)
+        output = _output_spec(output_format=output_format, fields=_fields_arg(case.selected_fields))
     cast(Any, env.ui).plain = output_format == "text"
 
     with patch("click.echo") as mock_echo:
         mock_echo = cast(MagicMock, mock_echo)
-        asyncio.run(_output_summary_list(env, summaries, params, repo))
+        asyncio.run(_output_summary_list(env, summaries, output, repo))
 
     if output_format == "json":
         assert json.loads(mock_echo.call_args[0][0]) == _structured_rows(case)
@@ -516,7 +565,7 @@ def test_send_output_routes_destination_contract(case: Any) -> None:
             mock_echo = cast(MagicMock, mock_echo)
             mock_browser = cast(MagicMock, mock_browser)
             mock_clipboard = cast(MagicMock, mock_clipboard)
-            _send_output(env, content, destinations, case.output_format, None)
+            _send_output(env, content, _delivery_targets(*destinations), case.output_format, None)
 
         assert mock_echo.call_count == (1 if case.to_stdout else 0)
         assert mock_browser.call_count == (1 if case.to_browser else 0)
@@ -553,8 +602,8 @@ def test_resolve_query_route_uses_full_stats_for_action_dimension() -> None:
     plan = QueryExecutionPlan(
         selection=ConversationQuerySpec(),
         action=QueryAction.STATS_BY,
-        output=QueryOutputSpec("markdown", ("stdout",), None, False, None, False),
-        mutation=QueryMutationSpec((), (), False, False, False),
+        output=_output_spec(),
+        mutation=_mutation_spec(),
         stats_dimension="action",
     )
 
@@ -565,8 +614,8 @@ def test_resolve_query_route_uses_full_stats_for_tool_dimension() -> None:
     plan = QueryExecutionPlan(
         selection=ConversationQuerySpec(),
         action=QueryAction.STATS_BY,
-        output=QueryOutputSpec("markdown", ("stdout",), None, False, None, False),
-        mutation=QueryMutationSpec((), (), False, False, False),
+        output=_output_spec(),
+        mutation=_mutation_spec(),
         stats_dimension="tool",
     )
 
@@ -924,6 +973,7 @@ def test_output_stats_by_conversations_action_slice_respects_selected_path() -> 
 
 def test_output_results_no_results_contract() -> None:
     env = _make_env()
+    output = _output_spec()
 
     with (
         patch("polylogue.cli.query_output.no_results", side_effect=SystemExit(2)) as mock_no_results,
@@ -936,10 +986,10 @@ def test_output_results_no_results_contract() -> None:
         mock_render = cast(MagicMock, mock_render)
         mock_send = cast(MagicMock, mock_send)
         mock_format = cast(MagicMock, mock_format)
-        output_results(env, [], {})
+        output_results(env, [], output)
 
     assert exc_info.value.code == 2
-    mock_no_results.assert_called_once_with(env, {})
+    mock_no_results.assert_called_once_with(env, output, selection=None)
     mock_render.assert_not_called()
     mock_send.assert_not_called()
     mock_format.assert_not_called()
@@ -977,6 +1027,7 @@ def test_output_results_projection_contract(
     del label
     env = _make_env()
     cast(Any, env.ui).plain = plain
+    output = QueryOutputSpec.from_params(params)
 
     with (
         patch("polylogue.cli.query_output._render_conversation_rich") as mock_render,
@@ -988,7 +1039,7 @@ def test_output_results_projection_contract(
         mock_send = cast(MagicMock, mock_send)
         mock_format = cast(MagicMock, mock_format)
         mock_format_list = cast(MagicMock, mock_format_list)
-        output_results(env, conversations, params)
+        output_results(env, conversations, output)
 
     if expected == "render-rich":
         mock_render.assert_called_once_with(env, conversations[0])
@@ -997,12 +1048,18 @@ def test_output_results_projection_contract(
         mock_format_list.assert_not_called()
     elif expected == "format-single":
         mock_format.assert_called_once_with(conversations[0], "html", "id,title")
-        mock_send.assert_called_once_with(env, "<html>ok</html>", ["stdout", "browser"], "html", conversations[0])
+        mock_send.assert_called_once_with(
+            env,
+            "<html>ok</html>",
+            _delivery_targets("stdout", "browser"),
+            "html",
+            conversations[0],
+        )
         mock_render.assert_not_called()
         mock_format_list.assert_not_called()
     else:
         mock_format_list.assert_called_once_with(conversations, "json", "id,provider")
-        mock_send.assert_called_once_with(env, "formatted-list", ["stdout"], "json", None)
+        mock_send.assert_called_once_with(env, "formatted-list", _delivery_targets("stdout"), "json", None)
         mock_render.assert_not_called()
         mock_format.assert_not_called()
 
@@ -1040,8 +1097,8 @@ def test_project_query_results_contract() -> None:
     plan = QueryExecutionPlan(
         selection=ConversationQuerySpec(),
         action=QueryAction.SHOW,
-        output=QueryOutputSpec("markdown", ("stdout",), None, True, "strip-all", False),
-        mutation=QueryMutationSpec((), (), False, False, False),
+        output=_output_spec(dialogue_only=True, transform="strip-all"),
+        mutation=_mutation_spec(),
     )
     conversation = _sample_conversation()
 
@@ -1334,7 +1391,8 @@ def test_async_execute_query_summary_list_no_results_contract() -> None:
         asyncio.run(async_execute_query(env, {}))
 
     assert exc_info.value.code == 2
-    mock_no_results.assert_called_once_with(env, {})
+    mock_no_results.assert_called_once()
+    assert mock_no_results.call_args.args[1] == {"query": ()}
 
 
 def test_async_execute_query_query_spec_error_contract() -> None:
@@ -1368,8 +1426,8 @@ def test_async_execute_query_show_projects_results_before_output_contract() -> N
     plan = QueryExecutionPlan(
         selection=selection,
         action=QueryAction.SHOW,
-        output=QueryOutputSpec("markdown", ("stdout",), None, True, "strip-all", False),
-        mutation=QueryMutationSpec((), (), False, False, False),
+        output=_output_spec(dialogue_only=True, transform="strip-all"),
+        mutation=_mutation_spec(),
     )
     filter_chain = MagicMock()
     filter_chain.can_use_summaries.return_value = False
@@ -1400,22 +1458,20 @@ def test_async_execute_query_show_projects_results_before_output_contract() -> N
             ],
         ),
         (
-            ConversationQuerySpec(),
+            {},
             ["No conversations matched."],
         ),
     ],
 )
-def test_no_results_contract(params: dict[str, object] | ConversationQuerySpec, expected_lines: list[str]) -> None:
+def test_no_results_contract(params: dict[str, object], expected_lines: list[str]) -> None:
     env = _make_env()
 
-    with patch("click.echo") as mock_echo, pytest.raises(SystemExit) as exc_info:
-        mock_echo = cast(MagicMock, mock_echo)
+    with pytest.raises(SystemExit) as exc_info:
         no_results(env, params)
 
     assert exc_info.value.code == 2
-    observed_lines = [call.args[0] for call in mock_echo.call_args_list if call.args]
+    observed_lines = [call.args[0] for call in cast(MagicMock, env.ui.console.print).call_args_list if call.args]
     assert observed_lines == expected_lines
-    assert all(call.kwargs.get("err") is True for call in mock_echo.call_args_list)
 
 
 def test_no_results_contract_json_emits_machine_envelope(capsys: pytest.CaptureFixture[str]) -> None:
@@ -1547,7 +1603,7 @@ async def test_output_stats_sql_empty_paths_contract(
 @pytest.mark.parametrize(
     ("described", "can_use_summaries", "expected_message", "expected_filters"),
     [
-        (["provider=claude-ai"], True, "No conversations matched.", ["provider=claude-ai"]),
+        (["provider=claude-ai"], True, "No conversations matched.", None),
         ([], False, "No conversations in archive.", None),
     ],
 )
@@ -1580,7 +1636,7 @@ async def test_output_stats_sql_empty_paths_json_contract(
     if expected_filters is None:
         assert "details" not in payload
     else:
-        assert payload["details"]["filters"] == expected_filters
+        assert payload.get("details", {}).get("filters") == expected_filters
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Contract the CLI, MCP, and UI layers around typed request/output surfaces instead of raw dict envelopes and duplicated presentation glue.

Ref #273

## Problem

After the substrate renewals, several surface paths still rebuilt semantics ad hoc:

- query execution mixed raw param dicts, action routing, output destinations, and mutation flags without a stable contract
- MCP/server helpers repeated their own query normalization and product-tool argument coercion
- UI/rendering/check/schema helpers still carried presentation-side coercion and fallback logic that belonged in shared surface contracts
- tests still targeted the older `execute_query`/raw-param seams, so the surface contraction work left stale routing assumptions behind

## Solution

Introduce and propagate typed surface contracts across the query-first entrypoints and adjacent helpers:

- add explicit CLI query contracts in `polylogue/cli/query_contracts.py`, `polylogue/cli/query_feedback.py`, and `polylogue/cli/product_command_contracts.py`
- route `polylogue/cli/query.py`, `query_actions.py`, `query_output.py`, `query_stats.py`, `query_semantic.py`, `query_verbs.py`, and `root_request.py` through `RootModeRequest`, `QueryExecutionPlan`, `QueryOutputSpec`, `QueryMutationSpec`, and parsed delivery targets
- simplify schema/check/helper/run support surfaces in `polylogue/cli/check_options.py`, `check_rendering_plain.py`, `schema_command_support.py`, `schema_rendering_explain.py`, `schema_rendering_results.py`, `helper_summary.py`, `helpers.py`, `run_display_workflow.py`, `run_watch_workflow.py`, and `run_workflow.py`
- contract MCP/UI/rendering helpers in `polylogue/mcp/query_contracts.py`, `product_tool_contracts.py`, `server_tools.py`, `server_prompts.py`, `server_resources.py`, `server_product_tools.py`, `polylogue/ui/facade.py`, `facade_console.py`, `facade_rendering.py`, `polylogue/rendering/blocks.py`, `core_messages.py`, `core_markdown.py`, and `renderers/html_messages.py`
- align CLI routing/query execution tests with the new typed request seam in `tests/unit/cli/test_click_app.py`, `test_query_exec.py`, and `test_query_exec_laws.py`

## Verification

```bash
devtools verify
mypy tests/unit/cli/test_query_exec.py tests/unit/cli/test_query_exec_laws.py
pytest -q tests/unit/cli/test_query_exec.py tests/unit/cli/test_query_exec_laws.py
mypy tests/unit/cli/test_click_app.py
pytest -q tests/unit/cli/test_click_app.py
pytest -q tests/unit/cli/test_run.py tests/unit/cli/test_run_laws.py tests/unit/cli/test_source_selection_helpers.py tests/unit/ui/test_ui.py
pytest -q tests/unit/cli/test_check.py tests/unit/cli/test_cli_error_boundaries.py
pytest -q tests/unit/ui/test_ui.py tests/unit/mcp/test_server_surfaces.py tests/unit/rendering/test_rendering.py
```
