### PR TITLE
fix(error): narrow excepts, surface degradations, replace asserts/RuntimeError

### DIFF
--- a/polylogue/cli/helper_summary.py
+++ b/polylogue/cli/helper_summary.py
@@ -66,7 +66,7 @@ def print_summary_impl(
     try:
         archive_stats = run_coroutine_sync(env.repository.get_archive_stats())
     except Exception:
-        logger.debug("Archive stats computation failed", exc_info=True)
+        logger.warning("Archive stats computation failed; summary will omit stats", exc_info=True)
 
     lines = [
         f"Archive: {config.archive_root}",
@@ -184,7 +184,7 @@ def print_summary_impl(
                     ui.console.print()
 
     except Exception:
-        logger.debug("Analytics computation failed", exc_info=True)
+        logger.warning("Analytics computation failed; summary will omit analytics", exc_info=True)
 
 
 __all__ = ["print_summary_impl"]

--- a/polylogue/lib/query_retrieval_search.py
+++ b/polylogue/lib/query_retrieval_search.py
@@ -7,7 +7,10 @@ from heapq import heappush, heappushpop
 from typing import TYPE_CHECKING
 
 from polylogue.lib.query_support import provider_values
+from polylogue.logging import get_logger
 from polylogue.storage.search_providers.hybrid import reciprocal_rank_fusion
+
+logger = get_logger(__name__)
 
 if TYPE_CHECKING:
     from polylogue.lib.models import Conversation
@@ -121,7 +124,13 @@ async def search_action_results(
         return await search_action_results_fallback(plan, repository, limit=limit)
     try:
         return await repository.search_actions(query, limit=limit, providers=provider_names)
-    except Exception:
+    except Exception as exc:
+        logger.warning(
+            "action search failed; falling back to slower path",
+            error=str(exc),
+            error_type=type(exc).__name__,
+            query=query,
+        )
         return await search_action_results_fallback(plan, repository, limit=limit)
 
 
@@ -143,7 +152,13 @@ async def search_hybrid_results(
                 limit=limit * 3,
                 vector_provider=plan.vector_provider,
             )
-        except Exception:
+        except Exception as exc:
+            logger.warning(
+                "vector search failed; hybrid results will skip vector lane",
+                error=str(exc),
+                error_type=type(exc).__name__,
+                vector_provider=plan.vector_provider,
+            )
             vector_results = []
 
     text_ranked = [(str(conversation.id), float(rank)) for rank, conversation in enumerate(text_results, start=1)]

--- a/polylogue/lib/security.py
+++ b/polylogue/lib/security.py
@@ -27,7 +27,10 @@ def sanitize_path(v: str | None) -> str | None:
     # 2. Symlinks in path (potential traversal bypass)
     has_traversal = ".." in original_v
 
-    # Check for symlinks in the path by checking path components
+    # Check for symlinks in the path by checking path components.
+    # On any filesystem error (PermissionError, OSError) treat the path as
+    # suspicious — this guard sits in front of traversal protection and a
+    # silent skip would let unreadable directories mask a real attack.
     has_symlink = False
     try:
         p = Path(v)
@@ -35,28 +38,20 @@ def sanitize_path(v: str | None) -> str | None:
             if parent.is_symlink():
                 has_symlink = True
                 break
-    except Exception:
-        logger.warning("Error checking symlinks in path: %s", v)
+    except OSError as exc:
+        logger.warning("symlink check failed for path %r: %s; treating as suspicious", v, exc)
+        has_symlink = True
 
     # If traversal or symlinks were detected, hash to prevent re-assembly
     if has_traversal or has_symlink:
         import hashlib
 
         original_hash = hashlib.sha256(original_v.encode()).hexdigest()[:12]
-        v = f"_blocked_{original_hash}"
-    # For safe paths, clean up components but preserve absolute/relative structure
-    else:
-        try:
-            parts = []
-            for component in v.split("/"):
-                component = component.strip()
-                if component and component not in (".", ".."):
-                    parts.append(component)
-            if original_v.startswith("/"):
-                v = "/" + "/".join(parts) if parts else "/"
-            else:
-                v = "/".join(parts) if parts else v
-        except Exception:
-            logger.warning("Error cleaning path components: %s", v)
+        return f"_blocked_{original_hash}"
 
-    return v if v else None
+    # Safe path: clean up components but preserve absolute/relative structure
+    parts = [c.strip() for c in v.split("/") if c.strip() and c.strip() not in (".", "..")]
+    joined = "/".join(parts)
+    if original_v.startswith("/"):
+        return "/" + joined if parts else "/"
+    return joined or v or None

--- a/polylogue/operations/archive.py
+++ b/polylogue/operations/archive.py
@@ -43,6 +43,7 @@ from polylogue.archive_products import (
     WorkThreadProductQuery,
 )
 from polylogue.archive_resume import ResumeBrief, ResumeOperations, build_resume_brief
+from polylogue.config import ConfigError
 from polylogue.lib.content_projection import ContentProjectionSpec
 from polylogue.lib.conversation_models import ConversationSummary
 from polylogue.lib.pricing import CostUsagePayload, _normalize_model, estimate_conversation_cost, generated_at
@@ -939,7 +940,7 @@ class ArchiveOperations(
     def config(self) -> Config:
         if self._config is None:
             if self._services is None:
-                raise RuntimeError("ArchiveOperations requires config or runtime services")
+                raise ConfigError("ArchiveOperations requires config or runtime services")
             self._config = self._services.get_config()
         return self._config
 
@@ -947,7 +948,7 @@ class ArchiveOperations(
     def repository(self) -> ConversationRepository:
         if self._repository is None:
             if self._services is None:
-                raise RuntimeError("ArchiveOperations requires repository or runtime services")
+                raise ConfigError("ArchiveOperations requires repository or runtime services")
             self._repository = self._services.get_repository()
         return self._repository
 

--- a/polylogue/pipeline/services/parsing.py
+++ b/polylogue/pipeline/services/parsing.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from polylogue.errors import DatabaseError
 from polylogue.pipeline.services.parsing_models import (
     IngestPhase,
     IngestResult,
@@ -51,7 +52,7 @@ class ParsingService:
         """Return the repository backend or fail explicitly."""
         backend = self.repository.backend
         if backend is None:
-            raise RuntimeError("repository backend is not initialized")
+            raise DatabaseError("repository backend is not initialized")
         return backend
 
     async def parse_sources(

--- a/polylogue/pipeline/services/parsing_models.py
+++ b/polylogue/pipeline/services/parsing_models.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import TYPE_CHECKING
 
+from polylogue.errors import PolylogueError
 from polylogue.pipeline.payload_types import IngestDiagnostics, ParseBatchObservation
 
 if TYPE_CHECKING:
@@ -84,7 +85,7 @@ class IngestState:
 
     def _expect_phase(self, expected: IngestPhase, action: str) -> None:
         if self.phase != expected:
-            raise RuntimeError(f"Cannot {action}: expected phase {expected.value}, got {self.phase.value}")
+            raise PolylogueError(f"Cannot {action}: expected phase {expected.value}, got {self.phase.value}")
 
 
 class ParseResult:

--- a/polylogue/storage/raw_state_models.py
+++ b/polylogue/storage/raw_state_models.py
@@ -56,7 +56,8 @@ def _coerce_update_provider(value: Provider | str | None | _RawStateUnset) -> Pr
         return None
     if isinstance(value, Provider):
         return value
-    assert isinstance(value, str)
+    if not isinstance(value, str):
+        raise TypeError(f"expected str, got {type(value).__name__}")
     return Provider.from_string(value)
 
 
@@ -69,7 +70,8 @@ def _coerce_update_status(
         return None
     if isinstance(value, ValidationStatus):
         return value
-    assert isinstance(value, str)
+    if not isinstance(value, str):
+        raise TypeError(f"expected str, got {type(value).__name__}")
     return ValidationStatus.from_string(value)
 
 
@@ -80,7 +82,8 @@ def _coerce_update_mode(value: ValidationMode | str | None | _RawStateUnset) -> 
         return None
     if isinstance(value, ValidationMode):
         return value
-    assert isinstance(value, str)
+    if not isinstance(value, str):
+        raise TypeError(f"expected str, got {type(value).__name__}")
     return ValidationMode.from_string(value)
 
 

--- a/tests/unit/pipeline/test_parsing_service.py
+++ b/tests/unit/pipeline/test_parsing_service.py
@@ -12,6 +12,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from polylogue.config import Config, Source
+from polylogue.errors import DatabaseError
 from polylogue.lib.raw_payload_decode import JSONValue
 from polylogue.pipeline.payload_types import ParseBatchObservation
 from polylogue.pipeline.services.acquisition import AcquireResult, AcquisitionService
@@ -322,7 +323,7 @@ class TestParsingServiceParseSources:
         service = ParsingService(repository=mock_repository, archive_root=Path("/tmp/archive"), config=mock_config)
         source = Source(name="test-source", path=Path("/tmp/inbox"))
 
-        with pytest.raises(RuntimeError, match="backend is not initialized"):
+        with pytest.raises(DatabaseError, match="backend is not initialized"):
             await service.parse_sources([source])
 
 

--- a/tests/unit/pipeline/test_prepare.py
+++ b/tests/unit/pipeline/test_prepare.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 
+from polylogue.errors import PolylogueError
 from polylogue.paths.sanitize import is_within_root
 from polylogue.pipeline.prepare import RecordBundle, save_bundle
 from polylogue.rendering.renderers import HTMLRenderer
@@ -297,7 +298,7 @@ def test_ingest_state_rejects_out_of_order_transition() -> None:
     from polylogue.pipeline.services.parsing import IngestState
 
     state = IngestState(source_names=("inbox",), parse_requested=True)
-    with pytest.raises(RuntimeError, match="expected phase acquired"):
+    with pytest.raises(PolylogueError, match="expected phase acquired"):
         state.record_validation_candidates(["raw-1"])
 
 

--- a/tests/unit/security/test_path_sanitization.py
+++ b/tests/unit/security/test_path_sanitization.py
@@ -74,6 +74,17 @@ class TestSanitizePathTraversal:
     def test_none_returns_none(self) -> None:
         assert sanitize_path(None) is None
 
+    def test_symlink_check_oserror_treats_path_as_suspicious(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Filesystem errors during symlink probing must not silently bypass the guard."""
+
+        def _raise_permission_error(self: Path) -> bool:
+            raise PermissionError("simulated unreadable directory")
+
+        monkeypatch.setattr(Path, "is_symlink", _raise_permission_error)
+        result = sanitize_path("/some/safe/looking/path")
+        assert result is not None
+        assert result.startswith("_blocked_")
+
 
 # =============================================================================
 # FileTokenStore: key sanitization and permissions


### PR DESCRIPTION
## Summary

Partial fix for the audit listed in #479. Tackles security-critical, visibility-critical, and typed-exception items; defers diagnostics-of-diagnostics, benchmark runtime, observers, and remaining asserts to a follow-up so this PR stays focused.

Ref #479.

## Problem

The 2026-04-26 adversarial audit catalogued 9 distinct error-handling failure modes. Three categories most directly affect users today:

1. **Path sanitization can be bypassed.** `lib/security.py:38` caught `Exception` and silently set `has_symlink = False`. A `PermissionError` on an unreadable directory would defeat the symlink probe — exactly the case where a real traversal attack would benefit from masked detection.
2. **Search degradations are silent.** `lib/query_retrieval_search.py` fell back to slower paths and emptied vector results on any exception with zero log output.
3. **Top-level boundaries can't catch internal failures.** Four `raise RuntimeError(...)` and three `assert isinstance(...)` calls bypassed the `PolylogueError` hierarchy and would either escape `except PolylogueError` or vanish under `python -O`.

## Solution

### Security path (CRITICAL) — `polylogue/lib/security.py`

- `sanitize_path` symlink probe: narrow to `OSError`; on uncertainty set `has_symlink = True` so the path is hashed/blocked. Defense-in-depth: an unreadable parent directory is treated as suspicious rather than waved through.
- Removed the dead `try/except` around the path-cleaning loop (split/strip on a known string can't raise).
- New test `test_symlink_check_oserror_treats_path_as_suspicious` monkey-patches `Path.is_symlink` to raise `PermissionError` and asserts the result starts with `_blocked_`.

### Visible degradation — `polylogue/lib/query_retrieval_search.py`

- `search_action_results` and `search_hybrid_results` log at `WARNING` with `error`/`error_type` before falling back. The fallback behavior is unchanged; only operator visibility improves.

### Visible degradation — `polylogue/cli/helper_summary.py`

- Archive stats and analytics failures escalated from `logger.debug` → `logger.warning`. Operators searching logs for "missing data" now find an attribution.

### Typed exceptions (replace RuntimeError)

| File | Was | Now |
| --- | --- | --- |
| `operations/archive.py` × 2 | `RuntimeError("ArchiveOperations requires …")` | `ConfigError(…)` |
| `pipeline/services/parsing.py` | `RuntimeError("repository backend is not initialized")` | `DatabaseError(…)` |
| `pipeline/services/parsing_models.py` | `RuntimeError("Cannot {action}: expected phase {x}, got {y}")` | `PolylogueError(…)` |

All four are now catchable by `except PolylogueError` at CLI/MCP boundaries.

### Replace `assert` with explicit type checks — `polylogue/storage/raw_state_models.py`

Three `assert isinstance(value, str)` instances after exhaustive type narrowing replaced with `if not isinstance(value, str): raise TypeError(...)`. Asserts vanish under `python -O`, so the original code would have silently fed the wrong type to `Provider.from_string` (etc.) and produced a downstream `AttributeError`.

### Test fixtures updated

- `tests/unit/pipeline/test_parsing_service.py`: expect `DatabaseError`.
- `tests/unit/pipeline/test_prepare.py`: expect `PolylogueError`.
- `tests/unit/security/test_path_sanitization.py`: new uncertainty-as-block test.

### Deferred (will track on #479 if not split into siblings)

- `lib/query_miss_diagnostics.py` (4 bare excepts in diagnostic-of-diagnostic paths)
- `devtools/synthetic_benchmark_runtime.py` (6 bare excepts; devtools-only)
- `pipeline/observers.py` (already logs warning; lower priority)
- `pipeline/services/ingest_batch.py:1242` (already returns `failed: True` marker; caller-side change)
- `cli/query_stats.py` and `pipeline/services/ingest_worker.py` asserts (mypy narrowing only; next line would `AttributeError` immediately if the assert vanished)

## Verification

```
$ nix develop -c devtools verify --quick
verify: all checks passed

$ nix develop -c pytest -q tests/ --ignore=tests/integration
5595 passed, 10 xfailed in 181.43s
```