### PR TITLE
fix(cli): route completions through query sources

### DIFF
--- a/docs/verification-catalog.md
+++ b/docs/verification-catalog.md
@@ -61,11 +61,11 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | --- | --- |
 | `polylogue` | `polylogue/cli/click_app.py:50` `polylogue.cli.click_app.cli` |
 | `polylogue auth` | `polylogue/cli/commands/auth.py:16` `polylogue.cli.commands.auth.auth_command` |
-| `polylogue bulk-export` | `polylogue/cli/query_verbs.py:110` `polylogue.cli.query_verbs.bulk_export_verb` |
+| `polylogue bulk-export` | `polylogue/cli/query_verbs.py:112` `polylogue.cli.query_verbs.bulk_export_verb` |
 | `polylogue completions` | `polylogue/cli/commands/completions.py:9` `polylogue.cli.commands.completions.completions_command` |
-| `polylogue count` | `polylogue/cli/query_verbs.py:46` `polylogue.cli.query_verbs.count_verb` |
+| `polylogue count` | `polylogue/cli/query_verbs.py:48` `polylogue.cli.query_verbs.count_verb` |
 | `polylogue dashboard` | `polylogue/cli/commands/dashboard.py:10` `polylogue.cli.commands.dashboard.dashboard_command` |
-| `polylogue delete` | `polylogue/cli/query_verbs.py:138` `polylogue.cli.query_verbs.delete_verb` |
+| `polylogue delete` | `polylogue/cli/query_verbs.py:140` `polylogue.cli.query_verbs.delete_verb` |
 | `polylogue diagnostics` | `polylogue/cli/commands/diagnostics.py:15` `polylogue.cli.commands.diagnostics.diagnostics_group` |
 | `polylogue diagnostics pace` | `polylogue/cli/commands/diagnostics.py:20` `polylogue.cli.commands.diagnostics.pace_command` |
 | `polylogue diagnostics tools` | `polylogue/cli/commands/diagnostics.py:139` `polylogue.cli.commands.diagnostics.tools_command` |
@@ -87,11 +87,11 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | `polylogue insights threads` | `polylogue/cli/commands/insights.py:100` `polylogue.cli.commands.insights._make_callback.<locals>.callback` |
 | `polylogue insights week-summaries` | `polylogue/cli/commands/insights.py:100` `polylogue.cli.commands.insights._make_callback.<locals>.callback` |
 | `polylogue insights work-events` | `polylogue/cli/commands/insights.py:100` `polylogue.cli.commands.insights._make_callback.<locals>.callback` |
-| `polylogue list` | `polylogue/cli/query_verbs.py:23` `polylogue.cli.query_verbs.list_verb` |
-| `polylogue messages` | `polylogue/cli/query_verbs.py:180` `polylogue.cli.query_verbs.messages_verb` |
+| `polylogue list` | `polylogue/cli/query_verbs.py:25` `polylogue.cli.query_verbs.list_verb` |
+| `polylogue messages` | `polylogue/cli/query_verbs.py:182` `polylogue.cli.query_verbs.messages_verb` |
 | `polylogue neighbors` | `polylogue/cli/commands/neighbors.py:42` `polylogue.cli.commands.neighbors.neighbors_command` |
-| `polylogue open` | `polylogue/cli/query_verbs.py:95` `polylogue.cli.query_verbs.open_verb` |
-| `polylogue raw` | `polylogue/cli/query_verbs.py:244` `polylogue.cli.query_verbs.raw_verb` |
+| `polylogue open` | `polylogue/cli/query_verbs.py:97` `polylogue.cli.query_verbs.open_verb` |
+| `polylogue raw` | `polylogue/cli/query_verbs.py:247` `polylogue.cli.query_verbs.raw_verb` |
 | `polylogue reset` | `polylogue/cli/commands/reset.py:23` `polylogue.cli.commands.reset.reset_command` |
 | `polylogue resume` | `polylogue/cli/commands/resume.py:22` `polylogue.cli.commands.resume.resume_command` |
 | `polylogue run` | `polylogue/cli/commands/run.py:178` `polylogue.cli.commands.run.run_command` |
@@ -110,8 +110,8 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | `polylogue schema compare` | `polylogue/cli/commands/schema.py:56` `polylogue.cli.commands.schema.schema_compare` |
 | `polylogue schema explain` | `polylogue/cli/commands/schema.py:94` `polylogue.cli.commands.schema.schema_explain` |
 | `polylogue schema list` | `polylogue/cli/commands/schema.py:45` `polylogue.cli.commands.schema.schema_list` |
-| `polylogue show` | `polylogue/cli/query_verbs.py:81` `polylogue.cli.query_verbs.show_verb` |
-| `polylogue stats` | `polylogue/cli/query_verbs.py:53` `polylogue.cli.query_verbs.stats_verb` |
+| `polylogue show` | `polylogue/cli/query_verbs.py:83` `polylogue.cli.query_verbs.show_verb` |
+| `polylogue stats` | `polylogue/cli/query_verbs.py:55` `polylogue.cli.query_verbs.stats_verb` |
 | `polylogue tags` | `polylogue/cli/commands/tags.py:12` `polylogue.cli.commands.tags.tags_command` |
 
 ## Schema Annotation Subjects

--- a/polylogue/archive/query/fields.py
+++ b/polylogue/archive/query/fields.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, replace
 from datetime import datetime
-from typing import Protocol, TypeAlias, cast
+from typing import Literal, Protocol, TypeAlias, cast
 
 from polylogue.storage.query_models import ConversationRecordQuery
 from polylogue.types import Provider
@@ -16,7 +16,18 @@ StorageValue = Callable[[object], object]
 _ReplaceRecordQuery: Callable[..., ConversationRecordQuery] = replace
 SqlPushdownValue: TypeAlias = str | int | bool | list[str]
 SqlPushdownParams: TypeAlias = dict[str, SqlPushdownValue]
-CompletionSource: TypeAlias = str
+CompletionSource: TypeAlias = Literal[
+    "action",
+    "action_sequence",
+    "conversation_id",
+    "cwd_prefix",
+    "message_type",
+    "provider",
+    "repo",
+    "retrieval_lane",
+    "tag",
+    "tool",
+]
 
 
 class _ProviderScopedPlan(Protocol):
@@ -215,6 +226,8 @@ QUERY_FIELD_DESCRIPTORS: tuple[QueryFieldDescriptor, ...] = (
         spec_description=_label("retrieval"),
         plan_description=_label("retrieval"),
         selection_filter=False,
+        completion_source="retrieval_lane",
+        completion_label="retrieval lane",
     ),
     QueryFieldDescriptor(
         name="referenced_path",
@@ -257,6 +270,8 @@ QUERY_FIELD_DESCRIPTORS: tuple[QueryFieldDescriptor, ...] = (
         requires_content_loading=True,
         blocks_sql_count=True,
         blocks_simple_message_hit=True,
+        completion_source="action",
+        completion_label="action",
     ),
     QueryFieldDescriptor(
         name="excluded_action_terms",
@@ -271,6 +286,8 @@ QUERY_FIELD_DESCRIPTORS: tuple[QueryFieldDescriptor, ...] = (
         requires_content_loading=True,
         blocks_sql_count=True,
         blocks_simple_message_hit=True,
+        completion_source="action",
+        completion_label="action",
     ),
     QueryFieldDescriptor(
         name="action_sequence",
@@ -285,6 +302,8 @@ QUERY_FIELD_DESCRIPTORS: tuple[QueryFieldDescriptor, ...] = (
         blocks_sql_count=True,
         blocks_action_event_stats=True,
         blocks_simple_message_hit=True,
+        completion_source="action_sequence",
+        completion_label="action sequence",
     ),
     QueryFieldDescriptor(
         name="action_text_terms",
@@ -750,7 +769,20 @@ def storage_filters_require_stats_join(filters: Mapping[str, object]) -> bool:
     return False
 
 
+def query_completion_sources() -> tuple[CompletionSource, ...]:
+    return tuple(
+        sorted(
+            {
+                descriptor.completion_source
+                for descriptor in QUERY_FIELD_DESCRIPTORS
+                if descriptor.completion_source is not None
+            }
+        )
+    )
+
+
 __all__ = [
+    "CompletionSource",
     "QUERY_FIELD_DESCRIPTORS",
     "QueryFieldDescriptor",
     "SqlPushdownParams",
@@ -762,6 +794,7 @@ __all__ = [
     "has_message_content_type_filter",
     "plan_has_fields_matching",
     "plan_has_selection_filters",
+    "query_completion_sources",
     "query_spec_has_selection_filters",
     "sql_pushdown_params_for_plan",
     "storage_filters_require_stats_join",

--- a/polylogue/cli/click_option_groups.py
+++ b/polylogue/cli/click_option_groups.py
@@ -10,28 +10,23 @@ import click
 from polylogue.archive.message.types import MessageType
 from polylogue.archive.query.spec import QUERY_ACTION_TYPES, QUERY_RETRIEVAL_LANES
 from polylogue.cli.query_contracts import normalize_message_role_option
-from polylogue.cli.shell_completion_values import (
-    complete_conversation_ids,
-    complete_cwd_prefix_values,
-    complete_provider_values,
-    complete_repo_values,
-    complete_tag_values,
-    complete_tool_values,
-)
+from polylogue.cli.shell_completion_values import complete_query_source
 from polylogue.core.provider_identity import CORE_SCHEMA_PROVIDERS
 
 ClickCallable: TypeAlias = Callable[..., object]
 
 # Providers the user can filter by (excludes "unknown" and "drive" which are internal).
 _CLI_PROVIDER_CHOICES: tuple[str, ...] = CORE_SCHEMA_PROVIDERS
-
-
-def _complete_providers(
-    ctx: click.Context,
-    param: click.Parameter,
-    incomplete: str,
-) -> list[click.shell_completion.CompletionItem]:
-    return complete_provider_values(ctx, param, incomplete)
+_complete_action = complete_query_source("action")
+_complete_action_sequence = complete_query_source("action_sequence")
+_complete_conversation_id = complete_query_source("conversation_id")
+_complete_cwd_prefix = complete_query_source("cwd_prefix")
+_complete_message_type = complete_query_source("message_type")
+_complete_provider = complete_query_source("provider")
+_complete_repo = complete_query_source("repo")
+_complete_retrieval_lane = complete_query_source("retrieval_lane")
+_complete_tag = complete_query_source("tag")
+_complete_tool = complete_query_source("tool")
 
 
 def _validate_provider_tokens(
@@ -69,7 +64,7 @@ FILTER_OPTION_DECORATORS: tuple[Callable[[ClickCallable], ClickCallable], ...] =
         "-i",
         "conv_id",
         help="Conversation ID (exact or prefix match)",
-        shell_complete=complete_conversation_ids,
+        shell_complete=_complete_conversation_id,
     ),
     click.option("--contains", "-c", multiple=True, help="FTS term (repeatable = AND)"),
     click.option("--exclude-text", multiple=True, help="Exclude FTS term"),
@@ -77,30 +72,29 @@ FILTER_OPTION_DECORATORS: tuple[Callable[[ClickCallable], ClickCallable], ...] =
         "--retrieval-lane",
         type=click.Choice(QUERY_RETRIEVAL_LANES),
         help="Query lane: dialogue FTS, action text, or hybrid",
+        shell_complete=_complete_retrieval_lane,
     ),
     click.option(
         "--provider",
         "-p",
         help="Include providers (comma = OR)",
         callback=_validate_provider_tokens,
-        shell_complete=_complete_providers,
+        shell_complete=_complete_provider,
     ),
     click.option(
         "--exclude-provider",
         help="Exclude providers",
         callback=_validate_provider_tokens,
-        shell_complete=_complete_providers,
+        shell_complete=_complete_provider,
     ),
     click.option(
         "--repo",
         "-r",
         help="Filter by repository name (comma = OR)",
-        shell_complete=complete_repo_values,
+        shell_complete=_complete_repo,
     ),
-    click.option(
-        "--tag", "-t", help="Include tags (comma = OR, supports key:value)", shell_complete=complete_tag_values
-    ),
-    click.option("--exclude-tag", help="Exclude tags", shell_complete=complete_tag_values),
+    click.option("--tag", "-t", help="Include tags (comma = OR, supports key:value)", shell_complete=_complete_tag),
+    click.option("--exclude-tag", help="Exclude tags", shell_complete=_complete_tag),
     click.option("--title", help="Title contains"),
     click.option(
         "--referenced-path",
@@ -113,23 +107,26 @@ FILTER_OPTION_DECORATORS: tuple[Callable[[ClickCallable], ClickCallable], ...] =
         "cwd_prefix",
         default=None,
         help="Filter conversations whose recorded working directory starts with this prefix",
-        shell_complete=complete_cwd_prefix_values,
+        shell_complete=_complete_cwd_prefix,
     ),
     click.option(
         "--action",
         multiple=True,
         type=click.Choice(QUERY_ACTION_TYPES),
         help="Require semantic action category (repeatable = AND)",
+        shell_complete=_complete_action,
     ),
     click.option(
         "--exclude-action",
         multiple=True,
         type=click.Choice(QUERY_ACTION_TYPES),
         help="Exclude semantic action category (repeatable = AND)",
+        shell_complete=_complete_action,
     ),
     click.option(
         "--action-sequence",
         help="Require ordered semantic action subsequence (comma-separated)",
+        shell_complete=_complete_action_sequence,
     ),
     click.option(
         "--action-text",
@@ -140,13 +137,13 @@ FILTER_OPTION_DECORATORS: tuple[Callable[[ClickCallable], ClickCallable], ...] =
         "--tool",
         multiple=True,
         help="Require normalized tool name (repeatable = AND)",
-        shell_complete=complete_tool_values,
+        shell_complete=_complete_tool,
     ),
     click.option(
         "--exclude-tool",
         multiple=True,
         help="Exclude normalized tool name (repeatable = AND)",
-        shell_complete=complete_tool_values,
+        shell_complete=_complete_tool,
     ),
     click.option("--similar", "similar_text", help="Semantic similarity query (requires embeddings)"),
     click.option(
@@ -187,6 +184,7 @@ FILTER_OPTION_DECORATORS: tuple[Callable[[ClickCallable], ClickCallable], ...] =
         "message_type",
         type=click.Choice([message_type.value for message_type in MessageType]),
         help="Filter by message content type (message, summary, tool_use, tool_result, thinking)",
+        shell_complete=_complete_message_type,
     ),
     click.option(
         "--since-session",

--- a/polylogue/cli/query_verbs.py
+++ b/polylogue/cli/query_verbs.py
@@ -13,11 +13,13 @@ import click
 from polylogue.archive.message.types import MessageType
 from polylogue.cli.root_request import RootModeRequest
 from polylogue.cli.shared.types import AppEnv
-from polylogue.cli.shell_completion_values import complete_conversation_ids, complete_open_targets
+from polylogue.cli.shell_completion_values import complete_open_targets, complete_query_source
 
 VERB_NAMES = frozenset({"list", "count", "stats", "open", "show", "bulk-export", "delete", "messages", "raw"})
 
 _BULK_EXPORT_FORMATS = ("jsonl", "json", "markdown", "yaml", "plaintext", "html", "obsidian", "org")
+_complete_conversation_id = complete_query_source("conversation_id")
+_complete_message_type = complete_query_source("message_type")
 
 
 @click.command("list")
@@ -178,12 +180,13 @@ def _execute_query_verb(
 
 
 @click.command("messages")
-@click.argument("conversation_id", required=False, shell_complete=complete_conversation_ids)
+@click.argument("conversation_id", required=False, shell_complete=_complete_conversation_id)
 @click.option("--message-role", "-r", "message_role", multiple=True, help="Filter by message role")
 @click.option(
     "--message-type",
     "message_type",
     type=click.Choice([message_type.value for message_type in MessageType]),
+    shell_complete=_complete_message_type,
     help="Filter by message content type",
 )
 @click.option("--limit", "-n", type=int, default=50, help="Max messages to return")
@@ -242,7 +245,7 @@ def messages_verb(
 
 
 @click.command("raw")
-@click.argument("conversation_id", required=False, shell_complete=complete_conversation_ids)
+@click.argument("conversation_id", required=False, shell_complete=_complete_conversation_id)
 @click.option("--limit", "-n", type=int, default=50, help="Max raw artifacts to return")
 @click.option("--offset", type=int, default=0, help="Offset for pagination")
 @click.option(

--- a/polylogue/cli/shell_completion_values.py
+++ b/polylogue/cli/shell_completion_values.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import sqlite3
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from typing import Final
 
 import click
 from click.shell_completion import CompletionItem
 
+from polylogue.archive.message.types import MessageType
+from polylogue.archive.query.fields import CompletionSource
+from polylogue.archive.query.spec import QUERY_ACTION_TYPES, QUERY_RETRIEVAL_LANES, QUERY_SEQUENCE_ACTION_TYPES
 from polylogue.paths import db_path
 from polylogue.storage.backends.connection import open_read_connection
 
@@ -23,6 +26,7 @@ _PROVIDER_DESCRIPTIONS: Final[dict[str, str]] = {
 _MAX_ID_COMPLETIONS = 24
 _MAX_VALUE_COMPLETIONS = 32
 CompletionHelpBuilder = Callable[[sqlite3.Row], str]
+CompletionCallback = Callable[[click.Context, click.Parameter, str], list[CompletionItem]]
 
 
 def _split_csv_incomplete(incomplete: str) -> tuple[str, str]:
@@ -77,6 +81,18 @@ def _trim_help(value: str, *, limit: int = 72) -> str:
     return cleaned[: limit - 1] + "…"
 
 
+def _static_completion_items(
+    values: tuple[str, ...],
+    incomplete: str,
+    *,
+    csv: bool = False,
+) -> list[CompletionItem]:
+    prefix, current = _split_csv_incomplete(incomplete) if csv else ("", incomplete.strip())
+    current_lower = current.lower()
+    items = [CompletionItem(value) for value in values if not current_lower or value.lower().startswith(current_lower)]
+    return _with_csv_prefix(items, prefix) if csv else items
+
+
 def complete_provider_values(
     ctx: click.Context,
     param: click.Parameter,
@@ -91,6 +107,42 @@ def complete_provider_values(
         if not current_lower or name.startswith(current_lower)
     ]
     return _with_csv_prefix(items, prefix)
+
+
+def complete_action_values(
+    ctx: click.Context,
+    param: click.Parameter,
+    incomplete: str,
+) -> list[CompletionItem]:
+    del ctx, param
+    return _static_completion_items(QUERY_ACTION_TYPES, incomplete)
+
+
+def complete_action_sequence_values(
+    ctx: click.Context,
+    param: click.Parameter,
+    incomplete: str,
+) -> list[CompletionItem]:
+    del ctx, param
+    return _static_completion_items(QUERY_SEQUENCE_ACTION_TYPES, incomplete, csv=True)
+
+
+def complete_message_type_values(
+    ctx: click.Context,
+    param: click.Parameter,
+    incomplete: str,
+) -> list[CompletionItem]:
+    del ctx, param
+    return _static_completion_items(tuple(message_type.value for message_type in MessageType), incomplete)
+
+
+def complete_retrieval_lane_values(
+    ctx: click.Context,
+    param: click.Parameter,
+    incomplete: str,
+) -> list[CompletionItem]:
+    del ctx, param
+    return _static_completion_items(QUERY_RETRIEVAL_LANES, incomplete)
 
 
 def complete_conversation_ids(
@@ -278,12 +330,36 @@ def complete_tool_values(
     )
 
 
+COMPLETION_SOURCE_HANDLERS: Final[Mapping[CompletionSource, CompletionCallback]] = {
+    "action": complete_action_values,
+    "action_sequence": complete_action_sequence_values,
+    "conversation_id": complete_conversation_ids,
+    "cwd_prefix": complete_cwd_prefix_values,
+    "message_type": complete_message_type_values,
+    "provider": complete_provider_values,
+    "repo": complete_repo_values,
+    "retrieval_lane": complete_retrieval_lane_values,
+    "tag": complete_tag_values,
+    "tool": complete_tool_values,
+}
+
+
+def complete_query_source(source: CompletionSource) -> CompletionCallback:
+    return COMPLETION_SOURCE_HANDLERS[source]
+
+
 __all__ = [
+    "COMPLETION_SOURCE_HANDLERS",
+    "complete_action_sequence_values",
+    "complete_action_values",
     "complete_conversation_ids",
     "complete_cwd_prefix_values",
+    "complete_message_type_values",
     "complete_open_targets",
     "complete_provider_values",
+    "complete_query_source",
     "complete_repo_values",
+    "complete_retrieval_lane_values",
     "complete_tag_values",
     "complete_tool_values",
 ]

--- a/tests/unit/cli/test_command_aux_runtime.py
+++ b/tests/unit/cli/test_command_aux_runtime.py
@@ -192,6 +192,10 @@ def test_completion_functions_cover_provider_conversation_tag_tool_and_open_targ
 
     provider_items = shell_completion_values.complete_provider_values(ctx, param, "chatgpt,cla")
     assert [item.value for item in provider_items] == ["chatgpt,claude-ai", "chatgpt,claude-code"]
+    action_items = shell_completion_values.complete_action_values(ctx, param, "file")
+    action_sequence_items = shell_completion_values.complete_action_sequence_values(ctx, param, "shell,file")
+    message_type_items = shell_completion_values.complete_message_type_values(ctx, param, "m")
+    retrieval_lane_items = shell_completion_values.complete_retrieval_lane_values(ctx, param, "h")
 
     conversation_rows = [
         {
@@ -201,24 +205,45 @@ def test_completion_functions_cover_provider_conversation_tag_tool_and_open_targ
         }
     ]
     tag_rows = [{"tag_name": "review", "cnt": 3}]
+    repo_rows = [{"repo_name": "polylogue", "cnt": 4}]
+    cwd_rows = [{"cwd_path": "/realm/project/polylogue", "cnt": 2}]
     tool_rows = [{"normalized_tool_name": "read_file", "cnt": 7}]
 
     with patch(
         "polylogue.cli.shell_completion_values._fetch_rows",
-        side_effect=[conversation_rows, conversation_rows, tag_rows, tool_rows],
+        side_effect=[conversation_rows, conversation_rows, tag_rows, repo_rows, cwd_rows, tool_rows],
     ):
         conversation_items = shell_completion_values.complete_conversation_ids(ctx, param, "conv")
         open_items = shell_completion_values.complete_open_targets(ctx, param, "conv")
         tag_items = shell_completion_values.complete_tag_values(ctx, param, "alpha,rev")
+        repo_items = shell_completion_values.complete_repo_values(ctx, param, "old,poly")
+        cwd_items = shell_completion_values.complete_cwd_prefix_values(ctx, param, "/realm")
         tool_items = shell_completion_values.complete_tool_values(ctx, param, "read")
 
+    assert [item.value for item in action_items] == ["file_read", "file_write", "file_edit"]
+    assert "shell,file_read" in [item.value for item in action_sequence_items]
+    assert [item.value for item in message_type_items] == ["message"]
+    assert [item.value for item in retrieval_lane_items] == ["hybrid"]
     assert conversation_items[0].value == "conv-1"
     assert conversation_items[0].help is not None and "claude-code" in conversation_items[0].help
     assert open_items[0].value == "conv-1"
     assert [item.value for item in tag_items] == ["alpha,review"]
     assert tag_items[0].help == "3 conversations"
+    assert [item.value for item in repo_items] == ["old,polylogue"]
+    assert repo_items[0].help == "4 sessions"
+    assert [item.value for item in cwd_items] == ["/realm/project/polylogue"]
+    assert cwd_items[0].help == "2 sessions"
     assert [item.value for item in tool_items] == ["read_file"]
     assert tool_items[0].help == "7 actions"
+
+
+def test_completion_source_registry_covers_descriptor_sources() -> None:
+    from polylogue.archive.query.fields import query_completion_sources
+
+    assert tuple(shell_completion_values.COMPLETION_SOURCE_HANDLERS) == query_completion_sources()
+    assert shell_completion_values.complete_query_source("message_type") is (
+        shell_completion_values.complete_message_type_values
+    )
 
 
 @pytest.fixture

--- a/tests/unit/core/test_query_fields.py
+++ b/tests/unit/core/test_query_fields.py
@@ -9,6 +9,7 @@ import pytest
 from polylogue.archive.query.fields import (
     QUERY_FIELD_DESCRIPTORS,
     active_plan_field_names,
+    query_completion_sources,
     storage_filters_require_stats_join,
 )
 from polylogue.archive.query.plan import ConversationQueryPlan
@@ -139,6 +140,11 @@ def test_query_field_catalog_marks_completion_sources() -> None:
 
     assert descriptors["conversation_id"].completion_source == "conversation_id"
     assert descriptors["since_session_id"].completion_source == "conversation_id"
+    assert descriptors["retrieval_lane"].completion_source == "retrieval_lane"
+    assert descriptors["referenced_path"].completion_source is None
+    assert descriptors["action_terms"].completion_source == "action"
+    assert descriptors["excluded_action_terms"].completion_source == "action"
+    assert descriptors["action_sequence"].completion_source == "action_sequence"
     assert descriptors["providers"].completion_source == "provider"
     assert descriptors["excluded_providers"].completion_source == "provider"
     assert descriptors["repo_names"].completion_source == "repo"
@@ -148,6 +154,18 @@ def test_query_field_catalog_marks_completion_sources() -> None:
     assert descriptors["tool_terms"].completion_source == "tool"
     assert descriptors["excluded_tool_terms"].completion_source == "tool"
     assert descriptors["message_type"].completion_source == "message_type"
+    assert query_completion_sources() == (
+        "action",
+        "action_sequence",
+        "conversation_id",
+        "cwd_prefix",
+        "message_type",
+        "provider",
+        "repo",
+        "retrieval_lane",
+        "tag",
+        "tool",
+    )
 
 
 def test_query_spec_normalizers_cover_scalar_iterable_and_error_paths() -> None:


### PR DESCRIPTION
## Summary

Turns #621 completion metadata into a real CLI completion-source registry. Query options now ask for completion by descriptor source ID, and static query values such as action categories, action sequences, message types, and retrieval lanes complete through the same path.

## Problem

#693 added completion metadata and fixed the most visible repo/cwd completion drift, but CLI wiring still imported individual helper functions directly. That left descriptor completion sources as passive metadata and left static query choices outside the same contract.

## Solution

- Narrowed `CompletionSource` to a typed descriptor value.
- Added `query_completion_sources()` so tests can compare descriptor-declared sources against the CLI registry.
- Added `COMPLETION_SOURCE_HANDLERS` and `complete_query_source(...)` in the CLI completion module.
- Routed root query options and `messages`/`raw` read verb completions through completion source IDs.
- Added static completion handlers for action categories, action sequences, message types, and retrieval lanes.
- Regenerated the verification catalog after query verb line-number shifts.

This still leaves full descriptor-generated CLI/MCP/API/docs parity and fuzzy selection in #621.

## Verification

- `pytest -q tests/integration/test_cli_query_mode.py::test_cli_completion_repo_cwd_and_read_ids_are_archive_backed tests/integration/test_cli_query_mode.py::test_cli_completion_provider_values_keep_csv_prefix_and_descriptions tests/unit/cli/test_command_aux_runtime.py::test_completion_functions_cover_provider_conversation_tag_tool_and_open_targets tests/unit/cli/test_command_aux_runtime.py::test_completion_source_registry_covers_descriptor_sources tests/unit/core/test_query_fields.py` → 9 passed
- `pytest -q tests/unit/cli tests/unit/proof/test_evidence_runners.py` → 866 passed
- `ruff check polylogue/archive/query/fields.py polylogue/cli/shell_completion_values.py polylogue/cli/click_option_groups.py polylogue/cli/query_verbs.py tests/unit/core/test_query_fields.py tests/unit/cli/test_command_aux_runtime.py` → all checks passed
- `mypy polylogue/archive/query/fields.py polylogue/cli/shell_completion_values.py polylogue/cli/click_option_groups.py polylogue/cli/query_verbs.py` → success
- `devtools render-all --check` → sync OK
- `devtools verify --quick` → all checks passed
- pre-push `devtools verify --quick` → all checks passed

Ref #621