### PR TITLE
refactor(proof): rename insight surface catalog subjects

### DIFF
--- a/docs/verification-catalog.md
+++ b/docs/verification-catalog.md
@@ -45,10 +45,10 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | `diagnostic.observable` | 1 |
 | `error.surface` | 2 |
 | `generated.scenario_family` | 9 |
+| `insight.surface` | 12 |
 | `maintenance.target` | 8 |
 | `operation.spec` | 43 |
 | `operation.spec.effect` | 108 |
-| `product.surface` | 12 |
 | `provider.capability` | 3 |
 | `schema.annotation` | 95 |
 | `schema.roundtrip` | 1 |
@@ -226,7 +226,7 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | `operation.effect.privacy_safe_evidence` | `serious` | `operation.effect.implication_violation` | tracked: abstract effect implication requires a concrete runner |
 | `operation.effect.explicit_dry_run_evidence` | `serious` | `operation.effect.implication_violation` | tracked: abstract effect implication requires a concrete runner |
 | `operation.effect.confirmed_before_execute` | `serious` | `operation.effect.implication_violation` | tracked: abstract effect implication requires a concrete runner |
-| `product.surface.registered` | `info` | `product.registry.omission` | tracked: None |
+| `insight.surface.registered` | `info` | `insight.registry.omission` | tracked: None |
 
 ## Runner Bindings
 
@@ -275,7 +275,7 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | `effect-implication-static-contract:operation.effect.privacy_safe_evidence` | `operation.effect.privacy_safe_evidence` | `structural` | `static` | commands=—; controlled_dims=`9`; uncontrolled_dims=`0`; network=`none`; live_archive=`False` | `authored` by `polylogue.proof.catalog` at `2026-04-22T00:00:00+00:00` |
 | `effect-implication-static-contract:operation.effect.explicit_dry_run_evidence` | `operation.effect.explicit_dry_run_evidence` | `structural` | `static` | commands=—; controlled_dims=`9`; uncontrolled_dims=`0`; network=`none`; live_archive=`False` | `authored` by `polylogue.proof.catalog` at `2026-04-22T00:00:00+00:00` |
 | `effect-implication-static-contract:operation.effect.confirmed_before_execute` | `operation.effect.confirmed_before_execute` | `structural` | `static` | commands=—; controlled_dims=`9`; uncontrolled_dims=`0`; network=`none`; live_archive=`False` | `authored` by `polylogue.proof.catalog` at `2026-04-22T00:00:00+00:00` |
-| `product-surface-static-contract:product.surface.registered` | `product.surface.registered` | `structural` | `static` | commands=—; controlled_dims=`9`; uncontrolled_dims=`0`; network=`none`; live_archive=`False` | `authored` by `polylogue.proof.catalog` at `2026-04-22T00:00:00+00:00` |
+| `insight-surface-static-contract:insight.surface.registered` | `insight.surface.registered` | `structural` | `static` | commands=—; controlled_dims=`9`; uncontrolled_dims=`0`; network=`none`; live_archive=`False` | `authored` by `polylogue.proof.catalog` at `2026-04-22T00:00:00+00:00` |
 
 ## Proof Obligations
 
@@ -300,6 +300,7 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | `generated.scenario.family_registered` | 9 |
 | `generated.scenario.local_deterministic` | 4 |
 | `generated.scenario.semantic_claim_mapping` | 9 |
+| `insight.surface.registered` | 12 |
 | `maintenance.repair.crash_consistency` | 8 |
 | `operation.effect.atomic` | 12 |
 | `operation.effect.atomic_rename` | 2 |
@@ -316,7 +317,6 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | `operation.effect.snapshot_consistent` | 34 |
 | `operation.effect.timeout_bounded` | 1 |
 | `parser.quarantine.context_redaction` | 1 |
-| `product.surface.registered` | 12 |
 | `provider.capability.identity_bridge` | 3 |
 | `provider.capability.partial_coverage_declared` | 3 |
 | `schema.foreign_key.resolves` | 7 |

--- a/polylogue/__init__.py
+++ b/polylogue/__init__.py
@@ -9,7 +9,7 @@ The package root intentionally exposes the archive-facing contract:
 
 Higher-order semantic-analysis helpers remain public, but they live behind
 their precise modules under ``polylogue.archive`` and related packages rather
-than being implied as part of the same root-level product surface.
+than being implied as part of the same root-level insight surface.
 """
 
 from __future__ import annotations

--- a/polylogue/proof/catalog.py
+++ b/polylogue/proof/catalog.py
@@ -481,7 +481,7 @@ def default_claims() -> tuple[Claim, ...]:
         *_architecture_control_claims(),
         *_schema_roundtrip_claims(),
         *_effect_implication_claims(),
-        *_product_surface_claims(),
+        *_insight_surface_claims(),
     )
 
 
@@ -783,18 +783,18 @@ def _effect_implication_claims() -> tuple[Claim, ...]:
     return tuple(claims)
 
 
-def _product_surface_claims() -> tuple[Claim, ...]:
+def _insight_surface_claims() -> tuple[Claim, ...]:
     """Mint claims for registered insight surfaces."""
     return (
         Claim(
-            id="product.surface.registered",
+            id="insight.surface.registered",
             description="Every registered insight type has a corresponding proof subject.",
-            subject_query=Kind("product.surface"),
+            subject_query=Kind("insight.surface"),
             evidence_schema=_evidence_schema("name", "display_name", "json_key"),
             oracle="construction_sanity",
             assurance_domain="surface_parity",
-            bug_classes=("product.registry.omission",),
-            runner_classes=("product_surface_static",),
+            bug_classes=("insight.registry.omission",),
+            runner_classes=("insight_surface_static",),
             observed_facts=("name", "display_name", "json_key"),
             staleness_conditions=("Insight registry entries are added or removed.",),
             severity="info",
@@ -930,9 +930,9 @@ def default_runner_bindings(claims: Iterable[Claim]) -> tuple[RunnerBinding, ...
             bindings.append(
                 _runner_binding(claim, runner="effect-implication-static-contract", evidence_class="structural")
             )
-        elif claim.id.startswith("product.surface."):
+        elif claim.id.startswith("insight.surface."):
             bindings.append(
-                _runner_binding(claim, runner="product-surface-static-contract", evidence_class="structural")
+                _runner_binding(claim, runner="insight-surface-static-contract", evidence_class="structural")
             )
     return tuple(bindings)
 

--- a/polylogue/proof/subjects.py
+++ b/polylogue/proof/subjects.py
@@ -175,12 +175,12 @@ def operation_spec_subjects() -> tuple[SubjectRef, ...]:
     return tuple(sorted(subjects, key=lambda subject: subject.id))
 
 
-def product_surface_subjects() -> tuple[SubjectRef, ...]:
+def insight_surface_subjects() -> tuple[SubjectRef, ...]:
     """Compile registered insight types into proof subjects."""
     subjects = [
         SubjectRef(
-            kind="product.surface",
-            id=f"product.surface.{name}",
+            kind="insight.surface",
+            id=f"insight.surface.{name}",
             attrs={
                 "name": name,
                 "display_name": pt.display_name,
@@ -510,7 +510,7 @@ def build_catalog_subjects() -> tuple[SubjectRef, ...]:
         *provider_capability_subjects(),
         *operation_spec_subjects(),
         *effect_implication_subjects(),
-        *product_surface_subjects(),
+        *insight_surface_subjects(),
         *architecture_control_subjects(),
         *schema_roundtrip_subjects(),
         *artifact_path_subjects(),

--- a/tests/unit/proof/test_catalog.py
+++ b/tests/unit/proof/test_catalog.py
@@ -67,7 +67,7 @@ def test_default_catalog_compiles_first_vertical_slice() -> None:
         "operation.effect.sampling_bounded",
         "operation.effect.snapshot_consistent",
         "operation.effect.timeout_bounded",
-        "product.surface.registered",
+        "insight.surface.registered",
     }
     assert catalog.subjects_by_kind()["cli.command"] >= 1
     assert catalog.subjects_by_kind()["cli.json_command"] >= 1


### PR DESCRIPTION
## Summary

Renames the serialized proof catalog subject family for registered archive insight surfaces from `product.surface` to `insight.surface`.

## Problem

The rest of the derived read-model cleanup moved from product vocabulary to insight vocabulary, but the proof catalog still minted `product.surface` subjects, a `product.surface.registered` claim, `product.registry.omission` bug class, and `product-surface-static-contract` runner binding. That kept the old concept alive in generated verification artifacts.

## Solution

- Renamed `product_surface_subjects()` to `insight_surface_subjects()`.
- Changed proof subject IDs/kinds from `product.surface.*` to `insight.surface.*`.
- Changed the registered-surface claim, bug class, runner class, and runner binding to insight vocabulary.
- Regenerated `docs/verification-catalog.md`.
- Updated the package-root docstring to avoid the old product-surface wording.

## Verification

- `ruff format polylogue/__init__.py polylogue/proof/catalog.py polylogue/proof/subjects.py tests/unit/proof/test_catalog.py`
- `ruff check polylogue/__init__.py polylogue/proof/catalog.py polylogue/proof/subjects.py tests/unit/proof/test_catalog.py`
- `mypy polylogue/`
- `pytest -q tests/unit/proof/test_catalog.py tests/unit/devtools/test_render_verification_catalog.py tests/unit/devtools/test_affected_obligations.py tests/unit/proof/test_diffing.py tests/unit/proof/test_diffing_runtime.py tests/proof/laws`
- `devtools render-all --check`
- `devtools verify --quick`

Ref #635
Ref #594
