### PR TITLE
feat: add neighbor candidate discovery (#364)

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -123,6 +123,7 @@ Commands:
   doctor       Health check with optional maintenance and cleanup previews.
   list         List matched conversations.
   mcp          Start the MCP server for AI assistant integration.
+  neighbors    Show explainable neighboring or near-duplicate candidates.
   open         Open matched conversation in browser/editor.
   products     Inspect durable archive data products.
   reset        Reset database, blob store, assets, rendered outputs, or...

--- a/docs/test-quality-workflows.md
+++ b/docs/test-quality-workflows.md
@@ -15,10 +15,10 @@ Current registry snapshot:
 - mutation campaigns: `19`
 - benchmark campaigns: `3`
 - synthetic benchmark campaigns: `6`
-- scenario projections: `237`
+- scenario projections: `238`
 - inferred corpus scenarios: `5`
   - benchmark-campaign: `3`
-  - exercise: `132`
+  - exercise: `133`
   - inferred-corpus-scenario: `5`
   - mutation-campaign: `19`
   - synthetic-benchmark: `6`
@@ -319,6 +319,7 @@ These are the authored scenario-bearing projections currently feeding runtime co
 | `exercise` | `help-list` | `conversation-query-loop` | `message_fts`<br>`conversation_query_results` | `cli.help`<br>`query-conversations` | — | `generated`<br>`help`<br>`structural` | list help |
 | `exercise` | `help-main` | — | — | — | — | — | Main help screen |
 | `exercise` | `help-mcp` | `conversation-query-loop` | `message_fts`<br>`conversation_query_results` | `cli.help`<br>`query-conversations` | — | `generated`<br>`help`<br>`structural` | mcp help |
+| `exercise` | `help-neighbors` | `conversation-query-loop` | `message_fts`<br>`conversation_query_results` | `cli.help`<br>`query-conversations` | — | `generated`<br>`help`<br>`structural` | neighbors help |
 | `exercise` | `help-open` | `conversation-query-loop` | `message_fts`<br>`conversation_query_results` | `cli.help`<br>`query-conversations` | — | `generated`<br>`help`<br>`structural` | open help |
 | `exercise` | `help-products` | — | — | `cli.help` | — | `generated`<br>`help`<br>`structural` | products help |
 | `exercise` | `help-products-analytics` | `provider-analytics-query-loop` | `session_product_rows`<br>`provider_analytics_results` | `cli.help`<br>`query-provider-analytics` | — | `generated`<br>`help`<br>`structural` | products analytics help |

--- a/docs/verification-catalog.md
+++ b/docs/verification-catalog.md
@@ -8,10 +8,10 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 
 ## Snapshot
 
-- subjects: `9033`
+- subjects: `9034`
 - claims: `22`
 - runner bindings: `22`
-- proof obligations: `9112`
+- proof obligations: `9115`
 
 ## Quality Checks
 
@@ -31,7 +31,7 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | --- | ---: |
 | `archive.query_law` | 1 |
 | `artifact.path` | 27 |
-| `cli.command` | 39 |
+| `cli.command` | 40 |
 | `cli.json_command` | 2 |
 | `diagnostic.observable` | 1 |
 | `error.surface` | 2 |
@@ -57,6 +57,7 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | `polylogue doctor` | `polylogue/cli/commands/check.py:31` `polylogue.cli.commands.check.check_command` |
 | `polylogue list` | `polylogue/cli/query_verbs.py:18` `polylogue.cli.query_verbs.list_verb` |
 | `polylogue mcp` | `polylogue/cli/commands/mcp.py:10` `polylogue.cli.commands.mcp.mcp_command` |
+| `polylogue neighbors` | `polylogue/cli/commands/neighbors.py:42` `polylogue.cli.commands.neighbors.neighbors_command` |
 | `polylogue open` | `polylogue/cli/query_verbs.py:76` `polylogue.cli.query_verbs.open_verb` |
 | `polylogue products` | `polylogue/cli/commands/products.py:129` `polylogue.cli.commands.products.products_command` |
 | `polylogue products analytics` | `polylogue/cli/commands/products.py:92` `polylogue.cli.commands.products._make_callback.<locals>.callback` |
@@ -183,10 +184,10 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | --- | ---: |
 | `archive.query.provider_filter_consistency` | 1 |
 | `artifact.path.dependency_closure` | 11 |
-| `cli.command.help` | 39 |
+| `cli.command.help` | 40 |
 | `cli.command.json_envelope` | 2 |
-| `cli.command.no_traceback` | 39 |
-| `cli.command.plain_mode` | 39 |
+| `cli.command.no_traceback` | 40 |
+| `cli.command.plain_mode` | 40 |
 | `diagnostic.observable_trace_mapping` | 1 |
 | `error.machine_user_context` | 2 |
 | `generated.scenario.family_registered` | 9 |

--- a/polylogue/cli/click_command_registration.py
+++ b/polylogue/cli/click_command_registration.py
@@ -9,6 +9,7 @@ from polylogue.cli.commands.check import check_command
 from polylogue.cli.commands.completions import completions_command
 from polylogue.cli.commands.dashboard import dashboard_command
 from polylogue.cli.commands.mcp import mcp_command
+from polylogue.cli.commands.neighbors import neighbors_command
 from polylogue.cli.commands.products import products_command
 from polylogue.cli.commands.qa import qa_command
 from polylogue.cli.commands.reset import reset_command
@@ -24,6 +25,7 @@ ROOT_COMMANDS: tuple[click.Command, ...] = (
     auth_command,
     completions_command,
     dashboard_command,
+    neighbors_command,
     products_command,
     tags_command,
     qa_command,
@@ -41,5 +43,6 @@ __all__ = [
     "completions_command",
     "dashboard_command",
     "mcp_command",
+    "neighbors_command",
     "register_root_commands",
 ]

--- a/polylogue/cli/commands/neighbors.py
+++ b/polylogue/cli/commands/neighbors.py
@@ -1,0 +1,101 @@
+"""Neighboring-conversation discovery command."""
+
+from __future__ import annotations
+
+import click
+
+from polylogue.cli.helper_support import fail
+from polylogue.cli.machine_errors import emit_success
+from polylogue.cli.types import AppEnv
+from polylogue.lib.neighbor_candidates import ConversationNeighborCandidate, NeighborDiscoveryError
+from polylogue.surface_payloads import ConversationNeighborCandidatePayload, model_json_document
+from polylogue.sync_bridge import run_coroutine_sync
+
+
+def _score_label(score: float) -> str:
+    return f"{score:.2f}".rstrip("0").rstrip(".")
+
+
+def _candidate_heading(candidate: ConversationNeighborCandidate) -> str:
+    summary = candidate.summary
+    date = f" {summary.display_date.isoformat()}" if summary.display_date else ""
+    return (
+        f"{candidate.rank}. {candidate.conversation_id} "
+        f"[{summary.provider}] {summary.display_title}{date} "
+        f"(score {_score_label(candidate.score)})"
+    )
+
+
+def _render_plain(candidates: list[ConversationNeighborCandidate]) -> None:
+    if not candidates:
+        click.echo("No neighboring candidates found.")
+        return
+
+    click.echo(f"Neighbor candidates ({len(candidates)}):")
+    for candidate in candidates:
+        click.echo(_candidate_heading(candidate))
+        for reason in candidate.reasons:
+            evidence = f" ({reason.evidence})" if reason.evidence else ""
+            click.echo(f"   - {reason.kind}: {reason.detail}{evidence}")
+
+
+@click.command("neighbors")
+@click.option("--id", "conversation_id", default=None, help="Known conversation id or prefix")
+@click.option("--query", "-q", default=None, help="Fuzzy query to seed candidate discovery")
+@click.option("--provider", "-p", default=None, help="Limit candidate scope to one provider")
+@click.option("--limit", "-n", type=int, default=10, show_default=True, help="Maximum candidates")
+@click.option(
+    "--window-hours",
+    type=int,
+    default=24,
+    show_default=True,
+    help="Neighboring time window around --id",
+)
+@click.option("--json", "json_mode", is_flag=True, help="Output as JSON")
+@click.option("--format", "-f", "output_format", type=click.Choice(["json"]), default=None, help="Output format")
+@click.pass_obj
+def neighbors_command(
+    env: AppEnv,
+    conversation_id: str | None,
+    query: str | None,
+    provider: str | None,
+    limit: int,
+    window_hours: int,
+    json_mode: bool,
+    output_format: str | None,
+) -> None:
+    """Show explainable neighboring or near-duplicate candidates."""
+    if not conversation_id and not (query and query.strip()):
+        fail("neighbors", "provide --id or --query")
+
+    try:
+        candidates = run_coroutine_sync(
+            env.operations.neighbor_candidates(
+                conversation_id=conversation_id,
+                query=query,
+                provider=provider,
+                limit=max(1, limit),
+                window_hours=max(1, window_hours),
+            )
+        )
+    except NeighborDiscoveryError as exc:
+        fail("neighbors", str(exc))
+
+    if json_mode or output_format == "json":
+        emit_success(
+            {
+                "neighbors": [
+                    model_json_document(
+                        ConversationNeighborCandidatePayload.from_candidate(candidate),
+                        exclude_none=True,
+                    )
+                    for candidate in candidates
+                ]
+            }
+        )
+        return
+
+    _render_plain(candidates)
+
+
+__all__ = ["neighbors_command"]

--- a/polylogue/lib/neighbor_candidates.py
+++ b/polylogue/lib/neighbor_candidates.py
@@ -1,0 +1,567 @@
+"""Explainable neighboring-conversation candidate discovery."""
+
+from __future__ import annotations
+
+import math
+import re
+from collections.abc import Iterable
+from dataclasses import dataclass, field, replace
+from datetime import datetime, timedelta
+from typing import TYPE_CHECKING
+
+from polylogue.storage.query_models import ConversationRecordQuery
+from polylogue.types import Provider
+
+if TYPE_CHECKING:
+    from polylogue.lib.conversation_models import Conversation, ConversationSummary
+    from polylogue.lib.search_hits import ConversationSearchHit
+    from polylogue.protocols import ConversationQueryRuntimeStore
+
+
+_TOKEN_RE = re.compile(r"[a-z0-9][a-z0-9_-]{2,}", re.IGNORECASE)
+_ATTACHMENT_IDENTITY_KEYS = frozenset(("provider_id", "id", "fileId", "driveId"))
+_STOPWORDS = frozenset(
+    {
+        "about",
+        "after",
+        "again",
+        "also",
+        "and",
+        "are",
+        "but",
+        "can",
+        "could",
+        "for",
+        "from",
+        "have",
+        "how",
+        "into",
+        "not",
+        "our",
+        "please",
+        "that",
+        "the",
+        "this",
+        "was",
+        "what",
+        "when",
+        "with",
+        "would",
+        "you",
+        "your",
+    }
+)
+
+
+class NeighborDiscoveryError(ValueError):
+    """Raised when a neighboring-candidate request cannot be executed."""
+
+
+@dataclass(frozen=True, slots=True)
+class NeighborReason:
+    """Evidence explaining why a conversation was suggested as a neighbor."""
+
+    kind: str
+    detail: str
+    evidence: str | None = None
+    weight: float = 0.0
+
+
+@dataclass(frozen=True, slots=True)
+class ConversationNeighborCandidate:
+    """Ranked neighboring-conversation candidate with explainable evidence."""
+
+    summary: ConversationSummary
+    rank: int
+    score: float
+    reasons: tuple[NeighborReason, ...]
+    source_conversation_id: str | None = None
+    query: str | None = None
+
+    @property
+    def conversation_id(self) -> str:
+        return str(self.summary.id)
+
+    def with_rank(self, rank: int) -> ConversationNeighborCandidate:
+        return replace(self, rank=rank)
+
+    def with_message_count(self, message_count: int | None) -> ConversationNeighborCandidate:
+        if message_count is None:
+            return self
+        summary = self.summary.model_copy(update={"message_count": message_count})
+        return replace(self, summary=summary)
+
+
+@dataclass(frozen=True, slots=True)
+class NeighborDiscoveryRequest:
+    """Request model for neighboring-conversation candidate discovery."""
+
+    conversation_id: str | None = None
+    query: str | None = None
+    provider: str | None = None
+    limit: int = 10
+    window_hours: int = 24
+    candidate_pool_limit: int = 100
+    similarity_threshold: float = 0.12
+
+
+@dataclass(slots=True)
+class _CandidateDraft:
+    summary: ConversationSummary
+    reasons: list[NeighborReason] = field(default_factory=list)
+    score: float = 0.0
+
+
+def _normalized_title(value: str | None) -> str:
+    if not value:
+        return ""
+    return " ".join(value.casefold().split())
+
+
+def _canonical_provider(value: str | None) -> str | None:
+    if value is None:
+        return None
+    return str(Provider.from_string(value))
+
+
+def _provider_list(value: str | None) -> list[str] | None:
+    provider = _canonical_provider(value)
+    return [provider] if provider else None
+
+
+def _source_timestamp(conversation: Conversation) -> datetime | None:
+    return conversation.updated_at or conversation.created_at
+
+
+def _summary_timestamp(summary: ConversationSummary) -> datetime | None:
+    return summary.updated_at or summary.created_at
+
+
+def _epoch(value: datetime | None) -> float:
+    if value is None:
+        return 0.0
+    return value.timestamp()
+
+
+def _format_hours(delta: timedelta) -> str:
+    hours = abs(delta.total_seconds()) / 3600
+    if hours < 1:
+        return f"{round(hours * 60)}m"
+    if hours < 24:
+        return f"{hours:.1f}h"
+    return f"{hours / 24:.1f}d"
+
+
+def _date_window(anchor: datetime, window_hours: int) -> tuple[str, str]:
+    window = timedelta(hours=max(0, window_hours))
+    return (anchor - window).isoformat(), (anchor + window).isoformat()
+
+
+def _tokens(text: str) -> set[str]:
+    return {token.casefold() for token in _TOKEN_RE.findall(text) if token.casefold() not in _STOPWORDS}
+
+
+def _ordered_tokens(text: str) -> tuple[str, ...]:
+    seen: set[str] = set()
+    tokens: list[str] = []
+    for raw_token in _TOKEN_RE.findall(text):
+        token = raw_token.casefold()
+        if token in seen or token in _STOPWORDS:
+            continue
+        seen.add(token)
+        tokens.append(token)
+    return tuple(tokens)
+
+
+def _conversation_text(conversation: Conversation) -> str:
+    return "\n".join(message.text for message in conversation.messages if message.text)
+
+
+def _source_search_seed(conversation: Conversation) -> str | None:
+    tokens = _ordered_tokens(_conversation_text(conversation))
+    if not tokens:
+        return None
+    selected = sorted(tokens, key=lambda token: (-len(token), token))[:2]
+    return " ".join(selected)
+
+
+def _summary_text(summary: ConversationSummary) -> str:
+    parts = [summary.display_title]
+    if summary.summary:
+        parts.append(summary.summary)
+    return "\n".join(parts)
+
+
+def _content_similarity(left: set[str], right: set[str]) -> float:
+    if not left or not right:
+        return 0.0
+    overlap = left & right
+    if not overlap:
+        return 0.0
+    return len(overlap) / math.sqrt(len(left) * len(right))
+
+
+def _shared_terms(left: set[str], right: set[str], *, limit: int = 6) -> tuple[str, ...]:
+    return tuple(sorted(left & right)[:limit])
+
+
+def _attachment_identities(conversation: Conversation) -> tuple[str, ...]:
+    identities: set[str] = set()
+    for message in conversation.messages:
+        for attachment in message.attachments:
+            if attachment.id:
+                identities.add(attachment.id)
+            for key, value in (attachment.provider_meta or {}).items():
+                if key not in _ATTACHMENT_IDENTITY_KEYS or value is None:
+                    continue
+                text = str(value).strip()
+                if text:
+                    identities.add(text)
+    return tuple(sorted(identities))
+
+
+def _add_candidate_reason(
+    drafts: dict[str, _CandidateDraft],
+    summary: ConversationSummary,
+    reason: NeighborReason,
+) -> None:
+    conversation_id = str(summary.id)
+    draft = drafts.get(conversation_id)
+    if draft is None:
+        draft = _CandidateDraft(summary=summary)
+        drafts[conversation_id] = draft
+    reason_key = (reason.kind, reason.detail, reason.evidence)
+    if not any((existing.kind, existing.detail, existing.evidence) == reason_key for existing in draft.reasons):
+        draft.reasons.append(reason)
+        draft.score += reason.weight
+
+
+def _non_source_summaries(
+    summaries: Iterable[ConversationSummary],
+    *,
+    source_id: str | None,
+) -> Iterable[ConversationSummary]:
+    for summary in summaries:
+        if source_id is not None and str(summary.id) == source_id:
+            continue
+        yield summary
+
+
+def _query_hits_reason(hit: ConversationSearchHit, query: str) -> NeighborReason:
+    surface = hit.match_surface.replace("_", " ")
+    detail = f"matches query via {surface}"
+    return NeighborReason(
+        kind="query_match",
+        detail=detail,
+        evidence=hit.snippet,
+        weight=2.0 if hit.score is None else max(0.5, min(3.0, float(hit.score))),
+    )
+
+
+async def _load_target(
+    store: ConversationQueryRuntimeStore,
+    conversation_id: str | None,
+) -> Conversation | None:
+    if conversation_id is None:
+        return None
+    resolved = await store.resolve_id(conversation_id)
+    target_id = str(resolved) if resolved is not None else conversation_id
+    target = await store.get(target_id)
+    if target is None:
+        raise NeighborDiscoveryError(f"Conversation not found: {conversation_id}")
+    return target
+
+
+async def _add_same_title_candidates(
+    drafts: dict[str, _CandidateDraft],
+    store: ConversationQueryRuntimeStore,
+    *,
+    target: Conversation,
+    provider: str | None,
+    source_id: str,
+    pool_limit: int,
+) -> None:
+    title = _normalized_title(target.display_title)
+    if not title:
+        return
+    summaries = await store.list_summaries_by_query(
+        ConversationRecordQuery(
+            provider=provider,
+            title_contains=target.display_title,
+            limit=pool_limit,
+        )
+    )
+    for summary in _non_source_summaries(summaries, source_id=source_id):
+        if _normalized_title(summary.display_title) != title:
+            continue
+        _add_candidate_reason(
+            drafts,
+            summary,
+            NeighborReason(
+                kind="same_title",
+                detail=f"same normalized title: {summary.display_title}",
+                weight=3.0,
+            ),
+        )
+
+
+async def _add_nearby_candidates(
+    drafts: dict[str, _CandidateDraft],
+    store: ConversationQueryRuntimeStore,
+    *,
+    target: Conversation,
+    provider: str | None,
+    source_id: str,
+    window_hours: int,
+    pool_limit: int,
+) -> None:
+    anchor = _source_timestamp(target)
+    if anchor is None:
+        return
+    since, until = _date_window(anchor, window_hours)
+    summaries = await store.list_summaries_by_query(
+        ConversationRecordQuery(
+            provider=provider,
+            since=since,
+            until=until,
+            limit=pool_limit,
+        )
+    )
+    window_seconds = max(1.0, float(max(1, window_hours) * 3600))
+    for summary in _non_source_summaries(summaries, source_id=source_id):
+        candidate_time = _summary_timestamp(summary)
+        if candidate_time is None:
+            continue
+        delta = abs((candidate_time - anchor).total_seconds())
+        closeness = max(0.1, 1.0 - (delta / window_seconds))
+        _add_candidate_reason(
+            drafts,
+            summary,
+            NeighborReason(
+                kind="nearby_time",
+                detail=f"within {_format_hours(candidate_time - anchor)} of source conversation",
+                evidence=f"source={anchor.isoformat()} candidate={candidate_time.isoformat()}",
+                weight=1.5 * closeness,
+            ),
+        )
+
+
+async def _add_query_candidates(
+    drafts: dict[str, _CandidateDraft],
+    store: ConversationQueryRuntimeStore,
+    *,
+    query: str | None,
+    providers: list[str] | None,
+    source_id: str | None,
+    pool_limit: int,
+) -> None:
+    if not query or not query.strip():
+        return
+    hits = await store.search_summary_hits(query.strip(), limit=pool_limit, providers=providers)
+    for hit in hits:
+        if source_id is not None and hit.conversation_id == source_id:
+            continue
+        _add_candidate_reason(drafts, hit.summary, _query_hits_reason(hit, query.strip()))
+
+
+async def _add_shared_attachment_candidates(
+    drafts: dict[str, _CandidateDraft],
+    store: ConversationQueryRuntimeStore,
+    *,
+    target: Conversation,
+    providers: list[str] | None,
+    source_id: str,
+    pool_limit: int,
+) -> None:
+    for identity in _attachment_identities(target):
+        hits = await store.search_summary_hits(identity, limit=pool_limit, providers=providers)
+        for hit in hits:
+            if hit.conversation_id == source_id:
+                continue
+            _add_candidate_reason(
+                drafts,
+                hit.summary,
+                NeighborReason(
+                    kind="shared_attachment_identity",
+                    detail=f"shares attachment identity: {identity}",
+                    evidence=hit.snippet,
+                    weight=4.0,
+                ),
+            )
+
+
+async def _add_source_content_search_candidates(
+    drafts: dict[str, _CandidateDraft],
+    store: ConversationQueryRuntimeStore,
+    *,
+    target: Conversation,
+    providers: list[str] | None,
+    source_id: str,
+    pool_limit: int,
+) -> None:
+    seed = _source_search_seed(target)
+    if seed is None:
+        return
+    hits = await store.search_summary_hits(seed, limit=pool_limit, providers=providers)
+    for hit in hits:
+        if hit.conversation_id == source_id:
+            continue
+        _add_candidate_reason(
+            drafts,
+            hit.summary,
+            NeighborReason(
+                kind="content_search",
+                detail=f"matches source content seed: {seed}",
+                evidence=hit.snippet,
+                weight=1.75,
+            ),
+        )
+
+
+async def _add_content_similarity_reasons(
+    drafts: dict[str, _CandidateDraft],
+    store: ConversationQueryRuntimeStore,
+    *,
+    target: Conversation | None,
+    query: str | None,
+    threshold: float,
+) -> None:
+    if not drafts:
+        return
+    target_tokens = _tokens(_conversation_text(target)) if target is not None else _tokens(query or "")
+    if not target_tokens:
+        return
+
+    for draft in drafts.values():
+        candidate = await store.get(str(draft.summary.id))
+        candidate_tokens = (
+            _tokens(_conversation_text(candidate)) if candidate is not None else _tokens(_summary_text(draft.summary))
+        )
+        similarity = _content_similarity(target_tokens, candidate_tokens)
+        if similarity < threshold:
+            continue
+        terms = _shared_terms(target_tokens, candidate_tokens)
+        detail = "shared content terms"
+        if terms:
+            detail = f"shared content terms: {', '.join(terms)}"
+        reason = NeighborReason(
+            kind="content_similarity",
+            detail=detail,
+            evidence=f"token_overlap={similarity:.3f}",
+            weight=3.0 * similarity,
+        )
+        _add_candidate_reason(drafts, draft.summary, reason)
+
+
+def _rank_candidates(
+    drafts: dict[str, _CandidateDraft],
+    *,
+    source_conversation_id: str | None,
+    query: str | None,
+    limit: int,
+) -> list[ConversationNeighborCandidate]:
+    candidates = [
+        ConversationNeighborCandidate(
+            summary=draft.summary,
+            rank=0,
+            score=round(draft.score, 6),
+            reasons=tuple(draft.reasons),
+            source_conversation_id=source_conversation_id,
+            query=query,
+        )
+        for draft in drafts.values()
+        if draft.reasons
+    ]
+    candidates.sort(
+        key=lambda candidate: (
+            -candidate.score,
+            -_epoch(_summary_timestamp(candidate.summary)),
+            candidate.summary.display_title.casefold(),
+            candidate.conversation_id,
+        )
+    )
+    return [candidate.with_rank(rank) for rank, candidate in enumerate(candidates[:limit], start=1)]
+
+
+async def discover_neighbor_candidates(
+    store: ConversationQueryRuntimeStore,
+    request: NeighborDiscoveryRequest,
+) -> list[ConversationNeighborCandidate]:
+    """Return ranked, explainable neighboring-conversation candidates."""
+    if request.limit <= 0:
+        return []
+    if not request.conversation_id and not (request.query and request.query.strip()):
+        raise NeighborDiscoveryError("Neighbor discovery requires a conversation id or query.")
+
+    target = await _load_target(store, request.conversation_id)
+    source_id = str(target.id) if target is not None else None
+    provider = _canonical_provider(request.provider) or (str(target.provider) if target is not None else None)
+    providers = _provider_list(provider)
+    pool_limit = max(request.candidate_pool_limit, request.limit)
+    drafts: dict[str, _CandidateDraft] = {}
+
+    if target is not None and source_id is not None:
+        await _add_same_title_candidates(
+            drafts,
+            store,
+            target=target,
+            provider=provider,
+            source_id=source_id,
+            pool_limit=pool_limit,
+        )
+        await _add_nearby_candidates(
+            drafts,
+            store,
+            target=target,
+            provider=provider,
+            source_id=source_id,
+            window_hours=request.window_hours,
+            pool_limit=pool_limit,
+        )
+        await _add_shared_attachment_candidates(
+            drafts,
+            store,
+            target=target,
+            providers=providers,
+            source_id=source_id,
+            pool_limit=pool_limit,
+        )
+        await _add_source_content_search_candidates(
+            drafts,
+            store,
+            target=target,
+            providers=providers,
+            source_id=source_id,
+            pool_limit=pool_limit,
+        )
+
+    await _add_query_candidates(
+        drafts,
+        store,
+        query=request.query,
+        providers=providers,
+        source_id=source_id,
+        pool_limit=pool_limit,
+    )
+    await _add_content_similarity_reasons(
+        drafts,
+        store,
+        target=target,
+        query=request.query,
+        threshold=request.similarity_threshold,
+    )
+    return _rank_candidates(
+        drafts,
+        source_conversation_id=source_id,
+        query=request.query.strip() if request.query else None,
+        limit=request.limit,
+    )
+
+
+__all__ = [
+    "ConversationNeighborCandidate",
+    "NeighborDiscoveryError",
+    "NeighborDiscoveryRequest",
+    "NeighborReason",
+    "discover_neighbor_candidates",
+]

--- a/polylogue/mcp/payloads.py
+++ b/polylogue/mcp/payloads.py
@@ -16,6 +16,9 @@ from polylogue.surface_payloads import (
     ConversationMessagePayload as MCPMessagePayload,
 )
 from polylogue.surface_payloads import (
+    ConversationNeighborCandidatePayload as MCPConversationNeighborCandidatePayload,
+)
+from polylogue.surface_payloads import (
     ConversationSearchHitPayload as MCPConversationSearchHitPayload,
 )
 from polylogue.surface_payloads import (
@@ -31,6 +34,7 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from polylogue.lib.models import Conversation
+    from polylogue.lib.neighbor_candidates import ConversationNeighborCandidate
     from polylogue.lib.query_miss_diagnostics import QueryMissDiagnostics, QueryMissReason
     from polylogue.lib.search_hits import ConversationSearchHit
     from polylogue.lib.stats import ArchiveStats
@@ -63,6 +67,10 @@ class MCPConversationSummaryListPayload(MCPRootPayload[list[MCPConversationSumma
 
 class MCPConversationSearchHitListPayload(MCPRootPayload[list[MCPConversationSearchHitPayload]]):
     root: list[MCPConversationSearchHitPayload]
+
+
+class MCPConversationNeighborCandidateListPayload(MCPRootPayload[list[MCPConversationNeighborCandidatePayload]]):
+    root: list[MCPConversationNeighborCandidatePayload]
 
 
 class MCPQueryMissReasonPayload(SurfacePayloadModel):
@@ -142,6 +150,14 @@ def conversation_search_hit_list_payload(
             )
             for hit in hits
         ]
+    )
+
+
+def conversation_neighbor_candidate_list_payload(
+    candidates: Sequence[ConversationNeighborCandidate],
+) -> MCPConversationNeighborCandidateListPayload:
+    return MCPConversationNeighborCandidateListPayload(
+        root=[MCPConversationNeighborCandidatePayload.from_candidate(candidate) for candidate in candidates]
     )
 
 
@@ -303,6 +319,8 @@ class MCPReadinessReportPayload(SurfacePayloadModel):
 __all__ = [
     "MCPArchiveStatsPayload",
     "MCPConversationDetailPayload",
+    "MCPConversationNeighborCandidateListPayload",
+    "MCPConversationNeighborCandidatePayload",
     "MCPConversationQueryNoResultsPayload",
     "MCPConversationSearchHitListPayload",
     "MCPConversationSearchHitPayload",
@@ -321,6 +339,7 @@ __all__ = [
     "MCPQueryMissReasonPayload",
     "MCPStatsByPayload",
     "MCPTagCountsPayload",
+    "conversation_neighbor_candidate_list_payload",
     "conversation_query_result_payload",
     "conversation_search_hit_list_payload",
     "conversation_search_result_payload",

--- a/polylogue/mcp/server_tools.py
+++ b/polylogue/mcp/server_tools.py
@@ -10,6 +10,7 @@ from polylogue.mcp.payloads import (
     MCPConversationSummaryPayload,
     MCPReadinessReportPayload,
     MCPStatsByPayload,
+    conversation_neighbor_candidate_list_payload,
     conversation_query_result_payload,
     conversation_search_result_payload,
     conversation_summary_list_payload,
@@ -129,6 +130,28 @@ def register_query_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
             return hooks.json_payload(MCPConversationDetailPayload.from_conversation(conv))
 
         return await hooks.async_safe_call("get_conversation", run)
+
+    @mcp.tool()
+    async def neighbor_candidates(
+        id: str | None = None,
+        query: str | None = None,
+        provider: str | None = None,
+        limit: int = 10,
+        window_hours: int = 24,
+    ) -> str:
+        async def run() -> str:
+            if not id and not (query and query.strip()):
+                return hooks.error_json("neighbor_candidates requires id or query")
+            candidates = await hooks.get_archive_ops().neighbor_candidates(
+                conversation_id=id,
+                query=query,
+                provider=provider,
+                limit=hooks.clamp_limit(limit),
+                window_hours=max(1, window_hours),
+            )
+            return hooks.json_payload(conversation_neighbor_candidate_list_payload(candidates), exclude_none=True)
+
+        return await hooks.async_safe_call("neighbor_candidates", run)
 
     @mcp.tool()
     async def stats() -> str:

--- a/polylogue/operations/archive.py
+++ b/polylogue/operations/archive.py
@@ -64,6 +64,7 @@ _PROFILE_FTS_STATUS_BY_TIER: dict[str, SessionProductReadyFlag] = {
 if TYPE_CHECKING:
     from polylogue.config import Config
     from polylogue.lib.conversation_models import Conversation
+    from polylogue.lib.neighbor_candidates import ConversationNeighborCandidate
     from polylogue.lib.query_miss_diagnostics import QueryMissDiagnostics
     from polylogue.lib.search_hits import ConversationSearchHit
     from polylogue.lib.stats import ArchiveStats as StorageArchiveStats
@@ -257,6 +258,32 @@ class ArchiveSearchMixin:
             return hits
         counts = await self.repository.get_message_counts_batch([hit.conversation_id for hit in hits])
         return [hit.with_message_count(counts.get(hit.conversation_id)) for hit in hits]
+
+    async def neighbor_candidates(
+        self,
+        *,
+        conversation_id: str | None = None,
+        query: str | None = None,
+        provider: str | None = None,
+        limit: int = 10,
+        window_hours: int = 24,
+    ) -> list[ConversationNeighborCandidate]:
+        from polylogue.lib.neighbor_candidates import NeighborDiscoveryRequest, discover_neighbor_candidates
+
+        candidates = await discover_neighbor_candidates(
+            self.repository,
+            NeighborDiscoveryRequest(
+                conversation_id=conversation_id,
+                query=query,
+                provider=provider,
+                limit=limit,
+                window_hours=window_hours,
+            ),
+        )
+        if not candidates:
+            return []
+        counts = await self.repository.get_message_counts_batch([candidate.conversation_id for candidate in candidates])
+        return [candidate.with_message_count(counts.get(candidate.conversation_id)) for candidate in candidates]
 
     async def diagnose_query_miss(self, spec: ConversationQuerySpec) -> QueryMissDiagnostics:
         from polylogue.lib.query_miss_diagnostics import diagnose_query_miss

--- a/polylogue/surface_payloads.py
+++ b/polylogue/surface_payloads.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
     from collections.abc import Container
 
     from polylogue.lib.models import Conversation, ConversationSummary, Message
+    from polylogue.lib.neighbor_candidates import ConversationNeighborCandidate, NeighborReason
     from polylogue.lib.search_hits import ConversationSearchHit
 
 
@@ -273,10 +274,58 @@ class ConversationSearchHitPayload(SurfacePayloadModel):
         )
 
 
+class ConversationNeighborReasonPayload(SurfacePayloadModel):
+    """Evidence explaining one neighboring-candidate reason."""
+
+    kind: str
+    detail: str
+    evidence: str | None = None
+    weight: float
+
+    @classmethod
+    def from_reason(cls, reason: NeighborReason) -> ConversationNeighborReasonPayload:
+        return cls(
+            kind=reason.kind,
+            detail=reason.detail,
+            evidence=reason.evidence,
+            weight=round(reason.weight, 6),
+        )
+
+
+class ConversationNeighborCandidatePayload(SurfacePayloadModel):
+    """Machine-readable neighboring-conversation candidate payload."""
+
+    conversation: ConversationSummaryPayload
+    rank: int
+    score: float
+    reasons: tuple[ConversationNeighborReasonPayload, ...]
+    source_conversation_id: str | None = None
+    query: str | None = None
+
+    @classmethod
+    def from_candidate(
+        cls,
+        candidate: ConversationNeighborCandidate,
+    ) -> ConversationNeighborCandidatePayload:
+        return cls(
+            conversation=ConversationSummaryPayload.from_summary(
+                candidate.summary,
+                message_count=candidate.summary.message_count,
+            ),
+            rank=candidate.rank,
+            score=candidate.score,
+            reasons=tuple(ConversationNeighborReasonPayload.from_reason(reason) for reason in candidate.reasons),
+            source_conversation_id=candidate.source_conversation_id,
+            query=candidate.query,
+        )
+
+
 __all__ = [
     "ConversationDetailPayload",
     "ConversationListRowPayload",
     "ConversationMessagePayload",
+    "ConversationNeighborCandidatePayload",
+    "ConversationNeighborReasonPayload",
     "ConversationSearchHitPayload",
     "ConversationSearchMatchPayload",
     "ConversationSummaryPayload",

--- a/tests/baselines/showcase/help-main.txt
+++ b/tests/baselines/showcase/help-main.txt
@@ -112,6 +112,7 @@ Commands:
   doctor       Health check with optional maintenance and cleanup previews.
   list         List matched conversations.
   mcp          Start the MCP server for AI assistant integration.
+  neighbors    Show explainable neighboring or near-duplicate candidates.
   open         Open matched conversation in browser/editor.
   products     Inspect durable archive data products.
   reset        Reset database, blob store, assets, rendered outputs, or...

--- a/tests/baselines/showcase/help-neighbors.txt
+++ b/tests/baselines/showcase/help-neighbors.txt
@@ -1,0 +1,13 @@
+Usage: polylogue neighbors [OPTIONS]
+
+  Show explainable neighboring or near-duplicate candidates.
+
+Options:
+  --id TEXT               Known conversation id or prefix
+  -q, --query TEXT        Fuzzy query to seed candidate discovery
+  -p, --provider TEXT     Limit candidate scope to one provider
+  -n, --limit INTEGER     Maximum candidates  [default: 10]
+  --window-hours INTEGER  Neighboring time window around --id  [default: 24]
+  --json                  Output as JSON
+  -f, --format [json]     Output format
+  -h, --help              Show this message and exit.

--- a/tests/infra/mcp.py
+++ b/tests/infra/mcp.py
@@ -16,6 +16,7 @@ EXPECTED_TOOL_NAMES = {
     "search",
     "list_conversations",
     "get_conversation",
+    "neighbor_candidates",
     "stats",
     "add_tag",
     "remove_tag",
@@ -156,6 +157,7 @@ def make_archive_ops_mock() -> MagicMock:
     operations.get_conversation_stats = AsyncMock(return_value={})
     operations.get_session_tree = AsyncMock(return_value=[])
     operations.get_stats_by = AsyncMock(return_value={})
+    operations.neighbor_candidates = AsyncMock(return_value=[])
     operations.storage_stats = AsyncMock(return_value=MagicMock())
     return operations
 

--- a/tests/unit/cli/__snapshots__/test_terminal_snapshots.ambr
+++ b/tests/unit/cli/__snapshots__/test_terminal_snapshots.ambr
@@ -205,6 +205,7 @@
     doctor       Health check with optional maintenance and cleanup previews.
     list         List matched conversations.
     mcp          Start the MCP server for AI assistant integration.
+    neighbors    Show explainable neighboring or near-duplicate candidates.
     open         Open matched conversation in browser<PATH>
     products     Inspect durable archive data products.
     reset        Reset database, blob store, assets, rendered outputs, or...
@@ -365,6 +366,8 @@
     list         List matched conversations.
     mcp          Start the MCP server for AI assistant integra
   tion.
+    neighbors    Show explainable neighboring or near-duplicat
+  e candidates.
     open         Open matched conversation in browser<PATH>
     products     Inspect durable archive data products.
     reset        Reset database, blob store, assets, rendered
@@ -484,6 +487,7 @@
     doctor       Health check with optional maintenance and cleanup previews.
     list         List matched conversations.
     mcp          Start the MCP server for AI assistant integration.
+    neighbors    Show explainable neighboring or near-duplicate candidates.
     open         Open matched conversation in browser<PATH>
     products     Inspect durable archive data products.
     reset        Reset database, blob store, assets, rendered outputs, or...

--- a/tests/unit/cli/test_click_app.py
+++ b/tests/unit/cli/test_click_app.py
@@ -448,6 +448,7 @@ class TestCliMetadata:
             "auth",
             "completions",
             "dashboard",
+            "neighbors",
             "products",
             "audit",
             "schema",

--- a/tests/unit/cli/test_neighbors_command.py
+++ b/tests/unit/cli/test_neighbors_command.py
@@ -1,0 +1,69 @@
+"""CLI tests for neighboring-conversation discovery."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+from click.testing import CliRunner
+
+from polylogue.cli.commands.neighbors import neighbors_command
+from polylogue.lib.models import ConversationSummary
+from polylogue.lib.neighbor_candidates import ConversationNeighborCandidate, NeighborReason
+from polylogue.types import ConversationId, Provider
+
+
+def _candidate() -> ConversationNeighborCandidate:
+    return ConversationNeighborCandidate(
+        summary=ConversationSummary(
+            id=ConversationId("candidate"),
+            provider=Provider.CODEX,
+            title="Archive Lock Retries",
+            updated_at=datetime(2026, 4, 22, 14, 0, tzinfo=timezone.utc),
+            message_count=2,
+        ),
+        rank=1,
+        score=3.25,
+        reasons=(
+            NeighborReason(
+                kind="same_title",
+                detail="same normalized title: Archive Lock Retries",
+                weight=3.0,
+            ),
+        ),
+        source_conversation_id="target",
+    )
+
+
+def test_neighbors_command_emits_json_payload(cli_runner: CliRunner) -> None:
+    env = MagicMock()
+    env.operations = MagicMock()
+    env.operations.neighbor_candidates = AsyncMock(return_value=[_candidate()])
+
+    result = cli_runner.invoke(
+        neighbors_command,
+        ["--id", "target", "--json"],
+        obj=env,
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    neighbor = payload["result"]["neighbors"][0]
+    assert neighbor["conversation"]["id"] == "candidate"
+    assert neighbor["reasons"][0]["kind"] == "same_title"
+    env.operations.neighbor_candidates.assert_called_once_with(
+        conversation_id="target",
+        query=None,
+        provider=None,
+        limit=10,
+        window_hours=24,
+    )
+
+
+def test_neighbors_command_requires_id_or_query(cli_runner: CliRunner) -> None:
+    result = cli_runner.invoke(neighbors_command, [], obj=MagicMock())
+
+    assert result.exit_code != 0
+    assert "provide --id or --query" in result.output

--- a/tests/unit/core/test_neighbor_candidates.py
+++ b/tests/unit/core/test_neighbor_candidates.py
@@ -1,0 +1,139 @@
+"""Neighboring-conversation candidate discovery tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from polylogue.lib.neighbor_candidates import NeighborDiscoveryRequest, discover_neighbor_candidates
+from polylogue.storage.backends.async_sqlite import SQLiteBackend
+from polylogue.storage.repository import ConversationRepository
+from tests.infra.storage_records import ConversationBuilder
+
+
+async def _discover(
+    db_path: Path,
+    request: NeighborDiscoveryRequest,
+) -> list[str]:
+    async with ConversationRepository(backend=SQLiteBackend(db_path=db_path)) as repo:
+        candidates = await discover_neighbor_candidates(repo, request)
+    return [candidate.conversation_id for candidate in candidates]
+
+
+@pytest.mark.asyncio
+async def test_same_title_different_body_is_explainable_candidate(db_path: Path) -> None:
+    (
+        ConversationBuilder(db_path, "target")
+        .provider("claude-ai")
+        .title("Vault Analysis")
+        .updated_at("2026-04-22T10:00:00+00:00")
+        .add_message("target-user", role="user", text="Map the archive verification roadmap.")
+        .save()
+    )
+    (
+        ConversationBuilder(db_path, "candidate")
+        .provider("claude-ai")
+        .title("Vault Analysis")
+        .updated_at("2026-04-20T10:00:00+00:00")
+        .add_message("candidate-user", role="user", text="Discuss unrelated dashboard styling decisions.")
+        .save()
+    )
+
+    async with ConversationRepository(backend=SQLiteBackend(db_path=db_path)) as repo:
+        candidates = await discover_neighbor_candidates(
+            repo,
+            NeighborDiscoveryRequest(conversation_id="target", window_hours=1),
+        )
+
+    assert [candidate.conversation_id for candidate in candidates] == ["candidate"]
+    assert {reason.kind for reason in candidates[0].reasons} == {"same_title"}
+    assert "same normalized title" in candidates[0].reasons[0].detail
+
+
+@pytest.mark.asyncio
+async def test_nearby_similar_content_gets_time_and_content_reasons(db_path: Path) -> None:
+    (
+        ConversationBuilder(db_path, "target")
+        .provider("codex")
+        .title("Checkpoint Failure")
+        .updated_at("2026-04-22T12:00:00+00:00")
+        .add_message("target-user", role="user", text="Debug sqlite checkpoint lock retry recovery in archive writes.")
+        .save()
+    )
+    (
+        ConversationBuilder(db_path, "candidate")
+        .provider("codex")
+        .title("Archive Lock Retries")
+        .updated_at("2026-04-22T14:00:00+00:00")
+        .add_message("candidate-user", role="user", text="Investigate sqlite checkpoint lock retry recovery behavior.")
+        .save()
+    )
+    (
+        ConversationBuilder(db_path, "distractor")
+        .provider("codex")
+        .title("Visual Cleanup")
+        .updated_at("2026-04-22T13:00:00+00:00")
+        .add_message("distractor-user", role="user", text="Adjust typography and color spacing.")
+        .save()
+    )
+
+    async with ConversationRepository(backend=SQLiteBackend(db_path=db_path)) as repo:
+        candidates = await discover_neighbor_candidates(
+            repo,
+            NeighborDiscoveryRequest(conversation_id="target", window_hours=6),
+        )
+
+    candidate = next(candidate for candidate in candidates if candidate.conversation_id == "candidate")
+    assert {"nearby_time", "content_similarity"} <= {reason.kind for reason in candidate.reasons}
+    assert candidate.rank == 1
+
+
+@pytest.mark.asyncio
+async def test_source_content_seed_finds_similar_candidate_outside_time_window(db_path: Path) -> None:
+    (
+        ConversationBuilder(db_path, "target")
+        .provider("codex")
+        .title("Checkpoint Failure")
+        .updated_at("2026-04-22T12:00:00+00:00")
+        .add_message("target-user", role="user", text="Debug sqlite checkpoint lock retry recovery in archive writes.")
+        .save()
+    )
+    (
+        ConversationBuilder(db_path, "candidate")
+        .provider("codex")
+        .title("Different Title")
+        .updated_at("2026-04-18T12:00:00+00:00")
+        .add_message("candidate-user", role="user", text="Investigate sqlite checkpoint lock retry recovery behavior.")
+        .save()
+    )
+
+    async with ConversationRepository(backend=SQLiteBackend(db_path=db_path)) as repo:
+        candidates = await discover_neighbor_candidates(
+            repo,
+            NeighborDiscoveryRequest(conversation_id="target", window_hours=1),
+        )
+
+    candidate = next(candidate for candidate in candidates if candidate.conversation_id == "candidate")
+    reason_kinds = {reason.kind for reason in candidate.reasons}
+    assert {"content_search", "content_similarity"} <= reason_kinds
+    assert "nearby_time" not in reason_kinds
+
+
+@pytest.mark.asyncio
+async def test_query_seed_returns_explainable_candidates(db_path: Path) -> None:
+    (
+        ConversationBuilder(db_path, "query-candidate")
+        .provider("chatgpt")
+        .title("Schema Audit")
+        .updated_at("2026-04-22T12:00:00+00:00")
+        .add_message("query-user", role="user", text="Run schema audit checks for provider annotations.")
+        .save()
+    )
+
+    ids = await _discover(
+        db_path,
+        NeighborDiscoveryRequest(query="schema audit", provider="chatgpt"),
+    )
+
+    assert ids == ["query-candidate"]

--- a/tests/unit/mcp/test_tool_contracts.py
+++ b/tests/unit/mcp/test_tool_contracts.py
@@ -35,6 +35,7 @@ from polylogue.archive_products import (
     WorkThreadProduct,
 )
 from polylogue.lib.models import Conversation, ConversationSummary
+from polylogue.lib.neighbor_candidates import ConversationNeighborCandidate, NeighborReason
 from polylogue.lib.query_miss_diagnostics import QueryMissDiagnostics, QueryMissReason
 from polylogue.lib.query_spec import ConversationQuerySpec
 from polylogue.lib.search_hits import ConversationSearchHit
@@ -262,6 +263,29 @@ def _make_attachment_search_hit(conversation: Conversation) -> ConversationSearc
     )
 
 
+def _make_neighbor_candidate() -> ConversationNeighborCandidate:
+    return ConversationNeighborCandidate(
+        summary=ConversationSummary(
+            id=ConversationId("candidate"),
+            provider=Provider.CODEX,
+            title="Archive Lock Retries",
+            message_count=2,
+            updated_at=datetime(2026, 4, 22, 14, 0, tzinfo=timezone.utc),
+        ),
+        rank=1,
+        score=3.25,
+        reasons=(
+            NeighborReason(
+                kind="nearby_time",
+                detail="within 2.0h of source conversation",
+                evidence="source=2026-04-22T12:00:00+00:00 candidate=2026-04-22T14:00:00+00:00",
+                weight=1.0,
+            ),
+        ),
+        source_conversation_id="target",
+    )
+
+
 def _provenance() -> ArchiveProductProvenance:
     return ArchiveProductProvenance(
         materializer_version=1,
@@ -432,6 +456,31 @@ class TestQueryTools:
         assert "provider_meta.fileId=drive-file-1" in payload[0]["match"]["snippet"]
         mock_ops.search_conversation_hits.assert_awaited_once()
         mock_ops.diagnose_query_miss.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_neighbor_candidates_exposes_candidate_reasons(self, mcp_server: MCPServerUnderTest) -> None:
+        with patch("polylogue.mcp.server._get_archive_ops") as mock_get_archive_ops:
+            mock_ops = MagicMock()
+            mock_ops.neighbor_candidates = AsyncMock(return_value=[_make_neighbor_candidate()])
+            mock_get_archive_ops.return_value = mock_ops
+
+            raw = await invoke_surface_async(
+                mcp_server._tool_manager._tools["neighbor_candidates"].fn,
+                id="target",
+                limit=3,
+            )
+
+        payload = json.loads(raw)
+        assert payload[0]["conversation"]["id"] == "candidate"
+        assert payload[0]["reasons"][0]["kind"] == "nearby_time"
+        assert payload[0]["source_conversation_id"] == "target"
+        mock_ops.neighbor_candidates.assert_awaited_once_with(
+            conversation_id="target",
+            query=None,
+            provider=None,
+            limit=3,
+            window_hours=24,
+        )
 
 
 class TestGetConversationTool:


### PR DESCRIPTION
## Summary

Adds explainable neighboring-conversation discovery for known conversation IDs and fuzzy query seeds. The new `polylogue neighbors` CLI command and `neighbor_candidates` MCP tool return ranked candidates with explicit reasons such as same title, nearby time, shared attachment identity, query match, source-content search, and body content similarity.

## Problem

Closes #220. Polylogue had canonical exact-ID retrieval and archival dedupe primitives, but users had no durable way to inspect nearby or near-duplicate candidates when several conversations looked plausible from title/date summaries alone. That pushed duplicate-like exploration into ad hoc search instead of an explainable retrieval surface.

## Solution

- Added `polylogue/lib/neighbor_candidates.py` as the shared selector and evidence model.
- Wired `ArchiveOperations.neighbor_candidates()` so surfaces share one substrate implementation.
- Added root CLI command `polylogue neighbors` with plain and JSON output.
- Added MCP tool `neighbor_candidates` plus shared CLI/MCP payload models.
- Updated generated CLI/proof/reference surfaces for the new command.
- Added tests for same-title-different-body candidates, nearby similar content, content-similar candidates outside the time window, query-seeded candidates, CLI JSON output, MCP payloads, command registration, and terminal help snapshots.
- Added committed showcase help baselines for the new command after remote `showcase-verify` exposed the missing baseline.

## Verification

```text
ruff check polylogue/lib/neighbor_candidates.py polylogue/operations/archive.py polylogue/surface_payloads.py polylogue/mcp/payloads.py polylogue/mcp/server_tools.py polylogue/cli/commands/neighbors.py polylogue/cli/click_command_registration.py tests/unit/core/test_neighbor_candidates.py tests/unit/cli/test_neighbors_command.py tests/unit/mcp/test_tool_contracts.py tests/infra/mcp.py
mypy polylogue/lib/neighbor_candidates.py polylogue/operations/archive.py polylogue/surface_payloads.py polylogue/mcp/payloads.py polylogue/mcp/server_tools.py polylogue/cli/commands/neighbors.py tests/unit/core/test_neighbor_candidates.py tests/unit/cli/test_neighbors_command.py tests/unit/mcp/test_tool_contracts.py tests/infra/mcp.py
pytest -q tests/unit/core/test_neighbor_candidates.py tests/unit/cli/test_neighbors_command.py tests/unit/mcp/test_tool_contracts.py
devtools render-all --check
pytest -q tests/unit/cli/test_click_app.py::TestCliMetadata::test_all_subcommands_registered tests/unit/cli/test_terminal_snapshots.py::TestHelpOutput::test_help_output_snapshot tests/unit/cli/test_terminal_snapshots.py::TestTerminalDimensions::test_help_at_narrow_width tests/unit/cli/test_terminal_snapshots.py::TestTerminalDimensions::test_help_at_wide_width
devtools verify
devtools verify-showcase
pytest -q --ignore=tests/integration
devtools verify --quick
```

`devtools verify` finished with `verify: all checks passed` before the showcase baseline follow-up. After refreshing baselines, `devtools verify-showcase` reported `All baselines match`, direct pytest reported `5108 passed in 173.83s`, and the pre-push hook ran `devtools verify --quick` with `verify: all checks passed`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `polylogue neighbors` command to discover and display conversations similar to a target or matching a query, with detailed explainable reasoning for candidate matches.

* **Documentation**
  * Updated documentation and CLI help to reflect the new neighbors command and its configuration options.

* **Tests**
  * Added test coverage for the new neighbors command and discovery functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->