### PR TITLE
feat: tail ahead-of-archive source sessions

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -33,6 +33,7 @@ Usage: polylogue [OPTIONS] COMMAND [ARGS]...
       polylogue --action-sequence file_read,file_edit,shell list
       polylogue --action-text "pytest -q" list
       polylogue "pytest -q tests/unit/core/test_semantic_facts.py" --retrieval-lane actions --limit 5
+      polylogue --tail --provider claude-code --latest list
       polylogue --action other stats --by tool --format json
       polylogue --provider claude-code --since 2026-01-01 stats --by repo --format json
       polylogue --tool bash --exclude-tool read list
@@ -115,6 +116,8 @@ Options:
                                   tool, unknown)
   --set TEXT...                   Set metadata key value
   --add-tag TEXT                  Add tags (comma-separated)
+  --tail                          Tail ahead-of-archive Claude Code source
+                                  state during queries
   --plain                         Force non-interactive plain output
   -v, --verbose                   Verbose output
   --version                       Show the version and exit.

--- a/polylogue/cli/click_app.py
+++ b/polylogue/cli/click_app.py
@@ -106,6 +106,7 @@ def cli(
     set_meta: tuple[tuple[str, str], ...],
     add_tag: tuple[str, ...],
     # Global
+    tail: bool,
     plain: bool,
     verbose: bool,
 ) -> None:
@@ -134,6 +135,7 @@ def cli(
         polylogue --action-sequence file_read,file_edit,shell list
         polylogue --action-text "pytest -q" list
         polylogue "pytest -q tests/unit/core/test_semantic_facts.py" --retrieval-lane actions --limit 5
+        polylogue --tail --provider claude-code --latest list
         polylogue --action other stats --by tool --format json
         polylogue --provider claude-code --since 2026-01-01 stats --by repo --format json
         polylogue --tool bash --exclude-tool read list

--- a/polylogue/cli/click_option_groups.py
+++ b/polylogue/cli/click_option_groups.py
@@ -213,6 +213,7 @@ MODIFIER_OPTION_DECORATORS: tuple[Callable[[ClickCallable], ClickCallable], ...]
 )
 
 GLOBAL_OPTION_DECORATORS: tuple[Callable[[ClickCallable], ClickCallable], ...] = (
+    click.option("--tail", is_flag=True, help="Tail ahead-of-archive Claude Code source state during queries"),
     click.option("--plain", is_flag=True, help="Force non-interactive plain output"),
     click.option("-v", "--verbose", is_flag=True, help="Verbose output"),
 )

--- a/polylogue/cli/query.py
+++ b/polylogue/cli/query.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import inspect
 from collections.abc import Awaitable, Iterable, Sequence
+from pathlib import Path
 from typing import TYPE_CHECKING, Protocol, TypeVar, overload
 
 import click
@@ -31,6 +32,7 @@ from polylogue.cli.types import AppEnv
 from polylogue.lib.json import JSONDocument
 from polylogue.lib.query_spec import QuerySpecError
 from polylogue.logging import get_logger
+from polylogue.pipeline.tail_overlay import TailOverlayUnavailableError, tail_overlay_services
 from polylogue.surface_payloads import ConversationListRowPayload
 from polylogue.sync_bridge import run_coroutine_sync
 
@@ -49,9 +51,13 @@ if TYPE_CHECKING:
         TagStore,
         VectorProvider,
     )
+    from polylogue.storage.backends.async_sqlite import SQLiteBackend
 
     class QueryExecutionStore(ConversationArchiveStatsStore, ConversationQueryRuntimeStore, TagStore, Protocol):
         """Repository surface needed by query execution and grouped stats helpers."""
+
+        @property
+        def backend(self) -> SQLiteBackend: ...
 
 
 _T = TypeVar("_T")
@@ -273,12 +279,12 @@ def execute_query_request(env: AppEnv, request: RootModeRequest) -> None:
     run_coroutine_sync(async_execute_query_request(env, request))
 
 
-def _create_query_vector_provider(config: Config) -> VectorProvider | None:
+def _create_query_vector_provider(config: Config, *, db_path: Path | None = None) -> VectorProvider | None:
     """Best-effort vector provider setup for query execution."""
     from polylogue.storage.search_providers import create_vector_provider
 
     try:
-        return create_vector_provider(config)
+        return create_vector_provider(config, db_path=db_path or config.db_path)
     except (ValueError, ImportError):
         return None
     except Exception as exc:
@@ -363,29 +369,18 @@ async def async_execute_query(env: AppEnv, params: QueryParams) -> None:
     await async_execute_query_request(env, RootModeRequest.from_params(params))
 
 
-async def async_execute_query_request(env: AppEnv, request: RootModeRequest) -> None:
-    """Async core of query execution over a typed request."""
+async def _execute_query_plan(
+    env: AppEnv,
+    params: QueryParams,
+    *,
+    config: Config,
+    repo: QueryExecutionStore,
+    plan: QueryExecutionPlan,
+) -> None:
     from polylogue.cli import query_actions as _query_actions
     from polylogue.cli import query_output as _query_output
-    from polylogue.cli.helpers import fail, load_effective_config
-    from polylogue.config import ConfigError
 
-    params = request.query_params()
-
-    try:
-        config = load_effective_config(env)
-    except ConfigError as exc:
-        fail("query", str(exc))
-
-    repo: QueryExecutionStore = env.repository
-
-    vector_provider = _create_query_vector_provider(config)
-
-    try:
-        plan = build_query_execution_plan(params)
-    except QueryPlanError as exc:
-        click.echo(f"Error: {exc}", err=True)
-        raise SystemExit(1) from exc
+    vector_provider = _create_query_vector_provider(config, db_path=repo.backend.db_path)
 
     if plan.selection.similar_text and vector_provider is None:
         click.echo(
@@ -600,6 +595,58 @@ async def async_execute_query_request(env: AppEnv, request: RootModeRequest) -> 
         selection=plan.selection,
         diagnostics=output_diagnostics,
     )
+
+
+async def async_execute_query_request(env: AppEnv, request: RootModeRequest) -> None:
+    """Async core of query execution over a typed request."""
+    from polylogue.cli.helpers import fail, load_effective_config
+    from polylogue.config import ConfigError
+
+    params = request.query_params()
+
+    try:
+        config = load_effective_config(env)
+    except ConfigError as exc:
+        fail("query", str(exc))
+
+    repo: QueryExecutionStore = env.repository
+
+    try:
+        plan = build_query_execution_plan(params)
+    except QueryPlanError as exc:
+        click.echo(f"Error: {exc}", err=True)
+        raise SystemExit(1) from exc
+
+    tail_requested = bool(params.get("tail"))
+    if tail_requested and plan.action in {QueryAction.MODIFY, QueryAction.DELETE}:
+        click.echo(
+            "Error: --tail is read-only. Mutation and delete routes must target the stable archive.",
+            err=True,
+        )
+        raise SystemExit(1)
+    if tail_requested and plan.action == QueryAction.OPEN:
+        click.echo(
+            "Error: --tail does not support `open` yet because rendered artifacts reflect stable archive state.",
+            err=True,
+        )
+        raise SystemExit(1)
+
+    if not tail_requested:
+        await _execute_query_plan(env, params, config=config, repo=repo, plan=plan)
+        return
+
+    try:
+        async with tail_overlay_services(env.services) as overlay_services:
+            await _execute_query_plan(
+                env,
+                params,
+                config=overlay_services.get_config(),
+                repo=overlay_services.get_repository(),
+                plan=plan,
+            )
+    except TailOverlayUnavailableError as exc:
+        click.echo(f"Error: {exc}", err=True)
+        raise SystemExit(1) from exc
 
 
 __all__ = [

--- a/polylogue/lib/conversation_runtime.py
+++ b/polylogue/lib/conversation_runtime.py
@@ -12,6 +12,7 @@ from polylogue.lib.message_models import DialoguePair, Message
 from polylogue.lib.message_roles import normalize_message_roles
 from polylogue.lib.messages import MessageCollection
 from polylogue.lib.roles import Role
+from polylogue.lib.tail_overlay import TailOverlayInfo, tail_overlay_from_provider_meta
 from polylogue.types import ConversationId
 
 if TYPE_CHECKING:
@@ -96,6 +97,10 @@ class ConversationRuntimeMixin:
     @property
     def tags(self) -> list[str]:
         return _metadata_tags(self.metadata)
+
+    @property
+    def tail_overlay(self) -> TailOverlayInfo | None:
+        return tail_overlay_from_provider_meta(self.provider_meta)
 
     def filter(self, predicate: Callable[[Message], bool]) -> Self:
         filtered_messages = [message for message in self.messages if predicate(message)]

--- a/polylogue/lib/conversation_summary_runtime.py
+++ b/polylogue/lib/conversation_summary_runtime.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from datetime import datetime
 
 from polylogue.lib.branch_type import BranchType
+from polylogue.lib.tail_overlay import TailOverlayInfo, tail_overlay_from_provider_meta
 from polylogue.types import ConversationId
 
 
@@ -59,6 +60,10 @@ class ConversationSummaryRuntimeMixin:
     @property
     def tags(self) -> list[str]:
         return _metadata_tags(self.metadata)
+
+    @property
+    def tail_overlay(self) -> TailOverlayInfo | None:
+        return tail_overlay_from_provider_meta(self.provider_meta)
 
     @property
     def summary(self) -> str | None:

--- a/polylogue/lib/tail_overlay.py
+++ b/polylogue/lib/tail_overlay.py
@@ -1,0 +1,79 @@
+"""Shared tail-overlay metadata for ahead-of-archive query results."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+TAIL_OVERLAY_PROVIDER_META_KEY = "tail_overlay"
+TailArchiveState = Literal["ahead_of_archive", "unseen"]
+
+
+@dataclass(frozen=True, slots=True)
+class TailOverlayInfo:
+    """Machine-readable freshness/provenance for tailed query results."""
+
+    source_name: str
+    source_path: str
+    archive_state: TailArchiveState
+    file_mtime: str | None = None
+
+    def to_provider_meta_payload(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "source_name": self.source_name,
+            "source_path": self.source_path,
+            "archive_state": self.archive_state,
+        }
+        if self.file_mtime is not None:
+            payload["file_mtime"] = self.file_mtime
+        return payload
+
+
+def tail_overlay_from_provider_meta(provider_meta: dict[str, object] | None) -> TailOverlayInfo | None:
+    """Parse tail-overlay provenance from provider metadata."""
+    if provider_meta is None:
+        return None
+
+    raw = provider_meta.get(TAIL_OVERLAY_PROVIDER_META_KEY)
+    if not isinstance(raw, dict):
+        return None
+
+    source_name = raw.get("source_name")
+    source_path = raw.get("source_path")
+    archive_state = raw.get("archive_state")
+    if not isinstance(source_name, str) or not source_name.strip():
+        return None
+    if not isinstance(source_path, str) or not source_path.strip():
+        return None
+    if archive_state not in {"ahead_of_archive", "unseen"}:
+        return None
+
+    file_mtime = raw.get("file_mtime")
+    if file_mtime is not None and not isinstance(file_mtime, str):
+        file_mtime = str(file_mtime)
+
+    return TailOverlayInfo(
+        source_name=source_name,
+        source_path=source_path,
+        archive_state=archive_state,
+        file_mtime=file_mtime,
+    )
+
+
+def with_tail_overlay_provider_meta(
+    provider_meta: dict[str, object] | None,
+    info: TailOverlayInfo,
+) -> dict[str, object]:
+    """Return provider metadata augmented with tail-overlay provenance."""
+    payload = dict(provider_meta or {})
+    payload[TAIL_OVERLAY_PROVIDER_META_KEY] = info.to_provider_meta_payload()
+    return payload
+
+
+__all__ = [
+    "TAIL_OVERLAY_PROVIDER_META_KEY",
+    "TailArchiveState",
+    "TailOverlayInfo",
+    "tail_overlay_from_provider_meta",
+    "with_tail_overlay_provider_meta",
+]

--- a/polylogue/pipeline/tail_overlay.py
+++ b/polylogue/pipeline/tail_overlay.py
@@ -1,0 +1,139 @@
+"""Temporary archive overlays built from ahead-of-archive source state."""
+
+from __future__ import annotations
+
+import sqlite3
+import tempfile
+from collections.abc import Sequence
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from polylogue.config import Config, Source
+from polylogue.lib.tail_overlay import TailOverlayInfo, with_tail_overlay_provider_meta
+from polylogue.pipeline.prepare import prepare_bundle, save_bundle
+from polylogue.services import RuntimeServices, build_runtime_services
+from polylogue.sources.source_parsing import iter_source_conversations_with_raw
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+SUPPORTED_TAIL_SOURCE_NAMES = frozenset({"claude-code"})
+
+
+class TailOverlayUnavailableError(ValueError):
+    """Raised when a tail overlay cannot be constructed for the current config."""
+
+
+def _snapshot_archive_db(source_db: Path, snapshot_db: Path) -> None:
+    """Copy a consistent SQLite snapshot into a temporary overlay path."""
+    if not source_db.exists():
+        return
+
+    source = sqlite3.connect(f"file:{source_db}?mode=ro", uri=True)
+    target = sqlite3.connect(snapshot_db)
+    try:
+        source.backup(target)
+    finally:
+        target.close()
+        source.close()
+
+
+def _tail_sources(config: Config, *, source_names: Sequence[str] | None = None) -> tuple[Source, ...]:
+    allowed_names = set(SUPPORTED_TAIL_SOURCE_NAMES)
+    if source_names is not None:
+        allowed_names &= {str(name) for name in source_names}
+
+    return tuple(
+        source
+        for source in config.sources
+        if source.name in allowed_names and source.path is not None and source.path.exists()
+    )
+
+
+async def _materialize_tail_sources(
+    base_services: RuntimeServices,
+    overlay_services: RuntimeServices,
+    *,
+    config: Config,
+    sources: Sequence[Source],
+) -> None:
+    base_repository = base_services.get_repository()
+    overlay_repository = overlay_services.get_repository()
+    known_mtimes = await base_repository.get_known_source_mtimes()
+
+    for source in sources:
+        for raw_data, conversation in iter_source_conversations_with_raw(
+            source,
+            known_mtimes=known_mtimes,
+            capture_raw=True,
+        ):
+            if raw_data is None:
+                continue
+
+            prepared = await prepare_bundle(
+                conversation,
+                source.name,
+                archive_root=config.archive_root,
+                repository=overlay_repository,
+            )
+            overlay_info = TailOverlayInfo(
+                source_name=source.name,
+                source_path=raw_data.source_path,
+                archive_state="ahead_of_archive" if raw_data.source_path in known_mtimes else "unseen",
+                file_mtime=raw_data.file_mtime,
+            )
+            prepared.bundle.conversation = prepared.bundle.conversation.model_copy(
+                update={
+                    "provider_meta": with_tail_overlay_provider_meta(
+                        prepared.bundle.conversation.provider_meta,
+                        overlay_info,
+                    )
+                }
+            )
+            await save_bundle(prepared.bundle, repository=overlay_repository)
+
+
+@asynccontextmanager
+async def tail_overlay_services(
+    services: RuntimeServices,
+    *,
+    source_names: Sequence[str] | None = None,
+) -> AsyncIterator[RuntimeServices]:
+    """Yield runtime services backed by a tailed archive overlay."""
+    base_config = services.get_config()
+    sources = _tail_sources(base_config, source_names=source_names)
+    if not sources:
+        raise TailOverlayUnavailableError(
+            "--tail currently supports configured Claude Code sources only; no readable claude-code source was found."
+        )
+
+    with tempfile.TemporaryDirectory(prefix="polylogue-tail-overlay-") as tmp:
+        overlay_db_path = Path(tmp) / "tail-overlay.db"
+        _snapshot_archive_db(services.get_backend().db_path, overlay_db_path)
+        overlay_config = Config(
+            archive_root=base_config.archive_root,
+            render_root=base_config.render_root,
+            sources=list(base_config.sources),
+            db_path=overlay_db_path,
+            drive_config=base_config.drive_config,
+            index_config=base_config.index_config,
+        )
+        overlay_services = build_runtime_services(config=overlay_config, db_path=overlay_db_path)
+        try:
+            await _materialize_tail_sources(
+                services,
+                overlay_services,
+                config=overlay_config,
+                sources=sources,
+            )
+            yield overlay_services
+        finally:
+            await overlay_services.close()
+
+
+__all__ = [
+    "SUPPORTED_TAIL_SOURCE_NAMES",
+    "TailOverlayUnavailableError",
+    "tail_overlay_services",
+]

--- a/polylogue/storage/backends/queries/conversations_reads.py
+++ b/polylogue/storage/backends/queries/conversations_reads.py
@@ -175,7 +175,11 @@ async def list_conversation_summaries(
             c.updated_at,
             c.sort_key,
             c.content_hash,
-            NULL AS provider_meta,
+            CASE
+                WHEN json_extract(c.provider_meta, '$.tail_overlay') IS NOT NULL
+                THEN json_object('tail_overlay', json_extract(c.provider_meta, '$.tail_overlay'))
+                ELSE NULL
+            END AS provider_meta,
             c.metadata,
             c.version,
             c.parent_conversation_id,
@@ -195,7 +199,11 @@ async def list_conversation_summaries(
             updated_at,
             sort_key,
             content_hash,
-            NULL AS provider_meta,
+            CASE
+                WHEN json_extract(provider_meta, '$.tail_overlay') IS NOT NULL
+                THEN json_object('tail_overlay', json_extract(provider_meta, '$.tail_overlay'))
+                ELSE NULL
+            END AS provider_meta,
             metadata,
             version,
             parent_conversation_id,

--- a/polylogue/surface_payloads.py
+++ b/polylogue/surface_payloads.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
     from polylogue.lib.models import Conversation, ConversationSummary, Message
     from polylogue.lib.neighbor_candidates import ConversationNeighborCandidate, NeighborReason
     from polylogue.lib.search_hits import ConversationSearchHit
+    from polylogue.lib.tail_overlay import TailOverlayInfo
 
 
 def serialize_surface_payload(payload: BaseModel, *, exclude_none: bool = False) -> str:
@@ -134,6 +135,24 @@ class ConversationMessagePayload(SurfacePayloadModel):
         )
 
 
+class TailOverlayPayload(SurfacePayloadModel):
+    """Machine-readable freshness/provenance for tailed query results."""
+
+    source_name: str
+    source_path: str
+    archive_state: str
+    file_mtime: str | None = None
+
+    @classmethod
+    def from_info(cls, info: TailOverlayInfo) -> TailOverlayPayload:
+        return cls(
+            source_name=info.source_name,
+            source_path=info.source_path,
+            archive_state=info.archive_state,
+            file_mtime=info.file_mtime,
+        )
+
+
 class ConversationSummaryPayload(SurfacePayloadModel):
     """Compact conversation summary payload used by MCP/search surfaces."""
 
@@ -143,9 +162,11 @@ class ConversationSummaryPayload(SurfacePayloadModel):
     message_count: int
     created_at: datetime | None = None
     updated_at: datetime | None = None
+    tail: TailOverlayPayload | None = None
 
     @classmethod
     def from_conversation(cls, conversation: Conversation) -> ConversationSummaryPayload:
+        tail = conversation.tail_overlay
         return cls(
             id=str(conversation.id),
             provider=str(conversation.provider),
@@ -153,6 +174,7 @@ class ConversationSummaryPayload(SurfacePayloadModel):
             message_count=len(conversation.messages),
             created_at=conversation.created_at,
             updated_at=conversation.updated_at,
+            tail=TailOverlayPayload.from_info(tail) if tail is not None else None,
         )
 
     @classmethod
@@ -162,6 +184,7 @@ class ConversationSummaryPayload(SurfacePayloadModel):
         *,
         message_count: int | None = None,
     ) -> ConversationSummaryPayload:
+        tail = summary.tail_overlay
         return cls(
             id=str(summary.id),
             provider=str(summary.provider),
@@ -169,6 +192,7 @@ class ConversationSummaryPayload(SurfacePayloadModel):
             message_count=summary.message_count or 0 if message_count is None else message_count,
             created_at=summary.created_at,
             updated_at=summary.updated_at,
+            tail=TailOverlayPayload.from_info(tail) if tail is not None else None,
         )
 
 
@@ -204,9 +228,11 @@ class ConversationListRowPayload(SurfacePayloadModel):
     tags: tuple[str, ...] = ()
     summary: str | None = None
     words: int | None = None
+    tail: TailOverlayPayload | None = None
 
     @classmethod
     def from_conversation(cls, conversation: Conversation) -> ConversationListRowPayload:
+        tail = conversation.tail_overlay
         return cls(
             id=str(conversation.id),
             provider=str(conversation.provider),
@@ -216,6 +242,7 @@ class ConversationListRowPayload(SurfacePayloadModel):
             tags=tuple(conversation.tags),
             summary=conversation.summary,
             words=sum(message.word_count for message in conversation.messages),
+            tail=TailOverlayPayload.from_info(tail) if tail is not None else None,
         )
 
     @classmethod
@@ -225,6 +252,7 @@ class ConversationListRowPayload(SurfacePayloadModel):
         *,
         message_count: int,
     ) -> ConversationListRowPayload:
+        tail = summary.tail_overlay
         return cls(
             id=str(summary.id),
             provider=str(summary.provider),
@@ -233,6 +261,7 @@ class ConversationListRowPayload(SurfacePayloadModel):
             messages=message_count,
             tags=tuple(summary.tags),
             summary=summary.summary,
+            tail=TailOverlayPayload.from_info(tail) if tail is not None else None,
         )
 
     def selected(self, fields: Container[str] | None = None) -> JSONDocument:
@@ -342,6 +371,7 @@ __all__ = [
     "MachineSuccessEnvelope",
     "MachineSuccessPayload",
     "SurfacePayloadModel",
+    "TailOverlayPayload",
     "JSONDocument",
     "JSONValue",
     "model_json_document",

--- a/tests/unit/cli/__snapshots__/test_terminal_snapshots.ambr
+++ b/tests/unit/cli/__snapshots__/test_terminal_snapshots.ambr
@@ -116,6 +116,7 @@
         polylogue --action-text "pytest -q" list
         polylogue "pytest -q tests<PATH>" --retrieval-l
   ane actions --limit 5
+        polylogue --tail --provider claude-code --latest list
         polylogue --action other stats --by tool --format json
         polylogue --provider claude-code --since 2026-01-01 stats --by repo --form
   at json
@@ -198,6 +199,8 @@
                                     tool, unknown)
     --set TEXT...                   Set metadata key value
     --add-tag TEXT                  Add tags (comma-separated)
+    --tail                          Tail ahead-of-archive Claude Code source
+                                    state during queries
     --plain                         Force non-interactive plain output
     -v, --verbose                   Verbose output
     --version                       Show the version and exit.
@@ -248,6 +251,7 @@
         polylogue --action-text "pytest -q" list
         polylogue "pytest -q tests<PATH>
   ts.py" --retrieval-lane actions --limit 5
+        polylogue --tail --provider claude-code --latest list
         polylogue --action other stats --by tool --format json
         polylogue --provider claude-code --since 2026-01-01 st
   ats --by repo --format json
@@ -367,6 +371,9 @@
                                     tool, unknown)
     --set TEXT...                   Set metadata key value
     --add-tag TEXT                  Add tags (comma-separated)
+    --tail                          Tail ahead-of-archive Clau
+  de Code source
+                                    state during queries
     --plain                         Force non-interactive plai
   n output
     -v, --verbose                   Verbose output
@@ -425,6 +432,7 @@
         polylogue --action-sequence file_read,file_edit,shell list
         polylogue --action-text "pytest -q" list
         polylogue "pytest -q tests<PATH>" --retrieval-lane actions --limit 5
+        polylogue --tail --provider claude-code --latest list
         polylogue --action other stats --by tool --format json
         polylogue --provider claude-code --since 2026-01-01 stats --by repo --format json
         polylogue --tool bash --exclude-tool read list
@@ -504,6 +512,8 @@
                                     tool, unknown)
     --set TEXT...                   Set metadata key value
     --add-tag TEXT                  Add tags (comma-separated)
+    --tail                          Tail ahead-of-archive Claude Code source
+                                    state during queries
     --plain                         Force non-interactive plain output
     -v, --verbose                   Verbose output
     --version                       Show the version and exit.

--- a/tests/unit/cli/test_click_app.py
+++ b/tests/unit/cli/test_click_app.py
@@ -54,6 +54,7 @@ class TestHandleQueryMode:
             "message_role": (),
             "set_meta": (),
             "add_tag": (),
+            "tail": False,
             "plain": False,
             "verbose": False,
             "filter_has_tool_use": False,
@@ -247,8 +248,10 @@ class TestQueryFirstGroupParseArgs:
         assert "products" in result.output
         assert "--provider" in result.output
         assert "--latest" in result.output
+        assert "--tail" in result.output
         assert "Subcommands:" not in result.output
         assert "polylogue --provider claude-code --since 2026-01-01 stats --by repo --format json" in result.output
+        assert "polylogue --tail --provider claude-code --latest list" in result.output
         assert "polylogue stats --by repo --provider claude-code --since 2026-01-01 --format json" not in result.output
 
     def test_root_query_option_after_verb_gets_specific_usage_error(self, cli_runner: CliRunner) -> None:

--- a/tests/unit/cli/test_query_exec.py
+++ b/tests/unit/cli/test_query_exec.py
@@ -225,6 +225,40 @@ async def test_async_execute_query_errors_for_similar_without_vector_support() -
 
 
 @pytest.mark.asyncio
+async def test_async_execute_query_rejects_tail_mutations() -> None:
+    from polylogue.cli.query import async_execute_query
+
+    env = _make_env(repo=MagicMock(), config=MagicMock())
+
+    with (
+        patch("polylogue.cli.helpers.load_effective_config", return_value=MagicMock()),
+        patch("click.echo") as mock_echo,
+    ):
+        with pytest.raises(SystemExit) as exc_info:
+            await async_execute_query(env, _make_params(tail=True, add_tag=("review",)))
+
+    assert exc_info.value.code == 1
+    assert "read-only" in mock_echo.call_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_async_execute_query_rejects_tail_open() -> None:
+    from polylogue.cli.query import async_execute_query
+
+    env = _make_env(repo=MagicMock(), config=MagicMock())
+
+    with (
+        patch("polylogue.cli.helpers.load_effective_config", return_value=MagicMock()),
+        patch("click.echo") as mock_echo,
+    ):
+        with pytest.raises(SystemExit) as exc_info:
+            await async_execute_query(env, _make_params(tail=True, open_result=True))
+
+    assert exc_info.value.code == 1
+    assert "does not support `open` yet" in mock_echo.call_args.args[0]
+
+
+@pytest.mark.asyncio
 async def test_async_execute_query_errors_for_similar_without_embeddings() -> None:
     from polylogue.cli.query import async_execute_query
 

--- a/tests/unit/cli/test_tail_query_runtime.py
+++ b/tests/unit/cli/test_tail_query_runtime.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from polylogue.cli.click_app import cli
+from polylogue.config import Config, get_config
+from polylogue.pipeline.services.parsing import ParsingService
+from polylogue.services import RuntimeServices, build_runtime_services
+from polylogue.sync_bridge import run_coroutine_sync
+
+
+def _write_claude_code_session(
+    path: Path,
+    *,
+    session_id: str = "session-1",
+    user_text: str = "hello",
+    assistant_text: str = "hi",
+) -> Path:
+    entries = [
+        {
+            "type": "user",
+            "uuid": "u1",
+            "sessionId": session_id,
+            "message": {"content": user_text},
+        },
+        {
+            "type": "assistant",
+            "uuid": "a1",
+            "sessionId": session_id,
+            "message": {"content": assistant_text},
+        },
+    ]
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("".join(json.dumps(entry) + "\n" for entry in entries), encoding="utf-8")
+    return path
+
+
+async def _configured_services() -> tuple[Config, RuntimeServices]:
+    config = get_config()
+    services = build_runtime_services(config=config, db_path=config.db_path)
+    return config, services
+
+
+async def _ingest_claude_code_source(config: Config, services: RuntimeServices) -> None:
+    claude_source = next(source for source in config.sources if source.name == "claude-code")
+    parsing_service = ParsingService(
+        repository=services.get_repository(),
+        archive_root=config.archive_root,
+        config=config,
+    )
+    await parsing_service.parse_sources([claude_source])
+
+
+def test_cli_tail_list_json_exposes_tail_provenance(
+    workspace_env: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    del workspace_env
+    home = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(home))
+    session_path = _write_claude_code_session(
+        home / ".claude" / "projects" / "project-cli" / "session.jsonl",
+        assistant_text="stable cli answer",
+    )
+
+    runner = CliRunner()
+    config, services = run_coroutine_sync(_configured_services())
+    try:
+        run_coroutine_sync(_ingest_claude_code_source(config, services))
+        _write_claude_code_session(session_path, assistant_text="tail cli answer")
+
+        result = runner.invoke(
+            cli,
+            [
+                "--tail",
+                "--plain",
+                "--provider",
+                "claude-code",
+                "--latest",
+                "list",
+                "--format",
+                "json",
+            ],
+            catch_exceptions=False,
+        )
+
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert len(payload) == 1
+        assert payload[0]["tail"]["archive_state"] == "ahead_of_archive"
+        assert payload[0]["tail"]["source_path"] == str(session_path)
+    finally:
+        run_coroutine_sync(services.close())
+
+
+def test_cli_tail_errors_when_no_supported_source_exists(
+    workspace_env: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    del workspace_env
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+
+    result = CliRunner().invoke(
+        cli,
+        ["--tail", "--plain", "list"],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 1
+    assert "supports configured Claude Code sources only" in result.output

--- a/tests/unit/pipeline/test_tail_overlay_runtime.py
+++ b/tests/unit/pipeline/test_tail_overlay_runtime.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from polylogue.config import Config, get_config
+from polylogue.lib.query_spec import ConversationQuerySpec
+from polylogue.pipeline.services.parsing import ParsingService
+from polylogue.pipeline.tail_overlay import tail_overlay_services
+from polylogue.services import RuntimeServices, build_runtime_services
+from polylogue.types import Provider
+
+
+def _write_claude_code_session(
+    path: Path,
+    *,
+    session_id: str = "session-1",
+    user_text: str = "hello",
+    assistant_text: str = "hi",
+) -> Path:
+    entries = [
+        {
+            "type": "user",
+            "uuid": "u1",
+            "sessionId": session_id,
+            "message": {"content": user_text},
+        },
+        {
+            "type": "assistant",
+            "uuid": "a1",
+            "sessionId": session_id,
+            "message": {"content": assistant_text},
+        },
+    ]
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("".join(json.dumps(entry) + "\n" for entry in entries), encoding="utf-8")
+    return path
+
+
+async def _configured_services() -> tuple[Config, RuntimeServices]:
+    config = get_config()
+    services = build_runtime_services(config=config, db_path=config.db_path)
+    return config, services
+
+
+async def _ingest_claude_code_source(config: Config, services: RuntimeServices) -> None:
+    claude_source = next(source for source in config.sources if source.name == "claude-code")
+    parsing_service = ParsingService(
+        repository=services.get_repository(),
+        archive_root=config.archive_root,
+        config=config,
+    )
+    await parsing_service.parse_sources([claude_source])
+
+
+@pytest.mark.asyncio
+async def test_tail_overlay_replaces_archived_state_with_newer_source_state(
+    workspace_env: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    del workspace_env
+    home = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(home))
+    session_path = _write_claude_code_session(
+        home / ".claude" / "projects" / "project-a" / "session.jsonl",
+        assistant_text="stable archive answer",
+    )
+
+    config, services = await _configured_services()
+    try:
+        await _ingest_claude_code_source(config, services)
+        _write_claude_code_session(session_path, assistant_text="tail only replacement text")
+
+        spec = ConversationQuerySpec(
+            providers=(Provider.CLAUDE_CODE,),
+            latest=True,
+        )
+
+        base_results = await spec.list(services.get_repository())
+        assert len(base_results) == 1
+        assert "stable archive answer" in base_results[0].to_text(include_role=False)
+
+        async with tail_overlay_services(services) as overlay_services:
+            results = await spec.list(overlay_services.get_repository())
+
+        assert len(results) == 1
+        assert "tail only replacement text" in results[0].to_text(include_role=False)
+        assert results[0].tail_overlay is not None
+        assert results[0].tail_overlay.archive_state == "ahead_of_archive"
+        assert results[0].tail_overlay.source_path == str(session_path)
+    finally:
+        await services.close()
+
+
+@pytest.mark.asyncio
+async def test_tail_overlay_reports_unseen_session_state(
+    workspace_env: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    del workspace_env
+    home = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(home))
+    session_path = _write_claude_code_session(
+        home / ".claude" / "projects" / "project-b" / "session.jsonl",
+        assistant_text="unseen tail session",
+    )
+
+    config, services = await _configured_services()
+    try:
+        spec = ConversationQuerySpec(providers=(Provider.CLAUDE_CODE,), latest=True)
+        assert await spec.list(services.get_repository()) == []
+
+        async with tail_overlay_services(services) as overlay_services:
+            results = await spec.list(overlay_services.get_repository())
+
+        assert len(results) == 1
+        assert results[0].tail_overlay is not None
+        assert results[0].tail_overlay.archive_state == "unseen"
+        assert results[0].tail_overlay.source_path == str(session_path)
+    finally:
+        await services.close()
+
+
+@pytest.mark.asyncio
+async def test_tail_overlay_falls_back_to_stable_archive_when_source_parse_fails(
+    workspace_env: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    del workspace_env
+    home = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(home))
+    session_path = _write_claude_code_session(
+        home / ".claude" / "projects" / "project-c" / "session.jsonl",
+        assistant_text="stable archive survives",
+    )
+
+    config, services = await _configured_services()
+    try:
+        await _ingest_claude_code_source(config, services)
+        session_path.write_text('{"type":"assistant","uuid":"broken"\n', encoding="utf-8")
+
+        spec = ConversationQuerySpec(providers=(Provider.CLAUDE_CODE,), latest=True)
+
+        async with tail_overlay_services(services) as overlay_services:
+            results = await spec.list(overlay_services.get_repository())
+
+        assert len(results) == 1
+        assert results[0].tail_overlay is None
+        assert "stable archive survives" in results[0].to_text(include_role=False)
+    finally:
+        await services.close()
+
+
+@pytest.mark.asyncio
+async def test_tail_overlay_delta_disappears_after_archive_catchup(
+    workspace_env: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    del workspace_env
+    home = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(home))
+    session_path = _write_claude_code_session(
+        home / ".claude" / "projects" / "project-d" / "session.jsonl",
+        assistant_text="first archived answer",
+    )
+
+    config, services = await _configured_services()
+    try:
+        await _ingest_claude_code_source(config, services)
+        _write_claude_code_session(session_path, assistant_text="caught up answer")
+        await _ingest_claude_code_source(config, services)
+
+        spec = ConversationQuerySpec(providers=(Provider.CLAUDE_CODE,), latest=True)
+
+        async with tail_overlay_services(services) as overlay_services:
+            results = await spec.list(overlay_services.get_repository())
+
+        assert len(results) == 1
+        assert results[0].tail_overlay is None
+        assert "caught up answer" in results[0].to_text(include_role=False)
+    finally:
+        await services.close()


### PR DESCRIPTION
## Summary

Add an opt-in `--tail` query mode that runs the normal query path against a
throwaway overlay archive built from source files that are ahead of stable
archive state. Query semantics stay the same as non-tail mode; the only
addition is machine-readable provenance showing when a result came from
source state the archive has not caught up to yet.

## Problem

`#308` originally used a looser “live session” framing, but the actual need is
narrower and more concrete: users want to tail sources that have advanced on
disk without inventing a separate transcript ontology or a second query model.
Before this change, Polylogue could only query the stable archive. Claude Code
sessions that were newer on disk were invisible until the next ingest, and any
attempt to expose that state risked drifting into bespoke live-only semantics.

## Solution

- add `polylogue.pipeline.tail_overlay` and `polylogue.lib.tail_overlay` to
  snapshot the stable archive into a temporary SQLite overlay and materialize
  ahead-of-archive Claude Code source state there
- keep the normal query planner and execution path intact by routing `--tail`
  queries through the overlay runtime services instead of inventing a second
  query surface
- expose tail provenance on conversation and summary runtime models plus JSON
  surface payloads
- preserve summary-query lightweight metadata behavior by projecting only the
  `tail_overlay` fragment out of `provider_meta`
- add read-only guardrails for mutation/delete/open routes while rendered
  artifacts still reflect stable archive state
- cover replacement, unseen-session, parse-failure fallback, catch-up, and CLI
  help/output behavior with direct runtime tests

## Verification

- `mypy --strict polylogue/cli/query.py polylogue/lib/tail_overlay.py polylogue/pipeline/tail_overlay.py polylogue/surface_payloads.py polylogue/lib/conversation_runtime.py polylogue/lib/conversation_summary_runtime.py polylogue/storage/backends/queries/conversations_reads.py`
- `pytest -q tests/unit/pipeline/test_tail_overlay_runtime.py tests/unit/cli/test_tail_query_runtime.py tests/unit/cli/test_click_app.py tests/unit/cli/test_query_exec.py`
- `pytest -q tests/unit/storage/test_store_ops.py::test_list_summaries_by_query_omits_large_provider_meta_payloads tests/unit/cli/test_tail_query_runtime.py tests/unit/cli/test_terminal_snapshots.py --snapshot-update`
- `devtools render-all`
- `devtools verify`
- `git push -u origin feature/feat/tail-ahead-of-archive-sessions` (pre-push `devtools verify --quick`)

Closes #308
