### PR TITLE
refactor: share sqlite backend connection semantics

### DIFF
--- a/docs/internals.md
+++ b/docs/internals.md
@@ -11,8 +11,10 @@ debugging landmarks. For the conceptual system shape, see
 | Archive writes are idempotent by content hash | `pipeline/ids.py`, `pipeline/prepare_enrichment.py` |
 | Content hash excludes user metadata (tags, summaries) | `pipeline/ids.py:conversation_content_hash()` |
 | Content hash uses NFC normalization | `lib/hashing.py:hash_text()` |
+| Async SQLite is the primary runtime; sync SQLite exists for CLI, schema tooling, and batch-ingest write paths | `storage/backends/async_sqlite.py`, `storage/backends/connection.py`, `pipeline/services/ingest_batch.py` |
+| SQLite read/write tuning is profile-driven, not backend-local | `storage/backends/connection_profile.py` |
 | FTS tokenizer is `unicode61` (no porter stemmer) | `storage/backends/schema_ddl_archive.py` |
-| Schema is fresh-only on version mismatch | `storage/backends/schema_upgrade.py` |
+| Schema bootstrap branching is shared across sync and async backends | `storage/backends/schema_bootstrap.py:decide_schema_bootstrap()` |
 
 ## Hot Files
 
@@ -31,7 +33,9 @@ debugging landmarks. For the conceptual system shape, see
 | File | Purpose |
 | --- | --- |
 | `storage/backends/schema_ddl.py` | Schema definition and `SCHEMA_VERSION` |
-| `storage/backends/schema_upgrade.py` | Fresh-init and version guard |
+| `storage/backends/schema.py` | Shared sync/async fresh-init, version guard, and extension application |
+| `storage/backends/schema_bootstrap.py` | Shared schema snapshot, bootstrap branching, and extension planning |
+| `storage/backends/connection_profile.py` | Canonical read/write SQLite timeouts, cache, mmap, and PRAGMA profiles |
 | `storage/repository.py` | Repository facade (10 mixin composition) |
 | `storage/search_providers/fts5.py` | Lexical search |
 | `storage/search_providers/hybrid.py` | Hybrid retrieval (RRF fusion) |

--- a/polylogue/pipeline/services/ingest_batch.py
+++ b/polylogue/pipeline/services/ingest_batch.py
@@ -38,10 +38,10 @@ from polylogue.pipeline.services.ingest_worker import (
     ingest_record,
 )
 from polylogue.pipeline.services.process_pool import process_pool_executor
-from polylogue.storage.backends.connection import (
+from polylogue.storage.backends.connection import _load_sqlite_vec
+from polylogue.storage.backends.connection_profile import (
     DB_TIMEOUT,
-    WRITE_CACHE_SIZE_KIB,
-    _load_sqlite_vec,
+    WRITE_CONNECTION_PRAGMA_STATEMENTS,
 )
 from polylogue.storage.conversation_replacement import (
     recount_and_prune_attachments_sync,
@@ -274,14 +274,8 @@ def _open_sync_connection(db_path: Path) -> sqlite3.Connection:
     db_path.parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(str(db_path), timeout=DB_TIMEOUT)
     conn.row_factory = sqlite3.Row
-    conn.execute("PRAGMA foreign_keys = ON")
-    conn.execute("PRAGMA journal_mode = WAL")
-    conn.execute(f"PRAGMA busy_timeout = {DB_TIMEOUT * 1000}")
-    conn.execute(f"PRAGMA cache_size = -{WRITE_CACHE_SIZE_KIB}")
-    conn.execute("PRAGMA synchronous = NORMAL")
-    conn.execute("PRAGMA mmap_size = 1073741824")
-    conn.execute("PRAGMA temp_store = MEMORY")
-    conn.execute("PRAGMA wal_autocheckpoint = 10000")
+    for statement in WRITE_CONNECTION_PRAGMA_STATEMENTS:
+        conn.execute(statement)
     _load_sqlite_vec(conn)
     return conn
 

--- a/polylogue/storage/backends/async_sqlite.py
+++ b/polylogue/storage/backends/async_sqlite.py
@@ -22,7 +22,7 @@ import polylogue.paths as _paths
 from polylogue.errors import DatabaseError
 from polylogue.storage.backends.async_sqlite_archive import SQLiteArchiveMixin
 from polylogue.storage.backends.async_sqlite_raw import SQLiteRawMixin
-from polylogue.storage.backends.connection import (
+from polylogue.storage.backends.connection_profile import (
     DB_TIMEOUT,
     READ_CONNECTION_PRAGMA_STATEMENTS,
     READ_DB_TIMEOUT,

--- a/polylogue/storage/backends/connection.py
+++ b/polylogue/storage/backends/connection.py
@@ -11,41 +11,24 @@ from typing import TYPE_CHECKING
 
 import polylogue.paths as _paths
 from polylogue.logging import get_logger
+from polylogue.storage.backends.connection_profile import (
+    DB_TIMEOUT,
+    READ_CACHE_SIZE_KIB,
+    READ_CONNECTION_PRAGMA_STATEMENTS,
+    READ_DB_TIMEOUT,
+    READ_MMAP_SIZE_BYTES,
+    WAL_AUTOCHECKPOINT_PAGES,
+    WRITE_CACHE_SIZE_KIB,
+    WRITE_CONNECTION_PRAGMA_STATEMENTS,
+    WRITE_MMAP_SIZE_BYTES,
+)
 from polylogue.storage.backends.schema import _ensure_schema
+from polylogue.storage.backends.sqlite_vec_extension import try_load_sqlite_vec
 
 if TYPE_CHECKING:
     from polylogue.storage.backends.async_sqlite import SQLiteBackend
 
 logger = get_logger(__name__)
-
-# Default SQLite connection timeout in seconds for writer-style connections.
-# Read/query paths should use a shorter read-only timeout and avoid write-ish
-# setup pragmas so they can observe the archive while a bulk ingest is active.
-DB_TIMEOUT = 30
-READ_DB_TIMEOUT = 1
-WRITE_CACHE_SIZE_KIB = 131072  # 128 MiB
-READ_CACHE_SIZE_KIB = 32768  # 32 MiB
-WRITE_MMAP_SIZE_BYTES = 1073741824  # 1 GiB
-READ_MMAP_SIZE_BYTES = 134217728  # 128 MiB
-WAL_AUTOCHECKPOINT_PAGES = 10000
-
-WRITE_CONNECTION_PRAGMA_STATEMENTS: tuple[str, ...] = (
-    "PRAGMA foreign_keys = ON",
-    "PRAGMA journal_mode=WAL",
-    f"PRAGMA busy_timeout = {DB_TIMEOUT * 1000}",
-    f"PRAGMA cache_size = -{WRITE_CACHE_SIZE_KIB}",
-    "PRAGMA synchronous = NORMAL",
-    f"PRAGMA mmap_size = {WRITE_MMAP_SIZE_BYTES}",
-    "PRAGMA temp_store = MEMORY",
-    f"PRAGMA wal_autocheckpoint = {WAL_AUTOCHECKPOINT_PAGES}",
-)
-
-READ_CONNECTION_PRAGMA_STATEMENTS: tuple[str, ...] = (
-    f"PRAGMA busy_timeout = {READ_DB_TIMEOUT * 1000}",
-    f"PRAGMA cache_size = -{READ_CACHE_SIZE_KIB}",
-    f"PRAGMA mmap_size = {READ_MMAP_SIZE_BYTES}",
-    "PRAGMA temp_store = MEMORY",
-)
 
 
 def _apply_pragma_statements(conn: sqlite3.Connection, statements: Sequence[str]) -> None:
@@ -64,20 +47,14 @@ def _load_sqlite_vec(conn: sqlite3.Connection) -> bool:
     extensions. We re-disable it after loading for security (prevents untrusted
     SQL from loading arbitrary extensions).
     """
-    try:
-        import sqlite_vec
-
-        conn.enable_load_extension(True)
-        try:
-            sqlite_vec.load(conn)
-            return True
-        finally:
-            conn.enable_load_extension(False)
-    except ImportError:
+    loaded, error = try_load_sqlite_vec(conn)
+    if loaded:
+        return True
+    if isinstance(error, ImportError):
         return False
-    except Exception as exc:
-        logger.warning("sqlite-vec extension load failed: %s", exc)
-        return False
+    if error is not None:
+        logger.warning("sqlite-vec extension load failed: %s", error)
+    return False
 
 
 def _configure_read_connection(conn: sqlite3.Connection) -> None:
@@ -237,11 +214,14 @@ def _build_provider_scope_filter(
 
 __all__ = [
     "DB_TIMEOUT",
+    "READ_CACHE_SIZE_KIB",
     "READ_CONNECTION_PRAGMA_STATEMENTS",
     "READ_MMAP_SIZE_BYTES",
     "READ_DB_TIMEOUT",
     "WAL_AUTOCHECKPOINT_PAGES",
+    "WRITE_CACHE_SIZE_KIB",
     "WRITE_CONNECTION_PRAGMA_STATEMENTS",
+    "WRITE_MMAP_SIZE_BYTES",
     "_build_provider_scope_filter",
     "_build_scope_filter",
     "_build_source_scope_filter",

--- a/polylogue/storage/backends/connection_profile.py
+++ b/polylogue/storage/backends/connection_profile.py
@@ -1,0 +1,95 @@
+"""Canonical SQLite connection profiles shared by sync and async backends."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+
+@dataclass(frozen=True, slots=True)
+class SQLiteConnectionProfile:
+    """SQLite timeout and PRAGMA profile for one connection role."""
+
+    role: Literal["read", "write"]
+    timeout_seconds: int
+    busy_timeout_ms: int
+    cache_size_kib: int
+    mmap_size_bytes: int
+    foreign_keys: bool = False
+    journal_mode: str | None = None
+    synchronous: str | None = None
+    temp_store: str = "MEMORY"
+    wal_autocheckpoint_pages: int | None = None
+
+    @property
+    def pragma_statements(self) -> tuple[str, ...]:
+        statements: list[str] = []
+        if self.foreign_keys:
+            statements.append("PRAGMA foreign_keys = ON")
+        if self.journal_mode is not None:
+            statements.append(f"PRAGMA journal_mode={self.journal_mode}")
+        statements.extend(
+            (
+                f"PRAGMA busy_timeout = {self.busy_timeout_ms}",
+                f"PRAGMA cache_size = -{self.cache_size_kib}",
+            )
+        )
+        if self.synchronous is not None:
+            statements.append(f"PRAGMA synchronous = {self.synchronous}")
+        statements.extend(
+            (
+                f"PRAGMA mmap_size = {self.mmap_size_bytes}",
+                f"PRAGMA temp_store = {self.temp_store}",
+            )
+        )
+        if self.wal_autocheckpoint_pages is not None:
+            statements.append(f"PRAGMA wal_autocheckpoint = {self.wal_autocheckpoint_pages}")
+        return tuple(statements)
+
+
+DB_TIMEOUT = 30
+READ_DB_TIMEOUT = 1
+WRITE_CACHE_SIZE_KIB = 131072  # 128 MiB
+READ_CACHE_SIZE_KIB = 32768  # 32 MiB
+WRITE_MMAP_SIZE_BYTES = 1073741824  # 1 GiB
+READ_MMAP_SIZE_BYTES = 134217728  # 128 MiB
+WAL_AUTOCHECKPOINT_PAGES = 10000
+
+WRITE_CONNECTION_PROFILE = SQLiteConnectionProfile(
+    role="write",
+    timeout_seconds=DB_TIMEOUT,
+    busy_timeout_ms=DB_TIMEOUT * 1000,
+    cache_size_kib=WRITE_CACHE_SIZE_KIB,
+    mmap_size_bytes=WRITE_MMAP_SIZE_BYTES,
+    foreign_keys=True,
+    journal_mode="WAL",
+    synchronous="NORMAL",
+    wal_autocheckpoint_pages=WAL_AUTOCHECKPOINT_PAGES,
+)
+
+READ_CONNECTION_PROFILE = SQLiteConnectionProfile(
+    role="read",
+    timeout_seconds=READ_DB_TIMEOUT,
+    busy_timeout_ms=READ_DB_TIMEOUT * 1000,
+    cache_size_kib=READ_CACHE_SIZE_KIB,
+    mmap_size_bytes=READ_MMAP_SIZE_BYTES,
+)
+
+WRITE_CONNECTION_PRAGMA_STATEMENTS = WRITE_CONNECTION_PROFILE.pragma_statements
+READ_CONNECTION_PRAGMA_STATEMENTS = READ_CONNECTION_PROFILE.pragma_statements
+
+
+__all__ = [
+    "DB_TIMEOUT",
+    "READ_CACHE_SIZE_KIB",
+    "READ_CONNECTION_PRAGMA_STATEMENTS",
+    "READ_CONNECTION_PROFILE",
+    "READ_DB_TIMEOUT",
+    "READ_MMAP_SIZE_BYTES",
+    "SQLiteConnectionProfile",
+    "WAL_AUTOCHECKPOINT_PAGES",
+    "WRITE_CACHE_SIZE_KIB",
+    "WRITE_CONNECTION_PRAGMA_STATEMENTS",
+    "WRITE_CONNECTION_PROFILE",
+    "WRITE_MMAP_SIZE_BYTES",
+]

--- a/polylogue/storage/backends/schema.py
+++ b/polylogue/storage/backends/schema.py
@@ -6,7 +6,6 @@ import sqlite3
 
 import aiosqlite
 
-from polylogue.errors import DatabaseError
 from polylogue.logging import get_logger
 from polylogue.storage.backends.schema_bootstrap import (
     SCHEMA_DDL,
@@ -19,9 +18,9 @@ from polylogue.storage.backends.schema_bootstrap import (
     build_current_schema_extension_plan,
     capture_schema_snapshot,
     capture_schema_snapshot_async,
+    decide_schema_bootstrap,
     ensure_vec0_table,
     ensure_vec0_table_async,
-    schema_version_mismatch_message,
 )
 
 logger = get_logger(__name__)
@@ -47,16 +46,22 @@ def _log_index_replacement(snapshot: SchemaSnapshot, plan: SchemaExtensionPlan) 
         logger.info("Replacing idx_raw_conv_source_mtime with partial covering definition")
 
 
-def _apply_extensions_for_snapshot(conn: sqlite3.Connection, snapshot: SchemaSnapshot) -> None:
-    plan = build_current_schema_extension_plan(snapshot)
+def _apply_extensions_for_plan(
+    conn: sqlite3.Connection,
+    snapshot: SchemaSnapshot,
+    plan: SchemaExtensionPlan,
+) -> None:
     _log_index_replacement(snapshot, plan)
     apply_schema_extension_plan(conn, plan)
     ensure_vec0_table(conn)
     conn.commit()
 
 
-async def _apply_extensions_for_snapshot_async(conn: aiosqlite.Connection, snapshot: SchemaSnapshot) -> None:
-    plan = build_current_schema_extension_plan(snapshot)
+async def _apply_extensions_for_plan_async(
+    conn: aiosqlite.Connection,
+    snapshot: SchemaSnapshot,
+    plan: SchemaExtensionPlan,
+) -> None:
     _log_index_replacement(snapshot, plan)
     await apply_schema_extension_plan_async(conn, plan)
     await ensure_vec0_table_async(conn)
@@ -64,7 +69,10 @@ async def _apply_extensions_for_snapshot_async(conn: aiosqlite.Connection, snaps
 
 
 def apply_current_schema_extensions(conn: sqlite3.Connection) -> None:
-    _apply_extensions_for_snapshot(conn, capture_schema_snapshot(conn))
+    snapshot = capture_schema_snapshot(conn)
+    decision = decide_schema_bootstrap(snapshot)
+    if decision.action == "apply_current_extensions" and decision.extension_plan is not None:
+        _apply_extensions_for_plan(conn, snapshot, decision.extension_plan)
 
 
 def _ensure_schema(conn: sqlite3.Connection) -> None:
@@ -75,7 +83,9 @@ def _ensure_schema(conn: sqlite3.Connection) -> None:
     """
     snapshot = capture_schema_snapshot(conn)
 
-    if snapshot.current_version == 0:
+    decision = decide_schema_bootstrap(snapshot)
+
+    if decision.action == "create_fresh":
         conn.execute("PRAGMA foreign_keys = ON")
         conn.executescript(SCHEMA_DDL)
         ensure_vec0_table(conn)
@@ -84,12 +94,8 @@ def _ensure_schema(conn: sqlite3.Connection) -> None:
         logger.debug("Created fresh schema v%s", SCHEMA_VERSION)
         return
 
-    assert_supported_archive_layout_snapshot(snapshot)
-
-    if snapshot.current_version != SCHEMA_VERSION:
-        raise DatabaseError(schema_version_mismatch_message(snapshot.current_version))
-
-    _apply_extensions_for_snapshot(conn, snapshot)
+    if decision.extension_plan is not None:
+        _apply_extensions_for_plan(conn, snapshot, decision.extension_plan)
 
 
 async def ensure_schema_async(conn: aiosqlite.Connection) -> None:
@@ -100,7 +106,9 @@ async def ensure_schema_async(conn: aiosqlite.Connection) -> None:
     """
     snapshot = await capture_schema_snapshot_async(conn)
 
-    if snapshot.current_version == 0:
+    decision = decide_schema_bootstrap(snapshot)
+
+    if decision.action == "create_fresh":
         await conn.execute("PRAGMA foreign_keys = ON")
         await conn.executescript(SCHEMA_DDL)
         await ensure_vec0_table_async(conn)
@@ -108,12 +116,8 @@ async def ensure_schema_async(conn: aiosqlite.Connection) -> None:
         await conn.commit()
         return
 
-    assert_supported_archive_layout_snapshot(snapshot)
-
-    if snapshot.current_version != SCHEMA_VERSION:
-        raise DatabaseError(schema_version_mismatch_message(snapshot.current_version))
-
-    await _apply_extensions_for_snapshot_async(conn, snapshot)
+    if decision.extension_plan is not None:
+        await _apply_extensions_for_plan_async(conn, snapshot, decision.extension_plan)
 
 
 __all__ = [

--- a/polylogue/storage/backends/schema_bootstrap.py
+++ b/polylogue/storage/backends/schema_bootstrap.py
@@ -6,6 +6,7 @@ import re
 import sqlite3
 from contextlib import suppress
 from dataclasses import dataclass
+from typing import Literal
 
 import aiosqlite
 
@@ -52,6 +53,14 @@ class SchemaExtensionPlan:
 
     statements: tuple[str, ...]
     scripts: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class SchemaBootstrapDecision:
+    """Shared schema bootstrap branch chosen from a schema snapshot."""
+
+    action: Literal["create_fresh", "apply_current_extensions"]
+    extension_plan: SchemaExtensionPlan | None = None
 
 
 def _normalize_sql(sql: str) -> str:
@@ -224,6 +233,22 @@ def build_current_schema_extension_plan(snapshot: SchemaSnapshot) -> SchemaExten
     return SchemaExtensionPlan(statements=tuple(statements), scripts=tuple(scripts))
 
 
+def decide_schema_bootstrap(snapshot: SchemaSnapshot) -> SchemaBootstrapDecision:
+    """Choose the canonical schema bootstrap path for sync and async backends."""
+    if snapshot.current_version == 0:
+        return SchemaBootstrapDecision(action="create_fresh")
+
+    assert_supported_archive_layout_snapshot(snapshot)
+
+    if snapshot.current_version != SCHEMA_VERSION:
+        raise DatabaseError(schema_version_mismatch_message(snapshot.current_version))
+
+    return SchemaBootstrapDecision(
+        action="apply_current_extensions",
+        extension_plan=build_current_schema_extension_plan(snapshot),
+    )
+
+
 def capture_schema_snapshot(conn: sqlite3.Connection) -> SchemaSnapshot:
     current_version = conn.execute("PRAGMA user_version").fetchone()[0]
     table_columns: dict[str, frozenset[str]] = {}
@@ -314,6 +339,7 @@ async def ensure_vec0_table_async(conn: aiosqlite.Connection) -> None:
 __all__ = [
     "SCHEMA_DDL",
     "SCHEMA_VERSION",
+    "SchemaBootstrapDecision",
     "SchemaExtensionPlan",
     "SchemaSnapshot",
     "apply_schema_extension_plan",
@@ -322,6 +348,7 @@ __all__ = [
     "build_current_schema_extension_plan",
     "capture_schema_snapshot",
     "capture_schema_snapshot_async",
+    "decide_schema_bootstrap",
     "ensure_vec0_table",
     "ensure_vec0_table_async",
     "schema_version_mismatch_message",

--- a/polylogue/storage/backends/sqlite_vec_extension.py
+++ b/polylogue/storage/backends/sqlite_vec_extension.py
@@ -1,0 +1,40 @@
+"""Shared sqlite-vec extension loading primitive."""
+
+from __future__ import annotations
+
+import sqlite3
+
+import aiosqlite
+
+
+def try_load_sqlite_vec(conn: sqlite3.Connection) -> tuple[bool, Exception | None]:
+    """Attempt to load sqlite-vec and return the failure for caller policy."""
+    try:
+        import sqlite_vec
+
+        conn.enable_load_extension(True)
+        try:
+            sqlite_vec.load(conn)
+            return True, None
+        finally:
+            conn.enable_load_extension(False)
+    except Exception as exc:
+        return False, exc
+
+
+async def try_load_sqlite_vec_async(conn: aiosqlite.Connection) -> tuple[bool, Exception | None]:
+    """Attempt to load sqlite-vec on an async connection."""
+    try:
+        import sqlite_vec
+
+        await conn.enable_load_extension(True)
+        try:
+            await conn.load_extension(sqlite_vec.loadable_path())
+            return True, None
+        finally:
+            await conn.enable_load_extension(False)
+    except Exception as exc:
+        return False, exc
+
+
+__all__ = ["try_load_sqlite_vec", "try_load_sqlite_vec_async"]

--- a/polylogue/storage/conversation_replacement.py
+++ b/polylogue/storage/conversation_replacement.py
@@ -6,6 +6,8 @@ import sqlite3
 
 import aiosqlite
 
+from polylogue.storage.backends.sqlite_vec_extension import try_load_sqlite_vec_async
+
 
 def _table_exists_sync(conn: sqlite3.Connection, table_name: str) -> bool:
     row = conn.execute(
@@ -26,19 +28,8 @@ async def _table_exists_async(conn: aiosqlite.Connection, table_name: str) -> bo
 
 
 async def _ensure_sqlite_vec_async(conn: aiosqlite.Connection) -> bool:
-    try:
-        import sqlite_vec
-
-        await conn.enable_load_extension(True)
-        try:
-            await conn.load_extension(sqlite_vec.loadable_path())
-            return True
-        finally:
-            await conn.enable_load_extension(False)
-    except ImportError:
-        return False
-    except Exception:
-        return False
+    loaded, _error = await try_load_sqlite_vec_async(conn)
+    return loaded
 
 
 def _invalidate_embedding_state_sync(conn: sqlite3.Connection, conversation_id: str) -> None:

--- a/polylogue/storage/search_providers/sqlite_vec_runtime.py
+++ b/polylogue/storage/search_providers/sqlite_vec_runtime.py
@@ -6,7 +6,8 @@ import sqlite3
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from polylogue.storage.backends.connection import DB_TIMEOUT
+from polylogue.storage.backends.connection_profile import DB_TIMEOUT
+from polylogue.storage.backends.sqlite_vec_extension import try_load_sqlite_vec
 from polylogue.storage.search_providers.sqlite_vec_support import SqliteVecError, logger
 
 
@@ -24,33 +25,22 @@ class SqliteVecRuntimeMixin:
         conn.row_factory = sqlite3.Row
 
         if self._vec_available is None:
-            try:
-                import sqlite_vec
-
-                conn.enable_load_extension(True)
-                try:
-                    sqlite_vec.load(conn)
-                finally:
-                    conn.enable_load_extension(False)
+            loaded, error = try_load_sqlite_vec(conn)
+            if loaded:
                 self._vec_available = True
-            except ImportError:
+            elif isinstance(error, ImportError):
                 logger.warning("sqlite-vec not installed")
                 self._vec_available = False
-            except (OSError, sqlite3.OperationalError) as exc:
-                logger.warning("sqlite-vec load failed: %s", exc)
+            else:
+                logger.warning("sqlite-vec load failed: %s", error)
                 self._vec_available = False
         elif self._vec_available:
-            try:
-                import sqlite_vec
-
-                conn.enable_load_extension(True)
-                try:
-                    sqlite_vec.load(conn)
-                finally:
-                    conn.enable_load_extension(False)
-            except (ImportError, OSError, sqlite3.OperationalError) as exc:
+            loaded, error = try_load_sqlite_vec(conn)
+            if not loaded:
                 conn.close()
-                raise SqliteVecError(f"sqlite-vec extension failed to load on connection: {exc}") from exc
+                if error is None:
+                    raise SqliteVecError("sqlite-vec extension failed to load on connection: unknown error")
+                raise SqliteVecError(f"sqlite-vec extension failed to load on connection: {error}") from error
 
         return conn
 

--- a/tests/unit/storage/test_backend.py
+++ b/tests/unit/storage/test_backend.py
@@ -17,14 +17,20 @@ import pytest
 import polylogue.paths
 from polylogue.lib.roles import Role
 from polylogue.storage.backends.async_sqlite import SQLiteBackend
-from polylogue.storage.backends.connection import (
+from polylogue.storage.backends.connection import connection_context, open_connection, open_read_connection
+from polylogue.storage.backends.connection_profile import (
     READ_CACHE_SIZE_KIB,
+    READ_CONNECTION_PRAGMA_STATEMENTS,
+    READ_CONNECTION_PROFILE,
     WRITE_CACHE_SIZE_KIB,
-    connection_context,
-    open_connection,
-    open_read_connection,
+    WRITE_CONNECTION_PRAGMA_STATEMENTS,
+    WRITE_CONNECTION_PROFILE,
 )
 from polylogue.storage.backends.schema import SCHEMA_VERSION, _ensure_schema
+from polylogue.storage.backends.schema_bootstrap import (
+    SchemaSnapshot,
+    decide_schema_bootstrap,
+)
 from polylogue.storage.embedding_stats_models import EmbeddingStatsSnapshot
 from polylogue.storage.query_models import ConversationRecordQuery
 from polylogue.storage.repository import ConversationRepository
@@ -100,6 +106,17 @@ def test_ensure_schema_rejects_unsupported_version(tmp_path: Path) -> None:
     assert exc_info.type.__name__ == "DatabaseError"
     assert "schema version" in str(exc_info.value).lower() or "incompatible" in str(exc_info.value).lower()
     conn.close()
+
+
+def test_schema_bootstrap_decision_rejects_unsupported_version() -> None:
+    """Sync and async schema runtimes should share version decision semantics."""
+    snapshot = SchemaSnapshot(current_version=999, table_columns={}, index_sql={})
+
+    with pytest.raises(Exception) as exc_info:
+        decide_schema_bootstrap(snapshot)
+
+    assert exc_info.type.__name__ == "DatabaseError"
+    assert "schema version" in str(exc_info.value).lower()
 
 
 def test_ensure_schema_adds_blob_size_to_legacy_v1_raw_table(tmp_path: Path) -> None:
@@ -199,6 +216,25 @@ def test_open_connection_contract(tmp_path: Path) -> None:
 
     assert db_path.exists()
     assert db_path.parent.exists()
+
+
+def test_connection_profiles_define_sqlite_tuning_once() -> None:
+    """Read and write PRAGMA statements should be derived from the shared profiles."""
+    import polylogue.pipeline.services.ingest_batch as ingest_batch_module
+    import polylogue.storage.backends.async_sqlite as async_sqlite_module
+    import polylogue.storage.backends.connection as connection_module
+
+    assert WRITE_CONNECTION_PROFILE.pragma_statements == WRITE_CONNECTION_PRAGMA_STATEMENTS
+    assert READ_CONNECTION_PROFILE.pragma_statements == READ_CONNECTION_PRAGMA_STATEMENTS
+    assert connection_module.WRITE_CONNECTION_PRAGMA_STATEMENTS == WRITE_CONNECTION_PRAGMA_STATEMENTS
+    assert vars(async_sqlite_module)["WRITE_CONNECTION_PRAGMA_STATEMENTS"] == WRITE_CONNECTION_PRAGMA_STATEMENTS
+    assert vars(ingest_batch_module)["WRITE_CONNECTION_PRAGMA_STATEMENTS"] == WRITE_CONNECTION_PRAGMA_STATEMENTS
+    assert connection_module.READ_CONNECTION_PRAGMA_STATEMENTS == READ_CONNECTION_PRAGMA_STATEMENTS
+    assert vars(async_sqlite_module)["READ_CONNECTION_PRAGMA_STATEMENTS"] == READ_CONNECTION_PRAGMA_STATEMENTS
+    assert WRITE_CONNECTION_PROFILE.busy_timeout_ms == 30000
+    assert WRITE_CONNECTION_PROFILE.cache_size_kib == WRITE_CACHE_SIZE_KIB
+    assert READ_CONNECTION_PROFILE.busy_timeout_ms == 1000
+    assert READ_CONNECTION_PROFILE.cache_size_kib == READ_CACHE_SIZE_KIB
 
 
 def test_open_read_connection_contract(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Add a shared SQLite read/write connection profile consumed by sync, async, and batch-ingest paths.
- Add shared sqlite-vec extension loading helpers for sqlite3 and aiosqlite callers.
- Move schema bootstrap branch selection into `schema_bootstrap.py` and document the canonical storage paths.

## Problem

The async runtime, sync connection helper, batch ingest writer, schema bootstrap path, and sqlite-vec callers could drift because connection tuning, extension loading mechanics, and schema branch decisions were split across backend-specific modules. That made #190 hard to verify and made future storage changes easier to land in only one path.

Closes #190.

## Solution

`polylogue/storage/backends/connection_profile.py` now owns the canonical read/write SQLite profiles and derives the PRAGMA statement tuples used by `connection.py`, `async_sqlite.py`, and `pipeline/services/ingest_batch.py`.

`polylogue/storage/backends/sqlite_vec_extension.py` now owns the extension-loading primitive for both sqlite3 and aiosqlite. Callers keep their existing policy decisions for warnings, silent fallback, or hard errors.

`polylogue/storage/backends/schema_bootstrap.py` now exposes `decide_schema_bootstrap()`, so sync and async schema runtimes share the version/bootstrap branch decision while `schema.py` remains the I/O adapter for actual sync/async application.

## Verification

- `ruff check polylogue/storage/backends/connection_profile.py polylogue/storage/backends/sqlite_vec_extension.py polylogue/storage/backends/connection.py polylogue/storage/backends/async_sqlite.py polylogue/pipeline/services/ingest_batch.py polylogue/storage/search_providers/sqlite_vec_runtime.py polylogue/storage/conversation_replacement.py tests/unit/storage/test_backend.py`
- `pytest -q tests/unit/storage/test_backend.py tests/unit/storage/test_vec.py tests/unit/test_protocol_conformance.py`
- `mypy polylogue/ tests/unit/storage/test_backend.py`
- `devtools render-all --check`
- `devtools verify`
- pre-push `devtools verify --quick`
