### PR TITLE
fix(proof): reduce proof-pack review noise

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,8 +46,8 @@ Use it this way:
 - Treat `Known Gaps` as actionable only when they are in a changed or directly
   affected domain. Broad repo-wide gap dumps should not block unrelated PRs, but
   recurring noise should be folded back into #594.
-- Until #594 fixes the label, read `stale evidence` as stable affected
-  obligations, not as real freshness/SLA evidence.
+- Read `stable affected obligations` as unchanged obligations touched by the
+  current diff, not as real freshness/SLA evidence.
 - If the Proof Pack is noisy, misleading, or misses a relevant gate, comment on
   the PR or #594 with the concrete mismatch. Do not silently ignore it.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,27 @@ on push, but the full baseline must pass before the PR is opened.
 Do not treat CI as the first verification pass. Anticipate failures
 locally.
 
+### Proof Pack workflow
+
+Every PR gets a `Polylogue Proof Pack` comment. Treat it as a verification
+impact report, not as decorative CI output and not as a complete proof.
+
+Use it this way:
+
+- Read the `Required Gates` before choosing verification. Run the gates that
+  match the touched files, or state in the PR why a suggested gate is only an
+  optional confidence gate for that change.
+- Use nonzero affected domains and claims to decide which focused tests or
+  proof-law suites to run. Ignore zero-claim domain noise unless the changed
+  files genuinely belong to that domain.
+- Treat `Known Gaps` as actionable only when they are in a changed or directly
+  affected domain. Broad repo-wide gap dumps should not block unrelated PRs, but
+  recurring noise should be folded back into #594.
+- Until #594 fixes the label, read `stale evidence` as stable affected
+  obligations, not as real freshness/SLA evidence.
+- If the Proof Pack is noisy, misleading, or misses a relevant gate, comment on
+  the PR or #594 with the concrete mismatch. Do not silently ignore it.
+
 ### PR body discipline
 
 The PR template requires sections: Summary, Problem, Solution,

--- a/devtools/proof_pack.py
+++ b/devtools/proof_pack.py
@@ -66,9 +66,24 @@ def build_proof_pack(
     affected_subjects = [
         subjects_by_id[item.subject_id] for item in affected.affected_obligations if item.subject_id in subjects_by_id
     ]
-    affected_domains = sorted(
+    affected_domain_names = sorted(
         {claim.assurance_domain for claim in affected_claims}
         | {domain for subject in affected_subjects for domain in (_subject_assurance_domain(subject),) if domain}
+    )
+    affected_domains = [
+        _domain_payload(domain, domains_data.get(domain, {}), affected_claims) for domain in affected_domain_names
+    ]
+    gate_groups = {
+        "focused": _checks_payload(affected.inner_loop_checks),
+        "required": _checks_payload(affected.pr_gates),
+        "optional_confidence": _checks_payload(affected.deployment_gates),
+    }
+    visible_gap_domains = {domain["domain"] for domain in affected_domains if domain["claim_count"] > 0}
+    known_gaps, additional_known_gaps = _known_gaps(
+        domains_data,
+        catalog,
+        affected_domain_names,
+        visible_domains=visible_gap_domains,
     )
     return {
         "refs": {"base_ref": base_ref, "head_ref": head_ref},
@@ -79,16 +94,14 @@ def build_proof_pack(
             "obligation_count": len(catalog.obligations),
         },
         "affected": affected.to_payload(),
-        "affected_domains": [
-            _domain_payload(domain, domains_data.get(domain, {}), affected_claims) for domain in affected_domains
-        ],
+        "affected_domains": affected_domains,
         "domain_coverage": _domain_coverage(domains_data, catalog),
-        "required_gates": _checks_payload(
-            (*affected.inner_loop_checks, *affected.pr_gates, *affected.deployment_gates)
-        ),
+        "gate_groups": gate_groups,
+        "required_gates": _checks_payload((*affected.inner_loop_checks, *affected.pr_gates)),
         "manual_review_cells": _manual_review_cells(affected_claims),
-        "stale_evidence": list(affected.obligation_diff.stale_evidence),
-        "known_gaps": _known_gaps(domains_data, catalog, affected_domains),
+        "stable_affected_obligations": list(affected.obligation_diff.stable_affected),
+        "known_gaps": known_gaps,
+        "additional_known_gaps": additional_known_gaps,
         "oracle_mix": dict(Counter(claim.oracle for claim in affected_claims)),
         "cost_tier": _cost_tier_counts(affected, catalog),
     }
@@ -161,7 +174,9 @@ def _known_gaps(
     domains_data: dict[str, dict[str, Any]],
     catalog: Any,
     affected_domains: list[str],
-) -> list[dict[str, Any]]:
+    *,
+    visible_domains: set[str],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     gaps_by_domain: dict[str, list[str]] = defaultdict(list)
     for subject in catalog.subjects:
         if subject.kind != "assurance.coverage_gap":
@@ -188,11 +203,14 @@ def _known_gaps(
         raw_gaps = info.get("coverage_gaps", []) if isinstance(info, dict) else []
         for raw_gap in raw_gaps:
             gaps_by_domain[domain].append(str(raw_gap))
-    return [
+    gap_payloads = [
         {"domain": domain, "gaps": sorted(dict.fromkeys(gaps))}
         for domain, gaps in sorted(gaps_by_domain.items())
         if gaps
     ]
+    visible = [item for item in gap_payloads if item["domain"] in visible_domains]
+    additional = [item for item in gap_payloads if item["domain"] not in visible_domains]
+    return visible, additional
 
 
 def _subject_assurance_domain(subject: Any) -> str | None:
@@ -248,28 +266,62 @@ def render_markdown(report: dict[str, Any]) -> str:
         "### Affected Domains",
     ]
     affected_domains = report.get("affected_domains", [])
-    if affected_domains:
-        for domain in affected_domains:
+    visible_domains = [domain for domain in affected_domains if domain.get("claim_count", 0) > 0]
+    zero_claim_domains = [domain for domain in affected_domains if domain.get("claim_count", 0) == 0]
+    if visible_domains:
+        for domain in visible_domains:
             lines.append(f"- `{domain['domain']}` — {domain['claim_count']} claim(s), maturity `{domain['maturity']}`")
     else:
-        lines.append("- none")
-    lines.extend(["", "### Required Gates"])
-    for gate in report.get("required_gates", []):
-        command = " ".join(gate["command"])
-        lines.append(f"- `{command}` — {gate['reason']}")
+        lines.append("- none with affected claims")
+    if zero_claim_domains:
+        lines.extend(
+            [
+                "",
+                "<details>",
+                "<summary>Additional routed domains with zero affected claims</summary>",
+                "",
+            ]
+        )
+        for domain in zero_claim_domains:
+            lines.append(f"- `{domain['domain']}` — maturity `{domain['maturity']}`")
+        lines.extend(["", "</details>"])
+
+    gate_groups = report.get("gate_groups", {})
+    lines.extend(["", "### Focused Gates"])
+    _append_gate_lines(lines, gate_groups.get("focused", []), empty_text="- none")
+    lines.extend(["", "### Required PR Gates"])
+    _append_gate_lines(lines, gate_groups.get("required", report.get("required_gates", [])), empty_text="- none")
+    lines.extend(["", "### Optional Confidence Gates"])
+    _append_gate_lines(lines, gate_groups.get("optional_confidence", []), empty_text="- none")
+
     lines.extend(["", "### Known Gaps"])
     known_gaps = report.get("known_gaps", [])
     if known_gaps:
         for item in known_gaps:
             lines.append(f"- `{item['domain']}`: {', '.join(item['gaps'])}")
     else:
-        lines.append("- none for affected domains")
+        lines.append("- none for domains with affected claims")
+    additional_known_gaps = report.get("additional_known_gaps", [])
+    if additional_known_gaps:
+        lines.extend(["", "<details>", "<summary>Additional gaps in zero-claim routed domains</summary>", ""])
+        for item in additional_known_gaps:
+            lines.append(f"- `{item['domain']}`: {', '.join(item['gaps'])}")
+        lines.extend(["", "</details>"])
     lines.extend(["", "### Oracle / Cost"])
     lines.append(f"- oracle mix: `{json.dumps(report.get('oracle_mix', {}), sort_keys=True)}`")
     lines.append(f"- cost tier: `{json.dumps(report.get('cost_tier', {}), sort_keys=True)}`")
-    lines.append(f"- stale evidence: {len(report.get('stale_evidence', []))}")
+    lines.append(f"- stable affected obligations: {len(report.get('stable_affected_obligations', []))}")
     lines.append(f"- manual review cells: {len(report.get('manual_review_cells', []))}")
     return "\n".join(lines)
+
+
+def _append_gate_lines(lines: list[str], gates: list[dict[str, Any]], *, empty_text: str) -> None:
+    if not gates:
+        lines.append(empty_text)
+        return
+    for gate in gates:
+        command = " ".join(gate["command"])
+        lines.append(f"- `{command}` — {gate['reason']}")
 
 
 def _print_human_report(report: dict[str, Any]) -> None:
@@ -282,18 +334,25 @@ def _print_human_report(report: dict[str, Any]) -> None:
     print(f"Changed paths: {len(report['changed_paths'])}")
     print()
     print("Affected domains:")
-    affected_domains = report.get("affected_domains", [])
+    affected_domains = [domain for domain in report.get("affected_domains", []) if domain.get("claim_count", 0) > 0]
     if not affected_domains:
-        print("  none")
+        print("  none with affected claims")
     for domain in affected_domains:
         print(f"  {domain['domain']:<30} {domain['claim_count']:>3} claims  {domain['oracle_counts']}")
     print()
-    print("Required gates:")
-    for gate in report.get("required_gates", []):
+    gate_groups = report.get("gate_groups", {})
+    print("Focused gates:")
+    for gate in gate_groups.get("focused", []):
+        print(f"  {' '.join(gate['command'])} — {gate['reason']}")
+    print("Required PR gates:")
+    for gate in gate_groups.get("required", []):
+        print(f"  {' '.join(gate['command'])} — {gate['reason']}")
+    print("Optional confidence gates:")
+    for gate in gate_groups.get("optional_confidence", []):
         print(f"  {' '.join(gate['command'])} — {gate['reason']}")
     print()
     print(f"Manual review cells: {len(report.get('manual_review_cells', []))}")
-    print(f"Stale evidence: {len(report.get('stale_evidence', []))}")
+    print(f"Stable affected obligations: {len(report.get('stable_affected_obligations', []))}")
     print(f"Known gaps: {len(report.get('known_gaps', []))}")
 
 

--- a/polylogue/proof/diffing.py
+++ b/polylogue/proof/diffing.py
@@ -33,7 +33,7 @@ ChangeKind = Literal[
     "unknown",
 ]
 CheckScope = Literal["inner_loop", "pr_gate", "deployment_gate"]
-DiffStatus = Literal["new", "dropped", "now_failing", "now_passing", "stale_evidence", "suppressed"]
+DiffStatus = Literal["new", "dropped", "now_failing", "now_passing", "stable_affected", "suppressed"]
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _ALL_COMMAND_KINDS = {"cli.command", "cli.json_command"}
@@ -76,7 +76,7 @@ _DIFF_STATUSES: tuple[DiffStatus, ...] = (
     "dropped",
     "now_failing",
     "now_passing",
-    "stale_evidence",
+    "stable_affected",
     "suppressed",
 )
 
@@ -157,7 +157,7 @@ class ObligationDiff:
     dropped: tuple[str, ...] = ()
     now_failing: tuple[str, ...] = ()
     now_passing: tuple[str, ...] = ()
-    stale_evidence: tuple[str, ...] = ()
+    stable_affected: tuple[str, ...] = ()
     suppressed: tuple[str, ...] = ()
 
     def bucket(self, status: DiffStatus) -> tuple[str, ...]:
@@ -169,8 +169,8 @@ class ObligationDiff:
             return self.now_failing
         if status == "now_passing":
             return self.now_passing
-        if status == "stale_evidence":
-            return self.stale_evidence
+        if status == "stable_affected":
+            return self.stable_affected
         return self.suppressed
 
     def to_payload(self) -> JSONDocument:
@@ -179,7 +179,7 @@ class ObligationDiff:
             "dropped": list(self.dropped),
             "now_failing": list(self.now_failing),
             "now_passing": list(self.now_passing),
-            "stale_evidence": list(self.stale_evidence),
+            "stable_affected": list(self.stable_affected),
             "suppressed": list(self.suppressed),
         }
 
@@ -362,7 +362,7 @@ def diff_obligation_ids(
     return ObligationDiff(
         new=tuple(sorted(new)),
         dropped=tuple(sorted(dropped)),
-        stale_evidence=tuple(sorted(stable_affected - new)),
+        stable_affected=tuple(sorted(stable_affected - new)),
         suppressed=tuple(sorted(dict.fromkeys(suppressed))),
     )
 

--- a/tests/unit/devtools/test_proof_pack.py
+++ b/tests/unit/devtools/test_proof_pack.py
@@ -16,10 +16,15 @@ def test_proof_pack_reports_diff_shaped_fields() -> None:
     assert report["changed_paths"] == ["docs/plans/layering.yaml"]
     assert report["affected_domains"]
     assert report["required_gates"]
+    assert report["gate_groups"]["focused"]
+    assert report["gate_groups"]["required"]
+    assert report["gate_groups"]["optional_confidence"]
     assert "oracle_mix" in report
     assert "cost_tier" in report
     assert "manual_review_cells" in report
     assert "known_gaps" in report
+    assert "additional_known_gaps" in report
+    assert "stable_affected_obligations" in report
 
 
 def test_proof_pack_markdown_is_pr_comment_ready() -> None:
@@ -33,7 +38,10 @@ def test_proof_pack_markdown_is_pr_comment_ready() -> None:
     rendered = render_markdown(report)
 
     assert "## Polylogue Proof Pack" in rendered
-    assert "### Required Gates" in rendered
+    assert "### Focused Gates" in rendered
+    assert "### Required PR Gates" in rendered
+    assert "### Optional Confidence Gates" in rendered
+    assert "stable affected obligations" in rendered
 
 
 def test_proof_pack_surfaces_manifest_known_gaps_for_affected_domains() -> None:
@@ -45,5 +53,21 @@ def test_proof_pack_surfaces_manifest_known_gaps_for_affected_domains() -> None:
     )
 
     gap_domains = {item["domain"] for item in report["known_gaps"]}
+    additional_gap_domains = {item["domain"] for item in report["additional_known_gaps"]}
 
-    assert "docs_media" in gap_domains
+    assert "docs_media" in gap_domains | additional_gap_domains
+
+
+def test_proof_pack_markdown_collapses_zero_claim_domains() -> None:
+    report = build_proof_pack(
+        Path.cwd(),
+        base_ref="origin/master",
+        head_ref="HEAD",
+        changed_paths=["polylogue/proof/catalog.py"],
+    )
+
+    rendered = render_markdown(report)
+
+    assert "Additional routed domains with zero affected claims" in rendered
+    assert "### Optional Confidence Gates" in rendered
+    assert "stale evidence" not in rendered

--- a/tests/unit/proof/test_diffing.py
+++ b/tests/unit/proof/test_diffing.py
@@ -135,7 +135,7 @@ def test_obligation_diff_buckets_new_dropped_stale_and_suppressed() -> None:
 
     assert diff.new == ("new",)
     assert diff.dropped == ("dropped",)
-    assert diff.stale_evidence == ("stable",)
+    assert diff.stable_affected == ("stable",)
     assert diff.now_failing == ()
     assert diff.now_passing == ()
     assert diff.suppressed == ("test:tests/unit/example.py",)

--- a/tests/unit/proof/test_diffing_runtime.py
+++ b/tests/unit/proof/test_diffing_runtime.py
@@ -77,7 +77,7 @@ def test_diff_obligation_ids_without_base_marks_every_affected_id_as_stale() -> 
 
     assert diff.new == ()
     assert diff.dropped == ()
-    assert diff.stale_evidence == ("a", "b")
+    assert diff.stable_affected == ("a", "b")
 
 
 def test_obligation_ids_for_ref_uses_current_catalog_for_head_aliases() -> None:


### PR DESCRIPTION
## Summary

Improves the Proof Pack PR report so it is usable as a review-routing artifact instead of a noisy checklist dump, and documents how Polylogue agents should consume it.

## Problem

Recent Proof Pack comments were useful in principle but hard to act on in practice. They mixed focused checks, required PR gates, and optional deployment confidence checks under one heading; surfaced zero-claim domains as if they were equally affected; dumped broad known gaps into unrelated PRs; and used `stale evidence` for a bucket that actually means stable affected obligations, not freshness/SLA failure.

## Solution

- Documented the intended Proof Pack workflow in `CLAUDE.md`.
- Split rendered gates into focused gates, required PR gates, and optional confidence gates.
- Collapsed zero-claim routed domains behind a details block.
- Kept visible known gaps to domains with affected claims, with zero-claim-domain gaps collapsed separately.
- Renamed the proof diff bucket and report payload from stale evidence to stable affected obligations.
- Updated proof-pack and affected-obligation tests to cover the new report shape.

## Verification

- `ruff format devtools/proof_pack.py polylogue/proof/diffing.py tests/unit/devtools/test_proof_pack.py tests/unit/proof/test_diffing.py tests/unit/proof/test_diffing_runtime.py`
- `ruff check devtools/proof_pack.py polylogue/proof/diffing.py tests/unit/devtools/test_proof_pack.py tests/unit/proof/test_diffing.py tests/unit/proof/test_diffing_runtime.py`
- `mypy polylogue/`
- `pytest -q tests/unit/devtools/test_proof_pack.py tests/unit/proof/test_diffing.py tests/unit/proof/test_diffing_runtime.py tests/unit/devtools/test_obligation_diff.py tests/unit/devtools/test_affected_obligations.py`
- `devtools proof-pack --path polylogue/proof/catalog.py --markdown`
- `devtools proof-pack --path docs/plans/layering.yaml --markdown`
- `devtools render-all --check`
- `devtools verify --quick`

Ref #594
Ref #635
