### PR TITLE
feat: add cost estimation products

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -297,6 +297,8 @@ Options:
 
 Commands:
   analytics       List provider-level analytics products.
+  cost-rollups    List provider/model cost rollups.
+  costs           List session-level cost estimates.
   day-summaries   List durable day-level session summary products.
   debt            List archive debt and maintenance readiness products.
   enrichments     List durable probabilistic session-enrichment products.

--- a/docs/test-quality-workflows.md
+++ b/docs/test-quality-workflows.md
@@ -15,10 +15,10 @@ Current registry snapshot:
 - mutation campaigns: `19`
 - benchmark campaigns: `3`
 - synthetic benchmark campaigns: `6`
-- scenario projections: `244`
+- scenario projections: `246`
 - inferred corpus scenarios: `5`
   - benchmark-campaign: `3`
-  - exercise: `138`
+  - exercise: `140`
   - inferred-corpus-scenario: `5`
   - mutation-campaign: `19`
   - synthetic-benchmark: `6`
@@ -337,6 +337,8 @@ These are the authored scenario-bearing projections currently feeding runtime co
 | `exercise` | `help-open` | `conversation-query-loop` | `message_fts`<br>`conversation_query_results` | `cli.help`<br>`query-conversations` | — | `generated`<br>`help`<br>`structural` | open help |
 | `exercise` | `help-products` | — | — | `cli.help` | — | `generated`<br>`help`<br>`structural` | products help |
 | `exercise` | `help-products-analytics` | `provider-analytics-query-loop` | `session_product_rows`<br>`provider_analytics_results` | `cli.help`<br>`query-provider-analytics` | — | `generated`<br>`help`<br>`structural` | products analytics help |
+| `exercise` | `help-products-cost-rollups` | — | — | `cli.help` | — | `generated`<br>`help`<br>`structural` | products cost-rollups help |
+| `exercise` | `help-products-costs` | — | — | `cli.help` | — | `generated`<br>`help`<br>`structural` | products costs help |
 | `exercise` | `help-products-day-summaries` | `day-summary-query-loop` | `day_session_summary_rows`<br>`day_session_summary_results` | `cli.help`<br>`query-day-session-summaries` | — | `generated`<br>`help`<br>`structural` | products day-summaries help |
 | `exercise` | `help-products-debt` | `archive-debt-query-loop` | `action_event_readiness`<br>`session_product_readiness`<br>`archive_readiness`<br>`archive_debt_results` | `cli.help`<br>`query-archive-debt` | — | `generated`<br>`help`<br>`structural` | products debt help |
 | `exercise` | `help-products-enrichments` | `session-enrichment-query-loop` | `session_profile_rows`<br>`session_profile_enrichment_fts`<br>`session_enrichment_results` | `cli.help`<br>`query-session-enrichments` | — | `generated`<br>`help`<br>`structural` | products enrichments help |

--- a/docs/verification-catalog.md
+++ b/docs/verification-catalog.md
@@ -8,10 +8,10 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 
 ## Snapshot
 
-- subjects: `9041`
+- subjects: `9043`
 - claims: `22`
 - runner bindings: `22`
-- proof obligations: `9132`
+- proof obligations: `9138`
 
 ## Quality Checks
 
@@ -31,7 +31,7 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | --- | ---: |
 | `archive.query_law` | 1 |
 | `artifact.path` | 27 |
-| `cli.command` | 45 |
+| `cli.command` | 47 |
 | `cli.json_command` | 2 |
 | `diagnostic.observable` | 1 |
 | `error.surface` | 2 |
@@ -62,6 +62,8 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | `polylogue open` | `polylogue/cli/query_verbs.py:76` `polylogue.cli.query_verbs.open_verb` |
 | `polylogue products` | `polylogue/cli/commands/products.py:139` `polylogue.cli.commands.products.products_command` |
 | `polylogue products analytics` | `polylogue/cli/commands/products.py:102` `polylogue.cli.commands.products._make_callback.<locals>.callback` |
+| `polylogue products cost-rollups` | `polylogue/cli/commands/products.py:102` `polylogue.cli.commands.products._make_callback.<locals>.callback` |
+| `polylogue products costs` | `polylogue/cli/commands/products.py:102` `polylogue.cli.commands.products._make_callback.<locals>.callback` |
 | `polylogue products day-summaries` | `polylogue/cli/commands/products.py:102` `polylogue.cli.commands.products._make_callback.<locals>.callback` |
 | `polylogue products debt` | `polylogue/cli/commands/products.py:102` `polylogue.cli.commands.products._make_callback.<locals>.callback` |
 | `polylogue products enrichments` | `polylogue/cli/commands/products.py:102` `polylogue.cli.commands.products._make_callback.<locals>.callback` |
@@ -189,10 +191,10 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | --- | ---: |
 | `archive.query.provider_filter_consistency` | 1 |
 | `artifact.path.dependency_closure` | 11 |
-| `cli.command.help` | 45 |
+| `cli.command.help` | 47 |
 | `cli.command.json_envelope` | 2 |
-| `cli.command.no_traceback` | 45 |
-| `cli.command.plain_mode` | 45 |
+| `cli.command.no_traceback` | 47 |
+| `cli.command.plain_mode` | 47 |
 | `diagnostic.observable_trace_mapping` | 1 |
 | `error.machine_user_context` | 2 |
 | `generated.scenario.family_registered` | 9 |

--- a/polylogue/archive_products.py
+++ b/polylogue/archive_products.py
@@ -23,6 +23,7 @@ from polylogue.archive_product_models import (
     WorkEventInferencePayload,
     WorkThreadPayload,
 )
+from polylogue.lib.pricing import CostEstimatePayload, CostUsagePayload
 from polylogue.lib.session_profile import SessionProfile
 from polylogue.storage.repair import ArchiveDebtStatus
 from polylogue.storage.store import (
@@ -121,6 +122,17 @@ class WeekSessionSummaryProductQuery(ProviderTimeWindowProductQuery):
 
 class ProviderAnalyticsProductQuery(PaginatedProductQuery):
     provider: str | None = None
+    limit: int | None = None
+
+
+class SessionCostProductQuery(ProviderTimeWindowProductQuery):
+    conversation_id: str | None = None
+    model: str | None = None
+    status: str | None = None
+
+
+class CostRollupProductQuery(ProviderTimeWindowProductQuery):
+    model: str | None = None
     limit: int | None = None
 
 
@@ -360,6 +372,36 @@ class ProviderAnalyticsProduct(ArchiveProductModel):
     thinking_percentage: float
 
 
+class SessionCostProduct(ArchiveProductModel):
+    contract_version: int = ARCHIVE_PRODUCT_CONTRACT_VERSION
+    product_kind: str = "session_cost"
+    semantic_tier: str = "estimate"
+    conversation_id: str
+    provider_name: str
+    title: str | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
+    estimate: CostEstimatePayload
+    provenance: ArchiveProductProvenance
+
+
+class CostRollupProduct(ArchiveProductModel):
+    contract_version: int = ARCHIVE_PRODUCT_CONTRACT_VERSION
+    product_kind: str = "cost_rollup"
+    semantic_tier: str = "estimate"
+    provider_name: str
+    model_name: str | None = None
+    normalized_model: str | None = None
+    session_count: int = 0
+    priced_session_count: int = 0
+    unavailable_session_count: int = 0
+    status_counts: dict[str, int]
+    total_usd: float = 0.0
+    usage: CostUsagePayload
+    confidence: float = 0.0
+    provenance: ArchiveProductProvenance
+
+
 class ArchiveDebtProduct(ArchiveProductModel):
     contract_version: int = ARCHIVE_PRODUCT_CONTRACT_VERSION
     product_kind: str = "archive_debt"
@@ -458,11 +500,15 @@ __all__ = [
     "ArchiveInferenceProvenance",
     "ArchiveProductModel",
     "ArchiveProductProvenance",
+    "CostRollupProduct",
+    "CostRollupProductQuery",
     "ArchiveProductUnavailableError",
     "DaySessionSummaryProduct",
     "DaySessionSummaryProductQuery",
     "ProviderAnalyticsProduct",
     "ProviderAnalyticsProductQuery",
+    "SessionCostProduct",
+    "SessionCostProductQuery",
     "SessionEnrichmentPayload",
     "SessionEnrichmentProduct",
     "SessionEnrichmentProductQuery",

--- a/polylogue/facade_products.py
+++ b/polylogue/facade_products.py
@@ -7,10 +7,14 @@ from typing import TYPE_CHECKING, Protocol
 from polylogue.archive_products import (
     ArchiveDebtProduct,
     ArchiveDebtProductQuery,
+    CostRollupProduct,
+    CostRollupProductQuery,
     DaySessionSummaryProduct,
     DaySessionSummaryProductQuery,
     ProviderAnalyticsProduct,
     ProviderAnalyticsProductQuery,
+    SessionCostProduct,
+    SessionCostProductQuery,
     SessionPhaseProduct,
     SessionPhaseProductQuery,
     SessionTagRollupProduct,
@@ -72,6 +76,16 @@ if TYPE_CHECKING:
             self,
             query: ProviderAnalyticsProductQuery | None = None,
         ) -> list[ProviderAnalyticsProduct]: ...
+
+        async def list_session_cost_products(
+            self,
+            query: SessionCostProductQuery | None = None,
+        ) -> list[SessionCostProduct]: ...
+
+        async def list_cost_rollup_products(
+            self,
+            query: CostRollupProductQuery | None = None,
+        ) -> list[CostRollupProduct]: ...
 
         async def list_archive_debt_products(
             self,
@@ -141,6 +155,18 @@ class PolylogueProductsMixin:
         query: ProviderAnalyticsProductQuery | None = None,
     ) -> list[ProviderAnalyticsProduct]:
         return await self.operations.list_provider_analytics_products(query)
+
+    async def list_session_cost_products(
+        self,
+        query: SessionCostProductQuery | None = None,
+    ) -> list[SessionCostProduct]:
+        return await self.operations.list_session_cost_products(query)
+
+    async def list_cost_rollup_products(
+        self,
+        query: CostRollupProductQuery | None = None,
+    ) -> list[CostRollupProduct]:
+        return await self.operations.list_cost_rollup_products(query)
 
     async def list_archive_debt_products(
         self,

--- a/polylogue/lib/pricing.py
+++ b/polylogue/lib/pricing.py
@@ -1,72 +1,291 @@
-"""Provider/model pricing table for cost estimation across all AI providers.
-
-Polylogue directly captures actual cost for Claude Code sessions as
-conversation-level totals. For all other providers (ChatGPT, Claude web, Gemini)
-cost must be estimated from token counts using public pricing.
-"""
+"""Typed provider/model cost estimation for archive conversations."""
 
 from __future__ import annotations
 
+from collections import Counter
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Literal
 
+from pydantic import BaseModel, ConfigDict, Field
+
+from polylogue.lib.json import json_document
 from polylogue.lib.semantic_facts import message_model_name, message_tokens
+from polylogue.lib.viewports import TokenUsage
 
 if TYPE_CHECKING:
-    from polylogue.lib.models import Conversation
+    from polylogue.lib.models import Conversation, Message
+
+CostEstimateStatus = Literal["exact", "priced", "partial", "unavailable"]
+
+LITELLM_PRICE_MAP_URL = "https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json"
+CATALOG_PROVENANCE = "polylogue-curated-litellm-shaped-seed"
+CATALOG_EFFECTIVE_DATE = "2026-04-24"
+
+
+class PricingModel(BaseModel):
+    """Base model for immutable cost-estimation payloads."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+class CostUsagePayload(PricingModel):
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read_tokens: int = 0
+    cache_write_tokens: int = 0
+    total_tokens: int = 0
+
+    @property
+    def billable_tokens(self) -> int:
+        return self.input_tokens + self.output_tokens + self.cache_read_tokens + self.cache_write_tokens
+
+    def plus(self, other: CostUsagePayload) -> CostUsagePayload:
+        return CostUsagePayload(
+            input_tokens=self.input_tokens + other.input_tokens,
+            output_tokens=self.output_tokens + other.output_tokens,
+            cache_read_tokens=self.cache_read_tokens + other.cache_read_tokens,
+            cache_write_tokens=self.cache_write_tokens + other.cache_write_tokens,
+            total_tokens=self.total_tokens + other.total_tokens,
+        )
+
+
+class CostPricePayload(PricingModel):
+    provider_name: str
+    model_name: str
+    normalized_model: str
+    currency: str = "USD"
+    input_usd_per_1m: float = 0.0
+    output_usd_per_1m: float = 0.0
+    cache_read_usd_per_1m: float = 0.0
+    cache_write_usd_per_1m: float = 0.0
+    provenance: str = CATALOG_PROVENANCE
+    source_url: str = LITELLM_PRICE_MAP_URL
+    effective_date: str = CATALOG_EFFECTIVE_DATE
+    historical_exact: bool = False
+
+
+class CostComponentPayload(PricingModel):
+    name: str
+    tokens: int = 0
+    usd: float = 0.0
+
+
+class CostEstimatePayload(PricingModel):
+    provider_name: str
+    conversation_id: str | None = None
+    message_id: str | None = None
+    model_name: str | None = None
+    normalized_model: str | None = None
+    status: CostEstimateStatus
+    confidence: float = 0.0
+    currency: str = "USD"
+    total_usd: float = 0.0
+    usage: CostUsagePayload = Field(default_factory=CostUsagePayload)
+    price: CostPricePayload | None = None
+    components: tuple[CostComponentPayload, ...] = ()
+    missing_reasons: tuple[str, ...] = ()
+    provenance: tuple[str, ...] = ()
+
+    @property
+    def priced(self) -> bool:
+        return self.status in {"exact", "priced", "partial"}
 
 
 @dataclass(frozen=True)
 class ModelPricing:
-    """Per-million-token pricing for a specific model."""
+    """Per-million-token pricing for a normalized model identifier."""
 
+    provider_name: str
     input_usd_per_1m: float
     output_usd_per_1m: float
     cache_read_usd_per_1m: float = 0.0
+    cache_write_usd_per_1m: float = 0.0
+    currency: str = "USD"
+    source_url: str = LITELLM_PRICE_MAP_URL
+    provenance: str = CATALOG_PROVENANCE
+    effective_date: str = CATALOG_EFFECTIVE_DATE
+
+    def to_payload(self, *, model_name: str, normalized_model: str) -> CostPricePayload:
+        return CostPricePayload(
+            provider_name=self.provider_name,
+            model_name=model_name,
+            normalized_model=normalized_model,
+            currency=self.currency,
+            input_usd_per_1m=self.input_usd_per_1m,
+            output_usd_per_1m=self.output_usd_per_1m,
+            cache_read_usd_per_1m=self.cache_read_usd_per_1m,
+            cache_write_usd_per_1m=self.cache_write_usd_per_1m,
+            provenance=self.provenance,
+            source_url=self.source_url,
+            effective_date=self.effective_date,
+        )
 
 
-# Public pricing as of early 2026 (USD per 1M tokens)
+# Curated seed shaped after LiteLLM's model price map. Costs are USD per
+# 1M tokens. This is intentionally small and provenance-marked; provider-
+# reported exact archive costs still take precedence.
 PRICING: dict[str, ModelPricing] = {
-    # Anthropic Claude 4 family
-    "claude-opus-4-6": ModelPricing(15.0, 75.0, 1.5),
-    "claude-opus-4-5": ModelPricing(15.0, 75.0, 1.5),
-    "claude-sonnet-4-6": ModelPricing(3.0, 15.0, 0.3),
-    "claude-sonnet-4-5": ModelPricing(3.0, 15.0, 0.3),
-    "claude-haiku-4-5": ModelPricing(0.8, 4.0, 0.08),
-    # Anthropic Claude 3.x
-    "claude-3-5-sonnet-20241022": ModelPricing(3.0, 15.0, 0.3),
-    "claude-3-5-sonnet-20240620": ModelPricing(3.0, 15.0, 0.3),
-    "claude-3-5-haiku-20241022": ModelPricing(0.8, 4.0, 0.08),
-    "claude-3-opus-20240229": ModelPricing(15.0, 75.0, 1.5),
-    "claude-3-sonnet-20240229": ModelPricing(3.0, 15.0, 0.3),
-    "claude-3-haiku-20240307": ModelPricing(0.25, 1.25, 0.03),
-    # OpenAI GPT-4
-    "gpt-4o": ModelPricing(2.5, 10.0),
-    "gpt-4o-mini": ModelPricing(0.15, 0.6),
-    "gpt-4-turbo": ModelPricing(10.0, 30.0),
-    "gpt-4": ModelPricing(30.0, 60.0),
-    "gpt-3.5-turbo": ModelPricing(0.5, 1.5),
-    "o1": ModelPricing(15.0, 60.0),
-    "o1-mini": ModelPricing(3.0, 12.0),
-    "o3": ModelPricing(10.0, 40.0),
-    "o3-mini": ModelPricing(1.1, 4.4),
-    # Google Gemini
-    "gemini-1.5-pro": ModelPricing(3.5, 10.5),
-    "gemini-1.5-flash": ModelPricing(0.075, 0.3),
-    "gemini-2.0-flash": ModelPricing(0.1, 0.4),
-    "gemini-2.5-pro": ModelPricing(1.25, 10.0),
+    "claude-opus-4-6": ModelPricing("anthropic", 15.0, 75.0, 1.5, 18.75),
+    "claude-opus-4-5": ModelPricing("anthropic", 15.0, 75.0, 1.5, 18.75),
+    "claude-sonnet-4-6": ModelPricing("anthropic", 3.0, 15.0, 0.3, 3.75),
+    "claude-sonnet-4-5": ModelPricing("anthropic", 3.0, 15.0, 0.3, 3.75),
+    "claude-haiku-4-5": ModelPricing("anthropic", 0.8, 4.0, 0.08, 1.0),
+    "claude-3-5-sonnet-20241022": ModelPricing("anthropic", 3.0, 15.0, 0.3, 3.75),
+    "claude-3-5-sonnet-20240620": ModelPricing("anthropic", 3.0, 15.0, 0.3, 3.75),
+    "claude-3-5-haiku-20241022": ModelPricing("anthropic", 0.8, 4.0, 0.08, 1.0),
+    "claude-3-opus-20240229": ModelPricing("anthropic", 15.0, 75.0, 1.5, 18.75),
+    "claude-3-sonnet-20240229": ModelPricing("anthropic", 3.0, 15.0, 0.3, 3.75),
+    "claude-3-haiku-20240307": ModelPricing("anthropic", 0.25, 1.25, 0.03, 0.3),
+    "gpt-4o": ModelPricing("openai", 2.5, 10.0),
+    "gpt-4o-mini": ModelPricing("openai", 0.15, 0.6),
+    "gpt-4-turbo": ModelPricing("openai", 10.0, 30.0),
+    "gpt-4": ModelPricing("openai", 30.0, 60.0),
+    "gpt-3.5-turbo": ModelPricing("openai", 0.5, 1.5),
+    "o1": ModelPricing("openai", 15.0, 60.0),
+    "o1-mini": ModelPricing("openai", 3.0, 12.0),
+    "o3": ModelPricing("openai", 10.0, 40.0),
+    "o3-mini": ModelPricing("openai", 1.1, 4.4),
+    "gemini-1.5-pro": ModelPricing("google", 3.5, 10.5),
+    "gemini-1.5-flash": ModelPricing("google", 0.075, 0.3),
+    "gemini-2.0-flash": ModelPricing("google", 0.1, 0.4),
+    "gemini-2.5-pro": ModelPricing("google", 1.25, 10.0),
 }
 
 
+def _coerce_float(value: object) -> float | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError:
+            return None
+    return None
+
+
+def _coerce_int(value: object) -> int:
+    if isinstance(value, bool) or value is None:
+        return 0
+    if isinstance(value, int):
+        return max(value, 0)
+    if isinstance(value, float):
+        return max(int(value), 0)
+    if isinstance(value, str):
+        try:
+            return max(int(float(value)), 0)
+        except ValueError:
+            return 0
+    return 0
+
+
+def _record(value: object) -> Mapping[str, object]:
+    document = json_document(value)
+    return document or {}
+
+
+def _provider_text(value: object) -> str:
+    return str(value) if value is not None else "unknown"
+
+
 def _normalize_model(model: str) -> str:
-    """Normalize a model name for lookup, trying prefix matches."""
-    if model in PRICING:
-        return model
-    # Try prefix: "claude-sonnet-4-6-20250101" → "claude-sonnet-4-6"
+    """Normalize a provider model name for catalog lookup."""
+
+    candidate = model.strip()
+    if not candidate:
+        return candidate
+    lowered = candidate.casefold()
+    lowered = lowered.removeprefix("openai/")
+    lowered = lowered.removeprefix("anthropic/")
+    lowered = lowered.removeprefix("google/")
+    lowered = lowered.removeprefix("gemini/")
+    if lowered in PRICING:
+        return lowered
     for key in PRICING:
-        if model.startswith(key):
+        if lowered.startswith(key):
             return key
-    return model
+    return lowered
+
+
+def _usage_payload(value: object) -> CostUsagePayload:
+    usage = _record(value)
+    input_tokens = _coerce_int(
+        usage.get("input_tokens")
+        or usage.get("prompt_tokens")
+        or usage.get("inputTokenCount")
+        or usage.get("promptTokenCount")
+    )
+    output_tokens = _coerce_int(
+        usage.get("output_tokens")
+        or usage.get("completion_tokens")
+        or usage.get("outputTokenCount")
+        or usage.get("candidatesTokenCount")
+    )
+    cache_read_tokens = _coerce_int(
+        usage.get("cache_read_tokens")
+        or usage.get("cache_read_input_tokens")
+        or usage.get("cached_tokens")
+        or usage.get("cachedContentTokenCount")
+    )
+    cache_write_tokens = _coerce_int(
+        usage.get("cache_write_tokens")
+        or usage.get("cache_creation_input_tokens")
+        or usage.get("cache_creation_tokens")
+    )
+    explicit_total = _coerce_int(usage.get("total_tokens") or usage.get("totalTokenCount"))
+    total = explicit_total or input_tokens + output_tokens + cache_read_tokens + cache_write_tokens
+    return CostUsagePayload(
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cache_read_tokens=cache_read_tokens,
+        cache_write_tokens=cache_write_tokens,
+        total_tokens=total,
+    )
+
+
+def _token_usage_payload(tokens: TokenUsage | None) -> CostUsagePayload:
+    if tokens is None:
+        return CostUsagePayload()
+    input_tokens = tokens.input_tokens or 0
+    output_tokens = tokens.output_tokens or 0
+    cache_read_tokens = tokens.cache_read_tokens or 0
+    cache_write_tokens = tokens.cache_write_tokens or 0
+    total = tokens.total_tokens or input_tokens + output_tokens + cache_read_tokens + cache_write_tokens
+    return CostUsagePayload(
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cache_read_tokens=cache_read_tokens,
+        cache_write_tokens=cache_write_tokens,
+        total_tokens=total,
+    )
+
+
+def _cost_components(usage: CostUsagePayload, pricing: ModelPricing) -> tuple[CostComponentPayload, ...]:
+    return (
+        CostComponentPayload(
+            name="input",
+            tokens=usage.input_tokens,
+            usd=usage.input_tokens * pricing.input_usd_per_1m / 1_000_000,
+        ),
+        CostComponentPayload(
+            name="output",
+            tokens=usage.output_tokens,
+            usd=usage.output_tokens * pricing.output_usd_per_1m / 1_000_000,
+        ),
+        CostComponentPayload(
+            name="cache_read",
+            tokens=usage.cache_read_tokens,
+            usd=usage.cache_read_tokens * pricing.cache_read_usd_per_1m / 1_000_000,
+        ),
+        CostComponentPayload(
+            name="cache_write",
+            tokens=usage.cache_write_tokens,
+            usd=usage.cache_write_tokens * pricing.cache_write_usd_per_1m / 1_000_000,
+        ),
+    )
 
 
 def estimate_cost(
@@ -74,45 +293,281 @@ def estimate_cost(
     output_tokens: int,
     model: str,
     cache_read_tokens: int = 0,
+    cache_write_tokens: int = 0,
 ) -> float:
-    """Estimate cost from token counts using public pricing table.
+    """Estimate cost from token counts using the curated price catalog."""
 
-    Returns 0.0 if the model is unknown.
-    """
-    pricing = PRICING.get(_normalize_model(model))
-    if not pricing:
+    normalized_model = _normalize_model(model)
+    pricing = PRICING.get(normalized_model)
+    if pricing is None:
         return 0.0
-    return (
-        input_tokens * pricing.input_usd_per_1m / 1_000_000
-        + output_tokens * pricing.output_usd_per_1m / 1_000_000
-        + cache_read_tokens * pricing.cache_read_usd_per_1m / 1_000_000
+    usage = CostUsagePayload(
+        input_tokens=max(input_tokens, 0),
+        output_tokens=max(output_tokens, 0),
+        cache_read_tokens=max(cache_read_tokens, 0),
+        cache_write_tokens=max(cache_write_tokens, 0),
+    )
+    return sum(component.usd for component in _cost_components(usage, pricing))
+
+
+def _exact_estimate(
+    *,
+    provider_name: str,
+    total_usd: float,
+    conversation_id: str | None = None,
+    message_id: str | None = None,
+    model_name: str | None = None,
+    usage: CostUsagePayload | None = None,
+) -> CostEstimatePayload:
+    normalized_model = _normalize_model(model_name) if model_name else None
+    return CostEstimatePayload(
+        provider_name=provider_name,
+        conversation_id=conversation_id,
+        message_id=message_id,
+        model_name=model_name,
+        normalized_model=normalized_model,
+        status="exact",
+        confidence=1.0,
+        total_usd=total_usd,
+        usage=usage or CostUsagePayload(),
+        components=(CostComponentPayload(name="provider_reported_total", usd=total_usd),),
+        provenance=("archive_provider_reported_cost",),
+    )
+
+
+def _estimate_from_usage(
+    *,
+    provider_name: str,
+    model_name: str | None,
+    usage: CostUsagePayload,
+    conversation_id: str | None = None,
+    message_id: str | None = None,
+    provenance: tuple[str, ...],
+) -> CostEstimatePayload:
+    if model_name is None or not model_name.strip():
+        return CostEstimatePayload(
+            provider_name=provider_name,
+            conversation_id=conversation_id,
+            message_id=message_id,
+            status="unavailable",
+            confidence=0.0,
+            usage=usage,
+            missing_reasons=("missing_model",),
+            provenance=provenance,
+        )
+    if usage.billable_tokens <= 0:
+        return CostEstimatePayload(
+            provider_name=provider_name,
+            conversation_id=conversation_id,
+            message_id=message_id,
+            model_name=model_name,
+            normalized_model=_normalize_model(model_name),
+            status="unavailable",
+            confidence=0.0,
+            usage=usage,
+            missing_reasons=("missing_token_usage",),
+            provenance=provenance,
+        )
+    normalized_model = _normalize_model(model_name)
+    pricing = PRICING.get(normalized_model)
+    if pricing is None:
+        return CostEstimatePayload(
+            provider_name=provider_name,
+            conversation_id=conversation_id,
+            message_id=message_id,
+            model_name=model_name,
+            normalized_model=normalized_model,
+            status="unavailable",
+            confidence=0.0,
+            usage=usage,
+            missing_reasons=("missing_price",),
+            provenance=provenance,
+        )
+    components = _cost_components(usage, pricing)
+    return CostEstimatePayload(
+        provider_name=provider_name,
+        conversation_id=conversation_id,
+        message_id=message_id,
+        model_name=model_name,
+        normalized_model=normalized_model,
+        status="priced",
+        confidence=0.85,
+        total_usd=sum(component.usd for component in components),
+        usage=usage,
+        price=pricing.to_payload(model_name=model_name, normalized_model=normalized_model),
+        components=components,
+        provenance=(*provenance, CATALOG_PROVENANCE),
+    )
+
+
+def estimate_message_cost(
+    message: Message,
+    *,
+    provider_name: str,
+    conversation_id: str | None = None,
+    fallback_model: str | None = None,
+) -> CostEstimatePayload:
+    """Estimate one message cost with explicit uncertainty."""
+
+    exact = message.cost_usd
+    provider_meta = _record(message.provider_meta)
+    raw = _record(provider_meta.get("raw")) or provider_meta
+    model_name = message_model_name(message) or str(raw.get("model") or fallback_model or "").strip() or None
+    usage = _token_usage_payload(message_tokens(message))
+    if usage.billable_tokens <= 0:
+        usage = _usage_payload(raw.get("usage") or raw.get("tokens") or raw)
+    if exact is not None and exact > 0.0:
+        return _exact_estimate(
+            provider_name=provider_name,
+            conversation_id=conversation_id,
+            message_id=str(message.id),
+            model_name=model_name,
+            usage=usage,
+            total_usd=exact,
+        )
+    return _estimate_from_usage(
+        provider_name=provider_name,
+        conversation_id=conversation_id,
+        message_id=str(message.id),
+        model_name=model_name,
+        usage=usage,
+        provenance=("message_token_usage",),
+    )
+
+
+def _conversation_level_estimate(conversation: Conversation) -> CostEstimatePayload | None:
+    provider_name = _provider_text(conversation.provider)
+    provider_meta = _record(conversation.provider_meta)
+    raw = _record(provider_meta.get("raw")) or provider_meta
+    exact = (
+        _coerce_float(raw.get("total_cost_usd"))
+        or _coerce_float(raw.get("costUSD"))
+        or _coerce_float(raw.get("cost_usd"))
+    )
+    model_name = str(raw.get("model") or raw.get("model_slug") or "").strip() or None
+    usage = _usage_payload(raw.get("usage") or raw.get("tokens") or raw)
+    if exact is not None and exact > 0.0:
+        return _exact_estimate(
+            provider_name=provider_name,
+            conversation_id=str(conversation.id),
+            model_name=model_name,
+            usage=usage,
+            total_usd=exact,
+        )
+    if usage.billable_tokens > 0 or model_name:
+        return _estimate_from_usage(
+            provider_name=provider_name,
+            conversation_id=str(conversation.id),
+            model_name=model_name,
+            usage=usage,
+            provenance=("conversation_provider_meta",),
+        )
+    return None
+
+
+def _dominant_model(estimates: Iterable[CostEstimatePayload]) -> tuple[str | None, str | None]:
+    counts: Counter[tuple[str | None, str | None]] = Counter()
+    for estimate in estimates:
+        if estimate.model_name or estimate.normalized_model:
+            counts[(estimate.model_name, estimate.normalized_model)] += 1
+    if not counts:
+        return None, None
+    return counts.most_common(1)[0][0]
+
+
+def estimate_conversation_cost(conversation: Conversation) -> CostEstimatePayload:
+    """Estimate cost for a conversation/session with confidence metadata."""
+
+    provider_name = _provider_text(conversation.provider)
+    conversation_estimate = _conversation_level_estimate(conversation)
+    if conversation_estimate is not None and conversation_estimate.status == "exact":
+        return conversation_estimate
+
+    message_estimates = [
+        estimate_message_cost(
+            message,
+            provider_name=provider_name,
+            conversation_id=str(conversation.id),
+            fallback_model=conversation_estimate.model_name if conversation_estimate else None,
+        )
+        for message in conversation.messages
+    ]
+    priced = [estimate for estimate in message_estimates if estimate.priced]
+    if not message_estimates and conversation_estimate is not None:
+        return conversation_estimate
+    if not priced and conversation_estimate is not None:
+        return conversation_estimate
+    if not priced:
+        missing = ("missing_token_usage",) if message_estimates else ("no_messages",)
+        return CostEstimatePayload(
+            provider_name=provider_name,
+            conversation_id=str(conversation.id),
+            status="unavailable",
+            confidence=0.0,
+            missing_reasons=missing,
+            provenance=("conversation_messages",),
+        )
+
+    usage = CostUsagePayload()
+    total_usd = 0.0
+    components: list[CostComponentPayload] = []
+    missing_reasons: list[str] = []
+    provenance: list[str] = []
+    for estimate in message_estimates:
+        usage = usage.plus(estimate.usage)
+        total_usd += estimate.total_usd
+        components.extend(estimate.components)
+        missing_reasons.extend(estimate.missing_reasons)
+        provenance.extend(estimate.provenance)
+    model_name, normalized_model = _dominant_model(message_estimates)
+    missing_count = len(message_estimates) - len(priced)
+    status: CostEstimateStatus = "priced" if missing_count == 0 else "partial"
+    confidence = 0.85 if status == "priced" else 0.55
+    if conversation_estimate is not None and conversation_estimate.status == "priced":
+        # Prefer conversation-level usage when present; it avoids double-counting
+        # per-message fallbacks from providers that report only session totals.
+        return conversation_estimate
+    return CostEstimatePayload(
+        provider_name=provider_name,
+        conversation_id=str(conversation.id),
+        model_name=model_name,
+        normalized_model=normalized_model,
+        status=status,
+        confidence=confidence,
+        total_usd=total_usd,
+        usage=usage,
+        components=tuple(components),
+        missing_reasons=tuple(sorted(set(missing_reasons))),
+        provenance=tuple(sorted(set(provenance))),
     )
 
 
 def harmonize_session_cost(conversation: Conversation) -> tuple[float, bool]:
-    """Return (cost_usd, is_estimated) for a conversation.
+    """Return the legacy ``(cost_usd, is_estimated)`` session-cost tuple."""
 
-    - If actual session cost metadata is present, use it directly (is_estimated=False).
-    - Otherwise, sum token counts from messages and look up pricing (is_estimated=True).
-    - Returns (0.0, True) if no cost data is available.
-    """
-    # Ingest persists actual Claude Code cost as conversation-level totals.
-    actual = conversation.total_cost_usd
-    if actual and actual > 0.0:
-        return actual, False
+    estimate = estimate_conversation_cost(conversation)
+    return estimate.total_usd, estimate.status != "exact"
 
-    # Try to estimate from token counts
-    total_estimated = 0.0
-    for msg in conversation.messages:
-        tokens = message_tokens(msg)
-        if tokens is None:
-            continue
-        model_name = message_model_name(msg)
-        if not model_name:
-            continue
-        input_tok = getattr(tokens, "input_tokens", 0) or 0
-        output_tok = getattr(tokens, "output_tokens", 0) or 0
-        cache_tok = getattr(tokens, "cache_read_tokens", 0) or 0
-        total_estimated += estimate_cost(input_tok, output_tok, model_name, cache_tok)
 
-    return total_estimated, True  # is_estimated=True even if 0 (unknown model)
+def generated_at() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+__all__ = [
+    "CATALOG_EFFECTIVE_DATE",
+    "CATALOG_PROVENANCE",
+    "LITELLM_PRICE_MAP_URL",
+    "CostComponentPayload",
+    "CostEstimatePayload",
+    "CostEstimateStatus",
+    "CostPricePayload",
+    "CostUsagePayload",
+    "ModelPricing",
+    "PRICING",
+    "_normalize_model",
+    "estimate_conversation_cost",
+    "estimate_cost",
+    "estimate_message_cost",
+    "generated_at",
+    "harmonize_session_cost",
+]

--- a/polylogue/operations/archive.py
+++ b/polylogue/operations/archive.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections import Counter
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, TypeVar, cast
@@ -16,11 +17,16 @@ from polylogue.archive_product_summaries import (
 from polylogue.archive_products import (
     ArchiveDebtProduct,
     ArchiveDebtProductQuery,
+    ArchiveProductProvenance,
     ArchiveProductUnavailableError,
+    CostRollupProduct,
+    CostRollupProductQuery,
     DaySessionSummaryProduct,
     DaySessionSummaryProductQuery,
     ProviderAnalyticsProduct,
     ProviderAnalyticsProductQuery,
+    SessionCostProduct,
+    SessionCostProductQuery,
     SessionEnrichmentProduct,
     SessionEnrichmentProductQuery,
     SessionPhaseProduct,
@@ -39,6 +45,7 @@ from polylogue.archive_products import (
 from polylogue.archive_resume import ResumeBrief, ResumeOperations, build_resume_brief
 from polylogue.lib.content_projection import ContentProjectionSpec
 from polylogue.lib.conversation_models import ConversationSummary
+from polylogue.lib.pricing import CostUsagePayload, _normalize_model, estimate_conversation_cost, generated_at
 from polylogue.lib.query_spec import ConversationQuerySpec
 from polylogue.maintenance_targets import build_maintenance_target_catalog
 from polylogue.paths.sanitize import conversation_render_root
@@ -62,6 +69,7 @@ from polylogue.storage.session_product_runtime import (
     SessionProductReadyFlag,
     SessionProductStatusSnapshot,
 )
+from polylogue.storage.store_constants import SESSION_PRODUCT_MATERIALIZER_VERSION
 from polylogue.types import Provider
 
 logger = structlog.get_logger(__name__)
@@ -212,6 +220,36 @@ def provider_analytics_product(row: ProviderMetricsRow) -> ProviderAnalyticsProd
         tool_use_percentage=tool_use_percentage,
         thinking_percentage=thinking_percentage,
     )
+
+
+def _session_cost_product(conversation: Conversation, *, materialized_at: str) -> SessionCostProduct:
+    estimate = estimate_conversation_cost(conversation)
+    source_updated = conversation.updated_at or conversation.created_at
+    return SessionCostProduct(
+        conversation_id=str(conversation.id),
+        provider_name=str(conversation.provider),
+        title=conversation.title,
+        created_at=conversation.created_at.isoformat() if conversation.created_at is not None else None,
+        updated_at=conversation.updated_at.isoformat() if conversation.updated_at is not None else None,
+        estimate=estimate,
+        provenance=ArchiveProductProvenance(
+            materializer_version=SESSION_PRODUCT_MATERIALIZER_VERSION,
+            materialized_at=materialized_at,
+            source_updated_at=source_updated.isoformat() if source_updated is not None else None,
+            source_sort_key=source_updated.timestamp() if source_updated is not None else None,
+        ),
+    )
+
+
+def _cost_model_matches(product: SessionCostProduct, model_filter: str | None) -> bool:
+    if not model_filter:
+        return True
+    normalized_filter = _normalize_model(model_filter)
+    return product.estimate.model_name == model_filter or product.estimate.normalized_model == normalized_filter
+
+
+def _cost_status_matches(product: SessionCostProduct, status_filter: str | None) -> bool:
+    return not status_filter or product.estimate.status == status_filter
 
 
 def _require_ready_flag(
@@ -694,6 +732,105 @@ class ArchiveProductAggregateMixin:
         if request.provider:
             products = [product for product in products if product.provider_name == request.provider]
         return _slice_products(products, offset=request.offset, limit=request.limit)
+
+    async def list_session_cost_products(
+        self,
+        query: SessionCostProductQuery | None = None,
+    ) -> list[SessionCostProduct]:
+        request = _default_query(query, SessionCostProductQuery)
+        conversations = await self.repository.list(
+            provider=request.provider,
+            since=request.since,
+            until=request.until,
+            limit=None,
+        )
+        materialized_at = generated_at()
+        products = [
+            _session_cost_product(conversation, materialized_at=materialized_at) for conversation in conversations
+        ]
+        if request.conversation_id:
+            products = [product for product in products if product.conversation_id == request.conversation_id]
+        products = [product for product in products if _cost_model_matches(product, request.model)]
+        products = [product for product in products if _cost_status_matches(product, request.status)]
+        products.sort(key=lambda product: product.provenance.source_sort_key or 0.0, reverse=True)
+        return _slice_products(products, offset=request.offset, limit=request.limit)
+
+    async def list_cost_rollup_products(
+        self,
+        query: CostRollupProductQuery | None = None,
+    ) -> list[CostRollupProduct]:
+        request = _default_query(query, CostRollupProductQuery)
+        session_products = await self.list_session_cost_products(
+            SessionCostProductQuery(
+                provider=request.provider,
+                since=request.since,
+                until=request.until,
+                model=request.model,
+                limit=None,
+            )
+        )
+        grouped: dict[tuple[str, str | None], list[SessionCostProduct]] = {}
+        for product in session_products:
+            key = (product.provider_name, product.estimate.normalized_model or product.estimate.model_name)
+            grouped.setdefault(key, []).append(product)
+
+        rollups: list[CostRollupProduct] = []
+        for (provider_name, normalized_model), products in sorted(
+            grouped.items(),
+            key=lambda item: (item[0][0], item[0][1] or ""),
+        ):
+            usage = CostUsagePayload()
+            status_counts: Counter[str] = Counter()
+            total_usd = 0.0
+            priced_count = 0
+            confidence_total = 0.0
+            source_updated_at = max(
+                (
+                    product.provenance.source_updated_at
+                    for product in products
+                    if product.provenance.source_updated_at is not None
+                ),
+                default=None,
+            )
+            source_sort_key = max(
+                (
+                    product.provenance.source_sort_key
+                    for product in products
+                    if product.provenance.source_sort_key is not None
+                ),
+                default=None,
+            )
+            model_names = Counter(product.estimate.model_name for product in products if product.estimate.model_name)
+            for product in products:
+                estimate = product.estimate
+                usage = usage.plus(estimate.usage)
+                status_counts[estimate.status] += 1
+                total_usd += estimate.total_usd
+                if estimate.priced:
+                    priced_count += 1
+                    confidence_total += estimate.confidence
+            rollups.append(
+                CostRollupProduct(
+                    provider_name=provider_name,
+                    model_name=model_names.most_common(1)[0][0] if model_names else None,
+                    normalized_model=normalized_model,
+                    session_count=len(products),
+                    priced_session_count=priced_count,
+                    unavailable_session_count=status_counts["unavailable"],
+                    status_counts=dict(sorted(status_counts.items())),
+                    total_usd=total_usd,
+                    usage=usage,
+                    confidence=(confidence_total / priced_count if priced_count else 0.0),
+                    provenance=ArchiveProductProvenance(
+                        materializer_version=SESSION_PRODUCT_MATERIALIZER_VERSION,
+                        materialized_at=generated_at(),
+                        source_updated_at=source_updated_at,
+                        source_sort_key=source_sort_key,
+                    ),
+                )
+            )
+        rollups.sort(key=lambda product: product.total_usd, reverse=True)
+        return _slice_products(rollups, offset=request.offset, limit=request.limit)
 
     async def get_product_readiness_report(
         self,

--- a/polylogue/products/registry.py
+++ b/polylogue/products/registry.py
@@ -25,8 +25,10 @@ import click
 from polylogue.archive_products import (
     ArchiveDebtProductQuery,
     ArchiveProductModel,
+    CostRollupProductQuery,
     DaySessionSummaryProductQuery,
     ProviderAnalyticsProductQuery,
+    SessionCostProductQuery,
     SessionEnrichmentProductQuery,
     SessionPhaseProductQuery,
     SessionProfileProductQuery,
@@ -512,6 +514,54 @@ register(
             ProductField("avg_messages", _formatted_float("avg_messages_per_conversation"), group=0),
             ProductField("tools", _count_with_percentage("tool_use_count", "tool_use_percentage"), group=1),
             ProductField("thinking", _count_with_percentage("thinking_count", "thinking_percentage"), group=1),
+        ),
+    )
+)
+
+register(
+    ProductType(
+        name="session_costs",
+        display_name="Session Costs",
+        json_key="session_costs",
+        empty_message="No session cost estimates matched.",
+        query_model=SessionCostProductQuery,
+        operations_method_name="list_session_cost_products",
+        cli_command_name="costs",
+        cli_help="List session-level cost estimates.",
+        cli_options=(
+            CliOption("conversation_id", ("--conversation-id",), help="Only one conversation"),
+            CliOption("model", ("--model",), help="Only this model or normalized model"),
+            CliOption("status", ("--status",), type=click.Choice(["exact", "priced", "partial", "unavailable"])),
+        ),
+        fields=(
+            ProductField("", _id_with_provider("conversation_id"), group=0),
+            ProductField("status", _nested("estimate", "status"), group=0),
+            ProductField("model", _nested("estimate", "normalized_model"), group=0),
+            ProductField("usd", _nested("estimate", "total_usd", "0"), group=1),
+            ProductField("confidence", _nested("estimate", "confidence", "0"), group=1),
+        ),
+    )
+)
+
+register(
+    ProductType(
+        name="cost_rollups",
+        display_name="Cost Rollups",
+        json_key="cost_rollups",
+        empty_message="No cost rollups matched.",
+        query_model=CostRollupProductQuery,
+        operations_method_name="list_cost_rollup_products",
+        cli_command_name="cost-rollups",
+        cli_help="List provider/model cost rollups.",
+        cli_options=(CliOption("model", ("--model",), help="Only this model or normalized model"),),
+        fields=(
+            ProductField("", _attr("provider_name"), group=0),
+            ProductField("model", _attr("normalized_model"), group=0),
+            ProductField("sessions", _attr("session_count", "0"), group=0),
+            ProductField("priced", _attr("priced_session_count", "0"), group=1),
+            ProductField("unavailable", _attr("unavailable_session_count", "0"), group=1),
+            ProductField("usd", _attr("total_usd", "0"), group=1),
+            ProductField("confidence", _attr("confidence", "0"), group=1),
         ),
     )
 )

--- a/polylogue/sync_product_queries.py
+++ b/polylogue/sync_product_queries.py
@@ -7,10 +7,14 @@ from typing import TYPE_CHECKING
 from polylogue.archive_products import (
     ArchiveDebtProduct,
     ArchiveDebtProductQuery,
+    CostRollupProduct,
+    CostRollupProductQuery,
     DaySessionSummaryProduct,
     DaySessionSummaryProductQuery,
     ProviderAnalyticsProduct,
     ProviderAnalyticsProductQuery,
+    SessionCostProduct,
+    SessionCostProductQuery,
     SessionEnrichmentProduct,
     SessionEnrichmentProductQuery,
     SessionPhaseProduct,
@@ -114,6 +118,18 @@ class SyncProductQueriesMixin:
         query: ProviderAnalyticsProductQuery | None = None,
     ) -> list[ProviderAnalyticsProduct]:
         return run_coroutine_sync(self._facade.list_provider_analytics_products(query))
+
+    def list_session_cost_products(
+        self,
+        query: SessionCostProductQuery | None = None,
+    ) -> list[SessionCostProduct]:
+        return run_coroutine_sync(self._facade.list_session_cost_products(query))
+
+    def list_cost_rollup_products(
+        self,
+        query: CostRollupProductQuery | None = None,
+    ) -> list[CostRollupProduct]:
+        return run_coroutine_sync(self._facade.list_cost_rollup_products(query))
 
     def list_archive_debt_products(
         self,

--- a/tests/infra/storage_records.py
+++ b/tests/infra/storage_records.py
@@ -655,6 +655,10 @@ class ConversationBuilder:
         self.conv = self.conv.model_copy(update={"metadata": metadata})
         return self
 
+    def provider_meta(self, provider_meta: JSONRecord | None) -> ConversationBuilder:
+        self.conv = self.conv.model_copy(update={"provider_meta": provider_meta})
+        return self
+
     def parent_conversation(self, parent_id: str) -> ConversationBuilder:
         self.conv = self.conv.model_copy(update={"parent_conversation_id": _conversation_id(parent_id)})
         return self

--- a/tests/unit/cli/test_products.py
+++ b/tests/unit/cli/test_products.py
@@ -141,6 +141,36 @@ def _seed_products(cli_workspace: CliWorkspace) -> None:
         rebuild_action_event_read_model_sync(conn)
 
 
+def _seed_cost_products(cli_workspace: CliWorkspace) -> None:
+    db_path = cli_workspace["db_path"]
+    (
+        ConversationBuilder(db_path, "conv-exact-cost")
+        .provider("claude-code")
+        .title("Exact Cost")
+        .provider_meta({"total_cost_usd": 1.25, "model": "claude-sonnet-4-5"})
+        .updated_at("2026-03-01T12:00:00+00:00")
+        .add_message("u1", role="user", text="Run exact-cost task", timestamp="2026-03-01T11:55:00+00:00")
+        .save()
+    )
+    (
+        ConversationBuilder(db_path, "conv-priced-cost")
+        .provider("chatgpt")
+        .title("Priced Cost")
+        .provider_meta({"model": "openai/gpt-4o-2024-08-06", "usage": {"input_tokens": 1000, "output_tokens": 500}})
+        .updated_at("2026-03-01T13:00:00+00:00")
+        .add_message("u2", role="user", text="Run priced-cost task", timestamp="2026-03-01T12:55:00+00:00")
+        .save()
+    )
+    (
+        ConversationBuilder(db_path, "conv-unavailable-cost")
+        .provider("chatgpt")
+        .title("Unavailable Cost")
+        .updated_at("2026-03-01T14:00:00+00:00")
+        .add_message("u3", role="user", text="Run unavailable-cost task", timestamp="2026-03-01T13:55:00+00:00")
+        .save()
+    )
+
+
 def test_products_profiles_json(cli_workspace: CliWorkspace) -> None:
     _seed_products(cli_workspace)
 
@@ -168,6 +198,50 @@ def test_products_profiles_json(cli_workspace: CliWorkspace) -> None:
     assert "evidence" in first
     assert "inference" in first
     assert "provenance" in first
+
+
+def test_products_costs_json(cli_workspace: CliWorkspace) -> None:
+    _seed_cost_products(cli_workspace)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["products", "costs", "--json"], catch_exceptions=False)
+
+    assert result.exit_code == 0
+    payload = extract_json_result(result.output)
+    costs = json_object_list(payload["session_costs"])
+    exact = next(item for item in costs if item["conversation_id"] == "conv-exact-cost")
+    priced = next(item for item in costs if item["conversation_id"] == "conv-priced-cost")
+    unavailable = next(item for item in costs if item["conversation_id"] == "conv-unavailable-cost")
+    exact_estimate = json_object(exact["estimate"])
+    priced_estimate = json_object(priced["estimate"])
+    unavailable_estimate = json_object(unavailable["estimate"])
+    assert exact["product_kind"] == "session_cost"
+    assert exact_estimate["status"] == "exact"
+    assert json_number(exact_estimate["total_usd"]) == pytest.approx(1.25)
+    assert priced_estimate["status"] == "priced"
+    assert priced_estimate["normalized_model"] == "gpt-4o"
+    assert json_number(priced_estimate["total_usd"]) == pytest.approx(0.0075)
+    assert unavailable_estimate["status"] == "unavailable"
+    assert "missing_token_usage" in json_array(unavailable_estimate["missing_reasons"])
+
+
+def test_products_cost_rollups_json(cli_workspace: CliWorkspace) -> None:
+    _seed_cost_products(cli_workspace)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["products", "cost-rollups", "--json"], catch_exceptions=False)
+
+    assert result.exit_code == 0
+    payload = extract_json_result(result.output)
+    rollups = json_object_list(payload["cost_rollups"])
+    claude = next(item for item in rollups if item["provider_name"] == "claude-code")
+    gpt = next(item for item in rollups if item["normalized_model"] == "gpt-4o")
+    unknown = next(item for item in rollups if item["provider_name"] == "chatgpt" and item["normalized_model"] is None)
+    assert claude["product_kind"] == "cost_rollup"
+    assert json_number(claude["total_usd"]) == pytest.approx(1.25)
+    assert json_int(claude["priced_session_count"]) == 1
+    assert json_number(gpt["total_usd"]) == pytest.approx(0.0075)
+    assert json_int(unknown["unavailable_session_count"]) == 1
 
 
 def test_products_profiles_support_wallclock_filters_and_sort(cli_workspace: CliWorkspace) -> None:

--- a/tests/unit/core/test_facade_api.py
+++ b/tests/unit/core/test_facade_api.py
@@ -9,7 +9,9 @@ import pytest
 from polylogue import Polylogue
 from polylogue.archive_products import (
     ArchiveDebtProductQuery,
+    CostRollupProductQuery,
     DaySessionSummaryProductQuery,
+    SessionCostProductQuery,
     SessionEnrichmentProductQuery,
     SessionPhaseProductQuery,
     SessionProfileProductQuery,
@@ -306,6 +308,7 @@ class TestPolylogueArchiveProducts:
             ConversationBuilder(db_path, "conv-root")
             .provider("claude-code")
             .title("Root Thread")
+            .provider_meta({"total_cost_usd": 1.25, "model": "claude-sonnet-4-5"})
             .updated_at("2026-03-01T10:10:00+00:00")
             .add_message(
                 "u1",
@@ -406,6 +409,10 @@ class TestPolylogueArchiveProducts:
             WeekSessionSummaryProductQuery(provider="claude-code", limit=10)
         )
         archive_debt = await archive.list_archive_debt_products(ArchiveDebtProductQuery(limit=10))
+        session_costs = await archive.list_session_cost_products(
+            SessionCostProductQuery(provider="claude-code", limit=10)
+        )
+        cost_rollups = await archive.list_cost_rollup_products(CostRollupProductQuery(provider="claude-code"))
 
         assert any(item.tag == "provider:claude-code" for item in tag_rollups)
         assert len(day_summaries) == 1
@@ -413,6 +420,8 @@ class TestPolylogueArchiveProducts:
         assert len(week_summaries) == 1
         assert week_summaries[0].summary.session_count == 2
         assert any(item.product_kind == "archive_debt" for item in archive_debt)
+        assert any(item.conversation_id == "conv-root" and item.estimate.status == "exact" for item in session_costs)
+        assert cost_rollups[0].total_usd == pytest.approx(1.25)
 
     @pytest.mark.asyncio
     async def test_archive_stats_health_and_rebuild_products_are_public(

--- a/tests/unit/core/test_pricing.py
+++ b/tests/unit/core/test_pricing.py
@@ -1,0 +1,92 @@
+"""Contracts for provider/model cost estimation."""
+
+from __future__ import annotations
+
+import pytest
+
+from polylogue.lib.messages import MessageCollection
+from polylogue.lib.pricing import _normalize_model, estimate_conversation_cost, estimate_cost
+from tests.infra.builders import make_conv, make_msg
+
+
+def test_exact_archive_cost_wins_over_catalog_estimate() -> None:
+    conversation = make_conv(
+        id="conv-exact-cost",
+        provider="claude-code",
+        provider_meta={"total_cost_usd": 1.25, "model": "claude-sonnet-4-5"},
+        messages=MessageCollection(messages=[]),
+    )
+
+    estimate = estimate_conversation_cost(conversation)
+
+    assert estimate.status == "exact"
+    assert estimate.confidence == 1.0
+    assert estimate.total_usd == 1.25
+    assert "archive_provider_reported_cost" in estimate.provenance
+
+
+def test_token_usage_prices_known_model_with_catalog_provenance() -> None:
+    conversation = make_conv(
+        id="conv-priced-cost",
+        provider="chatgpt",
+        provider_meta={
+            "model": "openai/gpt-4o-2024-08-06",
+            "usage": {"input_tokens": 1000, "output_tokens": 500},
+        },
+        messages=MessageCollection(messages=[]),
+    )
+
+    estimate = estimate_conversation_cost(conversation)
+
+    assert estimate.status == "priced"
+    assert estimate.normalized_model == "gpt-4o"
+    assert estimate.total_usd == pytest.approx(0.0075)
+    assert estimate.usage.input_tokens == 1000
+    assert estimate.usage.output_tokens == 500
+    assert estimate.price is not None
+    assert estimate.price.source_url.endswith("model_prices_and_context_window.json")
+
+
+def test_partial_conversation_preserves_missing_reasons() -> None:
+    conversation = make_conv(
+        id="conv-partial-cost",
+        provider="chatgpt",
+        messages=MessageCollection(
+            messages=[
+                make_msg(
+                    id="m-priced",
+                    role="assistant",
+                    provider="chatgpt",
+                    provider_meta={"model": "gpt-4o-mini", "usage": {"input_tokens": 100, "output_tokens": 50}},
+                ),
+                make_msg(id="m-missing", role="assistant", provider="chatgpt", provider_meta={"model": "gpt-4o"}),
+            ]
+        ),
+    )
+
+    estimate = estimate_conversation_cost(conversation)
+
+    assert estimate.status == "partial"
+    assert estimate.total_usd == pytest.approx(0.000045)
+    assert "missing_token_usage" in estimate.missing_reasons
+
+
+def test_missing_price_is_unavailable_not_zero_precision() -> None:
+    conversation = make_conv(
+        id="conv-unknown-model",
+        provider="chatgpt",
+        provider_meta={"model": "unknown-frontier-model", "usage": {"input_tokens": 100, "output_tokens": 50}},
+        messages=MessageCollection(messages=[]),
+    )
+
+    estimate = estimate_conversation_cost(conversation)
+
+    assert estimate.status == "unavailable"
+    assert estimate.total_usd == 0.0
+    assert estimate.missing_reasons == ("missing_price",)
+
+
+def test_model_normalization_accepts_provider_prefixes_and_version_suffixes() -> None:
+    assert _normalize_model("openai/gpt-4o-2024-08-06") == "gpt-4o"
+    assert _normalize_model("anthropic/claude-sonnet-4-5-20250929") == "claude-sonnet-4-5"
+    assert estimate_cost(1000, 500, "openai/gpt-4o-2024-08-06") == pytest.approx(0.0075)

--- a/tests/unit/mcp/test_tool_contracts.py
+++ b/tests/unit/mcp/test_tool_contracts.py
@@ -19,8 +19,10 @@ from polylogue.archive_products import (
     ArchiveEnrichmentProvenance,
     ArchiveInferenceProvenance,
     ArchiveProductProvenance,
+    CostRollupProduct,
     DaySessionSummaryProduct,
     ProviderAnalyticsProduct,
+    SessionCostProduct,
     SessionEnrichmentPayload,
     SessionEnrichmentProduct,
     SessionEvidencePayload,
@@ -38,6 +40,7 @@ from polylogue.archive_products import (
 )
 from polylogue.lib.models import Conversation, ConversationSummary
 from polylogue.lib.neighbor_candidates import ConversationNeighborCandidate, NeighborReason
+from polylogue.lib.pricing import CostEstimatePayload, CostUsagePayload
 from polylogue.lib.query_miss_diagnostics import QueryMissDiagnostics, QueryMissReason
 from polylogue.lib.query_spec import ConversationQuerySpec
 from polylogue.lib.search_hits import ConversationSearchHit
@@ -675,6 +678,35 @@ class TestProductTools:
             tool_use_percentage=100.0,
             thinking_percentage=0.0,
         )
+        session_cost = SessionCostProduct(
+            conversation_id="conv-root",
+            provider_name="claude-code",
+            title="Root Thread",
+            estimate=CostEstimatePayload(
+                provider_name="claude-code",
+                conversation_id="conv-root",
+                model_name="claude-sonnet-4-5",
+                normalized_model="claude-sonnet-4-5",
+                status="exact",
+                confidence=1.0,
+                total_usd=1.25,
+                provenance=("archive_provider_reported_cost",),
+            ),
+            provenance=_provenance(),
+        )
+        cost_rollup = CostRollupProduct(
+            provider_name="claude-code",
+            model_name="claude-sonnet-4-5",
+            normalized_model="claude-sonnet-4-5",
+            session_count=1,
+            priced_session_count=1,
+            unavailable_session_count=0,
+            status_counts={"exact": 1},
+            total_usd=1.25,
+            usage=CostUsagePayload(),
+            confidence=1.0,
+            provenance=_provenance(),
+        )
         debt = ArchiveDebtProduct(
             debt_name="session_products",
             category="products",
@@ -695,6 +727,8 @@ class TestProductTools:
             mock_ops.list_day_session_summary_products = AsyncMock(return_value=[day_summary])
             mock_ops.list_week_session_summary_products = AsyncMock(return_value=[week_summary])
             mock_ops.list_provider_analytics_products = AsyncMock(return_value=[analytics])
+            mock_ops.list_session_cost_products = AsyncMock(return_value=[session_cost])
+            mock_ops.list_cost_rollup_products = AsyncMock(return_value=[cost_rollup])
             mock_ops.list_archive_debt_products = AsyncMock(return_value=[debt])
             mock_get_archive_ops.return_value = mock_ops
 
@@ -747,6 +781,18 @@ class TestProductTools:
                 provider="claude-code",
                 limit=5,
             )
+            costs_raw = await invoke_surface_async(
+                mcp_server._tool_manager._tools["session_costs"].fn,
+                provider="claude-code",
+                status="exact",
+                limit=5,
+            )
+            cost_rollups_raw = await invoke_surface_async(
+                mcp_server._tool_manager._tools["cost_rollups"].fn,
+                provider="claude-code",
+                model="claude-sonnet-4-5",
+                limit=5,
+            )
             debt_raw = await invoke_surface_async(
                 mcp_server._tool_manager._tools["archive_debt"].fn,
                 category="products",
@@ -763,6 +809,8 @@ class TestProductTools:
         day_payload = json.loads(day_raw)
         week_payload = json.loads(week_raw)
         analytics_payload = json.loads(analytics_raw)
+        costs_payload = json.loads(costs_raw)
+        cost_rollups_payload = json.loads(cost_rollups_raw)
         debt_payload = json.loads(debt_raw)
 
         assert profiles_payload["count"] == 1
@@ -777,6 +825,10 @@ class TestProductTools:
         assert day_payload["items"][0]["product_kind"] == "day_session_summary"
         assert week_payload["items"][0]["product_kind"] == "week_session_summary"
         assert analytics_payload["items"][0]["product_kind"] == "provider_analytics"
+        assert costs_payload["items"][0]["product_kind"] == "session_cost"
+        assert costs_payload["items"][0]["estimate"]["status"] == "exact"
+        assert cost_rollups_payload["items"][0]["product_kind"] == "cost_rollup"
+        assert cost_rollups_payload["items"][0]["total_usd"] == 1.25
         assert debt_payload["items"][0]["product_kind"] == "archive_debt"
         debt_query = mock_ops.list_archive_debt_products.await_args.args[0]
         assert debt_query.category == "products"


### PR DESCRIPTION
## Summary

Add a typed cost-estimation substrate and expose it through registry-backed archive products. Polylogue can now report session-level cost estimates and provider/model rollups through CLI, facade, sync facade, and MCP surfaces.

## Problem

#388 asked for cost estimation across providers, models, and sessions. The repository had only a legacy `(cost_usd, is_estimated)` helper and no product contract for provenance, missing data, model normalization, or provider/model rollups. That made cost analysis ad hoc and encouraged false precision when token or price data was incomplete.

## Solution

- replace the pricing helper internals with typed usage, price, component, and estimate payloads while preserving `harmonize_session_cost()` as a compatibility adapter
- add a curated LiteLLM-shaped seed pricing catalog with explicit provenance and effective date; provider/archive-reported exact costs still win
- add `session_costs` and `cost_rollups` product contracts, operations, facade methods, sync facade methods, CLI commands, and MCP tools through the shared product registry
- represent estimate status as `exact`, `priced`, `partial`, or `unavailable`, with confidence and missing reasons
- refresh generated CLI/quality/verification docs for the new product commands
- cover exact archive cost, catalog-priced estimate, partial estimate, missing price, model normalization, CLI JSON, facade, and MCP contracts

## Verification

- `pytest -q tests/unit/core/test_pricing.py tests/unit/cli/test_products.py::test_products_costs_json tests/unit/cli/test_products.py::test_products_cost_rollups_json tests/unit/core/test_facade_api.py::TestPolylogueArchiveProducts::test_durable_session_products_are_publicly_queryable tests/unit/mcp/test_tool_contracts.py::TestProductTools::test_product_list_tools_use_archive_queries` passed: 9 passed in 10.91s
- `mypy --strict polylogue/lib/pricing.py polylogue/archive_products.py polylogue/operations/archive.py polylogue/products/registry.py polylogue/facade_products.py polylogue/sync_product_queries.py tests/unit/core/test_pricing.py tests/unit/cli/test_products.py tests/unit/core/test_facade_api.py tests/unit/mcp/test_tool_contracts.py` passed: Success, no issues found
- `devtools render-all --check` passed: all generated surfaces sync OK
- `devtools verify` passed: verify: all checks passed
- `git push -u origin feature/feat/cost-estimation` passed pre-push quick verification: verify: all checks passed

Closes #388
