### PR TITLE
fix: harden blob store against path injection, partial writes, and temp file leakage (#545)

### DIFF
--- a/polylogue/lib/security.py
+++ b/polylogue/lib/security.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 from pathlib import Path
 
 from polylogue.logging import get_logger
@@ -44,14 +45,19 @@ def sanitize_path(v: str | None) -> str | None:
 
     # If traversal or symlinks were detected, hash to prevent re-assembly
     if has_traversal or has_symlink:
-        import hashlib
-
         original_hash = hashlib.sha256(original_v.encode()).hexdigest()[:12]
         return f"_blocked_{original_hash}"
 
-    # Safe path: clean up components but preserve absolute/relative structure
+    # Safe path: clean up components
     parts = [c.strip() for c in v.split("/") if c.strip() and c.strip() not in (".", "..")]
     joined = "/".join(parts)
-    if original_v.startswith("/"):
-        return "/" + joined if parts else "/"
+
+    # Absolute paths are rejected — no allowlist for safe directories.
+    # An attacker-controlled input like "/etc/passwd" would otherwise pass
+    # through to the filesystem. Callers with a known root should resolve
+    # against it themselves.
+    if v.startswith("/"):
+        original_hash = hashlib.sha256(original_v.encode()).hexdigest()[:12]
+        return f"_blocked_{original_hash}"
+
     return joined or v or None

--- a/polylogue/storage/blob_store.py
+++ b/polylogue/storage/blob_store.py
@@ -18,13 +18,29 @@ from __future__ import annotations
 
 import hashlib
 import os
+import re
 import tempfile
 from collections.abc import Callable, Iterator
+from contextlib import suppress
 from pathlib import Path
 from typing import IO, BinaryIO
 
 _CHUNK_SIZE = 128 * 1024  # 128 KB
+
+# Valid blob hash: lowercase hex only
+_VALID_HEX = re.compile(r"^[0-9a-f]+$")
+
 Heartbeat = Callable[[], None]
+
+
+def _write_all(fd: int, data: bytes) -> None:
+    """Write all *data* to *fd*, retrying on partial writes."""
+    offset = 0
+    while offset < len(data):
+        written = os.write(fd, data[offset:])
+        if written == 0:
+            raise OSError("write() returned 0 — possible disk full or closed fd")
+        offset += written
 
 
 class BlobStore:
@@ -35,6 +51,8 @@ class BlobStore:
 
     def blob_path(self, hash_hex: str) -> Path:
         """Return the filesystem path for a blob by its hex digest."""
+        if not _VALID_HEX.match(hash_hex):
+            raise ValueError(f"invalid blob hash: {hash_hex!r} — expected lowercase hex string")
         return self.root / hash_hex[:2] / hash_hex[2:]
 
     def exists(self, hash_hex: str) -> bool:
@@ -79,10 +97,11 @@ class BlobStore:
                     if not chunk:
                         break
                     hasher.update(chunk)
-                    os.write(fd, chunk)
+                    _write_all(fd, chunk)
                     size += len(chunk)
                     if heartbeat is not None:
-                        heartbeat()
+                        with suppress(Exception):
+                            heartbeat()
             os.close(fd)
             fd = None
 
@@ -130,9 +149,10 @@ class BlobStore:
                     break
                 hasher.update(chunk)
                 size += len(chunk)
-                os.write(fd, chunk)
+                _write_all(fd, chunk)
                 if heartbeat is not None:
-                    heartbeat()
+                    with suppress(Exception):
+                        heartbeat()
 
             hash_hex = hasher.hexdigest()
             dest = self.blob_path(hash_hex)
@@ -173,7 +193,7 @@ class BlobStore:
         tmp_path: str | None = None
         try:
             fd, tmp_path = tempfile.mkstemp(dir=dest.parent, prefix=".blob.")
-            os.write(fd, data)
+            _write_all(fd, data)
             os.close(fd)
             fd = None
             os.chmod(tmp_path, 0o600)
@@ -232,7 +252,7 @@ class BlobStore:
             if not prefix_dir.is_dir() or len(prefix_dir.name) != 2:
                 continue
             for blob_file in sorted(prefix_dir.iterdir()):
-                if blob_file.is_file():
+                if blob_file.is_file() and not blob_file.name.startswith(".blob."):
                     yield prefix_dir.name + blob_file.name
 
     def remove(self, hash_hex: str) -> bool:

--- a/tests/unit/security/test_attachment_security.py
+++ b/tests/unit/security/test_attachment_security.py
@@ -32,13 +32,15 @@ def test_attachment_path_traversal_rejected() -> None:
     assert not str(normalized).endswith("/etc/passwd")
 
 
-def test_attachment_absolute_path_preserved() -> None:
+def test_attachment_absolute_path_blocked() -> None:
+    """Absolute paths are rejected to prevent sandbox escape."""
     att = ParsedAttachment(
         provider_attachment_id="att2",
         path="/etc/shadow",
         name="shadow",
     )
-    assert att.path == "/etc/shadow"
+    assert att.path is not None
+    assert att.path.startswith("_blocked_")
 
 
 def test_attachment_path_null_byte_rejected() -> None:

--- a/tests/unit/security/test_path_sanitization.py
+++ b/tests/unit/security/test_path_sanitization.py
@@ -59,17 +59,27 @@ class TestSanitizePathTraversal:
                 "conversations/chatgpt/export.json",
                 ("conversations", "chatgpt"),
             ),
-            (
-                "/home/user/conversations/export.json",
-                ("/", "conversations"),
-            ),
         ],
     )
-    def test_safe_paths_remain_usable(self, raw_path: str, checks: tuple[str, ...]) -> None:
+    def test_safe_relative_paths_remain_usable(self, raw_path: str, checks: tuple[str, ...]) -> None:
         result = sanitize_path(raw_path)
         assert result is not None
         for check in checks:
-            assert check in result or result.startswith(check)
+            assert check in result
+
+    @pytest.mark.parametrize(
+        "raw_path",
+        [
+            "/etc/passwd",
+            "/home/user/conversations/export.json",
+            "/",
+        ],
+    )
+    def test_absolute_paths_are_blocked(self, raw_path: str) -> None:
+        """Absolute paths are rejected to prevent sandbox escape."""
+        result = sanitize_path(raw_path)
+        assert result is not None
+        assert result.startswith("_blocked_")
 
     def test_none_returns_none(self) -> None:
         assert sanitize_path(None) is None


### PR DESCRIPTION
## Summary
Five security and data-integrity fixes to blob store and path sanitization.

## Problem
- `blob_path()` had no validation on `hash_hex`, allowing path injection via `../`
- `os.write()` partial writes could silently corrupt blobs
- Crash-left temp files (`*.blob.*`) were yielded as valid blobs
- Heartbeat callback exceptions aborted blob writes
- `sanitize_path()` passed absolute paths like `/etc/passwd` through unmodified

## Solution
- Validate hash_hex against `^[0-9a-f]+$` regex
- Retry partial `os.write()` in a loop
- Filter temp files from `iter_all()`
- Suppress heartbeat exceptions with `contextlib.suppress`
- Block absolute paths in `sanitize_path()`, returning `_blocked_<hash>`

Closes #545

🤖 Generated with [Claude Code](https://claude.com/claude-code)