### PR TITLE
test: ratchet coverage floor to 88

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,7 +141,7 @@ data_file = ".cache/coverage/.coverage"
 [tool.coverage.report]
 skip_empty = true
 show_missing = true
-fail_under = 87
+fail_under = 88
 
 [tool.mypy]
 python_version = "3.11"

--- a/tests/unit/cli/test_check_support_runtime.py
+++ b/tests/unit/cli/test_check_support_runtime.py
@@ -1,0 +1,311 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from polylogue.cli import check_workflow, formatting
+from polylogue.cli.check_models import CheckCommandResult, VacuumResult
+from polylogue.cli.check_workflow import CheckCommandOptions
+from polylogue.cli.types import AppEnv
+from polylogue.config import Config
+from polylogue.maintenance_targets import MaintenanceTargetMode
+from polylogue.readiness import ReadinessCheck, ReadinessReport, VerifyStatus
+from polylogue.schemas.verification_models import SchemaVerificationReport
+from polylogue.storage.repair import RepairResult
+
+
+def _env() -> AppEnv:
+    ui = MagicMock()
+    ui.console = MagicMock()
+    return cast(AppEnv, SimpleNamespace(ui=ui, config=None))
+
+
+def _config() -> Config:
+    return Config(
+        archive_root=Path("/tmp/archive"),
+        render_root=Path("/tmp/render"),
+        db_path=Path("/tmp/archive/polylogue.sqlite"),
+        sources=[],
+    )
+
+
+def _report() -> ReadinessReport:
+    return ReadinessReport(checks=[ReadinessCheck("database", VerifyStatus.OK, summary="ok")])
+
+
+def _options(**overrides: object) -> CheckCommandOptions:
+    payload = {
+        "json_output": False,
+        "verbose": False,
+        "repair": False,
+        "cleanup": False,
+        "preview": False,
+        "vacuum": False,
+        "deep": False,
+        "runtime": False,
+        "check_blob": False,
+        "check_schemas": False,
+        "check_proof": False,
+        "check_artifacts": False,
+        "check_cohorts": False,
+        "schema_providers": (),
+        "artifact_providers": (),
+        "artifact_statuses": (),
+        "artifact_kinds": (),
+        "artifact_limit": None,
+        "artifact_offset": 0,
+        "schema_samples": "all",
+        "schema_record_limit": None,
+        "schema_record_offset": 0,
+        "schema_quarantine_malformed": False,
+        "maintenance_targets": (),
+    }
+    payload.update(overrides)
+    return CheckCommandOptions(**cast(Any, payload))
+
+
+@pytest.mark.parametrize(
+    ("overrides", "expected"),
+    [
+        ({"vacuum": True}, "--vacuum requires --repair or --cleanup"),
+        ({"preview": True}, "--preview requires --repair or --cleanup"),
+        ({"maintenance_targets": ("session_products",)}, "--target requires --repair or --cleanup"),
+        ({"schema_providers": ("claude-code",)}, "--schema-provider requires --schemas"),
+        ({"schema_samples": "10"}, "--schema-samples requires --schemas"),
+        ({"schema_record_limit": 5}, "--schema-record-limit requires --schemas"),
+        ({"schema_record_offset": 2}, "--schema-record-offset requires --schemas"),
+        ({"schema_quarantine_malformed": True}, "--schema-quarantine-malformed requires --schemas"),
+        ({"artifact_providers": ("claude-code",)}, "--artifact-provider requires --proof, --artifacts, or --cohorts"),
+        ({"artifact_statuses": ("supported",)}, "--artifact-status requires --artifacts or --cohorts"),
+        ({"artifact_kinds": ("schema",)}, "--artifact-kind requires --artifacts or --cohorts"),
+        ({"artifact_limit": 5}, "--artifact-limit requires --proof, --artifacts, or --cohorts"),
+        ({"artifact_offset": 2}, "--artifact-offset requires --proof, --artifacts, or --cohorts"),
+        ({"check_schemas": True, "schema_record_limit": 0}, "--schema-record-limit must be a positive integer"),
+        ({"check_schemas": True, "schema_record_offset": -1}, "--schema-record-offset must be >= 0"),
+        ({"check_proof": True, "artifact_limit": 0}, "--artifact-limit must be a positive integer"),
+        ({"check_proof": True, "artifact_offset": -1}, "--artifact-offset must be >= 0"),
+    ],
+)
+def test_validate_check_options_rejects_invalid_flag_combinations(
+    overrides: dict[str, object],
+    expected: str,
+) -> None:
+    with pytest.raises(SystemExit, match=expected):
+        check_workflow.validate_check_options(_options(**overrides))
+
+
+def test_validate_check_options_rejects_target_mode_mismatches() -> None:
+    cleanup_spec = SimpleNamespace(mode=MaintenanceTargetMode.CLEANUP)
+    repair_spec = SimpleNamespace(mode=MaintenanceTargetMode.REPAIR)
+    catalog = SimpleNamespace(resolve=lambda names: [cleanup_spec] if names == ("cleanup_only",) else [repair_spec])
+
+    with patch("polylogue.cli.check_validation.build_maintenance_target_catalog", return_value=catalog):
+        with pytest.raises(SystemExit, match="only selected cleanup targets"):
+            check_workflow.validate_check_options(_options(repair=True, maintenance_targets=("cleanup_only",)))
+
+        with pytest.raises(SystemExit, match="only selected repair targets"):
+            check_workflow.validate_check_options(_options(cleanup=True, maintenance_targets=("repair_only",)))
+
+
+def test_formatting_helpers_cover_plan_counts_details_and_run_sections(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("POLYLOGUE_FORCE_PLAIN", raising=False)
+    assert formatting.plain_forced_by_env() is False
+    monkeypatch.setenv("POLYLOGUE_FORCE_PLAIN", "yes")
+    assert formatting.plain_forced_by_env() is True
+
+    counts = {
+        "conversations": 4,
+        "new_conversations": 2,
+        "changed_conversations": 1,
+        "acquired": 4,
+        "skipped": 1,
+        "acquire_errors": 1,
+        "validated": 3,
+        "validation_invalid": 1,
+        "validation_drift": 1,
+        "validation_skipped_no_schema": 2,
+        "validation_errors": 1,
+        "parse_failures": 2,
+        "materialized": 3,
+        "rendered": 2,
+        "render_failures": 1,
+        "schemas_generated": 1,
+        "schemas_failed": 1,
+    }
+    assert formatting.format_counts({"conversations": 4, "messages": 0}) == "4 conv (4 new)"
+    assert formatting.format_run_details(counts) == [
+        "Acquire: 4 acquired, 1 skipped, 1 errors",
+        "Validate: 3 passed, 1 invalid, 1 drift, 2 no-schema, 1 errors",
+        "Conversations: 2 new, 1 changed",
+        "Parse: 2 failures",
+        "Materialize: 3 conversations",
+        "Render: 2 rendered, 1 failures",
+        "Schemas: 1 generated, 1 failed",
+    ]
+    assert formatting.format_run_details({"conversations": 2}) == ["Conversations: 2 new"]
+
+    assert formatting.format_plan_counts({"scan": 2, "render": 1}) == "2 scan, 1 render"
+    assert formatting.format_plan_counts({}) == "no pipeline actions"
+    assert formatting.format_plan_details({"new_raw": 2, "preview_invalid": 1}) == (
+        "2 new raw, 1 would fail validation"
+    )
+    assert formatting.format_plan_details({}) is None
+    assert formatting.format_sources_summary([]) == "none"
+
+
+def test_run_blob_store_check_reports_missing_orphaned_and_verified_states() -> None:
+    env = _env()
+    config = _config()
+
+    rows = [("raw-a",), ("raw-b",)]
+
+    @contextmanager
+    def connection() -> Iterator[object]:
+        yield SimpleNamespace(execute=lambda sql: rows)
+
+    blob_store = SimpleNamespace(iter_all=lambda: ["raw-a", "orphan-c"])
+
+    with (
+        patch("polylogue.cli.check_workflow.connection_context", return_value=connection()),
+        patch("polylogue.storage.blob_store.get_blob_store", return_value=blob_store),
+    ):
+        check_workflow._run_blob_store_check(env, config)
+
+    console_print = cast(MagicMock, env.ui.console.print)
+    printed = [call.args[0] for call in console_print.call_args_list if call.args]
+    assert "Blob store: 2 blobs on disk, 2 raw records in DB" in printed
+    assert "  MISSING: 1 blobs referenced in DB but not on disk" in printed
+    assert "  Orphaned: 1 blobs on disk not in DB" in printed
+
+    env = _env()
+    verified_store = SimpleNamespace(iter_all=lambda: ["raw-a", "raw-b"])
+    with (
+        patch("polylogue.cli.check_workflow.connection_context", return_value=connection()),
+        patch("polylogue.storage.blob_store.get_blob_store", return_value=verified_store),
+    ):
+        check_workflow._run_blob_store_check(env, config)
+
+    verified_console_print = cast(MagicMock, env.ui.console.print)
+    assert verified_console_print.call_args_list[-1].args[0] == "  All blobs verified."
+
+
+def test_schema_verification_and_maintenance_helpers_cover_runtime_paths() -> None:
+    config = _config()
+    options = _options(
+        check_schemas=True,
+        schema_providers=("claude-code",),
+        schema_samples="25",
+        schema_record_limit=10,
+        schema_record_offset=2,
+        schema_quarantine_malformed=True,
+        repair=True,
+    )
+    report = _report()
+
+    schema_report = cast(SchemaVerificationReport, SimpleNamespace())
+    session_progress_callback = cast(Any, lambda: None)
+    with (
+        patch("polylogue.cli.check_workflow.run_schema_verification", return_value=schema_report) as run_verify,
+        patch("polylogue.cli.check_workflow.parse_schema_samples", return_value=25) as parse_samples,
+        patch("polylogue.cli.check_workflow.make_schema_progress_callback", return_value=session_progress_callback),
+        patch("builtins.print") as builtins_print,
+    ):
+        assert check_workflow._run_schema_verification(options, config) is schema_report
+
+    request = run_verify.call_args.args[0]
+    assert request.providers == ["claude-code"]
+    assert request.max_samples == 25
+    assert request.record_limit == 10
+    assert request.record_offset == 2
+    assert request.quarantine_malformed is True
+    assert request.progress_callback is session_progress_callback
+    assert run_verify.call_args.kwargs["db_path"] == config.db_path
+    parse_samples.assert_called_once_with("25")
+    builtins_print.assert_called_once()
+
+    with patch(
+        "polylogue.cli.check_workflow.make_session_product_progress_callback",
+        return_value=session_progress_callback,
+    ):
+        assert (
+            check_workflow._session_product_progress_callback(options, ("session_products",))
+            is session_progress_callback
+        )
+    assert check_workflow._session_product_progress_callback(_options(repair=True, preview=True), ()) is None
+    assert check_workflow._session_product_progress_callback(_options(repair=True, json_output=True), ()) is None
+
+    with (
+        patch("polylogue.cli.check_workflow._resolve_selected_maintenance_targets", return_value=("session_products",)),
+        patch("polylogue.cli.check_workflow._build_preview_counts", return_value={"session_products": 2}),
+    ):
+        preview_inputs = check_workflow._maintenance_run_inputs(_options(repair=True, preview=True), report)
+        assert preview_inputs.selected_targets == ("session_products",)
+        assert preview_inputs.preview_counts == {"session_products": 2}
+
+    result = CheckCommandResult(report=report)
+    inputs = check_workflow._MaintenanceRunInputs(selected_targets=("session_products",), preview_counts={"x": 1})
+    repair_result = cast(RepairResult, SimpleNamespace())
+    with patch("polylogue.cli.check_workflow.run_selected_maintenance", return_value=[repair_result]) as run_selected:
+        check_workflow._run_maintenance(config, result, _options(repair=True), inputs)
+    assert result.maintenance_targets == ("session_products",)
+    assert result.maintenance_results == [repair_result]
+    assert run_selected.call_args.kwargs["targets"] == ("session_products",)
+
+    env = _env()
+    result.vacuum_result = VacuumResult(ok=True, detail="done")
+    with patch("polylogue.cli.check_workflow.persist_maintenance_run") as persist_run:
+        check_workflow._persist_maintenance_run(
+            env,
+            report=report,
+            result=result,
+            options=_options(repair=True),
+            inputs=inputs,
+        )
+    persist_run.assert_called_once()
+
+
+def test_run_check_workflow_covers_runtime_blob_vacuum_and_persist_paths() -> None:
+    env = _env()
+    config = _config()
+    object.__setattr__(env, "config", config)
+    report = _report()
+    runtime_report = ReadinessReport(checks=[ReadinessCheck("runtime", VerifyStatus.OK, summary="ok")])
+    options = _options(
+        repair=True,
+        runtime=True,
+        check_blob=True,
+        vacuum=True,
+        json_output=True,
+    )
+
+    repair_result = cast(RepairResult, SimpleNamespace())
+    with (
+        patch("polylogue.cli.check_workflow.load_effective_config", return_value=config),
+        patch("polylogue.cli.check_workflow.get_readiness", return_value=report),
+        patch("polylogue.cli.check_workflow.run_runtime_readiness", return_value=runtime_report),
+        patch("polylogue.cli.check_workflow._run_blob_store_check") as run_blob_check,
+        patch(
+            "polylogue.cli.check_workflow._maintenance_run_inputs",
+            return_value=check_workflow._MaintenanceRunInputs(
+                selected_targets=("session_products",), preview_counts=None
+            ),
+        ),
+        patch("polylogue.cli.check_workflow.run_selected_maintenance", return_value=[repair_result]),
+        patch("polylogue.cli.check_workflow.make_session_product_progress_callback", return_value="progress"),
+        patch("polylogue.cli.check_workflow.vacuum_database", return_value=VacuumResult(ok=True, detail="vacuumed")),
+        patch("polylogue.cli.check_workflow.persist_maintenance_run") as persist_run,
+    ):
+        result = check_workflow.run_check_workflow(env, options)
+
+    assert result.report is report
+    assert result.runtime_report is runtime_report
+    assert result.maintenance_results == [repair_result]
+    assert result.vacuum_result == VacuumResult(ok=True, detail="vacuumed")
+    run_blob_check.assert_called_once_with(env, config)
+    persist_run.assert_called_once()

--- a/tests/unit/cli/test_command_aux_runtime.py
+++ b/tests/unit/cli/test_command_aux_runtime.py
@@ -1,0 +1,290 @@
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Iterator
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import click
+import pytest
+from click.shell_completion import CompletionItem
+from click.testing import CliRunner
+
+from polylogue.cli import shell_completion_values
+from polylogue.cli.commands.neighbors import (
+    _candidate_heading,
+    _render_plain,
+    _score_label,
+    neighbors_command,
+)
+from polylogue.cli.commands.tags import tags_command
+from polylogue.cli.filter_picker import _pick_index, pick_filter
+from polylogue.lib.filters import ConversationFilter
+from polylogue.lib.models import ConversationSummary
+from polylogue.lib.neighbor_candidates import ConversationNeighborCandidate, NeighborDiscoveryError, NeighborReason
+from polylogue.types import ConversationId, Provider
+
+
+def _ctx_param() -> tuple[click.Context, click.Parameter]:
+    return click.Context(click.Command("polylogue")), click.Option(["--value"])
+
+
+@contextmanager
+def _connection(rows: list[dict[str, object]]) -> Iterator[object]:
+    cursor = SimpleNamespace(fetchall=lambda: rows)
+    conn = SimpleNamespace(execute=lambda sql, params: cursor)
+    yield conn
+
+
+@contextmanager
+def _broken_connection() -> Iterator[object]:
+    raise sqlite3.OperationalError("boom")
+    yield
+
+
+def _candidate(*, message_id: str | None = "message-1") -> ConversationNeighborCandidate:
+    return ConversationNeighborCandidate(
+        summary=ConversationSummary(
+            id=ConversationId("candidate"),
+            provider=Provider.CODEX,
+            title="Archive Lock Retries",
+            updated_at=datetime(2026, 4, 23, 8, 30, tzinfo=timezone.utc),
+            message_count=2,
+        ),
+        rank=1,
+        score=3.20,
+        reasons=(
+            NeighborReason(
+                kind="same_title",
+                detail="same normalized title",
+                weight=3.0,
+                evidence=message_id,
+            ),
+        ),
+        source_conversation_id="target",
+    )
+
+
+def _picker_result(index: int) -> SimpleNamespace:
+    return SimpleNamespace(
+        provider="claude-code",
+        display_title=f"Conversation {index} " + ("x" * 60),
+        display_date=datetime(2026, 4, 23, tzinfo=timezone.utc),
+    )
+
+
+@pytest.mark.parametrize(
+    ("choice", "total_results", "expected"),
+    [
+        ("", 3, 0),
+        ("1", 3, 0),
+        ("3", 3, 2),
+        ("0", 3, None),
+        ("4", 3, None),
+        ("abc", 3, None),
+    ],
+)
+def test_pick_index_covers_blank_valid_and_invalid_choices(
+    choice: str,
+    total_results: int,
+    expected: int | None,
+) -> None:
+    assert _pick_index(choice, total_results) == expected
+
+
+@pytest.mark.asyncio
+async def test_pick_filter_returns_first_for_non_tty_and_none_for_empty_results() -> None:
+    filter_obj = cast(ConversationFilter, SimpleNamespace(list=AsyncMock(return_value=[_picker_result(1)])))
+    with patch("sys.stdout.isatty", return_value=False):
+        assert await pick_filter(filter_obj) == _picker_result(1)
+
+    empty_filter = cast(ConversationFilter, SimpleNamespace(list=AsyncMock(return_value=[])))
+    assert await pick_filter(empty_filter) is None
+
+
+@pytest.mark.asyncio
+async def test_pick_filter_tty_path_renders_menu_and_handles_blank_invalid_and_interrupt() -> None:
+    results = [_picker_result(index) for index in range(1, 23)]
+    filter_obj = cast(ConversationFilter, SimpleNamespace(list=AsyncMock(return_value=results)))
+
+    with (
+        patch("sys.stdout.isatty", return_value=True),
+        patch("builtins.input", return_value=""),
+        patch("builtins.print") as mock_print,
+    ):
+        assert await pick_filter(filter_obj) == results[0]
+
+    printed = [" ".join(str(arg) for arg in call.args) for call in mock_print.call_args_list]
+    assert any("22 matching conversations" in line for line in printed)
+    assert any("... and 2 more" in line for line in printed)
+
+    with (
+        patch("sys.stdout.isatty", return_value=True),
+        patch("builtins.input", return_value="99"),
+        patch("builtins.print"),
+    ):
+        assert await pick_filter(filter_obj) is None
+
+    with (
+        patch("sys.stdout.isatty", return_value=True),
+        patch("builtins.input", side_effect=KeyboardInterrupt),
+        patch("builtins.print"),
+    ):
+        assert await pick_filter(filter_obj) is None
+
+
+def test_shell_completion_helpers_cover_csv_prefix_rows_and_trimming(tmp_path: Path) -> None:
+    assert shell_completion_values._split_csv_incomplete("alpha,beta") == ("alpha,", "beta")
+    assert shell_completion_values._split_csv_incomplete("alpha, beta,g") == ("alpha,beta,", "g")
+    assert shell_completion_values._split_csv_incomplete("cla") == ("", "cla")
+
+    item = CompletionItem("tool", type="plain", help="help")
+    prefixed = shell_completion_values._with_csv_prefix([item], "alpha,")
+    assert [completion.value for completion in prefixed] == ["alpha,tool"]
+    assert shell_completion_values._with_csv_prefix([item], "") == [item]
+
+    assert shell_completion_values._trim_help("line one\nline two", limit=9) == "line one…"
+    assert shell_completion_values._trim_help("short help") == "short help"
+
+    db = tmp_path / "archive.sqlite"
+    with patch("polylogue.cli.shell_completion_values.db_path", return_value=db):
+        assert shell_completion_values._db_exists() is False
+        db.write_text("", encoding="utf-8")
+        assert shell_completion_values._db_exists() is True
+
+    rows: list[dict[str, object]] = [{"value": "alpha", "help": "example help"}]
+    items = shell_completion_values._rows_to_completion_items(
+        cast(list[sqlite3.Row], rows),
+        value_column="value",
+        help_builder=lambda row: str(row["help"]),
+    )
+    assert [(item.value, item.help) for item in items] == [("alpha", "example help")]
+
+
+def test_fetch_rows_handles_missing_db_errors_and_success() -> None:
+    with patch("polylogue.cli.shell_completion_values._db_exists", return_value=False):
+        assert shell_completion_values._fetch_rows("SELECT 1", ()) == []
+
+    with (
+        patch("polylogue.cli.shell_completion_values._db_exists", return_value=True),
+        patch("polylogue.cli.shell_completion_values.open_read_connection", _broken_connection),
+    ):
+        assert shell_completion_values._fetch_rows("SELECT 1", ()) == []
+
+    rows: list[dict[str, object]] = [{"conversation_id": "conv-1"}]
+    with (
+        patch("polylogue.cli.shell_completion_values._db_exists", return_value=True),
+        patch("polylogue.cli.shell_completion_values.open_read_connection", lambda: _connection(rows)),
+    ):
+        assert shell_completion_values._fetch_rows("SELECT 1", ("x",)) == rows
+
+
+def test_completion_functions_cover_provider_conversation_tag_tool_and_open_targets() -> None:
+    ctx, param = _ctx_param()
+
+    provider_items = shell_completion_values.complete_provider_values(ctx, param, "chatgpt,cla")
+    assert [item.value for item in provider_items] == ["chatgpt,claude-ai", "chatgpt,claude-code"]
+
+    conversation_rows = [
+        {
+            "conversation_id": "conv-1",
+            "provider_name": "claude-code",
+            "display_title": "A long title " * 10,
+        }
+    ]
+    tag_rows = [{"tag_name": "review", "cnt": 3}]
+    tool_rows = [{"normalized_tool_name": "read_file", "cnt": 7}]
+
+    with patch(
+        "polylogue.cli.shell_completion_values._fetch_rows",
+        side_effect=[conversation_rows, conversation_rows, tag_rows, tool_rows],
+    ):
+        conversation_items = shell_completion_values.complete_conversation_ids(ctx, param, "conv")
+        open_items = shell_completion_values.complete_open_targets(ctx, param, "conv")
+        tag_items = shell_completion_values.complete_tag_values(ctx, param, "alpha,rev")
+        tool_items = shell_completion_values.complete_tool_values(ctx, param, "read")
+
+    assert conversation_items[0].value == "conv-1"
+    assert conversation_items[0].help is not None and "claude-code" in conversation_items[0].help
+    assert open_items[0].value == "conv-1"
+    assert [item.value for item in tag_items] == ["alpha,review"]
+    assert tag_items[0].help == "3 conversations"
+    assert [item.value for item in tool_items] == ["read_file"]
+    assert tool_items[0].help == "7 actions"
+
+
+@pytest.fixture
+def cli_runner() -> CliRunner:
+    return CliRunner()
+
+
+def test_tags_command_plain_paths_cover_empty_hint_and_tabular_counts(cli_runner: CliRunner) -> None:
+    env = MagicMock()
+    env.repository.list_tags = AsyncMock(return_value={})
+
+    empty = cli_runner.invoke(tags_command, ["--provider", "chatgpt"], obj=env, catch_exceptions=False)
+    assert empty.exit_code == 0
+    assert "No tags found for provider 'chatgpt'." in empty.output
+    assert "Hint: use --add-tag" in empty.output
+
+    env.repository.list_tags = AsyncMock(return_value={"alpha": 5, "beta": 2})
+    table = cli_runner.invoke(tags_command, ["--count", "1"], obj=env, catch_exceptions=False)
+    assert table.exit_code == 0
+    assert "Tags (all providers, 1 total):" in table.output
+    assert "alpha" in table.output
+    assert "beta" not in table.output
+
+    env.repository.list_tags = AsyncMock(return_value={"alpha": 5})
+    with patch("polylogue.cli.commands.tags.emit_success") as emit_success:
+        json_result = cli_runner.invoke(tags_command, ["--json"], obj=env, catch_exceptions=False)
+    assert json_result.exit_code == 0
+    emit_success.assert_called_once_with({"tags": {"alpha": 5}})
+
+    env.repository.list_tags = AsyncMock(return_value={})
+    generic_empty = cli_runner.invoke(tags_command, [], obj=env, catch_exceptions=False)
+    assert generic_empty.exit_code == 0
+    assert "No tags found." in generic_empty.output
+
+
+def test_neighbor_helpers_and_command_cover_plain_rendering_and_errors(cli_runner: CliRunner) -> None:
+    assert _score_label(3.20) == "3.2"
+    assert "candidate" in _candidate_heading(_candidate(message_id=None))
+
+    with patch("click.echo") as echo:
+        _render_plain([])
+        _render_plain([_candidate()])
+
+    echoed = [call.args[0] for call in echo.call_args_list if call.args]
+    assert "No neighboring candidates found." in echoed
+    assert any("Neighbor candidates (1):" in line for line in echoed)
+    assert any("same_title: same normalized title (message-1)" in line for line in echoed)
+
+    env = MagicMock()
+    env.operations = MagicMock()
+    env.operations.neighbor_candidates = AsyncMock(return_value=[_candidate()])
+    plain = cli_runner.invoke(
+        neighbors_command,
+        ["--query", "lock retries", "--limit", "0", "--window-hours", "0"],
+        obj=env,
+        catch_exceptions=False,
+    )
+    assert plain.exit_code == 0
+    assert "Neighbor candidates (1):" in plain.output
+    env.operations.neighbor_candidates.assert_called_once_with(
+        conversation_id=None,
+        query="lock retries",
+        provider=None,
+        limit=1,
+        window_hours=1,
+    )
+
+    error_env = MagicMock()
+    error_env.operations = MagicMock()
+    error_env.operations.neighbor_candidates = AsyncMock(side_effect=NeighborDiscoveryError("no candidates"))
+    error = cli_runner.invoke(neighbors_command, ["--query", "lock retries"], obj=error_env)
+    assert error.exit_code != 0
+    assert "no candidates" in str(error.exception)

--- a/tests/unit/cli/test_query_progress_runtime.py
+++ b/tests/unit/cli/test_query_progress_runtime.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from polylogue.cli.query_contracts import QueryDeliveryTarget, QueryOutputSpec
+from polylogue.cli.query_progress import (
+    QuerySlowNotice,
+    _action_event_state,
+    _action_fallback_detail,
+    _async_method,
+    _format_elapsed,
+    build_query_slow_notice,
+    observe_slow_query,
+    should_emit_slow_query_notes,
+    slow_query_notice_threshold,
+)
+from polylogue.lib.query_spec import ConversationQuerySpec
+from polylogue.storage.action_event_artifacts import ActionEventArtifactState
+
+
+def _output_spec(output_format: str) -> QueryOutputSpec:
+    return QueryOutputSpec(
+        output_format=output_format,
+        destinations=(QueryDeliveryTarget.parse("stdout"),),
+        fields=None,
+        dialogue_only=False,
+        message_roles=(),
+        transform=None,
+        list_mode=False,
+        print_path=False,
+    )
+
+
+def test_slow_query_notice_threshold_and_output_mode_helpers(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("POLYLOGUE_SLOW_QUERY_NOTICE_SECONDS", raising=False)
+    assert slow_query_notice_threshold() == 2.0
+
+    monkeypatch.setenv("POLYLOGUE_SLOW_QUERY_NOTICE_SECONDS", "1.5")
+    assert slow_query_notice_threshold() == 1.5
+
+    monkeypatch.setenv("POLYLOGUE_SLOW_QUERY_NOTICE_SECONDS", "-4")
+    assert slow_query_notice_threshold() == 0.0
+
+    monkeypatch.setenv("POLYLOGUE_SLOW_QUERY_NOTICE_SECONDS", "invalid")
+    assert slow_query_notice_threshold() == 2.0
+
+    assert should_emit_slow_query_notes(_output_spec("markdown")) is True
+    assert should_emit_slow_query_notes(_output_spec("json")) is False
+
+
+def test_format_elapsed_and_async_method_cover_all_branches() -> None:
+    assert _format_elapsed(1.25) == "1.2s"
+    assert _format_elapsed(12.4) == "12s"
+    assert _format_elapsed(125.0) == "2m05s"
+
+    async def async_method() -> str:
+        return "ok"
+
+    holder = SimpleNamespace(run=async_method, value="not-callable")
+    assert _async_method(holder, "run") is async_method
+    assert _async_method(holder, "value") is None
+    assert _async_method(holder, "missing") is None
+
+
+@pytest.mark.asyncio
+async def test_action_event_state_handles_missing_methods_and_failures() -> None:
+    assert await _action_event_state(object()) is None
+
+    repo = SimpleNamespace(get_action_event_artifact_state=AsyncMock(side_effect=RuntimeError("boom")))
+    assert await _action_event_state(repo) is None
+
+    state = ActionEventArtifactState(
+        source_conversations=2,
+        materialized_conversations=1,
+        materialized_rows=2,
+        fts_rows=1,
+        stale_rows=1,
+    )
+    ready_repo = SimpleNamespace(get_action_event_artifact_state=AsyncMock(return_value=state))
+    assert await _action_event_state(ready_repo) == state
+    assert (
+        _action_fallback_detail(
+            ActionEventArtifactState(
+                source_conversations=1,
+                materialized_conversations=1,
+                materialized_rows=1,
+                fts_rows=1,
+            )
+        )
+        is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_build_query_slow_notice_handles_plan_failures_and_pending_action_models() -> None:
+    selection = ConversationQuerySpec(action_terms=("shell",))
+
+    with patch.object(ConversationQuerySpec, "to_plan", side_effect=RuntimeError("no plan")):
+        notice = await build_query_slow_notice(object(), selection, route="search")
+    assert notice == QuerySlowNotice(route="search", retrieval_lane="unknown", fallback_detail=None)
+
+    plan = ConversationQuerySpec(action_terms=("shell",)).to_plan()
+    pending_state = ActionEventArtifactState(
+        source_conversations=3,
+        materialized_conversations=1,
+        materialized_rows=2,
+        fts_rows=1,
+        stale_rows=1,
+    )
+    repo = SimpleNamespace(get_action_event_artifact_state=AsyncMock(return_value=pending_state))
+    with (
+        patch.object(ConversationQuerySpec, "to_plan", return_value=plan),
+        patch("polylogue.cli.query_progress.uses_action_read_model", return_value=True),
+    ):
+        notice = await build_query_slow_notice(repo, selection, route="stats")
+
+    assert notice.route == "stats"
+    assert notice.retrieval_lane == plan.retrieval_lane
+    assert notice.fallback_detail == pending_state.repair_detail()
+
+
+@pytest.mark.asyncio
+async def test_observe_slow_query_handles_disabled_immediate_and_delayed_paths() -> None:
+    assert (
+        await observe_slow_query(
+            asyncio.sleep(0, result="done"),
+            enabled=False,
+            notice_factory=AsyncMock(),
+        )
+        == "done"
+    )
+
+    immediate_notice_factory = AsyncMock()
+    assert (
+        await observe_slow_query(
+            asyncio.sleep(0, result="fast"),
+            enabled=True,
+            threshold_seconds=0.05,
+            notice_factory=immediate_notice_factory,
+        )
+        == "fast"
+    )
+    immediate_notice_factory.assert_not_awaited()
+
+    emitted: list[str] = []
+
+    async def _slow_operation() -> str:
+        await asyncio.sleep(0.01)
+        return "slow"
+
+    delayed_notice_factory = AsyncMock(return_value=QuerySlowNotice(route="show", retrieval_lane="hybrid"))
+    assert (
+        await observe_slow_query(
+            _slow_operation(),
+            enabled=True,
+            threshold_seconds=0.0,
+            notice_factory=delayed_notice_factory,
+            emit=emitted.append,
+        )
+        == "slow"
+    )
+
+    delayed_notice_factory.assert_awaited_once()
+    assert emitted == ["Query still running after 0.0s (route: show; retrieval: hybrid)."]

--- a/tests/unit/cli/test_query_support_runtime.py
+++ b/tests/unit/cli/test_query_support_runtime.py
@@ -1,0 +1,496 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from polylogue.cli import query_output, query_semantic, query_stats
+from polylogue.cli.query_actions import apply_modifiers, apply_transform, delete_conversations, resolve_stream_target
+from polylogue.cli.query_contracts import QueryDeliveryTarget, QueryMutationSpec, QueryOutputSpec
+from polylogue.cli.types import AppEnv
+from polylogue.lib.action_events import ActionEvent
+from polylogue.lib.models import ConversationSummary
+from polylogue.lib.query_spec import ConversationQuerySpec
+from polylogue.lib.roles import Role
+from polylogue.lib.search_hits import ConversationSearchHit
+from polylogue.lib.viewport_enums import ToolCategory
+from polylogue.storage.action_event_artifacts import ActionEventArtifactState
+from polylogue.types import ConversationId, Provider
+from tests.infra.builders import make_conv, make_msg
+
+
+def _env(*, plain: bool = True) -> AppEnv:
+    ui = MagicMock()
+    ui.plain = plain
+    ui.console = MagicMock()
+    ui.confirm = MagicMock(return_value=False)
+    return AppEnv(ui=ui)
+
+
+def _output_spec(output_format: str = "markdown") -> QueryOutputSpec:
+    return QueryOutputSpec(
+        output_format=output_format,
+        destinations=(QueryDeliveryTarget.parse("stdout"),),
+        fields=None,
+        dialogue_only=False,
+        message_roles=(),
+        transform=None,
+        list_mode=False,
+        print_path=False,
+    )
+
+
+def _mutation(*, dry_run: bool = False, force: bool = False, add_tags: tuple[str, ...] = ()) -> QueryMutationSpec:
+    return QueryMutationSpec(
+        set_meta=(("priority", "high"),),
+        add_tags=add_tags,
+        delete_matched=False,
+        dry_run=dry_run,
+        force=force,
+    )
+
+
+def _summary(
+    *,
+    conversation_id: str = "conv-1",
+    provider: Provider = Provider.CLAUDE_CODE,
+    title: str = "Archive Retry",
+    updated_at: datetime | None = None,
+) -> ConversationSummary:
+    return ConversationSummary(
+        id=ConversationId(conversation_id),
+        provider=provider,
+        title=title,
+        updated_at=updated_at or datetime(2026, 4, 23, 9, 0, tzinfo=timezone.utc),
+        message_count=2,
+    )
+
+
+def _action(
+    *,
+    kind: ToolCategory = ToolCategory.SHELL,
+    tool_name: str = "read_file",
+    search_text: str = "shell read_file /tmp/demo.py",
+    affected_paths: tuple[str, ...] = ("/tmp/demo.py",),
+) -> ActionEvent:
+    return ActionEvent(
+        event_id="event-1",
+        message_id="message-1",
+        timestamp=datetime(2026, 4, 23, 9, 0, tzinfo=timezone.utc),
+        sequence_index=0,
+        kind=kind,
+        tool_name=tool_name,
+        tool_id=None,
+        provider=Provider.CLAUDE_CODE,
+        affected_paths=affected_paths,
+        cwd_path="/tmp",
+        branch_names=(),
+        command="cat demo.py",
+        query=None,
+        url=None,
+        output_text="output",
+        search_text=search_text,
+        raw={},
+    )
+
+
+@pytest.mark.asyncio
+async def test_query_actions_cover_error_branches_and_abort_paths() -> None:
+    repo = SimpleNamespace(resolve_id=AsyncMock(side_effect=[None, None, "conv-123"]))
+    filter_chain = MagicMock()
+    filter_chain.list_summaries = AsyncMock(return_value=[])
+    filter_chain.sort.return_value.limit.return_value.list_summaries = AsyncMock(return_value=[])
+
+    with patch("click.echo") as echo:
+        with pytest.raises(SystemExit) as missing_id:
+            await resolve_stream_target(repo, filter_chain, ConversationQuerySpec(conversation_id="missing"))
+        with pytest.raises(SystemExit) as latest_missing:
+            await resolve_stream_target(repo, filter_chain, ConversationQuerySpec(latest=True))
+        with pytest.raises(SystemExit) as filtered_missing:
+            await resolve_stream_target(
+                repo,
+                filter_chain,
+                ConversationQuerySpec(providers=(Provider.CLAUDE_CODE,)),
+            )
+        query_selection = cast(
+            ConversationQuerySpec,
+            SimpleNamespace(
+                conversation_id=None,
+                latest=False,
+                query_terms=("missing",),
+                has_filters=lambda: False,
+            ),
+        )
+        with pytest.raises(SystemExit) as query_missing:
+            await resolve_stream_target(repo, filter_chain, query_selection)
+        with pytest.raises(SystemExit) as missing_selection:
+            await resolve_stream_target(repo, filter_chain, ConversationQuerySpec())
+
+    assert missing_id.value.code == 2
+    assert latest_missing.value.code == 2
+    assert filtered_missing.value.code == 2
+    assert query_missing.value.code == 2
+    assert missing_selection.value.code == 1
+    echoed = [call.args[0] for call in echo.call_args_list if call.args]
+    assert "No conversations matched." in echoed
+    assert "No conversations matched filters." in echoed
+    assert any("Hint: use" in line for line in echoed)
+
+    env = _env()
+    await apply_modifiers(env, [], _mutation())
+    console_print = cast(MagicMock, env.ui.console.print)
+    assert console_print.call_args_list[0].args[0] == "No conversations matched."
+
+    env = _env()
+    convs = [make_conv(id=f"conv-{index}", provider="claude-code") for index in range(12)]
+    await apply_modifiers(env, convs, _mutation(force=False, add_tags=("review",)))
+    console_print = cast(MagicMock, env.ui.console.print)
+    assert console_print.call_args_list[-1].args[0] == "Aborted."
+
+    env = _env()
+    await delete_conversations(env, [], _mutation())
+    console_print = cast(MagicMock, env.ui.console.print)
+    assert console_print.call_args_list[0].args[0] == "No conversations matched."
+
+    env = _env()
+    same_day = [
+        make_conv(
+            id=f"conv-{index}",
+            provider="claude-code",
+            updated_at=datetime(2026, 4, 23, 10, index, tzinfo=timezone.utc),
+        )
+        for index in range(2)
+    ]
+    await delete_conversations(env, same_day, _mutation(force=False))
+    console_print = cast(MagicMock, env.ui.console.print)
+    assert console_print.call_args_list[-1].args[0] == "Aborted."
+
+    success_selection = cast(
+        ConversationQuerySpec,
+        SimpleNamespace(
+            conversation_id=None,
+            latest=False,
+            query_terms=("conv-123",),
+            has_filters=lambda: False,
+        ),
+    )
+    success = await resolve_stream_target(
+        repo,
+        filter_chain,
+        success_selection,
+    )
+    assert success == "conv-123"
+
+    env = _env()
+    confirm = cast(MagicMock, env.ui.confirm)
+    confirm.return_value = False
+    many_conversations = [make_conv(id=f"conv-{index}", provider="claude-code") for index in range(11)]
+    await delete_conversations(env, many_conversations, _mutation(force=False))
+    console_print = cast(MagicMock, env.ui.console.print)
+    assert console_print.call_args_list[-1].args[0] == "Aborted."
+
+
+def test_apply_transform_covers_all_supported_variants() -> None:
+    conversation = make_conv(
+        id="conv-tools",
+        provider="claude-code",
+        messages=[
+            make_msg(role="assistant", text="Answer"),
+            make_msg(role="assistant", text="Thinking", is_thinking=True),
+        ],
+    )
+
+    assert len(apply_transform([conversation], "strip-tools")) == 1
+    assert len(apply_transform([conversation], "strip-thinking")) == 1
+    assert len(apply_transform([conversation], "strip-all")) == 1
+
+
+def test_query_semantic_matches_none_blocked_text_and_path_terms() -> None:
+    action = _action()
+
+    assert (
+        query_semantic.action_matches_slice(action, query_semantic.SemanticStatsSlice(action_terms=("none",))) is False
+    )
+    assert (
+        query_semantic.action_matches_slice(
+            action,
+            query_semantic.SemanticStatsSlice(excluded_action_terms=("shell",)),
+        )
+        is False
+    )
+    assert (
+        query_semantic.action_matches_slice(
+            action,
+            query_semantic.SemanticStatsSlice(action_text_terms=("missing",)),
+        )
+        is False
+    )
+    assert (
+        query_semantic.action_matches_slice(
+            action,
+            query_semantic.SemanticStatsSlice(tool_terms=("none",)),
+        )
+        is False
+    )
+    assert query_semantic.path_matches_slice(action, ("demo.py",)) is True
+    assert query_semantic.path_matches_slice(action, ("missing.py",)) is False
+
+
+@pytest.mark.asyncio
+async def test_query_semantic_helpers_cover_hydration_empty_and_plain_rendering() -> None:
+    assert (
+        await query_semantic._load_semantic_stats_conversations(
+            SimpleNamespace(
+                get_conversations_batch=AsyncMock(return_value=[]),
+                get_messages_batch=AsyncMock(return_value={}),
+                get_attachments_batch=lambda ids: {},
+            ),
+            [],
+        )
+        == []
+    )
+
+    with patch(
+        "polylogue.storage.hydrators.conversation_from_records",
+        side_effect=lambda record, messages, attachments: make_conv(id=str(record.conversation_id), messages=[]),
+    ):
+        conversations = await query_semantic._load_semantic_stats_conversations(
+            SimpleNamespace(
+                get_conversations_batch=AsyncMock(return_value=[SimpleNamespace(conversation_id="conv-1")]),
+                get_messages_batch=AsyncMock(return_value={"conv-1": []}),
+                get_attachments_batch=lambda ids: {},
+            ),
+            ["conv-1", "missing"],
+        )
+
+    assert [str(conv.id) for conv in conversations] == ["conv-1"]
+
+    env = _env()
+    repo = SimpleNamespace(
+        get_action_event_artifact_state=AsyncMock(
+            return_value=ActionEventArtifactState(
+                source_conversations=2,
+                materialized_conversations=2,
+                materialized_rows=2,
+                fts_rows=2,
+            )
+        ),
+        get_action_events_batch=AsyncMock(return_value={"conv-1": (_action(),), "conv-2": ()}),
+    )
+    await query_semantic.output_stats_by_semantic_ids(env, ["conv-1", "conv-2"], repo, "action")
+
+    console_print = cast(MagicMock, env.ui.console.print)
+    printed = [call.args[0] for call in console_print.call_args_list if call.args]
+    assert printed[0] == "\nMatched: 2 conversations (by action)\n"
+    assert "multiple action groups" in printed[-1]
+
+    with patch("polylogue.cli.query_semantic.emit_no_results") as emit_no_results:
+        await query_semantic.output_stats_by_semantic_ids(env, [], repo, "action")
+    emit_no_results.assert_called_once()
+
+    with patch("polylogue.cli.query_semantic.output_stats_by_semantic_ids", new_callable=AsyncMock) as output_ids:
+        await query_semantic.output_stats_by_semantic_query(env, ["conv-1"], repo, "action")
+    output_ids.assert_awaited_once()
+
+    with pytest.raises(ValueError, match="Unsupported semantic stats dimension"):
+        await query_semantic.output_stats_by_semantic_ids(env, ["conv-1"], repo, "provider")
+
+
+@pytest.mark.asyncio
+async def test_query_stats_helpers_cover_structured_sql_and_profile_paths() -> None:
+    with patch("click.echo") as echo:
+        assert (
+            query_stats.emit_structured_stats(
+                output_format="yaml",
+                dimension="provider",
+                rows=[{"group": "claude-code", "conversations": 1, "messages": 2}],
+                summary={"group": "TOTAL", "conversations": 1, "messages": 2},
+            )
+            is True
+        )
+        assert (
+            query_stats.emit_structured_stats(
+                output_format="csv",
+                dimension="provider",
+                rows=[{"group": "claude-code", "conversations": 1, "messages": 2}],
+                summary={"group": "TOTAL", "conversations": 1, "messages": 2},
+            )
+            is True
+        )
+    assert echo.call_count == 2
+    with pytest.raises(TypeError, match="must be int"):
+        query_stats._count_value({"messages": "two"}, "messages")
+
+    env = _env()
+    filter_chain = SimpleNamespace(
+        describe=lambda: ["provider=claude-code"],
+        can_use_summaries=lambda: False,
+        count=AsyncMock(return_value=0),
+    )
+    repo = SimpleNamespace()
+    with patch("polylogue.cli.query_stats.emit_no_results") as emit_no_results:
+        await query_stats.output_stats_sql(env, cast(Any, filter_chain), repo, output_format="json")
+    emit_no_results.assert_called_once()
+
+    env = _env()
+    archive_filter = SimpleNamespace(describe=lambda: [], can_use_summaries=lambda: False)
+    archive_repo = SimpleNamespace(
+        get_archive_stats=AsyncMock(
+            return_value=SimpleNamespace(
+                total_conversations=4,
+                embedded_conversations=3,
+                embedded_messages=9,
+                embedding_coverage=75.0,
+                pending_embedding_conversations=1,
+                stale_embedding_messages=2,
+                messages_missing_embedding_provenance=1,
+                embedding_readiness_status="pending",
+                retrieval_ready=False,
+            )
+        ),
+        aggregate_message_stats=AsyncMock(
+            return_value={
+                "total": 12,
+                "user": 5,
+                "assistant": 7,
+                "words_approx": 123,
+                "attachment_refs": 2,
+                "distinct_attachments": 1,
+                "providers": {"claude-code": 4},
+                "min_sort_key": 1713830400,
+                "max_sort_key": 1713916800,
+            }
+        ),
+    )
+    await query_stats.output_stats_sql(env, cast(Any, archive_filter), archive_repo, output_format="text")
+    console_print = cast(MagicMock, env.ui.console.print)
+    sql_lines = [call.args[0] for call in console_print.call_args_list if call.args]
+    assert any("Embeddings: 3/4 convs, 9 msgs (75.0%), pending 1, stale 2" in line for line in sql_lines)
+    assert any("Date range: 2024-04-23 to 2024-04-24" in line for line in sql_lines)
+
+    env = _env()
+    profile_repo = SimpleNamespace(
+        get_session_profiles_batch=AsyncMock(return_value={}),
+        get_many=AsyncMock(return_value=[make_conv(id="conv-1", provider="claude-code")]),
+    )
+    profile = SimpleNamespace(
+        repo_names=("repo-a", "repo-b"), auto_tags=("kind:implementation",), work_events=[1], message_count=3
+    )
+    with (
+        patch("polylogue.lib.session_profile.build_session_profile", return_value=profile),
+        patch("polylogue.cli.query_stats._emit_grouped_stats_table") as emit_table,
+        patch("polylogue.cli.query_stats.emit_no_results"),
+    ):
+        await query_stats.output_stats_by_profile_ids(env, ["conv-1"], profile_repo, "repo")
+        await query_stats.output_stats_by_profile_ids(env, ["conv-1"], profile_repo, "work-kind")
+        await query_stats.output_stats_by_profile_summaries(env, [_summary()], profile_repo, "repo")
+        await query_stats.output_stats_by_profile_query(env, ["conv-1"], profile_repo, "work-kind")
+
+    repo_call = emit_table.call_args_list[0].kwargs
+    work_kind_call = emit_table.call_args_list[1].kwargs
+    assert repo_call["multi_membership"] is True
+    assert repo_call["note"] == "Note: conversations may appear in multiple repo groups."
+    assert work_kind_call["multi_membership"] is False
+    assert work_kind_call["note"] is None
+
+    with pytest.raises(ValueError, match="Unsupported profile stats dimension"):
+        await query_stats.output_stats_by_profile_ids(env, ["conv-1"], profile_repo, "provider")
+
+
+@pytest.mark.asyncio
+async def test_query_output_helpers_cover_stream_dates_headers_and_rich_lists(tmp_path: Path) -> None:
+    class _DateLike:
+        def strftime(self, fmt: str) -> str:
+            assert fmt == "%Y-%m-%d %H:%M"
+            return "2026-04-23 12:00"
+
+        def __str__(self) -> str:
+            return "2026-04-23 12:00"
+
+    date_text, date_value = query_output._stream_date_parts(_DateLike())
+    assert (date_text, date_value) == ("2026-04-23 12:00", "2026-04-23 12:00")
+
+    message = make_msg(
+        id="message-1",
+        role=Role.USER,
+        text="hello",
+        timestamp=datetime(2026, 4, 23, 12, 0, tzinfo=timezone.utc),
+    )
+    assert query_output.render_stream_message(make_msg(text=None), "plaintext") == ""
+    assert query_output.render_stream_message(make_msg(text=None), "markdown") == ""
+    payload = json.loads(query_output.render_stream_message(message, "json-lines"))
+    assert payload["timestamp"] == "2026-04-23T12:00:00+00:00"
+
+    header = query_output.render_stream_header(
+        conversation_id="conv-1",
+        title="Archive Retry",
+        provider="claude-code",
+        display_date=_DateLike(),
+        output_format="markdown",
+        dialogue_only=False,
+        message_roles=(Role.USER, Role.SYSTEM),
+        message_limit=3,
+        stats={"total_messages": 4, "role_user_messages": 1, "role_system_messages": 1},
+    )
+    assert "_Showing 2 selected-role messages (limit: 3) of 4 total_" in header
+
+    env = _env(plain=False)
+    repo = SimpleNamespace(get_message_counts_batch=AsyncMock(return_value={"conv-1": 2}))
+    hit = ConversationSearchHit(
+        summary=_summary(),
+        rank=1,
+        retrieval_lane="fts",
+        match_surface="message",
+        snippet="lock retry",
+        message_id="message-1",
+    )
+    await query_output.output_search_hits(env, [hit], _output_spec("markdown"), repo=repo)
+
+    env = _env(plain=False)
+    repo = SimpleNamespace(get_message_counts_batch=AsyncMock(return_value={"conv-1": 2}))
+    await query_output.output_summary_list(env, [_summary()], _output_spec("markdown"), repo=repo)
+
+    env = _env(plain=True)
+    plain_repo = SimpleNamespace(get_message_counts_batch=AsyncMock(return_value={"conv-1": 2}))
+    await query_output.output_search_hits(env, [hit], _output_spec("markdown"), repo=plain_repo)
+    await query_output.output_summary_list(env, [_summary()], _output_spec("markdown"), repo=None)
+
+    with (
+        patch("polylogue.cli.helpers.load_effective_config", side_effect=RuntimeError("boom")),
+        patch("polylogue.paths.render_root", return_value=Path("/tmp/missing-render-root")),
+        patch("click.echo") as echo,
+    ):
+        with pytest.raises(SystemExit) as missing_root:
+            query_output.open_result(_env(), [make_conv(id="conv-open", provider="claude-code")], _output_spec("html"))
+    assert missing_root.value.code == 1
+    assert any("No rendered outputs found." in call.args[0] for call in echo.call_args_list if call.args)
+
+    render_root = tmp_path / "render-root"
+    render_root.mkdir()
+    with (
+        patch("polylogue.cli.helpers.load_effective_config", return_value=SimpleNamespace(render_root=render_root)),
+        patch("polylogue.paths.render_root", return_value=render_root),
+        patch(
+            "polylogue.paths.sanitize.conversation_render_root",
+            return_value=Path("/tmp/render-root/claude-code/conv-open"),
+        ),
+        patch("polylogue.cli.helpers.latest_render_path", return_value=None),
+        patch("click.echo") as echo,
+    ):
+        with pytest.raises(SystemExit) as missing_render:
+            query_output.open_result(_env(), [make_conv(id="conv-open", provider="claude-code")], _output_spec("html"))
+    assert missing_render.value.code == 1
+    assert any(
+        "No rendered output found for this conversation." in call.args[0] for call in echo.call_args_list if call.args
+    )
+
+    with patch("sys.stdout.write") as write, patch("sys.stdout.flush") as flush:
+        query_output.write_message_streaming(make_msg(text=None), "plaintext")
+        assert query_output.render_stream_message(message, "unknown") == ""
+    write.assert_not_called()
+    flush.assert_not_called()

--- a/tests/unit/test_entrypoints_runtime.py
+++ b/tests/unit/test_entrypoints_runtime.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import runpy
+from unittest.mock import patch
+
+
+def test_module_entrypoints_delegate_to_click_main() -> None:
+    with patch("polylogue.cli.click_app.main") as click_main:
+        runpy.run_module("polylogue.__main__", run_name="__main__")
+        runpy.run_module("polylogue.cli.__main__", run_name="__main__")
+
+    assert click_main.call_count == 2

--- a/tests/unit/test_logging_runtime.py
+++ b/tests/unit/test_logging_runtime.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import io
+import sys
+from typing import Any, cast
+from unittest.mock import patch
+
+from polylogue import logging as logging_mod
+from polylogue.logging import BoundLoggerLike
+
+
+class _FakeStderr:
+    def __init__(self) -> None:
+        self._stream = io.StringIO("alpha\nbeta\n")
+        self._buffer = io.BytesIO()
+
+    def write(self, s: str) -> int:
+        return self._stream.write(s)
+
+    def writelines(self, lines: list[str]) -> None:
+        self._stream.writelines(lines)
+
+    def flush(self) -> None:
+        self._stream.flush()
+
+    def close(self) -> None:
+        self._stream.close()
+
+    @property
+    def closed(self) -> bool:
+        return self._stream.closed
+
+    def isatty(self) -> bool:
+        return True
+
+    def fileno(self) -> int:
+        return 42
+
+    def read(self, n: int = -1, /) -> str:
+        return self._stream.read(n)
+
+    def readable(self) -> bool:
+        return self._stream.readable()
+
+    def readline(self, limit: int = -1, /) -> str:
+        return self._stream.readline(limit)
+
+    def readlines(self, hint: int = -1, /) -> list[str]:
+        return self._stream.readlines(hint)
+
+    def seek(self, offset: int, whence: int = 0, /) -> int:
+        return self._stream.seek(offset, whence)
+
+    def seekable(self) -> bool:
+        return self._stream.seekable()
+
+    def tell(self) -> int:
+        return self._stream.tell()
+
+    def truncate(self, size: int | None = None, /) -> int:
+        return self._stream.truncate(size)
+
+    def writable(self) -> bool:
+        return self._stream.writable()
+
+    def __iter__(self) -> _FakeStderr:
+        return self
+
+    def __next__(self) -> str:
+        line = self._stream.readline()
+        if not line:
+            raise StopIteration
+        return line
+
+    def __enter__(self) -> _FakeStderr:
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
+        return None
+
+    @property
+    def buffer(self) -> io.BytesIO:
+        return self._buffer
+
+    @property
+    def encoding(self) -> str:
+        return "utf-8"
+
+    @property
+    def errors(self) -> str | None:
+        return None
+
+    @property
+    def line_buffering(self) -> bool:
+        return True
+
+    @property
+    def newlines(self) -> str | tuple[str, ...] | None:
+        return "\n"
+
+
+def test_stderr_proxy_delegates_to_current_sys_stderr() -> None:
+    fake = _FakeStderr()
+
+    with patch.object(sys, "stderr", cast(Any, fake)):
+        assert logging_mod._stderr_proxy.write("prefix-") == len("prefix-")
+        logging_mod._stderr_proxy.writelines(["line-1", "line-2"])
+        logging_mod._stderr_proxy.flush()
+        assert logging_mod._stderr_proxy.closed is False
+        assert logging_mod._stderr_proxy.isatty() is True
+        assert logging_mod._stderr_proxy.fileno() == 42
+
+        logging_mod._stderr_proxy.seek(0)
+        assert logging_mod._stderr_proxy.read(6) == "prefix"
+        assert logging_mod._stderr_proxy.readable() is True
+        logging_mod._stderr_proxy.seek(0)
+        assert logging_mod._stderr_proxy.readline()
+        logging_mod._stderr_proxy.seek(0)
+        assert logging_mod._stderr_proxy.readlines()
+        logging_mod._stderr_proxy.seek(0)
+        assert logging_mod._stderr_proxy.seekable() is True
+        assert logging_mod._stderr_proxy.tell() == 0
+        assert logging_mod._stderr_proxy.truncate(5) == 5
+        assert logging_mod._stderr_proxy.writable() is True
+
+        fake.seek(0)
+        assert list(logging_mod._stderr_proxy)
+        fake.seek(0)
+        assert next(logging_mod._stderr_proxy)
+
+        with logging_mod._stderr_proxy as entered:
+            assert entered is logging_mod._stderr_proxy
+
+        assert logging_mod._stderr_proxy.buffer is fake.buffer
+        assert logging_mod._stderr_proxy.encoding == fake.encoding
+        assert logging_mod._stderr_proxy.errors == fake.errors
+        assert logging_mod._stderr_proxy.line_buffering is True
+        assert logging_mod._stderr_proxy.newlines == "\n"
+
+        logging_mod._stderr_proxy.close()
+        assert fake.closed is True
+
+
+def test_configure_logging_supports_console_and_json_modes_and_get_logger() -> None:
+    with (
+        patch("polylogue.logging.structlog.configure") as configure,
+        patch("polylogue.logging.structlog.dev.ConsoleRenderer", return_value="console-renderer") as console_renderer,
+        patch("polylogue.logging.structlog.processors.JSONRenderer", return_value="json-renderer") as json_renderer,
+        patch("sys.stderr.isatty", return_value=True),
+    ):
+        logging_mod.configure_logging(verbose=True, json_logs=False)
+        console_processors = configure.call_args.kwargs["processors"]
+        assert console_processors[-1] == "console-renderer"
+        console_renderer.assert_called_once_with(colors=True)
+
+        logging_mod.configure_logging(verbose=False, json_logs=True)
+        json_processors = configure.call_args.kwargs["processors"]
+        assert json_processors[-1] == "json-renderer"
+        json_renderer.assert_called_once_with()
+
+    bound_logger = cast(BoundLoggerLike, object())
+    with patch("polylogue.logging.structlog.get_logger", return_value=bound_logger) as get_logger:
+        assert logging_mod.get_logger("polylogue.tests") is bound_logger
+    get_logger.assert_called_once_with("polylogue.tests")


### PR DESCRIPTION
## Summary

Raise the repository coverage floor from 87 to 88 after a direct test tranche over CLI control-plane helpers, root entrypoints, and structured logging/runtime seams.

## Problem

`#197` was still carrying large ownership-level blind spots in the CLI/query control plane and a few root/runtime modules. The previous tranche justified 87, but several operator-facing helpers and entrypoints still had little or no direct coverage, so the next honest ratchet boundary had to be measured rather than assumed.

## Solution

Add focused runtime tests for:

- check workflow option validation and maintenance wiring
- picker and shell-completion helpers
- query progress and query helper error/formatting paths
- `tags` / `neighbors` helper surfaces
- root entrypoints (`polylogue.__main__`, `polylogue.cli.__main__`)
- structured logging proxy/configuration behavior

Then raise `tool.coverage.report.fail_under` to 88 in `pyproject.toml`.

This branch intentionally stops at 88. The measured full-suite result is 88.24%, which justifies ratcheting to 88 cleanly but does not honestly justify 89 yet.

## Verification

- `pytest -q tests/unit/cli/test_command_aux_runtime.py tests/unit/cli/test_check_support_runtime.py tests/unit/cli/test_query_progress_runtime.py tests/unit/cli/test_query_support_runtime.py tests/unit/test_entrypoints_runtime.py tests/unit/test_logging_runtime.py`
- targeted module probe over the affected CLI helpers -> direct coverage in the high 90s for the intended tranche modules
- `devtools coverage-gate` -> `5483 passed`, total coverage `88.24%`
- `devtools verify --quick`

Ref #197


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit test suites for CLI query progress, query support, command auxiliary runtime, and check support workflow functions.
  * Added entrypoint delegation tests and logging runtime validation tests.

* **Chores**
  * Increased minimum code coverage threshold to 88% to maintain higher code quality standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->