### PR TITLE
perf(storage): add expression index covering EFFECTIVE_RAW_PROVIDER_SQL

### DIFF
--- a/polylogue/storage/backends/schema_bootstrap.py
+++ b/polylogue/storage/backends/schema_bootstrap.py
@@ -189,6 +189,17 @@ _SCHEMA_EXTENSION_DESCRIPTORS: tuple[SchemaExtensionDescriptor, ...] = (
         ddl=_RAW_SOURCE_MTIME_INDEX_SQL,
         replace_on_drift=True,
     ),
+    # Expression index covering EFFECTIVE_RAW_PROVIDER_SQL. Without it, every
+    # raw provider-filter query becomes a full table scan because COALESCE
+    # cannot use idx_raw_conv_provider or idx_raw_conv_payload_provider.
+    SchemaIndexExtensionDescriptor(
+        table_name="raw_conversations",
+        index_name="idx_raw_conv_effective_provider",
+        ddl=(
+            "CREATE INDEX IF NOT EXISTS idx_raw_conv_effective_provider "
+            "ON raw_conversations(COALESCE(payload_provider, provider_name))"
+        ),
+    ),
     SchemaIndexExtensionDescriptor(
         table_name="content_blocks",
         index_name="idx_content_blocks_tool_use_conversation",

--- a/tests/unit/storage/test_backend.py
+++ b/tests/unit/storage/test_backend.py
@@ -190,6 +190,7 @@ def test_schema_extension_catalog_declares_snapshot_scope() -> None:
     assert {"raw_conversations", "attachments", "session_profiles", "session_phases"}.issubset(table_names)
     assert {
         "idx_raw_conv_source_mtime",
+        "idx_raw_conv_effective_provider",
         "idx_content_blocks_tool_use_conversation",
         "idx_attachments_provider_meta_file_id",
         "idx_attachment_refs_provider_meta_drive_id",
@@ -214,6 +215,7 @@ def test_schema_extension_plan_expands_catalog_descriptors() -> None:
     assert "ALTER TABLE raw_conversations ADD COLUMN blob_size INTEGER NOT NULL DEFAULT 0" in plan.statements
     assert any("idx_content_blocks_tool_use_conversation" in statement for statement in plan.statements)
     assert any("idx_attachments_provider_meta_id" in statement for statement in plan.statements)
+    assert any("idx_raw_conv_effective_provider" in statement for statement in plan.statements)
     assert any(
         "ALTER TABLE session_profiles ADD COLUMN evidence_search_text" in statement for statement in plan.statements
     )


### PR DESCRIPTION
## Summary

Closes #485.

## Problem

\`raw_state.py\` defines:

\`\`\`python
EFFECTIVE_RAW_PROVIDER_SQL = "COALESCE(payload_provider, provider_name)"
\`\`\`

Used in 7+ WHERE clauses across \`raw_reads.py\`, \`raw_state.py\`, \`iter_raw_conversations\`, and \`artifact_queries\`. Because the expression is \`COALESCE\`, SQLite couldn't use either single-column index (\`idx_raw_conv_provider\` on \`provider_name\` or the partial \`idx_raw_conv_payload_provider\` on \`payload_provider\`). Every provider-filtered raw query was a full \`raw_conversations\` table scan.

## Solution

Add a SQLite **expression index** keyed on the same COALESCE expression. The optimizer picks it whenever a query's WHERE matches the expression literally:

\`\`\`
$ EXPLAIN QUERY PLAN
    SELECT * FROM raw_conversations
     WHERE COALESCE(payload_provider, provider_name) = 'chatgpt';

SEARCH raw_conversations USING INDEX idx_raw_conv_effective_provider (<expr>=?)
\`\`\`

The descriptor is a \`SchemaIndexExtensionDescriptor\` — no \`SCHEMA_VERSION\` bump, no schema migration. Existing databases pick the index up on the next connection bootstrap.

## Verification

\`\`\`
$ nix develop -c devtools verify --quick
verify: all checks passed

$ nix develop -c pytest -q tests/unit/storage/test_backend.py
30 passed in 80.13s
\`\`\`

EXPLAIN proof inline (run against the in-memory schema with the descriptor applied):

\`\`\`python
import sqlite3
con = sqlite3.connect(':memory:')
con.executescript('''
CREATE TABLE raw_conversations (
    raw_id TEXT PRIMARY KEY, provider_name TEXT NOT NULL,
    payload_provider TEXT, acquired_at TEXT
);
INSERT INTO raw_conversations VALUES ('a', 'chatgpt', NULL, '2026-01-01');
CREATE INDEX idx_effective_provider ON raw_conversations(COALESCE(payload_provider, provider_name));
''')
for row in con.execute("EXPLAIN QUERY PLAN SELECT * FROM raw_conversations WHERE COALESCE(payload_provider, provider_name) = 'chatgpt'"):
    print(row)
# (3, 0, 61, 'SEARCH raw_conversations USING INDEX idx_effective_provider (<expr>=?)')
\`\`\`