### PR TITLE
fix(cli): fall back when systemd scope launch fails

### DIFF
--- a/polylogue/maintenance/resources.py
+++ b/polylogue/maintenance/resources.py
@@ -197,10 +197,14 @@ def _run_in_systemd_scope(
         *argv,
     ]
     try:
-        completed = subprocess.run(command, env=dict(env), check=False)
+        completed = subprocess.run(command, env=dict(env), check=False, capture_output=True, text=True)
     except OSError as exc:
         raise ScopeLaunchUnavailableError(f"could not launch systemd transient scope: {type(exc).__name__}") from exc
-    raise SystemExit(completed.returncode)
+    if completed.returncode == 0:
+        raise SystemExit(0)
+    raise ScopeLaunchUnavailableError(
+        f"systemd-run exited {completed.returncode}: " + (completed.stderr or completed.stdout or "").strip()[:200]
+    )
 
 
 def _apply_process_demotion(request: ResourceBoundaryRequest) -> ResourceBoundaryReport:

--- a/tests/unit/maintenance/test_resources.py
+++ b/tests/unit/maintenance/test_resources.py
@@ -2,6 +2,11 @@
 
 from __future__ import annotations
 
+import subprocess
+
+import pytest
+
+import polylogue.maintenance.resources as resource_module
 from polylogue.maintenance.resources import (
     ResourceWorkload,
     apply_resource_boundary,
@@ -67,6 +72,27 @@ def test_apply_resource_boundary_reports_explicit_opt_out() -> None:
     assert report.effective_mode == "off"
     assert report.status == "skipped"
     assert report.to_dict()["requested_mode"] == "off"
+
+
+def test_scope_mode_reports_systemd_launch_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    request = doctor_resource_request(repair=True, cleanup=False, preview=False, resource_mode="scope")
+
+    monkeypatch.setattr(resource_module, "_systemd_scope_available", lambda _env: True)
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(args=args[0], returncode=1, stderr="scope denied"),
+    )
+
+    report = apply_resource_boundary(
+        request,
+        environ={"XDG_RUNTIME_DIR": "/run/user/1000"},
+        argv=("polylogue", "doctor", "--repair"),
+    )
+
+    assert report.status == "unavailable"
+    assert report.effective_mode == "unavailable"
+    assert report.detail == "systemd-run exited 1: scope denied"
 
 
 def test_normalize_resource_mode_rejects_unknown_modes() -> None:


### PR DESCRIPTION
## Summary

Handle `systemd-run --user --scope` launch failures as unavailable resource isolation rather than exiting the original command with the `systemd-run` status.

## Problem

The resource boundary work from #711 made `auto` mode prefer transient systemd scopes for heavy foreground maintenance. A nonzero `systemd-run` exit is not the same as successful re-exec inside a scope: in `auto` mode it should fall through to process-local demotion, and in explicit `scope` mode it should report an unavailable scope with the diagnostic.

## Solution

- Capture `systemd-run` output and treat nonzero return codes as `ScopeLaunchUnavailableError`.
- Preserve the existing `SystemExit(0)` path when scope launch succeeds.
- Add a focused test for explicit scope-mode launch failure and diagnostic propagation.

## Verification

- `ruff check polylogue/maintenance/resources.py tests/unit/maintenance/test_resources.py`
- `ruff format --check polylogue/maintenance/resources.py tests/unit/maintenance/test_resources.py`
- `mypy tests/unit/maintenance/test_resources.py`
- `pytest -q tests/unit/maintenance/test_resources.py`
- `devtools verify --quick`
- pre-push hook: `devtools verify --quick`

Ref #708