### PR TITLE
fix(pipeline): four critical silent-failure sites

### DIFF
--- a/polylogue/pipeline/run_execution.py
+++ b/polylogue/pipeline/run_execution.py
@@ -313,7 +313,10 @@ async def run_sources(
             duration_ms=int((time.perf_counter() - start) * 1000),
         )
     finally:
-        # Restore FTS triggers that were suspended for bulk operations
+        # Restore FTS triggers that were suspended for bulk operations.
+        # Failure here leaves the search index in a degraded state until the
+        # next full rebuild; surface it loudly so operators see degraded state
+        # in logs rather than discovering stale results later.
         try:
             from polylogue.storage.fts_lifecycle import restore_fts_triggers_async
 
@@ -321,7 +324,10 @@ async def run_sources(
                 await restore_fts_triggers_async(conn)
                 await conn.commit()
         except Exception:
-            pass  # Don't fail on trigger restore — index rebuild handles FTS
+            logger.exception(
+                "FTS trigger restoration failed; search index may return stale "
+                "results until the next 'devtools verify' or 'polylogue run index' rebuild",
+            )
         if owns_repository:
             await active_repository.close()
         elif owns_backend:

--- a/polylogue/pipeline/services/ingest_worker.py
+++ b/polylogue/pipeline/services/ingest_worker.py
@@ -23,6 +23,7 @@ from polylogue.lib.branch_type import BranchType
 from polylogue.lib.json import dumps as json_dumps
 from polylogue.lib.raw_payload_decode import RawPayloadEnvelope
 from polylogue.lib.roles import Role
+from polylogue.logging import get_logger
 from polylogue.pipeline.materialization_runtime import (
     MaterializedContentBlock,
     MaterializedConversation,
@@ -58,6 +59,7 @@ if TYPE_CHECKING:
     from polylogue.sources.parsers.base import ParsedConversation
 
 
+logger = get_logger(__name__)
 _SOURCE_HASH_SUFFIX = re.compile(r"-(?:[0-9a-f]{16,64})$", re.IGNORECASE)
 _SCHEMA_REGISTRY: SchemaRegistry | None = None
 
@@ -405,6 +407,14 @@ def _build_stream_parse_plan(
             jsonl_dict_only=True,
         )
     except Exception:
+        # Sampling helper failed entirely (file I/O, decode, or worse). Logging
+        # this is critical because the caller falls back to a different parser
+        # path on `None`, which can produce different content hashes for the
+        # same input depending on whether the helper happened to succeed.
+        logger.exception(
+            "JSONL sample probe failed for %s; falling back to non-stream parsing",
+            stream_name,
+        )
         return None
 
     runtime_provider = Provider.from_string(payload_provider or context.raw_record.provider_name)

--- a/polylogue/sources/dispatch.py
+++ b/polylogue/sources/dispatch.py
@@ -144,6 +144,11 @@ def _detect_provider_from_raw_bytes(
     try:
         payloads = list(_iter_json_stream(BytesIO(raw_bytes), stream_name))
     except Exception:
+        logger.exception(
+            "Provider detection by JSON-stream parsing failed for %s; falling back to %s",
+            stream_name,
+            fallback_provider.value,
+        )
         return fallback_provider
 
     return detect_provider(payloads) or fallback_provider

--- a/polylogue/storage/backends/schema_bootstrap.py
+++ b/polylogue/storage/backends/schema_bootstrap.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 
 import re
 import sqlite3
-from contextlib import suppress
 from dataclasses import dataclass
 from typing import Literal, TypeAlias
 
 import aiosqlite
 
 from polylogue.errors import DatabaseError
+from polylogue.logging import get_logger
 from polylogue.storage.backends.schema_ddl import (
     _ACTION_EVENT_DDL,
     _ACTION_FTS_DDL,
@@ -21,6 +21,8 @@ from polylogue.storage.backends.schema_ddl import (
     SCHEMA_DDL,
     SCHEMA_VERSION,
 )
+
+logger = get_logger(__name__)
 
 _RAW_SOURCE_MTIME_INDEX_SQL = (
     "CREATE INDEX IF NOT EXISTS idx_raw_conv_source_mtime "
@@ -600,15 +602,36 @@ async def apply_schema_extension_plan_async(conn: aiosqlite.Connection, plan: Sc
 
 
 def ensure_vec0_table(conn: sqlite3.Connection) -> None:
-    with suppress(Exception):
+    # Probe gates whether vec0 is available; absence is the common case
+    # (extension not loaded) and is intentionally silent. DDL failure after
+    # the probe succeeds is corruption-shaped and must surface in logs.
+    try:
         conn.execute("SELECT vec_version()")
+    except Exception:
+        return
+    try:
         conn.execute(_VEC0_DDL)
+    except Exception:
+        logger.exception(
+            "vec_version() succeeded but _VEC0_DDL failed; vector table may be "
+            "partially initialized — semantic search will return empty results "
+            "until the database is reset",
+        )
 
 
 async def ensure_vec0_table_async(conn: aiosqlite.Connection) -> None:
-    with suppress(Exception):
+    try:
         await conn.execute("SELECT vec_version()")
+    except Exception:
+        return
+    try:
         await conn.execute(_VEC0_DDL)
+    except Exception:
+        logger.exception(
+            "vec_version() succeeded but _VEC0_DDL failed; vector table may be "
+            "partially initialized — semantic search will return empty results "
+            "until the database is reset",
+        )
 
 
 __all__ = [


### PR DESCRIPTION
## Summary

Closes #443. Four sites that swallowed exceptions and risked data-corruption or silent wrong-answer behavior, per the silent-failure audit (swarm 2026-04-26). Each fix adds explicit `logger.exception(...)` so operators see degraded state.

## Problem

Polylogue's archive uses content-hash idempotency: once a record is processed, subsequent ingests skip it. This is an asset for performance but a hazard when paired with silent failures — a misclassified or partially-processed record stays misclassified until manual recovery.

The silent-failure audit identified four critical sites where `except Exception:` paths swallowed failures with no log, surfacing in user-visible behavior only as "search returns stale results" / "duplicate conversations" / "vector search empty":

- `polylogue/sources/dispatch.py:144` — provider detection demoted on any exception, no log.
- `polylogue/pipeline/run_execution.py:317` — FTS-trigger restoration suppressed.
- `polylogue/pipeline/services/ingest_worker.py:401` — JSONL sample probe failure rerouted; broke content-hash stability.
- `polylogue/storage/backends/schema_bootstrap.py:602` — `with suppress(Exception)` hid both "vec0 not loaded" (intentional) and "vec0 DDL failed" (corruption).

## Solution

### Site 1 — `polylogue/sources/dispatch.py:144`

`logger.exception` with stream name and fallback target. Misclassified streams are now visible in logs.

### Site 2 — `polylogue/pipeline/run_execution.py:317`

`logger.exception` with explicit guidance to rebuild via `polylogue run index`. Replaces silent `pass` with operator-actionable diagnostic.

### Site 3 — `polylogue/pipeline/services/ingest_worker.py:401`

`logger.exception` documenting the rerouting and its hash-stability implication. Deeper fix (preserving content-hash stability under helper failure) is follow-up work tracked in #447.

### Site 4 — `polylogue/storage/backends/schema_bootstrap.py:602`

Split into a silent probe (vec0 not loaded → return) followed by the DDL with `logger.exception` on DDL failure after the probe succeeded. Distinguishes intentional skip from corruption-shaped failure.

The clean three-tier exception pattern in `polylogue/sources/source_acquisition.py` and `polylogue/sources/source_parsing.py` (cited in audit as exemplars) remains the canonical model.

## Verification

```
$ devtools verify --quick
verify: all checks passed (incl. all 8 lints)

$ ruff check polylogue/sources/dispatch.py polylogue/pipeline/run_execution.py polylogue/pipeline/services/ingest_worker.py polylogue/storage/backends/schema_bootstrap.py
All checks passed!

$ mypy <four files>
Success: no issues found in 4 source files
```

Behavior unchanged — only adds logging. Pytest already covers the recovery paths; no new test surface needed at this layer (deeper contract validation is #447's scope).

## Related

- #447 — pipeline runtime stage contract validation (the systemic fix; this PR is the localized one).
- #421 — proof obligations for these failure modes.
- #401 — post-renewal consolidation umbrella.

🤖 Generated with [Claude Code](https://claude.com/claude-code)