### PR TITLE
feat: diagnose query misses

### DIFF
--- a/polylogue/cli/machine_errors.py
+++ b/polylogue/cli/machine_errors.py
@@ -134,10 +134,13 @@ def error_no_results(
     *,
     command: list[str] | None = None,
     filters: list[str] | None = None,
+    diagnostics: JSONDocument | None = None,
 ) -> MachineError:
     details: JSONDocument = {}
     if filters:
         details["filters"] = list(filters)
+    if diagnostics:
+        details["diagnostics"] = diagnostics
     return MachineError(
         code=NO_RESULTS,
         message=message,

--- a/polylogue/cli/query.py
+++ b/polylogue/cli/query.py
@@ -40,6 +40,8 @@ if TYPE_CHECKING:
     from polylogue.config import Config
     from polylogue.lib.filters import ConversationFilter
     from polylogue.lib.models import Conversation, ConversationSummary
+    from polylogue.lib.query_miss_diagnostics import QueryMissDiagnostics
+    from polylogue.lib.query_spec import ConversationQuerySpec
     from polylogue.protocols import (
         ConversationArchiveStatsStore,
         ConversationQueryRuntimeStore,
@@ -76,12 +78,14 @@ def no_results(
     env: AppEnv,
     params: QueryParams,
     *,
+    diagnostics: QueryMissDiagnostics | None = None,
     exit_code: int | None = 2,
 ) -> None:
     """Emit the canonical query no-results message."""
     emit_no_results(
         env,
         selection=coerce_query_spec(params),
+        diagnostics=diagnostics,
         output_format=str(params.get("output_format") or "text"),
         exit_code=exit_code,
     )
@@ -283,6 +287,17 @@ def _stats_dimension(plan: QueryExecutionPlan) -> str:
     return plan.stats_dimension or "all"
 
 
+async def _diagnose_query_miss(
+    repo: QueryExecutionStore,
+    selection: ConversationQuerySpec,
+    *,
+    config: Config,
+) -> QueryMissDiagnostics:
+    from polylogue.lib.query_miss_diagnostics import diagnose_query_miss
+
+    return await diagnose_query_miss(repo, selection, config=config)
+
+
 async def _semantic_stats_summaries(
     repo: QueryExecutionStore,
     filter_chain: ConversationFilter,
@@ -376,7 +391,8 @@ async def async_execute_query_request(env: AppEnv, request: RootModeRequest) -> 
     if route == QueryRoute.SUMMARY_LIST:
         summary_results = await filter_chain.list_summaries()
         if not summary_results:
-            no_results(env, params)
+            summary_diagnostics = await _diagnose_query_miss(repo, plan.selection, config=config)
+            no_results(env, params, diagnostics=summary_diagnostics)
         await _query_output._output_summary_list(env, summary_results, plan.output, repo)
         return
 
@@ -459,7 +475,14 @@ async def async_execute_query_request(env: AppEnv, request: RootModeRequest) -> 
             open_results: Sequence[Conversation | ConversationSummary] = await filter_chain.list_summaries()
         else:
             open_results = await filter_chain.list()
-        _query_output._open_result(env, open_results, plan.output, selection=plan.selection)
+        open_diagnostics = await _diagnose_query_miss(repo, plan.selection, config=config) if not open_results else None
+        _query_output._open_result(
+            env,
+            open_results,
+            plan.output,
+            selection=plan.selection,
+            diagnostics=open_diagnostics,
+        )
         return
 
     if route in {QueryRoute.MODIFY, QueryRoute.SUMMARY_MODIFY}:
@@ -492,7 +515,16 @@ async def async_execute_query_request(env: AppEnv, request: RootModeRequest) -> 
 
     conversation_results = await filter_chain.list()
     projected_results = project_query_results(conversation_results, plan)
-    _query_output.output_results(env, projected_results, plan.output, selection=plan.selection)
+    output_diagnostics = (
+        await _diagnose_query_miss(repo, plan.selection, config=config) if not projected_results else None
+    )
+    _query_output.output_results(
+        env,
+        projected_results,
+        plan.output,
+        selection=plan.selection,
+        diagnostics=output_diagnostics,
+    )
 
 
 __all__ = [

--- a/polylogue/cli/query_feedback.py
+++ b/polylogue/cli/query_feedback.py
@@ -8,6 +8,7 @@ from polylogue.cli.machine_errors import error_no_results
 
 if TYPE_CHECKING:
     from polylogue.cli.types import AppEnv
+    from polylogue.lib.query_miss_diagnostics import QueryMissDiagnostics
     from polylogue.lib.query_spec import ConversationQuerySpec
 
 
@@ -15,6 +16,7 @@ def emit_no_results(
     env: AppEnv,
     *,
     selection: ConversationQuerySpec | None = None,
+    diagnostics: QueryMissDiagnostics | None = None,
     output_format: str = "text",
     message: str | None = None,
     hint: str | None = None,
@@ -24,7 +26,11 @@ def emit_no_results(
     filters = selection.describe() if selection is not None else []
     resolved_message = message or ("No conversations matched filters." if filters else "No conversations matched.")
     if output_format == "json":
-        error_no_results(resolved_message, filters=filters or None).emit(exit_code=exit_code or 2)
+        error_no_results(
+            resolved_message,
+            filters=filters or None,
+            diagnostics=diagnostics.to_dict() if diagnostics is not None else None,
+        ).emit(exit_code=exit_code or 2)
 
     if filters and message is None:
         env.ui.console.print("No conversations matched filters:")
@@ -33,6 +39,11 @@ def emit_no_results(
         env.ui.console.print(hint or "Hint: try broadening your filters or use `list` to browse")
     else:
         env.ui.console.print(resolved_message)
+
+    if diagnostics is not None and diagnostics.reasons:
+        env.ui.console.print("Why this may have missed:")
+        for line in diagnostics.human_reason_lines():
+            env.ui.console.print(f"  - {line}" if not line.startswith("  ") else f"    {line.strip()}")
 
     if exit_code is not None:
         raise SystemExit(exit_code)

--- a/polylogue/cli/query_output.py
+++ b/polylogue/cli/query_output.py
@@ -47,6 +47,7 @@ logger = get_logger(__name__)
 if TYPE_CHECKING:
     from polylogue.cli.types import AppEnv
     from polylogue.lib.models import Conversation, ConversationSummary, Message
+    from polylogue.lib.query_miss_diagnostics import QueryMissDiagnostics
     from polylogue.lib.query_spec import ConversationQuerySpec
     from polylogue.protocols import ConversationOutputStore
     from polylogue.storage.store import MessageRecord
@@ -263,9 +264,10 @@ def open_result(
     output: QueryOutputSpec,
     *,
     selection: ConversationQuerySpec | None = None,
+    diagnostics: QueryMissDiagnostics | None = None,
 ) -> None:
     if not results:
-        emit_no_results(env, selection=selection, output_format=output.output_format)
+        emit_no_results(env, selection=selection, diagnostics=diagnostics, output_format=output.output_format)
 
     conv = results[0]
 
@@ -648,12 +650,14 @@ def no_results(
     output: QueryOutputSpec,
     *,
     selection: ConversationQuerySpec | None = None,
+    diagnostics: QueryMissDiagnostics | None = None,
     exit_code: int | None = 2,
 ) -> None:
     """Emit the canonical no-results contract for output surfaces."""
     emit_no_results(
         env,
         selection=selection,
+        diagnostics=diagnostics,
         output_format=output.output_format,
         exit_code=exit_code,
     )
@@ -670,10 +674,11 @@ def output_results(
     output: QueryOutputSpec,
     *,
     selection: ConversationQuerySpec | None = None,
+    diagnostics: QueryMissDiagnostics | None = None,
 ) -> None:
     """Output query results."""
     if not results:
-        no_results(env, output, selection=selection)
+        no_results(env, output, selection=selection, diagnostics=diagnostics)
 
     if len(results) == 1 and not output.list_mode:
         conv = results[0]

--- a/polylogue/lib/query_miss_diagnostics.py
+++ b/polylogue/lib/query_miss_diagnostics.py
@@ -1,0 +1,289 @@
+"""Observable diagnostics for query no-result states."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Literal, cast
+
+from polylogue.lib.json import JSONDocument
+from polylogue.lib.query_retrieval_candidates import uses_action_read_model
+from polylogue.lib.query_spec import ConversationQuerySpec
+from polylogue.readiness import VerifyStatus, get_readiness
+
+if TYPE_CHECKING:
+    from polylogue.config import Config
+
+Severity = Literal["info", "warning", "error"]
+
+
+@dataclass(frozen=True, slots=True)
+class QueryMissReason:
+    """One observed reason a query may have returned no conversations."""
+
+    code: str
+    severity: Severity
+    summary: str
+    detail: str | None = None
+    count: int | None = None
+
+    def to_dict(self) -> JSONDocument:
+        payload: JSONDocument = {
+            "code": self.code,
+            "severity": self.severity,
+            "summary": self.summary,
+        }
+        if self.detail:
+            payload["detail"] = self.detail
+        if self.count is not None:
+            payload["count"] = self.count
+        return payload
+
+
+@dataclass(frozen=True, slots=True)
+class QueryMissDiagnostics:
+    """Structured no-result diagnosis shared by CLI and MCP surfaces."""
+
+    message: str
+    filters: tuple[str, ...]
+    reasons: tuple[QueryMissReason, ...]
+    archive_conversation_count: int | None = None
+    raw_conversation_count: int | None = None
+
+    def to_dict(self) -> JSONDocument:
+        payload: JSONDocument = {
+            "message": self.message,
+            "filters": list(self.filters),
+            "reasons": [reason.to_dict() for reason in self.reasons],
+        }
+        if self.archive_conversation_count is not None:
+            payload["archive_conversation_count"] = self.archive_conversation_count
+        if self.raw_conversation_count is not None:
+            payload["raw_conversation_count"] = self.raw_conversation_count
+        return payload
+
+    def human_reason_lines(self) -> list[str]:
+        """Return concise human-facing reason lines."""
+        lines: list[str] = []
+        for reason in self.reasons:
+            lines.append(reason.summary)
+            if reason.detail:
+                lines.append(f"  {reason.detail}")
+        return lines
+
+
+def _async_method(obj: object, method_name: str) -> Callable[..., Awaitable[object]] | None:
+    candidate = getattr(obj, method_name, None)
+    if not callable(candidate):
+        return None
+    return cast(Callable[..., Awaitable[object]], candidate)
+
+
+async def _call_optional(repository: object, method_name: str, *args: object, **kwargs: object) -> object | None:
+    method = _async_method(repository, method_name)
+    if method is None:
+        return None
+    try:
+        return await method(*args, **kwargs)
+    except Exception:
+        return None
+
+
+def _int_value(value: object) -> int | None:
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if isinstance(value, str):
+        try:
+            return int(value)
+        except ValueError:
+            return None
+    return None
+
+
+def _providers(stats: object | None) -> dict[str, int]:
+    value = getattr(stats, "providers", None)
+    if not isinstance(value, Mapping):
+        return {}
+    providers: dict[str, int] = {}
+    for key, count in value.items():
+        parsed = _int_value(count)
+        if parsed is not None:
+            providers[str(key)] = parsed
+    return providers
+
+
+def _selected_provider(selection: ConversationQuerySpec) -> str | None:
+    if len(selection.providers) != 1 or selection.excluded_providers:
+        return None
+    return selection.providers[0].value
+
+
+def _archive_count_for_selection(stats: object | None, selection: ConversationQuerySpec) -> int | None:
+    provider = _selected_provider(selection)
+    if provider is not None:
+        providers = _providers(stats)
+        if providers:
+            return providers.get(provider, 0)
+    return _int_value(getattr(stats, "total_conversations", None))
+
+
+def _query_miss_message(filters: tuple[str, ...]) -> str:
+    return "No conversations matched filters." if filters else "No conversations matched."
+
+
+def _readiness_index_reason(config: Config | None, selection: ConversationQuerySpec) -> QueryMissReason | None:
+    if config is None:
+        return None
+    if not isinstance(getattr(config, "db_path", None), Path):
+        return None
+    try:
+        plan = selection.to_plan()
+    except Exception:
+        return None
+    if not plan.fts_terms:
+        return None
+    try:
+        report = get_readiness(config, probe_only=True)
+    except Exception:
+        return None
+    index_check = next((check for check in report.checks if check.name == "index"), None)
+    if index_check is None or index_check.status is VerifyStatus.OK:
+        return None
+    return QueryMissReason(
+        code="message_index_degraded",
+        severity="warning",
+        summary="Message search index is not ready.",
+        detail=index_check.summary or None,
+        count=index_check.count,
+    )
+
+
+def _state_ready(state: object) -> bool:
+    ready = getattr(state, "ready", True)
+    return bool(ready)
+
+
+def _state_repair_count(state: object) -> int | None:
+    return _int_value(getattr(state, "repair_item_count", None))
+
+
+def _state_repair_detail(state: object) -> str | None:
+    repair_detail = getattr(state, "repair_detail", None)
+    if not callable(repair_detail):
+        return None
+    detail = repair_detail()
+    return str(detail) if detail else None
+
+
+async def _action_read_model_reason(
+    repository: object,
+    selection: ConversationQuerySpec,
+) -> QueryMissReason | None:
+    try:
+        plan = selection.to_plan()
+    except Exception:
+        return None
+    if not uses_action_read_model(plan):
+        return None
+    state = await _call_optional(repository, "get_action_event_artifact_state")
+    if state is None or _state_ready(state):
+        return None
+    return QueryMissReason(
+        code="action_read_model_degraded",
+        severity="warning",
+        summary="Action-event read model is not ready.",
+        detail=_state_repair_detail(state),
+        count=_state_repair_count(state),
+    )
+
+
+def _archive_empty_reason(archive_count: int | None) -> QueryMissReason | None:
+    if archive_count != 0:
+        return None
+    return QueryMissReason(
+        code="archive_empty",
+        severity="info",
+        summary="The selected archive scope has no materialized conversations.",
+        count=0,
+    )
+
+
+def _raw_backlog_reason(raw_count: int | None, archive_count: int | None) -> QueryMissReason | None:
+    if raw_count is None or raw_count <= 0:
+        return None
+    if archive_count is not None and archive_count > 0:
+        return None
+    return QueryMissReason(
+        code="raw_ingest_backlog",
+        severity="warning",
+        summary="Raw ingested conversations exist but are not materialized into searchable conversations.",
+        count=raw_count,
+    )
+
+
+def _fallback_reason(archive_count: int | None, reasons: list[QueryMissReason]) -> QueryMissReason | None:
+    if reasons:
+        return None
+    if archive_count is None or archive_count > 0:
+        return QueryMissReason(
+            code="no_matching_conversation",
+            severity="info",
+            summary="The archive is reachable, but no materialized conversation matched this selection.",
+            count=archive_count,
+        )
+    return None
+
+
+async def diagnose_query_miss(
+    repository: object,
+    selection: ConversationQuerySpec,
+    *,
+    config: Config | None = None,
+) -> QueryMissDiagnostics:
+    """Build a best-effort diagnosis for an empty query result."""
+    filters = tuple(selection.describe())
+    stats = await _call_optional(repository, "get_archive_stats")
+    archive_count = _archive_count_for_selection(stats, selection)
+    raw_count_result = await _call_optional(
+        repository,
+        "get_raw_conversation_count",
+        provider=_selected_provider(selection),
+    )
+    raw_count = _int_value(raw_count_result)
+
+    reasons: list[QueryMissReason] = []
+    readiness_reason = _readiness_index_reason(config, selection)
+    if readiness_reason is not None:
+        reasons.append(readiness_reason)
+    action_reason = await _action_read_model_reason(repository, selection)
+    if action_reason is not None:
+        reasons.append(action_reason)
+    archive_reason = _archive_empty_reason(archive_count)
+    if archive_reason is not None:
+        reasons.append(archive_reason)
+    backlog_reason = _raw_backlog_reason(raw_count, archive_count)
+    if backlog_reason is not None:
+        reasons.append(backlog_reason)
+    fallback_reason = _fallback_reason(archive_count, reasons)
+    if fallback_reason is not None:
+        reasons.append(fallback_reason)
+
+    return QueryMissDiagnostics(
+        message=_query_miss_message(filters),
+        filters=filters,
+        reasons=tuple(reasons),
+        archive_conversation_count=archive_count,
+        raw_conversation_count=raw_count,
+    )
+
+
+__all__ = [
+    "QueryMissDiagnostics",
+    "QueryMissReason",
+    "diagnose_query_miss",
+]

--- a/polylogue/mcp/payloads.py
+++ b/polylogue/mcp/payloads.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from polylogue.lib.models import Conversation
+    from polylogue.lib.query_miss_diagnostics import QueryMissDiagnostics, QueryMissReason
     from polylogue.lib.stats import ArchiveStats
     from polylogue.readiness import ReadinessCheck, ReadinessReport
 
@@ -56,11 +57,64 @@ class MCPConversationSummaryListPayload(MCPRootPayload[list[MCPConversationSumma
     root: list[MCPConversationSummaryPayload]
 
 
+class MCPQueryMissReasonPayload(SurfacePayloadModel):
+    code: str
+    severity: str
+    summary: str
+    detail: str | None = None
+    count: int | None = None
+
+    @classmethod
+    def from_reason(cls, reason: QueryMissReason) -> MCPQueryMissReasonPayload:
+        return cls(
+            code=reason.code,
+            severity=reason.severity,
+            summary=reason.summary,
+            detail=reason.detail,
+            count=reason.count,
+        )
+
+
+class MCPQueryMissDiagnosticsPayload(SurfacePayloadModel):
+    message: str
+    filters: tuple[str, ...]
+    reasons: tuple[MCPQueryMissReasonPayload, ...]
+    archive_conversation_count: int | None = None
+    raw_conversation_count: int | None = None
+
+    @classmethod
+    def from_diagnostics(cls, diagnostics: QueryMissDiagnostics) -> MCPQueryMissDiagnosticsPayload:
+        return cls(
+            message=diagnostics.message,
+            filters=diagnostics.filters,
+            reasons=tuple(MCPQueryMissReasonPayload.from_reason(reason) for reason in diagnostics.reasons),
+            archive_conversation_count=diagnostics.archive_conversation_count,
+            raw_conversation_count=diagnostics.raw_conversation_count,
+        )
+
+
+class MCPConversationQueryNoResultsPayload(SurfacePayloadModel):
+    results: tuple[MCPConversationSummaryPayload, ...] = ()
+    diagnostics: MCPQueryMissDiagnosticsPayload
+
+
 def conversation_summary_list_payload(
     conversations: Sequence[Conversation],
 ) -> MCPConversationSummaryListPayload:
     return MCPConversationSummaryListPayload(
         root=[MCPConversationSummaryPayload.from_conversation(conv) for conv in conversations]
+    )
+
+
+def conversation_query_result_payload(
+    conversations: Sequence[Conversation],
+    *,
+    diagnostics: QueryMissDiagnostics | None = None,
+) -> MCPConversationSummaryListPayload | MCPConversationQueryNoResultsPayload:
+    if conversations or diagnostics is None:
+        return conversation_summary_list_payload(conversations)
+    return MCPConversationQueryNoResultsPayload(
+        diagnostics=MCPQueryMissDiagnosticsPayload.from_diagnostics(diagnostics),
     )
 
 
@@ -210,6 +264,7 @@ class MCPReadinessReportPayload(SurfacePayloadModel):
 __all__ = [
     "MCPArchiveStatsPayload",
     "MCPConversationDetailPayload",
+    "MCPConversationQueryNoResultsPayload",
     "MCPConversationSummaryListPayload",
     "MCPConversationSummaryPayload",
     "MCPErrorPayload",
@@ -220,8 +275,11 @@ __all__ = [
     "MCPMetadataPayload",
     "MCPRootPayload",
     "MCPMutationStatusPayload",
+    "MCPQueryMissDiagnosticsPayload",
+    "MCPQueryMissReasonPayload",
     "MCPStatsByPayload",
     "MCPTagCountsPayload",
+    "conversation_query_result_payload",
     "conversation_summary_list_payload",
     "model_json_document",
     "normalize_role",

--- a/polylogue/mcp/server_tools.py
+++ b/polylogue/mcp/server_tools.py
@@ -10,6 +10,7 @@ from polylogue.mcp.payloads import (
     MCPConversationSummaryPayload,
     MCPReadinessReportPayload,
     MCPStatsByPayload,
+    conversation_query_result_payload,
     conversation_summary_list_payload,
 )
 from polylogue.mcp.query_contracts import MCPConversationQueryRequest
@@ -64,7 +65,8 @@ def register_query_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
                 min_words=min_words,
             ).build_spec(hooks.clamp_limit)
             results = await ops.query_conversations(spec)
-            return hooks.json_payload(conversation_summary_list_payload(results))
+            diagnostics = await ops.diagnose_query_miss(spec) if not results else None
+            return hooks.json_payload(conversation_query_result_payload(results, diagnostics=diagnostics))
 
         return await hooks.async_safe_call("search", run)
 
@@ -112,7 +114,8 @@ def register_query_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
                 min_words=min_words,
             ).build_spec(hooks.clamp_limit)
             conversations = await ops.query_conversations(spec)
-            return hooks.json_payload(conversation_summary_list_payload(conversations))
+            diagnostics = await ops.diagnose_query_miss(spec) if not conversations else None
+            return hooks.json_payload(conversation_query_result_payload(conversations, diagnostics=diagnostics))
 
         return await hooks.async_safe_call("list_conversations", run)
 

--- a/polylogue/operations/archive.py
+++ b/polylogue/operations/archive.py
@@ -64,6 +64,7 @@ _PROFILE_FTS_STATUS_BY_TIER: dict[str, SessionProductReadyFlag] = {
 if TYPE_CHECKING:
     from polylogue.config import Config
     from polylogue.lib.conversation_models import Conversation
+    from polylogue.lib.query_miss_diagnostics import QueryMissDiagnostics
     from polylogue.lib.stats import ArchiveStats as StorageArchiveStats
     from polylogue.storage.backends.async_sqlite import SQLiteBackend
     from polylogue.storage.repository import ConversationRepository
@@ -246,6 +247,11 @@ class ArchiveSearchMixin:
 
     async def query_conversations(self, spec: ConversationQuerySpec) -> list[Conversation]:
         return await spec.list(self.repository)
+
+    async def diagnose_query_miss(self, spec: ConversationQuerySpec) -> QueryMissDiagnostics:
+        from polylogue.lib.query_miss_diagnostics import diagnose_query_miss
+
+        return await diagnose_query_miss(self.repository, spec, config=self.config)
 
     async def get_session_tree(self, conversation_id: str) -> list[Conversation]:
         return await self.repository.get_session_tree(conversation_id)

--- a/tests/unit/cli/test_query_exec_laws.py
+++ b/tests/unit/cli/test_query_exec_laws.py
@@ -46,6 +46,7 @@ from polylogue.cli.types import AppEnv
 from polylogue.lib.json import JSONDocument
 from polylogue.lib.message_roles import MessageRoleFilter
 from polylogue.lib.models import Conversation
+from polylogue.lib.query_miss_diagnostics import QueryMissDiagnostics, QueryMissReason
 from polylogue.lib.query_spec import ConversationQuerySpec, QuerySpecError
 from polylogue.lib.roles import Role
 from polylogue.services import build_runtime_services
@@ -1008,7 +1009,7 @@ def test_output_results_no_results_contract() -> None:
         output_results(env, [], output)
 
     assert exc_info.value.code == 2
-    mock_no_results.assert_called_once_with(env, output, selection=None)
+    mock_no_results.assert_called_once_with(env, output, selection=None, diagnostics=None)
     mock_render.assert_not_called()
     mock_send.assert_not_called()
     mock_format.assert_not_called()
@@ -1534,6 +1535,65 @@ def test_no_results_contract_json_emits_machine_envelope(capsys: pytest.CaptureF
     assert payload["code"] == "no_results"
     assert payload["message"] == "No conversations matched filters."
     assert payload["details"]["filters"] == ["provider: claude-ai"]
+
+
+def test_no_results_contract_prints_diagnostics() -> None:
+    env = _make_env()
+    diagnostics = QueryMissDiagnostics(
+        message="No conversations matched filters.",
+        filters=("provider: claude-ai",),
+        reasons=(
+            QueryMissReason(
+                code="raw_ingest_backlog",
+                severity="warning",
+                summary="Raw ingested conversations exist but are not materialized into searchable conversations.",
+                detail="2 raw records observed",
+                count=2,
+            ),
+        ),
+        archive_conversation_count=0,
+        raw_conversation_count=2,
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        no_results(env, {"provider": "claude-ai"}, diagnostics=diagnostics)
+
+    assert exc_info.value.code == 2
+    observed_lines = [call.args[0] for call in _as_mock(env.ui.console.print).call_args_list if call.args]
+    assert observed_lines == [
+        "No conversations matched filters:",
+        "  provider: claude-ai",
+        "Hint: try broadening your filters or use `list` to browse",
+        "Why this may have missed:",
+        "  - Raw ingested conversations exist but are not materialized into searchable conversations.",
+        "    2 raw records observed",
+    ]
+
+
+def test_no_results_contract_json_includes_diagnostics(capsys: pytest.CaptureFixture[str]) -> None:
+    env = _make_env()
+    diagnostics = QueryMissDiagnostics(
+        message="No conversations matched filters.",
+        filters=("provider: claude-ai",),
+        reasons=(
+            QueryMissReason(
+                code="archive_empty",
+                severity="info",
+                summary="The selected archive scope has no materialized conversations.",
+                count=0,
+            ),
+        ),
+        archive_conversation_count=0,
+        raw_conversation_count=0,
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        no_results(env, {"output_format": "json", "provider": "claude-ai"}, diagnostics=diagnostics)
+
+    assert exc_info.value.code == 2
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["details"]["diagnostics"]["archive_conversation_count"] == 0
+    assert payload["details"]["diagnostics"]["reasons"][0]["code"] == "archive_empty"
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/lib/test_query_miss_diagnostics.py
+++ b/tests/unit/lib/test_query_miss_diagnostics.py
@@ -1,0 +1,122 @@
+"""Contracts for query miss diagnostics."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from polylogue.config import Config
+from polylogue.lib.outcomes import OutcomeCheck, OutcomeStatus
+from polylogue.lib.query_miss_diagnostics import QueryMissDiagnostics, diagnose_query_miss
+from polylogue.lib.query_spec import ConversationQuerySpec
+from polylogue.lib.stats import ArchiveStats
+from polylogue.readiness import ReadinessReport
+from polylogue.storage.action_event_artifacts import ActionEventArtifactState
+from polylogue.types import Provider
+
+
+def _codes(diagnostics: QueryMissDiagnostics) -> list[str]:
+    return [reason.code for reason in diagnostics.reasons]
+
+
+@pytest.mark.asyncio
+async def test_diagnose_query_miss_reports_empty_archive_scope() -> None:
+    repo = MagicMock()
+    repo.get_archive_stats = AsyncMock(return_value=ArchiveStats(total_conversations=0, total_messages=0))
+    repo.get_raw_conversation_count = AsyncMock(return_value=0)
+
+    diagnostics = await diagnose_query_miss(repo, ConversationQuerySpec())
+
+    assert _codes(diagnostics) == ["archive_empty"]
+    assert diagnostics.archive_conversation_count == 0
+    assert diagnostics.raw_conversation_count == 0
+    repo.get_raw_conversation_count.assert_awaited_once_with(provider=None)
+
+
+@pytest.mark.asyncio
+async def test_diagnose_query_miss_reports_raw_backlog_for_selected_provider() -> None:
+    repo = MagicMock()
+    repo.get_archive_stats = AsyncMock(
+        return_value=ArchiveStats(
+            total_conversations=3,
+            total_messages=12,
+            providers={"chatgpt": 3},
+        )
+    )
+    repo.get_raw_conversation_count = AsyncMock(return_value=2)
+    selection = ConversationQuerySpec(providers=(Provider.CLAUDE_AI,))
+
+    diagnostics = await diagnose_query_miss(repo, selection)
+
+    assert _codes(diagnostics) == ["archive_empty", "raw_ingest_backlog"]
+    assert diagnostics.archive_conversation_count == 0
+    assert diagnostics.raw_conversation_count == 2
+    repo.get_raw_conversation_count.assert_awaited_once_with(provider="claude-ai")
+
+
+@pytest.mark.asyncio
+async def test_diagnose_query_miss_reports_degraded_action_readiness() -> None:
+    repo = MagicMock()
+    repo.get_archive_stats = AsyncMock(return_value=ArchiveStats(total_conversations=5, total_messages=20))
+    repo.get_raw_conversation_count = AsyncMock(return_value=0)
+    repo.get_action_event_artifact_state = AsyncMock(
+        return_value=ActionEventArtifactState(
+            source_conversations=5,
+            materialized_conversations=3,
+            materialized_rows=4,
+            fts_rows=1,
+        )
+    )
+    selection = ConversationQuerySpec(action_terms=("file_edit",))
+
+    diagnostics = await diagnose_query_miss(repo, selection)
+
+    assert _codes(diagnostics) == ["action_read_model_degraded"]
+    reason = diagnostics.reasons[0]
+    assert reason.count == 5
+    assert "missing conversations" in str(reason.detail)
+
+
+@pytest.mark.asyncio
+async def test_diagnose_query_miss_reports_degraded_message_index() -> None:
+    repo = MagicMock()
+    repo.get_archive_stats = AsyncMock(return_value=ArchiveStats(total_conversations=5, total_messages=20))
+    repo.get_raw_conversation_count = AsyncMock(return_value=0)
+    report = ReadinessReport(
+        checks=[
+            OutcomeCheck(
+                "index",
+                OutcomeStatus.WARNING,
+                summary="messages indexed: 1/20",
+                count=1,
+            )
+        ]
+    )
+
+    with patch("polylogue.lib.query_miss_diagnostics.get_readiness", return_value=report) as mock_readiness:
+        diagnostics = await diagnose_query_miss(
+            repo,
+            ConversationQuerySpec(query_terms=("needle",)),
+            config=cast(Config, SimpleNamespace(db_path=Path("archive.sqlite"))),
+        )
+
+    assert _codes(diagnostics) == ["message_index_degraded"]
+    assert diagnostics.reasons[0].detail == "messages indexed: 1/20"
+    assert diagnostics.reasons[0].count == 1
+    mock_readiness.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_diagnose_query_miss_falls_back_to_matching_absence() -> None:
+    repo = MagicMock()
+    repo.get_archive_stats = AsyncMock(return_value=ArchiveStats(total_conversations=5, total_messages=20))
+    repo.get_raw_conversation_count = AsyncMock(return_value=0)
+
+    diagnostics = await diagnose_query_miss(repo, ConversationQuerySpec(query_terms=("absent",)))
+
+    assert _codes(diagnostics) == ["no_matching_conversation"]
+    assert diagnostics.reasons[0].count == 5

--- a/tests/unit/mcp/test_tool_contracts.py
+++ b/tests/unit/mcp/test_tool_contracts.py
@@ -35,6 +35,7 @@ from polylogue.archive_products import (
     WorkThreadProduct,
 )
 from polylogue.lib.models import Conversation, ConversationSummary
+from polylogue.lib.query_miss_diagnostics import QueryMissDiagnostics, QueryMissReason
 from polylogue.lib.query_spec import ConversationQuerySpec
 from polylogue.lib.stats import ArchiveStats
 from polylogue.types import ConversationId, Provider
@@ -306,15 +307,33 @@ class TestQueryTools:
 
     @pytest.mark.asyncio
     async def test_search_with_empty_query(self, mcp_server: MCPServerUnderTest) -> None:
+        diagnostics = QueryMissDiagnostics(
+            message="No conversations matched.",
+            filters=(),
+            reasons=(
+                QueryMissReason(
+                    code="archive_empty",
+                    severity="info",
+                    summary="The selected archive scope has no materialized conversations.",
+                    count=0,
+                ),
+            ),
+            archive_conversation_count=0,
+            raw_conversation_count=0,
+        )
         with patch("polylogue.mcp.server._get_archive_ops") as mock_get_archive_ops:
             mock_ops = MagicMock()
             mock_ops.query_conversations = AsyncMock(return_value=[])
+            mock_ops.diagnose_query_miss = AsyncMock(return_value=diagnostics)
             mock_get_archive_ops.return_value = mock_ops
 
             result = await invoke_surface_async(mcp_server._tool_manager._tools["search"].fn, query="", limit=10)
 
         parsed = json.loads(result)
-        assert isinstance(parsed, (list, dict))
+        assert parsed["results"] == []
+        assert parsed["diagnostics"]["archive_conversation_count"] == 0
+        assert parsed["diagnostics"]["reasons"][0]["code"] == "archive_empty"
+        mock_ops.diagnose_query_miss.assert_awaited_once()
 
 
 class TestGetConversationTool:


### PR DESCRIPTION
## Summary

- Adds a shared query-miss diagnostic model for empty query results.
- Surfaces observed no-result causes in CLI plain/JSON output and MCP search/list responses.
- Covers empty archive scopes, raw-ingest backlog, message FTS readiness, and action-event read-model readiness.

Closes #217

## Problem

Query and MCP no-result paths previously collapsed several distinct operator states into a generic empty result. That made an absent match look the same as an empty archive, an unbuilt/degraded index, an action read-model gap, or raw ingested data that had not reached materialized conversations.

## Solution

- Added `polylogue/lib/query_miss_diagnostics.py` as the shared diagnostic builder over observable archive stats, raw conversation counts, readiness checks, and action-event artifact state.
- Threaded diagnostics through CLI no-result emitters and machine-error details without changing the existing successful output shape.
- Added MCP empty-result payloads with `results: []` plus structured diagnostics while preserving the existing root-list payload for successful search/list calls.
- Exposed `ArchiveSearchMixin.diagnose_query_miss()` so MCP and other archive operation surfaces can reuse the same semantics.
- Added focused unit coverage for archive-empty, raw-backlog, degraded message FTS, degraded action readiness, CLI diagnostics, and MCP diagnostics.

## Verification

```bash
ruff check polylogue/lib/query_miss_diagnostics.py polylogue/cli/query.py polylogue/cli/query_feedback.py polylogue/cli/machine_errors.py polylogue/cli/query_output.py polylogue/mcp/payloads.py polylogue/mcp/server_tools.py polylogue/operations/archive.py tests/unit/lib/test_query_miss_diagnostics.py tests/unit/cli/test_query_exec_laws.py tests/unit/mcp/test_tool_contracts.py
mypy polylogue/lib/query_miss_diagnostics.py polylogue/cli/query.py polylogue/cli/query_feedback.py polylogue/cli/query_output.py polylogue/mcp/payloads.py polylogue/mcp/server_tools.py polylogue/operations/archive.py tests/unit/lib/test_query_miss_diagnostics.py tests/unit/cli/test_query_exec_laws.py tests/unit/mcp/test_tool_contracts.py
pytest -q tests/unit/lib/test_query_miss_diagnostics.py tests/unit/cli/test_query_exec_laws.py tests/unit/mcp/test_tool_contracts.py
devtools verify
```

Pre-push also ran `devtools verify --quick` through the repository hook.
