### PR TITLE
fix(verification): bind campaign coverage to authored catalog

### DIFF
--- a/devtools/verify_manifests.py
+++ b/devtools/verify_manifests.py
@@ -10,9 +10,11 @@ import shlex
 import sys
 from datetime import date
 from pathlib import Path
+from typing import Any
 
 import yaml
 
+from devtools.authored_scenario_catalog import get_authored_scenario_catalog
 from devtools.command_catalog import COMMANDS
 
 _COVERAGE_AXIS_KEYS = ("domain", "subject", "area", "dimension", "artifact", "platform", "concern")
@@ -20,7 +22,7 @@ _COVERAGE_GAP_SEVERITIES = {"info", "minor", "major", "serious"}
 _EVIDENCE_COMMANDS = {"pytest", "ruff", "mypy", "nix", "polylogue", "polylogued", "polylogue-mcp"}
 _COVERAGE_COMMAND_FIELDS = {"generated_by", "verified_by", "verification_command"}
 _COVERAGE_PATH_FIELDS = {"config_location", "location", "path", "strategies_location"}
-_COVERAGE_PATH_LIST_FIELDS = {"locations", "tests"}
+_COVERAGE_PATH_LIST_FIELDS = {"locations", "paths_to_mutate", "tests"}
 
 
 def load_manifest(path: Path) -> dict[str, object]:
@@ -254,6 +256,116 @@ def check_coverage_status_claims(plans_dir: Path) -> list[str]:
     return errors
 
 
+def check_campaign_coverage_catalog(plans_dir: Path) -> list[str]:
+    """Validate campaign-coverage.yaml against the authored campaign catalog."""
+    errors: list[str] = []
+    path = plans_dir / "campaign-coverage.yaml"
+    if not path.exists():
+        return errors
+    try:
+        data = load_manifest(path)
+    except ValueError as exc:
+        return [str(exc)]
+
+    catalog = get_authored_scenario_catalog()
+    errors.extend(
+        _compare_campaign_section(
+            path=path,
+            section="mutation_campaigns",
+            actual=data.get("mutation_campaigns"),
+            expected={
+                entry.name: {
+                    "paths_to_mutate": tuple(entry.paths_to_mutate),
+                    "tests": tuple(entry.tests),
+                    "status": "active",
+                }
+                for entry in catalog.mutation_campaigns
+            },
+        )
+    )
+    errors.extend(
+        _compare_campaign_section(
+            path=path,
+            section="benchmark_campaigns",
+            actual=data.get("benchmark_campaigns"),
+            expected={
+                entry.name: {
+                    "tests": tuple(entry.tests),
+                    "status": "active",
+                }
+                for entry in catalog.benchmark_campaigns
+            },
+        )
+    )
+    return errors
+
+
+def _compare_campaign_section(
+    *,
+    path: Path,
+    section: str,
+    actual: object,
+    expected: dict[str, dict[str, Any]],
+) -> list[str]:
+    errors: list[str] = []
+    actual_by_name = _manifest_named_entries(path, section, actual, errors)
+    if actual_by_name is None:
+        return errors
+
+    actual_names = set(actual_by_name)
+    expected_names = set(expected)
+    for name in sorted(expected_names - actual_names):
+        errors.append(f"{path}: {section} missing catalog campaign {name!r}")
+    for name in sorted(actual_names - expected_names):
+        errors.append(f"{path}: {section} declares unknown campaign {name!r}")
+
+    for name in sorted(actual_names & expected_names):
+        payload = actual_by_name[name]
+        for field, expected_value in expected[name].items():
+            actual_value: object
+            if isinstance(expected_value, tuple):
+                actual_value = _string_tuple(payload.get(field))
+            else:
+                actual_value = payload.get(field)
+            if actual_value != expected_value:
+                errors.append(
+                    f"{path}: {section}[{name!r}] {field} does not match authored catalog "
+                    f"(expected {expected_value!r}, got {actual_value!r})"
+                )
+    return errors
+
+
+def _manifest_named_entries(
+    path: Path,
+    section: str,
+    value: object,
+    errors: list[str],
+) -> dict[str, dict[object, object]] | None:
+    if not isinstance(value, list):
+        errors.append(f"{path}: {section!r} must be a list")
+        return None
+    entries: dict[str, dict[object, object]] = {}
+    for index, item in enumerate(value):
+        if not isinstance(item, dict):
+            errors.append(f"{path}: {section}[{index}] must be a mapping")
+            continue
+        name = item.get("name")
+        if not isinstance(name, str) or not name.strip():
+            errors.append(f"{path}: {section}[{index}] missing name")
+            continue
+        if name in entries:
+            errors.append(f"{path}: {section}[{index}] duplicate campaign name {name!r}")
+            continue
+        entries[name] = item
+    return entries
+
+
+def _string_tuple(value: object) -> tuple[str, ...]:
+    if not isinstance(value, list):
+        return ()
+    return tuple(item for item in value if isinstance(item, str))
+
+
 def _iter_manifest_mappings(
     value: object, prefix: tuple[str, ...] = ()
 ) -> list[tuple[tuple[str, ...], dict[object, object]]]:
@@ -381,6 +493,7 @@ def main(argv: list[str] | None = None) -> int:
         check_coverage_gaps,
         check_coverage_references,
         check_coverage_status_claims,
+        check_campaign_coverage_catalog,
     ):
         try:
             all_errors.extend(check(plans_dir))

--- a/docs/plans/campaign-coverage.yaml
+++ b/docs/plans/campaign-coverage.yaml
@@ -3,73 +3,279 @@
 # Documents active mutation and benchmark campaigns, their paths,
 # and their coverage targets. Consumed by devtools mutmut-campaign
 # and devtools benchmark-campaign.
+#
+# Updated 2026-05-02 from the authored scenario catalog.
 
 description: Mutation and benchmark campaign registry with covered paths and test targets.
 
 mutation_campaigns:
-  - name: filters
-    description: Filter chain mutation testing
+  - name: cli-query
+    description: >
+      Query command planning, action routing, and summary output contracts
     paths_to_mutate:
-      - polylogue/archive/filter/filters.py
+      - polylogue/cli/query.py
+      - polylogue/archive/query/plan.py
+      - polylogue/cli/query_actions.py
+      - polylogue/cli/query_output.py
     tests:
-      - tests/unit/core/test_filters_props.py
+      - tests/unit/cli/test_query_exec.py
+      - tests/unit/cli/test_query_exec_laws.py
+      - tests/unit/cli/test_query_fmt.py
     status: active
 
-  - name: models
-    description: Domain model mutation testing
+  - name: cli-run
+    description: >
+      Run command execution, display, and watch contracts
     paths_to_mutate:
-      - polylogue/types.py
-      - polylogue/archive/message/roles.py
-      - polylogue/core/timestamps.py
-      - polylogue/core/hashing.py
-      - polylogue/core/json.py
+      - polylogue/cli/commands/run.py
     tests:
-      - tests/unit/core/test_models.py
-      - tests/unit/core/test_message_laws.py
-      - tests/unit/core/test_hashing.py
-      - tests/unit/core/test_json.py
-      - tests/unit/core/test_timestamp_guards.py
-    status: active
-
-  - name: search
-    description: FTS5 and hybrid search mutation testing
-    paths_to_mutate:
-      - polylogue/storage/search_providers/fts5.py
-      - polylogue/storage/search_providers/hybrid.py
-    tests:
-      - tests/unit/storage/test_fts5.py
-      - tests/unit/storage/test_hybrid_laws.py
+      - tests/unit/cli/test_run.py
+      - tests/unit/cli/test_run_int.py
+      - tests/unit/cli/test_run_laws.py
     status: active
 
   - name: drive-client
-    description: Drive auth, transport, and parsing mutation testing
+    description: >
+      Drive auth, transport, JSON payload parsing, and ingest attachment contracts
     paths_to_mutate:
       - polylogue/sources/drive/source.py
       - polylogue/sources/drive/gateway.py
       - polylogue/sources/drive/auth.py
       - polylogue/sources/drive/__init__.py
     tests:
-      - tests/unit/sources/test_drive_auth.py
-      - tests/unit/sources/test_drive_gateway.py
-      - tests/unit/sources/test_drive_ops.py
       - tests/unit/sources/test_drive_source_client.py
+      - tests/unit/sources/test_drive_gateway.py
+      - tests/unit/sources/test_drive_auth.py
+      - tests/unit/sources/test_drive_ops.py
+    status: active
+
+  - name: filters
+    description: >
+      ConversationFilter semantics and summary/picker contracts
+    paths_to_mutate:
+      - polylogue/archive/filter/filters.py
+    tests:
+      - tests/unit/core/test_filters_schemas.py
+      - tests/unit/core/test_filters_props.py
+    status: active
+
+  - name: fts5
+    description: >
+      FTS5 query escaping and conversation search semantics
+    paths_to_mutate:
+      - polylogue/storage/search_providers/fts5.py
+    tests:
+      - tests/unit/storage/test_fts5.py
+    status: active
+
+  - name: hybrid
+    description: >
+      Hybrid search fusion and ranked-conversation resolution
+    paths_to_mutate:
+      - polylogue/storage/search_providers/hybrid.py
+    tests:
+      - tests/unit/storage/test_hybrid.py
+      - tests/unit/storage/test_hybrid_laws.py
+    status: active
+
+  - name: json
+    description: >
+      JSON serialization and parser laws
+    paths_to_mutate:
+      - polylogue/core/json.py
+    tests:
+      - tests/unit/core/test_json.py
+    status: active
+
+  - name: models
+    description: >
+      Message/Conversation semantic helpers and pairing logic
+    paths_to_mutate:
+      - polylogue/archive/models.py
+    tests:
+      - tests/unit/core/test_models.py
+      - tests/unit/core/test_message_laws.py
+      - tests/unit/core/test_conversation_semantics.py
+    status: active
+
+  - name: pipeline-services
+    description: >
+      Acquire/validate/parse planning and stage contracts
+    paths_to_mutate:
+      - polylogue/pipeline/services
+    tests:
+      - tests/unit/pipeline/test_acquisition_streams.py
+      - tests/unit/pipeline/test_parsing_service.py
+      - tests/unit/pipeline/test_render_service.py
+      - tests/unit/pipeline/test_indexing.py
+      - tests/unit/pipeline/test_ingest_batch.py
+      - tests/unit/pipeline/test_stage_independence.py
+      - tests/unit/pipeline/test_resilience.py
+    status: active
+
+  - name: provider-parsers
+    description: >
+      Provider parser semantic correctness where message extraction and compaction detection live
+    paths_to_mutate:
+      - polylogue/sources/parsers/chatgpt.py
+      - polylogue/sources/parsers/claude/code_parser.py
+      - polylogue/sources/parsers/codex.py
+      - polylogue/sources/parsers/claude/index.py
+      - polylogue/pipeline/semantic_capture.py
+    tests:
+      - tests/unit/sources/test_parsers_chatgpt.py
+      - tests/unit/sources/test_parsers_codex.py
+      - tests/unit/sources/test_parsers_props.py
+      - tests/unit/sources/test_parser_crashlessness.py
+      - tests/unit/sources/test_compaction.py
+      - tests/unit/sources/test_assembly.py
+    status: active
+
+  - name: providers-semantics
+    description: >
+      Provider semantic extraction, harmonization, and viewport contracts
+    paths_to_mutate:
+      - polylogue/sources/providers
+      - polylogue/schemas/registry.py
+    tests:
+      - tests/unit/sources/test_unified_semantic_laws.py
+      - tests/unit/sources/test_null_guard_properties.py
+      - tests/unit/sources/test_models.py
+      - tests/unit/sources/test_parsers_props.py
+      - tests/unit/sources/test_assembly.py
+    status: active
+
+  - name: repository
+    description: >
+      Repository query, projection, and CRUD contracts
+    paths_to_mutate:
+      - polylogue/storage/repository/__init__.py
+    tests:
+      - tests/unit/storage/test_store_ops.py
+      - tests/unit/storage/test_tree_laws.py
+    status: active
+
+  - name: schema-core
+    description: >
+      Schema generation, privacy, verification, and safety contracts
+    paths_to_mutate:
+      - polylogue/schemas/operator/schema_inference.py
+      - polylogue/schemas/validator.py
+      - polylogue/schemas/operator/verification.py
+    tests:
+      - tests/unit/core/test_schema_validation.py
+      - tests/unit/core/test_schema_generation.py
+      - tests/unit/core/test_schema_annotation_contracts.py
+      - tests/unit/core/test_schema_laws.py
+      - tests/unit/core/test_schema_privacy.py
+      - tests/unit/core/test_verification.py
+      - tests/unit/storage/test_schema_safety.py
+    status: active
+
+  - name: schema-inference
+    description: >
+      Schema inference and privacy heuristics
+    paths_to_mutate:
+      - polylogue/schemas/operator/schema_inference.py
+    tests:
+      - tests/unit/core/test_schema_generation.py
+      - tests/unit/core/test_schema_laws.py
+      - tests/unit/core/test_schema_privacy.py
+    status: active
+
+  - name: schema-validation
+    description: >
+      Schema validator and verification contracts
+    paths_to_mutate:
+      - polylogue/schemas/validator.py
+      - polylogue/schemas/operator/verification.py
+    tests:
+      - tests/unit/core/test_schema_validation.py
+      - tests/unit/core/test_schema_laws.py
+      - tests/unit/core/test_verification.py
+      - tests/unit/storage/test_schema_safety.py
+    status: active
+
+  - name: site-builder
+    description: >
+      Static-site builder and CLI archive contracts
+    paths_to_mutate:
+      - polylogue/site/builder.py
+    tests:
+      - tests/integration/test_site.py
+      - tests/integration/test_site_laws.py
+    status: active
+
+  - name: source-detection
+    description: >
+      Source detection, sniffing, and parser dispatch
+    paths_to_mutate:
+      - polylogue/sources/source_parsing.py
+      - polylogue/sources/source_acquisition.py
+      - polylogue/sources/dispatch.py
+      - polylogue/sources/decoders.py
+    tests:
+      - tests/unit/sources/test_source_laws.py
+      - tests/unit/sources/test_parsers_base.py
+      - tests/unit/sources/test_parsers_chatgpt.py
+      - tests/unit/sources/test_parsers_codex.py
+      - tests/unit/sources/test_parsers_props.py
+      - tests/unit/sources/test_parsers_drive.py
+    status: active
+
+  - name: sources-parse
+    description: >
+      Provider detection, parsing, harmonization, and parser laws
+    paths_to_mutate:
+      - polylogue/sources
+      - polylogue/schemas/registry.py
+    tests:
+      - tests/unit/sources/test_parsers_props.py
+      - tests/unit/sources/test_source_laws.py
+      - tests/unit/sources/test_unified_semantic_laws.py
+      - tests/unit/sources/test_parsers_base.py
+      - tests/unit/sources/test_parsers_chatgpt.py
+      - tests/unit/sources/test_parsers_codex.py
+      - tests/unit/sources/test_parsers_drive.py
+      - tests/unit/sources/test_drive_source_client.py
+      - tests/unit/sources/test_drive_gateway.py
+      - tests/unit/sources/test_drive_auth.py
+      - tests/unit/sources/test_drive_ops.py
+      - tests/unit/sources/test_null_guard_properties.py
+      - tests/unit/sources/test_models.py
+      - tests/unit/sources/test_token_store.py
+    status: active
+
+  - name: ui-core
+    description: >
+      UI prompt, progress, and facade interaction contracts
+    paths_to_mutate:
+      - polylogue/ui/__init__.py
+      - polylogue/ui/facade.py
+    tests:
+      - tests/unit/ui/test_ui.py
+      - tests/unit/ui/test_ui_visual.py
+      - tests/unit/ui/test_tui.py
     status: active
 
 benchmark_campaigns:
-  - name: search-filters
-    description: Filter chain query performance benchmarks
-    tests:
-      - tests/benchmarks/test_search_filters.py
-    status: active
-
   - name: pipeline
-    description: Pipeline throughput benchmarks
+    description: >
+      Index rebuild/update, action-event repair, plus hashing/semantic helper benchmark domain
     tests:
       - tests/benchmarks/test_pipeline.py
     status: active
 
-  - name: storage-scale
-    description: Storage scale benchmarks
+  - name: search-filters
+    description: >
+      FTS and ConversationFilter benchmark domain
+    tests:
+      - tests/benchmarks/test_search_filters.py
+    status: active
+
+  - name: storage
+    description: >
+      Repository/backend list/get-many/save benchmark domain
     tests:
       - tests/benchmarks/test_storage.py
     status: active

--- a/docs/verification-catalog.md
+++ b/docs/verification-catalog.md
@@ -8,10 +8,10 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 
 ## Snapshot
 
-- subjects: `502`
+- subjects: `517`
 - claims: `44`
 - runner bindings: `44`
-- proof obligations: `568`
+- proof obligations: `583`
 
 ## Quality Checks
 
@@ -38,7 +38,7 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | `archive.query_law` | 1 |
 | `artifact.path` | 27 |
 | `assurance.coverage_gap` | 23 |
-| `assurance.coverage_item` | 92 |
+| `assurance.coverage_item` | 107 |
 | `assurance.coverage_manifest` | 9 |
 | `cli.command` | 55 |
 | `cli.json_command` | 5 |
@@ -159,7 +159,7 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | `docs_media` | `assurance.coverage_item` | 17 |
 | `docs_media` | `assurance.coverage_manifest` | 1 |
 | `migration_safety` | `assurance.coverage_gap` | 1 |
-| `mutation_coverage` | `assurance.coverage_item` | 4 |
+| `mutation_coverage` | `assurance.coverage_item` | 19 |
 | `mutation_coverage` | `assurance.coverage_manifest` | 1 |
 | `operational_resilience` | `assurance.coverage_item` | 1 |
 | `performance` | `assurance.coverage_gap` | 1 |
@@ -290,7 +290,7 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | `archive.query.provider_filter_consistency` | 1 |
 | `artifact.path.dependency_closure` | 11 |
 | `assurance.coverage.gap_has_closure_path` | 23 |
-| `assurance.coverage.item_declared` | 92 |
+| `assurance.coverage.item_declared` | 107 |
 | `assurance.coverage.manifest_structured` | 9 |
 | `cli.command.help` | 55 |
 | `cli.command.json_envelope` | 5 |

--- a/tests/unit/devtools/test_verify_manifests.py
+++ b/tests/unit/devtools/test_verify_manifests.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
+
+from pytest import MonkeyPatch
 
 from devtools import verify_manifests
 
@@ -223,4 +226,110 @@ def test_coverage_status_claims_reject_missing_item_with_realized_evidence(tmp_p
         f"{plans / 'example-coverage.yaml'}: areas.dependency_audit implemented=false but controls are declared",
         f"{plans / 'example-coverage.yaml'}: areas.dependency_audit implemented=false "
         "but test_coverage.location is declared",
+    ]
+
+
+def test_campaign_coverage_catalog_accepts_authored_catalog(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    plans = tmp_path
+    monkeypatch.setattr(
+        verify_manifests,
+        "get_authored_scenario_catalog",
+        lambda: SimpleNamespace(
+            mutation_campaigns=(
+                SimpleNamespace(
+                    name="filters",
+                    description="Filter campaign",
+                    paths_to_mutate=("polylogue/archive/filter/filters.py",),
+                    tests=("tests/unit/core/test_filters_props.py",),
+                ),
+            ),
+            benchmark_campaigns=(
+                SimpleNamespace(
+                    name="storage",
+                    description="Storage benchmarks",
+                    tests=("tests/benchmarks/test_storage.py",),
+                ),
+            ),
+        ),
+    )
+    (plans / "campaign-coverage.yaml").write_text(
+        """mutation_campaigns:
+  - name: filters
+    description: Filter campaign
+    paths_to_mutate:
+      - polylogue/archive/filter/filters.py
+    tests:
+      - tests/unit/core/test_filters_props.py
+    status: active
+
+benchmark_campaigns:
+  - name: storage
+    description: Storage benchmarks
+    tests:
+      - tests/benchmarks/test_storage.py
+    status: active
+""",
+        encoding="utf-8",
+    )
+
+    assert verify_manifests.check_campaign_coverage_catalog(plans) == []
+
+
+def test_campaign_coverage_catalog_rejects_stale_manifest(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    plans = tmp_path
+    monkeypatch.setattr(
+        verify_manifests,
+        "get_authored_scenario_catalog",
+        lambda: SimpleNamespace(
+            mutation_campaigns=(
+                SimpleNamespace(
+                    name="filters",
+                    description="Filter campaign",
+                    paths_to_mutate=("polylogue/archive/filter/filters.py",),
+                    tests=("tests/unit/core/test_filters_props.py",),
+                ),
+            ),
+            benchmark_campaigns=(
+                SimpleNamespace(
+                    name="storage",
+                    description="Storage benchmarks",
+                    tests=("tests/benchmarks/test_storage.py",),
+                ),
+            ),
+        ),
+    )
+    (plans / "campaign-coverage.yaml").write_text(
+        """mutation_campaigns:
+  - name: filters
+    description: Old filter campaign
+    paths_to_mutate:
+      - polylogue/archive/filter/old_filters.py
+    tests:
+      - tests/unit/core/test_filters_props.py
+    status: active
+
+benchmark_campaigns:
+  - name: storage-scale
+    description: Storage benchmarks
+    tests:
+      - tests/benchmarks/test_storage.py
+    status: active
+""",
+        encoding="utf-8",
+    )
+
+    errors = verify_manifests.check_campaign_coverage_catalog(plans)
+
+    assert errors == [
+        f"{plans / 'campaign-coverage.yaml'}: mutation_campaigns['filters'] paths_to_mutate does not match "
+        "authored catalog (expected ('polylogue/archive/filter/filters.py',), "
+        "got ('polylogue/archive/filter/old_filters.py',))",
+        f"{plans / 'campaign-coverage.yaml'}: benchmark_campaigns missing catalog campaign 'storage'",
+        f"{plans / 'campaign-coverage.yaml'}: benchmark_campaigns declares unknown campaign 'storage-scale'",
     ]


### PR DESCRIPTION
## Summary
Make `docs/plans/campaign-coverage.yaml` executable against the authored mutation and benchmark campaign catalog.

## Problem
The campaign coverage manifest was still partly passive: it listed a small hand-maintained subset of mutation and benchmark campaigns, so the manifest could drift away from the authored scenario catalog while still passing generic YAML/reference checks.

## Solution
`devtools verify-manifests` now compares the campaign coverage manifest against `devtools.authored_scenario_catalog` for campaign names, active status, mutation paths, and test lists. The committed campaign coverage manifest was refreshed from the authored catalog, and unit tests cover both matching and stale manifests.

## Verification
- `devtools verify-manifests` → passed
- `pytest -q tests/unit/devtools/test_verify_manifests.py` → 12 passed
- `devtools render-all --check` → passed
- `devtools proof-pack --path devtools/verify_manifests.py --path tests/unit/devtools/test_verify_manifests.py --path docs/plans/campaign-coverage.yaml --path docs/verification-catalog.md --markdown --check` → passed
- `devtools verify --quick` → all checks passed

Ref #594