### PR TITLE
fix(verification): validate coverage manifest references

### DIFF
--- a/devtools/verify_manifests.py
+++ b/devtools/verify_manifests.py
@@ -18,6 +18,9 @@ from devtools.command_catalog import COMMANDS
 _COVERAGE_AXIS_KEYS = ("domain", "subject", "area", "dimension", "artifact", "platform", "concern")
 _COVERAGE_GAP_SEVERITIES = {"info", "minor", "major", "serious"}
 _EVIDENCE_COMMANDS = {"pytest", "ruff", "mypy", "nix", "polylogue", "polylogued", "polylogue-mcp"}
+_COVERAGE_COMMAND_FIELDS = {"generated_by", "verified_by", "verification_command"}
+_COVERAGE_PATH_FIELDS = {"config_location", "location", "path", "strategies_location"}
+_COVERAGE_PATH_LIST_FIELDS = {"locations", "tests"}
 
 
 def load_manifest(path: Path) -> dict[str, object]:
@@ -193,6 +196,71 @@ def check_coverage_gaps(plans_dir: Path) -> list[str]:
     return errors
 
 
+def check_coverage_references(plans_dir: Path) -> list[str]:
+    """Validate locally checkable command and path references in coverage manifests."""
+    errors: list[str] = []
+    repo_root = _repo_root_for_plans(plans_dir)
+    for path in sorted(plans_dir.glob("*coverage*.yaml")):
+        try:
+            data = load_manifest(path)
+        except ValueError as exc:
+            errors.append(str(exc))
+            continue
+        for ref_path, key, value in _iter_manifest_fields(data):
+            label = f"{path}: {'.'.join(ref_path)}"
+            if (
+                key in _COVERAGE_COMMAND_FIELDS
+                and isinstance(value, str)
+                and value.strip()
+                and not _resolvable_command(value)
+            ):
+                errors.append(f"{label} command does not resolve: {value!r}")
+            if key in _COVERAGE_PATH_FIELDS and isinstance(value, str) and value.strip():
+                candidate = _manifest_path_token(value)
+                if candidate and not _manifest_path_exists(repo_root, candidate):
+                    errors.append(f"{label} path does not exist: {candidate!r}")
+            if key in _COVERAGE_PATH_LIST_FIELDS and isinstance(value, list):
+                for item_index, item in enumerate(value):
+                    if not isinstance(item, str) or not item.strip():
+                        continue
+                    candidate = _manifest_path_token(item)
+                    if candidate and not _manifest_path_exists(repo_root, candidate):
+                        errors.append(f"{label}[{item_index}] path does not exist: {candidate!r}")
+    return errors
+
+
+def _iter_manifest_fields(value: object, prefix: tuple[str, ...] = ()) -> list[tuple[tuple[str, ...], str, object]]:
+    fields: list[tuple[tuple[str, ...], str, object]] = []
+    if isinstance(value, dict):
+        for raw_key, child in value.items():
+            key = str(raw_key)
+            child_path = (*prefix, key)
+            fields.append((child_path, key, child))
+            fields.extend(_iter_manifest_fields(child, child_path))
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            fields.extend(_iter_manifest_fields(child, (*prefix, str(index))))
+    return fields
+
+
+def _repo_root_for_plans(plans_dir: Path) -> Path:
+    if plans_dir.name == "plans" and plans_dir.parent.name == "docs":
+        return plans_dir.parent.parent
+    return plans_dir
+
+
+def _manifest_path_token(value: str) -> str:
+    token = value.strip().split(maxsplit=1)[0].strip()
+    return "" if token in {"", "null", "dynamic", "unknown"} else token
+
+
+def _manifest_path_exists(repo_root: Path, token: str) -> bool:
+    path = Path(token)
+    if path.is_absolute():
+        return path.exists()
+    return (repo_root / path).exists()
+
+
 def _coverage_gap_label(path: Path, index: int, gap: dict[object, object]) -> str:
     gap_id = gap.get("id")
     if isinstance(gap_id, str) and gap_id.strip():
@@ -226,6 +294,10 @@ def _valid_suppression_ref(value: object) -> bool:
 
 
 def _resolvable_next_evidence(value: str) -> bool:
+    return _resolvable_command(value)
+
+
+def _resolvable_command(value: str) -> bool:
     try:
         tokens = shlex.split(value)
     except ValueError:
@@ -252,7 +324,13 @@ def main(argv: list[str] | None = None) -> int:
         return 1
 
     all_errors: list[str] = []
-    for check in (check_lint_escalation, check_suppressions, check_assurance_domains, check_coverage_gaps):
+    for check in (
+        check_lint_escalation,
+        check_suppressions,
+        check_assurance_domains,
+        check_coverage_gaps,
+        check_coverage_references,
+    ):
         try:
             all_errors.extend(check(plans_dir))
         except Exception as exc:

--- a/docs/plans/campaign-coverage.yaml
+++ b/docs/plans/campaign-coverage.yaml
@@ -25,7 +25,10 @@ mutation_campaigns:
       - polylogue/core/json.py
     tests:
       - tests/unit/core/test_models.py
-      - tests/unit/core/test_properties.py
+      - tests/unit/core/test_message_laws.py
+      - tests/unit/core/test_hashing.py
+      - tests/unit/core/test_json.py
+      - tests/unit/core/test_timestamp_guards.py
     status: active
 
   - name: search
@@ -34,7 +37,7 @@ mutation_campaigns:
       - polylogue/storage/search_providers/fts5.py
       - polylogue/storage/search_providers/hybrid.py
     tests:
-      - tests/unit/storage/test_fts5_laws.py
+      - tests/unit/storage/test_fts5.py
       - tests/unit/storage/test_hybrid_laws.py
     status: active
 
@@ -56,17 +59,17 @@ benchmark_campaigns:
   - name: search-filters
     description: Filter chain query performance benchmarks
     tests:
-      - tests/benchmarks/test_search_bench.py
+      - tests/benchmarks/test_search_filters.py
     status: active
 
   - name: pipeline
     description: Pipeline throughput benchmarks
     tests:
-      - tests/benchmarks/test_pipeline_bench.py
+      - tests/benchmarks/test_pipeline.py
     status: active
 
   - name: storage-scale
     description: Storage scale benchmarks
     tests:
-      - tests/benchmarks/test_storage_scale.py
+      - tests/benchmarks/test_storage.py
     status: active

--- a/docs/plans/test-quality-coverage.yaml
+++ b/docs/plans/test-quality-coverage.yaml
@@ -53,7 +53,10 @@ dimensions:
           - tests/infra/strategies/
           - tests/unit/sources/test_parsers_props.py
           - tests/unit/sources/test_null_guard_properties.py
-          - tests/unit/core/test_properties.py
+          - tests/unit/core/test_message_laws.py
+          - tests/unit/core/test_hashing.py
+          - tests/unit/core/test_json.py
+          - tests/unit/core/test_timestamp_guards.py
           - tests/unit/core/test_schema_privacy.py
           - tests/unit/security/test_attachment_security.py
         strategies_location: tests/infra/strategies/
@@ -101,7 +104,10 @@ dimensions:
       - tests/unit/core/test_audit.py
       - tests/unit/core/test_sampling.py
       - tests/unit/core/test_verification.py
-      - tests/unit/core/test_properties.py
+      - tests/unit/core/test_message_laws.py
+      - tests/unit/core/test_hashing.py
+      - tests/unit/core/test_json.py
+      - tests/unit/core/test_timestamp_guards.py
       - tests/unit/core/test_models.py
     unit_sources:
       - tests/unit/sources/test_parsers_props.py

--- a/tests/unit/devtools/test_verify_manifests.py
+++ b/tests/unit/devtools/test_verify_manifests.py
@@ -125,3 +125,41 @@ def test_coverage_gap_manifest_rejects_proof_subject_slug_collision(tmp_path: Pa
         f"{plans / 'example-coverage.yaml'}: coverage_gaps[1] 'docs-media.generated-proof' "
         "duplicate proof subject slug 'docs-media-generated-proof'"
     ]
+
+
+def test_coverage_reference_manifest_accepts_existing_commands_and_paths(tmp_path: Path) -> None:
+    plans = tmp_path
+    (plans / "tests").mkdir()
+    (plans / "tests" / "test_example.py").write_text("def test_example(): pass\n", encoding="utf-8")
+    (plans / "example-coverage.yaml").write_text(
+        """items:
+  example:
+    location: tests/test_example.py (unit coverage)
+    verified_by: devtools verify-manifests
+    tests:
+      - tests/test_example.py
+""",
+        encoding="utf-8",
+    )
+
+    assert verify_manifests.check_coverage_references(plans) == []
+
+
+def test_coverage_reference_manifest_rejects_missing_command_and_path(tmp_path: Path) -> None:
+    plans = tmp_path
+    (plans / "example-coverage.yaml").write_text(
+        """items:
+  example:
+    location: tests/missing.py
+    verified_by: devtools missing-command
+""",
+        encoding="utf-8",
+    )
+
+    errors = verify_manifests.check_coverage_references(plans)
+
+    assert errors == [
+        f"{plans / 'example-coverage.yaml'}: items.example.location path does not exist: 'tests/missing.py'",
+        f"{plans / 'example-coverage.yaml'}: items.example.verified_by command does not resolve: "
+        "'devtools missing-command'",
+    ]


### PR DESCRIPTION
## Summary

Adds a realized-reference pass to `verify-manifests` for coverage manifests and fixes stale campaign/test-quality manifest paths that the new gate catches.

## Problem

#701 made coverage gaps structured lifecycle records, but coverage manifests could still claim generated/verified commands or source/test/config paths that do not exist. That kept a passive-manifest failure mode alive under #590: the row shape was valid, but the referenced consumer or evidence target could be stale.

## Solution

`devtools/verify_manifests.py` now recursively scans `docs/plans/*coverage*.yaml` for locally checkable reference fields:

- `generated_by`, `verified_by`, and `verification_command` must resolve to known devtools commands or accepted command families.
- `path`, `location`, `config_location`, and `strategies_location` must point at existing files/directories.
- `locations` and `tests` lists must point at existing files/directories.

The new gate caught stale references in `campaign-coverage.yaml` and `test-quality-coverage.yaml`; those now point at current test/benchmark files.

## Verification

- `devtools verify-manifests`
- `ruff check devtools/verify_manifests.py tests/unit/devtools/test_verify_manifests.py`
- `pytest tests/unit/devtools/test_verify_manifests.py -q`
- `devtools affected-obligations --path devtools/verify_manifests.py --path docs/plans/campaign-coverage.yaml --path docs/plans/test-quality-coverage.yaml`
- `devtools proof-pack --path devtools/verify_manifests.py --path docs/plans/campaign-coverage.yaml --path docs/plans/test-quality-coverage.yaml --check`
- `devtools render-quality-reference --check`
- `devtools render-verification-catalog --check`
- `devtools proof-pack --path docs/plans/campaign-coverage.yaml --path docs/plans/test-quality-coverage.yaml --markdown`
- `pytest tests/unit/devtools/test_verify_manifests.py tests/unit/proof/test_catalog.py -q`
- `devtools verify --quick`
- pre-push `devtools verify --quick`

Ref #590