### PR TITLE
fix(hooks): pre-push distinguishes env failure from verify failure

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -2,8 +2,30 @@
 # Pre-push gate: full verification baseline (quick mode).
 # Runs format + lint + render-all --check. Tests run in CI.
 # Installed automatically by the devshell (shellHook in flake.nix).
+#
+# Distinguishes "verify rejected your changes" from "devtools could not even
+# import in this shell" — the latter usually means polylogue's devshell isn't
+# loaded in the current terminal (see #423).
 
 set -euo pipefail
+
+# Pre-flight: confirm devtools imports cleanly. If it doesn't, the active
+# shell isn't pointing at polylogue's Python env, and a verify failure here
+# is environmental, not a defect in the diff being pushed.
+if ! devtools --help >/dev/null 2>&1; then
+    cat >&2 <<'MSG'
+pre-push: devtools is not importable in this shell.
+
+This usually means polylogue's devshell isn't loaded — the push isn't being
+rejected for any defect in your diff. To run the gate against the diff:
+
+    nix develop --command git push <args...>
+
+or re-enter the project directory under direnv (run `direnv allow` once if
+you haven't), and try the push again.
+MSG
+    exit 1
+fi
 
 echo "pre-push: running quick verification baseline" >&2
 devtools verify --quick

--- a/tests/unit/devtools/test_pre_push_hook.py
+++ b/tests/unit/devtools/test_pre_push_hook.py
@@ -1,0 +1,50 @@
+"""Pre-push hook env detection (#423).
+
+Simulates the hook's pre-flight by running it with a doctored ``PATH`` that
+either provides or omits ``devtools``. The successful path delegates to
+``devtools verify --quick``; the failed path emits an actionable hint about
+the devshell, instead of a Python traceback.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+HOOK_PATH = Path(__file__).resolve().parents[3] / ".githooks" / "pre-push"
+
+
+def test_hook_file_exists_and_is_executable() -> None:
+    assert HOOK_PATH.is_file()
+    assert os.access(HOOK_PATH, os.X_OK), "pre-push hook must be executable"
+
+
+def test_hook_emits_devshell_hint_when_devtools_missing(tmp_path: Path) -> None:
+    """When ``devtools`` is not on PATH, the hook prints a devshell hint, not a verify trace."""
+    bash = shutil.which("bash") or "/bin/bash"
+    coreutils_paths = [shutil.which(name) for name in ("cat", "echo")]
+    coreutils_dirs = sorted({Path(path).parent for path in coreutils_paths if path is not None})
+    minimal_path = ":".join(str(directory) for directory in coreutils_dirs) or os.environ["PATH"]
+    env = {"PATH": minimal_path, "HOME": str(tmp_path)}
+    result = subprocess.run(
+        [bash, str(HOOK_PATH)],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=str(tmp_path),
+        check=False,
+    )
+    assert result.returncode != 0, "hook must exit non-zero when env is broken"
+    combined = result.stdout + result.stderr
+    assert "devtools is not importable" in combined
+    assert "nix develop" in combined
+    assert "Traceback" not in combined, "the env-not-loaded path must not surface a Python traceback to the user"
+
+
+def test_hook_source_contains_quick_verify_step() -> None:
+    """Hook still delegates to ``devtools verify --quick`` when env is healthy."""
+    body = HOOK_PATH.read_text(encoding="utf-8")
+    assert "devtools verify --quick" in body
+    assert "devtools --help" in body, "pre-flight check must use a no-side-effects devtools invocation"


### PR DESCRIPTION
## Summary

Closes #423. Pre-push now detects when ``devtools`` cannot import in the
active shell (devshell not loaded) and prints an actionable hint instead
of a Python traceback that reads like a verify failure.

## Problem

When the calling shell is loaded with a sibling repo's Python env, the
hook fires ``devtools verify --quick`` against an ABI-mismatched
pydantic_core, dies with a traceback, and prints
``verify: FAILED — fix before pushing``. The user/agent then chases a
non-existent code defect; the actual fix is to enter the devshell.

## Solution

A pre-flight ``devtools --help`` check runs first. If it exits non-zero,
the hook emits a hint suggesting ``nix develop --command git push`` or
``direnv allow``, and exits without invoking the full verify pipeline.

## Verification

- ``tests/unit/devtools/test_pre_push_hook.py`` runs the hook with a
  doctored ``PATH`` that omits devtools, asserts the hint appears, and
  asserts no Python traceback surfaces.
- ``devtools verify --quick`` (full local baseline minus pytest): all
  checks pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added unit test coverage for pre-push hook validation scenarios.

* **Chores**
  * Improved pre-push hook with early environment validation to better detect missing development dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->