### PR TITLE
test: add semantic evidence runners

### DIFF
--- a/docs/verification-catalog.md
+++ b/docs/verification-catalog.md
@@ -8,10 +8,10 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 
 ## Snapshot
 
-- subjects: `8940`
-- claims: `6`
-- runner bindings: `6`
-- proof obligations: `9026`
+- subjects: `8943`
+- claims: `8`
+- runner bindings: `8`
+- proof obligations: `9029`
 
 ## Quality Checks
 
@@ -21,13 +21,16 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | `catalog.runner_trust_metadata` | `ok` | runner trust metadata is present and fresh |
 | `catalog.serious_claim_bug_classes` | `ok` | serious claims expose bug classes |
 | `catalog.serious_claim_breakers` | `ok` | serious claims expose breakers or tracked exceptions |
+| `catalog.serious_claim_adequacy` | `ok` | serious claims declare runner classes, observed facts, and staleness conditions |
 | `catalog.non_abstract_claim_subjects` | `ok` | non-abstract claims bind at least one subject |
 
 ## Subject Summary
 
 | Kind | Count |
 | --- | ---: |
+| `archive.query_law` | 1 |
 | `cli.command` | 43 |
+| `cli.json_command` | 2 |
 | `schema.annotation` | 8897 |
 
 ## Command Subjects
@@ -99,26 +102,32 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | `cli.command.help` | `serious` | `cli.help.regression`<br>`command.inventory.omission` | A hidden or broken command makes the help runner fail for that command. |
 | `cli.command.no_traceback` | `serious` | `cli.traceback.leak`<br>`operator-facing-error-regression` | A command callback or Click wiring error leaks traceback text into evidence. |
 | `cli.command.plain_mode` | `serious` | `cli.plain-mode.regression`<br>`terminal-rendering-regression` | A rich-only output path breaks the plain-mode runner comparison. |
+| `cli.command.json_envelope` | `serious` | `cli.json-envelope.regression`<br>`machine-contract.invalid-json` | A selected JSON command that emits invalid JSON or a missing success envelope breaks the claim. |
+| `archive.query.provider_filter_consistency` | `serious` | `query.provider-filter.drift`<br>`archive-count.semantic-mismatch` | A provider result outside all results, mismatched count, or divergent equivalent construction is a counterexample. |
 | `schema.values.value_closure` | `serious` | `schema.value-domain.drift`<br>`schema.privacy.enum-leak` | A generated payload outside the annotated value set is a counterexample. |
 | `schema.foreign_key.resolves` | `serious` | `schema.relationship.drift`<br>`synthetic-corpus.integrity` | A source path pointing at a missing target path breaks the relation claim. |
 | `schema.mutual_exclusion.exclusive` | `serious` | `schema.mutual-exclusion.drift`<br>`synthetic-corpus.invalid-combination` | A generated record containing two fields from the same exclusion group is a counterexample. |
 
 ## Runner Bindings
 
-| Runner Binding | Claim | Cost | Environment | Trust |
-| --- | --- | --- | --- | --- |
-| `cli-help-contract:cli.command.help` | `cli.command.help` | `static` | commands=`polylogue`; network=`none`; live_archive=`False` | `authored` by `polylogue.proof.catalog` at `2026-04-22T00:00:00+00:00` |
-| `cli-help-contract:cli.command.no_traceback` | `cli.command.no_traceback` | `static` | commands=`polylogue`; network=`none`; live_archive=`False` | `authored` by `polylogue.proof.catalog` at `2026-04-22T00:00:00+00:00` |
-| `cli-help-contract:cli.command.plain_mode` | `cli.command.plain_mode` | `static` | commands=`polylogue`; network=`none`; live_archive=`False` | `authored` by `polylogue.proof.catalog` at `2026-04-22T00:00:00+00:00` |
-| `schema-annotation-static-contract:schema.values.value_closure` | `schema.values.value_closure` | `static` | commands=—; network=`none`; live_archive=`False` | `authored` by `polylogue.proof.catalog` at `2026-04-22T00:00:00+00:00` |
-| `schema-annotation-static-contract:schema.foreign_key.resolves` | `schema.foreign_key.resolves` | `static` | commands=—; network=`none`; live_archive=`False` | `authored` by `polylogue.proof.catalog` at `2026-04-22T00:00:00+00:00` |
-| `schema-annotation-static-contract:schema.mutual_exclusion.exclusive` | `schema.mutual_exclusion.exclusive` | `static` | commands=—; network=`none`; live_archive=`False` | `authored` by `polylogue.proof.catalog` at `2026-04-22T00:00:00+00:00` |
+| Runner Binding | Claim | Evidence | Cost | Environment | Trust |
+| --- | --- | --- | --- | --- | --- |
+| `cli-help-contract:cli.command.help` | `cli.command.help` | `smoke` | `static` | commands=`polylogue`; network=`none`; live_archive=`False` | `authored` by `polylogue.proof.catalog` at `2026-04-22T00:00:00+00:00` |
+| `cli-help-contract:cli.command.no_traceback` | `cli.command.no_traceback` | `smoke` | `static` | commands=`polylogue`; network=`none`; live_archive=`False` | `authored` by `polylogue.proof.catalog` at `2026-04-22T00:00:00+00:00` |
+| `cli-plain-contract:cli.command.plain_mode` | `cli.command.plain_mode` | `structural` | `static` | commands=`polylogue`; network=`none`; live_archive=`False` | `authored` by `polylogue.proof.catalog` at `2026-04-22T00:00:00+00:00` |
+| `cli-json-envelope-contract:cli.command.json_envelope` | `cli.command.json_envelope` | `structural` | `unit` | commands=`polylogue`; network=`none`; live_archive=`False` | `authored` by `polylogue.proof.catalog` at `2026-04-22T00:00:00+00:00` |
+| `semantic-query-law-contract:archive.query.provider_filter_consistency` | `archive.query.provider_filter_consistency` | `semantic` | `unit` | commands=—; network=`none`; live_archive=`False` | `authored` by `polylogue.proof.catalog` at `2026-04-22T00:00:00+00:00` |
+| `schema-annotation-static-contract:schema.values.value_closure` | `schema.values.value_closure` | `structural` | `static` | commands=—; network=`none`; live_archive=`False` | `authored` by `polylogue.proof.catalog` at `2026-04-22T00:00:00+00:00` |
+| `schema-annotation-static-contract:schema.foreign_key.resolves` | `schema.foreign_key.resolves` | `structural` | `static` | commands=—; network=`none`; live_archive=`False` | `authored` by `polylogue.proof.catalog` at `2026-04-22T00:00:00+00:00` |
+| `schema-annotation-static-contract:schema.mutual_exclusion.exclusive` | `schema.mutual_exclusion.exclusive` | `structural` | `static` | commands=—; network=`none`; live_archive=`False` | `authored` by `polylogue.proof.catalog` at `2026-04-22T00:00:00+00:00` |
 
 ## Proof Obligations
 
 | Claim | Obligations |
 | --- | ---: |
+| `archive.query.provider_filter_consistency` | 1 |
 | `cli.command.help` | 43 |
+| `cli.command.json_envelope` | 2 |
 | `cli.command.no_traceback` | 43 |
 | `cli.command.plain_mode` | 43 |
 | `schema.foreign_key.resolves` | 7 |

--- a/polylogue/proof/__init__.py
+++ b/polylogue/proof/__init__.py
@@ -16,6 +16,7 @@ from polylogue.proof.models import (
     BreakerMetadata,
     Claim,
     EnvironmentContract,
+    EvidenceClass,
     EvidenceEnvelope,
     Kind,
     Not,
@@ -28,10 +29,19 @@ from polylogue.proof.models import (
     TrustMetadata,
     subject_query_from_payload,
 )
+from polylogue.proof.runners import (
+    SemanticQueryObservation,
+    run_cli_json_envelope_evidence,
+    run_cli_visual_evidence,
+    run_semantic_query_evidence,
+)
 from polylogue.proof.subjects import (
+    SELECTED_JSON_COMMANDS,
     SELECTED_SCHEMA_ANNOTATIONS,
     build_catalog_subjects,
     command_subjects,
+    json_command_subjects,
+    query_law_subjects,
     schema_annotation_subjects,
 )
 
@@ -42,6 +52,7 @@ __all__ = [
     "AttrIn",
     "BreakerMetadata",
     "Claim",
+    "EvidenceClass",
     "EnvironmentContract",
     "EvidenceEnvelope",
     "Kind",
@@ -49,7 +60,9 @@ __all__ = [
     "Or",
     "ProofObligation",
     "RunnerBinding",
+    "SELECTED_JSON_COMMANDS",
     "SELECTED_SCHEMA_ANNOTATIONS",
+    "SemanticQueryObservation",
     "SourceSpan",
     "SubjectQuery",
     "SubjectRef",
@@ -62,6 +75,11 @@ __all__ = [
     "compile_obligations",
     "default_claims",
     "default_runner_bindings",
+    "json_command_subjects",
+    "query_law_subjects",
+    "run_cli_json_envelope_evidence",
+    "run_cli_visual_evidence",
+    "run_semantic_query_evidence",
     "schema_annotation_subjects",
     "subject_query_from_payload",
 ]

--- a/polylogue/proof/catalog.py
+++ b/polylogue/proof/catalog.py
@@ -14,7 +14,9 @@ from polylogue.proof.models import (
     AttrEq,
     BreakerMetadata,
     Claim,
+    CostTier,
     EnvironmentContract,
+    EvidenceClass,
     Kind,
     ProofObligation,
     RunnerBinding,
@@ -138,6 +140,9 @@ def default_claims() -> tuple[Claim, ...]:
             subject_query=command_query,
             evidence_schema=_evidence_schema("help_exit_code", "help_output"),
             bug_classes=("cli.help.regression", "command.inventory.omission"),
+            runner_classes=("cli_visual",),
+            observed_facts=("help_exit_code", "help_usage_banner", "command_path"),
+            staleness_conditions=("Click command registration or help option handling changes.",),
             breaker=BreakerMetadata(
                 description="A hidden or broken command makes the help runner fail for that command.",
                 issue="#333",
@@ -150,6 +155,9 @@ def default_claims() -> tuple[Claim, ...]:
             subject_query=command_query,
             evidence_schema=_evidence_schema("stderr", "stdout"),
             bug_classes=("cli.traceback.leak", "operator-facing-error-regression"),
+            runner_classes=("cli_visual",),
+            observed_facts=("stdout", "stderr", "traceback_present", "exit_code"),
+            staleness_conditions=("Click error handling, command callbacks, or exception formatting changes.",),
             breaker=BreakerMetadata(
                 description="A command callback or Click wiring error leaks traceback text into evidence.",
                 issue="#333",
@@ -162,10 +170,50 @@ def default_claims() -> tuple[Claim, ...]:
             subject_query=command_query,
             evidence_schema=_evidence_schema("plain_stdout", "rich_stdout"),
             bug_classes=("cli.plain-mode.regression", "terminal-rendering-regression"),
+            runner_classes=("cli_visual",),
+            observed_facts=("plain_stdout", "ansi_present", "command_path"),
+            staleness_conditions=("Terminal renderer, rich/plain mode, or command output formatting changes.",),
             breaker=BreakerMetadata(
                 description="A rich-only output path breaks the plain-mode runner comparison.",
                 issue="#333",
                 command=("devtools", "render-verification-catalog", "--check"),
+            ),
+        ),
+        Claim(
+            id="cli.command.json_envelope",
+            description="Selected JSON-capable commands emit a valid machine envelope.",
+            subject_query=Kind("cli.json_command"),
+            evidence_schema=_evidence_schema("json_status", "json_result_type", "parse_error"),
+            bug_classes=("cli.json-envelope.regression", "machine-contract.invalid-json"),
+            runner_classes=("cli_json",),
+            observed_facts=("json_status", "json_result_type", "exit_code", "parse_error"),
+            staleness_conditions=(
+                "Machine-output envelope, selected JSON command list, or JSON serialization changes.",
+            ),
+            breaker=BreakerMetadata(
+                description="A selected JSON command that emits invalid JSON or a missing success envelope breaks the claim.",
+                issue="#333",
+                command=("devtools", "render-verification-catalog", "--check"),
+            ),
+        ),
+        Claim(
+            id="archive.query.provider_filter_consistency",
+            description="Provider-filter query results preserve subset, count, and equivalent-construction laws.",
+            subject_query=Kind("archive.query_law"),
+            evidence_schema=_evidence_schema(
+                "all_ids",
+                "provider_ids",
+                "provider_count",
+                "equivalent_provider_ids",
+            ),
+            bug_classes=("query.provider-filter.drift", "archive-count.semantic-mismatch"),
+            runner_classes=("semantic_query",),
+            observed_facts=("all_ids", "provider_ids", "provider_count", "equivalent_provider_ids"),
+            staleness_conditions=("Repository list/count behavior or equivalent filter construction changes.",),
+            breaker=BreakerMetadata(
+                description="A provider result outside all results, mismatched count, or divergent equivalent construction is a counterexample.",
+                issue="#333",
+                command=("pytest", "tests/unit/proof/test_evidence_runners.py"),
             ),
         ),
         Claim(
@@ -174,6 +222,11 @@ def default_claims() -> tuple[Claim, ...]:
             subject_query=values_query,
             evidence_schema=_evidence_schema("values", "observed_values"),
             bug_classes=("schema.value-domain.drift", "schema.privacy.enum-leak"),
+            runner_classes=("schema_static",),
+            observed_facts=("values", "observed_values", "schema_path"),
+            staleness_conditions=(
+                "Schema annotation grammar, synthetic corpus generation, or provider schema changes.",
+            ),
             breaker=BreakerMetadata(
                 description="A generated payload outside the annotated value set is a counterexample.",
                 issue="#332",
@@ -186,6 +239,11 @@ def default_claims() -> tuple[Claim, ...]:
             subject_query=foreign_key_query,
             evidence_schema=_evidence_schema("source_path", "target_path"),
             bug_classes=("schema.relationship.drift", "synthetic-corpus.integrity"),
+            runner_classes=("schema_static",),
+            observed_facts=("source_path", "target_path", "schema_element"),
+            staleness_conditions=(
+                "Schema relationship annotations or synthetic corpus relationship generation changes.",
+            ),
             breaker=BreakerMetadata(
                 description="A source path pointing at a missing target path breaks the relation claim.",
                 issue="#332",
@@ -198,6 +256,9 @@ def default_claims() -> tuple[Claim, ...]:
             subject_query=mutual_exclusion_query,
             evidence_schema=_evidence_schema("parent", "fields"),
             bug_classes=("schema.mutual-exclusion.drift", "synthetic-corpus.invalid-combination"),
+            runner_classes=("schema_static",),
+            observed_facts=("parent", "fields", "co_populated_fields"),
+            staleness_conditions=("Schema mutual-exclusion annotations or generated payload construction changes.",),
             breaker=BreakerMetadata(
                 description="A generated record containing two fields from the same exclusion group is a counterexample.",
                 issue="#332",
@@ -211,10 +272,47 @@ def default_runner_bindings(claims: Iterable[Claim]) -> tuple[RunnerBinding, ...
     """Bind every default claim to its first static runner contract."""
     bindings: list[RunnerBinding] = []
     for claim in claims:
-        if claim.id.startswith("cli.command."):
-            bindings.append(_runner_binding(claim, runner="cli-help-contract", required_commands=("polylogue",)))
+        if claim.id in {"cli.command.help", "cli.command.no_traceback"}:
+            bindings.append(
+                _runner_binding(
+                    claim,
+                    runner="cli-help-contract",
+                    evidence_class="smoke",
+                    required_commands=("polylogue",),
+                )
+            )
+        elif claim.id == "cli.command.plain_mode":
+            bindings.append(
+                _runner_binding(
+                    claim,
+                    runner="cli-plain-contract",
+                    evidence_class="structural",
+                    required_commands=("polylogue",),
+                )
+            )
+        elif claim.id == "cli.command.json_envelope":
+            bindings.append(
+                _runner_binding(
+                    claim,
+                    runner="cli-json-envelope-contract",
+                    evidence_class="structural",
+                    cost_tier="unit",
+                    required_commands=("polylogue",),
+                )
+            )
+        elif claim.id.startswith("archive.query."):
+            bindings.append(
+                _runner_binding(
+                    claim,
+                    runner="semantic-query-law-contract",
+                    evidence_class="semantic",
+                    cost_tier="unit",
+                )
+            )
         elif claim.id.startswith("schema."):
-            bindings.append(_runner_binding(claim, runner="schema-annotation-static-contract"))
+            bindings.append(
+                _runner_binding(claim, runner="schema-annotation-static-contract", evidence_class="structural")
+            )
     return tuple(bindings)
 
 
@@ -227,6 +325,7 @@ def catalog_quality_checks(catalog: VerificationCatalog, *, now: datetime | None
         _stale_trust_metadata_check(catalog.runner_bindings, now=now_value),
         _missing_serious_bug_classes_check(catalog.claims),
         _missing_serious_breakers_check(catalog.claims),
+        _missing_serious_claim_adequacy_check(catalog.claims),
         _zero_subject_claims_check(catalog.claims, obligations_by_claim),
     ]
     return tuple(checks)
@@ -255,19 +354,22 @@ def _runner_binding(
     claim: Claim,
     *,
     runner: str,
+    evidence_class: EvidenceClass,
+    cost_tier: CostTier = "static",
     required_commands: tuple[str, ...] = (),
 ) -> RunnerBinding:
     return RunnerBinding(
         id=f"{runner}:{claim.id}",
         claim_id=claim.id,
         runner=runner,
-        cost_tier="static",
+        evidence_class=evidence_class,
+        cost_tier=cost_tier,
         freshness_policy="Refresh when the subject compiler, claim metadata, or runner contract changes.",
         environment=EnvironmentContract(
             required_commands=required_commands,
             network="none",
             live_archive=False,
-            notes=("No live archive dependency in the #192 catalog slice.",),
+            notes=("No live archive dependency; evidence is generated from command help or seeded test archives.",),
         ),
         trust=TrustMetadata(
             producer="polylogue.proof.catalog",
@@ -327,6 +429,30 @@ def _missing_serious_breakers_check(claims: tuple[Claim, ...]) -> OutcomeCheck:
         missing,
         ok_summary="serious claims expose breakers or tracked exceptions",
         error_summary="serious claims missing breakers or tracked exceptions",
+    )
+
+
+def _missing_serious_claim_adequacy_check(claims: tuple[Claim, ...]) -> OutcomeCheck:
+    missing: list[str] = []
+    for claim in claims:
+        if claim.severity != "serious":
+            continue
+        missing_fields = [
+            field_name
+            for field_name, values in (
+                ("runner_classes", claim.runner_classes),
+                ("observed_facts", claim.observed_facts),
+                ("staleness_conditions", claim.staleness_conditions),
+            )
+            if not values
+        ]
+        if missing_fields:
+            missing.append(f"{claim.id}: {', '.join(missing_fields)}")
+    return _check(
+        "catalog.serious_claim_adequacy",
+        missing,
+        ok_summary="serious claims declare runner classes, observed facts, and staleness conditions",
+        error_summary="serious claims missing adequacy metadata",
     )
 
 

--- a/polylogue/proof/models.py
+++ b/polylogue/proof/models.py
@@ -19,6 +19,7 @@ from polylogue.lib.outcomes import OutcomeStatus
 
 ClaimSeverity = Literal["info", "serious"]
 CostTier = Literal["static", "unit", "integration", "live"]
+EvidenceClass = Literal["smoke", "semantic", "structural", "trace", "performance", "workflow"]
 NetworkPolicy = Literal["none", "optional", "required"]
 TrustLevel = Literal["authored", "generated", "external"]
 
@@ -254,6 +255,9 @@ class Claim:
     bug_classes: tuple[str, ...] = ()
     breaker: BreakerMetadata | None = None
     tracked_exception: str | None = None
+    runner_classes: tuple[str, ...] = ()
+    observed_facts: tuple[str, ...] = ()
+    staleness_conditions: tuple[str, ...] = ()
     severity: ClaimSeverity = "serious"
     abstract: bool = False
 
@@ -270,6 +274,9 @@ class Claim:
                 "bug_classes": list(self.bug_classes),
                 "breaker": self.breaker.to_payload() if self.breaker is not None else None,
                 "tracked_exception": self.tracked_exception,
+                "runner_classes": list(self.runner_classes),
+                "observed_facts": list(self.observed_facts),
+                "staleness_conditions": list(self.staleness_conditions),
                 "severity": self.severity,
                 "abstract": self.abstract,
             }
@@ -338,6 +345,7 @@ class RunnerBinding:
     id: str
     claim_id: str
     runner: str
+    evidence_class: EvidenceClass
     cost_tier: CostTier
     freshness_policy: str
     environment: EnvironmentContract
@@ -349,6 +357,7 @@ class RunnerBinding:
                 "id": self.id,
                 "claim_id": self.claim_id,
                 "runner": self.runner,
+                "evidence_class": self.evidence_class,
                 "cost_tier": self.cost_tier,
                 "freshness_policy": self.freshness_policy,
                 "environment": self.environment.to_payload(),
@@ -466,6 +475,7 @@ __all__ = [
     "CostTier",
     "EnvironmentContract",
     "EvidenceEnvelope",
+    "EvidenceClass",
     "Kind",
     "NetworkPolicy",
     "Not",

--- a/polylogue/proof/rendering.py
+++ b/polylogue/proof/rendering.py
@@ -130,8 +130,8 @@ def _render_claims(claims: tuple[Claim, ...]) -> list[str]:
 
 def _render_runner_bindings(runners: tuple[RunnerBinding, ...]) -> list[str]:
     lines = [
-        "| Runner Binding | Claim | Cost | Environment | Trust |",
-        "| --- | --- | --- | --- | --- |",
+        "| Runner Binding | Claim | Evidence | Cost | Environment | Trust |",
+        "| --- | --- | --- | --- | --- | --- |",
     ]
     for runner in runners:
         env_bits = [
@@ -141,7 +141,7 @@ def _render_runner_bindings(runners: tuple[RunnerBinding, ...]) -> list[str]:
         ]
         trust = f"`{runner.trust.level}` by `{runner.trust.producer}` at `{runner.trust.reviewed_at}`"
         lines.append(
-            f"| `{runner.id}` | `{runner.claim_id}` | `{runner.cost_tier}` | {'; '.join(env_bits)} | {trust} |"
+            f"| `{runner.id}` | `{runner.claim_id}` | `{runner.evidence_class}` | `{runner.cost_tier}` | {'; '.join(env_bits)} | {trust} |"
         )
     return lines
 

--- a/polylogue/proof/runners.py
+++ b/polylogue/proof/runners.py
@@ -1,0 +1,423 @@
+"""Executable proof evidence runners.
+
+The runners in this module are deliberately small adapters: they evaluate one
+obligation against already-selected command or semantic observations and return
+an `EvidenceEnvelope`. They do not decide which obligations exist.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+import click
+from click.testing import CliRunner, Result
+
+from polylogue.lib.json import JSONDocument, require_json_document
+from polylogue.lib.outcomes import OutcomeStatus
+from polylogue.proof.models import EvidenceEnvelope, ProofObligation, SourceSpan, TrustMetadata
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]|\x1b\].*?\x07|\x1b\[.*?m")
+_TRACEBACK_MARKER = "Traceback (most recent call last)"
+_REVIEWED_AT = "2026-04-22T00:00:00+00:00"
+_OUTPUT_SAMPLE_LIMIT = 1_000
+
+
+@dataclass(frozen=True, slots=True)
+class SemanticQueryObservation:
+    """Observed facts for a provider-filter semantic query law."""
+
+    provider: str
+    all_ids: tuple[str, ...]
+    provider_ids: tuple[str, ...]
+    provider_count: int
+    equivalent_provider_ids: tuple[str, ...]
+    query_name: str = "provider-filter"
+    surface_names: tuple[str, ...] = ()
+
+
+def run_cli_visual_evidence(
+    obligation: ProofObligation,
+    *,
+    args: Sequence[str] | None = None,
+    env: Mapping[str, str] | None = None,
+    root_command: click.Command | None = None,
+) -> EvidenceEnvelope:
+    """Run a help/no-traceback/plain-mode CLI obligation."""
+    if obligation.claim.id == "cli.command.help":
+        return _run_cli_help_evidence(obligation, args=args, env=env, root_command=root_command)
+    if obligation.claim.id == "cli.command.no_traceback":
+        return _run_cli_no_traceback_evidence(obligation, args=args, env=env, root_command=root_command)
+    if obligation.claim.id == "cli.command.plain_mode":
+        return _run_cli_plain_mode_evidence(obligation, args=args, env=env, root_command=root_command)
+    raise ValueError(f"unsupported CLI visual claim: {obligation.claim.id}")
+
+
+def run_cli_json_envelope_evidence(
+    obligation: ProofObligation,
+    *,
+    args: Sequence[str] | None = None,
+    env: Mapping[str, str] | None = None,
+    root_command: click.Command | None = None,
+) -> EvidenceEnvelope:
+    """Run a JSON-capable command and verify the success envelope shape."""
+    command_args = tuple(args) if args is not None else _json_args_for_subject(obligation)
+    result = _invoke_cli(command_args, env=env, root_command=root_command)
+    parsed, parse_error = _parse_json_object(result.output)
+    json_status = parsed.get("status") if parsed is not None else None
+    json_result = parsed.get("result") if parsed is not None else None
+    observed_state = _cli_result_state(
+        result,
+        command_args=command_args,
+        extra={
+            "json_status": json_status,
+            "json_result_type": type(json_result).__name__ if json_result is not None else None,
+            "parse_error": parse_error,
+            "parsed_keys": sorted(parsed) if parsed is not None else [],
+        },
+    )
+    expected_law = "command exits zero and emits a JSON object with status=ok and object result"
+    ok = result.exit_code == 0 and parse_error is None and json_status == "ok" and isinstance(json_result, dict)
+    evidence = _evidence_payload(
+        obligation,
+        runner_class="cli_json",
+        expected_law=expected_law,
+        observed_state=observed_state,
+    )
+    evidence["json_status"] = json_status
+    evidence["json_result_type"] = type(json_result).__name__ if json_result is not None else None
+    evidence["parse_error"] = parse_error
+    return _build_envelope(
+        obligation,
+        status=OutcomeStatus.OK if ok else OutcomeStatus.ERROR,
+        evidence=evidence,
+        expected_law=expected_law,
+        observed_state=observed_state,
+        reproducer=("polylogue", *command_args),
+        provenance=obligation.subject.source_span,
+        producer="polylogue.proof.runners.cli_json",
+    )
+
+
+def run_semantic_query_evidence(
+    obligation: ProofObligation,
+    observation: SemanticQueryObservation,
+    *,
+    reproducer: tuple[str, ...] = ("pytest", "tests/unit/proof/test_evidence_runners.py"),
+) -> EvidenceEnvelope:
+    """Verify provider-filter query laws from observed semantic facts."""
+    all_ids = _sorted_unique(observation.all_ids)
+    provider_ids = _sorted_unique(observation.provider_ids)
+    equivalent_provider_ids = _sorted_unique(observation.equivalent_provider_ids)
+    law_results: JSONDocument = {
+        "provider_subset": set(provider_ids).issubset(set(all_ids)),
+        "provider_count_matches_list": observation.provider_count == len(provider_ids),
+        "equivalent_provider_filter_constructions": equivalent_provider_ids == provider_ids,
+    }
+    observed_state: JSONDocument = {
+        "query_name": observation.query_name,
+        "provider": observation.provider,
+        "all_ids": list(all_ids),
+        "provider_ids": list(provider_ids),
+        "provider_count": observation.provider_count,
+        "equivalent_provider_ids": list(equivalent_provider_ids),
+        "surface_names": list(observation.surface_names),
+        "law_results": law_results,
+    }
+    expected_law = (
+        "provider-filter ids are a subset of all ids, count(provider) equals len(list(provider)), "
+        "and equivalent provider-filter constructions return identical ids"
+    )
+    evidence = _evidence_payload(
+        obligation,
+        runner_class="semantic_query",
+        expected_law=expected_law,
+        observed_state=observed_state,
+    )
+    evidence["all_ids"] = list(all_ids)
+    evidence["provider_ids"] = list(provider_ids)
+    evidence["provider_count"] = observation.provider_count
+    evidence["equivalent_provider_ids"] = list(equivalent_provider_ids)
+    return _build_envelope(
+        obligation,
+        status=OutcomeStatus.OK if all(law_results.values()) else OutcomeStatus.ERROR,
+        evidence=evidence,
+        expected_law=expected_law,
+        observed_state=observed_state,
+        reproducer=reproducer,
+        provenance=obligation.subject.source_span,
+        producer="polylogue.proof.runners.semantic_query",
+    )
+
+
+def _run_cli_help_evidence(
+    obligation: ProofObligation,
+    *,
+    args: Sequence[str] | None,
+    env: Mapping[str, str] | None,
+    root_command: click.Command | None,
+) -> EvidenceEnvelope:
+    command_args = tuple(args) if args is not None else _help_args_for_subject(obligation)
+    result = _invoke_cli(command_args, env=env, root_command=root_command)
+    observed_state = _cli_result_state(
+        result,
+        command_args=command_args,
+        extra={"help_usage_banner": "Usage:" in result.output},
+    )
+    expected_law = "help command exits zero and renders a Usage banner"
+    ok = result.exit_code == 0 and "Usage:" in result.output
+    evidence = _evidence_payload(
+        obligation,
+        runner_class="cli_visual",
+        expected_law=expected_law,
+        observed_state=observed_state,
+    )
+    evidence["help_exit_code"] = result.exit_code
+    evidence["help_output"] = result.output[:_OUTPUT_SAMPLE_LIMIT]
+    return _build_envelope(
+        obligation,
+        status=OutcomeStatus.OK if ok else OutcomeStatus.ERROR,
+        evidence=evidence,
+        expected_law=expected_law,
+        observed_state=observed_state,
+        reproducer=("polylogue", *command_args),
+        provenance=obligation.subject.source_span,
+        producer="polylogue.proof.runners.cli_visual",
+    )
+
+
+def _run_cli_no_traceback_evidence(
+    obligation: ProofObligation,
+    *,
+    args: Sequence[str] | None,
+    env: Mapping[str, str] | None,
+    root_command: click.Command | None,
+) -> EvidenceEnvelope:
+    command_args = tuple(args) if args is not None else _help_args_for_subject(obligation)
+    result = _invoke_cli(command_args, env=env, root_command=root_command)
+    traceback_present = _TRACEBACK_MARKER in result.output
+    observed_state = _cli_result_state(
+        result,
+        command_args=command_args,
+        extra={"traceback_present": traceback_present},
+    )
+    expected_law = "command output does not contain a Python traceback"
+    evidence = _evidence_payload(
+        obligation,
+        runner_class="cli_visual",
+        expected_law=expected_law,
+        observed_state=observed_state,
+    )
+    evidence["stdout"] = _stdout(result)[:_OUTPUT_SAMPLE_LIMIT]
+    evidence["stderr"] = _stderr(result)[:_OUTPUT_SAMPLE_LIMIT]
+    return _build_envelope(
+        obligation,
+        status=OutcomeStatus.ERROR if traceback_present else OutcomeStatus.OK,
+        evidence=evidence,
+        expected_law=expected_law,
+        observed_state=observed_state,
+        reproducer=("polylogue", *command_args),
+        provenance=obligation.subject.source_span,
+        producer="polylogue.proof.runners.cli_visual",
+    )
+
+
+def _run_cli_plain_mode_evidence(
+    obligation: ProofObligation,
+    *,
+    args: Sequence[str] | None,
+    env: Mapping[str, str] | None,
+    root_command: click.Command | None,
+) -> EvidenceEnvelope:
+    plain_args = tuple(args) if args is not None else _plain_help_args_for_subject(obligation)
+    rich_args = _without_plain_flag(plain_args)
+    runner_env = {"POLYLOGUE_FORCE_PLAIN": "1", **dict(env or {})}
+    plain_result = _invoke_cli(plain_args, env=runner_env, root_command=root_command)
+    rich_result = _invoke_cli(rich_args, env=env, root_command=root_command)
+    ansi_present = bool(_ANSI_RE.search(plain_result.output))
+    observed_state = _cli_result_state(
+        plain_result,
+        command_args=plain_args,
+        extra={
+            "ansi_present": ansi_present,
+            "rich_exit_code": rich_result.exit_code,
+            "rich_stdout_sample": _stdout(rich_result)[:_OUTPUT_SAMPLE_LIMIT],
+        },
+    )
+    expected_law = "plain-mode command output does not contain ANSI escape sequences"
+    evidence = _evidence_payload(
+        obligation,
+        runner_class="cli_visual",
+        expected_law=expected_law,
+        observed_state=observed_state,
+    )
+    evidence["plain_stdout"] = _stdout(plain_result)[:_OUTPUT_SAMPLE_LIMIT]
+    evidence["rich_stdout"] = _stdout(rich_result)[:_OUTPUT_SAMPLE_LIMIT]
+    return _build_envelope(
+        obligation,
+        status=OutcomeStatus.ERROR if ansi_present else OutcomeStatus.OK,
+        evidence=evidence,
+        expected_law=expected_law,
+        observed_state=observed_state,
+        reproducer=("polylogue", *plain_args),
+        provenance=obligation.subject.source_span,
+        producer="polylogue.proof.runners.cli_visual",
+    )
+
+
+def _invoke_cli(
+    args: Sequence[str],
+    *,
+    env: Mapping[str, str] | None,
+    root_command: click.Command | None,
+) -> Result:
+    if root_command is None:
+        from polylogue.cli.click_app import cli
+
+        root_command = cli
+    runner = CliRunner(env=dict(env or {}))
+    return runner.invoke(root_command, list(args), catch_exceptions=True)
+
+
+def _help_args_for_subject(obligation: ProofObligation) -> tuple[str, ...]:
+    command_path = _command_path_for_subject(obligation)
+    return (*command_path, "--help") if command_path else ("--help",)
+
+
+def _plain_help_args_for_subject(obligation: ProofObligation) -> tuple[str, ...]:
+    return ("--plain", *_help_args_for_subject(obligation))
+
+
+def _json_args_for_subject(obligation: ProofObligation) -> tuple[str, ...]:
+    value = obligation.subject.attrs.get("json_args")
+    if isinstance(value, list) and all(isinstance(item, str) for item in value):
+        return tuple(str(item) for item in value)
+    command_path = _command_path_for_subject(obligation)
+    return ("--plain", *command_path, "--json")
+
+
+def _command_path_for_subject(obligation: ProofObligation) -> tuple[str, ...]:
+    value = obligation.subject.attrs.get("command_path")
+    if isinstance(value, list) and all(isinstance(item, str) for item in value):
+        return tuple(str(item) for item in value)
+    return ()
+
+
+def _without_plain_flag(args: Sequence[str]) -> tuple[str, ...]:
+    filtered = tuple(arg for arg in args if arg != "--plain")
+    return filtered or ("--help",)
+
+
+def _parse_json_object(output: str) -> tuple[JSONDocument | None, str | None]:
+    lines = output.strip().splitlines()
+    for index, line in enumerate(lines):
+        if not line.strip().startswith("{"):
+            continue
+        try:
+            parsed = json.loads("\n".join(lines[index:]))
+            return require_json_document(parsed, context="CLI JSON envelope"), None
+        except (json.JSONDecodeError, TypeError) as exc:
+            return None, str(exc)
+    return None, "no JSON object found in output"
+
+
+def _cli_result_state(
+    result: Result,
+    *,
+    command_args: Sequence[str],
+    extra: Mapping[str, object],
+) -> JSONDocument:
+    payload: dict[str, Any] = {
+        "command_args": list(command_args),
+        "exit_code": result.exit_code,
+        "exception_type": type(result.exception).__name__ if result.exception is not None else None,
+        "stdout_sample": _stdout(result)[:_OUTPUT_SAMPLE_LIMIT],
+        "stderr_sample": _stderr(result)[:_OUTPUT_SAMPLE_LIMIT],
+    }
+    payload.update(extra)
+    return require_json_document(payload, context="CLI observed state")
+
+
+def _evidence_payload(
+    obligation: ProofObligation,
+    *,
+    runner_class: str,
+    expected_law: str,
+    observed_state: JSONDocument,
+) -> JSONDocument:
+    return {
+        "subject_id": obligation.subject.id,
+        "claim_id": obligation.claim.id,
+        "runner_id": obligation.runner.id,
+        "runner_class": runner_class,
+        "evidence_class": obligation.runner.evidence_class,
+        "expected_law": expected_law,
+        "observed_state": observed_state,
+    }
+
+
+def _build_envelope(
+    obligation: ProofObligation,
+    *,
+    status: OutcomeStatus,
+    evidence: JSONDocument,
+    expected_law: str,
+    observed_state: JSONDocument,
+    reproducer: tuple[str, ...],
+    provenance: SourceSpan | None,
+    producer: str,
+) -> EvidenceEnvelope:
+    counterexample: JSONDocument | None = None
+    if status is OutcomeStatus.ERROR:
+        counterexample = {
+            "subject_id": obligation.subject.id,
+            "claim_id": obligation.claim.id,
+            "runner_id": obligation.runner.id,
+            "observed_state": observed_state,
+            "expected_law": expected_law,
+            "reproducer": list(reproducer),
+        }
+    return EvidenceEnvelope.build(
+        obligation_id=obligation.id,
+        status=status,
+        evidence=evidence,
+        counterexample=counterexample,
+        reproducer=reproducer,
+        environment={
+            "runner": obligation.runner.runner,
+            "evidence_class": obligation.runner.evidence_class,
+            "cost_tier": obligation.runner.cost_tier,
+        },
+        provenance=provenance,
+        trust=TrustMetadata(
+            producer=producer,
+            reviewed_at=_REVIEWED_AT,
+            level="generated",
+            privacy="repo-local command metadata or seeded fixture ids only",
+        ),
+    )
+
+
+def _stdout(result: Result) -> str:
+    value = getattr(result, "stdout", result.output)
+    return value if isinstance(value, str) else result.output
+
+
+def _stderr(result: Result) -> str:
+    value = getattr(result, "stderr", "")
+    return value if isinstance(value, str) else ""
+
+
+def _sorted_unique(values: Sequence[str]) -> tuple[str, ...]:
+    return tuple(sorted(set(values)))
+
+
+__all__ = [
+    "SemanticQueryObservation",
+    "run_cli_json_envelope_evidence",
+    "run_cli_visual_evidence",
+    "run_semantic_query_evidence",
+]

--- a/polylogue/proof/subjects.py
+++ b/polylogue/proof/subjects.py
@@ -19,6 +19,7 @@ SELECTED_SCHEMA_ANNOTATIONS: tuple[str, ...] = (
     "x-polylogue-foreign-keys",
     "x-polylogue-mutually-exclusive",
 )
+SELECTED_JSON_COMMANDS: tuple[tuple[str, ...], ...] = (("doctor",), ("tags",))
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _SCHEMA_COMPOSITE_KEYWORDS = ("anyOf", "oneOf", "allOf")
@@ -68,6 +69,62 @@ def command_subjects(root_command: click.Command | None = None) -> tuple[Subject
     for command_path in iter_command_paths(root_command, include_root=True):
         subjects.append(_command_subject(command_path))
     return tuple(sorted(subjects, key=lambda subject: subject.id))
+
+
+def json_command_subjects(
+    root_command: click.Command | None = None,
+    *,
+    selected_paths: Iterable[tuple[str, ...]] = SELECTED_JSON_COMMANDS,
+) -> tuple[SubjectRef, ...]:
+    """Compile the selected JSON-capable commands into proof subjects."""
+    if root_command is None:
+        from polylogue.cli.click_app import cli
+
+        root_command = cli
+
+    selected = set(selected_paths)
+    subjects: list[SubjectRef] = []
+    for command_path in iter_command_paths(root_command, include_root=False):
+        if command_path.path not in selected:
+            continue
+        command_id = f"polylogue {' '.join(command_path.path)} --json"
+        attrs = _json_document(
+            {
+                "command_path": list(command_path.path),
+                "display_name": f"{command_path.display_name} --json",
+                "json_args": ["--plain", *command_path.path, "--json"],
+            }
+        )
+        subjects.append(
+            SubjectRef(
+                kind="cli.json_command",
+                id=command_id,
+                attrs=attrs,
+                source_span=_command_source_span(command_path.command, fallback_symbol=command_id),
+            )
+        )
+    return tuple(sorted(subjects, key=lambda subject: subject.id))
+
+
+def query_law_subjects() -> tuple[SubjectRef, ...]:
+    """Compile stable archive-query laws used by semantic evidence runners."""
+    return (
+        SubjectRef(
+            kind="archive.query_law",
+            id="archive.query_law.provider_filter.codex",
+            attrs=_json_document(
+                {
+                    "provider": "codex",
+                    "laws": [
+                        "provider_subset",
+                        "provider_count_matches_list",
+                        "equivalent_provider_filter_constructions",
+                    ],
+                }
+            ),
+            source_span=SourceSpan(path="polylogue/proof/subjects.py", symbol="query_law_subjects"),
+        ),
+    )
 
 
 def _command_subject(command_path: CommandPath) -> SubjectRef:
@@ -126,7 +183,7 @@ def schema_annotation_subjects(
 
 def build_catalog_subjects() -> tuple[SubjectRef, ...]:
     """Compile all subjects included in the first proof-catalog slice."""
-    return (*command_subjects(), *schema_annotation_subjects())
+    return (*command_subjects(), *json_command_subjects(), *query_law_subjects(), *schema_annotation_subjects())
 
 
 def _dedupe(subjects: Iterable[SubjectRef]) -> Iterator[SubjectRef]:
@@ -323,7 +380,10 @@ def _json_document(items: dict[str, object]) -> JSONDocument:
 
 __all__ = [
     "SELECTED_SCHEMA_ANNOTATIONS",
+    "SELECTED_JSON_COMMANDS",
     "build_catalog_subjects",
     "command_subjects",
+    "json_command_subjects",
+    "query_law_subjects",
     "schema_annotation_subjects",
 ]

--- a/tests/unit/cli/test_deterministic_output.py
+++ b/tests/unit/cli/test_deterministic_output.py
@@ -24,6 +24,9 @@ from click.testing import CliRunner
 
 from polylogue.cli.click_app import cli
 from polylogue.lib.outcomes import OutcomeCheck, OutcomeStatus
+from polylogue.proof.catalog import build_verification_catalog
+from polylogue.proof.models import ProofObligation
+from polylogue.proof.runners import run_cli_visual_evidence
 from polylogue.scenarios import polylogue_execution
 from polylogue.schemas.audit_models import AuditReport
 from polylogue.schemas.verification_models import ArtifactProofReport, ProviderArtifactProof
@@ -64,6 +67,16 @@ def _result_payload(data: JSONEnvelope) -> JSONEnvelope:
 def _has_ansi(text: str) -> bool:
     """Return True if text contains ANSI escape codes."""
     return bool(_ANSI_RE.search(text))
+
+
+def _plain_mode_obligation(args: list[str]) -> ProofObligation:
+    command_path = tuple(arg for arg in args if arg not in {"--plain", "--help"})
+    subject_id = "polylogue" if not command_path else f"polylogue {' '.join(command_path)}"
+    catalog = build_verification_catalog()
+    for obligation in catalog.obligations:
+        if obligation.claim.id == "cli.command.plain_mode" and obligation.subject.id == subject_id:
+            return obligation
+    raise AssertionError(f"missing plain-mode obligation for {args!r}")
 
 
 # ---------------------------------------------------------------------------
@@ -235,6 +248,8 @@ class TestPlainModeNoAnsi:
         result = runner.invoke(cli, args, catch_exceptions=True)
         # Commands may fail (e.g., no workspace) but output must be ANSI-free
         assert not _has_ansi(result.output), f"ANSI codes found in output for {args!r}:\n{result.output[:200]}"
+        evidence = run_cli_visual_evidence(_plain_mode_obligation(args), args=args)
+        assert evidence.status is OutcomeStatus.OK
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/devtools/test_render_verification_catalog.py
+++ b/tests/unit/devtools/test_render_verification_catalog.py
@@ -34,11 +34,15 @@ def _small_catalog() -> VerificationCatalog:
         evidence_schema={"type": "object"},
         bug_classes=("cli.help.regression",),
         breaker=BreakerMetadata("help failure"),
+        runner_classes=("cli_visual",),
+        observed_facts=("help_exit_code",),
+        staleness_conditions=("command registration changes",),
     )
     runner = RunnerBinding(
         id="runner:cli.command.help",
         claim_id=claim.id,
         runner="static",
+        evidence_class="smoke",
         cost_tier="static",
         freshness_policy="test",
         environment=EnvironmentContract(required_commands=("polylogue",)),

--- a/tests/unit/proof/test_catalog.py
+++ b/tests/unit/proof/test_catalog.py
@@ -27,13 +27,18 @@ def test_default_catalog_compiles_first_vertical_slice() -> None:
         "cli.command.help",
         "cli.command.no_traceback",
         "cli.command.plain_mode",
+        "cli.command.json_envelope",
+        "archive.query.provider_filter_consistency",
         "schema.values.value_closure",
         "schema.foreign_key.resolves",
         "schema.mutual_exclusion.exclusive",
     }
     assert catalog.subjects_by_kind()["cli.command"] >= 1
+    assert catalog.subjects_by_kind()["cli.json_command"] >= 1
+    assert catalog.subjects_by_kind()["archive.query_law"] == 1
     assert catalog.subjects_by_kind()["schema.annotation"] >= 1
     assert {runner.claim_id for runner in catalog.runner_bindings} == {claim.id for claim in catalog.claims}
+    assert {"smoke", "semantic", "structural"}.issubset({runner.evidence_class for runner in catalog.runner_bindings})
     assert all(check.status is OutcomeStatus.OK for check in catalog.quality_checks)
 
 
@@ -70,6 +75,7 @@ def test_catalog_self_quality_exposes_catalog_contract_failures() -> None:
         id="runner:claim",
         claim_id="claim",
         runner="static",
+        evidence_class="structural",
         cost_tier="static",
         freshness_policy="test",
         environment=EnvironmentContract(),
@@ -92,6 +98,9 @@ def test_catalog_self_quality_exposes_catalog_contract_failures() -> None:
         evidence_schema={"type": "object"},
         bug_classes=("bug",),
         tracked_exception="#999",
+        runner_classes=("static",),
+        observed_facts=("fact",),
+        staleness_conditions=("condition",),
     )
     obligations = compile_obligations((subject,), (claim, zero_subject_claim), (stale_runner,))
     catalog = VerificationCatalog(
@@ -109,4 +118,5 @@ def test_catalog_self_quality_exposes_catalog_contract_failures() -> None:
     assert checks["catalog.runner_trust_metadata"].status is OutcomeStatus.ERROR
     assert checks["catalog.serious_claim_bug_classes"].status is OutcomeStatus.ERROR
     assert checks["catalog.serious_claim_breakers"].status is OutcomeStatus.ERROR
+    assert checks["catalog.serious_claim_adequacy"].status is OutcomeStatus.ERROR
     assert checks["catalog.non_abstract_claim_subjects"].status is OutcomeStatus.ERROR

--- a/tests/unit/proof/test_evidence_runners.py
+++ b/tests/unit/proof/test_evidence_runners.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+
+import pytest
+
+from polylogue.lib.outcomes import OutcomeStatus
+from polylogue.proof.catalog import build_verification_catalog
+from polylogue.proof.models import EvidenceEnvelope, ProofObligation
+from polylogue.proof.runners import (
+    SemanticQueryObservation,
+    run_cli_json_envelope_evidence,
+    run_cli_visual_evidence,
+    run_semantic_query_evidence,
+)
+from tests.infra.archive_scenarios import ArchiveScenario, ScenarioMessage, seed_workspace_scenarios
+from tests.infra.query_cases import ArchiveQueryCase
+from tests.infra.surfaces import ArchiveSurfaceSet, build_archive_surface_set
+
+
+def _obligation(claim_id: str, *, subject_id: str | None = None) -> ProofObligation:
+    catalog = build_verification_catalog()
+    for obligation in catalog.obligations:
+        if obligation.claim.id != claim_id:
+            continue
+        if subject_id is not None and obligation.subject.id != subject_id:
+            continue
+        return obligation
+    raise AssertionError(f"missing obligation for claim={claim_id!r} subject={subject_id!r}")
+
+
+def test_cli_help_runner_emits_ok_evidence() -> None:
+    obligation = _obligation("cli.command.help", subject_id="polylogue doctor")
+
+    envelope = run_cli_visual_evidence(obligation)
+
+    assert envelope.status is OutcomeStatus.OK
+    assert envelope.evidence["subject_id"] == "polylogue doctor"
+    assert envelope.evidence["runner_class"] == "cli_visual"
+    assert envelope.evidence["help_exit_code"] == 0
+    assert envelope.counterexample is None
+
+
+def test_cli_json_envelope_runner_emits_ok_evidence(cli_workspace: Mapping[str, Path]) -> None:
+    obligation = _obligation("cli.command.json_envelope", subject_id="polylogue doctor --json")
+
+    envelope = run_cli_json_envelope_evidence(obligation)
+
+    assert cli_workspace["db_path"].exists()
+    assert envelope.status is OutcomeStatus.OK
+    assert envelope.evidence["runner_class"] == "cli_json"
+    assert envelope.evidence["json_status"] == "ok"
+    assert envelope.counterexample is None
+
+
+@pytest.mark.asyncio()
+async def test_semantic_query_law_runner_emits_ok_evidence(workspace_env: Mapping[str, Path]) -> None:
+    scenarios = (
+        ArchiveScenario(
+            name="chatgpt-semantic",
+            provider="chatgpt",
+            messages=(ScenarioMessage(role="user", text="Hello"),),
+        ),
+        ArchiveScenario(
+            name="codex-semantic",
+            provider="codex",
+            messages=(ScenarioMessage(role="user", text="Generate code"),),
+        ),
+    )
+    db_path, _ = seed_workspace_scenarios(workspace_env, scenarios)
+    surfaces = build_archive_surface_set(
+        db_path=db_path,
+        archive_root=workspace_env["archive_root"],
+        scenarios=scenarios,
+    )
+    try:
+        envelope = await _semantic_query_envelope(surfaces)
+    finally:
+        await surfaces.close()
+
+    assert envelope.status is OutcomeStatus.OK
+    assert envelope.evidence["runner_class"] == "semantic_query"
+    assert envelope.evidence["provider_ids"] == ["codex-semantic"]
+    assert envelope.evidence["provider_count"] == 1
+    assert envelope.counterexample is None
+
+
+async def _semantic_query_envelope(surfaces: ArchiveSurfaceSet) -> EvidenceEnvelope:
+    obligation = _obligation(
+        "archive.query.provider_filter_consistency",
+        subject_id="archive.query_law.provider_filter.codex",
+    )
+    repository_surface = next(surface for surface in surfaces.surfaces if surface.name == "repository")
+    facade_surface = next(surface for surface in surfaces.surfaces if surface.name == "facade")
+    provider_case = ArchiveQueryCase(name="provider-codex", provider="codex", expected_ids=())
+    archive_facts = await repository_surface.archive_facts()
+    observation = SemanticQueryObservation(
+        provider="codex",
+        all_ids=archive_facts.conversation_ids,
+        provider_ids=await repository_surface.query_ids(provider_case),
+        provider_count=await repository_surface.query_count(provider_case),
+        equivalent_provider_ids=await facade_surface.query_ids(provider_case),
+        surface_names=(repository_surface.name, facade_surface.name),
+    )
+    return run_semantic_query_evidence(obligation, observation)


### PR DESCRIPTION
## Summary

Closes #333.

Adds the first executable proof-evidence consumers on top of the proof-obligation catalog:

- claim adequacy metadata for runner classes, observed facts, and staleness conditions
- evidence-classed runner bindings so catalog rows distinguish smoke, structural, and semantic evidence
- selected JSON command subjects and a Codex provider-filter query-law subject
- CLI visual, CLI JSON envelope, and semantic query evidence runners that return `EvidenceEnvelope` values
- pytest consumers for those runners, including an existing plain-mode assertion augmented with proof evidence

## Problem

The proof-obligation catalog from #192 described subjects, claims, and runner bindings, but it did not yet have executable consumers. That left the catalog at risk of being metadata rather than a verification contract, and existing process-output assertions did not produce structured evidence with claim, subject, runner, expected-law, observed-state, and reproducer context.

## Solution

`polylogue.proof.models` now records claim adequacy fields and runner evidence classes. `polylogue.proof.catalog` binds the initial claims to smoke, structural, and semantic evidence classes, adds JSON envelope and provider-filter query consistency claims, and validates adequacy metadata in catalog quality checks.

`polylogue.proof.subjects` now contributes selected JSON command subjects plus a static provider-filter query-law subject. `polylogue.proof.runners` adds the first runner families: CLI visual checks, CLI JSON envelope checks, and semantic query-law checks over observed archive facts.

Tests consume those runners directly in `tests/unit/proof/test_evidence_runners.py`, and `tests/unit/cli/test_deterministic_output.py` now augments the existing plain-mode ANSI assertion with a matching `EvidenceEnvelope`.

## Verification

```bash
pytest -q -n 0 tests/unit/proof tests/unit/devtools/test_render_verification_catalog.py tests/unit/cli/test_deterministic_output.py
ruff check polylogue/proof tests/unit/proof tests/unit/cli/test_deterministic_output.py tests/unit/devtools/test_render_verification_catalog.py
mypy polylogue/proof
devtools render-all --check
devtools verify --quick
devtools verify
git push -u origin feature/test/semantic-evidence-runners
```

The push hook reran `devtools verify --quick` and passed.
