### PR TITLE
feat(proof): commit MCP tool schema and BlobStore witnesses

### DIFF
--- a/tests/data/witnesses/blob-store-layout.json
+++ b/tests/data/witnesses/blob-store-layout.json
@@ -1,0 +1,27 @@
+{
+  "scheme": "sha256",
+  "directory_split": [2, 62],
+  "fixtures": [
+    {
+      "name": "alpha",
+      "content_bytes_b64": "YWxwaGEK",
+      "expected_sha256": "b6a98d9ce9a2d9149288fa3df42d377c3e42737afdcdaf714e33c0a100b51060",
+      "expected_size": 6,
+      "expected_relative_path": "b6/a98d9ce9a2d9149288fa3df42d377c3e42737afdcdaf714e33c0a100b51060"
+    },
+    {
+      "name": "beta",
+      "content_bytes_b64": "YmV0YQo=",
+      "expected_sha256": "f2c82decdd7181cf98945929a62598db7e6b477e11f6e0eb0ae97020eff151ad",
+      "expected_size": 5,
+      "expected_relative_path": "f2/c82decdd7181cf98945929a62598db7e6b477e11f6e0eb0ae97020eff151ad"
+    },
+    {
+      "name": "gamma",
+      "content_bytes_b64": "Z2FtbWEK",
+      "expected_sha256": "ae9a6306a205417afddd14316cc1d0d5e04a98f1be10865dce643925ee070ce2",
+      "expected_size": 6,
+      "expected_relative_path": "ae/9a6306a205417afddd14316cc1d0d5e04a98f1be10865dce643925ee070ce2"
+    }
+  ]
+}

--- a/tests/data/witnesses/mcp-tool-schemas.json
+++ b/tests/data/witnesses/mcp-tool-schemas.json
@@ -1,0 +1,1277 @@
+[
+  {
+    "name": "add_tag",
+    "parameters": {
+      "properties": {
+        "conversation_id": {
+          "title": "Conversation Id",
+          "type": "string"
+        },
+        "tag": {
+          "title": "Tag",
+          "type": "string"
+        }
+      },
+      "required": [
+        "conversation_id",
+        "tag"
+      ],
+      "title": "add_tagArguments",
+      "type": "object"
+    }
+  },
+  {
+    "name": "archive_coverage",
+    "parameters": {
+      "properties": {},
+      "title": "archive_coverageArguments",
+      "type": "object"
+    }
+  },
+  {
+    "name": "archive_debt",
+    "parameters": {
+      "properties": {
+        "kw": {
+          "title": "kw",
+          "type": "string"
+        }
+      },
+      "required": [
+        "kw"
+      ],
+      "title": "archive_debtArguments",
+      "type": "object"
+    }
+  },
+  {
+    "name": "bulk_tag_conversations",
+    "parameters": {
+      "properties": {
+        "conversation_ids": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Conversation Ids",
+          "type": "array"
+        },
+        "tags": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Tags",
+          "type": "array"
+        }
+      },
+      "required": [
+        "conversation_ids",
+        "tags"
+      ],
+      "title": "bulk_tag_conversationsArguments",
+      "type": "object"
+    }
+  },
+  {
+    "name": "cost_rollups",
+    "parameters": {
+      "properties": {
+        "kw": {
+          "title": "kw",
+          "type": "string"
+        }
+      },
+      "required": [
+        "kw"
+      ],
+      "title": "cost_rollupsArguments",
+      "type": "object"
+    }
+  },
+  {
+    "name": "day_session_summaries",
+    "parameters": {
+      "properties": {
+        "kw": {
+          "title": "kw",
+          "type": "string"
+        }
+      },
+      "required": [
+        "kw"
+      ],
+      "title": "day_session_summariesArguments",
+      "type": "object"
+    }
+  },
+  {
+    "name": "delete_conversation",
+    "parameters": {
+      "properties": {
+        "confirm": {
+          "default": false,
+          "title": "Confirm",
+          "type": "boolean"
+        },
+        "conversation_id": {
+          "title": "Conversation Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "conversation_id"
+      ],
+      "title": "delete_conversationArguments",
+      "type": "object"
+    }
+  },
+  {
+    "name": "delete_metadata",
+    "parameters": {
+      "properties": {
+        "conversation_id": {
+          "title": "Conversation Id",
+          "type": "string"
+        },
+        "key": {
+          "title": "Key",
+          "type": "string"
+        }
+      },
+      "required": [
+        "conversation_id",
+        "key"
+      ],
+      "title": "delete_metadataArguments",
+      "type": "object"
+    }
+  },
+  {
+    "name": "export_conversation",
+    "parameters": {
+      "properties": {
+        "format": {
+          "default": "markdown",
+          "title": "Format",
+          "type": "string"
+        },
+        "id": {
+          "title": "Id",
+          "type": "string"
+        },
+        "no_code_blocks": {
+          "default": false,
+          "title": "No Code Blocks",
+          "type": "boolean"
+        },
+        "no_file_reads": {
+          "default": false,
+          "title": "No File Reads",
+          "type": "boolean"
+        },
+        "no_tool_calls": {
+          "default": false,
+          "title": "No Tool Calls",
+          "type": "boolean"
+        },
+        "no_tool_outputs": {
+          "default": false,
+          "title": "No Tool Outputs",
+          "type": "boolean"
+        },
+        "prose_only": {
+          "default": false,
+          "title": "Prose Only",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "title": "export_conversationArguments",
+      "type": "object"
+    }
+  },
+  {
+    "name": "export_query_results",
+    "parameters": {
+      "properties": {
+        "action": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Action"
+        },
+        "action_sequence": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Action Sequence"
+        },
+        "action_text": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Action Text"
+        },
+        "exclude_action": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Exclude Action"
+        },
+        "exclude_tool": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Exclude Tool"
+        },
+        "format": {
+          "default": "markdown",
+          "title": "Format",
+          "type": "string"
+        },
+        "has_thinking": {
+          "default": false,
+          "title": "Has Thinking",
+          "type": "boolean"
+        },
+        "has_tool_use": {
+          "default": false,
+          "title": "Has Tool Use",
+          "type": "boolean"
+        },
+        "limit": {
+          "default": 10,
+          "title": "Limit",
+          "type": "integer"
+        },
+        "min_messages": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Min Messages"
+        },
+        "min_words": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Min Words"
+        },
+        "no_code_blocks": {
+          "default": false,
+          "title": "No Code Blocks",
+          "type": "boolean"
+        },
+        "no_file_reads": {
+          "default": false,
+          "title": "No File Reads",
+          "type": "boolean"
+        },
+        "no_tool_calls": {
+          "default": false,
+          "title": "No Tool Calls",
+          "type": "boolean"
+        },
+        "no_tool_outputs": {
+          "default": false,
+          "title": "No Tool Outputs",
+          "type": "boolean"
+        },
+        "path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Path"
+        },
+        "prose_only": {
+          "default": false,
+          "title": "Prose Only",
+          "type": "boolean"
+        },
+        "provider": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Provider"
+        },
+        "query": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Query"
+        },
+        "retrieval_lane": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Retrieval Lane"
+        },
+        "since": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Since"
+        },
+        "sort": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Sort"
+        },
+        "tag": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Tag"
+        },
+        "title": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Title"
+        },
+        "tool": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Tool"
+        }
+      },
+      "title": "export_query_resultsArguments",
+      "type": "object"
+    }
+  },
+  {
+    "name": "get_conversation",
+    "parameters": {
+      "properties": {
+        "id": {
+          "title": "Id",
+          "type": "string"
+        },
+        "no_code_blocks": {
+          "default": false,
+          "title": "No Code Blocks",
+          "type": "boolean"
+        },
+        "no_file_reads": {
+          "default": false,
+          "title": "No File Reads",
+          "type": "boolean"
+        },
+        "no_tool_calls": {
+          "default": false,
+          "title": "No Tool Calls",
+          "type": "boolean"
+        },
+        "no_tool_outputs": {
+          "default": false,
+          "title": "No Tool Outputs",
+          "type": "boolean"
+        },
+        "prose_only": {
+          "default": false,
+          "title": "Prose Only",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "title": "get_conversationArguments",
+      "type": "object"
+    }
+  },
+  {
+    "name": "get_conversation_summary",
+    "parameters": {
+      "properties": {
+        "id": {
+          "title": "Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "title": "get_conversation_summaryArguments",
+      "type": "object"
+    }
+  },
+  {
+    "name": "get_metadata",
+    "parameters": {
+      "properties": {
+        "conversation_id": {
+          "title": "Conversation Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "conversation_id"
+      ],
+      "title": "get_metadataArguments",
+      "type": "object"
+    }
+  },
+  {
+    "name": "get_session_tree",
+    "parameters": {
+      "properties": {
+        "conversation_id": {
+          "title": "Conversation Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "conversation_id"
+      ],
+      "title": "get_session_treeArguments",
+      "type": "object"
+    }
+  },
+  {
+    "name": "get_stats_by",
+    "parameters": {
+      "properties": {
+        "group_by": {
+          "default": "provider",
+          "title": "Group By",
+          "type": "string"
+        }
+      },
+      "title": "get_stats_byArguments",
+      "type": "object"
+    }
+  },
+  {
+    "name": "list_conversations",
+    "parameters": {
+      "properties": {
+        "action": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Action"
+        },
+        "action_sequence": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Action Sequence"
+        },
+        "action_text": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Action Text"
+        },
+        "exclude_action": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Exclude Action"
+        },
+        "exclude_tool": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Exclude Tool"
+        },
+        "has_thinking": {
+          "default": false,
+          "title": "Has Thinking",
+          "type": "boolean"
+        },
+        "has_tool_use": {
+          "default": false,
+          "title": "Has Tool Use",
+          "type": "boolean"
+        },
+        "limit": {
+          "default": 10,
+          "title": "Limit",
+          "type": "integer"
+        },
+        "min_messages": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Min Messages"
+        },
+        "min_words": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Min Words"
+        },
+        "path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Path"
+        },
+        "provider": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Provider"
+        },
+        "retrieval_lane": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Retrieval Lane"
+        },
+        "since": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Since"
+        },
+        "sort": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Sort"
+        },
+        "tag": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Tag"
+        },
+        "title": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Title"
+        },
+        "tool": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Tool"
+        }
+      },
+      "title": "list_conversationsArguments",
+      "type": "object"
+    }
+  },
+  {
+    "name": "list_tags",
+    "parameters": {
+      "properties": {
+        "provider": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Provider"
+        }
+      },
+      "title": "list_tagsArguments",
+      "type": "object"
+    }
+  },
+  {
+    "name": "neighbor_candidates",
+    "parameters": {
+      "properties": {
+        "id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Id"
+        },
+        "limit": {
+          "default": 10,
+          "title": "Limit",
+          "type": "integer"
+        },
+        "provider": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Provider"
+        },
+        "query": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Query"
+        },
+        "window_hours": {
+          "default": 24,
+          "title": "Window Hours",
+          "type": "integer"
+        }
+      },
+      "title": "neighbor_candidatesArguments",
+      "type": "object"
+    }
+  },
+  {
+    "name": "provider_analytics",
+    "parameters": {
+      "properties": {
+        "kw": {
+          "title": "kw",
+          "type": "string"
+        }
+      },
+      "required": [
+        "kw"
+      ],
+      "title": "provider_analyticsArguments",
+      "type": "object"
+    }
+  },
+  {
+    "name": "readiness_check",
+    "parameters": {
+      "properties": {},
+      "title": "readiness_checkArguments",
+      "type": "object"
+    }
+  },
+  {
+    "name": "rebuild_index",
+    "parameters": {
+      "properties": {},
+      "title": "rebuild_indexArguments",
+      "type": "object"
+    }
+  },
+  {
+    "name": "rebuild_session_products",
+    "parameters": {
+      "properties": {
+        "conversation_ids": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Conversation Ids"
+        }
+      },
+      "title": "rebuild_session_productsArguments",
+      "type": "object"
+    }
+  },
+  {
+    "name": "remove_tag",
+    "parameters": {
+      "properties": {
+        "conversation_id": {
+          "title": "Conversation Id",
+          "type": "string"
+        },
+        "tag": {
+          "title": "Tag",
+          "type": "string"
+        }
+      },
+      "required": [
+        "conversation_id",
+        "tag"
+      ],
+      "title": "remove_tagArguments",
+      "type": "object"
+    }
+  },
+  {
+    "name": "search",
+    "parameters": {
+      "properties": {
+        "action": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Action"
+        },
+        "action_sequence": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Action Sequence"
+        },
+        "action_text": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Action Text"
+        },
+        "exclude_action": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Exclude Action"
+        },
+        "exclude_tool": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Exclude Tool"
+        },
+        "has_thinking": {
+          "default": false,
+          "title": "Has Thinking",
+          "type": "boolean"
+        },
+        "has_tool_use": {
+          "default": false,
+          "title": "Has Tool Use",
+          "type": "boolean"
+        },
+        "limit": {
+          "default": 10,
+          "title": "Limit",
+          "type": "integer"
+        },
+        "min_messages": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Min Messages"
+        },
+        "min_words": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Min Words"
+        },
+        "path": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Path"
+        },
+        "provider": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Provider"
+        },
+        "query": {
+          "title": "Query",
+          "type": "string"
+        },
+        "retrieval_lane": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Retrieval Lane"
+        },
+        "since": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Since"
+        },
+        "tool": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Tool"
+        }
+      },
+      "required": [
+        "query"
+      ],
+      "title": "searchArguments",
+      "type": "object"
+    }
+  },
+  {
+    "name": "session_costs",
+    "parameters": {
+      "properties": {
+        "kw": {
+          "title": "kw",
+          "type": "string"
+        }
+      },
+      "required": [
+        "kw"
+      ],
+      "title": "session_costsArguments",
+      "type": "object"
+    }
+  },
+  {
+    "name": "session_enrichments",
+    "parameters": {
+      "properties": {
+        "kw": {
+          "title": "kw",
+          "type": "string"
+        }
+      },
+      "required": [
+        "kw"
+      ],
+      "title": "session_enrichmentsArguments",
+      "type": "object"
+    }
+  },
+  {
+    "name": "session_phases",
+    "parameters": {
+      "properties": {
+        "kw": {
+          "title": "kw",
+          "type": "string"
+        }
+      },
+      "required": [
+        "kw"
+      ],
+      "title": "session_phasesArguments",
+      "type": "object"
+    }
+  },
+  {
+    "name": "session_profile",
+    "parameters": {
+      "properties": {
+        "conversation_id": {
+          "title": "Conversation Id",
+          "type": "string"
+        },
+        "tier": {
+          "default": "merged",
+          "title": "Tier",
+          "type": "string"
+        }
+      },
+      "required": [
+        "conversation_id"
+      ],
+      "title": "session_profileArguments",
+      "type": "object"
+    }
+  },
+  {
+    "name": "session_profiles",
+    "parameters": {
+      "properties": {
+        "kw": {
+          "title": "kw",
+          "type": "string"
+        }
+      },
+      "required": [
+        "kw"
+      ],
+      "title": "session_profilesArguments",
+      "type": "object"
+    }
+  },
+  {
+    "name": "session_tag_rollups",
+    "parameters": {
+      "properties": {
+        "kw": {
+          "title": "kw",
+          "type": "string"
+        }
+      },
+      "required": [
+        "kw"
+      ],
+      "title": "session_tag_rollupsArguments",
+      "type": "object"
+    }
+  },
+  {
+    "name": "session_work_events",
+    "parameters": {
+      "properties": {
+        "kw": {
+          "title": "kw",
+          "type": "string"
+        }
+      },
+      "required": [
+        "kw"
+      ],
+      "title": "session_work_eventsArguments",
+      "type": "object"
+    }
+  },
+  {
+    "name": "set_metadata",
+    "parameters": {
+      "properties": {
+        "conversation_id": {
+          "title": "Conversation Id",
+          "type": "string"
+        },
+        "key": {
+          "title": "Key",
+          "type": "string"
+        },
+        "value": {
+          "title": "Value",
+          "type": "string"
+        }
+      },
+      "required": [
+        "conversation_id",
+        "key",
+        "value"
+      ],
+      "title": "set_metadataArguments",
+      "type": "object"
+    }
+  },
+  {
+    "name": "stats",
+    "parameters": {
+      "properties": {},
+      "title": "statsArguments",
+      "type": "object"
+    }
+  },
+  {
+    "name": "update_index",
+    "parameters": {
+      "properties": {
+        "conversation_ids": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Conversation Ids",
+          "type": "array"
+        }
+      },
+      "required": [
+        "conversation_ids"
+      ],
+      "title": "update_indexArguments",
+      "type": "object"
+    }
+  },
+  {
+    "name": "week_session_summaries",
+    "parameters": {
+      "properties": {
+        "kw": {
+          "title": "kw",
+          "type": "string"
+        }
+      },
+      "required": [
+        "kw"
+      ],
+      "title": "week_session_summariesArguments",
+      "type": "object"
+    }
+  },
+  {
+    "name": "work_threads",
+    "parameters": {
+      "properties": {
+        "kw": {
+          "title": "kw",
+          "type": "string"
+        }
+      },
+      "required": [
+        "kw"
+      ],
+      "title": "work_threadsArguments",
+      "type": "object"
+    }
+  }
+]

--- a/tests/unit/mcp/test_tool_schema_witness.py
+++ b/tests/unit/mcp/test_tool_schema_witness.py
@@ -1,0 +1,63 @@
+"""Regression test: the published MCP tool wire schema matches the committed witness.
+
+Drift here would silently invalidate clients (CLI/agent integrations consume
+the published JSON Schema). Re-running ``build_server`` and diffing against the
+committed witness catches any change to a tool name, parameter set, required
+flag, or type.
+
+To accept legitimate changes, regenerate the witness data:
+
+    python -c "
+    import json
+    from polylogue.mcp.server import build_server
+    m = build_server()
+    out = sorted(({'name': name, 'parameters': t.parameters} for name, t in m._tool_manager._tools.items()), key=lambda r: r['name'])
+    with open('tests/data/witnesses/mcp-tool-schemas.json', 'w') as f:
+        json.dump(out, f, indent=2, sort_keys=True); f.write('\\n')
+    "
+
+See `#448 <https://github.com/Sinity/polylogue/issues/448>`_.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from polylogue.mcp.server import build_server
+from polylogue.proof.witnesses import WITNESS_SCHEMA_VERSION, WitnessMetadata
+
+WITNESS_PATH = Path(__file__).resolve().parents[3] / "tests" / "witnesses" / "mcp-tool-schemas.witness.json"
+DATA_PATH = Path(__file__).resolve().parents[3] / "tests" / "data" / "witnesses" / "mcp-tool-schemas.json"
+
+
+def _current_tool_catalog() -> list[dict[str, object]]:
+    server = build_server()
+    tools = server._tool_manager._tools
+    return [{"name": name, "parameters": tools[name].parameters} for name in sorted(tools)]
+
+
+def test_committed_witness_metadata_validates() -> None:
+    metadata = WitnessMetadata.read(WITNESS_PATH)
+    assert metadata.validation_errors() == ()
+    assert metadata.schema_version == WITNESS_SCHEMA_VERSION
+    assert metadata.committed is True
+
+
+def test_mcp_tool_catalog_matches_witness() -> None:
+    expected = json.loads(DATA_PATH.read_text(encoding="utf-8"))
+    actual = _current_tool_catalog()
+    assert actual == expected, (
+        "MCP tool wire schema drifted from committed witness. "
+        "If the change is intentional, regenerate "
+        "tests/data/witnesses/mcp-tool-schemas.json (see this test's docstring)."
+    )
+
+
+def test_mcp_tool_catalog_is_non_empty() -> None:
+    catalog = _current_tool_catalog()
+    assert catalog, "build_server registered no tools — registration regression?"
+    for entry in catalog:
+        params = entry["parameters"]
+        assert isinstance(params, dict)
+        assert params.get("type") == "object"

--- a/tests/unit/storage/test_blob_store_layout_witness.py
+++ b/tests/unit/storage/test_blob_store_layout_witness.py
@@ -1,0 +1,54 @@
+"""Regression test: BlobStore on-disk layout matches the committed witness.
+
+The blob store's content-addressed scheme is durable infrastructure: any
+change to it (different hash, different directory split, different framing)
+silently invalidates every previously written blob. Re-running the writes
+against fresh fixtures and diffing against the committed witness catches the
+change before it corrupts an archive.
+
+See `#448 <https://github.com/Sinity/polylogue/issues/448>`_.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from pathlib import Path
+
+from polylogue.proof.witnesses import WITNESS_SCHEMA_VERSION, WitnessMetadata
+from polylogue.storage.blob_store import BlobStore
+
+WITNESS_PATH = Path(__file__).resolve().parents[3] / "tests" / "witnesses" / "blob-store-layout.witness.json"
+DATA_PATH = Path(__file__).resolve().parents[3] / "tests" / "data" / "witnesses" / "blob-store-layout.json"
+
+
+def test_committed_witness_metadata_validates() -> None:
+    metadata = WitnessMetadata.read(WITNESS_PATH)
+    assert metadata.validation_errors() == ()
+    assert metadata.schema_version == WITNESS_SCHEMA_VERSION
+
+
+def test_blob_store_layout_matches_witness(tmp_path: Path) -> None:
+    fixture = json.loads(DATA_PATH.read_text(encoding="utf-8"))
+    store = BlobStore(tmp_path)
+    for entry in fixture["fixtures"]:
+        data = base64.b64decode(entry["content_bytes_b64"])
+        sha256_hex, size = store.write_from_bytes(data)
+        assert sha256_hex == entry["expected_sha256"], (
+            f"Blob {entry['name']!r} hash drifted from witness — addressing scheme changed?"
+        )
+        assert size == entry["expected_size"], f"Blob {entry['name']!r} size drifted"
+        relative_path = store.blob_path(sha256_hex).relative_to(tmp_path).as_posix()
+        assert relative_path == entry["expected_relative_path"], (
+            f"Blob {entry['name']!r} on-disk path drifted from witness — directory split changed?"
+        )
+
+
+def test_blob_store_addressing_is_content_only(tmp_path: Path) -> None:
+    """Same content always lands at the same path, regardless of write order."""
+    store = BlobStore(tmp_path)
+    payload = b"identical bytes\n"
+    h1, _ = store.write_from_bytes(payload)
+    h2, _ = store.write_from_bytes(payload)
+    assert h1 == h2
+    assert store.blob_path(h1) == store.blob_path(h2)

--- a/tests/witnesses/blob-store-layout.witness.json
+++ b/tests/witnesses/blob-store-layout.witness.json
@@ -1,0 +1,37 @@
+{
+  "schema_version": 1,
+  "witness_id": "storage.blob-store-layout",
+  "path": "tests/data/witnesses/blob-store-layout.json",
+  "origin": "synthetic",
+  "committed": true,
+  "provenance": {
+    "fixture_kind": "blob-store-on-disk-shape",
+    "source_test": "tests/unit/storage/test_blob_store_layout_witness.py",
+    "raw_material": "synthetic",
+    "generator": "polylogue.storage.blob_store.BlobStore.write_from_bytes"
+  },
+  "preserved_semantic_facts": [
+    "blob addressing is SHA-256 of the raw bytes",
+    "blobs land at root/<hash[:2]>/<hash[2:]> — 2/62 directory split",
+    "size returned by write_from_bytes equals len(input)",
+    "content-addressing is content-only — no metadata or framing affects the hash"
+  ],
+  "minimization_status": "minimized",
+  "privacy": {
+    "private_material": "not_observed",
+    "transformed": false,
+    "redacted": false,
+    "discarded": false,
+    "retained": false,
+    "notes": [
+      "fixtures are 5–6 bytes of synthetic ASCII content"
+    ]
+  },
+  "known_failing": false,
+  "xfail_strict": false,
+  "linked_issue": null,
+  "rejection_reason": null,
+  "notes": [
+    "any change to the on-disk addressing scheme requires a migration plan and a coordinated witness update"
+  ]
+}

--- a/tests/witnesses/mcp-tool-schemas.witness.json
+++ b/tests/witnesses/mcp-tool-schemas.witness.json
@@ -1,0 +1,36 @@
+{
+  "schema_version": 1,
+  "witness_id": "mcp.tool-schemas",
+  "path": "tests/data/witnesses/mcp-tool-schemas.json",
+  "origin": "synthetic",
+  "committed": true,
+  "provenance": {
+    "fixture_kind": "mcp-tool-wire-schema",
+    "source_test": "tests/unit/mcp/test_tool_schema_witness.py",
+    "raw_material": "synthetic",
+    "generator": "polylogue.mcp.server.build_server"
+  },
+  "preserved_semantic_facts": [
+    "the wire-visible MCP tool catalog (every registered tool name)",
+    "each tool's published JSON Schema for its arguments",
+    "argument required/optional shape — drift here breaks existing clients silently"
+  ],
+  "minimization_status": "not_applicable",
+  "privacy": {
+    "private_material": "not_observed",
+    "transformed": false,
+    "redacted": false,
+    "discarded": false,
+    "retained": false,
+    "notes": [
+      "schema is generated synthetically from the server registration code"
+    ]
+  },
+  "known_failing": false,
+  "xfail_strict": false,
+  "linked_issue": null,
+  "rejection_reason": null,
+  "notes": [
+    "regenerate via tests/unit/mcp/test_tool_schema_witness.py with --update-witness or by running the snapshot helper"
+  ]
+}


### PR DESCRIPTION
## Summary

Ref #448. Lands the first two committed witnesses identified by the
proof-coverage-audit (swarm 2026-04-26). Remaining three (TUI mutation,
site publication, browser-extension messaging) are deferred as separate
work — they each need a substantial harness, which the issue notes.

## Problem

`tests/witnesses/` had exactly one committed witness. The
`WitnessMetadata` lifecycle infrastructure was built out but underused.
Two surfaces with high regression value were missing snapshots:

- The MCP tool wire schema — drift here silently invalidates client
  integrations that consume the published JSON Schema.
- The BlobStore on-disk layout — any change to the addressing scheme
  or directory split silently invalidates every blob ever written.

## Solution

- ``mcp.tool-schemas`` — snapshot of ``build_server()._tool_manager._tools``
  reduced to ``{name, parameters}`` per tool. Regression test diffs the
  current registration against the committed JSON.
- ``storage.blob-store-layout`` — three synthetic fixtures with their
  base64-encoded content bytes, expected SHA-256, expected size, and
  expected on-disk relative path. Regression test re-writes them into a
  fresh ``BlobStore`` and asserts every field.

Both witnesses validate per ``WitnessMetadata.validation_errors() == ()``
and link the test file in their provenance.

## Verification

- ``devtools verify`` (full, with pytest): all checks pass.
- 6 new tests across both surfaces.