### PR TITLE
refactor(devtools): share generated surface writer

### DIFF
--- a/devtools/render_agents.py
+++ b/devtools/render_agents.py
@@ -9,6 +9,7 @@ import sys
 from pathlib import Path
 
 from devtools.command_catalog import control_plane_command
+from devtools.render_support import write_if_changed
 
 INCLUDE_RE = re.compile(r"^\s*@(.+?)\s*$")
 ESCAPED_CHAR_RE = re.compile(r"\\(.)")
@@ -81,19 +82,6 @@ def render_document(*, input_path: Path, output_path: Path | None) -> str:
         f"Edit {display_input} and included files instead. -->\n\n"
     )
     return header + body
-
-
-def write_if_changed(output_path: Path, content: str) -> None:
-    try:
-        current = output_path.read_text(encoding="utf-8")
-    except FileNotFoundError:
-        current = None
-    if current == content:
-        return
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-    tmp_path = output_path.with_suffix(output_path.suffix + ".tmp")
-    tmp_path.write_text(content, encoding="utf-8")
-    tmp_path.replace(output_path)
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/devtools/render_cli_reference.py
+++ b/devtools/render_cli_reference.py
@@ -9,6 +9,7 @@ import sys
 from pathlib import Path
 
 from devtools.command_catalog import control_plane_command
+from devtools.render_support import write_if_changed
 
 SECTIONS: tuple[tuple[str, tuple[str, ...]], ...] = (
     ("Top-Level Command", ()),
@@ -55,19 +56,6 @@ def build_document(sections: list[tuple[str, str]]) -> str:
     for title, body in sections:
         parts.extend([f"## {title}", "", "```text", body, "```", ""])
     return "\n".join(parts).rstrip() + "\n"
-
-
-def write_if_changed(output_path: Path, content: str) -> None:
-    try:
-        current = output_path.read_text(encoding="utf-8")
-    except FileNotFoundError:
-        current = None
-    if current == content:
-        return
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-    tmp_path = output_path.with_suffix(output_path.suffix + ".tmp")
-    tmp_path.write_text(content, encoding="utf-8")
-    tmp_path.replace(output_path)
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/devtools/render_devtools_reference.py
+++ b/devtools/render_devtools_reference.py
@@ -12,6 +12,7 @@ from devtools.command_catalog import (
     featured_command_specs,
     grouped_command_specs,
 )
+from devtools.render_support import write_if_changed
 
 MARKER = "devtools-command-catalog"
 
@@ -79,19 +80,6 @@ def replace_marked_section(text: str, replacement: str) -> str:
         raise ValueError(f"marker block not found: {MARKER}")
     finish += len(end)
     return text[:start] + replacement + text[finish:]
-
-
-def write_if_changed(output_path: Path, content: str) -> None:
-    try:
-        current = output_path.read_text(encoding="utf-8")
-    except FileNotFoundError:
-        current = None
-    if current == content:
-        return
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-    tmp_path = output_path.with_suffix(output_path.suffix + ".tmp")
-    tmp_path.write_text(content, encoding="utf-8")
-    tmp_path.replace(output_path)
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/devtools/render_docs_surface.py
+++ b/devtools/render_docs_surface.py
@@ -15,6 +15,7 @@ from devtools.docs_surface import (
     REPO_GUIDE_ENTRIES,
     DocsEntry,
 )
+from devtools.render_support import write_if_changed
 
 README_MARKER = "docs-surface"
 GENERATED_NOTE = (
@@ -103,19 +104,6 @@ def replace_marked_section(text: str, *, marker: str, replacement: str) -> str:
         raise ValueError(f"marker block not found: {marker}")
     finish += len(end)
     return text[:start] + replacement + text[finish:]
-
-
-def write_if_changed(output_path: Path, content: str) -> None:
-    try:
-        current = output_path.read_text(encoding="utf-8")
-    except FileNotFoundError:
-        current = None
-    if current == content:
-        return
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-    tmp_path = output_path.with_suffix(output_path.suffix + ".tmp")
-    tmp_path.write_text(content, encoding="utf-8")
-    tmp_path.replace(output_path)
 
 
 def render_outputs(*, readme_path: Path, docs_readme_path: Path) -> tuple[str, str]:

--- a/devtools/render_quality_reference.py
+++ b/devtools/render_quality_reference.py
@@ -11,6 +11,7 @@ from devtools.command_catalog import control_plane_command
 from devtools.lane_models import LaneEntry
 from devtools.mutation_catalog import MutationCampaignEntry
 from devtools.quality_registry import QualityRegistry, build_quality_registry
+from devtools.render_support import write_if_changed
 from devtools.scenario_coverage import RuntimeScenarioCoverage, build_runtime_scenario_coverage
 from devtools.validation_family_models import ValidationLaneFamily
 from polylogue.scenarios import CorpusScenario, ScenarioProjectionEntry
@@ -362,19 +363,6 @@ def build_document(registry: QualityRegistry, *, runtime_coverage: RuntimeScenar
         "",
     ]
     return "\n".join(parts)
-
-
-def write_if_changed(output_path: Path, content: str) -> None:
-    try:
-        current = output_path.read_text(encoding="utf-8")
-    except FileNotFoundError:
-        current = None
-    if current == content:
-        return
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-    tmp_path = output_path.with_suffix(output_path.suffix + ".tmp")
-    tmp_path.write_text(content, encoding="utf-8")
-    tmp_path.replace(output_path)
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/devtools/render_support.py
+++ b/devtools/render_support.py
@@ -1,0 +1,19 @@
+"""Shared helpers for generated repository surfaces."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def write_if_changed(output_path: Path, content: str) -> None:
+    """Write content atomically when it differs from the current file."""
+    try:
+        current = output_path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        current = None
+    if current == content:
+        return
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = output_path.with_suffix(output_path.suffix + ".tmp")
+    tmp_path.write_text(content, encoding="utf-8")
+    tmp_path.replace(output_path)


### PR DESCRIPTION
## Summary

- Extract the duplicated generated-surface `write_if_changed()` helper into `devtools/render_support.py`.
- Update the agent, CLI reference, devtools reference, docs surface, and quality reference renderers to use the shared helper.

## Problem

The low-churn audit in #315 found five `devtools/render_*` modules carrying the same atomic write helper. That duplication is small, but it is exactly the kind of generated-surface boilerplate that should be shared instead of preserved file-by-file.

## Solution

`devtools/render_support.py` now owns the atomic write-if-changed behavior. The renderers import that helper and keep their rendering/check logic unchanged.

Ref #315

## Verification

- `uv run ruff format devtools/render_support.py devtools/render_agents.py devtools/render_cli_reference.py devtools/render_devtools_reference.py devtools/render_docs_surface.py devtools/render_quality_reference.py`
- `uv run ruff check devtools/render_support.py devtools/render_agents.py devtools/render_cli_reference.py devtools/render_devtools_reference.py devtools/render_docs_surface.py devtools/render_quality_reference.py`
- `uv run mypy devtools/render_support.py devtools/render_agents.py devtools/render_cli_reference.py devtools/render_devtools_reference.py devtools/render_docs_surface.py devtools/render_quality_reference.py`
- `uv run pytest -q tests/unit/devtools/test_render_agents.py tests/unit/devtools/test_render_cli_reference.py tests/unit/devtools/test_render_devtools_reference.py tests/unit/devtools/test_render_docs_surface.py tests/unit/devtools/test_render_quality_reference.py`
- `uv run devtools render-all --check`
- `uv run devtools verify`
- `git push -u origin feature/refactor/devtools-render-support` (pre-push `devtools verify --quick` passed)
