### PR TITLE
fix: correct core library bugs in drift buckets, repo identity, provider aliases, pricing, and hashing (#549)

### DIFF
--- a/polylogue/lib/conversation/neighbor_candidates.py
+++ b/polylogue/lib/conversation/neighbor_candidates.py
@@ -495,7 +495,7 @@ async def discover_neighbor_candidates(
 
     target = await _load_target(store, request.conversation_id)
     source_id = str(target.id) if target is not None else None
-    provider = _canonical_provider(request.provider) or (str(target.provider) if target is not None else None)
+    provider = _canonical_provider(request.provider)
     providers = _provider_list(provider)
     pool_limit = max(request.candidate_pool_limit, request.limit)
     drafts: dict[str, _CandidateDraft] = {}

--- a/polylogue/lib/hashing.py
+++ b/polylogue/lib/hashing.py
@@ -10,8 +10,6 @@ import hashlib
 import unicodedata
 from pathlib import Path
 
-import orjson
-
 
 def hash_text(text: str) -> str:
     """Hash UTF-8 text to full SHA-256 hex digest (64 chars).
@@ -36,16 +34,17 @@ def hash_text_short(text: str, length: int = 16) -> str:
 def hash_payload(payload: object) -> str:
     """Hash a JSON-serializable object to full SHA-256 hex digest.
 
-    Note: String values within the payload are NOT normalized here.
+    Uses stdlib json for deterministic output across environments.
+    orjson would be faster but can produce different byte output for
+    non-ASCII content between versions, breaking content-addressed storage.
+
+    String values within the payload are NOT NFC-normalized here.
     Callers should normalize strings before including in payload if
     normalization-invariant hashing is required.
     """
-    try:
-        serialized = orjson.dumps(payload, option=orjson.OPT_SORT_KEYS)
-    except TypeError:
-        import json
+    import json
 
-        serialized = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    serialized = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
     return hashlib.sha256(serialized).hexdigest()
 
 

--- a/polylogue/lib/pricing.py
+++ b/polylogue/lib/pricing.py
@@ -521,8 +521,14 @@ def estimate_conversation_cost(conversation: Conversation) -> CostEstimatePayloa
         provenance.extend(estimate.provenance)
     model_name, normalized_model = _dominant_model(message_estimates)
     missing_count = len(message_estimates) - len(priced)
-    status: CostEstimateStatus = "priced" if missing_count == 0 else "partial"
-    confidence = 0.85 if status == "priced" else 0.55
+    all_exact = bool(priced) and all(e.status == "exact" for e in priced)
+    if all_exact:
+        status: CostEstimateStatus = "exact"
+    elif missing_count == 0:
+        status = "priced"
+    else:
+        status = "partial"
+    confidence = 0.95 if status == "exact" else 0.85 if status == "priced" else 0.55
     if conversation_estimate is not None and conversation_estimate.status == "priced":
         # Prefer conversation-level usage when present; it avoids double-counting
         # per-message fallbacks from providers that report only session totals.

--- a/polylogue/lib/provider_identity.py
+++ b/polylogue/lib/provider_identity.py
@@ -22,7 +22,14 @@ CORE_SCHEMA_PROVIDERS: Final[tuple[str, ...]] = (
     "gemini",
 )
 
-_RUNTIME_PROVIDER_ALIASES: Final[dict[str, str]] = {}
+_RUNTIME_PROVIDER_ALIASES: Final[dict[str, str]] = {
+    "claude": "claude-ai",
+    "anthropic": "claude-ai",
+    "openai": "chatgpt",
+    "google": "gemini",
+    "google-gemini": "gemini",
+    "cursor": "codex",
+}
 
 
 def normalize_provider_token(value: str | None) -> str:

--- a/polylogue/lib/repo_identity.py
+++ b/polylogue/lib/repo_identity.py
@@ -31,7 +31,7 @@ def _extract_local_path_candidate(value: str) -> str | None:
 
 def _iter_repo_root_candidates(path: Path) -> tuple[Path, ...]:
     expanded = path.expanduser()
-    current = expanded if not expanded.suffix else expanded.parent
+    current = expanded
     if current == Path("."):
         return ()
     return (current, *current.parents)

--- a/polylogue/lib/run_activity.py
+++ b/polylogue/lib/run_activity.py
@@ -23,7 +23,7 @@ def _drift_value(
     if drift is None:
         return 0
     bucket_mapping = drift.get(bucket)
-    if not isinstance(bucket_mapping, Mapping):
+    if not hasattr(bucket_mapping, "get"):
         return 0
     value = bucket_mapping.get(key)
     return value if isinstance(value, int) else 0


### PR DESCRIPTION
## Summary
Six fixes for core library correctness bugs found in the post-hoc audit.

## Changes
- **run_activity.py**: `isinstance(x, Mapping)` → `hasattr(x, "get")` — Pydantic RunDrift models don't implement `__iter__`/`__len__`, so `Mapping` check always returned False, silently dropping drift bucket values
- **repo_identity.py**: Don't skip a directory because it has a suffix — `my.repo` was treated as a file, causing `.git` detection to skip it
- **provider_identity.py**: Populated `_RUNTIME_PROVIDER_ALIASES` — "claude", "openai", "google", etc. now correctly resolve instead of falling through to "unknown"
- **pricing.py**: Check if all per-message estimates are exact before reporting "priced" — fully exact sessions now report `status="exact"` instead of `"priced"`
- **neighbor_candidates.py**: Don't default provider to the target conversation's provider — this silently limited cross-provider discovery
- **hashing.py**: Use stdlib json instead of orjson for `hash_payload` — orjson can produce different byte output across versions for non-ASCII content, breaking content-addressed storage

Closes #549

🤖 Generated with [Claude Code](https://claude.com/claude-code)