### PR TITLE
feat(proof): tests/proof/laws/ — anti-omission laws as named mechanism

### DIFF
--- a/tests/proof/laws/__init__.py
+++ b/tests/proof/laws/__init__.py
@@ -1,0 +1,14 @@
+"""Anti-omission laws over the verification catalog.
+
+Each test in this package is a single named law expressed as a parametrized
+pytest test over the compiled obligation set. The intent is to make the
+catalog's structural invariants explicit and enforceable rather than
+implicit in catalog construction:
+
+    completeness/         laws asserting required coverage exists
+    anti_dead_code/       laws asserting nothing is built but unused
+
+Adding a law here is the mechanism by which the catalog grows beyond
+"renderable" into "structurally complete." A law that fires names the
+specific subject(s) or claim(s) that violate the rule.
+"""

--- a/tests/proof/laws/anti_dead_code/__init__.py
+++ b/tests/proof/laws/anti_dead_code/__init__.py
@@ -1,0 +1,1 @@
+"""Anti-dead-code laws: every declared element is selected or exercised."""

--- a/tests/proof/laws/anti_dead_code/test_every_claim_selects_at_least_one_subject.py
+++ b/tests/proof/laws/anti_dead_code/test_every_claim_selects_at_least_one_subject.py
@@ -1,0 +1,23 @@
+"""Every catalog Claim selects at least one subject.
+
+Failure mode: a Claim is added (or its subject_query refactored) such
+that nothing matches. The catalog still renders, the obligations table
+shows zero for that claim, and there is no signal — silent dead code in
+a structure that's supposed to be enforcement.
+
+This law sits next to ``catalog.non_abstract_claim_subjects`` (the
+existing catalog quality check). The quality check produces an
+``OutcomeStatus.ERROR``; this law surfaces the same condition as a
+pytest failure with the offending claim id named.
+"""
+
+from __future__ import annotations
+
+from polylogue.proof.catalog import build_verification_catalog
+
+
+def test_every_claim_selects_at_least_one_subject() -> None:
+    catalog = build_verification_catalog()
+    obligations_by_claim = catalog.obligations_by_claim()
+    unbound = [claim.id for claim in catalog.claims if obligations_by_claim.get(claim.id, 0) == 0]
+    assert not unbound, f"claims with zero subjects: {sorted(unbound)}"

--- a/tests/proof/laws/anti_dead_code/test_every_subject_has_at_least_one_claim.py
+++ b/tests/proof/laws/anti_dead_code/test_every_subject_has_at_least_one_claim.py
@@ -1,0 +1,38 @@
+"""Every subject of a fully-bound kind is selected by at least one claim.
+
+Failure mode: a SubjectRef is built but no claim's ``subject_query``
+matches its kind/attrs. The subject sits in the catalog count but never
+contributes an obligation — the count goes up, the verified surface
+doesn't.
+
+Fully-bound kinds are the ones where 100% of subjects must be selected
+by definition. Partially-bound kinds (e.g. ``artifact.path``, where
+the dependency-closure claim deliberately filters to durable+non_core
+layers) are excluded — their partial coverage is intentional design.
+Adding a kind to ``_FULLY_BOUND_KINDS`` is the mechanism by which a
+catalog-construction guarantee becomes enforced.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from polylogue.proof.catalog import build_verification_catalog
+
+_FULLY_BOUND_KINDS = (
+    "cli.command",
+    "cli.json_command",
+    "provider.capability",
+    "operation.spec",
+    "trace.operation",
+    "diagnostic.observable",
+    "workflow.claim",
+)
+
+
+@pytest.mark.parametrize("kind", _FULLY_BOUND_KINDS)
+def test_every_subject_of_a_fully_bound_kind_is_selected(kind: str) -> None:
+    catalog = build_verification_catalog()
+    selected_ids = {obligation.subject.id for obligation in catalog.obligations}
+    orphans = [subject.id for subject in catalog.subjects if subject.kind == kind and subject.id not in selected_ids]
+    assert not orphans, f"{kind} subjects with no selecting claim: {sorted(orphans)}"

--- a/tests/proof/laws/completeness/__init__.py
+++ b/tests/proof/laws/completeness/__init__.py
@@ -1,0 +1,1 @@
+"""Completeness laws: required coverage exists for every subject of a kind."""

--- a/tests/proof/laws/completeness/test_every_command_has_help_claim.py
+++ b/tests/proof/laws/completeness/test_every_command_has_help_claim.py
@@ -1,0 +1,29 @@
+"""Every CLI command subject must be selected by every cli.command claim.
+
+Failure mode protected against: a new command lands without one of the
+help / no-traceback / plain-mode claims selecting it. The catalog still
+renders cleanly because the existing claims select the *other* commands —
+nothing forces full coverage. This law makes the missing-coverage case
+loud at the test level.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from polylogue.proof.catalog import build_verification_catalog
+
+_REQUIRED_COMMAND_CLAIMS = (
+    "cli.command.help",
+    "cli.command.no_traceback",
+    "cli.command.plain_mode",
+)
+
+
+@pytest.mark.parametrize("claim_id", _REQUIRED_COMMAND_CLAIMS)
+def test_every_command_subject_is_selected_by_required_command_claim(claim_id: str) -> None:
+    catalog = build_verification_catalog()
+    command_subjects = {subject.id for subject in catalog.subjects if subject.kind == "cli.command"}
+    selected = {obligation.subject.id for obligation in catalog.obligations if obligation.claim.id == claim_id}
+    missing = command_subjects - selected
+    assert not missing, f"commands missing {claim_id}: {sorted(missing)}"

--- a/tests/proof/laws/completeness/test_every_json_command_has_envelope_claim.py
+++ b/tests/proof/laws/completeness/test_every_json_command_has_envelope_claim.py
@@ -1,0 +1,22 @@
+"""Every cli.json_command subject must be selected by cli.command.json_envelope.
+
+Failure mode: a new --json command lands but isn't covered by the
+machine-envelope contract. The catalog stays renderable; the regression
+shows up at the next CI run that exercises the JSON path.
+"""
+
+from __future__ import annotations
+
+from polylogue.proof.catalog import build_verification_catalog
+
+
+def test_every_json_command_is_selected_by_envelope_claim() -> None:
+    catalog = build_verification_catalog()
+    json_command_subjects = {subject.id for subject in catalog.subjects if subject.kind == "cli.json_command"}
+    selected = {
+        obligation.subject.id
+        for obligation in catalog.obligations
+        if obligation.claim.id == "cli.command.json_envelope"
+    }
+    missing = json_command_subjects - selected
+    assert not missing, f"--json commands missing cli.command.json_envelope: {sorted(missing)}"


### PR DESCRIPTION
## Summary

Closes #517 (initial set; subsequent laws extend the same shape).

Adds \`tests/proof/laws/\` as the named home for anti-omission laws over the verification catalog. Each law is a parametrized pytest test that asserts a structural invariant the catalog should never lose.

## Problem

The verification catalog renders cleanly today, but nothing forces structural invariants like "every \`cli.command\` subject is selected by the help/no-traceback/plain-mode claims." A future refactor could shape-shift the catalog out of completeness — drop a claim, change a \`subject_query\`, build a subject the catalog ignores — and \`render-verification-catalog\` would still pass. The 2026-04-22 consolidated plan listed anti-omission laws as required substrate; today \`tests/anti_omission/\` (or equivalent) doesn't exist. Adjacent checks (\`verify-test-ownership\`, \`verify-topology\`, \`verify-cross-cuts\`) cover module-level structure, not the catalog graph.

## Solution

\`tests/proof/laws/\` with one file per law and a layered package layout:

\`\`\`
tests/proof/laws/
├── completeness/
│   ├── test_every_command_has_help_claim.py
│   └── test_every_json_command_has_envelope_claim.py
└── anti_dead_code/
    ├── test_every_claim_selects_at_least_one_subject.py
    └── test_every_subject_has_at_least_one_claim.py
\`\`\`

Each test loads \`build_verification_catalog()\` and asserts the shape — when a law fails, the assertion message names the offending subject(s) or claim(s).

\`test_every_subject_has_at_least_one_claim\` is parametrized over \`_FULLY_BOUND_KINDS\` (cli.command, cli.json_command, provider.capability, operation.spec, trace.operation, diagnostic.observable, workflow.claim). \`artifact.path\` is intentionally excluded — the \`dependency_closure\` claim deliberately filters by \`has_durable_layer + has_non_core_layer\`, so partial coverage there is design intent. Adding a kind to that tuple is the mechanism by which a catalog-construction guarantee becomes enforced.

This PR captures the easier, structurally-true-today laws. Follow-ups can extend with mutating-command preview, schema-annotation consumer coverage, witness exercise, and the evidence-quality / no-phantom-runner laws (those overlap with #498 / #509 and land with their cleanup).

## Verification

\`\`\`
$ nix develop -c pytest -q tests/proof/laws/
12 passed in 10.59s

$ nix develop -c devtools verify --quick
verify: all checks passed
\`\`\`

## Risks and Follow-ups

The 12 laws make implicit catalog invariants explicit but do not yet enforce them as a separate \`verify-laws\` lint — they're picked up by the normal pytest run, which is the cheaper integration. A standalone runner could come later if we want them to fire outside the test suite.