### PR TITLE
feat: add Gemini display labels (#362)

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -23,7 +23,9 @@
 | `tags` | list[str] | Tags (`important`, `repo:polylogue`) |
 | (custom) | str | Any user-defined key |
 
-Display title precedence: `metadata.title` > `original_title` > truncated ID.
+Display title precedence: `metadata.title` > `provider_meta.display_label` >
+`original_title` > truncated ID. Provider display labels are deterministic
+presentation labels, not replacements for the raw provider title.
 
 ## Message
 
@@ -69,6 +71,14 @@ Some providers include additional metadata:
 - `cost_usd`: API cost in USD
 - `duration_ms`: Response generation time
 - `model`: Model used (e.g., `claude-3-opus`)
+
+**Gemini**:
+
+- `title_source`: raw title provenance (`imported:title`,
+  `imported:displayName`, or `fallback:id`)
+- `display_label`: deterministic fallback label for weak imported titles
+- `display_label_source`: evidence used for that label, such as
+  `first-user-message` or `attachment-name:first-user-message`
 
 Access via `message.provider_meta` or convenience properties:
 

--- a/docs/providers/gemini.md
+++ b/docs/providers/gemini.md
@@ -18,6 +18,9 @@ Polylogue ingests Gemini chats through the Drive API and direct file uploads.
 - Captures `driveDocument` references as attachments.
 - Preserves Drive document provider ids plus `id`, `fileId`, and `driveId`
   metadata for exact attachment-identity retrieval.
+- Preserves raw title provenance and adds deterministic display labels from the
+  first substantive user prompt or attachment names when imported titles are
+  empty, id-like, or fallback-only.
 - Downloads Drive attachments into the archive assets folder during ingest.
 
 ## Defaults

--- a/polylogue/lib/conversation_runtime.py
+++ b/polylogue/lib/conversation_runtime.py
@@ -23,6 +23,16 @@ def _metadata_string(metadata: dict[str, object], key: str) -> str | None:
     return str(value) if value is not None else None
 
 
+def _provider_meta_string(provider_meta: dict[str, object] | None, key: str) -> str | None:
+    if provider_meta is None:
+        return None
+    value = provider_meta.get(key)
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
 def _metadata_tags(metadata: dict[str, object]) -> list[str]:
     raw_tags = metadata.get("tags", [])
     if not isinstance(raw_tags, list):
@@ -70,6 +80,9 @@ class ConversationRuntimeMixin:
         user_title = self.user_title
         if user_title:
             return user_title
+        provider_label = _provider_meta_string(self.provider_meta, "display_label")
+        if provider_label:
+            return provider_label
         if self.title:
             return self.title
         return self.id[:8]

--- a/polylogue/lib/conversation_summary_runtime.py
+++ b/polylogue/lib/conversation_summary_runtime.py
@@ -13,6 +13,16 @@ def _metadata_string(metadata: dict[str, object], key: str) -> str | None:
     return str(value) if value is not None else None
 
 
+def _provider_meta_string(provider_meta: dict[str, object] | None, key: str) -> str | None:
+    if provider_meta is None:
+        return None
+    value = provider_meta.get(key)
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
 def _metadata_tags(metadata: dict[str, object]) -> list[str]:
     raw_tags = metadata.get("tags", [])
     if not isinstance(raw_tags, list):
@@ -25,6 +35,7 @@ class ConversationSummaryRuntimeMixin:
     title: str | None
     created_at: datetime | None
     updated_at: datetime | None
+    provider_meta: dict[str, object] | None
     metadata: dict[str, object]
     parent_id: ConversationId | None
     branch_type: BranchType | None
@@ -38,6 +49,9 @@ class ConversationSummaryRuntimeMixin:
         user_title = _metadata_string(self.metadata, "title")
         if user_title:
             return user_title
+        provider_label = _provider_meta_string(self.provider_meta, "display_label")
+        if provider_label:
+            return provider_label
         if self.title:
             return self.title
         return self.id[:8]

--- a/polylogue/sources/assembly.py
+++ b/polylogue/sources/assembly.py
@@ -72,6 +72,10 @@ def get_assembly_spec(provider: Provider) -> ProviderAssemblySpec | None:
         from .assembly_codex import CodexAssemblySpec
 
         return CodexAssemblySpec()
+    if provider is Provider.GEMINI:
+        from .assembly_gemini import GeminiAssemblySpec
+
+        return GeminiAssemblySpec()
     return None
 
 

--- a/polylogue/sources/assembly_gemini.py
+++ b/polylogue/sources/assembly_gemini.py
@@ -1,0 +1,126 @@
+"""Gemini provider assembly for deterministic display labels."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from polylogue.lib.roles import Role
+
+from .assembly import SidecarData
+from .parsers.base import ParsedAttachment, ParsedConversation, ParsedMessage
+
+_DISPLAY_LABEL_LIMIT = 96
+_ID_CHARS = re.compile(r"[A-Za-z0-9_.:-]+")
+_HEX_ID = re.compile(r"[0-9a-f]{12,}", re.IGNORECASE)
+_UUIDISH = re.compile(
+    r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",
+    re.IGNORECASE,
+)
+
+
+class GeminiAssemblySpec:
+    """Gemini assembly using message and attachment evidence for display labels."""
+
+    def discover_sidecars(self, source_paths: list[Path]) -> SidecarData:
+        """Gemini display-label enrichment does not require sidecar files."""
+        del source_paths
+        return {}
+
+    def enrich_conversation(
+        self,
+        conv: ParsedConversation,
+        sidecar_data: SidecarData,
+    ) -> ParsedConversation:
+        """Add a display label for Gemini conversations whose imported title is weak."""
+        del sidecar_data
+        if not _weak_title(conv.title, conv.provider_conversation_id):
+            return conv
+
+        label, source = _derive_display_label(conv.messages, conv.attachments)
+        if label is None or source is None:
+            return conv
+
+        provider_meta = dict(conv.provider_meta or {})
+        provider_meta["display_label"] = label
+        provider_meta["display_label_source"] = source
+        provider_meta.setdefault("display_label_reason", "weak-title")
+        return conv.model_copy(update={"provider_meta": provider_meta})
+
+
+def _compact_text(value: object) -> str | None:
+    if value is None:
+        return None
+    text = " ".join(str(value).split())
+    return text or None
+
+
+def _truncate_label(text: str, *, limit: int = _DISPLAY_LABEL_LIMIT) -> str:
+    if len(text) <= limit:
+        return text
+    return f"{text[: limit - 3].rstrip()}..."
+
+
+def _looks_like_identifier(value: str) -> bool:
+    token = value.strip()
+    if not token or any(char.isspace() for char in token):
+        return False
+    if _UUIDISH.fullmatch(token) or _HEX_ID.fullmatch(token):
+        return True
+    if len(token) < 12 or _ID_CHARS.fullmatch(token) is None:
+        return False
+    digit_count = sum(char.isdigit() for char in token)
+    separator_count = sum(char in "-_.:" for char in token)
+    return digit_count >= 4 or separator_count >= 2
+
+
+def _weak_title(title: str | None, provider_conversation_id: str) -> bool:
+    text = _compact_text(title)
+    if text is None:
+        return True
+    if text == provider_conversation_id or text == f"gemini:{provider_conversation_id}":
+        return True
+    return _looks_like_identifier(text)
+
+
+def _first_user_prompt(messages: list[ParsedMessage]) -> str | None:
+    for message in messages:
+        if message.role is not Role.USER:
+            continue
+        text = _compact_text(message.text)
+        if text:
+            return text
+    return None
+
+
+def _first_attachment_name(attachments: list[ParsedAttachment]) -> str | None:
+    for attachment in attachments:
+        text = _compact_text(attachment.name)
+        if text:
+            return text
+        if attachment.provider_meta:
+            for key in ("name", "title"):
+                text = _compact_text(attachment.provider_meta.get(key))
+                if text:
+                    return text
+    return None
+
+
+def _derive_display_label(
+    messages: list[ParsedMessage],
+    attachments: list[ParsedAttachment],
+) -> tuple[str | None, str | None]:
+    prompt = _first_user_prompt(messages)
+    attachment_name = _first_attachment_name(attachments)
+    if prompt and attachment_name:
+        return _truncate_label(f"{attachment_name}: {prompt}"), "attachment-name:first-user-message"
+    if prompt:
+        return _truncate_label(prompt), "first-user-message"
+    if attachment_name:
+        return _truncate_label(f"Attachment: {attachment_name}"), "attachment-name"
+    return None, None
+
+
+__all__ = [
+    "GeminiAssemblySpec",
+]

--- a/polylogue/sources/parsers/drive.py
+++ b/polylogue/sources/parsers/drive.py
@@ -217,8 +217,13 @@ def parse_chunked_prompt(provider: Provider | str, payload: JSONDocument, fallba
         )
         attachments.extend(chunk_attachments)
 
-    title_val = payload.get("title") or payload.get("displayName")
+    title_val = payload.get("title")
+    title_source = "imported:title"
+    if not title_val:
+        title_val = payload.get("displayName")
+        title_source = "imported:displayName" if title_val else "fallback:id"
     title = str(title_val) if title_val else fallback_id
+    provider_meta: dict[str, object] = {"title_source": title_source}
     create_time_str = (
         str(payload.get("createTime"))
         if payload.get("createTime")
@@ -237,6 +242,7 @@ def parse_chunked_prompt(provider: Provider | str, payload: JSONDocument, fallba
         updated_at=update_time_str,
         messages=messages,
         attachments=attachments,
+        provider_meta=provider_meta,
     )
 
 

--- a/tests/unit/cli/test_query_fmt.py
+++ b/tests/unit/cli/test_query_fmt.py
@@ -558,6 +558,30 @@ class TestListFormatting:
         assert payload[0]["match"]["message_id"] == "msg-doc"
         assert "provider_meta.fileId=drive-file-1" in payload[0]["match"]["snippet"]
 
+    def test_format_summary_and_search_use_provider_display_label(self) -> None:
+        summary = ConversationSummary(
+            id=ConversationId("gemini:gemini-20250422-1234"),
+            provider=Provider.GEMINI,
+            title="gemini-20250422-1234",
+            provider_meta={"display_label": "Project Plan: Please review the attached project plan."},
+            created_at=datetime(2025, 6, 1, tzinfo=timezone.utc),
+            updated_at=datetime(2025, 6, 2, tzinfo=timezone.utc),
+        )
+        hit = ConversationSearchHit(
+            summary=summary,
+            rank=1,
+            retrieval_lane="dialogue",
+            match_surface="message",
+            message_id="msg-user",
+            snippet="Please review the attached project plan.",
+        )
+
+        summary_payload = json.loads(format_summary_list([summary], "json", None, message_counts={str(summary.id): 1}))
+        search_payload = json.loads(format_search_hit_list([hit], "json", None, message_counts={str(summary.id): 1}))
+
+        assert summary_payload[0]["title"] == "Project Plan: Please review the attached project plan."
+        assert search_payload[0]["conversation"]["title"] == "Project Plan: Please review the attached project plan."
+
 
 class TestStreamingOutput:
     @pytest.mark.parametrize("output_format,expected_role,expected_text", STREAM_CASES)

--- a/tests/unit/core/test_conversation_semantics.py
+++ b/tests/unit/core/test_conversation_semantics.py
@@ -265,6 +265,14 @@ class TestConversationMetadataAndAggregation:
         assert titled.user_title == "User Override"
         assert titled.display_title == "User Override"
 
+        provider_labeled = conversation_with_metadata.model_copy(
+            update={
+                "title": "gemini-20250422-1234",
+                "provider_meta": {"display_label": "Review the project plan"},
+            }
+        )
+        assert provider_labeled.display_title == "Review the project plan"
+
         fallback = make_conv(id="abc123def456", provider="test", title=None, messages=MessageCollection(messages=[]))
         assert fallback.display_title == "abc123de"
         assert fallback.tags == []

--- a/tests/unit/mcp/test_tool_contracts.py
+++ b/tests/unit/mcp/test_tool_contracts.py
@@ -383,6 +383,29 @@ class TestQueryTools:
         mock_ops.diagnose_query_miss.assert_awaited_once()
 
     @pytest.mark.asyncio
+    async def test_list_conversations_uses_provider_display_label(self, mcp_server: MCPServerUnderTest) -> None:
+        gemini_conversation = make_conv(
+            id="gemini:gemini-20250422-1234",
+            provider=Provider.GEMINI,
+            title="gemini-20250422-1234",
+            provider_meta={"display_label": "Project Plan: Please review the attached project plan."},
+            messages=[make_msg(id="msg-user", role="user", text="Please review the attached project plan.")],
+        )
+        with patch("polylogue.mcp.server._get_archive_ops") as mock_get_archive_ops:
+            mock_ops = MagicMock()
+            mock_ops.query_conversations = AsyncMock(return_value=[gemini_conversation])
+            mock_get_archive_ops.return_value = mock_ops
+
+            raw = await invoke_surface_async(
+                mcp_server._tool_manager._tools["list_conversations"].fn,
+                provider="gemini",
+                limit=10,
+            )
+
+        payload = json.loads(raw)
+        assert payload[0]["title"] == "Project Plan: Please review the attached project plan."
+
+    @pytest.mark.asyncio
     async def test_search_exposes_attachment_identity_evidence(
         self,
         simple_conversation: Conversation,

--- a/tests/unit/rendering/test_rendering.py
+++ b/tests/unit/rendering/test_rendering.py
@@ -430,3 +430,12 @@ class TestConversationSummaryDisplayDate:
             metadata={"title": "User Title"},
         )
         assert summary.display_title == "User Title"
+
+    def test_display_title_from_provider_display_label(self) -> None:
+        summary = ConversationSummary(
+            id=ConversationId("test"),
+            provider=Provider.GEMINI,
+            title="gemini-20250422-1234",
+            provider_meta={"display_label": "Review the project plan"},
+        )
+        assert summary.display_title == "Review the project plan"

--- a/tests/unit/sources/test_assembly.py
+++ b/tests/unit/sources/test_assembly.py
@@ -11,7 +11,8 @@ from polylogue.lib.roles import Role
 from polylogue.sources.assembly import SidecarData, get_assembly_spec
 from polylogue.sources.assembly_claude_code import ClaudeCodeAssemblySpec
 from polylogue.sources.assembly_codex import CodexAssemblySpec, _parse_codex_session_index
-from polylogue.sources.parsers.base import ParsedConversation, ParsedMessage
+from polylogue.sources.assembly_gemini import GeminiAssemblySpec
+from polylogue.sources.parsers.base import ParsedAttachment, ParsedConversation, ParsedMessage
 from polylogue.sources.parsers.claude_index import (
     SessionIndexEntry,
     _looks_like_git_branch,
@@ -27,11 +28,23 @@ def _parsed_message(provider_message_id: str, role: str, text: str) -> ParsedMes
     )
 
 
+def _parsed_attachment(name: str | None = None) -> ParsedAttachment:
+    return ParsedAttachment(
+        provider_attachment_id="attachment-1",
+        message_provider_id="m1",
+        name=name,
+        provider_meta={"name": name} if name else None,
+    )
+
+
 def _parsed_conversation(
     provider_name: Provider,
     provider_conversation_id: str,
     title: str,
     messages: list[ParsedMessage],
+    *,
+    attachments: list[ParsedAttachment] | None = None,
+    provider_meta: dict[str, object] | None = None,
 ) -> ParsedConversation:
     return ParsedConversation(
         provider_name=provider_name,
@@ -40,6 +53,8 @@ def _parsed_conversation(
         created_at=None,
         updated_at=None,
         messages=messages,
+        attachments=attachments or [],
+        provider_meta=provider_meta,
     )
 
 
@@ -72,9 +87,107 @@ class TestGetAssemblySpec:
         spec = get_assembly_spec(Provider.CODEX)
         assert isinstance(spec, CodexAssemblySpec)
 
-    @pytest.mark.parametrize("provider", [Provider.CHATGPT, Provider.CLAUDE_AI, Provider.GEMINI, Provider.UNKNOWN])
+    def test_gemini_returns_spec(self) -> None:
+        spec = get_assembly_spec(Provider.GEMINI)
+        assert isinstance(spec, GeminiAssemblySpec)
+
+    @pytest.mark.parametrize("provider", [Provider.CHATGPT, Provider.CLAUDE_AI, Provider.UNKNOWN])
     def test_no_spec_for_other_providers(self, provider: Provider) -> None:
         assert get_assembly_spec(provider) is None
+
+
+# ---------------------------------------------------------------------------
+# Gemini Assembly
+# ---------------------------------------------------------------------------
+
+
+class TestGeminiAssemblySpec:
+    def test_discover_sidecars_returns_empty_data(self, tmp_path: Path) -> None:
+        session_file = tmp_path / "gemini.json"
+        session_file.write_text("{}", encoding="utf-8")
+
+        sidecar_data = GeminiAssemblySpec().discover_sidecars([session_file])
+
+        assert sidecar_data == {}
+
+    def test_meaningful_imported_title_is_preserved(self) -> None:
+        conv = _parsed_conversation(
+            Provider.GEMINI,
+            "gemini-id-1234",
+            "Gemini Session",
+            [_parsed_message("m1", "user", "Summarize the roadmap")],
+            provider_meta={"title_source": "imported:displayName"},
+        )
+
+        result = GeminiAssemblySpec().enrich_conversation(conv, {})
+
+        assert result is conv
+        assert _provider_meta(result)["title_source"] == "imported:displayName"
+
+    def test_id_like_title_uses_first_user_message_display_label(self) -> None:
+        conv = _parsed_conversation(
+            Provider.GEMINI,
+            "gemini-20250422-1234",
+            "gemini-20250422-1234",
+            [
+                _parsed_message("m1", "assistant", "Opening context"),
+                _parsed_message("m2", "user", "Summarize the retention plan for Q2."),
+            ],
+            provider_meta={"title_source": "fallback:id"},
+        )
+
+        enriched = GeminiAssemblySpec().enrich_conversation(conv, {})
+
+        assert enriched.title == "gemini-20250422-1234"
+        metadata = _provider_meta(enriched)
+        assert metadata["title_source"] == "fallback:id"
+        assert metadata["display_label"] == "Summarize the retention plan for Q2."
+        assert metadata["display_label_source"] == "first-user-message"
+
+    def test_attachment_name_informs_display_label(self) -> None:
+        conv = _parsed_conversation(
+            Provider.GEMINI,
+            "gemini-attachment-221",
+            "gemini-attachment-221",
+            [_parsed_message("m1", "user", "Please review the attached project plan.")],
+            attachments=[_parsed_attachment("Project Plan")],
+            provider_meta={"title_source": "fallback:id"},
+        )
+
+        enriched = GeminiAssemblySpec().enrich_conversation(conv, {})
+
+        metadata = _provider_meta(enriched)
+        assert metadata["display_label"] == "Project Plan: Please review the attached project plan."
+        assert metadata["display_label_source"] == "attachment-name:first-user-message"
+
+    def test_empty_title_uses_attachment_name_when_no_prompt_exists(self) -> None:
+        conv = _parsed_conversation(
+            Provider.GEMINI,
+            "gemini-empty-title",
+            "",
+            [_parsed_message("m1", "assistant", "Ready")],
+            attachments=[_parsed_attachment("Project Plan")],
+            provider_meta={"title_source": "fallback:id"},
+        )
+
+        enriched = GeminiAssemblySpec().enrich_conversation(conv, {})
+
+        metadata = _provider_meta(enriched)
+        assert metadata["display_label"] == "Attachment: Project Plan"
+        assert metadata["display_label_source"] == "attachment-name"
+
+    def test_minimal_payload_without_label_evidence_is_unchanged(self) -> None:
+        conv = _parsed_conversation(
+            Provider.GEMINI,
+            "gemini-minimal-221",
+            "gemini-minimal-221",
+            [_parsed_message("m1", "assistant", "Ready")],
+            provider_meta={"title_source": "fallback:id"},
+        )
+
+        result = GeminiAssemblySpec().enrich_conversation(conv, {})
+
+        assert result is conv
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/sources/test_parsers_drive.py
+++ b/tests/unit/sources/test_parsers_drive.py
@@ -145,11 +145,24 @@ def test_parse_chunked_prompt_preserves_core_conversation_metadata() -> None:
     assert result.provider_name == "gemini"
     assert result.provider_conversation_id == "gemini-conv"
     assert result.title == "Gemini Session"
+    assert result.provider_meta == {"title_source": "imported:displayName"}
     assert result.created_at == "2024-01-15T10:30:00Z"
     assert result.updated_at == "2024-01-15T11:45:00Z"
     assert [message.provider_message_id for message in result.messages] == ["msg-user", "msg-model"]
     assert [message.role for message in result.messages] == ["user", "assistant"]
     assert [message.text for message in result.messages] == ["Question", "Answer"]
+
+
+def test_parse_chunked_prompt_records_fallback_title_source() -> None:
+    payload: JSONDocument = {
+        "id": "gemini-fallback-title",
+        "chunkedPrompt": {"chunks": [{"id": "msg-user", "role": "user", "text": "Question"}]},
+    }
+
+    result = parse_chunked_prompt("gemini", payload, "fallback-id")
+
+    assert result.title == "fallback-id"
+    assert result.provider_meta == {"title_source": "fallback:id"}
 
 
 def test_parse_chunked_prompt_preserves_reasoning_code_tool_results_and_attachments() -> None:

--- a/tests/unit/sources/test_source_laws.py
+++ b/tests/unit/sources/test_source_laws.py
@@ -1602,6 +1602,35 @@ def test_conversation_emitter_only_enriches_matching_claude_code_sessions_contra
     assert untouched.title == "untouched"
 
 
+def test_conversation_emitter_enriches_gemini_display_labels_contract() -> None:
+    ctx = _ParseContext(
+        provider_hint=Provider.GEMINI,
+        should_group=False,
+        source_path_str="/tmp/gemini.json",
+        fallback_id="gemini",
+        file_mtime="2026-03-11T00:00:00+00:00",
+        capture_raw=False,
+        sidecar_data={},
+    )
+    emitter = _ConversationEmitter(ctx)
+    conversation = _parsed_conversation(
+        provider_name=Provider.GEMINI,
+        provider_conversation_id="gemini-20250422-1234",
+        title="gemini-20250422-1234",
+        created_at=None,
+        updated_at=None,
+        messages=[_parsed_message("m1", role="user", text="Summarize the roadmap")],
+        provider_meta={"title_source": "fallback:id"},
+    )
+
+    enriched = emitter._maybe_enrich(conversation)
+
+    assert enriched.title == "gemini-20250422-1234"
+    assert enriched.provider_meta is not None
+    assert enriched.provider_meta["display_label"] == "Summarize the roadmap"
+    assert enriched.provider_meta["display_label_source"] == "first-user-message"
+
+
 def _zip_entry(name: str, *, size: int = 100, compressed: int = 50) -> zipfile.ZipInfo:
     entry = zipfile.ZipInfo(name)
     entry.file_size = size


### PR DESCRIPTION
## Summary

Add deterministic display labels for Gemini conversations whose imported titles are empty, id-like, or fallback-only. The raw provider title remains stored as the conversation title, while `provider_meta.display_label` gives search and summary surfaces a more recognizable presentation label.

## Problem

Closes #221

Gemini payloads often have weak top-level titles or only fallback identifiers. Since CLI, API, and MCP surfaces present `display_title`, those conversations could appear as opaque ids even when the first user prompt or attached Drive document name provided better human context.

## Solution

- Add a Gemini assembly spec that derives display labels from the first substantive user prompt and attachment names only when the imported title is weak.
- Preserve raw title fidelity by keeping `ParsedConversation.title` unchanged and storing `title_source`, `display_label`, and `display_label_source` in provider metadata.
- Update conversation and summary display-title precedence to prefer user metadata, then provider display labels, then raw title, then id fallback.
- Cover parser provenance, assembly heuristics, emitter enrichment, CLI JSON output, MCP list output, and domain display-title behavior.
- Document the Gemini metadata and display precedence.

## Verification

- `ruff format polylogue/lib/conversation_runtime.py polylogue/lib/conversation_summary_runtime.py polylogue/sources/assembly.py polylogue/sources/assembly_gemini.py polylogue/sources/parsers/drive.py tests/unit/sources/test_assembly.py tests/unit/sources/test_parsers_drive.py tests/unit/sources/test_source_laws.py tests/unit/rendering/test_rendering.py tests/unit/core/test_conversation_semantics.py tests/unit/cli/test_query_fmt.py tests/unit/mcp/test_tool_contracts.py`
- `ruff check polylogue/lib/conversation_runtime.py polylogue/lib/conversation_summary_runtime.py polylogue/sources/assembly.py polylogue/sources/assembly_gemini.py polylogue/sources/parsers/drive.py tests/unit/sources/test_assembly.py tests/unit/sources/test_parsers_drive.py tests/unit/sources/test_source_laws.py tests/unit/rendering/test_rendering.py tests/unit/core/test_conversation_semantics.py tests/unit/cli/test_query_fmt.py tests/unit/mcp/test_tool_contracts.py`
- `pytest -q tests/unit/sources/test_assembly.py tests/unit/sources/test_parsers_drive.py tests/unit/sources/test_source_laws.py::test_conversation_emitter_enriches_gemini_display_labels_contract tests/unit/rendering/test_rendering.py::TestConversationSummaryDisplayDate tests/unit/core/test_conversation_semantics.py::TestConversationMetadataAndAggregation::test_title_summary_tags_and_display_contract tests/unit/cli/test_query_fmt.py::TestListFormatting tests/unit/mcp/test_tool_contracts.py::TestQueryTools::test_list_conversations_uses_provider_display_label`
- `mypy polylogue/`
- `devtools render-all --check`
- `devtools verify`
- `git push -u origin feature/feat/gemini-display-labels` (pre-push `devtools verify --quick` passed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Gemini provider support with intelligent display label derivation from user prompts and attachment names.
  * Introduced provider-specific metadata fields (`display_label`, `title_source`, and `display_label_source`) for improved conversation identification.

* **Documentation**
  * Updated data model documentation to describe new metadata fields and their sources.

* **Tests**
  * Added comprehensive test coverage for Gemini provider functionality and metadata handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->