### PR TITLE
test: ratchet coverage floor to 87

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,7 +141,7 @@ data_file = ".cache/coverage/.coverage"
 [tool.coverage.report]
 skip_empty = true
 show_missing = true
-fail_under = 86
+fail_under = 87
 
 [tool.mypy]
 python_version = "3.11"

--- a/tests/unit/cli/test_products_helper_runtime.py
+++ b/tests/unit/cli/test_products_helper_runtime.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from unittest.mock import patch
+
+from polylogue.cli import products_rendering, products_workflow
+from polylogue.products import registry as product_registry
+
+
+@dataclass(frozen=True)
+class _ModelItem:
+    value: str
+
+    def model_dump(self, *, mode: str) -> object:
+        assert mode == "json"
+        return {"value": self.value}
+
+
+def test_model_payload_and_payloads_cover_model_dump_and_passthrough() -> None:
+    dumped = products_rendering.model_payload(_ModelItem("alpha"))
+    passthrough = products_rendering.model_payload({"value": "beta"})
+
+    assert dumped == {"value": "alpha"}
+    assert passthrough == {"value": "beta"}
+    assert products_rendering.model_payloads([_ModelItem("alpha"), {"value": "beta"}]) == [
+        {"value": "alpha"},
+        {"value": "beta"},
+    ]
+
+
+def test_emit_product_list_emits_count_and_json_ready_items() -> None:
+    with patch("polylogue.cli.products_rendering.emit_success") as emit_success:
+        products_rendering.emit_product_list(
+            key="items",
+            items=[_ModelItem("alpha"), {"value": "beta"}],
+        )
+
+    emit_success.assert_called_once_with(
+        {
+            "count": 2,
+            "items": [{"value": "alpha"}, {"value": "beta"}],
+        }
+    )
+
+
+def test_summarize_archive_debt_counts_actionable_items_and_issue_rows() -> None:
+    items = [
+        _ModelItem("healthy"),
+        type("DebtRow", (), {"healthy": False, "issue_count": 2})(),
+        type("DebtRow", (), {"healthy": False, "issue_count": 0})(),
+        type("DebtRow", (), {"healthy": True, "issue_count": 5})(),
+    ]
+
+    assert products_rendering.summarize_archive_debt(items) == {
+        "tracked_items": 4,
+        "actionable_items": 2,
+        "issue_rows": 7,
+    }
+
+
+def test_products_workflow_reexports_registry_fetch_products() -> None:
+    assert products_workflow.fetch_products is product_registry.fetch_products

--- a/tests/unit/cli/test_query_verbs_runtime.py
+++ b/tests/unit/cli/test_query_verbs_runtime.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import click
+import pytest
+
+from polylogue.cli import query_verbs
+from polylogue.cli.root_request import RootModeRequest
+
+
+def _context_pair(
+    *,
+    params: dict[str, object] | None = None,
+    query_terms: tuple[str, ...] = (),
+) -> tuple[click.Context, click.Context]:
+    parent = click.Context(click.Command("query"))
+    parent.params = {"query_term": query_terms, **(params or {})}
+    parent.meta["polylogue_query_terms"] = query_terms
+    child = click.Context(click.Command("verb"), parent=parent)
+    child.obj = SimpleNamespace()
+    return parent, child
+
+
+def test_parent_helpers_require_parent_context_and_build_request() -> None:
+    _, child = _context_pair(
+        params={"provider": "chatgpt", "limit": 5},
+        query_terms=("alpha", "beta"),
+    )
+
+    assert query_verbs._parent_query_terms(child) == ("alpha", "beta")
+    request = query_verbs._parent_request(child)
+    assert request.query_params()["provider"] == "chatgpt"
+    assert request.query_params()["query"] == ("alpha", "beta")
+
+    with pytest.raises(click.UsageError, match="Query verbs must be invoked"):
+        query_verbs._require_parent_context(click.Context(click.Command("verb")))
+
+
+def test_execute_query_verb_dispatches_typed_request() -> None:
+    _, child = _context_pair()
+    request = RootModeRequest.from_params({"query": ("alpha",)})
+
+    with patch("polylogue.cli.query.execute_query_request") as execute:
+        query_verbs._execute_query_verb(child, request)
+
+    execute.assert_called_once_with(child.obj, request)
+
+
+def test_list_and_count_verbs_update_parent_request() -> None:
+    _, child = _context_pair(params={"provider": "chatgpt"}, query_terms=("alpha",))
+
+    wrapped_list = getattr(query_verbs.list_verb.callback, "__wrapped__", None)
+    assert callable(wrapped_list)
+    with patch("polylogue.cli.query_verbs._execute_query_verb") as execute:
+        wrapped_list(child, "json", "id,title", 7)
+
+    request = execute.call_args.args[1]
+    assert isinstance(request, RootModeRequest)
+    assert request.query_params()["provider"] == "chatgpt"
+    assert request.query_params()["output_format"] == "json"
+    assert request.query_params()["fields"] == "id,title"
+    assert request.query_params()["limit"] == 7
+    assert request.query_params()["query"] == ("alpha",)
+
+    wrapped_count = getattr(query_verbs.count_verb.callback, "__wrapped__", None)
+    assert callable(wrapped_count)
+    with patch("polylogue.cli.query_verbs._execute_query_verb") as execute:
+        wrapped_count(child)
+
+    count_request = execute.call_args.args[1]
+    assert isinstance(count_request, RootModeRequest)
+    assert count_request.query_params()["count_only"] is True
+
+
+def test_stats_verb_toggles_stats_only_and_updates_grouping() -> None:
+    _, child = _context_pair(query_terms=("alpha",))
+    wrapped = getattr(query_verbs.stats_verb.callback, "__wrapped__", None)
+    assert callable(wrapped)
+
+    with patch("polylogue.cli.query_verbs._execute_query_verb") as execute:
+        wrapped(child, None, None, None)
+
+    request = execute.call_args.args[1]
+    assert isinstance(request, RootModeRequest)
+    assert request.query_params()["stats_only"] is True
+    assert request.query_params()["query"] == ("alpha",)
+
+    with patch("polylogue.cli.query_verbs._execute_query_verb") as execute:
+        wrapped(child, "provider", "markdown", 3)
+
+    grouped_request = execute.call_args.args[1]
+    assert isinstance(grouped_request, RootModeRequest)
+    assert grouped_request.query_params()["stats_only"] is False
+    assert grouped_request.query_params()["stats_by"] == "provider"
+    assert grouped_request.query_params()["output_format"] == "markdown"
+    assert grouped_request.query_params()["limit"] == 3
+
+
+def test_open_verb_routes_single_id_or_appends_target_terms() -> None:
+    _, child = _context_pair(query_terms=())
+    wrapped = getattr(query_verbs.open_verb.callback, "__wrapped__", None)
+    assert callable(wrapped)
+
+    with patch("polylogue.cli.query_verbs._execute_query_verb") as execute:
+        wrapped(child, True, ("chatgpt:123",))
+
+    request = execute.call_args.args[1]
+    assert isinstance(request, RootModeRequest)
+    assert request.query_params()["open_result"] is True
+    assert request.query_params()["print_path"] is True
+    assert request.query_params()["conv_id"] == "chatgpt:123"
+    assert request.query_params()["query"] == ()
+
+    _, child = _context_pair(query_terms=("existing",))
+    with patch("polylogue.cli.query_verbs._execute_query_verb") as execute:
+        wrapped(child, False, ("more", "terms"))
+
+    appended_request = execute.call_args.args[1]
+    assert isinstance(appended_request, RootModeRequest)
+    assert appended_request.query_params()["query"] == ("existing", "more", "terms")
+    assert appended_request.query_params()["open_result"] is True
+
+
+def test_delete_verb_updates_force_and_dry_run_flags() -> None:
+    _, child = _context_pair(query_terms=("alpha",))
+    wrapped = getattr(query_verbs.delete_verb.callback, "__wrapped__", None)
+    assert callable(wrapped)
+
+    with patch("polylogue.cli.query_verbs._execute_query_verb") as execute:
+        wrapped(child, True, False)
+
+    request = execute.call_args.args[1]
+    assert isinstance(request, RootModeRequest)
+    assert request.query_params()["delete_matched"] is True
+    assert request.query_params()["dry_run"] is True
+    assert request.query_params()["force"] is False
+    assert request.query_params()["query"] == ("alpha",)

--- a/tests/unit/cli/test_run_display_workflow_runtime.py
+++ b/tests/unit/cli/test_run_display_workflow_runtime.py
@@ -1,0 +1,247 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import MagicMock, patch
+
+from polylogue.cli.run_display_workflow import (
+    display_result,
+    handle_drive_error,
+    render_preview_summary,
+    render_sources,
+)
+from polylogue.cli.run_watch_workflow import WatchDisplayObserver, WatchStatusObserver
+from polylogue.cli.types import AppEnv
+from polylogue.config import Config
+from polylogue.sources import DriveError
+from polylogue.storage.run_state import (
+    DriftBucket,
+    PlanCounts,
+    PlanDetails,
+    PlanResult,
+    RenderFailurePayload,
+    RunCounts,
+    RunDrift,
+    RunResult,
+)
+
+
+def _env() -> AppEnv:
+    ui = MagicMock()
+    ui.console = MagicMock()
+    return cast(AppEnv, SimpleNamespace(ui=ui))
+
+
+def _cfg() -> Config:
+    return Config(
+        archive_root=Path("/tmp/archive"),
+        render_root=Path("/tmp/render"),
+        sources=[],
+    )
+
+
+def _run_result(
+    *,
+    index_error: str | None = None,
+    render_failures: list[RenderFailurePayload] | None = None,
+) -> RunResult:
+    return RunResult(
+        run_id="run-1",
+        counts=RunCounts(conversations=3, messages=4, attachments=1),
+        drift=RunDrift(new=DriftBucket(conversations=1), changed=DriftBucket(conversations=1)),
+        indexed=True,
+        index_error=index_error,
+        duration_ms=1500,
+        render_failures=render_failures or [],
+    )
+
+
+def test_display_result_renders_summary_latest_render_and_failure_hints() -> None:
+    env = _env()
+    cfg = _cfg()
+    result = _run_result(
+        index_error="index unavailable",
+        render_failures=[{"conversation_id": "conv-1", "error": "boom"}],
+    )
+
+    with (
+        patch("polylogue.cli.run_display_workflow.format_counts", return_value="3 conversations"),
+        patch("polylogue.cli.run_display_workflow.format_run_details", return_value=["new=1", "changed=1"]),
+        patch("polylogue.cli.run_display_workflow.format_index_status", return_value="Index status: failed"),
+        patch("polylogue.cli.helpers.latest_render_path", return_value=Path("/tmp/render/latest.html")),
+        patch("click.echo") as echo,
+    ):
+        display_result(
+            env,
+            cfg,
+            result,
+            "render",
+            ["drive"],
+            display_stage="site",
+            stage_sequence=("render", "site"),
+        )
+
+    summary = cast(MagicMock, env.ui.summary)
+    console_print = cast(MagicMock, env.ui.console.print)
+    summary.assert_called_once_with(
+        "Sync (site; drive)",
+        ["Counts: 3 conversations", "Index status: failed", "new=1", "changed=1", "Duration: 1500ms"],
+    )
+    console_print.assert_called_once_with("Latest render: /tmp/render/latest.html")
+    echoed = [call.args[0] for call in echo.call_args_list if call.args]
+    assert any("Render failures (1):" in line for line in echoed)
+    assert "  conv-1: boom" in echoed
+    assert "Hint: re-run with `polylogue run render` to retry rendering." in echoed
+    assert "Index error: index unavailable" in echoed
+    assert "Hint: run `polylogue run index` to rebuild the index." in echoed
+
+
+def test_display_result_uses_index_only_status_for_index_stage() -> None:
+    env = _env()
+    cfg = _cfg()
+
+    with (
+        patch("polylogue.cli.run_display_workflow.format_index_status", return_value="Index status: indexed"),
+        patch("click.echo"),
+    ):
+        display_result(
+            env,
+            cfg,
+            _run_result(),
+            "index",
+            None,
+            stage_sequence=("index",),
+        )
+
+    summary = cast(MagicMock, env.ui.summary)
+    console_print = cast(MagicMock, env.ui.console.print)
+    summary.assert_called_once_with(
+        "Sync (index)",
+        ["Index status: indexed", "Duration: 1500ms"],
+    )
+    console_print.assert_not_called()
+
+
+def test_render_sources_emits_json_payload_or_plain_summary() -> None:
+    cfg = cast(
+        Config,
+        SimpleNamespace(
+            sources=[
+                SimpleNamespace(name="drive", path=None, folder="folder-1"),
+                SimpleNamespace(name="local", path=Path("/tmp/inbox"), folder=None),
+                SimpleNamespace(name="missing", path=None, folder=None),
+            ]
+        ),
+    )
+    env = cast(AppEnv, SimpleNamespace(config=cfg, ui=MagicMock()))
+
+    with patch("polylogue.cli.machine_errors.emit_success") as emit_success:
+        render_sources(env, json_output=True)
+
+    emit_success.assert_called_once_with(
+        {
+            "sources": [
+                {"name": "drive", "path": None, "folder": "folder-1", "kind": "drive"},
+                {"name": "local", "path": "/tmp/inbox", "folder": None, "kind": "path"},
+                {"name": "missing", "path": None, "folder": None, "kind": "path"},
+            ]
+        }
+    )
+
+    render_sources(env, json_output=False)
+    summary = cast(MagicMock, env.ui.summary)
+    summary.assert_called_once_with(
+        "Sources",
+        [
+            "drive: drive folder 'folder-1'",
+            "local: /tmp/inbox",
+            "missing: (missing path)",
+        ],
+    )
+
+
+def test_handle_drive_error_routes_to_run_failure_surface() -> None:
+    with patch("polylogue.cli.run_display_workflow.fail") as fail:
+        handle_drive_error(DriveError("bad credentials"))
+
+    fail.assert_called_once_with("run", "bad credentials")
+
+
+def test_render_preview_summary_formats_plan_snapshot() -> None:
+    env = _env()
+    plan_result = PlanResult(
+        timestamp=1713873000,
+        counts=PlanCounts(scan=5, store_raw=2),
+        details=PlanDetails(new_raw=2, existing_raw=3),
+        sources=["drive"],
+        cursors={"drive": {"latest_path": "/tmp/inbox"}},
+    )
+
+    with (
+        patch("polylogue.cli.run_display_workflow.format_plan_counts", return_value="scan=5"),
+        patch("polylogue.cli.run_display_workflow.format_plan_details", return_value="new=2, existing=3"),
+        patch("polylogue.cli.run_display_workflow.format_cursors", return_value="latest=/tmp/inbox"),
+        patch("polylogue.cli.run_display_workflow.format_timestamp", return_value="2026-04-23 12:00:00"),
+    ):
+        render_preview_summary(env, selected_sources=["drive"], plan_snapshot=plan_result)
+
+    summary = cast(MagicMock, env.ui.summary)
+    summary.assert_called_once_with(
+        "Preview",
+        [
+            "Sources: drive",
+            "Work: scan=5",
+            "State: new=2, existing=3",
+            "Cursors: latest=/tmp/inbox",
+            "Snapshot: 2026-04-23 12:00:00",
+        ],
+    )
+
+
+def test_watch_display_observer_only_renders_when_activity_is_present() -> None:
+    env = _env()
+    cfg = _cfg()
+    result = _run_result()
+
+    observer = WatchDisplayObserver(env, cfg, "all", ["drive"], display_stage="render", stage_sequence=("render",))
+
+    with (
+        patch("polylogue.cli.run_watch_workflow.conversation_activity_counts", return_value=(2, 0, 0)),
+        patch("polylogue.cli.run_watch_workflow.display_result") as display,
+    ):
+        observer.on_completed(result)
+
+    display.assert_called_once_with(
+        env,
+        cfg,
+        result,
+        "all",
+        ["drive"],
+        display_stage="render",
+        stage_sequence=("render",),
+    )
+
+    with (
+        patch("polylogue.cli.run_watch_workflow.conversation_activity_counts", return_value=(0, 0, 0)),
+        patch("polylogue.cli.run_watch_workflow.display_result") as display,
+    ):
+        observer.on_completed(result)
+
+    display.assert_not_called()
+
+
+def test_watch_status_observer_renders_idle_drive_and_generic_errors() -> None:
+    observer = WatchStatusObserver()
+
+    with (
+        patch("time.strftime", return_value="12:34:56"),
+        patch("click.echo") as echo,
+    ):
+        observer.on_idle(_run_result())
+        observer.on_error(DriveError("drive failed"))
+        observer.on_error(RuntimeError("boom"))
+
+    echo.assert_any_call("No conversation changes at 12:34:56")
+    echo.assert_any_call("Sync error: drive failed", err=True)
+    echo.assert_any_call("Unexpected error during sync: boom", err=True)

--- a/tests/unit/cli/test_schema_helper_runtime.py
+++ b/tests/unit/cli/test_schema_helper_runtime.py
@@ -1,0 +1,482 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from polylogue.cli.schema_command_support import (
+    _privacy_config_payload,
+    _privacy_level,
+    build_schema_privacy_config,
+)
+from polylogue.cli.schema_rendering_explain import render_explain_verbose, render_schema_explain_result
+from polylogue.cli.schema_rendering_results import (
+    render_schema_audit_result,
+    render_schema_compare_result,
+    render_schema_generate_result,
+    render_schema_list_result,
+    render_schema_promote_result,
+)
+from polylogue.lib.outcomes import OutcomeStatus
+from polylogue.scenarios import CorpusProfile, CorpusSpec, build_corpus_scenarios
+from polylogue.schemas.audit_models import AuditCheck, AuditReport
+from polylogue.schemas.generation_models import GenerationResult
+from polylogue.schemas.operator_models import (
+    JSONDocument,
+    SchemaAnnotationSummary,
+    SchemaCompareResult,
+    SchemaCoverageSummary,
+    SchemaExplainResult,
+    SchemaInferResult,
+    SchemaListResult,
+    SchemaPromoteResult,
+    SchemaProviderSnapshot,
+    SchemaReviewProof,
+    SchemaRoleAssignment,
+    SchemaRoleProofEntry,
+)
+from polylogue.schemas.packages import SchemaElementManifest, SchemaPackageCatalog, SchemaVersionPackage
+from polylogue.schemas.privacy_config import PrivacyConfig
+from polylogue.schemas.redaction_report import SchemaReport
+from polylogue.schemas.tooling_models import ClusterManifest, SchemaCluster, SchemaDiff
+
+
+def _package(*, version: str = "v1") -> SchemaVersionPackage:
+    return SchemaVersionPackage(
+        provider="chatgpt",
+        version=version,
+        anchor_kind="conversation_document",
+        default_element_kind="conversation_document",
+        first_seen="2026-04-01T00:00:00Z",
+        last_seen="2026-04-02T00:00:00Z",
+        bundle_scope_count=2,
+        sample_count=12,
+        anchor_profile_family_id="cluster-a",
+        profile_family_ids=["cluster-a", "cluster-b"],
+        elements=[
+            SchemaElementManifest(
+                element_kind="conversation_document",
+                schema_file="conversation_document.schema.json",
+                sample_count=12,
+                artifact_count=12,
+                bundle_scope_count=2,
+                profile_family_ids=["cluster-a", "cluster-b"],
+                first_seen="2026-04-01T00:00:00Z",
+                last_seen="2026-04-02T00:00:00Z",
+            )
+        ],
+        orphan_adjunct_counts={"attachment": 2},
+    )
+
+
+def _manifest() -> ClusterManifest:
+    return ClusterManifest(
+        provider="chatgpt",
+        default_version="v1",
+        artifact_counts={"conversation_document": 12},
+        clusters=[
+            SchemaCluster(
+                cluster_id="cluster-a",
+                provider="chatgpt",
+                sample_count=12,
+                first_seen="2026-04-01T00:00:00Z",
+                last_seen="2026-04-02T00:00:00Z",
+                representative_paths=["/tmp/source.json"],
+                dominant_keys=["id", "messages"],
+                confidence=0.91,
+                artifact_kind="conversation_document",
+                promoted_package_version="v1",
+            )
+        ],
+    )
+
+
+def _corpus_specs() -> tuple[CorpusSpec, ...]:
+    return (
+        CorpusSpec.for_provider(
+            "chatgpt",
+            package_version="v1",
+            element_kind="conversation_document",
+            count=2,
+            messages_min=3,
+            messages_max=6,
+            profile=CorpusProfile(
+                family_ids=("cluster-a",),
+                artifact_kind="conversation_document",
+                observed_sample_count=12,
+            ),
+        ),
+        CorpusSpec.for_provider(
+            "chatgpt",
+            package_version="v1",
+            element_kind="conversation_document",
+            count=3,
+            messages_min=2,
+            messages_max=5,
+            profile=CorpusProfile(
+                family_ids=("cluster-b",),
+                artifact_kind="conversation_document",
+                observed_sample_count=7,
+            ),
+        ),
+    )
+
+
+def _annotation_summary() -> SchemaAnnotationSummary:
+    return SchemaAnnotationSummary(
+        semantic_count=2,
+        format_count=1,
+        values_count=1,
+        total_enum_values=6,
+        roles=[
+            SchemaRoleAssignment(
+                path="$.messages[*].role",
+                role="message_role",
+                confidence=0.95,
+                evidence={"signal": "name-match"},
+            )
+        ],
+        coverage=SchemaCoverageSummary(
+            total_fields=10,
+            with_format=3,
+            with_values=1,
+            with_role=2,
+        ),
+    )
+
+
+def _schema_payload() -> JSONDocument:
+    return {
+        "$id": "schema://chatgpt/v1",
+        "title": "ChatGPT Conversation",
+        "description": "Observed ChatGPT payload schema",
+        "x-polylogue-version": "v1",
+        "x-polylogue-generated-at": "2026-04-01T00:00:00Z",
+        "x-polylogue-registered-at": "2026-04-02T00:00:00Z",
+        "x-polylogue-promoted-at": "2026-04-03T00:00:00Z",
+        "x-polylogue-sample-count": 12,
+        "x-polylogue-sample-granularity": "conversation",
+        "x-polylogue-anchor-profile-family-id": "cluster-a",
+        "x-polylogue-profile-family-ids": ["cluster-a", "cluster-b"],
+        "x-polylogue-package-profile-family-ids": ["cluster-a", "cluster-b"],
+        "x-polylogue-observed-artifact-count": 12,
+        "x-polylogue-evidence-confidence": 0.91,
+        "x-polylogue-foreign-keys": [{"path": "$.messages[*].parent_id"}],
+        "x-polylogue-time-deltas": [{"path": "$.messages[*].created_at"}],
+        "x-polylogue-mutually-exclusive": [{"paths": ["$.a", "$.b"]}],
+        "properties": {
+            "role": {
+                "type": "string",
+                "x-polylogue-semantic-role": "message_role",
+                "x-polylogue-format": "enum",
+                "x-polylogue-frequency": 1.0,
+                "x-polylogue-values": ["user", "assistant", "system", "tool", "other", "extra"],
+            },
+            "messages": {
+                "type": "array",
+            },
+        },
+    }
+
+
+def _explain_result(*, review_proof: SchemaReviewProof | None = None) -> SchemaExplainResult:
+    return SchemaExplainResult(
+        provider="chatgpt",
+        version="v1",
+        element_kind="conversation_document",
+        package=_package(),
+        schema=_schema_payload(),
+        annotations=_annotation_summary(),
+        review_proof=review_proof,
+    )
+
+
+def test_schema_command_support_builds_payloads_from_privacy_inputs(tmp_path: Path) -> None:
+    config = PrivacyConfig(
+        level="strict",
+        field_overrides={"$.id": "deny"},
+        allow_value_patterns=["safe*"],
+        deny_value_patterns=["secret*"],
+        safe_enum_max_length=12,
+        high_entropy_min_length=14,
+        cross_conv_min_count=5,
+        cross_conv_proportional=True,
+    )
+
+    assert _privacy_level("strict") == "strict"
+    assert _privacy_level("permissive") == "permissive"
+    assert _privacy_level("bogus") == "standard"
+    assert _privacy_config_payload(config) == {
+        "level": "strict",
+        "safe_enum_max_length": 12,
+        "high_entropy_min_length": 14,
+        "cross_conv_min_count": 5,
+        "cross_conv_proportional": True,
+        "field_overrides": {"$.id": "deny"},
+        "allow_value_patterns": ["safe*"],
+        "deny_value_patterns": ["secret*"],
+    }
+
+    privacy_path = tmp_path / "polylogue-schemas.toml"
+    privacy_path.write_text("", encoding="utf-8")
+    with patch(
+        "polylogue.schemas.privacy_config.load_privacy_config",
+        return_value=config,
+    ) as load_privacy_config:
+        loaded = build_schema_privacy_config(privacy="strict", privacy_config_path=privacy_path)
+
+    load_privacy_config.assert_called_once_with(
+        cli_overrides={"level": "strict"},
+        project_path=tmp_path,
+    )
+    assert loaded == _privacy_config_payload(config)
+    assert build_schema_privacy_config(privacy="bogus", privacy_config_path=None) == {
+        "level": "standard",
+        "safe_enum_max_length": 50,
+        "high_entropy_min_length": 10,
+        "cross_conv_min_count": 3,
+        "cross_conv_proportional": False,
+    }
+    assert build_schema_privacy_config(privacy=None, privacy_config_path=None) is None
+
+
+def test_render_schema_explain_result_json_and_verbose_text_paths() -> None:
+    result = _explain_result()
+
+    with patch("polylogue.cli.schema_rendering_explain.emit_success") as emit_success:
+        render_schema_explain_result(result=result, json_output=True, verbose=False)
+
+    emit_success.assert_called_once_with(result.to_dict())
+
+    with (
+        patch("click.echo") as echo,
+        patch("polylogue.cli.schema_rendering_explain.render_explain_verbose") as render_verbose,
+    ):
+        render_schema_explain_result(result=result, json_output=False, verbose=True)
+
+    echoed = [call.args[0] for call in echo.call_args_list if call.args]
+    assert "Schema: chatgpt v1 [conversation_document]" in echoed
+    assert any("Package anchor=conversation_document" in line for line in echoed)
+    assert any("Properties (2):" in line for line in echoed)
+    assert any("role: string" in line for line in echoed)
+    assert any("x-polylogue-foreign-keys:" in line for line in echoed)
+    render_verbose.assert_called_once_with(result)
+
+
+def test_render_explain_verbose_and_review_proof_surfaces() -> None:
+    result = _explain_result()
+
+    with patch("click.echo") as echo:
+        render_explain_verbose(result)
+
+    echoed = [call.args[0] for call in echo.call_args_list if call.args]
+    assert "  Semantic Roles:" in echoed
+    assert any("message_role -> $.messages[*].role" in line for line in echoed)
+    assert any("Annotation Coverage (10 fields):" in line for line in echoed)
+
+    proof_result = _explain_result(
+        review_proof=SchemaReviewProof(
+            artifact_kind="conversation_document",
+            eligible_roles=["message_role", "message_text"],
+            ineligible_roles=["message_tokens"],
+            roles=[
+                SchemaRoleProofEntry(
+                    role="message_role",
+                    chosen_path="$.messages[*].role",
+                    chosen_score=0.97,
+                    competing=[{"path": "$.role", "score": 0.40}],
+                    evidence={"name_similarity": 1.0},
+                    abstained=False,
+                ),
+                SchemaRoleProofEntry(
+                    role="message_text",
+                    chosen_path=None,
+                    chosen_score=0.0,
+                    competing=[],
+                    evidence={},
+                    abstained=True,
+                    abstain_reason="no plausible path",
+                ),
+            ],
+        )
+    )
+
+    with patch("click.echo") as echo:
+        render_schema_explain_result(result=proof_result, json_output=False, verbose=False)
+
+    proof_lines = [call.args[0] for call in echo.call_args_list if call.args]
+    assert "Schema Review Proof: chatgpt v1" in proof_lines
+    assert any("message_role: $.messages[*].role" in line for line in proof_lines)
+    assert any("competing (1):" in line for line in proof_lines)
+    assert any("message_text: ABSTAINED" in line for line in proof_lines)
+    assert any("reason: no plausible path" in line for line in proof_lines)
+
+
+def test_render_schema_generate_result_covers_plain_and_json_paths(tmp_path: Path) -> None:
+    corpus_specs = _corpus_specs()
+    corpus_scenarios = build_corpus_scenarios(corpus_specs)
+    generation = GenerationResult(
+        provider="chatgpt",
+        schema={"type": "object"},
+        sample_count=12,
+        cluster_count=1,
+        package_count=2,
+        versions=["v1", "v2"],
+        default_version="v1",
+        artifact_counts={"conversation_document": 12},
+        redaction_report=SchemaReport(
+            provider="chatgpt",
+            privacy_level="standard",
+            total_fields=4,
+            total_values_considered=10,
+            total_included=3,
+            total_rejected=1,
+            rejection_reasons={"identifier_field": 1},
+        ),
+    )
+    result = SchemaInferResult(
+        generation=generation,
+        manifest=_manifest(),
+        manifest_path=tmp_path / "manifest.json",
+        corpus_specs=corpus_specs,
+        corpus_scenarios=corpus_scenarios,
+    )
+
+    with patch("polylogue.cli.schema_rendering_results.emit_success") as emit_success:
+        render_schema_generate_result(provider="chatgpt", result=result, json_output=True, report=False)
+
+    emit_payload = emit_success.call_args.args[0]
+    assert emit_payload["provider"] == "chatgpt"
+    assert emit_payload["manifest_path"] == str(tmp_path / "manifest.json")
+    assert len(emit_payload["corpus_specs"]) == 2
+    assert len(emit_payload["corpus_scenarios"]) == 1
+
+    with (
+        patch("click.echo") as echo,
+        patch("pathlib.Path.write_text") as write_text,
+    ):
+        render_schema_generate_result(provider="chatgpt", result=result, json_output=False, report=True)
+
+    write_text.assert_called_once()
+    assert write_text.call_args.kwargs == {"encoding": "utf-8"}
+    assert write_text.call_args.args[0].startswith("# Schema Redaction Report: chatgpt")
+    echoed = [call.args[0] for call in echo.call_args_list if call.args]
+    assert any(line.startswith("schema[chatgpt]: 4 fields, 10 samples") for line in echoed)
+    assert any("Redaction report: chatgpt-redaction-report.md" in line for line in echoed)
+    assert any("Generated schema package set for chatgpt" in line for line in echoed)
+    assert any("Suggested synthetic scenarios:" in line for line in echoed)
+    assert any("Suggested synthetic corpus specs:" in line for line in echoed)
+
+
+def test_render_schema_list_result_covers_selected_global_json_and_empty_paths() -> None:
+    corpus_specs = _corpus_specs()
+    corpus_scenarios = build_corpus_scenarios(corpus_specs)
+    snapshot = SchemaProviderSnapshot(
+        provider="chatgpt",
+        versions=["v1", "v2"],
+        catalog=SchemaPackageCatalog(
+            provider="chatgpt",
+            packages=[_package()],
+            default_version="v1",
+            latest_version="v2",
+            recommended_version="v1",
+            orphan_adjunct_counts={"attachment": 2},
+        ),
+        manifest=_manifest(),
+        latest_age_days=3,
+        corpus_specs=corpus_specs,
+        corpus_scenarios=corpus_scenarios,
+    )
+
+    with patch("click.echo") as echo:
+        render_schema_list_result(
+            provider="chatgpt",
+            result=SchemaListResult(provider="chatgpt", selected=snapshot),
+            json_output=False,
+        )
+
+    echoed = [call.args[0] for call in echo.call_args_list if call.args]
+    assert "Provider: chatgpt" in echoed
+    assert any("Versions: v1, v2" in line for line in echoed)
+    assert any("Orphan adjunct evidence: attachment=2" in line for line in echoed)
+    assert any("Evidence manifest (1 clusters):" in line for line in echoed)
+    assert any("Suggested synthetic corpus specs:" in line for line in echoed)
+    assert any("Suggested synthetic scenarios:" in line for line in echoed)
+
+    with patch("polylogue.cli.schema_rendering_results.emit_success") as emit_success:
+        render_schema_list_result(
+            provider=None,
+            result=SchemaListResult(provider=None, providers=[snapshot]),
+            json_output=True,
+        )
+
+    emit_success.assert_called_once_with(
+        {
+            "providers": [
+                {
+                    "provider": "chatgpt",
+                    "versions": ["v1", "v2"],
+                    "package_count": 1,
+                    "default_version": "v1",
+                    "latest_version": "v2",
+                    "cluster_count": 1,
+                    "corpus_spec_count": 2,
+                    "corpus_scenario_count": 1,
+                }
+            ]
+        }
+    )
+
+    with patch("click.echo") as echo:
+        render_schema_list_result(
+            provider=None,
+            result=SchemaListResult(provider=None, providers=[]),
+            json_output=False,
+        )
+
+    echo.assert_called_once_with("No schemas found.")
+
+
+def test_render_schema_compare_promote_and_audit_result_variants() -> None:
+    compare_result = SchemaCompareResult(
+        diff=SchemaDiff(
+            provider="chatgpt",
+            version_a="v1",
+            version_b="v2",
+            changed_properties=["messages"],
+        )
+    )
+    promote_result = SchemaPromoteResult(
+        provider="chatgpt",
+        cluster_id="cluster-a",
+        package_version="v2",
+        package=_package(version="v2"),
+        schema={"type": "object"},
+        versions=["v1", "v2"],
+    )
+    audit_report = AuditReport(
+        provider="chatgpt",
+        checks=[AuditCheck(name="schema_bundle", status=OutcomeStatus.OK, summary="bundle OK", provider="chatgpt")],
+    )
+
+    with patch("polylogue.cli.schema_rendering_results.emit_success") as emit_success:
+        render_schema_compare_result(result=compare_result, json_output=True, md_output=False)
+        render_schema_promote_result(result=promote_result, json_output=True)
+        render_schema_audit_result(report=audit_report, json_output=True)
+
+    assert emit_success.call_args_list[0].args[0]["provider"] == "chatgpt"
+    assert emit_success.call_args_list[1].args[0]["package_version"] == "v2"
+    assert emit_success.call_args_list[2].args[0]["summary"] == {"passed": 1, "warned": 0, "failed": 0}
+
+    with patch("click.echo") as echo:
+        render_schema_compare_result(result=compare_result, json_output=False, md_output=True)
+        render_schema_compare_result(result=compare_result, json_output=False, md_output=False)
+        render_schema_promote_result(result=promote_result, json_output=False)
+        render_schema_audit_result(report=audit_report, json_output=False)
+
+    echoed = [call.args[0] for call in echo.call_args_list if call.args]
+    assert any(line.startswith("# Schema Diff: chatgpt") for line in echoed)
+    assert any(line.startswith("Schema diff: chatgpt v1 -> v2") for line in echoed)
+    assert "Promoted cluster cluster-a -> package v2" in echoed
+    assert "Schema package registered for chatgpt as v2" in echoed
+    assert "Available versions: v1, v2" in echoed
+    assert any(line.startswith("Schema Audit (chatgpt): 1 pass, 0 warn, 0 fail") for line in echoed)


### PR DESCRIPTION
## Summary
Raise the coverage floor from 86 to 87 with a focused CLI operator-helper tranche that directly covers the rendering and workflow helpers that were still sitting at 0% or near-0% coverage.

## Problem
Ref #197 is now in the part of the climb where the remaining gap is not about broad package averages so much as real blind spots in active control-plane code. Several CLI helper modules in rendering, workflow, and schema/operator surfaces were effectively untested despite being on daily operator paths.

## Solution
- add direct unit tests for:
  - `polylogue/cli/products_rendering.py`
  - `polylogue/cli/products_workflow.py`
  - `polylogue/cli/run_display_workflow.py`
  - `polylogue/cli/run_watch_workflow.py`
  - `polylogue/cli/schema_command_support.py`
  - `polylogue/cli/schema_rendering_explain.py`
  - `polylogue/cli/schema_rendering_results.py`
  - `polylogue/cli/query_verbs.py`
- cover both human and machine-output branches instead of relying on incidental higher-level command coverage
- raise `fail_under` from 86 to 87 after the full suite cleared at 87.33%

Targeted module movement from the full coverage run:
- `products_rendering.py`: 100%
- `products_workflow.py`: 100%
- `query_verbs.py`: 100%
- `run_watch_workflow.py`: 100%
- `run_display_workflow.py`: 92%
- `schema_command_support.py`: 96%
- `schema_rendering_explain.py`: 92%
- `schema_rendering_results.py`: 87%

## Verification
- `ruff check tests/unit/cli/test_products_helper_runtime.py tests/unit/cli/test_run_display_workflow_runtime.py tests/unit/cli/test_schema_helper_runtime.py tests/unit/cli/test_query_verbs_runtime.py`
- `mypy --strict tests/unit/cli/test_products_helper_runtime.py tests/unit/cli/test_run_display_workflow_runtime.py tests/unit/cli/test_schema_helper_runtime.py tests/unit/cli/test_query_verbs_runtime.py`
- `pytest -q tests/unit/cli/test_products_helper_runtime.py tests/unit/cli/test_run_display_workflow_runtime.py tests/unit/cli/test_schema_helper_runtime.py tests/unit/cli/test_query_verbs_runtime.py`
- `devtools coverage-gate`
  - `5434 passed in 262.51s (0:04:22)`
  - `Required test coverage of 87% reached. Total coverage: 87.33%`
- `devtools verify --quick`

Ref #197


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit test modules for CLI product helpers, query verb runtime behavior, display workflow handling, and schema rendering operations.

* **Chores**
  * Adjusted code coverage reporting requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->