### PR TITLE
fix(query): reject invalid date filters

### DIFF
--- a/polylogue/storage/backends/queries/filter_builder.py
+++ b/polylogue/storage/backends/queries/filter_builder.py
@@ -18,10 +18,11 @@ def _iso_to_epoch(iso_str: str) -> float:
     try:
         return datetime.fromisoformat(iso_str).timestamp()
     except (ValueError, TypeError):
-        try:
-            return float(iso_str)
-        except (ValueError, TypeError):
-            return 0.0
+        pass
+    try:
+        return float(iso_str)
+    except (ValueError, TypeError):
+        raise ValueError(f"Invalid date filter value {iso_str!r}. Use ISO 8601 format (e.g., 2026-01-01).") from None
 
 
 def _build_conversation_filters(

--- a/tests/unit/storage/test_schema_safety.py
+++ b/tests/unit/storage/test_schema_safety.py
@@ -413,6 +413,20 @@ class TestConversationFilterSQL:
         # The special chars should be in params, not embedded in SQL
         assert len(params) > 0
 
+    def test_build_filters_rejects_invalid_since_filter(self) -> None:
+        """Invalid date filters should not silently broaden to epoch zero."""
+        from polylogue.storage.backends.queries.filter_builder import _build_conversation_filters
+
+        with pytest.raises(ValueError, match="Invalid date filter value"):
+            _build_conversation_filters(since="not-a-date")
+
+    def test_build_filters_rejects_invalid_until_filter(self) -> None:
+        """Invalid date filters should not silently broaden to epoch zero."""
+        from polylogue.storage.backends.queries.filter_builder import _build_conversation_filters
+
+        with pytest.raises(ValueError, match="Invalid date filter value"):
+            _build_conversation_filters(until="not-a-date")
+
 
 # =============================================================================
 # SQL: fetch_limit pagination correctness (f6896a9)


### PR DESCRIPTION
## Summary

Make storage-level `since`/`until` filter pushdown reject malformed date values instead of silently treating them as epoch zero.

## Problem

The low-level conversation filter builder converted invalid date strings to `0.0`. A malformed `since`/`until` value could therefore broaden to a near-unbounded query and look like a successful filter.

## Solution

After ISO and numeric parsing both fail, `_iso_to_epoch()` now raises `ValueError` with a format hint. Storage filter tests cover both `since` and `until`.

## Verification

- `ruff check polylogue/storage/backends/queries/filter_builder.py tests/unit/storage/test_schema_safety.py`
- `ruff format --check polylogue/storage/backends/queries/filter_builder.py tests/unit/storage/test_schema_safety.py`
- `pytest -q tests/unit/storage/test_schema_safety.py::TestConversationFilterSQL`
- `git push` pre-push hook: `devtools verify --quick` passed

Ref #621