### PR TITLE
refactor(verification): use insight vocabulary for read models

### DIFF
--- a/devtools/build_topology_projection.py
+++ b/devtools/build_topology_projection.py
@@ -118,7 +118,7 @@ STORAGE_ROOT_KEEP = frozenset(
 
 # Placement owner per target prefix.
 TARGET_TO_OWNER = [
-    ("polylogue/insights/", "product-domain"),
+    ("polylogue/insights/", "insight-domain"),
     ("polylogue/api/", "api-surface"),
     ("polylogue/artifacts/", "artifact-domain"),
     ("polylogue/readiness/", "readiness-domain"),

--- a/devtools/render_quality_reference.py
+++ b/devtools/render_quality_reference.py
@@ -166,9 +166,9 @@ def _render_test_infrastructure_section() -> list[str]:
         "",
         "| Helper | Contract | Primary consumers |",
         "| --- | --- | --- |",
-        "| `tests/infra/json_contracts.py` | Typed JSON object/envelope/result narrowing for machine surfaces | CLI, MCP, product, and devtools JSON tests |",
+        "| `tests/infra/json_contracts.py` | Typed JSON object/envelope/result narrowing for machine surfaces | CLI, MCP, insight, and devtools JSON tests |",
         "| `tests/infra/mcp.py` | MCP surface registration, invocation, and mock archive seams | MCP server and tool-contract tests |",
-        "| `tests/infra/storage_records.py` | Durable archive row builders and DB factories | Storage, CLI, product, and health tests |",
+        "| `tests/infra/storage_records.py` | Durable archive row builders and DB factories | Storage, CLI, insight, and health tests |",
         "| `tests/infra/surfaces.py` | Cross-surface archive adapters over SQLite, repository, and facade projections | Scenario/oracle tests |",
         "",
     ]

--- a/devtools/render_topology_status.py
+++ b/devtools/render_topology_status.py
@@ -24,7 +24,7 @@ GENERATED_END = "<!-- END GENERATED: topology-status -->"
 
 OWNER_TITLES = {
     "api-surface": "library API and sync adapters",
-    "product-domain": "derived product modules",
+    "insight-domain": "derived insight modules",
     "archive-filter": "archive filter semantics",
     "archive-query": "archive query semantics",
     "storage-repository": "repository persistence adapters",

--- a/devtools/validation_lane_catalog_live.py
+++ b/devtools/validation_lane_catalog_live.py
@@ -23,7 +23,7 @@ polylogue_lane = partial(_polylogue_lane, category="live")
 devtools_lane = partial(_devtools_lane, category="live")
 
 
-def _live_product_lanes() -> dict[str, LaneEntry]:
+def _live_insight_lanes() -> dict[str, LaneEntry]:
     return {
         spec.name: polylogue_lane(
             spec.name,
@@ -88,7 +88,7 @@ LIVE_LANES: dict[str, LaneEntry] = {
         "--json",
     ),
     **_live_operational_lanes(),
-    **_live_product_lanes(),
+    **_live_insight_lanes(),
     **_memory_budget_operational_lanes(),
 }
 

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -13,14 +13,14 @@ repo readiness: generated-surface rendering, baseline verification, validation
 lane dispatch, package/build checks, and branch/PR readiness gates.
 
 Domain proof semantics belong in the verification-lab, proof, schema, scenario,
-or product modules first. A `devtools` command may expose them only as a thin
-operator entrypoint that delegates to the owning lab/product implementation.
+or insight modules first. A `devtools` command may expose them only as a thin
+operator entrypoint that delegates to the owning lab or insight implementation.
 
 Routine command placement:
 
 - keep repo state, rendering, packaging, and PR-readiness orchestration in
   `devtools`;
-- keep archive/product workflows in `polylogue` CLI/API surfaces;
+- keep archive/insight workflows in `polylogue` CLI/API surfaces;
 - keep proof/evidence/scenario behavior behind the verification-lab surface;
 - prefer validation lanes and `devtools verify --lab` to compose lab checks
   rather than duplicating domain checks inside `devtools verify`.

--- a/docs/plans/assurance-domains.yaml
+++ b/docs/plans/assurance-domains.yaml
@@ -183,8 +183,8 @@ domains:
     oracle_present: false
     oracle: null
     notes: >
-      Scenario specs exist (scenarios/) for CLI surfaces, product
-      surfaces, operational surfaces, corpus scenarios. No oracle
+      Scenario specs exist (scenarios/) for CLI, insight,
+      operational, and corpus surfaces. No oracle
       verifying spec-to-behavior correspondence.
 
   migration_safety:
@@ -244,7 +244,7 @@ domains:
     oracle_present: true
     oracle: construction_sanity
     notes: >
-      Scenario surface families: CLI, product, operational, corpus.
+      Scenario surface families: CLI, insight, operational, corpus.
       ScenarioSpec base class with assertions, projections,
       metadata. No systematic coverage audit of which subjects
       have scenarios.

--- a/docs/plans/file-size-budgets.yaml
+++ b/docs/plans/file-size-budgets.yaml
@@ -35,7 +35,7 @@ exceptions:
 
   - path: tests/unit/storage/test_store_ops.py
     ceiling: 2000
-    reason: "tracked split into CRUD/FTS/hybrid/product-persistence contracts"
+    reason: "tracked split into CRUD/FTS/hybrid/insight-persistence contracts"
 
   - path: tests/unit/sources/test_models.py
     ceiling: 1700
@@ -51,7 +51,7 @@ exceptions:
 
   - path: tests/unit/mcp/test_tool_contracts.py
     ceiling: 1400
-    reason: "tracked split into archive-query vs product-tool contracts"
+    reason: "tracked split into archive-query vs insight-tool contracts"
 
   - path: tests/unit/pipeline/test_run_sources.py
     ceiling: 1400

--- a/docs/plans/layering.yaml
+++ b/docs/plans/layering.yaml
@@ -2,7 +2,7 @@
 #
 # Each rule declares forbidden imports for a package ring. The current
 # enforced baseline is intentionally the no-backward-import contract: substrate
-# rings must not reach into product/lab/surface adapters. Aspirational surface
+# rings must not reach into insight/lab/surface adapters. Aspirational surface
 # slimming belongs in coverage manifests until call sites are moved.
 #
 # Semantics:

--- a/docs/plans/scenario-coverage.yaml
+++ b/docs/plans/scenario-coverage.yaml
@@ -24,12 +24,12 @@ families:
       commands via help-output and exit-code assertions.
 
   - name: insight_surfaces
-    description: Product command surface exercises
+    description: Insight command surface exercises
     subject: cli_surface
     scenario_count: dynamic
     location: polylogue/scenarios/insight_surfaces.py
     notes: >
-      Covers product commands (resume, insights) and their
+      Covers insight commands (resume, insights) and their
       rendering contracts. Includes live and contract variants.
 
   - name: operational_surfaces

--- a/docs/test-quality-workflows.md
+++ b/docs/test-quality-workflows.md
@@ -70,9 +70,9 @@ per-suite JSON parsing, surface invocation, archive seeding, or cross-surface or
 
 | Helper | Contract | Primary consumers |
 | --- | --- | --- |
-| `tests/infra/json_contracts.py` | Typed JSON object/envelope/result narrowing for machine surfaces | CLI, MCP, product, and devtools JSON tests |
+| `tests/infra/json_contracts.py` | Typed JSON object/envelope/result narrowing for machine surfaces | CLI, MCP, insight, and devtools JSON tests |
 | `tests/infra/mcp.py` | MCP surface registration, invocation, and mock archive seams | MCP server and tool-contract tests |
-| `tests/infra/storage_records.py` | Durable archive row builders and DB factories | Storage, CLI, product, and health tests |
+| `tests/infra/storage_records.py` | Durable archive row builders and DB factories | Storage, CLI, insight, and health tests |
 | `tests/infra/surfaces.py` | Cross-surface archive adapters over SQLite, repository, and facade projections | Scenario/oracle tests |
 
 ### Validation lanes

--- a/docs/verification-lab.md
+++ b/docs/verification-lab.md
@@ -22,10 +22,10 @@ Selected vertical slices:
 
 This surface is intentionally a repo operator surface. It works over proof
 subjects, generated docs, changed files, evidence envelopes, and local
-verification artifacts. Product/archive-facing checks remain in the archive CLI
+verification artifacts. Archive-facing checks remain in the archive CLI
 where they already belong, such as `polylogue doctor --proof` and schema proof
 rendering. Schema package auditing moved to `devtools schema-audit` so
-repository QA does not pollute first-contact product help.
+repository QA does not pollute first-contact archive help.
 
 ## Catalog Grounding
 
@@ -56,7 +56,7 @@ settled.
 the archive CLI. That blurs the boundary between archive workflows and
 repository proof obligations.
 
-`polylogue audit` overloaded product help with repository QA. Keeping the lab
+`polylogue audit` overloaded archive help with repository QA. Keeping the lab
 surface in `devtools` avoids turning archive usage into source-tree ceremony.
 
 Exposing only `devtools render-verification-catalog` is now too narrow. The

--- a/polylogue/scenarios/execution.py
+++ b/polylogue/scenarios/execution.py
@@ -116,16 +116,16 @@ def _first_non_option(argv: tuple[str, ...]) -> str | None:
     return None
 
 
-def _metadata_for_polylogue_products(argv: tuple[str, ...]) -> ScenarioMetadata:
+def _metadata_for_polylogue_insights(argv: tuple[str, ...]) -> ScenarioMetadata:
     from polylogue.insights.registry import INSIGHT_REGISTRY
 
     try:
-        products_index = argv.index("insights")
+        insights_index = argv.index("insights")
     except ValueError:
         return ScenarioMetadata()
-    if products_index + 1 >= len(argv):
+    if insights_index + 1 >= len(argv):
         return ScenarioMetadata()
-    subcommand = argv[products_index + 1]
+    subcommand = argv[insights_index + 1]
     direct_operation = _INSIGHT_SUBCOMMAND_OPERATION_NAMES.get(subcommand)
     if direct_operation:
         return _metadata_for_operations(direct_operation)
@@ -213,7 +213,7 @@ def _default_metadata_for_polylogue(argv: tuple[str, ...]) -> ScenarioMetadata:
     if "schema" in argv:
         return _metadata_for_polylogue_schema(argv)
     if "insights" in argv:
-        return _metadata_for_polylogue_products(argv)
+        return _metadata_for_polylogue_insights(argv)
     if "doctor" in argv:
         return _metadata_for_polylogue_doctor(argv)
     if "embed" in argv:

--- a/polylogue/storage/derived/derived_status.py
+++ b/polylogue/storage/derived/derived_status.py
@@ -8,7 +8,7 @@ from typing import TypeAlias
 
 from polylogue.maintenance.models import DerivedModelStatus
 from polylogue.storage.action_events.status import action_event_read_model_status_sync
-from polylogue.storage.derived.insights import build_archive_product_statuses, pending_docs, pending_rows
+from polylogue.storage.derived.insights import build_archive_insight_statuses, pending_docs, pending_rows
 from polylogue.storage.embeddings.embedding_stats import read_embedding_stats_sync
 from polylogue.storage.embeddings.models import EmbeddingStatsSnapshot
 from polylogue.storage.fts.fts_lifecycle import message_fts_readiness_sync
@@ -175,7 +175,7 @@ def collect_derived_model_statuses_sync(
     )
 
     return {
-        **build_archive_product_statuses(metrics),
+        **build_archive_insight_statuses(metrics),
         **build_retrieval_statuses(metrics),
     }
 

--- a/polylogue/storage/derived/insights.py
+++ b/polylogue/storage/derived/insights.py
@@ -191,7 +191,7 @@ def build_profile_statuses(metrics: Metrics) -> dict[str, DerivedModelStatus]:
 
 
 # ---------------------------------------------------------------------------
-# Timeline/work-product statuses
+# Timeline/work insight statuses
 # ---------------------------------------------------------------------------
 
 
@@ -381,7 +381,7 @@ def build_aggregate_statuses(metrics: Metrics) -> dict[str, DerivedModelStatus]:
 # ---------------------------------------------------------------------------
 
 
-def build_archive_product_statuses(metrics: Metrics) -> dict[str, DerivedModelStatus]:
+def build_archive_insight_statuses(metrics: Metrics) -> dict[str, DerivedModelStatus]:
     return {
         **build_action_statuses(metrics),
         **build_profile_statuses(metrics),
@@ -390,4 +390,4 @@ def build_archive_product_statuses(metrics: Metrics) -> dict[str, DerivedModelSt
     }
 
 
-__all__ = ["build_archive_product_statuses"]
+__all__ = ["build_archive_insight_statuses"]

--- a/polylogue/storage/insights/aggregate/records.py
+++ b/polylogue/storage/insights/aggregate/records.py
@@ -1,4 +1,4 @@
-"""Aggregate derived product storage models."""
+"""Aggregate derived insight storage models."""
 
 from __future__ import annotations
 

--- a/polylogue/storage/insights/session/records.py
+++ b/polylogue/storage/insights/session/records.py
@@ -1,4 +1,4 @@
-"""Session-level derived product storage models."""
+"""Session-level derived insight storage models."""
 
 from __future__ import annotations
 

--- a/polylogue/storage/insights/session/status.py
+++ b/polylogue/storage/insights/session/status.py
@@ -19,7 +19,7 @@ CountEquality: TypeAlias = tuple[str, str]
 
 @dataclass(frozen=True)
 class SessionInsightTableDescriptor:
-    """Table presence and optional row-count query for product status."""
+    """Table presence and optional row-count query for insight status."""
 
     key: str
     table_name: str
@@ -146,7 +146,7 @@ class SessionInsightCountDescriptor:
 
 @dataclass(frozen=True)
 class SessionInsightReadyDescriptor:
-    """Readiness predicate over a product table and named status counts."""
+    """Readiness predicate over an insight table and named status counts."""
 
     ready_key: SessionInsightReadyFlag
     table_key: str

--- a/polylogue/storage/insights/session/storage.py
+++ b/polylogue/storage/insights/session/storage.py
@@ -1,4 +1,4 @@
-"""Session-product storage writes (profiles, timelines, aggregates)."""
+"""Session insight storage writes (profiles, timelines, aggregates)."""
 
 from __future__ import annotations
 

--- a/polylogue/storage/insights/timeline/records.py
+++ b/polylogue/storage/insights/timeline/records.py
@@ -1,4 +1,4 @@
-"""Timeline-oriented derived product storage models."""
+"""Timeline-oriented derived insight storage models."""
 
 from __future__ import annotations
 

--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -444,7 +444,7 @@ def collect_archive_debt_statuses_sync(
         "session_insights": _archive_debt_status(
             "session_insights",
             issue_count=session_insights,
-            detail="Session-product read models ready"
+            detail="Session insight read models ready"
             if session_insights == 0
             else f"{session_insights:,} pending/stale/orphaned session-insight rows",
         ),

--- a/tests/unit/devtools/test_quality_registry.py
+++ b/tests/unit/devtools/test_quality_registry.py
@@ -113,22 +113,22 @@ def test_build_quality_registry_exposes_live_catalogs() -> None:
     assert "session_insight_fts" in session_insights.artifact_targets
     assert session_insights.operation_targets == ("materialize-session-insights",)
     assert session_insights.tags == ("benchmark", "synthetic", "session-insights")
-    product_profiles = next(
+    insight_profiles = next(
         entry for entry in registry.catalog.exercise_scenarios if entry.name == "json-insights-profiles"
     )
-    assert product_profiles.path_targets == ("session-profile-query-loop",)
-    assert product_profiles.artifact_targets == (
+    assert insight_profiles.path_targets == ("session-profile-query-loop",)
+    assert insight_profiles.artifact_targets == (
         "session_profile_rows",
         "session_profile_merged_fts",
         "session_profile_results",
     )
-    assert product_profiles.operation_targets == ("cli.json-contract", "query-session-profiles")
-    product_threads = next(
+    assert insight_profiles.operation_targets == ("cli.json-contract", "query-session-profiles")
+    insight_threads = next(
         entry for entry in registry.catalog.exercise_scenarios if entry.name == "json-insights-threads"
     )
-    assert product_threads.path_targets == ("work-thread-query-loop",)
-    assert product_threads.artifact_targets == ("work_thread_rows", "work_thread_fts", "work_thread_results")
-    assert product_threads.operation_targets == ("cli.json-contract", "query-work-threads")
+    assert insight_threads.path_targets == ("work-thread-query-loop",)
+    assert insight_threads.artifact_targets == ("work_thread_rows", "work_thread_fts", "work_thread_results")
+    assert insight_threads.operation_targets == ("cli.json-contract", "query-work-threads")
     action_event_preview = next(
         entry for entry in registry.scenario_projections if entry.name == "json-doctor-action-event-preview"
     )

--- a/tests/unit/devtools/test_validation_lanes.py
+++ b/tests/unit/devtools/test_validation_lanes.py
@@ -103,14 +103,14 @@ class TestLaneParsing:
         assert "archive_readiness" in lane.artifact_targets
         assert "project-archive-readiness" in lane.operation_targets
 
-    def test_live_products_status_lane_infers_status_query_metadata(self) -> None:
+    def test_live_insights_status_lane_infers_status_query_metadata(self) -> None:
         lane = LANES["live-insights-status"]
 
         assert lane.path_targets == ("session-insight-status-query-loop",)
         assert lane.artifact_targets == ("session_insight_readiness", "session_insight_status_results")
         assert lane.operation_targets == ("query-session-insight-status",)
 
-    def test_live_products_debt_lane_infers_archive_debt_metadata(self) -> None:
+    def test_live_insights_debt_lane_infers_archive_debt_metadata(self) -> None:
         lane = LANES["live-insights-debt"]
 
         assert lane.path_targets == ("archive-debt-query-loop",)
@@ -265,7 +265,7 @@ class TestCommandConstruction:
         assert lane.operation_targets == ("publish-site",)
         assert lane.tags == ("contract", "maintenance", "publication")
 
-    def test_archive_data_products_lane_uses_product_and_consumer_suite(self) -> None:
+    def test_archive_data_insights_lane_uses_insight_and_consumer_suite(self) -> None:
         cmd = build_lane_command(LANES["archive-data-insights"])
         assert cmd[0] == "pytest"
         assert "tests/unit/cli/test_insights.py" in cmd
@@ -273,7 +273,7 @@ class TestCommandConstruction:
         assert "tests/unit/mcp/test_tool_contracts.py" in cmd
         assert "tests/integration/test_health.py" in cmd
 
-    def test_semantic_product_normalization_lane_uses_normalization_toolchain_suite(self) -> None:
+    def test_semantic_insight_normalization_lane_uses_normalization_toolchain_suite(self) -> None:
         cmd = build_lane_command(LANES["semantic-insight-normalization"])
         assert cmd[0] == "pytest"
         assert "tests/unit/core/test_repo_identity.py" in cmd
@@ -366,7 +366,7 @@ class TestCommandConstruction:
         )
         assert lane.tags == ("contract", "retrieval", "embeddings", "readiness")
 
-    def test_heuristic_inference_contracts_lane_uses_semantic_product_suite(self) -> None:
+    def test_heuristic_inference_contracts_lane_uses_semantic_insight_suite(self) -> None:
         cmd = build_lane_command(LANES["heuristic-inference-contracts"])
         assert cmd[0] == "pytest"
         assert "tests/unit/cli/test_insights.py" in cmd
@@ -441,7 +441,7 @@ class TestCommandConstruction:
         assert "--cleanup" in cmd
         assert "--preview" in cmd
 
-    def test_live_products_tags_lane_uses_products_entrypoint(self) -> None:
+    def test_live_insights_tags_lane_uses_insights_entrypoint(self) -> None:
         cmd = build_lane_command(LANES["live-insights-tags"])
         assert cmd[:1] == ["polylogue"]
         assert "insights" in cmd
@@ -449,7 +449,7 @@ class TestCommandConstruction:
         assert "--format" in cmd
         assert "json" in cmd
 
-    def test_live_products_day_summaries_lane_uses_products_entrypoint(self) -> None:
+    def test_live_insights_day_summaries_lane_uses_insights_entrypoint(self) -> None:
         cmd = build_lane_command(LANES["live-insights-day-summaries"])
         assert cmd[:1] == ["polylogue"]
         assert "insights" in cmd
@@ -487,7 +487,7 @@ class TestLaneAssertions:
         assert exit_code == 1
         assert "failed assertion" in captured.out
 
-    def test_live_products_analytics_lane_uses_products_entrypoint(self) -> None:
+    def test_live_insights_analytics_lane_uses_insights_entrypoint(self) -> None:
         cmd = build_lane_command(LANES["live-insights-analytics"])
         assert cmd[:1] == ["polylogue"]
         assert "insights" in cmd
@@ -495,7 +495,7 @@ class TestLaneAssertions:
         assert "--format" in cmd
         assert "json" in cmd
 
-    def test_live_products_debt_lane_uses_products_entrypoint(self) -> None:
+    def test_live_insights_debt_lane_uses_insights_entrypoint(self) -> None:
         cmd = build_lane_command(LANES["live-insights-debt"])
         assert cmd[:1] == ["polylogue"]
         assert "insights" in cmd
@@ -503,7 +503,7 @@ class TestLaneAssertions:
         assert "--format" in cmd
         assert "json" in cmd
 
-    def test_live_products_profiles_evidence_lane_uses_tiered_products_entrypoint(self) -> None:
+    def test_live_insights_profiles_evidence_lane_uses_tiered_insights_entrypoint(self) -> None:
         cmd = build_lane_command(LANES["live-insights-profiles-evidence"])
         assert cmd[:1] == ["polylogue"]
         assert "insights" in cmd
@@ -512,7 +512,7 @@ class TestLaneAssertions:
         assert "--format" in cmd
         assert "json" in cmd
 
-    def test_live_products_profiles_inference_lane_uses_tiered_products_entrypoint(self) -> None:
+    def test_live_insights_profiles_inference_lane_uses_tiered_insights_entrypoint(self) -> None:
         cmd = build_lane_command(LANES["live-insights-profiles-inference"])
         assert cmd[:1] == ["polylogue"]
         assert "insights" in cmd
@@ -521,7 +521,7 @@ class TestLaneAssertions:
         assert "--format" in cmd
         assert "json" in cmd
 
-    def test_live_products_enrichments_lane_uses_enrichment_entrypoint(self) -> None:
+    def test_live_insights_enrichments_lane_uses_enrichment_entrypoint(self) -> None:
         cmd = build_lane_command(LANES["live-insights-enrichments"])
         assert cmd[:1] == ["polylogue"]
         assert "insights" in cmd
@@ -591,7 +591,7 @@ class TestLaneAssertions:
         assert "live-maintenance-preview" in captured.out
         assert "maintenance-memory-budget" in captured.out
 
-    def test_archive_data_products_live_dry_run_includes_local_and_live_product_lanes(
+    def test_archive_data_insights_live_dry_run_includes_local_and_live_insight_lanes(
         self,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
@@ -602,7 +602,7 @@ class TestLaneAssertions:
         assert "archive-data-insights" in captured.out
         assert "live-insights-small" in captured.out
 
-    def test_domain_read_model_live_dry_run_includes_new_product_and_maintenance_lanes(
+    def test_domain_read_model_live_dry_run_includes_new_insight_and_maintenance_lanes(
         self,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
@@ -662,7 +662,7 @@ class TestLaneAssertions:
         assert "runtime-substrate-contracts" in captured.out
         assert "runtime-substrate-live" in captured.out
 
-    def test_semantic_product_live_dry_run_includes_normalized_product_and_maintenance_lanes(
+    def test_semantic_insight_live_dry_run_includes_normalized_insight_and_maintenance_lanes(
         self,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
@@ -675,7 +675,7 @@ class TestLaneAssertions:
         assert "live-insights-debt" in captured.out
         assert "live-maintenance-small" in captured.out
 
-    def test_semantic_product_hardening_dry_run_expands_both_subtrees(
+    def test_semantic_insight_hardening_dry_run_expands_both_subtrees(
         self,
         capsys: pytest.CaptureFixture[str],
     ) -> None:

--- a/tests/unit/storage/test_derived_status.py
+++ b/tests/unit/storage/test_derived_status.py
@@ -94,7 +94,7 @@ def test_collect_derived_statuses_skips_retrieval_band_recomputation(
             return EmbeddingStatsSnapshot()
 
         monkeypatch.setattr(derived_status_mod, "read_embedding_stats_sync", fake_embedding_stats)
-        monkeypatch.setattr(derived_status_mod, "build_archive_product_statuses", lambda _metrics: {})
+        monkeypatch.setattr(derived_status_mod, "build_archive_insight_statuses", lambda _metrics: {})
         monkeypatch.setattr(derived_status_mod, "build_retrieval_statuses", lambda _metrics: {})
 
         assert derived_status_mod.collect_derived_model_statuses_sync(conn, verify_full=False) == {}


### PR DESCRIPTION
## Summary

Renames the remaining developer-facing validation, topology, scenario, and derived-status wording for archive read models from product vocabulary to insight vocabulary.

## Problem

The public CLI and maintenance target cleanup moved derived archive read models toward `insights`, but repo verification surfaces still described those same read models as products. That kept a product/distribution term alive in validation lane helpers, topology owner labels, scenario coverage notes, derived-status entrypoints, and storage docstrings.

## Solution

- Renamed validation-lane helper/test names from product wording to insight wording.
- Renamed the scenario metadata helper for `polylogue insights` dispatch.
- Renamed `build_archive_product_statuses()` to `build_archive_insight_statuses()`.
- Updated topology owner labels, quality-reference text, scenario/assurance/layering manifest notes, verification-lab/devtools policy text, and session-insight storage/status docstrings.
- Left serialized proof-catalog names such as `product.surface` unchanged for a dedicated compatibility slice.

## Verification

- `ruff format devtools/render_quality_reference.py devtools/render_topology_status.py devtools/validation_lane_catalog_live.py devtools/build_topology_projection.py polylogue/scenarios/execution.py polylogue/storage/derived/derived_status.py polylogue/storage/derived/insights.py polylogue/storage/insights/session/storage.py polylogue/storage/insights/session/status.py tests/unit/devtools/test_quality_registry.py tests/unit/devtools/test_validation_lanes.py tests/unit/storage/test_derived_status.py`
- `ruff check devtools/render_quality_reference.py devtools/render_topology_status.py devtools/validation_lane_catalog_live.py devtools/build_topology_projection.py polylogue/scenarios/execution.py polylogue/storage/derived/derived_status.py polylogue/storage/derived/insights.py polylogue/storage/insights/session/storage.py polylogue/storage/insights/session/status.py tests/unit/devtools/test_quality_registry.py tests/unit/devtools/test_validation_lanes.py tests/unit/storage/test_derived_status.py`
- `mypy polylogue/`
- `pytest -q tests/unit/devtools/test_validation_lanes.py tests/unit/devtools/test_quality_registry.py tests/unit/storage/test_derived_status.py tests/unit/storage/test_repair.py`
- `devtools render-all --check`
- `devtools verify --quick`

Ref #635


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Clarified ownership and domain classifications for insight-related modules and workflows
  * Updated verification lab documentation to better distinguish devtools verification artifacts from archive-facing checks
  * Refined scenario coverage documentation for insight command surfaces

* **Chores**
  * Updated internal configuration and mappings to consistently classify insight-related targets and lanes
  * Adjusted storage model naming conventions and status messages for clarity
  * Updated test infrastructure references to reflect current primary consumers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->