### PR TITLE
test: type pipeline contracts

### DIFF
--- a/tests/unit/pipeline/test_differential_paths.py
+++ b/tests/unit/pipeline/test_differential_paths.py
@@ -8,10 +8,11 @@ from __future__ import annotations
 
 import io
 import json
-from typing import Any
+from pathlib import Path
 
 import pytest
 
+from polylogue.config import Config, get_config
 from polylogue.lib.raw_payload_decode import JSONValue
 
 # ---------------------------------------------------------------------------
@@ -57,7 +58,7 @@ class TestDecoderConvergence:
 
         return records
 
-    def test_well_formed_jsonl_same_record_count(self: Any) -> None:
+    def test_well_formed_jsonl_same_record_count(self) -> None:
         lines = [json.dumps({"id": i, "text": f"message {i}"}) for i in range(10)]
         raw = ("\n".join(lines) + "\n").encode("utf-8")
 
@@ -67,7 +68,7 @@ class TestDecoderConvergence:
         assert len(sample_records) == len(stream_records) == 10
         assert sample_malformed == 0
 
-    def test_mixed_valid_invalid_jsonl(self: Any) -> None:
+    def test_mixed_valid_invalid_jsonl(self) -> None:
         lines = [
             json.dumps({"id": 1, "text": "valid"}),
             "not valid json {{{",
@@ -86,7 +87,7 @@ class TestDecoderConvergence:
             f"Decoder agreement: sample={len(sample_records)}, stream={len(stream_records)}"
         )
 
-    def test_bom_handling_agrees(self: Any) -> None:
+    def test_bom_handling_agrees(self) -> None:
         line = json.dumps({"id": 1, "text": "bom test"})
         raw = ("\ufeff" + line + "\n").encode("utf-8")
 
@@ -96,7 +97,7 @@ class TestDecoderConvergence:
         assert len(sample_records) >= 1, "Sample should handle BOM"
         assert len(stream_records) >= 1, "Stream should handle BOM"
 
-    def test_empty_lines_skipped_by_both(self: Any) -> None:
+    def test_empty_lines_skipped_by_both(self) -> None:
         lines = [
             json.dumps({"id": 1}),
             "",
@@ -123,7 +124,7 @@ class TestHealthRepairConvergence:
     the same database state."""
 
     @pytest.fixture()
-    def seeded_db(self: Any, workspace_env: Any) -> Any:
+    def seeded_db(self: object, workspace_env: dict[str, Path]) -> Path:
         """Create a DB with some conversations and introduce orphaned messages."""
         from polylogue.storage.backends.connection import open_connection
         from tests.infra.storage_records import ConversationBuilder, db_setup
@@ -156,7 +157,7 @@ class TestHealthRepairConvergence:
 
         return db_path
 
-    def test_orphaned_message_count_agrees(self: Any, seeded_db: Any) -> None:
+    def test_orphaned_message_count_agrees(self: object, seeded_db: Path) -> None:
         from polylogue.storage.backends.connection import open_connection
         from polylogue.storage.repair import count_orphaned_messages_sync
 
@@ -165,7 +166,7 @@ class TestHealthRepairConvergence:
 
         assert count >= 1, "Should detect at least 1 orphaned message"
 
-    def test_empty_conversation_count_agrees(self: Any, workspace_env: Any) -> None:
+    def test_empty_conversation_count_agrees(self: object, workspace_env: dict[str, Path]) -> None:
         from polylogue.storage.backends.connection import open_connection
         from polylogue.storage.repair import count_empty_conversations_sync
         from tests.infra.storage_records import db_setup
@@ -192,7 +193,7 @@ class TestRepairPreviewConvergence:
     actual repair handler would find on a fresh connection."""
 
     @pytest.fixture()
-    def db_with_orphans(self: Any, workspace_env: Any) -> Any:
+    def db_with_orphans(self: object, workspace_env: dict[str, Path]) -> Config:
         from polylogue.storage.backends.connection import open_connection
         from tests.infra.storage_records import ConversationBuilder, db_setup
 
@@ -213,21 +214,21 @@ class TestRepairPreviewConvergence:
             )
             conn.commit()
             conn.execute("PRAGMA foreign_keys = ON")
-        return db_path
+        return get_config()
 
-    def test_preview_matches_live_orphan_count(self: Any, db_with_orphans: Any) -> None:
+    def test_preview_matches_live_orphan_count(self: object, db_with_orphans: Config) -> None:
         """The count from health/debt should match what repair would find."""
         from polylogue.storage.backends.connection import open_connection
         from polylogue.storage.repair import count_orphaned_messages_sync
 
-        with open_connection(db_with_orphans) as conn:
+        with open_connection(db_with_orphans.db_path) as conn:
             count1 = count_orphaned_messages_sync(conn)
             count2 = count_orphaned_messages_sync(conn)
 
         assert count1 == count2, "Same query on same state should return same count"
         assert count1 == 2, "Should find exactly 2 orphaned messages"
 
-    def test_repair_removes_exactly_previewed_count(self: Any, db_with_orphans: Any) -> None:
+    def test_repair_removes_exactly_previewed_count(self: object, db_with_orphans: Config) -> None:
         """After repair, orphan count should be zero."""
         from polylogue.storage.backends.connection import open_connection
         from polylogue.storage.repair import (
@@ -235,13 +236,13 @@ class TestRepairPreviewConvergence:
             repair_orphaned_messages,
         )
 
-        with open_connection(db_with_orphans) as conn:
+        with open_connection(db_with_orphans.db_path) as conn:
             before = count_orphaned_messages_sync(conn)
             assert before == 2
 
         result = repair_orphaned_messages(db_with_orphans, dry_run=False)
 
-        with open_connection(db_with_orphans) as conn:
+        with open_connection(db_with_orphans.db_path) as conn:
             after = count_orphaned_messages_sync(conn)
 
         assert after == 0, "Repair should remove all orphaned messages"

--- a/tests/unit/pipeline/test_ingest_batch.py
+++ b/tests/unit/pipeline/test_ingest_batch.py
@@ -6,7 +6,7 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any, NoReturn, cast
+from typing import NoReturn, cast
 from unittest.mock import AsyncMock
 
 import pytest
@@ -39,9 +39,12 @@ from polylogue.pipeline.services.ingest_worker import (
     StatsTuple,
     _make_ref_id,
 )
+from polylogue.pipeline.services.parsing import ParsingService
+from polylogue.storage.backends.async_sqlite import SQLiteBackend
 from polylogue.storage.backends.connection import open_connection
 from polylogue.storage.raw_state_models import RawConversationStateUpdate
 from polylogue.storage.session_product_refresh import SessionProductRefreshChunkObservation
+from polylogue.storage.store import RawConversationRecord
 from polylogue.types import AttachmentId, ContentBlockType, ContentHash, ConversationId, MessageId
 
 
@@ -360,14 +363,26 @@ def test_write_conversation_replaces_runtime_rows_on_content_change(tmp_path: Pa
 def test_iter_ingest_results_sync_runs_inline_for_single_worker(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    raw_records: list[Any] = [
-        SimpleNamespace(raw_id="raw-1"),
-        SimpleNamespace(raw_id="raw-2"),
+    raw_records = [
+        RawConversationRecord(
+            raw_id="raw-1",
+            provider_name="codex",
+            source_path="/tmp/raw-1.jsonl",
+            blob_size=12,
+            acquired_at="2026-04-02T00:00:00Z",
+        ),
+        RawConversationRecord(
+            raw_id="raw-2",
+            provider_name="codex",
+            source_path="/tmp/raw-2.jsonl",
+            blob_size=12,
+            acquired_at="2026-04-02T00:00:00Z",
+        ),
     ]
     seen: list[str] = []
 
     def fake_ingest_record(
-        raw_record: SimpleNamespace,
+        raw_record: RawConversationRecord,
         archive_root_str: str,
         validation_mode: str = "strict",
         measure_ingest_result_size: bool = False,
@@ -473,7 +488,7 @@ async def test_refresh_session_products_bulk_dedupes_related_refreshes(
     async def _connection() -> AsyncIterator[SimpleNamespace]:
         yield fake_conn
 
-    fake_backend = cast(Any, SimpleNamespace(connection=_connection))
+    fake_backend = cast(SQLiteBackend, SimpleNamespace(connection=_connection))
 
     async def _fake_apply(conn: object, conversation_ids: list[str], *, transaction_depth: int) -> object:
         del conn, transaction_depth
@@ -687,13 +702,13 @@ def test_build_batch_memory_observation_separates_lifetime_peak_from_batch_growt
 async def test_persist_batch_raw_state_updates_uses_one_typed_update_per_raw() -> None:
     update_raw_state = AsyncMock()
     repository = SimpleNamespace(update_raw_state=update_raw_state)
-    service = cast(Any, SimpleNamespace(repository=repository))
+    service = cast(ParsingService, SimpleNamespace(repository=repository))
 
     @asynccontextmanager
     async def _bulk_connection() -> AsyncIterator[None]:
         yield
 
-    backend = cast(Any, SimpleNamespace(bulk_connection=_bulk_connection))
+    backend = cast(SQLiteBackend, SimpleNamespace(bulk_connection=_bulk_connection))
     outcomes = {
         "raw-success": _RawIngestOutcome(
             raw_id="raw-success",
@@ -740,13 +755,13 @@ async def test_persist_batch_raw_state_updates_uses_one_typed_update_per_raw() -
 async def test_persist_batch_raw_state_updates_preserves_validation_only_failure_without_quarantine() -> None:
     update_raw_state = AsyncMock()
     repository = SimpleNamespace(update_raw_state=update_raw_state)
-    service = cast(Any, SimpleNamespace(repository=repository))
+    service = cast(ParsingService, SimpleNamespace(repository=repository))
 
     @asynccontextmanager
     async def _bulk_connection() -> AsyncIterator[None]:
         yield
 
-    backend = cast(Any, SimpleNamespace(bulk_connection=_bulk_connection))
+    backend = cast(SQLiteBackend, SimpleNamespace(bulk_connection=_bulk_connection))
     outcomes = {
         "raw-schema-invalid": _RawIngestOutcome(
             raw_id="raw-schema-invalid",

--- a/tests/unit/pipeline/test_ingestion_chaos.py
+++ b/tests/unit/pipeline/test_ingestion_chaos.py
@@ -13,11 +13,12 @@ import json
 from datetime import datetime, timezone
 from io import BytesIO
 from pathlib import Path
-from typing import Any
+from typing import cast
 
 from hypothesis import given, settings
 
 from polylogue.lib.timestamps import parse_timestamp
+from polylogue.pipeline.services.parsing import ParsingService
 from polylogue.sources.decoders import _decode_json_bytes, _iter_json_stream
 from polylogue.storage.store import RawConversationRecord
 from tests.infra.large_batches import (
@@ -31,6 +32,8 @@ from tests.infra.large_batches import (
     write_jsonl_with_bad_utf8,
 )
 from tests.infra.strategies import malformed_json_strategy
+
+TimestampInput = str | int | float | None
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -62,7 +65,7 @@ def _make_raw_record(
     )
 
 
-def _make_parsing_service(tmp_path: Path) -> Any:
+def _make_parsing_service(tmp_path: Path) -> ParsingService:
     from polylogue.config import Config
     from polylogue.pipeline.services.parsing import ParsingService
     from polylogue.storage.backends.async_sqlite import SQLiteBackend
@@ -86,13 +89,19 @@ def _jsonl_bytes(lines: list[str]) -> bytes:
     return ("\n".join(lines) + "\n").encode("utf-8")
 
 
-def _iter_jsonl_stream(data: bytes, name: str = "test.jsonl") -> list[Any]:
+def _iter_jsonl_stream(data: bytes, name: str = "test.jsonl") -> list[object]:
     """Convenience: parse JSONL bytes via _iter_json_stream and collect."""
     return list(_iter_json_stream(BytesIO(data), name))
 
 
-def _as_record(value: Any) -> dict[str, Any]:
+def _as_record(value: object) -> dict[str, object]:
     assert isinstance(value, dict)
+    return cast(dict[str, object], value)
+
+
+def _timestamp_value(record: dict[str, object]) -> TimestampInput:
+    value = record.get("timestamp")
+    assert value is None or isinstance(value, str | int | float)
     return value
 
 
@@ -166,7 +175,7 @@ class TestLargeBatchBadUtf8:
     BATCH_SIZE = 500
     CORRUPT_INDEX = 350
 
-    def test_bad_utf8_skipped_rest_processed(self, tmp_path: Any) -> None:
+    def test_bad_utf8_skipped_rest_processed(self, tmp_path: Path) -> None:
         """Pipeline skips the bad UTF-8 line, processes the rest."""
         lines = generate_large_jsonl(self.BATCH_SIZE, provider="codex")
         corrupted = corrupt_line_bad_utf8(lines, self.CORRUPT_INDEX)
@@ -184,7 +193,7 @@ class TestLargeBatchBadUtf8:
         # at least the valid lines.
         assert len(parsed) >= self.BATCH_SIZE - 1
 
-    def test_bad_utf8_no_crash(self, tmp_path: Any) -> None:
+    def test_bad_utf8_no_crash(self, tmp_path: Path) -> None:
         """No exception propagates from bad UTF-8 lines."""
         lines = generate_large_jsonl(self.BATCH_SIZE, provider="codex")
         corrupted = corrupt_line_bad_utf8(lines, self.CORRUPT_INDEX)
@@ -247,7 +256,7 @@ class TestMultipleCorruptionsInBatch:
         parsed = _iter_jsonl_stream(data)
         assert len(parsed) == self.BATCH_SIZE - len(corrupt_indices)
 
-    def test_mixed_corruption_types(self, tmp_path: Any) -> None:
+    def test_mixed_corruption_types(self, tmp_path: Path) -> None:
         """Different corruption types at different positions all handled."""
         lines = generate_large_jsonl(self.BATCH_SIZE, provider="codex")
         # Apply corruptions in reverse to preserve indices
@@ -293,7 +302,7 @@ class TestCorruptionAtBoundaries:
 class TestParsingServiceCorruption:
     """ingest_record handles partial corruption."""
 
-    def test_malformed_jsonl_line_in_codex_raw(self, tmp_path: Any) -> None:
+    def test_malformed_jsonl_line_in_codex_raw(self, tmp_path: Path) -> None:
         """Codex JSONL with 1 bad line: parsing succeeds with fewer messages."""
         from polylogue.pipeline.services.ingest_worker import ingest_record
 
@@ -307,7 +316,7 @@ class TestParsingServiceCorruption:
         if result.conversations:
             assert result.conversations[0].provider_name in ("codex", "codex-cli")
 
-    def test_truncated_jsonl_line_in_codex_raw(self, tmp_path: Any) -> None:
+    def test_truncated_jsonl_line_in_codex_raw(self, tmp_path: Path) -> None:
         """Codex JSONL with 1 truncated line: parsing succeeds."""
         from polylogue.pipeline.services.ingest_worker import ingest_record
 
@@ -319,7 +328,7 @@ class TestParsingServiceCorruption:
         result = ingest_record(record, str(tmp_path / "archive"), "off")
         assert result.error is None
 
-    def test_wrong_envelope_in_codex_raw(self, tmp_path: Any) -> None:
+    def test_wrong_envelope_in_codex_raw(self, tmp_path: Path) -> None:
         """Codex JSONL with 1 wrong-envelope line: parsing still works."""
         from polylogue.pipeline.services.ingest_worker import ingest_record
 
@@ -377,7 +386,7 @@ class TestDecodeRawPayloadCorruption:
         assert isinstance(envelope.payload, list)
         assert len(envelope.payload) == 95
 
-    def test_bad_utf8_lines_are_counted_and_salvaged(self, tmp_path: Any) -> None:
+    def test_bad_utf8_lines_are_counted_and_salvaged(self, tmp_path: Path) -> None:
         """Invalid UTF-8 lines count as malformed JSONL but do not poison the whole file."""
         from polylogue.lib.raw_payload import build_raw_payload_envelope
 
@@ -414,7 +423,7 @@ class TestTimestampEpochNearZero:
         records = patterns["epoch_near_zero"]
         for record in records:
             cast_record = _as_record(record)
-            ts = cast_record["timestamp"]
+            ts = _timestamp_value(cast_record)
             result = parse_timestamp(ts)
             assert result is not None, f"Failed to parse timestamp: {ts}"
             assert isinstance(result, datetime)
@@ -445,7 +454,7 @@ class TestTimestampY2K38:
         records = patterns["y2038_adjacent"]
         for record in records:
             cast_record = _as_record(record)
-            ts = cast_record["timestamp"]
+            ts = _timestamp_value(cast_record)
             result = parse_timestamp(ts)
             assert result is not None, f"Failed to parse timestamp: {ts}"
             assert isinstance(result, datetime)
@@ -480,7 +489,7 @@ class TestTimestampFarFuture:
         records = patterns["far_future"]
         for record in records:
             cast_record = _as_record(record)
-            ts = cast_record["timestamp"]
+            ts = _timestamp_value(cast_record)
             result = parse_timestamp(ts)
             assert result is not None, f"Failed to parse timestamp: {ts}"
             assert isinstance(result, datetime)
@@ -511,7 +520,7 @@ class TestTimestampMixedFormats:
         parsed_timestamps = []
         for record in records:
             cast_record = _as_record(record)
-            ts = cast_record["timestamp"]
+            ts = _timestamp_value(cast_record)
             result = parse_timestamp(ts)
             assert result is not None, f"Failed to parse timestamp: {ts}"
             parsed_timestamps.append(result)
@@ -566,7 +575,7 @@ class TestTimestampMissing:
         results = []
         for record in records:
             cast_record = _as_record(record)
-            ts = cast_record.get("timestamp")  # Key may be absent
+            ts = _timestamp_value(cast_record)
             results.append(parse_timestamp(ts))
 
         # First record has timestamp
@@ -629,7 +638,7 @@ class TestTimestampPatternsInJsonl:
         parsed = [_as_record(record) for record in _iter_jsonl_stream(data)]
         assert len(parsed) == len(records)
         for record in parsed:
-            ts = parse_timestamp(record["timestamp"])
+            ts = parse_timestamp(_timestamp_value(record))
             assert ts is not None
             assert ts.year == 1970
 
@@ -643,7 +652,7 @@ class TestTimestampPatternsInJsonl:
         parsed = [_as_record(record) for record in _iter_jsonl_stream(data)]
         assert len(parsed) == len(records)
         for record in parsed:
-            ts = parse_timestamp(record["timestamp"])
+            ts = parse_timestamp(_timestamp_value(record))
             assert ts is not None
             assert ts.year == 2038
 
@@ -657,7 +666,7 @@ class TestTimestampPatternsInJsonl:
         parsed = [_as_record(record) for record in _iter_jsonl_stream(data)]
         assert len(parsed) == len(records)
         for record in parsed:
-            ts = parse_timestamp(record["timestamp"])
+            ts = parse_timestamp(_timestamp_value(record))
             assert ts is not None
 
     def test_mixed_formats_through_stream(self) -> None:
@@ -670,7 +679,7 @@ class TestTimestampPatternsInJsonl:
         parsed = [_as_record(record) for record in _iter_jsonl_stream(data)]
         assert len(parsed) == len(records)
         for record in parsed:
-            ts = parse_timestamp(record["timestamp"])
+            ts = parse_timestamp(_timestamp_value(record))
             assert ts is not None
 
     def test_missing_timestamps_through_stream(self) -> None:
@@ -683,7 +692,7 @@ class TestTimestampPatternsInJsonl:
         parsed = [_as_record(record) for record in _iter_jsonl_stream(data)]
         assert len(parsed) == len(records)
         # Only records with timestamps should parse; missing should be None
-        timestamps = [parse_timestamp(r.get("timestamp")) for r in parsed]
+        timestamps = [parse_timestamp(_timestamp_value(r)) for r in parsed]
         assert timestamps[0] is not None
         assert timestamps[1] is None
         assert timestamps[2] is not None
@@ -697,7 +706,7 @@ class TestTimestampPatternsInJsonl:
 class TestRerunIdempotency:
     """Running the same batch twice produces identical records, no duplicates."""
 
-    def test_same_batch_twice_produces_same_records(self, tmp_path: Any) -> None:
+    def test_same_batch_twice_produces_same_records(self, tmp_path: Path) -> None:
         """Parsing the same raw record twice yields identical results."""
         from polylogue.pipeline.services.ingest_worker import ingest_record
 
@@ -715,7 +724,7 @@ class TestRerunIdempotency:
             assert conv1.provider_name == conv2.provider_name
             assert len(conv1.message_tuples) == len(conv2.message_tuples)
 
-    def test_reparse_with_corruption_then_clean(self, tmp_path: Any) -> None:
+    def test_reparse_with_corruption_then_clean(self, tmp_path: Path) -> None:
         """First parse with corruption, second with clean data — both succeed."""
         from polylogue.pipeline.services.ingest_worker import ingest_record
 

--- a/tests/unit/pipeline/test_observers.py
+++ b/tests/unit/pipeline/test_observers.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from polylogue.pipeline.observers import (
@@ -13,6 +12,7 @@ from polylogue.pipeline.observers import (
     WebhookObserver,
 )
 from polylogue.pipeline.services.rendering import RenderService
+from polylogue.storage.backends.async_sqlite import SQLiteBackend
 
 
 def _make_result(count: int = 5) -> MagicMock:
@@ -28,7 +28,7 @@ def _make_result(count: int = 5) -> MagicMock:
 
 
 class TestNotificationObserver:
-    def test_sends_notification(self: Any) -> None:
+    def test_sends_notification(self: object) -> None:
         with patch("subprocess.run") as mock_run:
             handler = NotificationObserver()
             handler.on_completed(_make_result(3))
@@ -37,13 +37,13 @@ class TestNotificationObserver:
             assert "notify-send" in args
             assert "3" in str(args)
 
-    def test_skips_when_no_new(self: Any) -> None:
+    def test_skips_when_no_new(self: object) -> None:
         with patch("subprocess.run") as mock_run:
             handler = NotificationObserver()
             handler.on_completed(_make_result(0))
             mock_run.assert_not_called()
 
-    def test_handles_missing_notifysend(self: Any) -> None:
+    def test_handles_missing_notifysend(self: object) -> None:
         with patch("subprocess.run", side_effect=FileNotFoundError):
             handler = NotificationObserver()
             handler.on_completed(_make_result(1))  # Should not raise
@@ -54,8 +54,8 @@ class TestWebhookObserver:
 
     _FAKE_ADDRINFO = [(2, 1, 6, "", ("93.184.216.34", 80))]
 
-    def test_posts_to_url(self: Any) -> None:
-        with patch("polylogue.pipeline.observers.socket.getaddrinfo", return_value=self._FAKE_ADDRINFO):
+    def test_posts_to_url(self: object) -> None:
+        with patch("polylogue.pipeline.observers.socket.getaddrinfo", return_value=TestWebhookObserver._FAKE_ADDRINFO):
             with patch("urllib.request.urlopen") as mock_urlopen:
                 handler = WebhookObserver("http://example.com/hook")
                 handler.on_completed(_make_result(7))
@@ -64,10 +64,10 @@ class TestWebhookObserver:
                 assert req.get_full_url() == "http://example.com/hook"
                 assert req.get_method() == "POST"
 
-    def test_payload_format(self: Any) -> None:
+    def test_payload_format(self: object) -> None:
         import json
 
-        with patch("polylogue.pipeline.observers.socket.getaddrinfo", return_value=self._FAKE_ADDRINFO):
+        with patch("polylogue.pipeline.observers.socket.getaddrinfo", return_value=TestWebhookObserver._FAKE_ADDRINFO):
             with patch("urllib.request.urlopen"):
                 with patch("urllib.request.Request") as mock_req:
                     handler = WebhookObserver("http://example.com/hook")
@@ -79,22 +79,22 @@ class TestWebhookObserver:
                     assert payload["new_conversations"] == 7
                     assert payload["changed_conversations"] == 0
 
-    def test_skips_when_no_new(self: Any) -> None:
-        with patch("polylogue.pipeline.observers.socket.getaddrinfo", return_value=self._FAKE_ADDRINFO):
+    def test_skips_when_no_new(self: object) -> None:
+        with patch("polylogue.pipeline.observers.socket.getaddrinfo", return_value=TestWebhookObserver._FAKE_ADDRINFO):
             with patch("urllib.request.urlopen") as mock_urlopen:
                 handler = WebhookObserver("http://example.com/hook")
                 handler.on_completed(_make_result(0))
                 mock_urlopen.assert_not_called()
 
-    def test_logs_on_failure(self: Any) -> None:
-        with patch("polylogue.pipeline.observers.socket.getaddrinfo", return_value=self._FAKE_ADDRINFO):
+    def test_logs_on_failure(self: object) -> None:
+        with patch("polylogue.pipeline.observers.socket.getaddrinfo", return_value=TestWebhookObserver._FAKE_ADDRINFO):
             with patch("urllib.request.urlopen", side_effect=ConnectionError("refused")):
                 handler = WebhookObserver("http://example.com/hook")
                 handler.on_completed(_make_result(1))  # Should not raise
 
 
 class TestExecObserver:
-    def test_executes_command(self: Any) -> None:
+    def test_executes_command(self: object) -> None:
         with patch("subprocess.run") as mock_run:
             handler = ExecObserver("echo hello")
             handler.on_completed(_make_result(3))
@@ -107,7 +107,7 @@ class TestExecObserver:
             assert call_kwargs["env"]["POLYLOGUE_NEW_CONVERSATION_COUNT"] == "3"
             assert call_kwargs["env"]["POLYLOGUE_CHANGED_CONVERSATION_COUNT"] == "0"
 
-    def test_skips_when_no_new(self: Any) -> None:
+    def test_skips_when_no_new(self: object) -> None:
         with patch("subprocess.run") as mock_run:
             handler = ExecObserver("echo hello")
             handler.on_completed(_make_result(0))
@@ -115,7 +115,7 @@ class TestExecObserver:
 
 
 class TestCompositeObserver:
-    def test_dispatches_to_all_observers(self: Any) -> None:
+    def test_dispatches_to_all_observers(self: object) -> None:
         h1 = MagicMock()
         h2 = MagicMock()
         composite = CompositeObserver([h1, h2])
@@ -124,7 +124,7 @@ class TestCompositeObserver:
         h1.on_completed.assert_called_once_with(result)
         h2.on_completed.assert_called_once_with(result)
 
-    def test_continues_on_observer_failure(self: Any) -> None:
+    def test_continues_on_observer_failure(self: object) -> None:
         h1 = MagicMock()
         h1.on_completed.side_effect = RuntimeError("boom")
         h2 = MagicMock()
@@ -134,7 +134,7 @@ class TestCompositeObserver:
         # h2 should still be called even though h1 raised
         h2.on_completed.assert_called_once_with(result)
 
-    def test_empty_observer_list(self: Any) -> None:
+    def test_empty_observer_list(self: object) -> None:
         composite = CompositeObserver([])
         composite.on_completed(_make_result(5))  # Should not raise
 
@@ -147,7 +147,7 @@ class TestCompositeObserver:
 class TestRenderProgressCallback:
     """Verify progress_callback fires during rendering."""
 
-    async def test_callback_called_for_each_conversation(self: Any) -> None:
+    async def test_callback_called_for_each_conversation(self: object) -> None:
         """progress_callback is invoked once per rendered conversation."""
         # Mock renderer that succeeds
         mock_renderer = AsyncMock()
@@ -164,16 +164,17 @@ class TestRenderProgressCallback:
         assert result.rendered_count == 3
         assert callback.call_count == 3
 
-    async def test_callback_desc_format(self: Any) -> None:
+    async def test_callback_desc_format(self: object) -> None:
         """progress_callback desc follows 'Rendering: N/total' format."""
         mock_renderer = AsyncMock()
         mock_renderer.render = AsyncMock()
 
         service = RenderService(renderer=mock_renderer, render_root=Path("/tmp/render"))
 
-        descs = []
+        descs: list[str | None] = []
 
-        def capture_callback(amount: Any, desc: Any = None) -> None:
+        def capture_callback(amount: int, desc: str | None = None) -> None:
+            del amount
             descs.append(desc)
 
         await service.render_conversations(
@@ -184,9 +185,11 @@ class TestRenderProgressCallback:
         # All desc values should match the "Rendering: N/2" pattern
         assert all(d is not None and d.startswith("Rendering:") for d in descs)
         # The last one should show total completed
-        assert "2/2" in descs[-1]
+        last_desc = descs[-1]
+        assert last_desc is not None
+        assert "2/2" in last_desc
 
-    async def test_callback_fires_on_failure_too(self: Any) -> None:
+    async def test_callback_fires_on_failure_too(self: object) -> None:
         """progress_callback fires even when rendering fails."""
         mock_renderer = AsyncMock()
         mock_renderer.render = AsyncMock(side_effect=[None, RuntimeError("render failed"), None])
@@ -204,7 +207,7 @@ class TestRenderProgressCallback:
         assert result.rendered_count == 2
         assert len(result.failures) == 1
 
-    async def test_no_callback_is_safe(self: Any) -> None:
+    async def test_no_callback_is_safe(self: object) -> None:
         """Rendering works without a progress_callback."""
         mock_renderer = AsyncMock()
         mock_renderer.render = AsyncMock()
@@ -214,16 +217,17 @@ class TestRenderProgressCallback:
         result = await service.render_conversations(["conv-1"])
         assert result.rendered_count == 1
 
-    async def test_callback_amount_is_one(self: Any) -> None:
+    async def test_callback_amount_is_one(self: object) -> None:
         """Each callback invocation passes amount=1."""
         mock_renderer = AsyncMock()
         mock_renderer.render = AsyncMock()
 
         service = RenderService(renderer=mock_renderer, render_root=Path("/tmp/render"))
 
-        amounts = []
+        amounts: list[int] = []
 
-        def capture(amount: Any, desc: Any = None) -> None:
+        def capture(amount: int, desc: str | None = None) -> None:
+            del desc
             amounts.append(amount)
 
         await service.render_conversations(
@@ -236,7 +240,7 @@ class TestRenderProgressCallback:
 class TestIndexProgressCallback:
     """Verify progress_callback firing during indexing is safe."""
 
-    async def test_index_update_without_callback_succeeds(self: Any, sqlite_backend: Any) -> None:
+    async def test_index_update_without_callback_succeeds(self: object, sqlite_backend: SQLiteBackend) -> None:
         """Index update works without a progress_callback."""
         from polylogue.config import Config
         from polylogue.pipeline.services.indexing import IndexService
@@ -251,7 +255,7 @@ class TestIndexProgressCallback:
         result = await service.update_index([])
         assert result is True
 
-    async def test_index_rebuild_without_callback_succeeds(self: Any, sqlite_backend: Any) -> None:
+    async def test_index_rebuild_without_callback_succeeds(self: object, sqlite_backend: SQLiteBackend) -> None:
         """Index rebuild works without a progress_callback."""
         from polylogue.config import Config
         from polylogue.pipeline.services.indexing import IndexService
@@ -270,7 +274,7 @@ class TestIndexProgressCallback:
 class TestCallbackEdgeCases:
     """Edge cases for progress callback handling."""
 
-    async def test_null_callback_safety(self: Any) -> None:
+    async def test_null_callback_safety(self: object) -> None:
         """Explicitly passing None as callback doesn't raise."""
         mock_renderer = AsyncMock()
         mock_renderer.render = AsyncMock()
@@ -284,7 +288,7 @@ class TestCallbackEdgeCases:
         )
         assert result.rendered_count == 2
 
-    async def test_callback_exception_does_not_crash_render(self: Any) -> None:
+    async def test_callback_exception_does_not_crash_render(self: object) -> None:
         """If the callback itself raises, rendering should still complete.
 
         Note: Current implementation does NOT catch callback exceptions
@@ -297,7 +301,8 @@ class TestCallbackEdgeCases:
 
         service = RenderService(renderer=mock_renderer, render_root=Path("/tmp/render"))
 
-        def bad_callback(amount: Any, desc: Any = None) -> None:
+        def bad_callback(amount: int, desc: str | None = None) -> None:
+            del amount, desc
             raise RuntimeError("callback exploded")
 
         # The callback exception propagates — verify it raises
@@ -307,7 +312,7 @@ class TestCallbackEdgeCases:
                 progress_callback=bad_callback,
             )
 
-    async def test_empty_conversation_list(self: Any) -> None:
+    async def test_empty_conversation_list(self: object) -> None:
         """Rendering zero conversations returns clean result with no callbacks."""
         mock_renderer = AsyncMock()
         mock_renderer.render = AsyncMock()

--- a/tests/unit/pipeline/test_prepare.py
+++ b/tests/unit/pipeline/test_prepare.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any
 
 import pytest
 
@@ -10,6 +9,7 @@ from polylogue.paths import is_within_root
 from polylogue.pipeline.prepare import RecordBundle, save_bundle
 from polylogue.rendering.renderers import HTMLRenderer
 from polylogue.storage.backends.connection import open_connection
+from polylogue.storage.repository import ConversationRepository
 from polylogue.storage.store import ConversationRecord
 from tests.infra.storage_records import make_attachment, make_conversation, make_message
 
@@ -18,7 +18,10 @@ def _conversation_record() -> ConversationRecord:
     return make_conversation("conv:hash", provider_name="codex", title="Demo")
 
 
-async def test_ingest_idempotent(workspace_env: dict[str, Path], storage_repository: Any) -> None:
+async def test_ingest_idempotent(
+    workspace_env: dict[str, Path],
+    storage_repository: ConversationRepository,
+) -> None:
     bundle = RecordBundle(
         conversation=_conversation_record(),
         messages=[make_message("msg:hash", "conv:hash", text="hello")],
@@ -33,7 +36,10 @@ async def test_ingest_idempotent(workspace_env: dict[str, Path], storage_reposit
     assert second.skipped_messages == 1
 
 
-async def test_render_writes_markdown(workspace_env: dict[str, Path], storage_repository: Any) -> None:
+async def test_render_writes_markdown(
+    workspace_env: dict[str, Path],
+    storage_repository: ConversationRepository,
+) -> None:
     archive_root = workspace_env["archive_root"]
     bundle = RecordBundle(
         conversation=_conversation_record(),
@@ -52,7 +58,10 @@ async def test_render_writes_markdown(workspace_env: dict[str, Path], storage_re
     assert "hello" in md_path.read_text(encoding="utf-8")
 
 
-async def test_render_escapes_html(workspace_env: dict[str, Path], storage_repository: Any) -> None:
+async def test_render_escapes_html(
+    workspace_env: dict[str, Path],
+    storage_repository: ConversationRepository,
+) -> None:
     archive_root = workspace_env["archive_root"]
     bundle = RecordBundle(
         conversation=make_conversation("conv-html", provider_name="codex", title="<script>alert(1)</script>"),
@@ -70,7 +79,10 @@ async def test_render_escapes_html(workspace_env: dict[str, Path], storage_repos
     assert "&lt;script&gt;" in html_text
 
 
-async def test_render_sanitizes_paths(workspace_env: dict[str, Path], storage_repository: Any) -> None:
+async def test_render_sanitizes_paths(
+    workspace_env: dict[str, Path],
+    storage_repository: ConversationRepository,
+) -> None:
     """Test that render paths are sanitized even with path-like conversation IDs.
 
     Note: Invalid provider names are now rejected at the validation layer, so we
@@ -94,7 +106,7 @@ async def test_render_sanitizes_paths(workspace_env: dict[str, Path], storage_re
 
 async def test_render_includes_orphan_attachments(
     workspace_env: dict[str, Path],
-    storage_repository: Any,
+    storage_repository: ConversationRepository,
 ) -> None:
     archive_root = workspace_env["archive_root"]
     bundle = RecordBundle(
@@ -122,7 +134,10 @@ async def test_render_includes_orphan_attachments(
     assert "- Attachment: notes.txt" in markdown
 
 
-async def test_ingest_updates_metadata(workspace_env: dict[str, Path], storage_repository: Any) -> None:
+async def test_ingest_updates_metadata(
+    workspace_env: dict[str, Path],
+    storage_repository: ConversationRepository,
+) -> None:
     bundle = RecordBundle(
         conversation=make_conversation(
             "conv-update",
@@ -168,7 +183,7 @@ async def test_ingest_updates_metadata(workspace_env: dict[str, Path], storage_r
 
 async def test_ingest_updates_fields_without_hash_changes(
     workspace_env: dict[str, Path],
-    storage_repository: Any,
+    storage_repository: ConversationRepository,
 ) -> None:
     """Conversation record fields (title, updated_at, provider_meta) should
     update via UPSERT even when the content_hash is unchanged.
@@ -227,7 +242,7 @@ async def test_ingest_updates_fields_without_hash_changes(
 
 async def test_ingest_removes_missing_attachments(
     workspace_env: dict[str, Path],
-    storage_repository: Any,
+    storage_repository: ConversationRepository,
 ) -> None:
     bundle = RecordBundle(
         conversation=_conversation_record(),

--- a/tests/unit/pipeline/test_prepare_records.py
+++ b/tests/unit/pipeline/test_prepare_records.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterator
 from pathlib import Path
-from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -13,6 +12,7 @@ from polylogue.lib.roles import Role
 from polylogue.pipeline.prepare import prepare_records
 from polylogue.pipeline.prepare_models import PersistedConversationResult
 from polylogue.pipeline.services.validation import ValidationService
+from polylogue.schemas import ValidationResult
 from polylogue.sources.parsers.base import ParsedAttachment, ParsedConversation, ParsedMessage
 from polylogue.storage.backends.async_sqlite import SQLiteBackend
 from polylogue.storage.repository import ConversationRepository
@@ -611,7 +611,6 @@ class TestValidationService:
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        from polylogue.schemas import ValidationResult
         from polylogue.storage.blob_store import get_blob_store
 
         raw_content = (
@@ -643,7 +642,7 @@ class TestValidationService:
                 self.max_samples_seen = max_samples
                 return [item for item in payload if isinstance(item, dict)] if isinstance(payload, list) else [payload]
 
-            def validate(self, _sample: object) -> Any:
+            def validate(self, _sample: object) -> ValidationResult:
                 return ValidationResult(is_valid=True)
 
         capturing = _CapturingValidator()
@@ -660,7 +659,6 @@ class TestValidationService:
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        from polylogue.schemas import ValidationResult
         from polylogue.storage.blob_store import get_blob_store
 
         raw_content = (b'{"type":"session_meta"}\n' * 1024) + b"not json at all\n"
@@ -686,7 +684,7 @@ class TestValidationService:
             def validation_samples(self, payload: object, max_samples: int = 16) -> list[object]:
                 return [item for item in payload if isinstance(item, dict)] if isinstance(payload, list) else [payload]
 
-            def validate(self, _sample: object) -> Any:
+            def validate(self, _sample: object) -> ValidationResult:
                 return ValidationResult(is_valid=True)
 
         monkeypatch.setenv("POLYLOGUE_SCHEMA_VALIDATION", "strict")
@@ -706,7 +704,6 @@ class TestValidationService:
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        from polylogue.schemas import ValidationResult
         from polylogue.storage.blob_store import get_blob_store
 
         blob_store = get_blob_store()
@@ -741,7 +738,7 @@ class TestValidationService:
             def validation_samples(self, payload: object, max_samples: int = 16) -> list[object]:
                 return [payload]
 
-            def validate(self, _sample: object) -> Any:
+            def validate(self, _sample: object) -> ValidationResult:
                 return ValidationResult(is_valid=True)
 
         monkeypatch.setattr(
@@ -757,7 +754,6 @@ class TestValidationService:
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        from polylogue.schemas import ValidationResult
         from polylogue.storage.blob_store import get_blob_store
 
         raw_content = b'[{"id":"conv-1","mapping":{}}]'
@@ -784,7 +780,7 @@ class TestValidationService:
             def validation_samples(self, payload: object, max_samples: int = 16) -> list[object]:
                 return [payload]
 
-            def validate(self, _sample: object) -> Any:
+            def validate(self, _sample: object) -> ValidationResult:
                 return ValidationResult(is_valid=True)
 
         monkeypatch.setattr(

--- a/tests/unit/pipeline/test_render_service.py
+++ b/tests/unit/pipeline/test_render_service.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 from collections.abc import AsyncGenerator
 from pathlib import Path
-from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -93,7 +92,8 @@ class TestRenderService:
         """Render errors collected in failures list."""
         renderer = AsyncMock()
 
-        async def render_side_effect(conv_id: Any, root: Any) -> None:
+        async def render_side_effect(conv_id: str, root: Path) -> None:
+            del root
             if conv_id == "conv-bad":
                 raise ValueError("render exploded")
 
@@ -116,8 +116,9 @@ class TestRenderService:
 
         renderer = AsyncMock()
 
-        async def tracked_render(conv_id: Any, root: Any) -> None:
+        async def tracked_render(conv_id: str, root: Path) -> None:
             nonlocal max_concurrent, current_concurrent
+            del conv_id, root
             async with lock:
                 current_concurrent += 1
                 max_concurrent = max(max_concurrent, current_concurrent)
@@ -158,7 +159,8 @@ class TestRenderService:
         service = RenderService(renderer=renderer, render_root=Path("/tmp/render"))
         descriptions: list[str | None] = []
 
-        def capture(amount: Any, desc: Any = None) -> None:
+        def capture(amount: int, desc: str | None = None) -> None:
+            del amount
             descriptions.append(desc)
 
         await service.render_conversations(
@@ -206,7 +208,8 @@ class TestRenderService:
         service = RenderService(renderer=renderer, render_root=Path("/tmp/render"))
         amounts: list[int] = []
 
-        def capture(amount: Any, desc: Any = None) -> None:
+        def capture(amount: int, desc: str | None = None) -> None:
+            del desc
             amounts.append(amount)
 
         await service.render_conversations(

--- a/tests/unit/pipeline/test_roundtrip_hydration_laws.py
+++ b/tests/unit/pipeline/test_roundtrip_hydration_laws.py
@@ -8,16 +8,21 @@ in the suite — a failure here means the archive silently loses data.
 from __future__ import annotations
 
 import json
+import sqlite3
 from collections import Counter
 from pathlib import Path
-from typing import Any
+from typing import TypeAlias
 
 import pytest
 from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 
+from polylogue.lib.conversation_models import Conversation
+from polylogue.pipeline.prepare_models import TransformResult
 from polylogue.pipeline.prepare_transform import transform_to_records
+from polylogue.schemas.synthetic.core import SyntheticCorpus
 from polylogue.sources.dispatch import detect_provider, parse_payload
+from polylogue.sources.parsers.base import ParsedConversation
 from polylogue.storage.hydrators import conversation_from_records
 from polylogue.storage.store import AttachmentRecord
 from tests.infra.storage_records import db_setup
@@ -27,20 +32,22 @@ from tests.infra.storage_records import db_setup
 # ---------------------------------------------------------------------------
 
 PROVIDERS_WITH_SYNTHETIC = ("chatgpt", "claude-code", "claude-ai", "codex", "gemini")
+SyntheticPayload: TypeAlias = tuple[str, bytes, str]
 
-_corpus_cache: dict[str, object] = {}
+_corpus_cache: dict[str, SyntheticCorpus] = {}
 
 
-def _get_corpus(provider: str) -> Any:
+def _get_corpus(provider: str) -> SyntheticCorpus:
     if provider not in _corpus_cache:
-        from polylogue.schemas.synthetic.core import SyntheticCorpus
-
         _corpus_cache[provider] = SyntheticCorpus.for_provider(provider)
     return _corpus_cache[provider]
 
 
 @st.composite
-def synthetic_payload(draw: Any, providers: Any = PROVIDERS_WITH_SYNTHETIC) -> Any:
+def synthetic_payload(
+    draw: st.DrawFn,
+    providers: tuple[str, ...] = PROVIDERS_WITH_SYNTHETIC,
+) -> SyntheticPayload:
     """Generate a (provider_name, raw_bytes, unique_id) tuple from synthetic corpus."""
     provider = draw(st.sampled_from(providers))
     seed = draw(st.integers(min_value=0, max_value=2**16))
@@ -55,7 +62,7 @@ def synthetic_payload(draw: Any, providers: Any = PROVIDERS_WITH_SYNTHETIC) -> A
 # ---------------------------------------------------------------------------
 
 
-def _decode_payload(raw_bytes: bytes) -> Any:
+def _decode_payload(raw_bytes: bytes) -> object:
     """Decode raw bytes, handling both JSON and JSONL (Codex/Claude Code)."""
     text = raw_bytes.decode("utf-8")
     try:
@@ -65,7 +72,12 @@ def _decode_payload(raw_bytes: bytes) -> Any:
         return lines
 
 
-def _parse_and_transform(provider_name: str, raw_bytes: bytes, archive_root: Path, unique_id: str = "default") -> Any:
+def _parse_and_transform(
+    provider_name: str,
+    raw_bytes: bytes,
+    archive_root: Path,
+    unique_id: str = "default",
+) -> tuple[ParsedConversation, TransformResult]:
     """Run the full parse → transform path, returning (parsed, transform_result)."""
     payload = _decode_payload(raw_bytes)
     detected = detect_provider(payload)
@@ -79,7 +91,7 @@ def _parse_and_transform(provider_name: str, raw_bytes: bytes, archive_root: Pat
     return parsed, result
 
 
-def _save_and_hydrate(result: Any, db_conn: Any) -> Any:
+def _save_and_hydrate(result: TransformResult, db_conn: sqlite3.Connection) -> Conversation:
     """Save records to DB and hydrate back to domain model."""
     from polylogue.storage.backends.queries.mappers_archive import (
         _row_to_conversation,
@@ -121,7 +133,7 @@ class TestMessageCountPreservation:
         suppress_health_check=[HealthCheck.too_slow, HealthCheck.function_scoped_fixture],
         deadline=None,
     )
-    def test_message_count_preserved(self: Any, data: Any, workspace_env: Any) -> None:
+    def test_message_count_preserved(self: object, data: SyntheticPayload, workspace_env: dict[str, Path]) -> None:
         provider_name, raw_bytes, unique_id = data
         parsed, result = _parse_and_transform(provider_name, raw_bytes, workspace_env["archive_root"], unique_id)
 
@@ -135,7 +147,9 @@ class TestMessageCountPreservation:
         suppress_health_check=[HealthCheck.too_slow, HealthCheck.function_scoped_fixture],
         deadline=None,
     )
-    def test_message_count_survives_save_hydrate(self: Any, data: Any, workspace_env: Any) -> None:
+    def test_message_count_survives_save_hydrate(
+        self: object, data: SyntheticPayload, workspace_env: dict[str, Path]
+    ) -> None:
         provider_name, raw_bytes, unique_id = data
         db_path = db_setup(workspace_env)
 
@@ -162,7 +176,7 @@ class TestRolePreservation:
         suppress_health_check=[HealthCheck.too_slow, HealthCheck.function_scoped_fixture],
         deadline=None,
     )
-    def test_role_multiset_preserved(self: Any, data: Any, workspace_env: Any) -> None:
+    def test_role_multiset_preserved(self: object, data: SyntheticPayload, workspace_env: dict[str, Path]) -> None:
         provider_name, raw_bytes, unique_id = data
         db_path = db_setup(workspace_env)
 
@@ -189,7 +203,7 @@ class TestTitleStability:
         suppress_health_check=[HealthCheck.too_slow, HealthCheck.function_scoped_fixture],
         deadline=None,
     )
-    def test_title_preserved(self: Any, data: Any, workspace_env: Any) -> None:
+    def test_title_preserved(self: object, data: SyntheticPayload, workspace_env: dict[str, Path]) -> None:
         provider_name, raw_bytes, unique_id = data
         db_path = db_setup(workspace_env)
 
@@ -214,7 +228,7 @@ class TestContentHashDeterminism:
         suppress_health_check=[HealthCheck.too_slow, HealthCheck.function_scoped_fixture],
         deadline=None,
     )
-    def test_same_payload_same_hash(self: Any, data: Any, tmp_path: Any) -> None:
+    def test_same_payload_same_hash(self: object, data: SyntheticPayload, tmp_path: Path) -> None:
         provider_name, raw_bytes, unique_id = data
         _, result1 = _parse_and_transform(provider_name, raw_bytes, tmp_path, unique_id)
         _, result2 = _parse_and_transform(provider_name, raw_bytes, tmp_path, unique_id)
@@ -234,7 +248,7 @@ class TestIdempotentReimport:
         suppress_health_check=[HealthCheck.too_slow, HealthCheck.function_scoped_fixture],
         deadline=None,
     )
-    def test_second_import_is_noop(self: Any, data: Any, workspace_env: Any) -> None:
+    def test_second_import_is_noop(self: object, data: SyntheticPayload, workspace_env: dict[str, Path]) -> None:
         provider_name, raw_bytes, unique_id = data
         db_path = db_setup(workspace_env)
 
@@ -275,7 +289,7 @@ class TestProviderIdentity:
         suppress_health_check=[HealthCheck.too_slow, HealthCheck.function_scoped_fixture],
         deadline=None,
     )
-    def test_provider_preserved(self: Any, data: Any, workspace_env: Any) -> None:
+    def test_provider_preserved(self: object, data: SyntheticPayload, workspace_env: dict[str, Path]) -> None:
         provider_name, raw_bytes, unique_id = data
         db_path = db_setup(workspace_env)
 
@@ -302,7 +316,7 @@ class TestConversationIdDeterminism:
         suppress_health_check=[HealthCheck.too_slow, HealthCheck.function_scoped_fixture],
         deadline=None,
     )
-    def test_same_payload_same_cid(self: Any, data: Any, tmp_path: Any) -> None:
+    def test_same_payload_same_cid(self: object, data: SyntheticPayload, tmp_path: Path) -> None:
         provider_name, raw_bytes, unique_id = data
         _, result1 = _parse_and_transform(provider_name, raw_bytes, tmp_path, unique_id)
         _, result2 = _parse_and_transform(provider_name, raw_bytes, tmp_path, unique_id)
@@ -316,7 +330,7 @@ class TestConversationIdDeterminism:
 
 
 @pytest.mark.parametrize("provider_name", PROVIDERS_WITH_SYNTHETIC)
-def test_provider_completes_full_roundtrip(provider_name: Any, workspace_env: Any) -> None:
+def test_provider_completes_full_roundtrip(provider_name: str, workspace_env: dict[str, Path]) -> None:
     """Each provider can complete generate → parse → transform → save → hydrate."""
     corpus = _get_corpus(provider_name)
     raw_items = corpus.generate(count=1, seed=42)

--- a/tests/unit/pipeline/test_stage_independence.py
+++ b/tests/unit/pipeline/test_stage_independence.py
@@ -8,7 +8,6 @@ input is handled cleanly.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
 
 import pytest
 
@@ -57,7 +56,7 @@ class TestAcquisitionStageIndependence:
     """The acquire stage stores raw bytes without parsing."""
 
     @pytest.mark.asyncio
-    async def test_acquire_runs_independently(self, tmp_path: Path, workspace_env: Any) -> None:
+    async def test_acquire_runs_independently(self, tmp_path: Path, workspace_env: dict[str, Path]) -> None:
         """Acquire stage completes without downstream stages."""
         from polylogue.config import Source
         from polylogue.pipeline.services.acquisition import AcquisitionService
@@ -73,7 +72,7 @@ class TestAcquisitionStageIndependence:
         await backend.close()
 
     @pytest.mark.asyncio
-    async def test_acquire_idempotent(self, tmp_path: Path, workspace_env: Any) -> None:
+    async def test_acquire_idempotent(self, tmp_path: Path, workspace_env: dict[str, Path]) -> None:
         """Running acquire twice does not create duplicates."""
         from polylogue.config import Source
         from polylogue.pipeline.services.acquisition import AcquisitionService
@@ -93,7 +92,7 @@ class TestAcquisitionStageIndependence:
         await backend.close()
 
     @pytest.mark.asyncio
-    async def test_acquire_empty_source(self, tmp_path: Path, workspace_env: Any) -> None:
+    async def test_acquire_empty_source(self, tmp_path: Path, workspace_env: dict[str, Path]) -> None:
         """Acquire with no source files completes cleanly."""
         from polylogue.pipeline.services.acquisition import AcquisitionService
 
@@ -115,7 +114,7 @@ class TestValidationStageIndependence:
     """The validate stage runs against raw records in DB."""
 
     @pytest.mark.asyncio
-    async def test_validate_empty(self, tmp_path: Path, workspace_env: Any) -> None:
+    async def test_validate_empty(self, tmp_path: Path, workspace_env: dict[str, Path]) -> None:
         """Validate with no raw IDs completes cleanly."""
         from polylogue.pipeline.services.validation import ValidationService
 
@@ -137,7 +136,7 @@ class TestParseStageIndependence:
     """The parse stage converts raw records to conversations."""
 
     @pytest.mark.asyncio
-    async def test_parse_empty(self, tmp_path: Path, workspace_env: Any) -> None:
+    async def test_parse_empty(self, tmp_path: Path, workspace_env: dict[str, Path]) -> None:
         """Parse with no sources (empty) completes cleanly."""
         from polylogue.config import Config
         from polylogue.pipeline.services.parsing import ParsingService
@@ -166,7 +165,7 @@ class TestParseStageIndependence:
         await backend.close()
 
     @pytest.mark.asyncio
-    async def test_parse_from_raw_empty(self, tmp_path: Path, workspace_env: Any) -> None:
+    async def test_parse_from_raw_empty(self, tmp_path: Path, workspace_env: dict[str, Path]) -> None:
         """Parse from raw with no raw IDs completes cleanly."""
         from polylogue.config import Config
         from polylogue.pipeline.services.parsing import ParsingService
@@ -203,7 +202,7 @@ class TestRenderStageIndependence:
     """The render stage generates output from conversations in DB."""
 
     @pytest.mark.asyncio
-    async def test_render_empty_conversation_list(self, tmp_path: Path, workspace_env: Any) -> None:
+    async def test_render_empty_conversation_list(self, tmp_path: Path, workspace_env: dict[str, Path]) -> None:
         """Render with empty conversation ID list completes cleanly."""
         from polylogue.pipeline.services.rendering import RenderService
         from polylogue.rendering.renderers import MarkdownRenderer
@@ -235,7 +234,7 @@ class TestIndexStageIndependence:
     """The index stage builds FTS and other search indices."""
 
     @pytest.mark.asyncio
-    async def test_index_empty_db(self, tmp_path: Path, workspace_env: Any) -> None:
+    async def test_index_empty_db(self, tmp_path: Path, workspace_env: dict[str, Path]) -> None:
         """Index on empty DB completes cleanly."""
         from polylogue.config import Config
         from polylogue.pipeline.services.indexing import IndexService
@@ -252,7 +251,7 @@ class TestIndexStageIndependence:
         await backend.close()
 
     @pytest.mark.asyncio
-    async def test_index_idempotent(self, tmp_path: Path, workspace_env: Any) -> None:
+    async def test_index_idempotent(self, tmp_path: Path, workspace_env: dict[str, Path]) -> None:
         """Running index twice produces the same result."""
         from polylogue.config import Config
         from polylogue.pipeline.services.indexing import IndexService
@@ -273,7 +272,7 @@ class TestIndexStageIndependence:
         await backend.close()
 
     @pytest.mark.asyncio
-    async def test_update_index_empty_ids(self, tmp_path: Path, workspace_env: Any) -> None:
+    async def test_update_index_empty_ids(self, tmp_path: Path, workspace_env: dict[str, Path]) -> None:
         """Updating index with no conversation IDs succeeds."""
         from polylogue.config import Config
         from polylogue.pipeline.services.indexing import IndexService

--- a/tests/unit/pipeline/test_watch.py
+++ b/tests/unit/pipeline/test_watch.py
@@ -2,27 +2,31 @@
 
 from __future__ import annotations
 
-from typing import Any
 from unittest.mock import MagicMock
 
 from polylogue.pipeline.observers import RunObserver
 from polylogue.pipeline.watch import WatchRunner
+from polylogue.storage.run_state import RunCounts, RunResult
 
 
-def _make_result(conversations: int = 0) -> MagicMock:
-    """Create a mock RunResult."""
-    result = MagicMock()
-    result.counts = {"conversations": conversations}
-    return result
+def _make_result(conversations: int = 0) -> RunResult:
+    """Create a minimal RunResult."""
+    return RunResult(
+        run_id="watch-test",
+        counts=RunCounts(conversations=conversations),
+        indexed=True,
+        index_error=None,
+        duration_ms=0,
+    )
 
 
 class TestWatchRunner:
-    def test_calls_sync_fn_and_observer(self) -> Any:
+    def test_calls_sync_fn_and_observer(self) -> None:
         """WatchRunner calls sync_fn and forwards completion to the observer."""
         result = _make_result(3)
         call_count = 0
 
-        def sync_fn() -> Any:
+        def sync_fn() -> RunResult:
             nonlocal call_count
             call_count += 1
             if call_count >= 2:
@@ -37,12 +41,12 @@ class TestWatchRunner:
         observer.on_completed.assert_called()
         assert observer.on_completed.call_args[0][0] is result
 
-    def test_on_idle_called_when_no_new(self) -> Any:
+    def test_on_idle_called_when_no_new(self) -> None:
         """Observer idle hook is called when no new conversations are found."""
         result = _make_result(0)
         observer = MagicMock(spec=RunObserver)
 
-        def sync_fn() -> Any:
+        def sync_fn() -> RunResult:
             runner.stop()
             return result
 
@@ -51,12 +55,12 @@ class TestWatchRunner:
 
         observer.on_idle.assert_called_once_with(result)
 
-    def test_on_idle_not_called_when_new(self) -> Any:
+    def test_on_idle_not_called_when_new(self) -> None:
         """Observer idle hook is not called when new conversations are found."""
         result = _make_result(5)
         observer = MagicMock(spec=RunObserver)
 
-        def sync_fn() -> Any:
+        def sync_fn() -> RunResult:
             runner.stop()
             return result
 
@@ -65,12 +69,12 @@ class TestWatchRunner:
 
         observer.on_idle.assert_not_called()
 
-    def test_on_error_called_on_exception(self) -> Any:
+    def test_on_error_called_on_exception(self) -> None:
         """Observer error hook receives exceptions from sync_fn."""
         call_count = 0
         observer = MagicMock(spec=RunObserver)
 
-        def sync_fn() -> Any:
+        def sync_fn() -> RunResult:
             nonlocal call_count
             call_count += 1
             if call_count >= 2:
@@ -84,11 +88,11 @@ class TestWatchRunner:
         observer.on_error.assert_called_once()
         assert isinstance(observer.on_error.call_args[0][0], RuntimeError)
 
-    def test_stop_terminates_loop(self) -> Any:
+    def test_stop_terminates_loop(self) -> None:
         """stop() causes the loop to exit."""
         call_count = 0
 
-        def sync_fn() -> Any:
+        def sync_fn() -> RunResult:
             nonlocal call_count
             call_count += 1
             if call_count >= 3:
@@ -100,11 +104,11 @@ class TestWatchRunner:
 
         assert call_count == 3
 
-    def test_keyboard_interrupt_stops_loop(self) -> Any:
+    def test_keyboard_interrupt_stops_loop(self) -> None:
         """KeyboardInterrupt stops the watch loop."""
         call_count = 0
 
-        def sync_fn() -> Any:
+        def sync_fn() -> RunResult:
             nonlocal call_count
             call_count += 1
             if call_count >= 2:
@@ -116,16 +120,16 @@ class TestWatchRunner:
 
         assert call_count == 2
 
-    def test_observer_receives_result(self) -> Any:
+    def test_observer_receives_result(self) -> None:
         """Observer receives the completed run result."""
         result = _make_result(42)
-        received: list[MagicMock] = []
+        received: list[RunResult] = []
 
         class TestObserver(RunObserver):
-            def on_completed(self, completed: Any) -> None:
+            def on_completed(self, completed: RunResult) -> None:
                 received.append(completed)
 
-        def sync_fn() -> Any:
+        def sync_fn() -> RunResult:
             runner.stop()
             return result
 


### PR DESCRIPTION
## Summary
- remove explicit dynamic typing from `tests/unit/pipeline`
- replace loose test doubles with concrete repository, backend, parsing, validation, and payload types
- keep pipeline behavior covered by the existing focused tests

## Problem
The ongoing refactor campaign is shrinking typed-test debt by eliminating explicit `Any` from test areas that exercise core archive behavior. `tests/unit/pipeline` still had broad dynamic annotations around stage services, ingestion fakes, validation stubs, and synthetic payload helpers, which weakened the value of strict mypy coverage.

Ref #281

## Solution
Typed the pipeline test contracts directly against production-facing models where practical: `ConversationRepository`, `SQLiteBackend`, `ParsingService`, `RunResult`, `TransformResult`, `ValidationResult`, `RawConversationRecord`, and typed synthetic payload aliases. The remaining fake objects are narrow casts to the production classes they stand in for, rather than `Any` escapes.

## Verification
- `ruff check --fix tests/unit/pipeline`
- `ruff format tests/unit/pipeline`
- `mypy tests/unit/pipeline`
- `pytest -q tests/unit/pipeline`
- `devtools verify --quick`
- push hook reran `devtools verify --quick` with repo-local `PATH` and passed
