### PR TITLE
chore(release): add CHANGELOG, release checklist, PR-template changelog hint

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,6 +14,10 @@ _What was done. Key modules, contracts, and boundaries touched._
 
 _Exact commands run and any manual validation performed._
 
+## Changelog
+
+_If user-visible (new flags, renamed/removed commands, output changes, breaking migrations, security fixes), add a one-line entry to the `Unreleased` section of `CHANGELOG.md`. Skip for refactors, internal renames, and test-only PRs._
+
 ## Risks and Follow-ups
 
 _Remaining risks, migrations, rollout concerns, or deferred work. Delete this section if none._

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,69 @@
+# Changelog
+
+All notable user-visible changes to Polylogue are recorded in this file.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+User-visible: anything an operator running `polylogue` would notice — new
+flags, removed or renamed commands, output changes, breaking schema
+migrations, security fixes. Internal refactors, test additions, and
+documentation polish do not require an entry.
+
+## [Unreleased]
+
+### Security
+
+- Webhook delivery now connects to the IP validated against the SSRF
+  denylist rather than re-resolving the hostname, closing a DNS-rebinding
+  TOCTOU window. Hostname is preserved for SNI/cert verification.
+- Path sanitization (`safe_path_component`) NFC-normalizes input before
+  applying the ASCII allowlist; visually-identical NFC and NFD forms now
+  hash to the same path.
+- `pip-audit` runs in CI on every PR that touches `pyproject.toml` or
+  `uv.lock`, on master pushes, and weekly. Bumped four CVE-affected deps
+  (`pygments`, `pytest`, `cryptography`, `python-multipart`) and pinned
+  the latter two as direct constraints.
+
+### Added
+
+- `dependabot.yml` for weekly Python and GitHub Actions updates with
+  patch grouping.
+- `actionlint` workflow validating workflow YAML on PRs that touch
+  `.github/`.
+- Expression index `idx_raw_conv_effective_provider` so raw-conversation
+  provider-filter queries no longer scan the full table.
+- Partial indexes scoped to the gating `WHERE` of each `session_profiles`
+  search-text backfill, so repeated bootstraps drain an empty index
+  instead of scanning the table.
+
+### Changed
+
+- `Config` rejects relative `archive_root`, `render_root`, or `db_path`
+  with `ConfigError` at construction.
+- `_privacy_level_value` raises `ValueError` on unknown level strings
+  instead of silently returning `"standard"`.
+- `get_stats_by` raises `ValueError` on unknown `group_by` instead of
+  silently falling back to provider grouping.
+- Top-level boundary-catchable errors: `ArchiveOperations` config/repository
+  init, parsing-service backend uninitialized, and parser state-machine
+  phase violations now raise from the `PolylogueError` hierarchy
+  (previously `RuntimeError`).
+- Search-path degradation visibility: `search_action_results`,
+  `search_hybrid_results`, and `helper_summary` log at `WARNING` (not
+  `DEBUG`) when falling back from a failed primary path.
+
+### Fixed
+
+- `sanitize_path` symlink probe narrowed to `OSError` and treats
+  uncertainty as suspicious (previously a `PermissionError` on an
+  unreadable directory could mask a traversal attempt).
+- `_clamp_limit` already enforced an upper bound (1000); confirmed
+  resolved.
+- `resolve_id` already supports `strict=True` and every MCP destructive
+  call site already uses it; confirmed resolved.
+
+## [0.1.0] — Unreleased
+
+Initial development snapshot. Versioned releases begin once the install
+path lands (#416).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,9 +96,17 @@ hash plus the dirty marker when applicable.
 Routine PRs do not touch `version = "X.Y.Z"`. Change it only when this exact
 slice is cutting the matching `vX.Y.Z` tag.
 
-The release procedure is:
+User-visible changes (new flags, renamed or removed commands, output changes,
+breaking migrations, security fixes) get a one-line entry in the `Unreleased`
+section of [CHANGELOG.md](CHANGELOG.md) as part of the PR. Refactors and
+test-only changes are exempt.
 
-1. Update `pyproject.toml` to `X.Y.Z`.
+See [docs/release.md](docs/release.md) for the cut-time checklist
+(pre-flight checks, the `Unreleased → [X.Y.Z]` move, tagging, and post-cut
+verification). The condensed procedure:
+
+1. Update `pyproject.toml` to `X.Y.Z` and roll the `Unreleased` heading
+   in `CHANGELOG.md` to `[X.Y.Z] — YYYY-MM-DD`.
 2. Run:
 
 ```bash
@@ -110,7 +118,7 @@ nix flake check
 ```
 
 3. Commit the version bump as its own small change, normally `chore: release X.Y.Z`.
-4. Tag that exact commit as `vX.Y.Z`.
+4. Tag that exact commit as `vX.Y.Z` (signed and annotated).
 
 If this slice is not producing the matching tag, leave `pyproject.toml`
 unchanged.

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,55 @@
+# Release Checklist
+
+This is the operator-facing checklist for cutting a `polylogue` release.
+The release procedure itself is documented in
+[CONTRIBUTING.md](../CONTRIBUTING.md#versioning-and-releases); this file
+captures the things to *check* at cut time.
+
+## Pre-flight
+
+- [ ] Open PRs reconciled or explicitly deferred.
+- [ ] `devtools verify` passes on the cut commit.
+- [ ] `devtools render-all --check` clean.
+- [ ] CI green on `master`.
+- [ ] `CHANGELOG.md` Unreleased entries reviewed and grouped under
+      `Added`, `Changed`, `Fixed`, `Security`, `Removed`.
+- [ ] `SCHEMA_VERSION` bumped if any change in this slice modified
+      `polylogue/storage/backends/schema_ddl.py` or its inputs.
+- [ ] No `until: "vX.Y.Z"` exception in `docs/plans/*.yaml` references
+      this release without a resolution PR.
+- [ ] `pip-audit` green (covered by CI; re-run locally if anything
+      changed since the last run).
+
+## Cut
+
+- [ ] In `CHANGELOG.md`, move the `Unreleased` section to a `[X.Y.Z] —
+      YYYY-MM-DD` heading. Leave a fresh empty `Unreleased` block above
+      it.
+- [ ] `pyproject.toml` `version` → `X.Y.Z`.
+- [ ] Commit as `chore: release X.Y.Z` (no other changes in this commit).
+- [ ] Sign and annotate the tag: `git tag -s vX.Y.Z -m "polylogue X.Y.Z"`.
+- [ ] Push the tag: `git push origin vX.Y.Z` (or
+      `git pst` — uses `--follow-tags`).
+
+## Post
+
+- [ ] Draft GitHub release notes from the `[X.Y.Z]` section of
+      `CHANGELOG.md`.
+- [ ] Verify `polylogue --version` on the tagged commit shows the
+      expected version, commit hash, and clean dirty state.
+- [ ] Verify wheel and sdist build (once #416 lands the install path).
+- [ ] Smoke `polylogue --help` from a clean install.
+
+## Rollback
+
+If a tagged release is found broken before downstream picks it up:
+
+- [ ] Delete the tag locally and on origin
+      (`git tag -d vX.Y.Z; git push --delete origin vX.Y.Z`).
+- [ ] Open a `release: revert vX.Y.Z` PR that reverts the
+      `chore: release X.Y.Z` commit.
+- [ ] Add a `Fixed` entry to `CHANGELOG.md` Unreleased noting the
+      rollback and the issue.
+
+If the release has already shipped, prefer cutting `X.Y.Z+1` over
+rewriting history; tag rewrites are disruptive once external links exist.


### PR DESCRIPTION
## Summary

Closes #501. Adds the user-facing release-record surface (\`CHANGELOG.md\` + \`docs/release.md\`) and a PR-template hint that prompts contributors to log user-visible changes.

## Problem

The repository had no \`CHANGELOG.md\` and no release checklist. \`pyproject.toml\` records \`0.1.0\` but no per-version record of user-facing changes existed. \`git log\` is the de facto changelog — readable for maintainers, opaque for users, and unsuitable for release notes once the install path (#416) lands. \`CONTRIBUTING.md\` already describes the release procedure but doesn't name a changelog or cut-time checklist.

## Solution

| File | Role |
| --- | --- |
| \`CHANGELOG.md\` | Keep a Changelog 1.1.0 format. Sections per version: Added/Changed/Fixed/Security/Removed. Unreleased block at top accepts entries during normal PR flow. Seeded with the user-visible work that landed in this slice (security fixes, perf indexes, exception typing) so the file isn't a stub. |
| \`docs/release.md\` | Cut-time checklist: pre-flight (verify, render-all, CI, changelog grouped, schema bump, sunset clauses resolved, \`pip-audit\` clean), cut steps (Unreleased → \`[X.Y.Z]\`, pyproject bump, signed tag), post verification, and a rollback section. |
| \`.github/pull_request_template.md\` | New optional \`## Changelog\` section between Verification and Risks. Prompt explicitly distinguishes user-visible changes from refactors so the file doesn't accumulate test/refactor noise. |
| \`CONTRIBUTING.md\` | Cross-references \`CHANGELOG.md\` and \`docs/release.md\` from the existing Versioning and Releases section; retains the condensed procedure inline. |

Skipped (per issue, "Useful but not required"): release-drafter automation. The manual \`CHANGELOG.md\` is the source of truth.

## Verification

\`\`\`
$ test -f CHANGELOG.md && echo present
present

$ test -f docs/release.md && echo present
present

$ grep -q "Unreleased" CHANGELOG.md && echo ok
ok

$ grep -q "Changelog" .github/pull_request_template.md && echo ok
ok

$ nix develop -c devtools verify --quick
verify: all checks passed
\`\`\`