### PR TITLE
fix(export): apply --message-role / --dialogue-only to single export

### DIFF
--- a/docs/verification-catalog.md
+++ b/docs/verification-catalog.md
@@ -58,7 +58,7 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | `polylogue dashboard` | `polylogue/cli/commands/dashboard.py:10` `polylogue.cli.commands.dashboard.dashboard_command` |
 | `polylogue delete` | `polylogue/cli/query_verbs.py:89` `polylogue.cli.query_verbs.delete_verb` |
 | `polylogue doctor` | `polylogue/cli/commands/check.py:31` `polylogue.cli.commands.check.check_command` |
-| `polylogue export` | `polylogue/cli/commands/export.py:13` `polylogue.cli.commands.export.export_command` |
+| `polylogue export` | `polylogue/cli/commands/export.py:29` `polylogue.cli.commands.export.export_command` |
 | `polylogue list` | `polylogue/cli/query_verbs.py:18` `polylogue.cli.query_verbs.list_verb` |
 | `polylogue mcp` | `polylogue/cli/commands/mcp.py:10` `polylogue.cli.commands.mcp.mcp_command` |
 | `polylogue neighbors` | `polylogue/cli/commands/neighbors.py:42` `polylogue.cli.commands.neighbors.neighbors_command` |

--- a/polylogue/cli/commands/export.py
+++ b/polylogue/cli/commands/export.py
@@ -6,8 +6,24 @@ import click
 
 from polylogue.cli.helper_support import fail
 from polylogue.cli.types import AppEnv
+from polylogue.lib.message_roles import normalize_message_roles
 from polylogue.rendering.formatting import CONVERSATION_OUTPUT_FORMATS, format_conversation
 from polylogue.sync_bridge import run_coroutine_sync
+
+
+def _root_message_roles(ctx: click.Context) -> tuple[object, ...]:
+    """Read the parent ``--message-role`` filter; honor ``--dialogue-only``."""
+    parent = ctx.parent
+    if parent is None:
+        return ()
+    raw_roles = parent.params.get("message_role")
+    if raw_roles:
+        return tuple(normalize_message_roles(raw_roles))
+    if parent.params.get("dialogue_only"):
+        from polylogue.lib.roles import Role
+
+        return (Role.USER, Role.ASSISTANT)
+    return ()
 
 
 @click.command("export")
@@ -22,12 +38,16 @@ from polylogue.sync_bridge import run_coroutine_sync
     help="Output format",
 )
 @click.option("--fields", help="Fields for JSON/YAML outputs")
-@click.pass_obj
-def export_command(env: AppEnv, conversation_id: str, output_format: str, fields: str | None) -> None:
+@click.pass_context
+def export_command(ctx: click.Context, conversation_id: str, output_format: str, fields: str | None) -> None:
     """Export one known conversation by ID."""
+    env: AppEnv = ctx.obj
     conversation = run_coroutine_sync(env.operations.get_conversation(conversation_id))
     if conversation is None:
         fail("export", f"Conversation not found: {conversation_id}")
+    roles = _root_message_roles(ctx)
+    if roles:
+        conversation = conversation.with_roles(roles)
     click.echo(format_conversation(conversation, output_format, fields))
 
 

--- a/tests/unit/cli/test_export.py
+++ b/tests/unit/cli/test_export.py
@@ -38,3 +38,51 @@ def test_export_missing_conversation_exits_with_clear_message(cli_workspace: dic
 
     assert result.exit_code == 1
     assert "Conversation not found: missing-id" in str(result.exception)
+
+
+def test_export_message_role_filter_applied(cli_workspace: dict[str, Path]) -> None:
+    """``--message-role user`` must drop assistant + system messages from the export (#406)."""
+    (
+        ConversationBuilder(cli_workspace["db_path"], "conv-roles")
+        .provider("codex")
+        .title("Mixed roles")
+        .add_message("u1", role="user", text="user prose")
+        .add_message("a1", role="assistant", text="assistant reply")
+        .add_message("s1", role="system", text="system note")
+        .save()
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        ["--message-role", "user", "export", "--format", "json", "conv-roles"],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    roles = [message["role"] for message in payload["messages"]]
+    assert roles == ["user"], f"export ignored --message-role user: roles={roles!r}"
+
+
+def test_export_dialogue_only_filter_applied(cli_workspace: dict[str, Path]) -> None:
+    """``--dialogue-only`` keeps user+assistant, drops system + tool (#406)."""
+    (
+        ConversationBuilder(cli_workspace["db_path"], "conv-dialogue")
+        .provider("codex")
+        .title("Dialogue-only")
+        .add_message("u1", role="user", text="user prose")
+        .add_message("a1", role="assistant", text="assistant reply")
+        .add_message("s1", role="system", text="system note")
+        .save()
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        ["--dialogue-only", "export", "--format", "json", "conv-dialogue"],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    roles = sorted({message["role"] for message in payload["messages"]})
+    assert roles == ["assistant", "user"], f"--dialogue-only export retained extra roles: {roles!r}"


### PR DESCRIPTION
## Summary

Closes #406. Stacked on #461.

## Problem

The single-conversation ``export`` command silently ignored root-level
``--message-role`` and ``--dialogue-only`` flags. Users had to dump full
JSON and post-filter in Python to extract user-only prose:

    polylogue --message-role user export <id> --format json
    # returns full message list, ignoring --message-role

## Solution

Wires the flags through the same helper the verbs use:
``conversation.with_roles(roles)``. Honors ``--message-role`` (one or
more roles); when ``--dialogue-only`` is set without an explicit role
filter, defaults to user+assistant.

## Verification

``tests/unit/cli/test_export.py`` covers both paths against a synthetic
conversation with mixed roles (user / assistant / system).
``devtools verify`` (full): all checks pass.