### PR TITLE
fix(security): pin webhook IP to close DNS rebinding; NFC-normalize path components

### DIFF
--- a/polylogue/paths/sanitize.py
+++ b/polylogue/paths/sanitize.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import re
+import unicodedata
 from hashlib import sha256
 from pathlib import Path
 
@@ -11,10 +12,16 @@ _SAFE_PATH_COMPONENT_RE = re.compile(r"[^A-Za-z0-9._-]")
 
 
 def safe_path_component(raw: object | None, *, fallback: str = "item") -> str:
-    """Return a filesystem-safe path component derived from raw input."""
+    """Return a filesystem-safe path component derived from raw input.
+
+    Input is NFC-normalized before sanitization so that visually-confusable
+    Unicode codepoints (e.g., NFKC-equivalent or compatibility-decomposed
+    forms) collapse to a stable canonical form before the ASCII allowlist
+    rewrites everything else to underscore-plus-digest.
+    """
     if raw is None:
         raw = ""
-    value = str(raw).strip()
+    value = unicodedata.normalize("NFC", str(raw)).strip()
     if not value:
         value = fallback
     has_sep = any(sep in value for sep in (os.sep, os.altsep) if sep)

--- a/polylogue/pipeline/observers.py
+++ b/polylogue/pipeline/observers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import http.client
 import ipaddress
 import re
 import shlex
@@ -95,20 +96,21 @@ class NotificationObserver(RunObserver):
             pass
 
 
-def _validate_webhook_url(url: str) -> None:
-    """Validate a webhook URL for SSRF protection."""
-    parsed = urlparse(url)
+def _resolve_and_validate(hostname: str, port: int) -> str:
+    """Resolve hostname and return the validated IP address.
 
-    if parsed.scheme not in ("http", "https"):
-        raise ValueError(f"Webhook URL must use http or https scheme, got: {parsed.scheme!r}")
-    if not parsed.hostname:
-        raise ValueError("Webhook URL must have a hostname")
-
-    hostname = parsed.hostname
+    All resolved addresses are checked against the SSRF denylist (private,
+    loopback, link-local, reserved). The returned IP is what the actual
+    connection will use, closing the DNS-rebinding TOCTOU window between
+    validation and connect.
+    """
     try:
-        addr_infos = socket.getaddrinfo(hostname, parsed.port or 443, proto=socket.IPPROTO_TCP)
+        addr_infos = socket.getaddrinfo(hostname, port, proto=socket.IPPROTO_TCP)
     except socket.gaierror as exc:
         raise ValueError(f"Cannot resolve webhook hostname {hostname!r}: {exc}") from exc
+
+    if not addr_infos:
+        raise ValueError(f"Cannot resolve webhook hostname {hostname!r}: no addresses")
 
     for _family, _type, _proto, _canonname, sockaddr in addr_infos:
         ip = ipaddress.ip_address(sockaddr[0])
@@ -118,39 +120,78 @@ def _validate_webhook_url(url: str) -> None:
                 f"(hostname: {hostname!r}). This is blocked for SSRF protection."
             )
 
+    # Use the first resolved address — same one we'd pin the connection to.
+    address = addr_infos[0][4][0]
+    return str(address)
 
-def _webhook_request_target(url: str) -> tuple[str, str, int, str]:
-    _validate_webhook_url(url)
+
+def _validate_webhook_url(url: str) -> None:
+    """Validate a webhook URL for SSRF protection (URL form + DNS resolution)."""
     parsed = urlparse(url)
+
+    if parsed.scheme not in ("http", "https"):
+        raise ValueError(f"Webhook URL must use http or https scheme, got: {parsed.scheme!r}")
+    if not parsed.hostname:
+        raise ValueError("Webhook URL must have a hostname")
+
+    _resolve_and_validate(parsed.hostname, parsed.port or (443 if parsed.scheme == "https" else 80))
+
+
+def _webhook_request_target(url: str) -> tuple[str, str, str, int, str]:
+    """Validate URL and return ``(scheme, hostname, validated_ip, port, path)``."""
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise ValueError(f"Webhook URL must use http or https scheme, got: {parsed.scheme!r}")
     if parsed.hostname is None:
         raise ValueError("Webhook URL must have a hostname")
     default_port = 443 if parsed.scheme == "https" else 80
+    port = parsed.port or default_port
+    validated_ip = _resolve_and_validate(parsed.hostname, port)
     path = parsed.path or "/"
     if parsed.query:
         path = f"{path}?{parsed.query}"
-    return parsed.scheme, parsed.hostname, parsed.port or default_port, path
+    return parsed.scheme, parsed.hostname, validated_ip, port, path
+
+
+class _PinnedHTTPSConnection(http.client.HTTPSConnection):
+    """HTTPSConnection that connects to a validated IP while keeping SNI/cert on the hostname.
+
+    Closes the DNS-rebinding window: ``_resolve_and_validate`` resolves the
+    hostname once, validates against the SSRF denylist, and the connection
+    is made directly to that IP rather than re-resolving at connect time.
+    SNI/cert verification still uses the original hostname.
+    """
+
+    def __init__(self, hostname: str, ip: str, *, port: int, timeout: float, context: ssl.SSLContext) -> None:
+        super().__init__(hostname, port=port, timeout=timeout, context=context)
+        self._validated_ip = ip
+        self._pinned_context = context
+
+    def connect(self) -> None:
+        sock = socket.create_connection((self._validated_ip, self.port), timeout=self.timeout)
+        self.sock = self._pinned_context.wrap_socket(sock, server_hostname=self.host)
 
 
 def _post_webhook(url: str, data: bytes) -> None:
-    import http.client
-
-    scheme, host, port, path = _webhook_request_target(url)
+    scheme, hostname, validated_ip, port, path = _webhook_request_target(url)
+    connection: http.client.HTTPConnection
     if scheme == "https":
-        connection: http.client.HTTPConnection = http.client.HTTPSConnection(
-            host,
+        connection = _PinnedHTTPSConnection(
+            hostname,
+            validated_ip,
             port=port,
             timeout=10,
             context=ssl.create_default_context(),
         )
     else:
-        connection = http.client.HTTPConnection(host, port=port, timeout=10)
+        connection = http.client.HTTPConnection(validated_ip, port=port, timeout=10)
     try:
-        connection.request(
-            "POST",
-            path,
-            body=data,
-            headers={"Content-Type": "application/json"},
-        )
+        headers = {"Content-Type": "application/json"}
+        if scheme == "http":
+            # Plain HTTP connects to validated IP; restore Host header so the
+            # server routes correctly when name-based virtual-hosted.
+            headers["Host"] = hostname if port in (80, 443) else f"{hostname}:{port}"
+        connection.request("POST", path, body=data, headers=headers)
         response = connection.getresponse()
         response.read()
     finally:

--- a/tests/unit/core/test_paths.py
+++ b/tests/unit/core/test_paths.py
@@ -66,6 +66,17 @@ class TestSafePathComponent:
         result = safe_path_component("café")
         assert "-" in result
 
+    def test_unicode_nfc_normalization_collapses_confusables(self) -> None:
+        """NFC normalization collapses decomposed equivalents to one stable form.
+
+        ``café`` written as NFC ("é" U+00E9) and as NFD ("e" + U+0301) must
+        produce the same sanitized output, so a confusable/decomposed input
+        cannot bypass an existing path by hashing to a different prefix.
+        """
+        precomposed = "caf\u00e9"  # café (NFC)
+        decomposed = "cafe\u0301"  # café (NFD: e + combining acute)
+        assert safe_path_component(precomposed) == safe_path_component(decomposed)
+
     def test_deterministic(self) -> None:
         """Same input always produces same output."""
         r1 = safe_path_component("hello world")

--- a/tests/unit/pipeline/test_observers_runtime.py
+++ b/tests/unit/pipeline/test_observers_runtime.py
@@ -69,35 +69,42 @@ def test_notification_observer_covers_changed_only_and_idle_paths() -> None:
 
 
 def test_webhook_request_target_and_post_webhook_cover_http_https_and_hostname_errors() -> None:
-    with patch("polylogue.pipeline.observers._validate_webhook_url") as validate:
-        scheme, host, port, path = observers_module._webhook_request_target("https://example.com/hook?x=1")
+    public_ip = "93.184.216.34"
+    with patch("polylogue.pipeline.observers.socket.getaddrinfo", return_value=[(2, 1, 6, "", (public_ip, 443))]):
+        scheme, host, validated_ip, port, path = observers_module._webhook_request_target(
+            "https://example.com/hook?x=1"
+        )
 
-    validate.assert_called_once_with("https://example.com/hook?x=1")
-    assert (scheme, host, port, path) == ("https", "example.com", 443, "/hook?x=1")
+    assert (scheme, host, validated_ip, port, path) == ("https", "example.com", public_ip, 443, "/hook?x=1")
 
-    with patch("polylogue.pipeline.observers._validate_webhook_url"):
-        try:
-            observers_module._webhook_request_target("http:///missing-host")
-        except ValueError as exc:
-            assert "hostname" in str(exc)
-        else:
-            raise AssertionError("expected ValueError for missing hostname")
+    try:
+        observers_module._webhook_request_target("http:///missing-host")
+    except ValueError as exc:
+        assert "hostname" in str(exc)
+    else:
+        raise AssertionError("expected ValueError for missing hostname")
 
     response = MagicMock()
     http_connection = MagicMock()
     http_connection.getresponse.return_value = response
-    https_connection = MagicMock()
-    https_connection.getresponse.return_value = response
-    with patch("http.client.HTTPConnection", return_value=http_connection):
-        observers_module._post_webhook("http://example.com/hook", b"{}")
+    pinned_https = MagicMock()
+    pinned_https.getresponse.return_value = response
+
+    with patch("polylogue.pipeline.observers.socket.getaddrinfo", return_value=[(2, 1, 6, "", (public_ip, 80))]):
+        with patch("polylogue.pipeline.observers.http.client.HTTPConnection", return_value=http_connection):
+            observers_module._post_webhook("http://example.com/hook", b"{}")
     http_connection.request.assert_called_once()
+    # HTTP path connects to the validated IP and restores the Host header.
+    request_kwargs = http_connection.request.call_args.kwargs
+    assert request_kwargs["headers"]["Host"] == "example.com"
     http_connection.close.assert_called_once()
 
-    with patch("http.client.HTTPSConnection", return_value=https_connection):
-        with patch("ssl.create_default_context", return_value="ctx"):
-            observers_module._post_webhook("https://example.com/hook", b"{}")
-    https_connection.request.assert_called_once()
-    https_connection.close.assert_called_once()
+    with patch("polylogue.pipeline.observers.socket.getaddrinfo", return_value=[(2, 1, 6, "", (public_ip, 443))]):
+        with patch("polylogue.pipeline.observers._PinnedHTTPSConnection", return_value=pinned_https):
+            with patch("polylogue.pipeline.observers.ssl.create_default_context", return_value="ctx"):
+                observers_module._post_webhook("https://example.com/hook", b"{}")
+    pinned_https.request.assert_called_once()
+    pinned_https.close.assert_called_once()
 
 
 def test_validate_webhook_url_rejects_bad_scheme_host_resolution_and_private_ips() -> None:


### PR DESCRIPTION
## Summary

Closes #480.

Three of the five sub-issues in #480 (blob file permissions, db file permissions, site manifest absolute-path leak) were already resolved on master by the audit-fix wave that landed via #504. This PR addresses the two real outstanding items.

## Problem

### DNS rebinding on webhook delivery

`polylogue/pipeline/observers.py:_validate_webhook_url` resolved the hostname against the SSRF denylist, but `_post_webhook` handed the *hostname* back to `http.client.HTTPSConnection`, which re-resolves at connect time. An attacker controlling a short-TTL DNS record could resolve to a public address during validation and to `127.0.0.1` (or any private RFC-1918 address) during the actual connection. Validation runs in microseconds; connection establishment is far slower; the rebinding window is real.

### Unicode confusable bypass in path sanitization

`polylogue/paths/sanitize.py:safe_path_component` ran an ASCII-only allowlist regex but never normalized the input. `café` written as NFC (`é` U+00E9) and `café` written as NFD (`e` + U+0301) hashed to different prefixes, so two visually-identical inputs landed at two different filesystem paths.

## Solution

### IP-pinned webhook delivery

- `_resolve_and_validate` returns the validated IP from the same `getaddrinfo` call that runs the SSRF check.
- `_webhook_request_target` returns `(scheme, hostname, validated_ip, port, path)` — the caller now has both hostname (for SNI/cert verification) and IP (for the actual socket).
- `_PinnedHTTPSConnection` subclasses `http.client.HTTPSConnection` and overrides `connect()` to `socket.create_connection` against the validated IP, then wraps with TLS using `server_hostname=hostname` so cert verification still binds to the original hostname.
- HTTP path connects to the validated IP and sets the `Host` header back to the original hostname (otherwise virtual-hosted servers fail to route).

### NFC normalization for path components

`safe_path_component` calls `unicodedata.normalize("NFC", ...)` before the allowlist regex runs. The ASCII allowlist still flattens everything else to `prefix-digest`; normalization just stabilizes the digest across decomposed forms.

## Verification

```
$ nix develop -c devtools verify --quick
verify: all checks passed

$ nix develop -c pytest -q tests/unit/pipeline/test_observers_runtime.py tests/unit/core/test_paths.py tests/unit/security/
136 passed in 10.49s

$ nix develop -c pytest -q tests/ --ignore=tests/integration
5595 passed, 10 xfailed in 176.75s
```

New tests:
- `test_unicode_nfc_normalization_collapses_confusables` — `safe_path_component(NFC) == safe_path_component(NFD)` for `café`.
- `test_webhook_request_target_and_post_webhook_cover_http_https_and_hostname_errors` updated for the new 5-tuple shape and to assert the HTTP path restores the `Host` header on the IP-pinned connection.

## Already resolved (no change needed)

| #480 sub-item | Status on master |
| --- | --- |
| `storage/blob_store.py` blob file permissions | Already `os.chmod(0o600)` at line 98 + line 149 |
| `storage/backends/connection.py` db permissions | Already `os.chmod(0o600)` at line 92 |
| `site/publication_flow.py` manifest path leak | Already serializes `output_dir="."` (line 215), not the absolute path |

The token-store note (configurable Drive credential path) is documentation of existing behavior, not a defect — token files themselves are written `0o600` (`token_store.py:73`).