### PR TITLE
test: ratchet coverage floor to 89

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,7 +141,7 @@ data_file = ".cache/coverage/.coverage"
 [tool.coverage.report]
 skip_empty = true
 show_missing = true
-fail_under = 88
+fail_under = 89
 
 [tool.mypy]
 python_version = "3.11"

--- a/tests/unit/cli/test_operator_support_runtime.py
+++ b/tests/unit/cli/test_operator_support_runtime.py
@@ -1,0 +1,91 @@
+# mypy: disable-error-code="assignment,arg-type,comparison-overlap"
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from polylogue.cli.commands.mcp import mcp_command
+from polylogue.sources.drive_source_factory import build_drive_source_client
+
+
+def test_mcp_command_runs_stdio_server_and_handles_missing_dependency() -> None:
+    runner = CliRunner()
+    env = SimpleNamespace(ui=SimpleNamespace(console=SimpleNamespace(print=lambda *_args: None)), services="services")
+
+    with patch("polylogue.mcp.server.serve_stdio") as mock_serve:
+        result = runner.invoke(mcp_command, ["--transport", "stdio"], obj=env)
+
+    assert result.exit_code == 0
+    mock_serve.assert_called_once_with("services")
+
+    console = SimpleNamespace(print=MagicMock())
+    env = SimpleNamespace(ui=SimpleNamespace(console=console), services="services")
+    original_module = sys.modules.get("polylogue.mcp.server")
+
+    try:
+        sys.modules["polylogue.mcp.server"] = None
+        result = runner.invoke(mcp_command, [], obj=env)
+    finally:
+        if original_module is None:
+            sys.modules.pop("polylogue.mcp.server", None)
+        else:
+            sys.modules["polylogue.mcp.server"] = original_module
+
+    assert result.exit_code == 1
+    assert "MCP dependencies not installed" in console.print.call_args_list[0].args[0]
+    assert "Install the base polylogue package" in console.print.call_args_list[1].args[0]
+
+
+def test_mcp_command_rejects_unsupported_transport_via_callback() -> None:
+    console = SimpleNamespace(print=MagicMock())
+    env = SimpleNamespace(ui=SimpleNamespace(console=console), services="services")
+
+    wrapped = getattr(mcp_command.callback, "__wrapped__", None)
+    assert callable(wrapped)
+
+    try:
+        wrapped(env, "http")
+    except SystemExit as exc:
+        assert exc.code == 1
+    else:  # pragma: no cover - defensive
+        raise AssertionError("expected SystemExit")
+
+    console.print.assert_called_once_with("Unsupported transport: http")
+
+
+def test_build_drive_source_client_wires_auth_gateway_and_client(tmp_path: Path) -> None:
+    ui = object()
+    config = object()
+
+    with (
+        patch(
+            "polylogue.sources.drive_source_factory.resolve_drive_retry_policy", return_value="retry-policy"
+        ) as mock_policy,
+        patch("polylogue.sources.drive_source_factory.DriveAuthManager", return_value="auth-manager") as mock_auth,
+        patch("polylogue.sources.drive_source_factory.DriveServiceGateway", return_value="gateway") as mock_gateway,
+        patch("polylogue.sources.drive_source_factory.DriveSourceClient", return_value="client") as mock_client,
+    ):
+        client = build_drive_source_client(
+            ui=ui,
+            credentials_path=tmp_path / "credentials.json",
+            token_path=tmp_path / "token.json",
+            retries=5,
+            retry_base=2.5,
+            config=config,
+        )
+
+    assert client == "client"
+    mock_policy.assert_called_once_with(retries=5, retry_base=2.5, config=config)
+    mock_auth.assert_called_once_with(
+        ui=ui,
+        credentials_path=tmp_path / "credentials.json",
+        token_path=tmp_path / "token.json",
+        config=config,
+    )
+    mock_gateway.assert_called_once_with(auth_manager="auth-manager", retry_policy="retry-policy")
+    mock_client.assert_called_once_with(gateway="gateway")

--- a/tests/unit/core/test_product_registry_runtime.py
+++ b/tests/unit/core/test_product_registry_runtime.py
@@ -1,0 +1,156 @@
+# mypy: disable-error-code="arg-type,comparison-overlap,attr-defined,index,list-item"
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from polylogue.archive_products import ProviderAnalyticsProduct
+from polylogue.products import registry as product_registry
+from polylogue.products.registry import (
+    CliOption,
+    ProductField,
+    ProductQueryError,
+    ProductType,
+    fetch_products,
+    fetch_products_async,
+    get_product_type,
+    list_product_types,
+    product_items_payload,
+    register,
+    render_product_items,
+)
+
+
+def _provider_analytics_product() -> ProviderAnalyticsProduct:
+    return ProviderAnalyticsProduct(
+        provider_name="claude-code",
+        conversation_count=1,
+        message_count=2,
+        user_message_count=1,
+        assistant_message_count=1,
+        avg_messages_per_conversation=2.0,
+        avg_user_words=3.0,
+        avg_assistant_words=4.0,
+        tool_use_count=1,
+        thinking_count=0,
+        total_conversations_with_tools=1,
+        total_conversations_with_thinking=0,
+        tool_use_percentage=100.0,
+        thinking_percentage=0.0,
+    )
+
+
+def test_registry_accessors_format_values_and_defaults() -> None:
+    item = SimpleNamespace(
+        provider_name="claude-code",
+        thread_id="thread-1",
+        nested=SimpleNamespace(value="nested-value"),
+        values=("a", "b", "c", "d"),
+        ratio=12.345,
+        count=7,
+        percentage=82.5,
+    )
+
+    assert product_registry._stringify(None) == "-"
+    assert product_registry._stringify("") == "-"
+    assert product_registry._attr("thread_id")(item) == "thread-1"
+    assert product_registry._nested("nested", "value")(item) == "nested-value"
+    assert product_registry._nested("missing", "value")(item) == "-"
+    assert product_registry._id_with_provider("thread_id")(item) == "thread-1 [claude-code]"
+    assert product_registry._list_preview("values", limit=2)(item) == "a, b"
+    assert product_registry._formatted_float("ratio", precision=2)(item) == "12.35"
+    assert product_registry._formatted_float("missing")(item) == "-"
+    assert product_registry._count_with_percentage("count", "percentage")(item) == "7 (82.5%)"
+    assert product_registry._count_with_percentage("missing", "percentage")(item) == "-"
+
+
+def test_product_type_registry_helpers_cover_register_lookup_and_sorting() -> None:
+    name = "runtime_dummy_product"
+    product_type = ProductType(
+        name=name,
+        display_name="Runtime Dummy",
+        json_key="items",
+        cli_options=(CliOption("flag", ("--flag",), help="flag"),),
+    )
+
+    try:
+        returned = register(product_type)
+        assert returned is product_type
+        assert get_product_type(name) is product_type
+        assert name in list_product_types()
+        assert product_type.resolved_cli_command_name == "runtime-dummy-product"
+    finally:
+        product_registry.PRODUCT_REGISTRY.pop(name, None)
+
+
+def test_get_product_type_and_build_query_raise_useful_errors() -> None:
+    with pytest.raises(KeyError, match="Unknown product type"):
+        get_product_type("missing-product")
+
+    with pytest.raises(ProductQueryError, match="does not declare a query model"):
+        product_registry._build_query(
+            ProductType(name="dummy", display_name="Dummy", json_key="items"),
+            query="value",
+        )
+
+    with pytest.raises(ProductQueryError, match="Unknown query field\\(s\\) for session_profiles: refined_work_kind"):
+        product_registry._build_query(get_product_type("session_profiles"), refined_work_kind="planning")
+
+
+def test_product_items_payload_and_rendering_cover_json_plain_and_empty_paths() -> None:
+    product = _provider_analytics_product()
+    product_type = get_product_type("provider_analytics")
+
+    payload = product_items_payload([product], product_type, item_key="items")
+    assert payload["count"] == 1
+    assert payload["items"][0]["provider_name"] == "claude-code"
+
+    with patch("polylogue.cli.machine_errors.emit_success") as mock_emit:
+        render_product_items([product], product_type, json_mode=True)
+    mock_emit.assert_called_once_with(product_items_payload([product], product_type))
+
+    custom_type = ProductType(
+        name="custom",
+        display_name="Custom",
+        json_key="items",
+        empty_message="No custom items.",
+        fields=(
+            ProductField("", lambda item: item.name),
+            ProductField("missing", lambda _item: (_ for _ in ()).throw(AttributeError("boom")), group=1),
+        ),
+    )
+    item = SimpleNamespace(name="item-1")
+
+    with patch("click.echo") as mock_echo:
+        render_product_items([], custom_type)
+        render_product_items([item], custom_type)
+
+    assert mock_echo.call_args_list[0].args == ("No custom items.",)
+    assert mock_echo.call_args_list[1].args == ("Custom: 1\n",)
+    assert mock_echo.call_args_list[2].args == ("  item-1",)
+    assert mock_echo.call_args_list[3].args == ("    missing=-",)
+
+
+def test_fetch_products_sync_uses_registry_dispatch() -> None:
+    product_type = get_product_type("provider_analytics")
+
+    class _Operations:
+        def list_provider_analytics_products(self, query: object) -> str:
+            return f"sync:{query.provider}"
+
+    with patch("polylogue.sync_bridge.run_coroutine_sync", side_effect=lambda value: [value]):
+        assert fetch_products(product_type, _Operations(), provider="claude-code") == ["sync:claude-code"]
+
+
+@pytest.mark.asyncio
+async def test_fetch_products_async_uses_registry_dispatch() -> None:
+    product_type = get_product_type("provider_analytics")
+
+    class _AsyncOperations:
+        async def list_provider_analytics_products(self, query: object) -> list[str]:
+            return [f"async:{query.provider}"]
+
+    assert await fetch_products_async(product_type, _AsyncOperations(), provider="claude-code") == ["async:claude-code"]

--- a/tests/unit/core/test_sync_surface_runtime.py
+++ b/tests/unit/core/test_sync_surface_runtime.py
@@ -1,0 +1,206 @@
+# mypy: disable-error-code="assignment,comparison-overlap,arg-type,override"
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from polylogue.facade_products import PolylogueProductsMixin
+from polylogue.sync import SyncPolylogue
+from polylogue.sync_conversation_queries import SyncConversationQueriesMixin
+from polylogue.sync_product_queries import SyncProductQueriesMixin
+
+
+class _FilterStub:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, object]] = []
+
+    def provider(self, value: object) -> _FilterStub:
+        self.calls.append(("provider", value))
+        return self
+
+    def since(self, value: object) -> _FilterStub:
+        self.calls.append(("since", value))
+        return self
+
+    def until(self, value: object) -> _FilterStub:
+        self.calls.append(("until", value))
+        return self
+
+    def limit(self, value: object) -> _FilterStub:
+        self.calls.append(("limit", value))
+        return self
+
+    def list_summaries(self) -> str:
+        self.calls.append(("list_summaries", None))
+        return "summaries-coro"
+
+
+class _SyncHarness(SyncConversationQueriesMixin, SyncProductQueriesMixin):
+    pass
+
+
+def test_sync_conversation_queries_forward_through_sync_bridge() -> None:
+    filter_stub = _FilterStub()
+    facade = SimpleNamespace(
+        get_conversation=lambda conversation_id: ("get_conversation", conversation_id),
+        get_conversations=lambda conversation_ids: ("get_conversations", tuple(conversation_ids)),
+        list_conversations=lambda **kwargs: ("list_conversations", kwargs),
+        filter=lambda: filter_stub,
+        search=lambda query, **kwargs: ("search", query, kwargs),
+        stats=lambda: "stats-coro",
+    )
+    archive = _SyncHarness()
+    archive._facade = facade
+
+    with patch("polylogue.sync_conversation_queries.run_coroutine_sync", side_effect=lambda coro: coro) as mock_run:
+        assert archive.get_conversation("conv-1") == ("get_conversation", "conv-1")
+        assert archive.get_conversations(["a", "b"]) == ("get_conversations", ("a", "b"))
+        assert archive.list_conversations(provider="claude-code", limit=3) == (
+            "list_conversations",
+            {"provider": "claude-code", "limit": 3},
+        )
+        assert (
+            archive.list_summaries(
+                provider="claude-code",
+                since="2026-01-01",
+                until="2026-01-31",
+                limit=5,
+            )
+            == "summaries-coro"
+        )
+        assert archive.search("query", limit=7, source="inbox", since="2026-01-01") == (
+            "search",
+            "query",
+            {"limit": 7, "source": "inbox", "since": "2026-01-01"},
+        )
+        assert archive.stats() == "stats-coro"
+
+    assert filter_stub.calls == [
+        ("provider", "claude-code"),
+        ("since", "2026-01-01"),
+        ("until", "2026-01-31"),
+        ("limit", 5),
+        ("list_summaries", None),
+    ]
+    assert mock_run.call_count == 6
+
+
+def test_sync_product_queries_forward_through_sync_bridge() -> None:
+    facade = SimpleNamespace(
+        get_session_product_status=lambda: "status-coro",
+        get_session_profile_product=lambda conversation_id, **kwargs: ("profile", conversation_id, kwargs),
+        list_session_profile_products=lambda query=None: ("profiles", query),
+        get_session_enrichment_product=lambda conversation_id: ("enrichment", conversation_id),
+        list_session_enrichment_products=lambda query=None: ("enrichments", query),
+        list_session_tag_rollup_products=lambda query=None: ("tags", query),
+        get_session_work_event_products=lambda conversation_id: ("events", conversation_id),
+        list_session_work_event_products=lambda query=None: ("events-list", query),
+        get_session_phase_products=lambda conversation_id: ("phases", conversation_id),
+        list_session_phase_products=lambda query=None: ("phases-list", query),
+        get_work_thread_product=lambda thread_id: ("thread", thread_id),
+        list_work_thread_products=lambda query=None: ("threads", query),
+        list_day_session_summary_products=lambda query=None: ("days", query),
+        list_week_session_summary_products=lambda query=None: ("weeks", query),
+        list_provider_analytics_products=lambda query=None: ("analytics", query),
+        list_archive_debt_products=lambda query=None: ("debt", query),
+    )
+    archive = _SyncHarness()
+    archive._facade = facade
+
+    with patch("polylogue.sync_product_queries.run_coroutine_sync", side_effect=lambda coro: coro) as mock_run:
+        assert archive.get_session_product_status() == "status-coro"
+        assert archive.get_session_profile_product("conv-1", tier="evidence") == (
+            "profile",
+            "conv-1",
+            {"tier": "evidence"},
+        )
+        assert archive.list_session_profile_products("query") == ("profiles", "query")
+        assert archive.get_session_enrichment_product("conv-1") == ("enrichment", "conv-1")
+        assert archive.list_session_enrichment_products("query") == ("enrichments", "query")
+        assert archive.list_session_tag_rollup_products("query") == ("tags", "query")
+        assert archive.get_session_work_event_products("conv-1") == ("events", "conv-1")
+        assert archive.list_session_work_event_products("query") == ("events-list", "query")
+        assert archive.get_session_phase_products("conv-1") == ("phases", "conv-1")
+        assert archive.list_session_phase_products("query") == ("phases-list", "query")
+        assert archive.get_work_thread_product("thread-1") == ("thread", "thread-1")
+        assert archive.list_work_thread_products("query") == ("threads", "query")
+        assert archive.list_day_session_summary_products("query") == ("days", "query")
+        assert archive.list_week_session_summary_products("query") == ("weeks", "query")
+        assert archive.list_provider_analytics_products("query") == ("analytics", "query")
+        assert archive.list_archive_debt_products("query") == ("debt", "query")
+
+    assert mock_run.call_count == 16
+
+
+def test_sync_polylogue_wraps_async_facade_and_context_manager() -> None:
+    facade = MagicMock()
+    facade.close.return_value = "close-coro"
+    facade.filter.return_value = "filter-object"
+
+    with (
+        patch("polylogue.facade.Polylogue", return_value=facade) as mock_facade_class,
+        patch("polylogue.sync._run", return_value=None) as mock_run,
+    ):
+        archive = SyncPolylogue(archive_root="archive-root", db_path="db.sqlite")
+        assert archive.filter() == "filter-object"
+        assert "SyncPolylogue(facade=" in repr(archive)
+        assert archive.__enter__() is archive
+        archive.close()
+        archive.__exit__(None, None, None)
+
+    mock_facade_class.assert_called_once_with(archive_root="archive-root", db_path="db.sqlite")
+    assert [call.args[0] for call in mock_run.call_args_list] == [facade.close.return_value, facade.close.return_value]
+
+
+@pytest.mark.asyncio
+async def test_polylogue_products_mixin_forwards_all_product_calls() -> None:
+    operations = SimpleNamespace(
+        list_session_tag_rollup_products=AsyncMock(return_value=["tags"]),
+        get_session_work_event_products=AsyncMock(return_value=["events"]),
+        list_session_work_event_products=AsyncMock(return_value=["events-list"]),
+        get_session_phase_products=AsyncMock(return_value=["phases"]),
+        list_session_phase_products=AsyncMock(return_value=["phases-list"]),
+        get_work_thread_product=AsyncMock(return_value="thread"),
+        list_work_thread_products=AsyncMock(return_value=["threads"]),
+        list_day_session_summary_products=AsyncMock(return_value=["days"]),
+        list_week_session_summary_products=AsyncMock(return_value=["weeks"]),
+        list_provider_analytics_products=AsyncMock(return_value=["analytics"]),
+        list_archive_debt_products=AsyncMock(return_value=["debt"]),
+    )
+
+    class _Harness(PolylogueProductsMixin):
+        def __init__(self, operations: object) -> None:
+            self._operations = operations
+
+        @property
+        def operations(self) -> object:
+            return self._operations
+
+    archive = _Harness(operations)
+
+    assert await archive.list_session_tag_rollup_products("query") == ["tags"]
+    assert await archive.get_session_work_event_products("conv-1") == ["events"]
+    assert await archive.list_session_work_event_products("query") == ["events-list"]
+    assert await archive.get_session_phase_products("conv-1") == ["phases"]
+    assert await archive.list_session_phase_products("query") == ["phases-list"]
+    assert await archive.get_work_thread_product("thread-1") == "thread"
+    assert await archive.list_work_thread_products("query") == ["threads"]
+    assert await archive.list_day_session_summary_products("query") == ["days"]
+    assert await archive.list_week_session_summary_products("query") == ["weeks"]
+    assert await archive.list_provider_analytics_products("query") == ["analytics"]
+    assert await archive.list_archive_debt_products("query") == ["debt"]
+
+    operations.list_session_tag_rollup_products.assert_awaited_once_with("query")
+    operations.get_session_work_event_products.assert_awaited_once_with("conv-1")
+    operations.list_session_work_event_products.assert_awaited_once_with("query")
+    operations.get_session_phase_products.assert_awaited_once_with("conv-1")
+    operations.list_session_phase_products.assert_awaited_once_with("query")
+    operations.get_work_thread_product.assert_awaited_once_with("thread-1")
+    operations.list_work_thread_products.assert_awaited_once_with("query")
+    operations.list_day_session_summary_products.assert_awaited_once_with("query")
+    operations.list_week_session_summary_products.assert_awaited_once_with("query")
+    operations.list_provider_analytics_products.assert_awaited_once_with("query")
+    operations.list_archive_debt_products.assert_awaited_once_with("query")

--- a/tests/unit/core/test_version_runtime.py
+++ b/tests/unit/core/test_version_runtime.py
@@ -1,0 +1,281 @@
+# mypy: disable-error-code="arg-type,attr-defined"
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+import polylogue.version as version_module
+from polylogue.version import (
+    _detect_git_dirty,
+    _get_embedded_build_info,
+    _read_head_commit,
+    _read_packed_ref,
+    _resolve_base_version,
+    _resolve_common_git_dir,
+    _resolve_git_dir,
+    _resolve_version,
+)
+
+
+def test_resolve_git_dir_supports_directory_relative_file_and_invalid_file(tmp_path: Path) -> None:
+    repo_dir = tmp_path / "repo-dir"
+    repo_dir.mkdir()
+    (repo_dir / ".git").mkdir()
+    assert _resolve_git_dir(repo_dir) == repo_dir / ".git"
+
+    repo_file = tmp_path / "repo-file"
+    repo_file.mkdir()
+    worktrees = tmp_path / "worktrees" / "repo"
+    worktrees.mkdir(parents=True)
+    (repo_file / ".git").write_text(f"gitdir: {Path('../worktrees/repo')}\n", encoding="utf-8")
+    assert _resolve_git_dir(repo_file) == worktrees.resolve()
+
+    repo_invalid = tmp_path / "repo-invalid"
+    repo_invalid.mkdir()
+    (repo_invalid / ".git").write_text("not-a-gitdir\n", encoding="utf-8")
+    assert _resolve_git_dir(repo_invalid) is None
+
+    repo_missing = tmp_path / "repo-missing"
+    repo_missing.mkdir()
+    assert _resolve_git_dir(repo_missing) is None
+
+
+def test_read_packed_ref_ignores_comments_and_malformed_lines(tmp_path: Path) -> None:
+    git_dir = tmp_path / "git"
+    git_dir.mkdir()
+    (git_dir / "packed-refs").write_text(
+        f"# pack-refs\n^ignore-me\nnot a valid line\n{'a' * 40} refs/heads/main\n",
+        encoding="utf-8",
+    )
+
+    assert _read_packed_ref(git_dir, "refs/heads/main") == "a" * 40
+    assert _read_packed_ref(git_dir, "refs/heads/missing") is None
+
+
+def test_read_packed_ref_handles_missing_file_and_read_errors(tmp_path: Path) -> None:
+    git_dir = tmp_path / "git"
+    git_dir.mkdir()
+    assert _read_packed_ref(git_dir, "refs/heads/main") is None
+
+    packed_refs = git_dir / "packed-refs"
+    packed_refs.write_text("placeholder", encoding="utf-8")
+    real_read_text = Path.read_text
+
+    def _read_text(self: Path, *args: object, **kwargs: object) -> str:
+        if self == packed_refs:
+            raise OSError("broken")
+        return real_read_text(self, *args, **kwargs)
+
+    with patch("pathlib.Path.read_text", new=_read_text):
+        assert _read_packed_ref(git_dir, "refs/heads/main") is None
+
+
+def test_resolve_common_git_dir_supports_relative_and_empty_commondir(tmp_path: Path) -> None:
+    git_dir = tmp_path / "git"
+    git_dir.mkdir()
+    assert _resolve_common_git_dir(git_dir) == git_dir
+
+    (git_dir / "commondir").write_text("../common\n", encoding="utf-8")
+    assert _resolve_common_git_dir(git_dir) == (tmp_path / "common").resolve()
+
+    (git_dir / "commondir").write_text("\n", encoding="utf-8")
+    assert _resolve_common_git_dir(git_dir) == git_dir
+
+
+def test_resolve_git_dir_and_common_dir_handle_read_errors(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    git_file = repo / ".git"
+    git_file.write_text("gitdir: worktree\n", encoding="utf-8")
+
+    common_dir = tmp_path / "git"
+    common_dir.mkdir()
+    commondir = common_dir / "commondir"
+    commondir.write_text("../common\n", encoding="utf-8")
+    real_read_text = Path.read_text
+
+    def _read_text(self: Path, *args: object, **kwargs: object) -> str:
+        if self in {git_file, commondir}:
+            raise OSError("broken")
+        return real_read_text(self, *args, **kwargs)
+
+    with patch("pathlib.Path.read_text", new=_read_text):
+        assert _resolve_git_dir(repo) is None
+        assert _resolve_common_git_dir(common_dir) == common_dir
+
+
+def test_read_head_commit_supports_direct_ref_common_dir_and_packed_refs(tmp_path: Path) -> None:
+    direct_repo = tmp_path / "direct"
+    direct_repo.mkdir()
+    git_dir = direct_repo / ".git"
+    refs_dir = git_dir / "refs" / "heads"
+    refs_dir.mkdir(parents=True)
+    direct_commit = "a" * 40
+    (git_dir / "HEAD").write_text(f"{direct_commit}\n", encoding="utf-8")
+    assert _read_head_commit(direct_repo) == direct_commit
+
+    ref_repo = tmp_path / "ref"
+    ref_repo.mkdir()
+    git_dir = ref_repo / ".git"
+    refs_dir = git_dir / "refs" / "heads"
+    refs_dir.mkdir(parents=True)
+    (git_dir / "HEAD").write_text("ref: refs/heads/main\n", encoding="utf-8")
+    (refs_dir / "main").write_text(f"{'b' * 40}\n", encoding="utf-8")
+    assert _read_head_commit(ref_repo) == "b" * 40
+
+    common_repo = tmp_path / "common-repo"
+    common_repo.mkdir()
+    git_dir = common_repo / ".git"
+    git_dir.mkdir()
+    common_dir = tmp_path / "common-dir"
+    (common_dir / "refs" / "heads").mkdir(parents=True)
+    (git_dir / "HEAD").write_text("ref: refs/heads/main\n", encoding="utf-8")
+    (git_dir / "commondir").write_text("../../common-dir\n", encoding="utf-8")
+    (common_dir / "refs" / "heads" / "main").write_text(f"{'c' * 40}\n", encoding="utf-8")
+    assert _read_head_commit(common_repo) == "c" * 40
+
+    packed_repo = tmp_path / "packed"
+    packed_repo.mkdir()
+    git_dir = packed_repo / ".git"
+    git_dir.mkdir()
+    (git_dir / "HEAD").write_text("ref: refs/heads/main\n", encoding="utf-8")
+    (git_dir / "packed-refs").write_text(f"{'d' * 40} refs/heads/main\n", encoding="utf-8")
+    assert _read_head_commit(packed_repo) == "d" * 40
+
+
+def test_read_head_commit_returns_none_for_invalid_or_missing_head(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    git_dir = repo / ".git"
+    git_dir.mkdir()
+    assert _read_head_commit(repo) is None
+
+    (git_dir / "HEAD").write_text("not-a-ref\n", encoding="utf-8")
+    assert _read_head_commit(repo) is None
+
+    (git_dir / "HEAD").write_text("ref:\n", encoding="utf-8")
+    assert _read_head_commit(repo) is None
+
+
+def test_read_head_commit_handles_head_and_ref_read_errors(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    git_dir = repo / ".git"
+    refs_dir = git_dir / "refs" / "heads"
+    refs_dir.mkdir(parents=True)
+    head_path = git_dir / "HEAD"
+    ref_path = refs_dir / "main"
+    packed_refs = git_dir / "packed-refs"
+
+    head_path.write_text("ref: refs/heads/main\n", encoding="utf-8")
+    ref_path.write_text("invalid\n", encoding="utf-8")
+    packed_refs.write_text(f"{'e' * 40} refs/heads/main\n", encoding="utf-8")
+
+    real_read_text = Path.read_text
+
+    def _read_text(self: Path, *args: object, **kwargs: object) -> str:
+        if self == head_path:
+            raise OSError("broken-head")
+        return real_read_text(self, *args, **kwargs)
+
+    with patch("pathlib.Path.read_text", new=_read_text):
+        assert _read_head_commit(repo) is None
+
+    def _read_ref_text(self: Path, *args: object, **kwargs: object) -> str:
+        if self == ref_path:
+            raise OSError("broken-ref")
+        return real_read_text(self, *args, **kwargs)
+
+    with patch("pathlib.Path.read_text", new=_read_ref_text):
+        assert _read_head_commit(repo) == "e" * 40
+
+
+def test_detect_git_dirty_handles_clean_dirty_and_failures(tmp_path: Path) -> None:
+    with patch("polylogue.version.subprocess.run", return_value=SimpleNamespace(returncode=0, stdout=" M file\n")):
+        assert _detect_git_dirty(tmp_path) is True
+
+    with patch("polylogue.version.subprocess.run", return_value=SimpleNamespace(returncode=0, stdout="")):
+        assert _detect_git_dirty(tmp_path) is False
+
+    with patch("polylogue.version.subprocess.run", return_value=SimpleNamespace(returncode=1, stdout="")):
+        assert _detect_git_dirty(tmp_path) is False
+
+    with patch("polylogue.version.subprocess.run", side_effect=FileNotFoundError("git")):
+        assert _detect_git_dirty(tmp_path) is False
+
+
+def test_resolve_base_version_prefers_pyproject_then_metadata(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text('[project]\nversion = "1.2.3"\n', encoding="utf-8")
+    assert _resolve_base_version(tmp_path) == "1.2.3"
+
+    (tmp_path / "pyproject.toml").unlink()
+    with patch("polylogue.version.metadata_version", return_value="9.9.9"):
+        assert _resolve_base_version(tmp_path) == "9.9.9"
+
+
+def test_resolve_base_version_raises_when_metadata_is_unavailable(tmp_path: Path) -> None:
+    with patch("polylogue.version.metadata_version", side_effect=version_module.PackageNotFoundError("polylogue")):
+        with pytest.raises(RuntimeError, match="unable to resolve package version"):
+            _resolve_base_version(tmp_path)
+
+
+def test_get_embedded_build_info_supports_success_and_incomplete_metadata() -> None:
+    fake_module = SimpleNamespace(BUILD_COMMIT="deadbeef", BUILD_DIRTY=True)
+    with patch.dict(sys.modules, {"polylogue._build_info": fake_module}):
+        assert _get_embedded_build_info() == ("deadbeef", True)
+
+    incomplete_module = SimpleNamespace(BUILD_COMMIT="unknown", BUILD_DIRTY=False)
+    with patch.dict(sys.modules, {"polylogue._build_info": incomplete_module}):
+        with pytest.raises(RuntimeError, match="embedded build metadata is incomplete"):
+            _get_embedded_build_info()
+
+
+def test_get_embedded_build_info_raises_when_module_is_missing() -> None:
+    real_import = __import__
+
+    def _import(
+        name: str, globals: object = None, locals: object = None, fromlist: tuple[str, ...] = (), level: int = 0
+    ) -> object:
+        if name == "polylogue._build_info":
+            raise ImportError("missing-build-info")
+        return real_import(name, globals, locals, fromlist, level)
+
+    with patch("builtins.__import__", side_effect=_import):
+        with pytest.raises(RuntimeError, match="built package is missing embedded git metadata"):
+            _get_embedded_build_info()
+
+
+def test_resolve_version_uses_embedded_metadata_for_non_git_paths(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text('[project]\nversion = "1.2.3"\n', encoding="utf-8")
+
+    with patch("polylogue.version._get_embedded_build_info", return_value=("deadbeef", False)):
+        info = _resolve_version(tmp_path)
+
+    assert info.version == "1.2.3"
+    assert info.commit == "deadbeef"
+
+
+def test_lazy_package_exports_cover_pipeline_services_storage_and_mcp() -> None:
+    import polylogue.mcp
+    import polylogue.pipeline
+    import polylogue.pipeline.services
+    import polylogue.storage
+
+    assert polylogue.mcp.server.__name__.endswith("server")
+    assert polylogue.pipeline.run_sources.__name__ == "run_sources"
+    assert polylogue.pipeline.services.ValidationService.__name__ == "ValidationService"
+    assert polylogue.storage.ConversationRepository.__name__ == "ConversationRepository"
+
+    with pytest.raises(AttributeError):
+        _ = polylogue.mcp.missing
+    with pytest.raises(AttributeError):
+        _ = polylogue.pipeline.missing
+    with pytest.raises(AttributeError):
+        _ = polylogue.pipeline.services.missing
+    with pytest.raises(AttributeError):
+        _ = polylogue.storage.missing

--- a/tests/unit/mcp/test_server_runtime.py
+++ b/tests/unit/mcp/test_server_runtime.py
@@ -1,0 +1,108 @@
+# mypy: disable-error-code="comparison-overlap,arg-type"
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from polylogue.mcp import server as server_module
+
+
+def test_server_repository_accessors_use_runtime_services() -> None:
+    repository = object()
+    backend = object()
+    services = SimpleNamespace(get_repository=lambda: repository, get_backend=lambda: backend, config="config")
+
+    with patch("polylogue.mcp.server._get_runtime_services", return_value=services):
+        assert server_module._get_repo() is repository
+        assert server_module._get_query_store() is repository
+        assert server_module._get_tag_store() is repository
+
+
+def test_get_backend_prefers_repository_backend_when_typed() -> None:
+    class DummyBackend:
+        pass
+
+    repo_backend = DummyBackend()
+    repository = SimpleNamespace(backend=repo_backend)
+    services = SimpleNamespace(get_backend=lambda: "fallback-backend")
+
+    with (
+        patch("polylogue.mcp.server.SQLiteBackend", DummyBackend),
+        patch("polylogue.mcp.server._get_repo", return_value=repository),
+        patch("polylogue.mcp.server._get_runtime_services", return_value=services),
+    ):
+        assert server_module._get_backend() is repo_backend
+
+    repository = SimpleNamespace(backend=object())
+    with (
+        patch("polylogue.mcp.server.SQLiteBackend", DummyBackend),
+        patch("polylogue.mcp.server._get_repo", return_value=repository),
+        patch("polylogue.mcp.server._get_runtime_services", return_value=services),
+    ):
+        assert server_module._get_backend() == "fallback-backend"
+
+
+def test_get_archive_ops_builds_from_runtime_services() -> None:
+    services = SimpleNamespace(config="config")
+
+    with (
+        patch("polylogue.mcp.server._get_runtime_services", return_value=services),
+        patch("polylogue.mcp.server._get_repo", return_value="repository"),
+        patch("polylogue.mcp.server._get_backend", return_value="backend"),
+        patch("polylogue.mcp.server.ArchiveOperations", return_value="archive-ops") as mock_ops,
+    ):
+        assert server_module._get_archive_ops() == "archive-ops"
+
+    mock_ops.assert_called_once_with(config="config", repository="repository", backend="backend")
+
+
+def test_build_server_registers_tools_resources_and_prompts() -> None:
+    fake_mcp = MagicMock()
+    fake_fast_mcp = MagicMock(return_value=fake_mcp)
+
+    with (
+        patch("mcp.server.fastmcp.FastMCP", fake_fast_mcp),
+        patch("polylogue.mcp.server.register_tools") as mock_tools,
+        patch("polylogue.mcp.server.register_resources") as mock_resources,
+        patch("polylogue.mcp.server.register_prompts") as mock_prompts,
+    ):
+        built = server_module.build_server()
+
+    assert built is fake_mcp
+    fake_fast_mcp.assert_called_once()
+    hooks = mock_tools.call_args.args[1]
+    assert callable(hooks.json_payload)
+    assert callable(hooks.clamp_limit)
+    assert callable(hooks.get_archive_ops)
+    mock_resources.assert_called_once_with(fake_mcp, hooks)
+    mock_prompts.assert_called_once_with(fake_mcp, hooks)
+
+
+def test_get_server_caches_instance_and_updates_runtime_services() -> None:
+    original = server_module._server_instance
+    server_module._server_instance = None
+    services = SimpleNamespace()
+
+    try:
+        with (
+            patch("polylogue.mcp.server._set_runtime_services") as mock_set_services,
+            patch("polylogue.mcp.server.build_server", return_value="server") as mock_build,
+        ):
+            assert server_module._get_server(services) == "server"
+            assert server_module._get_server() == "server"
+
+        mock_set_services.assert_called_once_with(services)
+        mock_build.assert_called_once_with()
+    finally:
+        server_module._server_instance = original
+
+
+def test_serve_stdio_runs_cached_server() -> None:
+    server = MagicMock()
+
+    with patch("polylogue.mcp.server._get_server", return_value=server) as mock_get_server:
+        server_module.serve_stdio(services="services")
+
+    mock_get_server.assert_called_once_with("services")
+    server.run.assert_called_once_with(transport="stdio")

--- a/tests/unit/showcase/test_catalog_loader_runtime.py
+++ b/tests/unit/showcase/test_catalog_loader_runtime.py
@@ -1,0 +1,179 @@
+# mypy: disable-error-code="union-attr"
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from polylogue.scenarios import AssertionSpec, CorpusSpec, ScenarioMetadata, polylogue_execution
+from polylogue.showcase.catalog_loader import (
+    _each_line_valid_json,
+    _is_integer,
+    _is_valid_json_array,
+    _json_only_fields,
+    _load_assertion,
+    _load_custom_validator,
+    _load_exercise,
+    _search_exit_ok,
+    load_exercise_catalog,
+)
+
+
+def test_is_integer_validates_integer_output() -> None:
+    assert _is_integer("42\n", 0) is None
+    assert _is_integer("", 0) == "output is empty"
+    assert _is_integer("forty-two", 0) == "expected integer, got: 'forty-two'"
+
+
+def test_is_valid_json_array_checks_shape() -> None:
+    assert _is_valid_json_array("[1, 2]", 0) is None
+    assert _is_valid_json_array('{"a": 1}', 0) == "expected JSON array, got dict"
+    assert _is_valid_json_array("{", 0).startswith("invalid JSON:")
+
+
+def test_each_line_valid_json_accepts_blank_lines_and_reports_line_number() -> None:
+    assert _each_line_valid_json('{"ok": true}\n\n{"id": 1}\n', 0) is None
+    assert _each_line_valid_json('{"ok": true}\nnot-json\n', 0).startswith("line 2 invalid JSON:")
+
+
+def test_json_only_fields_validator_checks_allowed_keys() -> None:
+    validator = _json_only_fields("id", "title")
+
+    assert validator('[{"id": 1}, {"title": "ok"}, "skip"]', 0) is None
+    assert validator('[{"id": 1, "extra": true}]', 0) == "item 0 has unexpected keys: {'extra'}"
+    assert validator("{", 0).startswith("invalid JSON:")
+    assert validator('{"id": 1}', 0) == "expected JSON array, got dict"
+
+
+@pytest.mark.parametrize(
+    ("exit_code", "expected"), [(0, None), (2, None), (1, "unexpected exit code 1 (expected 0 or 2)")]
+)
+def test_search_exit_ok_accepts_only_search_exit_codes(exit_code: int, expected: str | None) -> None:
+    assert _search_exit_ok("", exit_code) == expected
+
+
+def test_load_custom_validator_supports_json_only_fields() -> None:
+    validator = _load_custom_validator({"kind": "json_only_fields", "allowed": ["id", "title"]})
+
+    assert validator('[{"id": 1}]', 0) is None
+    assert validator('[{"extra": true}]', 0) == "item 0 has unexpected keys: {'extra'}"
+
+
+def test_load_custom_validator_rejects_unknown_kind() -> None:
+    with pytest.raises(ValueError, match="Unsupported showcase custom validator"):
+        _load_custom_validator({"kind": "unsupported"})
+
+
+def test_load_assertion_supports_custom_validator() -> None:
+    assertion = _load_assertion(
+        {
+            "exit_code": 2,
+            "stdout_contains": ["ok"],
+            "stdout_not_contains": ["boom"],
+            "stdout_is_valid_json": True,
+            "stdout_min_lines": 3,
+            "custom": {"kind": "is_integer"},
+        }
+    )
+
+    assert assertion == AssertionSpec(
+        exit_code=2,
+        stdout_contains=("ok",),
+        stdout_not_contains=("boom",),
+        stdout_is_valid_json=True,
+        stdout_min_lines=3,
+        custom=assertion.custom,
+    )
+    assert assertion.custom is not None
+    assert assertion.custom("12", 0) is None
+    assert assertion.custom("not-an-int", 0) == "expected integer, got: 'not-an-int'"
+
+
+def test_load_assertion_defaults_when_payload_is_none() -> None:
+    assert _load_assertion(None) == AssertionSpec()
+
+
+def test_load_exercise_requires_execution_payload() -> None:
+    with pytest.raises(ValueError, match="must declare execution payloads"):
+        _load_exercise(
+            {
+                "name": "missing-execution",
+                "group": "structural",
+                "description": "missing execution",
+            }
+        )
+
+
+def test_load_exercise_reads_metadata_assertion_and_corpus_specs() -> None:
+    payload = {
+        "name": "json-stats",
+        "group": "query-read",
+        "description": "Show stats as JSON",
+        "execution": polylogue_execution("stats", "--json").to_payload(),
+        "corpus_specs": [
+            CorpusSpec.for_provider("chatgpt", count=2, messages_min=4, messages_max=4).to_payload(),
+        ],
+        "assertion": {"stdout_is_valid_json": True},
+        "tier": 2,
+        "env": "seeded",
+        "output_ext": ".json",
+        "origin": "authored.showcase-catalog",
+        "path_targets": ["archive-query-loop"],
+        "artifact_targets": ["archive_readiness"],
+        "operation_targets": ["project-archive-readiness"],
+        "tags": ["json-contract", "query"],
+    }
+
+    exercise = _load_exercise(payload)
+
+    assert exercise.name == "json-stats"
+    assert exercise.args == ["stats", "--json"]
+    assert exercise.corpus_specs[0].provider == "chatgpt"
+    assert exercise.assertion.stdout_is_valid_json is True
+    assert exercise.tier == 2
+    assert exercise.env == "seeded"
+    assert exercise.output_ext == ".json"
+    assert exercise.origin == "authored.showcase-catalog"
+    assert exercise.path_targets == ("archive-query-loop",)
+    assert exercise.artifact_targets == ("archive_readiness",)
+    assert exercise.operation_targets == ("project-archive-readiness",)
+    assert exercise.tags == ("json-contract", "query")
+
+
+def test_load_exercise_catalog_reads_builtin_catalog() -> None:
+    catalog = load_exercise_catalog()
+
+    assert "structural" in catalog.groups
+    assert any(exercise.name == "help-main" for exercise in catalog.exercises)
+
+
+def test_load_exercise_catalog_requires_object_payload(tmp_path: Path) -> None:
+    catalog_path = tmp_path / "catalog.json"
+    catalog_path.write_text("[]", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="must be a JSON object"):
+        load_exercise_catalog(catalog_path)
+
+
+def test_load_exercise_catalog_loads_custom_file(tmp_path: Path) -> None:
+    catalog_path = tmp_path / "catalog.json"
+    payload = {
+        "groups": ["query-read"],
+        "exercises": [
+            {
+                "name": "custom",
+                "group": "query-read",
+                "description": "custom exercise",
+                "execution": polylogue_execution("stats").to_payload(),
+                "metadata": ScenarioMetadata(origin="authored.custom").to_payload(),
+            }
+        ],
+    }
+    catalog_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    catalog = load_exercise_catalog(catalog_path)
+
+    assert catalog.groups == ("query-read",)
+    assert catalog.exercises[0].name == "custom"

--- a/tests/unit/showcase/test_invariants_runtime.py
+++ b/tests/unit/showcase/test_invariants_runtime.py
@@ -1,0 +1,144 @@
+# mypy: disable-error-code="union-attr"
+
+from __future__ import annotations
+
+from dataclasses import replace
+from unittest.mock import patch
+
+from polylogue.lib.outcomes import OutcomeStatus
+from polylogue.scenarios import AssertionSpec, polylogue_execution
+from polylogue.showcase.exercise_models import Exercise
+from polylogue.showcase.invariants import (
+    SHOWCASE_INVARIANTS,
+    SKIP,
+    Invariant,
+    InvariantResult,
+    _check_clean_stderr,
+    _check_exit_code,
+    _check_json_valid,
+    _check_nonempty_output,
+    check_invariants,
+    format_invariant_summary,
+)
+from polylogue.showcase.runner import ExerciseResult
+
+
+def _make_exercise(
+    *args: str,
+    output_ext: str = ".txt",
+    writes: bool = False,
+    assertion: AssertionSpec | None = None,
+) -> Exercise:
+    return Exercise(
+        name="exercise",
+        group="query-read",
+        description="exercise",
+        execution=polylogue_execution(*args),
+        output_ext=output_ext,
+        writes=writes,
+        assertion=assertion or AssertionSpec(),
+    )
+
+
+def _make_result(
+    *,
+    args: tuple[str, ...] = ("stats",),
+    output: str = "ok",
+    exit_code: int = 0,
+    output_ext: str = ".txt",
+    writes: bool = False,
+    assertion: AssertionSpec | None = None,
+    skipped: bool = False,
+) -> ExerciseResult:
+    return ExerciseResult(
+        exercise=_make_exercise(*args, output_ext=output_ext, writes=writes, assertion=assertion),
+        passed=not skipped,
+        exit_code=exit_code,
+        output=output,
+        duration_ms=5.0,
+        skipped=skipped,
+        skip_reason="skip" if skipped else None,
+    )
+
+
+def test_json_valid_skips_non_json_and_validates_json_documents() -> None:
+    assert _check_json_valid(_make_result(args=("stats",), output="plain")) == SKIP
+    assert _check_json_valid(_make_result(args=("stats", "--json"), output='{"ok": true}', output_ext=".json")) is None
+    assert _check_json_valid(_make_result(args=("stats", "--json"), output="{", output_ext=".json")).startswith(
+        "Invalid JSON:"
+    )
+
+
+def test_json_valid_handles_jsonl_line_errors() -> None:
+    ok_result = _make_result(args=("query", "-f", "json"), output='{"a": 1}\n\n{"b": 2}\n', output_ext=".jsonl")
+    bad_result = _make_result(args=("query", "-f", "json"), output='{"a": 1}\nnot-json\n', output_ext=".jsonl")
+
+    assert _check_json_valid(ok_result) is None
+    assert _check_json_valid(bad_result).startswith("Invalid JSON on line 2:")
+
+
+def test_exit_code_invariant_uses_assertion_spec() -> None:
+    delegated = _make_result(args=("stats",), assertion=AssertionSpec(exit_code=None))
+    matching = _make_result(args=("stats",), exit_code=2, assertion=AssertionSpec(exit_code=2))
+    failing = _make_result(args=("stats",), exit_code=1, assertion=AssertionSpec(exit_code=0))
+
+    assert _check_exit_code(delegated) == SKIP
+    assert _check_exit_code(matching) is None
+    assert _check_exit_code(failing) == "exit code 1, expected 0"
+
+
+def test_clean_stderr_and_nonempty_output_skip_expected_cases() -> None:
+    assert _check_clean_stderr(_make_result(args=("run",), writes=True)) == SKIP
+    assert _check_clean_stderr(_make_result(args=("stats",))) is None
+
+    assert _check_nonempty_output(_make_result(args=("stats", "--count"), output="")) == SKIP
+    assert _check_nonempty_output(_make_result(args=("--help",), output="")) == SKIP
+    assert _check_nonempty_output(_make_result(args=("--version",), output="")) == SKIP
+    assert _check_nonempty_output(_make_result(args=("stats",), writes=True, output="")) == SKIP
+    assert _check_nonempty_output(_make_result(args=("stats",), output="")) == "Empty output for read command"
+    assert _check_nonempty_output(_make_result(args=("stats",), output="not empty")) is None
+
+
+def test_invariant_to_claim_emits_showcase_claim_metadata() -> None:
+    claim = SHOWCASE_INVARIANTS[0].to_claim()
+
+    assert claim.id == "showcase.invariant.json_valid"
+    assert claim.breaker is not None
+    assert claim.breaker.issue == "#192"
+    assert claim.breaker.command == ("devtools", "lab-scenario", "run", "archive-smoke", "--tier", "0")
+
+
+def test_check_invariants_collects_ok_skip_error_and_crash() -> None:
+    result = _make_result(args=("stats",), output="payload")
+    skipped_result = replace(result, skipped=True, skip_reason="skip")
+    invariants = [
+        Invariant(name="ok", description="ok", check=lambda _result: None),
+        Invariant(name="skip", description="skip", check=lambda _result: SKIP),
+        Invariant(name="error", description="error", check=lambda _result: "broken"),
+        Invariant(name="crash", description="crash", check=lambda _result: (_ for _ in ()).throw(RuntimeError("boom"))),
+    ]
+
+    with patch("polylogue.showcase.invariants.SHOWCASE_INVARIANTS", invariants):
+        results = check_invariants([result, skipped_result])
+
+    assert [(item.invariant_name, item.status) for item in results] == [
+        ("ok", OutcomeStatus.OK),
+        ("skip", OutcomeStatus.SKIP),
+        ("error", OutcomeStatus.ERROR),
+        ("crash", OutcomeStatus.ERROR),
+    ]
+    assert results[-1].error == "invariant check crashed: boom"
+
+
+def test_format_invariant_summary_lists_failures() -> None:
+    summary = format_invariant_summary(
+        [
+            InvariantResult("json_valid", "stats", OutcomeStatus.OK),
+            InvariantResult("nonempty_output", "stats", OutcomeStatus.ERROR, error="empty"),
+            InvariantResult("exit_code", "stats", OutcomeStatus.SKIP),
+        ]
+    )
+
+    assert "Invariant Checks: 1 pass, 1 fail, 1 skip" in summary
+    assert "Failures:" in summary
+    assert "nonempty_output @ stats: empty" in summary

--- a/tests/unit/showcase/test_operator_reporting_runtime.py
+++ b/tests/unit/showcase/test_operator_reporting_runtime.py
@@ -1,0 +1,238 @@
+# mypy: disable-error-code="arg-type,attr-defined,operator"
+
+from __future__ import annotations
+
+import json
+import sys
+from types import ModuleType, SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from polylogue.cli.qa_capture import run_vhs_capture
+from polylogue.lib.outcomes import OutcomeStatus
+from polylogue.showcase.invariants import InvariantResult
+from polylogue.showcase.qa_runner_models import QAResult
+from polylogue.showcase.qa_runner_reporting import format_qa_summary, save_qa_reports
+from polylogue.showcase.qa_summary import generate_qa_summary
+from polylogue.showcase.report_common import (
+    format_count_mapping,
+    format_semantic_metric_summary,
+    serialize_invariant_result,
+    status_label,
+    summarize_invariants,
+)
+
+
+def _make_env() -> SimpleNamespace:
+    return SimpleNamespace(ui=SimpleNamespace(console=MagicMock()))
+
+
+def test_run_vhs_capture_returns_on_import_error(tmp_path: object) -> None:
+    env = _make_env()
+    showcase_result = SimpleNamespace(output_dir=tmp_path, results=[])
+    real_import = __import__
+
+    def _raising_import(
+        name: str, globals: object = None, locals: object = None, fromlist: tuple[str, ...] = (), level: int = 0
+    ) -> object:
+        if name == "polylogue.showcase.vhs":
+            raise ImportError("missing")
+        return real_import(name, globals, locals, fromlist, level)
+
+    with patch("builtins.__import__", side_effect=_raising_import):
+        run_vhs_capture(env, showcase_result, json_output=False)
+
+    env.ui.console.print.assert_not_called()
+
+
+def test_run_vhs_capture_handles_missing_output_dir() -> None:
+    env = _make_env()
+    module = ModuleType("polylogue.showcase.vhs")
+    module.check_vhs_available = lambda: True
+    module.generate_all_tapes = lambda exercises, *, output_dir: ["demo"]
+    module.run_vhs_capture = lambda tape_path, gif_path: True
+
+    with patch.dict(sys.modules, {"polylogue.showcase.vhs": module}):
+        run_vhs_capture(env, SimpleNamespace(output_dir=None, results=[]), json_output=False)
+
+    env.ui.console.print.assert_not_called()
+
+
+def test_run_vhs_capture_reports_tape_results_and_missing_binary(tmp_path: object) -> None:
+    env = _make_env()
+    showcase_result = SimpleNamespace(
+        output_dir=tmp_path,
+        results=[SimpleNamespace(exercise="ex-1"), SimpleNamespace(exercise="ex-2")],
+    )
+    module = ModuleType("polylogue.showcase.vhs")
+    module.generate_all_tapes = lambda exercises, *, output_dir: ["demo", "broken"]
+    capture_results = {"demo": True, "broken": False}
+    module.run_vhs_capture = lambda tape_path, gif_path: capture_results[tape_path.stem]
+
+    module.check_vhs_available = lambda: True
+    with patch.dict(sys.modules, {"polylogue.showcase.vhs": module}):
+        run_vhs_capture(env, showcase_result, json_output=False)
+
+    assert env.ui.console.print.call_args_list[0].args == ("  VHS demo: ok",)
+    assert env.ui.console.print.call_args_list[1].args == ("  VHS broken: FAILED",)
+
+    env = _make_env()
+    module.check_vhs_available = lambda: False
+    with patch.dict(sys.modules, {"polylogue.showcase.vhs": module}):
+        run_vhs_capture(env, showcase_result, json_output=False)
+
+    assert "VHS binary not found" in env.ui.console.print.call_args.args[0]
+
+
+def test_report_common_helpers_serialize_and_format() -> None:
+    results = [
+        InvariantResult("json_valid", "stats", OutcomeStatus.OK),
+        InvariantResult("exit_code", "stats", OutcomeStatus.ERROR, error="boom"),
+        InvariantResult("nonempty_output", "stats", OutcomeStatus.SKIP),
+    ]
+
+    assert serialize_invariant_result(results[1]) == {
+        "invariant": "exit_code",
+        "exercise": "stats",
+        "status": "error",
+        "error": "boom",
+    }
+    assert summarize_invariants(results) == {"passed": 1, "failed": 1, "skipped": 1}
+    assert status_label(OutcomeStatus.OK) == "PASS"
+    assert status_label(OutcomeStatus.WARNING) == "WARN"
+    assert status_label(OutcomeStatus.ERROR) == "FAIL"
+    assert status_label(OutcomeStatus.SKIP) == "SKIPPED"
+    assert format_count_mapping({"b": 2, "a": 1}) == "a=1, b=2"
+    assert (
+        format_semantic_metric_summary(
+            {
+                "tokens": {"preserved": 2, "declared_loss": 1, "critical_loss": 0},
+                "tools": {"preserved": 3},
+            }
+        )
+        == "tokens(preserved=2, declared_loss=1, critical_loss=0), tools(preserved=3, declared_loss=0, critical_loss=0)"
+    )
+
+
+def test_generate_qa_summary_uses_provided_session_and_all_branches(tmp_path: object) -> None:
+    result = QAResult(
+        audit_report=SimpleNamespace(all_passed=True),
+        proof_report=SimpleNamespace(is_clean=True),
+        showcase_result=SimpleNamespace(failed=1),
+        report_dir=tmp_path,
+    )
+    session = SimpleNamespace(
+        proof=SimpleNamespace(
+            report={
+                "summary": {
+                    "contract_backed_records": 3,
+                    "unsupported_parseable_records": 1,
+                    "recognized_non_parseable_records": 0,
+                    "unknown_records": 0,
+                    "decode_errors": 0,
+                    "package_versions": {"v1": 2},
+                    "element_kinds": {"conversation_document": 3},
+                    "resolution_reasons": {"supported": 3},
+                }
+            }
+        ),
+        showcase=SimpleNamespace(
+            summary=SimpleNamespace(passed=3, total=4, failed=1, skipped=0, total_duration_ms=1200.0)
+        ),
+        invariants=SimpleNamespace(skipped=False, summary=SimpleNamespace(passed=5, failed=1, skipped=2)),
+    )
+
+    summary = generate_qa_summary(result, session=session)
+
+    assert "Schema Audit: PASS" in summary
+    assert "Artifact Proof: contract_backed=3, unsupported=1, non_parseable=0, unknown=0, decode_errors=0" in summary
+    assert "Packages: v1=2" in summary
+    assert "Elements: conversation_document=3" in summary
+    assert "Reasons: supported=3" in summary
+    assert "Exercises: 3/4 passed, 1 failed, 0 skipped (1.2s)" in summary
+    assert "Invariants: 5 pass, 1 fail, 2 skip" in summary
+    assert "Overall: FAIL" in summary
+    assert f"Reports: {tmp_path}" in summary
+
+
+def test_generate_qa_summary_builds_session_when_missing_and_handles_skips() -> None:
+    result = QAResult(
+        audit_error="audit failed",
+        proof_error="proof failed",
+        exercises_skipped=True,
+        invariants_skipped=True,
+    )
+    session = SimpleNamespace(
+        proof=SimpleNamespace(report=None),
+        showcase=SimpleNamespace(summary=None),
+        invariants=SimpleNamespace(skipped=True, summary=SimpleNamespace(passed=0, failed=0, skipped=0)),
+    )
+
+    with (
+        patch("polylogue.showcase.qa_session_payload.build_qa_session_record", return_value=session) as mock_session,
+        patch("polylogue.showcase.showcase_report_payloads.build_showcase_session_record") as mock_showcase,
+    ):
+        summary = generate_qa_summary(result)
+
+    mock_session.assert_called_once()
+    mock_showcase.assert_not_called()
+    assert "Schema Audit: FAIL" in summary
+    assert "Artifact Proof: FAIL (proof failed)" in summary
+    assert "Exercises: SKIPPED" in summary
+    assert "Invariants: SKIPPED" in summary
+    assert "Overall: FAIL" in summary
+
+
+def test_save_qa_reports_writes_success_and_error_payloads(tmp_path: object) -> None:
+    qa_session = SimpleNamespace(
+        to_payload=lambda: {"status": "ok"},
+        invariants=SimpleNamespace(checks=[SimpleNamespace(to_payload=lambda: {"name": "inv"})]),
+    )
+    result = QAResult(
+        audit_report=SimpleNamespace(to_json=lambda: {"audit": "ok"}),
+        proof_report=SimpleNamespace(to_dict=lambda: {"proof": "ok"}),
+        showcase_result=SimpleNamespace(),
+    )
+
+    with (
+        patch("polylogue.showcase.report_files.save_reports") as mock_save_reports,
+        patch(
+            "polylogue.showcase.showcase_report_payloads.build_showcase_session_record", return_value="showcase-session"
+        ),
+        patch("polylogue.showcase.qa_session_payload.build_qa_session_record", return_value=qa_session),
+        patch("polylogue.showcase.qa_report.generate_qa_markdown", return_value="# QA report"),
+    ):
+        save_qa_reports(result, tmp_path)
+
+    assert json.loads((tmp_path / "schema-audit.json").read_text()) == {"audit": "ok"}
+    assert json.loads((tmp_path / "artifact-proof.json").read_text()) == {"proof": "ok"}
+    assert json.loads((tmp_path / "qa-session.json").read_text()) == {"status": "ok"}
+    assert json.loads((tmp_path / "invariant-checks.json").read_text()) == [{"name": "inv"}]
+    assert (tmp_path / "qa-session.md").read_text() == "# QA report"
+    mock_save_reports.assert_called_once_with(result.showcase_result)
+
+    error_dir = tmp_path / "errors"
+    error_result = QAResult(audit_error="audit failed", proof_error="proof failed")
+    qa_session = SimpleNamespace(
+        to_payload=lambda: {"status": "error"},
+        invariants=SimpleNamespace(checks=[]),
+    )
+
+    with (
+        patch("polylogue.showcase.report_files.save_reports") as mock_save_reports,
+        patch("polylogue.showcase.qa_session_payload.build_qa_session_record", return_value=qa_session),
+        patch("polylogue.showcase.qa_report.generate_qa_markdown", return_value="# errors"),
+    ):
+        save_qa_reports(error_result, error_dir)
+
+    assert json.loads((error_dir / "schema-audit.json").read_text()) == {"error": "audit failed"}
+    assert json.loads((error_dir / "artifact-proof.json").read_text()) == {"error": "proof failed"}
+    mock_save_reports.assert_not_called()
+
+
+def test_format_qa_summary_delegates_to_renderer() -> None:
+    result = QAResult()
+
+    with patch("polylogue.showcase.qa_report.generate_qa_summary", return_value="summary") as mock_generate:
+        assert format_qa_summary(result) == "summary"
+
+    mock_generate.assert_called_once_with(result)

--- a/tests/unit/showcase/test_qa_runner_stages_runtime.py
+++ b/tests/unit/showcase/test_qa_runner_stages_runtime.py
@@ -1,0 +1,70 @@
+# mypy: disable-error-code="comparison-overlap"
+
+from __future__ import annotations
+
+from contextlib import nullcontext
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from polylogue.showcase.exercises import QA_EXTRA_EXERCISES
+from polylogue.showcase.qa_runner_models import QAResult
+from polylogue.showcase.qa_runner_stages import generate_extra_exercises, populate_proof
+
+
+def test_generate_extra_exercises_returns_list_copy() -> None:
+    exercises = generate_extra_exercises()
+
+    assert exercises == list(QA_EXTRA_EXERCISES)
+    assert exercises is not QA_EXTRA_EXERCISES
+
+
+def test_populate_proof_sets_report_without_workspace_override(tmp_path: Path) -> None:
+    result = QAResult()
+    proof_report = SimpleNamespace(is_clean=True)
+
+    with (
+        patch("polylogue.paths.db_path", return_value=tmp_path / "polylogue.db") as mock_db_path,
+        patch(
+            "polylogue.schemas.verification_artifacts.prove_raw_artifact_coverage", return_value=proof_report
+        ) as mock_prove,
+    ):
+        populate_proof(result, workspace_env=None)
+
+    mock_db_path.assert_called_once_with()
+    mock_prove.assert_called_once()
+    assert mock_prove.call_args.kwargs["db_path"] == tmp_path / "polylogue.db"
+    assert result.proof_report is proof_report
+    assert result.proof_error is None
+
+
+def test_populate_proof_uses_workspace_override_context(tmp_path: Path) -> None:
+    result = QAResult()
+    proof_report = SimpleNamespace(is_clean=True)
+
+    with (
+        patch("polylogue.paths.db_path", return_value=tmp_path / "polylogue.db"),
+        patch(
+            "polylogue.showcase.qa_runner_stages.override_workspace_env", return_value=nullcontext()
+        ) as mock_override,
+        patch(
+            "polylogue.schemas.verification_artifacts.prove_raw_artifact_coverage", return_value=proof_report
+        ) as mock_prove,
+    ):
+        populate_proof(result, workspace_env={"XDG_CONFIG_HOME": str(tmp_path / "config")})
+
+    mock_override.assert_called_once_with({"XDG_CONFIG_HOME": str(tmp_path / "config")})
+    mock_prove.assert_called_once()
+    assert result.proof_report is proof_report
+
+
+def test_populate_proof_captures_exceptions() -> None:
+    result = QAResult()
+
+    with patch(
+        "polylogue.schemas.verification_artifacts.prove_raw_artifact_coverage", side_effect=RuntimeError("broken")
+    ):
+        populate_proof(result, workspace_env=None)
+
+    assert result.proof_report is None
+    assert result.proof_error == "broken"

--- a/tests/unit/showcase/test_qa_workflow_runtime.py
+++ b/tests/unit/showcase/test_qa_workflow_runtime.py
@@ -1,0 +1,339 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, PropertyMock, patch
+
+import pytest
+
+from polylogue.lib.outcomes import OutcomeStatus
+from polylogue.pipeline.run_support import RUN_STAGE_SEQUENCES
+from polylogue.scenarios import polylogue_execution
+from polylogue.showcase.exercise_models import Exercise
+from polylogue.showcase.qa_runner_models import QAResult
+from polylogue.showcase.qa_runner_request import (
+    QASessionPlan,
+    QASessionRequest,
+    QAWorkspaceMode,
+)
+from polylogue.showcase.qa_runner_workflow import (
+    PreparedQARuntime,
+    _prepare_runtime,
+    _run_audit_stage,
+    _run_live_ingest,
+    run_qa_session,
+)
+from polylogue.showcase.runner import ExerciseResult, ShowcaseResult
+
+
+def _make_audit_report(*, all_passed: bool) -> SimpleNamespace:
+    return SimpleNamespace(all_passed=all_passed, format_text=lambda: "audit report")
+
+
+def _make_showcase_result() -> ShowcaseResult:
+    exercise = Exercise(
+        name="stats-default",
+        group="query-read",
+        description="stats",
+        execution=polylogue_execution("stats"),
+    )
+    result = ShowcaseResult()
+    result.results = [
+        ExerciseResult(
+            exercise=exercise,
+            passed=True,
+            exit_code=0,
+            output="stats output",
+            duration_ms=12.0,
+        )
+    ]
+    return result
+
+
+def test_prepare_runtime_returns_existing_context_when_workspace_not_needed(tmp_path: Path) -> None:
+    request = QASessionRequest(
+        skip_exercises=True,
+        workspace_env={"POLYLOGUE_ARCHIVE_ROOT": str(tmp_path / "archive")},
+        report_dir=tmp_path / "reports",
+    )
+
+    runtime = _prepare_runtime(request)
+
+    assert runtime == PreparedQARuntime(
+        workspace_env={"POLYLOGUE_ARCHIVE_ROOT": str(tmp_path / "archive")},
+        report_dir=tmp_path / "reports",
+    )
+
+
+def test_prepare_runtime_seeds_corpus_workspace_and_report_dir(tmp_path: Path) -> None:
+    request = QASessionRequest(
+        workspace_dir=tmp_path / "workspace",
+        report_dir=tmp_path / "reports",
+        regenerate_schemas=True,
+    )
+    workspace = SimpleNamespace(env_vars={"POLYLOGUE_ARCHIVE_ROOT": str(tmp_path / "workspace" / "archive")})
+
+    with (
+        patch(
+            "polylogue.showcase.qa_runner_workflow.create_verification_workspace", return_value=workspace
+        ) as mock_create,
+        patch("polylogue.showcase.qa_runner_workflow.seed_workspace_from_corpus_request") as mock_seed,
+        patch(
+            "polylogue.showcase.qa_runner_workflow.ensure_report_dir", return_value=tmp_path / "final-report"
+        ) as mock_report,
+    ):
+        runtime = _prepare_runtime(request)
+
+    mock_create.assert_called_once_with(request.workspace_dir)
+    mock_seed.assert_called_once_with(
+        workspace,
+        request=request.corpus_request,
+        regenerate_schemas=True,
+    )
+    mock_report.assert_called_once_with(workspace, request.report_dir)
+    assert runtime.workspace_env == workspace.env_vars
+    assert runtime.report_dir == tmp_path / "final-report"
+
+
+def test_prepare_runtime_uses_configured_sources_workspace_mode(tmp_path: Path) -> None:
+    request = QASessionRequest(
+        live=True,
+        fresh=True,
+        source_names=("codex",),
+        workspace_dir=tmp_path / "workspace",
+        report_dir=tmp_path / "reports",
+    )
+    workspace = SimpleNamespace(env_vars={"POLYLOGUE_ARCHIVE_ROOT": str(tmp_path / "workspace" / "archive")})
+
+    with (
+        patch("polylogue.showcase.qa_runner_workflow.create_verification_workspace", return_value=workspace),
+        patch("polylogue.showcase.qa_runner_workflow.run_pipeline_for_configured_sources") as mock_run,
+        patch("polylogue.showcase.qa_runner_workflow.ensure_report_dir", return_value=tmp_path / "configured-report"),
+    ):
+        runtime = _prepare_runtime(request)
+
+    mock_run.assert_called_once_with(
+        workspace,
+        source_names=["codex"],
+        regenerate_schemas=False,
+    )
+    assert runtime.workspace_env == workspace.env_vars
+    assert runtime.report_dir == tmp_path / "configured-report"
+
+
+def test_prepare_runtime_rejects_unexpected_workspace_mode(tmp_path: Path) -> None:
+    request = QASessionRequest(workspace_dir=tmp_path / "workspace")
+
+    with (
+        patch.object(
+            QASessionRequest,
+            "execution_plan",
+            new_callable=PropertyMock,
+            return_value=QASessionPlan(
+                workspace_mode=QAWorkspaceMode.LIVE_INGEST,
+                run_audit=True,
+                run_proof=True,
+                run_exercises=True,
+                run_invariants=True,
+            ),
+        ),
+        patch(
+            "polylogue.showcase.qa_runner_workflow.create_verification_workspace",
+            return_value=SimpleNamespace(env_vars={}),
+        ),
+    ):
+        with pytest.raises(RuntimeError, match="unexpected workspace mode"):
+            _prepare_runtime(request)
+
+
+def test_run_live_ingest_uses_schema_stage_sequence_when_regenerating() -> None:
+    request = QASessionRequest(
+        live=True,
+        ingest=True,
+        regenerate_schemas=True,
+        source_names=("chatgpt", "codex"),
+    )
+
+    with (
+        patch("polylogue.pipeline.runner.run_sources", new=MagicMock(return_value="coro")) as mock_run_sources,
+        patch("polylogue.showcase.qa_runner_workflow.run_coroutine_sync") as mock_sync,
+        patch("polylogue.config.get_config", return_value=SimpleNamespace(name="config")) as mock_get_config,
+    ):
+        _run_live_ingest(request)
+
+    mock_get_config.assert_called_once_with()
+    mock_run_sources.assert_called_once()
+    assert mock_run_sources.call_args.kwargs["config"].name == "config"
+    assert mock_run_sources.call_args.kwargs["stage"] == "all"
+    assert mock_run_sources.call_args.kwargs["stage_sequence"] == ("schema", *RUN_STAGE_SEQUENCES["all"])
+    assert mock_run_sources.call_args.kwargs["source_names"] == ["chatgpt", "codex"]
+    mock_sync.assert_called_once_with("coro")
+
+
+def test_run_audit_stage_marks_skip_without_running_audit() -> None:
+    result = QAResult()
+    request = QASessionRequest(skip_audit=True)
+
+    returned = _run_audit_stage(
+        result,
+        request=request,
+        workspace_env=None,
+        report_dir=None,
+    )
+
+    assert returned is None
+    assert result.audit_skipped is True
+
+
+def test_run_audit_stage_records_exception_and_returns_early_result(tmp_path: Path) -> None:
+    result = QAResult()
+    request = QASessionRequest()
+
+    with (
+        patch("polylogue.schemas.audit_workflow.audit_all_providers", side_effect=RuntimeError("boom")),
+        patch("polylogue.showcase.qa_runner_workflow.populate_proof") as mock_proof,
+        patch("polylogue.showcase.qa_runner_workflow.save_qa_reports") as mock_save,
+    ):
+        returned = _run_audit_stage(
+            result,
+            request=request,
+            workspace_env={"XDG_CONFIG_HOME": str(tmp_path / "config")},
+            report_dir=tmp_path / "report",
+        )
+
+    assert returned is result
+    assert result.audit_error == "boom"
+    assert result.exercises_skipped is True
+    assert result.invariants_skipped is True
+    assert result.report_dir == tmp_path / "report"
+    mock_proof.assert_called_once_with(result, workspace_env={"XDG_CONFIG_HOME": str(tmp_path / "config")})
+    mock_save.assert_called_once_with(result, tmp_path / "report")
+
+
+def test_run_audit_stage_returns_none_when_audit_passes() -> None:
+    result = QAResult()
+    request = QASessionRequest(provider="chatgpt")
+
+    with patch(
+        "polylogue.schemas.audit_workflow.audit_provider", return_value=_make_audit_report(all_passed=True)
+    ) as mock_audit:
+        returned = _run_audit_stage(
+            result,
+            request=request,
+            workspace_env=None,
+            report_dir=None,
+        )
+
+    assert returned is None
+    assert result.audit_report is not None
+    mock_audit.assert_called_once_with("chatgpt")
+
+
+def test_run_audit_stage_persists_failed_audit_and_prints_verbose_output(capsys: pytest.CaptureFixture[str]) -> None:
+    result = QAResult()
+    request = QASessionRequest(verbose=True)
+
+    with (
+        patch(
+            "polylogue.schemas.audit_workflow.audit_all_providers", return_value=_make_audit_report(all_passed=False)
+        ),
+        patch("polylogue.showcase.qa_runner_workflow.populate_proof") as mock_proof,
+    ):
+        returned = _run_audit_stage(
+            result,
+            request=request,
+            workspace_env=None,
+            report_dir=None,
+        )
+
+    captured = capsys.readouterr()
+    assert returned is result
+    assert result.exercises_skipped is True
+    assert result.invariants_skipped is True
+    assert "audit report" in captured.err
+    mock_proof.assert_called_once_with(result, workspace_env=None)
+
+
+def test_run_qa_session_returns_early_audit_result(tmp_path: Path) -> None:
+    request = QASessionRequest(fresh=False)
+    early = QAResult(report_dir=tmp_path / "report")
+
+    with (
+        patch(
+            "polylogue.showcase.qa_runner_workflow._prepare_runtime", return_value=PreparedQARuntime()
+        ) as mock_prepare,
+        patch("polylogue.showcase.qa_runner_workflow._run_audit_stage", return_value=early) as mock_audit,
+    ):
+        returned = run_qa_session(request)
+
+    assert returned is early
+    mock_prepare.assert_called_once_with(request)
+    mock_audit.assert_called_once()
+
+
+def test_run_qa_session_executes_full_success_path(tmp_path: Path) -> None:
+    request = QASessionRequest(fresh=False, report_dir=tmp_path / "report")
+    runtime = PreparedQARuntime(
+        workspace_env={"POLYLOGUE_ARCHIVE_ROOT": str(tmp_path / "archive")}, report_dir=tmp_path / "report"
+    )
+    showcase_result = _make_showcase_result()
+    invariant_result = SimpleNamespace(status=OutcomeStatus.OK)
+    runner = MagicMock()
+    runner.run.return_value = showcase_result
+
+    with (
+        patch("polylogue.showcase.qa_runner_workflow._prepare_runtime", return_value=runtime),
+        patch("polylogue.showcase.qa_runner_workflow._run_audit_stage", return_value=None),
+        patch("polylogue.showcase.qa_runner_workflow.populate_proof") as mock_proof,
+        patch("polylogue.showcase.qa_runner_workflow.ShowcaseRunner", return_value=runner) as mock_runner_class,
+        patch(
+            "polylogue.showcase.qa_runner_workflow.check_invariants", return_value=[invariant_result]
+        ) as mock_invariants,
+        patch("polylogue.showcase.qa_runner_workflow.save_qa_reports") as mock_save,
+    ):
+        result = run_qa_session(request)
+
+    mock_proof.assert_called_once_with(result, workspace_env=runtime.workspace_env)
+    mock_runner_class.assert_called_once_with(
+        live=False,
+        output_dir=runtime.report_dir,
+        fail_fast=False,
+        verbose=False,
+        tier_filter=None,
+        extra_exercises=mock_runner_class.call_args.kwargs["extra_exercises"],
+        workspace_env=runtime.workspace_env,
+        corpus_request=request.corpus_request,
+    )
+    assert isinstance(mock_runner_class.call_args.kwargs["extra_exercises"], list)
+    mock_invariants.assert_called_once_with(showcase_result.results)
+    mock_save.assert_called_once_with(result, tmp_path / "report")
+    assert result.showcase_result is showcase_result
+    assert result.invariant_results == [invariant_result]
+
+
+def test_run_qa_session_respects_skip_flags_and_live_ingest() -> None:
+    request = QASessionRequest(
+        live=True,
+        ingest=True,
+        skip_proof=True,
+        skip_exercises=True,
+        skip_invariants=True,
+    )
+
+    with (
+        patch("polylogue.showcase.qa_runner_workflow._prepare_runtime", return_value=PreparedQARuntime()),
+        patch("polylogue.showcase.qa_runner_workflow._run_live_ingest") as mock_ingest,
+        patch("polylogue.showcase.qa_runner_workflow._run_audit_stage", return_value=None),
+        patch("polylogue.showcase.qa_runner_workflow.populate_proof") as mock_proof,
+        patch("polylogue.showcase.qa_runner_workflow.ShowcaseRunner") as mock_runner_class,
+        patch("polylogue.showcase.qa_runner_workflow.check_invariants") as mock_invariants,
+    ):
+        result = run_qa_session(request)
+
+    mock_ingest.assert_called_once_with(request)
+    mock_proof.assert_not_called()
+    mock_runner_class.assert_not_called()
+    mock_invariants.assert_not_called()
+    assert result.proof_skipped is True
+    assert result.exercises_skipped is True
+    assert result.invariants_skipped is True

--- a/tests/unit/showcase/test_showcase_runner_support_runtime.py
+++ b/tests/unit/showcase/test_showcase_runner_support_runtime.py
@@ -1,0 +1,230 @@
+# mypy: disable-error-code="arg-type"
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from polylogue.scenarios import AssertionSpec, CorpusRequest, CorpusSpec, polylogue_execution
+from polylogue.showcase.exercise_models import Exercise
+from polylogue.showcase.showcase_runner_support import (
+    _merge_exercise_corpus_specs,
+    generate_showcase_fixtures,
+    run_exercise,
+    seed_workspace,
+    seed_workspace_with,
+    select_exercises,
+    validate_exercise_output,
+)
+
+
+def _make_exercise(
+    name: str,
+    *,
+    env: str = "any",
+    writes: bool = False,
+    tier: int = 1,
+    depends_on: str | None = None,
+    corpus_specs: tuple[CorpusSpec, ...] = (),
+    assertion: AssertionSpec | None = None,
+    timeout_s: float = 60.0,
+) -> Exercise:
+    return Exercise(
+        name=name,
+        group="query-read",
+        description=name,
+        execution=polylogue_execution("stats"),
+        env=env,
+        writes=writes,
+        tier=tier,
+        depends_on=depends_on,
+        corpus_specs=corpus_specs,
+        assertion=assertion or AssertionSpec(),
+        timeout_s=timeout_s,
+    )
+
+
+def test_select_exercises_filters_seeded_mode() -> None:
+    base = _make_exercise("base")
+    after = _make_exercise("after", depends_on="base")
+
+    with patch(
+        "polylogue.showcase.showcase_runner_support.EXERCISES",
+        [
+            _make_exercise("live-only", env="live"),
+            base,
+            after,
+            _make_exercise("seeded-only", env="seeded", tier=2),
+        ],
+    ):
+        selected = select_exercises(live=False, tier_filter=None, extra_exercises=[])
+
+    assert [exercise.name for exercise in selected] == ["base", "after", "seeded-only"]
+
+
+def test_select_exercises_filters_live_mode_and_writes() -> None:
+    with patch(
+        "polylogue.showcase.showcase_runner_support.EXERCISES",
+        [
+            _make_exercise("seeded-only", env="seeded"),
+            _make_exercise("write", writes=True),
+            _make_exercise("live", env="live", tier=2),
+            _make_exercise("any", tier=2),
+        ],
+    ):
+        selected = select_exercises(live=True, tier_filter=2, extra_exercises=[])
+
+    assert [exercise.name for exercise in selected] == ["live", "any"]
+
+
+def test_seed_workspace_uses_default_showcase_request(tmp_path: Path) -> None:
+    workspace = SimpleNamespace(env_vars={"POLYLOGUE_ARCHIVE_ROOT": str(tmp_path / "archive")})
+
+    with (
+        patch(
+            "polylogue.showcase.showcase_runner_support.create_verification_workspace", return_value=workspace
+        ) as mock_create,
+        patch(
+            "polylogue.showcase.showcase_runner_support.build_synthetic_corpus_scenarios", return_value=("scenario",)
+        ) as mock_build,
+        patch("polylogue.showcase.showcase_runner_support.seed_workspace_from_scenarios") as mock_seed,
+    ):
+        env = seed_workspace(tmp_path / "workspace")
+
+    mock_create.assert_called_once_with(tmp_path / "workspace")
+    mock_build.assert_called_once()
+    assert isinstance(mock_build.call_args.kwargs["request"], CorpusRequest)
+    mock_seed.assert_called_once_with(workspace, corpus_scenarios=("scenario",))
+    assert env == workspace.env_vars
+
+
+def test_seed_workspace_with_uses_fixture_generation_when_no_compiled_specs(tmp_path: Path) -> None:
+    workspace = SimpleNamespace(
+        env_vars={"POLYLOGUE_ARCHIVE_ROOT": str(tmp_path / "archive")},
+        fixture_dir=tmp_path / "fixtures",
+    )
+    called: dict[str, object] = {}
+
+    def _generate_fixtures(fixture_dir: Path, request: CorpusRequest) -> None:
+        called["fixture_dir"] = fixture_dir
+        called["request"] = request
+
+    with (
+        patch("polylogue.showcase.showcase_runner_support.create_verification_workspace", return_value=workspace),
+        patch("polylogue.showcase.showcase_runner_support.run_pipeline_for_fixture_workspace") as mock_run,
+    ):
+        env = seed_workspace_with(
+            tmp_path / "workspace",
+            generate_fixtures=_generate_fixtures,
+        )
+
+    assert called["fixture_dir"] == workspace.fixture_dir
+    assert isinstance(called["request"], CorpusRequest)
+    mock_run.assert_called_once_with(workspace)
+    assert env == workspace.env_vars
+
+
+def test_seed_workspace_with_prefers_corpus_specs_over_generated_fixtures(tmp_path: Path) -> None:
+    workspace = SimpleNamespace(
+        env_vars={"POLYLOGUE_ARCHIVE_ROOT": str(tmp_path / "archive")},
+        fixture_dir=tmp_path / "fixtures",
+    )
+    exercise = _make_exercise(
+        "seeded",
+        corpus_specs=(CorpusSpec.for_provider("chatgpt", count=2, messages_min=4, messages_max=4),),
+    )
+
+    with (
+        patch("polylogue.showcase.showcase_runner_support.create_verification_workspace", return_value=workspace),
+        patch("polylogue.showcase.showcase_runner_support.seed_workspace_from_specs") as mock_seed,
+        patch("polylogue.showcase.showcase_runner_support.run_pipeline_for_fixture_workspace") as mock_run,
+    ):
+        env = seed_workspace_with(
+            tmp_path / "workspace",
+            exercises=(exercise,),
+            generate_fixtures=lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("should not generate")),
+        )
+
+    mock_seed.assert_called_once()
+    mock_run.assert_not_called()
+    assert env == workspace.env_vars
+
+
+def test_merge_exercise_corpus_specs_deduplicates_payloads() -> None:
+    repeated = CorpusSpec.for_provider("chatgpt", count=2, messages_min=4, messages_max=4)
+    unique = CorpusSpec.for_provider("codex", count=1, messages_min=4, messages_max=4)
+
+    merged = _merge_exercise_corpus_specs(
+        (
+            _make_exercise("one", corpus_specs=(repeated, unique)),
+            _make_exercise("two", corpus_specs=(repeated,)),
+        )
+    )
+
+    assert merged == (repeated, unique)
+
+
+def test_generate_showcase_fixtures_uses_default_request(tmp_path: Path) -> None:
+    with patch("polylogue.showcase.showcase_runner_support.generate_synthetic_fixtures") as mock_generate:
+        generate_showcase_fixtures(tmp_path / "fixtures")
+
+    mock_generate.assert_called_once()
+    assert mock_generate.call_args.args[0] == tmp_path / "fixtures"
+    assert isinstance(mock_generate.call_args.kwargs["request"], CorpusRequest)
+
+
+def test_run_exercise_passes_plain_env_and_validates_output() -> None:
+    exercise = _make_exercise("json", assertion=AssertionSpec(stdout_contains=("ok",)))
+    calls: dict[str, object] = {}
+
+    def _invoke(
+        execution: object, *, env: dict[str, str] | None, cwd: Path | None = None, timeout: float = 60.0
+    ) -> SimpleNamespace:
+        calls["execution"] = execution
+        calls["env"] = env
+        calls["cwd"] = cwd
+        calls["timeout"] = timeout
+        return SimpleNamespace(output="ok output", exit_code=0)
+
+    result = run_exercise(exercise, env_vars={"EXISTING": "1"}, invoke_showcase_cli_fn=_invoke)
+
+    assert result.passed is True
+    assert result.error is None
+    assert calls["execution"] == exercise.execution
+    assert calls["env"] == {"EXISTING": "1", "POLYLOGUE_FORCE_PLAIN": "1"}
+    assert calls["timeout"] == exercise.timeout_s
+
+
+def test_run_exercise_handles_timeout() -> None:
+    exercise = _make_exercise("timeout", timeout_s=5.0)
+
+    def _invoke(*_args: object, **_kwargs: object) -> SimpleNamespace:
+        raise subprocess.TimeoutExpired("polylogue", 5.0)
+
+    result = run_exercise(exercise, env_vars={}, invoke_showcase_cli_fn=_invoke)
+
+    assert result.passed is False
+    assert result.exit_code == -1
+    assert result.error == "timed out after 5s"
+
+
+def test_run_exercise_handles_invoker_crash() -> None:
+    exercise = _make_exercise("crash")
+
+    def _invoke(*_args: object, **_kwargs: object) -> SimpleNamespace:
+        raise RuntimeError("boom")
+
+    result = run_exercise(exercise, env_vars={}, invoke_showcase_cli_fn=_invoke)
+
+    assert result.passed is False
+    assert result.exit_code == -1
+    assert result.error == "invoke crashed: boom"
+
+
+def test_validate_exercise_output_delegates_to_assertion() -> None:
+    exercise = _make_exercise("assert", assertion=AssertionSpec(stdout_contains=("ok",)))
+
+    assert validate_exercise_output(exercise, "ok output", 0) is None
+    assert validate_exercise_output(exercise, "bad output", 0) == "output missing 'ok'"

--- a/tests/unit/storage/test_repository_product_runtime.py
+++ b/tests/unit/storage/test_repository_product_runtime.py
@@ -1,0 +1,367 @@
+# mypy: disable-error-code="assignment,comparison-overlap,arg-type"
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from polylogue.storage.product_read_support import hydrate_mapping, hydrate_optional, hydrate_sequence
+from polylogue.storage.repository_product_profile_reads import RepositoryProductProfileReadMixin
+from polylogue.storage.repository_product_summary_reads import RepositoryProductSummaryReadMixin
+from polylogue.storage.repository_product_thread_reads import RepositoryProductThreadReadMixin
+from polylogue.storage.repository_product_timeline_reads import RepositoryProductTimelineReadMixin
+from polylogue.storage.repository_raw import RepositoryRawMixin
+
+
+def test_product_read_support_hydrates_optional_sequence_and_mapping() -> None:
+    assert hydrate_optional(None, lambda record: f"hydrated:{record}") is None
+    assert hydrate_optional("record", lambda record: f"hydrated:{record}") == "hydrated:record"
+    assert hydrate_sequence(["a", "b"], lambda record: record.upper()) == ["A", "B"]
+    assert hydrate_mapping({"a": "one", "b": "two"}, lambda record: record.upper()) == {"a": "ONE", "b": "TWO"}
+
+
+@pytest.mark.asyncio
+async def test_repository_product_profile_reads_build_typed_queries() -> None:
+    queries = SimpleNamespace(
+        get_session_profile=AsyncMock(return_value="record"),
+        get_session_profiles_batch=AsyncMock(return_value={"conv-1": "record-a"}),
+        _list_session_profiles_query=AsyncMock(return_value=["record-a", "record-b"]),
+    )
+
+    class _Repo(RepositoryProductProfileReadMixin):
+        def __init__(self, queries: object) -> None:
+            self.queries = queries
+
+    repo = _Repo(queries)
+
+    with patch(
+        "polylogue.storage.repository_product_profile_reads.hydrate_session_profile",
+        side_effect=lambda record: f"profile:{record}",
+    ):
+        assert await repo.get_session_profile_record("conv-1") == "record"
+        assert await repo.get_session_profile("conv-1") == "profile:record"
+        assert await repo.get_session_profiles_batch(["conv-1"]) == {"conv-1": "profile:record-a"}
+        assert await repo.list_session_profiles(
+            provider="claude-code",
+            since="2026-01-01",
+            until="2026-01-02",
+            first_message_since="2026-01-01T00:00:00Z",
+            first_message_until="2026-01-02T00:00:00Z",
+            session_date_since="2026-01-01",
+            session_date_until="2026-01-02",
+            tier="evidence",
+            limit=5,
+            offset=2,
+            query="refactor",
+        ) == ["profile:record-a", "profile:record-b"]
+        assert await repo.list_session_profile_records(query="refactor") == ["record-a", "record-b"]
+        assert await repo.get_session_enrichment_record("conv-1") == "record"
+        assert await repo.list_session_enrichment_records(query="enrichment") == ["record-a", "record-b"]
+
+    list_query = queries._list_session_profiles_query.await_args_list[0].args[0]
+    assert list_query.provider == "claude-code"
+    assert list_query.first_message_since == "2026-01-01T00:00:00Z"
+    assert list_query.session_date_until == "2026-01-02"
+    assert list_query.tier == "evidence"
+    assert list_query.limit == 5
+    assert list_query.offset == 2
+    assert list_query.query == "refactor"
+
+    enrichment_query = queries._list_session_profiles_query.await_args_list[-1].args[0]
+    assert enrichment_query.tier == "enrichment"
+    assert enrichment_query.query == "enrichment"
+
+
+@pytest.mark.asyncio
+async def test_repository_product_thread_and_timeline_reads_build_typed_queries() -> None:
+    queries = SimpleNamespace(
+        get_work_thread=AsyncMock(return_value="thread-record"),
+        _list_work_threads_query=AsyncMock(return_value=["thread-record"]),
+        get_session_work_events=AsyncMock(return_value=["event-record"]),
+        get_session_phases=AsyncMock(return_value=["phase-record"]),
+        _list_session_work_events_query=AsyncMock(return_value=["event-record"]),
+        _list_session_phases_query=AsyncMock(return_value=["phase-record"]),
+    )
+
+    class _Repo(RepositoryProductThreadReadMixin, RepositoryProductTimelineReadMixin):
+        def __init__(self, queries: object) -> None:
+            self.queries = queries
+
+    repo = _Repo(queries)
+
+    with (
+        patch(
+            "polylogue.storage.repository_product_thread_reads.hydrate_work_thread",
+            side_effect=lambda record: f"thread:{record}",
+        ),
+        patch(
+            "polylogue.storage.repository_product_timeline_reads.hydrate_work_event",
+            side_effect=lambda record: f"event:{record}",
+        ),
+        patch(
+            "polylogue.storage.repository_product_timeline_reads.hydrate_session_phase",
+            side_effect=lambda record: f"phase:{record}",
+        ),
+    ):
+        assert await repo.get_work_thread_record("thread-1") == "thread-record"
+        assert await repo.get_work_thread("thread-1") == "thread:thread-record"
+        assert await repo.list_work_threads(
+            since="2026-01-01", until="2026-01-02", limit=3, offset=1, query="repo"
+        ) == ["thread:thread-record"]
+        assert await repo.list_work_thread_records(query="repo") == ["thread-record"]
+
+        assert await repo.get_session_work_event_records("conv-1") == ["event-record"]
+        assert await repo.get_session_phase_records("conv-1") == ["phase-record"]
+        assert await repo.get_session_work_events("conv-1") == ["event:event-record"]
+        assert await repo.get_session_phases("conv-1") == ["phase:phase-record"]
+        assert await repo.list_session_work_events(
+            conversation_id="conv-1",
+            provider="claude-code",
+            since="2026-01-01",
+            until="2026-01-02",
+            kind="implementation",
+            limit=4,
+            offset=2,
+            query="editor",
+        ) == ["event:event-record"]
+        assert await repo.list_session_work_event_records(query="editor") == ["event-record"]
+        assert await repo.list_session_phases(
+            conversation_id="conv-1",
+            provider="claude-code",
+            since="2026-01-01",
+            until="2026-01-02",
+            kind="planning",
+            limit=2,
+            offset=1,
+        ) == ["phase:phase-record"]
+        assert await repo.list_session_phase_records(kind="planning") == ["phase-record"]
+
+    work_thread_query = queries._list_work_threads_query.await_args_list[0].args[0]
+    assert work_thread_query.since == "2026-01-01"
+    assert work_thread_query.offset == 1
+    assert work_thread_query.query == "repo"
+
+    timeline_query = queries._list_session_work_events_query.await_args_list[0].args[0]
+    assert timeline_query.conversation_id == "conv-1"
+    assert timeline_query.provider == "claude-code"
+    assert timeline_query.kind == "implementation"
+    assert timeline_query.query == "editor"
+
+
+@pytest.mark.asyncio
+async def test_repository_product_summary_reads_build_typed_queries() -> None:
+    queries = SimpleNamespace(
+        _list_session_tag_rollup_rows_query=AsyncMock(return_value=["tag-row"]),
+        _list_day_session_summaries_query=AsyncMock(return_value=["day-row"]),
+    )
+
+    class _Repo(RepositoryProductSummaryReadMixin):
+        def __init__(self, queries: object) -> None:
+            self.queries = queries
+
+    repo = _Repo(queries)
+
+    assert await repo.list_session_tag_rollup_records(
+        provider="claude-code",
+        since="2026-01-01",
+        until="2026-01-02",
+        query="tag",
+    ) == ["tag-row"]
+    assert await repo.list_day_session_summary_records(
+        provider="claude-code",
+        since="2026-01-01",
+        until="2026-01-02",
+    ) == ["day-row"]
+
+    tag_query = queries._list_session_tag_rollup_rows_query.await_args.args[0]
+    day_query = queries._list_day_session_summaries_query.await_args.args[0]
+    assert tag_query.provider == "claude-code"
+    assert tag_query.query == "tag"
+    assert day_query.provider == "claude-code"
+    assert day_query.until == "2026-01-02"
+
+
+class _ConnectionContext:
+    def __init__(self, conn: object) -> None:
+        self._conn = conn
+
+    async def __aenter__(self) -> object:
+        return self._conn
+
+    async def __aexit__(self, exc_type: object, exc: object, tb: object) -> bool:
+        return False
+
+
+class _Backend:
+    def __init__(self, conn: object) -> None:
+        self._conn = conn
+        self.transaction_depth = 7
+
+    def connection(self) -> _ConnectionContext:
+        return _ConnectionContext(self._conn)
+
+
+async def _aiter(items: list[object]) -> AsyncIterator[object]:
+    for item in items:
+        yield item
+
+
+@pytest.mark.asyncio
+async def test_repository_raw_forwards_query_and_mutation_calls() -> None:
+    conn = object()
+
+    class _Repo(RepositoryRawMixin):
+        def __init__(self, backend: object) -> None:
+            self._backend = backend
+
+    repo = _Repo(_Backend(conn))
+
+    with (
+        patch(
+            "polylogue.storage.repository_raw.raw_queries.save_raw_conversation", new=AsyncMock(return_value=True)
+        ) as mock_save_raw,
+        patch(
+            "polylogue.storage.repository_raw.artifacts_q.save_artifact_observation", new=AsyncMock(return_value=True)
+        ) as mock_save_artifact,
+        patch(
+            "polylogue.storage.repository_raw.raw_queries.get_raw_conversation",
+            new=AsyncMock(return_value="raw-record"),
+        ) as mock_get_raw,
+        patch(
+            "polylogue.storage.repository_raw.raw_queries.apply_raw_state_update", new=AsyncMock()
+        ) as mock_update_state,
+        patch("polylogue.storage.repository_raw.raw_queries.mark_raw_parsed", new=AsyncMock()) as mock_mark_parsed,
+        patch(
+            "polylogue.storage.repository_raw.raw_queries.mark_raw_validated", new=AsyncMock()
+        ) as mock_mark_validated,
+        patch(
+            "polylogue.storage.repository_raw.raw_queries.get_known_source_mtimes",
+            new=AsyncMock(return_value={"inbox": "1"}),
+        ) as mock_mtimes,
+        patch(
+            "polylogue.storage.repository_raw.raw_queries.reset_parse_status", new=AsyncMock(return_value=3)
+        ) as mock_reset_parse,
+        patch(
+            "polylogue.storage.repository_raw.raw_queries.reset_validation_status", new=AsyncMock(return_value=4)
+        ) as mock_reset_validation,
+        patch(
+            "polylogue.storage.repository_raw.raw_queries.get_raw_conversations_batch",
+            new=AsyncMock(return_value=["a"]),
+        ) as mock_batch,
+        patch(
+            "polylogue.storage.repository_raw.raw_queries.get_raw_blob_sizes", new=AsyncMock(return_value=[("a", 12)])
+        ) as mock_blob_sizes,
+        patch(
+            "polylogue.storage.repository_raw.raw_queries.get_raw_conversation_states",
+            new=AsyncMock(return_value={"a": "state"}),
+        ) as mock_states,
+        patch(
+            "polylogue.storage.repository_raw.raw_queries.get_raw_conversation_count", new=AsyncMock(return_value=9)
+        ) as mock_count,
+    ):
+        assert await repo.save_raw_conversation("record") is True
+        assert await repo.save_artifact_observation("artifact") is True
+        assert await repo.get_raw_conversation("raw-1") == "raw-record"
+        await repo.update_raw_state("raw-1", state="state-update")
+        await repo.mark_raw_parsed("raw-1", error="boom", payload_provider="chatgpt")
+        await repo.mark_raw_validated(
+            "raw-1",
+            status="error",
+            error="boom",
+            drift_count=2,
+            provider="chatgpt",
+            mode="strict",
+            payload_provider="chatgpt",
+        )
+        assert await repo.get_known_source_mtimes() == {"inbox": "1"}
+        assert await repo.reset_parse_status(provider="chatgpt", source_names=["inbox"]) == 3
+        assert await repo.reset_validation_status(provider="chatgpt", source_names=["inbox"]) == 4
+        assert await repo.get_raw_conversations_batch(["raw-1"]) == ["a"]
+        assert await repo.get_raw_blob_sizes(["raw-1"]) == [("a", 12)]
+        assert await repo.get_raw_conversation_states(["raw-1"]) == {"a": "state"}
+        assert await repo.get_raw_conversation_count("chatgpt") == 9
+
+    mock_save_raw.assert_awaited_once_with(conn, "record", 7)
+    mock_save_artifact.assert_awaited_once_with(conn, "artifact", 7)
+    mock_get_raw.assert_awaited_once_with(conn, "raw-1")
+    mock_update_state.assert_awaited_once_with(conn, "raw-1", state="state-update", transaction_depth=7)
+    mock_mark_parsed.assert_awaited_once_with(
+        conn,
+        "raw-1",
+        error="boom",
+        payload_provider="chatgpt",
+        transaction_depth=7,
+    )
+    mock_mark_validated.assert_awaited_once_with(
+        conn,
+        "raw-1",
+        status="error",
+        error="boom",
+        drift_count=2,
+        provider="chatgpt",
+        mode="strict",
+        payload_provider="chatgpt",
+        transaction_depth=7,
+    )
+    mock_mtimes.assert_awaited_once_with(conn)
+    mock_reset_parse.assert_awaited_once_with(conn, provider="chatgpt", source_names=["inbox"], transaction_depth=7)
+    mock_reset_validation.assert_awaited_once_with(
+        conn,
+        provider="chatgpt",
+        source_names=["inbox"],
+        transaction_depth=7,
+    )
+    mock_batch.assert_awaited_once_with(conn, ["raw-1"])
+    mock_blob_sizes.assert_awaited_once_with(conn, ["raw-1"])
+    mock_states.assert_awaited_once_with(conn, ["raw-1"])
+    mock_count.assert_awaited_once_with(conn, provider="chatgpt")
+
+
+@pytest.mark.asyncio
+async def test_repository_raw_streams_iterators() -> None:
+    conn = object()
+
+    class _Repo(RepositoryRawMixin):
+        def __init__(self, backend: object) -> None:
+            self._backend = backend
+
+    repo = _Repo(_Backend(conn))
+
+    with (
+        patch(
+            "polylogue.storage.repository_raw.raw_queries.iter_raw_conversations",
+            return_value=_aiter(["raw-a", "raw-b"]),
+        ) as mock_iter_raw,
+        patch(
+            "polylogue.storage.repository_raw.raw_queries.iter_raw_headers",
+            return_value=_aiter([("raw-a", 1), ("raw-b", 2)]),
+        ) as mock_iter_headers,
+    ):
+        conversations = [record async for record in repo.iter_raw_conversations(provider="chatgpt", limit=2)]
+        headers = [
+            header
+            async for header in repo.iter_raw_headers(
+                source_names=["inbox"],
+                provider_name="chatgpt",
+                require_unparsed=True,
+                require_unvalidated=True,
+                validation_statuses=["error"],
+                page_size=50,
+            )
+        ]
+
+    assert conversations == ["raw-a", "raw-b"]
+    assert headers == [("raw-a", 1), ("raw-b", 2)]
+    mock_iter_raw.assert_called_once_with(conn, provider="chatgpt", limit=2)
+    mock_iter_headers.assert_called_once_with(
+        conn,
+        source_names=["inbox"],
+        provider_name="chatgpt",
+        require_unparsed=True,
+        require_unvalidated=True,
+        validation_statuses=["error"],
+        page_size=50,
+    )

--- a/tests/unit/ui/test_facade_console_runtime.py
+++ b/tests/unit/ui/test_facade_console_runtime.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from rich.errors import MarkupError
+from rich.table import Table
+from rich.text import Text
+
+from polylogue.ui.facade_console import PlainConsole, _render_plain_object
+
+
+def test_render_plain_object_handles_text_markup_tables_and_fallbacks() -> None:
+    table = Table()
+    table.add_column("Name")
+    table.add_row("Value")
+
+    assert _render_plain_object(Text("hello")) == "hello"
+    assert _render_plain_object("[bold]hello[/bold]") == "hello"
+    with patch("polylogue.ui.facade_console.Text.from_markup", side_effect=MarkupError("boom")):
+        assert _render_plain_object("[broken") == "[broken"
+    assert "Name" in _render_plain_object(table)
+    assert _render_plain_object(123) == "123"
+
+
+def test_plain_console_print_renders_space_joined_plain_values() -> None:
+    console = PlainConsole()
+
+    with patch("builtins.print") as mock_print:
+        console.print(Text("hello"), "[bold]world[/bold]", 123)
+
+    mock_print.assert_called_once_with("hello world 123")


### PR DESCRIPTION
## Summary
Raise the repository coverage floor from 88% to 89% after a broader direct
runtime test tranche that pushes the measured suite to 89.46% total coverage.

## Problem
Issue #197 tracks the return from the temporary 80% floor back to an honest 90%.
After #386 the gate measured 88.24%, which was enough to justify 88 but not 89.
The next raise needed to do more than scrape the next integer: it needed to
cover the remaining active operator surface with headroom, especially showcase
QA workflow/control seams, sync/read wrappers, and runtime helper modules that
still distorted the floor despite being part of normal usage.

## Solution
This tranche broadened the target package map before touching code and then
added owning-module runtime tests across the remaining operator-facing surface:

- showcase QA workflow, stage dispatch, catalog loading, invariants, reporting,
  and runner support
- sync conversation/product query wrappers and repository product/raw reads
- product registry dispatch and facade product seams
- CLI/MCP operator helpers and plain-console rendering support
- version/runtime metadata helpers and a small remaining root/runtime tail

The floor in `pyproject.toml` now moves from 88 to 89 only after the full
coverage gate cleared with margin.

Ref #197

## Verification
- `pytest -q tests/unit/showcase/test_catalog_loader_runtime.py tests/unit/showcase/test_invariants_runtime.py tests/unit/showcase/test_operator_reporting_runtime.py tests/unit/showcase/test_qa_runner_stages_runtime.py tests/unit/showcase/test_qa_workflow_runtime.py tests/unit/showcase/test_showcase_runner_support_runtime.py`
  - `50 passed`
- `pytest -q tests/unit/core/test_product_registry_runtime.py tests/unit/core/test_sync_surface_runtime.py tests/unit/core/test_version_runtime.py tests/unit/storage/test_repository_product_runtime.py`
  - `26 passed`
- `pytest -q tests/unit/cli/test_operator_support_runtime.py tests/unit/mcp/test_server_runtime.py`
  - `18 passed`
- `pytest -q tests/unit/ui/test_facade_console_runtime.py tests/unit/core/test_version_runtime.py tests/unit/mcp/test_server_runtime.py tests/unit/showcase/test_operator_reporting_runtime.py`
  - `20 passed`
- `devtools coverage-gate`
  - `5583 passed in 311.67s`
  - `TOTAL ... 89.46%`
- `devtools verify --quick`
  - `verify: all checks passed`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive runtime test suites covering operator support, product registry, sync surface, versioning, MCP server, showcase catalog, invariants, operator reporting, QA workflows, and repository operations.

* **Chores**
  * Increased code coverage threshold to 89%.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->