### PR TITLE
refactor: renew schema, scenario, and sync runtime contracts

### DIFF
--- a/polylogue/lib/messages.py
+++ b/polylogue/lib/messages.py
@@ -9,7 +9,7 @@ used in production.
 from __future__ import annotations
 
 from collections.abc import Iterator, Sized
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from pydantic import GetCoreSchemaHandler, GetJsonSchemaHandler
 from pydantic_core import core_schema
@@ -85,7 +85,7 @@ class MessageCollection(Sized):
     @classmethod
     def __get_pydantic_core_schema__(
         cls,
-        _source_type: Any,
+        _source_type: object,
         _handler: GetCoreSchemaHandler,
     ) -> core_schema.CoreSchema:
         """Pydantic V2 schema: serialize as list[Message], accept MessageCollection or list."""
@@ -93,14 +93,14 @@ class MessageCollection(Sized):
 
         message_schema = _handler.generate_schema(Message)
 
-        def validate_messages(v: Any) -> MessageCollection:
+        def validate_messages(v: object) -> MessageCollection:
             if isinstance(v, MessageCollection):
                 return v
             if isinstance(v, list):
                 return MessageCollection(messages=v)
             raise ValueError(f"Expected MessageCollection or list, got {type(v)}")
 
-        def serialize_messages(v: MessageCollection) -> list[Any]:
+        def serialize_messages(v: MessageCollection) -> list[Message]:
             return v.to_list()
 
         return core_schema.no_info_plain_validator_function(

--- a/polylogue/pipeline/ids.py
+++ b/polylogue/pipeline/ids.py
@@ -4,16 +4,18 @@ from __future__ import annotations
 
 import shutil
 from pathlib import Path
-from typing import Any
+from typing import TypeAlias
 
 from polylogue.assets import asset_path
 from polylogue.lib.hashing import hash_file, hash_payload, hash_text
+from polylogue.lib.json import JSONValue
 from polylogue.sources import ParsedAttachment, ParsedConversation, ParsedMessage
 from polylogue.types import ContentHash, ConversationId, MessageId
 
 # Sentinel values to distinguish None from empty in hash computations
 _NULL_SENTINEL = "__POLYLOGUE_NULL__"
 _EMPTY_SENTINEL = "__POLYLOGUE_EMPTY__"
+HashScalar: TypeAlias = str | int | float | bool | None
 
 
 def move_attachment_to_archive(source: Path, dest: Path) -> None:
@@ -55,14 +57,14 @@ def materialize_attachment_path(source: Path, dest: Path) -> None:
     move_attachment_to_archive(source, dest)
 
 
-def _normalize_for_hash(value: Any) -> Any:
+def _normalize_for_hash(value: HashScalar) -> JSONValue:
     """Normalize a value for hashing, distinguishing None from empty.
 
     Args:
-        value: Any value to normalize.
+        value: Hash-compatible scalar value to normalize.
 
     Returns:
-        Normalized value with None → _NULL_SENTINEL and "" → _EMPTY_SENTINEL.
+        Normalized JSON value with None → _NULL_SENTINEL and "" → _EMPTY_SENTINEL.
     """
     if value is None:
         return _NULL_SENTINEL
@@ -164,9 +166,9 @@ def message_content_hash(message: ParsedMessage, provider_message_id: str) -> Co
     Returns:
         Content hash string.
     """
-    payload = {
+    payload: dict[str, JSONValue] = {
         "id": provider_message_id,
-        "role": message.role,
+        "role": str(message.role),
         "text": _normalize_for_hash(message.text),
         "timestamp": _normalize_for_hash(message.timestamp),
     }
@@ -184,13 +186,13 @@ def conversation_content_hash(convo: ParsedConversation) -> ContentHash:
     Returns:
         Content hash string.
     """
-    messages_payload = []
+    messages_payload: list[dict[str, JSONValue]] = []
     for idx, msg in enumerate(convo.messages, start=1):
         message_id = msg.provider_message_id or f"msg-{idx}"
         messages_payload.append(
             {
                 "id": message_id,
-                "role": msg.role,
+                "role": str(msg.role),
                 "text": _normalize_for_hash(msg.text),
                 "timestamp": _normalize_for_hash(msg.timestamp),
             }

--- a/polylogue/scenarios/corpus.py
+++ b/polylogue/scenarios/corpus.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field, replace
 from enum import Enum
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
+
+from polylogue.schemas.operator_registry import SchemaRegistryLike
 
 from .metadata import ScenarioMetadata
 from .payloads import (
@@ -167,7 +169,7 @@ class CorpusRequest:
         *,
         origin: str | None = None,
         tags: tuple[str, ...] | None = None,
-        registry: Any | None = None,
+        registry: SchemaRegistryLike | None = None,
     ) -> tuple[CorpusSpec, ...]:
         return resolve_corpus_specs(
             providers=self.available_providers(),
@@ -188,7 +190,7 @@ class CorpusRequest:
         *,
         origin: str = "compiled.synthetic-corpus-scenario",
         tags: tuple[str, ...] = ("synthetic", "scenario"),
-        registry: Any | None = None,
+        registry: SchemaRegistryLike | None = None,
     ) -> tuple[CorpusScenario, ...]:
         return resolve_corpus_scenarios(
             providers=self.available_providers(),
@@ -521,7 +523,7 @@ def resolve_corpus_specs(
     package_version: str = "default",
     origin: str | None = None,
     tags: tuple[str, ...] | None = None,
-    registry: Any | None = None,
+    registry: SchemaRegistryLike | None = None,
 ) -> tuple[CorpusSpec, ...]:
     source_kind = CorpusSourceKind(source)
     provider_names = tuple(providers) if providers is not None else None
@@ -570,7 +572,7 @@ def resolve_corpus_scenarios(
     package_version: str = "default",
     origin: str = "compiled.synthetic-corpus-scenario",
     tags: tuple[str, ...] = ("synthetic", "scenario"),
-    registry: Any | None = None,
+    registry: SchemaRegistryLike | None = None,
 ) -> tuple[CorpusScenario, ...]:
     specs = resolve_corpus_specs(
         providers=providers,

--- a/polylogue/schemas/operator_inference.py
+++ b/polylogue/schemas/operator_inference.py
@@ -2,16 +2,11 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
-from pathlib import Path
-from typing import Literal, Protocol, cast
+from collections.abc import Mapping
 
 from polylogue.scenarios import CorpusScenario, CorpusSpec, build_corpus_scenarios, build_inferred_corpus_specs
 from polylogue.schemas.audit_models import AuditReport
 from polylogue.schemas.json_types import JSONDocument
-from polylogue.schemas.operator_models import (
-    JSONDocument as OperatorJSONDocument,
-)
 from polylogue.schemas.operator_models import (
     SchemaAuditRequest,
     SchemaCompareRequest,
@@ -23,60 +18,21 @@ from polylogue.schemas.operator_models import (
     SchemaPromoteRequest,
     SchemaPromoteResult,
     SchemaProviderSnapshot,
+    operator_json_document,
 )
-from polylogue.schemas.operator_registry import schema_registry
-from polylogue.schemas.packages import SchemaPackageCatalog, SchemaVersionPackage
-from polylogue.schemas.privacy_config import PrivacyConfig
-from polylogue.schemas.tooling_models import ClusterManifest, SchemaDiff
+from polylogue.schemas.operator_registry import SchemaRegistryLike, schema_registry
+from polylogue.schemas.packages import SchemaPackageCatalog
+from polylogue.schemas.privacy_config import PrivacyConfig, PrivacyLevel
+from polylogue.schemas.tooling_models import ClusterManifest
 from polylogue.types import Provider
 
 
-class _SchemaRegistryLike(Protocol):
-    def load_package_catalog(self, provider: str) -> SchemaPackageCatalog | None: ...
-
-    def cluster_samples(self, provider: str, samples: Sequence[object]) -> ClusterManifest: ...
-
-    def save_cluster_manifest(self, manifest: ClusterManifest) -> Path: ...
-
-    def load_cluster_manifest(self, provider: str) -> ClusterManifest | None: ...
-
-    def list_providers(self) -> list[str]: ...
-
-    def list_versions(self, provider: str) -> list[str]: ...
-
-    def get_schema_age_days(self, provider: str) -> int | None: ...
-
-    def compare_versions(
-        self,
-        provider: str,
-        from_version: str,
-        to_version: str,
-        *,
-        element_kind: str | None = None,
-    ) -> SchemaDiff: ...
-
-    def promote_cluster(
-        self,
-        provider: str,
-        cluster_id: str,
-        *,
-        samples: Sequence[object] | None = None,
-    ) -> str: ...
-
-    def get_package(self, provider: str, *, version: str) -> SchemaVersionPackage | None: ...
-
-    def get_element_schema(self, provider: str, *, version: str) -> JSONDocument | None: ...
+def _typed_registry() -> SchemaRegistryLike:
+    return schema_registry()
 
 
-def _typed_registry() -> _SchemaRegistryLike:
-    return cast(_SchemaRegistryLike, schema_registry())
-
-
-def _registry_catalog(registry: object, provider: str) -> SchemaPackageCatalog | None:
-    load_catalog = getattr(registry, "load_package_catalog", None)
-    if load_catalog is None:
-        return None
-    return cast(SchemaPackageCatalog | None, load_catalog(provider))
+def _registry_catalog(registry: SchemaRegistryLike, provider: str) -> SchemaPackageCatalog | None:
+    return registry.load_package_catalog(provider)
 
 
 def _build_inferred_outputs(
@@ -102,7 +58,27 @@ def _build_inferred_outputs(
     return corpus_specs, corpus_scenarios
 
 
-def _privacy_config(payload: JSONDocument | None) -> PrivacyConfig | None:
+def _privacy_level(value: object) -> PrivacyLevel:
+    if value == "strict":
+        return "strict"
+    if value == "permissive":
+        return "permissive"
+    return "standard"
+
+
+def _string_mapping(value: object) -> dict[str, str]:
+    if not isinstance(value, Mapping):
+        return {}
+    return {key: item for key, item in value.items() if isinstance(key, str) and isinstance(item, str)}
+
+
+def _string_list(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, str)]
+
+
+def _privacy_config(payload: Mapping[str, object] | None) -> PrivacyConfig | None:
     if payload is None:
         return None
     field_overrides = payload.get("field_overrides")
@@ -112,28 +88,15 @@ def _privacy_config(payload: JSONDocument | None) -> PrivacyConfig | None:
     safe_enum_max_length = payload.get("safe_enum_max_length", 50)
     high_entropy_min_length = payload.get("high_entropy_min_length", 10)
     cross_conv_min_count = payload.get("cross_conv_min_count", 3)
-    config_level: Literal["strict", "standard", "permissive"]
-    if level in {"strict", "standard", "permissive"}:
-        config_level = cast(Literal["strict", "standard", "permissive"], level)
-    else:
-        config_level = "standard"
     return PrivacyConfig(
-        level=config_level,
+        level=_privacy_level(level),
         safe_enum_max_length=safe_enum_max_length if isinstance(safe_enum_max_length, int) else 50,
         high_entropy_min_length=high_entropy_min_length if isinstance(high_entropy_min_length, int) else 10,
         cross_conv_min_count=cross_conv_min_count if isinstance(cross_conv_min_count, int) else 3,
         cross_conv_proportional=bool(payload.get("cross_conv_proportional", False)),
-        field_overrides=(
-            {key: value for key, value in field_overrides.items() if isinstance(key, str) and isinstance(value, str)}
-            if isinstance(field_overrides, dict)
-            else {}
-        ),
-        allow_value_patterns=[value for value in allow_patterns if isinstance(value, str)]
-        if isinstance(allow_patterns, list)
-        else [],
-        deny_value_patterns=[value for value in deny_patterns if isinstance(value, str)]
-        if isinstance(deny_patterns, list)
-        else [],
+        field_overrides=_string_mapping(field_overrides),
+        allow_value_patterns=_string_list(allow_patterns),
+        deny_value_patterns=_string_list(deny_patterns),
     )
 
 
@@ -146,7 +109,7 @@ def infer_schema(request: SchemaInferRequest) -> SchemaInferResult:
         request.provider,
         db_path=request.db_path,
         max_samples=request.max_samples,
-        privacy_config=_privacy_config(cast(JSONDocument | None, request.privacy_config)),
+        privacy_config=_privacy_config(request.privacy_config),
         full_corpus=request.full_corpus,
     )
     package_version = result.default_version or "default"
@@ -218,7 +181,7 @@ def infer_schema(request: SchemaInferRequest) -> SchemaInferResult:
 def list_inferred_corpus_specs(
     *,
     provider: str | None = None,
-    registry: _SchemaRegistryLike | None = None,
+    registry: SchemaRegistryLike | None = None,
 ) -> tuple[CorpusSpec, ...]:
     registry = registry or _typed_registry()
     providers = (provider,) if provider is not None else tuple(registry.list_providers())
@@ -252,7 +215,7 @@ def list_inferred_corpus_specs(
 def list_inferred_corpus_scenarios(
     *,
     provider: str | None = None,
-    registry: _SchemaRegistryLike | None = None,
+    registry: SchemaRegistryLike | None = None,
 ) -> tuple[CorpusScenario, ...]:
     return build_corpus_scenarios(
         list_inferred_corpus_specs(provider=provider, registry=registry),
@@ -346,7 +309,11 @@ def promote_schema_cluster(request: SchemaPromoteRequest) -> SchemaPromoteResult
         cluster_id=request.cluster_id,
         package_version=new_version,
         package=registry.get_package(request.provider, version=new_version),
-        schema=cast(OperatorJSONDocument | None, registry.get_element_schema(request.provider, version=new_version)),
+        schema=(
+            operator_json_document(schema)
+            if (schema := registry.get_element_schema(request.provider, version=new_version)) is not None
+            else None
+        ),
         versions=registry.list_versions(request.provider),
     )
 

--- a/polylogue/schemas/operator_models.py
+++ b/polylogue/schemas/operator_models.py
@@ -21,12 +21,12 @@ JSONDocument: TypeAlias = dict[str, JSONValue]
 JSONDocumentList: TypeAlias = list[JSONDocument]
 
 
-def _json_document(payload: Mapping[str, object]) -> JSONDocument:
+def operator_json_document(payload: Mapping[str, object]) -> JSONDocument:
     return cast(JSONDocument, dict(payload))
 
 
 def _corpus_spec_payloads(specs: tuple[CorpusSpec, ...]) -> JSONDocumentList:
-    return [_json_document(spec.to_payload()) for spec in specs]
+    return [operator_json_document(spec.to_payload()) for spec in specs]
 
 
 def _corpus_scenario_payloads(scenarios: tuple[CorpusScenario, ...]) -> JSONDocumentList:
@@ -135,7 +135,7 @@ class SchemaCompareResult:
     diff: SchemaDiff
 
     def to_dict(self) -> JSONDocument:
-        return cast(JSONDocument, self.diff.to_dict())
+        return operator_json_document(self.diff.to_dict())
 
 
 @dataclass(frozen=True)

--- a/polylogue/schemas/operator_registry.py
+++ b/polylogue/schemas/operator_registry.py
@@ -2,19 +2,75 @@
 
 from __future__ import annotations
 
-from typing import Any
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Protocol
+
+from polylogue.lib.json import JSONDocument
+from polylogue.schemas.packages import SchemaPackageCatalog, SchemaVersionPackage
+from polylogue.schemas.tooling_models import ClusterManifest, SchemaDiff
 
 
-def schema_registry() -> Any:
+class RuntimeSchemaRegistryLike(Protocol):
+    def load_package_catalog(self, provider: str) -> SchemaPackageCatalog | None: ...
+
+    def get_package(self, provider: str, version: str = "default") -> SchemaVersionPackage | None: ...
+
+    def get_element_schema(
+        self,
+        provider: str,
+        *,
+        version: str = "default",
+        element_kind: str | None = None,
+    ) -> JSONDocument | None: ...
+
+    def list_versions(self, provider: str) -> list[str]: ...
+
+    def list_providers(self) -> list[str]: ...
+
+    def get_schema_age_days(self, provider: str) -> int | None: ...
+
+
+class SchemaRegistryLike(RuntimeSchemaRegistryLike, Protocol):
+    def compare_versions(
+        self,
+        provider: str,
+        v1: str,
+        v2: str,
+        *,
+        element_kind: str | None = None,
+    ) -> SchemaDiff: ...
+
+    def cluster_samples(self, provider: str, samples: Sequence[Mapping[str, object]]) -> ClusterManifest: ...
+
+    def save_cluster_manifest(self, manifest: ClusterManifest) -> Path: ...
+
+    def load_cluster_manifest(self, provider: str) -> ClusterManifest | None: ...
+
+    def promote_cluster(
+        self,
+        provider: str,
+        cluster_id: str,
+        *,
+        samples: Sequence[Mapping[str, object]] | None = None,
+    ) -> str: ...
+
+
+def schema_registry() -> SchemaRegistryLike:
     from polylogue.schemas.registry import SchemaRegistry
 
     return SchemaRegistry()
 
 
-def runtime_schema_registry() -> Any:
+def runtime_schema_registry() -> RuntimeSchemaRegistryLike:
     from polylogue.schemas.runtime_registry import SchemaRegistry
 
     return SchemaRegistry()
 
 
-__all__ = ["runtime_schema_registry", "schema_registry"]
+__all__ = [
+    "RuntimeSchemaRegistryLike",
+    "SchemaRegistryLike",
+    "runtime_schema_registry",
+    "schema_registry",
+]

--- a/polylogue/schemas/operator_registry.py
+++ b/polylogue/schemas/operator_registry.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Protocol
 
 from polylogue.lib.json import JSONDocument
-from polylogue.schemas.packages import SchemaPackageCatalog, SchemaVersionPackage
+from polylogue.schemas.packages import SchemaPackageCatalog, SchemaResolution, SchemaVersionPackage
 from polylogue.schemas.tooling_models import ClusterManifest, SchemaDiff
 
 
@@ -29,6 +29,14 @@ class RuntimeSchemaRegistryLike(Protocol):
     def list_providers(self) -> list[str]: ...
 
     def get_schema_age_days(self, provider: str) -> int | None: ...
+
+    def resolve_payload(
+        self,
+        provider: str,
+        payload: Mapping[str, object],
+        *,
+        source_path: str | None = None,
+    ) -> SchemaResolution | None: ...
 
 
 class SchemaRegistryLike(RuntimeSchemaRegistryLike, Protocol):

--- a/polylogue/schemas/operator_resolution.py
+++ b/polylogue/schemas/operator_resolution.py
@@ -8,6 +8,7 @@ from polylogue.schemas.operator_models import (
     SchemaExplainResult,
     SchemaPayloadResolveRequest,
     SchemaPayloadResolveResult,
+    operator_json_document,
 )
 from polylogue.schemas.operator_registry import runtime_schema_registry, schema_registry
 
@@ -31,7 +32,7 @@ def explain_schema(request: SchemaExplainRequest) -> SchemaExplainResult:
         version=request.version,
         element_kind=request.element_kind,
         package=package,
-        schema=schema,
+        schema=operator_json_document(schema),
         annotations=collect_annotation_summary(schema),
         review_proof=proof,
     )

--- a/polylogue/schemas/relational_inference_models.py
+++ b/polylogue/schemas/relational_inference_models.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any
+
+from polylogue.schemas.json_types import JSONDocument
+
+RelationEvidence = JSONDocument
 
 
 @dataclass(frozen=True, slots=True)
@@ -13,7 +16,7 @@ class ForeignKeyRelation:
     source_path: str
     target_path: str
     match_ratio: float
-    evidence: dict[str, Any] = field(default_factory=dict)
+    evidence: RelationEvidence = field(default_factory=dict)
 
 
 @dataclass(frozen=True, slots=True)
@@ -25,7 +28,7 @@ class TimeDeltaRelation:
     min_delta: float
     max_delta: float
     avg_delta: float
-    evidence: dict[str, Any] = field(default_factory=dict)
+    evidence: RelationEvidence = field(default_factory=dict)
 
 
 @dataclass(frozen=True, slots=True)
@@ -35,7 +38,7 @@ class MutualExclusion:
     parent_path: str
     field_names: frozenset[str]
     sample_count: int
-    evidence: dict[str, Any] = field(default_factory=dict)
+    evidence: RelationEvidence = field(default_factory=dict)
 
 
 @dataclass(frozen=True, slots=True)
@@ -47,7 +50,7 @@ class StringLengthProfile:
     max_length: int
     avg_length: float
     stddev: float
-    evidence: dict[str, Any] = field(default_factory=dict)
+    evidence: RelationEvidence = field(default_factory=dict)
 
 
 @dataclass
@@ -64,6 +67,7 @@ __all__ = [
     "ForeignKeyRelation",
     "MutualExclusion",
     "RelationalAnnotations",
+    "RelationEvidence",
     "StringLengthProfile",
     "TimeDeltaRelation",
 ]

--- a/polylogue/schemas/shape_fingerprint.py
+++ b/polylogue/schemas/shape_fingerprint.py
@@ -2,20 +2,28 @@
 
 from __future__ import annotations
 
-from typing import Any
+from collections.abc import Mapping
+from typing import TypeAlias
 
 from polylogue.schemas.field_stats import is_dynamic_key
+from polylogue.schemas.json_types import JSONDocument
 
 _FINGERPRINT_MAX_DEPTH = 8
 _FINGERPRINT_ARRAY_SAMPLE = 8
 
+FingerprintLeaf: TypeAlias = tuple[str] | tuple[str, str]
+FingerprintArray: TypeAlias = tuple[str, tuple["StructureFingerprint", ...]]
+FingerprintObjectEntry: TypeAlias = tuple[str, "StructureFingerprint"]
+FingerprintObject: TypeAlias = tuple[str, tuple[FingerprintObjectEntry, ...]]
+StructureFingerprint: TypeAlias = FingerprintLeaf | FingerprintArray | FingerprintObject
+
 
 def _structure_fingerprint(
-    value: Any,
+    value: object,
     *,
     depth: int = 0,
     max_depth: int = _FINGERPRINT_MAX_DEPTH,
-) -> Any:
+) -> StructureFingerprint:
     """Build a hashable structural fingerprint for schema-dedup heuristics."""
     if depth >= max_depth:
         return ("depth-limit", type(value).__name__)
@@ -37,19 +45,29 @@ def _structure_fingerprint(
         return ("array", tuple(sorted(item_shapes, key=repr)))
 
     if isinstance(value, dict):
-        props: list[tuple[str, Any]] = []
-        for key in sorted(value):
-            child = value[key]
-            normalized_key = "*" if is_dynamic_key(key) else key
-            props.append(
-                (
-                    normalized_key,
-                    _structure_fingerprint(child, depth=depth + 1, max_depth=max_depth),
-                )
-            )
+        props = _object_fingerprint_entries(value, depth=depth, max_depth=max_depth)
         return ("object", tuple(props))
 
     return ("other", type(value).__name__)
+
+
+def _object_fingerprint_entries(
+    value: JSONDocument | Mapping[str, object],
+    *,
+    depth: int,
+    max_depth: int,
+) -> list[FingerprintObjectEntry]:
+    props: list[FingerprintObjectEntry] = []
+    for key in sorted(value):
+        child = value[key]
+        normalized_key = "*" if is_dynamic_key(key) else key
+        props.append(
+            (
+                normalized_key,
+                _structure_fingerprint(child, depth=depth + 1, max_depth=max_depth),
+            )
+        )
+    return props
 
 
 __all__ = ["_structure_fingerprint"]

--- a/polylogue/schemas/verification_models.py
+++ b/polylogue/schemas/verification_models.py
@@ -2,8 +2,90 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Literal, TypeAlias, TypedDict
+
+CountPayload: TypeAlias = dict[str, int]
+AllLiteral: TypeAlias = Literal["all"]
+LimitPayload: TypeAlias = int | AllLiteral
+ArtifactProofCountKind: TypeAlias = Literal[
+    "artifact_counts",
+    "package_versions",
+    "element_kinds",
+    "resolution_reasons",
+]
+
+
+class ProviderSchemaVerificationPayload(TypedDict):
+    provider: str
+    total_records: int
+    valid_records: int
+    invalid_records: int
+    drift_records: int
+    skipped_no_schema: int
+    decode_errors: int
+    quarantined_records: int
+
+
+class SchemaVerificationReportPayload(TypedDict):
+    max_samples: LimitPayload
+    record_limit: LimitPayload
+    record_offset: int
+    total_records: int
+    providers: dict[str, ProviderSchemaVerificationPayload]
+
+
+class ProviderArtifactProofPayload(TypedDict):
+    provider: str
+    total_records: int
+    contract_backed_records: int
+    unsupported_parseable_records: int
+    recognized_non_parseable_records: int
+    unknown_records: int
+    decode_errors: int
+    artifact_counts: CountPayload
+    package_versions: CountPayload
+    element_kinds: CountPayload
+    resolution_reasons: CountPayload
+    linked_sidecars: int
+    orphan_sidecars: int
+    subagent_streams: int
+    streams_with_sidecars: int
+    sidecar_agent_types: CountPayload
+
+
+class ArtifactProofSummaryPayload(TypedDict):
+    contract_backed_records: int
+    unsupported_parseable_records: int
+    recognized_non_parseable_records: int
+    unknown_records: int
+    decode_errors: int
+    linked_sidecars: int
+    orphan_sidecars: int
+    subagent_streams: int
+    streams_with_sidecars: int
+    artifact_counts: CountPayload
+    package_versions: CountPayload
+    element_kinds: CountPayload
+    resolution_reasons: CountPayload
+    clean: bool
+
+
+class ArtifactProofReportPayload(TypedDict):
+    record_limit: LimitPayload
+    record_offset: int
+    total_records: int
+    summary: ArtifactProofSummaryPayload
+    providers: dict[str, ProviderArtifactProofPayload]
+
+
+def _limit_payload(value: int | None) -> LimitPayload:
+    return value if value is not None else "all"
+
+
+def _sorted_counts(counts: Mapping[str, int]) -> CountPayload:
+    return dict(sorted(counts.items()))
 
 
 @dataclass
@@ -19,7 +101,7 @@ class ProviderSchemaVerification:
     decode_errors: int = 0
     quarantined_records: int = 0
 
-    def to_dict(self) -> dict[str, int | str]:
+    def to_dict(self) -> ProviderSchemaVerificationPayload:
         return {
             "provider": self.provider,
             "total_records": self.total_records,
@@ -42,10 +124,10 @@ class SchemaVerificationReport:
     record_limit: int | None = None
     record_offset: int = 0
 
-    def to_dict(self) -> dict[str, Any]:
+    def to_dict(self) -> SchemaVerificationReportPayload:
         return {
-            "max_samples": self.max_samples if self.max_samples is not None else "all",
-            "record_limit": self.record_limit if self.record_limit is not None else "all",
+            "max_samples": _limit_payload(self.max_samples),
+            "record_limit": _limit_payload(self.record_limit),
             "record_offset": self.record_offset,
             "total_records": self.total_records,
             "providers": {provider: stats.to_dict() for provider, stats in sorted(self.providers.items())},
@@ -63,17 +145,17 @@ class ProviderArtifactProof:
     recognized_non_parseable_records: int = 0
     unknown_records: int = 0
     decode_errors: int = 0
-    artifact_counts: dict[str, int] = field(default_factory=dict)
-    package_versions: dict[str, int] = field(default_factory=dict)
-    element_kinds: dict[str, int] = field(default_factory=dict)
-    resolution_reasons: dict[str, int] = field(default_factory=dict)
+    artifact_counts: CountPayload = field(default_factory=dict)
+    package_versions: CountPayload = field(default_factory=dict)
+    element_kinds: CountPayload = field(default_factory=dict)
+    resolution_reasons: CountPayload = field(default_factory=dict)
     linked_sidecars: int = 0
     orphan_sidecars: int = 0
     subagent_streams: int = 0
     streams_with_sidecars: int = 0
-    sidecar_agent_types: dict[str, int] = field(default_factory=dict)
+    sidecar_agent_types: CountPayload = field(default_factory=dict)
 
-    def to_dict(self) -> dict[str, Any]:
+    def to_dict(self) -> ProviderArtifactProofPayload:
         return {
             "provider": self.provider,
             "total_records": self.total_records,
@@ -82,16 +164,34 @@ class ProviderArtifactProof:
             "recognized_non_parseable_records": self.recognized_non_parseable_records,
             "unknown_records": self.unknown_records,
             "decode_errors": self.decode_errors,
-            "artifact_counts": dict(sorted(self.artifact_counts.items())),
-            "package_versions": dict(sorted(self.package_versions.items())),
-            "element_kinds": dict(sorted(self.element_kinds.items())),
-            "resolution_reasons": dict(sorted(self.resolution_reasons.items())),
+            "artifact_counts": _sorted_counts(self.artifact_counts),
+            "package_versions": _sorted_counts(self.package_versions),
+            "element_kinds": _sorted_counts(self.element_kinds),
+            "resolution_reasons": _sorted_counts(self.resolution_reasons),
             "linked_sidecars": self.linked_sidecars,
             "orphan_sidecars": self.orphan_sidecars,
             "subagent_streams": self.subagent_streams,
             "streams_with_sidecars": self.streams_with_sidecars,
-            "sidecar_agent_types": dict(sorted(self.sidecar_agent_types.items())),
+            "sidecar_agent_types": _sorted_counts(self.sidecar_agent_types),
         }
+
+
+def _provider_artifact_counts(stats: ProviderArtifactProof, *, kind: ArtifactProofCountKind) -> Mapping[str, int]:
+    if kind == "artifact_counts":
+        return stats.artifact_counts
+    if kind == "package_versions":
+        return stats.package_versions
+    if kind == "element_kinds":
+        return stats.element_kinds
+    return stats.resolution_reasons
+
+
+def _aggregate_counts(providers: Mapping[str, ProviderArtifactProof], *, kind: ArtifactProofCountKind) -> CountPayload:
+    aggregated: CountPayload = {}
+    for stats in providers.values():
+        for key, count in _provider_artifact_counts(stats, kind=kind).items():
+            aggregated[key] = aggregated.get(key, 0) + count
+    return _sorted_counts(aggregated)
 
 
 @dataclass
@@ -140,44 +240,28 @@ class ArtifactProofReport:
         return sum(stats.streams_with_sidecars for stats in self.providers.values())
 
     @property
-    def artifact_counts(self) -> dict[str, int]:
-        counts: dict[str, int] = {}
-        for stats in self.providers.values():
-            for kind, count in stats.artifact_counts.items():
-                counts[kind] = counts.get(kind, 0) + count
-        return dict(sorted(counts.items()))
+    def artifact_counts(self) -> CountPayload:
+        return _aggregate_counts(self.providers, kind="artifact_counts")
 
     @property
-    def package_versions(self) -> dict[str, int]:
-        counts: dict[str, int] = {}
-        for stats in self.providers.values():
-            for version, count in stats.package_versions.items():
-                counts[version] = counts.get(version, 0) + count
-        return dict(sorted(counts.items()))
+    def package_versions(self) -> CountPayload:
+        return _aggregate_counts(self.providers, kind="package_versions")
 
     @property
-    def element_kinds(self) -> dict[str, int]:
-        counts: dict[str, int] = {}
-        for stats in self.providers.values():
-            for element_kind, count in stats.element_kinds.items():
-                counts[element_kind] = counts.get(element_kind, 0) + count
-        return dict(sorted(counts.items()))
+    def element_kinds(self) -> CountPayload:
+        return _aggregate_counts(self.providers, kind="element_kinds")
 
     @property
-    def resolution_reasons(self) -> dict[str, int]:
-        counts: dict[str, int] = {}
-        for stats in self.providers.values():
-            for reason, count in stats.resolution_reasons.items():
-                counts[reason] = counts.get(reason, 0) + count
-        return dict(sorted(counts.items()))
+    def resolution_reasons(self) -> CountPayload:
+        return _aggregate_counts(self.providers, kind="resolution_reasons")
 
     @property
     def is_clean(self) -> bool:
         return self.unsupported_parseable_records == 0 and self.unknown_records == 0 and self.decode_errors == 0
 
-    def to_dict(self) -> dict[str, Any]:
+    def to_dict(self) -> ArtifactProofReportPayload:
         return {
-            "record_limit": self.record_limit if self.record_limit is not None else "all",
+            "record_limit": _limit_payload(self.record_limit),
             "record_offset": self.record_offset,
             "total_records": self.total_records,
             "summary": {

--- a/polylogue/showcase/report_models.py
+++ b/polylogue/showcase/report_models.py
@@ -7,6 +7,7 @@ payload dictionaries.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 
 from polylogue.scenarios import PayloadDict, ScenarioMetadata
@@ -178,7 +179,7 @@ class ShowcaseSessionRecord:
 class QAAuditRecord:
     status: str
     skipped: bool
-    report: PayloadDict | None = None
+    report: Mapping[str, object] | None = None
     error: str | None = None
 
     def to_payload(self) -> PayloadDict:
@@ -194,7 +195,7 @@ class QAAuditRecord:
 class QAProofRecord:
     status: str
     skipped: bool
-    report: PayloadDict | None = None
+    report: Mapping[str, object] | None = None
     error: str | None = None
 
     def to_payload(self) -> PayloadDict:

--- a/polylogue/sync_bridge.py
+++ b/polylogue/sync_bridge.py
@@ -2,10 +2,14 @@ from __future__ import annotations
 
 import asyncio
 import threading
-from collections.abc import Awaitable, Coroutine
-from typing import Any, TypeVar, cast
+from collections.abc import Awaitable
+from typing import TypeVar
 
 T = TypeVar("T")
+
+
+async def _await_result(awaitable: Awaitable[T]) -> T:
+    return await awaitable
 
 
 def run_coroutine_sync(coro: Awaitable[T]) -> T:
@@ -13,14 +17,14 @@ def run_coroutine_sync(coro: Awaitable[T]) -> T:
     try:
         asyncio.get_running_loop()
     except RuntimeError:
-        return asyncio.run(cast(Coroutine[Any, Any, T], coro))
+        return asyncio.run(_await_result(coro))
 
     result: list[T] = []
     error: list[BaseException] = []
 
     def _worker() -> None:
         try:
-            result.append(asyncio.run(cast(Coroutine[Any, Any, T], coro)))
+            result.append(asyncio.run(_await_result(coro)))
         except BaseException as exc:  # pragma: no cover - re-raised on caller thread
             error.append(exc)
 

--- a/tests/unit/core/test_operator_inference.py
+++ b/tests/unit/core/test_operator_inference.py
@@ -14,7 +14,12 @@ from polylogue.schemas.operator_inference import (
 )
 from polylogue.schemas.operator_models import SchemaInferRequest
 from polylogue.schemas.operator_registry import SchemaRegistryLike
-from polylogue.schemas.packages import SchemaElementManifest, SchemaPackageCatalog, SchemaVersionPackage
+from polylogue.schemas.packages import (
+    SchemaElementManifest,
+    SchemaPackageCatalog,
+    SchemaResolution,
+    SchemaVersionPackage,
+)
 from polylogue.schemas.tooling_models import ClusterManifest, SchemaCluster, SchemaDiff
 
 
@@ -62,6 +67,15 @@ class _FakeSchemaRegistry(SchemaRegistryLike):
         return sorted(provider_names)
 
     def get_schema_age_days(self, provider: str) -> int | None:
+        return None
+
+    def resolve_payload(
+        self,
+        provider: str,
+        payload: Mapping[str, object],
+        *,
+        source_path: str | None = None,
+    ) -> SchemaResolution | None:
         return None
 
     def compare_versions(

--- a/tests/unit/core/test_operator_inference.py
+++ b/tests/unit/core/test_operator_inference.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
 from pathlib import Path
-from types import SimpleNamespace
 from unittest.mock import patch
 
+from polylogue.lib.json import JSONDocument
 from polylogue.schemas.generation_models import GenerationResult
 from polylogue.schemas.operator_inference import (
     infer_schema,
@@ -11,8 +13,86 @@ from polylogue.schemas.operator_inference import (
     list_inferred_corpus_specs,
 )
 from polylogue.schemas.operator_models import SchemaInferRequest
+from polylogue.schemas.operator_registry import SchemaRegistryLike
 from polylogue.schemas.packages import SchemaElementManifest, SchemaPackageCatalog, SchemaVersionPackage
-from polylogue.schemas.tooling_models import ClusterManifest, SchemaCluster
+from polylogue.schemas.tooling_models import ClusterManifest, SchemaCluster, SchemaDiff
+
+
+@dataclass(frozen=True)
+class _ProviderConfig:
+    db_provider_name: str | None
+
+
+class _FakeSchemaRegistry(SchemaRegistryLike):
+    def __init__(
+        self,
+        *,
+        catalogs: dict[str, SchemaPackageCatalog] | None = None,
+        manifests: dict[str, ClusterManifest | None] | None = None,
+        clustered_manifest: ClusterManifest | None = None,
+        manifest_path: Path | None = None,
+    ) -> None:
+        self._catalogs = catalogs or {}
+        self._manifests = manifests or {}
+        self._clustered_manifest = clustered_manifest
+        self._manifest_path = manifest_path or Path("manifest.json")
+
+    def load_package_catalog(self, provider: str) -> SchemaPackageCatalog | None:
+        return self._catalogs.get(provider)
+
+    def get_package(self, provider: str, version: str = "default") -> SchemaVersionPackage | None:
+        catalog = self.load_package_catalog(provider)
+        return catalog.package(version) if catalog is not None else None
+
+    def get_element_schema(
+        self,
+        provider: str,
+        *,
+        version: str = "default",
+        element_kind: str | None = None,
+    ) -> JSONDocument | None:
+        return None
+
+    def list_versions(self, provider: str) -> list[str]:
+        catalog = self.load_package_catalog(provider)
+        return [package.version for package in catalog.packages] if catalog is not None else []
+
+    def list_providers(self) -> list[str]:
+        provider_names = set(self._catalogs) | set(self._manifests)
+        return sorted(provider_names)
+
+    def get_schema_age_days(self, provider: str) -> int | None:
+        return None
+
+    def compare_versions(
+        self,
+        provider: str,
+        v1: str,
+        v2: str,
+        *,
+        element_kind: str | None = None,
+    ) -> SchemaDiff:
+        raise AssertionError("compare_versions should not be called in this test")
+
+    def cluster_samples(self, provider: str, samples: Sequence[Mapping[str, object]]) -> ClusterManifest:
+        if self._clustered_manifest is None:
+            raise AssertionError("cluster_samples should not be called without a manifest")
+        return self._clustered_manifest
+
+    def save_cluster_manifest(self, manifest: ClusterManifest) -> Path:
+        return self._manifest_path
+
+    def load_cluster_manifest(self, provider: str) -> ClusterManifest | None:
+        return self._manifests.get(provider)
+
+    def promote_cluster(
+        self,
+        provider: str,
+        cluster_id: str,
+        *,
+        samples: Sequence[Mapping[str, object]] | None = None,
+    ) -> str:
+        raise AssertionError("promote_cluster should not be called in this test")
 
 
 def test_infer_schema_emits_default_corpus_specs_without_clustering(tmp_path: Path) -> None:
@@ -66,11 +146,11 @@ def test_infer_schema_emits_cluster_backed_corpus_specs_when_manifest_exists(tmp
             )
         ],
     )
-    fake_registry = SimpleNamespace(
-        cluster_samples=lambda provider, samples: manifest,
-        save_cluster_manifest=lambda manifest: tmp_path / "manifest.json",
+    fake_registry = _FakeSchemaRegistry(
+        clustered_manifest=manifest,
+        manifest_path=tmp_path / "manifest.json",
     )
-    fake_provider = SimpleNamespace(db_provider_name="chatgpt")
+    fake_provider = _ProviderConfig(db_provider_name="chatgpt")
 
     with (
         patch("polylogue.schemas.generation_workflow.generate_provider_schema", return_value=generation),
@@ -140,10 +220,9 @@ def test_list_inferred_corpus_specs_reads_registry_catalog_and_manifest() -> Non
             )
         ],
     )
-    fake_registry = SimpleNamespace(
-        list_providers=lambda: ["chatgpt"],
-        load_package_catalog=lambda provider: catalog,
-        load_cluster_manifest=lambda provider: manifest,
+    fake_registry = _FakeSchemaRegistry(
+        catalogs={"chatgpt": catalog},
+        manifests={"chatgpt": manifest},
     )
 
     with patch("polylogue.schemas.operator_inference.schema_registry", return_value=fake_registry):
@@ -201,10 +280,9 @@ def test_list_inferred_corpus_scenarios_groups_specs_by_provider_and_version() -
         ],
         default_version="v7",
     )
-    fake_registry = SimpleNamespace(
-        list_providers=lambda: ["chatgpt"],
-        load_package_catalog=lambda provider: catalog,
-        load_cluster_manifest=lambda provider: manifest,
+    fake_registry = _FakeSchemaRegistry(
+        catalogs={"chatgpt": catalog},
+        manifests={"chatgpt": manifest},
     )
 
     with patch("polylogue.schemas.operator_inference.schema_registry", return_value=fake_registry):
@@ -249,10 +327,9 @@ def test_list_inferred_corpus_specs_can_scope_to_one_provider() -> None:
             )
         ],
     )
-    fake_registry = SimpleNamespace(
-        list_providers=lambda: ["chatgpt", "codex"],
-        load_package_catalog=lambda provider: {"chatgpt": chatgpt_catalog, "codex": codex_catalog}[provider],
-        load_cluster_manifest=lambda provider: None,
+    fake_registry = _FakeSchemaRegistry(
+        catalogs={"chatgpt": chatgpt_catalog, "codex": codex_catalog},
+        manifests={"chatgpt": None, "codex": None},
     )
 
     with patch("polylogue.schemas.operator_inference.schema_registry", return_value=fake_registry):

--- a/tests/unit/core/test_schema_relational_inference.py
+++ b/tests/unit/core/test_schema_relational_inference.py
@@ -477,7 +477,9 @@ class TestDetectStringLengths:
         assert slp.min_length == 10
         assert slp.max_length == 200
         assert slp.avg_length == 102.0
-        assert slp.evidence["multiline_rate"] > 0
+        multiline_rate = slp.evidence["multiline_rate"]
+        assert isinstance(multiline_rate, (int, float))
+        assert multiline_rate > 0
 
     def test_short_low_variance_excluded(self) -> None:
         """Short fields with low variance skipped."""

--- a/tests/unit/core/test_synthetic_relations.py
+++ b/tests/unit/core/test_synthetic_relations.py
@@ -11,13 +11,21 @@ import random
 
 import pytest
 
+from polylogue.schemas.synthetic.build_records import _coerce_schema
 from polylogue.schemas.synthetic.relations import (
     ForeignKeyGraph,
     MutualExclusionGroup,
-    RelationConstraintSolver,
     StringLengthConstraint,
     TimeDeltaConstraint,
 )
+from polylogue.schemas.synthetic.relations import (
+    RelationConstraintSolver as _RelationConstraintSolver,
+)
+
+
+def _solver(schema: object) -> _RelationConstraintSolver:
+    return _RelationConstraintSolver(_coerce_schema(schema))
+
 
 # ---------------------------------------------------------------------------
 # ForeignKeyGraph
@@ -154,7 +162,7 @@ class TestStringLengthConstraint:
 
 class TestRelationConstraintSolverParsing:
     def test_empty_schema_has_no_constraints(self) -> None:
-        solver = RelationConstraintSolver({})
+        solver = _solver({})
         assert not solver.has_constraints
 
     def test_parses_foreign_keys(self) -> None:
@@ -163,7 +171,7 @@ class TestRelationConstraintSolverParsing:
                 {"source": "$.mapping.*.parent", "target": "$.mapping.*.id"},
             ],
         }
-        solver = RelationConstraintSolver(schema)
+        solver = _solver(schema)
         assert solver.has_constraints
         assert "$.mapping.*.parent" in solver.fk_graph.references
         assert solver.fk_graph.references["$.mapping.*.parent"] == "$.mapping.*.id"
@@ -180,7 +188,7 @@ class TestRelationConstraintSolverParsing:
                 },
             ],
         }
-        solver = RelationConstraintSolver(schema)
+        solver = _solver(schema)
         assert solver.has_constraints
         assert len(solver.time_deltas) == 1
         assert solver.time_deltas[0].field_a == "$.create_time"
@@ -191,7 +199,7 @@ class TestRelationConstraintSolverParsing:
                 {"parent": "$.message", "fields": ["content", "parts"]},
             ],
         }
-        solver = RelationConstraintSolver(schema)
+        solver = _solver(schema)
         assert solver.has_constraints
         assert len(solver.mutual_exclusions) == 1
         assert solver.mutual_exclusions[0].field_names == frozenset({"content", "parts"})
@@ -202,7 +210,7 @@ class TestRelationConstraintSolverParsing:
                 {"parent": "$.message", "fields": ["only_one"]},
             ],
         }
-        solver = RelationConstraintSolver(schema)
+        solver = _solver(schema)
         assert len(solver.mutual_exclusions) == 0
 
     def test_parses_string_lengths(self) -> None:
@@ -217,7 +225,7 @@ class TestRelationConstraintSolverParsing:
                 },
             ],
         }
-        solver = RelationConstraintSolver(schema)
+        solver = _solver(schema)
         assert solver.has_constraints
         assert "$.message.text" in solver.string_lengths
         constraint = solver.string_lengths["$.message.text"]
@@ -237,14 +245,14 @@ class TestRelationConstraintSolverForeignKeys:
                 {"source": "$.child.ref", "target": "$.parent.id"},
             ],
         }
-        solver = RelationConstraintSolver(schema)
+        solver = _solver(schema)
         solver.register_generated_id("$.parent.id", "abc")
         rng = random.Random(0)
         ref = solver.resolve_foreign_key("$.child.ref", rng)
         assert ref == "abc"
 
     def test_resolve_returns_none_for_unregistered_path(self) -> None:
-        solver = RelationConstraintSolver({})
+        solver = _solver({})
         rng = random.Random(0)
         assert solver.resolve_foreign_key("$.no.such.path", rng) is None
 
@@ -267,7 +275,7 @@ class TestRelationConstraintSolverTimeDeltas:
                 },
             ],
         }
-        solver = RelationConstraintSolver(schema)
+        solver = _solver(schema)
         rng = random.Random(42)
 
         for _ in range(100):
@@ -288,7 +296,7 @@ class TestRelationConstraintSolverTimeDeltas:
                 },
             ],
         }
-        solver = RelationConstraintSolver(schema)
+        solver = _solver(schema)
         rng = random.Random(0)
 
         # Look up in reverse order
@@ -297,7 +305,7 @@ class TestRelationConstraintSolverTimeDeltas:
         assert 1.0 <= delta <= 10.0
 
     def test_get_time_delta_returns_none_for_unknown_pair(self) -> None:
-        solver = RelationConstraintSolver({})
+        solver = _solver({})
         rng = random.Random(0)
         assert solver.get_time_delta("$.x", "$.y", rng) is None
 
@@ -314,7 +322,7 @@ class TestRelationConstraintSolverTimeDeltas:
                 },
             ],
         }
-        solver = RelationConstraintSolver(schema)
+        solver = _solver(schema)
         rng = random.Random(0)
         delta = solver.get_time_delta("$.a", "$.b", rng)
         assert delta == 42.0
@@ -332,7 +340,7 @@ class TestRelationConstraintSolverMutualExclusion:
                 {"parent": "$", "fields": ["alpha", "beta", "gamma"]},
             ],
         }
-        solver = RelationConstraintSolver(schema)
+        solver = _solver(schema)
         rng = random.Random(0)
 
         candidates = {"alpha", "beta", "gamma", "delta"}
@@ -350,7 +358,7 @@ class TestRelationConstraintSolverMutualExclusion:
                 {"parent": "$.other", "fields": ["a", "b"]},
             ],
         }
-        solver = RelationConstraintSolver(schema)
+        solver = _solver(schema)
         rng = random.Random(0)
 
         candidates = {"a", "b", "c"}
@@ -359,7 +367,7 @@ class TestRelationConstraintSolverMutualExclusion:
         assert filtered == candidates
 
     def test_no_exclusion_groups_returns_all_fields(self) -> None:
-        solver = RelationConstraintSolver({})
+        solver = _solver({})
         rng = random.Random(0)
         candidates = {"x", "y", "z"}
         filtered = solver.filter_mutually_exclusive("$", candidates, rng)
@@ -373,7 +381,7 @@ class TestRelationConstraintSolverMutualExclusion:
                 {"parent": "$", "fields": ["opt_a", "opt_b"]},
             ],
         }
-        solver = RelationConstraintSolver(schema)
+        solver = _solver(schema)
         rng = random.Random(seed)
 
         candidates = {"opt_a", "opt_b", "required"}
@@ -390,7 +398,7 @@ class TestRelationConstraintSolverMutualExclusion:
 
 class TestRelationConstraintSolverStringLength:
     def test_no_constraint_returns_base_text_unchanged(self) -> None:
-        solver = RelationConstraintSolver({})
+        solver = _solver({})
         rng = random.Random(0)
         assert solver.generate_string_with_length("$.any", rng, "hello world") == "hello world"
 
@@ -400,7 +408,7 @@ class TestRelationConstraintSolverStringLength:
                 {"path": "$.short", "min": 3, "max": 10, "avg": 7.0, "stddev": 1.0},
             ],
         }
-        solver = RelationConstraintSolver(schema)
+        solver = _solver(schema)
         rng = random.Random(42)
         result = solver.generate_string_with_length("$.short", rng, "this is a very long text string")
         assert len(result) <= 10
@@ -411,7 +419,7 @@ class TestRelationConstraintSolverStringLength:
                 {"path": "$.long", "min": 50, "max": 100, "avg": 75.0, "stddev": 5.0},
             ],
         }
-        solver = RelationConstraintSolver(schema)
+        solver = _solver(schema)
         rng = random.Random(42)
         result = solver.generate_string_with_length("$.long", rng, "hi")
         assert len(result) >= 50
@@ -422,7 +430,7 @@ class TestRelationConstraintSolverStringLength:
                 {"path": "$.x", "min": 10, "max": 100, "avg": 50.0, "stddev": 5.0},
             ],
         }
-        solver = RelationConstraintSolver(schema)
+        solver = _solver(schema)
         rng = random.Random(0)
         assert solver.generate_string_with_length("$.x", rng, "") == ""
 
@@ -433,7 +441,7 @@ class TestRelationConstraintSolverStringLength:
                 {"path": "$.text", "min": 10, "max": 50, "avg": 30.0, "stddev": 8.0},
             ],
         }
-        solver = RelationConstraintSolver(schema)
+        solver = _solver(schema)
         rng = random.Random(seed)
         result = solver.generate_string_with_length("$.text", rng, "some example text for testing purposes")
         assert len(result) >= 10
@@ -467,7 +475,7 @@ class TestRelationConstraintSolverIntegration:
                 {"path": "$.message.body", "min": 20, "max": 500, "avg": 100.0, "stddev": 40.0},
             ],
         }
-        solver = RelationConstraintSolver(schema)
+        solver = _solver(schema)
         assert solver.has_constraints
 
         # FK
@@ -499,6 +507,6 @@ class TestRelationConstraintSolverIntegration:
         assert len(result) >= 20
 
     def test_path_matches_exact(self) -> None:
-        solver = RelationConstraintSolver({})
+        solver = _solver({})
         assert solver.path_matches("$.a.b", "$.a.b") is True
         assert solver.path_matches("$.a.b", "$.a.c") is False

--- a/tests/unit/scenarios/test_corpus.py
+++ b/tests/unit/scenarios/test_corpus.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from pathlib import Path
 
 import pytest
@@ -18,7 +19,12 @@ from polylogue.scenarios import (
     resolve_corpus_specs,
 )
 from polylogue.schemas.operator_registry import SchemaRegistryLike
-from polylogue.schemas.packages import SchemaElementManifest, SchemaPackageCatalog, SchemaVersionPackage
+from polylogue.schemas.packages import (
+    SchemaElementManifest,
+    SchemaPackageCatalog,
+    SchemaResolution,
+    SchemaVersionPackage,
+)
 from polylogue.schemas.tooling_models import ClusterManifest, SchemaCluster, SchemaDiff
 
 
@@ -45,6 +51,15 @@ class _PassiveRegistry(SchemaRegistryLike):
         return []
 
     def get_schema_age_days(self, provider: str) -> int | None:
+        return None
+
+    def resolve_payload(
+        self,
+        provider: str,
+        payload: Mapping[str, object],
+        *,
+        source_path: str | None = None,
+    ) -> SchemaResolution | None:
         return None
 
     def compare_versions(

--- a/tests/unit/scenarios/test_corpus.py
+++ b/tests/unit/scenarios/test_corpus.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
+from polylogue.lib.json import JSONDocument
 from polylogue.scenarios import (
     CorpusProfile,
     CorpusRequest,
@@ -14,8 +17,63 @@ from polylogue.scenarios import (
     resolve_corpus_scenarios,
     resolve_corpus_specs,
 )
+from polylogue.schemas.operator_registry import SchemaRegistryLike
 from polylogue.schemas.packages import SchemaElementManifest, SchemaPackageCatalog, SchemaVersionPackage
-from polylogue.schemas.tooling_models import ClusterManifest, SchemaCluster
+from polylogue.schemas.tooling_models import ClusterManifest, SchemaCluster, SchemaDiff
+
+
+class _PassiveRegistry(SchemaRegistryLike):
+    def load_package_catalog(self, provider: str) -> SchemaPackageCatalog | None:
+        return None
+
+    def get_package(self, provider: str, version: str = "default") -> SchemaVersionPackage | None:
+        return None
+
+    def get_element_schema(
+        self,
+        provider: str,
+        *,
+        version: str = "default",
+        element_kind: str | None = None,
+    ) -> JSONDocument | None:
+        return None
+
+    def list_versions(self, provider: str) -> list[str]:
+        return []
+
+    def list_providers(self) -> list[str]:
+        return []
+
+    def get_schema_age_days(self, provider: str) -> int | None:
+        return None
+
+    def compare_versions(
+        self,
+        provider: str,
+        v1: str,
+        v2: str,
+        *,
+        element_kind: str | None = None,
+    ) -> SchemaDiff:
+        raise AssertionError("compare_versions should not be called in this test")
+
+    def cluster_samples(self, provider: str, samples: object) -> ClusterManifest:
+        raise AssertionError("cluster_samples should not be called in this test")
+
+    def save_cluster_manifest(self, manifest: ClusterManifest) -> Path:
+        raise AssertionError("save_cluster_manifest should not be called in this test")
+
+    def load_cluster_manifest(self, provider: str) -> ClusterManifest | None:
+        return None
+
+    def promote_cluster(
+        self,
+        provider: str,
+        cluster_id: str,
+        *,
+        samples: object | None = None,
+    ) -> str:
+        raise AssertionError("promote_cluster should not be called in this test")
 
 
 def test_corpus_spec_payload_round_trip_preserves_inference_fields() -> None:
@@ -361,6 +419,46 @@ def test_corpus_request_resolves_inferred_source_without_provider_inventory() ->
             style="showcase",
         ).resolve_specs()
 
+    assert len(specs) == 1
+    assert specs[0].provider == "chatgpt"
+    assert specs[0].count == 2
+
+
+def test_corpus_request_passes_registry_through_inferred_resolution() -> None:
+    inferred = (
+        CorpusSpec(
+            provider="chatgpt",
+            package_version="v7",
+            count=1,
+            messages_min=4,
+            messages_max=4,
+            seed=3,
+            origin="inferred.schema",
+            tags=("inferred", "schema", "synthetic"),
+        ),
+    )
+    registry = _PassiveRegistry()
+    observed_registries: list[SchemaRegistryLike | None] = []
+
+    def _list_inferred(*, registry: SchemaRegistryLike | None = None) -> tuple[CorpusSpec, ...]:
+        observed_registries.append(registry)
+        return inferred
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(
+            "polylogue.schemas.operator_inference.list_inferred_corpus_specs",
+            _list_inferred,
+        )
+        specs = CorpusRequest(
+            source="inferred",
+            count=2,
+            messages_min=6,
+            messages_max=8,
+            seed=42,
+            style="showcase",
+        ).resolve_specs(registry=registry)
+
+    assert observed_registries == [registry]
     assert len(specs) == 1
     assert specs[0].provider == "chatgpt"
     assert specs[0].count == 2


### PR DESCRIPTION
## Summary
- tighten the sync/schema/scenario runtime anchors around registry access, payload hashing, and sync bridge execution
- renew the schema evidence/proof model layer with explicit payload aliases and typed fingerprint/report contracts
- replace namespace-style test doubles with protocol-shaped registry fakes, add direct registry pass-through coverage, and align the downstream resolution/report/test fallout

## Problem
The next weak-contract residue after the rendering/source tranche had shifted into the sync/schema/scenario runtime layer. The code was already type-checked, but these seams still relied on cast-heavy coroutine bridging, broad registry plumbing, weak serializer/hash helpers, and report/evidence models that serialized through loose JSON-shaped dictionaries.

## Solution
The branch is split into four coherent commits.

1. `refactor: tighten schema and sync runtime anchors`
- rewrites `polylogue/sync_bridge.py` to run awaitables through a typed bridge helper instead of coroutine casts
- introduces protocol-based registry access in `polylogue/schemas/operator_registry.py`
- threads that registry contract into `polylogue/scenarios/corpus.py` and `polylogue/schemas/operator_inference.py`
- tightens `polylogue/lib/messages.py`, `polylogue/pipeline/ids.py`, and `polylogue/schemas/operator_models.py` around explicit payload/hash serialization helpers

2. `refactor: tighten schema evidence and proof models`
- replaces `Any`-shaped evidence fields in `polylogue/schemas/relational_inference_models.py` with a shared JSON evidence alias
- gives `polylogue/schemas/shape_fingerprint.py` explicit structural fingerprint aliases instead of broad `Any` returns
- rebuilds `polylogue/schemas/verification_models.py` around typed payload records and explicit count/limit helpers

3. `test: cover schema registry precision seams`
- replaces `SimpleNamespace` registry doubles in `tests/unit/core/test_operator_inference.py` with a protocol-shaped fake registry
- adds direct pass-through coverage in `tests/unit/scenarios/test_corpus.py` so inferred corpus resolution actually proves the injected-registry seam

4. `fix: align schema precision fallout across reports and tests`
- completes the runtime registry protocol with payload resolution
- normalizes schema explanation output through the operator JSON payload helper
- widens QA report records to accept typed mapping payloads
- adapts synthetic relation tests and registry fakes to the stricter schema/runtime contracts

## Verification
- `ruff check polylogue/sync_bridge.py polylogue/lib/messages.py polylogue/pipeline/ids.py polylogue/scenarios/corpus.py polylogue/schemas/operator_registry.py polylogue/schemas/operator_inference.py polylogue/schemas/operator_models.py polylogue/schemas/relational_inference_models.py polylogue/schemas/shape_fingerprint.py polylogue/schemas/verification_models.py tests/unit/core/test_operator_inference.py tests/unit/scenarios/test_corpus.py`
- `mypy polylogue/sync_bridge.py polylogue/lib/messages.py polylogue/pipeline/ids.py polylogue/scenarios/corpus.py polylogue/schemas/operator_registry.py polylogue/schemas/operator_inference.py polylogue/schemas/operator_models.py polylogue/schemas/relational_inference_models.py polylogue/schemas/shape_fingerprint.py polylogue/schemas/verification_models.py tests/unit/core/test_operator_inference.py tests/unit/scenarios/test_corpus.py`
- `pytest -q tests/unit/core/test_operator_inference.py tests/unit/scenarios/test_corpus.py tests/unit/pipeline/test_pipeline_ids.py tests/unit/core/test_models.py tests/unit/core/test_verification.py tests/unit/core/test_schema_cluster_assignment.py tests/unit/core/test_schema_relational_inference.py`
- `ruff check polylogue/schemas/operator_registry.py polylogue/schemas/operator_resolution.py polylogue/showcase/report_models.py tests/unit/core/test_synthetic_relations.py tests/unit/core/test_schema_relational_inference.py`
- `mypy polylogue/schemas/operator_registry.py polylogue/schemas/operator_resolution.py polylogue/showcase/report_models.py tests/unit/core/test_synthetic_relations.py tests/unit/core/test_schema_relational_inference.py`
- `pytest -q tests/unit/core/test_synthetic_relations.py tests/unit/core/test_schema_relational_inference.py tests/unit/showcase/test_report.py tests/unit/core/test_operator_inference.py tests/unit/scenarios/test_corpus.py`
- `pytest -q tests/unit/core/test_operator_inference.py tests/unit/scenarios/test_corpus.py`
- `devtools render-all --check` in a clean detached worktree with branch-local `polylogue`/`devtools` launchers
- `mypy` and the non-test stages of `devtools verify` passed in the same clean detached worktree
- `pytest -q --tb=short --ignore=tests/integration` was attempted twice in the clean detached worktree; an initial full run exposed unrelated xdist/environment flakes that passed immediately when targeted (`test_scale.py::TestPerformanceBudget::test_semantic_filter_budget`, `test_reset.py::{test_reset_requires_target,test_reset_force_database}`, `test_tui.py::test_search_empty_db`), and the subsequent full-suite rerun was cut off by the local exec-session pruning while already past 96% without branch failures emitted

Closes #280
