### PR TITLE
test: type remaining test contracts

### DIFF
--- a/tests/benchmarks/helpers.py
+++ b/tests/benchmarks/helpers.py
@@ -6,13 +6,17 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from sqlite3 import Connection
-from typing import Any, TypeVar
+from typing import Protocol, TypeVar
 
 from polylogue.storage.backends.async_sqlite import SQLiteBackend
 from polylogue.storage.backends.connection import open_connection
 from polylogue.storage.repository import ConversationRepository
 
 T = TypeVar("T")
+
+
+class BenchmarkFixture(Protocol):
+    def __call__(self, func: Callable[[], T]) -> T: ...
 
 
 @dataclass
@@ -40,7 +44,7 @@ def open_bench_store(db_path: Path) -> Iterator[BenchAsyncStore]:
 
 
 def benchmark_store_call(
-    benchmark: Any,
+    benchmark: BenchmarkFixture,
     db_path: Path,
     operation: Callable[[BenchAsyncStore], Awaitable[T]],
 ) -> None:
@@ -50,7 +54,7 @@ def benchmark_store_call(
 
 
 def benchmark_connection_call(
-    benchmark: Any,
+    benchmark: BenchmarkFixture,
     db_path: Path,
     operation: Callable[[Connection], T],
 ) -> None:

--- a/tests/benchmarks/test_pipeline.py
+++ b/tests/benchmarks/test_pipeline.py
@@ -10,11 +10,12 @@ Run with:
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from sqlite3 import Connection
 
 import pytest
 
 from polylogue.lib.hashing import hash_payload, hash_text
+from polylogue.lib.json import JSONDocument
 from polylogue.lib.viewports import classify_tool
 from polylogue.pipeline.prepare import PrepareCache
 from polylogue.pipeline.semantic_metadata import extract_tool_metadata
@@ -25,14 +26,15 @@ from polylogue.storage.action_event_rebuild_runtime import (
 from polylogue.storage.fts_lifecycle import repair_fts_index_sync
 from polylogue.storage.index import rebuild_index, update_index_for_conversations
 from tests.benchmarks.helpers import (
+    BenchmarkFixture,
     benchmark_connection_call,
     benchmark_store_call,
 )
 
 
-def _make_diverse_tool_inputs(n: int) -> list[tuple[str, dict[str, Any]]]:
+def _make_diverse_tool_inputs(n: int) -> list[tuple[str, JSONDocument]]:
     """Create n diverse (tool_name, tool_input) pairs for classification benchmarks."""
-    patterns: list[tuple[str, dict[str, Any]]] = [
+    patterns: list[tuple[str, JSONDocument]] = [
         ("Read", {"file_path": "/path/to/file.py"}),
         ("Write", {"file_path": "/path/to/output.py", "content": "print('hello')"}),
         ("Edit", {"file_path": "/path/to/file.py", "old_string": "old", "new_string": "new"}),
@@ -53,16 +55,16 @@ def _make_diverse_tool_inputs(n: int) -> list[tuple[str, dict[str, Any]]]:
 
 @pytest.mark.benchmark
 @pytest.mark.parametrize("n_tools", [10, 100, 1000])
-def test_bench_classify_tool_calls(benchmark: Any, n_tools: int) -> None:
+def test_bench_classify_tool_calls(benchmark: BenchmarkFixture, n_tools: int) -> None:
     """classify_tool() throughput across ToolCategory variants."""
     tool_inputs = _make_diverse_tool_inputs(n_tools)
     benchmark(lambda: [classify_tool(name, inp) for name, inp in tool_inputs])
 
 
 @pytest.mark.benchmark
-def test_bench_extract_tool_metadata(benchmark: Any) -> None:
+def test_bench_extract_tool_metadata(benchmark: BenchmarkFixture) -> None:
     """extract_tool_metadata() for git, file, subagent variants."""
-    inputs: list[tuple[str, dict[str, Any]]] = [
+    inputs: list[tuple[str, JSONDocument]] = [
         ("Bash", {"command": "git commit -m 'fix: update schema'"}),
         ("Read", {"file_path": "/workspace/polylogue/polylogue/lib/models.py"}),
         ("Write", {"file_path": "/tmp/output.py", "content": "result = 42"}),
@@ -74,20 +76,20 @@ def test_bench_extract_tool_metadata(benchmark: Any) -> None:
 
 
 @pytest.mark.benchmark
-def test_bench_fts_rebuild_1k(benchmark: Any, bench_db_1k: Path) -> None:
+def test_bench_fts_rebuild_1k(benchmark: BenchmarkFixture, bench_db_1k: Path) -> None:
     """FTS5 full rebuild on 1k messages."""
     benchmark_connection_call(benchmark, bench_db_1k, rebuild_index)
 
 
 @pytest.mark.benchmark
-def test_bench_fts_rebuild_5k(benchmark: Any, bench_db_5k: Path) -> None:
+def test_bench_fts_rebuild_5k(benchmark: BenchmarkFixture, bench_db_5k: Path) -> None:
     """FTS5 full rebuild on 5k messages — shows O(N) scaling."""
     benchmark_connection_call(benchmark, bench_db_5k, rebuild_index)
 
 
 @pytest.mark.benchmark
 @pytest.mark.parametrize("n", [1, 10, 50])
-def test_bench_fts_incremental_update(benchmark: Any, bench_db_5k: Path, n: int) -> None:
+def test_bench_fts_incremental_update(benchmark: BenchmarkFixture, bench_db_5k: Path, n: int) -> None:
     """update_index_for_conversations() for 1, 10, 50 conversations."""
     ids = [f"bench-conv-{i:05d}" for i in range(n)]
     benchmark_connection_call(
@@ -98,10 +100,10 @@ def test_bench_fts_incremental_update(benchmark: Any, bench_db_5k: Path, n: int)
 
 
 @pytest.mark.benchmark
-def test_bench_action_event_repair_rebuild(benchmark: Any, bench_db_5k: Path) -> None:
+def test_bench_action_event_repair_rebuild(benchmark: BenchmarkFixture, bench_db_5k: Path) -> None:
     """Action-event repair loop over a realistic seeded archive."""
 
-    def repair_action_events(conn: Any) -> int:
+    def repair_action_events(conn: Connection) -> int:
         targets = valid_action_event_source_ids_sync(conn)
         conn.execute("DELETE FROM action_events")
         conn.execute("DELETE FROM action_events_fts")
@@ -117,7 +119,7 @@ def test_bench_action_event_repair_rebuild(benchmark: Any, bench_db_5k: Path) ->
 
 @pytest.mark.benchmark
 @pytest.mark.parametrize("size", [100, 1_000, 10_000])
-def test_bench_hash_text(benchmark: Any, size: int) -> None:
+def test_bench_hash_text(benchmark: BenchmarkFixture, size: int) -> None:
     """hash_text() throughput — NFC normalization + SHA-256. Tests text sizes."""
     text = "α" * size  # NFC normalization-heavy Unicode
     benchmark(lambda: hash_text(text))
@@ -125,7 +127,7 @@ def test_bench_hash_text(benchmark: Any, size: int) -> None:
 
 @pytest.mark.benchmark
 @pytest.mark.parametrize("depth", [1, 10, 50])
-def test_bench_hash_payload(benchmark: Any, depth: int) -> None:
+def test_bench_hash_payload(benchmark: BenchmarkFixture, depth: int) -> None:
     """hash_payload() — JSON serialization + SHA-256 for varying object complexity."""
 
     def _make_nested_payload(d: int) -> dict[str, object]:
@@ -140,7 +142,7 @@ def test_bench_hash_payload(benchmark: Any, depth: int) -> None:
 
 @pytest.mark.benchmark
 @pytest.mark.parametrize("n", [100, 500])
-def test_bench_prepare_cache_load(benchmark: Any, bench_db_5k: Path, n: int) -> None:
+def test_bench_prepare_cache_load(benchmark: BenchmarkFixture, bench_db_5k: Path, n: int) -> None:
     """PrepareCache.load() — bulk-loads N existing conversations in 2 queries."""
     cids = {f"bench-conv-{i:05d}" for i in range(n)}
     benchmark_store_call(

--- a/tests/benchmarks/test_search_filters.py
+++ b/tests/benchmarks/test_search_filters.py
@@ -10,17 +10,16 @@ Run with:
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
 
 import pytest
 
 from polylogue.lib.filters import ConversationFilter
 from polylogue.storage.query_models import ConversationRecordQuery
-from tests.benchmarks.helpers import benchmark_store_call
+from tests.benchmarks.helpers import BenchmarkFixture, benchmark_store_call
 
 
 @pytest.mark.benchmark
-def test_bench_fts_search_common_term(benchmark: Any, bench_db_5k: Path) -> None:
+def test_bench_fts_search_common_term(benchmark: BenchmarkFixture, bench_db_5k: Path) -> None:
     """FTS5 search for common word — many results, measures BM25 scoring cost."""
     benchmark_store_call(
         benchmark,
@@ -30,7 +29,7 @@ def test_bench_fts_search_common_term(benchmark: Any, bench_db_5k: Path) -> None
 
 
 @pytest.mark.benchmark
-def test_bench_fts_search_rare_term(benchmark: Any, bench_db_5k: Path) -> None:
+def test_bench_fts_search_rare_term(benchmark: BenchmarkFixture, bench_db_5k: Path) -> None:
     """FTS5 search for rare term — fast empty result path."""
     benchmark_store_call(
         benchmark,
@@ -40,7 +39,7 @@ def test_bench_fts_search_rare_term(benchmark: Any, bench_db_5k: Path) -> None:
 
 
 @pytest.mark.benchmark
-def test_bench_fts_search_multi_word(benchmark: Any, bench_db_5k: Path) -> None:
+def test_bench_fts_search_multi_word(benchmark: BenchmarkFixture, bench_db_5k: Path) -> None:
     """FTS5 multi-term AND search — intersection cost."""
     benchmark_store_call(
         benchmark,
@@ -50,7 +49,7 @@ def test_bench_fts_search_multi_word(benchmark: Any, bench_db_5k: Path) -> None:
 
 
 @pytest.mark.benchmark
-def test_bench_filter_provider(benchmark: Any, bench_db_5k: Path) -> None:
+def test_bench_filter_provider(benchmark: BenchmarkFixture, bench_db_5k: Path) -> None:
     """ConversationFilter + provider=chatgpt on 5k DB."""
     benchmark_store_call(
         benchmark,
@@ -60,7 +59,7 @@ def test_bench_filter_provider(benchmark: Any, bench_db_5k: Path) -> None:
 
 
 @pytest.mark.benchmark
-def test_bench_filter_has_tool_use(benchmark: Any, bench_db_5k: Path) -> None:
+def test_bench_filter_has_tool_use(benchmark: BenchmarkFixture, bench_db_5k: Path) -> None:
     """ConversationFilter + has_tool_use() — stats LEFT JOIN path."""
     benchmark_store_call(
         benchmark,
@@ -70,7 +69,7 @@ def test_bench_filter_has_tool_use(benchmark: Any, bench_db_5k: Path) -> None:
 
 
 @pytest.mark.benchmark
-def test_bench_filter_semantic_file_ops(benchmark: Any, bench_db_5k: Path) -> None:
+def test_bench_filter_semantic_file_ops(benchmark: BenchmarkFixture, bench_db_5k: Path) -> None:
     """ConversationFilter + has_file_operations() — EXISTS subquery path (schema v3)."""
     benchmark_store_call(
         benchmark,
@@ -80,7 +79,7 @@ def test_bench_filter_semantic_file_ops(benchmark: Any, bench_db_5k: Path) -> No
 
 
 @pytest.mark.benchmark
-def test_bench_filter_count(benchmark: Any, bench_db_5k: Path) -> None:
+def test_bench_filter_count(benchmark: BenchmarkFixture, bench_db_5k: Path) -> None:
     """ConversationFilter.count() — single COUNT(*) query, no data fetch."""
     benchmark_store_call(
         benchmark,
@@ -90,7 +89,7 @@ def test_bench_filter_count(benchmark: Any, bench_db_5k: Path) -> None:
 
 
 @pytest.mark.benchmark
-def test_bench_filter_combined(benchmark: Any, bench_db_10k: Path) -> None:
+def test_bench_filter_combined(benchmark: BenchmarkFixture, bench_db_10k: Path) -> None:
     """Stacked: provider + has_tool_use + min_messages — worst-case filter stack."""
     benchmark_store_call(
         benchmark,
@@ -103,7 +102,7 @@ def test_bench_filter_combined(benchmark: Any, bench_db_10k: Path) -> None:
 
 @pytest.mark.benchmark
 @pytest.mark.parametrize("limit", [10, 50, 200])
-def test_bench_filter_limit_scaling(benchmark: Any, bench_db_10k: Path, limit: int) -> None:
+def test_bench_filter_limit_scaling(benchmark: BenchmarkFixture, bench_db_10k: Path, limit: int) -> None:
     """How does result count affect list_conversations cost? Tests LIMIT effect."""
     benchmark_store_call(
         benchmark,

--- a/tests/benchmarks/test_storage.py
+++ b/tests/benchmarks/test_storage.py
@@ -11,12 +11,11 @@ from __future__ import annotations
 
 import hashlib
 from pathlib import Path
-from typing import Any
 
 import pytest
 
 from polylogue.storage.query_models import ConversationRecordQuery
-from tests.benchmarks.helpers import benchmark_store_call, open_bench_store
+from tests.benchmarks.helpers import BenchmarkFixture, benchmark_store_call, open_bench_store
 from tests.infra.storage_records import make_content_block, make_conversation, make_message
 
 
@@ -25,7 +24,7 @@ def _make_hash(s: str) -> str:
 
 
 @pytest.mark.benchmark
-def test_bench_list_conversations_no_filter(benchmark: Any, bench_db_5k: Path) -> None:
+def test_bench_list_conversations_no_filter(benchmark: BenchmarkFixture, bench_db_5k: Path) -> None:
     """list_conversations(limit=50) on 5k-message DB — baseline query cost."""
     benchmark_store_call(
         benchmark,
@@ -35,7 +34,7 @@ def test_bench_list_conversations_no_filter(benchmark: Any, bench_db_5k: Path) -
 
 
 @pytest.mark.benchmark
-def test_bench_list_conversations_provider_filter(benchmark: Any, bench_db_5k: Path) -> None:
+def test_bench_list_conversations_provider_filter(benchmark: BenchmarkFixture, bench_db_5k: Path) -> None:
     """list with provider=chatgpt — tests simple WHERE on indexed column."""
     benchmark_store_call(
         benchmark,
@@ -45,7 +44,7 @@ def test_bench_list_conversations_provider_filter(benchmark: Any, bench_db_5k: P
 
 
 @pytest.mark.benchmark
-def test_bench_list_conversations_has_tool_use(benchmark: Any, bench_db_5k: Path) -> None:
+def test_bench_list_conversations_has_tool_use(benchmark: BenchmarkFixture, bench_db_5k: Path) -> None:
     """list with has_tool_use=True — tests stats LEFT JOIN path."""
     benchmark_store_call(
         benchmark,
@@ -55,7 +54,7 @@ def test_bench_list_conversations_has_tool_use(benchmark: Any, bench_db_5k: Path
 
 
 @pytest.mark.benchmark
-def test_bench_list_conversations_semantic_filter(benchmark: Any, bench_db_5k: Path) -> None:
+def test_bench_list_conversations_semantic_filter(benchmark: BenchmarkFixture, bench_db_5k: Path) -> None:
     """list with action_terms=file_read — tests semantic EXISTS subquery path."""
     benchmark_store_call(
         benchmark,
@@ -67,7 +66,7 @@ def test_bench_list_conversations_semantic_filter(benchmark: Any, bench_db_5k: P
 
 
 @pytest.mark.benchmark
-def test_bench_list_conversations_combined_filter(benchmark: Any, bench_db_10k: Path) -> None:
+def test_bench_list_conversations_combined_filter(benchmark: BenchmarkFixture, bench_db_10k: Path) -> None:
     """provider + has_tool_use + min_messages — combined filter stack."""
     benchmark_store_call(
         benchmark,
@@ -84,7 +83,7 @@ def test_bench_list_conversations_combined_filter(benchmark: Any, bench_db_10k: 
 
 
 @pytest.mark.benchmark
-def test_bench_get_many_100(benchmark: Any, bench_db_5k: Path) -> None:
+def test_bench_get_many_100(benchmark: BenchmarkFixture, bench_db_5k: Path) -> None:
     """get_many() with 100 IDs — parallel batch fetch cost."""
     ids = [f"bench-conv-{i:05d}" for i in range(100)]
     benchmark_store_call(
@@ -96,7 +95,7 @@ def test_bench_get_many_100(benchmark: Any, bench_db_5k: Path) -> None:
 
 @pytest.mark.benchmark
 @pytest.mark.parametrize("n", [100, 500, 1000])
-def test_bench_save_messages_batch(benchmark: Any, tmp_path: Path, n: int) -> None:
+def test_bench_save_messages_batch(benchmark: BenchmarkFixture, tmp_path: Path, n: int) -> None:
     """save_messages() batch insert — measures executemany throughput."""
     db_path = tmp_path / f"save_bench_{n}.db"
     with open_bench_store(db_path) as store:
@@ -130,7 +129,7 @@ def test_bench_save_messages_batch(benchmark: Any, tmp_path: Path, n: int) -> No
 
 @pytest.mark.benchmark
 @pytest.mark.parametrize("n_msgs", [100, 500])
-def test_bench_save_content_blocks(benchmark: Any, tmp_path: Path, n_msgs: int) -> None:
+def test_bench_save_content_blocks(benchmark: BenchmarkFixture, tmp_path: Path, n_msgs: int) -> None:
     """save_content_blocks() — 5 blocks per message (tool_use + thinking mix)."""
     db_path = tmp_path / f"blocks_bench_{n_msgs}.db"
     with open_bench_store(db_path) as store:

--- a/tests/fuzz/fuzz_json_parsers.py
+++ b/tests/fuzz/fuzz_json_parsers.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 import json
 import os
 import sys
-from typing import Any
 
 # Check if atheris is available
 try:
@@ -310,21 +309,21 @@ class TestParserFuzz:
     """Pytest-compatible fuzz tests using seed corpus."""
 
     @pytest.mark.parametrize("data", CHATGPT_CORPUS + MALFORMED_CORPUS)
-    def test_chatgpt_parser_corpus(self: Any, data: bytes) -> None:
+    def test_chatgpt_parser_corpus(self, data: bytes) -> None:
         """Run ChatGPT parser fuzz with seed corpus."""
         fuzz_chatgpt_parser(data)
 
     @pytest.mark.parametrize("data", CODEX_CORPUS + MALFORMED_CORPUS)
-    def test_codex_parser_corpus(self: Any, data: bytes) -> None:
+    def test_codex_parser_corpus(self, data: bytes) -> None:
         """Run Codex parser fuzz with seed corpus."""
         fuzz_codex_parser(data)
 
     @pytest.mark.parametrize("data", CLAUDE_CODE_CORPUS + MALFORMED_CORPUS)
-    def test_claude_code_parser_corpus(self: Any, data: bytes) -> None:
+    def test_claude_code_parser_corpus(self, data: bytes) -> None:
         """Run Claude Code parser fuzz with seed corpus."""
         fuzz_claude_code_parser(data)
 
-    def test_chatgpt_parser_random(self: Any) -> None:
+    def test_chatgpt_parser_random(self) -> None:
         """Run ChatGPT parser with random bytes."""
         import random
 
@@ -333,7 +332,7 @@ class TestParserFuzz:
             data = bytes(random.randint(0, 255) for _ in range(length))
             fuzz_chatgpt_parser(data)
 
-    def test_codex_parser_random(self: Any) -> None:
+    def test_codex_parser_random(self) -> None:
         """Run Codex parser with random bytes."""
         import random
 
@@ -342,7 +341,7 @@ class TestParserFuzz:
             data = bytes(random.randint(0, 255) for _ in range(length))
             fuzz_codex_parser(data)
 
-    def test_claude_code_parser_random(self: Any) -> None:
+    def test_claude_code_parser_random(self) -> None:
         """Run Claude Code parser with random bytes."""
         import random
 

--- a/tests/fuzz/fuzz_timestamp.py
+++ b/tests/fuzz/fuzz_timestamp.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 import os
 import sys
 import time
-from typing import Any
 
 # Check if atheris is available
 try:
@@ -204,21 +203,21 @@ class TestTimestampFuzz:
     """Pytest-compatible fuzz tests using seed corpus."""
 
     @pytest.mark.parametrize("data", TIMESTAMP_CORPUS)
-    def test_parse_timestamp_corpus(self: Any, data: bytes) -> None:
+    def test_parse_timestamp_corpus(self, data: bytes) -> None:
         """Run parse_timestamp fuzz with seed corpus."""
         fuzz_parse_timestamp(data)
 
     @pytest.mark.parametrize("data", TIMESTAMP_CORPUS)
-    def test_normalize_timestamp_corpus(self: Any, data: bytes) -> None:
+    def test_normalize_timestamp_corpus(self, data: bytes) -> None:
         """Run normalize_timestamp fuzz with seed corpus."""
         fuzz_normalize_timestamp(data)
 
     @pytest.mark.parametrize("data", TIMESTAMP_CORPUS)
-    def test_format_timestamp_corpus(self: Any, data: bytes) -> None:
+    def test_format_timestamp_corpus(self, data: bytes) -> None:
         """Run format_timestamp fuzz with seed corpus."""
         fuzz_format_timestamp(data)
 
-    def test_parse_timestamp_random(self: Any) -> None:
+    def test_parse_timestamp_random(self) -> None:
         """Run parse_timestamp with random bytes."""
         import random
 
@@ -227,7 +226,7 @@ class TestTimestampFuzz:
             data = bytes(random.randint(0, 255) for _ in range(length))
             fuzz_parse_timestamp(data)
 
-    def test_parse_timestamp_numeric_strings(self: Any) -> None:
+    def test_parse_timestamp_numeric_strings(self) -> None:
         """Run parse_timestamp with random numeric strings."""
         import random
 
@@ -244,7 +243,7 @@ class TestTimestampFuzz:
 
             fuzz_parse_timestamp(digits.encode("utf-8"))
 
-    def test_parse_timestamp_date_strings(self: Any) -> None:
+    def test_parse_timestamp_date_strings(self) -> None:
         """Run parse_timestamp with random date-like strings."""
         import random
 

--- a/tests/property/test_rendering_preservation.py
+++ b/tests/property/test_rendering_preservation.py
@@ -10,11 +10,34 @@ from __future__ import annotations
 
 import json
 from collections import Counter
-from typing import Any
+from typing import NotRequired, TypedDict
 
 from hypothesis import HealthCheck, given, settings
 
+from polylogue.lib.messages import MessageCollection
+from polylogue.lib.models import Conversation, Message
+from polylogue.lib.roles import Role
+from polylogue.rendering.core_markdown import format_conversation_markdown
+from polylogue.rendering.formatting import format_conversation
+from polylogue.types import ConversationId, Provider
 from tests.infra.strategies.messages import conversation_strategy
+
+
+class RenderMessagePayload(TypedDict):
+    id: str
+    role: str
+    text: str
+    timestamp: NotRequired[object]
+    content_blocks: NotRequired[list[dict[str, object]]]
+
+
+class RenderConversationPayload(TypedDict):
+    id: str
+    provider: str
+    title: str
+    messages: list[RenderMessagePayload]
+    created_at: NotRequired[str]
+
 
 # ---------------------------------------------------------------------------
 # Helpers: extract semantic facts from rendered output
@@ -50,6 +73,15 @@ def _markdown_facts(md: str) -> dict[str, object]:
 def _json_facts(json_str: str) -> dict[str, object]:
     """Extract semantic facts from JSON export."""
     data = json.loads(json_str)
+    if not isinstance(data, dict):
+        return {
+            "conversation_id": "",
+            "provider": "",
+            "title": None,
+            "message_count": 0,
+            "role_counts": {},
+            "timestamped_messages": 0,
+        }
     messages = data.get("messages", [])
     role_counts: Counter[str] = Counter()
     timestamped = 0
@@ -68,24 +100,53 @@ def _json_facts(json_str: str) -> dict[str, object]:
     }
 
 
-def _csv_facts(csv_str: str) -> dict[str, object]:
-    """Extract semantic facts from CSV export."""
-    import csv
-    import io
+def _message_text(payload: RenderMessagePayload, *, placeholder: bool) -> str:
+    text = payload.get("text", "")
+    if not placeholder:
+        return text
+    return text.strip() or "placeholder"
 
-    reader = csv.DictReader(io.StringIO(csv_str))
-    rows = list(reader)
-    role_counts: Counter[str] = Counter()
-    timestamped = 0
-    for row in rows:
-        role_counts[str(row.get("role", "")).lower()] += 1
-        if row.get("timestamp"):
-            timestamped += 1
-    return {
-        "message_count": len(rows),
-        "role_counts": dict(role_counts),
-        "timestamped_messages": timestamped,
-    }
+
+def _messages(
+    payload: RenderConversationPayload,
+    *,
+    placeholder: bool = True,
+    non_empty_only: bool = False,
+    content_blocks: list[dict[str, object]] | None = None,
+) -> list[Message]:
+    messages: list[Message] = []
+    for index, item in enumerate(payload["messages"]):
+        text = _message_text(item, placeholder=placeholder)
+        if non_empty_only and not text.strip():
+            continue
+        blocks = content_blocks if content_blocks is not None and index == 0 and item["role"] == "assistant" else []
+        messages.append(
+            Message(
+                id=item["id"],
+                role=Role.normalize(item["role"]),
+                text=text,
+                timestamp=None,
+                content_blocks=blocks,
+            )
+        )
+    return messages
+
+
+def _conversation(payload: RenderConversationPayload, messages: list[Message]) -> Conversation:
+    return Conversation(
+        id=ConversationId(payload["id"]),
+        provider=Provider.from_string(payload["provider"]),
+        title=payload["title"],
+        messages=MessageCollection(messages=messages),
+    )
+
+
+def _render_json(payload: RenderConversationPayload) -> str:
+    return format_conversation(_conversation(payload, _messages(payload)), "json", None)
+
+
+def _render_yaml(payload: RenderConversationPayload) -> str:
+    return format_conversation(_conversation(payload, _messages(payload)), "yaml", None)
 
 
 # ---------------------------------------------------------------------------
@@ -95,33 +156,13 @@ def _csv_facts(csv_str: str) -> dict[str, object]:
 
 @given(conv_data=conversation_strategy(min_messages=1, max_messages=10))
 @settings(max_examples=30, deadline=5000)
-def test_markdown_preserves_message_count(conv_data: dict[str, Any]) -> None:
+def test_markdown_preserves_message_count(conv_data: RenderConversationPayload) -> None:
     """Every non-empty message must produce a ## section in markdown."""
-    from polylogue.lib.messages import MessageCollection
-    from polylogue.lib.models import Conversation, Message
-    from polylogue.rendering.core_markdown import format_conversation_markdown
-
-    messages = [
-        Message(
-            id=m["id"],
-            role=m["role"],
-            text=m.get("text", ""),
-            timestamp=None,
-        )
-        for m in conv_data["messages"]
-        if m.get("text", "").strip()  # non-empty only
-    ]
+    messages = _messages(conv_data, placeholder=False, non_empty_only=True)
     if not messages:
         return  # skip if all messages empty
 
-    conv = Conversation(
-        id=conv_data["id"],
-        provider=conv_data["provider"],
-        title=conv_data["title"],
-        messages=MessageCollection(messages=messages),
-    )
-
-    md = format_conversation_markdown(conv)
+    md = format_conversation_markdown(_conversation(conv_data, messages))
     facts = _markdown_facts(md)
 
     # Core invariant: renderable messages → ## sections
@@ -132,29 +173,10 @@ def test_markdown_preserves_message_count(conv_data: dict[str, Any]) -> None:
 
 @given(conv_data=conversation_strategy(min_messages=2, max_messages=8))
 @settings(max_examples=30, deadline=5000)
-def test_markdown_preserves_role_distribution(conv_data: dict[str, Any]) -> None:
+def test_markdown_preserves_role_distribution(conv_data: RenderConversationPayload) -> None:
     """Markdown role sections match the input role distribution."""
-    from polylogue.lib.messages import MessageCollection
-    from polylogue.lib.models import Conversation, Message
-    from polylogue.rendering.core_markdown import format_conversation_markdown
-
-    messages = [
-        Message(
-            id=m["id"],
-            role=m["role"],
-            # Ensure text is non-whitespace so the message is renderable
-            text=(m.get("text", "") or "").strip() or "placeholder",
-        )
-        for m in conv_data["messages"]
-    ]
-    conv = Conversation(
-        id=conv_data["id"],
-        provider=conv_data["provider"],
-        title=conv_data["title"],
-        messages=MessageCollection(messages=messages),
-    )
-
-    md = format_conversation_markdown(conv)
+    messages = _messages(conv_data)
+    md = format_conversation_markdown(_conversation(conv_data, messages))
     facts = _markdown_facts(md)
 
     # Build expected role distribution (only renderable messages — non-empty text)
@@ -173,27 +195,9 @@ def test_markdown_preserves_role_distribution(conv_data: dict[str, Any]) -> None
 
 @given(conv_data=conversation_strategy(min_messages=1, max_messages=10))
 @settings(max_examples=30, deadline=5000)
-def test_json_export_preserves_conversation_identity(conv_data: dict[str, Any]) -> None:
+def test_json_export_preserves_conversation_identity(conv_data: RenderConversationPayload) -> None:
     """JSON export must preserve conversation ID, provider, title."""
-    from polylogue.lib.messages import MessageCollection
-    from polylogue.lib.models import Conversation, Message
-    from polylogue.rendering.formatting import format_conversation
-
-    messages = [
-        Message(
-            id=m["id"],
-            role=m["role"],
-            text=m.get("text", "") or "placeholder",
-        )
-        for m in conv_data["messages"]
-    ]
-    conv = Conversation(
-        id=conv_data["id"],
-        provider=conv_data["provider"],
-        title=conv_data["title"],
-        messages=MessageCollection(messages=messages),
-    )
-
+    conv = _conversation(conv_data, _messages(conv_data))
     json_str = format_conversation(conv, "json", None)
     facts = _json_facts(json_str)
 
@@ -204,28 +208,10 @@ def test_json_export_preserves_conversation_identity(conv_data: dict[str, Any]) 
 
 @given(conv_data=conversation_strategy(min_messages=1, max_messages=10))
 @settings(max_examples=30, deadline=5000)
-def test_json_export_preserves_message_count(conv_data: dict[str, Any]) -> None:
+def test_json_export_preserves_message_count(conv_data: RenderConversationPayload) -> None:
     """JSON export must have one message entry per input message."""
-    from polylogue.lib.messages import MessageCollection
-    from polylogue.lib.models import Conversation, Message
-    from polylogue.rendering.formatting import format_conversation
-
-    messages = [
-        Message(
-            id=m["id"],
-            role=m["role"],
-            text=m.get("text", "") or "placeholder",
-        )
-        for m in conv_data["messages"]
-    ]
-    conv = Conversation(
-        id=conv_data["id"],
-        provider=conv_data["provider"],
-        title=conv_data["title"],
-        messages=MessageCollection(messages=messages),
-    )
-
-    json_str = format_conversation(conv, "json", None)
+    messages = _messages(conv_data)
+    json_str = format_conversation(_conversation(conv_data, messages), "json", None)
     facts = _json_facts(json_str)
 
     assert facts["message_count"] == len(messages)
@@ -238,72 +224,37 @@ def test_json_export_preserves_message_count(conv_data: dict[str, Any]) -> None:
 
 @given(conv_data=conversation_strategy(min_messages=1, max_messages=5))
 @settings(max_examples=20, deadline=5000)
-def test_json_yaml_agree_on_message_count(conv_data: dict[str, Any]) -> None:
+def test_json_yaml_agree_on_message_count(conv_data: RenderConversationPayload) -> None:
     """JSON and YAML exports of the same conversation have the same message count."""
     import yaml
 
-    from polylogue.lib.messages import MessageCollection
-    from polylogue.lib.models import Conversation, Message
-    from polylogue.rendering.formatting import format_conversation
-
-    messages = [
-        Message(
-            id=m["id"],
-            role=m["role"],
-            text=m.get("text", "") or "placeholder",
-        )
-        for m in conv_data["messages"]
-    ]
-    conv = Conversation(
-        id=conv_data["id"],
-        provider=conv_data["provider"],
-        title=conv_data["title"],
-        messages=MessageCollection(messages=messages),
-    )
-
-    json_str = format_conversation(conv, "json", None)
-    yaml_str = format_conversation(conv, "yaml", None)
-
-    json_data = json.loads(json_str)
-    yaml_data = yaml.safe_load(yaml_str)
+    json_data = json.loads(_render_json(conv_data))
+    yaml_data = yaml.safe_load(_render_yaml(conv_data))
+    assert isinstance(json_data, dict)
+    assert isinstance(yaml_data, dict)
 
     json_msgs = json_data.get("messages", [])
     yaml_msgs = yaml_data.get("messages", [])
+    assert isinstance(json_msgs, list)
+    assert isinstance(yaml_msgs, list)
 
     assert len(json_msgs) == len(yaml_msgs), f"JSON has {len(json_msgs)} messages, YAML has {len(yaml_msgs)}"
 
 
 @given(conv_data=conversation_strategy(min_messages=1, max_messages=5))
 @settings(max_examples=20, deadline=5000, suppress_health_check=[HealthCheck.filter_too_much])
-def test_json_yaml_agree_on_identity(conv_data: dict[str, Any]) -> None:
+def test_json_yaml_agree_on_identity(conv_data: RenderConversationPayload) -> None:
     """JSON and YAML agree on conversation_id, provider, title."""
     import yaml
     from hypothesis import assume
 
-    from polylogue.lib.messages import MessageCollection
-    from polylogue.lib.models import Conversation, Message
-    from polylogue.rendering.formatting import format_conversation
-
     # YAML has edge cases with certain Unicode control characters
     assume(conv_data["title"].isprintable())
 
-    messages = [
-        Message(
-            id=m["id"],
-            role=m["role"],
-            text=m.get("text", "") or "placeholder",
-        )
-        for m in conv_data["messages"]
-    ]
-    conv = Conversation(
-        id=conv_data["id"],
-        provider=conv_data["provider"],
-        title=conv_data["title"],
-        messages=MessageCollection(messages=messages),
-    )
-
-    json_data = json.loads(format_conversation(conv, "json", None))
-    yaml_data = yaml.safe_load(format_conversation(conv, "yaml", None))
+    json_data = json.loads(_render_json(conv_data))
+    yaml_data = yaml.safe_load(_render_yaml(conv_data))
+    assert isinstance(json_data, dict)
+    assert isinstance(yaml_data, dict)
 
     assert json_data["id"] == yaml_data["id"]
     assert json_data["provider"] == yaml_data["provider"]
@@ -317,37 +268,17 @@ def test_json_yaml_agree_on_identity(conv_data: dict[str, Any]) -> None:
 
 @given(conv_data=conversation_strategy(min_messages=2, max_messages=5))
 @settings(max_examples=20, deadline=5000)
-def test_content_blocks_produce_structured_markdown(conv_data: dict[str, Any]) -> None:
+def test_content_blocks_produce_structured_markdown(conv_data: RenderConversationPayload) -> None:
     """When content blocks are present, markdown should contain structural markers."""
-    from polylogue.lib.messages import MessageCollection
-    from polylogue.lib.models import Conversation, Message
-    from polylogue.rendering.core_markdown import format_conversation_markdown
-
     # Add content blocks to the first message
-    blocks: list[dict[str, Any]] = [
+    blocks: list[dict[str, object]] = [
         {"type": "thinking", "thinking": "Let me analyze this..."},
         {"type": "tool_use", "name": "Read", "id": "tool-1", "input": {"file_path": "/tmp/test.py"}},
         {"type": "text", "text": "Here's what I found."},
     ]
 
-    messages = []
-    for i, m in enumerate(conv_data["messages"]):
-        msg = Message(
-            id=m["id"],
-            role=m["role"],
-            text=m.get("text", "") or "placeholder",
-            content_blocks=blocks if i == 0 and m["role"] == "assistant" else [],
-        )
-        messages.append(msg)
-
-    conv = Conversation(
-        id=conv_data["id"],
-        provider=conv_data["provider"],
-        title=conv_data["title"],
-        messages=MessageCollection(messages=messages),
-    )
-
-    md = format_conversation_markdown(conv)
+    messages = _messages(conv_data, content_blocks=blocks)
+    md = format_conversation_markdown(_conversation(conv_data, messages))
 
     # If first message was assistant and had blocks, check structure
     if messages[0].role.value == "assistant":

--- a/tests/property/test_schema_roundtrip.py
+++ b/tests/property/test_schema_roundtrip.py
@@ -23,7 +23,7 @@ def test_chatgpt_schema_payload_parses_without_crash(payload: object) -> None:
     """Schema-conformant ChatGPT payloads must not crash with unhandled exceptions.
 
     ValueError (missing role) and ValidationError are expected for minimal
-    payloads and are caught by the extraction pipeline. Any other exception
+    payloads and are caught by the extraction pipeline. Other exceptions
     is a genuine crash.
     """
     from pydantic import ValidationError

--- a/tests/unit/cli/test_machine_main.py
+++ b/tests/unit/cli/test_machine_main.py
@@ -1,15 +1,24 @@
 from __future__ import annotations
 
 import json
-from typing import Any, cast
 
 import click
 import pytest
 
 from polylogue.cli.machine_main import run_machine_entry
 from polylogue.errors import DatabaseError
+from polylogue.lib.json import JSONDocument, json_document
 
 TRACEBACK_SENTINEL = "Traceback (most recent call last)"
+
+
+def _parse_json_payload(stdout: str) -> JSONDocument:
+    return json_document(json.loads(stdout))
+
+
+def _json_object(value: object, label: str) -> JSONDocument:
+    assert isinstance(value, dict), f"Expected {label} to be a JSON object"
+    return value
 
 
 def test_run_machine_entry_plain_polylogue_error_emits_click_style_error(
@@ -42,11 +51,12 @@ def test_run_machine_entry_json_polylogue_error_emits_runtime_envelope(
     captured = capsys.readouterr()
     combined = captured.out + captured.err
     assert TRACEBACK_SENTINEL not in combined
-    parsed = cast(dict[str, Any], json.loads(captured.out))
+    parsed = _parse_json_payload(captured.out)
+    details = _json_object(parsed["details"], "details")
     assert parsed["status"] == "error"
     assert parsed["code"] == "runtime_error"
     assert parsed["message"] == "Database schema version 0 is incompatible with expected version 1."
-    assert parsed["details"]["exception_type"] == "DatabaseError"
+    assert details["exception_type"] == "DatabaseError"
 
 
 def test_run_machine_entry_format_json_polylogue_error_emits_runtime_envelope(
@@ -63,7 +73,7 @@ def test_run_machine_entry_format_json_polylogue_error_emits_runtime_envelope(
     captured = capsys.readouterr()
     combined = captured.out + captured.err
     assert TRACEBACK_SENTINEL not in combined
-    parsed = cast(dict[str, Any], json.loads(captured.out))
+    parsed = json_document(json.loads(captured.out))
     assert parsed["status"] == "error"
     assert parsed["code"] == "runtime_error"
     assert parsed["message"] == "Database schema version 0 is incompatible with expected version 1."
@@ -80,8 +90,9 @@ def test_run_machine_entry_extracts_query_command_without_option_values(
         run_machine_entry(bad_args, ["stats", "--by", "provider", "--format", "json", "--limit", "20"])
 
     assert exc_info.value.code == 2
-    parsed = cast(dict[str, Any], json.loads(capsys.readouterr().out))
+    parsed = _parse_json_payload(capsys.readouterr().out)
+    details = _json_object(parsed["details"], "details")
     assert parsed["status"] == "error"
     assert parsed["code"] == "invalid_arguments"
     assert parsed["command"] == ["stats"]
-    assert parsed["details"]["option"] == "--limit"
+    assert details["option"] == "--limit"

--- a/tests/unit/cli/test_products.py
+++ b/tests/unit/cli/test_products.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any, cast
+from typing import Protocol, cast
 from unittest.mock import MagicMock
 
 import click
@@ -24,6 +24,16 @@ from tests.infra.storage_records import ConversationBuilder
 
 JsonObject = dict[str, object]
 CliWorkspace = dict[str, Path]
+
+
+class ProductCallback(Protocol):
+    def __wrapped__(
+        self,
+        ctx: click.Context,
+        *,
+        json_mode: bool,
+        refined_work_kind: str,
+    ) -> object: ...
 
 
 def _expect_object(value: object) -> JsonObject:
@@ -233,7 +243,7 @@ def test_products_callback_rejects_unknown_query_fields() -> None:
     with pytest.raises(
         SystemExit, match="products enrichments: Unknown query field\\(s\\) for session_enrichments: refined_work_kind"
     ):
-        cast(Any, callback).__wrapped__(mock_ctx, json_mode=False, refined_work_kind="planning")
+        cast(ProductCallback, callback).__wrapped__(mock_ctx, json_mode=False, refined_work_kind="planning")
 
 
 def test_products_profiles_json_supports_explicit_evidence_and_inference_tiers(cli_workspace: CliWorkspace) -> None:

--- a/tests/unit/cli/test_qa_requests.py
+++ b/tests/unit/cli/test_qa_requests.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -125,7 +124,7 @@ def test_execute_snapshot_plan_uses_fallback_report_dir(
         label: str,
         output_root: Path,
         json_output: bool,
-        env: Any,
+        env: object,
     ) -> None:
         captured.update(
             source_dir=source_dir,

--- a/tests/unit/cli/test_run.py
+++ b/tests/unit/cli/test_run.py
@@ -6,7 +6,7 @@ import asyncio
 from collections.abc import Iterator
 from contextlib import ExitStack
 from pathlib import Path
-from typing import Any, cast
+from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -28,6 +28,7 @@ from polylogue.storage.run_state import (
     RunDrift,
     RunResult,
 )
+from polylogue.ui import UI
 from tests.infra.storage_records import DbFactory
 
 PatchMap = dict[str, MagicMock]
@@ -169,7 +170,7 @@ def _make_prompt_env(*, plain: bool, choice: str | None = None) -> AppEnv:
     ui = MagicMock()
     ui.plain = plain
     ui.choose = MagicMock(return_value=choice)
-    return AppEnv(ui=cast(Any, ui))
+    return AppEnv(ui=cast(UI, ui))
 
 
 def _invoke_run_direct(

--- a/tests/unit/devtools/test_benchmark_campaigns.py
+++ b/tests/unit/devtools/test_benchmark_campaigns.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Literal
+from types import TracebackType
+from typing import Literal
 
 import pytest
 
@@ -11,6 +12,7 @@ from devtools.benchmark_campaigns import (
     run_full_campaign,
     run_synthetic_benchmark_campaign,
 )
+from devtools.large_archive_generator import ArchiveMetrics
 from devtools.synthetic_benchmark_catalog import (
     SYNTHETIC_BENCHMARK_REGISTRY,
     SYNTHETIC_BENCHMARK_SCENARIOS,
@@ -51,8 +53,10 @@ def test_all_authored_synthetic_benchmark_runners_resolve() -> None:
 
 
 @pytest.mark.asyncio
-async def test_run_synthetic_benchmark_campaign_preserves_scenario_metadata(monkeypatch: Any, tmp_path: Path) -> None:
-    async def fake_incremental(_db_path: Path) -> Any:
+async def test_run_synthetic_benchmark_campaign_preserves_scenario_metadata(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    async def fake_incremental(_db_path: Path) -> CampaignResult:
         return CampaignResult(
             campaign_name="incremental-index",
             scale_level="",
@@ -77,8 +81,12 @@ async def test_run_synthetic_benchmark_campaign_preserves_scenario_metadata(monk
 
 
 @pytest.mark.asyncio
-async def test_run_full_campaign_skips_scenarios_outside_scale_targets(monkeypatch: Any, tmp_path: Path) -> None:
-    async def fake_generate_archive(_spec: Any, archive_dir: Path, *, corpus_source: Any = None) -> Any:
+async def test_run_full_campaign_skips_scenarios_outside_scale_targets(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    async def fake_generate_archive(
+        _spec: object, archive_dir: Path, *, corpus_source: object = None
+    ) -> ArchiveMetrics:
         from devtools.large_archive_generator import ArchiveMetrics
 
         archive_dir.mkdir(parents=True, exist_ok=True)
@@ -90,7 +98,7 @@ async def test_run_full_campaign_skips_scenarios_outside_scale_targets(monkeypat
             conversation_count=2,
         )
 
-    async def fake_run_campaign(name: str, _db_path: Path) -> Any:
+    async def fake_run_campaign(name: str, _db_path: Path) -> CampaignResult:
         return CampaignResult(
             campaign_name=name,
             scale_level="",
@@ -119,7 +127,9 @@ async def test_run_full_campaign_skips_scenarios_outside_scale_targets(monkeypat
     assert "startup-readiness" not in {result.campaign_name for result in results}
 
 
-def test_action_event_materialization_campaign_reports_action_row_counts(monkeypatch: Any, tmp_path: Path) -> None:
+def test_action_event_materialization_campaign_reports_action_row_counts(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     before = {
         "action_events_count": 2,
         "action_fts_rows": 2,
@@ -135,17 +145,19 @@ def test_action_event_materialization_campaign_reports_action_row_counts(monkeyp
     committed: list[str] = []
 
     class FakeConn:
-        def execute(self: Any, sql: str) -> None:
+        def execute(self, sql: str) -> None:
             executed.append(sql)
 
-        def commit(self: Any) -> None:
+        def commit(self) -> None:
             committed.append("commit")
 
     class FakeContext:
-        def __enter__(self: Any) -> FakeConn:
+        def __enter__(self) -> FakeConn:
             return FakeConn()
 
-        def __exit__(self: Any, exc_type: Any, exc: Any, tb: Any) -> Literal[False]:
+        def __exit__(
+            self, exc_type: type[BaseException] | None, exc: BaseException | None, tb: TracebackType | None
+        ) -> Literal[False]:
             return False
 
     monkeypatch.setattr("devtools.synthetic_benchmark_runtime._db_row_counts", lambda _db_path: next(row_counts))
@@ -168,7 +180,9 @@ def test_action_event_materialization_campaign_reports_action_row_counts(monkeyp
     }
 
 
-def test_session_product_materialization_campaign_reports_rebuild_counts(monkeypatch: Any, tmp_path: Path) -> None:
+def test_session_product_materialization_campaign_reports_rebuild_counts(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     before = {
         "session_profiles_count": 1,
         "session_profiles_fts_count": 1,
@@ -189,14 +203,16 @@ def test_session_product_materialization_campaign_reports_rebuild_counts(monkeyp
     committed: list[str] = []
 
     class FakeConn:
-        def commit(self: Any) -> None:
+        def commit(self) -> None:
             committed.append("commit")
 
     class FakeContext:
-        def __enter__(self: Any) -> FakeConn:
+        def __enter__(self) -> FakeConn:
             return FakeConn()
 
-        def __exit__(self: Any, exc_type: Any, exc: Any, tb: Any) -> Literal[False]:
+        def __exit__(
+            self, exc_type: type[BaseException] | None, exc: BaseException | None, tb: TracebackType | None
+        ) -> Literal[False]:
             return False
 
     monkeypatch.setattr(

--- a/tests/unit/devtools/test_build_package.py
+++ b/tests/unit/devtools/test_build_package.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+
+import pytest
 
 from devtools import build_package
 
 
-def test_build_package_uses_repo_local_out_link(monkeypatch: Any, tmp_path: Path) -> None:
+def test_build_package_uses_repo_local_out_link(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     calls: list[list[str]] = []
 
     class Result:
@@ -24,7 +25,7 @@ def test_build_package_uses_repo_local_out_link(monkeypatch: Any, tmp_path: Path
     assert calls == [["nix", "build", ".#polylogue", "--out-link", ".local/result"]]
 
 
-def test_build_package_accepts_custom_package_and_out_link(monkeypatch: Any, tmp_path: Path) -> None:
+def test_build_package_accepts_custom_package_and_out_link(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     calls: list[list[str]] = []
 
     class Result:

--- a/tests/unit/devtools/test_devtools_main.py
+++ b/tests/unit/devtools/test_devtools_main.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 import json
 from collections.abc import Callable
-from typing import Any, cast
+from typing import cast
 
 import pytest
 
 import devtools.__main__ as devtools_main
-from devtools.command_catalog import COMMANDS
+from devtools.command_catalog import COMMANDS, CommandSpec
 
 
 def test_list_commands_json_includes_generated_surface(capsys: pytest.CaptureFixture[str]) -> None:
@@ -41,7 +41,7 @@ def test_global_json_flag_is_forwarded_to_command(monkeypatch: pytest.MonkeyPatc
         def resolve_main() -> Callable[[list[str] | None], int]:
             return fake_main
 
-    monkeypatch.setitem(COMMANDS, "status", cast(Any, FakeSpec()))
+    monkeypatch.setitem(COMMANDS, "status", cast(CommandSpec, FakeSpec()))
 
     assert devtools_main.main(["--json", "status"]) == 0
     assert captured == [["--json"]]

--- a/tests/unit/devtools/test_query_memory_budget.py
+++ b/tests/unit/devtools/test_query_memory_budget.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 import json
 import sys
-from typing import Any, cast
 
 import pytest
 
 from devtools.query_memory_budget import _read_vm_rss_kb, main, run_memory_budget
+from polylogue.lib.json import json_document
 
 
 def test_read_vm_rss_kb_missing_pid_returns_zero() -> None:
@@ -28,7 +28,7 @@ def test_run_memory_budget_reports_success_for_small_command() -> None:
 def test_main_emits_json_summary(capsys: pytest.CaptureFixture[str]) -> None:
     exit_code = main(["--max-rss-mb", "512", "--", sys.executable, "-c", "print('ok')"])
     captured = capsys.readouterr()
-    payload = cast(dict[str, Any], json.loads(captured.out))
+    payload = json_document(json.loads(captured.out))
 
     assert exit_code == 0
     assert payload["exit_code"] == 0

--- a/tests/unit/rendering/test_html_highlighting.py
+++ b/tests/unit/rendering/test_html_highlighting.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
+import pytest
 
 from polylogue.rendering.renderers.html_highlighting import (
     HTML_RENDER_CACHE_TEXT_MAX_CHARS,
@@ -59,7 +59,9 @@ def test_html_message_renderer_preserves_hard_breaks_via_markdown_it() -> None:
     assert "<br />" in rendered
 
 
-def test_html_message_renderer_oversized_markdown_like_text_bypasses_markdown_it(monkeypatch: Any) -> None:
+def test_html_message_renderer_oversized_markdown_like_text_bypasses_markdown_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     renderer = HTMLMessageRenderer()
     oversized = "# heading\n" + ("x" * HTML_RENDER_MARKDOWN_MAX_CHARS)
 

--- a/tests/unit/security/test_observers_security.py
+++ b/tests/unit/security/test_observers_security.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -48,7 +47,7 @@ class TestExecCommandValidation:
             r"echo hello\n",
         ],
     )
-    def test_shell_metacharacters_rejected(self, dangerous_cmd: Any) -> None:
+    def test_shell_metacharacters_rejected(self, dangerous_cmd: str) -> None:
         with pytest.raises(ValueError, match="unsafe shell metacharacters"):
             _validate_exec_command(dangerous_cmd)
 
@@ -88,7 +87,7 @@ class TestWebhookUrlValidation:
             "http://[::1]/webhook",
         ],
     )
-    def test_loopback_rejected(self, private_url: Any) -> None:
+    def test_loopback_rejected(self, private_url: str) -> None:
         with pytest.raises(ValueError, match="private|reserved|loopback"):
             _validate_webhook_url(private_url)
 
@@ -100,7 +99,7 @@ class TestWebhookUrlValidation:
             "http://172.16.0.1/webhook",
         ],
     )
-    def test_private_ip_rejected(self, private_url: Any) -> None:
+    def test_private_ip_rejected(self, private_url: str) -> None:
         with pytest.raises(ValueError, match="private|reserved"):
             _validate_webhook_url(private_url)
 

--- a/tests/unit/security/test_path_sanitization.py
+++ b/tests/unit/security/test_path_sanitization.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import os
 import stat
 from pathlib import Path
-from typing import Any
 
 import pytest
 
@@ -35,7 +34,7 @@ class TestSanitizePathTraversal:
             "..\\..\\system32",
         ],
     )
-    def test_traversal_inputs_are_blocked(self: Any, raw_path: Any) -> None:
+    def test_traversal_inputs_are_blocked(self, raw_path: str) -> None:
         result = sanitize_path(raw_path)
         assert result is not None
         assert result.startswith("_blocked_")
@@ -48,7 +47,7 @@ class TestSanitizePathTraversal:
             "file\x7fname",
         ],
     )
-    def test_control_characters_are_removed(self: Any, raw_path: Any) -> None:
+    def test_control_characters_are_removed(self, raw_path: str) -> None:
         result = sanitize_path(raw_path)
         assert result is not None
         assert not any((ord(c) < 32 or ord(c) == 127) for c in result)
@@ -66,13 +65,13 @@ class TestSanitizePathTraversal:
             ),
         ],
     )
-    def test_safe_paths_remain_usable(self: Any, raw_path: Any, checks: Any) -> None:
+    def test_safe_paths_remain_usable(self, raw_path: str, checks: tuple[str, ...]) -> None:
         result = sanitize_path(raw_path)
         assert result is not None
         for check in checks:
             assert check in result or result.startswith(check)
 
-    def test_none_returns_none(self: Any) -> None:
+    def test_none_returns_none(self) -> None:
         assert sanitize_path(None) is None
 
 
@@ -84,24 +83,24 @@ class TestSanitizePathTraversal:
 class TestFileTokenStoreSecurity:
     """Token store must prevent path traversal via key and set secure permissions."""
 
-    def test_slash_in_key_sanitized(self: Any, tmp_path: Path) -> None:
+    def test_slash_in_key_sanitized(self, tmp_path: Path) -> None:
         store = FileTokenStore(tmp_path)
         path = store._path_for_key("../../etc/passwd")
         # Must stay within the store directory
         assert tmp_path in path.parents or path.parent == tmp_path
 
-    def test_backslash_in_key_sanitized(self: Any, tmp_path: Path) -> None:
+    def test_backslash_in_key_sanitized(self, tmp_path: Path) -> None:
         store = FileTokenStore(tmp_path)
         path = store._path_for_key("..\\..\\secret")
         assert tmp_path in path.parents or path.parent == tmp_path
 
-    def test_dot_dot_in_key_sanitized(self: Any, tmp_path: Path) -> None:
+    def test_dot_dot_in_key_sanitized(self, tmp_path: Path) -> None:
         store = FileTokenStore(tmp_path)
         path = store._path_for_key("../secret_token")
         # Double-dot should be replaced with underscore
         assert ".." not in str(path.name)
 
-    def test_save_creates_file_with_0600(self: Any, tmp_path: Path) -> None:
+    def test_save_creates_file_with_0600(self, tmp_path: Path) -> None:
         store = FileTokenStore(tmp_path)
         store.save("test-token", '{"access_token": "secret"}')
 
@@ -110,18 +109,18 @@ class TestFileTokenStoreSecurity:
         mode = oct(stat.S_IMODE(os.stat(path).st_mode))
         assert mode == "0o600"
 
-    def test_save_and_load_roundtrip(self: Any, tmp_path: Path) -> None:
+    def test_save_and_load_roundtrip(self, tmp_path: Path) -> None:
         store = FileTokenStore(tmp_path)
         data = '{"access_token": "abc123", "refresh_token": "xyz789"}'
         store.save("oauth-token", data)
         loaded = store.load("oauth-token")
         assert loaded == data
 
-    def test_load_nonexistent_returns_none(self: Any, tmp_path: Path) -> None:
+    def test_load_nonexistent_returns_none(self, tmp_path: Path) -> None:
         store = FileTokenStore(tmp_path)
         assert store.load("nonexistent") is None
 
-    def test_delete_removes_file(self: Any, tmp_path: Path) -> None:
+    def test_delete_removes_file(self, tmp_path: Path) -> None:
         store = FileTokenStore(tmp_path)
         store.save("deleteme", "data")
         path = store._path_for_key("deleteme")
@@ -129,11 +128,11 @@ class TestFileTokenStoreSecurity:
         store.delete("deleteme")
         assert not path.exists()
 
-    def test_delete_nonexistent_no_error(self: Any, tmp_path: Path) -> None:
+    def test_delete_nonexistent_no_error(self, tmp_path: Path) -> None:
         store = FileTokenStore(tmp_path)
         store.delete("doesnt-exist")  # Should not raise
 
-    def test_key_with_special_chars(self: Any, tmp_path: Path) -> None:
+    def test_key_with_special_chars(self, tmp_path: Path) -> None:
         store = FileTokenStore(tmp_path)
         store.save("token/with/slashes", "data")
         loaded = store.load("token/with/slashes")
@@ -154,7 +153,7 @@ class TestRegexReDoSSafety:
     test runner will flag it.
     """
 
-    def test_path_pattern_adversarial_input(self: Any) -> None:
+    def test_path_pattern_adversarial_input(self) -> None:
         """_PATH_PATTERN must handle long strings without backtracking."""
         import time
 
@@ -168,7 +167,7 @@ class TestRegexReDoSSafety:
         elapsed = time.monotonic() - start
         assert elapsed < 1.0, f"_PATH_PATTERN took {elapsed:.2f}s on adversarial input"
 
-    def test_path_pattern_many_quoted_segments(self: Any) -> None:
+    def test_path_pattern_many_quoted_segments(self) -> None:
         """Quoted path segments must not cause exponential matching."""
         import time
 
@@ -182,7 +181,7 @@ class TestRegexReDoSSafety:
         assert elapsed < 1.0, f"_PATH_PATTERN took {elapsed:.2f}s on quoted paths"
         assert len(results) == 500
 
-    def test_uuid_pattern_adversarial_input(self: Any) -> None:
+    def test_uuid_pattern_adversarial_input(self) -> None:
         """UUID_PATTERN must reject near-miss inputs quickly."""
         import time
 
@@ -200,7 +199,7 @@ class TestRegexReDoSSafety:
         elapsed = time.monotonic() - start
         assert elapsed < 1.0, f"UUID_PATTERN took {elapsed:.2f}s on 3000 near-miss inputs"
 
-    def test_fts5_special_adversarial_input(self: Any) -> None:
+    def test_fts5_special_adversarial_input(self) -> None:
         """FTS5 escape patterns must handle pathological input."""
         import time
 

--- a/tests/unit/showcase/test_qa_markdown.py
+++ b/tests/unit/showcase/test_qa_markdown.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any
+from typing import cast
 from unittest.mock import MagicMock
 
 from polylogue.lib.json import JSONDocument, JSONDocumentList, json_document_list
+from polylogue.showcase.exercise_models import Exercise
 from polylogue.showcase.report_files import generate_manifest
 from polylogue.showcase.runner import ExerciseResult, ShowcaseResult
 from polylogue.showcase.showcase_report_text import generate_showcase_markdown
@@ -22,7 +23,7 @@ def _make_exercise(
     group: str = "structural",
     tier: int = 1,
     description: str = "A test exercise",
-) -> Any:
+) -> Exercise:
     ex = MagicMock()
     ex.name = name
     ex.group = group
@@ -30,7 +31,7 @@ def _make_exercise(
     ex.description = description
     ex.args = []
     ex.output_ext = ".txt"
-    return ex
+    return cast(Exercise, ex)
 
 
 def _make_result(
@@ -198,7 +199,7 @@ class TestGenerateManifest:
         assert manifest["entry_count"] == 0
         assert manifest["entries"] == []
 
-    def test_captures_files_with_hashes(self, tmp_path: Any) -> None:
+    def test_captures_files_with_hashes(self, tmp_path: Path) -> None:
         # Create some files in the output dir
         (tmp_path / "report.json").write_text('{"a": 1}')
         (tmp_path / "summary.txt").write_text("pass")
@@ -215,7 +216,7 @@ class TestGenerateManifest:
             assert isinstance(sha256, str)
             assert len(sha256) == 64  # SHA-256 hex length
 
-    def test_without_hashes(self, tmp_path: Any) -> None:
+    def test_without_hashes(self, tmp_path: Path) -> None:
         (tmp_path / "file.txt").write_text("hello")
 
         sr = _make_showcase([], output_dir=tmp_path)
@@ -224,7 +225,7 @@ class TestGenerateManifest:
         assert manifest["entry_count"] == 1
         assert "sha256" not in _manifest_entries(manifest)[0]
 
-    def test_manifest_serializes_to_json(self, tmp_path: Any) -> None:
+    def test_manifest_serializes_to_json(self, tmp_path: Path) -> None:
         (tmp_path / "data.json").write_text("{}")
 
         sr = _make_showcase([], output_dir=tmp_path)

--- a/tests/unit/showcase/test_report.py
+++ b/tests/unit/showcase/test_report.py
@@ -11,7 +11,8 @@ from __future__ import annotations
 
 import json
 from collections.abc import Mapping
-from typing import Any
+from pathlib import Path
+from typing import cast
 from unittest.mock import MagicMock
 
 from hypothesis import given, settings
@@ -42,7 +43,7 @@ from polylogue.showcase.showcase_report_payloads import (
 # ---------------------------------------------------------------------------
 
 
-def _make_exercise(name: str = "ex", group: str = "structural", tier: int = 1) -> Any:
+def _make_exercise(name: str = "ex", group: str = "structural", tier: int = 1) -> Exercise:
     ex = MagicMock()
     ex.name = name
     ex.group = group
@@ -50,7 +51,7 @@ def _make_exercise(name: str = "ex", group: str = "structural", tier: int = 1) -
     ex.description = "A test exercise"
     ex.args = []
     ex.output_ext = ".txt"
-    return ex
+    return cast(Exercise, ex)
 
 
 def _make_result(passed: bool = True, skipped: bool = False, error: str | None = None) -> ExerciseResult:
@@ -186,7 +187,7 @@ def test_generate_json_report_always_valid_json(n: int) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_write_qa_session_creates_one_file(tmp_path: Any) -> None:
+def test_write_qa_session_creates_one_file(tmp_path: Path) -> None:
     """write_showcase_session writes exactly one JSON file to the audit dir."""
     results = [_make_result(passed=True), _make_result(passed=False, error="boom")]
     sr = _make_showcase(results)
@@ -199,7 +200,7 @@ def test_write_qa_session_creates_one_file(tmp_path: Any) -> None:
     assert data["summary"]["failed"] == 1
 
 
-def test_write_qa_session_creates_audit_dir_if_missing(tmp_path: Any) -> None:
+def test_write_qa_session_creates_audit_dir_if_missing(tmp_path: Path) -> None:
     """write_showcase_session creates the audit directory if it does not exist."""
     audit_dir = tmp_path / "deep" / "nested" / "audit"
     assert not audit_dir.exists()

--- a/tests/unit/showcase/test_runner.py
+++ b/tests/unit/showcase/test_runner.py
@@ -4,17 +4,16 @@ from __future__ import annotations
 
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from polylogue.scenarios import CorpusSpec, polylogue_execution
+from polylogue.scenarios import CorpusRequest, CorpusSpec, polylogue_execution
 from polylogue.showcase.cli_boundary import ShowcaseCliResult
 from polylogue.showcase.corpus_requests import showcase_corpus_request
 from polylogue.showcase.exercises import Exercise
 from polylogue.showcase.runner import ShowcaseRunner
 
 
-async def _fake_run_sources(**_kwargs: Any) -> Any:  # pragma: no cover - test helper
+async def _fake_run_sources(**_kwargs: object) -> object:  # pragma: no cover - test helper
     return None
 
 
@@ -27,11 +26,11 @@ def _write_min_fixture(fixture_dir: Path, provider: str = "chatgpt") -> None:
 class TestShowcaseRunnerSeeding:
     """Covers synthetic seed behavior in ShowcaseRunner."""
 
-    def test_seed_workspace_generates_synthetic_fixtures(self: Any, tmp_path: Any) -> None:
+    def test_seed_workspace_generates_synthetic_fixtures(self, tmp_path: Path) -> None:
         runner = ShowcaseRunner(corpus_request=showcase_corpus_request(count=7))
         workspace = tmp_path / "workspace"
 
-        def _fake_generate(fixtures_root: Path, *, request: Any) -> None:
+        def _fake_generate(fixtures_root: Path, *, request: CorpusRequest) -> None:
             assert request.count == 7
             assert request.style == "showcase"
             _write_min_fixture(fixtures_root, provider="codex")
@@ -43,7 +42,7 @@ class TestShowcaseRunnerSeeding:
         assert mock_generate.call_count == 1
         assert (workspace / "data" / "polylogue" / "inbox" / "codex" / "sample.json").exists()
 
-    def test_runner_seeds_workspace_with_selected_exercises(self: Any, tmp_path: Any) -> None:
+    def test_runner_seeds_workspace_with_selected_exercises(self, tmp_path: Path) -> None:
         runner = ShowcaseRunner(output_dir=tmp_path / "output")
         selected = [
             Exercise(
@@ -62,7 +61,7 @@ class TestShowcaseRunnerSeeding:
         mock_seed.assert_called_once()
         assert mock_seed.call_args.kwargs["exercises"] == selected
 
-    def test_generate_synthetic_fixtures_uses_showcase_style(self: Any, tmp_path: Any) -> None:
+    def test_generate_synthetic_fixtures_uses_showcase_style(self, tmp_path: Path) -> None:
         request = showcase_corpus_request(count=1)
         runner = ShowcaseRunner(corpus_request=request)
         fixture_root = tmp_path / "fixtures"
@@ -97,7 +96,7 @@ class TestShowcaseRunnerSeeding:
 class TestShowcaseRunnerWorkspaceEnv:
     """Covers pre-configured workspace_env behavior."""
 
-    def test_workspace_env_skips_seeding(self: Any, tmp_path: Any) -> None:
+    def test_workspace_env_skips_seeding(self, tmp_path: Path) -> None:
         """When workspace_env is provided, _seed_workspace should not be called."""
         env_vars = {
             "HOME": str(tmp_path / "home"),
@@ -118,7 +117,7 @@ class TestShowcaseRunnerWorkspaceEnv:
         mock_seed.assert_not_called()
         assert runner._env_vars == env_vars
 
-    def test_no_workspace_env_seeds_normally(self: Any, tmp_path: Any) -> None:
+    def test_no_workspace_env_seeds_normally(self, tmp_path: Path) -> None:
         """Without workspace_env, _seed_workspace should be called."""
         runner = ShowcaseRunner(
             output_dir=tmp_path / "output",
@@ -142,7 +141,7 @@ class TestShowcaseRunnerWorkspaceEnv:
 
 
 class TestShowcaseRunnerExecution:
-    def test_run_exercise_uses_cli_boundary(self: Any, tmp_path: Any) -> None:
+    def test_run_exercise_uses_cli_boundary(self, tmp_path: Path) -> None:
         runner = ShowcaseRunner(
             output_dir=tmp_path / "output",
             workspace_env={"POLYLOGUE_ARCHIVE_ROOT": str(tmp_path / "archive")},

--- a/tests/unit/showcase/test_verification_lane.py
+++ b/tests/unit/showcase/test_verification_lane.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from typing import Any
+from pathlib import Path
+
+import pytest
 
 
 class TestVerifyShowcaseImportable:
@@ -100,7 +102,7 @@ class TestBaselineComparison:
 class TestBaselinePersistence:
     """Test baseline save/load cycle."""
 
-    def test_save_and_load_roundtrip(self, tmp_path: Any, monkeypatch: Any) -> None:
+    def test_save_and_load_roundtrip(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """Baselines saved to disk can be loaded back identically."""
         import devtools.verify_showcase as mod
 
@@ -115,7 +117,7 @@ class TestBaselinePersistence:
 
         assert loaded == outputs
 
-    def test_load_missing_dir_returns_empty(self, tmp_path: Any, monkeypatch: Any) -> None:
+    def test_load_missing_dir_returns_empty(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """Loading from non-existent directory returns empty dict."""
         import devtools.verify_showcase as mod
 
@@ -123,7 +125,7 @@ class TestBaselinePersistence:
         assert mod.load_baselines() == {}
 
 
-def test_main_returns_1_when_no_baselines_and_no_update(tmp_path: Any, monkeypatch: Any) -> None:
+def test_main_returns_1_when_no_baselines_and_no_update(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """main() exits 1 when baselines directory is empty and --update not passed."""
     import devtools.verify_showcase as mod
 

--- a/tests/unit/showcase/test_vhs_generation.py
+++ b/tests/unit/showcase/test_vhs_generation.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from pathlib import Path
 
 from polylogue.scenarios import polylogue_execution
 from polylogue.showcase.exercises import Exercise, vhs_exercises
@@ -133,7 +133,7 @@ class TestGenerateAllTapes:
         assert "cap" in tapes
         assert "nocap" not in tapes
 
-    def test_writes_to_output_dir(self, tmp_path: Any) -> None:
+    def test_writes_to_output_dir(self, tmp_path: Path) -> None:
         exs = [
             Exercise(
                 name="write-test",


### PR DESCRIPTION
## Summary
- removes the remaining explicit dynamic typing from tests outside the already-merged core, storage, CLI/MCP/UI, pipeline, source-parser, and integration slices
- adds typed benchmark fixture protocols and concrete payload contracts for benchmark, fuzz, property, CLI, devtools, security, rendering, and showcase tests
- rewrites rendering preservation property-test setup around local TypedDict payloads and shared model builders

## Problem
After the previous mypy campaign PRs, the remaining test surfaces still relied on explicit Any annotations across benchmark/fuzz/property tests and several focused unit-test areas. That kept the test suite less precise than the now-typed source contracts, especially around generated rendering payloads and machine JSON envelopes.

Ref #281

## Solution
Replace explicit Any annotations with concrete pytest, pathlib, JSON, SQLite, Click, protocol, and TypedDict contracts. The rendering preservation property tests now use a small typed payload model and shared builders instead of repeating untyped nested dict indexing. Benchmark tests use a local BenchmarkFixture protocol, and machine/devtools/showcase/security helpers now preserve concrete boundaries without casts to Any.

Touched areas:
- tests/benchmarks/
- tests/fuzz/
- tests/property/
- tests/unit/cli/
- tests/unit/devtools/
- tests/unit/rendering/
- tests/unit/security/
- tests/unit/showcase/

## Verification
- PATH=/tmp/polylogue-281/.cache/codex-bin:$PATH rg -n "\bAny\b|cast\(Any|typing import .*Any" tests -g "*.py"
- PATH=/tmp/polylogue-281/.cache/codex-bin:$PATH ruff check --fix tests
- PATH=/tmp/polylogue-281/.cache/codex-bin:$PATH ruff format tests
- PATH=/tmp/polylogue-281/.cache/codex-bin:$PATH mypy tests
- PATH=/tmp/polylogue-281/.cache/codex-bin:$PATH pytest -q tests/unit/security tests/unit/devtools tests/unit/showcase tests/unit/cli/test_machine_main.py tests/unit/cli/test_run.py tests/unit/cli/test_products.py tests/unit/cli/test_qa_requests.py tests/unit/rendering/test_html_highlighting.py tests/property/test_rendering_preservation.py tests/property/test_schema_roundtrip.py
- PATH=/tmp/polylogue-281/.cache/codex-bin:$PATH devtools verify --quick
- PATH=/tmp/polylogue-281/.cache/codex-bin:$PATH git push -u origin feature/refactor/remaining-test-contracts
