### PR TITLE
test: type integration workflow contracts

### DIFF
--- a/tests/integration/test_chronology_extremes.py
+++ b/tests/integration/test_chronology_extremes.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import json
 import sqlite3
-from typing import Any
+from pathlib import Path
 
 import pytest
 
@@ -22,7 +22,7 @@ pytestmark = [pytest.mark.integration, pytest.mark.chaos]
 # =============================================================================
 
 
-def test_epoch_near_zero_timestamps_ingested(tmp_path: Any) -> None:
+def test_epoch_near_zero_timestamps_ingested(tmp_path: Path) -> None:
     """Test that timestamps near Unix epoch (1970) are ingested correctly."""
     workspace = setup_isolated_workspace(tmp_path)
     inbox = workspace["paths"]["inbox"]
@@ -53,7 +53,7 @@ def test_epoch_near_zero_timestamps_ingested(tmp_path: Any) -> None:
         assert count == 5, f"Expected 5 epoch records, got {count}"
 
 
-def test_y2038_adjacent_timestamps_ingested(tmp_path: Any) -> None:
+def test_y2038_adjacent_timestamps_ingested(tmp_path: Path) -> None:
     """Test that timestamps near Unix Y2K38 boundary (2038) are ingested."""
     workspace = setup_isolated_workspace(tmp_path)
     inbox = workspace["paths"]["inbox"]
@@ -81,7 +81,7 @@ def test_y2038_adjacent_timestamps_ingested(tmp_path: Any) -> None:
         assert count == 5, f"Expected 5 Y2038 records, got {count}"
 
 
-def test_far_future_timestamps_ingested(tmp_path: Any) -> None:
+def test_far_future_timestamps_ingested(tmp_path: Path) -> None:
     """Test that far-future timestamps (year 2065+) are accepted."""
     workspace = setup_isolated_workspace(tmp_path)
     inbox = workspace["paths"]["inbox"]
@@ -114,7 +114,7 @@ def test_far_future_timestamps_ingested(tmp_path: Any) -> None:
 # =============================================================================
 
 
-def test_mixed_timestamp_formats_coexist(tmp_path: Any) -> None:
+def test_mixed_timestamp_formats_coexist(tmp_path: Path) -> None:
     """Test that ISO, epoch float, and epoch string formats coexist in same file.
 
     Records may have:
@@ -154,7 +154,7 @@ def test_mixed_timestamp_formats_coexist(tmp_path: Any) -> None:
 # =============================================================================
 
 
-def test_missing_timestamps_handled(tmp_path: Any) -> None:
+def test_missing_timestamps_handled(tmp_path: Path) -> None:
     """Test that records without timestamps coexist with timestamped ones.
 
     Records may be missing the timestamp field entirely, and this should
@@ -192,7 +192,7 @@ def test_missing_timestamps_handled(tmp_path: Any) -> None:
 # =============================================================================
 
 
-def test_chronological_ordering_preserved(tmp_path: Any) -> None:
+def test_chronological_ordering_preserved(tmp_path: Path) -> None:
     """Test that output ordering respects input timestamp order.
 
     After ingestion, records should be retrievable in a consistent order
@@ -251,7 +251,7 @@ def test_chronological_ordering_preserved(tmp_path: Any) -> None:
     assert ids == expected_ids, f"Order mismatch: got {ids}, expected {expected_ids}"
 
 
-def test_tomorrow_timestamps_ingested(tmp_path: Any) -> None:
+def test_tomorrow_timestamps_ingested(tmp_path: Path) -> None:
     """Test that future timestamps (tomorrow) are accepted without error."""
     workspace = setup_isolated_workspace(tmp_path)
     inbox = workspace["paths"]["inbox"]
@@ -284,7 +284,7 @@ def test_tomorrow_timestamps_ingested(tmp_path: Any) -> None:
 # =============================================================================
 
 
-def test_all_timestamp_patterns_in_single_inbox(tmp_path: Any) -> None:
+def test_all_timestamp_patterns_in_single_inbox(tmp_path: Path) -> None:
     """Integration test: all timestamp patterns in one inbox."""
     workspace = setup_isolated_workspace(tmp_path)
     inbox = workspace["paths"]["inbox"]

--- a/tests/integration/test_cli_machine_contract.py
+++ b/tests/integration/test_cli_machine_contract.py
@@ -4,17 +4,17 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any, cast
 
 import pytest
 
+from polylogue.lib.json import JSONDocument, json_document
 from tests.infra.cli_subprocess import run_cli, setup_isolated_workspace
 
 pytestmark = [pytest.mark.integration, pytest.mark.machine_contract]
 
 
-def _parse_json(stdout: str) -> dict[str, Any]:
-    return cast(dict[str, Any], json.loads(stdout))
+def _parse_json(stdout: str) -> JSONDocument:
+    return json_document(json.loads(stdout))
 
 
 def test_script_entrypoint_invalid_flag_emits_json_error(tmp_path: Path) -> None:

--- a/tests/integration/test_facade.py
+++ b/tests/integration/test_facade.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from typing import Any
+from pathlib import Path
 
 import pytest
 
@@ -12,7 +12,7 @@ from polylogue.config import Source
 
 
 @pytest.fixture
-def sample_chatgpt_file(tmp_path: Any) -> Any:
+def sample_chatgpt_file(tmp_path: Path) -> Path:
     """Create a sample ChatGPT export file."""
     export = {
         "title": "Python Help",
@@ -59,7 +59,7 @@ def sample_chatgpt_file(tmp_path: Any) -> Any:
 
 
 @pytest.fixture
-def sample_claude_file(tmp_path: Any) -> Any:
+def sample_claude_file(tmp_path: Path) -> Path:
     """Create a sample Claude AI export file."""
     # Claude AI exports are JSONL with chat_messages array
     export = {
@@ -92,7 +92,7 @@ class TestPolylogueParsing:
     """Test ingestion functionality."""
 
     @pytest.mark.asyncio
-    async def test_ingest_chatgpt_file(self, workspace_env: Any, sample_chatgpt_file: Any) -> None:
+    async def test_ingest_chatgpt_file(self, workspace_env: dict[str, Path], sample_chatgpt_file: Path) -> None:
         """Test ingesting a ChatGPT export file."""
         archive = Polylogue(
             archive_root=workspace_env["archive_root"],
@@ -111,7 +111,7 @@ class TestPolylogueParsing:
         assert conversations[0].title == "Python Help"
 
     @pytest.mark.asyncio
-    async def test_ingest_claude_file(self, workspace_env: Any, sample_claude_file: Any) -> None:
+    async def test_ingest_claude_file(self, workspace_env: dict[str, Path], sample_claude_file: Path) -> None:
         """Test ingesting a Claude AI export file."""
         archive = Polylogue(
             archive_root=workspace_env["archive_root"],
@@ -129,7 +129,9 @@ class TestPolylogueParsing:
         assert len(conversations) > 0
 
     @pytest.mark.asyncio
-    async def test_ingest_duplicate_is_idempotent(self, workspace_env: Any, sample_chatgpt_file: Any) -> None:
+    async def test_ingest_duplicate_is_idempotent(
+        self, workspace_env: dict[str, Path], sample_chatgpt_file: Path
+    ) -> None:
         """Test that re-ingesting the same file skips duplicates.
 
         With stage-based ingestion (acquire → parse), duplicates are skipped
@@ -156,7 +158,9 @@ class TestPolylogueParsing:
         assert len(conversations) == first_count
 
     @pytest.mark.asyncio
-    async def test_ingest_with_custom_source_name(self, workspace_env: Any, sample_chatgpt_file: Any) -> None:
+    async def test_ingest_with_custom_source_name(
+        self, workspace_env: dict[str, Path], sample_chatgpt_file: Path
+    ) -> None:
         """Test ingesting with a custom source name."""
         archive = Polylogue(
             archive_root=workspace_env["archive_root"],
@@ -167,7 +171,9 @@ class TestPolylogueParsing:
         assert result.counts["conversations"] > 0
 
     @pytest.mark.asyncio
-    async def test_parse_sources(self, workspace_env: Any, sample_chatgpt_file: Any, sample_claude_file: Any) -> None:
+    async def test_parse_sources(
+        self, workspace_env: dict[str, Path], sample_chatgpt_file: Path, sample_claude_file: Path
+    ) -> None:
         """Test ingesting multiple sources."""
         db_path = workspace_env["data_root"] / "polylogue.db"
 
@@ -203,7 +209,7 @@ class TestPolylogueQuery:
     """Test query functionality."""
 
     @pytest.mark.asyncio
-    async def test_get_conversation_by_full_id(self, workspace_env: Any, sample_chatgpt_file: Any) -> None:
+    async def test_get_conversation_by_full_id(self, workspace_env: dict[str, Path], sample_chatgpt_file: Path) -> None:
         """Test getting a conversation by full ID."""
         archive = Polylogue(
             archive_root=workspace_env["archive_root"],
@@ -222,7 +228,9 @@ class TestPolylogueQuery:
         assert conv.title == "Python Help"
 
     @pytest.mark.asyncio
-    async def test_get_conversation_by_partial_id(self, workspace_env: Any, sample_chatgpt_file: Any) -> None:
+    async def test_get_conversation_by_partial_id(
+        self, workspace_env: dict[str, Path], sample_chatgpt_file: Path
+    ) -> None:
         """Test getting a conversation by partial ID (prefix match)."""
         archive = Polylogue(
             archive_root=workspace_env["archive_root"],
@@ -241,7 +249,7 @@ class TestPolylogueQuery:
         assert conv.id == conv_id
 
     @pytest.mark.asyncio
-    async def test_get_conversation_nonexistent(self, workspace_env: Any) -> None:
+    async def test_get_conversation_nonexistent(self, workspace_env: dict[str, Path]) -> None:
         """Test getting a non-existent conversation returns None."""
         archive = Polylogue(
             archive_root=workspace_env["archive_root"],
@@ -253,7 +261,7 @@ class TestPolylogueQuery:
 
     @pytest.mark.asyncio
     async def test_list_conversations_all(
-        self, workspace_env: Any, sample_chatgpt_file: Any, sample_claude_file: Any
+        self, workspace_env: dict[str, Path], sample_chatgpt_file: Path, sample_claude_file: Path
     ) -> None:
         """Test listing all conversations."""
         archive = Polylogue(
@@ -271,7 +279,7 @@ class TestPolylogueQuery:
 
     @pytest.mark.asyncio
     async def test_list_conversations_filter_by_provider(
-        self, workspace_env: Any, sample_chatgpt_file: Any, sample_claude_file: Any
+        self, workspace_env: dict[str, Path], sample_chatgpt_file: Path, sample_claude_file: Path
     ) -> None:
         """Test filtering conversations by provider."""
         archive = Polylogue(
@@ -293,7 +301,9 @@ class TestPolylogueQuery:
         assert all(c.provider == "claude-ai" for c in claude_convs)
 
     @pytest.mark.asyncio
-    async def test_list_conversations_with_limit(self, workspace_env: Any, sample_chatgpt_file: Any) -> None:
+    async def test_list_conversations_with_limit(
+        self, workspace_env: dict[str, Path], sample_chatgpt_file: Path
+    ) -> None:
         """Test limiting the number of conversations returned."""
         archive = Polylogue(
             archive_root=workspace_env["archive_root"],
@@ -311,7 +321,9 @@ class TestPolylogueSemanticProjections:
     """Test semantic projections on retrieved conversations."""
 
     @pytest.mark.asyncio
-    async def test_conversation_substantive_only(self, workspace_env: Any, sample_chatgpt_file: Any) -> None:
+    async def test_conversation_substantive_only(
+        self, workspace_env: dict[str, Path], sample_chatgpt_file: Path
+    ) -> None:
         """Test getting substantive messages only."""
         archive = Polylogue(
             archive_root=workspace_env["archive_root"],
@@ -330,7 +342,7 @@ class TestPolylogueSemanticProjections:
         assert all(msg.is_substantive for msg in substantive)
 
     @pytest.mark.asyncio
-    async def test_conversation_iter_pairs(self, workspace_env: Any, sample_chatgpt_file: Any) -> None:
+    async def test_conversation_iter_pairs(self, workspace_env: dict[str, Path], sample_chatgpt_file: Path) -> None:
         """Test iterating user/assistant pairs."""
         archive = Polylogue(
             archive_root=workspace_env["archive_root"],
@@ -350,7 +362,7 @@ class TestPolylogueSemanticProjections:
             assert pair.assistant.role == "assistant"
 
     @pytest.mark.asyncio
-    async def test_conversation_without_noise(self, workspace_env: Any, sample_chatgpt_file: Any) -> None:
+    async def test_conversation_without_noise(self, workspace_env: dict[str, Path], sample_chatgpt_file: Path) -> None:
         """Test filtering out noise messages."""
         archive = Polylogue(
             archive_root=workspace_env["archive_root"],
@@ -371,7 +383,7 @@ class TestPolylogueSearch:
     """Test search functionality."""
 
     @pytest.mark.asyncio
-    async def test_search_basic(self, workspace_env: Any, sample_chatgpt_file: Any) -> None:
+    async def test_search_basic(self, workspace_env: dict[str, Path], sample_chatgpt_file: Path) -> None:
         """Test basic search functionality."""
         archive = Polylogue(
             archive_root=workspace_env["archive_root"],
@@ -394,7 +406,7 @@ class TestPolylogueSearch:
         assert first_hit.conversation_path.name == "conversation.md"
 
     @pytest.mark.asyncio
-    async def test_search_with_limit(self, workspace_env: Any, sample_chatgpt_file: Any) -> None:
+    async def test_search_with_limit(self, workspace_env: dict[str, Path], sample_chatgpt_file: Path) -> None:
         """Test search with result limit."""
         archive = Polylogue(
             archive_root=workspace_env["archive_root"],
@@ -419,7 +431,7 @@ class TestPolylogueEdgeCases:
     """Test edge cases and error handling."""
 
     @pytest.mark.asyncio
-    async def test_empty_archive(self, workspace_env: Any) -> None:
+    async def test_empty_archive(self, workspace_env: dict[str, Path]) -> None:
         """Test operations on an empty archive."""
         archive = Polylogue(
             archive_root=workspace_env["archive_root"],
@@ -435,7 +447,7 @@ class TestPolylogueEdgeCases:
         assert conv is None
 
     @pytest.mark.asyncio
-    async def test_ingest_nonexistent_file(self, workspace_env: Any, tmp_path: Any) -> None:
+    async def test_ingest_nonexistent_file(self, workspace_env: dict[str, Path], tmp_path: Path) -> None:
         """Test ingesting a non-existent file."""
         archive = Polylogue(
             archive_root=workspace_env["archive_root"],

--- a/tests/integration/test_health.py
+++ b/tests/integration/test_health.py
@@ -3,7 +3,11 @@
 from __future__ import annotations
 
 import hashlib
-from typing import Any
+import sqlite3
+from pathlib import Path
+from typing import TypeAlias
+
+CliWorkspace: TypeAlias = dict[str, Path]
 
 RUN_ALL_REPAIRS_EXPECTED = {
     "session_products",
@@ -17,7 +21,9 @@ RUN_ALL_REPAIRS_EXPECTED = {
 }
 
 
-def _insert_conversation(conn: Any, conversation_id: str, provider_name: str = "test", title: str = "Test") -> None:
+def _insert_conversation(
+    conn: sqlite3.Connection, conversation_id: str, provider_name: str = "test", title: str = "Test"
+) -> None:
     """Helper to insert a conversation with all required fields."""
     content_hash = hashlib.sha256(f"{provider_name}:{conversation_id}".encode()).hexdigest()
     conn.execute(
@@ -27,7 +33,7 @@ def _insert_conversation(conn: Any, conversation_id: str, provider_name: str = "
 
 
 def _insert_message(
-    conn: Any,
+    conn: sqlite3.Connection,
     message_id: str,
     conversation_id: str,
     role: str = "user",
@@ -54,7 +60,7 @@ def _insert_message(
 
 
 def _insert_content_block(
-    conn: Any,
+    conn: sqlite3.Connection,
     block_id: str,
     message_id: str,
     conversation_id: str,
@@ -94,7 +100,7 @@ def _insert_content_block(
 class TestRepairOrphanedMessages:
     """Tests for repair_orphaned_messages function."""
 
-    def test_clean_state_no_orphaned_messages(self, cli_workspace: Any) -> None:
+    def test_clean_state_no_orphaned_messages(self, cli_workspace: CliWorkspace) -> None:
         """repair_orphaned_messages should return 0 when no orphans exist."""
         from polylogue.config import get_config
         from polylogue.storage.backends.connection import connection_context
@@ -116,7 +122,7 @@ class TestRepairOrphanedMessages:
         assert result.success is True
         assert "No orphaned" in result.detail
 
-    def test_orphaned_messages_found_and_deleted(self, cli_workspace: Any) -> None:
+    def test_orphaned_messages_found_and_deleted(self, cli_workspace: CliWorkspace) -> None:
         """repair_orphaned_messages should find and delete orphaned messages."""
         from polylogue.config import get_config
         from polylogue.storage.backends.connection import connection_context
@@ -142,7 +148,7 @@ class TestRepairOrphanedMessages:
             remaining = conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0]
             assert remaining == 0
 
-    def test_orphaned_messages_dry_run_counts_but_doesnt_delete(self, cli_workspace: Any) -> None:
+    def test_orphaned_messages_dry_run_counts_but_doesnt_delete(self, cli_workspace: CliWorkspace) -> None:
         """repair_orphaned_messages with dry_run=True should count but not delete."""
         from polylogue.config import get_config
         from polylogue.storage.backends.connection import connection_context
@@ -166,7 +172,7 @@ class TestRepairOrphanedMessages:
             remaining = conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0]
             assert remaining == 1
 
-    def test_orphaned_messages_idempotency(self, cli_workspace: Any) -> None:
+    def test_orphaned_messages_idempotency(self, cli_workspace: CliWorkspace) -> None:
         """Running repair twice should find 0 on second run."""
         from polylogue.config import get_config
         from polylogue.storage.backends.connection import connection_context
@@ -189,7 +195,7 @@ class TestRepairOrphanedMessages:
 class TestRepairOrphanedContentBlocks:
     """Tests for repair_orphaned_content_blocks function."""
 
-    def test_clean_state_no_orphaned_content_blocks(self, cli_workspace: Any) -> None:
+    def test_clean_state_no_orphaned_content_blocks(self, cli_workspace: CliWorkspace) -> None:
         from polylogue.config import get_config
         from polylogue.storage.backends.connection import connection_context
         from polylogue.storage.repair import repair_orphaned_content_blocks
@@ -207,7 +213,7 @@ class TestRepairOrphanedContentBlocks:
         assert result.repaired_count == 0
         assert result.success is True
 
-    def test_orphaned_content_blocks_found_and_deleted(self, cli_workspace: Any) -> None:
+    def test_orphaned_content_blocks_found_and_deleted(self, cli_workspace: CliWorkspace) -> None:
         from polylogue.config import get_config
         from polylogue.storage.backends.connection import connection_context
         from polylogue.storage.repair import repair_orphaned_content_blocks
@@ -241,7 +247,7 @@ class TestRepairOrphanedContentBlocks:
             remaining = conn.execute("SELECT COUNT(*) FROM content_blocks").fetchone()[0]
             assert remaining == 0
 
-    def test_orphaned_content_blocks_dry_run_counts_but_doesnt_delete(self, cli_workspace: Any) -> None:
+    def test_orphaned_content_blocks_dry_run_counts_but_doesnt_delete(self, cli_workspace: CliWorkspace) -> None:
         from polylogue.config import get_config
         from polylogue.storage.backends.connection import connection_context
         from polylogue.storage.repair import repair_orphaned_content_blocks
@@ -267,7 +273,7 @@ class TestRepairOrphanedContentBlocks:
             remaining = conn.execute("SELECT COUNT(*) FROM content_blocks").fetchone()[0]
             assert remaining == 1
 
-    def test_orphaned_content_blocks_idempotency(self, cli_workspace: Any) -> None:
+    def test_orphaned_content_blocks_idempotency(self, cli_workspace: CliWorkspace) -> None:
         from polylogue.config import get_config
         from polylogue.storage.backends.connection import connection_context
         from polylogue.storage.repair import repair_orphaned_content_blocks
@@ -294,7 +300,7 @@ class TestRepairOrphanedContentBlocks:
 class TestRepairEmptyConversations:
     """Tests for repair_empty_conversations function."""
 
-    def test_clean_state_no_empty_conversations(self, cli_workspace: Any) -> None:
+    def test_clean_state_no_empty_conversations(self, cli_workspace: CliWorkspace) -> None:
         """repair_empty_conversations should return 0 when no empty convos exist."""
         from polylogue.config import get_config
         from polylogue.storage.backends.connection import connection_context
@@ -315,7 +321,7 @@ class TestRepairEmptyConversations:
         assert result.repaired_count == 0
         assert result.success is True
 
-    def test_empty_conversations_found_and_deleted(self, cli_workspace: Any) -> None:
+    def test_empty_conversations_found_and_deleted(self, cli_workspace: CliWorkspace) -> None:
         """repair_empty_conversations should find and delete empty conversations."""
         from polylogue.config import get_config
         from polylogue.storage.backends.connection import connection_context
@@ -341,7 +347,7 @@ class TestRepairEmptyConversations:
             remaining = conn.execute("SELECT COUNT(*) FROM conversations").fetchone()[0]
             assert remaining == 0
 
-    def test_empty_conversations_dry_run_counts_but_doesnt_delete(self, cli_workspace: Any) -> None:
+    def test_empty_conversations_dry_run_counts_but_doesnt_delete(self, cli_workspace: CliWorkspace) -> None:
         """repair_empty_conversations with dry_run=True should count but not delete."""
         from polylogue.config import get_config
         from polylogue.storage.backends.connection import connection_context
@@ -364,7 +370,7 @@ class TestRepairEmptyConversations:
             remaining = conn.execute("SELECT COUNT(*) FROM conversations").fetchone()[0]
             assert remaining == 1
 
-    def test_empty_conversations_idempotency(self, cli_workspace: Any) -> None:
+    def test_empty_conversations_idempotency(self, cli_workspace: CliWorkspace) -> None:
         """Running repair twice should find 0 on second run."""
         from polylogue.config import get_config
         from polylogue.storage.backends.connection import connection_context
@@ -387,7 +393,7 @@ class TestRepairEmptyConversations:
 class TestRepairDanglingFts:
     """Tests for repair_dangling_fts function."""
 
-    def test_clean_fts_state(self, cli_workspace: Any) -> None:
+    def test_clean_fts_state(self, cli_workspace: CliWorkspace) -> None:
         """repair_dangling_fts should return 0 when FTS is in sync."""
         from polylogue.config import get_config
         from polylogue.storage.backends.connection import connection_context
@@ -408,7 +414,7 @@ class TestRepairDanglingFts:
         assert result.repaired_count == 0
         assert result.success is True
 
-    def test_dangling_fts_orphaned_entry(self, cli_workspace: Any) -> None:
+    def test_dangling_fts_orphaned_entry(self, cli_workspace: CliWorkspace) -> None:
         """repair_dangling_fts should find and delete FTS entries without messages."""
         from polylogue.config import get_config
         from polylogue.storage.backends.connection import connection_context
@@ -442,7 +448,7 @@ class TestRepairDanglingFts:
         assert result.repaired_count == 1
         assert result.success is True
 
-    def test_dangling_fts_missing_entry(self, cli_workspace: Any) -> None:
+    def test_dangling_fts_missing_entry(self, cli_workspace: CliWorkspace) -> None:
         """repair_dangling_fts should insert missing FTS entries for messages."""
         from polylogue.config import get_config
         from polylogue.storage.backends.connection import connection_context
@@ -476,7 +482,7 @@ class TestRepairDanglingFts:
         assert result.repaired_count == 1
         assert result.success is True
 
-    def test_dangling_fts_dry_run_counts_but_doesnt_modify(self, cli_workspace: Any) -> None:
+    def test_dangling_fts_dry_run_counts_but_doesnt_modify(self, cli_workspace: CliWorkspace) -> None:
         """repair_dangling_fts with dry_run=True should count but not modify."""
         from polylogue.config import get_config
         from polylogue.storage.backends.connection import connection_context
@@ -505,7 +511,7 @@ class TestRepairDanglingFts:
             fts_count = conn.execute("SELECT COUNT(*) FROM messages_fts").fetchone()[0]
             assert abs(msg_count - fts_count) == initial_diff
 
-    def test_dangling_fts_ignores_null_text_messages(self, cli_workspace: Any) -> None:
+    def test_dangling_fts_ignores_null_text_messages(self, cli_workspace: CliWorkspace) -> None:
         """Null-text messages should not count as missing FTS rows."""
         from polylogue.config import get_config
         from polylogue.storage.backends.connection import connection_context
@@ -532,7 +538,7 @@ class TestRepairDanglingFts:
 class TestRepairActionEventReadModel:
     """Tests for repair_action_event_read_model function."""
 
-    def test_clean_action_event_state(self, cli_workspace: Any) -> None:
+    def test_clean_action_event_state(self, cli_workspace: CliWorkspace) -> None:
         from polylogue.config import get_config
         from polylogue.storage.backends.connection import connection_context
         from polylogue.storage.repair import repair_action_event_read_model
@@ -553,7 +559,7 @@ class TestRepairActionEventReadModel:
             assert conn.execute("SELECT COUNT(*) FROM action_events").fetchone()[0] > 0
             assert conn.execute("SELECT COUNT(*) FROM action_events_fts").fetchone()[0] > 0
 
-    def test_action_event_read_model_dry_run(self, cli_workspace: Any) -> None:
+    def test_action_event_read_model_dry_run(self, cli_workspace: CliWorkspace) -> None:
         from polylogue.config import get_config
         from polylogue.storage.backends.connection import connection_context
         from polylogue.storage.repair import repair_action_event_read_model
@@ -575,7 +581,7 @@ class TestRepairActionEventReadModel:
 class TestRepairOrphanedAttachments:
     """Tests for repair_orphaned_attachments function."""
 
-    def test_clean_attachments_state(self, cli_workspace: Any) -> None:
+    def test_clean_attachments_state(self, cli_workspace: CliWorkspace) -> None:
         """repair_orphaned_attachments should return 0 when all attachments are referenced."""
         from polylogue.config import get_config
         from polylogue.storage.backends.connection import connection_context
@@ -604,7 +610,7 @@ class TestRepairOrphanedAttachments:
         assert result.repaired_count == 0
         assert result.success is True
 
-    def test_orphaned_attachments_orphaned_refs(self, cli_workspace: Any) -> None:
+    def test_orphaned_attachments_orphaned_refs(self, cli_workspace: CliWorkspace) -> None:
         """repair_orphaned_attachments should detect orphaned attachment refs in dry-run."""
         from polylogue.config import get_config
         from polylogue.storage.backends.connection import connection_context
@@ -638,7 +644,7 @@ class TestRepairOrphanedAttachments:
         # Should delete at least the unreferenced attachment
         assert result.repaired_count >= 1
 
-    def test_orphaned_attachments_unreferenced_attachment(self, cli_workspace: Any) -> None:
+    def test_orphaned_attachments_unreferenced_attachment(self, cli_workspace: CliWorkspace) -> None:
         """repair_orphaned_attachments should delete unreferenced attachments."""
         from polylogue.config import get_config
         from polylogue.storage.backends.connection import connection_context
@@ -660,7 +666,7 @@ class TestRepairOrphanedAttachments:
         assert result.name == "orphaned_attachments"
         assert result.repaired_count >= 1  # Should delete the unreferenced attachment
 
-    def test_orphaned_attachments_dry_run(self, cli_workspace: Any) -> None:
+    def test_orphaned_attachments_dry_run(self, cli_workspace: CliWorkspace) -> None:
         """repair_orphaned_attachments with dry_run=True should count but not delete."""
         from polylogue.config import get_config
         from polylogue.storage.backends.connection import connection_context
@@ -689,7 +695,7 @@ class TestRepairOrphanedAttachments:
 class TestRepairWalCheckpoint:
     """Tests for repair_wal_checkpoint function."""
 
-    def test_wal_checkpoint_succeeds(self, cli_workspace: Any) -> None:
+    def test_wal_checkpoint_succeeds(self, cli_workspace: CliWorkspace) -> None:
         """repair_wal_checkpoint should execute without crashing."""
         from polylogue.config import get_config
         from polylogue.storage.repair import repair_wal_checkpoint
@@ -704,7 +710,7 @@ class TestRepairWalCheckpoint:
         assert result.success is True
         # repaired_count and detail depend on WAL file state; just verify no crash
 
-    def test_wal_checkpoint_dry_run(self, cli_workspace: Any) -> None:
+    def test_wal_checkpoint_dry_run(self, cli_workspace: CliWorkspace) -> None:
         """repair_wal_checkpoint with dry_run=True should inspect WAL without modifying."""
         from polylogue.config import get_config
         from polylogue.storage.repair import repair_wal_checkpoint
@@ -723,7 +729,7 @@ class TestRepairWalCheckpoint:
 class TestMaintenanceSelection:
     """Tests for safe repair and archive cleanup orchestration."""
 
-    def test_run_safe_repairs_returns_safe_results(self, cli_workspace: Any) -> None:
+    def test_run_safe_repairs_returns_safe_results(self, cli_workspace: CliWorkspace) -> None:
         """run_safe_repairs should return only non-destructive maintenance functions."""
         from polylogue.config import get_config
         from polylogue.storage.repair import run_safe_repairs
@@ -742,7 +748,7 @@ class TestMaintenanceSelection:
         assert all(r.destructive is False for r in results)
         assert all(r.category.value in {"derived_repair", "database_maintenance"} for r in results)
 
-    def test_run_archive_cleanup_returns_destructive_results(self, cli_workspace: Any) -> None:
+    def test_run_archive_cleanup_returns_destructive_results(self, cli_workspace: CliWorkspace) -> None:
         """run_archive_cleanup should return only destructive cleanup functions."""
         from polylogue.config import get_config
         from polylogue.storage.repair import run_archive_cleanup
@@ -758,7 +764,7 @@ class TestMaintenanceSelection:
         assert all(r.destructive is True for r in results)
         assert all(r.category.value == "archive_cleanup" for r in results)
 
-    def test_run_selected_maintenance_dry_run_all_have_would(self, cli_workspace: Any) -> None:
+    def test_run_selected_maintenance_dry_run_all_have_would(self, cli_workspace: CliWorkspace) -> None:
         """Selected maintenance dry run should describe pending work explicitly."""
         from polylogue.config import get_config
         from polylogue.storage.backends.connection import connection_context
@@ -775,7 +781,7 @@ class TestMaintenanceSelection:
 
         assert any("Would:" in r.detail for r in results), "Expected at least one 'Would:' in dry-run results"
 
-    def test_run_selected_maintenance_uses_preview_counts(self, cli_workspace: Any) -> None:
+    def test_run_selected_maintenance_uses_preview_counts(self, cli_workspace: CliWorkspace) -> None:
         """Dry-run maintenance can reuse known counts instead of rescanning the archive."""
         from polylogue.config import get_config
         from polylogue.storage.repair import run_selected_maintenance
@@ -804,7 +810,7 @@ class TestMaintenanceSelection:
         assert by_name["orphaned_content_blocks"].repaired_count == 11
         assert by_name["empty_conversations"].repaired_count == 5
 
-    def test_run_selected_maintenance_can_scope_to_session_products(self, cli_workspace: Any) -> None:
+    def test_run_selected_maintenance_can_scope_to_session_products(self, cli_workspace: CliWorkspace) -> None:
         """Scoped maintenance should repair only the durable session-product layer."""
         from polylogue.config import get_config
         from polylogue.storage.backends.connection import connection_context
@@ -836,7 +842,7 @@ class TestMaintenanceSelection:
         assert profile_count == 1
         assert thread_count == 1
 
-    def test_run_selected_maintenance_idempotency_after_full_run(self, cli_workspace: Any) -> None:
+    def test_run_selected_maintenance_idempotency_after_full_run(self, cli_workspace: CliWorkspace) -> None:
         """Selected maintenance twice should find 0 issues on second run."""
         from polylogue.config import get_config
         from polylogue.storage.backends.connection import connection_context

--- a/tests/integration/test_schema_operator_workflow.py
+++ b/tests/integration/test_schema_operator_workflow.py
@@ -12,8 +12,8 @@ commands that read/write from it.
 from __future__ import annotations
 
 import json
+from contextlib import AbstractContextManager
 from pathlib import Path
-from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -132,7 +132,7 @@ def seeded_registry(schema_storage: Path) -> SchemaRegistry:
     return registry
 
 
-def _patch_registry(registry: SchemaRegistry) -> Any:
+def _patch_registry(registry: SchemaRegistry) -> AbstractContextManager[object]:
     """Context manager to patch SchemaRegistry() calls to return our seeded instance."""
     return patch(
         "polylogue.schemas.registry.SchemaRegistry",

--- a/tests/integration/test_workflows.py
+++ b/tests/integration/test_workflows.py
@@ -17,11 +17,12 @@ import json
 import tempfile
 from collections.abc import AsyncGenerator
 from pathlib import Path
-from typing import Any
+from typing import Literal, Protocol, TypeAlias
 
 import pytest
 
 from polylogue.config import Config, Source
+from polylogue.lib.json import JSONDocument
 from polylogue.pipeline.runner import run_sources
 from polylogue.pipeline.services.parsing import ParsingService
 from polylogue.storage.backends.async_sqlite import SQLiteBackend
@@ -29,15 +30,29 @@ from polylogue.storage.repository import ConversationRepository
 
 pytestmark = pytest.mark.slow
 
+WorkflowRepos: TypeAlias = tuple[Config, ConversationRepository, ConversationRepository, Path, Path]
+ProviderName: TypeAlias = Literal["chatgpt", "claude-ai", "claude-code", "codex", "gemini"]
+RenderFormat: TypeAlias = Literal["markdown", "html"]
+PipelineStage: TypeAlias = Literal["all", "parse"]
+
+
+class SyntheticSourceFactory(Protocol):
+    def __call__(
+        self,
+        provider: str,
+        count: int = 1,
+        messages_per_conversation: range = range(4, 12),
+        seed: int = 42,
+    ) -> Source: ...
+
+
 # =============================================================================
 # FIXTURES
 # =============================================================================
 
 
 @pytest.fixture
-async def temp_config_and_repo(
-    tmp_path: Any, monkeypatch: Any
-) -> AsyncGenerator[tuple[Config, ConversationRepository, ConversationRepository, Path, Path], None]:
+async def temp_config_and_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> AsyncGenerator[WorkflowRepos, None]:
     """Create temporary config and storage repositories for testing."""
     monkeypatch.setenv("POLYLOGUE_SCHEMA_VALIDATION", "off")
     archive_root = tmp_path / "archive"
@@ -70,13 +85,13 @@ async def temp_config_and_repo(
 
 
 @pytest.fixture
-def chatgpt_sample_source(synthetic_source: Any) -> Any:
+def chatgpt_sample_source(synthetic_source: SyntheticSourceFactory) -> Source:
     """Source with synthetic ChatGPT data."""
     return synthetic_source("chatgpt")
 
 
 @pytest.fixture
-def gemini_sample_source(synthetic_source: Any) -> Any:
+def gemini_sample_source(synthetic_source: SyntheticSourceFactory) -> Source:
     """Source with synthetic Gemini data."""
     return synthetic_source("gemini")
 
@@ -87,7 +102,9 @@ def gemini_sample_source(synthetic_source: Any) -> Any:
 
 
 @pytest.mark.parametrize("provider", ["chatgpt", "claude-ai", "claude-code", "codex", "gemini"])
-async def test_full_workflow_per_provider(provider: Any, synthetic_source: Any, temp_config_and_repo: Any) -> None:
+async def test_full_workflow_per_provider(
+    provider: ProviderName, synthetic_source: SyntheticSourceFactory, temp_config_and_repo: WorkflowRepos
+) -> None:
     """Import → Store → Query → Render for each provider."""
     config, storage_repo, conv_repo, archive_root, db_path = temp_config_and_repo
 
@@ -137,8 +154,9 @@ async def test_full_workflow_per_provider(provider: Any, synthetic_source: Any, 
     assert any(m.text in markdown for m in conv.messages if m.text), "No message text found in markdown"
 
     # 5. SEARCH: Full-text search works
-    first_words = conv.messages[0].text.split()[:3]
-    if first_words:
+    first_text = next((message.text for message in conv.messages if message.text), None)
+    if first_text:
+        first_words = first_text.split()[:3]
         search_term = " ".join(first_words)
         search_result = search_messages(
             search_term,
@@ -156,7 +174,9 @@ async def test_full_workflow_per_provider(provider: Any, synthetic_source: Any, 
 
 
 @pytest.mark.parametrize("format", ["markdown", "html"])
-async def test_render_formats(format: Any, temp_config_and_repo: Any, chatgpt_sample_source: Any) -> None:
+async def test_render_formats(
+    format: RenderFormat, temp_config_and_repo: WorkflowRepos, chatgpt_sample_source: Source
+) -> None:
     """Verify each output format works end-to-end."""
     config, storage_repo, conv_repo, archive_root, db_path = temp_config_and_repo
 
@@ -204,7 +224,9 @@ async def test_render_formats(format: Any, temp_config_and_repo: Any, chatgpt_sa
 # =============================================================================
 
 
-async def test_incremental_sync_no_duplicates(temp_config_and_repo: Any, chatgpt_sample_source: Any) -> None:
+async def test_incremental_sync_no_duplicates(
+    temp_config_and_repo: WorkflowRepos, chatgpt_sample_source: Source
+) -> None:
     """Syncing same source twice doesn't create duplicates."""
     config, storage_repo, conv_repo, archive_root, db_path = temp_config_and_repo
 
@@ -230,13 +252,13 @@ async def test_incremental_sync_no_duplicates(temp_config_and_repo: Any, chatgpt
     assert len(all_convs) == count1
 
 
-async def test_incremental_sync_with_updates(temp_config_and_repo: Any) -> None:
+async def test_incremental_sync_with_updates(temp_config_and_repo: WorkflowRepos) -> None:
     """Modified conversations are updated, not duplicated."""
     config, storage_repo, conv_repo, archive_root, db_path = temp_config_and_repo
 
     # Create initial source with 1 conversation
     with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
-        conv_v1: dict[str, Any] = {
+        conv_v1: JSONDocument = {
             "id": "test-conv-1",
             "title": "Version 1",
             "mapping": {
@@ -275,9 +297,30 @@ async def test_incremental_sync_with_updates(temp_config_and_repo: Any) -> None:
 
         # Modify conversation
         with open(source_path_v1, "w") as f:
-            conv_v2: dict[str, Any] = conv_v1.copy()
-            conv_v2["title"] = "Version 2"
-            conv_v2["mapping"]["node2"]["message"]["content"]["parts"] = ["Updated answer"]
+            conv_v2: JSONDocument = {
+                "id": "test-conv-1",
+                "title": "Version 2",
+                "mapping": {
+                    "node1": {
+                        "id": "node1",
+                        "message": {
+                            "id": "msg1",
+                            "author": {"role": "user"},
+                            "content": {"parts": ["Original question"]},
+                        },
+                        "children": ["node2"],
+                    },
+                    "node2": {
+                        "id": "node2",
+                        "parent": "node1",
+                        "message": {
+                            "id": "msg2",
+                            "author": {"role": "assistant"},
+                            "content": {"parts": ["Updated answer"]},
+                        },
+                    },
+                },
+            }
             json.dump(conv_v2, f)
 
         # Second sync
@@ -296,7 +339,7 @@ async def test_incremental_sync_with_updates(temp_config_and_repo: Any) -> None:
         source_path_v1.unlink()
 
 
-async def test_sync_handles_deleted_conversations(temp_config_and_repo: Any) -> None:
+async def test_sync_handles_deleted_conversations(temp_config_and_repo: WorkflowRepos) -> None:
     """Conversations removed from source are NOT deleted from archive.
 
     This is expected behavior - archive is append-only.
@@ -367,7 +410,7 @@ async def test_sync_handles_deleted_conversations(temp_config_and_repo: Any) -> 
 
 
 async def test_multi_source_concurrent_sync(
-    temp_config_and_repo: Any, chatgpt_sample_source: Any, gemini_sample_source: Any
+    temp_config_and_repo: WorkflowRepos, chatgpt_sample_source: Source, gemini_sample_source: Source
 ) -> None:
     """Multiple sources can sync concurrently."""
     config, storage_repo, conv_repo, archive_root, db_path = temp_config_and_repo
@@ -391,7 +434,7 @@ async def test_multi_source_concurrent_sync(
     assert len(providers) >= 2
 
 
-async def test_multi_source_isolated_namespaces(temp_config_and_repo: Any) -> None:
+async def test_multi_source_isolated_namespaces(temp_config_and_repo: WorkflowRepos) -> None:
     """Each source can have different conversations."""
     config, storage_repo, conv_repo, archive_root, db_path = temp_config_and_repo
 
@@ -461,7 +504,7 @@ async def test_multi_source_isolated_namespaces(temp_config_and_repo: Any) -> No
 # =============================================================================
 
 
-async def test_sync_with_malformed_file_skips_gracefully(temp_config_and_repo: Any) -> None:
+async def test_sync_with_malformed_file_skips_gracefully(temp_config_and_repo: WorkflowRepos) -> None:
     """Malformed files are skipped, don't crash entire sync."""
     config, storage_repo, conv_repo, archive_root, db_path = temp_config_and_repo
 
@@ -488,7 +531,7 @@ async def test_sync_with_malformed_file_skips_gracefully(temp_config_and_repo: A
         bad_path.unlink()
 
 
-async def test_sync_with_missing_file_reports_error(temp_config_and_repo: Any) -> None:
+async def test_sync_with_missing_file_reports_error(temp_config_and_repo: WorkflowRepos) -> None:
     """Missing source files are reported, don't crash."""
     config, storage_repo, conv_repo, archive_root, db_path = temp_config_and_repo
 
@@ -506,7 +549,9 @@ async def test_sync_with_missing_file_reports_error(temp_config_and_repo: Any) -
     assert result.counts["conversations"] == 0
 
 
-async def test_sync_partial_success_with_mixed_sources(temp_config_and_repo: Any, chatgpt_sample_source: Any) -> None:
+async def test_sync_partial_success_with_mixed_sources(
+    temp_config_and_repo: WorkflowRepos, chatgpt_sample_source: Source
+) -> None:
     """If some sources fail, successful ones still sync."""
     config, storage_repo, conv_repo, archive_root, db_path = temp_config_and_repo
 
@@ -537,7 +582,7 @@ async def test_sync_partial_success_with_mixed_sources(temp_config_and_repo: Any
 # =============================================================================
 
 
-async def test_search_accuracy_basic_terms(temp_config_and_repo: Any, chatgpt_sample_source: Any) -> None:
+async def test_search_accuracy_basic_terms(temp_config_and_repo: WorkflowRepos, chatgpt_sample_source: Source) -> None:
     """Search returns correct conversations for basic queries."""
     config, storage_repo, conv_repo, archive_root, db_path = temp_config_and_repo
 
@@ -582,7 +627,7 @@ async def test_search_accuracy_basic_terms(temp_config_and_repo: Any, chatgpt_sa
     assert target_conv.id in result_ids, f"Failed to find conversation with '{search_term}'"
 
 
-async def test_search_with_special_characters(temp_config_and_repo: Any) -> None:
+async def test_search_with_special_characters(temp_config_and_repo: WorkflowRepos) -> None:
     """Search handles special FTS5 characters correctly."""
     config, storage_repo, conv_repo, archive_root, db_path = temp_config_and_repo
 
@@ -658,7 +703,9 @@ async def test_search_with_special_characters(temp_config_and_repo: Any) -> None
     "stage",
     ["all", "parse"],
 )
-async def test_pipeline_runner_stage_matrix(workspace_env: Any, chatgpt_sample_source: Any, stage: Any) -> None:
+async def test_pipeline_runner_stage_matrix(
+    workspace_env: dict[str, Path], chatgpt_sample_source: Source, stage: PipelineStage
+) -> None:
     """run_sources handles both full and parse-only execution modes."""
     from polylogue.config import get_config
 


### PR DESCRIPTION
## Summary
- removes explicit dynamic typing from the integration test suite
- gives health-repair database helpers concrete SQLite connection types
- types integration fixtures, JSON payloads, CLI machine-contract decoding, and schema patch context managers

## Problem
The integration tests still used explicit Any annotations across health repair workflows, facade ingestion flows, end-to-end workflow tests, timestamp chaos tests, schema operator workflow tests, and CLI machine-contract tests. That left the highest-level contract tests less precise than the code paths they exercise.

Ref #281

## Solution
Replace dynamic fixture and helper annotations with concrete Path, pytest.MonkeyPatch, Source, JSONDocument, sqlite3.Connection, and workflow-specific type aliases/protocols. Where JSON mutation was previously path-dependent through nested dynamic dictionaries, rebuild the typed JSON payload explicitly.

Touched files:
- tests/integration/test_chronology_extremes.py
- tests/integration/test_cli_machine_contract.py
- tests/integration/test_facade.py
- tests/integration/test_health.py
- tests/integration/test_schema_operator_workflow.py
- tests/integration/test_workflows.py

## Verification
- rg -n "\bAny\b|cast\(Any|typing import .*Any" tests/integration -g "*.py"
- PATH=/tmp/polylogue-281/.cache/codex-bin:$PATH ruff check --fix tests/integration
- PATH=/tmp/polylogue-281/.cache/codex-bin:$PATH ruff format tests/integration
- PATH=/tmp/polylogue-281/.cache/codex-bin:$PATH mypy tests/integration
- PATH=/tmp/polylogue-281/.cache/codex-bin:$PATH pytest -q tests/integration/test_health.py tests/integration/test_facade.py tests/integration/test_workflows.py tests/integration/test_chronology_extremes.py tests/integration/test_cli_machine_contract.py tests/integration/test_schema_operator_workflow.py
- PATH=/tmp/polylogue-281/.cache/codex-bin:$PATH git push --force-with-lease -u origin feature/refactor/integration-test-contracts
