### PR TITLE
test: type cli command contracts

### DIFF
--- a/tests/unit/cli/test_analytics.py
+++ b/tests/unit/cli/test_analytics.py
@@ -2,17 +2,24 @@
 
 from __future__ import annotations
 
-from typing import Any
+from collections.abc import Mapping
+from pathlib import Path
+from typing import TypeAlias
 
 from polylogue.archive_products import ProviderAnalyticsProduct
 from polylogue.operations.archive import list_provider_analytics_products
+from polylogue.storage.repository import ConversationRepository
 from tests.infra.storage_records import make_conversation, make_message
+
+ProviderMeta: TypeAlias = Mapping[str, object] | None
+AnalyticsRow: TypeAlias = tuple[str, str, str | None, ProviderMeta]
+AnalyticsRows: TypeAlias = list[AnalyticsRow]
 
 
 class TestProviderAnalyticsProduct:
     """Test ProviderAnalyticsProduct contract."""
 
-    def test_tool_use_percentage_with_data(self: Any) -> None:
+    def test_tool_use_percentage_with_data(self: object) -> None:
         """Tool use percentage is calculated correctly."""
         metrics = ProviderAnalyticsProduct(
             provider_name="test",
@@ -32,7 +39,7 @@ class TestProviderAnalyticsProduct:
         )
         assert metrics.tool_use_percentage == 20.0
 
-    def test_tool_use_percentage_zero_conversations(self: Any) -> None:
+    def test_tool_use_percentage_zero_conversations(self: object) -> None:
         """Tool use percentage returns 0 when no conversations."""
         metrics = ProviderAnalyticsProduct(
             provider_name="empty",
@@ -52,7 +59,7 @@ class TestProviderAnalyticsProduct:
         )
         assert metrics.tool_use_percentage == 0.0
 
-    def test_thinking_percentage_with_data(self: Any) -> None:
+    def test_thinking_percentage_with_data(self: object) -> None:
         """Thinking percentage is calculated correctly."""
         metrics = ProviderAnalyticsProduct(
             provider_name="test",
@@ -72,7 +79,7 @@ class TestProviderAnalyticsProduct:
         )
         assert metrics.thinking_percentage == 20.0
 
-    def test_thinking_percentage_zero_conversations(self: Any) -> None:
+    def test_thinking_percentage_zero_conversations(self: object) -> None:
         """Thinking percentage returns 0 when no conversations."""
         metrics = ProviderAnalyticsProduct(
             provider_name="empty",
@@ -96,13 +103,15 @@ class TestProviderAnalyticsProduct:
 class TestListProviderAnalyticsProducts:
     """Test list_provider_analytics_products function."""
 
-    async def test_empty_database(self: Any, workspace_env: Any) -> None:
+    async def test_empty_database(self: object, workspace_env: dict[str, Path]) -> None:
         """Empty database returns empty list."""
         db_path = workspace_env["data_root"] / "polylogue" / "polylogue.db"
         result = await list_provider_analytics_products(db_path=db_path)
         assert result == []
 
-    async def test_single_provider(self: Any, workspace_env: Any, storage_repository: Any) -> None:
+    async def test_single_provider(
+        self: object, workspace_env: dict[str, Path], storage_repository: ConversationRepository
+    ) -> None:
         """Single provider aggregation."""
         db_path = workspace_env["data_root"] / "polylogue" / "polylogue.db"
 
@@ -124,7 +133,9 @@ class TestListProviderAnalyticsProducts:
         assert result[0].user_message_count == 1
         assert result[0].assistant_message_count == 1
 
-    async def test_multiple_providers_sorted(self: Any, workspace_env: Any, storage_repository: Any) -> None:
+    async def test_multiple_providers_sorted(
+        self: object, workspace_env: dict[str, Path], storage_repository: ConversationRepository
+    ) -> None:
         """Multiple providers sorted by conversation count descending."""
         db_path = workspace_env["data_root"] / "polylogue" / "polylogue.db"
 
@@ -153,7 +164,9 @@ class TestListProviderAnalyticsProducts:
         assert result[1].provider_name == "claude-ai"
         assert result[1].conversation_count == 2
 
-    async def test_user_assistant_segregation(self: Any, workspace_env: Any, storage_repository: Any) -> None:
+    async def test_user_assistant_segregation(
+        self: object, workspace_env: dict[str, Path], storage_repository: ConversationRepository
+    ) -> None:
         """User and assistant messages are counted separately."""
         db_path = workspace_env["data_root"] / "polylogue" / "polylogue.db"
 
@@ -173,7 +186,9 @@ class TestListProviderAnalyticsProducts:
         assert result[0].assistant_message_count == 2
         assert result[0].message_count == 4
 
-    async def test_avg_messages_per_conversation(self: Any, workspace_env: Any, storage_repository: Any) -> None:
+    async def test_avg_messages_per_conversation(
+        self: object, workspace_env: dict[str, Path], storage_repository: ConversationRepository
+    ) -> None:
         """Average messages per conversation is computed correctly."""
         db_path = workspace_env["data_root"] / "polylogue" / "polylogue.db"
 
@@ -201,7 +216,9 @@ class TestListProviderAnalyticsProducts:
         # Total 6 messages across 2 conversations = 3.0 average
         assert result[0].avg_messages_per_conversation == 3.0
 
-    async def test_tool_use_detection(self: Any, workspace_env: Any, storage_repository: Any) -> None:
+    async def test_tool_use_detection(
+        self: object, workspace_env: dict[str, Path], storage_repository: ConversationRepository
+    ) -> None:
         """Tool use is detected from content_blocks."""
         db_path = workspace_env["data_root"] / "polylogue" / "polylogue.db"
 
@@ -226,7 +243,9 @@ class TestListProviderAnalyticsProducts:
         assert result[0].total_conversations_with_tools == 1
         assert result[0].tool_use_percentage == 100.0
 
-    async def test_thinking_detection(self: Any, workspace_env: Any, storage_repository: Any) -> None:
+    async def test_thinking_detection(
+        self: object, workspace_env: dict[str, Path], storage_repository: ConversationRepository
+    ) -> None:
         """Thinking is detected from content_blocks."""
         db_path = workspace_env["data_root"] / "polylogue" / "polylogue.db"
 
@@ -251,7 +270,9 @@ class TestListProviderAnalyticsProducts:
         assert result[0].total_conversations_with_thinking == 1
         assert result[0].thinking_percentage == 100.0
 
-    async def test_conversations_with_tools_set_dedup(self: Any, workspace_env: Any, storage_repository: Any) -> None:
+    async def test_conversations_with_tools_set_dedup(
+        self: object, workspace_env: dict[str, Path], storage_repository: ConversationRepository
+    ) -> None:
         """Multiple tool uses in same conversation counted once."""
         db_path = workspace_env["data_root"] / "polylogue" / "polylogue.db"
 
@@ -283,7 +304,9 @@ class TestListProviderAnalyticsProducts:
         assert result[0].total_conversations_with_tools == 1  # But one conversation
         assert result[0].tool_use_percentage == 100.0
 
-    async def test_division_by_zero_protection(self: Any, workspace_env: Any, storage_repository: Any) -> None:
+    async def test_division_by_zero_protection(
+        self: object, workspace_env: dict[str, Path], storage_repository: ConversationRepository
+    ) -> None:
         """Metrics handle zero counts gracefully."""
         db_path = workspace_env["data_root"] / "polylogue" / "polylogue.db"
 
@@ -307,7 +330,7 @@ class TestListProviderAnalyticsProducts:
 # ============================================================================
 
 
-async def _seed_db(tmp_path: Any, rows: Any) -> Any:
+async def _seed_db(tmp_path: Path, rows: AnalyticsRows) -> Path:
     """Seed database with raw rows: (provider, role, text, provider_meta_or_None).
 
     Returns: db_path (Path)
@@ -326,7 +349,7 @@ async def _seed_db(tmp_path: Any, rows: Any) -> Any:
     repo = ConversationRepository(backend=backend)
 
     # Group rows by provider and conversation
-    convos_by_provider: dict[str, list[tuple[str, str, dict[str, object] | None]]] = {}
+    convos_by_provider: dict[str, list[tuple[str, str | None, ProviderMeta]]] = {}
     for provider, role, text, provider_meta in rows:
         if provider not in convos_by_provider:
             convos_by_provider[provider] = []
@@ -367,7 +390,7 @@ async def _seed_db(tmp_path: Any, rows: Any) -> Any:
 class TestWordCountEdgeCases:
     """Verify word count SQL handles edge cases correctly."""
 
-    async def test_spaces_only_text_counts_zero_words(self: Any, tmp_path: Any) -> None:
+    async def test_spaces_only_text_counts_zero_words(self: object, tmp_path: Path) -> None:
         """Space-only messages should count as 0 words."""
         db = await _seed_db(
             tmp_path,
@@ -380,7 +403,7 @@ class TestWordCountEdgeCases:
         assert len(results) == 1
         assert results[0].avg_user_words == 0.0
 
-    async def test_tabs_newlines_are_stripped(self: Any, tmp_path: Any) -> None:
+    async def test_tabs_newlines_are_stripped(self: object, tmp_path: Path) -> None:
         """Python split() strips all whitespace including tabs/newlines.
 
         word_count is precomputed at insert time via len(text.split()).
@@ -396,7 +419,7 @@ class TestWordCountEdgeCases:
         results = await list_provider_analytics_products(db_path=db)
         assert results[0].avg_user_words == 0.0
 
-    async def test_single_word_counts_one(self: Any, tmp_path: Any) -> None:
+    async def test_single_word_counts_one(self: object, tmp_path: Path) -> None:
         """A single word with no spaces counts as 1."""
         db = await _seed_db(
             tmp_path,
@@ -407,7 +430,7 @@ class TestWordCountEdgeCases:
         results = await list_provider_analytics_products(db_path=db)
         assert results[0].avg_user_words == 1.0
 
-    async def test_multiple_spaces_between_words(self: Any, tmp_path: Any) -> None:
+    async def test_multiple_spaces_between_words(self: object, tmp_path: Path) -> None:
         """Multiple spaces between words count as expected.
 
         word_count is precomputed via len(text.split()), which splits on any
@@ -422,7 +445,7 @@ class TestWordCountEdgeCases:
         results = await list_provider_analytics_products(db_path=db)
         assert results[0].avg_user_words == 2.0
 
-    async def test_empty_text_counts_zero(self: Any, tmp_path: Any) -> None:
+    async def test_empty_text_counts_zero(self: object, tmp_path: Path) -> None:
         """Empty string text counts as 0 words."""
         db = await _seed_db(
             tmp_path,
@@ -433,7 +456,7 @@ class TestWordCountEdgeCases:
         results = await list_provider_analytics_products(db_path=db)
         assert results[0].avg_user_words == 0.0
 
-    async def test_none_text_counts_zero(self: Any, tmp_path: Any) -> None:
+    async def test_none_text_counts_zero(self: object, tmp_path: Path) -> None:
         """NULL text counts as 0 words."""
         db = await _seed_db(
             tmp_path,
@@ -453,7 +476,7 @@ class TestWordCountEdgeCases:
 class TestLikePatternResistance:
     """Verify LIKE-based tool_use/thinking detection doesn't false-positive."""
 
-    async def test_tool_use_in_message_text_not_detected(self: Any, tmp_path: Any) -> None:
+    async def test_tool_use_in_message_text_not_detected(self: object, tmp_path: Path) -> None:
         """Text containing 'tool_use' string should NOT count as tool use."""
         db = await _seed_db(
             tmp_path,
@@ -466,7 +489,7 @@ class TestLikePatternResistance:
         # tool_use_count should be 0 — the LIKE is on provider_meta, not text
         assert results[0].tool_use_count == 0
 
-    async def test_thinking_in_message_text_not_detected(self: Any, tmp_path: Any) -> None:
+    async def test_thinking_in_message_text_not_detected(self: object, tmp_path: Path) -> None:
         """Text containing 'thinking' should NOT count as thinking."""
         db = await _seed_db(
             tmp_path,
@@ -477,7 +500,7 @@ class TestLikePatternResistance:
         results = await list_provider_analytics_products(db_path=db)
         assert results[0].thinking_count == 0
 
-    async def test_tool_role_fallback_detected(self: Any, tmp_path: Any) -> None:
+    async def test_tool_role_fallback_detected(self: object, tmp_path: Path) -> None:
         """Messages with role='tool' should be counted as tool use."""
         db = await _seed_db(
             tmp_path,
@@ -488,7 +511,7 @@ class TestLikePatternResistance:
         results = await list_provider_analytics_products(db_path=db)
         assert results[0].tool_use_count == 1
 
-    async def test_tool_use_in_provider_meta_detected(self: Any, tmp_path: Any) -> None:
+    async def test_tool_use_in_provider_meta_detected(self: object, tmp_path: Path) -> None:
         """Tool use in provider_meta content_blocks is detected."""
         meta = {"content_blocks": [{"type": "tool_use", "name": "search", "id": "t1"}]}
         db = await _seed_db(
@@ -501,7 +524,7 @@ class TestLikePatternResistance:
         assert results[0].tool_use_count == 1
         assert results[0].total_conversations_with_tools == 1
 
-    async def test_thinking_in_provider_meta_detected(self: Any, tmp_path: Any) -> None:
+    async def test_thinking_in_provider_meta_detected(self: object, tmp_path: Path) -> None:
         """Thinking blocks in provider_meta are detected."""
         meta = {"content_blocks": [{"type": "thinking", "thinking": "Let me consider..."}]}
         db = await _seed_db(
@@ -514,7 +537,7 @@ class TestLikePatternResistance:
         assert results[0].thinking_count == 1
         assert results[0].total_conversations_with_thinking == 1
 
-    async def test_mixed_content_blocks_counted_correctly(self: Any, tmp_path: Any) -> None:
+    async def test_mixed_content_blocks_counted_correctly(self: object, tmp_path: Path) -> None:
         """Message with both tool_use and thinking blocks counts both."""
         meta = {
             "content_blocks": [
@@ -542,7 +565,7 @@ class TestLikePatternResistance:
 class TestCrossProviderConsistency:
     """Verify SQL detection works across different provider data structures."""
 
-    async def test_multiple_providers_with_tool_use(self: Any, tmp_path: Any) -> None:
+    async def test_multiple_providers_with_tool_use(self: object, tmp_path: Path) -> None:
         """Tool use is detected correctly across ChatGPT and Claude providers."""
         chatgpt_meta = {"content_blocks": [{"type": "tool_use", "name": "browser"}]}
         claude_meta = {"content_blocks": [{"type": "tool_use", "name": "computer", "id": "toolu_1"}]}

--- a/tests/unit/cli/test_auth.py
+++ b/tests/unit/cli/test_auth.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
+from click.testing import CliRunner
 
 from polylogue.cli.click_app import cli as click_cli
 from polylogue.cli.commands.auth import (
@@ -20,24 +20,24 @@ from polylogue.cli.commands.auth import (
 class TestAuthCommandRouting:
     """CLI command routing tests — service dispatch and error handling."""
 
-    def test_unknown_service_fails(self, cli_runner: Any) -> None:
+    def test_unknown_service_fails(self, cli_runner: CliRunner) -> None:
         result = cli_runner.invoke(click_cli, ["auth", "--service", "unknown", "--plain"])
         assert result.exit_code != 0
 
-    def test_default_service_is_drive(self, cli_runner: Any) -> None:
+    def test_default_service_is_drive(self, cli_runner: CliRunner) -> None:
         with patch("polylogue.cli.commands.auth._drive_oauth_flow"):
             result = cli_runner.invoke(click_cli, ["auth", "--plain"])
             assert "Unknown auth service" not in result.output
 
 
 class TestGetDrivePaths:
-    def test_get_drive_paths_returns_path_objects(self, tmp_path: Any) -> None:
+    def test_get_drive_paths_returns_path_objects(self, tmp_path: Path) -> None:
         env = MagicMock()
         creds_path, token_path = _get_drive_paths(env)
         assert isinstance(creds_path, Path)
         assert isinstance(token_path, Path)
 
-    def test_get_drive_paths_falls_back_on_config_error(self, tmp_path: Any) -> None:
+    def test_get_drive_paths_falls_back_on_config_error(self, tmp_path: Path) -> None:
         env = MagicMock()
         with patch("polylogue.cli.helpers.load_effective_config", side_effect=Exception("config error")):
             creds_path, token_path = _get_drive_paths(env)
@@ -46,7 +46,7 @@ class TestGetDrivePaths:
 
 
 class TestDriveOAuthFlow:
-    def test_oauth_missing_credentials_exits(self, tmp_path: Any) -> None:
+    def test_oauth_missing_credentials_exits(self, tmp_path: Path) -> None:
         env = MagicMock()
         creds_path = tmp_path / "missing.json"
         token_path = tmp_path / "token.json"
@@ -54,7 +54,7 @@ class TestDriveOAuthFlow:
             with pytest.raises(SystemExit):
                 _drive_oauth_flow(env)
 
-    def test_oauth_calls_load_credentials_on_auth_manager(self, tmp_path: Any) -> None:
+    def test_oauth_calls_load_credentials_on_auth_manager(self, tmp_path: Path) -> None:
         env = MagicMock()
         creds_path = tmp_path / "creds.json"
         creds_path.write_text("{}")
@@ -67,7 +67,7 @@ class TestDriveOAuthFlow:
                 _drive_oauth_flow(env)
                 mock_manager.load_credentials.assert_called_once()
 
-    def test_oauth_cached_token_reports_using_cached(self, tmp_path: Any) -> None:
+    def test_oauth_cached_token_reports_using_cached(self, tmp_path: Path) -> None:
         env = MagicMock()
         creds_path = tmp_path / "creds.json"
         creds_path.write_text("{}")
@@ -81,7 +81,7 @@ class TestDriveOAuthFlow:
                 # Should not raise
                 _drive_oauth_flow(env)
 
-    def test_oauth_file_not_found_exits(self, tmp_path: Any) -> None:
+    def test_oauth_file_not_found_exits(self, tmp_path: Path) -> None:
         env = MagicMock()
         creds_path = tmp_path / "creds.json"
         creds_path.write_text("{}")
@@ -94,7 +94,7 @@ class TestDriveOAuthFlow:
                 with pytest.raises(SystemExit):
                     _drive_oauth_flow(env)
 
-    def test_oauth_token_refresh_failure_retries(self, tmp_path: Any) -> Any:
+    def test_oauth_token_refresh_failure_retries(self, tmp_path: Path) -> None:
         env = MagicMock()
         creds_path = tmp_path / "creds.json"
         creds_path.write_text("{}")
@@ -103,7 +103,7 @@ class TestDriveOAuthFlow:
 
         call_count = [0]
 
-        def side_effect(*args: Any, **kwargs: Any) -> Any:
+        def side_effect(*args: object, **kwargs: object) -> MagicMock:
             call_count[0] += 1
             if call_count[0] == 1:
                 raise Exception("Token refresh failed")
@@ -115,7 +115,7 @@ class TestDriveOAuthFlow:
                 _drive_oauth_flow(env, retry_on_failure=True)
                 assert call_count[0] == 2
 
-    def test_oauth_non_retriable_error_exits(self, tmp_path: Any) -> None:
+    def test_oauth_non_retriable_error_exits(self, tmp_path: Path) -> None:
         env = MagicMock()
         creds_path = tmp_path / "creds.json"
         creds_path.write_text("{}")
@@ -131,7 +131,7 @@ class TestDriveOAuthFlow:
 
 
 class TestRefreshDriveToken:
-    def test_refresh_deletes_token_before_reauth(self, tmp_path: Any) -> None:
+    def test_refresh_deletes_token_before_reauth(self, tmp_path: Path) -> None:
         env = MagicMock()
         creds_path = tmp_path / "creds.json"
         creds_path.write_text("{}")
@@ -144,7 +144,7 @@ class TestRefreshDriveToken:
                 assert not token_path.exists()
                 mock_flow.assert_called_once_with(env)
 
-    def test_refresh_without_token_still_reauths(self, tmp_path: Any) -> None:
+    def test_refresh_without_token_still_reauths(self, tmp_path: Path) -> None:
         env = MagicMock()
         creds_path = tmp_path / "creds.json"
         creds_path.write_text("{}")
@@ -157,7 +157,7 @@ class TestRefreshDriveToken:
 
 
 class TestRevokeDriveCredentials:
-    def test_revoke_calls_auth_manager_revoke(self, tmp_path: Any) -> None:
+    def test_revoke_calls_auth_manager_revoke(self, tmp_path: Path) -> None:
         env = MagicMock()
         creds_path = tmp_path / "creds.json"
         token_path = tmp_path / "token.json"
@@ -170,7 +170,7 @@ class TestRevokeDriveCredentials:
                 _revoke_drive_credentials(env)
                 mock_manager.revoke.assert_called_once()
 
-    def test_revoke_without_token_does_not_raise(self, tmp_path: Any) -> None:
+    def test_revoke_without_token_does_not_raise(self, tmp_path: Path) -> None:
         env = MagicMock()
         creds_path = tmp_path / "creds.json"
         token_path = tmp_path / "token.json"
@@ -187,14 +187,14 @@ class TestRevokeDriveCredentials:
 class TestAuthCommand:
     """Integration tests for the auth command (subprocess)."""
 
-    def test_auth_unknown_service_fails(self, tmp_path: Any) -> None:
+    def test_auth_unknown_service_fails(self, tmp_path: Path) -> None:
         from tests.infra.cli_subprocess import run_cli, setup_isolated_workspace
 
         workspace = setup_isolated_workspace(tmp_path)
         result = run_cli(["auth", "--service", "unknown"], env=workspace["env"])
         assert result.exit_code != 0
 
-    def test_auth_revoke_no_token(self, tmp_path: Any) -> None:
+    def test_auth_revoke_no_token(self, tmp_path: Path) -> None:
         from tests.infra.cli_subprocess import run_cli, setup_isolated_workspace
 
         workspace = setup_isolated_workspace(tmp_path)
@@ -202,7 +202,7 @@ class TestAuthCommand:
         output_lower = result.output.lower()
         assert result.exit_code == 0 or "no token" in output_lower or "not found" in output_lower
 
-    def test_auth_missing_credentials(self, tmp_path: Any) -> None:
+    def test_auth_missing_credentials(self, tmp_path: Path) -> None:
         from tests.infra.cli_subprocess import run_cli, setup_isolated_workspace
 
         workspace = setup_isolated_workspace(tmp_path)

--- a/tests/unit/cli/test_check_runtime.py
+++ b/tests/unit/cli/test_check_runtime.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import importlib
 import os
 import sqlite3
-from typing import Any
+from pathlib import Path
 
 import pytest
 
@@ -31,7 +31,7 @@ pytestmark = pytest.mark.machine_contract
 class TestRuntimeReadinessCheckNames:
     """Tests that run_runtime_readiness includes expected check names."""
 
-    def test_runtime_health_includes_db_writable_check(self, tmp_path: Any) -> None:
+    def test_runtime_health_includes_db_writable_check(self, tmp_path: Path) -> None:
         """run_runtime_readiness includes db_writable check."""
         config = Config(
             archive_root=tmp_path / "archive",
@@ -46,7 +46,7 @@ class TestRuntimeReadinessCheckNames:
         check_names = [c.name for c in report.checks]
         assert "db_writable" in check_names
 
-    def test_runtime_health_includes_schema_version_check(self, tmp_path: Any) -> None:
+    def test_runtime_health_includes_schema_version_check(self, tmp_path: Path) -> None:
         """run_runtime_readiness includes schema_version check."""
         config = Config(
             archive_root=tmp_path / "archive",
@@ -61,7 +61,7 @@ class TestRuntimeReadinessCheckNames:
         check_names = [c.name for c in report.checks]
         assert "schema_version" in check_names
 
-    def test_runtime_health_includes_fts_tables_check(self, tmp_path: Any) -> None:
+    def test_runtime_health_includes_fts_tables_check(self, tmp_path: Path) -> None:
         """run_runtime_readiness includes fts_tables check."""
         config = Config(
             archive_root=tmp_path / "archive",
@@ -76,7 +76,7 @@ class TestRuntimeReadinessCheckNames:
         check_names = [c.name for c in report.checks]
         assert "fts_tables" in check_names
 
-    def test_runtime_health_includes_sqlite_vec_check(self, tmp_path: Any) -> None:
+    def test_runtime_health_includes_sqlite_vec_check(self, tmp_path: Path) -> None:
         """run_runtime_readiness includes sqlite_vec check."""
         config = Config(
             archive_root=tmp_path / "archive",
@@ -91,7 +91,7 @@ class TestRuntimeReadinessCheckNames:
         check_names = [c.name for c in report.checks]
         assert "sqlite_vec" in check_names
 
-    def test_runtime_health_includes_archive_root_writable_check(self, tmp_path: Any) -> None:
+    def test_runtime_health_includes_archive_root_writable_check(self, tmp_path: Path) -> None:
         """run_runtime_readiness includes archive_root_writable check."""
         config = Config(
             archive_root=tmp_path / "archive",
@@ -106,7 +106,7 @@ class TestRuntimeReadinessCheckNames:
         check_names = [c.name for c in report.checks]
         assert "archive_root_writable" in check_names
 
-    def test_runtime_health_includes_render_root_writable_check(self, tmp_path: Any) -> None:
+    def test_runtime_health_includes_render_root_writable_check(self, tmp_path: Path) -> None:
         """run_runtime_readiness includes render_root_writable check."""
         config = Config(
             archive_root=tmp_path / "archive",
@@ -121,7 +121,7 @@ class TestRuntimeReadinessCheckNames:
         check_names = [c.name for c in report.checks]
         assert "render_root_writable" in check_names
 
-    def test_runtime_health_includes_config_home_check(self, tmp_path: Any) -> None:
+    def test_runtime_health_includes_config_home_check(self, tmp_path: Path) -> None:
         """run_runtime_readiness includes config_home check."""
         config = Config(
             archive_root=tmp_path / "archive",
@@ -136,7 +136,7 @@ class TestRuntimeReadinessCheckNames:
         check_names = [c.name for c in report.checks]
         assert "config_home" in check_names
 
-    def test_runtime_health_includes_terminal_check(self, tmp_path: Any) -> None:
+    def test_runtime_health_includes_terminal_check(self, tmp_path: Path) -> None:
         """run_runtime_readiness includes terminal check."""
         config = Config(
             archive_root=tmp_path / "archive",
@@ -151,7 +151,7 @@ class TestRuntimeReadinessCheckNames:
         check_names = [c.name for c in report.checks]
         assert "terminal" in check_names
 
-    def test_runtime_health_includes_ui_libraries_check(self, tmp_path: Any) -> None:
+    def test_runtime_health_includes_ui_libraries_check(self, tmp_path: Path) -> None:
         """run_runtime_readiness includes ui_libraries check."""
         config = Config(
             archive_root=tmp_path / "archive",
@@ -166,7 +166,7 @@ class TestRuntimeReadinessCheckNames:
         check_names = [c.name for c in report.checks]
         assert "ui_libraries" in check_names
 
-    def test_runtime_health_includes_vhs_check(self, tmp_path: Any) -> None:
+    def test_runtime_health_includes_vhs_check(self, tmp_path: Path) -> None:
         """run_runtime_readiness includes vhs check."""
         config = Config(
             archive_root=tmp_path / "archive",
@@ -185,7 +185,7 @@ class TestRuntimeReadinessCheckNames:
 class TestRuntimeReadinessCheckResults:
     """Tests for runtime readiness check status results."""
 
-    def test_runtime_health_with_writable_paths(self, tmp_path: Any) -> None:
+    def test_runtime_health_with_writable_paths(self, tmp_path: Path) -> None:
         """Runtime health returns OK for writable archive and render roots."""
         archive_root = tmp_path / "archive"
         render_root = tmp_path / "render"
@@ -216,7 +216,7 @@ class TestRuntimeReadinessCheckResults:
         assert render_check is not None
         assert render_check.status == VerifyStatus.OK
 
-    def test_runtime_health_with_missing_paths(self, tmp_path: Any) -> None:
+    def test_runtime_health_with_missing_paths(self, tmp_path: Path) -> None:
         """Runtime health shows OK/WARNING for missing but creatable paths."""
         # Path that can be created (parent exists and is writable)
         archive_root = tmp_path / "archive"
@@ -247,7 +247,7 @@ class TestRuntimeReadinessCheckResults:
         assert render_check is not None
         assert render_check.status == VerifyStatus.OK
 
-    def test_runtime_health_returns_health_report(self, tmp_path: Any) -> None:
+    def test_runtime_health_returns_health_report(self, tmp_path: Path) -> None:
         """run_runtime_readiness returns a ReadinessReport object."""
         config = Config(
             archive_root=tmp_path / "archive",
@@ -263,7 +263,7 @@ class TestRuntimeReadinessCheckResults:
         assert isinstance(report.checks, list)
         assert isinstance(report.summary, dict)
 
-    def test_runtime_health_summary_has_ok_warning_error(self, tmp_path: Any) -> None:
+    def test_runtime_health_summary_has_ok_warning_error(self, tmp_path: Path) -> None:
         """ReadinessReport.summary includes ok, warning, error counts."""
         config = Config(
             archive_root=tmp_path / "archive",
@@ -282,7 +282,7 @@ class TestRuntimeReadinessCheckResults:
         assert isinstance(report.summary["warning"], int)
         assert isinstance(report.summary["error"], int)
 
-    def test_runtime_health_summary_counts_match_checks(self, tmp_path: Any) -> None:
+    def test_runtime_health_summary_counts_match_checks(self, tmp_path: Path) -> None:
         """ReadinessReport.summary counts should match the actual checks."""
         config = Config(
             archive_root=tmp_path / "archive",
@@ -303,7 +303,7 @@ class TestRuntimeReadinessCheckResults:
         assert report.summary["warning"] == warning_count
         assert report.summary["error"] == error_count
 
-    def test_runtime_health_all_checks_have_status(self, tmp_path: Any) -> None:
+    def test_runtime_health_all_checks_have_status(self, tmp_path: Path) -> None:
         """All checks in the report must have a valid status."""
         config = Config(
             archive_root=tmp_path / "archive",
@@ -319,7 +319,7 @@ class TestRuntimeReadinessCheckResults:
         for check in report.checks:
             assert check.status in valid_statuses
 
-    def test_runtime_health_all_checks_have_names(self, tmp_path: Any) -> None:
+    def test_runtime_health_all_checks_have_names(self, tmp_path: Path) -> None:
         """All checks in the report must have non-empty names."""
         config = Config(
             archive_root=tmp_path / "archive",
@@ -340,7 +340,7 @@ class TestRuntimeHealthReadOnlyPaths:
     """Tests for runtime readiness with read-only or inaccessible paths."""
 
     @pytest.mark.skipif(os.name == "nt", reason="Unix-specific permission testing")
-    def test_runtime_health_with_readonly_archive_root(self, tmp_path: Any) -> None:
+    def test_runtime_health_with_readonly_archive_root(self, tmp_path: Path) -> None:
         """Runtime health detects read-only archive_root."""
         archive_root = tmp_path / "archive"
         archive_root.mkdir(parents=True, exist_ok=True)
@@ -377,7 +377,9 @@ class TestRuntimeHealthReadOnlyPaths:
 class TestRuntimeHealthLegacySchema:
     """Tests for explicit reporting of unsupported legacy archive layouts."""
 
-    def test_runtime_health_reports_legacy_inline_raw_layout(self, tmp_path: Any, monkeypatch: Any) -> None:
+    def test_runtime_health_reports_legacy_inline_raw_layout(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         import polylogue.paths
 
         monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
@@ -433,7 +435,7 @@ class TestRuntimeHealthLegacySchema:
 class TestRuntimeHealthToDict:
     """Tests for ReadinessReport serialization from runtime checks."""
 
-    def test_runtime_health_report_to_dict(self, tmp_path: Any) -> None:
+    def test_runtime_health_report_to_dict(self, tmp_path: Path) -> None:
         """ReadinessReport from run_runtime_readiness serializes correctly."""
         config = Config(
             archive_root=tmp_path / "archive",

--- a/tests/unit/cli/test_deterministic_output.py
+++ b/tests/unit/cli/test_deterministic_output.py
@@ -16,7 +16,7 @@ import sys
 from datetime import datetime, timezone
 from io import StringIO
 from pathlib import Path
-from typing import Any, cast
+from typing import TypeAlias, cast
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -35,6 +35,7 @@ from polylogue.showcase.runner import ExerciseResult, ShowcaseResult
 
 # ANSI escape code pattern: ESC[ ... final-byte
 _ANSI_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]|\x1b\].*?\x07|\x1b\[.*?m")
+JSONEnvelope: TypeAlias = dict[str, object]
 
 
 # ---------------------------------------------------------------------------
@@ -42,13 +43,22 @@ _ANSI_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]|\x1b\].*?\x07|\x1b\[.*?m")
 # ---------------------------------------------------------------------------
 
 
-def _extract_json(output: str) -> dict[str, Any]:
+def _extract_json(output: str) -> JSONEnvelope:
     """Extract the first JSON object from CLI output, skipping log/banner lines."""
     lines = output.strip().splitlines()
     for i, line in enumerate(lines):
         if line.strip().startswith("{"):
-            return cast(dict[str, Any], json.loads("\n".join(lines[i:])))
+            parsed = json.loads("\n".join(lines[i:]))
+            if not isinstance(parsed, dict):
+                raise ValueError(f"Expected JSON object in output:\n{output}")
+            return cast(JSONEnvelope, parsed)
     raise ValueError(f"No JSON object in output:\n{output}")
+
+
+def _result_payload(data: JSONEnvelope) -> JSONEnvelope:
+    result = data["result"]
+    assert isinstance(result, dict)
+    return cast(JSONEnvelope, result)
 
 
 def _has_ansi(text: str) -> bool:
@@ -66,10 +76,12 @@ class TestFrozenClockCheckJson:
 
     FROZEN_EPOCH = 1700000000  # 2023-11-14T22:13:20Z
 
-    def test_check_json_timestamp_is_deterministic(self: Any, cli_workspace: Any) -> Any:
+    def test_check_json_timestamp_is_deterministic(
+        self: TestFrozenClockCheckJson, cli_workspace: dict[str, Path]
+    ) -> None:
         """Two runs with same frozen clock produce identical timestamps."""
 
-        def _run_check() -> dict[str, Any]:
+        def _run_check() -> JSONEnvelope:
             runner = CliRunner()
             with patch("time.time", return_value=float(self.FROZEN_EPOCH)):
                 result = runner.invoke(
@@ -86,11 +98,13 @@ class TestFrozenClockCheckJson:
         # Both runs use the same frozen epoch for their timestamp
         assert "result" in data_a
         assert "result" in data_b
-        ts_a = data_a["result"]["timestamp"]
-        ts_b = data_b["result"]["timestamp"]
+        ts_a = _result_payload(data_a)["timestamp"]
+        ts_b = _result_payload(data_b)["timestamp"]
         assert ts_a == ts_b == self.FROZEN_EPOCH
 
-    def test_check_json_timestamp_changes_with_clock(self: Any, cli_workspace: Any) -> None:
+    def test_check_json_timestamp_changes_with_clock(
+        self: TestFrozenClockCheckJson, cli_workspace: dict[str, Path]
+    ) -> None:
         """Different frozen times produce different timestamps."""
         runner = CliRunner()
 
@@ -99,8 +113,8 @@ class TestFrozenClockCheckJson:
         with patch("time.time", return_value=1800000000.0):
             result_b = runner.invoke(cli, ["--plain", "doctor", "--json"], catch_exceptions=False)
 
-        ts_a = _extract_json(result_a.output)["result"]["timestamp"]
-        ts_b = _extract_json(result_b.output)["result"]["timestamp"]
+        ts_a = _result_payload(_extract_json(result_a.output))["timestamp"]
+        ts_b = _result_payload(_extract_json(result_b.output))["timestamp"]
         assert ts_a != ts_b
 
 
@@ -157,7 +171,7 @@ class TestFrozenClockShowcaseReport:
             ],
         )
 
-    def test_qa_session_timestamp_is_deterministic(self: Any) -> None:
+    def test_qa_session_timestamp_is_deterministic(self: TestFrozenClockShowcaseReport) -> None:
         """Two calls with same frozen clock produce identical timestamps."""
         result = self._make_qa_result()
 
@@ -174,7 +188,7 @@ class TestFrozenClockShowcaseReport:
         assert session_a["timestamp"] == session_b["timestamp"]
         assert session_a["timestamp"] == "2024-06-15T12:00:00+00:00"
 
-    def test_qa_session_timestamp_changes_with_clock(self: Any) -> None:
+    def test_qa_session_timestamp_changes_with_clock(self: TestFrozenClockShowcaseReport) -> None:
         """Different frozen times produce different timestamps."""
         result = self._make_qa_result()
 
@@ -215,7 +229,7 @@ class TestPlainModeNoAnsi:
         COMMANDS,
         ids=[" ".join(c) for c in COMMANDS],
     )
-    def test_no_ansi_in_plain_mode(self: Any, args: list[str]) -> None:
+    def test_no_ansi_in_plain_mode(self: object, args: list[str]) -> None:
         """Output with --plain should never contain ANSI escape sequences."""
         runner = CliRunner(env={"POLYLOGUE_FORCE_PLAIN": "1"})
         result = runner.invoke(cli, args, catch_exceptions=True)
@@ -231,7 +245,7 @@ class TestPlainModeNoAnsi:
 class TestJsonOutputValidity:
     """--json commands must emit valid, parseable JSON."""
 
-    def test_check_json_is_valid(self: Any, cli_workspace: Any) -> None:
+    def test_check_json_is_valid(self: object, cli_workspace: dict[str, Path]) -> None:
         """polylogue doctor --json produces parseable JSON."""
         runner = CliRunner()
         result = runner.invoke(cli, ["--plain", "doctor", "--json"], catch_exceptions=False)
@@ -240,7 +254,7 @@ class TestJsonOutputValidity:
         assert isinstance(parsed, dict)
         assert "status" in parsed
 
-    def test_tags_json_is_valid(self: Any, cli_workspace: Any) -> None:
+    def test_tags_json_is_valid(self: object, cli_workspace: dict[str, Path]) -> None:
         """polylogue tags --json produces parseable JSON."""
         runner = CliRunner()
         result = runner.invoke(cli, ["--plain", "tags", "--json"], catch_exceptions=False)
@@ -248,7 +262,7 @@ class TestJsonOutputValidity:
         parsed = _extract_json(result.output)
         assert isinstance(parsed, dict)
         assert parsed["status"] == "ok"
-        assert "tags" in parsed["result"]
+        assert "tags" in _result_payload(parsed)
 
 
 # ---------------------------------------------------------------------------
@@ -268,8 +282,8 @@ class TestJsonEnvelopeParametrized:
         ids=["doctor", "tags"],
     )
     def test_json_envelope_shape(
-        self: Any,
-        cli_workspace: Any,
+        self: object,
+        cli_workspace: dict[str, Path],
         cmd_args: list[str],
         result_key: str | None,
     ) -> None:
@@ -281,12 +295,10 @@ class TestJsonEnvelopeParametrized:
         parsed = _extract_json(result.output)
         assert parsed["status"] == "ok"
         assert "result" in parsed
-        assert isinstance(parsed["result"], dict)
+        result_payload = _result_payload(parsed)
 
         if result_key is not None:
-            assert result_key in parsed["result"], (
-                f"Expected key {result_key!r} in result, got {list(parsed['result'].keys())}"
-            )
+            assert result_key in result_payload, f"Expected key {result_key!r} in result, got {list(result_payload)}"
 
     @pytest.mark.parametrize(
         "cmd_args",
@@ -297,8 +309,8 @@ class TestJsonEnvelopeParametrized:
         ids=["doctor", "tags"],
     )
     def test_json_output_no_ansi(
-        self: Any,
-        cli_workspace: Any,
+        self: object,
+        cli_workspace: dict[str, Path],
         cmd_args: list[str],
     ) -> None:
         """--json output must not contain ANSI escape codes."""
@@ -316,8 +328,8 @@ class TestJsonEnvelopeParametrized:
         ids=["doctor", "tags"],
     )
     def test_json_output_round_trips(
-        self: Any,
-        cli_workspace: Any,
+        self: object,
+        cli_workspace: dict[str, Path],
         cmd_args: list[str],
     ) -> None:
         """--json output can be serialized and deserialized without loss."""
@@ -340,22 +352,26 @@ class TestJsonDeterminism:
     """Same inputs with frozen time must produce byte-identical --json output."""
 
     @staticmethod
-    def _normalize_check_result(data: dict[str, Any]) -> dict[str, Any]:
+    def _normalize_check_result(data: JSONEnvelope) -> JSONEnvelope:
         """Remove provenance fields that legitimately vary between runs.
 
         The health system reports live provenance. That provenance is still a
         runtime artifact, not a determinism issue.
         """
-        result = dict(data.get("result", data))
-        provenance = dict(result.get("provenance") or {})
+        result = dict(_result_payload(data) if "result" in data else data)
+        raw_provenance = result.get("provenance")
+        assert raw_provenance is None or isinstance(raw_provenance, dict)
+        provenance = dict(raw_provenance or {})
         provenance.pop("source", None)
         result["provenance"] = provenance
         return {**data, "result": result}
 
-    def test_check_json_deterministic_with_frozen_time(self: Any, cli_workspace: Any) -> None:
+    def test_check_json_deterministic_with_frozen_time(
+        self: TestJsonDeterminism, cli_workspace: dict[str, Path]
+    ) -> None:
         """Two doctor --json runs with same frozen time produce identical results."""
         runner = CliRunner()
-        parsed: list[dict[str, Any]] = []
+        parsed: list[JSONEnvelope] = []
 
         for _ in range(2):
             with patch("time.time", return_value=1700000000.0):
@@ -369,7 +385,7 @@ class TestJsonDeterminism:
 
         assert parsed[0] == parsed[1]
 
-    def test_tags_json_deterministic(self: Any, cli_workspace: Any) -> None:
+    def test_tags_json_deterministic(self: object, cli_workspace: dict[str, Path]) -> None:
         """Two tags --json runs produce identical output."""
         runner = CliRunner()
         outputs: list[str] = []

--- a/tests/unit/cli/test_embed.py
+++ b/tests/unit/cli/test_embed.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import json
-from typing import Any
+from pathlib import Path
+from typing import TypeAlias
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import click
@@ -18,6 +19,8 @@ from polylogue.cli.commands.embed import (
 )
 from polylogue.storage.embedding_stats_models import EmbeddingStatsSnapshot
 
+MessageRow: TypeAlias = dict[str, str]
+
 
 @pytest.fixture
 def runner() -> CliRunner:
@@ -25,7 +28,7 @@ def runner() -> CliRunner:
 
 
 @pytest.fixture
-def mock_env() -> Any:
+def mock_env() -> MagicMock:
     from rich.console import Console
 
     env = MagicMock()
@@ -40,7 +43,7 @@ def mock_env() -> Any:
 
 
 @pytest.fixture
-def mock_env_rich() -> Any:
+def mock_env_rich() -> MagicMock:
     from rich.console import Console
 
     env = MagicMock()
@@ -55,21 +58,21 @@ def mock_env_rich() -> Any:
 
 
 @pytest.fixture
-def mock_conversation() -> Any:
+def mock_conversation() -> MagicMock:
     conv = MagicMock()
     conv.id = "conv-123"
     conv.title = "Test Conversation"
     return conv
 
 
-_MOCK_MESSAGES = [
+_MOCK_MESSAGES: list[MessageRow] = [
     {"message_id": "m1", "text": "Hello"},
     {"message_id": "m2", "text": "World"},
 ]
 
 
 @pytest.fixture
-def mock_repository() -> Any:
+def mock_repository() -> MagicMock:
     repo = MagicMock()
     repo.backend = MagicMock()
     repo.backend.queries = MagicMock()
@@ -78,7 +81,7 @@ def mock_repository() -> Any:
 
 
 @pytest.fixture
-def mock_repository_async(mock_conversation: Any) -> Any:
+def mock_repository_async(mock_conversation: MagicMock) -> MagicMock:
     repo = MagicMock()
     repo.view = AsyncMock(return_value=mock_conversation)
     repo.get_messages = AsyncMock(return_value=_MOCK_MESSAGES)
@@ -95,7 +98,12 @@ class TestShowEmbeddingStats:
         ],
     )
     def test_show_stats_variants(
-        self, mock_env: Any, capsys: Any, query_results: Any, expected_coverage: Any, expected_pending: Any
+        self,
+        mock_env: MagicMock,
+        capsys: pytest.CaptureFixture[str],
+        query_results: list[tuple[int]],
+        expected_coverage: str,
+        expected_pending: str,
     ) -> None:
         mock_conn = MagicMock()
         mock_conn.execute.return_value.fetchone.return_value = query_results[0]
@@ -121,7 +129,7 @@ class TestShowEmbeddingStats:
         assert f"Pending:               {expected_pending}" in captured.out
         assert "Retrieval ready:" in captured.out
 
-    def test_show_stats_embedding_status_missing(self, mock_env: Any, capsys: Any) -> None:
+    def test_show_stats_embedding_status_missing(self, mock_env: MagicMock, capsys: pytest.CaptureFixture[str]) -> None:
         mock_conn = MagicMock()
         mock_conn.execute.return_value.fetchone.return_value = (100,)
 
@@ -139,7 +147,7 @@ class TestShowEmbeddingStats:
         captured = capsys.readouterr()
         assert "Embedding Statistics" in captured.out
 
-    def test_show_stats_json_output(self, mock_env: Any, capsys: Any) -> None:
+    def test_show_stats_json_output(self, mock_env: MagicMock, capsys: pytest.CaptureFixture[str]) -> None:
         mock_conn = MagicMock()
         mock_conn.execute.side_effect = [
             MagicMock(fetchone=MagicMock(return_value=(100,))),
@@ -173,7 +181,9 @@ class TestShowEmbeddingStats:
 
 
 class TestEmbedSingle:
-    def test_embed_single_success(self, mock_env: Any, mock_repository_async: Any, capsys: Any) -> None:
+    def test_embed_single_success(
+        self, mock_env: MagicMock, mock_repository_async: MagicMock, capsys: pytest.CaptureFixture[str]
+    ) -> None:
         mock_vec_provider = MagicMock()
         _embed_single(mock_env, mock_repository_async, mock_vec_provider, "conv-123")
         mock_vec_provider.upsert.assert_called_once_with("conv-123", mock_repository_async.get_messages.return_value)
@@ -181,19 +191,21 @@ class TestEmbedSingle:
         assert "Embedding 2 messages" in captured.out
         assert "✓ Embedded" in captured.out
 
-    def test_embed_single_conversation_not_found(self, mock_env: Any, mock_repository_async: Any) -> None:
+    def test_embed_single_conversation_not_found(self, mock_env: MagicMock, mock_repository_async: MagicMock) -> None:
         mock_repository_async.view = AsyncMock(return_value=None)
         with pytest.raises(click.Abort):
             _embed_single(mock_env, mock_repository_async, MagicMock(), "nonexistent")
 
-    def test_embed_single_no_messages(self, mock_env: Any, mock_repository_async: Any, capsys: Any) -> None:
+    def test_embed_single_no_messages(
+        self, mock_env: MagicMock, mock_repository_async: MagicMock, capsys: pytest.CaptureFixture[str]
+    ) -> None:
         mock_repository_async.get_messages = AsyncMock(return_value=[])
         mock_vec_provider = MagicMock()
         _embed_single(mock_env, mock_repository_async, mock_vec_provider, "conv-123")
         mock_vec_provider.upsert.assert_not_called()
         assert "No messages to embed" in capsys.readouterr().out
 
-    def test_embed_single_upsert_exception(self, mock_env: Any, mock_repository_async: Any) -> None:
+    def test_embed_single_upsert_exception(self, mock_env: MagicMock, mock_repository_async: MagicMock) -> None:
         mock_vec_provider = MagicMock()
         mock_vec_provider.upsert.side_effect = ValueError("API error")
         with pytest.raises(click.Abort):
@@ -212,13 +224,13 @@ class TestEmbedBatch:
     )
     def test_embed_batch_variants(
         self,
-        mock_env: Any,
-        mock_repository: Any,
-        capsys: Any,
-        num_convs: Any,
-        limit: Any,
-        rebuild: Any,
-        expected_output: Any,
+        mock_env: MagicMock,
+        mock_repository: MagicMock,
+        capsys: pytest.CaptureFixture[str],
+        num_convs: int,
+        limit: int | None,
+        rebuild: bool,
+        expected_output: str,
     ) -> None:
         mock_env.ui.console = MagicMock()
         mock_vec_provider = MagicMock()
@@ -229,12 +241,14 @@ class TestEmbedBatch:
             mock_conn.execute.return_value.fetchmany.side_effect = [convs, []]
             mock_open.return_value.__enter__ = MagicMock(return_value=mock_conn)
             mock_open.return_value.__exit__ = MagicMock(return_value=False)
-            kwargs = {"limit": limit, "rebuild": rebuild} if limit is not None else {"rebuild": rebuild}
-            _embed_batch(mock_env, mock_repository, mock_vec_provider, **kwargs)
+            if limit is None:
+                _embed_batch(mock_env, mock_repository, mock_vec_provider, rebuild=rebuild)
+            else:
+                _embed_batch(mock_env, mock_repository, mock_vec_provider, limit=limit, rebuild=rebuild)
 
         assert expected_output in capsys.readouterr().out
 
-    def test_embed_batch_rebuild_flag(self, mock_env: Any, mock_repository: Any) -> None:
+    def test_embed_batch_rebuild_flag(self, mock_env: MagicMock, mock_repository: MagicMock) -> None:
         mock_vec_provider = MagicMock()
         with patch("polylogue.storage.backends.connection.open_connection") as mock_open:
             mock_conn = MagicMock()
@@ -244,7 +258,9 @@ class TestEmbedBatch:
             _embed_batch(mock_env, mock_repository, mock_vec_provider, rebuild=True)
         assert any("ORDER BY updated_at DESC" in str(call) for call in mock_conn.execute.call_args_list)
 
-    def test_embed_batch_error_handling(self, mock_env: Any, mock_repository: Any, capsys: Any) -> None:
+    def test_embed_batch_error_handling(
+        self, mock_env: MagicMock, mock_repository: MagicMock, capsys: pytest.CaptureFixture[str]
+    ) -> None:
         mock_vec_provider = MagicMock()
         mock_repository.backend.queries.get_messages = AsyncMock(
             side_effect=[[{"message_id": "m1"}], ValueError("Embed failed"), [{"message_id": "m3"}]]
@@ -264,23 +280,25 @@ class TestEmbedBatch:
 
 
 class TestEmbedCommand:
-    def test_embed_command_missing_api_key(self, runner: Any, cli_workspace: Any) -> None:
+    def test_embed_command_missing_api_key(self, runner: CliRunner, cli_workspace: dict[str, Path]) -> None:
         with patch.dict("os.environ", {"VOYAGE_API_KEY": ""}, clear=False):
             result = runner.invoke(cli, ["--plain", "run", "embed"])
         assert result.exit_code != 0
         assert "VOYAGE_API_KEY" in result.output or "Error" in result.output
 
-    def test_embed_command_help(self, runner: Any, cli_workspace: Any) -> None:
+    def test_embed_command_help(self, runner: CliRunner, cli_workspace: dict[str, Path]) -> None:
         result = runner.invoke(cli, ["run", "embed", "--help"])
         assert result.exit_code == 0
         assert "embed" in result.output.lower()
 
     @pytest.mark.parametrize("option", ["--stats", "--json", "--model", "--rebuild", "--limit", "--conversation"])
-    def test_embed_command_help_lists_options(self, runner: Any, cli_workspace: Any, option: Any) -> None:
+    def test_embed_command_help_lists_options(
+        self, runner: CliRunner, cli_workspace: dict[str, Path], option: str
+    ) -> None:
         result = runner.invoke(cli, ["run", "embed", "--help"])
         assert option in result.output
 
-    def test_embed_command_stats_short_circuit(self, runner: Any, cli_workspace: Any) -> None:
+    def test_embed_command_stats_short_circuit(self, runner: CliRunner, cli_workspace: dict[str, Path]) -> None:
         with patch("polylogue.cli.commands.run._run_embed_standalone") as mock_standalone:
             result = runner.invoke(cli, ["--plain", "run", "embed", "--stats"])
         assert result.exit_code == 0
@@ -288,12 +306,12 @@ class TestEmbedCommand:
         opts = mock_standalone.call_args[0][1]
         assert opts.stats is True
 
-    def test_embed_command_json_requires_stats(self, runner: Any, cli_workspace: Any) -> None:
+    def test_embed_command_json_requires_stats(self, runner: CliRunner, cli_workspace: dict[str, Path]) -> None:
         result = runner.invoke(cli, ["--plain", "run", "embed", "--json"])
         assert result.exit_code != 0
         assert "--json requires --stats" in result.output
 
-    def test_embed_command_stats_json_short_circuit(self, runner: Any, cli_workspace: Any) -> None:
+    def test_embed_command_stats_json_short_circuit(self, runner: CliRunner, cli_workspace: dict[str, Path]) -> None:
         with patch("polylogue.cli.commands.run._run_embed_standalone") as mock_standalone:
             result = runner.invoke(cli, ["--plain", "run", "embed", "--stats", "--json"])
         assert result.exit_code == 0
@@ -302,7 +320,9 @@ class TestEmbedCommand:
         assert opts.stats is True
         assert opts.json_output is True
 
-    def test_embed_command_single_conversation_dispatches(self, runner: Any, cli_workspace: Any) -> None:
+    def test_embed_command_single_conversation_dispatches(
+        self, runner: CliRunner, cli_workspace: dict[str, Path]
+    ) -> None:
         with patch("polylogue.cli.commands.run._run_embed_standalone") as mock_standalone:
             result = runner.invoke(cli, ["--plain", "run", "embed", "--conversation", "conv-123"])
         assert result.exit_code == 0
@@ -310,7 +330,9 @@ class TestEmbedCommand:
         opts = mock_standalone.call_args[0][1]
         assert opts.conversation == "conv-123"
 
-    def test_embed_command_batch_dispatches_limit_and_rebuild(self, runner: Any, cli_workspace: Any) -> None:
+    def test_embed_command_batch_dispatches_limit_and_rebuild(
+        self, runner: CliRunner, cli_workspace: dict[str, Path]
+    ) -> None:
         with patch("polylogue.cli.commands.run._run_embed_standalone") as mock_standalone:
             result = runner.invoke(cli, ["--plain", "run", "embed", "--rebuild", "--limit", "5"])
         assert result.exit_code == 0
@@ -319,7 +341,7 @@ class TestEmbedCommand:
         assert opts.rebuild is True
         assert opts.limit == 5
 
-    def test_embed_command_sets_non_default_model(self, runner: Any, cli_workspace: Any) -> None:
+    def test_embed_command_sets_non_default_model(self, runner: CliRunner, cli_workspace: dict[str, Path]) -> None:
         with patch("polylogue.cli.commands.run._run_embed_standalone") as mock_standalone:
             result = runner.invoke(cli, ["--plain", "run", "embed", "--model", "voyage-4-lite"])
         assert result.exit_code == 0
@@ -339,12 +361,12 @@ class TestEmbedBatchRichMode:
     )
     def test_embed_batch_rich_mode_variants(
         self,
-        mock_env_rich: Any,
-        mock_repository: Any,
-        capsys: Any,
-        num_convs: Any,
-        messages_side_effect: Any,
-        exception_type: Any,
+        mock_env_rich: MagicMock,
+        mock_repository: MagicMock,
+        capsys: pytest.CaptureFixture[str],
+        num_convs: int,
+        messages_side_effect: object,
+        exception_type: type[Exception] | None,
     ) -> None:
         mock_vec_provider = MagicMock()
         if exception_type:

--- a/tests/unit/cli/test_json_envelope_contract.py
+++ b/tests/unit/cli/test_json_envelope_contract.py
@@ -12,7 +12,7 @@ pure output formatting, independent of path caching).
 from __future__ import annotations
 
 import json
-from typing import Any, cast
+from typing import TypeAlias, cast
 
 import pytest
 from click.testing import CliRunner
@@ -25,6 +25,7 @@ from polylogue.cli.machine_errors import (
 )
 
 pytestmark = pytest.mark.machine_contract
+JSONEnvelope: TypeAlias = dict[str, object]
 
 
 # ---------------------------------------------------------------------------
@@ -35,7 +36,7 @@ pytestmark = pytest.mark.machine_contract
 class TestEmitSuccess:
     """Tests for the emit_success() helper."""
 
-    def test_emit_success_writes_envelope(self: Any, capsys: Any) -> None:
+    def test_emit_success_writes_envelope(self: object, capsys: pytest.CaptureFixture[str]) -> None:
         """emit_success() writes the success envelope to stdout."""
         emit_success({"count": 42})
         captured = capsys.readouterr()
@@ -43,14 +44,14 @@ class TestEmitSuccess:
         assert parsed["status"] == "ok"
         assert parsed["result"] == {"count": 42}
 
-    def test_emit_success_none_result(self: Any, capsys: Any) -> None:
+    def test_emit_success_none_result(self: object, capsys: pytest.CaptureFixture[str]) -> None:
         """emit_success(None) writes empty result."""
         emit_success(None)
         captured = capsys.readouterr()
         parsed = json.loads(captured.out)
         assert parsed == {"status": "ok", "result": {}}
 
-    def test_emit_success_empty_result(self: Any, capsys: Any) -> None:
+    def test_emit_success_empty_result(self: object, capsys: pytest.CaptureFixture[str]) -> None:
         """emit_success({}) writes empty result."""
         emit_success({})
         captured = capsys.readouterr()
@@ -63,7 +64,7 @@ class TestEmitSuccess:
 # ---------------------------------------------------------------------------
 
 
-def _parse_json_output(output: str) -> dict[str, Any]:
+def _parse_json_output(output: str) -> JSONEnvelope:
     """Parse JSON from CLI output, stripping any log lines."""
     # CLI may emit structlog lines to stderr; stdout should be clean JSON.
     # But CliRunner mixes output, so find the JSON object.
@@ -81,10 +82,16 @@ def _parse_json_output(output: str) -> dict[str, Any]:
     parsed = json.loads(json_text)
     if not isinstance(parsed, dict):
         raise ValueError(f"Expected object envelope, got {type(parsed).__name__}")
-    return cast(dict[str, Any], parsed)
+    return cast(JSONEnvelope, parsed)
 
 
-def _invoke_json_command(args: list[str], monkeypatch: Any) -> dict[str, Any] | None:
+def _result_payload(data: JSONEnvelope) -> JSONEnvelope:
+    result = data["result"]
+    assert isinstance(result, dict)
+    return cast(JSONEnvelope, result)
+
+
+def _invoke_json_command(args: list[str], monkeypatch: pytest.MonkeyPatch) -> JSONEnvelope | None:
     """Invoke a CLI command with --json flag, return parsed output or None on skip.
 
     Returns None (and calls pytest.skip) if the command fails due to DB errors
@@ -108,7 +115,7 @@ def _invoke_json_command(args: list[str], monkeypatch: Any) -> dict[str, Any] | 
 class TestCheckJsonEnvelope:
     """check --json wraps output in success envelope."""
 
-    def test_check_json_has_status_ok(self: Any, monkeypatch: Any) -> None:
+    def test_check_json_has_status_ok(self: object, monkeypatch: pytest.MonkeyPatch) -> None:
         """polylogue check --json output has status: ok."""
         parsed = _invoke_json_command(["doctor", "--json"], monkeypatch)
         assert parsed is not None
@@ -119,13 +126,13 @@ class TestCheckJsonEnvelope:
 class TestTagsJsonEnvelope:
     """tags --json wraps output in success envelope."""
 
-    def test_tags_json_has_status_ok(self: Any, monkeypatch: Any) -> None:
+    def test_tags_json_has_status_ok(self: object, monkeypatch: pytest.MonkeyPatch) -> None:
         """polylogue tags --json output has status: ok."""
         parsed = _invoke_json_command(["tags", "--json"], monkeypatch)
         assert parsed is not None
         assert parsed["status"] == "ok"
         assert "result" in parsed
-        assert "tags" in parsed["result"]
+        assert "tags" in _result_payload(parsed)
 
 
 # ---------------------------------------------------------------------------
@@ -146,7 +153,7 @@ class TestErrorEnvelopeContract:
             ("unsupported_environment", "No TTY"),
         ],
     )
-    def test_error_envelope_shape(self: Any, code: Any, message: Any) -> None:
+    def test_error_envelope_shape(self: object, code: str, message: str) -> None:
         """Error envelope has required fields."""
         err = MachineError(code=code, message=message)
         d = err.to_dict()
@@ -154,7 +161,7 @@ class TestErrorEnvelopeContract:
         assert d["code"] == code
         assert d["message"] == message
 
-    def test_error_envelope_is_valid_json(self: Any) -> None:
+    def test_error_envelope_is_valid_json(self: object) -> None:
         """Error envelope serializes to valid JSON."""
         err = MachineError(
             code="runtime_error",
@@ -171,21 +178,21 @@ class TestErrorEnvelopeContract:
 class TestSuccessEnvelopeContract:
     """MachineSuccess always has status: ok and result."""
 
-    def test_success_envelope_shape(self: Any) -> None:
+    def test_success_envelope_shape(self: object) -> None:
         """Success envelope has status: ok and result."""
         s = success({"data": [1, 2, 3]})
         d = s.to_dict()
         assert d["status"] == "ok"
         assert d["result"]["data"] == [1, 2, 3]
 
-    def test_success_envelope_is_valid_json(self: Any) -> None:
+    def test_success_envelope_is_valid_json(self: object) -> None:
         """Success envelope serializes to valid JSON."""
         s = success({"nested": {"deep": True}})
         text = json.dumps(s.to_dict())
         parsed = json.loads(text)
         assert parsed["status"] == "ok"
 
-    def test_success_none_gives_empty_result(self: Any) -> None:
+    def test_success_none_gives_empty_result(self: object) -> None:
         """success(None) produces empty result dict."""
         s = success(None)
         assert s.to_dict() == {"status": "ok", "result": {}}
@@ -199,17 +206,17 @@ class TestSuccessEnvelopeContract:
 class TestStatusFieldInvariant:
     """Both envelope types always include status as a string."""
 
-    def test_error_status_is_string(self: Any) -> None:
+    def test_error_status_is_string(self: object) -> None:
         err = MachineError(code="x", message="y")
         assert isinstance(err.to_dict()["status"], str)
         assert err.to_dict()["status"] == "error"
 
-    def test_success_status_is_string(self: Any) -> None:
+    def test_success_status_is_string(self: object) -> None:
         s = success()
         assert isinstance(s.to_dict()["status"], str)
         assert s.to_dict()["status"] == "ok"
 
-    def test_error_and_success_status_are_disjoint(self: Any) -> None:
+    def test_error_and_success_status_are_disjoint(self: object) -> None:
         """Error and success envelopes have distinct status values."""
         err_status = MachineError(code="x", message="y").to_dict()["status"]
         ok_status = success().to_dict()["status"]

--- a/tests/unit/cli/test_qa.py
+++ b/tests/unit/cli/test_qa.py
@@ -7,7 +7,7 @@ and that output directories can be customized.
 from __future__ import annotations
 
 import json
-from typing import Any
+from pathlib import Path
 
 from polylogue.scenarios import AssertionSpec, polylogue_execution
 from polylogue.showcase.exercises import Exercise
@@ -61,14 +61,14 @@ def _make_result(exercises: list[Exercise] | None = None) -> ShowcaseResult:
 class TestJsonEnvelopeValidation:
     """JSON report has correct envelope structure."""
 
-    def test_json_report_is_valid_json(self: Any) -> None:
+    def test_json_report_is_valid_json(self: object) -> None:
         """generate_json_report produces parseable JSON."""
         result = _make_result()
         report_json = generate_json_report(result)
         data = json.loads(report_json)
         assert isinstance(data, dict)
 
-    def test_json_report_has_required_fields(self: Any) -> None:
+    def test_json_report_has_required_fields(self: object) -> None:
         """JSON report contains total, passed, failed, skipped, exercises."""
         result = _make_result()
         data = json.loads(generate_json_report(result))
@@ -76,7 +76,7 @@ class TestJsonEnvelopeValidation:
         for field in ("total", "passed", "failed", "skipped", "exercises", "total_duration_ms"):
             assert field in data, f"Missing field: {field}"
 
-    def test_json_report_exercise_entries(self: Any) -> None:
+    def test_json_report_exercise_entries(self: object) -> None:
         """Each exercise entry has required keys."""
         result = _make_result()
         data = json.loads(generate_json_report(result))
@@ -87,7 +87,7 @@ class TestJsonEnvelopeValidation:
                 f"Entry {entry['name']} missing keys: {required_keys - set(entry.keys())}"
             )
 
-    def test_json_report_counts_match(self: Any) -> None:
+    def test_json_report_counts_match(self: object) -> None:
         """Report counts match actual results."""
         result = _make_result()
         data = json.loads(generate_json_report(result))
@@ -101,7 +101,7 @@ class TestJsonEnvelopeValidation:
 class TestCustomOutputRoot:
     """Reports can be saved to a custom output directory."""
 
-    def test_save_reports_creates_files(self: Any, tmp_path: Any) -> None:
+    def test_save_reports_creates_files(self: object, tmp_path: Path) -> None:
         """save_reports writes all three report files."""
         result = _make_result()
         result.output_dir = tmp_path
@@ -112,7 +112,7 @@ class TestCustomOutputRoot:
         assert (tmp_path / "showcase-report.json").exists()
         assert (tmp_path / "showcase-cookbook.md").exists()
 
-    def test_save_reports_json_is_valid(self: Any, tmp_path: Any) -> None:
+    def test_save_reports_json_is_valid(self: object, tmp_path: Path) -> None:
         """Saved JSON report is parseable."""
         result = _make_result()
         result.output_dir = tmp_path
@@ -122,7 +122,7 @@ class TestCustomOutputRoot:
         data = json.loads((tmp_path / "showcase-report.json").read_text())
         assert data["total"] == 2
 
-    def test_summary_contains_group_counts(self: Any) -> None:
+    def test_summary_contains_group_counts(self: object) -> None:
         """Summary text includes group-level pass/fail counts."""
         result = _make_result()
         summary = generate_summary(result)
@@ -131,7 +131,7 @@ class TestCustomOutputRoot:
         assert "sources" in summary
         assert "TOTAL" in summary
 
-    def test_cookbook_includes_exercise_output(self: Any) -> None:
+    def test_cookbook_includes_exercise_output(self: object) -> None:
         """Cookbook contains exercise descriptions and commands."""
         result = _make_result()
         cookbook = generate_cookbook(result)

--- a/tests/unit/cli/test_query_exec_laws.py
+++ b/tests/unit/cli/test_query_exec_laws.py
@@ -9,7 +9,7 @@ import json
 import tempfile
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any, cast
+from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -56,6 +56,11 @@ from polylogue.ui.facade_console import ConsoleLike
 from tests.infra.builders import make_conv, make_msg
 from tests.infra.strategies import (
     ConversationSummarySpec,
+    QueryDeleteCase,
+    QueryMutationCase,
+    SendOutputCase,
+    SummaryOutputCase,
+    SummaryStatsCase,
     build_conversation_summary,
     build_message_counts,
     query_delete_case_strategy,
@@ -109,7 +114,7 @@ def _fields_arg(fields: tuple[str, ...] | None) -> str | None:
     return None if not fields else ",".join(fields)
 
 
-def _structured_rows(case: Any) -> list[JSONDocument]:
+def _structured_rows(case: SummaryOutputCase) -> list[JSONDocument]:
     rows = [summary_to_dict(build_conversation_summary(spec), spec.message_count) for spec in case.summaries]
     if case.selected_fields:
         selected = set(case.selected_fields)
@@ -117,7 +122,7 @@ def _structured_rows(case: Any) -> list[JSONDocument]:
     return rows
 
 
-def _csv_rows(case: Any) -> list[dict[str, str]]:
+def _csv_rows(case: SummaryOutputCase) -> list[dict[str, str]]:
     rows: list[dict[str, str]] = []
     for spec in case.summaries:
         summary = build_conversation_summary(spec)
@@ -412,7 +417,7 @@ def _summary_group_key(spec: ConversationSummarySpec, dimension: str) -> str:
 
 @settings(max_examples=60, deadline=None)
 @given(case=query_mutation_case_strategy())
-def test_apply_modifiers_contract(case: Any) -> None:
+def test_apply_modifiers_contract(case: QueryMutationCase) -> None:
     repo = MagicMock()
     repo.update_metadata = AsyncMock()
     repo.add_tag = AsyncMock()
@@ -459,7 +464,7 @@ def test_apply_modifiers_contract(case: Any) -> None:
 
 @settings(max_examples=60, deadline=None)
 @given(case=query_delete_case_strategy())
-def test_delete_conversations_contract(case: Any) -> None:
+def test_delete_conversations_contract(case: QueryDeleteCase) -> None:
     repo = MagicMock()
     repo.delete_conversation = AsyncMock(side_effect=list(case.delete_results))
     env = _make_env(repo=repo)
@@ -508,7 +513,7 @@ def test_delete_conversations_contract(case: Any) -> None:
 @settings(max_examples=40, deadline=None)
 @given(case=summary_output_case_strategy())
 @pytest.mark.parametrize("output_format", ["json", "yaml", "csv", "text"])
-def test_output_summary_list_contract(case: Any, output_format: str) -> None:
+def test_output_summary_list_contract(case: SummaryOutputCase, output_format: str) -> None:
     repo = MagicMock()
     repo.get_message_counts_batch = AsyncMock(return_value=build_message_counts(case.summaries))
     env = _make_env(repo=repo)
@@ -516,7 +521,7 @@ def test_output_summary_list_contract(case: Any, output_format: str) -> None:
     output = _output_spec(output_format=output_format)
     if output_format in {"json", "yaml"}:
         output = _output_spec(output_format=output_format, fields=_fields_arg(case.selected_fields))
-    cast(Any, env.ui).plain = output_format == "text"
+    cast(MagicMock, env.ui).plain = output_format == "text"
 
     with patch("click.echo") as mock_echo:
         mock_echo = cast(MagicMock, mock_echo)
@@ -541,7 +546,7 @@ def test_output_summary_list_contract(case: Any, output_format: str) -> None:
     suppress_health_check=[HealthCheck.function_scoped_fixture],
 )
 @given(case=send_output_case_strategy())
-def test_send_output_routes_destination_contract(case: Any) -> None:
+def test_send_output_routes_destination_contract(case: SendOutputCase) -> None:
     with tempfile.TemporaryDirectory() as tmp:
         tmp_path = Path(tmp)
         env = _make_env()
@@ -624,7 +629,7 @@ def test_resolve_query_route_uses_full_stats_for_tool_dimension() -> None:
 
 @settings(max_examples=40, deadline=None)
 @given(case=summary_stats_case_strategy())
-def test_output_stats_by_summaries_contract(case: Any) -> None:
+def test_output_stats_by_summaries_contract(case: SummaryStatsCase) -> None:
     env, buffer = _make_recording_env()
     summaries = [build_conversation_summary(spec) for spec in case.summaries]
     msg_counts = build_message_counts(case.summaries)
@@ -1026,7 +1031,7 @@ def test_output_results_projection_contract(
 ) -> None:
     del label
     env = _make_env()
-    cast(Any, env.ui).plain = plain
+    cast(MagicMock, env.ui).plain = plain
     output = QueryOutputSpec.from_params(params)
 
     with (

--- a/tests/unit/cli/test_reset.py
+++ b/tests/unit/cli/test_reset.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from contextlib import ExitStack
-from typing import Any
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -34,7 +34,7 @@ RESET_DELETION_CASES = [
 class TestResetCommandSubprocess:
     """Subprocess integration tests for the reset command."""
 
-    def test_reset_requires_target(self, tmp_path: Any) -> None:
+    def test_reset_requires_target(self, tmp_path: Path) -> None:
         """reset without flags fails with helpful message."""
         workspace = setup_isolated_workspace(tmp_path)
         env = workspace["env"]
@@ -44,7 +44,7 @@ class TestResetCommandSubprocess:
         output_lower = result.output.lower()
         assert "specify" in output_lower or "target" in output_lower or "--database" in output_lower
 
-    def test_reset_database_requires_force(self, tmp_path: Any) -> None:
+    def test_reset_database_requires_force(self, tmp_path: Path) -> None:
         """reset --database without --yes prompts (plain mode fails)."""
         workspace = setup_isolated_workspace(tmp_path)
         env = workspace["env"]
@@ -55,7 +55,7 @@ class TestResetCommandSubprocess:
         output_lower = result.output.lower()
         assert result.exit_code == 0 or "force" in output_lower or "nothing" in output_lower
 
-    def test_reset_force_database(self, tmp_path: Any) -> None:
+    def test_reset_force_database(self, tmp_path: Path) -> None:
         """reset --database --yes deletes database."""
         from tests.infra.source_builders import GenericConversationBuilder
 
@@ -72,7 +72,7 @@ class TestResetCommandSubprocess:
         # Should succeed (either deleted or nothing existed)
         assert result.exit_code == 0
 
-    def test_reset_all_flag(self, tmp_path: Any) -> None:
+    def test_reset_all_flag(self, tmp_path: Path) -> None:
         """reset --all sets all targets."""
         workspace = setup_isolated_workspace(tmp_path)
         env = workspace["env"]
@@ -91,7 +91,7 @@ class TestResetCommandSubprocess:
 class TestResetCommandValidation:
     """Tests for reset command validation."""
 
-    def test_no_flags_shows_error(self, tmp_path: Any, monkeypatch: Any) -> None:
+    def test_no_flags_shows_error(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """Reset without any target flags shows error."""
         monkeypatch.setenv("POLYLOGUE_FORCE_PLAIN", "1")
 
@@ -101,7 +101,7 @@ class TestResetCommandValidation:
         assert result.exit_code == 1
         assert "specify" in result.output.lower()
 
-    def test_all_flag_sets_all_targets(self, tmp_path: Any, monkeypatch: Any) -> None:
+    def test_all_flag_sets_all_targets(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """--all enables all reset targets."""
         # Patch paths to point to tmp_path
         monkeypatch.setenv("POLYLOGUE_FORCE_PLAIN", "1")
@@ -126,7 +126,7 @@ class TestResetCommandDeletion:
 
     @pytest.mark.parametrize("flag,path_attr,desc", RESET_DELETION_CASES)
     def test_reset_flag_deletes_target(
-        self, tmp_path: Any, monkeypatch: Any, flag: Any, path_attr: Any, desc: Any
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, flag: str, path_attr: str, desc: str
     ) -> None:
         """Reset flags delete specified targets."""
         monkeypatch.setenv("POLYLOGUE_FORCE_PLAIN", "1")
@@ -177,6 +177,8 @@ class TestResetCommandDeletion:
                 patch("polylogue.cli.commands.reset.cache_home", return_value=tmp_path / "nonexistent"),
                 patch("polylogue.cli.commands.reset.drive_token_path", return_value=target_path),
             ]
+        else:
+            raise AssertionError(f"Unhandled reset target fixture: {path_attr}")
 
         assert target_path.exists()
 
@@ -189,7 +191,7 @@ class TestResetCommandDeletion:
             assert result.exit_code == 0
             assert not target_path.exists()
 
-    def test_multiple_flags(self, tmp_path: Any, monkeypatch: Any) -> None:
+    def test_multiple_flags(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """Multiple flags delete specified targets."""
         monkeypatch.setenv("POLYLOGUE_FORCE_PLAIN", "1")
 
@@ -223,7 +225,7 @@ class TestResetCommandDeletion:
 class TestResetConfirmation:
     """Tests for reset confirmation flow."""
 
-    def test_without_force_in_plain_mode_skips(self, tmp_path: Any, monkeypatch: Any) -> None:
+    def test_without_force_in_plain_mode_skips(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """Without --yes in plain mode, shows message and skips."""
         monkeypatch.setenv("POLYLOGUE_FORCE_PLAIN", "1")
 
@@ -242,7 +244,7 @@ class TestResetConfirmation:
             assert db_path.exists()
             assert "force" in result.output.lower()
 
-    def test_force_bypasses_confirmation(self, tmp_path: Any, monkeypatch: Any) -> None:
+    def test_force_bypasses_confirmation(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """--yes bypasses confirmation prompt."""
         monkeypatch.setenv("POLYLOGUE_FORCE_PLAIN", "1")
 
@@ -263,7 +265,7 @@ class TestResetConfirmation:
 class TestResetEmptyTargets:
     """Tests for reset when targets don't exist."""
 
-    def test_nothing_to_reset(self, tmp_path: Any, monkeypatch: Any) -> None:
+    def test_nothing_to_reset(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """When no files exist, shows 'nothing to reset'."""
         monkeypatch.setenv("POLYLOGUE_FORCE_PLAIN", "1")
 
@@ -280,7 +282,7 @@ class TestResetEmptyTargets:
             assert result.exit_code == 0
             assert "nothing to reset" in result.output.lower()
 
-    def test_partial_targets_exist(self, tmp_path: Any, monkeypatch: Any) -> None:
+    def test_partial_targets_exist(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """Only deletes targets that exist."""
         monkeypatch.setenv("POLYLOGUE_FORCE_PLAIN", "1")
 
@@ -302,7 +304,7 @@ class TestResetEmptyTargets:
 class TestResetErrorHandling:
     """Tests for reset error handling."""
 
-    def test_deletion_failure_shows_error(self, tmp_path: Any, monkeypatch: Any) -> None:
+    def test_deletion_failure_shows_error(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """Deletion failure shows error but continues."""
         monkeypatch.setenv("POLYLOGUE_FORCE_PLAIN", "1")
 
@@ -322,7 +324,7 @@ class TestResetErrorHandling:
             # Should report failure but not crash
             assert "failed" in result.output.lower() or result.exit_code == 0
 
-    def test_shows_what_will_be_deleted(self, tmp_path: Any, monkeypatch: Any) -> None:
+    def test_shows_what_will_be_deleted(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """Shows summary of what will be deleted."""
         monkeypatch.setenv("POLYLOGUE_FORCE_PLAIN", "1")
 

--- a/tests/unit/cli/test_run_int.py
+++ b/tests/unit/cli/test_run_int.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import json
 import time
+from collections.abc import AsyncIterable, Iterable
 from importlib import import_module
 from pathlib import Path
-from typing import Any, cast
+from typing import Protocol, cast
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -22,7 +23,19 @@ from polylogue.storage.run_state import (
 )
 from tests.infra.source_builders import ChatGPTExportBuilder, GenericConversationBuilder, InboxBuilder
 
-run_command = cast(Any, import_module("polylogue.cli.commands.run"))
+
+class RunCommandModule(Protocol):
+    def _display_result(
+        self,
+        env: MagicMock,
+        config: MagicMock,
+        result: RunResult,
+        stage: str,
+        latest_render_path: Path | None,
+    ) -> None: ...
+
+
+run_command = cast(RunCommandModule, import_module("polylogue.cli.commands.run"))
 
 
 def _observer_result(
@@ -50,7 +63,7 @@ def _observer_result(
 
 
 @pytest.fixture
-def mock_env() -> Any:
+def mock_env() -> MagicMock:
     from rich.console import Console
 
     env = MagicMock()
@@ -63,7 +76,7 @@ def mock_env() -> Any:
 
 
 @pytest.mark.parametrize("with_plan", [True, False])
-async def test_plan_and_run_sources(workspace_env: Any, tmp_path: Any, with_plan: Any) -> None:
+async def test_plan_and_run_sources(workspace_env: dict[str, Path], tmp_path: Path, with_plan: bool) -> None:
     inbox = tmp_path / "inbox"
     source_file = (
         GenericConversationBuilder("conv1")
@@ -97,12 +110,12 @@ async def test_plan_and_run_sources(workspace_env: Any, tmp_path: Any, with_plan
     ],
 )
 async def test_run_sources_filtered_by_stage(
-    workspace_env: Any,
-    tmp_path: Any,
-    setup_type: Any,
-    stage: Any,
-    expected_conv_count: Any,
-    check_render: Any,
+    workspace_env: dict[str, Path],
+    tmp_path: Path,
+    setup_type: str,
+    stage: str,
+    expected_conv_count: int,
+    check_render: bool,
 ) -> None:
     if setup_type == "multi_source_filter":
         inbox = (
@@ -135,7 +148,9 @@ async def test_run_sources_filtered_by_stage(
         assert any(config.render_root.rglob("conversation.md"))
 
 
-async def test_run_index_filters_selected_sources(workspace_env: Any, tmp_path: Any, monkeypatch: Any) -> Any:
+async def test_run_index_filters_selected_sources(
+    workspace_env: dict[str, Path], tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     inbox = (
         InboxBuilder(tmp_path / "inbox")
         .add_json_file("a.json", {"id": "conv-a", "messages": [{"id": "m1", "role": "user", "text": "alpha"}]})
@@ -156,15 +171,15 @@ async def test_run_index_filters_selected_sources(workspace_env: Any, tmp_path: 
     with open_connection(None) as conn:
         rows = conn.execute("SELECT conversation_id, provider_meta FROM conversations").fetchall()
     for row in rows:
-        meta = json.loads(row["provider_meta"] or "{}")
+        meta = cast(dict[str, object], json.loads(row["provider_meta"] or "{}"))
         name = meta.get("source")
         if name:
             id_by_source[name] = row["conversation_id"]
 
-    update_calls = []
+    update_calls: list[list[str]] = []
     from polylogue.pipeline.services.indexing import IndexService
 
-    async def fake_update_method(self: Any, ids: Any) -> Any:
+    async def fake_update_method(self: object, ids: AsyncIterable[str] | Iterable[str]) -> bool:
         if hasattr(ids, "__aiter__"):
             update_calls.append([conversation_id async for conversation_id in ids])
         else:
@@ -176,7 +191,9 @@ async def test_run_index_filters_selected_sources(workspace_env: Any, tmp_path: 
     assert update_calls == [[id_by_source["source-b"]]]
 
 
-async def test_run_writes_unique_report_files(workspace_env: Any, tmp_path: Any, monkeypatch: Any) -> None:
+async def test_run_writes_unique_report_files(
+    workspace_env: dict[str, Path], tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     inbox = tmp_path / "inbox"
     source_file = GenericConversationBuilder("conv1").add_user("hello").write_to(inbox / "conversation.json")
 
@@ -202,7 +219,7 @@ async def test_run_writes_unique_report_files(workspace_env: Any, tmp_path: Any,
 
 
 @pytest.mark.parametrize("setup_type", ["parsed_json", "null_columns"])
-async def test_latest_run_parsing(workspace_env: Any, tmp_path: Any, setup_type: Any) -> None:
+async def test_latest_run_parsing(workspace_env: dict[str, Path], tmp_path: Path, setup_type: str) -> None:
     if setup_type == "parsed_json":
         inbox = tmp_path / "inbox"
         GenericConversationBuilder("conv-latest-run").add_user("test").write_to(inbox / "conversation.json")
@@ -234,7 +251,7 @@ async def test_latest_run_parsing(workspace_env: Any, tmp_path: Any, setup_type:
         assert result.drift is None
 
 
-def test_display_result_reports_render_failures(mock_env: Any, capsys: Any) -> None:
+def test_display_result_reports_render_failures(mock_env: MagicMock, capsys: pytest.CaptureFixture[str]) -> None:
     mock_config = MagicMock(render_root=Path("/tmp/render"))
     failures: list[RenderFailurePayload] = [
         {"conversation_id": f"conv-{index}", "error": f"error {index}"} for index in range(15)
@@ -258,7 +275,7 @@ def test_display_result_reports_render_failures(mock_env: Any, capsys: Any) -> N
     assert "re-run with `polylogue run render`" in captured.err
 
 
-def test_display_result_reports_index_error_hint(mock_env: Any, capsys: Any) -> None:
+def test_display_result_reports_index_error_hint(mock_env: MagicMock, capsys: pytest.CaptureFixture[str]) -> None:
     mock_config = MagicMock(render_root=Path("/tmp/render"))
     result = RunResult(
         run_id="run-123",
@@ -312,7 +329,7 @@ class TestWatchModeCallbacks:
             "echo $(id)",
         ],
     )
-    def test_exec_callback_rejects_dangerous_commands(self, dangerous_command: Any) -> None:
+    def test_exec_callback_rejects_dangerous_commands(self, dangerous_command: str) -> None:
         with pytest.raises(ValueError, match="unsafe"):
             ExecObserver(dangerous_command)
 

--- a/tests/unit/cli/test_terminal_snapshots.py
+++ b/tests/unit/cli/test_terminal_snapshots.py
@@ -12,8 +12,6 @@ These tests verify:
 
 from __future__ import annotations
 
-from typing import Any
-
 import pytest
 
 syrupy = pytest.importorskip("syrupy")
@@ -27,7 +25,7 @@ pytestmark = pytest.mark.skipif(not HAS_PYTE, reason="pyte not installed")
 class TestHelpOutput:
     """Test --help output rendering."""
 
-    def test_help_output_snapshot(self, snapshot: Any) -> None:
+    def test_help_output_snapshot(self, snapshot: object) -> None:
         """Verify --help output renders correctly."""
         result = run_in_pty(["--help"], rows=80)
         assert result.exit_code == 0
@@ -52,7 +50,7 @@ class TestHelpOutput:
 class TestCommandOutputs:
     """Test individual command outputs."""
 
-    def test_check_output_snapshot(self, snapshot: Any) -> None:
+    def test_check_output_snapshot(self, snapshot: object) -> None:
         """Verify check command output renders correctly."""
         result = run_in_pty(["doctor", "--help"], rows=80)
         assert result.exit_code == 0
@@ -62,7 +60,7 @@ class TestCommandOutputs:
 
         assert output == snapshot
 
-    def test_run_help_output_snapshot(self, snapshot: Any) -> None:
+    def test_run_help_output_snapshot(self, snapshot: object) -> None:
         """Verify run command help renders correctly."""
         result = run_in_pty(["run", "--help"], cols=120, rows=80)
         assert result.exit_code == 0
@@ -79,7 +77,7 @@ class TestCommandOutputs:
 class TestErrorOutput:
     """Test error message rendering."""
 
-    def test_invalid_option_error_output(self, snapshot: Any) -> None:
+    def test_invalid_option_error_output(self, snapshot: object) -> None:
         """Verify invalid option error message."""
         result = run_in_pty(["--bogus"])
         assert result.exit_code != 0
@@ -99,7 +97,7 @@ class TestErrorOutput:
 class TestTerminalDimensions:
     """Test output at different terminal widths."""
 
-    def test_help_at_narrow_width(self, snapshot: Any) -> None:
+    def test_help_at_narrow_width(self, snapshot: object) -> None:
         """Verify help wraps correctly at 60 columns."""
         result = run_in_pty(["--help"], cols=60, rows=80)
         assert result.exit_code == 0
@@ -111,7 +109,7 @@ class TestTerminalDimensions:
         # Verify wrapping occurred (should have lines)
         assert len(output) > 0
 
-    def test_help_at_wide_width(self, snapshot: Any) -> None:
+    def test_help_at_wide_width(self, snapshot: object) -> None:
         """Verify help renders at 120 columns."""
         result = run_in_pty(["--help"], cols=120, rows=80)
         assert result.exit_code == 0


### PR DESCRIPTION
## Summary
- Replace dynamic test annotations across 11 CLI command-contract files with concrete fixture, path, runner, JSON, and generated-case types.
- Type CLI property-test case inputs from the existing strategy dataclasses instead of treating them as unstructured values.
- Add explicit JSON result narrowing helpers where CLI envelopes intentionally return object-shaped decoded payloads.

## Problem
The mypy cleanup campaign still had broad `Any` use in CLI tests. These files cover command routing, JSON envelopes, reset behavior, runtime health, query execution laws, and embed command contracts, but dynamic annotations hid fixture and payload contract drift.

## Solution
Typed the CLI test surfaces around existing shared fixtures (`dict[str, Path]`, `CliRunner`, `pytest.MonkeyPatch`, `pytest.CaptureFixture[str]`, `ConversationRepository`) and existing strategy case dataclasses. Where decoded JSON carries mixed payloads, tests now narrow result objects explicitly before indexing.

Ref #281

## Verification
- `ruff check tests/unit/cli/test_embed.py tests/unit/cli/test_analytics.py tests/unit/cli/test_check_runtime.py tests/unit/cli/test_auth.py tests/unit/cli/test_run_int.py tests/unit/cli/test_deterministic_output.py tests/unit/cli/test_reset.py tests/unit/cli/test_json_envelope_contract.py tests/unit/cli/test_query_exec_laws.py tests/unit/cli/test_qa.py tests/unit/cli/test_terminal_snapshots.py`
- `mypy tests/unit/cli/test_embed.py tests/unit/cli/test_analytics.py tests/unit/cli/test_check_runtime.py tests/unit/cli/test_auth.py tests/unit/cli/test_run_int.py tests/unit/cli/test_deterministic_output.py tests/unit/cli/test_reset.py tests/unit/cli/test_json_envelope_contract.py tests/unit/cli/test_query_exec_laws.py tests/unit/cli/test_qa.py tests/unit/cli/test_terminal_snapshots.py`
- `pytest -q tests/unit/cli/test_embed.py tests/unit/cli/test_analytics.py tests/unit/cli/test_check_runtime.py tests/unit/cli/test_auth.py tests/unit/cli/test_run_int.py tests/unit/cli/test_deterministic_output.py tests/unit/cli/test_reset.py tests/unit/cli/test_json_envelope_contract.py tests/unit/cli/test_query_exec_laws.py tests/unit/cli/test_qa.py tests/unit/cli/test_terminal_snapshots.py`
- `PATH=/tmp/polylogue-281/.cache/codex-bin:$PATH devtools verify --quick`
