### PR TITLE
refactor(pipeline): catalog executable stage specs (#370)

### DIFF
--- a/polylogue/pipeline/run_execution.py
+++ b/polylogue/pipeline/run_execution.py
@@ -26,6 +26,11 @@ from polylogue.pipeline.run_support import (
     normalize_stage_sequence,
     select_sources,
 )
+from polylogue.pipeline.stage_specs import (
+    PipelineStageSpec,
+    stage_sequence_suspends_fts,
+    stage_specs_for_sequence,
+)
 from polylogue.storage.backends import create_backend
 from polylogue.storage.repository import ConversationRepository
 from polylogue.storage.run_state import RunResult
@@ -99,11 +104,13 @@ async def run_sources(
     try:
         selected_sources = select_sources(config, source_names)
         normalized_stage_sequence = normalize_stage_sequence(stage=stage, stage_sequence=stage_sequence)
+        stage_specs = stage_specs_for_sequence(normalized_stage_sequence)
+        explicit_sequence = stage_sequence is not None
         executed_stages: set[str] = set()
         index_outcome = IndexStageOutcome(indexed=False, item_count=0)
 
-        async def _run_acquire_stage() -> None:
-            sm = metrics.start_stage("acquire")
+        async def _run_acquire_stage(spec: PipelineStageSpec) -> None:
+            sm = metrics.start_stage(spec.log_stage)
             acquire_result = await execute_acquire_stage(
                 config=config,
                 backend=active_backend,
@@ -115,10 +122,9 @@ async def run_sources(
             sm.stop(items=acquire_result.counts["acquired"])
             state.record_acquire(acquire_result)
             logger.info("Acquire stage complete", **sm.to_dict(), **acquire_result.counts)
-            executed_stages.add("acquire")
 
-        async def _run_schema_stage() -> None:
-            sm = metrics.start_stage("schema")
+        async def _run_schema_stage(spec: PipelineStageSpec) -> None:
+            sm = metrics.start_stage(spec.log_stage)
             schema_outcome = await execute_schema_generation_stage()
             state.record_schema_generation(
                 generated=schema_outcome.generated,
@@ -131,10 +137,9 @@ async def run_sources(
                 generated=schema_outcome.generated,
                 failed=schema_outcome.failed,
             )
-            executed_stages.add("schema")
 
-        async def _run_parse_stage(ingest_stage: str) -> None:
-            sm = metrics.start_stage("ingest")
+        async def _run_parse_stage(spec: PipelineStageSpec, ingest_stage: str) -> None:
+            sm = metrics.start_stage(spec.log_stage)
             ingest_result = await execute_ingest_stage(
                 config=config,
                 repository=active_repository,
@@ -170,10 +175,9 @@ async def run_sources(
                 processed_ids=len(state.processed_ids),
                 parse_failures=ingest_result.parse_result.parse_failures,
             )
-            executed_stages.add("parse")
 
-        async def _run_materialize_stage(materialize_stage: str) -> None:
-            sm = metrics.start_stage("materialize")
+        async def _run_materialize_stage(spec: PipelineStageSpec, materialize_stage: str) -> None:
+            sm = metrics.start_stage(spec.log_stage)
             materialize_outcome = await execute_materialize_stage(
                 stage=materialize_stage,
                 source_names=source_names,
@@ -191,10 +195,9 @@ async def run_sources(
                 **materialize_log_payload,
                 rebuilt=materialize_outcome.rebuilt,
             )
-            executed_stages.add("materialize")
 
-        async def _run_render_stage(render_stage: str) -> None:
-            sm = metrics.start_stage("render")
+        async def _run_render_stage(spec: PipelineStageSpec, render_stage: str) -> None:
+            sm = metrics.start_stage(spec.log_stage)
             render_outcome = await execute_render_stage(
                 config=config,
                 backend=active_backend,
@@ -217,10 +220,9 @@ async def run_sources(
                 failures=len(render_outcome.failures),
                 total=render_outcome.total,
             )
-            executed_stages.add("render")
 
-        async def _run_index_stage(index_stage: str) -> IndexStageOutcome:
-            sm = metrics.start_stage("index")
+        async def _run_index_stage(spec: PipelineStageSpec, index_stage: str) -> IndexStageOutcome:
+            sm = metrics.start_stage(spec.log_stage)
             next_index_outcome = await execute_index_stage(
                 config=config,
                 stage=index_stage,
@@ -237,11 +239,10 @@ async def run_sources(
                 **sm.to_dict(),
                 indexed=next_index_outcome.indexed,
             )
-            executed_stages.add("index")
             return next_index_outcome
 
-        async def _run_site_stage() -> None:
-            sm = metrics.start_stage("site")
+        async def _run_site_stage(spec: PipelineStageSpec) -> None:
+            sm = metrics.start_stage(spec.log_stage)
             site_outcome = await execute_site_stage(
                 backend=active_backend,
                 repository=active_repository,
@@ -258,70 +259,49 @@ async def run_sources(
                 index_pages=site_outcome.index_pages,
                 rendered_pages=site_outcome.rendered_pages,
             )
-            executed_stages.add("site")
 
-        def _explicit_leaf_stage_context(leaf_stage: str) -> str:
-            if leaf_stage == "parse":
-                return "parse"
-            if leaf_stage in {"materialize", "render", "index"} and "parse" in executed_stages:
-                return "all"
-            return leaf_stage
+        async def _run_stage_spec(spec: PipelineStageSpec) -> None:
+            nonlocal index_outcome
+            if not spec.pipeline_managed:
+                executed_stages.add(spec.name)
+                return
+            execution_stage = spec.execution_stage(
+                requested_stage=stage,
+                explicit_sequence=explicit_sequence,
+                executed_stages=executed_stages,
+            )
+            if spec.name == "acquire":
+                await _run_acquire_stage(spec)
+            elif spec.name == "schema":
+                await _run_schema_stage(spec)
+            elif spec.name == "parse":
+                await _run_parse_stage(spec, execution_stage)
+            elif spec.name == "materialize":
+                await _run_materialize_stage(spec, execution_stage)
+            elif spec.name == "render":
+                await _run_render_stage(spec, execution_stage)
+            elif spec.name == "site":
+                await _run_site_stage(spec)
+            elif spec.name == "index":
+                index_outcome = await _run_index_stage(spec, execution_stage)
+            else:
+                raise ValueError(f"Unknown pipeline stage spec: {spec.name}")
+            executed_stages.add(spec.name)
 
         # Suspend FTS triggers during bulk pipeline operations.
         # Triggers fire per-row during message INSERTs, causing massive
         # overhead (~8s per 50 updates with realistic text). The index
         # stage rebuilds FTS at the end anyway, making trigger updates
         # pure waste during ingest.
-        if any(stage_name in {"parse", "render", "index"} for stage_name in normalized_stage_sequence):
+        if stage_sequence_suspends_fts(stage_specs):
             from polylogue.storage.fts_lifecycle import suspend_fts_triggers_async
 
             async with active_backend.connection() as conn:
                 await suspend_fts_triggers_async(conn)
                 await conn.commit()
 
-        if stage_sequence is None:
-            if "acquire" in normalized_stage_sequence:
-                await _run_acquire_stage()
-
-            if "schema" in normalized_stage_sequence:
-                await _run_schema_stage()
-
-            if "parse" in normalized_stage_sequence:
-                await _run_parse_stage(stage)
-
-            if "materialize" in normalized_stage_sequence:
-                await _run_materialize_stage(stage)
-
-            if "render" in normalized_stage_sequence:
-                await _run_render_stage(stage)
-
-            if "site" in normalized_stage_sequence:
-                await _run_site_stage()
-
-            if "index" in normalized_stage_sequence:
-                index_outcome = await _run_index_stage(stage)
-        else:
-            for leaf_stage in normalized_stage_sequence:
-                if leaf_stage == "acquire":
-                    await _run_acquire_stage()
-                    continue
-                if leaf_stage == "schema":
-                    await _run_schema_stage()
-                    continue
-                if leaf_stage == "parse":
-                    await _run_parse_stage(_explicit_leaf_stage_context(leaf_stage))
-                    continue
-                if leaf_stage == "materialize":
-                    await _run_materialize_stage(_explicit_leaf_stage_context(leaf_stage))
-                    continue
-                if leaf_stage == "render":
-                    await _run_render_stage(_explicit_leaf_stage_context(leaf_stage))
-                    continue
-                if leaf_stage == "site":
-                    await _run_site_stage()
-                    continue
-                if leaf_stage == "index":
-                    index_outcome = await _run_index_stage(_explicit_leaf_stage_context(leaf_stage))
+        for stage_spec in stage_specs:
+            await _run_stage_spec(stage_spec)
 
         return await persist_run_result(
             config=config,

--- a/polylogue/pipeline/stage_specs.py
+++ b/polylogue/pipeline/stage_specs.py
@@ -1,0 +1,88 @@
+"""Executable pipeline stage specifications."""
+
+from __future__ import annotations
+
+from collections.abc import Collection, Sequence
+from dataclasses import dataclass
+from typing import Literal
+
+StageContextPolicy = Literal["none", "requested_or_leaf", "requested_or_all_after_parse"]
+
+
+@dataclass(frozen=True, slots=True)
+class PipelineStageSpec:
+    """Static execution facts for one pipeline leaf stage."""
+
+    name: str
+    log_stage: str
+    context_policy: StageContextPolicy = "none"
+    suspend_fts_triggers: bool = False
+    pipeline_managed: bool = True
+
+    def execution_stage(
+        self,
+        *,
+        requested_stage: str,
+        explicit_sequence: bool,
+        executed_stages: Collection[str],
+    ) -> str:
+        """Return the stage token expected by the existing stage implementation."""
+        if self.context_policy == "none":
+            return self.name
+        if not explicit_sequence:
+            return requested_stage
+        if self.context_policy == "requested_or_leaf":
+            return self.name
+        if "parse" in executed_stages:
+            return "all"
+        return self.name
+
+
+PIPELINE_STAGE_SPECS: dict[str, PipelineStageSpec] = {
+    "acquire": PipelineStageSpec(name="acquire", log_stage="acquire"),
+    "schema": PipelineStageSpec(name="schema", log_stage="schema"),
+    "parse": PipelineStageSpec(
+        name="parse",
+        log_stage="ingest",
+        context_policy="requested_or_leaf",
+        suspend_fts_triggers=True,
+    ),
+    "materialize": PipelineStageSpec(
+        name="materialize",
+        log_stage="materialize",
+        context_policy="requested_or_all_after_parse",
+    ),
+    "render": PipelineStageSpec(
+        name="render",
+        log_stage="render",
+        context_policy="requested_or_all_after_parse",
+        suspend_fts_triggers=True,
+    ),
+    "site": PipelineStageSpec(name="site", log_stage="site"),
+    "index": PipelineStageSpec(
+        name="index",
+        log_stage="index",
+        context_policy="requested_or_all_after_parse",
+        suspend_fts_triggers=True,
+    ),
+    "embed": PipelineStageSpec(name="embed", log_stage="embed", pipeline_managed=False),
+}
+
+
+def stage_specs_for_sequence(stage_sequence: Sequence[str]) -> tuple[PipelineStageSpec, ...]:
+    """Resolve normalized leaf stage names to executable stage specs."""
+    return tuple(PIPELINE_STAGE_SPECS[stage_name] for stage_name in stage_sequence)
+
+
+def stage_sequence_suspends_fts(stage_specs: Sequence[PipelineStageSpec]) -> bool:
+    """Return whether any stage in a sequence needs FTS triggers suspended."""
+    return any(stage.suspend_fts_triggers for stage in stage_specs)
+
+
+__all__ = [
+    "PIPELINE_STAGE_SPECS",
+    "PipelineStageSpec",
+    "StageContextPolicy",
+    "stage_sequence_suspends_fts",
+    "stage_specs_for_sequence",
+]

--- a/tests/unit/pipeline/test_run_sources.py
+++ b/tests/unit/pipeline/test_run_sources.py
@@ -19,10 +19,11 @@ from polylogue.pipeline.run_stages import (
     RenderStageOutcome,
     execute_materialize_stage,
 )
-from polylogue.pipeline.run_support import expand_requested_stage, normalize_stage_sequence
+from polylogue.pipeline.run_support import RUN_LEAF_STAGES, expand_requested_stage, normalize_stage_sequence
 from polylogue.pipeline.runner import _select_sources, latest_run, plan_sources, run_sources
 from polylogue.pipeline.services.parsing_models import IngestResult, ParseResult
 from polylogue.pipeline.stage_models import AcquireResult
+from polylogue.pipeline.stage_specs import PIPELINE_STAGE_SPECS, stage_sequence_suspends_fts, stage_specs_for_sequence
 from polylogue.sources.parsers.base import RawConversationData
 from polylogue.storage.backends import create_backend
 from polylogue.storage.backends.async_sqlite import SQLiteBackend
@@ -110,6 +111,20 @@ def test_expand_requested_stage_contract() -> None:
     assert expand_requested_stage("parse") == ("parse",)
     assert expand_requested_stage("reprocess") == ("parse", "materialize", "render", "index")
     assert expand_requested_stage("all") == ("acquire", "parse", "materialize", "render", "site", "index")
+
+
+def test_pipeline_stage_specs_cover_leaf_stage_vocabulary() -> None:
+    assert set(PIPELINE_STAGE_SPECS) == RUN_LEAF_STAGES
+    assert PIPELINE_STAGE_SPECS["parse"].log_stage == "ingest"
+    assert PIPELINE_STAGE_SPECS["embed"].pipeline_managed is False
+
+
+def test_stage_specs_preserve_sequence_order_and_fts_policy() -> None:
+    stage_specs = stage_specs_for_sequence(("render", "parse", "materialize", "index"))
+
+    assert [spec.name for spec in stage_specs] == ["render", "parse", "materialize", "index"]
+    assert stage_sequence_suspends_fts(stage_specs) is True
+    assert stage_sequence_suspends_fts(stage_specs_for_sequence(("acquire", "materialize", "site"))) is False
 
 
 def test_normalize_stage_sequence_rejects_duplicates() -> None:


### PR DESCRIPTION
## Summary

Adds an executable `PipelineStageSpec` catalog for pipeline leaf-stage facts and routes `run_sources()` through a single spec-driven execution loop.

## Problem

Closes #323.

`polylogue/pipeline/run_execution.py` carried stage order, explicit-sequence context, metrics labels, FTS trigger suspension, and executed-stage bookkeeping in duplicated default and explicit dispatch branches. That made stage semantics harder to inspect and created another place where future pipeline stages could drift from the normalized stage vocabulary.

## Solution

- Added `polylogue/pipeline/stage_specs.py` with the catalog of leaf-stage execution facts: log stage, context policy, FTS suspension policy, and whether the normal pipeline owns execution.
- Replaced the split default/explicit `run_sources()` dispatch with one spec-driven loop.
- Left individual stage helpers responsible only for stage bodies; the shared runner now owns context resolution and executed-stage tracking.
- Kept `embed` represented as an externally managed leaf stage because `polylogue run embed` is dispatched by the CLI before entering `run_sources()`, preserving direct `run_sources(stage="embed")` compatibility without introducing an API-key-requiring behavior change.
- Added unit coverage that the stage spec catalog covers the full leaf-stage vocabulary and preserves sequence/FTS policy; existing ordered parse/materialize/render/index tests continue to cover explicit-stage semantics.

## Verification

- `ruff check polylogue/pipeline/run_execution.py polylogue/pipeline/stage_specs.py tests/unit/pipeline/test_run_sources.py`
- `mypy polylogue/pipeline/run_execution.py polylogue/pipeline/stage_specs.py`
- `pytest -q tests/unit/pipeline/test_run_sources.py` -> `48 passed in 16.10s`
- `devtools render-all --check` -> all generated surfaces in sync
- `devtools verify` -> all checks passed
- `git push -u origin feature/refactor/pipeline-executable-stage-specs` -> pre-push `devtools verify --quick` all checks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured pipeline execution logic to improve code organization and consistency.

* **Tests**
  * Added unit tests to validate pipeline stage specifications and execution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->