### PR TITLE
refactor: split session product status counts

### DIFF
--- a/polylogue/storage/session_product_status.py
+++ b/polylogue/storage/session_product_status.py
@@ -3,12 +3,16 @@
 from __future__ import annotations
 
 import sqlite3
+from typing import TypeAlias
 
 import aiosqlite
 
 from polylogue.storage.session_product_aggregates import _PROFILE_BUCKET_DAY_SQL
 from polylogue.storage.session_product_runtime import SessionProductStatusSnapshot
 from polylogue.storage.store import SESSION_PRODUCT_MATERIALIZER_VERSION
+
+TablePresence: TypeAlias = dict[str, bool]
+StatusCounts: TypeAlias = dict[str, int]
 
 # ---------------------------------------------------------------------------
 # SQL constants for session-product status and drift checks
@@ -260,9 +264,288 @@ def _to_int(row: tuple[object, ...] | sqlite3.Row | None) -> int:
     return 0
 
 
+def _tables_sync(conn: sqlite3.Connection) -> TablePresence:
+    return {key: bool(conn.execute(sql).fetchone()) for key, sql in _TABLE_SQLS.items()}
+
+
+async def _tables_async(conn: aiosqlite.Connection) -> TablePresence:
+    tables: TablePresence = {}
+    for key, sql in _TABLE_SQLS.items():
+        tables[key] = bool(await (await conn.execute(sql)).fetchone())
+    return tables
+
+
+def _count_sync(conn: sqlite3.Connection, sql: str, *params: object) -> int:
+    return _to_int(conn.execute(sql, params).fetchone())
+
+
+async def _count_async(conn: aiosqlite.Connection, sql: str, *params: object) -> int:
+    return _to_int(await (await conn.execute(sql, params)).fetchone())
+
+
+def _table_count_sync(conn: sqlite3.Connection, table_exists: bool, table_name: str) -> int:
+    return _to_int(conn.execute(f"SELECT COUNT(*) FROM {table_name}").fetchone()) if table_exists else 0
+
+
+def _sync_fts_doc_count(
+    conn: sqlite3.Connection,
+    tables: TablePresence,
+    *,
+    table_key: str,
+    table_name: str,
+    distinct_sql: str,
+    verify_freshness: bool,
+) -> int:
+    if verify_freshness and tables[table_key]:
+        return _count_sync(conn, distinct_sql)
+    return _table_count_sync(conn, tables[table_key], table_name)
+
+
+def _sync_fts_duplicate_count(
+    conn: sqlite3.Connection,
+    tables: TablePresence,
+    *,
+    table_key: str,
+    duplicate_sql: str,
+    indexed_count: int,
+    source_count: int,
+    verify_freshness: bool,
+) -> int:
+    if verify_freshness and tables[table_key]:
+        return _count_sync(conn, duplicate_sql)
+    return max(0, indexed_count - source_count)
+
+
+def _materialized_counts_sync(
+    conn: sqlite3.Connection,
+    tables: TablePresence,
+    *,
+    verify_freshness: bool,
+) -> StatusCounts:
+    profile_row_count = _count_sync(conn, SESSION_PROFILE_COUNT_SQL) if tables["session_profiles"] else 0
+    thread_count = _count_sync(conn, WORK_THREAD_COUNT_SQL) if tables["work_threads"] else 0
+    counts: StatusCounts = {
+        "total_conversations": _count_sync(conn, TOTAL_CONVERSATIONS_SQL),
+        "root_threads": _count_sync(conn, ROOT_THREAD_COUNT_SQL) if verify_freshness else thread_count,
+        "profile_row_count": profile_row_count,
+        "work_event_inference_count": (
+            _count_sync(conn, SESSION_WORK_EVENT_COUNT_SQL) if tables["session_work_events"] else 0
+        ),
+        "phase_inference_count": _count_sync(conn, SESSION_PHASE_COUNT_SQL) if tables["session_phases"] else 0,
+        "thread_count": thread_count,
+        "tag_rollup_count": _count_sync(conn, SESSION_TAG_ROLLUP_COUNT_SQL) if tables["session_tag_rollups"] else 0,
+        "day_summary_count": _count_sync(conn, DAY_SESSION_SUMMARY_COUNT_SQL) if tables["day_session_summaries"] else 0,
+    }
+    counts["profile_merged_fts_count"] = _sync_fts_doc_count(
+        conn,
+        tables,
+        table_key="session_profiles_fts",
+        table_name="session_profiles_fts",
+        distinct_sql=SESSION_PROFILE_MERGED_FTS_DOC_COUNT_SQL,
+        verify_freshness=verify_freshness,
+    )
+    counts["profile_evidence_fts_count"] = _sync_fts_doc_count(
+        conn,
+        tables,
+        table_key="session_profile_evidence_fts",
+        table_name="session_profile_evidence_fts",
+        distinct_sql=SESSION_PROFILE_EVIDENCE_FTS_DOC_COUNT_SQL,
+        verify_freshness=verify_freshness,
+    )
+    counts["profile_inference_fts_count"] = _sync_fts_doc_count(
+        conn,
+        tables,
+        table_key="session_profile_inference_fts",
+        table_name="session_profile_inference_fts",
+        distinct_sql=SESSION_PROFILE_INFERENCE_FTS_DOC_COUNT_SQL,
+        verify_freshness=verify_freshness,
+    )
+    counts["profile_enrichment_fts_count"] = _sync_fts_doc_count(
+        conn,
+        tables,
+        table_key="session_profile_enrichment_fts",
+        table_name="session_profile_enrichment_fts",
+        distinct_sql=SESSION_PROFILE_ENRICHMENT_FTS_DOC_COUNT_SQL,
+        verify_freshness=verify_freshness,
+    )
+    counts["work_event_inference_fts_count"] = _sync_fts_doc_count(
+        conn,
+        tables,
+        table_key="session_work_events_fts",
+        table_name="session_work_events_fts",
+        distinct_sql=SESSION_WORK_EVENT_FTS_DOC_COUNT_SQL,
+        verify_freshness=verify_freshness,
+    )
+    counts["thread_fts_count"] = _sync_fts_doc_count(
+        conn,
+        tables,
+        table_key="work_threads_fts",
+        table_name="work_threads_fts",
+        distinct_sql=WORK_THREAD_FTS_DOC_COUNT_SQL,
+        verify_freshness=verify_freshness,
+    )
+    return counts
+
+
+def _sync_fts_duplicate_counts(
+    conn: sqlite3.Connection,
+    tables: TablePresence,
+    counts: StatusCounts,
+    *,
+    verify_freshness: bool,
+) -> StatusCounts:
+    profile_row_count = counts["profile_row_count"]
+    return {
+        "profile_merged_fts_duplicate_count": _sync_fts_duplicate_count(
+            conn,
+            tables,
+            table_key="session_profiles_fts",
+            duplicate_sql=SESSION_PROFILE_MERGED_FTS_DUPLICATE_COUNT_SQL,
+            indexed_count=counts["profile_merged_fts_count"],
+            source_count=profile_row_count,
+            verify_freshness=verify_freshness,
+        ),
+        "profile_evidence_fts_duplicate_count": _sync_fts_duplicate_count(
+            conn,
+            tables,
+            table_key="session_profile_evidence_fts",
+            duplicate_sql=SESSION_PROFILE_EVIDENCE_FTS_DUPLICATE_COUNT_SQL,
+            indexed_count=counts["profile_evidence_fts_count"],
+            source_count=profile_row_count,
+            verify_freshness=verify_freshness,
+        ),
+        "profile_inference_fts_duplicate_count": _sync_fts_duplicate_count(
+            conn,
+            tables,
+            table_key="session_profile_inference_fts",
+            duplicate_sql=SESSION_PROFILE_INFERENCE_FTS_DUPLICATE_COUNT_SQL,
+            indexed_count=counts["profile_inference_fts_count"],
+            source_count=profile_row_count,
+            verify_freshness=verify_freshness,
+        ),
+        "profile_enrichment_fts_duplicate_count": _sync_fts_duplicate_count(
+            conn,
+            tables,
+            table_key="session_profile_enrichment_fts",
+            duplicate_sql=SESSION_PROFILE_ENRICHMENT_FTS_DUPLICATE_COUNT_SQL,
+            indexed_count=counts["profile_enrichment_fts_count"],
+            source_count=profile_row_count,
+            verify_freshness=verify_freshness,
+        ),
+        "work_event_inference_fts_duplicate_count": _sync_fts_duplicate_count(
+            conn,
+            tables,
+            table_key="session_work_events_fts",
+            duplicate_sql=SESSION_WORK_EVENT_FTS_DUPLICATE_COUNT_SQL,
+            indexed_count=counts["work_event_inference_fts_count"],
+            source_count=counts["work_event_inference_count"],
+            verify_freshness=verify_freshness,
+        ),
+        "thread_fts_duplicate_count": _sync_fts_duplicate_count(
+            conn,
+            tables,
+            table_key="work_threads_fts",
+            duplicate_sql=WORK_THREAD_FTS_DUPLICATE_COUNT_SQL,
+            indexed_count=counts["thread_fts_count"],
+            source_count=counts["thread_count"],
+            verify_freshness=verify_freshness,
+        ),
+    }
+
+
+def _sync_repair_counts(
+    conn: sqlite3.Connection,
+    tables: TablePresence,
+    counts: StatusCounts,
+    *,
+    verify_freshness: bool,
+) -> StatusCounts:
+    return {
+        "missing_profile_row_count": (
+            _count_sync(conn, MISSING_SESSION_PROFILE_COUNT_SQL)
+            if tables["session_profiles"]
+            else counts["total_conversations"]
+        ),
+        "stale_profile_row_count": (
+            _count_sync(conn, STALE_SESSION_PROFILE_COUNT_SQL, SESSION_PRODUCT_MATERIALIZER_VERSION)
+            if verify_freshness and tables["session_profiles"]
+            else 0
+        ),
+        "orphan_profile_row_count": (
+            _count_sync(conn, ORPHAN_SESSION_PROFILE_COUNT_SQL)
+            if verify_freshness and tables["session_profiles"]
+            else 0
+        ),
+        "expected_work_event_inference_count": (
+            _count_sync(conn, EXPECTED_WORK_EVENT_COUNT_SQL) if tables["session_profiles"] else 0
+        ),
+        "expected_phase_inference_count": (
+            _count_sync(conn, EXPECTED_PHASE_COUNT_SQL) if tables["session_profiles"] else 0
+        ),
+        "stale_work_event_inference_count": (
+            _count_sync(conn, STALE_WORK_EVENT_COUNT_SQL, SESSION_PRODUCT_MATERIALIZER_VERSION)
+            if verify_freshness and tables["session_work_events"]
+            else 0
+        ),
+        "orphan_work_event_inference_count": (
+            _count_sync(conn, ORPHAN_SESSION_WORK_EVENT_COUNT_SQL)
+            if verify_freshness and tables["session_work_events"]
+            else 0
+        ),
+        "stale_phase_inference_count": (
+            _count_sync(conn, STALE_SESSION_PHASE_COUNT_SQL, SESSION_PRODUCT_MATERIALIZER_VERSION)
+            if verify_freshness and tables["session_phases"]
+            else 0
+        ),
+        "orphan_phase_inference_count": (
+            _count_sync(conn, ORPHAN_SESSION_PHASE_COUNT_SQL) if verify_freshness and tables["session_phases"] else 0
+        ),
+        "stale_thread_count": (
+            _count_sync(conn, STALE_WORK_THREAD_COUNT_SQL, SESSION_PRODUCT_MATERIALIZER_VERSION)
+            if verify_freshness and tables["work_threads"]
+            else 0
+        ),
+        "orphan_thread_count": (
+            _count_sync(conn, ORPHAN_WORK_THREAD_COUNT_SQL) if verify_freshness and tables["work_threads"] else 0
+        ),
+        "expected_tag_rollup_count": (
+            _count_sync(conn, EXPECTED_SESSION_TAG_ROLLUP_COUNT_SQL)
+            if verify_freshness and tables["session_profiles"]
+            else counts["tag_rollup_count"]
+        ),
+        "stale_tag_rollup_count": (
+            _count_sync(conn, STALE_SESSION_TAG_ROLLUP_COUNT_SQL, SESSION_PRODUCT_MATERIALIZER_VERSION)
+            if verify_freshness and tables["session_tag_rollups"]
+            else 0
+        ),
+        "expected_day_summary_count": (
+            _count_sync(conn, EXPECTED_DAY_SESSION_SUMMARY_COUNT_SQL)
+            if verify_freshness and tables["session_profiles"]
+            else counts["day_summary_count"]
+        ),
+        "stale_day_summary_count": (
+            _count_sync(conn, STALE_DAY_SESSION_SUMMARY_COUNT_SQL, SESSION_PRODUCT_MATERIALIZER_VERSION)
+            if verify_freshness and tables["day_session_summaries"]
+            else 0
+        ),
+    }
+
+
+def _status_counts_sync(
+    conn: sqlite3.Connection,
+    tables: TablePresence,
+    *,
+    verify_freshness: bool,
+) -> StatusCounts:
+    counts = _materialized_counts_sync(conn, tables, verify_freshness=verify_freshness)
+    counts.update(_sync_fts_duplicate_counts(conn, tables, counts, verify_freshness=verify_freshness))
+    counts.update(_sync_repair_counts(conn, tables, counts, verify_freshness=verify_freshness))
+    return counts
+
+
 def _status_payload(
-    tables: dict[str, bool],
-    counts: dict[str, int],
+    tables: TablePresence,
+    counts: StatusCounts,
 ) -> SessionProductStatusSnapshot:
     profile_count = counts["profile_row_count"]
     work_event_count = counts["work_event_inference_count"]
@@ -357,268 +640,145 @@ def session_product_status_sync(
     *,
     verify_freshness: bool = True,
 ) -> SessionProductStatusSnapshot:
-    tables = {key: bool(conn.execute(sql).fetchone()) for key, sql in _TABLE_SQLS.items()}
-
-    def count(sql: str, *params: object) -> int:
-        return _to_int(conn.execute(sql, params).fetchone())
-
-    def table_count(table_exists: bool, table_name: str) -> int:
-        return _to_int(conn.execute(f"SELECT COUNT(*) FROM {table_name}").fetchone()) if table_exists else 0
-
-    total_conversations = count(TOTAL_CONVERSATIONS_SQL)
-    thread_count = count(WORK_THREAD_COUNT_SQL) if tables["work_threads"] else 0
-    root_threads = count(ROOT_THREAD_COUNT_SQL) if verify_freshness else thread_count
-    profile_row_count = count(SESSION_PROFILE_COUNT_SQL) if tables["session_profiles"] else 0
-    profile_merged_fts_count = (
-        count(SESSION_PROFILE_MERGED_FTS_DOC_COUNT_SQL)
-        if verify_freshness and tables["session_profiles_fts"]
-        else table_count(tables["session_profiles_fts"], "session_profiles_fts")
-    )
-    profile_evidence_fts_count = (
-        count(SESSION_PROFILE_EVIDENCE_FTS_DOC_COUNT_SQL)
-        if verify_freshness and tables["session_profile_evidence_fts"]
-        else table_count(tables["session_profile_evidence_fts"], "session_profile_evidence_fts")
-    )
-    profile_inference_fts_count = (
-        count(SESSION_PROFILE_INFERENCE_FTS_DOC_COUNT_SQL)
-        if verify_freshness and tables["session_profile_inference_fts"]
-        else table_count(tables["session_profile_inference_fts"], "session_profile_inference_fts")
-    )
-    profile_enrichment_fts_count = (
-        count(SESSION_PROFILE_ENRICHMENT_FTS_DOC_COUNT_SQL)
-        if verify_freshness and tables["session_profile_enrichment_fts"]
-        else table_count(tables["session_profile_enrichment_fts"], "session_profile_enrichment_fts")
-    )
-    work_event_inference_count = count(SESSION_WORK_EVENT_COUNT_SQL) if tables["session_work_events"] else 0
-    work_event_inference_fts_count = (
-        count(SESSION_WORK_EVENT_FTS_DOC_COUNT_SQL)
-        if verify_freshness and tables["session_work_events_fts"]
-        else table_count(tables["session_work_events_fts"], "session_work_events_fts")
-    )
-    phase_inference_count = count(SESSION_PHASE_COUNT_SQL) if tables["session_phases"] else 0
-    thread_fts_count = (
-        count(WORK_THREAD_FTS_DOC_COUNT_SQL)
-        if verify_freshness and tables["work_threads_fts"]
-        else table_count(tables["work_threads_fts"], "work_threads_fts")
-    )
-    tag_rollup_count = count(SESSION_TAG_ROLLUP_COUNT_SQL) if tables["session_tag_rollups"] else 0
-    day_summary_count = count(DAY_SESSION_SUMMARY_COUNT_SQL) if tables["day_session_summaries"] else 0
-
-    counts = {
-        "total_conversations": total_conversations,
-        "root_threads": root_threads,
-        "profile_row_count": profile_row_count,
-        "profile_merged_fts_count": profile_merged_fts_count,
-        "profile_merged_fts_duplicate_count": (
-            count(SESSION_PROFILE_MERGED_FTS_DUPLICATE_COUNT_SQL)
-            if verify_freshness and tables["session_profiles_fts"]
-            else max(0, profile_merged_fts_count - profile_row_count)
-        ),
-        "profile_evidence_fts_count": profile_evidence_fts_count,
-        "profile_evidence_fts_duplicate_count": (
-            count(SESSION_PROFILE_EVIDENCE_FTS_DUPLICATE_COUNT_SQL)
-            if verify_freshness and tables["session_profile_evidence_fts"]
-            else max(0, profile_evidence_fts_count - profile_row_count)
-        ),
-        "profile_inference_fts_count": profile_inference_fts_count,
-        "profile_inference_fts_duplicate_count": (
-            count(SESSION_PROFILE_INFERENCE_FTS_DUPLICATE_COUNT_SQL)
-            if verify_freshness and tables["session_profile_inference_fts"]
-            else max(0, profile_inference_fts_count - profile_row_count)
-        ),
-        "profile_enrichment_fts_count": profile_enrichment_fts_count,
-        "profile_enrichment_fts_duplicate_count": (
-            count(SESSION_PROFILE_ENRICHMENT_FTS_DUPLICATE_COUNT_SQL)
-            if verify_freshness and tables["session_profile_enrichment_fts"]
-            else max(0, profile_enrichment_fts_count - profile_row_count)
-        ),
-        "work_event_inference_count": work_event_inference_count,
-        "work_event_inference_fts_count": work_event_inference_fts_count,
-        "work_event_inference_fts_duplicate_count": (
-            count(SESSION_WORK_EVENT_FTS_DUPLICATE_COUNT_SQL)
-            if verify_freshness and tables["session_work_events_fts"]
-            else max(0, work_event_inference_fts_count - work_event_inference_count)
-        ),
-        "phase_inference_count": phase_inference_count,
-        "thread_count": thread_count,
-        "thread_fts_count": thread_fts_count,
-        "thread_fts_duplicate_count": (
-            count(WORK_THREAD_FTS_DUPLICATE_COUNT_SQL)
-            if verify_freshness and tables["work_threads_fts"]
-            else max(0, thread_fts_count - thread_count)
-        ),
-        "tag_rollup_count": tag_rollup_count,
-        "day_summary_count": day_summary_count,
-    }
-    counts["missing_profile_row_count"] = (
-        count(MISSING_SESSION_PROFILE_COUNT_SQL) if tables["session_profiles"] else counts["total_conversations"]
-    )
-    counts["stale_profile_row_count"] = (
-        count(STALE_SESSION_PROFILE_COUNT_SQL, SESSION_PRODUCT_MATERIALIZER_VERSION)
-        if verify_freshness and tables["session_profiles"]
-        else 0
-    )
-    counts["orphan_profile_row_count"] = (
-        count(ORPHAN_SESSION_PROFILE_COUNT_SQL) if verify_freshness and tables["session_profiles"] else 0
-    )
-    counts["expected_work_event_inference_count"] = (
-        count(EXPECTED_WORK_EVENT_COUNT_SQL) if tables["session_profiles"] else 0
-    )
-    counts["expected_phase_inference_count"] = count(EXPECTED_PHASE_COUNT_SQL) if tables["session_profiles"] else 0
-    counts["stale_work_event_inference_count"] = (
-        count(STALE_WORK_EVENT_COUNT_SQL, SESSION_PRODUCT_MATERIALIZER_VERSION)
-        if verify_freshness and tables["session_work_events"]
-        else 0
-    )
-    counts["orphan_work_event_inference_count"] = (
-        count(ORPHAN_SESSION_WORK_EVENT_COUNT_SQL) if verify_freshness and tables["session_work_events"] else 0
-    )
-    counts["stale_phase_inference_count"] = (
-        count(STALE_SESSION_PHASE_COUNT_SQL, SESSION_PRODUCT_MATERIALIZER_VERSION)
-        if verify_freshness and tables["session_phases"]
-        else 0
-    )
-    counts["orphan_phase_inference_count"] = (
-        count(ORPHAN_SESSION_PHASE_COUNT_SQL) if verify_freshness and tables["session_phases"] else 0
-    )
-    counts["stale_thread_count"] = (
-        count(STALE_WORK_THREAD_COUNT_SQL, SESSION_PRODUCT_MATERIALIZER_VERSION)
-        if verify_freshness and tables["work_threads"]
-        else 0
-    )
-    counts["orphan_thread_count"] = (
-        count(ORPHAN_WORK_THREAD_COUNT_SQL) if verify_freshness and tables["work_threads"] else 0
-    )
-    counts["expected_tag_rollup_count"] = (
-        count(EXPECTED_SESSION_TAG_ROLLUP_COUNT_SQL)
-        if verify_freshness and tables["session_profiles"]
-        else counts["tag_rollup_count"]
-    )
-    counts["stale_tag_rollup_count"] = (
-        count(STALE_SESSION_TAG_ROLLUP_COUNT_SQL, SESSION_PRODUCT_MATERIALIZER_VERSION)
-        if verify_freshness and tables["session_tag_rollups"]
-        else 0
-    )
-    counts["expected_day_summary_count"] = (
-        count(EXPECTED_DAY_SESSION_SUMMARY_COUNT_SQL)
-        if verify_freshness and tables["session_profiles"]
-        else counts["day_summary_count"]
-    )
-    counts["stale_day_summary_count"] = (
-        count(STALE_DAY_SESSION_SUMMARY_COUNT_SQL, SESSION_PRODUCT_MATERIALIZER_VERSION)
-        if verify_freshness and tables["day_session_summaries"]
-        else 0
-    )
+    tables = _tables_sync(conn)
+    counts = _status_counts_sync(conn, tables, verify_freshness=verify_freshness)
     return _status_payload(tables, counts)
 
 
-async def session_product_status_async(conn: aiosqlite.Connection) -> SessionProductStatusSnapshot:
-    tables = {}
-    for key, sql in _TABLE_SQLS.items():
-        tables[key] = bool(await (await conn.execute(sql)).fetchone())
-
-    async def count(sql: str, *params: object) -> int:
-        return _to_int(await (await conn.execute(sql, params)).fetchone())
-
-    counts = {
-        "total_conversations": await count(TOTAL_CONVERSATIONS_SQL),
-        "root_threads": await count(ROOT_THREAD_COUNT_SQL),
-        "profile_row_count": await count(SESSION_PROFILE_COUNT_SQL) if tables["session_profiles"] else 0,
-        "profile_merged_fts_count": await count(SESSION_PROFILE_MERGED_FTS_DOC_COUNT_SQL)
+async def _materialized_counts_async(conn: aiosqlite.Connection, tables: TablePresence) -> StatusCounts:
+    return {
+        "total_conversations": await _count_async(conn, TOTAL_CONVERSATIONS_SQL),
+        "root_threads": await _count_async(conn, ROOT_THREAD_COUNT_SQL),
+        "profile_row_count": await _count_async(conn, SESSION_PROFILE_COUNT_SQL) if tables["session_profiles"] else 0,
+        "profile_merged_fts_count": await _count_async(conn, SESSION_PROFILE_MERGED_FTS_DOC_COUNT_SQL)
         if tables["session_profiles_fts"]
         else 0,
-        "profile_merged_fts_duplicate_count": await count(SESSION_PROFILE_MERGED_FTS_DUPLICATE_COUNT_SQL)
+        "profile_merged_fts_duplicate_count": await _count_async(conn, SESSION_PROFILE_MERGED_FTS_DUPLICATE_COUNT_SQL)
         if tables["session_profiles_fts"]
         else 0,
-        "profile_evidence_fts_count": await count(SESSION_PROFILE_EVIDENCE_FTS_DOC_COUNT_SQL)
+        "profile_evidence_fts_count": await _count_async(conn, SESSION_PROFILE_EVIDENCE_FTS_DOC_COUNT_SQL)
         if tables["session_profile_evidence_fts"]
         else 0,
-        "profile_evidence_fts_duplicate_count": await count(SESSION_PROFILE_EVIDENCE_FTS_DUPLICATE_COUNT_SQL)
+        "profile_evidence_fts_duplicate_count": await _count_async(
+            conn, SESSION_PROFILE_EVIDENCE_FTS_DUPLICATE_COUNT_SQL
+        )
         if tables["session_profile_evidence_fts"]
         else 0,
-        "profile_inference_fts_count": await count(SESSION_PROFILE_INFERENCE_FTS_DOC_COUNT_SQL)
+        "profile_inference_fts_count": await _count_async(conn, SESSION_PROFILE_INFERENCE_FTS_DOC_COUNT_SQL)
         if tables["session_profile_inference_fts"]
         else 0,
-        "profile_inference_fts_duplicate_count": await count(SESSION_PROFILE_INFERENCE_FTS_DUPLICATE_COUNT_SQL)
+        "profile_inference_fts_duplicate_count": await _count_async(
+            conn, SESSION_PROFILE_INFERENCE_FTS_DUPLICATE_COUNT_SQL
+        )
         if tables["session_profile_inference_fts"]
         else 0,
-        "profile_enrichment_fts_count": await count(SESSION_PROFILE_ENRICHMENT_FTS_DOC_COUNT_SQL)
+        "profile_enrichment_fts_count": await _count_async(conn, SESSION_PROFILE_ENRICHMENT_FTS_DOC_COUNT_SQL)
         if tables["session_profile_enrichment_fts"]
         else 0,
-        "profile_enrichment_fts_duplicate_count": await count(SESSION_PROFILE_ENRICHMENT_FTS_DUPLICATE_COUNT_SQL)
+        "profile_enrichment_fts_duplicate_count": await _count_async(
+            conn, SESSION_PROFILE_ENRICHMENT_FTS_DUPLICATE_COUNT_SQL
+        )
         if tables["session_profile_enrichment_fts"]
         else 0,
-        "work_event_inference_count": await count(SESSION_WORK_EVENT_COUNT_SQL) if tables["session_work_events"] else 0,
-        "work_event_inference_fts_count": await count(SESSION_WORK_EVENT_FTS_DOC_COUNT_SQL)
+        "work_event_inference_count": await _count_async(conn, SESSION_WORK_EVENT_COUNT_SQL)
+        if tables["session_work_events"]
+        else 0,
+        "work_event_inference_fts_count": await _count_async(conn, SESSION_WORK_EVENT_FTS_DOC_COUNT_SQL)
         if tables["session_work_events_fts"]
         else 0,
-        "work_event_inference_fts_duplicate_count": await count(SESSION_WORK_EVENT_FTS_DUPLICATE_COUNT_SQL)
+        "work_event_inference_fts_duplicate_count": await _count_async(conn, SESSION_WORK_EVENT_FTS_DUPLICATE_COUNT_SQL)
         if tables["session_work_events_fts"]
         else 0,
-        "phase_inference_count": await count(SESSION_PHASE_COUNT_SQL) if tables["session_phases"] else 0,
-        "thread_count": await count(WORK_THREAD_COUNT_SQL) if tables["work_threads"] else 0,
-        "thread_fts_count": await count(WORK_THREAD_FTS_DOC_COUNT_SQL) if tables["work_threads_fts"] else 0,
-        "thread_fts_duplicate_count": await count(WORK_THREAD_FTS_DUPLICATE_COUNT_SQL)
+        "phase_inference_count": await _count_async(conn, SESSION_PHASE_COUNT_SQL) if tables["session_phases"] else 0,
+        "thread_count": await _count_async(conn, WORK_THREAD_COUNT_SQL) if tables["work_threads"] else 0,
+        "thread_fts_count": await _count_async(conn, WORK_THREAD_FTS_DOC_COUNT_SQL)
         if tables["work_threads_fts"]
         else 0,
-        "tag_rollup_count": await count(SESSION_TAG_ROLLUP_COUNT_SQL) if tables["session_tag_rollups"] else 0,
-        "day_summary_count": await count(DAY_SESSION_SUMMARY_COUNT_SQL) if tables["day_session_summaries"] else 0,
-    }
-    counts["missing_profile_row_count"] = (
-        await count(MISSING_SESSION_PROFILE_COUNT_SQL) if tables["session_profiles"] else counts["total_conversations"]
-    )
-    counts["stale_profile_row_count"] = (
-        await count(STALE_SESSION_PROFILE_COUNT_SQL, SESSION_PRODUCT_MATERIALIZER_VERSION)
-        if tables["session_profiles"]
-        else counts["total_conversations"]
-    )
-    counts["orphan_profile_row_count"] = (
-        await count(ORPHAN_SESSION_PROFILE_COUNT_SQL) if tables["session_profiles"] else 0
-    )
-    counts["expected_work_event_inference_count"] = (
-        await count(EXPECTED_WORK_EVENT_COUNT_SQL) if tables["session_profiles"] else 0
-    )
-    counts["expected_phase_inference_count"] = (
-        await count(EXPECTED_PHASE_COUNT_SQL) if tables["session_profiles"] else 0
-    )
-    counts["stale_work_event_inference_count"] = (
-        await count(STALE_WORK_EVENT_COUNT_SQL, SESSION_PRODUCT_MATERIALIZER_VERSION)
-        if tables["session_work_events"]
-        else counts["expected_work_event_inference_count"]
-    )
-    counts["orphan_work_event_inference_count"] = (
-        await count(ORPHAN_SESSION_WORK_EVENT_COUNT_SQL) if tables["session_work_events"] else 0
-    )
-    counts["stale_phase_inference_count"] = (
-        await count(STALE_SESSION_PHASE_COUNT_SQL, SESSION_PRODUCT_MATERIALIZER_VERSION)
-        if tables["session_phases"]
-        else counts["expected_phase_inference_count"]
-    )
-    counts["orphan_phase_inference_count"] = (
-        await count(ORPHAN_SESSION_PHASE_COUNT_SQL) if tables["session_phases"] else 0
-    )
-    counts["stale_thread_count"] = (
-        await count(STALE_WORK_THREAD_COUNT_SQL, SESSION_PRODUCT_MATERIALIZER_VERSION)
-        if tables["work_threads"]
-        else counts["root_threads"]
-    )
-    counts["orphan_thread_count"] = await count(ORPHAN_WORK_THREAD_COUNT_SQL) if tables["work_threads"] else 0
-    counts["expected_tag_rollup_count"] = (
-        await count(EXPECTED_SESSION_TAG_ROLLUP_COUNT_SQL) if tables["session_profiles"] else 0
-    )
-    counts["stale_tag_rollup_count"] = (
-        await count(STALE_SESSION_TAG_ROLLUP_COUNT_SQL, SESSION_PRODUCT_MATERIALIZER_VERSION)
+        "thread_fts_duplicate_count": await _count_async(conn, WORK_THREAD_FTS_DUPLICATE_COUNT_SQL)
+        if tables["work_threads_fts"]
+        else 0,
+        "tag_rollup_count": await _count_async(conn, SESSION_TAG_ROLLUP_COUNT_SQL)
         if tables["session_tag_rollups"]
-        else counts["expected_tag_rollup_count"]
-    )
-    counts["expected_day_summary_count"] = (
-        await count(EXPECTED_DAY_SESSION_SUMMARY_COUNT_SQL) if tables["session_profiles"] else 0
-    )
-    counts["stale_day_summary_count"] = (
-        await count(STALE_DAY_SESSION_SUMMARY_COUNT_SQL, SESSION_PRODUCT_MATERIALIZER_VERSION)
+        else 0,
+        "day_summary_count": await _count_async(conn, DAY_SESSION_SUMMARY_COUNT_SQL)
         if tables["day_session_summaries"]
-        else counts["expected_day_summary_count"]
-    )
+        else 0,
+    }
+
+
+async def _async_repair_counts(
+    conn: aiosqlite.Connection,
+    tables: TablePresence,
+    counts: StatusCounts,
+) -> StatusCounts:
+    return {
+        "missing_profile_row_count": await _count_async(conn, MISSING_SESSION_PROFILE_COUNT_SQL)
+        if tables["session_profiles"]
+        else counts["total_conversations"],
+        "stale_profile_row_count": await _count_async(
+            conn, STALE_SESSION_PROFILE_COUNT_SQL, SESSION_PRODUCT_MATERIALIZER_VERSION
+        )
+        if tables["session_profiles"]
+        else counts["total_conversations"],
+        "orphan_profile_row_count": await _count_async(conn, ORPHAN_SESSION_PROFILE_COUNT_SQL)
+        if tables["session_profiles"]
+        else 0,
+        "expected_work_event_inference_count": await _count_async(conn, EXPECTED_WORK_EVENT_COUNT_SQL)
+        if tables["session_profiles"]
+        else 0,
+        "expected_phase_inference_count": await _count_async(conn, EXPECTED_PHASE_COUNT_SQL)
+        if tables["session_profiles"]
+        else 0,
+        "stale_work_event_inference_count": await _count_async(
+            conn, STALE_WORK_EVENT_COUNT_SQL, SESSION_PRODUCT_MATERIALIZER_VERSION
+        )
+        if tables["session_work_events"]
+        else counts["expected_work_event_inference_count"],
+        "orphan_work_event_inference_count": await _count_async(conn, ORPHAN_SESSION_WORK_EVENT_COUNT_SQL)
+        if tables["session_work_events"]
+        else 0,
+        "stale_phase_inference_count": await _count_async(
+            conn, STALE_SESSION_PHASE_COUNT_SQL, SESSION_PRODUCT_MATERIALIZER_VERSION
+        )
+        if tables["session_phases"]
+        else counts["expected_phase_inference_count"],
+        "orphan_phase_inference_count": await _count_async(conn, ORPHAN_SESSION_PHASE_COUNT_SQL)
+        if tables["session_phases"]
+        else 0,
+        "stale_thread_count": await _count_async(
+            conn, STALE_WORK_THREAD_COUNT_SQL, SESSION_PRODUCT_MATERIALIZER_VERSION
+        )
+        if tables["work_threads"]
+        else counts["root_threads"],
+        "orphan_thread_count": await _count_async(conn, ORPHAN_WORK_THREAD_COUNT_SQL) if tables["work_threads"] else 0,
+        "expected_tag_rollup_count": await _count_async(conn, EXPECTED_SESSION_TAG_ROLLUP_COUNT_SQL)
+        if tables["session_profiles"]
+        else 0,
+        "stale_tag_rollup_count": await _count_async(
+            conn, STALE_SESSION_TAG_ROLLUP_COUNT_SQL, SESSION_PRODUCT_MATERIALIZER_VERSION
+        )
+        if tables["session_tag_rollups"]
+        else counts["expected_tag_rollup_count"],
+        "expected_day_summary_count": await _count_async(conn, EXPECTED_DAY_SESSION_SUMMARY_COUNT_SQL)
+        if tables["session_profiles"]
+        else 0,
+        "stale_day_summary_count": await _count_async(
+            conn, STALE_DAY_SESSION_SUMMARY_COUNT_SQL, SESSION_PRODUCT_MATERIALIZER_VERSION
+        )
+        if tables["day_session_summaries"]
+        else counts["expected_day_summary_count"],
+    }
+
+
+async def _status_counts_async(conn: aiosqlite.Connection, tables: TablePresence) -> StatusCounts:
+    counts = await _materialized_counts_async(conn, tables)
+    counts.update(await _async_repair_counts(conn, tables, counts))
+    return counts
+
+
+async def session_product_status_async(conn: aiosqlite.Connection) -> SessionProductStatusSnapshot:
+    tables = await _tables_async(conn)
+    counts = await _status_counts_async(conn, tables)
     return _status_payload(tables, counts)
 
 


### PR DESCRIPTION
## Summary
- Split session-product status table probing and count assembly into explicit sync/async helpers.
- Preserve the public `session_product_status_sync` and `session_product_status_async` contracts as thin orchestration wrappers.
- Keep sync `verify_freshness=False` count behavior distinct from async full-freshness behavior.

## Problem
`session_product_status.py` had large public functions that mixed table existence probing, table counts, distinct FTS counts, duplicate estimates, stale/orphan repair counts, and final readiness projection. This made the session-product repair/status path harder to audit after the doctor readiness cleanup.

## Solution
- Added typed aliases for table-presence and status-count payloads.
- Factored sync count assembly into materialized-count, FTS duplicate-count, and repair-count helpers.
- Factored async count assembly into matching materialized and repair count helpers while preserving its existing semantics.

## Verification
- `pytest -q tests/unit/storage/test_derived_status.py tests/unit/cli/test_products.py tests/unit/core/test_health_core.py`
- `mypy polylogue/storage/session_product_status.py tests/unit/storage/test_derived_status.py tests/unit/cli/test_products.py tests/unit/core/test_health_core.py`
- `mypy polylogue tests`
- `devtools verify --quick`

Ref #270
