### PR TITLE
chore(ci): skip pr-policy validator for dependabot PRs

### DIFF
--- a/.github/workflows/pr-policy.yml
+++ b/.github/workflows/pr-policy.yml
@@ -16,6 +16,12 @@ concurrency:
 jobs:
   validate:
     name: Validate PR metadata
+    # Skip dependabot — it generates its own conventional title via the
+    # `chore(deps):` prefix but doesn't fill the human PR template, and the
+    # branch name follows `dependabot/<ecosystem>/<dep>-<version>`. The
+    # changes are mechanical version bumps that don't need the same review
+    # framing.
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 1
     steps:


### PR DESCRIPTION
## Summary

Skip the human PR-policy validator on dependabot PRs. Dependabot uses conventional titles (\`chore(deps):\`) but doesn't fill the human PR template, so the validator currently fails on every dep bump and blocks merge.

## Problem

Pull Request Policy validates branch name (\`feature/<category>/<description>\`), conventional title prefix, and required body sections (\`## Summary\`, \`## Problem\`, \`## Solution\`, \`## Verification\`). Dependabot generates:

- Branch: \`dependabot/<ecosystem>/<dep>-<version>\` — fails the branch regex.
- Title: \`chore(deps): bump X from Y to Z\` — passes the title regex.
- Body: a short table of changelog/release notes — fails the body section check.

Dependency bumps are mechanical and don't benefit from the same review framing the validator enforces for human PRs. Without this fix, every dependabot PR (#532 already showed up minutes after #528 merged) needs a manual override to merge, defeating the value of the automation.

## Solution

Add a job-level \`if: github.event.pull_request.user.login != 'dependabot[bot]'\` to the validate job in \`.github/workflows/pr-policy.yml\`. When dependabot is the author, the job is skipped (which counts as success for required-check purposes).

## Verification

\`\`\`
$ nix develop -c devtools verify --quick
verify: all checks passed
\`\`\`

The skip behavior will be observable on the next dependabot PR (already-open #532 should pass on the next sync).