### PR TITLE
fix(cli): back query completions with descriptors

### DIFF
--- a/docs/verification-catalog.md
+++ b/docs/verification-catalog.md
@@ -61,11 +61,11 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | --- | --- |
 | `polylogue` | `polylogue/cli/click_app.py:50` `polylogue.cli.click_app.cli` |
 | `polylogue auth` | `polylogue/cli/commands/auth.py:16` `polylogue.cli.commands.auth.auth_command` |
-| `polylogue bulk-export` | `polylogue/cli/query_verbs.py:109` `polylogue.cli.query_verbs.bulk_export_verb` |
+| `polylogue bulk-export` | `polylogue/cli/query_verbs.py:110` `polylogue.cli.query_verbs.bulk_export_verb` |
 | `polylogue completions` | `polylogue/cli/commands/completions.py:9` `polylogue.cli.commands.completions.completions_command` |
-| `polylogue count` | `polylogue/cli/query_verbs.py:45` `polylogue.cli.query_verbs.count_verb` |
+| `polylogue count` | `polylogue/cli/query_verbs.py:46` `polylogue.cli.query_verbs.count_verb` |
 | `polylogue dashboard` | `polylogue/cli/commands/dashboard.py:10` `polylogue.cli.commands.dashboard.dashboard_command` |
-| `polylogue delete` | `polylogue/cli/query_verbs.py:137` `polylogue.cli.query_verbs.delete_verb` |
+| `polylogue delete` | `polylogue/cli/query_verbs.py:138` `polylogue.cli.query_verbs.delete_verb` |
 | `polylogue diagnostics` | `polylogue/cli/commands/diagnostics.py:15` `polylogue.cli.commands.diagnostics.diagnostics_group` |
 | `polylogue diagnostics pace` | `polylogue/cli/commands/diagnostics.py:20` `polylogue.cli.commands.diagnostics.pace_command` |
 | `polylogue diagnostics tools` | `polylogue/cli/commands/diagnostics.py:139` `polylogue.cli.commands.diagnostics.tools_command` |
@@ -87,11 +87,11 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | `polylogue insights threads` | `polylogue/cli/commands/insights.py:100` `polylogue.cli.commands.insights._make_callback.<locals>.callback` |
 | `polylogue insights week-summaries` | `polylogue/cli/commands/insights.py:100` `polylogue.cli.commands.insights._make_callback.<locals>.callback` |
 | `polylogue insights work-events` | `polylogue/cli/commands/insights.py:100` `polylogue.cli.commands.insights._make_callback.<locals>.callback` |
-| `polylogue list` | `polylogue/cli/query_verbs.py:22` `polylogue.cli.query_verbs.list_verb` |
-| `polylogue messages` | `polylogue/cli/query_verbs.py:179` `polylogue.cli.query_verbs.messages_verb` |
+| `polylogue list` | `polylogue/cli/query_verbs.py:23` `polylogue.cli.query_verbs.list_verb` |
+| `polylogue messages` | `polylogue/cli/query_verbs.py:180` `polylogue.cli.query_verbs.messages_verb` |
 | `polylogue neighbors` | `polylogue/cli/commands/neighbors.py:42` `polylogue.cli.commands.neighbors.neighbors_command` |
-| `polylogue open` | `polylogue/cli/query_verbs.py:94` `polylogue.cli.query_verbs.open_verb` |
-| `polylogue raw` | `polylogue/cli/query_verbs.py:243` `polylogue.cli.query_verbs.raw_verb` |
+| `polylogue open` | `polylogue/cli/query_verbs.py:95` `polylogue.cli.query_verbs.open_verb` |
+| `polylogue raw` | `polylogue/cli/query_verbs.py:244` `polylogue.cli.query_verbs.raw_verb` |
 | `polylogue reset` | `polylogue/cli/commands/reset.py:23` `polylogue.cli.commands.reset.reset_command` |
 | `polylogue resume` | `polylogue/cli/commands/resume.py:22` `polylogue.cli.commands.resume.resume_command` |
 | `polylogue run` | `polylogue/cli/commands/run.py:178` `polylogue.cli.commands.run.run_command` |
@@ -110,8 +110,8 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | `polylogue schema compare` | `polylogue/cli/commands/schema.py:56` `polylogue.cli.commands.schema.schema_compare` |
 | `polylogue schema explain` | `polylogue/cli/commands/schema.py:94` `polylogue.cli.commands.schema.schema_explain` |
 | `polylogue schema list` | `polylogue/cli/commands/schema.py:45` `polylogue.cli.commands.schema.schema_list` |
-| `polylogue show` | `polylogue/cli/query_verbs.py:80` `polylogue.cli.query_verbs.show_verb` |
-| `polylogue stats` | `polylogue/cli/query_verbs.py:52` `polylogue.cli.query_verbs.stats_verb` |
+| `polylogue show` | `polylogue/cli/query_verbs.py:81` `polylogue.cli.query_verbs.show_verb` |
+| `polylogue stats` | `polylogue/cli/query_verbs.py:53` `polylogue.cli.query_verbs.stats_verb` |
 | `polylogue tags` | `polylogue/cli/commands/tags.py:12` `polylogue.cli.commands.tags.tags_command` |
 
 ## Schema Annotation Subjects

--- a/polylogue/archive/query/fields.py
+++ b/polylogue/archive/query/fields.py
@@ -16,6 +16,7 @@ StorageValue = Callable[[object], object]
 _ReplaceRecordQuery: Callable[..., ConversationRecordQuery] = replace
 SqlPushdownValue: TypeAlias = str | int | bool | list[str]
 SqlPushdownParams: TypeAlias = dict[str, SqlPushdownValue]
+CompletionSource: TypeAlias = str
 
 
 class _ProviderScopedPlan(Protocol):
@@ -136,6 +137,8 @@ class QueryFieldDescriptor:
     blocks_sql_count: bool = False
     blocks_action_event_stats: bool = False
     blocks_simple_message_hit: bool = False
+    completion_source: CompletionSource | None = None
+    completion_label: str | None = None
 
     def spec_value(self, spec: object) -> object:
         if self.spec_attr is None:
@@ -238,6 +241,8 @@ QUERY_FIELD_DESCRIPTORS: tuple[QueryFieldDescriptor, ...] = (
         record_attr="cwd_prefix",
         sql_param="cwd_prefix",
         blocks_simple_message_hit=True,
+        completion_source="cwd_prefix",
+        completion_label="working directory",
     ),
     QueryFieldDescriptor(
         name="action_terms",
@@ -308,6 +313,8 @@ QUERY_FIELD_DESCRIPTORS: tuple[QueryFieldDescriptor, ...] = (
         requires_content_loading=True,
         blocks_sql_count=True,
         blocks_simple_message_hit=True,
+        completion_source="tool",
+        completion_label="tool",
     ),
     QueryFieldDescriptor(
         name="excluded_tool_terms",
@@ -322,6 +329,8 @@ QUERY_FIELD_DESCRIPTORS: tuple[QueryFieldDescriptor, ...] = (
         requires_content_loading=True,
         blocks_sql_count=True,
         blocks_simple_message_hit=True,
+        completion_source="tool",
+        completion_label="tool",
     ),
     QueryFieldDescriptor(
         name="providers",
@@ -329,6 +338,8 @@ QUERY_FIELD_DESCRIPTORS: tuple[QueryFieldDescriptor, ...] = (
         plan_attr="providers",
         spec_description=_label("provider", _join_providers),
         plan_description=_label("provider", _join_providers),
+        completion_source="provider",
+        completion_label="provider",
     ),
     QueryFieldDescriptor(
         name="excluded_providers",
@@ -340,6 +351,8 @@ QUERY_FIELD_DESCRIPTORS: tuple[QueryFieldDescriptor, ...] = (
         blocks_sql_count=True,
         blocks_action_event_stats=True,
         blocks_simple_message_hit=True,
+        completion_source="provider",
+        completion_label="provider",
     ),
     QueryFieldDescriptor(
         name="repo_names",
@@ -350,6 +363,8 @@ QUERY_FIELD_DESCRIPTORS: tuple[QueryFieldDescriptor, ...] = (
         record_attr="repo_names",
         sql_param="repo_names",
         sql_value=_list_value,
+        completion_source="repo",
+        completion_label="repository",
     ),
     QueryFieldDescriptor(
         name="tags",
@@ -361,6 +376,8 @@ QUERY_FIELD_DESCRIPTORS: tuple[QueryFieldDescriptor, ...] = (
         blocks_sql_count=True,
         blocks_action_event_stats=True,
         blocks_simple_message_hit=True,
+        completion_source="tag",
+        completion_label="tag",
     ),
     QueryFieldDescriptor(
         name="excluded_tags",
@@ -372,6 +389,8 @@ QUERY_FIELD_DESCRIPTORS: tuple[QueryFieldDescriptor, ...] = (
         blocks_sql_count=True,
         blocks_action_event_stats=True,
         blocks_simple_message_hit=True,
+        completion_source="tag",
+        completion_label="tag",
     ),
     QueryFieldDescriptor(
         name="title",
@@ -535,6 +554,8 @@ QUERY_FIELD_DESCRIPTORS: tuple[QueryFieldDescriptor, ...] = (
         plan_description=_label("id"),
         blocks_sql_count=True,
         blocks_simple_message_hit=True,
+        completion_source="conversation_id",
+        completion_label="conversation",
     ),
     QueryFieldDescriptor(
         name="latest",
@@ -620,6 +641,8 @@ QUERY_FIELD_DESCRIPTORS: tuple[QueryFieldDescriptor, ...] = (
         selection_filter=True,
         requires_post_filter=True,
         blocks_sql_count=True,
+        completion_source="conversation_id",
+        completion_label="conversation",
     ),
     QueryFieldDescriptor(
         name="message_type",
@@ -633,6 +656,8 @@ QUERY_FIELD_DESCRIPTORS: tuple[QueryFieldDescriptor, ...] = (
         sql_param="message_type",
         storage_value=lambda v: str(v) if v else None,
         selection_filter=True,
+        completion_source="message_type",
+        completion_label="message type",
     ),
 )
 

--- a/polylogue/cli/click_option_groups.py
+++ b/polylogue/cli/click_option_groups.py
@@ -12,7 +12,9 @@ from polylogue.archive.query.spec import QUERY_ACTION_TYPES, QUERY_RETRIEVAL_LAN
 from polylogue.cli.query_contracts import normalize_message_role_option
 from polylogue.cli.shell_completion_values import (
     complete_conversation_ids,
+    complete_cwd_prefix_values,
     complete_provider_values,
+    complete_repo_values,
     complete_tag_values,
     complete_tool_values,
 )
@@ -93,7 +95,7 @@ FILTER_OPTION_DECORATORS: tuple[Callable[[ClickCallable], ClickCallable], ...] =
         "--repo",
         "-r",
         help="Filter by repository name (comma = OR)",
-        shell_complete=complete_tag_values,
+        shell_complete=complete_repo_values,
     ),
     click.option(
         "--tag", "-t", help="Include tags (comma = OR, supports key:value)", shell_complete=complete_tag_values
@@ -111,6 +113,7 @@ FILTER_OPTION_DECORATORS: tuple[Callable[[ClickCallable], ClickCallable], ...] =
         "cwd_prefix",
         default=None,
         help="Filter conversations whose recorded working directory starts with this prefix",
+        shell_complete=complete_cwd_prefix_values,
     ),
     click.option(
         "--action",

--- a/polylogue/cli/query_verbs.py
+++ b/polylogue/cli/query_verbs.py
@@ -10,9 +10,10 @@ from typing import cast
 
 import click
 
+from polylogue.archive.message.types import MessageType
 from polylogue.cli.root_request import RootModeRequest
 from polylogue.cli.shared.types import AppEnv
-from polylogue.cli.shell_completion_values import complete_open_targets
+from polylogue.cli.shell_completion_values import complete_conversation_ids, complete_open_targets
 
 VERB_NAMES = frozenset({"list", "count", "stats", "open", "show", "bulk-export", "delete", "messages", "raw"})
 
@@ -177,12 +178,12 @@ def _execute_query_verb(
 
 
 @click.command("messages")
-@click.argument("conversation_id", required=False)
+@click.argument("conversation_id", required=False, shell_complete=complete_conversation_ids)
 @click.option("--message-role", "-r", "message_role", multiple=True, help="Filter by message role")
 @click.option(
     "--message-type",
     "message_type",
-    type=click.Choice(["summary", "tool_use", "tool_result", "thinking"]),
+    type=click.Choice([message_type.value for message_type in MessageType]),
     help="Filter by message content type",
 )
 @click.option("--limit", "-n", type=int, default=50, help="Max messages to return")
@@ -241,7 +242,7 @@ def messages_verb(
 
 
 @click.command("raw")
-@click.argument("conversation_id", required=False)
+@click.argument("conversation_id", required=False, shell_complete=complete_conversation_ids)
 @click.option("--limit", "-n", type=int, default=50, help="Max raw artifacts to return")
 @click.option("--offset", type=int, default=0, help="Offset for pagination")
 @click.option(

--- a/polylogue/cli/shell_completion_values.py
+++ b/polylogue/cli/shell_completion_values.py
@@ -182,6 +182,71 @@ def complete_tag_values(
     return _with_csv_prefix(items, prefix)
 
 
+def complete_repo_values(
+    ctx: click.Context,
+    param: click.Parameter,
+    incomplete: str,
+) -> list[CompletionItem]:
+    del ctx, param
+    prefix, current = _split_csv_incomplete(incomplete)
+    rows = _fetch_rows(
+        """
+        SELECT
+            repo.value AS repo_name,
+            COUNT(*) AS cnt
+        FROM session_profiles AS sp,
+             json_each(COALESCE(sp.repo_names_json, '[]')) AS repo
+        WHERE (? = '' OR repo.value LIKE ?)
+        GROUP BY repo.value
+        ORDER BY cnt DESC, repo.value ASC
+        LIMIT ?
+        """,
+        (
+            current,
+            f"{current}%",
+            _MAX_VALUE_COMPLETIONS,
+        ),
+    )
+    items = _rows_to_completion_items(
+        rows,
+        value_column="repo_name",
+        help_builder=lambda row: f"{int(row['cnt'])} sessions",
+    )
+    return _with_csv_prefix(items, prefix)
+
+
+def complete_cwd_prefix_values(
+    ctx: click.Context,
+    param: click.Parameter,
+    incomplete: str,
+) -> list[CompletionItem]:
+    del ctx, param
+    current = incomplete.strip()
+    rows = _fetch_rows(
+        """
+        SELECT
+            cwd.value AS cwd_path,
+            COUNT(*) AS cnt
+        FROM session_profiles AS sp,
+             json_each(COALESCE(json_extract(sp.evidence_payload_json, '$.cwd_paths'), '[]')) AS cwd
+        WHERE (? = '' OR cwd.value LIKE ?)
+        GROUP BY cwd.value
+        ORDER BY cnt DESC, cwd.value ASC
+        LIMIT ?
+        """,
+        (
+            current,
+            f"{current}%",
+            _MAX_VALUE_COMPLETIONS,
+        ),
+    )
+    return _rows_to_completion_items(
+        rows,
+        value_column="cwd_path",
+        help_builder=lambda row: f"{int(row['cnt'])} sessions",
+    )
+
+
 def complete_tool_values(
     ctx: click.Context,
     param: click.Parameter,
@@ -215,8 +280,10 @@ def complete_tool_values(
 
 __all__ = [
     "complete_conversation_ids",
+    "complete_cwd_prefix_values",
     "complete_open_targets",
     "complete_provider_values",
+    "complete_repo_values",
     "complete_tag_values",
     "complete_tool_values",
 ]

--- a/tests/integration/test_cli_query_mode.py
+++ b/tests/integration/test_cli_query_mode.py
@@ -369,6 +369,59 @@ def test_cli_completion_tag_and_tool_values_are_archive_backed(tmp_path: Path) -
     assert bash["help"] == "1 actions"
 
 
+def test_cli_completion_repo_cwd_and_read_ids_are_archive_backed(tmp_path: Path) -> None:
+    workspace = setup_isolated_workspace(tmp_path)
+    inbox = workspace["paths"]["inbox"]
+
+    GenericConversationBuilder("conv-complete-insights").title("Completion Insights").add_user("alpha").add_assistant(
+        "beta"
+    ).write_to(inbox / "conversation.json")
+    _run_inbox(workspace, cwd=tmp_path)
+    list_result = run_cli(["--plain", "--latest", "list", "-f", "json"], env=workspace["env"], cwd=tmp_path)
+    assert list_result.exit_code == 0, list_result.output
+    conv_id = json.loads(list_result.stdout)[0]["id"]
+
+    db_path = workspace["paths"]["db_path"]
+    cwd_path = "/realm/project/polylogue"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            INSERT OR REPLACE INTO session_profiles (
+                conversation_id,
+                materialized_at,
+                provider_name,
+                title,
+                repo_names_json,
+                evidence_payload_json,
+                search_text
+            ) VALUES (?, '2026-01-01T00:00:00Z', 'claude-code', ?, json(?), json(?), ?)
+            """,
+            (
+                conv_id,
+                "Completion Insights",
+                json.dumps(["polylogue"]),
+                json.dumps({"cwd_paths": [cwd_path]}),
+                "Completion Insights polylogue",
+            ),
+        )
+        conn.commit()
+
+    repo_records = _run_completion(workspace, cwd=tmp_path, words="polylogue --repo po", cword=2)
+    repo_csv_records = _run_completion(workspace, cwd=tmp_path, words="polylogue --repo old,po", cword=2)
+    cwd_records = _run_completion(workspace, cwd=tmp_path, words="polylogue --cwd-prefix /realm/project/p", cword=2)
+    messages_records = _run_completion(workspace, cwd=tmp_path, words="polylogue messages conv", cword=2)
+    raw_records = _run_completion(workspace, cwd=tmp_path, words="polylogue raw conv", cword=2)
+
+    repo = next(record for record in repo_records if record["value"] == "polylogue")
+    repo_csv = next(record for record in repo_csv_records if record["value"] == "old,polylogue")
+    cwd = next(record for record in cwd_records if record["value"] == cwd_path)
+    assert repo["help"] == "1 sessions"
+    assert repo_csv["help"] == "1 sessions"
+    assert cwd["help"] == "1 sessions"
+    assert any(record["value"] == conv_id for record in messages_records)
+    assert any(record["value"] == conv_id for record in raw_records)
+
+
 def test_cli_completion_provider_values_keep_csv_prefix_and_descriptions(tmp_path: Path) -> None:
     workspace = setup_isolated_workspace(tmp_path)
 

--- a/tests/unit/cli/__snapshots__/test_terminal_snapshots.ambr
+++ b/tests/unit/cli/__snapshots__/test_terminal_snapshots.ambr
@@ -178,9 +178,9 @@
     --min-messages INTEGER          Minimum message count
     --max-messages INTEGER          Maximum message count
     --min-words INTEGER             Minimum total word count
-    --message-type [summary|tool_use|tool_result|thinking]
-                                    Filter by message content type (summary,
-                                    tool_use, tool_result, thinking)
+    --message-type [message|summary|tool_use|tool_result|thinking]
+                                    Filter by message content type (message,
+                                    summary, tool_use, tool_result, thinking)
     --since-session TEXT            Show sessions in same cwd after this
                                     conversation ID
     --since TEXT                    After date (ISO, 'yesterday', 'last week')
@@ -354,11 +354,12 @@
     --min-messages INTEGER          Minimum message count
     --max-messages INTEGER          Maximum message count
     --min-words INTEGER             Minimum total word count
-    --message-type [summary|tool_use|tool_result|thinking]
+    --message-type [message|summary|tool_use|tool_result|think
+  ing]
                                     Filter by message content
-  type (summary,
-                                    tool_use, tool_result, thi
-  nking)
+  type (message,
+                                    summary, tool_use, tool_re
+  sult, thinking)
     --since-session TEXT            Show sessions in same cwd
   after this
                                     conversation ID
@@ -535,9 +536,9 @@
     --min-messages INTEGER          Minimum message count
     --max-messages INTEGER          Maximum message count
     --min-words INTEGER             Minimum total word count
-    --message-type [summary|tool_use|tool_result|thinking]
-                                    Filter by message content type (summary,
-                                    tool_use, tool_result, thinking)
+    --message-type [message|summary|tool_use|tool_result|thinking]
+                                    Filter by message content type (message,
+                                    summary, tool_use, tool_result, thinking)
     --since-session TEXT            Show sessions in same cwd after this
                                     conversation ID
     --since TEXT                    After date (ISO, 'yesterday', 'last week')

--- a/tests/unit/core/test_query_fields.py
+++ b/tests/unit/core/test_query_fields.py
@@ -134,6 +134,22 @@ def test_query_field_catalog_marks_storage_stats_join_fields() -> None:
     assert _needs_stats_join() is False
 
 
+def test_query_field_catalog_marks_completion_sources() -> None:
+    descriptors = {descriptor.name: descriptor for descriptor in QUERY_FIELD_DESCRIPTORS}
+
+    assert descriptors["conversation_id"].completion_source == "conversation_id"
+    assert descriptors["since_session_id"].completion_source == "conversation_id"
+    assert descriptors["providers"].completion_source == "provider"
+    assert descriptors["excluded_providers"].completion_source == "provider"
+    assert descriptors["repo_names"].completion_source == "repo"
+    assert descriptors["cwd_prefix"].completion_source == "cwd_prefix"
+    assert descriptors["tags"].completion_source == "tag"
+    assert descriptors["excluded_tags"].completion_source == "tag"
+    assert descriptors["tool_terms"].completion_source == "tool"
+    assert descriptors["excluded_tool_terms"].completion_source == "tool"
+    assert descriptors["message_type"].completion_source == "message_type"
+
+
 def test_query_spec_normalizers_cover_scalar_iterable_and_error_paths() -> None:
     assert split_csv(None) == ()
     assert split_csv("file_read, shell") == ("file_read", "shell")


### PR DESCRIPTION
## Summary

Adds the first descriptor-backed completion slice for #621. Repo and cwd-prefix completions now come from session insight data instead of ad-hoc or missing sources, and read verbs complete conversation IDs.

## Problem

#621 calls for completion and fuzzy UX to become part of the query descriptor contract. The current CLI had concrete drift: `--repo` reused tag completion, `--cwd-prefix` had no archive-backed completion, and `messages <id>` / `raw <id>` did not reuse the conversation ID completer.

## Solution

- Added `completion_source` and `completion_label` metadata to key `QueryFieldDescriptor` entries.
- Added session-profile-backed `complete_repo_values()` from `repo_names_json` and `complete_cwd_prefix_values()` from evidence `cwd_paths`.
- Rewired `--repo` and `--cwd-prefix` to those sources.
- Reused conversation ID completion for `messages <id>` and `raw <id>`.
- Aligned `messages --message-type` choices with the root query filter by deriving from `MessageType`.
- Updated terminal help snapshots for the visible message-type choice change.
- Regenerated the verification catalog after the query verb line-number shift.

This intentionally leaves full descriptor-generated CLI/MCP/API/docs parity and fuzzy selection in #621.

## Verification

- `pytest -q tests/integration/test_cli_query_mode.py::test_cli_completion_id_offers_recent_conversation_ids_with_titles tests/integration/test_cli_query_mode.py::test_cli_completion_open_target_offers_recent_conversation_ids tests/integration/test_cli_query_mode.py::test_cli_completion_repo_cwd_and_read_ids_are_archive_backed tests/integration/test_cli_query_mode.py::test_cli_completion_tag_and_tool_values_are_archive_backed tests/integration/test_cli_query_mode.py::test_cli_completion_provider_values_keep_csv_prefix_and_descriptions tests/unit/core/test_query_fields.py tests/unit/core/test_message_types.py` → 12 passed
- `pytest -q tests/unit/cli/test_terminal_snapshots.py --snapshot-update` → 10 passed
- `pytest -q tests/unit/cli tests/unit/proof/test_evidence_runners.py` → 865 passed
- `ruff check polylogue/cli/shell_completion_values.py polylogue/cli/click_option_groups.py polylogue/cli/query_verbs.py polylogue/archive/query/fields.py tests/integration/test_cli_query_mode.py tests/unit/core/test_query_fields.py` → all checks passed
- `mypy polylogue/cli/shell_completion_values.py polylogue/cli/click_option_groups.py polylogue/cli/query_verbs.py polylogue/archive/query/fields.py` → success
- `devtools render-cli-reference --check` → sync OK
- `devtools render-all --check` → sync OK
- `devtools verify --quick` → all checks passed
- pre-push `devtools verify --quick` → all checks passed

Ref #621