### PR TITLE
refactor: add query field descriptor catalog (#363)

### DIFF
--- a/polylogue/lib/query_fields.py
+++ b/polylogue/lib/query_fields.py
@@ -1,0 +1,652 @@
+"""Shared query-field descriptors for selection, planning, and storage."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, replace
+from datetime import datetime
+from typing import Protocol, cast
+
+from polylogue.storage.query_models import ConversationRecordQuery
+from polylogue.types import Provider
+
+PresenceCheck = Callable[[object], bool]
+DescriptionRenderer = Callable[[object], str]
+StorageValue = Callable[[object], object]
+_ReplaceRecordQuery: Callable[..., ConversationRecordQuery] = replace
+
+
+class _ProviderScopedPlan(Protocol):
+    providers: tuple[Provider | str, ...]
+
+
+def _truthy(value: object) -> bool:
+    return bool(value)
+
+
+def _not_none(value: object) -> bool:
+    return value is not None
+
+
+def _is_true(value: object) -> bool:
+    return value is True
+
+
+def _not_auto(value: object) -> bool:
+    return value != "auto"
+
+
+def _as_tuple(value: object) -> tuple[object, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, tuple):
+        return value
+    if isinstance(value, list):
+        return tuple(value)
+    return (value,)
+
+
+def _join_comma(value: object) -> str:
+    return ", ".join(str(item) for item in _as_tuple(value))
+
+
+def _join_space(value: object) -> str:
+    return " ".join(str(item) for item in _as_tuple(value))
+
+
+def _join_arrow(value: object) -> str:
+    return " -> ".join(str(item) for item in _as_tuple(value))
+
+
+def _provider_values(value: object) -> tuple[str, ...]:
+    return tuple(str(Provider.from_string(cast(str | Provider | None, item))) for item in _as_tuple(value))
+
+
+def _join_providers(value: object) -> str:
+    return ", ".join(_provider_values(value))
+
+
+def _isoformat(value: object) -> str:
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return str(value)
+
+
+def _truncated_text(value: object) -> str:
+    return str(value)[:30]
+
+
+def _label(label: str, formatter: DescriptionRenderer = str) -> DescriptionRenderer:
+    def render(value: object) -> str:
+        return f"{label}: {formatter(value)}"
+
+    return render
+
+
+def _literal(text: str) -> DescriptionRenderer:
+    def render(_value: object) -> str:
+        return text
+
+    return render
+
+
+def _list_value(value: object) -> object:
+    return list(_as_tuple(value))
+
+
+def _identity(value: object) -> object:
+    return value
+
+
+def _iso_value(value: object) -> object:
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return value
+
+
+@dataclass(frozen=True, slots=True)
+class QueryFieldDescriptor:
+    """Semantic facts about one query field across query layers."""
+
+    name: str
+    spec_attr: str | None = None
+    plan_attr: str | None = None
+    spec_active: PresenceCheck = _truthy
+    plan_active: PresenceCheck = _truthy
+    spec_description: DescriptionRenderer | None = None
+    plan_description: DescriptionRenderer | None = None
+    selection_filter: bool = True
+    record_attr: str | None = None
+    sql_param: str | None = None
+    storage_value: StorageValue = _identity
+    sql_value: StorageValue | None = None
+    requires_stats_join: bool = False
+    requires_post_filter: bool = False
+    requires_content_loading: bool = False
+    blocks_sql_count: bool = False
+    blocks_action_event_stats: bool = False
+    blocks_simple_message_hit: bool = False
+
+    def spec_value(self, spec: object) -> object:
+        if self.spec_attr is None:
+            raise ValueError(f"{self.name} has no spec attribute")
+        return cast(object, getattr(spec, self.spec_attr))
+
+    def plan_value(self, plan: object) -> object:
+        if self.plan_attr is None:
+            raise ValueError(f"{self.name} has no plan attribute")
+        return cast(object, getattr(plan, self.plan_attr))
+
+    def is_active_for_spec(self, spec: object) -> bool:
+        if self.spec_attr is None:
+            return False
+        return self.spec_active(self.spec_value(spec))
+
+    def is_active_for_plan(self, plan: object) -> bool:
+        if self.plan_attr is None:
+            return False
+        return self.plan_active(self.plan_value(plan))
+
+    def describe_spec(self, spec: object) -> str | None:
+        if self.spec_description is None or not self.is_active_for_spec(spec):
+            return None
+        return self.spec_description(self.spec_value(spec))
+
+    def describe_plan(self, plan: object) -> str | None:
+        if self.plan_description is None or not self.is_active_for_plan(plan):
+            return None
+        return self.plan_description(self.plan_value(plan))
+
+    def storage_plan_value(self, plan: object) -> object:
+        return self.storage_value(self.plan_value(plan))
+
+    def sql_plan_value(self, plan: object) -> object:
+        if self.sql_value is not None:
+            return self.sql_value(self.plan_value(plan))
+        return self.storage_plan_value(plan)
+
+
+QUERY_FIELD_DESCRIPTORS: tuple[QueryFieldDescriptor, ...] = (
+    QueryFieldDescriptor(
+        name="query_terms",
+        spec_attr="query_terms",
+        plan_attr="fts_terms",
+        spec_description=_label("search", _join_space),
+        plan_description=_label("contains", _join_comma),
+        blocks_sql_count=True,
+        blocks_action_event_stats=True,
+    ),
+    QueryFieldDescriptor(
+        name="contains_terms",
+        spec_attr="contains_terms",
+        spec_description=_label("contains", _join_comma),
+    ),
+    QueryFieldDescriptor(
+        name="exclude_text_terms",
+        spec_attr="exclude_text_terms",
+        plan_attr="negative_terms",
+        spec_description=_label("exclude text", _join_comma),
+        plan_description=_label("exclude text", _join_comma),
+        requires_post_filter=True,
+        requires_content_loading=True,
+        blocks_sql_count=True,
+        blocks_action_event_stats=True,
+        blocks_simple_message_hit=True,
+    ),
+    QueryFieldDescriptor(
+        name="retrieval_lane",
+        spec_attr="retrieval_lane",
+        plan_attr="retrieval_lane",
+        spec_active=_not_auto,
+        plan_active=_not_auto,
+        spec_description=_label("retrieval"),
+        plan_description=_label("retrieval"),
+        selection_filter=False,
+    ),
+    QueryFieldDescriptor(
+        name="path_terms",
+        spec_attr="path_terms",
+        plan_attr="path_terms",
+        spec_description=_label("path", _join_comma),
+        plan_description=_label("path", _join_comma),
+        record_attr="path_terms",
+        sql_param="path_terms",
+        sql_value=_list_value,
+        requires_post_filter=True,
+        requires_content_loading=True,
+        blocks_sql_count=True,
+        blocks_simple_message_hit=True,
+    ),
+    QueryFieldDescriptor(
+        name="action_terms",
+        spec_attr="action_terms",
+        plan_attr="action_terms",
+        spec_description=_label("action", _join_comma),
+        plan_description=_label("action", _join_comma),
+        record_attr="action_terms",
+        sql_param="action_terms",
+        sql_value=_list_value,
+        requires_post_filter=True,
+        requires_content_loading=True,
+        blocks_sql_count=True,
+        blocks_simple_message_hit=True,
+    ),
+    QueryFieldDescriptor(
+        name="excluded_action_terms",
+        spec_attr="excluded_action_terms",
+        plan_attr="excluded_action_terms",
+        spec_description=_label("exclude action", _join_comma),
+        plan_description=_label("exclude action", _join_comma),
+        record_attr="excluded_action_terms",
+        sql_param="excluded_action_terms",
+        sql_value=_list_value,
+        requires_post_filter=True,
+        requires_content_loading=True,
+        blocks_sql_count=True,
+        blocks_simple_message_hit=True,
+    ),
+    QueryFieldDescriptor(
+        name="action_sequence",
+        spec_attr="action_sequence",
+        plan_attr="action_sequence",
+        spec_description=_label("action sequence", _join_arrow),
+        plan_description=_label("action sequence", _join_arrow),
+        sql_param="action_sequence",
+        sql_value=_list_value,
+        requires_post_filter=True,
+        requires_content_loading=True,
+        blocks_sql_count=True,
+        blocks_action_event_stats=True,
+        blocks_simple_message_hit=True,
+    ),
+    QueryFieldDescriptor(
+        name="action_text_terms",
+        spec_attr="action_text_terms",
+        plan_attr="action_text_terms",
+        spec_description=_label("action text", _join_comma),
+        plan_description=_label("action text", _join_comma),
+        sql_param="action_text_terms",
+        sql_value=_list_value,
+        requires_post_filter=True,
+        requires_content_loading=True,
+        blocks_sql_count=True,
+        blocks_action_event_stats=True,
+        blocks_simple_message_hit=True,
+    ),
+    QueryFieldDescriptor(
+        name="tool_terms",
+        spec_attr="tool_terms",
+        plan_attr="tool_terms",
+        spec_description=_label("tool", _join_comma),
+        plan_description=_label("tool", _join_comma),
+        record_attr="tool_terms",
+        sql_param="tool_terms",
+        sql_value=_list_value,
+        requires_post_filter=True,
+        requires_content_loading=True,
+        blocks_sql_count=True,
+        blocks_simple_message_hit=True,
+    ),
+    QueryFieldDescriptor(
+        name="excluded_tool_terms",
+        spec_attr="excluded_tool_terms",
+        plan_attr="excluded_tool_terms",
+        spec_description=_label("exclude tool", _join_comma),
+        plan_description=_label("exclude tool", _join_comma),
+        record_attr="excluded_tool_terms",
+        sql_param="excluded_tool_terms",
+        sql_value=_list_value,
+        requires_post_filter=True,
+        requires_content_loading=True,
+        blocks_sql_count=True,
+        blocks_simple_message_hit=True,
+    ),
+    QueryFieldDescriptor(
+        name="providers",
+        spec_attr="providers",
+        plan_attr="providers",
+        spec_description=_label("provider", _join_providers),
+        plan_description=_label("provider", _join_providers),
+    ),
+    QueryFieldDescriptor(
+        name="excluded_providers",
+        spec_attr="excluded_providers",
+        plan_attr="excluded_providers",
+        spec_description=_label("exclude provider", _join_providers),
+        plan_description=_label("exclude provider", _join_providers),
+        requires_post_filter=True,
+        blocks_sql_count=True,
+        blocks_action_event_stats=True,
+        blocks_simple_message_hit=True,
+    ),
+    QueryFieldDescriptor(
+        name="tags",
+        spec_attr="tags",
+        plan_attr="tags",
+        spec_description=_label("tag", _join_comma),
+        plan_description=_label("tag", _join_comma),
+        requires_post_filter=True,
+        blocks_sql_count=True,
+        blocks_action_event_stats=True,
+        blocks_simple_message_hit=True,
+    ),
+    QueryFieldDescriptor(
+        name="excluded_tags",
+        spec_attr="excluded_tags",
+        plan_attr="excluded_tags",
+        spec_description=_label("exclude tag", _join_comma),
+        plan_description=_label("exclude tag", _join_comma),
+        requires_post_filter=True,
+        blocks_sql_count=True,
+        blocks_action_event_stats=True,
+        blocks_simple_message_hit=True,
+    ),
+    QueryFieldDescriptor(
+        name="title",
+        spec_attr="title",
+        plan_attr="title",
+        spec_active=_not_none,
+        plan_active=_not_none,
+        spec_description=_label("title"),
+        plan_description=_label("title"),
+        record_attr="title_contains",
+        sql_param="title_contains",
+        blocks_simple_message_hit=True,
+    ),
+    QueryFieldDescriptor(
+        name="has_types",
+        spec_attr="has_types",
+        plan_attr="has_types",
+        spec_description=_label("has", _join_comma),
+        plan_description=_label("has", _join_comma),
+        requires_post_filter=True,
+        blocks_sql_count=True,
+        blocks_action_event_stats=True,
+        blocks_simple_message_hit=True,
+    ),
+    QueryFieldDescriptor(
+        name="filter_has_tool_use",
+        spec_attr="filter_has_tool_use",
+        plan_attr="filter_has_tool_use",
+        spec_active=_is_true,
+        plan_active=_is_true,
+        spec_description=_literal("has: tool_use (sql)"),
+        plan_description=_literal("has_tool_use"),
+        record_attr="has_tool_use",
+        sql_param="has_tool_use",
+        requires_stats_join=True,
+        blocks_simple_message_hit=True,
+    ),
+    QueryFieldDescriptor(
+        name="filter_has_thinking",
+        spec_attr="filter_has_thinking",
+        plan_attr="filter_has_thinking",
+        spec_active=_is_true,
+        plan_active=_is_true,
+        spec_description=_literal("has: thinking (sql)"),
+        plan_description=_literal("has_thinking"),
+        record_attr="has_thinking",
+        sql_param="has_thinking",
+        requires_stats_join=True,
+        blocks_simple_message_hit=True,
+    ),
+    QueryFieldDescriptor(
+        name="min_messages",
+        spec_attr="min_messages",
+        plan_attr="min_messages",
+        spec_active=_not_none,
+        plan_active=_not_none,
+        spec_description=_label("min_messages"),
+        plan_description=_label("min_messages"),
+        record_attr="min_messages",
+        sql_param="min_messages",
+        requires_stats_join=True,
+        blocks_simple_message_hit=True,
+    ),
+    QueryFieldDescriptor(
+        name="max_messages",
+        spec_attr="max_messages",
+        plan_attr="max_messages",
+        spec_active=_not_none,
+        plan_active=_not_none,
+        spec_description=_label("max_messages"),
+        plan_description=_label("max_messages"),
+        record_attr="max_messages",
+        sql_param="max_messages",
+        requires_stats_join=True,
+        blocks_simple_message_hit=True,
+    ),
+    QueryFieldDescriptor(
+        name="min_words",
+        spec_attr="min_words",
+        plan_attr="min_words",
+        spec_active=_not_none,
+        plan_active=_not_none,
+        spec_description=_label("min_words"),
+        plan_description=_label("min_words"),
+        record_attr="min_words",
+        sql_param="min_words",
+        requires_stats_join=True,
+        blocks_simple_message_hit=True,
+    ),
+    QueryFieldDescriptor(
+        name="similar_text",
+        spec_attr="similar_text",
+        plan_attr="similar_text",
+        spec_active=_not_none,
+        plan_active=_truthy,
+        spec_description=_label("similar"),
+        plan_description=_label("similar", _truncated_text),
+        requires_content_loading=True,
+        blocks_sql_count=True,
+        blocks_action_event_stats=True,
+        blocks_simple_message_hit=True,
+    ),
+    QueryFieldDescriptor(
+        name="since",
+        spec_attr="since",
+        plan_attr="since",
+        spec_active=_not_none,
+        plan_active=_not_none,
+        spec_description=_label("since"),
+        plan_description=_label("since", _isoformat),
+        record_attr="since",
+        sql_param="since",
+        storage_value=_iso_value,
+    ),
+    QueryFieldDescriptor(
+        name="until",
+        spec_attr="until",
+        plan_attr="until",
+        spec_active=_not_none,
+        plan_active=_not_none,
+        spec_description=_label("until"),
+        plan_description=_label("until", _isoformat),
+        record_attr="until",
+        sql_param="until",
+        storage_value=_iso_value,
+        blocks_simple_message_hit=True,
+    ),
+    QueryFieldDescriptor(
+        name="conversation_id",
+        spec_attr="conversation_id",
+        plan_attr="conversation_id",
+        spec_active=_not_none,
+        plan_active=_not_none,
+        spec_description=_label("id"),
+        plan_description=_label("id"),
+        blocks_sql_count=True,
+        blocks_simple_message_hit=True,
+    ),
+    QueryFieldDescriptor(
+        name="latest",
+        spec_attr="latest",
+        spec_active=_is_true,
+        selection_filter=True,
+    ),
+    QueryFieldDescriptor(
+        name="parent_id",
+        plan_attr="parent_id",
+        plan_active=_not_none,
+        plan_description=_label("parent"),
+        record_attr="parent_id",
+        sql_param="parent_id",
+    ),
+    QueryFieldDescriptor(
+        name="continuation",
+        plan_attr="continuation",
+        plan_active=_not_none,
+        plan_description=lambda value: "continuation" if value is True else "not continuation",
+        requires_post_filter=True,
+        blocks_sql_count=True,
+        blocks_action_event_stats=True,
+    ),
+    QueryFieldDescriptor(
+        name="sidechain",
+        plan_attr="sidechain",
+        plan_active=_not_none,
+        plan_description=lambda value: "sidechain" if value is True else "not sidechain",
+        requires_post_filter=True,
+        blocks_sql_count=True,
+        blocks_action_event_stats=True,
+    ),
+    QueryFieldDescriptor(
+        name="root",
+        plan_attr="root",
+        plan_active=_not_none,
+        plan_description=lambda value: "root" if value is True else "not root",
+        requires_post_filter=True,
+        blocks_sql_count=True,
+        blocks_action_event_stats=True,
+    ),
+    QueryFieldDescriptor(
+        name="has_branches",
+        plan_attr="has_branches",
+        plan_active=_not_none,
+        plan_description=lambda value: "has branches" if value is True else "no branches",
+        requires_post_filter=True,
+        requires_content_loading=True,
+        blocks_sql_count=True,
+        blocks_action_event_stats=True,
+    ),
+    QueryFieldDescriptor(
+        name="predicates",
+        plan_attr="predicates",
+        plan_description=lambda value: f"custom predicates: {len(_as_tuple(value))}",
+        requires_post_filter=True,
+        requires_content_loading=True,
+        blocks_sql_count=True,
+        blocks_action_event_stats=True,
+    ),
+    QueryFieldDescriptor(
+        name="sample",
+        plan_attr="sample",
+        plan_active=_not_none,
+        selection_filter=False,
+        blocks_simple_message_hit=True,
+    ),
+)
+
+
+def describe_spec_fields(spec: object) -> list[str]:
+    return [
+        description
+        for descriptor in QUERY_FIELD_DESCRIPTORS
+        if (description := descriptor.describe_spec(spec)) is not None
+    ]
+
+
+def describe_plan_fields(plan: object) -> list[str]:
+    return [
+        description
+        for descriptor in QUERY_FIELD_DESCRIPTORS
+        if (description := descriptor.describe_plan(plan)) is not None
+    ]
+
+
+def query_spec_has_selection_filters(spec: object) -> bool:
+    return any(
+        descriptor.selection_filter and descriptor.is_active_for_spec(spec) for descriptor in QUERY_FIELD_DESCRIPTORS
+    )
+
+
+def plan_has_selection_filters(plan: object) -> bool:
+    return any(
+        descriptor.selection_filter and descriptor.is_active_for_plan(plan) for descriptor in QUERY_FIELD_DESCRIPTORS
+    )
+
+
+def active_plan_field_names(plan: object) -> tuple[str, ...]:
+    """Return active plan descriptor names for tests and diagnostics."""
+    return tuple(descriptor.name for descriptor in QUERY_FIELD_DESCRIPTORS if descriptor.is_active_for_plan(plan))
+
+
+def plan_has_fields_matching(plan: object, predicate: Callable[[QueryFieldDescriptor], bool]) -> bool:
+    return any(predicate(descriptor) and descriptor.is_active_for_plan(plan) for descriptor in QUERY_FIELD_DESCRIPTORS)
+
+
+def has_message_content_type_filter(plan: object) -> bool:
+    for descriptor in QUERY_FIELD_DESCRIPTORS:
+        if descriptor.name != "has_types" or not descriptor.is_active_for_plan(plan):
+            continue
+        return any(str(kind) in {"thinking", "tools", "attachments"} for kind in _as_tuple(descriptor.plan_value(plan)))
+    return False
+
+
+def provider_scope_for_plan(plan: _ProviderScopedPlan) -> tuple[str | None, tuple[str, ...]]:
+    values = _provider_values(plan.providers)
+    provider = values[0] if len(values) == 1 else None
+    provider_group = values if len(values) > 1 else ()
+    return provider, provider_group
+
+
+def conversation_record_query_for_plan(plan: object) -> ConversationRecordQuery:
+    provider, providers = provider_scope_for_plan(cast(_ProviderScopedPlan, plan))
+    changes: dict[str, object] = {}
+    for descriptor in QUERY_FIELD_DESCRIPTORS:
+        if descriptor.record_attr is None or not descriptor.is_active_for_plan(plan):
+            continue
+        changes[descriptor.record_attr] = descriptor.storage_plan_value(plan)
+    return _ReplaceRecordQuery(
+        ConversationRecordQuery(provider=provider, providers=providers),
+        **changes,
+    )
+
+
+def sql_pushdown_params_for_plan(plan: object) -> dict[str, object]:
+    params: dict[str, object] = {}
+    provider, providers = provider_scope_for_plan(cast(_ProviderScopedPlan, plan))
+    if provider is not None:
+        params["provider"] = provider
+    elif providers:
+        params["providers"] = list(providers)
+    for descriptor in QUERY_FIELD_DESCRIPTORS:
+        if descriptor.sql_param is None or not descriptor.is_active_for_plan(plan):
+            continue
+        params[descriptor.sql_param] = descriptor.sql_plan_value(plan)
+    return params
+
+
+def storage_filters_require_stats_join(filters: Mapping[str, object]) -> bool:
+    for descriptor in QUERY_FIELD_DESCRIPTORS:
+        if not descriptor.requires_stats_join or descriptor.record_attr is None:
+            continue
+        if descriptor.plan_active(filters.get(descriptor.record_attr)):
+            return True
+    return False
+
+
+__all__ = [
+    "QUERY_FIELD_DESCRIPTORS",
+    "QueryFieldDescriptor",
+    "active_plan_field_names",
+    "conversation_record_query_for_plan",
+    "describe_plan_fields",
+    "describe_spec_fields",
+    "has_message_content_type_filter",
+    "plan_has_fields_matching",
+    "plan_has_selection_filters",
+    "query_spec_has_selection_filters",
+    "sql_pushdown_params_for_plan",
+    "storage_filters_require_stats_join",
+]

--- a/polylogue/lib/query_plan.py
+++ b/polylogue/lib/query_plan.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass, replace
 from datetime import datetime
 from typing import TYPE_CHECKING, TypeVar
 
+from polylogue.lib.query_fields import conversation_record_query_for_plan, sql_pushdown_params_for_plan
 from polylogue.lib.query_plan_description import describe_plan, effective_fetch_limit, plan_has_filters
 from polylogue.lib.query_retrieval import (
     action_event_rows_ready,
@@ -33,7 +34,7 @@ from polylogue.lib.query_runtime import (
     plan_needs_content_loading,
 )
 from polylogue.lib.query_sorting import SortKey, finalize_results, sort_conversations, sort_generic, sort_summaries
-from polylogue.lib.query_support import conversation_has_branches, provider_values
+from polylogue.lib.query_support import conversation_has_branches
 from polylogue.storage.query_models import ConversationRecordQuery
 from polylogue.types import Provider
 
@@ -53,69 +54,11 @@ _FilterableT = TypeVar("_FilterableT", bound="FilterableConversationLike")
 
 
 def plan_record_query(plan: ConversationQueryPlan) -> ConversationRecordQuery:
-    values = provider_values(plan.providers)
-    provider = values[0] if len(values) == 1 else None
-    providers = values if len(values) > 1 else ()
-    return ConversationRecordQuery(
-        provider=provider,
-        providers=providers,
-        parent_id=plan.parent_id,
-        since=plan.since.isoformat() if plan.since else None,
-        until=plan.until.isoformat() if plan.until else None,
-        title_contains=plan.title,
-        path_terms=plan.path_terms,
-        action_terms=plan.action_terms,
-        excluded_action_terms=plan.excluded_action_terms,
-        tool_terms=plan.tool_terms,
-        excluded_tool_terms=plan.excluded_tool_terms,
-        has_tool_use=plan.filter_has_tool_use,
-        has_thinking=plan.filter_has_thinking,
-        min_messages=plan.min_messages,
-        max_messages=plan.max_messages,
-        min_words=plan.min_words,
-    )
+    return conversation_record_query_for_plan(plan)
 
 
 def plan_sql_pushdown_params(plan: ConversationQueryPlan) -> dict[str, object]:
-    params: dict[str, object] = {}
-    values = provider_values(plan.providers)
-    if len(values) == 1:
-        params["provider"] = values[0]
-    elif values:
-        params["providers"] = list(values)
-    if plan.parent_id:
-        params["parent_id"] = plan.parent_id
-    if plan.since:
-        params["since"] = plan.since.isoformat()
-    if plan.until:
-        params["until"] = plan.until.isoformat()
-    if plan.title:
-        params["title_contains"] = plan.title
-    if plan.path_terms:
-        params["path_terms"] = list(plan.path_terms)
-    if plan.action_terms:
-        params["action_terms"] = list(plan.action_terms)
-    if plan.excluded_action_terms:
-        params["excluded_action_terms"] = list(plan.excluded_action_terms)
-    if plan.action_sequence:
-        params["action_sequence"] = list(plan.action_sequence)
-    if plan.action_text_terms:
-        params["action_text_terms"] = list(plan.action_text_terms)
-    if plan.tool_terms:
-        params["tool_terms"] = list(plan.tool_terms)
-    if plan.excluded_tool_terms:
-        params["excluded_tool_terms"] = list(plan.excluded_tool_terms)
-    if plan.filter_has_tool_use:
-        params["has_tool_use"] = True
-    if plan.filter_has_thinking:
-        params["has_thinking"] = True
-    if plan.min_messages is not None:
-        params["min_messages"] = plan.min_messages
-    if plan.max_messages is not None:
-        params["max_messages"] = plan.max_messages
-    if plan.min_words is not None:
-        params["min_words"] = plan.min_words
-    return params
+    return sql_pushdown_params_for_plan(plan)
 
 
 # ---------------------------------------------------------------------------

--- a/polylogue/lib/query_plan_description.py
+++ b/polylogue/lib/query_plan_description.py
@@ -4,122 +4,18 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from polylogue.lib.query_support import provider_values
+from polylogue.lib.query_fields import describe_plan_fields, plan_has_selection_filters
 
 if TYPE_CHECKING:
     from polylogue.lib.query_plan import ConversationQueryPlan
 
 
 def describe_plan(plan: ConversationQueryPlan) -> list[str]:
-    parts: list[str] = []
-    if plan.fts_terms:
-        parts.append(f"contains: {', '.join(plan.fts_terms)}")
-    if plan.negative_terms:
-        parts.append(f"exclude text: {', '.join(plan.negative_terms)}")
-    if plan.retrieval_lane != "auto":
-        parts.append(f"retrieval: {plan.retrieval_lane}")
-    if plan.path_terms:
-        parts.append(f"path: {', '.join(plan.path_terms)}")
-    if plan.action_terms:
-        parts.append(f"action: {', '.join(plan.action_terms)}")
-    if plan.excluded_action_terms:
-        parts.append(f"exclude action: {', '.join(plan.excluded_action_terms)}")
-    if plan.action_sequence:
-        parts.append(f"action sequence: {' -> '.join(plan.action_sequence)}")
-    if plan.action_text_terms:
-        parts.append(f"action text: {', '.join(plan.action_text_terms)}")
-    if plan.tool_terms:
-        parts.append(f"tool: {', '.join(plan.tool_terms)}")
-    if plan.excluded_tool_terms:
-        parts.append(f"exclude tool: {', '.join(plan.excluded_tool_terms)}")
-    if plan.providers:
-        parts.append(f"provider: {', '.join(provider_values(plan.providers))}")
-    if plan.excluded_providers:
-        parts.append(f"exclude provider: {', '.join(provider_values(plan.excluded_providers))}")
-    if plan.tags:
-        parts.append(f"tag: {', '.join(plan.tags)}")
-    if plan.excluded_tags:
-        parts.append(f"exclude tag: {', '.join(plan.excluded_tags)}")
-    if plan.title:
-        parts.append(f"title: {plan.title}")
-    if plan.has_types:
-        parts.append(f"has: {', '.join(plan.has_types)}")
-    if plan.filter_has_tool_use:
-        parts.append("has_tool_use")
-    if plan.filter_has_thinking:
-        parts.append("has_thinking")
-    if plan.min_messages is not None:
-        parts.append(f"min_messages: {plan.min_messages}")
-    if plan.max_messages is not None:
-        parts.append(f"max_messages: {plan.max_messages}")
-    if plan.min_words is not None:
-        parts.append(f"min_words: {plan.min_words}")
-    if plan.since:
-        parts.append(f"since: {plan.since.isoformat()}")
-    if plan.until:
-        parts.append(f"until: {plan.until.isoformat()}")
-    if plan.conversation_id:
-        parts.append(f"id: {plan.conversation_id}")
-    if plan.parent_id:
-        parts.append(f"parent: {plan.parent_id}")
-    if plan.continuation is True:
-        parts.append("continuation")
-    if plan.continuation is False:
-        parts.append("not continuation")
-    if plan.sidechain is True:
-        parts.append("sidechain")
-    if plan.sidechain is False:
-        parts.append("not sidechain")
-    if plan.root is True:
-        parts.append("root")
-    if plan.root is False:
-        parts.append("not root")
-    if plan.has_branches is True:
-        parts.append("has branches")
-    if plan.has_branches is False:
-        parts.append("no branches")
-    if plan.predicates:
-        parts.append(f"custom predicates: {len(plan.predicates)}")
-    if plan.similar_text:
-        parts.append(f"similar: {plan.similar_text[:30]}")
-    return parts
+    return describe_plan_fields(plan)
 
 
 def plan_has_filters(plan: ConversationQueryPlan) -> bool:
-    return any(
-        (
-            plan.fts_terms,
-            plan.negative_terms,
-            plan.path_terms,
-            plan.action_terms,
-            plan.excluded_action_terms,
-            plan.action_sequence,
-            plan.action_text_terms,
-            plan.tool_terms,
-            plan.excluded_tool_terms,
-            plan.providers,
-            plan.excluded_providers,
-            plan.tags,
-            plan.excluded_tags,
-            plan.has_types,
-            plan.title is not None,
-            plan.conversation_id is not None,
-            plan.parent_id is not None,
-            plan.since is not None,
-            plan.until is not None,
-            plan.similar_text is not None,
-            plan.continuation is not None,
-            plan.sidechain is not None,
-            plan.root is not None,
-            plan.has_branches is not None,
-            plan.filter_has_tool_use,
-            plan.filter_has_thinking,
-            plan.min_messages is not None,
-            plan.max_messages is not None,
-            plan.min_words is not None,
-            plan.predicates,
-        )
-    )
+    return plan_has_selection_filters(plan)
 
 
 def effective_fetch_limit(plan: ConversationQueryPlan) -> int | None:

--- a/polylogue/lib/query_runtime_plan.py
+++ b/polylogue/lib/query_runtime_plan.py
@@ -4,94 +4,32 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from polylogue.lib.query_fields import has_message_content_type_filter, plan_has_fields_matching
+
 if TYPE_CHECKING:
     from polylogue.lib.query_plan import ConversationQueryPlan
 
 
 def plan_has_post_filters(plan: ConversationQueryPlan) -> bool:
-    return bool(
-        plan.excluded_providers
-        or plan.tags
-        or plan.excluded_tags
-        or plan.has_types
-        or plan.predicates
-        or plan.negative_terms
-        or plan.path_terms
-        or plan.action_terms
-        or plan.excluded_action_terms
-        or plan.action_sequence
-        or plan.action_text_terms
-        or plan.tool_terms
-        or plan.excluded_tool_terms
-        or plan.continuation is not None
-        or plan.sidechain is not None
-        or plan.root is not None
-        or plan.has_branches is not None
-    )
+    return plan_has_fields_matching(plan, lambda descriptor: descriptor.requires_post_filter)
 
 
 def plan_needs_content_loading(plan: ConversationQueryPlan) -> bool:
     if plan.fts_terms and plan.retrieval_lane in {"actions", "hybrid"}:
         return True
-    if plan.has_types and any(kind in ("thinking", "tools", "attachments") for kind in plan.has_types):
+    if has_message_content_type_filter(plan):
         return True
-    if plan.negative_terms or plan.predicates or plan.similar_text:
-        return True
-    if plan.path_terms or plan.action_terms or plan.excluded_action_terms:
-        return True
-    if plan.tool_terms or plan.excluded_tool_terms:
-        return True
-    if plan.action_sequence:
-        return True
-    if plan.action_text_terms:
-        return True
-    if plan.has_branches is not None:
+    if plan_has_fields_matching(plan, lambda descriptor: descriptor.requires_content_loading):
         return True
     return plan.sort in ("messages", "words", "longest", "tokens")
 
 
 def plan_can_count_in_sql(plan: ConversationQueryPlan) -> bool:
-    return not (
-        plan.fts_terms
-        or plan.conversation_id
-        or plan.similar_text
-        or plan.path_terms
-        or plan.action_terms
-        or plan.excluded_action_terms
-        or plan.tool_terms
-        or plan.excluded_tool_terms
-        or plan.action_sequence
-        or plan.action_text_terms
-        or plan.predicates
-        or plan.has_types
-        or plan.negative_terms
-        or plan.excluded_providers
-        or plan.tags
-        or plan.excluded_tags
-        or plan.continuation is not None
-        or plan.sidechain is not None
-        or plan.root is not None
-        or plan.has_branches is not None
-    )
+    return not plan_has_fields_matching(plan, lambda descriptor: descriptor.blocks_sql_count)
 
 
 def plan_can_use_action_event_stats(plan: ConversationQueryPlan) -> bool:
-    return not (
-        plan.fts_terms
-        or plan.negative_terms
-        or plan.action_sequence
-        or plan.action_text_terms
-        or plan.predicates
-        or plan.has_types
-        or plan.tags
-        or plan.excluded_tags
-        or plan.excluded_providers
-        or plan.continuation is not None
-        or plan.sidechain is not None
-        or plan.root is not None
-        or plan.has_branches is not None
-        or plan.similar_text
-    )
+    return not plan_has_fields_matching(plan, lambda descriptor: descriptor.blocks_action_event_stats)
 
 
 __all__ = [

--- a/polylogue/lib/query_search_hits.py
+++ b/polylogue/lib/query_search_hits.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from polylogue.lib.query_fields import plan_has_fields_matching
 from polylogue.lib.query_retrieval import search_limit
 from polylogue.lib.query_retrieval_search import search_query_text
 from polylogue.lib.query_support import provider_values
@@ -25,28 +26,7 @@ def _simple_message_hit_plan(plan: ConversationQueryPlan) -> bool:
     return bool(
         plan.fts_terms
         and plan.retrieval_lane in {"auto", "dialogue"}
-        and plan.conversation_id is None
-        and plan.similar_text is None
-        and not plan.negative_terms
-        and not plan.path_terms
-        and not plan.action_terms
-        and not plan.excluded_action_terms
-        and not plan.action_sequence
-        and not plan.action_text_terms
-        and not plan.tool_terms
-        and not plan.excluded_tool_terms
-        and not plan.excluded_providers
-        and not plan.tags
-        and not plan.excluded_tags
-        and not plan.has_types
-        and plan.title is None
-        and plan.until is None
-        and plan.sample is None
-        and not plan.filter_has_tool_use
-        and not plan.filter_has_thinking
-        and plan.min_messages is None
-        and plan.max_messages is None
-        and plan.min_words is None
+        and not plan_has_fields_matching(plan, lambda descriptor: descriptor.blocks_simple_message_hit)
     )
 
 

--- a/polylogue/lib/query_spec.py
+++ b/polylogue/lib/query_spec.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, TypeVar
 
 from polylogue.lib.dates import parse_date
 from polylogue.lib.filter_types import SortField
+from polylogue.lib.query_fields import describe_spec_fields, query_spec_has_selection_filters
 from polylogue.lib.query_plan import ConversationQueryPlan
 from polylogue.lib.viewports import ToolCategory
 from polylogue.types import Provider
@@ -146,93 +147,11 @@ def optional_sort_field(value: object) -> SortField | None:
 
 
 def describe_query_spec(spec: ConversationQuerySpec) -> list[str]:
-    parts: list[str] = []
-    if spec.query_terms:
-        parts.append(f"search: {' '.join(spec.query_terms)}")
-    if spec.contains_terms:
-        parts.append(f"contains: {', '.join(spec.contains_terms)}")
-    if spec.exclude_text_terms:
-        parts.append(f"exclude text: {', '.join(spec.exclude_text_terms)}")
-    if spec.retrieval_lane != "auto":
-        parts.append(f"retrieval: {spec.retrieval_lane}")
-    if spec.path_terms:
-        parts.append(f"path: {', '.join(spec.path_terms)}")
-    if spec.action_terms:
-        parts.append(f"action: {', '.join(spec.action_terms)}")
-    if spec.excluded_action_terms:
-        parts.append(f"exclude action: {', '.join(spec.excluded_action_terms)}")
-    if spec.action_sequence:
-        parts.append(f"action sequence: {' -> '.join(spec.action_sequence)}")
-    if spec.action_text_terms:
-        parts.append(f"action text: {', '.join(spec.action_text_terms)}")
-    if spec.tool_terms:
-        parts.append(f"tool: {', '.join(spec.tool_terms)}")
-    if spec.excluded_tool_terms:
-        parts.append(f"exclude tool: {', '.join(spec.excluded_tool_terms)}")
-    if spec.providers:
-        parts.append(f"provider: {', '.join(p.value for p in spec.providers)}")
-    if spec.excluded_providers:
-        parts.append(f"exclude provider: {', '.join(p.value for p in spec.excluded_providers)}")
-    if spec.tags:
-        parts.append(f"tag: {', '.join(spec.tags)}")
-    if spec.excluded_tags:
-        parts.append(f"exclude tag: {', '.join(spec.excluded_tags)}")
-    if spec.title:
-        parts.append(f"title: {spec.title}")
-    if spec.has_types:
-        parts.append(f"has: {', '.join(spec.has_types)}")
-    if spec.filter_has_tool_use:
-        parts.append("has: tool_use (sql)")
-    if spec.filter_has_thinking:
-        parts.append("has: thinking (sql)")
-    if spec.min_messages is not None:
-        parts.append(f"min_messages: {spec.min_messages}")
-    if spec.max_messages is not None:
-        parts.append(f"max_messages: {spec.max_messages}")
-    if spec.min_words is not None:
-        parts.append(f"min_words: {spec.min_words}")
-    if spec.similar_text:
-        parts.append(f"similar: {spec.similar_text}")
-    if spec.since:
-        parts.append(f"since: {spec.since}")
-    if spec.until:
-        parts.append(f"until: {spec.until}")
-    if spec.conversation_id:
-        parts.append(f"id: {spec.conversation_id}")
-    return parts
+    return describe_spec_fields(spec)
 
 
 def query_spec_has_filters(spec: ConversationQuerySpec) -> bool:
-    return any(
-        (
-            spec.query_terms,
-            spec.contains_terms,
-            spec.exclude_text_terms,
-            spec.path_terms,
-            spec.action_terms,
-            spec.excluded_action_terms,
-            spec.action_sequence,
-            spec.action_text_terms,
-            spec.tool_terms,
-            spec.excluded_tool_terms,
-            spec.providers,
-            spec.excluded_providers,
-            spec.tags,
-            spec.excluded_tags,
-            spec.has_types,
-            spec.title is not None,
-            spec.conversation_id is not None,
-            spec.since is not None,
-            spec.until is not None,
-            spec.latest,
-            spec.filter_has_tool_use,
-            spec.filter_has_thinking,
-            spec.min_messages is not None,
-            spec.max_messages is not None,
-            spec.min_words is not None,
-            spec.similar_text is not None,
-        )
-    )
+    return query_spec_has_selection_filters(spec)
 
 
 # ---------------------------------------------------------------------------

--- a/polylogue/storage/backends/queries/filter_builder.py
+++ b/polylogue/storage/backends/queries/filter_builder.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from polylogue.lib.query_fields import storage_filters_require_stats_join
 from polylogue.lib.viewports import ToolCategory
 from polylogue.storage.backends.connection import _build_provider_scope_filter
 
@@ -50,9 +51,7 @@ def _build_conversation_filters(
     """
     where_clauses: list[str] = []
     params: list[str | int | float] = []
-    needs_stats_join = (
-        has_tool_use or has_thinking or min_messages is not None or max_messages is not None or min_words is not None
-    )
+    needs_stats_join = storage_filters_require_stats_join(locals())
 
     if source is not None:
         where_clauses.append("c.source_name = ?" if needs_stats_join else "source_name = ?")
@@ -176,4 +175,4 @@ def _needs_stats_join(
     min_words: int | None = None,
 ) -> bool:
     """Return True when the query requires a JOIN on conversation_stats."""
-    return has_tool_use or has_thinking or min_messages is not None or max_messages is not None or min_words is not None
+    return storage_filters_require_stats_join(locals())

--- a/tests/unit/core/test_query_fields.py
+++ b/tests/unit/core/test_query_fields.py
@@ -1,0 +1,108 @@
+"""Query-field descriptor catalog contracts."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from polylogue.lib.query_fields import (
+    QUERY_FIELD_DESCRIPTORS,
+    active_plan_field_names,
+    storage_filters_require_stats_join,
+)
+from polylogue.lib.query_plan import ConversationQueryPlan
+from polylogue.lib.query_spec import ConversationQuerySpec
+from polylogue.storage.backends.queries.filter_builder import _needs_stats_join
+from polylogue.types import Provider
+
+
+def test_query_field_catalog_drives_spec_presence_and_descriptions() -> None:
+    spec = ConversationQuerySpec(
+        query_terms=("sqlite", "locks"),
+        path_terms=("polylogue/storage",),
+        providers=(Provider.CODEX,),
+        filter_has_tool_use=True,
+        min_messages=3,
+        since="2024-01-01",
+    )
+
+    assert spec.has_filters() is True
+    assert spec.describe() == [
+        "search: sqlite locks",
+        "path: polylogue/storage",
+        "provider: codex",
+        "has: tool_use (sql)",
+        "min_messages: 3",
+        "since: 2024-01-01",
+    ]
+
+
+def test_query_field_catalog_drives_plan_presence_descriptions_and_pushdown() -> None:
+    since = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    plan = ConversationQueryPlan(
+        query_terms=("sqlite",),
+        path_terms=("polylogue/storage",),
+        tool_terms=("bash",),
+        providers=(Provider.CODEX,),
+        title="locks",
+        since=since,
+        filter_has_tool_use=True,
+        min_messages=3,
+    )
+
+    assert active_plan_field_names(plan) == (
+        "query_terms",
+        "path_terms",
+        "tool_terms",
+        "providers",
+        "title",
+        "filter_has_tool_use",
+        "min_messages",
+        "since",
+    )
+    assert plan.has_filters() is True
+    assert plan.describe() == [
+        "contains: sqlite",
+        "path: polylogue/storage",
+        "tool: bash",
+        "provider: codex",
+        "title: locks",
+        "has_tool_use",
+        "min_messages: 3",
+        "since: 2024-01-01T00:00:00+00:00",
+    ]
+
+    assert plan.sql_pushdown_params() == {
+        "provider": "codex",
+        "path_terms": ["polylogue/storage"],
+        "tool_terms": ["bash"],
+        "title_contains": "locks",
+        "has_tool_use": True,
+        "min_messages": 3,
+        "since": "2024-01-01T00:00:00+00:00",
+    }
+
+    record_query = plan.record_query
+    assert record_query.provider == "codex"
+    assert record_query.path_terms == ("polylogue/storage",)
+    assert record_query.tool_terms == ("bash",)
+    assert record_query.title_contains == "locks"
+    assert record_query.has_tool_use is True
+    assert record_query.min_messages == 3
+    assert record_query.since == "2024-01-01T00:00:00+00:00"
+
+
+def test_query_field_catalog_marks_storage_stats_join_fields() -> None:
+    assert {descriptor.name for descriptor in QUERY_FIELD_DESCRIPTORS if descriptor.requires_stats_join} == {
+        "filter_has_tool_use",
+        "filter_has_thinking",
+        "min_messages",
+        "max_messages",
+        "min_words",
+    }
+
+    assert storage_filters_require_stats_join({"has_tool_use": True}) is True
+    assert storage_filters_require_stats_join({"min_messages": 2}) is True
+    assert storage_filters_require_stats_join({"title_contains": "locks"}) is False
+    assert _needs_stats_join(has_tool_use=True) is True
+    assert _needs_stats_join(min_words=10) is True
+    assert _needs_stats_join() is False


### PR DESCRIPTION
## Summary

Adds a shared query field descriptor catalog and uses it to drive existing query-spec, query-plan, runtime capability, search-hit routing, and storage pushdown metadata paths.

## Problem

#321 tracks semantic duplication found in #315: query fields were restated across spec descriptions, plan descriptions, filter presence checks, runtime capability checks, storage record-query mapping, SQL pushdown parameters, and stats-join detection. That made adding or changing one query field require hand-updating several parallel inventories.

## Solution

Introduced `polylogue/lib/query_fields.py` as the shared descriptor catalog for query field facts: spec/plan attributes, active predicates, descriptions, record-query and SQL parameter mappings, stats-join requirements, runtime post-filter/content-loading flags, SQL-count blockers, action-event stats blockers, and search-hit evidence blockers.

Wired existing consumers through the catalog without changing CLI/MCP/facade signatures:

- `query_spec.py` now delegates descriptions and filter-presence checks to descriptors.
- `query_plan_description.py` delegates plan descriptions and presence checks.
- `query_plan.py` delegates record-query and SQL pushdown mapping.
- `query_runtime_plan.py` delegates runtime capability predicates.
- `query_search_hits.py` delegates simple-message-hit blockers.
- `storage/backends/queries/filter_builder.py` delegates stats-join detection.

Added descriptor tests covering spec/plan descriptions, active field names, SQL pushdown params, record-query tuple/list shape, and stats-join metadata.

## Verification

- `ruff check polylogue/lib/query_fields.py polylogue/lib/query_spec.py polylogue/lib/query_plan.py polylogue/lib/query_plan_description.py polylogue/lib/query_runtime_plan.py polylogue/lib/query_search_hits.py polylogue/storage/backends/queries/filter_builder.py tests/unit/core/test_query_fields.py`
- `mypy polylogue/lib/query_fields.py polylogue/lib/query_spec.py polylogue/lib/query_plan.py polylogue/lib/query_plan_description.py polylogue/lib/query_runtime_plan.py polylogue/lib/query_search_hits.py polylogue/storage/backends/queries/filter_builder.py tests/unit/core/test_query_fields.py`
- `pytest -q tests/unit/core/test_query_fields.py tests/unit/lib/test_filter_executor.py tests/unit/core/test_filters_props.py -q`
- `pytest -q tests/unit/cli/test_query_exec.py tests/unit/cli/test_click_app.py tests/unit/mcp/test_tool_contracts.py tests/unit/core/test_query_retrieval_candidates.py` (`175 passed`)
- `pytest -q tests/unit/storage/test_store_ops.py tests/unit/storage/test_scale.py tests/unit/storage/test_search_misc.py tests/unit/storage/test_query_mappers.py` (`119 passed`)
- `mypy polylogue/ tests/unit/core/test_query_fields.py`
- `devtools render-all --check`
- `devtools verify` (`all checks passed`)
- push hook: `devtools verify --quick` (`all checks passed`)

Closes #321
