### PR TITLE
test: type mcp and ui surface contracts

### DIFF
--- a/tests/infra/mcp.py
+++ b/tests/infra/mcp.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import asyncio
 import inspect
-from collections.abc import Awaitable, Callable, Coroutine, Sequence
+from collections.abc import Awaitable, Callable, Coroutine, Mapping, Sequence
 from datetime import datetime, timezone
-from typing import TypeVar, cast
+from typing import Protocol, TypeAlias, TypeVar, cast
 from unittest.mock import AsyncMock, MagicMock
 
 from polylogue.lib.models import Conversation
@@ -63,6 +63,30 @@ EXPECTED_PROMPT_NAMES = {
 }
 
 SurfaceResult = TypeVar("SurfaceResult")
+MCPSurfaceHandler: TypeAlias = Callable[..., str | Awaitable[str]]
+
+
+class RegisteredMCPSurface(Protocol):
+    fn: MCPSurfaceHandler
+
+
+class MCPToolManager(Protocol):
+    _tools: Mapping[str, RegisteredMCPSurface]
+
+
+class MCPResourceManager(Protocol):
+    _resources: Mapping[str, RegisteredMCPSurface]
+    _templates: Mapping[str, RegisteredMCPSurface]
+
+
+class MCPPromptManager(Protocol):
+    _prompts: Mapping[str, RegisteredMCPSurface]
+
+
+class MCPServerUnderTest(Protocol):
+    _tool_manager: MCPToolManager
+    _resource_manager: MCPResourceManager
+    _prompt_manager: MCPPromptManager
 
 
 def invoke_surface(

--- a/tests/unit/mcp/conftest.py
+++ b/tests/unit/mcp/conftest.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Any
+from typing import cast
 
 import pytest
 
+from tests.infra.mcp import MCPServerUnderTest
+
 
 @pytest.fixture
-def mcp_server() -> Any:
+def mcp_server() -> MCPServerUnderTest:
     """Build and return an MCP server instance for testing.
 
     Ensures a fresh event loop policy so that stale/closed loops left behind
@@ -21,4 +23,4 @@ def mcp_server() -> Any:
 
     from polylogue.mcp.server import build_server
 
-    return build_server()
+    return cast(MCPServerUnderTest, build_server())

--- a/tests/unit/mcp/test_mcp_edge_cases.py
+++ b/tests/unit/mcp/test_mcp_edge_cases.py
@@ -7,12 +7,12 @@ and concurrent access patterns.
 from __future__ import annotations
 
 import json
-from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from polylogue.mcp.server_support import _clamp_limit, _safe_call
+from tests.infra.mcp import MCPServerUnderTest, invoke_surface_async
 
 # =============================================================================
 # _clamp_limit boundary tests
@@ -81,15 +81,15 @@ class TestSafeCall:
 # =============================================================================
 
 
-def _invoke_tool(mcp_server: Any, tool_name: str, **kwargs: object) -> Any:
+async def _invoke_tool(mcp_server: MCPServerUnderTest, tool_name: str, **kwargs: object) -> str:
     """Invoke a registered MCP tool by name, matching the existing test pattern."""
     tool = mcp_server._tool_manager._tools[tool_name]
-    return tool.fn(**kwargs)
+    return await invoke_surface_async(tool.fn, **kwargs)
 
 
 class TestUnicodeHandling:
     @pytest.mark.asyncio
-    async def test_unicode_tag(self, mcp_server: Any) -> None:
+    async def test_unicode_tag(self, mcp_server: MCPServerUnderTest) -> None:
         """Unicode characters in tag names don't crash the server."""
         from tests.infra.mcp import make_tag_store_mock
 
@@ -109,7 +109,7 @@ class TestUnicodeHandling:
                 assert isinstance(result, str)
 
     @pytest.mark.asyncio
-    async def test_empty_query(self, mcp_server: Any) -> None:
+    async def test_empty_query(self, mcp_server: MCPServerUnderTest) -> None:
         """Empty query string doesn't crash search."""
         from tests.infra.mcp import make_mock_filter, make_query_store_mock
 
@@ -138,7 +138,7 @@ class TestUnicodeHandling:
 
 class TestBoundaryParameters:
     @pytest.mark.asyncio
-    async def test_limit_zero(self, mcp_server: Any) -> None:
+    async def test_limit_zero(self, mcp_server: MCPServerUnderTest) -> None:
         """limit=0 is clamped to 1 (returns minimal results)."""
         from tests.infra.mcp import make_mock_filter, make_query_store_mock
 
@@ -159,7 +159,7 @@ class TestBoundaryParameters:
             assert isinstance(result, str)
 
     @pytest.mark.asyncio
-    async def test_limit_negative(self, mcp_server: Any) -> None:
+    async def test_limit_negative(self, mcp_server: MCPServerUnderTest) -> None:
         """Negative limit is clamped to 1."""
         from tests.infra.mcp import make_mock_filter, make_query_store_mock
 

--- a/tests/unit/mcp/test_server_surfaces.py
+++ b/tests/unit/mcp/test_server_surfaces.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import json
 from collections.abc import Callable
 from datetime import datetime, timezone
-from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -19,6 +18,7 @@ from tests.infra.mcp import (
     EXPECTED_RESOURCE_TEMPLATE_URIS,
     EXPECTED_RESOURCE_URIS,
     EXPECTED_TOOL_NAMES,
+    MCPServerUnderTest,
     invoke_surface,
     invoke_surface_async,
     make_mock_filter,
@@ -97,7 +97,7 @@ def simple_conversation() -> Conversation:
 class TestServerSurfaceRegistration:
     """Server registration should expose the documented MCP surfaces."""
 
-    def testbuild_server_exposes_managers(self: object, mcp_server: Any) -> None:
+    def testbuild_server_exposes_managers(self: object, mcp_server: MCPServerUnderTest) -> None:
         assert mcp_server is not None
         assert hasattr(mcp_server, "_tool_manager")
         assert hasattr(mcp_server, "_resource_manager")
@@ -119,9 +119,9 @@ class TestServerSurfaceRegistration:
     def test_server_surface_contract(
         self: object,
         surface_attr: str,
-        actual_getter: Callable[[Any], set[str]],
+        actual_getter: Callable[[MCPServerUnderTest], set[str]],
         expected: set[str],
-        mcp_server: Any,
+        mcp_server: MCPServerUnderTest,
     ) -> None:
         actual = actual_getter(mcp_server)
         missing = expected - actual
@@ -129,7 +129,7 @@ class TestServerSurfaceRegistration:
 
 
 class TestResourceSurfaces:
-    def test_stats_returns_archive_statistics(self: object, mcp_server: Any) -> None:
+    def test_stats_returns_archive_statistics(self: object, mcp_server: MCPServerUnderTest) -> None:
         from polylogue.lib.stats import ArchiveStats
 
         with patch("polylogue.mcp.server._get_archive_ops") as mock_get_archive_ops:
@@ -153,7 +153,7 @@ class TestResourceSurfaces:
     async def test_conversations_resource_returns_list(
         self: object,
         simple_conversation: Conversation,
-        mcp_server: Any,
+        mcp_server: MCPServerUnderTest,
     ) -> None:
         with patch("polylogue.mcp.server._get_query_store") as mock_get_query_store:
             mock_get_query_store.return_value = MagicMock()
@@ -171,7 +171,7 @@ class TestResourceSurfaces:
     def test_single_conversation_resource(
         self: object,
         simple_conversation: Conversation,
-        mcp_server: Any,
+        mcp_server: MCPServerUnderTest,
     ) -> None:
         with patch("polylogue.mcp.server._get_archive_ops") as mock_get_archive_ops:
             mock_ops = MagicMock()
@@ -187,7 +187,7 @@ class TestResourceSurfaces:
         assert conv["id"] == "test:conv-123"
         assert "messages" in conv
 
-    def test_conversation_resource_not_found(self: object, mcp_server: Any) -> None:
+    def test_conversation_resource_not_found(self: object, mcp_server: MCPServerUnderTest) -> None:
         with patch("polylogue.mcp.server._get_archive_ops") as mock_get_archive_ops:
             mock_ops = MagicMock()
             mock_ops.get_conversation = AsyncMock(return_value=None)
@@ -201,7 +201,7 @@ class TestResourceSurfaces:
         result_dict = json.loads(result)
         assert "error" in result_dict
 
-    def test_tags_resource(self: object, mcp_server: Any) -> None:
+    def test_tags_resource(self: object, mcp_server: MCPServerUnderTest) -> None:
         with patch("polylogue.mcp.server._get_tag_store") as mock_get_tag_store:
             mock_tag_store = make_tag_store_mock()
             mock_tag_store.list_tags.return_value = {"feature": 10, "bug": 5}
@@ -212,7 +212,7 @@ class TestResourceSurfaces:
         parsed = json.loads(result)
         assert parsed == {"feature": 10, "bug": 5}
 
-    def test_readiness_resource(self: object, mcp_server: Any) -> None:
+    def test_readiness_resource(self: object, mcp_server: MCPServerUnderTest) -> None:
         mock_check = MagicMock()
         mock_check.name = "database"
         mock_check.status.value = "ok"
@@ -240,7 +240,7 @@ class TestPromptSurfaces:
     async def test_analyze_errors_with_conversations(
         self: object,
         simple_conversation: Conversation,
-        mcp_server: Any,
+        mcp_server: MCPServerUnderTest,
     ) -> None:
         simple_conversation.messages.to_list()[0].text = "Got an error while running"
 
@@ -249,13 +249,13 @@ class TestPromptSurfaces:
             with patch("polylogue.lib.filters.ConversationFilter") as mock_filter_cls:
                 mock_filter_cls.return_value = make_mock_filter(results=[simple_conversation])
 
-                result = await mcp_server._prompt_manager._prompts["analyze_errors"].fn()
+                result = await invoke_surface_async(mcp_server._prompt_manager._prompts["analyze_errors"].fn)
 
         assert isinstance(result, str)
         assert "error" in result.lower()
 
     @pytest.mark.asyncio
-    async def test_analyze_errors_limits_error_contexts_to_20(self: object, mcp_server: Any) -> None:
+    async def test_analyze_errors_limits_error_contexts_to_20(self: object, mcp_server: MCPServerUnderTest) -> None:
         msgs = [
             make_msg(
                 id=f"m{i}",
@@ -272,35 +272,35 @@ class TestPromptSurfaces:
             with patch("polylogue.lib.filters.ConversationFilter") as mock_filter_cls:
                 mock_filter_cls.return_value = make_mock_filter(results=[big_conv])
 
-                result = await mcp_server._prompt_manager._prompts["analyze_errors"].fn()
+                result = await invoke_surface_async(mcp_server._prompt_manager._prompts["analyze_errors"].fn)
 
         assert "20 error instances" in result
 
     @pytest.mark.asyncio
-    async def test_analyze_errors_no_matches(self: object, mcp_server: Any) -> None:
+    async def test_analyze_errors_no_matches(self: object, mcp_server: MCPServerUnderTest) -> None:
         with patch("polylogue.mcp.server._get_query_store") as mock_get_query_store:
             mock_get_query_store.return_value = MagicMock()
             with patch("polylogue.lib.filters.ConversationFilter") as mock_filter_cls:
                 mock_filter_cls.return_value = make_mock_filter(results=[])
 
-                result = await mcp_server._prompt_manager._prompts["analyze_errors"].fn()
+                result = await invoke_surface_async(mcp_server._prompt_manager._prompts["analyze_errors"].fn)
 
         assert "0 conversations" in result
 
     @pytest.mark.asyncio
-    async def test_summarize_week_empty(self: object, mcp_server: Any) -> None:
+    async def test_summarize_week_empty(self: object, mcp_server: MCPServerUnderTest) -> None:
         with patch("polylogue.mcp.server._get_query_store") as mock_get_query_store:
             mock_get_query_store.return_value = MagicMock()
             with patch("polylogue.lib.filters.ConversationFilter") as mock_filter_cls:
                 mock_filter_cls.return_value = make_mock_filter(results=[])
 
-                result = await mcp_server._prompt_manager._prompts["summarize_week"].fn()
+                result = await invoke_surface_async(mcp_server._prompt_manager._prompts["summarize_week"].fn)
 
         assert "0 conversations" in result
         assert "0 messages" in result
 
     @pytest.mark.asyncio
-    async def test_extract_code_no_code_blocks(self: object, mcp_server: Any) -> None:
+    async def test_extract_code_no_code_blocks(self: object, mcp_server: MCPServerUnderTest) -> None:
         conv = make_conv(
             id="nocode",
             provider=Provider.UNKNOWN,
@@ -313,12 +313,12 @@ class TestPromptSurfaces:
             with patch("polylogue.lib.filters.ConversationFilter") as mock_filter_cls:
                 mock_filter_cls.return_value = make_mock_filter(results=[conv])
 
-                result = await mcp_server._prompt_manager._prompts["extract_code"].fn()
+                result = await invoke_surface_async(mcp_server._prompt_manager._prompts["extract_code"].fn)
 
         assert "0 code blocks" in result
 
     @pytest.mark.asyncio
-    async def test_extract_code_with_language_filter(self: object, mcp_server: Any) -> None:
+    async def test_extract_code_with_language_filter(self: object, mcp_server: MCPServerUnderTest) -> None:
         conv = make_conv(
             id="code",
             provider=Provider.UNKNOWN,
@@ -337,12 +337,15 @@ class TestPromptSurfaces:
             with patch("polylogue.lib.filters.ConversationFilter") as mock_filter_cls:
                 mock_filter_cls.return_value = make_mock_filter(results=[conv])
 
-                result = await mcp_server._prompt_manager._prompts["extract_code"].fn(language="python")
+                result = await invoke_surface_async(
+                    mcp_server._prompt_manager._prompts["extract_code"].fn,
+                    language="python",
+                )
 
         assert "python" in result.lower()
 
     @pytest.mark.asyncio
-    async def test_extract_code_null_message_text(self: object, mcp_server: Any) -> None:
+    async def test_extract_code_null_message_text(self: object, mcp_server: MCPServerUnderTest) -> None:
         conv = make_conv(
             id="nulltext",
             provider=Provider.UNKNOWN,
@@ -355,14 +358,14 @@ class TestPromptSurfaces:
             with patch("polylogue.lib.filters.ConversationFilter") as mock_filter_cls:
                 mock_filter_cls.return_value = make_mock_filter(results=[conv])
 
-                result = await mcp_server._prompt_manager._prompts["extract_code"].fn()
+                result = await invoke_surface_async(mcp_server._prompt_manager._prompts["extract_code"].fn)
 
         assert isinstance(result, str)
 
     def test_compare_conversations_prompt(
         self: object,
         simple_conversation: Conversation,
-        mcp_server: Any,
+        mcp_server: MCPServerUnderTest,
     ) -> None:
         with patch("polylogue.mcp.server._get_query_store") as mock_get_query_store:
             mock_query_store = make_query_store_mock()
@@ -383,7 +386,7 @@ class TestPromptSurfaces:
     async def test_extract_patterns_prompt(
         self: object,
         simple_conversation: Conversation,
-        mcp_server: Any,
+        mcp_server: MCPServerUnderTest,
     ) -> None:
         with (
             patch("polylogue.mcp.server._get_query_store") as mock_get_query_store,
@@ -399,7 +402,7 @@ class TestPromptSurfaces:
 
 
 class TestExportConversationTool:
-    def test_export_markdown(self: object, simple_conversation: Conversation, mcp_server: Any) -> None:
+    def test_export_markdown(self: object, simple_conversation: Conversation, mcp_server: MCPServerUnderTest) -> None:
         with (
             patch("polylogue.mcp.server._get_archive_ops") as mock_get_archive_ops,
             patch("polylogue.rendering.formatting.format_conversation") as mock_format,
@@ -421,7 +424,7 @@ class TestExportConversationTool:
         assert call_args[0][0] == simple_conversation
         assert call_args[0][1] == "markdown"
 
-    def test_export_not_found(self: object, mcp_server: Any) -> None:
+    def test_export_not_found(self: object, mcp_server: MCPServerUnderTest) -> None:
         with patch("polylogue.mcp.server._get_archive_ops") as mock_get_archive_ops:
             mock_ops = MagicMock()
             mock_ops.get_conversation = AsyncMock(return_value=None)
@@ -436,7 +439,7 @@ class TestExportConversationTool:
     def test_export_invalid_format_falls_back_to_markdown(
         self: object,
         simple_conversation: Conversation,
-        mcp_server: Any,
+        mcp_server: MCPServerUnderTest,
     ) -> None:
         with (
             patch("polylogue.mcp.server._get_archive_ops") as mock_get_archive_ops,

--- a/tests/unit/mcp/test_tool_contracts.py
+++ b/tests/unit/mcp/test_tool_contracts.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 from datetime import datetime, timezone
-from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -41,6 +40,7 @@ from polylogue.lib.stats import ArchiveStats
 from polylogue.types import ConversationId, Provider
 from tests.infra.builders import make_conv, make_msg
 from tests.infra.mcp import (
+    MCPServerUnderTest,
     invoke_surface,
     invoke_surface_async,
     make_query_store_mock,
@@ -257,14 +257,14 @@ class TestQueryTools:
         tool_name: str,
         args: dict[str, object],
         expected_calls: dict[str, tuple[object, ...]],
-        mcp_server: Any,
+        mcp_server: MCPServerUnderTest,
     ) -> None:
         with patch("polylogue.mcp.server._get_archive_ops") as mock_get_archive_ops:
             mock_ops = MagicMock()
             mock_ops.query_conversations = AsyncMock(return_value=[simple_conversation])
             mock_get_archive_ops.return_value = mock_ops
 
-            raw = await mcp_server._tool_manager._tools[tool_name].fn(**args)
+            raw = await invoke_surface_async(mcp_server._tool_manager._tools[tool_name].fn, **args)
 
         payload = json.loads(raw)
         assert isinstance(payload, list)
@@ -305,7 +305,7 @@ class TestQueryTools:
                 assert spec.limit == expected_value
 
     @pytest.mark.asyncio
-    async def test_search_with_empty_query(self, mcp_server: Any) -> None:
+    async def test_search_with_empty_query(self, mcp_server: MCPServerUnderTest) -> None:
         with patch("polylogue.mcp.server._get_archive_ops") as mock_get_archive_ops:
             mock_ops = MagicMock()
             mock_ops.query_conversations = AsyncMock(return_value=[])
@@ -318,7 +318,7 @@ class TestQueryTools:
 
 
 class TestGetConversationTool:
-    def test_get_returns_conversation(self, simple_conversation: Conversation, mcp_server: Any) -> None:
+    def test_get_returns_conversation(self, simple_conversation: Conversation, mcp_server: MCPServerUnderTest) -> None:
         with patch("polylogue.mcp.server._get_archive_ops") as mock_get_archive_ops:
             mock_ops = MagicMock()
             mock_ops.get_conversation = AsyncMock(return_value=simple_conversation)
@@ -330,7 +330,7 @@ class TestGetConversationTool:
         assert conv["id"] == "test:conv-123"
         assert len(conv["messages"]) == 2
 
-    def test_get_not_found(self, mcp_server: Any) -> None:
+    def test_get_not_found(self, mcp_server: MCPServerUnderTest) -> None:
         with patch("polylogue.mcp.server._get_archive_ops") as mock_get_archive_ops:
             mock_ops = MagicMock()
             mock_ops.get_conversation = AsyncMock(return_value=None)
@@ -342,7 +342,7 @@ class TestGetConversationTool:
         assert "error" in parsed
         assert "not found" in parsed["error"].lower()
 
-    def test_get_returns_full_messages(self, mcp_server: Any) -> None:
+    def test_get_returns_full_messages(self, mcp_server: MCPServerUnderTest) -> None:
         long_text = "A" * 2000
         conv = make_conv(
             id="test:long",
@@ -361,7 +361,7 @@ class TestGetConversationTool:
         assert json.loads(result)["messages"][0]["text"] == long_text
 
     @pytest.mark.asyncio
-    async def test_get_with_nonexistent_id(self, mcp_server: Any) -> None:
+    async def test_get_with_nonexistent_id(self, mcp_server: MCPServerUnderTest) -> None:
         with patch("polylogue.mcp.server._get_archive_ops") as mock_get_archive_ops:
             mock_ops = MagicMock()
             mock_ops.get_conversation = AsyncMock(return_value=None)
@@ -376,7 +376,7 @@ class TestGetConversationTool:
 
 class TestProductTools:
     @pytest.mark.asyncio
-    async def test_session_profile_tool_uses_archive_product_contract(self, mcp_server: Any) -> None:
+    async def test_session_profile_tool_uses_archive_product_contract(self, mcp_server: MCPServerUnderTest) -> None:
         product = SessionProfileProduct(
             conversation_id="conv-1",
             provider_name="claude-code",
@@ -402,7 +402,7 @@ class TestProductTools:
         assert payload["conversation_id"] == "conv-1"
 
     @pytest.mark.asyncio
-    async def test_product_list_tools_use_archive_queries(self, mcp_server: Any) -> None:
+    async def test_product_list_tools_use_archive_queries(self, mcp_server: MCPServerUnderTest) -> None:
         profile = SessionProfileProduct(
             conversation_id="conv-1",
             provider_name="claude-code",
@@ -575,7 +575,7 @@ class TestProductTools:
         assert analytics_payload["items"][0]["product_kind"] == "provider_analytics"
 
     @pytest.mark.asyncio
-    async def test_session_enrichments_tool_rejects_unknown_query_fields(self, mcp_server: Any) -> None:
+    async def test_session_enrichments_tool_rejects_unknown_query_fields(self, mcp_server: MCPServerUnderTest) -> None:
         with patch("polylogue.mcp.server._get_archive_ops") as mock_get_archive_ops:
             mock_ops = MagicMock()
             mock_ops.list_session_enrichment_products = AsyncMock(return_value=[])
@@ -620,7 +620,7 @@ class TestStatsTool:
         db_size: int,
         expected_coverage: float,
         expected_mb: float | int,
-        mcp_server: Any,
+        mcp_server: MCPServerUnderTest,
     ) -> None:
         with patch("polylogue.mcp.server._get_archive_ops") as mock_get_archive_ops:
             mock_ops = MagicMock()
@@ -648,7 +648,7 @@ class TestStatsTool:
 
 
 class TestMutationTools:
-    def test_add_tag_success(self, mcp_server: Any) -> None:
+    def test_add_tag_success(self, mcp_server: MCPServerUnderTest) -> None:
         with patch("polylogue.mcp.server._get_tag_store") as mock_get_tag_store:
             mock_tag_store = make_tag_store_mock()
             mock_tag_store.add_tag.return_value = None
@@ -662,7 +662,7 @@ class TestMutationTools:
         assert parsed == {"status": "ok", "conversation_id": "test:conv-123", "tag": "important"}
         mock_tag_store.add_tag.assert_called_once_with("test:conv-123", "important")
 
-    def test_add_tag_error(self, mcp_server: Any) -> None:
+    def test_add_tag_error(self, mcp_server: MCPServerUnderTest) -> None:
         with patch("polylogue.mcp.server._get_tag_store") as mock_get_tag_store:
             mock_tag_store = make_tag_store_mock()
             mock_tag_store.add_tag.side_effect = ValueError("Invalid tag")
@@ -675,7 +675,7 @@ class TestMutationTools:
         parsed = json.loads(result)
         assert "Invalid tag" in parsed["error"]
 
-    def test_remove_tag_success(self, mcp_server: Any) -> None:
+    def test_remove_tag_success(self, mcp_server: MCPServerUnderTest) -> None:
         with patch("polylogue.mcp.server._get_tag_store") as mock_get_tag_store:
             mock_tag_store = make_tag_store_mock()
             mock_tag_store.remove_tag.return_value = None
@@ -689,7 +689,7 @@ class TestMutationTools:
         assert parsed == {"status": "ok", "conversation_id": "test:conv-123", "tag": "important"}
         mock_tag_store.remove_tag.assert_called_once_with("test:conv-123", "important")
 
-    def test_remove_tag_error(self, mcp_server: Any) -> None:
+    def test_remove_tag_error(self, mcp_server: MCPServerUnderTest) -> None:
         with patch("polylogue.mcp.server._get_tag_store") as mock_get_tag_store:
             mock_tag_store = make_tag_store_mock()
             mock_tag_store.remove_tag.side_effect = RuntimeError("Backend error")
@@ -701,7 +701,7 @@ class TestMutationTools:
 
         assert "error" in json.loads(result)
 
-    def test_list_tags_returns_counts(self, mcp_server: Any) -> None:
+    def test_list_tags_returns_counts(self, mcp_server: MCPServerUnderTest) -> None:
         with patch("polylogue.mcp.server._get_tag_store") as mock_get_tag_store:
             mock_tag_store = make_tag_store_mock()
             mock_tag_store.list_tags.return_value = {"bug": 3, "feature": 5, "urgent": 1}
@@ -711,7 +711,7 @@ class TestMutationTools:
 
         assert json.loads(result) == {"bug": 3, "feature": 5, "urgent": 1}
 
-    def test_list_tags_with_provider(self, mcp_server: Any) -> None:
+    def test_list_tags_with_provider(self, mcp_server: MCPServerUnderTest) -> None:
         with patch("polylogue.mcp.server._get_tag_store") as mock_get_tag_store:
             mock_tag_store = make_tag_store_mock()
             mock_tag_store.list_tags.return_value = {"claude-ai": 2}
@@ -722,7 +722,7 @@ class TestMutationTools:
         assert json.loads(result) == {"claude-ai": 2}
         mock_tag_store.list_tags.assert_called_once_with(provider="claude-ai")
 
-    def test_get_metadata_success(self, mcp_server: Any) -> None:
+    def test_get_metadata_success(self, mcp_server: MCPServerUnderTest) -> None:
         with patch("polylogue.mcp.server._get_tag_store") as mock_get_tag_store:
             mock_tag_store = make_tag_store_mock()
             mock_tag_store.get_metadata.return_value = {"key": "value", "count": 42}
@@ -732,7 +732,7 @@ class TestMutationTools:
 
         assert json.loads(result) == {"key": "value", "count": 42}
 
-    def test_set_metadata_string_value(self, mcp_server: Any) -> None:
+    def test_set_metadata_string_value(self, mcp_server: MCPServerUnderTest) -> None:
         with patch("polylogue.mcp.server._get_tag_store") as mock_get_tag_store:
             mock_tag_store = make_tag_store_mock()
             mock_tag_store.update_metadata.return_value = None
@@ -748,7 +748,7 @@ class TestMutationTools:
         assert json.loads(result)["status"] == "ok"
         mock_tag_store.update_metadata.assert_called_once_with("test:conv-123", "author", "john")
 
-    def test_set_metadata_json_value(self, mcp_server: Any) -> None:
+    def test_set_metadata_json_value(self, mcp_server: MCPServerUnderTest) -> None:
         with patch("polylogue.mcp.server._get_tag_store") as mock_get_tag_store:
             mock_tag_store = make_tag_store_mock()
             mock_tag_store.update_metadata.return_value = None
@@ -764,7 +764,7 @@ class TestMutationTools:
         assert json.loads(result)["status"] == "ok"
         mock_tag_store.update_metadata.assert_called_once_with("test:conv-123", "config", {"nested": True})
 
-    def test_delete_metadata_success(self, mcp_server: Any) -> None:
+    def test_delete_metadata_success(self, mcp_server: MCPServerUnderTest) -> None:
         with patch("polylogue.mcp.server._get_tag_store") as mock_get_tag_store:
             mock_tag_store = make_tag_store_mock()
             mock_tag_store.delete_metadata.return_value = None
@@ -781,7 +781,7 @@ class TestMutationTools:
         assert parsed["key"] == "author"
         mock_tag_store.delete_metadata.assert_called_once_with("test:conv-123", "author")
 
-    def test_delete_requires_confirm(self, mcp_server: Any) -> None:
+    def test_delete_requires_confirm(self, mcp_server: MCPServerUnderTest) -> None:
         with patch("polylogue.mcp.server._get_query_store") as mock_get_query_store:
             mock_query_store = make_query_store_mock()
             mock_get_query_store.return_value = mock_query_store
@@ -796,7 +796,7 @@ class TestMutationTools:
         assert "confirm=true" in parsed["error"]
         mock_query_store.delete_conversation.assert_not_called()
 
-    def test_delete_with_confirm(self, mcp_server: Any) -> None:
+    def test_delete_with_confirm(self, mcp_server: MCPServerUnderTest) -> None:
         with patch("polylogue.mcp.server._get_query_store") as mock_get_query_store:
             mock_query_store = make_query_store_mock()
             mock_query_store.delete_conversation.return_value = True
@@ -811,7 +811,7 @@ class TestMutationTools:
         assert json.loads(result)["status"] == "deleted"
         mock_query_store.delete_conversation.assert_called_once_with("test:conv-123")
 
-    def test_delete_not_found(self, mcp_server: Any) -> None:
+    def test_delete_not_found(self, mcp_server: MCPServerUnderTest) -> None:
         with patch("polylogue.mcp.server._get_query_store") as mock_get_query_store:
             mock_query_store = make_query_store_mock()
             mock_query_store.delete_conversation.return_value = False
@@ -825,7 +825,7 @@ class TestMutationTools:
 
         assert json.loads(result)["status"] == "not_found"
 
-    def test_summary_returns_metadata(self, mcp_server: Any) -> None:
+    def test_summary_returns_metadata(self, mcp_server: MCPServerUnderTest) -> None:
         with patch("polylogue.mcp.server._get_archive_ops") as mock_get_archive_ops:
             mock_ops = MagicMock()
             mock_summary = _make_summary(
@@ -847,7 +847,7 @@ class TestMutationTools:
         assert parsed["title"] == "Test Conv"
         assert parsed["message_count"] == 5
 
-    def test_summary_not_found(self, mcp_server: Any) -> None:
+    def test_summary_not_found(self, mcp_server: MCPServerUnderTest) -> None:
         with patch("polylogue.mcp.server._get_archive_ops") as mock_get_archive_ops:
             mock_ops = MagicMock()
             mock_ops.get_conversation_summary = AsyncMock(return_value=None)
@@ -857,7 +857,7 @@ class TestMutationTools:
 
         assert "not found" in json.loads(result)["error"].lower()
 
-    def test_session_tree_returns_list(self, simple_conversation: Conversation, mcp_server: Any) -> None:
+    def test_session_tree_returns_list(self, simple_conversation: Conversation, mcp_server: MCPServerUnderTest) -> None:
         with patch("polylogue.mcp.server._get_archive_ops") as mock_get_archive_ops:
             mock_ops = MagicMock()
             mock_ops.get_session_tree = AsyncMock(return_value=[simple_conversation])
@@ -878,7 +878,7 @@ class TestMutationTools:
             ("month", {"2024-01": 15, "2024-02": 20}),
         ],
     )
-    def test_stats_by_group(self, group_by: str, expected: dict[str, int], mcp_server: Any) -> None:
+    def test_stats_by_group(self, group_by: str, expected: dict[str, int], mcp_server: MCPServerUnderTest) -> None:
         with patch("polylogue.mcp.server._get_archive_ops") as mock_get_archive_ops:
             mock_ops = MagicMock()
             mock_ops.get_stats_by = AsyncMock(return_value=expected)
@@ -888,7 +888,7 @@ class TestMutationTools:
 
         assert json.loads(result) == expected
 
-    def test_health_check_success(self, mcp_server: Any) -> None:
+    def test_health_check_success(self, mcp_server: MCPServerUnderTest) -> None:
         mock_check = MagicMock()
         mock_check.name = "database"
         mock_check.status.value = "ok"
@@ -913,7 +913,7 @@ class TestMutationTools:
         assert parsed["summary"] == "Healthy"
         assert parsed["checks"][0]["name"] == "database"
 
-    def test_rebuild_index_success(self, mcp_server: Any) -> None:
+    def test_rebuild_index_success(self, mcp_server: MCPServerUnderTest) -> None:
         with (
             patch("polylogue.mcp.server._get_config") as mock_get_config,
             patch("polylogue.mcp.server._get_backend") as mock_get_backend,
@@ -933,7 +933,7 @@ class TestMutationTools:
         assert parsed["index_exists"] is True
         assert parsed["indexed_messages"] == 500
 
-    def test_update_index_success(self, mcp_server: Any) -> None:
+    def test_update_index_success(self, mcp_server: MCPServerUnderTest) -> None:
         with (
             patch("polylogue.mcp.server._get_config") as mock_get_config,
             patch("polylogue.mcp.server._get_backend") as mock_get_backend,

--- a/tests/unit/security/test_mcp_security.py
+++ b/tests/unit/security/test_mcp_security.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-from typing import Any
 
 from polylogue.mcp.server_support import _safe_call
 
@@ -11,11 +10,11 @@ from polylogue.mcp.server_support import _safe_call
 class TestMcpSafeCall:
     """Tests for _safe_call — traceback exposure prevention."""
 
-    def test_success_returns_result(self: Any) -> None:
+    def test_success_returns_result(self: object) -> None:
         result = _safe_call("test_tool", lambda: '{"ok": true}')
         assert result == '{"ok": true}'
 
-    def test_error_returns_json(self: Any) -> None:
+    def test_error_returns_json(self: object) -> None:
         def failing() -> None:
             raise ValueError("test error message")
 
@@ -25,7 +24,7 @@ class TestMcpSafeCall:
         assert parsed["tool"] == "test_tool"
         assert "test error message" in parsed["error"]
 
-    def test_no_traceback_in_error_response(self: Any) -> None:
+    def test_no_traceback_in_error_response(self: object) -> None:
         def failing() -> None:
             raise RuntimeError("internal error")
 
@@ -35,7 +34,7 @@ class TestMcpSafeCall:
         assert "Traceback" not in result
         assert "File " not in result  # No file paths leaked
 
-    def test_no_internal_paths_in_error(self: Any) -> None:
+    def test_no_internal_paths_in_error(self: object) -> None:
         def failing() -> None:
             raise ImportError("No module named 'secret_module'")
 

--- a/tests/unit/ui/test_tui.py
+++ b/tests/unit/ui/test_tui.py
@@ -1,12 +1,22 @@
-from typing import Any
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING, TypeAlias, cast
+from unittest.mock import MagicMock
 
 import pytest
+from textual.pilot import Pilot
 from textual.widgets import DataTable, Input, TabbedContent, Tree
 
+from polylogue.protocols import ConversationArchiveReadStore
 from polylogue.ui.tui.app import PolylogueApp
 from polylogue.ui.tui.screens.base import RepositoryBoundContainer
 from polylogue.ui.tui.screens.dashboard import Dashboard, ProviderBar
 from polylogue.ui.tui.widgets.stats import StatCard
+
+if TYPE_CHECKING:
+    from polylogue.storage.repository import ConversationRepository
+    from tests.infra.storage_records import ConversationBuilder
 
 pytestmark = pytest.mark.tui
 _skip = pytest.mark.skipif(False, reason="Textual not installed")
@@ -17,12 +27,15 @@ _skip = pytest.mark.skipif(False, reason="Textual not installed")
 # ---------------------------------------------------------------------------
 
 
-def _make_app(repo: Any) -> Any:
+ConversationBuilderFactory: TypeAlias = Callable[[str], "ConversationBuilder"]
+
+
+def _make_app(repo: ConversationArchiveReadStore) -> PolylogueApp:
     """Create PolylogueApp with an injected repository."""
     return PolylogueApp(repository=repo)
 
 
-async def _wait_workers(pilot: Any, *, selector: str | None = None, reject: str = "Loading...") -> None:
+async def _wait_workers(pilot: Pilot[None], *, selector: str | None = None, reject: str = "Loading...") -> None:
     """Wait for all thread workers to finish, then flush DOM (Phase 2B fix).
 
     Thread workers schedule call_from_thread() callbacks that haven't been
@@ -59,7 +72,9 @@ async def _wait_workers(pilot: Any, *, selector: str | None = None, reject: str 
 
 @_skip
 @pytest.mark.asyncio
-async def test_dashboard_stats_populated(storage_repository: Any, conversation_builder: Any) -> None:
+async def test_dashboard_stats_populated(
+    storage_repository: ConversationRepository, conversation_builder: ConversationBuilderFactory
+) -> None:
     """Seed data → mount → wait → assert stat card values match seeded counts."""
     conversation_builder("c1").add_message("m1", text="Hello").save()
     conversation_builder("c2").add_message("m2", text="World").add_message("m3", text="!").save()
@@ -76,7 +91,9 @@ async def test_dashboard_stats_populated(storage_repository: Any, conversation_b
 
 @_skip
 @pytest.mark.asyncio
-async def test_dashboard_provider_bars(storage_repository: Any, conversation_builder: Any) -> None:
+async def test_dashboard_provider_bars(
+    storage_repository: ConversationRepository, conversation_builder: ConversationBuilderFactory
+) -> None:
     """Seed 2 providers → assert ProviderBar widgets rendered with correct counts."""
     conversation_builder("c1").provider("chatgpt").add_message("m1", text="A").save()
     conversation_builder("c2").provider("chatgpt").add_message("m2", text="B").save()
@@ -89,7 +106,7 @@ async def test_dashboard_provider_bars(storage_repository: Any, conversation_bui
         bars = pilot.app.query(ProviderBar)
         assert len(bars) >= 2
         # chatgpt should have 2, claude should have 1
-        texts = [bar.render() for bar in bars]
+        texts = [str(bar.render()) for bar in bars]
         chatgpt_bar = [t for t in texts if "chatgpt" in t]
         claude_bar = [t for t in texts if "claude-ai" in t]
         assert len(chatgpt_bar) == 1
@@ -100,7 +117,7 @@ async def test_dashboard_provider_bars(storage_repository: Any, conversation_bui
 
 @_skip
 @pytest.mark.asyncio
-async def test_dashboard_empty_db(storage_repository: Any) -> None:
+async def test_dashboard_empty_db(storage_repository: ConversationRepository) -> None:
     """Empty DB → graceful '0' display, no errors."""
     app = _make_app(storage_repository)
     async with app.run_test() as pilot:
@@ -119,7 +136,9 @@ async def test_dashboard_empty_db(storage_repository: Any) -> None:
 
 @_skip
 @pytest.mark.asyncio
-async def test_browser_tree_populated(storage_repository: Any, conversation_builder: Any) -> None:
+async def test_browser_tree_populated(
+    storage_repository: ConversationRepository, conversation_builder: ConversationBuilderFactory
+) -> None:
     """Seed conversations → switch to browser → wait → assert tree nodes match."""
     conversation_builder("c1").provider("chatgpt").title("My Chat").add_message("m1", text="Hi").save()
 
@@ -144,7 +163,9 @@ async def test_browser_tree_populated(storage_repository: Any, conversation_buil
 
 @_skip
 @pytest.mark.asyncio
-async def test_browser_node_selection(storage_repository: Any, conversation_builder: Any) -> None:
+async def test_browser_node_selection(
+    storage_repository: ConversationRepository, conversation_builder: ConversationBuilderFactory
+) -> None:
     """Click leaf node → assert markdown viewer shows conversation content."""
     conversation_builder("c1").provider("chatgpt").title("Test Chat").add_message("m1", text="Hello World").save()
 
@@ -175,7 +196,7 @@ async def test_browser_node_selection(storage_repository: Any, conversation_buil
 
 @_skip
 @pytest.mark.asyncio
-async def test_browser_empty_db(storage_repository: Any) -> None:
+async def test_browser_empty_db(storage_repository: ConversationRepository) -> None:
     """Empty DB → fallback provider list shown."""
     import asyncio
 
@@ -205,7 +226,9 @@ async def test_browser_empty_db(storage_repository: Any) -> None:
 
 @_skip
 @pytest.mark.asyncio
-async def test_search_flow(storage_repository: Any, conversation_builder: Any) -> None:
+async def test_search_flow(
+    storage_repository: ConversationRepository, conversation_builder: ConversationBuilderFactory
+) -> None:
     """Seed + index → type query → wait → assert DataTable rows."""
     conversation_builder("c1").add_message("m1", text="UniqueSearchTerm123").save()
 
@@ -247,7 +270,9 @@ async def test_search_flow(storage_repository: Any, conversation_builder: Any) -
 
 @_skip
 @pytest.mark.asyncio
-async def test_search_no_results(storage_repository: Any, conversation_builder: Any) -> None:
+async def test_search_no_results(
+    storage_repository: ConversationRepository, conversation_builder: ConversationBuilderFactory
+) -> None:
     """Search non-existent term → empty results, no error."""
     conversation_builder("c1").add_message("m1", text="Hello").save()
 
@@ -276,7 +301,7 @@ async def test_search_no_results(storage_repository: Any, conversation_builder: 
 
 @_skip
 @pytest.mark.asyncio
-async def test_search_empty_db(storage_repository: Any) -> None:
+async def test_search_empty_db(storage_repository: ConversationRepository) -> None:
     """Empty DB with FTS table → 0 results, no crash (messages_fts always exists)."""
     app = _make_app(storage_repository)
     async with app.run_test() as pilot:
@@ -302,7 +327,7 @@ async def test_search_empty_db(storage_repository: Any) -> None:
 
 @_skip
 @pytest.mark.asyncio
-async def test_keyboard_tab_switch(storage_repository: Any) -> None:
+async def test_keyboard_tab_switch(storage_repository: ConversationRepository) -> None:
     """Press Tab key → verify tab changes (basic navigation)."""
     app = _make_app(storage_repository)
     async with app.run_test() as pilot:
@@ -322,7 +347,7 @@ async def test_keyboard_tab_switch(storage_repository: Any) -> None:
 
 @_skip
 @pytest.mark.asyncio
-async def test_dark_mode_toggle(storage_repository: Any) -> None:
+async def test_dark_mode_toggle(storage_repository: ConversationRepository) -> None:
     """Press 'd' → assert dark mode toggles without crashing."""
     app = _make_app(storage_repository)
     async with app.run_test() as pilot:
@@ -337,7 +362,9 @@ async def test_dark_mode_toggle(storage_repository: Any) -> None:
 
 @_skip
 @pytest.mark.asyncio
-async def test_search_missing_index_shows_rebuild_hint(storage_repository: Any, conversation_builder: Any) -> None:
+async def test_search_missing_index_shows_rebuild_hint(
+    storage_repository: ConversationRepository, conversation_builder: ConversationBuilderFactory
+) -> None:
     """Dropping FTS tables yields a direct rebuild hint instead of a crash."""
     from polylogue.storage.backends.connection import open_connection
 
@@ -377,7 +404,7 @@ def test_repository_bound_container_requires_injected_repo() -> None:
 
 @_skip
 @pytest.mark.asyncio
-async def test_quit_action(storage_repository: Any) -> None:
+async def test_quit_action(storage_repository: ConversationRepository) -> None:
     """Press 'q' → app exits cleanly."""
     app = _make_app(storage_repository)
     async with app.run_test() as pilot:
@@ -393,15 +420,15 @@ async def test_quit_action(storage_repository: Any) -> None:
 
 @_skip
 @pytest.mark.asyncio
-async def test_worker_failure_recovery(storage_repository: Any, monkeypatch: Any) -> None:
+async def test_worker_failure_recovery(
+    storage_repository: ConversationRepository, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Inject error in repo → assert app stays usable with error notification."""
-    from unittest.mock import MagicMock
-
     # Create a repo that raises on get_archive_stats
     broken_repo = MagicMock()
     broken_repo.get_archive_stats.side_effect = RuntimeError("DB exploded")
 
-    app = PolylogueApp(repository=broken_repo)
+    app = PolylogueApp(repository=cast(ConversationArchiveReadStore, broken_repo))
     async with app.run_test() as pilot:
         await _wait_workers(pilot)
 
@@ -420,7 +447,7 @@ async def test_worker_failure_recovery(storage_repository: Any, monkeypatch: Any
 
 @_skip
 @pytest.mark.asyncio
-async def test_app_startup(storage_repository: Any) -> None:
+async def test_app_startup(storage_repository: ConversationRepository) -> None:
     """Test that the app starts and loads the dashboard."""
     app = _make_app(storage_repository)
 

--- a/tests/unit/ui/test_ui.py
+++ b/tests/unit/ui/test_ui.py
@@ -8,8 +8,9 @@ surface that is specific to ``ConsoleFacade`` / ``UI``.
 from __future__ import annotations
 
 import json
-from collections.abc import Generator
-from typing import Any
+from collections.abc import Callable, Generator
+from pathlib import Path
+from typing import TypeAlias
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -19,15 +20,18 @@ from polylogue.ui import UI, _PlainProgressTracker, _RichProgressTracker, create
 from polylogue.ui.facade import ConsoleFacade, PlainConsole, UIError, create_console_facade
 from polylogue.ui.facade_prompts import PromptStubEntry
 
+PromptEntry: TypeAlias = dict[str, object]
+UICall: TypeAlias = Callable[[UI], object]
+
 
 @pytest.fixture
-def mock_prompt_file(tmp_path: Any) -> Any:
+def mock_prompt_file(tmp_path: Path) -> Path:
     prompt_file = tmp_path / "prompts.jsonl"
     return prompt_file
 
 
 @pytest.fixture
-def mock_facade() -> Generator[Any, None, None]:
+def mock_facade() -> Generator[MagicMock, None, None]:
     with patch("polylogue.ui.create_console_facade") as mock_create:
         facade = MagicMock(spec=ConsoleFacade)
         facade.console = MagicMock()
@@ -37,12 +41,12 @@ def mock_facade() -> Generator[Any, None, None]:
 
 
 @pytest.fixture
-def rich_facade() -> Any:
+def rich_facade() -> ConsoleFacade:
     return create_console_facade(plain=False)
 
 
 @pytest.fixture
-def plain_facade() -> Any:
+def plain_facade() -> ConsoleFacade:
     return create_console_facade(plain=True)
 
 
@@ -53,16 +57,20 @@ PROMPT_TOPICS = {
 }
 
 
-def _write_stubs(prompt_file: Any, *entries: dict[str, object]) -> None:
+def _write_stubs(prompt_file: Path, *entries: PromptEntry) -> None:
     prompt_file.write_text("\n".join(json.dumps(entry) for entry in entries) + "\n")
 
 
-def _questionary_stub(monkeypatch: Any, method: str, result: object) -> MagicMock:
+def _questionary_stub(monkeypatch: pytest.MonkeyPatch, method: str, result: object) -> MagicMock:
     import questionary
 
     question = MagicMock()
     question.ask.return_value = result
-    monkeypatch.setattr(questionary, method, lambda *args, **kwargs: question)
+
+    def _stub_question(*args: object, **kwargs: object) -> MagicMock:
+        return question
+
+    monkeypatch.setattr(questionary, method, _stub_question)
     return question
 
 
@@ -77,7 +85,13 @@ class TestPlainConsole:
             (("[unclosed markup",), "[unclosed markup", None),
         ],
     )
-    def test_print_contract(self, capsys: Any, objects: Any, expected: Any, unexpected: Any) -> None:
+    def test_print_contract(
+        self,
+        capsys: pytest.CaptureFixture[str],
+        objects: tuple[object, ...],
+        expected: str,
+        unexpected: str | None,
+    ) -> None:
         console = PlainConsole()
         console.print(*objects)
         output = capsys.readouterr().out
@@ -85,7 +99,7 @@ class TestPlainConsole:
         if unexpected:
             assert unexpected not in output
 
-    def test_print_ignores_extra_kwargs(self, capsys: Any) -> None:
+    def test_print_ignores_extra_kwargs(self, capsys: pytest.CaptureFixture[str]) -> None:
         PlainConsole().print("text", sep="|", end="!\n")
         assert "text" in capsys.readouterr().out
 
@@ -105,7 +119,9 @@ class TestConsoleFacadePromptStubs:
             ),
         ],
     )
-    def test_stub_loading_contract(self, tmp_path: Any, monkeypatch: Any, entries: Any, expected_count: Any) -> None:
+    def test_stub_loading_contract(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, entries: list[PromptEntry], expected_count: int
+    ) -> None:
         if entries:
             prompt_file = tmp_path / "stubs.jsonl"
             _write_stubs(prompt_file, *entries)
@@ -114,13 +130,13 @@ class TestConsoleFacadePromptStubs:
             facade = ConsoleFacade(plain=True)
         assert len(facade._prompt_responses) == expected_count
 
-    def test_invalid_json_raises_uierror(self, tmp_path: Any) -> None:
+    def test_invalid_json_raises_uierror(self, tmp_path: Path) -> None:
         prompt_file = tmp_path / "bad.jsonl"
         prompt_file.write_text("not json\n")
         with pytest.raises(UIError, match="Invalid prompt stub"):
             ConsoleFacade(plain=True, prompt_stub_path=prompt_file)
 
-    def test_pop_prompt_response_contract(self, mock_prompt_file: Any) -> None:
+    def test_pop_prompt_response_contract(self, mock_prompt_file: Path) -> None:
         _write_stubs(mock_prompt_file, {"type": "confirm", "value": True})
         facade = ConsoleFacade(plain=True, prompt_stub_path=mock_prompt_file)
         with pytest.raises(UIError, match="expected 'confirm' but got 'choose'"):
@@ -158,21 +174,29 @@ class TestConsoleFacadePrompts:
         ],
     )
     def test_plain_prompt_matrix(
-        self, monkeypatch: Any, kind: Any, plain_value: Any, default: Any, expected: Any
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        kind: str,
+        plain_value: str,
+        default: bool | str | None,
+        expected: bool | str | None,
     ) -> None:
         monkeypatch.setattr("sys.stdin.isatty", lambda: True)
         monkeypatch.setattr("builtins.input", lambda _: plain_value)
         facade = ConsoleFacade(plain=True)
 
         if kind == "confirm":
+            assert isinstance(default, bool)
+            assert isinstance(expected, bool)
             assert facade.confirm("Continue?", default=default) is expected
         elif kind == "choose":
             assert facade.choose("Pick:", ["a", "b", "c"]) == expected
         else:
+            assert default is None or isinstance(default, str)
             assert facade.input("Name:", default=default) == expected
 
     @pytest.mark.parametrize("kind", ["confirm", "choose", "input"])
-    def test_plain_non_tty_raises_uierror(self, monkeypatch: Any, kind: Any) -> None:
+    def test_plain_non_tty_raises_uierror(self, monkeypatch: pytest.MonkeyPatch, kind: str) -> None:
         monkeypatch.setattr("sys.stdin.isatty", lambda: False)
         facade = ConsoleFacade(plain=True)
         with pytest.raises(UIError, match=PROMPT_TOPICS[kind]):
@@ -190,7 +214,7 @@ class TestConsoleFacadePrompts:
         ],
         ids=["bool_true", "str_yes", "str_zero", "use_default"],
     )
-    def test_confirm_stub_contract(self, mock_prompt_file: Any, entry: Any, expected: Any) -> None:
+    def test_confirm_stub_contract(self, mock_prompt_file: Path, entry: PromptEntry, expected: object) -> None:
         _write_stubs(mock_prompt_file, entry)
         facade = ConsoleFacade(plain=False, prompt_stub_path=mock_prompt_file)
         assert facade.confirm("Continue?", default=False) is expected
@@ -204,7 +228,9 @@ class TestConsoleFacadePrompts:
             ({"type": "choose", "use_default": True}, ["first", "second"], "first"),
         ],
     )
-    def test_choose_stub_contract(self, mock_prompt_file: Any, entry: Any, options: Any, expected: Any) -> None:
+    def test_choose_stub_contract(
+        self, mock_prompt_file: Path, entry: PromptEntry, options: list[str], expected: object
+    ) -> None:
         _write_stubs(mock_prompt_file, entry)
         assert ConsoleFacade(plain=False, prompt_stub_path=mock_prompt_file).choose("Pick:", options) == expected
 
@@ -218,13 +244,15 @@ class TestConsoleFacadePrompts:
             ({"type": "input", "value": ""}, "default", ""),
         ],
     )
-    def test_input_stub_contract(self, mock_prompt_file: Any, entry: Any, default: Any, expected: Any) -> None:
+    def test_input_stub_contract(
+        self, mock_prompt_file: Path, entry: PromptEntry, default: str | None, expected: str | None
+    ) -> None:
         _write_stubs(mock_prompt_file, entry)
         assert (
             ConsoleFacade(plain=False, prompt_stub_path=mock_prompt_file).input("Prompt:", default=default) == expected
         )
 
-    def test_rich_choose_fallback_paths(self, monkeypatch: Any) -> None:
+    def test_rich_choose_fallback_paths(self, monkeypatch: pytest.MonkeyPatch) -> None:
         question = _questionary_stub(monkeypatch, "select", None)
         facade = ConsoleFacade(plain=False)
         assert facade.choose("Pick:", ["a", "b", "c"]) is None
@@ -234,7 +262,7 @@ class TestConsoleFacadePrompts:
         assert facade.choose("Pick:", [f"opt{i}" for i in range(15)]) == "opt13"
         question.ask.assert_called_once()
 
-    def test_rich_confirm_and_input_fallback_paths(self, monkeypatch: Any) -> None:
+    def test_rich_confirm_and_input_fallback_paths(self, monkeypatch: pytest.MonkeyPatch) -> None:
         confirm = _questionary_stub(monkeypatch, "confirm", None)
         input_box = _questionary_stub(monkeypatch, "text", "")
         facade = ConsoleFacade(plain=False)
@@ -263,14 +291,18 @@ class TestConsoleFacadeRendering:
             ("info", ("FYI",), ["FYI"]),
         ],
     )
-    def test_plain_rendering_surface_contract(self, capsys: Any, method: Any, args: Any, expected: Any) -> None:
+    def test_plain_rendering_surface_contract(
+        self, capsys: pytest.CaptureFixture[str], method: str, args: tuple[object, ...], expected: list[str]
+    ) -> None:
         facade = ConsoleFacade(plain=True)
         getattr(facade, method)(*args)
         output = capsys.readouterr().out
         for text in expected:
             assert text in output
 
-    def test_rich_rendering_surface_contract(self, rich_facade: Any, capsys: Any) -> None:
+    def test_rich_rendering_surface_contract(
+        self, rich_facade: ConsoleFacade, capsys: pytest.CaptureFixture[str]
+    ) -> None:
         rich_facade.banner("Welcome", "Dashboard")
         rich_facade.summary("Checklist", ["Item 1", "[red]Item 2[/red]"])
         rich_facade.render_markdown("# Title\n\nBody")
@@ -291,7 +323,7 @@ class TestConsoleFacadeRendering:
         assert "Oops" in output
         assert "FYI" in output
 
-    def test_render_diff_falls_back_when_pager_missing(self, plain_facade: Any) -> None:
+    def test_render_diff_falls_back_when_pager_missing(self, plain_facade: ConsoleFacade) -> None:
         plain_facade.render_diff("line1\n", "line2\n", "file.txt")
 
     def test_protocol_theme_contract(self) -> None:
@@ -307,7 +339,7 @@ class TestConsoleFacadeRendering:
 
 
 class TestUIWrapper:
-    def test_ui_init_and_create_contract(self, mock_facade: Any) -> None:
+    def test_ui_init_and_create_contract(self, mock_facade: MagicMock) -> None:
         ui = UI(plain=False)
         assert ui._facade == mock_facade
         assert ui.plain is False
@@ -318,7 +350,7 @@ class TestUIWrapper:
             with pytest.raises(SystemExit, match="boom"):
                 UI(plain=False)
 
-    def test_ui_delegation_contract(self, mock_facade: Any) -> None:
+    def test_ui_delegation_contract(self, mock_facade: MagicMock) -> None:
         ui = UI(plain=False)
         ui.banner("Title", "Subtitle")
         ui.summary("Summary", ["line1"])
@@ -339,7 +371,9 @@ class TestUIWrapper:
             ("input", ("Prompt",), {"default": None}),
         ],
     )
-    def test_ui_prompt_delegation_contract(self, mock_facade: Any, method: Any, args: Any, kwargs: Any) -> None:
+    def test_ui_prompt_delegation_contract(
+        self, mock_facade: MagicMock, method: str, args: tuple[object, ...], kwargs: dict[str, object]
+    ) -> None:
         ui = UI(plain=False)
         getattr(mock_facade, method).return_value = (
             True if method == "confirm" else "A" if method == "choose" else "val"
@@ -356,7 +390,7 @@ class TestUIWrapper:
             ("input", lambda ui: ui.input("Prompt")),
         ],
     )
-    def test_ui_plain_prompt_abort_contract(self, mock_facade: Any, method: Any, call: Any) -> None:
+    def test_ui_plain_prompt_abort_contract(self, mock_facade: MagicMock, method: str, call: UICall) -> None:
         mock_facade.plain = True
         mock_facade.console = MagicMock()
         getattr(mock_facade, method).side_effect = UIError(

--- a/tests/unit/ui/test_ui_visual.py
+++ b/tests/unit/ui/test_ui_visual.py
@@ -12,7 +12,8 @@ from __future__ import annotations
 import json
 import os
 import re
-from typing import Any
+from pathlib import Path
+from typing import TypeAlias
 
 import pytest
 
@@ -45,13 +46,19 @@ from tests.infra.storage_records import (
     store_records,
 )
 
+JSONRecord: TypeAlias = dict[str, object]
+WorkspaceEnv: TypeAlias = dict[str, Path]
+MessageOrderingRow: TypeAlias = tuple[str, str, str | None]
+AttachmentCaseMeta: TypeAlias = JSONRecord | list[JSONRecord] | None
+AttachmentExpected: TypeAlias = str | list[str]
+
 # =============================================================================
 # RENDERER IMPLEMENTATION TESTS (from test_rendering.py)
 # =============================================================================
 
 
 @pytest.fixture
-def sample_conversation_id() -> Any:
+def sample_conversation_id() -> str:
     """Create a sample conversation for testing."""
     conversation = make_conversation(
         "test-conv-1",
@@ -81,7 +88,7 @@ def sample_conversation_id() -> Any:
 
 
 @pytest.fixture
-def sample_conversation_with_json() -> Any:
+def sample_conversation_with_json() -> str:
     """Create a conversation with JSON content (tool use)."""
     conversation = make_conversation(
         "test-conv-json",
@@ -112,12 +119,12 @@ def sample_conversation_with_json() -> Any:
 class TestMarkdownRenderer:
     """Tests for MarkdownRenderer."""
 
-    def test_supports_format(self, workspace_env: Any) -> None:
+    def test_supports_format(self, workspace_env: WorkspaceEnv) -> None:
         renderer = MarkdownRenderer(archive_root=workspace_env["archive_root"])
         assert renderer.supports_format() == "markdown"
 
     @pytest.mark.asyncio
-    async def test_render_basic_conversation(self, workspace_env: Any, sample_conversation_id: Any) -> None:
+    async def test_render_basic_conversation(self, workspace_env: WorkspaceEnv, sample_conversation_id: str) -> None:
         renderer = MarkdownRenderer(archive_root=workspace_env["archive_root"])
         output_path = workspace_env["archive_root"] / "render"
         result_path = await renderer.render(sample_conversation_id, output_path)
@@ -134,7 +141,9 @@ class TestMarkdownRenderer:
         assert "I need help with Python testing" in content
 
     @pytest.mark.asyncio
-    async def test_render_with_json_formatting(self, workspace_env: Any, sample_conversation_with_json: Any) -> None:
+    async def test_render_with_json_formatting(
+        self, workspace_env: WorkspaceEnv, sample_conversation_with_json: str
+    ) -> None:
         renderer = MarkdownRenderer(archive_root=workspace_env["archive_root"])
         output_path = workspace_env["archive_root"] / "render"
         result_path = await renderer.render(sample_conversation_with_json, output_path)
@@ -144,14 +153,16 @@ class TestMarkdownRenderer:
         assert '"results"' in content
 
     @pytest.mark.asyncio
-    async def test_render_nonexistent_conversation(self, workspace_env: Any) -> None:
+    async def test_render_nonexistent_conversation(self, workspace_env: WorkspaceEnv) -> None:
         renderer = MarkdownRenderer(archive_root=workspace_env["archive_root"])
         output_path = workspace_env["archive_root"] / "render"
         with pytest.raises(ValueError, match="Conversation not found"):
             await renderer.render("nonexistent-id", output_path)
 
     @pytest.mark.asyncio
-    async def test_render_creates_output_directory(self, workspace_env: Any, sample_conversation_id: Any) -> None:
+    async def test_render_creates_output_directory(
+        self, workspace_env: WorkspaceEnv, sample_conversation_id: str
+    ) -> None:
         renderer = MarkdownRenderer(archive_root=workspace_env["archive_root"])
         output_path = workspace_env["archive_root"] / "custom" / "nested" / "render"
         assert not output_path.exists()
@@ -163,12 +174,12 @@ class TestMarkdownRenderer:
 class TestHTMLRenderer:
     """Tests for HTMLRenderer."""
 
-    def test_supports_format(self, workspace_env: Any) -> None:
+    def test_supports_format(self, workspace_env: WorkspaceEnv) -> None:
         renderer = HTMLRenderer(archive_root=workspace_env["archive_root"])
         assert renderer.supports_format() == "html"
 
     @pytest.mark.asyncio
-    async def test_render_basic_conversation(self, workspace_env: Any, sample_conversation_id: Any) -> None:
+    async def test_render_basic_conversation(self, workspace_env: WorkspaceEnv, sample_conversation_id: str) -> None:
         renderer = HTMLRenderer(archive_root=workspace_env["archive_root"])
         output_path = workspace_env["archive_root"] / "render"
         result_path = await renderer.render(sample_conversation_id, output_path)
@@ -185,14 +196,16 @@ class TestHTMLRenderer:
         assert "Hello, can you help me?" in content
 
     @pytest.mark.asyncio
-    async def test_render_nonexistent_conversation(self, workspace_env: Any) -> None:
+    async def test_render_nonexistent_conversation(self, workspace_env: WorkspaceEnv) -> None:
         renderer = HTMLRenderer(archive_root=workspace_env["archive_root"])
         output_path = workspace_env["archive_root"] / "render"
         with pytest.raises(ValueError, match="Conversation not found"):
             await renderer.render("nonexistent-id", output_path)
 
     @pytest.mark.asyncio
-    async def test_render_with_json_content(self, workspace_env: Any, sample_conversation_with_json: Any) -> None:
+    async def test_render_with_json_content(
+        self, workspace_env: WorkspaceEnv, sample_conversation_with_json: str
+    ) -> None:
         renderer = HTMLRenderer(archive_root=workspace_env["archive_root"])
         output_path = workspace_env["archive_root"] / "render"
         result_path = await renderer.render(sample_conversation_with_json, output_path)
@@ -204,7 +217,7 @@ class TestHTMLRenderer:
 class TestRendererFactory:
     """Tests for renderer factory functions."""
 
-    def test_create_markdown_renderer(self, workspace_env: Any) -> None:
+    def test_create_markdown_renderer(self, workspace_env: WorkspaceEnv) -> None:
         config = Config(
             archive_root=workspace_env["archive_root"],
             render_root=workspace_env["archive_root"] / "render",
@@ -214,7 +227,7 @@ class TestRendererFactory:
         assert isinstance(renderer, MarkdownRenderer)
         assert renderer.supports_format() == "markdown"
 
-    def test_create_html_renderer(self, workspace_env: Any) -> None:
+    def test_create_html_renderer(self, workspace_env: WorkspaceEnv) -> None:
         config = Config(
             archive_root=workspace_env["archive_root"],
             render_root=workspace_env["archive_root"] / "render",
@@ -224,7 +237,7 @@ class TestRendererFactory:
         assert isinstance(renderer, HTMLRenderer)
         assert renderer.supports_format() == "html"
 
-    def test_create_renderer_case_insensitive(self, workspace_env: Any) -> None:
+    def test_create_renderer_case_insensitive(self, workspace_env: WorkspaceEnv) -> None:
         config = Config(
             archive_root=workspace_env["archive_root"],
             render_root=workspace_env["archive_root"] / "render",
@@ -237,7 +250,7 @@ class TestRendererFactory:
         assert isinstance(renderer2, HTMLRenderer)
         assert isinstance(renderer3, MarkdownRenderer)
 
-    def test_create_renderer_unsupported_format(self, workspace_env: Any) -> None:
+    def test_create_renderer_unsupported_format(self, workspace_env: WorkspaceEnv) -> None:
         config = Config(
             archive_root=workspace_env["archive_root"],
             render_root=workspace_env["archive_root"] / "render",
@@ -258,7 +271,9 @@ class TestRendererIntegration:
     """Integration tests for renderers."""
 
     @pytest.mark.asyncio
-    async def test_both_renderers_produce_output(self, workspace_env: Any, sample_conversation_id: Any) -> None:
+    async def test_both_renderers_produce_output(
+        self, workspace_env: WorkspaceEnv, sample_conversation_id: str
+    ) -> None:
         md_renderer = MarkdownRenderer(archive_root=workspace_env["archive_root"])
         html_renderer = HTMLRenderer(archive_root=workspace_env["archive_root"])
         output_path = workspace_env["archive_root"] / "render"
@@ -273,7 +288,7 @@ class TestRendererIntegration:
         assert "Hello, can you help me?" in md_content
         assert "Hello, can you help me?" in html_content
 
-    def test_protocol_compliance(self, workspace_env: Any) -> None:
+    def test_protocol_compliance(self, workspace_env: WorkspaceEnv) -> None:
         from polylogue.protocols import OutputRenderer
 
         md_renderer = MarkdownRenderer(archive_root=workspace_env["archive_root"])
@@ -351,7 +366,7 @@ INIT_CASES = [
 
 
 @pytest.mark.parametrize("label,desc", INIT_CASES)
-def test_formatter_initialization_comprehensive(tmp_path: Any, label: Any, desc: Any) -> None:
+def test_formatter_initialization_comprehensive(tmp_path: Path, label: str, desc: str) -> None:
     if label == "basic path":
         formatter = ConversationFormatter(tmp_path)
         assert formatter.archive_root == tmp_path
@@ -371,7 +386,7 @@ FORMAT_CASES = [
 
 @pytest.mark.parametrize("label,conv_id,desc", FORMAT_CASES)
 @pytest.mark.asyncio
-async def test_formatter_format_comprehensive(workspace_env: Any, label: Any, conv_id: Any, desc: Any) -> None:
+async def test_formatter_format_comprehensive(workspace_env: WorkspaceEnv, label: str, conv_id: str, desc: str) -> None:
     db_path = db_setup(workspace_env)
     formatter = ConversationFormatter(workspace_env["archive_root"], db_path=db_path)
 
@@ -429,7 +444,7 @@ MESSAGE_ORDERING_CASES = [
 @pytest.mark.parametrize("label,conv_id,message_data,desc", MESSAGE_ORDERING_CASES)
 @pytest.mark.asyncio
 async def test_message_ordering_comprehensive(
-    workspace_env: Any, label: Any, conv_id: Any, message_data: Any, desc: Any
+    workspace_env: WorkspaceEnv, label: str, conv_id: str, message_data: list[MessageOrderingRow], desc: str
 ) -> None:
     db_path = db_setup(workspace_env)
     builder = ConversationBuilder(db_path, conv_id)
@@ -458,7 +473,9 @@ JSON_WRAPPING_CASES = [
 
 @pytest.mark.parametrize("text,wrapped,desc", JSON_WRAPPING_CASES)
 @pytest.mark.asyncio
-async def test_json_text_wrapping_comprehensive(workspace_env: Any, text: Any, wrapped: Any, desc: Any) -> None:
+async def test_json_text_wrapping_comprehensive(
+    workspace_env: WorkspaceEnv, text: str, wrapped: bool, desc: str
+) -> None:
     db_path = db_setup(workspace_env)
     conv_id = f"json-{hash(text) % 10000}-conv"
     (ConversationBuilder(db_path, conv_id).title("Test").add_message("m1", role="tool", text=text).save())
@@ -487,7 +504,9 @@ TIMESTAMP_RENDERING_CASES = [
 
 @pytest.mark.parametrize("timestamp,rendered,desc", TIMESTAMP_RENDERING_CASES)
 @pytest.mark.asyncio
-async def test_timestamp_rendering_comprehensive(workspace_env: Any, timestamp: Any, rendered: Any, desc: Any) -> None:
+async def test_timestamp_rendering_comprehensive(
+    workspace_env: WorkspaceEnv, timestamp: str | None, rendered: bool, desc: str
+) -> None:
     db_path = db_setup(workspace_env)
     conv_id = f"ts-{hash(str(timestamp)) % 10000}-conv"
     (
@@ -527,19 +546,26 @@ ATTACHMENT_CASES = [
 @pytest.mark.parametrize("label,meta,expected,desc", ATTACHMENT_CASES)
 @pytest.mark.asyncio
 async def test_attachment_handling_comprehensive(
-    workspace_env: Any, label: Any, meta: Any, expected: Any, desc: Any
+    workspace_env: WorkspaceEnv, label: str, meta: AttachmentCaseMeta, expected: AttachmentExpected, desc: str
 ) -> None:
     db_path = db_setup(workspace_env)
     conv_id = f"att-{label}-conv"
     builder = ConversationBuilder(db_path, conv_id).title("Test").add_message("m1", role="user", text="See attachment")
     if label == "multiple":
+        assert isinstance(meta, list)
         for att in meta:
+            attachment_id = att["id"]
+            provider_meta = att.get("meta")
+            assert isinstance(attachment_id, str)
+            assert provider_meta is None or isinstance(provider_meta, dict)
             builder.add_attachment(
-                attachment_id=att["id"],
+                attachment_id=attachment_id,
                 message_id="m1",
-                provider_meta=att.get("meta"),
+                provider_meta=provider_meta,
             )
     elif label == "path":
+        assert isinstance(expected, str)
+        assert meta is None or isinstance(meta, dict)
         builder.add_attachment(
             attachment_id="att1",
             message_id="m1",
@@ -547,6 +573,8 @@ async def test_attachment_handling_comprehensive(
             provider_meta=meta,
         )
     else:
+        assert isinstance(expected, str)
+        assert meta is None or isinstance(meta, dict)
         att_id = expected if meta is None or meta == {} else "att1"
         builder.add_attachment(
             attachment_id=att_id,
@@ -564,7 +592,7 @@ async def test_attachment_handling_comprehensive(
 
 
 @pytest.mark.asyncio
-async def test_orphaned_attachments_section(workspace_env: Any) -> None:
+async def test_orphaned_attachments_section(workspace_env: WorkspaceEnv) -> None:
     db_path = db_setup(workspace_env)
     conv_id = "orphan-att-conv"
     (
@@ -594,15 +622,19 @@ METADATA_CASES = [
 
 @pytest.mark.parametrize("label,data,desc", METADATA_CASES)
 @pytest.mark.asyncio
-async def test_metadata_comprehensive(workspace_env: Any, label: Any, data: Any, desc: Any) -> None:
+async def test_metadata_comprehensive(workspace_env: WorkspaceEnv, label: str, data: JSONRecord, desc: str) -> None:
     db_path = db_setup(workspace_env)
     conv_id = f"meta-{label}-conv"
     if label == "counts":
+        message_count = data["messages"]
+        attachment_count = data["attachments"]
+        assert isinstance(message_count, int)
+        assert isinstance(attachment_count, int)
         builder = ConversationBuilder(db_path, conv_id).title("Test")
-        for i in range(data["messages"]):
+        for i in range(message_count):
             role = "user" if i % 2 == 0 else "assistant"
             builder.add_message(f"m{i}", role=role, text=f"Message {i}")
-        for i in range(data["attachments"]):
+        for i in range(attachment_count):
             builder.add_attachment(
                 attachment_id=f"att{i}",
                 message_id="m0",
@@ -612,20 +644,18 @@ async def test_metadata_comprehensive(workspace_env: Any, label: Any, data: Any,
         builder.save()
         formatter = ConversationFormatter(workspace_env["archive_root"], db_path=db_path)
         result = await formatter.format(conv_id)
-        assert result.metadata.message_count == data["messages"], f"Failed {desc}"
-        assert result.metadata.attachment_count == data["attachments"], f"Failed {desc}"
+        assert result.metadata.message_count == message_count, f"Failed {desc}"
+        assert result.metadata.attachment_count == attachment_count, f"Failed {desc}"
     elif label == "timestamps":
-        (
-            ConversationBuilder(db_path, conv_id)
-            .title("Test")
-            .created_at(data["created"])
-            .updated_at(data["updated"])
-            .save()
-        )
+        created = data["created"]
+        updated = data["updated"]
+        assert isinstance(created, str)
+        assert isinstance(updated, str)
+        (ConversationBuilder(db_path, conv_id).title("Test").created_at(created).updated_at(updated).save())
         formatter = ConversationFormatter(workspace_env["archive_root"], db_path=db_path)
         result = await formatter.format(conv_id)
-        assert result.metadata.created_at == data["created"], f"Failed {desc}"
-        assert result.metadata.updated_at == data["updated"], f"Failed {desc}"
+        assert result.metadata.created_at == created, f"Failed {desc}"
+        assert result.metadata.updated_at == updated, f"Failed {desc}"
 
 
 MARKDOWN_STRUCTURE_CASES = [
@@ -654,15 +684,21 @@ MARKDOWN_STRUCTURE_CASES = [
 
 @pytest.mark.parametrize("label,messages_data,desc", MARKDOWN_STRUCTURE_CASES)
 @pytest.mark.asyncio
-async def test_markdown_structure_comprehensive(workspace_env: Any, label: Any, messages_data: Any, desc: Any) -> None:
+async def test_markdown_structure_comprehensive(
+    workspace_env: WorkspaceEnv, label: str, messages_data: list[JSONRecord], desc: str
+) -> None:
     db_path = db_setup(workspace_env)
     conv_id = f"md-{label}-conv"
     builder = ConversationBuilder(db_path, conv_id).provider("chatgpt").title("My Chat Title")
     for i, msg in enumerate(messages_data):
+        role = msg["role"]
+        text = msg["text"]
+        assert role is None or isinstance(role, str)
+        assert isinstance(text, str)
         builder.add_message(
             f"m{i}",
-            role=msg["role"],
-            text=msg["text"],
+            role=role,
+            text=text,
             timestamp=f"2024-01-01T10:00:{i:02d}Z",
         )
     builder.save()
@@ -721,7 +757,9 @@ class TestGoldenMarkdownRendering:
     """Test markdown rendering against golden reference files."""
 
     @pytest.mark.asyncio
-    async def test_chatgpt_simple_conversation(self, tmp_path: Any, workspace_env: Any, db_path: Any) -> None:
+    async def test_chatgpt_simple_conversation(
+        self, tmp_path: Path, workspace_env: WorkspaceEnv, db_path: Path
+    ) -> None:
         factory = DbFactory(db_path)
         conv_id = "golden-chatgpt-simple"
         factory.create_conversation(
@@ -762,7 +800,9 @@ class TestGoldenMarkdownRendering:
         assert_golden("chatgpt-simple", formatted.markdown_text)
 
     @pytest.mark.asyncio
-    async def test_claude_with_thinking_blocks(self, tmp_path: Any, workspace_env: Any, db_path: Any) -> None:
+    async def test_claude_with_thinking_blocks(
+        self, tmp_path: Path, workspace_env: WorkspaceEnv, db_path: Path
+    ) -> None:
         factory = DbFactory(db_path)
         conv_id = "golden-claude-thinking"
         factory.create_conversation(
@@ -788,7 +828,7 @@ class TestGoldenMarkdownRendering:
         assert_golden("claude-thinking", formatted.markdown_text)
 
     @pytest.mark.asyncio
-    async def test_json_tool_use_formatted(self, tmp_path: Any, workspace_env: Any, db_path: Any) -> None:
+    async def test_json_tool_use_formatted(self, tmp_path: Path, workspace_env: WorkspaceEnv, db_path: Path) -> None:
         factory = DbFactory(db_path)
         conv_id = "golden-tool-use"
         factory.create_conversation(
@@ -818,7 +858,7 @@ class TestGoldenMarkdownRendering:
         assert_golden("tool-use-json", formatted.markdown_text)
 
     @pytest.mark.asyncio
-    async def test_empty_messages_skipped(self, tmp_path: Any, workspace_env: Any, db_path: Any) -> None:
+    async def test_empty_messages_skipped(self, tmp_path: Path, workspace_env: WorkspaceEnv, db_path: Path) -> None:
         factory = DbFactory(db_path)
         conv_id = "golden-empty-messages"
         factory.create_conversation(
@@ -839,7 +879,7 @@ class TestGoldenMarkdownRendering:
         assert_golden("empty-messages", formatted.markdown_text)
 
     @pytest.mark.asyncio
-    async def test_unicode_content_preserved(self, tmp_path: Any, workspace_env: Any, db_path: Any) -> None:
+    async def test_unicode_content_preserved(self, tmp_path: Path, workspace_env: WorkspaceEnv, db_path: Path) -> None:
         factory = DbFactory(db_path)
         conv_id = "golden-unicode"
         factory.create_conversation(
@@ -876,7 +916,9 @@ class TestGoldenMarkdownRendering:
         assert_golden("unicode", formatted.markdown_text)
 
     @pytest.mark.asyncio
-    async def test_attachments_formatted_as_links(self, tmp_path: Any, workspace_env: Any, db_path: Any) -> None:
+    async def test_attachments_formatted_as_links(
+        self, tmp_path: Path, workspace_env: WorkspaceEnv, db_path: Path
+    ) -> None:
         factory = DbFactory(db_path)
         conv_id = "golden-attachments"
         factory.create_conversation(
@@ -908,7 +950,9 @@ class TestGoldenMarkdownRendering:
         assert_golden("attachments", formatted.markdown_text)
 
     @pytest.mark.asyncio
-    async def test_message_ordering_by_timestamp(self, tmp_path: Any, workspace_env: Any, db_path: Any) -> None:
+    async def test_message_ordering_by_timestamp(
+        self, tmp_path: Path, workspace_env: WorkspaceEnv, db_path: Path
+    ) -> None:
         factory = DbFactory(db_path)
         conv_id = "golden-ordering"
         factory.create_conversation(
@@ -934,7 +978,9 @@ class TestGoldenFileStructure:
     """Test file structure and naming conventions."""
 
     @pytest.mark.asyncio
-    async def test_markdown_renderer_output_path(self, tmp_path: Any, workspace_env: Any, db_path: Any) -> None:
+    async def test_markdown_renderer_output_path(
+        self, tmp_path: Path, workspace_env: WorkspaceEnv, db_path: Path
+    ) -> None:
         factory = DbFactory(db_path)
         conv_id = "test-file-structure"
         factory.create_conversation(
@@ -950,7 +996,9 @@ class TestGoldenFileStructure:
         assert "chatgpt" in str(output_path.parent)
 
     @pytest.mark.asyncio
-    async def test_multiple_conversations_isolated(self, tmp_path: Any, workspace_env: Any, db_path: Any) -> None:
+    async def test_multiple_conversations_isolated(
+        self, tmp_path: Path, workspace_env: WorkspaceEnv, db_path: Path
+    ) -> None:
         factory = DbFactory(db_path)
         conv1_id = "test-conv-1"
         conv2_id = "test-conv-2"
@@ -977,7 +1025,9 @@ class TestGoldenEdgeCases:
     """Test edge cases in rendering."""
 
     @pytest.mark.asyncio
-    async def test_very_long_text_not_truncated(self, tmp_path: Any, workspace_env: Any, db_path: Any) -> None:
+    async def test_very_long_text_not_truncated(
+        self, tmp_path: Path, workspace_env: WorkspaceEnv, db_path: Path
+    ) -> None:
         factory = DbFactory(db_path)
         long_text = "This is a very long message. " * 1000
         conv_id = "golden-long-text"
@@ -997,7 +1047,7 @@ class TestGoldenEdgeCases:
 
     @pytest.mark.asyncio
     async def test_special_markdown_chars_not_double_escaped(
-        self, tmp_path: Any, workspace_env: Any, db_path: Any
+        self, tmp_path: Path, workspace_env: WorkspaceEnv, db_path: Path
     ) -> None:
         factory = DbFactory(db_path)
         conv_id = "golden-markdown-chars"
@@ -1018,7 +1068,9 @@ class TestGoldenEdgeCases:
         assert_golden("markdown-chars", formatted.markdown_text)
 
     @pytest.mark.asyncio
-    async def test_messages_with_timestamps_rendered(self, tmp_path: Any, workspace_env: Any, db_path: Any) -> None:
+    async def test_messages_with_timestamps_rendered(
+        self, tmp_path: Path, workspace_env: WorkspaceEnv, db_path: Path
+    ) -> None:
         factory = DbFactory(db_path)
         conv_id = "golden-with-timestamp"
         factory.create_conversation(


### PR DESCRIPTION
## Summary
- Add typed MCP surface protocols for test helpers and fixtures.
- Replace dynamic MCP/security/UI test annotations with concrete fixture, callback, repository, and parameter data types.
- Route async MCP prompt/tool invocations through the shared surface helper instead of direct untyped calls.

## Problem
The mypy cleanup campaign still had dynamic seams in MCP and UI tests. These tests exercised real contracts, but their fixtures and parameter tables were typed as `Any`, which kept strict checking from proving the surface shapes.

## Solution
Typed the MCP server-under-test managers via lightweight protocols in `tests/infra/mcp.py`, converted the MCP fixture and tests to those contracts, and tightened UI rendering/TUI tests with explicit fixture and parameter aliases. Runtime assertions now narrow mixed parameterized case data where the test matrix intentionally carries multiple shapes.

Ref #281

## Verification
- `ruff check tests/infra/mcp.py tests/unit/mcp/conftest.py tests/unit/mcp/test_tool_contracts.py tests/unit/mcp/test_server_surfaces.py tests/unit/mcp/test_mcp_edge_cases.py tests/unit/security/test_mcp_security.py tests/unit/ui/test_ui.py tests/unit/ui/test_tui.py tests/unit/ui/test_ui_visual.py`
- `mypy tests/infra/mcp.py tests/unit/mcp/conftest.py tests/unit/mcp/test_tool_contracts.py tests/unit/mcp/test_server_surfaces.py tests/unit/mcp/test_mcp_edge_cases.py tests/unit/security/test_mcp_security.py tests/unit/ui/test_ui.py tests/unit/ui/test_tui.py tests/unit/ui/test_ui_visual.py`
- `pytest -q tests/unit/mcp tests/unit/security/test_mcp_security.py tests/unit/ui/test_ui.py tests/unit/ui/test_tui.py tests/unit/ui/test_ui_visual.py`
- `PATH=/tmp/polylogue-281/.cache/codex-bin:$PATH devtools verify --quick`
