### PR TITLE
test: type storage contracts

### DIFF
--- a/tests/unit/storage/test_archive_search_contracts.py
+++ b/tests/unit/storage/test_archive_search_contracts.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 import sqlite3
 from dataclasses import dataclass
-from typing import Any
+from typing import cast
 
 import pytest
 
 from polylogue.lib.conversation_models import Conversation
 from polylogue.lib.messages import MessageCollection
+from polylogue.storage.backends.query_store import SQLiteQueryStore
 from polylogue.storage.repository_archive_search import RepositoryArchiveSearchMixin
 from polylogue.storage.search_models import ConversationSearchResult
 from polylogue.storage.search_providers.hybrid_conversations import (
@@ -57,10 +58,10 @@ class _FakeQueries:
 
 
 class _FakeRepo(RepositoryArchiveSearchMixin):
-    queries: Any
+    queries: SQLiteQueryStore
 
     def __init__(self, queries: _FakeQueries) -> None:
-        self.queries = queries
+        self.queries = cast(SQLiteQueryStore, queries)
         self.ordered_ids_seen: list[str] | None = None
 
     async def _hydrate_conversations(

--- a/tests/unit/storage/test_backend.py
+++ b/tests/unit/storage/test_backend.py
@@ -7,9 +7,10 @@ import importlib
 import sqlite3
 import threading
 import time
+from collections.abc import Awaitable, Callable
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any, cast
+from typing import Protocol, cast
 
 import aiosqlite
 import pytest
@@ -35,6 +36,12 @@ from tests.infra.storage_records import (
     make_message,
     make_raw_conversation,
 )
+
+
+class MutableSchemaBackend(Protocol):
+    """Subset used by concurrency tests to wrap schema initialization."""
+
+    _ensure_schema: Callable[[aiosqlite.Connection], Awaitable[None]]
 
 
 def _table_names(conn: sqlite3.Connection) -> set[str]:
@@ -588,7 +595,7 @@ async def test_async_read_connection_closes_cleanly_after_pool_teardown(tmp_path
         await original_ensure_schema(conn)
 
     backend._schema_ensured = False
-    cast(Any, backend)._ensure_schema = counting_ensure_schema
+    cast(MutableSchemaBackend, backend)._ensure_schema = counting_ensure_schema
     await asyncio.gather(*[backend.queries.list_conversations(ConversationRecordQuery()) for _ in range(20)])
     assert init_count == 0
 
@@ -603,7 +610,7 @@ async def test_async_read_connection_closes_cleanly_after_pool_teardown(tmp_path
         events.append("end")
 
     slow_backend._schema_ensured = False
-    cast(Any, slow_backend)._ensure_schema = slow_ensure_schema
+    cast(MutableSchemaBackend, slow_backend)._ensure_schema = slow_ensure_schema
     await asyncio.gather(slow_backend.get_conversation("a"), slow_backend.get_conversation("b"))
     assert events.count("start") == 1
     assert events.count("end") == 1

--- a/tests/unit/storage/test_convergence_stale_to_healthy.py
+++ b/tests/unit/storage/test_convergence_stale_to_healthy.py
@@ -7,15 +7,16 @@ test state transitions, not just snapshots.
 
 from __future__ import annotations
 
-from typing import Any
+from pathlib import Path
 
 import pytest
 
+from polylogue.config import Config, get_config
 from tests.infra.storage_records import ConversationBuilder, db_setup
 
 
 @pytest.fixture()
-def archive_with_orphans(workspace_env: Any) -> Any:
+def archive_with_orphans(workspace_env: dict[str, Path]) -> Config:
     """Create a DB with valid conversations and injected orphan debt."""
     db_path = db_setup(workspace_env)
 
@@ -44,11 +45,11 @@ def archive_with_orphans(workspace_env: Any) -> Any:
         conn.commit()
         conn.execute("PRAGMA foreign_keys = ON")
 
-    return db_path
+    return get_config()
 
 
 @pytest.fixture()
-def archive_with_empty_conversations(workspace_env: Any) -> Any:
+def archive_with_empty_conversations(workspace_env: dict[str, Path]) -> Config:
     """Create a DB with valid conversations and injected empty conversation debt."""
     db_path = db_setup(workspace_env)
 
@@ -69,36 +70,36 @@ def archive_with_empty_conversations(workspace_env: Any) -> Any:
         )
         conn.commit()
 
-    return db_path
+    return get_config()
 
 
 class TestOrphanMessageConvergence:
     """debt(orphaned messages) > 0 → repair → debt = 0 → queries exclude orphans."""
 
-    def test_orphan_detected_then_repaired_to_zero(self, archive_with_orphans: Any) -> None:
+    def test_orphan_detected_then_repaired_to_zero(self, archive_with_orphans: Config) -> None:
         from polylogue.storage.backends.connection import open_connection
         from polylogue.storage.repair import (
             count_orphaned_messages_sync,
             repair_orphaned_messages,
         )
 
-        with open_connection(archive_with_orphans) as conn:
+        with open_connection(archive_with_orphans.db_path) as conn:
             before = count_orphaned_messages_sync(conn)
         assert before == 2, f"Expected 2 orphans, got {before}"
 
         result = repair_orphaned_messages(archive_with_orphans, dry_run=False)
         assert result.repaired_count == 2
 
-        with open_connection(archive_with_orphans) as conn:
+        with open_connection(archive_with_orphans.db_path) as conn:
             after = count_orphaned_messages_sync(conn)
         assert after == 0, f"After repair, expected 0 orphans, got {after}"
 
-    def test_healthy_messages_survive_orphan_repair(self, archive_with_orphans: Any) -> None:
+    def test_healthy_messages_survive_orphan_repair(self, archive_with_orphans: Config) -> None:
         """Repair must not touch non-orphaned messages."""
         from polylogue.storage.backends.connection import open_connection
         from polylogue.storage.repair import repair_orphaned_messages
 
-        with open_connection(archive_with_orphans) as conn:
+        with open_connection(archive_with_orphans.db_path) as conn:
             healthy_before = conn.execute(
                 "SELECT COUNT(*) FROM messages m "
                 "WHERE EXISTS (SELECT 1 FROM conversations c WHERE c.conversation_id = m.conversation_id)"
@@ -106,7 +107,7 @@ class TestOrphanMessageConvergence:
 
         repair_orphaned_messages(archive_with_orphans, dry_run=False)
 
-        with open_connection(archive_with_orphans) as conn:
+        with open_connection(archive_with_orphans.db_path) as conn:
             healthy_after = conn.execute(
                 "SELECT COUNT(*) FROM messages m "
                 "WHERE EXISTS (SELECT 1 FROM conversations c WHERE c.conversation_id = m.conversation_id)"
@@ -114,7 +115,7 @@ class TestOrphanMessageConvergence:
 
         assert healthy_after == healthy_before, f"Repair damaged healthy messages: {healthy_before} → {healthy_after}"
 
-    def test_repair_is_idempotent(self, archive_with_orphans: Any) -> None:
+    def test_repair_is_idempotent(self, archive_with_orphans: Config) -> None:
         """Second repair after convergence is a no-op."""
         from polylogue.storage.repair import repair_orphaned_messages
 
@@ -126,35 +127,35 @@ class TestOrphanMessageConvergence:
 class TestEmptyConversationConvergence:
     """debt(empty conversations) > 0 → repair → debt = 0."""
 
-    def test_empty_detected_then_repaired_to_zero(self, archive_with_empty_conversations: Any) -> None:
+    def test_empty_detected_then_repaired_to_zero(self, archive_with_empty_conversations: Config) -> None:
         from polylogue.storage.backends.connection import open_connection
         from polylogue.storage.repair import (
             count_empty_conversations_sync,
             repair_empty_conversations,
         )
 
-        with open_connection(archive_with_empty_conversations) as conn:
+        with open_connection(archive_with_empty_conversations.db_path) as conn:
             before = count_empty_conversations_sync(conn)
         assert before == 2, f"Expected 2 empty conversations, got {before}"
 
         result = repair_empty_conversations(archive_with_empty_conversations, dry_run=False)
         assert result.repaired_count == 2
 
-        with open_connection(archive_with_empty_conversations) as conn:
+        with open_connection(archive_with_empty_conversations.db_path) as conn:
             after = count_empty_conversations_sync(conn)
         assert after == 0
 
-    def test_non_empty_conversations_survive(self, archive_with_empty_conversations: Any) -> None:
+    def test_non_empty_conversations_survive(self, archive_with_empty_conversations: Config) -> None:
         from polylogue.storage.backends.connection import open_connection
         from polylogue.storage.repair import repair_empty_conversations
 
         repair_empty_conversations(archive_with_empty_conversations, dry_run=False)
 
-        with open_connection(archive_with_empty_conversations) as conn:
+        with open_connection(archive_with_empty_conversations.db_path) as conn:
             remaining = conn.execute("SELECT COUNT(*) FROM conversations").fetchone()[0]
         assert remaining == 1, "Only the conversation with messages should survive"
 
-    def test_repair_is_idempotent(self, archive_with_empty_conversations: Any) -> None:
+    def test_repair_is_idempotent(self, archive_with_empty_conversations: Config) -> None:
         from polylogue.storage.repair import repair_empty_conversations
 
         repair_empty_conversations(archive_with_empty_conversations, dry_run=False)
@@ -165,36 +166,36 @@ class TestEmptyConversationConvergence:
 class TestDryRunSafety:
     """Dry-run must never mutate archive state."""
 
-    def test_dry_run_orphan_repair_preserves_state(self, archive_with_orphans: Any) -> None:
+    def test_dry_run_orphan_repair_preserves_state(self, archive_with_orphans: Config) -> None:
         from polylogue.storage.backends.connection import open_connection
         from polylogue.storage.repair import (
             count_orphaned_messages_sync,
             repair_orphaned_messages,
         )
 
-        with open_connection(archive_with_orphans) as conn:
+        with open_connection(archive_with_orphans.db_path) as conn:
             before = count_orphaned_messages_sync(conn)
 
         repair_orphaned_messages(archive_with_orphans, dry_run=True)
 
-        with open_connection(archive_with_orphans) as conn:
+        with open_connection(archive_with_orphans.db_path) as conn:
             after = count_orphaned_messages_sync(conn)
 
         assert after == before, "Dry-run mutated state"
 
-    def test_dry_run_empty_repair_preserves_state(self, archive_with_empty_conversations: Any) -> None:
+    def test_dry_run_empty_repair_preserves_state(self, archive_with_empty_conversations: Config) -> None:
         from polylogue.storage.backends.connection import open_connection
         from polylogue.storage.repair import (
             count_empty_conversations_sync,
             repair_empty_conversations,
         )
 
-        with open_connection(archive_with_empty_conversations) as conn:
+        with open_connection(archive_with_empty_conversations.db_path) as conn:
             before = count_empty_conversations_sync(conn)
 
         repair_empty_conversations(archive_with_empty_conversations, dry_run=True)
 
-        with open_connection(archive_with_empty_conversations) as conn:
+        with open_connection(archive_with_empty_conversations.db_path) as conn:
             after = count_empty_conversations_sync(conn)
 
         assert after == before, "Dry-run mutated state"

--- a/tests/unit/storage/test_embedding_stats.py
+++ b/tests/unit/storage/test_embedding_stats.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import sqlite3
-from typing import Any
 
 import aiosqlite
 import pytest
@@ -54,7 +53,7 @@ def test_read_embedding_stats_sync_counts_available_tables() -> None:
 
 def test_read_embedding_stats_sync_propagates_non_missing_operational_errors() -> None:
     class LockedConnection:
-        def execute(self: Any, sql: str) -> None:  # pragma: no cover - trivial stub
+        def execute(self: object, sql: str) -> None:  # pragma: no cover - trivial stub
             raise sqlite3.OperationalError("database is locked")
 
     with pytest.raises(sqlite3.OperationalError, match="database is locked"):
@@ -63,7 +62,7 @@ def test_read_embedding_stats_sync_propagates_non_missing_operational_errors() -
 
 def test_read_embedding_stats_sync_treats_missing_vec_module_as_optional() -> None:
     class VeclessConnection:
-        def execute(self: Any, sql: str) -> None:
+        def execute(self: object, sql: str) -> None:
             if "message_embeddings" in sql:
                 raise sqlite3.OperationalError("no such module: vec0")
             raise sqlite3.OperationalError("no such table: embedding_status")
@@ -144,10 +143,10 @@ def test_read_embedding_stats_sync_exposes_retrieval_bands_when_archive_tables_e
 def test_read_embedding_stats_sync_can_skip_retrieval_band_status(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    def fail_action_status(_conn: Any) -> None:
+    def fail_action_status(_conn: object) -> None:
         raise AssertionError("action-event status should not be read")
 
-    def fail_session_status(_conn: Any) -> None:
+    def fail_session_status(_conn: object) -> None:
         raise AssertionError("session-product status should not be read")
 
     conn = sqlite3.connect(":memory:")
@@ -206,7 +205,7 @@ async def test_read_embedding_stats_async_missing_tables_returns_zeroes() -> Non
 async def test_read_embedding_stats_async_derives_pending_from_total_conversations(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    async def fake_action_status(_conn: Any) -> Any:
+    async def fake_action_status(_conn: object) -> dict[str, int | bool]:
         return {
             "count": 0,
             "action_fts_count": 0,
@@ -214,7 +213,7 @@ async def test_read_embedding_stats_async_derives_pending_from_total_conversatio
             "stale_count": 0,
         }
 
-    async def fake_session_status(_conn: Any) -> Any:
+    async def fake_session_status(_conn: object) -> SessionProductStatusSnapshot:
         return SessionProductStatusSnapshot(
             profile_row_count=0,
             profile_evidence_fts_count=0,
@@ -259,10 +258,10 @@ async def test_read_embedding_stats_async_derives_pending_from_total_conversatio
 async def test_read_embedding_stats_async_can_skip_retrieval_band_status(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    async def fail_action_status(_conn: Any) -> None:
+    async def fail_action_status(_conn: object) -> None:
         raise AssertionError("action-event status should not be read")
 
-    async def fail_session_status(_conn: Any) -> None:
+    async def fail_session_status(_conn: object) -> None:
         raise AssertionError("session-product status should not be read")
 
     async with aiosqlite.connect(":memory:") as conn:

--- a/tests/unit/storage/test_fts5.py
+++ b/tests/unit/storage/test_fts5.py
@@ -10,8 +10,8 @@ from __future__ import annotations
 
 import json
 import sqlite3
+from collections.abc import Iterator
 from pathlib import Path
-from typing import Any
 from unittest.mock import patch
 
 import hypothesis.strategies as st
@@ -22,6 +22,7 @@ from polylogue.config import Config, IndexConfig
 from polylogue.pipeline.prepare import RecordBundle, save_bundle
 from polylogue.storage.backends.connection import open_connection
 from polylogue.storage.index import rebuild_index, update_index_for_conversations
+from polylogue.storage.repository import ConversationRepository
 from polylogue.storage.search import escape_fts5_query, search_messages
 from polylogue.storage.search_providers import create_vector_provider
 from polylogue.storage.search_providers.fts5 import FTS5Provider
@@ -42,7 +43,9 @@ from tests.infra.strategies import fts5_match_text_strategy, search_query_strate
 # ============================================================================
 
 
-async def test_search_respects_limit(workspace_env: dict[str, Path], storage_repository: Any) -> None:
+async def test_search_respects_limit(
+    workspace_env: dict[str, Path], storage_repository: ConversationRepository
+) -> None:
     """search_messages() respects limit parameter."""
     for i in range(10):
         conv = make_conversation(f"conv{i}", title=f"Conv {i}")
@@ -57,7 +60,9 @@ async def test_search_respects_limit(workspace_env: dict[str, Path], storage_rep
     assert len(results.hits) == 3
 
 
-async def test_search_includes_snippet(workspace_env: dict[str, Path], storage_repository: Any) -> None:
+async def test_search_includes_snippet(
+    workspace_env: dict[str, Path], storage_repository: ConversationRepository
+) -> None:
     """search_messages() includes text snippet in results."""
     conv = make_conversation("conv1")
     msg = make_message("msg1", "conv1", text="The quick brown fox jumps over the lazy dog")
@@ -75,7 +80,7 @@ async def test_search_includes_snippet(workspace_env: dict[str, Path], storage_r
 
 async def test_search_includes_conversation_metadata(
     workspace_env: dict[str, Path],
-    storage_repository: Any,
+    storage_repository: ConversationRepository,
 ) -> None:
     """search_messages() includes conversation metadata in results."""
     conv = make_conversation(
@@ -100,7 +105,7 @@ async def test_search_includes_conversation_metadata(
 
 async def test_search_returns_best_message_per_conversation(
     workspace_env: dict[str, Path],
-    storage_repository: Any,
+    storage_repository: ConversationRepository,
 ) -> None:
     """search_messages() picks the strongest per-conversation hit deterministically."""
     archive_root = workspace_env["archive_root"]
@@ -148,7 +153,7 @@ SEARCH_WITH_SPECIAL_TEXT_CASES = [
 @pytest.mark.parametrize("text,search_term,description", SEARCH_WITH_SPECIAL_TEXT_CASES)
 async def test_search_with_special_text(
     workspace_env: dict[str, Path],
-    storage_repository: Any,
+    storage_repository: ConversationRepository,
     text: str,
     search_term: str,
     description: str,
@@ -229,7 +234,7 @@ def test_action_event_status_ignores_orphan_tool_sources(test_conn: sqlite3.Conn
 
 async def test_search_returns_searchresult_object(
     workspace_env: dict[str, Path],
-    storage_repository: Any,
+    storage_repository: ConversationRepository,
 ) -> None:
     """search_messages() returns SearchResult with hits list."""
     conv = make_conversation("conv1")
@@ -312,7 +317,7 @@ def test_update_index_deletes_old_entries_from_conversation(test_conn: sqlite3.C
 
 async def test_rebuild_index_populates_action_search_rows(
     workspace_env: dict[str, Path],
-    storage_repository: Any,
+    storage_repository: ConversationRepository,
 ) -> None:
     """rebuild_index() also populates persisted action-event search rows."""
     conv = make_conversation("conv-actions", title="Action indexing")
@@ -528,7 +533,7 @@ def test_batch_index_10k_messages(test_conn: sqlite3.Connection) -> None:
 
 async def test_batch_index_search_returns_correct_provider(
     workspace_env: dict[str, Path],
-    storage_repository: Any,
+    storage_repository: ConversationRepository,
 ) -> None:
     """Verify batch indexing allows retrieving correct provider_name via search."""
     # Create conversations with different providers
@@ -770,10 +775,16 @@ class TestCreateVectorProvider:
 
                 original_import = builtins.__import__
 
-                def mock_import(name: str, *args: Any, **kwargs: Any) -> Any:
+                def mock_import(
+                    name: str,
+                    globals_: dict[str, object] | None = None,
+                    locals_: dict[str, object] | None = None,
+                    fromlist: tuple[str, ...] = (),
+                    level: int = 0,
+                ) -> object:
                     if name == "sqlite_vec":
                         raise ImportError("No module named 'sqlite_vec'")
-                    return original_import(name, *args, **kwargs)
+                    return original_import(name, globals_, locals_, fromlist, level)
 
                 with patch.object(builtins, "__import__", mock_import):
                     provider = create_vector_provider()
@@ -793,10 +804,16 @@ class TestCreateVectorProvider:
 
         original_import = builtins.__import__
 
-        def mock_import(name: str, *args: Any, **kwargs: Any) -> Any:
+        def mock_import(
+            name: str,
+            globals_: dict[str, object] | None = None,
+            locals_: dict[str, object] | None = None,
+            fromlist: tuple[str, ...] = (),
+            level: int = 0,
+        ) -> object:
             if name == "sqlite_vec":
                 raise ImportError("No module named 'sqlite_vec'")
-            return original_import(name, *args, **kwargs)
+            return original_import(name, globals_, locals_, fromlist, level)
 
         with (
             patch.dict("sys.modules", {"sqlite_vec": None}),
@@ -848,7 +865,7 @@ class TestFTS5Provider:
     async def populated_fts(
         self: object,
         workspace_env: dict[str, Path],
-        storage_repository: Any,
+        storage_repository: ConversationRepository,
         fts_provider: FTS5Provider,
     ) -> FTS5Provider:
         """FTS provider with indexed test data."""
@@ -917,7 +934,7 @@ class TestFTS5Provider:
         self: object,
         workspace_env: dict[str, Path],
         fts_provider: FTS5Provider,
-        storage_repository: Any,
+        storage_repository: ConversationRepository,
     ) -> None:
         """Calling index multiple times is safe (idempotent)."""
         conv = make_conversation(
@@ -943,7 +960,7 @@ class TestFTS5Provider:
         self: object,
         workspace_env: dict[str, Path],
         fts_provider: FTS5Provider,
-        storage_repository: Any,
+        storage_repository: ConversationRepository,
     ) -> None:
         """Incremental indexing removes old entries before inserting."""
         conv = make_conversation(
@@ -977,7 +994,7 @@ class TestFTS5Provider:
         self: object,
         workspace_env: dict[str, Path],
         fts_provider: FTS5Provider,
-        storage_repository: Any,
+        storage_repository: ConversationRepository,
     ) -> None:
         """Messages with empty text are not indexed."""
         conv = make_conversation(
@@ -1063,7 +1080,7 @@ class TestSearchProviderInit:
         assert isinstance(provider, FTS5Provider)
 
 
-async def _seed_conversation(storage_repository: Any) -> None:
+async def _seed_conversation(storage_repository: ConversationRepository) -> None:
     """Helper to seed a test conversation."""
     await save_bundle(
         RecordBundle(
@@ -1075,7 +1092,7 @@ async def _seed_conversation(storage_repository: Any) -> None:
     )
 
 
-async def test_search_after_index(workspace_env: dict[str, Path], storage_repository: Any) -> None:
+async def test_search_after_index(workspace_env: dict[str, Path], storage_repository: ConversationRepository) -> None:
     """Test searching after building the index."""
     await _seed_conversation(storage_repository)
     rebuild_index()
@@ -1131,7 +1148,7 @@ def test_search_invalid_query_reports_error(
             return StubCursor()
 
     @contextmanager
-    def stub_open_connection(_: object) -> Any:
+    def stub_open_connection(_: object) -> Iterator[StubConn]:
         yield StubConn()
 
     monkeypatch.setattr("polylogue.storage.search.open_connection", stub_open_connection)
@@ -1144,7 +1161,7 @@ def test_search_invalid_query_reports_error(
 
 async def test_search_prefers_legacy_render_when_present(
     workspace_env: dict[str, Path],
-    storage_repository: Any,
+    storage_repository: ConversationRepository,
 ) -> None:
     """Test that search returns legacy render paths when they exist."""
     archive_root = workspace_env["archive_root"]
@@ -1201,7 +1218,7 @@ SEARCH_SINCE_VALID_CASES = [
 )
 async def test_search_since_filters(
     workspace_env: dict[str, Path],
-    storage_repository: Any,
+    storage_repository: ConversationRepository,
     conv_id: str,
     old_ts: str,
     new_ts: str,
@@ -1230,7 +1247,7 @@ async def test_search_since_filters(
 
 async def test_search_since_handles_mixed_timestamp_formats(
     workspace_env: dict[str, Path],
-    storage_repository: Any,
+    storage_repository: ConversationRepository,
 ) -> None:
     """--since works with mix of ISO and numeric timestamps in same DB."""
     archive_root = workspace_env["archive_root"]
@@ -1285,7 +1302,7 @@ SEARCH_SINCE_ERROR_CASES = [
 @pytest.mark.parametrize("invalid_date,expected_error", SEARCH_SINCE_ERROR_CASES)
 async def test_search_since_invalid_date_raises_error(
     workspace_env: dict[str, Path],
-    storage_repository: Any,
+    storage_repository: ConversationRepository,
     invalid_date: str,
     expected_error: str,
 ) -> None:
@@ -1305,7 +1322,7 @@ async def test_search_since_invalid_date_raises_error(
 
 async def test_search_since_boundary_condition(
     workspace_env: dict[str, Path],
-    storage_repository: Any,
+    storage_repository: ConversationRepository,
 ) -> None:
     """Messages at or after --since timestamp are included, earlier ones excluded."""
     archive_root = workspace_env["archive_root"]

--- a/tests/unit/storage/test_query_mappers.py
+++ b/tests/unit/storage/test_query_mappers.py
@@ -7,7 +7,7 @@ Functions: _parse_json, _row_get, _row_to_conversation, _row_to_message, _row_to
 from __future__ import annotations
 
 import sqlite3
-from typing import Any, cast
+from typing import cast
 
 import pytest
 
@@ -61,32 +61,32 @@ def make_row(columns: dict[str, object]) -> sqlite3.Row:
 class TestParseJson:
     """Tests for _parse_json helper."""
 
-    def test_valid_json_string(self: Any) -> None:
+    def test_valid_json_string(self: object) -> None:
         """Valid JSON string returns parsed data."""
         result = _parse_json('{"key": "value"}', field="test_field", record_id="rec1")
         assert result == {"key": "value"}
 
-    def test_none_returns_none(self: Any) -> None:
+    def test_none_returns_none(self: object) -> None:
         """None input returns None."""
         result = _parse_json(None, field="test_field", record_id="rec1")
         assert result is None
 
-    def test_empty_string_returns_none(self: Any) -> None:
+    def test_empty_string_returns_none(self: object) -> None:
         """Empty string returns None."""
         result = _parse_json("", field="test_field", record_id="rec1")
         assert result is None
 
-    def test_corrupt_json_raises_database_error(self: Any) -> None:
+    def test_corrupt_json_raises_database_error(self: object) -> None:
         """Corrupt JSON raises DatabaseError with diagnostic context."""
         with pytest.raises(DatabaseError, match="Corrupt JSON"):
             _parse_json("{invalid json}", field="provider_meta", record_id="conv-123")
 
-    def test_database_error_includes_field_name(self: Any) -> None:
+    def test_database_error_includes_field_name(self: object) -> None:
         """DatabaseError message includes the field name for diagnostics."""
         with pytest.raises(DatabaseError, match="provider_meta"):
             _parse_json("not valid", field="provider_meta", record_id="conv-1")
 
-    def test_database_error_includes_record_id(self: Any) -> None:
+    def test_database_error_includes_record_id(self: object) -> None:
         """DatabaseError message includes the record ID for diagnostics."""
         with pytest.raises(DatabaseError, match="conv-999"):
             _parse_json("{bad}", field="meta", record_id="conv-999")
@@ -100,19 +100,19 @@ class TestParseJson:
 class TestRowGet:
     """Tests for _row_get helper."""
 
-    def test_existing_key_returns_value(self: Any) -> None:
+    def test_existing_key_returns_value(self: object) -> None:
         """Returns value for an existing column key."""
         row = make_row({"name": "test", "value": "42"})
         assert _row_get(row, "name") == "test"
         assert _row_get(row, "value") == "42"
 
-    def test_missing_key_returns_default(self: Any) -> None:
+    def test_missing_key_returns_default(self: object) -> None:
         """Returns default for a missing column key."""
         row = make_row({"name": "test"})
         assert _row_get(row, "nonexistent") is None
         assert _row_get(row, "nonexistent", "fallback") == "fallback"
 
-    def test_default_none(self: Any) -> None:
+    def test_default_none(self: object) -> None:
         """Default is None when not specified."""
         row = make_row({"x": "1"})
         assert _row_get(row, "missing") is None
@@ -126,7 +126,7 @@ class TestRowGet:
 class TestRowToConversation:
     """Tests for _row_to_conversation mapper."""
 
-    def test_maps_required_fields(self: Any) -> None:
+    def test_maps_required_fields(self: object) -> None:
         """All required fields are mapped from row to ConversationRecord."""
         row = make_row(
             {
@@ -153,7 +153,7 @@ class TestRowToConversation:
         assert result.title == "Test Chat"
         assert result.content_hash == "abcdef1234567890"
 
-    def test_maps_json_provider_meta(self: Any) -> None:
+    def test_maps_json_provider_meta(self: object) -> None:
         """JSON provider_meta is parsed from string."""
         import json
 
@@ -188,7 +188,7 @@ class TestRowToConversation:
 class TestRowToMessage:
     """Tests for _row_to_message mapper."""
 
-    def test_maps_required_fields(self: Any) -> None:
+    def test_maps_required_fields(self: object) -> None:
         """All required fields are mapped from row to MessageRecord."""
         row = make_row(
             {
@@ -216,7 +216,7 @@ class TestRowToMessage:
         assert result.text == "Hello world"
         assert result.branch_index == 0
 
-    def test_null_branch_index_defaults_to_zero(self: Any) -> None:
+    def test_null_branch_index_defaults_to_zero(self: object) -> None:
         """Null branch_index from DB maps to 0."""
         row = make_row(
             {
@@ -248,7 +248,7 @@ class TestRowToMessage:
 class TestRowToRawConversation:
     """Tests for _row_to_raw_conversation mapper."""
 
-    def test_maps_all_fields(self: Any) -> None:
+    def test_maps_all_fields(self: object) -> None:
         """All fields are mapped from row to RawConversationRecord."""
         row = make_row(
             {

--- a/tests/unit/storage/test_query_security.py
+++ b/tests/unit/storage/test_query_security.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import sqlite3
-from typing import Any, cast
+from pathlib import Path
+from typing import cast
 
 import pytest
 from hypothesis import HealthCheck, given, settings
@@ -21,39 +22,39 @@ from tests.infra.strategies.adversarial import (
 
 
 @pytest.fixture
-async def temp_repo(tmp_path: Any) -> Any:
+async def temp_repo(tmp_path: Path) -> ConversationRepository:
     db_path = tmp_path / "test.db"
     backend = SQLiteBackend(db_path=db_path)
     return ConversationRepository(backend=backend)
 
 
-async def test_conversation_id_sql_injection_select(temp_repo: Any) -> None:
+async def test_conversation_id_sql_injection_select(temp_repo: ConversationRepository) -> None:
     assert await temp_repo.view("' OR '1'='1") is None
 
 
-async def test_conversation_id_sql_injection_drop_table(temp_repo: Any) -> None:
+async def test_conversation_id_sql_injection_drop_table(temp_repo: ConversationRepository) -> None:
     assert await temp_repo.view("'; DROP TABLE conversations--") is None
     assert isinstance(await temp_repo.list(), list)
 
 
-async def test_conversation_id_sql_injection_union(temp_repo: Any) -> None:
+async def test_conversation_id_sql_injection_union(temp_repo: ConversationRepository) -> None:
     assert await temp_repo.view("1 UNION SELECT * FROM sqlite_master--") is None
 
 
-async def test_message_id_sql_injection(temp_repo: Any) -> None:
+async def test_message_id_sql_injection(temp_repo: ConversationRepository) -> None:
     assert isinstance(await temp_repo.list(), list)
 
 
-async def test_provider_name_sql_injection(temp_repo: Any) -> None:
+async def test_provider_name_sql_injection(temp_repo: ConversationRepository) -> None:
     assert await temp_repo.list(provider="doesnotexist") == []
 
 
-async def test_conversation_title_sql_injection(temp_repo: Any) -> None:
+async def test_conversation_title_sql_injection(temp_repo: ConversationRepository) -> None:
     assert isinstance(await temp_repo.list(), list)
     assert isinstance(await temp_repo.list(), list)
 
 
-async def test_multiple_injection_attempts_in_sequence(temp_repo: Any) -> None:
+async def test_multiple_injection_attempts_in_sequence(temp_repo: ConversationRepository) -> None:
     for malicious_id in [
         "' OR '1'='1",
         "'; DROP TABLE conversations--",
@@ -64,7 +65,7 @@ async def test_multiple_injection_attempts_in_sequence(temp_repo: Any) -> None:
     assert isinstance(await temp_repo.list(), list)
 
 
-async def test_stored_xss_in_conversation_content(temp_repo: Any) -> None:
+async def test_stored_xss_in_conversation_content(temp_repo: ConversationRepository) -> None:
     xss_payload = "<script>alert('XSS')</script>"
     backend = temp_repo.backend
     conv_record = make_conversation("xss-test", title="XSS Test")
@@ -97,25 +98,25 @@ def test_escape_fts5_security_contract(raw_query: str, expected: str, should_com
             _assert_fts5_match_executes(escaped)
 
 
-async def test_empty_string_parameters_handled(temp_repo: Any) -> None:
+async def test_empty_string_parameters_handled(temp_repo: ConversationRepository) -> None:
     assert await temp_repo.view("") is None
     assert isinstance(await temp_repo.list(provider=""), list)
 
 
-async def test_none_parameters_handled(temp_repo: Any) -> None:
+async def test_none_parameters_handled(temp_repo: ConversationRepository) -> None:
     try:
-        conv = await temp_repo.view(cast(Any, None))
+        conv = await temp_repo.view(cast(str, None))
         assert conv is None
     except (TypeError, ValueError):
         pass
 
 
-async def test_very_long_string_parameters(temp_repo: Any) -> None:
+async def test_very_long_string_parameters(temp_repo: ConversationRepository) -> None:
     assert await temp_repo.view("a" * 10000) is None
     assert isinstance(await temp_repo.list(provider="x" * 1000), list)
 
 
-async def test_unicode_in_parameters(temp_repo: Any) -> None:
+async def test_unicode_in_parameters(temp_repo: ConversationRepository) -> None:
     for value in ["文件", "файл", "🎉🎊", "café"]:
         assert await temp_repo.view(value) is None
 
@@ -142,7 +143,9 @@ def test_control_chars_in_queries_handled(text_with_control: str) -> None:
 
 @given(sql_injection_strategy())
 @settings(max_examples=50, deadline=None, suppress_health_check=[HealthCheck.function_scoped_fixture])
-async def test_repository_survives_injection_property(temp_repo: Any, injection_payload: str) -> None:
+async def test_repository_survives_injection_property(
+    temp_repo: ConversationRepository, injection_payload: str
+) -> None:
     assert await temp_repo.view(injection_payload) is None
     result = await temp_repo.list(provider=injection_payload[:50])
     assert isinstance(result, list)

--- a/tests/unit/storage/test_retrieval_readiness_laws.py
+++ b/tests/unit/storage/test_retrieval_readiness_laws.py
@@ -6,7 +6,7 @@ agree with each other and with the underlying stored data.
 
 from __future__ import annotations
 
-from typing import Any
+from pathlib import Path
 
 import pytest
 
@@ -14,7 +14,7 @@ from tests.infra.storage_records import ConversationBuilder, db_setup
 
 
 @pytest.fixture()
-def populated_db(workspace_env: Any) -> Any:
+def populated_db(workspace_env: dict[str, Path]) -> Path:
     """Create a DB with conversations across multiple providers, with FTS indexed."""
     db_path = db_setup(workspace_env)
 
@@ -60,7 +60,7 @@ def populated_db(workspace_env: Any) -> Any:
 
 
 class TestProviderFilterSubset:
-    def test_provider_filter_returns_subset(self: Any, populated_db: Any) -> None:
+    def test_provider_filter_returns_subset(self: object, populated_db: Path) -> None:
         from polylogue.storage.backends.connection import open_connection
 
         with open_connection(populated_db) as conn:
@@ -79,7 +79,7 @@ class TestProviderFilterSubset:
             assert len(claude_ids) == 2
             assert len(all_ids) == 4
 
-    def test_all_providers_partition_total(self: Any, populated_db: Any) -> None:
+    def test_all_providers_partition_total(self: object, populated_db: Path) -> None:
         """Union of all per-provider sets equals the full set."""
         from polylogue.storage.backends.connection import open_connection
 
@@ -111,7 +111,7 @@ class TestProviderFilterSubset:
 
 
 class TestFTSIndexCompleteness:
-    def test_fts_message_count_matches_messages_table(self: Any, populated_db: Any) -> None:
+    def test_fts_message_count_matches_messages_table(self: object, populated_db: Path) -> None:
         from polylogue.storage.backends.connection import open_connection
 
         with open_connection(populated_db) as conn:
@@ -127,7 +127,7 @@ class TestFTSIndexCompleteness:
 
             assert fts_count == msg_count, f"FTS row count ({fts_count}) != messages table count ({msg_count})"
 
-    def test_fts_search_returns_subset_of_messages(self: Any, populated_db: Any) -> None:
+    def test_fts_search_returns_subset_of_messages(self: object, populated_db: Path) -> None:
         from polylogue.storage.backends.connection import open_connection
 
         with open_connection(populated_db) as conn:
@@ -155,7 +155,7 @@ class TestFTSIndexCompleteness:
 
 
 class TestCountListAgreement:
-    def test_count_matches_list_length(self: Any, populated_db: Any) -> None:
+    def test_count_matches_list_length(self: object, populated_db: Path) -> None:
         from polylogue.storage.backends.connection import open_connection
 
         with open_connection(populated_db) as conn:
@@ -164,7 +164,7 @@ class TestCountListAgreement:
 
             assert count == len(rows), f"COUNT(*) ({count}) != len(SELECT) ({len(rows)})"
 
-    def test_per_provider_count_matches_filtered_list(self: Any, populated_db: Any) -> None:
+    def test_per_provider_count_matches_filtered_list(self: object, populated_db: Path) -> None:
         from polylogue.storage.backends.connection import open_connection
 
         with open_connection(populated_db) as conn:
@@ -185,7 +185,7 @@ class TestCountListAgreement:
 
 
 class TestMessageStatsConsistency:
-    def test_conversation_stats_match_actual_messages(self: Any, populated_db: Any) -> None:
+    def test_conversation_stats_match_actual_messages(self: object, populated_db: Path) -> None:
         from polylogue.storage.backends.connection import open_connection
 
         with open_connection(populated_db) as conn:

--- a/tests/unit/storage/test_scale.py
+++ b/tests/unit/storage/test_scale.py
@@ -19,9 +19,9 @@ from __future__ import annotations
 import asyncio
 import time
 from pathlib import Path
-from typing import Any
 
 import pytest
+from typing_extensions import TypedDict, Unpack
 
 from polylogue.storage.backends.async_sqlite import SQLiteBackend
 from polylogue.storage.backends.connection import open_connection
@@ -36,7 +36,18 @@ from tests.infra.storage_records import make_content_block, make_conversation, m
 SCALE_COUNT = 200
 
 
-def _record_query(**kwargs: Any) -> ConversationRecordQuery:
+class RecordQueryKwargs(TypedDict, total=False):
+    provider: str
+    since: str
+    until: str
+    path_terms: tuple[str, ...]
+    action_terms: tuple[str, ...]
+    tool_terms: tuple[str, ...]
+    limit: int
+    has_tool_use: bool
+
+
+def _record_query(**kwargs: Unpack[RecordQueryKwargs]) -> ConversationRecordQuery:
     return ConversationRecordQuery(**kwargs)
 
 

--- a/tests/unit/storage/test_schema_safety.py
+++ b/tests/unit/storage/test_schema_safety.py
@@ -14,7 +14,7 @@ are invisible in unit tests with small datasets.
 from __future__ import annotations
 
 import sqlite3
-from typing import Any
+from pathlib import Path
 
 import pytest
 
@@ -72,7 +72,7 @@ class TestSchemaDDLParity:
         assert isinstance(SCHEMA_VERSION, int)
         assert SCHEMA_VERSION > 0
 
-    def test_schema_ddl_applied_to_fresh_database(self, tmp_path: Any) -> None:
+    def test_schema_ddl_applied_to_fresh_database(self, tmp_path: Path) -> None:
         """SCHEMA_DDL must apply cleanly to a fresh database."""
         db_path = tmp_path / "fresh.db"
         conn = sqlite3.connect(str(db_path))
@@ -88,7 +88,7 @@ class TestSchemaDDLParity:
         finally:
             conn.close()
 
-    def test_schema_ddl_is_idempotent(self, tmp_path: Any) -> None:
+    def test_schema_ddl_is_idempotent(self, tmp_path: Path) -> None:
         """Applying SCHEMA_DDL twice must not error."""
         db_path = tmp_path / "idempotent.db"
         conn = sqlite3.connect(str(db_path))
@@ -119,7 +119,7 @@ class TestMigrationRollbackSafety:
     instead of `executescript()`.
     """
 
-    def test_executescript_implicit_commit_behavior(self, tmp_path: Any) -> None:
+    def test_executescript_implicit_commit_behavior(self, tmp_path: Path) -> None:
         """Document that executescript() commits before executing.
 
         This test documents the SQLite behavior that caused the bug.
@@ -152,7 +152,7 @@ class TestMigrationRollbackSafety:
         finally:
             conn.close()
 
-    def test_execute_preserves_transaction(self, tmp_path: Any) -> None:
+    def test_execute_preserves_transaction(self, tmp_path: Path) -> None:
         """execute() within BEGIN/ROLLBACK correctly rolls back."""
         db_path = tmp_path / "test.db"
         conn = sqlite3.connect(str(db_path))
@@ -174,7 +174,7 @@ class TestMigrationRollbackSafety:
         finally:
             conn.close()
 
-    def test_fresh_db_schema_matches_migrated_db(self, tmp_path: Any) -> None:
+    def test_fresh_db_schema_matches_migrated_db(self, tmp_path: Path) -> None:
         """A fresh database and a migrated database must have the same schema.
 
         This catches drift between the DDL (for fresh installs) and the
@@ -232,7 +232,7 @@ class TestMigrationRollbackSafety:
 class TestSQLEdgeCases:
     """SQL edge cases that caused production bugs."""
 
-    def test_offset_without_limit_is_error(self, tmp_path: Any) -> None:
+    def test_offset_without_limit_is_error(self, tmp_path: Path) -> None:
         """SQLite requires LIMIT when using OFFSET. Verify our code handles this."""
         db_path = tmp_path / "test.db"
         conn = sqlite3.connect(str(db_path))
@@ -253,7 +253,7 @@ class TestSQLEdgeCases:
         finally:
             conn.close()
 
-    def test_like_wildcards_in_search(self, tmp_path: Any) -> None:
+    def test_like_wildcards_in_search(self, tmp_path: Path) -> None:
         """LIKE patterns with % and _ must be escaped properly.
 
         Regression: commit 177195c — unescaped LIKE wildcards in title search
@@ -289,7 +289,7 @@ class TestSQLEdgeCases:
         finally:
             conn.close()
 
-    def test_like_underscore_wildcard(self, tmp_path: Any) -> None:
+    def test_like_underscore_wildcard(self, tmp_path: Path) -> None:
         """Underscore in LIKE is a single-char wildcard, must be escaped."""
         db_path = tmp_path / "test.db"
         conn = sqlite3.connect(str(db_path))
@@ -330,7 +330,7 @@ class TestFTS5CountGuard:
     COUNT(*) on the regular messages table instead.
     """
 
-    def test_count_on_regular_table_not_fts(self, test_db: Any) -> None:
+    def test_count_on_regular_table_not_fts(self, test_db: Path) -> None:
         """Message count must come from the messages table, not messages_fts."""
         from polylogue.storage.backends.connection import open_connection
 
@@ -429,7 +429,7 @@ class TestFetchLimitPagination:
     This tests the low-level pagination SQL pattern used in async_sqlite.py.
     """
 
-    def test_limit_offset_returns_exact_count(self, tmp_path: Any) -> None:
+    def test_limit_offset_returns_exact_count(self, tmp_path: Path) -> None:
         """LIMIT N OFFSET M returns exactly N rows when enough data exists."""
         db_path = tmp_path / "test.db"
         conn = sqlite3.connect(str(db_path))
@@ -466,7 +466,7 @@ class TestFetchLimitPagination:
         finally:
             conn.close()
 
-    def test_limit_with_fewer_rows_than_limit(self, tmp_path: Any) -> None:
+    def test_limit_with_fewer_rows_than_limit(self, tmp_path: Path) -> None:
         """When total rows < limit, return all rows without error."""
         db_path = tmp_path / "test.db"
         conn = sqlite3.connect(str(db_path))
@@ -485,7 +485,7 @@ class TestFetchLimitPagination:
         finally:
             conn.close()
 
-    def test_offset_beyond_data_returns_empty(self, tmp_path: Any) -> None:
+    def test_offset_beyond_data_returns_empty(self, tmp_path: Path) -> None:
         """OFFSET past all data returns empty, not error."""
         db_path = tmp_path / "test.db"
         conn = sqlite3.connect(str(db_path))
@@ -518,7 +518,7 @@ class TestAnalyticsQueryPlan:
     would require a full table scan.
     """
 
-    def test_provider_group_by_uses_index(self, tmp_path: Any) -> None:
+    def test_provider_group_by_uses_index(self, tmp_path: Path) -> None:
         """GROUP BY provider_name should use idx_conversations_provider."""
         db_path = tmp_path / "test.db"
         conn = sqlite3.connect(str(db_path))
@@ -536,7 +536,7 @@ class TestAnalyticsQueryPlan:
         finally:
             conn.close()
 
-    def test_messages_by_conversation_uses_index(self, tmp_path: Any) -> None:
+    def test_messages_by_conversation_uses_index(self, tmp_path: Path) -> None:
         """WHERE conversation_id = ? should use idx_messages_conversation."""
         db_path = tmp_path / "test.db"
         conn = sqlite3.connect(str(db_path))
@@ -553,7 +553,7 @@ class TestAnalyticsQueryPlan:
         finally:
             conn.close()
 
-    def test_conversation_count_is_cheap(self, tmp_path: Any) -> None:
+    def test_conversation_count_is_cheap(self, tmp_path: Path) -> None:
         """COUNT(*) on conversations table should not require FTS scan."""
         db_path = tmp_path / "test.db"
         conn = sqlite3.connect(str(db_path))

--- a/tests/unit/storage/test_store_ops.py
+++ b/tests/unit/storage/test_store_ops.py
@@ -12,14 +12,14 @@ from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any, cast
+from typing import cast
 from unittest.mock import AsyncMock
 
 import pytest
 from hypothesis import given, settings
 from hypothesis import strategies as st
 from pydantic import ValidationError
-from typing_extensions import TypedDict
+from typing_extensions import TypedDict, Unpack
 
 from polylogue.lib.conversation_models import Conversation
 from polylogue.lib.messages import MessageCollection
@@ -77,6 +77,16 @@ class SimpleTagSpec(TypedDict):
 class SimpleTitleSearchSpec(TypedDict):
     title: str
     search_term: str
+
+
+class RecordQueryKwargs(TypedDict, total=False):
+    provider: str
+    path_terms: tuple[str, ...]
+    action_terms: tuple[str, ...]
+    excluded_action_terms: tuple[str, ...]
+    tool_terms: tuple[str, ...]
+    excluded_tool_terms: tuple[str, ...]
+    limit: int
 
 
 def _conversation_id(value: str) -> ConversationId:
@@ -215,8 +225,8 @@ def _attachment_row(conn: sqlite3.Connection, attachment_id: str) -> sqlite3.Row
     )
 
 
-def _record_query(**kwargs: object) -> ConversationRecordQuery:
-    return ConversationRecordQuery(**cast(dict[str, Any], kwargs))
+def _record_query(**kwargs: Unpack[RecordQueryKwargs]) -> ConversationRecordQuery:
+    return ConversationRecordQuery(**kwargs)
 
 
 @pytest.mark.asyncio
@@ -1122,30 +1132,42 @@ class TestCrudLaws:
 
     @given(conversation_strategy(min_messages=1, max_messages=5))
     @settings(max_examples=30, deadline=None)
-    async def test_save_retrieve_roundtrip(self, conv_data: dict[str, Any]) -> None:
+    async def test_save_retrieve_roundtrip(self, conv_data: dict[str, object]) -> None:
         """Saving a strategy-generated conversation and retrieving it preserves identity."""
         with tempfile.TemporaryDirectory() as tmp_dir:
             db_path = Path(tmp_dir) / "roundtrip.db"
             backend = SQLiteBackend(db_path=db_path)
 
-            conv_id = f"test-{conv_data['id'][:16]}"
-            provider = conv_data.get("provider", "test")
+            raw_id = conv_data["id"]
+            assert isinstance(raw_id, str)
+            conv_id = f"test-{raw_id[:16]}"
+            raw_provider = conv_data.get("provider", "test")
+            assert isinstance(raw_provider, str)
+            provider = raw_provider
+            raw_title = conv_data.get("title", "Generated")
+            assert isinstance(raw_title, str)
+            raw_created_at = conv_data.get("created_at")
+            assert raw_created_at is None or isinstance(raw_created_at, str)
 
             conv = make_conversation(
                 conversation_id=conv_id,
                 provider_name=provider,
-                title=conv_data.get("title", "Generated"),
-                created_at=conv_data.get("created_at"),
+                title=raw_title,
+                created_at=raw_created_at,
             )
 
             messages: list[MessageRecord] = []
-            message_payloads = cast(list[dict[str, Any]], conv_data.get("messages", []))
+            message_payloads = cast(list[dict[str, object]], conv_data.get("messages", []))
             for i, msg_data in enumerate(message_payloads):
+                raw_role = msg_data.get("role", "user")
+                assert isinstance(raw_role, str)
+                raw_text = msg_data.get("text", "")
+                assert isinstance(raw_text, str)
                 msg = make_message(
                     message_id=f"{conv_id}-m{i}",
                     conversation_id=conv_id,
-                    role=msg_data.get("role", "user"),
-                    text=msg_data.get("text", ""),
+                    role=raw_role,
+                    text=raw_text,
                 )
                 messages.append(msg)
 
@@ -1165,17 +1187,23 @@ class TestCrudLaws:
 
     @given(conversation_strategy(min_messages=1, max_messages=3))
     @settings(max_examples=20, deadline=None)
-    async def test_save_is_idempotent(self, conv_data: dict[str, Any]) -> None:
+    async def test_save_is_idempotent(self, conv_data: dict[str, object]) -> None:
         """Saving the same conversation twice yields the same stored data."""
         with tempfile.TemporaryDirectory() as tmp_dir:
             db_path = Path(tmp_dir) / "idempotent.db"
             backend = SQLiteBackend(db_path=db_path)
 
-            conv_id = f"idem-{conv_data['id'][:16]}"
+            raw_id = conv_data["id"]
+            assert isinstance(raw_id, str)
+            conv_id = f"idem-{raw_id[:16]}"
+            raw_provider = conv_data.get("provider", "test")
+            assert isinstance(raw_provider, str)
+            raw_title = conv_data.get("title", "Idempotent")
+            assert isinstance(raw_title, str)
             conv = make_conversation(
                 conversation_id=conv_id,
-                provider_name=conv_data.get("provider", "test"),
-                title=conv_data.get("title", "Idempotent"),
+                provider_name=raw_provider,
+                title=raw_title,
             )
 
             # Save twice

--- a/tests/unit/storage/test_vec.py
+++ b/tests/unit/storage/test_vec.py
@@ -4,15 +4,48 @@ from __future__ import annotations
 
 import sqlite3
 import struct
-from typing import Any
+from collections.abc import Callable
+from pathlib import Path
+from typing import Protocol, TypeAlias, cast
 from unittest.mock import MagicMock, patch
 
 import httpx
 import pytest
 
 from polylogue.lib.roles import Role
+from polylogue.storage.search_providers.sqlite_vec import SqliteVecProvider
 from polylogue.storage.store import MessageRecord
 from polylogue.types import ContentHash, ConversationId, MessageId
+
+Embedding: TypeAlias = list[float]
+SearchRows: TypeAlias = list[tuple[str, float]]
+
+
+class EmbeddingFetcher(Protocol):
+    def __call__(self, texts: list[str], input_type: str = "document") -> list[Embedding]: ...
+
+
+class MutableSqliteVecProvider(Protocol):
+    db_path: Path
+    voyage_key: str
+    model: str
+    dimension: int
+    _vec_available: bool | None
+    _tables_ensured: bool
+    _ensure_vec_available: Callable[[], None]
+    _ensure_tables: Callable[[], None]
+    _get_embeddings: EmbeddingFetcher
+    _get_connection: Callable[[], sqlite3.Connection]
+
+    def _should_embed_message(self, msg: MessageRecord) -> bool: ...
+
+    def upsert(self, conversation_id: str, messages: list[MessageRecord]) -> None: ...
+
+    def query(self, text: str, limit: int = 10) -> SearchRows: ...
+
+    def query_by_provider(self, text: str, provider: str, limit: int = 10) -> SearchRows: ...
+
+    def get_embedding_stats(self) -> dict[str, int]: ...
 
 
 def make_message(
@@ -35,14 +68,12 @@ def make_message(
 
 
 @pytest.fixture
-def provider_cls() -> Any:
-    from polylogue.storage.search_providers.sqlite_vec import SqliteVecProvider
-
+def provider_cls() -> type[SqliteVecProvider]:
     return SqliteVecProvider
 
 
 @pytest.fixture
-def mock_provider(tmp_path: Any, provider_cls: Any) -> Any:
+def mock_provider(tmp_path: Path, provider_cls: type[SqliteVecProvider]) -> MutableSqliteVecProvider:
     provider = object.__new__(provider_cls)
     provider.db_path = tmp_path / "test.db"
     provider.voyage_key = "test-voyage-key"
@@ -50,18 +81,18 @@ def mock_provider(tmp_path: Any, provider_cls: Any) -> Any:
     provider.dimension = 1024
     provider._vec_available = None
     provider._tables_ensured = True
-    return provider
+    return cast(MutableSqliteVecProvider, provider)
 
 
-def test_get_embeddings_request_contract(mock_provider: Any) -> None:
+def test_get_embeddings_request_contract(mock_provider: MutableSqliteVecProvider) -> None:
     """Embedding requests must send the canonical payload, headers, and optional dimension."""
     cases = [
-        {"dimension": 1024, "input_type": "document", "expected_dimension": None},
-        {"dimension": 512, "input_type": "query", "expected_dimension": 512},
+        (1024, "document", None),
+        (512, "query", 512),
     ]
 
-    for case in cases:
-        mock_provider.dimension = case["dimension"]
+    for dimension, input_type, expected_dimension in cases:
+        mock_provider.dimension = dimension
         captured_payload: dict[str, object] = {}
         captured_headers: dict[str, str] = {}
         response = MagicMock()
@@ -69,14 +100,19 @@ def test_get_embeddings_request_contract(mock_provider: Any) -> None:
         response.raise_for_status = MagicMock()
 
         def capture_post(
-            *args: Any,
-            _captured_payload: Any = captured_payload,
-            _captured_headers: Any = captured_headers,
-            _response: Any = response,
-            **kwargs: Any,
-        ) -> Any:
-            _captured_payload.update(kwargs.get("json", {}))
-            _captured_headers.update(kwargs.get("headers", {}))
+            *args: object,
+            _captured_payload: dict[str, object] = captured_payload,
+            _captured_headers: dict[str, str] = captured_headers,
+            _response: MagicMock = response,
+            **kwargs: object,
+        ) -> MagicMock:
+            del args
+            payload = kwargs.get("json")
+            assert isinstance(payload, dict)
+            _captured_payload.update({str(key): value for key, value in payload.items()})
+            headers = kwargs.get("headers")
+            assert isinstance(headers, dict)
+            _captured_headers.update({str(key): str(value) for key, value in headers.items()})
             return _response
 
         with patch("httpx.Client") as mock_client_cls:
@@ -86,29 +122,34 @@ def test_get_embeddings_request_contract(mock_provider: Any) -> None:
             client.__exit__ = MagicMock(return_value=False)
             mock_client_cls.return_value = client
 
-            result = mock_provider._get_embeddings(["test text"], input_type=case["input_type"])
+            result = mock_provider._get_embeddings(["test text"], input_type=input_type)
 
         assert result == [[0.1, 0.2, 0.3]]
         assert captured_payload["input"] == ["test text"]
         assert captured_payload["model"] == mock_provider.model
-        assert captured_payload["input_type"] == case["input_type"]
-        if case["expected_dimension"] is None:
+        assert captured_payload["input_type"] == input_type
+        if expected_dimension is None:
             assert "output_dimension" not in captured_payload
         else:
-            assert captured_payload["output_dimension"] == case["expected_dimension"]
+            assert captured_payload["output_dimension"] == expected_dimension
         assert captured_headers["Authorization"] == f"Bearer {mock_provider.voyage_key}"
 
 
 @pytest.mark.slow
-def test_get_embeddings_batches_large_input(mock_provider: Any) -> None:
+def test_get_embeddings_batches_large_input(mock_provider: MutableSqliteVecProvider) -> None:
     """Large requests must batch without dropping embeddings."""
     from polylogue.storage.search_providers.sqlite_vec import BATCH_SIZE
 
     texts = [f"text {i} is a long enough message for embedding purposes" for i in range(BATCH_SIZE + 10)]
     call_sizes: list[int] = []
 
-    def fake_post(*args: Any, **kwargs: Any) -> Any:
-        batch_size = len(kwargs.get("json", {}).get("input", []))
+    def fake_post(*args: object, **kwargs: object) -> MagicMock:
+        del args
+        payload = kwargs.get("json")
+        assert isinstance(payload, dict)
+        input_payload = payload.get("input")
+        assert isinstance(input_payload, list)
+        batch_size = len(input_payload)
         call_sizes.append(batch_size)
         response = MagicMock()
         response.json.return_value = {"data": [{"embedding": [0.1] * 3} for _ in range(batch_size)]}
@@ -143,7 +184,11 @@ def test_get_embeddings_batches_large_input(mock_provider: Any) -> None:
     ],
     ids=["http-status", "timeout"],
 )
-def test_get_embeddings_error_contract(mock_provider: Any, error: Any, pattern: Any) -> None:
+def test_get_embeddings_error_contract(
+    mock_provider: MutableSqliteVecProvider,
+    error: httpx.HTTPError,
+    pattern: str,
+) -> None:
     """HTTP-layer failures must surface as sanitized sqlite-vec errors."""
     from polylogue.storage.search_providers.sqlite_vec import SqliteVecError
 
@@ -158,7 +203,7 @@ def test_get_embeddings_error_contract(mock_provider: Any, error: Any, pattern: 
             mock_provider._get_embeddings(["test text"])
 
 
-def test_get_embeddings_error_does_not_leak_api_key(mock_provider: Any) -> None:
+def test_get_embeddings_error_does_not_leak_api_key(mock_provider: MutableSqliteVecProvider) -> None:
     """Sanitized errors must not expose the configured API key."""
     from polylogue.storage.search_providers.sqlite_vec import SqliteVecError
 
@@ -193,7 +238,12 @@ def test_get_embeddings_error_does_not_leak_api_key(mock_provider: Any) -> None:
         ("user", "12345678901234567890", True),
     ],
 )
-def test_should_embed_message_contract(mock_provider: Any, role: Any, text: Any, should_embed: Any) -> None:
+def test_should_embed_message_contract(
+    mock_provider: MutableSqliteVecProvider,
+    role: str,
+    text: str,
+    should_embed: bool,
+) -> None:
     """Only semantically useful messages should be embedded."""
     assert mock_provider._should_embed_message(make_message(role=role, text=text)) is should_embed
 
@@ -203,21 +253,28 @@ def test_should_embed_message_contract(mock_provider: Any, role: Any, text: Any,
     [([], False), ([make_message(text="short")], True)],
     ids=["empty", "no-embeddable"],
 )
-def test_upsert_noop_contract(mock_provider: Any, messages: Any, should_ensure: Any) -> None:
+def test_upsert_noop_contract(
+    mock_provider: MutableSqliteVecProvider,
+    messages: list[MessageRecord],
+    should_ensure: bool,
+) -> None:
     """Upsert should short-circuit on empty or non-embeddable input."""
-    mock_provider._ensure_vec_available = MagicMock()
-    mock_provider._ensure_tables = MagicMock()
-    mock_provider._get_connection = MagicMock()
+    ensure_vec_available = MagicMock()
+    ensure_tables = MagicMock()
+    get_connection = MagicMock()
+    mock_provider._ensure_vec_available = ensure_vec_available
+    mock_provider._ensure_tables = ensure_tables
+    mock_provider._get_connection = get_connection
 
     mock_provider.upsert("conv-1", messages)
 
     if should_ensure:
-        mock_provider._ensure_vec_available.assert_called_once()
-        mock_provider._ensure_tables.assert_called_once()
+        ensure_vec_available.assert_called_once()
+        ensure_tables.assert_called_once()
     else:
-        mock_provider._ensure_vec_available.assert_not_called()
-        mock_provider._ensure_tables.assert_not_called()
-    mock_provider._get_connection.assert_not_called()
+        ensure_vec_available.assert_not_called()
+        ensure_tables.assert_not_called()
+    get_connection.assert_not_called()
 
 
 @pytest.mark.parametrize(
@@ -225,7 +282,11 @@ def test_upsert_noop_contract(mock_provider: Any, messages: Any, should_ensure: 
     [("claude-ai", "claude-ai"), (None, "unknown")],
     ids=["provider-row", "missing-provider-row"],
 )
-def test_upsert_persistence_contract(mock_provider: Any, provider_name: Any, expected_provider: Any) -> None:
+def test_upsert_persistence_contract(
+    mock_provider: MutableSqliteVecProvider,
+    provider_name: str | None,
+    expected_provider: str,
+) -> None:
     """Upsert must filter messages, persist embeddings, and stamp provider metadata."""
     messages = [
         make_message(message_id="m1", text="This is a long embeddable message."),
@@ -237,11 +298,12 @@ def test_upsert_persistence_contract(mock_provider: Any, provider_name: Any, exp
     mock_provider._ensure_vec_available = MagicMock()
     mock_provider._ensure_tables = MagicMock()
 
-    def capture_embeddings(texts: Any, **kwargs: Any) -> Any:
+    def capture_embeddings(texts: list[str], input_type: str = "document") -> list[Embedding]:
+        del input_type
         embeddings_called_with.extend(texts)
         return [[0.1, 0.2] for _ in texts]
 
-    def capture_execute(sql: Any, params: Any = None) -> Any:
+    def capture_execute(sql: str, params: tuple[object, ...] | None = None) -> MagicMock:
         insert_calls.append((sql, params))
         cursor = MagicMock()
         if "SELECT provider_name FROM conversations" in sql:
@@ -270,7 +332,7 @@ def test_upsert_persistence_contract(mock_provider: Any, provider_name: Any, exp
     assert len(status_updates) == 1
 
 
-def test_upsert_closes_connection_on_embedding_error(mock_provider: Any) -> None:
+def test_upsert_closes_connection_on_embedding_error(mock_provider: MutableSqliteVecProvider) -> None:
     """Connection cleanup must happen even when embedding generation fails."""
     mock_provider._ensure_vec_available = MagicMock()
     mock_provider._ensure_tables = MagicMock()
@@ -290,17 +352,22 @@ def test_upsert_closes_connection_on_embedding_error(mock_provider: Any) -> None
     ],
     ids=["query", "query-by-provider", "query-empty", "query-by-provider-empty"],
 )
-def test_query_route_contract(mock_provider: Any, method_name: Any, provider: Any, embedding_result: Any) -> None:
+def test_query_route_contract(
+    mock_provider: MutableSqliteVecProvider,
+    method_name: str,
+    provider: str | None,
+    embedding_result: list[Embedding],
+) -> None:
     """Query methods must generate query embeddings, optionally filter by provider, and close connections."""
     mock_provider._ensure_vec_available = MagicMock()
     embedding_calls: list[tuple[list[str], str | None]] = []
     executed_queries: list[tuple[str, tuple[object, ...] | None]] = []
 
-    def capture_embeddings(texts: Any, input_type: Any = None) -> Any:
+    def capture_embeddings(texts: list[str], input_type: str = "document") -> list[Embedding]:
         embedding_calls.append((texts, input_type))
         return embedding_result
 
-    def capture_execute(sql: Any, params: Any = None) -> Any:
+    def capture_execute(sql: str, params: tuple[object, ...] | None = None) -> MagicMock:
         executed_queries.append((sql, params))
         row_1 = MagicMock(spec=sqlite3.Row)
         row_1.__getitem__.side_effect = lambda key: "msg-1" if key == "message_id" else 0.5
@@ -317,6 +384,7 @@ def test_query_route_contract(mock_provider: Any, method_name: Any, provider: An
     if method_name == "query":
         result = mock_provider.query("search text", limit=10)
     else:
+        assert provider is not None
         result = mock_provider.query_by_provider("search text", provider=provider, limit=10)
 
     assert embedding_calls == [(["search text"], "query")]
@@ -338,11 +406,17 @@ def test_query_route_contract(mock_provider: Any, method_name: Any, provider: An
     [(42, 5, False), (0, 0, False), (0, 0, True)],
     ids=["counts", "zeros", "missing-tables"],
 )
-def test_get_embedding_stats_contract(mock_provider: Any, msg_count: Any, pending: Any, operational_error: Any) -> None:
+def test_get_embedding_stats_contract(
+    mock_provider: MutableSqliteVecProvider,
+    msg_count: int,
+    pending: int,
+    operational_error: bool,
+) -> None:
     """Stats queries must tolerate absent tables and always close the connection."""
     connection = MagicMock()
 
-    def execute(sql: Any, params: Any = None) -> Any:
+    def execute(sql: str, params: tuple[object, ...] | None = None) -> MagicMock:
+        del params
         if operational_error:
             raise sqlite3.OperationalError("Table not found")
         if "sqlite_master" in sql and "conversations" in sql:
@@ -369,7 +443,10 @@ def test_get_embedding_stats_contract(mock_provider: Any, msg_count: Any, pendin
     ids=["cached-available", "cached-unavailable", "probe-available", "probe-unavailable"],
 )
 def test_ensure_vec_available_contract(
-    mock_provider: Any, initial_state: Any, probed_state: Any, should_raise: Any
+    mock_provider: MutableSqliteVecProvider,
+    initial_state: bool | None,
+    probed_state: bool,
+    should_raise: bool,
 ) -> None:
     """Availability probing should cache the result and raise with a helpful message when unavailable."""
     from polylogue.storage.search_providers.sqlite_vec import SqliteVecError
@@ -378,7 +455,7 @@ def test_ensure_vec_available_contract(
     connection = MagicMock()
     connection.close = MagicMock()
 
-    def get_connection() -> Any:
+    def get_connection() -> MagicMock:
         mock_provider._vec_available = probed_state
         return connection
 


### PR DESCRIPTION
## Summary
- Removes explicit dynamic typing from `tests/unit/storage`.
- Replaces broad test casts with typed query kwargs, fixture types, and narrow protocol/test doubles.
- Tightens sqlite-vec, FTS5, backend, repair-convergence, and storage CRUD test contracts without changing production behavior.

## Problem
The mypy/refactoring campaign had cleared source and several test surfaces, but unit storage tests still carried broad `Any` usage around repository fixtures, query helpers, sqlite-vec doubles, and property-generated payloads. That left storage tests weaker than the storage code they exercise.

## Solution
- Type storage fixtures and helpers around `ConversationRepository`, `Config`, `Path`, `sqlite3.Row`, and typed query kwargs.
- Replace private-method `Any` casts in backend/sqlite-vec tests with protocols or local typed doubles.
- Narrow property-generated conversation payloads before constructing storage records.
- Verify `tests/unit/storage` has no explicit `Any` occurrences.

Ref #281

## Verification
- `ruff format tests/unit/storage`
- `ruff check tests/unit/storage`
- `mypy tests/unit/storage`
- `pytest -q tests/unit/storage`
- `PATH=/tmp/polylogue-281/.cache/codex-bin:$PATH devtools verify --quick`
- `PATH=/tmp/polylogue-281/.cache/codex-bin:$PATH git push -u origin feature/refactor/storage-test-contracts`
