### PR TITLE
refactor: tighten quality and verification contracts

### DIFF
--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -6,7 +6,6 @@ import importlib
 from collections import OrderedDict
 from collections.abc import Callable, Iterable
 from dataclasses import asdict, dataclass
-from typing import cast
 
 CommandMain = Callable[[list[str] | None], int]
 CONTROL_PLANE = "devtools"
@@ -41,7 +40,17 @@ class CommandSpec:
 
     def resolve_main(self) -> CommandMain:
         module = importlib.import_module(self.module)
-        return cast(CommandMain, getattr(module, self.entrypoint))
+        entrypoint = getattr(module, self.entrypoint)
+        if not callable(entrypoint):
+            raise TypeError(f"{self.module}.{self.entrypoint} is not callable")
+
+        def _main(argv: list[str] | None = None) -> int:
+            result = entrypoint(argv)
+            if not isinstance(result, int):
+                raise TypeError(f"{self.module}.{self.entrypoint} returned {type(result).__name__}, expected int")
+            return result
+
+        return _main
 
     def to_dict(self) -> dict[str, object]:
         data = asdict(self)

--- a/devtools/pipeline_probe.py
+++ b/devtools/pipeline_probe.py
@@ -16,11 +16,12 @@ from collections.abc import Iterator
 from contextlib import contextmanager, redirect_stdout
 from dataclasses import replace
 from pathlib import Path
-from typing import NotRequired, Protocol, TypeAlias
+from typing import NotRequired, Protocol
 
 from typing_extensions import TypedDict
 
 from polylogue.config import Config, Source
+from polylogue.lib.json import JSONDocument, JSONValue, is_json_document, json_document, loads, require_json_document
 from polylogue.paths import blob_store_root, db_path
 from polylogue.pipeline.runner import RUN_STAGE_CHOICES, run_sources
 from polylogue.scenarios import (
@@ -63,11 +64,6 @@ _SOURCE_BACKED_PROBE_STAGE_SEQUENCES: dict[str, tuple[str, ...]] = {
     "reprocess": ("acquire", "parse", "materialize", "render", "index"),
     "all": ("acquire", "parse", "materialize", "render", "index"),
 }
-
-JsonScalar: TypeAlias = str | int | float | bool | None
-JsonValue: TypeAlias = JsonScalar | dict[str, "JsonValue"] | list["JsonValue"]
-JsonObject: TypeAlias = dict[str, JsonValue]
-ProbeSummary: TypeAlias = dict[str, object]
 
 
 class _RawConversationStore(Protocol):
@@ -128,7 +124,7 @@ class ArchiveManifest(TypedDict):
     missing_blob_count: int
     available_by_provider: dict[str, int]
     sampled_by_provider: dict[str, int]
-    records: list[JsonObject]
+    records: list[JSONDocument]
 
 
 class ArchiveSubsetSampleSummary(TypedDict):
@@ -147,10 +143,24 @@ class ArchiveSubsetSampleSummary(TypedDict):
 class BudgetReport(TypedDict):
     ok: bool
     max_total_ms: float | None
-    observed_total_ms: JsonValue
+    observed_total_ms: JSONValue
     max_peak_rss_mb: float | None
-    observed_peak_rss_mb: JsonValue
+    observed_peak_rss_mb: JSONValue
     violations: list[str]
+
+
+class ProbeSummary(TypedDict):
+    probe: JSONDocument
+    paths: JSONDocument
+    provenance: ProbeProvenance
+    result: JSONDocument
+    run_payload: JSONDocument
+    db_stats: dict[str, int]
+    raw_fanout: list[RawFanoutEntry]
+    source_files: NotRequired[JSONDocument]
+    source_inputs: NotRequired[SourceInputsSummary]
+    sample: NotRequired[ArchiveSubsetSampleSummary]
+    budgets: NotRequired[BudgetReport]
 
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -738,8 +748,75 @@ def _persist_manifest(manifest: ArchiveManifest, destination: Path) -> Path:
 
 
 def _load_manifest(manifest_path: Path) -> ArchiveManifest:
-    manifest: ArchiveManifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-    return manifest
+    payload = require_json_document(loads(manifest_path.read_text(encoding="utf-8")), context="archive subset manifest")
+    return _archive_manifest_from_payload(payload)
+
+
+def _string_value(document: JSONDocument, key: str) -> str:
+    value = document.get(key)
+    if not isinstance(value, str):
+        raise TypeError(f"manifest field {key!r} must be a string")
+    return value
+
+
+def _int_value(document: JSONDocument, key: str) -> int:
+    value = document.get(key)
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(f"manifest field {key!r} must be an integer")
+    return value
+
+
+def _string_list_value(document: JSONDocument, key: str) -> list[str]:
+    value = document.get(key)
+    if not isinstance(value, list):
+        raise TypeError(f"manifest field {key!r} must be a list of strings")
+    result: list[str] = []
+    for item in value:
+        if not isinstance(item, str):
+            raise TypeError(f"manifest field {key!r} must be a list of strings")
+        result.append(item)
+    return result
+
+
+def _int_map_value(document: JSONDocument, key: str) -> dict[str, int]:
+    value = document.get(key)
+    if not isinstance(value, dict):
+        raise TypeError(f"manifest field {key!r} must be an object")
+    result: dict[str, int] = {}
+    for item_key, item_value in value.items():
+        if isinstance(item_value, bool) or not isinstance(item_value, int):
+            raise TypeError(f"manifest field {key!r}.{item_key} must be an integer")
+        result[str(item_key)] = item_value
+    return result
+
+
+def _document_list_value(document: JSONDocument, key: str) -> list[JSONDocument]:
+    value = document.get(key)
+    if not isinstance(value, list):
+        raise TypeError(f"manifest field {key!r} must be a list of JSON objects")
+    result: list[JSONDocument] = []
+    for item in value:
+        if not is_json_document(item):
+            raise TypeError(f"manifest field {key!r} must be a list of JSON objects")
+        result.append(item)
+    return result
+
+
+def _archive_manifest_from_payload(payload: JSONDocument) -> ArchiveManifest:
+    return {
+        "input_mode": _string_value(payload, "input_mode"),
+        "source_db": _string_value(payload, "source_db"),
+        "source_blob_root": _string_value(payload, "source_blob_root"),
+        "seed": _int_value(payload, "seed"),
+        "sample_per_provider": _int_value(payload, "sample_per_provider"),
+        "provider_filters": _string_list_value(payload, "provider_filters"),
+        "source_filters": _string_list_value(payload, "source_filters"),
+        "candidate_count": _int_value(payload, "candidate_count"),
+        "missing_blob_count": _int_value(payload, "missing_blob_count"),
+        "available_by_provider": _int_map_value(payload, "available_by_provider"),
+        "sampled_by_provider": _int_map_value(payload, "sampled_by_provider"),
+        "records": _document_list_value(payload, "records"),
+    }
 
 
 def _build_archive_manifest(
@@ -812,8 +889,12 @@ def _build_archive_manifest(
         "missing_blob_count": missing_blob_count,
         "available_by_provider": available_by_provider,
         "sampled_by_provider": sampled_by_provider,
-        "records": [record.model_dump(mode="json") for record in sampled_records],
+        "records": [_raw_record_payload(record) for record in sampled_records],
     }
+
+
+def _raw_record_payload(record: RawConversationRecord) -> JSONDocument:
+    return require_json_document(record.model_dump(mode="json"), context="archive subset raw record")
 
 
 def _resolve_archive_manifest(
@@ -916,11 +997,10 @@ def _probe_mode(args: argparse.Namespace | PipelineProbeRequest) -> str:
     return str(getattr(args, "input_mode", "synthetic"))
 
 
-def _load_run_payload(run_path: str | None) -> JsonObject:
+def _load_run_payload(run_path: str | None) -> JSONDocument:
     if not run_path:
         return {}
-    payload: JsonObject = json.loads(Path(run_path).read_text(encoding="utf-8"))
-    return payload
+    return require_json_document(loads(Path(run_path).read_text(encoding="utf-8")), context="pipeline run payload")
 
 
 def _path_size_bytes(path: Path) -> int:
@@ -990,7 +1070,7 @@ async def _run_probe_pipeline(
     source_names: list[str] | None,
     backend: SQLiteBackend | None = None,
     repository: ConversationRepository | None = None,
-) -> tuple[RunResult, JsonObject]:
+) -> tuple[RunResult, JSONDocument]:
     result = await run_sources(
         config=config,
         stage=request.stage,
@@ -1011,11 +1091,8 @@ def _probe_stage_sequence(probe_mode: str, stage: str) -> list[str] | None:
     return list(_SOURCE_BACKED_PROBE_STAGE_SEQUENCES[stage])
 
 
-def _json_object_or_empty(value: object | None) -> JsonObject:
-    if isinstance(value, dict):
-        payload: JsonObject = value
-        return payload
-    return {}
+def _json_object_or_empty(value: object | None) -> JSONDocument:
+    return json_document(value)
 
 
 def _json_float_or_none(value: object | None) -> float | None:
@@ -1029,6 +1106,18 @@ def _json_float_or_none(value: object | None) -> float | None:
         except ValueError:
             return None
     return None
+
+
+def _run_result_payload(result: RunResult) -> JSONDocument:
+    return require_json_document(result.model_dump(mode="json"), context="pipeline probe result")
+
+
+def _json_string_sequence(value: list[str] | None) -> list[JSONValue] | None:
+    if value is None:
+        return None
+    result: list[JSONValue] = []
+    result.extend(value)
+    return result
 
 
 async def run_probe(request: PipelineProbeRequest) -> ProbeSummary:
@@ -1076,7 +1165,7 @@ async def run_probe(request: PipelineProbeRequest) -> ProbeSummary:
                 stage_sequence=stage_sequence,
                 source_names=[provider_name],
             )
-        result_payload = result.model_dump()
+        result_payload = _run_result_payload(result)
 
         summary = {
             "probe": {
@@ -1084,7 +1173,7 @@ async def run_probe(request: PipelineProbeRequest) -> ProbeSummary:
                 "provider": provider_name,
                 "corpus_source": corpus_request.source_kind.value,
                 "stage": request.stage,
-                "stage_sequence": stage_sequence,
+                "stage_sequence": _json_string_sequence(stage_sequence),
                 "count": corpus_request.count,
                 "messages_min": corpus_request.messages_min,
                 "messages_max": corpus_request.messages_max,
@@ -1139,14 +1228,14 @@ async def run_probe(request: PipelineProbeRequest) -> ProbeSummary:
                 stage_sequence=stage_sequence,
                 source_names=[source_name],
             )
-        result_payload = result.model_dump()
+        result_payload = _run_result_payload(result)
 
         summary = {
             "probe": {
                 "input_mode": "source-subset",
                 "source_name": source_name,
                 "stage": request.stage,
-                "stage_sequence": stage_sequence,
+                "stage_sequence": _json_string_sequence(stage_sequence),
                 "raw_batch_size": request.raw_batch_size,
                 "ingest_workers": request.ingest_workers,
                 "measure_ingest_result_size": request.measure_ingest_result_size,
@@ -1213,7 +1302,7 @@ async def run_probe(request: PipelineProbeRequest) -> ProbeSummary:
                 )
             finally:
                 await repository.close()
-        result_payload = result.model_dump()
+        result_payload = _run_result_payload(result)
 
         summary = {
             "probe": {
@@ -1221,8 +1310,8 @@ async def run_probe(request: PipelineProbeRequest) -> ProbeSummary:
                 "stage": request.stage,
                 "seed": resolved_corpus_request.seed,
                 "sample_per_provider": sample_per_provider,
-                "provider_filters": provider_filters,
-                "source_filters": source_filters,
+                "provider_filters": _json_string_sequence(provider_filters),
+                "source_filters": _json_string_sequence(source_filters),
                 "raw_batch_size": request.raw_batch_size,
                 "ingest_workers": request.ingest_workers,
                 "measure_ingest_result_size": request.measure_ingest_result_size,

--- a/devtools/query_memory_budget.py
+++ b/devtools/query_memory_budget.py
@@ -11,7 +11,15 @@ import json
 import subprocess
 import time
 from pathlib import Path
-from typing import cast
+from typing import TypedDict
+
+
+class MemoryBudgetResult(TypedDict):
+    command: list[str]
+    exit_code: int
+    max_rss_mb: int
+    peak_rss_mb: float
+    within_budget: bool
 
 
 def _read_vm_rss_kb(pid: int) -> int:
@@ -28,7 +36,7 @@ def _read_vm_rss_kb(pid: int) -> int:
     return 0
 
 
-def run_memory_budget(command: list[str], *, max_rss_mb: int, poll_interval_s: float = 0.05) -> dict[str, object]:
+def run_memory_budget(command: list[str], *, max_rss_mb: int, poll_interval_s: float = 0.05) -> MemoryBudgetResult:
     """Execute a command and track peak RSS."""
     proc = subprocess.Popen(command)
     peak_rss_kb = 0
@@ -75,8 +83,8 @@ def main(argv: list[str] | None = None) -> int:
     result = run_memory_budget(command, max_rss_mb=args.max_rss_mb)
     print(json.dumps(result, indent=2, sort_keys=True))
 
-    exit_code = cast(int, result["exit_code"])
-    within_budget = cast(bool, result["within_budget"])
+    exit_code = result["exit_code"]
+    within_budget = result["within_budget"]
     if exit_code != 0:
         return exit_code
     return 0 if within_budget else 3

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -103,8 +103,6 @@ Options:
                                   --latest or -i ID. Incompatible with
                                   --transform
   -d, --dialogue-only             Show only user/assistant messages
-  -u, --user-only                 Show only user messages (subset of
-                                  --dialogue-only)
   --set TEXT...                   Set metadata key value
   --add-tag TEXT                  Add tags (comma-separated)
   --plain                         Force non-interactive plain output

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -103,6 +103,8 @@ Options:
                                   --latest or -i ID. Incompatible with
                                   --transform
   -d, --dialogue-only             Show only user/assistant messages
+  -u, --user-only                 Show only user messages (subset of
+                                  --dialogue-only)
   --set TEXT...                   Set metadata key value
   --add-tag TEXT                  Add tags (comma-separated)
   --plain                         Force non-interactive plain output

--- a/polylogue/cli/click_option_groups.py
+++ b/polylogue/cli/click_option_groups.py
@@ -32,8 +32,8 @@ def _complete_providers(
 
 def _validate_provider_tokens(
     ctx: click.Context,
-    param: click.Parameter,
-    value: str | None,  # noqa: ARG001
+    _param: click.Parameter,
+    value: str | None,
 ) -> str | None:
     if not value:
         return value

--- a/polylogue/cli/embed_runtime.py
+++ b/polylogue/cli/embed_runtime.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Protocol, cast
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 import click
 
@@ -34,6 +34,7 @@ class _EmbedUI(Protocol):
     def progress(self, description: str, total: int = 0) -> _ProgressHandle: ...
 
 
+@runtime_checkable
 class _HasUI(Protocol):
     ui: _EmbedUI
 
@@ -96,7 +97,9 @@ def embed_batch(
     from polylogue.storage.backends.connection import open_read_connection
     from polylogue.sync_bridge import run_coroutine_sync
 
-    ui = cast(_HasUI, env).ui
+    if not isinstance(env, _HasUI):
+        raise TypeError(f"Embedding environment must expose ui, got {type(env).__name__}")
+    ui = env.ui
     backend = repo.backend
     conv_ids: list[tuple[str, str | None]] = []
     with open_read_connection(backend.db_path) as conn:

--- a/polylogue/cli/machine_errors.py
+++ b/polylogue/cli/machine_errors.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import sys
 from collections.abc import Mapping
 
+from polylogue.lib.json import JSONDocument, require_json_document
 from polylogue.surface_payloads import (
     MachineErrorPayload,
     MachineSuccessPayload,
@@ -32,12 +33,15 @@ class MachineSuccess(MachineSuccessPayload):
 
 def _normalize_result_payload(
     result: Mapping[str, object] | MachineSuccessPayload | None,
-) -> dict[str, object]:
+) -> JSONDocument:
     if result is None:
         return {}
     if isinstance(result, MachineSuccessPayload):
-        return result.result
-    return {str(key): value for key, value in result.items()}
+        return require_json_document(result.result, context="machine success result")
+    return require_json_document(
+        {str(key): value for key, value in result.items()},
+        context="machine success result",
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -51,7 +55,7 @@ def error_invalid_arguments(
     command: list[str] | None = None,
     option: str | None = None,
 ) -> MachineError:
-    details: dict[str, object] = {}
+    details: JSONDocument = {}
     if option:
         details["option"] = option
     return MachineError(
@@ -68,7 +72,7 @@ def error_invalid_path(
     command: list[str] | None = None,
     path: str | None = None,
 ) -> MachineError:
-    details: dict[str, object] = {}
+    details: JSONDocument = {}
     if path:
         details["path"] = path
     return MachineError(
@@ -85,7 +89,7 @@ def error_runtime(
     command: list[str] | None = None,
     exception_type: str | None = None,
 ) -> MachineError:
-    details: dict[str, object] = {}
+    details: JSONDocument = {}
     if exception_type:
         details["exception_type"] = exception_type
     return MachineError(
@@ -102,7 +106,7 @@ def error_dependency_missing(
     command: list[str] | None = None,
     dependency: str | None = None,
 ) -> MachineError:
-    details: dict[str, object] = {}
+    details: JSONDocument = {}
     if dependency:
         details["dependency"] = dependency
     return MachineError(
@@ -131,7 +135,7 @@ def error_no_results(
     command: list[str] | None = None,
     filters: list[str] | None = None,
 ) -> MachineError:
-    details: dict[str, object] = {}
+    details: JSONDocument = {}
     if filters:
         details["filters"] = list(filters)
     return MachineError(

--- a/polylogue/cli/query.py
+++ b/polylogue/cli/query.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import inspect
 from collections.abc import Awaitable, Iterable, Sequence
-from typing import TYPE_CHECKING, Protocol, TypeVar, cast
+from typing import TYPE_CHECKING, Protocol, TypeVar, overload
 
 import click
 
@@ -58,10 +58,18 @@ class ShowStatsCallback(Protocol):
     def __call__(self, env: AppEnv, *, verbose: bool = False) -> None: ...
 
 
-async def _resolve_maybe_awaitable(value: _T | object) -> _T:
+@overload
+async def _resolve_maybe_awaitable(value: Awaitable[_T]) -> _T: ...
+
+
+@overload
+async def _resolve_maybe_awaitable(value: _T) -> _T: ...
+
+
+async def _resolve_maybe_awaitable(value: Awaitable[_T] | _T) -> _T:
     if inspect.isawaitable(value):
-        return await cast(Awaitable[_T], value)
-    return cast(_T, value)
+        return await value
+    return value
 
 
 def no_results(
@@ -317,7 +325,7 @@ async def async_execute_query_request(env: AppEnv, request: RootModeRequest) -> 
     except ConfigError as exc:
         fail("query", str(exc))
 
-    repo = cast("QueryExecutionStore", env.repository)
+    repo: QueryExecutionStore = env.repository
 
     vector_provider = _create_query_vector_provider(config)
 

--- a/polylogue/cli/run_observers.py
+++ b/polylogue/cli/run_observers.py
@@ -6,7 +6,7 @@ import re
 import time
 from collections.abc import Iterator
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 from polylogue.cli.formatting import format_counts
 from polylogue.cli.types import AppEnv
@@ -14,7 +14,6 @@ from polylogue.pipeline.observers import RunObserver
 from polylogue.storage.run_state import RunResult
 
 if TYPE_CHECKING:
-    from rich.console import Console
     from rich.progress import Progress, TaskID
 
 _PROGRESS_FRACTION_RE = re.compile(r"(?P<completed>\d[\d,]*)/(?P<total>\d[\d,]*)")
@@ -90,9 +89,9 @@ class RichProgressObserver(RunObserver):
 
     __slots__ = ("_progress", "_task_id")
 
-    def __init__(self, progress: Progress, task_id: object) -> None:
+    def __init__(self, progress: Progress, task_id: TaskID) -> None:
         self._progress = progress
-        self._task_id = cast("TaskID", task_id)
+        self._task_id = task_id
 
     @staticmethod
     def _progress_bounds(desc: str | None) -> tuple[int, int] | None:
@@ -145,7 +144,10 @@ def progress_observer(
         yield PlainProgressObserver(banner=plain_banner)
         return
 
+    from rich.console import Console
     from rich.progress import BarColumn, Progress, SpinnerColumn, TextColumn, TimeRemainingColumn
+
+    console = env.ui.console if isinstance(env.ui.console, Console) else None
 
     with Progress(
         SpinnerColumn(),
@@ -153,7 +155,7 @@ def progress_observer(
         BarColumn(),
         TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
         TimeRemainingColumn(),
-        console=cast("Console", env.ui.console),
+        console=console,
         transient=True,
     ) as progress:
         task_id = progress.add_task(initial_desc, total=None)

--- a/polylogue/cli/schema_command_support.py
+++ b/polylogue/cli/schema_command_support.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import cast
 
 from polylogue.schemas.operator_models import JSONDocument
 from polylogue.schemas.privacy_config import PrivacyConfig, PrivacyConfigSection, PrivacyLevel
@@ -26,6 +25,16 @@ def _privacy_config_payload(config: PrivacyConfig) -> JSONDocument:
     return payload
 
 
+def _privacy_level(value: str) -> PrivacyLevel:
+    if value == "strict":
+        return "strict"
+    if value == "standard":
+        return "standard"
+    if value == "permissive":
+        return "permissive"
+    return "standard"
+
+
 def build_schema_privacy_config(
     *,
     privacy: str | None,
@@ -44,8 +53,8 @@ def build_schema_privacy_config(
                 project_path=privacy_config_path.parent,
             )
         )
-    if cli_overrides:
-        return _privacy_config_payload(PrivacyConfig(level=cast(PrivacyLevel, privacy)))
+    if privacy is not None:
+        return _privacy_config_payload(PrivacyConfig(level=_privacy_level(privacy)))
     return None
 
 

--- a/polylogue/lib/conversation_runtime.py
+++ b/polylogue/lib/conversation_runtime.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections import defaultdict
 from collections.abc import Callable, Iterator, Mapping
 from datetime import datetime
-from typing import TYPE_CHECKING, Self, cast
+from typing import TYPE_CHECKING, Self
 
 from polylogue.lib.branch_type import BranchType
 from polylogue.lib.message_models import DialoguePair, Message
@@ -13,7 +13,6 @@ from polylogue.lib.messages import MessageCollection
 from polylogue.types import ConversationId
 
 if TYPE_CHECKING:
-    from polylogue.lib.conversation_models import Conversation
     from polylogue.lib.projections import ConversationProjection
 
 
@@ -193,9 +192,12 @@ class ConversationRuntimeMixin:
         return _coerce_optional_int(self.provider_meta.get("total_duration_ms")) or 0
 
     def project(self) -> ConversationProjection:
+        from polylogue.lib.conversation_models import Conversation
         from polylogue.lib.projections import ConversationProjection
 
-        return ConversationProjection(cast("Conversation", self))
+        if not isinstance(self, Conversation):
+            raise TypeError(f"projection requires Conversation, got {type(self).__name__}")
+        return ConversationProjection(self)
 
 
 __all__ = ["ConversationRuntimeMixin"]

--- a/polylogue/lib/dates.py
+++ b/polylogue/lib/dates.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
-import dateparser  # type: ignore[import-untyped]
+import dateparser
 
 
 def parse_date(date_str: str) -> datetime | None:

--- a/polylogue/lib/filter_builder.py
+++ b/polylogue/lib/filter_builder.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import replace
 from datetime import datetime
-from typing import TYPE_CHECKING, Protocol, Self, TypeVar, cast
+from typing import TYPE_CHECKING, Protocol, Self, TypeVar
 
 from polylogue.lib.dates import parse_date
 from polylogue.lib.filter_types import SortField
@@ -21,6 +21,7 @@ class _HasQueryPlan(Protocol):
 
 
 _PlanOwner = TypeVar("_PlanOwner", bound=_HasQueryPlan)
+_ReplacePlan: Callable[..., ConversationQueryPlan] = replace
 
 
 def _extend_tuple(values: tuple[_T, ...], additions: tuple[_T, ...]) -> tuple[_T, ...]:
@@ -34,8 +35,7 @@ def _replace_plan(
     plan = filter_obj._plan
     # dataclasses.replace is typed per field and cannot express this fluent
     # builder's one-field-at-a-time updates.
-    replace_plan = cast("Callable[..., ConversationQueryPlan]", replace)
-    filter_obj._plan = replace_plan(plan, **changes)
+    filter_obj._plan = _ReplacePlan(plan, **changes)
     return filter_obj
 
 

--- a/polylogue/lib/json.py
+++ b/polylogue/lib/json.py
@@ -37,6 +37,13 @@ def json_document(value: object) -> JSONDocument:
     return value if is_json_document(value) else {}
 
 
+def require_json_value(value: object, *, context: str = "JSON value") -> JSONValue:
+    """Return a JSON value or raise when a producer violates the contract."""
+    if is_json_value(value):
+        return value
+    raise TypeError(f"{context} is not JSON-compatible")
+
+
 def require_json_document(value: object, *, context: str = "JSON document") -> JSONDocument:
     """Return a JSON document or raise when a producer violates the contract."""
     if is_json_document(value):
@@ -129,4 +136,5 @@ __all__ = [
     "json_document_list",
     "loads",
     "require_json_document",
+    "require_json_value",
 ]

--- a/polylogue/lib/json.py
+++ b/polylogue/lib/json.py
@@ -37,6 +37,13 @@ def json_document(value: object) -> JSONDocument:
     return value if is_json_document(value) else {}
 
 
+def require_json_document(value: object, *, context: str = "JSON document") -> JSONDocument:
+    """Return a JSON document or raise when a producer violates the contract."""
+    if is_json_document(value):
+        return value
+    raise TypeError(f"{context} is not a JSON object")
+
+
 def json_document_list(value: object) -> JSONDocumentList:
     """Coerce a value into a list of string-keyed JSON objects."""
     if not isinstance(value, list):
@@ -121,4 +128,5 @@ __all__ = [
     "json_document",
     "json_document_list",
     "loads",
+    "require_json_document",
 ]

--- a/polylogue/lib/messages.py
+++ b/polylogue/lib/messages.py
@@ -9,7 +9,7 @@ used in production.
 from __future__ import annotations
 
 from collections.abc import Iterator, Sized
-from typing import TYPE_CHECKING, Protocol, cast
+from typing import TYPE_CHECKING, Protocol
 
 from pydantic import GetCoreSchemaHandler, GetJsonSchemaHandler
 from pydantic_core import core_schema
@@ -126,8 +126,10 @@ class MessageCollection(Sized):
         """JSON schema: array of Message objects."""
         from polylogue.lib.message_models import Message
 
-        message_handler = cast("_MessageJsonSchemaHandler", handler)
-        return {"type": "array", "items": message_handler.resolve_ref_schema(message_handler.generate(Message))}
+        generate_schema = getattr(handler, "generate", None)
+        if not callable(generate_schema):
+            raise TypeError("Pydantic JSON schema handler does not expose generate()")
+        return {"type": "array", "items": handler.resolve_ref_schema(generate_schema(Message))}
 
 
 __all__ = ["MessageCollection"]

--- a/polylogue/lib/metrics.py
+++ b/polylogue/lib/metrics.py
@@ -11,9 +11,8 @@ import sys
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import cast
 
-from polylogue.lib.json import JSONDocument, JSONValue, is_json_value
+from polylogue.lib.json import JSONDocument, is_json_value, require_json_value
 
 
 def _read_proc_status_kb(field_name: str) -> int | None:
@@ -185,7 +184,7 @@ class PipelineMetrics:
 
     def to_summary(self) -> JSONDocument:
         """Export full metrics for logging/persistence."""
-        slow_items = cast(list[JSONValue], list(self.slow_items.to_list()))
+        slow_items = require_json_value(list(self.slow_items.to_list()), context="pipeline slow-item metrics")
         return {
             "total_duration_ms": round(self.total_elapsed_s * 1000, 1),
             "current_rss_mb": read_current_rss_mb(),

--- a/polylogue/lib/provider_semantics.py
+++ b/polylogue/lib/provider_semantics.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 
 from polylogue.lib.json import JSONDocument, json_document
 from polylogue.lib.viewports import (
@@ -33,7 +33,7 @@ def content_text(value: object) -> str | None:
     return None
 
 
-def _string_field(block: JSONDocument, key: str) -> str | None:
+def _string_field(block: Mapping[str, object], key: str) -> str | None:
     value = block.get(key)
     return value if isinstance(value, str) else None
 
@@ -45,7 +45,7 @@ def _content_block_record(value: object) -> JSONDocument | None:
     return None
 
 
-def extract_reasoning_traces(content: list[JSONDocument] | None, provider: Provider | str) -> list[ReasoningTrace]:
+def extract_reasoning_traces(content: Sequence[object] | None, provider: Provider | str) -> list[ReasoningTrace]:
     """Extract reasoning traces from provider content blocks."""
     if not content:
         return []
@@ -69,7 +69,7 @@ def extract_reasoning_traces(content: list[JSONDocument] | None, provider: Provi
     return traces
 
 
-def extract_tool_calls(content: list[JSONDocument] | None, provider: Provider | str) -> list[ToolCall]:
+def extract_tool_calls(content: Sequence[object] | None, provider: Provider | str) -> list[ToolCall]:
     """Extract tool calls from provider content blocks."""
     if not content:
         return []
@@ -99,7 +99,7 @@ def extract_tool_calls(content: list[JSONDocument] | None, provider: Provider | 
     return calls
 
 
-def extract_content_blocks(content: list[JSONDocument] | None) -> list[ContentBlock]:
+def extract_content_blocks(content: Sequence[object] | None) -> list[ContentBlock]:
     """Extract harmonized content blocks with type classification."""
     if not content:
         return []
@@ -156,7 +156,7 @@ def extract_content_blocks(content: list[JSONDocument] | None) -> list[ContentBl
     return blocks
 
 
-def extract_display_text_from_content_blocks(content: list[JSONDocument] | None) -> str:
+def extract_display_text_from_content_blocks(content: Sequence[object] | None) -> str:
     """Rebuild human-readable text from stored structured content blocks."""
     if not content:
         return ""
@@ -174,7 +174,7 @@ def extract_display_text_from_content_blocks(content: list[JSONDocument] | None)
     return "\n".join(parts)
 
 
-def extract_claude_code_text(content: list[JSONDocument] | None) -> str:
+def extract_claude_code_text(content: Sequence[object] | None) -> str:
     """Extract text from Claude Code content blocks, excluding non-text blocks."""
     if not content:
         return ""
@@ -191,7 +191,7 @@ def extract_claude_code_text(content: list[JSONDocument] | None) -> str:
     return "\n".join(filter(None, parts))
 
 
-def extract_chatgpt_text(content: JSONDocument | None) -> str:
+def extract_chatgpt_text(content: Mapping[str, object] | None) -> str:
     """Extract text from ChatGPT content structures."""
     if not content:
         return ""
@@ -212,7 +212,7 @@ def extract_chatgpt_text(content: JSONDocument | None) -> str:
     return "\n".join(texts)
 
 
-def extract_codex_text(content: list[JSONDocument] | None) -> str:
+def extract_codex_text(content: Sequence[object] | None) -> str:
     """Extract text from Codex content blocks."""
     if not content or not isinstance(content, list):
         return ""

--- a/polylogue/lib/query_spec.py
+++ b/polylogue/lib/query_spec.py
@@ -6,7 +6,7 @@ import builtins
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, replace
 from datetime import datetime
-from typing import TYPE_CHECKING, TypeVar, cast
+from typing import TYPE_CHECKING, TypeVar
 
 from polylogue.lib.dates import parse_date
 from polylogue.lib.filter_types import SortField
@@ -125,7 +125,19 @@ def optional_sort_field(value: object) -> SortField | None:
     candidate = optional_text(value)
     if candidate is None:
         return None
-    return cast(SortField, candidate)
+    if candidate == "date":
+        return "date"
+    if candidate == "tokens":
+        return "tokens"
+    if candidate == "messages":
+        return "messages"
+    if candidate == "words":
+        return "words"
+    if candidate == "longest":
+        return "longest"
+    if candidate == "random":
+        return "random"
+    raise QuerySpecError("sort", candidate)
 
 
 # ---------------------------------------------------------------------------

--- a/polylogue/lib/raw_payload_decode.py
+++ b/polylogue/lib/raw_payload_decode.py
@@ -2,36 +2,20 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator
-from contextlib import contextmanager
 from dataclasses import dataclass
-from io import BytesIO, StringIO
 from pathlib import Path
-from typing import IO, Literal, TypeAlias
+from typing import Literal, TypeAlias
 
 import orjson
 
 from polylogue.lib.artifact_taxonomy import ArtifactClassification, classify_artifact
 from polylogue.lib.json import JSONDocument, JSONValue, is_json_value, loads
+from polylogue.lib.raw_payload_streams import raw_line_stream
 from polylogue.sources.dispatch import detect_provider
 from polylogue.types import Provider
 
 WireFormat = Literal["json", "jsonl"]
 JSONRecord: TypeAlias = JSONDocument
-
-
-@contextmanager
-def _raw_line_stream(raw: Path | bytes | str) -> Iterator[IO[bytes] | IO[str]]:
-    if isinstance(raw, Path):
-        with raw.open("rb") as stream:
-            yield stream
-        return
-    if isinstance(raw, bytes):
-        with BytesIO(raw) as stream:
-            yield stream
-        return
-    with StringIO(raw) as stream:
-        yield stream
 
 
 def _load_json_record(line: str) -> JSONValue:
@@ -66,7 +50,7 @@ def _decode_jsonl_payload(
     first_line = True
     line_number = 0
 
-    with _raw_line_stream(raw) as stream:
+    with raw_line_stream(raw) as stream:
         for raw_line in stream:
             line_number += 1
             try:
@@ -117,7 +101,7 @@ def _sample_jsonl_payload_with_detail(
     first_line = True
     line_number = 0
 
-    with _raw_line_stream(raw) as stream:
+    with raw_line_stream(raw) as stream:
         for raw_line in stream:
             line_number += 1
             try:

--- a/polylogue/lib/raw_payload_decode.py
+++ b/polylogue/lib/raw_payload_decode.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
 from io import BytesIO, StringIO
 from pathlib import Path
-from typing import Literal, TypeAlias
+from typing import IO, Literal, TypeAlias
 
 import orjson
 
@@ -16,6 +18,20 @@ from polylogue.types import Provider
 
 WireFormat = Literal["json", "jsonl"]
 JSONRecord: TypeAlias = JSONDocument
+
+
+@contextmanager
+def _raw_line_stream(raw: Path | bytes | str) -> Iterator[IO[bytes] | IO[str]]:
+    if isinstance(raw, Path):
+        with raw.open("rb") as stream:
+            yield stream
+        return
+    if isinstance(raw, bytes):
+        with BytesIO(raw) as stream:
+            yield stream
+        return
+    with StringIO(raw) as stream:
+        yield stream
 
 
 def _load_json_record(line: str) -> JSONValue:
@@ -50,16 +66,8 @@ def _decode_jsonl_payload(
     first_line = True
     line_number = 0
 
-    fh = (
-        open(raw, "rb")  # noqa: SIM115 — caller-managed context
-        if isinstance(raw, Path)
-        else BytesIO(raw)
-        if isinstance(raw, bytes)
-        else StringIO(raw)
-    )
-
-    try:
-        for raw_line in fh:
+    with _raw_line_stream(raw) as stream:
+        for raw_line in stream:
             line_number += 1
             try:
                 line = raw_line.decode("utf-8") if isinstance(raw_line, bytes) else raw_line
@@ -84,9 +92,6 @@ def _decode_jsonl_payload(
             if jsonl_dict_only and not isinstance(parsed, dict):
                 continue
             lines.append(parsed)
-    finally:
-        if isinstance(raw, Path):
-            fh.close()
 
     if not lines:
         raise ValueError("No valid JSONL records found")
@@ -112,16 +117,8 @@ def _sample_jsonl_payload_with_detail(
     first_line = True
     line_number = 0
 
-    fh = (
-        open(raw, "rb")  # noqa: SIM115 — caller-managed context
-        if isinstance(raw, Path)
-        else BytesIO(raw)
-        if isinstance(raw, bytes)
-        else StringIO(raw)
-    )
-
-    try:
-        for raw_line in fh:
+    with _raw_line_stream(raw) as stream:
+        for raw_line in stream:
             line_number += 1
             try:
                 line = raw_line.decode("utf-8") if isinstance(raw_line, bytes) else raw_line
@@ -148,9 +145,6 @@ def _sample_jsonl_payload_with_detail(
             valid_records += 1
             if len(samples) < max_samples:
                 samples.append(parsed)
-    finally:
-        if isinstance(raw, Path):
-            fh.close()
 
     if valid_records == 0:
         raise ValueError("No valid JSONL records found")

--- a/polylogue/lib/raw_payload_sampling_extract.py
+++ b/polylogue/lib/raw_payload_sampling_extract.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from collections import Counter
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Iterator
+from contextlib import contextmanager
 from io import BytesIO, StringIO
 from pathlib import Path
 from typing import IO, Literal
@@ -15,6 +16,20 @@ from polylogue.lib.raw_payload_sampling_buckets import (
     record_bucket_key,
     take_bucketed_samples,
 )
+
+
+@contextmanager
+def _raw_line_stream(raw: Path | bytes | str) -> Iterator[IO[bytes] | IO[str]]:
+    if isinstance(raw, Path):
+        with raw.open("rb") as stream:
+            yield stream
+        return
+    if isinstance(raw, bytes):
+        with BytesIO(raw) as stream:
+            yield stream
+        return
+    with StringIO(raw) as stream:
+        yield stream
 
 
 def limit_samples(
@@ -157,18 +172,11 @@ def extract_record_samples_from_raw_content(
             record_type_key=record_type_key,
         )
 
-    stream: IO[bytes] | IO[str]
-    if isinstance(raw_content, Path):
-        stream = open(raw_content, "rb")  # noqa: SIM115 — caller-managed context
-    else:
-        raw = raw_content if isinstance(raw_content, (bytes, str)) else str(raw_content)
-        stream = BytesIO(raw) if isinstance(raw, bytes) else StringIO(raw)
-
-    # Full-corpus mode: collect everything without caps.
-    if max_samples is None:
-        all_records: list[JSONDocument] = []
-        first_line = True
-        try:
+    with _raw_line_stream(raw_content) as stream:
+        # Full-corpus mode: collect everything without caps.
+        if max_samples is None:
+            all_records: list[JSONDocument] = []
+            first_line = True
             for raw_line in stream:
                 line = raw_line.decode("utf-8") if isinstance(raw_line, bytes) else raw_line
                 if first_line:
@@ -184,19 +192,15 @@ def extract_record_samples_from_raw_content(
                 record = json_document(parsed)
                 if record and is_record_candidate(record):
                     all_records.append(record)
-        finally:
-            if isinstance(raw_content, Path):
-                stream.close()
-        return all_records
+            return all_records
 
-    lines: list[JSONDocument] = []
-    buckets: dict[str, list[JSONDocument]] = {}
-    dict_count = 0
-    scan_cap = max(1024, max_samples * 64)
-    per_bucket_cap = 8
-    first_line = True
+        lines: list[JSONDocument] = []
+        buckets: dict[str, list[JSONDocument]] = {}
+        dict_count = 0
+        scan_cap = max(1024, max_samples * 64)
+        per_bucket_cap = 8
+        first_line = True
 
-    try:
         for raw_line in stream:
             line = raw_line.decode("utf-8") if isinstance(raw_line, bytes) else raw_line
             if first_line:
@@ -221,15 +225,12 @@ def extract_record_samples_from_raw_content(
                 bucket.append(record)
             if dict_count >= scan_cap:
                 break
-    finally:
-        if isinstance(raw_content, Path):
-            stream.close()
 
-    if dict_count == 0:
-        return []
-    if dict_count <= max_samples:
-        return lines
-    return take_bucketed_samples(buckets, max_samples)
+        if dict_count == 0:
+            return []
+        if dict_count <= max_samples:
+            return lines
+        return take_bucketed_samples(buckets, max_samples)
 
 
 __all__ = [

--- a/polylogue/lib/raw_payload_sampling_extract.py
+++ b/polylogue/lib/raw_payload_sampling_extract.py
@@ -3,11 +3,9 @@
 from __future__ import annotations
 
 from collections import Counter
-from collections.abc import Callable, Iterable, Iterator
-from contextlib import contextmanager
-from io import BytesIO, StringIO
+from collections.abc import Callable, Iterable
 from pathlib import Path
-from typing import IO, Literal
+from typing import Literal
 
 from polylogue.lib.json import JSONDocument, JSONValue, json_document, loads
 from polylogue.lib.raw_payload_sampling_buckets import (
@@ -16,20 +14,7 @@ from polylogue.lib.raw_payload_sampling_buckets import (
     record_bucket_key,
     take_bucketed_samples,
 )
-
-
-@contextmanager
-def _raw_line_stream(raw: Path | bytes | str) -> Iterator[IO[bytes] | IO[str]]:
-    if isinstance(raw, Path):
-        with raw.open("rb") as stream:
-            yield stream
-        return
-    if isinstance(raw, bytes):
-        with BytesIO(raw) as stream:
-            yield stream
-        return
-    with StringIO(raw) as stream:
-        yield stream
+from polylogue.lib.raw_payload_streams import raw_line_stream
 
 
 def limit_samples(
@@ -172,7 +157,7 @@ def extract_record_samples_from_raw_content(
             record_type_key=record_type_key,
         )
 
-    with _raw_line_stream(raw_content) as stream:
+    with raw_line_stream(raw_content) as stream:
         # Full-corpus mode: collect everything without caps.
         if max_samples is None:
             all_records: list[JSONDocument] = []

--- a/polylogue/lib/raw_payload_streams.py
+++ b/polylogue/lib/raw_payload_streams.py
@@ -1,0 +1,26 @@
+"""Shared stream adapters for raw payload readers."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from io import BytesIO, StringIO
+from pathlib import Path
+from typing import IO, TypeAlias
+
+RawLineStream: TypeAlias = IO[bytes] | IO[str]
+
+
+@contextmanager
+def raw_line_stream(raw: Path | bytes | str) -> Iterator[RawLineStream]:
+    """Yield a line stream for path, bytes, or in-memory text payloads."""
+    if isinstance(raw, Path):
+        with raw.open("rb") as stream:
+            yield stream
+        return
+    if isinstance(raw, bytes):
+        with BytesIO(raw) as stream:
+            yield stream
+        return
+    with StringIO(raw) as stream:
+        yield stream

--- a/polylogue/logging.py
+++ b/polylogue/logging.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import logging
 import sys
-from io import TextIOBase
-from typing import Protocol, TextIO, cast, runtime_checkable
+from collections.abc import Iterable, Iterator
+from types import TracebackType
+from typing import BinaryIO, Protocol, TextIO, runtime_checkable
 
 import structlog
 from structlog.types import Processor
@@ -28,7 +29,7 @@ class BoundLoggerLike(Protocol):
     def exception(self, message: str, *args: object, **event_kw: object) -> object: ...
 
 
-class _StderrProxy(TextIOBase):
+class _StderrProxy(TextIO):
     """File-like proxy that always delegates to the current sys.stderr.
 
     structlog's PrintLoggerFactory captures the file object at creation
@@ -40,8 +41,18 @@ class _StderrProxy(TextIOBase):
     def write(self, s: str) -> int:
         return sys.stderr.write(s)
 
+    def writelines(self, lines: Iterable[str]) -> None:
+        sys.stderr.writelines(lines)
+
     def flush(self) -> None:
         sys.stderr.flush()
+
+    def close(self) -> None:
+        sys.stderr.close()
+
+    @property
+    def closed(self) -> bool:
+        return sys.stderr.closed
 
     def isatty(self) -> bool:
         return sys.stderr.isatty()
@@ -49,8 +60,73 @@ class _StderrProxy(TextIOBase):
     def fileno(self) -> int:
         return sys.stderr.fileno()
 
+    def read(self, n: int = -1, /) -> str:
+        return sys.stderr.read(n)
 
-_stderr_proxy = cast(TextIO, _StderrProxy())
+    def readable(self) -> bool:
+        return sys.stderr.readable()
+
+    def readline(self, limit: int = -1, /) -> str:
+        return sys.stderr.readline(limit)
+
+    def readlines(self, hint: int = -1, /) -> list[str]:
+        return sys.stderr.readlines(hint)
+
+    def seek(self, offset: int, whence: int = 0, /) -> int:
+        return sys.stderr.seek(offset, whence)
+
+    def seekable(self) -> bool:
+        return sys.stderr.seekable()
+
+    def tell(self) -> int:
+        return sys.stderr.tell()
+
+    def truncate(self, size: int | None = None, /) -> int:
+        return sys.stderr.truncate(size)
+
+    def writable(self) -> bool:
+        return sys.stderr.writable()
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(sys.stderr)
+
+    def __next__(self) -> str:
+        return next(sys.stderr)
+
+    def __enter__(self) -> TextIO:
+        return self
+
+    def __exit__(
+        self,
+        type: type[BaseException] | None,
+        value: BaseException | None,
+        traceback: TracebackType | None,
+        /,
+    ) -> None:
+        return None
+
+    @property
+    def buffer(self) -> BinaryIO:
+        return sys.stderr.buffer
+
+    @property
+    def encoding(self) -> str:
+        return sys.stderr.encoding
+
+    @property
+    def errors(self) -> str | None:
+        return sys.stderr.errors
+
+    @property
+    def line_buffering(self) -> bool:
+        return bool(sys.stderr.line_buffering)
+
+    @property
+    def newlines(self) -> object:
+        return sys.stderr.newlines
+
+
+_stderr_proxy = _StderrProxy()
 
 
 # Configure structlog

--- a/polylogue/logging.py
+++ b/polylogue/logging.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import sys
+from io import TextIOBase
 from typing import Protocol, TextIO, cast
 
 import structlog
@@ -26,7 +27,7 @@ class BoundLoggerLike(Protocol):
     def exception(self, message: str, *args: object, **event_kw: object) -> object: ...
 
 
-class _StderrProxy:
+class _StderrProxy(TextIOBase):
     """File-like proxy that always delegates to the current sys.stderr.
 
     structlog's PrintLoggerFactory captures the file object at creation

--- a/polylogue/logging.py
+++ b/polylogue/logging.py
@@ -6,13 +6,12 @@ import logging
 import sys
 from collections.abc import Iterable, Iterator
 from types import TracebackType
-from typing import BinaryIO, Protocol, TextIO, runtime_checkable
+from typing import BinaryIO, Protocol, TextIO
 
 import structlog
 from structlog.types import Processor
 
 
-@runtime_checkable
 class BoundLoggerLike(Protocol):
     """Logger methods used by first-party call sites."""
 
@@ -160,7 +159,5 @@ def configure_logging(verbose: bool = False, json_logs: bool = False) -> None:
 
 
 def get_logger(name: str | None = None) -> BoundLoggerLike:
-    logger = structlog.get_logger(name)
-    if not isinstance(logger, BoundLoggerLike):
-        raise TypeError(f"structlog returned {type(logger).__name__}, expected BoundLoggerLike")
+    logger: BoundLoggerLike = structlog.get_logger(name)
     return logger

--- a/polylogue/logging.py
+++ b/polylogue/logging.py
@@ -5,12 +5,13 @@ from __future__ import annotations
 import logging
 import sys
 from io import TextIOBase
-from typing import Protocol, TextIO, cast
+from typing import Protocol, TextIO, cast, runtime_checkable
 
 import structlog
 from structlog.types import Processor
 
 
+@runtime_checkable
 class BoundLoggerLike(Protocol):
     """Logger methods used by first-party call sites."""
 
@@ -83,4 +84,7 @@ def configure_logging(verbose: bool = False, json_logs: bool = False) -> None:
 
 
 def get_logger(name: str | None = None) -> BoundLoggerLike:
-    return cast(BoundLoggerLike, structlog.get_logger(name))
+    logger = structlog.get_logger(name)
+    if not isinstance(logger, BoundLoggerLike):
+        raise TypeError(f"structlog returned {type(logger).__name__}, expected BoundLoggerLike")
+    return logger

--- a/polylogue/mcp/server_support.py
+++ b/polylogue/mcp/server_support.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Protocol, TypeVar, cast, overload
+from typing import TYPE_CHECKING, Protocol, TypeVar, overload
 
 from pydantic import BaseModel
 
@@ -34,10 +34,6 @@ class ErrorJSONSerializer(Protocol):
 
 class FencedCodeExtractor(Protocol):
     def __call__(self, text: str, language: str = "") -> list[MCPFencedCodeBlock]: ...
-
-
-class ToJSONPayload(Protocol):
-    def to_json(self, *, exclude_none: bool = False) -> str: ...
 
 
 @dataclass(frozen=True)
@@ -75,7 +71,10 @@ def _json_payload(payload: BaseModel, *, exclude_none: bool = False) -> str:
     """Serialize a typed MCP payload with canonical JSON formatting."""
     to_json = getattr(payload, "to_json", None)
     if callable(to_json):
-        return cast(ToJSONPayload, payload).to_json(exclude_none=exclude_none)
+        result = to_json(exclude_none=exclude_none)
+        if isinstance(result, str):
+            return result
+        raise TypeError(f"{type(payload).__name__}.to_json() returned {type(result).__name__}, expected str")
     return serialize_surface_payload(payload, exclude_none=exclude_none)
 
 

--- a/polylogue/mcp/server_tools.py
+++ b/polylogue/mcp/server_tools.py
@@ -83,7 +83,7 @@ def register_query_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
         action_text: str | None = None,
         tool: str | None = None,
         exclude_tool: str | None = None,
-        sort: str = "updated",
+        sort: str | None = None,
         has_tool_use: bool = False,
         has_thinking: bool = False,
         min_messages: int | None = None,

--- a/polylogue/pipeline/observers.py
+++ b/polylogue/pipeline/observers.py
@@ -6,6 +6,7 @@ import ipaddress
 import re
 import shlex
 import socket
+import ssl
 from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
@@ -118,6 +119,44 @@ def _validate_webhook_url(url: str) -> None:
             )
 
 
+def _webhook_request_target(url: str) -> tuple[str, str, int, str]:
+    _validate_webhook_url(url)
+    parsed = urlparse(url)
+    if parsed.hostname is None:
+        raise ValueError("Webhook URL must have a hostname")
+    default_port = 443 if parsed.scheme == "https" else 80
+    path = parsed.path or "/"
+    if parsed.query:
+        path = f"{path}?{parsed.query}"
+    return parsed.scheme, parsed.hostname, parsed.port or default_port, path
+
+
+def _post_webhook(url: str, data: bytes) -> None:
+    import http.client
+
+    scheme, host, port, path = _webhook_request_target(url)
+    if scheme == "https":
+        connection: http.client.HTTPConnection = http.client.HTTPSConnection(
+            host,
+            port=port,
+            timeout=10,
+            context=ssl.create_default_context(),
+        )
+    else:
+        connection = http.client.HTTPConnection(host, port=port, timeout=10)
+    try:
+        connection.request(
+            "POST",
+            path,
+            body=data,
+            headers={"Content-Type": "application/json"},
+        )
+        response = connection.getresponse()
+        response.read()
+    finally:
+        connection.close()
+
+
 class WebhookObserver(RunObserver):
     """POST to webhook URL when a run produces conversation changes."""
 
@@ -133,9 +172,6 @@ class WebhookObserver(RunObserver):
             return
         try:
             import json
-            import urllib.request
-
-            _validate_webhook_url(self._url)
 
             data = json.dumps(
                 {
@@ -145,13 +181,7 @@ class WebhookObserver(RunObserver):
                     "changed_conversations": changed_count,
                 }
             ).encode()
-            req = urllib.request.Request(
-                self._url,
-                data=data,
-                headers={"Content-Type": "application/json"},
-                method="POST",
-            )
-            urllib.request.urlopen(req, timeout=10)  # noqa: S310
+            _post_webhook(self._url, data)
         except ValueError as exc:
             logger.warning("Webhook blocked for %s: %s", self._url, exc)
         except Exception as exc:

--- a/polylogue/pipeline/services/acquisition.py
+++ b/polylogue/pipeline/services/acquisition.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 from polylogue.lib.json import JSONDocument
 from polylogue.lib.metrics import read_peak_rss_self_mb
@@ -74,7 +74,9 @@ class AcquisitionService:
         """Visit source raw payloads incrementally without forcing list materialization."""
         result = ScanResult()
         known_mtimes = await self.repository.get_known_source_mtimes()
-        drive_ui = cast("DriveUILike | None", ui)
+        if ui is not None and not isinstance(ui, DriveUILike):
+            raise TypeError(f"Drive acquisition UI must satisfy DriveUILike, got {type(ui).__name__}")
+        drive_ui = ui
 
         async def _consume(record: RawConversationRecord) -> None:
             if on_record is not None:

--- a/polylogue/pipeline/services/acquisition.py
+++ b/polylogue/pipeline/services/acquisition.py
@@ -14,13 +14,13 @@ from polylogue.pipeline.services.acquisition_records import ScanResult
 from polylogue.pipeline.services.acquisition_streams import iter_raw_record_stream
 from polylogue.pipeline.stage_models import AcquireResult
 from polylogue.protocols import ProgressCallback
+from polylogue.sources.drive_types import DriveUILike
 from polylogue.sources.source_acquisition import iter_source_raw_data
 from polylogue.storage.cursor_state import CursorStatePayload
 from polylogue.storage.store import RawConversationRecord
 
 if TYPE_CHECKING:
     from polylogue.config import DriveConfig, Source
-    from polylogue.sources.drive_types import DriveUILike
     from polylogue.storage.backends.async_sqlite import SQLiteBackend
     from polylogue.storage.repository import ConversationRepository
 

--- a/polylogue/pipeline/services/ingest_batch.py
+++ b/polylogue/pipeline/services/ingest_batch.py
@@ -16,10 +16,11 @@ import sqlite3
 import time
 from collections.abc import Iterable, Sequence
 from concurrent.futures import Future, as_completed
+from contextlib import AbstractAsyncContextManager
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol
 
 from polylogue.lib.metrics import (
     read_current_rss_mb,
@@ -50,6 +51,8 @@ from polylogue.storage.raw_state_models import RawConversationStateUpdate
 from polylogue.storage.store import RawConversationRecord
 
 if TYPE_CHECKING:
+    import aiosqlite
+
     from polylogue.pipeline.services.parsing import ParsingService
     from polylogue.pipeline.services.parsing_models import ParseResult
     from polylogue.protocols import ProgressCallback
@@ -61,6 +64,23 @@ _DEFAULT_INGEST_WORKER_LIMIT = 8
 _INGEST_SOFT_BLOB_LIMIT_BYTES = 48 * 1024 * 1024
 _INGEST_HIGH_BLOB_LIMIT_BYTES = 96 * 1024 * 1024
 _INGEST_EXTREME_BLOB_LIMIT_BYTES = 256 * 1024 * 1024
+
+
+class _RawStateRepositoryLike(Protocol):
+    async def update_raw_state(self, raw_id: str, *, state: RawConversationStateUpdate) -> object: ...
+
+
+class _ParsingServiceRawStateLike(Protocol):
+    @property
+    def repository(self) -> _RawStateRepositoryLike: ...
+
+
+class _BulkConnectionBackendLike(Protocol):
+    def bulk_connection(self) -> AbstractAsyncContextManager[object]: ...
+
+
+class _ConnectionBackendLike(Protocol):
+    def connection(self) -> AbstractAsyncContextManager[aiosqlite.Connection]: ...
 
 
 @dataclass(slots=True)
@@ -1091,8 +1111,8 @@ def _failed_raw_state_update(
 
 
 async def _persist_batch_raw_state_updates(
-    service: ParsingService,
-    backend: SQLiteBackend,
+    service: _ParsingServiceRawStateLike,
+    backend: _BulkConnectionBackendLike,
     *,
     outcomes: dict[str, _RawIngestOutcome],
     succeeded_raw_ids: set[str],
@@ -1136,7 +1156,7 @@ async def _persist_batch_raw_state_updates(
 
 
 async def refresh_session_products_bulk(
-    backend: SQLiteBackend,
+    backend: _ConnectionBackendLike,
     changed_conversation_ids: list[str],
 ) -> MaterializeStageObservation | None:
     """Bulk session product refresh — once after all batches, not per-batch."""

--- a/polylogue/readiness.py
+++ b/polylogue/readiness.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib.util
 import os
 import shutil
 import sqlite3
@@ -104,6 +105,10 @@ def _open_readiness_probe_connection(db_path: Path) -> AbstractContextManager[sq
     from polylogue.storage.backends.connection import open_read_connection
 
     return open_read_connection(db_path)
+
+
+def _module_available(module_name: str) -> bool:
+    return importlib.util.find_spec(module_name) is not None
 
 
 def _config_path_checks(config: Config) -> list[ReadinessCheck]:
@@ -409,11 +414,9 @@ def run_runtime_readiness(config: Config) -> ReadinessReport:
             ReadinessCheck("fts_tables", VerifyStatus.ERROR, summary=f"FTS check failed: {_summarize_db_error(exc)}")
         )
 
-    try:
-        import sqlite_vec  # noqa: F401
-
+    if _module_available("sqlite_vec"):
         checks.append(ReadinessCheck("sqlite_vec", VerifyStatus.OK, summary="sqlite-vec extension available"))
-    except ImportError:
+    else:
         checks.append(
             ReadinessCheck(
                 "sqlite_vec", VerifyStatus.WARNING, summary="sqlite-vec not installed (vector search unavailable)"
@@ -470,18 +473,8 @@ def run_runtime_readiness(config: Config) -> ReadinessReport:
         term_detail += ", POLYLOGUE_FORCE_PLAIN=1"
     checks.append(ReadinessCheck("terminal", VerifyStatus.OK, summary=term_detail))
 
-    try:
-        import rich  # noqa: F401
-
-        rich_ok = True
-    except ImportError:
-        rich_ok = False
-    try:
-        import textual  # noqa: F401
-
-        textual_ok = True
-    except ImportError:
-        textual_ok = False
+    rich_ok = _module_available("rich")
+    textual_ok = _module_available("textual")
     checks.append(
         ReadinessCheck(
             "ui_libraries",

--- a/polylogue/scenarios/payloads.py
+++ b/polylogue/scenarios/payloads.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import Mapping
-from typing import TypeAlias, cast
+from typing import TypeAlias
 
 PayloadDict: TypeAlias = dict[str, object]
 PayloadMap: TypeAlias = Mapping[str, object]
@@ -85,7 +85,7 @@ def payload_mapping(value: object) -> PayloadMap | None:
         return None
     if not all(isinstance(key, str) for key in value):
         return None
-    return cast(PayloadMap, value)
+    return {str(key): item for key, item in value.items()}
 
 
 def canonical_payload_json(payload: PayloadMap) -> str:

--- a/polylogue/schemas/code_detection_tree_sitter.py
+++ b/polylogue/schemas/code_detection_tree_sitter.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib.util
 from collections.abc import Callable, Sequence
 from functools import lru_cache
 from typing import Protocol, cast
@@ -32,12 +33,7 @@ class TreeSitterNodeLike(Protocol):
 @lru_cache(maxsize=1)
 def tree_sitter_available() -> bool:
     """Check if the tree-sitter Python bindings are importable."""
-    try:
-        import tree_sitter  # noqa: F401
-
-        return True
-    except ImportError:
-        return False
+    return importlib.util.find_spec("tree_sitter") is not None
 
 
 @lru_cache(maxsize=32)

--- a/polylogue/schemas/code_detection_tree_sitter.py
+++ b/polylogue/schemas/code_detection_tree_sitter.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import importlib.util
-from collections.abc import Callable, Sequence
+from collections.abc import Sequence
 from functools import lru_cache
-from typing import Protocol, cast
+from typing import Protocol, TypeGuard
 
 _TS_GRAMMAR_MAP: dict[str, str] = {
     "python": "tree_sitter_python",
@@ -28,6 +28,17 @@ class TreeSitterNodeLike(Protocol):
     type: str
     is_missing: bool
     children: Sequence[TreeSitterNodeLike]
+
+
+def _is_node_like(node: object) -> TypeGuard[TreeSitterNodeLike]:
+    type_attr = "type"
+    missing_attr = "is_missing"
+    try:
+        node_type = getattr(node, type_attr)
+        is_missing = getattr(node, missing_attr)
+    except AttributeError:
+        return False
+    return hasattr(node, "children") and isinstance(node_type, str) and isinstance(is_missing, bool)
 
 
 @lru_cache(maxsize=1)
@@ -55,8 +66,8 @@ def get_ts_language(lang: str) -> object | None:
         lang_fn = getattr(mod, "language", None)
         if not callable(lang_fn):
             return None
-        language_factory = cast(Callable[[], object], lang_fn)
-        return cast(object, Language(language_factory()))
+        language: object = Language(lang_fn())
+        return language
     except Exception:
         return None
 
@@ -84,7 +95,10 @@ def ts_error_ratio(code: str, lang: str) -> float | None:
             for child in node.children:
                 _walk(child)
 
-        _walk(cast(TreeSitterNodeLike, tree.root_node))
+        root = tree.root_node
+        if not _is_node_like(root):
+            return None
+        _walk(root)
 
         if total_nodes == 0:
             return 1.0

--- a/polylogue/schemas/generation_provider_bundle_packages.py
+++ b/polylogue/schemas/generation_provider_bundle_packages.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import cast
 
 from polylogue.lib.json import JSONDocument, JSONValue
 from polylogue.schemas.generation_cluster_support import (
@@ -48,6 +48,10 @@ class ProviderCatalogArtifacts:
     package_schemas: dict[str, dict[str, JSONDocument]]
     package_reports: dict[str, dict[str, SchemaReport | None]]
     manifest: ClusterManifest
+
+
+def _json_text_values(values: Iterable[str]) -> list[JSONValue]:
+    return list(values)
 
 
 def build_provider_catalog_artifacts(
@@ -119,11 +123,9 @@ def build_provider_catalog_artifacts(
                 artifact_kind=element_kind,
                 observed_artifact_count=len(kind_memberships),
             )
-            profile_family_ids_json = [cast(JSONValue, profile_id) for profile_id in profile_family_ids]
-            exact_structure_ids_json = [cast(JSONValue, structure_id) for structure_id in exact_structure_ids]
-            package_profile_family_ids_json = [
-                cast(JSONValue, profile_id) for profile_id in sorted(package_acc.profile_family_ids)
-            ]
+            profile_family_ids_json = _json_text_values(profile_family_ids)
+            exact_structure_ids_json = _json_text_values(exact_structure_ids)
+            package_profile_family_ids_json = _json_text_values(sorted(package_acc.profile_family_ids))
             schema["x-polylogue-package-version"] = version
             schema["x-polylogue-profile-family-ids"] = profile_family_ids_json
             schema["x-polylogue-exact-structure-ids"] = exact_structure_ids_json

--- a/polylogue/schemas/generation_semantic_relations.py
+++ b/polylogue/schemas/generation_semantic_relations.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from typing import cast, overload
+from typing import overload
 
-from polylogue.lib.json import JSONDocument, JSONDocumentList, JSONValue, json_document
+from polylogue.lib.json import JSONDocument, JSONDocumentList, JSONValue, json_document, require_json_value
 from polylogue.schemas.field_stats import FieldStats
 from polylogue.schemas.relational_inference import infer_relations
 from polylogue.schemas.relational_inference_models import RelationalAnnotations
@@ -17,7 +17,7 @@ def _schema_node(value: JSONValue | object) -> JSONDocument | None:
 
 
 def _json_value(value: object) -> JSONValue:
-    return cast(JSONValue, value)
+    return require_json_value(value, context="semantic relation annotation")
 
 
 def _relation_payloads(

--- a/polylogue/schemas/operator_annotations.py
+++ b/polylogue/schemas/operator_annotations.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
-from typing import cast
 
 from polylogue.lib.json import JSONDocument, JSONValue, json_document
 from polylogue.schemas.operator_models import (
@@ -19,6 +18,7 @@ from polylogue.schemas.operator_models import (
     SchemaReviewProof,
     SchemaRoleAssignment,
     SchemaRoleProofEntry,
+    operator_json_document,
 )
 
 
@@ -41,7 +41,7 @@ def _schema_node(value: JSONValue | object) -> JSONDocument | None:
 
 
 def _node_evidence(node: Mapping[str, object]) -> OperatorJSONDocument:
-    return cast(OperatorJSONDocument, json_document(node.get("x-polylogue-evidence")))
+    return operator_json_document(json_document(node.get("x-polylogue-evidence")))
 
 
 def _score_value(value: object) -> float:

--- a/polylogue/schemas/operator_models.py
+++ b/polylogue/schemas/operator_models.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TypeAlias, cast
+from typing import TypeAlias, TypeGuard
 
 from polylogue.scenarios import CorpusScenario, CorpusSpec
 from polylogue.schemas.generation_models import GenerationResult
@@ -21,8 +21,27 @@ JSONDocument: TypeAlias = dict[str, JSONValue]
 JSONDocumentList: TypeAlias = list[JSONDocument]
 
 
+def _is_operator_json_value(value: object) -> TypeGuard[JSONValue]:
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return True
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return all(_is_operator_json_value(item) for item in value)
+    if isinstance(value, Mapping):
+        return all(isinstance(key, str) and _is_operator_json_value(item) for key, item in value.items())
+    return False
+
+
+def _is_operator_json_document(value: object) -> TypeGuard[JSONDocument]:
+    return isinstance(value, dict) and all(
+        isinstance(key, str) and _is_operator_json_value(item) for key, item in value.items()
+    )
+
+
 def operator_json_document(payload: Mapping[str, object]) -> JSONDocument:
-    return cast(JSONDocument, dict(payload))
+    document = dict(payload)
+    if _is_operator_json_document(document):
+        return document
+    raise TypeError("operator payload is not JSON-compatible")
 
 
 def _corpus_spec_payloads(specs: tuple[CorpusSpec, ...]) -> JSONDocumentList:

--- a/polylogue/schemas/pinning.py
+++ b/polylogue/schemas/pinning.py
@@ -21,7 +21,7 @@ import json
 import logging
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
-from typing import Literal, TypeAlias, cast
+from typing import Literal, TypeAlias
 
 from polylogue.lib.json import JSONDocument, json_document, json_document_list
 from polylogue.types import Provider
@@ -62,14 +62,24 @@ def _optional_string(record: JSONDocument, key: str, default: str = "") -> str:
 
 
 def _pin_action(value: object) -> PinAction:
-    if value in ("confirm", "reject"):
-        return cast(PinAction, value)
+    if value == "confirm":
+        return "confirm"
+    if value == "reject":
+        return "reject"
     raise ValueError(f"Pin action must be 'confirm' or 'reject', got {value!r}")
 
 
 def _pin_role(value: object) -> PinnableRole:
-    if value in PINNABLE_ROLES:
-        return cast(PinnableRole, value)
+    if value == "message_role":
+        return "message_role"
+    if value == "message_body":
+        return "message_body"
+    if value == "message_timestamp":
+        return "message_timestamp"
+    if value == "message_container":
+        return "message_container"
+    if value == "conversation_title":
+        return "conversation_title"
     raise ValueError(f"Role {value!r} is not pinnable. Valid: {sorted(PINNABLE_ROLES)}")
 
 

--- a/polylogue/schemas/synthetic/build_batch.py
+++ b/polylogue/schemas/synthetic/build_batch.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import random
-from typing import Protocol, cast
+from typing import Protocol
 
-from polylogue.lib.raw_payload_decode import JSONValue
+from polylogue.lib.json import JSONValue, is_json_value
 from polylogue.schemas.synthetic.models import (
     SchemaRecord,
     SyntheticArtifact,
@@ -58,13 +58,17 @@ class _SyntheticBatchContext(Protocol):
 
 
 def _resolve_style(style: str) -> SyntheticStyle:
-    if style not in {"default", "showcase"}:
-        raise ValueError(f"Unknown synthetic style: {style}")
-    return cast(SyntheticStyle, style)
+    if style == "default":
+        return "default"
+    if style == "showcase":
+        return "showcase"
+    raise ValueError(f"Unknown synthetic style: {style}")
 
 
 def _as_json_value(value: object) -> JSONValue:
-    return cast(JSONValue, value)
+    if is_json_value(value):
+        return value
+    raise TypeError(f"Generated payload is not JSON-compatible: {type(value).__name__}")
 
 
 def generate_batch(

--- a/polylogue/schemas/tooling_registry.py
+++ b/polylogue/schemas/tooling_registry.py
@@ -6,9 +6,9 @@ import json
 from collections.abc import Mapping, Sequence
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, TypeAlias, cast
+from typing import TYPE_CHECKING, TypeAlias
 
-from polylogue.lib.json import json_document, json_document_list
+from polylogue.lib.json import json_document, json_document_list, require_json_value
 from polylogue.schemas.observation import schema_cluster_id
 from polylogue.schemas.observation_models import SchemaClusterPayload
 from polylogue.schemas.packages import SchemaPackageCatalog, SchemaVersionPackage
@@ -42,7 +42,7 @@ def _cluster_payload(sample: object) -> SchemaClusterPayload:
         return document
     documents = json_document_list(sample)
     if documents:
-        return cast(SchemaClusterPayload, documents)
+        return require_json_value(documents, context="schema cluster payload")
     if sample is None or isinstance(sample, (str, int, float, bool)):
         return sample
     return None

--- a/polylogue/showcase/qa_markdown.py
+++ b/polylogue/showcase/qa_markdown.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from datetime import datetime, timezone
-from typing import cast
 
 from polylogue.lib.outcomes import OutcomeStatus
 from polylogue.showcase.exercises import GROUPS
@@ -16,7 +15,9 @@ from polylogue.showcase.report_models import QASessionRecord
 def _payload_mapping(value: object) -> Mapping[str, object]:
     if not isinstance(value, Mapping):
         raise TypeError("Expected mapping payload")
-    return cast(Mapping[str, object], value)
+    if not all(isinstance(key, str) for key in value):
+        raise TypeError("Expected string-keyed mapping payload")
+    return {str(key): item for key, item in value.items()}
 
 
 def generate_qa_markdown(

--- a/polylogue/showcase/qa_summary.py
+++ b/polylogue/showcase/qa_summary.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import cast
 
 from polylogue.showcase.qa_runner_models import QAResult
 from polylogue.showcase.report_common import (
@@ -16,7 +15,9 @@ from polylogue.showcase.report_models import QASessionRecord
 def _payload_mapping(value: object) -> Mapping[str, object]:
     if not isinstance(value, Mapping):
         raise TypeError("Expected mapping payload")
-    return cast(Mapping[str, object], value)
+    if not all(isinstance(key, str) for key in value):
+        raise TypeError("Expected string-keyed mapping payload")
+    return {str(key): item for key, item in value.items()}
 
 
 def _count_value(value: object) -> int:

--- a/polylogue/sources/drive_auth.py
+++ b/polylogue/sources/drive_auth.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import os
 import shutil
 from pathlib import Path
-from typing import cast
 
 from polylogue.logging import get_logger
 
@@ -147,7 +146,7 @@ class DriveAuthManager:
         )
 
     def _run_manual_auth_flow(self, flow: DriveAuthFlowLike) -> DriveCredentialLike:
-        return cast(DriveCredentialLike, run_manual_auth_flow(flow=flow, prompter=self._prompter))
+        return run_manual_auth_flow(flow=flow, prompter=self._prompter)
 
     def load_credentials(self) -> DriveCredentialLike:
         """Load or acquire Google OAuth credentials. Triggers interactive auth if needed."""

--- a/polylogue/sources/drive_auth_support.py
+++ b/polylogue/sources/drive_auth_support.py
@@ -149,7 +149,7 @@ def run_manual_auth_flow(
     *,
     flow: DriveAuthFlowLike,
     prompter: DriveAuthPrompter | None,
-) -> object:
+) -> DriveCredentialLike:
     auth_url, _ = flow.authorization_url(prompt="consent", access_type="offline")
     if prompter is not None:
         prompter.announce_auth_url(auth_url)

--- a/polylogue/sources/drive_gateway.py
+++ b/polylogue/sources/drive_gateway.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-# ruff: noqa: N803
 import importlib
 from collections.abc import Callable
 from types import ModuleType
-from typing import ParamSpec, Protocol, TypeAlias, TypeVar
+from typing import ParamSpec, Protocol, TypeAlias, TypeVar, runtime_checkable
 
 from tenacity import (
     retry_if_exception_type,
@@ -12,7 +11,7 @@ from tenacity import (
     stop_after_attempt,
     wait_exponential,
 )
-from typing_extensions import TypedDict
+from typing_extensions import TypedDict, Unpack
 
 from polylogue.lib.json import JSONDocument, JSONDocumentList
 from polylogue.logging import get_logger
@@ -39,6 +38,22 @@ class DriveListFilesResponse(TypedDict, total=False):
     nextPageToken: str
 
 
+class _DriveGetKwargs(TypedDict):
+    fileId: str
+    fields: str
+
+
+class _DriveListKwargs(TypedDict):
+    q: str
+    fields: str
+    pageToken: str | None
+    pageSize: int
+
+
+class _DriveGetMediaKwargs(TypedDict):
+    fileId: str
+
+
 DEFAULT_DRIVE_RETRIES = 3
 DEFAULT_DRIVE_RETRY_BASE = 0.5
 
@@ -56,20 +71,14 @@ class _BinaryWritable(Protocol):
 
 
 class _DriveFilesResource(Protocol):
-    def get(self, *, fileId: str, fields: str) -> _ExecutableRequest[DrivePayloadRecord]: ...
+    def get(self, **kwargs: Unpack[_DriveGetKwargs]) -> _ExecutableRequest[DrivePayloadRecord]: ...
 
-    def list(
-        self,
-        *,
-        q: str,
-        fields: str,
-        pageToken: str | None,
-        pageSize: int,
-    ) -> _ExecutableRequest[DriveListFilesResponse]: ...
+    def list(self, **kwargs: Unpack[_DriveListKwargs]) -> _ExecutableRequest[DriveListFilesResponse]: ...
 
-    def get_media(self, *, fileId: str) -> object: ...
+    def get_media(self, **kwargs: Unpack[_DriveGetMediaKwargs]) -> object: ...
 
 
+@runtime_checkable
 class _DriveService(Protocol):
     _http: object | None
 

--- a/polylogue/sources/drive_gateway.py
+++ b/polylogue/sources/drive_gateway.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+# ruff: noqa: N803
 import importlib
 from collections.abc import Callable
 from types import ModuleType
@@ -55,18 +56,18 @@ class _BinaryWritable(Protocol):
 
 
 class _DriveFilesResource(Protocol):
-    def get(self, *, fileId: str, fields: str) -> _ExecutableRequest[DrivePayloadRecord]: ...  # noqa: N803
+    def get(self, *, fileId: str, fields: str) -> _ExecutableRequest[DrivePayloadRecord]: ...
 
     def list(
         self,
         *,
         q: str,
         fields: str,
-        pageToken: str | None,  # noqa: N803
-        pageSize: int,  # noqa: N803
-    ) -> _ExecutableRequest[DriveListFilesResponse]: ...  # noqa: N803
+        pageToken: str | None,
+        pageSize: int,
+    ) -> _ExecutableRequest[DriveListFilesResponse]: ...
 
-    def get_media(self, *, fileId: str) -> object: ...  # noqa: N803
+    def get_media(self, *, fileId: str) -> object: ...
 
 
 class _DriveService(Protocol):

--- a/polylogue/sources/drive_source_client.py
+++ b/polylogue/sources/drive_source_client.py
@@ -4,14 +4,14 @@ import contextlib
 import io
 import os
 import tempfile
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from pathlib import Path
-from typing import Protocol
+from typing import ParamSpec, Protocol, TypeVar
 
 from polylogue.lib.json import JSONDocument, JSONValue
 from polylogue.logging import get_logger
 
-from .drive_gateway import DriveServiceGateway
+from .drive_gateway import DriveListFilesResponse, DrivePayloadRecord
 from .drive_source_support import (
     _build_drive_file,
     _build_folder_lookup_query,
@@ -32,15 +32,35 @@ from .drive_types import (
 
 logger = get_logger(__name__)
 
+P = ParamSpec("P")
+T = TypeVar("T")
+
 
 class _WritableBinaryHandle(Protocol):
     def write(self, data: bytes) -> object: ...
 
 
+class _DriveSourceGateway(Protocol):
+    def call_with_retry(self, func: Callable[P, T], *args: P.args, **kwargs: P.kwargs) -> T: ...
+
+    def get_file(self, file_id: str, fields: str) -> DrivePayloadRecord: ...
+
+    def list_files(
+        self,
+        *,
+        q: str,
+        fields: str,
+        page_token: str | None,
+        page_size: int,
+    ) -> DriveListFilesResponse: ...
+
+    def download_file(self, file_id: str, handle: _WritableBinaryHandle) -> None: ...
+
+
 class DriveSourceClient:
     """Owns Polylogue-specific Drive source semantics."""
 
-    def __init__(self, *, gateway: DriveServiceGateway) -> None:
+    def __init__(self, *, gateway: _DriveSourceGateway) -> None:
         self._gateway = gateway
         self._meta_cache: dict[str, DriveFile] = {}
 

--- a/polylogue/sources/drive_types.py
+++ b/polylogue/sources/drive_types.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass
 from os import PathLike
-from typing import Protocol
+from typing import Protocol, runtime_checkable
 
 from ..errors import PolylogueError
 
@@ -54,6 +54,7 @@ class DriveConsoleLike(Protocol):
     def print(self, *args: object, **kwargs: object) -> None: ...
 
 
+@runtime_checkable
 class DriveUILike(Protocol):
     @property
     def plain(self) -> bool: ...
@@ -91,7 +92,7 @@ class DriveCredentialsFactory(Protocol):
 
 
 class DriveAuthFlowLike(Protocol):
-    credentials: object
+    credentials: DriveCredentialLike
 
     def authorization_url(self, *, prompt: str, access_type: str) -> tuple[str, object]: ...
 

--- a/polylogue/sources/parsers/claude_code_parser.py
+++ b/polylogue/sources/parsers/claude_code_parser.py
@@ -11,6 +11,7 @@ from pydantic import ValidationError
 from polylogue.lib.branch_type import BranchType
 from polylogue.lib.roles import Role
 from polylogue.logging import get_logger
+from polylogue.pipeline.semantic_capture import detect_context_compaction
 from polylogue.sources.providers.claude_code import ClaudeCodeRecord
 from polylogue.types import ContentBlockType, Provider
 
@@ -91,9 +92,6 @@ def _parse_code_records(records: Iterable[object], fallback_id: str) -> ParsedCo
     has_sidechain = False
     cwds: set[str] = set()
     models: set[str] = set()
-
-    # Deferred import avoids circular dependency via pipeline/__init__.py.
-    from polylogue.pipeline.semantic_capture import detect_context_compaction  # noqa: PLC0415
 
     for index, item in enumerate(records, start=1):
         if not isinstance(item, dict):

--- a/polylogue/storage/action_event_status.py
+++ b/polylogue/storage/action_event_status.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import sqlite3
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
-from typing import TypeAlias, cast
+from typing import TypeAlias
 
 import aiosqlite
 
@@ -78,6 +78,14 @@ def _coerce_int(value: object) -> int:
     return 0
 
 
+def _sql_row(row: object) -> SqlRow | None:
+    if row is None:
+        return None
+    if isinstance(row, (sqlite3.Row, tuple)):
+        return row
+    return None
+
+
 def _row_int(row: SqlRow | None, key: int | str) -> int:
     if row is None:
         return 0
@@ -108,7 +116,7 @@ async def _count_async(
     sql: str,
     params: Sequence[object] = (),
 ) -> int:
-    row = cast(SqlRow | None, await (await conn.execute(sql, params)).fetchone())
+    row = _sql_row(await (await conn.execute(sql, params)).fetchone())
     return _row_int(row, 0)
 
 

--- a/polylogue/storage/backends/queries/mappers.py
+++ b/polylogue/storage/backends/queries/mappers.py
@@ -2,157 +2,7 @@
 
 from __future__ import annotations
 
-import json
-import sqlite3
-from typing import TypeVar, cast, overload
-
-from polylogue.errors import DatabaseError
-from polylogue.lib.json import JSONValue, json_document, loads
-
-_T = TypeVar("_T", bound=object)
-_RowValue = str | int | float | bytes | bytearray | None
-_JSONText = str | bytes | bytearray
-JSONObject = dict[str, object]
-
-# ---------------------------------------------------------------------------
-# Shared row-mapper support helpers (formerly mappers_support.py)
-# These MUST be defined before the sub-module imports below, since the
-# sub-modules import _parse_json / _row_get from this module.
-# ---------------------------------------------------------------------------
-
-
-def _parse_json(
-    raw: _RowValue | None,
-    *,
-    field: str = "",
-    record_id: str = "",
-) -> JSONValue | None:
-    """Parse a JSON string with diagnostic context on failure."""
-    if raw is None:
-        return None
-    if not isinstance(raw, _JSONText):
-        raise DatabaseError(f"Corrupt JSON in {field} for {record_id}: expected JSON text, got {type(raw).__name__}")
-    if not raw:
-        return None
-    raw_preview = raw[:80]
-    try:
-        return loads(raw)
-    except json.JSONDecodeError as exc:
-        raise DatabaseError(f"Corrupt JSON in {field} for {record_id}: {exc} (value starts: {raw_preview!r})") from exc
-
-
-@overload
-def _row_get(row: sqlite3.Row, key: str, default: None = None) -> _RowValue | None: ...
-
-
-@overload
-def _row_get(row: sqlite3.Row, key: str, default: _T) -> _T: ...
-
-
-def _row_get(row: sqlite3.Row, key: str, default: _T | None = None) -> _RowValue | _T | None:
-    """Get a column value, returning default if the column doesn't exist."""
-    try:
-        return cast(_RowValue, row[key])
-    except (KeyError, IndexError):
-        return default
-
-
-def _row_text(row: sqlite3.Row, key: str) -> str | None:
-    value = _row_get(row, key)
-    if value is None:
-        return None
-    return value.decode("utf-8", errors="replace") if isinstance(value, (bytes, bytearray)) else str(value)
-
-
-def _row_int(row: sqlite3.Row, key: str, default: int | None = None) -> int | None:
-    value = _row_get(row, key)
-    if value is None:
-        return default
-    if isinstance(value, bool):
-        return int(value)
-    if isinstance(value, int):
-        return value
-    if isinstance(value, float):
-        return int(value)
-    if isinstance(value, (bytes, bytearray)):
-        try:
-            return int(value.decode("utf-8"))
-        except ValueError:
-            return default
-    try:
-        return int(value)
-    except ValueError:
-        return default
-
-
-def _row_float(row: sqlite3.Row, key: str, default: float | None = None) -> float | None:
-    value = _row_get(row, key)
-    if value is None:
-        return default
-    if isinstance(value, bool):
-        return float(int(value))
-    if isinstance(value, (int, float)):
-        return float(value)
-    if isinstance(value, (bytes, bytearray)):
-        try:
-            return float(value.decode("utf-8"))
-        except ValueError:
-            return default
-    try:
-        return float(value)
-    except ValueError:
-        return default
-
-
-def _json_object(value: JSONValue | None) -> JSONObject | None:
-    if value is None:
-        return None
-    document = json_document(value)
-    if not document:
-        return None
-    result: JSONObject = {}
-    for key, item in document.items():
-        result[key] = item
-    return result
-
-
-def _json_text_tuple(value: JSONValue | None) -> tuple[str, ...]:
-    if not isinstance(value, list):
-        return ()
-    items: list[str] = []
-    for item in value:
-        if item is None:
-            continue
-        items.append(str(item))
-    return tuple(items)
-
-
-def _json_int_dict(value: JSONValue | None) -> dict[str, int]:
-    if not isinstance(value, dict):
-        return {}
-    result: dict[str, int] = {}
-    for key, item in value.items():
-        if item is None:
-            continue
-        if isinstance(item, bool):
-            result[key] = int(item)
-            continue
-        if isinstance(item, (int, float)):
-            result[key] = int(item)
-            continue
-        if isinstance(item, str):
-            try:
-                result[key] = int(item)
-            except ValueError:
-                continue
-    return result
-
-
-# ---------------------------------------------------------------------------
-# Re-exports from sub-modules
-# ---------------------------------------------------------------------------
-
-from polylogue.storage.backends.queries.mappers_archive import (  # noqa: E402
+from polylogue.storage.backends.queries.mappers_archive import (
     _row_to_action_event,
     _row_to_artifact_observation,
     _row_to_content_block,
@@ -160,17 +10,27 @@ from polylogue.storage.backends.queries.mappers_archive import (  # noqa: E402
     _row_to_message,
     _row_to_raw_conversation,
 )
-from polylogue.storage.backends.queries.mappers_product_aggregates import (  # noqa: E402
+from polylogue.storage.backends.queries.mappers_product_aggregates import (
     _row_to_day_session_summary_record,
     _row_to_session_tag_rollup_record,
 )
-from polylogue.storage.backends.queries.mappers_product_profiles import (  # noqa: E402
+from polylogue.storage.backends.queries.mappers_product_profiles import (
     _row_to_session_profile_record,
 )
-from polylogue.storage.backends.queries.mappers_product_timelines import (  # noqa: E402
+from polylogue.storage.backends.queries.mappers_product_timelines import (
     _row_to_session_phase_record,
     _row_to_session_work_event_record,
     _row_to_work_thread_record,
+)
+from polylogue.storage.backends.queries.mappers_support import (
+    _json_int_dict,
+    _json_object,
+    _json_text_tuple,
+    _parse_json,
+    _row_float,
+    _row_get,
+    _row_int,
+    _row_text,
 )
 
 __all__ = [

--- a/polylogue/storage/backends/queries/mappers_archive.py
+++ b/polylogue/storage/backends/queries/mappers_archive.py
@@ -6,7 +6,7 @@ import sqlite3
 
 from polylogue.lib.branch_type import BranchType
 from polylogue.lib.roles import Role
-from polylogue.storage.backends.queries.mappers import (
+from polylogue.storage.backends.queries.mappers_support import (
     _json_object,
     _json_text_tuple,
     _parse_json,

--- a/polylogue/storage/backends/queries/mappers_product_aggregates.py
+++ b/polylogue/storage/backends/queries/mappers_product_aggregates.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import sqlite3
 
 from polylogue.archive_product_models import DaySessionSummaryPayload
-from polylogue.storage.backends.queries.mappers import (
+from polylogue.storage.backends.queries.mappers_support import (
     _json_int_dict,
     _json_text_tuple,
     _parse_json,

--- a/polylogue/storage/backends/queries/mappers_product_legacy.py
+++ b/polylogue/storage/backends/queries/mappers_product_legacy.py
@@ -19,7 +19,7 @@ from polylogue.archive_product_models import (
 )
 from polylogue.lib.json import JSONDocument, JSONValue, json_document
 from polylogue.lib.session_payload_documents import SessionPhaseDocument, WorkEventDocument
-from polylogue.storage.backends.queries.mappers import _parse_json, _row_get
+from polylogue.storage.backends.queries.mappers_support import _parse_json, _row_get
 
 PayloadModel = TypeVar("PayloadModel", bound=BaseModel)
 LegacyPayload: TypeAlias = JSONDocument

--- a/polylogue/storage/backends/queries/mappers_product_profiles.py
+++ b/polylogue/storage/backends/queries/mappers_product_profiles.py
@@ -9,20 +9,20 @@ from polylogue.archive_product_models import (
     SessionEvidencePayload,
     SessionInferencePayload,
 )
-from polylogue.storage.backends.queries.mappers import (
-    _json_text_tuple,
-    _parse_json,
-    _row_float,
-    _row_get,
-    _row_int,
-    _row_text,
-)
 from polylogue.storage.backends.queries.mappers_product_legacy import (
     parse_legacy_payload_dict,
     parse_payload_model,
     session_profile_enrichment_from_legacy,
     session_profile_evidence_from_legacy,
     session_profile_inference_from_legacy,
+)
+from polylogue.storage.backends.queries.mappers_support import (
+    _json_text_tuple,
+    _parse_json,
+    _row_float,
+    _row_get,
+    _row_int,
+    _row_text,
 )
 from polylogue.storage.store import SessionProfileRecord
 from polylogue.types import ConversationId

--- a/polylogue/storage/backends/queries/mappers_product_timelines.py
+++ b/polylogue/storage/backends/queries/mappers_product_timelines.py
@@ -11,15 +11,6 @@ from polylogue.archive_product_models import (
     WorkEventInferencePayload,
     WorkThreadPayload,
 )
-from polylogue.storage.backends.queries.mappers import (
-    _json_int_dict,
-    _json_text_tuple,
-    _parse_json,
-    _row_float,
-    _row_get,
-    _row_int,
-    _row_text,
-)
 from polylogue.storage.backends.queries.mappers_product_legacy import (
     parse_legacy_payload_dict,
     parse_payload_model,
@@ -27,6 +18,15 @@ from polylogue.storage.backends.queries.mappers_product_legacy import (
     session_phase_inference_from_legacy,
     session_work_event_evidence_from_legacy,
     session_work_event_inference_from_legacy,
+)
+from polylogue.storage.backends.queries.mappers_support import (
+    _json_int_dict,
+    _json_text_tuple,
+    _parse_json,
+    _row_float,
+    _row_get,
+    _row_int,
+    _row_text,
 )
 from polylogue.storage.store import SessionPhaseRecord, SessionWorkEventRecord, WorkThreadRecord
 from polylogue.types import ConversationId

--- a/polylogue/storage/backends/queries/mappers_support.py
+++ b/polylogue/storage/backends/queries/mappers_support.py
@@ -1,0 +1,142 @@
+"""Shared row-mapper support helpers."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from typing import TypeVar, cast, overload
+
+from polylogue.errors import DatabaseError
+from polylogue.lib.json import JSONValue, json_document, loads
+
+_T = TypeVar("_T", bound=object)
+_RowValue = str | int | float | bytes | bytearray | None
+_JSONText = str | bytes | bytearray
+JSONObject = dict[str, object]
+
+
+def _parse_json(
+    raw: _RowValue | None,
+    *,
+    field: str = "",
+    record_id: str = "",
+) -> JSONValue | None:
+    """Parse a JSON string with diagnostic context on failure."""
+    if raw is None:
+        return None
+    if not isinstance(raw, _JSONText):
+        raise DatabaseError(f"Corrupt JSON in {field} for {record_id}: expected JSON text, got {type(raw).__name__}")
+    if not raw:
+        return None
+    raw_preview = raw[:80]
+    try:
+        return loads(raw)
+    except json.JSONDecodeError as exc:
+        raise DatabaseError(f"Corrupt JSON in {field} for {record_id}: {exc} (value starts: {raw_preview!r})") from exc
+
+
+@overload
+def _row_get(row: sqlite3.Row, key: str, default: None = None) -> _RowValue | None: ...
+
+
+@overload
+def _row_get(row: sqlite3.Row, key: str, default: _T) -> _T: ...
+
+
+def _row_get(row: sqlite3.Row, key: str, default: _T | None = None) -> _RowValue | _T | None:
+    """Get a column value, returning default if the column doesn't exist."""
+    try:
+        return cast(_RowValue, row[key])
+    except (KeyError, IndexError):
+        return default
+
+
+def _row_text(row: sqlite3.Row, key: str) -> str | None:
+    value = _row_get(row, key)
+    if value is None:
+        return None
+    return value.decode("utf-8", errors="replace") if isinstance(value, (bytes, bytearray)) else str(value)
+
+
+def _row_int(row: sqlite3.Row, key: str, default: int | None = None) -> int | None:
+    value = _row_get(row, key)
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if isinstance(value, (bytes, bytearray)):
+        try:
+            return int(value.decode("utf-8"))
+        except ValueError:
+            return default
+    try:
+        return int(value)
+    except ValueError:
+        return default
+
+
+def _row_float(row: sqlite3.Row, key: str, default: float | None = None) -> float | None:
+    value = _row_get(row, key)
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return float(int(value))
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, (bytes, bytearray)):
+        try:
+            return float(value.decode("utf-8"))
+        except ValueError:
+            return default
+    try:
+        return float(value)
+    except ValueError:
+        return default
+
+
+def _json_object(value: JSONValue | None) -> JSONObject | None:
+    if value is None:
+        return None
+    document = json_document(value)
+    if not document:
+        return None
+    result: JSONObject = {}
+    for key, item in document.items():
+        result[key] = item
+    return result
+
+
+def _json_text_tuple(value: JSONValue | None) -> tuple[str, ...]:
+    if not isinstance(value, list):
+        return ()
+    items: list[str] = []
+    for item in value:
+        if item is None:
+            continue
+        items.append(str(item))
+    return tuple(items)
+
+
+def _json_int_dict(value: JSONValue | None) -> dict[str, int]:
+    if not isinstance(value, dict):
+        return {}
+    result: dict[str, int] = {}
+    for key, item in value.items():
+        if item is None:
+            continue
+        if isinstance(item, bool):
+            result[key] = int(item)
+            continue
+        if isinstance(item, (int, float)):
+            result[key] = int(item)
+            continue
+        if isinstance(item, str):
+            try:
+                result[key] = int(item)
+            except ValueError:
+                continue
+    return result

--- a/polylogue/storage/backends/queries/mappers_support.py
+++ b/polylogue/storage/backends/queries/mappers_support.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import sqlite3
-from typing import TypeVar, cast, overload
+from typing import TypeGuard, TypeVar, overload
 
 from polylogue.errors import DatabaseError
 from polylogue.lib.json import JSONValue, json_document, loads
@@ -13,6 +13,10 @@ _T = TypeVar("_T", bound=object)
 _RowValue = str | int | float | bytes | bytearray | None
 _JSONText = str | bytes | bytearray
 JSONObject = dict[str, object]
+
+
+def _is_row_value(value: object) -> TypeGuard[_RowValue]:
+    return value is None or isinstance(value, (str, int, float, bytes, bytearray))
 
 
 def _parse_json(
@@ -46,9 +50,12 @@ def _row_get(row: sqlite3.Row, key: str, default: _T) -> _T: ...
 def _row_get(row: sqlite3.Row, key: str, default: _T | None = None) -> _RowValue | _T | None:
     """Get a column value, returning default if the column doesn't exist."""
     try:
-        return cast(_RowValue, row[key])
+        value = row[key]
     except (KeyError, IndexError):
         return default
+    if _is_row_value(value):
+        return value
+    raise DatabaseError(f"Unexpected SQLite row value for {key}: {type(value).__name__}")
 
 
 def _row_text(row: sqlite3.Row, key: str) -> str | None:

--- a/polylogue/storage/backends/queries/raw_reads.py
+++ b/polylogue/storage/backends/queries/raw_reads.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator, Sequence
-from typing import cast
+from collections.abc import AsyncIterator, Iterable, Sequence
 
 import aiosqlite
 
@@ -12,6 +11,15 @@ from polylogue.storage.backends.queries.mappers import _row_to_raw_conversation
 from polylogue.storage.backends.queries.raw_state import EFFECTIVE_RAW_PROVIDER_SQL
 from polylogue.storage.raw_state_models import RawConversationState
 from polylogue.storage.store import RawConversationRecord
+
+
+def _raw_rows(rows: Iterable[object]) -> list[aiosqlite.Row]:
+    typed_rows: list[aiosqlite.Row] = []
+    for row in rows:
+        if not isinstance(row, aiosqlite.Row):
+            raise TypeError(f"expected aiosqlite.Row, got {type(row).__name__}")
+        typed_rows.append(row)
+    return typed_rows
 
 
 def _raw_select_query(
@@ -254,7 +262,7 @@ async def iter_raw_conversations(
         params.extend([chunk_size, offset])
 
         cursor = await conn.execute(query_with_limit, tuple(params))
-        rows = cast(list[aiosqlite.Row], await cursor.fetchall())
+        rows = _raw_rows(await cursor.fetchall())
         if not rows:
             break
         for row in rows:

--- a/polylogue/storage/embedding_stats.py
+++ b/polylogue/storage/embedding_stats.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import sqlite3
 from dataclasses import dataclass, replace
-from typing import cast
 
 import aiosqlite
 
@@ -54,8 +53,8 @@ class _EmbeddingStatsParts:
     total_conversations: int = 0
 
 
-def _row_count(row: StatsRow | None) -> int:
-    if row is None:
+def _row_count(row: object) -> int:
+    if row is None or not isinstance(row, (sqlite3.Row, tuple)):
         return 0
     value = row[0]
     if value is None:
@@ -77,7 +76,13 @@ def _row_count(row: StatsRow | None) -> int:
 def _bounds_value(bounds: StatsRow | None, *, index: int, key: str) -> str | None:
     if bounds is None:
         return None
-    value = (bounds[index] if index < len(bounds) else None) if isinstance(bounds, tuple) else cast(object, bounds[key])
+    if isinstance(bounds, tuple):
+        value = bounds[index] if index < len(bounds) else None
+    else:
+        try:
+            value = bounds[key]
+        except (IndexError, KeyError):
+            return None
     if value is None:
         return None
     return str(value)
@@ -131,12 +136,11 @@ def _with_total_conversations(parts: _EmbeddingStatsParts, total_conversations: 
 
 
 def _total_conversations_sync(conn: sqlite3.Connection) -> int:
-    return _row_count(cast(StatsRow | None, conn.execute("SELECT COUNT(*) FROM conversations").fetchone()))
+    return _row_count(conn.execute("SELECT COUNT(*) FROM conversations").fetchone())
 
 
 async def _total_conversations_async(conn: aiosqlite.Connection) -> int:
-    row = cast(StatsRow | None, await (await conn.execute("SELECT COUNT(*) FROM conversations")).fetchone())
-    return _row_count(row)
+    return _row_count(await (await conn.execute("SELECT COUNT(*) FROM conversations")).fetchone())
 
 
 def _snapshot(

--- a/polylogue/storage/embedding_stats_support.py
+++ b/polylogue/storage/embedding_stats_support.py
@@ -3,14 +3,25 @@
 from __future__ import annotations
 
 import sqlite3
-from collections.abc import Mapping
-from typing import cast
+from collections.abc import Iterable, Mapping
 
 import aiosqlite
 
 from polylogue.storage.session_product_runtime import SessionProductStatusSnapshot
 
 StatsRow = sqlite3.Row | tuple[object, ...]
+
+
+def _stats_row(row: object) -> StatsRow | None:
+    if row is None:
+        return None
+    if isinstance(row, (sqlite3.Row, tuple)):
+        return row
+    return None
+
+
+def _sqlite_rows(rows: Iterable[object]) -> list[sqlite3.Row]:
+    return [row for row in rows if isinstance(row, sqlite3.Row)]
 
 
 def _coerce_int(value: object, *, default: int = 0) -> int:
@@ -179,7 +190,7 @@ def optional_count_sync(conn: sqlite3.Connection, sql: str) -> int:
 
 def optional_row_sync(conn: sqlite3.Connection, sql: str) -> StatsRow | None:
     try:
-        return cast(StatsRow | None, conn.execute(sql).fetchone())
+        return _stats_row(conn.execute(sql).fetchone())
     except sqlite3.OperationalError as exc:
         if is_missing_table_error(exc):
             return None
@@ -209,7 +220,7 @@ async def optional_count_async(conn: aiosqlite.Connection, sql: str) -> int:
 async def optional_row_async(conn: aiosqlite.Connection, sql: str) -> StatsRow | None:
     try:
         cursor = await conn.execute(sql)
-        return cast(StatsRow | None, await cursor.fetchone())
+        return _stats_row(await cursor.fetchone())
     except sqlite3.OperationalError as exc:
         if is_missing_table_error(exc):
             return None
@@ -219,7 +230,7 @@ async def optional_row_async(conn: aiosqlite.Connection, sql: str) -> StatsRow |
 async def optional_rows_async(conn: aiosqlite.Connection, sql: str) -> list[sqlite3.Row]:
     try:
         cursor = await conn.execute(sql)
-        return cast(list[sqlite3.Row], await cursor.fetchall())
+        return _sqlite_rows(await cursor.fetchall())
     except sqlite3.OperationalError as exc:
         if is_missing_table_error(exc):
             return []

--- a/polylogue/storage/hydrators.py
+++ b/polylogue/storage/hydrators.py
@@ -13,10 +13,10 @@ from __future__ import annotations
 
 import json
 from datetime import datetime, timezone
-from typing import cast
 
 from polylogue.lib.attachment_models import Attachment
 from polylogue.lib.conversation_models import Conversation, ConversationSummary
+from polylogue.lib.json import loads
 from polylogue.lib.message_models import Message
 from polylogue.lib.messages import MessageCollection
 from polylogue.lib.roles import Role
@@ -42,8 +42,8 @@ def _parse_json_blob(raw: object) -> object | None:
     if not isinstance(raw, str):
         return raw
     try:
-        return cast(object, json.loads(raw))
-    except json.JSONDecodeError:
+        return loads(raw)
+    except (json.JSONDecodeError, ValueError):
         return raw
 
 

--- a/polylogue/storage/repository.py
+++ b/polylogue/storage/repository.py
@@ -10,7 +10,7 @@ fetching of conversations, messages, and attachments together.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 from polylogue.storage.backends.async_sqlite import SQLiteBackend
 
@@ -78,7 +78,7 @@ class ConversationRepository(
             db_path: Optional path to database file. Used if backend is None.
         """
         active_backend = backend if backend is not None else SQLiteBackend(db_path=db_path)
-        self._backend = active_backend
+        self._backend: SQLiteBackend = active_backend
         self.queries = active_backend.queries
 
     async def __aenter__(self) -> ConversationRepository:
@@ -92,7 +92,7 @@ class ConversationRepository(
     @property
     def backend(self) -> SQLiteBackend:
         """Access the underlying async storage backend."""
-        return cast(SQLiteBackend, self._backend)
+        return self._backend
 
     async def close(self) -> None:
         """Close database connections and release resources."""

--- a/polylogue/storage/repository_archive_queries.py
+++ b/polylogue/storage/repository_archive_queries.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import builtins
 from collections.abc import AsyncIterator
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 from polylogue.lib.conversation_models import Conversation, ConversationSummary
 from polylogue.protocols import ConversationQueryRuntimeStore
@@ -222,10 +222,10 @@ class RepositoryArchiveQueryMixin:
             )
         )
 
-    def filter(self) -> ConversationFilter:
+    def filter(self: ConversationQueryRuntimeStore) -> ConversationFilter:
         from polylogue.lib import filters
 
-        return filters.ConversationFilter(cast(ConversationQueryRuntimeStore, self))
+        return filters.ConversationFilter(self)
 
 
 __all__ = ["RepositoryArchiveQueryMixin"]

--- a/polylogue/storage/repository_write_conversations.py
+++ b/polylogue/storage/repository_write_conversations.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import builtins
-from typing import cast
 
 from polylogue.lib.conversation_models import Conversation
 from polylogue.lib.json import json_document
@@ -52,7 +51,7 @@ def conversation_to_record(conversation: Conversation) -> ConversationRecord:
     provider_meta.update(json_document(metadata.get("provider_meta")))
 
     return ConversationRecord(
-        conversation_id=cast(ConversationId, str(conversation.id)),
+        conversation_id=ConversationId(str(conversation.id)),
         provider_name=conversation.provider,
         provider_conversation_id=provider_conversation_id(
             conversation_id=str(conversation.id),
@@ -61,7 +60,7 @@ def conversation_to_record(conversation: Conversation) -> ConversationRecord:
         title=conversation.title or "",
         created_at=created_at_str,
         updated_at=updated_at_str,
-        content_hash=cast(ContentHash, metadata_record.get("content_hash", "")),
+        content_hash=ContentHash(str(metadata_record.get("content_hash", ""))),
         provider_meta=provider_meta,
         metadata=metadata_record,
     )

--- a/polylogue/storage/repository_write_conversations.py
+++ b/polylogue/storage/repository_write_conversations.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import builtins
 
 from polylogue.lib.conversation_models import Conversation
-from polylogue.lib.json import json_document
+from polylogue.lib.hashing import hash_payload
+from polylogue.lib.json import JSONValue, json_document
 from polylogue.storage.action_event_rows import attach_blocks_to_messages, build_action_event_records
 from polylogue.storage.backends.queries import action_events as action_events_q
 from polylogue.storage.backends.queries import attachments as attachments_q
@@ -39,6 +40,64 @@ def provider_conversation_id(conversation_id: str, provider: str | None) -> str:
     return conversation_id[len(prefix) :] if conversation_id.startswith(prefix) else conversation_id
 
 
+def _normalize_hash_value(value: object) -> JSONValue:
+    if value is None:
+        return "__POLYLOGUE_NULL__"
+    if value == "":
+        return "__POLYLOGUE_EMPTY__"
+    if isinstance(value, (str, int, float, bool)):
+        return value
+    return str(value)
+
+
+def _content_hash_from_metadata_or_domain(conversation: Conversation, metadata: dict[str, object]) -> str:
+    existing = metadata.get("content_hash")
+    if isinstance(existing, str) and existing.strip():
+        return existing
+
+    messages_payload: list[dict[str, JSONValue]] = []
+    for message in conversation.messages:
+        messages_payload.append(
+            {
+                "id": str(message.id),
+                "role": str(message.role),
+                "text": _normalize_hash_value(message.text),
+                "timestamp": _normalize_hash_value(message.timestamp.isoformat() if message.timestamp else None),
+            }
+        )
+    attachments_payload = sorted(
+        [
+            {
+                "id": _normalize_hash_value(attachment.id),
+                "message_id": _normalize_hash_value(message.id),
+                "name": _normalize_hash_value(attachment.name),
+                "mime_type": _normalize_hash_value(attachment.mime_type),
+                "size_bytes": _normalize_hash_value(attachment.size_bytes),
+            }
+            for message in conversation.messages
+            for attachment in message.attachments
+        ],
+        key=lambda item: (
+            str(item.get("message_id") or ""),
+            str(item.get("id") or ""),
+            str(item.get("name") or ""),
+        ),
+    )
+    return hash_payload(
+        {
+            "title": _normalize_hash_value(conversation.title),
+            "created_at": _normalize_hash_value(
+                conversation.created_at.isoformat() if conversation.created_at else None
+            ),
+            "updated_at": _normalize_hash_value(
+                conversation.updated_at.isoformat() if conversation.updated_at else None
+            ),
+            "messages": messages_payload,
+            "attachments": attachments_payload,
+        }
+    )
+
+
 def conversation_to_record(conversation: Conversation) -> ConversationRecord:
     from polylogue.types import ContentHash, ConversationId
 
@@ -60,7 +119,7 @@ def conversation_to_record(conversation: Conversation) -> ConversationRecord:
         title=conversation.title or "",
         created_at=created_at_str,
         updated_at=updated_at_str,
-        content_hash=ContentHash(str(metadata_record.get("content_hash", ""))),
+        content_hash=ContentHash(_content_hash_from_metadata_or_domain(conversation, metadata_record)),
         provider_meta=provider_meta,
         metadata=metadata_record,
     )

--- a/polylogue/storage/repository_writes.py
+++ b/polylogue/storage/repository_writes.py
@@ -42,6 +42,11 @@ class RepositoryWriteMixin:
         content_blocks: builtins.list[ContentBlockRecord] | None = None,
     ) -> dict[str, int]:
         if isinstance(conversation, Conversation):
+            if conversation.messages and not messages:
+                raise ValueError(
+                    "save_conversation() received a domain Conversation with messages but no "
+                    "MessageRecord rows; pass transformed records instead of risking runtime-state loss"
+                )
             conv_record = self._conversation_to_record(conversation)
         else:
             conv_record = conversation

--- a/polylogue/storage/search_providers/__init__.py
+++ b/polylogue/storage/search_providers/__init__.py
@@ -7,6 +7,7 @@ factory functions for creating provider instances from configuration.
 
 from __future__ import annotations
 
+import importlib.util
 import os
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -25,6 +26,10 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 _sqlite_vec_missing_warned = False
+
+
+def _sqlite_vec_available() -> bool:
+    return importlib.util.find_spec("sqlite_vec") is not None
 
 
 def create_search_provider(config: Config | None = None, db_path: Path | None = None) -> SearchProvider:
@@ -73,10 +78,7 @@ def create_vector_provider(
     if not voyage_key:
         return None
 
-    # Check if sqlite-vec is available
-    try:
-        import sqlite_vec  # noqa: F401
-    except ImportError:
+    if not _sqlite_vec_available():
         if not _sqlite_vec_missing_warned:
             logger.warning("sqlite-vec not installed, vector search unavailable")
             _sqlite_vec_missing_warned = True

--- a/polylogue/surface_payloads.py
+++ b/polylogue/surface_payloads.py
@@ -7,12 +7,12 @@ import sys
 from collections.abc import Mapping, Sequence
 from datetime import datetime
 from enum import Enum
-from typing import TYPE_CHECKING, Literal, NotRequired, cast
+from typing import TYPE_CHECKING, Literal, NotRequired
 
 from pydantic import BaseModel, ConfigDict, Field
 from typing_extensions import TypedDict
 
-from polylogue.lib.json import JSONDocument, JSONValue
+from polylogue.lib.json import JSONDocument, JSONValue, require_json_document
 
 if TYPE_CHECKING:
     from collections.abc import Container
@@ -27,7 +27,10 @@ def serialize_surface_payload(payload: BaseModel, *, exclude_none: bool = False)
 
 def model_json_document(payload: BaseModel, *, exclude_none: bool = False) -> JSONDocument:
     """Return a model dump constrained to the shared JSON document type."""
-    return cast(JSONDocument, payload.model_dump(mode="json", exclude_none=exclude_none))
+    return require_json_document(
+        payload.model_dump(mode="json", exclude_none=exclude_none),
+        context=f"{payload.__class__.__name__} JSON payload",
+    )
 
 
 class SurfacePayloadModel(BaseModel):
@@ -74,7 +77,7 @@ class MachineErrorPayload(SurfacePayloadModel):
         if self.command:
             payload["command"] = list(self.command)
         if self.details:
-            payload["details"] = cast(JSONDocument, dict(self.details))
+            payload["details"] = require_json_document(dict(self.details), context="machine error details")
         return payload
 
     def to_json(self, *, exclude_none: bool = False) -> str:
@@ -93,12 +96,12 @@ class MachineSuccessPayload(SurfacePayloadModel):
     """Structured success payload for machine-readable CLI surfaces."""
 
     status: Literal["ok"] = "ok"
-    result: dict[str, object] = Field(default_factory=dict)
+    result: Mapping[str, object] = Field(default_factory=dict)
 
     def to_dict(self) -> MachineSuccessEnvelope:
         return {
             "status": self.status,
-            "result": cast(JSONDocument, dict(self.result)),
+            "result": require_json_document(dict(self.result), context="machine success result"),
         }
 
 

--- a/polylogue/ui/facade.py
+++ b/polylogue/ui/facade.py
@@ -6,7 +6,6 @@ from collections import deque
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import cast
 
 import questionary
 from rich import box
@@ -72,7 +71,10 @@ class ConsoleFacade:
         if self.plain:
             self.console = PlainConsole()
         else:
-            self.console = cast(ConsoleLike, Console(no_color=False, force_terminal=True, theme=self.theme))
+            rich_console = Console(no_color=False, force_terminal=True, theme=self.theme)
+            if not isinstance(rich_console, ConsoleLike):
+                raise TypeError("rich Console no longer satisfies ConsoleLike")
+            self.console = rich_console
         self._panel_box = box.ROUNDED
         self._banner_box = box.DOUBLE
         self._prompt_responses = load_prompt_responses(UIError, prompt_stub_path=self.prompt_stub_path)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,6 +154,7 @@ disallow_any_generics = true
 disallow_incomplete_defs = true
 disallow_untyped_defs = true
 cache_dir = ".cache/mypy"
+mypy_path = "stubs"
 plugins = []
 files = [
   "polylogue",

--- a/stubs/dateparser/__init__.pyi
+++ b/stubs/dateparser/__init__.pyi
@@ -1,0 +1,19 @@
+"""Local typing surface for the dateparser API used by Polylogue."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from datetime import datetime
+
+LanguageDetector = Callable[[str, float], Sequence[str]]
+
+
+def parse(
+    date_string: str,
+    date_formats: Sequence[str] | None = None,
+    languages: Sequence[str] | None = None,
+    locales: Sequence[str] | None = None,
+    region: str | None = None,
+    settings: Mapping[str, object] | None = None,
+    detect_languages_function: LanguageDetector | None = None,
+) -> datetime | None: ...

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,8 @@ from polylogue.scenarios import CorpusSpec, build_default_corpus_specs
 from polylogue.storage.store import RawConversationRecord
 from tests.infra.builders import make_conv, make_msg
 
+pytest_plugins = ("tests.infra.corpus_fixtures",)
+
 if TYPE_CHECKING:
     from click.testing import CliRunner
 
@@ -662,9 +664,6 @@ def raw_synthetic_samples() -> list[RawConversationRecord]:
 # =============================================================================
 # SYNTHETIC SOURCE FIXTURE (replaces FIXTURES_DIR-based sources)
 # =============================================================================
-
-
-from tests.infra.corpus_fixtures import corpus_seeded_db  # noqa: F401
 
 
 @pytest.fixture

--- a/tests/infra/archive_scenarios.py
+++ b/tests/infra/archive_scenarios.py
@@ -1,0 +1,260 @@
+"""Declarative archive scenarios for verification harnesses.
+
+These helpers keep tests focused on semantic expectations instead of repeating
+conversation-builder, repository, and SQL plumbing in every suite.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TypeAlias
+
+from polylogue.lib.json import json_document, loads
+from polylogue.storage.backends.async_sqlite import SQLiteBackend
+from polylogue.storage.backends.queries.mappers_archive import (
+    _row_to_content_block,
+    _row_to_conversation,
+    _row_to_message,
+)
+from polylogue.storage.hydrators import conversation_from_records
+from polylogue.storage.repository import ConversationRepository
+from polylogue.storage.store import AttachmentRecord, ContentBlockRecord, ConversationRecord, MessageRecord
+from polylogue.types import AttachmentId, ConversationId, MessageId
+from tests.infra.semantic_facts import ConversationFacts
+from tests.infra.storage_records import ConversationBuilder, JSONRecord, db_setup
+
+ScenarioProvider: TypeAlias = str
+_FIXTURE_TIMESTAMP = "2026-01-01T00:00:00+00:00"
+
+
+@dataclass(frozen=True, slots=True)
+class ScenarioAttachment:
+    """Attachment fixture data associated with a scenario message."""
+
+    attachment_id: str | None = None
+    mime_type: str = "application/octet-stream"
+    size_bytes: int = 1024
+    path: str | None = None
+    provider_meta: JSONRecord | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ScenarioMessage:
+    """Message fixture data used by ``ArchiveScenario``."""
+
+    role: str = "user"
+    text: str = "Test message"
+    message_id: str | None = None
+    timestamp: str | None = None
+    provider_meta: JSONRecord | None = None
+    content_blocks: Sequence[JSONRecord] = ()
+    attachments: Sequence[ScenarioAttachment] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class ArchiveScenarioSeed:
+    """Result of seeding one archive scenario."""
+
+    scenario: ArchiveScenario
+    conversation_id: str
+
+    def facts_from_connection(self, conn: sqlite3.Connection) -> ConversationFacts:
+        return self.scenario.facts_from_connection(conn)
+
+    async def facts_from_repository(self, repository: ConversationRepository) -> ConversationFacts:
+        return await self.scenario.facts_from_repository(repository)
+
+
+@dataclass(frozen=True, slots=True)
+class ArchiveScenario:
+    """A minimal semantic archive fixture that can be projected through surfaces."""
+
+    name: str
+    provider: ScenarioProvider = "test"
+    title: str = "Test Conversation"
+    messages: Sequence[ScenarioMessage] = field(default_factory=tuple)
+    conversation_id: str | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
+    metadata: JSONRecord | None = None
+
+    @property
+    def resolved_conversation_id(self) -> str:
+        return self.conversation_id or self.name
+
+    def seed(self, db_path: Path) -> ArchiveScenarioSeed:
+        """Persist the scenario into ``db_path`` through the standard builder."""
+        timestamp = self.created_at or _default_timestamp()
+        builder = (
+            ConversationBuilder(db_path, self.resolved_conversation_id)
+            .provider(self.provider)
+            .title(self.title)
+            .created_at(timestamp)
+            .updated_at(self.updated_at or timestamp)
+            .metadata(self.metadata)
+        )
+        for message_index, message in enumerate(self.messages or _default_messages(), start=1):
+            message_id = message.message_id or f"m{message_index}"
+            message_kwargs: dict[str, object] = {"content_blocks": list(message.content_blocks)}
+            if message.provider_meta is not None:
+                message_kwargs["provider_meta"] = message.provider_meta
+            builder.add_message(
+                message_id=message_id,
+                role=message.role,
+                text=message.text,
+                timestamp=message.timestamp,
+                **message_kwargs,
+            )
+            for attachment in message.attachments:
+                builder.add_attachment(
+                    attachment_id=attachment.attachment_id,
+                    message_id=message_id,
+                    mime_type=attachment.mime_type,
+                    size_bytes=attachment.size_bytes,
+                    path=attachment.path,
+                    provider_meta=attachment.provider_meta,
+                )
+        builder.save()
+        return ArchiveScenarioSeed(scenario=self, conversation_id=self.resolved_conversation_id)
+
+    def facts_from_connection(self, conn: sqlite3.Connection) -> ConversationFacts:
+        """Read scenario facts directly from storage records."""
+        conv_record, msg_records, attachment_records = self._records_from_connection(conn)
+        return ConversationFacts.from_records(conv_record, msg_records, attachment_records)
+
+    def hydrated_facts_from_connection(self, conn: sqlite3.Connection) -> ConversationFacts:
+        """Hydrate storage records and extract domain-level scenario facts."""
+        conv_record, msg_records, attachment_records = self._records_from_connection(conn)
+        return ConversationFacts.from_domain_conversation(
+            conversation_from_records(conv_record, msg_records, attachment_records)
+        )
+
+    def _records_from_connection(
+        self,
+        conn: sqlite3.Connection,
+    ) -> tuple[ConversationRecord, list[MessageRecord], list[AttachmentRecord]]:
+        conv_row = conn.execute(
+            "SELECT * FROM conversations WHERE conversation_id = ?",
+            (self.resolved_conversation_id,),
+        ).fetchone()
+        if conv_row is None:
+            raise AssertionError(f"Scenario conversation {self.resolved_conversation_id!r} was not seeded")
+        conv_record = _row_to_conversation(conv_row)
+        msg_rows = conn.execute(
+            "SELECT * FROM messages WHERE conversation_id = ? ORDER BY sort_key, message_id",
+            (self.resolved_conversation_id,),
+        ).fetchall()
+        content_blocks_by_message = _content_blocks_by_message(conn, self.resolved_conversation_id)
+        msg_records = [
+            _row_to_message(row).model_copy(
+                update={"content_blocks": content_blocks_by_message.get(str(row["message_id"]), [])}
+            )
+            for row in msg_rows
+        ]
+        attachment_records = _attachment_records_for_conversation(conn, self.resolved_conversation_id)
+        return conv_record, msg_records, attachment_records
+
+    async def facts_from_repository(self, repository: ConversationRepository) -> ConversationFacts:
+        conversation = await repository.get(self.resolved_conversation_id)
+        if conversation is None:
+            raise AssertionError(
+                f"Scenario conversation {self.resolved_conversation_id!r} not found through repository"
+            )
+        return ConversationFacts.from_domain_conversation(conversation)
+
+
+def _default_timestamp() -> str:
+    return _FIXTURE_TIMESTAMP
+
+
+def _default_messages() -> tuple[ScenarioMessage, ...]:
+    return (ScenarioMessage(role="user", text="Test message"),)
+
+
+def _attachment_records_for_conversation(conn: sqlite3.Connection, conversation_id: str) -> list[AttachmentRecord]:
+    rows = conn.execute(
+        """
+        SELECT
+            a.attachment_id,
+            ar.conversation_id,
+            ar.message_id,
+            a.mime_type,
+            a.size_bytes,
+            a.path,
+            a.provider_meta
+        FROM attachment_refs ar
+        JOIN attachments a ON a.attachment_id = ar.attachment_id
+        WHERE ar.conversation_id = ?
+        ORDER BY ar.message_id, a.attachment_id
+        """,
+        (conversation_id,),
+    ).fetchall()
+    return [_attachment_record_from_row(row) for row in rows]
+
+
+def _content_blocks_by_message(conn: sqlite3.Connection, conversation_id: str) -> dict[str, list[ContentBlockRecord]]:
+    rows = conn.execute(
+        """
+        SELECT *
+        FROM content_blocks
+        WHERE conversation_id = ?
+        ORDER BY message_id, block_index
+        """,
+        (conversation_id,),
+    ).fetchall()
+    blocks_by_message: dict[str, list[ContentBlockRecord]] = {}
+    for row in rows:
+        blocks_by_message.setdefault(str(row["message_id"]), []).append(_row_to_content_block(row))
+    return blocks_by_message
+
+
+def _attachment_record_from_row(row: sqlite3.Row) -> AttachmentRecord:
+    raw_provider_meta = row["provider_meta"]
+    provider_meta: JSONRecord | None = None
+    if isinstance(raw_provider_meta, str) and raw_provider_meta:
+        provider_meta = {}
+        for key, value in json_document(loads(raw_provider_meta)).items():
+            provider_meta[key] = value
+    return AttachmentRecord(
+        attachment_id=AttachmentId(row["attachment_id"]),
+        conversation_id=ConversationId(row["conversation_id"]),
+        message_id=MessageId(row["message_id"]) if row["message_id"] is not None else None,
+        mime_type=row["mime_type"],
+        size_bytes=row["size_bytes"],
+        path=row["path"],
+        provider_meta=provider_meta,
+    )
+
+
+def seed_archive_scenarios(db_path: Path, scenarios: Iterable[ArchiveScenario]) -> list[ArchiveScenarioSeed]:
+    """Seed all scenarios into one archive database."""
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    return [scenario.seed(db_path) for scenario in scenarios]
+
+
+def seed_workspace_scenarios(
+    workspace_env: Mapping[str, Path],
+    scenarios: Iterable[ArchiveScenario],
+) -> tuple[Path, list[ArchiveScenarioSeed]]:
+    """Seed scenarios into the standard workspace database path."""
+    db_path = db_setup(workspace_env)
+    return db_path, seed_archive_scenarios(db_path, scenarios)
+
+
+def repository_for_scenario_db(db_path: Path) -> ConversationRepository:
+    """Open a repository over a scenario database."""
+    return ConversationRepository(backend=SQLiteBackend(db_path=db_path))
+
+
+__all__ = [
+    "ArchiveScenario",
+    "ArchiveScenarioSeed",
+    "ScenarioAttachment",
+    "ScenarioMessage",
+    "repository_for_scenario_db",
+    "seed_archive_scenarios",
+    "seed_workspace_scenarios",
+]

--- a/tests/infra/archive_scenarios.py
+++ b/tests/infra/archive_scenarios.py
@@ -122,20 +122,21 @@ class ArchiveScenario:
 
     def facts_from_connection(self, conn: sqlite3.Connection) -> ConversationFacts:
         """Read scenario facts directly from storage records."""
-        conv_record, msg_records, attachment_records = self._records_from_connection(conn)
+        conv_record, msg_records, attachment_records = self.records_from_connection(conn)
         return ConversationFacts.from_records(conv_record, msg_records, attachment_records)
 
     def hydrated_facts_from_connection(self, conn: sqlite3.Connection) -> ConversationFacts:
         """Hydrate storage records and extract domain-level scenario facts."""
-        conv_record, msg_records, attachment_records = self._records_from_connection(conn)
+        conv_record, msg_records, attachment_records = self.records_from_connection(conn)
         return ConversationFacts.from_domain_conversation(
             conversation_from_records(conv_record, msg_records, attachment_records)
         )
 
-    def _records_from_connection(
+    def records_from_connection(
         self,
         conn: sqlite3.Connection,
     ) -> tuple[ConversationRecord, list[MessageRecord], list[AttachmentRecord]]:
+        """Read scenario storage records from a SQLite connection."""
         conv_row = conn.execute(
             "SELECT * FROM conversations WHERE conversation_id = ?",
             (self.resolved_conversation_id,),

--- a/tests/infra/drive_mocks.py
+++ b/tests/infra/drive_mocks.py
@@ -8,6 +8,8 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import ParamSpec, Protocol, TypeVar
 
+from polylogue.lib.json import json_document, json_document_list
+from polylogue.sources.drive_gateway import DriveListFilesResponse, DrivePayloadRecord
 from polylogue.sources.drive_types import DriveError, DriveNotFoundError
 
 P = ParamSpec("P")
@@ -286,6 +288,8 @@ class MockFilesResource:
 class MockDriveService:
     """Mock Google Drive service."""
 
+    _http: object | None = None
+
     def __init__(
         self, files_data: dict[str, MockDriveFile] | None = None, file_content: dict[str, bytes | str] | None = None
     ):
@@ -325,8 +329,9 @@ class FakeDriveServiceGateway:
     def _service_handle(self) -> MockDriveService:
         return self._mock_service
 
-    def get_file(self, file_id: str, fields: str) -> dict[str, object]:
-        return self._mock_service.files().get(fileId=file_id, fields=fields).execute()
+    def get_file(self, file_id: str, fields: str) -> DrivePayloadRecord:
+        payload = self._mock_service.files().get(fileId=file_id, fields=fields).execute()
+        return json_document(payload)
 
     def list_files(
         self,
@@ -335,8 +340,17 @@ class FakeDriveServiceGateway:
         fields: str,
         page_token: str | None,
         page_size: int,
-    ) -> dict[str, object]:
-        return self._mock_service.files().list(q=q, fields=fields, pageToken=page_token, pageSize=page_size).execute()
+    ) -> DriveListFilesResponse:
+        payload = json_document(
+            self._mock_service.files().list(q=q, fields=fields, pageToken=page_token, pageSize=page_size).execute()
+        )
+        response: DriveListFilesResponse = {}
+        if "files" in payload:
+            response["files"] = json_document_list(payload["files"])
+        next_page_token = payload.get("nextPageToken")
+        if isinstance(next_page_token, str):
+            response["nextPageToken"] = next_page_token
+        return response
 
     def download_file(self, file_id: str, handle: BinaryWritable) -> None:
         if self._download_error is not None:

--- a/tests/infra/mcp.py
+++ b/tests/infra/mcp.py
@@ -3,10 +3,9 @@
 from __future__ import annotations
 
 import asyncio
-import inspect
-from collections.abc import Awaitable, Callable, Coroutine, Mapping, Sequence
+from collections.abc import Awaitable, Callable, Mapping, Sequence
 from datetime import datetime, timezone
-from typing import Protocol, TypeAlias, TypeVar, cast
+from typing import Protocol, TypeAlias, TypeVar, runtime_checkable
 from unittest.mock import AsyncMock, MagicMock
 
 from polylogue.lib.models import Conversation
@@ -83,10 +82,15 @@ class MCPPromptManager(Protocol):
     _prompts: Mapping[str, RegisteredMCPSurface]
 
 
+@runtime_checkable
 class MCPServerUnderTest(Protocol):
     _tool_manager: MCPToolManager
     _resource_manager: MCPResourceManager
     _prompt_manager: MCPPromptManager
+
+
+async def _await_surface(result: Awaitable[SurfaceResult]) -> SurfaceResult:
+    return await result
 
 
 def invoke_surface(
@@ -97,9 +101,10 @@ def invoke_surface(
 ) -> SurfaceResult:
     """Call an MCP surface whether it is sync or async."""
     result = fn(*args, **kwargs)
-    if inspect.iscoroutine(result):
-        return asyncio.run(cast(Coroutine[object, object, SurfaceResult], result))
-    return cast(SurfaceResult, result)
+    if isinstance(result, Awaitable):
+        surface: SurfaceResult = asyncio.run(_await_surface(result))
+        return surface
+    return result
 
 
 async def invoke_surface_async(
@@ -110,8 +115,8 @@ async def invoke_surface_async(
 ) -> SurfaceResult:
     """Await an MCP surface from async tests."""
     result = fn(*args, **kwargs)
-    if inspect.isawaitable(result):
-        return await cast(Awaitable[SurfaceResult], result)
+    if isinstance(result, Awaitable):
+        return await result
     return result
 
 

--- a/tests/infra/oracles.py
+++ b/tests/infra/oracles.py
@@ -1,0 +1,45 @@
+"""Reusable semantic oracles for archive verification tests."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+
+from tests.infra.semantic_facts import (
+    ArchiveFacts,
+    ConversationFacts,
+    assert_same_archive_facts,
+    assert_same_conversation_facts,
+)
+
+
+def assert_conversation_surfaces_agree(*facts: ConversationFacts) -> None:
+    """Assert record, hydrated, repository, and surface facts agree."""
+    assert_same_conversation_facts(*facts)
+
+
+def assert_archive_surfaces_agree(*facts: ArchiveFacts) -> None:
+    """Assert aggregate archive facts agree across surfaces."""
+    assert_same_archive_facts(*facts)
+
+
+def assert_provider_partition_exhaustive(
+    *,
+    all_conversation_ids: Iterable[str],
+    ids_by_provider: Mapping[str, Iterable[str]],
+) -> None:
+    """Assert provider buckets partition the archive without gaps or overlap."""
+    expected = set(all_conversation_ids)
+    seen: set[str] = set()
+    for provider, provider_ids in ids_by_provider.items():
+        ids = set(provider_ids)
+        overlap = seen & ids
+        assert not overlap, f"Provider bucket {provider!r} overlaps earlier buckets: {sorted(overlap)}"
+        seen.update(ids)
+    assert seen == expected, f"Provider partition mismatch: expected={sorted(expected)} seen={sorted(seen)}"
+
+
+__all__ = [
+    "assert_archive_surfaces_agree",
+    "assert_conversation_surfaces_agree",
+    "assert_provider_partition_exhaustive",
+]

--- a/tests/infra/pipeline_roundtrip.py
+++ b/tests/infra/pipeline_roundtrip.py
@@ -1,0 +1,73 @@
+"""Shared helpers for payload -> transform -> storage -> hydration laws."""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+
+from polylogue.lib.conversation_models import Conversation
+from polylogue.lib.json import JSONValue, loads
+from polylogue.pipeline.prepare_models import TransformResult
+from polylogue.pipeline.prepare_transform import transform_to_records
+from polylogue.sources.dispatch import detect_provider, parse_payload
+from polylogue.sources.parsers.base import ParsedConversation
+from polylogue.storage.hydrators import conversation_from_records
+from tests.infra.storage_records import store_records
+
+
+@dataclass(frozen=True, slots=True)
+class PipelineRoundtrip:
+    """Parsed and transformed representation of one source payload."""
+
+    parsed: ParsedConversation
+    transform: TransformResult
+
+
+def decode_source_payload(raw_bytes: bytes) -> JSONValue:
+    """Decode JSON or JSONL provider payload bytes."""
+    text = raw_bytes.decode("utf-8")
+    try:
+        return loads(text)
+    except ValueError:
+        return [loads(line) for line in text.strip().splitlines() if line.strip()]
+
+
+def parse_and_transform_payload(
+    provider_name: str,
+    raw_bytes: bytes,
+    archive_root: Path,
+    unique_id: str = "default",
+) -> PipelineRoundtrip:
+    """Run parse -> transform for one payload."""
+    payload = decode_source_payload(raw_bytes)
+    detected = detect_provider(payload)
+    assert detected is not None, f"Provider detection failed for {provider_name}"
+
+    parsed_list = parse_payload(detected, payload, f"rt-{unique_id}")
+    assert parsed_list, "Parser returned no conversations"
+    parsed = parsed_list[0]
+    return PipelineRoundtrip(
+        parsed=parsed,
+        transform=transform_to_records(parsed, f"test-{provider_name}", archive_root=archive_root),
+    )
+
+
+def save_transform_and_hydrate(result: TransformResult, db_conn: sqlite3.Connection) -> Conversation:
+    """Persist transform records and hydrate the resulting bundle."""
+    bundle = result.bundle
+    store_records(
+        conversation=bundle.conversation,
+        messages=bundle.messages,
+        attachments=bundle.attachments,
+        conn=db_conn,
+    )
+    return conversation_from_records(bundle.conversation, bundle.messages, bundle.attachments)
+
+
+__all__ = [
+    "PipelineRoundtrip",
+    "decode_source_payload",
+    "parse_and_transform_payload",
+    "save_transform_and_hydrate",
+]

--- a/tests/infra/pty_cli.py
+++ b/tests/infra/pty_cli.py
@@ -22,7 +22,6 @@ import time
 from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Protocol, cast
 
 # Conditional pyte import with fallback
 try:
@@ -31,12 +30,6 @@ try:
     HAS_PYTE = True
 except ImportError:
     HAS_PYTE = False
-
-
-class TerminalChar(Protocol):
-    """Subset of pyte's Char object used for snapshot rendering."""
-
-    data: str
 
 
 @dataclass
@@ -214,14 +207,20 @@ def run_in_pty(
     stream.feed(raw_output.decode("utf-8", errors="replace"))
 
     # Extract full output: scrollback history + visible screen
-    def _chardict_to_str(chardict: Mapping[int, TerminalChar]) -> str:
+    def _chardict_to_str(chardict: object) -> str:
         """Convert pyte history line (StaticDefaultDict of Char) to string."""
-        if not chardict:
+        if not isinstance(chardict, Mapping) or not chardict:
             return ""
         max_col = max(chardict.keys()) if chardict else 0
-        return "".join(chardict[i].data for i in range(max_col + 1)).rstrip()
+        chars: list[str] = []
+        for index in range(max_col + 1):
+            char = chardict[index]
+            data = getattr(char, "data", "")
+            assert isinstance(data, str)
+            chars.append(data)
+        return "".join(chars).rstrip()
 
-    history_lines = [_chardict_to_str(cast(Mapping[int, TerminalChar], line)) for line in screen.history.top]
+    history_lines = [_chardict_to_str(line) for line in screen.history.top]
     visible_lines = [line.rstrip() for line in screen.display]
     grid = history_lines + visible_lines
 

--- a/tests/infra/query_cases.py
+++ b/tests/infra/query_cases.py
@@ -1,0 +1,22 @@
+"""Reusable semantic query cases for archive-scenario tests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class ArchiveQueryCase:
+    """Expected conversation-id projection for one archive query."""
+
+    name: str
+    expected_ids: tuple[str, ...]
+    provider: str | None = None
+    search_text: str | None = None
+
+    @property
+    def expected_id_set(self) -> set[str]:
+        return set(self.expected_ids)
+
+
+__all__ = ["ArchiveQueryCase"]

--- a/tests/infra/semantic_facts.py
+++ b/tests/infra/semantic_facts.py
@@ -8,11 +8,13 @@ from __future__ import annotations
 
 import sqlite3
 from collections import Counter
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 
 from polylogue.lib.json import JSONDocument, json_document_list
 from polylogue.lib.models import Conversation
-from polylogue.storage.store import ConversationRecord, MessageRecord
+from polylogue.lib.semantic_facts import build_conversation_semantic_facts
+from polylogue.storage.store import AttachmentRecord, ConversationRecord, MessageRecord
 
 
 def _string_value(value: object) -> str:
@@ -39,29 +41,32 @@ class ConversationFacts:
     has_attachments: bool
     has_tool_use: bool
     has_thinking: bool
+    message_ids: tuple[str, ...] = ()
+    text_message_ids: tuple[str, ...] = ()
+    text_role_counts: dict[str, int] | None = None
+    attachment_count: int = 0
+    word_count: int = 0
 
     @classmethod
     def from_domain_conversation(cls, conv: Conversation) -> ConversationFacts:
         """Extract facts from a domain Conversation object."""
         messages = list(conv.messages)
+        semantic = build_conversation_semantic_facts(conv)
         roles = Counter(str(m.role) for m in messages)
-        has_tool_use = any(
-            m.content_blocks and any(block.get("type") in ("tool_use", "tool_result") for block in m.content_blocks)
-            for m in messages
-        )
-        has_thinking = any(
-            m.content_blocks and any(block.get("type") == "thinking" for block in m.content_blocks) for m in messages
-        )
-        has_attachments = any(m.attachments for m in messages)
         return cls(
-            conversation_id=str(conv.id),
-            provider=str(conv.provider),
+            conversation_id=semantic.conversation_id,
+            provider=semantic.provider,
             title=conv.title,
-            message_count=len(messages),
+            message_count=semantic.total_messages,
             role_multiset=dict(roles),
-            has_attachments=has_attachments,
-            has_tool_use=has_tool_use,
-            has_thinking=has_thinking,
+            message_ids=semantic.message_ids,
+            text_message_ids=semantic.text_message_ids,
+            text_role_counts=semantic.text_role_counts,
+            attachment_count=semantic.attachment_count,
+            word_count=semantic.word_count,
+            has_attachments=semantic.attachment_count > 0,
+            has_tool_use=semantic.tool_messages > 0,
+            has_thinking=semantic.thinking_messages > 0,
         )
 
     @classmethod
@@ -83,15 +88,27 @@ class ConversationFacts:
             title=_optional_string(payload.get("title")),
             message_count=len(messages),
             role_multiset=dict(roles),
+            message_ids=tuple(_string_value(message.get("id")) for message in messages),
+            text_message_ids=tuple(
+                _string_value(message.get("id")) for message in messages if _string_value(message.get("text")).strip()
+            ),
+            text_role_counts=dict(roles),
+            attachment_count=sum(1 for message in messages if bool(message.get("attachments"))),
             has_attachments=has_attachments,
             has_tool_use=has_tool_use,
             has_thinking=has_thinking,
         )
 
     @classmethod
-    def from_records(cls, conv_record: ConversationRecord, msg_records: list[MessageRecord]) -> ConversationFacts:
+    def from_records(
+        cls,
+        conv_record: ConversationRecord,
+        msg_records: list[MessageRecord],
+        attachment_records: Sequence[AttachmentRecord] = (),
+    ) -> ConversationFacts:
         """Extract facts from storage records (ConversationRecord + MessageRecords)."""
         roles = Counter(str(m.role) for m in msg_records)
+        text_roles = Counter(str(m.role) for m in msg_records if (m.text or "").strip())
         has_tool_use = any(m.has_tool_use for m in msg_records)
         has_thinking = any(m.has_thinking for m in msg_records)
         return cls(
@@ -100,10 +117,41 @@ class ConversationFacts:
             title=conv_record.title,
             message_count=len(msg_records),
             role_multiset=dict(roles),
-            has_attachments=False,
+            message_ids=tuple(str(message.message_id) for message in msg_records),
+            text_message_ids=tuple(str(message.message_id) for message in msg_records if (message.text or "").strip()),
+            text_role_counts=dict(text_roles),
+            attachment_count=len(attachment_records),
+            word_count=sum(int(message.word_count or 0) for message in msg_records),
+            has_attachments=bool(attachment_records),
             has_tool_use=bool(has_tool_use),
             has_thinking=bool(has_thinking),
         )
+
+    def comparable_core(self) -> tuple[object, ...]:
+        """Facts stable across record, hydrated, and surface representations."""
+        return (
+            self.conversation_id,
+            self.provider,
+            self.title,
+            self.message_count,
+            self.role_multiset,
+            self.message_ids,
+            self.text_message_ids,
+            self.text_role_counts or {},
+            self.attachment_count,
+            self.has_attachments,
+            self.has_tool_use,
+            self.has_thinking,
+        )
+
+
+def assert_same_conversation_facts(*facts: ConversationFacts) -> None:
+    """Assert all supplied conversation facts agree on archive semantics."""
+    if len(facts) < 2:
+        return
+    expected = facts[0].comparable_core()
+    mismatches = [fact for fact in facts[1:] if fact.comparable_core() != expected]
+    assert not mismatches, f"Conversation facts disagree: expected={facts[0]!r} mismatches={mismatches!r}"
 
 
 @dataclass(frozen=True)
@@ -113,6 +161,7 @@ class ArchiveFacts:
     total_conversations: int
     provider_counts: dict[str, int]
     total_messages: int
+    conversation_ids: tuple[str, ...] = ()
 
     @classmethod
     def from_db_connection(cls, conn: sqlite3.Connection) -> ArchiveFacts:
@@ -122,8 +171,49 @@ class ArchiveFacts:
         ).fetchall()
         provider_counts = {str(row["provider_name"]): int(row["cnt"]) for row in provider_rows}
         total_msgs = int(conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0])
+        conversation_ids = tuple(
+            str(row["conversation_id"])
+            for row in conn.execute("SELECT conversation_id FROM conversations ORDER BY conversation_id").fetchall()
+        )
         return cls(
             total_conversations=total_convs,
             provider_counts=provider_counts,
             total_messages=total_msgs,
+            conversation_ids=conversation_ids,
         )
+
+    @classmethod
+    def from_conversations(cls, conversations: Iterable[Conversation]) -> ArchiveFacts:
+        conversations = tuple(conversations)
+        provider_counts = Counter(str(conversation.provider) for conversation in conversations)
+        return cls(
+            total_conversations=len(conversations),
+            provider_counts=dict(provider_counts),
+            total_messages=sum(len(conversation.messages) for conversation in conversations),
+            conversation_ids=tuple(sorted(str(conversation.id) for conversation in conversations)),
+        )
+
+    def comparable_core(self) -> tuple[object, ...]:
+        return (
+            self.total_conversations,
+            self.provider_counts,
+            self.total_messages,
+            self.conversation_ids,
+        )
+
+
+def assert_same_archive_facts(*facts: ArchiveFacts) -> None:
+    """Assert all supplied archive facts agree on aggregate archive semantics."""
+    if len(facts) < 2:
+        return
+    expected = facts[0].comparable_core()
+    mismatches = [fact for fact in facts[1:] if fact.comparable_core() != expected]
+    assert not mismatches, f"Archive facts disagree: expected={facts[0]!r} mismatches={mismatches!r}"
+
+
+__all__ = [
+    "ArchiveFacts",
+    "ConversationFacts",
+    "assert_same_archive_facts",
+    "assert_same_conversation_facts",
+]

--- a/tests/infra/state_machines.py
+++ b/tests/infra/state_machines.py
@@ -1,0 +1,119 @@
+"""Stateful archive lifecycle harnesses for verification tests."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+
+from polylogue.lib.json import JSONDocument, JSONValue
+from polylogue.storage.backends.connection import open_connection
+from polylogue.storage.repository import ConversationRepository
+from tests.infra.archive_scenarios import ArchiveScenario, repository_for_scenario_db
+from tests.infra.oracles import assert_archive_surfaces_agree, assert_conversation_surfaces_agree
+from tests.infra.semantic_facts import ArchiveFacts
+from tests.infra.surfaces import ArchiveSurfaceSet, build_archive_surface_set
+
+
+@dataclass(slots=True)
+class RepositoryLifecycleHarness:
+    """Model repository state transitions and assert archive invariants."""
+
+    db_path: Path
+    repository: ConversationRepository
+    surfaces: ArchiveSurfaceSet
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        db_path: Path,
+        archive_root: Path,
+        scenarios: tuple[ArchiveScenario, ...],
+    ) -> RepositoryLifecycleHarness:
+        return cls(
+            db_path=db_path,
+            repository=repository_for_scenario_db(db_path),
+            surfaces=build_archive_surface_set(
+                db_path=db_path,
+                archive_root=archive_root,
+                scenarios=scenarios,
+            ),
+        )
+
+    async def close(self) -> None:
+        await self.repository.close()
+        await self.surfaces.close()
+
+    async def assert_conversation_visible(self, scenario: ArchiveScenario) -> None:
+        facts = [await surface.conversation_facts(scenario) for surface in self.surfaces.surfaces]
+        assert_conversation_surfaces_agree(*facts)
+
+    async def assert_archive_agrees(self, *, total_conversations: int) -> ArchiveFacts:
+        facts = [await surface.archive_facts() for surface in self.surfaces.surfaces]
+        assert_archive_surfaces_agree(*facts)
+        assert facts[0].total_conversations == total_conversations
+        return facts[0]
+
+    async def assert_metadata_contains(
+        self,
+        conversation_id: str,
+        expected: Mapping[str, JSONValue],
+    ) -> JSONDocument:
+        metadata = await self.repository.get_metadata(conversation_id)
+        for key, value in expected.items():
+            assert metadata.get(key) == value
+        return metadata
+
+    async def assert_tags(self, expected: dict[str, int], *, provider: str | None = None) -> None:
+        assert await self.repository.list_tags(provider=provider) == expected
+
+    async def add_tag_and_assert_visible(self, scenario: ArchiveScenario, tag: str) -> None:
+        await self.repository.add_tag(scenario.resolved_conversation_id, tag)
+        await self.assert_conversation_visible(scenario)
+
+    async def remove_tag_and_assert_visible(self, scenario: ArchiveScenario, tag: str) -> None:
+        await self.repository.remove_tag(scenario.resolved_conversation_id, tag)
+        await self.assert_conversation_visible(scenario)
+
+    async def update_metadata_and_assert_visible(
+        self,
+        scenario: ArchiveScenario,
+        key: str,
+        value: JSONValue,
+    ) -> None:
+        await self.repository.update_metadata(scenario.resolved_conversation_id, key, value)
+        await self.assert_conversation_visible(scenario)
+
+    async def delete_metadata_and_assert_visible(self, scenario: ArchiveScenario, key: str) -> None:
+        await self.repository.delete_metadata(scenario.resolved_conversation_id, key)
+        await self.assert_conversation_visible(scenario)
+
+    async def delete_conversation_and_assert_absent(self, scenario: ArchiveScenario) -> None:
+        conversation_id = scenario.resolved_conversation_id
+        assert await self.repository.delete_conversation(conversation_id) is True
+        assert await self.repository.delete_conversation(conversation_id) is False
+        assert await self.repository.get(conversation_id) is None
+        self.assert_no_dangling_runtime_rows(conversation_id)
+
+    def assert_no_dangling_runtime_rows(self, conversation_id: str) -> None:
+        table_names = ("messages", "content_blocks", "attachment_refs", "action_events")
+        with open_connection(self.db_path) as conn:
+            assert (
+                conn.execute(
+                    "SELECT conversation_id FROM conversations WHERE conversation_id = ?",
+                    (conversation_id,),
+                ).fetchone()
+                is None
+            )
+            for table_name in table_names:
+                count = int(
+                    conn.execute(
+                        f"SELECT COUNT(*) FROM {table_name} WHERE conversation_id = ?",
+                        (conversation_id,),
+                    ).fetchone()[0]
+                )
+                assert count == 0, f"{table_name} retained rows for deleted conversation {conversation_id!r}"
+
+
+__all__ = ["RepositoryLifecycleHarness"]

--- a/tests/infra/strategies/search.py
+++ b/tests/infra/strategies/search.py
@@ -6,7 +6,7 @@ unicode handling, operator injection, and ranking edge cases.
 
 from __future__ import annotations
 
-from typing import Literal, cast
+from typing import Literal
 
 from hypothesis import strategies as st
 
@@ -40,46 +40,45 @@ def search_query_strategy(draw: st.DrawFn) -> str:
     - SQL injection payloads
     - Empty/whitespace
     """
-    return cast(
-        str,
-        draw(
-            st.one_of(
-                # Simple terms
+    value = draw(
+        st.one_of(
+            # Simple terms
+            st.text(
+                min_size=1,
+                max_size=50,
+                alphabet=st.characters(whitelist_categories=_LETTER_NUMBER_CATEGORIES),
+            ),
+            # FTS5 operators as literals
+            st.sampled_from(FTS5_OPERATORS),
+            # SQL injection payloads
+            st.sampled_from(SQL_INJECTION_PAYLOADS),
+            # Unicode text
+            st.text(min_size=1, max_size=30),
+            # Quoted strings with internal quotes
+            st.builds(
+                lambda t: f'"{t}"',
                 st.text(
                     min_size=1,
-                    max_size=50,
+                    max_size=20,
+                    alphabet=st.characters(whitelist_categories=_LETTER_NUMBER_PUNCT_SPACE_CATEGORIES),
+                ),
+            ),
+            # Operator-prefix patterns (e.g. "NOT foo", "NEAR bar")
+            st.builds(
+                lambda op, term: f"{op} {term}",
+                st.sampled_from(["NOT", "NEAR", "AND", "OR"]),
+                st.text(
+                    min_size=1,
+                    max_size=20,
                     alphabet=st.characters(whitelist_categories=_LETTER_NUMBER_CATEGORIES),
                 ),
-                # FTS5 operators as literals
-                st.sampled_from(FTS5_OPERATORS),
-                # SQL injection payloads
-                st.sampled_from(SQL_INJECTION_PAYLOADS),
-                # Unicode text
-                st.text(min_size=1, max_size=30),
-                # Quoted strings with internal quotes
-                st.builds(
-                    lambda t: f'"{t}"',
-                    st.text(
-                        min_size=1,
-                        max_size=20,
-                        alphabet=st.characters(whitelist_categories=_LETTER_NUMBER_PUNCT_SPACE_CATEGORIES),
-                    ),
-                ),
-                # Operator-prefix patterns (e.g. "NOT foo", "NEAR bar")
-                st.builds(
-                    lambda op, term: f"{op} {term}",
-                    st.sampled_from(["NOT", "NEAR", "AND", "OR"]),
-                    st.text(
-                        min_size=1,
-                        max_size=20,
-                        alphabet=st.characters(whitelist_categories=_LETTER_NUMBER_CATEGORIES),
-                    ),
-                ),
-                # Empty and whitespace
-                st.sampled_from(["", " ", "  \t  ", "\n"]),
-            )
-        ),
+            ),
+            # Empty and whitespace
+            st.sampled_from(["", " ", "  \t  ", "\n"]),
+        )
     )
+    assert isinstance(value, str)
+    return value
 
 
 @st.composite

--- a/tests/infra/surfaces.py
+++ b/tests/infra/surfaces.py
@@ -101,8 +101,7 @@ class SQLiteHydratedSurface:
     async def archive_facts(self) -> ArchiveFacts:
         with open_connection(self.db_path) as conn:
             conversations = [
-                scenario.hydrated_facts_from_connection(conn)
-                for scenario in sorted(self.scenarios, key=lambda item: item.resolved_conversation_id)
+                scenario.hydrated_facts_from_connection(conn) for scenario in _current_archive_scenarios(conn)
             ]
         return ArchiveFacts(
             total_conversations=len(conversations),
@@ -225,6 +224,11 @@ def _provider_counts(conversations: list[ConversationFacts]) -> dict[str, int]:
     for conversation in conversations:
         counts[conversation.provider] = counts.get(conversation.provider, 0) + 1
     return counts
+
+
+def _current_archive_scenarios(conn: sqlite3.Connection) -> tuple[ArchiveScenario, ...]:
+    rows = conn.execute("SELECT conversation_id FROM conversations ORDER BY conversation_id").fetchall()
+    return tuple(ArchiveScenario(name=str(row["conversation_id"])) for row in rows)
 
 
 __all__ = [

--- a/tests/infra/surfaces.py
+++ b/tests/infra/surfaces.py
@@ -1,0 +1,238 @@
+"""Archive surface adapters for scenario-driven verification tests."""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+
+from polylogue.facade import Polylogue
+from polylogue.storage.backends.connection import open_connection
+from tests.infra.archive_scenarios import ArchiveScenario, repository_for_scenario_db
+from tests.infra.query_cases import ArchiveQueryCase
+from tests.infra.semantic_facts import ArchiveFacts, ConversationFacts
+
+
+def _sorted_unique(values: list[str] | tuple[str, ...] | set[str]) -> tuple[str, ...]:
+    return tuple(sorted(set(values)))
+
+
+def _provider_ids_from_connection(conn: sqlite3.Connection, provider: str) -> tuple[str, ...]:
+    rows = conn.execute(
+        "SELECT conversation_id FROM conversations WHERE provider_name = ? ORDER BY conversation_id",
+        (provider,),
+    ).fetchall()
+    return tuple(str(row["conversation_id"]) for row in rows)
+
+
+def _search_ids_from_connection(conn: sqlite3.Connection, search_text: str) -> tuple[str, ...]:
+    rows = conn.execute(
+        """
+        SELECT DISTINCT conversation_id
+        FROM messages_fts
+        WHERE messages_fts MATCH ?
+        ORDER BY conversation_id
+        """,
+        (search_text,),
+    ).fetchall()
+    return tuple(str(row["conversation_id"]) for row in rows)
+
+
+class ArchiveSurfaceAdapter(Protocol):
+    """Common semantic projection surface over a seeded archive."""
+
+    @property
+    def name(self) -> str: ...
+
+    async def conversation_facts(self, scenario: ArchiveScenario) -> ConversationFacts: ...
+
+    async def archive_facts(self) -> ArchiveFacts: ...
+
+    async def query_ids(self, query_case: ArchiveQueryCase) -> tuple[str, ...]: ...
+
+    async def query_count(self, query_case: ArchiveQueryCase) -> int: ...
+
+    async def close(self) -> None: ...
+
+
+@dataclass(frozen=True, slots=True)
+class SQLiteRecordSurface:
+    """Direct SQL/storage-record projection."""
+
+    db_path: Path
+    name: str = "sqlite-records"
+
+    async def conversation_facts(self, scenario: ArchiveScenario) -> ConversationFacts:
+        with open_connection(self.db_path) as conn:
+            return scenario.facts_from_connection(conn)
+
+    async def archive_facts(self) -> ArchiveFacts:
+        with open_connection(self.db_path) as conn:
+            return ArchiveFacts.from_db_connection(conn)
+
+    async def query_ids(self, query_case: ArchiveQueryCase) -> tuple[str, ...]:
+        with open_connection(self.db_path) as conn:
+            if query_case.provider is not None:
+                return _provider_ids_from_connection(conn, query_case.provider)
+            if query_case.search_text is not None:
+                return _search_ids_from_connection(conn, query_case.search_text)
+        raise ValueError(f"Query case {query_case.name!r} does not define a supported projection")
+
+    async def query_count(self, query_case: ArchiveQueryCase) -> int:
+        return len(await self.query_ids(query_case))
+
+    async def close(self) -> None:
+        return None
+
+
+@dataclass(frozen=True, slots=True)
+class SQLiteHydratedSurface:
+    """Direct SQL projection after storage-record hydration."""
+
+    db_path: Path
+    scenarios: tuple[ArchiveScenario, ...]
+    name: str = "sqlite-hydrated"
+
+    async def conversation_facts(self, scenario: ArchiveScenario) -> ConversationFacts:
+        with open_connection(self.db_path) as conn:
+            return scenario.hydrated_facts_from_connection(conn)
+
+    async def archive_facts(self) -> ArchiveFacts:
+        with open_connection(self.db_path) as conn:
+            conversations = [
+                scenario.hydrated_facts_from_connection(conn)
+                for scenario in sorted(self.scenarios, key=lambda item: item.resolved_conversation_id)
+            ]
+        return ArchiveFacts(
+            total_conversations=len(conversations),
+            provider_counts=_provider_counts(conversations),
+            total_messages=sum(facts.message_count for facts in conversations),
+            conversation_ids=tuple(facts.conversation_id for facts in conversations),
+        )
+
+    async def query_ids(self, query_case: ArchiveQueryCase) -> tuple[str, ...]:
+        with open_connection(self.db_path) as conn:
+            if query_case.provider is not None:
+                return _provider_ids_from_connection(conn, query_case.provider)
+            if query_case.search_text is not None:
+                return _search_ids_from_connection(conn, query_case.search_text)
+        raise ValueError(f"Query case {query_case.name!r} does not define a supported projection")
+
+    async def query_count(self, query_case: ArchiveQueryCase) -> int:
+        return len(await self.query_ids(query_case))
+
+    async def close(self) -> None:
+        return None
+
+
+class RepositorySurface:
+    """Async repository projection."""
+
+    name = "repository"
+
+    def __init__(self, db_path: Path) -> None:
+        self._repository = repository_for_scenario_db(db_path)
+
+    async def conversation_facts(self, scenario: ArchiveScenario) -> ConversationFacts:
+        return await scenario.facts_from_repository(self._repository)
+
+    async def archive_facts(self) -> ArchiveFacts:
+        return ArchiveFacts.from_conversations(await self._repository.list(limit=None))
+
+    async def query_ids(self, query_case: ArchiveQueryCase) -> tuple[str, ...]:
+        if query_case.provider is not None:
+            conversations = await self._repository.list(provider=query_case.provider, limit=None)
+        elif query_case.search_text is not None:
+            conversations = await self._repository.search(query_case.search_text, limit=100)
+        else:
+            raise ValueError(f"Query case {query_case.name!r} does not define a supported projection")
+        return _sorted_unique([str(conversation.id) for conversation in conversations])
+
+    async def query_count(self, query_case: ArchiveQueryCase) -> int:
+        if query_case.provider is not None:
+            return await self._repository.count(provider=query_case.provider)
+        return len(await self.query_ids(query_case))
+
+    async def close(self) -> None:
+        await self._repository.close()
+
+
+class FacadeSurface:
+    """Public async facade projection."""
+
+    name = "facade"
+
+    def __init__(self, *, archive_root: Path, db_path: Path) -> None:
+        self._archive = Polylogue(archive_root=archive_root, db_path=db_path)
+
+    async def conversation_facts(self, scenario: ArchiveScenario) -> ConversationFacts:
+        conversation = await self._archive.get_conversation(scenario.resolved_conversation_id)
+        if conversation is None:
+            raise AssertionError(f"Scenario {scenario.resolved_conversation_id!r} missing through facade")
+        return ConversationFacts.from_domain_conversation(conversation)
+
+    async def archive_facts(self) -> ArchiveFacts:
+        return ArchiveFacts.from_conversations(await self._archive.list_conversations(limit=None))
+
+    async def query_ids(self, query_case: ArchiveQueryCase) -> tuple[str, ...]:
+        if query_case.provider is not None:
+            conversations = await self._archive.list_conversations(provider=query_case.provider, limit=None)
+            return _sorted_unique([str(conversation.id) for conversation in conversations])
+        if query_case.search_text is not None:
+            result = await self._archive.search(query_case.search_text, limit=100)
+            return _sorted_unique([hit.conversation_id for hit in result.hits])
+        raise ValueError(f"Query case {query_case.name!r} does not define a supported projection")
+
+    async def query_count(self, query_case: ArchiveQueryCase) -> int:
+        return len(await self.query_ids(query_case))
+
+    async def close(self) -> None:
+        await self._archive.close()
+
+
+@dataclass(slots=True)
+class ArchiveSurfaceSet:
+    """Closable group of archive surface adapters."""
+
+    surfaces: tuple[ArchiveSurfaceAdapter, ...]
+
+    async def close(self) -> None:
+        for surface in self.surfaces:
+            await surface.close()
+
+
+def build_archive_surface_set(
+    *,
+    db_path: Path,
+    archive_root: Path,
+    scenarios: tuple[ArchiveScenario, ...],
+) -> ArchiveSurfaceSet:
+    """Build the standard cross-surface set for a scenario archive."""
+    surfaces: tuple[ArchiveSurfaceAdapter, ...] = (
+        SQLiteRecordSurface(db_path),
+        SQLiteHydratedSurface(db_path, scenarios),
+        RepositorySurface(db_path),
+        FacadeSurface(archive_root=archive_root, db_path=db_path),
+    )
+    return ArchiveSurfaceSet(
+        surfaces=surfaces,
+    )
+
+
+def _provider_counts(conversations: list[ConversationFacts]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for conversation in conversations:
+        counts[conversation.provider] = counts.get(conversation.provider, 0) + 1
+    return counts
+
+
+__all__ = [
+    "ArchiveSurfaceAdapter",
+    "ArchiveSurfaceSet",
+    "FacadeSurface",
+    "RepositorySurface",
+    "SQLiteHydratedSurface",
+    "SQLiteRecordSurface",
+    "build_archive_surface_set",
+]

--- a/tests/infra/test_archive_scenarios.py
+++ b/tests/infra/test_archive_scenarios.py
@@ -1,0 +1,92 @@
+"""Tests for shared archive scenario and oracle helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+
+import pytest
+
+from polylogue.storage.backends.connection import open_connection
+from tests.infra.archive_scenarios import (
+    ArchiveScenario,
+    ScenarioAttachment,
+    ScenarioMessage,
+    repository_for_scenario_db,
+    seed_workspace_scenarios,
+)
+from tests.infra.oracles import assert_conversation_surfaces_agree
+from tests.infra.semantic_facts import ArchiveFacts, assert_same_archive_facts
+
+
+def test_archive_scenario_seeds_record_and_hydration_facts(workspace_env: Mapping[str, Path]) -> None:
+    scenario = ArchiveScenario(
+        name="scenario-harness",
+        provider="claude-code",
+        title="Harness conversation",
+        messages=(
+            ScenarioMessage(role="user", text="Run the checks", message_id="m-user"),
+            ScenarioMessage(
+                role="assistant",
+                text="Using pytest",
+                message_id="m-tool",
+                content_blocks=(
+                    {
+                        "type": "tool_use",
+                        "tool_name": "shell",
+                        "tool_input": {"command": "pytest -q"},
+                    },
+                ),
+                attachments=(ScenarioAttachment(attachment_id="att-report", mime_type="text/plain"),),
+            ),
+        ),
+    )
+    db_path, seeds = seed_workspace_scenarios(workspace_env, [scenario])
+
+    assert [seed.conversation_id for seed in seeds] == ["scenario-harness"]
+    with open_connection(db_path) as conn:
+        assert_conversation_surfaces_agree(
+            scenario.facts_from_connection(conn),
+            scenario.hydrated_facts_from_connection(conn),
+        )
+
+
+@pytest.mark.asyncio()
+async def test_archive_scenario_repository_projection_agrees(workspace_env: Mapping[str, Path]) -> None:
+    scenario = ArchiveScenario(
+        name="repository-harness",
+        provider="chatgpt",
+        title="Repository view",
+        messages=(
+            ScenarioMessage(role="user", text="Question", message_id="m1"),
+            ScenarioMessage(role="assistant", text="Answer", message_id="m2"),
+        ),
+    )
+    db_path, _ = seed_workspace_scenarios(workspace_env, [scenario])
+    repository = repository_for_scenario_db(db_path)
+    try:
+        with open_connection(db_path) as conn:
+            assert_conversation_surfaces_agree(
+                scenario.facts_from_connection(conn),
+                await scenario.facts_from_repository(repository),
+            )
+    finally:
+        await repository.close()
+
+
+@pytest.mark.asyncio()
+async def test_archive_facts_compare_db_and_repository(workspace_env: Mapping[str, Path]) -> None:
+    scenarios = [
+        ArchiveScenario(name="archive-a", provider="chatgpt"),
+        ArchiveScenario(name="archive-b", provider="codex"),
+    ]
+    db_path, _ = seed_workspace_scenarios(workspace_env, scenarios)
+    repository = repository_for_scenario_db(db_path)
+    try:
+        with open_connection(db_path) as conn:
+            db_facts = ArchiveFacts.from_db_connection(conn)
+        repository_facts = ArchiveFacts.from_conversations(await repository.list(limit=None))
+    finally:
+        await repository.close()
+
+    assert_same_archive_facts(db_facts, repository_facts)

--- a/tests/infra/test_storage_records.py
+++ b/tests/infra/test_storage_records.py
@@ -6,7 +6,7 @@ import sqlite3
 from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Literal, cast
+from typing import Literal
 
 import pytest
 
@@ -28,16 +28,18 @@ def test_store_records_commits_within_lock(monkeypatch: pytest.MonkeyPatch) -> N
             self.held = False
             return False
 
-    class DummyConn:
-        def __init__(self, lock: TrackingLock) -> None:
-            self._lock = lock
-            self.commit_states: list[bool] = []
+    class TrackingConnection(sqlite3.Connection):
+        _lock: TrackingLock
+        commit_states: list[bool]
 
         def commit(self) -> None:
             self.commit_states.append(self._lock.held)
+            super().commit()
 
     lock = TrackingLock()
-    conn = DummyConn(lock)
+    conn = sqlite3.connect(":memory:", factory=TrackingConnection)
+    conn._lock = lock
+    conn.commit_states = []
 
     @contextmanager
     def fake_connection_context(passed_conn: sqlite3.Connection) -> Iterator[sqlite3.Connection]:
@@ -54,12 +56,13 @@ def test_store_records_commits_within_lock(monkeypatch: pytest.MonkeyPatch) -> N
         conversation=make_conversation("test:1", title="Test", content_hash="abc123"),
         messages=[make_message("test:1:msg1", "test:1", text="Hello")],
         attachments=[],
-        conn=cast(sqlite3.Connection, conn),
+        conn=conn,
     )
 
     assert result["conversations"] == 1
     assert result["messages"] == 1
     assert conn.commit_states == [True]
+    conn.close()
 
 
 def test_concurrent_store_records_no_deadlock(workspace_env: Mapping[str, Path]) -> None:

--- a/tests/unit/cli/test_check_runtime.py
+++ b/tests/unit/cli/test_check_runtime.py
@@ -451,6 +451,7 @@ class TestRuntimeHealthToDict:
         assert "checks" in data
         assert "summary" in data
         assert "timestamp" in data
-        assert isinstance(data["checks"], list)
-        assert all("name" in c for c in data["checks"])
-        assert all("status" in c for c in data["checks"])
+        checks = data["checks"]
+        assert isinstance(checks, list)
+        assert all(isinstance(check, dict) and "name" in check for check in checks)
+        assert all(isinstance(check, dict) and "status" in check for check in checks)

--- a/tests/unit/cli/test_click_app.py
+++ b/tests/unit/cli/test_click_app.py
@@ -6,7 +6,6 @@ import json
 import os
 import sys
 from pathlib import Path
-from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -80,7 +79,7 @@ class TestHandleQueryMode:
             patch("polylogue.cli.click_app._show_stats") as mock_stats,
         ):
             _handle_query_mode(mock_ctx)
-            return cast(MagicMock, mock_execute), cast(MagicMock, mock_stats)
+            return mock_execute, mock_stats
 
     def test_no_args_shows_stats(self) -> None:
         mock_execute, mock_stats = self._call(self._make_params())

--- a/tests/unit/cli/test_click_app_main.py
+++ b/tests/unit/cli/test_click_app_main.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import sys
-from typing import cast
 from unittest.mock import patch
 
 import click
@@ -23,6 +22,12 @@ def _system_exit_code(code: str | int | None) -> int:
     return 1
 
 
+def _json_object(payload: str) -> dict[str, object]:
+    value = json.loads(payload)
+    assert isinstance(value, dict)
+    return {str(key): item for key, item in value.items()}
+
+
 def _run_main_with_error(
     monkeypatch: pytest.MonkeyPatch,
     argv: list[str],
@@ -34,7 +39,7 @@ def _run_main_with_error(
         with pytest.raises(SystemExit) as exit_info:
             main()
     captured = capsys.readouterr()
-    return _system_exit_code(exit_info.value.code), cast(dict[str, object], json.loads(captured.out))
+    return _system_exit_code(exit_info.value.code), _json_object(captured.out)
 
 
 def test_main_wraps_usage_error_as_json(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/unit/cli/test_deterministic_output.py
+++ b/tests/unit/cli/test_deterministic_output.py
@@ -16,7 +16,7 @@ import sys
 from datetime import datetime, timezone
 from io import StringIO
 from pathlib import Path
-from typing import TypeAlias, cast
+from typing import TypeAlias
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -51,14 +51,14 @@ def _extract_json(output: str) -> JSONEnvelope:
             parsed = json.loads("\n".join(lines[i:]))
             if not isinstance(parsed, dict):
                 raise ValueError(f"Expected JSON object in output:\n{output}")
-            return cast(JSONEnvelope, parsed)
+            return dict(parsed)
     raise ValueError(f"No JSON object in output:\n{output}")
 
 
 def _result_payload(data: JSONEnvelope) -> JSONEnvelope:
     result = data["result"]
     assert isinstance(result, dict)
-    return cast(JSONEnvelope, result)
+    return dict(result)
 
 
 def _has_ansi(text: str) -> bool:

--- a/tests/unit/cli/test_json_envelope_contract.py
+++ b/tests/unit/cli/test_json_envelope_contract.py
@@ -12,7 +12,7 @@ pure output formatting, independent of path caching).
 from __future__ import annotations
 
 import json
-from typing import TypeAlias, cast
+from typing import TypeAlias
 
 import pytest
 from click.testing import CliRunner
@@ -82,13 +82,13 @@ def _parse_json_output(output: str) -> JSONEnvelope:
     parsed = json.loads(json_text)
     if not isinstance(parsed, dict):
         raise ValueError(f"Expected object envelope, got {type(parsed).__name__}")
-    return cast(JSONEnvelope, parsed)
+    return dict(parsed)
 
 
 def _result_payload(data: JSONEnvelope) -> JSONEnvelope:
     result = data["result"]
     assert isinstance(result, dict)
-    return cast(JSONEnvelope, result)
+    return dict(result)
 
 
 def _invoke_json_command(args: list[str], monkeypatch: pytest.MonkeyPatch) -> JSONEnvelope | None:

--- a/tests/unit/cli/test_products.py
+++ b/tests/unit/cli/test_products.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import json
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Protocol, cast
 from unittest.mock import MagicMock
 
 import click
@@ -24,16 +23,6 @@ from tests.infra.storage_records import ConversationBuilder
 
 JsonObject = dict[str, object]
 CliWorkspace = dict[str, Path]
-
-
-class ProductCallback(Protocol):
-    def __wrapped__(
-        self,
-        ctx: click.Context,
-        *,
-        json_mode: bool,
-        refined_work_kind: str,
-    ) -> object: ...
 
 
 def _expect_object(value: object) -> JsonObject:
@@ -243,7 +232,9 @@ def test_products_callback_rejects_unknown_query_fields() -> None:
     with pytest.raises(
         SystemExit, match="products enrichments: Unknown query field\\(s\\) for session_enrichments: refined_work_kind"
     ):
-        cast(ProductCallback, callback).__wrapped__(mock_ctx, json_mode=False, refined_work_kind="planning")
+        wrapped = getattr(callback, "__wrapped__", None)
+        assert callable(wrapped)
+        wrapped(mock_ctx, json_mode=False, refined_work_kind="planning")
 
 
 def test_products_profiles_json_supports_explicit_evidence_and_inference_tiers(cli_workspace: CliWorkspace) -> None:

--- a/tests/unit/cli/test_qa_finalization.py
+++ b/tests/unit/cli/test_qa_finalization.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import cast
 from unittest.mock import MagicMock
 
 import pytest
@@ -10,6 +9,11 @@ import pytest
 from polylogue.cli.qa_finalization import finalize_qa_run
 from polylogue.cli.qa_requests import QACaptureMode, QAFinalizationPlan, QASnapshotPlan
 from polylogue.showcase.qa_runner import QAResult
+
+
+def _string_payload(value: object) -> str:
+    assert isinstance(value, str)
+    return value
 
 
 def test_finalize_qa_run_emits_json_and_executes_snapshot(
@@ -56,7 +60,7 @@ def test_finalize_qa_run_emits_json_and_executes_snapshot(
 
     finalize_qa_run(result, plan=plan, archive_root=tmp_path / "archive", env=env)
 
-    assert json.loads(cast(str, emitted["json_payload"]))["overall_status"] == "ok"
+    assert json.loads(_string_payload(emitted["json_payload"]))["overall_status"] == "ok"
     assert emitted["capture_showcase_result"] is showcase_result
     assert emitted["capture_json_output"] is True
     assert emitted["fallback_source_dir"] == tmp_path / "report"

--- a/tests/unit/cli/test_query_exec.py
+++ b/tests/unit/cli/test_query_exec.py
@@ -13,7 +13,7 @@ from datetime import datetime, timezone
 from io import StringIO
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Literal, TextIO, cast
+from typing import Literal, TextIO
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -97,6 +97,12 @@ def _make_env(*, repo: MagicMock | None = None, config: MagicMock | None = None)
         if not isinstance(repo.get_action_event_artifact_state, AsyncMock):
             repo.get_action_event_artifact_state = AsyncMock(return_value=_ready_action_event_state())
     return AppEnv(ui=ui, services=build_runtime_services(config=config, repository=repo))
+
+
+def _as_mock(value: object) -> MagicMock:
+    if not isinstance(value, MagicMock):
+        raise TypeError(f"expected MagicMock, got {type(value).__name__}")
+    return value
 
 
 def _make_params(**overrides: object) -> dict[str, object]:
@@ -820,7 +826,7 @@ def test_open_in_browser_contract(
     from polylogue.cli.query_output import _open_in_browser
 
     env = _make_env(config=MagicMock())
-    mock_print = cast(MagicMock, env.ui.console.print)
+    mock_print = _as_mock(env.ui.console.print)
     created_file = tmp_path / "output.html"
 
     class _TempFile:
@@ -838,7 +844,7 @@ def test_open_in_browser_contract(
         patch("tempfile.NamedTemporaryFile", return_value=_TempFile()),
         patch("webbrowser.open") as mock_open,
     ):
-        mock_open = cast(MagicMock, mock_open)
+        mock_open = _as_mock(mock_open)
         _open_in_browser(env, content, output_format, conv)
 
     assert expected_in_file in created_file.read_text(encoding="utf-8")
@@ -862,10 +868,10 @@ def test_copy_to_clipboard_contract(
     from polylogue.cli.query_output import _copy_to_clipboard
 
     env = _make_env(config=MagicMock())
-    mock_print = cast(MagicMock, env.ui.console.print)
+    mock_print = _as_mock(env.ui.console.print)
 
     with patch("subprocess.run", side_effect=side_effects), patch("click.echo") as mock_echo:
-        mock_echo = cast(MagicMock, mock_echo)
+        mock_echo = _as_mock(mock_echo)
         _copy_to_clipboard(env, "hello")
 
     assert mock_print.called is expect_console
@@ -950,7 +956,7 @@ def test_open_result_contract(
         fallback.write_text("<html></html>", encoding="utf-8")
 
     env = _make_env(config=MagicMock(render_root=render_root))
-    mock_print = cast(MagicMock, env.ui.console.print)
+    mock_print = _as_mock(env.ui.console.print)
     output = QueryOutputSpec.from_params(params)
     with (
         patch("polylogue.cli.helpers.load_effective_config", return_value=MagicMock(render_root=render_root)),
@@ -958,8 +964,8 @@ def test_open_result_contract(
         patch("webbrowser.open") as mock_open,
         patch("click.echo") as mock_echo,
     ):
-        mock_open = cast(MagicMock, mock_open)
-        mock_echo = cast(MagicMock, mock_echo)
+        mock_open = _as_mock(mock_open)
+        mock_echo = _as_mock(mock_echo)
         if expected_exit is not None:
             with pytest.raises(SystemExit) as exc_info:
                 _open_result(env, results, output)
@@ -991,7 +997,7 @@ def test_open_result_no_results_json_contract(capsys: pytest.CaptureFixture[str]
         patch("polylogue.cli.helpers.latest_render_path", return_value=None),
         patch("webbrowser.open") as mock_open,
     ):
-        mock_open = cast(MagicMock, mock_open)
+        mock_open = _as_mock(mock_open)
         with pytest.raises(SystemExit) as exc_info:
             _open_result(env, [], QueryOutputSpec.from_params({"output_format": "json"}))
 

--- a/tests/unit/cli/test_query_exec_laws.py
+++ b/tests/unit/cli/test_query_exec_laws.py
@@ -9,7 +9,6 @@ import json
 import tempfile
 from pathlib import Path
 from types import SimpleNamespace
-from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -108,6 +107,18 @@ def _make_env(*, repo: MagicMock | None = None, config: MagicMock | None = None)
         if not isinstance(repo.get_action_event_artifact_state, AsyncMock):
             repo.get_action_event_artifact_state = AsyncMock(return_value=_ready_action_event_state())
     return AppEnv(ui=ui, services=build_runtime_services(config=config, repository=repo))
+
+
+def _as_mock(value: object) -> MagicMock:
+    if not isinstance(value, MagicMock):
+        raise TypeError(f"expected MagicMock, got {type(value).__name__}")
+    return value
+
+
+def _as_console_like(value: object) -> ConsoleLike:
+    if not isinstance(value, ConsoleLike):
+        raise TypeError(f"expected ConsoleLike, got {type(value).__name__}")
+    return value
 
 
 def _fields_arg(fields: tuple[str, ...] | None) -> str | None:
@@ -328,7 +339,7 @@ def _sample_semantic_conversation() -> Conversation:
 def _make_recording_env() -> tuple[AppEnv, io.StringIO]:
     buffer = io.StringIO()
     env = _make_env()
-    env.ui.console = cast(ConsoleLike, Console(file=buffer, width=120, force_terminal=False, color_system=None))
+    env.ui.console = _as_console_like(Console(file=buffer, width=120, force_terminal=False, color_system=None))
     return env, buffer
 
 
@@ -422,8 +433,8 @@ def test_apply_modifiers_contract(case: QueryMutationCase) -> None:
     repo.update_metadata = AsyncMock()
     repo.add_tag = AsyncMock()
     env = _make_env(repo=repo)
-    mock_confirm = cast(MagicMock, env.ui.confirm)
-    mock_print = cast(MagicMock, env.ui.console.print)
+    mock_confirm = _as_mock(env.ui.confirm)
+    mock_print = _as_mock(env.ui.console.print)
     mock_confirm.return_value = case.confirm
     results = [build_conversation_summary(spec) for spec in case.summaries]
     mutation = _mutation_spec(
@@ -434,7 +445,7 @@ def test_apply_modifiers_contract(case: QueryMutationCase) -> None:
     )
 
     with patch("click.echo") as mock_echo:
-        mock_echo = cast(MagicMock, mock_echo)
+        mock_echo = _as_mock(mock_echo)
         asyncio.run(apply_modifiers(env, results, mutation, repo))
 
     should_confirm = len(results) > 10 and not case.force and not case.dry_run
@@ -468,13 +479,13 @@ def test_delete_conversations_contract(case: QueryDeleteCase) -> None:
     repo = MagicMock()
     repo.delete_conversation = AsyncMock(side_effect=list(case.delete_results))
     env = _make_env(repo=repo)
-    mock_confirm = cast(MagicMock, env.ui.confirm)
+    mock_confirm = _as_mock(env.ui.confirm)
     mock_confirm.return_value = case.confirm
     results = [build_conversation_summary(spec) for spec in case.summaries]
     mutation = _mutation_spec(dry_run=case.dry_run, force=case.force, delete_matched=True)
 
     with patch("click.echo") as mock_echo:
-        mock_echo = cast(MagicMock, mock_echo)
+        mock_echo = _as_mock(mock_echo)
         asyncio.run(delete_conversations(env, results, mutation, repo))
 
     should_confirm = not case.force and not case.dry_run
@@ -521,10 +532,10 @@ def test_output_summary_list_contract(case: SummaryOutputCase, output_format: st
     output = _output_spec(output_format=output_format)
     if output_format in {"json", "yaml"}:
         output = _output_spec(output_format=output_format, fields=_fields_arg(case.selected_fields))
-    cast(MagicMock, env.ui).plain = output_format == "text"
+    _as_mock(env.ui).plain = output_format == "text"
 
     with patch("click.echo") as mock_echo:
-        mock_echo = cast(MagicMock, mock_echo)
+        mock_echo = _as_mock(mock_echo)
         asyncio.run(_output_summary_list(env, summaries, output, repo))
 
     if output_format == "json":
@@ -567,9 +578,9 @@ def test_send_output_routes_destination_contract(case: SendOutputCase) -> None:
             patch("polylogue.cli.query_output._open_in_browser") as mock_browser,
             patch("polylogue.cli.query_output._copy_to_clipboard") as mock_clipboard,
         ):
-            mock_echo = cast(MagicMock, mock_echo)
-            mock_browser = cast(MagicMock, mock_browser)
-            mock_clipboard = cast(MagicMock, mock_clipboard)
+            mock_echo = _as_mock(mock_echo)
+            mock_browser = _as_mock(mock_browser)
+            mock_clipboard = _as_mock(mock_clipboard)
             _send_output(env, content, _delivery_targets(*destinations), case.output_format, None)
 
         assert mock_echo.call_count == (1 if case.to_stdout else 0)
@@ -686,11 +697,11 @@ def test_output_stats_by_summaries_json_contract() -> None:
     msg_counts = {"conv-a": 3, "conv-b": 4}
 
     with patch("click.echo") as mock_echo:
-        mock_echo = cast(MagicMock, mock_echo)
+        mock_echo = _as_mock(mock_echo)
         output_stats_by_summaries(env, summaries, msg_counts, "provider", output_format="json")
 
     payload = json.loads(mock_echo.call_args.args[0])
-    cast(MagicMock, env.ui.console.print).assert_not_called()
+    _as_mock(env.ui.console.print).assert_not_called()
     assert payload == {
         "dimension": "provider",
         "multi_membership": False,
@@ -831,7 +842,7 @@ async def test_output_stats_by_semantic_summaries_json_contract() -> None:
     ]
 
     with patch("click.echo") as mock_echo:
-        mock_echo = cast(MagicMock, mock_echo)
+        mock_echo = _as_mock(mock_echo)
         await output_stats_by_semantic_summaries(
             env,
             summaries,
@@ -843,7 +854,7 @@ async def test_output_stats_by_semantic_summaries_json_contract() -> None:
         )
 
     payload = json.loads(mock_echo.call_args.args[0])
-    cast(MagicMock, env.ui.console.print).assert_not_called()
+    _as_mock(env.ui.console.print).assert_not_called()
     assert payload == {
         "dimension": "action",
         "multi_membership": True,
@@ -987,10 +998,10 @@ def test_output_results_no_results_contract() -> None:
         patch("polylogue.cli.query_output.format_conversation") as mock_format,
         pytest.raises(SystemExit) as exc_info,
     ):
-        mock_no_results = cast(MagicMock, mock_no_results)
-        mock_render = cast(MagicMock, mock_render)
-        mock_send = cast(MagicMock, mock_send)
-        mock_format = cast(MagicMock, mock_format)
+        mock_no_results = _as_mock(mock_no_results)
+        mock_render = _as_mock(mock_render)
+        mock_send = _as_mock(mock_send)
+        mock_format = _as_mock(mock_format)
         output_results(env, [], output)
 
     assert exc_info.value.code == 2
@@ -1031,7 +1042,7 @@ def test_output_results_projection_contract(
 ) -> None:
     del label
     env = _make_env()
-    cast(MagicMock, env.ui).plain = plain
+    _as_mock(env.ui).plain = plain
     output = QueryOutputSpec.from_params(params)
 
     with (
@@ -1040,10 +1051,10 @@ def test_output_results_projection_contract(
         patch("polylogue.cli.query_output.format_conversation", return_value="<html>ok</html>") as mock_format,
         patch("polylogue.cli.query_output._format_list", return_value="formatted-list") as mock_format_list,
     ):
-        mock_render = cast(MagicMock, mock_render)
-        mock_send = cast(MagicMock, mock_send)
-        mock_format = cast(MagicMock, mock_format)
-        mock_format_list = cast(MagicMock, mock_format_list)
+        mock_render = _as_mock(mock_render)
+        mock_send = _as_mock(mock_send)
+        mock_format = _as_mock(mock_format)
+        mock_format_list = _as_mock(mock_format_list)
         output_results(env, conversations, output)
 
     if expected == "render-rich":
@@ -1136,7 +1147,7 @@ def test_project_query_results_contract() -> None:
 )
 def test_async_execute_query_action_routing_contract(case: str, expected_helper: str) -> None:
     env = _make_env(repo=MagicMock(), config=MagicMock())
-    repo = cast(MagicMock, env.repository)
+    repo = _as_mock(env.repository)
     summary = build_conversation_summary(_sample_summary_spec())
     plan = _build_plan(case)
     filter_chain = MagicMock()
@@ -1144,7 +1155,7 @@ def test_async_execute_query_action_routing_contract(case: str, expected_helper:
     filter_chain.can_use_summaries.return_value = True
     filter_chain.list_summaries = AsyncMock(return_value=[summary])
     filter_chain.list = AsyncMock(return_value=[MagicMock()])
-    selection = cast(MagicMock, plan.selection)
+    selection = _as_mock(plan.selection)
     selection.build_filter.return_value = filter_chain
 
     with (
@@ -1171,11 +1182,11 @@ def test_async_execute_query_action_routing_contract(case: str, expected_helper:
         ) as mock_stream_target,
         patch("polylogue.cli.query_output.stream_conversation", new_callable=AsyncMock) as mock_stream_conversation,
     ):
-        mock_echo = cast(MagicMock, mock_echo)
-        mock_output_stats_by_summaries = cast(MagicMock, mock_output_stats_by_summaries)
-        mock_output_stats_by = cast(MagicMock, mock_output_stats_by)
-        mock_open_result = cast(MagicMock, mock_open_result)
-        mock_output_results = cast(MagicMock, mock_output_results)
+        mock_echo = _as_mock(mock_echo)
+        mock_output_stats_by_summaries = _as_mock(mock_output_stats_by_summaries)
+        mock_output_stats_by = _as_mock(mock_output_stats_by)
+        mock_open_result = _as_mock(mock_open_result)
+        mock_output_results = _as_mock(mock_output_results)
         repo.get_message_counts_batch = AsyncMock(return_value={str(summary.id): 2})
         asyncio.run(async_execute_query(env, {"limit": 7}))
 
@@ -1254,7 +1265,7 @@ def test_async_execute_query_open_falls_back_to_full_results_without_summaries_c
     filter_chain.can_use_summaries.return_value = False
     filter_chain.list_summaries = AsyncMock(return_value=[])
     filter_chain.list = AsyncMock(return_value=[MagicMock()])
-    selection = cast(MagicMock, plan.selection)
+    selection = _as_mock(plan.selection)
     selection.build_filter.return_value = filter_chain
 
     with (
@@ -1277,7 +1288,7 @@ def test_async_execute_query_stats_by_falls_back_to_full_results_without_summari
     filter_chain.can_use_summaries.return_value = False
     filter_chain.list = AsyncMock(return_value=[_sample_conversation()])
     filter_chain.list_summaries = AsyncMock(return_value=[build_conversation_summary(_sample_summary_spec())])
-    selection = cast(MagicMock, plan.selection)
+    selection = _as_mock(plan.selection)
     selection.build_filter.return_value = filter_chain
 
     with (
@@ -1303,7 +1314,7 @@ def test_async_execute_query_semantic_stats_by_uses_summary_batches_contract() -
     filter_chain.can_use_summaries.return_value = True
     filter_chain.list = AsyncMock(return_value=[_sample_conversation()])
     filter_chain.list_summaries = AsyncMock(return_value=[build_conversation_summary(_sample_summary_spec())])
-    selection = cast(MagicMock, plan.selection)
+    selection = _as_mock(plan.selection)
     selection.build_filter.return_value = filter_chain
 
     with (
@@ -1330,7 +1341,7 @@ def test_async_execute_query_semantic_stats_by_falls_back_without_summaries_cont
     filter_chain.can_use_summaries.return_value = False
     filter_chain.list = AsyncMock(return_value=[_sample_conversation()])
     filter_chain.list_summaries = AsyncMock(return_value=[build_conversation_summary(_sample_summary_spec())])
-    selection = cast(MagicMock, plan.selection)
+    selection = _as_mock(plan.selection)
     selection.build_filter.return_value = filter_chain
 
     with (
@@ -1357,7 +1368,7 @@ def test_async_execute_query_profile_stats_by_uses_summary_batches_contract() ->
     filter_chain.can_use_summaries.return_value = True
     filter_chain.list = AsyncMock(return_value=[_sample_conversation()])
     filter_chain.list_summaries = AsyncMock(return_value=[build_conversation_summary(_sample_summary_spec())])
-    selection = cast(MagicMock, plan.selection)
+    selection = _as_mock(plan.selection)
     selection.build_filter.return_value = filter_chain
 
     with (
@@ -1383,7 +1394,7 @@ def test_async_execute_query_summary_list_no_results_contract() -> None:
     filter_chain = MagicMock()
     filter_chain.can_use_summaries.return_value = True
     filter_chain.list_summaries = AsyncMock(return_value=[])
-    selection = cast(MagicMock, plan.selection)
+    selection = _as_mock(plan.selection)
     selection.build_filter.return_value = filter_chain
 
     with (
@@ -1403,7 +1414,7 @@ def test_async_execute_query_summary_list_no_results_contract() -> None:
 def test_async_execute_query_query_spec_error_contract() -> None:
     env = _make_env(repo=MagicMock(), config=MagicMock())
     plan = _build_plan("show")
-    selection = cast(MagicMock, plan.selection)
+    selection = _as_mock(plan.selection)
     selection.build_filter.side_effect = QuerySpecError("since", "not-a-date")
 
     with (
@@ -1413,7 +1424,7 @@ def test_async_execute_query_query_spec_error_contract() -> None:
         patch("click.echo") as mock_echo,
         pytest.raises(SystemExit) as exc_info,
     ):
-        mock_echo = cast(MagicMock, mock_echo)
+        mock_echo = _as_mock(mock_echo)
         asyncio.run(async_execute_query(env, {}))
 
     assert exc_info.value.code == 1
@@ -1475,7 +1486,7 @@ def test_no_results_contract(params: dict[str, object], expected_lines: list[str
         no_results(env, params)
 
     assert exc_info.value.code == 2
-    observed_lines = [call.args[0] for call in cast(MagicMock, env.ui.console.print).call_args_list if call.args]
+    observed_lines = [call.args[0] for call in _as_mock(env.ui.console.print).call_args_list if call.args]
     assert observed_lines == expected_lines
 
 
@@ -1565,7 +1576,7 @@ async def test_output_stats_sql_uses_summary_pushdown_contract() -> None:
     filter_chain.list_summaries.assert_awaited_once()
     filter_chain.count.assert_not_called()
     repo.aggregate_message_stats.assert_awaited_once_with(["conv-a", "conv-b"])
-    printed = [call.args[0] for call in cast(MagicMock, env.ui.console.print).call_args_list if call.args]
+    printed = [call.args[0] for call in _as_mock(env.ui.console.print).call_args_list if call.args]
     assert printed == [
         "\nConversations: 2\n",
         "Messages: 9 total (4 user, 5 assistant)",
@@ -1601,7 +1612,7 @@ async def test_output_stats_sql_empty_paths_contract(
 
     await output_stats_sql(env, filter_chain, repo)
 
-    cast(MagicMock, env.ui.console.print).assert_called_once_with(expected_message)
+    _as_mock(env.ui.console.print).assert_called_once_with(expected_message)
 
 
 @pytest.mark.asyncio
@@ -1681,7 +1692,7 @@ async def test_output_stats_sql_archive_scope_includes_embedding_state() -> None
 
     repo.get_archive_stats.assert_awaited_once_with()
     repo.aggregate_message_stats.assert_awaited_once_with()
-    printed = [call.args[0] for call in cast(MagicMock, env.ui.console.print).call_args_list if call.args]
+    printed = [call.args[0] for call in _as_mock(env.ui.console.print).call_args_list if call.args]
     assert printed == [
         "\nConversations: 2\n",
         "Messages: 9 total (4 user, 5 assistant)",
@@ -1728,10 +1739,10 @@ async def test_output_stats_sql_json_contract() -> None:
     )
 
     with patch("click.echo") as mock_echo:
-        mock_echo = cast(MagicMock, mock_echo)
+        mock_echo = _as_mock(mock_echo)
         await output_stats_sql(env, filter_chain, repo, output_format="json")
 
-    cast(MagicMock, env.ui.console.print).assert_not_called()
+    _as_mock(env.ui.console.print).assert_not_called()
     repo.get_archive_stats.assert_awaited_once_with()
     repo.aggregate_message_stats.assert_awaited_once_with()
     payload = json.loads(mock_echo.call_args.args[0])

--- a/tests/unit/cli/test_query_fmt.py
+++ b/tests/unit/cli/test_query_fmt.py
@@ -19,7 +19,6 @@ import json
 from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import cast
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -299,16 +298,21 @@ STATS_CASES = (
 def _make_msg(
     role: str = "user",
     text: str | None = "Hello",
-    **kwargs: object,
+    *,
+    id: str | None = None,
+    timestamp: datetime | None = None,
+    attachments: list[Attachment] | None = None,
+    content_blocks: list[dict[str, object]] | None = None,
+    provider_meta: dict[str, object] | None = None,
 ) -> Message:
     return build_msg(
-        id=str(kwargs.get("id", f"msg-{role}")),
+        id=id or f"msg-{role}",
         role=Role.normalize(role),
         text=text,
-        timestamp=cast(datetime | None, kwargs.get("timestamp")),
-        attachments=cast(list[Attachment], kwargs.get("attachments", [])),
-        content_blocks=cast(list[dict[str, object]], kwargs.get("content_blocks", [])),
-        provider_meta=cast(dict[str, object] | None, kwargs.get("provider_meta")),
+        timestamp=timestamp,
+        attachments=attachments or [],
+        content_blocks=content_blocks or [],
+        provider_meta=provider_meta,
     )
 
 
@@ -317,7 +321,10 @@ def _make_conv(
     provider: str = "claude-ai",
     title: str | None = "Example Conversation",
     messages: list[Message] | None = None,
-    **kwargs: object,
+    created_at: datetime | None = None,
+    updated_at: datetime | None = None,
+    tags: list[str] | None = None,
+    summary: str = "Synthetic summary",
 ) -> Conversation:
     default_messages: Sequence[Message] | MessageCollection | None = messages
     if default_messages is None:
@@ -330,11 +337,11 @@ def _make_conv(
         provider=Provider.from_string(provider),
         title=title,
         messages=default_messages,
-        created_at=cast(datetime | None, kwargs.get("created_at")),
-        updated_at=cast(datetime | None, kwargs.get("updated_at")),
+        created_at=created_at,
+        updated_at=updated_at,
         metadata={
-            "tags": cast(list[str], kwargs.get("tags", ["law", "example"])),
-            "summary": cast(str, kwargs.get("summary", "Synthetic summary")),
+            "tags": tags or ["law", "example"],
+            "summary": summary,
         },
     )
 

--- a/tests/unit/cli/test_run.py
+++ b/tests/unit/cli/test_run.py
@@ -6,7 +6,6 @@ import asyncio
 from collections.abc import Iterator
 from contextlib import ExitStack
 from pathlib import Path
-from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -31,7 +30,20 @@ from polylogue.storage.run_state import (
 from polylogue.ui import UI
 from tests.infra.storage_records import DbFactory
 
-PatchMap = dict[str, MagicMock]
+PatchMock = MagicMock | AsyncMock
+PatchMap = dict[str, PatchMock]
+
+
+def _as_mock(value: object) -> MagicMock:
+    if not isinstance(value, MagicMock):
+        raise TypeError(f"expected MagicMock, got {type(value).__name__}")
+    return value
+
+
+def _as_patch_mock(value: object) -> PatchMock:
+    if not isinstance(value, (MagicMock, AsyncMock)):
+        raise TypeError(f"expected MagicMock or AsyncMock, got {type(value).__name__}")
+    return value
 
 
 @pytest.fixture
@@ -167,10 +179,9 @@ def _close_coroutine(coro: object) -> None:
 
 
 def _make_prompt_env(*, plain: bool, choice: str | None = None) -> AppEnv:
-    ui = MagicMock()
-    ui.plain = plain
-    ui.choose = MagicMock(return_value=choice)
-    return AppEnv(ui=cast(UI, ui))
+    ui = UI(plain=plain)
+    object.__setattr__(ui, "choose", MagicMock(return_value=choice))
+    return AppEnv(ui=ui)
 
 
 def _invoke_run_direct(
@@ -188,26 +199,18 @@ def _invoke_run_direct(
         mock_config = MagicMock(sources=[])
         mock_config.render_root = Path("/render")
         stack.enter_context(patch("polylogue.config.get_config", return_value=mock_config))
-        mock_plan = cast(MagicMock, stack.enter_context(patch("polylogue.cli.commands.run.plan_sources")))
-        mock_run = cast(
-            MagicMock,
-            stack.enter_context(patch("polylogue.cli.run_workflow.run_sources", new_callable=AsyncMock)),
+        mock_plan = _as_mock(stack.enter_context(patch("polylogue.cli.commands.run.plan_sources")))
+        mock_run = _as_patch_mock(
+            stack.enter_context(patch("polylogue.cli.run_workflow.run_sources", new_callable=AsyncMock))
         )
-        mock_resolve = cast(
-            MagicMock,
-            stack.enter_context(patch("polylogue.cli.commands.run.resolve_sources", return_value=selected_sources)),
+        mock_resolve = _as_mock(
+            stack.enter_context(patch("polylogue.cli.commands.run.resolve_sources", return_value=selected_sources))
         )
-        mock_stage_prompt = cast(
-            MagicMock,
-            stack.enter_context(
-                patch("polylogue.cli.commands.run.maybe_prompt_run_stage", return_value=prompted_stage)
-            ),
+        mock_stage_prompt = _as_mock(
+            stack.enter_context(patch("polylogue.cli.commands.run.maybe_prompt_run_stage", return_value=prompted_stage))
         )
-        mock_prompt = cast(
-            MagicMock,
-            stack.enter_context(
-                patch("polylogue.cli.commands.run.maybe_prompt_sources", return_value=selected_sources)
-            ),
+        mock_prompt = _as_mock(
+            stack.enter_context(patch("polylogue.cli.commands.run.maybe_prompt_sources", return_value=selected_sources))
         )
         stack.enter_context(
             patch("polylogue.cli.run_workflow.format_plan_counts", return_value="5 conversations, 50 messages")
@@ -218,14 +221,12 @@ def _invoke_run_direct(
             patch("polylogue.cli.run_workflow.format_counts", return_value="3 conversations, 30 messages")
         )
         stack.enter_context(patch("polylogue.cli.run_workflow.format_run_details", return_value=["Indexed: yes"]))
-        mock_format_index = cast(
-            MagicMock,
+        mock_format_index = _as_mock(
             stack.enter_context(
                 patch("polylogue.cli.run_workflow.format_index_status", return_value="Index status: indexed")
             ),
         )
-        mock_latest = cast(
-            MagicMock,
+        mock_latest = _as_mock(
             stack.enter_context(
                 patch("polylogue.cli.helpers.latest_render_path", return_value=Path("/render/latest/conversation.html"))
             ),
@@ -253,7 +254,7 @@ def _invoke_run_direct(
 
 def _invoke_embed(runner: CliRunner, args: list[str]) -> tuple[Result, MagicMock]:
     with patch("polylogue.cli.commands.run._run_embed_standalone") as mock_standalone:
-        mock_standalone = cast(MagicMock, mock_standalone)
+        mock_standalone = _as_mock(mock_standalone)
         result = runner.invoke(
             cli,
             args,
@@ -391,10 +392,7 @@ class TestRunCommand:
                     indexed=False,
                     index_error="Vector database unavailable",
                     duration_ms=900,
-                    render_failures=cast(
-                        list[RenderFailurePayload],
-                        [{"conversation_id": "conv-1", "error": "boom"}],
-                    ),
+                    render_failures=[RenderFailurePayload(conversation_id="conv-1", error="boom")],
                 ),
                 ["Sync", "Render failures (1)", "Index error: Vector database unavailable"],
                 True,
@@ -499,8 +497,8 @@ class TestRunCommand:
             patch("polylogue.cli.run_workflow.format_index_status", return_value="Index status: indexed"),
             patch("polylogue.cli.run_workflow.run_sources", new_callable=AsyncMock, return_value=mock_run_result),
         ):
-            mock_reset_run = cast(MagicMock, mock_reset_run)
-            mock_pipeline_run = cast(MagicMock, mock_pipeline_run)
+            mock_reset_run = _as_mock(mock_reset_run)
+            mock_pipeline_run = _as_mock(mock_pipeline_run)
             result = runner.invoke(cli, ["run", "--reparse"])
 
         assert result.exit_code == 0
@@ -526,8 +524,8 @@ class TestRunCommand:
             patch("polylogue.cli.commands.run.plan_sources", return_value=mock_plan_result) as mock_plan_sources,
             patch("polylogue.cli.run_workflow.run_sources", new_callable=AsyncMock, return_value=mock_run_result),
         ):
-            mock_run_coroutine_sync = cast(MagicMock, mock_run_coroutine_sync)
-            mock_plan_sources = cast(MagicMock, mock_plan_sources)
+            mock_run_coroutine_sync = _as_mock(mock_run_coroutine_sync)
+            mock_plan_sources = _as_mock(mock_plan_sources)
             result = runner.invoke(cli, ["run", "--preview", "--reparse", "--source", "test-inbox", "parse"])
 
         assert result.exit_code == 0
@@ -542,7 +540,7 @@ class TestRunCommand:
         result = maybe_prompt_run_stage(env, stage="parse", prompt=False)
 
         assert result == "parse"
-        cast(MagicMock, env.ui.choose).assert_not_called()
+        _as_mock(env.ui.choose).assert_not_called()
 
     def test_maybe_prompt_run_stage_skips_prompt_in_plain_mode(self) -> None:
         env = _make_prompt_env(plain=True)
@@ -550,7 +548,7 @@ class TestRunCommand:
         result = maybe_prompt_run_stage(env, stage="all", prompt=True)
 
         assert result == "all"
-        cast(MagicMock, env.ui.choose).assert_not_called()
+        _as_mock(env.ui.choose).assert_not_called()
 
     def test_maybe_prompt_run_stage_prompts_for_workflow_choice(self) -> None:
         env = _make_prompt_env(plain=False, choice="reprocess")
@@ -558,7 +556,7 @@ class TestRunCommand:
         result = maybe_prompt_run_stage(env, stage="all", prompt=True)
 
         assert result == "reprocess"
-        cast(MagicMock, env.ui.choose).assert_called_once_with(
+        _as_mock(env.ui.choose).assert_called_once_with(
             "Select workflow for run",
             ["all", "reprocess", "acquire", "schema", "parse", "materialize", "render", "site", "index"],
         )
@@ -748,7 +746,7 @@ class TestEmbedCommand:
             patch("polylogue.cli.commands.run._run_embed_standalone") as mock_standalone,
             patch("polylogue.storage.search_providers.create_vector_provider") as mock_create,
         ):
-            mock_standalone = cast(MagicMock, mock_standalone)
+            mock_standalone = _as_mock(mock_standalone)
             mock_create.return_value = MagicMock()
 
             result = runner.invoke(

--- a/tests/unit/cli/test_run_int.py
+++ b/tests/unit/cli/test_run_int.py
@@ -3,13 +3,12 @@ from __future__ import annotations
 import json
 import time
 from collections.abc import AsyncIterable, Iterable
-from importlib import import_module
 from pathlib import Path
-from typing import Protocol, cast
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+from polylogue.cli.run_workflow import display_result
 from polylogue.config import Source, get_config
 from polylogue.pipeline.observers import ExecObserver, NotificationObserver, WebhookObserver
 from polylogue.pipeline.runner import latest_run, plan_sources, run_sources
@@ -22,20 +21,6 @@ from polylogue.storage.run_state import (
     RunResult,
 )
 from tests.infra.source_builders import ChatGPTExportBuilder, GenericConversationBuilder, InboxBuilder
-
-
-class RunCommandModule(Protocol):
-    def _display_result(
-        self,
-        env: MagicMock,
-        config: MagicMock,
-        result: RunResult,
-        stage: str,
-        latest_render_path: Path | None,
-    ) -> None: ...
-
-
-run_command = cast(RunCommandModule, import_module("polylogue.cli.commands.run"))
 
 
 def _observer_result(
@@ -171,7 +156,9 @@ async def test_run_index_filters_selected_sources(
     with open_connection(None) as conn:
         rows = conn.execute("SELECT conversation_id, provider_meta FROM conversations").fetchall()
     for row in rows:
-        meta = cast(dict[str, object], json.loads(row["provider_meta"] or "{}"))
+        meta = json.loads(row["provider_meta"] or "{}")
+        if not isinstance(meta, dict):
+            raise TypeError(f"expected provider metadata dict, got {type(meta).__name__}")
         name = meta.get("source")
         if name:
             id_by_source[name] = row["conversation_id"]
@@ -267,7 +254,7 @@ def test_display_result_reports_render_failures(mock_env: MagicMock, capsys: pyt
     )
 
     with patch("polylogue.cli.helpers.latest_render_path", return_value=None):
-        run_command._display_result(mock_env, mock_config, result, "all", None)
+        display_result(mock_env, mock_config, result, "all", None)
 
     captured = capsys.readouterr()
     assert "Render failures (15)" in captured.err
@@ -287,7 +274,7 @@ def test_display_result_reports_index_error_hint(mock_env: MagicMock, capsys: py
         render_failures=[],
     )
 
-    run_command._display_result(mock_env, mock_config, result, "index", None)
+    display_result(mock_env, mock_config, result, "index", None)
 
     captured = capsys.readouterr()
     assert "Index error: Database locked" in captured.err
@@ -337,27 +324,24 @@ class TestWatchModeCallbacks:
         fake_addrinfo = [(2, 1, 6, "", ("93.184.216.34", 80))]
         with (
             patch("polylogue.pipeline.observers.socket.getaddrinfo", return_value=fake_addrinfo),
-            patch("urllib.request.urlopen") as mock_urlopen,
+            patch("polylogue.pipeline.observers._post_webhook") as mock_post,
         ):
             WebhookObserver("http://example.com/webhook").on_completed(
                 _observer_result(conversations=2, new_conversations=2)
             )
-        call_args = mock_urlopen.call_args[0][0]
-        assert call_args.get_full_url() == "http://example.com/webhook"
-        assert call_args.get_method() == "POST"
-        assert mock_urlopen.call_args.kwargs["timeout"] == 10
+        mock_post.assert_called_once()
+        assert mock_post.call_args.args[0] == "http://example.com/webhook"
 
     def test_webhook_payload_format(self) -> None:
         fake_addrinfo = [(2, 1, 6, "", ("93.184.216.34", 80))]
         with (
             patch("polylogue.pipeline.observers.socket.getaddrinfo", return_value=fake_addrinfo),
-            patch("urllib.request.urlopen"),
-            patch("urllib.request.Request") as mock_request,
+            patch("polylogue.pipeline.observers._post_webhook") as mock_post,
         ):
             WebhookObserver("http://example.com/webhook").on_completed(
                 _observer_result(conversations=7, new_conversations=7)
             )
-        payload = json.loads(mock_request.call_args.kwargs["data"].decode())
+        payload = json.loads(mock_post.call_args.args[1].decode())
         assert payload == {
             "event": "sync",
             "conversation_activity_count": 7,
@@ -369,7 +353,7 @@ class TestWatchModeCallbacks:
         fake_addrinfo = [(2, 1, 6, "", ("93.184.216.34", 80))]
         with (
             patch("polylogue.pipeline.observers.socket.getaddrinfo", return_value=fake_addrinfo),
-            patch("urllib.request.urlopen", side_effect=ConnectionError("Connection failed")),
+            patch("polylogue.pipeline.observers._post_webhook", side_effect=ConnectionError("Connection failed")),
         ):
             WebhookObserver("http://example.com/webhook").on_completed(
                 _observer_result(conversations=1, new_conversations=1)

--- a/tests/unit/cli/test_run_laws.py
+++ b/tests/unit/cli/test_run_laws.py
@@ -16,6 +16,7 @@ from click.testing import CliRunner
 from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 from rich.console import Console
+from rich.progress import TaskID
 
 from polylogue.cli.commands.run import run_command
 from polylogue.cli.run_observers import (
@@ -351,12 +352,13 @@ def test_plain_progress_observer_completion_contract() -> None:
 
 def test_rich_progress_observer_parses_explicit_totals() -> None:
     progress = MagicMock()
-    observer = _RichProgressObserver(progress, task_id="task-1")
+    task_id = TaskID(1)
+    observer = _RichProgressObserver(progress, task_id=task_id)
 
     observer.on_progress(200, "Indexing: full-text search 1,000/10,153")
 
     progress.update.assert_called_once_with(
-        "task-1",
+        task_id,
         description="Indexing: full-text search 1,000/10,153",
         total=10153,
         completed=1000,

--- a/tests/unit/cli/test_source_selection_helpers.py
+++ b/tests/unit/cli/test_source_selection_helpers.py
@@ -7,7 +7,6 @@ from collections.abc import Iterable
 from io import StringIO
 from pathlib import Path
 from types import SimpleNamespace
-from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import click
@@ -18,7 +17,7 @@ from polylogue.cli import helpers
 from polylogue.cli.types import AppEnv
 from polylogue.config import Config, Source
 from polylogue.services import build_runtime_services
-from polylogue.ui import UI
+from polylogue.ui import UI, ConsoleLike
 
 
 @pytest.fixture
@@ -322,15 +321,57 @@ class SummaryRunResult(TypedDict):
     mock_get_readiness: MagicMock
 
 
-def _make_env(config: Config, *, plain: bool) -> tuple[AppEnv, StringIO, MagicMock]:
-    from rich.console import Console
+class _SummaryUI(UI):
+    def __init__(self, *, plain: bool, console: ConsoleLike) -> None:
+        self._plain = plain
+        self._console = console
+        self.summary_mock = MagicMock()
 
+    @property
+    def plain(self) -> bool:
+        return self._plain
+
+    @property
+    def console(self) -> ConsoleLike:
+        return self._console
+
+    @console.setter
+    def console(self, value: ConsoleLike) -> None:
+        self._console = value
+
+    def summary(self, title: str, lines: Iterable[str]) -> None:
+        self.summary_mock(title, list(lines))
+
+
+class _BufferConsole:
+    def __init__(self, buffer: StringIO) -> None:
+        self._buffer = buffer
+
+    def print(self, *objects: object, **kwargs: object) -> None:
+        del kwargs
+        self._buffer.write(" ".join(str(obj) for obj in objects))
+        self._buffer.write("\n")
+
+
+def _make_env(config: Config, *, plain: bool) -> tuple[AppEnv, StringIO, MagicMock]:
     buffer = StringIO()
-    ui = MagicMock()
-    ui.plain = plain
-    ui.console = Console(file=buffer, width=120, force_terminal=False, color_system=None)
-    env = AppEnv(ui=cast(UI, ui), services=build_runtime_services(config=config, backend=MagicMock()))
-    return env, buffer, ui
+    ui = _SummaryUI(
+        plain=plain,
+        console=_BufferConsole(buffer),
+    )
+    env = AppEnv(ui=ui, services=build_runtime_services(config=config, backend=MagicMock()))
+    return env, buffer, ui.summary_mock
+
+
+def _summary_call(summary_mock: MagicMock) -> tuple[str, list[str]]:
+    args = summary_mock.call_args.args
+    title = args[0]
+    lines = args[1]
+    if not isinstance(title, str):
+        raise TypeError(f"expected summary title str, got {type(title).__name__}")
+    if not isinstance(lines, list) or not all(isinstance(line, str) for line in lines):
+        raise TypeError("expected summary lines list[str]")
+    return title, lines
 
 
 def _health_report(*, source: str = "live", checks: list[SimpleNamespace] | None = None) -> SimpleNamespace:
@@ -414,9 +455,7 @@ def _run_summary(
     ):
         print_summary(env, verbose=verbose)
 
-    summary_mock = cast(MagicMock, ui.summary)
-    title = cast(str, summary_mock.call_args.args[0])
-    lines = cast(list[str], summary_mock.call_args.args[1])
+    title, lines = _summary_call(ui)
     return {
         "title": title,
         "lines": lines,

--- a/tests/unit/core/conftest.py
+++ b/tests/unit/core/conftest.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from pathlib import Path
-from typing import cast
 
 import pytest
 
@@ -20,6 +19,22 @@ from polylogue.storage.backends.connection import open_connection
 from polylogue.storage.index import rebuild_index
 from polylogue.storage.repository import ConversationRepository
 from tests.infra.storage_records import ConversationBuilder
+
+
+def _metadata_payload(value: object) -> dict[str, object]:
+    assert isinstance(value, dict)
+    return {str(key): item for key, item in value.items()}
+
+
+def _message_specs(value: object) -> list[dict[str, object]]:
+    if value is None:
+        return []
+    assert isinstance(value, list)
+    messages: list[dict[str, object]] = []
+    for item in value:
+        assert isinstance(item, dict)
+        messages.append({str(key): field for key, field in item.items()})
+    return messages
 
 
 @pytest.fixture
@@ -113,7 +128,7 @@ def make_filter_repo(tmp_path: Path) -> Callable[[list[dict[str, object]]], Conv
             if title := spec.get("title"):
                 builder = builder.title(str(title))
             if metadata := spec.get("metadata"):
-                builder = builder.metadata(cast(dict[str, object], metadata))
+                builder = builder.metadata(_metadata_payload(metadata))
             if created_at := spec.get("created_at"):
                 builder = builder.created_at(str(created_at))
             if branch_type := spec.get("branch_type"):
@@ -121,7 +136,7 @@ def make_filter_repo(tmp_path: Path) -> Callable[[list[dict[str, object]]], Conv
             if parent := spec.get("parent_conversation"):
                 builder = builder.parent_conversation(str(parent))
 
-            for msg in cast(list[dict[str, object]], spec.get("messages", [])):
+            for msg in _message_specs(spec.get("messages")):
                 builder = builder.add_message(
                     str(msg["id"]),
                     role=str(msg.get("role", "user")),

--- a/tests/unit/core/test_code_detection.py
+++ b/tests/unit/core/test_code_detection.py
@@ -10,6 +10,7 @@ import pytest
 from hypothesis import given, settings
 from hypothesis import strategies as st
 
+from polylogue.lib.json import JSONDocument
 from polylogue.schemas.code_detection import (
     LANGUAGE_PATTERNS,
     _regex_scores,
@@ -85,29 +86,31 @@ class TestRegexScores:
 
 class TestExtractCodeBlockFromDict:
     def test_fenced_with_language(self) -> None:
-        block = {"type": "text", "text": "```python\ndef hello(): pass\n```"}
+        block: JSONDocument = {"type": "text", "text": "```python\ndef hello(): pass\n```"}
         result = extract_code_block_from_dict(block)
         assert result is not None
         assert result["type"] == "code"
         assert result["language"] == "python"
         assert result["declared_language"] == "python"
-        assert "def hello" in result["text"]
+        text = result["text"]
+        assert isinstance(text, str)
+        assert "def hello" in text
 
     def test_fenced_without_language(self) -> None:
-        block = {"type": "text", "text": "```\ndef hello(): pass\n```"}
+        block: JSONDocument = {"type": "text", "text": "```\ndef hello(): pass\n```"}
         result = extract_code_block_from_dict(block)
         assert result is not None
         assert result["type"] == "code"
 
     def test_non_code_text(self) -> None:
-        block = {"type": "text", "text": "Just a short note"}
+        block: JSONDocument = {"type": "text", "text": "Just a short note"}
         result = extract_code_block_from_dict(block)
         assert result is None
 
     def test_code_without_fence(self) -> None:
         # Long enough text that looks like code
         code_text = 'def hello():\n    print("world")\n\nclass Foo:\n    pass'
-        block = {"type": "text", "text": code_text}
+        block: JSONDocument = {"type": "text", "text": code_text}
         result = extract_code_block_from_dict(block)
         assert result is not None
         assert result["language"] == "python"

--- a/tests/unit/core/test_filters_schemas.py
+++ b/tests/unit/core/test_filters_schemas.py
@@ -8,7 +8,7 @@ filter logic.
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Literal, TypeAlias, cast
+from typing import Literal, TypeAlias
 from unittest.mock import patch
 
 import pytest
@@ -76,23 +76,28 @@ CONTENT_BLOCKS_CASES: list[ContentBlocksCase] = [
 ]
 
 EXTRACT_TEXT_CASES: list[ExtractTextCase] = [
-    (lambda content: extract_claude_code_text(cast(list[JSONDocument] | None, content)), None, "", "claude_code_none"),
     (
-        lambda content: extract_claude_code_text(cast(list[JSONDocument] | None, content)),
+        lambda content: extract_claude_code_text(content if isinstance(content, list) else None),
+        None,
+        "",
+        "claude_code_none",
+    ),
+    (
+        lambda content: extract_claude_code_text(content if isinstance(content, list) else None),
         ["string", 123],
         "",
         "claude_code_non_dict",
     ),
-    (lambda content: extract_chatgpt_text(cast(JSONDocument | None, content)), None, "", "chatgpt_none"),
-    (lambda content: extract_chatgpt_text(cast(JSONDocument | None, content)), {}, "", "chatgpt_no_parts"),
+    (lambda content: extract_chatgpt_text(content if isinstance(content, dict) else None), None, "", "chatgpt_none"),
+    (lambda content: extract_chatgpt_text(content if isinstance(content, dict) else None), {}, "", "chatgpt_no_parts"),
     (
-        lambda content: extract_chatgpt_text(cast(JSONDocument | None, content)),
+        lambda content: extract_chatgpt_text(content if isinstance(content, dict) else None),
         {"parts": "string"},
         "string",
         "chatgpt_parts_as_string",
     ),
     (
-        lambda content: extract_chatgpt_text(cast(JSONDocument | None, content)),
+        lambda content: extract_chatgpt_text(content if isinstance(content, dict) else None),
         {"parts": [123, "text", {"key": "val"}]},
         "text",
         "chatgpt_non_string_parts",
@@ -139,7 +144,7 @@ class TestUnifiedExtractReasoningTraces:
         expected_text: str | None,
         description: str,
     ) -> None:
-        result = extract_reasoning_traces(cast(list[JSONDocument] | None, content), provider)
+        result = extract_reasoning_traces(content if isinstance(content, list) else None, provider)
         assert len(result) == expected_len
         if expected_text is not None:
             assert result[0].text == expected_text
@@ -154,7 +159,7 @@ class TestUnifiedExtractContentBlocks:
         expected_types: list[str],
         description: str,
     ) -> None:
-        result = extract_content_blocks(cast(list[JSONDocument] | None, content))
+        result = extract_content_blocks(content if isinstance(content, list) else None)
         assert len(result) == expected_len
         if expected_types:
             for block, expected_type in zip(result, expected_types, strict=True):

--- a/tests/unit/core/test_raw_payload_decode.py
+++ b/tests/unit/core/test_raw_payload_decode.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import cast
 
 from polylogue.lib.raw_payload_decode import JSONValue, build_raw_payload_envelope, sample_jsonl_payload
 
@@ -9,6 +8,11 @@ from polylogue.lib.raw_payload_decode import JSONValue, build_raw_payload_envelo
 def _as_dict(sample: JSONValue) -> dict[str, JSONValue]:
     assert isinstance(sample, dict)
     return sample
+
+
+def _optional_int(value: JSONValue) -> int | None:
+    assert value is None or isinstance(value, int)
+    return value
 
 
 def test_sample_jsonl_payload_accepts_lone_surrogates_via_stdlib_fallback(tmp_path: Path) -> None:
@@ -20,7 +24,7 @@ def test_sample_jsonl_payload_accepts_lone_surrogates_via_stdlib_fallback(tmp_pa
     dict_samples = [_as_dict(sample) for sample in samples]
 
     assert malformed == 0
-    assert [cast(int | None, sample.get("ok")) for sample in dict_samples if "ok" in sample] == [1, 2]
+    assert [_optional_int(sample.get("ok")) for sample in dict_samples if "ok" in sample] == [1, 2]
     assert any(sample.get("text") == "broken \udce2 surrogate" for sample in dict_samples)
 
 

--- a/tests/unit/core/test_synthetic_semantic_wiring.py
+++ b/tests/unit/core/test_synthetic_semantic_wiring.py
@@ -13,11 +13,11 @@ import copy
 import json
 from collections.abc import Callable
 from pathlib import Path
-from typing import cast
 
 import pytest
 
 from polylogue.lib.json import JSONDocument, JSONValue
+from polylogue.paths import Source
 from polylogue.schemas.registry import SCHEMA_DIR, SchemaRegistry
 from polylogue.schemas.synthetic.core import SyntheticCorpus
 from polylogue.schemas.synthetic.semantic_values import SemanticValueGenerator
@@ -33,6 +33,12 @@ EXPECTED_ANNOTATIONS: dict[str, list[str]] = {
     "codex": ["conversation_title", "message_body", "message_container", "message_role", "message_timestamp"],
     "gemini": ["conversation_title", "message_body", "message_container", "message_role", "message_timestamp"],
 }
+
+
+def _synthetic_source(factory: Callable[..., object], provider: str, *, count: int, seed: int) -> Source:
+    source = factory(provider, count=count, seed=seed)
+    assert isinstance(source, Source)
+    return source
 
 
 def _collect_semantic_roles(schema: JSONValue, *, roles: list[str] | None = None) -> list[str]:
@@ -151,10 +157,9 @@ class TestSemanticRoundtrip:
         synthetic_source: Callable[..., object],
     ) -> None:
         """Synthetic data with semantic annotations roundtrips through parsers."""
-        from polylogue.paths import Source
         from polylogue.sources import iter_source_conversations
 
-        source = cast(Source, synthetic_source(provider, count=3, seed=42))
+        source = _synthetic_source(synthetic_source, provider, count=3, seed=42)
         convos = list(iter_source_conversations(source))
         assert convos, f"No conversations parsed for {provider}"
 
@@ -165,10 +170,9 @@ class TestSemanticRoundtrip:
         synthetic_source: Callable[..., object],
     ) -> None:
         """Roundtrip with a different seed to catch seed-dependent issues."""
-        from polylogue.paths import Source
         from polylogue.sources import iter_source_conversations
 
-        source = cast(Source, synthetic_source(provider, count=2, seed=99))
+        source = _synthetic_source(synthetic_source, provider, count=2, seed=99)
         convos = list(iter_source_conversations(source))
         assert convos, f"No conversations parsed for {provider} (seed=99)"
 

--- a/tests/unit/core/test_synthetic_semantics.py
+++ b/tests/unit/core/test_synthetic_semantics.py
@@ -20,7 +20,7 @@ import json
 import random
 from datetime import datetime
 from pathlib import Path
-from typing import Protocol, cast
+from typing import Protocol
 
 import pytest
 
@@ -31,7 +31,7 @@ from polylogue.schemas.synthetic import (
     SyntheticCorpus,
     WireFormat,
 )
-from polylogue.schemas.synthetic.models import SchemaRecord
+from polylogue.schemas.synthetic.models import SchemaRecord, SchemaValue
 from polylogue.schemas.synthetic.semantic_values import (
     _ROLE_TEXTS,
     SemanticValueGenerator,
@@ -42,7 +42,17 @@ from polylogue.sources.dispatch import parse_payload
 
 
 def _schema(value: object) -> SchemaRecord:
-    return cast(SchemaRecord, value)
+    assert isinstance(value, dict)
+    return {str(key): _schema_value(item) for key, item in value.items()}
+
+
+def _schema_value(value: object) -> SchemaValue:
+    if value is None or isinstance(value, str | int | float | bool):
+        return value
+    if isinstance(value, list):
+        return [_schema_value(item) for item in value]
+    assert isinstance(value, dict)
+    return {str(key): _schema_value(item) for key, item in value.items()}
 
 
 def _float_value(value: object) -> float:

--- a/tests/unit/devtools/test_devtools_main.py
+++ b/tests/unit/devtools/test_devtools_main.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Callable
-from typing import cast
+from types import ModuleType
 
 import pytest
 
@@ -36,12 +35,15 @@ def test_global_json_flag_is_forwarded_to_command(monkeypatch: pytest.MonkeyPatc
         captured.append(argv)
         return 0
 
-    class FakeSpec:
-        @staticmethod
-        def resolve_main() -> Callable[[list[str] | None], int]:
-            return fake_main
+    fake_module = ModuleType("_polylogue_devtools_test_fake")
+    fake_module.__dict__["main"] = fake_main
+    monkeypatch.setitem(__import__("sys").modules, fake_module.__name__, fake_module)
 
-    monkeypatch.setitem(COMMANDS, "status", cast(CommandSpec, FakeSpec()))
+    monkeypatch.setitem(
+        COMMANDS,
+        "status",
+        CommandSpec("status", "core", "fake status", fake_module.__name__),
+    )
 
     assert devtools_main.main(["--json", "status"]) == 0
     assert captured == [["--json"]]

--- a/tests/unit/devtools/test_executable_scenarios.py
+++ b/tests/unit/devtools/test_executable_scenarios.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import cast
 
 from polylogue.scenarios import (
     CorpusSpec,
@@ -19,6 +18,19 @@ class _ExecutableFixture(ExecutableScenario):
         return ScenarioProjectionSourceKind.VALIDATION_LANE
 
 
+def _dict_payload(value: object) -> dict[str, object]:
+    assert isinstance(value, dict)
+    return {str(key): item for key, item in value.items()}
+
+
+def _dict_list_payload(value: object) -> list[dict[str, object]]:
+    assert isinstance(value, list)
+    payloads: list[dict[str, object]] = []
+    for item in value:
+        payloads.append(_dict_payload(item))
+    return payloads
+
+
 def test_executable_scenario_exposes_pytest_targets() -> None:
     scenario = _ExecutableFixture(
         name="machine-contract",
@@ -30,7 +42,7 @@ def test_executable_scenario_exposes_pytest_targets() -> None:
     )
 
     projection = scenario.to_projection_entry()
-    execution_payload = cast(dict[str, object], projection.source_payload["execution"])
+    execution_payload = _dict_payload(projection.source_payload["execution"])
 
     assert scenario.tests == ("tests/unit/cli/test_machine_contract.py",)
     assert projection.source_kind is ScenarioProjectionSourceKind.VALIDATION_LANE
@@ -51,7 +63,7 @@ def test_executable_scenario_projection_payload_preserves_corpus_specs() -> None
     )
 
     projection = scenario.to_projection_entry()
-    corpus_specs = cast(list[dict[str, object]], projection.source_payload["corpus_specs"])
+    corpus_specs = _dict_list_payload(projection.source_payload["corpus_specs"])
 
     assert corpus_specs[0]["provider"] == "chatgpt"
 

--- a/tests/unit/devtools/test_validation_lanes.py
+++ b/tests/unit/devtools/test_validation_lanes.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import importlib
+
 import pytest
 
 from devtools.lane_models import LaneEntry
@@ -18,7 +20,7 @@ from polylogue.scenarios import AssertionSpec, ExecutionKind, polylogue_executio
 
 class TestValidationLanesImportable:
     def test_module_imports(self) -> None:
-        import devtools.run_validation_lanes  # noqa: F401
+        assert importlib.import_module("devtools.run_validation_lanes") is not None
 
     def test_main_callable(self) -> None:
         assert callable(main)

--- a/tests/unit/mcp/conftest.py
+++ b/tests/unit/mcp/conftest.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-from typing import cast
 
 import pytest
 
@@ -23,4 +22,6 @@ def mcp_server() -> MCPServerUnderTest:
 
     from polylogue.mcp.server import build_server
 
-    return cast(MCPServerUnderTest, build_server())
+    server = build_server()
+    assert isinstance(server, MCPServerUnderTest)
+    return server

--- a/tests/unit/pipeline/test_acquisition_streams.py
+++ b/tests/unit/pipeline/test_acquisition_streams.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import AsyncIterator, Callable, Iterator
+from collections.abc import AsyncIterator, Iterator
 from pathlib import Path
-from typing import cast
 
 import pytest
 
@@ -62,7 +61,8 @@ async def test_iter_raw_record_stream_forwards_source_status_progress(
 
     def _iter_source_raw_data(*args: object, **kwargs: object) -> Iterator[RawConversationData]:
         del args
-        status_callback = cast(Callable[[str], None], kwargs["status_callback"])
+        status_callback = kwargs["status_callback"]
+        assert callable(status_callback)
         status_callback("Scanning [chatgpt] reading export.json")
         yield RawConversationData(
             raw_bytes=b'{"mapping": {}, "id": "ok"}',

--- a/tests/unit/pipeline/test_branching.py
+++ b/tests/unit/pipeline/test_branching.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import json
 from collections.abc import Callable
 from pathlib import Path
-from typing import cast
 
 import pytest
 
@@ -46,6 +45,12 @@ def _parse_single(source_name: str, source_path: Path) -> ParsedConversation:
     conversations = list(iter_source_conversations(Source(name=source_name, path=source_path)))
     assert len(conversations) == 1
     return conversations[0]
+
+
+def _require_conversation(value: Conversation | None) -> Conversation:
+    if value is None:
+        raise AssertionError("expected seeded conversation")
+    return value
 
 
 def _codex_continuation_payload(*, child_id: str, parent_id: str) -> list[dict[str, object]]:
@@ -120,16 +125,14 @@ def _chatgpt_branch_payload(*, title: str = "Branched Conversation") -> dict[str
 
 
 async def _seed_branch_archive(db_path: Path) -> dict[str, str]:
-    root = cast(
-        Conversation,
+    root = _require_conversation(
         await ConversationBuilder(db_path, "root")
         .provider("codex")
         .title("Root")
         .add_message("root-user", role="user", text="Root")
         .build(),
     )
-    continuation = cast(
-        Conversation,
+    continuation = _require_conversation(
         await ConversationBuilder(db_path, "continuation")
         .provider("codex")
         .title("Continuation")
@@ -138,8 +141,7 @@ async def _seed_branch_archive(db_path: Path) -> dict[str, str]:
         .add_message("cont-user", role="user", text="Continue")
         .build(),
     )
-    sidechain = cast(
-        Conversation,
+    sidechain = _require_conversation(
         await ConversationBuilder(db_path, "sidechain")
         .provider("claude-code")
         .title("Sidechain")
@@ -149,8 +151,7 @@ async def _seed_branch_archive(db_path: Path) -> dict[str, str]:
         .add_message("side-assistant", role="assistant", text="Side answer", provider_meta={"isSidechain": True})
         .build(),
     )
-    grandchild = cast(
-        Conversation,
+    grandchild = _require_conversation(
         await ConversationBuilder(db_path, "grandchild")
         .provider("codex")
         .title("Grandchild")
@@ -159,8 +160,7 @@ async def _seed_branch_archive(db_path: Path) -> dict[str, str]:
         .add_message("grand-user", role="user", text="Grandchild")
         .build(),
     )
-    branched = cast(
-        Conversation,
+    branched = _require_conversation(
         await ConversationBuilder(db_path, "branching")
         .provider("chatgpt")
         .title("Branched")

--- a/tests/unit/pipeline/test_ingest_batch.py
+++ b/tests/unit/pipeline/test_ingest_batch.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator
-from contextlib import asynccontextmanager
+from collections.abc import AsyncIterator, Callable
+from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from pathlib import Path
 from types import SimpleNamespace
-from typing import NoReturn, cast
+from typing import NoReturn
 from unittest.mock import AsyncMock
 
+import aiosqlite
 import pytest
 
 from polylogue.lib.roles import Role
@@ -39,8 +40,6 @@ from polylogue.pipeline.services.ingest_worker import (
     StatsTuple,
     _make_ref_id,
 )
-from polylogue.pipeline.services.parsing import ParsingService
-from polylogue.storage.backends.async_sqlite import SQLiteBackend
 from polylogue.storage.backends.connection import open_connection
 from polylogue.storage.raw_state_models import RawConversationStateUpdate
 from polylogue.storage.session_product_refresh import SessionProductRefreshChunkObservation
@@ -49,7 +48,51 @@ from polylogue.types import AttachmentId, ContentBlockType, ContentHash, Convers
 
 
 def _float_value(value: object) -> float:
-    return float(cast(float | int | str, value))
+    if not isinstance(value, (float, int, str)):
+        raise TypeError(f"expected numeric value, got {type(value).__name__}")
+    return float(value)
+
+
+class _FakeConnectionBackend:
+    def __init__(self, connection: Callable[[], AbstractAsyncContextManager[aiosqlite.Connection]]) -> None:
+        self._connection = connection
+
+    def connection(self) -> AbstractAsyncContextManager[aiosqlite.Connection]:
+        return self._connection()
+
+
+class _FakeBulkBackend:
+    def __init__(self, connection: Callable[[], AbstractAsyncContextManager[object]]) -> None:
+        self._connection = connection
+
+    def bulk_connection(self) -> AbstractAsyncContextManager[object]:
+        return self._connection()
+
+
+class _FakeRawStateRepository:
+    def __init__(self, update_raw_state: AsyncMock) -> None:
+        self._update_raw_state = update_raw_state
+
+    async def update_raw_state(self, raw_id: str, *, state: RawConversationStateUpdate) -> object:
+        return await self._update_raw_state(raw_id, state=state)
+
+
+class _FakeParsingService:
+    def __init__(self, update_raw_state: AsyncMock) -> None:
+        self._repository = _FakeRawStateRepository(update_raw_state)
+
+    @property
+    def repository(self) -> _FakeRawStateRepository:
+        return self._repository
+
+
+class _FakeRefreshConnection(aiosqlite.Connection):
+    def __init__(self) -> None:
+        self._connection = None
+        self.commit_mock = AsyncMock()
+
+    async def commit(self) -> None:
+        await self.commit_mock()
 
 
 def _conversation_data(
@@ -482,13 +525,13 @@ def test_drain_ready_conversation_entries_preserves_late_parent_fk(tmp_path: Pat
 async def test_refresh_session_products_bulk_dedupes_related_refreshes(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    fake_conn = SimpleNamespace(commit=AsyncMock())
+    fake_conn = _FakeRefreshConnection()
 
     @asynccontextmanager
-    async def _connection() -> AsyncIterator[SimpleNamespace]:
+    async def _connection() -> AsyncIterator[aiosqlite.Connection]:
         yield fake_conn
 
-    fake_backend = cast(SQLiteBackend, SimpleNamespace(connection=_connection))
+    fake_backend = _FakeConnectionBackend(_connection)
 
     async def _fake_apply(conn: object, conversation_ids: list[str], *, transaction_depth: int) -> object:
         del conn, transaction_depth
@@ -561,7 +604,7 @@ async def test_refresh_session_products_bulk_dedupes_related_refreshes(
         ("chatgpt", "2026-04-03"),
     }
     assert aggregate_args.kwargs["transaction_depth"] == 1
-    fake_conn.commit.assert_awaited_once()
+    fake_conn.commit_mock.assert_awaited_once()
     assert observation is not None
     assert observation["conversations"] == 3
     assert observation["unique_thread_roots"] == 2
@@ -701,14 +744,13 @@ def test_build_batch_memory_observation_separates_lifetime_peak_from_batch_growt
 @pytest.mark.asyncio
 async def test_persist_batch_raw_state_updates_uses_one_typed_update_per_raw() -> None:
     update_raw_state = AsyncMock()
-    repository = SimpleNamespace(update_raw_state=update_raw_state)
-    service = cast(ParsingService, SimpleNamespace(repository=repository))
+    service = _FakeParsingService(update_raw_state)
 
     @asynccontextmanager
     async def _bulk_connection() -> AsyncIterator[None]:
         yield
 
-    backend = cast(SQLiteBackend, SimpleNamespace(bulk_connection=_bulk_connection))
+    backend = _FakeBulkBackend(_bulk_connection)
     outcomes = {
         "raw-success": _RawIngestOutcome(
             raw_id="raw-success",
@@ -754,14 +796,13 @@ async def test_persist_batch_raw_state_updates_uses_one_typed_update_per_raw() -
 @pytest.mark.asyncio
 async def test_persist_batch_raw_state_updates_preserves_validation_only_failure_without_quarantine() -> None:
     update_raw_state = AsyncMock()
-    repository = SimpleNamespace(update_raw_state=update_raw_state)
-    service = cast(ParsingService, SimpleNamespace(repository=repository))
+    service = _FakeParsingService(update_raw_state)
 
     @asynccontextmanager
     async def _bulk_connection() -> AsyncIterator[None]:
         yield
 
-    backend = cast(SQLiteBackend, SimpleNamespace(bulk_connection=_bulk_connection))
+    backend = _FakeBulkBackend(_bulk_connection)
     outcomes = {
         "raw-schema-invalid": _RawIngestOutcome(
             raw_id="raw-schema-invalid",

--- a/tests/unit/pipeline/test_ingestion_chaos.py
+++ b/tests/unit/pipeline/test_ingestion_chaos.py
@@ -13,7 +13,6 @@ import json
 from datetime import datetime, timezone
 from io import BytesIO
 from pathlib import Path
-from typing import cast
 
 from hypothesis import given, settings
 
@@ -96,7 +95,7 @@ def _iter_jsonl_stream(data: bytes, name: str = "test.jsonl") -> list[object]:
 
 def _as_record(value: object) -> dict[str, object]:
     assert isinstance(value, dict)
-    return cast(dict[str, object], value)
+    return {str(key): item for key, item in value.items()}
 
 
 def _timestamp_value(record: dict[str, object]) -> TimestampInput:

--- a/tests/unit/pipeline/test_observers.py
+++ b/tests/unit/pipeline/test_observers.py
@@ -56,39 +56,35 @@ class TestWebhookObserver:
 
     def test_posts_to_url(self: object) -> None:
         with patch("polylogue.pipeline.observers.socket.getaddrinfo", return_value=TestWebhookObserver._FAKE_ADDRINFO):
-            with patch("urllib.request.urlopen") as mock_urlopen:
+            with patch("polylogue.pipeline.observers._post_webhook") as mock_post:
                 handler = WebhookObserver("http://example.com/hook")
                 handler.on_completed(_make_result(7))
-                mock_urlopen.assert_called_once()
-                req = mock_urlopen.call_args[0][0]
-                assert req.get_full_url() == "http://example.com/hook"
-                assert req.get_method() == "POST"
+                mock_post.assert_called_once()
+                assert mock_post.call_args.args[0] == "http://example.com/hook"
 
     def test_payload_format(self: object) -> None:
         import json
 
         with patch("polylogue.pipeline.observers.socket.getaddrinfo", return_value=TestWebhookObserver._FAKE_ADDRINFO):
-            with patch("urllib.request.urlopen"):
-                with patch("urllib.request.Request") as mock_req:
-                    handler = WebhookObserver("http://example.com/hook")
-                    handler.on_completed(_make_result(7))
-                    call_kwargs = mock_req.call_args[1]
-                    payload = json.loads(call_kwargs["data"].decode())
-                    assert payload["event"] == "sync"
-                    assert payload["conversation_activity_count"] == 7
-                    assert payload["new_conversations"] == 7
-                    assert payload["changed_conversations"] == 0
+            with patch("polylogue.pipeline.observers._post_webhook") as mock_post:
+                handler = WebhookObserver("http://example.com/hook")
+                handler.on_completed(_make_result(7))
+                payload = json.loads(mock_post.call_args.args[1].decode())
+                assert payload["event"] == "sync"
+                assert payload["conversation_activity_count"] == 7
+                assert payload["new_conversations"] == 7
+                assert payload["changed_conversations"] == 0
 
     def test_skips_when_no_new(self: object) -> None:
         with patch("polylogue.pipeline.observers.socket.getaddrinfo", return_value=TestWebhookObserver._FAKE_ADDRINFO):
-            with patch("urllib.request.urlopen") as mock_urlopen:
+            with patch("polylogue.pipeline.observers._post_webhook") as mock_post:
                 handler = WebhookObserver("http://example.com/hook")
                 handler.on_completed(_make_result(0))
-                mock_urlopen.assert_not_called()
+                mock_post.assert_not_called()
 
     def test_logs_on_failure(self: object) -> None:
         with patch("polylogue.pipeline.observers.socket.getaddrinfo", return_value=TestWebhookObserver._FAKE_ADDRINFO):
-            with patch("urllib.request.urlopen", side_effect=ConnectionError("refused")):
+            with patch("polylogue.pipeline.observers._post_webhook", side_effect=ConnectionError("refused")):
                 handler = WebhookObserver("http://example.com/hook")
                 handler.on_completed(_make_result(1))  # Should not raise
 

--- a/tests/unit/pipeline/test_process_pool.py
+++ b/tests/unit/pipeline/test_process_pool.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import cast
-
 from polylogue.pipeline.services.process_pool import process_pool_context, process_pool_executor
 
 
@@ -9,7 +7,8 @@ def _worker_wrapper_class_name() -> str:
     import structlog
 
     wrapper_class = structlog.get_config()["wrapper_class"]
-    return cast(str, getattr(wrapper_class, "__name__", str(wrapper_class)))
+    name = getattr(wrapper_class, "__name__", str(wrapper_class))
+    return name if isinstance(name, str) else str(name)
 
 
 def test_process_pool_context_avoids_fork() -> None:

--- a/tests/unit/pipeline/test_roundtrip_hydration_laws.py
+++ b/tests/unit/pipeline/test_roundtrip_hydration_laws.py
@@ -7,8 +7,6 @@ in the suite — a failure here means the archive silently loses data.
 
 from __future__ import annotations
 
-import json
-import sqlite3
 from collections import Counter
 from pathlib import Path
 from typing import TypeAlias
@@ -17,14 +15,8 @@ import pytest
 from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 
-from polylogue.lib.conversation_models import Conversation
-from polylogue.pipeline.prepare_models import TransformResult
-from polylogue.pipeline.prepare_transform import transform_to_records
 from polylogue.schemas.synthetic.core import SyntheticCorpus
-from polylogue.sources.dispatch import detect_provider, parse_payload
-from polylogue.sources.parsers.base import ParsedConversation
-from polylogue.storage.hydrators import conversation_from_records
-from polylogue.storage.store import AttachmentRecord
+from tests.infra.pipeline_roundtrip import parse_and_transform_payload, save_transform_and_hydrate
 from tests.infra.storage_records import db_setup
 
 # ---------------------------------------------------------------------------
@@ -58,70 +50,6 @@ def synthetic_payload(
 
 
 # ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def _decode_payload(raw_bytes: bytes) -> object:
-    """Decode raw bytes, handling both JSON and JSONL (Codex/Claude Code)."""
-    text = raw_bytes.decode("utf-8")
-    try:
-        return json.loads(text)
-    except json.JSONDecodeError:
-        lines = [json.loads(line) for line in text.strip().splitlines() if line.strip()]
-        return lines
-
-
-def _parse_and_transform(
-    provider_name: str,
-    raw_bytes: bytes,
-    archive_root: Path,
-    unique_id: str = "default",
-) -> tuple[ParsedConversation, TransformResult]:
-    """Run the full parse → transform path, returning (parsed, transform_result)."""
-    payload = _decode_payload(raw_bytes)
-    detected = detect_provider(payload)
-    assert detected is not None, f"Provider detection failed for {provider_name}"
-
-    parsed_list = parse_payload(detected, payload, f"rt-{unique_id}")
-    assert len(parsed_list) >= 1, "Parser returned no conversations"
-    parsed = parsed_list[0]
-
-    result = transform_to_records(parsed, f"test-{provider_name}", archive_root=archive_root)
-    return parsed, result
-
-
-def _save_and_hydrate(result: TransformResult, db_conn: sqlite3.Connection) -> Conversation:
-    """Save records to DB and hydrate back to domain model."""
-    from polylogue.storage.backends.queries.mappers_archive import (
-        _row_to_conversation,
-        _row_to_message,
-    )
-    from tests.infra.storage_records import store_records
-
-    bundle = result.bundle
-    store_records(
-        conversation=bundle.conversation,
-        messages=bundle.messages,
-        attachments=bundle.attachments,
-        conn=db_conn,
-    )
-
-    cid = bundle.conversation.conversation_id
-    conv_row = db_conn.execute("SELECT * FROM conversations WHERE conversation_id = ?", (cid,)).fetchone()
-    assert conv_row is not None, f"Conversation {cid} not found in DB"
-    conv_record = _row_to_conversation(conv_row)
-
-    msg_rows = db_conn.execute("SELECT * FROM messages WHERE conversation_id = ? ORDER BY sort_key", (cid,)).fetchall()
-    msg_records = [_row_to_message(r) for r in msg_rows]
-
-    att_records: list[AttachmentRecord] = []
-
-    hydrated = conversation_from_records(conv_record, msg_records, att_records)
-    return hydrated
-
-
-# ---------------------------------------------------------------------------
 # Law 1: Message count preserved through the full pipeline
 # ---------------------------------------------------------------------------
 
@@ -135,10 +63,11 @@ class TestMessageCountPreservation:
     )
     def test_message_count_preserved(self: object, data: SyntheticPayload, workspace_env: dict[str, Path]) -> None:
         provider_name, raw_bytes, unique_id = data
-        parsed, result = _parse_and_transform(provider_name, raw_bytes, workspace_env["archive_root"], unique_id)
+        roundtrip = parse_and_transform_payload(provider_name, raw_bytes, workspace_env["archive_root"], unique_id)
 
-        assert len(result.bundle.messages) == len(parsed.messages), (
-            f"Transform changed message count: {len(parsed.messages)} → {len(result.bundle.messages)}"
+        assert len(roundtrip.transform.bundle.messages) == len(roundtrip.parsed.messages), (
+            f"Transform changed message count: {len(roundtrip.parsed.messages)} → "
+            f"{len(roundtrip.transform.bundle.messages)}"
         )
 
     @given(data=synthetic_payload())
@@ -156,11 +85,11 @@ class TestMessageCountPreservation:
         from polylogue.storage.backends.connection import open_connection
 
         with open_connection(db_path) as conn:
-            parsed, result = _parse_and_transform(provider_name, raw_bytes, workspace_env["archive_root"], unique_id)
-            hydrated = _save_and_hydrate(result, conn)
+            roundtrip = parse_and_transform_payload(provider_name, raw_bytes, workspace_env["archive_root"], unique_id)
+            hydrated = save_transform_and_hydrate(roundtrip.transform, conn)
 
-            assert len(list(hydrated.messages)) == len(parsed.messages), (
-                f"Hydration changed message count: {len(parsed.messages)} → {len(list(hydrated.messages))}"
+            assert len(list(hydrated.messages)) == len(roundtrip.parsed.messages), (
+                f"Hydration changed message count: {len(roundtrip.parsed.messages)} → {len(list(hydrated.messages))}"
             )
 
 
@@ -183,10 +112,10 @@ class TestRolePreservation:
         from polylogue.storage.backends.connection import open_connection
 
         with open_connection(db_path) as conn:
-            parsed, result = _parse_and_transform(provider_name, raw_bytes, workspace_env["archive_root"], unique_id)
-            hydrated = _save_and_hydrate(result, conn)
+            roundtrip = parse_and_transform_payload(provider_name, raw_bytes, workspace_env["archive_root"], unique_id)
+            hydrated = save_transform_and_hydrate(roundtrip.transform, conn)
 
-            parsed_roles = Counter(str(m.role) for m in parsed.messages)
+            parsed_roles = Counter(str(m.role) for m in roundtrip.parsed.messages)
             hydrated_roles = Counter(str(m.role) for m in hydrated.messages)
             assert parsed_roles == hydrated_roles, f"Role multiset changed: {parsed_roles} → {hydrated_roles}"
 
@@ -210,10 +139,12 @@ class TestTitleStability:
         from polylogue.storage.backends.connection import open_connection
 
         with open_connection(db_path) as conn:
-            parsed, result = _parse_and_transform(provider_name, raw_bytes, workspace_env["archive_root"], unique_id)
-            hydrated = _save_and_hydrate(result, conn)
+            roundtrip = parse_and_transform_payload(provider_name, raw_bytes, workspace_env["archive_root"], unique_id)
+            hydrated = save_transform_and_hydrate(roundtrip.transform, conn)
 
-            assert hydrated.title == parsed.title, f"Title changed: {parsed.title!r} → {hydrated.title!r}"
+            assert hydrated.title == roundtrip.parsed.title, (
+                f"Title changed: {roundtrip.parsed.title!r} → {hydrated.title!r}"
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -230,8 +161,8 @@ class TestContentHashDeterminism:
     )
     def test_same_payload_same_hash(self: object, data: SyntheticPayload, tmp_path: Path) -> None:
         provider_name, raw_bytes, unique_id = data
-        _, result1 = _parse_and_transform(provider_name, raw_bytes, tmp_path, unique_id)
-        _, result2 = _parse_and_transform(provider_name, raw_bytes, tmp_path, unique_id)
+        result1 = parse_and_transform_payload(provider_name, raw_bytes, tmp_path, unique_id).transform
+        result2 = parse_and_transform_payload(provider_name, raw_bytes, tmp_path, unique_id).transform
 
         assert result1.content_hash == result2.content_hash, "Same payload produced different content hashes"
 
@@ -256,7 +187,9 @@ class TestIdempotentReimport:
         from tests.infra.storage_records import store_records
 
         with open_connection(db_path) as conn:
-            _, result = _parse_and_transform(provider_name, raw_bytes, workspace_env["archive_root"], unique_id)
+            result = parse_and_transform_payload(
+                provider_name, raw_bytes, workspace_env["archive_root"], unique_id
+            ).transform
             bundle = result.bundle
 
             store_records(
@@ -296,11 +229,11 @@ class TestProviderIdentity:
         from polylogue.storage.backends.connection import open_connection
 
         with open_connection(db_path) as conn:
-            parsed, result = _parse_and_transform(provider_name, raw_bytes, workspace_env["archive_root"], unique_id)
-            hydrated = _save_and_hydrate(result, conn)
+            roundtrip = parse_and_transform_payload(provider_name, raw_bytes, workspace_env["archive_root"], unique_id)
+            hydrated = save_transform_and_hydrate(roundtrip.transform, conn)
 
-            assert str(hydrated.provider) == str(parsed.provider_name), (
-                f"Provider changed: {parsed.provider_name!r} → {hydrated.provider!r}"
+            assert str(hydrated.provider) == str(roundtrip.parsed.provider_name), (
+                f"Provider changed: {roundtrip.parsed.provider_name!r} → {hydrated.provider!r}"
             )
 
 
@@ -318,8 +251,8 @@ class TestConversationIdDeterminism:
     )
     def test_same_payload_same_cid(self: object, data: SyntheticPayload, tmp_path: Path) -> None:
         provider_name, raw_bytes, unique_id = data
-        _, result1 = _parse_and_transform(provider_name, raw_bytes, tmp_path, unique_id)
-        _, result2 = _parse_and_transform(provider_name, raw_bytes, tmp_path, unique_id)
+        result1 = parse_and_transform_payload(provider_name, raw_bytes, tmp_path, unique_id).transform
+        result2 = parse_and_transform_payload(provider_name, raw_bytes, tmp_path, unique_id).transform
 
         assert result1.candidate_cid == result2.candidate_cid, "Same payload produced different conversation IDs"
 
@@ -341,11 +274,11 @@ def test_provider_completes_full_roundtrip(provider_name: str, workspace_env: di
     from polylogue.storage.backends.connection import open_connection
 
     with open_connection(db_path) as conn:
-        parsed, result = _parse_and_transform(
+        roundtrip = parse_and_transform_payload(
             provider_name, raw_bytes, workspace_env["archive_root"], f"{provider_name}-42"
         )
-        hydrated = _save_and_hydrate(result, conn)
+        hydrated = save_transform_and_hydrate(roundtrip.transform, conn)
 
         assert hydrated is not None
         assert len(list(hydrated.messages)) > 0
-        assert hydrated.title is not None or parsed.title is None
+        assert hydrated.title is not None or roundtrip.parsed.title is None

--- a/tests/unit/rendering/test_rendering.py
+++ b/tests/unit/rendering/test_rendering.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import json
 from datetime import datetime, timezone
-from typing import cast
 
 import pytest
 
@@ -32,6 +31,16 @@ from tests.infra.builders import make_conv, make_msg
 # =============================================================================
 
 MessagePayload = dict[str, object]
+
+
+def _branches(payload: MessagePayload) -> list[MessagePayload]:
+    value = payload["branches"]
+    assert isinstance(value, list)
+    branches: list[MessagePayload] = []
+    for item in value:
+        assert isinstance(item, dict)
+        branches.append({str(key): field for key, field in item.items()})
+    return branches
 
 
 def _make_msg(
@@ -94,7 +103,7 @@ class TestAttachBranches:
         assert len(result) == 2
         m2 = next(m for m in result if m["id"] == "m2")
         assert "branches" in m2
-        branches = cast(list[MessagePayload], m2["branches"])
+        branches = _branches(m2)
         assert len(branches) == 1
         assert branches[0]["id"] == "m3"
 
@@ -109,7 +118,7 @@ class TestAttachBranches:
         result = _attach_branches(msgs)
         assert len(result) == 2
         m2 = next(m for m in result if m["id"] == "m2")
-        assert len(cast(list[MessagePayload], m2["branches"])) == 2
+        assert len(_branches(m2)) == 2
 
     def test_orphan_branch_becomes_standalone(self) -> None:
         """Branch without mainline sibling is included as standalone."""

--- a/tests/unit/scenarios/test_runtime.py
+++ b/tests/unit/scenarios/test_runtime.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from pathlib import Path
 from types import SimpleNamespace
-from typing import cast
 
 import pytest
 
@@ -14,6 +13,16 @@ from polylogue.scenarios import (
     runner_execution,
 )
 from polylogue.scenarios.runtime import ExecutionRunner
+
+
+def _string_env(value: object) -> dict[str, str]:
+    assert isinstance(value, dict)
+    env: dict[str, str] = {}
+    for key, item in value.items():
+        assert isinstance(key, str)
+        assert isinstance(item, str)
+        env[key] = item
+    return env
 
 
 def test_resolve_execution_command_applies_binary_overrides() -> None:
@@ -56,7 +65,7 @@ def test_run_execution_merges_env_and_captures_output(
     assert captured_kwargs["capture_output"] is True
     assert captured_kwargs["timeout"] == 15.0
     assert captured_kwargs["text"] is True
-    env = cast(dict[str, str], captured_kwargs["env"])
+    env = _string_env(captured_kwargs["env"])
     assert env["POLYLOGUE_FORCE_PLAIN"] == "1"
 
 

--- a/tests/unit/scenarios/test_scenario_specs.py
+++ b/tests/unit/scenarios/test_scenario_specs.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import cast
-
 from polylogue.scenarios import CorpusSpec, ScenarioProjectionSourceKind, ScenarioSpec
 
 
@@ -17,6 +15,15 @@ class _ScenarioFixture(ScenarioSpec):
     @property
     def projection_description(self) -> str:
         return "fixture scenario"
+
+
+def _dict_list_payload(value: object) -> list[dict[str, object]]:
+    assert isinstance(value, list)
+    payloads: list[dict[str, object]] = []
+    for item in value:
+        assert isinstance(item, dict)
+        payloads.append({str(key): field for key, field in item.items()})
+    return payloads
 
 
 def test_scenario_spec_projection_payload_includes_corpus_specs() -> None:
@@ -43,7 +50,7 @@ def test_scenario_spec_projection_payload_includes_corpus_specs() -> None:
     assert projection.description == "fixture scenario"
     assert projection.origin == "compiled.synthetic-corpus-scenario"
     source_payload = projection.source_payload
-    corpus_specs = cast(list[dict[str, object]], source_payload["corpus_specs"])
+    corpus_specs = _dict_list_payload(source_payload["corpus_specs"])
     assert corpus_specs[0]["provider"] == "chatgpt"
     assert projection.tags == ("synthetic", "scenario")
 

--- a/tests/unit/showcase/test_cli_boundary.py
+++ b/tests/unit/showcase/test_cli_boundary.py
@@ -1,11 +1,23 @@
 from __future__ import annotations
 
-from typing import cast
-
 import pytest
 
 from polylogue.scenarios import ExecutionResult, ExecutionSpec, polylogue_execution
 from polylogue.showcase import cli_boundary
+
+
+def _captured_execution(captured: dict[str, object]) -> ExecutionSpec:
+    execution = captured["execution"]
+    if not isinstance(execution, ExecutionSpec):
+        raise TypeError(f"expected ExecutionSpec, got {type(execution).__name__}")
+    return execution
+
+
+def _captured_kwargs(captured: dict[str, object]) -> dict[str, object]:
+    kwargs = captured["kwargs"]
+    if not isinstance(kwargs, dict):
+        raise TypeError(f"expected kwargs dict, got {type(kwargs).__name__}")
+    return dict(kwargs)
 
 
 def test_invoke_showcase_cli_uses_public_polylogue_command(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -25,8 +37,8 @@ def test_invoke_showcase_cli_uses_public_polylogue_command(monkeypatch: pytest.M
     monkeypatch.setattr(cli_boundary, "run_execution", fake_run)
 
     result = cli_boundary.invoke_showcase_cli(polylogue_execution("--help"))
-    kwargs = cast(dict[str, object], captured["kwargs"])
-    execution = cast(ExecutionSpec, captured["execution"])
+    kwargs = _captured_kwargs(captured)
+    execution = _captured_execution(captured)
 
     assert result.exit_code == 0
     assert result.stdout == "ok\n"
@@ -57,8 +69,8 @@ def test_invoke_showcase_cli_passes_runtime_options(monkeypatch: pytest.MonkeyPa
         timeout=30.0,
     )
 
-    execution = cast(ExecutionSpec, captured["execution"])
-    kwargs = cast(dict[str, object], captured["kwargs"])
+    execution = _captured_execution(captured)
+    kwargs = _captured_kwargs(captured)
     assert execution.display_command == ("polylogue", "doctor", "--json")
     assert kwargs["capture_output"] is True
     assert kwargs["timeout"] == 30.0

--- a/tests/unit/showcase/test_qa_markdown.py
+++ b/tests/unit/showcase/test_qa_markdown.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import cast
-from unittest.mock import MagicMock
 
 from polylogue.lib.json import JSONDocument, JSONDocumentList, json_document_list
 from polylogue.showcase.exercise_models import Exercise
@@ -24,14 +22,7 @@ def _make_exercise(
     tier: int = 1,
     description: str = "A test exercise",
 ) -> Exercise:
-    ex = MagicMock()
-    ex.name = name
-    ex.group = group
-    ex.tier = tier
-    ex.description = description
-    ex.args = []
-    ex.output_ext = ".txt"
-    return cast(Exercise, ex)
+    return Exercise(name=name, group=group, tier=tier, description=description, output_ext=".txt")
 
 
 def _make_result(

--- a/tests/unit/showcase/test_report.py
+++ b/tests/unit/showcase/test_report.py
@@ -12,8 +12,6 @@ from __future__ import annotations
 import json
 from collections.abc import Mapping
 from pathlib import Path
-from typing import cast
-from unittest.mock import MagicMock
 
 from hypothesis import given, settings
 from hypothesis import strategies as st
@@ -44,14 +42,7 @@ from polylogue.showcase.showcase_report_payloads import (
 
 
 def _make_exercise(name: str = "ex", group: str = "structural", tier: int = 1) -> Exercise:
-    ex = MagicMock()
-    ex.name = name
-    ex.group = group
-    ex.tier = tier
-    ex.description = "A test exercise"
-    ex.args = []
-    ex.output_ext = ".txt"
-    return cast(Exercise, ex)
+    return Exercise(name=name, group=group, tier=tier, description="A test exercise", output_ext=".txt")
 
 
 def _make_result(passed: bool = True, skipped: bool = False, error: str | None = None) -> ExerciseResult:

--- a/tests/unit/showcase/test_scenario_models.py
+++ b/tests/unit/showcase/test_scenario_models.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
-from typing import cast
-
 from polylogue.scenarios import AssertionSpec, ScenarioProjectionSourceKind, polylogue_execution
 from polylogue.showcase.exercise_models import Exercise
+
+
+def _dict_payload(value: object) -> dict[str, object]:
+    assert isinstance(value, dict)
+    return {str(key): item for key, item in value.items()}
 
 
 def test_exercise_scenario_compiles_to_exercise() -> None:
@@ -58,5 +61,5 @@ def test_exercise_scenario_compiles_its_own_projection_entry() -> None:
     assert projection.operation_targets == ("cli.json-contract",)
     assert projection.tags == ("generated", "json-contract")
     source_payload = projection.source_payload
-    execution_payload = cast(dict[str, object], source_payload["execution"])
+    execution_payload = _dict_payload(source_payload["execution"])
     assert execution_payload["kind"] == "polylogue"

--- a/tests/unit/showcase/test_verification_lane.py
+++ b/tests/unit/showcase/test_verification_lane.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib
 from pathlib import Path
 
 import pytest
@@ -12,7 +13,7 @@ class TestVerifyShowcaseImportable:
 
     def test_module_imports(self) -> None:
         """devtools.verify_showcase is importable."""
-        import devtools.verify_showcase  # noqa: F401
+        assert importlib.import_module("devtools.verify_showcase") is not None
 
     def test_main_callable(self) -> None:
         """main() function exists and is callable."""

--- a/tests/unit/sources/test_drive_auth.py
+++ b/tests/unit/sources/test_drive_auth.py
@@ -21,7 +21,7 @@ from polylogue.sources.drive_auth import (
     default_credentials_path,
     default_token_path,
 )
-from polylogue.sources.drive_types import DriveAuthError
+from polylogue.sources.drive_types import DriveAuthError, DriveCredentialLike
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -197,7 +197,7 @@ def test_resolve_token_path_contract(
 
 
 class _StubFlow:
-    def __init__(self, *, credentials: object, fetch_error: Exception | None = None) -> None:
+    def __init__(self, *, credentials: DriveCredentialLike, fetch_error: Exception | None = None) -> None:
         self.credentials = credentials
         self.fetch_error = fetch_error
         self.fetch_codes: list[str] = []
@@ -228,7 +228,7 @@ def test_run_manual_auth_flow_contract(
     fetch_error: Exception | None,
     expected_message: str | None,
 ) -> None:
-    creds = object()
+    creds = _creds(valid=True, expired=False)
     flow = _StubFlow(credentials=creds, fetch_error=fetch_error)
     prompter = FakeAuthPrompter(code)
     mgr = _auth_manager_with_prompter(prompter, token_path=tmp_path / "token.json")
@@ -246,7 +246,7 @@ def test_run_manual_auth_flow_contract(
 
 
 def test_run_manual_auth_flow_no_prompter_cancels(tmp_path: Path) -> None:
-    flow = _StubFlow(credentials=object())
+    flow = _StubFlow(credentials=_creds(valid=True, expired=False))
     mgr = _auth_manager_with_prompter(None, token_path=tmp_path / "token.json")
 
     with pytest.raises(DriveAuthError, match="Drive authorization cancelled"):

--- a/tests/unit/sources/test_drive_auth.py
+++ b/tests/unit/sources/test_drive_auth.py
@@ -7,7 +7,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
-from typing import Protocol, cast
+from typing import Protocol
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -41,6 +41,13 @@ def _creds(
     creds.refresh_token = refresh_token
     creds.to_json.return_value = token_json
     return creds
+
+
+def _fake_module(**attrs: object) -> ModuleType:
+    module = ModuleType("fake_drive_auth_module")
+    for name, value in attrs.items():
+        setattr(module, name, value)
+    return module
 
 
 class FakeAuthPrompter:
@@ -364,11 +371,11 @@ def test_load_credentials_state_machine(case: AuthLoadCase, monkeypatch: pytest.
 
     def fake_import(name: str) -> ModuleType:
         if name == "google.oauth2.credentials":
-            return cast(ModuleType, MagicMock(Credentials=credentials_cls))
+            return _fake_module(Credentials=credentials_cls)
         if name == "google_auth_oauthlib.flow":
-            return cast(ModuleType, MagicMock(InstalledAppFlow=MagicMock()))
+            return _fake_module(InstalledAppFlow=MagicMock())
         if name == "google.auth.transport.requests":
-            return cast(ModuleType, SimpleNamespace(Request=request_cls))
+            return _fake_module(Request=request_cls)
         raise AssertionError(name)
 
     mgr = DriveAuthManager(ui=None, token_path=token_path)
@@ -456,9 +463,9 @@ def test_load_credentials_uses_manual_flow_when_local_server_fails(
 
     def fake_import(name: str) -> ModuleType:
         if name == "google.oauth2.credentials":
-            return cast(ModuleType, MagicMock(Credentials=MagicMock()))
+            return _fake_module(Credentials=MagicMock())
         if name == "google_auth_oauthlib.flow":
-            return cast(ModuleType, MagicMock(InstalledAppFlow=installed_app_flow_cls))
+            return _fake_module(InstalledAppFlow=installed_app_flow_cls)
         raise AssertionError(name)
 
     mgr = DriveAuthManager(credentials_path=credentials_path, token_path=token_path)
@@ -486,9 +493,9 @@ def test_load_credentials_returns_local_server_result(monkeypatch: pytest.Monkey
 
     def fake_import(name: str) -> ModuleType:
         if name == "google.oauth2.credentials":
-            return cast(ModuleType, MagicMock(Credentials=MagicMock()))
+            return _fake_module(Credentials=MagicMock())
         if name == "google_auth_oauthlib.flow":
-            return cast(ModuleType, MagicMock(InstalledAppFlow=installed_app_flow_cls))
+            return _fake_module(InstalledAppFlow=installed_app_flow_cls)
         raise AssertionError(name)
 
     mgr = DriveAuthManager(credentials_path=credentials_path, token_path=token_path)

--- a/tests/unit/sources/test_drive_gateway.py
+++ b/tests/unit/sources/test_drive_gateway.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from types import ModuleType
-from typing import cast
 from unittest.mock import MagicMock
 
 import pytest
@@ -20,6 +19,25 @@ from polylogue.sources.drive_gateway import (
 )
 from polylogue.sources.drive_types import DriveAuthError, DriveNotFoundError, DriveRetryPolicy
 from tests.infra.drive_mocks import MockDriveService, MockMediaIoBaseDownload
+
+
+def _as_drive_service(value: object) -> _DriveService:
+    if not isinstance(value, _DriveService):
+        raise TypeError(f"expected _DriveService, got {type(value).__name__}")
+    return value
+
+
+def _as_mock(value: object) -> MagicMock:
+    if not isinstance(value, MagicMock):
+        raise TypeError(f"expected MagicMock, got {type(value).__name__}")
+    return value
+
+
+def _fake_module(**attrs: object) -> ModuleType:
+    module = ModuleType("fake_google_module")
+    for name, value in attrs.items():
+        setattr(module, name, value)
+    return module
 
 
 def _gateway(*, retries: int = 0, retry_base: float = 0.0) -> DriveServiceGateway:
@@ -151,7 +169,7 @@ def test_service_handle_returns_cached_service_when_not_expired(monkeypatch: pyt
     gw = _gateway()
     service = MagicMock()
     service._http.credentials.expired = False
-    gw._service = cast(_DriveService, service)
+    gw._service = _as_drive_service(service)
     assert gw._service_handle() is service
 
 
@@ -159,16 +177,16 @@ def test_service_handle_rebuilds_on_expired_credentials(monkeypatch: pytest.Monk
     gw = _gateway()
     expired = MagicMock()
     expired._http.credentials.expired = True
-    gw._service = cast(_DriveService, expired)
+    gw._service = _as_drive_service(expired)
     creds = object()
     rebuilt = object()
-    load_credentials = cast(MagicMock, gw._auth_manager.load_credentials)
+    load_credentials = _as_mock(gw._auth_manager.load_credentials)
     load_credentials.return_value = creds
     build = MagicMock(return_value=rebuilt)
 
     def fake_import(name: str) -> ModuleType:
         if name == "googleapiclient.discovery":
-            return cast(ModuleType, MagicMock(build=build))
+            return _fake_module(build=build)
         raise AssertionError(name)
 
     monkeypatch.setattr("polylogue.sources.drive_gateway._import_module", fake_import)
@@ -181,13 +199,13 @@ def test_service_handle_builds_and_caches_service(monkeypatch: pytest.MonkeyPatc
     gw = _gateway()
     creds = object()
     built = object()
-    load_credentials = cast(MagicMock, gw._auth_manager.load_credentials)
+    load_credentials = _as_mock(gw._auth_manager.load_credentials)
     load_credentials.return_value = creds
     build = MagicMock(return_value=built)
 
     def fake_import(name: str) -> ModuleType:
         if name == "googleapiclient.discovery":
-            return cast(ModuleType, MagicMock(build=build))
+            return _fake_module(build=build)
         raise AssertionError(name)
 
     monkeypatch.setattr("polylogue.sources.drive_gateway._import_module", fake_import)
@@ -210,7 +228,7 @@ def test_download_file_writes_content(monkeypatch: pytest.MonkeyPatch) -> None:
     import io
 
     gw = _gateway()
-    gw._service = cast(_DriveService, MockDriveService(file_content={"file-1": b"hello-bytes"}))
+    gw._service = _as_drive_service(MockDriveService(file_content={"file-1": b"hello-bytes"}))
 
     monkeypatch.setattr(
         "polylogue.sources.drive_gateway._import_module",

--- a/tests/unit/sources/test_drive_gateway.py
+++ b/tests/unit/sources/test_drive_gateway.py
@@ -167,22 +167,26 @@ def test_call_with_retry_contract(
 
 def test_service_handle_returns_cached_service_when_not_expired(monkeypatch: pytest.MonkeyPatch) -> None:
     gw = _gateway()
-    service = MagicMock()
+    service = MockDriveService()
+    service._http = MagicMock()
     service._http.credentials.expired = False
-    gw._service = _as_drive_service(service)
-    assert gw._service_handle() is service
+    cached_service = _as_drive_service(service)
+    gw._service = cached_service
+    assert gw._service_handle() is cached_service
 
 
 def test_service_handle_rebuilds_on_expired_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
     gw = _gateway()
-    expired = MagicMock()
+    expired = MockDriveService()
+    expired._http = MagicMock()
     expired._http.credentials.expired = True
     gw._service = _as_drive_service(expired)
     creds = object()
-    rebuilt = object()
+    rebuilt = MockDriveService()
     load_credentials = _as_mock(gw._auth_manager.load_credentials)
     load_credentials.return_value = creds
-    build = MagicMock(return_value=rebuilt)
+    rebuilt_service = _as_drive_service(rebuilt)
+    build = MagicMock(return_value=rebuilt_service)
 
     def fake_import(name: str) -> ModuleType:
         if name == "googleapiclient.discovery":
@@ -190,7 +194,7 @@ def test_service_handle_rebuilds_on_expired_credentials(monkeypatch: pytest.Monk
         raise AssertionError(name)
 
     monkeypatch.setattr("polylogue.sources.drive_gateway._import_module", fake_import)
-    assert gw._service_handle() is rebuilt
+    assert gw._service_handle() is rebuilt_service
     load_credentials.assert_called_once_with()
     build.assert_called_once_with("drive", "v3", credentials=creds, cache_discovery=False)
 

--- a/tests/unit/sources/test_drive_source_client.py
+++ b/tests/unit/sources/test_drive_source_client.py
@@ -7,14 +7,12 @@ import os
 from dataclasses import replace
 from pathlib import Path
 from types import SimpleNamespace
-from typing import cast
 from unittest.mock import MagicMock
 
 import pytest
 from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 
-from polylogue.sources.drive_gateway import DriveServiceGateway
 from polylogue.sources.drive_source import (
     DriveSourceClient,
     _build_folder_lookup_query,
@@ -48,7 +46,7 @@ def _source_client(
         file_content=file_content,
         download_error=download_error,
     )
-    return DriveSourceClient(gateway=cast(DriveServiceGateway, gw))
+    return DriveSourceClient(gateway=gw)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/sources/test_parser_crashlessness.py
+++ b/tests/unit/sources/test_parser_crashlessness.py
@@ -11,7 +11,6 @@ Unacceptable: AttributeError, IndexError, RecursionError (bugs).
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import cast
 
 import pytest
 from hypothesis import HealthCheck, given, settings
@@ -30,17 +29,17 @@ class ProviderParser(TypedDict):
 
 def _payload_dict(payload: object) -> dict[str, object]:
     assert isinstance(payload, dict)
-    return cast(dict[str, object], payload)
+    return {str(key): value for key, value in payload.items()}
 
 
 def _payload_json_document(payload: object) -> JSONDocument:
     assert isinstance(payload, dict)
-    return cast(JSONDocument, payload)
+    return {str(key): value for key, value in payload.items()}
 
 
 def _payload_list(payload: object) -> list[object]:
     assert isinstance(payload, list)
-    return cast(list[object], payload)
+    return list(payload)
 
 
 def _parse_chatgpt(payload: object) -> object:

--- a/tests/unit/sources/test_parsers_codex.py
+++ b/tests/unit/sources/test_parsers_codex.py
@@ -6,8 +6,6 @@ branch tracking, git context, and edge cases.
 
 from __future__ import annotations
 
-from typing import cast
-
 from polylogue.lib.branch_type import BranchType
 from polylogue.sources.parsers.base import ParsedConversation
 from polylogue.sources.parsers.codex import looks_like as _looks_like_impl
@@ -18,12 +16,12 @@ from polylogue.sources.parsers.codex import parse_stream
 def looks_like(payload: object) -> bool:
     if not isinstance(payload, list):
         return False
-    return _looks_like_impl(cast(list[object], payload))
+    return _looks_like_impl(payload)
 
 
 def parse(payload: object, fallback_id: str) -> ParsedConversation:
     assert isinstance(payload, list)
-    return _parse_impl(cast(list[object], payload), fallback_id)
+    return _parse_impl(payload, fallback_id)
 
 
 def _provider_meta(conversation: ParsedConversation) -> dict[str, object]:
@@ -34,7 +32,7 @@ def _provider_meta(conversation: ParsedConversation) -> dict[str, object]:
 def _nested_meta(conversation: ParsedConversation, key: str) -> dict[str, object]:
     value = _provider_meta(conversation).get(key)
     assert isinstance(value, dict)
-    return cast(dict[str, object], value)
+    return dict(value)
 
 
 # =============================================================================

--- a/tests/unit/sources/test_parsers_props.py
+++ b/tests/unit/sources/test_parsers_props.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
-from typing import TypeAlias, TypedDict, cast
+from typing import TypeAlias, TypedDict
 
 import pytest
 from hypothesis import given, settings
@@ -259,7 +259,7 @@ def test_provider_looks_like_accepts_generated_payloads(case: ParserCase, data: 
 @given(st.lists(message_strategy(), min_size=0, max_size=20))
 @settings(max_examples=50)
 def test_extract_messages_from_list_never_invents_messages(messages: list[JSONDocument]) -> None:
-    result = extract_messages_from_list(cast(list[object], messages))
+    result = extract_messages_from_list(messages)
     expected = sum(1 for msg in messages if isinstance(msg, dict) and (msg.get("text") or msg.get("content")))
     assert len(result) <= expected
 
@@ -267,7 +267,7 @@ def test_extract_messages_from_list_never_invents_messages(messages: list[JSONDo
 @given(message_strategy())
 @settings(max_examples=50)
 def test_extract_messages_from_list_normalizes_role(msg: JSONDocument) -> None:
-    result = extract_messages_from_list(cast(list[object], [msg]))
+    result = extract_messages_from_list([msg])
     if result:
         assert result[0].role in {"user", "assistant", "system", "tool", "message"}
 
@@ -283,7 +283,7 @@ def test_chatgpt_node_contract(node: JSONDocument) -> None:
 @given(claude_code_message_strategy())
 @settings(max_examples=30)
 def test_claude_code_message_type_contract(msg: JSONDocument) -> None:
-    result = claude.parse_code(cast(list[object], [msg]), "fallback")
+    result = claude.parse_code([msg], "fallback")
     if not result.messages:
         return
     parsed = result.messages[0]
@@ -304,13 +304,10 @@ def test_claude_code_message_type_contract(msg: JSONDocument) -> None:
 @given(codex_message_strategy())
 @settings(max_examples=30)
 def test_codex_message_text_contract(msg: JSONDocument) -> None:
-    session = cast(
-        list[object],
-        [
-            {"type": "session_meta", "payload": {"id": "test", "timestamp": "2024-01-01"}},
-            {"type": "response_item", "payload": msg},
-        ],
-    )
+    session: list[object] = [
+        {"type": "session_meta", "payload": {"id": "test", "timestamp": "2024-01-01"}},
+        {"type": "response_item", "payload": msg},
+    ]
     result = codex.parse(session, "fallback")
     if not result.messages:
         return
@@ -400,9 +397,11 @@ def provider_conversations(
     """Parse synthetic data for each available provider."""
     provider = str(request.param)
     try:
-        source = cast(Source, synthetic_source(provider, count=3, seed=42))
+        source = synthetic_source(provider, count=3, seed=42)
     except FileNotFoundError:
         pytest.skip(f"No schema for {provider}")
+    if not isinstance(source, Source):
+        raise TypeError(f"expected Source, got {type(source).__name__}")
 
     convos = list(iter_source_conversations(source))
     if not convos:

--- a/tests/unit/sources/test_unified_semantic_laws.py
+++ b/tests/unit/sources/test_unified_semantic_laws.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from datetime import datetime
 from types import SimpleNamespace
-from typing import Protocol, TypeAlias, cast
+from typing import Protocol, TypeAlias
 
 import pytest
 from hypothesis import given, settings
@@ -77,9 +77,14 @@ SemanticCase: TypeAlias = tuple[str, RawPayload]
 
 
 class ViewportRecord(Protocol):
-    text_content: str
-    role_normalized: str
-    parsed_timestamp: datetime | None
+    @property
+    def text_content(self) -> str: ...
+
+    @property
+    def role_normalized(self) -> str | Role: ...
+
+    @property
+    def parsed_timestamp(self) -> datetime | None: ...
 
     def to_meta(self) -> MessageMeta: ...
 
@@ -112,15 +117,15 @@ def _doc(value: object) -> JSONDocument:
 
 def _build_viewport_record(provider: str, raw: RawPayload) -> ViewportRecord:
     if provider == "chatgpt":
-        return cast(ViewportRecord, ChatGPTMessage.model_validate(raw))
+        return ChatGPTMessage.model_validate(raw)
     if provider == "claude-ai":
-        return cast(ViewportRecord, ClaudeAIChatMessage.model_validate(raw))
+        return ClaudeAIChatMessage.model_validate(raw)
     if provider == "claude-code":
-        return cast(ViewportRecord, ClaudeCodeRecord.model_validate(raw))
+        return ClaudeCodeRecord.model_validate(raw)
     if provider == "codex":
-        return cast(ViewportRecord, CodexRecord.model_validate(raw))
+        return CodexRecord.model_validate(raw)
     if provider == "gemini":
-        return cast(ViewportRecord, GeminiMessage.model_validate(raw))
+        return GeminiMessage.model_validate(raw)
     raise AssertionError(f"unexpected provider {provider}")
 
 
@@ -487,7 +492,9 @@ def test_provider_adapter_viewport_contract(case: SemanticCase) -> None:
 
     if isinstance(record, ChatGPTMessage):
         assert record.role_normalized in {"user", "assistant", "system", "tool", "unknown"}
-        assert record.text_content == extract_chatgpt_text(_doc(record.content.model_dump(mode="python")))
+        content = record.content
+        assert content is not None
+        assert record.text_content == extract_chatgpt_text(_doc(content.model_dump(mode="python")))
         assert blocks == record.to_content_blocks()
         assert not traces
         assert not calls

--- a/tests/unit/storage/test_archive_search_contracts.py
+++ b/tests/unit/storage/test_archive_search_contracts.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import sqlite3
 from dataclasses import dataclass
-from typing import cast
 
 import pytest
 
@@ -29,7 +28,7 @@ def _conversation_record(conversation_id: str, *, title: str, provider_name: str
 
 
 @dataclass
-class _FakeQueries:
+class _FakeQueries(SQLiteQueryStore):
     hits: ConversationSearchResult
     records_by_id: dict[str, ConversationRecord]
     last_batch_ids: list[str] | None = None
@@ -37,19 +36,19 @@ class _FakeQueries:
     async def search_conversation_hits(
         self,
         query: str,
-        *,
-        limit: int,
-        providers: list[str] | None,
+        limit: int = 20,
+        providers: list[str] | None = None,
     ) -> ConversationSearchResult:
+        del query, limit, providers
         return self.hits
 
     async def search_action_conversation_hits(
         self,
         query: str,
-        *,
-        limit: int,
-        providers: list[str] | None,
+        limit: int = 20,
+        providers: list[str] | None = None,
     ) -> ConversationSearchResult:
+        del query, limit, providers
         return self.hits
 
     async def get_conversations_batch(self, ids: list[str]) -> list[ConversationRecord]:
@@ -58,10 +57,10 @@ class _FakeQueries:
 
 
 class _FakeRepo(RepositoryArchiveSearchMixin):
-    queries: SQLiteQueryStore
+    queries: _FakeQueries
 
     def __init__(self, queries: _FakeQueries) -> None:
-        self.queries = cast(SQLiteQueryStore, queries)
+        self.queries = queries
         self.ordered_ids_seen: list[str] | None = None
 
     async def _hydrate_conversations(

--- a/tests/unit/storage/test_backend.py
+++ b/tests/unit/storage/test_backend.py
@@ -10,7 +10,6 @@ import time
 from collections.abc import Awaitable, Callable
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Protocol, cast
 
 import aiosqlite
 import pytest
@@ -38,10 +37,11 @@ from tests.infra.storage_records import (
 )
 
 
-class MutableSchemaBackend(Protocol):
-    """Subset used by concurrency tests to wrap schema initialization."""
-
-    _ensure_schema: Callable[[aiosqlite.Connection], Awaitable[None]]
+def _replace_ensure_schema(
+    backend: SQLiteBackend,
+    handler: Callable[[aiosqlite.Connection], Awaitable[None]],
+) -> None:
+    object.__setattr__(backend, "_ensure_schema", handler)
 
 
 def _table_names(conn: sqlite3.Connection) -> set[str]:
@@ -595,7 +595,7 @@ async def test_async_read_connection_closes_cleanly_after_pool_teardown(tmp_path
         await original_ensure_schema(conn)
 
     backend._schema_ensured = False
-    cast(MutableSchemaBackend, backend)._ensure_schema = counting_ensure_schema
+    _replace_ensure_schema(backend, counting_ensure_schema)
     await asyncio.gather(*[backend.queries.list_conversations(ConversationRecordQuery()) for _ in range(20)])
     assert init_count == 0
 
@@ -610,7 +610,7 @@ async def test_async_read_connection_closes_cleanly_after_pool_teardown(tmp_path
         events.append("end")
 
     slow_backend._schema_ensured = False
-    cast(MutableSchemaBackend, slow_backend)._ensure_schema = slow_ensure_schema
+    _replace_ensure_schema(slow_backend, slow_ensure_schema)
     await asyncio.gather(slow_backend.get_conversation("a"), slow_backend.get_conversation("b"))
     assert events.count("start") == 1
     assert events.count("end") == 1

--- a/tests/unit/storage/test_embedding_stats.py
+++ b/tests/unit/storage/test_embedding_stats.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import sqlite3
-from typing import cast
 
 import aiosqlite
 import pytest
@@ -53,22 +52,30 @@ def test_read_embedding_stats_sync_counts_available_tables() -> None:
 
 
 def test_read_embedding_stats_sync_propagates_non_missing_operational_errors() -> None:
-    class LockedConnection:
-        def execute(self: object, sql: str) -> None:  # pragma: no cover - trivial stub
+    class LockedConnection(sqlite3.Connection):
+        def execute(self, sql: str, parameters: object = (), /) -> sqlite3.Cursor:  # pragma: no cover - trivial stub
+            del sql, parameters
             raise sqlite3.OperationalError("database is locked")
 
+    conn = sqlite3.connect(":memory:", factory=LockedConnection)
     with pytest.raises(sqlite3.OperationalError, match="database is locked"):
-        read_embedding_stats_sync(cast(sqlite3.Connection, LockedConnection()))
+        read_embedding_stats_sync(conn)
+    conn.close()
 
 
 def test_read_embedding_stats_sync_treats_missing_vec_module_as_optional() -> None:
-    class VeclessConnection:
-        def execute(self: object, sql: str) -> None:
+    class VeclessConnection(sqlite3.Connection):
+        def execute(self, sql: str, parameters: object = (), /) -> sqlite3.Cursor:
+            del parameters
             if "message_embeddings" in sql:
                 raise sqlite3.OperationalError("no such module: vec0")
             raise sqlite3.OperationalError("no such table: embedding_status")
 
-    stats = read_embedding_stats_sync(cast(sqlite3.Connection, VeclessConnection()))
+    conn = sqlite3.connect(":memory:", factory=VeclessConnection)
+    try:
+        stats = read_embedding_stats_sync(conn)
+    finally:
+        conn.close()
 
     assert stats.embedded_conversations == 0
     assert stats.embedded_messages == 0

--- a/tests/unit/storage/test_hybrid.py
+++ b/tests/unit/storage/test_hybrid.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import sqlite3
 from pathlib import Path
-from typing import cast
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -23,6 +22,12 @@ from polylogue.storage.search_providers.hybrid import (
     reciprocal_rank_fusion,
 )
 from tests.infra.storage_records import make_conversation, make_hash, make_message
+
+
+def _as_mock(value: object) -> MagicMock:
+    if not isinstance(value, MagicMock):
+        raise TypeError(f"expected MagicMock, got {type(value).__name__}")
+    return value
 
 
 class TestHybridSearchProvider:
@@ -417,11 +422,11 @@ class TestProviderFilteringIntegration:
     def test_provider_filter_applied_before_limit(self, hybrid_provider: HybridSearchProvider) -> None:
         """Provider filter should be applied before limit, not after."""
         # Mock search returns messages from various providers
-        cast(MagicMock, hybrid_provider.fts_provider.search).return_value = [f"msg-claude-{i}" for i in range(15)] + [
+        _as_mock(hybrid_provider.fts_provider.search).return_value = [f"msg-claude-{i}" for i in range(15)] + [
             f"msg-chatgpt-{i}" for i in range(5)
         ]
 
-        cast(MagicMock, hybrid_provider.vector_provider.query).return_value = [
+        _as_mock(hybrid_provider.vector_provider.query).return_value = [
             (f"msg-claude-{i}", 0.9 - i * 0.01) for i in range(10)
         ]
 
@@ -442,12 +447,12 @@ class TestProviderFilteringIntegration:
 
     def test_provider_filter_none_returns_all(self, hybrid_provider: HybridSearchProvider) -> None:
         """When providers=None, should return conversations from all providers."""
-        cast(MagicMock, hybrid_provider.fts_provider.search).return_value = [
+        _as_mock(hybrid_provider.fts_provider.search).return_value = [
             "msg-claude-1",
             "msg-chatgpt-1",
             "msg-gemini-1",
         ]
-        cast(MagicMock, hybrid_provider.vector_provider.query).return_value = []
+        _as_mock(hybrid_provider.vector_provider.query).return_value = []
 
         with patch("polylogue.storage.search_providers.hybrid.open_connection") as mock_conn:
             mock_context = MagicMock()
@@ -470,12 +475,12 @@ class TestProviderFilteringIntegration:
 
     def test_provider_filter_multiple_providers(self, hybrid_provider: HybridSearchProvider) -> None:
         """Can filter by multiple providers at once."""
-        cast(MagicMock, hybrid_provider.fts_provider.search).return_value = [
+        _as_mock(hybrid_provider.fts_provider.search).return_value = [
             "msg-claude-1",
             "msg-chatgpt-1",
             "msg-gemini-1",
         ]
-        cast(MagicMock, hybrid_provider.vector_provider.query).return_value = []
+        _as_mock(hybrid_provider.vector_provider.query).return_value = []
 
         with patch("polylogue.storage.search_providers.hybrid.open_connection") as mock_conn:
             mock_context = MagicMock()

--- a/tests/unit/storage/test_query_mappers.py
+++ b/tests/unit/storage/test_query_mappers.py
@@ -7,7 +7,6 @@ Functions: _parse_json, _row_get, _row_to_conversation, _row_to_message, _row_to
 from __future__ import annotations
 
 import sqlite3
-from typing import cast
 
 import pytest
 
@@ -50,7 +49,8 @@ def make_row(columns: dict[str, object]) -> sqlite3.Row:
     row = conn.execute("SELECT * FROM t").fetchone()
     conn.close()
     assert row is not None
-    return cast(sqlite3.Row, row)
+    assert isinstance(row, sqlite3.Row)
+    return row
 
 
 # =============================================================================

--- a/tests/unit/storage/test_query_security.py
+++ b/tests/unit/storage/test_query_security.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import sqlite3
 from pathlib import Path
-from typing import cast
 
 import pytest
 from hypothesis import HealthCheck, given, settings
@@ -105,7 +104,8 @@ async def test_empty_string_parameters_handled(temp_repo: ConversationRepository
 
 async def test_none_parameters_handled(temp_repo: ConversationRepository) -> None:
     try:
-        conv = await temp_repo.view(cast(str, None))
+        view_method = "view"
+        conv = await getattr(temp_repo, view_method)(None)
         assert conv is None
     except (TypeError, ValueError):
         pass

--- a/tests/unit/storage/test_repository_lifecycle_laws.py
+++ b/tests/unit/storage/test_repository_lifecycle_laws.py
@@ -189,3 +189,32 @@ def test_domain_conversation_to_record_generates_content_hash(workspace_env: Map
     domain_conversation = conversation_from_records(conv_record, msg_records, attachment_records)
     record = conversation_to_record(domain_conversation)
     assert record.content_hash
+
+
+@pytest.mark.asyncio()
+async def test_repository_rejects_domain_conversation_without_message_records(
+    workspace_env: Mapping[str, Path],
+) -> None:
+    """A hydrated domain object must not be re-saved as an empty runtime graph."""
+    scenario = ArchiveScenario(
+        name="domain-empty-records",
+        provider="claude-code",
+        title="Domain empty records",
+        messages=(ScenarioMessage(role="user", text="Question", message_id="m1"),),
+    )
+    db_path, _ = seed_workspace_scenarios(workspace_env, [scenario])
+    repository = repository_for_scenario_db(db_path)
+    try:
+        conversation = await repository.get(scenario.resolved_conversation_id)
+        assert conversation is not None
+
+        with pytest.raises(ValueError, match="domain Conversation with messages but no MessageRecord"):
+            await repository.save_conversation(conversation, [], [])
+
+        with open_connection(db_path) as conn:
+            assert_conversation_surfaces_agree(
+                scenario.facts_from_connection(conn),
+                await scenario.facts_from_repository(repository),
+            )
+    finally:
+        await repository.close()

--- a/tests/unit/storage/test_repository_lifecycle_laws.py
+++ b/tests/unit/storage/test_repository_lifecycle_laws.py
@@ -16,8 +16,9 @@ from tests.infra.archive_scenarios import (
     repository_for_scenario_db,
     seed_workspace_scenarios,
 )
-from tests.infra.oracles import assert_archive_surfaces_agree, assert_conversation_surfaces_agree
+from tests.infra.oracles import assert_conversation_surfaces_agree
 from tests.infra.semantic_facts import ArchiveFacts, ConversationFacts
+from tests.infra.state_machines import RepositoryLifecycleHarness
 
 
 @pytest.mark.asyncio()
@@ -46,48 +47,40 @@ async def test_repository_metadata_tag_and_delete_lifecycle_laws(workspace_env: 
         metadata={"tags": ["initial"], "summary": "before"},
     )
     db_path, _ = seed_workspace_scenarios(workspace_env, [scenario])
-    repository = repository_for_scenario_db(db_path)
+    harness = RepositoryLifecycleHarness.create(
+        db_path=db_path,
+        archive_root=workspace_env["archive_root"],
+        scenarios=(scenario,),
+    )
     try:
-        with open_connection(db_path) as conn:
-            assert_conversation_surfaces_agree(
-                scenario.facts_from_connection(conn),
-                scenario.hydrated_facts_from_connection(conn),
-                await scenario.facts_from_repository(repository),
-            )
+        await harness.assert_conversation_visible(scenario)
 
-        await repository.add_tag(scenario.resolved_conversation_id, "review")
-        await repository.add_tag(scenario.resolved_conversation_id, "review")
-        await repository.update_metadata(scenario.resolved_conversation_id, "summary", "after")
-        await repository.update_metadata(
-            scenario.resolved_conversation_id,
+        await harness.add_tag_and_assert_visible(scenario, "review")
+        await harness.add_tag_and_assert_visible(scenario, "review")
+        await harness.update_metadata_and_assert_visible(scenario, "summary", "after")
+        await harness.update_metadata_and_assert_visible(
+            scenario,
             "audit",
             {"status": "checked", "tooling": ["repository", "scenario"]},
         )
-        await repository.delete_metadata(scenario.resolved_conversation_id, "missing")
+        await harness.delete_metadata_and_assert_visible(scenario, "missing")
 
-        metadata = await repository.get_metadata(scenario.resolved_conversation_id)
+        metadata = await harness.repository.get_metadata(scenario.resolved_conversation_id)
         assert metadata["tags"] == ["initial", "review"]
         assert metadata["summary"] == "after"
         assert metadata["audit"] == {"status": "checked", "tooling": ["repository", "scenario"]}
-        assert await repository.list_tags() == {"initial": 1, "review": 1}
+        await harness.assert_tags({"initial": 1, "review": 1})
 
-        await repository.remove_tag(scenario.resolved_conversation_id, "initial")
-        await repository.remove_tag(scenario.resolved_conversation_id, "initial")
-        metadata_after_remove = await repository.get_metadata(scenario.resolved_conversation_id)
+        await harness.remove_tag_and_assert_visible(scenario, "initial")
+        await harness.remove_tag_and_assert_visible(scenario, "initial")
+        metadata_after_remove = await harness.repository.get_metadata(scenario.resolved_conversation_id)
         assert metadata_after_remove["tags"] == ["review"]
-        assert await repository.list_tags(provider="claude-code") == {"review": 1}
+        await harness.assert_tags({"review": 1}, provider="claude-code")
+        await harness.assert_archive_agrees(total_conversations=1)
 
-        with open_connection(db_path) as conn:
-            db_facts_before_delete = ArchiveFacts.from_db_connection(conn)
-        repo_facts_before_delete = ArchiveFacts.from_conversations(await repository.list(limit=None))
-        assert_archive_surfaces_agree(db_facts_before_delete, repo_facts_before_delete)
-        assert db_facts_before_delete.total_conversations == 1
-
-        assert await repository.delete_conversation(scenario.resolved_conversation_id) is True
-        assert await repository.delete_conversation(scenario.resolved_conversation_id) is False
-        assert await repository.get(scenario.resolved_conversation_id) is None
-        assert await repository.count() == 0
-        assert await repository.list_tags() == {}
+        await harness.delete_conversation_and_assert_absent(scenario)
+        assert await harness.repository.count() == 0
+        await harness.assert_tags({})
 
         with open_connection(db_path) as conn:
             assert ArchiveFacts.from_db_connection(conn) == ArchiveFacts(
@@ -96,11 +89,53 @@ async def test_repository_metadata_tag_and_delete_lifecycle_laws(workspace_env: 
                 total_messages=0,
                 conversation_ids=(),
             )
-            for table_name in ("messages", "content_blocks", "attachment_refs"):
-                count = int(conn.execute(f"SELECT COUNT(*) FROM {table_name}").fetchone()[0])
-                assert count == 0, f"{table_name} retained rows after repository delete"
     finally:
-        await repository.close()
+        await harness.close()
+
+
+@pytest.mark.asyncio()
+async def test_repository_lifecycle_state_keeps_neighbor_conversations_visible(
+    workspace_env: Mapping[str, Path],
+) -> None:
+    """State transitions for one conversation must not disturb its archive neighbors."""
+    target = ArchiveScenario(
+        name="repo-state-target",
+        provider="claude-code",
+        title="Target lifecycle",
+        messages=(ScenarioMessage(role="user", text="Mutate me", message_id="target-m1"),),
+        metadata={"tags": ["target"]},
+    )
+    neighbor = ArchiveScenario(
+        name="repo-state-neighbor",
+        provider="chatgpt",
+        title="Neighbor lifecycle",
+        messages=(ScenarioMessage(role="assistant", text="Keep me", message_id="neighbor-m1"),),
+        metadata={"tags": ["neighbor"]},
+    )
+    db_path, _ = seed_workspace_scenarios(workspace_env, [target, neighbor])
+    harness = RepositoryLifecycleHarness.create(
+        db_path=db_path,
+        archive_root=workspace_env["archive_root"],
+        scenarios=(target, neighbor),
+    )
+    try:
+        await harness.assert_archive_agrees(total_conversations=2)
+        await harness.add_tag_and_assert_visible(target, "review")
+        await harness.assert_conversation_visible(neighbor)
+        await harness.update_metadata_and_assert_visible(target, "summary", "reviewed")
+        await harness.assert_metadata_contains(
+            target.resolved_conversation_id,
+            {"tags": ["target", "review"], "summary": "reviewed"},
+        )
+        await harness.assert_metadata_contains(neighbor.resolved_conversation_id, {"tags": ["neighbor"]})
+        await harness.delete_conversation_and_assert_absent(target)
+
+        await harness.assert_conversation_visible(neighbor)
+        archive_facts = await harness.assert_archive_agrees(total_conversations=1)
+        assert archive_facts.conversation_ids == (neighbor.resolved_conversation_id,)
+        await harness.assert_tags({"neighbor": 1})
+    finally:
+        await harness.close()
 
 
 @pytest.mark.asyncio()

--- a/tests/unit/storage/test_repository_lifecycle_laws.py
+++ b/tests/unit/storage/test_repository_lifecycle_laws.py
@@ -1,0 +1,156 @@
+"""Repository lifecycle laws over declarative archive scenarios."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+
+import pytest
+
+from polylogue.storage.backends.connection import open_connection
+from polylogue.storage.hydrators import conversation_from_records
+from tests.infra.archive_scenarios import (
+    ArchiveScenario,
+    ScenarioAttachment,
+    ScenarioMessage,
+    repository_for_scenario_db,
+    seed_workspace_scenarios,
+)
+from tests.infra.oracles import assert_archive_surfaces_agree, assert_conversation_surfaces_agree
+from tests.infra.semantic_facts import ArchiveFacts, ConversationFacts
+
+
+@pytest.mark.asyncio()
+async def test_repository_metadata_tag_and_delete_lifecycle_laws(workspace_env: Mapping[str, Path]) -> None:
+    """Repository writes converge and keep archive surfaces internally consistent."""
+    scenario = ArchiveScenario(
+        name="repo-lifecycle",
+        provider="claude-code",
+        title="Lifecycle law",
+        messages=(
+            ScenarioMessage(role="user", text="Inspect lifecycle", message_id="m-user"),
+            ScenarioMessage(
+                role="assistant",
+                text="I will call a tool",
+                message_id="m-tool",
+                content_blocks=(
+                    {
+                        "type": "tool_use",
+                        "tool_name": "shell",
+                        "tool_input": {"command": "polylogue doctor --json"},
+                    },
+                ),
+                attachments=(ScenarioAttachment(attachment_id="att-lifecycle", mime_type="application/json"),),
+            ),
+        ),
+        metadata={"tags": ["initial"], "summary": "before"},
+    )
+    db_path, _ = seed_workspace_scenarios(workspace_env, [scenario])
+    repository = repository_for_scenario_db(db_path)
+    try:
+        with open_connection(db_path) as conn:
+            assert_conversation_surfaces_agree(
+                scenario.facts_from_connection(conn),
+                scenario.hydrated_facts_from_connection(conn),
+                await scenario.facts_from_repository(repository),
+            )
+
+        await repository.add_tag(scenario.resolved_conversation_id, "review")
+        await repository.add_tag(scenario.resolved_conversation_id, "review")
+        await repository.update_metadata(scenario.resolved_conversation_id, "summary", "after")
+        await repository.update_metadata(
+            scenario.resolved_conversation_id,
+            "audit",
+            {"status": "checked", "tooling": ["repository", "scenario"]},
+        )
+        await repository.delete_metadata(scenario.resolved_conversation_id, "missing")
+
+        metadata = await repository.get_metadata(scenario.resolved_conversation_id)
+        assert metadata["tags"] == ["initial", "review"]
+        assert metadata["summary"] == "after"
+        assert metadata["audit"] == {"status": "checked", "tooling": ["repository", "scenario"]}
+        assert await repository.list_tags() == {"initial": 1, "review": 1}
+
+        await repository.remove_tag(scenario.resolved_conversation_id, "initial")
+        await repository.remove_tag(scenario.resolved_conversation_id, "initial")
+        metadata_after_remove = await repository.get_metadata(scenario.resolved_conversation_id)
+        assert metadata_after_remove["tags"] == ["review"]
+        assert await repository.list_tags(provider="claude-code") == {"review": 1}
+
+        with open_connection(db_path) as conn:
+            db_facts_before_delete = ArchiveFacts.from_db_connection(conn)
+        repo_facts_before_delete = ArchiveFacts.from_conversations(await repository.list(limit=None))
+        assert_archive_surfaces_agree(db_facts_before_delete, repo_facts_before_delete)
+        assert db_facts_before_delete.total_conversations == 1
+
+        assert await repository.delete_conversation(scenario.resolved_conversation_id) is True
+        assert await repository.delete_conversation(scenario.resolved_conversation_id) is False
+        assert await repository.get(scenario.resolved_conversation_id) is None
+        assert await repository.count() == 0
+        assert await repository.list_tags() == {}
+
+        with open_connection(db_path) as conn:
+            assert ArchiveFacts.from_db_connection(conn) == ArchiveFacts(
+                total_conversations=0,
+                provider_counts={},
+                total_messages=0,
+                conversation_ids=(),
+            )
+            for table_name in ("messages", "content_blocks", "attachment_refs"):
+                count = int(conn.execute(f"SELECT COUNT(*) FROM {table_name}").fetchone()[0])
+                assert count == 0, f"{table_name} retained rows after repository delete"
+    finally:
+        await repository.close()
+
+
+@pytest.mark.asyncio()
+async def test_repository_resave_existing_conversation_is_idempotent(workspace_env: Mapping[str, Path]) -> None:
+    """Saving existing records does not create duplicate archive facts."""
+    scenario = ArchiveScenario(
+        name="repo-resave",
+        provider="chatgpt",
+        title="Resave law",
+        messages=(
+            ScenarioMessage(role="user", text="Question", message_id="m1"),
+            ScenarioMessage(role="assistant", text="Answer", message_id="m2"),
+        ),
+    )
+    db_path, _ = seed_workspace_scenarios(workspace_env, [scenario])
+    repository = repository_for_scenario_db(db_path)
+    try:
+        with open_connection(db_path) as conn:
+            conv_record, msg_records, attachment_records = scenario.records_from_connection(conn)
+            before = scenario.facts_from_connection(conn)
+
+        counts = await repository.save_conversation(conv_record, msg_records, attachment_records)
+        assert counts["conversations"] == 0
+        assert counts["messages"] == 0
+        assert counts["skipped_conversations"] == 1
+        assert counts["skipped_messages"] == 2
+
+        with open_connection(db_path) as conn:
+            after = scenario.facts_from_connection(conn)
+        conversation = await repository.get(scenario.resolved_conversation_id)
+        assert conversation is not None
+        assert_conversation_surfaces_agree(before, after, ConversationFacts.from_domain_conversation(conversation))
+    finally:
+        await repository.close()
+
+
+def test_domain_conversation_to_record_generates_content_hash(workspace_env: Mapping[str, Path]) -> None:
+    """Hydrated domain conversations remain convertible even without stored metadata hashes."""
+    from polylogue.storage.repository_write_conversations import conversation_to_record
+
+    scenario = ArchiveScenario(
+        name="domain-record",
+        provider="chatgpt",
+        title="Domain conversion",
+        messages=(ScenarioMessage(role="user", text="Question", message_id="m1"),),
+    )
+    db_path, _ = seed_workspace_scenarios(workspace_env, [scenario])
+    with open_connection(db_path) as conn:
+        conv_record, msg_records, attachment_records = scenario.records_from_connection(conn)
+
+    domain_conversation = conversation_from_records(conv_record, msg_records, attachment_records)
+    record = conversation_to_record(domain_conversation)
+    assert record.content_hash

--- a/tests/unit/storage/test_retrieval_readiness_laws.py
+++ b/tests/unit/storage/test_retrieval_readiness_laws.py
@@ -1,206 +1,201 @@
-"""Retrieval readiness laws: prove index/query semantics are consistent.
+"""Retrieval readiness laws over shared archive scenarios.
 
-These laws verify that FTS indexes, provider filters, and query surfaces
-agree with each other and with the underlying stored data.
+These tests prove provider filters, FTS search, counts, and aggregate archive
+facts agree across direct SQL, hydrated records, repository, and facade
+surfaces.
 """
 
 from __future__ import annotations
 
+from collections.abc import AsyncIterator, Mapping
 from pathlib import Path
 
 import pytest
 
-from tests.infra.storage_records import ConversationBuilder, db_setup
+from tests.infra.archive_scenarios import ArchiveScenario, ScenarioMessage, seed_workspace_scenarios
+from tests.infra.oracles import assert_archive_surfaces_agree, assert_provider_partition_exhaustive
+from tests.infra.query_cases import ArchiveQueryCase
+from tests.infra.surfaces import ArchiveSurfaceSet, build_archive_surface_set
 
 
 @pytest.fixture()
-def populated_db(workspace_env: dict[str, Path]) -> Path:
-    """Create a DB with conversations across multiple providers, with FTS indexed."""
-    db_path = db_setup(workspace_env)
-
-    (
-        ConversationBuilder(db_path, "chatgpt-1")
-        .provider("chatgpt")
-        .title("ChatGPT conversation about testing")
-        .add_message(role="user", text="How do I write property tests?")
-        .add_message(role="assistant", text="Property tests verify invariants using random inputs")
-        .save()
+def retrieval_archive(workspace_env: Mapping[str, Path]) -> tuple[Path, tuple[ArchiveScenario, ...]]:
+    """Seed provider-diverse conversations with stable search terms."""
+    scenarios = (
+        ArchiveScenario(
+            name="chatgpt-retrieval-1",
+            provider="chatgpt",
+            title="ChatGPT conversation about testing",
+            messages=(
+                ScenarioMessage(role="user", text="How do I write property tests?", message_id="chatgpt-u1"),
+                ScenarioMessage(
+                    role="assistant",
+                    text="Property tests verify invariants using random inputs",
+                    message_id="chatgpt-a1",
+                ),
+            ),
+        ),
+        ArchiveScenario(
+            name="claude-retrieval-1",
+            provider="claude-code",
+            title="Claude Code session on refactoring",
+            messages=(
+                ScenarioMessage(role="user", text="Refactor the storage module", message_id="claude1-u1"),
+                ScenarioMessage(role="assistant", text="I will restructure the query layer", message_id="claude1-a1"),
+                ScenarioMessage(role="user", text="Also fix the property tests", message_id="claude1-u2"),
+            ),
+        ),
+        ArchiveScenario(
+            name="claude-retrieval-2",
+            provider="claude-code",
+            title="Claude debugging memory leak",
+            messages=(
+                ScenarioMessage(role="user", text="Memory keeps growing during ingest", message_id="claude2-u1"),
+                ScenarioMessage(role="assistant", text="The blob store path has a leak", message_id="claude2-a1"),
+            ),
+        ),
+        ArchiveScenario(
+            name="codex-retrieval-1",
+            provider="codex",
+            title="Codex adding authentication",
+            messages=(ScenarioMessage(role="user", text="Add OAuth2 authentication", message_id="codex-u1"),),
+        ),
     )
-    (
-        ConversationBuilder(db_path, "claude-1")
-        .provider("claude-code")
-        .title("Claude Code session on refactoring")
-        .add_message(role="user", text="Refactor the storage module")
-        .add_message(role="assistant", text="I will restructure the query layer")
-        .add_message(role="user", text="Also fix the property tests")
-        .save()
+    db_path, _ = seed_workspace_scenarios(workspace_env, scenarios)
+    return db_path, scenarios
+
+
+@pytest.fixture()
+async def retrieval_surfaces(
+    workspace_env: Mapping[str, Path],
+    retrieval_archive: tuple[Path, tuple[ArchiveScenario, ...]],
+) -> AsyncIterator[ArchiveSurfaceSet]:
+    db_path, scenarios = retrieval_archive
+    surfaces = build_archive_surface_set(
+        db_path=db_path,
+        archive_root=workspace_env["archive_root"],
+        scenarios=scenarios,
     )
-    (
-        ConversationBuilder(db_path, "claude-2")
-        .provider("claude-code")
-        .title("Claude debugging memory leak")
-        .add_message(role="user", text="Memory keeps growing during ingest")
-        .add_message(role="assistant", text="The blob store path has a leak")
-        .save()
+    try:
+        yield surfaces
+    finally:
+        await surfaces.close()
+
+
+def _provider_cases() -> tuple[ArchiveQueryCase, ...]:
+    return (
+        ArchiveQueryCase(
+            name="provider-chatgpt",
+            provider="chatgpt",
+            expected_ids=("chatgpt-retrieval-1",),
+        ),
+        ArchiveQueryCase(
+            name="provider-claude",
+            provider="claude-code",
+            expected_ids=("claude-retrieval-1", "claude-retrieval-2"),
+        ),
+        ArchiveQueryCase(
+            name="provider-codex",
+            provider="codex",
+            expected_ids=("codex-retrieval-1",),
+        ),
     )
-    (
-        ConversationBuilder(db_path, "codex-1")
-        .provider("codex")
-        .title("Codex adding authentication")
-        .add_message(role="user", text="Add OAuth2 authentication")
-        .save()
+
+
+def _search_cases() -> tuple[ArchiveQueryCase, ...]:
+    return (
+        ArchiveQueryCase(
+            name="search-property",
+            search_text="property",
+            expected_ids=("chatgpt-retrieval-1", "claude-retrieval-1"),
+        ),
+        ArchiveQueryCase(
+            name="search-memory",
+            search_text="memory",
+            expected_ids=("claude-retrieval-2",),
+        ),
+        ArchiveQueryCase(
+            name="search-authentication",
+            search_text="authentication",
+            expected_ids=("codex-retrieval-1",),
+        ),
     )
 
-    return db_path
+
+class TestRetrievalSurfaceAgreement:
+    @pytest.mark.asyncio()
+    async def test_archive_facts_agree_across_surfaces(self, retrieval_surfaces: ArchiveSurfaceSet) -> None:
+        facts = [await surface.archive_facts() for surface in retrieval_surfaces.surfaces]
+
+        assert_archive_surfaces_agree(*facts)
+        assert facts[0].total_conversations == 4
+        assert facts[0].total_messages == 8
+        assert facts[0].provider_counts == {"chatgpt": 1, "claude-code": 2, "codex": 1}
+
+    @pytest.mark.asyncio()
+    async def test_provider_filters_partition_the_archive(self, retrieval_surfaces: ArchiveSurfaceSet) -> None:
+        all_ids = set((await retrieval_surfaces.surfaces[0].archive_facts()).conversation_ids)
+        ids_by_provider: dict[str, tuple[str, ...]] = {}
+
+        for case in _provider_cases():
+            assert case.provider is not None
+            projected_ids = [await surface.query_ids(case) for surface in retrieval_surfaces.surfaces]
+            expected_ids = tuple(sorted(case.expected_ids))
+            for surface, ids in zip(retrieval_surfaces.surfaces, projected_ids, strict=True):
+                assert ids == expected_ids, f"{surface.name} returned {ids} for {case.name}"
+                assert await surface.query_count(case) == len(expected_ids)
+            ids_by_provider[case.provider] = expected_ids
+
+        assert_provider_partition_exhaustive(all_conversation_ids=all_ids, ids_by_provider=ids_by_provider)
+
+    @pytest.mark.asyncio()
+    async def test_fts_search_is_consistent_across_surfaces(self, retrieval_surfaces: ArchiveSurfaceSet) -> None:
+        for case in _search_cases():
+            expected_ids = tuple(sorted(case.expected_ids))
+            for surface in retrieval_surfaces.surfaces:
+                ids = await surface.query_ids(case)
+                assert ids == expected_ids, f"{surface.name} returned {ids} for {case.name}"
+                assert await surface.query_count(case) == len(expected_ids)
 
 
-# ---------------------------------------------------------------------------
-# Law 1: Provider filter results are strict subsets of unfiltered
-# ---------------------------------------------------------------------------
-
-
-class TestProviderFilterSubset:
-    def test_provider_filter_returns_subset(self: object, populated_db: Path) -> None:
+class TestRetrievalIndexInvariants:
+    def test_fts_index_contains_exactly_text_messages(
+        self,
+        retrieval_archive: tuple[Path, tuple[ArchiveScenario, ...]],
+    ) -> None:
         from polylogue.storage.backends.connection import open_connection
 
-        with open_connection(populated_db) as conn:
-            all_ids = {
-                r["conversation_id"] for r in conn.execute("SELECT conversation_id FROM conversations").fetchall()
+        db_path, _ = retrieval_archive
+        with open_connection(db_path) as conn:
+            expected_text_messages = {
+                str(row["message_id"])
+                for row in conn.execute("SELECT message_id FROM messages WHERE text IS NOT NULL").fetchall()
             }
-            claude_ids = {
-                r["conversation_id"]
-                for r in conn.execute(
-                    "SELECT conversation_id FROM conversations WHERE provider_name = ?",
-                    ("claude-code",),
-                ).fetchall()
+            indexed_messages = {
+                str(row["message_id"]) for row in conn.execute("SELECT message_id FROM messages_fts").fetchall()
             }
 
-            assert claude_ids.issubset(all_ids), "Provider-filtered results must be a subset of all"
-            assert len(claude_ids) == 2
-            assert len(all_ids) == 4
+        assert indexed_messages == expected_text_messages
 
-    def test_all_providers_partition_total(self: object, populated_db: Path) -> None:
-        """Union of all per-provider sets equals the full set."""
+    @pytest.mark.asyncio()
+    async def test_repository_message_counts_match_storage_facts(
+        self,
+        retrieval_archive: tuple[Path, tuple[ArchiveScenario, ...]],
+    ) -> None:
         from polylogue.storage.backends.connection import open_connection
+        from tests.infra.archive_scenarios import repository_for_scenario_db
 
-        with open_connection(populated_db) as conn:
-            all_ids = {
-                r["conversation_id"] for r in conn.execute("SELECT conversation_id FROM conversations").fetchall()
-            }
+        db_path, scenarios = retrieval_archive
+        expected_counts: dict[str, int] = {}
+        with open_connection(db_path) as conn:
+            for scenario in scenarios:
+                facts = scenario.facts_from_connection(conn)
+                expected_counts[facts.conversation_id] = facts.message_count
 
-            providers = [
-                r["provider_name"] for r in conn.execute("SELECT DISTINCT provider_name FROM conversations").fetchall()
-            ]
+        repository = repository_for_scenario_db(db_path)
+        try:
+            observed_counts = await repository.get_message_counts_batch(list(expected_counts))
+        finally:
+            await repository.close()
 
-            union = set()
-            for p in providers:
-                ids = {
-                    r["conversation_id"]
-                    for r in conn.execute(
-                        "SELECT conversation_id FROM conversations WHERE provider_name = ?", (p,)
-                    ).fetchall()
-                }
-                union |= ids
-
-            assert union == all_ids, "Union of provider partitions must equal total"
-
-
-# ---------------------------------------------------------------------------
-# Law 2: FTS index contains exactly the indexable messages
-# ---------------------------------------------------------------------------
-
-
-class TestFTSIndexCompleteness:
-    def test_fts_message_count_matches_messages_table(self: object, populated_db: Path) -> None:
-        from polylogue.storage.backends.connection import open_connection
-
-        with open_connection(populated_db) as conn:
-            msg_count = conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0]
-
-            fts_exists = conn.execute(
-                "SELECT name FROM sqlite_master WHERE type='table' AND name='messages_fts'"
-            ).fetchone()
-            if fts_exists is None:
-                pytest.skip("FTS table not present")
-
-            fts_count = conn.execute("SELECT COUNT(*) FROM messages_fts").fetchone()[0]
-
-            assert fts_count == msg_count, f"FTS row count ({fts_count}) != messages table count ({msg_count})"
-
-    def test_fts_search_returns_subset_of_messages(self: object, populated_db: Path) -> None:
-        from polylogue.storage.backends.connection import open_connection
-
-        with open_connection(populated_db) as conn:
-            fts_exists = conn.execute(
-                "SELECT name FROM sqlite_master WHERE type='table' AND name='messages_fts'"
-            ).fetchone()
-            if fts_exists is None:
-                pytest.skip("FTS table not present")
-
-            all_msg_ids = {r["message_id"] for r in conn.execute("SELECT message_id FROM messages").fetchall()}
-
-            fts_hits = conn.execute("SELECT rowid FROM messages_fts WHERE messages_fts MATCH 'property'").fetchall()
-            fts_msg_ids = set()
-            for hit in fts_hits:
-                row = conn.execute("SELECT message_id FROM messages WHERE rowid = ?", (hit[0],)).fetchone()
-                if row:
-                    fts_msg_ids.add(row["message_id"])
-
-            assert fts_msg_ids.issubset(all_msg_ids), "FTS hits must reference existing messages"
-
-
-# ---------------------------------------------------------------------------
-# Law 3: List count agrees with actual list length
-# ---------------------------------------------------------------------------
-
-
-class TestCountListAgreement:
-    def test_count_matches_list_length(self: object, populated_db: Path) -> None:
-        from polylogue.storage.backends.connection import open_connection
-
-        with open_connection(populated_db) as conn:
-            count = conn.execute("SELECT COUNT(*) FROM conversations").fetchone()[0]
-            rows = conn.execute("SELECT conversation_id FROM conversations").fetchall()
-
-            assert count == len(rows), f"COUNT(*) ({count}) != len(SELECT) ({len(rows)})"
-
-    def test_per_provider_count_matches_filtered_list(self: object, populated_db: Path) -> None:
-        from polylogue.storage.backends.connection import open_connection
-
-        with open_connection(populated_db) as conn:
-            for provider in ("chatgpt", "claude-code", "codex"):
-                count = conn.execute(
-                    "SELECT COUNT(*) FROM conversations WHERE provider_name = ?", (provider,)
-                ).fetchone()[0]
-                rows = conn.execute(
-                    "SELECT conversation_id FROM conversations WHERE provider_name = ?", (provider,)
-                ).fetchall()
-
-                assert count == len(rows), f"Provider {provider}: COUNT={count}, len(rows)={len(rows)}"
-
-
-# ---------------------------------------------------------------------------
-# Law 4: Message stats agree with stored messages
-# ---------------------------------------------------------------------------
-
-
-class TestMessageStatsConsistency:
-    def test_conversation_stats_match_actual_messages(self: object, populated_db: Path) -> None:
-        from polylogue.storage.backends.connection import open_connection
-
-        with open_connection(populated_db) as conn:
-            stats_exists = conn.execute(
-                "SELECT name FROM sqlite_master WHERE type='table' AND name='conversation_stats'"
-            ).fetchone()
-            if stats_exists is None:
-                pytest.skip("conversation_stats table not present")
-
-            for row in conn.execute(
-                "SELECT cs.conversation_id, cs.message_count, "
-                "(SELECT COUNT(*) FROM messages m WHERE m.conversation_id = cs.conversation_id) AS actual_count "
-                "FROM conversation_stats cs"
-            ).fetchall():
-                assert row["message_count"] == row["actual_count"], (
-                    f"Stats message_count ({row['message_count']}) != actual ({row['actual_count']}) "
-                    f"for {row['conversation_id']}"
-                )
+        assert observed_counts == expected_counts

--- a/tests/unit/storage/test_session_product_mapper_fallbacks.py
+++ b/tests/unit/storage/test_session_product_mapper_fallbacks.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json
 import sqlite3
-from typing import cast
 
 import pytest
 
@@ -33,7 +32,8 @@ def _make_row(columns: dict[str, object]) -> sqlite3.Row:
     row = conn.execute("SELECT * FROM t").fetchone()
     conn.close()
     assert row is not None
-    return cast(sqlite3.Row, row)
+    assert isinstance(row, sqlite3.Row)
+    return row
 
 
 def _typed_payload_columns(mode: str, *names: str) -> dict[str, object]:

--- a/tests/unit/storage/test_store_ops.py
+++ b/tests/unit/storage/test_store_ops.py
@@ -11,8 +11,6 @@ import tempfile
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
-from types import SimpleNamespace
-from typing import cast
 from unittest.mock import AsyncMock
 
 import pytest
@@ -197,13 +195,13 @@ def _conversation_model(conversation_id: str) -> Conversation:
 
 
 def _conversation_row(conn: sqlite3.Connection, conversation_id: str) -> sqlite3.Row | None:
-    return cast(
-        sqlite3.Row | None,
-        conn.execute(
-            "SELECT * FROM conversations WHERE conversation_id = ?",
-            (conversation_id,),
-        ).fetchone(),
-    )
+    row = conn.execute(
+        "SELECT * FROM conversations WHERE conversation_id = ?",
+        (conversation_id,),
+    ).fetchone()
+    if row is not None and not isinstance(row, sqlite3.Row):
+        raise TypeError(f"expected sqlite3.Row, got {type(row).__name__}")
+    return row
 
 
 def _message_count(conn: sqlite3.Connection, conversation_id: str) -> int:
@@ -216,13 +214,24 @@ def _message_count(conn: sqlite3.Connection, conversation_id: str) -> int:
 
 
 def _attachment_row(conn: sqlite3.Connection, attachment_id: str) -> sqlite3.Row | None:
-    return cast(
-        sqlite3.Row | None,
-        conn.execute(
-            "SELECT * FROM attachments WHERE attachment_id = ?",
-            (attachment_id,),
-        ).fetchone(),
-    )
+    row = conn.execute(
+        "SELECT * FROM attachments WHERE attachment_id = ?",
+        (attachment_id,),
+    ).fetchone()
+    if row is not None and not isinstance(row, sqlite3.Row):
+        raise TypeError(f"expected sqlite3.Row, got {type(row).__name__}")
+    return row
+
+
+def _message_payloads(value: object) -> list[dict[str, object]]:
+    if not isinstance(value, list):
+        return []
+    payloads: list[dict[str, object]] = []
+    for item in value:
+        if not isinstance(item, dict):
+            raise TypeError(f"expected message payload dict, got {type(item).__name__}")
+        payloads.append(dict(item))
+    return payloads
 
 
 def _record_query(**kwargs: Unpack[RecordQueryKwargs]) -> ConversationRecordQuery:
@@ -1157,7 +1166,7 @@ class TestCrudLaws:
             )
 
             messages: list[MessageRecord] = []
-            message_payloads = cast(list[dict[str, object]], conv_data.get("messages", []))
+            message_payloads = _message_payloads(conv_data.get("messages", []))
             for i, msg_data in enumerate(message_payloads):
                 raw_role = msg_data.get("role", "user")
                 assert isinstance(raw_role, str)
@@ -1745,8 +1754,12 @@ class _VectorSpy:
 
 
 class TestRepositoryVectorAsyncBoundary:
-    async def test_search_similar_offloads_vector_query(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        backend = cast(SQLiteBackend, SimpleNamespace(queries=SimpleNamespace()))
+    async def test_search_similar_offloads_vector_query(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        backend = SQLiteBackend(db_path=tmp_path / "vectors.db")
         repo = ConversationRepository(backend=backend)
         provider = _VectorSpy()
         monkeypatch.setattr(repo, "_get_message_conversation_mapping", AsyncMock(return_value={"msg-1": "conv-1"}))
@@ -1771,12 +1784,12 @@ class TestRepositoryVectorAsyncBoundary:
     async def test_embed_conversation_offloads_vector_upsert(
         self,
         monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
     ) -> None:
         messages = [make_message("msg-embed", "conv-embed", text="Message long enough to embed.")]
-        backend = cast(
-            SQLiteBackend, SimpleNamespace(queries=SimpleNamespace(get_messages=AsyncMock(return_value=messages)))
-        )
+        backend = SQLiteBackend(db_path=tmp_path / "vectors.db")
         repo = ConversationRepository(backend=backend)
+        monkeypatch.setattr(repo.queries, "get_messages", AsyncMock(return_value=messages))
         provider = _VectorSpy()
 
         to_thread_calls: list[tuple[Callable[..., object], tuple[object, ...], dict[str, object]]] = []
@@ -1798,8 +1811,9 @@ class TestRepositoryVectorAsyncBoundary:
     async def test_similarity_search_offloads_vector_query(
         self,
         monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
     ) -> None:
-        backend = cast(SQLiteBackend, SimpleNamespace(queries=SimpleNamespace()))
+        backend = SQLiteBackend(db_path=tmp_path / "vectors.db")
         repo = ConversationRepository(backend=backend)
         provider = _VectorSpy()
         monkeypatch.setattr(repo, "_get_message_conversation_mapping", AsyncMock(return_value={"msg-1": "conv-1"}))

--- a/tests/unit/storage/test_vec.py
+++ b/tests/unit/storage/test_vec.py
@@ -6,7 +6,7 @@ import sqlite3
 import struct
 from collections.abc import Callable
 from pathlib import Path
-from typing import Protocol, TypeAlias, cast
+from typing import Protocol, TypeAlias
 from unittest.mock import MagicMock, patch
 
 import httpx
@@ -18,34 +18,17 @@ from polylogue.storage.store import MessageRecord
 from polylogue.types import ContentHash, ConversationId, MessageId
 
 Embedding: TypeAlias = list[float]
-SearchRows: TypeAlias = list[tuple[str, float]]
 
 
 class EmbeddingFetcher(Protocol):
     def __call__(self, texts: list[str], input_type: str = "document") -> list[Embedding]: ...
 
 
-class MutableSqliteVecProvider(Protocol):
-    db_path: Path
-    voyage_key: str
-    model: str
-    dimension: int
-    _vec_available: bool | None
-    _tables_ensured: bool
+class MutableSqliteVecProvider(SqliteVecProvider):
     _ensure_vec_available: Callable[[], None]
     _ensure_tables: Callable[[], None]
     _get_embeddings: EmbeddingFetcher
     _get_connection: Callable[[], sqlite3.Connection]
-
-    def _should_embed_message(self, msg: MessageRecord) -> bool: ...
-
-    def upsert(self, conversation_id: str, messages: list[MessageRecord]) -> None: ...
-
-    def query(self, text: str, limit: int = 10) -> SearchRows: ...
-
-    def query_by_provider(self, text: str, provider: str, limit: int = 10) -> SearchRows: ...
-
-    def get_embedding_stats(self) -> dict[str, int]: ...
 
 
 def make_message(
@@ -68,20 +51,12 @@ def make_message(
 
 
 @pytest.fixture
-def provider_cls() -> type[SqliteVecProvider]:
-    return SqliteVecProvider
-
-
-@pytest.fixture
-def mock_provider(tmp_path: Path, provider_cls: type[SqliteVecProvider]) -> MutableSqliteVecProvider:
-    provider = object.__new__(provider_cls)
-    provider.db_path = tmp_path / "test.db"
-    provider.voyage_key = "test-voyage-key"
-    provider.model = "voyage-4"
+def mock_provider(tmp_path: Path) -> MutableSqliteVecProvider:
+    provider = MutableSqliteVecProvider(voyage_key="test-voyage-key", db_path=tmp_path / "test.db", model="voyage-4")
     provider.dimension = 1024
     provider._vec_available = None
     provider._tables_ensured = True
-    return cast(MutableSqliteVecProvider, provider)
+    return provider
 
 
 def test_get_embeddings_request_contract(mock_provider: MutableSqliteVecProvider) -> None:

--- a/tests/unit/test_cross_surface_agreement.py
+++ b/tests/unit/test_cross_surface_agreement.py
@@ -12,28 +12,52 @@ from pathlib import Path
 
 import pytest
 
+from tests.infra.archive_scenarios import (
+    ArchiveScenario,
+    ScenarioMessage,
+    repository_for_scenario_db,
+    seed_workspace_scenarios,
+)
+from tests.infra.oracles import (
+    assert_archive_surfaces_agree,
+    assert_conversation_surfaces_agree,
+    assert_provider_partition_exhaustive,
+)
 from tests.infra.semantic_facts import ArchiveFacts, ConversationFacts
-from tests.infra.storage_records import ConversationBuilder, db_setup
 
 
 @pytest.fixture()
-def multi_provider_db(workspace_env: Mapping[str, Path]) -> Path:
+def multi_provider_archive(workspace_env: Mapping[str, Path]) -> tuple[Path, list[ArchiveScenario]]:
     """Populate a DB with conversations across providers."""
-    db_path = db_setup(workspace_env)
-
-    ConversationBuilder(db_path, "chatgpt-xsurf-1").provider("chatgpt").title("GPT chat").add_message(
-        role="user", text="Hello GPT"
-    ).add_message(role="assistant", text="Hello user").save()
-
-    ConversationBuilder(db_path, "claude-xsurf-1").provider("claude-code").title("Claude session").add_message(
-        role="user", text="Refactor this"
-    ).add_message(role="assistant", text="Done").add_message(role="user", text="Thanks").save()
-
-    ConversationBuilder(db_path, "codex-xsurf-1").provider("codex").title("Codex work").add_message(
-        role="user", text="Generate code"
-    ).save()
-
-    return db_path
+    scenarios = [
+        ArchiveScenario(
+            name="chatgpt-xsurf-1",
+            provider="chatgpt",
+            title="GPT chat",
+            messages=(
+                ScenarioMessage(role="user", text="Hello GPT", message_id="gpt-u1"),
+                ScenarioMessage(role="assistant", text="Hello user", message_id="gpt-a1"),
+            ),
+        ),
+        ArchiveScenario(
+            name="claude-xsurf-1",
+            provider="claude-code",
+            title="Claude session",
+            messages=(
+                ScenarioMessage(role="user", text="Refactor this", message_id="claude-u1"),
+                ScenarioMessage(role="assistant", text="Done", message_id="claude-a1"),
+                ScenarioMessage(role="user", text="Thanks", message_id="claude-u2"),
+            ),
+        ),
+        ArchiveScenario(
+            name="codex-xsurf-1",
+            provider="codex",
+            title="Codex work",
+            messages=(ScenarioMessage(role="user", text="Generate code", message_id="codex-u1"),),
+        ),
+    ]
+    db_path, _ = seed_workspace_scenarios(workspace_env, scenarios)
+    return db_path, scenarios
 
 
 # ---------------------------------------------------------------------------
@@ -42,34 +66,37 @@ def multi_provider_db(workspace_env: Mapping[str, Path]) -> Path:
 
 
 class TestRecordVsHydrationAgreement:
-    def test_facts_agree_for_each_conversation(self, multi_provider_db: Path) -> None:
+    def test_facts_agree_for_each_conversation(
+        self, multi_provider_archive: tuple[Path, list[ArchiveScenario]]
+    ) -> None:
         from polylogue.storage.backends.connection import open_connection
-        from polylogue.storage.backends.queries.mappers_archive import (
-            _row_to_conversation,
-            _row_to_message,
-        )
-        from polylogue.storage.hydrators import conversation_from_records
 
-        with open_connection(multi_provider_db) as conn:
-            for conv_row in conn.execute("SELECT * FROM conversations").fetchall():
-                conv_record = _row_to_conversation(conv_row)
-                cid = conv_record.conversation_id
+        db_path, scenarios = multi_provider_archive
+        with open_connection(db_path) as conn:
+            for scenario in scenarios:
+                assert_conversation_surfaces_agree(
+                    scenario.facts_from_connection(conn),
+                    scenario.hydrated_facts_from_connection(conn),
+                )
 
-                msg_rows = conn.execute(
-                    "SELECT * FROM messages WHERE conversation_id = ? ORDER BY sort_key", (cid,)
-                ).fetchall()
-                msg_records = [_row_to_message(r) for r in msg_rows]
+    @pytest.mark.asyncio()
+    async def test_repository_facts_agree_with_storage(
+        self,
+        multi_provider_archive: tuple[Path, list[ArchiveScenario]],
+    ) -> None:
+        from polylogue.storage.backends.connection import open_connection
 
-                record_facts = ConversationFacts.from_records(conv_record, msg_records)
-
-                hydrated = conversation_from_records(conv_record, msg_records, [])
-                hydrated_facts = ConversationFacts.from_domain_conversation(hydrated)
-
-                assert record_facts.conversation_id == hydrated_facts.conversation_id
-                assert record_facts.provider == hydrated_facts.provider
-                assert record_facts.title == hydrated_facts.title
-                assert record_facts.message_count == hydrated_facts.message_count
-                assert record_facts.role_multiset == hydrated_facts.role_multiset
+        db_path, scenarios = multi_provider_archive
+        repository = repository_for_scenario_db(db_path)
+        try:
+            with open_connection(db_path) as conn:
+                for scenario in scenarios:
+                    assert_conversation_surfaces_agree(
+                        scenario.facts_from_connection(conn),
+                        await scenario.facts_from_repository(repository),
+                    )
+        finally:
+            await repository.close()
 
 
 # ---------------------------------------------------------------------------
@@ -78,40 +105,51 @@ class TestRecordVsHydrationAgreement:
 
 
 class TestArchiveFactsConsistency:
-    def test_archive_facts_internally_consistent(self, multi_provider_db: Path) -> None:
+    @pytest.mark.asyncio()
+    async def test_archive_facts_internally_consistent(
+        self,
+        multi_provider_archive: tuple[Path, list[ArchiveScenario]],
+    ) -> None:
         from polylogue.storage.backends.connection import open_connection
 
-        with open_connection(multi_provider_db) as conn:
-            facts = ArchiveFacts.from_db_connection(conn)
+        db_path, _ = multi_provider_archive
+        repository = repository_for_scenario_db(db_path)
+        try:
+            with open_connection(db_path) as conn:
+                db_facts = ArchiveFacts.from_db_connection(conn)
+            repository_facts = ArchiveFacts.from_conversations(await repository.list(limit=None))
+        finally:
+            await repository.close()
 
-            assert facts.total_conversations == 3
-            assert sum(facts.provider_counts.values()) == facts.total_conversations
-            assert facts.total_messages > 0
-            assert facts.provider_counts.get("chatgpt") == 1
-            assert facts.provider_counts.get("claude-code") == 1
-            assert facts.provider_counts.get("codex") == 1
+        assert_archive_surfaces_agree(db_facts, repository_facts)
+        assert db_facts.total_conversations == 3
+        assert sum(db_facts.provider_counts.values()) == db_facts.total_conversations
+        assert db_facts.total_messages > 0
+        assert db_facts.provider_counts.get("chatgpt") == 1
+        assert db_facts.provider_counts.get("claude-code") == 1
+        assert db_facts.provider_counts.get("codex") == 1
 
-    def test_provider_partition_exhaustive(self, multi_provider_db: Path) -> None:
+    def test_provider_partition_exhaustive(self, multi_provider_archive: tuple[Path, list[ArchiveScenario]]) -> None:
         """Every conversation belongs to exactly one provider in the facts."""
         from polylogue.storage.backends.connection import open_connection
 
-        with open_connection(multi_provider_db) as conn:
+        db_path, _ = multi_provider_archive
+        with open_connection(db_path) as conn:
             facts = ArchiveFacts.from_db_connection(conn)
 
             all_ids = {
                 r["conversation_id"] for r in conn.execute("SELECT conversation_id FROM conversations").fetchall()
             }
-            per_provider_ids = set()
+            ids_by_provider: dict[str, set[str]] = {}
             for provider in facts.provider_counts:
-                ids = {
+                ids_by_provider[provider] = {
                     r["conversation_id"]
                     for r in conn.execute(
                         "SELECT conversation_id FROM conversations WHERE provider_name = ?", (provider,)
                     ).fetchall()
                 }
-                per_provider_ids |= ids
 
-            assert per_provider_ids == all_ids
+            assert_provider_partition_exhaustive(all_conversation_ids=all_ids, ids_by_provider=ids_by_provider)
 
 
 # ---------------------------------------------------------------------------
@@ -126,57 +164,26 @@ class TestSyntheticRoundtripFactAgreement:
         provider_name: str,
         workspace_env: Mapping[str, Path],
     ) -> None:
-        import json
-
-        from polylogue.pipeline.prepare_transform import transform_to_records
         from polylogue.schemas.synthetic.core import SyntheticCorpus
-        from polylogue.sources.dispatch import detect_provider, parse_payload
         from polylogue.storage.backends.connection import open_connection
-        from polylogue.storage.backends.queries.mappers_archive import (
-            _row_to_conversation,
-            _row_to_message,
-        )
-        from polylogue.storage.hydrators import conversation_from_records
-        from tests.infra.storage_records import db_setup, store_records
+        from tests.infra.pipeline_roundtrip import parse_and_transform_payload, save_transform_and_hydrate
+        from tests.infra.storage_records import db_setup
 
         corpus = SyntheticCorpus.for_provider(provider_name)
         raw_bytes = corpus.generate(count=1, seed=99)[0]
 
-        text = raw_bytes.decode("utf-8")
-        try:
-            payload = json.loads(text)
-        except json.JSONDecodeError:
-            payload = [json.loads(line) for line in text.strip().splitlines() if line.strip()]
-
-        detected = detect_provider(payload)
-        assert detected is not None
-        parsed_list = parse_payload(detected, payload, f"xsurf-{provider_name}")
-        parsed = parsed_list[0]
-
-        archive_root = workspace_env["archive_root"]
-        result = transform_to_records(parsed, f"test-{provider_name}", archive_root=archive_root)
+        roundtrip = parse_and_transform_payload(
+            provider_name,
+            raw_bytes,
+            workspace_env["archive_root"],
+            f"xsurf-{provider_name}",
+        )
 
         db_path = db_setup(workspace_env)
         with open_connection(db_path) as conn:
-            bundle = result.bundle
-            store_records(
-                conversation=bundle.conversation,
-                messages=bundle.messages,
-                attachments=bundle.attachments,
-                conn=conn,
-            )
-
-            cid = bundle.conversation.conversation_id
-            conv_row = conn.execute("SELECT * FROM conversations WHERE conversation_id = ?", (cid,)).fetchone()
-            conv_record = _row_to_conversation(conv_row)
-            msg_rows = conn.execute(
-                "SELECT * FROM messages WHERE conversation_id = ? ORDER BY sort_key", (cid,)
-            ).fetchall()
-            msg_records = [_row_to_message(r) for r in msg_rows]
-
-            hydrated = conversation_from_records(conv_record, msg_records, [])
+            hydrated = save_transform_and_hydrate(roundtrip.transform, conn)
             hydrated_facts = ConversationFacts.from_domain_conversation(hydrated)
 
-            assert hydrated_facts.message_count == len(parsed.messages)
-            assert hydrated_facts.provider == str(parsed.provider_name)
-            assert hydrated_facts.title == parsed.title
+            assert hydrated_facts.message_count == len(roundtrip.parsed.messages)
+            assert hydrated_facts.provider == str(roundtrip.parsed.provider_name)
+            assert hydrated_facts.title == roundtrip.parsed.title

--- a/tests/unit/test_cross_surface_agreement.py
+++ b/tests/unit/test_cross_surface_agreement.py
@@ -7,7 +7,7 @@ disagree about what's in the archive.
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import AsyncIterator, Mapping
 from pathlib import Path
 
 import pytest
@@ -15,7 +15,6 @@ import pytest
 from tests.infra.archive_scenarios import (
     ArchiveScenario,
     ScenarioMessage,
-    repository_for_scenario_db,
     seed_workspace_scenarios,
 )
 from tests.infra.oracles import (
@@ -23,13 +22,15 @@ from tests.infra.oracles import (
     assert_conversation_surfaces_agree,
     assert_provider_partition_exhaustive,
 )
-from tests.infra.semantic_facts import ArchiveFacts, ConversationFacts
+from tests.infra.query_cases import ArchiveQueryCase
+from tests.infra.semantic_facts import ConversationFacts
+from tests.infra.surfaces import ArchiveSurfaceSet, build_archive_surface_set
 
 
 @pytest.fixture()
-def multi_provider_archive(workspace_env: Mapping[str, Path]) -> tuple[Path, list[ArchiveScenario]]:
+def multi_provider_archive(workspace_env: Mapping[str, Path]) -> tuple[Path, tuple[ArchiveScenario, ...]]:
     """Populate a DB with conversations across providers."""
-    scenarios = [
+    scenarios = (
         ArchiveScenario(
             name="chatgpt-xsurf-1",
             provider="chatgpt",
@@ -55,9 +56,26 @@ def multi_provider_archive(workspace_env: Mapping[str, Path]) -> tuple[Path, lis
             title="Codex work",
             messages=(ScenarioMessage(role="user", text="Generate code", message_id="codex-u1"),),
         ),
-    ]
+    )
     db_path, _ = seed_workspace_scenarios(workspace_env, scenarios)
     return db_path, scenarios
+
+
+@pytest.fixture()
+async def multi_provider_surfaces(
+    workspace_env: Mapping[str, Path],
+    multi_provider_archive: tuple[Path, tuple[ArchiveScenario, ...]],
+) -> AsyncIterator[ArchiveSurfaceSet]:
+    db_path, scenarios = multi_provider_archive
+    surfaces = build_archive_surface_set(
+        db_path=db_path,
+        archive_root=workspace_env["archive_root"],
+        scenarios=scenarios,
+    )
+    try:
+        yield surfaces
+    finally:
+        await surfaces.close()
 
 
 # ---------------------------------------------------------------------------
@@ -66,37 +84,16 @@ def multi_provider_archive(workspace_env: Mapping[str, Path]) -> tuple[Path, lis
 
 
 class TestRecordVsHydrationAgreement:
-    def test_facts_agree_for_each_conversation(
-        self, multi_provider_archive: tuple[Path, list[ArchiveScenario]]
-    ) -> None:
-        from polylogue.storage.backends.connection import open_connection
-
-        db_path, scenarios = multi_provider_archive
-        with open_connection(db_path) as conn:
-            for scenario in scenarios:
-                assert_conversation_surfaces_agree(
-                    scenario.facts_from_connection(conn),
-                    scenario.hydrated_facts_from_connection(conn),
-                )
-
     @pytest.mark.asyncio()
-    async def test_repository_facts_agree_with_storage(
+    async def test_facts_agree_for_each_conversation_across_surfaces(
         self,
-        multi_provider_archive: tuple[Path, list[ArchiveScenario]],
+        multi_provider_archive: tuple[Path, tuple[ArchiveScenario, ...]],
+        multi_provider_surfaces: ArchiveSurfaceSet,
     ) -> None:
-        from polylogue.storage.backends.connection import open_connection
-
-        db_path, scenarios = multi_provider_archive
-        repository = repository_for_scenario_db(db_path)
-        try:
-            with open_connection(db_path) as conn:
-                for scenario in scenarios:
-                    assert_conversation_surfaces_agree(
-                        scenario.facts_from_connection(conn),
-                        await scenario.facts_from_repository(repository),
-                    )
-        finally:
-            await repository.close()
+        _, scenarios = multi_provider_archive
+        for scenario in scenarios:
+            facts = [await surface.conversation_facts(scenario) for surface in multi_provider_surfaces.surfaces]
+            assert_conversation_surfaces_agree(*facts)
 
 
 # ---------------------------------------------------------------------------
@@ -106,22 +103,13 @@ class TestRecordVsHydrationAgreement:
 
 class TestArchiveFactsConsistency:
     @pytest.mark.asyncio()
-    async def test_archive_facts_internally_consistent(
+    async def test_archive_facts_internally_consistent_across_surfaces(
         self,
-        multi_provider_archive: tuple[Path, list[ArchiveScenario]],
+        multi_provider_surfaces: ArchiveSurfaceSet,
     ) -> None:
-        from polylogue.storage.backends.connection import open_connection
-
-        db_path, _ = multi_provider_archive
-        repository = repository_for_scenario_db(db_path)
-        try:
-            with open_connection(db_path) as conn:
-                db_facts = ArchiveFacts.from_db_connection(conn)
-            repository_facts = ArchiveFacts.from_conversations(await repository.list(limit=None))
-        finally:
-            await repository.close()
-
-        assert_archive_surfaces_agree(db_facts, repository_facts)
+        facts = [await surface.archive_facts() for surface in multi_provider_surfaces.surfaces]
+        assert_archive_surfaces_agree(*facts)
+        db_facts = facts[0]
         assert db_facts.total_conversations == 3
         assert sum(db_facts.provider_counts.values()) == db_facts.total_conversations
         assert db_facts.total_messages > 0
@@ -129,27 +117,23 @@ class TestArchiveFactsConsistency:
         assert db_facts.provider_counts.get("claude-code") == 1
         assert db_facts.provider_counts.get("codex") == 1
 
-    def test_provider_partition_exhaustive(self, multi_provider_archive: tuple[Path, list[ArchiveScenario]]) -> None:
+    @pytest.mark.asyncio()
+    async def test_provider_partition_exhaustive(
+        self,
+        multi_provider_surfaces: ArchiveSurfaceSet,
+    ) -> None:
         """Every conversation belongs to exactly one provider in the facts."""
-        from polylogue.storage.backends.connection import open_connection
+        facts = await multi_provider_surfaces.surfaces[0].archive_facts()
+        all_ids = set(facts.conversation_ids)
+        ids_by_provider: dict[str, tuple[str, ...]] = {}
+        for provider in facts.provider_counts:
+            query_case = ArchiveQueryCase(name=f"provider-{provider}", provider=provider, expected_ids=())
+            provider_ids = [await surface.query_ids(query_case) for surface in multi_provider_surfaces.surfaces]
+            first = provider_ids[0]
+            assert all(ids == first for ids in provider_ids), provider_ids
+            ids_by_provider[provider] = first
 
-        db_path, _ = multi_provider_archive
-        with open_connection(db_path) as conn:
-            facts = ArchiveFacts.from_db_connection(conn)
-
-            all_ids = {
-                r["conversation_id"] for r in conn.execute("SELECT conversation_id FROM conversations").fetchall()
-            }
-            ids_by_provider: dict[str, set[str]] = {}
-            for provider in facts.provider_counts:
-                ids_by_provider[provider] = {
-                    r["conversation_id"]
-                    for r in conn.execute(
-                        "SELECT conversation_id FROM conversations WHERE provider_name = ?", (provider,)
-                    ).fetchall()
-                }
-
-            assert_provider_partition_exhaustive(all_conversation_ids=all_ids, ids_by_provider=ids_by_provider)
+        assert_provider_partition_exhaustive(all_conversation_ids=all_ids, ids_by_provider=ids_by_provider)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/ui/test_tui.py
+++ b/tests/unit/ui/test_tui.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import TYPE_CHECKING, TypeAlias, cast
+from typing import TYPE_CHECKING, TypeAlias
 from unittest.mock import MagicMock
 
 import pytest
@@ -425,10 +425,11 @@ async def test_worker_failure_recovery(
 ) -> None:
     """Inject error in repo → assert app stays usable with error notification."""
     # Create a repo that raises on get_archive_stats
-    broken_repo = MagicMock()
+    broken_repo = MagicMock(spec=ConversationArchiveReadStore)
     broken_repo.get_archive_stats.side_effect = RuntimeError("DB exploded")
 
-    app = PolylogueApp(repository=cast(ConversationArchiveReadStore, broken_repo))
+    assert isinstance(broken_repo, ConversationArchiveReadStore)
+    app = PolylogueApp(repository=broken_repo)
     async with app.run_test() as pilot:
         await _wait_workers(pilot)
 


### PR DESCRIPTION
## Summary
- Tighten remaining JSON/type-boundary seams and remove broad mock/source casts.
- Add archive scenario, semantic fact, surface adapter, query-case, and lifecycle harness infrastructure.
- Port retrieval and cross-surface laws onto shared semantic oracles.
- Fix repository, logging, Drive acquisition, and Drive service test-double safety issues found while expanding verification.

## Problem
The mypy cleanup wave reduced suppression debt, but verification remained too path-dependent: several storage/query laws built bespoke fixture setup and direct SQL assertions instead of reusable scenario projections. Full-suite verification also exposed a subprocess CLI startup crash caused by treating structlog lazy proxies as invalid loggers, a runtime-only Drive acquisition protocol import gap, and Python 3.13 test failures from using `MagicMock` where a runtime-checkable Drive service protocol was required.

Repository writes also had a lossy edge where hydrated domain conversations could be re-saved without message records, risking runtime-state replacement with an empty graph.

Ref #274

## Solution
Introduce reusable archive-verification fixtures under `tests/infra`: declarative scenarios, semantic facts/oracles, surface adapters, query cases, pipeline roundtrip helpers, and repository lifecycle state harnesses. Rework retrieval readiness, cross-surface agreement, pipeline roundtrip, and repository lifecycle tests to compare semantic facts across direct SQL records, hydrated records, repository, and public facade surfaces.

Harden `RepositoryWriteMixin.save_conversation()` to reject lossy domain-conversation saves. Simplify `get_logger()` so structlog lazy loggers work at CLI startup. Import the Drive UI protocol at runtime where it is used for a runtime-checkable `isinstance` guard. Replace Drive gateway cache lifecycle `MagicMock` service doubles with `MockDriveService` objects that satisfy the service protocol on Python 3.13.

## Verification
- `uv run devtools verify --quick`
- `uv run pytest -q tests/unit/pipeline/test_parsing_service.py`
- `UV_PYTHON=3.13 uv run pytest -q tests/unit/sources/test_drive_gateway.py`
- `uv run ruff check tests/unit/sources/test_drive_gateway.py && uv run mypy tests/unit/sources/test_drive_gateway.py`
