### PR TITLE
fix(pipeline): wire embed stage dispatch, add webhook status check, fix upsert data loss (#546)

### DIFF
--- a/polylogue/pipeline/observers.py
+++ b/polylogue/pipeline/observers.py
@@ -194,6 +194,13 @@ def _post_webhook(url: str, data: bytes) -> None:
         connection.request("POST", path, body=data, headers=headers)
         response = connection.getresponse()
         response.read()
+        response_status = response.status
+        if isinstance(response_status, int) and not (200 <= response_status < 300):
+            logger.warning(
+                "Webhook returned non-2xx status: %s %s",
+                response_status,
+                response.reason,
+            )
     finally:
         connection.close()
 

--- a/polylogue/pipeline/run_execution.py
+++ b/polylogue/pipeline/run_execution.py
@@ -14,6 +14,7 @@ from polylogue.pipeline.run_finalization import persist_run_result
 from polylogue.pipeline.run_stages import (
     IndexStageOutcome,
     execute_acquire_stage,
+    execute_embed_stage,
     execute_index_stage,
     execute_ingest_stage,
     execute_materialize_stage,
@@ -262,6 +263,21 @@ async def run_sources(
                 rendered_pages=site_outcome.rendered_pages,
             )
 
+        async def _run_embed_stage(spec: PipelineStageSpec) -> None:
+            sm = metrics.start_stage(spec.log_stage)
+            embed_outcome = await execute_embed_stage(
+                config=config,
+                backend=active_backend,
+                progress_callback=progress_callback,
+            )
+            sm.stop(items=embed_outcome.embedded_count)
+            logger.info(
+                "Embed stage complete",
+                **sm.to_dict(),
+                embedded=embed_outcome.embedded_count,
+                errors=embed_outcome.error_count,
+            )
+
         async def _run_stage_spec(spec: PipelineStageSpec) -> None:
             nonlocal index_outcome
             if not spec.pipeline_managed:
@@ -288,6 +304,8 @@ async def run_sources(
                 await _run_site_stage(spec)
             elif spec.name == "index":
                 index_outcome = await _run_index_stage(spec, execution_stage)
+            elif spec.name == "embed":
+                await _run_embed_stage(spec)
             else:
                 raise ValueError(f"Unknown pipeline stage spec: {spec.name}")
             executed_stages.add(spec.name)

--- a/polylogue/pipeline/run_finalization.py
+++ b/polylogue/pipeline/run_finalization.py
@@ -111,6 +111,7 @@ async def persist_run_result(
         index_outcome=index_outcome,
         duration_ms=duration_ms,
     )
+    run_path = write_run_json(config.archive_root, _run_payload_document(run_payload))
     await repository.record_run(
         RunRecord(
             run_id=str(run_payload["run_id"]),
@@ -122,7 +123,6 @@ async def persist_run_result(
             duration_ms=duration_ms,
         ),
     )
-    run_path = write_run_json(config.archive_root, _run_payload_document(run_payload))
     return RunResult(
         run_id=str(run_payload["run_id"]),
         counts=state.counts.model_copy(deep=True),

--- a/polylogue/pipeline/run_support.py
+++ b/polylogue/pipeline/run_support.py
@@ -32,7 +32,7 @@ RUN_STAGE_SEQUENCES: dict[str, tuple[str, ...]] = {
     "index": ("index",),
     "embed": ("embed",),
     "schema": ("schema",),
-    "reprocess": ("parse", "materialize", "render", "index"),
+    "reprocess": ("parse", "materialize", "render", "site", "index"),
     "all": ("acquire", "parse", "materialize", "render", "site", "index"),
     "publish": ("render", "site"),
 }

--- a/polylogue/pipeline/services/ingest_batch.py
+++ b/polylogue/pipeline/services/ingest_batch.py
@@ -1,9 +1,9 @@
 """Batch ingest orchestration: ProcessPool workers + sync sqlite3 writes.
 
-Producer-consumer architecture:
+Architecture:
 - CPU-bound work (decode/validate/parse/transform) in ProcessPoolExecutor
 - DB writes in main thread via sync sqlite3 (no aiosqlite async overhead)
-- as_completed yields results as workers finish — parse and write overlap
+- as_completed yields results as workers finish; writes run after all results collected
 
 Replaces: parsing_batch.py, parsing_workflow.py, validation_flow.py.
 """
@@ -455,7 +455,8 @@ def _write_conversation(conn: sqlite3.Connection, cdata: ConversationData) -> tu
     if cdata.stats_tuple:
         conn.execute(_STATS_UPSERT_SQL, cdata.stats_tuple)
 
-    # Content blocks
+    # Content blocks (replace all for this conversation)
+    conn.execute("DELETE FROM content_blocks WHERE conversation_id = ?", (cdata.conversation_id,))
     if cdata.block_tuples:
         conn.executemany(_CONTENT_BLOCK_UPSERT_SQL, cdata.block_tuples)
 

--- a/polylogue/pipeline/services/validation_flow.py
+++ b/polylogue/pipeline/services/validation_flow.py
@@ -97,7 +97,8 @@ async def validate_raw_ids(
         )
         result.merge(batch_result)
 
-        missing = [raw_id for raw_id in batch_ids if raw_id not in {record.raw_id for record in raw_records}]
+        raw_records_ids = {record.raw_id for record in raw_records}
+        missing = [raw_id for raw_id in batch_ids if raw_id not in raw_records_ids]
         processed = batch_start + len(raw_records)
         for missing_index, raw_id in enumerate(missing, start=1):
             result.errors += 1

--- a/tests/unit/pipeline/test_run_sources.py
+++ b/tests/unit/pipeline/test_run_sources.py
@@ -109,7 +109,7 @@ def _write_chatgpt_export(path: Path, conversation_id: str, *, text: str = "Test
 def test_expand_requested_stage_contract() -> None:
     assert expand_requested_stage("acquire") == ("acquire",)
     assert expand_requested_stage("parse") == ("parse",)
-    assert expand_requested_stage("reprocess") == ("parse", "materialize", "render", "index")
+    assert expand_requested_stage("reprocess") == ("parse", "materialize", "render", "site", "index")
     assert expand_requested_stage("all") == ("acquire", "parse", "materialize", "render", "site", "index")
 
 

--- a/tests/unit/pipeline/test_stage_contract.py
+++ b/tests/unit/pipeline/test_stage_contract.py
@@ -33,8 +33,8 @@ def test_full_sequence_satisfies_all_inputs() -> None:
 
 
 def test_reprocess_sequence_satisfies_inputs() -> None:
-    """``reprocess`` (parse, materialize, render, index) satisfies the contract."""
-    sequence = stage_specs_for_sequence(("parse", "materialize", "render", "index"))
+    """``reprocess`` (parse, materialize, render, site, index) satisfies the contract."""
+    sequence = stage_specs_for_sequence(("parse", "materialize", "render", "site", "index"))
     executed: list[PipelineStageSpec] = []
     for spec in sequence:
         validate_stage_contract(spec, executed_specs=executed)


### PR DESCRIPTION
## Summary
Seven pipeline fixes from the post-hoc audit: embed stage dispatch, webhook status checking, content_blocks upsert data loss, write ordering, stage sequences, set rebuild optimization, and stale docstrings.

## Problem
- `execute_embed_stage` was imported but never called — `stage="embed"` raised ValueError
- Webhook responses were never checked — non-2xx silently treated as success
- `_write_conversation` upserted content_blocks without deleting old ones
- `write_run_json` could fail after `record_run` committed, leaving inconsistent state
- Reprocess sequence omitted the site stage

## Solution
Each fix is minimal and targeted at the specific call site.

Closes #546

🤖 Generated with [Claude Code](https://claude.com/claude-code)