### PR TITLE
perf: report slow query progress

### DIFF
--- a/polylogue/cli/query.py
+++ b/polylogue/cli/query.py
@@ -298,6 +298,25 @@ async def _diagnose_query_miss(
     return await diagnose_query_miss(repo, selection, config=config)
 
 
+async def _observe_query_operation(
+    repo: QueryExecutionStore,
+    plan: QueryExecutionPlan,
+    route: QueryRoute,
+    operation: Awaitable[_T],
+) -> _T:
+    from polylogue.cli.query_progress import (
+        build_query_slow_notice,
+        observe_slow_query,
+        should_emit_slow_query_notes,
+    )
+
+    return await observe_slow_query(
+        operation,
+        enabled=should_emit_slow_query_notes(plan.output),
+        notice_factory=lambda: build_query_slow_notice(repo, plan.selection, route=route.value),
+    )
+
+
 async def _semantic_stats_summaries(
     repo: QueryExecutionStore,
     filter_chain: ConversationFilter,
@@ -385,11 +404,11 @@ async def async_execute_query_request(env: AppEnv, request: RootModeRequest) -> 
     route = resolve_query_route(plan, can_use_summaries=filter_chain.can_use_summaries())
 
     if route == QueryRoute.COUNT:
-        click.echo(await filter_chain.count())
+        click.echo(await _observe_query_operation(repo, plan, route, filter_chain.count()))
         return
 
     if route == QueryRoute.SUMMARY_LIST:
-        summary_results = await filter_chain.list_summaries()
+        summary_results = await _observe_query_operation(repo, plan, route, filter_chain.list_summaries())
         if not summary_results:
             summary_diagnostics = await _diagnose_query_miss(repo, plan.selection, config=config)
             no_results(env, params, diagnostics=summary_diagnostics)
@@ -423,17 +442,22 @@ async def async_execute_query_request(env: AppEnv, request: RootModeRequest) -> 
         return
 
     if route == QueryRoute.STATS_SQL:
-        await _query_output.output_stats_sql(
-            env,
-            filter_chain,
+        await _observe_query_operation(
             repo,
-            selection=plan.selection,
-            output_format=plan.output.output_format,
+            plan,
+            route,
+            _query_output.output_stats_sql(
+                env,
+                filter_chain,
+                repo,
+                selection=plan.selection,
+                output_format=plan.output.output_format,
+            ),
         )
         return
 
     if route == QueryRoute.SUMMARY_STATS:
-        summaries = await filter_chain.list_summaries()
+        summaries = await _observe_query_operation(repo, plan, route, filter_chain.list_summaries())
         msg_counts = await repo.get_message_counts_batch([str(summary.id) for summary in summaries])
         _query_output.output_stats_by_summaries(
             env,
@@ -446,7 +470,12 @@ async def async_execute_query_request(env: AppEnv, request: RootModeRequest) -> 
         return
 
     if route == QueryRoute.STATS_BY and plan.stats_dimension in {"action", "tool"}:
-        semantic_summaries = await _semantic_stats_summaries(repo, filter_chain)
+        semantic_summaries = await _observe_query_operation(
+            repo,
+            plan,
+            route,
+            _semantic_stats_summaries(repo, filter_chain),
+        )
         if semantic_summaries is not None:
             await _query_output.output_stats_by_semantic_summaries(
                 env,
@@ -459,7 +488,7 @@ async def async_execute_query_request(env: AppEnv, request: RootModeRequest) -> 
             return
 
     if route == QueryRoute.STATS_BY and plan.stats_dimension in {"repo", "work-kind"}:
-        summaries = await _profile_stats_summaries(repo, filter_chain)
+        summaries = await _observe_query_operation(repo, plan, route, _profile_stats_summaries(repo, filter_chain))
         await _query_output.output_stats_by_profile_summaries(
             env,
             summaries,
@@ -472,9 +501,14 @@ async def async_execute_query_request(env: AppEnv, request: RootModeRequest) -> 
 
     if route == QueryRoute.OPEN:
         if filter_chain.can_use_summaries():
-            open_results: Sequence[Conversation | ConversationSummary] = await filter_chain.list_summaries()
+            open_results: Sequence[Conversation | ConversationSummary] = await _observe_query_operation(
+                repo,
+                plan,
+                route,
+                filter_chain.list_summaries(),
+            )
         else:
-            open_results = await filter_chain.list()
+            open_results = await _observe_query_operation(repo, plan, route, filter_chain.list())
         open_diagnostics = await _diagnose_query_miss(repo, plan.selection, config=config) if not open_results else None
         _query_output._open_result(
             env,
@@ -487,22 +521,27 @@ async def async_execute_query_request(env: AppEnv, request: RootModeRequest) -> 
 
     if route in {QueryRoute.MODIFY, QueryRoute.SUMMARY_MODIFY}:
         if route == QueryRoute.SUMMARY_MODIFY:
-            matched_results: Sequence[Conversation | ConversationSummary] = await filter_chain.list_summaries()
+            matched_results: Sequence[Conversation | ConversationSummary] = await _observe_query_operation(
+                repo,
+                plan,
+                route,
+                filter_chain.list_summaries(),
+            )
         else:
-            matched_results = await filter_chain.list()
+            matched_results = await _observe_query_operation(repo, plan, route, filter_chain.list())
         await _query_actions.apply_modifiers(env, matched_results, plan.mutation, repo)
         return
 
     if route in {QueryRoute.DELETE, QueryRoute.SUMMARY_DELETE}:
         if route == QueryRoute.SUMMARY_DELETE:
-            matched_results = await filter_chain.list_summaries()
+            matched_results = await _observe_query_operation(repo, plan, route, filter_chain.list_summaries())
         else:
-            matched_results = await filter_chain.list()
+            matched_results = await _observe_query_operation(repo, plan, route, filter_chain.list())
         await _query_actions.delete_conversations(env, matched_results, plan.mutation, repo)
         return
 
     if route == QueryRoute.STATS_BY:
-        conversation_results = await filter_chain.list()
+        conversation_results = await _observe_query_operation(repo, plan, route, filter_chain.list())
         projected_results = project_query_results(conversation_results, plan)
         _query_output._output_stats_by(
             env,
@@ -513,7 +552,7 @@ async def async_execute_query_request(env: AppEnv, request: RootModeRequest) -> 
         )
         return
 
-    conversation_results = await filter_chain.list()
+    conversation_results = await _observe_query_operation(repo, plan, route, filter_chain.list())
     projected_results = project_query_results(conversation_results, plan)
     output_diagnostics = (
         await _diagnose_query_miss(repo, plan.selection, config=config) if not projected_results else None

--- a/polylogue/cli/query_progress.py
+++ b/polylogue/cli/query_progress.py
@@ -1,0 +1,153 @@
+"""Slow-query transparency helpers for CLI query execution."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, TypeVar, cast
+
+import click
+
+from polylogue.cli.query_contracts import QueryOutputSpec
+from polylogue.lib.query_retrieval_candidates import uses_action_read_model
+from polylogue.lib.query_spec import ConversationQuerySpec
+
+if TYPE_CHECKING:
+    from polylogue.storage.action_event_artifacts import ActionEventArtifactState
+
+_T = TypeVar("_T")
+
+MACHINE_OUTPUT_FORMATS = frozenset({"json", "yaml", "csv"})
+SLOW_QUERY_NOTICE_SECONDS = 2.0
+
+
+@dataclass(frozen=True, slots=True)
+class QuerySlowNotice:
+    """One human-facing slow-query notice."""
+
+    route: str
+    retrieval_lane: str
+    fallback_detail: str | None = None
+
+    def message(self, *, elapsed_seconds: float) -> str:
+        parts = [
+            f"Query still running after {_format_elapsed(elapsed_seconds)}",
+            f"route: {self.route}",
+            f"retrieval: {self.retrieval_lane}",
+        ]
+        if self.fallback_detail:
+            parts.append(self.fallback_detail)
+        return f"{parts[0]} ({'; '.join(parts[1:])})."
+
+
+def slow_query_notice_threshold() -> float:
+    """Return the slow-query notice threshold, allowing local override."""
+    raw_value = os.environ.get("POLYLOGUE_SLOW_QUERY_NOTICE_SECONDS")
+    if raw_value is None:
+        return SLOW_QUERY_NOTICE_SECONDS
+    try:
+        value = float(raw_value)
+    except ValueError:
+        return SLOW_QUERY_NOTICE_SECONDS
+    return max(value, 0.0)
+
+
+def should_emit_slow_query_notes(output: QueryOutputSpec) -> bool:
+    """Return whether progress notes are safe for this output mode."""
+    return output.output_format not in MACHINE_OUTPUT_FORMATS
+
+
+def _format_elapsed(seconds: float) -> str:
+    if seconds < 10:
+        return f"{seconds:.1f}s"
+    if seconds < 60:
+        return f"{seconds:.0f}s"
+    minutes = int(seconds // 60)
+    remainder = int(seconds % 60)
+    return f"{minutes}m{remainder:02d}s"
+
+
+def _async_method(obj: object, method_name: str) -> Callable[..., Awaitable[object]] | None:
+    candidate = getattr(obj, method_name, None)
+    if not callable(candidate):
+        return None
+    return cast(Callable[..., Awaitable[object]], candidate)
+
+
+async def _action_event_state(repository: object) -> ActionEventArtifactState | None:
+    method = _async_method(repository, "get_action_event_artifact_state")
+    if method is None:
+        return None
+    try:
+        result = await method()
+    except Exception:
+        return None
+    return cast("ActionEventArtifactState | None", result)
+
+
+def _action_fallback_detail(state: ActionEventArtifactState | None) -> str | None:
+    if state is None or state.ready:
+        return None
+    return state.repair_detail()
+
+
+async def build_query_slow_notice(
+    repository: object,
+    selection: object,
+    *,
+    route: str,
+) -> QuerySlowNotice:
+    """Build a slow-query notice from facts available after the operation stalls."""
+    retrieval_lane = "unknown"
+    fallback_detail = None
+    if isinstance(selection, ConversationQuerySpec):
+        try:
+            plan = selection.to_plan()
+        except Exception:
+            plan = None
+        if plan is not None:
+            retrieval_lane = plan.retrieval_lane
+            if uses_action_read_model(plan):
+                fallback_detail = _action_fallback_detail(await _action_event_state(repository))
+    return QuerySlowNotice(
+        route=route,
+        retrieval_lane=retrieval_lane,
+        fallback_detail=fallback_detail,
+    )
+
+
+async def observe_slow_query(
+    operation: Awaitable[_T],
+    *,
+    enabled: bool,
+    notice_factory: Callable[[], Awaitable[QuerySlowNotice]],
+    threshold_seconds: float | None = None,
+    emit: Callable[[str], None] | None = None,
+) -> _T:
+    """Run an operation and emit one human notice if it exceeds the threshold."""
+    if not enabled:
+        return await operation
+
+    threshold = slow_query_notice_threshold() if threshold_seconds is None else max(threshold_seconds, 0.0)
+    task = asyncio.ensure_future(operation)
+    done, _pending = await asyncio.wait({task}, timeout=threshold)
+    if done:
+        return task.result()
+
+    notice = await notice_factory()
+    sink = emit or (lambda message: click.echo(message, err=True))
+    sink(notice.message(elapsed_seconds=threshold))
+    return await task
+
+
+__all__ = [
+    "MACHINE_OUTPUT_FORMATS",
+    "QuerySlowNotice",
+    "SLOW_QUERY_NOTICE_SECONDS",
+    "build_query_slow_notice",
+    "observe_slow_query",
+    "should_emit_slow_query_notes",
+    "slow_query_notice_threshold",
+]

--- a/tests/unit/cli/test_query_exec_laws.py
+++ b/tests/unit/cli/test_query_exec_laws.py
@@ -1495,6 +1495,103 @@ def test_async_execute_query_show_projects_results_before_output_contract() -> N
     assert [message.id for message in projected_results[0].messages] == ["m-user", "m-assistant"]
 
 
+def test_async_execute_query_slow_human_query_emits_progress_note() -> None:
+    env = _make_env(repo=MagicMock(), config=MagicMock())
+    selection = MagicMock()
+    selection.similar_text = None
+    plan = QueryExecutionPlan(
+        selection=selection,
+        action=QueryAction.SHOW,
+        output=_output_spec(),
+        mutation=_mutation_spec(),
+    )
+    filter_chain = MagicMock()
+    filter_chain.can_use_summaries.return_value = False
+
+    async def delayed_list() -> list[Conversation]:
+        await asyncio.sleep(0.01)
+        return [_sample_conversation()]
+
+    filter_chain.list = AsyncMock(side_effect=delayed_list)
+    selection.build_filter.return_value = filter_chain
+
+    with (
+        patch("polylogue.cli.helpers.load_effective_config", return_value=MagicMock()),
+        patch("polylogue.storage.search_providers.create_vector_provider", return_value=None),
+        patch("polylogue.cli.query.build_query_execution_plan", return_value=plan),
+        patch("polylogue.cli.query_progress.SLOW_QUERY_NOTICE_SECONDS", 0.001),
+        patch("polylogue.cli.query_output.output_results"),
+        patch("click.echo") as mock_echo,
+    ):
+        mock_echo = _as_mock(mock_echo)
+        asyncio.run(async_execute_query(env, {}))
+
+    filter_chain.list.assert_awaited_once()
+    progress_calls = [call for call in mock_echo.call_args_list if call.kwargs.get("err") is True]
+    assert len(progress_calls) == 1
+    assert "Query still running after 0.0s" in progress_calls[0].args[0]
+    assert "route: show" in progress_calls[0].args[0]
+
+
+def test_async_execute_query_slow_json_query_suppresses_progress_note() -> None:
+    env = _make_env(repo=MagicMock(), config=MagicMock())
+    selection = MagicMock()
+    selection.similar_text = None
+    plan = QueryExecutionPlan(
+        selection=selection,
+        action=QueryAction.SHOW,
+        output=_output_spec("json"),
+        mutation=_mutation_spec(),
+    )
+    filter_chain = MagicMock()
+    filter_chain.can_use_summaries.return_value = False
+
+    async def delayed_list() -> list[Conversation]:
+        await asyncio.sleep(0.01)
+        return [_sample_conversation()]
+
+    filter_chain.list = AsyncMock(side_effect=delayed_list)
+    selection.build_filter.return_value = filter_chain
+
+    with (
+        patch("polylogue.cli.helpers.load_effective_config", return_value=MagicMock()),
+        patch("polylogue.storage.search_providers.create_vector_provider", return_value=None),
+        patch("polylogue.cli.query.build_query_execution_plan", return_value=plan),
+        patch("polylogue.cli.query_progress.SLOW_QUERY_NOTICE_SECONDS", 0.001),
+        patch("polylogue.cli.query_output.output_results"),
+        patch("click.echo") as mock_echo,
+    ):
+        mock_echo = _as_mock(mock_echo)
+        asyncio.run(async_execute_query(env, {}))
+
+    filter_chain.list.assert_awaited_once()
+    mock_echo.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_slow_query_notice_reports_degraded_action_read_model() -> None:
+    from polylogue.cli.query_progress import build_query_slow_notice
+
+    repo = MagicMock()
+    repo.get_action_event_artifact_state = AsyncMock(
+        return_value=ActionEventArtifactState(
+            source_conversations=4,
+            materialized_conversations=2,
+            materialized_rows=2,
+            fts_rows=0,
+        )
+    )
+
+    notice = await build_query_slow_notice(
+        repo,
+        ConversationQuerySpec(retrieval_lane="actions"),
+        route=QueryRoute.SHOW.value,
+    )
+
+    assert notice.retrieval_lane == "actions"
+    assert "Action-event read model pending" in notice.message(elapsed_seconds=2.0)
+
+
 @pytest.mark.parametrize(
     ("params", "expected_lines"),
     [


### PR DESCRIPTION
## Summary
- Add a slow-query observer around CLI search/query execution paths.
- Emit one human-only stderr progress note after a configurable threshold.
- Include route, retrieval lane, and degraded action-read-model context when available.
- Keep JSON, YAML, and CSV output streams clean.

Closes #219

## Problem
Long CLI searches can appear hung, especially when execution falls back to a slower retrieval path or an action-event read model is not materialized. Before this change, human users received no progress signal while machine-readable output contracts could not tolerate extra status text.

## Solution
- Added `polylogue/cli/query_progress.py` with the slow-query notice model, machine-output suppression, threshold handling, and action read-model context probing.
- Wrapped the main query retrieval operations in `polylogue/cli/query.py` so slow searches, counts, stats, open, modify, and delete paths report progress consistently.
- Added CLI law tests proving human progress notes are emitted, JSON output stays silent, and degraded action read-model context is included.

## Verification
- `ruff check polylogue/cli/query_progress.py polylogue/cli/query.py tests/unit/cli/test_query_exec_laws.py tests/unit/cli/test_query_exec.py`
- `mypy polylogue/cli/query_progress.py polylogue/cli/query.py tests/unit/cli/test_query_exec_laws.py tests/unit/cli/test_query_exec.py`
- `pytest -q tests/unit/cli/test_query_exec_laws.py tests/unit/cli/test_query_exec.py tests/unit/cli/test_json_envelope_contract.py`
- `pytest -q tests/unit/security/test_attachment_security.py::test_path_traversal_creates_valid_attachment`
- `devtools verify`
- push hook: `devtools verify --quick`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * CLI queries now display progress notices when queries run longer than a configurable threshold.
  * Progress notices are suppressed for machine-readable output formats.
  * Notices include elapsed time, operation route, and retrieval lane information.

* **Tests**
  * Added test coverage for slow-query progress notification behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->