### PR TITLE
fix(logging): preserve critical exception tracebacks

### DIFF
--- a/polylogue/cli/query.py
+++ b/polylogue/cli/query.py
@@ -288,7 +288,7 @@ def _create_query_vector_provider(config: Config, *, db_path: Path | None = None
     except (ValueError, ImportError):
         return None
     except Exception as exc:
-        logger.warning("Vector search setup failed: %s", exc)
+        logger.warning("Vector search setup failed: %s", exc, exc_info=True)
         return None
 
 

--- a/polylogue/operations/archive.py
+++ b/polylogue/operations/archive.py
@@ -516,7 +516,7 @@ class ArchiveStatsMixin:
         try:
             last_sync = await self.backend.get_last_sync_timestamp()
         except Exception as exc:  # pragma: no cover - defensive debug path
-            logger.debug("failed to query last sync timestamp", error=str(exc))
+            logger.warning("failed to query last sync timestamp", error=str(exc), exc_info=True)
 
         return ArchiveStats(
             conversation_count=storage_snapshot.total_conversations,

--- a/polylogue/pipeline/services/acquisition.py
+++ b/polylogue/pipeline/services/acquisition.py
@@ -104,6 +104,7 @@ class AcquisitionService:
                     "Failed to scan source",
                     source=source.name,
                     error=str(exc),
+                    exc_info=True,
                 )
                 result.counts["errors"] += 1
                 prior_errors = cursor_state.get("error_count", 0)

--- a/polylogue/pipeline/services/acquisition_persistence.py
+++ b/polylogue/pipeline/services/acquisition_persistence.py
@@ -33,6 +33,7 @@ async def persist_raw_record(
             source=record.source_name,
             path=record.source_path,
             error=str(exc),
+            exc_info=True,
         )
         result.errors += 1
 

--- a/polylogue/pipeline/services/ingest_batch.py
+++ b/polylogue/pipeline/services/ingest_batch.py
@@ -1289,7 +1289,7 @@ async def refresh_session_insights_bulk(
             )
         return observation
     except Exception as exc:
-        logger.warning("Session product refresh failed (non-fatal): %s", exc)
+        logger.warning("Session product refresh failed (non-fatal): %s", exc, exc_info=True)
         return {
             "conversations": len(changed_conversation_ids),
             "failed": True,

--- a/polylogue/pipeline/services/rendering.py
+++ b/polylogue/pipeline/services/rendering.py
@@ -154,7 +154,7 @@ class RenderService:
                 )
                 result.record_failure(convo_id, f"render timed out after {RENDER_TIMEOUT_S}s")
             except Exception as exc:
-                logger.warning("Failed to render conversation %s: %s", convo_id, exc)
+                logger.warning("Failed to render conversation %s: %s", convo_id, exc, exc_info=True)
                 result.record_failure(convo_id, str(exc))
 
             elapsed = time.perf_counter() - t0


### PR DESCRIPTION
## Summary

Adds `exc_info=True` to warning/critical exception log sites that currently log only stringified exceptions.

## Problem

Several archive, acquisition, rendering, and query failure paths were preserving the error message but dropping the traceback. That makes post-incident diagnosis harder, especially for the same performance and maintenance work tracked in the daemon/event-history direction.

## Solution

Update the affected logger calls in:

- `polylogue/cli/query.py`
- `polylogue/operations/archive.py`
- `polylogue/pipeline/services/acquisition.py`
- `polylogue/pipeline/services/acquisition_persistence.py`
- `polylogue/pipeline/services/ingest_batch.py`
- `polylogue/pipeline/services/rendering.py`

Ref #716

## Verification

- `git diff --check HEAD~1..HEAD`
- `ruff check polylogue/cli/query.py polylogue/operations/archive.py polylogue/pipeline/services/acquisition.py polylogue/pipeline/services/acquisition_persistence.py polylogue/pipeline/services/ingest_batch.py polylogue/pipeline/services/rendering.py`
- Pre-push hook: `devtools verify --quick` passed (`ruff format`, `ruff check`, `mypy`, `render-all`, `verify-topology`, `verify-layering`, `verify-file-budgets`, `verify-test-ownership`, `verify-schema-roundtrip`, `verify-cross-cuts`, `verify-suppressions`, `verify-manifests`, `verify-witness-lifecycle`, `proof-pack check`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Improved error logging across core services to capture complete exception stack traces during failures in query processing, data acquisition, persistence, batch operations, and rendering, enabling better diagnostics and troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->