### PR TITLE
feat(pipeline): runtime stage contract validation

### DIFF
--- a/polylogue/pipeline/run_execution.py
+++ b/polylogue/pipeline/run_execution.py
@@ -30,6 +30,7 @@ from polylogue.pipeline.stage_specs import (
     PipelineStageSpec,
     stage_sequence_suspends_fts,
     stage_specs_for_sequence,
+    validate_stage_contract,
 )
 from polylogue.storage.backends import create_backend
 from polylogue.storage.repository import ConversationRepository
@@ -107,6 +108,7 @@ async def run_sources(
         stage_specs = stage_specs_for_sequence(normalized_stage_sequence)
         explicit_sequence = stage_sequence is not None
         executed_stages: set[str] = set()
+        executed_specs: list[PipelineStageSpec] = []
         index_outcome = IndexStageOutcome(indexed=False, item_count=0)
 
         async def _run_acquire_stage(spec: PipelineStageSpec) -> None:
@@ -264,7 +266,9 @@ async def run_sources(
             nonlocal index_outcome
             if not spec.pipeline_managed:
                 executed_stages.add(spec.name)
+                executed_specs.append(spec)
                 return
+            validate_stage_contract(spec, executed_specs=executed_specs)
             execution_stage = spec.execution_stage(
                 requested_stage=stage,
                 explicit_sequence=explicit_sequence,
@@ -287,6 +291,7 @@ async def run_sources(
             else:
                 raise ValueError(f"Unknown pipeline stage spec: {spec.name}")
             executed_stages.add(spec.name)
+            executed_specs.append(spec)
 
         # Suspend FTS triggers during bulk pipeline operations.
         # Triggers fire per-row during message INSERTs, causing massive

--- a/polylogue/pipeline/stage_specs.py
+++ b/polylogue/pipeline/stage_specs.py
@@ -1,12 +1,34 @@
-"""Executable pipeline stage specifications."""
+"""Executable pipeline stage specifications and contract validation.
+
+Each :class:`PipelineStageSpec` declares which named state slots it
+consumes (``inputs``) and produces (``outputs``). At each stage
+boundary, :func:`validate_stage_contract` verifies that every required
+input was produced by an upstream stage that already executed in the
+current run. On violation it raises :class:`StageContractError`.
+
+The structural validator catches misconfigured stage sequences such as
+``[acquire, materialize]`` (parse skipped) or ``[acquire, render]``
+(parse skipped). Single-stage runs skip validation, since their inputs
+come from durable archive state rather than upstream pipeline outputs.
+
+See `#447 <https://github.com/Sinity/polylogue/issues/447>`_.
+"""
 
 from __future__ import annotations
 
 from collections.abc import Collection, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Literal
 
 StageContextPolicy = Literal["none", "requested_or_leaf", "requested_or_all_after_parse"]
+
+
+@dataclass(frozen=True, slots=True)
+class StageInput:
+    """One named state slot a stage requires before it can execute."""
+
+    name: str
+    required: bool = True
 
 
 @dataclass(frozen=True, slots=True)
@@ -18,6 +40,8 @@ class PipelineStageSpec:
     context_policy: StageContextPolicy = "none"
     suspend_fts_triggers: bool = False
     pipeline_managed: bool = True
+    inputs: tuple[StageInput, ...] = field(default_factory=tuple)
+    outputs: tuple[str, ...] = field(default_factory=tuple)
 
     def execution_stage(
         self,
@@ -38,32 +62,62 @@ class PipelineStageSpec:
         return self.name
 
 
+class StageContractError(RuntimeError):
+    """Raised when a stage runs with required inputs not produced upstream."""
+
+    def __init__(self, *, stage: str, missing: Sequence[str], reason: str) -> None:
+        formatted = ", ".join(sorted(missing))
+        super().__init__(f"Stage {stage!r} missing required input(s) {{{formatted}}}: {reason}")
+        self.stage = stage
+        self.missing: tuple[str, ...] = tuple(missing)
+        self.reason = reason
+
+
 PIPELINE_STAGE_SPECS: dict[str, PipelineStageSpec] = {
-    "acquire": PipelineStageSpec(name="acquire", log_stage="acquire"),
-    "schema": PipelineStageSpec(name="schema", log_stage="schema"),
+    "acquire": PipelineStageSpec(
+        name="acquire",
+        log_stage="acquire",
+        outputs=("raw_records",),
+    ),
+    "schema": PipelineStageSpec(
+        name="schema",
+        log_stage="schema",
+        outputs=("schemas",),
+    ),
     "parse": PipelineStageSpec(
         name="parse",
         log_stage="ingest",
         context_policy="requested_or_leaf",
         suspend_fts_triggers=True,
+        inputs=(StageInput(name="raw_records", required=False),),
+        outputs=("processed_ids",),
     ),
     "materialize": PipelineStageSpec(
         name="materialize",
         log_stage="materialize",
         context_policy="requested_or_all_after_parse",
+        inputs=(StageInput(name="processed_ids"),),
+        outputs=("materialized",),
     ),
     "render": PipelineStageSpec(
         name="render",
         log_stage="render",
         context_policy="requested_or_all_after_parse",
         suspend_fts_triggers=True,
+        inputs=(StageInput(name="processed_ids"),),
+        outputs=("rendered",),
     ),
-    "site": PipelineStageSpec(name="site", log_stage="site"),
+    "site": PipelineStageSpec(
+        name="site",
+        log_stage="site",
+        inputs=(StageInput(name="rendered", required=False),),
+    ),
     "index": PipelineStageSpec(
         name="index",
         log_stage="index",
         context_policy="requested_or_all_after_parse",
         suspend_fts_triggers=True,
+        inputs=(StageInput(name="processed_ids"),),
     ),
     "embed": PipelineStageSpec(name="embed", log_stage="embed", pipeline_managed=False),
 }
@@ -79,10 +133,39 @@ def stage_sequence_suspends_fts(stage_specs: Sequence[PipelineStageSpec]) -> boo
     return any(stage.suspend_fts_triggers for stage in stage_specs)
 
 
+def validate_stage_contract(
+    spec: PipelineStageSpec,
+    *,
+    executed_specs: Sequence[PipelineStageSpec],
+) -> None:
+    """Verify ``spec``'s required inputs were produced by an executed upstream stage.
+
+    Single-stage runs (``executed_specs`` empty) skip validation: their inputs
+    come from durable archive state, not upstream pipeline outputs. Multi-stage
+    runs that omit a required producer raise :class:`StageContractError`.
+    """
+    if not executed_specs:
+        return
+    produced: set[str] = {output for upstream in executed_specs for output in upstream.outputs}
+    missing = [
+        stage_input.name for stage_input in spec.inputs if stage_input.required and stage_input.name not in produced
+    ]
+    if missing:
+        executed_names = [upstream.name for upstream in executed_specs]
+        raise StageContractError(
+            stage=spec.name,
+            missing=missing,
+            reason=f"upstream stages {executed_names} did not produce them",
+        )
+
+
 __all__ = [
     "PIPELINE_STAGE_SPECS",
     "PipelineStageSpec",
     "StageContextPolicy",
+    "StageContractError",
+    "StageInput",
     "stage_sequence_suspends_fts",
     "stage_specs_for_sequence",
+    "validate_stage_contract",
 ]

--- a/tests/unit/pipeline/test_stage_contract.py
+++ b/tests/unit/pipeline/test_stage_contract.py
@@ -1,0 +1,122 @@
+"""Stage contract validation tests.
+
+See `#447 <https://github.com/Sinity/polylogue/issues/447>`_.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from polylogue.pipeline.stage_specs import (
+    PIPELINE_STAGE_SPECS,
+    PipelineStageSpec,
+    StageContractError,
+    StageInput,
+    stage_specs_for_sequence,
+    validate_stage_contract,
+)
+
+
+def test_single_stage_run_skips_validation() -> None:
+    """A stage with no upstream executions is permitted; data may live in DB."""
+    materialize = PIPELINE_STAGE_SPECS["materialize"]
+    validate_stage_contract(materialize, executed_specs=())
+
+
+def test_full_sequence_satisfies_all_inputs() -> None:
+    """The default ``all`` sequence satisfies every stage's required inputs."""
+    sequence = stage_specs_for_sequence(("acquire", "parse", "materialize", "render", "site", "index"))
+    executed: list[PipelineStageSpec] = []
+    for spec in sequence:
+        validate_stage_contract(spec, executed_specs=executed)
+        executed.append(spec)
+
+
+def test_reprocess_sequence_satisfies_inputs() -> None:
+    """``reprocess`` (parse, materialize, render, index) satisfies the contract."""
+    sequence = stage_specs_for_sequence(("parse", "materialize", "render", "index"))
+    executed: list[PipelineStageSpec] = []
+    for spec in sequence:
+        validate_stage_contract(spec, executed_specs=executed)
+        executed.append(spec)
+
+
+def test_publish_sequence_satisfies_inputs() -> None:
+    """``publish`` (render, site) satisfies the contract — site's input is optional."""
+    sequence = stage_specs_for_sequence(("render", "site"))
+    executed: list[PipelineStageSpec] = []
+    for spec in sequence:
+        validate_stage_contract(spec, executed_specs=executed)
+        executed.append(spec)
+
+
+def test_skipped_parse_violates_materialize_contract() -> None:
+    """``[acquire, materialize]`` skips parse → materialize lacks ``processed_ids``."""
+    acquire = PIPELINE_STAGE_SPECS["acquire"]
+    materialize = PIPELINE_STAGE_SPECS["materialize"]
+    with pytest.raises(StageContractError) as excinfo:
+        validate_stage_contract(materialize, executed_specs=(acquire,))
+    assert excinfo.value.stage == "materialize"
+    assert "processed_ids" in excinfo.value.missing
+
+
+def test_skipped_parse_violates_render_contract() -> None:
+    """``[acquire, render]`` likewise lacks ``processed_ids`` for render."""
+    acquire = PIPELINE_STAGE_SPECS["acquire"]
+    render = PIPELINE_STAGE_SPECS["render"]
+    with pytest.raises(StageContractError) as excinfo:
+        validate_stage_contract(render, executed_specs=(acquire,))
+    assert excinfo.value.stage == "render"
+    assert "processed_ids" in excinfo.value.missing
+
+
+def test_skipped_parse_violates_index_contract() -> None:
+    """``[acquire, index]`` lacks ``processed_ids`` for index."""
+    acquire = PIPELINE_STAGE_SPECS["acquire"]
+    index = PIPELINE_STAGE_SPECS["index"]
+    with pytest.raises(StageContractError) as excinfo:
+        validate_stage_contract(index, executed_specs=(acquire,))
+    assert "processed_ids" in excinfo.value.missing
+
+
+def test_optional_input_does_not_violate() -> None:
+    """``site`` declares ``rendered`` as optional; running without render is OK."""
+    site = PIPELINE_STAGE_SPECS["site"]
+    parse = PIPELINE_STAGE_SPECS["parse"]
+    validate_stage_contract(site, executed_specs=(parse,))
+
+
+def test_violation_message_contains_stage_and_missing() -> None:
+    """Error message names both the stage and the missing inputs."""
+    materialize = PIPELINE_STAGE_SPECS["materialize"]
+    acquire = PIPELINE_STAGE_SPECS["acquire"]
+    with pytest.raises(StageContractError) as excinfo:
+        validate_stage_contract(materialize, executed_specs=(acquire,))
+    message = str(excinfo.value)
+    assert "materialize" in message
+    assert "processed_ids" in message
+
+
+def test_custom_spec_with_required_input_fires() -> None:
+    """A bespoke spec with required input names not produced upstream fails."""
+    custom = PipelineStageSpec(
+        name="custom",
+        log_stage="custom",
+        inputs=(StageInput(name="not_produced"),),
+    )
+    upstream = PIPELINE_STAGE_SPECS["acquire"]
+    with pytest.raises(StageContractError) as excinfo:
+        validate_stage_contract(custom, executed_specs=(upstream,))
+    assert excinfo.value.missing == ("not_produced",)
+
+
+def test_every_stage_input_is_produced_by_some_pipeline_stage() -> None:
+    """Each declared input matches an output declared by a pipeline-managed stage."""
+    produced: set[str] = set()
+    for spec in PIPELINE_STAGE_SPECS.values():
+        produced.update(spec.outputs)
+    for spec in PIPELINE_STAGE_SPECS.values():
+        for stage_input in spec.inputs:
+            assert stage_input.name in produced, (
+                f"Stage {spec.name!r} declares input {stage_input.name!r} with no producer in PIPELINE_STAGE_SPECS"
+            )


### PR DESCRIPTION
## Summary

Closes #447. Adds declarative input/output contracts to `PipelineStageSpec`
and a runtime validator that fires at every stage boundary.

## Problem

The `pipeline-stage-audit` (swarm 2026-04-26) identified the
implicit-contract pattern as the meta-cause behind the four silent-failure
sites fixed in #453: stages depend on prior-stage outputs through bare
`RunExecutionState` attributes, with no runtime check verifying the
contract is intact.

## Solution

- ``StageInput`` dataclass: named state slot a stage requires.
- ``PipelineStageSpec`` extended with ``inputs: tuple[StageInput, ...]``
  and ``outputs: tuple[str, ...]``.
- All eight stages declare their producer/consumer relations.
- ``StageContractError`` raised on violation, naming stage and missing inputs.
- ``validate_stage_contract`` invoked from ``run_execution._run_stage_spec``
  before the stage body runs.
- Single-stage runs skip validation (durable archive state can satisfy inputs).

## Verification

- 11 new tests in ``tests/unit/pipeline/test_stage_contract.py`` cover
  full / reprocess / publish sequences, missing-producer cases, optional
  inputs, message format, and a sanity check that every declared input has
  a producer somewhere in ``PIPELINE_STAGE_SPECS``.
- ``devtools verify`` (full, with pytest): all checks pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pipeline stages now validate contracts, automatically checking that all required inputs are available from previously executed stages.
  * Enhanced error reporting when stage validation fails, clearly identifying which inputs are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->