### PR TITLE
feat(search): degrade gracefully on small FTS gaps instead of hard-failing (#499)

### DIFF
--- a/polylogue/storage/backends/queries/conversations_search.py
+++ b/polylogue/storage/backends/queries/conversations_search.py
@@ -21,14 +21,10 @@ async def search_conversation_hits(
     limit: int = 100,
     providers: list[str] | None = None,
 ) -> ConversationSearchResult:
-    from polylogue.errors import DatabaseError
-    from polylogue.storage.fts.fts_lifecycle import message_fts_readiness_async
+    from polylogue.storage.fts.fts_lifecycle import check_fts_readiness, message_fts_readiness_async
 
-    readiness = await message_fts_readiness_async(conn)
-    if not bool(readiness["exists"]):
-        raise DatabaseError(f"Search index not built. {_MESSAGE_SEARCH_REPAIR_HINT}")
-    if not bool(readiness["ready"]):
-        raise DatabaseError(f"Search index is incomplete. {_MESSAGE_SEARCH_REPAIR_HINT}")
+    readiness = await message_fts_readiness_async(conn, exact_counts=True)
+    check_fts_readiness(readiness, _MESSAGE_SEARCH_REPAIR_HINT)
 
     from polylogue.storage.search import build_ranked_conversation_search_query
 
@@ -53,15 +49,11 @@ async def search_conversation_evidence_hits(
     providers: list[str] | None = None,
     since: str | None = None,
 ) -> list[ConversationSearchEvidenceHit]:
-    from polylogue.errors import DatabaseError
-    from polylogue.storage.fts.fts_lifecycle import message_fts_readiness_async
+    from polylogue.storage.fts.fts_lifecycle import check_fts_readiness, message_fts_readiness_async
     from polylogue.storage.search import build_ranked_conversation_search_query
 
-    readiness = await message_fts_readiness_async(conn)
-    if not bool(readiness["exists"]):
-        raise DatabaseError(f"Search index not built. {_MESSAGE_SEARCH_REPAIR_HINT}")
-    if not bool(readiness["ready"]):
-        raise DatabaseError(f"Search index is incomplete. {_MESSAGE_SEARCH_REPAIR_HINT}")
+    readiness = await message_fts_readiness_async(conn, exact_counts=True)
+    check_fts_readiness(readiness, _MESSAGE_SEARCH_REPAIR_HINT)
 
     query_spec = build_ranked_conversation_search_query(
         query=query,

--- a/polylogue/storage/fts/fts_lifecycle.py
+++ b/polylogue/storage/fts/fts_lifecycle.py
@@ -398,9 +398,46 @@ async def message_fts_readiness_async(
     }
 
 
+FTS_GAP_THRESHOLD = 0.01
+
+
+def check_fts_readiness(readiness: dict[str, object], repair_hint: str = "") -> None:
+    """Raise DatabaseError if the FTS index doesn't exist.
+
+    Degrade gracefully on small gaps: if the gap is ≤ FTS_GAP_THRESHOLD
+    (default 1%), warn and return instead of raising.
+    """
+    from polylogue.errors import DatabaseError
+
+    if not bool(readiness["exists"]):
+        raise DatabaseError(f"Search index not built. {repair_hint}")
+    if bool(readiness["ready"]):
+        return
+    indexed = int(readiness.get("indexed_rows", 0))
+    total = int(readiness.get("total_rows", 0))
+    if total > 0 and indexed > 0:
+        gap_ratio = (total - indexed) / total
+        if gap_ratio <= FTS_GAP_THRESHOLD:
+            missing = total - indexed
+            pct = gap_ratio * 100
+            import logging
+
+            logging.getLogger(__name__).warning(
+                "Search index is %d/%d messages behind (%.3f%%). "
+                "Results may be incomplete. Run `polylogue doctor --repair --target dangling_fts`.",
+                missing,
+                total,
+                pct,
+            )
+            return
+    raise DatabaseError(f"Search index is incomplete. {repair_hint}")
+
+
 __all__ = [
+    "FTS_GAP_THRESHOLD",
     "_MESSAGE_FTS_TRIGGER_DDL",
     "_chunked",
+    "check_fts_readiness",
     "ensure_fts_index_async",
     "ensure_fts_index_sync",
     "fts_index_status_async",

--- a/polylogue/storage/search/runtime.py
+++ b/polylogue/storage/search/runtime.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from polylogue.errors import DatabaseError
 from polylogue.maintenance.targets import build_maintenance_target_catalog
 from polylogue.storage.backends.connection import open_read_connection
-from polylogue.storage.fts.fts_lifecycle import message_fts_readiness_sync
+from polylogue.storage.fts.fts_lifecycle import check_fts_readiness, message_fts_readiness_sync
 from polylogue.storage.search.cache import SearchCacheKey
 from polylogue.storage.search.models import SearchHit, SearchResult
 from polylogue.storage.search.query_builders import build_ranked_conversation_search_query, resolve_conversation_path
@@ -54,11 +54,8 @@ def search_messages_impl(
 
     sql, params = query_spec.sql, query_spec.params
     with open_read_connection(db_path) as conn:
-        readiness = message_fts_readiness_sync(conn)
-        if not bool(readiness["exists"]):
-            raise DatabaseError(f"Search index not built. {_MESSAGE_SEARCH_REPAIR_HINT}")
-        if not bool(readiness["ready"]):
-            raise DatabaseError(f"Search index is incomplete. {_MESSAGE_SEARCH_REPAIR_HINT}")
+        readiness = message_fts_readiness_sync(conn, exact_counts=True)
+        check_fts_readiness(readiness, _MESSAGE_SEARCH_REPAIR_HINT)
         try:
             rows = conn.execute(sql, tuple(params)).fetchall()
         except sqlite3.Error as exc:


### PR DESCRIPTION
## Summary
When the FTS index is ≤1% behind the messages table, emit a warning instead of refusing all queries. Gaps above the threshold still hard-fail.

## Problem
Read-only query commands aborted with a hard error when the FTS index was even 0.002% behind. For 43 unindexed messages out of 1.86M, every search verb refused to execute.

## Solution
- Added `check_fts_readiness()` in `fts_lifecycle.py` — shared sync/async helper that computes gap ratio and either warns (≤1%) or raises (>1%)
- Updated `search_messages_impl` (runtime.py) to use the helper with `exact_counts=True`
- Updated both async search paths in `conversations_search.py`

The threshold (`FTS_GAP_THRESHOLD = 0.01`) is a module-level constant for now.

Closes #499

🤖 Generated with [Claude Code](https://claude.com/claude-code)