### PR TITLE
feat(devtools): lab list subcommands and artifact-graph --strict

### DIFF
--- a/devtools/artifact_graph.py
+++ b/devtools/artifact_graph.py
@@ -84,9 +84,18 @@ def render_artifact_graph(*, as_json: bool) -> str:
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--json", action="store_true", help="Emit the artifact graph as JSON.")
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Fail with exit 1 if any artifacts, operations, or maintenance targets are uncovered.",
+    )
     args = parser.parse_args(argv)
     sys.stdout.write(render_artifact_graph(as_json=args.json))
     sys.stdout.write("\n")
+    if args.strict:
+        coverage = build_runtime_scenario_coverage()
+        if coverage.uncovered_artifacts or coverage.uncovered_operations or coverage.uncovered_maintenance_targets:
+            return 1
     return 0
 
 

--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -174,7 +174,11 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
         "Render the runtime artifact, operation, and scenario-coverage map.",
         "devtools.artifact_graph",
         use_when="Inspect the authored runtime graph and see which scenarios currently cover declared artifacts and operations.",
-        examples=("devtools artifact-graph", "devtools artifact-graph --json"),
+        examples=(
+            "devtools artifact-graph",
+            "devtools artifact-graph --json",
+            "devtools artifact-graph --strict",
+        ),
     ),
     CommandSpec(
         "scenario-projections",
@@ -313,6 +317,7 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
         "devtools.lab_corpus",
         use_when="Seed synthetic corpus files or complete demo workspaces for lab exercises.",
         examples=(
+            "devtools lab-corpus list",
             "devtools lab-corpus generate --provider chatgpt --count 5",
             "devtools lab-corpus seed --env-only",
         ),
@@ -324,6 +329,7 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
         "devtools.lab_scenario",
         use_when="Run showcase exercise smoke scenarios and committed baseline checks outside the product CLI.",
         examples=(
+            "devtools lab-scenario list",
             "devtools lab-scenario run archive-smoke --tier 0",
             "devtools lab-scenario verify-baselines",
         ),

--- a/devtools/lab_corpus.py
+++ b/devtools/lab_corpus.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import sys
 from pathlib import Path
 
@@ -39,12 +40,33 @@ def _build_parser() -> argparse.ArgumentParser:
     seed_parser = subparsers.add_parser("seed", help="Seed a complete demo archive workspace.")
     _add_corpus_options(seed_parser)
     seed_parser.add_argument("--env-only", action="store_true", help="Print shell exports for the seeded workspace.")
+
+    list_parser = subparsers.add_parser("list", help="List available corpus sources.")
+    list_parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
     return parser
+
+
+def list_corpus_sources(*, as_json: bool) -> int:
+    """List the corpus source kinds available for `generate` / `seed`."""
+    payload = {
+        "corpus_sources": [
+            {"name": kind.value, "is_default": kind is CorpusSourceKind.DEFAULT} for kind in CorpusSourceKind
+        ]
+    }
+    if as_json:
+        print(json.dumps(payload, indent=2))
+        return 0
+    for entry in payload["corpus_sources"]:
+        marker = " (default)" if entry["is_default"] else ""
+        print(f"  {entry['name']}{marker}")
+    return 0
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = _build_parser()
     args = parser.parse_args(argv)
+    if args.action == "list":
+        return list_corpus_sources(as_json=bool(args.json))
     providers = tuple(str(provider) for provider in args.providers)
     corpus_source = CorpusSourceKind(str(args.corpus_source))
     try:

--- a/devtools/lab_scenario.py
+++ b/devtools/lab_scenario.py
@@ -133,7 +133,36 @@ def _build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Update baselines to current output instead of comparing.",
     )
+
+    list_parser = subparsers.add_parser("list", help="List available showcase scenarios.")
+    list_parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
     return parser
+
+
+def list_scenarios(*, as_json: bool) -> int:
+    """List available showcase scenarios with their tier-0 exercise inventory."""
+    tier_0 = get_tier_0_exercises()
+    payload = {
+        "scenarios": [
+            {
+                "name": name,
+                "tier_0_exercise_count": len(tier_0),
+                "baseline_dir": str(BASELINE_DIR.relative_to(BASELINE_DIR.parent.parent.parent))
+                if BASELINE_DIR.exists()
+                else None,
+                "baselines_committed": len(list(BASELINE_DIR.glob("*.txt"))) if BASELINE_DIR.exists() else 0,
+            }
+            for name in _SCENARIO_NAMES
+        ]
+    }
+    if as_json:
+        print(json.dumps(payload, indent=2))
+        return 0
+    for entry in payload["scenarios"]:
+        print(f"{entry['name']:<20s}  tier-0 exercises: {entry['tier_0_exercise_count']}")
+        if entry["baselines_committed"]:
+            print(f"  baselines: {entry['baselines_committed']} ({entry['baseline_dir']})")
+    return 0
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -141,6 +170,8 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
     if args.action == "verify-baselines":
         return verify_showcase_baselines(update=bool(args.update))
+    if args.action == "list":
+        return list_scenarios(as_json=bool(args.json))
     if args.action != "run":
         parser.error(f"unknown action: {args.action}")
     request = build_qa_session_request(

--- a/tests/unit/devtools/test_lab_list_subcommands.py
+++ b/tests/unit/devtools/test_lab_list_subcommands.py
@@ -1,0 +1,60 @@
+"""Tests for the `lab-scenario list` and `lab-corpus list` subcommands.
+
+Closes the discoverability gap surfaced by #446.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from devtools import artifact_graph, lab_corpus, lab_scenario
+
+
+def test_lab_scenario_list_human(capsys: pytest.CaptureFixture[str]) -> None:
+    rc = lab_scenario.main(["list"])
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "archive-smoke" in captured.out
+
+
+def test_lab_scenario_list_json(capsys: pytest.CaptureFixture[str]) -> None:
+    rc = lab_scenario.main(["list", "--json"])
+    captured = capsys.readouterr()
+    assert rc == 0
+    payload = json.loads(captured.out)
+    assert isinstance(payload, dict)
+    assert "scenarios" in payload
+    assert any(entry["name"] == "archive-smoke" for entry in payload["scenarios"])
+
+
+def test_lab_corpus_list_human(capsys: pytest.CaptureFixture[str]) -> None:
+    rc = lab_corpus.main(["list"])
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "default" in captured.out
+
+
+def test_lab_corpus_list_json(capsys: pytest.CaptureFixture[str]) -> None:
+    rc = lab_corpus.main(["list", "--json"])
+    captured = capsys.readouterr()
+    assert rc == 0
+    payload = json.loads(captured.out)
+    assert "corpus_sources" in payload
+    names = [entry["name"] for entry in payload["corpus_sources"]]
+    assert "default" in names
+
+
+def test_artifact_graph_strict_fails_on_uncovered(capsys: pytest.CaptureFixture[str]) -> None:
+    """Without explicit --strict, the command exits 0; with --strict, it fails on uncovered targets."""
+    rc_default = artifact_graph.main([])
+    capsys.readouterr()
+    assert rc_default == 0
+
+    rc_strict = artifact_graph.main(["--strict"])
+    capsys.readouterr()
+    # The realized tree currently has uncovered maintenance targets, so --strict
+    # MUST fail. If/when those are covered, this test flips and the assertion
+    # should be inverted in the same PR that covers them.
+    assert rc_strict == 1


### PR DESCRIPTION
## Summary

Closes #446. Adds `devtools lab-scenario list`, `devtools lab-corpus list`, and `devtools artifact-graph --strict`. Closes the discoverability gap surfaced by the lab-claims audit.

## Problem

The verification-lab surface had two specific gaps per the lab-claims audit (swarm 2026-04-26):

- **Missing list subcommands**: `devtools lab-scenario list` and `devtools lab-corpus list` are documented/expected patterns but didn't exist; users discovering scenarios failed with exit 2.
- **Silent partial failures**: `devtools artifact-graph` always exited 0 even when its own output reported `uncovered_artifacts`, `uncovered_operations`, `uncovered_maintenance_targets`. CI saw exit 0 and treated the lab as passed.

## Solution

### `devtools lab-scenario list`

Lists available scenario sets with their tier-0 exercise count and committed-baseline count. `--json` for tooling.

```
$ devtools lab-scenario list
archive-smoke         tier-0 exercises: 50
  baselines: 50 (tests/baselines/showcase)
```

### `devtools lab-corpus list`

Lists corpus source kinds (`default`, `inferred`).

```
$ devtools lab-corpus list
  default (default)
  inferred
```

### `devtools artifact-graph --strict`

Default behavior unchanged (exit 0). `--strict` returns exit 1 when uncovered artifacts, operations, or maintenance targets exist. Currently fails because the realized tree has 5 uncovered maintenance targets.

## Verification

```
$ devtools verify --quick
verify: all checks passed (incl. all 8 lints)

$ pytest tests/unit/devtools/test_lab_list_subcommands.py -v
5 passed

$ devtools lab-scenario list --json
{ "scenarios": [{ "name": "archive-smoke", ... }] }

$ devtools lab-corpus list --json
{ "corpus_sources": [{ "name": "default", "is_default": true }, ...] }

$ devtools artifact-graph --strict; echo "exit=$?"
exit=1   # uncovered maintenance targets surface
```

The companion sub-issue ("validate output before returning success" for `lab-corpus generate`) is deferred — verification of generated files requires inspecting parser output and is more naturally a follow-up issue.

## Related

- #401 — post-renewal consolidation umbrella.
- #410 — scenarios as docs/media/proof catalog (depends on `lab-scenario list`).
- #411 — representative provider corpora (depends on `lab-corpus list`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)