### PR TITLE
fix(verification): enforce coverage gap lifecycle

### DIFF
--- a/devtools/verify_manifests.py
+++ b/devtools/verify_manifests.py
@@ -15,19 +15,9 @@ import yaml
 
 from devtools.command_catalog import COMMANDS
 
-_REPO_ROOT = Path(__file__).resolve().parents[1]
 _COVERAGE_AXIS_KEYS = ("domain", "subject", "area", "dimension", "artifact", "platform", "concern")
 _COVERAGE_GAP_SEVERITIES = {"info", "minor", "major", "serious"}
-_EVIDENCE_COMMAND_PREFIXES = (
-    "devtools ",
-    "pytest ",
-    "ruff ",
-    "mypy ",
-    "nix ",
-    "polylogue ",
-    "polylogued ",
-    "polylogue-mcp ",
-)
+_EVIDENCE_COMMANDS = {"pytest", "ruff", "mypy", "nix", "polylogue", "polylogued", "polylogue-mcp"}
 
 
 def load_manifest(path: Path) -> dict[str, object]:
@@ -149,6 +139,7 @@ def check_coverage_gaps(plans_dir: Path) -> list[str]:
     """Validate that passive coverage gaps are tracked as actionable records."""
     errors: list[str] = []
     gap_ids: set[str] = set()
+    gap_subject_leaves: set[str] = set()
     for path in sorted(plans_dir.glob("*coverage*.yaml")):
         try:
             data = load_manifest(path)
@@ -173,6 +164,11 @@ def check_coverage_gaps(plans_dir: Path) -> list[str]:
                 errors.append(f"{label} duplicate id {gap_id!r}")
             else:
                 gap_ids.add(gap_id)
+                gap_subject_leaf = _coverage_gap_slug(gap_id)
+                if gap_subject_leaf in gap_subject_leaves:
+                    errors.append(f"{label} duplicate proof subject slug {gap_subject_leaf!r}")
+                else:
+                    gap_subject_leaves.add(gap_subject_leaf)
             if not any(isinstance(gap.get(key), str) and gap.get(key, "").strip() for key in _COVERAGE_AXIS_KEYS):
                 errors.append(f"{path}: coverage_gaps[{index}] missing coverage axis")
             if not isinstance(gap.get("gap"), str) or not gap.get("gap", "").strip():
@@ -230,11 +226,8 @@ def _valid_suppression_ref(value: object) -> bool:
 
 
 def _resolvable_next_evidence(value: str) -> bool:
-    stripped = value.strip()
-    if not any(stripped.startswith(prefix) for prefix in _EVIDENCE_COMMAND_PREFIXES):
-        return False
     try:
-        tokens = shlex.split(stripped)
+        tokens = shlex.split(value)
     except ValueError:
         return False
     if not tokens:
@@ -242,14 +235,11 @@ def _resolvable_next_evidence(value: str) -> bool:
     command = tokens[0]
     if command == "devtools":
         return len(tokens) >= 2 and tokens[1] in COMMANDS
-    if command == "pytest":
-        return _pytest_target_exists(tokens[1:])
-    return command in {"ruff", "mypy", "nix", "polylogue", "polylogued", "polylogue-mcp"}
+    return command in _EVIDENCE_COMMANDS
 
 
-def _pytest_target_exists(tokens: list[str]) -> bool:
-    targets = [token for token in tokens if not token.startswith("-")]
-    return not targets or any((_REPO_ROOT / token).exists() for token in targets)
+def _coverage_gap_slug(value: str) -> str:
+    return "".join(char if char.isalnum() else "-" for char in value.lower()).strip("-") or "unnamed"
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/devtools/verify_manifests.py
+++ b/devtools/verify_manifests.py
@@ -6,10 +6,28 @@ consistent. Runs as part of devtools verify.
 
 from __future__ import annotations
 
+import shlex
 import sys
+from datetime import date
 from pathlib import Path
 
 import yaml
+
+from devtools.command_catalog import COMMANDS
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_COVERAGE_AXIS_KEYS = ("domain", "subject", "area", "dimension", "artifact", "platform", "concern")
+_COVERAGE_GAP_SEVERITIES = {"info", "minor", "major", "serious"}
+_EVIDENCE_COMMAND_PREFIXES = (
+    "devtools ",
+    "pytest ",
+    "ruff ",
+    "mypy ",
+    "nix ",
+    "polylogue ",
+    "polylogued ",
+    "polylogue-mcp ",
+)
 
 
 def load_manifest(path: Path) -> dict[str, object]:
@@ -130,6 +148,7 @@ def check_assurance_domains(plans_dir: Path) -> list[str]:
 def check_coverage_gaps(plans_dir: Path) -> list[str]:
     """Validate that passive coverage gaps are tracked as actionable records."""
     errors: list[str] = []
+    gap_ids: set[str] = set()
     for path in sorted(plans_dir.glob("*coverage*.yaml")):
         try:
             data = load_manifest(path)
@@ -146,16 +165,91 @@ def check_coverage_gaps(plans_dir: Path) -> list[str]:
             if not isinstance(gap, dict):
                 errors.append(f"{path}: coverage_gaps[{index}] must be a mapping")
                 continue
-            axis_keys = ("domain", "subject", "area", "dimension", "artifact", "platform", "concern")
-            if not any(isinstance(gap.get(key), str) and gap.get(key, "").strip() for key in axis_keys):
+            label = _coverage_gap_label(path, index, gap)
+            gap_id = gap.get("id")
+            if not isinstance(gap_id, str) or not gap_id.strip():
+                errors.append(f"{label} missing id")
+            elif gap_id in gap_ids:
+                errors.append(f"{label} duplicate id {gap_id!r}")
+            else:
+                gap_ids.add(gap_id)
+            if not any(isinstance(gap.get(key), str) and gap.get(key, "").strip() for key in _COVERAGE_AXIS_KEYS):
                 errors.append(f"{path}: coverage_gaps[{index}] missing coverage axis")
             if not isinstance(gap.get("gap"), str) or not gap.get("gap", "").strip():
-                errors.append(f"{path}: coverage_gaps[{index}] missing gap text")
+                errors.append(f"{label} missing gap text")
             if not isinstance(gap.get("owner"), str) or not gap.get("owner", "").strip():
-                errors.append(f"{path}: coverage_gaps[{index}] missing owner")
-            if not isinstance(gap.get("next_evidence"), str) or not gap.get("next_evidence", "").strip():
-                errors.append(f"{path}: coverage_gaps[{index}] missing next_evidence")
+                errors.append(f"{label} missing owner")
+            severity = gap.get("severity")
+            if severity not in _COVERAGE_GAP_SEVERITIES:
+                errors.append(f"{label} missing or invalid severity")
+            for field in ("declared_at", "review_after"):
+                if not _valid_iso_date(gap.get(field)):
+                    errors.append(f"{label} missing or invalid {field}")
+            issue = gap.get("issue")
+            suppression = gap.get("suppression")
+            if not _valid_issue_ref(issue) and not _valid_suppression_ref(suppression):
+                errors.append(f"{label} missing issue or suppression")
+            next_evidence = gap.get("next_evidence")
+            if not isinstance(next_evidence, str) or not next_evidence.strip():
+                errors.append(f"{label} missing next_evidence")
+            elif not _resolvable_next_evidence(next_evidence):
+                errors.append(f"{label} next_evidence does not resolve to a known command")
     return errors
+
+
+def _coverage_gap_label(path: Path, index: int, gap: dict[object, object]) -> str:
+    gap_id = gap.get("id")
+    if isinstance(gap_id, str) and gap_id.strip():
+        return f"{path}: coverage_gaps[{index}] {gap_id!r}"
+    return f"{path}: coverage_gaps[{index}]"
+
+
+def _valid_iso_date(value: object) -> bool:
+    if not isinstance(value, str) or not value.strip():
+        return False
+    try:
+        date.fromisoformat(value)
+    except ValueError:
+        return False
+    return True
+
+
+def _valid_issue_ref(value: object) -> bool:
+    if isinstance(value, int):
+        return value > 0
+    if not isinstance(value, str):
+        return False
+    stripped = value.strip()
+    if stripped.startswith("#"):
+        stripped = stripped[1:]
+    return stripped.isdecimal() and int(stripped) > 0
+
+
+def _valid_suppression_ref(value: object) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def _resolvable_next_evidence(value: str) -> bool:
+    stripped = value.strip()
+    if not any(stripped.startswith(prefix) for prefix in _EVIDENCE_COMMAND_PREFIXES):
+        return False
+    try:
+        tokens = shlex.split(stripped)
+    except ValueError:
+        return False
+    if not tokens:
+        return False
+    command = tokens[0]
+    if command == "devtools":
+        return len(tokens) >= 2 and tokens[1] in COMMANDS
+    if command == "pytest":
+        return _pytest_target_exists(tokens[1:])
+    return command in {"ruff", "mypy", "nix", "polylogue", "polylogued", "polylogue-mcp"}
+
+
+def _pytest_target_exists(tokens: list[str]) -> bool:
+    targets = [token for token in tokens if not token.startswith("-")]
+    return not targets or any((_REPO_ROOT / token).exists() for token in targets)
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/docs/plans/distribution-coverage.yaml
+++ b/docs/plans/distribution-coverage.yaml
@@ -110,27 +110,57 @@ artifacts:
       3.13). No macOS or Windows runners.
 
 coverage_gaps:
-  - artifact: wheel
+  - id: distribution.wheel-ci
+    artifact: wheel
     gap: Distribution gate exists locally but is not scheduled in CI
     owner: distribution
-    next_evidence: Add CI job for devtools verify-distribution-surface
-  - artifact: sdist
+    severity: major
+    declared_at: "2026-05-02"
+    review_after: "2026-08-01"
+    issue: 593
+    next_evidence: devtools verify-distribution-surface
+  - id: distribution.sdist-ci
+    artifact: sdist
     gap: Distribution gate exists locally but is not scheduled in CI
     owner: distribution
-    next_evidence: Add CI job for devtools verify-distribution-surface
-  - artifact: dev_install
+    severity: major
+    declared_at: "2026-05-02"
+    review_after: "2026-08-01"
+    issue: 593
+    next_evidence: devtools verify-distribution-surface
+  - id: distribution.dev-install-ci
+    artifact: dev_install
     gap: Not verified in CI; devshell is canonical environment
     owner: distribution
-    next_evidence: Add package/build or cross-artifact CI gate
-  - platform: macos
+    severity: minor
+    declared_at: "2026-05-02"
+    review_after: "2026-08-01"
+    issue: 593
+    next_evidence: devtools verify-distribution-surface
+  - id: distribution.macos-ci
+    platform: macos
     gap: No macOS CI runner
     owner: distribution
-    next_evidence: Add package/build or cross-artifact CI gate
-  - platform: windows
+    severity: minor
+    declared_at: "2026-05-02"
+    review_after: "2026-08-01"
+    issue: 593
+    next_evidence: devtools verify-distribution-surface
+  - id: distribution.windows-ci
+    platform: windows
     gap: No Windows CI runner
     owner: distribution
-    next_evidence: Add package/build or cross-artifact CI gate
-  - concern: install_parity
+    severity: minor
+    declared_at: "2026-05-02"
+    review_after: "2026-08-01"
+    issue: 593
+    next_evidence: devtools verify-distribution-surface
+  - id: distribution.nix-wheel-parity
+    concern: install_parity
     gap: Local gate smokes wheel and sdist-built wheel, but exact Nix/devshell parity is not yet compared in CI
     owner: distribution
-    next_evidence: Add CI job comparing devtools verify-distribution-surface with nix flake check smoke output
+    severity: major
+    declared_at: "2026-05-02"
+    review_after: "2026-08-01"
+    issue: 593
+    next_evidence: devtools verify-distribution-surface

--- a/docs/plans/docs-media-coverage.yaml
+++ b/docs/plans/docs-media-coverage.yaml
@@ -171,15 +171,30 @@ surfaces:
       Manually maintained. Updated on version bumps.
 
 coverage_gaps:
-  - domain: docs_media
+  - id: docs-media.executable-examples
+    domain: docs_media
     gap: README examples and media are not yet generated from executable scenario projections.
     owner: docs-media
-    next_evidence: Add executable scenario projection or media integrity gate
-  - domain: docs_media
+    severity: major
+    declared_at: "2026-05-02"
+    review_after: "2026-08-01"
+    issue: 590
+    next_evidence: devtools render-docs-surface --check
+  - id: docs-media.screenshot-integrity
+    domain: docs_media
     gap: Screenshots and VHS media have no committed nonblank/readability verification.
     owner: docs-media
-    next_evidence: Add executable scenario projection or media integrity gate
-  - domain: site_publication
+    severity: major
+    declared_at: "2026-05-02"
+    review_after: "2026-08-01"
+    issue: 590
+    next_evidence: devtools render-docs-surface --check
+  - id: docs-media.site-publication-integrity
+    domain: site_publication
     gap: Static-site publication has no visual or hyperlink integrity gate.
     owner: docs-media
-    next_evidence: Add executable scenario projection or media integrity gate
+    severity: major
+    declared_at: "2026-05-02"
+    review_after: "2026-08-01"
+    issue: 590
+    next_evidence: devtools render-docs-surface --check

--- a/docs/plans/scenario-coverage.yaml
+++ b/docs/plans/scenario-coverage.yaml
@@ -91,27 +91,57 @@ families:
       and pipeline-probe execution kinds.
 
 coverage_gaps:
-  - subject: storage_correctness
+  - id: scenario.storage-correctness
+    subject: storage_correctness
     gap: No dedicated scenario family for storage-layer verification
     owner: scenario-coverage
-    next_evidence: Add scenario family or generated projection for this subject
-  - subject: performance
+    severity: major
+    declared_at: "2026-05-02"
+    review_after: "2026-08-01"
+    issue: 590
+    next_evidence: devtools scenario-projections
+  - id: scenario.performance
+    subject: performance
     gap: No scenario family exercising memory or throughput budgets
     owner: scenario-coverage
-    next_evidence: Add scenario family or generated projection for this subject
-  - subject: security_privacy
+    severity: major
+    declared_at: "2026-05-02"
+    review_after: "2026-08-01"
+    issue: 590
+    next_evidence: devtools scenario-projections
+  - id: scenario.security-privacy
+    subject: security_privacy
     gap: Security verification uses unit tests, not scenario specs
     owner: scenario-coverage
-    next_evidence: Add scenario family or generated projection for this subject
-  - subject: distribution
+    severity: major
+    declared_at: "2026-05-02"
+    review_after: "2026-08-01"
+    issue: 590
+    next_evidence: devtools scenario-projections
+  - id: scenario.distribution
+    subject: distribution
     gap: No scenario for install/package verification
     owner: scenario-coverage
-    next_evidence: Add scenario family or generated projection for this subject
-  - subject: migration_safety
+    severity: major
+    declared_at: "2026-05-02"
+    review_after: "2026-08-01"
+    issue: 590
+    next_evidence: devtools scenario-projections
+  - id: scenario.migration-safety
+    subject: migration_safety
     gap: No scenario for migration safety verification
     owner: scenario-coverage
-    next_evidence: Add scenario family or generated projection for this subject
-  - subject: docs_media
+    severity: major
+    declared_at: "2026-05-02"
+    review_after: "2026-08-01"
+    issue: 590
+    next_evidence: devtools scenario-projections
+  - id: scenario.docs-media
+    subject: docs_media
     gap: No scenario for documentation freshness verification
     owner: scenario-coverage
-    next_evidence: Add scenario family or generated projection for this subject
+    severity: major
+    declared_at: "2026-05-02"
+    review_after: "2026-08-01"
+    issue: 590
+    next_evidence: devtools scenario-projections

--- a/docs/plans/security-privacy-coverage.yaml
+++ b/docs/plans/security-privacy-coverage.yaml
@@ -161,19 +161,39 @@ areas:
       pip-audit, etc.) configured in CI.
 
 coverage_gaps:
-   - area: xss_prevention
+   - id: security.xss-prevention
+     area: xss_prevention
      gap: No dedicated XSS test file; relies on snapshot rendering
      owner: security-privacy
-     next_evidence: Add dedicated security/privacy gate for this area
-   - area: dependency_audit
+     severity: major
+     declared_at: "2026-05-02"
+     review_after: "2026-08-01"
+     issue: 590
+     next_evidence: pytest -q tests/unit/security
+   - id: security.dependency-audit
+     area: dependency_audit
      gap: No dependency vulnerability scanning in CI
      owner: security-privacy
-     next_evidence: Add dedicated security/privacy gate for this area
-   - area: file_permissions
+     severity: major
+     declared_at: "2026-05-02"
+     review_after: "2026-08-01"
+     issue: 590
+     next_evidence: devtools verify --quick
+   - id: security.file-permissions
+     area: file_permissions
      gap: Crawl-source file permissions not verified
      owner: security-privacy
-     next_evidence: Add dedicated security/privacy gate for this area
-   - area: secrets_detection
+     severity: major
+     declared_at: "2026-05-02"
+     review_after: "2026-08-01"
+     issue: 590
+     next_evidence: pytest -q tests/unit/security
+   - id: security.secrets-detection
+     area: secrets_detection
      gap: No automated secrets scanning in CI
      owner: security-privacy
-     next_evidence: Add dedicated security/privacy gate for this area
+     severity: major
+     declared_at: "2026-05-02"
+     review_after: "2026-08-01"
+     issue: 590
+     next_evidence: devtools verify --quick

--- a/docs/plans/test-quality-coverage.yaml
+++ b/docs/plans/test-quality-coverage.yaml
@@ -129,19 +129,39 @@ dimensions:
       - tests/fuzz/
 
 coverage_gaps:
-  - dimension: flakiness
+  - id: test-quality.flakiness
+    dimension: flakiness
     gap: No systematic flakiness tracking, CI retry, or quarantine
     owner: test-quality
-    next_evidence: Add measurable quality gate for this dimension
-  - dimension: mock_depth
+    severity: major
+    declared_at: "2026-05-02"
+    review_after: "2026-08-01"
+    issue: 590
+    next_evidence: devtools run-validation-lanes --list
+  - id: test-quality.mock-depth
+    dimension: mock_depth
     gap: Mock depth not measured or enforced
     owner: test-quality
-    next_evidence: Add measurable quality gate for this dimension
-  - dimension: fuzz
+    severity: major
+    declared_at: "2026-05-02"
+    review_after: "2026-08-01"
+    issue: 590
+    next_evidence: devtools run-validation-lanes --list
+  - id: test-quality.fuzz-ci
+    dimension: fuzz
     gap: Atheris fuzz targets not run in CI
     owner: test-quality
-    next_evidence: Add measurable quality gate for this dimension
-  - dimension: direct_coverage
+    severity: major
+    declared_at: "2026-05-02"
+    review_after: "2026-08-01"
+    issue: 590
+    next_evidence: devtools run-validation-lanes --list
+  - id: test-quality.per-module-coverage
+    dimension: direct_coverage
     gap: Coverage per-module not tracked (only aggregate fail_under)
     owner: test-quality
-    next_evidence: Add measurable quality gate for this dimension
+    severity: major
+    declared_at: "2026-05-02"
+    review_after: "2026-08-01"
+    issue: 590
+    next_evidence: devtools coverage-gate

--- a/polylogue/proof/coverage_manifests.py
+++ b/polylogue/proof/coverage_manifests.py
@@ -165,10 +165,16 @@ def _iter_manifest_gaps(entry: CoverageManifestEntry) -> Iterator[dict[str, Any]
         axis = _gap_axis(payload)
         yield {
             "index": index,
+            "id": str(payload.get("id") or ""),
             "axis": axis,
             "domain": _gap_domain(entry, axis, payload),
             "gap": str(payload.get("gap") or payload.get("note") or payload.get("value") or ""),
             "owner": str(payload.get("owner") or ""),
+            "severity": str(payload.get("severity") or ""),
+            "declared_at": str(payload.get("declared_at") or ""),
+            "review_after": str(payload.get("review_after") or ""),
+            "issue": str(payload.get("issue") or ""),
+            "suppression": str(payload.get("suppression") or ""),
             "next_evidence": str(payload.get("next_evidence") or ""),
             "payload": payload,
         }
@@ -207,15 +213,23 @@ def _coverage_item_subject(entry: CoverageManifestEntry, item: Mapping[str, Any]
 def _coverage_gap_subject(entry: CoverageManifestEntry, gap: Mapping[str, Any]) -> SubjectRef:
     index = int(gap.get("index") or 0)
     axis = str(gap.get("axis") or "gap")
+    gap_id = str(gap.get("id") or "")
     domain = str(gap.get("domain") or entry.domain)
-    subject_id = f"assurance.coverage_gap.{entry.manifest_id}.{index:03d}.{_slug(axis)}"
+    subject_leaf = _slug(gap_id) if gap_id else f"{index:03d}.{_slug(axis)}"
+    subject_id = f"assurance.coverage_gap.{entry.manifest_id}.{subject_leaf}"
     attrs = _json_document(
         {
             "manifest_id": entry.manifest_id,
+            "gap_id": gap_id,
             "assurance_domain": domain,
             "axis": axis,
             "gap": str(gap.get("gap") or ""),
             "owner": str(gap.get("owner") or ""),
+            "severity": str(gap.get("severity") or ""),
+            "declared_at": str(gap.get("declared_at") or ""),
+            "review_after": str(gap.get("review_after") or ""),
+            "issue": str(gap.get("issue") or ""),
+            "suppression": str(gap.get("suppression") or ""),
             "next_evidence": str(gap.get("next_evidence") or ""),
             "path": entry.repo_path,
         }

--- a/tests/baselines/showcase/help-main.txt
+++ b/tests/baselines/showcase/help-main.txt
@@ -80,9 +80,9 @@ Options:
   --min-messages INTEGER          Minimum message count
   --max-messages INTEGER          Maximum message count
   --min-words INTEGER             Minimum total word count
-  --message-type [summary|tool_use|tool_result|thinking]
-                                  Filter by message content type (summary,
-                                  tool_use, tool_result, thinking)
+  --message-type [message|summary|tool_use|tool_result|thinking]
+                                  Filter by message content type (message,
+                                  summary, tool_use, tool_result, thinking)
   --since-session TEXT            Show sessions in same cwd after this
                                   conversation ID
   --since TEXT                    After date (ISO, 'yesterday', 'last week')
@@ -145,6 +145,7 @@ Commands:
   resume       Reconstruct work-state context for a fresh agent session.
   run          Run pipeline stages on configured sources and/or transient...
   schema       Inspect schema packages, versions, and evidence.
+  select       Select one matched conversation and print a field.
   show         Show matched conversations with default full-content output.
   stats        Show statistics for matched conversations.
   tags         List all tags with conversation counts.

--- a/tests/baselines/showcase/help-messages.txt
+++ b/tests/baselines/showcase/help-messages.txt
@@ -4,7 +4,7 @@ Usage: polylogue messages [OPTIONS] [CONVERSATION_ID]
 
 Options:
   -r, --message-role TEXT         Filter by message role
-  --message-type [summary|tool_use|tool_result|thinking]
+  --message-type [message|summary|tool_use|tool_result|thinking]
                                   Filter by message content type
   -n, --limit INTEGER             Max messages to return
   --offset INTEGER                Offset for pagination

--- a/tests/baselines/showcase/help-select.txt
+++ b/tests/baselines/showcase/help-select.txt
@@ -1,0 +1,8 @@
+Usage: polylogue select [OPTIONS] [[conversation]]
+
+  Select one matched conversation and print a field.
+
+Options:
+  --print [id|title|provider|json]
+  -n, --limit INTEGER             Max candidates to offer
+  -h, --help                      Show this message and exit.

--- a/tests/unit/devtools/test_verify_manifests.py
+++ b/tests/unit/devtools/test_verify_manifests.py
@@ -71,3 +71,57 @@ def test_coverage_gap_manifest_rejects_non_command_next_evidence(tmp_path: Path)
         f"{plans / 'example-coverage.yaml'}: coverage_gaps[0] 'docs-media.generated-proof' "
         "next_evidence does not resolve to a known command"
     ]
+
+
+def test_coverage_gap_manifest_allows_pytest_filter_next_evidence(tmp_path: Path) -> None:
+    plans = tmp_path
+    (plans / "example-coverage.yaml").write_text(
+        """coverage_gaps:
+  - id: docs-media.generated-proof
+    domain: docs_media
+    gap: Missing generated media proof
+    owner: docs-media
+    severity: major
+    declared_at: "2026-05-02"
+    review_after: "2026-08-01"
+    issue: "#590"
+    next_evidence: pytest -k "docs_media and not slow"
+""",
+        encoding="utf-8",
+    )
+
+    assert verify_manifests.check_coverage_gaps(plans) == []
+
+
+def test_coverage_gap_manifest_rejects_proof_subject_slug_collision(tmp_path: Path) -> None:
+    plans = tmp_path
+    (plans / "example-coverage.yaml").write_text(
+        """coverage_gaps:
+  - id: docs_media.generated_proof
+    domain: docs_media
+    gap: Missing generated media proof
+    owner: docs-media
+    severity: major
+    declared_at: "2026-05-02"
+    review_after: "2026-08-01"
+    issue: "#590"
+    next_evidence: devtools render-docs-surface --check
+  - id: docs-media.generated-proof
+    domain: docs_media
+    gap: Missing generated media proof
+    owner: docs-media
+    severity: major
+    declared_at: "2026-05-02"
+    review_after: "2026-08-01"
+    issue: "#590"
+    next_evidence: devtools render-docs-surface --check
+""",
+        encoding="utf-8",
+    )
+
+    errors = verify_manifests.check_coverage_gaps(plans)
+
+    assert errors == [
+        f"{plans / 'example-coverage.yaml'}: coverage_gaps[1] 'docs-media.generated-proof' "
+        "duplicate proof subject slug 'docs-media-generated-proof'"
+    ]

--- a/tests/unit/devtools/test_verify_manifests.py
+++ b/tests/unit/devtools/test_verify_manifests.py
@@ -9,10 +9,15 @@ def test_coverage_gap_manifest_records_require_closure_path(tmp_path: Path) -> N
     plans = tmp_path
     (plans / "example-coverage.yaml").write_text(
         """coverage_gaps:
-  - domain: docs_media
+  - id: docs-media.generated-proof
+    domain: docs_media
     gap: Missing generated media proof
     owner: docs-media
-    next_evidence: Add generated media proof gate
+    severity: major
+    declared_at: "2026-05-02"
+    review_after: "2026-08-01"
+    issue: 590
+    next_evidence: devtools render-docs-surface --check
 """,
         encoding="utf-8",
     )
@@ -33,6 +38,36 @@ def test_coverage_gap_manifest_rejects_gap_without_closure_path(tmp_path: Path) 
     errors = verify_manifests.check_coverage_gaps(plans)
 
     assert errors == [
+        f"{plans / 'example-coverage.yaml'}: coverage_gaps[0] missing id",
         f"{plans / 'example-coverage.yaml'}: coverage_gaps[0] missing owner",
+        f"{plans / 'example-coverage.yaml'}: coverage_gaps[0] missing or invalid severity",
+        f"{plans / 'example-coverage.yaml'}: coverage_gaps[0] missing or invalid declared_at",
+        f"{plans / 'example-coverage.yaml'}: coverage_gaps[0] missing or invalid review_after",
+        f"{plans / 'example-coverage.yaml'}: coverage_gaps[0] missing issue or suppression",
         f"{plans / 'example-coverage.yaml'}: coverage_gaps[0] missing next_evidence",
+    ]
+
+
+def test_coverage_gap_manifest_rejects_non_command_next_evidence(tmp_path: Path) -> None:
+    plans = tmp_path
+    (plans / "example-coverage.yaml").write_text(
+        """coverage_gaps:
+  - id: docs-media.generated-proof
+    domain: docs_media
+    gap: Missing generated media proof
+    owner: docs-media
+    severity: major
+    declared_at: "2026-05-02"
+    review_after: "2026-08-01"
+    issue: "#590"
+    next_evidence: Add generated media proof gate
+""",
+        encoding="utf-8",
+    )
+
+    errors = verify_manifests.check_coverage_gaps(plans)
+
+    assert errors == [
+        f"{plans / 'example-coverage.yaml'}: coverage_gaps[0] 'docs-media.generated-proof' "
+        "next_evidence does not resolve to a known command"
     ]

--- a/tests/unit/proof/test_catalog.py
+++ b/tests/unit/proof/test_catalog.py
@@ -97,6 +97,12 @@ def test_default_catalog_compiles_first_vertical_slice() -> None:
     assert {"distribution", "docs_media", "performance", "security_privacy", "test_quality"}.issubset(
         coverage_gap_domains
     )
+    coverage_gap_attrs = [subject.attrs for subject in catalog.subjects if subject.kind == "assurance.coverage_gap"]
+    assert all(attrs.get("gap_id") for attrs in coverage_gap_attrs)
+    assert all(attrs.get("severity") for attrs in coverage_gap_attrs)
+    assert all(attrs.get("declared_at") for attrs in coverage_gap_attrs)
+    assert all(attrs.get("review_after") for attrs in coverage_gap_attrs)
+    assert all(attrs.get("issue") or attrs.get("suppression") for attrs in coverage_gap_attrs)
     assert {runner.claim_id for runner in catalog.runner_bindings} == {claim.id for claim in catalog.claims}
     assert {"smoke", "semantic", "structural", "trace"}.issubset(
         {runner.evidence_class for runner in catalog.runner_bindings}


### PR DESCRIPTION
## Summary

Tightens `verify-manifests` so coverage gaps are lifecycle records instead of prose-only rows, and updates every current `docs/plans/*coverage*.yaml` gap to satisfy the new contract.

## Problem

#590 tracks the fact that coverage manifests were visible but passive: a row could name a gap and owner without stable identity, issue/suppression linkage, review metadata, severity, or a resolvable next evidence path. That made proof-pack known-gap reporting useful but too shallow to support durable closure.

## Solution

`devtools/verify_manifests.py` now requires each coverage gap to have a stable `id`, axis, `gap`, `owner`, `severity`, `declared_at`, `review_after`, issue or suppression linkage, and `next_evidence` that resolves to a known devtools command or supported command family such as pytest.

The existing distribution, docs/media, scenario, security/privacy, and test-quality coverage gaps now carry that lifecycle metadata. `polylogue/proof/coverage_manifests.py` also forwards the new metadata into `assurance.coverage_gap` subjects and uses stable gap IDs in subject IDs instead of index-derived IDs.

Automated review caught two edge cases, both addressed: pytest evidence commands are parsed by command token instead of naive path extraction, and the manifest verifier rejects coverage-gap IDs that collide after proof-subject slugging.

This intentionally keeps ordinary known gaps report-only per the latest #590 policy; serious affected gaps still escalate through proof-pack/check policy rather than every known gap failing quick verification.

CI also exposed stale showcase help baselines from the previously merged selector/message-type work. This PR refreshes those committed baselines so the showcase lane matches current CLI behavior.

## Verification

- `ruff check devtools/verify_manifests.py tests/unit/devtools/test_verify_manifests.py polylogue/proof/coverage_manifests.py tests/unit/proof/test_catalog.py`
- `devtools verify-manifests`
- `pytest tests/unit/devtools/test_verify_manifests.py tests/unit/proof/test_catalog.py tests/unit/proof/test_diffing.py -q`
- `pytest tests/unit/proof tests/unit/devtools/test_proof_pack.py tests/unit/devtools/test_render_verification_catalog.py -q`
- `devtools render-verification-catalog --check`
- `devtools proof-pack --path docs/plans/distribution-coverage.yaml --path docs/plans/docs-media-coverage.yaml --path devtools/verify_manifests.py --path polylogue/proof/coverage_manifests.py --check`
- `devtools proof-pack --path docs/plans/distribution-coverage.yaml --path docs/plans/docs-media-coverage.yaml --path docs/plans/scenario-coverage.yaml --path docs/plans/security-privacy-coverage.yaml --path docs/plans/test-quality-coverage.yaml --markdown`
- `devtools lab-scenario verify-baselines --update`
- `devtools lab-scenario verify-baselines`
- `devtools verify --quick`
- `devtools verify`
- pre-push `devtools verify --quick` after each push

Proof-pack with explicit changed paths reports the expected known-gap warnings under the current #590/#594 policy. GitHub proof-pack, lint, typecheck, nix-build, nix-check, analysis, and showcase checks passed. Remaining GitHub pytest jobs were pending under the known CI-capacity issue; local full `devtools verify` passed.

Ref #590