### PR TITLE
test: cover schema and query semantic helpers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,7 +141,7 @@ data_file = ".cache/coverage/.coverage"
 [tool.coverage.report]
 skip_empty = true
 show_missing = true
-fail_under = 84
+fail_under = 85
 
 [tool.mypy]
 python_version = "3.11"

--- a/tests/unit/core/test_schema_pinning.py
+++ b/tests/unit/core/test_schema_pinning.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from typing import cast
+
+import pytest
+
+from polylogue.lib.json import JSONDocument
+from polylogue.schemas.pinning import PinDecision, PinSet, apply_pins_to_schema, resolve_pinned_paths
+
+
+def test_pin_decision_rejects_unknown_actions_and_roles() -> None:
+    with pytest.raises(ValueError, match="Pin action"):
+        PinDecision(path=".role", role="message_role", action="maybe")  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="not pinnable"):
+        PinDecision.from_dict({"path": ".role", "role": "provider", "action": "confirm"})
+
+    with pytest.raises(ValueError, match="must be a string"):
+        PinDecision.from_dict({"path": 123, "role": "message_role", "action": "confirm"})
+
+
+def test_pin_set_round_trips_confirmed_and_rejected_decisions() -> None:
+    pin_set = PinSet(
+        provider="chatgpt",
+        pins=[
+            PinDecision(path=".role", role="message_role", action="confirm", reason="reviewed"),
+            PinDecision(path=".body", role="message_body", action="reject", reason="wrong field"),
+        ],
+    )
+
+    restored = PinSet.from_dict(pin_set.to_dict())
+
+    assert restored.provider == "chatgpt"
+    assert restored.confirmed_path("message_role") == ".role"
+    assert restored.is_rejected(".body", "message_body") is True
+    assert restored.is_rejected(".role", "message_body") is False
+
+
+def test_resolve_pinned_paths_exposes_confirmed_roles_only() -> None:
+    pin_set = PinSet(
+        provider="claude-ai",
+        pins=[PinDecision(path=".chat_messages[].text", role="message_body", action="confirm")],
+    )
+
+    resolved = resolve_pinned_paths({}, pin_set)
+
+    assert resolved["message_body"] == ".chat_messages[].text"
+    assert resolved["message_role"] is None
+
+
+def test_apply_pins_marks_confirmed_nodes_and_suppresses_rejected_annotations() -> None:
+    schema = cast(
+        JSONDocument,
+        {
+            "type": "object",
+            "properties": {
+                "role": {
+                    "type": "string",
+                    "x-polylogue-semantic-role": "message_role",
+                },
+                "body": {
+                    "type": "string",
+                    "x-polylogue-semantic-role": "message_body",
+                    "x-polylogue-evidence": ["candidate"],
+                },
+                "messages": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "x-polylogue-semantic-role": "message_container",
+                    },
+                },
+            },
+            "anyOf": [
+                {
+                    "x-polylogue-semantic-role": "conversation_title",
+                }
+            ],
+        },
+    )
+    pins = PinSet(
+        provider="chatgpt",
+        pins=[
+            PinDecision(path=".role", role="message_role", action="confirm"),
+            PinDecision(path=".body", role="message_body", action="reject"),
+            PinDecision(path=".messages[]", role="message_container", action="confirm"),
+            PinDecision(path=".anyOf[0]", role="conversation_title", action="confirm"),
+        ],
+    )
+
+    result = apply_pins_to_schema(schema, pins)
+    properties = cast(dict[str, JSONDocument], result["properties"])
+    role_node = properties["role"]
+    body_node = properties["body"]
+    messages_node = properties["messages"]
+    messages_items = cast(JSONDocument, messages_node["items"])
+    any_of = cast(list[JSONDocument], result["anyOf"])
+
+    assert role_node["x-polylogue-pinned"] is True
+    assert "x-polylogue-semantic-role" not in body_node
+    assert "x-polylogue-evidence" not in body_node
+    assert body_node["x-polylogue-rejected"] is True
+    assert messages_items["x-polylogue-pinned"] is True
+    assert any_of[0]["x-polylogue-pinned"] is True

--- a/tests/unit/lib/test_coverage_diagnostics.py
+++ b/tests/unit/lib/test_coverage_diagnostics.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from polylogue.lib.conversation_models import ConversationSummary
+from polylogue.lib.coverage import analyze_coverage
+from polylogue.types import ConversationId, Provider
+
+
+def _summary(
+    conversation_id: str,
+    *,
+    provider: Provider,
+    updated_at: datetime | None,
+    message_count: int | None,
+) -> ConversationSummary:
+    return ConversationSummary(
+        id=ConversationId(conversation_id),
+        provider=provider,
+        updated_at=updated_at,
+        message_count=message_count,
+    )
+
+
+def test_analyze_coverage_handles_empty_archive() -> None:
+    coverage = analyze_coverage(())
+
+    assert coverage.provider_ranges == ()
+    assert coverage.provider_counts == {}
+    assert coverage.gaps == ()
+    assert coverage.truncated_sessions == 0
+    assert coverage.total_conversations == 0
+    assert coverage.total_messages == 0
+    assert coverage.date_range == (None, None)
+
+
+def test_analyze_coverage_reports_provider_ranges_gaps_and_truncation() -> None:
+    coverage = analyze_coverage(
+        (
+            _summary(
+                "chatgpt:first",
+                provider=Provider.CHATGPT,
+                updated_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+                message_count=1,
+            ),
+            _summary(
+                "chatgpt:second",
+                provider=Provider.CHATGPT,
+                updated_at=datetime(2026, 1, 4, tzinfo=timezone.utc),
+                message_count=5,
+            ),
+            _summary(
+                "claude-ai:first",
+                provider=Provider.CLAUDE_AI,
+                updated_at=datetime(2026, 1, 4, 12, tzinfo=timezone.utc),
+                message_count=None,
+            ),
+        )
+    )
+
+    assert coverage.provider_counts == {"chatgpt": 2, "claude-ai": 1}
+    assert [
+        (item.provider, item.first_date.isoformat(), item.last_date.isoformat(), item.count)
+        for item in coverage.provider_ranges
+    ] == [
+        ("chatgpt", "2026-01-01", "2026-01-04", 2),
+        ("claude-ai", "2026-01-04", "2026-01-04", 1),
+    ]
+    assert [(gap.start_date.isoformat(), gap.end_date.isoformat(), gap.days) for gap in coverage.gaps] == [
+        ("2026-01-02", "2026-01-03", 2)
+    ]
+    assert coverage.truncated_sessions == 2
+    assert coverage.total_conversations == 3
+    assert coverage.total_messages == 6
+    assert tuple(item.isoformat() for item in coverage.date_range if item is not None) == ("2026-01-01", "2026-01-04")

--- a/tests/unit/lib/test_query_runtime_matching.py
+++ b/tests/unit/lib/test_query_runtime_matching.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from polylogue.lib.action_events import ActionEvent
+from polylogue.lib.conversation_models import Conversation
+from polylogue.lib.messages import MessageCollection
+from polylogue.lib.query_plan import ConversationQueryPlan
+from polylogue.lib.query_runtime_matching import (
+    matches_action_sequence,
+    matches_action_terms,
+    matches_action_text_terms,
+    matches_path_terms,
+    matches_tool_terms,
+)
+from polylogue.lib.viewport_enums import ToolCategory
+from polylogue.types import ConversationId, Provider
+
+
+def _conversation() -> Conversation:
+    return Conversation(
+        id=ConversationId("conv"),
+        provider=Provider.CLAUDE_CODE,
+        messages=MessageCollection.empty(),
+    )
+
+
+def _event(
+    kind: ToolCategory,
+    *,
+    tool_name: str = "unknown",
+    affected_paths: tuple[str, ...] = (),
+    search_text: str = "",
+    index: int = 0,
+) -> ActionEvent:
+    return ActionEvent(
+        event_id=f"event-{index}",
+        message_id="message-1",
+        timestamp=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        sequence_index=index,
+        kind=kind,
+        tool_name=tool_name,
+        tool_id=None,
+        provider=Provider.CLAUDE_CODE,
+        affected_paths=affected_paths,
+        cwd_path=None,
+        branch_names=(),
+        command=None,
+        query=None,
+        url=None,
+        output_text=None,
+        search_text=search_text,
+        raw={},
+    )
+
+
+def _patch_events(
+    monkeypatch: pytest.MonkeyPatch,
+    events: tuple[ActionEvent, ...],
+) -> None:
+    monkeypatch.setattr("polylogue.lib.query_runtime_matching._action_events_for", lambda _conversation: events)
+
+
+def test_matches_path_terms_requires_each_term_across_affected_paths(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_events(
+        monkeypatch,
+        (
+            _event(
+                ToolCategory.FILE_EDIT,
+                affected_paths=("/repo/src/app.py", "/repo/tests/test_app.py"),
+            ),
+        ),
+    )
+
+    assert matches_path_terms(ConversationQueryPlan(path_terms=("SRC\\APP", "tests")), _conversation()) is True
+    assert matches_path_terms(ConversationQueryPlan(path_terms=("missing",)), _conversation()) is False
+
+
+def test_matches_action_and_tool_terms_handle_none_and_exclusions(monkeypatch: pytest.MonkeyPatch) -> None:
+    conversation = _conversation()
+    _patch_events(
+        monkeypatch,
+        (
+            _event(ToolCategory.SHELL, tool_name="Bash"),
+            _event(ToolCategory.FILE_EDIT, tool_name="Edit"),
+        ),
+    )
+
+    assert matches_action_terms(ConversationQueryPlan(action_terms=("shell",)), conversation) is True
+    assert matches_action_terms(ConversationQueryPlan(action_terms=("none",)), conversation) is False
+    assert matches_action_terms(ConversationQueryPlan(excluded_action_terms=("web",)), conversation) is True
+    assert matches_action_terms(ConversationQueryPlan(excluded_action_terms=("shell",)), conversation) is False
+
+    assert matches_tool_terms(ConversationQueryPlan(tool_terms=("bash",)), conversation) is True
+    assert matches_tool_terms(ConversationQueryPlan(excluded_tool_terms=("edit",)), conversation) is False
+
+    _patch_events(monkeypatch, ())
+    assert matches_action_terms(ConversationQueryPlan(action_terms=("none",)), conversation) is True
+    assert matches_tool_terms(ConversationQueryPlan(tool_terms=("none",)), conversation) is True
+    assert matches_tool_terms(ConversationQueryPlan(excluded_tool_terms=("none",)), conversation) is False
+
+
+def test_matches_action_sequence_and_search_text(monkeypatch: pytest.MonkeyPatch) -> None:
+    conversation = _conversation()
+    _patch_events(
+        monkeypatch,
+        (
+            _event(ToolCategory.SEARCH, search_text="ripgrep found schema pinning", index=0),
+            _event(ToolCategory.FILE_EDIT, search_text="edited schema pinning tests", index=1),
+            _event(ToolCategory.SHELL, search_text="pytest passed", index=2),
+        ),
+    )
+
+    assert matches_action_sequence(ConversationQueryPlan(action_sequence=("search", "shell")), conversation) is True
+    assert matches_action_sequence(ConversationQueryPlan(action_sequence=("shell", "search")), conversation) is False
+    assert (
+        matches_action_text_terms(ConversationQueryPlan(action_text_terms=("schema", "pytest")), conversation) is True
+    )
+    assert matches_action_text_terms(ConversationQueryPlan(action_text_terms=("deployment",)), conversation) is False

--- a/tests/unit/lib/test_search_hits.py
+++ b/tests/unit/lib/test_search_hits.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from polylogue.lib.conversation_models import Conversation, ConversationSummary
+from polylogue.lib.message_models import Message
+from polylogue.lib.messages import MessageCollection
+from polylogue.lib.roles import Role
+from polylogue.lib.search_hits import (
+    build_search_snippet,
+    conversation_search_hit_from_conversation,
+    conversation_search_hit_from_summary,
+    search_hit_surface,
+    search_query_text,
+    search_terms,
+)
+from polylogue.types import ConversationId, Provider
+
+
+def _conversation() -> Conversation:
+    return Conversation(
+        id=ConversationId("chatgpt:search"),
+        provider=Provider.CHATGPT,
+        title="Search evidence",
+        created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        messages=MessageCollection(
+            messages=[
+                Message(id="m1", role=Role.USER, text="intro text", provider=Provider.CHATGPT),
+                Message(id="m2", role=Role.ASSISTANT, text="the exact Needle appears here", provider=Provider.CHATGPT),
+            ]
+        ),
+    )
+
+
+def test_search_query_text_and_terms_normalize_empty_and_split_terms() -> None:
+    assert search_query_text(("  alpha beta  ", "", " gamma ")) == "alpha beta gamma"
+    assert search_terms(("Alpha beta", "  GAMMA  ", "")) == ("alpha", "beta", "gamma")
+
+
+def test_build_search_snippet_anchors_earliest_match_and_adds_ellipses() -> None:
+    text = "prefix " * 20 + "needle " + "suffix " * 30
+
+    snippet = build_search_snippet(text, ("needle",))
+
+    assert snippet.startswith("...")
+    assert "needle" in snippet
+    assert snippet.endswith("...")
+
+
+def test_search_hit_from_conversation_preserves_match_evidence() -> None:
+    hit = conversation_search_hit_from_conversation(
+        _conversation(),
+        query_terms=("needle",),
+        rank=3,
+        retrieval_lane="dialogue",
+        score=0.42,
+    )
+
+    assert hit.conversation_id == "chatgpt:search"
+    assert hit.message_id == "m2"
+    assert hit.match_surface == "message"
+    assert hit.snippet == "the exact Needle appears here"
+    assert hit.score == 0.42
+    assert hit.with_message_count(7).summary.message_count == 7
+
+
+def test_search_hit_from_summary_and_lane_surface_are_explicit() -> None:
+    summary = ConversationSummary(
+        id=ConversationId("claude-ai:summary"),
+        provider=Provider.CLAUDE_AI,
+        title="Summary",
+    )
+
+    hit = conversation_search_hit_from_summary(
+        summary,
+        rank=1,
+        retrieval_lane="attachment",
+        match_surface="attachment",
+        message_id=None,
+        snippet="provider_meta.fileId=abc",
+    )
+
+    assert hit.conversation_id == "claude-ai:summary"
+    assert hit.match_surface == "attachment"
+    assert search_hit_surface("actions") == "action"
+    assert search_hit_surface("hybrid") == "hybrid"
+    assert search_hit_surface("semantic") == "semantic"
+    assert search_hit_surface("dialogue") == "message"

--- a/tests/unit/sources/test_source_laws.py
+++ b/tests/unit/sources/test_source_laws.py
@@ -295,7 +295,7 @@ def test_parse_payload_accepts_provider_enum() -> None:
     ids=["chatgpt-bundle", "claude-bundle", "gemini-bundle", "conversations-wrapper"],
 )
 @given(data=st.data())
-@settings(max_examples=20, suppress_health_check=[HealthCheck.too_slow])
+@settings(deadline=None, max_examples=20, suppress_health_check=[HealthCheck.too_slow])
 def test_parse_payload_bundle_cardinality_contract(
     provider: str,
     wrapper: bool,
@@ -330,7 +330,7 @@ def test_iter_json_stream_root_list_round_trips_documents(case: tuple[list[dict[
 
 
 @given(conversations_wrapper_bytes_strategy())
-@settings(max_examples=30)
+@settings(max_examples=30, suppress_health_check=[HealthCheck.too_slow])
 def test_iter_json_stream_conversations_wrapper_round_trips_documents(
     case: tuple[list[dict[str, object]], bytes],
 ) -> None:


### PR DESCRIPTION
## Summary
Close the stale #193 package-coverage gap by adding direct semantic tests for the remaining weak helpers in `polylogue/lib` and `polylogue/schemas`, then ratchet the repository-wide coverage floor from 84% to 85% with a default coverage gate that still passes under full instrumentation.

## Problem
Issue #193 started as a broad package-coverage ticket, but the package-level baseline had already moved. The real remaining gap was narrower: several semantic helpers in `polylogue.lib.coverage`, `polylogue.lib.search_hits`, `polylogue.lib.query_runtime_matching`, and `polylogue.schemas.pinning` were still lightly exercised, and the repo-level coverage ratchet needed proof that the full default gate could sustain a higher floor without flaking on Hypothesis-generated source laws.

Closes #193
Ref #197

## Solution
- add focused tests for coverage diagnostics, search-hit construction, query runtime action/path/tool matching, and schema pin confirmation/rejection behavior
- ratchet `[tool.coverage.report].fail_under` from 84 to 85 in `pyproject.toml`
- stabilize the two source-law tests that failed only under coverage instrumentation by disabling the deadline for generated provider bundle cardinality checks and suppressing slow-generation health checks for the conversations-wrapper stream law
- keep the history explicit with one commit for semantic coverage additions and one commit for the ratchet/stability slice

## Verification
- `pytest -q tests/unit/lib/test_coverage_diagnostics.py tests/unit/lib/test_search_hits.py tests/unit/lib/test_query_runtime_matching.py tests/unit/core/test_schema_pinning.py`
  - `13 passed`
- `pytest -q tests/unit/sources/test_source_laws.py::test_iter_json_stream_conversations_wrapper_round_trips_documents tests/unit/sources/test_source_laws.py::test_parse_payload_bundle_cardinality_contract`
  - `5 passed`
- `devtools coverage-gate --ignore-integration`
  - `5188 passed`, total coverage `85.21%`
- `devtools coverage-gate`
  - `5368 passed`, total coverage `86.02%`
- `devtools verify --quick`
  - passed locally and again in the pre-push hook


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suites validating schema pinning, coverage diagnostics, query runtime matching, and search functionality.
  * Updated test configurations to improve stability and performance across multiple test modules.

* **Chores**
  * Increased code coverage enforcement threshold to improve quality standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->