### PR TITLE
test: capture probe regressions and growth budgets

### DIFF
--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -152,6 +152,11 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
         "verification",
         "Run typed pipeline probes against synthetic, staged, or archive-subset inputs.",
         "devtools.pipeline_probe",
+        use_when="Exercise real pipeline stages and optionally capture emitted summaries as regression cases.",
+        examples=(
+            "devtools pipeline-probe --provider chatgpt --stage parse",
+            "devtools pipeline-probe --input-mode archive-subset --capture-regression live-parse-drift",
+        ),
     ),
     CommandSpec(
         "query-memory-budget",

--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -162,6 +162,17 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
         examples=("devtools query-memory-budget --max-rss-mb 1536 -- polylogue --plain stats",),
     ),
     CommandSpec(
+        "regression-capture",
+        "verification",
+        "Capture pipeline-probe summaries as durable local regression cases.",
+        "devtools.regression_capture",
+        use_when="Turn a live or probe failure JSON summary into a replayable local regression artifact.",
+        examples=(
+            "devtools regression-capture --input probe.json --name parse-drift",
+            "devtools pipeline-probe --json | devtools regression-capture --name parse-drift --tag live",
+        ),
+    ),
+    CommandSpec(
         "inject-semantic-annotations",
         "maintenance",
         "Annotate baseline provider schemas with semantic-role metadata.",

--- a/devtools/pipeline_probe.py
+++ b/devtools/pipeline_probe.py
@@ -20,6 +20,7 @@ from typing import NotRequired, Protocol
 
 from typing_extensions import TypedDict
 
+from devtools.regression_cases import DEFAULT_REGRESSION_CASE_DIR, RegressionCase, RegressionCaseStore
 from polylogue.config import Config, Source
 from polylogue.lib.json import JSONDocument, JSONValue, is_json_document, json_document, loads, require_json_document
 from polylogue.paths import blob_store_root, db_path
@@ -149,6 +150,13 @@ class BudgetReport(TypedDict):
     violations: list[str]
 
 
+class RegressionCaseSummary(TypedDict):
+    case_id: str
+    name: str
+    path: str
+    tags: list[str]
+
+
 class ProbeSummary(TypedDict):
     probe: JSONDocument
     paths: JSONDocument
@@ -161,6 +169,7 @@ class ProbeSummary(TypedDict):
     source_inputs: NotRequired[SourceInputsSummary]
     sample: NotRequired[ArchiveSubsetSampleSummary]
     budgets: NotRequired[BudgetReport]
+    regression_case: NotRequired[RegressionCaseSummary]
 
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -313,6 +322,32 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--json-out",
         type=Path,
         help="Optional path for the JSON summary.",
+    )
+    parser.add_argument(
+        "--capture-regression",
+        metavar="NAME",
+        help=(
+            "Capture the emitted probe summary as a durable regression case under "
+            ".local/regression-cases or --regression-output-dir."
+        ),
+    )
+    parser.add_argument(
+        "--regression-output-dir",
+        type=Path,
+        default=DEFAULT_REGRESSION_CASE_DIR,
+        help=f"Output directory for --capture-regression (default: {DEFAULT_REGRESSION_CASE_DIR}).",
+    )
+    parser.add_argument(
+        "--regression-tag",
+        action="append",
+        default=[],
+        help="Tag to attach to the captured regression case. Repeatable.",
+    )
+    parser.add_argument(
+        "--regression-note",
+        action="append",
+        default=[],
+        help="Note to attach to the captured regression case. Repeatable.",
     )
     parser.add_argument(
         "--max-total-ms",
@@ -1378,8 +1413,33 @@ def _build_budget_report(summary: ProbeSummary, request: PipelineProbeRequest) -
     }
 
 
+def _capture_regression_case(summary: ProbeSummary, args: argparse.Namespace) -> RegressionCaseSummary | None:
+    name = getattr(args, "capture_regression", None)
+    if not isinstance(name, str) or not name.strip():
+        return None
+    output_dir = getattr(args, "regression_output_dir", DEFAULT_REGRESSION_CASE_DIR)
+    if not isinstance(output_dir, Path):
+        output_dir = Path(str(output_dir))
+    tags = tuple(str(tag) for tag in getattr(args, "regression_tag", []) or [])
+    notes = tuple(str(note) for note in getattr(args, "regression_note", []) or [])
+    case = RegressionCase.from_probe_summary(
+        name=name,
+        summary=json_document(summary),
+        tags=tags,
+        notes=notes,
+    )
+    path = RegressionCaseStore(output_dir).write(case)
+    return {
+        "case_id": case.case_id,
+        "name": case.name,
+        "path": str(path),
+        "tags": list(case.tags),
+    }
+
+
 def main(argv: list[str] | None = None) -> int:
-    request = _request_from_args(_parse_args(argv))
+    args = _parse_args(argv)
+    request = _request_from_args(args)
     active_request = request
     if request.workdir is None:
         with tempfile.TemporaryDirectory(prefix="polylogue-pipeline-probe-") as tempdir:
@@ -1392,6 +1452,9 @@ def main(argv: list[str] | None = None) -> int:
     budget_report = _build_budget_report(summary, active_request)
     if budget_report is not None:
         summary["budgets"] = budget_report
+    regression_case = _capture_regression_case(summary, args)
+    if regression_case is not None:
+        summary["regression_case"] = regression_case
     encoded = json.dumps(summary, indent=2, sort_keys=True)
     if active_request.json_out is not None:
         json_out = Path(active_request.json_out)

--- a/devtools/regression_capture.py
+++ b/devtools/regression_capture.py
@@ -8,13 +8,12 @@ import sys
 from pathlib import Path
 
 from devtools.regression_cases import (
+    DEFAULT_REGRESSION_CASE_DIR,
     RegressionCase,
     RegressionCaseStore,
     json_input_document,
     regression_case_path_payload,
 )
-
-DEFAULT_OUTPUT_DIR = Path(".local/regression-cases")
 
 
 def _read_input(input_path: Path | None) -> str:
@@ -38,8 +37,8 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--output-dir",
         type=Path,
-        default=DEFAULT_OUTPUT_DIR,
-        help=f"Output directory for captured cases (default: {DEFAULT_OUTPUT_DIR}).",
+        default=DEFAULT_REGRESSION_CASE_DIR,
+        help=f"Output directory for captured cases (default: {DEFAULT_REGRESSION_CASE_DIR}).",
     )
     parser.add_argument("--tag", action="append", default=[], help="Tag to attach to the captured case. Repeatable.")
     parser.add_argument("--note", action="append", default=[], help="Note to attach to the captured case. Repeatable.")

--- a/devtools/regression_capture.py
+++ b/devtools/regression_capture.py
@@ -1,0 +1,66 @@
+"""Capture pipeline-probe summaries as durable local regression cases."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from devtools.regression_cases import (
+    RegressionCase,
+    RegressionCaseStore,
+    json_input_document,
+    regression_case_path_payload,
+)
+
+DEFAULT_OUTPUT_DIR = Path(".local/regression-cases")
+
+
+def _read_input(input_path: Path | None) -> str:
+    if input_path is None or str(input_path) == "-":
+        return sys.stdin.read()
+    return input_path.read_text(encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Capture a devtools pipeline-probe JSON summary as a durable regression case.",
+    )
+    parser.add_argument(
+        "--input",
+        "-i",
+        type=Path,
+        default=None,
+        help="Pipeline-probe JSON summary path. Reads stdin when omitted or set to '-'.",
+    )
+    parser.add_argument("--name", required=True, help="Human-readable regression case name.")
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=DEFAULT_OUTPUT_DIR,
+        help=f"Output directory for captured cases (default: {DEFAULT_OUTPUT_DIR}).",
+    )
+    parser.add_argument("--tag", action="append", default=[], help="Tag to attach to the captured case. Repeatable.")
+    parser.add_argument("--note", action="append", default=[], help="Note to attach to the captured case. Repeatable.")
+    parser.add_argument("--json", action="store_true", help="Emit the captured case payload as JSON.")
+    args = parser.parse_args(argv)
+
+    summary = json_input_document(_read_input(args.input))
+    case = RegressionCase.from_probe_summary(
+        name=args.name,
+        summary=summary,
+        tags=tuple(args.tag),
+        notes=tuple(args.note),
+    )
+    output_path = RegressionCaseStore(args.output_dir).write(case)
+
+    if args.json:
+        print(json.dumps(regression_case_path_payload(case, output_path), indent=2, sort_keys=True))
+        return 0
+    print(output_path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/devtools/regression_cases.py
+++ b/devtools/regression_cases.py
@@ -1,0 +1,191 @@
+"""Durable regression-case records for verification probe failures."""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from hashlib import sha256
+from pathlib import Path
+
+from polylogue.lib.json import JSONDocument, loads, require_json_document
+
+SCHEMA_VERSION = 1
+DEFAULT_CAPTURE_KEYS: tuple[str, ...] = (
+    "probe",
+    "paths",
+    "provenance",
+    "result",
+    "run_payload",
+    "db_stats",
+    "raw_fanout",
+    "source_files",
+    "source_inputs",
+    "sample",
+    "budgets",
+)
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).isoformat(timespec="seconds")
+
+
+def _slug(value: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+    return slug[:80] or "regression"
+
+
+def _stable_digest(payload: JSONDocument) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    return sha256(encoded).hexdigest()[:12]
+
+
+def _string_tuple(values: Iterable[str]) -> tuple[str, ...]:
+    return tuple(value for value in values if value)
+
+
+def _selected_summary(summary: JSONDocument, capture_keys: tuple[str, ...]) -> JSONDocument:
+    selected: JSONDocument = {}
+    for key in capture_keys:
+        if key in summary:
+            selected[key] = summary[key]
+    if not selected:
+        raise ValueError("regression case summary did not contain any recognized capture keys")
+    return selected
+
+
+@dataclass(frozen=True, slots=True)
+class RegressionCase:
+    """A minimized, replayable record derived from a failed verification probe."""
+
+    case_id: str
+    name: str
+    source: str
+    created_at: str
+    summary: JSONDocument
+    provenance: JSONDocument = field(default_factory=dict)
+    tags: tuple[str, ...] = ()
+    notes: tuple[str, ...] = ()
+    schema_version: int = SCHEMA_VERSION
+
+    @classmethod
+    def from_probe_summary(
+        cls,
+        *,
+        name: str,
+        summary: JSONDocument,
+        tags: Iterable[str] = (),
+        notes: Iterable[str] = (),
+        created_at: str | None = None,
+        capture_keys: tuple[str, ...] = DEFAULT_CAPTURE_KEYS,
+    ) -> RegressionCase:
+        """Create a regression case from a ``devtools pipeline-probe`` summary."""
+        if "probe" not in summary or "result" not in summary:
+            raise ValueError("pipeline probe regression cases require `probe` and `result` summary keys")
+        selected = _selected_summary(summary, capture_keys)
+        provenance = require_json_document(summary.get("provenance", {}), context="probe provenance")
+        case_id = f"{_slug(name)}-{_stable_digest(selected)}"
+        return cls(
+            case_id=case_id,
+            name=name,
+            source="pipeline-probe",
+            created_at=created_at or _utc_now(),
+            summary=selected,
+            provenance=provenance,
+            tags=_string_tuple(tags),
+            notes=_string_tuple(notes),
+        )
+
+    @classmethod
+    def from_payload(cls, payload: JSONDocument) -> RegressionCase:
+        """Hydrate a stored regression case payload."""
+        raw_schema_version = payload.get("schema_version")
+        schema_version = raw_schema_version if isinstance(raw_schema_version, int) else 0
+        if schema_version != SCHEMA_VERSION:
+            raise ValueError(f"unsupported regression case schema_version: {schema_version}")
+        tags_raw = payload.get("tags", [])
+        notes_raw = payload.get("notes", [])
+        tags = tuple(str(value) for value in tags_raw) if isinstance(tags_raw, list) else ()
+        notes = tuple(str(value) for value in notes_raw) if isinstance(notes_raw, list) else ()
+        return cls(
+            case_id=str(payload["case_id"]),
+            name=str(payload["name"]),
+            source=str(payload["source"]),
+            created_at=str(payload["created_at"]),
+            summary=require_json_document(payload["summary"], context="regression case summary"),
+            provenance=require_json_document(payload.get("provenance", {}), context="regression case provenance"),
+            tags=tags,
+            notes=notes,
+            schema_version=schema_version,
+        )
+
+    @classmethod
+    def read(cls, path: Path) -> RegressionCase:
+        """Read a regression case JSON file."""
+        return cls.from_payload(require_json_document(loads(path.read_text(encoding="utf-8"))))
+
+    def to_payload(self) -> JSONDocument:
+        """Render the regression case as a stable JSON document."""
+        return {
+            "schema_version": self.schema_version,
+            "case_id": self.case_id,
+            "name": self.name,
+            "source": self.source,
+            "created_at": self.created_at,
+            "tags": list(self.tags),
+            "notes": list(self.notes),
+            "provenance": self.provenance,
+            "summary": self.summary,
+        }
+
+    def to_json_text(self) -> str:
+        """Render pretty, deterministic JSON for durable storage."""
+        return json.dumps(self.to_payload(), indent=2, sort_keys=True, ensure_ascii=False) + "\n"
+
+    def write(self, directory: Path) -> Path:
+        """Write the case under ``directory`` and return the JSON path."""
+        directory.mkdir(parents=True, exist_ok=True)
+        path = directory / f"{self.case_id}.json"
+        path.write_text(self.to_json_text(), encoding="utf-8")
+        return path
+
+
+@dataclass(frozen=True, slots=True)
+class RegressionCaseStore:
+    """Repository-local store for captured regression cases."""
+
+    root: Path
+
+    def write(self, case: RegressionCase) -> Path:
+        return case.write(self.root)
+
+    def read(self, case_id: str) -> RegressionCase:
+        return RegressionCase.read(self.root / f"{case_id}.json")
+
+    def list_paths(self) -> tuple[Path, ...]:
+        if not self.root.exists():
+            return ()
+        return tuple(sorted(self.root.glob("*.json")))
+
+
+def regression_case_path_payload(case: RegressionCase, path: Path) -> JSONDocument:
+    """Render a small machine payload after capture."""
+    payload = case.to_payload()
+    payload["path"] = str(path)
+    return payload
+
+
+def json_input_document(raw: str | bytes) -> JSONDocument:
+    """Parse command input as a JSON document."""
+    return require_json_document(loads(raw), context="regression capture input")
+
+
+__all__ = [
+    "DEFAULT_CAPTURE_KEYS",
+    "RegressionCase",
+    "RegressionCaseStore",
+    "json_input_document",
+    "regression_case_path_payload",
+]

--- a/devtools/regression_cases.py
+++ b/devtools/regression_cases.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from polylogue.lib.json import JSONDocument, loads, require_json_document
 
 SCHEMA_VERSION = 1
+DEFAULT_REGRESSION_CASE_DIR = Path(".local/regression-cases")
 DEFAULT_CAPTURE_KEYS: tuple[str, ...] = (
     "probe",
     "paths",
@@ -184,6 +185,7 @@ def json_input_document(raw: str | bytes) -> JSONDocument:
 
 __all__ = [
     "DEFAULT_CAPTURE_KEYS",
+    "DEFAULT_REGRESSION_CASE_DIR",
     "RegressionCase",
     "RegressionCaseStore",
     "json_input_document",

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -59,6 +59,7 @@ These are the commands worth remembering during normal repo work:
 | `devtools artifact-graph` | Render the runtime artifact, operation, and scenario-coverage map. |
 | `devtools pipeline-probe` | Run typed pipeline probes against synthetic, staged, or archive-subset inputs. |
 | `devtools query-memory-budget` | Measure query-memory envelopes on generated fixtures. |
+| `devtools regression-capture` | Capture pipeline-probe summaries as durable local regression cases. |
 | `devtools run-validation-lanes` | Run named validation lanes. |
 | `devtools scenario-projections` | Render the authored scenario-bearing verification projections. |
 | `devtools verify` | Run the local verification baseline before pushing or creating a PR. |

--- a/tests/infra/growth_budgets.py
+++ b/tests/infra/growth_budgets.py
@@ -1,0 +1,136 @@
+"""Reusable growth-envelope assertions for tiered verification workloads."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class GrowthObservation:
+    """One workload observation at a concrete archive or input size."""
+
+    tier: str
+    size: int
+    metrics: Mapping[str, float]
+
+    def metric(self, name: str) -> float:
+        try:
+            return float(self.metrics[name])
+        except KeyError as exc:
+            raise KeyError(f"growth observation {self.tier!r} is missing metric {name!r}") from exc
+
+
+@dataclass(frozen=True, slots=True)
+class GrowthViolation:
+    """One growth-budget failure."""
+
+    metric: str
+    tier: str
+    message: str
+
+
+@dataclass(frozen=True, slots=True)
+class GrowthBudget:
+    """Envelope for one metric over increasing size tiers."""
+
+    metric: str
+    max_step_multiplier: float | None = None
+    max_per_unit: float | None = None
+    require_monotonic_size: bool = True
+
+    def evaluate(self, observations: Sequence[GrowthObservation]) -> tuple[GrowthViolation, ...]:
+        ordered = _ordered_observations(observations, require_monotonic_size=self.require_monotonic_size)
+        violations: list[GrowthViolation] = []
+        previous: GrowthObservation | None = None
+        for observation in ordered:
+            metric_value = observation.metric(self.metric)
+            if observation.size <= 0:
+                violations.append(
+                    GrowthViolation(self.metric, observation.tier, f"size must be positive, got {observation.size}")
+                )
+                previous = observation
+                continue
+            if self.max_per_unit is not None:
+                per_unit = metric_value / observation.size
+                if per_unit > self.max_per_unit:
+                    violations.append(
+                        GrowthViolation(
+                            self.metric,
+                            observation.tier,
+                            f"{per_unit:.3f} per unit exceeds budget {self.max_per_unit:.3f}",
+                        )
+                    )
+            if previous is not None and self.max_step_multiplier is not None:
+                previous_value = previous.metric(self.metric)
+                if previous_value > 0:
+                    multiplier = metric_value / previous_value
+                    if multiplier > self.max_step_multiplier:
+                        violations.append(
+                            GrowthViolation(
+                                self.metric,
+                                observation.tier,
+                                (
+                                    f"{multiplier:.3f}x step growth from {previous.tier!r} exceeds "
+                                    f"budget {self.max_step_multiplier:.3f}x"
+                                ),
+                            )
+                        )
+            previous = observation
+        return tuple(violations)
+
+
+@dataclass(frozen=True, slots=True)
+class GrowthBudgetReport:
+    """Evaluation result for one or more growth budgets."""
+
+    observations: tuple[GrowthObservation, ...]
+    violations: tuple[GrowthViolation, ...]
+
+    @property
+    def ok(self) -> bool:
+        return not self.violations
+
+    def assert_ok(self) -> None:
+        assert self.ok, "; ".join(violation.message for violation in self.violations)
+
+
+def evaluate_growth_budgets(
+    observations: Iterable[GrowthObservation],
+    budgets: Iterable[GrowthBudget],
+) -> GrowthBudgetReport:
+    """Evaluate budgets over size-tiered workload observations."""
+    observation_tuple = tuple(observations)
+    violations: list[GrowthViolation] = []
+    for budget in budgets:
+        violations.extend(budget.evaluate(observation_tuple))
+    return GrowthBudgetReport(observations=observation_tuple, violations=tuple(violations))
+
+
+def assert_growth_budgets(
+    observations: Iterable[GrowthObservation],
+    budgets: Iterable[GrowthBudget],
+) -> None:
+    """Assert that all supplied growth budgets hold."""
+    evaluate_growth_budgets(observations, budgets).assert_ok()
+
+
+def _ordered_observations(
+    observations: Sequence[GrowthObservation],
+    *,
+    require_monotonic_size: bool,
+) -> tuple[GrowthObservation, ...]:
+    ordered = tuple(sorted(observations, key=lambda observation: observation.size))
+    if require_monotonic_size and len({observation.size for observation in ordered}) != len(ordered):
+        raise ValueError("growth observations must have unique size tiers")
+    return ordered
+
+
+__all__ = [
+    "GrowthBudget",
+    "GrowthBudgetReport",
+    "GrowthObservation",
+    "GrowthViolation",
+    "assert_growth_budgets",
+    "evaluate_growth_budgets",
+]

--- a/tests/infra/regression_cases.py
+++ b/tests/infra/regression_cases.py
@@ -1,0 +1,7 @@
+"""Test-facing regression-case helpers."""
+
+from __future__ import annotations
+
+from devtools.regression_cases import RegressionCase, RegressionCaseStore
+
+__all__ = ["RegressionCase", "RegressionCaseStore"]

--- a/tests/unit/devtools/test_devtools_main.py
+++ b/tests/unit/devtools/test_devtools_main.py
@@ -14,6 +14,7 @@ def test_list_commands_json_includes_generated_surface(capsys: pytest.CaptureFix
     payload = json.loads(capsys.readouterr().out)
     commands = {entry["name"] for entry in payload["commands"]}
     assert "artifact-graph" in commands
+    assert "regression-capture" in commands
     assert "scenario-projections" in commands
     assert "render-devtools-reference" in commands
     assert "status" in commands
@@ -24,6 +25,7 @@ def test_list_commands_human_output(capsys: pytest.CaptureFixture[str]) -> None:
     captured = capsys.readouterr()
     assert "generated surfaces:" in captured.out
     assert "artifact-graph" in captured.out
+    assert "regression-capture" in captured.out
     assert "scenario-projections" in captured.out
     assert "render-devtools-reference" in captured.out
 

--- a/tests/unit/devtools/test_pipeline_probe.py
+++ b/tests/unit/devtools/test_pipeline_probe.py
@@ -9,6 +9,7 @@ from typing import TypeAlias
 import pytest
 
 from devtools.pipeline_probe import _write_probe_sources, main, run_probe
+from devtools.regression_cases import RegressionCase
 from polylogue.scenarios import CorpusRequest, CorpusScenario, CorpusSpec, PipelineProbeRequest
 from polylogue.schemas.synthetic import SyntheticCorpus
 from polylogue.storage.backends import create_backend
@@ -542,6 +543,50 @@ def test_main_returns_nonzero_when_budget_is_exceeded(capsys: pytest.CaptureFixt
     assert exit_code == 1
     assert _json_path(printed, "budgets", "ok") is False
     assert len(_require_json_array(_json_path(printed, "budgets", "violations"))) >= 1
+
+
+def test_main_can_capture_probe_summary_as_regression_case(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    output_dir = tmp_path / "regression-cases"
+
+    exit_code = main(
+        [
+            "--provider",
+            "chatgpt",
+            "--count",
+            "1",
+            "--messages-min",
+            "3",
+            "--messages-max",
+            "4",
+            "--stage",
+            "parse",
+            "--max-total-ms",
+            "0.0",
+            "--capture-regression",
+            "Probe Budget Drift",
+            "--regression-output-dir",
+            str(output_dir),
+            "--regression-tag",
+            "budget",
+            "--regression-note",
+            "captured by pipeline-probe",
+        ]
+    )
+
+    printed = _load_json_object(capsys.readouterr().out)
+    regression_case = _require_json_object(_json_path(printed, "regression_case"))
+    case_path = Path(_require_str(regression_case["path"]))
+    case = RegressionCase.read(case_path)
+
+    assert exit_code == 1
+    assert case_path.parent == output_dir
+    assert case.name == "Probe Budget Drift"
+    assert case.tags == ("budget",)
+    assert case.notes == ("captured by pipeline-probe",)
+    assert _json_path(case.summary, "budgets", "ok") is False
 
 
 async def test_run_probe_can_sample_archive_subset_and_persist_manifest(tmp_path: Path) -> None:

--- a/tests/unit/devtools/test_regression_capture.py
+++ b/tests/unit/devtools/test_regression_capture.py
@@ -3,11 +3,14 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from devtools import regression_capture
 from devtools.regression_cases import RegressionCase
+from polylogue.lib.json import JSONDocument
 
 
-def _probe_summary() -> dict[str, object]:
+def _probe_summary() -> JSONDocument:
     return {
         "probe": {"input_mode": "archive-subset", "stage": "parse"},
         "paths": {"workdir": "/tmp/polylogue-probe"},
@@ -20,7 +23,7 @@ def _probe_summary() -> dict[str, object]:
     }
 
 
-def test_regression_capture_writes_probe_case(tmp_path: Path, capsys) -> None:
+def test_regression_capture_writes_probe_case(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     input_path = tmp_path / "probe.json"
     output_dir = tmp_path / "cases"
     input_path.write_text(json.dumps(_probe_summary()), encoding="utf-8")
@@ -53,7 +56,7 @@ def test_regression_capture_writes_probe_case(tmp_path: Path, capsys) -> None:
     assert case.summary["result"] == {"ok": False, "error": "parse drift"}
 
 
-def test_regression_capture_json_output_includes_path(tmp_path: Path, capsys) -> None:
+def test_regression_capture_json_output_includes_path(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     input_path = tmp_path / "probe.json"
     output_dir = tmp_path / "cases"
     input_path.write_text(json.dumps(_probe_summary()), encoding="utf-8")

--- a/tests/unit/devtools/test_regression_capture.py
+++ b/tests/unit/devtools/test_regression_capture.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from devtools import regression_capture
+from devtools.regression_cases import RegressionCase
+
+
+def _probe_summary() -> dict[str, object]:
+    return {
+        "probe": {"input_mode": "archive-subset", "stage": "parse"},
+        "paths": {"workdir": "/tmp/polylogue-probe"},
+        "provenance": {"git_commit": "abc123", "worktree_dirty": False},
+        "result": {"ok": False, "error": "parse drift"},
+        "run_payload": {"metrics": {"total_duration_ms": 12.5}},
+        "db_stats": {"conversations": 0, "raw_conversations": 1},
+        "raw_fanout": [{"raw_id": "raw-1", "parse_error": "boom"}],
+        "budgets": {"ok": False, "violations": ["rss"]},
+    }
+
+
+def test_regression_capture_writes_probe_case(tmp_path: Path, capsys) -> None:
+    input_path = tmp_path / "probe.json"
+    output_dir = tmp_path / "cases"
+    input_path.write_text(json.dumps(_probe_summary()), encoding="utf-8")
+
+    assert (
+        regression_capture.main(
+            [
+                "--input",
+                str(input_path),
+                "--name",
+                "Parse Drift",
+                "--output-dir",
+                str(output_dir),
+                "--tag",
+                "live",
+                "--note",
+                "captured from probe",
+            ]
+        )
+        == 0
+    )
+
+    output_path = Path(capsys.readouterr().out.strip())
+    case = RegressionCase.read(output_path)
+    assert output_path.parent == output_dir
+    assert case.name == "Parse Drift"
+    assert case.source == "pipeline-probe"
+    assert case.tags == ("live",)
+    assert case.notes == ("captured from probe",)
+    assert case.summary["result"] == {"ok": False, "error": "parse drift"}
+
+
+def test_regression_capture_json_output_includes_path(tmp_path: Path, capsys) -> None:
+    input_path = tmp_path / "probe.json"
+    output_dir = tmp_path / "cases"
+    input_path.write_text(json.dumps(_probe_summary()), encoding="utf-8")
+
+    assert (
+        regression_capture.main(
+            [
+                "--input",
+                str(input_path),
+                "--name",
+                "Parse Drift",
+                "--output-dir",
+                str(output_dir),
+                "--json",
+            ]
+        )
+        == 0
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["source"] == "pipeline-probe"
+    assert Path(payload["path"]).exists()
+    assert payload["summary"]["db_stats"] == {"conversations": 0, "raw_conversations": 1}

--- a/tests/unit/devtools/test_render_devtools_reference.py
+++ b/tests/unit/devtools/test_render_devtools_reference.py
@@ -18,6 +18,10 @@ def test_build_command_catalog_includes_discovery_and_commands() -> None:
         "| `devtools scenario-projections` | Render the authored scenario-bearing verification projections. |"
         in rendered
     )
+    assert (
+        "| `devtools regression-capture` | Capture pipeline-probe summaries as durable local regression cases. |"
+        in rendered
+    )
     assert "| `devtools render-all` |" in rendered
     assert "Common forms: `devtools status`" in rendered
 

--- a/tests/unit/infra/test_growth_budgets.py
+++ b/tests/unit/infra/test_growth_budgets.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import pytest
+
+from tests.infra.growth_budgets import (
+    GrowthBudget,
+    GrowthObservation,
+    assert_growth_budgets,
+    evaluate_growth_budgets,
+)
+
+
+def test_growth_budget_accepts_linear_envelope() -> None:
+    observations = (
+        GrowthObservation("small", 10, {"rss_mb": 20.0, "elapsed_ms": 100.0}),
+        GrowthObservation("medium", 20, {"rss_mb": 38.0, "elapsed_ms": 190.0}),
+        GrowthObservation("large", 40, {"rss_mb": 78.0, "elapsed_ms": 390.0}),
+    )
+
+    report = evaluate_growth_budgets(
+        observations,
+        (
+            GrowthBudget("rss_mb", max_step_multiplier=2.2, max_per_unit=2.1),
+            GrowthBudget("elapsed_ms", max_step_multiplier=2.2, max_per_unit=10.0),
+        ),
+    )
+
+    assert report.ok
+    report.assert_ok()
+
+
+def test_growth_budget_reports_step_multiplier_violations() -> None:
+    observations = (
+        GrowthObservation("small", 10, {"elapsed_ms": 100.0}),
+        GrowthObservation("large", 20, {"elapsed_ms": 500.0}),
+    )
+
+    report = evaluate_growth_budgets(observations, (GrowthBudget("elapsed_ms", max_step_multiplier=2.0),))
+
+    assert not report.ok
+    assert report.violations[0].metric == "elapsed_ms"
+    assert "5.000x" in report.violations[0].message
+
+
+def test_growth_budget_assertion_summarizes_violations() -> None:
+    observations = (
+        GrowthObservation("small", 10, {"rss_mb": 20.0}),
+        GrowthObservation("large", 20, {"rss_mb": 100.0}),
+    )
+
+    with pytest.raises(AssertionError, match="exceeds budget"):
+        assert_growth_budgets(observations, (GrowthBudget("rss_mb", max_per_unit=3.0),))
+
+
+def test_growth_budget_rejects_duplicate_size_tiers() -> None:
+    observations = (
+        GrowthObservation("small-a", 10, {"rss_mb": 20.0}),
+        GrowthObservation("small-b", 10, {"rss_mb": 21.0}),
+    )
+
+    with pytest.raises(ValueError, match="unique size tiers"):
+        evaluate_growth_budgets(observations, (GrowthBudget("rss_mb"),))

--- a/tests/unit/infra/test_regression_cases.py
+++ b/tests/unit/infra/test_regression_cases.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 from devtools.regression_cases import RegressionCase, RegressionCaseStore
+from polylogue.lib.json import JSONDocument
 
 
-def test_regression_case_roundtrips_probe_summary(tmp_path) -> None:
-    summary = {
+def test_regression_case_roundtrips_probe_summary(tmp_path: Path) -> None:
+    summary: JSONDocument = {
         "probe": {"stage": "parse"},
         "provenance": {"git_commit": "abc123"},
         "result": {"ok": False},
@@ -23,8 +26,9 @@ def test_regression_case_roundtrips_probe_summary(tmp_path) -> None:
 
 
 def test_regression_case_requires_probe_and_result_keys() -> None:
+    summary: JSONDocument = {"probe": {}}
     try:
-        RegressionCase.from_probe_summary(name="bad", summary={"probe": {}})
+        RegressionCase.from_probe_summary(name="bad", summary=summary)
     except ValueError as exc:
         assert "probe" in str(exc)
         assert "result" in str(exc)

--- a/tests/unit/infra/test_regression_cases.py
+++ b/tests/unit/infra/test_regression_cases.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from devtools.regression_cases import RegressionCase, RegressionCaseStore
+
+
+def test_regression_case_roundtrips_probe_summary(tmp_path) -> None:
+    summary = {
+        "probe": {"stage": "parse"},
+        "provenance": {"git_commit": "abc123"},
+        "result": {"ok": False},
+        "db_stats": {"raw_conversations": 1},
+        "ignored": "not captured",
+    }
+
+    case = RegressionCase.from_probe_summary(name="Parse Failure", summary=summary, tags=("probe",))
+    path = RegressionCaseStore(tmp_path).write(case)
+    loaded = RegressionCase.read(path)
+
+    assert loaded == case
+    assert loaded.case_id.startswith("parse-failure-")
+    assert loaded.tags == ("probe",)
+    assert "ignored" not in loaded.summary
+
+
+def test_regression_case_requires_probe_and_result_keys() -> None:
+    try:
+        RegressionCase.from_probe_summary(name="bad", summary={"probe": {}})
+    except ValueError as exc:
+        assert "probe" in str(exc)
+        assert "result" in str(exc)
+    else:
+        raise AssertionError("expected missing result to fail")


### PR DESCRIPTION
## Summary

- Add durable regression-case capture for pipeline probe summaries.
- Add a `devtools regression-capture` command and direct `pipeline-probe --capture-regression` integration.
- Add reusable growth-budget helpers for size-tiered verification checks.

## Problem

Live/probe failures needed a deterministic path into local regression artifacts, and scale-related checks needed reusable budget assertions instead of ad hoc comparisons. Without those pieces, real failures could be observed during operator runs but not reduced into repeatable evidence for later verification.

## Solution

This introduces a typed `RegressionCase` model/store, command-catalog wiring, direct pipeline-probe capture flags, and test infrastructure for growth observations and budget reports. The generated devtools reference is refreshed so the new command is discoverable through the normal maintenance surface.

## Verification

- `uv run devtools verify`
- `uv run devtools verify --quick`
- `uv run ruff check devtools/regression_cases.py devtools/regression_capture.py devtools/pipeline_probe.py devtools/command_catalog.py tests/unit/devtools/test_pipeline_probe.py tests/unit/devtools/test_regression_capture.py tests/unit/infra/test_growth_budgets.py tests/unit/infra/test_regression_cases.py`
- `uv run mypy devtools/regression_cases.py devtools/regression_capture.py devtools/pipeline_probe.py tests/infra/growth_budgets.py`
- `uv run pytest -q tests/unit/devtools/test_pipeline_probe.py tests/unit/devtools/test_regression_capture.py tests/unit/infra/test_growth_budgets.py tests/unit/infra/test_regression_cases.py tests/unit/devtools/test_devtools_main.py tests/unit/devtools/test_render_devtools_reference.py`

Ref #196
Ref #274
Ref #192
