### PR TITLE
refactor(test): centralize JSON verification helpers (#366)

### DIFF
--- a/devtools/render_quality_reference.py
+++ b/devtools/render_quality_reference.py
@@ -157,6 +157,23 @@ def _render_runtime_coverage_section(coverage: RuntimeScenarioCoverage) -> list[
     ]
 
 
+def _render_test_infrastructure_section() -> list[str]:
+    return [
+        "## Test Infrastructure Contracts",
+        "",
+        "Shared helpers under `tests/infra/` are verification substrate. Prefer these contracts over",
+        "per-suite JSON parsing, surface invocation, archive seeding, or cross-surface oracle helpers.",
+        "",
+        "| Helper | Contract | Primary consumers |",
+        "| --- | --- | --- |",
+        "| `tests/infra/json_contracts.py` | Typed JSON object/envelope/result narrowing for machine surfaces | CLI, MCP, product, and devtools JSON tests |",
+        "| `tests/infra/mcp.py` | MCP surface registration, invocation, and mock archive seams | MCP server and tool-contract tests |",
+        "| `tests/infra/storage_records.py` | Durable archive row builders and DB factories | Storage, CLI, product, and health tests |",
+        "| `tests/infra/surfaces.py` | Cross-surface archive adapters over SQLite, repository, and facade projections | Scenario/oracle tests |",
+        "",
+    ]
+
+
 def _render_scenario_projection_snapshot(registry: QualityRegistry) -> list[str]:
     projection_counts: dict[str, int] = {}
     for entry in registry.scenario_projections:
@@ -210,6 +227,7 @@ def build_document(registry: QualityRegistry, *, runtime_coverage: RuntimeScenar
         'pytest -q -n 0 -m "not slow and not benchmark"',
         "```",
         "",
+        *_render_test_infrastructure_section(),
         "### Validation lanes",
         "",
         "```bash",

--- a/docs/test-quality-workflows.md
+++ b/docs/test-quality-workflows.md
@@ -63,6 +63,18 @@ Use this when iterating locally and skipping slow checks and benchmarks.
 pytest -q -n 0 -m "not slow and not benchmark"
 ```
 
+## Test Infrastructure Contracts
+
+Shared helpers under `tests/infra/` are verification substrate. Prefer these contracts over
+per-suite JSON parsing, surface invocation, archive seeding, or cross-surface oracle helpers.
+
+| Helper | Contract | Primary consumers |
+| --- | --- | --- |
+| `tests/infra/json_contracts.py` | Typed JSON object/envelope/result narrowing for machine surfaces | CLI, MCP, product, and devtools JSON tests |
+| `tests/infra/mcp.py` | MCP surface registration, invocation, and mock archive seams | MCP server and tool-contract tests |
+| `tests/infra/storage_records.py` | Durable archive row builders and DB factories | Storage, CLI, product, and health tests |
+| `tests/infra/surfaces.py` | Cross-surface archive adapters over SQLite, repository, and facade projections | Scenario/oracle tests |
+
 ### Validation lanes
 
 ```bash

--- a/tests/infra/json_contracts.py
+++ b/tests/infra/json_contracts.py
@@ -1,0 +1,110 @@
+"""Shared JSON assertion contracts for CLI, MCP, and devtools tests."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from polylogue.lib.json import JSONDocument, JSONValue, loads, require_json_document, require_json_value
+
+JSONArray = list[JSONValue]
+
+
+def json_object(value: object, *, context: str = "JSON object") -> JSONDocument:
+    """Return a JSON object or fail with test-oriented context."""
+    try:
+        return require_json_document(value, context=context)
+    except TypeError as exc:
+        raise AssertionError(str(exc)) from exc
+
+
+def json_array(value: object, *, context: str = "JSON array") -> JSONArray:
+    """Return a JSON array whose members satisfy the JSONValue contract."""
+    if not isinstance(value, list):
+        raise AssertionError(f"{context} is not a JSON array")
+    return [require_json_value(item, context=f"{context}[{index}]") for index, item in enumerate(value)]
+
+
+def json_object_list(value: object, *, context: str = "JSON object list") -> list[JSONDocument]:
+    """Return a JSON array narrowed to object entries."""
+    return [
+        json_object(item, context=f"{context}[{index}]")
+        for index, item in enumerate(json_array(value, context=context))
+    ]
+
+
+def json_bool(value: object, *, context: str = "JSON boolean") -> bool:
+    if not isinstance(value, bool):
+        raise AssertionError(f"{context} is not a JSON boolean")
+    return value
+
+
+def json_int(value: object, *, context: str = "JSON integer") -> int:
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise AssertionError(f"{context} is not a JSON integer")
+    return value
+
+
+def json_number(value: object, *, context: str = "JSON number") -> float:
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        raise AssertionError(f"{context} is not a JSON number")
+    return float(value)
+
+
+def json_object_field(payload: JSONDocument, key: str, *, context: str = "JSON object") -> JSONDocument:
+    return json_object(payload.get(key), context=f"{context}.{key}")
+
+
+def json_array_field(payload: JSONDocument, key: str, *, context: str = "JSON object") -> JSONArray:
+    return json_array(payload.get(key), context=f"{context}.{key}")
+
+
+def json_array_item(items: Sequence[JSONValue], index: int, *, context: str = "JSON array") -> JSONDocument:
+    return json_object(items[index], context=f"{context}[{index}]")
+
+
+def parse_json_object(text: str, *, context: str = "JSON text") -> JSONDocument:
+    return json_object(loads(text), context=context)
+
+
+def extract_json_object(output: str, *, context: str = "CLI output") -> JSONDocument:
+    """Extract the first JSON object from output that may include banners/logs."""
+    lines = output.strip().splitlines()
+    for index, line in enumerate(lines):
+        if line.strip().startswith("{"):
+            return parse_json_object("\n".join(lines[index:]), context=context)
+    raise AssertionError(f"No JSON object found in {context}:\n{output}")
+
+
+def envelope_result(payload: JSONDocument, *, context: str = "JSON envelope") -> JSONDocument:
+    if "result" not in payload:
+        raise AssertionError(f"{context} is missing result")
+    return json_object(payload["result"], context=f"{context}.result")
+
+
+def unwrap_success_result(payload: JSONDocument, *, context: str = "JSON envelope") -> JSONDocument:
+    if payload.get("status") == "ok" and "result" in payload:
+        return envelope_result(payload, context=context)
+    return payload
+
+
+def extract_json_result(output: str, *, context: str = "CLI output") -> JSONDocument:
+    return unwrap_success_result(extract_json_object(output, context=context), context=context)
+
+
+__all__ = [
+    "JSONArray",
+    "envelope_result",
+    "extract_json_object",
+    "extract_json_result",
+    "json_array",
+    "json_array_field",
+    "json_array_item",
+    "json_bool",
+    "json_int",
+    "json_number",
+    "json_object",
+    "json_object_field",
+    "json_object_list",
+    "parse_json_object",
+    "unwrap_success_result",
+]

--- a/tests/infra/test_json_contracts.py
+++ b/tests/infra/test_json_contracts.py
@@ -1,0 +1,39 @@
+"""Tests for shared JSON assertion contracts."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.infra.json_contracts import (
+    extract_json_object,
+    extract_json_result,
+    json_array_field,
+    json_int,
+    json_object_list,
+    parse_json_object,
+)
+
+
+def test_extract_json_object_skips_banner_lines() -> None:
+    payload = extract_json_object('banner\n{"status":"ok","result":{"count":2}}\n', context="sample")
+
+    assert payload["status"] == "ok"
+    assert parse_json_object('{"value": 1}')["value"] == 1
+
+
+def test_extract_json_result_unwraps_success_envelope() -> None:
+    payload = extract_json_result('debug\n{"status":"ok","result":{"count":2}}\n')
+
+    assert payload == {"count": 2}
+
+
+def test_json_object_list_and_numeric_contracts() -> None:
+    payload = parse_json_object('{"rows":[{"count":2},{"count":3}]}')
+    rows = json_object_list(json_array_field(payload, "rows"))
+
+    assert [json_int(row["count"]) for row in rows] == [2, 3]
+
+
+def test_parse_json_object_rejects_arrays() -> None:
+    with pytest.raises(AssertionError, match="not a JSON object"):
+        parse_json_object("[1, 2, 3]", context="array")

--- a/tests/unit/cli/test_check.py
+++ b/tests/unit/cli/test_check.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import ANY, patch
@@ -13,7 +12,7 @@ from click.testing import CliRunner
 from polylogue.cli import cli
 from polylogue.cli.check_workflow import CheckCommandOptions, run_check_workflow
 from polylogue.cli.types import AppEnv
-from polylogue.lib.raw_payload_decode import JSONValue
+from polylogue.lib.json import JSONDocument
 from polylogue.readiness import ReadinessCheck, ReadinessReport, VerifyStatus
 from polylogue.schemas.operator_models import (
     ArtifactCohortListResult,
@@ -31,11 +30,17 @@ from polylogue.storage.backends.connection import open_connection
 from polylogue.storage.store import ArtifactObservationRecord
 from polylogue.types import ArtifactSupportStatus, Provider
 from polylogue.ui import create_ui
+from tests.infra.json_contracts import (
+    extract_json_result,
+    json_array_field,
+    json_array_item,
+    json_object,
+    json_object_field,
+    parse_json_object,
+)
 from tests.infra.storage_records import ConversationBuilder, DbFactory
 
 WorkspacePaths = dict[str, Path]
-JsonObject = dict[str, JSONValue]
-JsonArray = list[JSONValue]
 
 
 @pytest.fixture
@@ -44,36 +49,10 @@ def cli_runner() -> CliRunner:
     return CliRunner()
 
 
-def _require_json_object(value: object, *, context: str) -> JsonObject:
-    if not isinstance(value, dict):
-        raise ValueError(f"Expected {context} object, got {type(value).__name__}")
-    if not all(isinstance(key, str) for key in value):
-        raise ValueError(f"Expected {context} keys to be strings")
-    return {str(key): item for key, item in value.items()}
-
-
-def _require_json_array(value: object, *, context: str) -> JsonArray:
-    if not isinstance(value, list):
-        raise ValueError(f"Expected {context} array, got {type(value).__name__}")
-    return list(value)
-
-
-def _json_object_field(payload: JsonObject, key: str, *, context: str) -> JsonObject:
-    return _require_json_object(payload.get(key), context=f"{context}.{key}")
-
-
-def _json_array_field(payload: JsonObject, key: str, *, context: str) -> JsonArray:
-    return _require_json_array(payload.get(key), context=f"{context}.{key}")
-
-
-def _json_array_item(items: JsonArray, index: int, *, context: str) -> JsonObject:
-    return _require_json_object(items[index], context=f"{context}[{index}]")
-
-
-def _find_named_check(payload: JsonObject, name: str) -> JsonObject:
-    checks = _json_array_field(payload, "checks", context="check payload")
+def _find_named_check(payload: JSONDocument, name: str) -> JSONDocument:
+    checks = json_array_field(payload, "checks", context="check payload")
     for check in checks:
-        check_payload = _require_json_object(check, context=f"check {name}")
+        check_payload = json_object(check, context=f"check {name}")
         if check_payload.get("name") == name:
             return check_payload
     raise AssertionError(f"Missing check named {name}")
@@ -112,20 +91,9 @@ def _insert_raw_blob(
     return raw_id
 
 
-def _extract_json(output: str) -> JsonObject:
+def _extract_json(output: str) -> JSONDocument:
     """Extract JSON from CLI output, unwrapping the success envelope."""
-    lines = output.strip().split("\n")
-    # Find first line that starts with { and join all subsequent lines
-    json_start = next((i for i, line in enumerate(lines) if line.strip().startswith("{")), None)
-    if json_start is None:
-        raise ValueError(f"No JSON found in output: {output}")
-    json_str = "\n".join(lines[json_start:])
-    data = json.loads(json_str)
-    data_object = _require_json_object(data, context="JSON")
-    # Unwrap success envelope
-    if data_object.get("status") == "ok" and "result" in data_object:
-        return _require_json_object(data_object["result"], context="result")
-    return data_object
+    return extract_json_result(output, context="doctor output")
 
 
 class TestReadinessReportConstruction:
@@ -210,10 +178,10 @@ def test_check_records_scoped_maintenance_preview(cli_workspace: WorkspacePaths,
 
     assert result.exit_code == 0
     payload = _extract_json(result.output)
-    maintenance = _json_object_field(payload, "maintenance", context="check payload")
+    maintenance = json_object_field(payload, "maintenance", context="check payload")
     assert maintenance.get("targets") == ["session_products"]
-    maintenance_item = _json_array_item(
-        _json_array_field(maintenance, "items", context="maintenance"), 0, context="maintenance.items"
+    maintenance_item = json_array_item(
+        json_array_field(maintenance, "items", context="maintenance"), 0, context="maintenance.items"
     )
     assert maintenance_item.get("name") == "session_products"
     assert maintenance_item.get("repaired_count") == 1
@@ -250,10 +218,10 @@ def test_check_records_scoped_maintenance_apply(cli_workspace: WorkspacePaths, c
 
     assert result.exit_code == 0
     payload = _extract_json(result.output)
-    maintenance = _json_object_field(payload, "maintenance", context="check payload")
+    maintenance = json_object_field(payload, "maintenance", context="check payload")
     assert maintenance.get("targets") == ["session_products"]
-    maintenance_item = _json_array_item(
-        _json_array_field(maintenance, "items", context="maintenance"), 0, context="maintenance.items"
+    maintenance_item = json_array_item(
+        json_array_field(maintenance, "items", context="maintenance"), 0, context="maintenance.items"
     )
     assert maintenance_item.get("name") == "session_products"
     assert maintenance_item.get("success") is True
@@ -389,8 +357,8 @@ class TestCheckCommand:
         data = _extract_json(result.output)
         assert "checks" in data
         assert "summary" in data
-        checks = _json_array_field(data, "checks", context="check payload")
-        summary = _json_object_field(data, "summary", context="check payload")
+        checks = json_array_field(data, "checks", context="check payload")
+        summary = json_object_field(data, "summary", context="check payload")
         assert isinstance(checks, list)
         assert isinstance(summary, dict)
 
@@ -477,7 +445,7 @@ class TestCheckCommand:
         assert orphan_check["count"] == 1
 
         # Summary should show at least one error
-        summary = _json_object_field(data, "summary", context="check payload")
+        summary = json_object_field(data, "summary", context="check payload")
         assert summary.get("error") == 1
 
     def test_check_verbose_output(self, db_path: Path, cli_runner: CliRunner) -> None:
@@ -711,8 +679,11 @@ class TestCheckCommandSupplementary:
         runner = CliRunner()
         result = runner.invoke(cli, ["doctor", "--json", "--repair", "--preview"])
         assert result.exit_code == 0
-        envelope = json.loads(result.output.split("\n", 1)[-1] if "Plain" in result.output else result.output)
-        data = _require_json_object(envelope.get("result", envelope), context="repair preview payload")
+        envelope = parse_json_object(
+            result.output.split("\n", 1)[-1] if "Plain" in result.output else result.output,
+            context="repair preview envelope",
+        )
+        data = json_object(envelope.get("result", envelope), context="repair preview payload")
         assert "maintenance" in data
 
     def test_repair_with_no_issues_shows_message(self, cli_workspace: WorkspacePaths) -> None:
@@ -751,10 +722,10 @@ class TestCheckCommandSupplementary:
         result = runner.invoke(cli, ["--plain", "doctor", "--json", "--repair", "--preview", "--vacuum"])
 
         assert result.exit_code == 0
-        envelope = json.loads(result.output)
-        data = _require_json_object(envelope.get("result", envelope), context="repair vacuum payload")
+        envelope = parse_json_object(result.output, context="repair vacuum envelope")
+        data = json_object(envelope.get("result", envelope), context="repair vacuum payload")
         assert "maintenance" in data
-        vacuum = _json_object_field(data, "vacuum", context="repair vacuum payload")
+        vacuum = json_object_field(data, "vacuum", context="repair vacuum payload")
         assert vacuum.get("ok") is True
         assert vacuum.get("preview") is True
 
@@ -786,7 +757,7 @@ class TestCheckCommandSupplementary:
         assert result.exit_code == 0
         data = _extract_json(result.output)
         assert "schema_verification" in data
-        schema_verification = _json_object_field(data, "schema_verification", context="schema verification payload")
+        schema_verification = json_object_field(data, "schema_verification", context="schema verification payload")
         assert schema_verification.get("total_records") == 3
         assert schema_verification.get("max_samples") == "all"
         assert schema_verification.get("record_limit") == "all"
@@ -958,8 +929,8 @@ class TestCheckCommandSupplementary:
         assert result.exit_code == 0
         data = _extract_json(result.output)
         assert "artifact_proof" in data
-        artifact_proof = _json_object_field(data, "artifact_proof", context="artifact proof payload")
-        artifact_summary = _json_object_field(artifact_proof, "summary", context="artifact proof payload")
+        artifact_proof = json_object_field(data, "artifact_proof", context="artifact proof payload")
+        artifact_summary = json_object_field(artifact_proof, "summary", context="artifact proof payload")
         assert artifact_proof.get("total_records") == 2
         assert artifact_summary.get("linked_sidecars") == 1
         assert artifact_summary.get("unsupported_parseable_records") == 1
@@ -1094,12 +1065,12 @@ class TestCheckCommandSupplementary:
 
         assert result.exit_code == 0
         data = _extract_json(result.output)
-        artifact_observations = _json_object_field(
+        artifact_observations = json_object_field(
             data, "artifact_observations", context="artifact observations payload"
         )
         assert artifact_observations.get("count") == 1
-        observation = _json_array_item(
-            _json_array_field(artifact_observations, "items", context="artifact observations payload"),
+        observation = json_array_item(
+            json_array_field(artifact_observations, "items", context="artifact observations payload"),
             0,
             context="artifact_observations.items",
         )

--- a/tests/unit/cli/test_click_app_main.py
+++ b/tests/unit/cli/test_click_app_main.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import sys
 from unittest.mock import patch
 
@@ -10,6 +9,8 @@ import click
 import pytest
 
 from polylogue.cli.click_app import main
+from polylogue.lib.json import JSONDocument
+from tests.infra.json_contracts import parse_json_object
 
 pytestmark = pytest.mark.machine_contract
 
@@ -22,24 +23,18 @@ def _system_exit_code(code: str | int | None) -> int:
     return 1
 
 
-def _json_object(payload: str) -> dict[str, object]:
-    value = json.loads(payload)
-    assert isinstance(value, dict)
-    return {str(key): item for key, item in value.items()}
-
-
 def _run_main_with_error(
     monkeypatch: pytest.MonkeyPatch,
     argv: list[str],
     exc: BaseException,
     capsys: pytest.CaptureFixture[str],
-) -> tuple[int, dict[str, object]]:
+) -> tuple[int, JSONDocument]:
     monkeypatch.setattr(sys, "argv", ["polylogue", *argv])
     with patch("polylogue.cli.click_app.cli", side_effect=exc):
         with pytest.raises(SystemExit) as exit_info:
             main()
     captured = capsys.readouterr()
-    return _system_exit_code(exit_info.value.code), _json_object(captured.out)
+    return _system_exit_code(exit_info.value.code), parse_json_object(captured.out, context="main stdout")
 
 
 def test_main_wraps_usage_error_as_json(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/unit/cli/test_deterministic_output.py
+++ b/tests/unit/cli/test_deterministic_output.py
@@ -16,13 +16,13 @@ import sys
 from datetime import datetime, timezone
 from io import StringIO
 from pathlib import Path
-from typing import TypeAlias
 from unittest.mock import MagicMock, patch
 
 import pytest
 from click.testing import CliRunner
 
 from polylogue.cli.click_app import cli
+from polylogue.lib.json import JSONDocument
 from polylogue.lib.outcomes import OutcomeCheck, OutcomeStatus
 from polylogue.proof.catalog import build_verification_catalog
 from polylogue.proof.models import ProofObligation
@@ -35,10 +35,10 @@ from polylogue.showcase.invariants import InvariantResult
 from polylogue.showcase.qa_report import generate_qa_session
 from polylogue.showcase.qa_runner import QAResult
 from polylogue.showcase.runner import ExerciseResult, ShowcaseResult
+from tests.infra.json_contracts import envelope_result, extract_json_object
 
 # ANSI escape code pattern: ESC[ ... final-byte
 _ANSI_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]|\x1b\].*?\x07|\x1b\[.*?m")
-JSONEnvelope: TypeAlias = dict[str, object]
 
 
 # ---------------------------------------------------------------------------
@@ -46,22 +46,13 @@ JSONEnvelope: TypeAlias = dict[str, object]
 # ---------------------------------------------------------------------------
 
 
-def _extract_json(output: str) -> JSONEnvelope:
+def _extract_json(output: str) -> JSONDocument:
     """Extract the first JSON object from CLI output, skipping log/banner lines."""
-    lines = output.strip().splitlines()
-    for i, line in enumerate(lines):
-        if line.strip().startswith("{"):
-            parsed = json.loads("\n".join(lines[i:]))
-            if not isinstance(parsed, dict):
-                raise ValueError(f"Expected JSON object in output:\n{output}")
-            return dict(parsed)
-    raise ValueError(f"No JSON object in output:\n{output}")
+    return extract_json_object(output, context="CLI output")
 
 
-def _result_payload(data: JSONEnvelope) -> JSONEnvelope:
-    result = data["result"]
-    assert isinstance(result, dict)
-    return dict(result)
+def _result_payload(data: JSONDocument) -> JSONDocument:
+    return envelope_result(data, context="CLI envelope")
 
 
 def _has_ansi(text: str) -> bool:
@@ -94,7 +85,7 @@ class TestFrozenClockCheckJson:
     ) -> None:
         """Two runs with same frozen clock produce identical timestamps."""
 
-        def _run_check() -> JSONEnvelope:
+        def _run_check() -> JSONDocument:
             runner = CliRunner()
             with patch("time.time", return_value=float(self.FROZEN_EPOCH)):
                 result = runner.invoke(
@@ -367,7 +358,7 @@ class TestJsonDeterminism:
     """Same inputs with frozen time must produce byte-identical --json output."""
 
     @staticmethod
-    def _normalize_check_result(data: JSONEnvelope) -> JSONEnvelope:
+    def _normalize_check_result(data: JSONDocument) -> JSONDocument:
         """Remove provenance fields that legitimately vary between runs.
 
         The health system reports live provenance. That provenance is still a
@@ -386,7 +377,7 @@ class TestJsonDeterminism:
     ) -> None:
         """Two doctor --json runs with same frozen time produce identical results."""
         runner = CliRunner()
-        parsed: list[JSONEnvelope] = []
+        parsed: list[JSONDocument] = []
 
         for _ in range(2):
             with patch("time.time", return_value=1700000000.0):

--- a/tests/unit/cli/test_json_envelope_contract.py
+++ b/tests/unit/cli/test_json_envelope_contract.py
@@ -12,7 +12,6 @@ pure output formatting, independent of path caching).
 from __future__ import annotations
 
 import json
-from typing import TypeAlias
 
 import pytest
 from click.testing import CliRunner
@@ -23,9 +22,10 @@ from polylogue.cli.machine_errors import (
     emit_success,
     success,
 )
+from polylogue.lib.json import JSONDocument
+from tests.infra.json_contracts import envelope_result, extract_json_object, json_object_field, parse_json_object
 
 pytestmark = pytest.mark.machine_contract
-JSONEnvelope: TypeAlias = dict[str, object]
 
 
 # ---------------------------------------------------------------------------
@@ -40,7 +40,7 @@ class TestEmitSuccess:
         """emit_success() writes the success envelope to stdout."""
         emit_success({"count": 42})
         captured = capsys.readouterr()
-        parsed = json.loads(captured.out)
+        parsed = parse_json_object(captured.out, context="emit_success stdout")
         assert parsed["status"] == "ok"
         assert parsed["result"] == {"count": 42}
 
@@ -48,14 +48,14 @@ class TestEmitSuccess:
         """emit_success(None) writes empty result."""
         emit_success(None)
         captured = capsys.readouterr()
-        parsed = json.loads(captured.out)
+        parsed = parse_json_object(captured.out, context="emit_success stdout")
         assert parsed == {"status": "ok", "result": {}}
 
     def test_emit_success_empty_result(self: object, capsys: pytest.CaptureFixture[str]) -> None:
         """emit_success({}) writes empty result."""
         emit_success({})
         captured = capsys.readouterr()
-        parsed = json.loads(captured.out)
+        parsed = parse_json_object(captured.out, context="emit_success stdout")
         assert parsed == {"status": "ok", "result": {}}
 
 
@@ -64,34 +64,7 @@ class TestEmitSuccess:
 # ---------------------------------------------------------------------------
 
 
-def _parse_json_output(output: str) -> JSONEnvelope:
-    """Parse JSON from CLI output, stripping any log lines."""
-    # CLI may emit structlog lines to stderr; stdout should be clean JSON.
-    # But CliRunner mixes output, so find the JSON object.
-    lines = output.strip().splitlines()
-    # Find the first line that starts with '{' and parse from there
-    json_start = None
-    for i, line in enumerate(lines):
-        stripped = line.strip()
-        if stripped.startswith("{"):
-            json_start = i
-            break
-    if json_start is None:
-        raise ValueError(f"No JSON object found in output:\n{output}")
-    json_text = "\n".join(lines[json_start:])
-    parsed = json.loads(json_text)
-    if not isinstance(parsed, dict):
-        raise ValueError(f"Expected object envelope, got {type(parsed).__name__}")
-    return dict(parsed)
-
-
-def _result_payload(data: JSONEnvelope) -> JSONEnvelope:
-    result = data["result"]
-    assert isinstance(result, dict)
-    return dict(result)
-
-
-def _invoke_json_command(args: list[str], monkeypatch: pytest.MonkeyPatch) -> JSONEnvelope | None:
+def _invoke_json_command(args: list[str], monkeypatch: pytest.MonkeyPatch) -> JSONDocument | None:
     """Invoke a CLI command with --json flag, return parsed output or None on skip.
 
     Returns None (and calls pytest.skip) if the command fails due to DB errors
@@ -109,7 +82,7 @@ def _invoke_json_command(args: list[str], monkeypatch: pytest.MonkeyPatch) -> JS
         if result.exception:
             pytest.skip(f"{args[0]} --json raised {type(result.exception).__name__}: {result.exception}")
         pytest.skip(f"{args[0]} --json failed (exit {result.exit_code})")
-    return _parse_json_output(result.output)
+    return extract_json_object(result.output, context=f"{args[0]} output")
 
 
 class TestCheckJsonEnvelope:
@@ -132,7 +105,7 @@ class TestTagsJsonEnvelope:
         assert parsed is not None
         assert parsed["status"] == "ok"
         assert "result" in parsed
-        assert "tags" in _result_payload(parsed)
+        assert "tags" in envelope_result(parsed, context="tags envelope")
 
 
 # ---------------------------------------------------------------------------
@@ -170,9 +143,11 @@ class TestErrorEnvelopeContract:
             details={"nested": {"data": True}},
         )
         text = json.dumps(err.to_dict())
-        parsed = json.loads(text)
+        parsed = parse_json_object(text, context="error envelope")
+        details = json_object_field(parsed, "details", context="error envelope")
+        nested = json_object_field(details, "nested", context="error envelope.details")
         assert parsed["status"] == "error"
-        assert parsed["details"]["nested"]["data"] is True
+        assert nested["data"] is True
 
 
 class TestSuccessEnvelopeContract:
@@ -189,7 +164,7 @@ class TestSuccessEnvelopeContract:
         """Success envelope serializes to valid JSON."""
         s = success({"nested": {"deep": True}})
         text = json.dumps(s.to_dict())
-        parsed = json.loads(text)
+        parsed = parse_json_object(text, context="success envelope")
         assert parsed["status"] == "ok"
 
     def test_success_none_gives_empty_result(self: object) -> None:

--- a/tests/unit/cli/test_machine_main.py
+++ b/tests/unit/cli/test_machine_main.py
@@ -1,24 +1,13 @@
 from __future__ import annotations
 
-import json
-
 import click
 import pytest
 
 from polylogue.cli.machine_main import run_machine_entry
 from polylogue.errors import DatabaseError
-from polylogue.lib.json import JSONDocument, json_document
+from tests.infra.json_contracts import json_object, parse_json_object
 
 TRACEBACK_SENTINEL = "Traceback (most recent call last)"
-
-
-def _parse_json_payload(stdout: str) -> JSONDocument:
-    return json_document(json.loads(stdout))
-
-
-def _json_object(value: object, label: str) -> JSONDocument:
-    assert isinstance(value, dict), f"Expected {label} to be a JSON object"
-    return value
 
 
 def test_run_machine_entry_plain_polylogue_error_emits_click_style_error(
@@ -51,8 +40,8 @@ def test_run_machine_entry_json_polylogue_error_emits_runtime_envelope(
     captured = capsys.readouterr()
     combined = captured.out + captured.err
     assert TRACEBACK_SENTINEL not in combined
-    parsed = _parse_json_payload(captured.out)
-    details = _json_object(parsed["details"], "details")
+    parsed = parse_json_object(captured.out, context="machine stdout")
+    details = json_object(parsed["details"], context="details")
     assert parsed["status"] == "error"
     assert parsed["code"] == "runtime_error"
     assert parsed["message"] == "Database schema version 0 is incompatible with expected version 1."
@@ -73,7 +62,7 @@ def test_run_machine_entry_format_json_polylogue_error_emits_runtime_envelope(
     captured = capsys.readouterr()
     combined = captured.out + captured.err
     assert TRACEBACK_SENTINEL not in combined
-    parsed = json_document(json.loads(captured.out))
+    parsed = parse_json_object(captured.out, context="machine stdout")
     assert parsed["status"] == "error"
     assert parsed["code"] == "runtime_error"
     assert parsed["message"] == "Database schema version 0 is incompatible with expected version 1."
@@ -90,8 +79,8 @@ def test_run_machine_entry_extracts_query_command_without_option_values(
         run_machine_entry(bad_args, ["stats", "--by", "provider", "--format", "json", "--limit", "20"])
 
     assert exc_info.value.code == 2
-    parsed = _parse_json_payload(capsys.readouterr().out)
-    details = _json_object(parsed["details"], "details")
+    parsed = parse_json_object(capsys.readouterr().out, context="machine stdout")
+    details = json_object(parsed["details"], context="details")
     assert parsed["status"] == "error"
     assert parsed["code"] == "invalid_arguments"
     assert parsed["command"] == ["stats"]

--- a/tests/unit/cli/test_products.py
+++ b/tests/unit/cli/test_products.py
@@ -20,47 +20,17 @@ from polylogue.storage.backends.connection import open_connection
 from polylogue.storage.session_product_rebuild import rebuild_session_products_sync
 from polylogue.storage.session_product_status import session_product_status_sync
 from polylogue.storage.store_constants import SESSION_PRODUCT_MATERIALIZER_VERSION
+from tests.infra.json_contracts import (
+    extract_json_result,
+    json_array,
+    json_int,
+    json_number,
+    json_object,
+    json_object_list,
+)
 from tests.infra.storage_records import ConversationBuilder
 
-JsonObject = dict[str, object]
 CliWorkspace = dict[str, Path]
-
-
-def _expect_object(value: object) -> JsonObject:
-    assert isinstance(value, dict)
-    return value
-
-
-def _expect_list(value: object) -> list[object]:
-    assert isinstance(value, list)
-    return value
-
-
-def _expect_object_list(value: object) -> list[JsonObject]:
-    values = _expect_list(value)
-    return [_expect_object(item) for item in values]
-
-
-def _expect_int(value: object) -> int:
-    assert isinstance(value, int) and not isinstance(value, bool)
-    return value
-
-
-def _expect_bool(value: object) -> bool:
-    assert isinstance(value, bool)
-    return value
-
-
-def _expect_number(value: object) -> float:
-    assert isinstance(value, (int, float)) and not isinstance(value, bool)
-    return float(value)
-
-
-def _extract_json(output: str) -> JsonObject:
-    data = json.loads(output)
-    if isinstance(data, dict) and data.get("status") == "ok":
-        return _expect_object(data["result"])
-    return _expect_object(data)
 
 
 def _exception_message(result: Result) -> str:
@@ -90,9 +60,9 @@ def test_product_items_payload_can_render_cli_and_mcp_keys() -> None:
     mcp_payload = product_items_payload([product], product_type, item_key="items")
 
     assert cli_payload["count"] == 1
-    assert _expect_object_list(cli_payload["provider_analytics"])[0]["product_kind"] == "provider_analytics"
+    assert json_object_list(cli_payload["provider_analytics"])[0]["product_kind"] == "provider_analytics"
     assert mcp_payload["count"] == 1
-    assert _expect_object_list(mcp_payload["items"])[0]["provider_name"] == "claude-code"
+    assert json_object_list(mcp_payload["items"])[0]["provider_name"] == "claude-code"
 
 
 def _seed_products(cli_workspace: CliWorkspace) -> None:
@@ -177,16 +147,16 @@ def test_products_profiles_json(cli_workspace: CliWorkspace) -> None:
     result = runner.invoke(cli, ["products", "profiles", "--json"], catch_exceptions=False)
 
     assert result.exit_code == 0
-    payload = _extract_json(result.output)
-    assert _expect_int(payload["count"]) == 2
-    first = _expect_object_list(payload["session_profiles"])[0]
-    evidence = _expect_object(first["evidence"])
-    inference = _expect_object(first["inference"])
-    assert _expect_int(first["contract_version"]) == 4
+    payload = extract_json_result(result.output)
+    assert json_int(payload["count"]) == 2
+    first = json_object_list(payload["session_profiles"])[0]
+    evidence = json_object(first["evidence"])
+    inference = json_object(first["inference"])
+    assert json_int(first["contract_version"]) == 4
     assert first["product_kind"] == "session_profile"
     assert first["semantic_tier"] == "merged"
     assert evidence["canonical_session_date"] == "2026-03-01"
-    assert _expect_number(inference["engaged_duration_ms"]) >= 0
+    assert json_number(inference["engaged_duration_ms"]) >= 0
     assert "evidence" in first
     assert "inference" in first
     assert "provenance" in first
@@ -199,8 +169,8 @@ def test_products_profiles_format_json_alias(cli_workspace: CliWorkspace) -> Non
     result = runner.invoke(cli, ["products", "profiles", "--format", "json"], catch_exceptions=False)
 
     assert result.exit_code == 0
-    payload = _extract_json(result.output)
-    assert _expect_int(payload["count"]) == 2
+    payload = extract_json_result(result.output)
+    assert json_int(payload["count"]) == 2
 
 
 def test_products_profiles_inherit_root_format_json(cli_workspace: CliWorkspace) -> None:
@@ -214,8 +184,8 @@ def test_products_profiles_inherit_root_format_json(cli_workspace: CliWorkspace)
     )
 
     assert result.exit_code == 0
-    payload = _extract_json(result.output)
-    assert _expect_int(payload["count"]) == 1
+    payload = extract_json_result(result.output)
+    assert json_int(payload["count"]) == 1
 
 
 def test_products_enrichments_json(cli_workspace: CliWorkspace) -> None:
@@ -237,12 +207,12 @@ def test_products_enrichments_json(cli_workspace: CliWorkspace) -> None:
     )
 
     assert result.exit_code == 0
-    payload = _extract_json(result.output)
-    assert _expect_int(payload["count"]) == 2
-    first = _expect_object_list(payload["session_enrichments"])[0]
-    enrichment_provenance = _expect_object(first["enrichment_provenance"])
-    enrichment = _expect_object(first["enrichment"])
-    assert _expect_int(first["contract_version"]) == 4
+    payload = extract_json_result(result.output)
+    assert json_int(payload["count"]) == 2
+    first = json_object_list(payload["session_enrichments"])[0]
+    enrichment_provenance = json_object(first["enrichment_provenance"])
+    enrichment = json_object(first["enrichment"])
+    assert json_int(first["contract_version"]) == 4
     assert first["product_kind"] == "session_enrichment"
     assert first["semantic_tier"] == "enrichment"
     assert enrichment_provenance["enrichment_family"] == "scored_session_enrichment"
@@ -284,22 +254,20 @@ def test_products_profiles_json_supports_explicit_evidence_and_inference_tiers(c
     assert evidence_result.exit_code == 0
     assert inference_result.exit_code == 0
 
-    evidence_payload = _extract_json(evidence_result.output)
-    inference_payload = _extract_json(inference_result.output)
-    evidence_profile = _expect_object_list(evidence_payload["session_profiles"])[0]
-    inference_profile = _expect_object_list(inference_payload["session_profiles"])[0]
+    evidence_payload = extract_json_result(evidence_result.output)
+    inference_payload = extract_json_result(inference_result.output)
+    evidence_profile = json_object_list(evidence_payload["session_profiles"])[0]
+    inference_profile = json_object_list(inference_payload["session_profiles"])[0]
 
     assert evidence_profile["semantic_tier"] == "evidence"
-    assert _expect_object(evidence_profile["evidence"])["canonical_session_date"] == "2026-03-01"
+    assert json_object(evidence_profile["evidence"])["canonical_session_date"] == "2026-03-01"
     assert evidence_profile["inference"] is None
     assert evidence_profile["inference_provenance"] is None
 
     assert inference_profile["semantic_tier"] == "inference"
     assert inference_profile["evidence"] is None
-    assert _expect_number(_expect_object(inference_profile["inference"])["engaged_duration_ms"]) >= 0
-    assert (
-        _expect_object(inference_profile["inference_provenance"])["inference_family"] == "heuristic_session_semantics"
-    )
+    assert json_number(json_object(inference_profile["inference"])["engaged_duration_ms"]) >= 0
+    assert json_object(inference_profile["inference_provenance"])["inference_family"] == "heuristic_session_semantics"
 
 
 def test_products_profiles_json_handles_blank_tier_search_text_from_migrated_rows(cli_workspace: CliWorkspace) -> None:
@@ -322,8 +290,8 @@ def test_products_profiles_json_handles_blank_tier_search_text_from_migrated_row
 
     assert evidence_result.exit_code == 0
     assert inference_result.exit_code == 0
-    assert _expect_int(_extract_json(evidence_result.output)["count"]) == 2
-    assert _expect_int(_extract_json(inference_result.output)["count"]) == 2
+    assert json_int(extract_json_result(evidence_result.output)["count"]) == 2
+    assert json_int(extract_json_result(inference_result.output)["count"]) == 2
 
 
 def test_products_reconstructs_tiered_payloads_from_blank_migrated_rows(cli_workspace: CliWorkspace) -> None:
@@ -353,24 +321,20 @@ def test_products_reconstructs_tiered_payloads_from_blank_migrated_rows(cli_work
     assert work_events.exit_code == 0
     assert phases.exit_code == 0
 
-    evidence_profiles_payload = _expect_object_list(_extract_json(evidence_profiles.output)["session_profiles"])
-    inference_profiles_payload = _expect_object_list(_extract_json(inference_profiles.output)["session_profiles"])
-    work_event = _expect_object_list(_extract_json(work_events.output)["session_work_events"])[0]
-    phase = _expect_object_list(_extract_json(phases.output)["session_phases"])[0]
+    evidence_profiles_payload = json_object_list(extract_json_result(evidence_profiles.output)["session_profiles"])
+    inference_profiles_payload = json_object_list(extract_json_result(inference_profiles.output)["session_profiles"])
+    work_event = json_object_list(extract_json_result(work_events.output)["session_work_events"])[0]
+    phase = json_object_list(extract_json_result(phases.output)["session_phases"])[0]
 
+    assert all(json_int(json_object(item["evidence"])["message_count"]) >= 1 for item in evidence_profiles_payload)
     assert all(
-        _expect_int(_expect_object(item["evidence"])["message_count"]) >= 1 for item in evidence_profiles_payload
+        json_object(item["evidence"])["canonical_session_date"] == "2026-03-01" for item in evidence_profiles_payload
     )
-    assert all(
-        _expect_object(item["evidence"])["canonical_session_date"] == "2026-03-01" for item in evidence_profiles_payload
-    )
-    assert all(
-        _expect_int(_expect_object(item["inference"])["work_event_count"]) >= 0 for item in inference_profiles_payload
-    )
-    assert _expect_int(_expect_object(work_event["evidence"])["start_index"]) >= 0
-    assert _expect_object(work_event["inference"])["kind"] in {"implementation", "testing", "planning", "debugging"}
-    assert _expect_int(_expect_list(_expect_object(phase["evidence"])["message_range"])[0]) >= 0
-    assert _expect_number(_expect_object(phase["inference"])["confidence"]) >= 0.0
+    assert all(json_int(json_object(item["inference"])["work_event_count"]) >= 0 for item in inference_profiles_payload)
+    assert json_int(json_object(work_event["evidence"])["start_index"]) >= 0
+    assert json_object(work_event["inference"])["kind"] in {"implementation", "testing", "planning", "debugging"}
+    assert json_int(json_array(json_object(phase["evidence"])["message_range"])[0]) >= 0
+    assert json_number(json_object(phase["inference"])["confidence"]) >= 0.0
 
 
 def test_products_profile_date_filters_and_phases_json(cli_workspace: CliWorkspace) -> None:
@@ -395,11 +359,11 @@ def test_products_profile_date_filters_and_phases_json(cli_workspace: CliWorkspa
     assert profiles.exit_code == 0
     assert phases.exit_code == 0
 
-    profile_payload = _extract_json(profiles.output)
-    phase_payload = _extract_json(phases.output)
-    assert _expect_int(profile_payload["count"]) == 2
-    assert _expect_int(phase_payload["count"]) >= 1
-    assert _expect_object_list(phase_payload["session_phases"])[0]["product_kind"] == "session_phase"
+    profile_payload = extract_json_result(profiles.output)
+    phase_payload = extract_json_result(phases.output)
+    assert json_int(profile_payload["count"]) == 2
+    assert json_int(phase_payload["count"]) >= 1
+    assert json_object_list(phase_payload["session_phases"])[0]["product_kind"] == "session_phase"
 
 
 def test_session_product_rebuild_supports_legacy_payload_columns(cli_workspace: CliWorkspace) -> None:
@@ -444,7 +408,7 @@ def test_session_product_rebuild_sync_reports_progress(cli_workspace: CliWorkspa
         rebuild_session_products_sync(
             conn,
             page_size=1,
-            progress_callback=lambda amount, desc=None: observed.append((_expect_int(amount), desc)),
+            progress_callback=lambda amount, desc=None: observed.append((json_int(amount), desc)),
             progress_total=2,
         )
 
@@ -500,10 +464,10 @@ def test_session_product_rebuild_preserves_profile_semantics_without_loading_ful
 
     assert counts.profiles == 1
     assert row is not None
-    repo_names = _expect_list(json.loads(row["repo_names_json"]))
-    evidence_payload = _expect_object(json.loads(row["evidence_payload_json"]))
+    repo_names = json_array(json.loads(row["repo_names_json"]))
+    evidence_payload = json_object(json.loads(row["evidence_payload_json"]))
     assert "sinex" in repo_names
-    assert _expect_int(evidence_payload["compaction_count"]) == 1
+    assert json_int(evidence_payload["compaction_count"]) == 1
 
 
 def test_products_threads_json(cli_workspace: CliWorkspace) -> None:
@@ -514,9 +478,9 @@ def test_products_threads_json(cli_workspace: CliWorkspace) -> None:
 
     assert threads.exit_code == 0
 
-    threads_payload = _extract_json(threads.output)
-    assert _expect_int(threads_payload["count"]) == 1
-    assert _expect_object_list(threads_payload["work_threads"])[0]["product_kind"] == "work_thread"
+    threads_payload = extract_json_result(threads.output)
+    assert json_int(threads_payload["count"]) == 1
+    assert json_object_list(threads_payload["work_threads"])[0]["product_kind"] == "work_thread"
 
 
 def test_products_tag_and_summary_rollups_json(cli_workspace: CliWorkspace) -> None:
@@ -531,16 +495,14 @@ def test_products_tag_and_summary_rollups_json(cli_workspace: CliWorkspace) -> N
     assert days.exit_code == 0
     assert weeks.exit_code == 0
 
-    tag_payload = _extract_json(tags.output)
-    day_payload = _extract_json(days.output)
-    week_payload = _extract_json(weeks.output)
-    assert any(
-        item["tag"] == "provider:claude-code" for item in _expect_object_list(tag_payload["session_tag_rollups"])
-    )
-    assert _expect_int(day_payload["count"]) == 1
-    assert _expect_object_list(day_payload["day_session_summaries"])[0]["product_kind"] == "day_session_summary"
-    assert _expect_int(week_payload["count"]) == 1
-    assert _expect_object_list(week_payload["week_session_summaries"])[0]["product_kind"] == "week_session_summary"
+    tag_payload = extract_json_result(tags.output)
+    day_payload = extract_json_result(days.output)
+    week_payload = extract_json_result(weeks.output)
+    assert any(item["tag"] == "provider:claude-code" for item in json_object_list(tag_payload["session_tag_rollups"]))
+    assert json_int(day_payload["count"]) == 1
+    assert json_object_list(day_payload["day_session_summaries"])[0]["product_kind"] == "day_session_summary"
+    assert json_int(week_payload["count"]) == 1
+    assert json_object_list(week_payload["week_session_summaries"])[0]["product_kind"] == "week_session_summary"
 
 
 def test_products_analytics_json(cli_workspace: CliWorkspace) -> None:
@@ -554,13 +516,13 @@ def test_products_analytics_json(cli_workspace: CliWorkspace) -> None:
     )
 
     assert result.exit_code == 0
-    payload = _extract_json(result.output)
-    assert _expect_int(payload["count"]) == 1
-    item = _expect_object_list(payload["provider_analytics"])[0]
+    payload = extract_json_result(result.output)
+    assert json_int(payload["count"]) == 1
+    item = json_object_list(payload["provider_analytics"])[0]
     assert item["product_kind"] == "provider_analytics"
     assert item["provider_name"] == "claude-code"
-    assert _expect_int(item["conversation_count"]) == 2
-    assert _expect_int(item["tool_use_count"]) == 2
+    assert json_int(item["conversation_count"]) == 2
+    assert json_int(item["tool_use_count"]) == 2
 
 
 def test_session_product_status_accepts_epoch_backed_conversation_timestamps(cli_workspace: CliWorkspace) -> None:

--- a/tests/unit/devtools/test_validation_lanes.py
+++ b/tests/unit/devtools/test_validation_lanes.py
@@ -42,6 +42,13 @@ class TestLaneParsing:
             assert lane.description
             assert lane.timeout_s > 0
 
+    def test_pytest_lanes_do_not_repeat_explicit_targets(self) -> None:
+        for lane in LANES.values():
+            if lane.execution is None or lane.execution.kind is not ExecutionKind.PYTEST:
+                continue
+            explicit_targets = tuple(arg for arg in lane.execution.argv if arg.startswith("tests/"))
+            assert len(explicit_targets) == len(set(explicit_targets)), lane.name
+
     def test_machine_contract_lane_carries_shared_operation_metadata(self) -> None:
         lane = LANES["machine-contract"]
 


### PR DESCRIPTION
## Summary

Adds a shared typed JSON assertion helper for verification tests, migrates repeated CLI JSON helper code into it, and updates the generated quality reference so verification helper contracts are visible from the devtools docs.

## Problem

Issue #274 asks for the verification/test/devtools layer to reflect the renewed substrate and surface contracts. Several CLI test suites still carried local JSON object/envelope/result parsers from older surface ambiguity, which meant the same contract was reimplemented slightly differently across check, machine main, deterministic output, products, and JSON envelope tests. The generated quality reference also listed lanes and campaigns but did not point readers at the shared `tests/infra` verification substrate.

## Solution

- Added `tests/infra/json_contracts.py` with typed helpers for JSON object extraction, success-envelope unwrapping, object/list narrowing, and numeric assertions.
- Added `tests/infra/test_json_contracts.py` to lock down the shared helper behavior.
- Migrated repeated local JSON helper functions in CLI check, machine, JSON envelope, deterministic-output, and product tests to the shared helper.
- Added a validation-lane test that rejects duplicate explicit pytest targets in authored lanes.
- Updated `devtools/render_quality_reference.py` and regenerated `docs/test-quality-workflows.md` with a “Test Infrastructure Contracts” section covering the shared helper surfaces.

Closes #274.

## Verification

- `pytest -q tests/infra/test_json_contracts.py tests/unit/cli/test_check.py tests/unit/cli/test_click_app_main.py tests/unit/cli/test_deterministic_output.py tests/unit/cli/test_json_envelope_contract.py tests/unit/cli/test_machine_main.py tests/unit/cli/test_products.py tests/unit/devtools/test_validation_lanes.py` -> `293 passed in 9.84s`
- `ruff check devtools/render_quality_reference.py tests/infra/json_contracts.py tests/infra/test_json_contracts.py tests/unit/cli/test_check.py tests/unit/cli/test_click_app_main.py tests/unit/cli/test_deterministic_output.py tests/unit/cli/test_json_envelope_contract.py tests/unit/cli/test_machine_main.py tests/unit/cli/test_products.py tests/unit/devtools/test_validation_lanes.py` -> passed
- `mypy devtools/render_quality_reference.py tests/infra/json_contracts.py tests/infra/test_json_contracts.py tests/unit/cli/test_check.py tests/unit/cli/test_click_app_main.py tests/unit/cli/test_deterministic_output.py tests/unit/cli/test_json_envelope_contract.py tests/unit/cli/test_machine_main.py tests/unit/cli/test_products.py tests/unit/devtools/test_validation_lanes.py` -> passed
- `devtools render-all --check` -> passed
- `devtools verify` -> `verify: all checks passed`
- `git push -u origin feature/refactor/verification-contracts` pre-push hook ran `devtools verify --quick` -> `verify: all checks passed`