### PR TITLE
feat(daemon): add run supervisor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ documentation polish do not require an entry.
 
 - `polylogued` as the daemon/service executable; live source watching now runs
   as `polylogued watch`.
+- `polylogued run` to run live watching and the browser-capture receiver
+  together as daemon-owned components.
 - `dependabot.yml` for weekly Python and GitHub Actions updates with
   patch grouping.
 - `actionlint` workflow validating workflow YAML on PRs that touch

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Pipeline and maintenance verbs are explicit:
 ```bash
 polylogue run acquire parse materialize render index
 polylogue doctor --daemon
+polylogued run
 polylogued status
 polylogued watch
 polylogued browser-capture serve --host 127.0.0.1 --port 8765
@@ -119,6 +120,7 @@ Products are materialized from the archive and updated incrementally.
 ### Browser capture
 
 ```bash
+polylogued run
 polylogued browser-capture serve --host 127.0.0.1 --port 8765
 polylogued browser-capture status
 polylogued status

--- a/docs/browser-capture.md
+++ b/docs/browser-capture.md
@@ -9,6 +9,9 @@ Start the receiver:
 polylogued browser-capture serve
 ```
 
+For normal long-running local service use, `polylogued run` starts the browser
+capture receiver together with live source watching.
+
 The receiver listens on `127.0.0.1:8765` by default and accepts:
 
 - `GET /v1/status`

--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import click
 
 from polylogue.api import Polylogue
+from polylogue.browser_capture.server import BrowserCaptureHTTPServer, make_server
 from polylogue.core.json import dumps
 from polylogue.daemon.browser_capture import browser_capture_command
 from polylogue.daemon.status import daemon_status_payload, format_daemon_status_lines
@@ -28,6 +29,55 @@ async def run_live_watcher(
             watcher.stop()
 
 
+async def run_daemon_services(
+    *,
+    sources: tuple[WatchSource, ...],
+    debounce_s: float,
+    enable_watch: bool,
+    enable_browser_capture: bool,
+    browser_capture_host: str,
+    browser_capture_port: int,
+    browser_capture_spool_path: Path | None,
+) -> None:
+    """Run configured daemon components until interrupted."""
+    server: BrowserCaptureHTTPServer | None = None
+    server_task: asyncio.Task[None] | None = None
+    watcher: LiveWatcher | None = None
+    watcher_task: asyncio.Task[None] | None = None
+    tasks: list[asyncio.Task[None]] = []
+
+    try:
+        if enable_browser_capture:
+            server = make_server(browser_capture_host, browser_capture_port, spool_path=browser_capture_spool_path)
+            server_task = asyncio.create_task(asyncio.to_thread(server.serve_forever, 0.5))
+            tasks.append(server_task)
+
+        if enable_watch:
+            async with Polylogue() as polylogue:
+                watcher = LiveWatcher(polylogue, sources, debounce_s=debounce_s)
+                watcher_task = asyncio.create_task(watcher.run())
+                tasks.append(watcher_task)
+                await asyncio.gather(*tasks)
+        elif tasks:
+            await asyncio.gather(*tasks)
+    finally:
+        if watcher is not None:
+            watcher.stop()
+        if server is not None:
+            server.shutdown()
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+        await _drain_tasks(tasks)
+        if server is not None:
+            server.server_close()
+
+
+async def _drain_tasks(tasks: list[asyncio.Task[None]]) -> None:
+    if tasks:
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+
 @click.group(help="Run long-lived Polylogue local services.")
 def main() -> None:
     pass
@@ -46,6 +96,64 @@ def status_command(spool_path: Path | None, output_format: str | None) -> None:
         return
     for line in format_daemon_status_lines(payload):
         click.echo(line)
+
+
+@main.command("run", help="Run configured long-lived daemon components.")
+@click.option(
+    "--root",
+    "roots",
+    multiple=True,
+    type=click.Path(exists=False, path_type=Path),
+    help="Override watch root (repeatable). Defaults to ~/.claude/projects and ~/.codex/sessions.",
+)
+@click.option(
+    "--debounce-s",
+    type=float,
+    default=2.0,
+    show_default=True,
+    help="Quiet-period (seconds) before parsing a modified file.",
+)
+@click.option("--host", default="127.0.0.1", show_default=True, help="Browser-capture receiver host.")
+@click.option("--port", default=8765, show_default=True, type=int, help="Browser-capture receiver port.")
+@click.option("--spool", "spool_path", type=click.Path(path_type=Path), default=None)
+@click.option("--no-watch", is_flag=True, help="Do not run the live source watcher.")
+@click.option("--no-browser-capture", is_flag=True, help="Do not run the browser-capture receiver.")
+def run_command(
+    roots: tuple[Path, ...],
+    debounce_s: float,
+    host: str,
+    port: int,
+    spool_path: Path | None,
+    no_watch: bool,
+    no_browser_capture: bool,
+) -> None:
+    enable_watch = not no_watch
+    enable_browser_capture = not no_browser_capture
+    if not enable_watch and not enable_browser_capture:
+        raise click.UsageError("at least one daemon component must be enabled")
+
+    sources = tuple(WatchSource(name=p.name, root=p) for p in roots) if roots else default_sources()
+    components = []
+    if enable_watch:
+        components.append(f"watch={len(sources)} source(s)")
+    if enable_browser_capture:
+        components.append(f"browser-capture=http://{host}:{port}")
+    click.echo(f"Starting polylogued ({', '.join(components)}). Ctrl-C to stop.", err=True)
+
+    try:
+        asyncio.run(
+            run_daemon_services(
+                sources=sources,
+                debounce_s=debounce_s,
+                enable_watch=enable_watch,
+                enable_browser_capture=enable_browser_capture,
+                browser_capture_host=host,
+                browser_capture_port=port,
+                browser_capture_spool_path=spool_path,
+            )
+        )
+    except KeyboardInterrupt:
+        click.echo("Stopping polylogued.", err=True)
 
 
 @main.command("watch", help="Watch source directories and ingest new sessions live.")
@@ -73,4 +181,4 @@ def watch_command(roots: tuple[Path, ...], debounce_s: float) -> None:
     asyncio.run(run_live_watcher(sources=sources, debounce_s=debounce_s))
 
 
-__all__ = ["main", "run_live_watcher", "status_command", "watch_command"]
+__all__ = ["main", "run_command", "run_daemon_services", "run_live_watcher", "status_command", "watch_command"]

--- a/tests/unit/daemon/test_daemon_cli.py
+++ b/tests/unit/daemon/test_daemon_cli.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import cast
 from unittest.mock import patch
 
+import pytest
 from click.testing import CliRunner
 
 from polylogue.core.json import JSONDocument, loads
@@ -18,6 +19,7 @@ def test_polylogued_help_lists_watch_command() -> None:
 
     assert result.exit_code == 0
     assert "browser-capture" in result.output
+    assert "run" in result.output
     assert "status" in result.output
     assert "watch" in result.output
     assert "long-lived Polylogue local services" in result.output
@@ -71,6 +73,30 @@ def test_polylogued_browser_capture_help_lists_service_commands() -> None:
     assert result.exit_code == 0
     assert "serve" in result.output
     assert "status" in result.output
+
+
+def test_polylogued_run_uses_default_sources() -> None:
+    sources = (WatchSource(name="codex", root=Path("/tmp/codex")),)
+
+    with (
+        patch("polylogue.daemon.cli.default_sources", return_value=sources) as default_sources,
+        patch("polylogue.daemon.cli.asyncio.run") as run,
+    ):
+        result = CliRunner().invoke(main, ["run", "--no-browser-capture", "--debounce-s", "0.25"])
+
+    assert result.exit_code == 0
+    default_sources.assert_called_once_with()
+    coroutine = run.call_args.kwargs.get("main") or run.call_args.args[0]
+    assert inspect.iscoroutine(coroutine)
+    coroutine.close()
+    assert "Starting polylogued (watch=1 source(s)). Ctrl-C to stop." in result.stderr
+
+
+def test_polylogued_run_rejects_empty_component_set() -> None:
+    result = CliRunner().invoke(main, ["run", "--no-watch", "--no-browser-capture"])
+
+    assert result.exit_code != 0
+    assert "at least one daemon component must be enabled" in result.output
 
 
 def test_polylogued_watch_uses_default_sources() -> None:
@@ -148,3 +174,83 @@ def test_run_live_watcher_stops_on_keyboard_interrupt() -> None:
         asyncio.run(daemon_cli.run_live_watcher(sources=sources, debounce_s=1.0))
 
     assert stopped == [True]
+
+
+def test_run_daemon_services_stops_live_watcher_on_failure() -> None:
+    from polylogue.daemon import cli as daemon_cli
+
+    class FakePolylogue:
+        async def __aenter__(self) -> object:
+            return object()
+
+        async def __aexit__(self, *exc: object) -> None:
+            return None
+
+    stopped: list[bool] = []
+
+    class FakeWatcher:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            pass
+
+        async def run(self) -> None:
+            raise RuntimeError("watch stopped")
+
+        def stop(self) -> None:
+            stopped.append(True)
+
+    with (
+        patch.object(daemon_cli, "Polylogue", FakePolylogue),
+        patch.object(daemon_cli, "LiveWatcher", FakeWatcher),
+        pytest.raises(RuntimeError, match="watch stopped"),
+    ):
+        asyncio.run(
+            daemon_cli.run_daemon_services(
+                sources=(WatchSource(name="codex", root=Path("/tmp/codex")),),
+                debounce_s=1.0,
+                enable_watch=True,
+                enable_browser_capture=False,
+                browser_capture_host="127.0.0.1",
+                browser_capture_port=8765,
+                browser_capture_spool_path=None,
+            )
+        )
+
+    assert stopped == [True]
+
+
+def test_run_daemon_services_closes_browser_capture_server_on_failure() -> None:
+    from polylogue.daemon import cli as daemon_cli
+
+    class FakeServer:
+        shutdown_called = False
+        close_called = False
+
+        def serve_forever(self, poll_interval: float = 0.5) -> None:
+            assert poll_interval == 0.5
+            raise RuntimeError("server stopped")
+
+        def shutdown(self) -> None:
+            self.shutdown_called = True
+
+        def server_close(self) -> None:
+            self.close_called = True
+
+    server = FakeServer()
+    with (
+        patch.object(daemon_cli, "make_server", return_value=server),
+        pytest.raises(RuntimeError, match="server stopped"),
+    ):
+        asyncio.run(
+            daemon_cli.run_daemon_services(
+                sources=(),
+                debounce_s=1.0,
+                enable_watch=False,
+                enable_browser_capture=True,
+                browser_capture_host="127.0.0.1",
+                browser_capture_port=8765,
+                browser_capture_spool_path=None,
+            )
+        )
+
+    assert server.shutdown_called is True
+    assert server.close_called is True


### PR DESCRIPTION
## Summary

Adds `polylogued run` as the normal long-running daemon entrypoint. It supervises live source watching and the browser-capture receiver together, with flags to disable either component when needed.

## Problem

The service/protocol cleanup split live watching and browser capture out of the interactive `polylogue` CLI, but the resulting daemon still only had component-specific commands. Normal local operation needed one daemon-owned process entrypoint instead of asking users to start separate long-running commands.

## Solution

- Added `run_daemon_services()` to start configured daemon components and shut down watcher/server resources on interruption or task failure.
- Added `polylogued run` with live-watch options, browser-capture host/port/spool options, and `--no-watch` / `--no-browser-capture` component selection.
- Kept `polylogued watch` and `polylogued browser-capture serve/status` as focused component commands.
- Updated README, browser-capture docs, changelog, and daemon CLI tests.

This does not add localhost web/API serving yet; it only supervises the daemon components that already exist.

## Verification

- `ruff format polylogue/daemon tests/unit/daemon/test_daemon_cli.py`
- `ruff check polylogue/daemon tests/unit/daemon/test_daemon_cli.py --fix`
- `mypy polylogue/ tests/unit/daemon/test_daemon_cli.py`
- `pytest -q tests/unit/daemon/test_daemon_cli.py`
- `devtools render-all --check`
- `uv run polylogued run --help`
- `uv run polylogued run --no-watch --no-browser-capture`
- `devtools verify --quick`
- pre-push `devtools verify --quick`

Ref #635