### PR TITLE
fix(pipeline): keep explicit index catch-up incremental

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,9 @@ documentation polish do not require an entry.
 - Schema v3 archives now upgrade to v4 by rebuilding action-event FTS rows
   with base-table rowids, enabling targeted incremental FTS repairs instead
   of archive-wide FTS scans.
+- Explicit `polylogue run ... index` sequences now repair only conversations
+  processed earlier in the same run when the FTS index already exists, avoiding
+  a full archive index rebuild after ordinary catch-up runs.
 - `sanitize_path` symlink probe narrowed to `OSError` and treats
   uncertainty as suspicious (previously a `PermissionError` on an
   unreadable directory could mask a traversal attempt).

--- a/polylogue/pipeline/run_stages.py
+++ b/polylogue/pipeline/run_stages.py
@@ -354,6 +354,14 @@ async def execute_index_stage(
             return IndexStageOutcome(indexed=False, item_count=0)
 
         if stage == "index":
+            if processed_ids:
+                status = await index_service.get_index_status()
+                if status["exists"]:
+                    index_kwargs = {"progress_callback": progress_callback} if progress_callback is not None else {}
+                    return IndexStageOutcome(
+                        indexed=await index_service.update_index(processed_ids, **index_kwargs),
+                        item_count=len(processed_ids),
+                    )
             if source_names:
                 scoped_source_names = list(source_names)
                 total = await backend.count_conversation_ids(source_names=scoped_source_names)

--- a/tests/unit/pipeline/test_run_stages_runtime.py
+++ b/tests/unit/pipeline/test_run_stages_runtime.py
@@ -294,6 +294,17 @@ async def test_execute_index_stage_covers_parse_index_reprocess_and_error_paths(
         )
         assert index_ids == IndexStageOutcome(indexed=True, item_count=2)
 
+        update_calls_before_explicit_index = index_service.update_index.await_count
+        explicit_index_delta = await run_stages.execute_index_stage(
+            config=SimpleNamespace(),
+            stage="index",
+            source_names=None,
+            processed_ids={"conv-delta"},
+            backend=_backend(),
+        )
+        assert explicit_index_delta == IndexStageOutcome(indexed=True, item_count=1)
+        assert index_service.update_index.await_count == update_calls_before_explicit_index + 1
+
         rebuild_backend = _backend(count=4)
         rebuild = await run_stages.execute_index_stage(
             config=SimpleNamespace(),


### PR DESCRIPTION
## Summary

Explicit `polylogue run ... index` sequences now keep same-run catch-up incremental when the FTS index already exists. A trailing `index` stage with `processed_ids` repairs just those conversations instead of rebuilding the full archive.

## Problem

Sinnix runs Polylogue as an explicit `acquire parse materialize render index` systemd sequence. After #744, the `all`/`reprocess` path no longer duplicated FTS repair, but the explicit trailing `index` stage still meant archive-wide rebuild. Live deployment reproduced the issue: schema v4 worked and the raw backlog dropped from 356 to 3, but the service still read about 16.5 GB before I stopped it.

## Solution

`execute_index_stage()` now checks `processed_ids` before the standalone full-rebuild branch for `stage == "index"`. If the index already exists, it calls `IndexService.update_index(processed_ids)` and reports that delta count. Missing-index recovery, source-scoped `polylogue run index --source ...`, and standalone archive rebuilds keep the existing behavior.

## Verification

- `env POLYLOGUE_REPO_ROOT=/realm/project/polylogue-explicit-index PYTHONPATH=. direnv exec /realm/project/polylogue-explicit-index python -m pytest tests/unit/pipeline/test_run_stages_runtime.py -q` -> `8 passed in 9.87s`
- `env POLYLOGUE_REPO_ROOT=/realm/project/polylogue-explicit-index PYTHONPATH=. direnv exec /realm/project/polylogue-explicit-index python -m ruff check polylogue/pipeline/run_stages.py tests/unit/pipeline/test_run_stages_runtime.py` -> `All checks passed!`
- Pre-push `devtools verify --quick` -> `verify: all checks passed`

Ref #719

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed an issue where explicit index operations unnecessarily triggered full archive index rebuilds following standard catch-up runs. The system now only repairs conversations processed earlier in the same run when the index already exists, avoiding redundant rebuilds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->