### PR TITLE
test: type strategy and infra contracts

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,8 @@ import os
 import sqlite3
 from collections.abc import AsyncIterator, Callable, Iterator, Mapping
 from pathlib import Path
-from typing import Any
+from types import ModuleType
+from typing import TYPE_CHECKING
 
 import pytest
 from hypothesis import HealthCheck, settings
@@ -16,6 +17,14 @@ from polylogue.lib.models import Conversation
 from polylogue.scenarios import CorpusSpec, build_default_corpus_specs
 from polylogue.storage.store import RawConversationRecord
 from tests.infra.builders import make_conv, make_msg
+
+if TYPE_CHECKING:
+    from click.testing import CliRunner
+
+    from polylogue.paths import Source
+    from polylogue.storage.backends import SQLiteBackend
+    from polylogue.storage.repository import ConversationRepository
+    from tests.infra.storage_records import ConversationBuilder
 
 # ---------------------------------------------------------------------------
 # Scale markers for data-gravity and long-haul validation (Workstream H)
@@ -138,7 +147,7 @@ def db_without_fts(tmp_path: Path) -> Path:
 
 
 @pytest.fixture
-def storage_repository(workspace_env: dict[str, Path]) -> Any:
+def storage_repository(workspace_env: dict[str, Path]) -> ConversationRepository:
     """Storage repository with its own write lock.
 
     Use this fixture in tests that need thread-safe storage operations.
@@ -331,12 +340,12 @@ def mock_media_downloader(monkeypatch: pytest.MonkeyPatch) -> dict[str, object]:
     from tests.infra.drive_mocks import MockMediaIoBaseDownload
 
     # Patch the _import_module function to return mock for MediaIoBaseDownload
+    class MockHttpModule(ModuleType):
+        MediaIoBaseDownload: type[MockMediaIoBaseDownload]
 
-    def mock_import_module(name: str) -> Any:
+    def mock_import_module(name: str) -> ModuleType:
         if name == "googleapiclient.http":
-            import types
-
-            mock_http: Any = types.ModuleType("googleapiclient.http")
+            mock_http = MockHttpModule("googleapiclient.http")
             mock_http.MediaIoBaseDownload = MockMediaIoBaseDownload
             return mock_http
         # Fall through to original for other modules
@@ -370,7 +379,7 @@ def db_path(workspace_env: Mapping[str, Path]) -> Path:
 
 
 @pytest.fixture
-def conversation_builder(db_path: Path) -> Callable[[str], Any]:
+def conversation_builder(db_path: Path) -> Callable[[str], ConversationBuilder]:
     """Fixture that provides ConversationBuilder factory.
 
     Usage in tests:
@@ -381,7 +390,7 @@ def conversation_builder(db_path: Path) -> Callable[[str], Any]:
     """
     from tests.infra.storage_records import ConversationBuilder
 
-    def _builder(conversation_id: str = "test-conv") -> Any:
+    def _builder(conversation_id: str = "test-conv") -> ConversationBuilder:
         return ConversationBuilder(db_path, conversation_id)
 
     return _builder
@@ -420,7 +429,7 @@ def test_conn(test_db: Path) -> Iterator[sqlite3.Connection]:
 
 
 @pytest.fixture
-async def sqlite_backend(tmp_path: Path) -> AsyncIterator[Any]:
+async def sqlite_backend(tmp_path: Path) -> AsyncIterator[SQLiteBackend]:
     """Create a SQLite backend for testing."""
 
     from polylogue.storage.backends import SQLiteBackend
@@ -467,7 +476,7 @@ def sample_conversation() -> Conversation:
 
 
 @pytest.fixture
-def cli_runner() -> Any:
+def cli_runner() -> CliRunner:
     """Create a CliRunner for testing CLI commands.
 
     Replaces duplicate definitions across CLI test files.
@@ -590,7 +599,7 @@ def seeded_db(tmp_path_factory: pytest.TempPathFactory) -> Path:
 
 
 @pytest.fixture
-def seeded_repository(seeded_db: Path) -> Any:
+def seeded_repository(seeded_db: Path) -> ConversationRepository:
     """Repository backed by the seeded database.
 
     Use this when tests need a ConversationRepository with real provider data.
@@ -659,7 +668,7 @@ from tests.infra.corpus_fixtures import corpus_seeded_db  # noqa: F401
 
 
 @pytest.fixture
-def synthetic_source(tmp_path: Path) -> Callable[[str, int, range, int], Any]:
+def synthetic_source(tmp_path: Path) -> Callable[[str, int, range, int], Source]:
     """Factory fixture that generates synthetic Source objects for any provider.
 
     Writes SyntheticCorpus output to temp files, returning Source objects that

--- a/tests/infra/builders.py
+++ b/tests/infra/builders.py
@@ -18,7 +18,6 @@ Usage:
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import Any
 
 from polylogue.lib.messages import MessageCollection
 from polylogue.lib.models import Conversation, Message
@@ -30,7 +29,7 @@ def make_msg(
     id: str = "m1",
     role: Role | str = Role.USER,
     text: str | None = "hello",
-    **kwargs: Any,
+    **kwargs: object,
 ) -> Message:
     """Build a Message with sensible defaults for testing.
 
@@ -38,13 +37,15 @@ def make_msg(
         id: Message ID (default "m1").
         role: Message role — "user", "assistant", "system", etc. (default "user").
         text: Message text; may be None to exercise None-guard code paths.
-        **kwargs: Any additional Message fields (timestamp, attachments, etc.).
+        **kwargs: Additional Message fields (timestamp, attachments, etc.).
 
     Returns:
         A fully constructed Message domain object.
     """
     role_value = role if isinstance(role, Role) else (Role.normalize(role.strip()) if role.strip() else Role.UNKNOWN)
-    return Message(id=id, role=role_value, text=text, **kwargs)
+    payload: dict[str, object] = {"id": id, "role": role_value, "text": text}
+    payload.update(kwargs)
+    return Message.model_validate(payload)
 
 
 def make_conv(
@@ -52,7 +53,7 @@ def make_conv(
     title: str | None = "Test",
     provider: Provider | str = Provider.UNKNOWN,
     id: str = "test-conv",
-    **kwargs: Any,
+    **kwargs: object,
 ) -> Conversation:
     """Build a Conversation with sensible defaults for testing.
 
@@ -61,7 +62,7 @@ def make_conv(
         title: Conversation title; may be None to exercise None-guard code paths.
         provider: Provider name (default "test").
         id: Conversation ID (default "test-conv").
-        **kwargs: Any additional Conversation fields (created_at, metadata, etc.).
+        **kwargs: Additional Conversation fields (created_at, metadata, etc.).
 
     Returns:
         A fully constructed Conversation domain object with an eager MessageCollection.
@@ -73,10 +74,11 @@ def make_conv(
         message_collection = messages
     else:
         message_collection = MessageCollection(messages=list(messages))
-    return Conversation(
-        id=ConversationId(id),
-        provider=provider_value,
-        title=title,
-        messages=message_collection,
-        **kwargs,
-    )
+    payload: dict[str, object] = {
+        "id": ConversationId(id),
+        "provider": provider_value,
+        "title": title,
+        "messages": message_collection,
+    }
+    payload.update(kwargs)
+    return Conversation.model_validate(payload)

--- a/tests/infra/chaos_sources.py
+++ b/tests/infra/chaos_sources.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any
+from typing import TypeAlias
 
 from tests.infra.large_batches import (
     corrupt_line_bad_utf8,
@@ -19,6 +19,23 @@ from tests.infra.large_batches import (
     write_jsonl_file,
     write_jsonl_with_bad_utf8,
 )
+
+ChaosFileSpec: TypeAlias = dict[str, object]
+
+
+def _spec_str(spec: ChaosFileSpec, key: str, default: str = "") -> str:
+    value = spec.get(key, default)
+    return value if isinstance(value, str) else default
+
+
+def _spec_int(spec: ChaosFileSpec, key: str, default: int = 0) -> int:
+    value = spec.get(key, default)
+    return value if isinstance(value, int) else default
+
+
+def _spec_indices(spec: ChaosFileSpec) -> list[int]:
+    value = spec.get("corrupt_indices", [])
+    return [item for item in value if isinstance(item, int)] if isinstance(value, list) else []
 
 
 class ChaosInboxBuilder:
@@ -34,7 +51,7 @@ class ChaosInboxBuilder:
     def __init__(self, base_path: Path):
         self.base_path = base_path
         self.base_path.mkdir(parents=True, exist_ok=True)
-        self._files: dict[str, dict[str, Any]] = {}
+        self._files: dict[str, ChaosFileSpec] = {}
 
     def add_valid_jsonl(
         self,
@@ -110,20 +127,22 @@ class ChaosInboxBuilder:
             path = self.base_path / filename
             path.parent.mkdir(parents=True, exist_ok=True)
 
-            if spec["type"] == "empty":
+            spec_type = _spec_str(spec, "type")
+
+            if spec_type == "empty":
                 path.write_bytes(b"")
 
-            elif spec["type"] == "binary_garbage":
-                path.write_bytes(b"\x00\xff\xde\xad\xbe\xef" * (spec["size"] // 6))
+            elif spec_type == "binary_garbage":
+                path.write_bytes(b"\x00\xff\xde\xad\xbe\xef" * (_spec_int(spec, "size") // 6))
 
-            elif spec["type"] == "valid_jsonl":
+            elif spec_type == "valid_jsonl":
                 lines = generate_large_jsonl(
-                    spec["count"],
-                    provider=spec["provider"],
+                    _spec_int(spec, "count"),
+                    provider=_spec_str(spec, "provider", "codex"),
                 )
                 write_jsonl_file(path, lines)
 
-            elif spec["type"] == "jsonl_with_bom":
+            elif spec_type == "jsonl_with_bom":
                 # Valid codex JSONL but with UTF-8 BOM marker
                 lines = generate_large_jsonl(5, provider="codex")
                 path.parent.mkdir(parents=True, exist_ok=True)
@@ -134,20 +153,21 @@ class ChaosInboxBuilder:
                     for line in lines:
                         f.write(line.encode("utf-8") + b"\n")
 
-            elif spec["type"] == "corrupted_jsonl":
+            elif spec_type == "corrupted_jsonl":
                 lines = generate_large_jsonl(
-                    spec["count"],
-                    provider=spec["provider"],
+                    _spec_int(spec, "count"),
+                    provider=_spec_str(spec, "provider", "codex"),
                 )
 
                 # Apply corruptions in reverse order to preserve indices
-                corruption_fn = self._get_corruption_fn(spec["corruption_type"])
-                for idx in sorted(spec["corrupt_indices"], reverse=True):
+                corruption_type = _spec_str(spec, "corruption_type", "malformed")
+                corruption_fn = self._get_corruption_fn(corruption_type)
+                for idx in sorted(_spec_indices(spec), reverse=True):
                     if 0 <= idx < len(lines):
                         lines = corruption_fn(lines, idx)
 
                 # Special handling for bad UTF-8
-                if spec["corruption_type"] == "bad_utf8":
+                if corruption_type == "bad_utf8":
                     write_jsonl_with_bad_utf8(path, lines)
                 else:
                     write_jsonl_file(path, lines)

--- a/tests/infra/drive_mocks.py
+++ b/tests/infra/drive_mocks.py
@@ -3,10 +3,21 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Any
+from datetime import datetime
+from typing import ParamSpec, Protocol, TypeVar
 
 from polylogue.sources.drive_types import DriveError, DriveNotFoundError
+
+P = ParamSpec("P")
+T = TypeVar("T")
+
+
+class BinaryWritable(Protocol):
+    """Minimal writable handle contract used by Drive downloads."""
+
+    def write(self, data: bytes) -> object: ...
 
 
 @dataclass
@@ -19,12 +30,13 @@ class MockCredentials:
     client_id: str = "mock_client_id.apps.googleusercontent.com"
     client_secret: str = "mock_client_secret"
     scopes: list[str] = field(default_factory=lambda: ["https://www.googleapis.com/auth/drive.readonly"])
-    expiry: Any = None
+    expiry: datetime | None = None
     valid: bool = True
     expired: bool = False
 
-    def refresh(self, request: Any) -> None:
+    def refresh(self, request: object) -> None:
         """Mock refresh method."""
+        del request
         if not self.refresh_token:
             raise Exception("Refresh token not found")
         self.token = "refreshed_access_token"
@@ -125,7 +137,7 @@ class MockMediaIoBaseDownload:
             status, done = downloader.next_chunk()
     """
 
-    def __init__(self, fd: Any, request: MockGetMediaResponse, chunksize: int = 1024 * 1024):
+    def __init__(self, fd: BinaryWritable, request: MockGetMediaResponse, chunksize: int = 1024 * 1024):
         """Initialize the mock downloader.
 
         Args:
@@ -139,7 +151,7 @@ class MockMediaIoBaseDownload:
         self._done = False
         self._progress = 0.0
 
-    def next_chunk(self) -> tuple[Any, bool]:
+    def next_chunk(self) -> tuple[MockDownloadStatus | None, bool]:
         """Download the next chunk of the file.
 
         Returns:
@@ -188,7 +200,7 @@ class MockFilesResource:
         """
         self.files = files or {}
         self.file_content = file_content or {}
-        self._list_filters: dict[str, Any] = {}
+        self._list_filters: dict[str, object] = {}
 
     def _parse_query(self, q: str) -> dict[str, str]:
         """Parse Drive API query string into filters.
@@ -307,13 +319,13 @@ class FakeDriveServiceGateway:
         self._service = self._mock_service
         self._download_error = download_error
 
-    def call_with_retry(self, func: Any, *args: Any, **kwargs: Any) -> Any:
+    def call_with_retry(self, func: Callable[P, T], *args: P.args, **kwargs: P.kwargs) -> T:
         return func(*args, **kwargs)
 
     def _service_handle(self) -> MockDriveService:
         return self._mock_service
 
-    def get_file(self, file_id: str, fields: str) -> dict[str, Any]:
+    def get_file(self, file_id: str, fields: str) -> dict[str, object]:
         return self._mock_service.files().get(fileId=file_id, fields=fields).execute()
 
     def list_files(
@@ -323,10 +335,10 @@ class FakeDriveServiceGateway:
         fields: str,
         page_token: str | None,
         page_size: int,
-    ) -> dict[str, Any]:
+    ) -> dict[str, object]:
         return self._mock_service.files().list(q=q, fields=fields, pageToken=page_token, pageSize=page_size).execute()
 
-    def download_file(self, file_id: str, handle: Any) -> None:
+    def download_file(self, file_id: str, handle: BinaryWritable) -> None:
         if self._download_error is not None:
             raise self._download_error
         content = self._mock_service.files().get_media(fileId=file_id).execute()
@@ -334,9 +346,9 @@ class FakeDriveServiceGateway:
 
     def _download_request(
         self,
-        request: Any,
-        handle: Any,
-        downloader_cls: Any,
+        request: MockGetMediaResponse,
+        handle: BinaryWritable,
+        downloader_cls: type[MockMediaIoBaseDownload],
         *,
         file_id: str,
     ) -> None:

--- a/tests/infra/large_batches.py
+++ b/tests/infra/large_batches.py
@@ -13,7 +13,8 @@ import json
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+
+from polylogue.lib.json import JSONDocument
 
 
 def generate_valid_jsonl_record(
@@ -22,7 +23,7 @@ def generate_valid_jsonl_record(
     provider: str = "codex",
     base_ts: float = 1700000000.0,
     session_id: str | None = None,
-) -> dict[str, Any]:
+) -> JSONDocument:
     """Generate a single valid JSONL record for a given provider."""
     ts = base_ts + index * 60  # 1-minute intervals
     role = "user" if index % 2 == 0 else "assistant"
@@ -147,9 +148,9 @@ def corrupt_line_wrong_envelope(lines: list[str], index: int) -> list[str]:
     return result
 
 
-def generate_timestamp_patterns() -> dict[str, list[dict[str, Any]]]:
+def generate_timestamp_patterns() -> dict[str, list[JSONDocument]]:
     """Generate records with extreme timestamp patterns for chronology testing."""
-    patterns: dict[str, list[dict[str, Any]]] = {}
+    patterns: dict[str, list[JSONDocument]] = {}
 
     # 1970-adjacent
     patterns["epoch_near_zero"] = [_make_ts_record(i, ts=86400 + i * 3600) for i in range(5)]
@@ -218,7 +219,7 @@ def generate_timestamp_patterns() -> dict[str, list[dict[str, Any]]]:
     return patterns
 
 
-def _make_ts_record(index: int, ts: float) -> dict[str, Any]:
+def _make_ts_record(index: int, ts: float) -> JSONDocument:
     """Make a codex-shaped record with a specific timestamp."""
     role = "user" if index % 2 == 0 else "assistant"
     return {

--- a/tests/infra/mcp.py
+++ b/tests/infra/mcp.py
@@ -6,7 +6,7 @@ import asyncio
 import inspect
 from collections.abc import Awaitable, Callable, Coroutine, Sequence
 from datetime import datetime, timezone
-from typing import Any, TypeVar, cast
+from typing import TypeVar, cast
 from unittest.mock import AsyncMock, MagicMock
 
 from polylogue.lib.models import Conversation
@@ -74,7 +74,7 @@ def invoke_surface(
     """Call an MCP surface whether it is sync or async."""
     result = fn(*args, **kwargs)
     if inspect.iscoroutine(result):
-        return asyncio.run(cast(Coroutine[Any, Any, SurfaceResult], result))
+        return asyncio.run(cast(Coroutine[object, object, SurfaceResult], result))
     return cast(SurfaceResult, result)
 
 

--- a/tests/infra/pty_cli.py
+++ b/tests/infra/pty_cli.py
@@ -19,9 +19,10 @@ import re
 import subprocess
 import sys
 import time
+from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Protocol, cast
 
 # Conditional pyte import with fallback
 try:
@@ -30,6 +31,12 @@ try:
     HAS_PYTE = True
 except ImportError:
     HAS_PYTE = False
+
+
+class TerminalChar(Protocol):
+    """Subset of pyte's Char object used for snapshot rendering."""
+
+    data: str
 
 
 @dataclass
@@ -207,14 +214,14 @@ def run_in_pty(
     stream.feed(raw_output.decode("utf-8", errors="replace"))
 
     # Extract full output: scrollback history + visible screen
-    def _chardict_to_str(chardict: Any) -> str:
+    def _chardict_to_str(chardict: Mapping[int, TerminalChar]) -> str:
         """Convert pyte history line (StaticDefaultDict of Char) to string."""
         if not chardict:
             return ""
         max_col = max(chardict.keys()) if chardict else 0
         return "".join(chardict[i].data for i in range(max_col + 1)).rstrip()
 
-    history_lines = [_chardict_to_str(line) for line in screen.history.top]
+    history_lines = [_chardict_to_str(cast(Mapping[int, TerminalChar], line)) for line in screen.history.top]
     visible_lines = [line.rstrip() for line in screen.display]
     grid = history_lines + visible_lines
 

--- a/tests/infra/semantic_facts.py
+++ b/tests/infra/semantic_facts.py
@@ -6,9 +6,25 @@ semantic fact tuples so tests can compare meaning rather than formatting.
 
 from __future__ import annotations
 
+import sqlite3
 from collections import Counter
 from dataclasses import dataclass
-from typing import Any
+
+from polylogue.lib.json import JSONDocument, json_document_list
+from polylogue.lib.models import Conversation
+from polylogue.storage.store import ConversationRecord, MessageRecord
+
+
+def _string_value(value: object) -> str:
+    return value if isinstance(value, str) else ""
+
+
+def _optional_string(value: object) -> str | None:
+    return value if isinstance(value, str) else None
+
+
+def _content_blocks(message: JSONDocument) -> list[JSONDocument]:
+    return json_document_list(message.get("content_blocks"))
 
 
 @dataclass(frozen=True)
@@ -25,21 +41,18 @@ class ConversationFacts:
     has_thinking: bool
 
     @classmethod
-    def from_domain_conversation(cls, conv: Any) -> ConversationFacts:
+    def from_domain_conversation(cls, conv: Conversation) -> ConversationFacts:
         """Extract facts from a domain Conversation object."""
         messages = list(conv.messages)
         roles = Counter(str(m.role) for m in messages)
         has_tool_use = any(
-            getattr(m, "content_blocks", None)
-            and any(b.get("type") in ("tool_use", "tool_result") for b in m.content_blocks if isinstance(b, dict))
+            m.content_blocks and any(block.get("type") in ("tool_use", "tool_result") for block in m.content_blocks)
             for m in messages
         )
         has_thinking = any(
-            getattr(m, "content_blocks", None)
-            and any(b.get("type") == "thinking" for b in m.content_blocks if isinstance(b, dict))
-            for m in messages
+            m.content_blocks and any(block.get("type") == "thinking" for block in m.content_blocks) for m in messages
         )
-        has_attachments = any(getattr(m, "attachments", None) for m in messages)
+        has_attachments = any(m.attachments for m in messages)
         return cls(
             conversation_id=str(conv.id),
             provider=str(conv.provider),
@@ -52,19 +65,22 @@ class ConversationFacts:
         )
 
     @classmethod
-    def from_json_payload(cls, payload: dict[str, Any]) -> ConversationFacts:
+    def from_json_payload(cls, payload: JSONDocument) -> ConversationFacts:
         """Extract facts from a CLI JSON output payload."""
-        messages = payload.get("messages", [])
-        roles = Counter(m.get("role", "unknown") for m in messages)
+        messages = json_document_list(payload.get("messages"))
+        roles = Counter(_string_value(m.get("role")) or "unknown" for m in messages)
         has_tool_use = any(
-            any(b.get("type") in ("tool_use", "tool_result") for b in m.get("content_blocks", [])) for m in messages
+            any(block.get("type") in ("tool_use", "tool_result") for block in _content_blocks(message))
+            for message in messages
         )
-        has_thinking = any(any(b.get("type") == "thinking" for b in m.get("content_blocks", [])) for m in messages)
-        has_attachments = any(m.get("attachments") for m in messages)
+        has_thinking = any(
+            any(block.get("type") == "thinking" for block in _content_blocks(message)) for message in messages
+        )
+        has_attachments = any(bool(message.get("attachments")) for message in messages)
         return cls(
-            conversation_id=payload.get("id", payload.get("conversation_id", "")),
-            provider=payload.get("provider", payload.get("provider_name", "")),
-            title=payload.get("title"),
+            conversation_id=_string_value(payload.get("id")) or _string_value(payload.get("conversation_id")),
+            provider=_string_value(payload.get("provider")) or _string_value(payload.get("provider_name")),
+            title=_optional_string(payload.get("title")),
             message_count=len(messages),
             role_multiset=dict(roles),
             has_attachments=has_attachments,
@@ -73,11 +89,11 @@ class ConversationFacts:
         )
 
     @classmethod
-    def from_records(cls, conv_record: Any, msg_records: list[Any]) -> ConversationFacts:
+    def from_records(cls, conv_record: ConversationRecord, msg_records: list[MessageRecord]) -> ConversationFacts:
         """Extract facts from storage records (ConversationRecord + MessageRecords)."""
         roles = Counter(str(m.role) for m in msg_records)
-        has_tool_use = any(getattr(m, "has_tool_use", 0) for m in msg_records)
-        has_thinking = any(getattr(m, "has_thinking", 0) for m in msg_records)
+        has_tool_use = any(m.has_tool_use for m in msg_records)
+        has_thinking = any(m.has_thinking for m in msg_records)
         return cls(
             conversation_id=str(conv_record.conversation_id),
             provider=str(conv_record.provider_name),
@@ -99,13 +115,13 @@ class ArchiveFacts:
     total_messages: int
 
     @classmethod
-    def from_db_connection(cls, conn: Any) -> ArchiveFacts:
-        total_convs = conn.execute("SELECT COUNT(*) FROM conversations").fetchone()[0]
+    def from_db_connection(cls, conn: sqlite3.Connection) -> ArchiveFacts:
+        total_convs = int(conn.execute("SELECT COUNT(*) FROM conversations").fetchone()[0])
         provider_rows = conn.execute(
             "SELECT provider_name, COUNT(*) as cnt FROM conversations GROUP BY provider_name"
         ).fetchall()
-        provider_counts = {r["provider_name"]: r["cnt"] for r in provider_rows}
-        total_msgs = conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0]
+        provider_counts = {str(row["provider_name"]): int(row["cnt"]) for row in provider_rows}
+        total_msgs = int(conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0])
         return cls(
             total_conversations=total_convs,
             provider_counts=provider_counts,

--- a/tests/infra/strategies/filters.py
+++ b/tests/infra/strategies/filters.py
@@ -7,9 +7,11 @@ algebra properties (monotonicity, composition, etc).
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
-from typing import Any
+from typing import TypeAlias
 
 from hypothesis import strategies as st
+
+FilterArg: TypeAlias = dict[str, object]
 
 # =============================================================================
 # Filter Type Strategies
@@ -45,7 +47,7 @@ def filter_type_strategy(draw: st.DrawFn) -> str:
 
 
 @st.composite
-def provider_filter_arg_strategy(draw: st.DrawFn) -> dict[str, Any]:
+def provider_filter_arg_strategy(draw: st.DrawFn) -> FilterArg:
     """Generate arguments for provider filter."""
     return {
         "type": "provider",
@@ -54,7 +56,7 @@ def provider_filter_arg_strategy(draw: st.DrawFn) -> dict[str, Any]:
 
 
 @st.composite
-def contains_filter_arg_strategy(draw: st.DrawFn) -> dict[str, Any]:
+def contains_filter_arg_strategy(draw: st.DrawFn) -> FilterArg:
     """Generate arguments for contains (text search) filter."""
     return {
         "type": "contains",
@@ -72,7 +74,7 @@ def contains_filter_arg_strategy(draw: st.DrawFn) -> dict[str, Any]:
 
 
 @st.composite
-def date_filter_arg_strategy(draw: st.DrawFn) -> dict[str, Any]:
+def date_filter_arg_strategy(draw: st.DrawFn) -> FilterArg:
     """Generate arguments for date filters (since/until)."""
     filter_type = draw(st.sampled_from(["since", "until"]))
     base_date = datetime(2024, 1, 1, tzinfo=timezone.utc)
@@ -86,7 +88,7 @@ def date_filter_arg_strategy(draw: st.DrawFn) -> dict[str, Any]:
 
 
 @st.composite
-def limit_filter_arg_strategy(draw: st.DrawFn) -> dict[str, Any]:
+def limit_filter_arg_strategy(draw: st.DrawFn) -> FilterArg:
     """Generate arguments for limit filter."""
     return {
         "type": "limit",
@@ -95,7 +97,7 @@ def limit_filter_arg_strategy(draw: st.DrawFn) -> dict[str, Any]:
 
 
 @st.composite
-def offset_filter_arg_strategy(draw: st.DrawFn) -> dict[str, Any]:
+def offset_filter_arg_strategy(draw: st.DrawFn) -> FilterArg:
     """Generate arguments for offset filter."""
     return {
         "type": "offset",
@@ -104,7 +106,7 @@ def offset_filter_arg_strategy(draw: st.DrawFn) -> dict[str, Any]:
 
 
 @st.composite
-def sort_filter_arg_strategy(draw: st.DrawFn) -> dict[str, Any]:
+def sort_filter_arg_strategy(draw: st.DrawFn) -> FilterArg:
     """Generate arguments for sort filter."""
     return {
         "type": "sort",
@@ -114,7 +116,7 @@ def sort_filter_arg_strategy(draw: st.DrawFn) -> dict[str, Any]:
 
 
 @st.composite
-def role_filter_arg_strategy(draw: st.DrawFn) -> dict[str, Any]:
+def role_filter_arg_strategy(draw: st.DrawFn) -> FilterArg:
     """Generate arguments for role filter."""
     return {
         "type": "role",
@@ -123,7 +125,7 @@ def role_filter_arg_strategy(draw: st.DrawFn) -> dict[str, Any]:
 
 
 @st.composite
-def word_count_filter_arg_strategy(draw: st.DrawFn) -> dict[str, Any]:
+def word_count_filter_arg_strategy(draw: st.DrawFn) -> FilterArg:
     """Generate arguments for word count filters."""
     filter_type = draw(st.sampled_from(["min_words", "max_words"]))
     return {
@@ -137,18 +139,18 @@ def word_count_filter_arg_strategy(draw: st.DrawFn) -> dict[str, Any]:
 # =============================================================================
 
 
-def has_tool_use_filter_arg_strategy() -> st.SearchStrategy[dict[str, Any]]:
+def has_tool_use_filter_arg_strategy() -> st.SearchStrategy[FilterArg]:
     """Generate arguments for has_tool_use filter."""
     return st.just({"type": "has_tool_use"})
 
 
-def has_thinking_filter_arg_strategy() -> st.SearchStrategy[dict[str, Any]]:
+def has_thinking_filter_arg_strategy() -> st.SearchStrategy[FilterArg]:
     """Generate arguments for has_thinking filter."""
     return st.just({"type": "has_thinking"})
 
 
 @st.composite
-def min_messages_filter_arg_strategy(draw: st.DrawFn) -> dict[str, Any]:
+def min_messages_filter_arg_strategy(draw: st.DrawFn) -> FilterArg:
     """Generate arguments for min_messages filter."""
     return {
         "type": "min_messages",
@@ -157,7 +159,7 @@ def min_messages_filter_arg_strategy(draw: st.DrawFn) -> dict[str, Any]:
 
 
 @st.composite
-def max_messages_filter_arg_strategy(draw: st.DrawFn) -> dict[str, Any]:
+def max_messages_filter_arg_strategy(draw: st.DrawFn) -> FilterArg:
     """Generate arguments for max_messages filter."""
     return {
         "type": "max_messages",
@@ -166,7 +168,7 @@ def max_messages_filter_arg_strategy(draw: st.DrawFn) -> dict[str, Any]:
 
 
 @st.composite
-def tag_filter_arg_strategy(draw: st.DrawFn) -> dict[str, Any]:
+def tag_filter_arg_strategy(draw: st.DrawFn) -> FilterArg:
     """Generate arguments for tag filter."""
     return {
         "type": "tag",
@@ -181,7 +183,7 @@ def tag_filter_arg_strategy(draw: st.DrawFn) -> dict[str, Any]:
 
 
 @st.composite
-def exclude_tag_filter_arg_strategy(draw: st.DrawFn) -> dict[str, Any]:
+def exclude_tag_filter_arg_strategy(draw: st.DrawFn) -> FilterArg:
     """Generate arguments for exclude_tag filter."""
     return {
         "type": "exclude_tag",
@@ -201,7 +203,7 @@ def exclude_tag_filter_arg_strategy(draw: st.DrawFn) -> dict[str, Any]:
 
 
 @st.composite
-def filter_arg_strategy(draw: st.DrawFn) -> dict[str, Any]:
+def filter_arg_strategy(draw: st.DrawFn) -> FilterArg:
     """Generate any valid filter argument."""
     return draw(
         st.one_of(
@@ -228,7 +230,7 @@ def filter_chain_strategy(
     draw: st.DrawFn,
     min_filters: int = 1,
     max_filters: int = 5,
-) -> list[dict[str, Any]]:
+) -> list[FilterArg]:
     """Generate a chain of filters for composition testing.
 
     Properties to test with this strategy:
@@ -246,7 +248,7 @@ def filter_chain_strategy(
 
 
 @st.composite
-def pagination_filter_chain_strategy(draw: st.DrawFn) -> list[dict[str, Any]]:
+def pagination_filter_chain_strategy(draw: st.DrawFn) -> list[FilterArg]:
     """Generate pagination filter combinations.
 
     Tests that offset + limit work correctly together.
@@ -261,7 +263,7 @@ def pagination_filter_chain_strategy(draw: st.DrawFn) -> list[dict[str, Any]]:
 
 
 @st.composite
-def date_range_filter_chain_strategy(draw: st.DrawFn) -> list[dict[str, Any]]:
+def date_range_filter_chain_strategy(draw: st.DrawFn) -> list[FilterArg]:
     """Generate date range filter combinations.
 
     Tests that since + until work correctly together.

--- a/tests/infra/strategies/messages.py
+++ b/tests/infra/strategies/messages.py
@@ -7,7 +7,7 @@ and the semantic models.
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, TypeAlias
 
 from hypothesis import strategies as st
 
@@ -17,13 +17,15 @@ from polylogue.types import ConversationId, Provider
 if TYPE_CHECKING:
     from polylogue.lib.models import Conversation, Message
 
+JSONRecord: TypeAlias = dict[str, object]
+
 # =============================================================================
 # Content Block Strategies
 # =============================================================================
 
 
 @st.composite
-def text_content_strategy(draw: st.DrawFn) -> dict[str, Any]:
+def text_content_strategy(draw: st.DrawFn) -> JSONRecord:
     """Generate a text content block."""
     return {
         "type": "text",
@@ -32,7 +34,7 @@ def text_content_strategy(draw: st.DrawFn) -> dict[str, Any]:
 
 
 @st.composite
-def thinking_block_strategy(draw: st.DrawFn) -> dict[str, Any]:
+def thinking_block_strategy(draw: st.DrawFn) -> JSONRecord:
     """Generate a thinking/reasoning block."""
     thinking_text = draw(st.text(min_size=10, max_size=1000))
     return {
@@ -42,7 +44,7 @@ def thinking_block_strategy(draw: st.DrawFn) -> dict[str, Any]:
 
 
 @st.composite
-def tool_use_block_strategy(draw: st.DrawFn) -> dict[str, Any]:
+def tool_use_block_strategy(draw: st.DrawFn) -> JSONRecord:
     """Generate a tool_use block."""
     tool_names = ["Read", "Write", "Edit", "Bash", "Glob", "Grep", "Task", "WebFetch"]
     return {
@@ -60,7 +62,7 @@ def tool_use_block_strategy(draw: st.DrawFn) -> dict[str, Any]:
 
 
 @st.composite
-def tool_result_block_strategy(draw: st.DrawFn) -> dict[str, Any]:
+def tool_result_block_strategy(draw: st.DrawFn) -> JSONRecord:
     """Generate a tool_result block."""
     return {
         "type": "tool_result",
@@ -70,7 +72,7 @@ def tool_result_block_strategy(draw: st.DrawFn) -> dict[str, Any]:
 
 
 @st.composite
-def code_block_strategy(draw: st.DrawFn) -> dict[str, Any]:
+def code_block_strategy(draw: st.DrawFn) -> JSONRecord:
     """Generate a code content block."""
     return {
         "type": "code",
@@ -80,7 +82,7 @@ def code_block_strategy(draw: st.DrawFn) -> dict[str, Any]:
 
 
 @st.composite
-def content_block_strategy(draw: st.DrawFn) -> dict[str, Any]:
+def content_block_strategy(draw: st.DrawFn) -> JSONRecord:
     """Generate any type of content block."""
     return draw(
         st.one_of(
@@ -104,7 +106,7 @@ def message_strategy(
     roles: list[str] | None = None,
     with_timestamp: bool = True,
     with_content_blocks: bool = False,
-) -> dict[str, Any]:
+) -> JSONRecord:
     """Generate a generic message dict.
 
     Args:
@@ -115,7 +117,7 @@ def message_strategy(
     if roles is None:
         roles = ["user", "assistant"]
 
-    msg: dict[str, Any] = {
+    msg: JSONRecord = {
         "id": draw(st.uuids()).hex[:12],
         "role": draw(st.sampled_from(roles)),
         "text": draw(st.text(min_size=1, max_size=500)),
@@ -164,7 +166,7 @@ def conversation_strategy(
     min_messages: int = 1,
     max_messages: int = 20,
     providers: list[str] | None = None,
-) -> dict[str, Any]:
+) -> JSONRecord:
     """Generate a conversation dict.
 
     Args:
@@ -218,7 +220,7 @@ def message_model_strategy(draw: st.DrawFn, *, role: str | None = None) -> Messa
     text = draw(st.one_of(st.none(), st.text(max_size=200)))
 
     # Optionally add content_blocks in provider_meta
-    provider_meta: dict[str, Any] | None = None
+    provider_meta: JSONRecord | None = None
     block_type = draw(st.sampled_from(["text", "thinking", "tool_use", "none"]))
     if block_type != "none":
         block_text = draw(st.text(max_size=100))
@@ -230,7 +232,7 @@ def message_model_strategy(draw: st.DrawFn, *, role: str | None = None) -> Messa
     )
     duration = draw(st.one_of(st.none(), st.integers(min_value=1, max_value=60000)))
     if cost is not None or duration is not None:
-        raw: dict[str, Any] = {}
+        raw: JSONRecord = {}
         if cost is not None:
             raw["costUSD"] = cost
         if duration is not None:

--- a/tests/infra/strategies/pipeline.py
+++ b/tests/infra/strategies/pipeline.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
-from typing import Any
+from typing import TypedDict
 
 from hypothesis import strategies as st
 
@@ -34,6 +34,20 @@ class ParseMergeEvent:
     conversation_id: str
     result_counts: dict[str, int]
     content_changed: bool
+
+
+class ValidationContract(TypedDict):
+    parseable: bool
+    status: str
+    invalid_count: int
+    mark_raw_parsed: bool
+    validation_samples_called: bool
+
+
+class ParseMergeTotals(TypedDict):
+    counts: dict[str, int]
+    changed_counts: dict[str, int]
+    processed_ids: set[str]
 
 
 @st.composite
@@ -131,7 +145,7 @@ def build_validation_payload(case: ValidationCase) -> tuple[bytes, str, str]:
     return b'{"id":"doc-1","mapping":{}}', "chatgpt", "/tmp/conversations.json"
 
 
-def expected_validation_contract(case: ValidationCase) -> dict[str, Any]:
+def expected_validation_contract(case: ValidationCase) -> ValidationContract:
     """Return the expected persisted validation outcome for a generated case."""
     malformed_blocks = case.mode == "strict" and case.malformed_jsonl_lines > 0
     schema_invalid = case.invalid_sample_count > 0
@@ -148,7 +162,7 @@ def expected_validation_contract(case: ValidationCase) -> dict[str, Any]:
     }
 
 
-def expected_parse_merge_totals(events: list[ParseMergeEvent]) -> dict[str, Any]:
+def expected_parse_merge_totals(events: list[ParseMergeEvent]) -> ParseMergeTotals:
     """Compute the aggregate ParseResult contract for a generated event list."""
     counts = {
         "conversations": 0,

--- a/tests/infra/strategies/providers.py
+++ b/tests/infra/strategies/providers.py
@@ -12,10 +12,12 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any, cast
+from typing import TypedDict
 
 from hypothesis import strategies as st
 
+from polylogue.lib.json import JSONDocument, json_document
+from polylogue.lib.json import loads as json_loads
 from polylogue.scenarios import CorpusSpec
 from polylogue.schemas.synthetic import SyntheticCorpus
 
@@ -42,11 +44,29 @@ _PROVIDER_HINT_PATHS: dict[str, tuple[str, ...]] = {
 }
 
 
-def decode_provider_payload(provider: str, raw: bytes) -> Any:
+ProviderPayload = JSONDocument | list[JSONDocument]
+
+
+class ProviderSourceCase(TypedDict):
+    provider: str
+    raw: bytes
+    payload: ProviderPayload
+    path: Path
+
+
+def _json_document_from_bytes(raw: bytes) -> JSONDocument:
+    return json_document(json_loads(raw))
+
+
+def _jsonl_documents(raw: bytes) -> list[JSONDocument]:
+    return [json_document(json_loads(line)) for line in raw.decode().splitlines() if line.strip()]
+
+
+def decode_provider_payload(provider: str, raw: bytes) -> ProviderPayload:
     """Decode schema-generated provider bytes into the wire payload type."""
     if provider in _JSONL_PROVIDERS:
-        return [json.loads(line) for line in raw.decode().splitlines() if line.strip()]
-    return cast(dict[str, Any], json.loads(raw))
+        return _jsonl_documents(raw)
+    return _json_document_from_bytes(raw)
 
 
 # =============================================================================
@@ -59,7 +79,7 @@ def chatgpt_export_strategy(
     draw: st.DrawFn,
     min_messages: int = 1,
     max_messages: int = 10,
-) -> dict[str, Any]:
+) -> JSONDocument:
     """Generate a complete ChatGPT export structure from schema.
 
     Returns a dict with id, title, mapping (UUID→node), create_time, etc.
@@ -68,26 +88,26 @@ def chatgpt_export_strategy(
     seed = draw(st.integers(min_value=0, max_value=2**32))
     n = draw(st.integers(min_value=max(min_messages, 2), max_value=max_messages))
     raw = corpus.generate(count=1, messages_per_conversation=range(n, n + 1), seed=seed)[0]
-    return cast(dict[str, Any], json.loads(raw))
+    return _json_document_from_bytes(raw)
 
 
 @st.composite
 def chatgpt_message_node_strategy(
     draw: st.DrawFn,
     with_children: bool = True,
-) -> dict[str, Any]:
+) -> JSONDocument:
     """Generate a single ChatGPT mapping node.
 
     Extracts a random node from a generated export, so the node has
     valid schema-driven field values and realistic structure.
     """
     export = draw(chatgpt_export_strategy(min_messages=2, max_messages=6))
-    nodes = list(export.get("mapping", {}).values())
+    nodes = [json_document(node) for node in json_document(export.get("mapping")).values()]
     if not nodes:
         # Fallback — shouldn't happen with valid generation
         return {"id": "fallback", "message": None, "children": []}
     idx = draw(st.integers(min_value=0, max_value=len(nodes) - 1))
-    return cast(dict[str, Any], nodes[idx])
+    return nodes[idx]
 
 
 # =============================================================================
@@ -100,13 +120,13 @@ def claude_ai_export_strategy(
     draw: st.DrawFn,
     min_messages: int = 1,
     max_messages: int = 10,
-) -> dict[str, Any]:
+) -> JSONDocument:
     """Generate a complete Claude AI export structure from schema."""
     corpus = _corpus_for("claude-ai")
     seed = draw(st.integers(min_value=0, max_value=2**32))
     n = draw(st.integers(min_value=max(min_messages, 2), max_value=max_messages))
     raw = corpus.generate(count=1, messages_per_conversation=range(n, n + 1), seed=seed)[0]
-    return cast(dict[str, Any], json.loads(raw))
+    return _json_document_from_bytes(raw)
 
 
 # =============================================================================
@@ -115,7 +135,7 @@ def claude_ai_export_strategy(
 
 
 @st.composite
-def claude_code_message_strategy(draw: st.DrawFn) -> dict[str, Any]:
+def claude_code_message_strategy(draw: st.DrawFn) -> JSONDocument:
     """Generate a single Claude Code JSONL message entry."""
     session = draw(claude_code_session_strategy(min_messages=2, max_messages=6))
     if not session:
@@ -129,13 +149,13 @@ def claude_code_session_strategy(
     draw: st.DrawFn,
     min_messages: int = 1,
     max_messages: int = 10,
-) -> list[dict[str, Any]]:
+) -> list[JSONDocument]:
     """Generate a complete Claude Code JSONL session (list of messages)."""
     corpus = _corpus_for("claude-code")
     seed = draw(st.integers(min_value=0, max_value=2**32))
     n = draw(st.integers(min_value=max(min_messages, 2), max_value=max_messages))
     raw = corpus.generate(count=1, messages_per_conversation=range(n, n + 1), seed=seed)[0]
-    return [json.loads(line) for line in raw.decode().strip().split("\n") if line.strip()]
+    return _jsonl_documents(raw)
 
 
 # =============================================================================
@@ -148,24 +168,25 @@ def gemini_export_strategy(
     draw: st.DrawFn,
     min_messages: int = 1,
     max_messages: int = 10,
-) -> dict[str, Any]:
+) -> JSONDocument:
     """Generate a complete Gemini export structure from schema."""
     corpus = _corpus_for("gemini")
     seed = draw(st.integers(min_value=0, max_value=2**32))
     n = draw(st.integers(min_value=max(min_messages, 2), max_value=max_messages))
     raw = corpus.generate(count=1, messages_per_conversation=range(n, n + 1), seed=seed)[0]
-    return cast(dict[str, Any], json.loads(raw))
+    return _json_document_from_bytes(raw)
 
 
 @st.composite
-def gemini_message_strategy(draw: st.DrawFn) -> dict[str, Any]:
+def gemini_message_strategy(draw: st.DrawFn) -> JSONDocument:
     """Generate a single Gemini chunk/message entry."""
     export = draw(gemini_export_strategy(min_messages=2, max_messages=6))
-    messages = export.get("chunkedPrompt", {}).get("chunks", [])
+    chunks = json_document(export.get("chunkedPrompt")).get("chunks")
+    messages = [json_document(message) for message in chunks] if isinstance(chunks, list) else []
     if not messages:
         return {"role": "user", "text": "test"}
     idx = draw(st.integers(min_value=0, max_value=len(messages) - 1))
-    return cast(dict[str, Any], messages[idx])
+    return messages[idx]
 
 
 # =============================================================================
@@ -174,7 +195,7 @@ def gemini_message_strategy(draw: st.DrawFn) -> dict[str, Any]:
 
 
 @st.composite
-def codex_message_strategy(draw: st.DrawFn) -> dict[str, Any]:
+def codex_message_strategy(draw: st.DrawFn) -> JSONDocument:
     """Generate a single Codex message entry."""
     session = draw(codex_session_strategy(min_messages=2, max_messages=6))
     if not session:
@@ -189,7 +210,7 @@ def codex_session_strategy(
     min_messages: int = 1,
     max_messages: int = 10,
     use_envelope: bool = True,
-) -> list[dict[str, Any]]:
+) -> list[JSONDocument]:
     """Generate a Codex JSONL session (list of message records).
 
     Args:
@@ -201,13 +222,13 @@ def codex_session_strategy(
     seed = draw(st.integers(min_value=0, max_value=2**32))
     n = draw(st.integers(min_value=max(min_messages, 2), max_value=max_messages))
     raw = corpus.generate(count=1, messages_per_conversation=range(n, n + 1), seed=seed)[0]
-    records = [json.loads(line) for line in raw.decode().strip().split("\n") if line.strip()]
+    records = _jsonl_documents(raw)
 
     if use_envelope and records:
         # Wrap in the envelope format the parser also supports
         import uuid as _uuid
 
-        envelope: list[dict[str, Any]] = [
+        envelope: list[JSONDocument] = [
             {
                 "type": "session_meta",
                 "payload": {
@@ -228,7 +249,7 @@ def codex_session_strategy(
 # =============================================================================
 
 
-_CHATGPT_SEMANTIC_MESSAGES: tuple[dict[str, Any], ...] = (
+_CHATGPT_SEMANTIC_MESSAGES: tuple[JSONDocument, ...] = (
     {
         "id": "chatgpt-text",
         "author": {"role": "user"},
@@ -252,7 +273,7 @@ _CHATGPT_SEMANTIC_MESSAGES: tuple[dict[str, Any], ...] = (
     },
 )
 
-_CLAUDE_AI_SEMANTIC_MESSAGES: tuple[dict[str, Any], ...] = (
+_CLAUDE_AI_SEMANTIC_MESSAGES: tuple[JSONDocument, ...] = (
     {
         "uuid": "claude-ai-human",
         "text": "question",
@@ -269,7 +290,7 @@ _CLAUDE_AI_SEMANTIC_MESSAGES: tuple[dict[str, Any], ...] = (
     },
 )
 
-_CLAUDE_CODE_SEMANTIC_RECORDS: tuple[dict[str, Any], ...] = (
+_CLAUDE_CODE_SEMANTIC_RECORDS: tuple[JSONDocument, ...] = (
     {
         "type": "assistant",
         "uuid": "claude-code-rich",
@@ -300,7 +321,7 @@ _CLAUDE_CODE_SEMANTIC_RECORDS: tuple[dict[str, Any], ...] = (
     },
 )
 
-_GEMINI_SEMANTIC_MESSAGES: tuple[dict[str, Any], ...] = (
+_GEMINI_SEMANTIC_MESSAGES: tuple[JSONDocument, ...] = (
     {
         "role": "model",
         "text": "thinking message",
@@ -319,7 +340,7 @@ _GEMINI_SEMANTIC_MESSAGES: tuple[dict[str, Any], ...] = (
     },
 )
 
-_CODEX_SEMANTIC_RECORDS: tuple[dict[str, Any], ...] = (
+_CODEX_SEMANTIC_RECORDS: tuple[JSONDocument, ...] = (
     {
         "type": "message",
         "id": "codex-direct",
@@ -347,41 +368,41 @@ _CODEX_SEMANTIC_RECORDS: tuple[dict[str, Any], ...] = (
 
 
 @st.composite
-def chatgpt_semantic_message_strategy(draw: st.DrawFn) -> dict[str, Any]:
+def chatgpt_semantic_message_strategy(draw: st.DrawFn) -> JSONDocument:
     """Generate ChatGPT messages with richer semantic content variants."""
     return dict(draw(st.sampled_from(_CHATGPT_SEMANTIC_MESSAGES)))
 
 
 @st.composite
-def claude_ai_semantic_message_strategy(draw: st.DrawFn) -> dict[str, Any]:
+def claude_ai_semantic_message_strategy(draw: st.DrawFn) -> JSONDocument:
     """Generate Claude AI messages with stable semantic metadata variants."""
     return dict(draw(st.sampled_from(_CLAUDE_AI_SEMANTIC_MESSAGES)))
 
 
 @st.composite
-def claude_code_semantic_record_strategy(draw: st.DrawFn) -> dict[str, Any]:
+def claude_code_semantic_record_strategy(draw: st.DrawFn) -> JSONDocument:
     """Generate Claude Code records with text/thinking/tool/code coverage."""
     return dict(draw(st.sampled_from(_CLAUDE_CODE_SEMANTIC_RECORDS)))
 
 
 @st.composite
-def gemini_semantic_message_strategy(draw: st.DrawFn) -> dict[str, Any]:
+def gemini_semantic_message_strategy(draw: st.DrawFn) -> JSONDocument:
     """Generate Gemini messages exercising thought/code/file branches."""
     return dict(draw(st.sampled_from(_GEMINI_SEMANTIC_MESSAGES)))
 
 
 @st.composite
-def codex_semantic_record_strategy(draw: st.DrawFn) -> dict[str, Any]:
+def codex_semantic_record_strategy(draw: st.DrawFn) -> JSONDocument:
     """Generate Codex direct and envelope records with mixed block types."""
     raw = draw(st.sampled_from(_CODEX_SEMANTIC_RECORDS))
-    return cast(dict[str, Any], json.loads(json.dumps(raw)))
+    return json_document(json_loads(json.dumps(raw)))
 
 
 @st.composite
 def provider_semantic_case_strategy(
     draw: st.DrawFn,
     providers: tuple[str, ...] = ("chatgpt", "claude-ai", "claude-code", "codex", "gemini"),
-) -> tuple[str, dict[str, Any]]:
+) -> tuple[str, JSONDocument]:
     """Generate provider/raw pairs for semantically rich viewport laws."""
     provider = draw(st.sampled_from(providers))
     raw = {
@@ -422,7 +443,7 @@ def provider_payload_strategy(
     provider: str,
     min_msgs: int = 1,
     max_msgs: int = 10,
-) -> Any:
+) -> ProviderPayload:
     """Generate and decode a provider wire payload."""
     raw = draw(provider_export_strategy(provider, min_msgs=min_msgs, max_msgs=max_msgs))
     return decode_provider_payload(provider, raw)
@@ -434,7 +455,7 @@ def provider_payload_case_strategy(
     providers: tuple[str, ...] = ("chatgpt", "claude-ai", "claude-code", "codex", "gemini"),
     min_msgs: int = 1,
     max_msgs: int = 10,
-) -> tuple[str, Any]:
+) -> tuple[str, ProviderPayload]:
     """Generate `(provider, payload)` pairs for dispatch/harmonization laws."""
     provider = draw(st.sampled_from(providers))
     payload = draw(provider_payload_strategy(provider, min_msgs=min_msgs, max_msgs=max_msgs))
@@ -453,7 +474,7 @@ def provider_source_case_strategy(
     providers: tuple[str, ...] = ("chatgpt", "claude-ai", "claude-code", "codex", "gemini"),
     min_msgs: int = 1,
     max_msgs: int = 10,
-) -> dict[str, Any]:
+) -> ProviderSourceCase:
     """Generate a provider payload together with a representative hint path."""
     provider = draw(st.sampled_from(providers))
     raw = draw(provider_export_strategy(provider, min_msgs=min_msgs, max_msgs=max_msgs))

--- a/tests/infra/strategies/schema.py
+++ b/tests/infra/strategies/schema.py
@@ -3,13 +3,16 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any
+from typing import TypeAlias
 
 from hypothesis import strategies as st
 
+from polylogue.lib.json import JSONDocument
 from tests.infra.strategies.sources import json_document_strategy
 
+JSONRecord: TypeAlias = dict[str, object]
 _STATIC_KEY_ALPHABET = "abcdefghijklmnopqrstuvwxyz_"
 _RECORD_VARIANTS: tuple[tuple[str, str], ...] = (
     ("type", "session_meta"),
@@ -25,7 +28,7 @@ class SessionJsonlFileSpec:
 
     relative_path: str
     text: str
-    expected_documents: tuple[dict[str, Any], ...]
+    expected_documents: tuple[JSONDocument, ...]
 
 
 @st.composite
@@ -68,10 +71,10 @@ def static_key_strategy(draw: st.DrawFn) -> str:
 
 
 @st.composite
-def nested_required_schema_strategy(draw: st.DrawFn, *, max_depth: int = 3) -> dict[str, Any]:
+def nested_required_schema_strategy(draw: st.DrawFn, *, max_depth: int = 3) -> JSONRecord:
     """Generate a JSON-schema-like tree with required fields at every object node."""
 
-    def _node(depth: int) -> dict[str, Any]:
+    def _node(depth: int) -> JSONRecord:
         if depth <= 0:
             return {"type": draw(st.sampled_from(("string", "integer", "boolean")))}
 
@@ -110,7 +113,7 @@ def record_payload_strategy(
     max_variants: int = 4,
     min_records_per_variant: int = 1,
     max_records_per_variant: int = 6,
-) -> list[dict[str, Any]]:
+) -> list[JSONRecord]:
     """Generate heterogeneous record payloads for record-granularity validation laws."""
     variants = draw(
         st.lists(
@@ -120,11 +123,11 @@ def record_payload_strategy(
             unique=True,
         )
     )
-    payload: list[dict[str, Any]] = []
+    payload: list[JSONRecord] = []
     for key, value in variants:
         count = draw(st.integers(min_value=min_records_per_variant, max_value=max_records_per_variant))
         for index in range(count):
-            record: dict[str, Any] = (
+            record: JSONRecord = (
                 {"payload": {"type": value}, "idx": index} if key == "payload.type" else {key: value, "idx": index}
             )
             payload.append(record)
@@ -182,7 +185,7 @@ def session_jsonl_tree_strategy(
     return tuple(files)
 
 
-def record_variant_signature(record: dict[str, Any]) -> str:
+def record_variant_signature(record: Mapping[str, object]) -> str:
     """Return the same stratification signature family used by record sampling."""
     for key in ("type", "record_type"):
         value = record.get(key)
@@ -196,9 +199,9 @@ def record_variant_signature(record: dict[str, Any]) -> str:
     return "unknown"
 
 
-def expected_session_documents(files: tuple[SessionJsonlFileSpec, ...]) -> list[dict[str, Any]]:
+def expected_session_documents(files: tuple[SessionJsonlFileSpec, ...]) -> list[JSONDocument]:
     """Return session-loader output order when file mtimes follow tuple order."""
-    documents: list[dict[str, Any]] = []
+    documents: list[JSONDocument] = []
     for file_spec in reversed(files):
         documents.extend(file_spec.expected_documents)
     return documents

--- a/tests/infra/strategies/schema_driven.py
+++ b/tests/infra/strategies/schema_driven.py
@@ -8,18 +8,18 @@ metaschema declarations that upset ``hypothesis-jsonschema``.
 from __future__ import annotations
 
 import copy
-from typing import Any
 
 from hypothesis import strategies as st
 from hypothesis_jsonschema import from_schema
 
+from polylogue.lib.json import JSONDocument, JSONValue, json_document
 from polylogue.schemas.registry import SchemaRegistry
 
 
-def strip_schema_extensions(schema: Any, *, is_root: bool = True) -> Any:
+def strip_schema_extensions(schema: JSONValue, *, is_root: bool = True) -> JSONValue:
     """Recursively remove generator-hostile keys from a JSON schema."""
     if isinstance(schema, dict):
-        cleaned: dict[str, Any] = {}
+        cleaned: JSONDocument = {}
         for key, value in schema.items():
             if key.startswith("x-polylogue-"):
                 continue
@@ -35,7 +35,7 @@ def strip_schema_extensions(schema: Any, *, is_root: bool = True) -> Any:
 
 
 @st.composite
-def schema_conformant_payload(draw: st.DrawFn, provider: str) -> Any:
+def schema_conformant_payload(draw: st.DrawFn, provider: str) -> JSONValue:
     """Generate a payload conformant to a provider's JSON schema.
 
     Loads the latest schema for the given provider from the registry,
@@ -53,5 +53,5 @@ def schema_conformant_payload(draw: st.DrawFn, provider: str) -> Any:
     if raw_schema is None:
         # Fall back — draw a minimal valid dict
         return draw(st.fixed_dictionaries({}))
-    cleaned = strip_schema_extensions(copy.deepcopy(raw_schema))
+    cleaned = json_document(strip_schema_extensions(copy.deepcopy(raw_schema)))
     return draw(from_schema(cleaned))

--- a/tests/unit/core/test_repo_identity.py
+++ b/tests/unit/core/test_repo_identity.py
@@ -175,7 +175,7 @@ def test_build_session_profile_normalizes_repo_roots_from_workdirs_and_tool_path
     profile = build_session_profile(conversation)
 
     assert profile.repo_paths == (str(REPO_ROOT), str(sinnix_repo))
-    assert profile.repo_names == ("polylogue", "sinnix")
+    assert profile.repo_names == (REPO_ROOT.name, "sinnix")
 
 
 def test_extract_attribution_preserves_repo_name_from_provider_git_remote() -> None:


### PR DESCRIPTION
## Summary

- Replaces broad `Any` in `tests/infra` strategy helpers, Drive mocks, semantic-fact helpers, PTY/MCP helpers, large-batch/chaos builders, and shared pytest fixtures with explicit JSON, protocol, fixture, and typed-dict contracts.
- Keeps the flexible test-builder APIs by validating explicit payload dictionaries through Pydantic rather than forwarding untyped `**kwargs` into generated constructors.
- Makes the repo-identity test derive the active checkout name from `REPO_ROOT`, so temporary worktree clones such as `polylogue-281` verify correctly.

## Problem

The mypy cleanup has made production and core test contracts stricter, but reusable test infrastructure still carried broad dynamic types. Those helpers feed source laws, schema laws, MCP tests, Drive tests, and ingestion-hostility tests, so leaving them untyped weakens the suite exactly where generated and cross-surface tests should be most precise.

Ref #281

## Solution

- Added explicit provider payload/source-case contracts and JSON narrowing in `tests/infra/strategies/providers.py`.
- Added typed strategy records and helper return contracts in schema, message, filter, and pipeline strategy helpers.
- Replaced Drive mock dynamic seams with a writable protocol, param-spec retry wrapper, concrete mock downloader result types, and typed service response dictionaries.
- Tightened semantic fact extraction around domain conversations, storage records, CLI JSON payloads, and SQLite aggregate rows.
- Typed shared pytest fixtures for repositories, backends, CLI runners, synthetic sources, and conversation builders.

## Verification

- `ruff format tests/infra/strategies/filters.py tests/infra/strategies/messages.py tests/infra/strategies/pipeline.py tests/infra/strategies/providers.py tests/infra/strategies/schema.py tests/infra/strategies/schema_driven.py tests/infra/drive_mocks.py tests/infra/semantic_facts.py tests/infra/large_batches.py tests/infra/chaos_sources.py tests/infra/mcp.py tests/infra/pty_cli.py tests/infra/builders.py tests/conftest.py`
- `ruff check tests/infra/strategies/filters.py tests/infra/strategies/messages.py tests/infra/strategies/pipeline.py tests/infra/strategies/providers.py tests/infra/strategies/schema.py tests/infra/strategies/schema_driven.py tests/infra/drive_mocks.py tests/infra/semantic_facts.py tests/infra/large_batches.py tests/infra/chaos_sources.py tests/infra/mcp.py tests/infra/pty_cli.py tests/infra/builders.py tests/conftest.py`
- `mypy tests/infra/strategies/filters.py tests/infra/strategies/messages.py tests/infra/strategies/pipeline.py tests/infra/strategies/providers.py tests/infra/strategies/schema.py tests/infra/strategies/schema_driven.py tests/infra/drive_mocks.py tests/infra/semantic_facts.py tests/infra/large_batches.py tests/infra/chaos_sources.py tests/infra/mcp.py tests/infra/pty_cli.py tests/infra/builders.py tests/conftest.py`
- `pytest -q tests/unit/sources/test_drive_source_client.py tests/unit/sources/test_drive_gateway.py tests/unit/test_cross_surface_agreement.py tests/unit/pipeline/test_ingestion_chaos.py tests/integration/test_chronology_extremes.py` (141 passed)
- `pytest -q tests/unit/mcp tests/unit/core/test_schema_laws.py tests/unit/core/test_filters_props.py tests/unit/lib/test_filter_executor.py tests/unit/sources/test_parsers_props.py tests/unit/sources/test_source_laws.py tests/property/test_rendering_preservation.py tests/unit/pipeline/test_resilience.py` (404 passed)
- `PATH=/tmp/polylogue-281/.cache/codex-bin:$PATH devtools verify --quick`
- `pytest -q --tb=short --ignore=tests/integration` (4975 passed)
- `PATH=/tmp/polylogue-281/.cache/codex-bin:$PATH git push -u origin feature/refactor/test-strategy-contracts` (pre-push `devtools verify --quick` passed)

Note: I also attempted full `devtools verify`. Its pytest subphase first exposed the hard-coded repo-name assertion fixed in this PR; a later run hit local xdist teardown/process instability without a test failure. The exact pytest command wrapped by `devtools verify` passed cleanly afterward.
