### PR TITLE
fix(devtools): fix topology projection stem bugs and strict-name validation (#547)

### DIFF
--- a/devtools/build_topology_projection.py
+++ b/devtools/build_topology_projection.py
@@ -307,6 +307,10 @@ def _resolve_target(name: str, sub: str, prefix: str) -> str:
     stem = stem.lstrip("_")
     if not stem or stem == ".py":
         return f"polylogue/{sub}{name}"
+    # Guard against creating a target that would double the __init__.py
+    # suffix when the stem itself is __init__.py.
+    if stem == "__init__.py" and sub.endswith("/"):
+        return f"polylogue/{sub}{name}"
     return f"polylogue/{sub}{stem}"
 
 
@@ -428,10 +432,13 @@ def classify(path: Path) -> dict[str, Any]:
         if suffix.startswith("drive") and "/" not in suffix:
             target = f"polylogue/sources/drive/{suffix.replace('drive_', '').replace('drive.py', '__init__.py') or '__init__.py'}"
             issue = "#403"
-        elif suffix.startswith("parsers/claude") and "/" not in suffix[len("parsers/") :]:
+        elif suffix.startswith("parsers/claude_") and "/" not in suffix[len("parsers/") :]:
             # parsers/claude_*
             stem = suffix[len("parsers/claude_") :] or "__init__.py"
             target = f"polylogue/sources/parsers/claude/{stem}"
+            issue = "#403"
+        elif suffix == "parsers/claude.py":
+            target = "polylogue/sources/parsers/claude/__init__.py"
             issue = "#403"
         else:
             target = rel

--- a/devtools/verify_migrations.py
+++ b/devtools/verify_migrations.py
@@ -28,6 +28,26 @@ ROOT = Path(__file__).resolve().parents[1]
 MANIFEST = ROOT / "docs" / "plans" / "migrations.yaml"
 
 
+def _strip_inline_comment(text: str) -> str:
+    """Strip a trailing YAML comment (`` # ...``) from a value line.
+
+    Only strips `` #`` when the ``#`` is outside any quoted string, so
+    ``value: "foo # bar"`` is not truncated.
+    """
+    in_quotes = False
+    quote_char: str | None = None
+    for i, ch in enumerate(text):
+        if ch in ('"', "'"):
+            if not in_quotes:
+                in_quotes = True
+                quote_char = ch
+            elif ch == quote_char:
+                in_quotes = False
+        elif ch == "#" and not in_quotes and i > 0 and text[i - 1] == " ":
+            return text[:i].rstrip()
+    return text
+
+
 def parse_yaml(text: str) -> dict[str, Any]:
     """Tiny YAML reader for the migrations schema."""
     out: dict[str, Any] = {"migrations": {}, "completed": []}
@@ -39,6 +59,7 @@ def parse_yaml(text: str) -> dict[str, Any]:
         line = raw.rstrip()
         if not line or line.lstrip().startswith("#"):
             continue
+        line = _strip_inline_comment(line)
         indent = len(line) - len(line.lstrip())
         stripped = line.lstrip()
         if indent == 0:
@@ -172,6 +193,15 @@ def main(argv: list[str] | None = None) -> int:
     args = p.parse_args(argv)
 
     manifest = parse_yaml(args.yaml.read_text())
+    migration_names = set(manifest["migrations"].keys())
+    unknown_strict = sorted(n for n in args.strict if n not in migration_names)
+    if unknown_strict:
+        msg = f"unknown --strict migration name(s): {unknown_strict}"
+        print(f"[error] {msg}")
+        if args.json:
+            json.dump({"blocking": True, "error": msg}, sys.stdout, indent=2)
+            sys.stdout.write("\n")
+        return 1
     results: list[dict[str, Any]] = []
     blocking = False
     for name, spec in manifest["migrations"].items():


### PR DESCRIPTION
## Summary
Fix devtools bugs: topology projection incorrect stem resolution and verify-migrations strict-name validation.

## Problem
- `_resolve_target` could produce `__init__.pyinit__.py` from mixed prefix/file entries
- Off-by-one in `parsers/claude` suffix matching missed `parsers/claude.py`
- YAML parser didn't strip inline comments
- Misspelled `--strict` migration names silently passed

Closes #547

🤖 Generated with [Claude Code](https://claude.com/claude-code)