### PR TITLE
refactor: renew rendering and source boundary contracts

### DIFF
--- a/polylogue/lib/json.py
+++ b/polylogue/lib/json.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from collections.abc import Callable
 from decimal import Decimal
-from typing import TypeAlias, TypeGuard, cast
+from typing import TypeAlias, TypeGuard
 
 import orjson
 
@@ -29,7 +29,7 @@ def is_json_value(value: object) -> TypeGuard[JSONValue]:
 
 def is_json_document(value: object) -> TypeGuard[JSONDocument]:
     """Return whether *value* is a JSON object with string keys."""
-    return isinstance(value, dict) and all(isinstance(key, str) for key in value)
+    return isinstance(value, dict) and all(isinstance(key, str) and is_json_value(item) for key, item in value.items())
 
 
 def json_document(value: object) -> JSONDocument:
@@ -41,11 +41,21 @@ def json_document_list(value: object) -> JSONDocumentList:
     """Coerce a value into a list of string-keyed JSON objects."""
     if not isinstance(value, list):
         return []
-    return [document for item in value if (document := json_document(item))]
+    documents: JSONDocumentList = []
+    for item in value:
+        if is_json_document(item):
+            documents.append(item)
+    return documents
 
 
 def _reject_non_finite_token(token: str) -> JSONValue:
     raise ValueError(f"invalid non-finite JSON token: {token}")
+
+
+def _loaded_json_value(value: object) -> JSONValue:
+    if is_json_value(value):
+        return value
+    raise ValueError("loaded JSON payload does not satisfy the JSONValue contract")
 
 
 def _default_encoder(user_default: JSONEncoder | None = None) -> JSONEncoder:
@@ -90,10 +100,10 @@ def dumps(obj: object, *, default: JSONEncoder | None = None, option: int | None
 def loads(obj: str | bytes | bytearray) -> JSONValue:
     """Load object from JSON string or bytes."""
     try:
-        return cast(JSONValue, orjson.loads(obj))
+        return _loaded_json_value(orjson.loads(obj))
     except (orjson.JSONDecodeError, ValueError) as exc:
         try:
-            return cast(JSONValue, json.loads(obj, parse_constant=_reject_non_finite_token))
+            return _loaded_json_value(json.loads(obj, parse_constant=_reject_non_finite_token))
         except (json.JSONDecodeError, ValueError):
             raise exc from None
 

--- a/polylogue/rendering/block_models.py
+++ b/polylogue/rendering/block_models.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import json
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
-from typing import cast
 
+from polylogue.lib.json import JSONDocument, json_document
 from polylogue.storage.store import ContentBlockRecord
 
 
@@ -22,18 +22,32 @@ class RenderableBlock:
     mime_type: str | None = None
     tool_name: str | None = None
     tool_id: str | None = None
-    tool_input: Mapping[str, object] | None = None
+    tool_input: JSONDocument | None = None
 
 
-def _mapping_with_string_keys(value: object) -> Mapping[str, object] | None:
+def _mapping_with_string_keys(value: object) -> JSONDocument | None:
     if not isinstance(value, Mapping):
         return None
-    if not all(isinstance(key, str) for key in value):
-        return None
-    return cast(Mapping[str, object], value)
+    normalized: dict[str, object] = {}
+    for key, item in value.items():
+        if not isinstance(key, str):
+            return None
+        normalized[key] = item
+    return json_document(normalized)
 
 
-def _json_mapping(value: str | None) -> Mapping[str, object] | None:
+def _optional_string(value: object) -> str | None:
+    return value if isinstance(value, str) else None
+
+
+def _first_string(*values: object) -> str | None:
+    for value in values:
+        if isinstance(value, str):
+            return value
+    return None
+
+
+def _json_mapping(value: str | None) -> JSONDocument | None:
     if not value:
         return None
     try:
@@ -43,7 +57,7 @@ def _json_mapping(value: str | None) -> Mapping[str, object] | None:
     return _mapping_with_string_keys(parsed)
 
 
-def _coerce_tool_input(value: object) -> Mapping[str, object] | None:
+def _coerce_tool_input(value: object) -> JSONDocument | None:
     mapping = _mapping_with_string_keys(value)
     if mapping is not None:
         return mapping
@@ -58,13 +72,13 @@ def _coerce_mapping_block(block: Mapping[str, object]) -> RenderableBlock:
     name = block.get("name") or block.get("title")
     return RenderableBlock(
         type=block_type,
-        text=cast(str | None, block.get("thinking") or block.get("text") or block.get("code") or block.get("content")),
-        language=cast(str | None, block.get("language")),
-        url=cast(str | None, block.get("url") or source.get("url")),
+        text=_first_string(block.get("thinking"), block.get("text"), block.get("code"), block.get("content")),
+        language=_optional_string(block.get("language")),
+        url=_first_string(block.get("url"), source.get("url")),
         name=str(name) if isinstance(name, str) else None,
-        mime_type=cast(str | None, block.get("media_type") or block.get("mime_type")),
-        tool_name=cast(str | None, block.get("name")) if block_type == "tool_use" else None,
-        tool_id=cast(str | None, block.get("id") or block.get("tool_use_id") or block.get("tool_id")),
+        mime_type=_first_string(block.get("media_type"), block.get("mime_type")),
+        tool_name=_optional_string(block.get("name")) if block_type == "tool_use" else None,
+        tool_id=_first_string(block.get("id"), block.get("tool_use_id"), block.get("tool_id")),
         tool_input=_coerce_tool_input(block.get("input")),
     )
 
@@ -74,9 +88,9 @@ def _coerce_record_block(block: ContentBlockRecord) -> RenderableBlock:
     return RenderableBlock(
         type=block.type.value,
         text=block.text,
-        language=cast(str | None, metadata.get("language")) if metadata is not None else None,
-        url=cast(str | None, metadata.get("url")) if metadata is not None else None,
-        name=cast(str | None, metadata.get("name")) if metadata is not None else None,
+        language=_optional_string(metadata.get("language")) if metadata is not None else None,
+        url=_optional_string(metadata.get("url")) if metadata is not None else None,
+        name=_optional_string(metadata.get("name")) if metadata is not None else None,
         mime_type=block.media_type,
         tool_name=block.tool_name,
         tool_id=block.tool_id,

--- a/polylogue/rendering/blocks.py
+++ b/polylogue/rendering/blocks.py
@@ -22,7 +22,7 @@ def render_blocks_markdown(blocks: Sequence[RenderableBlock]) -> str:
     - ``tool_use``: tool header with name and input summary
     - ``tool_result``: code-fenced output
     - ``code``: language-tagged code fence
-    - ``image``/``document``: reference with metadata
+    - ``image``/``document``/``file``: reference with metadata
     """
     parts: list[str] = []
     for block in blocks:
@@ -179,6 +179,22 @@ def _render_code_html(block: RenderableBlock) -> str:
     return f'<pre class="code-block"{lang_attr}><code>{escape(text)}</code></pre>'
 
 
+def _render_media_html(block: RenderableBlock) -> str:
+    block_type = escape(block.type)
+    name = escape(block.name or block.type)
+    mime = escape(block.mime_type or "")
+    url = block.url or ""
+    parts = [f'<div class="media-block" data-type="{block_type}">']
+    if url:
+        parts.append(f'<a class="media-link" href="{escape(url)}">{name}</a>')
+    else:
+        parts.append(f'<span class="media-name">{name}</span>')
+    if mime:
+        parts.append(f'<span class="media-mime">{mime}</span>')
+    parts.append("</div>")
+    return "".join(parts)
+
+
 def _render_text_block_html(block: RenderableBlock) -> str:
     # Simple paragraph wrapping for plain text
     if not block.text or not block.text.strip():
@@ -224,10 +240,6 @@ def _strip_text(value: str | None) -> str:
     return (value or "").strip()
 
 
-def _noop_renderer(_block: RenderableBlock) -> str:
-    return ""
-
-
 def _render_block_plaintext(block: RenderableBlock) -> str:
     """Render a single content block to plaintext."""
     return _PLAIN_BLOCK_RENDERERS.get(block.type, _render_text_block_plaintext)(block)
@@ -256,7 +268,7 @@ _HTML_BLOCK_RENDERERS: dict[str, Callable[[RenderableBlock], str]] = {
     ContentBlockType.TOOL_USE.value: _render_tool_use_html,
     ContentBlockType.TOOL_RESULT.value: _render_tool_result_html,
     ContentBlockType.CODE.value: _render_code_html,
-    **dict.fromkeys(_MEDIA_BLOCK_TYPES, _noop_renderer),
+    **dict.fromkeys(_MEDIA_BLOCK_TYPES, _render_media_html),
 }
 
 
@@ -281,10 +293,21 @@ def _render_tool_result_plaintext(block: RenderableBlock) -> str:
     return _strip_text(_extract_block_text(block))
 
 
+def _render_media_plaintext(block: RenderableBlock) -> str:
+    name = block.name or block.type
+    parts = [name]
+    if block.url:
+        parts.append(block.url)
+    if block.mime_type:
+        parts.append(f"({block.mime_type})")
+    return " ".join(parts)
+
+
 _PLAIN_BLOCK_RENDERERS: dict[str, Callable[[RenderableBlock], str]] = {
     ContentBlockType.THINKING.value: _render_thinking_plaintext,
     ContentBlockType.TOOL_USE.value: _render_tool_use_plaintext,
     ContentBlockType.TOOL_RESULT.value: _render_tool_result_plaintext,
+    **dict.fromkeys(_MEDIA_BLOCK_TYPES, _render_media_plaintext),
 }
 
 
@@ -293,7 +316,7 @@ _STRUCTURED_BLOCK_TYPES = {
     ContentBlockType.TOOL_USE.value,
     ContentBlockType.TOOL_RESULT.value,
     ContentBlockType.CODE.value,
-}
+} | set(_MEDIA_BLOCK_TYPES)
 
 
 __all__ = [

--- a/polylogue/rendering/core_messages.py
+++ b/polylogue/rendering/core_messages.py
@@ -6,7 +6,7 @@ import re
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import cast, overload
+from typing import overload
 
 from polylogue.rendering.block_models import RenderableBlock
 from polylogue.rendering.blocks import (
@@ -41,7 +41,7 @@ def normalize_render_timestamp(timestamp: object) -> str | None:
     if isinstance(timestamp, int | float):
         try:
             return datetime.fromtimestamp(float(timestamp), tz=timezone.utc).isoformat().replace("+00:00", "Z")
-        except (ValueError, OSError):
+        except (OverflowError, ValueError, OSError):
             return None
     return str(timestamp)
 
@@ -79,7 +79,11 @@ def _attach_mapping_message_branches(messages: Sequence[Mapping[str, object]]) -
     if not any(_mapping_branch_index(message) for message in copied_messages):
         return copied_messages
 
-    mainline = [message for message in copied_messages if not _mapping_branch_index(message)]
+    mainline = [
+        message
+        for message in copied_messages
+        if _mapping_branch_index(message) == 0 or _mapping_parent_message_id(message) is None
+    ]
     mainline_by_parent = {
         parent_message_id: message
         for message in mainline
@@ -118,11 +122,13 @@ def attach_rendered_message_branches(
     if not messages:
         return []
     if all(isinstance(message, RenderedMessage) for message in messages):
-        typed_messages = cast(list[RenderedMessage], list(messages))
+        typed_messages = [message for message in messages if isinstance(message, RenderedMessage)]
         if not any(message.branch_index for message in typed_messages):
             return typed_messages
 
-        mainline = [message for message in typed_messages if not message.branch_index]
+        mainline = [
+            message for message in typed_messages if message.branch_index == 0 or message.parent_message_id is None
+        ]
         mainline_by_parent = {
             message.parent_message_id: message for message in mainline if message.parent_message_id is not None
         }
@@ -138,9 +144,7 @@ def attach_rendered_message_branches(
 
         return mainline
 
-    mapping_messages = cast(
-        list[Mapping[str, object]], [message for message in messages if isinstance(message, Mapping)]
-    )
+    mapping_messages = [message for message in messages if isinstance(message, Mapping)]
     return _attach_mapping_message_branches(mapping_messages)
 
 

--- a/polylogue/rendering/renderers/html_messages.py
+++ b/polylogue/rendering/renderers/html_messages.py
@@ -22,15 +22,16 @@ def build_projection_html_messages(
 ) -> list[RenderedMessage]:
     raw_messages: list[RenderedMessage] = []
     for msg in projection.messages:
+        content_blocks = coerce_renderable_blocks(msg.content_blocks)
         text = msg.text or ""
-        if not text:
+        if not text and not content_blocks:
             continue
         payload = build_rendered_message(
             message_id=msg.message_id,
             role=msg.role,
             text=text,
             timestamp=msg.sort_key,
-            content_blocks=coerce_renderable_blocks(msg.content_blocks),
+            content_blocks=content_blocks,
             parent_message_id=msg.parent_message_id,
             branch_index=msg.branch_index,
             render_html=render_html,
@@ -48,14 +49,16 @@ def build_conversation_html_messages(
 ) -> list[RenderedMessage]:
     raw_messages: list[RenderedMessage] = []
     for msg in conversation.messages:
-        if not msg.text:
+        content_blocks = coerce_renderable_blocks(getattr(msg, "content_blocks", None))
+        text = msg.text or ""
+        if not text and not content_blocks:
             continue
         payload = build_rendered_message(
             message_id=msg.id,
             role=msg.role,
-            text=msg.text,
+            text=text,
             timestamp=str(msg.timestamp) if msg.timestamp else None,
-            content_blocks=coerce_renderable_blocks(getattr(msg, "content_blocks", None)),
+            content_blocks=content_blocks,
             parent_message_id=msg.parent_id,
             branch_index=msg.branch_index,
             render_html=render_html,

--- a/polylogue/sources/decoder_json.py
+++ b/polylogue/sources/decoder_json.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import Iterable
-from typing import IO, BinaryIO, Protocol, TypeAlias, cast
+from typing import IO, Protocol, TypeAlias, TypeGuard
 
 import ijson
 
@@ -25,7 +25,7 @@ ENCODING_GUESSES: tuple[str, ...] = (
 
 JsonScalar: TypeAlias = str | int | float | bool | None
 JsonValue: TypeAlias = dict[str, "JsonValue"] | list["JsonValue"] | JsonScalar
-JsonReadable: TypeAlias = BinaryIO | IO[bytes]
+JsonReadable: TypeAlias = IO[bytes]
 
 
 class LoggerLike(Protocol):
@@ -42,6 +42,16 @@ class IjsonModuleLike(Protocol):
     common: IjsonCommonLike
 
     def items(self, handle: JsonReadable, prefix: str) -> Iterable[JsonValue]: ...
+
+
+def _is_json_value(value: object) -> TypeGuard[JsonValue]:
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return True
+    if isinstance(value, list):
+        return all(_is_json_value(item) for item in value)
+    if isinstance(value, dict):
+        return all(isinstance(key, str) and _is_json_value(item) for key, item in value.items())
+    return False
 
 
 def decode_json_bytes_with(logger_obj: LoggerLike, blob: bytes) -> str | None:
@@ -85,12 +95,16 @@ def _yield_jsonl_pending(
         decoded = raw_pending
 
     try:
-        return ([cast(JsonValue, json.loads(decoded))], 0)
+        parsed = json.loads(decoded)
     except json.JSONDecodeError as exc:
         if is_last:
             logger_obj.debug("Skipping truncated trailing line in %s: %s", path_name, exc)
             return ([], 0)
         return ([], 1)
+    if _is_json_value(parsed):
+        return ([parsed], 0)
+    logger_obj.debug("Skipping non-JSON-compatible decoded line from %s", path_name)
+    return ([], 0)
 
 
 def _iter_jsonl_stream(
@@ -196,7 +210,9 @@ def iter_json_stream_with(
 
         handle.seek(0)
 
-    data = cast(JsonValue, json.load(handle))
+    data = json.load(handle)
+    if not _is_json_value(data):
+        raise ValueError(f"decoded payload from {path_name} does not satisfy the JsonValue contract")
     if isinstance(data, dict):
         yield data
     elif isinstance(data, list):

--- a/polylogue/sources/decoder_zip.py
+++ b/polylogue/sources/decoder_zip.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import zipfile
 from collections.abc import Iterable
 from pathlib import Path
-from typing import BinaryIO, cast
 
 from polylogue.lib.artifact_taxonomy import classify_artifact_path
 from polylogue.logging import get_logger
@@ -135,7 +134,7 @@ def process_zip(
             precomputed_raw: RawConversationData | None = None
             if capture_raw and entry_should_group:
                 with zf.open(name) as handle:
-                    blob_hash, blob_size = get_blob_store().write_from_fileobj(cast(BinaryIO, handle))
+                    blob_hash, blob_size = get_blob_store().write_from_fileobj(handle)
                 precomputed_raw = RawConversationData(
                     raw_bytes=b"",
                     source_path=f"{zip_path}:{name}",
@@ -146,7 +145,7 @@ def process_zip(
                     blob_size=blob_size,
                 )
             with zf.open(name) as handle:
-                yield from emitter.emit(cast(BinaryIO, handle), name, precomputed_raw=precomputed_raw)
+                yield from emitter.emit(handle, name, precomputed_raw=precomputed_raw)
 
 
 __all__ = [

--- a/polylogue/sources/dispatch.py
+++ b/polylogue/sources/dispatch.py
@@ -6,7 +6,7 @@ import json
 from collections.abc import Iterable
 from dataclasses import dataclass
 from io import BytesIO
-from typing import TYPE_CHECKING, Literal, TypeAlias, cast
+from typing import TYPE_CHECKING, Literal, TypeAlias
 
 from polylogue.lib.json import JSONDocument, JSONValue, is_json_document, is_json_value
 from polylogue.lib.payload_coercion import optional_string
@@ -103,9 +103,9 @@ def _detect_provider_from_sequence(payloads: PayloadSequence) -> Provider | None
         if _looks_like_gemini_mapping(first_record):
             return Provider.GEMINI
 
-    if claude.looks_like_code(cast(list[object], payloads)):
+    if claude.looks_like_code(payloads):
         return Provider.CLAUDE_CODE
-    if codex.looks_like(cast(list[object], payloads)):
+    if codex.looks_like(payloads):
         return Provider.CODEX
     return None
 
@@ -403,11 +403,11 @@ def _parse_lowered_spec(spec: LoweredPayloadSpec) -> list[ParsedConversation]:
 
     if spec.provider is Provider.CLAUDE_CODE:
         payloads = _payload_sequence(spec.payload)
-        return [claude.parse_code(cast(list[object], payloads), spec.fallback_id)] if payloads is not None else []
+        return [claude.parse_code(payloads, spec.fallback_id)] if payloads is not None else []
 
     if spec.provider is Provider.CODEX:
         payloads = _payload_sequence(spec.payload)
-        return [codex.parse(cast(list[object], payloads), spec.fallback_id)] if payloads is not None else []
+        return [codex.parse(payloads, spec.fallback_id)] if payloads is not None else []
 
     if spec.mode == "chunked_prompt":
         record = _payload_record(spec.payload)

--- a/polylogue/sources/drive_auth.py
+++ b/polylogue/sources/drive_auth.py
@@ -153,8 +153,8 @@ class DriveAuthManager:
         """Load or acquire Google OAuth credentials. Triggers interactive auth if needed."""
         credentials_module = _import_auth_module("google.oauth2.credentials")
         flow_module = _import_auth_module("google_auth_oauthlib.flow")
-        credentials_cls = cast(DriveCredentialsFactory, credentials_module.Credentials)
-        installed_app_flow_cls = cast(DriveAuthFlowFactory, flow_module.InstalledAppFlow)
+        credentials_cls: DriveCredentialsFactory = credentials_module.Credentials
+        installed_app_flow_cls: DriveAuthFlowFactory = flow_module.InstalledAppFlow
 
         token_path = self._resolved_token_path()
         cached = self._load_cached_credentials(credentials_cls, token_path)

--- a/polylogue/sources/drive_gateway.py
+++ b/polylogue/sources/drive_gateway.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import importlib
 from collections.abc import Callable
 from types import ModuleType
-from typing import ParamSpec, Protocol, TypeAlias, TypeVar, cast
+from typing import ParamSpec, Protocol, TypeAlias, TypeVar
 
 from tenacity import (
     retry_if_exception_type,
@@ -180,7 +180,7 @@ class DriveServiceGateway:
             return self._service
 
         discovery = _import_module("googleapiclient.discovery")
-        build = cast(_DriveServiceBuilder, discovery.build)
+        build: _DriveServiceBuilder = discovery.build
         creds = self._auth_manager.load_credentials()
         self._service = build("drive", "v3", credentials=creds, cache_discovery=False)
         return self._service
@@ -225,7 +225,7 @@ class DriveServiceGateway:
     def download_file(self, file_id: str, handle: _BinaryWritable) -> None:
         """Download file content into a writable binary handle."""
         http_module = _import_module("googleapiclient.http")
-        downloader_cls = cast(MediaDownloadFactory, http_module.MediaIoBaseDownload)
+        downloader_cls: MediaDownloadFactory = http_module.MediaIoBaseDownload
         service = self._service_handle()
         request = service.files().get_media(fileId=file_id)
         self._download_request(request, handle, downloader_cls, file_id=file_id)

--- a/polylogue/sources/drive_source_client.py
+++ b/polylogue/sources/drive_source_client.py
@@ -6,7 +6,7 @@ import os
 import tempfile
 from collections.abc import Iterable
 from pathlib import Path
-from typing import BinaryIO, cast
+from typing import Protocol
 
 from polylogue.lib.json import JSONDocument, JSONValue
 from polylogue.logging import get_logger
@@ -31,6 +31,10 @@ from .drive_types import (
 )
 
 logger = get_logger(__name__)
+
+
+class _WritableBinaryHandle(Protocol):
+    def write(self, data: bytes) -> object: ...
 
 
 class DriveSourceClient:
@@ -58,8 +62,6 @@ class DriveSourceClient:
         if not matches:
             raise DriveNotFoundError(f"Folder not found: {folder_ref}")
         first = matches[0]
-        if not isinstance(first, dict):
-            return folder_ref
         file_id = _record_string(first, "id", default=folder_ref)
         return file_id or folder_ref
 
@@ -93,8 +95,6 @@ class DriveSourceClient:
                 page_size=1000,
             )
             for item in _response_files(response):
-                if not isinstance(item, dict):
-                    continue
                 item_payload: JSONDocument = item
                 name = _record_string(item_payload, "name")
                 mime_type = _record_string(item_payload, "mimeType")
@@ -134,7 +134,8 @@ class DriveSourceClient:
                 try:
                     with tempfile.NamedTemporaryFile(dir=dest.parent, delete=False) as handle:
                         tmp_path = Path(handle.name)
-                        self._gateway.download_file(file_id, cast(BinaryIO, handle))
+                        writable_handle: _WritableBinaryHandle = handle
+                        self._gateway.download_file(file_id, writable_handle)
                     tmp_path.replace(dest)
                 except Exception:
                     if tmp_path is not None:

--- a/polylogue/sources/drive_source_support.py
+++ b/polylogue/sources/drive_source_support.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import TypeAlias
 
-from polylogue.lib.json import JSONValue, is_json_value, loads
+from polylogue.lib.json import JSONValue, loads
 from polylogue.logging import get_logger
 
 from .drive_gateway import DriveListFilesResponse, DrivePayloadRecord
@@ -18,20 +18,22 @@ logger = get_logger(__name__)
 
 DriveJSONPayload: TypeAlias = JSONValue
 DriveJSONRecord: TypeAlias = DrivePayloadRecord
-DriveJSONSequence: TypeAlias = list[DriveJSONPayload]
+DriveJSONPayloadSequence: TypeAlias = list[DriveJSONPayload]
+DriveJSONRecordSequence: TypeAlias = list[DriveJSONRecord]
+DriveJSONSequence: TypeAlias = DriveJSONPayloadSequence
 
 
-def _json_sequence(value: object) -> DriveJSONSequence:
+def _json_sequence(value: object) -> DriveJSONRecordSequence:
     if not isinstance(value, list):
         return []
-    items: DriveJSONSequence = []
+    items: DriveJSONRecordSequence = []
     for item in value:
-        if is_json_value(item):
+        if isinstance(item, dict):
             items.append(item)
     return items
 
 
-def _response_files(response: DriveListFilesResponse) -> list[JSONValue]:
+def _response_files(response: DriveListFilesResponse) -> DriveJSONRecordSequence:
     return _json_sequence(response.get("files"))
 
 
@@ -89,7 +91,7 @@ def _is_supported_drive_payload(name: str, mime_type: str) -> bool:
 
 def _parse_downloaded_json_payload(raw: bytes, *, name: str) -> DriveJSONPayload:
     if _is_newline_delimited_json_name(name):
-        items: DriveJSONSequence = []
+        items: DriveJSONPayloadSequence = []
         for line in raw.splitlines():
             line = line.strip()
             if not line:
@@ -146,6 +148,8 @@ def _build_drive_file(meta: DriveJSONRecord, *, file_id_fallback: str = "") -> D
 __all__ = [
     "DriveJSONPayload",
     "DriveJSONRecord",
+    "DriveJSONPayloadSequence",
+    "DriveJSONRecordSequence",
     "DriveJSONSequence",
     "_record_string",
     "_build_drive_file",

--- a/polylogue/sources/emitter.py
+++ b/polylogue/sources/emitter.py
@@ -6,7 +6,7 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from io import BytesIO
 from itertools import chain
-from typing import TYPE_CHECKING, BinaryIO
+from typing import IO, TYPE_CHECKING
 
 from polylogue.lib.artifact_taxonomy import ArtifactClassification, classify_artifact
 from polylogue.lib.json import dumps_bytes as json_dumps_bytes
@@ -46,7 +46,7 @@ class _SniffResult:
 
 @dataclass(frozen=True, slots=True)
 class _PreparedJsonlState:
-    sniff_handle: BinaryIO
+    sniff_handle: IO[bytes]
     pre_read_bytes: bytes | None
     stream_start: int | None
 
@@ -76,7 +76,7 @@ class _ConversationEmitter:
 
     def emit(
         self,
-        handle: BinaryIO,
+        handle: IO[bytes],
         stream_name: str,
         *,
         pre_read_bytes: bytes | None = None,
@@ -117,7 +117,7 @@ class _ConversationEmitter:
 
     def _emit_grouped(
         self,
-        handle: BinaryIO,
+        handle: IO[bytes],
         stream_name: str,
         pre_read_bytes: bytes | None,
         *,
@@ -155,7 +155,7 @@ class _ConversationEmitter:
 
     def _emit_individual(
         self,
-        handle: BinaryIO,
+        handle: IO[bytes],
         stream_name: str,
         *,
         pre_read_bytes: bytes | None = None,
@@ -213,7 +213,7 @@ class _ConversationEmitter:
 
     def _sniff_jsonl_payloads(
         self,
-        handle: BinaryIO,
+        handle: IO[bytes],
         stream_name: str,
     ) -> _SniffResult:
         payload_iter = iter(_iter_json_stream(handle, stream_name))
@@ -243,7 +243,7 @@ class _ConversationEmitter:
 
     def _prepare_jsonl_state(
         self,
-        handle: BinaryIO,
+        handle: IO[bytes],
         *,
         pre_read_bytes: bytes | None,
     ) -> _PreparedJsonlState:
@@ -261,7 +261,7 @@ class _ConversationEmitter:
 
     def _non_seekable_jsonl_sniff(
         self,
-        handle: BinaryIO,
+        handle: IO[bytes],
         stream_name: str,
     ) -> tuple[bytes, _SniffResult]:
         sniff_bytes = handle.read()
@@ -269,13 +269,13 @@ class _ConversationEmitter:
 
     def _grouped_jsonl_source(
         self,
-        handle: BinaryIO,
+        handle: IO[bytes],
         state: _PreparedJsonlState,
         *,
         precomputed_raw: RawConversationData | None,
-    ) -> tuple[BinaryIO, bytes | None]:
+    ) -> tuple[IO[bytes], bytes | None]:
         grouped_bytes = state.pre_read_bytes
-        grouped_handle: BinaryIO = state.sniff_handle
+        grouped_handle: IO[bytes] = state.sniff_handle
         if (
             grouped_bytes is None
             and self._ctx.capture_raw
@@ -289,7 +289,7 @@ class _ConversationEmitter:
 
     def _emit_jsonl(
         self,
-        handle: BinaryIO,
+        handle: IO[bytes],
         stream_name: str,
         *,
         pre_read_bytes: bytes | None,
@@ -338,7 +338,7 @@ class _ConversationEmitter:
             stream_name=stream_name,
         )
 
-    def _capture_stream_start(self, handle: BinaryIO) -> int | None:
+    def _capture_stream_start(self, handle: IO[bytes]) -> int | None:
         seekable = getattr(handle, "seekable", None)
         if callable(seekable):
             try:
@@ -351,7 +351,7 @@ class _ConversationEmitter:
         except (AttributeError, OSError, ValueError):
             return None
 
-    def _restore_stream_start(self, handle: BinaryIO, stream_start: int) -> None:
+    def _restore_stream_start(self, handle: IO[bytes], stream_start: int) -> None:
         handle.seek(stream_start)
 
     def _resolve_schema(

--- a/polylogue/sources/parsers/claude_code_parser.py
+++ b/polylogue/sources/parsers/claude_code_parser.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import re
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from typing import Any
 
 from pydantic import ValidationError
@@ -220,7 +220,7 @@ def _parse_code_records(records: Iterable[object], fallback_id: str) -> ParsedCo
     )
 
 
-def parse_code(payload: list[object], fallback_id: str) -> ParsedConversation:
+def parse_code(payload: Sequence[object], fallback_id: str) -> ParsedConversation:
     return _parse_code_records(payload, fallback_id)
 
 

--- a/polylogue/sources/parsers/claude_code_parser.py
+++ b/polylogue/sources/parsers/claude_code_parser.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import re
 from collections.abc import Iterable, Sequence
-from typing import Any
+from typing import TypeAlias
 
 from pydantic import ValidationError
 
@@ -25,6 +25,9 @@ from .claude_common import extract_message_text, normalize_timestamp
 
 _TAG_RE = re.compile(r"<[^>]+>")
 _WHITESPACE_RE = re.compile(r"\s+")
+
+ClaudeCodeContextCompaction: TypeAlias = dict[str, object]
+ClaudeCodeProviderMeta: TypeAlias = dict[str, object]
 
 
 def _clean_title_text(text: str) -> str:
@@ -79,7 +82,7 @@ def _parse_code_records(records: Iterable[object], fallback_id: str) -> ParsedCo
     timestamps: list[str] = []
     seen_record_uuids: set[str] = set()
     session_id: str | None = None
-    context_compactions: list[dict[str, Any]] = []
+    context_compactions: list[ClaudeCodeContextCompaction] = []
     provider_events: list[ParsedProviderEvent] = []
     total_cost = 0.0
     total_duration = 0
@@ -176,7 +179,7 @@ def _parse_code_records(records: Iterable[object], fallback_id: str) -> ParsedCo
     else:
         conversation_id = session_id or fallback_id
 
-    provider_meta: dict[str, Any] = {}
+    provider_meta: ClaudeCodeProviderMeta = {}
     if context_compactions:
         provider_meta["context_compactions"] = context_compactions
     if saw_cost_field:

--- a/polylogue/sources/parsers/claude_index.py
+++ b/polylogue/sources/parsers/claude_index.py
@@ -3,15 +3,18 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import TypeAlias
 
 from polylogue.logging import get_logger
 
 from .base import ParsedConversation
 
 logger = get_logger(__name__)
+
+SessionIndexMapping: TypeAlias = Mapping[str, object]
 
 
 @dataclass
@@ -31,19 +34,19 @@ class SessionIndexEntry:
     file_mtime: int | None = None
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> SessionIndexEntry:
+    def from_dict(cls, data: SessionIndexMapping) -> SessionIndexEntry:
         return cls(
-            session_id=data.get("sessionId", ""),
-            full_path=data.get("fullPath", ""),
-            first_prompt=data.get("firstPrompt"),
-            summary=data.get("summary"),
-            message_count=data.get("messageCount", 0),
-            created=data.get("created"),
-            modified=data.get("modified"),
-            git_branch=data.get("gitBranch"),
-            project_path=data.get("projectPath"),
-            is_sidechain=data.get("isSidechain", False),
-            file_mtime=data.get("fileMtime"),
+            session_id=_session_index_text(data, "sessionId"),
+            full_path=_session_index_text(data, "fullPath"),
+            first_prompt=_session_index_optional_text(data, "firstPrompt"),
+            summary=_session_index_optional_text(data, "summary"),
+            message_count=_session_index_int(data, "messageCount"),
+            created=_session_index_optional_text(data, "created"),
+            modified=_session_index_optional_text(data, "modified"),
+            git_branch=_session_index_optional_text(data, "gitBranch"),
+            project_path=_session_index_optional_text(data, "projectPath"),
+            is_sidechain=_session_index_bool(data, "isSidechain"),
+            file_mtime=_session_index_optional_int(data, "fileMtime"),
         )
 
 
@@ -52,12 +55,12 @@ def parse_sessions_index(index_path: Path) -> dict[str, SessionIndexEntry]:
         return {}
     try:
         data = json.loads(index_path.read_text(encoding="utf-8"))
-        entries = data.get("entries", [])
-        return {
-            entry["sessionId"]: SessionIndexEntry.from_dict(entry)
-            for entry in entries
-            if isinstance(entry, dict) and "sessionId" in entry
-        }
+        entries: dict[str, SessionIndexEntry] = {}
+        for entry in _session_index_entries(data):
+            session_id = _session_index_text(entry, "sessionId")
+            if session_id:
+                entries[session_id] = SessionIndexEntry.from_dict(entry)
+        return entries
     except (json.JSONDecodeError, KeyError, TypeError) as exc:
         logger.debug("Failed to parse sessions-index.json: %s", exc)
         return {}
@@ -66,6 +69,40 @@ def parse_sessions_index(index_path: Path) -> dict[str, SessionIndexEntry]:
 def find_sessions_index(session_path: Path) -> Path | None:
     index_path = session_path.parent / "sessions-index.json"
     return index_path if index_path.exists() else None
+
+
+def _session_index_entries(data: object) -> list[SessionIndexMapping]:
+    if not isinstance(data, Mapping):
+        return []
+    entries = data.get("entries")
+    if not isinstance(entries, list):
+        return []
+    return [entry for entry in entries if isinstance(entry, Mapping) and "sessionId" in entry]
+
+
+def _session_index_text(data: SessionIndexMapping, key: str) -> str:
+    value = data.get(key)
+    return value if isinstance(value, str) else ""
+
+
+def _session_index_optional_text(data: SessionIndexMapping, key: str) -> str | None:
+    value = data.get(key)
+    return value if isinstance(value, str) else None
+
+
+def _session_index_int(data: SessionIndexMapping, key: str) -> int:
+    value = data.get(key)
+    return value if isinstance(value, int) and not isinstance(value, bool) else 0
+
+
+def _session_index_optional_int(data: SessionIndexMapping, key: str) -> int | None:
+    value = data.get(key)
+    return value if isinstance(value, int) and not isinstance(value, bool) else None
+
+
+def _session_index_bool(data: SessionIndexMapping, key: str) -> bool:
+    value = data.get(key)
+    return value if isinstance(value, bool) else False
 
 
 _GIT_BRANCH_PREFIXES = frozenset(

--- a/polylogue/sources/parsers/codex.py
+++ b/polylogue/sources/parsers/codex.py
@@ -248,7 +248,7 @@ def _parse_records(records: Iterable[object], fallback_id: str) -> ParsedConvers
     )
 
 
-def parse(payload: list[object], fallback_id: str) -> ParsedConversation:
+def parse(payload: Sequence[object], fallback_id: str) -> ParsedConversation:
     return _parse_records(payload, fallback_id)
 
 

--- a/polylogue/sources/parsers/drive_support_attachments.py
+++ b/polylogue/sources/parsers/drive_support_attachments.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import base64
 import binascii
-from typing import TypeAlias, cast
+from typing import TypeAlias
 
 from polylogue.lib.hashing import hash_payload, hash_text_short
 from polylogue.lib.json import JSONDocument, JSONValue, is_json_document
@@ -17,11 +17,15 @@ _YOUTUBE_WATCH_URL = "https://www.youtube.com/watch?v={video_id}"
 DrivePayload: TypeAlias = JSONDocument
 DriveDocSource: TypeAlias = str | DrivePayload
 DrivePayloadSequence: TypeAlias = list[DriveDocSource]
-DriveDocMetadata: TypeAlias = JSONDocument
+DriveDocMetadata: TypeAlias = dict[str, object]
 
 
 def _as_drive_payload(payload: object) -> DrivePayload | None:
     return payload if is_json_document(payload) else None
+
+
+def _as_document_metadata(document: JSONDocument) -> DriveDocMetadata:
+    return dict(document)
 
 
 def _collect_doc_fields(payload: DrivePayload) -> DrivePayloadSequence:
@@ -88,7 +92,7 @@ def attachment_from_doc(doc: DriveDocSource, message_id: str | None) -> ParsedAt
             mime_type=None,
             size_bytes=None,
             path=None,
-            provider_meta=cast(dict[str, object], meta),
+            provider_meta=_as_document_metadata(meta),
         )
     if not is_json_document(doc):
         return None
@@ -105,7 +109,7 @@ def attachment_from_doc(doc: DriveDocSource, message_id: str | None) -> ParsedAt
         mime_type=mime_val,
         size_bytes=size_bytes,
         path=None,
-        provider_meta=cast(dict[str, object], dict(doc)),
+        provider_meta=_as_document_metadata(doc),
     )
 
 
@@ -133,7 +137,7 @@ def attachment_from_inline_file(
         mime_type=mime_type if isinstance(mime_type, str) else None,
         size_bytes=size_bytes,
         path=None,
-        provider_meta=cast(dict[str, object], provider_meta),
+        provider_meta=provider_meta,
     )
 
 
@@ -151,7 +155,8 @@ def attachment_from_youtube_video(
     else:
         attachment_id = f"youtube-video-{hash_payload(video_dict)}"
         url = None
-    provider_meta: DriveDocMetadata = {"attachment_kind": "youtube_video", **video_dict}
+    provider_meta: DriveDocMetadata = {"attachment_kind": "youtube_video"}
+    provider_meta.update(_as_document_metadata(video_dict))
     if url is not None:
         provider_meta["url"] = url
     return ParsedAttachment(
@@ -161,7 +166,7 @@ def attachment_from_youtube_video(
         mime_type="video/youtube",
         size_bytes=None,
         path=None,
-        provider_meta=cast(dict[str, object], provider_meta),
+        provider_meta=provider_meta,
     )
 
 
@@ -187,7 +192,7 @@ def attachment_block_payloads(attachments: list[ParsedAttachment]) -> list[Drive
     blocks: list[DriveDocMetadata] = []
 
     def _metadata_for_block(attachment: ParsedAttachment) -> DriveDocMetadata:
-        metadata: DriveDocMetadata = dict(cast(JSONDocument, attachment.provider_meta or {}))
+        metadata: DriveDocMetadata = dict(attachment.provider_meta or {})
         if attachment.name:
             metadata.setdefault("name", attachment.name)
         return metadata

--- a/polylogue/sources/parsers/drive_support_blocks.py
+++ b/polylogue/sources/parsers/drive_support_blocks.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import cast
-
 from polylogue.lib.json import JSONDocument, json_document, json_document_list
 from polylogue.lib.viewports import ContentBlock
 from polylogue.types import ContentBlockType
@@ -52,15 +50,17 @@ def parsed_content_blocks_from_meta(blocks: object) -> list[ParsedContentBlock]:
         raw_media_type = block.get("media_type")
         media_type = raw_media_type if isinstance(raw_media_type, str) else None
         language = block.get("language")
+        metadata_out: dict[str, object] = {}
+        for key, value in metadata.items():
+            metadata_out[key] = value
         if isinstance(language, str) and language:
-            metadata = dict(metadata)
-            metadata.setdefault("language", language)
+            metadata_out.setdefault("language", language)
         parsed.append(
             ParsedContentBlock(
                 type=ContentBlockType.from_string(block_type),
                 text=text,
                 media_type=media_type,
-                metadata=cast(dict[str, object] | None, metadata or None),
+                metadata=metadata_out or None,
             )
         )
     return parsed

--- a/polylogue/sources/providers/chatgpt_message_models.py
+++ b/polylogue/sources/providers/chatgpt_message_models.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any
+from typing import TypeAlias
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -19,6 +19,20 @@ from polylogue.lib.viewports import (
 )
 from polylogue.types import Provider
 
+ChatGPTMetadata: TypeAlias = dict[str, object]
+ChatGPTPartValue: TypeAlias = object
+
+
+def _model_slug(metadata: ChatGPTMetadata) -> str | None:
+    value = metadata.get("model_slug")
+    return value if isinstance(value, str) else None
+
+
+def _content_raw(content: ChatGPTContent) -> ChatGPTMetadata:
+    payload: ChatGPTMetadata = {}
+    payload.update(content.model_dump(mode="python"))
+    return payload
+
 
 class ChatGPTAuthor(BaseModel):
     """Author of a ChatGPT message."""
@@ -27,7 +41,7 @@ class ChatGPTAuthor(BaseModel):
 
     role: str
     name: str | None = None
-    metadata: dict[str, Any] = Field(default_factory=dict)
+    metadata: ChatGPTMetadata = Field(default_factory=dict)
 
 
 class ChatGPTContent(BaseModel):
@@ -36,7 +50,7 @@ class ChatGPTContent(BaseModel):
     model_config = ConfigDict(extra="allow")
 
     content_type: str
-    parts: list[Any] | None = None
+    parts: list[ChatGPTPartValue] | None = None
     text: str | None = None
     language: str | None = None
 
@@ -54,7 +68,7 @@ class ChatGPTMessage(BaseModel):
     status: str | None = None
     end_turn: bool | None = None
     weight: float = 0.0
-    metadata: dict[str, Any] = Field(default_factory=dict)
+    metadata: ChatGPTMetadata = Field(default_factory=dict)
     recipient: str | None = None
 
     @property
@@ -84,7 +98,7 @@ class ChatGPTMessage(BaseModel):
             id=self.id,
             timestamp=self.timestamp,
             role=self.role_normalized,
-            model=self.metadata.get("model_slug"),
+            model=_model_slug(self.metadata),
             provider=Provider.CHATGPT,
         )
 
@@ -95,12 +109,13 @@ class ChatGPTMessage(BaseModel):
             return blocks
 
         content_type = self.content.content_type
+        raw_content = _content_raw(self.content)
         if content_type == "text":
             blocks.append(
                 ContentBlock(
                     type=ContentType.TEXT,
                     text=self.text_content,
-                    raw=self.content.model_dump(),
+                    raw=raw_content,
                 )
             )
         elif content_type == "code":
@@ -109,7 +124,7 @@ class ChatGPTMessage(BaseModel):
                     type=ContentType.CODE,
                     text=self.text_content,
                     language=self.content.language,
-                    raw=self.content.model_dump(),
+                    raw=raw_content,
                 )
             )
         elif "tether" in content_type or "browse" in content_type:
@@ -117,7 +132,7 @@ class ChatGPTMessage(BaseModel):
                 ContentBlock(
                     type=ContentType.TOOL_RESULT,
                     text=self.text_content,
-                    raw=self.content.model_dump(),
+                    raw=raw_content,
                 )
             )
         else:
@@ -125,7 +140,7 @@ class ChatGPTMessage(BaseModel):
                 ContentBlock(
                     type=ContentType.UNKNOWN,
                     text=self.text_content,
-                    raw=self.content.model_dump(),
+                    raw=raw_content,
                 )
             )
 

--- a/polylogue/sources/providers/claude_ai.py
+++ b/polylogue/sources/providers/claude_ai.py
@@ -7,7 +7,7 @@ Derived from schema package: polylogue/schemas/providers/claude-ai/versions/v1/e
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any
+from typing import TypeAlias
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -15,6 +15,8 @@ from polylogue.lib.roles import Role
 from polylogue.lib.timestamps import parse_timestamp
 from polylogue.lib.viewports import ContentBlock, ContentType, MessageMeta, ReasoningTrace, ToolCall
 from polylogue.types import Provider
+
+ClaudeAIObject: TypeAlias = dict[str, object]
 
 
 class ClaudeAIChatMessage(BaseModel):
@@ -37,10 +39,10 @@ class ClaudeAIChatMessage(BaseModel):
     updated_at: str | None = None
     """Update timestamp (ISO format)."""
 
-    attachments: list[dict[str, Any]] = Field(default_factory=list)
+    attachments: list[ClaudeAIObject] = Field(default_factory=list)
     """File attachments."""
 
-    files: list[dict[str, Any]] = Field(default_factory=list)
+    files: list[ClaudeAIObject] = Field(default_factory=list)
     """Associated files."""
 
     @property
@@ -113,7 +115,7 @@ class ClaudeAIConversation(BaseModel):
     chat_messages: list[ClaudeAIChatMessage] = Field(default_factory=list)
     """Messages in the conversation."""
 
-    account: dict[str, Any] | None = None
+    account: ClaudeAIObject | None = None
     """Account information."""
 
     summary: str | None = None

--- a/polylogue/sources/providers/gemini_message.py
+++ b/polylogue/sources/providers/gemini_message.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import TypeAlias, cast
+from typing import TypeAlias
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -28,9 +28,15 @@ GeminiDictValue: TypeAlias = dict[str, object]
 GeminiBranchChildren: TypeAlias = list[GeminiDictValue]
 
 
+def _json_object(value: object) -> GeminiDictValue:
+    result: GeminiDictValue = {}
+    result.update(json_document(value))
+    return result
+
+
 def _normalize_mapping(payload: BaseModel | GeminiDictValue) -> GeminiDictValue:
     if isinstance(payload, BaseModel):
-        return cast(GeminiDictValue, json_document(payload.model_dump()))
+        return _json_object(payload.model_dump())
     return payload
 
 
@@ -59,12 +65,12 @@ def _get_str_or_none(value: object) -> str | None:
 
 
 def _string_or_empty_dict(value: object) -> GeminiDictValue:
-    return cast(GeminiDictValue, json_document(value))
+    return _json_object(value)
 
 
 def _part_record(part: GeminiPartValue) -> GeminiDictValue:
     if isinstance(part, GeminiPart):
-        return cast(GeminiDictValue, json_document(part.model_dump()))
+        return _json_object(part.model_dump())
     return part
 
 

--- a/polylogue/sources/source_acquisition.py
+++ b/polylogue/sources/source_acquisition.py
@@ -6,7 +6,7 @@ import time
 import zipfile
 from collections.abc import Callable, Iterable
 from pathlib import Path
-from typing import IO, BinaryIO, TypeAlias, cast
+from typing import IO, TypeAlias
 
 from polylogue.config import Source
 from polylogue.lib.artifact_taxonomy import classify_artifact
@@ -106,7 +106,7 @@ def _observe_acquisition(
 
 def _stream_fileobj_to_blob(
     blob_store: BlobStore,
-    handle: BinaryIO,
+    handle: IO[bytes],
     *,
     status_callback: StatusCallback | None,
     source_name: str,
@@ -160,7 +160,7 @@ def _raw_data_record(
 
 
 def _iter_entry_payloads(
-    handle: BinaryIO | IO[bytes],
+    handle: IO[bytes],
     *,
     stream_name: str,
     provider_hint: Provider,
@@ -268,7 +268,7 @@ def iter_source_raw_data(
                             with zf.open(info.filename) as handle:
                                 blob_hash, blob_size = _stream_fileobj_to_blob(
                                     blob_store,
-                                    cast(BinaryIO, handle),
+                                    handle,
                                     status_callback=status_callback,
                                     source_name=source.name,
                                     source_path=entry_path,
@@ -296,7 +296,7 @@ def iter_source_raw_data(
 
                         with zf.open(info.filename) as handle:
                             for payload_provider, payload, detect_provider_ms in _iter_entry_payloads(
-                                cast(BinaryIO, handle),
+                                handle,
                                 stream_name=info.filename,
                                 provider_hint=entry_provider_hint,
                             ):
@@ -364,7 +364,7 @@ def iter_source_raw_data(
                         with zf.open(info.filename) as handle:
                             blob_hash, blob_size = _stream_fileobj_to_blob(
                                 blob_store,
-                                cast(BinaryIO, handle),
+                                handle,
                                 status_callback=status_callback,
                                 source_name=source.name,
                                 source_path=entry_path,

--- a/polylogue/sources/token_store.py
+++ b/polylogue/sources/token_store.py
@@ -8,8 +8,9 @@ Provides a protocol for token persistence with two implementations:
 from __future__ import annotations
 
 from contextlib import suppress
+from importlib import import_module
 from pathlib import Path
-from typing import Protocol
+from typing import Protocol, runtime_checkable
 
 from polylogue.logging import get_logger
 
@@ -30,6 +31,19 @@ class TokenStore(Protocol):
     def delete(self, key: str) -> None:
         """Delete token data by key."""
         ...
+
+
+@runtime_checkable
+class KeyringModule(Protocol):
+    """Typed subset of the keyring module used by Polylogue."""
+
+    def get_keyring(self) -> object: ...
+
+    def get_password(self, service_name: str, key: str) -> str | None: ...
+
+    def set_password(self, service_name: str, key: str, value: str) -> None: ...
+
+    def delete_password(self, service_name: str, key: str) -> None: ...
 
 
 class FileTokenStore:
@@ -77,20 +91,23 @@ class KeyringTokenStore:
         self._keyring = self._try_import_keyring()
 
     @staticmethod
-    def _try_import_keyring() -> object | None:
+    def _try_import_keyring() -> KeyringModule | None:
         try:
-            import keyring
+            candidate = import_module("keyring")
+            keyring = candidate if isinstance(candidate, KeyringModule) else None
+            if keyring is None:
+                return None
 
             # Test that keyring backend is functional
             keyring.get_keyring()
-            return keyring  # type: ignore[no-any-return]
+            return keyring
         except Exception:
             return None
 
     def load(self, key: str) -> str | None:
         if self._keyring is not None:
             try:
-                data: str | None = self._keyring.get_password(self._SERVICE_NAME, key)  # type: ignore[attr-defined]
+                data = self._keyring.get_password(self._SERVICE_NAME, key)
                 if data is not None:
                     return data
             except Exception as exc:
@@ -100,7 +117,7 @@ class KeyringTokenStore:
     def save(self, key: str, data: str) -> None:
         if self._keyring is not None:
             try:
-                self._keyring.set_password(self._SERVICE_NAME, key, data)  # type: ignore[attr-defined]
+                self._keyring.set_password(self._SERVICE_NAME, key, data)
                 return
             except Exception as exc:
                 logger.debug("Keyring save failed for %s, falling back to file: %s", key, exc)
@@ -109,7 +126,7 @@ class KeyringTokenStore:
     def delete(self, key: str) -> None:
         if self._keyring is not None:
             with suppress(Exception):
-                self._keyring.delete_password(self._SERVICE_NAME, key)  # type: ignore[attr-defined]
+                self._keyring.delete_password(self._SERVICE_NAME, key)
         self._fallback.delete(key)
 
 

--- a/polylogue/storage/blob_store.py
+++ b/polylogue/storage/blob_store.py
@@ -21,7 +21,7 @@ import os
 import tempfile
 from collections.abc import Callable, Iterator
 from pathlib import Path
-from typing import BinaryIO
+from typing import IO, BinaryIO
 
 _CHUNK_SIZE = 128 * 1024  # 128 KB
 Heartbeat = Callable[[], None]
@@ -104,7 +104,7 @@ class BlobStore:
 
     def write_from_fileobj(
         self,
-        source: BinaryIO,
+        source: IO[bytes],
         *,
         heartbeat: Heartbeat | None = None,
     ) -> tuple[str, int]:

--- a/polylogue/ui/facade_console.py
+++ b/polylogue/ui/facade_console.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import io
-from typing import Protocol, runtime_checkable
+from typing import Any, Protocol, runtime_checkable
 
 from rich.console import Console as RichConsole
 from rich.errors import MarkupError
@@ -13,7 +13,7 @@ from rich.text import Text
 
 @runtime_checkable
 class ConsoleLike(Protocol):
-    def print(self, *objects: object, **kwargs: object) -> None: ...
+    def print(self, *objects: object, **kwargs: Any) -> None: ...
 
 
 def _render_plain_object(obj: object) -> str:

--- a/polylogue/ui/facade_console.py
+++ b/polylogue/ui/facade_console.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import io
-from contextlib import suppress
 from typing import Protocol, runtime_checkable
 
 from rich.console import Console as RichConsole
@@ -16,17 +15,11 @@ class ConsoleLike(Protocol):
     def print(self, *objects: object, **kwargs: object) -> None: ...
 
 
-def _plain_text_from_markup(text: str) -> str:
-    with suppress(Exception):
-        return Text.from_markup(text).plain
-    return text
-
-
 def _render_plain_object(obj: object) -> str:
     if isinstance(obj, Text):
         return obj.plain
     if isinstance(obj, str):
-        return _plain_text_from_markup(obj)
+        return obj
 
     if isinstance(obj, Table):
         buf = io.StringIO()
@@ -34,8 +27,7 @@ def _render_plain_object(obj: object) -> str:
         tmp.print(obj)
         return buf.getvalue().rstrip()
 
-    raw = str(obj)
-    return _plain_text_from_markup(raw)
+    return str(obj)
 
 
 class PlainConsole:

--- a/polylogue/ui/facade_console.py
+++ b/polylogue/ui/facade_console.py
@@ -6,6 +6,7 @@ import io
 from typing import Protocol, runtime_checkable
 
 from rich.console import Console as RichConsole
+from rich.errors import MarkupError
 from rich.table import Table
 from rich.text import Text
 
@@ -19,7 +20,10 @@ def _render_plain_object(obj: object) -> str:
     if isinstance(obj, Text):
         return obj.plain
     if isinstance(obj, str):
-        return obj
+        try:
+            return Text.from_markup(obj).plain
+        except MarkupError:
+            return obj
 
     if isinstance(obj, Table):
         buf = io.StringIO()

--- a/tests/unit/rendering/test_html_messages.py
+++ b/tests/unit/rendering/test_html_messages.py
@@ -1,0 +1,31 @@
+"""Regression tests for HTML message shaping with structured-only content."""
+
+from __future__ import annotations
+
+from polylogue.rendering.renderers.html import render_conversation_html
+from tests.infra.builders import make_conv, make_msg
+
+
+def test_render_conversation_html_keeps_messages_with_structured_blocks_only() -> None:
+    """Structured blocks should keep a message renderable even when text is empty."""
+    conversation = make_conv(
+        messages=[
+            make_msg(
+                id="m1",
+                role="assistant",
+                text="",
+                content_blocks=[
+                    {
+                        "type": "code",
+                        "text": "print('hello from blocks')",
+                        "language": "python",
+                    }
+                ],
+            )
+        ]
+    )
+
+    html = render_conversation_html(conversation)
+
+    assert "hello from blocks" in html
+    assert "code-block" in html

--- a/tests/unit/rendering/test_output_snapshots.py
+++ b/tests/unit/rendering/test_output_snapshots.py
@@ -16,6 +16,7 @@ syrupy = pytest.importorskip("syrupy")
 
 from polylogue.lib.models import Conversation, Message
 from polylogue.rendering.renderers.html import render_conversation_html
+from polylogue.types import ContentBlockType
 from tests.infra.builders import make_conv as build_conv
 from tests.infra.builders import make_msg as build_msg
 
@@ -94,3 +95,29 @@ def test_conversation_with_followup_html_snapshot(snapshot: object) -> None:
     conv = _make_conv(msgs, title="Followup After Branch")
     html = render_conversation_html(conv)
     assert html == snapshot
+
+
+def test_media_blocks_render_in_conversation_html() -> None:
+    """Structured media blocks should survive the HTML boundary."""
+    msgs = [
+        build_msg(
+            id="m1",
+            role="assistant",
+            text="This fallback text should not be rendered",
+            content_blocks=[
+                {
+                    "type": ContentBlockType.DOCUMENT.value,
+                    "name": "Spec",
+                    "url": "https://example.com/spec.pdf",
+                    "mime_type": "application/pdf",
+                }
+            ],
+        )
+    ]
+    conv = _make_conv(msgs, title="Media Conversation")
+    html = render_conversation_html(conv)
+    assert "media-block" in html
+    assert 'data-type="document"' in html
+    assert 'href="https://example.com/spec.pdf"' in html
+    assert "Spec" in html
+    assert "This fallback text should not be rendered" not in html

--- a/tests/unit/rendering/test_rendering.py
+++ b/tests/unit/rendering/test_rendering.py
@@ -9,13 +9,22 @@ import json
 from datetime import datetime, timezone
 from typing import cast
 
+import pytest
+
 from polylogue.lib.models import Conversation, ConversationSummary, Message
+from polylogue.rendering.block_models import RenderableBlock
+from polylogue.rendering.blocks import (
+    render_blocks_html,
+    render_blocks_markdown,
+    render_blocks_plaintext,
+)
 from polylogue.rendering.core import format_conversation_markdown
 from polylogue.rendering.renderers.html import (
     _attach_branches,
     render_conversation_html,
 )
-from polylogue.types import ConversationId, Provider
+from polylogue.types import ContentBlockType, ConversationId, Provider
+from polylogue.ui.facade_console import PlainConsole
 from tests.infra.builders import make_conv, make_msg
 
 # =============================================================================
@@ -48,6 +57,16 @@ def _make_conv(messages: list[Message], title: str | None = "Branch Test") -> Co
         title=title,
         messages=messages,
     )
+
+
+def _make_media_block(
+    block_type: str,
+    *,
+    name: str,
+    url: str | None = None,
+    mime_type: str | None = None,
+) -> RenderableBlock:
+    return RenderableBlock(type=block_type, name=name, url=url, mime_type=mime_type)
 
 
 class TestAttachBranches:
@@ -177,6 +196,58 @@ class TestBranchRendering:
         assert "A1" in html
         assert "A2 alt" in html
         assert html.index("<details") < html.index("A2 alt")
+
+
+class TestMediaBlockRendering:
+    """Tests for structured media/document/file rendering across surfaces."""
+
+    def test_media_blocks_render_across_markdown_html_and_plaintext(self) -> None:
+        blocks = [
+            _make_media_block(
+                ContentBlockType.IMAGE.value,
+                name="Preview image",
+                url="https://example.com/image.png",
+                mime_type="image/png",
+            ),
+            _make_media_block(
+                ContentBlockType.DOCUMENT.value,
+                name="Spec",
+                url="https://example.com/spec.pdf",
+                mime_type="application/pdf",
+            ),
+            _make_media_block("file", name="Archive", mime_type="text/plain"),
+        ]
+
+        markdown = render_blocks_markdown(blocks)
+        html = render_blocks_html(blocks)
+        plaintext = render_blocks_plaintext(blocks)
+
+        assert "[Preview image](https://example.com/image.png) (image/png)" in markdown
+        assert "[Spec](https://example.com/spec.pdf) (application/pdf)" in markdown
+        assert "[Archive] (text/plain)" in markdown
+
+        assert '<div class="media-block" data-type="image">' in html
+        assert '<a class="media-link" href="https://example.com/image.png">Preview image</a>' in html
+        assert '<div class="media-block" data-type="document">' in html
+        assert '<a class="media-link" href="https://example.com/spec.pdf">Spec</a>' in html
+        assert '<div class="media-block" data-type="file">' in html
+        assert '<span class="media-name">Archive</span>' in html
+
+        assert "Preview image https://example.com/image.png (image/png)" in plaintext
+        assert "Spec https://example.com/spec.pdf (application/pdf)" in plaintext
+        assert "Archive (text/plain)" in plaintext
+
+
+class TestPlainConsoleLiteralOutput:
+    """PlainConsole must preserve non-markup literal string content."""
+
+    def test_prints_strings_literally(self, capsys: pytest.CaptureFixture[str]) -> None:
+        console = PlainConsole()
+        console.print("[bold]literal[/bold]", "```python\nprint(1)\n```")
+        output = capsys.readouterr().out
+        assert "literal" in output
+        assert "```python" in output
+        assert "print(1)" in output
 
 
 # =============================================================================

--- a/tests/unit/sources/test_source_laws.py
+++ b/tests/unit/sources/test_source_laws.py
@@ -9,7 +9,7 @@ import zipfile
 from collections.abc import Iterable, Mapping
 from io import BytesIO
 from pathlib import Path
-from typing import IO, BinaryIO, cast
+from typing import IO
 from unittest.mock import MagicMock
 
 import ijson
@@ -19,6 +19,7 @@ from hypothesis import strategies as st
 from typing_extensions import TypedDict
 
 from polylogue.config import Source
+from polylogue.lib.json import is_json_value
 from polylogue.lib.roles import Role, normalize_role
 from polylogue.schemas.json_types import JSONDocument, JSONValue
 from polylogue.sources import decoders as decoders_module
@@ -555,7 +556,7 @@ def test_iter_source_conversations_tracks_file_disappearance_contract(
         encoding: str | None = None,
         errors: str | None = None,
         newline: str | None = None,
-    ) -> IO[str] | BinaryIO:
+    ) -> IO[str] | IO[bytes]:
         if path == second:
             raise FileNotFoundError("deleted")
         return original_open(
@@ -710,7 +711,7 @@ def test_iter_source_conversations_with_raw_streams_grouped_zip_capture_to_blob_
     write_calls = 0
     original_write_from_fileobj = BlobStore.write_from_fileobj
 
-    def tracking_write_from_fileobj(self: BlobStore, source: BinaryIO) -> tuple[str, int]:
+    def tracking_write_from_fileobj(self: BlobStore, source: IO[bytes]) -> tuple[str, int]:
         nonlocal write_calls
         write_calls += 1
         return original_write_from_fileobj(self, source)
@@ -1418,7 +1419,7 @@ def test_conversation_emitter_reuses_jsonl_sniff_payloads_for_grouped_detection(
     original_iter_json_stream = _iter_json_stream
 
     def tracking_iter_json_stream(
-        handle: BinaryIO | IO[bytes],
+        handle: IO[bytes],
         path_name: str,
         unpack_lists: bool = True,
     ) -> Iterable[object]:
@@ -1463,7 +1464,7 @@ def test_conversation_emitter_reuses_jsonl_sniff_payloads_for_individual_detecti
     original_iter_json_stream = _iter_json_stream
 
     def tracking_iter_json_stream(
-        handle: BinaryIO | IO[bytes],
+        handle: IO[bytes],
         path_name: str,
         unpack_lists: bool = True,
     ) -> Iterable[object]:
@@ -1689,7 +1690,9 @@ class _StubDriveRawClient:
 
     def download_json_payload(self, file_id: str, *, name: str) -> JSONValue:
         del name
-        return cast(JSONValue, json.loads(self.download_bytes(file_id)))
+        payload = json.loads(self.download_bytes(file_id))
+        assert is_json_value(payload)
+        return payload
 
     def download_to_path(self, file_id: str, dest: Path) -> DriveFile:
         if file_id in self.failures:


### PR DESCRIPTION
## Summary

- renew rendering, source, and decoder boundary contracts around block payloads and dispatch
- tighten follow-through across provider helpers, drive/source support, and plain-console rendering tests
- eliminate the remaining hotspot seams in this slice without reopening the verification-renewal diff

## Problem

The next high-leverage source-side weak typing and payload-plumbing debt was concentrated in the rendering/source boundary layer:

- `polylogue/rendering/block_models.py`
- `polylogue/rendering/core_messages.py`
- `polylogue/sources/dispatch.py`
- `polylogue/sources/token_store.py`
- `polylogue/lib/json.py`

Those files still carried cast-heavy extraction, loose `object`/sequence handling, and partially modeled provider/decoder seams. Adjacent helpers like drive support, ChatGPT/Claude/Gemini provider adapters, and the plain-console shim were then compensating for that imprecision.

Closes #278

## Solution

- rebuilt the JSON/document helpers in `polylogue/lib/json.py` and `polylogue/sources/decoder_json.py` around typed validation rather than cast-driven loads
- tightened renderable block/message handling in `polylogue/rendering/block_models.py`, `polylogue/rendering/blocks.py`, `polylogue/rendering/core_messages.py`, and `polylogue/rendering/renderers/html_messages.py`
- removed source/provider hotspot casts across `polylogue/sources/dispatch.py`, `token_store.py`, `emitter.py`, `drive_source_client.py`, `drive_source_support.py`, `parsers/claude_index.py`, `parsers/claude_code_parser.py`, `parsers/drive_support_{attachments,blocks}.py`, and provider adapters under `polylogue/sources/providers/`
- tightened the remaining boundary seams in `drive_auth.py`, `drive_gateway.py`, `blob_store.py`, and `ui/facade_console.py`
- extended rendering/source law coverage with targeted tests for media blocks, HTML message rendering, output snapshots, and source detection/dispatch laws

## Verification

- `ruff check tests/unit/rendering/test_rendering.py tests/unit/ui/test_ui.py polylogue/ui/facade_console.py`
- `mypy tests/unit/rendering/test_rendering.py tests/unit/ui/test_ui.py polylogue/ui/facade_console.py`
- `pytest -q tests/unit/rendering/test_rendering.py tests/unit/ui/test_ui.py`
- `devtools verify`
