### PR TITLE
feat: add product-backed resume briefs (#379)

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -128,6 +128,7 @@ Commands:
   open         Open matched conversation in browser/editor.
   products     Inspect durable archive data products.
   reset        Reset database, blob store, assets, rendered outputs, or...
+  resume       Reconstruct work-state context for a fresh agent session.
   run          Run pipeline stages on configured sources.
   schema       Inspect schema packages, versions, and evidence.
   stats        Show statistics for matched conversations.

--- a/docs/test-quality-workflows.md
+++ b/docs/test-quality-workflows.md
@@ -15,10 +15,10 @@ Current registry snapshot:
 - mutation campaigns: `19`
 - benchmark campaigns: `3`
 - synthetic benchmark campaigns: `6`
-- scenario projections: `241`
+- scenario projections: `242`
 - inferred corpus scenarios: `5`
   - benchmark-campaign: `3`
-  - exercise: `135`
+  - exercise: `136`
   - inferred-corpus-scenario: `5`
   - mutation-campaign: `19`
   - synthetic-benchmark: `6`
@@ -347,6 +347,7 @@ These are the authored scenario-bearing projections currently feeding runtime co
 | `exercise` | `help-products-week-summaries` | `week-summary-query-loop` | `day_session_summary_rows`<br>`week_session_summary_results` | `cli.help`<br>`query-week-session-summaries` | — | `generated`<br>`help`<br>`structural` | products week-summaries help |
 | `exercise` | `help-products-work-events` | `session-work-event-query-loop` | `session_work_event_rows`<br>`session_work_event_fts`<br>`session_work_event_results` | `cli.help`<br>`query-session-work-events` | — | `generated`<br>`help`<br>`structural` | products work-events help |
 | `exercise` | `help-reset` | `conversation-query-loop` | `message_fts`<br>`conversation_query_results` | `cli.help`<br>`query-conversations` | — | `generated`<br>`help`<br>`structural` | reset help |
+| `exercise` | `help-resume` | `conversation-query-loop` | `message_fts`<br>`conversation_query_results` | `cli.help`<br>`query-conversations` | — | `generated`<br>`help`<br>`structural` | resume help |
 | `exercise` | `help-run` | — | — | `cli.help` | — | `generated`<br>`help`<br>`structural` | run help |
 | `exercise` | `help-run-acquire` | `source-acquisition-loop` | `configured_sources`<br>`source_payload_stream`<br>`raw_validation_state`<br>`artifact_observation_rows` | `cli.help`<br>`acquire-raw-conversations` | — | `generated`<br>`help`<br>`structural` | run acquire help |
 | `exercise` | `help-run-all` | — | — | `cli.help` | — | `generated`<br>`help`<br>`structural` | run all help |

--- a/docs/verification-catalog.md
+++ b/docs/verification-catalog.md
@@ -8,10 +8,10 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 
 ## Snapshot
 
-- subjects: `9038`
+- subjects: `9039`
 - claims: `22`
 - runner bindings: `22`
-- proof obligations: `9123`
+- proof obligations: `9126`
 
 ## Quality Checks
 
@@ -31,7 +31,7 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | --- | ---: |
 | `archive.query_law` | 1 |
 | `artifact.path` | 27 |
-| `cli.command` | 42 |
+| `cli.command` | 43 |
 | `cli.json_command` | 2 |
 | `diagnostic.observable` | 1 |
 | `error.surface` | 2 |
@@ -72,6 +72,7 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | `polylogue products week-summaries` | `polylogue/cli/commands/products.py:92` `polylogue.cli.commands.products._make_callback.<locals>.callback` |
 | `polylogue products work-events` | `polylogue/cli/commands/products.py:92` `polylogue.cli.commands.products._make_callback.<locals>.callback` |
 | `polylogue reset` | `polylogue/cli/commands/reset.py:23` `polylogue.cli.commands.reset.reset_command` |
+| `polylogue resume` | `polylogue/cli/commands/resume.py:22` `polylogue.cli.commands.resume.resume_command` |
 | `polylogue run` | `polylogue/cli/commands/run.py:164` `polylogue.cli.commands.run.run_command` |
 | `polylogue run acquire` | `polylogue/cli/commands/run.py:357` `polylogue.cli.commands.run.run_acquire_stage` |
 | `polylogue run all` | `polylogue/cli/commands/run.py:407` `polylogue.cli.commands.run.run_all_stage` |
@@ -186,10 +187,10 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | --- | ---: |
 | `archive.query.provider_filter_consistency` | 1 |
 | `artifact.path.dependency_closure` | 11 |
-| `cli.command.help` | 42 |
+| `cli.command.help` | 43 |
 | `cli.command.json_envelope` | 2 |
-| `cli.command.no_traceback` | 42 |
-| `cli.command.plain_mode` | 42 |
+| `cli.command.no_traceback` | 43 |
+| `cli.command.plain_mode` | 43 |
 | `diagnostic.observable_trace_mapping` | 1 |
 | `error.machine_user_context` | 2 |
 | `generated.scenario.family_registered` | 9 |

--- a/polylogue/archive_resume.py
+++ b/polylogue/archive_resume.py
@@ -1,0 +1,452 @@
+"""Typed resume-brief assembly over archived conversations and products."""
+
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from typing import TYPE_CHECKING, Protocol
+
+from pydantic import Field
+
+from polylogue.archive_product_models import ArchiveProductModel
+from polylogue.archive_products import (
+    ArchiveProductUnavailableError,
+    SessionEnrichmentProduct,
+    SessionPhaseProduct,
+    SessionProfileProduct,
+    SessionWorkEventProduct,
+    WorkThreadProduct,
+    WorkThreadProductQuery,
+)
+from polylogue.lib.action_events import build_tool_calls_from_content_blocks
+from polylogue.lib.conversation_models import Conversation
+from polylogue.storage.search_query_support import normalize_fts5_query
+
+if TYPE_CHECKING:
+    from polylogue.lib.message_models import Message
+
+
+class ResumeLastMessage(ArchiveProductModel):
+    role: str
+    timestamp: str | None = None
+    preview: str = ""
+
+
+class ResumeFacts(ArchiveProductModel):
+    conversation_id: str
+    provider_name: str
+    title: str | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
+    parent_id: str | None = None
+    branch_type: str | None = None
+    message_count: int = 0
+    tags: tuple[str, ...] = ()
+    repo_paths: tuple[str, ...] = ()
+    cwd_paths: tuple[str, ...] = ()
+    branch_names: tuple[str, ...] = ()
+    file_paths_touched: tuple[str, ...] = ()
+    tool_categories: dict[str, int] = Field(default_factory=dict)
+    last_message: ResumeLastMessage | None = None
+
+
+class ResumeWorkEvent(ArchiveProductModel):
+    kind: str
+    summary: str
+    confidence: float
+    support_level: str
+
+
+class ResumePhase(ArchiveProductModel):
+    phase_index: int
+    message_range: tuple[int, int]
+    confidence: float
+    support_level: str
+
+
+class ResumeWorkThread(ArchiveProductModel):
+    thread_id: str
+    root_id: str
+    dominant_repo: str | None = None
+    session_count: int = 0
+    depth: int = 0
+    branch_count: int = 0
+    session_ids: tuple[str, ...] = ()
+
+
+class ResumeInferences(ArchiveProductModel):
+    intent_summary: str | None = None
+    outcome_summary: str | None = None
+    blockers: tuple[str, ...] = ()
+    confidence: float = 0.0
+    support_level: str = "unknown"
+    repo_names: tuple[str, ...] = ()
+    auto_tags: tuple[str, ...] = ()
+    work_events: tuple[ResumeWorkEvent, ...] = ()
+    phases: tuple[ResumePhase, ...] = ()
+    work_thread: ResumeWorkThread | None = None
+
+
+class ResumeRelatedSession(ArchiveProductModel):
+    conversation_id: str
+    relation: str
+    provider_name: str
+    title: str | None = None
+    updated_at: str | None = None
+    message_count: int = 0
+
+
+class ResumeUncertainty(ArchiveProductModel):
+    source: str
+    detail: str
+
+
+class ResumeBrief(ArchiveProductModel):
+    session_id: str
+    facts: ResumeFacts
+    inferences: ResumeInferences
+    related_sessions: tuple[ResumeRelatedSession, ...] = ()
+    uncertainties: tuple[ResumeUncertainty, ...] = ()
+    next_steps: tuple[str, ...] = ()
+
+
+class ResumeOperations(Protocol):
+    async def get_conversation(self, conversation_id: str) -> Conversation | None: ...
+
+    async def get_conversations(self, conversation_ids: list[str]) -> list[Conversation]: ...
+
+    async def get_session_tree(self, conversation_id: str) -> list[Conversation]: ...
+
+    async def get_session_profile_product(
+        self,
+        conversation_id: str,
+        *,
+        tier: str = "merged",
+    ) -> SessionProfileProduct | None: ...
+
+    async def get_session_enrichment_product(self, conversation_id: str) -> SessionEnrichmentProduct | None: ...
+
+    async def get_session_work_event_products(self, conversation_id: str) -> list[SessionWorkEventProduct]: ...
+
+    async def get_session_phase_products(self, conversation_id: str) -> list[SessionPhaseProduct]: ...
+
+    async def list_work_thread_products(
+        self,
+        query: WorkThreadProductQuery | None = None,
+    ) -> list[WorkThreadProduct]: ...
+
+
+def _iso(value: object) -> str | None:
+    isoformat = getattr(value, "isoformat", None)
+    if callable(isoformat):
+        return str(isoformat())
+    return str(value) if value is not None else None
+
+
+def _preview(text: str | None, *, limit: int = 180) -> str:
+    normalized = " ".join((text or "").split())
+    if len(normalized) <= limit:
+        return normalized
+    return normalized[: limit - 3].rstrip() + "..."
+
+
+def _metadata_tags(metadata: Mapping[str, object] | None) -> tuple[str, ...]:
+    raw = metadata.get("tags") if metadata else None
+    if not isinstance(raw, Sequence) or isinstance(raw, (str, bytes)):
+        return ()
+    return tuple(str(item) for item in raw if isinstance(item, str) and item)
+
+
+def _last_message(messages: Sequence[Message]) -> ResumeLastMessage | None:
+    if not messages:
+        return None
+    message = messages[-1]
+    return ResumeLastMessage(
+        role=str(message.role),
+        timestamp=_iso(message.timestamp),
+        preview=_preview(message.text),
+    )
+
+
+def _tool_facts(conversation: Conversation) -> tuple[dict[str, int], tuple[str, ...]]:
+    categories: Counter[str] = Counter()
+    paths: list[str] = []
+    for message in conversation.messages:
+        tool_calls = build_tool_calls_from_content_blocks(
+            provider=conversation.provider,
+            content_blocks=message.content_blocks,
+        )
+        for tool_call in tool_calls:
+            category = getattr(tool_call.category, "value", str(tool_call.category))
+            categories[str(category)] += 1
+            paths.extend(tool_call.affected_paths)
+    return dict(sorted(categories.items())), tuple(dict.fromkeys(paths))
+
+
+def _facts_from_conversation(
+    conversation: Conversation,
+    profile: SessionProfileProduct | None,
+) -> ResumeFacts:
+    messages = conversation.messages.to_list()
+    tool_categories, file_paths = _tool_facts(conversation)
+    evidence = profile.evidence if profile is not None else None
+    return ResumeFacts(
+        conversation_id=str(conversation.id),
+        provider_name=str(conversation.provider),
+        title=conversation.title,
+        created_at=_iso(conversation.created_at),
+        updated_at=_iso(conversation.updated_at),
+        parent_id=str(conversation.parent_id) if conversation.parent_id is not None else None,
+        branch_type=str(conversation.branch_type) if conversation.branch_type is not None else None,
+        message_count=len(messages),
+        tags=evidence.tags if evidence is not None else _metadata_tags(conversation.metadata),
+        repo_paths=evidence.repo_paths if evidence is not None else (),
+        cwd_paths=evidence.cwd_paths if evidence is not None else (),
+        branch_names=evidence.branch_names if evidence is not None else (),
+        file_paths_touched=evidence.file_paths_touched if evidence is not None else file_paths,
+        tool_categories=evidence.tool_categories if evidence is not None else tool_categories,
+        last_message=_last_message(messages),
+    )
+
+
+def _event_summary(events: Sequence[SessionWorkEventProduct]) -> tuple[ResumeWorkEvent, ...]:
+    return tuple(
+        ResumeWorkEvent(
+            kind=event.inference.kind,
+            summary=event.inference.summary,
+            confidence=event.inference.confidence,
+            support_level=event.inference.support_level,
+        )
+        for event in events[:5]
+    )
+
+
+def _phase_summary(phases: Sequence[SessionPhaseProduct]) -> tuple[ResumePhase, ...]:
+    return tuple(
+        ResumePhase(
+            phase_index=phase.phase_index,
+            message_range=phase.evidence.message_range,
+            confidence=phase.inference.confidence,
+            support_level=phase.inference.support_level,
+        )
+        for phase in phases[:5]
+    )
+
+
+def _work_thread_summary(thread: WorkThreadProduct | None) -> ResumeWorkThread | None:
+    if thread is None:
+        return None
+    return ResumeWorkThread(
+        thread_id=thread.thread_id,
+        root_id=thread.root_id,
+        dominant_repo=thread.dominant_repo,
+        session_count=thread.thread.session_count,
+        depth=thread.thread.depth,
+        branch_count=thread.thread.branch_count,
+        session_ids=thread.thread.session_ids,
+    )
+
+
+def _inferences(
+    *,
+    profile: SessionProfileProduct | None,
+    enrichment: SessionEnrichmentProduct | None,
+    events: Sequence[SessionWorkEventProduct],
+    phases: Sequence[SessionPhaseProduct],
+    work_thread: WorkThreadProduct | None,
+) -> ResumeInferences:
+    profile_inference = profile.inference if profile is not None else None
+    enrichment_payload = enrichment.enrichment if enrichment is not None else None
+    return ResumeInferences(
+        intent_summary=enrichment_payload.intent_summary if enrichment_payload is not None else None,
+        outcome_summary=enrichment_payload.outcome_summary if enrichment_payload is not None else None,
+        blockers=enrichment_payload.blockers if enrichment_payload is not None else (),
+        confidence=enrichment_payload.confidence if enrichment_payload is not None else 0.0,
+        support_level=enrichment_payload.support_level if enrichment_payload is not None else "unknown",
+        repo_names=profile_inference.repo_names if profile_inference is not None else (),
+        auto_tags=profile_inference.auto_tags if profile_inference is not None else (),
+        work_events=_event_summary(events),
+        phases=_phase_summary(phases),
+        work_thread=_work_thread_summary(work_thread),
+    )
+
+
+def _relation(target: Conversation, candidate: Conversation, work_thread_ids: set[str]) -> str:
+    candidate_id = str(candidate.id)
+    if target.parent_id is not None and candidate_id == str(target.parent_id):
+        return "parent"
+    if candidate.parent_id is not None and str(candidate.parent_id) == str(target.id):
+        return str(candidate.branch_type or "child")
+    if candidate_id in work_thread_ids:
+        return "work_thread"
+    return "session_tree"
+
+
+def _related_session(
+    target: Conversation,
+    candidate: Conversation,
+    work_thread_ids: set[str],
+) -> ResumeRelatedSession:
+    return ResumeRelatedSession(
+        conversation_id=str(candidate.id),
+        relation=_relation(target, candidate, work_thread_ids),
+        provider_name=str(candidate.provider),
+        title=candidate.title,
+        updated_at=_iso(candidate.updated_at or candidate.created_at),
+        message_count=len(candidate.messages),
+    )
+
+
+async def _related_sessions(
+    operations: ResumeOperations,
+    target: Conversation,
+    work_thread: WorkThreadProduct | None,
+    *,
+    related_limit: int,
+) -> tuple[ResumeRelatedSession, ...]:
+    work_thread_ids = set(work_thread.thread.session_ids if work_thread is not None else ())
+    conversations_by_id: dict[str, Conversation] = {}
+
+    for conversation in await operations.get_session_tree(str(target.id)):
+        conversations_by_id[str(conversation.id)] = conversation
+
+    missing_work_thread_ids = [session_id for session_id in work_thread_ids if session_id not in conversations_by_id]
+    if missing_work_thread_ids:
+        for conversation in await operations.get_conversations(missing_work_thread_ids):
+            conversations_by_id[str(conversation.id)] = conversation
+
+    conversations_by_id.pop(str(target.id), None)
+    related = [_related_session(target, conversation, work_thread_ids) for conversation in conversations_by_id.values()]
+    related.sort(key=lambda item: item.updated_at or "", reverse=True)
+    return tuple(related[:related_limit])
+
+
+async def _find_work_thread(
+    operations: ResumeOperations,
+    conversation_id: str,
+    uncertainties: list[ResumeUncertainty],
+) -> WorkThreadProduct | None:
+    fts_query = normalize_fts5_query(conversation_id)
+    if fts_query is not None:
+        try:
+            for candidate in await operations.list_work_thread_products(
+                WorkThreadProductQuery(query=fts_query, limit=10)
+            ):
+                if conversation_id in candidate.thread.session_ids:
+                    return candidate
+        except ArchiveProductUnavailableError:
+            pass
+
+    try:
+        candidates = await operations.list_work_thread_products(WorkThreadProductQuery(limit=None))
+    except ArchiveProductUnavailableError as exc:
+        uncertainties.append(ResumeUncertainty(source="work_thread", detail=str(exc)))
+        return None
+
+    for candidate in candidates:
+        if conversation_id in candidate.thread.session_ids:
+            return candidate
+    return None
+
+
+def _next_steps(
+    conversation: Conversation,
+    inferences: ResumeInferences,
+) -> tuple[str, ...]:
+    steps: list[str] = []
+    if inferences.blockers:
+        steps.append(f"Resolve blocker: {inferences.blockers[0]}")
+
+    last = inferences.work_events[-1] if inferences.work_events else None
+    if last is not None:
+        steps.append(f"Continue after latest work event: {last.summary}")
+
+    last_message = _last_message(conversation.messages.to_list())
+    if last_message is not None and last_message.role == "user" and last_message.preview:
+        steps.append(f"Respond to latest user request: {last_message.preview}")
+
+    if not steps and inferences.intent_summary:
+        steps.append(f"Continue intent: {inferences.intent_summary}")
+    if not steps and inferences.outcome_summary:
+        steps.append(f"Verify or close out outcome: {inferences.outcome_summary}")
+    if not steps:
+        steps.append("Review the latest archived message and continue from that state.")
+
+    return tuple(dict.fromkeys(steps[:3]))
+
+
+async def build_resume_brief(
+    operations: ResumeOperations,
+    session_id: str,
+    *,
+    related_limit: int = 6,
+) -> ResumeBrief | None:
+    """Build a compact handoff brief for one archived session."""
+    conversation = await operations.get_conversation(session_id)
+    if conversation is None:
+        return None
+
+    conversation_id = str(conversation.id)
+    uncertainties: list[ResumeUncertainty] = []
+
+    profile: SessionProfileProduct | None = None
+    try:
+        profile = await operations.get_session_profile_product(conversation_id)
+    except ArchiveProductUnavailableError as exc:
+        uncertainties.append(ResumeUncertainty(source="session_profile", detail=str(exc)))
+
+    enrichment: SessionEnrichmentProduct | None = None
+    try:
+        enrichment = await operations.get_session_enrichment_product(conversation_id)
+    except ArchiveProductUnavailableError as exc:
+        uncertainties.append(ResumeUncertainty(source="session_enrichment", detail=str(exc)))
+
+    events: list[SessionWorkEventProduct] = []
+    try:
+        events = await operations.get_session_work_event_products(conversation_id)
+    except ArchiveProductUnavailableError as exc:
+        uncertainties.append(ResumeUncertainty(source="work_events", detail=str(exc)))
+
+    phases: list[SessionPhaseProduct] = []
+    try:
+        phases = await operations.get_session_phase_products(conversation_id)
+    except ArchiveProductUnavailableError as exc:
+        uncertainties.append(ResumeUncertainty(source="phases", detail=str(exc)))
+
+    work_thread = await _find_work_thread(operations, conversation_id, uncertainties)
+    inferences = _inferences(
+        profile=profile,
+        enrichment=enrichment,
+        events=events,
+        phases=phases,
+        work_thread=work_thread,
+    )
+
+    return ResumeBrief(
+        session_id=conversation_id,
+        facts=_facts_from_conversation(conversation, profile),
+        inferences=inferences,
+        related_sessions=await _related_sessions(
+            operations,
+            conversation,
+            work_thread,
+            related_limit=related_limit,
+        ),
+        uncertainties=tuple(uncertainties),
+        next_steps=_next_steps(conversation, inferences),
+    )
+
+
+__all__ = [
+    "ResumeBrief",
+    "ResumeFacts",
+    "ResumeInferences",
+    "ResumeLastMessage",
+    "ResumeOperations",
+    "ResumePhase",
+    "ResumeRelatedSession",
+    "ResumeUncertainty",
+    "ResumeWorkEvent",
+    "ResumeWorkThread",
+    "build_resume_brief",
+]

--- a/polylogue/cli/click_command_registration.py
+++ b/polylogue/cli/click_command_registration.py
@@ -14,6 +14,7 @@ from polylogue.cli.commands.neighbors import neighbors_command
 from polylogue.cli.commands.products import products_command
 from polylogue.cli.commands.qa import qa_command
 from polylogue.cli.commands.reset import reset_command
+from polylogue.cli.commands.resume import resume_command
 from polylogue.cli.commands.run import run_command
 from polylogue.cli.commands.schema import schema_command
 from polylogue.cli.commands.tags import tags_command
@@ -28,6 +29,7 @@ ROOT_COMMANDS: tuple[click.Command, ...] = (
     dashboard_command,
     neighbors_command,
     export_command,
+    resume_command,
     products_command,
     tags_command,
     qa_command,
@@ -47,5 +49,6 @@ __all__ = [
     "export_command",
     "mcp_command",
     "neighbors_command",
+    "resume_command",
     "register_root_commands",
 ]

--- a/polylogue/cli/commands/resume.py
+++ b/polylogue/cli/commands/resume.py
@@ -1,0 +1,51 @@
+"""Resume command for reconstructing agent handoff context."""
+
+from __future__ import annotations
+
+import click
+
+from polylogue.cli.helper_support import fail
+from polylogue.cli.machine_errors import emit_success
+from polylogue.cli.product_command_contracts import find_root_params
+from polylogue.cli.resume_rendering import render_resume_brief
+from polylogue.cli.types import AppEnv
+from polylogue.sync_bridge import run_coroutine_sync
+
+
+def _wants_json(ctx: click.Context, *, json_mode: bool, output_format: str | None) -> bool:
+    if json_mode or output_format == "json":
+        return True
+    root_output = find_root_params(ctx).get("output_format")
+    return root_output == "json"
+
+
+@click.command("resume")
+@click.argument("session_id")
+@click.option("--related-limit", type=int, default=6, show_default=True, help="Maximum related sessions to include.")
+@click.option("--json", "json_mode", is_flag=True, help="Output as JSON.")
+@click.option("--format", "output_format", type=click.Choice(["json"]), default=None, help="Output format.")
+@click.pass_context
+def resume_command(
+    ctx: click.Context,
+    session_id: str,
+    related_limit: int,
+    json_mode: bool,
+    output_format: str | None,
+) -> None:
+    """Reconstruct work-state context for a fresh agent session."""
+    env: AppEnv = ctx.obj
+    brief = run_coroutine_sync(
+        env.operations.build_resume_brief(
+            session_id,
+            related_limit=related_limit,
+        )
+    )
+    if brief is None:
+        fail("resume", f"Conversation not found: {session_id}")
+    if _wants_json(ctx, json_mode=json_mode, output_format=output_format):
+        emit_success(brief.model_dump(mode="json"))
+        return
+    render_resume_brief(brief)
+
+
+__all__ = ["resume_command"]

--- a/polylogue/cli/resume_rendering.py
+++ b/polylogue/cli/resume_rendering.py
@@ -1,0 +1,83 @@
+"""Plain terminal rendering for resume briefs."""
+
+from __future__ import annotations
+
+import click
+
+from polylogue.archive_resume import ResumeBrief
+
+
+def _line(label: str, value: object | None) -> None:
+    if value is None or value == "" or value == ():
+        return
+    if isinstance(value, (list, tuple)):
+        rendered = ", ".join(str(item) for item in value)
+    elif isinstance(value, dict):
+        rendered = ", ".join(f"{key}={value[key]}" for key in sorted(value))
+    else:
+        rendered = str(value)
+    if rendered:
+        click.echo(f"  {label}: {rendered}")
+
+
+def render_resume_brief(brief: ResumeBrief) -> None:
+    """Render a concise human handoff from a typed resume brief."""
+    facts = brief.facts
+    inferences = brief.inferences
+
+    click.echo("Resume Brief")
+    click.echo(f"Session: {facts.conversation_id}")
+    _line("Title", facts.title)
+    _line("Provider", facts.provider_name)
+    _line("Updated", facts.updated_at)
+    _line("Messages", facts.message_count)
+    _line("Parent", facts.parent_id)
+    _line("Branch", facts.branch_type)
+    if facts.last_message is not None:
+        _line("Last message", f"{facts.last_message.role}: {facts.last_message.preview}")
+
+    click.echo("\nFacts")
+    _line("Tags", facts.tags)
+    _line("Repos", facts.repo_paths)
+    _line("CWDs", facts.cwd_paths)
+    _line("Branches", facts.branch_names)
+    _line("Files touched", facts.file_paths_touched[:6])
+    _line("Tool categories", facts.tool_categories)
+
+    click.echo("\nInferred State")
+    _line("Intent", inferences.intent_summary)
+    _line("Outcome", inferences.outcome_summary)
+    _line("Blockers", inferences.blockers)
+    _line("Support", inferences.support_level)
+    _line("Repo names", inferences.repo_names)
+    _line("Auto tags", inferences.auto_tags)
+    for event in inferences.work_events:
+        click.echo(f"  Work event: {event.kind} - {event.summary}")
+    for phase in inferences.phases:
+        click.echo(
+            f"  Phase {phase.phase_index}: messages {phase.message_range[0]}-{phase.message_range[1]} "
+            f"support={phase.support_level}"
+        )
+    if inferences.work_thread is not None:
+        thread = inferences.work_thread
+        click.echo(
+            f"  Work thread: {thread.thread_id} sessions={thread.session_count} repo={thread.dominant_repo or '-'}"
+        )
+
+    if brief.related_sessions:
+        click.echo("\nRelated Sessions")
+        for related in brief.related_sessions:
+            title = f" - {related.title}" if related.title else ""
+            click.echo(f"  {related.relation}: {related.conversation_id}{title}")
+
+    if brief.uncertainties:
+        click.echo("\nUncertainties")
+        for uncertainty in brief.uncertainties:
+            click.echo(f"  {uncertainty.source}: {uncertainty.detail}")
+
+    click.echo("\nNext Steps")
+    for step in brief.next_steps:
+        click.echo(f"  - {step}")
+
+
+__all__ = ["render_resume_brief"]

--- a/polylogue/facade_archive.py
+++ b/polylogue/facade_archive.py
@@ -15,6 +15,7 @@ from polylogue.archive_products import (
 from polylogue.storage.session_product_runtime import SessionProductStatusSnapshot
 
 if TYPE_CHECKING:
+    from polylogue.archive_resume import ResumeBrief
     from polylogue.config import Config
     from polylogue.lib.conversation_models import Conversation
     from polylogue.lib.filters import ConversationFilter
@@ -75,6 +76,13 @@ if TYPE_CHECKING:
             self,
             conversation_ids: Sequence[str] | None = None,
         ) -> SessionProductCounts: ...
+
+        async def build_resume_brief(
+            self,
+            session_id: str,
+            *,
+            related_limit: int = 6,
+        ) -> ResumeBrief | None: ...
 
 
 class PolylogueArchiveMixin:
@@ -178,3 +186,12 @@ class PolylogueArchiveMixin:
     ) -> SessionProductCounts:
         """Rebuild durable session-product read models."""
         return await self.operations.rebuild_session_products(conversation_ids=conversation_ids)
+
+    async def resume_brief(
+        self,
+        session_id: str,
+        *,
+        related_limit: int = 6,
+    ) -> ResumeBrief | None:
+        """Build a compact handoff brief for an archived session."""
+        return await self.operations.build_resume_brief(session_id, related_limit=related_limit)

--- a/polylogue/operations/archive.py
+++ b/polylogue/operations/archive.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from pathlib import Path
-from typing import TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING, TypeVar, cast
 
 import structlog
 
@@ -36,6 +36,7 @@ from polylogue.archive_products import (
     WorkThreadProduct,
     WorkThreadProductQuery,
 )
+from polylogue.archive_resume import ResumeBrief, ResumeOperations, build_resume_brief
 from polylogue.lib.conversation_models import ConversationSummary
 from polylogue.lib.query_spec import ConversationQuerySpec
 from polylogue.maintenance_targets import build_maintenance_target_catalog
@@ -697,7 +698,24 @@ class ArchiveMaintenanceMixin:
             )
 
 
-class ArchiveOperations(ArchiveSearchMixin, ArchiveStatsMixin, ArchiveProductMixin, ArchiveMaintenanceMixin):
+class ArchiveResumeMixin:
+    async def build_resume_brief(
+        self,
+        session_id: str,
+        *,
+        related_limit: int = 6,
+    ) -> ResumeBrief | None:
+        """Build a compact resume handoff brief for an archived session."""
+        return await build_resume_brief(cast(ResumeOperations, self), session_id, related_limit=related_limit)
+
+
+class ArchiveOperations(
+    ArchiveSearchMixin,
+    ArchiveStatsMixin,
+    ArchiveProductMixin,
+    ArchiveMaintenanceMixin,
+    ArchiveResumeMixin,
+):
     """Canonical archive-level operations over configured runtime dependencies."""
 
     def __init__(

--- a/tests/baselines/showcase/help-main.txt
+++ b/tests/baselines/showcase/help-main.txt
@@ -117,6 +117,7 @@ Commands:
   open         Open matched conversation in browser/editor.
   products     Inspect durable archive data products.
   reset        Reset database, blob store, assets, rendered outputs, or...
+  resume       Reconstruct work-state context for a fresh agent session.
   run          Run pipeline stages on configured sources.
   schema       Inspect schema packages, versions, and evidence.
   stats        Show statistics for matched conversations.

--- a/tests/baselines/showcase/help-resume.txt
+++ b/tests/baselines/showcase/help-resume.txt
@@ -1,0 +1,9 @@
+Usage: polylogue resume [OPTIONS] SESSION_ID
+
+  Reconstruct work-state context for a fresh agent session.
+
+Options:
+  --related-limit INTEGER  Maximum related sessions to include.  [default: 6]
+  --json                   Output as JSON.
+  --format [json]          Output format.
+  -h, --help               Show this message and exit.

--- a/tests/unit/cli/__snapshots__/test_terminal_snapshots.ambr
+++ b/tests/unit/cli/__snapshots__/test_terminal_snapshots.ambr
@@ -210,6 +210,7 @@
     open         Open matched conversation in browser<PATH>
     products     Inspect durable archive data products.
     reset        Reset database, blob store, assets, rendered outputs, or...
+    resume       Reconstruct work-state context for a fresh agent session.
     run          Run pipeline stages on configured sources.
     schema       Inspect schema packages, versions, and evidence.
     stats        Show statistics for matched conversations.
@@ -374,6 +375,8 @@
     products     Inspect durable archive data products.
     reset        Reset database, blob store, assets, rendered
   outputs, or...
+    resume       Reconstruct work-state context for a fresh ag
+  ent session.
     run          Run pipeline stages on configured sources.
     schema       Inspect schema packages, versions, and eviden
   ce.
@@ -494,6 +497,7 @@
     open         Open matched conversation in browser<PATH>
     products     Inspect durable archive data products.
     reset        Reset database, blob store, assets, rendered outputs, or...
+    resume       Reconstruct work-state context for a fresh agent session.
     run          Run pipeline stages on configured sources.
     schema       Inspect schema packages, versions, and evidence.
     stats        Show statistics for matched conversations.

--- a/tests/unit/cli/test_click_app.py
+++ b/tests/unit/cli/test_click_app.py
@@ -450,6 +450,7 @@ class TestCliMetadata:
             "dashboard",
             "neighbors",
             "export",
+            "resume",
             "products",
             "audit",
             "schema",

--- a/tests/unit/cli/test_resume.py
+++ b/tests/unit/cli/test_resume.py
@@ -1,0 +1,75 @@
+"""Tests for the resume command surface."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from polylogue.cli.click_app import cli
+from polylogue.storage.backends.connection import open_connection
+from polylogue.storage.session_product_rebuild import rebuild_session_products_sync
+from tests.infra.storage_records import ConversationBuilder
+
+
+def _seed_resume_session(db_path: Path) -> None:
+    (
+        ConversationBuilder(db_path, "cli-resume-root")
+        .provider("codex")
+        .title("CLI Resume")
+        .created_at("2026-04-21T09:00:00+00:00")
+        .updated_at("2026-04-21T09:30:00+00:00")
+        .add_message(
+            "u1",
+            role="user",
+            text="Add resume JSON output.",
+            timestamp="2026-04-21T09:00:00+00:00",
+        )
+        .add_message(
+            "a1",
+            role="assistant",
+            text="Implemented JSON output and ready to verify.",
+            timestamp="2026-04-21T09:25:00+00:00",
+        )
+        .save()
+    )
+    with open_connection(db_path) as conn:
+        rebuild_session_products_sync(conn)
+
+
+def test_resume_json_by_root_format(cli_workspace: dict[str, Path]) -> None:
+    _seed_resume_session(cli_workspace["db_path"])
+
+    result = CliRunner().invoke(
+        cli,
+        ["--format", "json", "resume", "cli-resume-root"],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["status"] == "ok"
+    brief = payload["result"]
+    assert brief["session_id"] == "cli-resume-root"
+    assert brief["facts"]["title"] == "CLI Resume"
+    assert set(brief) >= {"facts", "inferences", "related_sessions", "uncertainties", "next_steps"}
+
+
+def test_resume_plain_names_evidence_sections(cli_workspace: dict[str, Path]) -> None:
+    _seed_resume_session(cli_workspace["db_path"])
+
+    result = CliRunner().invoke(cli, ["resume", "cli-resume-root"], catch_exceptions=False)
+
+    assert result.exit_code == 0
+    assert "Resume Brief" in result.output
+    assert "Facts" in result.output
+    assert "Inferred State" in result.output
+    assert "Next Steps" in result.output
+
+
+def test_resume_missing_session_exits_with_clear_message(cli_workspace: dict[str, Path]) -> None:
+    result = CliRunner().invoke(cli, ["resume", "missing-session"], catch_exceptions=False)
+
+    assert result.exit_code == 1
+    assert "Conversation not found: missing-session" in str(result.exception)

--- a/tests/unit/core/test_resume.py
+++ b/tests/unit/core/test_resume.py
@@ -1,0 +1,122 @@
+"""Tests for typed resume brief construction."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from polylogue.facade import Polylogue
+from polylogue.storage.backends.connection import open_connection
+from polylogue.storage.session_product_rebuild import rebuild_session_products_sync
+from tests.infra.storage_records import ConversationBuilder
+
+
+def _seed_resume_sessions(db_path: Path) -> None:
+    (
+        ConversationBuilder(db_path, "resume-root")
+        .provider("claude-code")
+        .title("Resume Root")
+        .created_at("2026-04-20T10:00:00+00:00")
+        .updated_at("2026-04-20T10:15:00+00:00")
+        .metadata({"tags": ["issue:309"]})
+        .add_message(
+            "root-u1",
+            role="user",
+            text="Implement a resume command for fresh agents.",
+            timestamp="2026-04-20T10:00:00+00:00",
+        )
+        .add_message(
+            "root-a1",
+            role="assistant",
+            text="I will inspect command wiring and product surfaces.",
+            timestamp="2026-04-20T10:05:00+00:00",
+            provider_meta={
+                "content_blocks": [
+                    {
+                        "type": "tool_use",
+                        "tool_name": "Read",
+                        "semantic_type": "file_read",
+                        "input": {"path": "/workspace/polylogue/polylogue/cli/click_app.py"},
+                    }
+                ]
+            },
+        )
+        .save()
+    )
+    (
+        ConversationBuilder(db_path, "resume-child")
+        .provider("claude-code")
+        .title("Resume Continuation")
+        .parent_conversation("resume-root")
+        .branch_type("continuation")
+        .created_at("2026-04-20T11:00:00+00:00")
+        .updated_at("2026-04-20T11:20:00+00:00")
+        .add_message(
+            "child-u1",
+            role="user",
+            text="System crashed, continue the resume command and run focused tests.",
+            timestamp="2026-04-20T11:00:00+00:00",
+        )
+        .add_message(
+            "child-a1",
+            role="assistant",
+            text="Continuing implementation and running pytest for resume tests.",
+            timestamp="2026-04-20T11:15:00+00:00",
+            provider_meta={
+                "content_blocks": [
+                    {
+                        "type": "tool_use",
+                        "tool_name": "Bash",
+                        "semantic_type": "shell",
+                        "input": {"command": "pytest -q tests/unit/core/test_resume.py"},
+                    }
+                ]
+            },
+        )
+        .save()
+    )
+
+
+@pytest.mark.asyncio
+async def test_resume_brief_composes_products_and_related_sessions(cli_workspace: dict[str, Path]) -> None:
+    db_path = cli_workspace["db_path"]
+    _seed_resume_sessions(db_path)
+    with open_connection(db_path) as conn:
+        rebuild_session_products_sync(conn)
+
+    archive = Polylogue(archive_root=cli_workspace["archive_root"], db_path=db_path)
+    brief = await archive.resume_brief("resume-child")
+
+    assert brief is not None
+    assert brief.session_id == "resume-child"
+    assert brief.facts.parent_id == "resume-root"
+    assert brief.facts.branch_type == "continuation"
+    assert brief.facts.message_count == 2
+    assert "shell" in brief.facts.tool_categories
+    assert brief.inferences.intent_summary == "System crashed, continue the resume command and run focused tests."
+    assert brief.inferences.work_events
+    assert brief.inferences.work_thread is not None
+    assert brief.inferences.work_thread.session_count == 2
+    assert any(session.conversation_id == "resume-root" for session in brief.related_sessions)
+    assert brief.next_steps
+    assert brief.uncertainties == ()
+
+
+@pytest.mark.asyncio
+async def test_resume_brief_degrades_when_products_are_unavailable(cli_workspace: dict[str, Path]) -> None:
+    db_path = cli_workspace["db_path"]
+    _seed_resume_sessions(db_path)
+
+    archive = Polylogue(archive_root=cli_workspace["archive_root"], db_path=db_path)
+    brief = await archive.resume_brief("resume-root")
+
+    assert brief is not None
+    assert brief.facts.conversation_id == "resume-root"
+    assert brief.facts.message_count == 2
+    assert {uncertainty.source for uncertainty in brief.uncertainties} >= {
+        "session_profile",
+        "session_enrichment",
+        "work_thread",
+    }
+    assert all("session_products" in uncertainty.detail for uncertainty in brief.uncertainties)


### PR DESCRIPTION
## Summary

Adds `polylogue resume <session-id>` as a typed, product-backed handoff surface for reconstructing agent work state from an archived session. The brief combines archive facts, session-product inferences, work events, phase summaries, work-thread context, related sessions, uncertainties, and next-step hints.

## Problem

Issue #309 needs a restart/resume path that is more useful than a transcript dump. Fresh agents need stable facts and explicit inference provenance from the archive/product layers, plus clear degradation when session products have not been materialized.

## Solution

- Added `polylogue/archive_resume.py` with `ResumeBrief` models and `build_resume_brief()` assembly over conversations, session profiles, enrichments, work events, phases, and work threads.
- Exposed resume briefs through `ArchiveOperations`, `Polylogue.resume_brief()`, and the new `polylogue resume` CLI command.
- Added plain rendering plus JSON output via `--json`, command-local `--format json`, and root `--format json`.
- Included exact work-thread matching through normalized FTS plus unbounded exact fallback over stored `session_ids`, avoiding unsafe raw FTS queries and arbitrary result windows.
- Refreshed CLI reference, proof catalog, quality workflow projections, showcase baselines, and terminal snapshots.

## Verification

- `devtools verify` -> all checks passed
- `pytest -q tests/unit/core/test_resume.py tests/unit/cli/test_resume.py`
- `pytest -q tests/unit/core/test_resume.py tests/unit/cli/test_resume.py tests/unit/cli/test_click_app.py tests/unit/cli/test_terminal_snapshots.py`
- `devtools verify-showcase`
- `devtools render-all --check`
- `ruff check polylogue/archive_resume.py polylogue/cli/commands/resume.py polylogue/cli/resume_rendering.py polylogue/cli/click_command_registration.py polylogue/facade_archive.py polylogue/operations/archive.py tests/unit/core/test_resume.py tests/unit/cli/test_resume.py tests/unit/cli/test_click_app.py`
- `mypy polylogue/archive_resume.py polylogue/operations/archive.py`
- push hook: `devtools verify --quick` -> all checks passed

Closes #309


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `resume` command to reconstruct work-state context for starting fresh agent sessions, displaying conversation facts, inferred state, related sessions, and recommended next steps. Supports JSON output format.

* **Documentation**
  * Updated CLI reference and help documentation for the new `resume` command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->