### PR TITLE
fix(storage): upgrade schema v2 archives in place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,10 @@ documentation polish do not require an entry.
 
 ### Fixed
 
+- Schema v2 archives now upgrade in place to the additive schema v3
+  `messages.message_type` column/index, preserving existing archive rows
+  instead of failing the next run after an older binary rewrites
+  `PRAGMA user_version`.
 - `sanitize_path` symlink probe narrowed to `OSError` and treats
   uncertainty as suspicious (previously a `PermissionError` on an
   unreadable directory could mask a traversal attempt).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -114,9 +114,9 @@ The `all` pipeline stage runs: acquire → parse → materialize → render → 
 ## Database
 
 - Single SQLite file, WAL mode.
-- Schema is fresh-only: no migration chain. On version mismatch the database is
-  rejected with a reset/re-import diagnostic rather than patched in place.
-  `SCHEMA_VERSION` lives in `storage/backends/schema_ddl.py`.
+- Schema is fresh-first: version mismatches are rejected unless an explicit,
+  reviewed in-place upgrade exists for that exact transition. `SCHEMA_VERSION`
+  lives in `storage/backends/schema_ddl.py`.
 - FTS5 with `unicode61` tokenizer (no porter stemmer in this SQLite build).
 
 ## Placement Rules

--- a/docs/plans/assurance-domains.yaml
+++ b/docs/plans/assurance-domains.yaml
@@ -193,10 +193,11 @@ domains:
     oracle_present: false
     oracle: null
     notes: >
-      Schema is fresh-only (no migration chain). Mismatch blocks with a
-      reset/re-import diagnostic rather than attempting in-place migration.
-      Active transition checks can use docs/plans/migrations.yaml while
-      work is in flight, but completed retirements are not durable proof.
+      Schema is fresh-first rather than migration-chain driven. Version
+      mismatch blocks with a reset/re-import diagnostic unless an explicit,
+      reviewed in-place upgrade exists for that exact transition. Active
+      transition checks can use docs/plans/migrations.yaml while work is in
+      flight, but completed retirements are not durable proof.
 
   provider_coverage:
     description: Known provider support breadth and depth

--- a/docs/plans/docs-media-coverage.yaml
+++ b/docs/plans/docs-media-coverage.yaml
@@ -104,13 +104,13 @@ surfaces:
       conversation markdown files.
 
   vhs_tapes:
-    path: .local/readme-demo/example.tape
-    count: 1
+    path: null
+    count: 0
     notes: >
-      Single VHS tape at .local/readme-demo/example.tape.
-      Produces example.gif output. Minimal tape: types
-      "echo 'Welcome to VHS!'". Not integrated into CI
-      or verification gates.
+      No VHS tapes are committed to the repository. Local README
+      demo experiments may live under .local/readme-demo/, but
+      .local is machine-local state and must not be required by
+      manifest verification.
 
   provider_docs:
     path: docs/providers/

--- a/polylogue/storage/backends/schema.py
+++ b/polylogue/storage/backends/schema.py
@@ -79,6 +79,46 @@ async def _apply_extensions_for_plan_async(
     await conn.commit()
 
 
+def _apply_version_upgrade_plan(
+    conn: sqlite3.Connection,
+    snapshot: SchemaSnapshot,
+    plan: SchemaExtensionPlan,
+) -> None:
+    if plan.scripts:
+        raise DatabaseError("Schema version upgrade plans must use statement-level SQL")
+    _log_index_replacement(snapshot, plan)
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        for statement in plan.statements:
+            conn.execute(statement)
+        ensure_vec0_table(conn)
+        conn.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
+    except Exception:
+        conn.rollback()
+        raise
+    conn.commit()
+
+
+async def _apply_version_upgrade_plan_async(
+    conn: aiosqlite.Connection,
+    snapshot: SchemaSnapshot,
+    plan: SchemaExtensionPlan,
+) -> None:
+    if plan.scripts:
+        raise DatabaseError("Schema version upgrade plans must use statement-level SQL")
+    _log_index_replacement(snapshot, plan)
+    try:
+        await conn.execute("BEGIN IMMEDIATE")
+        for statement in plan.statements:
+            await conn.execute(statement)
+        await ensure_vec0_table_async(conn)
+        await conn.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
+    except Exception:
+        await conn.rollback()
+        raise
+    await conn.commit()
+
+
 def apply_current_schema_extensions(conn: sqlite3.Connection) -> None:
     snapshot = capture_schema_snapshot(conn)
     decision = decide_schema_bootstrap(snapshot)
@@ -109,6 +149,11 @@ def _ensure_schema(conn: sqlite3.Connection) -> None:
         raise DatabaseError(schema_version_mismatch_message(decision.current_version or 0))
         return
 
+    if decision.action == "upgrade_v2_to_v3" and decision.extension_plan is not None:
+        _apply_version_upgrade_plan(conn, snapshot, decision.extension_plan)
+        logger.info("Upgraded schema from v%s to v%s", decision.current_version, SCHEMA_VERSION)
+        return
+
     if decision.extension_plan is not None:
         _apply_extensions_for_plan(conn, snapshot, decision.extension_plan)
 
@@ -133,6 +178,11 @@ async def ensure_schema_async(conn: aiosqlite.Connection) -> None:
 
     if decision.action == "version_mismatch":
         raise DatabaseError(schema_version_mismatch_message(decision.current_version or 0))
+        return
+
+    if decision.action == "upgrade_v2_to_v3" and decision.extension_plan is not None:
+        await _apply_version_upgrade_plan_async(conn, snapshot, decision.extension_plan)
+        logger.info("Upgraded schema from v%s to v%s", decision.current_version, SCHEMA_VERSION)
         return
 
     if decision.extension_plan is not None:

--- a/polylogue/storage/backends/schema_bootstrap.py
+++ b/polylogue/storage/backends/schema_bootstrap.py
@@ -30,6 +30,10 @@ _RAW_SOURCE_MTIME_INDEX_SQL = (
     "WHERE file_mtime IS NOT NULL"
 )
 
+_MESSAGE_TYPE_INDEX_SQL = (
+    "CREATE INDEX IF NOT EXISTS idx_messages_conversation_message_type ON messages(conversation_id, message_type)"
+)
+
 
 @dataclass(frozen=True)
 class SchemaSnapshot:
@@ -61,7 +65,7 @@ class SchemaExtensionPlan:
 class SchemaBootstrapDecision:
     """Shared schema bootstrap branch chosen from a schema snapshot."""
 
-    action: Literal["create_fresh", "apply_current_extensions", "version_mismatch"]
+    action: Literal["create_fresh", "apply_current_extensions", "upgrade_v2_to_v3", "version_mismatch"]
     extension_plan: SchemaExtensionPlan | None = None
     current_version: int | None = None
 
@@ -178,7 +182,21 @@ def _normalize_sql(sql: str) -> str:
     return " ".join(normalized.split())
 
 
+_MESSAGE_TYPE_EXTENSION_DESCRIPTORS: tuple[SchemaExtensionDescriptor, ...] = (
+    SchemaColumnExtensionDescriptor(
+        table_name="messages",
+        column_name="message_type",
+        ddl="ALTER TABLE messages ADD COLUMN message_type TEXT NOT NULL DEFAULT 'message'",
+    ),
+    SchemaIndexExtensionDescriptor(
+        table_name="messages",
+        index_name="idx_messages_conversation_message_type",
+        ddl=_MESSAGE_TYPE_INDEX_SQL,
+    ),
+)
+
 _SCHEMA_EXTENSION_DESCRIPTORS: tuple[SchemaExtensionDescriptor, ...] = (
+    *_MESSAGE_TYPE_EXTENSION_DESCRIPTORS,
     SchemaColumnExtensionDescriptor(
         table_name="raw_conversations",
         column_name="blob_size",
@@ -517,6 +535,61 @@ _SCHEMA_EXTENSION_DESCRIPTORS: tuple[SchemaExtensionDescriptor, ...] = (
     SchemaScriptExtensionDescriptor(_SESSION_INSIGHT_DDL),
 )
 
+_V2_TO_V3_MESSAGE_TYPE_BACKFILL_SQL = """
+        UPDATE messages
+        SET message_type = CASE
+            WHEN has_thinking != 0 THEN 'thinking'
+            WHEN role = 'tool' THEN 'tool_result'
+            WHEN has_tool_use != 0 THEN 'tool_use'
+            ELSE 'message'
+        END
+        WHERE message_type = 'message'
+          AND (
+            has_thinking != 0
+            OR role = 'tool'
+            OR has_tool_use != 0
+          )
+        """
+
+_V2_TO_V3_MESSAGE_TYPE_BACKFILL_WITH_BLOCKS_SQL = """
+        UPDATE messages
+        SET message_type = CASE
+            WHEN has_thinking != 0
+              OR EXISTS (
+                SELECT 1 FROM content_blocks
+                WHERE content_blocks.message_id = messages.message_id
+                  AND content_blocks.type = 'thinking'
+              )
+            THEN 'thinking'
+            WHEN role = 'tool'
+              OR EXISTS (
+                SELECT 1 FROM content_blocks
+                WHERE content_blocks.message_id = messages.message_id
+                  AND content_blocks.type = 'tool_result'
+              )
+            THEN 'tool_result'
+            WHEN has_tool_use != 0
+              OR EXISTS (
+                SELECT 1 FROM content_blocks
+                WHERE content_blocks.message_id = messages.message_id
+                  AND content_blocks.type = 'tool_use'
+              )
+            THEN 'tool_use'
+            ELSE 'message'
+        END
+        WHERE message_type = 'message'
+          AND (
+            has_thinking != 0
+            OR has_tool_use != 0
+            OR role = 'tool'
+            OR EXISTS (
+              SELECT 1 FROM content_blocks
+              WHERE content_blocks.message_id = messages.message_id
+                AND content_blocks.type IN ('thinking', 'tool_result', 'tool_use')
+            )
+          )
+        """
+
 
 def schema_extension_snapshot_tables() -> tuple[str, ...]:
     """Tables that current-schema extension planning must inspect."""
@@ -539,8 +612,8 @@ def schema_extension_snapshot_indexes() -> tuple[str, ...]:
 def schema_version_mismatch_message(current_version: int) -> str:
     return (
         f"Database schema version {current_version} is incompatible with expected version {SCHEMA_VERSION}. "
-        "Polylogue does not migrate older archive schemas in place. Move the database aside or rebuild it with "
-        "`polylogue reset --database && polylogue run`."
+        "Polylogue only supports explicitly declared in-place archive upgrades. Move the database aside or rebuild "
+        "it with `polylogue reset --database && polylogue run`."
     )
 
 
@@ -570,12 +643,40 @@ def build_current_schema_extension_plan(snapshot: SchemaSnapshot) -> SchemaExten
     return SchemaExtensionPlan(statements=tuple(statements), scripts=tuple(scripts))
 
 
+def build_v2_to_v3_upgrade_plan(snapshot: SchemaSnapshot) -> SchemaExtensionPlan:
+    """Build the additive v2 -> v3 upgrade plan.
+
+    v3 only adds the stored message_type read-model column and its lookup
+    index. The rest of the product -> insight rename kept the physical table
+    names stable, so old v2 archives can be upgraded without rebuilding the
+    full archive.
+    """
+    assert_supported_archive_layout_snapshot(snapshot)
+
+    statements: list[str] = []
+    for descriptor in _MESSAGE_TYPE_EXTENSION_DESCRIPTORS:
+        statements.extend(descriptor.statements(snapshot))
+    if snapshot.has_table("messages"):
+        if snapshot.has_table("content_blocks"):
+            statements.append(_V2_TO_V3_MESSAGE_TYPE_BACKFILL_WITH_BLOCKS_SQL)
+        else:
+            statements.append(_V2_TO_V3_MESSAGE_TYPE_BACKFILL_SQL)
+    return SchemaExtensionPlan(statements=tuple(statements), scripts=())
+
+
 def decide_schema_bootstrap(snapshot: SchemaSnapshot) -> SchemaBootstrapDecision:
     """Choose the canonical schema bootstrap path for sync and async backends."""
     if snapshot.current_version == 0:
         return SchemaBootstrapDecision(action="create_fresh")
 
     assert_supported_archive_layout_snapshot(snapshot)
+
+    if snapshot.current_version == 2 and SCHEMA_VERSION == 3 and snapshot.has_table("messages"):
+        return SchemaBootstrapDecision(
+            action="upgrade_v2_to_v3",
+            extension_plan=build_v2_to_v3_upgrade_plan(snapshot),
+            current_version=snapshot.current_version,
+        )
 
     if snapshot.current_version != SCHEMA_VERSION:
         return SchemaBootstrapDecision(
@@ -697,6 +798,7 @@ __all__ = [
     "apply_schema_extension_plan_async",
     "assert_supported_archive_layout_snapshot",
     "build_current_schema_extension_plan",
+    "build_v2_to_v3_upgrade_plan",
     "capture_schema_snapshot",
     "capture_schema_snapshot_async",
     "decide_schema_bootstrap",

--- a/tests/unit/storage/test_backend.py
+++ b/tests/unit/storage/test_backend.py
@@ -61,6 +61,69 @@ def _table_names(conn: sqlite3.Connection) -> set[str]:
     return {row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()}
 
 
+def _message_types(conn: sqlite3.Connection) -> dict[str, str]:
+    return {row[0]: row[1] for row in conn.execute("SELECT message_id, message_type FROM messages").fetchall()}
+
+
+def _create_v2_message_type_fixture(conn: sqlite3.Connection, *, include_message_type: bool = False) -> None:
+    message_type_column = ", message_type TEXT NOT NULL DEFAULT 'message'" if include_message_type else ""
+    message_type_insert_column = ", message_type" if include_message_type else ""
+    explicit_value = ", 'summary'" if include_message_type else ""
+    conn.executescript(
+        f"""
+        CREATE TABLE messages (
+            message_id TEXT PRIMARY KEY,
+            conversation_id TEXT NOT NULL,
+            role TEXT,
+            text TEXT,
+            sort_key REAL,
+            content_hash TEXT NOT NULL,
+            version INTEGER NOT NULL,
+            branch_index INTEGER NOT NULL DEFAULT 0,
+            provider_name TEXT NOT NULL DEFAULT '',
+            word_count INTEGER NOT NULL DEFAULT 0,
+            has_tool_use INTEGER NOT NULL DEFAULT 0,
+            has_thinking INTEGER NOT NULL DEFAULT 0,
+            has_paste INTEGER NOT NULL DEFAULT 0
+            {message_type_column}
+        );
+        CREATE TABLE content_blocks (
+            block_id TEXT PRIMARY KEY,
+            message_id TEXT NOT NULL,
+            conversation_id TEXT NOT NULL,
+            block_index INTEGER NOT NULL,
+            type TEXT NOT NULL,
+            text TEXT,
+            tool_name TEXT,
+            tool_id TEXT,
+            tool_input TEXT,
+            media_type TEXT,
+            metadata TEXT,
+            semantic_type TEXT,
+            UNIQUE (message_id, block_index)
+        );
+        INSERT INTO messages (
+            message_id, conversation_id, role, text, sort_key, content_hash,
+            version, provider_name, has_tool_use, has_thinking{message_type_insert_column}
+        ) VALUES
+            ('normal', 'conv-1', 'user', 'hello', 1, 'h-normal', 1, 'codex', 0, 0{explicit_value}),
+            ('thinking-block', 'conv-1', 'assistant', '', 2, 'h-thinking', 1, 'codex', 0, 0{explicit_value}),
+            ('tool-result-block', 'conv-1', 'assistant', '', 3, 'h-tool-result', 1, 'codex', 1, 0{explicit_value}),
+            ('tool-role', 'conv-1', 'tool', '', 4, 'h-tool-role', 1, 'codex', 1, 0{explicit_value}),
+            ('tool-use-block', 'conv-1', 'assistant', '', 5, 'h-tool-use', 1, 'codex', 1, 0{explicit_value}),
+            ('tool-flag', 'conv-1', 'assistant', '', 6, 'h-tool-flag', 1, 'codex', 1, 0{explicit_value});
+        INSERT INTO content_blocks (
+            block_id, message_id, conversation_id, block_index, type
+        ) VALUES
+            ('block-thinking', 'thinking-block', 'conv-1', 0, 'thinking'),
+            ('block-tool-result', 'tool-result-block', 'conv-1', 0, 'tool_result'),
+            ('block-tool-use', 'tool-use-block', 'conv-1', 0, 'tool_use');
+        PRAGMA user_version = 2;
+        """
+    )
+    conn.commit()
+
+
 def _build_record(conversation_id: str = "conv-1") -> ConversationRecord:
     return make_conversation(
         conversation_id=conversation_id,
@@ -99,6 +162,51 @@ def test_ensure_schema_contract(tmp_path: Path) -> None:
     conn.close()
 
 
+def test_ensure_schema_upgrades_v2_message_types_without_reimport(tmp_path: Path) -> None:
+    """The supported v2->v3 path adds message_type without deleting archive rows."""
+    db_path = tmp_path / "v2.db"
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    _create_v2_message_type_fixture(conn)
+
+    before_count = conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0]
+
+    _ensure_schema(conn)
+
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION
+    assert conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0] == before_count
+    assert "message_type" in {row[1] for row in conn.execute("PRAGMA table_info(messages)").fetchall()}
+    assert (
+        conn.execute(
+            "SELECT sql FROM sqlite_master WHERE type='index' AND name='idx_messages_conversation_message_type'"
+        ).fetchone()
+        is not None
+    )
+    assert _message_types(conn) == {
+        "normal": "message",
+        "thinking-block": "thinking",
+        "tool-result-block": "tool_result",
+        "tool-role": "tool_result",
+        "tool-use-block": "tool_use",
+        "tool-flag": "tool_use",
+    }
+    conn.close()
+
+
+def test_ensure_schema_upgrades_v2_already_extended_without_overwriting(tmp_path: Path) -> None:
+    """A v2 archive that already has message_type only needs the version marker."""
+    db_path = tmp_path / "v2-already-extended.db"
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    _create_v2_message_type_fixture(conn, include_message_type=True)
+
+    _ensure_schema(conn)
+
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION
+    assert set(_message_types(conn).values()) == {"summary"}
+    conn.close()
+
+
 def test_ensure_schema_rejects_version_mismatch_without_mutating(tmp_path: Path) -> None:
     """Version mismatch fails clearly instead of partially patching old layouts."""
     db_path = tmp_path / "test.db"
@@ -120,7 +228,7 @@ def test_ensure_schema_rejects_version_mismatch_without_mutating(tmp_path: Path)
     with pytest.raises(DatabaseError) as exc_info:
         _ensure_schema(conn)
 
-    assert "does not migrate older archive schemas in place" in str(exc_info.value)
+    assert "only supports explicitly declared in-place archive upgrades" in str(exc_info.value)
     assert conn.execute("PRAGMA user_version").fetchone()[0] == 2
     assert conn.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name='messages'").fetchone() is None
     conn.close()
@@ -201,6 +309,7 @@ def test_schema_extension_catalog_declares_snapshot_scope() -> None:
     assert len(index_names) == len(set(index_names))
     assert {"raw_conversations", "attachments", "session_profiles", "session_phases"}.issubset(table_names)
     assert {
+        "idx_messages_conversation_message_type",
         "idx_raw_conv_source_mtime",
         "idx_raw_conv_effective_provider",
         "idx_content_blocks_tool_use_conversation",
@@ -214,6 +323,7 @@ def test_schema_extension_plan_expands_catalog_descriptors() -> None:
     snapshot = SchemaSnapshot(
         current_version=SCHEMA_VERSION,
         table_columns={
+            "messages": frozenset({"message_id", "conversation_id"}),
             "raw_conversations": frozenset({"raw_id", "source_path", "file_mtime"}),
             "content_blocks": frozenset({"conversation_id", "type"}),
             "attachments": frozenset({"provider_meta"}),
@@ -224,6 +334,8 @@ def test_schema_extension_plan_expands_catalog_descriptors() -> None:
 
     plan = build_current_schema_extension_plan(snapshot)
 
+    assert "ALTER TABLE messages ADD COLUMN message_type TEXT NOT NULL DEFAULT 'message'" in plan.statements
+    assert any("idx_messages_conversation_message_type" in statement for statement in plan.statements)
     assert "ALTER TABLE raw_conversations ADD COLUMN blob_size INTEGER NOT NULL DEFAULT 0" in plan.statements
     assert any("idx_content_blocks_tool_use_conversation" in statement for statement in plan.statements)
     assert any("idx_attachments_provider_meta_id" in statement for statement in plan.statements)
@@ -279,7 +391,7 @@ def test_ensure_schema_rejects_old_raw_table_version_without_mutating(tmp_path: 
     with pytest.raises(DatabaseError) as exc_info:
         _ensure_schema(conn)
 
-    assert "does not migrate older archive schemas in place" in str(exc_info.value)
+    assert "only supports explicitly declared in-place archive upgrades" in str(exc_info.value)
     assert conn.execute("PRAGMA user_version").fetchone()[0] == 2
     assert conn.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name='messages'").fetchone() is None
     conn.close()
@@ -407,7 +519,7 @@ def test_open_read_connection_rejects_old_schema_without_mutating(tmp_path: Path
         with open_read_connection(db_path):
             pass
 
-    assert "does not migrate older archive schemas in place" in str(exc_info.value)
+    assert "only supports explicitly declared in-place archive upgrades" in str(exc_info.value)
     with sqlite3.connect(db_path) as verify_conn:
         assert verify_conn.execute("PRAGMA user_version").fetchone()[0] == 2
         assert (
@@ -559,6 +671,25 @@ async def test_async_backend_schema_and_lock_contracts(tmp_path: Path) -> None:
     assert all(result is None for result in results)
 
 
+async def test_async_backend_upgrades_v2_message_types_without_reimport(tmp_path: Path) -> None:
+    """Async schema initialization should use the same v2->v3 upgrade path."""
+    db_path = tmp_path / "v2-async.db"
+    conn = sqlite3.connect(db_path)
+    _create_v2_message_type_fixture(conn)
+    conn.close()
+
+    backend = SQLiteBackend(db_path=db_path)
+    async with backend.connection():
+        pass
+
+    with sqlite3.connect(db_path) as verify_conn:
+        assert verify_conn.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION
+        assert verify_conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0] == 6
+        assert _message_types(verify_conn)["tool-result-block"] == "tool_result"
+        assert _message_types(verify_conn)["thinking-block"] == "thinking"
+    await backend.close()
+
+
 async def test_async_backend_rejects_old_raw_table_version(tmp_path: Path) -> None:
     """Async backend init should not silently patch old-version raw tables."""
     db_path = tmp_path / "legacy-v1-async.db"
@@ -602,7 +733,7 @@ async def test_async_backend_rejects_old_raw_table_version(tmp_path: Path) -> No
             )
         )
 
-    assert "does not migrate older archive schemas in place" in str(exc_info.value)
+    assert "only supports explicitly declared in-place archive upgrades" in str(exc_info.value)
 
     with sqlite3.connect(db_path) as verify_conn:
         assert verify_conn.execute("PRAGMA user_version").fetchone()[0] == 2

--- a/tests/unit/storage/test_schema_safety.py
+++ b/tests/unit/storage/test_schema_safety.py
@@ -223,6 +223,52 @@ class TestMigrationRollbackSafety:
             f"Only in fresh: {fresh_names - migrated_names}"
         )
 
+    def test_v2_to_v3_upgrade_rolls_back_on_failure(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The supported v2->v3 upgrade must not leave partial DDL behind."""
+        from polylogue.storage.backends import schema as schema_module
+
+        db_path = tmp_path / "v2-failing-upgrade.db"
+        conn = sqlite3.connect(str(db_path))
+        try:
+            conn.executescript(
+                """
+                CREATE TABLE messages (
+                    message_id TEXT PRIMARY KEY,
+                    conversation_id TEXT NOT NULL,
+                    role TEXT,
+                    text TEXT,
+                    content_hash TEXT NOT NULL,
+                    version INTEGER NOT NULL,
+                    branch_index INTEGER NOT NULL DEFAULT 0,
+                    provider_name TEXT NOT NULL DEFAULT '',
+                    word_count INTEGER NOT NULL DEFAULT 0,
+                    has_tool_use INTEGER NOT NULL DEFAULT 0,
+                    has_thinking INTEGER NOT NULL DEFAULT 0,
+                    has_paste INTEGER NOT NULL DEFAULT 0
+                );
+                INSERT INTO messages (
+                    message_id, conversation_id, role, text, content_hash,
+                    version, provider_name, has_tool_use, has_thinking
+                ) VALUES ('tool-row', 'conv-1', 'tool', '', 'hash-tool', 1, 'codex', 1, 0);
+                PRAGMA user_version = 2;
+                """
+            )
+            conn.commit()
+
+            def fail_vec_probe(_conn: sqlite3.Connection) -> None:
+                raise sqlite3.OperationalError("forced upgrade failure")
+
+            monkeypatch.setattr(schema_module, "ensure_vec0_table", fail_vec_probe)
+
+            with pytest.raises(sqlite3.OperationalError, match="forced upgrade failure"):
+                schema_module._ensure_schema(conn)
+
+            assert conn.execute("PRAGMA user_version").fetchone()[0] == 2
+            columns = {row[1] for row in conn.execute("PRAGMA table_info(messages)").fetchall()}
+            assert "message_type" not in columns
+        finally:
+            conn.close()
+
 
 # =============================================================================
 # SQL edge cases: OFFSET without LIMIT (7ebfd71)


### PR DESCRIPTION
## Summary
Adds a narrow in-place schema v2 to v3 upgrade for the additive `messages.message_type` archive facet, and fixes a broken devtools manifest gate that required untracked `.local` demo state.

## Problem
A live archive can be physically compatible with schema v3 while carrying `PRAGMA user_version = 2` after an older binary rewrites only the version marker. Current schema bootstrap then rejects the database and scheduled runs can drift into expensive reimport/catch-up behavior instead of applying the small additive delta.

The publish gate was also not reproducible in clean worktrees: `docs/plans/docs-media-coverage.yaml` required `.local/readme-demo/example.tape`, which is machine-local state and not committed evidence.

## Solution
- Add a transactional v2-to-v3 upgrade path that adds `messages.message_type`, creates `idx_messages_conversation_message_type`, backfills message types from existing role/content-block flags, and updates `PRAGMA user_version` without deleting archive rows.
- Keep unsupported schema versions and legacy raw layouts rejected with the reset/re-import diagnostic.
- Update architecture/assurance docs and changelog to describe the explicit-upgrade posture.
- Mark VHS tape coverage as absent from committed sources instead of requiring `.local/readme-demo`.

## Verification
- `PYTHONPATH=. /realm/project/polylogue/.venv/bin/python -m pytest -q tests/unit/storage/test_backend.py tests/unit/storage/test_schema_safety.py` -> `60 passed in 8.31s`
- `PYTHONPATH=. /realm/project/polylogue/.venv/bin/ruff check polylogue/storage/backends/schema.py polylogue/storage/backends/schema_bootstrap.py tests/unit/storage/test_backend.py tests/unit/storage/test_schema_safety.py` -> `All checks passed!`
- `PYTHONPATH=. /realm/project/polylogue/.venv/bin/ruff format --check polylogue/storage/backends/schema.py polylogue/storage/backends/schema_bootstrap.py tests/unit/storage/test_backend.py tests/unit/storage/test_schema_safety.py` -> `4 files already formatted`
- `git diff --check`
- `/realm/project/sinnix/scripts/sinnix-scope build -- nix develop --command devtools verify --quick` -> `verify: all checks passed`
- Pre-push hook under the Polylogue devshell -> `verify: all checks passed`

Ref #618

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Database archives can now upgrade in-place to the new schema format while preserving all existing data, rather than requiring a fresh import.

* **Documentation**
  * Updated schema evolution policy to reflect a "fresh-first" approach with explicit upgrade paths.
  * Updated assurance and changelog documentation to clarify migration strategy.

* **Tests**
  * Added comprehensive tests for in-place schema upgrade behavior and failure recovery with rollback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->