### PR TITLE
test: type core verification and semantic contracts

### DIFF
--- a/tests/unit/core/test_conversation_semantics.py
+++ b/tests/unit/core/test_conversation_semantics.py
@@ -10,13 +10,13 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any
 
 import pytest
 
 from polylogue.lib.messages import MessageCollection
 from polylogue.lib.models import Attachment, Conversation, DialoguePair, Message
 from polylogue.lib.pricing import harmonize_session_cost
+from polylogue.lib.projections import ConversationProjection
 from tests.infra.assertions import assert_contains_all, assert_not_contains_any
 from tests.infra.builders import make_conv, make_msg
 
@@ -122,7 +122,7 @@ class TestDialoguePairContracts:
         ],
     )
     def test_dialogue_pair_role_contract(
-        self: Any,
+        self,
         user_role: str,
         assistant_role: str,
         should_pass: bool,
@@ -138,7 +138,7 @@ class TestDialoguePairContracts:
             with pytest.raises(ValueError, match=error):
                 DialoguePair(user=user, assistant=assistant)
 
-    def test_dialogue_pair_exchange_and_semantic_payload(self: Any) -> None:
+    def test_dialogue_pair_exchange_and_semantic_payload(self) -> None:
         pair = DialoguePair(
             user=make_msg(id="u1", role="user", text="Hard problem"),
             assistant=make_msg(
@@ -170,7 +170,7 @@ class TestMessageSemanticProjection:
         ids=["content_blocks", "multiple_blocks", "gemini", "chatgpt", "non_thinking"],
     )
     def test_extract_thinking_projection_contract(
-        self: Any,
+        self,
         provider_meta: dict[str, object] | None,
         text: str,
         expected: str | None,
@@ -189,7 +189,7 @@ class TestMessageSemanticProjection:
         ],
     )
     def test_message_metadata_projection_contract(
-        self: Any,
+        self,
         provider_meta: dict[str, object] | None,
         expected_cost: float | None,
         expected_duration: int | None,
@@ -198,7 +198,7 @@ class TestMessageSemanticProjection:
         assert msg.cost_usd == expected_cost
         assert msg.duration_ms == expected_duration
 
-    def test_message_attachments_and_classification_contract(self: Any) -> None:
+    def test_message_attachments_and_classification_contract(self) -> None:
         attachment = Attachment(
             id="att-1",
             name="doc.pdf",
@@ -226,7 +226,7 @@ class TestMessageSemanticProjection:
         assert thinking.is_thinking is True
         assert tool.is_tool_use is True
 
-    def test_context_wrappers_are_context_dumps(self: Any) -> None:
+    def test_context_wrappers_are_context_dumps(self) -> None:
         msg = make_msg(
             id="m1",
             role="user",
@@ -234,7 +234,7 @@ class TestMessageSemanticProjection:
         )
         assert msg.is_context_dump is True
 
-    def test_multiline_context_markers_are_context_dumps(self: Any) -> None:
+    def test_multiline_context_markers_are_context_dumps(self) -> None:
         contents_dump = make_msg(
             id="m2",
             role="user",
@@ -251,7 +251,7 @@ class TestMessageSemanticProjection:
 
 
 class TestConversationMetadataAndAggregation:
-    def test_title_summary_tags_and_display_contract(self: Any, conversation_with_metadata: Conversation) -> None:
+    def test_title_summary_tags_and_display_contract(self, conversation_with_metadata: Conversation) -> None:
         assert conversation_with_metadata.user_title is None
         assert conversation_with_metadata.display_title == "Complex Conversation"
         assert conversation_with_metadata.summary == "A test conversation"
@@ -267,7 +267,7 @@ class TestConversationMetadataAndAggregation:
         assert fallback.display_title == "abc123de"
         assert fallback.tags == []
 
-    def test_cost_duration_branch_and_equality_contract(self: Any, conversation_with_metadata: Conversation) -> None:
+    def test_cost_duration_branch_and_equality_contract(self, conversation_with_metadata: Conversation) -> None:
         assert conversation_with_metadata.total_cost_usd == 0.015
         assert conversation_with_metadata.total_duration_ms == 5500
 
@@ -289,7 +289,7 @@ class TestConversationMetadataAndAggregation:
         assert branched.assistant_message_count == 3
         assert conversation_with_metadata.model_copy() == conversation_with_metadata
 
-    def test_cost_duration_fall_back_to_conversation_provider_meta(self: Any) -> None:
+    def test_cost_duration_fall_back_to_conversation_provider_meta(self) -> None:
         conversation = make_conv(
             id="claude-code-session",
             provider="claude-code",
@@ -361,12 +361,12 @@ VIEW_CASES = [
 
 class TestConversationViewsAndIteration:
     @pytest.mark.parametrize("case", VIEW_CASES, ids=lambda case: case.name)
-    def test_view_projection_contract(self: Any, case: ViewCase) -> None:
+    def test_view_projection_contract(self, case: ViewCase) -> None:
         conversation = make_conv(id="c1", provider="test", messages=MessageCollection(messages=case.messages))
         projected = getattr(conversation, case.view)()
         assert tuple(message.id for message in projected.messages) == case.expected_ids
 
-    def test_iterators_share_projection_contract(self: Any, dialogue_noise_mix: Conversation) -> None:
+    def test_iterators_share_projection_contract(self, dialogue_noise_mix: Conversation) -> None:
         assert [message.id for message in dialogue_noise_mix.iter_dialogue()] == ["u1", "a1", "a2", "a3"]
         assert [message.id for message in dialogue_noise_mix.iter_substantive()] == ["u1", "a1"]
         assert list(dialogue_noise_mix.iter_thinking()) == ["Reasoning trace"]
@@ -403,14 +403,14 @@ class TestConversationViewsAndIteration:
         ids=["paired", "orphan_user", "out_of_order"],
     )
     def test_iter_pairs_contract(
-        self: Any,
+        self,
         messages: list[Message],
         expected_pairs: list[tuple[str, str]],
     ) -> None:
         conversation = make_conv(id="c1", provider="test", messages=MessageCollection(messages=messages))
         assert [(pair.user.id, pair.assistant.id) for pair in conversation.iter_pairs()] == expected_pairs
 
-    def test_iter_branches_contract(self: Any) -> None:
+    def test_iter_branches_contract(self) -> None:
         conversation = make_conv(
             id="c1",
             provider="claude-ai",
@@ -430,7 +430,7 @@ class TestConversationViewsAndIteration:
 
 
 class TestConversationProjectionContracts:
-    def test_projection_count_and_execute_contract(self: Any, projection_conversation: Conversation) -> None:
+    def test_projection_count_and_execute_contract(self, projection_conversation: Conversation) -> None:
         projection = projection_conversation.project()
         assert projection.count() == 4
         assert [message.id for message in projection.to_list()] == ["u1", "a1", "u2", "a2"]
@@ -448,9 +448,9 @@ class TestConversationProjectionContracts:
         ],
     )
     def test_projection_window_contract_matrix(
-        self: Any,
+        self,
         projection_conversation: Conversation,
-        projector: Callable[[Any], Any],
+        projector: Callable[[ConversationProjection], ConversationProjection],
         expected_ids: list[str],
     ) -> None:
         projection = projector(projection_conversation.project())
@@ -459,7 +459,7 @@ class TestConversationProjectionContracts:
 
 class TestConversationRendering:
     @pytest.fixture
-    def render_cases(self: Any) -> list[RenderCase]:
+    def render_cases(self) -> list[RenderCase]:
         unicode_conv = make_conv(
             id="unicode",
             provider="test",
@@ -546,12 +546,12 @@ class TestConversationRendering:
         ]
 
     @pytest.mark.parametrize("include_empty", [True, False])
-    def test_empty_conversation_rendering_contract(self: Any, include_empty: bool) -> None:
+    def test_empty_conversation_rendering_contract(self, include_empty: bool) -> None:
         conversation = make_conv(id="empty", provider="test", messages=MessageCollection(messages=[]))
         assert conversation.to_text() == ""
         assert conversation.to_clean_text() == ""
 
-    def test_render_contract_matrix(self: Any, render_cases: list[RenderCase]) -> None:
+    def test_render_contract_matrix(self, render_cases: list[RenderCase]) -> None:
         for case in render_cases:
             rendered = getattr(case.conversation, case.method)(**(case.kwargs or {}))
             assert_contains_all(rendered, *case.expected)

--- a/tests/unit/core/test_filter_composition_laws.py
+++ b/tests/unit/core/test_filter_composition_laws.py
@@ -7,7 +7,8 @@ properties of the filter DSL.
 
 from __future__ import annotations
 
-from typing import Any
+import sqlite3
+from pathlib import Path
 
 import pytest
 
@@ -15,7 +16,7 @@ from tests.infra.storage_records import ConversationBuilder, db_setup
 
 
 @pytest.fixture()
-def filterable_db(workspace_env: Any) -> Any:
+def filterable_db(workspace_env: dict[str, Path]) -> Path:
     """Create a rich DB with varied conversations for filter testing."""
     db_path = db_setup(workspace_env)
 
@@ -40,7 +41,7 @@ def filterable_db(workspace_env: Any) -> Any:
     return db_path
 
 
-def _query_ids(conn: Any, where_clause: str = "", params: tuple[object, ...] = ()) -> set[str]:
+def _query_ids(conn: sqlite3.Connection, where_clause: str = "", params: tuple[object, ...] = ()) -> set[str]:
     sql = "SELECT conversation_id FROM conversations"
     if where_clause:
         sql += f" WHERE {where_clause}"
@@ -50,7 +51,7 @@ def _query_ids(conn: Any, where_clause: str = "", params: tuple[object, ...] = (
 class TestFilterMonotonicity:
     """Adding a filter can only narrow or maintain the result set."""
 
-    def test_provider_filter_narrows(self: Any, filterable_db: Any) -> None:
+    def test_provider_filter_narrows(self, filterable_db: Path) -> None:
         from polylogue.storage.backends.connection import open_connection
 
         with open_connection(filterable_db) as conn:
@@ -60,7 +61,7 @@ class TestFilterMonotonicity:
             assert chatgpt_ids.issubset(all_ids)
             assert len(chatgpt_ids) < len(all_ids)
 
-    def test_combined_filters_narrow_further(self: Any, filterable_db: Any) -> None:
+    def test_combined_filters_narrow_further(self, filterable_db: Path) -> None:
         from polylogue.storage.backends.connection import open_connection
 
         with open_connection(filterable_db) as conn:
@@ -78,7 +79,7 @@ class TestFilterMonotonicity:
             assert chatgpt_with_stats.issubset(chatgpt_ids)
             assert chatgpt_ids.issubset(all_ids)
 
-    def test_empty_provider_returns_empty(self: Any, filterable_db: Any) -> None:
+    def test_empty_provider_returns_empty(self, filterable_db: Path) -> None:
         from polylogue.storage.backends.connection import open_connection
 
         with open_connection(filterable_db) as conn:
@@ -89,7 +90,7 @@ class TestFilterMonotonicity:
 class TestFilterCommutativity:
     """Independent filters commute — order of application doesn't matter."""
 
-    def test_provider_then_message_count_equals_reverse(self: Any, filterable_db: Any) -> None:
+    def test_provider_then_message_count_equals_reverse(self, filterable_db: Path) -> None:
         from polylogue.storage.backends.connection import open_connection
 
         with open_connection(filterable_db) as conn:
@@ -114,7 +115,7 @@ class TestFilterCommutativity:
 class TestFilterIdempotence:
     """Applying the same filter twice yields the same result."""
 
-    def test_double_provider_filter_is_idempotent(self: Any, filterable_db: Any) -> None:
+    def test_double_provider_filter_is_idempotent(self, filterable_db: Path) -> None:
         from polylogue.storage.backends.connection import open_connection
 
         with open_connection(filterable_db) as conn:
@@ -126,7 +127,7 @@ class TestFilterIdempotence:
 class TestFilterPartition:
     """Provider filters partition the conversation space."""
 
-    def test_providers_partition_total(self: Any, filterable_db: Any) -> None:
+    def test_providers_partition_total(self, filterable_db: Path) -> None:
         from polylogue.storage.backends.connection import open_connection
 
         with open_connection(filterable_db) as conn:
@@ -139,7 +140,7 @@ class TestFilterPartition:
 
             assert union == all_ids
 
-    def test_provider_partitions_are_disjoint(self: Any, filterable_db: Any) -> None:
+    def test_provider_partitions_are_disjoint(self, filterable_db: Path) -> None:
         from polylogue.storage.backends.connection import open_connection
 
         with open_connection(filterable_db) as conn:

--- a/tests/unit/core/test_filters_schemas.py
+++ b/tests/unit/core/test_filters_schemas.py
@@ -8,7 +8,7 @@ filter logic.
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Any, Literal, TypeAlias
+from typing import Literal, TypeAlias, cast
 from unittest.mock import patch
 
 import pytest
@@ -38,10 +38,9 @@ from polylogue.schemas.validator import (
 
 
 ProviderName: TypeAlias = Literal["claude-code", "claude-ai", "chatgpt", "gemini", "codex"]
-ProviderPayload: TypeAlias = dict[str, Any]
-ProviderContent: TypeAlias = Any
-UsagePayload: TypeAlias = dict[str, Any] | None
-ExtractTextFn: TypeAlias = Callable[[Any], str]
+ProviderContent: TypeAlias = object
+UsagePayload: TypeAlias = JSONDocument | None
+ExtractTextFn: TypeAlias = Callable[[object], str]
 ReasoningTraceCase: TypeAlias = tuple[ProviderContent, str, int, str | None, str]
 ContentBlocksCase: TypeAlias = tuple[ProviderContent, int, list[str], str]
 ExtractTextCase: TypeAlias = tuple[ExtractTextFn, ProviderContent | UsagePayload, str, str]
@@ -77,12 +76,27 @@ CONTENT_BLOCKS_CASES: list[ContentBlocksCase] = [
 ]
 
 EXTRACT_TEXT_CASES: list[ExtractTextCase] = [
-    (extract_claude_code_text, None, "", "claude_code_none"),
-    (extract_claude_code_text, ["string", 123], "", "claude_code_non_dict"),
-    (extract_chatgpt_text, None, "", "chatgpt_none"),
-    (extract_chatgpt_text, {}, "", "chatgpt_no_parts"),
-    (extract_chatgpt_text, {"parts": "string"}, "string", "chatgpt_parts_as_string"),
-    (extract_chatgpt_text, {"parts": [123, "text", {"key": "val"}]}, "text", "chatgpt_non_string_parts"),
+    (lambda content: extract_claude_code_text(cast(list[JSONDocument] | None, content)), None, "", "claude_code_none"),
+    (
+        lambda content: extract_claude_code_text(cast(list[JSONDocument] | None, content)),
+        ["string", 123],
+        "",
+        "claude_code_non_dict",
+    ),
+    (lambda content: extract_chatgpt_text(cast(JSONDocument | None, content)), None, "", "chatgpt_none"),
+    (lambda content: extract_chatgpt_text(cast(JSONDocument | None, content)), {}, "", "chatgpt_no_parts"),
+    (
+        lambda content: extract_chatgpt_text(cast(JSONDocument | None, content)),
+        {"parts": "string"},
+        "string",
+        "chatgpt_parts_as_string",
+    ),
+    (
+        lambda content: extract_chatgpt_text(cast(JSONDocument | None, content)),
+        {"parts": [123, "text", {"key": "val"}]},
+        "text",
+        "chatgpt_non_string_parts",
+    ),
 ]
 
 HARMONIZED_MESSAGE_PROVIDER_CASES: list[tuple[ProviderName, str, str]] = [
@@ -125,7 +139,7 @@ class TestUnifiedExtractReasoningTraces:
         expected_text: str | None,
         description: str,
     ) -> None:
-        result = extract_reasoning_traces(content, provider)
+        result = extract_reasoning_traces(cast(list[JSONDocument] | None, content), provider)
         assert len(result) == expected_len
         if expected_text is not None:
             assert result[0].text == expected_text
@@ -140,7 +154,7 @@ class TestUnifiedExtractContentBlocks:
         expected_types: list[str],
         description: str,
     ) -> None:
-        result = extract_content_blocks(content)
+        result = extract_content_blocks(cast(list[JSONDocument] | None, content))
         assert len(result) == expected_len
         if expected_types:
             for block, expected_type in zip(result, expected_types, strict=True):

--- a/tests/unit/core/test_message_laws.py
+++ b/tests/unit/core/test_message_laws.py
@@ -7,111 +7,110 @@ Conversation. Example-heavy semantic projections live in
 
 from __future__ import annotations
 
-from typing import Any
-
 from hypothesis import given
 
+from polylogue.lib.models import Conversation, Message
 from polylogue.lib.roles import Role
 from tests.infra.strategies.messages import conversation_model_strategy, message_model_strategy
 
 
 @given(message_model_strategy())
-def test_message_role_is_typed_enum(msg: Any) -> None:
+def test_message_role_is_typed_enum(msg: Message) -> None:
     assert isinstance(msg.role, Role)
 
 
 @given(message_model_strategy())
-def test_word_count_matches_text_split(msg: Any) -> None:
+def test_word_count_matches_text_split(msg: Message) -> None:
     assert msg.word_count == len((msg.text or "").split())
 
 
 @given(message_model_strategy())
-def test_noise_and_substantive_mutually_exclusive(msg: Any) -> None:
+def test_noise_and_substantive_mutually_exclusive(msg: Message) -> None:
     assert not (msg.is_noise and msg.is_substantive)
 
 
 @given(message_model_strategy())
-def test_thinking_and_substantive_mutually_exclusive(msg: Any) -> None:
+def test_thinking_and_substantive_mutually_exclusive(msg: Message) -> None:
     assert not (msg.is_thinking and msg.is_substantive)
 
 
 @given(message_model_strategy())
-def test_tool_use_implies_noise(msg: Any) -> None:
+def test_tool_use_implies_noise(msg: Message) -> None:
     if msg.is_tool_use:
         assert msg.is_noise
 
 
 @given(message_model_strategy())
-def test_context_dump_implies_noise(msg: Any) -> None:
+def test_context_dump_implies_noise(msg: Message) -> None:
     if msg.is_context_dump:
         assert msg.is_noise
 
 
 @given(message_model_strategy())
-def test_substantive_implies_dialogue(msg: Any) -> None:
+def test_substantive_implies_dialogue(msg: Message) -> None:
     if msg.is_substantive:
         assert msg.is_dialogue
 
 
 @given(message_model_strategy())
-def test_dialogue_implies_user_or_assistant(msg: Any) -> None:
+def test_dialogue_implies_user_or_assistant(msg: Message) -> None:
     if msg.is_dialogue:
         assert msg.is_user or msg.is_assistant
 
 
 @given(conversation_model_strategy())
-def test_without_noise_removes_all_noise(conv: Any) -> None:
+def test_without_noise_removes_all_noise(conv: Conversation) -> None:
     clean = conv.without_noise()
     assert all(not msg.is_noise for msg in clean.messages)
 
 
 @given(conversation_model_strategy())
-def test_substantive_only_all_substantive(conv: Any) -> None:
+def test_substantive_only_all_substantive(conv: Conversation) -> None:
     filtered = conv.substantive_only()
     assert all(msg.is_substantive for msg in filtered.messages)
 
 
 @given(conversation_model_strategy())
-def test_without_noise_preserves_non_noise_count(conv: Any) -> None:
+def test_without_noise_preserves_non_noise_count(conv: Conversation) -> None:
     expected_ids = [msg.id for msg in conv.messages if not msg.is_noise]
     clean = conv.without_noise()
     assert [msg.id for msg in clean.messages] == expected_ids
 
 
 @given(conversation_model_strategy())
-def test_substantive_only_preserves_count(conv: Any) -> None:
+def test_substantive_only_preserves_count(conv: Conversation) -> None:
     expected_ids = [msg.id for msg in conv.messages if msg.is_substantive]
     filtered = conv.substantive_only()
     assert [msg.id for msg in filtered.messages] == expected_ids
 
 
 @given(conversation_model_strategy())
-def test_user_only_preserves_count(conv: Any) -> None:
+def test_user_only_preserves_count(conv: Conversation) -> None:
     expected_ids = [msg.id for msg in conv.messages if msg.is_user]
     filtered = conv.user_only()
     assert [msg.id for msg in filtered.messages] == expected_ids
 
 
 @given(conversation_model_strategy())
-def test_without_noise_idempotent(conv: Any) -> None:
+def test_without_noise_idempotent(conv: Conversation) -> None:
     once = conv.without_noise()
     twice = once.without_noise()
     assert [msg.id for msg in once.messages] == [msg.id for msg in twice.messages]
 
 
 @given(message_model_strategy())
-def test_extract_thinking_never_empty_string(msg: Any) -> None:
+def test_extract_thinking_never_empty_string(msg: Message) -> None:
     result = msg.extract_thinking()
     assert result is None or (isinstance(result, str) and len(result.strip()) > 0)
 
 
 @given(message_model_strategy())
-def test_cost_usd_none_or_positive(msg: Any) -> None:
+def test_cost_usd_none_or_positive(msg: Message) -> None:
     if msg.cost_usd is not None:
         assert msg.cost_usd > 0
 
 
 @given(message_model_strategy())
-def test_duration_ms_none_or_positive(msg: Any) -> None:
+def test_duration_ms_none_or_positive(msg: Message) -> None:
     if msg.duration_ms is not None:
         assert msg.duration_ms > 0

--- a/tests/unit/core/test_models.py
+++ b/tests/unit/core/test_models.py
@@ -7,7 +7,6 @@ regressions and storage-record conversions, code language detection, and provide
 
 from __future__ import annotations
 
-from typing import Any
 from unittest.mock import Mock
 
 import pytest
@@ -87,43 +86,43 @@ def _json_input(payload: dict[str, JSONValue]) -> JSONDocument:
 
 class TestToolCallProperties:
     @pytest.mark.parametrize(("tool_name", "expected"), TOOL_FILE_OPS)
-    def test_is_file_operation(self: Any, tool_name: str, expected: bool) -> None:
+    def test_is_file_operation(self, tool_name: str, expected: bool) -> None:
         assert _make_tool(tool_name).is_file_operation is expected
 
     @pytest.mark.parametrize(("tool_name", "input_data", "expected"), TOOL_GIT_OPS)
-    def test_is_git_operation(self: Any, tool_name: str, input_data: dict[str, object], expected: bool) -> None:
+    def test_is_git_operation(self, tool_name: str, input_data: dict[str, object], expected: bool) -> None:
         assert _make_tool(tool_name, input_data).is_git_operation is expected
 
     @pytest.mark.parametrize(("tool_name", "input_data", "expected"), TOOL_AFFECTED_PATHS)
     def test_affected_paths(
-        self: Any,
+        self,
         tool_name: str,
         input_data: dict[str, object],
         expected: list[str],
     ) -> None:
         assert _make_tool(tool_name, input_data).affected_paths == expected
 
-    def test_affected_paths_bash_extraction(self: Any) -> None:
+    def test_affected_paths_bash_extraction(self) -> None:
         tool = _make_tool("Bash", {"command": "ls /tmp/file1 /tmp/file2"})
         assert "/tmp/file1" in tool.affected_paths
         assert "/tmp/file2" in tool.affected_paths
 
-    def test_affected_paths_bash_skips_flags(self: Any) -> None:
+    def test_affected_paths_bash_skips_flags(self) -> None:
         tool = _make_tool("Bash", {"command": "ls -la /tmp/file"})
         assert "-la" not in tool.affected_paths
         assert "/tmp/file" in tool.affected_paths
 
-    def test_affected_paths_filters_globs_and_noise(self: Any) -> None:
+    def test_affected_paths_filters_globs_and_noise(self) -> None:
         tool = _make_tool("Bash", {"command": "ls /workspace/* /tmp/file ... /dev/null"})
         assert "/tmp/file" in tool.affected_paths
         assert all(path not in tool.affected_paths for path in ("/workspace/*", "...", "/dev/null"))
 
-    def test_affected_paths_filters_shell_suffix_fragments(self: Any) -> None:
+    def test_affected_paths_filters_shell_suffix_fragments(self) -> None:
         tool = _make_tool("Bash", {"command": "tar -xf archive.tar.gz .tar.gz ./fixtures/sample.txt"})
         assert ".tar.gz" not in tool.affected_paths
         assert "./fixtures/sample.txt" in tool.affected_paths
 
-    def test_affected_paths_uses_structured_metadata_files(self: Any) -> None:
+    def test_affected_paths_uses_structured_metadata_files(self) -> None:
         bash_input = _json_input({"command": "git add pyproject.toml README.md"})
         tool = ToolCall(
             name="Bash",
@@ -134,7 +133,7 @@ class TestToolCallProperties:
         )
         assert tool.affected_paths == ["pyproject.toml", "/workspace/polylogue/README.md"]
 
-    def test_affected_paths_filters_noisy_structured_metadata_files(self: Any) -> None:
+    def test_affected_paths_filters_noisy_structured_metadata_files(self) -> None:
         bash_input = _json_input(
             {"command": "git add modules/services/sinex/bridge.nix && git commit -m \"$(cat <<'EOF'\""}
         )
@@ -163,21 +162,21 @@ class TestToolCallProperties:
 
 
 class TestMessageCollectionContracts:
-    def test_is_lazy_is_always_false(self: Any) -> None:
+    def test_is_lazy_is_always_false(self) -> None:
         assert MessageCollection(messages=[]).is_lazy is False
 
-    def test_materialize_is_noop(self: Any) -> None:
+    def test_materialize_is_noop(self) -> None:
         collection = MessageCollection(messages=[make_msg(id="m1", role=Role.USER, text="hello")])
         assert collection.materialize() is collection
 
-    def test_get_pydantic_core_schema(self: Any) -> None:
+    def test_get_pydantic_core_schema(self) -> None:
         handler = Mock()
         handler.generate_schema.return_value = {"type": "object"}
         schema = MessageCollection.__get_pydantic_core_schema__(MessageCollection, handler)
         assert schema is not None
         assert hasattr(schema, "__iter__") or isinstance(schema, dict)
 
-    def test_get_pydantic_json_schema(self: Any) -> None:
+    def test_get_pydantic_json_schema(self) -> None:
         handler = Mock()
         handler.generate.return_value = {"type": "object"}
         handler.resolve_ref_schema.return_value = {"type": "object"}
@@ -187,7 +186,7 @@ class TestMessageCollectionContracts:
 
 
 class TestPinnedSemanticRegressions:
-    def test_extract_thinking_prefers_db_content_blocks(self: Any) -> None:
+    def test_extract_thinking_prefers_db_content_blocks(self) -> None:
         msg = Message(
             id="m1",
             role=Role.ASSISTANT,
@@ -200,7 +199,7 @@ class TestPinnedSemanticRegressions:
         )
         assert msg.extract_thinking() == "db thought 1\n\ndb thought 2"
 
-    def test_extract_thinking_db_blocks_require_thinking_type_and_string_text(self: Any) -> None:
+    def test_extract_thinking_db_blocks_require_thinking_type_and_string_text(self) -> None:
         msg = Message(
             id="m1",
             role=Role.ASSISTANT,
@@ -213,7 +212,7 @@ class TestPinnedSemanticRegressions:
         )
         assert msg.extract_thinking() == "db-only thinking"
 
-    def test_is_tool_use_detection_raw_claude_code(self: Any) -> None:
+    def test_is_tool_use_detection_raw_claude_code(self) -> None:
         msg = Message(
             id="m-tool",
             role=Role.ASSISTANT,
@@ -238,7 +237,7 @@ class TestPinnedSemanticRegressions:
         assert msg.harmonized.tool_calls[0].id == "tool-1"
         assert msg.harmonized.tool_calls[0].input == {"file_path": "README.md"}
 
-    def test_is_thinking_detection_raw_claude_code(self: Any) -> None:
+    def test_is_thinking_detection_raw_claude_code(self) -> None:
         msg = Message(
             id="m-think",
             role=Role.ASSISTANT,
@@ -263,7 +262,7 @@ class TestPinnedSemanticRegressions:
 class TestAttachmentFromRecord:
     @pytest.mark.parametrize(("provider_meta", "expected_name"), ATTACHMENT_NAME_CASES)
     def test_from_record_derives_name(
-        self: Any,
+        self,
         provider_meta: dict[str, object] | None,
         expected_name: str,
     ) -> None:
@@ -278,7 +277,7 @@ class TestAttachmentFromRecord:
 
 class TestMessageFromRecord:
     @pytest.mark.parametrize(("role", "expected_role"), MESSAGE_ROLE_CASES)
-    def test_from_record_normalizes_role(self: Any, role: str, expected_role: str) -> None:
+    def test_from_record_normalizes_role(self, role: str, expected_role: str) -> None:
         record = MessageRecord.model_validate(
             {
                 "message_id": MessageId("m1"),
@@ -291,7 +290,7 @@ class TestMessageFromRecord:
         message = message_from_record(record, [])
         assert message.role == expected_role
 
-    def test_from_record_preserves_structured_content_block_semantics(self: Any) -> None:
+    def test_from_record_preserves_structured_content_block_semantics(self) -> None:
         record = make_message(
             message_id="m1",
             conversation_id="c1",
@@ -329,7 +328,7 @@ class TestMessageFromRecord:
 
 
 class TestConversationSummaryFromRecord:
-    def test_from_record_projects_metadata(self: Any) -> None:
+    def test_from_record_projects_metadata(self) -> None:
         record = make_conversation(
             conversation_id="c1",
             provider_name="claude-ai",
@@ -349,7 +348,7 @@ class TestConversationSummaryFromRecord:
 
 
 class TestConversationFromRecords:
-    def test_from_records_attaches_records_to_messages(self: Any) -> None:
+    def test_from_records_attaches_records_to_messages(self) -> None:
         conversation_record = make_conversation(
             conversation_id="c1",
             provider_name="claude-ai",

--- a/tests/unit/core/test_privacy_guards.py
+++ b/tests/unit/core/test_privacy_guards.py
@@ -7,7 +7,7 @@ focuses on boundary conditions and corner cases.
 
 from __future__ import annotations
 
-from typing import Any, Literal
+from typing import Literal
 
 from hypothesis import given, settings
 from hypothesis import strategies as st
@@ -26,41 +26,41 @@ LETTER_CATEGORIES: tuple[Literal["L"], ...] = ("L",)
 class TestSafeEnumEdgeCases:
     """Boundary conditions for _is_safe_enum_value."""
 
-    def test_exactly_max_length_is_accepted(self: Any) -> None:
+    def test_exactly_max_length_is_accepted(self) -> None:
         """A value at exactly 50 chars (the cap) should still pass if safe."""
         value = "a" * 50
         assert _is_safe_enum_value(value)
 
-    def test_one_over_max_length_is_rejected(self: Any) -> None:
+    def test_one_over_max_length_is_rejected(self) -> None:
         """A value at 51 chars is rejected."""
         value = "a" * 51
         assert not _is_safe_enum_value(value)
 
-    def test_private_tld_mixed_case(self: Any) -> None:
+    def test_private_tld_mixed_case(self) -> None:
         """Domain-like values with known TLDs are rejected regardless of case."""
         assert not _is_safe_enum_value("Example.COM")
         assert not _is_safe_enum_value("test.IO")
         assert not _is_safe_enum_value("host.Org")
 
-    def test_domain_trailing_content(self: Any) -> None:
+    def test_domain_trailing_content(self) -> None:
         """TLD pattern uses word boundary -- trailing text after TLD is handled."""
         # ".com" followed by nothing → rejected
         assert not _is_safe_enum_value("example.com")
         # ".com" with trailing slash → still has "://" path? No -- just has dot
         assert not _is_safe_enum_value("host.net")
 
-    def test_non_public_tlds_are_allowed(self: Any) -> None:
+    def test_non_public_tlds_are_allowed(self) -> None:
         """Domains with TLDs not in the denylist pass through."""
         # .xyz, .dev, .app are not in the denylist
         assert _is_safe_enum_value("x.xyz")
         assert _is_safe_enum_value("a.dev")
 
-    def test_timestamp_prefix_rejected(self: Any) -> None:
+    def test_timestamp_prefix_rejected(self) -> None:
         """ISO-like timestamps at string start are rejected."""
         assert not _is_safe_enum_value("2024-01-15T10:30:00")
         assert not _is_safe_enum_value("2024-01-15 10:30:00")
 
-    def test_non_ascii_rejected(self: Any) -> None:
+    def test_non_ascii_rejected(self) -> None:
         """Non-ASCII values are rejected even if short."""
         assert not _is_safe_enum_value("caf\u00e9")
         assert not _is_safe_enum_value("\u00fcber")
@@ -71,19 +71,19 @@ class TestSafeEnumEdgeCases:
         )
     )
     @settings(max_examples=30)
-    def test_non_ascii_always_rejected(self: Any, value: Any) -> None:
+    def test_non_ascii_always_rejected(self, value: str) -> None:
         """Property: any non-ASCII string is rejected."""
         assert not _is_safe_enum_value(value)
 
-    def test_empty_string_rejected(self: Any) -> None:
+    def test_empty_string_rejected(self) -> None:
         """Empty string is rejected."""
         assert not _is_safe_enum_value("")
 
-    def test_slash_prefix_rejected(self: Any) -> None:
+    def test_slash_prefix_rejected(self) -> None:
         """Strings starting with / are rejected (path-like)."""
         assert not _is_safe_enum_value("/usr/bin")
 
-    def test_plus_prefix_rejected(self: Any) -> None:
+    def test_plus_prefix_rejected(self) -> None:
         """Strings starting with + are rejected (phone-like)."""
         assert not _is_safe_enum_value("+1234567890")
 
@@ -91,16 +91,16 @@ class TestSafeEnumEdgeCases:
 class TestContentFieldDetection:
     """Edge cases for _is_content_field."""
 
-    def test_nested_path_terminal_match(self: Any) -> None:
+    def test_nested_path_terminal_match(self) -> None:
         """Content field detection works on nested dotted paths."""
         assert _is_content_field("$.mapping.*.message.content.text")
         assert _is_content_field("deep.path.title")
 
-    def test_array_marker_stripped(self: Any) -> None:
+    def test_array_marker_stripped(self) -> None:
         """Array markers like [*] are stripped before matching."""
         assert _is_content_field("items[*].description")
 
-    def test_non_content_field(self: Any) -> None:
+    def test_non_content_field(self) -> None:
         """Non-content fields are correctly identified."""
         assert not _is_content_field("$.role")
         assert not _is_content_field("type")
@@ -110,7 +110,7 @@ class TestContentFieldDetection:
 class TestAnnotationPrivacyIntegration:
     """Integration tests: privacy guards applied through the annotation pipeline."""
 
-    def test_high_cardinality_values_excluded_from_annotation(self: Any) -> None:
+    def test_high_cardinality_values_excluded_from_annotation(self) -> None:
         """Fields with >50 distinct values don't get x-polylogue-values."""
         # Create samples with 60 distinct role values (high cardinality)
         samples = [{"status": f"status-{i}"} for i in range(60)]
@@ -122,7 +122,7 @@ class TestAnnotationPrivacyIntegration:
         # High cardinality → not enum-like → no values annotation
         assert not schema_values(schema_property(annotated, "status"))
 
-    def test_content_field_values_excluded(self: Any) -> None:
+    def test_content_field_values_excluded(self) -> None:
         """Known content fields never get x-polylogue-values even if low cardinality."""
         samples = [{"title": "hello"}, {"title": "world"}]
         stats = _collect_field_stats(samples)

--- a/tests/unit/core/test_query_retrieval_candidates.py
+++ b/tests/unit/core/test_query_retrieval_candidates.py
@@ -1,18 +1,19 @@
 from __future__ import annotations
 
-from typing import Any
-
 import pytest
 
 from polylogue.errors import DatabaseError
 from polylogue.lib.query_plan import ConversationQueryPlan
 from polylogue.lib.query_retrieval_candidates import fetch_search_results
 from polylogue.storage.backends.connection import open_connection
+from polylogue.storage.repository import ConversationRepository
 from tests.infra.storage_records import ConversationBuilder
 
 
 @pytest.mark.asyncio
-async def test_fetch_search_results_raises_when_message_index_is_incomplete(storage_repository: Any) -> None:
+async def test_fetch_search_results_raises_when_message_index_is_incomplete(
+    storage_repository: ConversationRepository,
+) -> None:
     ConversationBuilder(storage_repository.backend.db_path, "conv-incomplete-search").add_message(
         "m1",
         text="python search contract",

--- a/tests/unit/core/test_schema_corpus_alignment.py
+++ b/tests/unit/core/test_schema_corpus_alignment.py
@@ -10,11 +10,10 @@ Covers:
 from __future__ import annotations
 
 from collections import Counter
-from typing import Any
 
 import pytest
 
-from polylogue.lib.json import JSONValue, json_document
+from polylogue.lib.json import JSONDocument, JSONValue, json_document
 from polylogue.lib.raw_payload_sampling_extract import (
     extract_payload_samples,
     extract_record_samples_from_raw_content,
@@ -194,7 +193,7 @@ class TestRecordStreamTitleAbstention:
 
     def test_annotate_semantic_threads_artifact_kind(self) -> None:
         """annotate_semantic_and_relational passes artifact_kind through."""
-        schema: dict[str, Any] = {
+        schema: JSONDocument = {
             "type": "object",
             "properties": {
                 "title": {"type": "string"},
@@ -219,7 +218,7 @@ class TestRecordStreamTitleAbstention:
             artifact_kind="conversation_record_stream",
         )
         # Title should NOT be annotated for record streams
-        title_prop = result.get("properties", {}).get("title", {})
+        title_prop = json_document(json_document(result.get("properties")).get("title"))
         assert title_prop.get("x-polylogue-semantic-role") != "conversation_title"
 
     def test_record_stream_eligible_roles_are_subset_of_semantic_roles(self) -> None:
@@ -236,7 +235,7 @@ class TestProofSurface:
     """Schema review proof surface has required structure."""
 
     @pytest.fixture()
-    def schema_with_roles(self) -> dict[str, Any]:
+    def schema_with_roles(self) -> JSONDocument:
         """A schema with some semantic role annotations."""
         return {
             "type": "object",
@@ -271,13 +270,13 @@ class TestProofSurface:
             },
         }
 
-    def test_proof_contains_all_semantic_roles(self, schema_with_roles: dict[str, Any]) -> None:
+    def test_proof_contains_all_semantic_roles(self, schema_with_roles: JSONDocument) -> None:
         """Proof has an entry for every semantic role."""
         proof = build_review_proof(schema_with_roles)
         proof_roles = {entry.role for entry in proof.roles}
         assert proof_roles == set(SEMANTIC_ROLES)
 
-    def test_proof_entry_fields(self, schema_with_roles: dict[str, Any]) -> None:
+    def test_proof_entry_fields(self, schema_with_roles: JSONDocument) -> None:
         """Each proof entry has required fields."""
         proof = build_review_proof(schema_with_roles)
         for entry in proof.roles:
@@ -287,7 +286,7 @@ class TestProofSurface:
             assert isinstance(entry.competing, list)
             assert isinstance(entry.evidence, dict)
 
-    def test_proof_chosen_path_for_assigned_roles(self, schema_with_roles: dict[str, Any]) -> None:
+    def test_proof_chosen_path_for_assigned_roles(self, schema_with_roles: JSONDocument) -> None:
         """Assigned roles have a chosen_path."""
         proof = build_review_proof(schema_with_roles)
         title_entry = next(e for e in proof.roles if e.role == "conversation_title")
@@ -295,7 +294,7 @@ class TestProofSurface:
         assert title_entry.chosen_score == pytest.approx(0.72)
         assert not title_entry.abstained
 
-    def test_proof_abstained_roles(self, schema_with_roles: dict[str, Any]) -> None:
+    def test_proof_abstained_roles(self, schema_with_roles: JSONDocument) -> None:
         """Roles with no candidates are marked as abstained."""
         proof = build_review_proof(schema_with_roles)
         # message_container and message_timestamp have no assignment in the fixture
@@ -303,7 +302,7 @@ class TestProofSurface:
         assert container_entry.abstained
         assert container_entry.abstain_reason is not None
 
-    def test_proof_to_dict_roundtrip(self, schema_with_roles: dict[str, Any]) -> None:
+    def test_proof_to_dict_roundtrip(self, schema_with_roles: JSONDocument) -> None:
         """to_dict produces JSON-serializable output."""
         import json
 
@@ -318,7 +317,7 @@ class TestProofSurface:
         assert "eligible_roles" in parsed
         assert "ineligible_roles" in parsed
 
-    def test_proof_eligible_roles_for_document(self, schema_with_roles: dict[str, Any]) -> None:
+    def test_proof_eligible_roles_for_document(self, schema_with_roles: JSONDocument) -> None:
         """conversation_document has all roles eligible."""
         proof = build_review_proof(schema_with_roles)
         assert proof.eligible_roles == list(SEMANTIC_ROLES)
@@ -326,7 +325,7 @@ class TestProofSurface:
 
     def test_proof_record_stream_ineligible_roles(self) -> None:
         """Record-stream schemas show title as ineligible."""
-        schema: dict[str, Any] = {
+        schema: JSONDocument = {
             "type": "object",
             "x-polylogue-artifact-kind": "conversation_record_stream",
             "properties": {
@@ -355,7 +354,7 @@ class TestConfidenceToScoreRename:
 
     def test_no_confidence_key_in_annotated_schema(self) -> None:
         """Annotated schema uses x-polylogue-score, not x-polylogue-confidence."""
-        schema: dict[str, Any] = {
+        schema: JSONDocument = {
             "type": "object",
             "properties": {
                 "role": {"type": "string"},
@@ -406,13 +405,14 @@ class TestConfidenceToScoreRename:
         assert not hits, f"Source files still reference old key: {hits}"
 
 
-def _collect_all_keys(obj: Any, _keys: set[str] | None = None) -> set[str]:
+def _collect_all_keys(obj: object, _keys: set[str] | None = None) -> set[str]:
     """Recursively collect all dict keys in a nested structure."""
     if _keys is None:
         _keys = set()
     if isinstance(obj, dict):
         for k, v in obj.items():
-            _keys.add(k)
+            if isinstance(k, str):
+                _keys.add(k)
             _collect_all_keys(v, _keys)
     elif isinstance(obj, list):
         for item in obj:

--- a/tests/unit/core/test_schema_generation.py
+++ b/tests/unit/core/test_schema_generation.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import json
 from collections.abc import Generator
+from pathlib import Path
 from types import SimpleNamespace
-from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -39,7 +39,7 @@ class TestProviderSchemaGeneration:
 
     @pytest.mark.slow
     @pytest.mark.parametrize("provider", ["chatgpt", "claude-code", "codex"])
-    def test_generate_schema_from_db(self, seeded_db: Any, provider: Any) -> None:
+    def test_generate_schema_from_db(self, seeded_db: Path, provider: str) -> None:
         result = generate_provider_schema(provider, db_path=seeded_db, max_samples=100)
         if result.sample_count > 0:
             assert result.success, f"Failed: {result.error}"
@@ -65,20 +65,22 @@ class TestProviderSchemaGeneration:
 class TestLoadSamples:
     """Database-backed sample loading behavior."""
 
-    def test_load_limited_samples(self, seeded_db: Any) -> None:
+    def test_load_limited_samples(self, seeded_db: Path) -> None:
         samples = load_samples_from_db("chatgpt", db_path=seeded_db, max_samples=10)
         assert len(samples) <= 10
 
-    def test_load_nonexistent_provider(self, seeded_db: Any) -> None:
+    def test_load_nonexistent_provider(self, seeded_db: Path) -> None:
         assert load_samples_from_db("nonexistent-provider", db_path=seeded_db) == []
 
     def test_load_limited_document_samples_stops_without_full_materialization(
-        self, monkeypatch: Any, tmp_path: Any
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
     ) -> None:
         db_path = tmp_path / "samples.db"
         db_path.write_text("")
 
-        def _iter(*args: Any, **kwargs: Any) -> Generator[dict[str, str], None, None]:
+        def _iter(*args: object, **kwargs: object) -> Generator[dict[str, str], None, None]:
             yield {"id": "one"}
             yield {"id": "two"}
             raise AssertionError("iterator should not be exhausted past the limit")
@@ -98,15 +100,15 @@ def test_remove_nested_required_non_dict_returns_unchanged() -> None:
 class TestLoadSamplesFromSessions:
     """Session-dir sample loading edge cases."""
 
-    def test_nonexistent_dir_returns_empty(self, tmp_path: Any) -> None:
+    def test_nonexistent_dir_returns_empty(self, tmp_path: Path) -> None:
         assert load_samples_from_sessions(tmp_path / "does_not_exist") == []
 
-    def test_empty_dir_returns_empty(self, tmp_path: Any) -> None:
+    def test_empty_dir_returns_empty(self, tmp_path: Path) -> None:
         session_dir = tmp_path / "empty"
         session_dir.mkdir()
         assert load_samples_from_sessions(session_dir) == []
 
-    def test_max_sessions_limits_files(self, tmp_path: Any) -> None:
+    def test_max_sessions_limits_files(self, tmp_path: Path) -> None:
         session_dir = tmp_path / "sessions"
         session_dir.mkdir()
         for i in range(10):
@@ -119,10 +121,10 @@ class TestLoadSamplesFromSessions:
 class TestGetSampleCountFromDb:
     """Sample-count queries against persisted conversations."""
 
-    def test_nonexistent_db_returns_zero(self, tmp_path: Any) -> None:
+    def test_nonexistent_db_returns_zero(self, tmp_path: Path) -> None:
         assert get_sample_count_from_db("chatgpt", db_path=tmp_path / "missing.db") == 0
 
-    def test_empty_db_returns_zero(self, tmp_path: Any) -> None:
+    def test_empty_db_returns_zero(self, tmp_path: Path) -> None:
         from polylogue.storage.backends.connection import open_connection
 
         db_path = tmp_path / "empty.db"
@@ -130,7 +132,7 @@ class TestGetSampleCountFromDb:
             pass
         assert get_sample_count_from_db("chatgpt", db_path=db_path) == 0
 
-    def test_matching_provider_returns_count(self, tmp_path: Any) -> None:
+    def test_matching_provider_returns_count(self, tmp_path: Path) -> None:
         from polylogue.storage.backends.connection import open_connection
 
         db_path = tmp_path / "test.db"
@@ -170,7 +172,7 @@ class TestGetSampleCountFromDb:
 
         assert get_sample_count_from_db("chatgpt", db_path=db_path) == 1
 
-    def test_wrong_provider_returns_zero(self, tmp_path: Any) -> None:
+    def test_wrong_provider_returns_zero(self, tmp_path: Path) -> None:
         from polylogue.storage.backends.connection import open_connection
 
         db_path = tmp_path / "test.db"
@@ -251,7 +253,7 @@ class TestGenerateSchemaFromSamples:
 class TestGenerateAllSchemas:
     """Filesystem effects of schema bundle generation."""
 
-    def test_creates_output_directory(self, tmp_path: Any) -> None:
+    def test_creates_output_directory(self, tmp_path: Path) -> None:
         output_dir = tmp_path / "schemas" / "nested"
         package = SchemaVersionPackage(
             provider="chatgpt",
@@ -312,7 +314,7 @@ class TestGenerateAllSchemas:
             output_dir / "chatgpt" / "versions" / "v1" / "elements" / "conversation_document.schema.json.gz"
         ).exists()
 
-    def test_skips_failed_schemas(self, tmp_path: Any) -> None:
+    def test_skips_failed_schemas(self, tmp_path: Path) -> None:
         failed_result = GenerationResult(provider="broken", sample_count=0, schema=None, error="No samples")
 
         with patch("polylogue.schemas.generation_workflow.generate_provider_schema", return_value=failed_result):
@@ -323,7 +325,11 @@ class TestGenerateAllSchemas:
 
 
 class TestProfileClustering:
-    def test_collect_cluster_accumulators_merges_same_profile_documents(self, monkeypatch: Any, tmp_path: Any) -> None:
+    def test_collect_cluster_accumulators_merges_same_profile_documents(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
         units = [
             SchemaUnit(
                 cluster_payload={"id": "1", "mapping": {"node-1": {"message": {"id": "m1"}}}},
@@ -363,7 +369,9 @@ class TestProfileClustering:
         assert acc.sample_count == 2
 
     def test_build_provider_bundle_captures_element_windows_and_bundle_scopes(
-        self, monkeypatch: Any, tmp_path: Any
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
     ) -> None:
         units = [
             SchemaUnit(
@@ -422,7 +430,7 @@ class TestProfileClustering:
 class TestCliMain:
     """CLI entry point behavior."""
 
-    def test_cli_with_no_db(self, tmp_path: Any) -> None:
+    def test_cli_with_no_db(self, tmp_path: Path) -> None:
         exit_code = cli_main(
             [
                 "--provider",

--- a/tests/unit/core/test_semantic_facts.py
+++ b/tests/unit/core/test_semantic_facts.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, cast
 
 import pytest
 
@@ -12,8 +11,11 @@ from polylogue.lib import session_profile_runtime, work_event_extraction
 from polylogue.lib.messages import MessageCollection
 from polylogue.lib.models import Conversation as ConversationModel
 from polylogue.lib.models import ConversationSummary
+from polylogue.lib.phase_extraction import SessionPhase
+from polylogue.lib.phase_extraction import extract_phases as phase_extract_phases
 from polylogue.lib.pricing import harmonize_session_cost
 from polylogue.lib.semantic_facts import (
+    ConversationSemanticFacts,
     build_conversation_semantic_facts,
     build_mcp_summary_semantic_facts,
     build_projection_semantic_facts,
@@ -25,6 +27,7 @@ from tests.infra.builders import make_conv, make_msg
 from tests.infra.storage_records import make_attachment, make_conversation, make_message
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
+EXPECTED_REPO_NAME = REPO_ROOT.name
 README_PATH = REPO_ROOT / "README.md"
 LIB_PATH = REPO_ROOT / "polylogue" / "lib"
 SHOWCASE_REPORT_PATH = REPO_ROOT / "polylogue" / "showcase" / "report.py"
@@ -256,7 +259,7 @@ def test_build_session_profile_reuses_shared_semantic_facts() -> None:
     assert profile.tool_use_count == 1
     assert profile.thinking_count == 1
     assert profile.tool_categories == {"file_read": 1}
-    assert profile.repo_names == ("polylogue",)
+    assert profile.repo_names == (EXPECTED_REPO_NAME,)
     assert profile.first_message_at == datetime(2026, 3, 23, 9, 0, tzinfo=timezone.utc)
     assert profile.last_message_at == datetime(2026, 3, 23, 9, 4, tzinfo=timezone.utc)
     assert profile.canonical_session_date is not None
@@ -267,16 +270,24 @@ def test_build_session_profile_reuses_shared_semantic_facts() -> None:
 
 def test_build_session_analysis_reuses_precomputed_phases(monkeypatch: pytest.MonkeyPatch) -> None:
     conversation = _semantic_conversation()
-    original_extract_phases = cast(Any, session_profile_runtime).extract_phases
+    original_extract_phases = phase_extract_phases
     runtime_phase_calls = 0
     work_event_phase_calls = 0
 
-    def counting_runtime_extract_phases(conv: object, *, facts: object = None) -> object:
+    def counting_runtime_extract_phases(
+        conv: ConversationModel,
+        *,
+        facts: ConversationSemanticFacts | None = None,
+    ) -> list[SessionPhase]:
         nonlocal runtime_phase_calls
         runtime_phase_calls += 1
         return original_extract_phases(conv, facts=facts)
 
-    def unexpected_work_event_extract_phases(conv: object, *, facts: object = None) -> object:
+    def unexpected_work_event_extract_phases(
+        conv: ConversationModel,
+        *,
+        facts: ConversationSemanticFacts | None = None,
+    ) -> list[SessionPhase]:
         nonlocal work_event_phase_calls
         work_event_phase_calls += 1
         raise AssertionError("work-event extraction should reuse precomputed phases")
@@ -354,7 +365,7 @@ def test_build_conversation_semantic_facts_uses_canonical_db_content_blocks() ->
     assert facts.message_facts[1].affected_paths == (str(README_PATH),)
     assert facts.message_facts[1].tool_calls[0].output == "README contents"
     assert profile.tool_categories == {"file_read": 1}
-    assert profile.repo_names == ("polylogue",)
+    assert profile.repo_names == (EXPECTED_REPO_NAME,)
 
 
 def test_build_conversation_semantic_facts_preserves_tool_results_before_tool_use() -> None:
@@ -490,7 +501,7 @@ def test_action_events_capture_normalized_command_query_branch_and_cwd() -> None
     assert str(LIB_PATH) in search_action.search_text
 
     profile = build_session_profile(conversation)
-    assert profile.repo_names == ("polylogue",)
+    assert profile.repo_names == (EXPECTED_REPO_NAME,)
 
 
 def test_action_events_do_not_treat_checkout_pathspec_as_branch_or_commit_message_words_as_paths() -> None:
@@ -553,7 +564,7 @@ def test_action_events_do_not_treat_checkout_pathspec_as_branch_or_commit_messag
     profile = build_session_profile(conversation)
     assert profile.branch_names == ()
     assert profile.file_paths_touched == ("modules/services/sinex/bridge.nix",)
-    assert profile.repo_names == ("polylogue",)
+    assert profile.repo_names == (EXPECTED_REPO_NAME,)
 
 
 def test_build_session_profile_does_not_infer_repos_from_dialogue_paths() -> None:
@@ -617,7 +628,7 @@ def test_build_session_profile_ignores_persisted_output_paths_in_dialogue_text()
 
     profile = build_session_profile(conversation)
 
-    assert profile.repo_names == ("polylogue",)
+    assert profile.repo_names == (EXPECTED_REPO_NAME,)
     assert profile.repo_paths == (str(REPO_ROOT),)
     assert profile.file_paths_touched == ()
 
@@ -697,7 +708,7 @@ def test_build_session_profile_uses_conversation_level_git_context() -> None:
     profile = build_session_profile(conversation)
 
     assert profile.branch_names == ("feature/runtime-cleanup",)
-    assert profile.repo_names == ("polylogue",)
+    assert profile.repo_names == (EXPECTED_REPO_NAME,)
 
 
 def test_build_session_profile_ignores_context_dump_wrappers_for_work_event_intent() -> None:

--- a/tests/unit/core/test_synthetic_semantic_wiring.py
+++ b/tests/unit/core/test_synthetic_semantic_wiring.py
@@ -13,10 +13,11 @@ import copy
 import json
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any, cast
+from typing import cast
 
 import pytest
 
+from polylogue.lib.json import JSONDocument, JSONValue
 from polylogue.schemas.registry import SCHEMA_DIR, SchemaRegistry
 from polylogue.schemas.synthetic.core import SyntheticCorpus
 from polylogue.schemas.synthetic.semantic_values import SemanticValueGenerator
@@ -34,25 +35,25 @@ EXPECTED_ANNOTATIONS: dict[str, list[str]] = {
 }
 
 
-def _collect_semantic_roles(schema: dict[str, Any], *, roles: list[str] | None = None) -> list[str]:
+def _collect_semantic_roles(schema: JSONValue, *, roles: list[str] | None = None) -> list[str]:
     """Recursively collect all x-polylogue-semantic-role values from a schema."""
     if roles is None:
         roles = []
     if not isinstance(schema, dict):
         return roles
-    if "x-polylogue-semantic-role" in schema:
-        roles.append(schema["x-polylogue-semantic-role"])
-    for _key, value in schema.items():
+    role = schema.get("x-polylogue-semantic-role")
+    if isinstance(role, str):
+        roles.append(role)
+    for value in schema.values():
         if isinstance(value, dict):
             _collect_semantic_roles(value, roles=roles)
         elif isinstance(value, list):
             for item in value:
-                if isinstance(item, dict):
-                    _collect_semantic_roles(item, roles=roles)
+                _collect_semantic_roles(item, roles=roles)
     return roles
 
 
-def _bundled_schema(provider: str) -> dict[str, Any]:
+def _bundled_schema(provider: str) -> JSONDocument:
     package = _BUNDLED_REGISTRY.get_package(provider, version="default")
     assert package is not None, f"No bundled package for provider {provider}"
     schema = _BUNDLED_REGISTRY.get_element_schema(
@@ -206,7 +207,7 @@ class TestWireFormatFallback:
         assert convos, f"No conversations parsed without annotations for {provider}"
 
 
-def _strip_semantic_roles(schema: dict[str, Any]) -> None:
+def _strip_semantic_roles(schema: JSONValue) -> None:
     """Recursively remove all x-polylogue-semantic-role annotations."""
     if not isinstance(schema, dict):
         return

--- a/tests/unit/core/test_timestamp_guards.py
+++ b/tests/unit/core/test_timestamp_guards.py
@@ -13,7 +13,6 @@ Covers bugs from:
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from typing import Any
 
 import pytest
 from hypothesis import example, given
@@ -23,6 +22,9 @@ from polylogue.lib.dates import parse_date
 from polylogue.lib.timestamps import format_timestamp, parse_timestamp
 from polylogue.schemas.schema_inference import _is_safe_enum_value
 from tests.infra.tables import FORMAT_TIMESTAMP_TABLE, PARSE_TIMESTAMP_FORMAT_TABLE
+
+TimestampInput = str | int | float | None
+FormatTimestampInput = int | float | datetime
 
 # =============================================================================
 # Property: parse_timestamp never crashes on any input
@@ -42,7 +44,7 @@ def test_parse_timestamp_never_crashes_on_text(value: str) -> None:
 @given(st.one_of(st.none(), st.text(), st.integers(), st.floats(allow_nan=False, allow_infinity=False)))
 @example(0)
 @example(-1000)
-def test_parse_timestamp_never_crashes_on_mixed_types(value: Any) -> None:
+def test_parse_timestamp_never_crashes_on_mixed_types(value: TimestampInput) -> None:
     """parse_timestamp never raises on any type of input."""
     result = parse_timestamp(value)
     assert result is None or isinstance(result, datetime)
@@ -60,7 +62,7 @@ def test_parse_timestamp_never_crashes_on_mixed_types(value: Any) -> None:
         st.from_regex(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z", fullmatch=True),
     )
 )
-def test_parse_timestamp_result_always_utc_aware(value: Any) -> None:
+def test_parse_timestamp_result_always_utc_aware(value: int | float | str) -> None:
     """When parse_timestamp returns a datetime, it is always UTC-aware."""
     result = parse_timestamp(value)
     if result is not None:
@@ -76,7 +78,7 @@ class TestTimestampYearGuard:
     """Year-like strings must NOT be treated as epoch seconds."""
 
     @pytest.mark.parametrize("value", ["2024", "2025", "2026", "1999", "3000"])
-    def test_year_strings_not_treated_as_epoch(self, value: Any) -> None:
+    def test_year_strings_not_treated_as_epoch(self, value: str) -> None:
         result = parse_timestamp(value)
         assert result is None
 
@@ -186,7 +188,13 @@ class TestParseTimestampFormats:
         PARSE_TIMESTAMP_FORMAT_TABLE,
     )
     def test_parse_timestamp_table(
-        self, input_val: Any, exp_year: Any, exp_month: Any, exp_day: Any, exp_micro: Any, desc: Any
+        self,
+        input_val: TimestampInput,
+        exp_year: int | None,
+        exp_month: int | None,
+        exp_day: int | None,
+        exp_micro: int | None,
+        desc: str,
     ) -> None:
         result = parse_timestamp(input_val)
         if exp_year is None:
@@ -207,7 +215,7 @@ class TestParseTimestampFormats:
 
 class TestFormatTimestamp:
     @pytest.mark.parametrize("input_val,expected_prefix,desc", FORMAT_TIMESTAMP_TABLE)
-    def test_format_timestamp_table(self, input_val: Any, expected_prefix: Any, desc: Any) -> None:
+    def test_format_timestamp_table(self, input_val: FormatTimestampInput, expected_prefix: str, desc: str) -> None:
         result = format_timestamp(input_val)
         assert result is not None
         assert expected_prefix in result, f"Expected {expected_prefix!r} in result for {desc!r}"
@@ -271,12 +279,12 @@ SAFE_ENUM_BLOCKED = [
 
 
 @pytest.mark.parametrize("value,category", SAFE_ENUM_ALLOWED)
-def test_safe_enum_value_allowed(value: Any, category: Any) -> None:
+def test_safe_enum_value_allowed(value: str, category: str) -> None:
     assert _is_safe_enum_value(value) is True, f"Should allow {category}: {value!r}"
 
 
 @pytest.mark.parametrize("value,category", SAFE_ENUM_BLOCKED)
-def test_safe_enum_value_blocked(value: Any, category: Any) -> None:
+def test_safe_enum_value_blocked(value: str, category: str) -> None:
     assert _is_safe_enum_value(value) is False, f"Should block {category}: {value!r}"
 
 

--- a/tests/unit/core/test_verification.py
+++ b/tests/unit/core/test_verification.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
 
 import orjson
 import pytest
@@ -71,7 +70,7 @@ def _insert_raw_record(
 
 
 class TestProviderSchemaVerification:
-    def test_to_dict(self: Any) -> None:
+    def test_to_dict(self) -> None:
         v = ProviderSchemaVerification(
             provider="chatgpt",
             total_records=100,
@@ -90,7 +89,7 @@ class TestProviderSchemaVerification:
         assert d["decode_errors"] == 2
         assert d["skipped_no_schema"] == 0
 
-    def test_to_dict_quarantined(self: Any) -> None:
+    def test_to_dict_quarantined(self) -> None:
         v = ProviderSchemaVerification(
             provider="test",
             total_records=10,
@@ -99,7 +98,7 @@ class TestProviderSchemaVerification:
         d = v.to_dict()
         assert d["quarantined_records"] == 2
 
-    def test_default_zeros(self: Any) -> None:
+    def test_default_zeros(self) -> None:
         v = ProviderSchemaVerification(provider="test")
         d = v.to_dict()
         assert d["total_records"] == 0
@@ -108,7 +107,7 @@ class TestProviderSchemaVerification:
         assert d["decode_errors"] == 0
         assert d["quarantined_records"] == 0
 
-    def test_partial_specification(self: Any) -> None:
+    def test_partial_specification(self) -> None:
         v = ProviderSchemaVerification(
             provider="partial",
             total_records=50,
@@ -121,7 +120,7 @@ class TestProviderSchemaVerification:
 
 
 class TestSchemaVerificationReport:
-    def test_to_dict_structure(self: Any) -> None:
+    def test_to_dict_structure(self) -> None:
         report = SchemaVerificationReport(
             providers={
                 "chatgpt": ProviderSchemaVerification(provider="chatgpt", total_records=10),
@@ -136,7 +135,7 @@ class TestSchemaVerificationReport:
         assert d["record_limit"] == "all"
         assert d["record_offset"] == 0
 
-    def test_to_dict_with_limits(self: Any) -> None:
+    def test_to_dict_with_limits(self) -> None:
         report = SchemaVerificationReport(
             providers={},
             max_samples=5,
@@ -149,7 +148,7 @@ class TestSchemaVerificationReport:
         assert d["record_limit"] == 100
         assert d["record_offset"] == 10
 
-    def test_to_dict_multiple_providers(self: Any) -> None:
+    def test_to_dict_multiple_providers(self) -> None:
         report = SchemaVerificationReport(
             providers={
                 "chatgpt": ProviderSchemaVerification(provider="chatgpt", total_records=10),
@@ -163,7 +162,7 @@ class TestSchemaVerificationReport:
         assert "chatgpt" in d["providers"]
         assert "claude-ai" in d["providers"]
 
-    def test_to_dict_sorts_providers(self: Any) -> None:
+    def test_to_dict_sorts_providers(self) -> None:
         report = SchemaVerificationReport(
             providers={
                 "zebra": ProviderSchemaVerification(provider="zebra", total_records=1),
@@ -177,7 +176,7 @@ class TestSchemaVerificationReport:
         provider_names = list(d["providers"].keys())
         assert provider_names == ["alpha", "beta", "zebra"]
 
-    def test_max_samples_none_displays_as_all(self: Any) -> None:
+    def test_max_samples_none_displays_as_all(self) -> None:
         report = SchemaVerificationReport(
             providers={},
             max_samples=None,
@@ -186,7 +185,7 @@ class TestSchemaVerificationReport:
         d = report.to_dict()
         assert d["max_samples"] == "all"
 
-    def test_record_limit_none_displays_as_all(self: Any) -> None:
+    def test_record_limit_none_displays_as_all(self) -> None:
         report = SchemaVerificationReport(
             providers={},
             max_samples=None,
@@ -198,7 +197,7 @@ class TestSchemaVerificationReport:
 
 
 class TestProviderArtifactProof:
-    def test_to_dict(self: Any) -> None:
+    def test_to_dict(self) -> None:
         report = ProviderArtifactProof(
             provider="claude-code",
             total_records=4,
@@ -227,7 +226,7 @@ class TestProviderArtifactProof:
 
 
 class TestArtifactProofReport:
-    def test_to_dict_structure(self: Any) -> None:
+    def test_to_dict_structure(self) -> None:
         report = ArtifactProofReport(
             providers={
                 "chatgpt": ProviderArtifactProof(
@@ -254,12 +253,12 @@ class TestArtifactProofReport:
 
 
 class TestVerifyRawCorpus:
-    def test_nonexistent_db_returns_empty(self: Any, tmp_path: Path) -> None:
+    def test_nonexistent_db_returns_empty(self, tmp_path: Path) -> None:
         report = verify_raw_corpus(db_path=tmp_path / "nope.db", request=SchemaVerificationRequest())
         assert report.total_records == 0
         assert report.providers == {}
 
-    def test_empty_db(self: Any, tmp_path: Path) -> None:
+    def test_empty_db(self, tmp_path: Path) -> None:
         from polylogue.storage.backends.connection import open_connection
 
         db = tmp_path / "empty.db"
@@ -269,7 +268,7 @@ class TestVerifyRawCorpus:
         assert report.total_records == 0
         assert report.providers == {}
 
-    def test_provider_filter_empty(self: Any, tmp_path: Path) -> None:
+    def test_provider_filter_empty(self, tmp_path: Path) -> None:
         from polylogue.storage.backends.connection import open_connection
 
         db = tmp_path / "empty.db"
@@ -281,7 +280,7 @@ class TestVerifyRawCorpus:
         )
         assert report.total_records == 0
 
-    def test_max_samples_preserved_in_report(self: Any, tmp_path: Path) -> None:
+    def test_max_samples_preserved_in_report(self, tmp_path: Path) -> None:
         from polylogue.storage.backends.connection import open_connection
 
         db = tmp_path / "empty.db"
@@ -293,7 +292,7 @@ class TestVerifyRawCorpus:
         )
         assert report.max_samples == 100
 
-    def test_record_limit_preserved_in_report(self: Any, tmp_path: Path) -> None:
+    def test_record_limit_preserved_in_report(self, tmp_path: Path) -> None:
         from polylogue.storage.backends.connection import open_connection
 
         db = tmp_path / "empty.db"
@@ -305,7 +304,7 @@ class TestVerifyRawCorpus:
         )
         assert report.record_limit == 50
 
-    def test_record_offset_preserved_in_report(self: Any, tmp_path: Path) -> None:
+    def test_record_offset_preserved_in_report(self, tmp_path: Path) -> None:
         from polylogue.storage.backends.connection import open_connection
 
         db = tmp_path / "empty.db"
@@ -317,7 +316,7 @@ class TestVerifyRawCorpus:
         )
         assert report.record_offset == 25
 
-    def test_offset_negative_becomes_zero(self: Any, tmp_path: Path) -> None:
+    def test_offset_negative_becomes_zero(self, tmp_path: Path) -> None:
         from polylogue.storage.backends.connection import open_connection
 
         db = tmp_path / "empty.db"
@@ -329,7 +328,7 @@ class TestVerifyRawCorpus:
         )
         assert report.record_offset == 0
 
-    def test_quarantine_malformed_flag_preserved(self: Any, tmp_path: Path) -> None:
+    def test_quarantine_malformed_flag_preserved(self, tmp_path: Path) -> None:
         from polylogue.storage.backends.connection import open_connection
 
         db = tmp_path / "empty.db"
@@ -342,7 +341,7 @@ class TestVerifyRawCorpus:
         )
         assert report.total_records == 0
 
-    def test_report_structure_matches_schema(self: Any, tmp_path: Path) -> None:
+    def test_report_structure_matches_schema(self, tmp_path: Path) -> None:
         from polylogue.storage.backends.connection import open_connection
 
         db = tmp_path / "empty.db"
@@ -355,7 +354,7 @@ class TestVerifyRawCorpus:
         assert hasattr(report, "record_limit")
         assert hasattr(report, "record_offset")
 
-    def test_provider_stats_have_required_fields(self: Any, tmp_path: Path) -> None:
+    def test_provider_stats_have_required_fields(self, tmp_path: Path) -> None:
         from polylogue.storage.backends.connection import open_connection
 
         db = tmp_path / "empty.db"
@@ -374,7 +373,7 @@ class TestVerifyRawCorpus:
 
 
 class TestProveRawArtifactCoverage:
-    def test_nonexistent_db_returns_empty(self: Any, tmp_path: Path) -> None:
+    def test_nonexistent_db_returns_empty(self, tmp_path: Path) -> None:
         report = prove_raw_artifact_coverage(
             db_path=tmp_path / "missing.db",
             request=ArtifactProofRequest(),
@@ -383,7 +382,7 @@ class TestProveRawArtifactCoverage:
         assert report.providers == {}
 
     def test_reports_contracts_sidecars_unknowns_and_decode_errors(
-        self: Any,
+        self,
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
@@ -456,7 +455,13 @@ class TestProveRawArtifactCoverage:
             ],
         )
 
-        def _resolve_payload(self: Any, provider: Any, payload: Any, *, source_path: Any = None) -> Any:
+        def _resolve_payload(
+            self: object,
+            provider: object,
+            payload: object,
+            *,
+            source_path: str | None = None,
+        ) -> SchemaResolution | None:
             if str(provider) == "chatgpt":
                 return SchemaResolution(
                     provider="chatgpt",
@@ -468,7 +473,11 @@ class TestProveRawArtifactCoverage:
                 )
             return None
 
-        def _get_package(self: Any, provider: Any, version: Any = "default") -> Any:
+        def _get_package(
+            self: object,
+            provider: object,
+            version: str = "default",
+        ) -> SchemaVersionPackage | None:
             if str(provider) == "chatgpt" and version == "v1":
                 return package
             return None
@@ -505,7 +514,7 @@ class TestProveRawArtifactCoverage:
         assert observation_count == 5
 
     def test_refreshes_stale_existing_observation_resolution(
-        self: Any,
+        self,
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
@@ -608,7 +617,13 @@ class TestProveRawArtifactCoverage:
             ],
         )
 
-        def _resolve_payload(self: Any, provider: Any, payload: Any, *, source_path: Any = None) -> Any:
+        def _resolve_payload(
+            self: object,
+            provider: object,
+            payload: object,
+            *,
+            source_path: str | None = None,
+        ) -> SchemaResolution | None:
             if str(provider) == "chatgpt":
                 return SchemaResolution(
                     provider="chatgpt",
@@ -620,7 +635,11 @@ class TestProveRawArtifactCoverage:
                 )
             return None
 
-        def _get_package(self: Any, provider: Any, version: Any = "default") -> Any:
+        def _get_package(
+            self: object,
+            provider: object,
+            version: str = "default",
+        ) -> SchemaVersionPackage | None:
             if str(provider) == "chatgpt" and version == "v1":
                 return package
             return None
@@ -652,7 +671,7 @@ class TestProveRawArtifactCoverage:
         assert refreshed["resolution_reason"] == "exact_structure"
 
     def test_lists_artifact_rows_and_cohorts_from_durable_control_plane(
-        self: Any,
+        self,
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
@@ -704,7 +723,13 @@ class TestProveRawArtifactCoverage:
             ],
         )
 
-        def _resolve_payload(self: Any, provider: Any, payload: Any, *, source_path: Any = None) -> Any:
+        def _resolve_payload(
+            self: object,
+            provider: object,
+            payload: object,
+            *,
+            source_path: str | None = None,
+        ) -> SchemaResolution | None:
             if str(provider) == "chatgpt":
                 return SchemaResolution(
                     provider="chatgpt",
@@ -716,7 +741,11 @@ class TestProveRawArtifactCoverage:
                 )
             return None
 
-        def _get_package(self: Any, provider: Any, version: Any = "default") -> Any:
+        def _get_package(
+            self: object,
+            provider: object,
+            version: str = "default",
+        ) -> SchemaVersionPackage | None:
             if str(provider) == "chatgpt" and version == "v1":
                 return package
             return None
@@ -754,7 +783,7 @@ class TestProveRawArtifactCoverage:
         assert sidecar_cohort.linked_sidecar_count == 1
 
     def test_large_json_documents_use_bounded_full_read_fallback(
-        self: Any,
+        self,
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
@@ -802,7 +831,13 @@ class TestProveRawArtifactCoverage:
             ],
         )
 
-        def _resolve_payload(self: Any, provider: Any, payload: Any, *, source_path: Any = None) -> Any:
+        def _resolve_payload(
+            self: object,
+            provider: object,
+            payload: object,
+            *,
+            source_path: str | None = None,
+        ) -> SchemaResolution | None:
             if str(provider) == "claude-ai":
                 return SchemaResolution(
                     provider="claude-ai",
@@ -814,7 +849,11 @@ class TestProveRawArtifactCoverage:
                 )
             return None
 
-        def _get_package(self: Any, provider: Any, version: Any = "default") -> Any:
+        def _get_package(
+            self: object,
+            provider: object,
+            version: str = "default",
+        ) -> SchemaVersionPackage | None:
             if str(provider) == "claude-ai" and version == "v1":
                 return package
             return None


### PR DESCRIPTION
## Summary
- Remove explicit `Any` usage from `tests/unit/core` by promoting core test fixtures, schema payloads, repository fixtures, and Hypothesis model strategies to concrete typed contracts.
- Tighten schema generation/verification tests, conversation semantic tests, timestamp/privacy/filter law tests, and semantic-facts tests without changing production behavior.
- Make semantic-facts repo-name expectations derive from the test checkout root instead of hard-coding `polylogue`, so isolated worktrees remain valid.

## Problem
- The mypy cleanup campaign had already tightened production and devtools seams, but `tests/unit/core` still had broad dynamic boundaries that obscured the model/schema contracts those tests are supposed to verify.
- Several malformed-input tests used `Any` where the intent was actually `object` plus explicit narrowing/casting at the invalid boundary.
- Some semantic-facts tests assumed a fixed checkout directory name, which fails in isolated worktrees like `/tmp/polylogue-281`.

## Solution
- Replace `Any` annotations in 13 core test files with concrete `Conversation`, `Message`, `ConversationRepository`, `Path`, JSON document/value aliases, and targeted callable/projection contracts.
- Use `object` for deliberately malformed payloads and narrow at the exact call site where runtime guard behavior is under test.
- Keep dynamic schema traversal local and typed through `JSONDocument`, `JSONValue`, and `json_document` helpers.
- Derive expected repo names from `REPO_ROOT.name` in semantic-facts coverage.

## Verification
- `ruff format tests/unit/core/test_message_laws.py tests/unit/core/test_filter_composition_laws.py tests/unit/core/test_privacy_guards.py tests/unit/core/test_timestamp_guards.py tests/unit/core/test_conversation_semantics.py tests/unit/core/test_query_retrieval_candidates.py tests/unit/core/test_semantic_facts.py tests/unit/core/test_synthetic_semantic_wiring.py tests/unit/core/test_schema_corpus_alignment.py tests/unit/core/test_filters_schemas.py`
- `ruff check tests/unit/core/test_message_laws.py tests/unit/core/test_filter_composition_laws.py tests/unit/core/test_privacy_guards.py tests/unit/core/test_timestamp_guards.py tests/unit/core/test_conversation_semantics.py tests/unit/core/test_query_retrieval_candidates.py tests/unit/core/test_semantic_facts.py tests/unit/core/test_synthetic_semantic_wiring.py tests/unit/core/test_schema_corpus_alignment.py tests/unit/core/test_filters_schemas.py`
- `mypy tests/unit/core/test_message_laws.py tests/unit/core/test_filter_composition_laws.py tests/unit/core/test_privacy_guards.py tests/unit/core/test_timestamp_guards.py tests/unit/core/test_conversation_semantics.py tests/unit/core/test_query_retrieval_candidates.py tests/unit/core/test_semantic_facts.py tests/unit/core/test_synthetic_semantic_wiring.py tests/unit/core/test_schema_corpus_alignment.py tests/unit/core/test_filters_schemas.py`
- `pytest -q tests/unit/core/test_message_laws.py tests/unit/core/test_filter_composition_laws.py tests/unit/core/test_privacy_guards.py tests/unit/core/test_timestamp_guards.py tests/unit/core/test_conversation_semantics.py tests/unit/core/test_query_retrieval_candidates.py tests/unit/core/test_semantic_facts.py tests/unit/core/test_synthetic_semantic_wiring.py tests/unit/core/test_schema_corpus_alignment.py tests/unit/core/test_filters_schemas.py`
- `PATH=/tmp/polylogue-281/.cache/codex-bin:$PATH devtools verify --quick`
- pre-push `devtools verify --quick`

Ref #281
