### PR TITLE
fix(storage): block schema version mismatch

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -115,7 +115,8 @@ The `all` pipeline stage runs: acquire → parse → materialize → render → 
 
 - Single SQLite file, WAL mode.
 - Schema is fresh-only: no migration chain. On version mismatch the database is
-  wiped and rebuilt. `SCHEMA_VERSION` lives in `storage/backends/schema_ddl.py`.
+  rejected with a reset/re-import diagnostic rather than patched in place.
+  `SCHEMA_VERSION` lives in `storage/backends/schema_ddl.py`.
 - FTS5 with `unicode61` tokenizer (no porter stemmer in this SQLite build).
 
 ## Placement Rules

--- a/docs/plans/assurance-domains.yaml
+++ b/docs/plans/assurance-domains.yaml
@@ -193,7 +193,8 @@ domains:
     oracle_present: false
     oracle: null
     notes: >
-      Schema is fresh-only (no migration chain). Wipe-on-mismatch.
+      Schema is fresh-only (no migration chain). Mismatch blocks with a
+      reset/re-import diagnostic rather than attempting in-place migration.
       Active transition checks can use docs/plans/migrations.yaml while
       work is in flight, but completed retirements are not durable proof.
 

--- a/polylogue/pipeline/materialization_runtime.py
+++ b/polylogue/pipeline/materialization_runtime.py
@@ -14,6 +14,7 @@ from polylogue.archive.message.types import MessageType
 from polylogue.archive.viewport.viewports import ToolCategory, classify_tool
 from polylogue.core.json import JSONDocument, json_document
 from polylogue.core.json import dumps as json_dumps
+from polylogue.core.timestamps import parse_timestamp
 from polylogue.pipeline.ids import (
     attachment_content_id,
     conversation_content_hash,
@@ -120,17 +121,10 @@ def _timestamp_sort_key(ts: str | None) -> float | None:
         return value
     except (ValueError, TypeError):
         pass
-
-    from datetime import datetime, timezone
-
-    try:
-        normalized = ts.replace("Z", "+00:00")
-        dt = datetime.fromisoformat(normalized)
-        if dt.tzinfo is None:
-            dt = dt.replace(tzinfo=timezone.utc)
-        return dt.timestamp()
-    except (ValueError, TypeError):
-        return None
+    parsed = parse_timestamp(ts)
+    if parsed is not None:
+        return parsed.timestamp()
+    return None
 
 
 def _merged_conversation_provider_meta(

--- a/polylogue/sources/parsers/chatgpt.py
+++ b/polylogue/sources/parsers/chatgpt.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 
 from polylogue.archive.message.roles import Role
+from polylogue.core.timestamps import parse_timestamp
 from polylogue.types import ContentBlockType, Provider
 
 from .base import ParsedAttachment, ParsedContentBlock, ParsedConversation, ParsedMessage
@@ -17,8 +18,11 @@ def _coerce_float(value: object) -> float | None:
     if isinstance(value, str):
         try:
             return float(value)
-        except ValueError:
-            return None
+        except (ValueError, TypeError):
+            pass
+        parsed = parse_timestamp(value)
+        if parsed is not None:
+            return parsed.timestamp()
     return None
 
 

--- a/polylogue/storage/backends/connection.py
+++ b/polylogue/storage/backends/connection.py
@@ -24,7 +24,7 @@ from polylogue.storage.backends.connection_profile import (
     WRITE_CONNECTION_PRAGMA_STATEMENTS,
     WRITE_MMAP_SIZE_BYTES,
 )
-from polylogue.storage.backends.schema import _ensure_schema
+from polylogue.storage.backends.schema import _ensure_schema, assert_readable_archive_layout
 from polylogue.storage.backends.sqlite_vec_extension import try_load_sqlite_vec
 
 if TYPE_CHECKING:
@@ -165,6 +165,7 @@ def open_read_connection(db_path: Path | str | None = None) -> Iterator[sqlite3.
     conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True, timeout=READ_DB_TIMEOUT)
     _configure_read_connection(conn)
     try:
+        assert_readable_archive_layout(conn)
         yield conn
     finally:
         conn.close()

--- a/polylogue/storage/backends/schema.py
+++ b/polylogue/storage/backends/schema.py
@@ -6,6 +6,7 @@ import sqlite3
 
 import aiosqlite
 
+from polylogue.errors import DatabaseError
 from polylogue.logging import get_logger
 from polylogue.storage.backends.schema_bootstrap import (
     SCHEMA_DDL,
@@ -21,8 +22,7 @@ from polylogue.storage.backends.schema_bootstrap import (
     decide_schema_bootstrap,
     ensure_vec0_table,
     ensure_vec0_table_async,
-    export_user_metadata,
-    import_user_metadata,
+    schema_version_mismatch_message,
 )
 
 logger = get_logger(__name__)
@@ -39,6 +39,15 @@ def _ensure_raw_source_mtime_index(conn: sqlite3.Connection) -> None:
 def assert_supported_archive_layout(conn: sqlite3.Connection) -> None:
     """Reject legacy archive layouts that the current runtime cannot write safely."""
     assert_supported_archive_layout_snapshot(capture_schema_snapshot(conn))
+
+
+def assert_readable_archive_layout(conn: sqlite3.Connection) -> None:
+    """Reject archive layouts that cannot be interpreted safely in read-only mode."""
+    snapshot = capture_schema_snapshot(conn)
+    assert_supported_archive_layout_snapshot(snapshot)
+
+    if snapshot.current_version != SCHEMA_VERSION:
+        raise DatabaseError(schema_version_mismatch_message(snapshot.current_version))
 
 
 def _log_index_replacement(snapshot: SchemaSnapshot, plan: SchemaExtensionPlan) -> None:
@@ -80,9 +89,8 @@ def apply_current_schema_extensions(conn: sqlite3.Connection) -> None:
 def _ensure_schema(conn: sqlite3.Connection) -> None:
     """Ensure the database is at the current schema version.
 
-    When the schema version has changed, user metadata (tags, summaries)
-    is preserved across the wipe. Conversation data must be re-imported
-    via ``polylogue run``.
+    Polylogue has no versioned migration chain. Databases with a mismatched
+    schema version are rejected rather than partially patched with additive DDL.
     """
     snapshot = capture_schema_snapshot(conn)
 
@@ -98,65 +106,18 @@ def _ensure_schema(conn: sqlite3.Connection) -> None:
         return
 
     if decision.action == "version_mismatch":
-        _handle_version_mismatch(conn, decision.current_version or 0)
+        raise DatabaseError(schema_version_mismatch_message(decision.current_version or 0))
         return
 
     if decision.extension_plan is not None:
         _apply_extensions_for_plan(conn, snapshot, decision.extension_plan)
 
 
-def _handle_version_mismatch(conn: sqlite3.Connection, current_version: int) -> None:
-    """Preserve user metadata across a schema version bump.
-
-    Exports tags and summaries from the old-schema database, recreates
-    with the current schema, and restores what was saved. Conversation
-    data (messages, content blocks, FTS indexes, vectors) is not preserved
-    and must be re-imported.
-    """
-    logger.warning(
-        "Schema version mismatch: db=%s, expected=%s. Preserving user metadata.",
-        current_version,
-        SCHEMA_VERSION,
-    )
-
-    metadata = export_user_metadata(conn)
-    tags = metadata.get("tags")
-    summaries = metadata.get("summaries")
-    tag_list: list[object] = tags if isinstance(tags, list) else []
-    summary_list: list[object] = summaries if isinstance(summaries, list) else []
-
-    if tag_list or summary_list:
-        logger.info(
-            "Exported user metadata: %s tags, %s summaries",
-            len(tag_list),
-            len(summary_list),
-        )
-
-    conn.execute("PRAGMA foreign_keys = ON")
-    conn.executescript(SCHEMA_DDL)
-    ensure_vec0_table(conn)
-    conn.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
-    conn.commit()
-
-    if tag_list or summary_list:
-        restored = import_user_metadata(conn, metadata)
-        conn.commit()
-        logger.info("Restored %s user metadata rows", restored)
-
-    logger.warning(
-        "Schema upgraded from v%s to v%s. User metadata preserved; "
-        "conversation data must be re-imported: polylogue run",
-        current_version,
-        SCHEMA_VERSION,
-    )
-
-
 async def ensure_schema_async(conn: aiosqlite.Connection) -> None:
     """Ensure the database is at the current schema version.
 
-    When the schema version has changed, user metadata (tags, summaries)
-    is preserved across the wipe. Conversation data must be re-imported
-    via ``polylogue run``.
+    Polylogue has no versioned migration chain. Databases with a mismatched
+    schema version are rejected rather than partially patched with additive DDL.
     """
     snapshot = await capture_schema_snapshot_async(conn)
 
@@ -171,96 +132,11 @@ async def ensure_schema_async(conn: aiosqlite.Connection) -> None:
         return
 
     if decision.action == "version_mismatch":
-        await _handle_version_mismatch_async(conn, decision.current_version or 0)
+        raise DatabaseError(schema_version_mismatch_message(decision.current_version or 0))
         return
 
     if decision.extension_plan is not None:
         await _apply_extensions_for_plan_async(conn, snapshot, decision.extension_plan)
-
-
-async def _handle_version_mismatch_async(conn: aiosqlite.Connection, current_version: int) -> None:
-    """Preserve user metadata across a schema version bump (async variant).
-
-    Exports tags and summaries before the wipe using the async connection,
-    recreates the schema, then restores metadata through the same connection.
-    """
-    logger.warning(
-        "Schema version mismatch: db=%s, expected=%s. Preserving user metadata.",
-        current_version,
-        SCHEMA_VERSION,
-    )
-
-    tags: list[dict[str, object]] = []
-    summaries: list[dict[str, object]] = []
-
-    try:
-        cursor = await conn.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name='conversation_tags'")
-        if await cursor.fetchone():
-            cursor = await conn.execute(
-                "SELECT conversation_id, tag FROM conversation_tags ORDER BY conversation_id, tag"
-            )
-            rows = await cursor.fetchall()
-            tags = [{"conversation_id": r[0], "tag": r[1]} for r in rows]
-    except Exception:
-        logger.warning("Failed to export tags", exc_info=True)
-
-    try:
-        cursor = await conn.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name='conversations'")
-        if await cursor.fetchone():
-            cursor = await conn.execute(
-                "SELECT conversation_id, summary FROM conversations WHERE summary IS NOT NULL AND summary != ''"
-            )
-            rows = await cursor.fetchall()
-            summaries = [{"conversation_id": r[0], "summary": r[1]} for r in rows]
-    except Exception:
-        logger.warning("Failed to export summaries", exc_info=True)
-
-    if tags or summaries:
-        logger.info("Exported user metadata: %s tags, %s summaries", len(tags), len(summaries))
-
-    await conn.execute("PRAGMA foreign_keys = ON")
-    await conn.executescript(SCHEMA_DDL)
-    await ensure_vec0_table_async(conn)
-    await conn.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
-    await conn.commit()
-
-    restored = 0
-    for tag_entry in tags:
-        cid = tag_entry.get("conversation_id")
-        tag = tag_entry.get("tag")
-        if cid and tag:
-            try:
-                await conn.execute(
-                    "INSERT OR IGNORE INTO conversation_tags (conversation_id, tag) VALUES (?, ?)",
-                    (cid, tag),
-                )
-                restored += 1
-            except Exception:
-                pass
-
-    for summary_entry in summaries:
-        cid = summary_entry.get("conversation_id")
-        summary = summary_entry.get("summary")
-        if cid and summary:
-            try:
-                await conn.execute(
-                    "UPDATE conversations SET summary = ? WHERE conversation_id = ?",
-                    (summary, cid),
-                )
-                restored += 1
-            except Exception:
-                pass
-
-    if restored:
-        await conn.commit()
-        logger.info("Restored %s user metadata rows", restored)
-
-    logger.warning(
-        "Schema upgraded from v%s to v%s. User metadata preserved; "
-        "conversation data must be re-imported: polylogue run",
-        current_version,
-        SCHEMA_VERSION,
-    )
 
 
 __all__ = [
@@ -269,6 +145,7 @@ __all__ = [
     "_ensure_raw_source_mtime_index",
     "_ensure_schema",
     "apply_current_schema_extensions",
+    "assert_readable_archive_layout",
     "assert_supported_archive_layout",
     "ensure_schema_async",
     "ensure_vec0_table",

--- a/polylogue/storage/backends/schema_bootstrap.py
+++ b/polylogue/storage/backends/schema_bootstrap.py
@@ -539,7 +539,8 @@ def schema_extension_snapshot_indexes() -> tuple[str, ...]:
 def schema_version_mismatch_message(current_version: int) -> str:
     return (
         f"Database schema version {current_version} is incompatible with expected version {SCHEMA_VERSION}. "
-        "Delete the database and re-import: `polylogue reset --database && polylogue run`."
+        "Polylogue does not migrate older archive schemas in place. Move the database aside or rebuild it with "
+        "`polylogue reset --database && polylogue run`."
     )
 
 
@@ -682,89 +683,6 @@ async def ensure_vec0_table_async(conn: aiosqlite.Connection) -> None:
         )
 
 
-def export_user_metadata(conn: sqlite3.Connection) -> dict[str, object]:
-    """Export user-authored metadata from an old-schema database.
-
-    Returns a dict safe for JSON serialization containing tags,
-    summaries, and other user-editable fields that should survive
-    a schema version bump. Excludes derived/auto-generated content.
-    """
-    metadata: dict[str, object] = {"tags": [], "summaries": []}
-
-    try:
-        if _table_exists(conn, "conversation_tags"):
-            rows = conn.execute(
-                "SELECT conversation_id, tag FROM conversation_tags ORDER BY conversation_id, tag"
-            ).fetchall()
-            metadata["tags"] = [{"conversation_id": r[0], "tag": r[1]} for r in rows]
-    except Exception:
-        logger.warning("Failed to export tags", exc_info=True)
-
-    try:
-        if _table_exists(conn, "conversations"):
-            rows = conn.execute(
-                "SELECT conversation_id, summary FROM conversations WHERE summary IS NOT NULL AND summary != ''"
-            ).fetchall()
-            metadata["summaries"] = [{"conversation_id": r[0], "summary": r[1]} for r in rows]
-    except Exception:
-        logger.warning("Failed to export summaries", exc_info=True)
-
-    return metadata
-
-
-def import_user_metadata(conn: sqlite3.Connection, metadata: dict[str, object]) -> int:
-    """Restore user metadata into a freshly-created database.
-
-    Returns the number of rows restored. Safe to call when the
-    metadata dict is empty or tables are missing — silently skips.
-    """
-    restored = 0
-
-    tags = metadata.get("tags")
-    if isinstance(tags, list):
-        for tag_entry in tags:
-            if not isinstance(tag_entry, dict):
-                continue
-            cid = tag_entry.get("conversation_id")
-            tag = tag_entry.get("tag")
-            if cid and tag:
-                try:
-                    conn.execute(
-                        "INSERT OR IGNORE INTO conversation_tags (conversation_id, tag) VALUES (?, ?)",
-                        (cid, tag),
-                    )
-                    restored += 1
-                except Exception:
-                    pass
-
-    summaries = metadata.get("summaries")
-    if isinstance(summaries, list):
-        for summary_entry in summaries:
-            if not isinstance(summary_entry, dict):
-                continue
-            cid = summary_entry.get("conversation_id")
-            summary = summary_entry.get("summary")
-            if cid and summary:
-                try:
-                    conn.execute(
-                        "UPDATE conversations SET summary = ? WHERE conversation_id = ?",
-                        (summary, cid),
-                    )
-                    restored += 1
-                except Exception:
-                    pass
-
-    return restored
-
-
-def _table_exists(conn: sqlite3.Connection, table_name: str) -> bool:
-    row = conn.execute(
-        "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?",
-        (table_name,),
-    ).fetchone()
-    return row is not None
-
-
 __all__ = [
     "SCHEMA_DDL",
     "SCHEMA_VERSION",
@@ -782,8 +700,6 @@ __all__ = [
     "capture_schema_snapshot",
     "capture_schema_snapshot_async",
     "decide_schema_bootstrap",
-    "export_user_metadata",
-    "import_user_metadata",
     "ensure_vec0_table",
     "ensure_vec0_table_async",
     "schema_extension_snapshot_indexes",

--- a/tests/unit/pipeline/test_materialization_runtime.py
+++ b/tests/unit/pipeline/test_materialization_runtime.py
@@ -1,0 +1,13 @@
+"""Tests for shared conversation materialization helpers."""
+
+from __future__ import annotations
+
+from polylogue.pipeline.materialization_runtime import _timestamp_sort_key
+
+
+def test_timestamp_sort_key_accepts_iso_datetime() -> None:
+    assert _timestamp_sort_key("2024-01-15T10:30:00Z") == 1705314600.0
+
+
+def test_timestamp_sort_key_normalizes_millisecond_epoch() -> None:
+    assert _timestamp_sort_key("1705314600000") == 1705314600.0

--- a/tests/unit/sources/test_parsers_chatgpt.py
+++ b/tests/unit/sources/test_parsers_chatgpt.py
@@ -69,6 +69,7 @@ COERCE_FLOAT_CASES: list[CoerceFloatCase] = [
     (42, 42.0, "int"),
     (3.14, 3.14, "float"),
     ("2.5", 2.5, "string number"),
+    ("2024-01-15T10:30:00Z", 1705314600.0, "ISO datetime string"),
     ("invalid", None, "invalid string"),
     (None, None, "None"),
 ]
@@ -79,6 +80,33 @@ def test_coerce_float(input_val: object, expected: float | None, desc: str) -> N
     """Test _coerce_float conversion."""
     result = _coerce_float(input_val)
     assert result == expected, f"Failed {desc}"
+
+
+def test_chatgpt_message_extraction_sorts_iso_timestamps() -> None:
+    mapping = {
+        "late": {
+            "id": "late",
+            "message": {
+                "id": "late",
+                "author": {"role": "assistant"},
+                "content": {"parts": ["later"]},
+                "create_time": "2024-01-15T10:31:00Z",
+            },
+        },
+        "early": {
+            "id": "early",
+            "message": {
+                "id": "early",
+                "author": {"role": "user"},
+                "content": {"parts": ["earlier"]},
+                "create_time": "2024-01-15T10:30:00Z",
+            },
+        },
+    }
+
+    messages, _attachments = extract_messages_from_mapping(mapping)
+
+    assert [message.provider_message_id for message in messages] == ["early", "late"]
 
 
 # MESSAGE EXTRACTION - PARAMETRIZED (1 test replacing 17)

--- a/tests/unit/storage/test_backend.py
+++ b/tests/unit/storage/test_backend.py
@@ -16,6 +16,7 @@ import pytest
 
 import polylogue.paths
 from polylogue.archive.message.roles import Role
+from polylogue.errors import DatabaseError
 from polylogue.storage.backends.async_sqlite import SQLiteBackend
 from polylogue.storage.backends.connection import connection_context, open_connection, open_read_connection
 from polylogue.storage.backends.connection_profile import (
@@ -98,20 +99,30 @@ def test_ensure_schema_contract(tmp_path: Path) -> None:
     conn.close()
 
 
-def test_ensure_schema_upgrades_version_with_metadata_preservation(tmp_path: Path) -> None:
-    """Version mismatch preserves user metadata and upgrades the schema."""
+def test_ensure_schema_rejects_version_mismatch_without_mutating(tmp_path: Path) -> None:
+    """Version mismatch fails clearly instead of partially patching old layouts."""
     db_path = tmp_path / "test.db"
     conn = sqlite3.connect(db_path)
-    conn.execute("PRAGMA user_version = 999")
+    conn.executescript(
+        """
+        CREATE TABLE raw_conversations (
+            raw_id TEXT PRIMARY KEY,
+            provider_name TEXT NOT NULL,
+            source_path TEXT NOT NULL,
+            blob_size INTEGER NOT NULL,
+            acquired_at TEXT NOT NULL
+        );
+        PRAGMA user_version = 2;
+        """
+    )
     conn.commit()
 
-    _ensure_schema(conn)
+    with pytest.raises(DatabaseError) as exc_info:
+        _ensure_schema(conn)
 
-    version = conn.execute("PRAGMA user_version").fetchone()[0]
-    assert version == SCHEMA_VERSION
-    assert (
-        conn.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name='conversations'").fetchone() is not None
-    )
+    assert "does not migrate older archive schemas in place" in str(exc_info.value)
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == 2
+    assert conn.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name='messages'").fetchone() is None
     conn.close()
 
 
@@ -234,8 +245,8 @@ def test_schema_extension_plan_expands_catalog_descriptors() -> None:
     assert len(plan.scripts) == 5
 
 
-def test_ensure_schema_adds_blob_size_to_legacy_v1_raw_table(tmp_path: Path) -> None:
-    """Legacy v1 databases without blob_size should be extended in place."""
+def test_ensure_schema_rejects_old_raw_table_version_without_mutating(tmp_path: Path) -> None:
+    """Old-version raw tables are blocked instead of being partially patched."""
     db_path = tmp_path / "legacy-v1.db"
     conn = sqlite3.connect(db_path)
     conn.row_factory = sqlite3.Row
@@ -265,10 +276,12 @@ def test_ensure_schema_adds_blob_size_to_legacy_v1_raw_table(tmp_path: Path) -> 
     )
     conn.commit()
 
-    _ensure_schema(conn)
+    with pytest.raises(DatabaseError) as exc_info:
+        _ensure_schema(conn)
 
-    raw_columns = {row[1] for row in conn.execute("PRAGMA table_info(raw_conversations)").fetchall()}
-    assert "blob_size" in raw_columns
+    assert "does not migrate older archive schemas in place" in str(exc_info.value)
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == 2
+    assert conn.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name='messages'").fetchone() is None
     conn.close()
 
 
@@ -369,6 +382,37 @@ def test_open_read_connection_contract(tmp_path: Path) -> None:
         with pytest.raises(sqlite3.OperationalError):
             conn.execute("INSERT INTO sentinel(value) VALUES (2)")
             conn.commit()
+
+
+def test_open_read_connection_rejects_old_schema_without_mutating(tmp_path: Path) -> None:
+    """Read-only opens should report incompatible schemas before later SQL fails."""
+    db_path = tmp_path / "old-readonly.db"
+    conn = sqlite3.connect(db_path)
+    conn.executescript(
+        """
+        CREATE TABLE raw_conversations (
+            raw_id TEXT PRIMARY KEY,
+            provider_name TEXT NOT NULL,
+            source_path TEXT NOT NULL,
+            blob_size INTEGER NOT NULL,
+            acquired_at TEXT NOT NULL
+        );
+        PRAGMA user_version = 2;
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    with pytest.raises(DatabaseError) as exc_info:
+        with open_read_connection(db_path):
+            pass
+
+    assert "does not migrate older archive schemas in place" in str(exc_info.value)
+    with sqlite3.connect(db_path) as verify_conn:
+        assert verify_conn.execute("PRAGMA user_version").fetchone()[0] == 2
+        assert (
+            verify_conn.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name='messages'").fetchone() is None
+        )
 
 
 @pytest.mark.slow
@@ -515,8 +559,8 @@ async def test_async_backend_schema_and_lock_contracts(tmp_path: Path) -> None:
     assert all(result is None for result in results)
 
 
-async def test_async_backend_extends_legacy_v1_raw_table(tmp_path: Path) -> None:
-    """Async backend init should repair legacy v1 raw tables before writes."""
+async def test_async_backend_rejects_old_raw_table_version(tmp_path: Path) -> None:
+    """Async backend init should not silently patch old-version raw tables."""
     db_path = tmp_path / "legacy-v1-async.db"
     conn = sqlite3.connect(db_path)
     conn.executescript(
@@ -547,32 +591,22 @@ async def test_async_backend_extends_legacy_v1_raw_table(tmp_path: Path) -> None
     conn.close()
 
     backend = SQLiteBackend(db_path=db_path)
-    await backend.save_raw_conversation(
-        make_raw_conversation(
-            raw_id="raw-legacy",
-            provider_name="chatgpt",
-            source_path="/tmp/legacy.json",
-            blob_size=123,
-            acquired_at=datetime.now(timezone.utc).isoformat(),
+    with pytest.raises(DatabaseError) as exc_info:
+        await backend.save_raw_conversation(
+            make_raw_conversation(
+                raw_id="raw-legacy",
+                provider_name="chatgpt",
+                source_path="/tmp/legacy.json",
+                blob_size=123,
+                acquired_at=datetime.now(timezone.utc).isoformat(),
+            )
         )
-    )
+
+    assert "does not migrate older archive schemas in place" in str(exc_info.value)
 
     with sqlite3.connect(db_path) as verify_conn:
-        columns = {row[1] for row in verify_conn.execute("PRAGMA table_info(raw_conversations)").fetchall()}
-        row = verify_conn.execute(
-            "SELECT blob_size FROM raw_conversations WHERE raw_id = ?",
-            ("raw-legacy",),
-        ).fetchone()
-        index_row = verify_conn.execute(
-            "SELECT sql FROM sqlite_master WHERE type='index' AND name='idx_raw_conv_source_mtime'"
-        ).fetchone()
-
-    assert "blob_size" in columns
-    assert row is not None
-    assert row[0] == 123
-    assert index_row is not None
-    assert index_row[0] is not None
-    assert "WHERE file_mtime IS NOT NULL" in index_row[0]
+        assert verify_conn.execute("PRAGMA user_version").fetchone()[0] == 2
+        assert verify_conn.execute("SELECT COUNT(*) FROM raw_conversations").fetchone()[0] == 0
     await backend.close()
 
 


### PR DESCRIPTION
## Summary

Make mismatched archive schema versions fail explicitly instead of pretending to recreate or migrate legacy layouts, and incorporate timestamp parsing fixes left in the worktree by another agent.

## Problem

#618 identified that the version-mismatch path claimed to preserve metadata and recreate the database, but the implementation only reran additive `CREATE ... IF NOT EXISTS` DDL. That could leave old table shapes in place while setting `PRAGMA user_version` to the current schema. Read-only opens also skipped compatibility checks, so old databases could fail later with unclear SQL errors.

Separately, another agent had started replacing local timestamp parsing in materialization and ChatGPT ordering with the shared timestamp parser. Those edits were present in the worktree but needed cleanup and coverage.

## Solution

- Reject schema-version mismatches in sync and async schema setup with the reset/re-import diagnostic.
- Add a non-mutating read-only compatibility check so `open_read_connection()` fails clearly on mismatched versions or known legacy inline raw layouts.
- Remove the unused metadata export/import recreate path tied to the misleading in-place upgrade story.
- Update architecture and assurance text to say mismatches block rather than wipe or migrate.
- Finish the materialization timestamp fix by routing non-numeric sort-key parsing through `parse_timestamp()` and covering ISO datetime plus millisecond epoch behavior.
- Finish the ChatGPT parser timestamp fix so ISO `create_time` values participate in message ordering, with parser-level coverage.

## Verification

- `ruff check polylogue/storage/backends/schema.py polylogue/storage/backends/schema_bootstrap.py polylogue/storage/backends/connection.py polylogue/pipeline/materialization_runtime.py tests/unit/storage/test_backend.py tests/unit/pipeline/test_materialization_runtime.py`
- `ruff format --check polylogue/storage/backends/schema.py polylogue/storage/backends/schema_bootstrap.py polylogue/storage/backends/connection.py polylogue/pipeline/materialization_runtime.py tests/unit/storage/test_backend.py tests/unit/pipeline/test_materialization_runtime.py`
- `pytest -q tests/unit/storage/test_backend.py tests/unit/pipeline/test_materialization_runtime.py`
- `ruff check polylogue/sources/parsers/chatgpt.py tests/unit/sources/test_parsers_chatgpt.py`
- `ruff format --check polylogue/sources/parsers/chatgpt.py tests/unit/sources/test_parsers_chatgpt.py`
- `pytest -q tests/unit/sources/test_parsers_chatgpt.py tests/unit/pipeline/test_materialization_runtime.py`
- `devtools verify-manifests`
- `devtools render-all --check`
- `git push` pre-push hook: `devtools verify --quick` passed

Ref #618