### PR TITLE
chore: housekeeping — remove unused TypeVar, cache sorted pricing keys, export CheckCommandDecorator

### DIFF
--- a/polylogue/cli/check_options.py
+++ b/polylogue/cli/check_options.py
@@ -110,4 +110,4 @@ def apply_check_command_options(func: Callable[..., object]) -> Callable[..., ob
     return func
 
 
-__all__ = ["CHECK_COMMAND_OPTION_DECORATORS", "apply_check_command_options"]
+__all__ = ["CHECK_COMMAND_OPTION_DECORATORS", "CheckCommandDecorator", "apply_check_command_options"]

--- a/polylogue/lib/pricing.py
+++ b/polylogue/lib/pricing.py
@@ -153,6 +153,8 @@ PRICING: dict[str, ModelPricing] = {
     "gemini-2.5-pro": ModelPricing("google", 1.25, 10.0),
 }
 
+_PRICING_KEYS_DESC = tuple(sorted(PRICING, key=len, reverse=True))
+
 
 def _coerce_float(value: object) -> float | None:
     if isinstance(value, bool) or value is None:
@@ -204,7 +206,7 @@ def _normalize_model(model: str) -> str:
     lowered = lowered.removeprefix("gemini/")
     if lowered in PRICING:
         return lowered
-    for key in sorted(PRICING, key=len, reverse=True):
+    for key in _PRICING_KEYS_DESC:
         if lowered.startswith(key):
             return key
     return lowered

--- a/polylogue/pipeline/run_support.py
+++ b/polylogue/pipeline/run_support.py
@@ -2,13 +2,10 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from pathlib import Path
-from typing import TypeVar
 
 from polylogue.api.sync.bridge import run_coroutine_sync
 from polylogue.config import Config, Source
 from polylogue.lib.json import JSONDocument, dumps
-
-T = TypeVar("T")
 
 RUN_STAGE_CHOICES: tuple[str, ...] = (
     "acquire",


### PR DESCRIPTION
## Summary
Small housekeeping fixes from #550 audit findings.

- Remove unused `TypeVar("T")` from run_support.py
- Cache `sorted(PRICING, key=len, reverse=True)` as module-level `_PRICING_KEYS_DESC`
- Add `CheckCommandDecorator` to `__all__` in check_options.py

Ref #550

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized pricing model normalization to reduce redundant computations

* **Chores**
  * Removed unused imports from pipeline support utilities
  * Updated module exports for CLI check options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->