### PR TITLE
refactor: promote schema relation and core test contracts

### DIFF
--- a/polylogue/cli/run_observers.py
+++ b/polylogue/cli/run_observers.py
@@ -14,6 +14,7 @@ from polylogue.pipeline.observers import RunObserver
 from polylogue.storage.run_state import RunResult
 
 if TYPE_CHECKING:
+    from rich.console import Console
     from rich.progress import Progress, TaskID
 
 _PROGRESS_FRACTION_RE = re.compile(r"(?P<completed>\d[\d,]*)/(?P<total>\d[\d,]*)")
@@ -152,7 +153,7 @@ def progress_observer(
         BarColumn(),
         TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
         TimeRemainingColumn(),
-        console=env.ui.console,  # type: ignore[arg-type]
+        console=cast("Console", env.ui.console),
         transient=True,
     ) as progress:
         task_id = progress.add_task(initial_desc, total=None)

--- a/polylogue/lib/messages.py
+++ b/polylogue/lib/messages.py
@@ -9,7 +9,7 @@ used in production.
 from __future__ import annotations
 
 from collections.abc import Iterator, Sized
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol, cast
 
 from pydantic import GetCoreSchemaHandler, GetJsonSchemaHandler
 from pydantic_core import core_schema
@@ -18,6 +18,11 @@ if TYPE_CHECKING:
     from pydantic.json_schema import JsonSchemaValue
 
     from polylogue.lib.message_models import Message
+
+    class _MessageJsonSchemaHandler(Protocol):
+        def generate(self, schema_type: type[Message]) -> JsonSchemaValue: ...
+
+        def resolve_ref_schema(self, maybe_ref_json_schema: JsonSchemaValue) -> JsonSchemaValue: ...
 
 
 class MessageCollection(Sized):
@@ -121,7 +126,8 @@ class MessageCollection(Sized):
         """JSON schema: array of Message objects."""
         from polylogue.lib.message_models import Message
 
-        return {"type": "array", "items": handler.resolve_ref_schema(handler.generate(Message))}  # type: ignore[attr-defined]
+        message_handler = cast("_MessageJsonSchemaHandler", handler)
+        return {"type": "array", "items": message_handler.resolve_ref_schema(message_handler.generate(Message))}
 
 
 __all__ = ["MessageCollection"]

--- a/polylogue/logging.py
+++ b/polylogue/logging.py
@@ -48,7 +48,7 @@ class _StderrProxy:
         return sys.stderr.fileno()
 
 
-_stderr_proxy: TextIO = _StderrProxy()  # type: ignore[assignment]
+_stderr_proxy = cast(TextIO, _StderrProxy())
 
 
 # Configure structlog

--- a/polylogue/schemas/field_stats_collection.py
+++ b/polylogue/schemas/field_stats_collection.py
@@ -164,7 +164,7 @@ def _collect_field_stats(
                 continue
             overlap = len(observed & keys)
             if overlap / len(observed) >= REF_MATCH_THRESHOLD:
-                stats._ref_target = dict_path  # type: ignore[attr-defined]
+                stats.ref_target = dict_path
 
     return all_stats
 

--- a/polylogue/schemas/field_stats_models.py
+++ b/polylogue/schemas/field_stats_models.py
@@ -35,6 +35,7 @@ class FieldStats:
     co_occurring_fields: Counter[str] = field(default_factory=Counter)
     object_key_counts: list[int] = field(default_factory=list)
     max_depth_seen: int = 0
+    ref_target: str | None = None
 
     @property
     def frequency(self) -> float:

--- a/polylogue/schemas/generation_field_annotations.py
+++ b/polylogue/schemas/generation_field_annotations.py
@@ -128,9 +128,8 @@ def annotate_schema(
         ):
             schema_node["x-polylogue-multiline"] = True
 
-        ref_target = getattr(field_stats, "_ref_target", None)
-        if ref_target:
-            schema_node["x-polylogue-ref"] = ref_target
+        if field_stats.ref_target:
+            schema_node["x-polylogue-ref"] = field_stats.ref_target
 
     properties = _schema_node(schema_node.get("properties"))
     if properties is not None:

--- a/polylogue/schemas/privacy_config.py
+++ b/polylogue/schemas/privacy_config.py
@@ -9,15 +9,16 @@ project-level → CLI flags.
 from __future__ import annotations
 
 import os
+import sys
 from dataclasses import dataclass, field
 from fnmatch import fnmatch
 from pathlib import Path
 from typing import Literal, TypeAlias
 
-try:
+if sys.version_info >= (3, 11):
     import tomllib
-except ModuleNotFoundError:  # Python <3.11
-    import tomli as tomllib  # type: ignore[no-redef]
+else:
+    import tomli as tomllib
 
 
 # ---------------------------------------------------------------------------

--- a/polylogue/schemas/relational_inference_foreign_keys.py
+++ b/polylogue/schemas/relational_inference_foreign_keys.py
@@ -13,12 +13,11 @@ def detect_foreign_keys(stats: dict[str, FieldStats]) -> list[ForeignKeyRelation
     results: list[ForeignKeyRelation] = []
 
     for path, field_stats in stats.items():
-        ref_target = getattr(field_stats, "_ref_target", None)
-        if ref_target:
+        if field_stats.ref_target:
             results.append(
                 ForeignKeyRelation(
                     source_path=path,
-                    target_path=ref_target,
+                    target_path=field_stats.ref_target,
                     match_ratio=1.0,
                     evidence={"source": "field_stats_ref_detection"},
                 )
@@ -40,7 +39,7 @@ def detect_foreign_keys(stats: dict[str, FieldStats]) -> list[ForeignKeyRelation
             "source_id",
         }:
             continue
-        if getattr(field_stats, "_ref_target", None):
+        if field_stats.ref_target:
             continue
 
         observed = set(field_stats.observed_values.keys())

--- a/tests/unit/core/test_config.py
+++ b/tests/unit/core/test_config.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 import sys
 from io import StringIO
 from pathlib import Path
-from typing import Any
 
 import pytest
 
@@ -20,7 +19,7 @@ from polylogue.paths import DriveConfig, IndexConfig, Source
 class TestConfig:
     """Tests for Config dataclass."""
 
-    def test_config_basic_construction(self, tmp_path: Any) -> None:
+    def test_config_basic_construction(self, tmp_path: Path) -> None:
         """Config can be constructed with required fields."""
         config = Config(
             archive_root=tmp_path / "archive",
@@ -31,7 +30,7 @@ class TestConfig:
         assert config.render_root == tmp_path / "render"
         assert config.sources == []
 
-    def test_config_with_sources(self, tmp_path: Any) -> None:
+    def test_config_with_sources(self, tmp_path: Path) -> None:
         """Config stores source list."""
         sources = [
             Source(name="inbox", path=tmp_path / "inbox"),
@@ -46,7 +45,7 @@ class TestConfig:
         assert config.sources[0].name == "inbox"
         assert config.sources[1].name == "claude-code"
 
-    def test_config_db_path_property(self, workspace_env: Any) -> None:
+    def test_config_db_path_property(self, workspace_env: dict[str, Path]) -> None:
         """db_path property returns paths.DB_PATH."""
         config = Config(
             archive_root=Path(workspace_env["archive_root"]),
@@ -56,7 +55,7 @@ class TestConfig:
         assert config.db_path.name == "polylogue.db"
         assert "polylogue" in str(config.db_path)
 
-    def test_config_optional_fields_default_none(self, tmp_path: Any) -> None:
+    def test_config_optional_fields_default_none(self, tmp_path: Path) -> None:
         """Optional fields default to None."""
         config = Config(
             archive_root=tmp_path,
@@ -90,7 +89,7 @@ class TestConfigError:
 class TestSource:
     """Tests for Source dataclass validation."""
 
-    def test_source_with_path(self, tmp_path: Any) -> None:
+    def test_source_with_path(self, tmp_path: Path) -> None:
         """Source with path is valid."""
         src = Source(name="test", path=tmp_path)
         assert src.name == "test"
@@ -158,14 +157,14 @@ class TestDriveConfig:
 class TestIndexConfig:
     """Tests for IndexConfig from environment."""
 
-    def test_from_env_defaults(self, monkeypatch: Any) -> None:
+    def test_from_env_defaults(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Default IndexConfig has FTS enabled and no vector provider configured."""
         monkeypatch.delenv("VOYAGE_API_KEY", raising=False)
         config = IndexConfig.from_env()
         assert config.fts_enabled is True
         assert config.voyage_api_key is None
 
-    def test_from_env_voyage_key(self, monkeypatch: Any) -> None:
+    def test_from_env_voyage_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """VOYAGE_API_KEY is used for embeddings."""
         monkeypatch.setenv("VOYAGE_API_KEY", "voyage-key")
         config = IndexConfig.from_env()
@@ -175,7 +174,7 @@ class TestIndexConfig:
 class TestXDGPaths:
     """Tests for XDG path resolution."""
 
-    def test_xdg_data_home_respected(self, monkeypatch: Any) -> None:
+    def test_xdg_data_home_respected(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """XDG_DATA_HOME env var overrides default."""
         monkeypatch.setenv("XDG_DATA_HOME", "/custom/data")
 
@@ -185,7 +184,7 @@ class TestXDGPaths:
 
         monkeypatch.delenv("XDG_DATA_HOME", raising=False)
 
-    def test_db_path_under_data_home(self, workspace_env: Any) -> None:
+    def test_db_path_under_data_home(self, workspace_env: dict[str, Path]) -> None:
         """DB_PATH is under XDG_DATA_HOME/polylogue/."""
         import polylogue.paths
 
@@ -194,7 +193,11 @@ class TestXDGPaths:
 
 
 class TestConfiguredSources:
-    def test_get_sources_skips_drive_source_without_cache_or_credentials(self, monkeypatch: Any, tmp_path: Any) -> None:
+    def test_get_sources_skips_drive_source_without_cache_or_credentials(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
         monkeypatch.setenv("HOME", str(tmp_path / "home"))
         monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
         monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "state"))
@@ -205,7 +208,11 @@ class TestConfiguredSources:
         sources = get_sources()
         assert [source.name for source in sources] == ["inbox"]
 
-    def test_get_sources_includes_drive_source_when_credentials_exist(self, monkeypatch: Any, tmp_path: Any) -> None:
+    def test_get_sources_includes_drive_source_when_credentials_exist(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
         home = tmp_path / "home"
         data = tmp_path / "data"
         state = tmp_path / "state"
@@ -235,7 +242,7 @@ class TestConfiguredSources:
 
 
 class TestRuntimeServices:
-    def test_repository_is_cached_per_runtime_scope(self, workspace_env: Any) -> None:
+    def test_repository_is_cached_per_runtime_scope(self, workspace_env: dict[str, Path]) -> None:
         from polylogue.services import build_runtime_services
 
         services = build_runtime_services()
@@ -243,7 +250,7 @@ class TestRuntimeServices:
         repo2 = services.get_repository()
         assert repo1 is repo2
 
-    def test_backend_is_cached_per_runtime_scope(self, workspace_env: Any) -> None:
+    def test_backend_is_cached_per_runtime_scope(self, workspace_env: dict[str, Path]) -> None:
         from polylogue.services import build_runtime_services
 
         services = build_runtime_services()
@@ -251,14 +258,14 @@ class TestRuntimeServices:
         backend2 = services.get_backend()
         assert backend1 is backend2
 
-    def test_repository_uses_runtime_backend(self, workspace_env: Any) -> None:
+    def test_repository_uses_runtime_backend(self, workspace_env: dict[str, Path]) -> None:
         from polylogue.services import build_runtime_services
 
         services = build_runtime_services()
         repo = services.get_repository()
         assert repo.backend is services.get_backend()
 
-    def test_distinct_runtime_scopes_do_not_share_instances(self, workspace_env: Any) -> None:
+    def test_distinct_runtime_scopes_do_not_share_instances(self, workspace_env: dict[str, Path]) -> None:
         from polylogue.services import build_runtime_services
 
         services1 = build_runtime_services()

--- a/tests/unit/core/test_field_stats.py
+++ b/tests/unit/core/test_field_stats.py
@@ -7,12 +7,12 @@ properties, and _collect_field_stats() sample collection.
 from __future__ import annotations
 
 from collections import Counter
-from typing import Any
 
 import pytest
 from hypothesis import given, settings
 from hypothesis import strategies as st
 
+from polylogue.lib.json import JSONDocument
 from polylogue.schemas.field_stats import (
     FieldStats,
     _collect_field_stats,
@@ -250,7 +250,7 @@ class TestFieldStatsProperties:
 
 class TestCollectFieldStats:
     def test_discovers_all_top_level_keys(self) -> None:
-        samples: list[dict[str, Any]] = [
+        samples: list[JSONDocument] = [
             {"a": 1, "b": "hello"},
             {"b": "world", "c": True},
             {"a": 2, "c": False, "d": None},
@@ -267,27 +267,27 @@ class TestCollectFieldStats:
             assert s.total_samples == 5
 
     def test_present_count_tracks_non_null(self) -> None:
-        samples: list[dict[str, Any]] = [{"x": 1}, {"x": None}, {"x": 3}]
+        samples: list[JSONDocument] = [{"x": 1}, {"x": None}, {"x": 3}]
         stats = _collect_field_stats(samples)
         assert stats["$.x"].present_count == 2
 
     def test_nested_fields_discovered(self) -> None:
-        samples: list[dict[str, Any]] = [{"outer": {"inner": "value"}}]
+        samples: list[JSONDocument] = [{"outer": {"inner": "value"}}]
         stats = _collect_field_stats(samples)
         assert "$.outer.inner" in stats
 
     def test_array_items_use_wildcard_path(self) -> None:
-        samples: list[dict[str, Any]] = [{"items": [1, 2, 3]}]
+        samples: list[JSONDocument] = [{"items": [1, 2, 3]}]
         stats = _collect_field_stats(samples)
         assert "$.items[*]" in stats
 
     def test_dynamic_keys_use_wildcard(self) -> None:
-        samples: list[dict[str, Any]] = [{"mapping": {"550e8400-e29b-41d4-a716-446655440000": {"v": 1}}}]
+        samples: list[JSONDocument] = [{"mapping": {"550e8400-e29b-41d4-a716-446655440000": {"v": 1}}}]
         stats = _collect_field_stats(samples)
         assert "$.mapping.*" in stats
 
     def test_conversation_ids_tracked(self) -> None:
-        samples: list[dict[str, Any]] = [{"status": "active"}, {"status": "active"}, {"status": "pending"}]
+        samples: list[JSONDocument] = [{"status": "active"}, {"status": "active"}, {"status": "pending"}]
         conv_ids: list[str | None] = ["conv1", "conv1", "conv2"]
         stats = _collect_field_stats(samples, conversation_ids=conv_ids)
         status_stats = stats["$.status"]

--- a/tests/unit/core/test_json.py
+++ b/tests/unit/core/test_json.py
@@ -10,8 +10,9 @@ example tests.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from decimal import Decimal
-from typing import Any, Literal
+from typing import Literal
 
 import orjson
 import pytest
@@ -61,7 +62,7 @@ def _loaded_document(payload: str | bytes) -> core_json.JSONDocument:
 
 @given(_json_value)
 def test_json_roundtrip_basic_types(value: object) -> None:
-    """Any JSON-serializable value survives a dumps/loads roundtrip."""
+    """Every JSON-serializable value survives a dumps/loads roundtrip."""
     output = core_json.dumps(value)
     result = core_json.loads(output)
     assert result == value
@@ -167,14 +168,14 @@ def test_provider_from_string_idempotent(value: str) -> None:
 # =============================================================================
 
 
-def test_dumps_custom_type_default_handler() -> Any:
+def test_dumps_custom_type_default_handler() -> None:
     """Custom default handler serializes custom types."""
 
     class CustomType:
-        def __init__(self: Any, value: Any) -> None:
+        def __init__(self, value: object) -> None:
             self.value = value
 
-    def custom_handler(obj: Any) -> Any:
+    def custom_handler(obj: object) -> object:
         if isinstance(obj, CustomType):
             return {"custom": obj.value}
         raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")
@@ -188,7 +189,7 @@ def test_dumps_custom_type_default_handler() -> Any:
 def test_dumps_custom_fallback_to_encoder() -> None:
     """When custom handler raises, built-in encoder handles known types like Decimal."""
 
-    def custom_handler(obj: Any) -> Any:
+    def custom_handler(obj: object) -> object:
         raise TypeError("Not handled")
 
     payload = {"decimal": Decimal("1.5")}
@@ -197,10 +198,10 @@ def test_dumps_custom_fallback_to_encoder() -> None:
     assert data["decimal"] == 1.5
 
 
-def test_dumps_custom_handler_takes_precedence_for_decimal() -> Any:
+def test_dumps_custom_handler_takes_precedence_for_decimal() -> None:
     """Custom handlers can override Decimal serialization instead of falling through."""
 
-    def custom_handler(obj: Any) -> Any:
+    def custom_handler(obj: object) -> object:
         if isinstance(obj, Decimal):
             return f"decimal:{obj}"
         raise TypeError("Not handled")
@@ -213,7 +214,7 @@ def test_dumps_custom_handler_takes_precedence_for_decimal() -> Any:
 def test_dumps_preserves_non_type_errors_from_custom_handler() -> None:
     """Only TypeError falls through to built-in encoding."""
 
-    def custom_handler(obj: Any) -> Any:
+    def custom_handler(obj: object) -> object:
         raise ValueError("boom")
 
     with pytest.raises(ValueError, match="boom"):
@@ -238,14 +239,14 @@ def test_dumps_bytes_roundtrips_as_utf8_json() -> None:
     assert core_json.loads(output) == {"a": 2.5, "b": 1}
 
 
-def test_dumps_fallback_uses_stdlib_encoder_when_orjson_option_rejects_object() -> Any:
+def test_dumps_fallback_uses_stdlib_encoder_when_orjson_option_rejects_object() -> None:
     """The stdlib fallback still uses the combined encoder contract."""
 
     class CustomType:
-        def __init__(self: Any, value: int) -> None:
+        def __init__(self, value: int) -> None:
             self.value = value
 
-    def custom_handler(obj: Any) -> Any:
+    def custom_handler(obj: object) -> object:
         if isinstance(obj, CustomType):
             return {"custom": obj.value}
         raise TypeError("Not handled")
@@ -259,14 +260,14 @@ def test_dumps_fallback_uses_stdlib_encoder_when_orjson_option_rejects_object() 
     assert data == {"payload": {"custom": 7}}
 
 
-def test_dumps_bytes_fallback_uses_stdlib_encoder_when_orjson_option_rejects_object() -> Any:
+def test_dumps_bytes_fallback_uses_stdlib_encoder_when_orjson_option_rejects_object() -> None:
     """dumps_bytes preserves the same semantic encoder contract as dumps."""
 
     class CustomType:
-        def __init__(self: Any, value: int) -> None:
+        def __init__(self, value: int) -> None:
             self.value = value
 
-    def custom_handler(obj: Any) -> Any:
+    def custom_handler(obj: object) -> object:
         if isinstance(obj, CustomType):
             return {"custom": obj.value}
         raise TypeError("Not handled")
@@ -296,7 +297,7 @@ def test_encoder_unhandled_type_raises_type_error() -> None:
     class UnhandledType:
         pass
 
-    def custom_handler(obj: Any) -> Any:
+    def custom_handler(obj: object) -> object:
         raise TypeError("Not handled by custom handler")
 
     obj = UnhandledType()
@@ -304,10 +305,10 @@ def test_encoder_unhandled_type_raises_type_error() -> None:
         core_json.dumps(obj, default=custom_handler)
 
 
-def test_encoder_decimal_serialized_when_custom_fails() -> Any:
+def test_encoder_decimal_serialized_when_custom_fails() -> None:
     """Built-in encoder handles Decimal even when custom handler raises for other types."""
 
-    def custom_handler(obj: Any) -> Any:
+    def custom_handler(obj: object) -> object:
         if isinstance(obj, str):
             return obj.upper()
         raise TypeError("Not handled")
@@ -326,11 +327,12 @@ def test_encoder_decimal_serialized_when_custom_fails() -> Any:
 # All NewType string wrappers share identical runtime behavior
 NEWTYPE_WRAPPERS = [ConversationId, MessageId, AttachmentId, ContentHash]
 NEWTYPE_IDS = ["ConversationId", "MessageId", "AttachmentId", "ContentHash"]
+IdWrapper = Callable[[str], str]
 
 
 @pytest.mark.parametrize("wrapper", NEWTYPE_WRAPPERS, ids=NEWTYPE_IDS)
 @given(st.text())
-def test_newtype_preserves_string_semantics(wrapper: Any, text: str) -> None:
+def test_newtype_preserves_string_semantics(wrapper: IdWrapper, text: str) -> None:
     """NewType wrappers are str at runtime - all string operations work."""
     wrapped = wrapper(text)
 
@@ -346,7 +348,7 @@ def test_newtype_preserves_string_semantics(wrapper: Any, text: str) -> None:
 
 @pytest.mark.parametrize("wrapper", NEWTYPE_WRAPPERS, ids=NEWTYPE_IDS)
 @given(st.text(), st.text())
-def test_newtype_equality_reflects_string(wrapper: Any, a: str, b: str) -> None:
+def test_newtype_equality_reflects_string(wrapper: IdWrapper, a: str, b: str) -> None:
     """Equality between wrapped values reflects underlying string equality."""
     wrapped_a = wrapper(a)
     wrapped_b = wrapper(b)
@@ -357,7 +359,7 @@ def test_newtype_equality_reflects_string(wrapper: Any, a: str, b: str) -> None:
 
 @pytest.mark.parametrize("wrapper", NEWTYPE_WRAPPERS, ids=NEWTYPE_IDS)
 @given(st.text())
-def test_newtype_hashable_as_string(wrapper: Any, text: str) -> None:
+def test_newtype_hashable_as_string(wrapper: IdWrapper, text: str) -> None:
     """NewType values hash identically to their underlying string."""
     wrapped = wrapper(text)
 
@@ -374,7 +376,7 @@ def test_newtype_hashable_as_string(wrapper: Any, text: str) -> None:
 
 @pytest.mark.parametrize("wrapper", NEWTYPE_WRAPPERS, ids=NEWTYPE_IDS)
 @given(st.lists(st.text(), min_size=0, max_size=20))
-def test_newtype_set_deduplication(wrapper: Any, texts: list[str]) -> None:
+def test_newtype_set_deduplication(wrapper: IdWrapper, texts: list[str]) -> None:
     """Set deduplication works correctly with NewType values."""
     wrapped_values = [wrapper(t) for t in texts]
     wrapped_set = set(wrapped_values)
@@ -435,13 +437,13 @@ def test_provider_from_string_unknown_fallback(value: str) -> None:
 
 
 @pytest.mark.parametrize("empty_value", [None, "", "   ", "\t\n"])
-def test_provider_from_string_empty_returns_unknown(empty_value: Any) -> None:
+def test_provider_from_string_empty_returns_unknown(empty_value: str | None) -> None:
     """Empty/None values return UNKNOWN."""
     assert Provider.from_string(empty_value) == Provider.UNKNOWN
 
 
 @given(st.data())
-def test_all_id_types_as_dict_keys(data: Any) -> None:
+def test_all_id_types_as_dict_keys(data: st.DataObject) -> None:
     """All ID types work together as dict keys."""
     conv_str = data.draw(st.text(min_size=1, max_size=50), label="conv_str")
     msg_str = data.draw(st.text(min_size=1, max_size=50), label="msg_str")

--- a/tests/unit/core/test_privacy_config.py
+++ b/tests/unit/core/test_privacy_config.py
@@ -6,27 +6,29 @@ value allow/deny patterns, and TOML config loading.
 
 from __future__ import annotations
 
-from typing import Any
+from pathlib import Path
+
+import pytest
 
 from polylogue.schemas.privacy_config import PrivacyConfig, load_privacy_config
 
 
 class TestPrivacyConfigPresets:
-    def test_strict_preset_values(self: Any) -> None:
+    def test_strict_preset_values(self) -> None:
         config = PrivacyConfig(level="strict")
         assert config.safe_enum_max_length == 30
         assert config.high_entropy_min_length == 8
         assert config.cross_conv_min_count == 5
         assert config.cross_conv_proportional is True
 
-    def test_standard_preset_values(self: Any) -> None:
+    def test_standard_preset_values(self) -> None:
         config = PrivacyConfig(level="standard")
         assert config.safe_enum_max_length == 50
         assert config.high_entropy_min_length == 10
         assert config.cross_conv_min_count == 3
         assert config.cross_conv_proportional is False
 
-    def test_permissive_preset_values(self: Any) -> None:
+    def test_permissive_preset_values(self) -> None:
         config = PrivacyConfig(level="permissive")
         assert config.safe_enum_max_length == 80
         assert config.high_entropy_min_length == 16
@@ -34,39 +36,39 @@ class TestPrivacyConfigPresets:
 
 
 class TestEffectiveCrossConvThreshold:
-    def test_proportional_mode(self: Any) -> None:
+    def test_proportional_mode(self) -> None:
         config = PrivacyConfig(level="strict")  # proportional=True
         # max(3, int(1000 * 0.02)) = max(3, 20) = 20
         assert config.effective_cross_conv_threshold(1000) == 20
 
-    def test_proportional_mode_small_corpus(self: Any) -> None:
+    def test_proportional_mode_small_corpus(self) -> None:
         config = PrivacyConfig(level="strict")
         # max(3, int(50 * 0.02)) = max(3, 1) = 3
         assert config.effective_cross_conv_threshold(50) == 3
 
-    def test_fixed_mode(self: Any) -> None:
+    def test_fixed_mode(self) -> None:
         config = PrivacyConfig(level="standard")  # proportional=False
         assert config.effective_cross_conv_threshold(1000) == 3
         assert config.effective_cross_conv_threshold(50) == 3
 
 
 class TestFieldOverride:
-    def test_glob_matching(self: Any) -> None:
+    def test_glob_matching(self) -> None:
         config = PrivacyConfig(field_overrides={"$.mapping.*": "allow"})
         assert config.field_override("$.mapping.abc") == "allow"
         assert config.field_override("$.other") is None
 
-    def test_deny_override(self: Any) -> None:
+    def test_deny_override(self) -> None:
         config = PrivacyConfig(field_overrides={"$.secret*": "deny"})
         assert config.field_override("$.secret_key") == "deny"
 
-    def test_no_overrides(self: Any) -> None:
+    def test_no_overrides(self) -> None:
         config = PrivacyConfig()
         assert config.field_override("$.anything") is None
 
 
 class TestValueAllowDeny:
-    def test_deny_beats_allow(self: Any) -> None:
+    def test_deny_beats_allow(self) -> None:
         config = PrivacyConfig(
             deny_value_patterns=["secret*"],
             allow_value_patterns=["secret_public"],
@@ -74,15 +76,15 @@ class TestValueAllowDeny:
         # Deny is checked first, so "secret_public" is denied
         assert config.is_value_allowed("secret_public") is False
 
-    def test_allow_pattern(self: Any) -> None:
+    def test_allow_pattern(self) -> None:
         config = PrivacyConfig(allow_value_patterns=["safe_*"])
         assert config.is_value_allowed("safe_value") is True
 
-    def test_deny_pattern(self: Any) -> None:
+    def test_deny_pattern(self) -> None:
         config = PrivacyConfig(deny_value_patterns=["bad_*"])
         assert config.is_value_allowed("bad_token") is False
 
-    def test_no_match_returns_none(self: Any) -> None:
+    def test_no_match_returns_none(self) -> None:
         config = PrivacyConfig(
             deny_value_patterns=["bad_*"],
             allow_value_patterns=["good_*"],
@@ -91,7 +93,7 @@ class TestValueAllowDeny:
 
 
 class TestLoadPrivacyConfig:
-    def test_cli_overrides_take_effect(self: Any) -> None:
+    def test_cli_overrides_take_effect(self) -> None:
         config = load_privacy_config(
             cli_overrides={"level": "strict", "safe_enum_max_length": 100},
             project_path=None,
@@ -99,14 +101,14 @@ class TestLoadPrivacyConfig:
         # CLI override should win
         assert config.safe_enum_max_length == 100
 
-    def test_toml_cascade(self: Any, tmp_path: Any) -> None:
+    def test_toml_cascade(self, tmp_path: Path) -> None:
         toml_path = tmp_path / "polylogue-schemas.toml"
         toml_path.write_text('[schema.privacy]\nlevel = "permissive"\nsafe_enum_max_length = 99\n')
         config = load_privacy_config(project_path=tmp_path)
         assert config.level == "permissive"
         assert config.safe_enum_max_length == 99
 
-    def test_field_overrides_merge(self: Any, tmp_path: Any) -> None:
+    def test_field_overrides_merge(self, tmp_path: Path) -> None:
         toml_path = tmp_path / "polylogue-schemas.toml"
         toml_path.write_text('[schema.privacy]\n[schema.privacy.field_overrides]\n"$.a" = "allow"\n')
         config = load_privacy_config(
@@ -115,7 +117,7 @@ class TestLoadPrivacyConfig:
         )
         assert config.field_overrides == {"$.a": "allow", "$.b": "deny"}
 
-    def test_default_with_no_files(self: Any, tmp_path: Any, monkeypatch: Any) -> None:
+    def test_default_with_no_files(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "nonexistent"))
         config = load_privacy_config(project_path=tmp_path)
         assert config.level == "standard"

--- a/tests/unit/core/test_schema_annotation_contracts.py
+++ b/tests/unit/core/test_schema_annotation_contracts.py
@@ -133,8 +133,8 @@ class TestAnnotateSemanticAndRelational:
                 value_count=10,
             ),
         }
-        # Set up FK detection
-        field_stats["$.user_id"]._ref_target = "$.users"  # type: ignore
+        # Set up FK detection.
+        field_stats["$.user_id"].ref_target = "$.users"
         result_schema = _annotate_semantic_and_relational(schema, field_stats)
 
         # Check if FK annotations are present when relations exist

--- a/tests/unit/core/test_schema_annotation_contracts.py
+++ b/tests/unit/core/test_schema_annotation_contracts.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 from collections import Counter
 from collections.abc import Mapping
-from typing import Any
 
 import pytest
 
@@ -637,11 +636,11 @@ def _load_schema(provider: str) -> JSONDocument | None:
 def _find_annotations(
     schema: Mapping[str, object],
     prefix: str = "x-polylogue-",
-) -> dict[str, list[tuple[str, Any]]]:
+) -> dict[str, list[tuple[str, object]]]:
     """Walk the schema tree and collect all x-polylogue-* annotations by key."""
-    result: dict[str, list[tuple[str, Any]]] = {}
+    result: dict[str, list[tuple[str, object]]] = {}
 
-    def _walk(obj: Any, path: str) -> None:
+    def _walk(obj: object, path: str) -> None:
         if not isinstance(obj, Mapping):
             return
         for key, value in obj.items():
@@ -779,7 +778,8 @@ class TestSchemaAnnotations:
             pytest.skip(f"{provider} schema not available")
 
         for path, frequency in _find_annotations(schema).get("x-polylogue-frequency", []):
-            assert 0.0 < frequency < 1.0, f"{provider} {path}: frequency {frequency} not in (0, 1)"
+            assert not isinstance(frequency, bool) and isinstance(frequency, (int, float))
+            assert 0.0 < float(frequency) < 1.0, f"{provider} {path}: frequency {frequency} not in (0, 1)"
 
     @pytest.mark.parametrize("provider", ["chatgpt", "claude-code", "claude-ai", "codex"])
     def test_numeric_ranges_plausible(self, provider: str) -> None:

--- a/tests/unit/core/test_schema_relational_inference.py
+++ b/tests/unit/core/test_schema_relational_inference.py
@@ -112,8 +112,8 @@ class TestInferRelations:
 class TestDetectForeignKeys:
     """_detect_foreign_keys() identifies reference relationships."""
 
-    def test_ref_target_attribute_detected(self) -> None:
-        """Fields with _ref_target set by field_stats are recognized."""
+    def test_ref_target_detected(self) -> None:
+        """Fields with ref_target set by field_stats are recognized."""
         stats = {
             "$.user_id": FieldStats(
                 path="$.user_id",
@@ -123,8 +123,8 @@ class TestDetectForeignKeys:
                 value_count=20,
             ),
         }
-        # Manually set the _ref_target (as field_stats would)
-        stats["$.user_id"]._ref_target = "$.users"  # type: ignore
+        # Manually set the relation target as field_stats would.
+        stats["$.user_id"].ref_target = "$.users"
         result = infer_relations(stats)
         assert len(result.foreign_keys) == 1
         fk = result.foreign_keys[0]
@@ -193,7 +193,7 @@ class TestDetectForeignKeys:
                 value_count=15,
             ),
         }
-        stats["$.ref"]._ref_target = "$.items"  # type: ignore
+        stats["$.ref"].ref_target = "$.items"
         result = infer_relations(stats)
         assert len(result.foreign_keys) > 0
         assert "source" in result.foreign_keys[0].evidence

--- a/tests/unit/core/test_schema_validation.py
+++ b/tests/unit/core/test_schema_validation.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+from contextlib import AbstractContextManager
 from datetime import datetime, timezone
 from functools import partial
-from typing import Any
+from pathlib import Path
+from typing import TYPE_CHECKING, Protocol
 from unittest.mock import patch
 
 import pytest
@@ -20,15 +22,28 @@ from polylogue.schemas.verification_requests import SchemaVerificationRequest
 from polylogue.storage.backends.connection import open_connection
 from polylogue.types import Provider
 
+if TYPE_CHECKING:
+    from polylogue.paths import Source
 
-def _patch_validator_registry(mock_schema_dir: Any) -> Any:
+
+class SyntheticSourceFactory(Protocol):
+    def __call__(
+        self,
+        provider: str,
+        count: int = ...,
+        messages_per_conversation: range = ...,
+        seed: int = ...,
+    ) -> Source: ...
+
+
+def _patch_validator_registry(mock_schema_dir: Path) -> AbstractContextManager[object]:
     return patch(
         "polylogue.schemas.validator.SchemaRegistry",
         partial(SchemaRegistry, storage_root=mock_schema_dir),
     )
 
 
-def test_schema_validator_loads_provider(mock_schema_dir: Any) -> None:
+def test_schema_validator_loads_provider(mock_schema_dir: Path) -> None:
     """SchemaValidator.for_provider loads the requested schema."""
     with _patch_validator_registry(mock_schema_dir):
         SchemaValidator._cache.clear()
@@ -39,7 +54,7 @@ def test_schema_validator_loads_provider(mock_schema_dir: Any) -> None:
             SchemaValidator.for_provider("nonexistent")
 
 
-def test_validate_valid_data(mock_schema_dir: Any) -> None:
+def test_validate_valid_data(mock_schema_dir: Path) -> None:
     """Valid payloads should pass with no errors or drift."""
     with _patch_validator_registry(mock_schema_dir):
         validator = SchemaValidator.for_provider("chatgpt")
@@ -50,7 +65,7 @@ def test_validate_valid_data(mock_schema_dir: Any) -> None:
     assert not result.drift_warnings
 
 
-def test_validate_detects_errors(mock_schema_dir: Any) -> None:
+def test_validate_detects_errors(mock_schema_dir: Path) -> None:
     """Validation should report required-field and type errors."""
     with _patch_validator_registry(mock_schema_dir):
         validator = SchemaValidator.for_provider("chatgpt")
@@ -64,7 +79,7 @@ def test_validate_detects_errors(mock_schema_dir: Any) -> None:
     assert any("123" in error for error in wrong_type.errors)
 
 
-def test_validate_detects_drift(mock_schema_dir: Any) -> None:
+def test_validate_detects_drift(mock_schema_dir: Path) -> None:
     """Strict mode should surface unexpected fields as drift."""
     with _patch_validator_registry(mock_schema_dir):
         validator = SchemaValidator.for_provider("codex", strict=True)
@@ -75,7 +90,7 @@ def test_validate_detects_drift(mock_schema_dir: Any) -> None:
     assert "extra" in result.drift_warnings[0]
 
 
-def test_schema_validator_loads_canonical_claude_ai_provider(mock_schema_dir: Any) -> None:
+def test_schema_validator_loads_canonical_claude_ai_provider(mock_schema_dir: Path) -> None:
     """Schema validation should use the canonical Claude AI provider token."""
     schema = {
         "type": "object",
@@ -93,7 +108,7 @@ def test_schema_validator_loads_canonical_claude_ai_provider(mock_schema_dir: An
     assert "uuid" in json_document(validator.schema["properties"])
 
 
-def test_schema_validator_accepts_provider_enum(mock_schema_dir: Any) -> None:
+def test_schema_validator_accepts_provider_enum(mock_schema_dir: Path) -> None:
     """Known provider enums should flow through validator lookup without string routing."""
     schema = {
         "type": "object",
@@ -124,7 +139,7 @@ def test_validation_samples_record_mode_skips_non_record_documents() -> None:
     assert validator.validation_samples({"version": 1, "entries": []}, max_samples=16) == []
 
 
-def test_schema_validator_prefers_registry_latest(monkeypatch: Any) -> Any:
+def test_schema_validator_prefers_registry_latest(monkeypatch: pytest.MonkeyPatch) -> None:
     """Latest registry schemas should override packaged fallback files."""
     fake_schema = {
         "type": "object",
@@ -133,7 +148,7 @@ def test_schema_validator_prefers_registry_latest(monkeypatch: Any) -> Any:
     }
 
     class _FakeRegistry:
-        def get_schema(self: Any, provider: str, version: str = "latest") -> Any:
+        def get_schema(self, provider: str, version: str = "latest") -> dict[str, object] | None:
             if provider == "chatgpt" and version == "latest":
                 return fake_schema
             return None
@@ -279,7 +294,7 @@ def test_looks_dynamic_key_matches_expected_identifier_patterns() -> None:
     assert not validator._looks_dynamic_key("message_text")
 
 
-def test_available_providers(mock_schema_dir: Any) -> None:
+def test_available_providers(mock_schema_dir: Path) -> None:
     """available_providers should reflect packaged schema files."""
     with _patch_validator_registry(mock_schema_dir):
         providers = SchemaValidator.available_providers()
@@ -289,7 +304,7 @@ def test_available_providers(mock_schema_dir: Any) -> None:
     assert "nonexistent" not in providers
 
 
-def test_validate_helper(mock_schema_dir: Any) -> None:
+def test_validate_helper(mock_schema_dir: Path) -> None:
     """validate_provider_export should delegate to SchemaValidator cleanly."""
     with _patch_validator_registry(mock_schema_dir):
         result = validate_provider_export({"id": "123"}, "chatgpt")
@@ -489,7 +504,11 @@ class TestSyntheticRoundTrip:
     """Synthetic data should remain parser-compatible for supported providers."""
 
     @pytest.mark.parametrize("provider", ["chatgpt", "claude-code", "claude-ai", "codex", "gemini"])
-    def test_synthetic_parses_successfully(self: Any, provider: str, synthetic_source: Any) -> None:
+    def test_synthetic_parses_successfully(
+        self,
+        provider: str,
+        synthetic_source: SyntheticSourceFactory,
+    ) -> None:
         from polylogue.sources import iter_source_conversations
 
         source = synthetic_source(provider, count=3, seed=42)
@@ -525,7 +544,7 @@ def test_validation_result_properties() -> None:
 
 def _insert_raw_record(
     *,
-    db_path: Any,
+    db_path: Path,
     raw_id: str,
     provider_name: str,
     payload_provider: str | None = None,
@@ -566,14 +585,17 @@ def _insert_raw_record(
     return actual_raw_id
 
 
-def test_verify_raw_corpus_reports_valid_synthetic_chatgpt(db_path: Any, monkeypatch: Any) -> Any:
+def test_verify_raw_corpus_reports_valid_synthetic_chatgpt(
+    db_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     class _AlwaysValidValidator:
         provider = "chatgpt"
 
-        def validation_samples(self: Any, payload: Any, max_samples: Any = 16) -> Any:
+        def validation_samples(self, payload: object, max_samples: int = 16) -> list[object]:
             return [payload] if isinstance(payload, dict) else []
 
-        def validate(self: Any, _sample: Any) -> Any:
+        def validate(self, _sample: object) -> ValidationResult:
             return ValidationResult(is_valid=True)
 
     monkeypatch.setattr(
@@ -612,7 +634,7 @@ def test_verify_raw_corpus_reports_valid_synthetic_chatgpt(db_path: Any, monkeyp
     assert stats.decode_errors == 0
 
 
-def test_verify_raw_corpus_counts_missing_schema_as_skipped(db_path: Any) -> None:
+def test_verify_raw_corpus_counts_missing_schema_as_skipped(db_path: Path) -> None:
     _insert_raw_record(
         db_path=db_path,
         raw_id="raw-inbox-1",
@@ -636,14 +658,17 @@ def test_verify_raw_corpus_counts_missing_schema_as_skipped(db_path: Any) -> Non
 
 
 @pytest.mark.slow
-def test_verify_raw_corpus_uses_persisted_payload_provider_for_filters(db_path: Any, monkeypatch: Any) -> Any:
+def test_verify_raw_corpus_uses_persisted_payload_provider_for_filters(
+    db_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     class _AlwaysValidValidator:
         provider = "chatgpt"
 
-        def validation_samples(self: Any, payload: Any, max_samples: Any = 16) -> Any:
+        def validation_samples(self, payload: object, max_samples: int = 16) -> list[object]:
             return [payload] if isinstance(payload, dict) else []
 
-        def validate(self: Any, _sample: Any) -> Any:
+        def validate(self, _sample: object) -> ValidationResult:
             return ValidationResult(is_valid=True)
 
     monkeypatch.setattr(
@@ -671,7 +696,7 @@ def test_verify_raw_corpus_uses_persisted_payload_provider_for_filters(db_path: 
     assert report.providers["chatgpt"].valid_records == 1
 
 
-def test_verify_raw_corpus_counts_malformed_jsonl_as_decode_error(db_path: Any) -> None:
+def test_verify_raw_corpus_counts_malformed_jsonl_as_decode_error(db_path: Path) -> None:
     raw_id = _insert_raw_record(
         db_path=db_path,
         raw_id="raw-codex-1",
@@ -709,7 +734,7 @@ def test_verify_raw_corpus_counts_malformed_jsonl_as_decode_error(db_path: Any) 
     assert row[3] is None
 
 
-def test_verify_raw_corpus_quarantine_malformed_updates_validation_state(db_path: Any) -> None:
+def test_verify_raw_corpus_quarantine_malformed_updates_validation_state(db_path: Path) -> None:
     raw_id = _insert_raw_record(
         db_path=db_path,
         raw_id="raw-codex-q1",
@@ -756,7 +781,7 @@ def test_verify_raw_corpus_quarantine_malformed_updates_validation_state(db_path
     assert isinstance(row[6], str) and "Malformed JSONL lines" in row[6]
 
 
-def test_verify_raw_corpus_quarantine_empty_payload_updates_validation_state(db_path: Any) -> None:
+def test_verify_raw_corpus_quarantine_empty_payload_updates_validation_state(db_path: Path) -> None:
     raw_id = _insert_raw_record(
         db_path=db_path,
         raw_id="raw-codex-empty",
@@ -801,14 +826,17 @@ def test_verify_raw_corpus_quarantine_empty_payload_updates_validation_state(db_
     assert isinstance(row[6], str) and "zero-length" in row[6]
 
 
-def test_verify_raw_corpus_honors_record_limit_and_offset(db_path: Any, monkeypatch: Any) -> Any:
+def test_verify_raw_corpus_honors_record_limit_and_offset(
+    db_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     class _AlwaysValidValidator:
         provider = "chatgpt"
 
-        def validation_samples(self: Any, payload: Any, max_samples: Any = 16) -> Any:
+        def validation_samples(self, payload: object, max_samples: int = 16) -> list[object]:
             return [payload] if isinstance(payload, dict) else []
 
-        def validate(self: Any, _sample: Any) -> Any:
+        def validate(self, _sample: object) -> ValidationResult:
             return ValidationResult(is_valid=True)
 
     monkeypatch.setattr(

--- a/tests/unit/core/test_version.py
+++ b/tests/unit/core/test_version.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import fields
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as importlib_metadata_version
 from pathlib import Path
-from typing import Any
 
 import pytest
 
@@ -121,7 +121,7 @@ def test_schema_root_does_not_export_tooling_registry_surfaces(name: str) -> Non
 
 
 class TestVersionInfo:
-    def test_version_only_and_repr(self: Any) -> None:
+    def test_version_only_and_repr(self) -> None:
         info = VersionInfo(version="1.0.0")
         assert str(info) == "1.0.0"
         assert info.full == "1.0.0"
@@ -131,7 +131,7 @@ class TestVersionInfo:
     @pytest.mark.parametrize(
         "commit,dirty,has_dirty_suffix", [("abc123def456", False, False), ("abc123def456", True, True)]
     )
-    def test_version_with_commit(self: Any, commit: str, dirty: bool, has_dirty_suffix: bool) -> None:
+    def test_version_with_commit(self, commit: str, dirty: bool, has_dirty_suffix: bool) -> None:
         info = VersionInfo(version="1.0.0", commit=commit, dirty=dirty)
         rendered = str(info)
         assert "1.0.0+" in rendered
@@ -139,20 +139,20 @@ class TestVersionInfo:
         assert ("-dirty" in rendered) is has_dirty_suffix
 
     @pytest.mark.parametrize("version,commit", [("2.5.3", "fedcba9876543210"), ("3.2.1", "deadbeef12345678")])
-    def test_version_properties(self: Any, version: str, commit: str) -> None:
+    def test_version_properties(self, version: str, commit: str) -> None:
         info = VersionInfo(version=version, commit=commit)
         assert str(info) == f"{version}+{commit[:8]}"
         assert info.full == f"{version}+{commit[:8]}"
         assert info.short == version
 
-    def test_version_dirty_without_commit_and_equality(self: Any) -> None:
+    def test_version_dirty_without_commit_and_equality(self) -> None:
         assert str(VersionInfo(version="1.0.0", dirty=True)) == "1.0.0"
         assert VersionInfo(version="1.0.0") == VersionInfo(version="1.0.0")
         assert {field.name for field in fields(VersionInfo)} == {"version", "commit", "dirty"}
 
 
 class TestGetGitInfo:
-    def test_valid_git_repo(self: Any) -> None:
+    def test_valid_git_repo(self) -> None:
         repo_root = Path(__file__).resolve().parents[3]
         if (repo_root / ".git").exists():
             commit, dirty = _get_git_info(repo_root)
@@ -161,15 +161,19 @@ class TestGetGitInfo:
             assert isinstance(dirty, bool)
 
     @pytest.mark.parametrize("path_factory", [lambda tmp_path: tmp_path / "nonexistent", lambda tmp_path: tmp_path])
-    def test_returns_none_for_missing_or_non_git_paths(self: Any, tmp_path: Any, path_factory: Any) -> None:
+    def test_returns_none_for_missing_or_non_git_paths(
+        self,
+        tmp_path: Path,
+        path_factory: Callable[[Path], Path],
+    ) -> None:
         commit, dirty = _get_git_info(path_factory(tmp_path))
         assert commit is None
         assert dirty is False
 
-    def test_timeout_returns_none(self: Any, tmp_path: Any, monkeypatch: Any) -> None:
+    def test_timeout_returns_none(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         import subprocess
 
-        def mock_run(*args: Any, **kwargs: Any) -> None:
+        def mock_run(*args: object, **kwargs: object) -> None:
             raise subprocess.TimeoutExpired("git", 2)
 
         monkeypatch.setattr(subprocess, "run", mock_run)
@@ -177,13 +181,17 @@ class TestGetGitInfo:
         assert commit is None
         assert dirty is False
 
-    def test_returns_tuple_and_dirty_is_bool(self: Any, tmp_path: Any) -> None:
+    def test_returns_tuple_and_dirty_is_bool(self, tmp_path: Path) -> None:
         result = _get_git_info(tmp_path)
         assert isinstance(result, tuple)
         assert len(result) == 2
         assert isinstance(result[1], bool)
 
-    def test_reads_head_commit_without_git_executable(self: Any, tmp_path: Any, monkeypatch: Any) -> None:
+    def test_reads_head_commit_without_git_executable(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
         git_dir = tmp_path / ".git"
         refs_dir = git_dir / "refs" / "heads"
         refs_dir.mkdir(parents=True)
@@ -191,7 +199,7 @@ class TestGetGitInfo:
         (git_dir / "HEAD").write_text("ref: refs/heads/main\n", encoding="utf-8")
         (refs_dir / "main").write_text(f"{commit}\n", encoding="utf-8")
 
-        def missing_git(*args: Any, **kwargs: Any) -> None:
+        def missing_git(*args: object, **kwargs: object) -> None:
             raise FileNotFoundError("git")
 
         monkeypatch.setattr("polylogue.version.subprocess.run", missing_git)
@@ -201,21 +209,21 @@ class TestGetGitInfo:
 
 
 class TestResolveVersion:
-    def test_returns_version_info_and_attributes(self: Any) -> None:
+    def test_returns_version_info_and_attributes(self) -> None:
         result = _resolve_version()
         assert isinstance(result, VersionInfo)
         assert result.version not in {"", "unknown"}
         assert isinstance(result.commit, str)
         assert isinstance(result.dirty, bool)
 
-    def test_resolve_version_consistency_and_fallback(self: Any, monkeypatch: Any) -> None:
+    def test_resolve_version_consistency_and_fallback(self, monkeypatch: pytest.MonkeyPatch) -> None:
         result1 = _resolve_version()
         result2 = _resolve_version()
         assert isinstance(result1, VersionInfo)
         assert isinstance(result2, VersionInfo)
         assert result1.version == result2.version
 
-        def mock_metadata_version(name: Any) -> None:
+        def mock_metadata_version(name: str) -> None:
             raise PackageNotFoundError(name)
 
         original = importlib_metadata_version
@@ -228,14 +236,22 @@ class TestResolveVersion:
         assert result.version is not None
         assert len(result.version) > 0
 
-    def test_source_checkout_requires_git_metadata(self: Any, tmp_path: Any, monkeypatch: Any) -> None:
+    def test_source_checkout_requires_git_metadata(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
         (tmp_path / ".git").mkdir()
         (tmp_path / "pyproject.toml").write_text('[project]\nversion = "1.2.3"\n', encoding="utf-8")
         monkeypatch.setattr(version_module, "_get_git_info", lambda _: (None, False))
         with pytest.raises(RuntimeError, match="source checkout is missing git commit metadata"):
             _resolve_version(tmp_path)
 
-    def test_built_artifact_uses_embedded_metadata(self: Any, tmp_path: Any, monkeypatch: Any) -> None:
+    def test_built_artifact_uses_embedded_metadata(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
         (tmp_path / "pyproject.toml").write_text('[project]\nversion = "1.2.3"\n', encoding="utf-8")
         monkeypatch.setattr(version_module, "_get_embedded_build_info", lambda: ("deadbeefdeadbeef", True))
         result = _resolve_version(tmp_path)
@@ -243,7 +259,11 @@ class TestResolveVersion:
         assert result.commit == "deadbeefdeadbeef"
         assert result.dirty is True
 
-    def test_built_artifact_requires_embedded_metadata(self: Any, tmp_path: Any, monkeypatch: Any) -> None:
+    def test_built_artifact_requires_embedded_metadata(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
         (tmp_path / "pyproject.toml").write_text('[project]\nversion = "1.2.3"\n', encoding="utf-8")
 
         def raise_missing_metadata() -> tuple[str, bool]:
@@ -255,7 +275,7 @@ class TestResolveVersion:
 
 
 class TestEmbeddedBuildInfo:
-    def test_unknown_build_commit_is_rejected(self: Any, monkeypatch: Any) -> None:
+    def test_unknown_build_commit_is_rejected(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delitem(__import__("sys").modules, "polylogue._build_info", raising=False)
 
         class BuildInfo:
@@ -268,7 +288,7 @@ class TestEmbeddedBuildInfo:
 
 
 class TestVersionConstants:
-    def test_all_version_exports(self: Any) -> None:
+    def test_all_version_exports(self) -> None:
         from polylogue import version
         from polylogue.version import POLYLOGUE_VERSION, VERSION_INFO
 


### PR DESCRIPTION
## Summary
- Promote schema relation targets from a dynamic `_ref_target` attribute into the typed `FieldStats.ref_target` contract.
- Replace several source-side `type: ignore` suppressions with explicit protocols, casts, or version-gated imports.
- Remove explicit `Any` from core config, privacy, schema validation, field stats, JSON, annotation, and version test files.

## Problem
The previous mypy cleanup removed the broad exclusion list and explicit first-party `Any` from source modules, but a few source suppressions still represented real internal concepts rather than unavoidable dynamic boundaries. Core tests also still had substantial fixture/callback `Any` usage, making the test suite less useful as documentation of the typed contracts it exercises.

Ref #281

## Solution
- Added `FieldStats.ref_target` and updated relation detection, annotation generation, and relation tests to use the typed field directly.
- Replaced source suppressions around Rich progress, structlog stderr proxying, Pydantic schema handler access, and TOML loading with explicit typed boundaries.
- Retained only the source suppressions that still reflect valid external/dynamic constraints: untyped `dateparser` and dataclass `replace` over the fluent query-plan builder.
- Typed core test fixtures and helpers with `Path`, `pytest.MonkeyPatch`, protocols, callable aliases, `JSONDocument`, and Hypothesis `DataObject`.

## Verification
- `pytest -q tests/unit/core/test_schema_relational_inference.py tests/unit/core/test_schema_annotation_contracts.py tests/unit/core/test_schema_generation.py tests/unit/core/test_schema_validation.py`
- `pytest -q tests/unit/core/test_privacy_config.py tests/unit/core/test_config.py tests/unit/core/test_schema_validation.py`
- `pytest -q tests/unit/core/test_json.py tests/unit/core/test_field_stats.py tests/unit/core/test_schema_annotation_contracts.py`
- `pytest -q tests/unit/core/test_version.py`
- `PATH=/tmp/polylogue-281/.cache/codex-bin:$PATH devtools verify --quick`
- `PATH=/tmp/polylogue-281/.cache/codex-bin:$PATH git push -u origin feature/refactor/source-test-contract-cleanup`
