### PR TITLE
test: remove ceremonial absence sentinels

### DIFF
--- a/tests/integration/test_site.py
+++ b/tests/integration/test_site.py
@@ -95,8 +95,8 @@ def test_build_index_requests_all_summaries_without_silent_cap(tmp_path: Path) -
     repository.iter_summary_pages.assert_called_once_with(page_size=500, provider=None)
 
 
-def test_conversation_index_no_source_attribute_reference(tmp_path: Path) -> None:
-    """Regression: ConversationIndex must not touch the removed conv.source attribute."""
+def test_conversation_index_uses_summary_provider_metadata(tmp_path: Path) -> None:
+    """Conversation index construction uses summary provider metadata."""
     backend = _make_backend()
     backend.queries.get_message_counts_batch.return_value = {"test-conv-001": 3}
     repository = AsyncMock()
@@ -115,7 +115,6 @@ def test_conversation_index_no_source_attribute_reference(tmp_path: Path) -> Non
     assert index.id == "test-conv-001"
     assert index.title == "Test Conversation"
     assert index.provider == "claude-ai"
-    assert not hasattr(index, "source")
     assert index.message_count == 3
 
 

--- a/tests/unit/architecture/test_topology_invariants.py
+++ b/tests/unit/architecture/test_topology_invariants.py
@@ -29,32 +29,10 @@ def root_files() -> set[str]:
     return {p.name for p in (ROOT / "polylogue").glob("*.py")}
 
 
-# Insight modules live under polylogue/insights/.
-
-
-def test_no_legacy_insight_modules_at_root() -> None:
-    files = root_files()
-    legacy = {f for f in files if f.startswith("archive_product") or f.startswith("product_")}
-    legacy.update({f for f in files if f in {"archive_resume.py", "authored_payloads.py"}})
-    assert not legacy, f"legacy insight modules still at root: {sorted(legacy)}"
-
-
-# Facade/sync surfaces live under polylogue/api/.
-
-
-def test_no_facade_or_sync_modules_at_root() -> None:
-    files = root_files()
-    legacy = {f for f in files if f.startswith("facade") or f.startswith("sync")}
-    assert not legacy, f"facade/sync modules still at root: {sorted(legacy)}"
-
-
 def test_polylogue_root_matches_kernel_rule() -> None:
     files = root_files()
     extra = files - KERNEL_ROOT_FILES
     assert not extra, f"non-kernel files at polylogue/ root: {sorted(extra)}"
-
-
-# Query semantics live under the archive query package.
 
 
 def test_archive_has_query_subpackage() -> None:
@@ -67,23 +45,8 @@ def test_archive_package_imports() -> None:
     assert archive.__doc__
 
 
-def test_no_query_runtime_at_lib_root() -> None:
-    files = {p.name for p in (ROOT / "polylogue" / "lib").glob("*.py")}
-    legacy = {f for f in files if f.startswith("query_")}
-    assert not legacy, f"query_* modules still at lib/ root: {sorted(legacy)}"
-
-
-# Insight storage lives under the storage insights package.
-
-
 def test_storage_has_insights_session_subpackage() -> None:
     assert (ROOT / "polylogue" / "storage" / "insights" / "session" / "__init__.py").exists()
-
-
-def test_no_legacy_insight_modules_at_storage_root() -> None:
-    files = {p.name for p in (ROOT / "polylogue" / "storage").glob("*.py")}
-    legacy = {f for f in files if f.startswith("session_insight_") or f.startswith("store_insight_")}
-    assert not legacy, f"insight-storage modules still at storage/ root: {sorted(legacy)}"
 
 
 # Structural verification commands exist.

--- a/tests/unit/cli/test_click_app.py
+++ b/tests/unit/cli/test_click_app.py
@@ -509,9 +509,6 @@ class TestCliMetadata:
         assert result.exit_code == 0
         for command in ("run", "doctor", "tags", "list", "count", "stats"):
             assert command in result.output
-        assert "mcp" not in click_cli.commands
-        assert "watch" not in click_cli.commands
-        assert "browser-capture" not in click_cli.commands
         assert result.output.count("Commands:") == 1
 
     def test_all_subcommands_registered(self) -> None:

--- a/tests/unit/core/test_config.py
+++ b/tests/unit/core/test_config.py
@@ -287,21 +287,6 @@ class TestConfigPublicBoundary:
         }
         assert expected.issubset(set(config.__all__))
 
-    def test_paths_does_not_reexport_configuration_symbols(self) -> None:
-        import polylogue.paths as paths
-
-        forbidden = {
-            "DriveConfig",
-            "IndexConfig",
-            "Source",
-            "get_drive_config",
-            "get_index_config",
-            "get_sources",
-        }
-        assert forbidden.isdisjoint(set(paths.__all__))
-        for name in forbidden:
-            assert not hasattr(paths, name)
-
 
 # =============================================================================
 # Merged from test_logging.py (2024-03-15)

--- a/tests/unit/core/test_paths.py
+++ b/tests/unit/core/test_paths.py
@@ -152,15 +152,3 @@ class TestPathsPublicBoundary:
             "state_home",
             "state_root",
         }
-
-    def test_paths_root_does_not_reexport_sanitization_helpers(self) -> None:
-        import polylogue.paths as paths
-
-        forbidden = {
-            "conversation_render_root",
-            "is_within_root",
-            "safe_path_component",
-        }
-        assert forbidden.isdisjoint(set(paths.__all__))
-        for name in forbidden:
-            assert not hasattr(paths, name)

--- a/tests/unit/core/test_schema_corpus_alignment.py
+++ b/tests/unit/core/test_schema_corpus_alignment.py
@@ -392,18 +392,6 @@ class TestConfidenceToScoreRename:
         found_keys = _collect_all_keys(schema)
         assert "x-polylogue-confidence" not in found_keys
 
-    def test_source_files_have_no_old_annotation_key(self) -> None:
-        """Grep-equivalent: no Python source uses the old annotation key literal."""
-        import pathlib
-
-        src_root = pathlib.Path(__file__).resolve().parents[3] / "polylogue"
-        hits: list[str] = []
-        for py_file in src_root.rglob("*.py"):
-            content = py_file.read_text(errors="replace")
-            if "x-polylogue-confidence" in content:
-                hits.append(str(py_file.relative_to(src_root)))
-        assert not hits, f"Source files still reference old key: {hits}"
-
 
 def _collect_all_keys(obj: object, _keys: set[str] | None = None) -> set[str]:
     """Recursively collect all dict keys in a nested structure."""

--- a/tests/unit/core/test_version.py
+++ b/tests/unit/core/test_version.py
@@ -43,47 +43,12 @@ def test_lazy_import_unknown_raises_root() -> None:
 
 @pytest.mark.parametrize(
     "name",
-    [
-        "ArchiveCoverage",
-        "ConversationAttribution",
-        "ConversationRepository",
-        "DaySessionSummary",
-        "ModelPricing",
-        "SessionProfile",
-        "WeekSessionSummary",
-        "WorkEvent",
-        "WorkEventKind",
-        "WorkThread",
-        "build_session_profile",
-        "build_session_threads",
-        "estimate_cost",
-        "harmonize_session_cost",
-        "infer_auto_tags",
-    ],
-)
-def test_root_does_not_export_semantic_or_storage_helpers(name: str) -> None:
-    import polylogue
-
-    with pytest.raises(AttributeError, match="has no attribute"):
-        _ = getattr(polylogue, name)
-
-
-@pytest.mark.parametrize(
-    "name",
     ["HarmonizedMessage", "SchemaValidator", "ValidationResult", "validate_provider_export"],
 )
 def test_runtime_schema_exports_are_narrow(name: str) -> None:
     import polylogue.schemas
 
     assert getattr(polylogue.schemas, name).__name__ == name
-
-
-@pytest.mark.parametrize("name", ["SchemaDiff", "SchemaRegistry"])
-def test_schema_root_does_not_export_tooling_registry_surfaces(name: str) -> None:
-    import polylogue.schemas
-
-    with pytest.raises(AttributeError, match="has no attribute"):
-        _ = getattr(polylogue.schemas, name)
 
 
 class TestVersionInfo:


### PR DESCRIPTION
## Summary
Remove test-only anti-regression sentinels that freeze old filenames, removed attributes, old annotation key literals, absent root exports, or absent root commands without proving useful behavior.

## Problem
A repo-wide sentinel audit found several tests that existed mainly to remember old cleanup targets. These checks can block future intentional naming/API choices while duplicating stronger positive contracts already present in topology, export-surface, schema-output, CLI, and daemon tests.

## Solution
Deleted the ceremonial absence checks and left the positive contracts in place:
- topology root/kernel and subpackage smokes still exist;
- config/path/schema positive exports and output behavior still exist;
- site index construction still proves provider metadata and message count behavior;
- root CLI help still proves the query-first command list shape;
- daemon tests still prove service commands live under `polylogued`.

## Verification
- `ruff check tests/unit/architecture/test_topology_invariants.py tests/integration/test_site.py tests/unit/core/test_schema_corpus_alignment.py tests/unit/core/test_paths.py tests/unit/core/test_config.py tests/unit/core/test_version.py tests/unit/cli/test_click_app.py` → passed
- `pytest -q tests/unit/architecture/test_topology_invariants.py tests/integration/test_site.py tests/unit/core/test_schema_corpus_alignment.py tests/unit/core/test_paths.py tests/unit/core/test_config.py tests/unit/core/test_version.py tests/unit/cli/test_click_app.py` → 175 passed
- `devtools proof-pack --path tests/unit/architecture/test_topology_invariants.py --path tests/integration/test_site.py --path tests/unit/core/test_schema_corpus_alignment.py --path tests/unit/core/test_paths.py --path tests/unit/core/test_config.py --path tests/unit/core/test_version.py --path tests/unit/cli/test_click_app.py --markdown --check` → passed
- `devtools verify --quick` → all checks passed