### PR TITLE
refactor: split embedding status rendering

### DIFF
--- a/polylogue/cli/embed_stats.py
+++ b/polylogue/cli/embed_stats.py
@@ -3,10 +3,14 @@
 from __future__ import annotations
 
 import json
+import sqlite3
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Protocol
 
 import click
 from typing_extensions import TypedDict
+
+from polylogue.storage.embedding_stats_models import EmbeddingStatsSnapshot
 
 if TYPE_CHECKING:
     from polylogue.config import Config
@@ -46,7 +50,91 @@ class EmbeddingStatusPayload(TypedDict):
 
 def _payload_int(value: object) -> int:
     """Coerce loosely typed payload counters to ints for display."""
-    return int(value) if isinstance(value, bool | int | float | str) else 0
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if isinstance(value, str):
+        try:
+            return int(value)
+        except ValueError:
+            return 0
+    return 0
+
+
+def _total_conversations(conn: sqlite3.Connection) -> int:
+    row = conn.execute("SELECT COUNT(*) FROM conversations").fetchone()
+    return _payload_int(row[0]) if row is not None else 0
+
+
+def _coverage_percent(*, embedded_conversations: int, total_conversations: int) -> float:
+    if total_conversations <= 0:
+        return 0.0
+    return embedded_conversations / total_conversations * 100
+
+
+def _embedding_status(
+    *,
+    total_conversations: int,
+    embedded_conversations: int,
+    pending_conversations: int,
+) -> str:
+    if total_conversations <= 0:
+        return "empty"
+    if embedded_conversations <= 0:
+        return "none"
+    if pending_conversations > 0:
+        return "partial"
+    return "complete"
+
+
+def _freshness_status(status: str, stats: EmbeddingStatsSnapshot) -> str:
+    if stats.embedded_messages > 0 and (stats.stale_messages > 0 or stats.messages_missing_provenance > 0):
+        return "stale"
+    return status
+
+
+def _retrieval_ready(stats: EmbeddingStatsSnapshot) -> bool:
+    return stats.embedded_messages > stats.stale_messages
+
+
+def _payload_from_stats(
+    *,
+    total_conversations: int,
+    stats: EmbeddingStatsSnapshot,
+) -> EmbeddingStatusPayload:
+    embedded_conversations = stats.embedded_conversations
+    pending_conversations = stats.pending_conversations or max(total_conversations - embedded_conversations, 0)
+    status = _embedding_status(
+        total_conversations=total_conversations,
+        embedded_conversations=embedded_conversations,
+        pending_conversations=pending_conversations,
+    )
+    return {
+        "status": status,
+        "total_conversations": total_conversations,
+        "embedded_conversations": embedded_conversations,
+        "embedded_messages": stats.embedded_messages,
+        "pending_conversations": pending_conversations,
+        "embedding_coverage_percent": round(
+            _coverage_percent(
+                embedded_conversations=embedded_conversations,
+                total_conversations=total_conversations,
+            ),
+            1,
+        ),
+        "retrieval_ready": _retrieval_ready(stats),
+        "freshness_status": _freshness_status(status, stats),
+        "stale_messages": stats.stale_messages,
+        "messages_missing_provenance": stats.messages_missing_provenance,
+        "oldest_embedded_at": stats.oldest_embedded_at,
+        "newest_embedded_at": stats.newest_embedded_at,
+        "embedding_models": stats.model_counts,
+        "embedding_dimensions": stats.dimension_counts,
+        "retrieval_bands": stats.retrieval_bands,
+    }
 
 
 def embedding_status_payload(env: _HasConfig) -> EmbeddingStatusPayload:
@@ -55,44 +143,35 @@ def embedding_status_payload(env: _HasConfig) -> EmbeddingStatusPayload:
     from polylogue.storage.embedding_stats import read_embedding_stats_sync
 
     with open_read_connection(env.config.db_path) as conn:
-        total_convs = conn.execute("SELECT COUNT(*) FROM conversations").fetchone()[0]
+        total_conversations = _total_conversations(conn)
         embedding_stats = read_embedding_stats_sync(conn)
 
-    embedded_convs = embedding_stats.embedded_conversations
-    embedded_msgs = embedding_stats.embedded_messages
-    pending = embedding_stats.pending_conversations or max(total_convs - embedded_convs, 0)
-    coverage = (embedded_convs / total_convs * 100) if total_convs > 0 else 0
-    if total_convs <= 0:
-        status = "empty"
-    elif embedded_convs <= 0:
-        status = "none"
-    elif pending > 0:
-        status = "partial"
-    else:
-        status = "complete"
-    freshness_status = status
-    if embedding_stats.embedded_messages > 0 and (
-        embedding_stats.stale_messages > 0 or embedding_stats.messages_missing_provenance > 0
-    ):
-        freshness_status = "stale"
+    return _payload_from_stats(total_conversations=total_conversations, stats=embedding_stats)
 
-    return {
-        "status": status,
-        "total_conversations": int(total_convs),
-        "embedded_conversations": int(embedded_convs),
-        "embedded_messages": int(embedded_msgs),
-        "pending_conversations": int(pending),
-        "embedding_coverage_percent": round(float(coverage), 1),
-        "retrieval_ready": bool(embedded_msgs > embedding_stats.stale_messages),
-        "freshness_status": freshness_status,
-        "stale_messages": int(embedding_stats.stale_messages),
-        "messages_missing_provenance": int(embedding_stats.messages_missing_provenance),
-        "oldest_embedded_at": embedding_stats.oldest_embedded_at,
-        "newest_embedded_at": embedding_stats.newest_embedded_at,
-        "embedding_models": embedding_stats.model_counts,
-        "embedding_dimensions": embedding_stats.dimension_counts,
-        "retrieval_bands": embedding_stats.retrieval_bands,
-    }
+
+def _render_embedding_window(payload: EmbeddingStatusPayload) -> None:
+    if payload["oldest_embedded_at"] or payload["newest_embedded_at"]:
+        click.echo(
+            f"  Embedded at:           {payload['oldest_embedded_at'] or '-'} -> {payload['newest_embedded_at'] or '-'}"
+        )
+
+
+def _render_named_counts(label: str, values: Mapping[str, int] | Mapping[int, int]) -> None:
+    if values:
+        click.echo(f"  {label}:                {', '.join(f'{name} ({count})' for name, count in values.items())}")
+
+
+def _render_retrieval_bands(payload: EmbeddingStatusPayload) -> None:
+    if not payload["retrieval_bands"]:
+        return
+    click.echo("  Retrieval bands:")
+    for band_name, band in payload["retrieval_bands"].items():
+        status_text = "ready" if band.get("ready") else str(band.get("status", "pending"))
+        click.echo(
+            f"    {band_name}: {status_text}; "
+            f"rows={_payload_int(band.get('materialized_rows', 0)):,}/{_payload_int(band.get('source_rows', 0)):,}; "
+            f"docs={_payload_int(band.get('materialized_documents', 0)):,}/{_payload_int(band.get('source_documents', 0)):,}"
+        )
 
 
 def render_embedding_stats(payload: EmbeddingStatusPayload, *, json_output: bool = False) -> None:
@@ -112,27 +191,10 @@ def render_embedding_stats(payload: EmbeddingStatusPayload, *, json_output: bool
     click.echo(f"  Freshness:             {payload['freshness_status']}")
     click.echo(f"  Stale messages:        {payload['stale_messages']}")
     click.echo(f"  Missing provenance:    {payload['messages_missing_provenance']}")
-    if payload["oldest_embedded_at"] or payload["newest_embedded_at"]:
-        click.echo(
-            f"  Embedded at:           {payload['oldest_embedded_at'] or '-'} -> {payload['newest_embedded_at'] or '-'}"
-        )
-    if payload["embedding_models"]:
-        click.echo(
-            f"  Models:                {', '.join(f'{name} ({count})' for name, count in payload['embedding_models'].items())}"
-        )
-    if payload["embedding_dimensions"]:
-        click.echo(
-            f"  Dimensions:            {', '.join(f'{dimension} ({count})' for dimension, count in payload['embedding_dimensions'].items())}"
-        )
-    if payload["retrieval_bands"]:
-        click.echo("  Retrieval bands:")
-        for band_name, band in payload["retrieval_bands"].items():
-            status_text = "ready" if band.get("ready") else str(band.get("status", "pending"))
-            click.echo(
-                f"    {band_name}: {status_text}; "
-                f"rows={_payload_int(band.get('materialized_rows', 0)):,}/{_payload_int(band.get('source_rows', 0)):,}; "
-                f"docs={_payload_int(band.get('materialized_documents', 0)):,}/{_payload_int(band.get('source_documents', 0)):,}"
-            )
+    _render_embedding_window(payload)
+    _render_named_counts("Models", payload["embedding_models"])
+    _render_named_counts("Dimensions", payload["embedding_dimensions"])
+    _render_retrieval_bands(payload)
 
 
 def show_embedding_stats(env: _HasConfig, *, json_output: bool = False) -> None:


### PR DESCRIPTION
## Summary
- Split embedding CLI payload derivation into focused status, coverage, freshness, and readiness helpers.
- Split terminal rendering into named sections for timestamp windows, model/dimension counts, and retrieval bands.
- Preserve the existing `embedding_status_payload`, `render_embedding_stats`, and `show_embedding_stats` public helpers.

## Problem
`polylogue/cli/embed_stats.py` mixed database reads, status derivation, freshness decisions, JSON payload construction, and terminal rendering in a single flow. That made it harder to audit after the embedding-stat reader cleanup in the parent PR.

## Solution
- Added private helpers for total conversation reads, coverage/status/freshness derivation, and payload construction.
- Added private rendering helpers for optional embedding windows, named count collections, and retrieval bands.
- Kept output labels and payload keys stable.

## Verification
- `pytest -q tests/unit/cli/test_embed.py`
- `mypy polylogue/cli/embed_stats.py tests/unit/cli/test_embed.py`
- `mypy polylogue tests`
- `devtools verify --quick`

Ref #270
