### PR TITLE
refactor(cli): contract query and product outputs (#365)

### DIFF
--- a/polylogue/cli/query_output.py
+++ b/polylogue/cli/query_output.py
@@ -17,6 +17,7 @@ import click
 
 from polylogue.cli.query_contracts import QueryDeliveryTarget, QueryOutputSpec
 from polylogue.cli.query_feedback import emit_no_results
+from polylogue.cli.query_output_contracts import QueryOutputDocument, StructuredRowsDocument
 from polylogue.cli.query_semantic import (
     SemanticStatsSlice,
     action_matches_slice,
@@ -202,24 +203,23 @@ def render_conversation_rich(env: AppEnv, conv: Conversation) -> None:
 # ---------------------------------------------------------------------------
 
 
-def send_output(
+def deliver_query_output(
     env: AppEnv,
-    content: str,
-    destinations: list[str],
-    output_format: str,
-    conv: Conversation | None,
+    document: QueryOutputDocument,
 ) -> None:
-    for dest in destinations:
-        if dest == "stdout":
-            click.echo(content)
-        elif dest == "browser":
-            open_in_browser(env, content, output_format, conv)
-        elif dest == "clipboard":
-            copy_to_clipboard(env, content)
+    """Deliver a rendered query document to every requested destination."""
+    for destination in document.destinations:
+        if destination.kind == "stdout":
+            click.echo(document.content)
+        elif destination.kind == "browser":
+            _open_in_browser(env, document.content, document.output_format, document.conversation)
+        elif destination.kind == "clipboard":
+            _copy_to_clipboard(env, document.content)
         else:
-            path = Path(dest)
+            assert destination.path is not None
+            path = destination.path
             path.parent.mkdir(parents=True, exist_ok=True)
-            path.write_text(content, encoding="utf-8")
+            path.write_text(document.content, encoding="utf-8")
             env.ui.console.print(f"Wrote to {path}")
 
 
@@ -350,44 +350,24 @@ def format_summary_list(
 ) -> str:
     """Format summary-list output for deterministic machine/plain surfaces."""
     message_counts = message_counts or {}
-
-    selected = {field.strip() for field in fields.split(",")} if fields else None
-
-    data = [summary_to_dict(summary, message_counts.get(str(summary.id), 0)) for summary in summaries]
-    if selected:
-        data = [{key: value for key, value in item.items() if key in selected} for item in data]
-
-    if output_format == "json":
-        return json.dumps(data, indent=2)
-
-    if output_format == "yaml":
-        import yaml
-
-        return yaml.dump(data, default_flow_style=False, allow_unicode=True)
-
-    if output_format == "csv":
-        import csv
-        import io
-
-        buf = io.StringIO()
-        writer = csv.writer(buf)
-        writer.writerow(["id", "date", "provider", "title", "messages", "tags", "summary"])
-        for summary in summaries:
-            tags_str = ",".join(summary.tags) if summary.tags else ""
-            writer.writerow(
-                [
-                    str(summary.id),
-                    _display_date(summary.display_date),
-                    summary.provider,
-                    summary.display_title or "",
-                    message_counts.get(str(summary.id), 0),
-                    tags_str,
-                    summary.summary or "",
-                ]
+    document = StructuredRowsDocument(
+        rows=tuple(summary_to_dict(summary, message_counts.get(str(summary.id), 0)) for summary in summaries),
+        csv_headers=("id", "date", "provider", "title", "messages", "tags", "summary"),
+        csv_rows=tuple(
+            (
+                str(summary.id),
+                _display_date(summary.display_date),
+                summary.provider,
+                summary.display_title or "",
+                message_counts.get(str(summary.id), 0),
+                ",".join(summary.tags) if summary.tags else "",
+                summary.summary or "",
             )
-        return buf.getvalue().rstrip("\r\n")
-
-    return "\n".join(_summary_list_line(summary, message_counts.get(str(summary.id), 0)) for summary in summaries)
+            for summary in summaries
+        ),
+        text_lines=tuple(_summary_list_line(summary, message_counts.get(str(summary.id), 0)) for summary in summaries),
+    )
+    return document.with_selected_fields(fields).render(output_format)
 
 
 def _search_hit_to_payload(
@@ -410,67 +390,46 @@ def format_search_hit_list(
 ) -> str:
     """Format evidence-bearing search hits for deterministic surfaces."""
     message_counts = message_counts or {}
-    selected = {field.strip() for field in fields.split(",")} if fields else None
-
-    data = [
-        _search_hit_to_payload(
-            hit, message_count=message_counts.get(hit.conversation_id, hit.summary.message_count or 0)
-        )
-        for hit in hits
-    ]
-    if selected:
-        data = [{key: value for key, value in item.items() if key in selected} for item in data]
-
-    if output_format == "json":
-        return json.dumps(data, indent=2)
-
-    if output_format == "yaml":
-        import yaml
-
-        return yaml.dump(data, default_flow_style=False, allow_unicode=True)
-
-    if output_format == "csv":
-        import csv
-        import io
-
-        buf = io.StringIO()
-        writer = csv.writer(buf)
-        writer.writerow(
-            [
-                "id",
-                "date",
-                "provider",
-                "title",
-                "messages",
-                "rank",
-                "retrieval_lane",
-                "match_surface",
-                "message_id",
-                "snippet",
-            ]
-        )
-        for hit in hits:
-            summary = hit.summary
-            writer.writerow(
-                [
-                    str(summary.id),
-                    _display_date(summary.display_date),
-                    summary.provider,
-                    summary.display_title or "",
-                    message_counts.get(hit.conversation_id, summary.message_count or 0),
-                    hit.rank,
-                    hit.retrieval_lane,
-                    hit.match_surface,
-                    hit.message_id or "",
-                    hit.snippet or "",
-                ]
+    document = StructuredRowsDocument(
+        rows=tuple(
+            _search_hit_to_payload(
+                hit, message_count=message_counts.get(hit.conversation_id, hit.summary.message_count or 0)
             )
-        return buf.getvalue().rstrip("\r\n")
-
-    return "\n".join(
-        _search_hit_list_line(hit, message_counts.get(hit.conversation_id, hit.summary.message_count or 0))
-        for hit in hits
+            for hit in hits
+        ),
+        csv_headers=(
+            "id",
+            "date",
+            "provider",
+            "title",
+            "messages",
+            "rank",
+            "retrieval_lane",
+            "match_surface",
+            "message_id",
+            "snippet",
+        ),
+        csv_rows=tuple(
+            (
+                str(hit.summary.id),
+                _display_date(hit.summary.display_date),
+                hit.summary.provider,
+                hit.summary.display_title or "",
+                message_counts.get(hit.conversation_id, hit.summary.message_count or 0),
+                hit.rank,
+                hit.retrieval_lane,
+                hit.match_surface,
+                hit.message_id or "",
+                hit.snippet or "",
+            )
+            for hit in hits
+        ),
+        text_lines=tuple(
+            _search_hit_list_line(hit, message_counts.get(hit.conversation_id, hit.summary.message_count or 0))
+            for hit in hits
+        ),
     )
+    return document.with_selected_fields(fields).render(output_format)
 
 
 async def output_search_hits(
@@ -859,19 +818,15 @@ def _send_output(
     conv: Conversation | None,
 ) -> None:
     """Send output to specified destinations."""
-    for destination in destinations:
-        if destination.kind == "stdout":
-            click.echo(content)
-        elif destination.kind == "browser":
-            _open_in_browser(env, content, output_format, conv)
-        elif destination.kind == "clipboard":
-            _copy_to_clipboard(env, content)
-        else:
-            assert destination.path is not None
-            path = destination.path
-            path.parent.mkdir(parents=True, exist_ok=True)
-            path.write_text(content, encoding="utf-8")
-            env.ui.console.print(f"Wrote to {path}")
+    deliver_query_output(
+        env,
+        QueryOutputDocument(
+            content=content,
+            output_format=output_format,
+            destinations=tuple(destinations),
+            conversation=conv,
+        ),
+    )
 
 
 __all__ = [
@@ -879,6 +834,7 @@ __all__ = [
     "action_matches_slice",
     "conversations_to_csv",
     "copy_to_clipboard",
+    "deliver_query_output",
     "emit_structured_stats",
     "filtered_action_events",
     "format_list",
@@ -904,7 +860,6 @@ __all__ = [
     "render_stream_header",
     "render_stream_message",
     "render_stream_transcript",
-    "send_output",
     "stream_conversation",
     "summary_to_dict",
     "write_message_streaming",

--- a/polylogue/cli/query_output_contracts.py
+++ b/polylogue/cli/query_output_contracts.py
@@ -1,0 +1,82 @@
+"""Typed output documents for query CLI surfaces."""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from polylogue.cli.query_contracts import QueryDeliveryTarget, QueryOutputFormat
+from polylogue.lib.json import JSONDocument
+
+if TYPE_CHECKING:
+    from polylogue.lib.models import Conversation
+
+
+def _selected_field_names(fields: str | None) -> frozenset[str] | None:
+    if not fields:
+        return None
+    return frozenset(field.strip() for field in fields.split(",") if field.strip())
+
+
+def _selected_row(row: JSONDocument, selected: frozenset[str] | None) -> JSONDocument:
+    if selected is None:
+        return dict(row)
+    return {key: value for key, value in row.items() if key in selected}
+
+
+@dataclass(frozen=True, slots=True)
+class StructuredRowsDocument:
+    """Rows plus alternate renderers for deterministic query-list output."""
+
+    rows: tuple[JSONDocument, ...]
+    csv_headers: tuple[str, ...]
+    csv_rows: tuple[tuple[object, ...], ...]
+    text_lines: tuple[str, ...]
+
+    def with_selected_fields(self, fields: str | None) -> StructuredRowsDocument:
+        selected = _selected_field_names(fields)
+        if selected is None:
+            return self
+        return StructuredRowsDocument(
+            rows=tuple(_selected_row(row, selected) for row in self.rows),
+            csv_headers=self.csv_headers,
+            csv_rows=self.csv_rows,
+            text_lines=self.text_lines,
+        )
+
+    def render(self, output_format: QueryOutputFormat) -> str:
+        if output_format == "json":
+            return json.dumps(list(self.rows), indent=2)
+        if output_format == "yaml":
+            import yaml
+
+            return yaml.dump(list(self.rows), default_flow_style=False, allow_unicode=True)
+        if output_format == "csv":
+            return self._render_csv()
+        return "\n".join(self.text_lines)
+
+    def _render_csv(self) -> str:
+        buffer = io.StringIO()
+        writer = csv.writer(buffer)
+        writer.writerow(self.csv_headers)
+        writer.writerows(self.csv_rows)
+        return buffer.getvalue().rstrip("\r\n")
+
+
+@dataclass(frozen=True, slots=True)
+class QueryOutputDocument:
+    """Rendered content plus delivery contract for query output surfaces."""
+
+    content: str
+    output_format: QueryOutputFormat
+    destinations: tuple[QueryDeliveryTarget, ...]
+    conversation: Conversation | None = None
+
+
+__all__ = [
+    "QueryOutputDocument",
+    "StructuredRowsDocument",
+]

--- a/polylogue/mcp/server_product_tools.py
+++ b/polylogue/mcp/server_product_tools.py
@@ -15,6 +15,7 @@ from polylogue.products.registry import (
     PRODUCT_REGISTRY,
     ProductType,
     fetch_products_async,
+    product_items_payload,
 )
 
 if TYPE_CHECKING:
@@ -36,14 +37,7 @@ def _register_list_tool(
             ops = hooks.get_archive_ops()
             normalized_kwargs = spec.normalize_kwargs(hooks.clamp_limit, kwargs)
             products = await fetch_products_async(pt, ops, **normalized_kwargs)
-            return hooks.json_payload(
-                MCPRootPayload(
-                    root={
-                        "count": len(products),
-                        "items": [product.model_dump(mode="json") for product in products],
-                    }
-                )
-            )
+            return hooks.json_payload(MCPRootPayload(root=product_items_payload(products, pt, item_key="items")))
 
         return await hooks.async_safe_call(pt.name, run)
 

--- a/polylogue/products/registry.py
+++ b/polylogue/products/registry.py
@@ -88,6 +88,20 @@ def _model_payload(item: ArchiveProductModel) -> dict[str, object]:
     return item.model_dump(mode="json")
 
 
+def product_items_payload(
+    items: Sequence[ArchiveProductModel],
+    product_type: ProductType,
+    *,
+    item_key: str | None = None,
+) -> dict[str, object]:
+    """Return the shared machine payload for a product list surface."""
+
+    return {
+        "count": len(items),
+        item_key or product_type.json_key: [_model_payload(item) for item in items],
+    }
+
+
 def _stringify(value: object | None, default: str = "-") -> str:
     if value is None:
         return default
@@ -107,12 +121,7 @@ def render_product_items(
     if json_mode:
         from polylogue.cli.machine_errors import emit_success
 
-        emit_success(
-            {
-                "count": len(items),
-                product_type.json_key: [_model_payload(item) for item in items],
-            }
-        )
+        emit_success(product_items_payload(items, product_type))
         return
 
     if not items:
@@ -526,6 +535,7 @@ __all__ = [
     "fetch_products_async",
     "get_product_type",
     "list_product_types",
+    "product_items_payload",
     "register",
     "render_product_items",
 ]

--- a/tests/unit/cli/test_products.py
+++ b/tests/unit/cli/test_products.py
@@ -11,9 +11,10 @@ import click
 import pytest
 from click.testing import CliRunner, Result
 
+from polylogue.archive_products import ProviderAnalyticsProduct
 from polylogue.cli.click_app import cli
 from polylogue.cli.commands.products import _make_callback
-from polylogue.products.registry import get_product_type
+from polylogue.products.registry import get_product_type, product_items_payload
 from polylogue.storage.action_event_rebuild_runtime import rebuild_action_event_read_model_sync
 from polylogue.storage.backends.connection import open_connection
 from polylogue.storage.session_product_rebuild import rebuild_session_products_sync
@@ -64,6 +65,34 @@ def _extract_json(output: str) -> JsonObject:
 
 def _exception_message(result: Result) -> str:
     return str(result.exception) if result.exception is not None else result.output.strip()
+
+
+def test_product_items_payload_can_render_cli_and_mcp_keys() -> None:
+    product = ProviderAnalyticsProduct(
+        provider_name="claude-code",
+        conversation_count=1,
+        message_count=2,
+        user_message_count=1,
+        assistant_message_count=1,
+        avg_messages_per_conversation=2.0,
+        avg_user_words=3.0,
+        avg_assistant_words=4.0,
+        tool_use_count=1,
+        thinking_count=0,
+        total_conversations_with_tools=1,
+        total_conversations_with_thinking=0,
+        tool_use_percentage=100.0,
+        thinking_percentage=0.0,
+    )
+    product_type = get_product_type("provider_analytics")
+
+    cli_payload = product_items_payload([product], product_type)
+    mcp_payload = product_items_payload([product], product_type, item_key="items")
+
+    assert cli_payload["count"] == 1
+    assert _expect_object_list(cli_payload["provider_analytics"])[0]["product_kind"] == "provider_analytics"
+    assert mcp_payload["count"] == 1
+    assert _expect_object_list(mcp_payload["items"])[0]["provider_name"] == "claude-code"
 
 
 def _seed_products(cli_workspace: CliWorkspace) -> None:

--- a/tests/unit/cli/test_query_fmt.py
+++ b/tests/unit/cli/test_query_fmt.py
@@ -34,6 +34,7 @@ from polylogue.cli.query_output import (
     format_summary_list,
     render_stream_transcript,
 )
+from polylogue.cli.query_output_contracts import StructuredRowsDocument
 from polylogue.lib.attachment_models import Attachment
 from polylogue.lib.messages import MessageCollection
 from polylogue.lib.models import Conversation, ConversationSummary, Message
@@ -429,6 +430,26 @@ class TestConversationFormatting:
 
 
 class TestListFormatting:
+    def test_structured_rows_document_centralizes_machine_and_plain_rendering(self) -> None:
+        document = StructuredRowsDocument(
+            rows=(
+                {
+                    "id": "conv-a",
+                    "provider": "claude-ai",
+                    "title": "A",
+                    "messages": 2,
+                },
+            ),
+            csv_headers=("id", "provider", "title", "messages"),
+            csv_rows=(("conv-a", "claude-ai", "A", 2),),
+            text_lines=("conv-a  claude-ai  A (2 msgs)",),
+        )
+
+        assert json.loads(document.with_selected_fields("id,title").render("json")) == [{"id": "conv-a", "title": "A"}]
+        assert yaml.safe_load(document.render("yaml"))[0]["provider"] == "claude-ai"
+        assert document.render("csv").splitlines()[0] == "id,provider,title,messages"
+        assert document.render("text") == "conv-a  claude-ai  A (2 msgs)"
+
     @pytest.mark.parametrize("case", LIST_FORMAT_CASES, ids=lambda case: case.name)
     def test_format_list_contract_matrix(self, sample_conversation: Conversation, case: ListFormatCase) -> None:
         other = _make_conv(


### PR DESCRIPTION
## Summary

Adds typed query output documents for list-style CLI surfaces, routes query output delivery through an explicit delivery contract, and centralizes archive-product list payload construction so CLI and MCP product tools share the same model-dump semantics.

## Problem

Issue #273 tracks contraction of user-facing surfaces over the renewed substrate. The remaining high-value duplication was concentrated in query list output and archive-product listing: summary/search-hit formatters each rebuilt JSON/YAML/CSV/plain rows independently, destination dispatch still accepted loose content arguments, and CLI/MCP product list payloads each rebuilt their own count/items dictionaries.

The named UI/rendering anchors already consume explicit rendering models (`RenderableBlock`, `RenderedMessage`) from the previous renewal work, so this PR keeps the change focused on the places where substrate-shaped glue was still active.

## Solution

- Added `polylogue/cli/query_output_contracts.py` with `StructuredRowsDocument` and `QueryOutputDocument`.
- Reworked `format_summary_list` and `format_search_hit_list` to render through `StructuredRowsDocument` instead of duplicating machine/plain branches.
- Replaced loose query delivery internals with `deliver_query_output(env, QueryOutputDocument)` while preserving the existing `_send_output` test seam.
- Added `product_items_payload()` to `polylogue/products/registry.py` and reused it from both CLI JSON rendering and MCP product list tools.
- Added targeted tests covering the shared row-rendering contract and shared product payload shape.

Closes #273.

## Verification

- `ruff format polylogue/cli/query_output_contracts.py polylogue/cli/query_output.py polylogue/products/registry.py polylogue/mcp/server_product_tools.py tests/unit/cli/test_query_fmt.py tests/unit/cli/test_products.py`
- `ruff check polylogue/cli/query_output_contracts.py polylogue/cli/query_output.py polylogue/products/registry.py polylogue/mcp/server_product_tools.py tests/unit/cli/test_query_fmt.py tests/unit/cli/test_products.py`
- `mypy polylogue/cli/query_output_contracts.py polylogue/cli/query_output.py polylogue/products/registry.py polylogue/mcp/server_product_tools.py tests/unit/cli/test_query_fmt.py tests/unit/cli/test_products.py`
- `pytest -q tests/unit/cli/test_query_fmt.py tests/unit/cli/test_query_exec_laws.py tests/unit/cli/test_products.py tests/unit/mcp/test_tool_contracts.py` -> `216 passed in 18.43s`
- `devtools verify` -> `verify: all checks passed`
- `git push -u origin feature/refactor/surface-contracts` pre-push hook ran `devtools verify --quick` -> `verify: all checks passed`