### PR TITLE
test: add single-source coverage gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: uv sync --extra dev --frozen
-      - run: uv run pytest --cov=polylogue --cov-report=xml --cov-fail-under=80 -q
+      - run: uv run devtools coverage-gate
         env:
           POLYLOGUE_FORCE_PLAIN: "1"
           HYPOTHESIS_PROFILE: ci

--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -144,6 +144,18 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
         featured=True,
     ),
     CommandSpec(
+        "coverage-gate",
+        "verification",
+        "Run pytest with the repository coverage floor from pyproject.toml.",
+        "devtools.coverage_gate",
+        use_when="Enforce the committed coverage ratchet locally or in CI without duplicating threshold values.",
+        examples=(
+            "devtools coverage-gate",
+            "devtools coverage-gate --ignore-integration --term-missing",
+            "devtools coverage-gate -- --maxfail=1",
+        ),
+    ),
+    CommandSpec(
         "affected-obligations",
         "verification",
         "Route changed paths or refs to affected verification-lab proof obligations and focused checks.",

--- a/devtools/coverage_gate.py
+++ b/devtools/coverage_gate.py
@@ -1,0 +1,93 @@
+"""Coverage gate shared by CI and local release-readiness checks."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+
+import tomllib
+
+CoverageThreshold = int | float
+
+
+def read_coverage_threshold(pyproject_path: Path) -> CoverageThreshold:
+    data = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+    threshold = data.get("tool", {}).get("coverage", {}).get("report", {}).get("fail_under")
+    if not isinstance(threshold, (int, float)):
+        raise ValueError(f"{pyproject_path} does not define tool.coverage.report.fail_under")
+    return threshold
+
+
+def _format_threshold(threshold: CoverageThreshold) -> str:
+    if isinstance(threshold, int) or threshold.is_integer():
+        return str(int(threshold))
+    return str(threshold)
+
+
+def build_coverage_command(
+    *,
+    pyproject_path: Path,
+    ignore_integration: bool,
+    term_missing: bool,
+    extra_args: Sequence[str] = (),
+) -> list[str]:
+    threshold = read_coverage_threshold(pyproject_path)
+    command = [
+        "pytest",
+        "--cov=polylogue",
+        "--cov-report=xml",
+    ]
+    if term_missing:
+        command.append("--cov-report=term-missing:skip-covered")
+    command.extend(["--cov-fail-under", _format_threshold(threshold), "-q"])
+    if ignore_integration:
+        command.append("--ignore=tests/integration")
+    command.extend(extra_args)
+    return command
+
+
+def _strip_arg_separator(args: list[str]) -> list[str]:
+    if args and args[0] == "--":
+        return args[1:]
+    return args
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Run pytest coverage using tool.coverage.report.fail_under from pyproject.toml.",
+    )
+    parser.add_argument(
+        "--pyproject",
+        type=Path,
+        default=Path("pyproject.toml"),
+        help="Path to the pyproject.toml file containing the coverage threshold.",
+    )
+    parser.add_argument(
+        "--ignore-integration",
+        action="store_true",
+        help="Skip tests/integration for local ratchet measurements.",
+    )
+    parser.add_argument(
+        "--term-missing",
+        action="store_true",
+        help="Also render missing-line coverage in the terminal.",
+    )
+    parser.add_argument("pytest_args", nargs=argparse.REMAINDER, help="Extra arguments passed to pytest after `--`.")
+    args = parser.parse_args(argv)
+
+    threshold = read_coverage_threshold(args.pyproject)
+    command = build_coverage_command(
+        pyproject_path=args.pyproject,
+        ignore_integration=bool(args.ignore_integration),
+        term_missing=bool(args.term_missing),
+        extra_args=_strip_arg_separator(list(args.pytest_args)),
+    )
+    sys.stderr.write(f"coverage-gate: enforcing fail_under={_format_threshold(threshold)} from {args.pyproject}\n")
+    return subprocess.run(command).returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -94,6 +94,7 @@ These are the commands worth remembering during normal repo work:
 | --- | --- |
 | `devtools affected-obligations` | Route changed paths or refs to affected verification-lab proof obligations and focused checks. |
 | `devtools artifact-graph` | Render the runtime artifact, operation, and scenario-coverage map. |
+| `devtools coverage-gate` | Run pytest with the repository coverage floor from pyproject.toml. |
 | `devtools lab-corpus` | Generate verification-lab synthetic corpus fixtures and demo archives. |
 | `devtools lab-scenario` | Run verification-lab showcase scenario sets and baseline checks. |
 | `devtools pipeline-probe` | Run typed pipeline probes against synthetic, staged, or archive-subset inputs. |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,7 +141,7 @@ data_file = ".cache/coverage/.coverage"
 [tool.coverage.report]
 skip_empty = true
 show_missing = true
-fail_under = 83
+fail_under = 84
 
 [tool.mypy]
 python_version = "3.11"

--- a/tests/integration/test_mcp.py
+++ b/tests/integration/test_mcp.py
@@ -71,8 +71,9 @@ class TestMCPRealRepositoryPaths:
 
             parsed = json.loads(result)
             assert len(parsed) == 1
-            assert parsed[0]["id"] == "chatgpt:needle"
-            assert parsed[0]["provider"] == "chatgpt"
+            assert parsed[0]["conversation"]["id"] == "chatgpt:needle"
+            assert parsed[0]["conversation"]["provider"] == "chatgpt"
+            assert parsed[0]["match"]["match_surface"] == "message"
         finally:
             await backend.close()
 

--- a/tests/unit/devtools/test_coverage_gate.py
+++ b/tests/unit/devtools/test_coverage_gate.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from devtools import coverage_gate
+
+
+def write_pyproject(path: Path, threshold: int | float) -> Path:
+    pyproject = path / "pyproject.toml"
+    pyproject.write_text(
+        f"[tool.coverage.report]\nfail_under = {threshold}\n",
+        encoding="utf-8",
+    )
+    return pyproject
+
+
+def test_read_coverage_threshold_uses_pyproject_report_floor(tmp_path: Path) -> None:
+    pyproject = write_pyproject(tmp_path, 84)
+
+    assert coverage_gate.read_coverage_threshold(pyproject) == 84
+
+
+def test_build_coverage_command_uses_threshold_and_local_options(tmp_path: Path) -> None:
+    pyproject = write_pyproject(tmp_path, 84)
+
+    command = coverage_gate.build_coverage_command(
+        pyproject_path=pyproject,
+        ignore_integration=True,
+        term_missing=True,
+        extra_args=("--maxfail=1",),
+    )
+
+    assert command == [
+        "pytest",
+        "--cov=polylogue",
+        "--cov-report=xml",
+        "--cov-report=term-missing:skip-covered",
+        "--cov-fail-under",
+        "84",
+        "-q",
+        "--ignore=tests/integration",
+        "--maxfail=1",
+    ]
+
+
+def test_main_strips_separator_and_runs_coverage_command(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pyproject = write_pyproject(tmp_path, 84)
+    captured: list[list[str]] = []
+
+    def fake_run(command: list[str]) -> subprocess.CompletedProcess[str]:
+        captured.append(command)
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr("devtools.coverage_gate.subprocess.run", fake_run)
+
+    assert coverage_gate.main(["--pyproject", str(pyproject), "--ignore-integration", "--", "--maxfail=1"]) == 0
+    assert captured == [
+        [
+            "pytest",
+            "--cov=polylogue",
+            "--cov-report=xml",
+            "--cov-fail-under",
+            "84",
+            "-q",
+            "--ignore=tests/integration",
+            "--maxfail=1",
+        ]
+    ]

--- a/tests/unit/sources/test_parsers_props.py
+++ b/tests/unit/sources/test_parsers_props.py
@@ -21,7 +21,7 @@ from dataclasses import dataclass
 from typing import TypeAlias, TypedDict
 
 import pytest
-from hypothesis import given, settings
+from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 from hypothesis.strategies import SearchStrategy
 
@@ -230,7 +230,7 @@ PARSER_CASES: tuple[ParserCase, ...] = (
 
 @pytest.mark.parametrize("case", PARSER_CASES, ids=lambda case: case.name)
 @given(st.data())
-@settings(max_examples=35)
+@settings(max_examples=35, suppress_health_check=[HealthCheck.too_slow])
 def test_provider_parser_contract(case: ParserCase, data: st.DataObject) -> None:
     payload = data.draw(case.strategy)
     result = case.parse(payload)
@@ -250,7 +250,7 @@ def test_provider_parser_contract(case: ParserCase, data: st.DataObject) -> None
 
 @pytest.mark.parametrize("case", PARSER_CASES, ids=lambda case: case.name)
 @given(st.data())
-@settings(max_examples=20)
+@settings(max_examples=20, suppress_health_check=[HealthCheck.too_slow])
 def test_provider_looks_like_accepts_generated_payloads(case: ParserCase, data: st.DataObject) -> None:
     payload = data.draw(case.strategy)
     assert case.looks_like(payload)
@@ -273,7 +273,7 @@ def test_extract_messages_from_list_normalizes_role(msg: JSONDocument) -> None:
 
 
 @given(chatgpt_message_node_strategy())
-@settings(max_examples=30)
+@settings(max_examples=30, suppress_health_check=[HealthCheck.too_slow])
 def test_chatgpt_node_contract(node: JSONDocument) -> None:
     export: dict[str, object] = {"mapping": {str(node["id"]): node}, "id": "test"}
     result = chatgpt.parse(export, "fallback")
@@ -281,7 +281,7 @@ def test_chatgpt_node_contract(node: JSONDocument) -> None:
 
 
 @given(claude_code_message_strategy())
-@settings(max_examples=30)
+@settings(max_examples=30, suppress_health_check=[HealthCheck.too_slow])
 def test_claude_code_message_type_contract(msg: JSONDocument) -> None:
     result = claude.parse_code([msg], "fallback")
     if not result.messages:
@@ -302,7 +302,7 @@ def test_claude_code_message_type_contract(msg: JSONDocument) -> None:
 
 
 @given(codex_message_strategy())
-@settings(max_examples=30)
+@settings(max_examples=30, suppress_health_check=[HealthCheck.too_slow])
 def test_codex_message_text_contract(msg: JSONDocument) -> None:
     session: list[object] = [
         {"type": "session_meta", "payload": {"id": "test", "timestamp": "2024-01-01"}},

--- a/tests/unit/sources/test_source_laws.py
+++ b/tests/unit/sources/test_source_laws.py
@@ -205,7 +205,7 @@ def _empty_cursor_state() -> CursorStatePayload:
         )
     )
 )
-@settings(max_examples=40)
+@settings(max_examples=40, suppress_health_check=[HealthCheck.too_slow])
 def test_detect_provider_recognizes_generated_payloads(case: tuple[str, object]) -> None:
     """Generated provider payloads are self-identifying without filename hints."""
     provider, payload = case
@@ -253,7 +253,7 @@ def test_entry_payload_detection_overrides_misleading_grouped_fallback_law(
 
 
 @given(provider_payload_case_strategy(_CANONICAL_PROVIDERS))
-@settings(max_examples=35)
+@settings(max_examples=35, suppress_health_check=[HealthCheck.too_slow])
 def test_parse_payload_generated_exports_produce_provider_named_conversations(case: tuple[str, object]) -> None:
     """Runtime dispatch parses generated provider payloads into provider-owned conversations."""
     provider, payload = case


### PR DESCRIPTION
## Summary

Adds a shared `devtools coverage-gate` command, points CI at it, and ratchets the committed coverage floor from 83% to 84% using the current measured suite.

## Problem

#197 tracks restoring the coverage floor toward the original 90%, but enforcement had drifted: `pyproject.toml` declared `fail_under = 83` while CI still invoked pytest with `--cov-fail-under=80`. A fresh coverage run also showed that instrumentation made several generated-payload Hypothesis properties trip `HealthCheck.too_slow`, so the gate could fail for test-generation cost rather than product behavior.

## Solution

- Added `devtools coverage-gate`, which reads `tool.coverage.report.fail_under` from `pyproject.toml` and passes that value to pytest.
- Updated CI to call `uv run devtools coverage-gate` instead of hard-coding a separate threshold.
- Raised the committed coverage floor to 84%, below the measured 85.60% CI-shaped result.
- Registered the new devtools command and regenerated `docs/devtools.md`.
- Stabilized generated provider/source property tests under coverage instrumentation.
- Updated the real-repository MCP search integration assertion to the current nested `conversation`/`match` search-hit payload.

## Verification

- `pytest -q tests/unit/devtools/test_coverage_gate.py tests/unit/devtools/test_command_catalog.py tests/unit/devtools/test_devtools_main.py tests/unit/sources/test_parsers_props.py` -> 51 passed.
- `pytest -q tests/unit/sources/test_source_laws.py::test_detect_provider_recognizes_generated_payloads tests/integration/test_mcp.py::TestMCPRealRepositoryPaths::test_search_uses_real_repository_and_filter_stack` -> 2 passed.
- `devtools coverage-gate --ignore-integration` -> 5175 passed, required coverage 84% reached, total coverage 84.83%.
- `devtools coverage-gate` -> 5355 passed, required coverage 84% reached, total coverage 85.60%.
- `devtools verify --quick` -> all checks passed.
- `git push -u origin feature/test/coverage-ratchet-gate` -> pre-push `devtools verify --quick` passed.

Ref #197
