### PR TITLE
refactor: split doctor readiness workflows

### DIFF
--- a/polylogue/cli/check_workflow.py
+++ b/polylogue/cli/check_workflow.py
@@ -18,13 +18,16 @@ from polylogue.cli.check_models import CheckCommandResult, VacuumResult
 from polylogue.cli.check_validation import validate_check_options as _validate_check_options
 from polylogue.cli.helpers import load_effective_config
 from polylogue.cli.types import AppEnv
-from polylogue.readiness import get_readiness, run_runtime_readiness
+from polylogue.config import Config
+from polylogue.protocols import ProgressCallback
+from polylogue.readiness import ReadinessReport, get_readiness, run_runtime_readiness
 from polylogue.schemas.operator_workflow import (
     list_artifact_cohorts,
     list_artifact_observations,
     run_artifact_proof,
     run_schema_verification,
 )
+from polylogue.schemas.verification_models import SchemaVerificationReport
 from polylogue.schemas.verification_requests import (
     ArtifactObservationQuery,
     ArtifactProofRequest,
@@ -69,6 +72,12 @@ class CheckCommandOptions:
     maintenance_targets: tuple[str, ...]
 
 
+@dataclass(frozen=True)
+class _MaintenanceRunInputs:
+    selected_targets: tuple[str, ...]
+    preview_counts: dict[str, int] | None
+
+
 def validate_check_options(options: CheckCommandOptions) -> None:
     _validate_check_options(options)
 
@@ -88,6 +97,116 @@ def _runtime_only_requested(options: CheckCommandOptions) -> bool:
     )
 
 
+def _provider_filter(values: tuple[str, ...]) -> list[str] | None:
+    return list(values) if values else None
+
+
+def _artifact_query(options: CheckCommandOptions) -> ArtifactObservationQuery:
+    return ArtifactObservationQuery(
+        providers=_provider_filter(options.artifact_providers),
+        support_statuses=list(options.artifact_statuses) if options.artifact_statuses else None,
+        artifact_kinds=list(options.artifact_kinds) if options.artifact_kinds else None,
+        record_limit=options.artifact_limit,
+        record_offset=options.artifact_offset,
+    )
+
+
+def _run_blob_store_check(env: AppEnv, config: Config) -> None:
+    from polylogue.storage.blob_store import get_blob_store
+
+    blob_store = get_blob_store()
+    db_raw_ids: set[str] = set()
+    with connection_context(config.db_path) as conn:
+        for row in conn.execute("SELECT raw_id FROM raw_conversations"):
+            db_raw_ids.add(row[0])
+    disk_hashes = set(blob_store.iter_all())
+    missing = db_raw_ids - disk_hashes
+    orphaned = disk_hashes - db_raw_ids
+    env.ui.console.print(f"Blob store: {len(disk_hashes)} blobs on disk, {len(db_raw_ids)} raw records in DB")
+    if missing:
+        env.ui.console.print(f"  MISSING: {len(missing)} blobs referenced in DB but not on disk")
+        for h in sorted(missing)[:10]:
+            env.ui.console.print(f"    {h[:16]}...")
+    if orphaned:
+        env.ui.console.print(f"  Orphaned: {len(orphaned)} blobs on disk not in DB")
+    if not missing and not orphaned:
+        env.ui.console.print("  All blobs verified.")
+
+
+def _run_schema_verification(options: CheckCommandOptions, config: Config) -> SchemaVerificationReport:
+    report = run_schema_verification(
+        SchemaVerificationRequest(
+            providers=_provider_filter(options.schema_providers),
+            max_samples=parse_schema_samples(options.schema_samples),
+            record_limit=options.schema_record_limit,
+            record_offset=options.schema_record_offset,
+            quarantine_malformed=options.schema_quarantine_malformed,
+            progress_callback=make_schema_progress_callback(),
+        ),
+        db_path=config.db_path,
+    )
+    print(file=sys.stderr)
+    return report
+
+
+def _session_product_progress_callback(
+    options: CheckCommandOptions,
+    selected_targets: tuple[str, ...],
+) -> ProgressCallback | None:
+    if (
+        options.repair
+        and not options.preview
+        and not options.json_output
+        and (not selected_targets or "session_products" in selected_targets)
+    ):
+        return make_session_product_progress_callback()
+    return None
+
+
+def _maintenance_run_inputs(options: CheckCommandOptions, report: ReadinessReport) -> _MaintenanceRunInputs:
+    return _MaintenanceRunInputs(
+        selected_targets=_resolve_selected_maintenance_targets(options),
+        preview_counts=_build_preview_counts(report) if options.preview else None,
+    )
+
+
+def _run_maintenance(
+    config: Config,
+    result: CheckCommandResult,
+    options: CheckCommandOptions,
+    inputs: _MaintenanceRunInputs,
+) -> None:
+    result.maintenance_targets = inputs.selected_targets
+    result.maintenance_results = run_selected_maintenance(
+        config,
+        repair=options.repair,
+        cleanup=options.cleanup,
+        dry_run=options.preview,
+        preview_counts=inputs.preview_counts,
+        targets=inputs.selected_targets,
+        session_product_progress_callback=_session_product_progress_callback(options, inputs.selected_targets),
+    )
+
+
+def _persist_maintenance_run(
+    env: AppEnv,
+    *,
+    report: ReadinessReport,
+    result: CheckCommandResult,
+    options: CheckCommandOptions,
+    inputs: _MaintenanceRunInputs,
+) -> None:
+    persist_maintenance_run(
+        env,
+        report=report,
+        options=options,
+        targets=inputs.selected_targets,
+        maintenance_results=result.maintenance_results or [],
+        vacuum_result=result.vacuum_result,
+        preview_counts=inputs.preview_counts,
+    )
+
+
 def run_check_workflow(env: AppEnv, options: CheckCommandOptions) -> CheckCommandResult:
     config = load_effective_config(env)
     if _runtime_only_requested(options):
@@ -99,49 +218,21 @@ def run_check_workflow(env: AppEnv, options: CheckCommandOptions) -> CheckComman
         probe_only=not (options.deep or options.repair or options.cleanup),
     )
     result = CheckCommandResult(report=report)
+    maintenance_inputs: _MaintenanceRunInputs | None = None
 
     if options.runtime:
         result.runtime_report = run_runtime_readiness(config)
 
     if options.check_blob:
-        from polylogue.storage.blob_store import get_blob_store
-
-        blob_store = get_blob_store()
-        db_raw_ids: set[str] = set()
-        with connection_context(config.db_path) as conn:
-            for row in conn.execute("SELECT raw_id FROM raw_conversations"):
-                db_raw_ids.add(row[0])
-        disk_hashes = set(blob_store.iter_all())
-        missing = db_raw_ids - disk_hashes
-        orphaned = disk_hashes - db_raw_ids
-        env.ui.console.print(f"Blob store: {len(disk_hashes)} blobs on disk, {len(db_raw_ids)} raw records in DB")
-        if missing:
-            env.ui.console.print(f"  MISSING: {len(missing)} blobs referenced in DB but not on disk")
-            for h in sorted(missing)[:10]:
-                env.ui.console.print(f"    {h[:16]}...")
-        if orphaned:
-            env.ui.console.print(f"  Orphaned: {len(orphaned)} blobs on disk not in DB")
-        if not missing and not orphaned:
-            env.ui.console.print("  All blobs verified.")
+        _run_blob_store_check(env, config)
 
     if options.check_schemas:
-        result.schema_report = run_schema_verification(
-            SchemaVerificationRequest(
-                providers=list(options.schema_providers) if options.schema_providers else None,
-                max_samples=parse_schema_samples(options.schema_samples),
-                record_limit=options.schema_record_limit,
-                record_offset=options.schema_record_offset,
-                quarantine_malformed=options.schema_quarantine_malformed,
-                progress_callback=make_schema_progress_callback(),
-            ),
-            db_path=config.db_path,
-        )
-        print(file=sys.stderr)
+        result.schema_report = _run_schema_verification(options, config)
 
     if options.check_proof:
         result.proof_report = run_artifact_proof(
             ArtifactProofRequest(
-                providers=list(options.artifact_providers) if options.artifact_providers else None,
+                providers=_provider_filter(options.artifact_providers),
                 record_limit=options.artifact_limit,
                 record_offset=options.artifact_offset,
             ),
@@ -150,49 +241,19 @@ def run_check_workflow(env: AppEnv, options: CheckCommandOptions) -> CheckComman
 
     if options.check_artifacts:
         result.artifact_rows = list_artifact_observations(
-            ArtifactObservationQuery(
-                providers=list(options.artifact_providers) if options.artifact_providers else None,
-                support_statuses=list(options.artifact_statuses) if options.artifact_statuses else None,
-                artifact_kinds=list(options.artifact_kinds) if options.artifact_kinds else None,
-                record_limit=options.artifact_limit,
-                record_offset=options.artifact_offset,
-            ),
+            _artifact_query(options),
             db_path=config.db_path,
         ).rows
 
     if options.check_cohorts:
         result.cohort_rows = list_artifact_cohorts(
-            ArtifactObservationQuery(
-                providers=list(options.artifact_providers) if options.artifact_providers else None,
-                support_statuses=list(options.artifact_statuses) if options.artifact_statuses else None,
-                artifact_kinds=list(options.artifact_kinds) if options.artifact_kinds else None,
-                record_limit=options.artifact_limit,
-                record_offset=options.artifact_offset,
-            ),
+            _artifact_query(options),
             db_path=config.db_path,
         ).rows
 
     if options.repair or options.cleanup:
-        preview_counts = _build_preview_counts(report) if options.preview else None
-        selected_targets = _resolve_selected_maintenance_targets(options)
-        result.maintenance_targets = selected_targets
-        session_product_progress_callback = None
-        if (
-            options.repair
-            and not options.preview
-            and not options.json_output
-            and (not selected_targets or "session_products" in selected_targets)
-        ):
-            session_product_progress_callback = make_session_product_progress_callback()
-        result.maintenance_results = run_selected_maintenance(
-            config,
-            repair=options.repair,
-            cleanup=options.cleanup,
-            dry_run=options.preview,
-            preview_counts=preview_counts,
-            targets=selected_targets,
-            session_product_progress_callback=session_product_progress_callback,
-        )
+        maintenance_inputs = _maintenance_run_inputs(options, report)
+        _run_maintenance(config, result, options, maintenance_inputs)
 
     if (options.repair or options.cleanup) and options.vacuum:
         if options.preview:
@@ -200,17 +261,13 @@ def run_check_workflow(env: AppEnv, options: CheckCommandOptions) -> CheckComman
         elif options.json_output:
             result.vacuum_result = vacuum_database(env)
 
-    if result.maintenance_results is not None:
-        selected_targets = _resolve_selected_maintenance_targets(options)
-        preview_counts = _build_preview_counts(report) if options.preview else None
-        persist_maintenance_run(
+    if result.maintenance_results is not None and maintenance_inputs is not None:
+        _persist_maintenance_run(
             env,
             report=report,
+            result=result,
             options=options,
-            targets=selected_targets,
-            maintenance_results=result.maintenance_results,
-            vacuum_result=result.vacuum_result,
-            preview_counts=preview_counts,
+            inputs=maintenance_inputs,
         )
 
     return result

--- a/polylogue/readiness.py
+++ b/polylogue/readiness.py
@@ -29,6 +29,25 @@ _MAINTENANCE_TARGET_CATALOG = build_maintenance_target_catalog()
 JSONScalar: TypeAlias = str | int | float | bool | None
 JSONValue: TypeAlias = JSONScalar | list["JSONValue"] | Mapping[str, "JSONValue"]
 
+_DERIVED_MODEL_READINESS_CHECKS: tuple[tuple[str, str], ...] = (
+    ("action_event_read_model", "action_events"),
+    ("action_event_fts", "action_events_fts"),
+    ("fts_sync", "messages_fts"),
+    ("retrieval_evidence", "retrieval_evidence"),
+    ("retrieval_inference", "retrieval_inference"),
+    ("retrieval_enrichment", "retrieval_enrichment"),
+    ("session_profile_rows", "session_profile_rows"),
+    ("session_profile_evidence_fts", "session_profile_evidence_fts"),
+    ("session_profile_inference_fts", "session_profile_inference_fts"),
+    ("session_profile_enrichment_fts", "session_profile_enrichment_fts"),
+    ("session_work_event_inference", "session_work_event_inference"),
+    ("session_work_event_inference_fts", "session_work_event_inference_fts"),
+    ("session_tag_rollups", "session_tag_rollups"),
+    ("session_phase_inference", "session_phase_inference"),
+    ("day_session_summaries", "day_session_summaries"),
+    ("week_session_summaries", "week_session_summaries"),
+)
+
 
 @dataclass
 class ReadinessReport(OutcomeReport):
@@ -89,29 +108,21 @@ def _open_readiness_probe_connection(db_path: Path) -> AbstractContextManager[sq
     return open_read_connection(db_path)
 
 
-# ---------------------------------------------------------------------------
-# Archive readiness (database, derived models, orphans, providers)
-# ---------------------------------------------------------------------------
-
-
-def run_archive_readiness(config: Config, *, deep: bool = False, probe_only: bool = False) -> ReadinessReport:
-    from polylogue.storage.backends.schema import assert_supported_archive_layout
-    from polylogue.storage.derived_status import collect_derived_model_statuses_sync
-    from polylogue.storage.fts_lifecycle import message_fts_readiness_sync
-    from polylogue.storage.repair import collect_archive_debt_statuses_sync
-
+def _config_path_checks(config: Config) -> list[ReadinessCheck]:
     checks: list[ReadinessCheck] = []
-    checks.append(ReadinessCheck("config", VerifyStatus.OK, summary="XDG defaults active"))
-
     for path_name in ("archive_root", "render_root"):
         path = getattr(config, path_name)
         if path.exists():
             checks.append(ReadinessCheck(path_name, VerifyStatus.OK, summary=str(path)))
         else:
             checks.append(ReadinessCheck(path_name, VerifyStatus.WARNING, summary=f"Missing {path}"))
+    return checks
 
-    # --- database reachability ---
-    db_error: str | None = None
+
+def _database_probe_checks(config: Config, *, deep: bool) -> tuple[list[ReadinessCheck], str | None]:
+    from polylogue.storage.backends.schema import assert_supported_archive_layout
+
+    checks: list[ReadinessCheck] = []
     try:
         with _open_readiness_probe_connection(config.db_path) as conn:
             assert_supported_archive_layout(conn)
@@ -128,16 +139,175 @@ def run_archive_readiness(config: Config, *, deep: bool = False, probe_only: boo
     except Exception as exc:
         db_error = _summarize_db_error(exc)
         checks.append(ReadinessCheck("database", VerifyStatus.ERROR, summary=f"DB error: {db_error}"))
+        return checks, db_error
+    return checks, None
+
+
+def _skipped_index_check(db_error: str) -> ReadinessCheck:
+    return ReadinessCheck(
+        "index",
+        VerifyStatus.WARNING,
+        summary=f"Skipped: database unavailable ({db_error})",
+    )
+
+
+def _message_index_check(conn: sqlite3.Connection, *, exact_counts: bool) -> ReadinessCheck:
+    from polylogue.storage.fts_lifecycle import message_fts_readiness_sync
+
+    index_readiness = message_fts_readiness_sync(conn, verify_total_rows=exact_counts)
+    if not index_readiness["exists"]:
+        return ReadinessCheck("index", VerifyStatus.WARNING, summary="index not built")
+
+    indexed_rows = int(index_readiness["indexed_rows"])
+    total_rows = int(index_readiness["total_rows"])
+    if bool(index_readiness["ready"]):
+        return ReadinessCheck(
+            "index",
+            VerifyStatus.OK,
+            count=indexed_rows if exact_counts else 0,
+            summary=(f"messages indexed: {indexed_rows}" if exact_counts else "messages FTS present"),
+        )
+    return ReadinessCheck(
+        "index",
+        VerifyStatus.WARNING,
+        count=indexed_rows if exact_counts else 0,
+        summary=(
+            f"messages indexed: {indexed_rows:,}/{total_rows:,}"
+            if exact_counts
+            else "messages FTS missing or empty; use --deep to verify full coverage"
+        ),
+    )
+
+
+def _archive_debt_checks(archive_debt: dict[str, ArchiveDebtStatus], *, deep: bool) -> list[ReadinessCheck]:
+    checks: list[ReadinessCheck] = []
+    for spec in _MAINTENANCE_TARGET_CATALOG.archive_readiness_specs(deep=deep):
+        debt = archive_debt.get(spec.name)
+        if debt is None:
+            continue
+        unready_status = spec.archive_readiness_unready_status or VerifyStatus.WARNING
+        checks.append(
+            ReadinessCheck(
+                debt.name,
+                VerifyStatus.OK if debt.healthy else unready_status,
+                count=debt.issue_count,
+                summary=debt.detail,
+            )
+        )
+    return checks
+
+
+def _duplicate_conversations_check(conn: sqlite3.Connection) -> ReadinessCheck:
+    duplicate_count = conn.execute(
+        """
+        SELECT COUNT(*) FROM (
+            SELECT conversation_id FROM conversations GROUP BY conversation_id HAVING COUNT(*) > 1
+        )
+        """
+    ).fetchone()[0]
+    return ReadinessCheck(
+        "duplicate_conversations",
+        VerifyStatus.OK if duplicate_count == 0 else VerifyStatus.ERROR,
+        count=duplicate_count,
+        summary="No duplicates" if duplicate_count == 0 else f"{duplicate_count} duplicate conversation IDs",
+    )
+
+
+def _provider_distribution_check(conn: sqlite3.Connection) -> ReadinessCheck:
+    provider_rows = conn.execute(
+        """
+        SELECT provider_name, COUNT(*) AS count
+        FROM conversations
+        GROUP BY provider_name
+        ORDER BY count DESC, provider_name ASC
+        """
+    ).fetchall()
+    provider_breakdown = {str(row["provider_name"]): int(row["count"]) for row in provider_rows}
+    return ReadinessCheck(
+        "provider_distribution",
+        VerifyStatus.OK,
+        count=sum(provider_breakdown.values()),
+        summary=f"{len(provider_breakdown)} provider(s) represented",
+        breakdown=provider_breakdown,
+    )
+
+
+def _derived_model_checks(derived_statuses: dict[str, DerivedModelStatus]) -> list[ReadinessCheck]:
+    checks: list[ReadinessCheck] = []
+    for name, status_key in _DERIVED_MODEL_READINESS_CHECKS:
+        status = derived_statuses.get(status_key)
+        if status is None:
+            continue
+        checks.append(
+            ReadinessCheck(
+                name,
+                VerifyStatus.OK if status.ready else VerifyStatus.WARNING,
+                count=status.materialized_documents or status.materialized_rows or status.pending_rows,
+                summary=status.detail,
+            )
+        )
+    return checks
+
+
+def _transcript_embedding_checks(derived_statuses: dict[str, DerivedModelStatus]) -> list[ReadinessCheck]:
+    transcript_embeddings = derived_statuses.get("transcript_embeddings")
+    if transcript_embeddings is None:
+        return []
+
+    freshness_status = (
+        VerifyStatus.OK
+        if transcript_embeddings.materialized_rows == 0
+        or (transcript_embeddings.stale_rows == 0 and transcript_embeddings.missing_provenance_rows == 0)
+        else VerifyStatus.WARNING
+    )
+    freshness_summary = (
+        "No embedded messages to assess freshness"
+        if transcript_embeddings.materialized_rows == 0
+        else (
+            f"Transcript embeddings fresh ({transcript_embeddings.materialized_rows:,} messages)"
+            if freshness_status is VerifyStatus.OK
+            else (
+                f"Transcript embeddings stale ({transcript_embeddings.stale_rows:,} stale, "
+                f"{transcript_embeddings.missing_provenance_rows:,} missing provenance)"
+            )
+        )
+    )
+    return [
+        ReadinessCheck(
+            "transcript_embeddings",
+            VerifyStatus.OK if transcript_embeddings.ready else VerifyStatus.WARNING,
+            count=transcript_embeddings.pending_documents,
+            summary=transcript_embeddings.detail,
+        ),
+        ReadinessCheck(
+            "transcript_embedding_freshness",
+            freshness_status,
+            count=transcript_embeddings.stale_rows,
+            summary=freshness_summary,
+        ),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Archive readiness (database, derived models, orphans, providers)
+# ---------------------------------------------------------------------------
+
+
+def run_archive_readiness(config: Config, *, deep: bool = False, probe_only: bool = False) -> ReadinessReport:
+    from polylogue.storage.derived_status import collect_derived_model_statuses_sync
+    from polylogue.storage.repair import collect_archive_debt_statuses_sync
+
+    checks: list[ReadinessCheck] = []
+    checks.append(ReadinessCheck("config", VerifyStatus.OK, summary="XDG defaults active"))
+    checks.extend(_config_path_checks(config))
+
+    # --- database reachability ---
+    db_checks, db_error = _database_probe_checks(config, deep=deep)
+    checks.extend(db_checks)
 
     # --- index ---
     if db_error is not None:
-        checks.append(
-            ReadinessCheck(
-                "index",
-                VerifyStatus.WARNING,
-                summary=f"Skipped: database unavailable ({db_error})",
-            )
-        )
+        checks.append(_skipped_index_check(db_error))
         return ReadinessReport(checks=checks)
 
     # --- derived models, debt, duplicates, providers ---
@@ -145,34 +315,7 @@ def run_archive_readiness(config: Config, *, deep: bool = False, probe_only: boo
     archive_debt: dict[str, ArchiveDebtStatus] = {}
     with _open_readiness_probe_connection(config.db_path) as conn:
         exact_index_counts = deep or not probe_only
-        index_readiness = message_fts_readiness_sync(conn, verify_total_rows=exact_index_counts)
-        if not index_readiness["exists"]:
-            checks.append(ReadinessCheck("index", VerifyStatus.WARNING, summary="index not built"))
-        else:
-            indexed_rows = int(index_readiness["indexed_rows"])
-            total_rows = int(index_readiness["total_rows"])
-            if bool(index_readiness["ready"]):
-                checks.append(
-                    ReadinessCheck(
-                        "index",
-                        VerifyStatus.OK,
-                        count=indexed_rows if exact_index_counts else 0,
-                        summary=(f"messages indexed: {indexed_rows}" if exact_index_counts else "messages FTS present"),
-                    )
-                )
-            else:
-                checks.append(
-                    ReadinessCheck(
-                        "index",
-                        VerifyStatus.WARNING,
-                        count=indexed_rows if exact_index_counts else 0,
-                        summary=(
-                            f"messages indexed: {indexed_rows:,}/{total_rows:,}"
-                            if exact_index_counts
-                            else "messages FTS missing or empty; use --deep to verify full coverage"
-                        ),
-                    )
-                )
+        checks.append(_message_index_check(conn, exact_counts=exact_index_counts))
 
         derived_statuses = collect_derived_model_statuses_sync(conn, verify_full=deep)
         archive_debt = collect_archive_debt_statuses_sync(
@@ -181,119 +324,13 @@ def run_archive_readiness(config: Config, *, deep: bool = False, probe_only: boo
             include_expensive=deep,
             probe_only=probe_only,
         )
-        for spec in _MAINTENANCE_TARGET_CATALOG.archive_readiness_specs(deep=deep):
-            debt = archive_debt.get(spec.name)
-            if debt is None:
-                continue
-            unready_status = spec.archive_readiness_unready_status or VerifyStatus.WARNING
-            checks.append(
-                ReadinessCheck(
-                    debt.name,
-                    VerifyStatus.OK if debt.healthy else unready_status,
-                    count=debt.issue_count,
-                    summary=debt.detail,
-                )
-            )
+        checks.extend(_archive_debt_checks(archive_debt, deep=deep))
 
-        dup_conv = conn.execute(
-            """
-            SELECT COUNT(*) FROM (
-                SELECT conversation_id FROM conversations GROUP BY conversation_id HAVING COUNT(*) > 1
-            )
-            """
-        ).fetchone()[0]
-        checks.append(
-            ReadinessCheck(
-                "duplicate_conversations",
-                VerifyStatus.OK if dup_conv == 0 else VerifyStatus.ERROR,
-                count=dup_conv,
-                summary="No duplicates" if dup_conv == 0 else f"{dup_conv} duplicate conversation IDs",
-            )
-        )
+        checks.append(_duplicate_conversations_check(conn))
 
-        provider_rows = conn.execute(
-            """
-            SELECT provider_name, COUNT(*) AS count
-            FROM conversations
-            GROUP BY provider_name
-            ORDER BY count DESC, provider_name ASC
-            """
-        ).fetchall()
-        provider_breakdown = {str(row["provider_name"]): int(row["count"]) for row in provider_rows}
-        checks.append(
-            ReadinessCheck(
-                "provider_distribution",
-                VerifyStatus.OK,
-                count=sum(provider_breakdown.values()),
-                summary=f"{len(provider_breakdown)} provider(s) represented",
-                breakdown=provider_breakdown,
-            )
-        )
-        for name, status_key in (
-            ("action_event_read_model", "action_events"),
-            ("action_event_fts", "action_events_fts"),
-            ("fts_sync", "messages_fts"),
-            ("retrieval_evidence", "retrieval_evidence"),
-            ("retrieval_inference", "retrieval_inference"),
-            ("retrieval_enrichment", "retrieval_enrichment"),
-            ("session_profile_rows", "session_profile_rows"),
-            ("session_profile_evidence_fts", "session_profile_evidence_fts"),
-            ("session_profile_inference_fts", "session_profile_inference_fts"),
-            ("session_profile_enrichment_fts", "session_profile_enrichment_fts"),
-            ("session_work_event_inference", "session_work_event_inference"),
-            ("session_work_event_inference_fts", "session_work_event_inference_fts"),
-            ("session_tag_rollups", "session_tag_rollups"),
-            ("session_phase_inference", "session_phase_inference"),
-            ("day_session_summaries", "day_session_summaries"),
-            ("week_session_summaries", "week_session_summaries"),
-        ):
-            status = derived_statuses.get(status_key)
-            if status is None:
-                continue
-            checks.append(
-                ReadinessCheck(
-                    name,
-                    VerifyStatus.OK if status.ready else VerifyStatus.WARNING,
-                    count=status.materialized_documents or status.materialized_rows or status.pending_rows,
-                    summary=status.detail,
-                )
-            )
-
-        transcript_embeddings = derived_statuses.get("transcript_embeddings")
-        if transcript_embeddings is not None:
-            checks.append(
-                ReadinessCheck(
-                    "transcript_embeddings",
-                    VerifyStatus.OK if transcript_embeddings.ready else VerifyStatus.WARNING,
-                    count=transcript_embeddings.pending_documents,
-                    summary=transcript_embeddings.detail,
-                )
-            )
-            freshness_status = (
-                VerifyStatus.OK
-                if transcript_embeddings.materialized_rows == 0
-                or (transcript_embeddings.stale_rows == 0 and transcript_embeddings.missing_provenance_rows == 0)
-                else VerifyStatus.WARNING
-            )
-            checks.append(
-                ReadinessCheck(
-                    "transcript_embedding_freshness",
-                    freshness_status,
-                    count=transcript_embeddings.stale_rows,
-                    summary=(
-                        "No embedded messages to assess freshness"
-                        if transcript_embeddings.materialized_rows == 0
-                        else (
-                            f"Transcript embeddings fresh ({transcript_embeddings.materialized_rows:,} messages)"
-                            if freshness_status is VerifyStatus.OK
-                            else (
-                                f"Transcript embeddings stale ({transcript_embeddings.stale_rows:,} stale, "
-                                f"{transcript_embeddings.missing_provenance_rows:,} missing provenance)"
-                            )
-                        )
-                    ),
-                )
-            )
+        checks.append(_provider_distribution_check(conn))
+        checks.extend(_derived_model_checks(derived_statuses))
+        checks.extend(_transcript_embedding_checks(derived_statuses))
 
     # --- source checks ---
     checks.extend(_build_source_readiness_checks(config))

--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -19,12 +19,29 @@ from polylogue.maintenance_targets import (
 )
 from polylogue.protocols import ProgressCallback
 from polylogue.storage.action_event_artifacts import ActionEventArtifactState
+from polylogue.storage.session_product_runtime import SessionProductReadyFlag, SessionProductStatusSnapshot
 
 logger = get_logger(__name__)
 _MAINTENANCE_TARGET_CATALOG = build_maintenance_target_catalog()
 
 JSONScalar: TypeAlias = str | int | float | bool | None
 JSONValue: TypeAlias = JSONScalar | list["JSONValue"] | dict[str, "JSONValue"]
+
+_SESSION_PRODUCT_READY_FLAGS: tuple[SessionProductReadyFlag, ...] = (
+    "profile_rows_ready",
+    "profile_merged_fts_ready",
+    "profile_evidence_fts_ready",
+    "profile_inference_fts_ready",
+    "profile_enrichment_fts_ready",
+    "work_event_inference_rows_ready",
+    "work_event_inference_fts_ready",
+    "phase_inference_rows_ready",
+    "threads_ready",
+    "threads_fts_ready",
+    "tag_rollups_ready",
+    "day_summaries_ready",
+    "week_summaries_ready",
+)
 
 
 # ---------------------------------------------------------------------------
@@ -52,6 +69,16 @@ class RepairResult:
             "success": self.success,
             "detail": self.detail,
         }
+
+
+@dataclass(slots=True, frozen=True)
+class _SessionProductRepairAssessment:
+    row_debt: int
+    fts_debt: int
+
+    @property
+    def pending(self) -> int:
+        return self.row_debt + self.fts_debt
 
 
 # ---------------------------------------------------------------------------
@@ -165,6 +192,78 @@ def session_product_repair_count(derived_statuses: dict[str, DerivedModelStatus]
         total += max(0, int(s.stale_rows or 0))
         total += max(0, int(s.orphan_rows or 0))
     return total
+
+
+def _positive_count(value: int) -> int:
+    return max(0, value)
+
+
+def _fts_repair_count(*, source_rows: int, indexed_rows: int, duplicates: int) -> int:
+    return _positive_count(source_rows - indexed_rows) + _positive_count(duplicates)
+
+
+def _session_product_row_repair_count(status: SessionProductStatusSnapshot) -> int:
+    return (
+        status.missing_profile_row_count
+        + status.stale_profile_row_count
+        + status.orphan_profile_row_count
+        + status.stale_work_event_inference_count
+        + status.orphan_work_event_inference_count
+        + status.stale_phase_inference_count
+        + status.orphan_phase_inference_count
+        + status.stale_thread_count
+        + status.orphan_thread_count
+        + status.stale_tag_rollup_count
+        + status.stale_day_summary_count
+    )
+
+
+def _session_product_fts_repair_count(status: SessionProductStatusSnapshot) -> int:
+    return sum(
+        (
+            _fts_repair_count(
+                source_rows=status.profile_row_count,
+                indexed_rows=status.profile_merged_fts_count,
+                duplicates=status.profile_merged_fts_duplicate_count,
+            ),
+            _fts_repair_count(
+                source_rows=status.profile_row_count,
+                indexed_rows=status.profile_evidence_fts_count,
+                duplicates=status.profile_evidence_fts_duplicate_count,
+            ),
+            _fts_repair_count(
+                source_rows=status.profile_row_count,
+                indexed_rows=status.profile_inference_fts_count,
+                duplicates=status.profile_inference_fts_duplicate_count,
+            ),
+            _fts_repair_count(
+                source_rows=status.profile_row_count,
+                indexed_rows=status.profile_enrichment_fts_count,
+                duplicates=status.profile_enrichment_fts_duplicate_count,
+            ),
+            _fts_repair_count(
+                source_rows=status.work_event_inference_count,
+                indexed_rows=status.work_event_inference_fts_count,
+                duplicates=status.work_event_inference_fts_duplicate_count,
+            ),
+            _fts_repair_count(
+                source_rows=status.thread_count,
+                indexed_rows=status.thread_fts_count,
+                duplicates=status.thread_fts_duplicate_count,
+            ),
+        )
+    )
+
+
+def _assess_session_product_repairs(status: SessionProductStatusSnapshot) -> _SessionProductRepairAssessment:
+    return _SessionProductRepairAssessment(
+        row_debt=_session_product_row_repair_count(status),
+        fts_debt=_session_product_fts_repair_count(status),
+    )
+
+
+def _session_product_status_ready(status: SessionProductStatusSnapshot) -> bool:
+    return all(status.ready_flag(flag) for flag in _SESSION_PRODUCT_READY_FLAGS)
 
 
 def action_event_repair_count(derived_statuses: dict[str, DerivedModelStatus]) -> int:
@@ -608,52 +707,16 @@ def repair_session_products(
     try:
         with connection_context(None) as conn:
             status = session_product_status_sync(conn)
-            profile_merged_fts_pending = max(0, status.profile_row_count - status.profile_merged_fts_count)
-            profile_merged_fts_duplicates = max(0, status.profile_merged_fts_duplicate_count)
-            profile_evidence_fts_pending = max(0, status.profile_row_count - status.profile_evidence_fts_count)
-            profile_evidence_fts_duplicates = max(0, status.profile_evidence_fts_duplicate_count)
-            profile_inference_fts_pending = max(0, status.profile_row_count - status.profile_inference_fts_count)
-            profile_inference_fts_duplicates = max(0, status.profile_inference_fts_duplicate_count)
-            profile_enrichment_fts_pending = max(0, status.profile_row_count - status.profile_enrichment_fts_count)
-            profile_enrichment_fts_duplicates = max(0, status.profile_enrichment_fts_duplicate_count)
-            work_event_fts_pending = max(0, status.work_event_inference_count - status.work_event_inference_fts_count)
-            work_event_fts_duplicates = max(0, status.work_event_inference_fts_duplicate_count)
-            thread_fts_pending = max(0, status.thread_count - status.thread_fts_count)
-            thread_fts_duplicates = max(0, status.thread_fts_duplicate_count)
-            pending = (
-                status.missing_profile_row_count
-                + status.stale_profile_row_count
-                + status.orphan_profile_row_count
-                + status.stale_work_event_inference_count
-                + status.orphan_work_event_inference_count
-                + status.stale_phase_inference_count
-                + status.orphan_phase_inference_count
-                + status.stale_thread_count
-                + status.orphan_thread_count
-                + status.stale_tag_rollup_count
-                + status.stale_day_summary_count
-                + profile_merged_fts_pending
-                + profile_merged_fts_duplicates
-                + profile_evidence_fts_pending
-                + profile_evidence_fts_duplicates
-                + profile_inference_fts_pending
-                + profile_inference_fts_duplicates
-                + profile_enrichment_fts_pending
-                + profile_enrichment_fts_duplicates
-                + work_event_fts_pending
-                + work_event_fts_duplicates
-                + thread_fts_pending
-                + thread_fts_duplicates
-            )
+            assessment = _assess_session_product_repairs(status)
 
             if dry_run:
                 return _repair_result(
                     "session_products",
-                    repaired_count=pending,
+                    repaired_count=assessment.pending,
                     success=True,
                     detail="Would: session products already ready"
-                    if pending == 0
-                    else f"Would: rebuild session products ({pending:,} pending items)",
+                    if assessment.pending == 0
+                    else f"Would: rebuild session products ({assessment.pending:,} pending items)",
                 )
 
             rebuilt = rebuild_session_products_sync(
@@ -663,21 +726,7 @@ def repair_session_products(
             )
             conn.commit()
             refreshed = session_product_status_sync(conn)
-            success = (
-                refreshed.profile_rows_ready
-                and refreshed.profile_merged_fts_ready
-                and refreshed.profile_evidence_fts_ready
-                and refreshed.profile_inference_fts_ready
-                and refreshed.profile_enrichment_fts_ready
-                and refreshed.work_event_inference_rows_ready
-                and refreshed.work_event_inference_fts_ready
-                and refreshed.phase_inference_rows_ready
-                and refreshed.threads_ready
-                and refreshed.threads_fts_ready
-                and refreshed.tag_rollups_ready
-                and refreshed.day_summaries_ready
-                and refreshed.week_summaries_ready
-            )
+            success = _session_product_status_ready(refreshed)
             return _repair_result(
                 "session_products",
                 repaired_count=rebuilt.total(),


### PR DESCRIPTION
## Summary
- Split doctor repair/session-product assessment into typed helper functions.
- Split doctor CLI maintenance execution into reusable workflow helpers while preserving VACUUM/persistence ordering.
- Split archive readiness report construction into focused check builders.

## Problem
Doctor maintenance and readiness logic had accumulated large inline blocks for session-product debt counting, CLI maintenance dispatch, archive debt checks, provider summaries, derived-model checks, and transcript-embedding freshness. That made the status/repair surface hard to audit and fragile to extend during the broader renewal push.

## Solution
- Added explicit session-product repair assessment helpers in `polylogue/storage/repair.py`.
- Added small workflow helpers and a typed maintenance input object in `polylogue/cli/check_workflow.py`.
- Extracted readiness builder functions in `polylogue/readiness.py` for config paths, DB probes, message index status, archive debt, duplicate/provider summaries, derived models, and embedding freshness.

## Verification
- `pytest -q tests/unit/storage/test_repair.py tests/unit/cli/test_check.py`
- `pytest -q tests/unit/core/test_health_core.py tests/unit/cli/test_check.py tests/unit/cli/test_check_runtime.py tests/unit/storage/test_fts5.py`
- `mypy polylogue/storage/repair.py polylogue/cli/check_workflow.py tests/unit/storage/test_repair.py tests/unit/cli/test_check.py`
- `mypy polylogue/readiness.py polylogue/cli/check_workflow.py polylogue/storage/repair.py tests/unit/core/test_health_core.py tests/unit/cli/test_check.py tests/unit/cli/test_check_runtime.py tests/unit/storage/test_fts5.py`
- `mypy polylogue tests`
- `devtools verify --quick`

Ref #270
