### PR TITLE
fix(query): cover API facade names in descriptors

### DIFF
--- a/polylogue/archive/query/fields.py
+++ b/polylogue/archive/query/fields.py
@@ -159,6 +159,7 @@ class QueryFieldDescriptor:
     completion_source: CompletionSource | None = None
     completion_label: str | None = None
     mcp_names: tuple[str, ...] = ()
+    api_names: tuple[str, ...] = ()
 
     def spec_value(self, spec: object) -> object:
         if self.spec_attr is None:
@@ -209,6 +210,7 @@ QUERY_FIELD_DESCRIPTORS: tuple[QueryFieldDescriptor, ...] = (
         blocks_sql_count=True,
         blocks_action_event_stats=True,
         mcp_names=("query",),
+        api_names=("query",),
     ),
     QueryFieldDescriptor(
         name="contains_terms",
@@ -379,6 +381,7 @@ QUERY_FIELD_DESCRIPTORS: tuple[QueryFieldDescriptor, ...] = (
         completion_source="provider",
         completion_label="provider",
         mcp_names=("provider",),
+        api_names=("provider", "source"),
     ),
     QueryFieldDescriptor(
         name="excluded_providers",
@@ -579,6 +582,7 @@ QUERY_FIELD_DESCRIPTORS: tuple[QueryFieldDescriptor, ...] = (
         sql_param="since",
         storage_value=_iso_value,
         mcp_names=("since",),
+        api_names=("since",),
     ),
     QueryFieldDescriptor(
         name="until",
@@ -645,6 +649,7 @@ QUERY_FIELD_DESCRIPTORS: tuple[QueryFieldDescriptor, ...] = (
         plan_description=_label("limit"),
         selection_filter=False,
         mcp_names=("limit",),
+        api_names=("limit",),
     ),
     QueryFieldDescriptor(
         name="parent_id",
@@ -867,6 +872,13 @@ def mcp_query_field_names() -> frozenset[str]:
     return frozenset(names)
 
 
+def api_query_field_names() -> frozenset[str]:
+    names: set[str] = set()
+    for descriptor in QUERY_FIELD_DESCRIPTORS:
+        names.update(descriptor.api_names)
+    return frozenset(names)
+
+
 __all__ = [
     "CompletionSource",
     "QUERY_FIELD_DESCRIPTORS",
@@ -874,6 +886,7 @@ __all__ = [
     "SqlPushdownParams",
     "SqlPushdownValue",
     "active_plan_field_names",
+    "api_query_field_names",
     "conversation_record_query_for_plan",
     "describe_plan_fields",
     "describe_spec_fields",

--- a/tests/unit/core/test_query_fields.py
+++ b/tests/unit/core/test_query_fields.py
@@ -10,6 +10,7 @@ import pytest
 from polylogue.archive.query.fields import (
     QUERY_FIELD_DESCRIPTORS,
     active_plan_field_names,
+    api_query_field_names,
     mcp_query_field_names,
     query_completion_sources,
     storage_filters_require_stats_join,
@@ -143,6 +144,21 @@ def test_query_field_catalog_covers_mcp_query_request_fields() -> None:
     mcp_fields = {field.name for field in fields(MCPConversationQueryRequest)}
 
     assert mcp_fields - mcp_query_field_names() == set()
+
+
+def test_query_field_catalog_covers_api_query_method_names() -> None:
+    from inspect import signature
+
+    from polylogue.api.archive import PolylogueArchiveMixin
+    from polylogue.archive.query.read_fields import read_field_names_for_surface
+
+    covered = api_query_field_names() | read_field_names_for_surface("api")
+    method_names = ("search", "list_conversations")
+
+    for method_name in method_names:
+        params = set(signature(getattr(PolylogueArchiveMixin, method_name)).parameters)
+        params.discard("self")
+        assert params - covered == set()
 
 
 def test_query_field_catalog_marks_storage_stats_join_fields() -> None:

--- a/tests/unit/core/test_query_read_fields.py
+++ b/tests/unit/core/test_query_read_fields.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from inspect import signature
 
 import click
 
+from polylogue.api.archive import PolylogueArchiveMixin
 from polylogue.archive.query.read_fields import (
     READ_FIELD_DESCRIPTORS,
     read_field_descriptor_map,
@@ -78,3 +80,19 @@ def test_read_field_surface_name_sets_are_intentional() -> None:
     assert {"content_projection", "conversation_id", "limit", "offset", "group_by"}.issubset(
         read_field_names_for_surface("api")
     )
+
+
+def test_api_point_read_method_parameters_have_read_descriptors() -> None:
+    covered = read_field_names_for_surface("api")
+    method_names = (
+        "get_conversation",
+        "get_conversations",
+        "get_messages_paginated",
+        "get_raw_artifacts_for_conversation",
+        "resume_brief",
+    )
+
+    for method_name in method_names:
+        params = set(signature(getattr(PolylogueArchiveMixin, method_name)).parameters)
+        params.discard("self")
+        assert params - covered == set()


### PR DESCRIPTION
## Summary

Adds API-facing query-name ownership to the query descriptor registry and tests the public facade query/read signatures against the query/read descriptor catalogs.

## Problem

#621 is about making one descriptor vocabulary own the public query/read surface. MCP query names were already covered, but the Python facade still had implicit mappings like `search(source=...)` selecting providers without any descriptor-level ownership. That leaves API names outside the drift guard even though they are part of the public surface.

## Solution

- Added `api_names` to `QueryFieldDescriptor` and exposed `api_query_field_names()`.
- Recorded API names for the facade search/list query concepts: `query`, provider aliases `provider`/`source`, `since`, and query `limit`.
- Added tests that inspect `PolylogueArchiveMixin.search()` and `list_conversations()` and require every public parameter to be covered by query or read descriptors.
- Added tests that inspect point-read facade methods (`get_conversation`, `get_conversations`, `get_messages_paginated`, `get_raw_artifacts_for_conversation`, and `resume_brief`) and require every read parameter to be covered by read descriptors.

Ref #621

## Verification

- `pytest tests/unit/core/test_query_fields.py tests/unit/core/test_query_read_fields.py -q` → 12 passed.
- `ruff format --check polylogue/archive/query/fields.py tests/unit/core/test_query_fields.py tests/unit/core/test_query_read_fields.py` → 3 files already formatted.
- `ruff check polylogue/archive/query/fields.py tests/unit/core/test_query_fields.py tests/unit/core/test_query_read_fields.py` → all checks passed.
- `devtools verify --quick` → all checks passed.
- Pre-push `devtools verify --quick` → all checks passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added validation tests ensuring comprehensive API parameter coverage for query methods

<!-- end of auto-generated comment: release notes by coderabbit.ai -->