### PR TITLE
fix(parser): reclassify claude tool_result-only user envelopes to Role.TOOL

### DIFF
--- a/polylogue/sources/parsers/claude_code_parser.py
+++ b/polylogue/sources/parsers/claude_code_parser.py
@@ -22,7 +22,7 @@ from .base import (
     ParsedProviderEvent,
     content_blocks_from_segments,
 )
-from .claude_common import extract_message_text, normalize_timestamp
+from .claude_common import extract_message_text, normalize_timestamp, reclassify_tool_result_envelope
 
 _TAG_RE = re.compile(r"<[^>]+>")
 _WHITESPACE_RE = re.compile(r"\s+")
@@ -139,13 +139,15 @@ def _parse_code_records(records: Iterable[object], fallback_id: str) -> ParsedCo
         text = record.text_content or extract_message_text(
             record.message.get("content") if isinstance(record.message, dict) else None
         )
+        envelope_role = Role.normalize(record.role) if record.role else Role.UNKNOWN
+        content_blocks = _content_blocks_from_record(record, text)
         messages.append(
             ParsedMessage(
                 provider_message_id=str(record.uuid or f"msg-{index}"),
-                role=Role.normalize(record.role) if record.role else Role.UNKNOWN,
+                role=reclassify_tool_result_envelope(envelope_role, content_blocks),
                 text=text or "",
                 timestamp=timestamp,
-                content_blocks=_content_blocks_from_record(record, text),
+                content_blocks=content_blocks,
                 parent_message_provider_id=record.parentUuid,
             )
         )

--- a/polylogue/sources/parsers/claude_common.py
+++ b/polylogue/sources/parsers/claude_common.py
@@ -16,6 +16,27 @@ from .base import (
 )
 
 
+def reclassify_tool_result_envelope(role: Role, content_blocks: list[ParsedContentBlock]) -> Role:
+    """Reclassify a ``role: user`` envelope whose content is all ``tool_result`` to ``Role.TOOL``.
+
+    The Anthropic API protocol requires ``tool_result`` blocks to be carried by
+    ``role: user`` messages — the assistant emits ``tool_use`` blocks and the
+    runtime replies with corresponding ``tool_result`` blocks under the
+    protocol-mandated ``user`` role. Polylogue's outer-envelope role
+    normalization classifies these as ``Role.USER``, polluting
+    ``--message-role user`` filters with non-typed content.
+
+    See `#428 <https://github.com/Sinity/polylogue/issues/428>`_.
+    """
+    if role is not Role.USER:
+        return role
+    if not content_blocks:
+        return role
+    if all(block.type == ContentBlockType.TOOL_RESULT for block in content_blocks):
+        return Role.TOOL
+    return role
+
+
 def extract_text_from_segments(segments: list[object]) -> str | None:
     lines: list[str] = []
     for segment in segments:
@@ -97,6 +118,8 @@ def extract_messages_from_chat_messages(
         content_blocks = content_blocks_from_segments(raw_content) if isinstance(raw_content, list) else []
         if not content_blocks and text:
             content_blocks = [ParsedContentBlock(type=ContentBlockType.TEXT, text=text)]
+
+        role = reclassify_tool_result_envelope(role, content_blocks)
 
         if text:
             messages.append(

--- a/tests/unit/sources/test_tool_result_role_reclassification.py
+++ b/tests/unit/sources/test_tool_result_role_reclassification.py
@@ -1,0 +1,73 @@
+"""Claude tool_result envelopes are reclassified from USER to TOOL (#428).
+
+Anthropic's protocol requires ``tool_result`` blocks to be carried by
+``role: user`` envelopes. Polylogue's outer-envelope role normalization
+puts those under ``Role.USER``, polluting ``--message-role user`` filters.
+The reclassification flips USER → TOOL when content is exclusively
+``tool_result`` blocks; mixed envelopes (text + tool_result) keep USER.
+"""
+
+from __future__ import annotations
+
+from polylogue.lib.roles import Role
+from polylogue.sources.parsers.base import ParsedContentBlock
+from polylogue.sources.parsers.claude_common import (
+    extract_messages_from_chat_messages,
+    reclassify_tool_result_envelope,
+)
+from polylogue.types import ContentBlockType
+
+
+def _tool_result(idx: int) -> ParsedContentBlock:
+    return ParsedContentBlock(type=ContentBlockType.TOOL_RESULT, text=f"result {idx}")
+
+
+def _text(text: str) -> ParsedContentBlock:
+    return ParsedContentBlock(type=ContentBlockType.TEXT, text=text)
+
+
+class TestReclassifyToolResultEnvelope:
+    def test_user_with_only_tool_result_becomes_tool(self) -> None:
+        assert reclassify_tool_result_envelope(Role.USER, [_tool_result(1)]) is Role.TOOL
+
+    def test_user_with_multiple_tool_result_blocks_becomes_tool(self) -> None:
+        assert reclassify_tool_result_envelope(Role.USER, [_tool_result(1), _tool_result(2)]) is Role.TOOL
+
+    def test_user_with_text_only_stays_user(self) -> None:
+        assert reclassify_tool_result_envelope(Role.USER, [_text("typed prose")]) is Role.USER
+
+    def test_user_with_mixed_text_and_tool_result_stays_user(self) -> None:
+        """Conservative: mixed envelopes preserve USER (split-on-parse is a separate change)."""
+        assert reclassify_tool_result_envelope(Role.USER, [_text("hi"), _tool_result(1)]) is Role.USER
+
+    def test_user_with_no_blocks_stays_user(self) -> None:
+        assert reclassify_tool_result_envelope(Role.USER, []) is Role.USER
+
+    def test_assistant_unaffected(self) -> None:
+        """Assistant tool_use envelopes never get touched."""
+        assert reclassify_tool_result_envelope(Role.ASSISTANT, [_tool_result(1)]) is Role.ASSISTANT
+
+    def test_system_unaffected(self) -> None:
+        assert reclassify_tool_result_envelope(Role.SYSTEM, [_tool_result(1)]) is Role.SYSTEM
+
+
+class TestChatMessagesWithToolResults:
+    def test_chat_message_with_tool_result_blocks_gets_tool_role(self) -> None:
+        messages, _ = extract_messages_from_chat_messages(
+            [
+                {
+                    "uuid": "m-typed",
+                    "role": "user",
+                    "content": [{"type": "text", "text": "typed prose"}],
+                },
+                {
+                    "uuid": "m-tool",
+                    "role": "user",
+                    "content": [{"type": "tool_result", "content": "tool output"}],
+                    "text": "tool output",
+                },
+            ]
+        )
+        roles = {message.provider_message_id: message.role for message in messages}
+        assert roles["m-typed"] is Role.USER
+        assert roles["m-tool"] is Role.TOOL, "tool_result-only user envelope must be reclassified to TOOL (#428)"


### PR DESCRIPTION
## Summary

Closes #428 (conservative slice).

## Problem

Anthropic's API protocol requires ``tool_result`` blocks to be carried
by ``role: user`` envelopes. Polylogue's outer-envelope role
normalization put those under ``Role.USER``, polluting
``--message-role user`` with non-typed content. The issue's mining of
three claude-code sessions found ~96% of user-role messages were tool
results, not typed user prose.

## Solution

``polylogue/sources/parsers/claude_common.py`` gains
``reclassify_tool_result_envelope(role, content_blocks)``. The function
flips ``USER → TOOL`` when content is exclusively ``tool_result`` blocks;
mixed envelopes (text + tool_result) keep ``USER`` (the
split-on-parse alternative is left for follow-up).

Applied in both parsers:
- ``claude_common.extract_messages_from_chat_messages`` (claude web)
- ``claude_code_parser._parse_code_records`` (claude-code JSONL)

Side benefit: title extraction in ``claude_code_parser`` (which iterates
"first user message" and uses ``_clean_title_text`` as a workaround)
naturally skips tool_result envelopes now.

## Verification

- 8 new tests in
  ``tests/unit/sources/test_tool_result_role_reclassification.py``
  cover the helper directly and end-to-end through the chat-messages
  parser.
- 166 claude-related tests pass; ``devtools verify --quick`` passes.

## Follow-ups (left for #428 reopens or successor)

- Mixed envelope splitting (Option 1 from the issue).
- Schema-level ``message_kind`` field (Option 2).
- Companion improvements once #405 lands.