### PR TITLE
feat: add shared content projection surface

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -99,6 +99,13 @@ Options:
   --transform [strip-tools|strip-thinking|strip-all]
                                   Remove content: strip-tools (tool calls),
                                   strip-thinking (reasoning), strip-all (both)
+  --no-code-blocks                Exclude fenced and structured code blocks
+                                  from output
+  --no-tool-calls                 Exclude tool invocation records from output
+  --no-tool-outputs               Exclude tool-result payloads from output
+  --no-file-reads                 Exclude file-read payloads while keeping
+                                  other tool output
+  --prose-only                    Show only authored prose text
   --stream                        Stream output (low memory). Requires
                                   --latest or -i ID. Incompatible with
                                   --transform

--- a/polylogue/cli/click_app.py
+++ b/polylogue/cli/click_app.py
@@ -93,6 +93,11 @@ def cli(
     output: str | None,
     output_format: str | None,
     transform: str | None,
+    no_code_blocks: bool,
+    no_tool_calls: bool,
+    no_tool_outputs: bool,
+    no_file_reads: bool,
+    prose_only: bool,
     # Streaming
     stream: bool,
     dialogue_only: bool,

--- a/polylogue/cli/click_option_groups.py
+++ b/polylogue/cli/click_option_groups.py
@@ -184,6 +184,11 @@ OUTPUT_OPTION_DECORATORS: tuple[Callable[[ClickCallable], ClickCallable], ...] =
         type=click.Choice(["strip-tools", "strip-thinking", "strip-all"]),
         help="Remove content: strip-tools (tool calls), strip-thinking (reasoning), strip-all (both)",
     ),
+    click.option("--no-code-blocks", is_flag=True, help="Exclude fenced and structured code blocks from output"),
+    click.option("--no-tool-calls", is_flag=True, help="Exclude tool invocation records from output"),
+    click.option("--no-tool-outputs", is_flag=True, help="Exclude tool-result payloads from output"),
+    click.option("--no-file-reads", is_flag=True, help="Exclude file-read payloads while keeping other tool output"),
+    click.option("--prose-only", is_flag=True, help="Show only authored prose text"),
 )
 
 STREAMING_OPTION_DECORATORS: tuple[Callable[[ClickCallable], ClickCallable], ...] = (

--- a/polylogue/cli/query.py
+++ b/polylogue/cli/query.py
@@ -258,6 +258,8 @@ def project_query_results(results: list[Conversation], plan: QueryExecutionPlan)
     message_roles = plan.output.effective_message_roles()
     if message_roles:
         projected = [conversation.with_roles(message_roles) for conversation in projected]
+    if plan.output.filters_content():
+        projected = [conversation.with_content_projection(plan.output.content_projection) for conversation in projected]
     return projected
 
 
@@ -465,6 +467,7 @@ async def async_execute_query_request(env: AppEnv, request: RootModeRequest) -> 
             output_format=plan.output.stream_format(),
             dialogue_only=plan.output.dialogue_only,
             message_roles=plan.output.effective_message_roles(),
+            content_projection=plan.output.content_projection if plan.output.filters_content() else None,
             message_limit=message_limit,
         )
         return

--- a/polylogue/cli/query_contracts.py
+++ b/polylogue/cli/query_contracts.py
@@ -9,6 +9,7 @@ from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal, TypeAlias
 
+from polylogue.lib.content_projection import ContentProjectionSpec
 from polylogue.lib.message_roles import MessageRoleFilter, normalize_message_roles
 from polylogue.lib.query_spec import ConversationQuerySpec
 from polylogue.lib.roles import Role
@@ -82,9 +83,10 @@ class QueryOutputSpec:
     fields: str | None
     dialogue_only: bool
     message_roles: MessageRoleFilter
-    transform: QueryTransform
-    list_mode: bool
-    print_path: bool
+    transform: QueryTransform = None
+    list_mode: bool = False
+    print_path: bool = False
+    content_projection: ContentProjectionSpec = ContentProjectionSpec()
 
     @classmethod
     def from_params(cls, params: Mapping[str, object]) -> QueryOutputSpec:
@@ -98,6 +100,7 @@ class QueryOutputSpec:
             fields=str(params["fields"]) if params.get("fields") is not None else None,
             dialogue_only=bool(params.get("dialogue_only", False)),
             message_roles=normalize_message_roles(params.get("message_role") or params.get("message_roles")),
+            content_projection=ContentProjectionSpec.from_params(params),
             transform=str(params["transform"]) if params.get("transform") is not None else None,
             list_mode=bool(params.get("list_mode", False)),
             print_path=bool(params.get("print_path", False)),
@@ -122,6 +125,9 @@ class QueryOutputSpec:
 
     def filters_messages(self) -> bool:
         return bool(self.effective_message_roles())
+
+    def filters_content(self) -> bool:
+        return self.content_projection.filters_content()
 
 
 @dataclass(frozen=True, slots=True)
@@ -232,6 +238,7 @@ class QueryExecutionPlan:
             and self.output.list_mode
             and self.output.transform is None
             and not self.output.filters_messages()
+            and not self.output.filters_content()
         )
 
     def prefers_summary_stats(self) -> bool:

--- a/polylogue/cli/query_output.py
+++ b/polylogue/cli/query_output.py
@@ -36,6 +36,7 @@ from polylogue.cli.query_stats import (
     output_stats_by_summaries,
     output_stats_sql,
 )
+from polylogue.lib.content_projection import ContentProjectionSpec, coerce_content_projection_spec
 from polylogue.lib.json import JSONDocument
 from polylogue.lib.message_roles import MessageRoleFilter, message_role_count_key, message_role_labels
 from polylogue.lib.roles import Role
@@ -698,6 +699,7 @@ async def stream_conversation(
     output_format: str = "plaintext",
     dialogue_only: bool = False,
     message_roles: MessageRoleFilter = (),
+    content_projection: ContentProjectionSpec | None = None,
     message_limit: int | None = None,
 ) -> int:
     """Stream conversation messages to stdout without buffering."""
@@ -709,6 +711,7 @@ async def stream_conversation(
 
     stats = await repo.get_conversation_stats(conversation_id)
     effective_roles = message_roles or (DIALOGUE_MESSAGE_ROLES if dialogue_only else ())
+    projection_spec = coerce_content_projection_spec(content_projection)
     sys.stdout.write(
         render_stream_header(
             conversation_id=conversation_id,
@@ -725,17 +728,32 @@ async def stream_conversation(
     sys.stdout.flush()
 
     count = 0
-    async for message in repo.iter_messages(
-        conversation_id,
-        dialogue_only=dialogue_only,
-        message_roles=effective_roles,
-        limit=message_limit,
-    ):
-        chunk = render_stream_message(message, output_format)
-        if chunk:
-            sys.stdout.write(chunk)
-            count += 1
-        sys.stdout.flush()
+    if projection_spec.filters_content():
+        conversation = await repo.get(conversation_id)
+        if conversation is None:
+            click.echo(f"Conversation not found: {conversation_id}", err=True)
+            raise SystemExit(1)
+        if effective_roles:
+            conversation = conversation.with_roles(effective_roles)
+        conversation = conversation.with_content_projection(projection_spec)
+        for message in list(conversation.messages)[: message_limit if message_limit is not None else None]:
+            chunk = render_stream_message(message, output_format)
+            if chunk:
+                sys.stdout.write(chunk)
+                count += 1
+            sys.stdout.flush()
+    else:
+        async for message in repo.iter_messages(
+            conversation_id,
+            dialogue_only=dialogue_only,
+            message_roles=effective_roles,
+            limit=message_limit,
+        ):
+            chunk = render_stream_message(message, output_format)
+            if chunk:
+                sys.stdout.write(chunk)
+                count += 1
+            sys.stdout.flush()
 
     sys.stdout.write(render_stream_footer(output_format=output_format, emitted_messages=count))
     sys.stdout.flush()

--- a/polylogue/facade_archive.py
+++ b/polylogue/facade_archive.py
@@ -12,6 +12,7 @@ from polylogue.archive_products import (
     SessionProfileProduct,
     SessionProfileProductQuery,
 )
+from polylogue.lib.content_projection import ContentProjectionSpec
 from polylogue.storage.session_product_runtime import SessionProductStatusSnapshot
 
 if TYPE_CHECKING:
@@ -28,15 +29,26 @@ if TYPE_CHECKING:
     from polylogue.storage.session_product_runtime import SessionProductCounts
 
     class _ArchiveOperationsSurface(Protocol):
-        async def get_conversation(self, conversation_id: str) -> Conversation | None: ...
+        async def get_conversation(
+            self,
+            conversation_id: str,
+            *,
+            content_projection: ContentProjectionSpec | None = None,
+        ) -> Conversation | None: ...
 
-        async def get_conversations(self, conversation_ids: list[str]) -> list[Conversation]: ...
+        async def get_conversations(
+            self,
+            conversation_ids: list[str],
+            *,
+            content_projection: ContentProjectionSpec | None = None,
+        ) -> list[Conversation]: ...
 
         async def list_conversations(
             self,
             *,
             provider: str | None = None,
             limit: int | None = None,
+            content_projection: ContentProjectionSpec | None = None,
         ) -> list[Conversation]: ...
 
         async def search(
@@ -109,20 +121,32 @@ class PolylogueArchiveMixin:
         @property
         def repository(self) -> ConversationRepository: ...
 
-    async def get_conversation(self, conversation_id: str) -> Conversation | None:
-        return await self.operations.get_conversation(conversation_id)
+    async def get_conversation(
+        self,
+        conversation_id: str,
+        *,
+        content_projection: ContentProjectionSpec | None = None,
+    ) -> Conversation | None:
+        return await self.operations.get_conversation(conversation_id, content_projection=content_projection)
 
-    async def get_conversations(self, conversation_ids: list[str]) -> list[Conversation]:
-        return await self.operations.get_conversations(conversation_ids)
+    async def get_conversations(
+        self,
+        conversation_ids: list[str],
+        *,
+        content_projection: ContentProjectionSpec | None = None,
+    ) -> list[Conversation]:
+        return await self.operations.get_conversations(conversation_ids, content_projection=content_projection)
 
     async def list_conversations(
         self,
         provider: str | None = None,
         limit: int | None = None,
+        content_projection: ContentProjectionSpec | None = None,
     ) -> list[Conversation]:
         return await self.operations.list_conversations(
             provider=provider,
             limit=limit,
+            content_projection=content_projection,
         )
 
     async def search(

--- a/polylogue/lib/__init__.py
+++ b/polylogue/lib/__init__.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from polylogue.lib.attachment_models import Attachment
     from polylogue.lib.branch_type import BranchType
+    from polylogue.lib.content_projection import ContentKind, ContentProjectionSpec
     from polylogue.lib.conversation_models import Conversation
     from polylogue.lib.message_models import DialoguePair, Message
     from polylogue.lib.messages import MessageCollection
@@ -21,6 +22,8 @@ def __getattr__(name: str) -> object:
     lazy_exports = {
         "Attachment": ("polylogue.lib.attachment_models", "Attachment"),
         "BranchType": ("polylogue.lib.branch_type", "BranchType"),
+        "ContentKind": ("polylogue.lib.content_projection", "ContentKind"),
+        "ContentProjectionSpec": ("polylogue.lib.content_projection", "ContentProjectionSpec"),
         "Conversation": ("polylogue.lib.conversation_models", "Conversation"),
         "ConversationProjection": ("polylogue.lib.projections", "ConversationProjection"),
         "DialoguePair": ("polylogue.lib.message_models", "DialoguePair"),
@@ -39,6 +42,8 @@ def __getattr__(name: str) -> object:
 __all__ = [
     "Attachment",
     "BranchType",
+    "ContentKind",
+    "ContentProjectionSpec",
     "Conversation",
     "ConversationProjection",
     "DialoguePair",

--- a/polylogue/lib/content_projection.py
+++ b/polylogue/lib/content_projection.py
@@ -1,0 +1,326 @@
+"""Shared content-kind projection for conversation/message output surfaces."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, replace
+from enum import Enum
+from typing import TYPE_CHECKING
+
+from polylogue.lib.messages import MessageCollection
+from polylogue.lib.roles import Role
+
+if TYPE_CHECKING:
+    from polylogue.lib.conversation_models import Conversation
+    from polylogue.lib.message_models import Message
+
+
+class ContentKind(str, Enum):
+    """Canonical projected content kinds for rendered/query output."""
+
+    PROSE = "prose"
+    CODE = "code"
+    TOOL_CALL = "tool_call"
+    TOOL_OUTPUT = "tool_output"
+    FILE_READ = "file_read"
+    REASONING = "reasoning"
+    SYSTEM_NOISE = "system_noise"
+    ATTACHMENT = "attachment"
+
+
+@dataclass(frozen=True, slots=True)
+class ContentProjectionSpec:
+    """Shared output projection controls for conversation content."""
+
+    include_prose: bool = True
+    include_code: bool = True
+    include_tool_calls: bool = True
+    include_tool_outputs: bool = True
+    include_file_reads: bool = True
+    include_reasoning: bool = True
+    include_system_noise: bool = True
+    include_attachments: bool = True
+
+    @classmethod
+    def prose_only(cls) -> ContentProjectionSpec:
+        return cls(
+            include_code=False,
+            include_tool_calls=False,
+            include_tool_outputs=False,
+            include_file_reads=False,
+            include_reasoning=False,
+            include_system_noise=False,
+            include_attachments=False,
+        )
+
+    @classmethod
+    def from_params(cls, params: Mapping[str, object]) -> ContentProjectionSpec:
+        spec = cls.prose_only() if bool(params.get("prose_only")) else cls()
+        if params.get("no_code_blocks"):
+            spec = replace(spec, include_code=False)
+        if params.get("no_tool_calls"):
+            spec = replace(spec, include_tool_calls=False)
+        if params.get("no_tool_outputs"):
+            spec = replace(spec, include_tool_outputs=False)
+        if params.get("no_file_reads"):
+            spec = replace(spec, include_file_reads=False)
+        return spec
+
+    def is_default(self) -> bool:
+        return self == type(self)()
+
+    def filters_content(self) -> bool:
+        return not self.is_default()
+
+
+@dataclass(frozen=True, slots=True)
+class _Segment:
+    kind: ContentKind
+    text: str | None
+    block: dict[str, object] | None = None
+
+
+_CODE_FENCE_PATTERN = re.compile(r"```(?P<lang>[^\n`]*)\n?(?P<code>.*?)```", re.DOTALL)
+_THINKING_PATTERN = re.compile(r"<(?:antml:)?thinking>(?P<thinking>.*?)</(?:antml:)?thinking>", re.DOTALL)
+
+
+def coerce_content_projection_spec(
+    value: ContentProjectionSpec | Mapping[str, object] | None,
+) -> ContentProjectionSpec:
+    if value is None:
+        return ContentProjectionSpec()
+    if isinstance(value, ContentProjectionSpec):
+        return value
+    return ContentProjectionSpec.from_params(value)
+
+
+def project_conversation_content(
+    conversation: Conversation,
+    projection: ContentProjectionSpec | Mapping[str, object] | None,
+) -> Conversation:
+    """Return a conversation with content-kind projection applied."""
+    spec = coerce_content_projection_spec(projection)
+    if spec.is_default():
+        return conversation
+
+    tool_semantics = _tool_semantics_by_id(list(conversation.messages))
+    projected_messages = [
+        projected
+        for message in conversation.messages
+        if (projected := _project_message_content(message, spec, tool_semantics)) is not None
+    ]
+    return conversation.model_copy(update={"messages": MessageCollection(messages=projected_messages)})
+
+
+def _tool_semantics_by_id(messages: Sequence[Message]) -> dict[str, str]:
+    semantics: dict[str, str] = {}
+    for message in messages:
+        for block in message.content_blocks:
+            if block.get("type") != "tool_use":
+                continue
+            tool_id = block.get("tool_id") or block.get("id")
+            semantic_type = block.get("semantic_type")
+            if isinstance(tool_id, str) and tool_id and isinstance(semantic_type, str) and semantic_type:
+                semantics[tool_id] = semantic_type
+    return semantics
+
+
+def _project_message_content(
+    message: Message,
+    spec: ContentProjectionSpec,
+    tool_semantics: Mapping[str, str],
+) -> Message | None:
+    segments = _segments_for_message(message, tool_semantics)
+    kept_segments = [segment for segment in segments if _keep_segment(segment, spec)]
+    kept_blocks = [dict(segment.block) for segment in kept_segments if segment.block is not None]
+    projected_text = _render_segments_text(kept_segments)
+    projected_attachments = list(message.attachments) if spec.include_attachments else []
+
+    if not projected_text and not kept_blocks and not projected_attachments:
+        return None
+
+    return message.model_copy(
+        update={
+            "text": projected_text or None,
+            "content_blocks": kept_blocks,
+            "attachments": projected_attachments,
+        }
+    )
+
+
+def _segments_for_message(
+    message: Message,
+    tool_semantics: Mapping[str, str],
+) -> list[_Segment]:
+    if message.content_blocks:
+        return _segments_from_blocks(message.content_blocks, tool_semantics)
+    return _segments_from_text(message)
+
+
+def _segments_from_blocks(
+    blocks: Sequence[Mapping[str, object]],
+    tool_semantics: Mapping[str, str],
+) -> list[_Segment]:
+    segments: list[_Segment] = []
+    for raw_block in blocks:
+        block = dict(raw_block)
+        block_type = str(block.get("type") or "text")
+        if block_type == "text":
+            segments.append(_Segment(ContentKind.PROSE, _block_text(block), block=block))
+            continue
+        if block_type == "code":
+            segments.append(_Segment(ContentKind.CODE, _block_text(block), block=block))
+            continue
+        if block_type == "thinking":
+            segments.append(_Segment(ContentKind.REASONING, _block_text(block), block=block))
+            continue
+        if block_type == "tool_use":
+            segments.append(_Segment(ContentKind.TOOL_CALL, _tool_call_text(block), block=block))
+            continue
+        if block_type == "tool_result":
+            tool_id = block.get("tool_id") or block.get("tool_use_id") or block.get("id")
+            semantic_type = tool_semantics.get(str(tool_id), "")
+            kind = ContentKind.FILE_READ if semantic_type == "file_read" else ContentKind.TOOL_OUTPUT
+            segments.append(_Segment(kind, _tool_result_text(block), block=block))
+            continue
+        if block_type in {"image", "document", "file"}:
+            segments.append(_Segment(ContentKind.ATTACHMENT, _attachment_text(block), block=block))
+            continue
+        segments.append(_Segment(ContentKind.PROSE, _block_text(block), block=block))
+    return segments
+
+
+def _segments_from_text(message: Message) -> list[_Segment]:
+    text = (message.text or "").strip()
+    if not text:
+        return []
+    if message.role == Role.TOOL or message.is_tool_use:
+        return [_Segment(ContentKind.TOOL_OUTPUT, text)]
+    if message.is_context_dump or message.is_system:
+        return [_Segment(ContentKind.SYSTEM_NOISE, text)]
+
+    segments: list[_Segment] = []
+    cursor = 0
+    for match in _CODE_FENCE_PATTERN.finditer(text):
+        segments.extend(_segments_from_noncode_text(text[cursor : match.start()]))
+        code = (match.group("code") or "").strip()
+        if code:
+            segments.append(_Segment(ContentKind.CODE, code))
+        cursor = match.end()
+    segments.extend(_segments_from_noncode_text(text[cursor:]))
+
+    if segments:
+        return segments
+
+    if message.is_thinking:
+        thinking = message.extract_thinking()
+        if thinking:
+            return [_Segment(ContentKind.REASONING, thinking)]
+    return [_Segment(ContentKind.PROSE, text)]
+
+
+def _segments_from_noncode_text(text: str) -> list[_Segment]:
+    stripped = text.strip()
+    if not stripped:
+        return []
+
+    segments: list[_Segment] = []
+    cursor = 0
+    for match in _THINKING_PATTERN.finditer(text):
+        prose = text[cursor : match.start()].strip()
+        if prose:
+            segments.append(_Segment(ContentKind.PROSE, prose))
+        thinking = (match.group("thinking") or "").strip()
+        if thinking:
+            segments.append(_Segment(ContentKind.REASONING, thinking))
+        cursor = match.end()
+    tail = text[cursor:].strip()
+    if tail:
+        segments.append(_Segment(ContentKind.PROSE, tail))
+    return segments
+
+
+def _block_text(block: Mapping[str, object]) -> str | None:
+    for key in ("text", "code", "content", "thinking"):
+        value = block.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def _tool_call_text(block: Mapping[str, object]) -> str:
+    name = block.get("tool_name") or block.get("name") or "unknown"
+    summary = _tool_input_summary(block.get("tool_input") or block.get("input"))
+    return f"[Tool: {name}] {summary}".strip()
+
+
+def _tool_result_text(block: Mapping[str, object]) -> str | None:
+    return _block_text(block)
+
+
+def _attachment_text(block: Mapping[str, object]) -> str:
+    name = block.get("name") or block.get("title") or block.get("type") or "attachment"
+    url = block.get("url")
+    mime = block.get("media_type") or block.get("mime_type")
+    parts = [str(name)]
+    if isinstance(url, str) and url:
+        parts.append(url)
+    if isinstance(mime, str) and mime:
+        parts.append(f"({mime})")
+    return " ".join(parts)
+
+
+def _tool_input_summary(value: object) -> str:
+    if not isinstance(value, Mapping):
+        return ""
+    path = value.get("file_path") or value.get("path") or value.get("file")
+    if path:
+        return f"`{path}`"
+    command = value.get("command")
+    if isinstance(command, str) and command:
+        return f"`{command[:77]}...`" if len(command) > 80 else f"`{command}`"
+    pattern = value.get("pattern")
+    if pattern:
+        return f"`{pattern}`"
+    query = value.get("query") or value.get("prompt")
+    if isinstance(query, str) and query:
+        return f'"{query[:57]}..."' if len(query) > 60 else f'"{query}"'
+    for key, item in value.items():
+        if isinstance(item, str) and item and len(item) < 60:
+            return f"{key}={item}"
+    return ""
+
+
+def _keep_segment(segment: _Segment, spec: ContentProjectionSpec) -> bool:
+    kind = segment.kind
+    if kind is ContentKind.PROSE:
+        return spec.include_prose
+    if kind is ContentKind.CODE:
+        return spec.include_code
+    if kind is ContentKind.TOOL_CALL:
+        return spec.include_tool_calls
+    if kind is ContentKind.TOOL_OUTPUT:
+        return spec.include_tool_outputs
+    if kind is ContentKind.FILE_READ:
+        return spec.include_tool_outputs and spec.include_file_reads
+    if kind is ContentKind.REASONING:
+        return spec.include_reasoning
+    if kind is ContentKind.SYSTEM_NOISE:
+        return spec.include_system_noise
+    if kind is ContentKind.ATTACHMENT:
+        return spec.include_attachments
+    return True
+
+
+def _render_segments_text(segments: Sequence[_Segment]) -> str:
+    parts = [segment.text.strip() for segment in segments if isinstance(segment.text, str) and segment.text.strip()]
+    return "\n\n".join(parts)
+
+
+__all__ = [
+    "ContentKind",
+    "ContentProjectionSpec",
+    "coerce_content_projection_spec",
+    "project_conversation_content",
+]

--- a/polylogue/lib/conversation_runtime.py
+++ b/polylogue/lib/conversation_runtime.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections import defaultdict
 from collections.abc import Callable, Iterator, Mapping
 from datetime import datetime
-from typing import TYPE_CHECKING, Self
+from typing import TYPE_CHECKING, Self, cast
 
 from polylogue.lib.branch_type import BranchType
 from polylogue.lib.message_models import DialoguePair, Message
@@ -15,6 +15,8 @@ from polylogue.lib.roles import Role
 from polylogue.types import ConversationId
 
 if TYPE_CHECKING:
+    from polylogue.lib.content_projection import ContentProjectionSpec
+    from polylogue.lib.conversation_models import Conversation
     from polylogue.lib.projections import ConversationProjection
 
 
@@ -102,6 +104,14 @@ class ConversationRuntimeMixin:
     def with_roles(self, roles: object) -> Self:
         selected_roles = normalize_message_roles(roles)
         return self.filter(lambda message: message.role in selected_roles)
+
+    def with_content_projection(
+        self,
+        projection: ContentProjectionSpec | Mapping[str, object] | None,
+    ) -> Self:
+        from polylogue.lib.content_projection import project_conversation_content
+
+        return cast(Self, project_conversation_content(cast("Conversation", self), projection))
 
     def dialogue_only(self) -> Self:
         return self.with_roles((Role.USER, Role.ASSISTANT))

--- a/polylogue/mcp/query_contracts.py
+++ b/polylogue/mcp/query_contracts.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 
+from polylogue.lib.content_projection import ContentProjectionSpec
 from polylogue.lib.query_spec import ConversationQuerySpec
 
 _QUERY_PARAM_ALIASES = {
@@ -76,4 +77,31 @@ class MCPConversationQueryRequest:
         )
 
 
-__all__ = ["build_query_spec", "MCPConversationQueryRequest", "normalize_query_params"]
+@dataclass(frozen=True, slots=True)
+class MCPContentProjectionRequest:
+    """Typed MCP-side content projection request shared by read/export surfaces."""
+
+    no_code_blocks: bool = False
+    no_tool_calls: bool = False
+    no_tool_outputs: bool = False
+    no_file_reads: bool = False
+    prose_only: bool = False
+
+    def build_projection(self) -> ContentProjectionSpec:
+        return ContentProjectionSpec.from_params(
+            {
+                "no_code_blocks": self.no_code_blocks,
+                "no_tool_calls": self.no_tool_calls,
+                "no_tool_outputs": self.no_tool_outputs,
+                "no_file_reads": self.no_file_reads,
+                "prose_only": self.prose_only,
+            }
+        )
+
+
+__all__ = [
+    "build_query_spec",
+    "MCPContentProjectionRequest",
+    "MCPConversationQueryRequest",
+    "normalize_query_params",
+]

--- a/polylogue/mcp/server_maintenance_tools.py
+++ b/polylogue/mcp/server_maintenance_tools.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from polylogue.mcp.payloads import MCPMutationStatusPayload, MCPRootPayload
-from polylogue.mcp.query_contracts import MCPConversationQueryRequest
+from polylogue.mcp.query_contracts import MCPContentProjectionRequest, MCPConversationQueryRequest
 
 if TYPE_CHECKING:
     from mcp.server.fastmcp import FastMCP
@@ -53,15 +53,30 @@ def register_maintenance_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
         return await hooks.async_safe_call("update_index", run)
 
     @mcp.tool()
-    async def export_conversation(id: str, format: str = "markdown") -> str:
+    async def export_conversation(
+        id: str,
+        format: str = "markdown",
+        no_code_blocks: bool = False,
+        no_tool_calls: bool = False,
+        no_tool_outputs: bool = False,
+        no_file_reads: bool = False,
+        prose_only: bool = False,
+    ) -> str:
         async def run() -> str:
             from polylogue.rendering.formatting import format_conversation, normalize_conversation_output_format
 
-            conv = await hooks.get_archive_ops().get_conversation(id)
+            projection = MCPContentProjectionRequest(
+                no_code_blocks=no_code_blocks,
+                no_tool_calls=no_tool_calls,
+                no_tool_outputs=no_tool_outputs,
+                no_file_reads=no_file_reads,
+                prose_only=prose_only,
+            ).build_projection()
+            conv = await hooks.get_archive_ops().get_conversation(id, content_projection=projection)
             if conv is None:
                 return hooks.error_json(f"Conversation not found: {id}")
             fmt = normalize_conversation_output_format(format)
-            return format_conversation(conv, fmt, None)
+            return format_conversation(conv, fmt, None, content_projection=projection)
 
         return await hooks.async_safe_call("export_conversation", run)
 
@@ -105,6 +120,11 @@ def register_maintenance_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
         has_thinking: bool = False,
         min_messages: int | None = None,
         min_words: int | None = None,
+        no_code_blocks: bool = False,
+        no_tool_calls: bool = False,
+        no_tool_outputs: bool = False,
+        no_file_reads: bool = False,
+        prose_only: bool = False,
     ) -> str:
         async def run() -> str:
             from polylogue.rendering.formatting import format_conversation, normalize_conversation_output_format
@@ -131,7 +151,14 @@ def register_maintenance_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
                 min_messages=min_messages,
                 min_words=min_words,
             ).build_spec(hooks.clamp_limit)
-            conversations = await hooks.get_archive_ops().query_conversations(spec)
+            projection = MCPContentProjectionRequest(
+                no_code_blocks=no_code_blocks,
+                no_tool_calls=no_tool_calls,
+                no_tool_outputs=no_tool_outputs,
+                no_file_reads=no_file_reads,
+                prose_only=prose_only,
+            ).build_projection()
+            conversations = await hooks.get_archive_ops().query_conversations(spec, content_projection=projection)
             return hooks.json_payload(
                 MCPRootPayload(
                     root={
@@ -142,7 +169,7 @@ def register_maintenance_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
                                 "conversation_id": str(conversation.id),
                                 "provider": str(conversation.provider),
                                 "title": conversation.display_title,
-                                "content": format_conversation(conversation, fmt, None),
+                                "content": format_conversation(conversation, fmt, None, content_projection=projection),
                             }
                             for conversation in conversations
                         ],

--- a/polylogue/mcp/server_tools.py
+++ b/polylogue/mcp/server_tools.py
@@ -15,7 +15,7 @@ from polylogue.mcp.payloads import (
     conversation_search_result_payload,
     conversation_summary_list_payload,
 )
-from polylogue.mcp.query_contracts import MCPConversationQueryRequest
+from polylogue.mcp.query_contracts import MCPContentProjectionRequest, MCPConversationQueryRequest
 from polylogue.mcp.server_maintenance_tools import register_maintenance_tools
 from polylogue.mcp.server_mutation_tools import register_mutation_tools
 from polylogue.mcp.server_product_tools import register_product_tools
@@ -122,12 +122,28 @@ def register_query_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
         return await hooks.async_safe_call("list_conversations", run)
 
     @mcp.tool()
-    async def get_conversation(id: str) -> str:
+    async def get_conversation(
+        id: str,
+        no_code_blocks: bool = False,
+        no_tool_calls: bool = False,
+        no_tool_outputs: bool = False,
+        no_file_reads: bool = False,
+        prose_only: bool = False,
+    ) -> str:
         async def run() -> str:
-            conv = await hooks.get_archive_ops().get_conversation(id)
+            projection = MCPContentProjectionRequest(
+                no_code_blocks=no_code_blocks,
+                no_tool_calls=no_tool_calls,
+                no_tool_outputs=no_tool_outputs,
+                no_file_reads=no_file_reads,
+                prose_only=prose_only,
+            ).build_projection()
+            conv = await hooks.get_archive_ops().get_conversation(id, content_projection=projection)
             if conv is None:
                 return hooks.error_json(f"Conversation not found: {id}")
-            return hooks.json_payload(MCPConversationDetailPayload.from_conversation(conv))
+            return hooks.json_payload(
+                MCPConversationDetailPayload.from_conversation(conv, content_projection=projection)
+            )
 
         return await hooks.async_safe_call("get_conversation", run)
 

--- a/polylogue/operations/archive.py
+++ b/polylogue/operations/archive.py
@@ -37,6 +37,7 @@ from polylogue.archive_products import (
     WorkThreadProductQuery,
 )
 from polylogue.archive_resume import ResumeBrief, ResumeOperations, build_resume_brief
+from polylogue.lib.content_projection import ContentProjectionSpec
 from polylogue.lib.conversation_models import ConversationSummary
 from polylogue.lib.query_spec import ConversationQuerySpec
 from polylogue.maintenance_targets import build_maintenance_target_catalog
@@ -238,8 +239,16 @@ class ArchiveSearchMixin:
         @property
         def config(self) -> Config: ...
 
-    async def get_conversation(self, conversation_id: str) -> Conversation | None:
-        return await self.repository.view(conversation_id)
+    async def get_conversation(
+        self,
+        conversation_id: str,
+        *,
+        content_projection: ContentProjectionSpec | None = None,
+    ) -> Conversation | None:
+        conversation = await self.repository.view(conversation_id)
+        if conversation is None or content_projection is None or not content_projection.filters_content():
+            return conversation
+        return conversation.with_content_projection(content_projection)
 
     async def get_conversation_summary(self, conversation_id: str) -> ConversationSummary | None:
         full_id = await self.repository.resolve_id(conversation_id) or conversation_id
@@ -249,19 +258,39 @@ class ArchiveSearchMixin:
         full_id = await self.repository.resolve_id(conversation_id) or conversation_id
         return await self.repository.get_conversation_stats(str(full_id))
 
-    async def get_conversations(self, conversation_ids: list[str]) -> list[Conversation]:
-        return await self.repository.get_many(conversation_ids)
+    async def get_conversations(
+        self,
+        conversation_ids: list[str],
+        *,
+        content_projection: ContentProjectionSpec | None = None,
+    ) -> list[Conversation]:
+        conversations = await self.repository.get_many(conversation_ids)
+        if content_projection is None or not content_projection.filters_content():
+            return conversations
+        return [conversation.with_content_projection(content_projection) for conversation in conversations]
 
     async def list_conversations(
         self,
         *,
         provider: str | None = None,
         limit: int | None = None,
+        content_projection: ContentProjectionSpec | None = None,
     ) -> list[Conversation]:
-        return await self.repository.list(provider=provider, limit=limit)
+        conversations = await self.repository.list(provider=provider, limit=limit)
+        if content_projection is None or not content_projection.filters_content():
+            return conversations
+        return [conversation.with_content_projection(content_projection) for conversation in conversations]
 
-    async def query_conversations(self, spec: ConversationQuerySpec) -> list[Conversation]:
-        return await spec.list(self.repository)
+    async def query_conversations(
+        self,
+        spec: ConversationQuerySpec,
+        *,
+        content_projection: ContentProjectionSpec | None = None,
+    ) -> list[Conversation]:
+        conversations = await spec.list(self.repository)
+        if content_projection is None or not content_projection.filters_content():
+            return conversations
+        return [conversation.with_content_projection(content_projection) for conversation in conversations]
 
     async def search_conversation_hits(self, spec: ConversationQuerySpec) -> list[ConversationSearchHit]:
         from polylogue.lib.query_search_hits import search_hits_for_plan

--- a/polylogue/rendering/formatting.py
+++ b/polylogue/rendering/formatting.py
@@ -18,6 +18,7 @@ import io
 import json
 from typing import TYPE_CHECKING
 
+from polylogue.lib.content_projection import ContentProjectionSpec
 from polylogue.surface_payloads import (
     ConversationDetailPayload,
     ConversationListRowPayload,
@@ -49,6 +50,7 @@ def format_conversation(
     conv: Conversation,
     output_format: str,
     fields: str | None,
+    content_projection: ContentProjectionSpec | None = None,
 ) -> str:
     """Format a single conversation for output.
 
@@ -61,6 +63,8 @@ def format_conversation(
         Formatted string
     """
     output_format = normalize_conversation_output_format(output_format)
+    if content_projection is not None and content_projection.filters_content():
+        conv = conv.with_content_projection(content_projection)
 
     if output_format == "json":
         return _conv_to_json(conv, fields)

--- a/polylogue/surface_payloads.py
+++ b/polylogue/surface_payloads.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Literal, NotRequired
 from pydantic import BaseModel, ConfigDict, Field
 from typing_extensions import TypedDict
 
+from polylogue.lib.content_projection import ContentProjectionSpec
 from polylogue.lib.json import JSONDocument, JSONValue, require_json_document
 
 if TYPE_CHECKING:
@@ -177,7 +178,14 @@ class ConversationDetailPayload(ConversationSummaryPayload):
     messages: tuple[ConversationMessagePayload, ...]
 
     @classmethod
-    def from_conversation(cls, conversation: Conversation) -> ConversationDetailPayload:
+    def from_conversation(
+        cls,
+        conversation: Conversation,
+        *,
+        content_projection: ContentProjectionSpec | None = None,
+    ) -> ConversationDetailPayload:
+        if content_projection is not None and content_projection.filters_content():
+            conversation = conversation.with_content_projection(content_projection)
         summary = ConversationSummaryPayload.from_conversation(conversation)
         return cls(
             **summary.model_dump(),

--- a/tests/baselines/showcase/help-main.txt
+++ b/tests/baselines/showcase/help-main.txt
@@ -88,6 +88,13 @@ Options:
   --transform [strip-tools|strip-thinking|strip-all]
                                   Remove content: strip-tools (tool calls),
                                   strip-thinking (reasoning), strip-all (both)
+  --no-code-blocks                Exclude fenced and structured code blocks
+                                  from output
+  --no-tool-calls                 Exclude tool invocation records from output
+  --no-tool-outputs               Exclude tool-result payloads from output
+  --no-file-reads                 Exclude file-read payloads while keeping
+                                  other tool output
+  --prose-only                    Show only authored prose text
   --stream                        Stream output (low memory). Requires
                                   --latest or -i ID. Incompatible with
                                   --transform

--- a/tests/unit/cli/__snapshots__/test_terminal_snapshots.ambr
+++ b/tests/unit/cli/__snapshots__/test_terminal_snapshots.ambr
@@ -182,6 +182,13 @@
     --transform [strip-tools|strip-thinking|strip-all]
                                     Remove content: strip-tools (tool calls),
                                     strip-thinking (reasoning), strip-all (both)
+    --no-code-blocks                Exclude fenced and structured code blocks
+                                    from output
+    --no-tool-calls                 Exclude tool invocation records from output
+    --no-tool-outputs               Exclude tool-result payloads from output
+    --no-file-reads                 Exclude file-read payloads while keeping
+                                    other tool output
+    --prose-only                    Show only authored prose text
     --stream                        Stream output (low memory). Requires
                                     --latest or -i ID. Incompatible with
                                     --transform
@@ -334,6 +341,18 @@
   s (tool calls),
                                     strip-thinking (reasoning)
   , strip-all (both)
+    --no-code-blocks                Exclude fenced and structu
+  red code blocks
+                                    from output
+    --no-tool-calls                 Exclude tool invocation re
+  cords from output
+    --no-tool-outputs               Exclude tool-result payloa
+  ds from output
+    --no-file-reads                 Exclude file-read payloads
+   while keeping
+                                    other tool output
+    --prose-only                    Show only authored prose t
+  ext
     --stream                        Stream output (low memory)
   . Requires
                                     --latest or -i ID. Incompa
@@ -469,6 +488,13 @@
     --transform [strip-tools|strip-thinking|strip-all]
                                     Remove content: strip-tools (tool calls),
                                     strip-thinking (reasoning), strip-all (both)
+    --no-code-blocks                Exclude fenced and structured code blocks
+                                    from output
+    --no-tool-calls                 Exclude tool invocation records from output
+    --no-tool-outputs               Exclude tool-result payloads from output
+    --no-file-reads                 Exclude file-read payloads while keeping
+                                    other tool output
+    --prose-only                    Show only authored prose text
     --stream                        Stream output (low memory). Requires
                                     --latest or -i ID. Incompatible with
                                     --transform

--- a/tests/unit/cli/test_query_exec.py
+++ b/tests/unit/cli/test_query_exec.py
@@ -21,6 +21,7 @@ import pytest
 from polylogue.cli.query import QueryAction, QueryOutputSpec, QueryRoute
 from polylogue.cli.query_contracts import QueryDeliveryTarget
 from polylogue.cli.types import AppEnv
+from polylogue.lib.content_projection import ContentProjectionSpec
 from polylogue.lib.models import Conversation as ConversationModel
 from polylogue.lib.models import ConversationSummary
 from polylogue.lib.models import Message as MessageModel
@@ -839,6 +840,49 @@ async def test_stream_conversation_errors_for_missing_conversation() -> None:
     mock_echo.assert_called_once_with("Conversation not found: missing", err=True)
 
 
+@pytest.mark.asyncio
+async def test_stream_conversation_applies_content_projection_when_requested() -> None:
+    from polylogue.cli.query_output import stream_conversation
+
+    repo = MagicMock()
+    repo.get_render_projection = AsyncMock(
+        return_value=SimpleNamespace(
+            conversation=SimpleNamespace(
+                title="Projected Stream",
+                provider_name=None,
+                updated_at=None,
+                created_at=None,
+            )
+        )
+    )
+    repo.get_conversation_stats = AsyncMock(return_value={"dialogue_messages": 1, "total_messages": 1})
+    repo.get = AsyncMock(
+        return_value=_make_conv(
+            id="conv-stream",
+            messages=[_make_msg("m1", "assistant", "Alpha\n\n```python\nprint('x')\n```\n\nOmega")],
+        )
+    )
+    repo.iter_messages = MagicMock()
+    env = _make_env(repo=repo, config=MagicMock())
+    stdout = StringIO()
+
+    with patch("sys.stdout", stdout):
+        count = await stream_conversation(
+            env,
+            repo,
+            "conv-stream",
+            output_format="plaintext",
+            content_projection=ContentProjectionSpec.prose_only(),
+        )
+
+    output = stdout.getvalue()
+    assert count == 1
+    assert "Alpha" in output
+    assert "Omega" in output
+    assert "print('x')" not in output
+    repo.iter_messages.assert_not_called()
+
+
 @pytest.mark.parametrize(
     ("content", "output_format", "conv", "expected_in_file"),
     [
@@ -1096,6 +1140,9 @@ class TestBuildQueryExecutionPlan:
 
         transformed = build_query_execution_plan({"list_mode": True, "transform": "strip-tools", "query": ("abc",)})
         assert transformed.prefers_summary_list() is False
+
+        projected = build_query_execution_plan({"list_mode": True, "prose_only": True, "query": ("abc",)})
+        assert projected.prefers_summary_list() is False
 
     def test_mutation_fields_are_normalized(self) -> None:
         from polylogue.cli.query import build_query_execution_plan

--- a/tests/unit/cli/test_query_exec_laws.py
+++ b/tests/unit/cli/test_query_exec_laws.py
@@ -1278,6 +1278,7 @@ def test_async_execute_query_action_routing_contract(case: str, expected_helper:
             output_format="json-lines",
             dialogue_only=True,
             message_roles=(Role.USER, Role.ASSISTANT),
+            content_projection=None,
             message_limit=7,
         )
         warnings = [call.args[0] for call in mock_echo.call_args_list if call.args]

--- a/tests/unit/cli/test_query_fmt.py
+++ b/tests/unit/cli/test_query_fmt.py
@@ -36,6 +36,7 @@ from polylogue.cli.query_output import (
 )
 from polylogue.cli.query_output_contracts import StructuredRowsDocument
 from polylogue.lib.attachment_models import Attachment
+from polylogue.lib.content_projection import ContentProjectionSpec
 from polylogue.lib.messages import MessageCollection
 from polylogue.lib.models import Conversation, ConversationSummary, Message
 from polylogue.lib.roles import Role
@@ -427,6 +428,21 @@ class TestConversationFormatting:
         rendered = format_conversation(conv, "csv", None)
         assert "empty" not in rendered
         assert "reply" in rendered
+
+    def test_format_conversation_applies_content_projection(self) -> None:
+        conv = _make_conv(
+            messages=[
+                _make_msg(
+                    "assistant",
+                    "Alpha\n\n```python\nprint('x')\n```\n\nOmega",
+                    id="projected",
+                )
+            ]
+        )
+
+        rendered = format_conversation(conv, "plaintext", None, content_projection=ContentProjectionSpec.prose_only())
+
+        assert rendered == "Alpha\n\nOmega"
 
 
 class TestListFormatting:

--- a/tests/unit/core/test_content_projection.py
+++ b/tests/unit/core/test_content_projection.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from polylogue.lib.attachment_models import Attachment
+from polylogue.lib.content_projection import ContentProjectionSpec
+from tests.infra.builders import make_conv, make_msg
+
+
+def test_projection_removes_only_file_read_payloads_when_requested() -> None:
+    conversation = make_conv(
+        messages=[
+            make_msg(
+                id="a1",
+                role="assistant",
+                text="Working",
+                content_blocks=[
+                    {"type": "text", "text": "Working"},
+                    {
+                        "type": "tool_use",
+                        "name": "Read",
+                        "tool_id": "tool-read",
+                        "tool_input": {"path": "README.md"},
+                        "semantic_type": "file_read",
+                    },
+                    {
+                        "type": "tool_use",
+                        "name": "Bash",
+                        "tool_id": "tool-shell",
+                        "tool_input": {"command": "pytest -q"},
+                        "semantic_type": "shell",
+                    },
+                ],
+            ),
+            make_msg(
+                id="t1",
+                role="tool",
+                text="README contents",
+                content_blocks=[{"type": "tool_result", "tool_id": "tool-read", "text": "README contents"}],
+            ),
+            make_msg(
+                id="t2",
+                role="tool",
+                text="pytest ok",
+                content_blocks=[{"type": "tool_result", "tool_id": "tool-shell", "text": "pytest ok"}],
+            ),
+        ]
+    )
+
+    projected = conversation.with_content_projection(ContentProjectionSpec.from_params({"no_file_reads": True}))
+
+    assert [message.id for message in projected.messages] == ["a1", "t2"]
+    texts = [message.text or "" for message in projected.messages]
+    assert any("[Tool: Read]" in text for text in texts)
+    assert any("pytest ok" in text for text in texts)
+    assert all("README contents" not in text for text in texts)
+
+
+def test_prose_only_uses_text_fallback_and_preserves_order() -> None:
+    conversation = make_conv(
+        messages=[
+            make_msg(
+                id="fallback",
+                role="assistant",
+                text="Alpha\n\n```python\nprint('x')\n```\n\n<thinking>step one</thinking>\n\nOmega",
+            )
+        ]
+    )
+
+    projected = conversation.with_content_projection(ContentProjectionSpec.prose_only())
+
+    assert len(projected.messages) == 1
+    message = next(iter(projected.messages))
+    assert message.text == "Alpha\n\nOmega"
+
+
+def test_projection_filters_structured_code_and_tool_outputs_without_losing_prose() -> None:
+    conversation = make_conv(
+        messages=[
+            make_msg(
+                id="mixed",
+                role="assistant",
+                text="ignored",
+                content_blocks=[
+                    {"type": "text", "text": "Plan"},
+                    {"type": "code", "text": "print('x')", "language": "python"},
+                    {
+                        "type": "tool_use",
+                        "name": "Read",
+                        "tool_id": "tool-read",
+                        "tool_input": {"path": "README.md"},
+                        "semantic_type": "file_read",
+                    },
+                    {"type": "tool_result", "tool_id": "tool-read", "text": "README body"},
+                ],
+            )
+        ]
+    )
+
+    projected = conversation.with_content_projection(
+        ContentProjectionSpec.from_params(
+            {
+                "no_code_blocks": True,
+                "no_tool_outputs": True,
+            }
+        )
+    )
+
+    message = next(iter(projected.messages))
+    assert message.text == "Plan\n\n[Tool: Read] `README.md`"
+    assert [block["type"] for block in message.content_blocks] == ["text", "tool_use"]
+
+
+def test_prose_only_drops_attachment_only_messages() -> None:
+    conversation = make_conv(
+        messages=[
+            make_msg(
+                id="attachment-only",
+                role="assistant",
+                text=None,
+                attachments=[Attachment(id="att-1", name="README.md", path="README.md")],
+            )
+        ]
+    )
+
+    projected = conversation.with_content_projection(ContentProjectionSpec.prose_only())
+
+    assert list(projected.messages) == []

--- a/tests/unit/core/test_facade_api.py
+++ b/tests/unit/core/test_facade_api.py
@@ -18,6 +18,7 @@ from polylogue.archive_products import (
     WorkThreadProductQuery,
 )
 from polylogue.facade import ArchiveStats
+from polylogue.lib.content_projection import ContentProjectionSpec
 from tests.infra.builders import make_conv, make_msg
 from tests.infra.storage_records import ConversationBuilder, make_conversation, make_message
 
@@ -196,6 +197,44 @@ class TestPolylogueGetConversation:
         assert conv is not None
         assert conv.id == "conv-1"
         assert conv.title == "Test Conversation"
+
+    @pytest.mark.asyncio
+    async def test_get_conversation_applies_content_projection(self: object, tmp_path: Path) -> None:
+        archive = _archive(tmp_path)
+        repository = archive.repository
+
+        await repository.save_conversation(
+            make_conversation(
+                "conv-projection",
+                provider_name="claude-ai",
+                title="Projected Conversation",
+                provider_conversation_id="provider-projection",
+                created_at="2025-01-01T00:00:00Z",
+                updated_at="2025-01-01T00:00:00Z",
+                content_hash="hash-projection",
+            ),
+            [
+                make_message(
+                    "msg-projection",
+                    "conv-projection",
+                    role="assistant",
+                    text="Alpha\n\n```python\nprint('x')\n```\n\nOmega",
+                    timestamp="2025-01-01T00:00:00Z",
+                    content_hash="msg-hash-projection",
+                )
+            ],
+            [],
+        )
+
+        projected = await archive.get_conversation(
+            "conv-projection",
+            content_projection=ContentProjectionSpec.prose_only(),
+        )
+
+        assert projected is not None
+        assert len(projected.messages) == 1
+        message = next(iter(projected.messages))
+        assert message.text == "Alpha\n\nOmega"
 
 
 class TestPolylogueGetConversations:

--- a/tests/unit/mcp/test_server_surfaces.py
+++ b/tests/unit/mcp/test_server_surfaces.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from polylogue.lib.content_projection import ContentProjectionSpec
 from polylogue.lib.models import Conversation
 from polylogue.lib.roles import Role
 from polylogue.types import Provider
@@ -402,6 +403,39 @@ class TestPromptSurfaces:
 
 
 class TestExportConversationTool:
+    def test_get_conversation_tool_applies_content_projection(
+        self: object,
+        mcp_server: MCPServerUnderTest,
+    ) -> None:
+        projected_input = make_conv(
+            id="test:conv-123",
+            provider=Provider.CHATGPT,
+            title="Projected Conversation",
+            messages=[
+                make_msg(
+                    id="msg-1",
+                    role="assistant",
+                    text="Alpha\n\n```python\nprint('x')\n```\n\nOmega",
+                )
+            ],
+        )
+
+        with patch("polylogue.mcp.server._get_archive_ops") as mock_get_archive_ops:
+            mock_ops = MagicMock()
+            mock_ops.get_conversation = AsyncMock(return_value=projected_input)
+            mock_get_archive_ops.return_value = mock_ops
+
+            result = invoke_surface(
+                mcp_server._tool_manager._tools["get_conversation"].fn,
+                id="test:conv-123",
+                no_code_blocks=True,
+            )
+
+        payload = json.loads(result)
+        assert payload["messages"][0]["text"] == "Alpha\n\nOmega"
+        projection = mock_ops.get_conversation.await_args.kwargs["content_projection"]
+        assert projection.include_code is False
+
     def test_export_markdown(self: object, simple_conversation: Conversation, mcp_server: MCPServerUnderTest) -> None:
         with (
             patch("polylogue.mcp.server._get_archive_ops") as mock_get_archive_ops,
@@ -480,6 +514,29 @@ class TestTypedPayloads:
         assert len(result["messages"]) == 2
         msg = result["messages"][0]
         assert {"id", "role", "text", "timestamp"} <= msg.keys()
+
+    def test_conversation_to_full_dict_applies_projection(self: object) -> None:
+        from polylogue.mcp.payloads import MCPConversationDetailPayload
+
+        conversation = make_conv(
+            id="projected",
+            provider=Provider.CHATGPT,
+            title="Projected",
+            messages=[
+                make_msg(
+                    id="m1",
+                    role="assistant",
+                    text="Alpha\n\n```python\nprint('x')\n```\n\nOmega",
+                )
+            ],
+        )
+
+        result = MCPConversationDetailPayload.from_conversation(
+            conversation,
+            content_projection=ContentProjectionSpec.prose_only(),
+        ).model_dump(mode="json")
+
+        assert result["messages"][0]["text"] == "Alpha\n\nOmega"
 
     @pytest.mark.parametrize(("case_id", "conv", "expected_fields", "payload_kind"), SERIALIZATION_CASES)
     def test_serialization_edge_cases(


### PR DESCRIPTION
## Summary
Add a shared content-kind projection contract for conversation output and wire it through the CLI, facade, MCP, and formatter/payload surfaces. This lands prose-only and selective content suppression without reintroducing one-off string surgery in each consumer.

## Problem
`#310` called for content-kind decomposition as a real shared projection contract, not ad hoc trimming. Before this slice, Polylogue only had narrow transforms like `strip-tools` and `strip-thinking`, while full conversation output still flowed through CLI, facade, MCP, and formatter paths without a shared way to remove code blocks, tool calls, tool outputs, or file-read payloads. That made the projection semantics incomplete and surface-specific.

## Solution
- add `polylogue.lib.content_projection` with canonical content kinds and a reusable `ContentProjectionSpec`
- project structured blocks first, then fall back to text segmentation for fenced code and reasoning tags
- preserve file-read vs general tool-output distinctions by pairing tool results with tool-use semantic types
- wire projection through conversation runtime helpers, archive operations, facade methods, CLI query output, and MCP read/export tools
- add root CLI flags `--no-code-blocks`, `--no-tool-calls`, `--no-tool-outputs`, `--no-file-reads`, and `--prose-only`
- refresh the generated CLI reference, showcase help baseline, and PTY help snapshots for the new surface
- cover the contract across core, CLI, facade, and MCP tests, including the attachment-only edge case

## Verification
- `pytest -q tests/unit/core/test_content_projection.py tests/unit/cli/test_query_fmt.py tests/unit/cli/test_query_exec_laws.py tests/unit/cli/test_query_exec.py tests/unit/cli/test_click_app.py tests/unit/cli/test_terminal_snapshots.py tests/unit/core/test_facade_api.py tests/unit/mcp/test_server_surfaces.py -q`
- `devtools verify`

Closes #310


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Five new CLI flags control conversation output filtering: `--no-code-blocks`, `--no-tool-calls`, `--no-tool-outputs`, `--no-file-reads`, and `--prose-only`. Users can exclude specific content types such as code blocks, tool records, tool outputs, or file-read results, or view only authored prose.
  * Content filtering capabilities now available across conversation retrieval and export operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->