### PR TITLE
fix(schema+config): validate Config paths, raise on invalid privacy level, dedup XDG state

### DIFF
--- a/polylogue/cli/helper_source_state.py
+++ b/polylogue/cli/helper_source_state.py
@@ -3,14 +3,13 @@
 from __future__ import annotations
 
 import json
-import os
 from pathlib import Path
+
+from polylogue.paths import state_home
 
 
 def source_state_path() -> Path:
-    raw_state_root = os.environ.get("XDG_STATE_HOME")
-    state_root = Path(raw_state_root).expanduser() if raw_state_root else Path.home() / ".local/state"
-    return state_root / "polylogue" / "last-source.json"
+    return state_home() / "last-source.json"
 
 
 def load_last_source() -> str | None:

--- a/polylogue/config.py
+++ b/polylogue/config.py
@@ -86,6 +86,17 @@ class Config:
     drive_config: DriveConfig | None = None
     index_config: IndexConfig | None = None
 
+    def __post_init__(self) -> None:
+        # Paths must be absolute. Relative paths are interpreted against the
+        # caller's CWD and silently change meaning across processes (CLI vs
+        # service vs MCP server). Catch the misuse at construction.
+        for attr in ("archive_root", "render_root", "db_path"):
+            value = getattr(self, attr)
+            if not isinstance(value, Path):
+                raise ConfigError(f"Config.{attr} must be a Path, got {type(value).__name__}")
+            if not value.is_absolute():
+                raise ConfigError(f"Config.{attr} must be an absolute path, got {value!r}")
+
 
 def get_sources() -> list[Source]:
     """Return the configured conversation sources."""

--- a/polylogue/schemas/privacy_config.py
+++ b/polylogue/schemas/privacy_config.py
@@ -216,13 +216,11 @@ def _merge_into(
 
 
 def _privacy_level_value(value: PrivacySettingValue) -> PrivacyLevel:
-    if value == "strict":
-        return "strict"
-    if value == "standard":
+    if value is None:
         return "standard"
-    if value == "permissive":
-        return "permissive"
-    return "standard"
+    if value in ("strict", "standard", "permissive"):
+        return value  # type: ignore[return-value]
+    raise ValueError(f"Invalid privacy level {value!r}; expected one of: strict, standard, permissive")
 
 
 def _int_config_value(value: PrivacySettingValue, *, default: int) -> int:

--- a/tests/unit/core/test_config.py
+++ b/tests/unit/core/test_config.py
@@ -79,6 +79,32 @@ class TestConfig:
         assert config.drive_config is None
         assert config.index_config is None
 
+    def test_config_rejects_relative_archive_root(self, tmp_path: Path) -> None:
+        """Relative paths silently shift meaning across processes; reject at construction."""
+        with pytest.raises(ConfigError, match="archive_root must be an absolute path"):
+            Config(
+                archive_root=Path("relative/archive"),
+                render_root=tmp_path / "render",
+                sources=[],
+            )
+
+    def test_config_rejects_relative_render_root(self, tmp_path: Path) -> None:
+        with pytest.raises(ConfigError, match="render_root must be an absolute path"):
+            Config(
+                archive_root=tmp_path,
+                render_root=Path("relative/render"),
+                sources=[],
+            )
+
+    def test_config_rejects_relative_db_path(self, tmp_path: Path) -> None:
+        with pytest.raises(ConfigError, match="db_path must be an absolute path"):
+            Config(
+                archive_root=tmp_path,
+                render_root=tmp_path / "render",
+                sources=[],
+                db_path=Path("relative/db.sqlite"),
+            )
+
 
 class TestConfigError:
     """Tests for ConfigError exception."""

--- a/tests/unit/core/test_privacy_config.py
+++ b/tests/unit/core/test_privacy_config.py
@@ -10,7 +10,20 @@ from pathlib import Path
 
 import pytest
 
-from polylogue.schemas.privacy_config import PrivacyConfig, load_privacy_config
+from polylogue.schemas.privacy_config import PrivacyConfig, _privacy_level_value, load_privacy_config
+
+
+def test_privacy_level_value_rejects_unknown_level() -> None:
+    """Invalid privacy level must raise rather than silently fall back to standard."""
+    with pytest.raises(ValueError, match="Invalid privacy level"):
+        _privacy_level_value("paranoid")
+
+
+def test_privacy_level_value_passes_through_known_levels() -> None:
+    assert _privacy_level_value("strict") == "strict"
+    assert _privacy_level_value("standard") == "standard"
+    assert _privacy_level_value("permissive") == "permissive"
+    assert _privacy_level_value(None) == "standard"
 
 
 class TestPrivacyConfigPresets:


### PR DESCRIPTION
## Summary

Closes #481.

Four of the six items in #481 were already resolved on master in earlier audit-fix waves (likely #504 and predecessors). This PR addresses the two real outstanding defects plus tightens \`Config\` construction.

## Problem

| Sub-item | Status |
| --- | --- |
| \`name\` not in content field denylist | Already fixed (\`schemas/privacy.py:97\` includes \`name\`, \`body\`, \`message\`, \`input\`, \`output\`) |
| \`max_length=0\` treated as falsy | Already fixed (\`schemas/privacy.py:220\`: \`max_length if max_length is not None else _SAFE_ENUM_MAX_LEN\`) |
| \`POLYLOGUE_FORCE_PLAIN\` color suppression | Already fixed (\`logging.py:151\`: \`colors=sys.stderr.isatty() and not force_plain\`) |
| \`privacy_config.py\` XDG path duplication | Already fixed (uses \`config_root()\` from \`polylogue.paths\`) |
| \`helper_source_state.py\` XDG path duplication | **Outstanding** — duplicates the \`XDG_STATE_HOME\` fallback inline; if \`_roots.py\` changes, it diverges silently |
| \`Config\` accepts invalid paths; \`PrivacyConfig\` swallows invalid level | **Outstanding** — relative paths and typo'd levels both succeed silently |

## Solution

### XDG state path duplication

\`polylogue/cli/helper_source_state.py:source_state_path\` reimplemented the \`XDG_STATE_HOME\` fallback inline. Replace with \`state_home()\` from \`polylogue.paths\` so the fallback stays single-source.

### Silent fallback on invalid privacy level

\`_privacy_level_value\` returned \`"standard"\` for any unrecognized input — a typo in TOML or a CLI flag silently mapped to "standard". Raise \`ValueError\` on unknown levels; preserve the explicit \`None → "standard"\` default.

### \`Config\` path validation

\`Config\` dataclass had no post-init validation. Relative paths silently shift meaning across processes (CLI from \`\$PWD\` vs MCP server vs systemd unit) — different archive locations for the same nominal \`Config(...)\`. Add \`__post_init__\` requiring \`archive_root\`, \`render_root\`, and \`db_path\` to be absolute \`Path\`s; raise \`ConfigError\` otherwise.

## Verification

\`\`\`
$ nix develop -c devtools verify --quick
verify: all checks passed

$ nix develop -c pytest -q tests/unit/core/test_config.py tests/unit/core/test_privacy_config.py
58 passed in 8.72s

$ nix develop -c pytest -q tests/ --ignore=tests/integration
5595 passed, 10 xfailed
\`\`\`

New tests:
- \`test_privacy_level_value_rejects_unknown_level\` + positive cases for known levels including \`None\`.
- \`test_config_rejects_relative_{archive_root,render_root,db_path}\`.