### PR TITLE
test: add structural error proof evidence

### DIFF
--- a/docs/test-quality-workflows.md
+++ b/docs/test-quality-workflows.md
@@ -27,7 +27,7 @@ Current registry snapshot:
 
 ## Runtime Coverage
 
-- covered runtime paths: `26`
+- covered runtime paths: `27`
 - covered runtime artifacts: `59`
 - covered runtime operations: `31`
 - covered maintenance targets: `3`

--- a/docs/verification-catalog.md
+++ b/docs/verification-catalog.md
@@ -8,10 +8,10 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 
 ## Snapshot
 
-- subjects: `8989`
-- claims: `13`
-- runner bindings: `13`
-- proof obligations: `9078`
+- subjects: `9026`
+- claims: `17`
+- runner bindings: `17`
+- proof obligations: `9100`
 
 ## Quality Checks
 
@@ -30,8 +30,11 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | Kind | Count |
 | --- | ---: |
 | `archive.query_law` | 1 |
+| `artifact.path` | 27 |
 | `cli.command` | 43 |
 | `cli.json_command` | 2 |
+| `error.surface` | 2 |
+| `maintenance.target` | 8 |
 | `operation.spec` | 41 |
 | `provider.capability` | 3 |
 | `schema.annotation` | 8897 |
@@ -122,6 +125,10 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | `schema.foreign_key.resolves` | `serious` | `schema.relationship.drift`<br>`synthetic-corpus.integrity` | A source path pointing at a missing target path breaks the relation claim. |
 | `schema.mutual_exclusion.exclusive` | `serious` | `schema.mutual-exclusion.drift`<br>`synthetic-corpus.invalid-combination` | A generated record containing two fields from the same exclusion group is a counterexample. |
 | `operation.spec.routing_metadata` | `serious` | `operation.routing.metadata-missing`<br>`agent-verification.unroutable-operation` | An operation without stable routing metadata cannot be mapped to focused proof checks. |
+| `artifact.path.dependency_closure` | `serious` | `artifact-graph.unresolved-dependency`<br>`structural-proof.missing-derived-layer` | A runtime path with unresolved dependencies or no derived/index/projection layer breaks routing. |
+| `maintenance.repair.crash_consistency` | `serious` | `maintenance.failure-state.ambiguous`<br>`destructive-repair.preview-mismatch` | A repair failure without an explicit unchanged/changed/rolled-back/partial state is ambiguous. |
+| `parser.quarantine.context_redaction` | `serious` | `parser-quarantine.context-loss`<br>`parser-quarantine.payload-leak` | A quarantine error without source context, or one that echoes private payload text, breaks the claim. |
+| `error.machine_user_context` | `serious` | `error-envelope.context-loss`<br>`operator-error.unactionable` | An error surface that only carries prose, or omits required context keys, is not actionable. |
 | `workflow.generated_surfaces_current` | `serious` | `generated-surface.drift`<br>`agent-context.stale-generated-doc` | Generated docs or AGENTS surfaces drift when render-all is not refreshed. |
 | `workflow.pr_verification_recorded` | `serious` | `workflow.verification-record.omitted`<br>`workflow.issue-link.omitted` | A non-trivial PR without a verification record or issue reference loses proof provenance. |
 
@@ -140,6 +147,10 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | `schema-annotation-static-contract:schema.foreign_key.resolves` | `schema.foreign_key.resolves` | `structural` | `static` | commands=—; controlled_dims=`9`; uncontrolled_dims=`0`; network=`none`; live_archive=`False` | `authored` by `polylogue.proof.catalog` at `2026-04-22T00:00:00+00:00` |
 | `schema-annotation-static-contract:schema.mutual_exclusion.exclusive` | `schema.mutual_exclusion.exclusive` | `structural` | `static` | commands=—; controlled_dims=`9`; uncontrolled_dims=`0`; network=`none`; live_archive=`False` | `authored` by `polylogue.proof.catalog` at `2026-04-22T00:00:00+00:00` |
 | `operation-spec-static-contract:operation.spec.routing_metadata` | `operation.spec.routing_metadata` | `structural` | `static` | commands=—; controlled_dims=`9`; uncontrolled_dims=`0`; network=`none`; live_archive=`False` | `authored` by `polylogue.proof.catalog` at `2026-04-22T00:00:00+00:00` |
+| `artifact-path-static-contract:artifact.path.dependency_closure` | `artifact.path.dependency_closure` | `structural` | `static` | commands=—; controlled_dims=`9`; uncontrolled_dims=`0`; network=`none`; live_archive=`False` | `authored` by `polylogue.proof.catalog` at `2026-04-22T00:00:00+00:00` |
+| `maintenance-repair-state-contract:maintenance.repair.crash_consistency` | `maintenance.repair.crash_consistency` | `structural` | `unit` | commands=—; controlled_dims=`9`; uncontrolled_dims=`0`; network=`none`; live_archive=`False` | `authored` by `polylogue.proof.catalog` at `2026-04-22T00:00:00+00:00` |
+| `parser-quarantine-error-contract:parser.quarantine.context_redaction` | `parser.quarantine.context_redaction` | `structural` | `unit` | commands=—; controlled_dims=`9`; uncontrolled_dims=`0`; network=`none`; live_archive=`False` | `authored` by `polylogue.proof.catalog` at `2026-04-22T00:00:00+00:00` |
+| `error-context-contract:error.machine_user_context` | `error.machine_user_context` | `structural` | `static` | commands=—; controlled_dims=`9`; uncontrolled_dims=`0`; network=`none`; live_archive=`False` | `authored` by `polylogue.proof.catalog` at `2026-04-22T00:00:00+00:00` |
 | `workflow-static-contract:workflow.generated_surfaces_current` | `workflow.generated_surfaces_current` | `workflow` | `static` | commands=—; controlled_dims=`9`; uncontrolled_dims=`0`; network=`none`; live_archive=`False` | `authored` by `polylogue.proof.catalog` at `2026-04-22T00:00:00+00:00` |
 | `workflow-static-contract:workflow.pr_verification_recorded` | `workflow.pr_verification_recorded` | `workflow` | `static` | commands=—; controlled_dims=`9`; uncontrolled_dims=`0`; network=`none`; live_archive=`False` | `authored` by `polylogue.proof.catalog` at `2026-04-22T00:00:00+00:00` |
 
@@ -148,11 +159,15 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | Claim | Obligations |
 | --- | ---: |
 | `archive.query.provider_filter_consistency` | 1 |
+| `artifact.path.dependency_closure` | 11 |
 | `cli.command.help` | 43 |
 | `cli.command.json_envelope` | 2 |
 | `cli.command.no_traceback` | 43 |
 | `cli.command.plain_mode` | 43 |
+| `error.machine_user_context` | 2 |
+| `maintenance.repair.crash_consistency` | 8 |
 | `operation.spec.routing_metadata` | 41 |
+| `parser.quarantine.context_redaction` | 1 |
 | `provider.capability.identity_bridge` | 3 |
 | `provider.capability.partial_coverage_declared` | 3 |
 | `schema.foreign_key.resolves` | 7 |

--- a/polylogue/artifacts.py
+++ b/polylogue/artifacts.py
@@ -843,6 +843,28 @@ RUNTIME_ARTIFACT_PATHS: tuple[ArtifactPath, ...] = (
         ),
     ),
     ArtifactPath(
+        name="raw-session-product-repair-loop",
+        description=(
+            "Raw validation and archive core rows through durable session-product rows, FTS, and projected repair semantics."
+        ),
+        nodes=(
+            "configured_sources",
+            "source_payload_stream",
+            "raw_validation_state",
+            "archive_conversation_rows",
+            "session_product_source_conversations",
+            "session_profile_rows",
+            "session_work_event_rows",
+            "session_phase_rows",
+            "work_thread_rows",
+            "session_tag_rollup_rows",
+            "day_session_summary_rows",
+            "session_product_rows",
+            "session_product_fts",
+            "session_product_readiness",
+        ),
+    ),
+    ArtifactPath(
         name="retrieval-band-readiness-loop",
         description="Embedding state plus action/session-product readiness through retrieval-band and archive readiness projections.",
         nodes=(

--- a/polylogue/proof/catalog.py
+++ b/polylogue/proof/catalog.py
@@ -148,6 +148,16 @@ def default_claims() -> tuple[Claim, ...]:
     mutual_exclusion_query = _schema_annotation_query("x-polylogue-mutually-exclusive")
     provider_capability_query = Kind("provider.capability")
     operation_query = Kind("operation.spec")
+    artifact_path_query = And(
+        (
+            Kind("artifact.path"),
+            AttrEq("has_durable_layer", True),
+            AttrEq("has_non_core_layer", True),
+        )
+    )
+    maintenance_target_query = Kind("maintenance.target")
+    parser_quarantine_query = AttrEq("error_family", "parser-quarantine")
+    error_surface_query = Kind("error.surface")
     return (
         Claim(
             id="cli.command.help",
@@ -346,6 +356,87 @@ def default_claims() -> tuple[Claim, ...]:
             ),
         ),
         Claim(
+            id="artifact.path.dependency_closure",
+            description=(
+                "Runtime artifact paths resolve declared dependencies and span durable, derived, index, or projection "
+                "layers beyond conversation/message rows."
+            ),
+            subject_query=artifact_path_query,
+            evidence_schema=_evidence_schema("path_name", "nodes", "layers", "missing_dependencies"),
+            bug_classes=("artifact-graph.unresolved-dependency", "structural-proof.missing-derived-layer"),
+            runner_classes=("artifact_path_static",),
+            observed_facts=("path_name", "nodes", "layers", "missing_dependencies", "operation_targets"),
+            staleness_conditions=("Artifact graph nodes, runtime paths, operation targets, or repair targets change.",),
+            breaker=BreakerMetadata(
+                description="A runtime path with unresolved dependencies or no derived/index/projection layer breaks routing.",
+                issue="#340",
+                command=("pytest", "tests/unit/proof/test_structural_error_evidence.py"),
+            ),
+        ),
+        Claim(
+            id="maintenance.repair.crash_consistency",
+            description=(
+                "Maintenance repair crash-consistency evidence states preview, execution, idempotence, and failure "
+                "state effects."
+            ),
+            subject_query=maintenance_target_query,
+            evidence_schema=_evidence_schema(
+                "target",
+                "preview_repaired_count",
+                "repaired_count",
+                "state_effect",
+                "failure_state",
+            ),
+            bug_classes=("maintenance.failure-state.ambiguous", "destructive-repair.preview-mismatch"),
+            runner_classes=("maintenance_repair_state",),
+            observed_facts=(
+                "target",
+                "before_count",
+                "after_dry_run_count",
+                "after_count",
+                "state_effect",
+                "failure_state",
+            ),
+            staleness_conditions=("Repair result semantics, doctor preview behavior, or maintenance targets change.",),
+            breaker=BreakerMetadata(
+                description="A repair failure without an explicit unchanged/changed/rolled-back/partial state is ambiguous.",
+                issue="#340",
+                command=("pytest", "tests/unit/proof/test_structural_error_evidence.py"),
+            ),
+        ),
+        Claim(
+            id="parser.quarantine.context_redaction",
+            description="Parser quarantine evidence keeps provider/source/path context while redacting payload fragments.",
+            subject_query=parser_quarantine_query,
+            evidence_schema=_evidence_schema("provider", "source_path", "parse_error", "payload_leak_detected"),
+            bug_classes=("parser-quarantine.context-loss", "parser-quarantine.payload-leak"),
+            runner_classes=("parser_quarantine_error",),
+            observed_facts=("provider", "source_path", "raw_id", "parse_error", "payload_leak_detected"),
+            staleness_conditions=(
+                "Raw ingest envelopes, parser diagnostics, or validation quarantine persistence changes.",
+            ),
+            breaker=BreakerMetadata(
+                description="A quarantine error without source context, or one that echoes private payload text, breaks the claim.",
+                issue="#340",
+                command=("pytest", "tests/unit/proof/test_structural_error_evidence.py"),
+            ),
+        ),
+        Claim(
+            id="error.machine_user_context",
+            description="Error surfaces expose machine-readable context and matching user-facing context checks.",
+            subject_query=error_surface_query,
+            evidence_schema=_evidence_schema("machine_payload", "user_context_checks", "privacy_checks"),
+            bug_classes=("error-envelope.context-loss", "operator-error.unactionable"),
+            runner_classes=("error_context",),
+            observed_facts=("machine_payload", "user_message", "user_context_checks", "privacy_checks"),
+            staleness_conditions=("Machine error envelope, CLI error rendering, or diagnostic context keys change.",),
+            breaker=BreakerMetadata(
+                description="An error surface that only carries prose, or omits required context keys, is not actionable.",
+                issue="#340",
+                command=("pytest", "tests/unit/proof/test_structural_error_evidence.py"),
+            ),
+        ),
+        Claim(
             id="workflow.generated_surfaces_current",
             description="Generated documentation and agent surfaces are current after their sources change.",
             subject_query=AttrEq("claim_family", "generated-surfaces"),
@@ -431,6 +522,28 @@ def default_runner_bindings(claims: Iterable[Claim]) -> tuple[RunnerBinding, ...
             bindings.append(
                 _runner_binding(claim, runner="operation-spec-static-contract", evidence_class="structural")
             )
+        elif claim.id.startswith("artifact.path."):
+            bindings.append(_runner_binding(claim, runner="artifact-path-static-contract", evidence_class="structural"))
+        elif claim.id.startswith("maintenance.repair."):
+            bindings.append(
+                _runner_binding(
+                    claim,
+                    runner="maintenance-repair-state-contract",
+                    evidence_class="structural",
+                    cost_tier="unit",
+                )
+            )
+        elif claim.id.startswith("parser.quarantine."):
+            bindings.append(
+                _runner_binding(
+                    claim,
+                    runner="parser-quarantine-error-contract",
+                    evidence_class="structural",
+                    cost_tier="unit",
+                )
+            )
+        elif claim.id.startswith("error."):
+            bindings.append(_runner_binding(claim, runner="error-context-contract", evidence_class="structural"))
         elif claim.id.startswith("workflow."):
             bindings.append(_runner_binding(claim, runner="workflow-static-contract", evidence_class="workflow"))
     return tuple(bindings)

--- a/polylogue/proof/runners.py
+++ b/polylogue/proof/runners.py
@@ -54,6 +54,52 @@ class SchemaValueGenerationObservation:
     generator: str = "hypothesis-jsonschema"
 
 
+@dataclass(frozen=True, slots=True)
+class MaintenanceRepairObservation:
+    """Observed repair/cleanup transition facts for a maintenance target."""
+
+    target: str
+    before_count: int
+    preview_repaired_count: int
+    after_dry_run_count: int
+    repaired_count: int
+    after_count: int
+    second_repair_count: int
+    state_effect: str
+    destructive: bool
+    result_success: bool = True
+    failure_state: str | None = None
+    operation: str = "polylogue doctor --repair"
+
+
+@dataclass(frozen=True, slots=True)
+class QuarantineErrorObservation:
+    """Observed parser quarantine diagnostic facts with privacy witnesses."""
+
+    provider: str
+    source_path: str
+    raw_id: str
+    parse_error: str
+    machine_payload: JSONDocument
+    user_message: str
+    payload_fragments: tuple[str, ...] = ()
+    validation_status: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ErrorContextObservation:
+    """Observed generic machine/user error context for a proof surface."""
+
+    error_family: str
+    machine_payload: JSONDocument
+    user_message: str
+    required_context: tuple[str, ...] = ()
+    payload_fragments: tuple[str, ...] = ()
+
+
+_STATE_EFFECT_VALUES = {"unchanged", "changed", "rolled_back", "partially_changed"}
+
+
 def run_cli_visual_evidence(
     obligation: ProofObligation,
     *,
@@ -224,6 +270,275 @@ def run_provider_capability_evidence(
     if obligation.claim.id == "provider.capability.partial_coverage_declared":
         return _run_provider_partial_coverage_evidence(obligation, reproducer=reproducer)
     raise ValueError(f"unsupported provider capability claim: {obligation.claim.id}")
+
+
+def run_artifact_path_evidence(
+    obligation: ProofObligation,
+    *,
+    reproducer: tuple[str, ...] = ("pytest", "tests/unit/proof/test_structural_error_evidence.py"),
+) -> EvidenceEnvelope:
+    """Verify static structural closure for one runtime artifact path."""
+    if obligation.claim.id != "artifact.path.dependency_closure":
+        raise ValueError(f"unsupported artifact path claim: {obligation.claim.id}")
+
+    attrs = obligation.subject.attrs
+    nodes = _string_tuple_attr(attrs.get("nodes"))
+    layers = require_json_document(attrs.get("layers"), context="artifact path layers")
+    missing_dependencies = _string_tuple_attr(attrs.get("missing_dependencies"))
+    operation_targets = _string_tuple_attr(attrs.get("operation_targets"))
+    external_dependencies = _string_tuple_attr(attrs.get("external_dependencies"))
+    layer_values = {value for value in layers.values() if isinstance(value, str)}
+    has_durable_layer = "durable" in layer_values
+    has_non_core_layer = bool({"derived", "index", "projection"} & layer_values)
+    observed_state: JSONDocument = {
+        "path_name": attrs.get("path_name"),
+        "nodes": list(nodes),
+        "layers": dict(layers),
+        "missing_dependencies": list(missing_dependencies),
+        "external_dependencies": list(external_dependencies),
+        "operation_targets": list(operation_targets),
+        "has_durable_layer": has_durable_layer,
+        "has_non_core_layer": has_non_core_layer,
+    }
+    expected_law = (
+        "runtime artifact paths resolve dependencies and include durable plus derived/index/projection semantics"
+    )
+    evidence = _evidence_payload(
+        obligation,
+        runner_class="artifact_path_static",
+        expected_law=expected_law,
+        observed_state=observed_state,
+    )
+    evidence["path_name"] = attrs.get("path_name")
+    evidence["nodes"] = list(nodes)
+    evidence["layers"] = dict(layers)
+    evidence["missing_dependencies"] = list(missing_dependencies)
+    evidence["external_dependencies"] = list(external_dependencies)
+    ok = bool(nodes) and not missing_dependencies and has_durable_layer and has_non_core_layer
+    return _build_envelope(
+        obligation,
+        status=OutcomeStatus.OK if ok else OutcomeStatus.ERROR,
+        evidence=evidence,
+        expected_law=expected_law,
+        observed_state=observed_state,
+        reproducer=reproducer,
+        provenance=obligation.subject.source_span,
+        producer="polylogue.proof.runners.artifact_path_static",
+    )
+
+
+def run_maintenance_repair_state_evidence(
+    obligation: ProofObligation,
+    observation: MaintenanceRepairObservation,
+    *,
+    reproducer: tuple[str, ...] = ("pytest", "tests/unit/proof/test_structural_error_evidence.py"),
+) -> EvidenceEnvelope:
+    """Verify maintenance repair evidence states dry-run, execution, and failure effects."""
+    if obligation.claim.id != "maintenance.repair.crash_consistency":
+        raise ValueError(f"unsupported maintenance repair claim: {obligation.claim.id}")
+
+    expected_target = str(obligation.subject.attrs.get("name", ""))
+    target_matches = observation.target == expected_target
+    dry_run_unchanged = observation.before_count == observation.after_dry_run_count
+    preview_matches_execution = not observation.result_success or (
+        observation.preview_repaired_count == observation.repaired_count
+    )
+    state_effect_explicit = observation.state_effect in _STATE_EFFECT_VALUES
+    failure_state_explicit = observation.result_success or observation.failure_state in _STATE_EFFECT_VALUES
+    converged_or_explained = observation.result_success or observation.after_count == observation.before_count
+    idempotent_after_success = not observation.result_success or observation.second_repair_count == 0
+    observed_state: JSONDocument = {
+        "target": observation.target,
+        "expected_target": expected_target,
+        "destructive": observation.destructive,
+        "before_count": observation.before_count,
+        "preview_repaired_count": observation.preview_repaired_count,
+        "after_dry_run_count": observation.after_dry_run_count,
+        "repaired_count": observation.repaired_count,
+        "after_count": observation.after_count,
+        "second_repair_count": observation.second_repair_count,
+        "state_effect": observation.state_effect,
+        "result_success": observation.result_success,
+        "failure_state": observation.failure_state,
+        "operation": observation.operation,
+        "checks": {
+            "target_matches": target_matches,
+            "dry_run_unchanged": dry_run_unchanged,
+            "preview_matches_execution": preview_matches_execution,
+            "state_effect_explicit": state_effect_explicit,
+            "failure_state_explicit": failure_state_explicit,
+            "converged_or_explained": converged_or_explained,
+            "idempotent_after_success": idempotent_after_success,
+        },
+    }
+    expected_law = "maintenance evidence explicitly states preview, execution, idempotence, and failure state effects"
+    evidence = _evidence_payload(
+        obligation,
+        runner_class="maintenance_repair_state",
+        expected_law=expected_law,
+        observed_state=observed_state,
+    )
+    evidence["target"] = observation.target
+    evidence["preview_repaired_count"] = observation.preview_repaired_count
+    evidence["repaired_count"] = observation.repaired_count
+    evidence["state_effect"] = observation.state_effect
+    evidence["failure_state"] = observation.failure_state
+    ok = all(
+        (
+            target_matches,
+            dry_run_unchanged,
+            preview_matches_execution,
+            state_effect_explicit,
+            failure_state_explicit,
+            converged_or_explained,
+            idempotent_after_success,
+        )
+    )
+    return _build_envelope(
+        obligation,
+        status=OutcomeStatus.OK if ok else OutcomeStatus.ERROR,
+        evidence=evidence,
+        expected_law=expected_law,
+        observed_state=observed_state,
+        reproducer=reproducer,
+        provenance=obligation.subject.source_span,
+        producer="polylogue.proof.runners.maintenance_repair_state",
+    )
+
+
+def run_quarantine_error_evidence(
+    obligation: ProofObligation,
+    observation: QuarantineErrorObservation,
+    *,
+    reproducer: tuple[str, ...] = ("pytest", "tests/unit/proof/test_structural_error_evidence.py"),
+) -> EvidenceEnvelope:
+    """Verify parser quarantine diagnostics retain context without leaking payload text."""
+    if obligation.claim.id != "parser.quarantine.context_redaction":
+        raise ValueError(f"unsupported parser quarantine claim: {obligation.claim.id}")
+
+    payload_leak_detected = _payload_leak_detected(
+        observation.payload_fragments,
+        observation.parse_error,
+        observation.user_message,
+        json.dumps(observation.machine_payload, sort_keys=True),
+    )
+    machine_details = _machine_details(observation.machine_payload)
+    context_checks: JSONDocument = {
+        "provider": bool(observation.provider) and machine_details.get("provider") == observation.provider,
+        "source_path": bool(observation.source_path) and machine_details.get("source_path") == observation.source_path,
+        "raw_id": bool(observation.raw_id) and machine_details.get("raw_id") == observation.raw_id,
+    }
+    user_context_checks: JSONDocument = {
+        "provider": observation.provider in observation.user_message,
+        "source_path": observation.source_path in observation.user_message,
+    }
+    observed_state: JSONDocument = {
+        "provider": observation.provider,
+        "source_path": observation.source_path,
+        "raw_id": observation.raw_id,
+        "parse_error": observation.parse_error,
+        "validation_status": observation.validation_status,
+        "machine_payload": dict(observation.machine_payload),
+        "user_message": observation.user_message,
+        "context_checks": context_checks,
+        "user_context_checks": user_context_checks,
+        "payload_leak_detected": payload_leak_detected,
+    }
+    expected_law = "parser quarantine diagnostics preserve source context and redact private payload fragments"
+    evidence = _evidence_payload(
+        obligation,
+        runner_class="parser_quarantine_error",
+        expected_law=expected_law,
+        observed_state=observed_state,
+    )
+    evidence["provider"] = observation.provider
+    evidence["source_path"] = observation.source_path
+    evidence["parse_error"] = observation.parse_error
+    evidence["payload_leak_detected"] = payload_leak_detected
+    ok = (
+        observation.machine_payload.get("status") == "error"
+        and all(bool(value) for value in context_checks.values())
+        and all(bool(value) for value in user_context_checks.values())
+        and not payload_leak_detected
+    )
+    return _build_envelope(
+        obligation,
+        status=OutcomeStatus.OK if ok else OutcomeStatus.ERROR,
+        evidence=evidence,
+        expected_law=expected_law,
+        observed_state=observed_state,
+        reproducer=reproducer,
+        provenance=obligation.subject.source_span,
+        producer="polylogue.proof.runners.parser_quarantine_error",
+    )
+
+
+def run_error_context_evidence(
+    obligation: ProofObligation,
+    observation: ErrorContextObservation,
+    *,
+    reproducer: tuple[str, ...] = ("pytest", "tests/unit/proof/test_structural_error_evidence.py"),
+) -> EvidenceEnvelope:
+    """Verify machine/user error context for a durable error surface."""
+    if obligation.claim.id != "error.machine_user_context":
+        raise ValueError(f"unsupported error context claim: {obligation.claim.id}")
+
+    subject_required_context = _string_tuple_attr(obligation.subject.attrs.get("required_context"))
+    required_context = observation.required_context or subject_required_context
+    machine_details = _machine_details(observation.machine_payload)
+    user_context_checks: JSONDocument = {
+        key: key in machine_details and str(machine_details.get(key)) in observation.user_message
+        for key in required_context
+    }
+    machine_context_checks: JSONDocument = {
+        key: key in machine_details and bool(machine_details.get(key)) for key in required_context
+    }
+    payload_leak_detected = _payload_leak_detected(
+        observation.payload_fragments,
+        observation.user_message,
+        json.dumps(observation.machine_payload, sort_keys=True),
+    )
+    privacy_checks: JSONDocument = {
+        "payload_fragments_redacted": not payload_leak_detected,
+        "payload_leak_detected": payload_leak_detected,
+    }
+    observed_state: JSONDocument = {
+        "error_family": observation.error_family,
+        "machine_payload": dict(observation.machine_payload),
+        "user_message": observation.user_message,
+        "required_context": list(required_context),
+        "machine_context_checks": machine_context_checks,
+        "user_context_checks": user_context_checks,
+        "privacy_checks": privacy_checks,
+    }
+    expected_law = "machine error payloads and user-facing text expose matching context without payload leaks"
+    evidence = _evidence_payload(
+        obligation,
+        runner_class="error_context",
+        expected_law=expected_law,
+        observed_state=observed_state,
+    )
+    evidence["machine_payload"] = dict(observation.machine_payload)
+    evidence["user_context_checks"] = dict(user_context_checks)
+    evidence["privacy_checks"] = dict(privacy_checks)
+    ok = (
+        observation.machine_payload.get("status") == "error"
+        and bool(observation.machine_payload.get("code"))
+        and bool(observation.machine_payload.get("message"))
+        and all(machine_context_checks.values())
+        and all(user_context_checks.values())
+        and not payload_leak_detected
+    )
+    return _build_envelope(
+        obligation,
+        status=OutcomeStatus.OK if ok else OutcomeStatus.ERROR,
+        evidence=evidence,
+        expected_law=expected_law,
+        observed_state=observed_state,
+        reproducer=reproducer,
+        provenance=obligation.subject.source_span,
+        producer="polylogue.proof.runners.error_context",
+    )
 
 
 def _run_provider_identity_bridge_evidence(
@@ -670,11 +985,27 @@ def _json_value_key(value: JSONValue) -> str:
     return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
 
 
+def _machine_details(machine_payload: JSONDocument) -> JSONDocument:
+    details = machine_payload.get("details")
+    return require_json_document(details, context="machine error details") if isinstance(details, dict) else {}
+
+
+def _payload_leak_detected(fragments: Sequence[str], *texts: str) -> bool:
+    return any(fragment and any(fragment in text for text in texts) for fragment in fragments)
+
+
 __all__ = [
+    "ErrorContextObservation",
+    "MaintenanceRepairObservation",
+    "QuarantineErrorObservation",
     "SemanticQueryObservation",
     "SchemaValueGenerationObservation",
+    "run_artifact_path_evidence",
     "run_cli_json_envelope_evidence",
     "run_provider_capability_evidence",
+    "run_error_context_evidence",
+    "run_maintenance_repair_state_evidence",
+    "run_quarantine_error_evidence",
     "run_schema_value_generation_evidence",
     "run_cli_visual_evidence",
     "run_semantic_query_evidence",

--- a/polylogue/proof/subjects.py
+++ b/polylogue/proof/subjects.py
@@ -8,9 +8,11 @@ from pathlib import Path
 
 import click
 
+from polylogue.artifact_graph import ArtifactGraph, build_artifact_graph
 from polylogue.cli.command_inventory import CommandPath, iter_command_paths
 from polylogue.lib.json import JSONDocument, json_document, json_document_list, require_json_value
 from polylogue.lib.provider_capabilities import iter_provider_capabilities
+from polylogue.maintenance_targets import MaintenanceTargetCatalog, build_maintenance_target_catalog
 from polylogue.operations import build_declared_operation_catalog
 from polylogue.proof.models import SourceSpan, SubjectRef
 from polylogue.schemas.packages import SchemaVersionPackage
@@ -160,6 +162,105 @@ def operation_spec_subjects() -> tuple[SubjectRef, ...]:
     return tuple(sorted(subjects, key=lambda subject: subject.id))
 
 
+def artifact_path_subjects(graph: ArtifactGraph | None = None) -> tuple[SubjectRef, ...]:
+    """Compile curated runtime artifact paths into structural proof subjects."""
+    runtime_graph = graph or build_artifact_graph()
+    nodes_by_name = runtime_graph.by_name()
+    subjects: list[SubjectRef] = []
+    for path in runtime_graph.paths:
+        path_nodes = tuple(nodes_by_name[name] for name in path.nodes if name in nodes_by_name)
+        path_node_names = set(path.nodes)
+        repair_targets = sorted({target for node in path_nodes for target in node.repair_targets})
+        operation_targets = tuple(operation.name for operation in runtime_graph.operations_for_path(path))
+        layer_names = sorted({node.layer.value for node in path_nodes})
+        missing_dependencies = sorted(
+            {dependency for node in path_nodes for dependency in node.depends_on if dependency not in nodes_by_name}
+        )
+        external_dependencies = sorted(
+            {
+                dependency
+                for node in path_nodes
+                for dependency in node.depends_on
+                if dependency in nodes_by_name and dependency not in path_node_names
+            }
+        )
+        attrs = _json_document(
+            {
+                "path_name": path.name,
+                "description": path.description,
+                "nodes": list(path.nodes),
+                "layers": {node.name: node.layer.value for node in path_nodes},
+                "layer_names": layer_names,
+                "has_durable_layer": "durable" in layer_names,
+                "has_non_core_layer": bool({"derived", "index", "projection"} & set(layer_names)),
+                "repair_targets": repair_targets,
+                "operation_targets": list(operation_targets),
+                "missing_dependencies": missing_dependencies,
+                "external_dependencies": external_dependencies,
+            }
+        )
+        subjects.append(
+            SubjectRef(
+                kind="artifact.path",
+                id=f"artifact.path.{path.name}",
+                attrs=attrs,
+                source_span=SourceSpan(path="polylogue/artifacts.py", symbol=path.name),
+            )
+        )
+    return tuple(sorted(subjects, key=lambda subject: subject.id))
+
+
+def maintenance_target_subjects(
+    catalog: MaintenanceTargetCatalog | None = None,
+) -> tuple[SubjectRef, ...]:
+    """Compile maintenance targets into proof subjects for repair effect claims."""
+    maintenance_catalog = catalog or build_maintenance_target_catalog()
+    return tuple(
+        sorted(
+            (
+                SubjectRef(
+                    kind="maintenance.target",
+                    id=f"maintenance.target.{target.name}",
+                    attrs=target.to_dict(),
+                    source_span=SourceSpan(path="polylogue/maintenance_targets.py", symbol=target.name),
+                )
+                for target in maintenance_catalog.specs
+            ),
+            key=lambda subject: subject.id,
+        )
+    )
+
+
+def error_surface_subjects() -> tuple[SubjectRef, ...]:
+    """Compile durable error-reporting contracts into proof subjects."""
+    return (
+        SubjectRef(
+            kind="error.surface",
+            id="error.surface.parser_quarantine",
+            attrs=_json_document(
+                {
+                    "error_family": "parser-quarantine",
+                    "required_context": ["provider", "source_path", "raw_id"],
+                    "privacy_rule": "Payload fragments are not emitted in user or machine diagnostics.",
+                }
+            ),
+            source_span=SourceSpan(path="polylogue/pipeline/services/ingest_worker.py", symbol="ingest_record"),
+        ),
+        SubjectRef(
+            kind="error.surface",
+            id="error.surface.maintenance_failure",
+            attrs=_json_document(
+                {
+                    "error_family": "maintenance-failure",
+                    "required_context": ["target", "state_effect", "operation"],
+                    "privacy_rule": "Maintenance failures report state effect, not archive payload contents.",
+                }
+            ),
+            source_span=SourceSpan(path="polylogue/storage/repair.py", symbol="RepairResult"),
+        ),
+    )
+
+
 def workflow_claim_subjects() -> tuple[SubjectRef, ...]:
     """Compile durable workflow claims that are not coupled to GitHub runtime state."""
     return (
@@ -258,6 +359,9 @@ def build_catalog_subjects() -> tuple[SubjectRef, ...]:
         *query_law_subjects(),
         *provider_capability_subjects(),
         *operation_spec_subjects(),
+        *artifact_path_subjects(),
+        *maintenance_target_subjects(),
+        *error_surface_subjects(),
         *schema_annotation_subjects(),
         *workflow_claim_subjects(),
     )
@@ -458,9 +562,12 @@ def _json_document(items: dict[str, object]) -> JSONDocument:
 __all__ = [
     "SELECTED_SCHEMA_ANNOTATIONS",
     "SELECTED_JSON_COMMANDS",
+    "artifact_path_subjects",
     "build_catalog_subjects",
     "command_subjects",
+    "error_surface_subjects",
     "json_command_subjects",
+    "maintenance_target_subjects",
     "operation_spec_subjects",
     "provider_capability_subjects",
     "query_law_subjects",

--- a/polylogue/rendering/core_markdown.py
+++ b/polylogue/rendering/core_markdown.py
@@ -49,7 +49,12 @@ def format_message_text(text: str) -> str:
             return f"```json\n{json.dumps(parsed, indent=2)}\n```"
         except json.JSONDecodeError:
             pass
-    return text
+    return _escape_message_section_markers(text)
+
+
+def _escape_message_section_markers(text: str) -> str:
+    """Prevent message body lines from masquerading as renderer section headers."""
+    return "\n".join(f"\\{line}" if line.startswith("## ") else line for line in text.split("\n"))
 
 
 def append_attachment_markdown(att: MarkdownAttachment, lines: list[str], archive_root: Path) -> None:

--- a/tests/unit/core/test_artifact_graph.py
+++ b/tests/unit/core/test_artifact_graph.py
@@ -240,6 +240,7 @@ def test_artifact_graph_paths_reference_only_declared_nodes() -> None:
         "conversation-query-loop",
         "action-event-repair-loop",
         "session-product-repair-loop",
+        "raw-session-product-repair-loop",
         "session-profile-query-loop",
         "session-enrichment-query-loop",
         "session-work-event-query-loop",

--- a/tests/unit/core/test_artifact_specs.py
+++ b/tests/unit/core/test_artifact_specs.py
@@ -55,6 +55,7 @@ def test_runtime_artifact_specs_expose_the_curated_vertical_paths() -> None:
         "raw-archive-ingest-loop",
         "action-event-repair-loop",
         "session-product-repair-loop",
+        "raw-session-product-repair-loop",
         "message-fts-readiness-loop",
         "conversation-query-loop",
         "session-profile-query-loop",

--- a/tests/unit/devtools/test_scenario_coverage.py
+++ b/tests/unit/devtools/test_scenario_coverage.py
@@ -17,6 +17,7 @@ def test_build_runtime_scenario_coverage_tracks_the_current_authored_map() -> No
         "conversation-query-loop",
         "action-event-repair-loop",
         "session-product-repair-loop",
+        "raw-session-product-repair-loop",
         "session-profile-query-loop",
         "session-enrichment-query-loop",
         "session-work-event-query-loop",

--- a/tests/unit/proof/test_catalog.py
+++ b/tests/unit/proof/test_catalog.py
@@ -35,6 +35,10 @@ def test_default_catalog_compiles_first_vertical_slice() -> None:
         "schema.foreign_key.resolves",
         "schema.mutual_exclusion.exclusive",
         "operation.spec.routing_metadata",
+        "artifact.path.dependency_closure",
+        "maintenance.repair.crash_consistency",
+        "parser.quarantine.context_redaction",
+        "error.machine_user_context",
         "workflow.generated_surfaces_current",
         "workflow.pr_verification_recorded",
     }
@@ -43,6 +47,9 @@ def test_default_catalog_compiles_first_vertical_slice() -> None:
     assert catalog.subjects_by_kind()["archive.query_law"] == 1
     assert catalog.subjects_by_kind()["provider.capability"] >= 2
     assert catalog.subjects_by_kind()["operation.spec"] >= 1
+    assert catalog.subjects_by_kind()["artifact.path"] >= 1
+    assert catalog.subjects_by_kind()["maintenance.target"] >= 1
+    assert catalog.subjects_by_kind()["error.surface"] == 2
     assert catalog.subjects_by_kind()["schema.annotation"] >= 1
     assert catalog.subjects_by_kind()["workflow.claim"] == 2
     assert {runner.claim_id for runner in catalog.runner_bindings} == {claim.id for claim in catalog.claims}

--- a/tests/unit/proof/test_structural_error_evidence.py
+++ b/tests/unit/proof/test_structural_error_evidence.py
@@ -1,0 +1,315 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import datetime, timezone
+from pathlib import Path
+
+from polylogue.config import get_config
+from polylogue.lib.json import JSONDocument, require_json_document
+from polylogue.lib.outcomes import OutcomeStatus
+from polylogue.pipeline.services.ingest_worker import ingest_record
+from polylogue.proof.catalog import build_verification_catalog
+from polylogue.proof.models import ProofObligation
+from polylogue.proof.runners import (
+    ErrorContextObservation,
+    MaintenanceRepairObservation,
+    QuarantineErrorObservation,
+    run_artifact_path_evidence,
+    run_error_context_evidence,
+    run_maintenance_repair_state_evidence,
+    run_quarantine_error_evidence,
+)
+from polylogue.storage.backends.connection import open_connection
+from polylogue.storage.blob_store import get_blob_store
+from polylogue.storage.repair import count_orphaned_messages_sync, repair_orphaned_messages
+from polylogue.storage.store import RawConversationRecord
+from polylogue.surface_payloads import MachineErrorPayload
+from tests.infra.storage_records import ConversationBuilder, db_setup
+
+PRIVATE_PAYLOAD_FRAGMENT = "private payload transcript fragment"
+
+
+def _obligation(claim_id: str, *, subject_id: str | None = None) -> ProofObligation:
+    catalog = build_verification_catalog()
+    for obligation in catalog.obligations:
+        if obligation.claim.id != claim_id:
+            continue
+        if subject_id is not None and obligation.subject.id != subject_id:
+            continue
+        return obligation
+    raise AssertionError(f"missing obligation for claim={claim_id!r} subject={subject_id!r}")
+
+
+def test_artifact_path_runner_emits_structural_closure_evidence() -> None:
+    obligation = _obligation(
+        "artifact.path.dependency_closure",
+        subject_id="artifact.path.raw-session-product-repair-loop",
+    )
+
+    envelope = run_artifact_path_evidence(obligation)
+
+    assert envelope.status is OutcomeStatus.OK
+    assert envelope.evidence["path_name"] == "raw-session-product-repair-loop"
+    assert envelope.evidence["missing_dependencies"] == []
+    nodes = envelope.evidence["nodes"]
+    assert isinstance(nodes, list)
+    assert {"raw_validation_state", "archive_conversation_rows", "session_product_rows"}.issubset(nodes)
+    layers = envelope.evidence["layers"]
+    assert isinstance(layers, dict)
+    assert "source" in set(layers.values())
+    assert "durable" in set(layers.values())
+    assert "derived" in set(layers.values())
+    assert "index" in set(layers.values())
+    assert "projection" in set(layers.values())
+    assert envelope.counterexample is None
+
+
+def test_maintenance_repair_runner_exercises_synthetic_archive_transition(
+    workspace_env: Mapping[str, Path],
+) -> None:
+    db_path = _archive_with_orphaned_messages(workspace_env)
+    config = get_config()
+
+    before_count = _orphaned_message_count(db_path)
+    preview = repair_orphaned_messages(config, dry_run=True)
+    after_dry_run_count = _orphaned_message_count(db_path)
+    repaired = repair_orphaned_messages(config, dry_run=False)
+    after_count = _orphaned_message_count(db_path)
+    second_repair = repair_orphaned_messages(config, dry_run=False)
+
+    observation = MaintenanceRepairObservation(
+        target="orphaned_messages",
+        before_count=before_count,
+        preview_repaired_count=preview.repaired_count,
+        after_dry_run_count=after_dry_run_count,
+        repaired_count=repaired.repaired_count,
+        after_count=after_count,
+        second_repair_count=second_repair.repaired_count,
+        state_effect="changed",
+        destructive=repaired.destructive,
+        result_success=repaired.success,
+        failure_state=None,
+        operation="polylogue doctor --cleanup --target orphaned_messages",
+    )
+    obligation = _obligation(
+        "maintenance.repair.crash_consistency",
+        subject_id="maintenance.target.orphaned_messages",
+    )
+
+    envelope = run_maintenance_repair_state_evidence(obligation, observation)
+
+    assert before_count == 2
+    assert preview.repaired_count == 2
+    assert after_dry_run_count == 2
+    assert repaired.repaired_count == 2
+    assert after_count == 0
+    assert second_repair.repaired_count == 0
+    assert envelope.status is OutcomeStatus.OK
+    assert envelope.evidence["target"] == "orphaned_messages"
+    assert envelope.evidence["state_effect"] == "changed"
+    assert envelope.counterexample is None
+
+
+def test_maintenance_repair_runner_rejects_ambiguous_failure_state() -> None:
+    obligation = _obligation(
+        "maintenance.repair.crash_consistency",
+        subject_id="maintenance.target.orphaned_messages",
+    )
+    observation = MaintenanceRepairObservation(
+        target="orphaned_messages",
+        before_count=2,
+        preview_repaired_count=2,
+        after_dry_run_count=2,
+        repaired_count=0,
+        after_count=2,
+        second_repair_count=0,
+        state_effect="ambiguous",
+        destructive=True,
+        result_success=False,
+        failure_state=None,
+        operation="polylogue doctor --cleanup --target orphaned_messages",
+    )
+
+    envelope = run_maintenance_repair_state_evidence(obligation, observation)
+
+    assert envelope.status is OutcomeStatus.ERROR
+    assert envelope.counterexample is not None
+
+
+def test_maintenance_repair_runner_accepts_explicit_rollback_failure_state() -> None:
+    obligation = _obligation(
+        "maintenance.repair.crash_consistency",
+        subject_id="maintenance.target.orphaned_messages",
+    )
+    observation = MaintenanceRepairObservation(
+        target="orphaned_messages",
+        before_count=2,
+        preview_repaired_count=2,
+        after_dry_run_count=2,
+        repaired_count=0,
+        after_count=2,
+        second_repair_count=0,
+        state_effect="rolled_back",
+        destructive=True,
+        result_success=False,
+        failure_state="rolled_back",
+        operation="polylogue doctor --cleanup --target orphaned_messages",
+    )
+
+    envelope = run_maintenance_repair_state_evidence(obligation, observation)
+
+    assert envelope.status is OutcomeStatus.OK
+    assert envelope.evidence["failure_state"] == "rolled_back"
+    assert envelope.counterexample is None
+
+
+def test_quarantine_runner_preserves_context_without_payload_leak(
+    workspace_env: Mapping[str, Path],
+) -> None:
+    record = _make_raw_record(
+        _codex_malformed_jsonl_bytes(),
+        provider="codex",
+        path="/exports/codex-session.jsonl",
+    )
+    result = ingest_record(record, str(workspace_env["archive_root"]), "strict")
+    parse_error = result.parse_error or result.error or ""
+    machine_payload = _machine_error_payload(
+        code="parser.quarantine",
+        message="Raw payload was quarantined",
+        details={
+            "provider": "codex",
+            "source_path": record.source_path,
+            "raw_id": record.raw_id,
+            "parse_error": parse_error,
+        },
+    )
+    observation = QuarantineErrorObservation(
+        provider="codex",
+        source_path=record.source_path,
+        raw_id=record.raw_id,
+        parse_error=parse_error,
+        machine_payload=machine_payload,
+        user_message=f"codex raw {record.source_path} was quarantined as {record.raw_id}",
+        payload_fragments=(PRIVATE_PAYLOAD_FRAGMENT,),
+        validation_status=result.validation_status,
+    )
+    obligation = _obligation(
+        "parser.quarantine.context_redaction",
+        subject_id="error.surface.parser_quarantine",
+    )
+
+    envelope = run_quarantine_error_evidence(obligation, observation)
+
+    assert result.error is not None
+    assert parse_error
+    assert PRIVATE_PAYLOAD_FRAGMENT not in parse_error
+    assert envelope.status is OutcomeStatus.OK
+    assert envelope.evidence["provider"] == "codex"
+    assert envelope.evidence["source_path"] == record.source_path
+    assert envelope.evidence["payload_leak_detected"] is False
+    assert envelope.counterexample is None
+
+
+def test_error_context_runner_checks_machine_and_user_context() -> None:
+    machine_payload = _machine_error_payload(
+        code="maintenance.failed",
+        message="Maintenance repair failed",
+        details={
+            "target": "orphaned_messages",
+            "state_effect": "rolled_back",
+            "operation": "polylogue doctor --cleanup --target orphaned_messages",
+        },
+    )
+    observation = ErrorContextObservation(
+        error_family="maintenance-failure",
+        machine_payload=machine_payload,
+        user_message=(
+            "Maintenance target orphaned_messages failed; state_effect=rolled_back; "
+            "operation=polylogue doctor --cleanup --target orphaned_messages"
+        ),
+        payload_fragments=(PRIVATE_PAYLOAD_FRAGMENT,),
+    )
+    obligation = _obligation(
+        "error.machine_user_context",
+        subject_id="error.surface.maintenance_failure",
+    )
+
+    envelope = run_error_context_evidence(obligation, observation)
+
+    assert envelope.status is OutcomeStatus.OK
+    assert envelope.evidence["user_context_checks"] == {
+        "target": True,
+        "state_effect": True,
+        "operation": True,
+    }
+    assert envelope.evidence["privacy_checks"] == {
+        "payload_fragments_redacted": True,
+        "payload_leak_detected": False,
+    }
+    assert envelope.counterexample is None
+
+
+def _archive_with_orphaned_messages(workspace_env: Mapping[str, Path]) -> Path:
+    db_path = db_setup(workspace_env)
+    ConversationBuilder(db_path, "healthy-1").provider("chatgpt").title("Healthy").add_message(
+        role="user",
+        text="A valid message",
+    ).save()
+
+    with open_connection(db_path) as conn:
+        conn.execute("PRAGMA foreign_keys = OFF")
+        conn.execute(
+            "INSERT INTO messages (message_id, conversation_id, role, text, content_hash, version, "
+            "provider_name, word_count, has_tool_use, has_thinking) "
+            "VALUES ('orphan-m1', 'deleted-conv', 'user', 'orphan text', 'oh1', 1, 'test', 2, 0, 0)"
+        )
+        conn.execute(
+            "INSERT INTO messages (message_id, conversation_id, role, text, content_hash, version, "
+            "provider_name, word_count, has_tool_use, has_thinking) "
+            "VALUES ('orphan-m2', 'deleted-conv', 'assistant', 'orphan reply', 'oh2', 1, 'test', 2, 0, 0)"
+        )
+        conn.commit()
+        conn.execute("PRAGMA foreign_keys = ON")
+    return db_path
+
+
+def _orphaned_message_count(db_path: Path) -> int:
+    with open_connection(db_path) as conn:
+        return count_orphaned_messages_sync(conn)
+
+
+def _make_raw_record(content: bytes, *, provider: str, path: str) -> RawConversationRecord:
+    raw_id, size = get_blob_store().write_from_bytes(content)
+    now = datetime.now(timezone.utc).isoformat()
+    return RawConversationRecord(
+        raw_id=raw_id,
+        provider_name=provider,
+        source_name="proof-quarantine-fixture",
+        source_path=path,
+        source_index=None,
+        blob_size=size,
+        acquired_at=now,
+        file_mtime=now,
+    )
+
+
+def _codex_malformed_jsonl_bytes() -> bytes:
+    meta = b'{"type":"session_meta","payload":{"id":"session-x","timestamp":"2025-01-01T00:00:00Z"}}'
+    good = (
+        b'{"type":"message","id":"msg-1","role":"user",'
+        b'"timestamp":"2025-01-01T00:00:01Z",'
+        b'"content":[{"type":"input_text","text":"ping"}]}'
+    )
+    bad = (
+        b'{"type":"message","id":"msg-2","role":"assistant",'
+        b'"timestamp":"2025-01-01T00:00:02Z",'
+        b'"content":[{"type":"output_text","text":"' + PRIVATE_PAYLOAD_FRAGMENT.encode() + b'"}]'
+    )
+    return meta + b"\n" + good + b"\n" + bad + b"\n"
+
+
+def _machine_error_payload(*, code: str, message: str, details: Mapping[str, object]) -> JSONDocument:
+    return require_json_document(
+        MachineErrorPayload(code=code, message=message, details=details).to_dict(),
+        context="proof machine error payload",
+    )

--- a/tests/unit/rendering/test_rendering.py
+++ b/tests/unit/rendering/test_rendering.py
@@ -340,6 +340,18 @@ class TestFormatConversationMarkdownNoneGuards:
         md = format_conversation_markdown(conv)
         assert "```json" in md
 
+    def test_message_text_heading_marker_does_not_create_extra_section(self) -> None:
+        """Body lines that look like renderer headers stay message content."""
+        conv = self._make_conv(
+            [
+                make_msg(id="m1", role="user", text="## not a message header"),
+                make_msg(id="m2", role="assistant", text="Response"),
+            ]
+        )
+        md = format_conversation_markdown(conv)
+        assert "\\## not a message header" in md
+        assert sum(1 for line in md.splitlines() if line.startswith("## ")) == 2
+
     def test_all_messages_none_text(self) -> None:
         """All messages with None text should produce header-only markdown."""
         conv = self._make_conv(


### PR DESCRIPTION
## Summary

Closes #340.

Adds structural proof subjects and evidence runners for runtime artifact paths, maintenance repair crash-consistency, parser quarantine redaction, and machine/user error context. Also fixes a markdown rendering preservation bug exposed by the full local verification baseline.

## Problem

The proof catalog covered CLI, schema, provider, and operation metadata, but it did not yet prove archive structure, destructive/repair state effects, parser quarantine diagnostics, or machine-readable/user-facing error context. #340 also requires at least one synthetic archive exercise for crash/interruption semantics and privacy-safe quarantine evidence.

While running the full baseline, Hypothesis exposed that a message body line beginning with `## ` could masquerade as a renderer message section and break markdown message-count preservation.

## Solution

- Added `artifact.path`, `maintenance.target`, and `error.surface` proof subjects.
- Added the `raw-session-product-repair-loop` curated artifact path so one structural invariant spans raw validation, archive core rows, derived session-product rows, FTS, and projected readiness.
- Added catalog claims and runner bindings for:
  - `artifact.path.dependency_closure`
  - `maintenance.repair.crash_consistency`
  - `parser.quarantine.context_redaction`
  - `error.machine_user_context`
- Added observation-based proof runners for structural paths, maintenance repair state effects, quarantine context/redaction, and generic machine/user error context.
- Added synthetic tests that exercise orphan-message dry-run/repair/idempotence, ambiguous vs rolled-back repair failure state, malformed Codex JSONL quarantine redaction, and structured error context.
- Escaped markdown message body lines starting with `## ` so body text cannot be counted as renderer section headers.
- Regenerated `docs/verification-catalog.md` and `docs/test-quality-workflows.md`.

## Verification

- `pytest tests/unit/proof/test_catalog.py tests/unit/proof/test_structural_error_evidence.py -q`
- `pytest tests/unit/proof -q`
- `ruff check polylogue/artifacts.py polylogue/proof tests/unit/proof`
- `ruff format --check polylogue/artifacts.py polylogue/proof tests/unit/proof`
- `devtools render-all --check`
- `mypy polylogue/`
- `pytest tests/unit/core/test_artifact_graph.py tests/unit/core/test_artifact_specs.py tests/unit/devtools/test_scenario_coverage.py tests/unit/proof -q`
- `pytest tests/property/test_rendering_preservation.py::test_markdown_preserves_message_count tests/unit/rendering/test_rendering.py::TestFormatConversationMarkdownNoneGuards::test_message_text_heading_marker_does_not_create_extra_section -q`
- `devtools verify`
- pre-push `devtools verify --quick`
