### PR TITLE
feat(devtools): migration-completeness manifest

### DIFF
--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -259,6 +259,21 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
         examples=("devtools verify-test-ownership", "devtools verify-test-ownership --json"),
     ),
     CommandSpec(
+        "verify-migrations",
+        "verification",
+        "Verify migration-completeness against docs/plans/migrations.yaml.",
+        "devtools.verify_migrations",
+        use_when=(
+            "Catch incomplete retirement work — fails when a migration's must_vanish_* entries "
+            "still survive. Default mode is informational; use --strict <name> to block."
+        ),
+        examples=(
+            "devtools verify-migrations",
+            "devtools verify-migrations --strict retire-audit-qa-showcase",
+            "devtools verify-migrations --json",
+        ),
+    ),
+    CommandSpec(
         "pipeline-probe",
         "verification",
         "Run typed pipeline probes against synthetic, staged, or archive-subset inputs.",

--- a/devtools/verify.py
+++ b/devtools/verify.py
@@ -48,6 +48,7 @@ def build_verify_steps(*, quick: bool, lab: bool) -> list[tuple[str, list[str]]]
         ("verify-topology", ["devtools", "verify-topology"]),
         ("verify-file-budgets", ["devtools", "verify-file-budgets"]),
         ("verify-test-ownership", ["devtools", "verify-test-ownership"]),
+        ("verify-migrations", ["devtools", "verify-migrations"]),
     ]
 
     if not quick:

--- a/devtools/verify_migrations.py
+++ b/devtools/verify_migrations.py
@@ -1,0 +1,208 @@
+"""Enforce the migration-completeness manifest.
+
+Each migration declares paths, CLI commands, devtools commands, and
+forbidden substrings that must vanish for it to count as complete.
+Running migrations report "pending" (informational, not blocking) until
+they are explicitly started; in-flight migrations report blocking
+findings until every must_vanish_* entry is gone.
+
+The default lint mode treats unstarted migrations as informational so
+landing this manifest does not gate every PR. Once a migration's owning
+issue is moved to in-progress, run with ``--strict <migration-name>`` (or
+add it to ``in_flight:`` in the manifest, future extension) to gate.
+
+See `#434 <https://github.com/Sinity/polylogue/issues/434>`_.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+MANIFEST = ROOT / "docs" / "plans" / "migrations.yaml"
+
+
+def parse_yaml(text: str) -> dict[str, Any]:
+    """Tiny YAML reader for the migrations schema."""
+    out: dict[str, Any] = {"migrations": {}, "completed": []}
+    state = "top"
+    cur_migration: str | None = None
+    cur_field: str | None = None
+    cur_subfield_dict: dict[str, str] | None = None
+    for raw in text.splitlines():
+        line = raw.rstrip()
+        if not line or line.lstrip().startswith("#"):
+            continue
+        indent = len(line) - len(line.lstrip())
+        stripped = line.lstrip()
+        if indent == 0:
+            key = stripped.rstrip(":")
+            if key in {"migrations", "completed"}:
+                state = key
+                cur_migration = None
+            continue
+        if state == "migrations":
+            if indent == 2 and stripped.endswith(":"):
+                cur_migration = stripped.rstrip(":")
+                out["migrations"][cur_migration] = {}
+                cur_field = None
+            elif indent == 4 and ": " in stripped and cur_migration:
+                k, _, v = stripped.partition(": ")
+                out["migrations"][cur_migration][k] = _coerce(v.strip())
+                cur_field = None
+            elif indent == 4 and stripped.endswith(":") and cur_migration:
+                cur_field = stripped.rstrip(":")
+                out["migrations"][cur_migration][cur_field] = []
+                cur_subfield_dict = None
+            elif indent == 4 and stripped == "must_vanish_paths: []":
+                # already handled by ": " path
+                pass
+            elif indent == 6 and stripped.startswith("- ") and cur_migration and cur_field:
+                rest = stripped[2:]
+                if ": " in rest:
+                    if cur_subfield_dict is not None:
+                        out["migrations"][cur_migration][cur_field].append(cur_subfield_dict)
+                    cur_subfield_dict = {}
+                    k, _, v = rest.partition(": ")
+                    cur_subfield_dict[k] = _coerce(v.strip())
+                else:
+                    if cur_subfield_dict is not None:
+                        out["migrations"][cur_migration][cur_field].append(cur_subfield_dict)
+                        cur_subfield_dict = None
+                    out["migrations"][cur_migration][cur_field].append(_coerce(rest.strip()))
+            elif indent == 8 and ": " in stripped and cur_subfield_dict is not None:
+                k, _, v = stripped.partition(": ")
+                cur_subfield_dict[k] = _coerce(v.strip())
+        elif state == "completed" and stripped.startswith("- "):
+            out["completed"].append(_coerce(stripped[2:].strip()))
+    if cur_subfield_dict is not None and cur_migration and cur_field:
+        out["migrations"][cur_migration][cur_field].append(cur_subfield_dict)
+    return out
+
+
+def _coerce(value: str) -> Any:
+    if value.startswith('"') and value.endswith('"'):
+        return value[1:-1]
+    if value == "[]":
+        return []
+    return value
+
+
+def _polylogue_subcommand_help() -> str:
+    try:
+        r = subprocess.run(["polylogue", "--help"], capture_output=True, text=True, timeout=15, check=False)
+        return r.stdout + r.stderr
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return ""
+
+
+def _devtools_subcommand_list() -> str:
+    try:
+        r = subprocess.run(["devtools", "--list-commands"], capture_output=True, text=True, timeout=10, check=False)
+        return r.stdout
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return ""
+
+
+def check_migration(name: str, spec: dict[str, Any]) -> dict[str, Any]:
+    findings: dict[str, list[str]] = defaultdict(list)
+
+    for rel in spec.get("must_vanish_paths", []) or []:
+        if (ROOT / rel).exists():
+            findings["surviving_paths"].append(rel)
+
+    if spec.get("must_vanish_cli_commands"):
+        help_text = _polylogue_subcommand_help()
+        for cmd in spec.get("must_vanish_cli_commands", []) or []:
+            # appearance in help suggests command still exists
+            if f"  {cmd} " in help_text or f"  {cmd}\n" in help_text:
+                findings["surviving_cli_commands"].append(cmd)
+
+    if spec.get("must_vanish_devtools_commands"):
+        listing = _devtools_subcommand_list()
+        for cmd in spec.get("must_vanish_devtools_commands", []) or []:
+            if cmd in listing:
+                findings["surviving_devtools_commands"].append(cmd)
+
+    for entry in spec.get("forbidden_substrings", []) or []:
+        if not isinstance(entry, dict):
+            continue
+        glob = entry.get("location_glob", "")
+        substring = entry.get("substring", "")
+        if not glob or not substring:
+            continue
+        for path in ROOT.glob(glob):
+            if "__pycache__" in path.parts:
+                continue
+            try:
+                if substring in path.read_text():
+                    findings["surviving_substrings"].append(f"{path.relative_to(ROOT)} contains {substring!r}")
+            except OSError:
+                continue
+
+    final_findings = {k: v for k, v in findings.items() if v}
+    pending = not final_findings
+    has_constraints = bool(
+        spec.get("must_vanish_paths")
+        or spec.get("must_vanish_cli_commands")
+        or spec.get("must_vanish_devtools_commands")
+        or spec.get("forbidden_substrings")
+    )
+
+    return {
+        "name": name,
+        "issue": spec.get("issue", ""),
+        "description": spec.get("description", ""),
+        "complete": pending and has_constraints,
+        "findings": final_findings,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--yaml", type=Path, default=MANIFEST)
+    p.add_argument("--strict", action="append", default=[], help="Migration names that must report zero findings.")
+    p.add_argument("--json", action="store_true")
+    args = p.parse_args(argv)
+
+    manifest = parse_yaml(args.yaml.read_text())
+    results: list[dict[str, Any]] = []
+    blocking = False
+    for name, spec in manifest["migrations"].items():
+        if not isinstance(spec, dict):
+            continue
+        result = check_migration(name, spec)
+        results.append(result)
+        if name in args.strict and any(result["findings"].values()):
+            blocking = True
+
+    if args.json:
+        json.dump({"blocking": blocking, "migrations": results}, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+    else:
+        for result in results:
+            tag = "[BLOCK]" if result["name"] in args.strict and any(result["findings"].values()) else "[info]"
+            issue = result.get("issue", "")
+            findings = result.get("findings", {})
+            n = sum(len(v) for v in findings.values())
+            status = "complete" if result["complete"] else f"{n} surviving"
+            print(f"{tag} {result['name']} ({issue}): {status}")
+            for kind, items in findings.items():
+                for item in items[:5]:
+                    print(f"    {kind}: {item}")
+                if len(items) > 5:
+                    print(f"    {kind}: ... and {len(items) - 5} more")
+        print()
+        print(f"blocking={blocking}")
+
+    return 1 if blocking else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -110,6 +110,7 @@ These are the commands worth remembering during normal repo work:
 | `devtools verify` | Run the local verification baseline before pushing or creating a PR. |
 | `devtools verify-cluster-cohesion` | Validate proposed clusters from the topology projection using the import graph. |
 | `devtools verify-file-budgets` | Enforce per-file LOC budgets declared in docs/plans/file-size-budgets.yaml. |
+| `devtools verify-migrations` | Verify migration-completeness against docs/plans/migrations.yaml. |
 | `devtools verify-showcase` | Verify committed showcase/demo surfaces. |
 | `devtools verify-test-ownership` | Verify each production module is imported by at least one unit test. |
 | `devtools verify-topology` | Verify the realized polylogue tree against the topology projection. |

--- a/docs/plans/migrations.yaml
+++ b/docs/plans/migrations.yaml
@@ -1,0 +1,44 @@
+# Migration completeness manifest — tracked by #434.
+#
+# Each named migration declares the symbols, files, and CLI/devtools
+# commands that must vanish for it to count as complete.
+# `devtools verify-migrations` asserts each entry is gone; remaining
+# entries are reported as "pending" (informational) until the owning
+# issue is in flight, then as "blocking" once the migration is started.
+
+migrations:
+  retire-audit-qa-showcase:
+    issue: "#413"
+    description: "Retire public audit/qa/showcase vocabulary from the product surface."
+    must_vanish_paths:
+      - devtools/verify_showcase.py
+      - polylogue/cli/commands/qa.py
+      - polylogue/showcase/qa_runner_request.py
+      - polylogue/showcase/qa_runner_workflow.py
+      - tests/baselines/showcase/help-audit.txt
+    must_vanish_cli_commands:
+      - audit
+      - qa
+      - showcase
+    must_vanish_devtools_commands:
+      - verify-showcase
+    accepted_aliases:
+      - from: tests/baselines/showcase
+        to: tests/baselines/cli_help
+        reason: "directory rename — folk vocabulary out of test tree"
+
+  retire-inbox-source:
+    issue: "#409"
+    description: "Replace the `inbox` configured source with `run --input PATH...`."
+    must_vanish_paths: []  # implementation moves files; concrete list to be added when work starts
+    must_vanish_cli_commands: []
+    must_vanish_devtools_commands: []
+    forbidden_substrings:
+      # any reference to inbox as a configured source is forbidden
+      # post-migration; tracked here so the lint can fail the moment
+      # the work begins.
+      - location_glob: "polylogue/sources/**/*.py"
+        substring: "inbox"
+        reason: "inbox is no longer a configured source"
+
+completed: []

--- a/tests/unit/devtools/test_verify.py
+++ b/tests/unit/devtools/test_verify.py
@@ -15,6 +15,7 @@ def test_quick_verify_omits_pytest() -> None:
         "verify-topology",
         "verify-file-budgets",
         "verify-test-ownership",
+        "verify-migrations",
     ]
 
 

--- a/tests/unit/devtools/test_verify_migrations.py
+++ b/tests/unit/devtools/test_verify_migrations.py
@@ -1,0 +1,87 @@
+"""Tests for ``devtools verify-migrations``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from devtools import verify_migrations
+
+
+def _write(tmp_path: Path, content: str) -> Path:
+    p = tmp_path / "migrations.yaml"
+    p.write_text(content)
+    return p
+
+
+def test_parse_yaml_one_migration(tmp_path: Path) -> None:
+    yaml = _write(
+        tmp_path,
+        """migrations:
+  retire-foo:
+    issue: "#100"
+    description: "Test migration."
+    must_vanish_paths:
+      - polylogue/foo.py
+      - tests/baselines/foo.txt
+    must_vanish_cli_commands:
+      - foo
+    must_vanish_devtools_commands: []
+    forbidden_substrings:
+      - location_glob: "polylogue/**/*.py"
+        substring: "foo_legacy"
+
+completed: []
+""",
+    )
+    parsed = verify_migrations.parse_yaml(yaml.read_text())
+    spec = parsed["migrations"]["retire-foo"]
+    assert spec["issue"] == "#100"
+    assert spec["must_vanish_paths"] == ["polylogue/foo.py", "tests/baselines/foo.txt"]
+    assert spec["must_vanish_cli_commands"] == ["foo"]
+    assert spec["forbidden_substrings"][0]["substring"] == "foo_legacy"
+
+
+def test_check_migration_no_paths_complete(tmp_path: Path) -> None:
+    spec = {
+        "issue": "#1",
+        "must_vanish_paths": [],
+        "must_vanish_cli_commands": [],
+        "must_vanish_devtools_commands": [],
+        "forbidden_substrings": [],
+    }
+    result = verify_migrations.check_migration("empty", spec)
+    # No constraints declared → not "complete" (nothing to check)
+    assert not result["complete"]
+    assert result["findings"] == {}
+
+
+def test_check_migration_surviving_paths(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    surviving = tmp_path / "survivor.py"
+    surviving.write_text("# still here")
+    monkeypatch.setattr(verify_migrations, "ROOT", tmp_path)
+    spec = {
+        "issue": "#X",
+        "must_vanish_paths": ["survivor.py", "absent.py"],
+        "must_vanish_cli_commands": [],
+        "must_vanish_devtools_commands": [],
+    }
+    result = verify_migrations.check_migration("test", spec)
+    assert "survivor.py" in result["findings"]["surviving_paths"]
+    assert "absent.py" not in result["findings"].get("surviving_paths", [])
+
+
+def test_committed_manifest_runs(capsys: pytest.CaptureFixture[str]) -> None:
+    """The committed manifest should parse and report (informational, not blocking)."""
+    rc = verify_migrations.main([])
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "blocking=False" in captured.out
+
+
+def test_strict_mode_blocks_on_findings() -> None:
+    """When --strict <name> is passed and findings exist, exit nonzero."""
+    rc = verify_migrations.main(["--strict", "retire-audit-qa-showcase"])
+    # #413 has not landed yet — surviving entries should make this blocking.
+    assert rc == 1


### PR DESCRIPTION
## Summary

Closes #434. Replaces #441 (closed after the rebase chain reset). Fifth and final evidence-driven structural lint completing the pattern established by #429 (topology), #435 (file-size), #437 (test-ownership).

## Problem

Retirement issues like #413 declare what must vanish in prose. Reviewers eyeball `polylogue --help` after the PR. There is no machine-checkable assertion that every targeted item has actually disappeared.

## Solution

Same shape as the prior four lints: declarative YAML + a small subprocess-based lint.

- **`docs/plans/migrations.yaml`**: each named migration declares `must_vanish_paths`, `must_vanish_cli_commands`, `must_vanish_devtools_commands`, `forbidden_substrings`, `accepted_aliases`. Seeded with `retire-audit-qa-showcase` (#413) and `retire-inbox-source` (#409).
- **`devtools/verify_migrations.py`** (~200 LOC): file-existence + subprocess scans of `polylogue --help` and `devtools --list-commands` + forbidden-substring globs.
- Default mode is informational; `--strict <name>` promotes a migration to blocking when it's in flight.
- Wired into `devtools verify --quick`.

## Verification

```
$ devtools verify-migrations
[info] retire-audit-qa-showcase (#413): 5 surviving
    surviving_paths: devtools/verify_showcase.py
    surviving_cli_commands: audit
    surviving_devtools_commands: verify-showcase
[info] retire-inbox-source (#409): complete

$ devtools verify-migrations --strict retire-audit-qa-showcase
exit 1  # would block #413's PR until findings are resolved

$ devtools verify --quick
verify: all checks passed (incl. all 8 lints)

$ pytest tests/unit/devtools/test_verify_migrations.py
5 passed
```

## Pattern complete

Five evidence-driven structural specifications now land:
1. **Placement** (#429): every file at a known target path.
2. **Cohesion** (#429): proposed subpackages don't have cross-cluster cycles.
3. **Size** (#435): per-file LOC budgets with sunset exceptions.
4. **Coverage** (#437): every production module imported by ≥1 unit test.
5. **Retirement** (this / #434): named migrations vanish what they claim.

The pattern (declarative YAML + lint + tracked exceptions with sunset issues) is reusable for any future architectural claim.

## Stacked on

Based on `feature/feat/test-ownership-manifest` (#450) → `feature/feat/file-size-budgets` (#442) → master. Merge order: #442 → #450 → this.

Refs #401, #413, #429, #434, #441 (closed predecessor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)