### PR TITLE
feat: add evidence-bearing search hits

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ polylogue --latest open
 polylogue "urgent" --tag review delete --dry-run
 ```
 
+Text searches that render result lists include match evidence alongside the
+conversation identity: rank, retrieval lane, matched surface, message id, and a
+snippet when the FTS index can provide one.
+
 The pipeline and archive-maintenance surfaces are explicit verbs:
 
 ```bash

--- a/docs/library-api.md
+++ b/docs/library-api.md
@@ -270,7 +270,7 @@ asyncio.run(main())
 | `get_conversation(id)` | Get single conversation by ID |
 | `get_conversations(ids)` | Parallel batch fetch (5-10x faster) |
 | `list_conversations(provider, limit)` | List with optional filtering |
-| `search(query, limit, source, since)` | Full-text search |
+| `search(query, limit, source, since)` | Full-text search returning message-level evidence snippets |
 | `parse_file(path, source_name)` | Parse a single export file |
 | `parse_sources(sources, download_assets)` | Parse from configured sources |
 | `rebuild_index()` | Rebuild FTS5 search index |

--- a/docs/mcp-integration.md
+++ b/docs/mcp-integration.md
@@ -49,7 +49,7 @@ Add to `~/.config/claude/claude_desktop_config.json`:
 
 | Tool | Description |
 |------|-------------|
-| `search` | Search conversations by text query with optional provider/date filters |
+| `search` | Search conversations by text query with optional provider/date filters; returns conversation summaries plus match rank, lane, surface, message id, and snippet evidence |
 | `list_conversations` | List recent conversations, optionally filtered |
 | `get_conversation` | Get a single conversation by ID (supports prefix matching) |
 | `stats` | Archive statistics: totals, provider breakdown, database size |

--- a/polylogue/cli/query.py
+++ b/polylogue/cli/query.py
@@ -42,6 +42,7 @@ if TYPE_CHECKING:
     from polylogue.lib.models import Conversation, ConversationSummary
     from polylogue.lib.query_miss_diagnostics import QueryMissDiagnostics
     from polylogue.lib.query_spec import ConversationQuerySpec
+    from polylogue.lib.search_hits import ConversationSearchHit
     from polylogue.protocols import (
         ConversationArchiveStatsStore,
         ConversationQueryRuntimeStore,
@@ -317,6 +318,20 @@ async def _observe_query_operation(
     )
 
 
+async def _search_hits_for_execution_plan(
+    repo: QueryExecutionStore,
+    plan: QueryExecutionPlan,
+    *,
+    vector_provider: VectorProvider | None,
+) -> list[ConversationSearchHit] | None:
+    from polylogue.lib.query_search_hits import plan_has_search_hit_evidence, search_hits_for_plan
+
+    query_plan = plan.selection.to_plan(vector_provider=vector_provider)
+    if not plan_has_search_hit_evidence(query_plan):
+        return None
+    return await search_hits_for_plan(query_plan, repo)
+
+
 async def _semantic_stats_summaries(
     repo: QueryExecutionStore,
     filter_chain: ConversationFilter,
@@ -408,6 +423,19 @@ async def async_execute_query_request(env: AppEnv, request: RootModeRequest) -> 
         return
 
     if route == QueryRoute.SUMMARY_LIST:
+        search_hits = await _observe_query_operation(
+            repo,
+            plan,
+            route,
+            _search_hits_for_execution_plan(repo, plan, vector_provider=vector_provider),
+        )
+        if search_hits is not None:
+            if not search_hits:
+                summary_diagnostics = await _diagnose_query_miss(repo, plan.selection, config=config)
+                no_results(env, params, diagnostics=summary_diagnostics)
+            await _query_output.output_search_hits(env, search_hits, plan.output, repo)
+            return
+
         summary_results = await _observe_query_operation(repo, plan, route, filter_chain.list_summaries())
         if not summary_results:
             summary_diagnostics = await _diagnose_query_miss(repo, plan.selection, config=config)
@@ -557,6 +585,11 @@ async def async_execute_query_request(env: AppEnv, request: RootModeRequest) -> 
     output_diagnostics = (
         await _diagnose_query_miss(repo, plan.selection, config=config) if not projected_results else None
     )
+    if output_diagnostics is None and (plan.output.list_mode or len(projected_results) > 1):
+        search_hits = await _search_hits_for_execution_plan(repo, plan, vector_provider=vector_provider)
+        if search_hits is not None:
+            await _query_output.output_search_hits(env, search_hits, plan.output, repo)
+            return
     _query_output.output_results(
         env,
         projected_results,

--- a/polylogue/cli/query_output.py
+++ b/polylogue/cli/query_output.py
@@ -40,7 +40,7 @@ from polylogue.lib.message_roles import MessageRoleFilter, message_role_count_ke
 from polylogue.lib.roles import Role
 from polylogue.logging import get_logger
 from polylogue.rendering.formatting import format_conversation
-from polylogue.surface_payloads import ConversationListRowPayload
+from polylogue.surface_payloads import ConversationListRowPayload, ConversationSearchHitPayload, model_json_document
 
 logger = get_logger(__name__)
 
@@ -49,6 +49,7 @@ if TYPE_CHECKING:
     from polylogue.lib.models import Conversation, ConversationSummary, Message
     from polylogue.lib.query_miss_diagnostics import QueryMissDiagnostics
     from polylogue.lib.query_spec import ConversationQuerySpec
+    from polylogue.lib.search_hits import ConversationSearchHit
     from polylogue.protocols import ConversationOutputStore
     from polylogue.storage.store import MessageRecord
 
@@ -75,6 +76,16 @@ def _summary_list_line(summary: ConversationSummary, message_count: int) -> str:
     date = _display_date(summary.display_date)
     title = _ellipsize(summary.display_title or str(summary.id)[:20], 50)
     return f"{str(summary.id)[:24]:24s}  {date:10s}  {summary.provider:12s}  {title} ({message_count} msgs)"
+
+
+def _search_hit_list_line(hit: ConversationSearchHit, message_count: int) -> str:
+    base = _summary_list_line(hit.summary, message_count)
+    evidence_parts = [hit.match_surface, hit.retrieval_lane]
+    if hit.message_id:
+        evidence_parts.append(f"message {hit.message_id}")
+    evidence = "/".join(evidence_parts)
+    snippet = f": {hit.snippet}" if hit.snippet else ""
+    return f"{base}\n  match[{hit.rank}]: {evidence}{snippet}"
 
 
 def _stream_date_parts(display_date: object | None) -> tuple[str | None, str | None]:
@@ -377,6 +388,142 @@ def format_summary_list(
         return buf.getvalue().rstrip("\r\n")
 
     return "\n".join(_summary_list_line(summary, message_counts.get(str(summary.id), 0)) for summary in summaries)
+
+
+def _search_hit_to_payload(
+    hit: ConversationSearchHit,
+    *,
+    message_count: int,
+) -> JSONDocument:
+    return model_json_document(
+        ConversationSearchHitPayload.from_search_hit(hit, message_count=message_count),
+        exclude_none=True,
+    )
+
+
+def format_search_hit_list(
+    hits: list[ConversationSearchHit],
+    output_format: str,
+    fields: str | None,
+    *,
+    message_counts: dict[str, int] | None = None,
+) -> str:
+    """Format evidence-bearing search hits for deterministic surfaces."""
+    message_counts = message_counts or {}
+    selected = {field.strip() for field in fields.split(",")} if fields else None
+
+    data = [
+        _search_hit_to_payload(
+            hit, message_count=message_counts.get(hit.conversation_id, hit.summary.message_count or 0)
+        )
+        for hit in hits
+    ]
+    if selected:
+        data = [{key: value for key, value in item.items() if key in selected} for item in data]
+
+    if output_format == "json":
+        return json.dumps(data, indent=2)
+
+    if output_format == "yaml":
+        import yaml
+
+        return yaml.dump(data, default_flow_style=False, allow_unicode=True)
+
+    if output_format == "csv":
+        import csv
+        import io
+
+        buf = io.StringIO()
+        writer = csv.writer(buf)
+        writer.writerow(
+            [
+                "id",
+                "date",
+                "provider",
+                "title",
+                "messages",
+                "rank",
+                "retrieval_lane",
+                "match_surface",
+                "message_id",
+                "snippet",
+            ]
+        )
+        for hit in hits:
+            summary = hit.summary
+            writer.writerow(
+                [
+                    str(summary.id),
+                    _display_date(summary.display_date),
+                    summary.provider,
+                    summary.display_title or "",
+                    message_counts.get(hit.conversation_id, summary.message_count or 0),
+                    hit.rank,
+                    hit.retrieval_lane,
+                    hit.match_surface,
+                    hit.message_id or "",
+                    hit.snippet or "",
+                ]
+            )
+        return buf.getvalue().rstrip("\r\n")
+
+    return "\n".join(
+        _search_hit_list_line(hit, message_counts.get(hit.conversation_id, hit.summary.message_count or 0))
+        for hit in hits
+    )
+
+
+async def output_search_hits(
+    env: AppEnv,
+    hits: list[ConversationSearchHit],
+    output: QueryOutputSpec,
+    repo: ConversationOutputStore | None = None,
+) -> None:
+    """Output evidence-bearing search hits with optional rich table rendering."""
+    msg_counts: dict[str, int] = {}
+    if repo:
+        ids = [hit.conversation_id for hit in hits]
+        msg_counts = await repo.get_message_counts_batch(ids)
+
+    if output.output_format in MACHINE_OUTPUT_FORMATS or env.ui.plain:
+        click.echo(
+            format_search_hit_list(
+                hits,
+                "text" if env.ui.plain and output.output_format not in MACHINE_OUTPUT_FORMATS else output.output_format,
+                output.fields,
+                message_counts=msg_counts,
+            )
+        )
+        return
+
+    from rich.table import Table
+    from rich.text import Text
+
+    from polylogue.ui.theme import provider_color
+
+    table = Table(show_header=True, header_style="bold", box=None, pad_edge=False, show_edge=False)
+    table.add_column("ID", style="dim", max_width=24, no_wrap=True)
+    table.add_column("Date", style="dim")
+    table.add_column("Provider")
+    table.add_column("Title", ratio=1)
+    table.add_column("Msgs", justify="right")
+    table.add_column("Match", ratio=1)
+
+    for hit in hits:
+        summary = hit.summary
+        date = _display_date(summary.display_date)
+        title = _ellipsize(summary.display_title or str(summary.id)[:20], 54)
+        count = msg_counts.get(hit.conversation_id, summary.message_count or 0)
+        provider_text = Text(summary.provider, style=provider_color(summary.provider).hex)
+        snippet = _ellipsize(hit.snippet or "", 80)
+        match = f"{hit.match_surface}/{hit.retrieval_lane}"
+        if hit.message_id:
+            match = f"{match} {hit.message_id}"
+        if snippet:
+            match = f"{match}: {snippet}"
+        table.add_row(str(summary.id)[:24], date, provider_text, title, str(count), match)
+
+    env.ui.console.print(table)
 
 
 async def output_summary_list(
@@ -735,11 +882,13 @@ __all__ = [
     "emit_structured_stats",
     "filtered_action_events",
     "format_list",
+    "format_search_hit_list",
     "format_summary_list",
     "normalized_tool_name",
     "open_in_browser",
     "open_result",
     "output_results",
+    "output_search_hits",
     "output_stats_by_conversations",
     "output_stats_by_profile_ids",
     "output_stats_by_profile_query",

--- a/polylogue/lib/query_search_hits.py
+++ b/polylogue/lib/query_search_hits.py
@@ -1,0 +1,97 @@
+"""Evidence-bearing search-hit execution over canonical query plans."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from polylogue.lib.query_retrieval import search_limit
+from polylogue.lib.query_retrieval_search import search_query_text
+from polylogue.lib.query_support import provider_values
+from polylogue.lib.search_hits import (
+    ConversationSearchHit,
+    conversation_search_hit_from_conversation,
+)
+
+if TYPE_CHECKING:
+    from polylogue.lib.query_plan import ConversationQueryPlan
+    from polylogue.protocols import ConversationQueryRuntimeStore
+
+
+def plan_has_search_hit_evidence(plan: ConversationQueryPlan) -> bool:
+    return bool(plan.fts_terms or plan.similar_text)
+
+
+def _simple_message_hit_plan(plan: ConversationQueryPlan) -> bool:
+    return bool(
+        plan.fts_terms
+        and plan.retrieval_lane in {"auto", "dialogue"}
+        and plan.conversation_id is None
+        and plan.similar_text is None
+        and not plan.negative_terms
+        and not plan.path_terms
+        and not plan.action_terms
+        and not plan.excluded_action_terms
+        and not plan.action_sequence
+        and not plan.action_text_terms
+        and not plan.tool_terms
+        and not plan.excluded_tool_terms
+        and not plan.excluded_providers
+        and not plan.tags
+        and not plan.excluded_tags
+        and not plan.has_types
+        and plan.title is None
+        and plan.until is None
+        and plan.sample is None
+        and not plan.filter_has_tool_use
+        and not plan.filter_has_thinking
+        and plan.min_messages is None
+        and plan.max_messages is None
+        and plan.min_words is None
+    )
+
+
+def _resolved_retrieval_lane(plan: ConversationQueryPlan) -> str:
+    if plan.similar_text:
+        return "semantic"
+    if plan.retrieval_lane == "auto":
+        return "dialogue"
+    return plan.retrieval_lane
+
+
+async def search_hits_for_plan(
+    plan: ConversationQueryPlan,
+    repository: ConversationQueryRuntimeStore,
+) -> list[ConversationSearchHit]:
+    """Return evidence-bearing hits for search-like query plans."""
+    if not plan_has_search_hit_evidence(plan):
+        return []
+
+    query_text = plan.similar_text or search_query_text(plan)
+    if not query_text:
+        return []
+
+    if _simple_message_hit_plan(plan):
+        provider_names = list(provider_values(plan.providers)) or None
+        limit = plan.limit or search_limit(plan)
+        return await repository.search_summary_hits(
+            query_text,
+            limit=limit,
+            providers=provider_names,
+            since=plan.since.isoformat() if plan.since else None,
+        )
+
+    conversations = await plan.list(repository)
+    retrieval_lane = _resolved_retrieval_lane(plan)
+    query_terms = (query_text,)
+    return [
+        conversation_search_hit_from_conversation(
+            conversation,
+            query_terms=query_terms,
+            rank=rank,
+            retrieval_lane=retrieval_lane,
+        )
+        for rank, conversation in enumerate(conversations, start=1)
+    ]
+
+
+__all__ = ["plan_has_search_hit_evidence", "search_hits_for_plan"]

--- a/polylogue/lib/search_hits.py
+++ b/polylogue/lib/search_hits.py
@@ -1,0 +1,132 @@
+"""Evidence-bearing search-hit contracts shared by CLI, MCP, and archive ops."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import TYPE_CHECKING
+
+from polylogue.lib.query_support import conversation_to_summary
+
+if TYPE_CHECKING:
+    from polylogue.lib.models import Conversation, ConversationSummary
+
+
+@dataclass(frozen=True, slots=True)
+class ConversationSearchHit:
+    """A conversation summary plus evidence explaining why it matched."""
+
+    summary: ConversationSummary
+    rank: int
+    retrieval_lane: str
+    match_surface: str
+    message_id: str | None = None
+    snippet: str | None = None
+    score: float | None = None
+
+    @property
+    def conversation_id(self) -> str:
+        return str(self.summary.id)
+
+    def with_message_count(self, message_count: int | None) -> ConversationSearchHit:
+        return replace(self, summary=self.summary.model_copy(update={"message_count": message_count}))
+
+
+def search_query_text(query_terms: tuple[str, ...]) -> str:
+    return " ".join(term.strip() for term in query_terms if term.strip()).strip()
+
+
+def search_terms(query_terms: tuple[str, ...]) -> tuple[str, ...]:
+    terms: list[str] = []
+    for query_term in query_terms:
+        terms.extend(term.lower() for term in query_term.split() if term.strip())
+    return tuple(terms)
+
+
+def build_search_snippet(text: str, query_terms: tuple[str, ...]) -> str:
+    """Create a deterministic snippet around the earliest query-term match."""
+    if not text:
+        return ""
+
+    lowered = text.lower()
+    positions = [lowered.find(term) for term in search_terms(query_terms) if lowered.find(term) >= 0]
+    anchor = min(positions) if positions else 0
+    start = max(0, anchor - 60)
+    end = min(len(text), anchor + 140)
+    snippet = text[start:end].strip()
+    if start > 0:
+        snippet = f"...{snippet}"
+    if end < len(text):
+        snippet = f"{snippet}..."
+    return snippet
+
+
+def search_hit_surface(retrieval_lane: str) -> str:
+    if retrieval_lane == "actions":
+        return "action"
+    if retrieval_lane == "hybrid":
+        return "hybrid"
+    if retrieval_lane == "semantic":
+        return "semantic"
+    return "message"
+
+
+def conversation_search_hit_from_conversation(
+    conversation: Conversation,
+    *,
+    query_terms: tuple[str, ...],
+    rank: int,
+    retrieval_lane: str,
+    match_surface: str | None = None,
+    score: float | None = None,
+) -> ConversationSearchHit:
+    terms = search_terms(query_terms)
+    matching_message = next(
+        (
+            message
+            for message in conversation.messages
+            if message.text and any(term in message.text.lower() for term in terms)
+        ),
+        next((message for message in conversation.messages if message.text), None),
+    )
+    snippet = build_search_snippet(matching_message.text or "", query_terms) if matching_message else None
+    return ConversationSearchHit(
+        summary=conversation_to_summary(conversation),
+        rank=rank,
+        retrieval_lane=retrieval_lane,
+        match_surface=match_surface or search_hit_surface(retrieval_lane),
+        message_id=str(matching_message.id) if matching_message else None,
+        snippet=snippet,
+        score=score,
+    )
+
+
+def conversation_search_hit_from_summary(
+    summary: ConversationSummary,
+    *,
+    rank: int,
+    retrieval_lane: str,
+    match_surface: str,
+    message_id: str | None,
+    snippet: str | None,
+    score: float | None = None,
+) -> ConversationSearchHit:
+    return ConversationSearchHit(
+        summary=summary,
+        rank=rank,
+        retrieval_lane=retrieval_lane,
+        match_surface=match_surface,
+        message_id=message_id,
+        snippet=snippet,
+        score=score,
+    )
+
+
+__all__ = [
+    "ConversationSearchHit",
+    "build_search_snippet",
+    "conversation_search_hit_from_conversation",
+    "conversation_search_hit_from_summary",
+    "search_hit_surface",
+    "search_query_text",
+    "search_terms",
+]

--- a/polylogue/mcp/payloads.py
+++ b/polylogue/mcp/payloads.py
@@ -16,6 +16,9 @@ from polylogue.surface_payloads import (
     ConversationMessagePayload as MCPMessagePayload,
 )
 from polylogue.surface_payloads import (
+    ConversationSearchHitPayload as MCPConversationSearchHitPayload,
+)
+from polylogue.surface_payloads import (
     ConversationSummaryPayload as MCPConversationSummaryPayload,
 )
 from polylogue.surface_payloads import (
@@ -29,6 +32,7 @@ if TYPE_CHECKING:
 
     from polylogue.lib.models import Conversation
     from polylogue.lib.query_miss_diagnostics import QueryMissDiagnostics, QueryMissReason
+    from polylogue.lib.search_hits import ConversationSearchHit
     from polylogue.lib.stats import ArchiveStats
     from polylogue.readiness import ReadinessCheck, ReadinessReport
 
@@ -55,6 +59,10 @@ class MCPFencedCodeBlock(TypedDict):
 
 class MCPConversationSummaryListPayload(MCPRootPayload[list[MCPConversationSummaryPayload]]):
     root: list[MCPConversationSummaryPayload]
+
+
+class MCPConversationSearchHitListPayload(MCPRootPayload[list[MCPConversationSearchHitPayload]]):
+    root: list[MCPConversationSearchHitPayload]
 
 
 class MCPQueryMissReasonPayload(SurfacePayloadModel):
@@ -98,6 +106,11 @@ class MCPConversationQueryNoResultsPayload(SurfacePayloadModel):
     diagnostics: MCPQueryMissDiagnosticsPayload
 
 
+class MCPConversationSearchNoResultsPayload(SurfacePayloadModel):
+    results: tuple[MCPConversationSearchHitPayload, ...] = ()
+    diagnostics: MCPQueryMissDiagnosticsPayload
+
+
 def conversation_summary_list_payload(
     conversations: Sequence[Conversation],
 ) -> MCPConversationSummaryListPayload:
@@ -114,6 +127,32 @@ def conversation_query_result_payload(
     if conversations or diagnostics is None:
         return conversation_summary_list_payload(conversations)
     return MCPConversationQueryNoResultsPayload(
+        diagnostics=MCPQueryMissDiagnosticsPayload.from_diagnostics(diagnostics),
+    )
+
+
+def conversation_search_hit_list_payload(
+    hits: Sequence[ConversationSearchHit],
+) -> MCPConversationSearchHitListPayload:
+    return MCPConversationSearchHitListPayload(
+        root=[
+            MCPConversationSearchHitPayload.from_search_hit(
+                hit,
+                message_count=hit.summary.message_count,
+            )
+            for hit in hits
+        ]
+    )
+
+
+def conversation_search_result_payload(
+    hits: Sequence[ConversationSearchHit],
+    *,
+    diagnostics: QueryMissDiagnostics | None = None,
+) -> MCPConversationSearchHitListPayload | MCPConversationSearchNoResultsPayload:
+    if hits or diagnostics is None:
+        return conversation_search_hit_list_payload(hits)
+    return MCPConversationSearchNoResultsPayload(
         diagnostics=MCPQueryMissDiagnosticsPayload.from_diagnostics(diagnostics),
     )
 
@@ -265,6 +304,9 @@ __all__ = [
     "MCPArchiveStatsPayload",
     "MCPConversationDetailPayload",
     "MCPConversationQueryNoResultsPayload",
+    "MCPConversationSearchHitListPayload",
+    "MCPConversationSearchHitPayload",
+    "MCPConversationSearchNoResultsPayload",
     "MCPConversationSummaryListPayload",
     "MCPConversationSummaryPayload",
     "MCPErrorPayload",
@@ -280,6 +322,8 @@ __all__ = [
     "MCPStatsByPayload",
     "MCPTagCountsPayload",
     "conversation_query_result_payload",
+    "conversation_search_hit_list_payload",
+    "conversation_search_result_payload",
     "conversation_summary_list_payload",
     "model_json_document",
     "normalize_role",

--- a/polylogue/mcp/server_tools.py
+++ b/polylogue/mcp/server_tools.py
@@ -11,6 +11,7 @@ from polylogue.mcp.payloads import (
     MCPReadinessReportPayload,
     MCPStatsByPayload,
     conversation_query_result_payload,
+    conversation_search_result_payload,
     conversation_summary_list_payload,
 )
 from polylogue.mcp.query_contracts import MCPConversationQueryRequest
@@ -64,9 +65,9 @@ def register_query_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
                 min_messages=min_messages,
                 min_words=min_words,
             ).build_spec(hooks.clamp_limit)
-            results = await ops.query_conversations(spec)
+            results = await ops.search_conversation_hits(spec)
             diagnostics = await ops.diagnose_query_miss(spec) if not results else None
-            return hooks.json_payload(conversation_query_result_payload(results, diagnostics=diagnostics))
+            return hooks.json_payload(conversation_search_result_payload(results, diagnostics=diagnostics))
 
         return await hooks.async_safe_call("search", run)
 

--- a/polylogue/operations/archive.py
+++ b/polylogue/operations/archive.py
@@ -65,6 +65,7 @@ if TYPE_CHECKING:
     from polylogue.config import Config
     from polylogue.lib.conversation_models import Conversation
     from polylogue.lib.query_miss_diagnostics import QueryMissDiagnostics
+    from polylogue.lib.search_hits import ConversationSearchHit
     from polylogue.lib.stats import ArchiveStats as StorageArchiveStats
     from polylogue.storage.backends.async_sqlite import SQLiteBackend
     from polylogue.storage.repository import ConversationRepository
@@ -247,6 +248,15 @@ class ArchiveSearchMixin:
 
     async def query_conversations(self, spec: ConversationQuerySpec) -> list[Conversation]:
         return await spec.list(self.repository)
+
+    async def search_conversation_hits(self, spec: ConversationQuerySpec) -> list[ConversationSearchHit]:
+        from polylogue.lib.query_search_hits import search_hits_for_plan
+
+        hits = await search_hits_for_plan(spec.to_plan(), self.repository)
+        if not hits:
+            return hits
+        counts = await self.repository.get_message_counts_batch([hit.conversation_id for hit in hits])
+        return [hit.with_message_count(counts.get(hit.conversation_id)) for hit in hits]
 
     async def diagnose_query_miss(self, spec: ConversationQuerySpec) -> QueryMissDiagnostics:
         from polylogue.lib.query_miss_diagnostics import diagnose_query_miss

--- a/polylogue/protocols.py
+++ b/polylogue/protocols.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
     from polylogue.lib.conversation_models import Conversation, ConversationSummary
     from polylogue.lib.message_models import Message
     from polylogue.lib.message_roles import MessageRoleFilter
+    from polylogue.lib.search_hits import ConversationSearchHit
     from polylogue.lib.session_profile import SessionProfile
     from polylogue.lib.stats import ArchiveStats
     from polylogue.storage.action_event_artifacts import ActionEventArtifactState
@@ -205,6 +206,14 @@ class SearchStore(Protocol):
         limit: int = 20,
         providers: builtins.list[str] | None = None,
     ) -> list[ConversationSummary]: ...
+
+    async def search_summary_hits(
+        self,
+        query: str,
+        limit: int = 20,
+        providers: builtins.list[str] | None = None,
+        since: str | None = None,
+    ) -> list[ConversationSearchHit]: ...
 
     async def search_similar(
         self,

--- a/polylogue/storage/backends/queries/conversations.py
+++ b/polylogue/storage/backends/queries/conversations.py
@@ -24,6 +24,7 @@ from polylogue.storage.backends.queries.conversations_reads import (
 from polylogue.storage.backends.queries.conversations_search import (
     search_action_conversation_hits,
     search_action_conversations,
+    search_conversation_evidence_hits,
     search_conversation_hits,
     search_conversations,
 )
@@ -52,6 +53,7 @@ __all__ = [
     "save_conversation_record",
     "search_action_conversation_hits",
     "search_action_conversations",
+    "search_conversation_evidence_hits",
     "search_conversation_hits",
     "search_conversations",
     "set_metadata",

--- a/polylogue/storage/backends/queries/conversations_search.py
+++ b/polylogue/storage/backends/queries/conversations_search.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import aiosqlite
 
 from polylogue.maintenance_targets import build_maintenance_target_catalog
-from polylogue.storage.search_models import ConversationSearchResult
+from polylogue.storage.search_models import ConversationSearchEvidenceHit, ConversationSearchResult
 
 _MAINTENANCE_TARGET_CATALOG = build_maintenance_target_catalog()
 _MESSAGE_SEARCH_REPAIR_HINT = _MAINTENANCE_TARGET_CATALOG.repair_hint(("dangling_fts",), include_run_all=True)
@@ -44,6 +44,49 @@ async def search_conversation_hits(
     cursor = await conn.execute(sql, params)
     rows = await cursor.fetchall()
     return ConversationSearchResult.from_ids([str(row["conversation_id"]) for row in rows])
+
+
+async def search_conversation_evidence_hits(
+    conn: aiosqlite.Connection,
+    query: str,
+    limit: int = 100,
+    providers: list[str] | None = None,
+    since: str | None = None,
+) -> list[ConversationSearchEvidenceHit]:
+    from polylogue.errors import DatabaseError
+    from polylogue.storage.fts_lifecycle import message_fts_readiness_async
+    from polylogue.storage.search import build_ranked_conversation_search_query
+
+    readiness = await message_fts_readiness_async(conn)
+    if not bool(readiness["exists"]):
+        raise DatabaseError(f"Search index not built. {_MESSAGE_SEARCH_REPAIR_HINT}")
+    if not bool(readiness["ready"]):
+        raise DatabaseError(f"Search index is incomplete. {_MESSAGE_SEARCH_REPAIR_HINT}")
+
+    query_spec = build_ranked_conversation_search_query(
+        query=query,
+        limit=limit,
+        scope_names=providers,
+        since=since,
+        include_snippet=True,
+    )
+    if query_spec is None:
+        return []
+
+    cursor = await conn.execute(query_spec.sql, query_spec.params)
+    rows = await cursor.fetchall()
+    return [
+        ConversationSearchEvidenceHit(
+            conversation_id=str(row["conversation_id"]),
+            rank=rank,
+            score=float(row["relevance"]) if row["relevance"] is not None else None,
+            message_id=str(row["message_id"]) if row["message_id"] is not None else None,
+            snippet=str(row["snippet"]) if row["snippet"] is not None else None,
+            match_surface="message",
+            retrieval_lane="dialogue",
+        )
+        for rank, row in enumerate(rows, start=1)
+    ]
 
 
 async def search_conversations(
@@ -97,6 +140,7 @@ async def search_action_conversations(
 __all__ = [
     "search_action_conversation_hits",
     "search_action_conversations",
+    "search_conversation_evidence_hits",
     "search_conversation_hits",
     "search_conversations",
 ]

--- a/polylogue/storage/backends/query_store_archive.py
+++ b/polylogue/storage/backends/query_store_archive.py
@@ -19,7 +19,7 @@ from polylogue.storage.backends.queries.stats import (
     ProviderMetricsRow,
 )
 from polylogue.storage.query_models import ConversationRecordQuery
-from polylogue.storage.search_models import ConversationSearchResult
+from polylogue.storage.search_models import ConversationSearchEvidenceHit, ConversationSearchResult
 from polylogue.storage.store import (
     AttachmentRecord,
     ContentBlockRecord,
@@ -85,6 +85,16 @@ class SQLiteQueryStoreArchiveMixin:
     ) -> ConversationSearchResult:
         async with self._connection_factory() as conn:
             return await conversations_q.search_conversation_hits(conn, query, limit, providers)
+
+    async def search_conversation_evidence_hits(
+        self,
+        query: str,
+        limit: int = 100,
+        providers: list[str] | None = None,
+        since: str | None = None,
+    ) -> list[ConversationSearchEvidenceHit]:
+        async with self._connection_factory() as conn:
+            return await conversations_q.search_conversation_evidence_hits(conn, query, limit, providers, since)
 
     async def search_action_conversation_hits(
         self,

--- a/polylogue/storage/repository_archive_search.py
+++ b/polylogue/storage/repository_archive_search.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from polylogue.lib.conversation_models import Conversation, ConversationSummary
+    from polylogue.lib.search_hits import ConversationSearchHit
     from polylogue.storage.backends.query_store import SQLiteQueryStore
     from polylogue.storage.search_models import ConversationSearchResult
     from polylogue.storage.store import ConversationRecord
@@ -35,6 +36,41 @@ class RepositoryArchiveSearchMixin:
         if not hits.hits:
             return []
         return [conversation_summary_from_record(record) for record in records]
+
+    async def search_summary_hits(
+        self,
+        query: str,
+        limit: int = 20,
+        providers: builtins.list[str] | None = None,
+        since: str | None = None,
+    ) -> builtins.list[ConversationSearchHit]:
+        from polylogue.lib.search_hits import conversation_search_hit_from_summary
+        from polylogue.storage.hydrators import conversation_summary_from_record
+
+        evidence_hits = await self.queries.search_conversation_evidence_hits(
+            query,
+            limit=limit,
+            providers=providers,
+            since=since,
+        )
+        if not evidence_hits:
+            return []
+
+        records = await self.queries.get_conversations_batch([hit.conversation_id for hit in evidence_hits])
+        summaries_by_id = {str(record.conversation_id): conversation_summary_from_record(record) for record in records}
+        return [
+            conversation_search_hit_from_summary(
+                summaries_by_id[hit.conversation_id],
+                rank=hit.rank,
+                retrieval_lane=hit.retrieval_lane,
+                match_surface=hit.match_surface,
+                message_id=hit.message_id,
+                snippet=hit.snippet,
+                score=hit.score,
+            )
+            for hit in evidence_hits
+            if hit.conversation_id in summaries_by_id
+        ]
 
     async def search(
         self,

--- a/polylogue/storage/search_models.py
+++ b/polylogue/storage/search_models.py
@@ -32,6 +32,17 @@ class ConversationSearchHit:
 
 
 @dataclass(frozen=True)
+class ConversationSearchEvidenceHit:
+    conversation_id: str
+    rank: int
+    score: float | None = None
+    message_id: str | None = None
+    snippet: str | None = None
+    match_surface: str = "message"
+    retrieval_lane: str = "dialogue"
+
+
+@dataclass(frozen=True)
 class ConversationSearchResult:
     hits: list[ConversationSearchHit]
 
@@ -49,6 +60,7 @@ class ConversationSearchResult:
 
 
 __all__ = [
+    "ConversationSearchEvidenceHit",
     "ConversationSearchHit",
     "ConversationSearchResult",
     "SearchHit",

--- a/polylogue/surface_payloads.py
+++ b/polylogue/surface_payloads.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
     from collections.abc import Container
 
     from polylogue.lib.models import Conversation, ConversationSummary, Message
+    from polylogue.lib.search_hits import ConversationSearchHit
 
 
 def serialize_surface_payload(payload: BaseModel, *, exclude_none: bool = False) -> str:
@@ -232,10 +233,52 @@ class ConversationListRowPayload(SurfacePayloadModel):
         return {key: value for key, value in data.items() if key in fields}
 
 
+class ConversationSearchMatchPayload(SurfacePayloadModel):
+    """Evidence explaining why a conversation appeared in search results."""
+
+    rank: int
+    retrieval_lane: str
+    match_surface: str
+    message_id: str | None = None
+    snippet: str | None = None
+    score: float | None = None
+
+
+class ConversationSearchHitPayload(SurfacePayloadModel):
+    """Search-hit payload with summary identity and match evidence."""
+
+    conversation: ConversationSummaryPayload
+    match: ConversationSearchMatchPayload
+
+    @classmethod
+    def from_search_hit(
+        cls,
+        hit: ConversationSearchHit,
+        *,
+        message_count: int | None = None,
+    ) -> ConversationSearchHitPayload:
+        return cls(
+            conversation=ConversationSummaryPayload.from_summary(
+                hit.summary,
+                message_count=message_count if message_count is not None else hit.summary.message_count,
+            ),
+            match=ConversationSearchMatchPayload(
+                rank=hit.rank,
+                retrieval_lane=hit.retrieval_lane,
+                match_surface=hit.match_surface,
+                message_id=hit.message_id,
+                snippet=hit.snippet,
+                score=hit.score,
+            ),
+        )
+
+
 __all__ = [
     "ConversationDetailPayload",
     "ConversationListRowPayload",
     "ConversationMessagePayload",
+    "ConversationSearchHitPayload",
+    "ConversationSearchMatchPayload",
     "ConversationSummaryPayload",
     "MachineErrorPayload",
     "MachineErrorEnvelope",

--- a/tests/unit/cli/test_query_exec_laws.py
+++ b/tests/unit/cli/test_query_exec_laws.py
@@ -49,6 +49,7 @@ from polylogue.lib.models import Conversation
 from polylogue.lib.query_miss_diagnostics import QueryMissDiagnostics, QueryMissReason
 from polylogue.lib.query_spec import ConversationQuerySpec, QuerySpecError
 from polylogue.lib.roles import Role
+from polylogue.lib.search_hits import ConversationSearchHit
 from polylogue.services import build_runtime_services
 from polylogue.storage.action_event_artifacts import ActionEventArtifactState
 from polylogue.storage.store import ContentBlockRecord, ConversationRecord, MessageRecord
@@ -213,6 +214,7 @@ def _mutation_spec(
 def _build_plan(case: str) -> QueryExecutionPlan:
     selection = MagicMock()
     selection.similar_text = None
+    selection.to_plan.return_value = ConversationQuerySpec().to_plan()
     action = QueryAction.SHOW
     output = _output_spec()
     mutation = _mutation_spec()
@@ -1289,6 +1291,42 @@ def test_async_execute_query_action_routing_contract(case: str, expected_helper:
         filter_chain.list.assert_awaited_once()
         filter_chain.list_summaries.assert_not_called()
         mock_output_results.assert_called_once()
+
+
+def test_async_execute_query_summary_list_uses_evidence_hits_for_search_contract() -> None:
+    env = _make_env(repo=MagicMock(), config=MagicMock())
+    repo = _as_mock(env.repository)
+    summary = build_conversation_summary(_sample_summary_spec())
+    hit = ConversationSearchHit(
+        summary=summary,
+        rank=1,
+        retrieval_lane="dialogue",
+        match_surface="message",
+        message_id="msg-law-1",
+        snippet="[needle] evidence",
+    )
+    plan = _build_plan("summary_list")
+    selection = _as_mock(plan.selection)
+    selection.to_plan.return_value = ConversationQuerySpec(query_terms=("needle",), limit=5).to_plan()
+    filter_chain = MagicMock()
+    filter_chain.can_use_summaries.return_value = True
+    filter_chain.list_summaries = AsyncMock(return_value=[summary])
+    selection.build_filter.return_value = filter_chain
+    repo.search_summary_hits = AsyncMock(return_value=[hit])
+
+    with (
+        patch("polylogue.cli.helpers.load_effective_config", return_value=MagicMock()),
+        patch("polylogue.storage.search_providers.create_vector_provider", return_value=None),
+        patch("polylogue.cli.query.build_query_execution_plan", return_value=plan),
+        patch("polylogue.cli.query_output.output_search_hits", new_callable=AsyncMock) as mock_output_search_hits,
+        patch("polylogue.cli.query_output._output_summary_list", new_callable=AsyncMock) as mock_output_summary_list,
+    ):
+        asyncio.run(async_execute_query(env, {"query": ("needle",), "limit": 5}))
+
+    repo.search_summary_hits.assert_awaited_once_with("needle", limit=5, providers=None, since=None)
+    filter_chain.list_summaries.assert_not_called()
+    mock_output_search_hits.assert_awaited_once_with(env, [hit], plan.output, repo)
+    mock_output_summary_list.assert_not_called()
 
 
 def test_async_execute_query_open_falls_back_to_full_results_without_summaries_contract() -> None:

--- a/tests/unit/cli/test_query_fmt.py
+++ b/tests/unit/cli/test_query_fmt.py
@@ -30,6 +30,7 @@ from polylogue.cli.query_output import (
     _format_list,
     _output_stats_by,
     _write_message_streaming,
+    format_search_hit_list,
     format_summary_list,
     render_stream_transcript,
 )
@@ -37,6 +38,7 @@ from polylogue.lib.attachment_models import Attachment
 from polylogue.lib.messages import MessageCollection
 from polylogue.lib.models import Conversation, ConversationSummary, Message
 from polylogue.lib.roles import Role
+from polylogue.lib.search_hits import ConversationSearchHit
 from polylogue.rendering.formatting import _conv_to_dict, _yaml_safe, format_conversation
 from polylogue.types import ConversationId, Provider
 from tests.infra.builders import make_conv as build_conv
@@ -484,6 +486,52 @@ class TestListFormatting:
             assert "conv-summary-1" in rendered
             assert "claude-ai" in rendered
             assert "(7 msgs)" in rendered
+
+    @pytest.mark.parametrize("output_format", ["json", "yaml", "csv", "text"])
+    def test_format_search_hit_list_contract(self, output_format: str) -> None:
+        summary = ConversationSummary(
+            id=ConversationId("conv-hit-1"),
+            provider=Provider.CLAUDE_AI,
+            title="Hit Conversation",
+            created_at=datetime(2025, 6, 1, tzinfo=timezone.utc),
+            updated_at=datetime(2025, 6, 2, tzinfo=timezone.utc),
+            metadata={"summary": "Summary text"},
+        )
+        hit = ConversationSearchHit(
+            summary=summary,
+            rank=1,
+            retrieval_lane="dialogue",
+            match_surface="message",
+            message_id="msg-hit-1",
+            snippet="[needle] in context",
+            score=-2.5,
+        )
+
+        rendered = format_search_hit_list(
+            [hit],
+            output_format,
+            None,
+            message_counts={"conv-hit-1": 4},
+        )
+
+        if output_format == "json":
+            payload = json.loads(rendered)
+            assert payload[0]["conversation"]["id"] == "conv-hit-1"
+            assert payload[0]["conversation"]["message_count"] == 4
+            assert payload[0]["match"]["message_id"] == "msg-hit-1"
+            assert payload[0]["match"]["snippet"] == "[needle] in context"
+        elif output_format == "yaml":
+            payload = yaml.safe_load(rendered)
+            assert payload[0]["conversation"]["provider"] == "claude-ai"
+            assert payload[0]["match"]["retrieval_lane"] == "dialogue"
+        elif output_format == "csv":
+            assert "id,date,provider,title,messages,rank,retrieval_lane,match_surface,message_id,snippet" in rendered
+            assert "conv-hit-1" in rendered
+            assert "msg-hit-1" in rendered
+        else:
+            assert "conv-hit-1" in rendered
+            assert "match[1]: message/dialogue/message msg-hit-1" in rendered
+            assert "[needle] in context" in rendered
 
 
 class TestStreamingOutput:

--- a/tests/unit/mcp/test_tool_contracts.py
+++ b/tests/unit/mcp/test_tool_contracts.py
@@ -37,6 +37,7 @@ from polylogue.archive_products import (
 from polylogue.lib.models import Conversation, ConversationSummary
 from polylogue.lib.query_miss_diagnostics import QueryMissDiagnostics, QueryMissReason
 from polylogue.lib.query_spec import ConversationQuerySpec
+from polylogue.lib.search_hits import ConversationSearchHit
 from polylogue.lib.stats import ArchiveStats
 from polylogue.types import ConversationId, Provider
 from tests.infra.builders import make_conv, make_msg
@@ -224,6 +225,25 @@ def _make_summary(
     )
 
 
+def _make_search_hit(conversation: Conversation) -> ConversationSearchHit:
+    messages = conversation.messages.to_list()
+    return ConversationSearchHit(
+        summary=ConversationSummary(
+            id=ConversationId(str(conversation.id)),
+            provider=Provider.from_string(str(conversation.provider)),
+            title=conversation.display_title,
+            message_count=len(conversation.messages),
+            created_at=conversation.created_at,
+            updated_at=conversation.updated_at,
+        ),
+        rank=1,
+        retrieval_lane="dialogue",
+        match_surface="message",
+        message_id=str(messages[0].id) if messages else None,
+        snippet="hello evidence",
+    )
+
+
 def _provenance() -> ArchiveProductProvenance:
     return ArchiveProductProvenance(
         materializer_version=1,
@@ -263,6 +283,7 @@ class TestQueryTools:
         with patch("polylogue.mcp.server._get_archive_ops") as mock_get_archive_ops:
             mock_ops = MagicMock()
             mock_ops.query_conversations = AsyncMock(return_value=[simple_conversation])
+            mock_ops.search_conversation_hits = AsyncMock(return_value=[_make_search_hit(simple_conversation)])
             mock_get_archive_ops.return_value = mock_ops
 
             raw = await invoke_surface_async(mcp_server._tool_manager._tools[tool_name].fn, **args)
@@ -270,9 +291,17 @@ class TestQueryTools:
         payload = json.loads(raw)
         assert isinstance(payload, list)
         assert len(payload) == 1
-        assert payload[0]["id"] == simple_conversation.id
-        mock_ops.query_conversations.assert_awaited_once()
-        spec = mock_ops.query_conversations.await_args.args[0]
+        if tool_name == "search":
+            assert payload[0]["conversation"]["id"] == str(simple_conversation.id)
+            assert payload[0]["match"]["message_id"] == str(simple_conversation.messages.to_list()[0].id)
+            mock_ops.search_conversation_hits.assert_awaited_once()
+            mock_ops.query_conversations.assert_not_called()
+            spec = mock_ops.search_conversation_hits.await_args.args[0]
+        else:
+            assert payload[0]["id"] == simple_conversation.id
+            mock_ops.query_conversations.assert_awaited_once()
+            mock_ops.search_conversation_hits.assert_not_called()
+            spec = mock_ops.query_conversations.await_args.args[0]
         assert isinstance(spec, ConversationQuerySpec)
         for method_name, method_args in expected_calls.items():
             expected_value = method_args[0] if len(method_args) == 1 else method_args
@@ -323,7 +352,7 @@ class TestQueryTools:
         )
         with patch("polylogue.mcp.server._get_archive_ops") as mock_get_archive_ops:
             mock_ops = MagicMock()
-            mock_ops.query_conversations = AsyncMock(return_value=[])
+            mock_ops.search_conversation_hits = AsyncMock(return_value=[])
             mock_ops.diagnose_query_miss = AsyncMock(return_value=diagnostics)
             mock_get_archive_ops.return_value = mock_ops
 

--- a/tests/unit/storage/test_archive_search_contracts.py
+++ b/tests/unit/storage/test_archive_search_contracts.py
@@ -9,7 +9,7 @@ from polylogue.lib.conversation_models import Conversation
 from polylogue.lib.messages import MessageCollection
 from polylogue.storage.backends.query_store import SQLiteQueryStore
 from polylogue.storage.repository_archive_search import RepositoryArchiveSearchMixin
-from polylogue.storage.search_models import ConversationSearchResult
+from polylogue.storage.search_models import ConversationSearchEvidenceHit, ConversationSearchResult
 from polylogue.storage.search_providers.hybrid_conversations import (
     _resolve_ranked_conversation_hits,
 )
@@ -50,6 +50,25 @@ class _FakeQueries(SQLiteQueryStore):
     ) -> ConversationSearchResult:
         del query, limit, providers
         return self.hits
+
+    async def search_conversation_evidence_hits(
+        self,
+        query: str,
+        limit: int = 20,
+        providers: list[str] | None = None,
+        since: str | None = None,
+    ) -> list[ConversationSearchEvidenceHit]:
+        del query, limit, providers, since
+        return [
+            ConversationSearchEvidenceHit(
+                conversation_id=hit.conversation_id,
+                rank=hit.rank,
+                score=hit.score,
+                message_id=f"msg-{hit.conversation_id}",
+                snippet=f"snippet for {hit.conversation_id}",
+            )
+            for hit in self.hits.hits
+        ]
 
     async def get_conversations_batch(self, ids: list[str]) -> list[ConversationRecord]:
         self.last_batch_ids = ids
@@ -143,6 +162,27 @@ async def test_repository_search_summaries_follow_conversation_hit_order() -> No
     assert queries.last_batch_ids == ["conv-b", "conv-a"]
     assert [summary.id for summary in summaries] == [ConversationId("conv-b"), ConversationId("conv-a")]
     assert [summary.title for summary in summaries] == ["Second", "First"]
+
+
+@pytest.mark.asyncio
+async def test_repository_search_summary_hits_keep_evidence_and_conversation_order() -> None:
+    hits = ConversationSearchResult.from_ids(["conv-b", "conv-a"])
+    queries = _FakeQueries(
+        hits=hits,
+        records_by_id={
+            "conv-a": _conversation_record("conv-a", title="First"),
+            "conv-b": _conversation_record("conv-b", title="Second"),
+        },
+    )
+    repo = _FakeRepo(queries)
+
+    summary_hits = await repo.search_summary_hits("storage", limit=5, providers=["chatgpt"], since="2025-01-01")
+
+    assert queries.last_batch_ids == ["conv-b", "conv-a"]
+    assert [hit.conversation_id for hit in summary_hits] == ["conv-b", "conv-a"]
+    assert [hit.rank for hit in summary_hits] == [1, 2]
+    assert [hit.message_id for hit in summary_hits] == ["msg-conv-b", "msg-conv-a"]
+    assert [hit.snippet for hit in summary_hits] == ["snippet for conv-b", "snippet for conv-a"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Add a shared evidence-bearing `ConversationSearchHit` contract for CLI, MCP, and archive operations.
- Preserve ranked message FTS evidence for simple search/list result sets, including rank, score, retrieval lane, match surface, message id, and snippet.
- Return the new evidence-bearing hit payload from MCP `search` while leaving `list_conversations` on compact summaries.

## Problem

Closes #216.

Search and discovery surfaces returned conversation identities without explaining why each result matched. That made downstream retrieval work hard to verify, because CLI and MCP consumers could not inspect the matched message or distinguish the retrieval lane/surface that produced a hit.

## Solution

- Added `polylogue/lib/search_hits.py` and `polylogue/lib/query_search_hits.py` as the shared search-hit model and plan execution adapter.
- Added `ConversationSearchEvidenceHit` and `search_conversation_evidence_hits()` in the storage query layer so FTS-ranked message searches keep their witness metadata before summary hydration.
- Added repository and archive-operation methods for evidence-bearing summary hits.
- Added `ConversationSearchHitPayload` and MCP list/no-result payloads for search results.
- Updated CLI list/search output paths to render evidence-bearing hits for search-like result lists, including JSON/YAML/CSV/plain/rich table output.
- Documented the evidence fields in README, library API, and MCP integration docs.
- Added storage, CLI formatting/routing, and MCP tool contract coverage.

## Verification

```bash
ruff check polylogue/lib/search_hits.py polylogue/lib/query_search_hits.py polylogue/cli/query.py polylogue/cli/query_output.py polylogue/mcp/payloads.py polylogue/mcp/server_tools.py polylogue/operations/archive.py polylogue/protocols.py polylogue/storage/backends/queries/conversations_search.py polylogue/storage/backends/query_store_archive.py polylogue/storage/repository_archive_search.py polylogue/storage/search_models.py polylogue/surface_payloads.py tests/unit/storage/test_archive_search_contracts.py tests/unit/cli/test_query_fmt.py tests/unit/cli/test_query_exec_laws.py tests/unit/mcp/test_tool_contracts.py
pytest -q tests/unit/storage/test_archive_search_contracts.py tests/unit/cli/test_query_fmt.py::TestListFormatting::test_format_search_hit_list_contract tests/unit/cli/test_query_exec_laws.py::test_async_execute_query_summary_list_uses_evidence_hits_for_search_contract tests/unit/mcp/test_tool_contracts.py::TestQueryTools
pytest -q tests/unit/cli/test_query_fmt.py tests/unit/cli/test_query_exec_laws.py tests/unit/mcp/test_tool_contracts.py tests/unit/storage/test_archive_search_contracts.py
mypy polylogue/
devtools render-all --check
pytest -q tests/unit/ui/test_tui.py::test_search_empty_db
pytest -q tests/unit/ui/test_tui.py
devtools verify
```

Pre-push hook also ran `devtools verify --quick` successfully during branch push.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated documentation to clarify that search results now include match evidence: rank, retrieval lane, matched surface, message ID, and snippet.

* **New Features**
  * Enhanced search functionality to display detailed match evidence in results, including ranking information and snippet context.

* **Tests**
  * Added test coverage for search result formatting and evidence hit retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->