### PR TITLE
fix(cli): add show verb that resolves provider:id directly

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -142,6 +142,7 @@ Commands:
   resume           Reconstruct work-state context for a fresh agent session.
   run              Run pipeline stages on configured sources.
   schema           Inspect schema packages, versions, and evidence.
+  show             Show matched conversation content (default streaming...
   stats            Show statistics for matched conversations.
   tags             List all tags with conversation counts.
 ```

--- a/docs/test-quality-workflows.md
+++ b/docs/test-quality-workflows.md
@@ -15,10 +15,10 @@ Current registry snapshot:
 - mutation campaigns: `19`
 - benchmark campaigns: `3`
 - synthetic benchmark campaigns: `6`
-- scenario projections: `249`
+- scenario projections: `250`
 - inferred corpus scenarios: `5`
   - benchmark-campaign: `3`
-  - exercise: `143`
+  - exercise: `144`
   - inferred-corpus-scenario: `5`
   - mutation-campaign: `19`
   - synthetic-benchmark: `6`
@@ -370,6 +370,7 @@ These are the authored scenario-bearing projections currently feeding runtime co
 | `exercise` | `help-schema-compare` | — | — | `cli.help` | — | `generated`<br>`help`<br>`structural` | schema compare help |
 | `exercise` | `help-schema-explain` | `schema-explain-query-loop` | `schema_packages`<br>`schema_explanation_results` | `cli.help`<br>`query-schema-explanations` | — | `generated`<br>`help`<br>`structural` | schema explain help |
 | `exercise` | `help-schema-list` | `schema-list-query-loop` | `schema_packages`<br>`schema_cluster_manifests`<br>`inferred_corpus_specs`<br>`inferred_corpus_scenarios`<br>`schema_list_results` | `cli.help`<br>`query-schema-catalog` | — | `generated`<br>`help`<br>`structural` | schema list help |
+| `exercise` | `help-show` | `conversation-query-loop` | `message_fts`<br>`conversation_query_results` | `cli.help`<br>`query-conversations` | — | `generated`<br>`help`<br>`structural` | show help |
 | `exercise` | `help-stats` | `conversation-query-loop` | `message_fts`<br>`conversation_query_results` | `cli.help`<br>`query-conversations` | — | `generated`<br>`help`<br>`structural` | stats help |
 | `exercise` | `help-tags` | — | — | `cli.help` | — | `generated`<br>`help`<br>`structural` | tags help |
 | `exercise` | `json-audit` | — | — | `cli.json-contract` | — | `generated`<br>`json-contract` | audit JSON contract |

--- a/docs/verification-catalog.md
+++ b/docs/verification-catalog.md
@@ -8,10 +8,10 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 
 ## Snapshot
 
-- subjects: `9046`
+- subjects: `9047`
 - claims: `22`
 - runner bindings: `22`
-- proof obligations: `9147`
+- proof obligations: `9150`
 
 ## Quality Checks
 
@@ -31,7 +31,7 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | --- | ---: |
 | `archive.query_law` | 1 |
 | `artifact.path` | 27 |
-| `cli.command` | 50 |
+| `cli.command` | 51 |
 | `cli.json_command` | 2 |
 | `diagnostic.observable` | 1 |
 | `error.surface` | 2 |
@@ -56,7 +56,7 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | `polylogue completions` | `polylogue/cli/commands/completions.py:9` `polylogue.cli.commands.completions.completions_command` |
 | `polylogue count` | `polylogue/cli/query_verbs.py:41` `polylogue.cli.query_verbs.count_verb` |
 | `polylogue dashboard` | `polylogue/cli/commands/dashboard.py:10` `polylogue.cli.commands.dashboard.dashboard_command` |
-| `polylogue delete` | `polylogue/cli/query_verbs.py:89` `polylogue.cli.query_verbs.delete_verb` |
+| `polylogue delete` | `polylogue/cli/query_verbs.py:110` `polylogue.cli.query_verbs.delete_verb` |
 | `polylogue doctor` | `polylogue/cli/commands/check.py:31` `polylogue.cli.commands.check.check_command` |
 | `polylogue export` | `polylogue/cli/commands/export.py:29` `polylogue.cli.commands.export.export_command` |
 | `polylogue list` | `polylogue/cli/query_verbs.py:18` `polylogue.cli.query_verbs.list_verb` |
@@ -95,6 +95,7 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | `polylogue schema compare` | `polylogue/cli/commands/schema.py:56` `polylogue.cli.commands.schema.schema_compare` |
 | `polylogue schema explain` | `polylogue/cli/commands/schema.py:90` `polylogue.cli.commands.schema.schema_explain` |
 | `polylogue schema list` | `polylogue/cli/commands/schema.py:45` `polylogue.cli.commands.schema.schema_list` |
+| `polylogue show` | `polylogue/cli/query_verbs.py:89` `polylogue.cli.query_verbs.show_verb` |
 | `polylogue stats` | `polylogue/cli/query_verbs.py:48` `polylogue.cli.query_verbs.stats_verb` |
 | `polylogue tags` | `polylogue/cli/commands/tags.py:12` `polylogue.cli.commands.tags.tags_command` |
 
@@ -194,10 +195,10 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | --- | ---: |
 | `archive.query.provider_filter_consistency` | 1 |
 | `artifact.path.dependency_closure` | 11 |
-| `cli.command.help` | 50 |
+| `cli.command.help` | 51 |
 | `cli.command.json_envelope` | 2 |
-| `cli.command.no_traceback` | 50 |
-| `cli.command.plain_mode` | 50 |
+| `cli.command.no_traceback` | 51 |
+| `cli.command.plain_mode` | 51 |
 | `diagnostic.observable_trace_mapping` | 1 |
 | `error.machine_user_context` | 2 |
 | `generated.scenario.family_registered` | 9 |

--- a/polylogue/cli/query_verbs.py
+++ b/polylogue/cli/query_verbs.py
@@ -12,7 +12,7 @@ from polylogue.cli.root_request import RootModeRequest
 from polylogue.cli.shell_completion_values import complete_open_targets
 from polylogue.cli.types import AppEnv
 
-VERB_NAMES = frozenset({"list", "count", "stats", "open", "delete"})
+VERB_NAMES = frozenset({"list", "count", "stats", "open", "show", "delete"})
 
 
 @click.command("list")
@@ -86,6 +86,27 @@ def open_verb(ctx: click.Context, print_path: bool, target_terms: tuple[str, ...
     _execute_query_verb(ctx, request.append_query_terms(target_terms))
 
 
+@click.command("show")
+@click.argument("target_terms", nargs=-1, shell_complete=complete_open_targets)
+@click.pass_context
+def show_verb(ctx: click.Context, target_terms: tuple[str, ...]) -> None:
+    """Show matched conversation content (default streaming output).
+
+    Accepts an optional ``provider:id`` positional that routes directly
+    to the conversation by id (prefix match), bypassing FTS search.
+    """
+    request = _parent_request(ctx)
+    parent_terms = _parent_query_terms(ctx)
+    candidates = parent_terms + target_terms
+    if len(candidates) == 1 and ":" in candidates[0]:
+        _execute_query_verb(
+            ctx,
+            request.with_query_terms(()).with_param_updates(conv_id=candidates[0]),
+        )
+        return
+    _execute_query_verb(ctx, request.append_query_terms(target_terms))
+
+
 @click.command("delete")
 @click.option("--dry-run", is_flag=True, help="Preview without deleting")
 @click.option("--force", is_flag=True, help="Skip confirmation")
@@ -128,7 +149,7 @@ def _execute_query_verb(
     execute_query_request(env, request)
 
 
-QUERY_VERBS = (list_verb, count_verb, stats_verb, open_verb, delete_verb)
+QUERY_VERBS = (list_verb, count_verb, stats_verb, open_verb, show_verb, delete_verb)
 
 
 __all__ = [
@@ -138,5 +159,6 @@ __all__ = [
     "delete_verb",
     "list_verb",
     "open_verb",
+    "show_verb",
     "stats_verb",
 ]

--- a/tests/baselines/showcase/help-main.txt
+++ b/tests/baselines/showcase/help-main.txt
@@ -131,5 +131,6 @@ Commands:
   resume           Reconstruct work-state context for a fresh agent session.
   run              Run pipeline stages on configured sources.
   schema           Inspect schema packages, versions, and evidence.
+  show             Show matched conversation content (default streaming...
   stats            Show statistics for matched conversations.
   tags             List all tags with conversation counts.

--- a/tests/baselines/showcase/help-show.txt
+++ b/tests/baselines/showcase/help-show.txt
@@ -1,0 +1,9 @@
+Usage: polylogue show [OPTIONS] [TARGET_TERMS]...
+
+  Show matched conversation content (default streaming output).
+
+  Accepts an optional ``provider:id`` positional that routes directly to the
+  conversation by id (prefix match), bypassing FTS search.
+
+Options:
+  -h, --help  Show this message and exit.

--- a/tests/unit/cli/__snapshots__/test_terminal_snapshots.ambr
+++ b/tests/unit/cli/__snapshots__/test_terminal_snapshots.ambr
@@ -224,6 +224,7 @@
     resume           Reconstruct work-state context for a fresh agent session.
     run              Run pipeline stages on configured sources.
     schema           Inspect schema packages, versions, and evidence.
+    show             Show matched conversation content (default streaming...
     stats            Show statistics for matched conversations.
     tags             List all tags with conversation counts.
   '''
@@ -411,6 +412,8 @@
   .
     schema           Inspect schema packages, versions, and ev
   idence.
+    show             Show matched conversation content (defaul
+  t streaming...
     stats            Show statistics for matched conversations
   .
     tags             List all tags with conversation counts.
@@ -543,6 +546,7 @@
     resume           Reconstruct work-state context for a fresh agent session.
     run              Run pipeline stages on configured sources.
     schema           Inspect schema packages, versions, and evidence.
+    show             Show matched conversation content (default streaming...
     stats            Show statistics for matched conversations.
     tags             List all tags with conversation counts.
   '''

--- a/tests/unit/cli/test_click_app.py
+++ b/tests/unit/cli/test_click_app.py
@@ -464,6 +464,7 @@ class TestCliMetadata:
             "count",
             "stats",
             "open",
+            "show",
             "delete",
         }
         assert set(cli.commands.keys()) == expected

--- a/tests/unit/cli/test_query_verbs_runtime.py
+++ b/tests/unit/cli/test_query_verbs_runtime.py
@@ -123,6 +123,51 @@ def test_open_verb_routes_single_id_or_appends_target_terms() -> None:
     assert appended_request.query_params()["open_result"] is True
 
 
+def test_show_verb_routes_provider_id_from_target_terms() -> None:
+    _, child = _context_pair(query_terms=())
+    wrapped = getattr(query_verbs.show_verb.callback, "__wrapped__", None)
+    assert callable(wrapped)
+
+    with patch("polylogue.cli.query_verbs._execute_query_verb") as execute:
+        wrapped(child, ("codex:019dbae3-699e-7d42",))
+
+    request = execute.call_args.args[1]
+    assert isinstance(request, RootModeRequest)
+    assert request.query_params()["conv_id"] == "codex:019dbae3-699e-7d42"
+    assert request.query_params()["query"] == ()
+
+
+def test_show_verb_routes_provider_id_from_parent_query_terms() -> None:
+    """Regression: ``polylogue codex:abc show`` captured ``codex:abc`` as a
+    bare query term before ``show`` was a verb. Now the verb consumes the
+    parent term and routes to a direct id lookup."""
+    _, child = _context_pair(query_terms=("claude-code:b78f986e-995",))
+    wrapped = getattr(query_verbs.show_verb.callback, "__wrapped__", None)
+    assert callable(wrapped)
+
+    with patch("polylogue.cli.query_verbs._execute_query_verb") as execute:
+        wrapped(child, ())
+
+    request = execute.call_args.args[1]
+    assert isinstance(request, RootModeRequest)
+    assert request.query_params()["conv_id"] == "claude-code:b78f986e-995"
+    assert request.query_params()["query"] == ()
+
+
+def test_show_verb_falls_back_to_search_for_non_id_terms() -> None:
+    _, child = _context_pair(query_terms=("error",))
+    wrapped = getattr(query_verbs.show_verb.callback, "__wrapped__", None)
+    assert callable(wrapped)
+
+    with patch("polylogue.cli.query_verbs._execute_query_verb") as execute:
+        wrapped(child, ("regression",))
+
+    request = execute.call_args.args[1]
+    assert isinstance(request, RootModeRequest)
+    assert "conv_id" not in request.query_params() or not request.query_params().get("conv_id")
+    assert request.query_params()["query"] == ("error", "regression")
+
+
 def test_delete_verb_updates_force_and_dry_run_flags() -> None:
     _, child = _context_pair(query_terms=("alpha",))
     wrapped = getattr(query_verbs.delete_verb.callback, "__wrapped__", None)


### PR DESCRIPTION
## Summary

- Register `show` as a query verb so `polylogue <provider:id> show` resolves directly by id instead of falling into FTS.
- Mirror `open`'s positional-id pattern, but accept the id from either the parent query terms (`<id> show`) or the verb's target terms (`show <id>`).
- Update CLI help snapshots and generated catalogs (cli-reference, verification-catalog, test-quality-workflows) to include the new verb.

Closes #422.

## Problem

Before this change, `polylogue codex:019dbae3-... show` exited after ~95s with `No conversations matched filters: search: codex:019dbae3-... show`. Root cause: there was no `show` verb registered, so the bare-token interception in `_split_query_mode_args` swept both `codex:...` and `show` into `query_terms`, ran the concatenated string as an FTS search, and timed out. The conversation existed in the archive (visible via `list`); only the surface was broken.

## Solution

`polylogue/cli/query_verbs.py`:

- Add `show_verb`. When the parent query terms plus the verb's positional `target_terms` collapse to exactly one token containing `:`, set `conv_id` and clear the query terms — direct id lookup, prefix match handled by `_apply_runtime_filters`. Otherwise append `target_terms` to existing query terms (preserving the search path).
- Add `"show"` to `VERB_NAMES` so `_split_query_mode_args` recognizes it as a verb at any position (matching `list`, `count`, `stats`, `open`, `delete`).
- Add `show_verb` to `QUERY_VERBS` so it's registered with the root group.

Other surfaces:

- `tests/unit/cli/test_query_verbs_runtime.py`: three new tests covering id-from-target-terms, id-from-parent-query-terms (the regression), and search fallback for non-id terms.
- `tests/unit/cli/test_click_app.py`: extend the registered-commands assertion.
- `tests/unit/cli/__snapshots__/test_terminal_snapshots.ambr`: refreshed via `--snapshot-update` (help now lists `show`).
- `docs/cli-reference.md`, `docs/verification-catalog.md`, `docs/test-quality-workflows.md`: regenerated by `devtools render-all`.

## Verification

```
nix develop -c pytest tests/unit/cli/ -q                # 844 passed
nix develop -c devtools verify --quick                  # all checks passed
nix develop -c pytest -q --ignore=tests/integration     # 5570 passed, 10 xfailed
                                                        # (1 unrelated flaky pass on re-run:
                                                        #  test_async_backend_schema_and_lock_contracts)
```

End-to-end:

```
$ time polylogue --plain --limit 1 claude-code:8d821a23-10a show
# investigate open issues and propose a set you'd tackle next ...
Provider: claude-code
Conversation ID: claude-code:8d821a23-10a6-4aa9-9c1f-ce5c7086f784
real  0m3.12s
```

(Was ~95s timeout with no results before this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `show` command to display matched conversation content via existing query execution paths.

* **Documentation**
  * Updated CLI reference with documentation for the new `show` command.

* **Tests**
  * Updated test snapshots and assertions to include the new `show` command.
  * Added runtime tests validating the new command's routing behavior for conversation lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->