### PR TITLE
fix(storage): raise on unknown get_stats_by group_by; close #476

### DIFF
--- a/polylogue/storage/backends/queries/stats.py
+++ b/polylogue/storage/backends/queries/stats.py
@@ -220,7 +220,13 @@ async def upsert_conversation_stats(
 
 
 async def get_stats_by(conn: aiosqlite.Connection, group_by: str = "provider") -> dict[str, int]:
-    """Get conversation counts grouped by provider, month, or year."""
+    """Get conversation counts grouped by provider, month, or year.
+
+    Raises ValueError on unknown ``group_by`` rather than silently returning
+    provider counts. Each branch is a literal SQL constant — the validated
+    input never reaches string interpolation — but the explicit reject closes
+    the door on future branches that might.
+    """
     if group_by == "month":
         cursor = await conn.execute(
             """
@@ -239,7 +245,7 @@ async def get_stats_by(conn: aiosqlite.Connection, group_by: str = "provider") -
             GROUP BY period ORDER BY period DESC
             """
         )
-    else:
+    elif group_by == "provider":
         cursor = await conn.execute(
             """
             SELECT provider_name as period, COUNT(*) as count
@@ -247,6 +253,8 @@ async def get_stats_by(conn: aiosqlite.Connection, group_by: str = "provider") -
             GROUP BY provider_name ORDER BY count DESC
             """
         )
+    else:
+        raise ValueError(f"Unknown group_by {group_by!r}; expected one of: provider, month, year")
     rows = await cursor.fetchall()
     return {row["period"]: row["count"] for row in rows}
 


### PR DESCRIPTION
## Summary

Closes #476. Three of the five sub-issues are already resolved on master; one defense-in-depth tightening remaining.

## Problem

#476 catalogued five MCP/storage surface issues. Three are already fixed on master:

| Sub-item | Status |
| --- | --- |
| \`_clamp_limit\` had no upper bound | Already capped at \`min(limit, 1000)\` (\`mcp/server_support.py:87\`) |
| \`resolve_id\` prefix-matched on destructive ops | Already exposes \`strict: bool = False\`; every MCP destructive call site (\`server_mutation_tools.py\`: \`add_tag\`, \`remove_tag\`, \`set_meta\`, \`delete_conversation\`, …) already passes \`strict=True\` |
| \`get_stats_by\` user string with fragile whitelist | MCP wrapper already declares \`group_by: Literal["provider", "month", "year"]\` (\`server_tools.py:214\`); deeper layer still accepts \`str\` and silently falls back |

Two remaining items are larger refactors and tracked separately:
- Asymmetric \`search\`/\`list_conversations\` filter surfaces (calls for unifying the tools or extending parameter sets — design choice).
- \`bulk_tag_conversations\` O(N×M) in separate transactions (needs batched single-transaction implementation with a size limit).

## Solution

Tighten the deeper \`get_stats_by\` (\`storage/backends/queries/stats.py\`) to raise \`ValueError\` on unknown \`group_by\` instead of silently falling back to provider grouping. Each SQL branch is a literal — no interpolation — but a future contributor adding a branch that *does* interpolate would inherit a silent fallback as their input validation. Closing the door on that.

## Verification

\`\`\`
$ nix develop -c devtools verify --quick
verify: all checks passed

$ nix develop -c pytest -q tests/ --ignore=tests/integration
5596 passed, 10 xfailed in 160.24s
\`\`\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced parameter validation to provide explicit error messages for invalid inputs instead of silently defaulting to alternative behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->