### PR TITLE
fix(storage): skip redundant v2 message backfill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,8 @@ documentation polish do not require an entry.
   `messages.message_type` column/index, preserving existing archive rows
   instead of failing the next run after an older binary rewrites
   `PRAGMA user_version`.
+- Schema v2 archives that already have `messages.message_type` skip the
+  message-type backfill scan and only repair the missing version/index state.
 - `sanitize_path` symlink probe narrowed to `OSError` and treats
   uncertainty as suspicious (previously a `PermissionError` on an
   unreadable directory could mask a traversal attempt).

--- a/polylogue/storage/backends/schema_bootstrap.py
+++ b/polylogue/storage/backends/schema_bootstrap.py
@@ -656,7 +656,7 @@ def build_v2_to_v3_upgrade_plan(snapshot: SchemaSnapshot) -> SchemaExtensionPlan
     statements: list[str] = []
     for descriptor in _MESSAGE_TYPE_EXTENSION_DESCRIPTORS:
         statements.extend(descriptor.statements(snapshot))
-    if snapshot.has_table("messages"):
+    if snapshot.has_table("messages") and "message_type" not in snapshot.columns("messages"):
         if snapshot.has_table("content_blocks"):
             statements.append(_V2_TO_V3_MESSAGE_TYPE_BACKFILL_WITH_BLOCKS_SQL)
         else:

--- a/tests/unit/storage/test_backend.py
+++ b/tests/unit/storage/test_backend.py
@@ -33,6 +33,7 @@ from polylogue.storage.backends.schema_bootstrap import (
     SchemaIndexExtensionDescriptor,
     SchemaSnapshot,
     build_current_schema_extension_plan,
+    build_v2_to_v3_upgrade_plan,
     decide_schema_bootstrap,
     schema_extension_snapshot_indexes,
     schema_extension_snapshot_tables,
@@ -205,6 +206,23 @@ def test_ensure_schema_upgrades_v2_already_extended_without_overwriting(tmp_path
     assert conn.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION
     assert set(_message_types(conn).values()) == {"summary"}
     conn.close()
+
+
+def test_v2_to_v3_upgrade_plan_skips_backfill_when_message_type_exists() -> None:
+    """Already-extended v2 archives should not pay for an archive-wide backfill."""
+    snapshot = SchemaSnapshot(
+        current_version=2,
+        table_columns={
+            "messages": frozenset({"message_id", "conversation_id", "message_type"}),
+            "content_blocks": frozenset({"message_id", "type"}),
+        },
+        index_sql={"idx_messages_conversation_message_type": None},
+    )
+
+    plan = build_v2_to_v3_upgrade_plan(snapshot)
+
+    assert any("idx_messages_conversation_message_type" in statement for statement in plan.statements)
+    assert not any(statement.lstrip().startswith("UPDATE messages") for statement in plan.statements)
 
 
 def test_ensure_schema_rejects_version_mismatch_without_mutating(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
Avoids an unnecessary archive-wide message-type backfill when a schema v2 archive already has the v3 `messages.message_type` column.

## Problem
PR #742 added the right v2-to-v3 upgrade path, but the upgrade plan still appended the message-type backfill whenever `messages` existed. That is wasteful for the live failure shape: a physically v3-shaped DB whose `PRAGMA user_version` was rewritten to 2 by an older binary. Running the backfill there would scan the archive even though the column already exists.

## Solution
Only append the message-type backfill when `messages.message_type` is absent. Already-extended v2 archives now repair missing version/index state without rereading all messages/content blocks.

## Verification
- `PYTHONPATH=. /realm/project/polylogue-schema-v2-upgrade/.venv/bin/python -m pytest -q tests/unit/storage/test_backend.py tests/unit/storage/test_schema_safety.py` -> `61 passed in 8.72s`
- `PYTHONPATH=. /realm/project/polylogue-schema-v2-upgrade/.venv/bin/ruff check polylogue/storage/backends/schema_bootstrap.py tests/unit/storage/test_backend.py` -> `All checks passed!`
- `PYTHONPATH=. /realm/project/polylogue-schema-v2-upgrade/.venv/bin/ruff format --check polylogue/storage/backends/schema_bootstrap.py tests/unit/storage/test_backend.py` -> `2 files already formatted`
- `git diff --check`
- Pre-push hook under the Polylogue devshell -> `verify: all checks passed`

Ref #618