### PR TITLE
fix(pipeline): add NotebookEdit dispatch to extract_file_changes (#552)

### DIFF
--- a/polylogue/pipeline/semantic_capture.py
+++ b/polylogue/pipeline/semantic_capture.py
@@ -177,6 +177,12 @@ def extract_file_changes(tool_invocations: Sequence[Mapping[str, object]]) -> li
             if new_string is not None:
                 entry["new_content"] = new_string[:200]
             changes.append(entry)
+        elif tool_name == "NotebookEdit":
+            new_source = optional_string(input_data.get("new_source"))
+            entry: FileChangeSummary = {"path": path, "operation": "edit"}
+            if new_source is not None:
+                entry["new_content"] = new_source[:500]
+            changes.append(entry)
     return changes
 
 


### PR DESCRIPTION
## Summary
Add NotebookEdit tool dispatch to `extract_file_changes` in semantic_capture.py.

## Problem
The function handled Read, Write, and Edit tool invocations but silently dropped NotebookEdit operations from Claude Code sessions.

## Solution
Added NotebookEdit branch that extracts `new_source` content and records it as an edit operation.

Note: the other two items from #552 (FTS suspend outside try block, missing embed stage dispatch) were already fixed in #554 and #558.

Closes #552

🤖 Generated with [Claude Code](https://claude.com/claude-code)