### PR TITLE
feat: define verification lab surface

### DIFF
--- a/devtools/__main__.py
+++ b/devtools/__main__.py
@@ -6,13 +6,17 @@ import argparse
 import json
 import sys
 
-from devtools.command_catalog import COMMAND_SPECS, COMMANDS, grouped_command_specs
+from devtools.command_catalog import COMMAND_SPECS, COMMANDS, grouped_command_specs, verification_lab_command_specs
 
 
 def _print_command_inventory(*, as_json: bool) -> None:
+    verification_lab = verification_lab_command_specs()
     if as_json:
         payload = {
             "commands": [spec.to_dict() for spec in COMMAND_SPECS],
+            "surfaces": {
+                "verification_lab": [spec.name for spec in verification_lab],
+            },
             "categories": [
                 {
                     "name": category,
@@ -26,6 +30,10 @@ def _print_command_inventory(*, as_json: bool) -> None:
         return
 
     print("Commands:")
+    if verification_lab:
+        print("\n  verification lab surface:")
+        for spec in verification_lab:
+            print(f"    {spec.name:<25} {spec.description}")
     for category, specs in grouped_command_specs().items():
         print(f"\n  {category}:")
         for spec in specs:

--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -9,6 +9,11 @@ from dataclasses import asdict, dataclass
 
 CommandMain = Callable[[list[str] | None], int]
 CONTROL_PLANE = "devtools"
+VERIFICATION_LAB_COMMAND_NAMES: tuple[str, ...] = (
+    "render-verification-catalog",
+    "affected-obligations",
+    "semantic-axis-evidence",
+)
 
 CATEGORY_ORDER: tuple[str, ...] = (
     "core",
@@ -112,9 +117,12 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
     CommandSpec(
         "render-verification-catalog",
         "generated surfaces",
-        "Render docs/verification-catalog.md from proof-obligation registries.",
+        "Render the verification-lab proof catalog from obligation registries.",
         "devtools.render_verification_catalog",
-        use_when="Refresh or verify the proof-obligation catalog after changing proof subjects, claims, runners, or catalog rendering.",
+        use_when=(
+            "Refresh or verify the proof-obligation catalog that anchors the verification-lab surface after "
+            "changing proof subjects, claims, runners, or catalog rendering."
+        ),
         examples=(
             "devtools render-verification-catalog",
             "devtools render-verification-catalog --check",
@@ -133,7 +141,7 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
     CommandSpec(
         "affected-obligations",
         "verification",
-        "Route changed paths or refs to affected proof obligations and focused checks.",
+        "Route changed paths or refs to affected verification-lab proof obligations and focused checks.",
         "devtools.affected_obligations",
         use_when="Find the proof obligations and inner-loop checks affected by local changes before escalating to full PR gates.",
         examples=(
@@ -193,7 +201,7 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
     CommandSpec(
         "semantic-axis-evidence",
         "verification",
-        "Generate proof-envelope performance evidence across synthetic semantic scale tiers.",
+        "Generate verification-lab performance evidence across synthetic semantic scale tiers.",
         "devtools.semantic_axis_evidence",
         use_when=(
             "Produce comparative performance evidence that describes growth shape over semantic axes "
@@ -275,6 +283,11 @@ def featured_command_specs(commands: Iterable[CommandSpec] = COMMAND_SPECS) -> t
     return tuple(spec for spec in commands if spec.featured)
 
 
+def verification_lab_command_specs(commands: Iterable[CommandSpec] = COMMAND_SPECS) -> tuple[CommandSpec, ...]:
+    by_name = {spec.name: spec for spec in commands}
+    return tuple(by_name[name] for name in VERIFICATION_LAB_COMMAND_NAMES)
+
+
 def grouped_command_specs(commands: Iterable[CommandSpec] = COMMAND_SPECS) -> OrderedDict[str, list[CommandSpec]]:
     grouped: OrderedDict[str, list[CommandSpec]] = OrderedDict((category, []) for category in CATEGORY_ORDER)
     for spec in commands:
@@ -296,4 +309,6 @@ __all__ = [
     "control_plane_command",
     "featured_command_specs",
     "grouped_command_specs",
+    "VERIFICATION_LAB_COMMAND_NAMES",
+    "verification_lab_command_specs",
 ]

--- a/devtools/docs_surface.py
+++ b/devtools/docs_surface.py
@@ -39,6 +39,11 @@ DOCS_REFERENCE_ENTRIES: tuple[DocsEntry, ...] = (
         "docs/verification-catalog.md",
         "Generated proof-obligation subjects, claims, runners, and catalog self-checks.",
     ),
+    DocsEntry(
+        "Verification Lab",
+        "docs/verification-lab.md",
+        "Accepted command-surface decision for proof catalog, routing, and evidence operators.",
+    ),
 )
 
 REPO_GUIDE_ENTRIES: tuple[DocsEntry, ...] = (

--- a/devtools/render_devtools_reference.py
+++ b/devtools/render_devtools_reference.py
@@ -11,6 +11,7 @@ from devtools.command_catalog import (
     control_plane_command,
     featured_command_specs,
     grouped_command_specs,
+    verification_lab_command_specs,
 )
 from devtools.render_support import write_if_changed
 
@@ -45,9 +46,28 @@ def _render_featured_commands(commands: tuple[CommandSpec, ...]) -> list[str]:
     return lines
 
 
+def _render_verification_lab_surface(commands: tuple[CommandSpec, ...]) -> list[str]:
+    if not commands:
+        return []
+    lines = [
+        "## Verification Lab Surface",
+        "",
+        "The proof-lab operator surface intentionally lives in `devtools` for now. These commands operate on",
+        "repo proof obligations and evidence records, not end-user archive workflows.",
+        "",
+        "| Command | Role |",
+        "| --- | --- |",
+    ]
+    for spec in commands:
+        lines.append(f"| `{spec.invocation}` | {spec.use_when or spec.description} |")
+    lines.append("")
+    return lines
+
+
 def build_command_catalog() -> str:
     groups = grouped_command_specs()
     featured = featured_command_specs()
+    verification_lab = verification_lab_command_specs()
     lines = [
         "<!-- BEGIN GENERATED: devtools-command-catalog -->",
         "## Command Catalog",
@@ -63,6 +83,7 @@ def build_command_catalog() -> str:
         "```",
         "",
     ]
+    lines.extend(_render_verification_lab_surface(verification_lab))
     if featured:
         lines.extend(_render_featured_commands(featured))
     for category, commands in groups.items():

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,7 @@ This directory holds the current repository-facing documentation.
 | [Providers](providers/README.md) | Provider-specific parsing and export-format notes. |
 | [Test Quality Workflows](test-quality-workflows.md) | Generated validation lanes, mutation campaigns, and benchmark campaigns. |
 | [Verification Catalog](verification-catalog.md) | Generated proof-obligation subjects, claims, runners, and catalog self-checks. |
+| [Verification Lab](verification-lab.md) | Accepted command-surface decision for proof catalog, routing, and evidence operators. |
 
 ## Repository Guides
 

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -19,6 +19,17 @@ devtools status
 devtools status --json
 ```
 
+## Verification Lab Surface
+
+The proof-lab operator surface intentionally lives in `devtools` for now. These commands operate on
+repo proof obligations and evidence records, not end-user archive workflows.
+
+| Command | Role |
+| --- | --- |
+| `devtools render-verification-catalog` | Refresh or verify the proof-obligation catalog that anchors the verification-lab surface after changing proof subjects, claims, runners, or catalog rendering. |
+| `devtools affected-obligations` | Find the proof obligations and inner-loop checks affected by local changes before escalating to full PR gates. |
+| `devtools semantic-axis-evidence` | Produce comparative performance evidence that describes growth shape over semantic axes instead of machine-specific absolute budgets. |
+
 ## Core Loop
 
 These are the commands worth remembering during normal repo work:
@@ -51,20 +62,20 @@ These are the commands worth remembering during normal repo work:
 | `devtools render-devtools-reference` | Render the command catalog inside docs/devtools.md. |
 | `devtools render-docs-surface` | Render docs/README.md and the README documentation table. |
 | `devtools render-quality-reference` | Render docs/test-quality-workflows.md from live validation, mutation, and benchmark registries. |
-| `devtools render-verification-catalog` | Render docs/verification-catalog.md from proof-obligation registries. |
+| `devtools render-verification-catalog` | Render the verification-lab proof catalog from obligation registries. |
 
 ### Verification
 
 | Command | Description |
 | --- | --- |
-| `devtools affected-obligations` | Route changed paths or refs to affected proof obligations and focused checks. |
+| `devtools affected-obligations` | Route changed paths or refs to affected verification-lab proof obligations and focused checks. |
 | `devtools artifact-graph` | Render the runtime artifact, operation, and scenario-coverage map. |
 | `devtools pipeline-probe` | Run typed pipeline probes against synthetic, staged, or archive-subset inputs. |
 | `devtools query-memory-budget` | Measure query-memory envelopes on generated fixtures. |
 | `devtools regression-capture` | Capture pipeline-probe summaries as durable local regression cases. |
 | `devtools run-validation-lanes` | Run named validation lanes. |
 | `devtools scenario-projections` | Render the authored scenario-bearing verification projections. |
-| `devtools semantic-axis-evidence` | Generate proof-envelope performance evidence across synthetic semantic scale tiers. |
+| `devtools semantic-axis-evidence` | Generate verification-lab performance evidence across synthetic semantic scale tiers. |
 | `devtools verify` | Run the local verification baseline before pushing or creating a PR. |
 | `devtools verify-showcase` | Verify committed showcase/demo surfaces. |
 

--- a/docs/verification-lab.md
+++ b/docs/verification-lab.md
@@ -1,0 +1,71 @@
+# Verification Lab Command Surface
+
+Status: accepted for the current proof-kernel generation. Revisit when proof and
+evidence runners need a stable end-user distribution surface outside the repo
+control plane.
+
+## Decision
+
+The verification lab lives under `devtools` for now, with a narrow, named
+surface instead of a new `polylogue-lab` executable, `polylogue lab` namespace,
+or more commands under `polylogue audit`.
+
+Selected vertical slices:
+
+| Slice | Command | Role |
+| --- | --- | --- |
+| Catalog | `devtools render-verification-catalog` | Render and check the proof-obligation catalog generated from subjects, claims, runners, and compiled obligations. |
+| Routing | `devtools affected-obligations` | Map changed paths or refs to affected proof obligations and focused verification commands. |
+| Evidence | `devtools semantic-axis-evidence` | Produce comparative proof-envelope performance evidence across semantic scale tiers. |
+
+This surface is intentionally a repo operator surface. It works over proof
+subjects, generated docs, changed files, evidence envelopes, and local
+verification artifacts. Product/archive-facing checks remain in the product CLI
+where they already belong, such as `polylogue doctor --proof`, schema proof
+rendering, and archive audit exercises.
+
+## Catalog Grounding
+
+The decision depends on the proof-obligation catalog from issue #192, not on a
+hypothetical future taxonomy. The catalog at
+[`docs/verification-catalog.md`](verification-catalog.md) already records:
+
+- command subjects for the product CLI;
+- claims for CLI, schema, provider capability, operation-spec, workflow, and
+  semantic archive behavior;
+- runner bindings and trust metadata;
+- compiled obligations that affected-change routing can target.
+
+That means the first lab surface can be explicit without moving command
+implementations. `devtools render-verification-catalog` is the catalog slice,
+`devtools affected-obligations` is the routing slice, and
+`devtools semantic-axis-evidence` is the first comparative evidence slice.
+
+## Alternatives Rejected
+
+`polylogue-lab` is premature. A separate executable implies a stable public
+distribution and packaging boundary before the proof/evidence runner UX is
+settled.
+
+`polylogue lab` would put repo verification and source-control operations into
+the product CLI. That blurs the boundary between archive workflows and
+repository proof obligations.
+
+`polylogue audit` is already an archive/product QA surface. Adding the proof lab
+there would deepen the overload that this issue is meant to resolve.
+
+Exposing only `devtools render-verification-catalog` is now too narrow. The
+catalog slice exists, but affected-obligation routing and semantic-axis evidence
+also exist and need discoverable operator entry points.
+
+## Surface Rules
+
+New verification-lab commands should implement a real proof, evidence, routing,
+or catalog operation. They should not be aliases over older overloaded commands.
+
+Generated docs and `devtools --list-commands --json` must keep naming the
+selected surface, so agents and scripts can discover it without scraping prose.
+
+If a future command must operate on user archives rather than repo proof
+obligations, it belongs in the product CLI or API first, not in the
+verification-lab surface.

--- a/tests/unit/devtools/test_command_catalog.py
+++ b/tests/unit/devtools/test_command_catalog.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 from devtools.command_catalog import (
     CATEGORY_ORDER,
     COMMAND_SPECS,
+    VERIFICATION_LAB_COMMAND_NAMES,
     control_plane_argv,
     control_plane_command,
     featured_command_specs,
     grouped_command_specs,
+    verification_lab_command_specs,
 )
 
 
@@ -35,3 +37,18 @@ def test_featured_command_specs_are_actionable() -> None:
         assert spec.use_when
         assert spec.examples
         assert spec.to_dict()["argv"] == list(spec.argv)
+
+
+def test_verification_lab_surface_is_explicit_and_implemented() -> None:
+    specs = verification_lab_command_specs()
+
+    assert tuple(spec.name for spec in specs) == VERIFICATION_LAB_COMMAND_NAMES
+    assert {spec.category for spec in specs} == {"generated surfaces", "verification"}
+    assert len({spec.module for spec in specs}) == len(specs)
+
+    for spec in specs:
+        assert spec.module.startswith("devtools.")
+        assert "Alias" not in spec.description
+        assert spec.use_when
+        assert spec.examples
+        assert callable(spec.resolve_main())

--- a/tests/unit/devtools/test_devtools_main.py
+++ b/tests/unit/devtools/test_devtools_main.py
@@ -13,6 +13,11 @@ def test_list_commands_json_includes_generated_surface(capsys: pytest.CaptureFix
     assert devtools_main.main(["--list-commands", "--json"]) == 0
     payload = json.loads(capsys.readouterr().out)
     commands = {entry["name"] for entry in payload["commands"]}
+    assert payload["surfaces"]["verification_lab"] == [
+        "render-verification-catalog",
+        "affected-obligations",
+        "semantic-axis-evidence",
+    ]
     assert "artifact-graph" in commands
     assert "regression-capture" in commands
     assert "scenario-projections" in commands
@@ -24,6 +29,8 @@ def test_list_commands_json_includes_generated_surface(capsys: pytest.CaptureFix
 def test_list_commands_human_output(capsys: pytest.CaptureFixture[str]) -> None:
     assert devtools_main.main(["--list-commands"]) == 0
     captured = capsys.readouterr()
+    assert "verification lab surface:" in captured.out
+    assert "semantic-axis-evidence" in captured.out
     assert "generated surfaces:" in captured.out
     assert "artifact-graph" in captured.out
     assert "regression-capture" in captured.out

--- a/tests/unit/devtools/test_render_devtools_reference.py
+++ b/tests/unit/devtools/test_render_devtools_reference.py
@@ -3,14 +3,20 @@ from __future__ import annotations
 from pathlib import Path
 
 from devtools import render_devtools_reference
+from devtools.render_support import write_if_changed
 
 
 def test_build_command_catalog_includes_discovery_and_commands() -> None:
     rendered = render_devtools_reference.build_command_catalog()
 
     assert "## Core Loop" in rendered
+    assert "## Verification Lab Surface" in rendered
     assert "devtools --list-commands --json" in rendered
     assert "devtools status --json" in rendered
+    assert "`devtools render-verification-catalog`" in rendered
+    assert "`devtools affected-obligations`" in rendered
+    assert "`devtools semantic-axis-evidence`" in rendered
+    assert "not end-user archive workflows" in rendered
     assert (
         "| `devtools artifact-graph` | Render the runtime artifact, operation, and scenario-coverage map. |" in rendered
     )
@@ -47,10 +53,10 @@ def test_replace_marked_section_updates_catalog_block() -> None:
 def test_write_if_changed_reuses_existing_output(tmp_path: Path) -> None:
     output_path = tmp_path / "devtools.md"
     content = "hello\n"
-    render_devtools_reference.write_if_changed(output_path, content)
+    write_if_changed(output_path, content)
     original_mtime = output_path.stat().st_mtime_ns
 
-    render_devtools_reference.write_if_changed(output_path, content)
+    write_if_changed(output_path, content)
 
     assert output_path.read_text(encoding="utf-8") == content
     assert output_path.stat().st_mtime_ns == original_mtime

--- a/tests/unit/devtools/test_render_docs_surface.py
+++ b/tests/unit/devtools/test_render_docs_surface.py
@@ -10,6 +10,7 @@ def test_build_docs_readme_lists_core_and_repo_guides() -> None:
     assert "## Core References" in rendered
     assert "[CLI Reference](cli-reference.md)" in rendered
     assert "[Developer Tools](devtools.md)" in rendered
+    assert "[Verification Lab](verification-lab.md)" in rendered
     assert "## Repository Guides" in rendered
     assert "[Contributing](../CONTRIBUTING.md)" in rendered
     assert "[Local Cache Layout](../.cache/README.md)" in rendered


### PR DESCRIPTION
## Summary

Closes #336.

Defines the verification-lab command surface as a narrowed `devtools` operator surface and documents the rejected alternatives.

## Problem

After the proof-obligation kernel landed, proof/catalog/evidence capabilities existed across generated docs, devtools commands, product CLI proof outputs, and audit/showcase helpers. Without a documented surface decision, the next command-cleanliness work could either overload `polylogue audit`, prematurely create a `polylogue-lab` executable, or hide proof-lab operations as generic devtools commands.

## Solution

- Added `docs/verification-lab.md` with the accepted `devtools` surface, catalog grounding, rejection rationale, and surface rules.
- Added `VERIFICATION_LAB_COMMAND_NAMES` and `verification_lab_command_specs()` in `devtools.command_catalog`.
- Exposed the selected surface through `devtools --list-commands --json` under `surfaces.verification_lab` and in human command discovery.
- Rendered a generated Verification Lab Surface section in `docs/devtools.md` and added the reference to the generated docs map.
- Added focused devtools tests to keep the surface explicit, actionable, rendered, and backed by real command modules rather than aliases.

## Verification

- `pytest tests/unit/devtools/test_command_catalog.py tests/unit/devtools/test_render_devtools_reference.py tests/unit/devtools/test_devtools_main.py tests/unit/devtools/test_render_docs_surface.py -q`
- `pytest tests/unit/devtools -q`
- `mypy tests/unit/devtools/test_render_devtools_reference.py`
- `ruff format --check devtools tests/unit/devtools`
- `ruff check devtools tests/unit/devtools`
- `devtools render-all --check`
- `devtools verify`
- pre-push `devtools verify --quick`
