### PR TITLE
test: type source parser contracts

### DIFF
--- a/tests/unit/sources/test_drive_auth.py
+++ b/tests/unit/sources/test_drive_auth.py
@@ -6,8 +6,8 @@ import json
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
-from types import SimpleNamespace
-from typing import Any, Protocol
+from types import ModuleType, SimpleNamespace
+from typing import Protocol, cast
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -362,13 +362,13 @@ def test_load_credentials_state_machine(case: AuthLoadCase, monkeypatch: pytest.
 
     request_cls = MagicMock(return_value=SimpleNamespace(session=SimpleNamespace(timeout=None)))
 
-    def fake_import(name: str) -> Any:
+    def fake_import(name: str) -> ModuleType:
         if name == "google.oauth2.credentials":
-            return MagicMock(Credentials=credentials_cls)
+            return cast(ModuleType, MagicMock(Credentials=credentials_cls))
         if name == "google_auth_oauthlib.flow":
-            return MagicMock(InstalledAppFlow=MagicMock())
+            return cast(ModuleType, MagicMock(InstalledAppFlow=MagicMock()))
         if name == "google.auth.transport.requests":
-            return SimpleNamespace(Request=request_cls)
+            return cast(ModuleType, SimpleNamespace(Request=request_cls))
         raise AssertionError(name)
 
     mgr = DriveAuthManager(ui=None, token_path=token_path)
@@ -378,7 +378,7 @@ def test_load_credentials_state_machine(case: AuthLoadCase, monkeypatch: pytest.
 
     if case.refreshes and creds is not None:
 
-        def refresh(_request: Any) -> None:
+        def refresh(_request: object) -> None:
             creds.valid = True
             creds.expired = False
 
@@ -421,7 +421,7 @@ def test_refresh_credentials_if_needed_contract(tmp_path: Path, monkeypatch: pyt
     creds = _creds(valid=False, expired=True, token_json='{"token":"fresh"}')
     request = SimpleNamespace(session=SimpleNamespace(timeout=None))
 
-    def refresh(_request: Any) -> None:
+    def refresh(_request: object) -> None:
         creds.valid = True
         creds.expired = False
 
@@ -454,11 +454,11 @@ def test_load_credentials_uses_manual_flow_when_local_server_fails(
     installed_app_flow_cls.from_client_secrets_file.return_value = flow
     manual_creds = _creds(valid=True, expired=False, token_json='{"token":"manual"}')
 
-    def fake_import(name: str) -> Any:
+    def fake_import(name: str) -> ModuleType:
         if name == "google.oauth2.credentials":
-            return MagicMock(Credentials=MagicMock())
+            return cast(ModuleType, MagicMock(Credentials=MagicMock()))
         if name == "google_auth_oauthlib.flow":
-            return MagicMock(InstalledAppFlow=installed_app_flow_cls)
+            return cast(ModuleType, MagicMock(InstalledAppFlow=installed_app_flow_cls))
         raise AssertionError(name)
 
     mgr = DriveAuthManager(credentials_path=credentials_path, token_path=token_path)
@@ -484,11 +484,11 @@ def test_load_credentials_returns_local_server_result(monkeypatch: pytest.Monkey
     installed_app_flow_cls = MagicMock()
     installed_app_flow_cls.from_client_secrets_file.return_value = flow
 
-    def fake_import(name: str) -> Any:
+    def fake_import(name: str) -> ModuleType:
         if name == "google.oauth2.credentials":
-            return MagicMock(Credentials=MagicMock())
+            return cast(ModuleType, MagicMock(Credentials=MagicMock()))
         if name == "google_auth_oauthlib.flow":
-            return MagicMock(InstalledAppFlow=installed_app_flow_cls)
+            return cast(ModuleType, MagicMock(InstalledAppFlow=installed_app_flow_cls))
         raise AssertionError(name)
 
     mgr = DriveAuthManager(credentials_path=credentials_path, token_path=token_path)

--- a/tests/unit/sources/test_drive_gateway.py
+++ b/tests/unit/sources/test_drive_gateway.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Any, cast
+from types import ModuleType
+from typing import cast
 from unittest.mock import MagicMock
 
 import pytest
@@ -11,6 +12,7 @@ from polylogue.sources.drive_gateway import (
     DEFAULT_DRIVE_RETRIES,
     DEFAULT_DRIVE_RETRY_BASE,
     DriveServiceGateway,
+    _DriveService,
     _import_module,
     _resolve_retries,
     _resolve_retry_base,
@@ -149,7 +151,7 @@ def test_service_handle_returns_cached_service_when_not_expired(monkeypatch: pyt
     gw = _gateway()
     service = MagicMock()
     service._http.credentials.expired = False
-    cast(Any, gw)._service = service
+    gw._service = cast(_DriveService, service)
     assert gw._service_handle() is service
 
 
@@ -157,16 +159,16 @@ def test_service_handle_rebuilds_on_expired_credentials(monkeypatch: pytest.Monk
     gw = _gateway()
     expired = MagicMock()
     expired._http.credentials.expired = True
-    cast(Any, gw)._service = expired
+    gw._service = cast(_DriveService, expired)
     creds = object()
     rebuilt = object()
     load_credentials = cast(MagicMock, gw._auth_manager.load_credentials)
     load_credentials.return_value = creds
     build = MagicMock(return_value=rebuilt)
 
-    def fake_import(name: str) -> Any:
+    def fake_import(name: str) -> ModuleType:
         if name == "googleapiclient.discovery":
-            return MagicMock(build=build)
+            return cast(ModuleType, MagicMock(build=build))
         raise AssertionError(name)
 
     monkeypatch.setattr("polylogue.sources.drive_gateway._import_module", fake_import)
@@ -183,9 +185,9 @@ def test_service_handle_builds_and_caches_service(monkeypatch: pytest.MonkeyPatc
     load_credentials.return_value = creds
     build = MagicMock(return_value=built)
 
-    def fake_import(name: str) -> Any:
+    def fake_import(name: str) -> ModuleType:
         if name == "googleapiclient.discovery":
-            return MagicMock(build=build)
+            return cast(ModuleType, MagicMock(build=build))
         raise AssertionError(name)
 
     monkeypatch.setattr("polylogue.sources.drive_gateway._import_module", fake_import)
@@ -208,7 +210,7 @@ def test_download_file_writes_content(monkeypatch: pytest.MonkeyPatch) -> None:
     import io
 
     gw = _gateway()
-    cast(Any, gw)._service = MockDriveService(file_content={"file-1": b"hello-bytes"})
+    gw._service = cast(_DriveService, MockDriveService(file_content={"file-1": b"hello-bytes"}))
 
     monkeypatch.setattr(
         "polylogue.sources.drive_gateway._import_module",

--- a/tests/unit/sources/test_null_guard_properties.py
+++ b/tests/unit/sources/test_null_guard_properties.py
@@ -20,16 +20,23 @@ Covers:
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from typing import Any
+from typing import TypeAlias
 
 from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
+from hypothesis.strategies import SearchStrategy
 
 from polylogue.lib.messages import MessageCollection
 from polylogue.lib.models import Conversation, ConversationSummary, Message
 from polylogue.lib.roles import Role
 from polylogue.lib.timestamps import parse_timestamp
 from polylogue.types import ConversationId, Provider
+
+TimestampInput: TypeAlias = str | int | float | None
+SparseProviderMeta: TypeAlias = dict[str, object] | None
+SparseMetadata: TypeAlias = dict[str, object]
+SparseMessagePayload: TypeAlias = dict[str, object] | None
+GeminiPartPayload: TypeAlias = dict[str, object]
 
 # =============================================================================
 # Hypothesis strategies for sparse/adversarial provider data
@@ -71,7 +78,7 @@ _timestamp_or_none = st.one_of(
     ),
 )
 
-_provider_meta_or_none: Any = st.one_of(
+_provider_meta_or_none: SearchStrategy[SparseProviderMeta] = st.one_of(
     st.none(),
     st.just({}),
     st.fixed_dictionaries(
@@ -164,7 +171,7 @@ class TestMessageNoneGuardProperties:
 
     @given(msg=sparse_message())
     @settings(max_examples=200, suppress_health_check=_SPARSE_MESSAGE_HEALTH_CHECKS)
-    def test_word_count_never_crashes(self: Any, msg: Message) -> None:
+    def test_word_count_never_crashes(self, msg: Message) -> None:
         """word_count must return int matching len(text.split()), even with None text."""
         result = msg.word_count
         assert isinstance(result, int)
@@ -173,52 +180,52 @@ class TestMessageNoneGuardProperties:
 
     @given(msg=sparse_message())
     @settings(max_examples=200, suppress_health_check=_SPARSE_MESSAGE_HEALTH_CHECKS)
-    def test_is_tool_use_never_crashes(self: Any, msg: Message) -> None:
+    def test_is_tool_use_never_crashes(self, msg: Message) -> None:
         """is_tool_use must return bool, even with None content_blocks."""
         result = msg.is_tool_use
         assert isinstance(result, bool)
 
     @given(msg=sparse_message())
     @settings(max_examples=200, suppress_health_check=_SPARSE_MESSAGE_HEALTH_CHECKS)
-    def test_is_thinking_never_crashes(self: Any, msg: Message) -> None:
+    def test_is_thinking_never_crashes(self, msg: Message) -> None:
         """is_thinking must return bool, even with None/missing fields."""
         result = msg.is_thinking
         assert isinstance(result, bool)
 
     @given(msg=sparse_message())
     @settings(max_examples=200, suppress_health_check=_SPARSE_MESSAGE_HEALTH_CHECKS)
-    def test_is_substantive_never_crashes(self: Any, msg: Message) -> None:
+    def test_is_substantive_never_crashes(self, msg: Message) -> None:
         result = msg.is_substantive
         assert isinstance(result, bool)
 
     @given(msg=sparse_message())
     @settings(max_examples=200, suppress_health_check=_SPARSE_MESSAGE_HEALTH_CHECKS)
-    def test_is_noise_never_crashes(self: Any, msg: Message) -> None:
+    def test_is_noise_never_crashes(self, msg: Message) -> None:
         result = msg.is_noise
         assert isinstance(result, bool)
 
     @given(msg=sparse_message())
     @settings(max_examples=200, suppress_health_check=_SPARSE_MESSAGE_HEALTH_CHECKS)
-    def test_is_context_dump_never_crashes(self: Any, msg: Message) -> None:
+    def test_is_context_dump_never_crashes(self, msg: Message) -> None:
         result = msg.is_context_dump
         assert isinstance(result, bool)
 
     @given(msg=sparse_message())
     @settings(max_examples=200, suppress_health_check=_SPARSE_MESSAGE_HEALTH_CHECKS)
-    def test_extract_thinking_never_crashes(self: Any, msg: Message) -> None:
+    def test_extract_thinking_never_crashes(self, msg: Message) -> None:
         """extract_thinking must return str or None, never crash."""
         result = msg.extract_thinking()
         assert result is None or isinstance(result, str)
 
     @given(msg=sparse_message())
     @settings(max_examples=200, suppress_health_check=_SPARSE_MESSAGE_HEALTH_CHECKS)
-    def test_cost_usd_never_crashes(self: Any, msg: Message) -> None:
+    def test_cost_usd_never_crashes(self, msg: Message) -> None:
         result = msg.cost_usd
         assert result is None or isinstance(result, float)
 
     @given(msg=sparse_message())
     @settings(max_examples=200, suppress_health_check=_SPARSE_MESSAGE_HEALTH_CHECKS)
-    def test_duration_ms_never_crashes(self: Any, msg: Message) -> None:
+    def test_duration_ms_never_crashes(self, msg: Message) -> None:
         result = msg.duration_ms
         assert result is None or isinstance(result, int)
 
@@ -233,14 +240,14 @@ class TestConversationNoneGuardProperties:
 
     @given(conv=sparse_conversation())
     @settings(max_examples=100, suppress_health_check=_SPARSE_CONVERSATION_HEALTH_CHECKS)
-    def test_display_date_never_crashes(self: Any, conv: Conversation) -> None:
+    def test_display_date_never_crashes(self, conv: Conversation) -> None:
         """display_date with None updated_at/created_at must not crash."""
         result = conv.display_date
         assert result is None or isinstance(result, datetime)
 
     @given(conv=sparse_conversation())
     @settings(max_examples=100, suppress_health_check=_SPARSE_CONVERSATION_HEALTH_CHECKS)
-    def test_tags_never_crashes(self: Any, conv: Conversation) -> None:
+    def test_tags_never_crashes(self, conv: Conversation) -> None:
         """tags property must handle None/missing metadata."""
         result = conv.tags
         assert isinstance(result, list)
@@ -248,7 +255,7 @@ class TestConversationNoneGuardProperties:
 
     @given(conv=sparse_conversation())
     @settings(max_examples=100, suppress_health_check=_SPARSE_CONVERSATION_HEALTH_CHECKS)
-    def test_len_messages_never_crashes(self: Any, conv: Conversation) -> None:
+    def test_len_messages_never_crashes(self, conv: Conversation) -> None:
         """len(messages) matches the count of message objects in the conversation."""
         result = len(conv.messages)
         assert isinstance(result, int)
@@ -256,7 +263,7 @@ class TestConversationNoneGuardProperties:
 
     @given(conv=sparse_conversation())
     @settings(max_examples=100, suppress_health_check=_SPARSE_CONVERSATION_HEALTH_CHECKS)
-    def test_iter_messages_never_crashes(self: Any, conv: Conversation) -> None:
+    def test_iter_messages_never_crashes(self, conv: Conversation) -> None:
         """Iterating messages must not crash."""
         for msg in conv.messages:
             assert isinstance(msg, Message)
@@ -277,7 +284,7 @@ class TestSortMixedTimestamps:
 
     @given(convs=st.lists(sparse_conversation(), min_size=2, max_size=20))
     @settings(max_examples=50, suppress_health_check=_SPARSE_CONVERSATION_HEALTH_CHECKS)
-    def test_sort_by_display_date_never_crashes(self: Any, convs: list[Conversation]) -> None:
+    def test_sort_by_display_date_never_crashes(self, convs: list[Conversation]) -> None:
         """Sorting by display_date must handle None values gracefully."""
         _epoch = datetime.min.replace(tzinfo=timezone.utc)
         # This is the exact pattern from facade.py that was crashing
@@ -290,7 +297,7 @@ class TestSortMixedTimestamps:
 
     @given(convs=st.lists(sparse_conversation(), min_size=0, max_size=15))
     @settings(max_examples=50, suppress_health_check=_SPARSE_CONVERSATION_HEALTH_CHECKS)
-    def test_sort_stability_with_all_none(self: Any, convs: list[Conversation]) -> None:
+    def test_sort_stability_with_all_none(self, convs: list[Conversation]) -> None:
         """When all timestamps are None, sort must preserve relative order."""
         _epoch = datetime.min.replace(tzinfo=timezone.utc)
         # Force all timestamps to None
@@ -327,7 +334,7 @@ class TestChatGPTNonePartsProperty:
         )
     )
     @settings(max_examples=200)
-    def test_chatgpt_parts_extraction_never_crashes(self: Any, parts: Any) -> None:
+    def test_chatgpt_parts_extraction_never_crashes(self, parts: list[object]) -> None:
         """ChatGPT text extraction from parts must never crash."""
         from polylogue.sources.providers.chatgpt import ChatGPTAuthor, ChatGPTContent, ChatGPTMessage
 
@@ -362,7 +369,11 @@ class TestGeminiNonePartsProperty:
         ),
     )
     @settings(max_examples=200)
-    def test_gemini_text_extraction_never_crashes(self: Any, text: Any, parts: Any) -> None:
+    def test_gemini_text_extraction_never_crashes(
+        self,
+        text: str | None,
+        parts: list[GeminiPartPayload],
+    ) -> None:
         """Gemini text_content must handle any combination of text + parts."""
         from polylogue.sources.providers.gemini import GeminiMessage
 
@@ -414,7 +425,11 @@ class TestClaudeCodeNoneGuardProperty:
         ),
     )
     @settings(max_examples=200)
-    def test_claude_code_text_content_never_crashes(self: Any, record_type: Any, message: Any) -> None:
+    def test_claude_code_text_content_never_crashes(
+        self,
+        record_type: str,
+        message: SparseMessagePayload,
+    ) -> None:
         """text_content must handle any record type with any message shape."""
         from polylogue.sources.providers.claude_code import ClaudeCodeRecord
 
@@ -435,7 +450,11 @@ class TestClaudeCodeNoneGuardProperty:
         ),
     )
     @settings(max_examples=100)
-    def test_claude_code_content_blocks_raw_never_crashes(self: Any, record_type: Any, message: Any) -> None:
+    def test_claude_code_content_blocks_raw_never_crashes(
+        self,
+        record_type: str,
+        message: SparseMessagePayload,
+    ) -> None:
         """content_blocks_raw must return list, never crash."""
         from polylogue.sources.providers.claude_code import ClaudeCodeRecord
 
@@ -447,7 +466,7 @@ class TestClaudeCodeNoneGuardProperty:
         record_type=st.sampled_from(["user", "assistant", "summary", "progress"]),
     )
     @settings(max_examples=50)
-    def test_claude_code_role_mapping_systematic(self: Any, record_type: Any) -> None:
+    def test_claude_code_role_mapping_systematic(self, record_type: str) -> None:
         """Every record type must map to a known role."""
         from polylogue.sources.providers.claude_code import ClaudeCodeRecord
 
@@ -478,7 +497,11 @@ class TestConversationSummaryNoneGuards:
     )
     @settings(max_examples=100)
     def test_display_title_never_crashes(
-        self: Any, title: Any, created_at: Any, updated_at: Any, metadata: Any
+        self,
+        title: str | None,
+        created_at: datetime | None,
+        updated_at: datetime | None,
+        metadata: SparseMetadata,
     ) -> None:
         summary = ConversationSummary(
             id=ConversationId("test-id"),
@@ -497,7 +520,11 @@ class TestConversationSummaryNoneGuards:
         updated_at=_timestamp_or_none,
     )
     @settings(max_examples=50)
-    def test_display_date_never_crashes(self: Any, created_at: Any, updated_at: Any) -> None:
+    def test_display_date_never_crashes(
+        self,
+        created_at: datetime | None,
+        updated_at: datetime | None,
+    ) -> None:
         summary = ConversationSummary(
             id=ConversationId("test-id"),
             provider=Provider.CHATGPT,
@@ -529,7 +556,7 @@ class TestParseTimestampProperty:
         )
     )
     @settings(max_examples=300)
-    def test_parse_timestamp_never_crashes(self: Any, value: Any) -> None:
+    def test_parse_timestamp_never_crashes(self, value: TimestampInput) -> None:
         """parse_timestamp must return datetime or None, never raise."""
         result = parse_timestamp(value)
         assert result is None or isinstance(result, datetime)
@@ -541,7 +568,7 @@ class TestParseTimestampProperty:
         )
     )
     @settings(max_examples=200)
-    def test_parse_timestamp_numeric_always_utc_or_none(self: Any, value: Any) -> None:
+    def test_parse_timestamp_numeric_always_utc_or_none(self, value: int | float) -> None:
         """When a numeric value produces a datetime, it must be UTC-aware."""
         result = parse_timestamp(value)
         if result is not None:
@@ -549,7 +576,7 @@ class TestParseTimestampProperty:
 
     @given(value=st.text(min_size=1, max_size=50).filter(lambda s: s.replace(".", "").isdigit()))
     @settings(max_examples=100)
-    def test_digit_strings_either_none_or_utc(self: Any, value: Any) -> None:
+    def test_digit_strings_either_none_or_utc(self, value: str) -> None:
         """Digit-only strings must produce None or UTC-aware datetime."""
         result = parse_timestamp(value)
         if result is not None:

--- a/tests/unit/sources/test_null_guard_properties.py
+++ b/tests/unit/sources/test_null_guard_properties.py
@@ -30,13 +30,14 @@ from polylogue.lib.messages import MessageCollection
 from polylogue.lib.models import Conversation, ConversationSummary, Message
 from polylogue.lib.roles import Role
 from polylogue.lib.timestamps import parse_timestamp
+from polylogue.sources.providers.gemini import GeminiMessage, GeminiPart
 from polylogue.types import ConversationId, Provider
 
 TimestampInput: TypeAlias = str | int | float | None
 SparseProviderMeta: TypeAlias = dict[str, object] | None
 SparseMetadata: TypeAlias = dict[str, object]
 SparseMessagePayload: TypeAlias = dict[str, object] | None
-GeminiPartPayload: TypeAlias = dict[str, object]
+GeminiPartPayload: TypeAlias = GeminiPart | dict[str, object]
 
 # =============================================================================
 # Hypothesis strategies for sparse/adversarial provider data
@@ -375,8 +376,6 @@ class TestGeminiNonePartsProperty:
         parts: list[GeminiPartPayload],
     ) -> None:
         """Gemini text_content must handle any combination of text + parts."""
-        from polylogue.sources.providers.gemini import GeminiMessage
-
         msg = GeminiMessage(
             text=text or "",  # GeminiMessage requires text field
             role="model",

--- a/tests/unit/sources/test_parsers_chatgpt.py
+++ b/tests/unit/sources/test_parsers_chatgpt.py
@@ -3,16 +3,35 @@
 from __future__ import annotations
 
 import json
-from typing import Any, cast
+from collections.abc import Callable, Mapping, Sequence
+from typing import TypeAlias
 
 import pytest
 
 from polylogue.scenarios import CorpusSpec
+from polylogue.sources.parsers.base import ParsedConversation
 from polylogue.sources.parsers.chatgpt import _coerce_float, extract_messages_from_mapping
 from polylogue.sources.parsers.chatgpt import looks_like as chatgpt_looks_like
 from polylogue.sources.parsers.chatgpt import parse as chatgpt_parse
 from polylogue.sources.parsers.claude import looks_like_ai, looks_like_code
 from tests.infra.source_builders import make_chatgpt_node
+
+ProviderCheck: TypeAlias = Callable[[object], bool]
+ProviderDetectionCase: TypeAlias = tuple[object, bool, ProviderCheck, str]
+CoerceFloatCase: TypeAlias = tuple[object, float | None, str]
+ChatGPTMapping: TypeAlias = dict[str, object]
+ExtractMessagesCase: TypeAlias = tuple[ChatGPTMapping, int, str]
+ParentBranchCase: TypeAlias = tuple[ChatGPTMapping, list[str | None], list[int], str]
+MetadataCase: TypeAlias = tuple[object, str | None, str]
+ParseFn: TypeAlias = Callable[[Mapping[str, object], str], ParsedConversation]
+ParseConversationCase: TypeAlias = tuple[ParseFn, ChatGPTMapping, str, str]
+
+
+def _looks_like_code_payload(data: object) -> bool:
+    if not isinstance(data, Sequence) or isinstance(data, (str, bytes, bytearray)):
+        return False
+    return looks_like_code(data)
+
 
 # =============================================================================
 # CHATGPT PARSER TESTS
@@ -20,7 +39,7 @@ from tests.infra.source_builders import make_chatgpt_node
 
 
 # MERGED FORMAT + COERCE DETECTION
-PROVIDER_FORMAT_DETECTION_CASES = [
+PROVIDER_FORMAT_DETECTION_CASES: list[ProviderDetectionCase] = [
     # ChatGPT
     ({"mapping": {}}, True, chatgpt_looks_like, "ChatGPT: valid empty mapping"),
     ({"mapping": {"node1": {}}}, True, chatgpt_looks_like, "ChatGPT: valid with nodes"),
@@ -31,14 +50,14 @@ PROVIDER_FORMAT_DETECTION_CASES = [
     ({}, False, looks_like_ai, "Claude AI: missing chat_messages"),
     (None, False, looks_like_ai, "Claude AI: None"),
     # Claude Code
-    ([{"parentUuid": "123"}], True, looks_like_code, "Claude Code: parentUuid"),
-    ([], False, looks_like_code, "Claude Code: empty list"),
-    (None, False, looks_like_code, "Claude Code: None"),
+    ([{"parentUuid": "123"}], True, _looks_like_code_payload, "Claude Code: parentUuid"),
+    ([], False, _looks_like_code_payload, "Claude Code: empty list"),
+    (None, False, _looks_like_code_payload, "Claude Code: None"),
 ]
 
 
 @pytest.mark.parametrize("data,expected,check_fn,desc", PROVIDER_FORMAT_DETECTION_CASES)
-def test_provider_format_detection(data: Any, expected: Any, check_fn: Any, desc: Any) -> None:
+def test_provider_format_detection(data: object, expected: bool, check_fn: ProviderCheck, desc: str) -> None:
     """Unified format detection across all providers."""
     result = check_fn(data)
     assert result == expected, f"Failed {desc}"
@@ -46,7 +65,7 @@ def test_provider_format_detection(data: Any, expected: Any, check_fn: Any, desc
 
 # COERCE FLOAT - MERGED WITH FORMAT DETECTION ABOVE
 
-COERCE_FLOAT_CASES = [
+COERCE_FLOAT_CASES: list[CoerceFloatCase] = [
     (42, 42.0, "int"),
     (3.14, 3.14, "float"),
     ("2.5", 2.5, "string number"),
@@ -56,7 +75,7 @@ COERCE_FLOAT_CASES = [
 
 
 @pytest.mark.parametrize("input_val,expected,desc", COERCE_FLOAT_CASES)
-def test_coerce_float(input_val: Any, expected: Any, desc: Any) -> None:
+def test_coerce_float(input_val: object, expected: float | None, desc: str) -> None:
     """Test _coerce_float conversion."""
     result = _coerce_float(input_val)
     assert result == expected, f"Failed {desc}"
@@ -65,7 +84,7 @@ def test_coerce_float(input_val: Any, expected: Any, desc: Any) -> None:
 # MESSAGE EXTRACTION - PARAMETRIZED (1 test replacing 17)
 
 
-CHATGPT_EXTRACT_MESSAGES_CASES = [
+CHATGPT_EXTRACT_MESSAGES_CASES: list[ExtractMessagesCase] = [
     # Basic extraction
     ({"node1": make_chatgpt_node("msg1", "user", ["Hello"])}, 1, "basic message"),
     # Timestamp handling
@@ -84,7 +103,19 @@ CHATGPT_EXTRACT_MESSAGES_CASES = [
     ),
     # Content variants
     ({"node1": make_chatgpt_node("msg1", "user", ["Part1", "Part2"])}, 1, "multiple parts"),
-    ({"node1": make_chatgpt_node("msg1", "user", cast(Any, [None, "Valid"]))}, 1, "parts with None"),
+    (
+        {
+            "node1": {
+                "message": {
+                    "id": "msg1",
+                    "author": {"role": "user"},
+                    "content": {"parts": [None, "Valid"]},
+                }
+            }
+        },
+        1,
+        "parts with None",
+    ),
     ({"node1": {"message": {"id": "1", "author": {"role": "user"}, "content": {"parts": []}}}}, 0, "empty parts"),
     # Role normalization
     ({"node1": make_chatgpt_node("msg1", "human", ["Hi"])}, 1, "human role alias"),
@@ -103,7 +134,7 @@ CHATGPT_EXTRACT_MESSAGES_CASES = [
 
 
 @pytest.mark.parametrize("mapping,expected_count,desc", CHATGPT_EXTRACT_MESSAGES_CASES)
-def test_chatgpt_extract_messages_comprehensive(mapping: Any, expected_count: Any, desc: Any) -> None:
+def test_chatgpt_extract_messages_comprehensive(mapping: ChatGPTMapping, expected_count: int, desc: str) -> None:
     """Comprehensive message extraction test.
 
     Replaces 17 individual extraction tests.
@@ -123,7 +154,7 @@ def test_chatgpt_extract_messages_comprehensive(mapping: Any, expected_count: An
 # -----------------------------------------------------------------------------
 
 
-CHATGPT_PARENT_BRANCH_CASES = [
+CHATGPT_PARENT_BRANCH_CASES: list[ParentBranchCase] = [
     # No parent (root message)
     ({"node1": make_chatgpt_node("msg1", "user", ["Hello"])}, [None], [0], "root message no parent"),
     # Simple linear chain
@@ -185,7 +216,10 @@ CHATGPT_PARENT_BRANCH_CASES = [
 
 @pytest.mark.parametrize("mapping,expected_parents,expected_indexes,desc", CHATGPT_PARENT_BRANCH_CASES)
 def test_chatgpt_extract_parent_and_branch_index(
-    mapping: Any, expected_parents: Any, expected_indexes: Any, desc: Any
+    mapping: ChatGPTMapping,
+    expected_parents: list[str | None],
+    expected_indexes: list[int],
+    desc: str,
 ) -> None:
     """Test extraction of parent_message_provider_id and branch_index.
 
@@ -213,7 +247,7 @@ def test_chatgpt_extract_parent_and_branch_index(
 # -----------------------------------------------------------------------------
 
 
-CHATGPT_METADATA_CASES = [
+CHATGPT_METADATA_CASES: list[MetadataCase] = [
     # Attachments
     ({"attachments": [{"id": "att1", "name": "file.pdf"}]}, "attachments", "attachments field"),
     ({"image_asset_pointer": "asset_123"}, None, "image asset pointer metadata ignored"),
@@ -230,7 +264,7 @@ CHATGPT_METADATA_CASES = [
 
 
 @pytest.mark.parametrize("metadata,expected_type,desc", CHATGPT_METADATA_CASES)
-def test_chatgpt_metadata_extraction(metadata: Any, expected_type: Any, desc: Any) -> None:
+def test_chatgpt_metadata_extraction(metadata: object, expected_type: str | None, desc: str) -> None:
     """Test metadata extraction from message metadata field.
 
     Explicit tests for attachment/cost/thinking metadata.
@@ -267,7 +301,7 @@ def test_chatgpt_metadata_extraction(metadata: Any, expected_type: Any, desc: An
 # -----------------------------------------------------------------------------
 
 
-PARSE_CONVERSATION_CASES = [
+PARSE_CONVERSATION_CASES: list[ParseConversationCase] = [
     # ChatGPT title extraction
     (chatgpt_parse, {"title": "My Conv", "mapping": {}}, "title", "ChatGPT: title field"),
     (chatgpt_parse, {"name": "Conv Name", "mapping": {}}, "name", "ChatGPT: name field"),
@@ -277,7 +311,7 @@ PARSE_CONVERSATION_CASES = [
 
 
 @pytest.mark.parametrize("parse_fn,conv_data,check_type,desc", PARSE_CONVERSATION_CASES)
-def test_parse_conversation(parse_fn: Any, conv_data: Any, check_type: Any, desc: Any) -> None:
+def test_parse_conversation(parse_fn: ParseFn, conv_data: ChatGPTMapping, check_type: str, desc: str) -> None:
     """Unified conversation parsing across providers."""
     result = parse_fn(conv_data, "fallback-id")
 

--- a/tests/unit/sources/test_parsers_props.py
+++ b/tests/unit/sources/test_parsers_props.py
@@ -16,14 +16,16 @@ Source-detection/container-shape laws live in ``test_source_laws.py``.
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
-from typing import Any, cast
+from typing import TypeAlias, TypedDict, cast
 
 import pytest
 from hypothesis import given, settings
 from hypothesis import strategies as st
+from hypothesis.strategies import SearchStrategy
 
+from polylogue.lib.json import JSONDocument, json_document
 from polylogue.paths import Source
 from polylogue.schemas.synthetic import SyntheticCorpus
 from polylogue.sources import iter_source_conversations
@@ -45,57 +47,113 @@ from tests.infra.strategies import (
 from tests.infra.strategies.providers import claude_code_session_strategy, codex_session_strategy
 
 NormalizedTimestampInput = int | float | str | None
+ParserPayload: TypeAlias = object
 
 
-def _chatgpt_message_node_count(export: dict[str, Any]) -> int:
-    mapping = export.get("mapping", {})
+class AttachmentMeta(TypedDict):
+    id: str
+    name: str
+    mime_type: str
+    size: int
+
+
+def _chatgpt_message_node_count(payload: ParserPayload) -> int:
+    export = json_document(payload)
+    mapping = json_document(export.get("mapping"))
     return sum(
         1
         for node in mapping.values()
         if isinstance(node, dict)
-        and isinstance(node.get("message"), dict)
-        and node["message"].get("content", {}).get("parts")
+        and (message := json_document(node.get("message")))
+        and json_document(message.get("content")).get("parts")
     )
 
 
-def _claude_ai_message_count(export: dict[str, Any]) -> int:
-    return sum(1 for msg in export.get("chat_messages", []) if isinstance(msg, dict) and msg.get("text"))
+def _claude_ai_message_count(payload: ParserPayload) -> int:
+    export = json_document(payload)
+    messages = export.get("chat_messages")
+    return sum(1 for msg in messages if isinstance(msg, dict) and msg.get("text")) if isinstance(messages, list) else 0
 
 
-def _jsonl_record_count(records: list[dict[str, Any]]) -> int:
-    return len([record for record in records if isinstance(record, dict)])
+def _jsonl_record_count(payload: ParserPayload) -> int:
+    return len([record for record in payload if isinstance(record, dict)]) if isinstance(payload, list) else 0
 
 
-def _gemini_chunk_count(export: dict[str, Any]) -> int:
-    chunks = export.get("chunkedPrompt", {}).get("chunks", [])
+def _gemini_chunk_count(payload: ParserPayload) -> int:
+    export = json_document(payload)
+    chunks = json_document(export.get("chunkedPrompt")).get("chunks")
+    if not isinstance(chunks, list):
+        return 0
     return len([c for c in chunks if isinstance(c, dict) and c.get("text") and c.get("role")])
+
+
+def _payload_sequence(payload: ParserPayload) -> Sequence[object]:
+    if not isinstance(payload, Sequence) or isinstance(payload, (str, bytes, bytearray)):
+        return ()
+    return payload
+
+
+def _looks_like_sequence(predicate: Callable[[Sequence[object]], bool], payload: ParserPayload) -> bool:
+    return predicate(_payload_sequence(payload))
+
+
+def _payload_id(payload: ParserPayload) -> str:
+    document = json_document(payload)
+    return str(document.get("id") or document.get("uuid") or document.get("conversation_id") or "fallback")
+
+
+def _payload_title(payload: ParserPayload) -> str:
+    document = json_document(payload)
+    return str(document.get("title") or document.get("name") or "fallback")
+
+
+def _parse_chatgpt(payload: ParserPayload) -> ParsedConversation:
+    return chatgpt.parse(json_document(payload), "fallback")
+
+
+def _parse_claude_ai(payload: ParserPayload) -> ParsedConversation:
+    return claude.parse_ai(json_document(payload), "fallback")
+
+
+def _parse_claude_code(payload: ParserPayload) -> ParsedConversation:
+    return claude.parse_code(_payload_sequence(payload), "fallback")
+
+
+def _parse_codex(payload: ParserPayload) -> ParsedConversation:
+    return codex.parse(_payload_sequence(payload), "fallback")
+
+
+def _parse_gemini(payload: ParserPayload) -> ParsedConversation:
+    return drive.parse_chunked_prompt("gemini", json_document(payload), "fallback")
 
 
 @dataclass(frozen=True)
 class ParserCase:
     name: str
-    strategy: Any
-    parse: Callable[[Any], ParsedConversation]
-    looks_like: Callable[[Any], bool]
+    strategy: SearchStrategy[ParserPayload]
+    parse: Callable[[ParserPayload], ParsedConversation]
+    looks_like: Callable[[ParserPayload], bool]
     expected_provider: str
-    message_cap: Callable[[Any], int]
-    id_oracle: Callable[[Any], str] | None = None
-    title_oracle: Callable[[Any], str] | None = None
-    extra_assertion: Callable[[Any, ParsedConversation], None] | None = None
+    message_cap: Callable[[ParserPayload], int]
+    id_oracle: Callable[[ParserPayload], str] | None = None
+    title_oracle: Callable[[ParserPayload], str] | None = None
+    extra_assertion: Callable[[ParserPayload, ParsedConversation], None] | None = None
 
 
-def _assert_claude_code_cleanup(_payload: Any, result: ParsedConversation) -> None:
+def _assert_claude_code_cleanup(_payload: ParserPayload, result: ParsedConversation) -> None:
     for message in result.messages:
         assert message.provider_meta is None
         assert isinstance(message.content_blocks, list)
         assert message.timestamp is None or isinstance(message.timestamp, str)
 
 
-def _assert_codex_text_recovery(payload: list[dict[str, Any]], result: ParsedConversation) -> None:
+def _assert_codex_text_recovery(payload: ParserPayload, result: ParsedConversation) -> None:
     if not result.messages:
         return
     for message in result.messages:
         assert message.provider_meta is None
+    if not isinstance(payload, list):
+        return
     response_items = [
         record.get("payload", record)
         for record in payload
@@ -106,11 +164,17 @@ def _assert_codex_text_recovery(payload: list[dict[str, Any]], result: ParsedCon
     if not response_items:
         return
     first = response_items[0]
-    expected_text = "\n".join(
-        item.get("text", "")
-        for item in first.get("content", [])
-        if isinstance(item, dict) and item.get("type") == "input_text"
-    )
+    content = first.get("content")
+    if not isinstance(content, list):
+        return
+    expected_parts: list[str] = []
+    for item in content:
+        if not isinstance(item, dict) or item.get("type") != "input_text":
+            continue
+        text = item.get("text")
+        if isinstance(text, str):
+            expected_parts.append(text)
+    expected_text = "\n".join(expected_parts)
     if expected_text:
         assert result.messages[0].text == expected_text
 
@@ -119,31 +183,27 @@ PARSER_CASES: tuple[ParserCase, ...] = (
     ParserCase(
         name="chatgpt",
         strategy=chatgpt_export_strategy(min_messages=1, max_messages=10),
-        parse=lambda payload: chatgpt.parse(payload, "fallback"),
+        parse=_parse_chatgpt,
         looks_like=chatgpt.looks_like,
         expected_provider="chatgpt",
         message_cap=_chatgpt_message_node_count,
-        id_oracle=lambda export: str(
-            export.get("id") or export.get("uuid") or export.get("conversation_id") or "fallback"
-        ),
-        title_oracle=lambda export: str(export.get("title") or export.get("name") or "fallback"),
+        id_oracle=_payload_id,
+        title_oracle=_payload_title,
     ),
     ParserCase(
         name="claude-ai",
         strategy=claude_ai_export_strategy(min_messages=1, max_messages=10),
-        parse=lambda payload: claude.parse_ai(payload, "fallback"),
+        parse=_parse_claude_ai,
         looks_like=claude.looks_like_ai,
         expected_provider="claude-ai",
         message_cap=_claude_ai_message_count,
-        id_oracle=lambda export: str(
-            export.get("id") or export.get("uuid") or export.get("conversation_id") or "fallback"
-        ),
+        id_oracle=_payload_id,
     ),
     ParserCase(
         name="claude-code",
         strategy=claude_code_session_strategy(min_messages=1, max_messages=10),
-        parse=lambda payload: claude.parse_code(payload, "fallback"),
-        looks_like=claude.looks_like_code,
+        parse=_parse_claude_code,
+        looks_like=lambda payload: _looks_like_sequence(claude.looks_like_code, payload),
         expected_provider="claude-code",
         message_cap=_jsonl_record_count,
         extra_assertion=_assert_claude_code_cleanup,
@@ -151,8 +211,8 @@ PARSER_CASES: tuple[ParserCase, ...] = (
     ParserCase(
         name="codex",
         strategy=codex_session_strategy(min_messages=1, max_messages=10, use_envelope=True),
-        parse=lambda payload: codex.parse(payload, "fallback"),
-        looks_like=codex.looks_like,
+        parse=_parse_codex,
+        looks_like=lambda payload: _looks_like_sequence(codex.looks_like, payload),
         expected_provider="codex",
         message_cap=_jsonl_record_count,
         extra_assertion=_assert_codex_text_recovery,
@@ -160,7 +220,7 @@ PARSER_CASES: tuple[ParserCase, ...] = (
     ParserCase(
         name="gemini",
         strategy=gemini_export_strategy(min_messages=1, max_messages=10),
-        parse=lambda payload: drive.parse_chunked_prompt("gemini", payload, "fallback"),
+        parse=_parse_gemini,
         looks_like=drive.looks_like,
         expected_provider="gemini",
         message_cap=_gemini_chunk_count,
@@ -198,7 +258,7 @@ def test_provider_looks_like_accepts_generated_payloads(case: ParserCase, data: 
 
 @given(st.lists(message_strategy(), min_size=0, max_size=20))
 @settings(max_examples=50)
-def test_extract_messages_from_list_never_invents_messages(messages: list[dict[str, Any]]) -> None:
+def test_extract_messages_from_list_never_invents_messages(messages: list[JSONDocument]) -> None:
     result = extract_messages_from_list(cast(list[object], messages))
     expected = sum(1 for msg in messages if isinstance(msg, dict) and (msg.get("text") or msg.get("content")))
     assert len(result) <= expected
@@ -206,7 +266,7 @@ def test_extract_messages_from_list_never_invents_messages(messages: list[dict[s
 
 @given(message_strategy())
 @settings(max_examples=50)
-def test_extract_messages_from_list_normalizes_role(msg: dict[str, Any]) -> None:
+def test_extract_messages_from_list_normalizes_role(msg: JSONDocument) -> None:
     result = extract_messages_from_list(cast(list[object], [msg]))
     if result:
         assert result[0].role in {"user", "assistant", "system", "tool", "message"}
@@ -214,7 +274,7 @@ def test_extract_messages_from_list_normalizes_role(msg: dict[str, Any]) -> None
 
 @given(chatgpt_message_node_strategy())
 @settings(max_examples=30)
-def test_chatgpt_node_contract(node: dict[str, Any]) -> None:
+def test_chatgpt_node_contract(node: JSONDocument) -> None:
     export: dict[str, object] = {"mapping": {str(node["id"]): node}, "id": "test"}
     result = chatgpt.parse(export, "fallback")
     assert all(message.role in {"user", "assistant", "system", "tool", "message"} for message in result.messages)
@@ -222,7 +282,7 @@ def test_chatgpt_node_contract(node: dict[str, Any]) -> None:
 
 @given(claude_code_message_strategy())
 @settings(max_examples=30)
-def test_claude_code_message_type_contract(msg: dict[str, Any]) -> None:
+def test_claude_code_message_type_contract(msg: JSONDocument) -> None:
     result = claude.parse_code(cast(list[object], [msg]), "fallback")
     if not result.messages:
         return
@@ -230,8 +290,9 @@ def test_claude_code_message_type_contract(msg: dict[str, Any]) -> None:
     # ClaudeCodeRecord.role precedence: message.role > type field.
     # When message.role is present and valid, it overrides the type field.
     inner_role = None
-    if isinstance(msg.get("message"), dict):
-        inner_role = msg["message"].get("role")
+    message = msg.get("message")
+    if isinstance(message, dict):
+        inner_role = message.get("role")
     if isinstance(inner_role, str) and inner_role in {"user", "assistant", "system", "tool"}:
         assert parsed.role == inner_role
     elif msg.get("type") == "user":
@@ -242,7 +303,7 @@ def test_claude_code_message_type_contract(msg: dict[str, Any]) -> None:
 
 @given(codex_message_strategy())
 @settings(max_examples=30)
-def test_codex_message_text_contract(msg: dict[str, Any]) -> None:
+def test_codex_message_text_contract(msg: JSONDocument) -> None:
     session = cast(
         list[object],
         [
@@ -253,11 +314,16 @@ def test_codex_message_text_contract(msg: dict[str, Any]) -> None:
     result = codex.parse(session, "fallback")
     if not result.messages:
         return
-    expected_text = "\n".join(
-        item.get("text", "")
-        for item in msg.get("content", [])
-        if isinstance(item, dict) and item.get("type") == "input_text"
-    )
+    content = msg.get("content")
+    expected_parts: list[str] = []
+    if isinstance(content, list):
+        for item in content:
+            if not isinstance(item, dict) or item.get("type") != "input_text":
+                continue
+            text = item.get("text")
+            if isinstance(text, str):
+                expected_parts.append(text)
+    expected_text = "\n".join(expected_parts)
     if expected_text:
         assert result.messages[0].text == expected_text
 
@@ -306,7 +372,7 @@ def test_timestamp_normalization_handles_milliseconds(epoch_ms: int) -> None:
         }
     )
 )
-def test_attachment_extraction_preserves_metadata(attachment_meta: dict[str, Any]) -> None:
+def test_attachment_extraction_preserves_metadata(attachment_meta: AttachmentMeta) -> None:
     result = attachment_from_meta(attachment_meta, "msg-1", 1)
 
     assert result is not None
@@ -329,7 +395,7 @@ def test_attachment_extraction_preserves_metadata(attachment_meta: dict[str, Any
 @pytest.fixture(params=sorted(SyntheticCorpus.available_providers()) or ["chatgpt"])
 def provider_conversations(
     request: pytest.FixtureRequest,
-    synthetic_source: Callable[..., Any],
+    synthetic_source: Callable[..., object],
 ) -> tuple[str, list[ParsedConversation]]:
     """Parse synthetic data for each available provider."""
     provider = str(request.param)


### PR DESCRIPTION
## Summary
- removes explicit dynamic typing from source parser and source gateway tests
- narrows parser property payloads through typed JSON/sequence helpers before parser calls
- types sparse null-guard strategies and generated Gemini part payloads without weakening provider contracts

## Problem
The source test surface still carried explicit Any/cast(Any) usage around parser payloads, Google Drive import fakes, and adversarial null-guard strategies. That weakened mypy coverage in the parser boundary tests and left generated payload shapes less clear than the production parser contracts they exercise.

Ref #281

## Solution
Introduce local type aliases and parser-boundary helpers in tests/unit/sources so object-shaped Hypothesis data is narrowed before parser calls. Replace private-service casts in Drive gateway/auth tests with concrete service/module types, and type the sparse property strategies directly.

Touched files:
- tests/unit/sources/test_drive_auth.py
- tests/unit/sources/test_drive_gateway.py
- tests/unit/sources/test_null_guard_properties.py
- tests/unit/sources/test_parsers_chatgpt.py
- tests/unit/sources/test_parsers_props.py

## Verification
- PATH=/tmp/polylogue-281/.cache/codex-bin:$PATH ruff check --fix tests/unit/sources
- PATH=/tmp/polylogue-281/.cache/codex-bin:$PATH ruff format tests/unit/sources
- rg -n "\bAny\b|cast\(Any|typing import .*Any" tests/unit/sources -g "*.py"
- PATH=/tmp/polylogue-281/.cache/codex-bin:$PATH mypy tests/unit/sources
- PATH=/tmp/polylogue-281/.cache/codex-bin:$PATH pytest -q tests/unit/sources
- PATH=/tmp/polylogue-281/.cache/codex-bin:$PATH mypy polylogue tests/unit/sources
- PATH=/tmp/polylogue-281/.cache/codex-bin:$PATH devtools verify --quick
- PATH=/tmp/polylogue-281/.cache/codex-bin:$PATH git push -u origin feature/refactor/sources-test-contracts
