### PR TITLE
test: compile schema provider obligations

### DIFF
--- a/docs/verification-catalog.md
+++ b/docs/verification-catalog.md
@@ -8,10 +8,10 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 
 ## Snapshot
 
-- subjects: `8943`
-- claims: `8`
-- runner bindings: `8`
-- proof obligations: `9029`
+- subjects: `8946`
+- claims: `10`
+- runner bindings: `10`
+- proof obligations: `9035`
 
 ## Quality Checks
 
@@ -31,6 +31,7 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | `archive.query_law` | 1 |
 | `cli.command` | 43 |
 | `cli.json_command` | 2 |
+| `provider.capability` | 3 |
 | `schema.annotation` | 8897 |
 
 ## Command Subjects
@@ -95,6 +96,14 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | `gemini` | `conversation_document` | `x-polylogue-mutually-exclusive` | 285 | `gemini:v1:conversation_document:x-polylogue-mutually-exclusive:0:$:applets,runSettings` |
 | `gemini` | `conversation_document` | `x-polylogue-values` | 14 | `gemini:v1:conversation_document:x-polylogue-values:$.chunkedPrompt.chunks[*].finishReason` |
 
+## Provider Capability Subjects
+
+| Provider | Parser Identity | Reasoning | Streaming | Sidecars | Explicit Gaps |
+| --- | --- | --- | --- | --- | --- |
+| `chatgpt` | ChatGPT mapping graph export with typed conversation and node models | supported when exported as thoughts or reasoning_recap content types | snapshot mapping graph, not an append-only stream | `absent` | `streaming_capability_absent`<br>`sidecar_spec_absent`<br>`tool_use_variant_partial` |
+| `claude-code` | Claude Code JSONL record stream with typed record models | supported; thinking blocks are extracted from provider content blocks | record stream grouped by sessionId with parentUuid continuity | `partial` | `sidecar_artifact_contract_not_modeled` |
+| `codex` | Codex JSONL session envelope and response item stream | partial; reasoning is preserved when exported as content blocks, not inferred | record stream with session metadata, response items, compactions, and context turns | `absent` | `reasoning_capability_partial`<br>`sidecar_spec_absent` |
+
 ## Claims
 
 | Claim | Severity | Bug Classes | Breaker / Exception |
@@ -104,6 +113,8 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | `cli.command.plain_mode` | `serious` | `cli.plain-mode.regression`<br>`terminal-rendering-regression` | A rich-only output path breaks the plain-mode runner comparison. |
 | `cli.command.json_envelope` | `serious` | `cli.json-envelope.regression`<br>`machine-contract.invalid-json` | A selected JSON command that emits invalid JSON or a missing success envelope breaks the claim. |
 | `archive.query.provider_filter_consistency` | `serious` | `query.provider-filter.drift`<br>`archive-count.semantic-mismatch` | A provider result outside all results, mismatched count, or divergent equivalent construction is a counterexample. |
+| `provider.capability.identity_bridge` | `serious` | `provider.identity.loss`<br>`normalization.native-fact-drop` | A provider without native/canonical identity mappings can silently drop provider-native facts. |
+| `provider.capability.partial_coverage_declared` | `serious` | `provider.capability.implicit-gap`<br>`provider-semantics.untracked-partial-support` | A provider with absent or partial facets but no explicit gap record hides verification scope. |
 | `schema.values.value_closure` | `serious` | `schema.value-domain.drift`<br>`schema.privacy.enum-leak` | A generated payload outside the annotated value set is a counterexample. |
 | `schema.foreign_key.resolves` | `serious` | `schema.relationship.drift`<br>`synthetic-corpus.integrity` | A source path pointing at a missing target path breaks the relation claim. |
 | `schema.mutual_exclusion.exclusive` | `serious` | `schema.mutual-exclusion.drift`<br>`synthetic-corpus.invalid-combination` | A generated record containing two fields from the same exclusion group is a counterexample. |
@@ -117,6 +128,8 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | `cli-plain-contract:cli.command.plain_mode` | `cli.command.plain_mode` | `structural` | `static` | commands=`polylogue`; network=`none`; live_archive=`False` | `authored` by `polylogue.proof.catalog` at `2026-04-22T00:00:00+00:00` |
 | `cli-json-envelope-contract:cli.command.json_envelope` | `cli.command.json_envelope` | `structural` | `unit` | commands=`polylogue`; network=`none`; live_archive=`False` | `authored` by `polylogue.proof.catalog` at `2026-04-22T00:00:00+00:00` |
 | `semantic-query-law-contract:archive.query.provider_filter_consistency` | `archive.query.provider_filter_consistency` | `semantic` | `unit` | commands=—; network=`none`; live_archive=`False` | `authored` by `polylogue.proof.catalog` at `2026-04-22T00:00:00+00:00` |
+| `provider-capability-static-contract:provider.capability.identity_bridge` | `provider.capability.identity_bridge` | `structural` | `static` | commands=—; network=`none`; live_archive=`False` | `authored` by `polylogue.proof.catalog` at `2026-04-22T00:00:00+00:00` |
+| `provider-capability-static-contract:provider.capability.partial_coverage_declared` | `provider.capability.partial_coverage_declared` | `structural` | `static` | commands=—; network=`none`; live_archive=`False` | `authored` by `polylogue.proof.catalog` at `2026-04-22T00:00:00+00:00` |
 | `schema-annotation-static-contract:schema.values.value_closure` | `schema.values.value_closure` | `structural` | `static` | commands=—; network=`none`; live_archive=`False` | `authored` by `polylogue.proof.catalog` at `2026-04-22T00:00:00+00:00` |
 | `schema-annotation-static-contract:schema.foreign_key.resolves` | `schema.foreign_key.resolves` | `structural` | `static` | commands=—; network=`none`; live_archive=`False` | `authored` by `polylogue.proof.catalog` at `2026-04-22T00:00:00+00:00` |
 | `schema-annotation-static-contract:schema.mutual_exclusion.exclusive` | `schema.mutual_exclusion.exclusive` | `structural` | `static` | commands=—; network=`none`; live_archive=`False` | `authored` by `polylogue.proof.catalog` at `2026-04-22T00:00:00+00:00` |
@@ -130,6 +143,8 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | `cli.command.json_envelope` | 2 |
 | `cli.command.no_traceback` | 43 |
 | `cli.command.plain_mode` | 43 |
+| `provider.capability.identity_bridge` | 3 |
+| `provider.capability.partial_coverage_declared` | 3 |
 | `schema.foreign_key.resolves` | 7 |
 | `schema.mutual_exclusion.exclusive` | 8802 |
 | `schema.values.value_closure` | 88 |

--- a/polylogue/lib/provider_capabilities.py
+++ b/polylogue/lib/provider_capabilities.py
@@ -1,0 +1,264 @@
+"""Typed provider capability metadata used by verification surfaces."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+from polylogue.lib.json import JSONDocument, require_json_value
+from polylogue.types import Provider
+
+
+@dataclass(frozen=True, slots=True)
+class IdentityMapping:
+    """Relationship between provider-native facts and canonical archive fields."""
+
+    native: str
+    canonical: str
+    note: str
+
+    def to_payload(self) -> JSONDocument:
+        return {
+            "native": self.native,
+            "canonical": self.canonical,
+            "note": self.note,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderCapability:
+    """Static capability contract for a provider parser and normalizer."""
+
+    provider: Provider
+    parser_identity: str
+    parser_source_paths: tuple[str, ...]
+    sidecar_spec: str
+    tool_use_variant: str
+    reasoning_capability: str
+    streaming_capability: str
+    native_identity_fields: tuple[str, ...]
+    canonical_identity_fields: tuple[str, ...]
+    identity_mappings: tuple[IdentityMapping, ...]
+    timestamp_semantics: str
+    coverage_facets: Mapping[str, str]
+    partial_coverage: tuple[str, ...]
+
+    @property
+    def source_symbol(self) -> str:
+        return f"PROVIDER_CAPABILITIES[{self.provider.value}]"
+
+    def to_payload(self) -> JSONDocument:
+        return {
+            "provider": self.provider.value,
+            "parser_identity": self.parser_identity,
+            "parser_source_paths": list(self.parser_source_paths),
+            "sidecar_spec": self.sidecar_spec,
+            "tool_use_variant": self.tool_use_variant,
+            "reasoning_capability": self.reasoning_capability,
+            "streaming_capability": self.streaming_capability,
+            "native_identity_fields": list(self.native_identity_fields),
+            "canonical_identity_fields": list(self.canonical_identity_fields),
+            "identity_mappings": [mapping.to_payload() for mapping in self.identity_mappings],
+            "timestamp_semantics": self.timestamp_semantics,
+            "coverage_facets": {
+                key: require_json_value(value, context=f"coverage_facets.{key}")
+                for key, value in self.coverage_facets.items()
+            },
+            "partial_coverage": list(self.partial_coverage),
+        }
+
+
+PROVIDER_CAPABILITIES: tuple[ProviderCapability, ...] = (
+    ProviderCapability(
+        provider=Provider.CODEX,
+        parser_identity="Codex JSONL session envelope and response item stream",
+        parser_source_paths=(
+            "polylogue/sources/parsers/codex.py",
+            "polylogue/sources/providers/codex.py",
+        ),
+        sidecar_spec="none; Codex facts are carried inline in session, response, and context records",
+        tool_use_variant="content segments normalized through content_blocks_from_segments()",
+        reasoning_capability="partial; reasoning is preserved when exported as content blocks, not inferred",
+        streaming_capability="record stream with session metadata, response items, compactions, and context turns",
+        native_identity_fields=(
+            "session_meta.id",
+            "session_meta.created_at",
+            "response_item.payload.id",
+            "payload.id",
+            "git.repository_url",
+            "timestamp",
+        ),
+        canonical_identity_fields=(
+            "Conversation.provider_conversation_id",
+            "Conversation.created_at",
+            "Conversation.updated_at",
+            "Message.provider_message_id",
+            "Conversation.provider_meta.git.repository_url",
+        ),
+        identity_mappings=(
+            IdentityMapping(
+                native="session_meta.id",
+                canonical="Conversation.provider_conversation_id",
+                note="Session ids remain the native provider conversation id.",
+            ),
+            IdentityMapping(
+                native="payload.id",
+                canonical="Message.provider_message_id",
+                note="Record item ids remain available as native provider message ids.",
+            ),
+            IdentityMapping(
+                native="git.repository_url",
+                canonical="Conversation.provider_meta.git.repository_url",
+                note="Repository attribution is retained in provider metadata instead of folded into canonical ids.",
+            ),
+        ),
+        timestamp_semantics="Session and message timestamps are parsed with parse_timestamp() and stored as canonical created/updated timestamps.",
+        coverage_facets={
+            "reasoning": "partial",
+            "streaming": "supported",
+            "sidecars": "absent",
+            "tool_use": "supported",
+            "native_identity": "supported",
+            "timestamps": "supported",
+        },
+        partial_coverage=(
+            "reasoning_capability_partial",
+            "sidecar_spec_absent",
+        ),
+    ),
+    ProviderCapability(
+        provider=Provider.CLAUDE_CODE,
+        parser_identity="Claude Code JSONL record stream with typed record models",
+        parser_source_paths=(
+            "polylogue/sources/parsers/claude_code_parser.py",
+            "polylogue/sources/providers/claude_code_record.py",
+        ),
+        sidecar_spec="isSidechain and agent-* ids are normalized as sidechain/subagent branches",
+        tool_use_variant="message.content tool_use/tool_result blocks normalized into canonical content blocks",
+        reasoning_capability="supported; thinking blocks are extracted from provider content blocks",
+        streaming_capability="record stream grouped by sessionId with parentUuid continuity",
+        native_identity_fields=(
+            "sessionId",
+            "uuid",
+            "parentUuid",
+            "cwd",
+            "message.model",
+            "timestamp",
+        ),
+        canonical_identity_fields=(
+            "Conversation.provider_conversation_id",
+            "Message.provider_message_id",
+            "Message.parent_message_provider_id",
+            "Conversation.provider_meta.working_directories",
+            "Conversation.provider_meta.models_used",
+            "Conversation.created_at",
+            "Conversation.updated_at",
+        ),
+        identity_mappings=(
+            IdentityMapping(
+                native="sessionId",
+                canonical="Conversation.provider_conversation_id",
+                note="Session ids remain the native provider conversation id.",
+            ),
+            IdentityMapping(
+                native="uuid",
+                canonical="Message.provider_message_id",
+                note="Message uuids remain available as native provider message ids.",
+            ),
+            IdentityMapping(
+                native="parentUuid",
+                canonical="Message.parent_message_provider_id",
+                note="Native parent pointers are preserved for branch and continuity reconstruction.",
+            ),
+            IdentityMapping(
+                native="cwd",
+                canonical="Conversation.provider_meta.working_directories",
+                note="Working directory facts are retained as provider-native metadata.",
+            ),
+        ),
+        timestamp_semantics="Record timestamps are parsed per message and collapsed into conversation created/updated bounds.",
+        coverage_facets={
+            "reasoning": "supported",
+            "streaming": "supported",
+            "sidecars": "partial",
+            "tool_use": "supported",
+            "native_identity": "supported",
+            "timestamps": "supported",
+        },
+        partial_coverage=("sidecar_artifact_contract_not_modeled",),
+    ),
+    ProviderCapability(
+        provider=Provider.CHATGPT,
+        parser_identity="ChatGPT mapping graph export with typed conversation and node models",
+        parser_source_paths=(
+            "polylogue/sources/parsers/chatgpt.py",
+            "polylogue/sources/providers/chatgpt.py",
+        ),
+        sidecar_spec="none; attachments and tool facts are embedded in mapping-node metadata",
+        tool_use_variant="author/recipient/status metadata plus citations and code_execution provider_meta",
+        reasoning_capability="supported when exported as thoughts or reasoning_recap content types",
+        streaming_capability="snapshot mapping graph, not an append-only stream",
+        native_identity_fields=(
+            "conversation.id",
+            "mapping node id",
+            "message.id",
+            "parent",
+            "children",
+            "create_time",
+            "update_time",
+        ),
+        canonical_identity_fields=(
+            "Conversation.provider_conversation_id",
+            "Message.provider_message_id",
+            "Message.parent_message_provider_id",
+            "Message.branch_index",
+            "Conversation.created_at",
+            "Conversation.updated_at",
+            "Message.provider_meta.raw",
+        ),
+        identity_mappings=(
+            IdentityMapping(
+                native="mapping node id",
+                canonical="Message.provider_message_id",
+                note="Mapping keys remain the native message identity when message.id is absent.",
+            ),
+            IdentityMapping(
+                native="parent",
+                canonical="Message.parent_message_provider_id",
+                note="Native mapping graph edges are retained for threaded reconstruction.",
+            ),
+            IdentityMapping(
+                native="message",
+                canonical="Message.provider_meta.raw",
+                note="Raw message metadata is retained for provider-native facts not projected into canonical fields.",
+            ),
+        ),
+        timestamp_semantics="create_time/update_time floats are normalized into canonical conversation and message timestamps.",
+        coverage_facets={
+            "reasoning": "supported",
+            "streaming": "absent",
+            "sidecars": "absent",
+            "tool_use": "partial",
+            "native_identity": "supported",
+            "timestamps": "supported",
+        },
+        partial_coverage=(
+            "streaming_capability_absent",
+            "sidecar_spec_absent",
+            "tool_use_variant_partial",
+        ),
+    ),
+)
+
+
+def iter_provider_capabilities() -> tuple[ProviderCapability, ...]:
+    """Return the static provider capability contracts."""
+    return PROVIDER_CAPABILITIES
+
+
+__all__ = [
+    "IdentityMapping",
+    "PROVIDER_CAPABILITIES",
+    "ProviderCapability",
+    "iter_provider_capabilities",
+]

--- a/polylogue/proof/catalog.py
+++ b/polylogue/proof/catalog.py
@@ -133,6 +133,7 @@ def default_claims() -> tuple[Claim, ...]:
     values_query = _schema_annotation_query("x-polylogue-values")
     foreign_key_query = _schema_annotation_query("x-polylogue-foreign-keys")
     mutual_exclusion_query = _schema_annotation_query("x-polylogue-mutually-exclusive")
+    provider_capability_query = Kind("provider.capability")
     return (
         Claim(
             id="cli.command.help",
@@ -214,6 +215,56 @@ def default_claims() -> tuple[Claim, ...]:
                 description="A provider result outside all results, mismatched count, or divergent equivalent construction is a counterexample.",
                 issue="#333",
                 command=("pytest", "tests/unit/proof/test_evidence_runners.py"),
+            ),
+        ),
+        Claim(
+            id="provider.capability.identity_bridge",
+            description="Provider capability metadata maps native identity facts onto canonical archive fields.",
+            subject_query=provider_capability_query,
+            evidence_schema=_evidence_schema(
+                "native_identity_fields",
+                "canonical_identity_fields",
+                "identity_mappings",
+            ),
+            bug_classes=("provider.identity.loss", "normalization.native-fact-drop"),
+            runner_classes=("provider_static",),
+            observed_facts=("native_identity_fields", "canonical_identity_fields", "identity_mappings"),
+            staleness_conditions=(
+                "Provider parser identity, provider_meta projection, or conversation/message id semantics change.",
+            ),
+            breaker=BreakerMetadata(
+                description="A provider without native/canonical identity mappings can silently drop provider-native facts.",
+                issue="#332",
+                command=("devtools", "render-verification-catalog", "--check"),
+            ),
+        ),
+        Claim(
+            id="provider.capability.partial_coverage_declared",
+            description="Provider capability metadata declares unsupported or partial reasoning, streaming, sidecar, and tool-use facets.",
+            subject_query=provider_capability_query,
+            evidence_schema=_evidence_schema(
+                "reasoning_capability",
+                "streaming_capability",
+                "sidecar_spec",
+                "coverage_facets",
+                "partial_coverage",
+            ),
+            bug_classes=("provider.capability.implicit-gap", "provider-semantics.untracked-partial-support"),
+            runner_classes=("provider_static",),
+            observed_facts=(
+                "reasoning_capability",
+                "streaming_capability",
+                "sidecar_spec",
+                "coverage_facets",
+                "partial_coverage",
+            ),
+            staleness_conditions=(
+                "Provider parser support for reasoning, streaming, sidecars, or tool-use variants changes.",
+            ),
+            breaker=BreakerMetadata(
+                description="A provider with absent or partial facets but no explicit gap record hides verification scope.",
+                issue="#332",
+                command=("devtools", "render-verification-catalog", "--check"),
             ),
         ),
         Claim(
@@ -308,6 +359,10 @@ def default_runner_bindings(claims: Iterable[Claim]) -> tuple[RunnerBinding, ...
                     evidence_class="semantic",
                     cost_tier="unit",
                 )
+            )
+        elif claim.id.startswith("provider.capability."):
+            bindings.append(
+                _runner_binding(claim, runner="provider-capability-static-contract", evidence_class="structural")
             )
         elif claim.id.startswith("schema."):
             bindings.append(

--- a/polylogue/proof/rendering.py
+++ b/polylogue/proof/rendering.py
@@ -44,6 +44,10 @@ def build_catalog_markdown(catalog: VerificationCatalog) -> str:
         "",
         *_render_schema_subject_summary(catalog.subjects),
         "",
+        "## Provider Capability Subjects",
+        "",
+        *_render_provider_capability_subjects(catalog.subjects),
+        "",
         "## Claims",
         "",
         *_render_claims(catalog.claims),
@@ -112,6 +116,28 @@ def _render_schema_subject_summary(subjects: tuple[SubjectRef, ...]) -> list[str
     for (provider, element_kind, annotation), count in sorted(rows.items()):
         lines.append(
             f"| `{provider}` | `{element_kind}` | `{annotation}` | {count} | `{examples[(provider, element_kind, annotation)]}` |"
+        )
+    return lines
+
+
+def _render_provider_capability_subjects(subjects: tuple[SubjectRef, ...]) -> list[str]:
+    provider_subjects = [subject for subject in subjects if subject.kind == "provider.capability"]
+    lines = [
+        "| Provider | Parser Identity | Reasoning | Streaming | Sidecars | Explicit Gaps |",
+        "| --- | --- | --- | --- | --- | --- |",
+    ]
+    for subject in provider_subjects:
+        coverage = subject.attrs.get("coverage_facets")
+        sidecars = ""
+        if isinstance(coverage, dict):
+            sidecar_value = coverage.get("sidecars")
+            sidecars = sidecar_value if isinstance(sidecar_value, str) else ""
+        gaps = subject.attrs.get("partial_coverage")
+        gap_list = tuple(str(item) for item in gaps) if isinstance(gaps, list) else ()
+        lines.append(
+            f"| `{_string_attr(subject, 'provider')}` | {_string_attr(subject, 'parser_identity')} | "
+            f"{_string_attr(subject, 'reasoning_capability')} | {_string_attr(subject, 'streaming_capability')} | "
+            f"`{sidecars}` | {_code_list(gap_list)} |"
         )
     return lines
 

--- a/polylogue/proof/runners.py
+++ b/polylogue/proof/runners.py
@@ -16,7 +16,7 @@ from typing import Any
 import click
 from click.testing import CliRunner, Result
 
-from polylogue.lib.json import JSONDocument, require_json_document
+from polylogue.lib.json import JSONDocument, JSONValue, require_json_document, require_json_value
 from polylogue.lib.outcomes import OutcomeStatus
 from polylogue.proof.models import EvidenceEnvelope, ProofObligation, SourceSpan, TrustMetadata
 
@@ -37,6 +37,15 @@ class SemanticQueryObservation:
     equivalent_provider_ids: tuple[str, ...]
     query_name: str = "provider-filter"
     surface_names: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class SchemaValueGenerationObservation:
+    """Observed generated values for a schema value-domain annotation."""
+
+    observed_values: tuple[JSONValue, ...]
+    schema_path: str
+    generator: str = "hypothesis-jsonschema"
 
 
 def run_cli_visual_evidence(
@@ -150,6 +159,161 @@ def run_semantic_query_evidence(
         reproducer=reproducer,
         provenance=obligation.subject.source_span,
         producer="polylogue.proof.runners.semantic_query",
+    )
+
+
+def run_schema_value_generation_evidence(
+    obligation: ProofObligation,
+    observation: SchemaValueGenerationObservation,
+    *,
+    reproducer: tuple[str, ...] = ("pytest", "tests/unit/proof/test_schema_provider_obligations.py"),
+) -> EvidenceEnvelope:
+    """Verify that generated schema values stay inside an annotated finite domain."""
+    if obligation.claim.id != "schema.values.value_closure":
+        raise ValueError(f"unsupported schema generation claim: {obligation.claim.id}")
+
+    annotation_values = _json_value_tuple_attr(obligation.subject.attrs.get("values"))
+    observed_values = tuple(
+        require_json_value(value, context="schema generation observed value") for value in observation.observed_values
+    )
+    allowed_keys = {_json_value_key(value) for value in annotation_values}
+    unexpected_values = tuple(value for value in observed_values if _json_value_key(value) not in allowed_keys)
+    observed_state: JSONDocument = {
+        "schema_path": observation.schema_path,
+        "generator": observation.generator,
+        "values": list(annotation_values),
+        "observed_values": list(observed_values),
+        "unexpected_values": list(unexpected_values),
+    }
+    expected_law = "values generated from the schema are members of the x-polylogue-values annotation set"
+    evidence = _evidence_payload(
+        obligation,
+        runner_class="schema_static",
+        expected_law=expected_law,
+        observed_state=observed_state,
+    )
+    evidence["values"] = list(annotation_values)
+    evidence["observed_values"] = list(observed_values)
+    evidence["schema_path"] = observation.schema_path
+    return _build_envelope(
+        obligation,
+        status=OutcomeStatus.OK if annotation_values and not unexpected_values else OutcomeStatus.ERROR,
+        evidence=evidence,
+        expected_law=expected_law,
+        observed_state=observed_state,
+        reproducer=reproducer,
+        provenance=obligation.subject.source_span,
+        producer="polylogue.proof.runners.schema_static",
+    )
+
+
+def run_provider_capability_evidence(
+    obligation: ProofObligation,
+    *,
+    reproducer: tuple[str, ...] = ("pytest", "tests/unit/proof/test_schema_provider_obligations.py"),
+) -> EvidenceEnvelope:
+    """Verify static provider capability metadata for a provider subject."""
+    if obligation.claim.id == "provider.capability.identity_bridge":
+        return _run_provider_identity_bridge_evidence(obligation, reproducer=reproducer)
+    if obligation.claim.id == "provider.capability.partial_coverage_declared":
+        return _run_provider_partial_coverage_evidence(obligation, reproducer=reproducer)
+    raise ValueError(f"unsupported provider capability claim: {obligation.claim.id}")
+
+
+def _run_provider_identity_bridge_evidence(
+    obligation: ProofObligation,
+    *,
+    reproducer: tuple[str, ...],
+) -> EvidenceEnvelope:
+    attrs = obligation.subject.attrs
+    native_fields = _string_tuple_attr(attrs.get("native_identity_fields"))
+    canonical_fields = _string_tuple_attr(attrs.get("canonical_identity_fields"))
+    mappings = _json_document_tuple_attr(attrs.get("identity_mappings"))
+    mapping_checks = tuple(
+        bool(str(mapping.get("native", "")).strip() and str(mapping.get("canonical", "")).strip())
+        for mapping in mappings
+    )
+    observed_state: JSONDocument = {
+        "provider": attrs.get("provider"),
+        "native_identity_fields": list(native_fields),
+        "canonical_identity_fields": list(canonical_fields),
+        "identity_mappings": [dict(mapping) for mapping in mappings],
+        "mapping_checks": list(mapping_checks),
+    }
+    expected_law = "provider-native identity fields are explicitly mapped to canonical archive fields"
+    evidence = _evidence_payload(
+        obligation,
+        runner_class="provider_static",
+        expected_law=expected_law,
+        observed_state=observed_state,
+    )
+    evidence["native_identity_fields"] = list(native_fields)
+    evidence["canonical_identity_fields"] = list(canonical_fields)
+    evidence["identity_mappings"] = [dict(mapping) for mapping in mappings]
+    ok = bool(native_fields and canonical_fields and mappings and all(mapping_checks))
+    return _build_envelope(
+        obligation,
+        status=OutcomeStatus.OK if ok else OutcomeStatus.ERROR,
+        evidence=evidence,
+        expected_law=expected_law,
+        observed_state=observed_state,
+        reproducer=reproducer,
+        provenance=obligation.subject.source_span,
+        producer="polylogue.proof.runners.provider_static",
+    )
+
+
+def _run_provider_partial_coverage_evidence(
+    obligation: ProofObligation,
+    *,
+    reproducer: tuple[str, ...],
+) -> EvidenceEnvelope:
+    attrs = obligation.subject.attrs
+    coverage_facets = require_json_document(attrs.get("coverage_facets"), context="coverage_facets")
+    partial_coverage = _string_tuple_attr(attrs.get("partial_coverage"))
+    required_facets = ("reasoning", "streaming", "sidecars", "tool_use", "native_identity", "timestamps")
+    missing_facets = tuple(
+        facet
+        for facet in required_facets
+        if not isinstance(coverage_facets.get(facet), str) or not str(coverage_facets.get(facet)).strip()
+    )
+    partial_or_absent = tuple(
+        facet
+        for facet in required_facets
+        if isinstance(coverage_facets.get(facet), str) and coverage_facets[facet] in {"partial", "absent"}
+    )
+    observed_state: JSONDocument = {
+        "provider": attrs.get("provider"),
+        "reasoning_capability": attrs.get("reasoning_capability"),
+        "streaming_capability": attrs.get("streaming_capability"),
+        "sidecar_spec": attrs.get("sidecar_spec"),
+        "coverage_facets": dict(coverage_facets),
+        "partial_coverage": list(partial_coverage),
+        "missing_facets": list(missing_facets),
+        "partial_or_absent_facets": list(partial_or_absent),
+    }
+    expected_law = "partial or absent provider capability facets are explicit in provider metadata"
+    evidence = _evidence_payload(
+        obligation,
+        runner_class="provider_static",
+        expected_law=expected_law,
+        observed_state=observed_state,
+    )
+    evidence["reasoning_capability"] = attrs.get("reasoning_capability")
+    evidence["streaming_capability"] = attrs.get("streaming_capability")
+    evidence["sidecar_spec"] = attrs.get("sidecar_spec")
+    evidence["coverage_facets"] = dict(coverage_facets)
+    evidence["partial_coverage"] = list(partial_coverage)
+    ok = not missing_facets and (not partial_or_absent or bool(partial_coverage))
+    return _build_envelope(
+        obligation,
+        status=OutcomeStatus.OK if ok else OutcomeStatus.ERROR,
+        evidence=evidence,
+        expected_law=expected_law,
+        observed_state=observed_state,
+        reproducer=reproducer,
+        provenance=obligation.subject.source_span,
+        producer="polylogue.proof.runners.provider_static",
     )
 
 
@@ -415,9 +579,36 @@ def _sorted_unique(values: Sequence[str]) -> tuple[str, ...]:
     return tuple(sorted(set(values)))
 
 
+def _string_tuple_attr(value: object) -> tuple[str, ...]:
+    if not isinstance(value, list):
+        return ()
+    return tuple(item for item in value if isinstance(item, str) and item.strip())
+
+
+def _json_value_tuple_attr(value: object) -> tuple[JSONValue, ...]:
+    if not isinstance(value, list):
+        return ()
+    return tuple(require_json_value(item, context="JSON value attribute") for item in value)
+
+
+def _json_document_tuple_attr(value: object) -> tuple[JSONDocument, ...]:
+    if not isinstance(value, list):
+        return ()
+    return tuple(
+        require_json_document(item, context="JSON document attribute") for item in value if isinstance(item, dict)
+    )
+
+
+def _json_value_key(value: JSONValue) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
 __all__ = [
     "SemanticQueryObservation",
+    "SchemaValueGenerationObservation",
     "run_cli_json_envelope_evidence",
+    "run_provider_capability_evidence",
+    "run_schema_value_generation_evidence",
     "run_cli_visual_evidence",
     "run_semantic_query_evidence",
 ]

--- a/polylogue/proof/subjects.py
+++ b/polylogue/proof/subjects.py
@@ -10,6 +10,7 @@ import click
 
 from polylogue.cli.command_inventory import CommandPath, iter_command_paths
 from polylogue.lib.json import JSONDocument, json_document, json_document_list, require_json_value
+from polylogue.lib.provider_capabilities import iter_provider_capabilities
 from polylogue.proof.models import SourceSpan, SubjectRef
 from polylogue.schemas.packages import SchemaVersionPackage
 from polylogue.schemas.runtime_registry import SCHEMA_DIR, SchemaRegistry
@@ -127,6 +128,23 @@ def query_law_subjects() -> tuple[SubjectRef, ...]:
     )
 
 
+def provider_capability_subjects() -> tuple[SubjectRef, ...]:
+    """Compile typed provider capability metadata into proof subjects."""
+    subjects = [
+        SubjectRef(
+            kind="provider.capability",
+            id=f"provider.capability.{capability.provider.value}",
+            attrs=capability.to_payload(),
+            source_span=SourceSpan(
+                path="polylogue/lib/provider_capabilities.py",
+                symbol=capability.source_symbol,
+            ),
+        )
+        for capability in iter_provider_capabilities()
+    ]
+    return tuple(sorted(subjects, key=lambda subject: subject.id))
+
+
 def _command_subject(command_path: CommandPath) -> SubjectRef:
     is_root = not command_path.path
     command_id = "polylogue" if is_root else f"polylogue {' '.join(command_path.path)}"
@@ -183,7 +201,13 @@ def schema_annotation_subjects(
 
 def build_catalog_subjects() -> tuple[SubjectRef, ...]:
     """Compile all subjects included in the first proof-catalog slice."""
-    return (*command_subjects(), *json_command_subjects(), *query_law_subjects(), *schema_annotation_subjects())
+    return (
+        *command_subjects(),
+        *json_command_subjects(),
+        *query_law_subjects(),
+        *provider_capability_subjects(),
+        *schema_annotation_subjects(),
+    )
 
 
 def _dedupe(subjects: Iterable[SubjectRef]) -> Iterator[SubjectRef]:
@@ -384,6 +408,7 @@ __all__ = [
     "build_catalog_subjects",
     "command_subjects",
     "json_command_subjects",
+    "provider_capability_subjects",
     "query_law_subjects",
     "schema_annotation_subjects",
 ]

--- a/tests/infra/strategies/schema_driven.py
+++ b/tests/infra/strategies/schema_driven.py
@@ -12,12 +12,17 @@ import copy
 from hypothesis import strategies as st
 from hypothesis_jsonschema import from_schema
 
-from polylogue.lib.json import JSONDocument, JSONValue, json_document
+from polylogue.lib.json import JSONDocument, JSONValue, json_document, require_json_value
 from polylogue.schemas.registry import SchemaRegistry
 
 
 def strip_schema_extensions(schema: JSONValue, *, is_root: bool = True) -> JSONValue:
-    """Recursively remove generator-hostile keys from a JSON schema."""
+    """Recursively remove generator-hostile keys from a JSON schema.
+
+    ``x-polylogue-values`` is the exception: it is translated into JSON
+    Schema ``enum`` before the extension key is stripped so the same finite
+    value-domain annotation constrains Hypothesis generation.
+    """
     if isinstance(schema, dict):
         cleaned: JSONDocument = {}
         for key, value in schema.items():
@@ -28,10 +33,20 @@ def strip_schema_extensions(schema: JSONValue, *, is_root: bool = True) -> JSONV
                     cleaned[key] = "https://json-schema.org/draft/2020-12/schema"
                 continue
             cleaned[key] = strip_schema_extensions(value, is_root=False)
+        enum_values = _polylogue_value_enum(schema)
+        if enum_values and "enum" not in cleaned:
+            cleaned["enum"] = enum_values
         return cleaned
     if isinstance(schema, list):
         return [strip_schema_extensions(item, is_root=False) for item in schema]
     return schema
+
+
+def _polylogue_value_enum(schema: JSONDocument) -> list[JSONValue]:
+    values = schema.get("x-polylogue-values")
+    if not isinstance(values, list):
+        return []
+    return [require_json_value(value, context="x-polylogue-values item") for value in values]
 
 
 @st.composite

--- a/tests/unit/proof/test_catalog.py
+++ b/tests/unit/proof/test_catalog.py
@@ -29,6 +29,8 @@ def test_default_catalog_compiles_first_vertical_slice() -> None:
         "cli.command.plain_mode",
         "cli.command.json_envelope",
         "archive.query.provider_filter_consistency",
+        "provider.capability.identity_bridge",
+        "provider.capability.partial_coverage_declared",
         "schema.values.value_closure",
         "schema.foreign_key.resolves",
         "schema.mutual_exclusion.exclusive",
@@ -36,6 +38,7 @@ def test_default_catalog_compiles_first_vertical_slice() -> None:
     assert catalog.subjects_by_kind()["cli.command"] >= 1
     assert catalog.subjects_by_kind()["cli.json_command"] >= 1
     assert catalog.subjects_by_kind()["archive.query_law"] == 1
+    assert catalog.subjects_by_kind()["provider.capability"] >= 2
     assert catalog.subjects_by_kind()["schema.annotation"] >= 1
     assert {runner.claim_id for runner in catalog.runner_bindings} == {claim.id for claim in catalog.claims}
     assert {"smoke", "semantic", "structural"}.issubset({runner.evidence_class for runner in catalog.runner_bindings})

--- a/tests/unit/proof/test_schema_provider_obligations.py
+++ b/tests/unit/proof/test_schema_provider_obligations.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import copy
+import json
+
+from hypothesis import given
+from hypothesis import strategies as st
+from hypothesis_jsonschema import from_schema
+
+from polylogue.lib.json import JSONValue, json_document, require_json_value
+from polylogue.lib.outcomes import OutcomeStatus
+from polylogue.proof.catalog import build_verification_catalog
+from polylogue.proof.models import ProofObligation
+from polylogue.proof.runners import (
+    SchemaValueGenerationObservation,
+    run_provider_capability_evidence,
+    run_schema_value_generation_evidence,
+)
+from tests.infra.strategies.schema_driven import strip_schema_extensions
+
+
+def _obligation(claim_id: str, *, subject_id: str | None = None) -> ProofObligation:
+    catalog = build_verification_catalog()
+    for obligation in catalog.obligations:
+        if obligation.claim.id != claim_id:
+            continue
+        if subject_id is not None and obligation.subject.id != subject_id:
+            continue
+        return obligation
+    raise AssertionError(f"missing obligation for claim={claim_id!r} subject={subject_id!r}")
+
+
+def test_provider_capability_subjects_compile_into_provider_claims() -> None:
+    catalog = build_verification_catalog()
+    provider_subject_ids = {subject.id for subject in catalog.subjects if subject.kind == "provider.capability"}
+
+    assert {"provider.capability.codex", "provider.capability.claude-code"}.issubset(provider_subject_ids)
+    assert len(provider_subject_ids) >= 2
+    assert catalog.obligations_by_claim()["provider.capability.identity_bridge"] == len(provider_subject_ids)
+    assert catalog.obligations_by_claim()["provider.capability.partial_coverage_declared"] == len(provider_subject_ids)
+
+
+def test_provider_capability_identity_runner_preserves_native_and_canonical_facts() -> None:
+    envelope = run_provider_capability_evidence(
+        _obligation("provider.capability.identity_bridge", subject_id="provider.capability.codex")
+    )
+
+    assert envelope.status is OutcomeStatus.OK
+    assert envelope.evidence["runner_class"] == "provider_static"
+    assert "git.repository_url" in _string_values(envelope.evidence["native_identity_fields"])
+    assert "Conversation.provider_meta.git.repository_url" in _string_values(
+        envelope.evidence["canonical_identity_fields"]
+    )
+    assert envelope.counterexample is None
+
+
+def test_provider_capability_partial_coverage_runner_requires_explicit_gaps() -> None:
+    envelope = run_provider_capability_evidence(
+        _obligation("provider.capability.partial_coverage_declared", subject_id="provider.capability.chatgpt")
+    )
+
+    assert envelope.status is OutcomeStatus.OK
+    assert envelope.evidence["runner_class"] == "provider_static"
+    assert "streaming_capability_absent" in _string_values(envelope.evidence["partial_coverage"])
+    assert "sidecar_spec_absent" in _string_values(envelope.evidence["partial_coverage"])
+    assert envelope.counterexample is None
+
+
+@given(data=st.data())
+def test_value_annotation_metadata_drives_generation_and_verification(data: st.DataObject) -> None:
+    obligation = _obligation("schema.values.value_closure")
+    annotation_values = _json_values_attr(obligation.subject.attrs.get("values"))
+    generator_raw_schema: JSONValue = {"x-polylogue-values": list(annotation_values)}
+    generator_schema = json_document(strip_schema_extensions(copy.deepcopy(generator_raw_schema)))
+
+    observed_values = tuple(
+        require_json_value(data.draw(from_schema(generator_schema)), context="generated schema value") for _ in range(5)
+    )
+    envelope = run_schema_value_generation_evidence(
+        obligation,
+        SchemaValueGenerationObservation(
+            observed_values=observed_values,
+            schema_path=str(obligation.subject.attrs.get("schema_path", "")),
+        ),
+    )
+
+    assert {_json_value_key(value) for value in observed_values}.issubset(
+        {_json_value_key(value) for value in annotation_values}
+    )
+    assert envelope.status is OutcomeStatus.OK
+    assert envelope.evidence["runner_class"] == "schema_static"
+    assert envelope.counterexample is None
+
+
+def test_schema_value_generation_runner_reports_counterexamples() -> None:
+    obligation = _obligation("schema.values.value_closure")
+    annotation_values = _json_values_attr(obligation.subject.attrs.get("values"))
+    unexpected_value = _outside_value(annotation_values)
+
+    envelope = run_schema_value_generation_evidence(
+        obligation,
+        SchemaValueGenerationObservation(
+            observed_values=(unexpected_value,),
+            schema_path=str(obligation.subject.attrs.get("schema_path", "")),
+        ),
+    )
+
+    assert envelope.status is OutcomeStatus.ERROR
+    assert envelope.counterexample is not None
+    observed_state = envelope.counterexample["observed_state"]
+    assert isinstance(observed_state, dict)
+    assert unexpected_value in _string_values(observed_state["unexpected_values"])
+
+
+def _json_values_attr(value: object) -> tuple[JSONValue, ...]:
+    if not isinstance(value, list):
+        raise AssertionError("expected JSON value list")
+    return tuple(require_json_value(item, context="values item") for item in value)
+
+
+def _string_values(value: object) -> tuple[str, ...]:
+    if not isinstance(value, list):
+        raise AssertionError("expected string list")
+    return tuple(item for item in value if isinstance(item, str))
+
+
+def _outside_value(values: tuple[JSONValue, ...]) -> str:
+    value_keys = {_json_value_key(value) for value in values}
+    candidate = "__polylogue_outside_value__"
+    while _json_value_key(candidate) in value_keys:
+        candidate = f"{candidate}_x"
+    return candidate
+
+
+def _json_value_key(value: JSONValue) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)

--- a/tests/unit/sources/test_schema_driven.py
+++ b/tests/unit/sources/test_schema_driven.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import copy
 
+from polylogue.lib.json import JSONValue
 from polylogue.schemas.registry import SchemaRegistry
 from tests.infra.strategies.schema_driven import strip_schema_extensions
 
@@ -28,3 +29,25 @@ def test_strip_schema_extensions_removes_nested_metaschema_declarations() -> Non
     schema_paths = _collect_schema_paths(cleaned)
 
     assert schema_paths == [("root", "https://json-schema.org/draft/2020-12/schema")]
+
+
+def test_strip_schema_extensions_translates_polylogue_values_to_enum() -> None:
+    raw_schema: JSONValue = {
+        "type": "object",
+        "properties": {
+            "role": {
+                "type": "string",
+                "x-polylogue-values": ["user", "assistant"],
+            },
+        },
+    }
+
+    cleaned = strip_schema_extensions(copy.deepcopy(raw_schema))
+
+    assert isinstance(cleaned, dict)
+    properties = cleaned["properties"]
+    assert isinstance(properties, dict)
+    role_schema = properties["role"]
+    assert isinstance(role_schema, dict)
+    assert "x-polylogue-values" not in role_schema
+    assert role_schema["enum"] == ["user", "assistant"]


### PR DESCRIPTION
Closes #332

## Summary

- Add typed provider capability metadata for `codex`, `claude-code`, and `chatgpt`.
- Compile provider capability subjects into the proof catalog and bind identity/partial-coverage claims.
- Translate `x-polylogue-values` into JSON Schema `enum` for schema-driven Hypothesis generation.
- Add evidence runners and tests proving schema value generation and provider capability obligations.

## Problem

Schema annotations and provider semantics were still partly outside the proof-obligation vocabulary. The catalog had initial schema annotation subjects, but provider capability semantics were not typed subjects, and `schema_conformant_payload()` stripped `x-polylogue-*` metadata before Hypothesis generation could use it.

## Solution

- Added `polylogue/lib/provider_capabilities.py` as the substrate record for provider capability facts and native-to-canonical identity mappings.
- Added `provider.capability.*` subjects in `polylogue/proof/subjects.py`.
- Added `provider.capability.identity_bridge` and `provider.capability.partial_coverage_declared` claims plus static runner bindings in `polylogue/proof/catalog.py`.
- Added provider capability rendering to `docs/verification-catalog.md`.
- Added proof runners for schema value-generation closure and provider capability metadata checks in `polylogue/proof/runners.py`.
- Updated `tests/infra/strategies/schema_driven.py` so `x-polylogue-values` drives generation as JSON Schema `enum` before the extension key is stripped.

## Verification

```text
pytest -q -n 0 tests/unit/proof tests/unit/sources/test_schema_driven.py
ruff check polylogue/lib/provider_capabilities.py polylogue/proof tests/unit/proof tests/unit/sources/test_schema_driven.py tests/infra/strategies/schema_driven.py
mypy polylogue/lib/provider_capabilities.py polylogue/proof tests/unit/proof/test_schema_provider_obligations.py tests/infra/strategies/schema_driven.py
devtools render-all --check
pytest -q -n 0 tests/unit/sources/test_parser_crashlessness.py tests/property/test_schema_roundtrip.py tests/property/test_semantic_properties.py
devtools verify --quick
devtools verify
git push -u origin feature/test/schema-provider-obligations
```

The push hook reran `devtools verify --quick` successfully.
