### PR TITLE
fix(nix): add watchfiles to flake propagated deps

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -75,6 +75,7 @@
             glom
             mcp
             pyyaml
+            watchfiles
           ];
 
           # Skip tests in build (run in checks instead)


### PR DESCRIPTION
## Summary

\`polylogue watch\` (#539, landed in #541) imports \`watchfiles\` at runtime; the pyproject dep was added but \`flake.nix\` hardcodes \`propagatedBuildInputs\` separately and \`watchfiles\` was missed there. Nix-built binary fails with \`ModuleNotFoundError: No module named 'watchfiles'\` when \`polylogue-watch.service\` starts.

## Problem

The \`polylogue\` Nix derivation lists Python deps explicitly, not from pyproject. Anyone deploying via \`pkgs.polylogue\` (sinnix) gets a binary missing \`watchfiles\`.

## Solution

Add \`watchfiles\` to the \`propagatedBuildInputs\` list.

## Verification

\`\`\`bash
nix build .#polylogue
./result/bin/polylogue watch --help   # exits 0; previously crashed
\`\`\`

Repro of the underlying failure: starting \`polylogue-watch.service\` on a host with the master version pre-fix produces:
\`\`\`
ModuleNotFoundError: No module named 'watchfiles'
\`\`\`