### PR TITLE
test: add mutation law frontier suites

### DIFF
--- a/tests/unit/core/test_filters_props.py
+++ b/tests/unit/core/test_filters_props.py
@@ -294,6 +294,10 @@ def _apply_filter_spec(f: ConversationFilter, spec: FilterSpec) -> ConversationF
     return f
 
 
+def _conversation_ids(conversations: list[Conversation]) -> list[str]:
+    return [str(conversation.id) for conversation in conversations]
+
+
 @given(filter_chain_strategy(min_filters=1, max_filters=4))
 @settings(max_examples=30, suppress_health_check=[HealthCheck.too_slow])
 def test_filter_chain_never_crashes_on_build(chain: list[FilterSpec]) -> None:
@@ -409,6 +413,44 @@ async def test_filter_idempotence_exclude(filter_repo: ConversationRepository) -
     once = await ConversationFilter(filter_repo).exclude_provider("claude-ai").list()
     twice = await ConversationFilter(filter_repo).exclude_provider("claude-ai").exclude_provider("claude-ai").list()
     assert {c.id for c in once} == {c.id for c in twice}
+
+
+# =============================================================================
+# Property: Filter semantic oracles for mutation-frontier campaigns
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_provider_filter_list_count_subset_and_order_law(filter_repo: ConversationRepository) -> None:
+    """Provider filtering agrees across list/count and preserves base result order."""
+    all_items = await ConversationFilter(filter_repo).list()
+    filtered = await ConversationFilter(filter_repo).provider("claude-ai").list()
+    expected = [conversation for conversation in all_items if conversation.provider == "claude-ai"]
+
+    assert _conversation_ids(filtered) == _conversation_ids(expected)
+    assert await ConversationFilter(filter_repo).provider("claude-ai").count() == len(filtered)
+    assert all(conversation.provider == "claude-ai" for conversation in filtered)
+
+
+@pytest.mark.asyncio
+async def test_equivalent_filter_order_list_count_and_first_law(filter_repo: ConversationRepository) -> None:
+    """Commutative filter constraints must agree across all terminal methods."""
+    provider_then_title = await ConversationFilter(filter_repo).provider("claude-ai").title("Python").list()
+    title_then_provider = await ConversationFilter(filter_repo).title("Python").provider("claude-ai").list()
+
+    assert _conversation_ids(provider_then_title) == _conversation_ids(title_then_provider)
+    assert await ConversationFilter(filter_repo).provider("claude-ai").title("Python").count() == len(
+        provider_then_title
+    )
+    assert await ConversationFilter(filter_repo).title("Python").provider("claude-ai").count() == len(
+        title_then_provider
+    )
+
+    first_provider_then_title = await ConversationFilter(filter_repo).provider("claude-ai").title("Python").first()
+    first_title_then_provider = await ConversationFilter(filter_repo).title("Python").provider("claude-ai").first()
+    assert first_provider_then_title is not None
+    assert first_title_then_provider is not None
+    assert first_provider_then_title.id == first_title_then_provider.id
 
 
 # =============================================================================

--- a/tests/unit/sources/test_source_laws.py
+++ b/tests/unit/sources/test_source_laws.py
@@ -176,6 +176,19 @@ _CANONICAL_PROVIDERS = (
 )
 
 
+def _minimal_chatgpt_payload(text: str) -> dict[str, object]:
+    return {
+        "mapping": {
+            "node-1": {
+                "message": {
+                    "author": {"role": "user"},
+                    "content": {"content_type": "text", "parts": [text]},
+                }
+            }
+        }
+    }
+
+
 def _empty_cursor_state() -> CursorStatePayload:
     return {}
 
@@ -215,6 +228,27 @@ def test_detect_provider_prefers_payload_shape_over_conflicting_path_hint() -> N
     }
 
     assert detect_provider(payload, Path("misleading/claude-code/session.jsonl")) == Provider.CHATGPT
+
+
+@pytest.mark.parametrize(
+    ("provider_hint", "stream_name"),
+    [
+        (Provider.CLAUDE_CODE, "misleading/claude-code/session.jsonl"),
+        (Provider.CODEX, "misleading/codex/session.jsonl"),
+    ],
+)
+def test_entry_payload_detection_overrides_misleading_grouped_fallback_law(
+    provider_hint: Provider,
+    stream_name: str,
+) -> None:
+    payloads = [_minimal_chatgpt_payload("first"), _minimal_chatgpt_payload("second")]
+    raw = "\n".join(json.dumps(payload) for payload in payloads).encode("utf-8")
+
+    observed = list(_iter_entry_payloads(BytesIO(raw), stream_name=stream_name, provider_hint=provider_hint))
+
+    assert [provider for provider, _, _ in observed] == [Provider.CHATGPT, Provider.CHATGPT]
+    assert [payload for _, payload, _ in observed] == payloads
+    assert all(detect_provider_ms >= 0.0 for _, _, detect_provider_ms in observed)
 
 
 @given(provider_payload_case_strategy(_CANONICAL_PROVIDERS))


### PR DESCRIPTION
## Summary

Adds two focused law-style mutation frontier suites for `#327`:

- filter semantic oracles covering provider/title composition across `list`, `count`, and `first`
- source-detection adversary coverage where grouped-provider hints wrap ChatGPT-shaped JSONL payloads and payload shape must win

Ref #327

## Problem

Issue #327 asks for mutation-guided law densification, not broad test-count growth. The current suite already has general filter and source laws, but it was missing small executable oracles for mutation classes such as count/list divergence, order-sensitive filter composition, and fallback/path-hint precedence over payload detection.

## Solution

- Added filter frontier laws in `tests/unit/core/test_filters_props.py`:
  - provider filtering must agree with the base result order
  - filtered `count()` must match filtered `list()` length
  - equivalent provider/title filter order must agree across `list`, `count`, and `first`
- Added source-detection frontier coverage in `tests/unit/sources/test_source_laws.py`:
  - `claude-code` and `codex` fallback hints cannot override ChatGPT-shaped JSONL entry payloads
  - emitted payloads remain preserved while provider attribution follows payload shape

## Verification

- `pytest tests/unit/core/test_filters_props.py -q -k "provider_filter_list_count_subset_and_order_law or equivalent_filter_order_list_count_and_first_law"` — 2 passed
- `pytest tests/unit/sources/test_source_laws.py -q -k "entry_payload_detection_overrides_misleading_grouped_fallback_law"` — 2 passed
- `pytest tests/unit/core/test_filters_props.py -q` — 92 passed
- `pytest tests/unit/sources/test_source_laws.py -q` — 110 passed
- `ruff format tests/unit/core/test_filters_props.py tests/unit/sources/test_source_laws.py`
- `ruff check tests/unit/core/test_filters_props.py tests/unit/sources/test_source_laws.py`
- `devtools verify` — all checks passed
- pre-push `devtools verify --quick` — all checks passed

Relevant mutation campaign commands for this slice, not run locally here:

- `devtools mutmut-campaign run filters`
- `devtools mutmut-campaign run source-detection`
