### PR TITLE
feat: complete TUI and site functional smokes (#368)

### DIFF
--- a/polylogue/ui/tui/screens/browser.py
+++ b/polylogue/ui/tui/screens/browser.py
@@ -28,9 +28,6 @@ class Browser(RepositoryBoundContainer):
             stats = await repo.get_archive_stats()
             providers = sorted(stats.providers.keys()) if stats.providers else []
 
-            if not providers:
-                providers = ["chatgpt", "claude-ai"]  # Fallback for empty DB
-
             # Collect tree data: list of (provider_label, [(title, conv_id), ...])
             tree_data: list[tuple[str, list[tuple[str, str]]]] = []
             for provider in providers:
@@ -48,6 +45,10 @@ class Browser(RepositoryBoundContainer):
         """Apply fetched tree data to DOM (runs on main thread)."""
         tree = self.query_one("#browser-tree", Tree)
         tree.root.expand()
+
+        if not tree_data:
+            tree.root.add_leaf("No conversations in archive")
+            return
 
         for provider_label, leaves in tree_data:
             provider_node = tree.root.add(provider_label, expand=False)

--- a/tests/integration/test_site.py
+++ b/tests/integration/test_site.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from collections.abc import AsyncIterator, Sequence
 from datetime import datetime, timezone
 from pathlib import Path
@@ -15,6 +16,7 @@ from polylogue.lib.models import ConversationSummary
 from polylogue.site.builder import SiteBuilder, SiteConfig
 from polylogue.site.models import ConversationIndex
 from polylogue.types import ConversationId, Provider
+from tests.infra.storage_records import ConversationBuilder
 
 WorkspaceEnv = dict[str, Path]
 MessagePayload = tuple[str, str]
@@ -130,6 +132,61 @@ def test_run_site_no_rich_markup_in_output(workspace_env: WorkspaceEnv) -> None:
     assert result.exit_code == 0
     for token in ("[bold]", "[/bold]", "[green]", "[/green]", "[red]", "[/red]"):
         assert token not in result.output
+
+
+def test_run_site_builds_browsable_static_site(workspace_env: WorkspaceEnv) -> None:
+    """Smoke: `polylogue run site` writes linked HTML pages from a seeded archive."""
+    db_path = workspace_env["data_root"] / "polylogue" / "polylogue.db"
+    (
+        ConversationBuilder(db_path, "site-smoke-1")
+        .provider("chatgpt")
+        .title("Smoke Conversation")
+        .updated_at("2026-03-22T12:00:00+00:00")
+        .add_message("m1", role="user", text="site smoke body")
+        .save()
+    )
+
+    runner = CliRunner()
+    output_dir = workspace_env["archive_root"] / "site-smoke"
+    result = runner.invoke(
+        cli,
+        [
+            "--plain",
+            "run",
+            "site",
+            "--output",
+            str(output_dir),
+            "--title",
+            "Smoke Archive",
+            "--search-provider",
+            "lunr",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    index_html = (output_dir / "index.html").read_text(encoding="utf-8")
+    dashboard_html = (output_dir / "dashboard.html").read_text(encoding="utf-8")
+    conversation_path = output_dir / "chatgpt" / "site-smoke-1" / "conversation.html"
+    conversation_html = conversation_path.read_text(encoding="utf-8")
+    search_index = json.loads((output_dir / "search-index.json").read_text(encoding="utf-8"))
+
+    assert "<!DOCTYPE html>" in index_html
+    assert "Smoke Archive" in index_html
+    assert "Smoke Conversation" in index_html
+    assert "dashboard.html" in index_html
+    assert "<!DOCTYPE html>" in dashboard_html
+    assert "Smoke Archive" in dashboard_html
+    assert "<!DOCTYPE html>" in conversation_html
+    assert "site smoke body" in conversation_html
+    assert search_index == [
+        {
+            "id": "site-smoke-1",
+            "title": "Smoke Conversation",
+            "provider": "chatgpt",
+            "preview": "",
+            "path": "chatgpt/site-smoke-1/conversation.html",
+        }
+    ]
 
 
 def test_run_site_error_handling(workspace_env: WorkspaceEnv) -> None:

--- a/tests/integration/test_tui_dashboard.py
+++ b/tests/integration/test_tui_dashboard.py
@@ -1,0 +1,58 @@
+"""Headless TUI launch smokes."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Coroutine
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from textual.pilot import Pilot
+from textual.widgets import TabbedContent
+
+from polylogue.ui.tui.app import PolylogueApp
+from polylogue.ui.tui.widgets.stats import StatCard
+
+if TYPE_CHECKING:
+    from polylogue.storage.repository import ConversationRepository
+    from tests.infra.storage_records import ConversationBuilder
+
+ConversationBuilderFactory = Callable[[str], "ConversationBuilder"]
+DashboardAutopilot = Callable[[Pilot[object]], Coroutine[Any, Any, None]]
+
+
+def _dashboard_autopilot(repository: ConversationRepository) -> DashboardAutopilot:
+    async def autopilot(pilot: Pilot[object]) -> None:
+        try:
+            await pilot.pause()
+            tabs = pilot.app.query_one(TabbedContent)
+            assert tabs.active == "dashboard"
+
+            await pilot.app.workers.wait_for_complete()
+            for _ in range(20):
+                await pilot.pause()
+                stat = pilot.app.query_one("#stat-conversations", StatCard)
+                if stat.value != "Loading...":
+                    break
+
+            assert pilot.app.query_one("#stat-conversations", StatCard).value == "1"
+            assert pilot.app.query_one("#stat-messages", StatCard).value == "1"
+        finally:
+            await repository.backend.close()
+            pilot.app.exit()
+
+    return autopilot
+
+
+@pytest.mark.tui
+def test_dashboard_app_launches_headless_with_real_repository(
+    storage_repository: ConversationRepository,
+    conversation_builder: ConversationBuilderFactory,
+) -> None:
+    conversation_builder("tui-smoke-1").provider("chatgpt").title("Dashboard Smoke").add_message(
+        "m1",
+        text="Dashboard launch smoke",
+    ).save()
+
+    app = PolylogueApp(repository=storage_repository)
+
+    app.run(headless=True, size=(100, 30), auto_pilot=_dashboard_autopilot(storage_repository))

--- a/tests/unit/ui/test_tui.py
+++ b/tests/unit/ui/test_tui.py
@@ -197,7 +197,7 @@ async def test_browser_node_selection(
 @_skip
 @pytest.mark.asyncio
 async def test_browser_empty_db(storage_repository: ConversationRepository) -> None:
-    """Empty DB → fallback provider list shown."""
+    """Empty DB → direct empty-state leaf shown."""
     import asyncio
 
     app = _make_app(storage_repository)
@@ -214,9 +214,8 @@ async def test_browser_empty_db(storage_repository: ConversationRepository) -> N
             await asyncio.sleep(0.1)
             await pilot.pause()
 
-        # Should have fallback providers (chatgpt, claude-ai)
-        provider_names = [str(child.label) for child in tree.root.children]
-        assert len(provider_names) >= 2
+        node_labels = [str(child.label) for child in tree.root.children]
+        assert node_labels == ["No conversations in archive"]
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

Makes the TUI Browser empty state honest and adds smoke coverage that proves the dashboard app and static-site generation paths run against seeded repository state.

## Problem

Issue #198 asked whether the TUI and site builder were actually functional rather than just scaffolded. The current Browser and Search tabs already have real behavior and focused Textual coverage, but Browser rendered fake provider nodes for an empty archive. The dashboard CLI wiring test also mocked `PolylogueApp.run`, and the site CLI smoke only checked the publication manifest rather than the generated browsable site artifacts.

## Solution

- Replaced the Browser tab's fake empty-archive provider fallback with a `No conversations in archive` tree leaf.
- Updated the Browser empty-state test to assert the direct empty state.
- Added a headless Textual integration smoke that runs `PolylogueApp.run()` against a real seeded repository and exits through autopilot after dashboard stats render.
- Added a seeded CLI site smoke that runs `polylogue run site` and verifies `index.html`, `dashboard.html`, a conversation page, and `search-index.json`.

Closes #198

## Verification

- `pytest -q tests/unit/ui/test_tui.py tests/integration/test_tui_dashboard.py` (`17 passed`)
- `pytest -q tests/unit/site/test_builder.py tests/unit/cli/test_site.py tests/integration/test_site.py` (`13 passed`)
- `ruff check polylogue/ui/tui/screens/browser.py tests/unit/ui/test_tui.py tests/integration/test_tui_dashboard.py tests/integration/test_site.py tests/unit/cli/test_site.py tests/unit/site/test_builder.py`
- `mypy polylogue/ui/tui/screens/browser.py tests/unit/ui/test_tui.py tests/integration/test_tui_dashboard.py tests/integration/test_site.py tests/unit/cli/test_site.py tests/unit/site/test_builder.py`
- `devtools verify` (`all checks passed`)
- `pytest -q tests/integration/test_tui_dashboard.py tests/integration/test_site.py` (`9 passed`)
- pre-push `devtools verify --quick` (`all checks passed`)

Manual note: `timeout 5s polylogue --plain dashboard` rendered the dashboard TUI and exited with timeout as expected because the app remains running interactively.