### PR TITLE
fix(storage): avoid FTS repair table scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,9 @@ documentation polish do not require an entry.
   `PRAGMA user_version`.
 - Schema v2 archives that already have `messages.message_type` skip the
   message-type backfill scan and only repair the missing version/index state.
+- Schema v3 archives now upgrade to v4 by rebuilding action-event FTS rows
+  with base-table rowids, enabling targeted incremental FTS repairs instead
+  of archive-wide FTS scans.
 - `sanitize_path` symlink probe narrowed to `OSError` and treats
   uncertainty as suspicious (previously a `PermissionError` on an
   unreadable directory could mask a traversal attempt).

--- a/polylogue/pipeline/run_stages.py
+++ b/polylogue/pipeline/run_stages.py
@@ -379,11 +379,10 @@ async def execute_index_stage(
                     item_count=len(processed_ids),
                 )
             if processed_ids:
-                index_kwargs = {"progress_callback": progress_callback} if progress_callback is not None else {}
-                return IndexStageOutcome(
-                    indexed=await index_service.update_index(processed_ids, **index_kwargs),
-                    item_count=len(processed_ids),
-                )
+                # The parse stage repairs FTS for changed conversations as a
+                # synchronous ingest side effect. Re-running the same repair in
+                # the chained index stage doubles FTS I/O on large archives.
+                return IndexStageOutcome(indexed=True, item_count=0)
         return IndexStageOutcome(indexed=False, item_count=0)
     except Exception as exc:
         return IndexStageOutcome(

--- a/polylogue/storage/backends/schema.py
+++ b/polylogue/storage/backends/schema.py
@@ -149,7 +149,7 @@ def _ensure_schema(conn: sqlite3.Connection) -> None:
         raise DatabaseError(schema_version_mismatch_message(decision.current_version or 0))
         return
 
-    if decision.action == "upgrade_v2_to_v3" and decision.extension_plan is not None:
+    if decision.action in {"upgrade_v2_to_current", "upgrade_v3_to_v4"} and decision.extension_plan is not None:
         _apply_version_upgrade_plan(conn, snapshot, decision.extension_plan)
         logger.info("Upgraded schema from v%s to v%s", decision.current_version, SCHEMA_VERSION)
         return
@@ -180,7 +180,7 @@ async def ensure_schema_async(conn: aiosqlite.Connection) -> None:
         raise DatabaseError(schema_version_mismatch_message(decision.current_version or 0))
         return
 
-    if decision.action == "upgrade_v2_to_v3" and decision.extension_plan is not None:
+    if decision.action in {"upgrade_v2_to_current", "upgrade_v3_to_v4"} and decision.extension_plan is not None:
         await _apply_version_upgrade_plan_async(conn, snapshot, decision.extension_plan)
         logger.info("Upgraded schema from v%s to v%s", decision.current_version, SCHEMA_VERSION)
         return

--- a/polylogue/storage/backends/schema_bootstrap.py
+++ b/polylogue/storage/backends/schema_bootstrap.py
@@ -21,6 +21,7 @@ from polylogue.storage.backends.schema_ddl import (
     SCHEMA_DDL,
     SCHEMA_VERSION,
 )
+from polylogue.storage.fts.sql import ACTION_FTS_REBUILD_SQL, FTS_ACTIONS_TABLE_SQL
 
 logger = get_logger(__name__)
 
@@ -65,7 +66,13 @@ class SchemaExtensionPlan:
 class SchemaBootstrapDecision:
     """Shared schema bootstrap branch chosen from a schema snapshot."""
 
-    action: Literal["create_fresh", "apply_current_extensions", "upgrade_v2_to_v3", "version_mismatch"]
+    action: Literal[
+        "create_fresh",
+        "apply_current_extensions",
+        "upgrade_v2_to_current",
+        "upgrade_v3_to_v4",
+        "version_mismatch",
+    ]
     extension_plan: SchemaExtensionPlan | None = None
     current_version: int | None = None
 
@@ -193,6 +200,27 @@ _MESSAGE_TYPE_EXTENSION_DESCRIPTORS: tuple[SchemaExtensionDescriptor, ...] = (
         index_name="idx_messages_conversation_message_type",
         ddl=_MESSAGE_TYPE_INDEX_SQL,
     ),
+)
+
+_ACTION_FTS_TRIGGER_REPLACEMENT_STATEMENTS: tuple[str, ...] = (
+    "DROP TRIGGER IF EXISTS action_events_fts_ai",
+    "DROP TRIGGER IF EXISTS action_events_fts_ad",
+    "DROP TRIGGER IF EXISTS action_events_fts_au",
+    """CREATE TRIGGER action_events_fts_ai
+       AFTER INSERT ON action_events BEGIN
+           INSERT INTO action_events_fts(rowid, event_id, message_id, conversation_id, action_kind, tool_name, text)
+           VALUES (new.rowid, new.event_id, new.message_id, new.conversation_id, new.action_kind, new.normalized_tool_name, new.search_text);
+       END""",
+    """CREATE TRIGGER action_events_fts_ad
+       AFTER DELETE ON action_events BEGIN
+           DELETE FROM action_events_fts WHERE rowid = old.rowid;
+       END""",
+    """CREATE TRIGGER action_events_fts_au
+       AFTER UPDATE ON action_events BEGIN
+           DELETE FROM action_events_fts WHERE rowid = old.rowid;
+           INSERT INTO action_events_fts(rowid, event_id, message_id, conversation_id, action_kind, tool_name, text)
+           VALUES (new.rowid, new.event_id, new.message_id, new.conversation_id, new.action_kind, new.normalized_tool_name, new.search_text);
+       END""",
 )
 
 _SCHEMA_EXTENSION_DESCRIPTORS: tuple[SchemaExtensionDescriptor, ...] = (
@@ -597,6 +625,7 @@ def schema_extension_snapshot_tables() -> tuple[str, ...]:
     for descriptor in _SCHEMA_EXTENSION_DESCRIPTORS:
         for table_name in descriptor.snapshot_tables():
             table_names.setdefault(table_name, None)
+    table_names.setdefault("action_events_fts", None)
     return tuple(table_names)
 
 
@@ -664,6 +693,33 @@ def build_v2_to_v3_upgrade_plan(snapshot: SchemaSnapshot) -> SchemaExtensionPlan
     return SchemaExtensionPlan(statements=tuple(statements), scripts=())
 
 
+def build_v3_to_v4_upgrade_plan(snapshot: SchemaSnapshot) -> SchemaExtensionPlan:
+    """Align action-event FTS rowids with the base table for targeted repair."""
+    assert_supported_archive_layout_snapshot(snapshot)
+
+    if not snapshot.has_table("action_events"):
+        return SchemaExtensionPlan(statements=(), scripts=())
+
+    statements: list[str] = []
+    if not snapshot.has_table("action_events_fts"):
+        statements.append(FTS_ACTIONS_TABLE_SQL)
+    statements.extend(_ACTION_FTS_TRIGGER_REPLACEMENT_STATEMENTS[:3])
+    statements.append("DELETE FROM action_events_fts")
+    statements.append(ACTION_FTS_REBUILD_SQL)
+    statements.extend(_ACTION_FTS_TRIGGER_REPLACEMENT_STATEMENTS[3:])
+    return SchemaExtensionPlan(statements=tuple(statements), scripts=())
+
+
+def build_v2_to_current_upgrade_plan(snapshot: SchemaSnapshot) -> SchemaExtensionPlan:
+    """Build the declared v2 upgrade path to the current archive version."""
+    v2_to_v3 = build_v2_to_v3_upgrade_plan(snapshot)
+    v3_to_v4 = build_v3_to_v4_upgrade_plan(snapshot)
+    return SchemaExtensionPlan(
+        statements=(*v2_to_v3.statements, *v3_to_v4.statements),
+        scripts=(),
+    )
+
+
 def decide_schema_bootstrap(snapshot: SchemaSnapshot) -> SchemaBootstrapDecision:
     """Choose the canonical schema bootstrap path for sync and async backends."""
     if snapshot.current_version == 0:
@@ -671,10 +727,17 @@ def decide_schema_bootstrap(snapshot: SchemaSnapshot) -> SchemaBootstrapDecision
 
     assert_supported_archive_layout_snapshot(snapshot)
 
-    if snapshot.current_version == 2 and SCHEMA_VERSION == 3 and snapshot.has_table("messages"):
+    if snapshot.current_version == 2 and SCHEMA_VERSION == 4 and snapshot.has_table("messages"):
         return SchemaBootstrapDecision(
-            action="upgrade_v2_to_v3",
-            extension_plan=build_v2_to_v3_upgrade_plan(snapshot),
+            action="upgrade_v2_to_current",
+            extension_plan=build_v2_to_current_upgrade_plan(snapshot),
+            current_version=snapshot.current_version,
+        )
+
+    if snapshot.current_version == 3 and SCHEMA_VERSION == 4:
+        return SchemaBootstrapDecision(
+            action="upgrade_v3_to_v4",
+            extension_plan=build_v3_to_v4_upgrade_plan(snapshot),
             current_version=snapshot.current_version,
         )
 
@@ -798,7 +861,9 @@ __all__ = [
     "apply_schema_extension_plan_async",
     "assert_supported_archive_layout_snapshot",
     "build_current_schema_extension_plan",
+    "build_v2_to_current_upgrade_plan",
     "build_v2_to_v3_upgrade_plan",
+    "build_v3_to_v4_upgrade_plan",
     "capture_schema_snapshot",
     "capture_schema_snapshot_async",
     "decide_schema_bootstrap",

--- a/polylogue/storage/backends/schema_ddl.py
+++ b/polylogue/storage/backends/schema_ddl.py
@@ -36,7 +36,7 @@ from polylogue.storage.backends.schema_ddl_insight_timelines import (
     SESSION_INSIGHT_TIMELINE_DDL as _SESSION_INSIGHT_TIMELINE_DDL,
 )
 
-SCHEMA_VERSION = 3
+SCHEMA_VERSION = 4
 
 
 # Complete target schema applied to fresh databases.

--- a/polylogue/storage/backends/schema_ddl_actions.py
+++ b/polylogue/storage/backends/schema_ddl_actions.py
@@ -57,8 +57,9 @@ ACTION_FTS_DDL = """
 
         CREATE TRIGGER IF NOT EXISTS action_events_fts_ai
         AFTER INSERT ON action_events BEGIN
-            INSERT INTO action_events_fts (event_id, message_id, conversation_id, action_kind, tool_name, text)
+            INSERT INTO action_events_fts (rowid, event_id, message_id, conversation_id, action_kind, tool_name, text)
             VALUES (
+                new.rowid,
                 new.event_id,
                 new.message_id,
                 new.conversation_id,
@@ -76,8 +77,9 @@ ACTION_FTS_DDL = """
         CREATE TRIGGER IF NOT EXISTS action_events_fts_au
         AFTER UPDATE ON action_events BEGIN
             DELETE FROM action_events_fts WHERE rowid = old.rowid;
-            INSERT INTO action_events_fts (event_id, message_id, conversation_id, action_kind, tool_name, text)
+            INSERT INTO action_events_fts (rowid, event_id, message_id, conversation_id, action_kind, tool_name, text)
             VALUES (
+                new.rowid,
                 new.event_id,
                 new.message_id,
                 new.conversation_id,

--- a/polylogue/storage/fts/fts_lifecycle.py
+++ b/polylogue/storage/fts/fts_lifecycle.py
@@ -112,6 +112,7 @@ async def suspend_fts_triggers_async(conn: aiosqlite.Connection) -> None:
 
 async def restore_fts_triggers_async(conn: aiosqlite.Connection) -> None:
     """Re-create FTS triggers after bulk insert."""
+    await suspend_fts_triggers_async(conn)
     for ddl in _MESSAGE_FTS_TRIGGER_DDL + _ACTION_FTS_TRIGGER_DDL:
         await conn.execute(ddl)
 
@@ -140,8 +141,8 @@ _MESSAGE_FTS_TRIGGER_DDL = [
 _ACTION_FTS_TRIGGER_DDL = [
     """CREATE TRIGGER IF NOT EXISTS action_events_fts_ai
        AFTER INSERT ON action_events BEGIN
-           INSERT INTO action_events_fts(event_id, message_id, conversation_id, action_kind, tool_name, text)
-           VALUES (new.event_id, new.message_id, new.conversation_id, new.action_kind, new.normalized_tool_name, new.search_text);
+           INSERT INTO action_events_fts(rowid, event_id, message_id, conversation_id, action_kind, tool_name, text)
+           VALUES (new.rowid, new.event_id, new.message_id, new.conversation_id, new.action_kind, new.normalized_tool_name, new.search_text);
        END""",
     """CREATE TRIGGER IF NOT EXISTS action_events_fts_ad
        AFTER DELETE ON action_events BEGIN
@@ -150,8 +151,8 @@ _ACTION_FTS_TRIGGER_DDL = [
     """CREATE TRIGGER IF NOT EXISTS action_events_fts_au
        AFTER UPDATE ON action_events BEGIN
            DELETE FROM action_events_fts WHERE rowid = old.rowid;
-           INSERT INTO action_events_fts(event_id, message_id, conversation_id, action_kind, tool_name, text)
-           VALUES (new.event_id, new.message_id, new.conversation_id, new.action_kind, new.normalized_tool_name, new.search_text);
+           INSERT INTO action_events_fts(rowid, event_id, message_id, conversation_id, action_kind, tool_name, text)
+           VALUES (new.rowid, new.event_id, new.message_id, new.conversation_id, new.action_kind, new.normalized_tool_name, new.search_text);
        END""",
 ]
 
@@ -164,6 +165,7 @@ def suspend_fts_triggers_sync(conn: sqlite3.Connection) -> None:
 
 def restore_fts_triggers_sync(conn: sqlite3.Connection) -> None:
     """Re-create FTS triggers after bulk insert."""
+    suspend_fts_triggers_sync(conn)
     for ddl in _MESSAGE_FTS_TRIGGER_DDL + _ACTION_FTS_TRIGGER_DDL:
         conn.execute(ddl)
 

--- a/polylogue/storage/fts/sql.py
+++ b/polylogue/storage/fts/sql.py
@@ -39,8 +39,9 @@ FTS_REBUILD_SQL = """
 """
 
 ACTION_FTS_REBUILD_SQL = """
-    INSERT INTO action_events_fts (event_id, message_id, conversation_id, action_kind, tool_name, text)
+    INSERT INTO action_events_fts (rowid, event_id, message_id, conversation_id, action_kind, tool_name, text)
     SELECT
+        ae.rowid,
         ae.event_id,
         ae.message_id,
         ae.conversation_id,
@@ -64,7 +65,14 @@ def chunked(items: Sequence[str], *, size: int) -> Iterable[Sequence[str]]:
 
 def delete_conversation_rows_sql(chunk_size: int) -> str:
     placeholders = ", ".join("?" for _ in range(chunk_size))
-    return f"DELETE FROM messages_fts WHERE conversation_id IN ({placeholders})"
+    return f"""
+        DELETE FROM messages_fts
+        WHERE rowid IN (
+            SELECT messages.rowid
+            FROM messages
+            WHERE messages.conversation_id IN ({placeholders})
+        )
+    """
 
 
 def insert_conversation_rows_sql(chunk_size: int) -> str:
@@ -79,14 +87,22 @@ def insert_conversation_rows_sql(chunk_size: int) -> str:
 
 def delete_action_rows_sql(chunk_size: int) -> str:
     placeholders = ", ".join("?" for _ in range(chunk_size))
-    return f"DELETE FROM action_events_fts WHERE conversation_id IN ({placeholders})"
+    return f"""
+        DELETE FROM action_events_fts
+        WHERE rowid IN (
+            SELECT ae.rowid
+            FROM action_events ae
+            WHERE ae.conversation_id IN ({placeholders})
+        )
+    """
 
 
 def insert_action_rows_sql(chunk_size: int) -> str:
     placeholders = ", ".join("?" for _ in range(chunk_size))
     return f"""
-        INSERT INTO action_events_fts (event_id, message_id, conversation_id, action_kind, tool_name, text)
+        INSERT INTO action_events_fts (rowid, event_id, message_id, conversation_id, action_kind, tool_name, text)
         SELECT
+            ae.rowid,
             ae.event_id,
             ae.message_id,
             ae.conversation_id,

--- a/tests/unit/pipeline/test_run_stages_runtime.py
+++ b/tests/unit/pipeline/test_run_stages_runtime.py
@@ -315,6 +315,7 @@ async def test_execute_index_stage_covers_parse_index_reprocess_and_error_paths(
         assert all_rebuild == IndexStageOutcome(indexed=True, item_count=2)
 
         index_service.get_index_status.return_value = {"exists": True}
+        update_calls_before_reprocess = index_service.update_index.await_count
         reprocess = await run_stages.execute_index_stage(
             config=SimpleNamespace(),
             stage="reprocess",
@@ -322,7 +323,8 @@ async def test_execute_index_stage_covers_parse_index_reprocess_and_error_paths(
             processed_ids={"conv-9"},
             backend=_backend(),
         )
-        assert reprocess == IndexStageOutcome(indexed=True, item_count=1)
+        assert reprocess == IndexStageOutcome(indexed=True, item_count=0)
+        assert index_service.update_index.await_count == update_calls_before_reprocess
 
         index_service.update_index.side_effect = RuntimeError("bad index")
         error = await run_stages.execute_index_stage(

--- a/tests/unit/storage/test_action_fts_schema_upgrade.py
+++ b/tests/unit/storage/test_action_fts_schema_upgrade.py
@@ -1,0 +1,117 @@
+"""Schema upgrade coverage for action-event FTS rowid alignment."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from polylogue.storage.backends.schema import SCHEMA_VERSION, _ensure_schema
+from polylogue.storage.backends.schema_bootstrap import SchemaSnapshot, build_v3_to_v4_upgrade_plan
+
+
+def _create_v3_action_fts_fixture(conn: sqlite3.Connection) -> None:
+    conn.executescript(
+        """
+        CREATE TABLE action_events (
+            event_id TEXT PRIMARY KEY,
+            conversation_id TEXT NOT NULL,
+            message_id TEXT NOT NULL,
+            materializer_version INTEGER NOT NULL DEFAULT 1,
+            sequence_index INTEGER NOT NULL,
+            action_kind TEXT NOT NULL,
+            normalized_tool_name TEXT NOT NULL,
+            search_text TEXT NOT NULL
+        );
+        CREATE INDEX idx_action_events_conversation
+        ON action_events(conversation_id);
+        CREATE VIRTUAL TABLE action_events_fts USING fts5(
+            event_id UNINDEXED,
+            message_id UNINDEXED,
+            conversation_id UNINDEXED,
+            action_kind UNINDEXED,
+            tool_name UNINDEXED,
+            text,
+            tokenize='unicode61'
+        );
+        CREATE TRIGGER action_events_fts_ai
+        AFTER INSERT ON action_events BEGIN
+            INSERT INTO action_events_fts (event_id, message_id, conversation_id, action_kind, tool_name, text)
+            VALUES (
+                new.event_id,
+                new.message_id,
+                new.conversation_id,
+                new.action_kind,
+                new.normalized_tool_name,
+                new.search_text
+            );
+        END;
+        CREATE TRIGGER action_events_fts_ad
+        AFTER DELETE ON action_events BEGIN
+            DELETE FROM action_events_fts WHERE rowid = old.rowid;
+        END;
+        INSERT INTO action_events_fts (event_id, message_id, conversation_id, action_kind, tool_name, text)
+        VALUES ('sentinel', 'msg-sentinel', 'conv-sentinel', 'shell', 'bash', 'old rowid offset');
+        INSERT INTO action_events (
+            event_id, conversation_id, message_id, sequence_index,
+            action_kind, normalized_tool_name, search_text
+        ) VALUES
+            ('event-a', 'conv-a', 'msg-a', 0, 'shell', 'bash', 'rowid migration needle'),
+            ('event-b', 'conv-a', 'msg-b', 1, 'search', 'rg', 'second action');
+        PRAGMA user_version = 3;
+        """
+    )
+    conn.commit()
+
+
+def test_ensure_schema_upgrades_v3_action_fts_rowids_without_reimport(tmp_path: Path) -> None:
+    """The v3->v4 path rebuilds action FTS rows with base-table rowids."""
+    db_path = tmp_path / "v3-action-fts.db"
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    _create_v3_action_fts_fixture(conn)
+
+    before_count = conn.execute("SELECT COUNT(*) FROM action_events").fetchone()[0]
+    mismatch_before = conn.execute(
+        """
+        SELECT COUNT(*)
+        FROM action_events ae
+        LEFT JOIN action_events_fts f ON f.rowid = ae.rowid
+        WHERE f.event_id IS NULL OR f.event_id != ae.event_id
+        """
+    ).fetchone()[0]
+    assert mismatch_before == before_count
+
+    _ensure_schema(conn)
+
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION
+    assert conn.execute("SELECT COUNT(*) FROM action_events").fetchone()[0] == before_count
+    mismatch_after = conn.execute(
+        """
+        SELECT COUNT(*)
+        FROM action_events ae
+        LEFT JOIN action_events_fts f ON f.rowid = ae.rowid
+        WHERE f.event_id IS NULL OR f.event_id != ae.event_id
+        """
+    ).fetchone()[0]
+    assert mismatch_after == 0
+    trigger_sql = conn.execute(
+        "SELECT sql FROM sqlite_master WHERE type='trigger' AND name='action_events_fts_ai'"
+    ).fetchone()[0]
+    assert "rowid, event_id" in trigger_sql
+    conn.close()
+
+
+def test_v3_to_v4_upgrade_plan_rebuilds_action_fts_with_rowids() -> None:
+    snapshot = SchemaSnapshot(
+        current_version=3,
+        table_columns={
+            "action_events": frozenset({"event_id", "conversation_id"}),
+            "action_events_fts": frozenset({"event_id", "conversation_id", "text"}),
+        },
+        index_sql={},
+    )
+
+    plan = build_v3_to_v4_upgrade_plan(snapshot)
+
+    assert "DELETE FROM action_events_fts" in plan.statements
+    assert any("INSERT INTO action_events_fts (rowid," in " ".join(statement.split()) for statement in plan.statements)

--- a/tests/unit/storage/test_fts_repair_sql.py
+++ b/tests/unit/storage/test_fts_repair_sql.py
@@ -1,0 +1,76 @@
+"""Targeted SQL contracts for incremental FTS repair."""
+
+from __future__ import annotations
+
+import sqlite3
+
+from polylogue.storage.fts.fts_lifecycle import restore_fts_triggers_sync
+from polylogue.storage.fts.sql import (
+    ACTION_FTS_REBUILD_SQL,
+    delete_action_rows_sql,
+    delete_conversation_rows_sql,
+    insert_action_rows_sql,
+)
+from tests.infra.storage_records import make_conversation, make_message, store_records
+
+
+def test_incremental_fts_repair_deletes_via_base_rowid(test_conn: sqlite3.Connection) -> None:
+    """Incremental FTS repair must not filter FTS5 virtual tables by conversation_id."""
+    message_delete_sql = " ".join(delete_conversation_rows_sql(1).split())
+    action_delete_sql = " ".join(delete_action_rows_sql(1).split())
+
+    assert "DELETE FROM messages_fts WHERE rowid IN" in message_delete_sql
+    assert "DELETE FROM messages_fts WHERE conversation_id" not in message_delete_sql
+    assert "DELETE FROM action_events_fts WHERE rowid IN" in action_delete_sql
+    assert "DELETE FROM action_events_fts WHERE conversation_id" not in action_delete_sql
+    assert "INSERT INTO action_events_fts (rowid," in " ".join(insert_action_rows_sql(1).split())
+    assert "INSERT INTO action_events_fts (rowid," in " ".join(ACTION_FTS_REBUILD_SQL.split())
+
+    plan = "\n".join(
+        row[3] for row in test_conn.execute(f"EXPLAIN QUERY PLAN {delete_conversation_rows_sql(1)}", ("conv1",))
+    )
+    assert "SEARCH messages USING" in plan
+
+
+def test_action_fts_trigger_rowids_track_action_event_rowids(test_conn: sqlite3.Connection) -> None:
+    """Action-event FTS triggers use base-table rowids so rowid deletes are targeted."""
+    restore_fts_triggers_sync(test_conn)
+    conv = make_conversation("conv-action-rowid", title="Action rowid")
+    msg = make_message("msg-action-rowid", "conv-action-rowid", text="Ran command")
+    store_records(conversation=conv, messages=[msg], attachments=[], conn=test_conn)
+
+    test_conn.execute(
+        """
+        INSERT INTO action_events (
+            event_id, conversation_id, message_id, sequence_index,
+            action_kind, normalized_tool_name, search_text
+        ) VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            "event-action-rowid",
+            "conv-action-rowid",
+            "msg-action-rowid",
+            0,
+            "shell",
+            "bash",
+            "pytest rowid needle",
+        ),
+    )
+    row = test_conn.execute(
+        """
+        SELECT ae.rowid AS action_rowid, f.rowid AS fts_rowid
+        FROM action_events ae
+        JOIN action_events_fts f ON f.event_id = ae.event_id
+        WHERE ae.event_id = ?
+        """,
+        ("event-action-rowid",),
+    ).fetchone()
+    assert row is not None
+    assert row["action_rowid"] == row["fts_rowid"]
+
+    test_conn.execute("DELETE FROM action_events WHERE event_id = ?", ("event-action-rowid",))
+    remaining = test_conn.execute(
+        "SELECT COUNT(*) FROM action_events_fts WHERE action_events_fts MATCH ?",
+        ("rowid",),
+    ).fetchone()[0]
+    assert remaining == 0


### PR DESCRIPTION
## Summary

Avoid incremental FTS repair table scans by deleting FTS rows through base-table rowids, aligning action-event FTS rowids with `action_events.rowid`, and skipping duplicate chained index repairs after parse has already repaired changed conversations.

## Problem

Issue #719 captured production runs where small changed batches produced multi-GB reads and high I/O PSI. The 2026-05-03 live run reproduced that shape: `polylogue-run.service` processed a small raw backlog but its cgroup reached roughly 8.4 GB read bytes and `io.full avg10` around 25%. Code inspection showed incremental repair deleting from FTS5 virtual tables by `conversation_id`, which is declared `UNINDEXED`, and `all`/`reprocess` then repeated the same repair in the index leaf.

## Solution

- `polylogue/storage/fts/sql.py` now deletes `messages_fts` and `action_events_fts` rows by `rowid IN (SELECT ... FROM base_table WHERE conversation_id IN (...))`.
- Action-event FTS inserts, rebuilds, and triggers now use `action_events.rowid` as the FTS rowid.
- Schema v4 adds a declared v3->v4 upgrade that rebuilds action-event FTS once so existing archives do not keep stale/misaligned action FTS rowids.
- Chained `all` / `reprocess` index stages no longer repeat `IndexService.update_index(processed_ids)` when parse already repaired changed conversations. Standalone `polylogue run index` remains unchanged.
- Added focused tests for SQL shape, trigger rowid alignment, schema upgrade behavior, and the chained index-stage no-op.

Refs #719.
Refs #716.

## Verification

- `POLYLOGUE_REPO_ROOT=/realm/project/polylogue-ingest-amplification PYTHONPATH=. devtools verify --quick`
- Pre-push hook reran the same quick baseline successfully on push.
- Focused slice: `PYTHONPATH=. python -m pytest -q -n 0 tests/unit/storage/test_backend.py tests/unit/storage/test_schema_safety.py tests/unit/storage/test_fts5.py tests/unit/pipeline/test_indexing.py tests/unit/pipeline/test_ingest_batch.py::test_process_ingest_batch_sync_commits_fts_repair_and_invalidates_search_cache tests/unit/pipeline/test_run_stages_runtime.py::test_execute_index_stage_covers_parse_index_reprocess_and_error_paths`
- `devtools verify-file-budgets`
- Production read-only probe before the fix showed `action_events_fts` rowids were misaligned in sampled rows and the action FTS row count was already stale; this is why the schema upgrade rebuild is included.

## Changelog

- Added an Unreleased fixed entry for the schema v3->v4 action-event FTS rebuild.

## Risks and Follow-ups

- First run after deployment will upgrade the archive from schema v3 to v4 and rebuild action-event FTS once. That is intentional migration I/O; subsequent incremental repairs should be targeted.
- This fixes one confirmed FTS/index amplification path. #719 still tracks append-aware live watching, raw blob acquisition/parse read amplification, and per-stage I/O counters.
