### PR TITLE
fix(acquisition): harden live freshness and reparse writes

### DIFF
--- a/polylogue/pipeline/services/acquisition_streams.py
+++ b/polylogue/pipeline/services/acquisition_streams.py
@@ -80,9 +80,18 @@ async def iter_drive_raw_stream(
     ui: DriveUILike | None = None,
     cursor_state: CursorStatePayload | None = None,
     drive_config: DriveConfigLike | None = None,
+    observation_callback: ObservationCallback | None = None,
+    progress_callback: Callable[[int, str | None], None] | None = None,
 ) -> AsyncIterator[RawConversationData]:
     """Stream Drive payloads as raw records without touching the local cache."""
     from polylogue.sources.drive import iter_drive_raw_data
+
+    loop = asyncio.get_running_loop()
+
+    def _status_callback(desc: str) -> None:
+        if progress_callback is None:
+            return
+        loop.call_soon_threadsafe(progress_callback, 0, desc)
 
     batch_size = 32
     iterator = iter(
@@ -92,6 +101,8 @@ async def iter_drive_raw_stream(
             cursor_state=cursor_state,
             drive_config=drive_config,
             known_mtimes=known_mtimes,
+            observation_callback=observation_callback,
+            status_callback=_status_callback if progress_callback is not None else None,
         )
     )
 
@@ -127,6 +138,8 @@ async def iter_raw_record_stream(
             ui=ui,
             cursor_state=cursor_state,
             drive_config=drive_config,
+            observation_callback=observation_callback,
+            progress_callback=progress_callback,
         )
     else:
         raw_stream = iter_source_raw_stream(

--- a/polylogue/pipeline/services/ingest_batch.py
+++ b/polylogue/pipeline/services/ingest_batch.py
@@ -207,6 +207,7 @@ WHERE
     content_hash != excluded.content_hash
     OR IFNULL(role, '') != IFNULL(excluded.role, '')
     OR IFNULL(text, '') != IFNULL(excluded.text, '')
+    OR IFNULL(sort_key, 0) != IFNULL(excluded.sort_key, 0)
     OR IFNULL(parent_message_id, '') != IFNULL(excluded.parent_message_id, '')
     OR branch_index != excluded.branch_index
     OR word_count != excluded.word_count
@@ -442,51 +443,55 @@ def _write_conversation(
         "skipped_attachments": 0,
     }
 
-    content_unchanged = (
-        False if force_write else _check_content_unchanged(conn, cdata.conversation_id, cdata.content_hash)
-    )
+    content_unchanged = (not force_write) and _check_content_unchanged(conn, cdata.conversation_id, cdata.content_hash)
 
-    conn.execute(_CONVERSATION_UPSERT_SQL, _resolved_conversation_tuple(conn, cdata))
-
-    if content_unchanged:
+    if not force_write and content_unchanged:
         counts["skipped_conversations"] = 1
         counts["skipped_messages"] = len(cdata.message_tuples)
         counts["skipped_attachments"] = len(cdata.attachment_tuples)
         return False, counts
 
-    counts["conversations"] = 1
-    affected_attachment_ids = replace_conversation_runtime_state_sync(conn, cdata.conversation_id)
+    conn.execute(_CONVERSATION_UPSERT_SQL, _resolved_conversation_tuple(conn, cdata))
 
-    # Messages (topo-sorted for parent FK)
+    affected_attachment_ids: set[str] = set()
+    if not content_unchanged:
+        counts["conversations"] = 1
+        affected_attachment_ids = replace_conversation_runtime_state_sync(conn, cdata.conversation_id)
+    else:
+        counts["conversations"] = 0
+
     if cdata.message_tuples:
         sorted_msgs = _topo_sort_message_tuples(cdata.message_tuples)
         conn.executemany(_MESSAGE_UPSERT_SQL, sorted_msgs)
         counts["messages"] = len(sorted_msgs)
 
     # Conversation stats
-    if cdata.stats_tuple:
+    if cdata.stats_tuple and not content_unchanged:
         conn.execute(_STATS_UPSERT_SQL, cdata.stats_tuple)
 
-    # Content blocks (replace all for this conversation)
-    conn.execute("DELETE FROM content_blocks WHERE conversation_id = ?", (cdata.conversation_id,))
-    if cdata.block_tuples:
-        conn.executemany(_CONTENT_BLOCK_UPSERT_SQL, cdata.block_tuples)
+    if not content_unchanged:
+        conn.execute("DELETE FROM content_blocks WHERE conversation_id = ?", (cdata.conversation_id,))
+        if cdata.block_tuples:
+            conn.executemany(_CONTENT_BLOCK_UPSERT_SQL, cdata.block_tuples)
 
-    # Action events (replace all for this conversation)
-    conn.execute("DELETE FROM action_events WHERE conversation_id = ?", (cdata.conversation_id,))
-    if cdata.action_event_tuples:
-        conn.executemany(_ACTION_EVENT_INSERT_SQL, cdata.action_event_tuples)
+    if not content_unchanged:
+        conn.execute("DELETE FROM action_events WHERE conversation_id = ?", (cdata.conversation_id,))
+        if cdata.action_event_tuples:
+            conn.executemany(_ACTION_EVENT_INSERT_SQL, cdata.action_event_tuples)
 
     # Attachments
-    new_attachment_ids = {
-        attachment_id for attachment_id, *_rest in cdata.attachment_tuples if isinstance(attachment_id, str)
-    }
-    affected_attachment_ids |= new_attachment_ids
-    if cdata.attachment_tuples:
-        conn.executemany(_ATTACHMENT_UPSERT_SQL, cdata.attachment_tuples)
-        conn.executemany(_ATTACHMENT_REF_INSERT_SQL, cdata.attachment_ref_tuples)
-        counts["attachments"] = len(cdata.attachment_tuples)
-    recount_and_prune_attachments_sync(conn, affected_attachment_ids)
+    if not content_unchanged:
+        new_attachment_ids = {
+            attachment_id for attachment_id, *_rest in cdata.attachment_tuples if isinstance(attachment_id, str)
+        }
+        affected_attachment_ids |= new_attachment_ids
+        if cdata.attachment_tuples:
+            conn.executemany(_ATTACHMENT_UPSERT_SQL, cdata.attachment_tuples)
+            conn.executemany(_ATTACHMENT_REF_INSERT_SQL, cdata.attachment_ref_tuples)
+            counts["attachments"] = len(cdata.attachment_tuples)
+        recount_and_prune_attachments_sync(conn, affected_attachment_ids)
+    else:
+        counts["attachments"] = 0
 
     return True, counts
 
@@ -1247,11 +1252,6 @@ async def refresh_session_insights_bulk(
 
         elapsed = time.perf_counter() - t_start
         chunk_observations = update.chunk_observations
-        chunk_total_values = [chunk.total_ms for chunk in chunk_observations]
-        chunk_load_values = [chunk.load_ms for chunk in chunk_observations]
-        chunk_hydrate_values = [chunk.hydrate_ms for chunk in chunk_observations]
-        chunk_build_values = [chunk.build_ms for chunk in chunk_observations]
-        chunk_write_values = [chunk.write_ms for chunk in chunk_observations]
         observation: MaterializeStageObservation = {
             "conversations": len(changed_conversation_ids),
             "unique_thread_roots": len(thread_root_ids),
@@ -1263,17 +1263,16 @@ async def refresh_session_insights_bulk(
             "update_chunk_count": len(chunk_observations),
             "update_slow_chunk_count": sum(1 for chunk in chunk_observations if chunk.slow),
         }
-        if chunk_total_values:
-            observation["update_max_chunk_ms"] = round(max(chunk_total_values), 1)
-        if chunk_load_values:
-            observation["update_max_chunk_load_ms"] = round(max(chunk_load_values), 1)
-        if chunk_hydrate_values:
-            observation["update_max_chunk_hydrate_ms"] = round(max(chunk_hydrate_values), 1)
-        if chunk_build_values:
-            observation["update_max_chunk_build_ms"] = round(max(chunk_build_values), 1)
-        if chunk_write_values:
-            observation["update_max_chunk_write_ms"] = round(max(chunk_write_values), 1)
         if chunk_observations:
+            observation.update(
+                {
+                    "update_max_chunk_ms": round(max(chunk.total_ms for chunk in chunk_observations), 1),
+                    "update_max_chunk_load_ms": round(max(chunk.load_ms for chunk in chunk_observations), 1),
+                    "update_max_chunk_hydrate_ms": round(max(chunk.hydrate_ms for chunk in chunk_observations), 1),
+                    "update_max_chunk_build_ms": round(max(chunk.build_ms for chunk in chunk_observations), 1),
+                    "update_max_chunk_write_ms": round(max(chunk.write_ms for chunk in chunk_observations), 1),
+                }
+            )
             observation["update_chunks"] = [chunk.to_observation() for chunk in chunk_observations]
         if elapsed > 2.0:
             logger.info(

--- a/polylogue/sources/drive/__init__.py
+++ b/polylogue/sources/drive/__init__.py
@@ -13,6 +13,12 @@ from ...config import Source
 from ...paths.sanitize import safe_path_component
 from ..dispatch import parse_drive_payload
 from ..parsers.base import ParsedConversation, RawConversationData
+from ..source_acquisition_components import (
+    ObservationCallback,
+    StatusCallback,
+    make_status_heartbeat,
+    observe_acquisition,
+)
 from .source import DriveSourceAPI, _parse_modified_time, build_drive_source_client
 from .types import DriveConfigLike, DriveFile, DriveUILike
 
@@ -207,6 +213,8 @@ def iter_drive_raw_data(
     cursor_state: CursorStatePayload | None = None,
     drive_config: DriveConfigLike | None = None,
     known_mtimes: dict[str, str] | None = None,
+    observation_callback: ObservationCallback | None = None,
+    status_callback: StatusCallback | None = None,
 ) -> Iterable[RawConversationData]:
     """Iterate Drive payloads as raw bytes without writing a local cache.
 
@@ -225,6 +233,13 @@ def iter_drive_raw_data(
         dest_path = drive_cache_file_path(source.path or Path(source.name), file_meta.name)
         source_path = str(dest_path)
         tracker.observe_file(file_meta)
+        heartbeat = make_status_heartbeat(
+            status_callback,
+            source_name=source.name,
+            source_path=source_path,
+        )
+        if heartbeat is not None:
+            heartbeat()
 
         if (
             known_mtimes is not None
@@ -264,6 +279,17 @@ def iter_drive_raw_data(
             del raw_bytes
 
         provider_hint = Provider.from_string(source.name)
+        observe_acquisition(
+            observation_callback,
+            phase="drive-file-streamed",
+            source_path=source_path,
+            provider_hint=provider_hint,
+            blob_size=blob_size,
+            drive_file_id=file_meta.file_id,
+            drive_file_name=file_meta.name,
+            drive_modified_time=file_meta.modified_time,
+            drive_size_bytes=file_meta.size_bytes,
+        )
         yield RawConversationData(
             raw_bytes=b"",
             source_path=source_path,

--- a/polylogue/sources/live/cursor.py
+++ b/polylogue/sources/live/cursor.py
@@ -1,14 +1,15 @@
 """Per-file processing cursor for live ingestion.
 
-Records the file size we've already routed through the parse pipeline so the
-watcher can skip files that haven't grown since we last saw them. Stored in a
-small auxiliary table inside the main archive SQLite — no schema-version bump,
-created lazily via ``CREATE TABLE IF NOT EXISTS`` on first use.
+Stores enough file state for the watcher to avoid metadata-only freshness
+decisions. The current watcher still reparses complete files, but skip
+decisions are based on content fingerprint plus byte position so same-size
+rewrites and truncation are detected.
 """
 
 from __future__ import annotations
 
 import sqlite3
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -16,48 +17,159 @@ _DDL = """
 CREATE TABLE IF NOT EXISTS live_cursor (
     source_path TEXT PRIMARY KEY,
     byte_size INTEGER NOT NULL,
+    byte_offset INTEGER NOT NULL DEFAULT 0,
+    last_complete_newline INTEGER NOT NULL DEFAULT 0,
     record_count INTEGER NOT NULL DEFAULT 0,
+    last_record_ts TEXT,
+    parser_fingerprint TEXT,
+    content_fingerprint TEXT,
+    source_name TEXT,
     updated_at TEXT NOT NULL
 )
 """
 
 
+@dataclass(frozen=True, slots=True)
+class CursorRecord:
+    """Stored live cursor state for one source file."""
+
+    source_path: str
+    byte_size: int
+    byte_offset: int
+    last_complete_newline: int
+    record_count: int
+    updated_at: str
+    last_record_ts: str | None = None
+    parser_fingerprint: str | None = None
+    content_fingerprint: str | None = None
+    source_name: str | None = None
+
+
 class CursorStore:
-    """SQLite-backed map of ``source_path -> byte_size`` last parsed."""
+    """SQLite-backed live cursor store keyed by source path."""
 
     def __init__(self, db_path: Path) -> None:
         self._db_path = db_path
         with self._connect() as conn:
             conn.execute(_DDL)
+            self._ensure_columns(conn)
 
     def _connect(self) -> sqlite3.Connection:
         conn = sqlite3.connect(self._db_path, timeout=10.0)
         conn.execute("PRAGMA journal_mode=WAL")
         return conn
 
+    def _ensure_columns(self, conn: sqlite3.Connection) -> None:
+        existing = {row[1] for row in conn.execute("PRAGMA table_info(live_cursor)")}
+        columns = {
+            "byte_offset": "INTEGER NOT NULL DEFAULT 0",
+            "last_complete_newline": "INTEGER NOT NULL DEFAULT 0",
+            "last_record_ts": "TEXT",
+            "parser_fingerprint": "TEXT",
+            "content_fingerprint": "TEXT",
+            "source_name": "TEXT",
+        }
+        for name, definition in columns.items():
+            if name not in existing:
+                conn.execute(f"ALTER TABLE live_cursor ADD COLUMN {name} {definition}")
+        conn.commit()
+
     def get(self, path: Path) -> int:
+        record = self.get_record(path)
+        return record.byte_offset if record is not None else 0
+
+    def get_record(self, path: Path) -> CursorRecord | None:
         with self._connect() as conn:
             row = conn.execute(
-                "SELECT byte_size FROM live_cursor WHERE source_path = ?",
+                """
+                SELECT
+                    source_path,
+                    byte_size,
+                    byte_offset,
+                    last_complete_newline,
+                    record_count,
+                    updated_at,
+                    last_record_ts,
+                    parser_fingerprint,
+                    content_fingerprint,
+                    source_name
+                FROM live_cursor
+                WHERE source_path = ?
+                """,
                 (str(path),),
             ).fetchone()
-        return int(row[0]) if row else 0
+        if row is None:
+            return None
+        return CursorRecord(
+            source_path=str(row[0]),
+            byte_size=int(row[1]),
+            byte_offset=int(row[2]),
+            last_complete_newline=int(row[3]),
+            record_count=int(row[4]),
+            updated_at=str(row[5]),
+            last_record_ts=row[6],
+            parser_fingerprint=row[7],
+            content_fingerprint=row[8],
+            source_name=row[9],
+        )
 
-    def set(self, path: Path, byte_size: int, *, record_count: int = 0) -> None:
+    def set(
+        self,
+        path: Path,
+        byte_size: int,
+        *,
+        byte_offset: int | None = None,
+        last_complete_newline: int | None = None,
+        record_count: int = 0,
+        last_record_ts: str | None = None,
+        parser_fingerprint: str | None = None,
+        content_fingerprint: str | None = None,
+        source_name: str | None = None,
+    ) -> None:
         now = datetime.now(UTC).isoformat()
+        offset = byte_size if byte_offset is None else byte_offset
+        newline_offset = offset if last_complete_newline is None else last_complete_newline
         with self._connect() as conn:
             conn.execute(
                 """
-                INSERT INTO live_cursor (source_path, byte_size, record_count, updated_at)
-                VALUES (?, ?, ?, ?)
+                INSERT INTO live_cursor (
+                    source_path,
+                    byte_size,
+                    byte_offset,
+                    last_complete_newline,
+                    record_count,
+                    last_record_ts,
+                    parser_fingerprint,
+                    content_fingerprint,
+                    source_name,
+                    updated_at
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT (source_path) DO UPDATE SET
                     byte_size = excluded.byte_size,
+                    byte_offset = excluded.byte_offset,
+                    last_complete_newline = excluded.last_complete_newline,
                     record_count = excluded.record_count,
+                    last_record_ts = excluded.last_record_ts,
+                    parser_fingerprint = excluded.parser_fingerprint,
+                    content_fingerprint = excluded.content_fingerprint,
+                    source_name = excluded.source_name,
                     updated_at = excluded.updated_at
                 """,
-                (str(path), byte_size, record_count, now),
+                (
+                    str(path),
+                    byte_size,
+                    offset,
+                    newline_offset,
+                    record_count,
+                    last_record_ts,
+                    parser_fingerprint,
+                    content_fingerprint,
+                    source_name,
+                    now,
+                ),
             )
             conn.commit()
 
 
-__all__ = ["CursorStore"]
+__all__ = ["CursorRecord", "CursorStore"]

--- a/polylogue/sources/live/watcher.py
+++ b/polylogue/sources/live/watcher.py
@@ -2,8 +2,8 @@
 
 Watches one or more roots for ``*.jsonl`` changes via ``watchfiles`` and
 re-parses each grown file through the existing ingest pipeline. Idempotent
-via content-hash dedup; the cursor table only suppresses re-work when a file
-hasn't grown since we last saw it.
+via content-hash dedup; the cursor table only suppresses re-work when the
+stored content fingerprint and parser fingerprint still match the file.
 
 There's no concept of a "live" or "active" session here — any JSONL under the
 roots may grow at any time, including ones years old (resume). The watcher
@@ -13,6 +13,7 @@ treats every grown file identically.
 from __future__ import annotations
 
 import asyncio
+import hashlib
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -25,6 +26,7 @@ if TYPE_CHECKING:
     from polylogue.api import Polylogue
 
 logger = get_logger(__name__)
+_PARSER_FINGERPRINT = "live-jsonl-full-file-v1"
 
 
 @dataclass(frozen=True, slots=True)
@@ -121,16 +123,44 @@ class LiveWatcher:
         except FileNotFoundError:
             return
         size = stat.st_size
-        cursor = self._cursor.get(path)
-        if size == cursor:
-            return
         try:
-            await self._polylogue.parse_file(path, source_name=path.parent.name)
+            fingerprint, last_complete_newline = _fingerprint_file(path)
+        except FileNotFoundError:
+            return
+        cursor = self._cursor.get_record(path)
+        if (
+            cursor is not None
+            and size == cursor.byte_size
+            and fingerprint == cursor.content_fingerprint
+            and cursor.parser_fingerprint == _PARSER_FINGERPRINT
+        ):
+            return
+        source_name = self._source_name_for(path)
+        try:
+            await self._polylogue.parse_file(path, source_name=source_name)
         except Exception as exc:
             logger.warning("live.watcher: parse failed for %s: %s", path, exc)
             return
-        self._cursor.set(path, size)
-        logger.debug("live.watcher: ingested %s (size=%d)", path, size)
+        self._cursor.set(
+            path,
+            size,
+            byte_offset=last_complete_newline,
+            last_complete_newline=last_complete_newline,
+            parser_fingerprint=_PARSER_FINGERPRINT,
+            content_fingerprint=fingerprint,
+            source_name=source_name,
+        )
+        logger.debug("live.watcher: ingested %s (size=%d, source=%s)", path, size, source_name)
+
+    def _source_name_for(self, path: Path) -> str:
+        resolved = path.resolve()
+        for source in self._sources:
+            try:
+                if resolved.is_relative_to(source.root.resolve()):
+                    return source.name
+            except OSError:
+                continue
+        return path.parent.name
 
 
 def default_sources() -> tuple[WatchSource, ...]:
@@ -141,6 +171,13 @@ def default_sources() -> tuple[WatchSource, ...]:
         WatchSource(name="claude-code", root=claude_code_path()),
         WatchSource(name="codex", root=codex_path()),
     )
+
+
+def _fingerprint_file(path: Path) -> tuple[str, int]:
+    content = path.read_bytes()
+    newline_at = content.rfind(b"\n")
+    last_complete_newline = 0 if newline_at < 0 else newline_at + 1
+    return hashlib.sha256(content).hexdigest(), last_complete_newline
 
 
 __all__ = ["LiveWatcher", "WatchSource", "default_sources"]

--- a/tests/unit/pipeline/test_acquisition_streams.py
+++ b/tests/unit/pipeline/test_acquisition_streams.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 
 from polylogue.config import Source
+from polylogue.core.json import JSONDocument
 from polylogue.pipeline.services import acquisition_streams
 from polylogue.sources.parsers.base import RawConversationData
 from polylogue.types import Provider
@@ -88,3 +89,47 @@ async def test_iter_raw_record_stream_forwards_source_status_progress(
 
     assert len(items) == 1
     assert progress_events == [(0, "Scanning [chatgpt] reading export.json")]
+
+
+@pytest.mark.asyncio
+async def test_iter_raw_record_stream_forwards_drive_progress_and_observations(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import polylogue.sources.drive as drive_module
+
+    observations: list[JSONDocument] = []
+    progress_events: list[tuple[int, str | None]] = []
+
+    def _iter_drive_raw_data(*args: object, **kwargs: object) -> Iterator[RawConversationData]:
+        del args
+        observation_callback = kwargs["observation_callback"]
+        status_callback = kwargs["status_callback"]
+        assert callable(observation_callback)
+        assert callable(status_callback)
+        observation_callback({"phase": "drive-test", "source_path": "drive.json"})
+        status_callback("Scanning [gemini] reading drive.json")
+        yield RawConversationData(
+            raw_bytes=b'{"id":"drive"}',
+            source_path=str(tmp_path / "drive.json"),
+            provider_hint=Provider.GEMINI,
+        )
+
+    def _record_progress(amount: int, desc: str | None = None) -> None:
+        progress_events.append((amount, desc))
+
+    monkeypatch.setattr(drive_module, "iter_drive_raw_data", _iter_drive_raw_data)
+
+    items = [
+        item
+        async for item in acquisition_streams.iter_raw_record_stream(
+            Source(name="gemini", path=tmp_path, folder="Google AI Studio"),
+            observation_callback=observations.append,
+            progress_callback=_record_progress,
+        )
+    ]
+    await asyncio.sleep(0)
+
+    assert len(items) == 1
+    assert observations == [{"phase": "drive-test", "source_path": "drive.json"}]
+    assert progress_events == [(0, "Scanning [gemini] reading drive.json")]

--- a/tests/unit/sources/test_live_watcher.py
+++ b/tests/unit/sources/test_live_watcher.py
@@ -8,8 +8,11 @@ import sqlite3
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
+
+import polylogue.sources.live.watcher as live_watcher
 from polylogue.sources.live import LiveWatcher, WatchSource
-from polylogue.sources.live.cursor import CursorStore
+from polylogue.sources.live.cursor import CursorRecord, CursorStore
 
 # --- CursorStore ---------------------------------------------------------------
 
@@ -24,6 +27,12 @@ def test_cursor_round_trip(tmp_path: Path) -> None:
     p = tmp_path / "session.jsonl"
     store.set(p, 42, record_count=3)
     assert store.get(p) == 42
+    record = store.get_record(p)
+    assert isinstance(record, CursorRecord)
+    assert record.byte_size == 42
+    assert record.byte_offset == 42
+    assert record.last_complete_newline == 42
+    assert record.record_count == 3
 
 
 def test_cursor_upsert_overwrites(tmp_path: Path) -> None:
@@ -71,6 +80,64 @@ def test_cursor_writes_updated_at(tmp_path: Path) -> None:
     assert "T" in row[0]  # ISO 8601
 
 
+def test_cursor_round_trips_freshness_metadata(tmp_path: Path) -> None:
+    store = CursorStore(tmp_path / "live.sqlite")
+    p = tmp_path / "session.jsonl"
+    store.set(
+        p,
+        42,
+        byte_offset=40,
+        last_complete_newline=37,
+        last_record_ts="2026-05-01T12:00:00+00:00",
+        parser_fingerprint="parser-v1",
+        content_fingerprint="abc123",
+        source_name="codex",
+    )
+
+    record = store.get_record(p)
+
+    assert record is not None
+    assert record.byte_size == 42
+    assert record.byte_offset == 40
+    assert record.last_complete_newline == 37
+    assert record.last_record_ts == "2026-05-01T12:00:00+00:00"
+    assert record.parser_fingerprint == "parser-v1"
+    assert record.content_fingerprint == "abc123"
+    assert record.source_name == "codex"
+
+
+def test_cursor_migrates_size_only_rows(tmp_path: Path) -> None:
+    db = tmp_path / "live.sqlite"
+    legacy_path = tmp_path / "legacy.jsonl"
+    with sqlite3.connect(db) as conn:
+        conn.execute(
+            """
+            CREATE TABLE live_cursor (
+                source_path TEXT PRIMARY KEY,
+                byte_size INTEGER NOT NULL,
+                record_count INTEGER NOT NULL DEFAULT 0,
+                updated_at TEXT NOT NULL
+            )
+            """
+        )
+        conn.execute(
+            "INSERT INTO live_cursor (source_path, byte_size, record_count, updated_at) VALUES (?, ?, ?, ?)",
+            (str(legacy_path), 12, 2, "2026-05-01T00:00:00+00:00"),
+        )
+        conn.commit()
+
+    store = CursorStore(db)
+    record = store.get_record(legacy_path)
+
+    assert record is not None
+    assert record.byte_size == 12
+    assert record.byte_offset == 0
+    assert record.content_fingerprint is None
+    with sqlite3.connect(db) as conn:
+        columns = {row[1] for row in conn.execute("PRAGMA table_info(live_cursor)")}
+    assert {"byte_offset", "content_fingerprint", "source_name"}.issubset(columns)
+
+
 # --- LiveWatcher: ingest_if_grown ---------------------------------------------
 
 
@@ -112,6 +179,108 @@ def test_reingest_when_file_grows(tmp_path: Path) -> None:
     asyncio.run(watcher._ingest_if_grown(f))
 
     assert parse_file.await_count == 3
+
+
+def test_same_size_rewrite_triggers_reingest(tmp_path: Path) -> None:
+    root = tmp_path / "src"
+    root.mkdir()
+    f = root / "session.jsonl"
+    f.write_text('{"a":1}\n')
+    watcher, parse_file = _make_watcher(tmp_path, root)
+
+    asyncio.run(watcher._ingest_if_grown(f))
+    assert parse_file.await_count == 1
+
+    f.write_text('{"b":2}\n')
+    assert f.stat().st_size == len('{"a":1}\n')
+    asyncio.run(watcher._ingest_if_grown(f))
+
+    assert parse_file.await_count == 2
+
+
+def test_legacy_size_only_cursor_reingests_to_populate_fingerprint(tmp_path: Path) -> None:
+    root = tmp_path / "src"
+    root.mkdir()
+    f = root / "session.jsonl"
+    f.write_text('{"a":1}\n')
+    watcher, parse_file = _make_watcher(tmp_path, root)
+    watcher._cursor.set(f, f.stat().st_size)
+
+    asyncio.run(watcher._ingest_if_grown(f))
+    asyncio.run(watcher._ingest_if_grown(f))
+
+    assert parse_file.await_count == 1
+    record = watcher._cursor.get_record(f)
+    assert record is not None
+    assert record.content_fingerprint
+    assert record.parser_fingerprint
+
+
+def test_parser_fingerprint_change_triggers_reingest(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    root = tmp_path / "src"
+    root.mkdir()
+    f = root / "session.jsonl"
+    f.write_text('{"a":1}\n')
+    watcher, parse_file = _make_watcher(tmp_path, root)
+
+    asyncio.run(watcher._ingest_if_grown(f))
+    monkeypatch.setattr(live_watcher, "_PARSER_FINGERPRINT", "live-jsonl-full-file-v2")
+    asyncio.run(watcher._ingest_if_grown(f))
+
+    assert parse_file.await_count == 2
+    record = watcher._cursor.get_record(f)
+    assert record is not None
+    assert record.parser_fingerprint == "live-jsonl-full-file-v2"
+
+
+def test_truncate_rewrite_triggers_reingest(tmp_path: Path) -> None:
+    root = tmp_path / "src"
+    root.mkdir()
+    f = root / "session.jsonl"
+    f.write_text('{"a":1}\n{"b":2}\n')
+    watcher, parse_file = _make_watcher(tmp_path, root)
+
+    asyncio.run(watcher._ingest_if_grown(f))
+    f.write_text('{"c":3}\n')
+    asyncio.run(watcher._ingest_if_grown(f))
+
+    assert parse_file.await_count == 2
+
+
+def test_partial_trailing_line_keeps_cursor_at_last_newline(tmp_path: Path) -> None:
+    root = tmp_path / "src"
+    root.mkdir()
+    f = root / "session.jsonl"
+    complete = b'{"a":1}\n'
+    partial = b'{"b":'
+    f.write_bytes(complete + partial)
+    watcher, parse_file = _make_watcher(tmp_path, root)
+
+    asyncio.run(watcher._ingest_if_grown(f))
+
+    record = watcher._cursor.get_record(f)
+    assert parse_file.await_count == 1
+    assert record is not None
+    assert record.byte_size == len(complete + partial)
+    assert record.byte_offset == len(complete)
+    assert record.last_complete_newline == len(complete)
+
+
+def test_append_after_partial_line_reingests_completed_record(tmp_path: Path) -> None:
+    root = tmp_path / "src"
+    root.mkdir()
+    f = root / "session.jsonl"
+    f.write_text('{"a":1}\n{"b":')
+    watcher, parse_file = _make_watcher(tmp_path, root)
+
+    asyncio.run(watcher._ingest_if_grown(f))
+    f.write_text('{"a":1}\n{"b":2}\n')
+    asyncio.run(watcher._ingest_if_grown(f))
+
+    assert parse_file.await_count == 2
+    record = watcher._cursor.get_record(f)
+    assert record is not None
+    assert record.byte_offset == f.stat().st_size
 
 
 def test_year_old_file_resumed_triggers_reingest(tmp_path: Path) -> None:
@@ -168,7 +337,7 @@ def test_parse_failure_retries_on_next_event(tmp_path: Path) -> None:
     assert parse_file.await_count == 2
 
 
-def test_parse_file_receives_parent_dir_as_source_name(tmp_path: Path) -> None:
+def test_parse_file_receives_watch_source_name(tmp_path: Path) -> None:
     root = tmp_path / "src"
     project_dir = root / "my-project-slug"
     project_dir.mkdir(parents=True)
@@ -180,7 +349,22 @@ def test_parse_file_receives_parent_dir_as_source_name(tmp_path: Path) -> None:
     parse_file.assert_awaited_once()
     call = parse_file.await_args
     assert call is not None
-    assert call.kwargs["source_name"] == "my-project-slug"
+    assert call.kwargs["source_name"] == "test"
+
+
+def test_cursor_records_watch_source_name(tmp_path: Path) -> None:
+    root = tmp_path / "src"
+    nested = root / "my-project-slug"
+    nested.mkdir(parents=True)
+    f = nested / "session.jsonl"
+    f.write_text('{"a":1}\n')
+    watcher, _parse_file = _make_watcher(tmp_path, root)
+
+    asyncio.run(watcher._ingest_if_grown(f))
+
+    record = watcher._cursor.get_record(f)
+    assert record is not None
+    assert record.source_name == "test"
 
 
 # --- catch_up bootstrap --------------------------------------------------------
@@ -204,7 +388,8 @@ def test_catch_up_skips_already_processed(tmp_path: Path) -> None:
     f = root / "s.jsonl"
     f.write_text('{"a":1}\n')
     watcher, parse_file = _make_watcher(tmp_path, root)
-    watcher._cursor.set(f, f.stat().st_size)
+    asyncio.run(watcher._ingest_if_grown(f))
+    parse_file.reset_mock()
 
     asyncio.run(watcher._catch_up([root]))
     assert parse_file.await_count == 0

--- a/tests/unit/sources/test_source_laws.py
+++ b/tests/unit/sources/test_source_laws.py
@@ -1789,6 +1789,35 @@ def test_iter_drive_raw_data_contract() -> None:
     assert cursor_state["latest_file_name"] == "gemini-prompt.json"
 
 
+def test_iter_drive_raw_data_reports_status_and_observations(monkeypatch: pytest.MonkeyPatch) -> None:
+    source = Source(name="gemini", folder="Google AI Studio", path=Path("/tmp/drive-cache"))
+    files = [DriveFile("gemini-1", "gemini-prompt.json", "application/json", "2025-01-01T00:05:00Z", 8)]
+    client = _StubDriveRawClient(files, raw_bytes={"gemini-1": b'{"role":"model"}'})
+    statuses: list[str] = []
+    observations: list[dict[str, object]] = []
+
+    def _observe(_callback: object, **kwargs: object) -> None:
+        observations.append(dict(kwargs))
+
+    monkeypatch.setattr("polylogue.sources.drive.observe_acquisition", _observe)
+
+    items = list(
+        iter_drive_raw_data(
+            source=source,
+            client=client,
+            status_callback=statuses.append,
+            observation_callback=lambda payload: observations.append(dict(payload)),
+        )
+    )
+
+    assert len(items) == 1
+    assert statuses == ["Scanning [gemini] reading gemini-prompt.json"]
+    assert observations[0]["phase"] == "drive-file-streamed"
+    assert observations[0]["source_path"] == "/tmp/drive-cache/gemini-prompt.json"
+    assert observations[0]["drive_file_id"] == "gemini-1"
+    assert observations[0]["drive_file_name"] == "gemini-prompt.json"
+
+
 def test_iter_drive_raw_data_skips_known_mtimes_and_tracks_failures() -> None:
     source = Source(name="gemini", folder="Google AI Studio", path=Path("/tmp/drive-cache"))
     files = [


### PR DESCRIPTION
## Summary

Make live ingestion cursor decisions content-aware and preserve forced reparse replacement semantics. This PR records richer live cursor state, stops deriving watcher source names from parent directories, forwards Drive acquisition diagnostics through the raw stream, and folds in the pending forced-reparse write fix from the other-agent workstream.

## Problem

#620 tracks that live ingestion used byte size as truth: same-size rewrites could be skipped, parser changes could not invalidate cursor state, partial trailing lines did not leave a replay boundary, and watcher source names could become arbitrary directory names. Drive raw acquisition also bypassed the observation/progress diagnostics used by local sources.

The pending force-write ingestion fix also needed cleanup before incorporation: the uncommitted hunk allowed same-hash forced reparses to append new message rows while leaving old rows behind, and one SQL condition was initially placed in the update expression rather than the `WHERE` predicate.

## Solution

- Add `CursorRecord` and extend `live_cursor` with byte offset, last complete newline, parser fingerprint, content fingerprint, source name, and optional last-record timestamp fields, including migration for old size-only rows.
- Make `LiveWatcher` skip only when size, content fingerprint, and parser fingerprint all match, and persist the configured `WatchSource.name` instead of `path.parent.name`.
- Leave the replay offset at the last complete newline when a file has a partial trailing JSONL line, while still using the existing full-file parser path for now.
- Forward Drive raw acquisition observation/progress callbacks through `iter_drive_raw_stream()` and `iter_drive_raw_data()`.
- Preserve forced reparse replacement behavior in sync ingest and keep the large ingest file under the configured file budget.

## Verification

- `ruff check polylogue/pipeline/services/acquisition_streams.py polylogue/sources/drive/__init__.py polylogue/sources/live/cursor.py polylogue/sources/live/watcher.py tests/unit/pipeline/test_acquisition_streams.py tests/unit/sources/test_live_watcher.py tests/unit/sources/test_source_laws.py`
- `ruff format --check polylogue/pipeline/services/acquisition_streams.py polylogue/sources/drive/__init__.py polylogue/sources/live/cursor.py polylogue/sources/live/watcher.py tests/unit/pipeline/test_acquisition_streams.py tests/unit/sources/test_live_watcher.py tests/unit/sources/test_source_laws.py`
- `pytest -q tests/unit/pipeline/test_acquisition_streams.py tests/unit/sources/test_live_watcher.py`
- `pytest -q tests/unit/sources/test_source_laws.py -k 'drive_raw_data'`
- `pytest -q tests/unit/pipeline/test_ingest_batch.py`
- `devtools render-all --check`
- `devtools verify-topology`
- `devtools affected-obligations --path polylogue/sources/live/watcher.py --path polylogue/sources/live/cursor.py --path polylogue/sources/drive/__init__.py --path polylogue/pipeline/services/acquisition_streams.py`
- `devtools verify --quick`
- pre-push hook: `devtools verify --quick`

Ref #620
Ref #618