### PR TITLE
fix(distribution): remove devtools absence sentinels

### DIFF
--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -348,7 +348,7 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
         "devtools.verify_distribution_surface",
         use_when=(
             "Build wheel and sdist artifacts, rebuild a wheel from an unpacked sdist without .git, "
-            "smoke installed runtime console scripts, and ensure source-checkout devtools are not shipped."
+            "and smoke installed runtime console scripts."
         ),
         examples=("devtools verify-distribution-surface",),
     ),

--- a/devtools/verify_distribution_surface.py
+++ b/devtools/verify_distribution_surface.py
@@ -15,7 +15,6 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 RUNTIME_SCRIPTS = ("polylogue", "polylogued", "polylogue-mcp")
-SOURCE_ONLY_SCRIPTS = ("devtools",)
 
 
 class DistributionVerificationError(RuntimeError):
@@ -91,15 +90,10 @@ def _verify_wheel_surface(wheel: Path) -> None:
         names = set(archive.namelist())
         if "polylogue/_build_info.py" not in names:
             raise DistributionVerificationError(f"{wheel.name} is missing polylogue/_build_info.py")
-        if any(name.startswith("devtools/") for name in names):
-            raise DistributionVerificationError(f"{wheel.name} includes source-checkout-only devtools package")
         entry_points = _read_entry_points(archive)
     for script in RUNTIME_SCRIPTS:
         if f"{script} =" not in entry_points:
             raise DistributionVerificationError(f"{wheel.name} is missing console script {script}")
-    for script in SOURCE_ONLY_SCRIPTS:
-        if f"{script} =" in entry_points:
-            raise DistributionVerificationError(f"{wheel.name} exposes source-checkout-only console script {script}")
 
 
 def _read_entry_points(archive: zipfile.ZipFile) -> str:
@@ -125,17 +119,6 @@ def _smoke_installed_wheel(wheel: Path, install_dir: Path) -> None:
     _run((str(python), "-m", "polylogue", "--version"), cwd=install_dir, env=env)
     _run((str(bin_dir / "polylogued"), "--help"), cwd=install_dir, env=env)
     _run((str(bin_dir / "polylogue-mcp"), "--help"), cwd=install_dir, env=env)
-    if (bin_dir / "devtools").exists():
-        raise DistributionVerificationError("installed wheel exposes devtools console script")
-    _run(
-        (
-            str(python),
-            "-c",
-            "import importlib.util; raise SystemExit(importlib.util.find_spec('devtools') is not None)",
-        ),
-        cwd=install_dir,
-        env=env,
-    )
 
 
 def _smoke_env(archive_root: Path) -> dict[str, str]:

--- a/docs/plans/distribution-coverage.yaml
+++ b/docs/plans/distribution-coverage.yaml
@@ -3,8 +3,7 @@
 # Documents the current state of install-artifact parity across
 # wheel, sdist, and Nix package. The local distribution gate now
 # builds wheel/sdist artifacts, rebuilds from unpacked sdist without
-# .git, smokes installed runtime entrypoints, and verifies that the
-# source-checkout-only devtools surface is not shipped in user wheels.
+# .git, and smokes installed runtime entrypoints.
 #
 # Updated 2026-05-02 from realized codebase state.
 
@@ -28,8 +27,8 @@ artifacts:
       pyproject.toml uses [build-system] with hatchling.
       The source-checkout distribution gate builds the wheel,
       installs it in a fresh environment, smokes polylogue,
-      polylogued, polylogue-mcp, python -m polylogue, and asserts
-      devtools is not installed. The gate is not yet scheduled in CI.
+      polylogued, polylogue-mcp, and python -m polylogue. The
+      gate is not yet scheduled in CI.
 
   sdist:
     description: Python source distribution (sdist)
@@ -94,8 +93,7 @@ artifacts:
     ci_present: true
     notes: >
       Devtools are intentionally source-checkout-only. They are
-      exposed in the devshell by the devtools wrapper in flake.nix,
-      not as a user-wheel console script or installed wheel package.
+      exposed in the devshell by the devtools wrapper in flake.nix.
 
   pip_dependencies:
     count: null

--- a/flake.nix
+++ b/flake.nix
@@ -204,7 +204,6 @@
               polylogue --help >/dev/null
               polylogued --help >/dev/null
               polylogue-mcp --help >/dev/null
-              ! command -v devtools >/dev/null
               touch $out
             '';
       }

--- a/tests/unit/devtools/test_verify_distribution_surface.py
+++ b/tests/unit/devtools/test_verify_distribution_surface.py
@@ -6,29 +6,14 @@ import zipfile
 from pathlib import Path
 
 import pytest
-import tomllib
 
 from devtools import verify_distribution_surface as surface
 
 
-def test_verify_wheel_surface_accepts_runtime_scripts_without_devtools(tmp_path: Path) -> None:
+def test_verify_wheel_surface_accepts_runtime_scripts(tmp_path: Path) -> None:
     wheel = _write_wheel(tmp_path, entry_points=_runtime_entry_points())
 
     surface._verify_wheel_surface(wheel)
-
-
-def test_verify_wheel_surface_rejects_devtools_script(tmp_path: Path) -> None:
-    wheel = _write_wheel(tmp_path, entry_points=f"{_runtime_entry_points()}devtools = devtools.__main__:main\n")
-
-    with pytest.raises(surface.DistributionVerificationError, match="devtools"):
-        surface._verify_wheel_surface(wheel)
-
-
-def test_verify_wheel_surface_rejects_devtools_package(tmp_path: Path) -> None:
-    wheel = _write_wheel(tmp_path, entry_points=_runtime_entry_points(), extra_files={"devtools/__main__.py": ""})
-
-    with pytest.raises(surface.DistributionVerificationError, match="devtools package"):
-        surface._verify_wheel_surface(wheel)
 
 
 def test_verify_distribution_surface_builds_sdist_wheel_and_smokes(
@@ -62,14 +47,6 @@ def test_verify_distribution_surface_builds_sdist_wheel_and_smokes(
     rendered = [" ".join(call[:2]) for call in calls]
     assert rendered.count("uv build") == 2
     assert rendered.count("uv venv") == 2
-    assert not any("devtools" in call for call in calls)
-
-
-def test_pyproject_keeps_devtools_source_only() -> None:
-    data = tomllib.loads((surface.ROOT / "pyproject.toml").read_text(encoding="utf-8"))
-
-    assert "devtools" not in data["project"]["scripts"]
-    assert data["tool"]["hatch"]["build"]["targets"]["wheel"]["packages"] == ["polylogue"]
 
 
 def _runtime_entry_points() -> str:


### PR DESCRIPTION
## Summary
Remove the extra negative devtools absence checks from the distribution verifier and related docs.

## Problem
#593 already has a settled decision: devtools are source-checkout-only. The build metadata and package configuration encode the supported wheel surface. The verifier had grown beyond that into permanent anti-reintroduction sentinels that rejected a devtools package, console script, installed binary, or import. That kind of name-specific negative guard was not intended.

## Solution
The distribution gate now proves only the supported runtime surface: wheel/sdist build, embedded build metadata, and installed smokes for `polylogue`, `polylogued`, `polylogue-mcp`, and `python -m polylogue`. The equivalent Nix smoke and command-catalog/coverage wording were simplified to match.

## Verification
- `pytest -q tests/unit/devtools/test_verify_distribution_surface.py tests/unit/devtools/test_command_catalog.py` → 7 passed
- `devtools verify-manifests` → passed
- `devtools render-all --check` → passed
- `devtools render-verification-catalog --check` → passed
- `devtools proof-pack --path devtools/verify_distribution_surface.py --path tests/unit/devtools/test_verify_distribution_surface.py --path flake.nix --path docs/plans/distribution-coverage.yaml --path devtools/command_catalog.py --markdown --check` → passed
- `devtools verify-distribution-surface --work-dir .local/distribution-surface-check` → ok
- `devtools verify --quick` → all checks passed

Ref #593

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Simplified distribution surface verification to focus on essential runtime components and build metadata presence.
  * Removed redundant distribution artifact validation checks.

* **Documentation**
  * Updated distribution coverage documentation with clarified phrasing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->