### PR TITLE
fix(proof): enforce proof-pack check policy

### DIFF
--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -316,6 +316,7 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
         examples=(
             "devtools proof-pack --base-ref origin/master --head-ref HEAD",
             "devtools proof-pack --base-ref origin/master --head-ref HEAD --markdown",
+            "devtools proof-pack --path polylogue/proof/catalog.py --check",
             "devtools proof-pack --json --path polylogue/site/",
         ),
     ),

--- a/devtools/proof_pack.py
+++ b/devtools/proof_pack.py
@@ -100,7 +100,7 @@ def build_proof_pack(
         "domain_coverage": _domain_coverage(domains_data, catalog),
         "gate_groups": gate_groups,
         "required_gates": _checks_payload((*affected.inner_loop_checks, *affected.pr_gates)),
-        "manual_review_cells": _manual_review_cells(affected_claims),
+        "agent_judgment_cells": _agent_judgment_cells(affected_claims),
         "stable_affected_obligations": list(affected.obligation_diff.stable_affected),
         "known_gaps": known_gaps,
         "additional_known_gaps": additional_known_gaps,
@@ -125,14 +125,14 @@ def evaluate_check_policy(report: dict[str, Any]) -> dict[str, Any]:
         elif status == OutcomeStatus.WARNING.value:
             warnings.append(line)
 
-    serious_manual_cells = [
+    serious_judgment_cells = [
         cell
-        for cell in report.get("manual_review_cells", [])
+        for cell in report.get("agent_judgment_cells", [])
         if isinstance(cell, dict) and cell.get("severity") == "serious" and not cell.get("tracked_exception")
     ]
-    for cell in serious_manual_cells:
+    for cell in serious_judgment_cells:
         errors.append(
-            "affected serious claim needs manual/same-source review: "
+            "affected serious claim needs agent judgment artifact: "
             f"{cell.get('claim_id')} ({cell.get('oracle')}, {cell.get('independence_level')})"
         )
 
@@ -213,7 +213,7 @@ def _checks_payload(checks: tuple[RecommendedCheck, ...]) -> list[dict[str, Any]
     return payload
 
 
-def _manual_review_cells(claims: list[Any]) -> list[dict[str, Any]]:
+def _agent_judgment_cells(claims: list[Any]) -> list[dict[str, Any]]:
     cells: list[dict[str, Any]] = []
     for claim in claims:
         if claim.oracle == "manual_review" or claim.independence_level in {"same_source", "self_attesting"}:
@@ -224,7 +224,7 @@ def _manual_review_cells(claims: list[Any]) -> list[dict[str, Any]]:
                     "independence_level": claim.independence_level,
                     "severity": claim.severity,
                     "tracked_exception": claim.tracked_exception,
-                    "reason": "requires human confirmation or independent evidence upgrade",
+                    "reason": "requires agent judgment artifact or independent evidence upgrade",
                 }
             )
     return cells
@@ -387,7 +387,7 @@ def render_markdown(report: dict[str, Any]) -> str:
     lines.append(f"- oracle mix: `{json.dumps(report.get('oracle_mix', {}), sort_keys=True)}`")
     lines.append(f"- cost tier: `{json.dumps(report.get('cost_tier', {}), sort_keys=True)}`")
     lines.append(f"- stable affected obligations: {len(report.get('stable_affected_obligations', []))}")
-    lines.append(f"- manual review cells: {len(report.get('manual_review_cells', []))}")
+    lines.append(f"- agent judgment cells: {len(report.get('agent_judgment_cells', []))}")
     return "\n".join(lines)
 
 
@@ -427,7 +427,7 @@ def _print_human_report(report: dict[str, Any]) -> None:
     for gate in gate_groups.get("optional_confidence", []):
         print(f"  {' '.join(gate['command'])} — {gate['reason']}")
     print()
-    print(f"Manual review cells: {len(report.get('manual_review_cells', []))}")
+    print(f"Agent judgment cells: {len(report.get('agent_judgment_cells', []))}")
     print(f"Stable affected obligations: {len(report.get('stable_affected_obligations', []))}")
     print(f"Known gaps: {len(report.get('known_gaps', []))}")
     check_result = report.get("check")

--- a/devtools/proof_pack.py
+++ b/devtools/proof_pack.py
@@ -224,6 +224,11 @@ def _agent_judgment_cells(claims: list[Any]) -> list[dict[str, Any]]:
                     "independence_level": claim.independence_level,
                     "severity": claim.severity,
                     "tracked_exception": claim.tracked_exception,
+                    "artifact": None,
+                    "reviewer": None,
+                    "produced_at": None,
+                    "freshness": None,
+                    "result": "tracked_exception" if claim.tracked_exception else "missing",
                     "reason": "requires agent judgment artifact or independent evidence upgrade",
                 }
             )
@@ -387,7 +392,18 @@ def render_markdown(report: dict[str, Any]) -> str:
     lines.append(f"- oracle mix: `{json.dumps(report.get('oracle_mix', {}), sort_keys=True)}`")
     lines.append(f"- cost tier: `{json.dumps(report.get('cost_tier', {}), sort_keys=True)}`")
     lines.append(f"- stable affected obligations: {len(report.get('stable_affected_obligations', []))}")
-    lines.append(f"- agent judgment cells: {len(report.get('agent_judgment_cells', []))}")
+    agent_judgment_cells = report.get("agent_judgment_cells", [])
+    lines.append(f"- agent judgment cells: {len(agent_judgment_cells)}")
+    if agent_judgment_cells:
+        lines.extend(["", "### Agent Judgment Cells"])
+        for cell in agent_judgment_cells:
+            lines.append(
+                f"- `{cell['claim_id']}` — result `{cell['result']}`; "
+                f"artifact `{cell['artifact'] or 'missing'}`; "
+                f"reviewer `{cell['reviewer'] or 'missing'}`; "
+                f"produced_at `{cell['produced_at'] or 'missing'}`; "
+                f"freshness `{cell['freshness'] or 'missing'}`"
+            )
     return "\n".join(lines)
 
 

--- a/devtools/proof_pack.py
+++ b/devtools/proof_pack.py
@@ -128,7 +128,7 @@ def evaluate_check_policy(report: dict[str, Any]) -> dict[str, Any]:
     serious_judgment_cells = [
         cell
         for cell in report.get("agent_judgment_cells", [])
-        if isinstance(cell, dict) and cell.get("severity") == "serious" and not cell.get("tracked_exception")
+        if isinstance(cell, dict) and cell.get("severity") == "serious" and not _judgment_cell_satisfied(cell)
     ]
     for cell in serious_judgment_cells:
         errors.append(
@@ -138,7 +138,7 @@ def evaluate_check_policy(report: dict[str, Any]) -> dict[str, Any]:
 
     suppressed = _suppressed_change_subjects(report)
     if suppressed:
-        warnings.append("changed paths were suppressed from obligation routing: " + ", ".join(suppressed[:10]))
+        warnings.append("change-subject IDs were suppressed from obligation routing: " + ", ".join(suppressed[:10]))
     known_gaps = report.get("known_gaps", [])
     if known_gaps:
         warnings.append(f"known coverage gaps intersect affected domains: {len(known_gaps)} domain(s)")
@@ -150,6 +150,15 @@ def evaluate_check_policy(report: dict[str, Any]) -> dict[str, Any]:
         "errors": errors,
         "warnings": warnings,
     }
+
+
+def _judgment_cell_satisfied(cell: dict[str, Any]) -> bool:
+    if cell.get("tracked_exception"):
+        return True
+    result = str(cell.get("result") or "").strip().lower()
+    if result not in {"accepted", "passed", "pass", "ok"}:
+        return False
+    return all(str(cell.get(field) or "").strip() for field in ("artifact", "reviewer", "produced_at", "freshness"))
 
 
 def _suppressed_change_subjects(report: dict[str, Any]) -> list[str]:

--- a/devtools/proof_pack.py
+++ b/devtools/proof_pack.py
@@ -13,6 +13,7 @@ from collections import Counter, defaultdict
 from pathlib import Path
 from typing import Any
 
+from polylogue.core.outcomes import OutcomeStatus
 from polylogue.proof.catalog import build_verification_catalog
 from polylogue.proof.diffing import (
     AffectedObligationReport,
@@ -93,6 +94,7 @@ def build_proof_pack(
             "subject_count": len(catalog.subjects),
             "obligation_count": len(catalog.obligations),
         },
+        "catalog_quality_checks": [check.to_dict() for check in catalog.quality_checks],
         "affected": affected.to_payload(),
         "affected_domains": affected_domains,
         "domain_coverage": _domain_coverage(domains_data, catalog),
@@ -105,6 +107,62 @@ def build_proof_pack(
         "oracle_mix": dict(Counter(claim.oracle for claim in affected_claims)),
         "cost_tier": _cost_tier_counts(affected, catalog),
     }
+
+
+def evaluate_check_policy(report: dict[str, Any]) -> dict[str, Any]:
+    """Evaluate proof-pack blocking policy over an already-built report."""
+    errors: list[str] = []
+    warnings: list[str] = []
+    for check in report.get("catalog_quality_checks", []):
+        if not isinstance(check, dict):
+            continue
+        name = str(check.get("name", "catalog.check"))
+        summary = str(check.get("summary", "")).strip()
+        line = f"{name}: {summary}" if summary else name
+        status = str(check.get("status", "")).strip().lower()
+        if status == OutcomeStatus.ERROR.value:
+            errors.append(line)
+        elif status == OutcomeStatus.WARNING.value:
+            warnings.append(line)
+
+    serious_manual_cells = [
+        cell
+        for cell in report.get("manual_review_cells", [])
+        if isinstance(cell, dict) and cell.get("severity") == "serious" and not cell.get("tracked_exception")
+    ]
+    for cell in serious_manual_cells:
+        errors.append(
+            "affected serious claim needs manual/same-source review: "
+            f"{cell.get('claim_id')} ({cell.get('oracle')}, {cell.get('independence_level')})"
+        )
+
+    suppressed = _suppressed_change_subjects(report)
+    if suppressed:
+        warnings.append("changed paths were suppressed from obligation routing: " + ", ".join(suppressed[:10]))
+    known_gaps = report.get("known_gaps", [])
+    if known_gaps:
+        warnings.append(f"known coverage gaps intersect affected domains: {len(known_gaps)} domain(s)")
+    if report.get("additional_known_gaps"):
+        warnings.append("additional known gaps exist in zero-claim routed domains")
+
+    return {
+        "status": "error" if errors else "ok",
+        "errors": errors,
+        "warnings": warnings,
+    }
+
+
+def _suppressed_change_subjects(report: dict[str, Any]) -> list[str]:
+    affected = report.get("affected")
+    if not isinstance(affected, dict):
+        return []
+    diff = affected.get("obligation_diff")
+    if not isinstance(diff, dict):
+        return []
+    suppressed = diff.get("suppressed")
+    if not isinstance(suppressed, list):
+        return []
+    return [str(item) for item in suppressed]
 
 
 def _domain_payload(domain: str, info: object, claims: list[Any]) -> dict[str, Any]:
@@ -155,8 +213,8 @@ def _checks_payload(checks: tuple[RecommendedCheck, ...]) -> list[dict[str, Any]
     return payload
 
 
-def _manual_review_cells(claims: list[Any]) -> list[dict[str, str]]:
-    cells: list[dict[str, str]] = []
+def _manual_review_cells(claims: list[Any]) -> list[dict[str, Any]]:
+    cells: list[dict[str, Any]] = []
     for claim in claims:
         if claim.oracle == "manual_review" or claim.independence_level in {"same_source", "self_attesting"}:
             cells.append(
@@ -164,6 +222,8 @@ def _manual_review_cells(claims: list[Any]) -> list[dict[str, str]]:
                     "claim_id": claim.id,
                     "oracle": claim.oracle,
                     "independence_level": claim.independence_level,
+                    "severity": claim.severity,
+                    "tracked_exception": claim.tracked_exception,
                     "reason": "requires human confirmation or independent evidence upgrade",
                 }
             )
@@ -233,6 +293,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--path", action="append", dest="paths", default=None, help="Changed file path (repeatable).")
     parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
     parser.add_argument("--markdown", action="store_true", help="Emit PR-comment-ready Markdown.")
+    parser.add_argument("--check", action="store_true", help="Exit non-zero when proof-pack blocking policy fails.")
     args = parser.parse_args(argv)
 
     root = Path(__file__).resolve().parents[1]
@@ -242,6 +303,9 @@ def main(argv: list[str] | None = None) -> int:
         head_ref=args.head_ref,
         changed_paths=args.paths,
     )
+    check_result = evaluate_check_policy(report)
+    if args.check:
+        report["check"] = check_result
 
     if args.json:
         json.dump(report, sys.stdout, indent=2, sort_keys=True)
@@ -252,6 +316,8 @@ def main(argv: list[str] | None = None) -> int:
     else:
         _print_human_report(report)
 
+    if args.check and check_result["status"] != "ok":
+        return 1
     return 0
 
 
@@ -262,9 +328,19 @@ def render_markdown(report: dict[str, Any]) -> str:
         "",
         f"**Refs:** `{refs['base_ref']}..{refs['head_ref']}`",
         f"**Changed paths:** {len(report['changed_paths'])}",
-        "",
-        "### Affected Domains",
     ]
+    check_result = report.get("check")
+    if isinstance(check_result, dict):
+        lines.extend(["", "### Check Policy"])
+        if check_result.get("status") == "ok":
+            lines.append("- status: `ok`")
+        else:
+            lines.append("- status: `error`")
+        for error in check_result.get("errors", []) or []:
+            lines.append(f"- blocking: {error}")
+        for warning in check_result.get("warnings", []) or []:
+            lines.append(f"- warning: {warning}")
+    lines.extend(["", "### Affected Domains"])
     affected_domains = report.get("affected_domains", [])
     visible_domains = [domain for domain in affected_domains if domain.get("claim_count", 0) > 0]
     zero_claim_domains = [domain for domain in affected_domains if domain.get("claim_count", 0) == 0]
@@ -354,6 +430,13 @@ def _print_human_report(report: dict[str, Any]) -> None:
     print(f"Manual review cells: {len(report.get('manual_review_cells', []))}")
     print(f"Stable affected obligations: {len(report.get('stable_affected_obligations', []))}")
     print(f"Known gaps: {len(report.get('known_gaps', []))}")
+    check_result = report.get("check")
+    if isinstance(check_result, dict):
+        print(f"Check policy: {check_result.get('status', 'unknown')}")
+        for error in check_result.get("errors", []) or []:
+            print(f"  blocking: {error}")
+        for warning in check_result.get("warnings", []) or []:
+            print(f"  warning: {warning}")
 
 
 if __name__ == "__main__":

--- a/devtools/verify.py
+++ b/devtools/verify.py
@@ -8,9 +8,10 @@ Steps:
   2. ruff check (fast, <2s)
   3. mypy (polylogue + tests + devtools) (warm ~1s, cold ~25s)
   4. devtools render-all --check (fast, <5s)
-  5. pytest --ignore=tests/integration (slow but essential, ~3min)
+  5. devtools proof-pack --check (fast proof-policy gate)
+  6. pytest --ignore=tests/integration (slow but essential, ~3min)
 
-Use --quick to run only steps 1-4 (suitable for pre-commit).
+Use --quick to run only the non-pytest gates (suitable for pre-commit).
 Use --lab to add verification-lab scenario checks through lab commands.
 """
 
@@ -54,6 +55,7 @@ def build_verify_steps(*, quick: bool, lab: bool) -> list[tuple[str, list[str]]]
         ("verify-suppressions", ["devtools", "verify-suppressions"]),
         ("verify-manifests", ["devtools", "verify-manifests"]),
         ("verify-witness-lifecycle", ["devtools", "verify-witness-lifecycle"]),
+        ("proof-pack check", ["devtools", "proof-pack", "--check"]),
     ]
 
     if not quick:

--- a/polylogue/proof/diffing.py
+++ b/polylogue/proof/diffing.py
@@ -590,6 +590,7 @@ def _classify_path(path: str) -> ChangeKind:
         "devtools/affected_obligations.py",
         "devtools/obligation_diff.py",
         "devtools/proof_pack.py",
+        "tests/unit/devtools/test_proof_pack.py",
     }:
         return "proof_catalog"
     if path == "polylogue/operations/specs.py":
@@ -686,7 +687,9 @@ def _checks_for_change(kind: ChangeKind, *, path: str) -> tuple[RecommendedCheck
     if kind == "proof_catalog":
         return (
             _check(("pytest", "tests/unit/proof"), "proof kernel or catalog changed"),
+            _check(("pytest", "tests/unit/devtools/test_proof_pack.py"), "proof-pack policy or CLI changed"),
             _check(("pytest", "tests/unit/devtools/test_render_verification_catalog.py"), "catalog renderer changed"),
+            _check(("devtools", "proof-pack", "--check"), "proof-pack policy gate changed"),
             _check(("devtools", "render-verification-catalog", "--check"), "verification catalog must stay current"),
         )
     if kind == "operation.spec":

--- a/polylogue/proof/diffing.py
+++ b/polylogue/proof/diffing.py
@@ -586,7 +586,11 @@ def _classify_path(path: str) -> ChangeKind:
         or path in {"devtools/generated_surfaces.py", "devtools/command_catalog.py"}
     ):
         return "generated_surface"
-    if path.startswith("polylogue/proof/") or path == "devtools/affected_obligations.py":
+    if path.startswith("polylogue/proof/") or path in {
+        "devtools/affected_obligations.py",
+        "devtools/obligation_diff.py",
+        "devtools/proof_pack.py",
+    }:
         return "proof_catalog"
     if path == "polylogue/operations/specs.py":
         return "operation.spec"

--- a/tests/unit/devtools/test_proof_pack.py
+++ b/tests/unit/devtools/test_proof_pack.py
@@ -171,6 +171,33 @@ def test_proof_pack_check_policy_allows_tracked_judgment_cells() -> None:
     assert result["status"] == "ok"
 
 
+def test_proof_pack_check_policy_allows_completed_judgment_artifact() -> None:
+    report = build_proof_pack(
+        Path.cwd(),
+        base_ref="origin/master",
+        head_ref="HEAD",
+        changed_paths=["docs/plans/layering.yaml"],
+    )
+    report["agent_judgment_cells"] = [
+        {
+            "claim_id": "claim.reviewed",
+            "oracle": "manual_review",
+            "independence_level": "independent",
+            "severity": "serious",
+            "tracked_exception": None,
+            "artifact": "docs/reviews/proof-pack-claim-reviewed.md",
+            "reviewer": "codex",
+            "produced_at": "2026-05-02T00:00:00+00:00",
+            "freshness": "current PR",
+            "result": "accepted",
+        }
+    ]
+
+    result = evaluate_check_policy(report)
+
+    assert result["status"] == "ok"
+
+
 def test_proof_pack_check_flag_returns_nonzero_on_policy_failure(monkeypatch: pytest.MonkeyPatch) -> None:
     report = build_proof_pack(
         Path.cwd(),

--- a/tests/unit/devtools/test_proof_pack.py
+++ b/tests/unit/devtools/test_proof_pack.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from devtools.proof_pack import build_proof_pack, render_markdown
+from devtools import proof_pack
+from devtools.proof_pack import build_proof_pack, evaluate_check_policy, render_markdown
 
 
 def test_proof_pack_reports_diff_shaped_fields() -> None:
@@ -25,6 +26,7 @@ def test_proof_pack_reports_diff_shaped_fields() -> None:
     assert "known_gaps" in report
     assert "additional_known_gaps" in report
     assert "stable_affected_obligations" in report
+    assert "catalog_quality_checks" in report
 
 
 def test_proof_pack_markdown_is_pr_comment_ready() -> None:
@@ -71,3 +73,94 @@ def test_proof_pack_markdown_collapses_zero_claim_domains() -> None:
     assert "Additional routed domains with zero affected claims" in rendered
     assert "### Optional Confidence Gates" in rendered
     assert "stale evidence" not in rendered
+
+
+def test_proof_pack_check_policy_blocks_catalog_quality_errors() -> None:
+    report = build_proof_pack(
+        Path.cwd(),
+        base_ref="origin/master",
+        head_ref="HEAD",
+        changed_paths=["docs/plans/layering.yaml"],
+    )
+    report["catalog_quality_checks"] = [
+        {
+            "name": "catalog.serious_claim_oracle_independence",
+            "status": "error",
+            "summary": "serious claims rely on weak oracle independence: 1",
+            "count": 1,
+            "details": ["claim.id: self_attesting"],
+            "breakdown": {},
+        }
+    ]
+
+    result = evaluate_check_policy(report)
+
+    assert result["status"] == "error"
+    assert "catalog.serious_claim_oracle_independence" in result["errors"][0]
+
+
+def test_proof_pack_check_policy_blocks_serious_manual_cells() -> None:
+    report = build_proof_pack(
+        Path.cwd(),
+        base_ref="origin/master",
+        head_ref="HEAD",
+        changed_paths=["docs/plans/layering.yaml"],
+    )
+    report["manual_review_cells"] = [
+        {
+            "claim_id": "claim.needs.review",
+            "oracle": "manual_review",
+            "independence_level": "independent",
+            "severity": "serious",
+            "tracked_exception": None,
+        }
+    ]
+
+    result = evaluate_check_policy(report)
+
+    assert result["status"] == "error"
+    assert "claim.needs.review" in result["errors"][0]
+
+
+def test_proof_pack_check_policy_allows_tracked_manual_cells() -> None:
+    report = build_proof_pack(
+        Path.cwd(),
+        base_ref="origin/master",
+        head_ref="HEAD",
+        changed_paths=["docs/plans/layering.yaml"],
+    )
+    report["manual_review_cells"] = [
+        {
+            "claim_id": "claim.tracked.review",
+            "oracle": "manual_review",
+            "independence_level": "independent",
+            "severity": "serious",
+            "tracked_exception": "tracked by #594",
+        }
+    ]
+
+    result = evaluate_check_policy(report)
+
+    assert result["status"] == "ok"
+
+
+def test_proof_pack_check_flag_returns_nonzero_on_policy_failure(monkeypatch) -> None:
+    report = build_proof_pack(
+        Path.cwd(),
+        base_ref="origin/master",
+        head_ref="HEAD",
+        changed_paths=["docs/plans/layering.yaml"],
+    )
+    report["catalog_quality_checks"] = [
+        {
+            "name": "catalog.runner_trust_metadata",
+            "status": "error",
+            "summary": "runner trust metadata is stale or incomplete: 1",
+            "count": 1,
+            "details": ["runner.id: expired"],
+            "breakdown": {},
+        }
+    ]
+    monkeypatch.setattr(proof_pack, "build_proof_pack", lambda *args, **kwargs: report)
+
+    assert proof_pack.main(["--path", "docs/plans/layering.yaml", "--check"]) == 1

--- a/tests/unit/devtools/test_proof_pack.py
+++ b/tests/unit/devtools/test_proof_pack.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from devtools import proof_pack
 from devtools.proof_pack import build_proof_pack, evaluate_check_policy, render_markdown
 
@@ -75,6 +77,21 @@ def test_proof_pack_markdown_collapses_zero_claim_domains() -> None:
     assert "stale evidence" not in rendered
 
 
+def test_proof_pack_markdown_lists_agent_judgment_cells() -> None:
+    report = build_proof_pack(
+        Path.cwd(),
+        base_ref="origin/master",
+        head_ref="HEAD",
+        changed_paths=["polylogue/proof/catalog.py"],
+    )
+
+    rendered = render_markdown(report)
+
+    assert "### Agent Judgment Cells" in rendered
+    assert "operation.effect.privacy_safe_evidence" in rendered
+    assert "artifact `missing`" in rendered
+
+
 def test_proof_pack_check_policy_blocks_catalog_quality_errors() -> None:
     report = build_proof_pack(
         Path.cwd(),
@@ -113,6 +130,11 @@ def test_proof_pack_check_policy_blocks_serious_judgment_cells() -> None:
             "independence_level": "independent",
             "severity": "serious",
             "tracked_exception": None,
+            "artifact": None,
+            "reviewer": None,
+            "produced_at": None,
+            "freshness": None,
+            "result": "missing",
         }
     ]
 
@@ -136,6 +158,11 @@ def test_proof_pack_check_policy_allows_tracked_judgment_cells() -> None:
             "independence_level": "independent",
             "severity": "serious",
             "tracked_exception": "tracked by #594",
+            "artifact": None,
+            "reviewer": None,
+            "produced_at": None,
+            "freshness": None,
+            "result": "tracked_exception",
         }
     ]
 
@@ -144,7 +171,7 @@ def test_proof_pack_check_policy_allows_tracked_judgment_cells() -> None:
     assert result["status"] == "ok"
 
 
-def test_proof_pack_check_flag_returns_nonzero_on_policy_failure(monkeypatch) -> None:
+def test_proof_pack_check_flag_returns_nonzero_on_policy_failure(monkeypatch: pytest.MonkeyPatch) -> None:
     report = build_proof_pack(
         Path.cwd(),
         base_ref="origin/master",

--- a/tests/unit/devtools/test_proof_pack.py
+++ b/tests/unit/devtools/test_proof_pack.py
@@ -22,7 +22,7 @@ def test_proof_pack_reports_diff_shaped_fields() -> None:
     assert report["gate_groups"]["optional_confidence"]
     assert "oracle_mix" in report
     assert "cost_tier" in report
-    assert "manual_review_cells" in report
+    assert "agent_judgment_cells" in report
     assert "known_gaps" in report
     assert "additional_known_gaps" in report
     assert "stable_affected_obligations" in report
@@ -99,14 +99,14 @@ def test_proof_pack_check_policy_blocks_catalog_quality_errors() -> None:
     assert "catalog.serious_claim_oracle_independence" in result["errors"][0]
 
 
-def test_proof_pack_check_policy_blocks_serious_manual_cells() -> None:
+def test_proof_pack_check_policy_blocks_serious_judgment_cells() -> None:
     report = build_proof_pack(
         Path.cwd(),
         base_ref="origin/master",
         head_ref="HEAD",
         changed_paths=["docs/plans/layering.yaml"],
     )
-    report["manual_review_cells"] = [
+    report["agent_judgment_cells"] = [
         {
             "claim_id": "claim.needs.review",
             "oracle": "manual_review",
@@ -122,14 +122,14 @@ def test_proof_pack_check_policy_blocks_serious_manual_cells() -> None:
     assert "claim.needs.review" in result["errors"][0]
 
 
-def test_proof_pack_check_policy_allows_tracked_manual_cells() -> None:
+def test_proof_pack_check_policy_allows_tracked_judgment_cells() -> None:
     report = build_proof_pack(
         Path.cwd(),
         base_ref="origin/master",
         head_ref="HEAD",
         changed_paths=["docs/plans/layering.yaml"],
     )
-    report["manual_review_cells"] = [
+    report["agent_judgment_cells"] = [
         {
             "claim_id": "claim.tracked.review",
             "oracle": "manual_review",

--- a/tests/unit/devtools/test_verify.py
+++ b/tests/unit/devtools/test_verify.py
@@ -21,6 +21,7 @@ def test_quick_verify_omits_pytest() -> None:
         "verify-suppressions",
         "verify-manifests",
         "verify-witness-lifecycle",
+        "proof-pack check",
     ]
 
 

--- a/tests/unit/proof/test_diffing.py
+++ b/tests/unit/proof/test_diffing.py
@@ -138,7 +138,25 @@ def test_proof_report_tool_change_routes_to_catalog_obligations() -> None:
     assert report.change_subjects[0].kind == "proof_catalog"
     assert report.obligation_diff.suppressed == ()
     assert report.affected_obligations
-    assert "pytest tests/unit/proof" in [check.rendered_command for check in report.inner_loop_checks]
+    commands = [check.rendered_command for check in report.inner_loop_checks]
+    assert "pytest tests/unit/proof" in commands
+    assert "pytest tests/unit/devtools/test_proof_pack.py" in commands
+    assert "devtools proof-pack --check" in commands
+
+
+def test_proof_pack_test_change_routes_to_catalog_obligations() -> None:
+    catalog = build_verification_catalog()
+
+    report = build_affected_obligation_report(
+        ("tests/unit/devtools/test_proof_pack.py",),
+        catalog=catalog,
+        base_obligation_ids=(obligation.id for obligation in catalog.obligations),
+        head_obligation_ids=(obligation.id for obligation in catalog.obligations),
+    )
+
+    assert report.change_subjects[0].kind == "proof_catalog"
+    assert report.obligation_diff.suppressed == ()
+    assert "devtools proof-pack --check" in [check.rendered_command for check in report.inner_loop_checks]
 
 
 def test_obligation_diff_buckets_new_dropped_stale_and_suppressed() -> None:

--- a/tests/unit/proof/test_diffing.py
+++ b/tests/unit/proof/test_diffing.py
@@ -125,6 +125,22 @@ def test_schema_change_routes_to_roundtrip_obligation() -> None:
     assert "schema.roundtrip.inference_validation" in {item.claim_id for item in affected}
 
 
+def test_proof_report_tool_change_routes_to_catalog_obligations() -> None:
+    catalog = build_verification_catalog()
+
+    report = build_affected_obligation_report(
+        ("devtools/proof_pack.py",),
+        catalog=catalog,
+        base_obligation_ids=(obligation.id for obligation in catalog.obligations),
+        head_obligation_ids=(obligation.id for obligation in catalog.obligations),
+    )
+
+    assert report.change_subjects[0].kind == "proof_catalog"
+    assert report.obligation_diff.suppressed == ()
+    assert report.affected_obligations
+    assert "pytest tests/unit/proof" in [check.rendered_command for check in report.inner_loop_checks]
+
+
 def test_obligation_diff_buckets_new_dropped_stale_and_suppressed() -> None:
     diff = diff_obligation_ids(
         base_ids=("stable", "dropped"),


### PR DESCRIPTION
## Summary

Adds a blocking proof-pack policy mode and wires it into the fast verification baseline. The report now carries catalog-quality check results, exposes agent judgment cells as structured artifact-oriented records, and routes proof-pack devtools changes through proof-catalog impact instead of treating them as unknown paths.

Ref #594
Ref #635

## Problem

#594 identified that proof-pack was useful as a confidence report but still passive: existing catalog quality checks for weak evidence, stale runner trust, missing breaker metadata, and zero-subject claims were not connected to a nonzero command mode. The quick verification path also had no focused proof-check lane, so proof quality could regress unless a reviewer manually noticed report output.

The report also still described manual-review cells, even though the intended workflow is for coding agents to produce or cite judgment artifacts.

## Solution

- Add `devtools proof-pack --check`, including a `check` payload in JSON/Markdown/human output when requested.
- Reuse existing catalog quality checks from `build_verification_catalog()` as blocking policy failures.
- Block affected serious agent-judgment cells unless they carry a tracked exception.
- Keep known gaps and suppressed routing visible as warnings until #590/#594 make gap lifecycle and unrouted-path suppressions executable enough to fail globally.
- Add `devtools proof-pack --check` to `devtools verify --quick`.
- Classify `devtools/proof_pack.py` and `devtools/obligation_diff.py` as proof-catalog changes for impact routing.
- Rename `manual_review_cells` to `agent_judgment_cells` and render artifact/reviewer/produced_at/freshness/result fields.

## Verification

- `pytest -q tests/unit/devtools/test_proof_pack.py`
- `pytest -q tests/unit/devtools/test_verify.py tests/unit/proof/test_diffing.py`
- `pytest -q tests/unit/devtools/test_verify.py tests/unit/devtools/test_proof_pack.py tests/unit/proof/test_diffing.py`
- `mypy tests/unit/devtools/test_proof_pack.py`
- `ruff check devtools/proof_pack.py tests/unit/devtools/test_proof_pack.py devtools/command_catalog.py`
- `ruff check devtools/verify.py devtools/proof_pack.py polylogue/proof/diffing.py tests/unit/devtools/test_verify.py tests/unit/devtools/test_proof_pack.py tests/unit/proof/test_diffing.py`
- `ruff format --check devtools/verify.py devtools/proof_pack.py polylogue/proof/diffing.py tests/unit/devtools/test_verify.py tests/unit/devtools/test_proof_pack.py tests/unit/proof/test_diffing.py`
- `devtools render-all --check`
- `devtools proof-pack --check --json | jq '.check'`
- `devtools proof-pack --path polylogue/proof/catalog.py --check --markdown | sed -n '/### Agent Judgment Cells/,$p'`
- `devtools verify --quick`
- push hook: `devtools verify --quick`

## Remaining Risk

This is not the full #594 closure. Evidence freshness still needs persisted CI/local run metadata, serious known-gap lifecycle still belongs with #590 manifest contracts, and unrouted changed paths are warnings until there is an explicit suppression model precise enough to avoid false failures on tests and non-source files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `--check` flag to the proof-pack command that evaluates quality checks and returns a failure status if issues are detected.
  * Verification process now includes an automatic proof-pack quality check gate as part of the pre-push/pre-PR verification steps.

* **Tests**
  * Added comprehensive tests for quality check policy evaluation, agent judgment cells, and CLI flag behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->