### PR TITLE
feat: add attachment identity search evidence (#361)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,10 @@ polylogue "urgent" --tag review delete --dry-run
 
 Text searches that render result lists include match evidence alongside the
 conversation identity: rank, retrieval lane, matched surface, message id, and a
-snippet when the FTS index can provide one.
+snippet when the FTS index can provide one. Drive/Gemini attachment identities
+are also queryable through the same surfaces: provider attachment ids plus
+stored `provider_id`, `id`, `fileId`, and `driveId` metadata return hits with
+`match_surface=attachment`.
 
 The pipeline and archive-maintenance surfaces are explicit verbs:
 

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -48,6 +48,11 @@ Display title precedence: `metadata.title` > `original_title` > truncated ID.
 | `path` | str? | Local path (if downloaded) |
 
 Attachments are stored as references. For Drive sources, attachments can be downloaded on demand.
+Drive/Gemini attachment lookup is limited to explicit identity fields that are
+already preserved at ingest: the provider attachment id stored as `provider_id`
+plus `id`, `fileId`, and `driveId` in attachment metadata. These identifiers are
+indexed for exact lookup and search results report the match as attachment
+evidence.
 
 ## Branching
 

--- a/docs/library-api.md
+++ b/docs/library-api.md
@@ -246,7 +246,7 @@ async def main():
         ids = [c.id for c in recent]
         convs = await archive.get_conversations(ids)
 
-        # Full-text search
+        # Search with evidence snippets
         results = await archive.search("error handling", limit=20)
         for hit in results.hits:
             print(f"{hit.title}: {hit.snippet}")
@@ -270,7 +270,7 @@ asyncio.run(main())
 | `get_conversation(id)` | Get single conversation by ID |
 | `get_conversations(ids)` | Parallel batch fetch (5-10x faster) |
 | `list_conversations(provider, limit)` | List with optional filtering |
-| `search(query, limit, source, since)` | Full-text search returning message-level evidence snippets |
+| `search(query, limit, source, since)` | Search returning evidence snippets; text matches report message evidence and Drive/Gemini `provider_id` / `id` / `fileId` / `driveId` attachment-id matches report attachment evidence |
 | `parse_file(path, source_name)` | Parse a single export file |
 | `parse_sources(sources, download_assets)` | Parse from configured sources |
 | `rebuild_index()` | Rebuild FTS5 search index |

--- a/docs/mcp-integration.md
+++ b/docs/mcp-integration.md
@@ -49,7 +49,7 @@ Add to `~/.config/claude/claude_desktop_config.json`:
 
 | Tool | Description |
 |------|-------------|
-| `search` | Search conversations by text query with optional provider/date filters; returns conversation summaries plus match rank, lane, surface, message id, and snippet evidence |
+| `search` | Search conversations by text query with optional provider/date filters; returns conversation summaries plus match rank, lane, surface, message id, and snippet evidence. Drive/Gemini provider attachment ids and stored `provider_id`, `id`, `fileId`, or `driveId` metadata return `match_surface=attachment` hits. |
 | `list_conversations` | List recent conversations, optionally filtered |
 | `get_conversation` | Get a single conversation by ID (supports prefix matching) |
 | `stats` | Archive statistics: totals, provider breakdown, database size |

--- a/docs/providers/gemini.md
+++ b/docs/providers/gemini.md
@@ -16,6 +16,8 @@ Polylogue ingests Gemini chats through the Drive API and direct file uploads.
 
 - Reads `chunkedPrompt.chunks` in order and renders user/assistant turns.
 - Captures `driveDocument` references as attachments.
+- Preserves Drive document provider ids plus `id`, `fileId`, and `driveId`
+  metadata for exact attachment-identity retrieval.
 - Downloads Drive attachments into the archive assets folder during ingest.
 
 ## Defaults

--- a/polylogue/storage/backends/queries/attachment_records.py
+++ b/polylogue/storage/backends/queries/attachment_records.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+from datetime import datetime
+
 import aiosqlite
 
+from polylogue.storage.backends.connection import _build_provider_scope_filter
 from polylogue.storage.backends.queries.mappers import _json_object, _parse_json
+from polylogue.storage.search_models import ConversationSearchEvidenceHit
 from polylogue.storage.store import AttachmentRecord
 from polylogue.types import ConversationId
 
@@ -71,7 +75,162 @@ async def get_attachments_batch(
     return result
 
 
+def _parse_since_timestamp(since: str) -> float:
+    try:
+        return datetime.fromisoformat(since).timestamp()
+    except ValueError as exc:
+        raise ValueError(f"Invalid --since date '{since}': {exc}. Use ISO format (e.g., 2023-01-01)") from exc
+
+
+def _compact_text(value: object) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    return text if len(text) <= 120 else f"{text[:117]}..."
+
+
+def _attachment_identity_snippet(row: aiosqlite.Row) -> str:
+    field = _compact_text(row["identity_field"]) or "attachment"
+    value = _compact_text(row["identity_value"]) or ""
+    parts = [f"{field}={value}"]
+
+    attachment_id = _compact_text(row["attachment_id"])
+    if attachment_id and attachment_id != value:
+        parts.append(f"attachment_id={attachment_id}")
+    name = _compact_text(row["attachment_name"])
+    if name:
+        parts.append(f'name="{name}"')
+    mime_type = _compact_text(row["mime_type"])
+    if mime_type:
+        parts.append(f"mime={mime_type}")
+    path = _compact_text(row["path"])
+    if path:
+        parts.append(f"path={path}")
+    return "attachment identity " + " ".join(parts)
+
+
+async def search_attachment_identity_evidence_hits(
+    conn: aiosqlite.Connection,
+    query: str,
+    limit: int = 100,
+    providers: list[str] | None = None,
+    since: str | None = None,
+) -> list[ConversationSearchEvidenceHit]:
+    """Search selected attachment identity fields and return evidence-bearing hits."""
+    identity = query.strip()
+    if not identity or limit <= 0:
+        return []
+
+    sql = """
+        WITH base_attachments AS (
+            SELECT
+                r.conversation_id,
+                r.message_id,
+                a.attachment_id,
+                a.mime_type,
+                a.path,
+                a.provider_meta AS attachment_meta,
+                r.provider_meta AS ref_meta,
+                c.provider_name,
+                COALESCE(m.sort_key, c.sort_key, 0) AS sort_key,
+                COALESCE(
+                    json_extract(a.provider_meta, '$.name'),
+                    json_extract(a.provider_meta, '$.title'),
+                    json_extract(r.provider_meta, '$.name'),
+                    json_extract(r.provider_meta, '$.title')
+                ) AS attachment_name
+            FROM attachments a
+            JOIN attachment_refs r ON r.attachment_id = a.attachment_id
+            JOIN conversations c ON c.conversation_id = r.conversation_id
+            LEFT JOIN messages m ON m.message_id = r.message_id
+            WHERE 1 = 1
+    """
+    params: list[str | int | float] = []
+
+    if providers:
+        scope_sql, scope_params = _build_provider_scope_filter(providers, provider_column="c.provider_name")
+        sql += f" AND {scope_sql}"
+        params.extend(scope_params)
+
+    if since:
+        sql += " AND COALESCE(m.sort_key, c.sort_key, 0) >= ?"
+        params.append(_parse_since_timestamp(since))
+
+    sql += """
+        ),
+        identity_candidates AS (
+            SELECT *, 'attachment_id' AS identity_field, attachment_id AS identity_value, 0 AS identity_rank
+            FROM base_attachments
+            UNION ALL
+            SELECT *, 'provider_meta.provider_id', CAST(json_extract(attachment_meta, '$.provider_id') AS TEXT), 1
+            FROM base_attachments
+            UNION ALL
+            SELECT *, 'provider_meta.id', CAST(json_extract(attachment_meta, '$.id') AS TEXT), 2
+            FROM base_attachments
+            UNION ALL
+            SELECT *, 'provider_meta.fileId', CAST(json_extract(attachment_meta, '$.fileId') AS TEXT), 3
+            FROM base_attachments
+            UNION ALL
+            SELECT *, 'provider_meta.driveId', CAST(json_extract(attachment_meta, '$.driveId') AS TEXT), 4
+            FROM base_attachments
+            UNION ALL
+            SELECT *, 'ref_meta.provider_id', CAST(json_extract(ref_meta, '$.provider_id') AS TEXT), 5
+            FROM base_attachments
+            UNION ALL
+            SELECT *, 'ref_meta.id', CAST(json_extract(ref_meta, '$.id') AS TEXT), 6
+            FROM base_attachments
+            UNION ALL
+            SELECT *, 'ref_meta.fileId', CAST(json_extract(ref_meta, '$.fileId') AS TEXT), 7
+            FROM base_attachments
+            UNION ALL
+            SELECT *, 'ref_meta.driveId', CAST(json_extract(ref_meta, '$.driveId') AS TEXT), 8
+            FROM base_attachments
+        ),
+        matched AS (
+            SELECT
+                *,
+                ROW_NUMBER() OVER (
+                    PARTITION BY conversation_id
+                    ORDER BY identity_rank ASC, sort_key DESC, attachment_id ASC, COALESCE(message_id, '') ASC
+                ) AS conversation_rank
+            FROM identity_candidates
+            WHERE identity_value = ?
+        )
+        SELECT
+            conversation_id,
+            message_id,
+            attachment_id,
+            mime_type,
+            path,
+            identity_field,
+            identity_value,
+            attachment_name
+        FROM matched
+        WHERE conversation_rank = 1
+        ORDER BY identity_rank ASC, sort_key DESC, attachment_id ASC, COALESCE(message_id, '') ASC
+        LIMIT ?
+    """
+    params.extend((identity, limit))
+    cursor = await conn.execute(sql, params)
+    rows = await cursor.fetchall()
+    return [
+        ConversationSearchEvidenceHit(
+            conversation_id=str(row["conversation_id"]),
+            rank=rank,
+            score=None,
+            message_id=str(row["message_id"]) if row["message_id"] is not None else None,
+            snippet=_attachment_identity_snippet(row),
+            match_surface="attachment",
+            retrieval_lane="attachment",
+        )
+        for rank, row in enumerate(rows, start=1)
+    ]
+
+
 __all__ = [
     "get_attachments",
     "get_attachments_batch",
+    "search_attachment_identity_evidence_hits",
 ]

--- a/polylogue/storage/backends/queries/attachments.py
+++ b/polylogue/storage/backends/queries/attachments.py
@@ -13,6 +13,7 @@ from polylogue.storage.backends.queries.attachment_mutations import (
 from polylogue.storage.backends.queries.attachment_records import (
     get_attachments,
     get_attachments_batch,
+    search_attachment_identity_evidence_hits,
 )
 
 __all__ = [
@@ -20,6 +21,7 @@ __all__ = [
     "save_content_blocks",
     "get_attachments",
     "get_attachments_batch",
+    "search_attachment_identity_evidence_hits",
     "save_attachments",
     "prune_attachments",
 ]

--- a/polylogue/storage/backends/query_store_archive.py
+++ b/polylogue/storage/backends/query_store_archive.py
@@ -96,6 +96,16 @@ class SQLiteQueryStoreArchiveMixin:
         async with self._connection_factory() as conn:
             return await conversations_q.search_conversation_evidence_hits(conn, query, limit, providers, since)
 
+    async def search_attachment_identity_evidence_hits(
+        self,
+        query: str,
+        limit: int = 100,
+        providers: list[str] | None = None,
+        since: str | None = None,
+    ) -> list[ConversationSearchEvidenceHit]:
+        async with self._connection_factory() as conn:
+            return await attachments_q.search_attachment_identity_evidence_hits(conn, query, limit, providers, since)
+
     async def search_action_conversation_hits(
         self,
         query: str,

--- a/polylogue/storage/backends/schema_bootstrap.py
+++ b/polylogue/storage/backends/schema_bootstrap.py
@@ -116,6 +116,58 @@ def build_current_schema_extension_plan(snapshot: SchemaSnapshot) -> SchemaExten
             """
         )
 
+    if snapshot.has_table("attachments"):
+        statements.extend(
+            (
+                """
+                CREATE INDEX IF NOT EXISTS idx_attachments_provider_meta_id
+                ON attachments(json_extract(provider_meta, '$.id'))
+                WHERE provider_meta IS NOT NULL
+                """,
+                """
+                CREATE INDEX IF NOT EXISTS idx_attachments_provider_meta_provider_id
+                ON attachments(json_extract(provider_meta, '$.provider_id'))
+                WHERE provider_meta IS NOT NULL
+                """,
+                """
+                CREATE INDEX IF NOT EXISTS idx_attachments_provider_meta_file_id
+                ON attachments(json_extract(provider_meta, '$.fileId'))
+                WHERE provider_meta IS NOT NULL
+                """,
+                """
+                CREATE INDEX IF NOT EXISTS idx_attachments_provider_meta_drive_id
+                ON attachments(json_extract(provider_meta, '$.driveId'))
+                WHERE provider_meta IS NOT NULL
+                """,
+            )
+        )
+
+    if snapshot.has_table("attachment_refs"):
+        statements.extend(
+            (
+                """
+                CREATE INDEX IF NOT EXISTS idx_attachment_refs_provider_meta_id
+                ON attachment_refs(json_extract(provider_meta, '$.id'))
+                WHERE provider_meta IS NOT NULL
+                """,
+                """
+                CREATE INDEX IF NOT EXISTS idx_attachment_refs_provider_meta_provider_id
+                ON attachment_refs(json_extract(provider_meta, '$.provider_id'))
+                WHERE provider_meta IS NOT NULL
+                """,
+                """
+                CREATE INDEX IF NOT EXISTS idx_attachment_refs_provider_meta_file_id
+                ON attachment_refs(json_extract(provider_meta, '$.fileId'))
+                WHERE provider_meta IS NOT NULL
+                """,
+                """
+                CREATE INDEX IF NOT EXISTS idx_attachment_refs_provider_meta_drive_id
+                ON attachment_refs(json_extract(provider_meta, '$.driveId'))
+                WHERE provider_meta IS NOT NULL
+                """,
+            )
+        )
+
     scripts.extend((_ARTIFACT_OBSERVATION_DDL, _PUBLICATION_DDL, _ACTION_EVENT_DDL))
     if snapshot.has_table("action_events") and "materializer_version" not in snapshot.columns("action_events"):
         statements.append("ALTER TABLE action_events ADD COLUMN materializer_version INTEGER NOT NULL DEFAULT 1")
@@ -256,6 +308,8 @@ def capture_schema_snapshot(conn: sqlite3.Connection) -> SchemaSnapshot:
 
     for table_name in (
         "raw_conversations",
+        "attachments",
+        "attachment_refs",
         "content_blocks",
         "action_events",
         "session_profiles",
@@ -287,6 +341,8 @@ async def capture_schema_snapshot_async(conn: aiosqlite.Connection) -> SchemaSna
 
     for table_name in (
         "raw_conversations",
+        "attachments",
+        "attachment_refs",
         "content_blocks",
         "action_events",
         "session_profiles",

--- a/polylogue/storage/backends/schema_ddl_archive.py
+++ b/polylogue/storage/backends/schema_ddl_archive.py
@@ -205,6 +205,38 @@ ARCHIVE_STORAGE_DDL = """
         CREATE INDEX IF NOT EXISTS idx_attachment_refs_attachment
         ON attachment_refs(attachment_id);
 
+        CREATE INDEX IF NOT EXISTS idx_attachments_provider_meta_id
+        ON attachments(json_extract(provider_meta, '$.id'))
+        WHERE provider_meta IS NOT NULL;
+
+        CREATE INDEX IF NOT EXISTS idx_attachments_provider_meta_provider_id
+        ON attachments(json_extract(provider_meta, '$.provider_id'))
+        WHERE provider_meta IS NOT NULL;
+
+        CREATE INDEX IF NOT EXISTS idx_attachments_provider_meta_file_id
+        ON attachments(json_extract(provider_meta, '$.fileId'))
+        WHERE provider_meta IS NOT NULL;
+
+        CREATE INDEX IF NOT EXISTS idx_attachments_provider_meta_drive_id
+        ON attachments(json_extract(provider_meta, '$.driveId'))
+        WHERE provider_meta IS NOT NULL;
+
+        CREATE INDEX IF NOT EXISTS idx_attachment_refs_provider_meta_id
+        ON attachment_refs(json_extract(provider_meta, '$.id'))
+        WHERE provider_meta IS NOT NULL;
+
+        CREATE INDEX IF NOT EXISTS idx_attachment_refs_provider_meta_provider_id
+        ON attachment_refs(json_extract(provider_meta, '$.provider_id'))
+        WHERE provider_meta IS NOT NULL;
+
+        CREATE INDEX IF NOT EXISTS idx_attachment_refs_provider_meta_file_id
+        ON attachment_refs(json_extract(provider_meta, '$.fileId'))
+        WHERE provider_meta IS NOT NULL;
+
+        CREATE INDEX IF NOT EXISTS idx_attachment_refs_provider_meta_drive_id
+        ON attachment_refs(json_extract(provider_meta, '$.driveId'))
+        WHERE provider_meta IS NOT NULL;
+
         CREATE TABLE IF NOT EXISTS runs (
             run_id TEXT PRIMARY KEY,
             timestamp TEXT NOT NULL,

--- a/polylogue/storage/repository_archive_search.py
+++ b/polylogue/storage/repository_archive_search.py
@@ -3,14 +3,41 @@
 from __future__ import annotations
 
 import builtins
+from dataclasses import replace
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from polylogue.lib.conversation_models import Conversation, ConversationSummary
     from polylogue.lib.search_hits import ConversationSearchHit
     from polylogue.storage.backends.query_store import SQLiteQueryStore
-    from polylogue.storage.search_models import ConversationSearchResult
+    from polylogue.storage.search_models import ConversationSearchEvidenceHit, ConversationSearchResult
     from polylogue.storage.store import ConversationRecord
+
+
+def _rerank_evidence_hits(
+    hits: builtins.list[ConversationSearchEvidenceHit],
+) -> builtins.list[ConversationSearchEvidenceHit]:
+    return [replace(hit, rank=rank) for rank, hit in enumerate(hits, start=1)]
+
+
+def _merge_evidence_hits(
+    *,
+    attachment_hits: builtins.list[ConversationSearchEvidenceHit],
+    message_hits: builtins.list[ConversationSearchEvidenceHit],
+    limit: int,
+) -> builtins.list[ConversationSearchEvidenceHit]:
+    if limit <= 0:
+        return []
+    merged: builtins.list[ConversationSearchEvidenceHit] = []
+    seen: set[str] = set()
+    for hit in (*attachment_hits, *message_hits):
+        if hit.conversation_id in seen:
+            continue
+        seen.add(hit.conversation_id)
+        merged.append(hit)
+        if len(merged) >= limit:
+            break
+    return _rerank_evidence_hits(merged)
 
 
 class RepositoryArchiveSearchMixin:
@@ -44,14 +71,32 @@ class RepositoryArchiveSearchMixin:
         providers: builtins.list[str] | None = None,
         since: str | None = None,
     ) -> builtins.list[ConversationSearchHit]:
+        from polylogue.errors import DatabaseError
         from polylogue.lib.search_hits import conversation_search_hit_from_summary
         from polylogue.storage.hydrators import conversation_summary_from_record
 
-        evidence_hits = await self.queries.search_conversation_evidence_hits(
+        attachment_hits = await self.queries.search_attachment_identity_evidence_hits(
             query,
             limit=limit,
             providers=providers,
             since=since,
+        )
+        try:
+            message_hits = await self.queries.search_conversation_evidence_hits(
+                query,
+                limit=limit,
+                providers=providers,
+                since=since,
+            )
+        except DatabaseError:
+            if not attachment_hits:
+                raise
+            message_hits = []
+
+        evidence_hits = _merge_evidence_hits(
+            attachment_hits=attachment_hits,
+            message_hits=message_hits,
+            limit=limit,
         )
         if not evidence_hits:
             return []

--- a/tests/unit/cli/test_query_fmt.py
+++ b/tests/unit/cli/test_query_fmt.py
@@ -533,6 +533,31 @@ class TestListFormatting:
             assert "match[1]: message/dialogue/message msg-hit-1" in rendered
             assert "[needle] in context" in rendered
 
+    def test_format_search_hit_list_exposes_attachment_identity_evidence(self) -> None:
+        summary = ConversationSummary(
+            id=ConversationId("conv-attachment-hit"),
+            provider=Provider.GEMINI,
+            title="Attachment Hit",
+            created_at=datetime(2025, 6, 1, tzinfo=timezone.utc),
+            updated_at=datetime(2025, 6, 2, tzinfo=timezone.utc),
+        )
+        hit = ConversationSearchHit(
+            summary=summary,
+            rank=1,
+            retrieval_lane="attachment",
+            match_surface="attachment",
+            message_id="msg-doc",
+            snippet='attachment identity provider_meta.fileId=drive-file-1 name="Project Plan"',
+        )
+
+        rendered = format_search_hit_list([hit], "json", None, message_counts={"conv-attachment-hit": 1})
+        payload = json.loads(rendered)
+
+        assert payload[0]["match"]["match_surface"] == "attachment"
+        assert payload[0]["match"]["retrieval_lane"] == "attachment"
+        assert payload[0]["match"]["message_id"] == "msg-doc"
+        assert "provider_meta.fileId=drive-file-1" in payload[0]["match"]["snippet"]
+
 
 class TestStreamingOutput:
     @pytest.mark.parametrize("output_format,expected_role,expected_text", STREAM_CASES)

--- a/tests/unit/mcp/test_tool_contracts.py
+++ b/tests/unit/mcp/test_tool_contracts.py
@@ -244,6 +244,24 @@ def _make_search_hit(conversation: Conversation) -> ConversationSearchHit:
     )
 
 
+def _make_attachment_search_hit(conversation: Conversation) -> ConversationSearchHit:
+    return ConversationSearchHit(
+        summary=ConversationSummary(
+            id=ConversationId(str(conversation.id)),
+            provider=Provider.from_string(str(conversation.provider)),
+            title=conversation.display_title,
+            message_count=len(conversation.messages),
+            created_at=conversation.created_at,
+            updated_at=conversation.updated_at,
+        ),
+        rank=1,
+        retrieval_lane="attachment",
+        match_surface="attachment",
+        message_id="msg-doc",
+        snippet='attachment identity provider_meta.fileId=drive-file-1 name="Project Plan"',
+    )
+
+
 def _provenance() -> ArchiveProductProvenance:
     return ArchiveProductProvenance(
         materializer_version=1,
@@ -363,6 +381,34 @@ class TestQueryTools:
         assert parsed["diagnostics"]["archive_conversation_count"] == 0
         assert parsed["diagnostics"]["reasons"][0]["code"] == "archive_empty"
         mock_ops.diagnose_query_miss.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_search_exposes_attachment_identity_evidence(
+        self,
+        simple_conversation: Conversation,
+        mcp_server: MCPServerUnderTest,
+    ) -> None:
+        with patch("polylogue.mcp.server._get_archive_ops") as mock_get_archive_ops:
+            mock_ops = MagicMock()
+            mock_ops.search_conversation_hits = AsyncMock(
+                return_value=[_make_attachment_search_hit(simple_conversation)]
+            )
+            mock_ops.diagnose_query_miss = AsyncMock()
+            mock_get_archive_ops.return_value = mock_ops
+
+            raw = await invoke_surface_async(
+                mcp_server._tool_manager._tools["search"].fn,
+                query="drive-file-1",
+                limit=10,
+            )
+
+        payload = json.loads(raw)
+        assert payload[0]["match"]["match_surface"] == "attachment"
+        assert payload[0]["match"]["retrieval_lane"] == "attachment"
+        assert payload[0]["match"]["message_id"] == "msg-doc"
+        assert "provider_meta.fileId=drive-file-1" in payload[0]["match"]["snippet"]
+        mock_ops.search_conversation_hits.assert_awaited_once()
+        mock_ops.diagnose_query_miss.assert_not_called()
 
 
 class TestGetConversationTool:

--- a/tests/unit/sources/test_parsers_drive.py
+++ b/tests/unit/sources/test_parsers_drive.py
@@ -120,6 +120,10 @@ def test_attachment_from_doc_contract(doc: object, expected_id: str | None, expe
         assert attachment.provider_attachment_id == expected_id
         assert attachment.message_provider_id == "msg-1"
         assert attachment.size_bytes == expected_size
+        if isinstance(doc, dict):
+            assert attachment.provider_meta is not None
+            for key, value in doc.items():
+                assert attachment.provider_meta[key] == value
 
 
 def test_parse_chunked_prompt_preserves_core_conversation_metadata() -> None:

--- a/tests/unit/storage/test_archive_search_contracts.py
+++ b/tests/unit/storage/test_archive_search_contracts.py
@@ -2,12 +2,18 @@ from __future__ import annotations
 
 import sqlite3
 from dataclasses import dataclass
+from pathlib import Path
 
 import pytest
 
 from polylogue.lib.conversation_models import Conversation
+from polylogue.lib.json import JSONDocument
 from polylogue.lib.messages import MessageCollection
+from polylogue.pipeline.prepare import prepare_records
+from polylogue.sources.parsers.drive import parse_chunked_prompt
+from polylogue.storage.backends.async_sqlite import SQLiteBackend
 from polylogue.storage.backends.query_store import SQLiteQueryStore
+from polylogue.storage.repository import ConversationRepository
 from polylogue.storage.repository_archive_search import RepositoryArchiveSearchMixin
 from polylogue.storage.search_models import ConversationSearchEvidenceHit, ConversationSearchResult
 from polylogue.storage.search_providers.hybrid_conversations import (
@@ -31,6 +37,7 @@ def _conversation_record(conversation_id: str, *, title: str, provider_name: str
 class _FakeQueries(SQLiteQueryStore):
     hits: ConversationSearchResult
     records_by_id: dict[str, ConversationRecord]
+    attachment_hits: list[ConversationSearchEvidenceHit] | None = None
     last_batch_ids: list[str] | None = None
 
     async def search_conversation_hits(
@@ -69,6 +76,16 @@ class _FakeQueries(SQLiteQueryStore):
             )
             for hit in self.hits.hits
         ]
+
+    async def search_attachment_identity_evidence_hits(
+        self,
+        query: str,
+        limit: int = 20,
+        providers: list[str] | None = None,
+        since: str | None = None,
+    ) -> list[ConversationSearchEvidenceHit]:
+        del query, limit, providers, since
+        return self.attachment_hits or []
 
     async def get_conversations_batch(self, ids: list[str]) -> list[ConversationRecord]:
         self.last_batch_ids = ids
@@ -183,6 +200,100 @@ async def test_repository_search_summary_hits_keep_evidence_and_conversation_ord
     assert [hit.rank for hit in summary_hits] == [1, 2]
     assert [hit.message_id for hit in summary_hits] == ["msg-conv-b", "msg-conv-a"]
     assert [hit.snippet for hit in summary_hits] == ["snippet for conv-b", "snippet for conv-a"]
+
+
+@pytest.mark.asyncio
+async def test_repository_search_summary_hits_prioritize_attachment_identity_evidence() -> None:
+    hits = ConversationSearchResult.from_ids(["conv-b", "conv-a"])
+    attachment_hit = ConversationSearchEvidenceHit(
+        conversation_id="conv-a",
+        rank=1,
+        message_id="msg-attachment",
+        snippet="attachment identity provider_meta.fileId=drive-file-1",
+        match_surface="attachment",
+        retrieval_lane="attachment",
+    )
+    queries = _FakeQueries(
+        hits=hits,
+        attachment_hits=[attachment_hit],
+        records_by_id={
+            "conv-a": _conversation_record("conv-a", title="Attachment Match"),
+            "conv-b": _conversation_record("conv-b", title="Message Match"),
+        },
+    )
+    repo = _FakeRepo(queries)
+
+    summary_hits = await repo.search_summary_hits("drive-file-1", limit=5, providers=["gemini"])
+
+    assert queries.last_batch_ids == ["conv-a", "conv-b"]
+    assert [hit.conversation_id for hit in summary_hits] == ["conv-a", "conv-b"]
+    assert [hit.rank for hit in summary_hits] == [1, 2]
+    assert summary_hits[0].match_surface == "attachment"
+    assert summary_hits[0].retrieval_lane == "attachment"
+    assert summary_hits[0].message_id == "msg-attachment"
+    assert summary_hits[1].match_surface == "message"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("query", "expected_snippet"),
+    [
+        ("provider-attachment-218", "provider_meta.provider_id=provider-attachment-218"),
+        ("drive-file-218", "provider_meta.fileId=drive-file-218"),
+        ("drive-root-218", "provider_meta.driveId=drive-root-218"),
+    ],
+    ids=["provider-attachment-id", "drive-file-id", "drive-id"],
+)
+async def test_gemini_drive_attachment_id_is_searchable_after_parse_and_prepare(
+    tmp_path: Path,
+    query: str,
+    expected_snippet: str,
+) -> None:
+    payload: JSONDocument = {
+        "id": "gemini-attachment-identity",
+        "displayName": "Gemini Attachment Identity",
+        "chunkedPrompt": {
+            "chunks": [
+                {
+                    "id": "msg-doc",
+                    "role": "user",
+                    "text": "Please review the attached project plan.",
+                    "driveDocument": {
+                        "id": "provider-attachment-218",
+                        "fileId": "drive-file-218",
+                        "driveId": "drive-root-218",
+                        "name": "Project Plan",
+                        "mimeType": "application/vnd.google-apps.document",
+                    },
+                }
+            ]
+        },
+    }
+    backend = SQLiteBackend(db_path=tmp_path / "attachment-identity.db")
+    repo = ConversationRepository(backend=backend)
+    try:
+        parsed = parse_chunked_prompt("gemini", payload, "fallback-id")
+        await prepare_records(
+            parsed,
+            "gemini-export.json",
+            archive_root=tmp_path / "archive",
+            backend=backend,
+            repository=repo,
+        )
+
+        hits = await repo.search_summary_hits(query, limit=5, providers=["gemini"])
+    finally:
+        await repo.close()
+
+    assert len(hits) == 1
+    hit = hits[0]
+    assert hit.conversation_id == "gemini:gemini-attachment-identity"
+    assert hit.match_surface == "attachment"
+    assert hit.retrieval_lane == "attachment"
+    assert hit.message_id == "gemini:gemini-attachment-identity:msg-doc"
+    assert hit.snippet is not None
+    assert expected_snippet in hit.snippet
+    assert 'name="Project Plan"' in hit.snippet
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Add exact Drive/Gemini attachment identity retrieval to the existing evidence-bearing search contract. The branch indexes selected attachment metadata fields, merges attachment evidence ahead of message-text evidence, and documents the CLI/API/MCP result surface.

## Problem

Closes #218

Gemini Drive document identifiers were already preserved during parsing and materialization, but the retrieval path only searched message text. A provider file id or drive id could exist in `attachments.provider_meta` while remaining unreachable through normal search, which meant agents and users could not resolve a referenced Drive attachment by its durable identity.

## Solution

- Add `search_attachment_identity_evidence_hits` for exact lookup over internal attachment ids plus stored `provider_id`, `id`, `fileId`, and `driveId` metadata on attachments and attachment references.
- Merge attachment identity evidence into `search_summary_hits` before message evidence while preserving the common `ConversationSearchHit` contract.
- Add JSON-expression indexes and current-schema extension planning for those identity fields.
- Cover parser preservation, storage retrieval after Gemini parse/prepare, CLI JSON formatting, and MCP search output.
- Update README and docs for the attachment evidence contract.

## Verification

- `ruff check polylogue/storage/backends/queries/attachment_records.py`
- `ruff format --check polylogue/storage/backends/queries/attachment_records.py`
- `pytest -q tests/unit/storage/test_archive_search_contracts.py`
- `pytest -q tests/unit/storage/test_archive_search_contracts.py tests/unit/cli/test_query_fmt.py tests/unit/mcp/test_tool_contracts.py tests/unit/sources/test_parsers_drive.py`
- `mypy polylogue/`
- `devtools render-all --check`
- `devtools verify`
- `git push -u origin feature/feat/attachment-identity-retrieval` (pre-push `devtools verify --quick` passed)
