### PR TITLE
refactor: tighten privacy audit and runtime contracts

### DIFF
--- a/polylogue/artifact_graph.py
+++ b/polylogue/artifact_graph.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
 
 from polylogue.artifacts import (
     ArtifactLayer,
@@ -12,6 +11,7 @@ from polylogue.artifacts import (
     build_runtime_artifact_nodes,
     build_runtime_artifact_paths,
 )
+from polylogue.lib.json import JSONDocument, json_document
 from polylogue.maintenance_targets import MaintenanceTargetSpec, build_maintenance_target_catalog
 from polylogue.operations import OperationSpec, build_runtime_operation_catalog
 
@@ -76,13 +76,15 @@ class ArtifactGraph:
     def maintenance_targets_for_operation_names(self, names: tuple[str, ...]) -> tuple[MaintenanceTargetSpec, ...]:
         return build_maintenance_target_catalog().maintenance_targets_for_operation_names(names)
 
-    def to_dict(self) -> dict[str, Any]:
-        return {
-            "nodes": [node.to_dict() for node in self.nodes],
-            "paths": [path.to_dict() for path in self.paths],
-            "operations": [operation.to_dict() for operation in self.operations],
-            "maintenance_targets": [target.to_dict() for target in self.maintenance_targets],
-        }
+    def to_dict(self) -> JSONDocument:
+        return json_document(
+            {
+                "nodes": [node.to_dict() for node in self.nodes],
+                "paths": [path.to_dict() for path in self.paths],
+                "operations": [operation.to_dict() for operation in self.operations],
+                "maintenance_targets": [target.to_dict() for target in self.maintenance_targets],
+            }
+        )
 
 
 def build_artifact_graph() -> ArtifactGraph:

--- a/polylogue/artifacts.py
+++ b/polylogue/artifacts.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 from enum import Enum
-from typing import Any
+
+from polylogue.lib.json import JSONDocument, json_document
 
 
 class ArtifactLayer(str, Enum):
@@ -27,10 +28,18 @@ class ArtifactNode:
     repair_targets: tuple[str, ...] = ()
     readiness_surfaces: tuple[str, ...] = ()
 
-    def to_dict(self) -> dict[str, Any]:
-        data = asdict(self)
-        data["layer"] = self.layer.value
-        return data
+    def to_dict(self) -> JSONDocument:
+        return json_document(
+            {
+                "name": self.name,
+                "layer": self.layer.value,
+                "description": self.description,
+                "depends_on": list(self.depends_on),
+                "code_refs": list(self.code_refs),
+                "repair_targets": list(self.repair_targets),
+                "readiness_surfaces": list(self.readiness_surfaces),
+            }
+        )
 
 
 @dataclass(frozen=True, slots=True)
@@ -41,8 +50,14 @@ class ArtifactPath:
     description: str
     nodes: tuple[str, ...]
 
-    def to_dict(self) -> dict[str, Any]:
-        return asdict(self)
+    def to_dict(self) -> JSONDocument:
+        return json_document(
+            {
+                "name": self.name,
+                "description": self.description,
+                "nodes": list(self.nodes),
+            }
+        )
 
 
 RUNTIME_ARTIFACT_NODES: tuple[ArtifactNode, ...] = (

--- a/polylogue/lib/outcomes.py
+++ b/polylogue/lib/outcomes.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any
+
+from polylogue.lib.json import JSONDocument, json_document
 
 
 class OutcomeStatus(str, Enum):
@@ -45,15 +46,17 @@ class OutcomeCheck:
     def message(self) -> str:
         return self.summary
 
-    def to_dict(self) -> dict[str, Any]:
-        return {
-            "name": self.name,
-            "status": self.status.value,
-            "summary": self.summary,
-            "count": self.count,
-            "details": list(self.details),
-            "breakdown": dict(self.breakdown),
-        }
+    def to_dict(self) -> JSONDocument:
+        return json_document(
+            {
+                "name": self.name,
+                "status": self.status.value,
+                "summary": self.summary,
+                "count": self.count,
+                "details": list(self.details),
+                "breakdown": dict(self.breakdown),
+            }
+        )
 
     def format_line(
         self,

--- a/polylogue/lib/query_plan.py
+++ b/polylogue/lib/query_plan.py
@@ -6,7 +6,7 @@ import builtins
 from collections.abc import Callable
 from dataclasses import dataclass, replace
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, TypeVar
 
 from polylogue.lib.query_plan_description import describe_plan, effective_fetch_limit, plan_has_filters
 from polylogue.lib.query_retrieval import (
@@ -32,7 +32,7 @@ from polylogue.lib.query_runtime import (
     plan_has_post_filters,
     plan_needs_content_loading,
 )
-from polylogue.lib.query_sorting import finalize_results, sort_conversations, sort_generic, sort_summaries
+from polylogue.lib.query_sorting import SortKey, finalize_results, sort_conversations, sort_generic, sort_summaries
 from polylogue.lib.query_support import conversation_has_branches, provider_values
 from polylogue.storage.query_models import ConversationRecordQuery
 from polylogue.types import Provider
@@ -237,7 +237,7 @@ class ConversationQueryPlan:
     def _apply_full_filters(self, conversations: list[Conversation], *, sql_pushed: bool) -> list[Conversation]:
         return apply_full_filters(self, conversations, sql_pushed=sql_pushed)
 
-    def _sort_generic(self, items: list[_T], key_fn: Callable[[_T], Any]) -> list[_T]:
+    def _sort_generic(self, items: list[_T], key_fn: Callable[[_T], SortKey]) -> list[_T]:
         return sort_generic(self, items, key_fn)
 
     def _sort_conversations(self, conversations: list[Conversation]) -> list[Conversation]:

--- a/polylogue/lib/query_sorting.py
+++ b/polylogue/lib/query_sorting.py
@@ -5,19 +5,20 @@ from __future__ import annotations
 import random
 from collections.abc import Callable
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, TypeAlias, TypeVar
 
 if TYPE_CHECKING:
     from polylogue.lib.models import Conversation, ConversationSummary
     from polylogue.lib.query_plan import ConversationQueryPlan
 
 _T = TypeVar("_T")
+SortKey: TypeAlias = datetime | float | int | str
 
 
 def sort_generic(
     plan: ConversationQueryPlan,
     items: list[_T],
-    key_fn: Callable[[_T], Any],
+    key_fn: Callable[[_T], SortKey],
 ) -> list[_T]:
     if plan.sort == "random":
         shuffled = list(items)
@@ -32,7 +33,7 @@ def sort_conversations(
 ) -> list[Conversation]:
     dt_min = datetime.min.replace(tzinfo=timezone.utc)
 
-    def _key(conversation: Conversation) -> Any:
+    def _key(conversation: Conversation) -> SortKey:
         if plan.sort == "date":
             return conversation.updated_at or dt_min
         if plan.sort == "messages":

--- a/polylogue/maintenance_models.py
+++ b/polylogue/maintenance_models.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any
 
 
 class MaintenanceCategory(str, Enum):
@@ -30,7 +29,7 @@ class DerivedModelStatus:
     materializer_version: int | None = None
     matches_version: bool | None = None
 
-    def to_dict(self) -> dict[str, Any]:
+    def to_dict(self) -> dict[str, object]:
         return {
             "name": self.name,
             "ready": self.ready,

--- a/polylogue/maintenance_targets.py
+++ b/polylogue/maintenance_targets.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import Enum
 from functools import lru_cache
-from typing import Any
 
+from polylogue.lib.json import JSONDocument, json_document
 from polylogue.lib.outcomes import OutcomeStatus
 from polylogue.maintenance_models import MaintenanceCategory
 
@@ -35,23 +35,25 @@ class MaintenanceTargetSpec:
     archive_readiness_requires_deep: bool = False
     aliases: tuple[str, ...] = ()
 
-    def to_dict(self) -> dict[str, Any]:
-        return {
-            "name": self.name,
-            "mode": self.mode.value,
-            "category": self.category.value,
-            "destructive": self.destructive,
-            "description": self.description,
-            "include_preview_when_ready": self.include_preview_when_ready,
-            "doctor_readiness_operation": self.doctor_readiness_operation,
-            "doctor_repair_operation": self.doctor_repair_operation,
-            "include_in_archive_readiness": self.include_in_archive_readiness,
-            "archive_readiness_unready_status": (
-                self.archive_readiness_unready_status.value if self.archive_readiness_unready_status else None
-            ),
-            "archive_readiness_requires_deep": self.archive_readiness_requires_deep,
-            "aliases": list(self.aliases),
-        }
+    def to_dict(self) -> JSONDocument:
+        return json_document(
+            {
+                "name": self.name,
+                "mode": self.mode.value,
+                "category": self.category.value,
+                "destructive": self.destructive,
+                "description": self.description,
+                "include_preview_when_ready": self.include_preview_when_ready,
+                "doctor_readiness_operation": self.doctor_readiness_operation,
+                "doctor_repair_operation": self.doctor_repair_operation,
+                "include_in_archive_readiness": self.include_in_archive_readiness,
+                "archive_readiness_unready_status": (
+                    self.archive_readiness_unready_status.value if self.archive_readiness_unready_status else None
+                ),
+                "archive_readiness_requires_deep": self.archive_readiness_requires_deep,
+                "aliases": list(self.aliases),
+            }
+        )
 
 
 @dataclass(frozen=True, slots=True)

--- a/polylogue/operations/specs.py
+++ b/polylogue/operations/specs.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 from enum import Enum
 from functools import lru_cache
-from typing import Any
+
+from polylogue.lib.json import JSONDocument, JSONDocumentList, json_document
 
 
 class OperationKind(str, Enum):
@@ -37,10 +38,22 @@ class OperationSpec:
     previewable: bool = False
     idempotent: bool = True
 
-    def to_dict(self) -> dict[str, Any]:
-        data = asdict(self)
-        data["kind"] = self.kind.value
-        return data
+    def to_dict(self) -> JSONDocument:
+        return json_document(
+            {
+                "name": self.name,
+                "kind": self.kind.value,
+                "description": self.description,
+                "consumes": list(self.consumes),
+                "produces": list(self.produces),
+                "path_targets": list(self.path_targets),
+                "code_refs": list(self.code_refs),
+                "surfaces": list(self.surfaces),
+                "mutates_state": self.mutates_state,
+                "previewable": self.previewable,
+                "idempotent": self.idempotent,
+            }
+        )
 
 
 @dataclass(frozen=True, slots=True)
@@ -59,7 +72,7 @@ class OperationCatalog:
         by_name = self.by_name()
         return tuple(by_name[name] for name in names if name in by_name)
 
-    def to_dict(self) -> list[dict[str, Any]]:
+    def to_dict(self) -> JSONDocumentList:
         return [spec.to_dict() for spec in self.specs]
 
 

--- a/polylogue/pipeline/prepare.py
+++ b/polylogue/pipeline/prepare.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from polylogue.logging import get_logger
 from polylogue.pipeline.ids import (
@@ -27,6 +27,7 @@ from polylogue.pipeline.prepare_models import (
 from polylogue.pipeline.prepare_transform import transform_to_records
 
 if TYPE_CHECKING:
+    from polylogue.sources.parsers.base import ParsedConversation
     from polylogue.storage.backends.async_sqlite import SQLiteBackend
     from polylogue.storage.repository import ConversationRepository
 
@@ -44,7 +45,7 @@ async def save_bundle(bundle: RecordBundle, repository: ConversationRepository) 
 
 
 async def prepare_bundle(
-    convo: Any,
+    convo: ParsedConversation,
     source_name: str,
     *,
     archive_root: Path,
@@ -100,7 +101,7 @@ async def persist_prepared_bundle(
 
 
 async def prepare_records(
-    convo: Any,
+    convo: ParsedConversation,
     source_name: str,
     *,
     archive_root: Path,

--- a/polylogue/publication.py
+++ b/polylogue/publication.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import hashlib
 from pathlib import Path
-from typing import Any
 
 from pydantic import BaseModel, Field, field_validator
 
@@ -71,7 +70,7 @@ class PublicationRunSummary(BaseModel):
 
     run_id: str
     timestamp: str
-    counts: dict[str, Any] | None = None
+    counts: dict[str, object] | None = None
     indexed: bool | None = None
     duration_ms: int | None = None
 
@@ -159,7 +158,7 @@ class SitePublicationManifest(BaseModel):
     generated_at: str
     output_dir: str
     duration_ms: int
-    config: dict[str, Any]
+    config: dict[str, object]
     archive: ArchivePublicationSummary
     outputs: SiteOutputSummary
     latest_run: PublicationRunSummary | None = None

--- a/polylogue/scenarios/runtime.py
+++ b/polylogue/scenarios/runtime.py
@@ -2,13 +2,11 @@
 
 from __future__ import annotations
 
-import inspect
 import os
 import subprocess
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
 
 from .execution import ExecutionSpec
 
@@ -104,14 +102,16 @@ async def dispatch_execution(
     runner_resolver: ExecutionRunnerResolver | None = None,
     runner_args: Sequence[object] = (),
     runner_kwargs: Mapping[str, object] | None = None,
-) -> Any:
+) -> object:
     """Dispatch one authored execution through either subprocess or runner runtime."""
     if execution.is_runner:
         if runner_resolver is None:
             raise ValueError("runner execution requires a runner_resolver")
         runner = resolve_execution_runner(execution, runner_resolver=runner_resolver)
         dispatched = runner(*runner_args, **dict(runner_kwargs or {}))
-        return await dispatched if inspect.isawaitable(dispatched) else dispatched
+        if isinstance(dispatched, Awaitable):
+            return await dispatched
+        return dispatched
     return run_execution(
         execution,
         cwd=cwd,

--- a/polylogue/schemas/audit_models.py
+++ b/polylogue/schemas/audit_models.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
 
 from polylogue.lib.outcomes import OutcomeCheck, OutcomeReport, OutcomeStatus
+from polylogue.schemas.json_types import JSONDocument, json_document
 
 
 @dataclass
@@ -63,25 +63,27 @@ class AuditReport(OutcomeReport):
                 lines.append(f"      {d}")
         return "\n".join(lines)
 
-    def to_json(self) -> dict[str, Any]:
-        return {
-            "provider": self.provider,
-            "summary": {
-                "passed": self.passed,
-                "warned": self.warned,
-                "failed": self.failed,
-            },
-            "checks": [
-                {
-                    "name": c.name,
-                    "provider": getattr(c, "provider", None),
-                    "status": self._LABELS[c.status],
-                    "message": c.summary,
-                    "details": c.details,
-                }
-                for c in self.checks
-            ],
-        }
+    def to_json(self) -> JSONDocument:
+        return json_document(
+            {
+                "provider": self.provider,
+                "summary": {
+                    "passed": self.passed,
+                    "warned": self.warned,
+                    "failed": self.failed,
+                },
+                "checks": [
+                    {
+                        "name": c.name,
+                        "provider": getattr(c, "provider", None),
+                        "status": self._LABELS[c.status],
+                        "message": c.summary,
+                        "details": c.details,
+                    }
+                    for c in self.checks
+                ],
+            }
+        )
 
 
 __all__ = ["AuditCheck", "AuditReport"]

--- a/polylogue/schemas/privacy.py
+++ b/polylogue/schemas/privacy.py
@@ -9,7 +9,7 @@ is rejected.
 from __future__ import annotations
 
 import re
-from typing import Any
+from typing import Protocol, runtime_checkable
 
 _SAFE_ENUM_MAX_LEN = 50  # structural enums are short tokens, not content
 
@@ -45,6 +45,19 @@ _HIGH_ENTROPY_TOKEN_RE = re.compile(r"^[A-Za-z0-9_-]{10,}$")
 # Pattern matching structural identifiers: lowercase tokens with underscores
 # (e.g. "chatgpt_agent", "deep_research") — not random IDs.
 _STRUCTURAL_CONSTANT_RE = re.compile(r"^[a-z][a-z0-9_]{2,30}$")
+
+
+@runtime_checkable
+class PrivacyConfigLike(Protocol):
+    """Runtime privacy config surface consumed by enum-value guards."""
+
+    @property
+    def safe_enum_max_length(self) -> int: ...
+
+    def field_override(self, path: str) -> str | None: ...
+
+    def is_value_allowed(self, value: str) -> bool | None: ...
+
 
 _IDENTIFIER_FIELD_TOKENS = frozenset(
     {
@@ -192,11 +205,11 @@ def _is_content_field(path: str) -> bool:
 
 
 def _is_safe_enum_value(
-    value: Any,
+    value: object,
     *,
     path: str = "$",
     max_length: int | None = None,
-    config: Any | None = None,
+    config: object | None = None,
 ) -> bool:
     """Return True if a string value is safe to include in schema annotations.
 
@@ -217,27 +230,32 @@ def _is_safe_enum_value(
     effective_max_len = max_length or _SAFE_ENUM_MAX_LEN
 
     # Check config-level overrides first (highest precedence)
-    if config is not None:
+    privacy_config = config if isinstance(config, PrivacyConfigLike) else None
+
+    if privacy_config is not None:
         # Field-level override
-        field_action = config.field_override(path)
+        field_action = privacy_config.field_override(path)
         if field_action == "allow":
             return True
         if field_action == "deny":
             return False
         # Value-level override
         if isinstance(value, str):
-            val_override = config.is_value_allowed(value)
+            val_override = privacy_config.is_value_allowed(value)
             if val_override is True:
                 return True
             if val_override is False:
                 return False
         # Use config's max_length if not explicitly overridden
         if max_length is None:
-            effective_max_len = config.safe_enum_max_length
+            effective_max_len = privacy_config.safe_enum_max_length
+
+    if not isinstance(value, str):
+        return False
 
     # Identifier fields are normally blocked, but structural constants
     # (lowercase underscore-separated tokens like "chatgpt_agent") pass through.
-    if _is_identifier_field(path) and not (isinstance(value, str) and _STRUCTURAL_CONSTANT_RE.match(value)):
+    if _is_identifier_field(path) and not _STRUCTURAL_CONSTANT_RE.match(value):
         return False
     if not value or len(value) > effective_max_len:
         return False

--- a/polylogue/schemas/redaction_report.py
+++ b/polylogue/schemas/redaction_report.py
@@ -8,7 +8,9 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Any, Literal
+from typing import Literal
+
+from polylogue.schemas.json_types import JSONDocument, json_document
 
 
 @dataclass
@@ -153,40 +155,42 @@ class SchemaReport:
 
         return "\n".join(lines)
 
-    def to_json(self) -> dict[str, Any]:
+    def to_json(self) -> JSONDocument:
         """Structured JSON representation."""
-        return {
-            "provider": self.provider,
-            "timestamp": self.timestamp,
-            "privacy_level": self.privacy_level,
-            "summary": {
-                "total_fields": self.total_fields,
-                "fields_with_enums": self.fields_with_enums,
-                "total_values_considered": self.total_values_considered,
-                "total_included": self.total_included,
-                "total_rejected": self.total_rejected,
-            },
-            "rejection_reasons": self.rejection_reasons,
-            "borderline_decisions": [
-                {
-                    "path": d.path,
-                    "value": d.value,
-                    "count": d.count,
-                    "reason": d.reason,
-                }
-                for d in self.borderline_decisions
-            ],
-            "field_reports": [
-                {
-                    "path": fr.path,
-                    "included_count": len(fr.included_values),
-                    "rejected_count": len(fr.rejected),
-                    "content_field_blocked": fr.content_field_blocked,
-                    "identifier_field_blocked": fr.identifier_field_blocked,
-                }
-                for fr in self.field_reports
-            ],
-        }
+        return json_document(
+            {
+                "provider": self.provider,
+                "timestamp": self.timestamp,
+                "privacy_level": self.privacy_level,
+                "summary": {
+                    "total_fields": self.total_fields,
+                    "fields_with_enums": self.fields_with_enums,
+                    "total_values_considered": self.total_values_considered,
+                    "total_included": self.total_included,
+                    "total_rejected": self.total_rejected,
+                },
+                "rejection_reasons": self.rejection_reasons,
+                "borderline_decisions": [
+                    {
+                        "path": d.path,
+                        "value": d.value,
+                        "count": d.count,
+                        "reason": d.reason,
+                    }
+                    for d in self.borderline_decisions
+                ],
+                "field_reports": [
+                    {
+                        "path": fr.path,
+                        "included_count": len(fr.included_values),
+                        "rejected_count": len(fr.rejected),
+                        "content_field_blocked": fr.content_field_blocked,
+                        "identifier_field_blocked": fr.identifier_field_blocked,
+                    }
+                    for fr in self.field_reports
+                ],
+            }
+        )
 
 
 __all__ = [

--- a/polylogue/showcase/qa_markdown.py
+++ b/polylogue/showcase/qa_markdown.py
@@ -60,7 +60,7 @@ def generate_qa_markdown(
     lines.append("")
 
     if result.audit_report is not None:
-        audit_summary = result.audit_report.to_json()["summary"]
+        audit_summary = _payload_mapping(result.audit_report.to_json().get("summary", {}))
         lines.append("## Schema Audit")
         lines.append("")
         lines.append(f"- Passed: {audit_summary['passed']}")

--- a/polylogue/showcase/report_files.py
+++ b/polylogue/showcase/report_files.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
 
+from polylogue.lib.json import JSONDocument, json_document
 from polylogue.publication import OutputManifest
 from polylogue.showcase.runner import ShowcaseResult
 
@@ -36,9 +36,11 @@ def scan_manifest(result: ShowcaseResult, *, include_hashes: bool = True) -> Out
     )
 
 
-def generate_manifest(result: ShowcaseResult, *, include_hashes: bool = True) -> dict[str, Any]:
+def generate_manifest(result: ShowcaseResult, *, include_hashes: bool = True) -> JSONDocument:
     """Produce a JSON-serializable manifest payload for showcase artifacts."""
-    return scan_manifest(result, include_hashes=include_hashes).model_dump(mode="json", exclude_none=True)
+    return json_document(
+        scan_manifest(result, include_hashes=include_hashes).model_dump(mode="json", exclude_none=True)
+    )
 
 
 def _report_artifacts(result: ShowcaseResult) -> tuple[ShowcaseReportArtifact, ...]:

--- a/polylogue/storage/artifact_persistence.py
+++ b/polylogue/storage/artifact_persistence.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import sqlite3
-from typing import Any
 
 from polylogue.storage.artifact_inspection import inspect_raw_artifact
 from polylogue.storage.backends.queries.mappers import _row_to_raw_conversation
@@ -126,7 +125,7 @@ def ensure_artifact_observations(
                 ")"
             )
         where_clauses = [f"({' OR '.join(state_clauses)})", "r.rowid > ?"]
-        params: list[Any] = [last_rowid]
+        params: list[object] = [last_rowid]
         if providers:
             placeholders = ",".join("?" for _ in providers)
             where_clauses.append(f"COALESCE(r.payload_provider, r.provider_name) IN ({placeholders})")

--- a/polylogue/storage/derived_status_products.py
+++ b/polylogue/storage/derived_status_products.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
+
 from polylogue.maintenance_models import DerivedModelStatus
 from polylogue.storage.action_event_artifacts import ActionEventArtifactState
 from polylogue.storage.store import ACTION_EVENT_MATERIALIZER_VERSION, SESSION_PRODUCT_MATERIALIZER_VERSION
@@ -23,8 +25,7 @@ def pending_docs(source_docs: int, materialized_docs: int) -> int:
 def build_action_statuses(metrics: dict[str, int | bool]) -> dict[str, DerivedModelStatus]:
     state = ActionEventArtifactState.from_metrics(metrics)
     action_rows_status = state.row_status()
-    action_rows_payload = action_rows_status.to_dict()
-    action_rows_payload["materializer_version"] = ACTION_EVENT_MATERIALIZER_VERSION
+    action_rows_status = replace(action_rows_status, materializer_version=ACTION_EVENT_MATERIALIZER_VERSION)
     message_fts_exact_counts = bool(metrics.get("message_fts_exact_counts", True))
     return {
         "messages_fts": DerivedModelStatus(
@@ -47,7 +48,7 @@ def build_action_statuses(metrics: dict[str, int | bool]) -> dict[str, DerivedMo
             materialized_rows=int(metrics["message_fts_rows"]),
             pending_rows=pending_rows(int(metrics["message_source_rows"]), int(metrics["message_fts_rows"])),
         ),
-        "action_events": DerivedModelStatus(**action_rows_payload),
+        "action_events": action_rows_status,
         "action_events_fts": state.fts_status(),
     }
 

--- a/polylogue/version.py
+++ b/polylogue/version.py
@@ -71,6 +71,23 @@ def _read_packed_ref(git_dir: Path, ref_name: str) -> str | None:
     return None
 
 
+def _resolve_common_git_dir(git_dir: Path) -> Path:
+    """Return the common git directory for normal and linked worktree checkouts."""
+    common_dir_path = git_dir / "commondir"
+    if not common_dir_path.exists():
+        return git_dir
+    try:
+        common_dir_text = common_dir_path.read_text(encoding="utf-8").strip()
+    except OSError:
+        return git_dir
+    if not common_dir_text:
+        return git_dir
+    common_dir = Path(common_dir_text)
+    if not common_dir.is_absolute():
+        common_dir = (git_dir / common_dir).resolve()
+    return common_dir
+
+
 def _read_head_commit(repo_root: Path) -> str | None:
     git_dir = _resolve_git_dir(repo_root)
     if git_dir is None:
@@ -90,14 +107,17 @@ def _read_head_commit(repo_root: Path) -> str | None:
     ref_name = head_text[len(prefix) :].strip()
     if not ref_name:
         return None
-    ref_path = git_dir / ref_name
-    if ref_path.exists():
+    for ref_root in (git_dir, _resolve_common_git_dir(git_dir)):
+        ref_path = ref_root / ref_name
+        if not ref_path.exists():
+            continue
         try:
             commit = ref_path.read_text(encoding="utf-8").strip()
         except OSError:
-            return None
-        return commit if re.fullmatch(r"[0-9a-f]{40}", commit) else None
-    return _read_packed_ref(git_dir, ref_name)
+            continue
+        if re.fullmatch(r"[0-9a-f]{40}", commit):
+            return commit
+    return _read_packed_ref(_resolve_common_git_dir(git_dir), ref_name)
 
 
 def _detect_git_dirty(repo_root: Path) -> bool:

--- a/tests/unit/core/test_artifact_graph.py
+++ b/tests/unit/core/test_artifact_graph.py
@@ -2,8 +2,13 @@ from __future__ import annotations
 
 from polylogue.artifact_graph import ArtifactLayer, build_artifact_graph
 from polylogue.artifacts import build_runtime_artifact_nodes, build_runtime_artifact_paths
+from polylogue.lib.json import JSONDocument, JSONDocumentList, json_document_list
 from polylogue.maintenance_targets import MAINTENANCE_TARGET_NAMES
 from polylogue.operations import OperationKind, build_runtime_operation_catalog
+
+
+def _document_list_field(payload: JSONDocument, field: str) -> JSONDocumentList:
+    return json_document_list(payload[field])
 
 
 def test_artifact_graph_contains_the_current_runtime_paths() -> None:
@@ -266,11 +271,14 @@ def test_artifact_graph_nodes_and_paths_come_from_runtime_artifact_specs() -> No
 
 def test_artifact_graph_serializes_layers_as_strings() -> None:
     payload = build_artifact_graph().to_dict()
+    nodes = _document_list_field(payload, "nodes")
+    paths = _document_list_field(payload, "paths")
+    operations = _document_list_field(payload, "operations")
 
-    assert any(node["layer"] == "durable" for node in payload["nodes"])
-    assert any(path["name"] == "raw-reparse-loop" for path in payload["paths"])
-    assert any(operation["name"] == "plan-validation-backlog" for operation in payload["operations"])
-    assert any(operation["kind"] == "planning" for operation in payload["operations"])
+    assert any(node["layer"] == "durable" for node in nodes)
+    assert any(path["name"] == "raw-reparse-loop" for path in paths)
+    assert any(operation["name"] == "plan-validation-backlog" for operation in operations)
+    assert any(operation["kind"] == "planning" for operation in operations)
 
 
 def test_artifact_graph_operations_reference_only_declared_nodes() -> None:

--- a/tests/unit/core/test_audit.py
+++ b/tests/unit/core/test_audit.py
@@ -182,14 +182,20 @@ class TestAuditReport:
             ],
         )
         data = report.to_json()
+        summary = data["summary"]
+        checks = data["checks"]
+        assert isinstance(summary, dict)
+        assert isinstance(checks, list)
+        assert len(checks) == 1
+        check = checks[0]
+        assert isinstance(check, dict)
         assert data["provider"] == "test"
-        assert data["summary"]["passed"] == 1
-        assert data["summary"]["warned"] == 0
-        assert data["summary"]["failed"] == 0
-        assert len(data["checks"]) == 1
-        assert data["checks"][0]["name"] == "a"
-        assert data["checks"][0]["provider"] is None
-        assert data["checks"][0]["details"] == ["detail1"]
+        assert summary["passed"] == 1
+        assert summary["warned"] == 0
+        assert summary["failed"] == 0
+        assert check["name"] == "a"
+        assert check["provider"] is None
+        assert check["details"] == ["detail1"]
 
     def test_to_json_no_provider(self) -> None:
         report = AuditReport(checks=[])
@@ -215,9 +221,13 @@ class TestAuditReport:
         )
 
         data = report.to_json()
+        checks = data["checks"]
+        assert isinstance(checks, list)
+        check = checks[0]
+        assert isinstance(check, dict)
 
         assert data["provider"] is None
-        assert data["checks"][0]["provider"] == "chatgpt"
+        assert check["provider"] == "chatgpt"
 
 
 class TestCheckPrivacyGuards:

--- a/tests/unit/core/test_redaction_report.py
+++ b/tests/unit/core/test_redaction_report.py
@@ -127,12 +127,16 @@ class TestToJson:
             FieldReport(path="$.x", included_values=["a"], rejected=[]),
         ]
         data = report.to_json()
+        summary = data["summary"]
+        field_reports = data["field_reports"]
+        assert isinstance(summary, dict)
+        assert isinstance(field_reports, list)
         # Verify structure
         assert data["provider"] == "chatgpt"
-        assert data["summary"]["total_fields"] == 5
-        assert data["summary"]["total_included"] == 3
-        assert data["summary"]["total_rejected"] == 2
+        assert summary["total_fields"] == 5
+        assert summary["total_included"] == 3
+        assert summary["total_rejected"] == 2
         assert data["rejection_reasons"] == {"high_entropy": 2}
-        assert len(data["field_reports"]) == 1
+        assert len(field_reports) == 1
         # Should be JSON-serializable
         json.dumps(data)

--- a/tests/unit/showcase/test_qa_markdown.py
+++ b/tests/unit/showcase/test_qa_markdown.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
 
+from polylogue.lib.json import JSONDocument, JSONDocumentList, json_document_list
 from polylogue.showcase.report_files import generate_manifest
 from polylogue.showcase.runner import ExerciseResult, ShowcaseResult
 from polylogue.showcase.showcase_report_text import generate_showcase_markdown
@@ -58,6 +59,10 @@ def _make_showcase(results: list[ExerciseResult], output_dir: Path | None = None
     sr.total_duration_ms = sum(r.duration_ms for r in results)
     sr.output_dir = output_dir
     return sr
+
+
+def _manifest_entries(manifest: JSONDocument) -> JSONDocumentList:
+    return json_document_list(manifest["entries"])
 
 
 # ---------------------------------------------------------------------------
@@ -202,11 +207,13 @@ class TestGenerateManifest:
         manifest = generate_manifest(sr, include_hashes=True)
 
         assert manifest["entry_count"] == 2
-        for entry in manifest["entries"]:
+        for entry in _manifest_entries(manifest):
             assert "relative_path" in entry
             assert "size_bytes" in entry
             assert "sha256" in entry
-            assert len(entry["sha256"]) == 64  # SHA-256 hex length
+            sha256 = entry["sha256"]
+            assert isinstance(sha256, str)
+            assert len(sha256) == 64  # SHA-256 hex length
 
     def test_without_hashes(self, tmp_path: Any) -> None:
         (tmp_path / "file.txt").write_text("hello")
@@ -215,7 +222,7 @@ class TestGenerateManifest:
         manifest = generate_manifest(sr, include_hashes=False)
 
         assert manifest["entry_count"] == 1
-        assert "sha256" not in manifest["entries"][0]
+        assert "sha256" not in _manifest_entries(manifest)[0]
 
     def test_manifest_serializes_to_json(self, tmp_path: Any) -> None:
         (tmp_path / "data.json").write_text("{}")

--- a/tests/unit/showcase/test_report.py
+++ b/tests/unit/showcase/test_report.py
@@ -88,8 +88,8 @@ def _payload_mapping(value: object) -> Mapping[str, object]:
     n_failed=st.integers(min_value=0, max_value=20),
     n_skipped=st.integers(min_value=0, max_value=20),
 )
-@settings(max_examples=50)
-def test_qa_session_always_has_required_keys(n_passed: Any, n_failed: Any, n_skipped: Any) -> None:
+@settings(max_examples=50, deadline=None)
+def test_qa_session_always_has_required_keys(n_passed: int, n_failed: int, n_skipped: int) -> None:
     """generate_showcase_session always returns the mandatory schema fields."""
     results = (
         [_make_result(passed=True) for _ in range(n_passed)]
@@ -115,8 +115,8 @@ def test_qa_session_always_has_required_keys(n_passed: Any, n_failed: Any, n_ski
     n_failed=st.integers(min_value=0, max_value=15),
     n_skipped=st.integers(min_value=0, max_value=15),
 )
-@settings(max_examples=50)
-def test_qa_session_summary_counts_consistent(n_passed: Any, n_failed: Any, n_skipped: Any) -> None:
+@settings(max_examples=50, deadline=None)
+def test_qa_session_summary_counts_consistent(n_passed: int, n_failed: int, n_skipped: int) -> None:
     """Summary passed+failed+skipped must equal total and match exercise list."""
     results = (
         [_make_result(passed=True) for _ in range(n_passed)]
@@ -140,8 +140,8 @@ def test_qa_session_summary_counts_consistent(n_passed: Any, n_failed: Any, n_sk
 
 
 @given(n=st.integers(min_value=0, max_value=30))
-@settings(max_examples=40)
-def test_qa_session_serializes_to_valid_json(n: Any) -> None:
+@settings(max_examples=40, deadline=None)
+def test_qa_session_serializes_to_valid_json(n: int) -> None:
     """generate_showcase_session output round-trips through JSON without error."""
     results = [_make_result(passed=i % 3 != 0) for i in range(n)]
     session = generate_showcase_session(_make_showcase(results))
@@ -156,8 +156,8 @@ def test_qa_session_serializes_to_valid_json(n: Any) -> None:
 
 
 @given(n=st.integers(min_value=0, max_value=10))
-@settings(max_examples=20)
-def test_qa_session_schema_version_is_always_one(n: Any) -> None:
+@settings(max_examples=20, deadline=None)
+def test_qa_session_schema_version_is_always_one(n: int) -> None:
     """schema_version field is always 1 regardless of result set."""
     results = [_make_result() for _ in range(n)]
     session = build_showcase_session_record(_make_showcase(results), timestamp="2026-01-01T00:00:00Z")
@@ -170,8 +170,8 @@ def test_qa_session_schema_version_is_always_one(n: Any) -> None:
 
 
 @given(n=st.integers(min_value=0, max_value=20))
-@settings(max_examples=40)
-def test_generate_json_report_always_valid_json(n: Any) -> None:
+@settings(max_examples=40, deadline=None)
+def test_generate_json_report_always_valid_json(n: int) -> None:
     """generate_json_report always returns a valid JSON string."""
     results = [_make_result(passed=i % 2 == 0) for i in range(n)]
     raw = generate_json_report(_make_showcase(results))


### PR DESCRIPTION
## Summary

- Tighten privacy, audit, redaction, query sorting, preparation, and scenario runtime contracts by replacing loose `Any` boundaries with explicit object, protocol, JSON, and parsed-conversation types.
- Fix source-checkout version resolution for linked git worktrees by resolving symbolic refs through the common git directory.
- Tighten report payload tests so strict mypy can index JSON-shaped outputs only after runtime narrowing, and disable Hypothesis deadlines for timing-variable report serialization properties.

Ref #281

## Problem

The remaining runtime/reporting seams still carried broad `Any` annotations and ad hoc payload assumptions. Those loose contracts obscured the actual shape of privacy config overrides, report JSON payloads, query sort keys, parsed conversation preparation, and runner dispatch results.

Linked worktree checkouts also failed version resolution because symbolic branch refs were read only from the worktree git directory, not from the common git dir where normal branch refs live.

## Solution

- Added a runtime-checkable privacy config protocol and narrowed enum-value checking to string values after explicit config override handling.
- Introduced typed JSON document returns for outcome, audit, and redaction reports, with downstream markdown/tests narrowing JSON unions before indexing.
- Typed query sort keys, preparation inputs, and scenario runner dispatch returns without changing runtime behavior.
- Resolved linked-worktree version metadata through `commondir`.
- Updated report property tests to avoid deadline flakes under xdist and strict typing.

## Verification

- `ruff check polylogue/schemas/privacy.py polylogue/scenarios/runtime.py polylogue/lib/outcomes.py polylogue/lib/query_sorting.py polylogue/lib/query_plan.py polylogue/pipeline/prepare.py polylogue/schemas/audit_models.py polylogue/schemas/redaction_report.py polylogue/showcase/qa_markdown.py polylogue/version.py`
- `mypy polylogue/schemas/privacy.py polylogue/scenarios/runtime.py polylogue/lib/outcomes.py polylogue/lib/query_sorting.py polylogue/lib/query_plan.py polylogue/pipeline/prepare.py polylogue/schemas/audit_models.py polylogue/schemas/redaction_report.py polylogue/showcase/qa_markdown.py polylogue/version.py`
- `pytest -q tests/unit/core/test_privacy_guards.py tests/unit/core/test_schema_privacy.py tests/unit/core/test_privacy_config.py tests/unit/scenarios/test_runtime.py tests/unit/pipeline/test_prepare.py tests/unit/pipeline/test_prepare_records.py tests/unit/core/test_audit.py tests/unit/core/test_redaction_report.py tests/unit/showcase/test_qa_markdown.py tests/unit/showcase/test_report.py`
- `PATH=/tmp/polylogue-281/.cache/codex-bin:$PATH devtools verify --quick`
- Pre-push hook: `devtools verify --quick`
- Basename-correct detached verification worktree: `PATH=/tmp/polylogue-281-verify/polylogue/.cache/codex-bin:$PATH devtools verify` reached and passed pytest; the first overall exit was nonzero only because ignored `AGENTS.md` was absent in the fresh detached worktree. After `devtools render-agents --input CLAUDE.md --output AGENTS.md`, `PATH=/tmp/polylogue-281-verify/polylogue/.cache/codex-bin:$PATH devtools verify --quick` passed.
