### PR TITLE
fix(verification): reject coverage status contradictions

### DIFF
--- a/devtools/verify_manifests.py
+++ b/devtools/verify_manifests.py
@@ -229,6 +229,56 @@ def check_coverage_references(plans_dir: Path) -> list[str]:
     return errors
 
 
+def check_coverage_status_claims(plans_dir: Path) -> list[str]:
+    """Validate internally contradictory coverage status claims."""
+    errors: list[str] = []
+    for path in sorted(plans_dir.glob("*coverage*.yaml")):
+        try:
+            data = load_manifest(path)
+        except ValueError as exc:
+            errors.append(str(exc))
+            continue
+        for ref_path, payload in _iter_manifest_mappings(data):
+            label = f"{path}: {'.'.join(ref_path)}"
+            implemented = payload.get("implemented")
+            if implemented is True:
+                if not _non_empty_list(payload.get("controls")):
+                    errors.append(f"{label} implemented=true but controls are missing or empty")
+                if not _has_test_coverage_location(payload.get("test_coverage")):
+                    errors.append(f"{label} implemented=true but test_coverage.location is missing")
+            elif implemented is False:
+                if _non_empty_list(payload.get("controls")):
+                    errors.append(f"{label} implemented=false but controls are declared")
+                if _has_test_coverage_location(payload.get("test_coverage")):
+                    errors.append(f"{label} implemented=false but test_coverage.location is declared")
+    return errors
+
+
+def _iter_manifest_mappings(
+    value: object, prefix: tuple[str, ...] = ()
+) -> list[tuple[tuple[str, ...], dict[object, object]]]:
+    mappings: list[tuple[tuple[str, ...], dict[object, object]]] = []
+    if isinstance(value, dict):
+        mappings.append((prefix, value))
+        for raw_key, child in value.items():
+            mappings.extend(_iter_manifest_mappings(child, (*prefix, str(raw_key))))
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            mappings.extend(_iter_manifest_mappings(child, (*prefix, str(index))))
+    return mappings
+
+
+def _non_empty_list(value: object) -> bool:
+    return isinstance(value, list) and bool(value)
+
+
+def _has_test_coverage_location(value: object) -> bool:
+    if not isinstance(value, dict):
+        return False
+    location = value.get("location")
+    return isinstance(location, str) and bool(_manifest_path_token(location))
+
+
 def _iter_manifest_fields(value: object, prefix: tuple[str, ...] = ()) -> list[tuple[tuple[str, ...], str, object]]:
     fields: list[tuple[tuple[str, ...], str, object]] = []
     if isinstance(value, dict):
@@ -330,6 +380,7 @@ def main(argv: list[str] | None = None) -> int:
         check_assurance_domains,
         check_coverage_gaps,
         check_coverage_references,
+        check_coverage_status_claims,
     ):
         try:
             all_errors.extend(check(plans_dir))

--- a/tests/unit/devtools/test_verify_manifests.py
+++ b/tests/unit/devtools/test_verify_manifests.py
@@ -163,3 +163,64 @@ def test_coverage_reference_manifest_rejects_missing_command_and_path(tmp_path: 
         f"{plans / 'example-coverage.yaml'}: items.example.verified_by command does not resolve: "
         "'devtools missing-command'",
     ]
+
+
+def test_coverage_status_claims_accept_realized_implemented_item(tmp_path: Path) -> None:
+    plans = tmp_path
+    (plans / "example-coverage.yaml").write_text(
+        """areas:
+  path_traversal:
+    implemented: true
+    controls:
+      - sanitize_path: blocks traversal
+    test_coverage:
+      location: tests/unit/security/test_path_sanitization.py
+""",
+        encoding="utf-8",
+    )
+
+    assert verify_manifests.check_coverage_status_claims(plans) == []
+
+
+def test_coverage_status_claims_reject_implemented_item_without_evidence(tmp_path: Path) -> None:
+    plans = tmp_path
+    (plans / "example-coverage.yaml").write_text(
+        """areas:
+  path_traversal:
+    implemented: true
+    controls: []
+    test_coverage:
+      location: null
+""",
+        encoding="utf-8",
+    )
+
+    errors = verify_manifests.check_coverage_status_claims(plans)
+
+    assert errors == [
+        f"{plans / 'example-coverage.yaml'}: areas.path_traversal implemented=true but controls are missing or empty",
+        f"{plans / 'example-coverage.yaml'}: areas.path_traversal implemented=true but test_coverage.location is missing",
+    ]
+
+
+def test_coverage_status_claims_reject_missing_item_with_realized_evidence(tmp_path: Path) -> None:
+    plans = tmp_path
+    (plans / "example-coverage.yaml").write_text(
+        """areas:
+  dependency_audit:
+    implemented: false
+    controls:
+      - pip_audit: configured
+    test_coverage:
+      location: tests/unit/security/test_dependency_audit.py
+""",
+        encoding="utf-8",
+    )
+
+    errors = verify_manifests.check_coverage_status_claims(plans)
+
+    assert errors == [
+        f"{plans / 'example-coverage.yaml'}: areas.dependency_audit implemented=false but controls are declared",
+        f"{plans / 'example-coverage.yaml'}: areas.dependency_audit implemented=false "
+        "but test_coverage.location is declared",
+    ]


### PR DESCRIPTION
## Summary

Add a coverage-manifest verifier that rejects internally contradictory `implemented` status rows.

## Problem

#590 is moving coverage manifests from passive dashboards toward executable contracts. After the gap-lifecycle and reference-resolution slices, manifest rows could still claim `implemented: true` without realized controls or test coverage, or claim `implemented: false` while declaring realized controls/test locations. That contradiction made the manifest state look stronger or weaker than the evidence actually recorded.

## Solution

`devtools verify-manifests` now recursively inspects `docs/plans/*coverage*.yaml` mappings for `implemented` status claims:

- `implemented: true` requires a non-empty `controls` list and `test_coverage.location`.
- `implemented: false` rejects declared controls and declared `test_coverage.location`.

The new unit coverage exercises the accepted realized shape and both contradiction classes.

## Verification

- `ruff format devtools/verify_manifests.py tests/unit/devtools/test_verify_manifests.py`
- `ruff check devtools/verify_manifests.py tests/unit/devtools/test_verify_manifests.py`
- `devtools verify-manifests`
- `pytest tests/unit/devtools/test_verify_manifests.py -q` → `10 passed in 8.89s`
- `devtools affected-obligations --path devtools/verify_manifests.py --path tests/unit/devtools/test_verify_manifests.py`
- `devtools proof-pack --path devtools/verify_manifests.py --path tests/unit/devtools/test_verify_manifests.py --check`
- `devtools verify --quick` → `verify: all checks passed`
- `devtools verify` → `verify: all checks passed`

Ref #590