### PR TITLE
refactor(cli): generalize message role filtering

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -103,6 +103,9 @@ Options:
                                   --latest or -i ID. Incompatible with
                                   --transform
   -d, --dialogue-only             Show only user/assistant messages
+  --message-role TEXT             Show only selected message roles (repeatable
+                                  or comma-separated: user, assistant, system,
+                                  tool, unknown)
   --set TEXT...                   Set metadata key value
   --add-tag TEXT                  Add tags (comma-separated)
   --plain                         Force non-interactive plain output

--- a/polylogue/cli/click_app.py
+++ b/polylogue/cli/click_app.py
@@ -96,6 +96,7 @@ def cli(
     # Streaming
     stream: bool,
     dialogue_only: bool,
+    message_role: tuple[str, ...],
     # Modifiers
     set_meta: tuple[tuple[str, str], ...],
     add_tag: tuple[str, ...],

--- a/polylogue/cli/click_option_groups.py
+++ b/polylogue/cli/click_option_groups.py
@@ -7,6 +7,7 @@ from typing import TypeAlias
 
 import click
 
+from polylogue.cli.query_contracts import normalize_message_role_option
 from polylogue.cli.shell_completion_values import (
     complete_conversation_ids,
     complete_provider_values,
@@ -45,6 +46,17 @@ def _validate_provider_tokens(
             param_hint="--provider",
         )
     return value
+
+
+def _validate_message_role_tokens(
+    ctx: click.Context,
+    _param: click.Parameter,
+    value: tuple[str, ...],
+) -> tuple[str, ...]:
+    try:
+        return normalize_message_role_option(value)
+    except ValueError as exc:
+        raise click.BadParameter(str(exc), param_hint="--message-role") from exc
 
 
 FILTER_OPTION_DECORATORS: tuple[Callable[[ClickCallable], ClickCallable], ...] = (
@@ -181,6 +193,13 @@ STREAMING_OPTION_DECORATORS: tuple[Callable[[ClickCallable], ClickCallable], ...
         help="Stream output (low memory). Requires --latest or -i ID. Incompatible with --transform",
     ),
     click.option("--dialogue-only", "-d", is_flag=True, help="Show only user/assistant messages"),
+    click.option(
+        "--message-role",
+        "message_role",
+        multiple=True,
+        callback=_validate_message_role_tokens,
+        help="Show only selected message roles (repeatable or comma-separated: user, assistant, system, tool, unknown)",
+    ),
 )
 
 MODIFIER_OPTION_DECORATORS: tuple[Callable[[ClickCallable], ClickCallable], ...] = (

--- a/polylogue/cli/query.py
+++ b/polylogue/cli/query.py
@@ -250,8 +250,9 @@ def project_query_results(results: list[Conversation], plan: QueryExecutionPlan)
     projected = results
     if plan.output.transform is not None:
         projected = _query_actions.apply_transform(projected, plan.output.transform)
-    if plan.output.dialogue_only:
-        projected = [conversation.dialogue_only() for conversation in projected]
+    message_roles = plan.output.effective_message_roles()
+    if message_roles:
+        projected = [conversation.with_roles(message_roles) for conversation in projected]
     return projected
 
 
@@ -400,6 +401,7 @@ async def async_execute_query_request(env: AppEnv, request: RootModeRequest) -> 
             full_id,
             output_format=plan.output.stream_format(),
             dialogue_only=plan.output.dialogue_only,
+            message_roles=plan.output.effective_message_roles(),
             message_limit=message_limit,
         )
         return

--- a/polylogue/cli/query_contracts.py
+++ b/polylogue/cli/query_contracts.py
@@ -9,7 +9,9 @@ from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal, TypeAlias
 
+from polylogue.lib.message_roles import MessageRoleFilter, normalize_message_roles
 from polylogue.lib.query_spec import ConversationQuerySpec
+from polylogue.lib.roles import Role
 
 if TYPE_CHECKING:
     from polylogue.lib.models import Conversation, ConversationSummary
@@ -46,6 +48,11 @@ def describe_query_filters(params: QueryParamSource) -> list[str]:
     return coerce_query_spec(params).describe()
 
 
+def normalize_message_role_option(value: object) -> tuple[str, ...]:
+    """Normalize raw Click message-role values to canonical strings."""
+    return tuple(role.value for role in normalize_message_roles(value))
+
+
 @dataclass(frozen=True, slots=True)
 class QueryDeliveryTarget:
     """Single parsed delivery target for query output."""
@@ -74,6 +81,7 @@ class QueryOutputSpec:
     destinations: tuple[QueryDeliveryTarget, ...]
     fields: str | None
     dialogue_only: bool
+    message_roles: MessageRoleFilter
     transform: QueryTransform
     list_mode: bool
     print_path: bool
@@ -89,6 +97,7 @@ class QueryOutputSpec:
             destinations=destinations,
             fields=str(params["fields"]) if params.get("fields") is not None else None,
             dialogue_only=bool(params.get("dialogue_only", False)),
+            message_roles=normalize_message_roles(params.get("message_role") or params.get("message_roles")),
             transform=str(params["transform"]) if params.get("transform") is not None else None,
             list_mode=bool(params.get("list_mode", False)),
             print_path=bool(params.get("print_path", False)),
@@ -103,6 +112,16 @@ class QueryOutputSpec:
 
     def destination_labels(self) -> tuple[str, ...]:
         return tuple(target.raw for target in self.destinations)
+
+    def effective_message_roles(self) -> MessageRoleFilter:
+        if self.message_roles:
+            return self.message_roles
+        if self.dialogue_only:
+            return (Role.USER, Role.ASSISTANT)
+        return ()
+
+    def filters_messages(self) -> bool:
+        return bool(self.effective_message_roles())
 
 
 @dataclass(frozen=True, slots=True)
@@ -212,7 +231,7 @@ class QueryExecutionPlan:
             self.action == QueryAction.SHOW
             and self.output.list_mode
             and self.output.transform is None
-            and not self.output.dialogue_only
+            and not self.output.filters_messages()
         )
 
     def prefers_summary_stats(self) -> bool:

--- a/polylogue/cli/query_output.py
+++ b/polylogue/cli/query_output.py
@@ -36,6 +36,8 @@ from polylogue.cli.query_stats import (
     output_stats_sql,
 )
 from polylogue.lib.json import JSONDocument
+from polylogue.lib.message_roles import MessageRoleFilter, message_role_count_key, message_role_labels
+from polylogue.lib.roles import Role
 from polylogue.logging import get_logger
 from polylogue.rendering.formatting import format_conversation
 from polylogue.surface_payloads import ConversationListRowPayload
@@ -51,6 +53,7 @@ if TYPE_CHECKING:
 
 ConversationStats: TypeAlias = dict[str, int]
 MACHINE_OUTPUT_FORMATS = frozenset({"json", "yaml", "csv"})
+DIALOGUE_MESSAGE_ROLES: MessageRoleFilter = (Role.USER, Role.ASSISTANT)
 
 
 def _display_date(value: datetime | None, date_format: str = "%Y-%m-%d") -> str:
@@ -84,6 +87,21 @@ def _stream_date_parts(display_date: object | None) -> tuple[str | None, str | N
         value = str(display_date)
         return value, value
     return None, None
+
+
+def _role_filter_label(message_roles: MessageRoleFilter) -> str:
+    if message_roles == DIALOGUE_MESSAGE_ROLES:
+        return "dialogue"
+    labels = message_role_labels(message_roles)
+    if len(labels) == 1:
+        return labels[0]
+    return "selected-role"
+
+
+def _role_filter_count(stats: ConversationStats, message_roles: MessageRoleFilter) -> int:
+    if message_roles == DIALOGUE_MESSAGE_ROLES:
+        return stats.get("dialogue_messages", 0)
+    return sum(stats.get(message_role_count_key(role), 0) for role in message_roles)
 
 
 # ---------------------------------------------------------------------------
@@ -474,6 +492,7 @@ def render_stream_header(
     display_date: object | None,
     output_format: str,
     dialogue_only: bool,
+    message_roles: MessageRoleFilter,
     message_limit: int | None,
     stats: ConversationStats | None,
 ) -> str:
@@ -488,8 +507,10 @@ def render_stream_header(
             lines.append(f"**Provider**: {provider}")
         if display_date_text is not None or provider:
             lines.append("")
-        if dialogue_only and stats:
-            line = f"_Showing {stats['dialogue_messages']} dialogue messages"
+        if message_roles and stats:
+            shown = _role_filter_count(stats, message_roles)
+            label = _role_filter_label(message_roles)
+            line = f"_Showing {shown} {label} messages"
             if message_limit:
                 line += f" (limit: {message_limit})"
             line += f" of {stats['total_messages']} total_"
@@ -504,6 +525,7 @@ def render_stream_header(
             "provider": provider,
             "date": display_date_value,
             "dialogue_only": dialogue_only,
+            "message_roles": list(message_role_labels(message_roles)),
             "message_limit": message_limit,
             "stats": stats,
         }
@@ -530,10 +552,13 @@ def render_stream_transcript(
     messages: list[Message],
     output_format: str,
     dialogue_only: bool = False,
+    message_roles: MessageRoleFilter = (),
     message_limit: int | None = None,
     stats: ConversationStats | None = None,
 ) -> tuple[str, int]:
     """Render the full stream transcript deterministically for proof/tests."""
+    effective_roles = message_roles or (DIALOGUE_MESSAGE_ROLES if dialogue_only else ())
+    filtered_messages = [message for message in messages if not effective_roles or message.role in effective_roles]
     parts = [
         render_stream_header(
             conversation_id=conversation_id,
@@ -542,12 +567,13 @@ def render_stream_transcript(
             display_date=display_date,
             output_format=output_format,
             dialogue_only=dialogue_only,
+            message_roles=effective_roles,
             message_limit=message_limit,
             stats=stats,
         )
     ]
     emitted = 0
-    for message in messages[: message_limit if message_limit is not None else None]:
+    for message in filtered_messages[: message_limit if message_limit is not None else None]:
         chunk = render_stream_message(message, output_format)
         if chunk:
             parts.append(chunk)
@@ -563,6 +589,7 @@ async def stream_conversation(
     *,
     output_format: str = "plaintext",
     dialogue_only: bool = False,
+    message_roles: MessageRoleFilter = (),
     message_limit: int | None = None,
 ) -> int:
     """Stream conversation messages to stdout without buffering."""
@@ -573,6 +600,7 @@ async def stream_conversation(
     conv_record = projection.conversation
 
     stats = await repo.get_conversation_stats(conversation_id)
+    effective_roles = message_roles or (DIALOGUE_MESSAGE_ROLES if dialogue_only else ())
     sys.stdout.write(
         render_stream_header(
             conversation_id=conversation_id,
@@ -581,6 +609,7 @@ async def stream_conversation(
             display_date=(getattr(conv_record, "updated_at", None) or getattr(conv_record, "created_at", None)),
             output_format=output_format,
             dialogue_only=dialogue_only,
+            message_roles=effective_roles,
             message_limit=message_limit,
             stats=stats,
         )
@@ -591,6 +620,7 @@ async def stream_conversation(
     async for message in repo.iter_messages(
         conversation_id,
         dialogue_only=dialogue_only,
+        message_roles=effective_roles,
         limit=message_limit,
     ):
         chunk = render_stream_message(message, output_format)

--- a/polylogue/cli/root_request.py
+++ b/polylogue/cli/root_request.py
@@ -50,6 +50,7 @@ class RootModeRequest:
                 "limit",
                 "stream",
                 "dialogue_only",
+                "message_role",
             )
         )
 

--- a/polylogue/lib/conversation_runtime.py
+++ b/polylogue/lib/conversation_runtime.py
@@ -9,7 +9,9 @@ from typing import TYPE_CHECKING, Self
 
 from polylogue.lib.branch_type import BranchType
 from polylogue.lib.message_models import DialoguePair, Message
+from polylogue.lib.message_roles import normalize_message_roles
 from polylogue.lib.messages import MessageCollection
+from polylogue.lib.roles import Role
 from polylogue.types import ConversationId
 
 if TYPE_CHECKING:
@@ -84,14 +86,12 @@ class ConversationRuntimeMixin:
         filtered_messages = [message for message in self.messages if predicate(message)]
         return self.model_copy(update={"messages": MessageCollection(messages=filtered_messages)})
 
-    def user_only(self) -> Self:
-        return self.filter(lambda message: message.is_user)
-
-    def assistant_only(self) -> Self:
-        return self.filter(lambda message: message.is_assistant)
+    def with_roles(self, roles: object) -> Self:
+        selected_roles = normalize_message_roles(roles)
+        return self.filter(lambda message: message.role in selected_roles)
 
     def dialogue_only(self) -> Self:
-        return self.filter(lambda message: message.is_dialogue)
+        return self.with_roles((Role.USER, Role.ASSISTANT))
 
     def without_noise(self) -> Self:
         return self.filter(lambda message: not message.is_noise)

--- a/polylogue/lib/message_roles.py
+++ b/polylogue/lib/message_roles.py
@@ -1,0 +1,87 @@
+"""Shared message-role filtering helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+from typing import TypeAlias
+
+from polylogue.lib.roles import Role
+
+MessageRoleFilter: TypeAlias = tuple[Role, ...]
+
+ROLE_SQL_VALUES: dict[Role, tuple[str, ...]] = {
+    Role.USER: ("user", "human"),
+    Role.ASSISTANT: ("assistant", "model", "ai"),
+    Role.SYSTEM: ("system",),
+    Role.TOOL: ("tool", "function", "tool_use", "tool_result", "progress", "result"),
+    Role.UNKNOWN: ("unknown",),
+}
+
+
+def _split_role_tokens(value: str) -> tuple[str, ...]:
+    return tuple(part.strip() for part in value.split(",") if part.strip())
+
+
+def _iter_role_values(value: object) -> Iterable[object]:
+    if value is None:
+        return ()
+    if isinstance(value, Role):
+        return (value,)
+    if isinstance(value, str):
+        return _split_role_tokens(value)
+    if isinstance(value, Iterable):
+        return value
+    return (value,)
+
+
+def normalize_message_role_token(value: object) -> Role:
+    """Normalize one user-supplied message role token."""
+    if isinstance(value, Role):
+        return value
+    token = str(value).strip()
+    role = Role.normalize(token)
+    if role == Role.UNKNOWN and token.lower() != Role.UNKNOWN.value:
+        valid = ", ".join(role.value for role in Role)
+        msg = f"Unknown message role {token!r}. Valid roles: {valid}"
+        raise ValueError(msg)
+    return role
+
+
+def normalize_message_roles(value: object) -> MessageRoleFilter:
+    """Normalize repeated or comma-separated role values to canonical roles."""
+    roles: list[Role] = []
+    for raw in _iter_role_values(value):
+        if isinstance(raw, str):
+            candidates: Sequence[object] = _split_role_tokens(raw)
+        else:
+            candidates = (raw,)
+        for candidate in candidates:
+            role = normalize_message_role_token(candidate)
+            if role not in roles:
+                roles.append(role)
+    return tuple(roles)
+
+
+def message_role_labels(roles: Sequence[Role]) -> tuple[str, ...]:
+    return tuple(role.value for role in roles)
+
+
+def message_role_count_key(role: Role) -> str:
+    return f"role_{role.value}_messages"
+
+
+def message_role_sql_values(roles: Sequence[Role]) -> tuple[str, ...]:
+    values: list[str] = []
+    for role in roles:
+        values.extend(ROLE_SQL_VALUES[role])
+    return tuple(dict.fromkeys(values))
+
+
+__all__ = [
+    "MessageRoleFilter",
+    "message_role_count_key",
+    "message_role_labels",
+    "message_role_sql_values",
+    "normalize_message_role_token",
+    "normalize_message_roles",
+]

--- a/polylogue/lib/semantic_fact_models.py
+++ b/polylogue/lib/semantic_fact_models.py
@@ -150,6 +150,7 @@ class StreamSemanticFacts:
     tool_messages: int
     branch_messages: int
     dialogue_only: bool
+    message_roles: tuple[str, ...]
     message_limit: int | None
 
     def to_proof_input(self) -> JSONDocument:
@@ -168,6 +169,7 @@ class StreamSemanticFacts:
                 "tool_messages": self.tool_messages,
                 "branch_messages": self.branch_messages,
                 "dialogue_only": self.dialogue_only,
+                "message_roles": list(self.message_roles),
                 "message_limit": self.message_limit,
             }
         )

--- a/polylogue/lib/semantic_facts.py
+++ b/polylogue/lib/semantic_facts.py
@@ -8,6 +8,8 @@ from datetime import datetime
 from typing import Protocol
 
 from polylogue.lib.action_events import ActionEvent, build_action_events
+from polylogue.lib.message_roles import MessageRoleFilter, message_role_labels
+from polylogue.lib.roles import Role
 from polylogue.lib.semantic_fact_models import (
     ConversationSemanticFacts,
     MCPDetailSemanticFacts,
@@ -357,9 +359,15 @@ def build_stream_semantic_facts(
     conversation: SemanticConversationLike,
     *,
     dialogue_only: bool = False,
+    message_roles: MessageRoleFilter = (),
     message_limit: int | None = None,
 ) -> StreamSemanticFacts:
-    filtered_messages = [message for message in conversation.messages if not dialogue_only or message.is_dialogue]
+    effective_roles = message_roles or ((Role.USER, Role.ASSISTANT) if dialogue_only else ())
+
+    def _passes_role_filter(message: SemanticConversationMessageLike) -> bool:
+        return not effective_roles or Role.normalize(str(message.role)) in effective_roles
+
+    filtered_messages = [message for message in conversation.messages if _passes_role_filter(message)]
     if message_limit is not None:
         filtered_messages = filtered_messages[:message_limit]
 
@@ -381,6 +389,7 @@ def build_stream_semantic_facts(
         tool_messages=sum(1 for message in filtered_messages if message.is_tool_use),
         branch_messages=sum(1 for message in filtered_messages if message.branch_index > 0),
         dialogue_only=dialogue_only,
+        message_roles=message_role_labels(effective_roles),
         message_limit=message_limit,
     )
 

--- a/polylogue/protocols.py
+++ b/polylogue/protocols.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
     from polylogue.lib.action_events import ActionEvent
     from polylogue.lib.conversation_models import Conversation, ConversationSummary
     from polylogue.lib.message_models import Message
+    from polylogue.lib.message_roles import MessageRoleFilter
     from polylogue.lib.session_profile import SessionProfile
     from polylogue.lib.stats import ArchiveStats
     from polylogue.storage.action_event_artifacts import ActionEventArtifactState
@@ -182,6 +183,7 @@ class ConversationReader(Protocol):
         conversation_id: str,
         *,
         dialogue_only: bool = False,
+        message_roles: MessageRoleFilter = (),
         limit: int | None = None,
     ) -> AsyncIterator[Message]: ...
 

--- a/polylogue/storage/backends/async_sqlite_archive.py
+++ b/polylogue/storage/backends/async_sqlite_archive.py
@@ -6,6 +6,7 @@ from collections.abc import AsyncIterator
 from contextlib import AbstractAsyncContextManager
 from typing import TYPE_CHECKING
 
+from polylogue.lib.message_roles import MessageRoleFilter
 from polylogue.storage.backends.queries import attachments as attachments_q
 from polylogue.storage.backends.queries import conversations as conversations_q
 from polylogue.storage.backends.queries import messages as messages_q
@@ -167,6 +168,7 @@ class SQLiteArchiveMixin:
         *,
         chunk_size: int = 100,
         dialogue_only: bool = False,
+        message_roles: MessageRoleFilter = (),
         limit: int | None = None,
     ) -> AsyncIterator[MessageRecord]:
         """Stream messages in chunks instead of loading all at once."""
@@ -177,6 +179,7 @@ class SQLiteArchiveMixin:
                     conversation_id,
                     chunk_size=chunk_size,
                     dialogue_only=dialogue_only,
+                    message_roles=message_roles,
                     limit=limit,
                 ):
                     yield msg
@@ -184,6 +187,7 @@ class SQLiteArchiveMixin:
         async for msg in self.queries.iter_messages(
             conversation_id,
             dialogue_only=dialogue_only,
+            message_roles=message_roles,
             limit=limit,
         ):
             yield msg

--- a/polylogue/storage/backends/queries/message_query_reads.py
+++ b/polylogue/storage/backends/queries/message_query_reads.py
@@ -6,6 +6,8 @@ from collections.abc import AsyncIterator
 
 import aiosqlite
 
+from polylogue.lib.message_roles import MessageRoleFilter, message_role_sql_values
+from polylogue.lib.roles import Role
 from polylogue.storage.backends.queries.mappers import _row_to_message
 from polylogue.storage.store import MessageRecord
 
@@ -54,17 +56,22 @@ async def iter_messages(
     *,
     chunk_size: int = 100,
     dialogue_only: bool = False,
+    message_roles: MessageRoleFilter = (),
     limit: int | None = None,
 ) -> AsyncIterator[MessageRecord]:
     offset = 0
     yielded = 0
+    effective_roles = message_roles or ((Role.USER, Role.ASSISTANT) if dialogue_only else ())
+    role_values = message_role_sql_values(effective_roles)
 
     while True:
         query = "SELECT * FROM messages WHERE conversation_id = ?"
         params: list[str | int] = [conversation_id]
 
-        if dialogue_only:
-            query += " AND role IN ('user', 'assistant', 'human')"
+        if role_values:
+            placeholders = ",".join("?" for _ in role_values)
+            query += f" AND role IN ({placeholders})"
+            params.extend(role_values)
 
         query += " ORDER BY (sort_key IS NULL), sort_key, message_id"
 

--- a/polylogue/storage/backends/queries/message_query_stats.py
+++ b/polylogue/storage/backends/queries/message_query_stats.py
@@ -4,6 +4,13 @@ from __future__ import annotations
 
 import aiosqlite
 
+from polylogue.lib.message_roles import message_role_count_key, message_role_sql_values
+from polylogue.lib.roles import Role
+
+
+def _role_count(role_counts: dict[str, int], role: Role) -> int:
+    return sum(role_counts.get(value, 0) for value in message_role_sql_values((role,)))
+
 
 async def get_conversation_stats(conn: aiosqlite.Connection, conversation_id: str) -> dict[str, int]:
     cursor = await conn.execute(
@@ -20,10 +27,23 @@ async def get_conversation_stats(conn: aiosqlite.Connection, conversation_id: st
     row = await cursor.fetchone()
     dialogue = int(row["cnt"]) if row else 0
 
+    cursor = await conn.execute(
+        """
+        SELECT role, COUNT(*) as cnt
+        FROM messages
+        WHERE conversation_id = ?
+        GROUP BY role
+        """,
+        (conversation_id,),
+    )
+    role_counts = {str(row["role"]): int(row["cnt"]) for row in await cursor.fetchall()}
+    canonical_role_counts = {message_role_count_key(role): _role_count(role_counts, role) for role in Role}
+
     return {
         "total_messages": total,
         "dialogue_messages": dialogue,
         "tool_messages": total - dialogue,
+        **canonical_role_counts,
     }
 
 

--- a/polylogue/storage/backends/query_store_archive.py
+++ b/polylogue/storage/backends/query_store_archive.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 
 import aiosqlite
 
+from polylogue.lib.message_roles import MessageRoleFilter
 from polylogue.storage.backends.queries import attachments as attachments_q
 from polylogue.storage.backends.queries import conversations as conversations_q
 from polylogue.storage.backends.queries import messages as messages_q
@@ -141,6 +142,7 @@ class SQLiteQueryStoreArchiveMixin:
         conversation_id: str,
         *,
         dialogue_only: bool = False,
+        message_roles: MessageRoleFilter = (),
         limit: int | None = None,
     ) -> AsyncIterator[MessageRecord]:
         async with self._connection_factory() as conn:
@@ -148,6 +150,7 @@ class SQLiteQueryStoreArchiveMixin:
                 conn,
                 conversation_id,
                 dialogue_only=dialogue_only,
+                message_roles=message_roles,
                 limit=limit,
             ):
                 yield record

--- a/polylogue/storage/repository_archive_conversations.py
+++ b/polylogue/storage/repository_archive_conversations.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 
 from polylogue.lib.conversation_models import Conversation, ConversationSummary
 from polylogue.lib.message_models import Message
+from polylogue.lib.message_roles import MessageRoleFilter
 from polylogue.storage.archive_views import ConversationRenderProjection
 from polylogue.storage.hydrators import (
     conversation_from_records,
@@ -145,6 +146,7 @@ class RepositoryArchiveConversationMixin:
         conversation_id: str,
         *,
         dialogue_only: bool = False,
+        message_roles: MessageRoleFilter = (),
         limit: int | None = None,
     ) -> AsyncIterator[Message]:
         conv_record = await self.queries.get_conversation(conversation_id)
@@ -152,6 +154,7 @@ class RepositoryArchiveConversationMixin:
         async for record in self.queries.iter_messages(
             conversation_id,
             dialogue_only=dialogue_only,
+            message_roles=message_roles,
             limit=limit,
         ):
             yield message_from_record(record, attachments=[], provider=provider_name)

--- a/tests/baselines/showcase/help-main.txt
+++ b/tests/baselines/showcase/help-main.txt
@@ -92,6 +92,9 @@ Options:
                                   --latest or -i ID. Incompatible with
                                   --transform
   -d, --dialogue-only             Show only user/assistant messages
+  --message-role TEXT             Show only selected message roles (repeatable
+                                  or comma-separated: user, assistant, system,
+                                  tool, unknown)
   --set TEXT...                   Set metadata key value
   --add-tag TEXT                  Add tags (comma-separated)
   --plain                         Force non-interactive plain output

--- a/tests/unit/cli/__snapshots__/test_terminal_snapshots.ambr
+++ b/tests/unit/cli/__snapshots__/test_terminal_snapshots.ambr
@@ -186,6 +186,9 @@
                                     --latest or -i ID. Incompatible with
                                     --transform
     -d, --dialogue-only             Show only user<PATH> messages
+    --message-role TEXT             Show only selected message roles (repeatable
+                                    or comma-separated: user, assistant, system,
+                                    tool, unknown)
     --set TEXT...                   Set metadata key value
     --add-tag TEXT                  Add tags (comma-separated)
     --plain                         Force non-interactive plain output
@@ -335,6 +338,11 @@
                                     --transform
     -d, --dialogue-only             Show only user<PATH> m
   essages
+    --message-role TEXT             Show only selected message
+   roles (repeatable
+                                    or comma-separated: user,
+  assistant, system,
+                                    tool, unknown)
     --set TEXT...                   Set metadata key value
     --add-tag TEXT                  Add tags (comma-separated)
     --plain                         Force non-interactive plai
@@ -457,6 +465,9 @@
                                     --latest or -i ID. Incompatible with
                                     --transform
     -d, --dialogue-only             Show only user<PATH> messages
+    --message-role TEXT             Show only selected message roles (repeatable
+                                    or comma-separated: user, assistant, system,
+                                    tool, unknown)
     --set TEXT...                   Set metadata key value
     --add-tag TEXT                  Add tags (comma-separated)
     --plain                         Force non-interactive plain output

--- a/tests/unit/cli/test_click_app.py
+++ b/tests/unit/cli/test_click_app.py
@@ -53,6 +53,7 @@ class TestHandleQueryMode:
             "transform": None,
             "stream": False,
             "dialogue_only": False,
+            "message_role": (),
             "set_meta": (),
             "add_tag": (),
             "plain": False,
@@ -143,6 +144,7 @@ class TestHandleQueryMode:
             self._make_params(limit=10),
             self._make_params(stream=True),
             self._make_params(dialogue_only=True),
+            self._make_params(message_role=("user",)),
         ):
             mock_execute, _ = self._call(params)
             mock_execute.assert_called_once()

--- a/tests/unit/cli/test_query_exec.py
+++ b/tests/unit/cli/test_query_exec.py
@@ -138,6 +138,7 @@ def _make_params(**overrides: object) -> dict[str, object]:
         "output": None,
         "transform": None,
         "dialogue_only": False,
+        "message_role": (),
         "stats_only": False,
         "stats_by": None,
         "set_meta": None,
@@ -262,7 +263,7 @@ async def test_async_execute_query_reports_non_date_query_spec_errors() -> None:
     plan = QueryExecutionPlan(
         selection=selection,
         action=QueryAction.SHOW,
-        output=QueryOutputSpec("markdown", _delivery_targets("stdout"), None, False, None, False, False),
+        output=QueryOutputSpec("markdown", _delivery_targets("stdout"), None, False, (), None, False, False),
         mutation=QueryMutationSpec((), (), False, False, False),
     )
 
@@ -737,12 +738,13 @@ async def test_async_execute_query_uses_session_product_stats_lane_for_repo_stat
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("output_format", "dialogue_only", "limit", "expected_fragments"),
+    ("output_format", "dialogue_only", "message_roles", "limit", "expected_fragments"),
     [
-        ("plaintext", False, None, ["[USER]", "Hello", "[ASSISTANT]", "Hi"]),
+        ("plaintext", False, (), None, ["[USER]", "Hello", "[ASSISTANT]", "Hi"]),
         (
             "markdown",
             True,
+            (),
             1,
             [
                 "# Test Title",
@@ -752,14 +754,32 @@ async def test_async_execute_query_uses_session_product_stats_lane_for_repo_stat
                 "_Streamed 1 messages_",
             ],
         ),
-        ("json-lines", False, None, ['"type": "header"', '"type": "message"', '"type": "footer"']),
+        ("json-lines", False, (), None, ['"type": "header"', '"type": "message"', '"type": "footer"']),
+        (
+            "markdown",
+            False,
+            ("user",),
+            1,
+            [
+                "# Test Title",
+                "_Showing 1 user messages (limit: 1) of 2 total_",
+                "## User",
+                "---",
+                "_Streamed 1 messages_",
+            ],
+        ),
     ],
-    ids=["plaintext", "markdown", "json-lines"],
+    ids=["plaintext", "markdown", "json-lines", "markdown-message-role-user"],
 )
 async def test_stream_conversation_output_contract(
-    output_format: str, dialogue_only: bool, limit: int | None, expected_fragments: list[str]
+    output_format: str,
+    dialogue_only: bool,
+    message_roles: tuple[str, ...],
+    limit: int | None,
+    expected_fragments: list[str],
 ) -> None:
     from polylogue.cli.query_output import stream_conversation
+    from polylogue.lib.message_roles import normalize_message_roles
 
     repo = MagicMock()
     repo.get_render_projection = AsyncMock(
@@ -772,7 +792,9 @@ async def test_stream_conversation_output_contract(
             )
         )
     )
-    repo.get_conversation_stats = AsyncMock(return_value={"dialogue_messages": 1, "total_messages": 2})
+    repo.get_conversation_stats = AsyncMock(
+        return_value={"dialogue_messages": 1, "role_user_messages": 1, "total_messages": 2}
+    )
 
     async def _iter_messages(*_args: object, **_kwargs: object) -> AsyncIterator[MessageModel]:
         messages = [_make_msg("m1", "user", "Hello"), _make_msg("m2", "assistant", "Hi")]
@@ -787,7 +809,13 @@ async def test_stream_conversation_output_contract(
 
     with patch("sys.stdout", stdout):
         count = await stream_conversation(
-            env, repo, "conv-1", output_format=output_format, dialogue_only=dialogue_only, message_limit=limit
+            env,
+            repo,
+            "conv-1",
+            output_format=output_format,
+            dialogue_only=dialogue_only,
+            message_roles=normalize_message_roles(message_roles),
+            message_limit=limit,
         )
 
     output = stdout.getvalue()

--- a/tests/unit/cli/test_query_exec_laws.py
+++ b/tests/unit/cli/test_query_exec_laws.py
@@ -44,6 +44,7 @@ from polylogue.cli.query_output import (
 )
 from polylogue.cli.types import AppEnv
 from polylogue.lib.json import JSONDocument
+from polylogue.lib.message_roles import MessageRoleFilter
 from polylogue.lib.models import Conversation
 from polylogue.lib.query_spec import ConversationQuerySpec, QuerySpecError
 from polylogue.lib.roles import Role
@@ -174,6 +175,7 @@ def _output_spec(
     destinations: tuple[str, ...] = ("stdout",),
     fields: str | None = None,
     dialogue_only: bool = False,
+    message_roles: MessageRoleFilter = (),
     transform: str | None = None,
     list_mode: bool = False,
     print_path: bool = False,
@@ -183,6 +185,7 @@ def _output_spec(
         destinations=_delivery_targets(*destinations),
         fields=fields,
         dialogue_only=dialogue_only,
+        message_roles=message_roles,
         transform=transform,
         list_mode=list_mode,
         print_path=print_path,
@@ -1129,6 +1132,34 @@ def test_project_query_results_contract() -> None:
     ]
 
 
+def test_project_query_results_message_role_contract() -> None:
+    plan = QueryExecutionPlan(
+        selection=ConversationQuerySpec(),
+        action=QueryAction.SHOW,
+        output=_output_spec(message_roles=(Role.USER,)),
+        mutation=_mutation_spec(),
+    )
+    conversation = _sample_conversation()
+
+    projected = project_query_results([conversation], plan)
+
+    assert [message.id for message in projected[0].messages] == ["m-user"]
+
+
+def test_project_query_results_explicit_message_role_supersedes_dialogue_only() -> None:
+    plan = QueryExecutionPlan(
+        selection=ConversationQuerySpec(),
+        action=QueryAction.SHOW,
+        output=_output_spec(dialogue_only=True, message_roles=(Role.TOOL,)),
+        mutation=_mutation_spec(),
+    )
+    conversation = _sample_conversation()
+
+    projected = project_query_results([conversation], plan)
+
+    assert [message.id for message in projected[0].messages] == ["m-tool"]
+
+
 @pytest.mark.parametrize(
     ("case", "expected_helper"),
     [
@@ -1243,6 +1274,7 @@ def test_async_execute_query_action_routing_contract(case: str, expected_helper:
             "conv-stream",
             output_format="json-lines",
             dialogue_only=True,
+            message_roles=(Role.USER, Role.ASSISTANT),
             message_limit=7,
         )
         warnings = [call.args[0] for call in mock_echo.call_args_list if call.args]

--- a/tests/unit/core/test_conversation_semantics.py
+++ b/tests/unit/core/test_conversation_semantics.py
@@ -17,6 +17,7 @@ from polylogue.lib.messages import MessageCollection
 from polylogue.lib.models import Attachment, Conversation, DialoguePair, Message
 from polylogue.lib.pricing import harmonize_session_cost
 from polylogue.lib.projections import ConversationProjection
+from polylogue.lib.roles import Role
 from tests.infra.assertions import assert_contains_all, assert_not_contains_any
 from tests.infra.builders import make_conv, make_msg
 
@@ -25,8 +26,9 @@ from tests.infra.builders import make_conv, make_msg
 class ViewCase:
     name: str
     messages: list[Message]
-    view: str
     expected_ids: tuple[str, ...]
+    view: str | None = None
+    role_filter: tuple[Role, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -316,18 +318,18 @@ VIEW_CASES = [
             make_msg(id="s1", role="system", text="System prompt"),
             make_msg(id="t1", role="tool", text="tool"),
         ],
-        view="dialogue_only",
         expected_ids=("u1", "a1"),
+        view="dialogue_only",
     ),
     ViewCase(
-        name="assistant_only",
+        name="assistant_role_filter",
         messages=[
             make_msg(id="u1", role="user", text="Question one with enough detail"),
             make_msg(id="a1", role="assistant", text="Answer one with enough detail"),
             make_msg(id="a2", role="assistant", text="Answer two with enough detail"),
         ],
-        view="assistant_only",
         expected_ids=("a1", "a2"),
+        role_filter=(Role.ASSISTANT,),
     ),
     ViewCase(
         name="without_noise",
@@ -363,7 +365,11 @@ class TestConversationViewsAndIteration:
     @pytest.mark.parametrize("case", VIEW_CASES, ids=lambda case: case.name)
     def test_view_projection_contract(self, case: ViewCase) -> None:
         conversation = make_conv(id="c1", provider="test", messages=MessageCollection(messages=case.messages))
-        projected = getattr(conversation, case.view)()
+        if case.role_filter:
+            projected = conversation.with_roles(case.role_filter)
+        else:
+            assert case.view is not None
+            projected = getattr(conversation, case.view)()
         assert tuple(message.id for message in projected.messages) == case.expected_ids
 
     def test_iterators_share_projection_contract(self, dialogue_noise_mix: Conversation) -> None:

--- a/tests/unit/core/test_message_laws.py
+++ b/tests/unit/core/test_message_laws.py
@@ -85,9 +85,9 @@ def test_substantive_only_preserves_count(conv: Conversation) -> None:
 
 
 @given(conversation_model_strategy())
-def test_user_only_preserves_count(conv: Conversation) -> None:
+def test_with_roles_preserves_selected_role_count(conv: Conversation) -> None:
     expected_ids = [msg.id for msg in conv.messages if msg.is_user]
-    filtered = conv.user_only()
+    filtered = conv.with_roles((Role.USER,))
     assert [msg.id for msg in filtered.messages] == expected_ids
 
 

--- a/tests/unit/storage/test_backend.py
+++ b/tests/unit/storage/test_backend.py
@@ -15,6 +15,7 @@ import aiosqlite
 import pytest
 
 import polylogue.paths
+from polylogue.lib.roles import Role
 from polylogue.storage.backends.async_sqlite import SQLiteBackend
 from polylogue.storage.backends.connection import (
     READ_CACHE_SIZE_KIB,
@@ -996,6 +997,34 @@ async def test_backend_delete_contracts(tmp_path: Path) -> None:
         )
         assert conn.execute("SELECT COUNT(*) FROM day_session_summaries").fetchone()[0] == 0
         assert conn.execute("SELECT COUNT(*) FROM session_tag_rollups").fetchone()[0] == 0
+    await backend.close()
+
+
+async def test_backend_stream_messages_accepts_generic_role_filter(tmp_path: Path) -> None:
+    backend = SQLiteBackend(db_path=tmp_path / "role-filter.db")
+    conv = make_conversation("conv-role-filter", title="Role Filter")
+    messages = [
+        make_message("msg-user", "conv-role-filter", role="user", text="User text"),
+        make_message("msg-assistant", "conv-role-filter", role="assistant", text="Assistant text"),
+        make_message("msg-tool", "conv-role-filter", role="tool", text="Tool text"),
+        make_message("msg-system", "conv-role-filter", role="system", text="System text"),
+    ]
+
+    async with backend.transaction():
+        await backend.save_conversation_record(conv)
+        await backend.save_messages(messages)
+
+    user_messages = [message async for message in backend.iter_messages("conv-role-filter", message_roles=(Role.USER,))]
+    dialogue_messages = [message async for message in backend.iter_messages("conv-role-filter", dialogue_only=True)]
+    stats = await backend.get_conversation_stats("conv-role-filter")
+
+    assert [message.message_id for message in user_messages] == ["msg-user"]
+    assert [message.message_id for message in dialogue_messages] == ["msg-user", "msg-assistant"]
+    assert stats["role_user_messages"] == 1
+    assert stats["role_assistant_messages"] == 1
+    assert stats["role_tool_messages"] == 1
+    assert stats["role_system_messages"] == 1
+
     await backend.close()
 
 

--- a/tests/unit/storage/test_repository_state_machine.py
+++ b/tests/unit/storage/test_repository_state_machine.py
@@ -7,10 +7,7 @@ after arbitrary interleaving.
 
 from __future__ import annotations
 
-import shutil
 import sqlite3
-import tempfile
-from pathlib import Path
 
 from hypothesis import settings
 from hypothesis.stateful import Bundle, RuleBasedStateMachine, rule
@@ -36,11 +33,7 @@ class ArchiveLifecycleStateMachine(RuleBasedStateMachine):
 
         from polylogue.storage.backends.schema import _ensure_schema
 
-        self._tmpdir = tempfile.mkdtemp()
-        self._db_path = Path(self._tmpdir) / "state_machine.db"
-        self._db_path.parent.mkdir(parents=True, exist_ok=True)
-
-        self._conn = sqlite3.connect(self._db_path)
+        self._conn = sqlite3.connect(":memory:")
         self._conn.row_factory = sqlite3.Row
         _ensure_schema(self._conn)
 
@@ -127,7 +120,6 @@ class ArchiveLifecycleStateMachine(RuleBasedStateMachine):
 
     def teardown(self) -> None:
         self._conn.close()
-        shutil.rmtree(self._tmpdir, ignore_errors=True)
 
 
 TestArchiveLifecycle = ArchiveLifecycleStateMachine.TestCase


### PR DESCRIPTION
## Summary

Closes #318.
Closes #319.

Replaces the bespoke user-only output idea with a composable message-role projection that works across CLI parsing, in-memory conversation projection, streaming storage reads, stream headers, and semantic facts. Also removes the unrelated local full-verification blocker that surfaced while validating this PR.

## Problem

`--user-only` made one role projection special even though the model already has canonical roles and provider role normalization. That left an arbitrary surface where `user`, `assistant`, `tool`, `system`, and `unknown` should all be expressible through the same mechanism.

Full local verification was also not actually usable: `tests/unit/storage/test_repository_state_machine.py::TestArchiveLifecycle::runTest` spent most of its runtime recreating file-backed SQLite schemas for Hypothesis examples and could exceed practical local budgets.

## Solution

- Add `--message-role`, accepting repeated or comma-separated canonical roles with provider aliases normalized through the shared role model.
- Keep `--dialogue-only` as a shorthand for `user,assistant`, while explicit `--message-role` wins when both are supplied.
- Add shared `polylogue.lib.message_roles` helpers for canonical role filters, SQL aliases, labels, and stats keys.
- Push role filtering into streaming SQL reads and expose canonical role counts from conversation stats.
- Replace arbitrary `Conversation.user_only()` / `assistant_only()` helpers with generic `Conversation.with_roles(...)`; `dialogue_only()` now delegates to that generic projection.
- Carry effective role filters through stream semantic facts and generated CLI docs.
- Switch the archive lifecycle state-machine test to in-memory SQLite so it keeps the same lifecycle model coverage without paying multi-second file-backed schema setup per example.
- Refresh terminal and showcase help baselines for the new CLI option.

## Verification

```bash
uv run ruff check docs/cli-reference.md polylogue/cli/click_app.py polylogue/cli/click_option_groups.py polylogue/cli/query.py polylogue/cli/query_contracts.py polylogue/cli/query_output.py polylogue/cli/root_request.py polylogue/lib/conversation_runtime.py polylogue/lib/message_roles.py polylogue/lib/semantic_fact_models.py polylogue/lib/semantic_facts.py polylogue/protocols.py polylogue/storage/backends/async_sqlite_archive.py polylogue/storage/backends/queries/message_query_reads.py polylogue/storage/backends/queries/message_query_stats.py polylogue/storage/backends/query_store_archive.py polylogue/storage/repository_archive_conversations.py tests/unit/cli/test_click_app.py tests/unit/cli/test_query_exec.py tests/unit/cli/test_query_exec_laws.py tests/unit/core/test_conversation_semantics.py tests/unit/core/test_message_laws.py tests/unit/storage/test_backend.py
uv run mypy polylogue/cli/click_app.py polylogue/cli/click_option_groups.py polylogue/cli/query.py polylogue/cli/query_contracts.py polylogue/cli/query_output.py polylogue/cli/root_request.py polylogue/lib/conversation_runtime.py polylogue/lib/message_roles.py polylogue/lib/semantic_fact_models.py polylogue/lib/semantic_facts.py polylogue/protocols.py polylogue/storage/backends/async_sqlite_archive.py polylogue/storage/backends/queries/message_query_reads.py polylogue/storage/backends/queries/message_query_stats.py polylogue/storage/backends/query_store_archive.py polylogue/storage/repository_archive_conversations.py tests/unit/cli/test_click_app.py tests/unit/cli/test_query_exec.py tests/unit/cli/test_query_exec_laws.py tests/unit/core/test_conversation_semantics.py tests/unit/core/test_message_laws.py tests/unit/storage/test_backend.py
uv run pytest -q tests/unit/cli/test_click_app.py tests/unit/cli/test_query_exec.py tests/unit/cli/test_query_exec_laws.py tests/unit/core/test_conversation_semantics.py tests/unit/core/test_message_laws.py tests/unit/storage/test_backend.py
uv run devtools render-all --check
uv run devtools verify --quick
timeout 90s uv run pytest -q -n0 tests/unit/storage/test_repository_state_machine.py::TestArchiveLifecycle::runTest
uv run pytest -q tests/unit/cli/test_terminal_snapshots.py --snapshot-update
uv run devtools verify
uv run devtools verify-showcase --update
uv run devtools verify-showcase
git push
```
