### PR TITLE
test: ratchet coverage floor to 86

### DIFF
--- a/devtools/render_cli_reference.py
+++ b/devtools/render_cli_reference.py
@@ -115,3 +115,6 @@ def main(argv: list[str] | None = None) -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
+
+
+__all__ = ["SECTIONS", "build_document", "main", "render_help", "write_if_changed"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,7 +141,7 @@ data_file = ".cache/coverage/.coverage"
 [tool.coverage.report]
 skip_empty = true
 show_missing = true
-fail_under = 85
+fail_under = 86
 
 [tool.mypy]
 python_version = "3.11"

--- a/tests/integration/test_cli_query_mode.py
+++ b/tests/integration/test_cli_query_mode.py
@@ -45,6 +45,14 @@ def _run_completion(workspace: IsolatedWorkspace, *, cwd: Path, words: str, cwor
     return records
 
 
+def _assert_only_optional_open_progress(stderr: str) -> None:
+    lines = [line for line in stderr.splitlines() if line.strip()]
+    assert all(
+        line.startswith("Query still running after ") and "route: open" in line and "retrieval: auto" in line
+        for line in lines
+    )
+
+
 def test_cli_query_count_route_returns_exact_count(tmp_path: Path) -> None:
     workspace = setup_isolated_workspace(tmp_path)
     inbox = workspace["paths"]["inbox"]
@@ -152,7 +160,7 @@ def test_cli_query_open_print_path_returns_render_target_without_launching(tmp_p
     result = run_cli(["--plain", "--latest", "open", "--print-path"], env=workspace["env"], cwd=tmp_path)
 
     assert result.exit_code == 0, result.output
-    assert result.stderr == ""
+    _assert_only_optional_open_progress(result.stderr)
     render_path = result.stdout.strip()
     assert render_path.endswith("conversation.html") or render_path.endswith("conversation.md")
 
@@ -178,7 +186,7 @@ def test_cli_query_open_print_path_accepts_query_after_verb(tmp_path: Path) -> N
     )
 
     assert result.exit_code == 0, result.output
-    assert result.stderr == ""
+    _assert_only_optional_open_progress(result.stderr)
     render_path = result.stdout.strip()
     assert render_path.endswith("conversation.html") or render_path.endswith("conversation.md")
 

--- a/tests/unit/core/test_archive_stats.py
+++ b/tests/unit/core/test_archive_stats.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from polylogue.lib.stats import ArchiveStats
+
+
+def test_archive_stats_properties_handle_empty_and_partial_embedding_states() -> None:
+    empty = ArchiveStats(total_conversations=0, total_messages=0)
+    partial = ArchiveStats(
+        total_conversations=4,
+        total_messages=10,
+        providers={"chatgpt": 2, "claude-ai": 2},
+        embedded_conversations=2,
+        embedded_messages=5,
+        pending_embedding_conversations=1,
+    )
+    stale = ArchiveStats(
+        total_conversations=4,
+        total_messages=10,
+        embedded_conversations=5,
+        embedded_messages=5,
+        stale_embedding_messages=2,
+        messages_missing_embedding_provenance=1,
+    )
+    fresh = ArchiveStats(
+        total_conversations=4,
+        total_messages=10,
+        embedded_conversations=4,
+        embedded_messages=5,
+    )
+
+    assert empty.provider_count == 0
+    assert empty.avg_messages_per_conversation == 0.0
+    assert empty.embedding_coverage == 0.0
+    assert empty.embedding_readiness_status == "none"
+    assert empty.retrieval_ready is False
+
+    assert partial.provider_count == 2
+    assert partial.avg_messages_per_conversation == 2.5
+    assert partial.embedding_coverage == 50.0
+    assert partial.embedding_readiness_status == "partial"
+    assert partial.retrieval_ready is True
+
+    assert stale.embedding_readiness_status == "stale"
+    assert stale.retrieval_ready is True
+    assert fresh.embedding_readiness_status == "fresh"
+
+
+def test_archive_stats_to_dict_rounds_and_serializes_derived_fields() -> None:
+    stats = ArchiveStats(
+        total_conversations=3,
+        total_messages=10,
+        total_attachments=2,
+        providers={"chatgpt": 3},
+        embedded_conversations=2,
+        embedded_messages=4,
+        embedding_oldest_at="2026-04-01T00:00:00Z",
+        embedding_newest_at="2026-04-02T00:00:00Z",
+        embedding_models={"text-embedding-3-small": 4},
+        embedding_dimensions={1536: 4},
+        db_size_bytes=2048,
+    )
+
+    payload = stats.to_dict()
+
+    assert payload["provider_count"] == 1
+    assert payload["embedding_coverage_percent"] == 66.7
+    assert payload["embedding_readiness_status"] == "fresh"
+    assert payload["retrieval_ready"] is True
+    assert payload["avg_messages_per_conversation"] == 3.3
+    assert payload["db_size_bytes"] == 2048

--- a/tests/unit/core/test_conversation_semantics.py
+++ b/tests/unit/core/test_conversation_semantics.py
@@ -470,6 +470,143 @@ class TestConversationProjectionContracts:
         projection = projector(projection_conversation.project())
         assert [message.id for message in projection.to_list()] == expected_ids
 
+    def test_projection_filter_helpers_cover_text_role_time_and_noise_contracts(self) -> None:
+        conversation = make_conv(
+            id="projection-rich",
+            provider="claude-ai",
+            messages=MessageCollection(
+                messages=[
+                    make_msg(
+                        id="u1",
+                        role="user",
+                        text="Needle question with detail",
+                        timestamp=datetime(2024, 1, 1, 9, 0),
+                        attachments=[Attachment(id="att-1", name="spec.md")],
+                    ),
+                    make_msg(
+                        id="a1",
+                        role="assistant",
+                        text="Needle answer with detail",
+                        timestamp=datetime(2024, 1, 1, 9, 5),
+                    ),
+                    make_msg(
+                        id="a2",
+                        role="assistant",
+                        text="Thinking step",
+                        timestamp=datetime(2024, 1, 1, 9, 10),
+                        provider_meta={"content_blocks": [{"type": "thinking", "text": "step"}]},
+                    ),
+                    make_msg(
+                        id="a3",
+                        role="assistant",
+                        text="Calling tool",
+                        timestamp=datetime(2024, 1, 1, 9, 15),
+                        content_blocks=[{"type": "tool_use", "name": "Edit"}],
+                    ),
+                    make_msg(
+                        id="s1",
+                        role="system",
+                        text="System notice",
+                        timestamp=datetime(2024, 1, 1, 9, 20),
+                    ),
+                ]
+            ),
+        )
+
+        assert [message.id for message in conversation.project().assistant_messages().to_list()] == ["a1", "a2", "a3"]
+        assert [message.id for message in conversation.project().dialogue().to_list()] == ["u1", "a1", "a2", "a3"]
+        assert [message.id for message in conversation.project().substantive().to_list()] == ["a1"]
+        assert [message.id for message in conversation.project().without_noise().to_list()] == ["a1", "a2"]
+        assert [message.id for message in conversation.project().with_attachments().to_list()] == ["u1"]
+        assert [message.id for message in conversation.project().min_words(3).to_list()] == ["u1", "a1"]
+        assert [message.id for message in conversation.project().max_words(2).to_list()] == ["a2", "a3", "s1"]
+        assert [message.id for message in conversation.project().contains("needle").to_list()] == ["u1", "a1"]
+        assert [message.id for message in conversation.project().contains("Needle", case_sensitive=True).to_list()] == [
+            "u1",
+            "a1",
+        ]
+        assert [message.id for message in conversation.project().matches(r"Needle\s+answer").to_list()] == ["a1"]
+        assert [message.id for message in conversation.project().since(datetime(2024, 1, 1, 9, 5)).to_list()] == [
+            "a1",
+            "a2",
+            "a3",
+            "s1",
+        ]
+        assert [message.id for message in conversation.project().until(datetime(2024, 1, 1, 9, 10)).to_list()] == [
+            "u1",
+            "a1",
+            "a2",
+        ]
+        assert [
+            message.id
+            for message in conversation.project()
+            .between(datetime(2024, 1, 1, 9, 5), datetime(2024, 1, 1, 9, 15))
+            .to_list()
+        ] == ["a1", "a2", "a3"]
+        assert [message.id for message in conversation.project().thinking_only().to_list()] == ["a2"]
+        assert [message.id for message in conversation.project().tool_use_only().to_list()] == ["a3"]
+
+    def test_projection_transform_and_terminal_helpers_cover_empty_and_render_paths(self) -> None:
+        conversation = make_conv(
+            id="projection-transform",
+            provider="claude-ai",
+            messages=MessageCollection(
+                messages=[
+                    make_msg(
+                        id="u1",
+                        role="user",
+                        text="Alpha text",
+                        attachments=[Attachment(id="att-1", name="draft.md")],
+                    ),
+                    make_msg(
+                        id="a1",
+                        role="assistant",
+                        text="Very long assistant answer",
+                    ),
+                    make_msg(
+                        id="a2",
+                        role="assistant",
+                        text="Thinking trace",
+                        provider_meta={"content_blocks": [{"type": "thinking", "text": "trace"}]},
+                    ),
+                    make_msg(
+                        id="a3",
+                        role="assistant",
+                        text="Tool output",
+                        content_blocks=[{"type": "tool_use", "name": "Edit"}],
+                    ),
+                ]
+            ),
+        )
+
+        stripped = conversation.project().strip_attachments().truncate_text(4, suffix="..").execute()
+        stripped_messages = list(stripped.messages)
+        assert stripped_messages[0].attachments == []
+        assert stripped_messages[1].text == "Very.."
+
+        assert [message.id for message in conversation.project().strip_tools().to_list()] == ["u1", "a1", "a2"]
+        assert [message.id for message in conversation.project().strip_thinking().to_list()] == ["u1", "a1", "a3"]
+        assert [message.id for message in conversation.project().strip_all().to_list()] == ["u1", "a1"]
+        assert [message.id for message in conversation.project().first_n(2).to_list()] == ["u1", "a1"]
+        assert [message.id for message in conversation.project().last_n(2).to_list()] == ["a3", "a2"]
+        first_message = conversation.project().first()
+        last_message = conversation.project().last()
+        assert first_message is not None
+        assert last_message is not None
+        assert first_message.id == "u1"
+        assert last_message.id == "a3"
+        assert conversation.project().exists() is True
+        assert conversation.project().to_text(separator=" | ") == (
+            "user: Alpha text | assistant: Very long assistant answer | assistant: Thinking trace | assistant: Tool output"
+        )
+        assert conversation.project().to_text(include_role=False, separator=" | ") == (
+            "Alpha text | Very long assistant answer | Thinking trace | Tool output"
+        )
+        assert conversation.project().limit(0).to_list() == []
+        assert conversation.project().limit(0).first() is None
+        assert conversation.project().limit(0).last() is None
+        assert conversation.project().limit(0).exists() is False
+
 
 class TestConversationRendering:
     @pytest.fixture

--- a/tests/unit/core/test_message_laws.py
+++ b/tests/unit/core/test_message_laws.py
@@ -7,7 +7,7 @@ Conversation. Example-heavy semantic projections live in
 
 from __future__ import annotations
 
-from hypothesis import given
+from hypothesis import HealthCheck, given, settings
 
 from polylogue.lib.models import Conversation, Message
 from polylogue.lib.roles import Role
@@ -15,62 +15,73 @@ from tests.infra.strategies.messages import conversation_model_strategy, message
 
 
 @given(message_model_strategy())
+@settings(suppress_health_check=[HealthCheck.too_slow])
 def test_message_role_is_typed_enum(msg: Message) -> None:
     assert isinstance(msg.role, Role)
 
 
 @given(message_model_strategy())
+@settings(suppress_health_check=[HealthCheck.too_slow])
 def test_word_count_matches_text_split(msg: Message) -> None:
     assert msg.word_count == len((msg.text or "").split())
 
 
 @given(message_model_strategy())
+@settings(suppress_health_check=[HealthCheck.too_slow])
 def test_noise_and_substantive_mutually_exclusive(msg: Message) -> None:
     assert not (msg.is_noise and msg.is_substantive)
 
 
 @given(message_model_strategy())
+@settings(suppress_health_check=[HealthCheck.too_slow])
 def test_thinking_and_substantive_mutually_exclusive(msg: Message) -> None:
     assert not (msg.is_thinking and msg.is_substantive)
 
 
 @given(message_model_strategy())
+@settings(suppress_health_check=[HealthCheck.too_slow])
 def test_tool_use_implies_noise(msg: Message) -> None:
     if msg.is_tool_use:
         assert msg.is_noise
 
 
 @given(message_model_strategy())
+@settings(suppress_health_check=[HealthCheck.too_slow])
 def test_context_dump_implies_noise(msg: Message) -> None:
     if msg.is_context_dump:
         assert msg.is_noise
 
 
 @given(message_model_strategy())
+@settings(suppress_health_check=[HealthCheck.too_slow])
 def test_substantive_implies_dialogue(msg: Message) -> None:
     if msg.is_substantive:
         assert msg.is_dialogue
 
 
 @given(message_model_strategy())
+@settings(suppress_health_check=[HealthCheck.too_slow])
 def test_dialogue_implies_user_or_assistant(msg: Message) -> None:
     if msg.is_dialogue:
         assert msg.is_user or msg.is_assistant
 
 
 @given(conversation_model_strategy())
+@settings(suppress_health_check=[HealthCheck.too_slow])
 def test_without_noise_removes_all_noise(conv: Conversation) -> None:
     clean = conv.without_noise()
     assert all(not msg.is_noise for msg in clean.messages)
 
 
 @given(conversation_model_strategy())
+@settings(suppress_health_check=[HealthCheck.too_slow])
 def test_substantive_only_all_substantive(conv: Conversation) -> None:
     filtered = conv.substantive_only()
     assert all(msg.is_substantive for msg in filtered.messages)
 
 
 @given(conversation_model_strategy())
+@settings(suppress_health_check=[HealthCheck.too_slow])
 def test_without_noise_preserves_non_noise_count(conv: Conversation) -> None:
     expected_ids = [msg.id for msg in conv.messages if not msg.is_noise]
     clean = conv.without_noise()
@@ -78,6 +89,7 @@ def test_without_noise_preserves_non_noise_count(conv: Conversation) -> None:
 
 
 @given(conversation_model_strategy())
+@settings(suppress_health_check=[HealthCheck.too_slow])
 def test_substantive_only_preserves_count(conv: Conversation) -> None:
     expected_ids = [msg.id for msg in conv.messages if msg.is_substantive]
     filtered = conv.substantive_only()
@@ -85,6 +97,7 @@ def test_substantive_only_preserves_count(conv: Conversation) -> None:
 
 
 @given(conversation_model_strategy())
+@settings(suppress_health_check=[HealthCheck.too_slow])
 def test_with_roles_preserves_selected_role_count(conv: Conversation) -> None:
     expected_ids = [msg.id for msg in conv.messages if msg.is_user]
     filtered = conv.with_roles((Role.USER,))
@@ -92,6 +105,7 @@ def test_with_roles_preserves_selected_role_count(conv: Conversation) -> None:
 
 
 @given(conversation_model_strategy())
+@settings(suppress_health_check=[HealthCheck.too_slow])
 def test_without_noise_idempotent(conv: Conversation) -> None:
     once = conv.without_noise()
     twice = once.without_noise()
@@ -99,18 +113,21 @@ def test_without_noise_idempotent(conv: Conversation) -> None:
 
 
 @given(message_model_strategy())
+@settings(suppress_health_check=[HealthCheck.too_slow])
 def test_extract_thinking_never_empty_string(msg: Message) -> None:
     result = msg.extract_thinking()
     assert result is None or (isinstance(result, str) and len(result.strip()) > 0)
 
 
 @given(message_model_strategy())
+@settings(suppress_health_check=[HealthCheck.too_slow])
 def test_cost_usd_none_or_positive(msg: Message) -> None:
     if msg.cost_usd is not None:
         assert msg.cost_usd > 0
 
 
 @given(message_model_strategy())
+@settings(suppress_health_check=[HealthCheck.too_slow])
 def test_duration_ms_none_or_positive(msg: Message) -> None:
     if msg.duration_ms is not None:
         assert msg.duration_ms > 0

--- a/tests/unit/core/test_models.py
+++ b/tests/unit/core/test_models.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from unittest.mock import Mock
 
 import pytest
+from pydantic import TypeAdapter
 
 from polylogue.lib.json import JSONDocument, JSONValue, json_document
 from polylogue.lib.messages import MessageCollection
@@ -165,6 +166,25 @@ class TestMessageCollectionContracts:
     def test_is_lazy_is_always_false(self) -> None:
         assert MessageCollection(messages=[]).is_lazy is False
 
+    def test_sequence_surface_round_trips_eager_messages(self) -> None:
+        msg1 = make_msg(id="m1", role=Role.USER, text="hello")
+        msg2 = make_msg(id="m2", role=Role.ASSISTANT, text="world")
+        collection = MessageCollection(messages=[msg1, msg2])
+
+        assert len(collection) == 2
+        assert bool(collection) is True
+        assert list(collection) == [msg1, msg2]
+        assert collection[0] == msg1
+        assert collection[:1] == [msg1]
+        assert repr(collection) == "MessageCollection(eager, 2 messages)"
+        assert collection == MessageCollection(messages=[msg1, msg2])
+        assert collection.__eq__(object()) is NotImplemented
+        assert hash(collection) == id(collection)
+        copy = collection.to_list()
+        copy.pop()
+        assert len(collection) == 2
+        assert MessageCollection.empty().to_list() == []
+
     def test_materialize_is_noop(self) -> None:
         collection = MessageCollection(messages=[make_msg(id="m1", role=Role.USER, text="hello")])
         assert collection.materialize() is collection
@@ -183,6 +203,27 @@ class TestMessageCollectionContracts:
         json_schema = MessageCollection.__get_pydantic_json_schema__(Mock(), handler)
         assert json_schema["type"] == "array"
         assert "items" in json_schema
+
+    def test_type_adapter_accepts_list_and_existing_collection(self) -> None:
+        adapter = TypeAdapter(MessageCollection)
+        existing = MessageCollection(messages=[make_msg(id="m2", role=Role.ASSISTANT, text="existing")])
+
+        from_list = adapter.validate_python([make_msg(id="m1", role=Role.USER, text="hello")])
+        reused = adapter.validate_python(existing)
+
+        assert isinstance(from_list, MessageCollection)
+        assert from_list.to_list()[0].id == "m1"
+        assert reused is existing
+
+        with pytest.raises(ValueError, match="Expected MessageCollection or list"):
+            adapter.validate_python("bad")
+
+    def test_get_pydantic_json_schema_requires_generate(self) -> None:
+        handler = Mock()
+        del handler.generate
+
+        with pytest.raises(TypeError, match="does not expose generate"):
+            MessageCollection.__get_pydantic_json_schema__(Mock(), handler)
 
 
 class TestPinnedSemanticRegressions:

--- a/tests/unit/core/test_operator_inference.py
+++ b/tests/unit/core/test_operator_inference.py
@@ -3,16 +3,29 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
+from typing import cast
 from unittest.mock import patch
+
+import pytest
 
 from polylogue.lib.json import JSONDocument
 from polylogue.schemas.generation_models import GenerationResult
 from polylogue.schemas.operator_inference import (
+    audit_schemas,
+    compare_schema_versions,
     infer_schema,
     list_inferred_corpus_scenarios,
     list_inferred_corpus_specs,
+    list_schemas,
+    promote_schema_cluster,
 )
-from polylogue.schemas.operator_models import SchemaInferRequest
+from polylogue.schemas.operator_models import (
+    SchemaAuditRequest,
+    SchemaCompareRequest,
+    SchemaInferRequest,
+    SchemaListRequest,
+    SchemaPromoteRequest,
+)
 from polylogue.schemas.operator_registry import SchemaRegistryLike
 from polylogue.schemas.packages import (
     SchemaElementManifest,
@@ -20,6 +33,7 @@ from polylogue.schemas.packages import (
     SchemaResolution,
     SchemaVersionPackage,
 )
+from polylogue.schemas.privacy_config import PrivacyConfig
 from polylogue.schemas.tooling_models import ClusterManifest, SchemaCluster, SchemaDiff
 
 
@@ -36,16 +50,28 @@ class _FakeSchemaRegistry(SchemaRegistryLike):
         manifests: dict[str, ClusterManifest | None] | None = None,
         clustered_manifest: ClusterManifest | None = None,
         manifest_path: Path | None = None,
+        diff: SchemaDiff | None = None,
+        promoted_version: str = "v99",
+        promoted_package: SchemaVersionPackage | None = None,
+        promoted_schema: JSONDocument | None = None,
+        schema_age_days: dict[str, int | None] | None = None,
     ) -> None:
         self._catalogs = catalogs or {}
         self._manifests = manifests or {}
         self._clustered_manifest = clustered_manifest
         self._manifest_path = manifest_path or Path("manifest.json")
+        self._diff = diff or SchemaDiff(provider="test", version_a="v1", version_b="v2")
+        self._promoted_version = promoted_version
+        self._promoted_package = promoted_package
+        self._promoted_schema = promoted_schema
+        self._schema_age_days = schema_age_days or {}
 
     def load_package_catalog(self, provider: str) -> SchemaPackageCatalog | None:
         return self._catalogs.get(provider)
 
     def get_package(self, provider: str, version: str = "default") -> SchemaVersionPackage | None:
+        if self._promoted_package is not None and version == self._promoted_version:
+            return self._promoted_package
         catalog = self.load_package_catalog(provider)
         return catalog.package(version) if catalog is not None else None
 
@@ -56,9 +82,13 @@ class _FakeSchemaRegistry(SchemaRegistryLike):
         version: str = "default",
         element_kind: str | None = None,
     ) -> JSONDocument | None:
+        if version == self._promoted_version:
+            return self._promoted_schema
         return None
 
     def list_versions(self, provider: str) -> list[str]:
+        if self._promoted_package is not None:
+            return [self._promoted_version]
         catalog = self.load_package_catalog(provider)
         return [package.version for package in catalog.packages] if catalog is not None else []
 
@@ -67,7 +97,7 @@ class _FakeSchemaRegistry(SchemaRegistryLike):
         return sorted(provider_names)
 
     def get_schema_age_days(self, provider: str) -> int | None:
-        return None
+        return self._schema_age_days.get(provider)
 
     def resolve_payload(
         self,
@@ -86,7 +116,7 @@ class _FakeSchemaRegistry(SchemaRegistryLike):
         *,
         element_kind: str | None = None,
     ) -> SchemaDiff:
-        raise AssertionError("compare_versions should not be called in this test")
+        return self._diff
 
     def cluster_samples(self, provider: str, samples: Sequence[Mapping[str, object]]) -> ClusterManifest:
         if self._clustered_manifest is None:
@@ -106,7 +136,7 @@ class _FakeSchemaRegistry(SchemaRegistryLike):
         *,
         samples: Sequence[Mapping[str, object]] | None = None,
     ) -> str:
-        raise AssertionError("promote_cluster should not be called in this test")
+        return self._promoted_version
 
 
 def test_infer_schema_emits_default_corpus_specs_without_clustering(tmp_path: Path) -> None:
@@ -351,3 +381,211 @@ def test_list_inferred_corpus_specs_can_scope_to_one_provider() -> None:
 
     assert tuple(spec.provider for spec in specs) == ("chatgpt",)
     assert specs[0].package_version == "v3"
+
+
+def test_infer_schema_coerces_privacy_config_and_falls_back_without_db_provider(tmp_path: Path) -> None:
+    captured_privacy: list[PrivacyConfig | None] = []
+    generation = GenerationResult(
+        provider="chatgpt",
+        schema={"type": "object"},
+        sample_count=5,
+        default_version="v2",
+    )
+    fake_provider = _ProviderConfig(db_provider_name=None)
+
+    def _generate_provider_schema(*args: object, **kwargs: object) -> GenerationResult:
+        captured_privacy.append(cast(PrivacyConfig | None, kwargs["privacy_config"]))
+        return generation
+
+    with (
+        patch("polylogue.schemas.generation_workflow.generate_provider_schema", side_effect=_generate_provider_schema),
+        patch.dict("polylogue.schemas.observation.PROVIDERS", {"chatgpt": fake_provider}, clear=False),
+    ):
+        result = infer_schema(
+            SchemaInferRequest(
+                provider="chatgpt",
+                db_path=tmp_path / "archive.db",
+                cluster=True,
+                privacy_config={
+                    "level": "strict",
+                    "field_overrides": {"$.id": "drop", "bad": 1},
+                    "allow_value_patterns": ["ok", 2],
+                    "deny_value_patterns": ["secret"],
+                    "safe_enum_max_length": "bad",
+                    "high_entropy_min_length": 14,
+                    "cross_conv_min_count": 5,
+                    "cross_conv_proportional": True,
+                },
+            )
+        )
+
+    privacy = cast(PrivacyConfig, captured_privacy[0])
+    assert privacy is not None
+    assert privacy.level == "strict"
+    assert privacy.safe_enum_max_length == 30
+    assert privacy.high_entropy_min_length == 14
+    assert privacy.cross_conv_min_count == 5
+    assert privacy.cross_conv_proportional is True
+    assert privacy.field_overrides == {"$.id": "drop"}
+    assert privacy.allow_value_patterns == ["ok"]
+    assert privacy.deny_value_patterns == ["secret"]
+    assert result.manifest is None
+    assert len(result.corpus_scenarios) == 1
+
+
+def test_list_schemas_returns_selected_and_all_provider_snapshots() -> None:
+    catalog = SchemaPackageCatalog(
+        provider="chatgpt",
+        default_version="v7",
+        latest_version="v7",
+        packages=[
+            SchemaVersionPackage(
+                provider="chatgpt",
+                version="v7",
+                anchor_kind="conversation_document",
+                default_element_kind="conversation_document",
+                first_seen="2026-04-01T00:00:00Z",
+                last_seen="2026-04-02T00:00:00Z",
+                bundle_scope_count=1,
+                sample_count=12,
+            )
+        ],
+    )
+    manifest = ClusterManifest(
+        provider="chatgpt",
+        clusters=[
+            SchemaCluster(
+                cluster_id="cluster-a",
+                provider="chatgpt",
+                sample_count=12,
+                first_seen="2026-04-01T00:00:00Z",
+                last_seen="2026-04-02T00:00:00Z",
+                representative_paths=["/tmp/source.json"],
+                dominant_keys=["id"],
+                confidence=0.9,
+                artifact_kind="conversation_document",
+            )
+        ],
+    )
+    fake_registry = _FakeSchemaRegistry(
+        catalogs={"chatgpt": catalog},
+        manifests={"chatgpt": manifest, "codex": None},
+        schema_age_days={"chatgpt": 3, "codex": None},
+    )
+
+    with patch("polylogue.schemas.operator_inference.schema_registry", return_value=fake_registry):
+        selected = list_schemas(SchemaListRequest(provider="chatgpt"))
+        listing = list_schemas(SchemaListRequest())
+
+    assert selected.selected is not None
+    assert selected.selected.provider == "chatgpt"
+    assert selected.selected.latest_age_days == 3
+    assert selected.selected.to_dict()["provider"] == "chatgpt"
+    assert [snapshot.provider for snapshot in listing.providers] == ["chatgpt", "codex"]
+
+
+def test_compare_schema_versions_wraps_registry_diff() -> None:
+    diff = SchemaDiff(
+        provider="chatgpt",
+        version_a="v1",
+        version_b="v2",
+        changed_properties=["messages"],
+    )
+    fake_registry = _FakeSchemaRegistry(diff=diff)
+
+    with patch("polylogue.schemas.operator_inference.schema_registry", return_value=fake_registry):
+        result = compare_schema_versions(SchemaCompareRequest(provider="chatgpt", from_version="v1", to_version="v2"))
+
+    assert result.diff is diff
+    assert result.to_dict()["provider"] == "chatgpt"
+
+
+def test_promote_schema_cluster_with_samples_filters_matching_cluster(tmp_path: Path) -> None:
+    promoted_package = SchemaVersionPackage(
+        provider="chatgpt",
+        version="v8",
+        anchor_kind="conversation_document",
+        default_element_kind="conversation_document",
+        first_seen="2026-04-01T00:00:00Z",
+        last_seen="2026-04-02T00:00:00Z",
+        bundle_scope_count=1,
+        sample_count=2,
+    )
+    fake_registry = _FakeSchemaRegistry(
+        promoted_version="v8",
+        promoted_package=promoted_package,
+        promoted_schema={"type": "object"},
+    )
+    fake_provider = _ProviderConfig(db_provider_name="chatgpt")
+
+    with (
+        patch("polylogue.schemas.operator_inference.schema_registry", return_value=fake_registry),
+        patch.dict("polylogue.schemas.observation.PROVIDERS", {"chatgpt": fake_provider}, clear=False),
+        patch("polylogue.schemas.sampling.load_samples_from_db", return_value=[{"id": "one"}, {"id": "two"}]),
+        patch("polylogue.schemas.shape_fingerprint._structure_fingerprint", lambda sample: sample["id"]),
+        patch(
+            "polylogue.schemas.observation.fingerprint_hash",
+            lambda fingerprint: "cluster-a" if fingerprint == "one" else "other",
+        ),
+    ):
+        result = promote_schema_cluster(
+            SchemaPromoteRequest(
+                provider="chatgpt",
+                cluster_id="cluster-a",
+                db_path=tmp_path / "archive.db",
+                with_samples=True,
+            )
+        )
+
+    assert result.package_version == "v8"
+    assert result.package is promoted_package
+    assert result.schema == {"type": "object"}
+    assert result.versions == ["v8"]
+
+
+def test_promote_schema_cluster_rejects_unknown_provider_and_missing_cluster_samples(tmp_path: Path) -> None:
+    fake_registry = _FakeSchemaRegistry()
+
+    with (
+        patch("polylogue.schemas.operator_inference.schema_registry", return_value=fake_registry),
+        patch.dict("polylogue.schemas.observation.PROVIDERS", {}, clear=True),
+    ):
+        with pytest.raises(ValueError, match="Unknown provider"):
+            promote_schema_cluster(
+                SchemaPromoteRequest(
+                    provider="chatgpt",
+                    cluster_id="cluster-a",
+                    db_path=tmp_path / "archive.db",
+                    with_samples=True,
+                )
+            )
+
+    fake_provider = _ProviderConfig(db_provider_name="chatgpt")
+    with (
+        patch("polylogue.schemas.operator_inference.schema_registry", return_value=fake_registry),
+        patch.dict("polylogue.schemas.observation.PROVIDERS", {"chatgpt": fake_provider}, clear=False),
+        patch("polylogue.schemas.sampling.load_samples_from_db", return_value=[{"id": "two"}]),
+        patch("polylogue.schemas.shape_fingerprint._structure_fingerprint", lambda sample: sample["id"]),
+        patch("polylogue.schemas.observation.fingerprint_hash", lambda _fingerprint: "other"),
+    ):
+        with pytest.raises(ValueError, match="No samples match cluster"):
+            promote_schema_cluster(
+                SchemaPromoteRequest(
+                    provider="chatgpt",
+                    cluster_id="cluster-a",
+                    db_path=tmp_path / "archive.db",
+                    with_samples=True,
+                )
+            )
+
+
+def test_audit_schemas_selects_provider_or_global_workflow() -> None:
+    provider_report = object()
+    all_report = object()
+
+    with (
+        patch("polylogue.schemas.audit_workflow.audit_provider", return_value=provider_report),
+        patch("polylogue.schemas.audit_workflow.audit_all_providers", return_value=all_report),
+    ):
+        assert audit_schemas(SchemaAuditRequest(provider="chatgpt")) is provider_report
+        assert audit_schemas(SchemaAuditRequest()) is all_report

--- a/tests/unit/core/test_runtime_registry_helpers.py
+++ b/tests/unit/core/test_runtime_registry_helpers.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+import gzip
+import json
+from pathlib import Path
+
+import pytest
+
+from polylogue.schemas.packages import SchemaElementManifest, SchemaPackageCatalog, SchemaVersionPackage
+from polylogue.schemas.runtime_registry import (
+    SchemaRegistry,
+    _ObservedPayload,
+    _read_gzip_json_dict,
+    _read_json_dict,
+    _resolved_package_version,
+    canonical_schema_provider,
+)
+from polylogue.types import Provider
+
+
+def _package(
+    version: str,
+    *,
+    default_element_kind: str = "conversation_document",
+    exact_structure_ids: list[str] | None = None,
+    bundle_scopes: list[str] | None = None,
+    profile_tokens: list[str] | None = None,
+    schema_file: str | None = "conversation_document.schema.json.gz",
+) -> SchemaVersionPackage:
+    return SchemaVersionPackage(
+        provider="chatgpt",
+        version=version,
+        anchor_kind=default_element_kind,
+        default_element_kind=default_element_kind,
+        first_seen="2026-04-01T00:00:00Z",
+        last_seen="2026-04-02T00:00:00Z",
+        bundle_scope_count=1,
+        sample_count=1,
+        bundle_scopes=bundle_scopes or [],
+        elements=[
+            SchemaElementManifest(
+                element_kind=default_element_kind,
+                schema_file=schema_file,
+                sample_count=1,
+                artifact_count=1,
+                bundle_scopes=bundle_scopes or [],
+                exact_structure_ids=exact_structure_ids or [],
+                profile_tokens=profile_tokens or [],
+            ),
+            SchemaElementManifest(
+                element_kind="adjunct",
+                schema_file=None,
+                sample_count=0,
+                artifact_count=0,
+            ),
+        ],
+    )
+
+
+def _catalog(*packages: SchemaVersionPackage) -> SchemaPackageCatalog:
+    return SchemaPackageCatalog(
+        provider="chatgpt",
+        packages=list(packages),
+        default_version=packages[0].version if packages else None,
+        latest_version=packages[-1].version if packages else None,
+        recommended_version=packages[0].version if packages else None,
+    )
+
+
+def test_runtime_registry_helper_contracts_cover_json_and_provider_normalization(tmp_path: Path) -> None:
+    json_path = tmp_path / "schema.json"
+    json_path.write_text(json.dumps({"type": "object"}), encoding="utf-8")
+    gzip_path = tmp_path / "schema.json.gz"
+    gzip_path.write_bytes(gzip.compress(json.dumps({"type": "object"}).encode("utf-8")))
+
+    assert _read_json_dict(json_path) == {"type": "object"}
+    assert _read_gzip_json_dict(gzip_path) == {"type": "object"}
+    assert canonical_schema_provider("chatgpt") is Provider.CHATGPT
+    assert canonical_schema_provider(" custom-provider ") == "custom-provider"
+    assert canonical_schema_provider("") is Provider.UNKNOWN
+
+    bad_json_path = tmp_path / "bad.json"
+    bad_json_path.write_text(json.dumps(["bad"]), encoding="utf-8")
+    bad_gzip_path = tmp_path / "bad.json.gz"
+    bad_gzip_path.write_bytes(gzip.compress(json.dumps(["bad"]).encode("utf-8")))
+
+    with pytest.raises(ValueError, match="Expected JSON object"):
+        _read_json_dict(bad_json_path)
+
+    with pytest.raises(ValueError, match="Expected gzipped JSON object"):
+        _read_gzip_json_dict(bad_gzip_path)
+
+
+def test_resolved_package_version_prefers_default_latest_and_recommended() -> None:
+    catalog = SchemaPackageCatalog(
+        provider="chatgpt",
+        packages=[],
+        default_version="v2",
+        latest_version="v3",
+        recommended_version="v1",
+    )
+
+    assert _resolved_package_version(catalog, "default") == "v2"
+    assert _resolved_package_version(catalog, "latest") == "v3"
+    assert _resolved_package_version(catalog, "recommended") == "v1"
+    assert _resolved_package_version(catalog, "v9") == "v9"
+
+
+def test_write_and_replace_provider_packages_remove_stale_versions(tmp_path: Path) -> None:
+    registry = SchemaRegistry(storage_root=tmp_path / "schemas")
+    old_catalog = _catalog(_package("v1"))
+    new_catalog = _catalog(_package("v2"))
+
+    registry.replace_provider_packages(
+        "chatgpt",
+        old_catalog,
+        {"v1": {"conversation_document": {"type": "object"}}},
+    )
+    old_manifest = registry._package_manifest_path("chatgpt", "v1")
+    assert old_manifest.exists()
+
+    registry.replace_provider_packages(
+        "chatgpt",
+        new_catalog,
+        {"v2": {"conversation_document": {"type": "object"}}},
+    )
+
+    assert not old_manifest.exists()
+    assert registry._package_manifest_path("chatgpt", "v2").exists()
+    assert "chatgpt" in registry.list_providers()
+
+
+def test_get_element_schema_handles_missing_elements_and_files(tmp_path: Path) -> None:
+    registry = SchemaRegistry(storage_root=tmp_path / "schemas")
+    catalog = _catalog(_package("v1", schema_file="conversation_document.schema.json.gz"))
+    registry.replace_provider_packages(
+        "chatgpt",
+        catalog,
+        {"v1": {"conversation_document": {"type": "object"}}},
+    )
+
+    assert registry.get_element_schema("chatgpt", version="v1", element_kind="adjunct") is None
+
+    schema_path = registry._package_dir("chatgpt", "v1") / "elements" / "conversation_document.schema.json.gz"
+    schema_path.unlink()
+    registry.clear_cache()
+
+    assert registry.get_element_schema("chatgpt", version="v1") is None
+
+
+def test_resolve_payload_prefers_exact_structure_then_profile_then_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    registry = SchemaRegistry()
+    catalog = _catalog(
+        _package("v1", exact_structure_ids=["exact-1"], bundle_scopes=["document"], profile_tokens=["field:mapping"]),
+        _package("v2", bundle_scopes=["session"], profile_tokens=["field:messages"]),
+    )
+    monkeypatch.setattr(registry, "load_package_catalog", lambda _provider: catalog)
+
+    exact_then_profile = (
+        _ObservedPayload(
+            artifact_kind="conversation_document",
+            bundle_scope="session",
+            exact_structure_id=None,
+            profile_tokens=("field:messages",),
+        ),
+        _ObservedPayload(
+            artifact_kind="conversation_document",
+            bundle_scope="document",
+            exact_structure_id="exact-1",
+            profile_tokens=("field:mapping",),
+        ),
+    )
+    monkeypatch.setattr(
+        SchemaRegistry,
+        "_observed_payloads",
+        lambda self, provider, payload, source_path=None: exact_then_profile,
+    )
+
+    exact = registry.resolve_payload("chatgpt", {"mapping": {}}, source_path="/tmp/chat.json")
+    assert exact is not None
+    assert exact.package_version == "v1"
+    assert exact.reason == "exact_structure"
+
+    profile_only = (
+        _ObservedPayload(
+            artifact_kind="conversation_document",
+            bundle_scope=None,
+            exact_structure_id=None,
+            profile_tokens=("field:messages",),
+        ),
+    )
+    monkeypatch.setattr(
+        SchemaRegistry,
+        "_observed_payloads",
+        lambda self, provider, payload, source_path=None: profile_only,
+    )
+
+    profile = registry.resolve_payload("chatgpt", {"messages": []}, source_path="/tmp/chat.json")
+    assert profile is not None
+    assert profile.package_version == "v2"
+    assert profile.reason == "profile_family"
+    assert profile.profile_score is not None
+
+    default_only = (
+        _ObservedPayload(
+            artifact_kind="conversation_document",
+            bundle_scope="unmatched",
+            exact_structure_id=None,
+            profile_tokens=(),
+        ),
+    )
+    monkeypatch.setattr(
+        SchemaRegistry,
+        "_observed_payloads",
+        lambda self, provider, payload, source_path=None: default_only,
+    )
+
+    default = registry.resolve_payload("chatgpt", {"messages": []}, source_path="/tmp/chat.json")
+    assert default is not None
+    assert default.package_version == "v1"
+    assert default.reason == "package_default"
+
+
+def test_resolve_payload_returns_none_when_catalog_is_absent(monkeypatch: pytest.MonkeyPatch) -> None:
+    registry = SchemaRegistry()
+    monkeypatch.setattr(registry, "load_package_catalog", lambda _provider: None)
+
+    assert registry.resolve_payload("chatgpt", {"mapping": {}}) is None

--- a/tests/unit/core/test_schema_extraction_runtime.py
+++ b/tests/unit/core/test_schema_extraction_runtime.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
+
+import pytest
+
 from polylogue.lib.json import JSONDocument
 from polylogue.schemas.extraction import extract_message_from_schema
 from polylogue.schemas.observation import ProviderConfig, extract_schema_units_from_payload
@@ -68,6 +72,78 @@ class TestExtractMessageFromSchema:
         assert len(message.content_blocks) == 3
         assert len(message.reasoning_traces) == 1
         assert len(message.tool_calls) == 1
+
+    def test_uses_pinned_paths_with_wildcards_and_message_id_aliases(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr("polylogue.schemas.extraction.load_pins", lambda _provider: object())
+        monkeypatch.setattr(
+            "polylogue.schemas.extraction.resolve_pinned_paths",
+            lambda _schema, _pins: {
+                "message_role": ".meta.*.sender",
+                "message_body": ".payload.parts",
+                "message_timestamp": ".timestamps.anyOf[0].created_at",
+            },
+        )
+        raw: JSONDocument = {
+            "messageId": "msg-2",
+            "meta": {"nested": {"sender": "assistant"}},
+            "payload": {
+                "parts": [
+                    {"type": "text", "text": "Pinned text"},
+                    {"type": "tool_use", "name": "edit", "input": {"path": "a.txt"}},
+                ]
+            },
+            "timestamps": {"created_at": "2026-01-02T00:00:00Z"},
+            "message": {"model": 123, "usage": {"output_tokens": 7}},
+        }
+
+        message = extract_message_from_schema(raw, schema={}, provider=Provider.CLAUDE_CODE)
+
+        assert message.id == "msg-2"
+        assert str(message.role) == "assistant"
+        assert message.text == "Pinned text"
+        assert message.timestamp == datetime(2026, 1, 2, tzinfo=timezone.utc)
+        assert message.model is None
+        assert message.tokens is not None
+        assert message.tokens.output_tokens == 7
+        assert len(message.content_blocks) == 2
+        assert len(message.tool_calls) == 1
+
+    def test_extracts_nested_parts_and_scalar_body_fallbacks(self) -> None:
+        nested_raw: JSONDocument = {
+            "id": "msg-nested",
+            "author": "assistant",
+            "message": {
+                "content": {
+                    "parts": [
+                        {"text": "Nested"},
+                        {"content": "parts"},
+                    ]
+                }
+            },
+            "cost_usd": 0.5,
+            "duration_ms": 4.9,
+        }
+        scalar_raw: JSONDocument = {
+            "id": "msg-scalar",
+            "body": 5,
+            "durationMs": True,
+            "costUSD": "bad",
+        }
+
+        nested = extract_message_from_schema(nested_raw, schema={}, provider=Provider.CHATGPT)
+        scalar = extract_message_from_schema(scalar_raw, schema={}, provider=Provider.UNKNOWN)
+
+        assert nested.text == "Nested\nparts"
+        assert nested.cost is not None
+        assert nested.cost.total_usd == 0.5
+        assert nested.duration_ms == 4
+        assert scalar.text == "5"
+        assert str(scalar.role) == "unknown"
+        assert scalar.duration_ms is None
+        assert scalar.cost is None
 
 
 class TestExtractSchemaUnitsFromPayload:

--- a/tests/unit/core/test_session_summaries.py
+++ b/tests/unit/core/test_session_summaries.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+
+from polylogue.lib.session_profile import SessionProfile
+from polylogue.lib.session_summaries import summarize_day, summarize_days, summarize_week, summarize_weeks
+from polylogue.lib.work_event_extraction import WorkEvent, WorkEventKind
+
+
+def _profile(
+    conversation_id: str,
+    *,
+    provider: str,
+    created_at: datetime | None,
+    first_message_at: datetime | None,
+    canonical_session_date: date | None,
+    repo_names: tuple[str, ...] = (),
+    repo_paths: tuple[str, ...] = (),
+    work_events: tuple[WorkEvent, ...] = (),
+    total_cost_usd: float = 0.0,
+    total_duration_ms: int = 0,
+    wall_duration_ms: int = 0,
+    message_count: int = 0,
+    word_count: int = 0,
+) -> SessionProfile:
+    return SessionProfile(
+        conversation_id=conversation_id,
+        provider=provider,
+        title=None,
+        created_at=created_at,
+        updated_at=created_at,
+        message_count=message_count,
+        substantive_count=message_count,
+        tool_use_count=0,
+        thinking_count=0,
+        attachment_count=0,
+        word_count=word_count,
+        total_cost_usd=total_cost_usd,
+        total_duration_ms=total_duration_ms,
+        tool_categories={},
+        repo_paths=repo_paths,
+        cwd_paths=(),
+        branch_names=(),
+        file_paths_touched=(),
+        languages_detected=(),
+        repo_names=repo_names,
+        work_events=work_events,
+        phases=(),
+        first_message_at=first_message_at,
+        canonical_session_date=canonical_session_date,
+        wall_duration_ms=wall_duration_ms,
+    )
+
+
+def _work_event(kind: WorkEventKind, index: int) -> WorkEvent:
+    return WorkEvent(
+        kind=kind,
+        start_index=index,
+        end_index=index,
+        confidence=1.0,
+        evidence=(kind.value,),
+        file_paths=(),
+        tools_used=(kind.value,),
+        summary=f"{kind.value} event",
+        start_time=datetime(2026, 4, 23, 12, index),
+        end_time=datetime(2026, 4, 23, 12, index, 1),
+    )
+
+
+def test_summarize_day_aggregates_cost_duration_words_and_repos() -> None:
+    profile = _profile(
+        "conv-1",
+        provider="claude-code",
+        created_at=datetime(2026, 4, 23, 8, 0),
+        first_message_at=None,
+        canonical_session_date=date(2026, 4, 23),
+        repo_names=("polylogue",),
+        work_events=(_work_event(WorkEventKind.TESTING, 0), _work_event(WorkEventKind.RESEARCH, 1)),
+        total_cost_usd=0.125,
+        total_duration_ms=900,
+        wall_duration_ms=1200,
+        message_count=6,
+        word_count=42,
+    )
+
+    summary = summarize_day([profile], date(2026, 4, 23))
+
+    assert summary.to_dict()["total_cost_usd"] == 0.125
+    assert summary.work_event_breakdown == {"testing": 1, "research": 1}
+    assert summary.repos_active == ("polylogue",)
+    assert summary.providers == {"claude-code": 1}
+
+
+def test_summarize_days_and_weeks_use_profile_date_fallbacks_and_sort_descending() -> None:
+    first = _profile(
+        "conv-first",
+        provider="chatgpt",
+        created_at=datetime(2026, 4, 21, 9, 0),
+        first_message_at=datetime(2026, 4, 22, 9, 0),
+        canonical_session_date=None,
+        repo_names=("polylogue",),
+        message_count=3,
+        word_count=10,
+    )
+    second = _profile(
+        "conv-second",
+        provider="codex",
+        created_at=datetime(2026, 4, 23, 9, 0),
+        first_message_at=None,
+        canonical_session_date=None,
+        repo_names=("sinex",),
+        message_count=4,
+        word_count=20,
+    )
+    ignored = _profile(
+        "conv-ignored",
+        provider="claude-ai",
+        created_at=None,
+        first_message_at=None,
+        canonical_session_date=None,
+    )
+
+    day_summaries = summarize_days([first, second, ignored])
+    week_summary = summarize_week(day_summaries)
+    week_summaries = summarize_weeks(day_summaries)
+
+    assert [summary.date.isoformat() for summary in day_summaries] == ["2026-04-23", "2026-04-22"]
+    assert week_summary.iso_week == "2026-W17"
+    assert week_summary.session_count == 2
+    assert week_summary.total_messages == 7
+    assert week_summary.to_dict()["iso_week"] == "2026-W17"
+    assert [summary.iso_week for summary in week_summaries] == ["2026-W17"]
+    assert summarize_week(()).iso_week == ""

--- a/tests/unit/lib/test_payload_coercion.py
+++ b/tests/unit/lib/test_payload_coercion.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+
+import pytest
+
+from polylogue.lib.payload_coercion import (
+    coerce_float,
+    coerce_int,
+    int_pair,
+    is_payload_mapping,
+    mapping_or_empty,
+    mapping_sequence,
+    optional_date,
+    optional_datetime,
+    optional_string,
+    string_int_mapping,
+    string_sequence,
+)
+
+
+def test_mapping_helpers_accept_string_keyed_mappings_and_iterables() -> None:
+    mapping = {"name": "value"}
+
+    assert is_payload_mapping(mapping) is True
+    assert is_payload_mapping({1: "value"}) is False
+    assert mapping_or_empty(mapping) == mapping
+    assert mapping_or_empty("not-a-mapping") == {}
+    assert mapping_sequence(mapping) == (mapping,)
+    assert mapping_sequence([mapping, {"count": 2}, {1: "ignored"}, "ignored"]) == (
+        {"name": "value"},
+        {"count": 2},
+    )
+
+
+def test_string_sequence_and_optional_string_handle_scalars_and_mappings() -> None:
+    assert string_sequence(None) == ()
+    assert string_sequence("alpha") == ("alpha",)
+    assert string_sequence({"name": "value"}) == ()
+    assert string_sequence(["alpha", 2, True]) == ("alpha", "2", "True")
+    assert optional_string(None) is None
+    assert optional_string("ready") == "ready"
+    assert optional_string(42) == "42"
+
+
+def test_optional_datetime_and_date_support_instances_and_iso_strings() -> None:
+    dt = datetime(2026, 4, 23, 12, 30, 0)
+    day = date(2026, 4, 23)
+
+    assert optional_datetime(dt) is dt
+    assert optional_datetime("2026-04-23T12:30:00") == dt
+    assert optional_date(dt) == day
+    assert optional_date(day) == day
+    assert optional_date("2026-04-23") == day
+
+
+def test_numeric_coercion_handles_defaults_booleans_and_stringish_inputs() -> None:
+    assert coerce_int(None, default=7) == 7
+    assert coerce_int(True) == 1
+    assert coerce_int(3.9) == 3
+    assert coerce_int(b"8") == 8
+    assert coerce_float(None, default=1.5) == 1.5
+    assert coerce_float(False) == 0.0
+    assert coerce_float(4) == 4.0
+    assert coerce_float("3.25") == 3.25
+
+
+def test_string_int_mapping_and_int_pair_cover_mapping_scalar_and_empty_inputs() -> None:
+    assert string_int_mapping({"ok": "2", "other": 1.9, "flag": True}) == {"ok": 2, "other": 1, "flag": 1}
+    assert int_pair(None, default=(4, 5)) == (4, 5)
+    assert int_pair({"x": 1}, default=(4, 5)) == (4, 5)
+    assert int_pair("9", default=(4, 5)) == (9, 5)
+    assert int_pair([], default=(4, 5)) == (4, 5)
+    assert int_pair(["6", 7, 8], default=(4, 5)) == (6, 7)
+
+
+def test_invalid_temporal_strings_raise_value_errors() -> None:
+    with pytest.raises(ValueError):
+        optional_datetime("not-a-datetime")
+
+    with pytest.raises(ValueError):
+        optional_date("not-a-date")

--- a/tests/unit/lib/test_query_runtime_filters.py
+++ b/tests/unit/lib/test_query_runtime_filters.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from polylogue.lib.branch_type import BranchType
+from polylogue.lib.conversation_models import ConversationSummary
+from polylogue.lib.models import Attachment, Conversation, Message
+from polylogue.lib.query_plan import ConversationQueryPlan
+from polylogue.lib.query_runtime_filters import apply_common_filters, apply_full_filters
+from polylogue.types import ConversationId, Provider
+from tests.infra.builders import make_conv, make_msg
+
+
+def _summary(
+    conversation_id: str,
+    *,
+    provider: Provider,
+    title: str,
+    updated_at: datetime | None,
+    tags: list[str] | None = None,
+    summary: str | None = None,
+    parent_id: str | None = None,
+    branch_type: BranchType | None = None,
+) -> ConversationSummary:
+    metadata: dict[str, object] = {}
+    if tags is not None:
+        metadata["tags"] = tags
+    if summary is not None:
+        metadata["summary"] = summary
+    return ConversationSummary(
+        id=ConversationId(conversation_id),
+        provider=provider,
+        title=title,
+        updated_at=updated_at,
+        metadata=metadata,
+        parent_id=ConversationId(parent_id) if parent_id is not None else None,
+        branch_type=branch_type,
+    )
+
+
+def _conversation(
+    conversation_id: str,
+    *messages: Message,
+    provider: Provider = Provider.CLAUDE_CODE,
+    title: str = "Conversation",
+    metadata: dict[str, object] | None = None,
+    parent_id: str | None = None,
+    branch_type: BranchType | None = None,
+) -> Conversation:
+    return make_conv(
+        id=conversation_id,
+        provider=provider,
+        title=title,
+        metadata=metadata or {},
+        parent_id=parent_id,
+        branch_type=branch_type,
+        messages=list(messages),
+    )
+
+
+def test_apply_common_filters_respects_non_sql_fields_and_shared_selection_flags() -> None:
+    items = [
+        _summary(
+            "chatgpt:alpha",
+            provider=Provider.CHATGPT,
+            title="Alpha build plan",
+            updated_at=datetime(2026, 4, 22, tzinfo=timezone.utc),
+            tags=["ship", "alpha"],
+            summary="ready",
+        ),
+        _summary(
+            "claude-ai:beta",
+            provider=Provider.CLAUDE_AI,
+            title="Beta deploy plan",
+            updated_at=datetime(2026, 4, 24, tzinfo=timezone.utc),
+            tags=["beta"],
+            summary="deploy",
+            parent_id="chatgpt:alpha",
+            branch_type=BranchType.CONTINUATION,
+        ),
+        _summary(
+            "codex:gamma",
+            provider=Provider.CODEX,
+            title="Gamma sidechain",
+            updated_at=datetime(2026, 4, 23, tzinfo=timezone.utc),
+            tags=["ship", "ops"],
+            branch_type=BranchType.SIDECHAIN,
+        ),
+    ]
+
+    narrowed = apply_common_filters(
+        ConversationQueryPlan(
+            providers=(Provider.CHATGPT, Provider.CLAUDE_AI),
+            since=datetime(2026, 4, 22, tzinfo=timezone.utc),
+            until=datetime(2026, 4, 24, tzinfo=timezone.utc),
+            title="deploy",
+            parent_id="chatgpt:alpha",
+            tags=("beta",),
+            conversation_id="claude-ai",
+            has_types=("summary",),
+            continuation=True,
+        ),
+        items,
+        sql_pushed=False,
+    )
+
+    assert [str(item.id) for item in narrowed] == ["claude-ai:beta"]
+
+    not_continuations = apply_common_filters(
+        ConversationQueryPlan(
+            excluded_providers=(Provider.CODEX,),
+            tags=("ship",),
+            excluded_tags=("ops",),
+            continuation=False,
+            sidechain=False,
+            root=True,
+        ),
+        items,
+        sql_pushed=False,
+    )
+
+    assert [str(item.id) for item in not_continuations] == ["chatgpt:alpha"]
+
+
+def test_apply_common_filters_skips_sql_pushed_predicates_but_keeps_shared_ones() -> None:
+    items = [
+        _summary(
+            "chatgpt:root",
+            provider=Provider.CHATGPT,
+            title="Wrong title",
+            updated_at=datetime(2026, 4, 22, tzinfo=timezone.utc),
+            tags=["keep"],
+        ),
+        _summary(
+            "claude-ai:child",
+            provider=Provider.CLAUDE_AI,
+            title="Still wrong title",
+            updated_at=datetime(2026, 4, 24, tzinfo=timezone.utc),
+            tags=["keep", "drop"],
+            parent_id="chatgpt:root",
+        ),
+    ]
+
+    preserved = apply_common_filters(
+        ConversationQueryPlan(
+            providers=(Provider.CODEX,),
+            since=datetime(2026, 4, 25, tzinfo=timezone.utc),
+            title="missing",
+            parent_id="other-parent",
+            excluded_tags=("missing",),
+            root=False,
+        ),
+        items,
+        sql_pushed=True,
+    )
+
+    assert [str(item.id) for item in preserved] == ["claude-ai:child"]
+
+
+def test_apply_full_filters_handles_content_word_branch_predicate_and_action_filters(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    branchy = _conversation(
+        "conv-branchy",
+        make_msg(
+            id="u1",
+            role="user",
+            text="Needle question with enough words",
+            attachments=[Attachment(id="att-1", name="spec.txt")],
+            timestamp=datetime(2026, 4, 23, 10, 0, tzinfo=timezone.utc),
+        ),
+        make_msg(
+            id="a1",
+            role="assistant",
+            text="Thinking out loud",
+            provider_meta={"content_blocks": [{"type": "thinking", "text": "step"}]},
+            timestamp=datetime(2026, 4, 23, 10, 1, tzinfo=timezone.utc),
+        ),
+        make_msg(
+            id="a2",
+            role="assistant",
+            text="Using tool",
+            content_blocks=[{"type": "tool_use", "name": "Edit"}],
+            branch_index=1,
+            timestamp=datetime(2026, 4, 23, 10, 2, tzinfo=timezone.utc),
+        ),
+        metadata={"tags": ["ship"], "summary": "ship summary"},
+    )
+    plain = _conversation(
+        "conv-plain",
+        make_msg(
+            id="u2",
+            role="user",
+            text="boring negative term here",
+            timestamp=datetime(2026, 4, 23, 9, 0, tzinfo=timezone.utc),
+        ),
+        make_msg(
+            id="a3",
+            role="assistant",
+            text="short reply",
+            timestamp=datetime(2026, 4, 23, 9, 1, tzinfo=timezone.utc),
+        ),
+    )
+
+    for name in (
+        "matches_path_terms",
+        "matches_action_terms",
+        "matches_action_sequence",
+        "matches_action_text_terms",
+        "matches_tool_terms",
+    ):
+        monkeypatch.setattr(
+            "polylogue.lib.query_runtime_filters." + name,
+            lambda _plan, conversation, *, _target="conv-branchy": str(conversation.id) == _target,
+        )
+
+    filtered = apply_full_filters(
+        ConversationQueryPlan(
+            has_types=("thinking", "tools", "attachments"),
+            filter_has_tool_use=True,
+            filter_has_thinking=True,
+            min_messages=3,
+            max_messages=3,
+            min_words=5,
+            negative_terms=("negative",),
+            has_branches=True,
+            predicates=(lambda conversation: "branchy" in str(conversation.id),),
+            path_terms=("/repo/src/app.py",),
+            action_terms=("shell",),
+            action_sequence=("search", "shell"),
+            action_text_terms=("pytest",),
+            tool_terms=("bash",),
+        ),
+        [branchy, plain],
+        sql_pushed=False,
+    )
+
+    assert [str(conversation.id) for conversation in filtered] == ["conv-branchy"]
+
+    no_branches = apply_full_filters(
+        ConversationQueryPlan(
+            negative_terms=("needle",),
+            has_branches=False,
+            max_messages=2,
+            min_words=2,
+        ),
+        [branchy, plain],
+        sql_pushed=False,
+    )
+
+    assert [str(conversation.id) for conversation in no_branches] == ["conv-plain"]

--- a/tests/unit/lib/test_query_search_runtime.py
+++ b/tests/unit/lib/test_query_search_runtime.py
@@ -1,0 +1,273 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import AsyncMock
+
+import pytest
+
+from polylogue.lib.conversation_models import ConversationSummary
+from polylogue.lib.models import Conversation
+from polylogue.lib.query_plan import ConversationQueryPlan
+from polylogue.lib.query_retrieval_search import (
+    conversation_action_search_score,
+    fetch_batched_filtered_conversations,
+    score_action_search_text,
+    search_action_results,
+    search_hybrid_results,
+    search_query_terms,
+    search_query_text,
+)
+from polylogue.lib.query_search_hits import plan_has_search_hit_evidence, search_hits_for_plan
+from polylogue.lib.search_hits import ConversationSearchHit
+from polylogue.protocols import VectorProvider
+from polylogue.types import ConversationId, Provider
+from tests.infra.builders import make_conv, make_msg
+
+
+@dataclass(frozen=True)
+class _Request:
+    limit: int | None = None
+    offset: int = 0
+
+    def with_limit(self, limit: int) -> _Request:
+        return replace(self, limit=limit)
+
+    def with_offset(self, offset: int) -> _Request:
+        return replace(self, offset=offset)
+
+
+def _conversation(conversation_id: str, *, text: str = "needle here", updated_hour: int = 0) -> Conversation:
+    return make_conv(
+        id=conversation_id,
+        provider=Provider.CLAUDE_CODE,
+        updated_at=datetime(2026, 4, 23, updated_hour, tzinfo=timezone.utc),
+        messages=[make_msg(id=f"{conversation_id}-m1", role="assistant", text=text)],
+    )
+
+
+def test_search_query_text_terms_and_scoring_are_normalized() -> None:
+    plan = ConversationQueryPlan(query_terms=("Alpha",), contains_terms=("Beta", ""))
+
+    assert search_query_text(plan) == "Alpha Beta"
+    assert search_query_terms(plan) == ("alpha", "beta")
+    assert score_action_search_text("Alpha beta gamma", query_text="alpha beta", terms=("alpha", "beta")) == 30.0
+    assert score_action_search_text("no match", query_text="alpha", terms=("beta",)) == 0.0
+
+
+def test_conversation_action_search_score_uses_best_match_and_bonus(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "polylogue.lib.semantic_facts.build_conversation_semantic_facts",
+        lambda _conversation: SimpleNamespace(
+            action_events=[
+                SimpleNamespace(search_text="alpha beta"),
+                SimpleNamespace(search_text="beta only"),
+                SimpleNamespace(search_text=None),
+            ]
+        ),
+    )
+
+    score = conversation_action_search_score(
+        _conversation("conv-score"),
+        query_text="alpha beta",
+        terms=("alpha", "beta"),
+    )
+
+    assert score == 31.0
+
+
+@pytest.mark.asyncio
+async def test_search_action_results_fallback_batches_scores_and_keeps_best(monkeypatch: pytest.MonkeyPatch) -> None:
+    conv_a = _conversation("conv-a", updated_hour=9)
+    conv_b = _conversation("conv-b", updated_hour=11)
+    conv_c = _conversation("conv-c", updated_hour=10)
+    repository = SimpleNamespace()
+    repository.list_by_query = AsyncMock(
+        side_effect=lambda request: {
+            0: [conv_a, conv_b],
+            2: [conv_c],
+        }.get(request.offset, [])
+    )
+
+    async def _candidate_record_query_for(_plan: ConversationQueryPlan, _repository: object) -> tuple[_Request, bool]:
+        return (_Request(), False)
+
+    monkeypatch.setattr(
+        "polylogue.lib.query_retrieval_candidates.candidate_record_query_for", _candidate_record_query_for
+    )
+    monkeypatch.setattr("polylogue.lib.query_retrieval_candidates.candidate_batch_limit", lambda _plan: 2)
+    monkeypatch.setattr("polylogue.lib.query_runtime.apply_common_filters", lambda _plan, batch, *, sql_pushed: batch)
+    monkeypatch.setattr(
+        "polylogue.lib.query_retrieval_search.conversation_action_search_score",
+        lambda conversation, *, query_text, terms: {
+            "conv-a": 1.0,
+            "conv-b": 6.0,
+            "conv-c": 4.0,
+        }[str(conversation.id)],
+    )
+
+    results = await search_action_results(
+        ConversationQueryPlan(query_terms=("needle",)),
+        repository,
+        limit=2,
+    )
+
+    assert [str(conversation.id) for conversation in results] == ["conv-b", "conv-c"]
+
+
+@pytest.mark.asyncio
+async def test_search_action_results_uses_ready_path_and_falls_back_on_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    repository = SimpleNamespace(search_actions=AsyncMock())
+    direct = [_conversation("conv-direct")]
+    fallback = AsyncMock(return_value=[_conversation("conv-fallback")])
+
+    monkeypatch.setattr("polylogue.lib.query_retrieval_candidates.action_search_ready", AsyncMock(return_value=True))
+    monkeypatch.setattr("polylogue.lib.query_retrieval_search.search_action_results_fallback", fallback)
+
+    repository.search_actions.return_value = direct
+    ready_results = await search_action_results(
+        ConversationQueryPlan(query_terms=("needle",), providers=(Provider.CHATGPT,)),
+        repository,
+        limit=3,
+    )
+
+    assert [str(conversation.id) for conversation in ready_results] == ["conv-direct"]
+    repository.search_actions.assert_awaited_once_with("needle", limit=3, providers=["chatgpt"])
+    fallback.assert_not_awaited()
+
+    repository.search_actions.reset_mock(side_effect=True, return_value=True)
+    repository.search_actions.side_effect = RuntimeError("boom")
+    errored_results = await search_action_results(ConversationQueryPlan(query_terms=("needle",)), repository, limit=2)
+
+    assert [str(conversation.id) for conversation in errored_results] == ["conv-fallback"]
+    fallback.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_search_hybrid_results_orders_fused_ids_and_skips_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    conv_text = _conversation("conv-text")
+    conv_action = _conversation("conv-action")
+    conv_vector = _conversation("conv-vector")
+    repository = SimpleNamespace(
+        search=AsyncMock(return_value=[conv_text]),
+        search_similar=AsyncMock(return_value=[conv_vector]),
+    )
+
+    monkeypatch.setattr(
+        "polylogue.lib.query_retrieval_search.search_action_results",
+        AsyncMock(return_value=[conv_action]),
+    )
+    monkeypatch.setattr(
+        "polylogue.lib.query_retrieval_search.reciprocal_rank_fusion",
+        lambda *_ranked: [
+            ("conv-action", 0.9),
+            ("conv-text", 0.8),
+            ("missing", 0.7),
+            ("conv-vector", 0.6),
+        ],
+    )
+
+    results = await search_hybrid_results(
+        ConversationQueryPlan(
+            query_terms=("needle",),
+            vector_provider=cast(
+                VectorProvider,
+                SimpleNamespace(
+                    model="stub",
+                    upsert=lambda conversation_id, messages: None,
+                    query=lambda text, limit=10: [],
+                ),
+            ),
+        ),
+        repository,
+        limit=4,
+    )
+
+    assert [str(conversation.id) for conversation in results] == [
+        "conv-action",
+        "conv-text",
+        "conv-vector",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_fetch_batched_filtered_conversations_deduplicates_and_respects_limit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conv_a = _conversation("conv-a")
+    conv_b = _conversation("conv-b")
+    conv_c = _conversation("conv-c")
+    repository = SimpleNamespace()
+    repository.list_by_query = AsyncMock(
+        side_effect=lambda request: {
+            0: [conv_a, conv_b],
+            2: [conv_a, conv_c],
+        }.get(request.offset, [])
+    )
+
+    async def _candidate_record_query_for(_plan: ConversationQueryPlan, _repository: object) -> tuple[_Request, bool]:
+        return (_Request(), False)
+
+    monkeypatch.setattr(
+        "polylogue.lib.query_retrieval_candidates.candidate_record_query_for", _candidate_record_query_for
+    )
+    monkeypatch.setattr("polylogue.lib.query_retrieval_candidates.candidate_batch_limit", lambda _plan: 2)
+    monkeypatch.setattr("polylogue.lib.query_runtime.apply_full_filters", lambda _plan, batch, *, sql_pushed: batch)
+
+    results = await fetch_batched_filtered_conversations(
+        ConversationQueryPlan(limit=3),
+        repository,
+    )
+
+    assert [str(conversation.id) for conversation in results] == ["conv-a", "conv-b", "conv-c"]
+
+
+@pytest.mark.asyncio
+async def test_search_hits_for_plan_handles_empty_simple_and_fallback_paths(monkeypatch: pytest.MonkeyPatch) -> None:
+    repository = SimpleNamespace(search_summary_hits=AsyncMock())
+    repository.search_summary_hits.return_value = [
+        ConversationSearchHit(
+            summary=ConversationSummary(id=ConversationId("conv-summary"), provider=Provider.CHATGPT),
+            message_id=None,
+            rank=1,
+            retrieval_lane="dialogue",
+            match_surface="message",
+            snippet="needle",
+        )
+    ]
+
+    assert plan_has_search_hit_evidence(ConversationQueryPlan()) is False
+    assert await search_hits_for_plan(ConversationQueryPlan(query_terms=("   ",)), repository) == []
+
+    monkeypatch.setattr("polylogue.lib.query_search_hits.plan_has_fields_matching", lambda _plan, _predicate: False)
+    simple_hits = await search_hits_for_plan(
+        ConversationQueryPlan(
+            query_terms=("needle",),
+            providers=(Provider.CHATGPT,),
+            limit=5,
+            since=datetime(2026, 4, 20, tzinfo=timezone.utc),
+        ),
+        repository,
+    )
+
+    assert [hit.conversation_id for hit in simple_hits] == ["conv-summary"]
+    repository.search_summary_hits.assert_awaited_once_with(
+        "needle",
+        limit=5,
+        providers=["chatgpt"],
+        since="2026-04-20T00:00:00+00:00",
+    )
+
+    async def _list(_self: ConversationQueryPlan, _repository: object) -> list[object]:
+        return [_conversation("conv-message", text="needle in message")]
+
+    monkeypatch.setattr(ConversationQueryPlan, "list", _list)
+    fallback_hits = await search_hits_for_plan(
+        ConversationQueryPlan(similar_text="semantic needle", retrieval_lane="actions"),
+        repository,
+    )
+
+    assert [hit.conversation_id for hit in fallback_hits] == ["conv-message"]
+    assert fallback_hits[0].retrieval_lane == "semantic"

--- a/tests/unit/scenarios/test_authored_payloads.py
+++ b/tests/unit/scenarios/test_authored_payloads.py
@@ -7,8 +7,18 @@ import pytest
 from polylogue.authored_payloads import (
     PayloadDict,
     canonical_payload_json,
+    merge_unique_string_tuples,
+    payload_bool,
+    payload_count,
     payload_count_mapping,
+    payload_float,
+    payload_int,
+    payload_items,
+    payload_mapping,
+    payload_optional_string,
     payload_records,
+    payload_string,
+    payload_string_tuple,
     require_payload_mapping,
 )
 
@@ -37,6 +47,43 @@ def test_payload_count_mapping_coerces_count_values() -> None:
     counts = payload_count_mapping({"passed": "2", "failed": 1.0}, context="qa.summary")
 
     assert counts == {"passed": 2, "failed": 1}
+
+
+def test_payload_scalar_and_sequence_helpers_preserve_contracts() -> None:
+    assert payload_items(["a", "b"]) == ("a", "b")
+    assert payload_items("not-a-sequence") == ()
+    assert payload_string(None, default="fallback") == "fallback"
+    assert payload_string(9) == "9"
+    assert payload_optional_string("ready") == "ready"
+    assert payload_optional_string("") is None
+    assert payload_string_tuple(["a", "b"]) == ("a", "b")
+    assert payload_string_tuple(["a", 2]) == ()
+
+
+def test_payload_numeric_and_bool_helpers_coerce_supported_values() -> None:
+    assert payload_int(True, "count") == 1
+    assert payload_count("3", "count") == 3
+    assert payload_float("1.5", "cost") == 1.5
+    assert payload_bool("yes") is True
+    assert payload_bool("off") is False
+    assert payload_bool(None, default=True) is True
+
+
+def test_payload_mapping_and_tuple_merge_cover_rejections() -> None:
+    assert payload_mapping({"ok": 1}) == {"ok": 1}
+    assert payload_mapping({1: "bad"}) is None
+    assert merge_unique_string_tuples(("a", "", "b"), ("b", "c"), skip_empty=True) == ("a", "b", "c")
+
+
+def test_payload_type_errors_are_actionable() -> None:
+    with pytest.raises(TypeError, match="count must be present"):
+        payload_count(None, "count")
+
+    with pytest.raises(TypeError, match="cost must be a float-compatible value"):
+        payload_float(object(), "cost")
+
+    with pytest.raises(TypeError, match="Expected a boolean-compatible payload value"):
+        payload_bool(object())
 
 
 def test_payload_records_serializes_typed_records() -> None:

--- a/tests/unit/sources/test_source_laws.py
+++ b/tests/unit/sources/test_source_laws.py
@@ -340,7 +340,7 @@ def test_iter_json_stream_conversations_wrapper_round_trips_documents(
 
 
 @given(json_array_bytes_strategy())
-@settings(max_examples=30)
+@settings(max_examples=30, suppress_health_check=[HealthCheck.too_slow])
 def test_iter_json_stream_unpack_lists_false_preserves_single_list(case: tuple[list[dict[str, object]], bytes]) -> None:
     """`unpack_lists=False` keeps the JSON root list intact as one item."""
     documents, raw = case
@@ -348,7 +348,7 @@ def test_iter_json_stream_unpack_lists_false_preserves_single_list(case: tuple[l
 
 
 @given(jsonl_bytes_strategy())
-@settings(max_examples=35)
+@settings(max_examples=35, suppress_health_check=[HealthCheck.too_slow])
 def test_iter_json_stream_jsonl_preserves_valid_records_with_blank_lines(
     case: tuple[list[dict[str, object]], bytes],
 ) -> None:

--- a/tests/unit/sources/test_unified_semantic_laws.py
+++ b/tests/unit/sources/test_unified_semantic_laws.py
@@ -8,7 +8,7 @@ from types import SimpleNamespace
 from typing import Protocol, TypeAlias
 
 import pytest
-from hypothesis import given, settings
+from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 
 from polylogue.lib.json import JSONDocument, json_document, json_document_list
@@ -359,6 +359,7 @@ def test_typed_content_blocks_extract_without_crash(
     ),
     st.sampled_from(["claude-code", "claude-ai", "chatgpt", "gemini", "codex"]),
 )
+@settings(suppress_health_check=[HealthCheck.too_slow])
 def test_extract_reasoning_traces_preserve_reasoning_blocks_contract(
     content: list[object],
     provider: str,
@@ -379,6 +380,7 @@ def test_extract_reasoning_traces_preserve_reasoning_blocks_contract(
     ),
     st.sampled_from(["claude-code", "claude-ai", "chatgpt", "gemini", "codex"]),
 )
+@settings(suppress_health_check=[HealthCheck.too_slow])
 def test_extract_tool_calls_preserve_tool_use_blocks_contract(
     content: list[object],
     provider: str,
@@ -403,6 +405,7 @@ def test_extract_tool_calls_preserve_tool_use_blocks_contract(
         max_size=10,
     )
 )
+@settings(suppress_health_check=[HealthCheck.too_slow])
 def test_extract_content_blocks_preserve_recognized_block_order_contract(
     content: list[object],
 ) -> None:
@@ -426,6 +429,7 @@ def test_extract_content_blocks_preserve_recognized_block_order_contract(
         max_size=8,
     )
 )
+@settings(suppress_health_check=[HealthCheck.too_slow])
 def test_extract_codex_text_prefers_first_available_text_field_contract(content: list[object]) -> None:
     expected: list[str] = []
     for block in content:


### PR DESCRIPTION
## Summary
Raise the coverage floor from 85 to 86 with a semantic coverage tranche over query/runtime/schema helpers, plus the gate hardening needed to make that ratchet reliable.

## Problem
Ref #197 tracks the staged push toward a materially higher repository coverage floor. The next step could not be an arbitrary percentage bump: it needed meaningful tests over under-covered semantic helpers and a stable full coverage lane. The branch also surfaced a strict-mypy export defect in `devtools.render_cli_reference` while running the required quick baseline.

## Solution
- add focused unit coverage for payload coercion, query runtime filtering and retrieval helpers, schema extraction and operator workflows, runtime registry helpers, archive stats, session summaries, authored payload helpers, and projection/message collection contracts
- harden the slow semantic/property suites for coverage execution and relax the `open --print-path` integration assertions to accept the expected optional progress stderr
- raise `[tool.coverage.report].fail_under` from 85 to 86 after the full gate measured 86.77%
- make `devtools.render_cli_reference` explicitly export its tested helper surface so `devtools verify --quick` stays green

## Verification
- `mypy --strict tests/unit/core/test_session_summaries.py tests/unit/core/test_operator_inference.py tests/unit/lib/test_query_search_runtime.py tests/unit/lib/test_query_runtime_filters.py tests/unit/core/test_conversation_semantics.py tests/unit/core/test_models.py`
- `pytest -q tests/unit/core/test_conversation_semantics.py::TestConversationProjectionContracts::test_projection_transform_and_terminal_helpers_cover_empty_and_render_paths`
- `pytest -q tests/unit/core/test_session_summaries.py::test_summarize_day_aggregates_cost_duration_words_and_repos`
- `devtools coverage-gate`
  - `5411 passed in 257.11s (0:04:17)`
  - `Required test coverage of 86% reached. Total coverage: 86.77%`
- `devtools verify --quick`

Ref #197


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit test coverage for archive statistics, conversation filtering, message collections, schema operations, payload coercion, and query runtime functionality
  * Enhanced integration tests for query routing with improved error validation

* **Chores**
  * Increased minimum code coverage requirement from 85% to 86%

<!-- end of auto-generated comment: release notes by coderabbit.ai -->