### PR TITLE
refactor: remove dynamic seam Any typing

### DIFF
--- a/devtools/benchmark_campaign.py
+++ b/devtools/benchmark_campaign.py
@@ -7,6 +7,7 @@ import json
 import subprocess
 import tempfile
 import time
+from collections.abc import Iterable, Mapping
 from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
@@ -122,11 +123,14 @@ def _benchmark_key(entry: JSONDocument) -> str:
     return str(entry.get("fullname") or entry.get("fullfunc") or entry.get("name"))
 
 
-def _number_field(payload: JSONDocument, field: str) -> str | int | float:
-    value = payload[field]
+def _number_value(value: object, *, field: str) -> str | int | float:
     if isinstance(value, bool) or not isinstance(value, (str, int, float)):
         raise ValueError(f"Benchmark payload field {field!r} is not numeric: {value!r}")
     return value
+
+
+def _number_field(payload: JSONDocument, field: str) -> str | int | float:
+    return _number_value(payload[field], field=field)
 
 
 def _float_field(payload: JSONDocument, field: str) -> float:
@@ -182,14 +186,14 @@ def _load_campaign_result(path: Path) -> CampaignResult:
     return CampaignResult(**json.loads(path.read_text()))
 
 
-def _compare_results(current: list[BenchmarkStat], baseline: list[BenchmarkStatRecord]) -> list[Regression]:
+def _compare_results(current: list[BenchmarkStat], baseline: Iterable[Mapping[str, object]]) -> list[Regression]:
     baseline_map = {str(item["fullname"]): item for item in baseline}
     regressions: list[Regression] = []
     for bench in current:
         previous = baseline_map.get(bench.fullname)
         if previous is None:
             continue
-        baseline_mean = float(previous["mean"])
+        baseline_mean = float(_number_value(previous["mean"], field="mean"))
         if baseline_mean <= 0:
             continue
         delta_pct = ((bench.mean - baseline_mean) / baseline_mean) * 100.0

--- a/devtools/benchmark_campaign.py
+++ b/devtools/benchmark_campaign.py
@@ -10,8 +10,9 @@ import time
 from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import TypedDict
 
+from polylogue.lib.json import JSONDocument, json_document, json_document_list
 from polylogue.scenarios import ExecutionKind, ScenarioMetadata, pytest_execution, run_execution
 
 from .authored_scenario_catalog import get_authored_scenario_catalog
@@ -23,6 +24,26 @@ STATUS_IGNORE_PREFIXES = (f"{ARTIFACT_DIR.as_posix()}/",)
 DEFAULT_WARN_PCT = 10.0
 DEFAULT_FAIL_PCT = 20.0
 CAMPAIGNS = get_authored_scenario_catalog().benchmark_campaign_index()
+
+
+class BenchmarkStatRecord(TypedDict):
+    name: str
+    fullname: str
+    group: str
+    mean: float
+    median: float
+    minimum: float
+    maximum: float
+    stddev: float
+    rounds: int
+    ops: float | None
+
+
+class RegressionRecord(TypedDict):
+    fullname: str
+    baseline_mean: float
+    current_mean: float
+    delta_pct: float
 
 
 @dataclass(frozen=True)
@@ -61,13 +82,13 @@ class CampaignResult:
     benchmark_count: int
     runtime_seconds: float
     exit_code: int
-    machine_info: dict[str, Any]
-    benchmarks: list[dict[str, Any]]
-    slowest: list[dict[str, Any]]
+    machine_info: JSONDocument
+    benchmarks: list[BenchmarkStatRecord]
+    slowest: list[BenchmarkStatRecord]
     compare_to: str | None
     warn_pct: float
     fail_pct: float
-    regressions: list[dict[str, Any]]
+    regressions: list[RegressionRecord]
     worst_regression_pct: float | None
     origin: str = "authored"
     path_targets: list[str] = field(default_factory=list)
@@ -97,32 +118,71 @@ def _default_artifact_path(campaign: str, suffix: str) -> Path:
     return ROOT / ARTIFACT_DIR / f"{date}-{campaign}.{suffix}"
 
 
-def _benchmark_key(entry: dict[str, Any]) -> str:
+def _benchmark_key(entry: JSONDocument) -> str:
     return str(entry.get("fullname") or entry.get("fullfunc") or entry.get("name"))
 
 
-def _parse_stats(raw: dict[str, Any]) -> BenchmarkStat:
-    stats = raw["stats"]
-    mean = float(stats["mean"])
+def _number_field(payload: JSONDocument, field: str) -> str | int | float:
+    value = payload[field]
+    if isinstance(value, bool) or not isinstance(value, (str, int, float)):
+        raise ValueError(f"Benchmark payload field {field!r} is not numeric: {value!r}")
+    return value
+
+
+def _float_field(payload: JSONDocument, field: str) -> float:
+    return float(_number_field(payload, field))
+
+
+def _int_field(payload: JSONDocument, field: str) -> int:
+    return int(_number_field(payload, field))
+
+
+def _parse_stats(raw: JSONDocument) -> BenchmarkStat:
+    stats = json_document(raw.get("stats"))
+    mean = _float_field(stats, "mean")
     return BenchmarkStat(
         name=str(raw.get("name", "unknown")),
         fullname=_benchmark_key(raw),
         group=str(raw.get("group", "benchmark")),
         mean=mean,
-        median=float(stats["median"]),
-        minimum=float(stats["min"]),
-        maximum=float(stats["max"]),
-        stddev=float(stats.get("stddev", 0.0)),
-        rounds=int(stats.get("rounds", 0)),
+        median=_float_field(stats, "median"),
+        minimum=_float_field(stats, "min"),
+        maximum=_float_field(stats, "max"),
+        stddev=_float_field(stats, "stddev") if "stddev" in stats else 0.0,
+        rounds=_int_field(stats, "rounds") if "rounds" in stats else 0,
         ops=(1.0 / mean) if mean > 0 else None,
     )
+
+
+def _benchmark_stat_record(stat: BenchmarkStat) -> BenchmarkStatRecord:
+    return {
+        "name": stat.name,
+        "fullname": stat.fullname,
+        "group": stat.group,
+        "mean": stat.mean,
+        "median": stat.median,
+        "minimum": stat.minimum,
+        "maximum": stat.maximum,
+        "stddev": stat.stddev,
+        "rounds": stat.rounds,
+        "ops": stat.ops,
+    }
+
+
+def _regression_record(regression: Regression) -> RegressionRecord:
+    return {
+        "fullname": regression.fullname,
+        "baseline_mean": regression.baseline_mean,
+        "current_mean": regression.current_mean,
+        "delta_pct": regression.delta_pct,
+    }
 
 
 def _load_campaign_result(path: Path) -> CampaignResult:
     return CampaignResult(**json.loads(path.read_text()))
 
 
-def _compare_results(current: list[BenchmarkStat], baseline: list[dict[str, Any]]) -> list[Regression]:
+def _compare_results(current: list[BenchmarkStat], baseline: list[BenchmarkStatRecord]) -> list[Regression]:
     baseline_map = {str(item["fullname"]): item for item in baseline}
     regressions: list[Regression] = []
     for bench in current:
@@ -254,7 +314,8 @@ def run_campaign(
             raise SystemExit(f"Benchmark run for {campaign.name} produced no JSON artifact")
         payload = json.loads(raw_json.read_text())
 
-    benchmarks = [_parse_stats(entry) for entry in payload.get("benchmarks", [])]
+    payload_document = json_document(payload)
+    benchmarks = [_parse_stats(entry) for entry in json_document_list(payload_document.get("benchmarks"))]
     benchmarks.sort(key=lambda item: item.mean, reverse=True)
     baseline_result = _load_campaign_result(compare_to) if compare_to else None
     regressions = _compare_results(benchmarks, baseline_result.benchmarks) if baseline_result else []
@@ -276,13 +337,13 @@ def run_campaign(
         benchmark_count=len(benchmarks),
         runtime_seconds=runtime_seconds,
         exit_code=completed.exit_code,
-        machine_info=dict(payload.get("machine_info", {})),
-        benchmarks=[asdict(bench) for bench in benchmarks],
-        slowest=[asdict(bench) for bench in benchmarks[:10]],
+        machine_info=json_document(payload_document.get("machine_info")),
+        benchmarks=[_benchmark_stat_record(bench) for bench in benchmarks],
+        slowest=[_benchmark_stat_record(bench) for bench in benchmarks[:10]],
         compare_to=str(compare_to) if compare_to else None,
         warn_pct=warn_threshold,
         fail_pct=fail_threshold,
-        regressions=[asdict(item) for item in regressions],
+        regressions=[_regression_record(item) for item in regressions],
         worst_regression_pct=worst_regression,
         origin=metadata.origin,
         path_targets=list(metadata.path_targets),

--- a/devtools/inject_semantic_annotations.py
+++ b/devtools/inject_semantic_annotations.py
@@ -12,8 +12,8 @@ import gzip
 import json
 import sys
 from pathlib import Path
-from typing import Any
 
+from polylogue.lib.json import JSONDocument, is_json_document, json_document
 from polylogue.schemas.registry import SchemaRegistry
 
 SCHEMAS_DIR = Path(__file__).resolve().parent.parent / "polylogue" / "schemas" / "providers"
@@ -138,11 +138,11 @@ ANNOTATION_MAP: dict[str, list[tuple[list[str], str]]] = {
 }
 
 
-def _navigate(schema: dict[str, Any], path_segments: list[str]) -> dict[str, Any] | None:
+def _navigate(schema: JSONDocument, path_segments: list[str]) -> JSONDocument | None:
     """Navigate a schema using path segments, returning the target node."""
     node: object = schema
     for segment in path_segments:
-        if not isinstance(node, dict):
+        if not is_json_document(node):
             return None
 
         mapping = node
@@ -150,7 +150,7 @@ def _navigate(schema: dict[str, Any], path_segments: list[str]) -> dict[str, Any
         if segment.startswith("properties."):
             key = segment[len("properties.") :]
             properties = mapping.get("properties")
-            if not isinstance(properties, dict):
+            if not is_json_document(properties):
                 return None
             node = properties.get(key)
         elif segment == "items":
@@ -161,18 +161,22 @@ def _navigate(schema: dict[str, Any], path_segments: list[str]) -> dict[str, Any
             # Find the anyOf variant that has "properties"
             variants = mapping.get("anyOf", [])
             found = None
-            for v in variants:
-                if isinstance(v, dict) and "properties" in v:
-                    found = v
+            if not isinstance(variants, list):
+                return None
+            for variant in variants:
+                if is_json_document(variant) and "properties" in variant:
+                    found = variant
                     break
             node = found
         elif segment == "anyOf:array":
             # Find the anyOf variant with type="array"
             variants = mapping.get("anyOf", [])
             found = None
-            for v in variants:
-                if isinstance(v, dict) and v.get("type") == "array":
-                    found = v
+            if not isinstance(variants, list):
+                return None
+            for variant in variants:
+                if is_json_document(variant) and variant.get("type") == "array":
+                    found = variant
                     break
             node = found
         else:
@@ -181,10 +185,10 @@ def _navigate(schema: dict[str, Any], path_segments: list[str]) -> dict[str, Any
         if node is None:
             return None
 
-    return node if isinstance(node, dict) else None
+    return node if is_json_document(node) else None
 
 
-def inject_annotations(provider: str, schema: dict[str, Any], *, dry_run: bool = False) -> int:
+def inject_annotations(provider: str, schema: JSONDocument, *, dry_run: bool = False) -> int:
     """Inject semantic role annotations into a schema. Returns count of annotations added."""
     annotations = ANNOTATION_MAP.get(provider, [])
     count = 0
@@ -232,7 +236,7 @@ def main(argv: list[str] | None = None) -> int:
 
         print(f"\n--- {provider} ---")
         with gzip.open(schema_path, "rt") as f:
-            schema = json.load(f)
+            schema = json_document(json.load(f))
 
         count = inject_annotations(provider, schema, dry_run=args.dry_run)
         total += count

--- a/devtools/scenario_coverage.py
+++ b/devtools/scenario_coverage.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
 
 from devtools.scenario_projection_catalog import build_scenario_projection_entries
 from polylogue.artifact_graph import build_artifact_graph
+from polylogue.lib.json import JSONDocument, json_document
 from polylogue.operations import build_declared_operation_catalog
 from polylogue.scenarios import ScenarioProjectionEntry
 
@@ -36,13 +36,15 @@ class RuntimePathCoverage:
     def complete(self) -> bool:
         return not self.uncovered_artifacts and not self.uncovered_operations
 
-    def to_dict(self) -> dict[str, Any]:
-        return {
-            "refs": [ref.to_dict() for ref in self.refs],
-            "uncovered_artifacts": list(self.uncovered_artifacts),
-            "uncovered_operations": list(self.uncovered_operations),
-            "complete": self.complete,
-        }
+    def to_dict(self) -> JSONDocument:
+        return json_document(
+            {
+                "refs": [ref.to_dict() for ref in self.refs],
+                "uncovered_artifacts": list(self.uncovered_artifacts),
+                "uncovered_operations": list(self.uncovered_operations),
+                "complete": self.complete,
+            }
+        )
 
 
 @dataclass(frozen=True, slots=True)
@@ -57,22 +59,24 @@ class RuntimeScenarioCoverage:
     uncovered_maintenance_targets: tuple[str, ...]
     uncovered_declared_operations: tuple[str, ...]
 
-    def to_dict(self) -> dict[str, Any]:
-        return {
-            "artifacts": {name: [ref.to_dict() for ref in refs] for name, refs in self.artifacts.items()},
-            "operations": {name: [ref.to_dict() for ref in refs] for name, refs in self.operations.items()},
-            "maintenance_targets": {
-                name: [ref.to_dict() for ref in refs] for name, refs in self.maintenance_targets.items()
-            },
-            "declared_operations": {
-                name: [ref.to_dict() for ref in refs] for name, refs in self.declared_operations.items()
-            },
-            "paths": {name: path.to_dict() for name, path in self.paths.items()},
-            "uncovered_artifacts": list(self.uncovered_artifacts),
-            "uncovered_operations": list(self.uncovered_operations),
-            "uncovered_maintenance_targets": list(self.uncovered_maintenance_targets),
-            "uncovered_declared_operations": list(self.uncovered_declared_operations),
-        }
+    def to_dict(self) -> JSONDocument:
+        return json_document(
+            {
+                "artifacts": {name: [ref.to_dict() for ref in refs] for name, refs in self.artifacts.items()},
+                "operations": {name: [ref.to_dict() for ref in refs] for name, refs in self.operations.items()},
+                "maintenance_targets": {
+                    name: [ref.to_dict() for ref in refs] for name, refs in self.maintenance_targets.items()
+                },
+                "declared_operations": {
+                    name: [ref.to_dict() for ref in refs] for name, refs in self.declared_operations.items()
+                },
+                "paths": {name: path.to_dict() for name, path in self.paths.items()},
+                "uncovered_artifacts": list(self.uncovered_artifacts),
+                "uncovered_operations": list(self.uncovered_operations),
+                "uncovered_maintenance_targets": list(self.uncovered_maintenance_targets),
+                "uncovered_declared_operations": list(self.uncovered_declared_operations),
+            }
+        )
 
 
 def build_runtime_scenario_coverage(

--- a/polylogue/cli/click_option_groups.py
+++ b/polylogue/cli/click_option_groups.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Any
+from typing import TypeAlias
 
 import click
 
@@ -16,7 +16,7 @@ from polylogue.cli.shell_completion_values import (
 from polylogue.lib.provider_identity import CORE_SCHEMA_PROVIDERS
 from polylogue.lib.query_spec import QUERY_ACTION_TYPES, QUERY_RETRIEVAL_LANES
 
-ClickCallable = Callable[..., Any]
+ClickCallable: TypeAlias = Callable[..., object]
 
 # Providers the user can filter by (excludes "unknown" and "drive" which are internal).
 _CLI_PROVIDER_CHOICES: tuple[str, ...] = CORE_SCHEMA_PROVIDERS

--- a/polylogue/cli/machine_main.py
+++ b/polylogue/cli/machine_main.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
-from typing import Any
+from typing import Protocol
 
 import click
+
+
+class ClickEntrypoint(Protocol):
+    def __call__(self, *args: object, **kwargs: object) -> object: ...
 
 
 def extract_option(message: str) -> str | None:
@@ -16,7 +19,7 @@ def extract_option(message: str) -> str | None:
 
 
 def run_machine_entry(
-    cli: Callable[..., Any],
+    cli: ClickEntrypoint,
     argv: list[str],
 ) -> None:
     """Run the CLI, emitting JSON machine errors when requested."""

--- a/polylogue/cli/machine_main.py
+++ b/polylogue/cli/machine_main.py
@@ -2,13 +2,9 @@
 
 from __future__ import annotations
 
-from typing import Protocol
+from collections.abc import Callable
 
 import click
-
-
-class ClickEntrypoint(Protocol):
-    def __call__(self, *args: object, **kwargs: object) -> object: ...
 
 
 def extract_option(message: str) -> str | None:
@@ -19,7 +15,7 @@ def extract_option(message: str) -> str | None:
 
 
 def run_machine_entry(
-    cli: ClickEntrypoint,
+    cli: Callable[..., object],
     argv: list[str],
 ) -> None:
     """Run the CLI, emitting JSON machine errors when requested."""

--- a/polylogue/cli/qa_capture.py
+++ b/polylogue/cli/qa_capture.py
@@ -2,10 +2,15 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING
+
+from polylogue.cli.types import AppEnv
+
+if TYPE_CHECKING:
+    from polylogue.showcase.runner import ShowcaseResult
 
 
-def run_vhs_capture(env: Any, showcase_result: Any, json_output: bool) -> None:
+def run_vhs_capture(env: AppEnv, showcase_result: ShowcaseResult, json_output: bool) -> None:
     """Run VHS tape captures if available."""
     try:
         from polylogue.showcase.vhs import (

--- a/polylogue/cli/qa_snapshot.py
+++ b/polylogue/cli/qa_snapshot.py
@@ -7,10 +7,10 @@ import json
 import shutil
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
 
 from polylogue.cli.machine_errors import emit_success
 from polylogue.cli.qa_requests import QASnapshotPlan
+from polylogue.cli.types import AppEnv
 from polylogue.paths import safe_path_component
 
 
@@ -58,7 +58,7 @@ def snapshot_results(
     label: str,
     output_root: Path,
     json_output: bool,
-    env: Any,
+    env: AppEnv,
 ) -> None:
     """Archive a QA output directory into a timestamped snapshot."""
     stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
@@ -114,7 +114,7 @@ def execute_snapshot_plan(
     fallback_source_dir: Path | None,
     output_root: Path,
     json_output: bool,
-    env: Any,
+    env: AppEnv,
 ) -> bool:
     """Execute a normalized snapshot plan if a source directory is available."""
     source_dir = plan.resolve_source_dir(fallback_source_dir)

--- a/polylogue/cli/run_observers.py
+++ b/polylogue/cli/run_observers.py
@@ -6,7 +6,7 @@ import re
 import time
 from collections.abc import Iterator
 from contextlib import contextmanager
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from polylogue.cli.formatting import format_counts
 from polylogue.cli.types import AppEnv
@@ -89,9 +89,9 @@ class RichProgressObserver(RunObserver):
 
     __slots__ = ("_progress", "_task_id")
 
-    def __init__(self, progress: Progress, task_id: TaskID) -> None:
+    def __init__(self, progress: Progress, task_id: object) -> None:
         self._progress = progress
-        self._task_id = task_id
+        self._task_id = cast("TaskID", task_id)
 
     @staticmethod
     def _progress_bounds(desc: str | None) -> tuple[int, int] | None:

--- a/polylogue/cli/run_observers.py
+++ b/polylogue/cli/run_observers.py
@@ -6,27 +6,17 @@ import re
 import time
 from collections.abc import Iterator
 from contextlib import contextmanager
-from typing import Any, Protocol
+from typing import TYPE_CHECKING
 
 from polylogue.cli.formatting import format_counts
 from polylogue.cli.types import AppEnv
 from polylogue.pipeline.observers import RunObserver
 from polylogue.storage.run_state import RunResult
 
+if TYPE_CHECKING:
+    from rich.progress import Progress, TaskID
+
 _PROGRESS_FRACTION_RE = re.compile(r"(?P<completed>\d[\d,]*)/(?P<total>\d[\d,]*)")
-
-
-class _ProgressHandle(Protocol):
-    def update(
-        self,
-        task_id: Any,
-        *,
-        description: str | None = None,
-        total: float | None = None,
-        completed: float | None = None,
-        advance: float | None = None,
-        **fields: Any,
-    ) -> None: ...
 
 
 def _format_elapsed(seconds: float) -> str:
@@ -99,7 +89,7 @@ class RichProgressObserver(RunObserver):
 
     __slots__ = ("_progress", "_task_id")
 
-    def __init__(self, progress: _ProgressHandle, task_id: object) -> None:
+    def __init__(self, progress: Progress, task_id: TaskID) -> None:
         self._progress = progress
         self._task_id = task_id
 

--- a/polylogue/lib/conversation_runtime.py
+++ b/polylogue/lib/conversation_runtime.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections import defaultdict
 from collections.abc import Callable, Iterator, Mapping
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Self, cast
+from typing import TYPE_CHECKING, Self, cast
 
 from polylogue.lib.branch_type import BranchType
 from polylogue.lib.message_models import DialoguePair, Message
@@ -42,7 +42,7 @@ class ConversationRuntimeMixin:
 
     if TYPE_CHECKING:
 
-        def model_copy(self, *, update: Mapping[str, Any] | None = None, deep: bool = False) -> Self: ...
+        def model_copy(self, *, update: Mapping[str, object] | None = None, deep: bool = False) -> Self: ...
 
     @property
     def display_date(self) -> datetime | None:

--- a/polylogue/lib/filter_builder.py
+++ b/polylogue/lib/filter_builder.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import replace
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Protocol, Self, TypeVar, cast
+from typing import TYPE_CHECKING, Protocol, Self, TypeVar
 
 from polylogue.lib.dates import parse_date
 from polylogue.lib.filter_types import SortField
@@ -32,7 +32,9 @@ def _replace_plan(
     **changes: object,
 ) -> _PlanOwner:
     plan = filter_obj._plan
-    filter_obj._plan = cast("ConversationQueryPlan", cast(Any, replace)(plan, **changes))
+    # dataclasses.replace is precisely typed per field and cannot express this
+    # fluent builder's dynamic one-field-at-a-time updates.
+    filter_obj._plan = replace(plan, **changes)  # type: ignore[arg-type]
     return filter_obj
 
 

--- a/polylogue/logging.py
+++ b/polylogue/logging.py
@@ -4,10 +4,26 @@ from __future__ import annotations
 
 import logging
 import sys
-from typing import Any, TextIO
+from typing import Protocol, TextIO, cast
 
 import structlog
 from structlog.types import Processor
+
+
+class BoundLoggerLike(Protocol):
+    """Logger methods used by first-party call sites."""
+
+    def bind(self, **new_values: object) -> BoundLoggerLike: ...
+
+    def debug(self, message: str, *args: object, **event_kw: object) -> object: ...
+
+    def info(self, message: str, *args: object, **event_kw: object) -> object: ...
+
+    def warning(self, message: str, *args: object, **event_kw: object) -> object: ...
+
+    def error(self, message: str, *args: object, **event_kw: object) -> object: ...
+
+    def exception(self, message: str, *args: object, **event_kw: object) -> object: ...
 
 
 class _StderrProxy:
@@ -65,5 +81,5 @@ def configure_logging(verbose: bool = False, json_logs: bool = False) -> None:
     )
 
 
-def get_logger(name: str | None = None) -> Any:
-    return structlog.get_logger(name)
+def get_logger(name: str | None = None) -> BoundLoggerLike:
+    return cast(BoundLoggerLike, structlog.get_logger(name))

--- a/polylogue/schemas/code_detection_extractors.py
+++ b/polylogue/schemas/code_detection_extractors.py
@@ -3,37 +3,44 @@
 from __future__ import annotations
 
 import re
-from typing import Any
 
+from polylogue.lib.json import JSONDocument, json_document
 from polylogue.schemas.code_detection_runtime import detect_language
 
 
-def extract_code_block_from_dict(content_block: dict[str, Any]) -> dict[str, Any] | None:
+def extract_code_block_from_dict(content_block: JSONDocument) -> JSONDocument | None:
     """Extract and enrich a code block from a content-block dict."""
     block_type = content_block.get("type")
-    text = content_block.get("text", "")
+    text_value = content_block.get("text", "")
+    if not isinstance(text_value, str):
+        return None
+    text = text_value
 
     fence_match = re.match(r"```(\w*)\n(.*?)\n```", text, re.DOTALL)
     if fence_match:
         declared_lang = fence_match.group(1) or None
         code = fence_match.group(2)
         detected_lang = detect_language(code, declared_lang)
-        return {
-            "type": "code",
-            "language": detected_lang,
-            "text": code,
-            "declared_language": declared_lang,
-        }
+        return json_document(
+            {
+                "type": "code",
+                "language": detected_lang,
+                "text": code,
+                "declared_language": declared_lang,
+            }
+        )
 
     if block_type == "text" and len(text) > 20:
         detected_lang = detect_language(text)
         if detected_lang:
-            return {
-                "type": "code",
-                "language": detected_lang,
-                "text": text,
-                "declared_language": None,
-            }
+            return json_document(
+                {
+                    "type": "code",
+                    "language": detected_lang,
+                    "text": text,
+                    "declared_language": None,
+                }
+            )
     return None
 
 

--- a/polylogue/schemas/code_detection_tree_sitter.py
+++ b/polylogue/schemas/code_detection_tree_sitter.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable, Sequence
 from functools import lru_cache
-from typing import Any
+from typing import Protocol, cast
 
 _TS_GRAMMAR_MAP: dict[str, str] = {
     "python": "tree_sitter_python",
@@ -22,6 +23,12 @@ _TS_GRAMMAR_MAP: dict[str, str] = {
 }
 
 
+class TreeSitterNodeLike(Protocol):
+    type: str
+    is_missing: bool
+    children: Sequence[TreeSitterNodeLike]
+
+
 @lru_cache(maxsize=1)
 def tree_sitter_available() -> bool:
     """Check if the tree-sitter Python bindings are importable."""
@@ -34,7 +41,7 @@ def tree_sitter_available() -> bool:
 
 
 @lru_cache(maxsize=32)
-def get_ts_language(lang: str) -> Any | None:
+def get_ts_language(lang: str) -> object | None:
     """Load a tree-sitter Language for *lang*, or ``None`` on failure."""
     if not tree_sitter_available():
         return None
@@ -50,9 +57,10 @@ def get_ts_language(lang: str) -> Any | None:
 
         mod = importlib.import_module(module_name)
         lang_fn = getattr(mod, "language", None)
-        if lang_fn is None:
+        if not callable(lang_fn):
             return None
-        return Language(lang_fn())
+        language_factory = cast(Callable[[], object], lang_fn)
+        return cast(object, Language(language_factory()))
     except Exception:
         return None
 
@@ -72,7 +80,7 @@ def ts_error_ratio(code: str, lang: str) -> float | None:
         total_nodes = 0
         error_nodes = 0
 
-        def _walk(node: Any) -> None:
+        def _walk(node: TreeSitterNodeLike) -> None:
             nonlocal total_nodes, error_nodes
             total_nodes += 1
             if node.type == "ERROR" or node.is_missing:
@@ -80,7 +88,7 @@ def ts_error_ratio(code: str, lang: str) -> float | None:
             for child in node.children:
                 _walk(child)
 
-        _walk(tree.root_node)
+        _walk(cast(TreeSitterNodeLike, tree.root_node))
 
         if total_nodes == 0:
             return 1.0

--- a/polylogue/schemas/validator.py
+++ b/polylogue/schemas/validator.py
@@ -33,7 +33,7 @@ from .validator_resolution import (
 if TYPE_CHECKING:
     from polylogue.schemas.packages import SchemaResolution
 
-ValidationSchema: TypeAlias = Mapping[str, JSONValue]
+ValidationSchema: TypeAlias = Mapping[str, object]
 ValidationSample: TypeAlias = JSONDocument
 
 

--- a/polylogue/schemas/validator.py
+++ b/polylogue/schemas/validator.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Literal, Protocol, TypeAlias
+from typing import TYPE_CHECKING, Literal, Protocol, TypeAlias
 
 try:
     import jsonschema
@@ -33,7 +33,7 @@ from .validator_resolution import (
 if TYPE_CHECKING:
     from polylogue.schemas.packages import SchemaResolution
 
-ValidationSchema: TypeAlias = Mapping[str, Any]
+ValidationSchema: TypeAlias = Mapping[str, JSONValue]
 ValidationSample: TypeAlias = JSONDocument
 
 

--- a/polylogue/ui/facade_console.py
+++ b/polylogue/ui/facade_console.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import io
-from typing import Any, Protocol, runtime_checkable
+from typing import Protocol, runtime_checkable
 
 from rich.console import Console as RichConsole
 from rich.errors import MarkupError
@@ -13,7 +13,7 @@ from rich.text import Text
 
 @runtime_checkable
 class ConsoleLike(Protocol):
-    def print(self, *objects: object, **kwargs: Any) -> None: ...
+    def print(self, *objects: object, **kwargs: object) -> None: ...
 
 
 def _render_plain_object(obj: object) -> str:

--- a/tests/unit/core/test_schema_validation.py
+++ b/tests/unit/core/test_schema_validation.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 
 import pytest
 
+from polylogue.lib.json import json_document
 from polylogue.scenarios import CorpusSpec
 from polylogue.schemas import ValidationResult
 from polylogue.schemas.registry import SchemaRegistry
@@ -89,7 +90,7 @@ def test_schema_validator_loads_canonical_claude_ai_provider(mock_schema_dir: An
         validator = SchemaValidator.for_provider("claude-ai")
 
     assert validator.provider == "claude-ai"
-    assert "uuid" in validator.schema["properties"]
+    assert "uuid" in json_document(validator.schema["properties"])
 
 
 def test_schema_validator_accepts_provider_enum(mock_schema_dir: Any) -> None:
@@ -141,7 +142,7 @@ def test_schema_validator_prefers_registry_latest(monkeypatch: Any) -> Any:
     SchemaValidator._cache.clear()
 
     validator = SchemaValidator.for_provider("chatgpt")
-    assert "from_registry" in validator.schema["properties"]
+    assert "from_registry" in json_document(validator.schema["properties"])
 
 
 def test_dynamic_key_maps_do_not_emit_drift_warnings() -> None:

--- a/tests/unit/devtools/test_benchmark_campaign.py
+++ b/tests/unit/devtools/test_benchmark_campaign.py
@@ -9,6 +9,7 @@ from pytest import MonkeyPatch
 
 from devtools.benchmark_campaign import (
     BenchmarkStat,
+    BenchmarkStatRecord,
     CampaignResult,
     Regression,
     _compare_results,
@@ -30,6 +31,21 @@ from polylogue.scenarios import (
     ScenarioProjectionSourceKind,
     pytest_execution,
 )
+
+
+def _benchmark_record(fullname: str, mean: float) -> BenchmarkStatRecord:
+    return {
+        "name": fullname,
+        "fullname": fullname,
+        "group": "group",
+        "mean": mean,
+        "median": mean,
+        "minimum": mean,
+        "maximum": mean,
+        "stddev": 0.0,
+        "rounds": 1,
+        "ops": (1.0 / mean) if mean > 0 else None,
+    }
 
 
 def test_compare_results_orders_regressions_by_worst_delta() -> None:
@@ -63,7 +79,7 @@ def test_compare_artifacts_fails_when_threshold_is_exceeded(tmp_path: Path) -> N
         runtime_seconds=1.0,
         exit_code=0,
         machine_info={},
-        benchmarks=[{"fullname": "bench.a", "mean": 1.0}],
+        benchmarks=[_benchmark_record("bench.a", 1.0)],
         slowest=[],
         compare_to=None,
         warn_pct=10.0,
@@ -85,20 +101,7 @@ def test_compare_artifacts_fails_when_threshold_is_exceeded(tmp_path: Path) -> N
         runtime_seconds=1.0,
         exit_code=0,
         machine_info={},
-        benchmarks=[
-            {
-                "name": "bench.a",
-                "fullname": "bench.a",
-                "group": "group",
-                "mean": 1.5,
-                "median": 1.5,
-                "minimum": 1.4,
-                "maximum": 1.6,
-                "stddev": 0.05,
-                "rounds": 5,
-                "ops": 0.66,
-            }
-        ],
+        benchmarks=[_benchmark_record("bench.a", 1.5)],
         slowest=[],
         compare_to=None,
         warn_pct=10.0,


### PR DESCRIPTION
## Summary
- Remove the remaining explicit first-party `Any` typing from `polylogue/` and `devtools/` dynamic seam modules.
- Replace loose dynamic boundaries with protocol, typed-dict, JSON document, callable, and explicit cast contracts where runtime APIs are inherently dynamic.
- Tighten benchmark artifact rows, schema validation inputs, tree-sitter extraction, logging, click option decorators, runtime copy/update helpers, QA capture helpers, and facade console protocols.

## Problem
The mypy/refactor campaign had shrunk broad typing debt, but several boundary files still encoded dynamic behavior as explicit `Any`. That left strict checking less meaningful exactly at the seams where provider payloads, click decorators, rich progress IDs, benchmark JSON, schema documents, and logging adapters cross typed code.

Ref #281

## Solution
- Introduced typed artifact records for benchmark campaign output and narrowed JSON payload parsing through explicit numeric helpers.
- Reworked schema/devtools JSON handling to use `JSONDocument` constructors and validation helpers instead of unchecked dictionaries.
- Replaced loose CLI/runtime surface typing with `Callable[..., object]`, protocol-based logger/console contracts, type-only imports, and localized casts for third-party dynamic values.
- Updated tests to assert through the same typed JSON and benchmark artifact contracts.

## Verification
- `ruff format tests/unit/devtools/test_benchmark_campaign.py devtools/benchmark_campaign.py polylogue/cli/machine_main.py polylogue/cli/run_observers.py polylogue/schemas/validator.py tests/unit/core/test_schema_validation.py`
- `ruff check tests/unit/devtools/test_benchmark_campaign.py devtools/benchmark_campaign.py polylogue/cli/machine_main.py polylogue/cli/run_observers.py polylogue/schemas/validator.py tests/unit/core/test_schema_validation.py`
- `mypy tests/unit/core/test_schema_validation.py tests/unit/core/test_filters_schemas.py tests/unit/cli/test_run_laws.py tests/unit/cli/test_machine_main.py tests/unit/devtools/test_benchmark_campaign.py polylogue/schemas/validator.py polylogue/cli/machine_main.py polylogue/cli/run_observers.py devtools/benchmark_campaign.py`
- `pytest -q tests/unit/cli/test_machine_main.py tests/unit/cli/test_qa_requests.py tests/unit/cli/test_qa_finalization.py tests/unit/cli/test_run_laws.py tests/unit/core/test_schema_validation.py tests/unit/core/test_filters_schemas.py tests/unit/core/test_code_detection.py tests/unit/devtools/test_scenario_coverage.py tests/unit/devtools/test_artifact_graph.py tests/unit/devtools/test_benchmark_campaign.py tests/unit/core/test_config.py`
- `PATH=/tmp/polylogue-281/.cache/codex-bin:$PATH devtools verify --quick`
- `PATH=/tmp/polylogue-281/.cache/codex-bin:$PATH git push -u origin feature/refactor/dynamic-seam-contracts`
