### PR TITLE
refactor: share query stats rendering

### DIFF
--- a/polylogue/cli/query_stats.py
+++ b/polylogue/cli/query_stats.py
@@ -4,6 +4,9 @@ semantic action/tool grouping, and profile-backed grouping."""
 from __future__ import annotations
 
 import json
+from collections import Counter, defaultdict
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
@@ -13,10 +16,130 @@ from polylogue.cli.query_feedback import emit_no_results
 
 if TYPE_CHECKING:
     from polylogue.cli.types import AppEnv
+    from polylogue.lib.action_events import ActionEvent
     from polylogue.lib.filters import ConversationFilter
     from polylogue.lib.models import Conversation, ConversationSummary
     from polylogue.lib.query_spec import ConversationQuerySpec
     from polylogue.protocols import ConversationArchiveStatsStore
+
+
+DATE_GROUP_DIMENSIONS = frozenset({"month", "year", "day"})
+DATE_GROUP_FORMATS = {
+    "day": "%Y-%m-%d",
+    "month": "%Y-%m",
+    "year": "%Y",
+}
+GROUP_COUNT_COLUMNS = (
+    ("conversations", "Convs"),
+    ("messages", "Messages"),
+)
+GROUP_WORD_COLUMNS = (
+    ("conversations", "Convs"),
+    ("messages", "Messages"),
+    ("words", "Words"),
+)
+SEMANTIC_COLUMNS = (
+    ("conversations", "Convs"),
+    ("facts", "Facts"),
+    ("messages", "Msgs"),
+)
+PROFILE_COLUMNS = (
+    ("conversations", "Convs"),
+    ("work_events", "Events"),
+    ("messages", "Msgs"),
+)
+
+
+@dataclass(frozen=True, slots=True)
+class GroupedStatsPayload:
+    rows: list[dict[str, object]]
+    summary: dict[str, object]
+
+
+def _sort_group_keys(groups: Mapping[str, object], dimension: str) -> list[str]:
+    return sorted(groups.keys(), reverse=dimension in DATE_GROUP_DIMENSIONS)
+
+
+def _summary_group_key(summary: ConversationSummary, dimension: str) -> str:
+    if dimension == "provider":
+        return str(summary.provider) if summary.provider else "unknown"
+    if dimension in DATE_GROUP_DIMENSIONS:
+        dt = summary.updated_at or summary.created_at
+        return dt.strftime(DATE_GROUP_FORMATS[dimension]) if dt else "unknown"
+    return "all"
+
+
+def _conversation_group_key(conversation: Conversation, dimension: str) -> str:
+    if dimension == "provider":
+        return conversation.provider or "unknown"
+    if dimension in DATE_GROUP_DIMENSIONS:
+        dt = conversation.display_date
+        return dt.strftime(DATE_GROUP_FORMATS[dimension]) if dt else "unknown"
+    return "all"
+
+
+def _count_value(row: dict[str, object], key: str) -> int:
+    value = row[key]
+    if isinstance(value, int):
+        return value
+    raise TypeError(f"Stats value {key!r} must be int, got {type(value).__name__}")
+
+
+def _formatted_group_label(group_label: str, *, color_provider: bool) -> str:
+    if not color_provider:
+        return group_label
+
+    from polylogue.ui.theme import provider_color
+
+    return f"[{provider_color(group_label).hex}]{group_label}[/]"
+
+
+def _emit_grouped_stats_table(
+    env: AppEnv,
+    *,
+    dimension: str,
+    rows: list[dict[str, object]],
+    summary: dict[str, object],
+    columns: tuple[tuple[str, str], ...],
+    total_label: str,
+    matched_conversations: int,
+    output_format: str,
+    color_provider: bool = False,
+    multi_membership: bool = False,
+    note: str | None = None,
+) -> None:
+    if emit_structured_stats(
+        output_format=output_format,
+        dimension=dimension,
+        rows=rows,
+        summary=summary,
+        multi_membership=multi_membership,
+    ):
+        return
+
+    from rich.table import Table
+
+    env.ui.console.print(f"\nMatched: {matched_conversations:,} conversations (by {dimension})\n")
+    table = Table(show_header=True, header_style="bold", box=None, pad_edge=False)
+    table.add_column("Group", style="bold", min_width=12)
+    for _, title in columns:
+        table.add_column(title, justify="right")
+
+    for row in rows:
+        group_label = str(row["group"])
+        table.add_row(
+            _formatted_group_label(group_label, color_provider=color_provider),
+            *(f"{_count_value(row, key):,}" for key, _ in columns),
+        )
+
+    table.add_section()
+    table.add_row(
+        f"[bold]{total_label}[/]",
+        *(f"[bold]{_count_value(summary, key):,}[/]" for key, _ in columns),
+    )
+    env.ui.console.print(table)
+    if note is not None:
+        env.ui.console.print(note)
 
 
 # ---------------------------------------------------------------------------
@@ -232,38 +355,16 @@ def output_stats_by_summaries(
     selection: ConversationQuerySpec | None = None,
     output_format: str = "text",
 ) -> None:
-    from collections import defaultdict
-
-    from rich.table import Table
-
-    from polylogue.ui.theme import provider_color
-
     if not summaries:
         emit_no_results(env, selection=selection, output_format=output_format)
 
     groups: dict[str, list[ConversationSummary]] = defaultdict(list)
     for summary in summaries:
-        if dimension == "provider":
-            key = str(summary.provider) if summary.provider else "unknown"
-        elif dimension == "month":
-            dt = summary.updated_at or summary.created_at
-            key = dt.strftime("%Y-%m") if dt else "unknown"
-        elif dimension == "year":
-            dt = summary.updated_at or summary.created_at
-            key = dt.strftime("%Y") if dt else "unknown"
-        elif dimension == "day":
-            dt = summary.updated_at or summary.created_at
-            key = dt.strftime("%Y-%m-%d") if dt else "unknown"
-        else:
-            key = "all"
-        groups[key].append(summary)
+        groups[_summary_group_key(summary, dimension)].append(summary)
 
-    sorted_keys = (
-        sorted(groups.keys(), reverse=True) if dimension in {"month", "year", "day"} else sorted(groups.keys())
-    )
     rows: list[dict[str, object]] = []
 
-    for key in sorted_keys:
+    for key in _sort_group_keys(groups, dimension):
         group_summaries = groups[key]
         rows.append(
             {
@@ -278,32 +379,17 @@ def output_stats_by_summaries(
         "conversations": len(summaries),
         "messages": sum(msg_counts.get(str(summary.id), 0) for summary in summaries),
     }
-    if emit_structured_stats(
-        output_format=output_format,
+    _emit_grouped_stats_table(
+        env,
         dimension=dimension,
         rows=rows,
         summary=summary_row,
-    ):
-        return
-
-    env.ui.console.print(f"\nMatched: {len(summaries)} conversations (by {dimension})\n")
-
-    table = Table(show_header=True, header_style="bold", box=None, pad_edge=False)
-    table.add_column("Group", style="bold", min_width=12)
-    table.add_column("Convs", justify="right")
-    table.add_column("Messages", justify="right")
-
-    for row in rows:
-        group_label = str(row["group"])
-        label = f"[{provider_color(group_label).hex}]{group_label}[/]" if dimension == "provider" else group_label
-        table.add_row(label, f"{row['conversations']:,}", f"{row['messages']:,}")
-
-    table.add_section()
-    table.add_row(
-        "[bold]TOTAL[/]", f"[bold]{summary_row['conversations']:,}[/]", f"[bold]{summary_row['messages']:,}[/]"
+        columns=GROUP_COUNT_COLUMNS,
+        total_label="TOTAL",
+        matched_conversations=len(summaries),
+        output_format=output_format,
+        color_provider=dimension == "provider",
     )
-
-    env.ui.console.print(table)
 
 
 def output_stats_by_grouped_conversations(
@@ -313,38 +399,12 @@ def output_stats_by_grouped_conversations(
     *,
     output_format: str = "text",
 ) -> None:
-    from collections import defaultdict
-
-    from rich.table import Table
-
-    from polylogue.ui.theme import provider_color
-
     groups: dict[str, list[Conversation]] = defaultdict(list)
     for conv in results:
-        if dimension == "provider":
-            key = conv.provider or "unknown"
-            groups[key].append(conv)
-        elif dimension == "month":
-            dt = conv.display_date
-            key = dt.strftime("%Y-%m") if dt else "unknown"
-            groups[key].append(conv)
-        elif dimension == "year":
-            dt = conv.display_date
-            key = dt.strftime("%Y") if dt else "unknown"
-            groups[key].append(conv)
-        elif dimension == "day":
-            dt = conv.display_date
-            key = dt.strftime("%Y-%m-%d") if dt else "unknown"
-            groups[key].append(conv)
-        else:
-            groups["all"].append(conv)
-
-    sorted_keys = (
-        sorted(groups.keys(), reverse=True) if dimension in {"month", "year", "day"} else sorted(groups.keys())
-    )
+        groups[_conversation_group_key(conv, dimension)].append(conv)
 
     rows: list[dict[str, object]] = []
-    for key in sorted_keys:
+    for key in _sort_group_keys(groups, dimension):
         convs = groups[key]
         rows.append(
             {
@@ -361,41 +421,92 @@ def output_stats_by_grouped_conversations(
         "messages": sum(len(conv.messages) for conv in results),
         "words": sum(sum(message.word_count for message in conv.messages) for conv in results),
     }
-    if emit_structured_stats(
-        output_format=output_format,
+    _emit_grouped_stats_table(
+        env,
         dimension=dimension,
         rows=rows,
         summary=summary,
-    ):
-        return
-
-    env.ui.console.print(f"\nMatched: {len(results)} conversations (by {dimension})\n")
-
-    table = Table(show_header=True, header_style="bold", box=None, pad_edge=False)
-    table.add_column("Group", style="bold", min_width=12)
-    table.add_column("Convs", justify="right")
-    table.add_column("Messages", justify="right")
-    table.add_column("Words", justify="right")
-
-    for row in rows:
-        group_label = str(row["group"])
-        label = f"[{provider_color(group_label).hex}]{group_label}[/]" if dimension == "provider" else group_label
-        table.add_row(label, f"{row['conversations']:,}", f"{row['messages']:,}", f"{row['words']:,}")
-
-    table.add_section()
-    table.add_row(
-        "[bold]TOTAL[/]",
-        f"[bold]{summary['conversations']:,}[/]",
-        f"[bold]{summary['messages']:,}[/]",
-        f"[bold]{summary['words']:,}[/]",
+        columns=GROUP_WORD_COLUMNS,
+        total_label="TOTAL",
+        matched_conversations=len(results),
+        output_format=output_format,
+        color_provider=dimension == "provider",
     )
-
-    env.ui.console.print(table)
 
 
 # ---------------------------------------------------------------------------
 # Semantic action/tool grouped stats (from query_grouped_stats_semantic.py)
 # ---------------------------------------------------------------------------
+
+
+def _action_kind_name(action: ActionEvent) -> str:
+    return action.kind.value
+
+
+def _semantic_grouped_payload(
+    results: list[Conversation],
+    *,
+    selection: ConversationQuerySpec | None,
+    key_for_action: Callable[[ActionEvent], str],
+) -> GroupedStatsPayload:
+    from polylogue.cli.query_semantic import (
+        SemanticStatsSlice,
+        action_matches_slice,
+        filtered_action_events,
+    )
+    from polylogue.lib.semantic_facts import build_conversation_semantic_facts
+
+    semantic_slice = SemanticStatsSlice.from_selection(selection)
+    groups: dict[str, dict[str, int]] = defaultdict(lambda: {"convs": 0, "facts": 0, "msgs": 0})
+    matched_facts = 0
+    matched_messages = 0
+
+    for conv in results:
+        facts = build_conversation_semantic_facts(conv)
+        filtered_actions = filtered_action_events(facts, semantic_slice)
+        fact_counts = Counter(key_for_action(action) for action in filtered_actions)
+        if not fact_counts:
+            groups["none"]["convs"] += 1
+            continue
+
+        matched_facts += sum(fact_counts.values())
+        matched_messages += sum(
+            1
+            for message in facts.message_facts
+            if any(action_matches_slice(action, semantic_slice) for action in message.action_events)
+        )
+
+        message_groups: dict[str, set[str]] = defaultdict(set)
+        for message in facts.message_facts:
+            for key in {
+                key_for_action(action)
+                for action in message.action_events
+                if action_matches_slice(action, semantic_slice)
+            }:
+                message_groups[key].add(message.message_id)
+
+        for key, fact_count in fact_counts.items():
+            groups[key]["convs"] += 1
+            groups[key]["facts"] += fact_count
+            groups[key]["msgs"] += len(message_groups[key])
+
+    return GroupedStatsPayload(
+        rows=[
+            {
+                "group": key,
+                "conversations": stats["convs"],
+                "facts": stats["facts"],
+                "messages": stats["msgs"],
+            }
+            for key, stats in sorted(groups.items())
+        ],
+        summary={
+            "group": "MATCHED",
+            "conversations": len(results),
+            "facts": matched_facts,
+            "messages": matched_messages,
+        },
+    )
 
 
 def output_semantic_grouped_stats(
@@ -406,154 +517,29 @@ def output_semantic_grouped_stats(
     selection: ConversationQuerySpec | None = None,
     output_format: str = "text",
 ) -> bool:
-    from collections import Counter, defaultdict
-
-    from rich.table import Table
-
-    from polylogue.cli.query_semantic import (
-        SemanticStatsSlice,
-        action_matches_slice,
-        filtered_action_events,
-        normalized_tool_name,
-    )
-    from polylogue.lib.semantic_facts import build_conversation_semantic_facts
-
-    semantic_slice = SemanticStatsSlice.from_selection(selection)
+    from polylogue.cli.query_semantic import normalized_tool_name
 
     if dimension == "action":
-        action_groups: dict[str, dict[str, int]] = defaultdict(lambda: {"convs": 0, "facts": 0, "msgs": 0})
-        matched_action_events = 0
-        matched_action_msgs = 0
-
-        for conv in results:
-            facts = build_conversation_semantic_facts(conv)
-            filtered_actions = filtered_action_events(facts, semantic_slice)
-            action_counts = Counter(action.kind.value for action in filtered_actions)
-            if not action_counts:
-                action_groups["none"]["convs"] += 1
-                continue
-
-            matched_action_events += sum(action_counts.values())
-            matched_action_msgs += sum(
-                1
-                for message in facts.message_facts
-                if any(action_matches_slice(action, semantic_slice) for action in message.action_events)
-            )
-
-            action_message_groups: dict[str, set[str]] = defaultdict(set)
-            for message in facts.message_facts:
-                for key in {
-                    action.kind.value
-                    for action in message.action_events
-                    if action_matches_slice(action, semantic_slice)
-                }:
-                    action_message_groups[key].add(message.message_id)
-
-            for key, fact_count in action_counts.items():
-                action_groups[key]["convs"] += 1
-                action_groups[key]["facts"] += fact_count
-                action_groups[key]["msgs"] += len(action_message_groups[key])
-
-        rows = [
-            {
-                "group": key,
-                "conversations": stats["convs"],
-                "facts": stats["facts"],
-                "messages": stats["msgs"],
-            }
-            for key, stats in sorted(action_groups.items())
-        ]
-        summary = {
-            "group": "MATCHED",
-            "conversations": len(results),
-            "facts": matched_action_events,
-            "messages": matched_action_msgs,
-        }
+        payload = _semantic_grouped_payload(results, selection=selection, key_for_action=_action_kind_name)
         note = "Note: conversations may appear in multiple action groups."
     elif dimension == "tool":
-        tool_groups: dict[str, dict[str, int]] = defaultdict(lambda: {"convs": 0, "facts": 0, "msgs": 0})
-        matched_tool_facts = 0
-        matched_tool_msgs = 0
-
-        for conv in results:
-            facts = build_conversation_semantic_facts(conv)
-            filtered_actions = filtered_action_events(facts, semantic_slice)
-            tool_counts = Counter(normalized_tool_name(action) for action in filtered_actions)
-            if not tool_counts:
-                tool_groups["none"]["convs"] += 1
-                continue
-
-            matched_tool_facts += sum(tool_counts.values())
-            matched_tool_msgs += sum(
-                1
-                for message in facts.message_facts
-                if any(action_matches_slice(action, semantic_slice) for action in message.action_events)
-            )
-
-            tool_message_groups: dict[str, set[str]] = defaultdict(set)
-            for message in facts.message_facts:
-                for key in {
-                    normalized_tool_name(action)
-                    for action in message.action_events
-                    if action_matches_slice(action, semantic_slice)
-                }:
-                    tool_message_groups[key].add(message.message_id)
-
-            for key, fact_count in tool_counts.items():
-                tool_groups[key]["convs"] += 1
-                tool_groups[key]["facts"] += fact_count
-                tool_groups[key]["msgs"] += len(tool_message_groups[key])
-
-        rows = [
-            {
-                "group": key,
-                "conversations": stats["convs"],
-                "facts": stats["facts"],
-                "messages": stats["msgs"],
-            }
-            for key, stats in sorted(tool_groups.items())
-        ]
-        summary = {
-            "group": "MATCHED",
-            "conversations": len(results),
-            "facts": matched_tool_facts,
-            "messages": matched_tool_msgs,
-        }
+        payload = _semantic_grouped_payload(results, selection=selection, key_for_action=normalized_tool_name)
         note = "Note: conversations may appear in multiple tool groups."
     else:
         return False
 
-    if emit_structured_stats(
-        output_format=output_format,
+    _emit_grouped_stats_table(
+        env,
         dimension=dimension,
-        rows=rows,
-        summary=summary,
+        rows=payload.rows,
+        summary=payload.summary,
+        columns=SEMANTIC_COLUMNS,
+        total_label="MATCHED",
+        matched_conversations=len(results),
+        output_format=output_format,
         multi_membership=True,
-    ):
-        return True
-
-    env.ui.console.print(f"\nMatched: {len(results)} conversations (by {dimension})\n")
-    table = Table(show_header=True, header_style="bold", box=None, pad_edge=False)
-    table.add_column("Group", style="bold", min_width=12)
-    table.add_column("Convs", justify="right")
-    table.add_column("Facts", justify="right")
-    table.add_column("Msgs", justify="right")
-    for row in rows:
-        table.add_row(
-            str(row["group"]),
-            f"{row['conversations']:,}",
-            f"{row['facts']:,}",
-            f"{row['messages']:,}",
-        )
-    table.add_section()
-    table.add_row(
-        "[bold]MATCHED[/]",
-        f"[bold]{summary['conversations']:,}[/]",
-        f"[bold]{summary['facts']:,}[/]",
-        f"[bold]{summary['messages']:,}[/]",
+        note=note,
     )
-    env.ui.console.print(table)
-    env.ui.console.print(note)
     return True
 
 
@@ -647,10 +633,6 @@ async def output_stats_by_profile_ids(
     output_format: str = "text",
     batch_size: int = 100,
 ) -> None:
-    from collections import defaultdict
-
-    from rich.table import Table
-
     if dimension not in {"repo", "work-kind"}:
         raise ValueError(f"Unsupported profile stats dimension: {dimension}")
     if not conversation_ids:
@@ -711,38 +693,18 @@ async def output_stats_by_profile_ids(
         "messages": matched_messages,
     }
     multi_membership = dimension == "repo"
-    if emit_structured_stats(
-        output_format=output_format,
+    _emit_grouped_stats_table(
+        env,
         dimension=dimension,
         rows=rows,
         summary=summary,
+        columns=PROFILE_COLUMNS,
+        total_label="MATCHED",
+        matched_conversations=matched_conversations,
+        output_format=output_format,
         multi_membership=multi_membership,
-    ):
-        return
-
-    env.ui.console.print(f"\nMatched: {matched_conversations} conversations (by {dimension})\n")
-    table = Table(show_header=True, header_style="bold", box=None, pad_edge=False)
-    table.add_column("Group", style="bold", min_width=12)
-    table.add_column("Convs", justify="right")
-    table.add_column("Events", justify="right")
-    table.add_column("Msgs", justify="right")
-    for row in rows:
-        table.add_row(
-            str(row["group"]),
-            f"{row['conversations']:,}",
-            f"{row['work_events']:,}",
-            f"{row['messages']:,}",
-        )
-    table.add_section()
-    table.add_row(
-        "[bold]MATCHED[/]",
-        f"[bold]{summary['conversations']:,}[/]",
-        f"[bold]{summary['work_events']:,}[/]",
-        f"[bold]{summary['messages']:,}[/]",
+        note="Note: conversations may appear in multiple repo groups." if multi_membership else None,
     )
-    env.ui.console.print(table)
-    if multi_membership:
-        env.ui.console.print("Note: conversations may appear in multiple repo groups.")
 
 
 __all__ = [


### PR DESCRIPTION
## Summary
- Adds shared grouped-stats table rendering for query stats surfaces.
- Reuses common date/provider grouping helpers across summary, conversation, semantic, and profile-backed stats.
- Preserves existing public function names and structured output payloads.

## Problem
`polylogue/cli/query_stats.py` repeated the same group sorting, Rich table construction, total-row rendering, and semantic grouping loops across several stats paths. That made the surface harder to review and easy to drift when changing output contracts.

## Solution
- Introduce typed internal helpers for grouped stats payloads, date/provider grouping keys, and table rendering.
- Route summary/date/provider stats, in-memory grouped conversation stats, semantic action/tool stats, and profile-backed stats through the shared renderer.
- Keep SQL archive stats and exported function names stable for existing call sites.

Ref #270

## Verification
- `ruff format polylogue/cli/query_stats.py`
- `ruff check polylogue/cli/query_stats.py`
- `mypy polylogue/cli/query_stats.py tests/unit/cli/test_query_exec_laws.py`
- `pytest -q tests/unit/cli/test_query_exec_laws.py -k 'stats'`
- push hook: `devtools verify --quick`
