### PR TITLE
feat: add product export bundles

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -290,6 +290,7 @@ Commands:
   day-summaries   List durable day-level session summary products.
   debt            List archive debt and maintenance readiness products.
   enrichments     List durable probabilistic session-enrichment products.
+  export          Export versioned archive-product bundles.
   phases          List durable session-phase products.
   profiles        List durable session-profile products.
   status          Report product materialization coverage and readiness.

--- a/docs/test-quality-workflows.md
+++ b/docs/test-quality-workflows.md
@@ -15,10 +15,10 @@ Current registry snapshot:
 - mutation campaigns: `19`
 - benchmark campaigns: `3`
 - synthetic benchmark campaigns: `6`
-- scenario projections: `243`
+- scenario projections: `244`
 - inferred corpus scenarios: `5`
   - benchmark-campaign: `3`
-  - exercise: `137`
+  - exercise: `138`
   - inferred-corpus-scenario: `5`
   - mutation-campaign: `19`
   - synthetic-benchmark: `6`
@@ -340,6 +340,7 @@ These are the authored scenario-bearing projections currently feeding runtime co
 | `exercise` | `help-products-day-summaries` | `day-summary-query-loop` | `day_session_summary_rows`<br>`day_session_summary_results` | `cli.help`<br>`query-day-session-summaries` | — | `generated`<br>`help`<br>`structural` | products day-summaries help |
 | `exercise` | `help-products-debt` | `archive-debt-query-loop` | `action_event_readiness`<br>`session_product_readiness`<br>`archive_readiness`<br>`archive_debt_results` | `cli.help`<br>`query-archive-debt` | — | `generated`<br>`help`<br>`structural` | products debt help |
 | `exercise` | `help-products-enrichments` | `session-enrichment-query-loop` | `session_profile_rows`<br>`session_profile_enrichment_fts`<br>`session_enrichment_results` | `cli.help`<br>`query-session-enrichments` | — | `generated`<br>`help`<br>`structural` | products enrichments help |
+| `exercise` | `help-products-export` | — | — | `cli.help` | — | `generated`<br>`help`<br>`structural` | products export help |
 | `exercise` | `help-products-phases` | `session-phase-query-loop` | `session_phase_rows`<br>`session_phase_results` | `cli.help`<br>`query-session-phases` | — | `generated`<br>`help`<br>`structural` | products phases help |
 | `exercise` | `help-products-profiles` | `session-profile-query-loop` | `session_profile_rows`<br>`session_profile_merged_fts`<br>`session_profile_results` | `cli.help`<br>`query-session-profiles` | — | `generated`<br>`help`<br>`structural` | products profiles help |
 | `exercise` | `help-products-status` | `session-product-status-query-loop` | `session_product_readiness`<br>`session_product_status_results` | `cli.help`<br>`query-session-product-status` | — | `generated`<br>`help`<br>`structural` | products status help |

--- a/docs/verification-catalog.md
+++ b/docs/verification-catalog.md
@@ -8,10 +8,10 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 
 ## Snapshot
 
-- subjects: `9040`
+- subjects: `9041`
 - claims: `22`
 - runner bindings: `22`
-- proof obligations: `9129`
+- proof obligations: `9132`
 
 ## Quality Checks
 
@@ -31,7 +31,7 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | --- | ---: |
 | `archive.query_law` | 1 |
 | `artifact.path` | 27 |
-| `cli.command` | 44 |
+| `cli.command` | 45 |
 | `cli.json_command` | 2 |
 | `diagnostic.observable` | 1 |
 | `error.surface` | 2 |
@@ -60,18 +60,19 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | `polylogue mcp` | `polylogue/cli/commands/mcp.py:10` `polylogue.cli.commands.mcp.mcp_command` |
 | `polylogue neighbors` | `polylogue/cli/commands/neighbors.py:42` `polylogue.cli.commands.neighbors.neighbors_command` |
 | `polylogue open` | `polylogue/cli/query_verbs.py:76` `polylogue.cli.query_verbs.open_verb` |
-| `polylogue products` | `polylogue/cli/commands/products.py:132` `polylogue.cli.commands.products.products_command` |
-| `polylogue products analytics` | `polylogue/cli/commands/products.py:95` `polylogue.cli.commands.products._make_callback.<locals>.callback` |
-| `polylogue products day-summaries` | `polylogue/cli/commands/products.py:95` `polylogue.cli.commands.products._make_callback.<locals>.callback` |
-| `polylogue products debt` | `polylogue/cli/commands/products.py:95` `polylogue.cli.commands.products._make_callback.<locals>.callback` |
-| `polylogue products enrichments` | `polylogue/cli/commands/products.py:95` `polylogue.cli.commands.products._make_callback.<locals>.callback` |
-| `polylogue products phases` | `polylogue/cli/commands/products.py:95` `polylogue.cli.commands.products._make_callback.<locals>.callback` |
-| `polylogue products profiles` | `polylogue/cli/commands/products.py:95` `polylogue.cli.commands.products._make_callback.<locals>.callback` |
-| `polylogue products status` | `polylogue/cli/commands/products.py:174` `polylogue.cli.commands.products.products_status_command` |
-| `polylogue products tags` | `polylogue/cli/commands/products.py:95` `polylogue.cli.commands.products._make_callback.<locals>.callback` |
-| `polylogue products threads` | `polylogue/cli/commands/products.py:95` `polylogue.cli.commands.products._make_callback.<locals>.callback` |
-| `polylogue products week-summaries` | `polylogue/cli/commands/products.py:95` `polylogue.cli.commands.products._make_callback.<locals>.callback` |
-| `polylogue products work-events` | `polylogue/cli/commands/products.py:95` `polylogue.cli.commands.products._make_callback.<locals>.callback` |
+| `polylogue products` | `polylogue/cli/commands/products.py:139` `polylogue.cli.commands.products.products_command` |
+| `polylogue products analytics` | `polylogue/cli/commands/products.py:102` `polylogue.cli.commands.products._make_callback.<locals>.callback` |
+| `polylogue products day-summaries` | `polylogue/cli/commands/products.py:102` `polylogue.cli.commands.products._make_callback.<locals>.callback` |
+| `polylogue products debt` | `polylogue/cli/commands/products.py:102` `polylogue.cli.commands.products._make_callback.<locals>.callback` |
+| `polylogue products enrichments` | `polylogue/cli/commands/products.py:102` `polylogue.cli.commands.products._make_callback.<locals>.callback` |
+| `polylogue products export` | `polylogue/cli/commands/products.py:234` `polylogue.cli.commands.products.products_export_command` |
+| `polylogue products phases` | `polylogue/cli/commands/products.py:102` `polylogue.cli.commands.products._make_callback.<locals>.callback` |
+| `polylogue products profiles` | `polylogue/cli/commands/products.py:102` `polylogue.cli.commands.products._make_callback.<locals>.callback` |
+| `polylogue products status` | `polylogue/cli/commands/products.py:194` `polylogue.cli.commands.products.products_status_command` |
+| `polylogue products tags` | `polylogue/cli/commands/products.py:102` `polylogue.cli.commands.products._make_callback.<locals>.callback` |
+| `polylogue products threads` | `polylogue/cli/commands/products.py:102` `polylogue.cli.commands.products._make_callback.<locals>.callback` |
+| `polylogue products week-summaries` | `polylogue/cli/commands/products.py:102` `polylogue.cli.commands.products._make_callback.<locals>.callback` |
+| `polylogue products work-events` | `polylogue/cli/commands/products.py:102` `polylogue.cli.commands.products._make_callback.<locals>.callback` |
 | `polylogue reset` | `polylogue/cli/commands/reset.py:23` `polylogue.cli.commands.reset.reset_command` |
 | `polylogue resume` | `polylogue/cli/commands/resume.py:22` `polylogue.cli.commands.resume.resume_command` |
 | `polylogue run` | `polylogue/cli/commands/run.py:164` `polylogue.cli.commands.run.run_command` |
@@ -188,10 +189,10 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | --- | ---: |
 | `archive.query.provider_filter_consistency` | 1 |
 | `artifact.path.dependency_closure` | 11 |
-| `cli.command.help` | 44 |
+| `cli.command.help` | 45 |
 | `cli.command.json_envelope` | 2 |
-| `cli.command.no_traceback` | 44 |
-| `cli.command.plain_mode` | 44 |
+| `cli.command.no_traceback` | 45 |
+| `cli.command.plain_mode` | 45 |
 | `diagnostic.observable_trace_mapping` | 1 |
 | `error.machine_user_context` | 2 |
 | `generated.scenario.family_registered` | 9 |

--- a/polylogue/cli/commands/products.py
+++ b/polylogue/cli/commands/products.py
@@ -8,6 +8,7 @@ works without re-specifying the filter on the subcommand.
 from __future__ import annotations
 
 from collections.abc import Callable
+from pathlib import Path
 
 import click
 
@@ -16,6 +17,12 @@ from polylogue.cli.helper_support import fail
 from polylogue.cli.machine_errors import emit_success
 from polylogue.cli.product_command_contracts import ProductCommandRequest, query_model_field_names
 from polylogue.cli.types import AppEnv
+from polylogue.product_export_bundles import (
+    ProductExportBundleError,
+    ProductExportBundleRequest,
+    ProductExportBundleResult,
+    ProductExportFormat,
+)
 from polylogue.product_readiness import ProductReadinessQuery, ProductReadinessReport, known_product_readiness_names
 from polylogue.products.registry import (
     PRODUCT_REGISTRY,
@@ -171,6 +178,19 @@ def _render_status_plain(report: ProductReadinessReport) -> None:
             click.echo(f"  schema: {', '.join(product.schema_contract_issues)}")
 
 
+def _render_export_plain(result: ProductExportBundleResult) -> None:
+    click.echo(f"Product export bundle: {result.output_path}")
+    click.echo(f"Manifest: {result.manifest_path}")
+    click.echo(f"Coverage: {result.coverage_path}")
+    click.echo("")
+    for product in result.manifest.products:
+        click.echo(f"{product.product_name}: rows={product.row_count} readiness={product.readiness_verdict or '-'}")
+        for warning in product.warnings:
+            click.echo(f"  warning: {warning}")
+        for error in product.errors:
+            click.echo(f"  error: {error}")
+
+
 @products_command.command("status")
 @click.option("--product", "products", multiple=True, help="Product readiness target. May be repeated.")
 @click.option("--provider", default=None, help="Limit provider coverage details to one provider.")
@@ -209,6 +229,57 @@ def products_status_command(
         emit_success(report.model_dump(mode="json"))
         return
     _render_status_plain(report)
+
+
+@products_command.command("export")
+@click.option("--out", "output_path", required=True, type=click.Path(path_type=Path), help="Output bundle directory.")
+@click.option("--product", "products", multiple=True, help="Product to include. Defaults to all exportable products.")
+@click.option("--provider", default=None, help="Limit supported products to one provider.")
+@click.option("--since", default=None, help="Limit supported products to rows at/after this timestamp or date.")
+@click.option("--until", default=None, help="Limit supported products to rows at/before this timestamp or date.")
+@click.option("--format", "output_format", type=click.Choice(["jsonl"]), default="jsonl", show_default=True)
+@click.option(
+    "--overwrite", is_flag=True, help="Replace an existing bundle directory after writing a complete new one."
+)
+@click.option("--json", "json_mode", is_flag=True, help="Output bundle metadata as JSON.")
+@click.pass_context
+def products_export_command(
+    ctx: click.Context,
+    output_path: Path,
+    products: tuple[str, ...],
+    provider: str | None,
+    since: str | None,
+    until: str | None,
+    output_format: str,
+    overwrite: bool,
+    json_mode: bool,
+) -> None:
+    """Export versioned archive-product bundles."""
+    env: AppEnv = ctx.obj
+    root_params = ctx.find_root().params
+    inherited_provider = provider if provider is not None else root_params.get("provider")
+    inherited_since = since if since is not None else root_params.get("since")
+    inherited_until = until if until is not None else root_params.get("until")
+    try:
+        export_format: ProductExportFormat = "jsonl"
+        if output_format != "jsonl":
+            fail("products export", f"unsupported export format: {output_format}")
+        request = ProductExportBundleRequest(
+            output_path=output_path,
+            products=products,
+            provider=str(inherited_provider) if inherited_provider is not None else None,
+            since=str(inherited_since) if inherited_since is not None else None,
+            until=str(inherited_until) if inherited_until is not None else None,
+            output_format=export_format,
+            overwrite=overwrite,
+        )
+        result = run_coroutine_sync(env.operations.export_product_bundle(request))
+    except ProductExportBundleError as exc:
+        fail("products export", str(exc))
+    if json_mode or ctx.find_root().params.get("output_format") == "json":
+        emit_success(result.model_dump(mode="json"))
+        return
+    _render_export_plain(result)
 
 
 # Register all product types as subcommands

--- a/polylogue/facade_archive.py
+++ b/polylogue/facade_archive.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
     from polylogue.lib.conversation_models import Conversation
     from polylogue.lib.filters import ConversationFilter
     from polylogue.operations import ArchiveStats
+    from polylogue.product_export_bundles import ProductExportBundleRequest, ProductExportBundleResult
     from polylogue.product_readiness import ProductReadinessQuery, ProductReadinessReport
     from polylogue.readiness import ReadinessReport
     from polylogue.storage.repository import ConversationRepository
@@ -89,6 +90,11 @@ if TYPE_CHECKING:
             self,
             query: ProductReadinessQuery | None = None,
         ) -> ProductReadinessReport: ...
+
+        async def export_product_bundle(
+            self,
+            request: ProductExportBundleRequest,
+        ) -> ProductExportBundleResult: ...
 
 
 class PolylogueArchiveMixin:
@@ -208,3 +214,10 @@ class PolylogueArchiveMixin:
     ) -> ProductReadinessReport:
         """Return product materialization readiness for downstream consumers."""
         return await self.operations.get_product_readiness_report(query)
+
+    async def export_product_bundle(
+        self,
+        request: ProductExportBundleRequest,
+    ) -> ProductExportBundleResult:
+        """Write a versioned archive-product export bundle."""
+        return await self.operations.export_product_bundle(request)

--- a/polylogue/operations/archive.py
+++ b/polylogue/operations/archive.py
@@ -41,6 +41,12 @@ from polylogue.lib.conversation_models import ConversationSummary
 from polylogue.lib.query_spec import ConversationQuerySpec
 from polylogue.maintenance_targets import build_maintenance_target_catalog
 from polylogue.paths.sanitize import conversation_render_root
+from polylogue.product_export_bundles import (
+    ProductExportBundleRequest,
+    ProductExportBundleResult,
+    ProductExportOperations,
+    export_product_bundle,
+)
 from polylogue.product_readiness import (
     ProductReadinessQuery,
     ProductReadinessReport,
@@ -594,6 +600,9 @@ class ArchiveProductAggregateMixin:
         @property
         def backend(self) -> SQLiteBackend: ...
 
+        @property
+        def config(self) -> Config: ...
+
     async def list_session_tag_rollup_products(
         self,
         query: SessionTagRollupQuery | None = None,
@@ -658,6 +667,12 @@ class ArchiveProductAggregateMixin:
         status = await _read_session_product_status(self.backend)
         async with self.backend.connection() as conn:
             return await build_product_readiness_report(conn, status, query)
+
+    async def export_product_bundle(
+        self,
+        request: ProductExportBundleRequest,
+    ) -> ProductExportBundleResult:
+        return await export_product_bundle(cast(ProductExportOperations, self), self.config, request)
 
 
 class ArchiveProductDebtMixin:

--- a/polylogue/product_export_bundles.py
+++ b/polylogue/product_export_bundles.py
@@ -1,0 +1,327 @@
+"""Versioned archive-product export bundle contracts and writer."""
+
+from __future__ import annotations
+
+import shutil
+import uuid
+from collections.abc import Sequence
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Literal, Protocol
+
+from polylogue.archive_product_models import ARCHIVE_PRODUCT_CONTRACT_VERSION, ArchiveProductModel
+from polylogue.archive_products import (
+    ArchiveProductUnavailableError,
+    DaySessionSummaryProduct,
+    ProviderAnalyticsProduct,
+    SessionEnrichmentProduct,
+    SessionPhaseProduct,
+    SessionProfileProduct,
+    SessionTagRollupProduct,
+    SessionWorkEventProduct,
+    WeekSessionSummaryProduct,
+    WorkThreadProduct,
+)
+from polylogue.config import Config
+from polylogue.lib.json import JSONDocument, dumps, require_json_document
+from polylogue.product_readiness import ProductReadinessQuery, ProductReadinessReport
+from polylogue.products.registry import PRODUCT_REGISTRY, ProductQueryError, ProductType, fetch_products_async
+from polylogue.version import VERSION_INFO
+
+ProductExportFormat = Literal["jsonl"]
+PRODUCT_EXPORT_BUNDLE_VERSION = 1
+DEFAULT_EXPORT_PRODUCTS: tuple[str, ...] = (
+    "session_profiles",
+    "session_enrichments",
+    "session_work_events",
+    "session_phases",
+    "work_threads",
+    "session_tag_rollups",
+    "day_session_summaries",
+    "week_session_summaries",
+    "provider_analytics",
+)
+_PRODUCT_MODEL_BY_NAME: dict[str, type[ArchiveProductModel]] = {
+    "session_profiles": SessionProfileProduct,
+    "session_enrichments": SessionEnrichmentProduct,
+    "session_work_events": SessionWorkEventProduct,
+    "session_phases": SessionPhaseProduct,
+    "work_threads": WorkThreadProduct,
+    "session_tag_rollups": SessionTagRollupProduct,
+    "day_session_summaries": DaySessionSummaryProduct,
+    "week_session_summaries": WeekSessionSummaryProduct,
+    "provider_analytics": ProviderAnalyticsProduct,
+}
+_PRODUCT_ALIASES = {
+    **{name.replace("_", "-"): name for name in DEFAULT_EXPORT_PRODUCTS},
+    **{
+        product_type.resolved_cli_command_name: name
+        for name, product_type in PRODUCT_REGISTRY.items()
+        if name in DEFAULT_EXPORT_PRODUCTS
+    },
+}
+
+
+class ProductExportBundleError(RuntimeError):
+    """Raised when a product export bundle cannot be written."""
+
+
+class ProductExportBundleRequest(ArchiveProductModel):
+    output_path: Path
+    products: tuple[str, ...] = ()
+    provider: str | None = None
+    since: str | None = None
+    until: str | None = None
+    output_format: ProductExportFormat = "jsonl"
+    overwrite: bool = False
+    include_readme: bool = True
+
+
+class ProductExportFileSummary(ArchiveProductModel):
+    product_name: str
+    file: str
+    schema_file: str
+    row_count: int = 0
+    readiness_verdict: str | None = None
+    warnings: tuple[str, ...] = ()
+    errors: tuple[str, ...] = ()
+
+
+class ProductExportBundleManifest(ArchiveProductModel):
+    bundle_version: int = PRODUCT_EXPORT_BUNDLE_VERSION
+    product_contract_version: int = ARCHIVE_PRODUCT_CONTRACT_VERSION
+    generated_at: str
+    polylogue_version: str
+    git_revision: str | None = None
+    git_dirty: bool = False
+    archive_root: str
+    database_path: str
+    output_format: ProductExportFormat = "jsonl"
+    query: dict[str, str | tuple[str, ...] | None]
+    products: tuple[ProductExportFileSummary, ...] = ()
+    warnings: tuple[str, ...] = ()
+
+
+class ProductExportBundleResult(ArchiveProductModel):
+    output_path: Path
+    manifest_path: Path
+    coverage_path: Path
+    manifest: ProductExportBundleManifest
+
+
+class ProductExportOperations(Protocol):
+    async def get_product_readiness_report(
+        self,
+        query: ProductReadinessQuery | None = None,
+    ) -> ProductReadinessReport: ...
+
+
+def normalize_export_product_name(value: str) -> str:
+    normalized = value.strip().replace("-", "_")
+    if normalized in DEFAULT_EXPORT_PRODUCTS:
+        return normalized
+    alias = _PRODUCT_ALIASES.get(value.strip()) or _PRODUCT_ALIASES.get(value.strip().replace("_", "-"))
+    if alias is not None:
+        return alias
+    raise ProductExportBundleError(f"Unknown export product: {value}")
+
+
+def _selected_product_names(products: Sequence[str]) -> tuple[str, ...]:
+    if not products:
+        return DEFAULT_EXPORT_PRODUCTS
+    selected: list[str] = []
+    for product in products:
+        name = normalize_export_product_name(product)
+        if name not in selected:
+            selected.append(name)
+    return tuple(selected)
+
+
+def _product_path(product_name: str) -> str:
+    return f"products/{product_name}.jsonl"
+
+
+def _schema_path(product_name: str) -> str:
+    return f"schemas/{product_name}.schema.json"
+
+
+def _query_kwargs(
+    product_type: ProductType, request: ProductExportBundleRequest
+) -> tuple[dict[str, object], tuple[str, ...]]:
+    query_model = product_type.query_model
+    if query_model is None:
+        return {}, (f"{product_type.name} has no query model and cannot be fetched",)
+    fields = set(query_model.model_fields)
+    kwargs: dict[str, object] = {}
+    warnings: list[str] = []
+    if "limit" in fields:
+        kwargs["limit"] = None
+    if "offset" in fields:
+        kwargs["offset"] = 0
+    for key, value in (("provider", request.provider), ("since", request.since), ("until", request.until)):
+        if value is None:
+            continue
+        if key in fields:
+            kwargs[key] = value
+        else:
+            warnings.append(f"{product_type.name} does not support {key} bounds")
+    return kwargs, tuple(warnings)
+
+
+def _json_schema_document(product_name: str) -> JSONDocument:
+    model = _PRODUCT_MODEL_BY_NAME[product_name]
+    schema = require_json_document(model.model_json_schema(), context=f"{product_name} JSON schema")
+    return {
+        "product_name": product_name,
+        "model_name": model.__name__,
+        "contract_version": ARCHIVE_PRODUCT_CONTRACT_VERSION,
+        "schema": schema,
+    }
+
+
+def _write_json(path: Path, payload: object) -> None:
+    path.write_text(dumps(payload) + "\n", encoding="utf-8")
+
+
+def _write_product_jsonl(path: Path, items: Sequence[ArchiveProductModel]) -> None:
+    lines = [item.model_dump_json(exclude_none=True) for item in items]
+    path.write_text(("\n".join(lines) + "\n") if lines else "", encoding="utf-8")
+
+
+def _write_readme(path: Path, manifest: ProductExportBundleManifest) -> None:
+    lines = [
+        "# Polylogue Product Export Bundle",
+        "",
+        f"- Generated: `{manifest.generated_at}`",
+        f"- Polylogue: `{manifest.polylogue_version}`",
+        f"- Product contract: `{manifest.product_contract_version}`",
+        f"- Products: `{len(manifest.products)}`",
+        "",
+        "| Product | Rows | Readiness | File |",
+        "| --- | ---: | --- | --- |",
+    ]
+    for product in manifest.products:
+        lines.append(
+            f"| `{product.product_name}` | {product.row_count} | `{product.readiness_verdict or '-'}` | `{product.file}` |"
+        )
+    if manifest.warnings:
+        lines.extend(["", "## Warnings", ""])
+        lines.extend(f"- {warning}" for warning in manifest.warnings)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _prepare_target(request: ProductExportBundleRequest) -> Path:
+    target = request.output_path
+    if target.exists() and not request.overwrite:
+        raise ProductExportBundleError(f"Export target already exists: {target}")
+    target.parent.mkdir(parents=True, exist_ok=True)
+    tmp_target = target.parent / f".{target.name}.tmp-{uuid.uuid4().hex}"
+    tmp_target.mkdir(parents=False)
+    (tmp_target / "products").mkdir()
+    (tmp_target / "schemas").mkdir()
+    return tmp_target
+
+
+def _publish_target(tmp_target: Path, request: ProductExportBundleRequest) -> None:
+    target = request.output_path
+    if target.exists():
+        if target.is_dir():
+            shutil.rmtree(target)
+        else:
+            target.unlink()
+    tmp_target.replace(target)
+
+
+async def export_product_bundle(
+    operations: ProductExportOperations,
+    config: Config,
+    request: ProductExportBundleRequest,
+) -> ProductExportBundleResult:
+    selected_products = _selected_product_names(request.products)
+    readiness = await operations.get_product_readiness_report(
+        ProductReadinessQuery(
+            products=selected_products,
+            provider=request.provider,
+            since=request.since,
+            until=request.until,
+        )
+    )
+    readiness_by_name = {entry.product_name: entry for entry in readiness.products}
+    tmp_target = _prepare_target(request)
+    summaries: list[ProductExportFileSummary] = []
+    bundle_warnings: list[str] = []
+    try:
+        for product_name in selected_products:
+            product_type = PRODUCT_REGISTRY[product_name]
+            product_file = _product_path(product_name)
+            schema_file = _schema_path(product_name)
+            kwargs, warnings = _query_kwargs(product_type, request)
+            errors: list[str] = []
+            items: list[ArchiveProductModel] = []
+            try:
+                items = await fetch_products_async(product_type, operations, **kwargs)
+            except (ArchiveProductUnavailableError, ProductQueryError) as exc:
+                errors.append(str(exc))
+            _write_product_jsonl(tmp_target / product_file, items)
+            _write_json(tmp_target / schema_file, _json_schema_document(product_name))
+            readiness_entry = readiness_by_name.get(product_name)
+            summaries.append(
+                ProductExportFileSummary(
+                    product_name=product_name,
+                    file=product_file,
+                    schema_file=schema_file,
+                    row_count=len(items),
+                    readiness_verdict=readiness_entry.verdict if readiness_entry is not None else None,
+                    warnings=warnings,
+                    errors=tuple(errors),
+                )
+            )
+            bundle_warnings.extend(f"{product_name}: {warning}" for warning in warnings)
+            bundle_warnings.extend(f"{product_name}: {error}" for error in errors)
+
+        manifest = ProductExportBundleManifest(
+            generated_at=datetime.now(timezone.utc).isoformat(),
+            polylogue_version=VERSION_INFO.full,
+            git_revision=VERSION_INFO.commit,
+            git_dirty=VERSION_INFO.dirty,
+            archive_root=str(config.archive_root),
+            database_path=str(config.db_path),
+            output_format=request.output_format,
+            query={
+                "products": selected_products,
+                "provider": request.provider,
+                "since": request.since,
+                "until": request.until,
+            },
+            products=tuple(summaries),
+            warnings=tuple(bundle_warnings),
+        )
+        _write_json(tmp_target / "manifest.json", manifest.model_dump(mode="json"))
+        _write_json(tmp_target / "coverage.json", readiness.model_dump(mode="json"))
+        if request.include_readme:
+            _write_readme(tmp_target / "README.md", manifest)
+        _publish_target(tmp_target, request)
+    except Exception:
+        shutil.rmtree(tmp_target, ignore_errors=True)
+        raise
+
+    return ProductExportBundleResult(
+        output_path=request.output_path,
+        manifest_path=request.output_path / "manifest.json",
+        coverage_path=request.output_path / "coverage.json",
+        manifest=manifest,
+    )
+
+
+__all__ = [
+    "DEFAULT_EXPORT_PRODUCTS",
+    "PRODUCT_EXPORT_BUNDLE_VERSION",
+    "ProductExportBundleError",
+    "ProductExportBundleManifest",
+    "ProductExportBundleRequest",
+    "ProductExportBundleResult",
+    "ProductExportFileSummary",
+    "ProductExportFormat",
+    "export_product_bundle",
+    "normalize_export_product_name",
+]

--- a/tests/baselines/showcase/help-products-export.txt
+++ b/tests/baselines/showcase/help-products-export.txt
@@ -1,0 +1,17 @@
+Usage: polylogue products export [OPTIONS]
+
+  Export versioned archive-product bundles.
+
+Options:
+  --out PATH        Output bundle directory.  [required]
+  --product TEXT    Product to include. Defaults to all exportable products.
+  --provider TEXT   Limit supported products to one provider.
+  --since TEXT      Limit supported products to rows at/after this timestamp
+                    or date.
+  --until TEXT      Limit supported products to rows at/before this timestamp
+                    or date.
+  --format [jsonl]  [default: jsonl]
+  --overwrite       Replace an existing bundle directory after writing a
+                    complete new one.
+  --json            Output bundle metadata as JSON.
+  -h, --help        Show this message and exit.

--- a/tests/baselines/showcase/help-products.txt
+++ b/tests/baselines/showcase/help-products.txt
@@ -10,6 +10,7 @@ Commands:
   day-summaries   List durable day-level session summary products.
   debt            List archive debt and maintenance readiness products.
   enrichments     List durable probabilistic session-enrichment products.
+  export          Export versioned archive-product bundles.
   phases          List durable session-phase products.
   profiles        List durable session-profile products.
   status          Report product materialization coverage and readiness.

--- a/tests/unit/cli/test_products.py
+++ b/tests/unit/cli/test_products.py
@@ -253,6 +253,25 @@ def test_products_status_plain(cli_workspace: CliWorkspace) -> None:
     assert "session_profiles: ready" in result.output
 
 
+def test_products_export_json(cli_workspace: CliWorkspace) -> None:
+    _seed_products(cli_workspace)
+    target = cli_workspace["archive_root"] / "exports" / "products-bundle"
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["products", "export", "--out", str(target), "--product", "profiles", "--json"],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    payload = extract_json_result(result.output)
+    assert payload["output_path"] == str(target)
+    assert (target / "manifest.json").exists()
+    assert (target / "coverage.json").exists()
+    assert (target / "products" / "session_profiles.jsonl").exists()
+
+
 def test_products_enrichments_json(cli_workspace: CliWorkspace) -> None:
     _seed_products(cli_workspace)
 

--- a/tests/unit/core/test_product_export_bundles.py
+++ b/tests/unit/core/test_product_export_bundles.py
@@ -1,0 +1,151 @@
+"""Tests for versioned product export bundle contracts."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from polylogue.facade import Polylogue
+from polylogue.product_export_bundles import ProductExportBundleError, ProductExportBundleRequest
+from polylogue.storage.backends.connection import open_connection
+from polylogue.storage.session_product_rebuild import rebuild_session_products_sync
+from tests.infra.storage_records import ConversationBuilder
+
+
+def _json_file(path: Path) -> dict[str, object]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(payload, dict)
+    return payload
+
+
+def _jsonl_file(path: Path) -> list[dict[str, object]]:
+    rows: list[dict[str, object]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        payload = json.loads(line)
+        assert isinstance(payload, dict)
+        rows.append(payload)
+    return rows
+
+
+def _seed_export_products(db_path: Path) -> None:
+    (
+        ConversationBuilder(db_path, "codex-export")
+        .provider("codex")
+        .title("Codex Export")
+        .created_at("2026-03-02T09:00:00+00:00")
+        .updated_at("2026-03-02T09:15:00+00:00")
+        .add_message("u1", role="user", text="Inspect product export code.", timestamp="2026-03-02T09:00:00+00:00")
+        .add_message(
+            "a1",
+            role="assistant",
+            text="Editing the bundle writer.",
+            timestamp="2026-03-02T09:10:00+00:00",
+            provider_meta={
+                "content_blocks": [
+                    {
+                        "type": "tool_use",
+                        "tool_name": "Edit",
+                        "semantic_type": "file_edit",
+                        "input": {"path": "/workspace/polylogue/polylogue/product_export_bundles.py"},
+                    }
+                ]
+            },
+        )
+        .save()
+    )
+    (
+        ConversationBuilder(db_path, "claude-export")
+        .provider("claude-code")
+        .title("Claude Export")
+        .created_at("2026-03-03T09:00:00+00:00")
+        .updated_at("2026-03-03T09:10:00+00:00")
+        .add_message("u2", role="user", text="Run bundle tests.", timestamp="2026-03-03T09:00:00+00:00")
+        .save()
+    )
+    with open_connection(db_path) as conn:
+        rebuild_session_products_sync(conn)
+
+
+@pytest.mark.asyncio
+async def test_product_export_bundle_writes_bounded_products(cli_workspace: dict[str, Path]) -> None:
+    db_path = cli_workspace["db_path"]
+    _seed_export_products(db_path)
+    archive = Polylogue(archive_root=cli_workspace["archive_root"], db_path=db_path)
+    target = cli_workspace["archive_root"] / "exports" / "bundle"
+
+    result = await archive.export_product_bundle(
+        ProductExportBundleRequest(
+            output_path=target,
+            products=("profiles", "work-events"),
+            provider="codex",
+            since="2026-03-01",
+            until="2026-03-31",
+        )
+    )
+
+    assert result.output_path == target
+    manifest = _json_file(target / "manifest.json")
+    assert manifest["bundle_version"] == 1
+    assert manifest["query"] == {
+        "products": ["session_profiles", "session_work_events"],
+        "provider": "codex",
+        "since": "2026-03-01",
+        "until": "2026-03-31",
+    }
+    assert (target / "coverage.json").exists()
+    assert (target / "README.md").exists()
+    assert (target / "schemas" / "session_profiles.schema.json").exists()
+    assert (target / "schemas" / "session_work_events.schema.json").exists()
+    profiles = _jsonl_file(target / "products" / "session_profiles.jsonl")
+    events = _jsonl_file(target / "products" / "session_work_events.jsonl")
+    assert {profile["provider_name"] for profile in profiles} == {"codex"}
+    assert profiles
+    assert events
+    summaries = manifest["products"]
+    assert isinstance(summaries, list)
+    assert {summary["product_name"] for summary in summaries if isinstance(summary, dict)} == {
+        "session_profiles",
+        "session_work_events",
+    }
+
+
+@pytest.mark.asyncio
+async def test_product_export_bundle_protects_existing_targets(cli_workspace: dict[str, Path]) -> None:
+    db_path = cli_workspace["db_path"]
+    _seed_export_products(db_path)
+    archive = Polylogue(archive_root=cli_workspace["archive_root"], db_path=db_path)
+    target = cli_workspace["archive_root"] / "exports" / "existing"
+    target.mkdir(parents=True)
+    marker = target / "marker.txt"
+    marker.write_text("keep", encoding="utf-8")
+
+    with pytest.raises(ProductExportBundleError, match="already exists"):
+        await archive.export_product_bundle(ProductExportBundleRequest(output_path=target, products=("profiles",)))
+
+    assert marker.read_text(encoding="utf-8") == "keep"
+
+
+@pytest.mark.asyncio
+async def test_product_export_bundle_records_stale_readiness(cli_workspace: dict[str, Path]) -> None:
+    db_path = cli_workspace["db_path"]
+    _seed_export_products(db_path)
+    with open_connection(db_path) as conn:
+        conn.execute("UPDATE conversations SET sort_key = sort_key + 1 WHERE conversation_id = ?", ("codex-export",))
+        conn.commit()
+    archive = Polylogue(archive_root=cli_workspace["archive_root"], db_path=db_path)
+    target = cli_workspace["archive_root"] / "exports" / "stale-bundle"
+
+    await archive.export_product_bundle(ProductExportBundleRequest(output_path=target, products=("profiles",)))
+
+    coverage = _json_file(target / "coverage.json")
+    coverage_products = coverage["products"]
+    assert isinstance(coverage_products, list)
+    assert coverage_products[0]["verdict"] == "stale"
+    manifest = _json_file(target / "manifest.json")
+    manifest_products = manifest["products"]
+    assert isinstance(manifest_products, list)
+    assert manifest_products[0]["row_count"] == 0
+    assert manifest_products[0]["errors"]
+    assert (target / "products" / "session_profiles.jsonl").read_text(encoding="utf-8") == ""


### PR DESCRIPTION
## Summary

Adds a versioned archive-product export bundle surface for downstream consumers. Bundles contain product JSONL payloads, Pydantic-derived product schemas, readiness coverage, a manifest with provenance, and a generated README.

## Problem

Product surfaces were inspectable through CLI/API commands, but there was no durable handoff format that packaged product rows together with the readiness evidence and schema contracts needed by downstream tools. Consumers had to infer whether exported rows were complete, stale, or safe to trust.

## Solution

- Added `polylogue/product_export_bundles.py` with typed bundle request/result models, exportable product normalization, registry-backed product fetching, product schema emission, manifest writing, readiness coverage, target protection, and cleanup on failed writes.
- Wired the bundle writer through archive operations and the `Polylogue` facade with `export_product_bundle()`.
- Added `polylogue products export` with provider/date bounds, repeated `--product`, JSON output, overwrite support, and inherited root filters.
- Updated generated CLI, quality, verification-catalog, and showcase help baselines for the new command.
- Added unit coverage for bounded exports, existing-target protection, stale-readiness manifests, and the CLI JSON surface.

## Verification

- `ruff check polylogue/product_export_bundles.py polylogue/operations/archive.py polylogue/facade_archive.py polylogue/cli/commands/products.py tests/unit/core/test_product_export_bundles.py tests/unit/cli/test_products.py`
- `mypy polylogue/product_export_bundles.py polylogue/operations/archive.py polylogue/facade_archive.py polylogue/cli/commands/products.py tests/unit/core/test_product_export_bundles.py tests/unit/cli/test_products.py`
- `pytest -q tests/unit/core/test_product_export_bundles.py tests/unit/cli/test_products.py` -> `36 passed`
- `devtools lab-scenario verify-baselines` -> `All baselines match`
- `devtools verify` -> `all checks passed`
- `devtools verify --quick` -> `all checks passed`
- pre-push `devtools verify --quick` -> `all checks passed`

Closes #375

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Added `products export` subcommand to export product data as versioned bundles with manifest and coverage metadata
- Supports filtering by product, provider, and time range
- Supports JSON output mode and overwrite semantics

## Documentation
- Updated CLI reference and help text for new export functionality

## Tests
- Added unit and integration tests for product export operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->