### PR TITLE
feat: add browser capture sync

### DIFF
--- a/browser-extension/polylogue-browser-capture/README.md
+++ b/browser-extension/polylogue-browser-capture/README.md
@@ -1,0 +1,21 @@
+# Polylogue Browser Capture
+
+This is a local-first Manifest V3 extension for capturing supported web LLM
+sessions into Polylogue.
+
+Run the receiver:
+
+```bash
+polylogue browser-capture serve
+```
+
+Then load this directory as an unpacked Chrome extension. The popup shows
+receiver state, current-page support, archive capture state, the last accepted
+capture, and the configured local receiver URL. Captures are posted to
+`http://127.0.0.1:8765/v1/browser-captures`, written into the normal Polylogue
+inbox, and parsed by the normal source dispatch path on the next ingest run.
+
+The extension does not send session content to any remote service. It only
+talks to the local receiver. When the receiver is unavailable, the extension
+badge and popup report the offline state. ChatGPT and Claude.ai are the minimum
+supported provider adapters in this slice.

--- a/browser-extension/polylogue-browser-capture/manifest.json
+++ b/browser-extension/polylogue-browser-capture/manifest.json
@@ -1,0 +1,32 @@
+{
+  "manifest_version": 3,
+  "name": "Polylogue Browser Capture",
+  "version": "0.1.0",
+  "description": "Capture supported web LLM sessions into the local Polylogue inbox.",
+  "permissions": ["activeTab", "scripting", "storage", "tabs"],
+  "host_permissions": [
+    "https://chatgpt.com/*",
+    "https://claude.ai/*",
+    "http://127.0.0.1:8765/*"
+  ],
+  "background": {
+    "service_worker": "src/background.js",
+    "type": "module"
+  },
+  "action": {
+    "default_title": "Polylogue Capture",
+    "default_popup": "src/popup.html"
+  },
+  "content_scripts": [
+    {
+      "matches": ["https://chatgpt.com/*"],
+      "js": ["src/common.js", "src/content/chatgpt.js"],
+      "run_at": "document_idle"
+    },
+    {
+      "matches": ["https://claude.ai/*"],
+      "js": ["src/common.js", "src/content/claude.js"],
+      "run_at": "document_idle"
+    }
+  ]
+}

--- a/browser-extension/polylogue-browser-capture/src/background.js
+++ b/browser-extension/polylogue-browser-capture/src/background.js
@@ -1,0 +1,74 @@
+const DEFAULT_RECEIVER = "http://127.0.0.1:8765";
+
+async function receiverBase() {
+  const stored = await chrome.storage.local.get({ receiverBaseUrl: DEFAULT_RECEIVER });
+  return stored.receiverBaseUrl.replace(/\/+$/, "");
+}
+
+async function saveReceiverBaseUrl(receiverBaseUrl) {
+  await chrome.storage.local.set({ receiverBaseUrl: receiverBaseUrl.replace(/\/+$/, "") || DEFAULT_RECEIVER });
+  return receiverBase();
+}
+
+async function setState(state) {
+  await chrome.storage.local.set({ polylogueState: { ...state, updated_at: new Date().toISOString() } });
+  const text = state.captured ? "ok" : state.online ? "on" : "off";
+  await chrome.action.setBadgeText({ text });
+  await chrome.action.setBadgeBackgroundColor({ color: state.captured ? "#1f7a4d" : state.online ? "#805ad5" : "#9b2c2c" });
+}
+
+async function postJson(path, payload) {
+  const base = await receiverBase();
+  const response = await fetch(`${base}${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload)
+  });
+  const body = await response.json().catch(() => ({}));
+  if (!response.ok) throw new Error(body.error || `HTTP ${response.status}`);
+  return body;
+}
+
+async function getJson(path) {
+  const base = await receiverBase();
+  const response = await fetch(`${base}${path}`);
+  const body = await response.json().catch(() => ({}));
+  if (!response.ok) throw new Error(body.error || `HTTP ${response.status}`);
+  return body;
+}
+
+chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+  (async () => {
+    if (message.type === "polylogue.configureReceiver") {
+      const receiverBaseUrl = await saveReceiverBaseUrl(message.receiverBaseUrl || DEFAULT_RECEIVER);
+      sendResponse({ ok: true, receiverBaseUrl });
+      return;
+    }
+    if (message.type === "polylogue.capture") {
+      const result = await postJson("/v1/browser-captures", message.envelope);
+      await setState({ online: true, captured: true, last_capture: result });
+      sendResponse(result);
+      return;
+    }
+    if (message.type === "polylogue.archiveState") {
+      const query = new URLSearchParams({
+        provider: message.provider,
+        provider_session_id: message.provider_session_id
+      });
+      const state = await getJson(`/v1/archive-state?${query.toString()}`);
+      await setState({ online: true, captured: Boolean(state.captured), archive_state: state });
+      sendResponse(state);
+      return;
+    }
+    if (message.type === "polylogue.status") {
+      const status = await getJson("/v1/status");
+      await setState({ online: true, captured: false, status });
+      sendResponse(status);
+      return;
+    }
+  })().catch(async (error) => {
+    await setState({ online: false, captured: false, error: String(error.message || error) });
+    sendResponse({ ok: false, error: String(error.message || error) });
+  });
+  return true;
+});

--- a/browser-extension/polylogue-browser-capture/src/common.js
+++ b/browser-extension/polylogue-browser-capture/src/common.js
@@ -1,0 +1,82 @@
+(function () {
+  const SCHEMA_VERSION = 1;
+  const CAPTURE_KIND = "browser_llm_session";
+
+  function fnv1a(text) {
+    let hash = 0x811c9dc5;
+    for (let index = 0; index < text.length; index += 1) {
+      hash ^= text.charCodeAt(index);
+      hash = Math.imul(hash, 0x01000193);
+    }
+    return (hash >>> 0).toString(16).padStart(8, "0");
+  }
+
+  function conversationIdFromUrl(provider, url) {
+    const parsed = new URL(url);
+    const parts = parsed.pathname.split("/").filter(Boolean);
+    const conversationToken = parts.at(-1) || parsed.pathname || parsed.hostname;
+    return `${provider}:${conversationToken}:${fnv1a(parsed.origin + parsed.pathname)}`;
+  }
+
+  function visibleText(node) {
+    return (node?.innerText || node?.textContent || "").replace(/\s+\n/g, "\n").trim();
+  }
+
+  function buildEnvelope({ provider, adapterName, turns, model = null }) {
+    const sourceUrl = window.location.href;
+    const providerSessionId = conversationIdFromUrl(provider, sourceUrl);
+    const now = new Date().toISOString();
+    return {
+      polylogue_capture_kind: CAPTURE_KIND,
+      schema_version: SCHEMA_VERSION,
+      capture_id: `${provider}:${providerSessionId}`,
+      source: "browser-extension",
+      provenance: {
+        source_url: sourceUrl,
+        page_title: document.title || null,
+        captured_at: now,
+        extension_id: chrome.runtime.id,
+        adapter_name: adapterName,
+        adapter_version: chrome.runtime.getManifest().version,
+        capture_mode: "snapshot"
+      },
+      session: {
+        provider,
+        provider_session_id: providerSessionId,
+        title: document.title || providerSessionId,
+        updated_at: now,
+        model,
+        turns: turns.map((turn, ordinal) => ({
+          provider_turn_id: turn.provider_turn_id || `${providerSessionId}:turn:${ordinal}:${fnv1a(turn.role + ":" + turn.text)}`,
+          role: turn.role,
+          text: turn.text,
+          ordinal,
+          provider_meta: turn.provider_meta || {}
+        }))
+      }
+    };
+  }
+
+  async function sendCapture(envelope) {
+    const response = await chrome.runtime.sendMessage({ type: "polylogue.capture", envelope });
+    return response;
+  }
+
+  async function refreshArchiveState(provider, providerSessionId) {
+    return chrome.runtime.sendMessage({
+      type: "polylogue.archiveState",
+      provider,
+      provider_session_id: providerSessionId
+    });
+  }
+
+  window.polylogueCapture = {
+    buildEnvelope,
+    conversationIdFromUrl,
+    capturePage: null,
+    fnv1a,
+    refreshArchiveState,
+    sendCapture,
+    visibleText
+  };
+})();

--- a/browser-extension/polylogue-browser-capture/src/content/chatgpt.js
+++ b/browser-extension/polylogue-browser-capture/src/content/chatgpt.js
@@ -1,0 +1,62 @@
+(function () {
+  const adapterName = "chatgpt-dom-v1";
+
+  function roleFromNode(node, index) {
+    const testId = node.getAttribute("data-testid") || "";
+    if (testId.includes("user")) return "user";
+    if (testId.includes("assistant")) return "assistant";
+    const labelled = node.getAttribute("aria-label") || "";
+    if (/you|user/i.test(labelled)) return "user";
+    if (/chatgpt|assistant/i.test(labelled)) return "assistant";
+    return index % 2 === 0 ? "user" : "assistant";
+  }
+
+  function collectTurns() {
+    const nodes = [
+      ...document.querySelectorAll('[data-testid^="conversation-turn-"], article, [data-message-author-role]')
+    ];
+    return nodes
+      .map((node, index) => {
+        const explicitRole = node.getAttribute("data-message-author-role");
+        const role = explicitRole || roleFromNode(node, index);
+        const text = window.polylogueCapture.visibleText(node);
+        return text ? { role, text, provider_meta: { selector_index: index } } : null;
+      })
+      .filter(Boolean);
+  }
+
+  async function capture() {
+    const turns = collectTurns();
+    if (!turns.length) return { ok: false, error: "no_turns" };
+    const envelope = window.polylogueCapture.buildEnvelope({
+      provider: "chatgpt",
+      adapterName,
+      turns
+    });
+    const captureResult = await window.polylogueCapture.sendCapture(envelope);
+    const archiveState = await window.polylogueCapture.refreshArchiveState(
+      "chatgpt",
+      envelope.session.provider_session_id
+    );
+    return { ok: true, envelope, captureResult, archiveState };
+  }
+
+  let timer = 0;
+  function scheduleCapture() {
+    window.clearTimeout(timer);
+    timer = window.setTimeout(capture, 1200);
+  }
+
+  scheduleCapture();
+  window.polylogueCapture.capturePage = capture;
+  chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+    if (message.type !== "polylogue.capturePage") return false;
+    capture().then(sendResponse).catch((error) => sendResponse({ ok: false, error: String(error.message || error) }));
+    return true;
+  });
+  new MutationObserver(scheduleCapture).observe(document.documentElement, {
+    childList: true,
+    subtree: true,
+    characterData: true
+  });
+})();

--- a/browser-extension/polylogue-browser-capture/src/content/claude.js
+++ b/browser-extension/polylogue-browser-capture/src/content/claude.js
@@ -1,0 +1,57 @@
+(function () {
+  const adapterName = "claude-ai-dom-v1";
+
+  function roleFromNode(node, index) {
+    const role = node.getAttribute("data-message-author-role") || node.getAttribute("data-testid") || "";
+    if (/human|user/i.test(role)) return "user";
+    if (/assistant|claude/i.test(role)) return "assistant";
+    return index % 2 === 0 ? "user" : "assistant";
+  }
+
+  function collectTurns() {
+    const nodes = [
+      ...document.querySelectorAll('[data-testid*="message"], [data-message-author-role], article')
+    ];
+    return nodes
+      .map((node, index) => {
+        const text = window.polylogueCapture.visibleText(node);
+        return text ? { role: roleFromNode(node, index), text, provider_meta: { selector_index: index } } : null;
+      })
+      .filter(Boolean);
+  }
+
+  async function capture() {
+    const turns = collectTurns();
+    if (!turns.length) return { ok: false, error: "no_turns" };
+    const envelope = window.polylogueCapture.buildEnvelope({
+      provider: "claude-ai",
+      adapterName,
+      turns
+    });
+    const captureResult = await window.polylogueCapture.sendCapture(envelope);
+    const archiveState = await window.polylogueCapture.refreshArchiveState(
+      "claude-ai",
+      envelope.session.provider_session_id
+    );
+    return { ok: true, envelope, captureResult, archiveState };
+  }
+
+  let timer = 0;
+  function scheduleCapture() {
+    window.clearTimeout(timer);
+    timer = window.setTimeout(capture, 1200);
+  }
+
+  scheduleCapture();
+  window.polylogueCapture.capturePage = capture;
+  chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+    if (message.type !== "polylogue.capturePage") return false;
+    capture().then(sendResponse).catch((error) => sendResponse({ ok: false, error: String(error.message || error) }));
+    return true;
+  });
+  new MutationObserver(scheduleCapture).observe(document.documentElement, {
+    childList: true,
+    subtree: true,
+    characterData: true
+  });
+})();

--- a/browser-extension/polylogue-browser-capture/src/popup.html
+++ b/browser-extension/polylogue-browser-capture/src/popup.html
@@ -1,0 +1,161 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Polylogue Capture</title>
+    <style>
+      :root {
+        color-scheme: light;
+        --ink: #172026;
+        --muted: #5f6b76;
+        --line: #d7dde2;
+        --surface: #ffffff;
+        --panel: #f4f7f9;
+        --ok: #14764e;
+        --warn: #9a5b00;
+        --bad: #ad2f2f;
+        --accent: #325d8f;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        width: 360px;
+        margin: 0;
+        color: var(--ink);
+        background: var(--surface);
+        font: 13px/1.4 system-ui, sans-serif;
+      }
+      main {
+        padding: 14px;
+      }
+      header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+        padding-bottom: 12px;
+        border-bottom: 1px solid var(--line);
+      }
+      h1 {
+        margin: 0;
+        font-size: 16px;
+        letter-spacing: 0;
+      }
+      .subtitle {
+        color: var(--muted);
+        font-size: 12px;
+      }
+      .badge {
+        min-width: 72px;
+        padding: 4px 8px;
+        border-radius: 999px;
+        color: #fff;
+        text-align: center;
+        font-size: 12px;
+        background: var(--muted);
+      }
+      .badge.ok { background: var(--ok); }
+      .badge.warn { background: var(--warn); }
+      .badge.bad { background: var(--bad); }
+      section {
+        padding: 12px 0;
+        border-bottom: 1px solid var(--line);
+      }
+      section:last-child {
+        border-bottom: 0;
+        padding-bottom: 0;
+      }
+      .row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+        margin: 7px 0;
+      }
+      .label {
+        color: var(--muted);
+      }
+      .value {
+        max-width: 220px;
+        overflow: hidden;
+        text-align: right;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      .controls {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 8px;
+      }
+      button {
+        width: 100%;
+        min-height: 34px;
+        padding: 7px 10px;
+        border: 1px solid var(--line);
+        border-radius: 6px;
+        color: var(--ink);
+        background: var(--panel);
+        font: inherit;
+      }
+      button.primary {
+        border-color: var(--accent);
+        color: #fff;
+        background: var(--accent);
+      }
+      input {
+        width: 100%;
+        padding: 7px 8px;
+        border: 1px solid var(--line);
+        border-radius: 6px;
+        font: inherit;
+      }
+      .setting-row {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) 86px;
+        gap: 8px;
+        margin-top: 6px;
+      }
+      #state {
+        min-height: 38px;
+        margin: 0;
+        color: var(--muted);
+        white-space: pre-wrap;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <header>
+        <div>
+          <h1>Polylogue Capture</h1>
+          <div class="subtitle">ChatGPT and Claude.ai web sync</div>
+        </div>
+        <div id="badge" class="badge">checking</div>
+      </header>
+
+      <section>
+        <div class="row"><span class="label">Page</span><span id="page" class="value">Unknown</span></div>
+        <div class="row"><span class="label">Receiver</span><span id="receiver" class="value">127.0.0.1:8765</span></div>
+        <div class="row"><span class="label">Archive</span><span id="archive" class="value">Not checked</span></div>
+      </section>
+
+      <section>
+        <p id="state">Checking receiver...</p>
+        <div class="controls">
+          <button id="capture" class="primary">Capture page</button>
+          <button id="check">Check status</button>
+        </div>
+      </section>
+
+      <section>
+        <label class="label" for="receiver-url">Local receiver URL</label>
+        <div class="setting-row">
+          <input id="receiver-url" value="http://127.0.0.1:8765">
+          <button id="save">Save</button>
+        </div>
+      </section>
+    </main>
+    <script src="popup.js"></script>
+  </body>
+</html>

--- a/browser-extension/polylogue-browser-capture/src/popup.js
+++ b/browser-extension/polylogue-browser-capture/src/popup.js
@@ -1,0 +1,87 @@
+const DEFAULT_RECEIVER = "http://127.0.0.1:8765";
+
+function hostLabel(url) {
+  try {
+    const parsed = new URL(url);
+    if (parsed.hostname.includes("chatgpt.com")) return "ChatGPT";
+    if (parsed.hostname.includes("claude.ai")) return "Claude.ai";
+    return parsed.hostname;
+  } catch {
+    return "Unknown";
+  }
+}
+
+function setBadge(kind, text) {
+  const badge = document.getElementById("badge");
+  badge.className = `badge ${kind}`;
+  badge.textContent = text;
+}
+
+async function activeTab() {
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  return tab;
+}
+
+async function render() {
+  const stateNode = document.getElementById("state");
+  const stored = await chrome.storage.local.get({
+    polylogueState: null,
+    receiverBaseUrl: DEFAULT_RECEIVER
+  });
+  document.getElementById("receiver-url").value = stored.receiverBaseUrl;
+  document.getElementById("receiver").textContent = stored.receiverBaseUrl;
+  const tab = await activeTab();
+  document.getElementById("page").textContent = hostLabel(tab?.url || "");
+  const state = stored.polylogueState;
+  if (!state) {
+    stateNode.textContent = "No capture state yet.";
+    setBadge("warn", "idle");
+    return;
+  }
+  if (!state.online) {
+    stateNode.textContent = `Receiver offline. Start: polylogue browser-capture serve\n${state.error || ""}`.trim();
+    document.getElementById("archive").textContent = "Offline";
+    setBadge("bad", "offline");
+    return;
+  }
+  document.getElementById("archive").textContent = state.captured ? "Captured" : "Receiver online";
+  if (state.last_capture) {
+    stateNode.textContent = `Last capture: ${state.last_capture.provider} / ${state.last_capture.provider_session_id}`;
+  } else {
+    stateNode.textContent = "Receiver online. Open ChatGPT or Claude.ai to capture.";
+  }
+  setBadge(state.captured ? "ok" : "warn", state.captured ? "captured" : "online");
+}
+
+document.getElementById("check").addEventListener("click", async () => {
+  await chrome.runtime.sendMessage({ type: "polylogue.status" });
+  await render();
+});
+
+document.getElementById("save").addEventListener("click", async () => {
+  const receiverBaseUrl = document.getElementById("receiver-url").value;
+  await chrome.runtime.sendMessage({ type: "polylogue.configureReceiver", receiverBaseUrl });
+  await render();
+});
+
+document.getElementById("capture").addEventListener("click", async () => {
+  const tab = await activeTab();
+  if (!tab?.id) return;
+  const result = await chrome.tabs.sendMessage(tab.id, { type: "polylogue.capturePage" }).catch((error) => ({
+    ok: false,
+    error: String(error.message || error)
+  }));
+  if (!result?.ok) {
+    await chrome.storage.local.set({
+      polylogueState: {
+        online: false,
+        captured: false,
+        error: result?.error || "This page is not supported.",
+        updated_at: new Date().toISOString()
+      }
+    });
+  }
+  await render();
+});
+
+render();

--- a/devtools/docs_surface.py
+++ b/devtools/docs_surface.py
@@ -27,6 +27,11 @@ DOCS_REFERENCE_ENTRIES: tuple[DocsEntry, ...] = (
     DocsEntry("Architecture", "docs/architecture.md", "System rings, ownership boundaries, and data flow."),
     DocsEntry("Internals", "docs/internals.md", "Working implementation reference and debugging landmarks."),
     DocsEntry("MCP Integration", "docs/mcp-integration.md", "Model Context Protocol server setup and usage."),
+    DocsEntry(
+        "Browser Capture",
+        "docs/browser-capture.md",
+        "Local browser extension capture for ChatGPT and Claude.ai sessions.",
+    ),
     DocsEntry("Generate", "docs/generate.md", "Synthetic archive generation, seed mode, and demo workflows."),
     DocsEntry("Providers", "docs/providers/README.md", "Provider-specific parsing and export-format notes."),
     DocsEntry(

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ This directory holds the current repository-facing documentation.
 | [Architecture](architecture.md) | System rings, ownership boundaries, and data flow. |
 | [Internals](internals.md) | Working implementation reference and debugging landmarks. |
 | [MCP Integration](mcp-integration.md) | Model Context Protocol server setup and usage. |
+| [Browser Capture](browser-capture.md) | Local browser extension capture for ChatGPT and Claude.ai sessions. |
 | [Generate](generate.md) | Synthetic archive generation, seed mode, and demo workflows. |
 | [Providers](providers/README.md) | Provider-specific parsing and export-format notes. |
 | [Test Quality Workflows](test-quality-workflows.md) | Generated validation lanes, mutation campaigns, and benchmark campaigns. |

--- a/docs/browser-capture.md
+++ b/docs/browser-capture.md
@@ -1,0 +1,32 @@
+# Browser Capture
+
+Polylogue can receive browser-observed LLM sessions through a local-only
+Manifest V3 extension.
+
+Start the receiver:
+
+```bash
+polylogue browser-capture serve
+```
+
+The receiver listens on `127.0.0.1:8765` by default and accepts:
+
+- `GET /v1/status`
+- `GET /v1/archive-state?provider=chatgpt&provider_session_id=...`
+- `POST /v1/browser-captures`
+
+Accepted captures are typed browser-capture envelopes and are written
+atomically under the configured inbox at `browser-capture/<provider>/...json`.
+The filename is deterministic from provider and provider session id, so repeated
+observation of the same web session replaces the same source artifact.
+
+The extension lives in `browser-extension/polylogue-browser-capture/` and can be
+loaded unpacked in Chrome. It includes ChatGPT and Claude.ai DOM adapters, a
+popup control panel, receiver configuration, current-page capture controls,
+badge state, and archive-state feedback. Provider adapters are intentionally
+thin; the shared envelope carries session, turn, attachment, provenance, and
+provider metadata semantics.
+
+The transport is local-only. Browser origins are allowlisted to ChatGPT,
+Claude.ai, and extension pages. If the receiver is unavailable, the extension
+surfaces an offline state instead of dropping content silently.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -124,25 +124,26 @@ Options:
   -h, --help                      Show this message and exit.
 
 Commands:
-  audit        Run archive QA: schema audit and artifact proof checks.
-  auth         Authenticate with external services (Google Drive for...
-  completions  Generate shell completion scripts.
-  count        Print count of matched conversations.
-  dashboard    Launch the dashboard TUI.
-  delete       Delete matched conversations.
-  doctor       Health check with optional maintenance and cleanup previews.
-  export       Export one known conversation by ID.
-  list         List matched conversations.
-  mcp          Start the MCP server for AI assistant integration.
-  neighbors    Show explainable neighboring or near-duplicate candidates.
-  open         Open matched conversation in browser/editor.
-  products     Inspect durable archive data products.
-  reset        Reset database, blob store, assets, rendered outputs, or...
-  resume       Reconstruct work-state context for a fresh agent session.
-  run          Run pipeline stages on configured sources.
-  schema       Inspect schema packages, versions, and evidence.
-  stats        Show statistics for matched conversations.
-  tags         List all tags with conversation counts.
+  audit            Run archive QA: schema audit and artifact proof checks.
+  auth             Authenticate with external services (Google Drive for...
+  browser-capture  Receive browser-extension captures into the normal inbox.
+  completions      Generate shell completion scripts.
+  count            Print count of matched conversations.
+  dashboard        Launch the dashboard TUI.
+  delete           Delete matched conversations.
+  doctor           Health check with optional maintenance and cleanup...
+  export           Export one known conversation by ID.
+  list             List matched conversations.
+  mcp              Start the MCP server for AI assistant integration.
+  neighbors        Show explainable neighboring or near-duplicate...
+  open             Open matched conversation in browser/editor.
+  products         Inspect durable archive data products.
+  reset            Reset database, blob store, assets, rendered outputs,...
+  resume           Reconstruct work-state context for a fresh agent session.
+  run              Run pipeline stages on configured sources.
+  schema           Inspect schema packages, versions, and evidence.
+  stats            Show statistics for matched conversations.
+  tags             List all tags with conversation counts.
 ```
 
 ## List Verb

--- a/docs/test-quality-workflows.md
+++ b/docs/test-quality-workflows.md
@@ -15,10 +15,10 @@ Current registry snapshot:
 - mutation campaigns: `19`
 - benchmark campaigns: `3`
 - synthetic benchmark campaigns: `6`
-- scenario projections: `246`
+- scenario projections: `249`
 - inferred corpus scenarios: `5`
   - benchmark-campaign: `3`
-  - exercise: `140`
+  - exercise: `143`
   - inferred-corpus-scenario: `5`
   - mutation-campaign: `19`
   - synthetic-benchmark: `6`
@@ -324,6 +324,9 @@ These are the authored scenario-bearing projections currently feeding runtime co
 | `exercise` | `gen-schema-list` | `schema-list-query-loop` | `schema_packages`<br>`schema_cluster_manifests`<br>`inferred_corpus_specs`<br>`inferred_corpus_scenarios`<br>`schema_list_results` | `query-schema-catalog` | — | `generated`<br>`schema`<br>`list` | Generated: schema list --json returns valid JSON |
 | `exercise` | `help-audit` | — | — | `cli.help` | — | `generated`<br>`help`<br>`structural` | audit help |
 | `exercise` | `help-auth` | `conversation-query-loop` | `message_fts`<br>`conversation_query_results` | `cli.help`<br>`query-conversations` | — | `generated`<br>`help`<br>`structural` | auth help |
+| `exercise` | `help-browser-capture` | `conversation-query-loop` | `message_fts`<br>`conversation_query_results` | `cli.help`<br>`query-conversations` | — | `generated`<br>`help`<br>`structural` | browser-capture help |
+| `exercise` | `help-browser-capture-serve` | `conversation-query-loop` | `message_fts`<br>`conversation_query_results` | `cli.help`<br>`query-conversations` | — | `generated`<br>`help`<br>`structural` | browser-capture serve help |
+| `exercise` | `help-browser-capture-status` | `conversation-query-loop` | `message_fts`<br>`conversation_query_results` | `cli.help`<br>`query-conversations` | — | `generated`<br>`help`<br>`structural` | browser-capture status help |
 | `exercise` | `help-completions` | `conversation-query-loop` | `message_fts`<br>`conversation_query_results` | `cli.help`<br>`query-conversations` | — | `generated`<br>`help`<br>`structural` | completions help |
 | `exercise` | `help-count` | `conversation-query-loop` | `message_fts`<br>`conversation_query_results` | `cli.help`<br>`query-conversations` | — | `generated`<br>`help`<br>`structural` | count help |
 | `exercise` | `help-dashboard` | `conversation-query-loop` | `message_fts`<br>`conversation_query_results` | `cli.help`<br>`query-conversations` | — | `generated`<br>`help`<br>`structural` | dashboard help |

--- a/docs/verification-catalog.md
+++ b/docs/verification-catalog.md
@@ -8,10 +8,10 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 
 ## Snapshot
 
-- subjects: `9043`
+- subjects: `9046`
 - claims: `22`
 - runner bindings: `22`
-- proof obligations: `9138`
+- proof obligations: `9147`
 
 ## Quality Checks
 
@@ -31,7 +31,7 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | --- | ---: |
 | `archive.query_law` | 1 |
 | `artifact.path` | 27 |
-| `cli.command` | 47 |
+| `cli.command` | 50 |
 | `cli.json_command` | 2 |
 | `diagnostic.observable` | 1 |
 | `error.surface` | 2 |
@@ -50,6 +50,9 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | `polylogue` | `polylogue/cli/click_app.py:51` `polylogue.cli.click_app.cli` |
 | `polylogue audit` | `polylogue/cli/commands/qa.py:21` `polylogue.cli.commands.qa.qa_command` |
 | `polylogue auth` | `polylogue/cli/commands/auth.py:16` `polylogue.cli.commands.auth.auth_command` |
+| `polylogue browser-capture` | `polylogue/cli/commands/browser_capture.py:14` `polylogue.cli.commands.browser_capture.browser_capture_command` |
+| `polylogue browser-capture serve` | `polylogue/cli/commands/browser_capture.py:38` `polylogue.cli.commands.browser_capture.serve_command` |
+| `polylogue browser-capture status` | `polylogue/cli/commands/browser_capture.py:19` `polylogue.cli.commands.browser_capture.status_command` |
 | `polylogue completions` | `polylogue/cli/commands/completions.py:9` `polylogue.cli.commands.completions.completions_command` |
 | `polylogue count` | `polylogue/cli/query_verbs.py:41` `polylogue.cli.query_verbs.count_verb` |
 | `polylogue dashboard` | `polylogue/cli/commands/dashboard.py:10` `polylogue.cli.commands.dashboard.dashboard_command` |
@@ -191,10 +194,10 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | --- | ---: |
 | `archive.query.provider_filter_consistency` | 1 |
 | `artifact.path.dependency_closure` | 11 |
-| `cli.command.help` | 47 |
+| `cli.command.help` | 50 |
 | `cli.command.json_envelope` | 2 |
-| `cli.command.no_traceback` | 47 |
-| `cli.command.plain_mode` | 47 |
+| `cli.command.no_traceback` | 50 |
+| `cli.command.plain_mode` | 50 |
 | `diagnostic.observable_trace_mapping` | 1 |
 | `error.machine_user_context` | 2 |
 | `generated.scenario.family_registered` | 9 |

--- a/polylogue/browser_capture/__init__.py
+++ b/polylogue/browser_capture/__init__.py
@@ -1,0 +1,33 @@
+"""Browser capture envelope and local receiver support."""
+
+from polylogue.browser_capture.models import (
+    BROWSER_CAPTURE_KIND,
+    BROWSER_CAPTURE_SCHEMA_VERSION,
+    BrowserCaptureAttachment,
+    BrowserCaptureEnvelope,
+    BrowserCaptureProvenance,
+    BrowserCaptureSession,
+    BrowserCaptureTurn,
+)
+from polylogue.browser_capture.receiver import (
+    BrowserCaptureReceiverConfig,
+    BrowserCaptureWriteResult,
+    capture_artifact_path,
+    receiver_status_payload,
+    write_capture_envelope,
+)
+
+__all__ = [
+    "BROWSER_CAPTURE_KIND",
+    "BROWSER_CAPTURE_SCHEMA_VERSION",
+    "BrowserCaptureAttachment",
+    "BrowserCaptureEnvelope",
+    "BrowserCaptureProvenance",
+    "BrowserCaptureReceiverConfig",
+    "BrowserCaptureSession",
+    "BrowserCaptureTurn",
+    "BrowserCaptureWriteResult",
+    "capture_artifact_path",
+    "receiver_status_payload",
+    "write_capture_envelope",
+]

--- a/polylogue/browser_capture/models.py
+++ b/polylogue/browser_capture/models.py
@@ -1,0 +1,168 @@
+"""Typed browser-capture envelope shared by receiver and parser."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+from polylogue.lib.json import is_json_document, json_document
+from polylogue.lib.roles import Role
+from polylogue.types import Provider
+
+BROWSER_CAPTURE_KIND: Literal["browser_llm_session"] = "browser_llm_session"
+BROWSER_CAPTURE_SCHEMA_VERSION: Literal[1] = 1
+
+
+class BrowserCaptureAttachment(BaseModel):
+    """Attachment reference observed in a browser-hosted LLM session."""
+
+    provider_attachment_id: str
+    message_provider_id: str | None = None
+    name: str | None = None
+    mime_type: str | None = None
+    size_bytes: int | None = None
+    url: str | None = None
+    provider_meta: dict[str, object] = Field(default_factory=dict)
+
+    @field_validator("provider_meta", mode="before")
+    @classmethod
+    def coerce_provider_meta(cls, value: object) -> dict[str, object]:
+        return dict(json_document(value))
+
+
+class BrowserCaptureTurn(BaseModel):
+    """Provider-neutral turn observed from the page."""
+
+    provider_turn_id: str
+    role: Role
+    text: str | None = None
+    timestamp: str | None = None
+    ordinal: int = 0
+    parent_turn_id: str | None = None
+    attachments: list[BrowserCaptureAttachment] = Field(default_factory=list)
+    provider_meta: dict[str, object] = Field(default_factory=dict)
+
+    @field_validator("provider_meta", mode="before")
+    @classmethod
+    def coerce_provider_meta(cls, value: object) -> dict[str, object]:
+        return dict(json_document(value))
+
+    @field_validator("role", mode="before")
+    @classmethod
+    def coerce_role(cls, value: object) -> Role:
+        if isinstance(value, Role):
+            return value
+        return Role.normalize(str(value) if value is not None else "unknown")
+
+    @model_validator(mode="after")
+    def require_content(self) -> BrowserCaptureTurn:
+        if (self.text is None or not self.text.strip()) and not self.attachments:
+            raise ValueError("browser capture turn must include text or attachments")
+        return self
+
+
+class BrowserCaptureProvenance(BaseModel):
+    """How and where the capture was observed."""
+
+    source_url: str
+    page_title: str | None = None
+    captured_at: str
+    extension_id: str | None = None
+    browser_profile: str | None = None
+    adapter_name: str
+    adapter_version: str | None = None
+    capture_mode: Literal["snapshot", "tail"] = "snapshot"
+    provider_meta: dict[str, object] = Field(default_factory=dict)
+
+    @field_validator("provider_meta", mode="before")
+    @classmethod
+    def coerce_provider_meta(cls, value: object) -> dict[str, object]:
+        return dict(json_document(value))
+
+
+class BrowserCaptureSession(BaseModel):
+    """A browser-visible provider session."""
+
+    provider: Provider
+    provider_session_id: str
+    title: str | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
+    model: str | None = None
+    turns: list[BrowserCaptureTurn] = Field(default_factory=list)
+    attachments: list[BrowserCaptureAttachment] = Field(default_factory=list)
+    provider_meta: dict[str, object] = Field(default_factory=dict)
+
+    @field_validator("provider_meta", mode="before")
+    @classmethod
+    def coerce_provider_meta(cls, value: object) -> dict[str, object]:
+        return dict(json_document(value))
+
+    @field_validator("provider", mode="before")
+    @classmethod
+    def coerce_provider(cls, value: object) -> Provider:
+        if isinstance(value, Provider):
+            return value
+        return Provider.from_string(str(value) if value is not None else None)
+
+    @model_validator(mode="after")
+    def require_turns(self) -> BrowserCaptureSession:
+        if not self.turns:
+            raise ValueError("browser capture session must include at least one turn")
+        return self
+
+
+class BrowserCaptureEnvelope(BaseModel):
+    """Source artifact posted by the browser extension to Polylogue."""
+
+    polylogue_capture_kind: Literal["browser_llm_session"] = BROWSER_CAPTURE_KIND
+    schema_version: Literal[1] = BROWSER_CAPTURE_SCHEMA_VERSION
+    capture_id: str | None = None
+    source: Literal["browser-extension"] = "browser-extension"
+    provenance: BrowserCaptureProvenance
+    session: BrowserCaptureSession
+    provider_meta: dict[str, object] = Field(default_factory=dict)
+
+    @field_validator("provider_meta", mode="before")
+    @classmethod
+    def coerce_provider_meta(cls, value: object) -> dict[str, object]:
+        return dict(json_document(value))
+
+    @model_validator(mode="after")
+    def fill_capture_id(self) -> BrowserCaptureEnvelope:
+        if self.capture_id is None:
+            self.capture_id = f"{self.session.provider.value}:{self.session.provider_session_id}"
+        return self
+
+    @property
+    def provider(self) -> Provider:
+        return self.session.provider
+
+    @property
+    def provider_session_id(self) -> str:
+        return self.session.provider_session_id
+
+
+def looks_like_browser_capture(payload: object) -> bool:
+    """Return whether a payload is a browser-capture envelope."""
+    if not isinstance(payload, dict):
+        return False
+    return (
+        payload.get("polylogue_capture_kind") == BROWSER_CAPTURE_KIND
+        and payload.get("schema_version") == BROWSER_CAPTURE_SCHEMA_VERSION
+        and is_json_document(payload.get("session"))
+        and is_json_document(payload.get("provenance"))
+    )
+
+
+__all__ = [
+    "BROWSER_CAPTURE_KIND",
+    "BROWSER_CAPTURE_SCHEMA_VERSION",
+    "BrowserCaptureAttachment",
+    "BrowserCaptureEnvelope",
+    "BrowserCaptureProvenance",
+    "BrowserCaptureSession",
+    "BrowserCaptureTurn",
+    "looks_like_browser_capture",
+]

--- a/polylogue/browser_capture/receiver.py
+++ b/polylogue/browser_capture/receiver.py
@@ -1,0 +1,145 @@
+"""Local-only browser-capture receiver helpers."""
+
+from __future__ import annotations
+
+import json
+import re
+import tempfile
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+import orjson
+
+from polylogue.browser_capture.models import BrowserCaptureEnvelope
+from polylogue.lib.hashing import hash_text_short
+from polylogue.paths import inbox_root
+
+_SAFE_TOKEN = re.compile(r"[^A-Za-z0-9._-]+")
+
+
+@dataclass(frozen=True, slots=True)
+class BrowserCaptureReceiverConfig:
+    """Configuration for the localhost browser-capture receiver."""
+
+    inbox_path: Path
+    allowed_origins: frozenset[str] = frozenset(
+        {
+            "https://chatgpt.com",
+            "https://claude.ai",
+        }
+    )
+
+    @classmethod
+    def default(cls) -> BrowserCaptureReceiverConfig:
+        return cls(inbox_path=inbox_root() / "browser-capture")
+
+
+@dataclass(frozen=True, slots=True)
+class BrowserCaptureWriteResult:
+    """Result of accepting a browser-capture envelope."""
+
+    provider: str
+    provider_session_id: str
+    path: Path
+    bytes_written: int
+    replaced: bool
+
+
+def _safe_token(value: str) -> str:
+    token = _SAFE_TOKEN.sub("-", value.strip()).strip(".-")
+    return token[:96] if token else "session"
+
+
+def capture_artifact_path(envelope: BrowserCaptureEnvelope, inbox_path: Path | None = None) -> Path:
+    """Return the deterministic inbox artifact path for an envelope."""
+    root = inbox_path if inbox_path is not None else BrowserCaptureReceiverConfig.default().inbox_path
+    provider = _safe_token(envelope.provider.value)
+    session = _safe_token(envelope.provider_session_id)
+    suffix = hash_text_short(f"{envelope.provider.value}:{envelope.provider_session_id}", 12)
+    return root / provider / f"{session}-{suffix}.json"
+
+
+def write_capture_envelope(
+    envelope: BrowserCaptureEnvelope,
+    *,
+    inbox_path: Path | None = None,
+) -> BrowserCaptureWriteResult:
+    """Atomically write a browser-capture source artifact into the inbox."""
+    target = capture_artifact_path(envelope, inbox_path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    payload = envelope.model_dump(mode="json", exclude_none=True)
+    raw = orjson.dumps(payload, option=orjson.OPT_INDENT_2 | orjson.OPT_SORT_KEYS)
+    replaced = target.exists()
+    with tempfile.NamedTemporaryFile("wb", dir=target.parent, prefix=f".{target.name}.", delete=False) as handle:
+        temp_path = Path(handle.name)
+        handle.write(raw)
+        handle.write(b"\n")
+    temp_path.replace(target)
+    return BrowserCaptureWriteResult(
+        provider=envelope.provider.value,
+        provider_session_id=envelope.provider_session_id,
+        path=target,
+        bytes_written=target.stat().st_size,
+        replaced=replaced,
+    )
+
+
+def receiver_status_payload(config: BrowserCaptureReceiverConfig) -> dict[str, object]:
+    """Return JSON status for extension health checks."""
+    return {
+        "ok": True,
+        "receiver": "polylogue-browser-capture",
+        "schema_version": 1,
+        "inbox_path": str(config.inbox_path),
+        "allowed_origins": sorted(config.allowed_origins),
+        "checked_at": datetime.now(UTC).isoformat(),
+    }
+
+
+def existing_capture_state(
+    provider: str,
+    provider_session_id: str,
+    *,
+    inbox_path: Path | None = None,
+) -> dict[str, object]:
+    """Return the local capture state visible to the browser extension."""
+    envelope = BrowserCaptureEnvelope.model_validate(
+        {
+            "provenance": {
+                "source_url": "about:blank",
+                "captured_at": "1970-01-01T00:00:00+00:00",
+                "adapter_name": "state-lookup",
+            },
+            "session": {
+                "provider": provider,
+                "provider_session_id": provider_session_id,
+                "turns": [{"provider_turn_id": "lookup", "role": "system", "text": "lookup"}],
+            },
+        }
+    )
+    path = capture_artifact_path(envelope, inbox_path)
+    state: dict[str, object] = {
+        "provider": envelope.provider.value,
+        "provider_session_id": envelope.provider_session_id,
+        "captured": path.exists(),
+        "artifact_path": str(path),
+    }
+    if path.exists():
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+            state["capture_id"] = payload.get("capture_id")
+            state["updated_at"] = payload.get("session", {}).get("updated_at")
+        except (OSError, json.JSONDecodeError, AttributeError):
+            state["artifact_readable"] = False
+    return state
+
+
+__all__ = [
+    "BrowserCaptureReceiverConfig",
+    "BrowserCaptureWriteResult",
+    "capture_artifact_path",
+    "existing_capture_state",
+    "receiver_status_payload",
+    "write_capture_envelope",
+]

--- a/polylogue/browser_capture/server.py
+++ b/polylogue/browser_capture/server.py
@@ -1,0 +1,149 @@
+"""HTTP surface for the local browser-capture receiver."""
+
+from __future__ import annotations
+
+import json
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+
+from pydantic import ValidationError
+
+from polylogue.browser_capture.models import BrowserCaptureEnvelope
+from polylogue.browser_capture.receiver import (
+    BrowserCaptureReceiverConfig,
+    existing_capture_state,
+    receiver_status_payload,
+    write_capture_envelope,
+)
+from polylogue.lib.json import dumps_bytes
+
+
+def _json_bytes(payload: object) -> bytes:
+    return dumps_bytes(payload, option=None)
+
+
+def _origin_allowed(origin: str | None, config: BrowserCaptureReceiverConfig) -> bool:
+    if origin is None:
+        return True
+    if origin.startswith("chrome-extension://"):
+        return True
+    return origin in config.allowed_origins
+
+
+class BrowserCaptureHTTPServer(ThreadingHTTPServer):
+    """Threading HTTP server carrying receiver configuration."""
+
+    config: BrowserCaptureReceiverConfig
+
+    def __init__(self, server_address: tuple[str, int], config: BrowserCaptureReceiverConfig) -> None:
+        self.config = config
+        super().__init__(server_address, BrowserCaptureHandler)
+
+
+class BrowserCaptureHandler(BaseHTTPRequestHandler):
+    """Local JSON API used by the browser extension."""
+
+    server: BrowserCaptureHTTPServer
+
+    def log_message(self, format: str, *args: object) -> None:
+        return
+
+    def _send_json(self, status: HTTPStatus, payload: object) -> None:
+        raw = _json_bytes(payload)
+        origin = self.headers.get("Origin")
+        self.send_response(status.value)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(raw)))
+        if _origin_allowed(origin, self.server.config):
+            self.send_header("Access-Control-Allow-Origin", origin or "null")
+            self.send_header("Vary", "Origin")
+        self.end_headers()
+        self.wfile.write(raw)
+
+    def _reject_origin(self) -> bool:
+        origin = self.headers.get("Origin")
+        if _origin_allowed(origin, self.server.config):
+            return False
+        self._send_json(HTTPStatus.FORBIDDEN, {"ok": False, "error": "origin_not_allowed"})
+        return True
+
+    def do_OPTIONS(self) -> None:
+        if self._reject_origin():
+            return
+        origin = self.headers.get("Origin")
+        self.send_response(HTTPStatus.NO_CONTENT.value)
+        self.send_header("Access-Control-Allow-Origin", origin or "null")
+        self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+        self.send_header("Access-Control-Allow-Headers", "Content-Type")
+        self.send_header("Access-Control-Max-Age", "600")
+        self.end_headers()
+
+    def do_GET(self) -> None:
+        if self._reject_origin():
+            return
+        parsed = urlparse(self.path)
+        if parsed.path == "/v1/status":
+            self._send_json(HTTPStatus.OK, receiver_status_payload(self.server.config))
+            return
+        if parsed.path == "/v1/archive-state":
+            params = parse_qs(parsed.query)
+            provider = params.get("provider", [""])[0]
+            session_id = params.get("provider_session_id", [""])[0]
+            if not provider or not session_id:
+                self._send_json(
+                    HTTPStatus.BAD_REQUEST,
+                    {"ok": False, "error": "missing_provider_or_session"},
+                )
+                return
+            self._send_json(
+                HTTPStatus.OK,
+                existing_capture_state(provider, session_id, inbox_path=self.server.config.inbox_path),
+            )
+            return
+        self._send_json(HTTPStatus.NOT_FOUND, {"ok": False, "error": "not_found"})
+
+    def do_POST(self) -> None:
+        if self._reject_origin():
+            return
+        if urlparse(self.path).path != "/v1/browser-captures":
+            self._send_json(HTTPStatus.NOT_FOUND, {"ok": False, "error": "not_found"})
+            return
+        try:
+            length = int(self.headers.get("Content-Length", "0"))
+        except ValueError:
+            self._send_json(HTTPStatus.BAD_REQUEST, {"ok": False, "error": "invalid_content_length"})
+            return
+        if length <= 0 or length > 10 * 1024 * 1024:
+            self._send_json(HTTPStatus.BAD_REQUEST, {"ok": False, "error": "invalid_body_size"})
+            return
+        try:
+            payload = json.loads(self.rfile.read(length))
+            envelope = BrowserCaptureEnvelope.model_validate(payload)
+            result = write_capture_envelope(envelope, inbox_path=self.server.config.inbox_path)
+        except (json.JSONDecodeError, ValidationError, OSError) as exc:
+            self._send_json(HTTPStatus.BAD_REQUEST, {"ok": False, "error": type(exc).__name__, "detail": str(exc)})
+            return
+        self._send_json(
+            HTTPStatus.ACCEPTED,
+            {
+                "ok": True,
+                "provider": result.provider,
+                "provider_session_id": result.provider_session_id,
+                "artifact_path": str(result.path),
+                "bytes_written": result.bytes_written,
+                "replaced": result.replaced,
+            },
+        )
+
+
+def make_server(host: str, port: int, *, inbox_path: Path | None = None) -> BrowserCaptureHTTPServer:
+    """Create a configured browser-capture receiver server."""
+    config = BrowserCaptureReceiverConfig.default()
+    if inbox_path is not None:
+        config = BrowserCaptureReceiverConfig(inbox_path=inbox_path, allowed_origins=config.allowed_origins)
+    return BrowserCaptureHTTPServer((host, port), config)
+
+
+__all__ = ["BrowserCaptureHTTPServer", "BrowserCaptureHandler", "make_server"]

--- a/polylogue/cli/click_command_registration.py
+++ b/polylogue/cli/click_command_registration.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import click
 
 from polylogue.cli.commands.auth import auth_command
+from polylogue.cli.commands.browser_capture import browser_capture_command
 from polylogue.cli.commands.check import check_command
 from polylogue.cli.commands.completions import completions_command
 from polylogue.cli.commands.dashboard import dashboard_command
@@ -21,6 +22,7 @@ from polylogue.cli.commands.tags import tags_command
 
 ROOT_COMMANDS: tuple[click.Command, ...] = (
     run_command,
+    browser_capture_command,
     check_command,
     reset_command,
     mcp_command,

--- a/polylogue/cli/commands/browser_capture.py
+++ b/polylogue/cli/commands/browser_capture.py
@@ -1,0 +1,55 @@
+"""Browser-capture receiver CLI commands."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+
+from polylogue.browser_capture.receiver import BrowserCaptureReceiverConfig, receiver_status_payload
+from polylogue.browser_capture.server import make_server
+from polylogue.lib.json import dumps
+
+
+@click.group("browser-capture")
+def browser_capture_command() -> None:
+    """Receive browser-extension captures into the normal inbox."""
+
+
+@browser_capture_command.command("status")
+@click.option("--inbox", "inbox_path", type=click.Path(path_type=Path), default=None)
+@click.option("--json", "as_json", is_flag=True)
+def status_command(inbox_path: Path | None, as_json: bool) -> None:
+    """Show receiver configuration and inbox target."""
+    config = BrowserCaptureReceiverConfig.default()
+    if inbox_path is not None:
+        config = BrowserCaptureReceiverConfig(inbox_path=inbox_path, allowed_origins=config.allowed_origins)
+    payload = receiver_status_payload(config)
+    if as_json:
+        click.echo(dumps(payload))
+        return
+    click.echo("Browser capture receiver")
+    click.echo(f"Inbox: {payload['inbox_path']}")
+    origins = payload.get("allowed_origins", [])
+    origin_text = ", ".join(str(item) for item in origins) if isinstance(origins, list) else str(origins)
+    click.echo(f"Allowed origins: {origin_text}")
+
+
+@browser_capture_command.command("serve")
+@click.option("--host", default="127.0.0.1", show_default=True)
+@click.option("--port", default=8765, show_default=True, type=int)
+@click.option("--inbox", "inbox_path", type=click.Path(path_type=Path), default=None)
+def serve_command(host: str, port: int, inbox_path: Path | None) -> None:
+    """Run the local browser-capture receiver."""
+    server = make_server(host, port, inbox_path=inbox_path)
+    click.echo(f"Listening on http://{host}:{port}")
+    click.echo(f"Writing captures to {server.config.inbox_path}")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        click.echo("Stopping browser capture receiver")
+    finally:
+        server.server_close()
+
+
+__all__ = ["browser_capture_command"]

--- a/polylogue/lib/artifact_taxonomy_support.py
+++ b/polylogue/lib/artifact_taxonomy_support.py
@@ -32,6 +32,8 @@ def path_only_sidecars() -> dict[str, str]:
 
 
 def looks_like_conversation_document(payload: JSONDocument) -> bool:
+    if payload.get("polylogue_capture_kind") == "browser_llm_session":
+        return True
     if isinstance(payload.get("mapping"), dict):
         return True
     if isinstance(payload.get("chat_messages"), list):

--- a/polylogue/sources/dispatch.py
+++ b/polylogue/sources/dispatch.py
@@ -14,7 +14,7 @@ from polylogue.logging import get_logger
 from polylogue.types import Provider
 
 from .decoders import _decode_json_bytes, _iter_json_stream
-from .parsers import chatgpt, claude, codex, drive
+from .parsers import browser_capture, chatgpt, claude, codex, drive
 from .parsers.base import ParsedConversation, extract_messages_from_list
 
 if TYPE_CHECKING:
@@ -32,6 +32,7 @@ PayloadRecord: TypeAlias = JSONDocument
 PayloadSequence: TypeAlias = list[JSONValue]
 LoweredPayloadMode: TypeAlias = Literal[
     "bundle_record",
+    "browser_capture",
     "chunked_prompt",
     "generic_messages",
     "grouped_records",
@@ -77,6 +78,10 @@ def _looks_like_gemini_mapping(record: PayloadRecord) -> bool:
 
 
 def _detect_provider_from_record(record: PayloadRecord) -> Provider | None:
+    if browser_capture.looks_like(record):
+        session = record.get("session")
+        provider = session.get("provider") if isinstance(session, dict) else None
+        return Provider.from_string(provider if isinstance(provider, str) else None)
     if chatgpt.looks_like(record):
         return Provider.CHATGPT
     if claude.looks_like_ai(record):
@@ -340,6 +345,16 @@ def _lower_payload_specs(
 
     shaped_payload = _schema_guided_payload(runtime_provider, payload, schema_resolution)
     record = _payload_record(shaped_payload)
+    if record is not None and browser_capture.looks_like(record):
+        provider = _detect_provider_from_record(record) or runtime_provider
+        return [
+            LoweredPayloadSpec(
+                provider=provider,
+                fallback_id=fallback_id,
+                mode="browser_capture",
+                payload=record,
+            )
+        ]
     if record is not None and (conversations := _record_conversations(record)):
         lowered_specs: list[LoweredPayloadSpec] = []
         for index, item in enumerate(conversations):
@@ -393,6 +408,10 @@ def _generic_messages_conversation(
 
 
 def _parse_lowered_spec(spec: LoweredPayloadSpec) -> list[ParsedConversation]:
+    if spec.mode == "browser_capture":
+        record = _payload_record(spec.payload)
+        return [browser_capture.parse(record, spec.fallback_id)] if record is not None else []
+
     if spec.provider is Provider.CHATGPT:
         record = _payload_record(spec.payload)
         return [chatgpt.parse(record, spec.fallback_id)] if record is not None else []

--- a/polylogue/sources/parsers/browser_capture.py
+++ b/polylogue/sources/parsers/browser_capture.py
@@ -1,0 +1,101 @@
+"""Parser for Polylogue browser-capture envelopes."""
+
+from __future__ import annotations
+
+from polylogue.browser_capture.models import BrowserCaptureEnvelope, looks_like_browser_capture
+from polylogue.sources.parsers.base_models import ParsedAttachment, ParsedConversation, ParsedMessage
+from polylogue.types import Provider
+
+
+def looks_like(payload: object) -> bool:
+    """Return whether a payload is a browser-capture envelope."""
+    return looks_like_browser_capture(payload)
+
+
+def _provider_meta(envelope: BrowserCaptureEnvelope) -> dict[str, object]:
+    meta: dict[str, object] = {
+        "source": envelope.source,
+        "capture_id": envelope.capture_id,
+        "browser_capture": True,
+        "provenance": envelope.provenance.model_dump(mode="json", exclude_none=True),
+    }
+    if envelope.session.model:
+        meta["model"] = envelope.session.model
+    if envelope.session.provider_meta:
+        meta["session"] = envelope.session.provider_meta
+    if envelope.provider_meta:
+        meta["capture"] = envelope.provider_meta
+    return meta
+
+
+def parse(payload: object, fallback_id: str) -> ParsedConversation:
+    """Parse a browser-capture envelope into the canonical parser contract."""
+    envelope = BrowserCaptureEnvelope.model_validate(payload)
+    seen_turns: set[str] = set()
+    messages: list[ParsedMessage] = []
+    attachments: list[ParsedAttachment] = []
+
+    for index, turn in enumerate(envelope.session.turns):
+        if turn.provider_turn_id in seen_turns:
+            continue
+        seen_turns.add(turn.provider_turn_id)
+        provider_meta: dict[str, object] = {
+            "browser_capture": True,
+            "ordinal": turn.ordinal if turn.ordinal else index,
+        }
+        if turn.provider_meta:
+            provider_meta.update(turn.provider_meta)
+        messages.append(
+            ParsedMessage(
+                provider_message_id=turn.provider_turn_id,
+                role=turn.role,
+                text=turn.text,
+                timestamp=turn.timestamp,
+                provider_meta=provider_meta,
+                parent_message_provider_id=turn.parent_turn_id,
+            )
+        )
+        for attachment in turn.attachments:
+            attachments.append(
+                ParsedAttachment(
+                    provider_attachment_id=attachment.provider_attachment_id,
+                    message_provider_id=attachment.message_provider_id or turn.provider_turn_id,
+                    name=attachment.name,
+                    mime_type=attachment.mime_type,
+                    size_bytes=attachment.size_bytes,
+                    path=None,
+                    provider_meta={**attachment.provider_meta, "url": attachment.url}
+                    if attachment.url
+                    else attachment.provider_meta or None,
+                )
+            )
+
+    for attachment in envelope.session.attachments:
+        attachments.append(
+            ParsedAttachment(
+                provider_attachment_id=attachment.provider_attachment_id,
+                message_provider_id=attachment.message_provider_id,
+                name=attachment.name,
+                mime_type=attachment.mime_type,
+                size_bytes=attachment.size_bytes,
+                path=None,
+                provider_meta={**attachment.provider_meta, "url": attachment.url}
+                if attachment.url
+                else attachment.provider_meta or None,
+            )
+        )
+
+    provider = envelope.session.provider if envelope.session.provider is not Provider.UNKNOWN else Provider.UNKNOWN
+    return ParsedConversation(
+        provider_name=provider,
+        provider_conversation_id=envelope.session.provider_session_id or fallback_id,
+        title=envelope.session.title or envelope.provenance.page_title or fallback_id,
+        created_at=envelope.session.created_at,
+        updated_at=envelope.session.updated_at or envelope.provenance.captured_at,
+        messages=messages,
+        attachments=attachments,
+        provider_meta=_provider_meta(envelope),
+    )
+
+
+__all__ = ["looks_like", "parse"]

--- a/tests/unit/browser_capture/test_receiver.py
+++ b/tests/unit/browser_capture/test_receiver.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import json
+from http import HTTPStatus
+from http.client import HTTPConnection
+from pathlib import Path
+from threading import Thread
+from typing import cast
+
+from click.testing import CliRunner
+
+from polylogue.browser_capture.models import BrowserCaptureEnvelope
+from polylogue.browser_capture.receiver import (
+    capture_artifact_path,
+    existing_capture_state,
+    write_capture_envelope,
+)
+from polylogue.browser_capture.server import make_server
+from polylogue.cli.click_app import cli
+
+
+def _payload(provider: str = "chatgpt", session_id: str = "conv-123") -> dict[str, object]:
+    return {
+        "polylogue_capture_kind": "browser_llm_session",
+        "schema_version": 1,
+        "provenance": {
+            "source_url": "https://chatgpt.com/c/conv-123",
+            "page_title": "ChatGPT - Work plan",
+            "captured_at": "2026-04-24T00:00:00+00:00",
+            "adapter_name": "chatgpt-dom-v1",
+        },
+        "session": {
+            "provider": provider,
+            "provider_session_id": session_id,
+            "title": "Work plan",
+            "turns": [{"provider_turn_id": "u1", "role": "user", "text": "Draft"}],
+        },
+    }
+
+
+def test_capture_artifact_path_is_deterministic(tmp_path: Path) -> None:
+    envelope = BrowserCaptureEnvelope.model_validate(_payload(session_id="c/with spaces"))
+
+    first = capture_artifact_path(envelope, tmp_path)
+    second = capture_artifact_path(envelope, tmp_path)
+
+    assert first == second
+    assert first.parent.name == "chatgpt"
+    assert "with-spaces" in first.name
+
+
+def test_write_capture_envelope_replaces_same_artifact(tmp_path: Path) -> None:
+    envelope = BrowserCaptureEnvelope.model_validate(_payload())
+
+    first = write_capture_envelope(envelope, inbox_path=tmp_path)
+    second = write_capture_envelope(envelope, inbox_path=tmp_path)
+
+    assert first.path == second.path
+    assert first.replaced is False
+    assert second.replaced is True
+    assert json.loads(first.path.read_text(encoding="utf-8"))["session"]["provider_session_id"] == "conv-123"
+
+
+def test_existing_capture_state_reports_written_artifact(tmp_path: Path) -> None:
+    envelope = BrowserCaptureEnvelope.model_validate(_payload())
+    write_capture_envelope(envelope, inbox_path=tmp_path)
+
+    state = existing_capture_state("chatgpt", "conv-123", inbox_path=tmp_path)
+
+    assert state["captured"] is True
+    assert state["provider"] == "chatgpt"
+
+
+def test_browser_capture_status_cli_json(cli_workspace: dict[str, Path]) -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(cli, ["browser-capture", "status", "--json"], catch_exceptions=False)
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["ok"] is True
+    assert payload["receiver"] == "polylogue-browser-capture"
+
+
+def test_receiver_http_accepts_capture_and_rejects_unknown_origin(tmp_path: Path) -> None:
+    server = make_server("127.0.0.1", 0, inbox_path=tmp_path)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    host, port = cast(tuple[str, int], server.server_address[:2])
+
+    try:
+        conn = HTTPConnection(host, port)
+        conn.request("GET", "/v1/status", headers={"Origin": "https://evil.example"})
+        response = conn.getresponse()
+        assert response.status == HTTPStatus.FORBIDDEN
+        response.read()
+        conn.close()
+
+        conn = HTTPConnection(host, port)
+        conn.request(
+            "POST",
+            "/v1/browser-captures",
+            body=json.dumps(_payload()),
+            headers={"Content-Type": "application/json", "Origin": "https://chatgpt.com"},
+        )
+        response = conn.getresponse()
+        body = json.loads(response.read())
+        assert response.status == HTTPStatus.ACCEPTED
+        assert body["ok"] is True
+        assert Path(body["artifact_path"]).exists()
+        conn.close()
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)

--- a/tests/unit/cli/__snapshots__/test_terminal_snapshots.ambr
+++ b/tests/unit/cli/__snapshots__/test_terminal_snapshots.ambr
@@ -206,25 +206,26 @@
     --version                       Show the version and exit.
     -h, --help                      Show this message and exit.
   Commands:
-    audit        Run archive QA: schema audit and artifact proof checks.
-    auth         Authenticate with external services (Google Drive for...
-    completions  Generate shell completion scripts.
-    count        Print count of matched conversations.
-    dashboard    Launch the dashboard TUI.
-    delete       Delete matched conversations.
-    doctor       Health check with optional maintenance and cleanup previews.
-    export       Export one known conversation by ID.
-    list         List matched conversations.
-    mcp          Start the MCP server for AI assistant integration.
-    neighbors    Show explainable neighboring or near-duplicate candidates.
-    open         Open matched conversation in browser<PATH>
-    products     Inspect durable archive data products.
-    reset        Reset database, blob store, assets, rendered outputs, or...
-    resume       Reconstruct work-state context for a fresh agent session.
-    run          Run pipeline stages on configured sources.
-    schema       Inspect schema packages, versions, and evidence.
-    stats        Show statistics for matched conversations.
-    tags         List all tags with conversation counts.
+    audit            Run archive QA: schema audit and artifact proof checks.
+    auth             Authenticate with external services (Google Drive for...
+    browser-capture  Receive browser-extension captures into the normal inbox.
+    completions      Generate shell completion scripts.
+    count            Print count of matched conversations.
+    dashboard        Launch the dashboard TUI.
+    delete           Delete matched conversations.
+    doctor           Health check with optional maintenance and cleanup...
+    export           Export one known conversation by ID.
+    list             List matched conversations.
+    mcp              Start the MCP server for AI assistant integration.
+    neighbors        Show explainable neighboring or near-duplicate...
+    open             Open matched conversation in browser<PATH>
+    products         Inspect durable archive data products.
+    reset            Reset database, blob store, assets, rendered outputs,...
+    resume           Reconstruct work-state context for a fresh agent session.
+    run              Run pipeline stages on configured sources.
+    schema           Inspect schema packages, versions, and evidence.
+    stats            Show statistics for matched conversations.
+    tags             List all tags with conversation counts.
   '''
 # ---
 # name: TestTerminalDimensions.test_help_at_narrow_width
@@ -381,33 +382,38 @@
     -h, --help                      Show this message and exit
   .
   Commands:
-    audit        Run archive QA: schema audit and artifact pro
-  of checks.
-    auth         Authenticate with external services (Google D
-  rive for...
-    completions  Generate shell completion scripts.
-    count        Print count of matched conversations.
-    dashboard    Launch the dashboard TUI.
-    delete       Delete matched conversations.
-    doctor       Health check with optional maintenance and cl
-  eanup previews.
-    export       Export one known conversation by ID.
-    list         List matched conversations.
-    mcp          Start the MCP server for AI assistant integra
-  tion.
-    neighbors    Show explainable neighboring or near-duplicat
-  e candidates.
-    open         Open matched conversation in browser<PATH>
-    products     Inspect durable archive data products.
-    reset        Reset database, blob store, assets, rendered
-  outputs, or...
-    resume       Reconstruct work-state context for a fresh ag
-  ent session.
-    run          Run pipeline stages on configured sources.
-    schema       Inspect schema packages, versions, and eviden
-  ce.
-    stats        Show statistics for matched conversations.
-    tags         List all tags with conversation counts.
+    audit            Run archive QA: schema audit and artifact
+   proof checks.
+    auth             Authenticate with external services (Goog
+  le Drive for...
+    browser-capture  Receive browser-extension captures into t
+  he normal inbox.
+    completions      Generate shell completion scripts.
+    count            Print count of matched conversations.
+    dashboard        Launch the dashboard TUI.
+    delete           Delete matched conversations.
+    doctor           Health check with optional maintenance an
+  d cleanup...
+    export           Export one known conversation by ID.
+    list             List matched conversations.
+    mcp              Start the MCP server for AI assistant int
+  egration.
+    neighbors        Show explainable neighboring or near-dupl
+  icate...
+    open             Open matched conversation in browser<PATH>
+  or.
+    products         Inspect durable archive data products.
+    reset            Reset database, blob store, assets, rende
+  red outputs,...
+    resume           Reconstruct work-state context for a fres
+  h agent session.
+    run              Run pipeline stages on configured sources
+  .
+    schema           Inspect schema packages, versions, and ev
+  idence.
+    stats            Show statistics for matched conversations
+  .
+    tags             List all tags with conversation counts.
   '''
 # ---
 # name: TestTerminalDimensions.test_help_at_wide_width
@@ -519,24 +525,25 @@
     --version                       Show the version and exit.
     -h, --help                      Show this message and exit.
   Commands:
-    audit        Run archive QA: schema audit and artifact proof checks.
-    auth         Authenticate with external services (Google Drive for...
-    completions  Generate shell completion scripts.
-    count        Print count of matched conversations.
-    dashboard    Launch the dashboard TUI.
-    delete       Delete matched conversations.
-    doctor       Health check with optional maintenance and cleanup previews.
-    export       Export one known conversation by ID.
-    list         List matched conversations.
-    mcp          Start the MCP server for AI assistant integration.
-    neighbors    Show explainable neighboring or near-duplicate candidates.
-    open         Open matched conversation in browser<PATH>
-    products     Inspect durable archive data products.
-    reset        Reset database, blob store, assets, rendered outputs, or...
-    resume       Reconstruct work-state context for a fresh agent session.
-    run          Run pipeline stages on configured sources.
-    schema       Inspect schema packages, versions, and evidence.
-    stats        Show statistics for matched conversations.
-    tags         List all tags with conversation counts.
+    audit            Run archive QA: schema audit and artifact proof checks.
+    auth             Authenticate with external services (Google Drive for...
+    browser-capture  Receive browser-extension captures into the normal inbox.
+    completions      Generate shell completion scripts.
+    count            Print count of matched conversations.
+    dashboard        Launch the dashboard TUI.
+    delete           Delete matched conversations.
+    doctor           Health check with optional maintenance and cleanup...
+    export           Export one known conversation by ID.
+    list             List matched conversations.
+    mcp              Start the MCP server for AI assistant integration.
+    neighbors        Show explainable neighboring or near-duplicate...
+    open             Open matched conversation in browser<PATH>
+    products         Inspect durable archive data products.
+    reset            Reset database, blob store, assets, rendered outputs,...
+    resume           Reconstruct work-state context for a fresh agent session.
+    run              Run pipeline stages on configured sources.
+    schema           Inspect schema packages, versions, and evidence.
+    stats            Show statistics for matched conversations.
+    tags             List all tags with conversation counts.
   '''
 # ---

--- a/tests/unit/cli/test_click_app.py
+++ b/tests/unit/cli/test_click_app.py
@@ -445,6 +445,7 @@ class TestCliMetadata:
 
         expected = {
             "run",
+            "browser-capture",
             "doctor",
             "reset",
             "mcp",

--- a/tests/unit/sources/test_browser_capture.py
+++ b/tests/unit/sources/test_browser_capture.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from polylogue.browser_capture.models import BrowserCaptureEnvelope
+from polylogue.browser_capture.receiver import write_capture_envelope
+from polylogue.config import Source, get_config
+from polylogue.pipeline.runner import run_sources
+from polylogue.sources.dispatch import detect_provider, parse_payload
+from polylogue.storage.backends.connection import open_connection
+from polylogue.types import Provider
+
+
+def _capture_payload() -> dict[str, object]:
+    return {
+        "polylogue_capture_kind": "browser_llm_session",
+        "schema_version": 1,
+        "capture_id": "chatgpt:conv-123",
+        "provenance": {
+            "source_url": "https://chatgpt.com/c/conv-123",
+            "page_title": "ChatGPT - Work plan",
+            "captured_at": "2026-04-24T00:00:00+00:00",
+            "adapter_name": "chatgpt-dom-v1",
+            "capture_mode": "snapshot",
+        },
+        "session": {
+            "provider": "chatgpt",
+            "provider_session_id": "conv-123",
+            "title": "Work plan",
+            "updated_at": "2026-04-24T00:00:01+00:00",
+            "model": "gpt-5.4",
+            "turns": [
+                {"provider_turn_id": "u1", "role": "user", "text": "Draft the plan", "ordinal": 0},
+                {
+                    "provider_turn_id": "a1",
+                    "role": "assistant",
+                    "text": "Here is the plan",
+                    "ordinal": 1,
+                    "attachments": [
+                        {
+                            "provider_attachment_id": "att-1",
+                            "name": "plan.md",
+                            "mime_type": "text/markdown",
+                            "url": "https://chatgpt.com/attachment/1",
+                        }
+                    ],
+                },
+                {"provider_turn_id": "a1", "role": "assistant", "text": "duplicate", "ordinal": 2},
+            ],
+        },
+    }
+
+
+def test_browser_capture_detects_inner_provider() -> None:
+    assert detect_provider(_capture_payload()) is Provider.CHATGPT
+
+
+def test_browser_capture_parses_session_metadata_and_deduplicates_turns() -> None:
+    parsed = parse_payload(Provider.CHATGPT, _capture_payload(), "fallback")
+
+    assert len(parsed) == 1
+    conversation = parsed[0]
+    assert conversation.provider_name is Provider.CHATGPT
+    assert conversation.provider_conversation_id == "conv-123"
+    assert conversation.title == "Work plan"
+    assert [message.provider_message_id for message in conversation.messages] == ["u1", "a1"]
+    assert conversation.provider_meta is not None
+    assert conversation.provider_meta["browser_capture"] is True
+    assert conversation.provider_meta["model"] == "gpt-5.4"
+    assert len(conversation.attachments) == 1
+    assert conversation.attachments[0].message_provider_id == "a1"
+    assert conversation.attachments[0].provider_meta == {"url": "https://chatgpt.com/attachment/1"}
+
+
+def test_browser_capture_supports_claude_ai_provider() -> None:
+    payload = _capture_payload()
+    session = payload["session"]
+    assert isinstance(session, dict)
+    session["provider"] = "claude-ai"
+    session["provider_session_id"] = "claude-session"
+
+    assert detect_provider(payload) is Provider.CLAUDE_AI
+    parsed = parse_payload(Provider.CLAUDE_AI, payload, "fallback")
+    assert parsed[0].provider_name is Provider.CLAUDE_AI
+    assert parsed[0].provider_conversation_id == "claude-session"
+
+
+@pytest.mark.asyncio
+async def test_browser_capture_receiver_artifact_lands_in_archive(
+    workspace_env: dict[str, Path],
+    tmp_path: Path,
+) -> None:
+    envelope = BrowserCaptureEnvelope.model_validate(_capture_payload())
+    artifact = write_capture_envelope(envelope, inbox_path=tmp_path / "browser-capture").path
+    config = get_config()
+    config.sources = [Source(name="inbox", path=artifact)]
+
+    await run_sources(config=config, stage="acquire")
+    await run_sources(config=config, stage="parse")
+
+    with open_connection(None) as conn:
+        row = conn.execute(
+            "SELECT provider_name, provider_conversation_id, provider_meta FROM conversations"
+        ).fetchone()
+
+    assert row is not None
+    assert row["provider_name"] == "chatgpt"
+    assert row["provider_conversation_id"] == "conv-123"
+    assert "browser_capture" in row["provider_meta"]


### PR DESCRIPTION
## Summary

Adds a local-first browser capture path for web LLM sessions. Browser-observed ChatGPT and Claude.ai sessions now flow through a typed Polylogue capture envelope, a localhost receiver, normal inbox artifacts, source dispatch, parsing, and archive storage.

Closes #312.

## Problem

ChatGPT and Claude.ai sessions required manual exports, so browser-hosted model work was disconnected from Polylogue's normal archive/query/product surfaces. The extension also needed archive-aware feedback rather than blind background upload.

## Solution

- Added `polylogue.browser_capture` typed envelope models, deterministic inbox artifact naming, receiver status/archive-state helpers, and a local HTTP server.
- Wired browser-capture envelopes into artifact taxonomy, provider detection, source dispatch, and parser lowering so they ingest as normal conversations.
- Added `polylogue browser-capture status|serve` and generated command/docs surfaces.
- Added a static Manifest V3 extension under `browser-extension/polylogue-browser-capture/` with ChatGPT and Claude.ai adapters, background transport, badge state, receiver configuration, capture/check controls, and a popup UI.
- Documented setup, privacy/local-only transport, endpoint contract, and provider-adapter expectations.

## Verification

- `pytest -q tests/unit/sources/test_browser_capture.py tests/unit/browser_capture/test_receiver.py` → `9 passed`
- `pytest -q tests/unit/browser_capture/test_receiver.py tests/unit/sources/test_browser_capture.py tests/unit/cli/test_click_app.py::TestCliMetadata::test_all_subcommands_registered tests/unit/cli/test_terminal_snapshots.py` → `20 passed`
- `node --check` on all extension scripts plus `python -m json.tool` on the manifest → passed
- Headless Chrome screenshot rendered `browser-extension/polylogue-browser-capture/src/popup.html` without clipped controls after CSS fix
- `devtools render-all --check` → sync OK
- `devtools verify` → all checks passed
- pre-push `devtools verify --quick` → all checks passed