### PR TITLE
refactor: renew privacy audit runtime contracts (#369)

### DIFF
--- a/devtools/benchmark_campaigns.py
+++ b/devtools/benchmark_campaigns.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from polylogue.scenarios import CorpusSourceKind, dispatch_execution
+from polylogue.scenarios import CorpusSourceKind, RunnerInvocation, dispatch_runner_execution
 
 from .authored_scenario_catalog import get_authored_scenario_catalog
 from .benchmark_catalog import BenchmarkCampaignEntry
@@ -25,15 +25,11 @@ async def run_synthetic_benchmark_campaign(name: str, db_path: Path) -> Campaign
     campaign = SYNTHETIC_CAMPAIGNS[name]
     if campaign.execution is None:
         raise ValueError(f"Synthetic benchmark campaign {campaign.name!r} has no execution")
-    result = await dispatch_execution(
+    result = await dispatch_runner_execution(
         campaign.execution,
         runner_resolver=resolve_synthetic_benchmark_runner,
-        runner_args=(db_path,),
+        invocation=RunnerInvocation(args=(db_path,)),
     )
-    if not isinstance(result, CampaignResult):
-        raise TypeError(
-            f"Synthetic benchmark campaign {campaign.name!r} returned unexpected result type {type(result).__name__}"
-        )
     result.origin = campaign.origin
     result.path_targets = list(campaign.path_targets)
     result.artifact_targets = list(campaign.artifact_targets)

--- a/polylogue/lib/filters.py
+++ b/polylogue/lib/filters.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 
 from polylogue.lib.filter_builder import ConversationFilterBuilderMixin
 from polylogue.lib.filter_types import SortField
+from polylogue.lib.query_fields import SqlPushdownParams
 from polylogue.lib.query_plan import ConversationQueryPlan
 from polylogue.lib.query_plan_execution import (
     count_for_plan,
@@ -66,7 +67,7 @@ class ConversationFilter(ConversationFilterBuilderMixin):
     def build_query_plan(self) -> ConversationQueryPlan:
         return self._plan
 
-    def _sql_pushdown_params(self) -> dict[str, object]:
+    def _sql_pushdown_params(self) -> SqlPushdownParams:
         return self._plan.sql_pushdown_params()
 
     def _has_post_filters(self) -> bool:

--- a/polylogue/lib/outcomes.py
+++ b/polylogue/lib/outcomes.py
@@ -72,6 +72,26 @@ class OutcomeCheck:
         return f"{prefix}[{label}] {self.name}: {self.summary}"
 
 
+@dataclass(frozen=True)
+class OutcomeCounts:
+    """Typed status-count payload shared by outcome reports."""
+
+    ok: int = 0
+    warning: int = 0
+    error: int = 0
+    skip: int | None = None
+
+    def to_json(self, *, include_skip: bool = False) -> JSONDocument:
+        payload: JSONDocument = {
+            OutcomeStatus.OK.value: self.ok,
+            OutcomeStatus.WARNING.value: self.warning,
+            OutcomeStatus.ERROR.value: self.error,
+        }
+        if include_skip:
+            payload[OutcomeStatus.SKIP.value] = self.skip or 0
+        return payload
+
+
 @dataclass
 class OutcomeReport:
     """Shared report container for collections of outcome checks."""
@@ -81,15 +101,24 @@ class OutcomeReport:
     def count(self, status: OutcomeStatus) -> int:
         return sum(1 for check in self.checks if check.status is status)
 
+    def counts(self) -> OutcomeCounts:
+        return OutcomeCounts(
+            ok=self.count(OutcomeStatus.OK),
+            warning=self.count(OutcomeStatus.WARNING),
+            error=self.count(OutcomeStatus.ERROR),
+            skip=self.count(OutcomeStatus.SKIP),
+        )
+
     def summary_counts(self, *, include_skip: bool = False) -> dict[str, int]:
-        statuses = [
-            OutcomeStatus.OK,
-            OutcomeStatus.WARNING,
-            OutcomeStatus.ERROR,
-        ]
+        counts = self.counts()
+        payload = {
+            OutcomeStatus.OK.value: counts.ok,
+            OutcomeStatus.WARNING.value: counts.warning,
+            OutcomeStatus.ERROR.value: counts.error,
+        }
         if include_skip:
-            statuses.append(OutcomeStatus.SKIP)
-        return {status.value: self.count(status) for status in statuses}
+            payload[OutcomeStatus.SKIP.value] = counts.skip or 0
+        return payload
 
     @property
     def ok_count(self) -> int:
@@ -114,6 +143,7 @@ class OutcomeReport:
 
 __all__ = [
     "OutcomeCheck",
+    "OutcomeCounts",
     "OutcomeReport",
     "OutcomeStatus",
 ]

--- a/polylogue/lib/query_fields.py
+++ b/polylogue/lib/query_fields.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, replace
 from datetime import datetime
-from typing import Protocol, cast
+from typing import Protocol, TypeAlias, cast
 
 from polylogue.storage.query_models import ConversationRecordQuery
 from polylogue.types import Provider
@@ -14,6 +14,8 @@ PresenceCheck = Callable[[object], bool]
 DescriptionRenderer = Callable[[object], str]
 StorageValue = Callable[[object], object]
 _ReplaceRecordQuery: Callable[..., ConversationRecordQuery] = replace
+SqlPushdownValue: TypeAlias = str | int | bool | list[str]
+SqlPushdownParams: TypeAlias = dict[str, SqlPushdownValue]
 
 
 class _ProviderScopedPlan(Protocol):
@@ -92,6 +94,14 @@ def _literal(text: str) -> DescriptionRenderer:
 
 def _list_value(value: object) -> object:
     return list(_as_tuple(value))
+
+
+def _sql_pushdown_value(value: object) -> SqlPushdownValue:
+    if isinstance(value, (str, int, bool)):
+        return value
+    if isinstance(value, list) and all(isinstance(item, str) for item in value):
+        return value
+    raise TypeError(f"SQL pushdown parameter is not supported: {value!r}")
 
 
 def _identity(value: object) -> object:
@@ -613,8 +623,8 @@ def conversation_record_query_for_plan(plan: object) -> ConversationRecordQuery:
     )
 
 
-def sql_pushdown_params_for_plan(plan: object) -> dict[str, object]:
-    params: dict[str, object] = {}
+def sql_pushdown_params_for_plan(plan: object) -> SqlPushdownParams:
+    params: SqlPushdownParams = {}
     provider, providers = provider_scope_for_plan(cast(_ProviderScopedPlan, plan))
     if provider is not None:
         params["provider"] = provider
@@ -623,7 +633,7 @@ def sql_pushdown_params_for_plan(plan: object) -> dict[str, object]:
     for descriptor in QUERY_FIELD_DESCRIPTORS:
         if descriptor.sql_param is None or not descriptor.is_active_for_plan(plan):
             continue
-        params[descriptor.sql_param] = descriptor.sql_plan_value(plan)
+        params[descriptor.sql_param] = _sql_pushdown_value(descriptor.sql_plan_value(plan))
     return params
 
 
@@ -639,6 +649,8 @@ def storage_filters_require_stats_join(filters: Mapping[str, object]) -> bool:
 __all__ = [
     "QUERY_FIELD_DESCRIPTORS",
     "QueryFieldDescriptor",
+    "SqlPushdownParams",
+    "SqlPushdownValue",
     "active_plan_field_names",
     "conversation_record_query_for_plan",
     "describe_plan_fields",

--- a/polylogue/lib/query_plan.py
+++ b/polylogue/lib/query_plan.py
@@ -8,7 +8,11 @@ from dataclasses import dataclass, replace
 from datetime import datetime
 from typing import TYPE_CHECKING, TypeVar
 
-from polylogue.lib.query_fields import conversation_record_query_for_plan, sql_pushdown_params_for_plan
+from polylogue.lib.query_fields import (
+    SqlPushdownParams,
+    conversation_record_query_for_plan,
+    sql_pushdown_params_for_plan,
+)
 from polylogue.lib.query_plan_description import describe_plan, effective_fetch_limit, plan_has_filters
 from polylogue.lib.query_retrieval import (
     action_event_rows_ready,
@@ -57,7 +61,7 @@ def plan_record_query(plan: ConversationQueryPlan) -> ConversationRecordQuery:
     return conversation_record_query_for_plan(plan)
 
 
-def plan_sql_pushdown_params(plan: ConversationQueryPlan) -> dict[str, object]:
+def plan_sql_pushdown_params(plan: ConversationQueryPlan) -> SqlPushdownParams:
     return sql_pushdown_params_for_plan(plan)
 
 
@@ -122,7 +126,7 @@ class ConversationQueryPlan:
     def record_query(self) -> ConversationRecordQuery:
         return plan_record_query(self)
 
-    def sql_pushdown_params(self) -> dict[str, object]:
+    def sql_pushdown_params(self) -> SqlPushdownParams:
         return plan_sql_pushdown_params(self)
 
     def describe(self) -> list[str]:

--- a/polylogue/lib/query_sorting.py
+++ b/polylogue/lib/query_sorting.py
@@ -4,19 +4,49 @@ from __future__ import annotations
 
 import random
 from collections.abc import Callable
+from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, TypeAlias, TypeVar
+from typing import TYPE_CHECKING, Protocol, TypeAlias, TypeVar
 
 if TYPE_CHECKING:
     from polylogue.lib.models import Conversation, ConversationSummary
-    from polylogue.lib.query_plan import ConversationQueryPlan
+
+from polylogue.lib.filter_types import SortField
 
 _T = TypeVar("_T")
 SortKey: TypeAlias = datetime | float | int | str
 
 
+class QuerySortPlan(Protocol):
+    """Minimal plan surface required by result sorting/finalization."""
+
+    @property
+    def sort(self) -> SortField: ...
+
+    @property
+    def reverse(self) -> bool: ...
+
+    @property
+    def limit(self) -> int | None: ...
+
+    @property
+    def sample(self) -> int | None: ...
+
+
+@dataclass(frozen=True, slots=True)
+class ResultWindow:
+    """Typed sampling and limit settings for finalized query results."""
+
+    sample: int | None = None
+    limit: int | None = None
+
+    @classmethod
+    def from_plan(cls, plan: QuerySortPlan) -> ResultWindow:
+        return cls(sample=plan.sample, limit=plan.limit)
+
+
 def sort_generic(
-    plan: ConversationQueryPlan,
+    plan: QuerySortPlan,
     items: list[_T],
     key_fn: Callable[[_T], SortKey],
 ) -> list[_T]:
@@ -28,7 +58,7 @@ def sort_generic(
 
 
 def sort_conversations(
-    plan: ConversationQueryPlan,
+    plan: QuerySortPlan,
     conversations: list[Conversation],
 ) -> list[Conversation]:
     dt_min = datetime.min.replace(tzinfo=timezone.utc)
@@ -50,7 +80,7 @@ def sort_conversations(
 
 
 def sort_summaries(
-    plan: ConversationQueryPlan,
+    plan: QuerySortPlan,
     summaries: list[ConversationSummary],
 ) -> list[ConversationSummary]:
     dt_min = datetime.min.replace(tzinfo=timezone.utc)
@@ -58,19 +88,30 @@ def sort_summaries(
 
 
 def finalize_results(
-    plan: ConversationQueryPlan,
+    plan: QuerySortPlan,
     items: list[_T],
 ) -> list[_T]:
+    return finalize_window(ResultWindow.from_plan(plan), items)
+
+
+def finalize_window(
+    window: ResultWindow,
+    items: list[_T],
+) -> list[_T]:
+    """Apply a typed result window to already sorted query results."""
     results = list(items)
-    if plan.sample is not None and plan.sample < len(results):
-        results = random.sample(results, plan.sample)
-    if plan.limit is not None:
-        results = results[: plan.limit]
+    if window.sample is not None and window.sample < len(results):
+        results = random.sample(results, window.sample)
+    if window.limit is not None:
+        results = results[: window.limit]
     return results
 
 
 __all__ = [
     "finalize_results",
+    "finalize_window",
+    "QuerySortPlan",
+    "ResultWindow",
     "sort_conversations",
     "sort_generic",
     "sort_summaries",

--- a/polylogue/pipeline/prepare.py
+++ b/polylogue/pipeline/prepare.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol
 
 from polylogue.logging import get_logger
 from polylogue.pipeline.ids import (
@@ -25,16 +25,36 @@ from polylogue.pipeline.prepare_models import (
     _timestamp_sort_key,
 )
 from polylogue.pipeline.prepare_transform import transform_to_records
+from polylogue.storage.store import (
+    AttachmentRecord,
+    ContentBlockRecord,
+    ConversationRecord,
+    MessageRecord,
+)
 
 if TYPE_CHECKING:
     from polylogue.sources.parsers.base import ParsedConversation
     from polylogue.storage.backends.async_sqlite import SQLiteBackend
-    from polylogue.storage.repository import ConversationRepository
 
 logger = get_logger(__name__)
 
 
-async def save_bundle(bundle: RecordBundle, repository: ConversationRepository) -> SaveResult:
+class PrepareRepository(Protocol):
+    """Repository surface needed by record preparation."""
+
+    @property
+    def backend(self) -> SQLiteBackend: ...
+
+    async def save_conversation(
+        self,
+        conversation: ConversationRecord,
+        messages: list[MessageRecord],
+        attachments: list[AttachmentRecord],
+        content_blocks: list[ContentBlockRecord] | None = None,
+    ) -> dict[str, int]: ...
+
+
+async def save_bundle(bundle: RecordBundle, repository: PrepareRepository) -> SaveResult:
     counts = await repository.save_conversation(
         conversation=bundle.conversation,
         messages=bundle.messages,
@@ -50,7 +70,7 @@ async def prepare_bundle(
     *,
     archive_root: Path,
     backend: SQLiteBackend | None = None,
-    repository: ConversationRepository | None = None,
+    repository: PrepareRepository | None = None,
     raw_id: str | None = None,
     cache: PrepareCache | None = None,
 ) -> PreparedBundle:
@@ -73,7 +93,7 @@ async def prepare_bundle(
 async def persist_prepared_bundle(
     prepared: PreparedBundle,
     *,
-    repository: ConversationRepository,
+    repository: PrepareRepository,
 ) -> PersistedConversationResult:
     """Persist a prepared conversation bundle, including attachment materialization."""
     applied_moves: list[tuple[Path, Path]] = []
@@ -106,7 +126,7 @@ async def prepare_records(
     *,
     archive_root: Path,
     backend: SQLiteBackend | None = None,
-    repository: ConversationRepository | None = None,
+    repository: PrepareRepository | None = None,
     raw_id: str | None = None,
     cache: PrepareCache | None = None,
 ) -> PersistedConversationResult:
@@ -152,6 +172,7 @@ __all__ = [
     "AttachmentMaterializationPlan",
     "PersistedConversationResult",
     "PrepareCache",
+    "PrepareRepository",
     "PreparedBundle",
     "RecordBundle",
     "SaveResult",

--- a/polylogue/scenarios/__init__.py
+++ b/polylogue/scenarios/__init__.py
@@ -64,7 +64,9 @@ from .projections import (
 )
 from .runtime import (
     ExecutionResult,
+    RunnerInvocation,
     dispatch_execution,
+    dispatch_runner_execution,
     resolve_execution_command,
     resolve_execution_runner,
     run_execution,
@@ -97,6 +99,7 @@ __all__ = [
     "CorpusSpec",
     "compile_projection_entries",
     "dispatch_execution",
+    "dispatch_runner_execution",
     "declared_operation_target_names",
     "ExecutableScenario",
     "ExecutionKind",
@@ -119,6 +122,7 @@ __all__ = [
     "pytest_execution",
     "resolve_execution_command",
     "resolve_execution_runner",
+    "RunnerInvocation",
     "runner_execution",
     "run_execution",
     "build_live_product_surface_lanes",

--- a/polylogue/scenarios/runtime.py
+++ b/polylogue/scenarios/runtime.py
@@ -7,8 +7,11 @@ import subprocess
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
+from typing import TypeAlias, TypeVar
 
 from .execution import ExecutionSpec
+
+_RunnerT = TypeVar("_RunnerT")
 
 
 @dataclass(frozen=True, slots=True)
@@ -26,8 +29,16 @@ class ExecutionResult:
         return self.stdout + self.stderr
 
 
-ExecutionRunner = Callable[..., object | Awaitable[object]]
-ExecutionRunnerResolver = Callable[[str], ExecutionRunner]
+ExecutionRunner: TypeAlias = Callable[..., _RunnerT | Awaitable[_RunnerT]]
+ExecutionRunnerResolver: TypeAlias = Callable[[str], ExecutionRunner[_RunnerT]]
+
+
+@dataclass(frozen=True, slots=True)
+class RunnerInvocation:
+    """Typed argument bundle for named in-process execution runners."""
+
+    args: tuple[object, ...] = ()
+    kwargs: Mapping[str, object] | None = None
 
 
 def resolve_execution_command(
@@ -83,12 +94,27 @@ def run_execution(
 def resolve_execution_runner(
     execution: ExecutionSpec,
     *,
-    runner_resolver: ExecutionRunnerResolver,
-) -> ExecutionRunner:
+    runner_resolver: ExecutionRunnerResolver[_RunnerT],
+) -> ExecutionRunner[_RunnerT]:
     """Resolve one runner-backed execution spec into a callable."""
     if not execution.is_runner or not execution.runner:
         raise ValueError(f"{execution.kind.value} execution has no named runner")
     return runner_resolver(execution.runner)
+
+
+async def dispatch_runner_execution(
+    execution: ExecutionSpec,
+    *,
+    runner_resolver: ExecutionRunnerResolver[_RunnerT],
+    invocation: RunnerInvocation | None = None,
+) -> _RunnerT:
+    """Dispatch one runner-backed execution with a typed result contract."""
+    runner = resolve_execution_runner(execution, runner_resolver=runner_resolver)
+    call = invocation or RunnerInvocation()
+    dispatched = runner(*call.args, **dict(call.kwargs or {}))
+    if isinstance(dispatched, Awaitable):
+        return await dispatched
+    return dispatched
 
 
 async def dispatch_execution(
@@ -99,7 +125,7 @@ async def dispatch_execution(
     timeout: float | None = None,
     capture_output: bool = False,
     binary_overrides: Mapping[str, str] | None = None,
-    runner_resolver: ExecutionRunnerResolver | None = None,
+    runner_resolver: ExecutionRunnerResolver[object] | None = None,
     runner_args: Sequence[object] = (),
     runner_kwargs: Mapping[str, object] | None = None,
 ) -> object:
@@ -107,11 +133,11 @@ async def dispatch_execution(
     if execution.is_runner:
         if runner_resolver is None:
             raise ValueError("runner execution requires a runner_resolver")
-        runner = resolve_execution_runner(execution, runner_resolver=runner_resolver)
-        dispatched = runner(*runner_args, **dict(runner_kwargs or {}))
-        if isinstance(dispatched, Awaitable):
-            return await dispatched
-        return dispatched
+        return await dispatch_runner_execution(
+            execution,
+            runner_resolver=runner_resolver,
+            invocation=RunnerInvocation(args=tuple(runner_args), kwargs=runner_kwargs),
+        )
     return run_execution(
         execution,
         cwd=cwd,
@@ -124,9 +150,11 @@ async def dispatch_execution(
 
 __all__ = [
     "dispatch_execution",
+    "dispatch_runner_execution",
     "ExecutionResult",
     "ExecutionRunner",
     "ExecutionRunnerResolver",
+    "RunnerInvocation",
     "resolve_execution_command",
     "resolve_execution_runner",
     "run_execution",

--- a/polylogue/schemas/audit_models.py
+++ b/polylogue/schemas/audit_models.py
@@ -14,6 +14,37 @@ class AuditCheck(OutcomeCheck):
 
     provider: str | None = None
 
+    def to_json(self, *, label: str | None = None) -> JSONDocument:
+        """Return the machine payload for this audit check."""
+        return audit_check_json(self, provider=self.provider, label=label)
+
+
+@dataclass(frozen=True)
+class AuditSummary:
+    """Machine-readable schema-audit summary counts."""
+
+    passed: int
+    warned: int
+    failed: int
+
+    def to_json(self) -> JSONDocument:
+        return {
+            "passed": self.passed,
+            "warned": self.warned,
+            "failed": self.failed,
+        }
+
+
+def audit_check_json(check: OutcomeCheck, *, provider: str | None, label: str | None) -> JSONDocument:
+    """Return the schema-audit JSON payload for one check."""
+    return {
+        "name": check.name,
+        "provider": provider,
+        "status": label or check.status.value,
+        "message": check.summary,
+        "details": list(check.details),
+    }
+
 
 @dataclass
 class AuditReport(OutcomeReport):
@@ -50,6 +81,10 @@ class AuditReport(OutcomeReport):
     def all_passed(self) -> bool:
         return self.all_ok
 
+    @property
+    def summary(self) -> AuditSummary:
+        return AuditSummary(passed=self.passed, warned=self.warned, failed=self.failed)
+
     def format_text(self) -> str:
         lines = []
         scope = f" ({self.provider})" if self.provider else ""
@@ -67,23 +102,17 @@ class AuditReport(OutcomeReport):
         return json_document(
             {
                 "provider": self.provider,
-                "summary": {
-                    "passed": self.passed,
-                    "warned": self.warned,
-                    "failed": self.failed,
-                },
+                "summary": self.summary.to_json(),
                 "checks": [
-                    {
-                        "name": c.name,
-                        "provider": getattr(c, "provider", None),
-                        "status": self._LABELS[c.status],
-                        "message": c.summary,
-                        "details": c.details,
-                    }
+                    audit_check_json(
+                        c,
+                        provider=getattr(c, "provider", None),
+                        label=self._LABELS[c.status],
+                    )
                     for c in self.checks
                 ],
             }
         )
 
 
-__all__ = ["AuditCheck", "AuditReport"]
+__all__ = ["AuditCheck", "AuditReport", "AuditSummary", "audit_check_json"]

--- a/polylogue/schemas/generation_field_annotations.py
+++ b/polylogue/schemas/generation_field_annotations.py
@@ -11,6 +11,7 @@ from polylogue.schemas.privacy import (
     _is_content_field,
     _is_safe_enum_value,
 )
+from polylogue.schemas.privacy_config import SchemaPrivacyConfig
 
 _ENUM_VALUE_CAP = 200
 _ENUM_OUTPUT_CAP = 20
@@ -23,7 +24,7 @@ def _enum_values(
     *,
     path: str,
     min_conversation_count: int,
-    privacy_config: object | None,
+    privacy_config: SchemaPrivacyConfig | None,
 ) -> list[JSONValue]:
     total = max(field_stats.value_count, 1)
     min_count = _ENUM_MIN_COUNT if total >= 20 else 1
@@ -57,7 +58,7 @@ def annotate_schema(
     path: str = "$",
     *,
     min_conversation_count: int = 1,
-    privacy_config: object | None = None,
+    privacy_config: SchemaPrivacyConfig | None = None,
 ) -> JSONDocument: ...
 
 
@@ -68,7 +69,7 @@ def annotate_schema(
     path: str = "$",
     *,
     min_conversation_count: int = 1,
-    privacy_config: object | None = None,
+    privacy_config: SchemaPrivacyConfig | None = None,
 ) -> JSONValue: ...
 
 
@@ -78,7 +79,7 @@ def annotate_schema(
     path: str = "$",
     *,
     min_conversation_count: int = 1,
-    privacy_config: object | None = None,
+    privacy_config: SchemaPrivacyConfig | None = None,
 ) -> JSONValue:
     """Apply x-polylogue-* annotations to a schema from collected field stats."""
     schema_node = _schema_node(schema)

--- a/polylogue/schemas/generation_provider_bundle.py
+++ b/polylogue/schemas/generation_provider_bundle.py
@@ -21,8 +21,9 @@ from polylogue.schemas.generation_provider_bundle_packages import (
     build_provider_catalog_artifacts,
     build_success_provider_bundle,
 )
-from polylogue.schemas.generation_support import GENSON_AVAILABLE, PrivacyConfigLike
+from polylogue.schemas.generation_support import GENSON_AVAILABLE
 from polylogue.schemas.observation import PROVIDERS, ProviderConfig, resolve_provider_config
+from polylogue.schemas.privacy_config import SchemaPrivacyConfig
 from polylogue.schemas.registry import ClusterManifest, SchemaCluster
 from polylogue.types import Provider
 
@@ -55,7 +56,7 @@ def _build_provider_bundle(
     *,
     db_path: Path | None,
     max_samples: int | None,
-    privacy_config: PrivacyConfigLike | None,
+    privacy_config: SchemaPrivacyConfig | None,
     full_corpus: bool = False,
 ) -> _ProviderBundle:
     """Generate all inferred schema versions plus the default result for a provider."""

--- a/polylogue/schemas/generation_provider_bundle_packages.py
+++ b/polylogue/schemas/generation_provider_bundle_packages.py
@@ -28,13 +28,13 @@ from polylogue.schemas.generation_schema_builder import (
     _apply_schema_metadata,
     _generate_cluster_schema,
 )
-from polylogue.schemas.generation_support import PrivacyConfigLike
 from polylogue.schemas.observation import ProviderConfig
 from polylogue.schemas.packages import (
     SchemaElementManifest,
     SchemaPackageCatalog,
     SchemaVersionPackage,
 )
+from polylogue.schemas.privacy_config import SchemaPrivacyConfig
 from polylogue.schemas.redaction_report import SchemaReport
 from polylogue.schemas.registry import ClusterManifest, SchemaCluster
 from polylogue.types import Provider
@@ -65,7 +65,7 @@ def build_provider_catalog_artifacts(
     sample_count: int,
     artifact_counts: dict[str, int],
     orphan_adjunct_counts: dict[str, int],
-    privacy_config: PrivacyConfigLike | None,
+    privacy_config: SchemaPrivacyConfig | None,
 ) -> ProviderCatalogArtifacts:
     """Build package schemas, catalog metadata, and manifest for a provider."""
     total_units = max(sum(acc.sample_count for acc in clusters.values()), 1)

--- a/polylogue/schemas/generation_redaction.py
+++ b/polylogue/schemas/generation_redaction.py
@@ -9,6 +9,7 @@ from polylogue.schemas.privacy import (
     _is_safe_enum_value,
     _looks_high_entropy_token,
 )
+from polylogue.schemas.privacy_config import SchemaPrivacyConfig
 from polylogue.schemas.redaction_report import (
     FieldReport,
     RedactionDecision,
@@ -21,7 +22,7 @@ def _build_redaction_report(
     stats: dict[str, FieldStats],
     schema: SchemaNode,
     *,
-    privacy_config: object | None = None,
+    privacy_config: SchemaPrivacyConfig | None = None,
     privacy_level: str = "standard",
 ) -> SchemaReport:
     report = SchemaReport(provider=provider, privacy_level=privacy_level)

--- a/polylogue/schemas/generation_schema_builder.py
+++ b/polylogue/schemas/generation_schema_builder.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from datetime import datetime, timezone
-from typing import Protocol, TypeAlias
+from typing import TypeAlias
 
 from polylogue.lib.json import JSONDocument, json_document
 from polylogue.schemas.field_stats import _collect_field_stats
@@ -18,17 +18,13 @@ from polylogue.schemas.generation_support import (
     collapse_dynamic_keys,
 )
 from polylogue.schemas.observation import ProviderConfig
+from polylogue.schemas.privacy_config import SchemaPrivacyConfig
 from polylogue.schemas.redaction_report import SchemaReport
 from polylogue.schemas.shape_fingerprint import _structure_fingerprint
 
 SchemaInput: TypeAlias = Mapping[str, object]
 SchemaPayload: TypeAlias = JSONDocument
 MutableSchemaPayload: TypeAlias = JSONDocument
-
-
-class PrivacyConfigLike(Protocol):
-    @property
-    def level(self) -> str: ...
 
 
 _STRUCTURE_EXEMPLARS_PER_FINGERPRINT = 8
@@ -40,7 +36,7 @@ def _generate_cluster_schema(
     samples: Sequence[SchemaInput],
     conv_ids: Sequence[str | None],
     *,
-    privacy_config: PrivacyConfigLike | None,
+    privacy_config: SchemaPrivacyConfig | None,
     full_corpus: bool = False,
     artifact_kind: str | None = None,
 ) -> tuple[MutableSchemaPayload, SchemaReport | None]:

--- a/polylogue/schemas/generation_support.py
+++ b/polylogue/schemas/generation_support.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from typing import Protocol, TypeAlias, overload
+from typing import TypeAlias, overload
 
 from polylogue.lib.json import JSONDocument, json_document
 from polylogue.schemas import generation_dynamic_keys as _dynamic_keys
@@ -11,16 +11,12 @@ from polylogue.schemas.field_stats import FieldStats
 from polylogue.schemas.generation_field_annotations import annotate_schema, remove_nested_required
 from polylogue.schemas.generation_redaction import _build_redaction_report
 from polylogue.schemas.generation_semantic_relations import annotate_semantic_and_relational
+from polylogue.schemas.privacy_config import SchemaPrivacyConfig
 
 SchemaPayload: TypeAlias = JSONDocument
 SchemaMapping: TypeAlias = Mapping[str, object]
 SchemaCollection: TypeAlias = Sequence[SchemaMapping]
 FieldStatsMapping: TypeAlias = Mapping[str, FieldStats]
-
-
-class PrivacyConfigLike(Protocol):
-    @property
-    def level(self) -> str: ...
 
 
 GENSON_AVAILABLE = _dynamic_keys.GENSON_AVAILABLE
@@ -38,7 +34,7 @@ def _annotate_schema(
     path: str = "$",
     *,
     min_conversation_count: int = 1,
-    privacy_config: PrivacyConfigLike | None = None,
+    privacy_config: SchemaPrivacyConfig | None = None,
 ) -> SchemaPayload:
     return annotate_schema(
         json_document(dict(schema)),

--- a/polylogue/schemas/generation_workflow.py
+++ b/polylogue/schemas/generation_workflow.py
@@ -8,8 +8,8 @@ from polylogue.paths import db_path as archive_db_path
 from polylogue.schemas.generation_models import GenerationResult, _ProviderBundle
 from polylogue.schemas.generation_provider_bundle import _build_provider_bundle
 from polylogue.schemas.generation_schema_builder import generate_schema_from_samples
-from polylogue.schemas.generation_support import PrivacyConfigLike
 from polylogue.schemas.observation import PROVIDERS
+from polylogue.schemas.privacy_config import SchemaPrivacyConfig
 from polylogue.schemas.registry import SchemaRegistry
 from polylogue.schemas.runtime_registry import ElementSchemaMap
 
@@ -45,7 +45,7 @@ def generate_provider_schema(
     provider: str,
     db_path: Path | None = None,
     max_samples: int | None = None,
-    privacy_config: PrivacyConfigLike | None = None,
+    privacy_config: SchemaPrivacyConfig | None = None,
     full_corpus: bool = False,
 ) -> GenerationResult:
     """Generate the default inferred schema for a provider."""
@@ -63,7 +63,7 @@ def generate_all_schemas(
     db_path: Path | None = None,
     providers: list[str] | None = None,
     max_samples: int | None = None,
-    privacy_config: PrivacyConfigLike | None = None,
+    privacy_config: SchemaPrivacyConfig | None = None,
 ) -> list[GenerationResult]:
     """Generate versioned schemas for all providers."""
     if db_path is None:

--- a/polylogue/schemas/privacy.py
+++ b/polylogue/schemas/privacy.py
@@ -9,7 +9,8 @@ is rejected.
 from __future__ import annotations
 
 import re
-from typing import Protocol, runtime_checkable
+
+from polylogue.schemas.privacy_config import SchemaPrivacyConfig
 
 _SAFE_ENUM_MAX_LEN = 50  # structural enums are short tokens, not content
 
@@ -45,18 +46,6 @@ _HIGH_ENTROPY_TOKEN_RE = re.compile(r"^[A-Za-z0-9_-]{10,}$")
 # Pattern matching structural identifiers: lowercase tokens with underscores
 # (e.g. "chatgpt_agent", "deep_research") — not random IDs.
 _STRUCTURAL_CONSTANT_RE = re.compile(r"^[a-z][a-z0-9_]{2,30}$")
-
-
-@runtime_checkable
-class PrivacyConfigLike(Protocol):
-    """Runtime privacy config surface consumed by enum-value guards."""
-
-    @property
-    def safe_enum_max_length(self) -> int: ...
-
-    def field_override(self, path: str) -> str | None: ...
-
-    def is_value_allowed(self, value: str) -> bool | None: ...
 
 
 _IDENTIFIER_FIELD_TOKENS = frozenset(
@@ -209,7 +198,7 @@ def _is_safe_enum_value(
     *,
     path: str = "$",
     max_length: int | None = None,
-    config: object | None = None,
+    config: SchemaPrivacyConfig | None = None,
 ) -> bool:
     """Return True if a string value is safe to include in schema annotations.
 
@@ -230,7 +219,7 @@ def _is_safe_enum_value(
     effective_max_len = max_length or _SAFE_ENUM_MAX_LEN
 
     # Check config-level overrides first (highest precedence)
-    privacy_config = config if isinstance(config, PrivacyConfigLike) else None
+    privacy_config = config if isinstance(config, SchemaPrivacyConfig) else None
 
     if privacy_config is not None:
         # Field-level override

--- a/polylogue/schemas/privacy_config.py
+++ b/polylogue/schemas/privacy_config.py
@@ -13,7 +13,7 @@ import sys
 from dataclasses import dataclass, field
 from fnmatch import fnmatch
 from pathlib import Path
-from typing import Literal, TypeAlias
+from typing import Literal, Protocol, TypeAlias, runtime_checkable
 
 if sys.version_info >= (3, 11):
     import tomllib
@@ -30,6 +30,21 @@ PrivacySettingValue: TypeAlias = str | int | bool | float | list[str] | dict[str
 PrivacyConfigSection: TypeAlias = dict[str, PrivacySettingValue]
 FieldOverride: TypeAlias = dict[str, str]
 PatternList: TypeAlias = list[str]
+
+
+@runtime_checkable
+class SchemaPrivacyConfig(Protocol):
+    """Runtime contract shared by schema generation privacy guards."""
+
+    @property
+    def level(self) -> PrivacyLevel: ...
+
+    @property
+    def safe_enum_max_length(self) -> int: ...
+
+    def field_override(self, path: str) -> str | None: ...
+
+    def is_value_allowed(self, value: str) -> bool | None: ...
 
 
 # ---------------------------------------------------------------------------
@@ -224,5 +239,6 @@ def _bool_config_value(value: PrivacySettingValue, *, default: bool) -> bool:
 
 __all__ = [
     "PrivacyConfig",
+    "SchemaPrivacyConfig",
     "load_privacy_config",
 ]

--- a/polylogue/schemas/redaction_report.py
+++ b/polylogue/schemas/redaction_report.py
@@ -25,6 +25,19 @@ class RedactionDecision:
     conversation_count: int | None = None
     risk: Literal["none", "low", "medium", "high"] | None = None
 
+    def to_json(self) -> JSONDocument:
+        """Return the complete machine payload for this decision."""
+        payload: JSONDocument = {
+            "path": self.path,
+            "value": self.value,
+            "action": self.action,
+            "reason": self.reason,
+            "count": self.count,
+            "conversation_count": self.conversation_count,
+            "risk": self.risk,
+        }
+        return payload
+
 
 @dataclass
 class FieldReport:
@@ -35,6 +48,39 @@ class FieldReport:
     rejected: list[RedactionDecision] = field(default_factory=list)
     content_field_blocked: bool = False
     identifier_field_blocked: bool = False
+
+    def to_json(self) -> JSONDocument:
+        """Return the machine payload for this field summary."""
+        payload: JSONDocument = {
+            "path": self.path,
+            "included_values": list(self.included_values),
+            "included_count": len(self.included_values),
+            "rejected": [decision.to_json() for decision in self.rejected],
+            "rejected_count": len(self.rejected),
+            "content_field_blocked": self.content_field_blocked,
+            "identifier_field_blocked": self.identifier_field_blocked,
+        }
+        return payload
+
+
+@dataclass(frozen=True)
+class SchemaReportSummary:
+    """Machine-readable redaction summary counts."""
+
+    total_fields: int
+    fields_with_enums: int
+    total_values_considered: int
+    total_included: int
+    total_rejected: int
+
+    def to_json(self) -> JSONDocument:
+        return {
+            "total_fields": self.total_fields,
+            "fields_with_enums": self.fields_with_enums,
+            "total_values_considered": self.total_values_considered,
+            "total_included": self.total_included,
+            "total_rejected": self.total_rejected,
+        }
 
 
 @dataclass
@@ -52,6 +98,17 @@ class SchemaReport:
     field_reports: list[FieldReport] = field(default_factory=list)
     rejection_reasons: dict[str, int] = field(default_factory=dict)
     borderline_decisions: list[RedactionDecision] = field(default_factory=list)
+
+    @property
+    def summary(self) -> SchemaReportSummary:
+        """Return typed summary counts for the report."""
+        return SchemaReportSummary(
+            total_fields=self.total_fields,
+            fields_with_enums=self.fields_with_enums,
+            total_values_considered=self.total_values_considered,
+            total_included=self.total_included,
+            total_rejected=self.total_rejected,
+        )
 
     def add_decision(self, decision: RedactionDecision) -> None:
         """Track a single redaction decision."""
@@ -162,33 +219,10 @@ class SchemaReport:
                 "provider": self.provider,
                 "timestamp": self.timestamp,
                 "privacy_level": self.privacy_level,
-                "summary": {
-                    "total_fields": self.total_fields,
-                    "fields_with_enums": self.fields_with_enums,
-                    "total_values_considered": self.total_values_considered,
-                    "total_included": self.total_included,
-                    "total_rejected": self.total_rejected,
-                },
+                "summary": self.summary.to_json(),
                 "rejection_reasons": self.rejection_reasons,
-                "borderline_decisions": [
-                    {
-                        "path": d.path,
-                        "value": d.value,
-                        "count": d.count,
-                        "reason": d.reason,
-                    }
-                    for d in self.borderline_decisions
-                ],
-                "field_reports": [
-                    {
-                        "path": fr.path,
-                        "included_count": len(fr.included_values),
-                        "rejected_count": len(fr.rejected),
-                        "content_field_blocked": fr.content_field_blocked,
-                        "identifier_field_blocked": fr.identifier_field_blocked,
-                    }
-                    for fr in self.field_reports
-                ],
+                "borderline_decisions": [decision.to_json() for decision in self.borderline_decisions],
+                "field_reports": [field_report.to_json() for field_report in self.field_reports],
             }
         )
 
@@ -196,5 +230,6 @@ class SchemaReport:
 __all__ = [
     "FieldReport",
     "RedactionDecision",
+    "SchemaReportSummary",
     "SchemaReport",
 ]

--- a/tests/unit/core/test_audit.py
+++ b/tests/unit/core/test_audit.py
@@ -229,6 +229,28 @@ class TestAuditReport:
         assert data["provider"] is None
         assert check["provider"] == "chatgpt"
 
+    def test_typed_summary_payload(self) -> None:
+        report = AuditReport(
+            checks=[
+                AuditCheck(name="schema_exists", status=PASS, summary="ok"),
+                AuditCheck(name="privacy", status=WARN, summary="review"),
+                AuditCheck(name="package", status=FAIL, summary="missing"),
+            ]
+        )
+
+        assert report.summary.to_json() == {"passed": 1, "warned": 1, "failed": 1}
+
+    def test_audit_check_json_payload(self) -> None:
+        check = AuditCheck(name="privacy", status=PASS, summary="ok", details=["safe"], provider="chatgpt")
+
+        assert check.to_json(label="PASS") == {
+            "name": "privacy",
+            "provider": "chatgpt",
+            "status": "PASS",
+            "message": "ok",
+            "details": ["safe"],
+        }
+
 
 class TestCheckPrivacyGuards:
     def test_clean_schema_passes(self) -> None:

--- a/tests/unit/core/test_query_fields.py
+++ b/tests/unit/core/test_query_fields.py
@@ -80,6 +80,11 @@ def test_query_field_catalog_drives_plan_presence_descriptions_and_pushdown() ->
         "min_messages": 3,
         "since": "2024-01-01T00:00:00+00:00",
     }
+    assert all(
+        isinstance(value, (str, int, bool))
+        or (isinstance(value, list) and all(isinstance(item, str) for item in value))
+        for value in plan.sql_pushdown_params().values()
+    )
 
     record_query = plan.record_query
     assert record_query.provider == "codex"

--- a/tests/unit/core/test_redaction_report.py
+++ b/tests/unit/core/test_redaction_report.py
@@ -124,7 +124,21 @@ class TestToJson:
         report = SchemaReport(provider="chatgpt", total_fields=5, total_included=3, total_rejected=2)
         report.rejection_reasons = {"high_entropy": 2}
         report.field_reports = [
-            FieldReport(path="$.x", included_values=["a"], rejected=[]),
+            FieldReport(
+                path="$.x",
+                included_values=["a"],
+                rejected=[
+                    RedactionDecision(
+                        path="$.x",
+                        value="secret",
+                        action="rejected",
+                        reason="high_entropy",
+                        count=2,
+                        conversation_count=1,
+                        risk="medium",
+                    )
+                ],
+            ),
         ]
         data = report.to_json()
         summary = data["summary"]
@@ -138,5 +152,33 @@ class TestToJson:
         assert summary["total_rejected"] == 2
         assert data["rejection_reasons"] == {"high_entropy": 2}
         assert len(field_reports) == 1
+        field_report = field_reports[0]
+        assert isinstance(field_report, dict)
+        assert field_report["included_values"] == ["a"]
+        rejected = field_report["rejected"]
+        assert isinstance(rejected, list)
+        rejected_decision = rejected[0]
+        assert isinstance(rejected_decision, dict)
+        assert rejected_decision["action"] == "rejected"
+        assert rejected_decision["conversation_count"] == 1
+        assert rejected_decision["risk"] == "medium"
         # Should be JSON-serializable
         json.dumps(data)
+
+    def test_typed_summary_payload(self) -> None:
+        report = SchemaReport(
+            provider="chatgpt",
+            total_fields=2,
+            fields_with_enums=1,
+            total_values_considered=4,
+            total_included=3,
+            total_rejected=1,
+        )
+
+        assert report.summary.to_json() == {
+            "total_fields": 2,
+            "fields_with_enums": 1,
+            "total_values_considered": 4,
+            "total_included": 3,
+            "total_rejected": 1,
+        }

--- a/tests/unit/lib/test_outcomes.py
+++ b/tests/unit/lib/test_outcomes.py
@@ -1,0 +1,35 @@
+"""Outcome report contract tests."""
+
+from __future__ import annotations
+
+from polylogue.lib.outcomes import OutcomeCheck, OutcomeReport, OutcomeStatus
+
+
+def test_outcome_report_counts_are_typed_and_json_ready() -> None:
+    report = OutcomeReport(
+        checks=[
+            OutcomeCheck(name="ok", status=OutcomeStatus.OK),
+            OutcomeCheck(name="warn", status=OutcomeStatus.WARNING),
+            OutcomeCheck(name="error", status=OutcomeStatus.ERROR),
+            OutcomeCheck(name="skip", status=OutcomeStatus.SKIP),
+        ]
+    )
+
+    counts = report.counts()
+
+    assert counts.ok == 1
+    assert counts.warning == 1
+    assert counts.error == 1
+    assert counts.skip == 1
+    assert counts.to_json(include_skip=True) == {
+        "ok": 1,
+        "warning": 1,
+        "error": 1,
+        "skip": 1,
+    }
+    assert report.summary_counts(include_skip=True) == {
+        "ok": 1,
+        "warning": 1,
+        "error": 1,
+        "skip": 1,
+    }

--- a/tests/unit/scenarios/test_runtime.py
+++ b/tests/unit/scenarios/test_runtime.py
@@ -6,7 +6,9 @@ from types import SimpleNamespace
 import pytest
 
 from polylogue.scenarios import (
+    RunnerInvocation,
     dispatch_execution,
+    dispatch_runner_execution,
     polylogue_execution,
     resolve_execution_command,
     run_execution,
@@ -84,7 +86,7 @@ async def test_dispatch_execution_routes_runner_executions_through_resolver() ->
         captured["db_path"] = db_path
         return {"ok": True}
 
-    def resolve_runner(name: str) -> ExecutionRunner:
+    def resolve_runner(name: str) -> ExecutionRunner[dict[str, bool]]:
         assert name == "startup-readiness"
         return fake_runner
 
@@ -96,6 +98,29 @@ async def test_dispatch_execution_routes_runner_executions_through_resolver() ->
 
     assert result == {"ok": True}
     assert captured["db_path"] == Path("/tmp/benchmark.db")
+
+
+@pytest.mark.asyncio
+async def test_dispatch_runner_execution_preserves_typed_result_and_kwargs() -> None:
+    captured: dict[str, object] = {}
+
+    def fake_runner(db_path: Path, *, scale: str) -> int:
+        captured["db_path"] = db_path
+        captured["scale"] = scale
+        return 3
+
+    def resolve_runner(name: str) -> ExecutionRunner[int]:
+        assert name == "startup-readiness"
+        return fake_runner
+
+    result = await dispatch_runner_execution(
+        runner_execution("startup-readiness"),
+        runner_resolver=resolve_runner,
+        invocation=RunnerInvocation(args=(Path("/tmp/benchmark.db"),), kwargs={"scale": "small"}),
+    )
+
+    assert result == 3
+    assert captured == {"db_path": Path("/tmp/benchmark.db"), "scale": "small"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Renew the non-CLI privacy, audit, runtime, query, and prepare helper contracts named in #281.

Closes #281

## Problem

The remaining utility/runtime precision tranche was no longer mostly missing annotations; it was still broad at semantic boundaries. Privacy config behavior was described through duplicate partial protocols, schema audit and redaction JSON payloads were assembled as inline dictionaries, runner dispatch returned opaque objects even when the authored execution was runner-backed, SQL pushdown params were exposed as `dict[str, object]`, query sorting consumed the full query plan instead of the actual sort/window surface, and prepare persistence depended on the concrete repository class.

## Solution

- Added a shared `SchemaPrivacyConfig` protocol and routed schema generation privacy helpers through it.
- Added typed payload surfaces for `OutcomeCounts`, `AuditSummary`, audit check JSON, redaction decisions, field reports, and schema redaction summaries.
- Added typed runner invocation and generic `dispatch_runner_execution`, and moved synthetic benchmark dispatch to the typed runner path.
- Added explicit SQL pushdown value/params contracts and updated query plan/filter call sites.
- Added a minimal query sort protocol plus `ResultWindow` for finalization.
- Added `PrepareRepository` as the persistence protocol needed by record preparation.
- Extended focused tests for audit/redaction payloads, outcome counts, runner dispatch, and query pushdown contracts.

## Verification

- `ruff check polylogue/schemas/privacy_config.py polylogue/schemas/privacy.py polylogue/schemas/generation_support.py polylogue/schemas/generation_schema_builder.py polylogue/schemas/generation_workflow.py polylogue/schemas/generation_provider_bundle.py polylogue/schemas/generation_provider_bundle_packages.py polylogue/schemas/generation_redaction.py polylogue/schemas/generation_field_annotations.py polylogue/schemas/redaction_report.py polylogue/schemas/audit_models.py polylogue/lib/outcomes.py polylogue/lib/query_sorting.py polylogue/lib/query_fields.py polylogue/lib/query_plan.py polylogue/scenarios/runtime.py polylogue/scenarios/__init__.py devtools/benchmark_campaigns.py polylogue/pipeline/prepare.py tests/unit/core/test_audit.py tests/unit/core/test_redaction_report.py tests/unit/scenarios/test_runtime.py tests/unit/lib/test_outcomes.py tests/unit/core/test_query_fields.py` -> all checks passed
- `mypy polylogue/schemas/privacy.py polylogue/schemas/privacy_config.py polylogue/schemas/audit_models.py polylogue/schemas/redaction_report.py polylogue/schemas/generation_support.py polylogue/schemas/generation_schema_builder.py polylogue/schemas/generation_workflow.py polylogue/schemas/generation_provider_bundle.py polylogue/schemas/generation_provider_bundle_packages.py polylogue/schemas/generation_redaction.py polylogue/schemas/generation_field_annotations.py polylogue/scenarios/runtime.py polylogue/scenarios/__init__.py devtools/benchmark_campaigns.py polylogue/pipeline/prepare.py polylogue/lib/query_sorting.py polylogue/lib/query_fields.py polylogue/lib/query_plan.py polylogue/lib/outcomes.py tests/unit/core/test_audit.py tests/unit/core/test_redaction_report.py tests/unit/scenarios/test_runtime.py tests/unit/lib/test_outcomes.py tests/unit/core/test_query_fields.py` -> success
- `pytest -q tests/unit/core/test_audit.py tests/unit/core/test_redaction_report.py tests/unit/core/test_schema_privacy.py tests/unit/core/test_privacy_config.py tests/unit/core/test_schema_generation.py tests/unit/scenarios/test_runtime.py tests/unit/lib/test_outcomes.py tests/unit/core/test_query_fields.py tests/unit/pipeline/test_prepare_records.py` -> 221 passed
- `devtools verify` -> all checks passed
- `git push -u origin feature/refactor/privacy-audit-runtime-contracts` -> pre-push quick verification passed
