### PR TITLE
refactor: split ingest pipeline runtimes

### DIFF
--- a/polylogue/pipeline/services/ingest_batch.py
+++ b/polylogue/pipeline/services/ingest_batch.py
@@ -127,6 +127,9 @@ class _IngestWorkerRequest:
     measure_ingest_result_size: bool
 
 
+_ConversationEntry = tuple[str, ConversationData]
+
+
 # ---------------------------------------------------------------------------
 # SQL statements (copied from async query modules — sync versions)
 # ---------------------------------------------------------------------------
@@ -311,12 +314,12 @@ def _conversation_parent_id(cdata: ConversationData) -> str | None:
 
 
 def _topo_sort_conversation_entries(
-    entries: list[tuple[str, ConversationData]],
-) -> list[tuple[str, ConversationData]]:
+    entries: list[_ConversationEntry],
+) -> list[_ConversationEntry]:
     """Sort conversation entries so parents in the same batch precede children."""
     ids_in_batch = {entry[1].conversation_id for entry in entries}
-    no_parent: list[tuple[str, ConversationData]] = []
-    has_parent: list[tuple[str, ConversationData]] = []
+    no_parent: list[_ConversationEntry] = []
+    has_parent: list[_ConversationEntry] = []
 
     for entry in entries:
         parent_id = _conversation_parent_id(entry[1])
@@ -334,7 +337,7 @@ def _topo_sort_conversation_entries(
     for _ in range(len(remaining) + 1):
         if not remaining:
             break
-        next_remaining: list[tuple[str, ConversationData]] = []
+        next_remaining: list[_ConversationEntry] = []
         for entry in remaining:
             parent_id = _conversation_parent_id(entry[1])
             if parent_id in inserted_ids:
@@ -548,11 +551,11 @@ def _write_conversation_entry(
 
 def _drain_ready_conversation_entries(
     conn: sqlite3.Connection,
-    ready_entries: list[tuple[str, ConversationData]],
+    ready_entries: list[_ConversationEntry],
     *,
     summary: _IngestBatchSummary,
     materialized_ids: set[str],
-    pending_by_parent: dict[str, list[tuple[str, ConversationData]]],
+    pending_by_parent: dict[str, list[_ConversationEntry]],
 ) -> None:
     stack = list(reversed(ready_entries))
     while stack:
@@ -572,7 +575,7 @@ def _drain_ready_conversation_entries(
 
 def _flush_pending_conversation_entries(
     conn: sqlite3.Connection,
-    pending_by_parent: dict[str, list[tuple[str, ConversationData]]],
+    pending_by_parent: dict[str, list[_ConversationEntry]],
     *,
     summary: _IngestBatchSummary,
     materialized_ids: set[str],
@@ -661,6 +664,125 @@ def _select_ingest_worker_count(raw_records: Sequence[object], ingest_workers: i
     return base_worker_count
 
 
+def _new_ingest_batch_summary(
+    raw_records: list[RawConversationRecord],
+    *,
+    ingest_workers: int | None,
+) -> _IngestBatchSummary:
+    summary = _IngestBatchSummary()
+    summary.raw_record_count = len(raw_records)
+    summary.worker_count = _select_ingest_worker_count(raw_records, ingest_workers)
+    summary.total_blob_mb = sum(record.blob_size for record in raw_records) / (1024 * 1024)
+    return summary
+
+
+def _make_ingest_worker_request(
+    *,
+    archive_root_str: str,
+    blob_root_str: str,
+    validation_mode: str,
+    measure_ingest_result_size: bool,
+) -> _IngestWorkerRequest:
+    return _IngestWorkerRequest(
+        archive_root_str=archive_root_str,
+        blob_root_str=blob_root_str,
+        validation_mode=validation_mode,
+        measure_ingest_result_size=measure_ingest_result_size,
+    )
+
+
+def _record_failed_ingest_result(summary: _IngestBatchSummary, ir: IngestRecordResult) -> None:
+    logger.error("Failed to ingest raw record", raw_id=ir.raw_id, error=ir.error)
+    summary.parse_failures += 1
+    summary.failed_raw_ids[ir.raw_id] = (ir.error or "unknown worker failure")[:500]
+
+
+def _drain_ingest_result(
+    conn: sqlite3.Connection,
+    ir: IngestRecordResult,
+    *,
+    summary: _IngestBatchSummary,
+    materialized_ids: set[str],
+    pending_by_parent: dict[str, list[_ConversationEntry]],
+) -> None:
+    _record_outcome(summary, ir)
+    _observe_current_rss(summary)
+
+    if ir.error:
+        _record_failed_ingest_result(summary, ir)
+        return
+
+    if not ir.conversations:
+        summary.skipped_raw_ids.add(ir.raw_id)
+        return
+
+    for cdata in ir.conversations:
+        drain_started = time.perf_counter()
+        _drain_ready_conversation_entries(
+            conn,
+            [(ir.raw_id, cdata)],
+            summary=summary,
+            materialized_ids=materialized_ids,
+            pending_by_parent=pending_by_parent,
+        )
+        summary.drain_elapsed_s += time.perf_counter() - drain_started
+        _observe_current_rss(summary)
+
+
+def _consume_ingest_results(
+    conn: sqlite3.Connection,
+    raw_records: list[RawConversationRecord],
+    *,
+    worker_request: _IngestWorkerRequest,
+    summary: _IngestBatchSummary,
+    materialized_ids: set[str],
+    pending_by_parent: dict[str, list[_ConversationEntry]],
+) -> None:
+    result_iterator = iter(
+        _iter_ingest_results_sync(
+            raw_records,
+            request=worker_request,
+            worker_count=summary.worker_count,
+        )
+    )
+    while True:
+        wait_started = time.perf_counter()
+        try:
+            ir = next(result_iterator)
+        except StopIteration:
+            summary.teardown_elapsed_s = time.perf_counter() - wait_started
+            break
+        summary.result_wait_s += time.perf_counter() - wait_started
+        _drain_ingest_result(
+            conn,
+            ir,
+            summary=summary,
+            materialized_ids=materialized_ids,
+            pending_by_parent=pending_by_parent,
+        )
+
+
+def _commit_ingest_results(
+    conn: sqlite3.Connection,
+    *,
+    summary: _IngestBatchSummary,
+    materialized_ids: set[str],
+    pending_by_parent: dict[str, list[_ConversationEntry]],
+) -> None:
+    flush_started = time.perf_counter()
+    _flush_pending_conversation_entries(
+        conn,
+        pending_by_parent,
+        summary=summary,
+        materialized_ids=materialized_ids,
+    )
+    summary.flush_elapsed_s = time.perf_counter() - flush_started
+    _observe_current_rss(summary)
+    commit_started = time.perf_counter()
+    conn.commit()
+    summary.commit_elapsed_s = time.perf_counter() - commit_started
+
+
 def _process_ingest_batch_sync(
     raw_records: list[RawConversationRecord],
     *,
@@ -673,11 +795,8 @@ def _process_ingest_batch_sync(
 ) -> _IngestBatchSummary:
     from polylogue.storage.fts_lifecycle import suspend_fts_triggers_sync
 
-    summary = _IngestBatchSummary()
-    summary.raw_record_count = len(raw_records)
-    summary.worker_count = _select_ingest_worker_count(raw_records, ingest_workers)
-    summary.total_blob_mb = sum(r.blob_size for r in raw_records) / (1024 * 1024)
-    worker_request = _IngestWorkerRequest(
+    summary = _new_ingest_batch_summary(raw_records, ingest_workers=ingest_workers)
+    worker_request = _make_ingest_worker_request(
         archive_root_str=archive_root_str,
         blob_root_str=blob_root_str,
         validation_mode=validation_mode,
@@ -692,62 +811,24 @@ def _process_ingest_batch_sync(
     summary.setup_elapsed_s = time.perf_counter() - setup_started
 
     materialized_ids: set[str] = set()
-    pending_by_parent: dict[str, list[tuple[str, ConversationData]]] = {}
+    pending_by_parent: dict[str, list[_ConversationEntry]] = {}
     _observe_current_rss(summary)
 
     try:
-        result_iterator = iter(
-            _iter_ingest_results_sync(
-                raw_records,
-                request=worker_request,
-                worker_count=summary.worker_count,
-            )
-        )
-        while True:
-            wait_started = time.perf_counter()
-            try:
-                ir = next(result_iterator)
-            except StopIteration:
-                summary.teardown_elapsed_s = time.perf_counter() - wait_started
-                break
-            summary.result_wait_s += time.perf_counter() - wait_started
-            _record_outcome(summary, ir)
-            _observe_current_rss(summary)
-
-            if ir.error:
-                logger.error("Failed to ingest raw record", raw_id=ir.raw_id, error=ir.error)
-                summary.parse_failures += 1
-                summary.failed_raw_ids[ir.raw_id] = ir.error[:500]
-                continue
-
-            if not ir.conversations:
-                summary.skipped_raw_ids.add(ir.raw_id)
-                continue
-
-            for cdata in ir.conversations:
-                drain_started = time.perf_counter()
-                _drain_ready_conversation_entries(
-                    conn,
-                    [(ir.raw_id, cdata)],
-                    summary=summary,
-                    materialized_ids=materialized_ids,
-                    pending_by_parent=pending_by_parent,
-                )
-                summary.drain_elapsed_s += time.perf_counter() - drain_started
-                _observe_current_rss(summary)
-
-        flush_started = time.perf_counter()
-        _flush_pending_conversation_entries(
+        _consume_ingest_results(
             conn,
-            pending_by_parent,
+            raw_records,
+            worker_request=worker_request,
             summary=summary,
             materialized_ids=materialized_ids,
+            pending_by_parent=pending_by_parent,
         )
-        summary.flush_elapsed_s = time.perf_counter() - flush_started
-        _observe_current_rss(summary)
-        commit_started = time.perf_counter()
-        conn.commit()
-        summary.commit_elapsed_s = time.perf_counter() - commit_started
+        _commit_ingest_results(
+            conn,
+            summary=summary,
+            materialized_ids=materialized_ids,
+            pending_by_parent=pending_by_parent,
+        )
     except Exception:
         conn.rollback()
         raise
@@ -803,6 +884,85 @@ def _build_batch_memory_observation(
     return observation
 
 
+def _apply_ingest_batch_summary(result: ParseResult, batch_summary: _IngestBatchSummary) -> None:
+    result.parse_failures += batch_summary.parse_failures
+    result.processed_ids.update(batch_summary.processed_ids)
+    result._changed_conversation_ids.extend(batch_summary.changed_conversation_ids)
+    for key, value in batch_summary.counts.items():
+        if key in result.counts:
+            result.counts[key] += value
+    for key, value in batch_summary.changed_counts.items():
+        if key in result.changed_counts:
+            result.changed_counts[key] += value
+
+
+def _progressed_raw_count(batch_summary: _IngestBatchSummary) -> int:
+    return sum(1 for outcome in batch_summary.outcomes.values() if outcome.had_conversations and outcome.error is None)
+
+
+def _successful_raw_ids(batch_summary: _IngestBatchSummary) -> set[str]:
+    return {
+        raw_id
+        for raw_id, outcome in batch_summary.outcomes.items()
+        if outcome.had_conversations and raw_id not in batch_summary.failed_raw_ids
+    }
+
+
+def _build_parse_batch_observation(
+    *,
+    batch_summary: _IngestBatchSummary,
+    elapsed_s: float,
+    raw_state_update_elapsed_s: float,
+    rss_start_mb: float | None,
+    rss_end_mb: float | None,
+    peak_rss_self_start_mb: float | None,
+    peak_rss_self_end_mb: float | None,
+    peak_rss_children_mb: float | None,
+) -> ParseBatchObservation:
+    observation: ParseBatchObservation = {
+        "records": batch_summary.raw_record_count,
+        "blob_mb": round(batch_summary.total_blob_mb, 1),
+        "result_mb": round(batch_summary.total_result_bytes / (1024 * 1024), 3),
+        "max_result_mb": round(batch_summary.max_result_bytes / (1024 * 1024), 3),
+        "conversations": batch_summary.total_convos,
+        "messages": batch_summary.total_msgs,
+        "changed_conversations": len(batch_summary.changed_conversation_ids),
+        "workers": batch_summary.worker_count,
+        "failed_raw_count": len(batch_summary.failed_raw_ids),
+        "skipped_raw_count": len(batch_summary.skipped_raw_ids),
+        "elapsed_ms": round(elapsed_s * 1000, 1),
+        "sync_ingest_elapsed_ms": round(batch_summary.elapsed_s * 1000, 1),
+        "sync_setup_elapsed_ms": round(batch_summary.setup_elapsed_s * 1000, 1),
+        "result_wait_elapsed_ms": round(batch_summary.result_wait_s * 1000, 1),
+        "drain_elapsed_ms": round(batch_summary.drain_elapsed_s * 1000, 1),
+        "write_elapsed_ms": round(batch_summary.write_elapsed_s * 1000, 1),
+        "max_write_elapsed_ms": round(batch_summary.max_write_elapsed_s * 1000, 1),
+        "flush_elapsed_ms": round(batch_summary.flush_elapsed_s * 1000, 1),
+        "commit_elapsed_ms": round(batch_summary.commit_elapsed_s * 1000, 1),
+        "executor_teardown_elapsed_ms": round(batch_summary.teardown_elapsed_s * 1000, 1),
+        "raw_state_update_elapsed_ms": round(raw_state_update_elapsed_s * 1000, 1),
+    }
+    residual_elapsed_s = _unattributed_batch_elapsed_s(
+        elapsed_s=elapsed_s,
+        batch_summary=batch_summary,
+        raw_state_update_elapsed_s=raw_state_update_elapsed_s,
+    )
+    observation["unattributed_elapsed_ms"] = round(residual_elapsed_s * 1000, 1)
+    observation.update(
+        _build_batch_memory_observation(
+            rss_start_mb=rss_start_mb,
+            rss_end_mb=rss_end_mb,
+            peak_rss_self_start_mb=peak_rss_self_start_mb,
+            peak_rss_self_end_mb=peak_rss_self_end_mb,
+            peak_rss_children_mb=peak_rss_children_mb,
+            max_current_rss_mb=batch_summary.max_current_rss_mb,
+        )
+    )
+    if batch_summary.max_result_raw_id is not None:
+        observation["max_result_raw_id"] = batch_summary.max_result_raw_id
+    return observation
+
+
 # ---------------------------------------------------------------------------
 # Batch processing
 # ---------------------------------------------------------------------------
@@ -847,19 +1007,8 @@ async def process_ingest_batch(
         measure_ingest_result_size=service.measure_ingest_result_size,
     )
 
-    result.parse_failures += batch_summary.parse_failures
-    result.processed_ids.update(batch_summary.processed_ids)
-    result._changed_conversation_ids.extend(batch_summary.changed_conversation_ids)
-    for key, value in batch_summary.counts.items():
-        if key in result.counts:
-            result.counts[key] += value
-    for key, value in batch_summary.changed_counts.items():
-        if key in result.changed_counts:
-            result.changed_counts[key] += value
-
-    progressed_raw_count = sum(
-        1 for outcome in batch_summary.outcomes.values() if outcome.had_conversations and outcome.error is None
-    )
+    _apply_ingest_batch_summary(result, batch_summary)
+    progressed_raw_count = _progressed_raw_count(batch_summary)
     if progress_callback and progressed_raw_count:
         progress_callback(progressed_raw_count)
 
@@ -875,21 +1024,13 @@ async def process_ingest_batch(
             changed=len(batch_summary.changed_conversation_ids),
         )
 
-    succeeded_raw_ids = {
-        raw_id
-        for raw_id, outcome in batch_summary.outcomes.items()
-        if outcome.had_conversations and raw_id not in batch_summary.failed_raw_ids
-    }
-    skipped_raw_ids = batch_summary.skipped_raw_ids
-    failed_raw_ids = batch_summary.failed_raw_ids
-
     raw_state_update_elapsed_s = await _persist_batch_raw_state_updates(
         service,
         backend,
         outcomes=batch_summary.outcomes,
-        succeeded_raw_ids=succeeded_raw_ids,
-        skipped_raw_ids=skipped_raw_ids,
-        failed_raw_ids=failed_raw_ids,
+        succeeded_raw_ids=_successful_raw_ids(batch_summary),
+        skipped_raw_ids=batch_summary.skipped_raw_ids,
+        failed_raw_ids=batch_summary.failed_raw_ids,
         validation_mode=validation_mode,
     )
 
@@ -897,48 +1038,16 @@ async def process_ingest_batch(
     rss_end_mb = read_current_rss_mb()
     peak_rss_self_end_mb = read_peak_rss_self_mb()
     peak_rss_children_mb = read_peak_rss_children_mb()
-    observation: ParseBatchObservation = {
-        "records": batch_summary.raw_record_count,
-        "blob_mb": round(batch_summary.total_blob_mb, 1),
-        "result_mb": round(batch_summary.total_result_bytes / (1024 * 1024), 3),
-        "max_result_mb": round(batch_summary.max_result_bytes / (1024 * 1024), 3),
-        "conversations": batch_summary.total_convos,
-        "messages": batch_summary.total_msgs,
-        "changed_conversations": len(batch_summary.changed_conversation_ids),
-        "workers": batch_summary.worker_count,
-        "failed_raw_count": len(batch_summary.failed_raw_ids),
-        "skipped_raw_count": len(batch_summary.skipped_raw_ids),
-        "elapsed_ms": round(elapsed_s * 1000, 1),
-        "sync_ingest_elapsed_ms": round(batch_summary.elapsed_s * 1000, 1),
-        "sync_setup_elapsed_ms": round(batch_summary.setup_elapsed_s * 1000, 1),
-        "result_wait_elapsed_ms": round(batch_summary.result_wait_s * 1000, 1),
-        "drain_elapsed_ms": round(batch_summary.drain_elapsed_s * 1000, 1),
-        "write_elapsed_ms": round(batch_summary.write_elapsed_s * 1000, 1),
-        "max_write_elapsed_ms": round(batch_summary.max_write_elapsed_s * 1000, 1),
-        "flush_elapsed_ms": round(batch_summary.flush_elapsed_s * 1000, 1),
-        "commit_elapsed_ms": round(batch_summary.commit_elapsed_s * 1000, 1),
-        "executor_teardown_elapsed_ms": round(batch_summary.teardown_elapsed_s * 1000, 1),
-        "raw_state_update_elapsed_ms": round(raw_state_update_elapsed_s * 1000, 1),
-    }
-    residual_elapsed_s = _unattributed_batch_elapsed_s(
-        elapsed_s=elapsed_s,
+    return _build_parse_batch_observation(
         batch_summary=batch_summary,
+        elapsed_s=elapsed_s,
         raw_state_update_elapsed_s=raw_state_update_elapsed_s,
+        rss_start_mb=rss_start_mb,
+        rss_end_mb=rss_end_mb,
+        peak_rss_self_start_mb=peak_rss_self_start_mb,
+        peak_rss_self_end_mb=peak_rss_self_end_mb,
+        peak_rss_children_mb=peak_rss_children_mb,
     )
-    observation["unattributed_elapsed_ms"] = round(max(residual_elapsed_s, 0.0) * 1000, 1)
-    observation.update(
-        _build_batch_memory_observation(
-            rss_start_mb=rss_start_mb,
-            rss_end_mb=rss_end_mb,
-            peak_rss_self_start_mb=peak_rss_self_start_mb,
-            peak_rss_self_end_mb=peak_rss_self_end_mb,
-            peak_rss_children_mb=peak_rss_children_mb,
-            max_current_rss_mb=batch_summary.max_current_rss_mb,
-        )
-    )
-    if batch_summary.max_result_raw_id is not None:
-        observation["max_result_raw_id"] = batch_summary.max_result_raw_id
-    return observation
 
 
 def _successful_raw_state_update(

--- a/polylogue/pipeline/services/ingest_worker.py
+++ b/polylogue/pipeline/services/ingest_worker.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import pickle
 import re
 from dataclasses import dataclass, field
+from datetime import timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
@@ -23,13 +24,21 @@ from polylogue.lib.json import dumps as json_dumps
 from polylogue.lib.raw_payload_decode import RawPayloadEnvelope
 from polylogue.lib.roles import Role
 from polylogue.pipeline.materialization_runtime import (
+    MaterializedContentBlock,
     MaterializedConversation,
+    MaterializedMessage,
     materialize_conversation,
 )
 from polylogue.sources.decoders import _iter_json_stream
 from polylogue.sources.dispatch import STREAM_RECORD_PROVIDERS
 from polylogue.storage.blob_store import BlobStore
-from polylogue.storage.store import RawConversationRecord, _json_or_none
+from polylogue.storage.store import (
+    ACTION_EVENT_MATERIALIZER_VERSION,
+    ContentBlockRecord,
+    MessageRecord,
+    RawConversationRecord,
+    _json_or_none,
+)
 from polylogue.types import (
     AttachmentId,
     ContentBlockType,
@@ -43,6 +52,7 @@ from polylogue.types import (
 )
 
 if TYPE_CHECKING:
+    from polylogue.lib.action_events import ActionEvent
     from polylogue.schemas.packages import SchemaResolution
     from polylogue.schemas.runtime_registry import SchemaRegistry
     from polylogue.sources.parsers.base import ParsedConversation
@@ -674,91 +684,99 @@ def ingest_record(
 # ---------------------------------------------------------------------------
 
 
-def _transform_to_tuples(
-    convo: ParsedConversation,
-    *,
-    source_name: str,
-    archive_root: Path,
-    raw_id: str | None,
-) -> ConversationData:
-    """Convert a ParsedConversation to DB-ready tuples."""
-    materialized = materialize_conversation(
-        convo,
-        source_name=source_name,
-        archive_root=archive_root,
-    )
-
-    conv_tuple: ConversationTuple = (
-        materialized.conversation_id,
-        materialized.provider_name,
-        materialized.provider_conversation_id,
-        materialized.title,
-        materialized.created_at,
-        materialized.updated_at,
-        materialized.sort_key,
-        materialized.content_hash,
-        _json_or_none(materialized.provider_meta),
+def _conversation_tuple(conversation: MaterializedConversation, *, raw_id: str | None) -> ConversationTuple:
+    return (
+        conversation.conversation_id,
+        conversation.provider_name,
+        conversation.provider_conversation_id,
+        conversation.title,
+        conversation.created_at,
+        conversation.updated_at,
+        conversation.sort_key,
+        conversation.content_hash,
+        _json_or_none(conversation.provider_meta),
         "{}",
         1,
-        materialized.parent_conversation_id,
-        materialized.branch_type,
+        conversation.parent_conversation_id,
+        conversation.branch_type,
         raw_id,
     )
 
-    msg_tuples: list[MessageTuple] = [
-        (
-            message.message_id,
-            materialized.conversation_id,
-            message.provider_message_id,
-            message.role,
-            message.text,
-            message.sort_key,
-            message.content_hash,
-            1,
-            message.parent_message_id,
-            message.branch_index,
-            materialized.provider_name,
-            message.word_count,
-            message.has_tool_use,
-            message.has_thinking,
-        )
-        for message in materialized.messages
-    ]
 
-    block_tuples: list[ContentBlockTuple] = []
-    for message in materialized.messages:
-        for block in message.blocks:
-            block_tuples.append(
-                (
-                    block.block_id,
-                    message.message_id,
-                    materialized.conversation_id,
-                    block.block_index,
-                    block.type,
-                    block.text,
-                    block.tool_name,
-                    block.tool_id,
-                    block.tool_input_json,
-                    block.media_type,
-                    block.metadata_json,
-                    block.semantic_type,
-                )
-            )
-
-    stats_tuple: StatsTuple = (
-        materialized.conversation_id,
-        materialized.provider_name,
-        materialized.stats.message_count,
-        materialized.stats.word_count,
-        materialized.stats.tool_use_count,
-        materialized.stats.thinking_count,
+def _message_tuple(conversation: MaterializedConversation, message: MaterializedMessage) -> MessageTuple:
+    return (
+        message.message_id,
+        conversation.conversation_id,
+        message.provider_message_id,
+        message.role,
+        message.text,
+        message.sort_key,
+        message.content_hash,
+        1,
+        message.parent_message_id,
+        message.branch_index,
+        conversation.provider_name,
+        message.word_count,
+        message.has_tool_use,
+        message.has_thinking,
     )
 
-    action_event_tuples = _build_action_event_tuples(materialized)
 
+def _message_tuples(conversation: MaterializedConversation) -> list[MessageTuple]:
+    return [_message_tuple(conversation, message) for message in conversation.messages]
+
+
+def _content_block_tuple(
+    *,
+    conversation_id: ConversationId,
+    message_id: MessageId,
+    block: MaterializedContentBlock,
+) -> ContentBlockTuple:
+    return (
+        block.block_id,
+        message_id,
+        conversation_id,
+        block.block_index,
+        block.type,
+        block.text,
+        block.tool_name,
+        block.tool_id,
+        block.tool_input_json,
+        block.media_type,
+        block.metadata_json,
+        block.semantic_type,
+    )
+
+
+def _content_block_tuples(conversation: MaterializedConversation) -> list[ContentBlockTuple]:
+    return [
+        _content_block_tuple(
+            conversation_id=conversation.conversation_id,
+            message_id=message.message_id,
+            block=block,
+        )
+        for message in conversation.messages
+        for block in message.blocks
+    ]
+
+
+def _stats_tuple(conversation: MaterializedConversation) -> StatsTuple:
+    return (
+        conversation.conversation_id,
+        conversation.provider_name,
+        conversation.stats.message_count,
+        conversation.stats.word_count,
+        conversation.stats.tool_use_count,
+        conversation.stats.thinking_count,
+    )
+
+
+def _attachment_tuples(
+    conversation: MaterializedConversation,
+) -> tuple[list[AttachmentTuple], list[AttachmentRefTuple]]:
     attachment_tuples: list[AttachmentTuple] = []
     attachment_ref_tuples: list[AttachmentRefTuple] = []
-    for attachment in materialized.attachments:
+    for attachment in conversation.attachments:
         meta_json = _json_or_none(attachment.provider_meta)
         attachment_tuples.append(
             (
@@ -774,29 +792,144 @@ def _transform_to_tuples(
             (
                 _make_ref_id(
                     attachment.attachment_id,
-                    materialized.conversation_id,
+                    conversation.conversation_id,
                     attachment.message_id,
                 ),
                 attachment.attachment_id,
-                materialized.conversation_id,
+                conversation.conversation_id,
                 attachment.message_id,
                 meta_json,
             )
         )
+    return attachment_tuples, attachment_ref_tuples
+
+
+def _transform_to_tuples(
+    convo: ParsedConversation,
+    *,
+    source_name: str,
+    archive_root: Path,
+    raw_id: str | None,
+) -> ConversationData:
+    """Convert a ParsedConversation to DB-ready tuples."""
+    materialized = materialize_conversation(
+        convo,
+        source_name=source_name,
+        archive_root=archive_root,
+    )
+
+    attachment_tuples, attachment_ref_tuples = _attachment_tuples(materialized)
 
     return ConversationData(
         conversation_id=materialized.conversation_id,
         content_hash=materialized.content_hash,
         provider_name=materialized.provider_name,
-        conversation_tuple=conv_tuple,
-        message_tuples=msg_tuples,
-        block_tuples=block_tuples,
-        action_event_tuples=action_event_tuples,
-        stats_tuple=stats_tuple,
+        conversation_tuple=_conversation_tuple(materialized, raw_id=raw_id),
+        message_tuples=_message_tuples(materialized),
+        block_tuples=_content_block_tuples(materialized),
+        action_event_tuples=_build_action_event_tuples(materialized),
+        stats_tuple=_stats_tuple(materialized),
         attachment_tuples=attachment_tuples,
         attachment_ref_tuples=attachment_ref_tuples,
         source_name=source_name,
         raw_id=raw_id,
+    )
+
+
+def _content_block_record_for_action_event(
+    *,
+    conversation_id: ConversationId,
+    message_id: MessageId,
+    block: MaterializedContentBlock,
+) -> ContentBlockRecord:
+    return ContentBlockRecord(
+        block_id=block.block_id,
+        message_id=message_id,
+        conversation_id=conversation_id,
+        block_index=block.block_index,
+        type=block.type,
+        text=block.text,
+        tool_name=block.tool_name,
+        tool_id=block.tool_id,
+        tool_input=block.tool_input_json,
+        media_type=block.media_type,
+        metadata=block.metadata_json,
+        semantic_type=block.semantic_type,
+    )
+
+
+def _message_record_for_action_events(
+    conversation: MaterializedConversation,
+    message: MaterializedMessage,
+) -> MessageRecord:
+    return MessageRecord(
+        message_id=message.message_id,
+        conversation_id=conversation.conversation_id,
+        provider_message_id=message.provider_message_id,
+        role=message.role,
+        text=message.text,
+        sort_key=message.sort_key,
+        content_hash=message.content_hash,
+        provider_name=conversation.provider_name,
+        word_count=message.word_count,
+        has_tool_use=message.has_tool_use,
+        has_thinking=message.has_thinking,
+        content_blocks=[
+            _content_block_record_for_action_event(
+                conversation_id=conversation.conversation_id,
+                message_id=message.message_id,
+                block=block,
+            )
+            for block in message.blocks
+        ],
+    )
+
+
+def _timestamp_iso_for_action_event(event: ActionEvent) -> str | None:
+    if event.timestamp is None:
+        return None
+    timestamp = event.timestamp
+    if timestamp.tzinfo is None:
+        timestamp = timestamp.replace(tzinfo=timezone.utc)
+    return timestamp.isoformat()
+
+
+def _action_event_source_block_id(event: ActionEvent) -> str | None:
+    if not isinstance(event.raw, dict):
+        return None
+    block_id = event.raw.get("block_id")
+    return block_id if isinstance(block_id, str) else None
+
+
+def _action_event_tuple(
+    conversation: MaterializedConversation,
+    message: MaterializedMessage,
+    event: ActionEvent,
+) -> ActionEventTuple:
+    affected_paths_json = json_dumps(list(event.affected_paths)) if event.affected_paths else None
+    branch_names_json = json_dumps(list(event.branch_names)) if event.branch_names else None
+    return (
+        event.event_id,
+        conversation.conversation_id,
+        message.message_id,
+        ACTION_EVENT_MATERIALIZER_VERSION,
+        _action_event_source_block_id(event),
+        _timestamp_iso_for_action_event(event),
+        message.sort_key,
+        event.sequence_index,
+        conversation.provider_name,
+        event.kind.value,
+        event.tool_name,
+        event.normalized_tool_name,
+        event.tool_id,
+        affected_paths_json,
+        event.cwd_path,
+        branch_names_json,
+        event.command,
+        event.query,
+        event.url,
+        event.output_text,
+        event.search_text,
     )
 
 
@@ -810,95 +943,25 @@ def _build_action_event_tuples(
     """
     from polylogue.lib.action_events import build_action_events, build_tool_calls_from_content_blocks
     from polylogue.storage.hydrators import message_from_record
-    from polylogue.storage.store import (
-        ACTION_EVENT_MATERIALIZER_VERSION,
-        ContentBlockRecord,
-        MessageRecord,
-    )
-    from polylogue.types import Provider
 
     provider = Provider.from_string(conversation.provider_name)
     action_tuples: list[ActionEventTuple] = []
-    conversation_id_token = conversation.conversation_id
 
     for message in conversation.messages:
         if not message.has_tool_use:
             continue
 
-        msg_record = MessageRecord(
-            message_id=message.message_id,
-            conversation_id=conversation_id_token,
-            provider_message_id=message.provider_message_id,
-            role=message.role,
-            text=message.text,
-            sort_key=message.sort_key,
-            content_hash=message.content_hash,
-            provider_name=conversation.provider_name,
-            word_count=message.word_count,
-            has_tool_use=message.has_tool_use,
-            has_thinking=message.has_thinking,
-            content_blocks=[
-                ContentBlockRecord(
-                    block_id=block.block_id,
-                    message_id=message.message_id,
-                    conversation_id=conversation_id_token,
-                    block_index=block.block_index,
-                    type=block.type,
-                    text=block.text,
-                    tool_name=block.tool_name,
-                    tool_id=block.tool_id,
-                    tool_input=block.tool_input_json,
-                    media_type=block.media_type,
-                    metadata=block.metadata_json,
-                    semantic_type=block.semantic_type,
-                )
-                for block in message.blocks
-            ],
+        domain_message = message_from_record(
+            _message_record_for_action_events(conversation, message),
+            attachments=[],
+            provider=provider,
         )
-
-        domain_message = message_from_record(msg_record, attachments=[], provider=provider)
         tool_calls = build_tool_calls_from_content_blocks(
             provider=provider,
             content_blocks=domain_message.content_blocks,
         )
         for event in build_action_events(domain_message, tool_calls):
-            from datetime import timezone
-
-            timestamp_iso = None
-            if event.timestamp is not None:
-                ts = event.timestamp
-                if ts.tzinfo is None:
-                    ts = ts.replace(tzinfo=timezone.utc)
-                timestamp_iso = ts.isoformat()
-
-            affected_paths_json = json_dumps(list(event.affected_paths)) if event.affected_paths else None
-            branch_names_json = json_dumps(list(event.branch_names)) if event.branch_names else None
-
-            action_tuples.append(
-                (
-                    event.event_id,  # event_id
-                    conversation.conversation_id,  # conversation_id
-                    message.message_id,  # message_id
-                    ACTION_EVENT_MATERIALIZER_VERSION,  # materializer_version
-                    event.raw.get("block_id") if isinstance(event.raw, dict) else None,  # source_block_id
-                    timestamp_iso,  # timestamp
-                    message.sort_key,  # sort_key
-                    event.sequence_index,  # sequence_index
-                    conversation.provider_name,  # provider_name
-                    event.kind.value,  # action_kind
-                    event.tool_name,  # tool_name
-                    event.normalized_tool_name,  # normalized_tool_name
-                    event.tool_id,  # tool_id
-                    affected_paths_json,  # affected_paths_json
-                    event.cwd_path,  # cwd_path
-                    branch_names_json,  # branch_names_json
-                    event.command,  # command
-                    event.query,  # query_text
-                    event.url,  # url
-                    event.output_text,  # output_text
-                    event.search_text,  # search_text
-                )
-            )
+            action_tuples.append(_action_event_tuple(conversation, message, event))
 
     return action_tuples
 

--- a/polylogue/pipeline/services/planning_runtime.py
+++ b/polylogue/pipeline/services/planning_runtime.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import time
 from collections.abc import Sequence
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from polylogue.config import Source
@@ -21,9 +22,34 @@ from .planning_models import IngestPlan
 from .validation import ValidationService
 
 if TYPE_CHECKING:
+    from polylogue.storage.cursor_state import CursorStatePayload
+
     from .planning import PlanningService
 
 _SCAN_STATE_BATCH_SIZE = 200  # Metadata-only rows (no BLOBs) — can batch larger
+
+
+@dataclass(frozen=True)
+class _PlanStageFlags:
+    acquire: bool
+    parse: bool
+    materialize: bool
+    render: bool
+    index: bool
+
+    @classmethod
+    def from_stage_names(cls, stage_names: tuple[str, ...]) -> _PlanStageFlags:
+        return cls(
+            acquire="acquire" in stage_names,
+            parse="parse" in stage_names,
+            materialize="materialize" in stage_names,
+            render="render" in stage_names,
+            index="index" in stage_names,
+        )
+
+    @property
+    def has_conversation_products(self) -> bool:
+        return self.materialize or self.render or self.index
 
 
 def _normalize_plan_stage_sequence(normalized_stage_sequence: tuple[str, ...]) -> list[PlanStage]:
@@ -44,6 +70,133 @@ def _summarize_plan_stage(
     return PlanStage.CUSTOM
 
 
+def _apply_conversation_stage_counts(counts: PlanCounts, *, conversation_count: int, flags: _PlanStageFlags) -> None:
+    if flags.materialize and conversation_count:
+        counts.materialize = conversation_count
+    if flags.render and conversation_count:
+        counts.render = conversation_count
+    if flags.index and conversation_count:
+        counts.index = conversation_count
+
+
+def _plan_summary(
+    *,
+    summary_stage: PlanStage,
+    stage_sequence: list[PlanStage],
+    counts: PlanCounts,
+    sources: list[str],
+    details: PlanDetails | None = None,
+    cursors: dict[str, CursorStatePayload] | None = None,
+) -> PlanResult:
+    return PlanResult(
+        timestamp=int(time.time()),
+        stage=summary_stage,
+        stage_sequence=stage_sequence,
+        counts=counts,
+        details=details or PlanDetails(),
+        sources=sources,
+        cursors=cursors or {},
+    )
+
+
+async def _plan_existing_conversation_stages(
+    service: PlanningService,
+    *,
+    source_names: list[str],
+    db_scope_names: list[str] | None,
+    summary_stage: PlanStage,
+    stage_sequence: list[PlanStage],
+    flags: _PlanStageFlags,
+) -> IngestPlan:
+    conversation_count = 0
+    if flags.has_conversation_products:
+        conversation_count = await service.backend.count_conversation_ids(source_names=db_scope_names)
+
+    counts = PlanCounts()
+    _apply_conversation_stage_counts(counts, conversation_count=conversation_count, flags=flags)
+    return IngestPlan(
+        summary=_plan_summary(
+            summary_stage=summary_stage,
+            stage_sequence=stage_sequence,
+            counts=counts,
+            sources=source_names,
+        ),
+        validate_raw_ids=[],
+        parse_ready_raw_ids=[],
+    )
+
+
+async def _plan_parse_backlog(
+    service: PlanningService,
+    *,
+    source_names: list[str],
+    db_scope_names: list[str] | None,
+    summary_stage: PlanStage,
+    stage_sequence: list[PlanStage],
+    flags: _PlanStageFlags,
+    force_reparse: bool,
+) -> IngestPlan:
+    validate_backlog_ids = await collect_validation_backlog(
+        service.backend,
+        source_names=db_scope_names,
+        exclude_raw_ids=[],
+        force_reparse=force_reparse,
+    )
+    parse_backlog_ids = await collect_parse_backlog(
+        service.backend,
+        source_names=db_scope_names,
+        exclude_raw_ids=validate_backlog_ids,
+        force_reparse=force_reparse,
+    )
+    reprocess_raw_ids = dedupe_ids([*validate_backlog_ids, *parse_backlog_ids])
+    counts = PlanCounts()
+    details = PlanDetails()
+    if validate_backlog_ids:
+        counts.validate_count = len(validate_backlog_ids)
+        details.backlog_validate = len(validate_backlog_ids)
+    if reprocess_raw_ids:
+        counts.parse = len(reprocess_raw_ids)
+        details.backlog_parse = len(parse_backlog_ids)
+        _apply_conversation_stage_counts(counts, conversation_count=len(reprocess_raw_ids), flags=flags)
+    return IngestPlan(
+        summary=_plan_summary(
+            summary_stage=summary_stage,
+            stage_sequence=stage_sequence,
+            counts=counts,
+            details=details,
+            sources=source_names,
+        ),
+        validate_raw_ids=validate_backlog_ids,
+        parse_ready_raw_ids=reprocess_raw_ids,
+    )
+
+
+async def _final_scan_counts(
+    service: PlanningService,
+    *,
+    scanned_count: int,
+    plan_details: PlanDetails,
+    validate_raw_ids: list[str],
+    parse_ready_raw_ids: list[str],
+    db_scope_names: list[str] | None,
+    flags: _PlanStageFlags,
+) -> PlanCounts:
+    counts = PlanCounts()
+    if scanned_count:
+        counts.scan = scanned_count
+    if plan_details.int_value("new_raw") and flags.acquire:
+        counts.store_raw = plan_details.int_value("new_raw")
+    if flags.parse and validate_raw_ids:
+        counts.validate_count = len(validate_raw_ids)
+    if flags.parse and parse_ready_raw_ids:
+        counts.parse = len(parse_ready_raw_ids)
+        _apply_conversation_stage_counts(counts, conversation_count=len(parse_ready_raw_ids), flags=flags)
+    elif not flags.parse and flags.has_conversation_products:
+        conversation_count = await service.backend.count_conversation_ids(source_names=db_scope_names)
+        _apply_conversation_stage_counts(counts, conversation_count=conversation_count, flags=flags)
+    return counts
+
+
 async def build_ingest_plan(
     service: PlanningService,
     *,
@@ -60,81 +213,32 @@ async def build_ingest_plan(
 
     normalized_stage_names = normalize_stage_sequence(stage=stage, stage_sequence=stage_sequence)
     normalized_plan_stage_sequence = _normalize_plan_stage_sequence(normalized_stage_names)
+    stage_flags = _PlanStageFlags.from_stage_names(normalized_stage_names)
     summary_stage = _summarize_plan_stage(
         stage=stage,
         normalized_stage_sequence=normalized_stage_names,
         stage_sequence=stage_sequence,
     )
-    has_acquire = "acquire" in normalized_stage_names
-    has_parse = "parse" in normalized_stage_names
-    has_materialize = "materialize" in normalized_stage_names
-    has_render = "render" in normalized_stage_names
-    has_index = "index" in normalized_stage_names
 
-    if not has_acquire and not has_parse:
-        conversation_count = 0
-        if has_materialize or has_render or has_index:
-            conversation_count = await service.backend.count_conversation_ids(source_names=db_scope_names)
-        stage_counts = PlanCounts()
-        if has_materialize and conversation_count:
-            stage_counts.materialize = conversation_count
-        if has_render and conversation_count:
-            stage_counts.render = conversation_count
-        if has_index and conversation_count:
-            stage_counts.index = conversation_count
-        return IngestPlan(
-            summary=PlanResult(
-                timestamp=int(time.time()),
-                stage=summary_stage,
-                stage_sequence=normalized_plan_stage_sequence,
-                counts=stage_counts,
-                sources=source_names,
-                cursors={},
-            ),
-            validate_raw_ids=[],
-            parse_ready_raw_ids=[],
+    if not stage_flags.acquire and not stage_flags.parse:
+        return await _plan_existing_conversation_stages(
+            service,
+            source_names=source_names,
+            db_scope_names=db_scope_names,
+            summary_stage=summary_stage,
+            stage_sequence=normalized_plan_stage_sequence,
+            flags=stage_flags,
         )
 
-    if has_parse and not has_acquire:
-        validate_backlog_ids = await collect_validation_backlog(
-            service.backend,
-            source_names=db_scope_names,
-            exclude_raw_ids=[],
+    if stage_flags.parse and not stage_flags.acquire:
+        return await _plan_parse_backlog(
+            service,
+            source_names=source_names,
+            db_scope_names=db_scope_names,
+            summary_stage=summary_stage,
+            stage_sequence=normalized_plan_stage_sequence,
+            flags=stage_flags,
             force_reparse=force_reparse,
-        )
-        parse_backlog_ids = await collect_parse_backlog(
-            service.backend,
-            source_names=db_scope_names,
-            exclude_raw_ids=validate_backlog_ids,
-            force_reparse=force_reparse,
-        )
-        reprocess_raw_ids = dedupe_ids([*validate_backlog_ids, *parse_backlog_ids])
-        backlog_counts = PlanCounts()
-        backlog_details = PlanDetails()
-        if validate_backlog_ids:
-            backlog_counts.validate_count = len(validate_backlog_ids)
-            backlog_details.backlog_validate = len(validate_backlog_ids)
-        if reprocess_raw_ids:
-            backlog_counts.parse = len(reprocess_raw_ids)
-            backlog_details.backlog_parse = len(parse_backlog_ids)
-            if has_materialize:
-                backlog_counts.materialize = len(reprocess_raw_ids)
-            if has_render:
-                backlog_counts.render = len(reprocess_raw_ids)
-            if has_index:
-                backlog_counts.index = len(reprocess_raw_ids)
-        return IngestPlan(
-            summary=PlanResult(
-                timestamp=int(time.time()),
-                stage=summary_stage,
-                stage_sequence=normalized_plan_stage_sequence,
-                counts=backlog_counts,
-                details=backlog_details,
-                sources=source_names,
-                cursors={},
-            ),
-            validate_raw_ids=validate_backlog_ids,
-            parse_ready_raw_ids=reprocess_raw_ids,
         )
 
     acquisition = AcquisitionService(service.backend)
@@ -150,7 +254,7 @@ async def build_ingest_plan(
         backlog_parse=0,
     )
     pending_records: list[RawConversationRecord] = []
-    preview_validation = ValidateResult() if preview and has_parse else None
+    preview_validation = ValidateResult() if preview and stage_flags.parse else None
     seen_scanned_raw_ids: set[str] = set()
 
     max_preview_validation_records = 50  # Cap preview validation to bound memory
@@ -172,7 +276,7 @@ async def build_ingest_plan(
             state = scanned_states.get(record.raw_id)
             if state is None:
                 plan_details.new_raw = plan_details.int_value("new_raw") + 1
-                if has_parse:
+                if stage_flags.parse:
                     validate_raw_ids.append(record.raw_id)
                     if (
                         preview
@@ -183,7 +287,7 @@ async def build_ingest_plan(
                 continue
 
             plan_details.existing_raw = plan_details.int_value("existing_raw") + 1
-            if not has_parse:
+            if not stage_flags.parse:
                 continue
 
             artifact_state = RawIngestArtifactState.from_state(state)
@@ -218,7 +322,7 @@ async def build_ingest_plan(
     )
     await flush_pending_records()
 
-    if has_parse:
+    if stage_flags.parse:
         backlog_validate_ids = await collect_validation_backlog(
             service.backend,
             source_names=db_scope_names,
@@ -241,7 +345,7 @@ async def build_ingest_plan(
             if preview_validation is not None and preview_validation.counts["skipped_no_schema"]:
                 plan_details.preview_skipped_no_schema = preview_validation.counts["skipped_no_schema"]
 
-    if has_parse:
+    if stage_flags.parse:
         backlog_parse_ids = await collect_parse_backlog(
             service.backend,
             source_names=db_scope_names,
@@ -255,41 +359,24 @@ async def build_ingest_plan(
         parse_ready_raw_ids = dedupe_ids(parse_ready_raw_ids)
         validate_raw_ids = dedupe_ids(validate_raw_ids)
 
-    final_counts = PlanCounts()
-    if scanned_count:
-        final_counts.scan = scanned_count
-    if plan_details.int_value("new_raw") and has_acquire:
-        final_counts.store_raw = plan_details.int_value("new_raw")
-    if has_parse and validate_raw_ids:
-        final_counts.validate_count = len(validate_raw_ids)
-    if has_parse and parse_ready_raw_ids:
-        final_counts.parse = len(parse_ready_raw_ids)
-        if has_materialize:
-            final_counts.materialize = len(parse_ready_raw_ids)
-        if has_render:
-            final_counts.render = len(parse_ready_raw_ids)
-        if has_index:
-            final_counts.index = len(parse_ready_raw_ids)
-    elif not has_parse and (has_materialize or has_render or has_index):
-        conversation_count = await service.backend.count_conversation_ids(source_names=db_scope_names)
-        if has_materialize and conversation_count:
-            final_counts.materialize = conversation_count
-        if has_render and conversation_count:
-            final_counts.render = conversation_count
-        if has_index and conversation_count:
-            final_counts.index = conversation_count
-
-    summary = PlanResult(
-        timestamp=int(time.time()),
-        stage=summary_stage,
-        stage_sequence=normalized_plan_stage_sequence,
-        counts=final_counts,
-        details=plan_details,
-        sources=source_names,
-        cursors=scan_result.cursors,
+    final_counts = await _final_scan_counts(
+        service,
+        scanned_count=scanned_count,
+        plan_details=plan_details,
+        validate_raw_ids=validate_raw_ids,
+        parse_ready_raw_ids=parse_ready_raw_ids,
+        db_scope_names=db_scope_names,
+        flags=stage_flags,
     )
     return IngestPlan(
-        summary=summary,
+        summary=_plan_summary(
+            summary_stage=summary_stage,
+            stage_sequence=normalized_plan_stage_sequence,
+            counts=final_counts,
+            details=plan_details,
+            sources=source_names,
+            cursors=scan_result.cursors,
+        ),
         validate_raw_ids=validate_raw_ids,
         parse_ready_raw_ids=parse_ready_raw_ids,
     )


### PR DESCRIPTION
## Summary
- Split `build_ingest_plan` into focused helpers for stage flags, early plan summaries, parse backlog planning, and final count construction.
- Split ingest batch processing into typed lifecycle helpers for sync setup, worker-result consumption, commit/flush, parse-result application, and observation construction.
- Split ingest worker materialization into named DB tuple builders for conversations, messages, content blocks, stats, attachments, and action events.
- Preserve existing SQL, worker process, cursor, raw-state, and session-product refresh behavior while making each lifecycle boundary explicit.

## Problem
The ingest path had several path-dependent long functions where independent concerns were interleaved: stage planning, source scanning, worker result waiting, DB writes, parent/child conversation drainage, raw-state updates, metrics observation, and DB tuple construction. That shape made future changes risky because a small edit had to reason through the whole function body.

## Solution
Introduced small typed helper boundaries around the existing ingest runtime contracts. Planning now delegates independent plan modes and count projection. Batch ingest now names the sync lifecycle phases and async result projection. Worker materialization now exposes tuple construction as stable, local builder functions instead of embedding every row shape in the main transform path.

## Verification
- `ruff check --fix polylogue/pipeline/services/planning_runtime.py`
- `ruff format polylogue/pipeline/services/planning_runtime.py`
- `mypy polylogue/pipeline/services/planning_runtime.py tests/unit/pipeline/test_parsing_service.py`
- `pytest -q tests/unit/pipeline/test_parsing_service.py`
- `pytest -q tests/unit/pipeline/test_parsing_service.py tests/unit/pipeline/test_run_sources.py tests/unit/cli/test_run_int.py tests/unit/cli/test_run.py`
- `ruff check --fix polylogue/pipeline/services/ingest_batch.py`
- `ruff format polylogue/pipeline/services/ingest_batch.py`
- `mypy polylogue/pipeline/services/ingest_batch.py tests/unit/pipeline/test_ingest_batch.py tests/unit/pipeline/test_run_sources.py`
- `pytest -q tests/unit/pipeline/test_ingest_batch.py tests/unit/pipeline/test_run_sources.py tests/unit/pipeline/test_parsing_service.py`
- `ruff check --fix polylogue/pipeline/services/ingest_worker.py`
- `ruff format polylogue/pipeline/services/ingest_worker.py`
- `mypy polylogue/pipeline/services/ingest_worker.py tests/unit/pipeline/test_ingest_batch.py tests/unit/pipeline/test_prepare_records.py`
- `pytest -q tests/unit/pipeline/test_ingest_batch.py tests/unit/pipeline/test_prepare_records.py tests/unit/pipeline/test_run_sources.py`
- `mypy polylogue tests`
- `devtools verify --quick`

Ref #281
