### PR TITLE
fix(distribution): keep devtools out of user artifacts

### DIFF
--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -342,6 +342,17 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
         examples=("devtools verify-witness-lifecycle", "devtools verify-witness-lifecycle --json"),
     ),
     CommandSpec(
+        "verify-distribution-surface",
+        "verification",
+        "Verify wheel/sdist installed artifacts expose only supported runtime entrypoints.",
+        "devtools.verify_distribution_surface",
+        use_when=(
+            "Build wheel and sdist artifacts, rebuild a wheel from an unpacked sdist without .git, "
+            "smoke installed runtime console scripts, and ensure source-checkout devtools are not shipped."
+        ),
+        examples=("devtools verify-distribution-surface",),
+    ),
+    CommandSpec(
         "pipeline-probe",
         "verification",
         "Run typed pipeline probes against synthetic, staged, or archive-subset inputs.",

--- a/devtools/verify_distribution_surface.py
+++ b/devtools/verify_distribution_surface.py
@@ -1,0 +1,198 @@
+"""Verify installed distribution artifacts expose the intended runtime surface."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+import zipfile
+from collections.abc import Iterable
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+RUNTIME_SCRIPTS = ("polylogue", "polylogued", "polylogue-mcp")
+SOURCE_ONLY_SCRIPTS = ("devtools",)
+
+
+class DistributionVerificationError(RuntimeError):
+    """Raised when a distribution artifact violates the supported surface."""
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Verify wheel/sdist installed distribution behavior.")
+    parser.add_argument(
+        "--work-dir",
+        type=Path,
+        default=None,
+        help="Directory for temporary build/install artifacts. Defaults to a temporary directory.",
+    )
+    parser.add_argument(
+        "--keep-work-dir",
+        action="store_true",
+        help="Keep the generated work directory for inspection.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.work_dir is not None:
+        work_dir = args.work_dir.resolve()
+        work_dir.mkdir(parents=True, exist_ok=True)
+        cleanup = False
+    else:
+        work_dir = Path(tempfile.mkdtemp(prefix="polylogue-distribution-"))
+        cleanup = not args.keep_work_dir
+
+    try:
+        verify_distribution_surface(work_dir)
+    except DistributionVerificationError as exc:
+        print(f"verify-distribution-surface: FAILED: {exc}", file=sys.stderr)
+        if not cleanup:
+            print(f"verify-distribution-surface: work dir: {work_dir}", file=sys.stderr)
+        return 1
+    finally:
+        if cleanup:
+            shutil.rmtree(work_dir, ignore_errors=True)
+
+    if args.keep_work_dir or args.work_dir is not None:
+        print(f"verify-distribution-surface: work dir: {work_dir}", file=sys.stderr)
+    print("verify-distribution-surface: ok", file=sys.stderr)
+    return 0
+
+
+def verify_distribution_surface(work_dir: Path) -> None:
+    """Build and smoke installed wheel artifacts from checkout and unpacked sdist."""
+    work_dir = work_dir.resolve()
+    dist_dir = work_dir / "dist"
+    _run(("uv", "build", "--out-dir", str(dist_dir), "--sdist", "--wheel", str(ROOT)), cwd=ROOT)
+
+    wheel = _single_artifact(dist_dir, "*.whl")
+    sdist = _single_artifact(dist_dir, "*.tar.gz")
+    _verify_wheel_surface(wheel)
+    _smoke_installed_wheel(wheel, work_dir / "wheel-install")
+
+    unpacked = _unpack_sdist(sdist, work_dir / "unpacked-sdist")
+    if (unpacked / ".git").exists():
+        raise DistributionVerificationError("unpacked sdist unexpectedly contains .git")
+    if not (unpacked / "polylogue" / "_build_info.py").exists():
+        raise DistributionVerificationError("sdist is missing embedded polylogue/_build_info.py")
+
+    sdist_wheel_dir = work_dir / "sdist-wheel"
+    _run(("uv", "build", "--out-dir", str(sdist_wheel_dir), "--wheel", str(unpacked)), cwd=work_dir)
+    sdist_wheel = _single_artifact(sdist_wheel_dir, "*.whl")
+    _verify_wheel_surface(sdist_wheel)
+    _smoke_installed_wheel(sdist_wheel, work_dir / "sdist-wheel-install")
+
+
+def _verify_wheel_surface(wheel: Path) -> None:
+    with zipfile.ZipFile(wheel) as archive:
+        names = set(archive.namelist())
+        if "polylogue/_build_info.py" not in names:
+            raise DistributionVerificationError(f"{wheel.name} is missing polylogue/_build_info.py")
+        if any(name.startswith("devtools/") for name in names):
+            raise DistributionVerificationError(f"{wheel.name} includes source-checkout-only devtools package")
+        entry_points = _read_entry_points(archive)
+    for script in RUNTIME_SCRIPTS:
+        if f"{script} =" not in entry_points:
+            raise DistributionVerificationError(f"{wheel.name} is missing console script {script}")
+    for script in SOURCE_ONLY_SCRIPTS:
+        if f"{script} =" in entry_points:
+            raise DistributionVerificationError(f"{wheel.name} exposes source-checkout-only console script {script}")
+
+
+def _read_entry_points(archive: zipfile.ZipFile) -> str:
+    matches = [name for name in archive.namelist() if name.endswith(".dist-info/entry_points.txt")]
+    if not matches:
+        raise DistributionVerificationError("wheel is missing entry_points.txt")
+    return archive.read(matches[0]).decode()
+
+
+def _smoke_installed_wheel(wheel: Path, install_dir: Path) -> None:
+    wheel = wheel.resolve()
+    install_dir = install_dir.resolve()
+    install_dir.mkdir(parents=True, exist_ok=True)
+    venv_dir = install_dir / "venv"
+    _run(("uv", "venv", str(venv_dir)), cwd=install_dir)
+    python = _venv_python(venv_dir)
+    _run(("uv", "pip", "install", "--python", str(python), str(wheel)), cwd=install_dir)
+    env = _smoke_env(install_dir / "archive")
+    bin_dir = venv_dir / ("Scripts" if os.name == "nt" else "bin")
+    _run((str(bin_dir / "polylogue"), "--version"), cwd=install_dir, env=env)
+    _run((str(bin_dir / "polylogue"), "--help"), cwd=install_dir, env=env)
+    _run((str(bin_dir / "polylogue"), "--plain", "count"), cwd=install_dir, env=env)
+    _run((str(python), "-m", "polylogue", "--version"), cwd=install_dir, env=env)
+    _run((str(bin_dir / "polylogued"), "--help"), cwd=install_dir, env=env)
+    _run((str(bin_dir / "polylogue-mcp"), "--help"), cwd=install_dir, env=env)
+    if (bin_dir / "devtools").exists():
+        raise DistributionVerificationError("installed wheel exposes devtools console script")
+    _run(
+        (
+            str(python),
+            "-c",
+            "import importlib.util; raise SystemExit(importlib.util.find_spec('devtools') is not None)",
+        ),
+        cwd=install_dir,
+        env=env,
+    )
+
+
+def _smoke_env(archive_root: Path) -> dict[str, str]:
+    env = os.environ.copy()
+    env.pop("PYTHONPATH", None)
+    env["POLYLOGUE_ARCHIVE_ROOT"] = str(archive_root.resolve())
+    env["POLYLOGUE_FORCE_PLAIN"] = "1"
+    return env
+
+
+def _venv_python(venv_dir: Path) -> Path:
+    return venv_dir / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
+
+
+def _single_artifact(directory: Path, pattern: str) -> Path:
+    matches = sorted(directory.glob(pattern))
+    if len(matches) != 1:
+        raise DistributionVerificationError(f"expected one {pattern} in {directory}, found {len(matches)}")
+    return matches[0]
+
+
+def _unpack_sdist(sdist: Path, output_dir: Path) -> Path:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    with tarfile.open(sdist) as archive:
+        _safe_extract(archive, output_dir)
+    roots = [path for path in output_dir.iterdir() if path.is_dir()]
+    if len(roots) != 1:
+        raise DistributionVerificationError(f"expected one unpacked sdist root, found {len(roots)}")
+    return roots[0]
+
+
+def _safe_extract(archive: tarfile.TarFile, output_dir: Path) -> None:
+    destination = output_dir.resolve()
+    for member in archive.getmembers():
+        target = (output_dir / member.name).resolve()
+        if destination not in (target, *target.parents):
+            raise DistributionVerificationError(f"unsafe sdist member path: {member.name}")
+    try:
+        archive.extractall(output_dir, filter="data")
+    except TypeError:
+        archive.extractall(output_dir)
+
+
+def _run(
+    cmd: Iterable[str],
+    *,
+    cwd: Path,
+    env: dict[str, str] | None = None,
+) -> None:
+    rendered = " ".join(cmd)
+    print(f"verify-distribution-surface: {rendered}", file=sys.stderr)
+    result = subprocess.run(tuple(cmd), cwd=cwd, env=env, text=True, capture_output=True, check=False)
+    if result.returncode == 0:
+        return
+    output = "\n".join(part for part in (result.stdout.strip(), result.stderr.strip()) if part)
+    raise DistributionVerificationError(f"command failed ({result.returncode}): {rendered}\n{output}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -114,6 +114,7 @@ These are the commands worth remembering during normal repo work:
 | `devtools verify` | Run the local verification baseline before pushing or creating a PR. |
 | `devtools verify-cluster-cohesion` | Validate proposed clusters from the topology projection using the import graph. |
 | `devtools verify-cross-cuts` | Verify cross-cut tags in the topology projection match module-name conventions. |
+| `devtools verify-distribution-surface` | Verify wheel/sdist installed artifacts expose only supported runtime entrypoints. |
 | `devtools verify-file-budgets` | Enforce per-file LOC budgets declared in docs/plans/file-size-budgets.yaml. |
 | `devtools verify-layering` | Check inter-package imports against declared layering rules from docs/plans/layering.yaml. |
 | `devtools verify-manifests` | Verify internal consistency across all docs/plans/*.yaml manifest files. |

--- a/docs/plans/distribution-coverage.yaml
+++ b/docs/plans/distribution-coverage.yaml
@@ -1,11 +1,12 @@
 # Distribution-coverage manifest.
 #
 # Documents the current state of install-artifact parity across
-# wheel, sdist, and Nix package. Seed state: each artifact builds
-# independently but there is no automated cross-artifact
-# equivalence verification.
+# wheel, sdist, and Nix package. The local distribution gate now
+# builds wheel/sdist artifacts, rebuilds from unpacked sdist without
+# .git, smokes installed runtime entrypoints, and verifies that the
+# source-checkout-only devtools surface is not shipped in user wheels.
 #
-# Updated 2026-04-29 from realized codebase state.
+# Updated 2026-05-02 from realized codebase state.
 
 description: >
   Wheel/sdist/Nix install parity for polylogue. Documents build
@@ -17,28 +18,34 @@ artifacts:
     description: Python wheel distribution (bdist_wheel)
     build_system: hatchling
     config_location: pyproject.toml
-    build_command: pip wheel --no-deps .
+    build_command: uv build --wheel .
     install_command: pip install polylogue-*.whl
+    verification_command: devtools verify-distribution-surface
     ci_build: false
     ci_test: false
     freshness_days: null
     notes: >
       pyproject.toml uses [build-system] with hatchling.
-      Wheel is buildable but not built in CI. No automated
-      smoke test after wheel install.
+      The source-checkout distribution gate builds the wheel,
+      installs it in a fresh environment, smokes polylogue,
+      polylogued, polylogue-mcp, python -m polylogue, and asserts
+      devtools is not installed. The gate is not yet scheduled in CI.
 
   sdist:
     description: Python source distribution (sdist)
     build_system: hatchling
     config_location: pyproject.toml
-    build_command: pip wheel --no-binary polylogue .
+    build_command: uv build --sdist .
     install_command: pip install polylogue-*.tar.gz
+    verification_command: devtools verify-distribution-surface
     ci_build: false
     ci_test: false
     freshness_days: null
     notes: >
-      Source distribution buildable via hatchling but not
-      built in CI. No automated sdist-install verification.
+      Source distribution embeds polylogue/_build_info.py. The
+      distribution gate unpacks the sdist outside .git, rebuilds
+      a wheel from it, installs that wheel, and runs the same
+      runtime smoke surface. The gate is not yet scheduled in CI.
 
   nix_package:
     description: Nix flake package derivation
@@ -79,6 +86,17 @@ artifacts:
       via direnv. Installs all dependencies and git hooks.
       Verified by nix flake check in CI.
 
+  devtools:
+    description: Source-checkout repository control plane
+    build_system: source checkout / Nix devshell wrapper
+    config_location: flake.nix
+    install_command: nix develop
+    ci_present: true
+    notes: >
+      Devtools are intentionally source-checkout-only. They are
+      exposed in the devshell by the devtools wrapper in flake.nix,
+      not as a user-wheel console script or installed wheel package.
+
   pip_dependencies:
     count: null
     resolved_by: flake.nix (overrides pyproject.toml)
@@ -93,13 +111,13 @@ artifacts:
 
 coverage_gaps:
   - artifact: wheel
-    gap: Not built or tested in CI
+    gap: Distribution gate exists locally but is not scheduled in CI
     owner: distribution
-    next_evidence: Add package/build or cross-artifact CI gate
+    next_evidence: Add CI job for devtools verify-distribution-surface
   - artifact: sdist
-    gap: Not built or tested in CI
+    gap: Distribution gate exists locally but is not scheduled in CI
     owner: distribution
-    next_evidence: Add package/build or cross-artifact CI gate
+    next_evidence: Add CI job for devtools verify-distribution-surface
   - artifact: dev_install
     gap: Not verified in CI; devshell is canonical environment
     owner: distribution
@@ -113,6 +131,6 @@ coverage_gaps:
     owner: distribution
     next_evidence: Add package/build or cross-artifact CI gate
   - concern: install_parity
-    gap: No cross-artifact equivalence verification (wheel vs sdist vs Nix)
+    gap: Local gate smokes wheel and sdist-built wheel, but exact Nix/devshell parity is not yet compared in CI
     owner: distribution
-    next_evidence: Add package/build or cross-artifact CI gate
+    next_evidence: Add CI job comparing devtools verify-distribution-surface with nix flake check smoke output

--- a/docs/verification-catalog.md
+++ b/docs/verification-catalog.md
@@ -8,10 +8,10 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 
 ## Snapshot
 
-- subjects: `500`
+- subjects: `501`
 - claims: `44`
 - runner bindings: `44`
-- proof obligations: `564`
+- proof obligations: `565`
 
 ## Quality Checks
 
@@ -38,7 +38,7 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | `archive.query_law` | 1 |
 | `artifact.path` | 27 |
 | `assurance.coverage_gap` | 23 |
-| `assurance.coverage_item` | 91 |
+| `assurance.coverage_item` | 92 |
 | `assurance.coverage_manifest` | 9 |
 | `cli.command` | 54 |
 | `cli.json_command` | 5 |
@@ -152,7 +152,7 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | `benchmark_coverage` | `assurance.coverage_item` | 3 |
 | `cli_surface` | `assurance.coverage_item` | 2 |
 | `distribution` | `assurance.coverage_gap` | 7 |
-| `distribution` | `assurance.coverage_item` | 7 |
+| `distribution` | `assurance.coverage_item` | 8 |
 | `distribution` | `assurance.coverage_manifest` | 1 |
 | `docs_media` | `assurance.coverage_gap` | 3 |
 | `docs_media` | `assurance.coverage_item` | 17 |
@@ -289,7 +289,7 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | `archive.query.provider_filter_consistency` | 1 |
 | `artifact.path.dependency_closure` | 11 |
 | `assurance.coverage.gap_has_closure_path` | 23 |
-| `assurance.coverage.item_declared` | 91 |
+| `assurance.coverage.item_declared` | 92 |
 | `assurance.coverage.manifest_structured` | 9 |
 | `cli.command.help` | 54 |
 | `cli.command.json_envelope` | 5 |

--- a/flake.nix
+++ b/flake.nix
@@ -82,7 +82,6 @@
           doCheck = false;
           pythonImportsCheck = [
             "polylogue"
-            "devtools"
           ];
           dontCheckRuntimeDeps = true;
 
@@ -203,6 +202,9 @@
             ''
               export HOME=$TMPDIR
               polylogue --help >/dev/null
+              polylogued --help >/dev/null
+              polylogue-mcp --help >/dev/null
+              ! command -v devtools >/dev/null
               touch $out
             '';
       }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,10 +111,9 @@ Documentation = "https://github.com/sinity/polylogue#readme"
 polylogue = "polylogue.cli:main"
 polylogued = "polylogue.daemon.cli:main"
 polylogue-mcp = "polylogue.mcp.cli:main"
-devtools = "devtools.__main__:main"
 
 [tool.hatch.build.targets.wheel]
-packages = ["polylogue", "devtools"]
+packages = ["polylogue"]
 
 [tool.hatch.build.hooks.custom]
 path = "hatch_build.py"

--- a/tests/unit/devtools/test_verify_distribution_surface.py
+++ b/tests/unit/devtools/test_verify_distribution_surface.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import os
+import tarfile
+import zipfile
+from pathlib import Path
+
+import pytest
+import tomllib
+
+from devtools import verify_distribution_surface as surface
+
+
+def test_verify_wheel_surface_accepts_runtime_scripts_without_devtools(tmp_path: Path) -> None:
+    wheel = _write_wheel(tmp_path, entry_points=_runtime_entry_points())
+
+    surface._verify_wheel_surface(wheel)
+
+
+def test_verify_wheel_surface_rejects_devtools_script(tmp_path: Path) -> None:
+    wheel = _write_wheel(tmp_path, entry_points=f"{_runtime_entry_points()}devtools = devtools.__main__:main\n")
+
+    with pytest.raises(surface.DistributionVerificationError, match="devtools"):
+        surface._verify_wheel_surface(wheel)
+
+
+def test_verify_wheel_surface_rejects_devtools_package(tmp_path: Path) -> None:
+    wheel = _write_wheel(tmp_path, entry_points=_runtime_entry_points(), extra_files={"devtools/__main__.py": ""})
+
+    with pytest.raises(surface.DistributionVerificationError, match="devtools package"):
+        surface._verify_wheel_surface(wheel)
+
+
+def test_verify_distribution_surface_builds_sdist_wheel_and_smokes(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    calls: list[tuple[str, ...]] = []
+
+    def fake_run(cmd: tuple[str, ...], *, cwd: Path, env: dict[str, str] | None = None) -> None:
+        del cwd, env
+        calls.append(cmd)
+        if cmd[:2] == ("uv", "build") and "--sdist" in cmd:
+            dist_dir = Path(cmd[cmd.index("--out-dir") + 1])
+            dist_dir.mkdir(parents=True, exist_ok=True)
+            _write_wheel(dist_dir, entry_points=_runtime_entry_points())
+            _write_sdist(dist_dir / "polylogue-0.1.0.tar.gz")
+        elif cmd[:2] == ("uv", "build") and "--wheel" in cmd:
+            out_dir = Path(cmd[cmd.index("--out-dir") + 1])
+            out_dir.mkdir(parents=True, exist_ok=True)
+            _write_wheel(out_dir, entry_points=_runtime_entry_points())
+        elif cmd[:2] == ("uv", "venv"):
+            venv = Path(cmd[2])
+            bin_dir = venv / ("Scripts" if os.name == "nt" else "bin")
+            bin_dir.mkdir(parents=True, exist_ok=True)
+            for script in (*surface.RUNTIME_SCRIPTS, "python"):
+                (bin_dir / script).write_text("", encoding="utf-8")
+
+    monkeypatch.setattr(surface, "_run", fake_run)
+
+    surface.verify_distribution_surface(tmp_path)
+
+    rendered = [" ".join(call[:2]) for call in calls]
+    assert rendered.count("uv build") == 2
+    assert rendered.count("uv venv") == 2
+    assert not any("devtools" in call for call in calls)
+
+
+def test_pyproject_keeps_devtools_source_only() -> None:
+    data = tomllib.loads((surface.ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+
+    assert "devtools" not in data["project"]["scripts"]
+    assert data["tool"]["hatch"]["build"]["targets"]["wheel"]["packages"] == ["polylogue"]
+
+
+def _runtime_entry_points() -> str:
+    return "\n".join(
+        [
+            "[console_scripts]",
+            "polylogue = polylogue.cli:main",
+            "polylogued = polylogue.daemon.cli:main",
+            "polylogue-mcp = polylogue.mcp.cli:main",
+            "",
+        ]
+    )
+
+
+def _write_wheel(
+    directory: Path,
+    *,
+    entry_points: str,
+    extra_files: dict[str, str] | None = None,
+) -> Path:
+    wheel = directory / "polylogue-0.1.0-py3-none-any.whl"
+    with zipfile.ZipFile(wheel, "w") as archive:
+        archive.writestr("polylogue/__init__.py", "")
+        archive.writestr("polylogue/_build_info.py", 'BUILD_COMMIT = "deadbeef"\nBUILD_DIRTY = False\n')
+        archive.writestr("polylogue-0.1.0.dist-info/entry_points.txt", entry_points)
+        for name, content in (extra_files or {}).items():
+            archive.writestr(name, content)
+    return wheel
+
+
+def _write_sdist(path: Path) -> None:
+    root = path.parent / "polylogue-0.1.0"
+    (root / "polylogue").mkdir(parents=True)
+    (root / "polylogue" / "_build_info.py").write_text(
+        'BUILD_COMMIT = "deadbeef"\nBUILD_DIRTY = False\n',
+        encoding="utf-8",
+    )
+    with tarfile.open(path, "w:gz") as archive:
+        archive.add(root, arcname=root.name)


### PR DESCRIPTION
## Summary

Keeps `devtools` as a source-checkout control plane instead of a shipped user artifact, and adds an installed distribution gate for the wheel/sdist surface.

## Problem

#593 called out that Polylogue's distribution boundary was confused: `pyproject.toml` exposed `devtools` as a console script and shipped the `devtools` package in user wheels. That made repo-maintenance tooling look like part of the installed product surface, while the build only proved that artifacts could be produced, not that installed artifacts had the intended entrypoints or build metadata.

## Solution

Remove `devtools` from wheel packaging and console scripts while keeping `polylogue`, `polylogued`, and `polylogue-mcp` as runtime entrypoints. Extend the Nix package smoke check to prove those runtime scripts exist and that `devtools` is absent.

Add `devtools verify-distribution-surface`, which builds checkout wheel/sdist artifacts, verifies wheel contents and entry points, installs the checkout-built wheel in a fresh environment, unpacks the sdist outside `.git`, rebuilds a wheel from that unpacked sdist, installs it, and smokes the same runtime surface. The gate also rejects importable or executable `devtools` from installed wheels.

Update the distribution coverage manifest and generated docs to record the realized state: local wheel/sdist verification now exists, while CI scheduling and exact Nix/devshell parity remain coverage gaps.

## Verification

- `ruff check devtools/verify_distribution_surface.py tests/unit/devtools/test_verify_distribution_surface.py devtools/command_catalog.py`
- `ruff format --check devtools/verify_distribution_surface.py tests/unit/devtools/test_verify_distribution_surface.py devtools/command_catalog.py`
- `mypy devtools/verify_distribution_surface.py tests/unit/devtools/test_verify_distribution_surface.py`
- `pytest -q tests/unit/devtools/test_verify_distribution_surface.py tests/unit/devtools/test_devtools_main.py tests/unit/devtools/test_render_devtools_reference.py tests/unit/devtools/test_build_package.py` (`14 passed`)
- `devtools verify-distribution-surface --work-dir .local/distribution-surface-check`
- `devtools verify-manifests`
- `devtools render-all --check`
- `devtools verify --quick` via pre-push hook
- `nix flake check` (`all checks passed`; omitted incompatible non-Linux systems)

Closes #593
