### PR TITLE
perf(storage): scope session-profile backfill UPDATEs to partial indexes

### DIFF
--- a/polylogue/storage/backends/schema_bootstrap.py
+++ b/polylogue/storage/backends/schema_bootstrap.py
@@ -370,6 +370,39 @@ _SCHEMA_EXTENSION_DESCRIPTORS: tuple[SchemaExtensionDescriptor, ...] = (
             "TEXT NOT NULL DEFAULT 'heuristic_session_semantics'"
         ),
     ),
+    # Partial indexes scoped to the gating WHERE clause of each backfill below.
+    # SQLite uses a partial index when the query's WHERE matches the index's WHERE
+    # exactly, so the backfill UPDATE becomes an index lookup. Once a row is
+    # backfilled the gating condition no longer holds and the row leaves the
+    # index, so subsequent connection bootstraps scan an empty index instead of
+    # the full session_profiles table.
+    SchemaIndexExtensionDescriptor(
+        table_name="session_profiles",
+        index_name="idx_session_profiles_evidence_search_text_unbackfilled",
+        ddl=(
+            "CREATE INDEX IF NOT EXISTS idx_session_profiles_evidence_search_text_unbackfilled "
+            "ON session_profiles(conversation_id) "
+            "WHERE TRIM(COALESCE(evidence_search_text, '')) = ''"
+        ),
+    ),
+    SchemaIndexExtensionDescriptor(
+        table_name="session_profiles",
+        index_name="idx_session_profiles_inference_search_text_unbackfilled",
+        ddl=(
+            "CREATE INDEX IF NOT EXISTS idx_session_profiles_inference_search_text_unbackfilled "
+            "ON session_profiles(conversation_id) "
+            "WHERE TRIM(COALESCE(inference_search_text, '')) = ''"
+        ),
+    ),
+    SchemaIndexExtensionDescriptor(
+        table_name="session_profiles",
+        index_name="idx_session_profiles_enrichment_search_text_unbackfilled",
+        ddl=(
+            "CREATE INDEX IF NOT EXISTS idx_session_profiles_enrichment_search_text_unbackfilled "
+            "ON session_profiles(conversation_id) "
+            "WHERE TRIM(COALESCE(enrichment_search_text, '')) = ''"
+        ),
+    ),
     SchemaBackfillDescriptor(
         table_name="session_profiles",
         ddl="""

--- a/tests/unit/storage/test_backend.py
+++ b/tests/unit/storage/test_backend.py
@@ -218,6 +218,16 @@ def test_schema_extension_plan_expands_catalog_descriptors() -> None:
         "ALTER TABLE session_profiles ADD COLUMN evidence_search_text" in statement for statement in plan.statements
     )
     assert any("UPDATE session_profiles" in statement for statement in plan.statements)
+    # Partial indexes scoping each backfill UPDATE to unbackfilled rows.
+    assert any("idx_session_profiles_evidence_search_text_unbackfilled" in statement for statement in plan.statements)
+    assert any("idx_session_profiles_inference_search_text_unbackfilled" in statement for statement in plan.statements)
+    assert any("idx_session_profiles_enrichment_search_text_unbackfilled" in statement for statement in plan.statements)
+    # Indexes precede the matching UPDATE so the optimizer can use them on first run.
+    statements = list(plan.statements)
+    for column in ("evidence_search_text", "inference_search_text", "enrichment_search_text"):
+        index_position = next(i for i, s in enumerate(statements) if f"idx_session_profiles_{column}_unbackfilled" in s)
+        update_position = next(i for i, s in enumerate(statements) if "UPDATE session_profiles" in s and column in s)
+        assert index_position < update_position, f"{column}: index must be created before its backfill UPDATE"
     assert len(plan.scripts) == 5
 
 


### PR DESCRIPTION
## Summary

Scopes the three session_profiles backfill UPDATEs to partial indexes so repeated connection bootstraps drain an empty index instead of scanning the full table.

Closes #487.

## Problem

`schema_bootstrap.py` runs three `SchemaBackfillDescriptor` entries on every connection bootstrap when the schema is at the current version:

\`\`\`sql
UPDATE session_profiles SET evidence_search_text = search_text
WHERE TRIM(COALESCE(evidence_search_text, '')) = ''
\`\`\`

Same shape for `inference_search_text` and `enrichment_search_text`. The gating `WHERE TRIM(COALESCE(...)) = ''` made each idempotent, but the table scan ran every time — measurable startup latency on archives with millions of session profiles.

## Solution

Add a partial index per backfill, scoped to the exact same WHERE clause:

\`\`\`sql
CREATE INDEX IF NOT EXISTS idx_session_profiles_<col>_unbackfilled
ON session_profiles(conversation_id)
WHERE TRIM(COALESCE(<col>, '')) = ''
\`\`\`

SQLite uses the partial index when the query's WHERE matches the index's WHERE exactly. Verified with `EXPLAIN QUERY PLAN`:

\`\`\`
(5, 0, 214, 'SCAN session_profiles USING INDEX idx_unbackfilled')
\`\`\`

On the first bootstrap after this lands the optimizer hits the partial index (still cheaper than a full scan because we only index unbackfilled rows). On every subsequent bootstrap the index is empty (rows leave the partial index as soon as they're backfilled), so the UPDATE drains an empty index instead of touching the table.

The index descriptors are placed *before* the matching backfill descriptors in `_SCHEMA_EXTENSION_DESCRIPTORS` so the indexes exist on the same bootstrap that runs the first UPDATE. Test asserts the ordering invariant.

Considered but rejected: tracking backfill completion via `PRAGMA user_version` metadata or a status table. Both are more invasive (new persistence path, custom comparison logic) for a problem the existing partial-index machinery solves cleanly.

## Verification

\`\`\`
$ nix develop -c pytest -q tests/unit/storage/test_backend.py -x
30 passed in 70.28s

$ nix develop -c devtools verify --quick
verify: all checks passed
\`\`\`

Three pre-existing flakes in the full pytest run (`test_fts_search_budget`, `test_batch_insert_under_budget`, `test_cli_tail_list_json_exposes_tail_provenance`) all pass when re-run individually — order/budget sensitive, unrelated to this change.

EXPLAIN proof:

\`\`\`python
import sqlite3
con = sqlite3.connect(':memory:')
con.executescript('''
CREATE TABLE session_profiles (conversation_id TEXT PRIMARY KEY, search_text TEXT NOT NULL DEFAULT '', evidence_search_text TEXT NOT NULL DEFAULT '');
INSERT INTO session_profiles (conversation_id, search_text) VALUES ('a', 'foo'), ('b', 'bar'), ('c', 'baz');
UPDATE session_profiles SET evidence_search_text = 'done' WHERE conversation_id = 'a';
CREATE INDEX idx_unbackfilled ON session_profiles(conversation_id) WHERE TRIM(COALESCE(evidence_search_text, '')) = '';
''')
for row in con.execute("EXPLAIN QUERY PLAN UPDATE session_profiles SET evidence_search_text = search_text WHERE TRIM(COALESCE(evidence_search_text, '')) = ''"):
    print(row)
# (5, 0, 214, 'SCAN session_profiles USING INDEX idx_unbackfilled')
\`\`\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added partial database indexes on session search text fields (evidence, inference, enrichment).
  * Enhanced test coverage for schema extension planning and index statement ordering validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->