### PR TITLE
test: capture raw quarantine regressions

### DIFF
--- a/tests/unit/cli/test_check.py
+++ b/tests/unit/cli/test_check.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import ANY, patch
 
@@ -76,6 +77,39 @@ def _find_named_check(payload: JsonObject, name: str) -> JsonObject:
         if check_payload.get("name") == name:
             return check_payload
     raise AssertionError(f"Missing check named {name}")
+
+
+def _insert_raw_blob(
+    *,
+    db_path: Path,
+    provider_name: str,
+    source_name: str,
+    source_path: str,
+    raw_content: bytes,
+) -> str:
+    from polylogue.storage.blob_store import get_blob_store
+
+    raw_id, blob_size = get_blob_store().write_from_bytes(raw_content)
+    with open_connection(db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO raw_conversations (
+                raw_id, provider_name, source_name, source_path, source_index,
+                blob_size, acquired_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                raw_id,
+                provider_name,
+                source_name,
+                source_path,
+                0,
+                blob_size,
+                datetime.now(tz=timezone.utc).isoformat(),
+            ),
+        )
+        conn.commit()
+    return raw_id
 
 
 def _extract_json(output: str) -> JsonObject:
@@ -835,6 +869,60 @@ class TestCheckCommandSupplementary:
         assert request.record_offset == 0
         assert request.quarantine_malformed is True
         assert request.progress_callback is not None
+
+    def test_check_schemas_quarantine_reports_and_persists_decode_failure(
+        self,
+        cli_workspace: WorkspacePaths,
+        cli_runner: CliRunner,
+    ) -> None:
+        """`doctor --schemas` reports and persists legitimate raw quarantine failures."""
+        raw_id = _insert_raw_blob(
+            db_path=cli_workspace["db_path"],
+            provider_name="codex",
+            source_name="codex",
+            source_path="/tmp/session.jsonl",
+            raw_content=(
+                b'{"type":"session_meta"}\nnot json at all\n{"type":"response_item","payload":{"type":"message"}}'
+            ),
+        )
+
+        result = cli_runner.invoke(
+            cli,
+            [
+                "--plain",
+                "doctor",
+                "--schemas",
+                "--schema-provider",
+                "codex",
+                "--schema-quarantine-malformed",
+            ],
+            catch_exceptions=False,
+        )
+
+        assert result.exit_code == 0
+        assert "Schema verification: 1 raw records" in result.output
+        assert "codex: valid=0 invalid=0 drift=0 skipped=0 decode_errors=1 quarantined=1" in result.output
+
+        with open_connection(cli_workspace["db_path"]) as conn:
+            row = conn.execute(
+                """
+                SELECT validation_status, validation_error, validation_mode, validation_provider,
+                       payload_provider, validated_at, parsed_at, parse_error
+                FROM raw_conversations
+                WHERE raw_id = ?
+                """,
+                (raw_id,),
+            ).fetchone()
+
+        assert row is not None
+        assert row[0] == "failed"
+        assert isinstance(row[1], str) and "Malformed JSONL lines:" in row[1]
+        assert row[2] == "strict"
+        assert row[3] == "codex"
+        assert row[4] == "codex"
+        assert row[5] is not None
+        assert row[6] is None
+        assert isinstance(row[7], str) and "Malformed JSONL lines:" in row[7]
 
     def test_check_proof_json_output(self, cli_workspace: WorkspacePaths) -> None:
         """--proof adds artifact_proof block to JSON output."""

--- a/tests/unit/pipeline/test_quarantine_fixtures.py
+++ b/tests/unit/pipeline/test_quarantine_fixtures.py
@@ -35,11 +35,12 @@ from pathlib import Path
 import pytest
 
 from polylogue.pipeline.services.ingest_worker import ingest_record
+from polylogue.pipeline.services.validation_flow import validate_raw_ids
 from polylogue.storage.blob_store import get_blob_store
 from polylogue.storage.raw_ingest_artifacts import RawIngestArtifactState
 from polylogue.storage.raw_state_models import RawConversationState
 from polylogue.storage.store import RawConversationRecord
-from polylogue.types import ValidationStatus
+from polylogue.types import ValidationMode, ValidationStatus
 
 EMPTY_SHA256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
@@ -262,5 +263,66 @@ async def test_quarantine_state_round_trip_through_mark_raw_parsed(tmp_path: Pat
         )
         assert state.quarantined is True
         assert state.parsed is False
+    finally:
+        await backend.close()
+
+
+async def test_validation_flow_persists_decode_quarantine_state(tmp_path: Path) -> None:
+    """Validation persistence records both decode-failure shapes as quarantines."""
+    from polylogue.storage.backends.async_sqlite import SQLiteBackend
+
+    cases = [
+        (
+            _make_raw_record(zero_length_bytes(), "codex", "/exports/empty-codex.jsonl"),
+            "zero-length",
+        ),
+        (
+            _make_raw_record(codex_malformed_jsonl_bytes(), "codex", "/exports/malformed-codex.jsonl"),
+            "Malformed JSONL lines:",
+        ),
+    ]
+
+    backend = SQLiteBackend(db_path=tmp_path / "archive.db")
+    try:
+        for record, _expected_error in cases:
+            await backend.save_raw_conversation(record)
+
+        result = await validate_raw_ids(
+            repository=backend,
+            raw_ids=[record.raw_id for record, _expected_error in cases],
+            persist=True,
+            validation_mode=ValidationMode.STRICT,
+            raw_batch_size=10,
+        )
+
+        assert len(result.records) == 2
+        assert result.parseable_raw_ids == []
+        assert set(result.invalid_raw_ids) == {record.raw_id for record, _expected_error in cases}
+
+        for record, expected_error in cases:
+            validation_record = next(item for item in result.records if item.raw_id == record.raw_id)
+            assert validation_record.validation_status == ValidationStatus.FAILED
+            assert validation_record.parse_error is not None
+            assert expected_error in validation_record.parse_error
+
+            stored = await backend.get_raw_conversation(record.raw_id)
+            assert stored is not None
+            assert stored.validation_status == ValidationStatus.FAILED
+            assert stored.validation_error is not None
+            assert expected_error in stored.validation_error
+            assert stored.parse_error is not None
+            assert expected_error in stored.parse_error
+            assert stored.parsed_at is None
+
+            state = RawIngestArtifactState.from_state(
+                RawConversationState(
+                    raw_id=stored.raw_id,
+                    parsed_at=stored.parsed_at,
+                    parse_error=stored.parse_error,
+                    validation_status=stored.validation_status,
+                )
+            )
+            assert state.quarantined is True
+            assert state.needs_parse_backlog() is False
     finally:
         await backend.close()


### PR DESCRIPTION
## Summary

Closes #328.

Adds focused regression coverage for legitimate raw quarantine failures seen during archive repair: zero-length raw blobs and malformed JSONL records.

## Problem

The existing quarantine coverage mostly exercised `ingest_record` result objects and schema-verifier internals. The deployment-readiness gap was proving that these failure shapes persist through the raw validation path and remain visible in the operator-facing `doctor --schemas --schema-quarantine-malformed` output.

## Solution

- Added validation-flow coverage in `tests/unit/pipeline/test_quarantine_fixtures.py` proving zero-length and malformed JSONL records persist as failed validation rows with `parse_error`, stay unparsed, and classify as quarantined.
- Added a real CLI regression in `tests/unit/cli/test_check.py` proving `doctor --schemas --schema-quarantine-malformed` reports `decode_errors=1 quarantined=1` and persists the quarantine state for malformed JSONL.
- Kept the existing recoverable malformed JSONL validation-off behavior unchanged.

## Verification

```bash
pytest tests/unit/pipeline/test_quarantine_fixtures.py -q
pytest tests/unit/cli/test_check.py -q -k quarantine
ruff format --check tests/unit/pipeline/test_quarantine_fixtures.py tests/unit/cli/test_check.py
ruff check tests/unit/pipeline/test_quarantine_fixtures.py tests/unit/cli/test_check.py
devtools verify

git push -u origin feature/test/raw-quarantine-regressions
# pre-push: devtools verify --quick
```
