### PR TITLE
fix: add logging to silent exception swallows in diagnostics and schema sampling (#551)

### DIFF
--- a/polylogue/cli/query_output.py
+++ b/polylogue/cli/query_output.py
@@ -195,6 +195,7 @@ def render_conversation_rich(env: AppEnv, conv: Conversation) -> None:
             )
             console.print(panel)
         except Exception:
+            logger.exception("render_conversation_rich: Panel rendering failed for role %s", role)
             console.print(f"[{rc.label}]{role.capitalize()}:[/{rc.label}] {msg.text[:200]}")
         console.print()
 

--- a/polylogue/cli/query_progress.py
+++ b/polylogue/cli/query_progress.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
@@ -13,6 +14,8 @@ import click
 from polylogue.cli.query_contracts import QueryOutputSpec
 from polylogue.lib.query.retrieval_candidates import uses_action_read_model
 from polylogue.lib.query.spec import ConversationQuerySpec
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from polylogue.storage.action_events.artifacts import ActionEventArtifactState
@@ -83,6 +86,7 @@ async def _action_event_state(repository: object) -> ActionEventArtifactState | 
     try:
         result = await method()
     except Exception:
+        logger.exception("_action_event_state: get_action_event_artifact_state() failed")
         return None
     return cast("ActionEventArtifactState | None", result)
 
@@ -106,6 +110,7 @@ async def build_query_slow_notice(
         try:
             plan = selection.to_plan()
         except Exception:
+            logger.exception("build_query_slow_notice: selection.to_plan() failed")
             plan = None
         if plan is not None:
             retrieval_lane = plan.retrieval_lane

--- a/polylogue/lib/query/miss_diagnostics.py
+++ b/polylogue/lib/query/miss_diagnostics.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
@@ -11,6 +12,8 @@ from polylogue.lib.json import JSONDocument
 from polylogue.lib.query.retrieval_candidates import uses_action_read_model
 from polylogue.lib.query.spec import ConversationQuerySpec
 from polylogue.readiness import VerifyStatus, get_readiness
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from polylogue.config import Config
@@ -87,6 +90,7 @@ async def _call_optional(repository: object, method_name: str, *args: object, **
     try:
         return await method(*args, **kwargs)
     except Exception:
+        logger.exception("_call_optional: repository method `%s` failed", method_name)
         return None
 
 
@@ -144,12 +148,14 @@ def _readiness_index_reason(config: Config | None, selection: ConversationQueryS
     try:
         plan = selection.to_plan()
     except Exception:
+        logger.exception("_readiness_index_reason: selection.to_plan() failed")
         return None
     if not plan.fts_terms:
         return None
     try:
         report = get_readiness(config, probe_only=True)
     except Exception:
+        logger.exception("_readiness_index_reason: get_readiness() failed")
         return None
     index_check = next((check for check in report.checks if check.name == "index"), None)
     if index_check is None or index_check.status is VerifyStatus.OK:
@@ -187,6 +193,7 @@ async def _action_read_model_reason(
     try:
         plan = selection.to_plan()
     except Exception:
+        logger.exception("_action_read_model_reason: selection.to_plan() failed")
         return None
     if not uses_action_read_model(plan):
         return None

--- a/polylogue/schemas/sampling_db.py
+++ b/polylogue/schemas/sampling_db.py
@@ -110,6 +110,7 @@ def _iter_record_stream_units(
             record_type_key=config.record_type_key,
         )
     except Exception:
+        logger.exception("Failed to extract record samples from raw content: %s", raw_content)
         samples = []
 
     if not samples:
@@ -144,6 +145,7 @@ def _build_raw_payload_envelope_for_row(
             jsonl_dict_only=config.sample_granularity == "record",
         )
     except Exception:
+        logger.exception("Failed to build raw payload envelope for %s", raw_content)
         return None
 
 

--- a/polylogue/schemas/unified.py
+++ b/polylogue/schemas/unified.py
@@ -83,6 +83,7 @@ def try_schema_extraction(provider: Provider | str, raw: JSONDocument) -> Harmon
     except FileNotFoundError:
         return None
     except Exception:
+        logger.exception("try_schema_extraction: unexpected failure for provider %s", p)
         return None
 
 


### PR DESCRIPTION
## Summary
Add `logger.exception()` calls at 10 sites where bare `except Exception` silently suppressed errors.

## Problem
Silent exception swallowing made programming errors and transient DB failures invisible. Schema generation could proceed with zero data after sampling failures.

## Solution
Added `logger.exception()` before each silent continue/return across miss_diagnostics, query_progress, sampling_db, unified, and query_output. Sites in ingest_batch/acquisition already had structured error logging.

Closes #551

🤖 Generated with [Claude Code](https://claude.com/claude-code)