### PR TITLE
fix(query): cover public spec modifiers in descriptors

### DIFF
--- a/polylogue/archive/query/fields.py
+++ b/polylogue/archive/query/fields.py
@@ -46,8 +46,16 @@ def _is_true(value: object) -> bool:
     return value is True
 
 
+def _positive_int(value: object) -> bool:
+    return isinstance(value, int) and value > 0
+
+
 def _not_auto(value: object) -> bool:
     return value != "auto"
+
+
+def _not_date_sort(value: object) -> bool:
+    return value is not None and value != "date"
 
 
 def _as_tuple(value: object) -> tuple[object, ...]:
@@ -583,6 +591,38 @@ QUERY_FIELD_DESCRIPTORS: tuple[QueryFieldDescriptor, ...] = (
         selection_filter=True,
     ),
     QueryFieldDescriptor(
+        name="sort",
+        spec_attr="sort",
+        plan_attr="sort",
+        spec_active=_not_none,
+        plan_active=_not_date_sort,
+        spec_description=_label("sort"),
+        plan_description=_label("sort"),
+        selection_filter=False,
+        blocks_simple_message_hit=True,
+    ),
+    QueryFieldDescriptor(
+        name="reverse",
+        spec_attr="reverse",
+        plan_attr="reverse",
+        spec_active=_is_true,
+        plan_active=_is_true,
+        spec_description=_literal("reverse"),
+        plan_description=_literal("reverse"),
+        selection_filter=False,
+        blocks_simple_message_hit=True,
+    ),
+    QueryFieldDescriptor(
+        name="limit",
+        spec_attr="limit",
+        plan_attr="limit",
+        spec_active=_not_none,
+        plan_active=_not_none,
+        spec_description=_label("limit"),
+        plan_description=_label("limit"),
+        selection_filter=False,
+    ),
+    QueryFieldDescriptor(
         name="parent_id",
         plan_attr="parent_id",
         plan_active=_not_none,
@@ -638,23 +678,35 @@ QUERY_FIELD_DESCRIPTORS: tuple[QueryFieldDescriptor, ...] = (
     ),
     QueryFieldDescriptor(
         name="sample",
+        spec_attr="sample",
         plan_attr="sample",
         plan_active=_not_none,
+        spec_active=_not_none,
+        spec_description=_label("sample"),
+        plan_description=_label("sample"),
         selection_filter=False,
         blocks_simple_message_hit=True,
     ),
     QueryFieldDescriptor(
         name="offset",
+        spec_attr="offset",
         plan_attr="offset",
-        plan_active=lambda v: int(cast(int, v)) > 0,
+        spec_active=_positive_int,
+        plan_active=_positive_int,
+        spec_description=_label("offset"),
+        plan_description=_label("offset"),
         record_attr="offset",
         storage_value=lambda v: int(cast(int, v)) if v else 0,
         selection_filter=False,
     ),
     QueryFieldDescriptor(
         name="since_session_id",
+        spec_attr="since_session_id",
         plan_attr="since_session_id",
+        spec_active=_not_none,
         plan_active=_not_none,
+        spec_description=_label("since-session"),
+        plan_description=_label("since-session"),
         record_attr="since_session_id",
         storage_value=lambda v: str(v) if v else None,
         selection_filter=True,

--- a/tests/unit/core/test_query_fields.py
+++ b/tests/unit/core/test_query_fields.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import fields
 from datetime import datetime, timezone
 
 import pytest
@@ -37,6 +38,8 @@ def test_query_field_catalog_drives_spec_presence_and_descriptions() -> None:
         filter_has_tool_use=True,
         min_messages=3,
         since="2024-01-01",
+        since_session_id="conv-anchor",
+        offset=10,
     )
 
     assert spec.has_filters() is True
@@ -48,6 +51,8 @@ def test_query_field_catalog_drives_spec_presence_and_descriptions() -> None:
         "has: tool_use (sql)",
         "min_messages: 3",
         "since: 2024-01-01",
+        "offset: 10",
+        "since-session: conv-anchor",
     ]
 
 
@@ -63,6 +68,8 @@ def test_query_field_catalog_drives_plan_presence_descriptions_and_pushdown() ->
         since=since,
         filter_has_tool_use=True,
         min_messages=3,
+        since_session_id="conv-anchor",
+        offset=10,
     )
 
     assert active_plan_field_names(plan) == (
@@ -75,6 +82,8 @@ def test_query_field_catalog_drives_plan_presence_descriptions_and_pushdown() ->
         "filter_has_tool_use",
         "min_messages",
         "since",
+        "offset",
+        "since_session_id",
     )
     assert plan.has_filters() is True
     assert plan.describe() == [
@@ -87,6 +96,8 @@ def test_query_field_catalog_drives_plan_presence_descriptions_and_pushdown() ->
         "has_tool_use",
         "min_messages: 3",
         "since: 2024-01-01T00:00:00+00:00",
+        "offset: 10",
+        "since-session: conv-anchor",
     ]
 
     assert plan.sql_pushdown_params() == {
@@ -114,6 +125,15 @@ def test_query_field_catalog_drives_plan_presence_descriptions_and_pushdown() ->
     assert record_query.has_tool_use is True
     assert record_query.min_messages == 3
     assert record_query.since == "2024-01-01T00:00:00+00:00"
+    assert record_query.offset == 10
+    assert record_query.since_session_id == "conv-anchor"
+
+
+def test_query_field_catalog_covers_public_spec_fields() -> None:
+    descriptor_spec_attrs = {descriptor.spec_attr for descriptor in QUERY_FIELD_DESCRIPTORS if descriptor.spec_attr}
+    spec_fields = {field.name for field in fields(ConversationQuerySpec)}
+
+    assert spec_fields - descriptor_spec_attrs == set()
 
 
 def test_query_field_catalog_marks_storage_stats_join_fields() -> None:


### PR DESCRIPTION
## Summary

Adds descriptor coverage for the remaining public `ConversationQuerySpec` execution modifiers so #621 can distinguish intentional non-selection behavior from missing descriptor mapping.

## Problem

The query descriptor table covered most archive filters, but several real public spec fields were still plan-only or uncovered: `sort`, `reverse`, `limit`, `sample`, `offset`, and `since_session_id`. That meant descriptor parity tests could not enforce that public query fields are deliberately modeled.

## Solution

- Added descriptor coverage for `sort`, `reverse`, `limit`, `sample`, `offset`, and `since_session_id`.
- Classified `sort`, `reverse`, `limit`, `sample`, and `offset` as execution modifiers / non-selection filters.
- Kept `since_session_id` as a true selection filter.
- Added a test that every `ConversationQuerySpec` dataclass field is descriptor-covered.
- Extended descriptor description tests for `offset` and `since_session_id`.

This leaves cross-surface CLI/MCP/API name parity and read/output descriptors in #621.

## Verification

- `pytest -q tests/unit/core/test_query_fields.py` → 6 passed
- `pytest -q tests/unit/cli/test_click_app.py tests/unit/cli/test_query_exec.py tests/unit/cli/test_query_support_runtime.py tests/unit/core/test_query_fields.py` → 133 passed
- `ruff check polylogue/archive/query/fields.py tests/unit/core/test_query_fields.py` → all checks passed
- `mypy polylogue/archive/query/fields.py` → success
- `devtools render-all --check` → sync OK
- `devtools verify --quick` → all checks passed
- pre-push `devtools verify --quick` → all checks passed

Ref #621