### PR TITLE
feat: add product readiness status reports

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -292,6 +292,7 @@ Commands:
   enrichments     List durable probabilistic session-enrichment products.
   phases          List durable session-phase products.
   profiles        List durable session-profile products.
+  status          Report product materialization coverage and readiness.
   tags            List durable session-tag rollup products.
   threads         List durable work-thread products.
   week-summaries  List durable week-level session summary products.

--- a/docs/test-quality-workflows.md
+++ b/docs/test-quality-workflows.md
@@ -15,10 +15,10 @@ Current registry snapshot:
 - mutation campaigns: `19`
 - benchmark campaigns: `3`
 - synthetic benchmark campaigns: `6`
-- scenario projections: `242`
+- scenario projections: `243`
 - inferred corpus scenarios: `5`
   - benchmark-campaign: `3`
-  - exercise: `136`
+  - exercise: `137`
   - inferred-corpus-scenario: `5`
   - mutation-campaign: `19`
   - synthetic-benchmark: `6`
@@ -342,6 +342,7 @@ These are the authored scenario-bearing projections currently feeding runtime co
 | `exercise` | `help-products-enrichments` | `session-enrichment-query-loop` | `session_profile_rows`<br>`session_profile_enrichment_fts`<br>`session_enrichment_results` | `cli.help`<br>`query-session-enrichments` | — | `generated`<br>`help`<br>`structural` | products enrichments help |
 | `exercise` | `help-products-phases` | `session-phase-query-loop` | `session_phase_rows`<br>`session_phase_results` | `cli.help`<br>`query-session-phases` | — | `generated`<br>`help`<br>`structural` | products phases help |
 | `exercise` | `help-products-profiles` | `session-profile-query-loop` | `session_profile_rows`<br>`session_profile_merged_fts`<br>`session_profile_results` | `cli.help`<br>`query-session-profiles` | — | `generated`<br>`help`<br>`structural` | products profiles help |
+| `exercise` | `help-products-status` | `session-product-status-query-loop` | `session_product_readiness`<br>`session_product_status_results` | `cli.help`<br>`query-session-product-status` | — | `generated`<br>`help`<br>`structural` | products status help |
 | `exercise` | `help-products-tags` | `session-tag-rollup-query-loop` | `session_tag_rollup_rows`<br>`session_tag_rollup_results` | `cli.help`<br>`query-session-tag-rollups` | — | `generated`<br>`help`<br>`structural` | products tags help |
 | `exercise` | `help-products-threads` | `work-thread-query-loop` | `work_thread_rows`<br>`work_thread_fts`<br>`work_thread_results` | `cli.help`<br>`query-work-threads` | — | `generated`<br>`help`<br>`structural` | products threads help |
 | `exercise` | `help-products-week-summaries` | `week-summary-query-loop` | `day_session_summary_rows`<br>`week_session_summary_results` | `cli.help`<br>`query-week-session-summaries` | — | `generated`<br>`help`<br>`structural` | products week-summaries help |

--- a/docs/verification-catalog.md
+++ b/docs/verification-catalog.md
@@ -8,10 +8,10 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 
 ## Snapshot
 
-- subjects: `9039`
+- subjects: `9040`
 - claims: `22`
 - runner bindings: `22`
-- proof obligations: `9126`
+- proof obligations: `9129`
 
 ## Quality Checks
 
@@ -31,7 +31,7 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | --- | ---: |
 | `archive.query_law` | 1 |
 | `artifact.path` | 27 |
-| `cli.command` | 43 |
+| `cli.command` | 44 |
 | `cli.json_command` | 2 |
 | `diagnostic.observable` | 1 |
 | `error.surface` | 2 |
@@ -60,17 +60,18 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | `polylogue mcp` | `polylogue/cli/commands/mcp.py:10` `polylogue.cli.commands.mcp.mcp_command` |
 | `polylogue neighbors` | `polylogue/cli/commands/neighbors.py:42` `polylogue.cli.commands.neighbors.neighbors_command` |
 | `polylogue open` | `polylogue/cli/query_verbs.py:76` `polylogue.cli.query_verbs.open_verb` |
-| `polylogue products` | `polylogue/cli/commands/products.py:129` `polylogue.cli.commands.products.products_command` |
-| `polylogue products analytics` | `polylogue/cli/commands/products.py:92` `polylogue.cli.commands.products._make_callback.<locals>.callback` |
-| `polylogue products day-summaries` | `polylogue/cli/commands/products.py:92` `polylogue.cli.commands.products._make_callback.<locals>.callback` |
-| `polylogue products debt` | `polylogue/cli/commands/products.py:92` `polylogue.cli.commands.products._make_callback.<locals>.callback` |
-| `polylogue products enrichments` | `polylogue/cli/commands/products.py:92` `polylogue.cli.commands.products._make_callback.<locals>.callback` |
-| `polylogue products phases` | `polylogue/cli/commands/products.py:92` `polylogue.cli.commands.products._make_callback.<locals>.callback` |
-| `polylogue products profiles` | `polylogue/cli/commands/products.py:92` `polylogue.cli.commands.products._make_callback.<locals>.callback` |
-| `polylogue products tags` | `polylogue/cli/commands/products.py:92` `polylogue.cli.commands.products._make_callback.<locals>.callback` |
-| `polylogue products threads` | `polylogue/cli/commands/products.py:92` `polylogue.cli.commands.products._make_callback.<locals>.callback` |
-| `polylogue products week-summaries` | `polylogue/cli/commands/products.py:92` `polylogue.cli.commands.products._make_callback.<locals>.callback` |
-| `polylogue products work-events` | `polylogue/cli/commands/products.py:92` `polylogue.cli.commands.products._make_callback.<locals>.callback` |
+| `polylogue products` | `polylogue/cli/commands/products.py:132` `polylogue.cli.commands.products.products_command` |
+| `polylogue products analytics` | `polylogue/cli/commands/products.py:95` `polylogue.cli.commands.products._make_callback.<locals>.callback` |
+| `polylogue products day-summaries` | `polylogue/cli/commands/products.py:95` `polylogue.cli.commands.products._make_callback.<locals>.callback` |
+| `polylogue products debt` | `polylogue/cli/commands/products.py:95` `polylogue.cli.commands.products._make_callback.<locals>.callback` |
+| `polylogue products enrichments` | `polylogue/cli/commands/products.py:95` `polylogue.cli.commands.products._make_callback.<locals>.callback` |
+| `polylogue products phases` | `polylogue/cli/commands/products.py:95` `polylogue.cli.commands.products._make_callback.<locals>.callback` |
+| `polylogue products profiles` | `polylogue/cli/commands/products.py:95` `polylogue.cli.commands.products._make_callback.<locals>.callback` |
+| `polylogue products status` | `polylogue/cli/commands/products.py:174` `polylogue.cli.commands.products.products_status_command` |
+| `polylogue products tags` | `polylogue/cli/commands/products.py:95` `polylogue.cli.commands.products._make_callback.<locals>.callback` |
+| `polylogue products threads` | `polylogue/cli/commands/products.py:95` `polylogue.cli.commands.products._make_callback.<locals>.callback` |
+| `polylogue products week-summaries` | `polylogue/cli/commands/products.py:95` `polylogue.cli.commands.products._make_callback.<locals>.callback` |
+| `polylogue products work-events` | `polylogue/cli/commands/products.py:95` `polylogue.cli.commands.products._make_callback.<locals>.callback` |
 | `polylogue reset` | `polylogue/cli/commands/reset.py:23` `polylogue.cli.commands.reset.reset_command` |
 | `polylogue resume` | `polylogue/cli/commands/resume.py:22` `polylogue.cli.commands.resume.resume_command` |
 | `polylogue run` | `polylogue/cli/commands/run.py:164` `polylogue.cli.commands.run.run_command` |
@@ -187,10 +188,10 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | --- | ---: |
 | `archive.query.provider_filter_consistency` | 1 |
 | `artifact.path.dependency_closure` | 11 |
-| `cli.command.help` | 43 |
+| `cli.command.help` | 44 |
 | `cli.command.json_envelope` | 2 |
-| `cli.command.no_traceback` | 43 |
-| `cli.command.plain_mode` | 43 |
+| `cli.command.no_traceback` | 44 |
+| `cli.command.plain_mode` | 44 |
 | `diagnostic.observable_trace_mapping` | 1 |
 | `error.machine_user_context` | 2 |
 | `generated.scenario.family_registered` | 9 |

--- a/polylogue/cli/commands/products.py
+++ b/polylogue/cli/commands/products.py
@@ -13,8 +13,10 @@ import click
 
 from polylogue.archive_products import ArchiveProductUnavailableError
 from polylogue.cli.helper_support import fail
+from polylogue.cli.machine_errors import emit_success
 from polylogue.cli.product_command_contracts import ProductCommandRequest, query_model_field_names
 from polylogue.cli.types import AppEnv
+from polylogue.product_readiness import ProductReadinessQuery, ProductReadinessReport, known_product_readiness_names
 from polylogue.products.registry import (
     PRODUCT_REGISTRY,
     ProductQueryError,
@@ -22,6 +24,7 @@ from polylogue.products.registry import (
     fetch_products,
     render_product_items,
 )
+from polylogue.sync_bridge import run_coroutine_sync
 
 _ROOT_FILTER_KEYS = ("provider", "since", "until")
 
@@ -129,6 +132,83 @@ def _build_product_command(pt: ProductType) -> click.Command:
 @click.group("products")
 def products_command() -> None:
     """Inspect durable archive data products."""
+
+
+def _status_wants_json(ctx: click.Context, *, json_mode: bool, output_format: str | None) -> bool:
+    if json_mode or output_format == "json":
+        return True
+    root_output = ctx.find_root().params.get("output_format")
+    return root_output == "json"
+
+
+def _render_status_plain(report: ProductReadinessReport) -> None:
+    click.echo(f"Product Readiness: {report.aggregate_verdict}")
+    click.echo(f"Total conversations: {report.total_conversations}")
+    if report.provider or report.since or report.until:
+        click.echo(f"Scope: provider={report.provider or '-'} since={report.since or '-'} until={report.until or '-'}")
+    click.echo("")
+    for product in report.products:
+        expected = f" expected={product.expected_row_count}" if product.expected_row_count is not None else ""
+        click.echo(f"{product.product_name}: {product.verdict} rows={product.row_count}{expected}")
+        if product.missing_count or product.stale_count or product.orphan_count or product.legacy_incompatible_count:
+            click.echo(
+                "  "
+                f"missing={product.missing_count} stale={product.stale_count} "
+                f"orphan={product.orphan_count} legacy={product.legacy_incompatible_count}"
+            )
+        if product.ready_flags:
+            flags = ", ".join(f"{key}={value}" for key, value in sorted(product.ready_flags.items()))
+            click.echo(f"  flags: {flags}")
+        if product.provider_coverage:
+            providers = ", ".join(
+                f"{coverage.provider_name}={coverage.row_count}" for coverage in product.provider_coverage
+            )
+            click.echo(f"  providers: {providers}")
+        if product.version_coverage:
+            versions = ", ".join(f"{coverage.field}={dict(coverage.versions)}" for coverage in product.version_coverage)
+            click.echo(f"  versions: {versions}")
+        if product.schema_contract_issues:
+            click.echo(f"  schema: {', '.join(product.schema_contract_issues)}")
+
+
+@products_command.command("status")
+@click.option("--product", "products", multiple=True, help="Product readiness target. May be repeated.")
+@click.option("--provider", default=None, help="Limit provider coverage details to one provider.")
+@click.option("--since", default=None, help="Limit coverage details to rows at/after this timestamp or date.")
+@click.option("--until", default=None, help="Limit coverage details to rows at/before this timestamp or date.")
+@click.option("--json", "json_mode", is_flag=True, help="Output as JSON.")
+@click.option("--format", "output_format", type=click.Choice(["json"]), default=None, help="Output format.")
+@click.pass_context
+def products_status_command(
+    ctx: click.Context,
+    products: tuple[str, ...],
+    provider: str | None,
+    since: str | None,
+    until: str | None,
+    json_mode: bool,
+    output_format: str | None,
+) -> None:
+    """Report product materialization coverage and readiness."""
+    env: AppEnv = ctx.obj
+    root_params = ctx.find_root().params
+    inherited_provider = provider if provider is not None else root_params.get("provider")
+    inherited_since = since if since is not None else root_params.get("since")
+    inherited_until = until if until is not None else root_params.get("until")
+    try:
+        query = ProductReadinessQuery(
+            products=products,
+            provider=str(inherited_provider) if inherited_provider is not None else None,
+            since=str(inherited_since) if inherited_since is not None else None,
+            until=str(inherited_until) if inherited_until is not None else None,
+        )
+        report = run_coroutine_sync(env.operations.get_product_readiness_report(query))
+    except ValueError as exc:
+        valid = ", ".join(known_product_readiness_names())
+        fail("products status", f"{exc}. Known products: {valid}")
+    if _status_wants_json(ctx, json_mode=json_mode, output_format=output_format):
+        emit_success(report.model_dump(mode="json"))
+        return
+    _render_status_plain(report)
 
 
 # Register all product types as subcommands

--- a/polylogue/facade_archive.py
+++ b/polylogue/facade_archive.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
     from polylogue.lib.conversation_models import Conversation
     from polylogue.lib.filters import ConversationFilter
     from polylogue.operations import ArchiveStats
+    from polylogue.product_readiness import ProductReadinessQuery, ProductReadinessReport
     from polylogue.readiness import ReadinessReport
     from polylogue.storage.repository import ConversationRepository
     from polylogue.storage.search_models import SearchResult
@@ -83,6 +84,11 @@ if TYPE_CHECKING:
             *,
             related_limit: int = 6,
         ) -> ResumeBrief | None: ...
+
+        async def get_product_readiness_report(
+            self,
+            query: ProductReadinessQuery | None = None,
+        ) -> ProductReadinessReport: ...
 
 
 class PolylogueArchiveMixin:
@@ -195,3 +201,10 @@ class PolylogueArchiveMixin:
     ) -> ResumeBrief | None:
         """Build a compact handoff brief for an archived session."""
         return await self.operations.build_resume_brief(session_id, related_limit=related_limit)
+
+    async def product_readiness_report(
+        self,
+        query: ProductReadinessQuery | None = None,
+    ) -> ProductReadinessReport:
+        """Return product materialization readiness for downstream consumers."""
+        return await self.operations.get_product_readiness_report(query)

--- a/polylogue/operations/archive.py
+++ b/polylogue/operations/archive.py
@@ -41,6 +41,11 @@ from polylogue.lib.conversation_models import ConversationSummary
 from polylogue.lib.query_spec import ConversationQuerySpec
 from polylogue.maintenance_targets import build_maintenance_target_catalog
 from polylogue.paths.sanitize import conversation_render_root
+from polylogue.product_readiness import (
+    ProductReadinessQuery,
+    ProductReadinessReport,
+    build_product_readiness_report,
+)
 from polylogue.services import RuntimeServices, build_runtime_services
 from polylogue.storage.backends.connection import connection_context
 from polylogue.storage.backends.queries.stats import ProviderMetricsRow
@@ -645,6 +650,14 @@ class ArchiveProductAggregateMixin:
         if request.provider:
             products = [product for product in products if product.provider_name == request.provider]
         return _slice_products(products, offset=request.offset, limit=request.limit)
+
+    async def get_product_readiness_report(
+        self,
+        query: ProductReadinessQuery | None = None,
+    ) -> ProductReadinessReport:
+        status = await _read_session_product_status(self.backend)
+        async with self.backend.connection() as conn:
+            return await build_product_readiness_report(conn, status, query)
 
 
 class ArchiveProductDebtMixin:

--- a/polylogue/product_readiness.py
+++ b/polylogue/product_readiness.py
@@ -1,0 +1,569 @@
+"""Typed product materialization readiness reports."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Literal
+
+import aiosqlite
+from pydantic import Field
+
+from polylogue.archive_product_models import ARCHIVE_PRODUCT_CONTRACT_VERSION, ArchiveProductModel
+from polylogue.maintenance_targets import build_maintenance_target_catalog
+from polylogue.storage.session_product_runtime import SessionProductStatusSnapshot
+from polylogue.storage.store_constants import (
+    SESSION_ENRICHMENT_VERSION,
+    SESSION_INFERENCE_VERSION,
+    SESSION_PRODUCT_MATERIALIZER_VERSION,
+)
+
+ProductReadinessVerdict = Literal["ready", "partial", "empty", "missing", "stale", "legacy", "unknown"]
+_REPAIR_HINT = build_maintenance_target_catalog().repair_hint(("session_products",), include_run_all=True)
+
+
+class ProductReadinessQuery(ArchiveProductModel):
+    products: tuple[str, ...] = ()
+    provider: str | None = None
+    since: str | None = None
+    until: str | None = None
+
+
+class ProductStorageArtifact(ArchiveProductModel):
+    name: str
+    present: bool
+    ready: bool | None = None
+
+
+class ProductVersionCoverage(ArchiveProductModel):
+    field: str
+    current_version: int
+    versions: dict[str, int] = Field(default_factory=dict)
+    legacy_count: int = 0
+
+
+class ProductProviderCoverage(ArchiveProductModel):
+    provider_name: str
+    row_count: int
+    min_time: str | None = None
+    max_time: str | None = None
+
+
+class ProductReadinessEntry(ArchiveProductModel):
+    product_name: str
+    display_name: str
+    contract_version: int = ARCHIVE_PRODUCT_CONTRACT_VERSION
+    verdict: ProductReadinessVerdict = "unknown"
+    row_count: int = 0
+    expected_row_count: int | None = None
+    missing_count: int = 0
+    stale_count: int = 0
+    orphan_count: int = 0
+    legacy_incompatible_count: int = 0
+    storage_artifacts: tuple[ProductStorageArtifact, ...] = ()
+    ready_flags: dict[str, bool] = Field(default_factory=dict)
+    provider_coverage: tuple[ProductProviderCoverage, ...] = ()
+    version_coverage: tuple[ProductVersionCoverage, ...] = ()
+    schema_contract_issues: tuple[str, ...] = ()
+    min_time: str | None = None
+    max_time: str | None = None
+    repair_command: str = _REPAIR_HINT
+    evidence: tuple[str, ...] = ()
+
+
+class ProductReadinessReport(ArchiveProductModel):
+    checked_at: str
+    aggregate_verdict: ProductReadinessVerdict
+    total_conversations: int = 0
+    provider: str | None = None
+    since: str | None = None
+    until: str | None = None
+    products: tuple[ProductReadinessEntry, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class ProductReadinessSpec:
+    product_name: str
+    display_name: str
+    table_name: str | None
+    row_count_attr: str
+    expected_count_attr: str | None = None
+    missing_count_attr: str | None = None
+    stale_count_attr: str | None = None
+    orphan_count_attr: str | None = None
+    ready_flags: tuple[str, ...] = ()
+    artifacts: tuple[str, ...] = ()
+    provider_column: str | None = "provider_name"
+    time_column: str | None = "source_updated_at"
+    version_fields: tuple[tuple[str, int], ...] = (("materializer_version", SESSION_PRODUCT_MATERIALIZER_VERSION),)
+
+
+_SPECS: tuple[ProductReadinessSpec, ...] = (
+    ProductReadinessSpec(
+        product_name="session_profiles",
+        display_name="Session Profiles",
+        table_name="session_profiles",
+        row_count_attr="profile_row_count",
+        expected_count_attr="total_conversations",
+        missing_count_attr="missing_profile_row_count",
+        stale_count_attr="stale_profile_row_count",
+        orphan_count_attr="orphan_profile_row_count",
+        ready_flags=(
+            "profile_rows_ready",
+            "profile_merged_fts_ready",
+            "profile_evidence_fts_ready",
+            "profile_inference_fts_ready",
+        ),
+        artifacts=(
+            "session_profiles",
+            "session_profiles_fts",
+            "session_profile_evidence_fts",
+            "session_profile_inference_fts",
+        ),
+        time_column="source_updated_at",
+        version_fields=(
+            ("materializer_version", SESSION_PRODUCT_MATERIALIZER_VERSION),
+            ("inference_version", SESSION_INFERENCE_VERSION),
+        ),
+    ),
+    ProductReadinessSpec(
+        product_name="session_enrichments",
+        display_name="Session Enrichments",
+        table_name="session_profiles",
+        row_count_attr="profile_row_count",
+        expected_count_attr="total_conversations",
+        missing_count_attr="missing_profile_row_count",
+        stale_count_attr="stale_profile_row_count",
+        orphan_count_attr="orphan_profile_row_count",
+        ready_flags=("profile_rows_ready", "profile_enrichment_fts_ready"),
+        artifacts=("session_profiles", "session_profile_enrichment_fts"),
+        time_column="source_updated_at",
+        version_fields=(
+            ("materializer_version", SESSION_PRODUCT_MATERIALIZER_VERSION),
+            ("enrichment_version", SESSION_ENRICHMENT_VERSION),
+        ),
+    ),
+    ProductReadinessSpec(
+        product_name="session_work_events",
+        display_name="Work Events",
+        table_name="session_work_events",
+        row_count_attr="work_event_inference_count",
+        expected_count_attr="expected_work_event_inference_count",
+        stale_count_attr="stale_work_event_inference_count",
+        orphan_count_attr="orphan_work_event_inference_count",
+        ready_flags=("work_event_inference_rows_ready", "work_event_inference_fts_ready"),
+        artifacts=("session_work_events", "session_work_events_fts"),
+        time_column="start_time",
+        version_fields=(
+            ("materializer_version", SESSION_PRODUCT_MATERIALIZER_VERSION),
+            ("inference_version", SESSION_INFERENCE_VERSION),
+        ),
+    ),
+    ProductReadinessSpec(
+        product_name="session_phases",
+        display_name="Session Phases",
+        table_name="session_phases",
+        row_count_attr="phase_inference_count",
+        expected_count_attr="expected_phase_inference_count",
+        stale_count_attr="stale_phase_inference_count",
+        orphan_count_attr="orphan_phase_inference_count",
+        ready_flags=("phase_inference_rows_ready",),
+        artifacts=("session_phases",),
+        time_column="start_time",
+        version_fields=(
+            ("materializer_version", SESSION_PRODUCT_MATERIALIZER_VERSION),
+            ("inference_version", SESSION_INFERENCE_VERSION),
+        ),
+    ),
+    ProductReadinessSpec(
+        product_name="work_threads",
+        display_name="Work Threads",
+        table_name="work_threads",
+        row_count_attr="thread_count",
+        expected_count_attr="root_threads",
+        stale_count_attr="stale_thread_count",
+        orphan_count_attr="orphan_thread_count",
+        ready_flags=("threads_ready", "threads_fts_ready"),
+        artifacts=("work_threads", "work_threads_fts"),
+        provider_column=None,
+        time_column="end_time",
+    ),
+    ProductReadinessSpec(
+        product_name="session_tag_rollups",
+        display_name="Session Tag Rollups",
+        table_name="session_tag_rollups",
+        row_count_attr="tag_rollup_count",
+        expected_count_attr="expected_tag_rollup_count",
+        stale_count_attr="stale_tag_rollup_count",
+        ready_flags=("tag_rollups_ready",),
+        artifacts=("session_tag_rollups",),
+        time_column="bucket_day",
+    ),
+    ProductReadinessSpec(
+        product_name="day_session_summaries",
+        display_name="Day Session Summaries",
+        table_name="day_session_summaries",
+        row_count_attr="day_summary_count",
+        expected_count_attr="expected_day_summary_count",
+        stale_count_attr="stale_day_summary_count",
+        ready_flags=("day_summaries_ready",),
+        artifacts=("day_session_summaries",),
+        time_column="day",
+    ),
+    ProductReadinessSpec(
+        product_name="week_session_summaries",
+        display_name="Week Session Summaries",
+        table_name="day_session_summaries",
+        row_count_attr="day_summary_count",
+        expected_count_attr="expected_day_summary_count",
+        stale_count_attr="stale_day_summary_count",
+        ready_flags=("week_summaries_ready",),
+        artifacts=("day_session_summaries",),
+        time_column="day",
+    ),
+    ProductReadinessSpec(
+        product_name="provider_analytics",
+        display_name="Provider Analytics",
+        table_name="conversations",
+        row_count_attr="total_conversations",
+        ready_flags=(),
+        artifacts=("conversations",),
+        provider_column="provider_name",
+        time_column="updated_at",
+        version_fields=(),
+    ),
+)
+
+_SPEC_BY_NAME = {spec.product_name: spec for spec in _SPECS}
+_ALIASES = {
+    **{spec.product_name.replace("_", "-"): spec.product_name for spec in _SPECS},
+    "profiles": "session_profiles",
+    "enrichments": "session_enrichments",
+    "work-events": "session_work_events",
+    "phases": "session_phases",
+    "threads": "work_threads",
+    "tags": "session_tag_rollups",
+    "day-summaries": "day_session_summaries",
+    "week-summaries": "week_session_summaries",
+    "analytics": "provider_analytics",
+}
+
+
+def known_product_readiness_names() -> tuple[str, ...]:
+    return tuple(spec.product_name for spec in _SPECS)
+
+
+def normalize_product_readiness_name(value: str) -> str:
+    normalized = value.strip().replace("-", "_")
+    if normalized in _SPEC_BY_NAME:
+        return normalized
+    alias = _ALIASES.get(value.strip()) or _ALIASES.get(value.strip().replace("_", "-"))
+    if alias is not None:
+        return alias
+    raise ValueError(f"Unknown product readiness target: {value}")
+
+
+def _count(status: SessionProductStatusSnapshot, attr: str | None) -> int:
+    if attr is None:
+        return 0
+    return int(getattr(status, attr))
+
+
+def _artifact_ready(status: SessionProductStatusSnapshot, artifact_name: str) -> bool | None:
+    mapping = {
+        "session_profiles": "profile_rows_ready",
+        "session_profiles_fts": "profile_merged_fts_ready",
+        "session_profile_evidence_fts": "profile_evidence_fts_ready",
+        "session_profile_inference_fts": "profile_inference_fts_ready",
+        "session_profile_enrichment_fts": "profile_enrichment_fts_ready",
+        "session_work_events": "work_event_inference_rows_ready",
+        "session_work_events_fts": "work_event_inference_fts_ready",
+        "session_phases": "phase_inference_rows_ready",
+        "work_threads": "threads_ready",
+        "work_threads_fts": "threads_fts_ready",
+        "session_tag_rollups": "tag_rollups_ready",
+        "day_session_summaries": "day_summaries_ready",
+    }
+    attr = mapping.get(artifact_name)
+    return bool(getattr(status, attr)) if attr is not None else None
+
+
+def _entry_verdict(
+    *,
+    table_present: bool,
+    row_count: int,
+    expected_row_count: int | None,
+    missing_count: int,
+    stale_count: int,
+    orphan_count: int,
+    legacy_count: int,
+    ready_flags: dict[str, bool],
+) -> ProductReadinessVerdict:
+    if not table_present:
+        return "missing"
+    if legacy_count:
+        return "legacy"
+    if stale_count or orphan_count:
+        return "stale"
+    if missing_count or (expected_row_count is not None and row_count < expected_row_count):
+        return "partial"
+    if row_count == 0:
+        return "empty"
+    if ready_flags and all(ready_flags.values()):
+        return "ready"
+    if not ready_flags:
+        return "ready"
+    return "unknown"
+
+
+def _aggregate_verdict(entries: tuple[ProductReadinessEntry, ...]) -> ProductReadinessVerdict:
+    verdicts = {entry.verdict for entry in entries}
+    priority: tuple[ProductReadinessVerdict, ...] = ("legacy", "stale", "partial", "missing", "unknown", "empty")
+    for verdict in priority:
+        if verdict in verdicts:
+            return verdict
+    return "ready"
+
+
+async def _table_exists(conn: aiosqlite.Connection, table: str) -> bool:
+    row = await (
+        await conn.execute("SELECT name FROM sqlite_master WHERE type='table' AND name = ?", (table,))
+    ).fetchone()
+    return bool(row)
+
+
+async def _table_columns(conn: aiosqlite.Connection, table: str) -> set[str]:
+    rows = await (await conn.execute(f"PRAGMA table_info({table})")).fetchall()
+    return {str(row[1]) for row in rows}
+
+
+def _where_clause(
+    spec: ProductReadinessSpec,
+    query: ProductReadinessQuery,
+    columns: set[str],
+) -> tuple[str, list[object]]:
+    clauses: list[str] = []
+    params: list[object] = []
+    if query.provider and spec.provider_column and spec.provider_column in columns:
+        clauses.append(f"{spec.provider_column} = ?")
+        params.append(query.provider)
+    if query.since and spec.time_column and spec.time_column in columns:
+        clauses.append(f"{spec.time_column} >= ?")
+        params.append(query.since)
+    if query.until and spec.time_column and spec.time_column in columns:
+        clauses.append(f"{spec.time_column} <= ?")
+        params.append(query.until)
+    return (" WHERE " + " AND ".join(clauses), params) if clauses else ("", params)
+
+
+async def _provider_coverage(
+    conn: aiosqlite.Connection,
+    spec: ProductReadinessSpec,
+    query: ProductReadinessQuery,
+    *,
+    table_present: bool,
+    columns: set[str],
+) -> tuple[ProductProviderCoverage, ...]:
+    if (
+        not table_present
+        or spec.table_name is None
+        or spec.provider_column is None
+        or spec.provider_column not in columns
+    ):
+        return ()
+    where, params = _where_clause(spec, query, columns)
+    time_min = f"MIN({spec.time_column})" if spec.time_column and spec.time_column in columns else "NULL"
+    time_max = f"MAX({spec.time_column})" if spec.time_column and spec.time_column in columns else "NULL"
+    sql = (
+        f"SELECT {spec.provider_column} AS provider_name, COUNT(*) AS row_count, "
+        f"{time_min} AS min_time, {time_max} AS max_time "
+        f"FROM {spec.table_name}{where} GROUP BY {spec.provider_column} ORDER BY {spec.provider_column}"
+    )
+    rows = await (await conn.execute(sql, tuple(params))).fetchall()
+    return tuple(
+        ProductProviderCoverage(
+            provider_name=str(row["provider_name"] or "unknown"),
+            row_count=int(row["row_count"]),
+            min_time=str(row["min_time"]) if row["min_time"] is not None else None,
+            max_time=str(row["max_time"]) if row["max_time"] is not None else None,
+        )
+        for row in rows
+    )
+
+
+async def _version_coverage(
+    conn: aiosqlite.Connection,
+    spec: ProductReadinessSpec,
+    *,
+    table_present: bool,
+    columns: set[str],
+) -> tuple[ProductVersionCoverage, ...]:
+    if not table_present or spec.table_name is None or not spec.version_fields:
+        return ()
+    coverage: list[ProductVersionCoverage] = []
+    for field, current_version in spec.version_fields:
+        if field not in columns:
+            continue
+        rows = await (
+            await conn.execute(
+                f"SELECT {field} AS version, COUNT(*) AS row_count FROM {spec.table_name} GROUP BY {field}"
+            )
+        ).fetchall()
+        versions = {str(row["version"]): int(row["row_count"]) for row in rows}
+        legacy_count = sum(count for version, count in versions.items() if version != str(current_version))
+        coverage.append(
+            ProductVersionCoverage(
+                field=field,
+                current_version=current_version,
+                versions=versions,
+                legacy_count=legacy_count,
+            )
+        )
+    return tuple(coverage)
+
+
+def _schema_contract_issues(spec: ProductReadinessSpec, columns: set[str]) -> tuple[str, ...]:
+    issues: list[str] = []
+    if spec.provider_column is not None and spec.provider_column not in columns:
+        issues.append(f"missing provider column: {spec.provider_column}")
+    if spec.time_column is not None and spec.time_column not in columns:
+        issues.append(f"missing time column: {spec.time_column}")
+    for field, _current_version in spec.version_fields:
+        if field not in columns:
+            issues.append(f"missing version field: {field}")
+    return tuple(issues)
+
+
+def _evidence(
+    *,
+    row_count: int,
+    expected_row_count: int | None,
+    missing_count: int,
+    stale_count: int,
+    orphan_count: int,
+    legacy_count: int,
+    schema_contract_issues: tuple[str, ...],
+    ready_flags: dict[str, bool],
+) -> tuple[str, ...]:
+    values = [f"rows={row_count}"]
+    if expected_row_count is not None:
+        values.append(f"expected={expected_row_count}")
+    if missing_count:
+        values.append(f"missing={missing_count}")
+    if stale_count:
+        values.append(f"stale={stale_count}")
+    if orphan_count:
+        values.append(f"orphan={orphan_count}")
+    if legacy_count:
+        values.append(f"legacy={legacy_count}")
+    values.extend(f"schema_issue={issue}" for issue in schema_contract_issues)
+    values.extend(f"{key}={value}" for key, value in sorted(ready_flags.items()))
+    return tuple(values)
+
+
+async def _entry(
+    conn: aiosqlite.Connection,
+    status: SessionProductStatusSnapshot,
+    spec: ProductReadinessSpec,
+    query: ProductReadinessQuery,
+) -> ProductReadinessEntry:
+    table_present = bool(spec.table_name and await _table_exists(conn, spec.table_name))
+    row_count = _count(status, spec.row_count_attr)
+    expected_row_count = _count(status, spec.expected_count_attr) if spec.expected_count_attr is not None else None
+    missing_count = _count(status, spec.missing_count_attr)
+    stale_count = _count(status, spec.stale_count_attr)
+    orphan_count = _count(status, spec.orphan_count_attr)
+    ready_flags = {flag: bool(getattr(status, flag)) for flag in spec.ready_flags}
+    columns = await _table_columns(conn, spec.table_name) if table_present and spec.table_name is not None else set()
+    schema_contract_issues = _schema_contract_issues(spec, columns) if table_present else ()
+    version_coverage = await _version_coverage(conn, spec, table_present=table_present, columns=columns)
+    version_legacy_count = sum(version.legacy_count for version in version_coverage)
+    schema_legacy_count = row_count if schema_contract_issues else 0
+    legacy_count = max(version_legacy_count, schema_legacy_count)
+    provider_coverage = await _provider_coverage(conn, spec, query, table_present=table_present, columns=columns)
+    artifacts: list[ProductStorageArtifact] = []
+    for artifact in spec.artifacts:
+        artifacts.append(
+            ProductStorageArtifact(
+                name=artifact,
+                present=await _table_exists(conn, artifact),
+                ready=_artifact_ready(status, artifact),
+            )
+        )
+    min_time = min((item.min_time for item in provider_coverage if item.min_time), default=None)
+    max_time = max((item.max_time for item in provider_coverage if item.max_time), default=None)
+    verdict = _entry_verdict(
+        table_present=table_present,
+        row_count=row_count,
+        expected_row_count=expected_row_count,
+        missing_count=missing_count,
+        stale_count=stale_count,
+        orphan_count=orphan_count,
+        legacy_count=legacy_count,
+        ready_flags=ready_flags,
+    )
+    return ProductReadinessEntry(
+        product_name=spec.product_name,
+        display_name=spec.display_name,
+        verdict=verdict,
+        row_count=row_count,
+        expected_row_count=expected_row_count,
+        missing_count=missing_count,
+        stale_count=stale_count,
+        orphan_count=orphan_count,
+        legacy_incompatible_count=legacy_count,
+        storage_artifacts=tuple(artifacts),
+        ready_flags=ready_flags,
+        provider_coverage=provider_coverage,
+        version_coverage=version_coverage,
+        schema_contract_issues=schema_contract_issues,
+        min_time=min_time,
+        max_time=max_time,
+        evidence=_evidence(
+            row_count=row_count,
+            expected_row_count=expected_row_count,
+            missing_count=missing_count,
+            stale_count=stale_count,
+            orphan_count=orphan_count,
+            legacy_count=legacy_count,
+            schema_contract_issues=schema_contract_issues,
+            ready_flags=ready_flags,
+        ),
+    )
+
+
+async def build_product_readiness_report(
+    conn: aiosqlite.Connection,
+    status: SessionProductStatusSnapshot,
+    query: ProductReadinessQuery | None = None,
+) -> ProductReadinessReport:
+    request = query or ProductReadinessQuery()
+    selected = tuple(normalize_product_readiness_name(product) for product in request.products)
+    specs = tuple(_SPEC_BY_NAME[name] for name in selected) if selected else _SPECS
+    entries: list[ProductReadinessEntry] = []
+    for spec in specs:
+        entries.append(await _entry(conn, status, spec, request))
+    products = tuple(entries)
+    return ProductReadinessReport(
+        checked_at=datetime.now(timezone.utc).isoformat(),
+        aggregate_verdict=_aggregate_verdict(products),
+        total_conversations=status.total_conversations,
+        provider=request.provider,
+        since=request.since,
+        until=request.until,
+        products=products,
+    )
+
+
+__all__ = [
+    "ProductProviderCoverage",
+    "ProductReadinessEntry",
+    "ProductReadinessQuery",
+    "ProductReadinessReport",
+    "ProductReadinessVerdict",
+    "ProductStorageArtifact",
+    "ProductVersionCoverage",
+    "build_product_readiness_report",
+    "known_product_readiness_names",
+    "normalize_product_readiness_name",
+]

--- a/tests/baselines/showcase/help-products-status.txt
+++ b/tests/baselines/showcase/help-products-status.txt
@@ -1,0 +1,14 @@
+Usage: polylogue products status [OPTIONS]
+
+  Report product materialization coverage and readiness.
+
+Options:
+  --product TEXT   Product readiness target. May be repeated.
+  --provider TEXT  Limit provider coverage details to one provider.
+  --since TEXT     Limit coverage details to rows at/after this timestamp or
+                   date.
+  --until TEXT     Limit coverage details to rows at/before this timestamp or
+                   date.
+  --json           Output as JSON.
+  --format [json]  Output format.
+  -h, --help       Show this message and exit.

--- a/tests/baselines/showcase/help-products.txt
+++ b/tests/baselines/showcase/help-products.txt
@@ -12,6 +12,7 @@ Commands:
   enrichments     List durable probabilistic session-enrichment products.
   phases          List durable session-phase products.
   profiles        List durable session-profile products.
+  status          Report product materialization coverage and readiness.
   tags            List durable session-tag rollup products.
   threads         List durable work-thread products.
   week-summaries  List durable week-level session summary products.

--- a/tests/unit/cli/test_products.py
+++ b/tests/unit/cli/test_products.py
@@ -188,6 +188,71 @@ def test_products_profiles_inherit_root_format_json(cli_workspace: CliWorkspace)
     assert json_int(payload["count"]) == 1
 
 
+def test_products_status_json(cli_workspace: CliWorkspace) -> None:
+    _seed_products(cli_workspace)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["products", "status", "--json"], catch_exceptions=False)
+
+    assert result.exit_code == 0
+    payload = extract_json_result(result.output)
+    assert payload["aggregate_verdict"] == "ready"
+    products = {item["product_name"]: item for item in json_object_list(payload["products"])}
+    assert set(products) >= {
+        "session_profiles",
+        "session_enrichments",
+        "session_work_events",
+        "session_phases",
+        "work_threads",
+        "session_tag_rollups",
+        "day_session_summaries",
+        "week_session_summaries",
+        "provider_analytics",
+    }
+    assert products["session_profiles"]["verdict"] == "ready"
+    assert json_int(products["session_work_events"]["row_count"]) >= 1
+
+
+def test_products_status_inherits_root_format_and_filters(cli_workspace: CliWorkspace) -> None:
+    _seed_products(cli_workspace)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "--format",
+            "json",
+            "--provider",
+            "claude-code",
+            "products",
+            "status",
+            "--product",
+            "session-work-events",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    payload = extract_json_result(result.output)
+    assert payload["provider"] == "claude-code"
+    products = json_object_list(payload["products"])
+    assert len(products) == 1
+    assert products[0]["product_name"] == "session_work_events"
+    coverage = json_object_list(products[0]["provider_coverage"])
+    assert coverage[0]["provider_name"] == "claude-code"
+
+
+def test_products_status_plain(cli_workspace: CliWorkspace) -> None:
+    _seed_products(cli_workspace)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["products", "status", "--product", "profiles"], catch_exceptions=False)
+
+    assert result.exit_code == 0
+    assert "Product Readiness: ready" in result.output
+    assert "session_profiles: ready" in result.output
+
+
 def test_products_enrichments_json(cli_workspace: CliWorkspace) -> None:
     _seed_products(cli_workspace)
 

--- a/tests/unit/core/test_product_readiness.py
+++ b/tests/unit/core/test_product_readiness.py
@@ -1,0 +1,178 @@
+"""Tests for product readiness report construction."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import aiosqlite
+import pytest
+
+from polylogue.facade import Polylogue
+from polylogue.product_readiness import (
+    ProductReadinessEntry,
+    ProductReadinessQuery,
+    ProductReadinessReport,
+    build_product_readiness_report,
+)
+from polylogue.storage.backends.connection import open_connection
+from polylogue.storage.session_product_rebuild import rebuild_session_products_sync
+from polylogue.storage.session_product_status import session_product_status_sync
+from polylogue.storage.store_constants import SESSION_PRODUCT_MATERIALIZER_VERSION
+from tests.infra.storage_records import ConversationBuilder
+
+
+def _entry_by_name(report: ProductReadinessReport, name: str) -> ProductReadinessEntry:
+    return next(product for product in report.products if product.product_name == name)
+
+
+def _seed_readiness_conversations(db_path: Path) -> None:
+    (
+        ConversationBuilder(db_path, "ready-root")
+        .provider("codex")
+        .title("Ready Root")
+        .created_at("2026-04-01T09:00:00+00:00")
+        .updated_at("2026-04-01T09:10:00+00:00")
+        .add_message(
+            "u1",
+            role="user",
+            text="Plan product readiness reporting.",
+            timestamp="2026-04-01T09:00:00+00:00",
+        )
+        .add_message(
+            "a1",
+            role="assistant",
+            text="Implement readiness report and tests.",
+            timestamp="2026-04-01T09:05:00+00:00",
+        )
+        .save()
+    )
+
+
+@pytest.mark.asyncio
+async def test_product_readiness_report_marks_rebuilt_products_ready(cli_workspace: dict[str, Path]) -> None:
+    db_path = cli_workspace["db_path"]
+    _seed_readiness_conversations(db_path)
+    with open_connection(db_path) as conn:
+        rebuild_session_products_sync(conn)
+
+    archive = Polylogue(archive_root=cli_workspace["archive_root"], db_path=db_path)
+    report = await archive.product_readiness_report()
+
+    assert report.aggregate_verdict == "ready"
+    assert {product.product_name for product in report.products} >= {
+        "session_profiles",
+        "session_enrichments",
+        "session_work_events",
+        "session_phases",
+        "work_threads",
+        "session_tag_rollups",
+        "day_session_summaries",
+        "week_session_summaries",
+        "provider_analytics",
+    }
+    profile = _entry_by_name(report, "session_profiles")
+    assert profile.verdict == "ready"
+    assert profile.row_count == 1
+    assert profile.provider_coverage[0].provider_name == "codex"
+    assert profile.version_coverage[0].versions[str(SESSION_PRODUCT_MATERIALIZER_VERSION)] == 1
+
+
+@pytest.mark.asyncio
+async def test_product_readiness_report_marks_empty_products(cli_workspace: dict[str, Path]) -> None:
+    archive = Polylogue(archive_root=cli_workspace["archive_root"], db_path=cli_workspace["db_path"])
+
+    report = await archive.product_readiness_report(ProductReadinessQuery(products=("session_profiles",)))
+
+    profile = _entry_by_name(report, "session_profiles")
+    assert report.aggregate_verdict == "empty"
+    assert profile.verdict == "empty"
+    assert profile.row_count == 0
+    assert profile.expected_row_count == 0
+
+
+@pytest.mark.asyncio
+async def test_product_readiness_report_marks_partial_and_legacy_products(cli_workspace: dict[str, Path]) -> None:
+    db_path = cli_workspace["db_path"]
+    _seed_readiness_conversations(db_path)
+    (
+        ConversationBuilder(db_path, "ready-second")
+        .provider("codex")
+        .title("Ready Second")
+        .created_at("2026-04-01T10:00:00+00:00")
+        .updated_at("2026-04-01T10:05:00+00:00")
+        .add_message("u2", role="user", text="Second session.", timestamp="2026-04-01T10:00:00+00:00")
+        .save()
+    )
+    with open_connection(db_path) as conn:
+        rebuild_session_products_sync(conn)
+        conn.execute("DELETE FROM session_profiles WHERE conversation_id = ?", ("ready-second",))
+        conn.commit()
+
+    archive = Polylogue(archive_root=cli_workspace["archive_root"], db_path=db_path)
+    partial = await archive.product_readiness_report(ProductReadinessQuery(products=("session_profiles",)))
+    assert _entry_by_name(partial, "session_profiles").verdict == "partial"
+
+    with open_connection(db_path) as conn:
+        rebuild_session_products_sync(conn)
+        conn.execute(
+            "UPDATE session_profiles SET materializer_version = ?", (SESSION_PRODUCT_MATERIALIZER_VERSION - 1,)
+        )
+        conn.commit()
+
+    legacy = await archive.product_readiness_report(ProductReadinessQuery(products=("session_profiles",)))
+    profile = _entry_by_name(legacy, "session_profiles")
+    assert profile.verdict == "legacy"
+    assert profile.legacy_incompatible_count == 2
+
+
+@pytest.mark.asyncio
+async def test_product_readiness_report_marks_stale_products(cli_workspace: dict[str, Path]) -> None:
+    db_path = cli_workspace["db_path"]
+    _seed_readiness_conversations(db_path)
+    with open_connection(db_path) as conn:
+        rebuild_session_products_sync(conn)
+        conn.execute("UPDATE conversations SET sort_key = sort_key + 1 WHERE conversation_id = ?", ("ready-root",))
+        conn.commit()
+
+    archive = Polylogue(archive_root=cli_workspace["archive_root"], db_path=db_path)
+    report = await archive.product_readiness_report(ProductReadinessQuery(products=("session_profiles",)))
+
+    profile = _entry_by_name(report, "session_profiles")
+    assert report.aggregate_verdict == "stale"
+    assert profile.verdict == "stale"
+    assert profile.stale_count == 1
+
+
+@pytest.mark.asyncio
+async def test_product_readiness_report_marks_missing_product_tables(tmp_path: Path) -> None:
+    db_path = tmp_path / "missing.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        conn.executescript(
+            """
+            CREATE TABLE conversations (
+                conversation_id TEXT PRIMARY KEY,
+                parent_conversation_id TEXT,
+                provider_name TEXT,
+                sort_key REAL,
+                updated_at TEXT
+            );
+            INSERT INTO conversations (conversation_id, parent_conversation_id, provider_name, sort_key, updated_at)
+            VALUES ('missing-root', NULL, 'codex', 1.0, '2026-04-01T00:00:00Z');
+            """
+        )
+        status = session_product_status_sync(conn)
+
+    async with aiosqlite.connect(db_path) as conn:
+        conn.row_factory = aiosqlite.Row
+        report = await build_product_readiness_report(
+            conn,
+            status,
+            ProductReadinessQuery(products=("session_profiles",)),
+        )
+
+    profile = _entry_by_name(report, "session_profiles")
+    assert profile.verdict == "missing"
+    assert profile.row_count == 0
+    assert profile.expected_row_count == 1


### PR DESCRIPTION
## Summary

Adds a reusable product-readiness report contract and exposes it through `polylogue products status`, the archive operations layer, and the facade. The report covers storage artifacts, provider/date coverage, version compatibility, schema-contract issues, aggregate verdicts, evidence strings, and repair guidance for current derived product families.

## Problem

Downstream consumers and deployment/export gates need to know whether Polylogue data products are safe to consume without reimplementing SQLite checks. Existing status surfaces were not enough to distinguish absent tables, empty products, partial materialization, stale rows, legacy materializer versions, or schema-incompatible product tables.

## Solution

- Added `polylogue/product_readiness.py` with typed query/report/entry models and readiness specs for session profiles, enrichments, work events, phases, threads, tag rollups, day summaries, week summaries, and provider analytics.
- Wired the report through archive operations and `Polylogue.product_readiness_report()` so future export bundles, MCP surfaces, and deployment checks can consume the same contract without scraping CLI output.
- Added `polylogue products status` with plain and JSON rendering, root filter inheritance, product aliases, schema-contract issue display, and generated help/proof/showcase updates.
- Added unit coverage for ready, empty, partial, stale, missing, and legacy product states plus CLI JSON/plain behavior.

## Verification

- `pytest -q tests/unit/core/test_product_readiness.py tests/unit/cli/test_products.py` -> `37 passed`
- `devtools lab-scenario verify-baselines` -> `Ran 44 exercises`; `All baselines match`
- `devtools verify` -> `all checks passed`
- `devtools verify --quick` -> `all checks passed`
- pre-push `devtools verify --quick` -> `all checks passed`

Closes #376