### PR TITLE
fix(proof): drop x-polylogue-mutually-exclusive from catalog subjects

### DIFF
--- a/docs/verification-catalog.md
+++ b/docs/verification-catalog.md
@@ -8,10 +8,10 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 
 ## Snapshot
 
-- subjects: `9048`
-- claims: `22`
-- runner bindings: `22`
-- proof obligations: `9153`
+- subjects: `246`
+- claims: `21`
+- runner bindings: `21`
+- proof obligations: `351`
 
 ## Quality Checks
 
@@ -39,7 +39,7 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | `maintenance.target` | 8 |
 | `operation.spec` | 43 |
 | `provider.capability` | 3 |
-| `schema.annotation` | 8897 |
+| `schema.annotation` | 95 |
 | `trace.operation` | 1 |
 | `workflow.claim` | 2 |
 
@@ -105,13 +105,8 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | Provider | Element | Annotation | Count | Example Subject |
 | --- | --- | --- | ---: | --- |
 | `chatgpt` | `conversation_document` | `x-polylogue-foreign-keys` | 7 | `chatgpt:v1:conversation_document:x-polylogue-foreign-keys:0:$.mapping.*.id:$.mapping` |
-| `chatgpt` | `conversation_document` | `x-polylogue-mutually-exclusive` | 6065 | `chatgpt:v1:conversation_document:x-polylogue-mutually-exclusive:0:$:email,title` |
-| `claude-ai` | `conversation_document` | `x-polylogue-mutually-exclusive` | 312 | `claude-ai:v1:conversation_document:x-polylogue-mutually-exclusive:0:$.chat_messages[*].content[*]:start_timestamp,thinking` |
-| `claude-code` | `conversation_record_stream` | `x-polylogue-mutually-exclusive` | 1353 | `claude-code:v1:conversation_record_stream:x-polylogue-mutually-exclusive:0:$:messageId,parentUuid` |
 | `claude-code` | `conversation_record_stream` | `x-polylogue-values` | 42 | `claude-code:v1:conversation_record_stream:x-polylogue-values:$.data.command` |
-| `codex` | `conversation_record_stream` | `x-polylogue-mutually-exclusive` | 787 | `codex:v1:conversation_record_stream:x-polylogue-mutually-exclusive:0:$.payload:cwd,type` |
 | `codex` | `conversation_record_stream` | `x-polylogue-values` | 32 | `codex:v1:conversation_record_stream:x-polylogue-values:$.payload.agent_nickname` |
-| `gemini` | `conversation_document` | `x-polylogue-mutually-exclusive` | 285 | `gemini:v1:conversation_document:x-polylogue-mutually-exclusive:0:$:applets,runSettings` |
 | `gemini` | `conversation_document` | `x-polylogue-values` | 14 | `gemini:v1:conversation_document:x-polylogue-values:$.chunkedPrompt.chunks[*].finishReason` |
 
 ## Provider Capability Subjects
@@ -149,7 +144,6 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | `provider.capability.partial_coverage_declared` | `serious` | `provider.capability.implicit-gap`<br>`provider-semantics.untracked-partial-support` | A provider with absent or partial facets but no explicit gap record hides verification scope. |
 | `schema.values.value_closure` | `serious` | `schema.value-domain.drift`<br>`schema.privacy.enum-leak` | A generated payload outside the annotated value set is a counterexample. |
 | `schema.foreign_key.resolves` | `serious` | `schema.relationship.drift`<br>`synthetic-corpus.integrity` | A source path pointing at a missing target path breaks the relation claim. |
-| `schema.mutual_exclusion.exclusive` | `serious` | `schema.mutual-exclusion.drift`<br>`synthetic-corpus.invalid-combination` | A generated record containing two fields from the same exclusion group is a counterexample. |
 | `operation.spec.routing_metadata` | `serious` | `operation.routing.metadata-missing`<br>`agent-verification.unroutable-operation` | An operation without stable routing metadata cannot be mapped to focused proof checks. |
 | `artifact.path.dependency_closure` | `serious` | `artifact-graph.unresolved-dependency`<br>`structural-proof.missing-derived-layer` | A runtime path with unresolved dependencies or no derived/index/projection layer breaks routing. |
 | `maintenance.repair.crash_consistency` | `serious` | `maintenance.failure-state.ambiguous`<br>`destructive-repair.preview-mismatch` | A repair failure without an explicit unchanged/changed/rolled-back/partial state is ambiguous. |
@@ -176,7 +170,6 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | `provider-capability-static-contract:provider.capability.partial_coverage_declared` | `provider.capability.partial_coverage_declared` | `structural` | `static` | commands=—; controlled_dims=`9`; uncontrolled_dims=`0`; network=`none`; live_archive=`False` | `authored` by `polylogue.proof.catalog` at `2026-04-22T00:00:00+00:00` |
 | `schema-annotation-static-contract:schema.values.value_closure` | `schema.values.value_closure` | `structural` | `static` | commands=—; controlled_dims=`9`; uncontrolled_dims=`0`; network=`none`; live_archive=`False` | `authored` by `polylogue.proof.catalog` at `2026-04-22T00:00:00+00:00` |
 | `schema-annotation-static-contract:schema.foreign_key.resolves` | `schema.foreign_key.resolves` | `structural` | `static` | commands=—; controlled_dims=`9`; uncontrolled_dims=`0`; network=`none`; live_archive=`False` | `authored` by `polylogue.proof.catalog` at `2026-04-22T00:00:00+00:00` |
-| `schema-annotation-static-contract:schema.mutual_exclusion.exclusive` | `schema.mutual_exclusion.exclusive` | `structural` | `static` | commands=—; controlled_dims=`9`; uncontrolled_dims=`0`; network=`none`; live_archive=`False` | `authored` by `polylogue.proof.catalog` at `2026-04-22T00:00:00+00:00` |
 | `operation-spec-static-contract:operation.spec.routing_metadata` | `operation.spec.routing_metadata` | `structural` | `static` | commands=—; controlled_dims=`9`; uncontrolled_dims=`0`; network=`none`; live_archive=`False` | `authored` by `polylogue.proof.catalog` at `2026-04-22T00:00:00+00:00` |
 | `artifact-path-static-contract:artifact.path.dependency_closure` | `artifact.path.dependency_closure` | `structural` | `static` | commands=—; controlled_dims=`9`; uncontrolled_dims=`0`; network=`none`; live_archive=`False` | `authored` by `polylogue.proof.catalog` at `2026-04-22T00:00:00+00:00` |
 | `maintenance-repair-state-contract:maintenance.repair.crash_consistency` | `maintenance.repair.crash_consistency` | `structural` | `unit` | commands=—; controlled_dims=`9`; uncontrolled_dims=`0`; network=`none`; live_archive=`False` | `authored` by `polylogue.proof.catalog` at `2026-04-22T00:00:00+00:00` |
@@ -211,7 +204,6 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | `provider.capability.identity_bridge` | 3 |
 | `provider.capability.partial_coverage_declared` | 3 |
 | `schema.foreign_key.resolves` | 7 |
-| `schema.mutual_exclusion.exclusive` | 8802 |
 | `schema.values.value_closure` | 88 |
 | `trace.operation.surface_equivalence` | 1 |
 | `workflow.generated_surfaces_current` | 1 |

--- a/polylogue/proof/catalog.py
+++ b/polylogue/proof/catalog.py
@@ -145,7 +145,6 @@ def default_claims() -> tuple[Claim, ...]:
     command_query = Kind("cli.command")
     values_query = _schema_annotation_query("x-polylogue-values")
     foreign_key_query = _schema_annotation_query("x-polylogue-foreign-keys")
-    mutual_exclusion_query = _schema_annotation_query("x-polylogue-mutually-exclusive")
     provider_capability_query = Kind("provider.capability")
     operation_query = Kind("operation.spec")
     artifact_path_query = And(
@@ -325,21 +324,6 @@ def default_claims() -> tuple[Claim, ...]:
             ),
             breaker=BreakerMetadata(
                 description="A source path pointing at a missing target path breaks the relation claim.",
-                issue="#332",
-                command=("devtools", "render-verification-catalog", "--check"),
-            ),
-        ),
-        Claim(
-            id="schema.mutual_exclusion.exclusive",
-            description="Schema mutual-exclusion annotations prevent co-populating exclusive fields.",
-            subject_query=mutual_exclusion_query,
-            evidence_schema=_evidence_schema("parent", "fields"),
-            bug_classes=("schema.mutual-exclusion.drift", "synthetic-corpus.invalid-combination"),
-            runner_classes=("schema_static",),
-            observed_facts=("parent", "fields", "co_populated_fields"),
-            staleness_conditions=("Schema mutual-exclusion annotations or generated payload construction changes.",),
-            breaker=BreakerMetadata(
-                description="A generated record containing two fields from the same exclusion group is a counterexample.",
                 issue="#332",
                 command=("devtools", "render-verification-catalog", "--check"),
             ),

--- a/polylogue/proof/subjects.py
+++ b/polylogue/proof/subjects.py
@@ -22,7 +22,6 @@ from polylogue.schemas.runtime_registry import SCHEMA_DIR, SchemaRegistry
 SELECTED_SCHEMA_ANNOTATIONS: tuple[str, ...] = (
     "x-polylogue-values",
     "x-polylogue-foreign-keys",
-    "x-polylogue-mutually-exclusive",
 )
 SELECTED_JSON_COMMANDS: tuple[tuple[str, ...], ...] = (("doctor",), ("tags",))
 
@@ -451,16 +450,6 @@ def _annotation_subjects_for_schema(
             schema_source=schema_source,
             annotation="x-polylogue-foreign-keys",
             id_fields=("source", "target"),
-        )
-    if "x-polylogue-mutually-exclusive" in annotation_keys:
-        yield from _root_record_annotation_subjects(
-            provider=provider,
-            version=version,
-            element_kind=element_kind,
-            schema=schema,
-            schema_source=schema_source,
-            annotation="x-polylogue-mutually-exclusive",
-            id_fields=("parent", "fields"),
         )
 
 

--- a/tests/unit/proof/test_catalog.py
+++ b/tests/unit/proof/test_catalog.py
@@ -33,7 +33,6 @@ def test_default_catalog_compiles_first_vertical_slice() -> None:
         "provider.capability.partial_coverage_declared",
         "schema.values.value_closure",
         "schema.foreign_key.resolves",
-        "schema.mutual_exclusion.exclusive",
         "operation.spec.routing_metadata",
         "artifact.path.dependency_closure",
         "maintenance.repair.crash_consistency",
@@ -88,10 +87,6 @@ def test_selected_schema_annotations_bind_schema_claims() -> None:
     assert catalog.obligations_by_claim()["schema.values.value_closure"] == annotation_counts["x-polylogue-values"]
     assert (
         catalog.obligations_by_claim()["schema.foreign_key.resolves"] == annotation_counts["x-polylogue-foreign-keys"]
-    )
-    assert (
-        catalog.obligations_by_claim()["schema.mutual_exclusion.exclusive"]
-        == annotation_counts["x-polylogue-mutually-exclusive"]
     )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1363,6 +1363,7 @@ dependencies = [
     { name = "structlog" },
     { name = "tenacity" },
     { name = "textual" },
+    { name = "typing-extensions" },
 ]
 
 [package.optional-dependencies]
@@ -1474,6 +1475,7 @@ requires-dist = [
     { name = "tree-sitter-yaml", marker = "extra == 'tree-sitter'", specifier = ">=0.6.0" },
     { name = "types-dateparser", marker = "extra == 'dev'", specifier = ">=1.2.0" },
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
+    { name = "typing-extensions", specifier = ">=4.7" },
 ]
 provides-extras = ["dev", "ocr", "fuzz", "tree-sitter"]
 


### PR DESCRIPTION
## Summary

Stops generating proof catalog subjects from `x-polylogue-mutually-exclusive`. Catalog drops from 9046 subjects / 9149 obligations to 246 / 351.

Closes #496.

## Problem

8802 of 9046 proof catalog subjects (97%) were `kind="schema.annotation"` rows derived from inferred `x-polylogue-mutually-exclusive` pairs. They drowned out the rest of the catalog and verified almost nothing:

1. **Sampling artifact, not invariant.** A pair like `{fields: ['email', 'title'], parent: '$'}` (chatgpt) means "in 2122 samples, email and title never co-occurred" — not "they are mutually exclusive in the format."
2. **Self-referential.** The runner (`schema.mutual_exclusion.exclusive`, runner class `schema_static`) checks that the synthetic-payload generator does not co-populate exclusive fields. But the generator reads the same annotations to know what to avoid. Both sides of the obligation come from the same inference output. The obligation cannot detect what would matter — fresh provider data co-populating fields the inference said were exclusive — because nothing on either side looks at fresh provider data.

The result: a catalog reporting 9149 obligations that looked deeply covered, while one claim accounted for 96% of obligations and produced no signal.

## Solution

- `polylogue/proof/subjects.py`: drop `"x-polylogue-mutually-exclusive"` from `SELECTED_SCHEMA_ANNOTATIONS` and the corresponding branch in `_annotation_subjects_for_schema()`.
- `polylogue/proof/catalog.py`: drop `mutual_exclusion_query` and the `schema.mutual_exclusion.exclusive` Claim from `default_claims()`. The `schema-annotation-static-contract` runner binding stays — it still serves `schema.values.value_closure` and `schema.foreign_key.resolves`.
- `tests/unit/proof/test_catalog.py`: drop the claim id from the expected set and the obligation-count assertion for it.
- `docs/verification-catalog.md`: regenerated by `devtools render-verification-catalog`.

What we keep:
- `x-polylogue-values` subjects (88) — discriminated-union tags and status enums; runner checks `observed_values ⊆ declared_values`, which catches genuine provider drift.
- `x-polylogue-foreign-keys` subjects (7) — small, structurally verifiable.
- The `x-polylogue-mutually-exclusive` annotation itself in committed schemas (still used by the generator and inference). Only the proof-subject minting goes away.

Bundles a one-line `uv.lock` regeneration: `typing-extensions` has been declared in `pyproject.toml` since the TypedDict pinning landed; the lockfile was out of sync.

## Verification

```
$ nix develop -c python -c "from polylogue.proof.subjects import build_catalog_subjects; from collections import Counter; print(dict(Counter(s.kind for s in build_catalog_subjects())))"
{'cli.command': 52, 'cli.json_command': 2, 'archive.query_law': 1, 'provider.capability': 3,
 'operation.spec': 43, 'artifact.path': 27, 'maintenance.target': 8, 'error.surface': 2,
 'trace.operation': 1, 'diagnostic.observable': 1, 'generated.scenario_family': 9,
 'schema.annotation': 95, 'workflow.claim': 2}

$ nix develop -c devtools verify
verify: all checks passed
  ruff format ... ok
  ruff check ... ok
  mypy ... ok
  render-all ... ok
  verify-topology / file-budgets / test-ownership / migrations / cross-cuts ... ok
  pytest ... ok (172.2s)
```

Catalog snapshot delta:

| | subjects | claims | obligations |
| --- | ---: | ---: | ---: |
| before | 9046 | 22 | 9149 |
| after  |  246 | 21 |  351 |

## Related

- #506 — holistic assurance umbrella
- #421 — claim depth (now operates on an honest base)
- #494 — evidence freshness SLA (mutual-exclusion would distort the metric trivially)