### PR TITLE
feat(api): formalize Polylogue as canonical surface, rewire CLI+MCP adapters (#723, #578)

### DIFF
--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -20,6 +20,7 @@ from polylogue.storage.sqlite.queries.message_query_reads import MessageTypeName
 
 if TYPE_CHECKING:
     from polylogue.archive.conversation.models import Conversation, ConversationSummary
+    from polylogue.archive.conversation.neighbor_candidates import ConversationNeighborCandidate
     from polylogue.archive.filter.filters import ConversationFilter
     from polylogue.archive.message.models import Message
     from polylogue.config import Config
@@ -124,6 +125,26 @@ if TYPE_CHECKING:
             self,
             request: InsightExportBundleRequest,
         ) -> InsightExportBundleResult: ...
+
+        async def neighbor_candidates(
+            self,
+            *,
+            conversation_id: str | None = None,
+            query: str | None = None,
+            provider: str | None = None,
+            limit: int = 10,
+            window_hours: int = 24,
+        ) -> list[ConversationNeighborCandidate]: ...
+
+        async def get_session_tree(self, conversation_id: str) -> list[Conversation]: ...
+
+        async def list_tags(self, *, provider: str | None = None) -> dict[str, int]: ...
+
+        async def get_conversation_stats(self, conversation_id: str) -> dict[str, int]: ...
+
+
+class ConversationNotFoundError(ValueError):
+    """Raised when a requested conversation does not exist in the archive."""
 
 
 class PolylogueArchiveMixin:
@@ -265,14 +286,17 @@ class PolylogueArchiveMixin:
         limit: int = 50,
         offset: int = 0,
         content_projection: ContentProjectionSpec | None = None,
-    ) -> tuple[list[dict[str, object]], int]:
-        """Return paginated messages for a conversation."""
+    ) -> tuple[list[Message], int]:
+        """Return paginated ``Message`` objects for a conversation.
+
+        Raises ``ConversationNotFoundError`` if the conversation does not exist.
+        """
         summary = await self.operations.get_conversation_summary(conversation_id)
         if summary is None:
-            return [], 0
+            raise ConversationNotFoundError(conversation_id)
         full_id = str(summary.id)
 
-        messages, total = await self.operations.get_messages_paginated(
+        return await self.operations.get_messages_paginated(
             full_id,
             message_role=message_role,
             message_type=message_type,
@@ -280,22 +304,6 @@ class PolylogueArchiveMixin:
             offset=offset,
             content_projection=content_projection,
         )
-
-        result = []
-        for m in messages:
-            result.append(
-                {
-                    "id": str(getattr(m, "id", "")),
-                    "role": str(getattr(m, "role", "")),
-                    "text": getattr(m, "text", None) or "",
-                    "sort_key": getattr(m, "sort_key", None),
-                    "has_tool_use": getattr(m, "is_tool_use", False),
-                    "has_thinking": getattr(m, "is_thinking", False),
-                    "message_type": getattr(getattr(m, "message_type", "message"), "value", "message"),
-                }
-            )
-
-        return result, total
 
     async def get_raw_artifacts_for_conversation(
         self,
@@ -414,3 +422,96 @@ class PolylogueArchiveMixin:
     ) -> InsightExportBundleResult:
         """Write a versioned archive-insight export bundle."""
         return await self.operations.export_insight_bundle(request)
+
+    async def get_conversation_summary(self, conversation_id: str) -> ConversationSummary | None:
+        """Return a summary record for a single conversation, or ``None`` if not found."""
+        return await self.operations.get_conversation_summary(conversation_id)
+
+    async def get_conversation_stats(self, conversation_id: str) -> dict[str, int]:
+        """Return message-count and word-count stats for a single conversation."""
+        return await self.operations.get_conversation_stats(conversation_id)
+
+    async def neighbor_candidates(
+        self,
+        *,
+        conversation_id: str | None = None,
+        query: str | None = None,
+        provider: str | None = None,
+        limit: int = 10,
+        window_hours: int = 24,
+    ) -> list[ConversationNeighborCandidate]:
+        """Discover explainable neighboring or near-duplicate candidates.
+
+        At least one of ``conversation_id`` or ``query`` must be provided.
+        """
+        return await self.operations.neighbor_candidates(
+            conversation_id=conversation_id,
+            query=query,
+            provider=provider,
+            limit=limit,
+            window_hours=window_hours,
+        )
+
+    async def get_session_tree(self, conversation_id: str) -> list[Conversation]:
+        """Return the full session tree (parent + children) for a conversation."""
+        return await self.operations.get_session_tree(conversation_id)
+
+    async def list_tags(self, *, provider: str | None = None) -> dict[str, int]:
+        """List all tags with conversation counts, optionally filtered by provider."""
+        return await self.operations.list_tags(provider=provider)
+
+    async def delete_conversation(self, conversation_id: str) -> bool:
+        """Permanently delete a conversation and all associated data.
+
+        Returns ``True`` if something was deleted, ``False`` if the conversation
+        was not found.
+        """
+        deleted_count = await self.filter().id(conversation_id).delete()
+        return deleted_count > 0
+
+    async def add_tag(self, conversation_id: str, tag: str) -> bool:
+        """Add a tag to a conversation. Returns ``True`` if the tag was newly added."""
+        resolved = await self.repository.resolve_id(conversation_id, strict=True)
+        if resolved is None:
+            raise ConversationNotFoundError(conversation_id)
+        from polylogue.storage.repository.archive.repository_writes import RepositoryWriteMixin
+
+        store: RepositoryWriteMixin = self.repository  # type: ignore[assignment]
+        existing = await store.list_tags()
+        await store.add_tag(str(resolved), tag)
+        after = await store.list_tags()
+        return after.get(tag, 0) > existing.get(tag, 0)
+
+    async def remove_tag(self, conversation_id: str, tag: str) -> bool:
+        """Remove a tag from a conversation. Returns ``True`` if the tag was removed."""
+        resolved = await self.repository.resolve_id(conversation_id, strict=True)
+        if resolved is None:
+            raise ConversationNotFoundError(conversation_id)
+        from polylogue.storage.repository.archive.repository_writes import RepositoryWriteMixin
+
+        store: RepositoryWriteMixin = self.repository  # type: ignore[assignment]
+        existing = await store.list_tags()
+        await store.remove_tag(str(resolved), tag)
+        after = await store.list_tags()
+        return after.get(tag, 0) < existing.get(tag, 0)
+
+    async def get_metadata(self, conversation_id: str) -> dict[str, str]:
+        """Return all metadata key-value pairs for a conversation."""
+        from polylogue.storage.repository.archive.repository_writes import RepositoryWriteMixin
+
+        store: RepositoryWriteMixin = self.repository  # type: ignore[assignment]
+        result: dict[str, str] = {}
+        doc = await store.get_metadata(conversation_id)
+        for k, v in doc.items():
+            result[str(k)] = str(v) if not isinstance(v, str) else v
+        return result
+
+    async def update_metadata(self, conversation_id: str, key: str, value: str) -> None:
+        """Set a metadata key on a conversation. Creates or updates the key."""
+        resolved = await self.repository.resolve_id(conversation_id, strict=True)
+        if resolved is None:
+            raise ConversationNotFoundError(conversation_id)
+        from polylogue.storage.repository.archive.repository_writes import RepositoryWriteMixin
+
+        store: RepositoryWriteMixin = self.repository  # type: ignore[assignment]
+        await store.update_metadata(str(resolved), key, value)

--- a/polylogue/cli/commands/export.py
+++ b/polylogue/cli/commands/export.py
@@ -42,7 +42,7 @@ def _root_message_roles(ctx: click.Context) -> tuple[object, ...]:
 def export_command(ctx: click.Context, conversation_id: str, output_format: str, fields: str | None) -> None:
     """Export one known conversation by ID. IDs can use the provider:id-prefix form (e.g. claude-ai:abc123)."""
     env: AppEnv = ctx.obj
-    conversation = run_coroutine_sync(env.operations.get_conversation(conversation_id))
+    conversation = run_coroutine_sync(env.polylogue.get_conversation(conversation_id))
     if conversation is None:
         fail("export", f"Conversation not found: {conversation_id}")
     roles = _root_message_roles(ctx)

--- a/polylogue/cli/commands/neighbors.py
+++ b/polylogue/cli/commands/neighbors.py
@@ -68,7 +68,7 @@ def neighbors_command(
 
     try:
         candidates = run_coroutine_sync(
-            env.operations.neighbor_candidates(
+            env.polylogue.neighbor_candidates(
                 conversation_id=conversation_id,
                 query=query,
                 provider=provider,

--- a/polylogue/cli/commands/tags.py
+++ b/polylogue/cli/commands/tags.py
@@ -29,7 +29,7 @@ def tags_command(
         polylogue tags --format json    # Machine-readable output
         polylogue tags -n 10            # Top 10 tags
     """
-    tags = run_coroutine_sync(env.repository.list_tags(provider=provider))
+    tags = run_coroutine_sync(env.polylogue.list_tags(provider=provider))
 
     if count is not None:
         # Truncate to top N (already sorted by count desc from SQL)

--- a/polylogue/cli/messages.py
+++ b/polylogue/cli/messages.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import cast
 
+from polylogue.api.archive import ConversationNotFoundError
 from polylogue.api.sync.bridge import run_coroutine_sync
 from polylogue.archive.message.roles import MessageRoleFilter, normalize_message_roles
 from polylogue.archive.semantic.content_projection import ContentProjectionSpec
@@ -45,20 +46,19 @@ def run_messages(
                 }
             )
 
-            result = await api.get_messages_paginated(
-                conversation_id,
-                message_role=roles,
-                message_type=cast(MessageTypeName, message_type),
-                limit=limit,
-                offset=offset,
-                content_projection=projection,
-            )
-
-            if result is None:
+            try:
+                messages, total = await api.get_messages_paginated(
+                    conversation_id,
+                    message_role=roles,
+                    message_type=cast(MessageTypeName, message_type),
+                    limit=limit,
+                    offset=offset,
+                    content_projection=projection,
+                )
+            except ConversationNotFoundError:
                 env.ui.error(f"Conversation not found: {conversation_id}")
                 return
 
-            messages, total = result
             fmt = output_format or "markdown"
 
             if fmt == "json":
@@ -68,10 +68,10 @@ def run_messages(
                     "conversation_id": conversation_id,
                     "messages": [
                         {
-                            "id": m.get("id", ""),
-                            "role": m.get("role", ""),
-                            "message_type": m.get("message_type", "message"),
-                            "text": m.get("text", ""),
+                            "id": str(m.id),
+                            "role": str(m.role),
+                            "message_type": str(m.message_type.value),
+                            "text": m.text or "",
                         }
                         for m in messages
                     ],
@@ -82,9 +82,9 @@ def run_messages(
                 env.ui.print(_json.dumps(payload, indent=2))
             else:
                 for msg in messages:
-                    role = str(msg.get("role", "unknown"))
-                    message_type_label = str(msg.get("message_type", "message"))
-                    text = str(msg.get("text", ""))
+                    role = str(msg.role)
+                    message_type_label = str(msg.message_type.value)
+                    text = msg.text or ""
                     if text:
                         env.ui.print(f"[{role} {message_type_label}] {text[:500]}{'...' if len(text) > 500 else ''}")
                         env.ui.print("---")

--- a/polylogue/cli/shared/types.py
+++ b/polylogue/cli/shared/types.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
 
 from polylogue.config import Config
 from polylogue.operations import ArchiveOperations
@@ -10,6 +11,9 @@ from polylogue.services import RuntimeServices, build_runtime_services
 from polylogue.storage.repository import ConversationRepository
 from polylogue.storage.sqlite.async_sqlite import SQLiteBackend
 from polylogue.ui import UI
+
+if TYPE_CHECKING:
+    from polylogue.api import Polylogue
 
 
 @dataclass
@@ -34,3 +38,9 @@ class AppEnv:
     @property
     def operations(self) -> ArchiveOperations:
         return ArchiveOperations.from_services(self.services)
+
+    @property
+    def polylogue(self) -> Polylogue:
+        from polylogue.api import Polylogue
+
+        return Polylogue(archive_root=self.config.archive_root, db_path=self.config.db_path)

--- a/polylogue/daemon/http.py
+++ b/polylogue/daemon/http.py
@@ -334,7 +334,15 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
                 HTTPStatus.OK,
                 {
                     "ok": True,
-                    "messages": messages,
+                    "messages": [
+                        {
+                            "id": m.id,
+                            "role": str(m.role),
+                            "text": m.text or "",
+                            "message_type": m.message_type.value,
+                        }
+                        for m in messages
+                    ],
                     "total": total,
                     "limit": limit,
                     "offset": offset,

--- a/polylogue/mcp/server.py
+++ b/polylogue/mcp/server.py
@@ -14,6 +14,7 @@ from polylogue.mcp.server_support import (
     _error_json,
     _extract_fenced_code,
     _get_config,
+    _get_polylogue,
     _get_runtime_services,
     _json_payload,
     _safe_call,
@@ -87,6 +88,7 @@ def build_server(*, role: MCPRole = "read") -> FastMCP:
         get_backend=lambda: _get_backend(),
         get_config=lambda: _get_config(),
         get_archive_ops=lambda: _get_archive_ops(),
+        get_polylogue=lambda: _get_polylogue(),
         extract_fenced_code=_extract_fenced_code,
         role=role,
     )

--- a/polylogue/mcp/server_insight_tools.py
+++ b/polylogue/mcp/server_insight_tools.py
@@ -35,9 +35,9 @@ def _register_list_tool(
 
     async def tool_fn(**kwargs: object) -> str:
         async def run() -> str:
-            ops = hooks.get_archive_ops()
+            poly = hooks.get_polylogue()
             normalized_kwargs = spec.normalize_kwargs(hooks.clamp_limit, kwargs)
-            insights = await fetch_insights_async(pt, ops, **normalized_kwargs)
+            insights = await fetch_insights_async(pt, poly, **normalized_kwargs)
             return hooks.json_payload(MCPRootPayload(root=insight_items_payload(insights, pt, item_key="items")))
 
         return await hooks.async_safe_call(pt.name, run)
@@ -74,7 +74,8 @@ def register_insight_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
         """Get a single session profile by conversation ID."""
 
         async def run() -> str:
-            insight = await hooks.get_archive_ops().get_session_profile_insight(
+            poly = hooks.get_polylogue()
+            insight = await poly.get_session_profile_insight(
                 conversation_id,
                 tier=tier,
             )

--- a/polylogue/mcp/server_maintenance_tools.py
+++ b/polylogue/mcp/server_maintenance_tools.py
@@ -77,7 +77,9 @@ def register_maintenance_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
                 no_file_reads=no_file_reads,
                 prose_only=prose_only,
             ).build_projection()
-            conv = await hooks.get_archive_ops().get_conversation(id, content_projection=projection)
+
+            poly = hooks.get_polylogue()
+            conv = await poly.get_conversation(id, content_projection=projection)
             if conv is None:
                 return hooks.error_json(f"Conversation not found: {id}")
             fmt = normalize_conversation_output_format(format)
@@ -88,7 +90,8 @@ def register_maintenance_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
     @mcp.tool()
     async def rebuild_session_insights(conversation_ids: list[str] | None = None) -> str:
         async def run() -> str:
-            counts = await hooks.get_archive_ops().rebuild_session_insights(conversation_ids=conversation_ids)
+            poly = hooks.get_polylogue()
+            counts = await poly.rebuild_insights(conversation_ids=conversation_ids)
             return hooks.json_payload(
                 MCPRootPayload(
                     root={

--- a/polylogue/mcp/server_mutation_tools.py
+++ b/polylogue/mcp/server_mutation_tools.py
@@ -17,14 +17,17 @@ def register_mutation_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
     @mcp.tool()
     async def add_tag(conversation_id: str, tag: str) -> str:
         async def run() -> str:
-            resolved = await hooks.get_query_store().resolve_id(conversation_id, strict=True)
-            if not resolved:
+            from polylogue.api.archive import ConversationNotFoundError
+
+            poly = hooks.get_polylogue()
+            try:
+                await poly.add_tag(conversation_id, tag)
+            except ConversationNotFoundError:
                 return hooks.error_json("conversation not found", conversation_id=conversation_id)
-            await hooks.get_tag_store().add_tag(resolved, tag)
             return hooks.json_payload(
                 MCPMutationStatusPayload(
                     status="ok",
-                    conversation_id=resolved,
+                    conversation_id=conversation_id,
                     tag=tag,
                 ),
                 exclude_none=True,
@@ -35,14 +38,17 @@ def register_mutation_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
     @mcp.tool()
     async def remove_tag(conversation_id: str, tag: str) -> str:
         async def run() -> str:
-            resolved = await hooks.get_query_store().resolve_id(conversation_id, strict=True)
-            if not resolved:
+            from polylogue.api.archive import ConversationNotFoundError
+
+            poly = hooks.get_polylogue()
+            try:
+                await poly.remove_tag(conversation_id, tag)
+            except ConversationNotFoundError:
                 return hooks.error_json("conversation not found", conversation_id=conversation_id)
-            await hooks.get_tag_store().remove_tag(resolved, tag)
             return hooks.json_payload(
                 MCPMutationStatusPayload(
                     status="ok",
-                    conversation_id=resolved,
+                    conversation_id=conversation_id,
                     tag=tag,
                 ),
                 exclude_none=True,
@@ -79,7 +85,8 @@ def register_mutation_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
     @mcp.tool()
     async def list_tags(provider: str | None = None) -> str:
         async def run() -> str:
-            tags = await hooks.get_tag_store().list_tags(provider=provider)
+            poly = hooks.get_polylogue()
+            tags = await poly.list_tags(provider=provider)
             return hooks.json_payload(MCPTagCountsPayload(root=tags))
 
         return await hooks.async_safe_call("list_tags", run)
@@ -87,7 +94,8 @@ def register_mutation_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
     @mcp.tool()
     async def get_metadata(conversation_id: str) -> str:
         async def run() -> str:
-            metadata = await hooks.get_tag_store().get_metadata(conversation_id)
+            poly = hooks.get_polylogue()
+            metadata = await poly.get_metadata(conversation_id)
             return hooks.json_payload(MCPMetadataPayload.from_document(metadata))
 
         return await hooks.async_safe_call("get_metadata", run)
@@ -95,18 +103,22 @@ def register_mutation_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
     @mcp.tool()
     async def set_metadata(conversation_id: str, key: str, value: str) -> str:
         async def run() -> str:
-            resolved = await hooks.get_query_store().resolve_id(conversation_id, strict=True)
-            if not resolved:
-                return hooks.error_json("conversation not found", conversation_id=conversation_id)
+            from polylogue.api.archive import ConversationNotFoundError
+
+            poly = hooks.get_polylogue()
             try:
-                parsed_value = json.loads(value)
-            except (json.JSONDecodeError, TypeError):
-                parsed_value = value
-            await hooks.get_tag_store().update_metadata(resolved, key, parsed_value)
+                from contextlib import suppress
+
+                parsed_value: object = value
+                with suppress(json.JSONDecodeError, TypeError):
+                    parsed_value = json.loads(value)
+                await poly.update_metadata(conversation_id, key, str(parsed_value))
+            except ConversationNotFoundError:
+                return hooks.error_json("conversation not found", conversation_id=conversation_id)
             return hooks.json_payload(
                 MCPMutationStatusPayload(
                     status="ok",
-                    conversation_id=resolved,
+                    conversation_id=conversation_id,
                     key=key,
                 ),
                 exclude_none=True,
@@ -140,14 +152,18 @@ def register_mutation_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
                     "Safety guard: set confirm=true to delete",
                     conversation_id=conversation_id,
                 )
-            resolved = await hooks.get_query_store().resolve_id(conversation_id, strict=True)
-            if not resolved:
+            from polylogue.api.archive import ConversationNotFoundError
+            from polylogue.mcp.server_support import _get_polylogue
+
+            poly = _get_polylogue()
+            try:
+                deleted = await poly.delete_conversation(conversation_id)
+            except ConversationNotFoundError:
                 return hooks.error_json("conversation not found", conversation_id=conversation_id)
-            deleted = await hooks.get_query_store().delete_conversation(resolved)
             return hooks.json_payload(
                 MCPMutationStatusPayload(
                     status="deleted" if deleted else "not_found",
-                    conversation_id=resolved,
+                    conversation_id=conversation_id,
                 ),
                 exclude_none=True,
             )

--- a/polylogue/mcp/server_support.py
+++ b/polylogue/mcp/server_support.py
@@ -16,6 +16,7 @@ from polylogue.services import RuntimeServices, build_runtime_services
 from polylogue.surfaces.payloads import serialize_surface_payload
 
 if TYPE_CHECKING:
+    from polylogue.api import Polylogue
     from polylogue.config import Config
     from polylogue.storage.sqlite.async_sqlite import SQLiteBackend
 
@@ -49,6 +50,7 @@ class ServerCallbacks:
     get_backend: Callable[[], SQLiteBackend]
     get_config: Callable[[], Config]
     get_archive_ops: Callable[[], ArchiveOperations]
+    get_polylogue: Callable[[], Polylogue]
     extract_fenced_code: FencedCodeExtractor
     role: MCPRole
 
@@ -194,6 +196,14 @@ def _get_config() -> Config:
     return _get_runtime_services().get_config()
 
 
+def _get_polylogue() -> Polylogue:
+    """Return a ``Polylogue`` facade bound to the configured archive/database."""
+    from polylogue.api import Polylogue
+
+    cfg = _get_config()
+    return Polylogue(archive_root=cfg.archive_root, db_path=cfg.db_path)
+
+
 __all__ = [
     "MCPRole",
     "ServerCallbacks",
@@ -203,6 +213,7 @@ __all__ = [
     "_extract_fenced_code",
     "_get_backend",
     "_get_config",
+    "_get_polylogue",
     "_get_query_store",
     "_get_runtime_services",
     "_get_tag_store",

--- a/polylogue/mcp/server_tools.py
+++ b/polylogue/mcp/server_tools.py
@@ -158,11 +158,11 @@ def register_query_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
         id: str,
     ) -> str:
         async def run() -> str:
-            ops = hooks.get_archive_ops()
-            summary = await ops.get_conversation_summary(id)
+            poly = hooks.get_polylogue()
+            summary = await poly.get_conversation_summary(id)
             if summary is None:
                 return hooks.error_json(f"Conversation not found: {id}")
-            stats = await ops.get_conversation_stats(id)
+            stats = await poly.get_conversation_stats(id)
             return hooks.json_payload(
                 MCPConversationSummaryPayload.from_summary(
                     summary,
@@ -183,7 +183,9 @@ def register_query_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
         async def run() -> str:
             if not id and not (query and query.strip()):
                 return hooks.error_json("neighbor_candidates requires id or query")
-            candidates = await hooks.get_archive_ops().neighbor_candidates(
+
+            poly = hooks.get_polylogue()
+            candidates = await poly.neighbor_candidates(
                 conversation_id=id,
                 query=query,
                 provider=provider,
@@ -213,11 +215,11 @@ def register_read_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
     @mcp.tool()
     async def get_conversation_summary(id: str) -> str:
         async def run() -> str:
-            ops = hooks.get_archive_ops()
-            summary = await ops.get_conversation_summary(id)
+            poly = hooks.get_polylogue()
+            summary = await poly.get_conversation_summary(id)
             if summary is None:
                 return hooks.error_json(f"Conversation not found: {id}")
-            stats = await ops.get_conversation_stats(id)
+            stats = await poly.get_conversation_stats(id)
             return hooks.json_payload(
                 MCPConversationSummaryPayload.from_summary(
                     summary,
@@ -230,7 +232,8 @@ def register_read_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
     @mcp.tool()
     async def get_session_tree(conversation_id: str) -> str:
         async def run() -> str:
-            tree = await hooks.get_archive_ops().get_session_tree(conversation_id)
+            poly = hooks.get_polylogue()
+            tree = await poly.get_session_tree(conversation_id)
             return hooks.json_payload(conversation_summary_list_payload(tree))
 
         return await hooks.async_safe_call("get_session_tree", run)
@@ -265,11 +268,9 @@ def register_read_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
                 prose_only=prose_only,
             ).build_projection()
 
-            ops = hooks.get_archive_ops()
-            summary = await ops.get_conversation_summary(conversation_id)
-            if summary is None:
-                return hooks.error_json(f"Conversation not found: {conversation_id}")
-            canonical_id = str(summary.id)
+            from polylogue.api.archive import ConversationNotFoundError
+
+            poly = hooks.get_polylogue()
             from polylogue.archive.message.roles import normalize_message_roles
             from polylogue.archive.message.types import validate_message_type_filter
 
@@ -277,18 +278,21 @@ def register_read_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
             normalized_message_type = (
                 validate_message_type_filter(message_type).value if message_type is not None else None
             )
-            paginated, total = await ops.get_messages_paginated(
-                canonical_id,
-                message_role=roles,
-                message_type=cast("MessageTypeName | None", normalized_message_type),
-                limit=hooks.clamp_limit(limit),
-                offset=max(0, offset),
-                content_projection=projection,
-            )
+            try:
+                paginated, total = await poly.get_messages_paginated(
+                    conversation_id,
+                    message_role=roles,
+                    message_type=cast("MessageTypeName | None", normalized_message_type),
+                    limit=hooks.clamp_limit(limit),
+                    offset=max(0, offset),
+                    content_projection=projection,
+                )
+            except ConversationNotFoundError:
+                return hooks.error_json(f"Conversation not found: {conversation_id}")
 
             return hooks.json_payload(
                 MCPMessagesListPayload(
-                    conversation_id=canonical_id,
+                    conversation_id=conversation_id,
                     messages=tuple(MCPMessagePayload.from_message(msg) for msg in paginated),
                     total=total,
                     limit=hooks.clamp_limit(limit),

--- a/tests/infra/mcp.py
+++ b/tests/infra/mcp.py
@@ -172,6 +172,40 @@ def make_archive_ops_mock() -> MagicMock:
     return operations
 
 
+def make_polylogue_mock() -> MagicMock:
+    """Create a Polylogue facade mock matching the current MCP tool surface."""
+    poly = MagicMock()
+    poly.add_tag = AsyncMock()
+    poly.remove_tag = AsyncMock()
+    poly.list_tags = AsyncMock(return_value={})
+    poly.get_metadata = AsyncMock(return_value={})
+    poly.update_metadata = AsyncMock()
+    poly.delete_conversation = AsyncMock(return_value=False)
+    poly.get_conversation_summary = AsyncMock(return_value=None)
+    poly.get_conversation_stats = AsyncMock(return_value={})
+    poly.get_session_tree = AsyncMock(return_value=[])
+    poly.get_messages_paginated = AsyncMock(return_value=([], 0))
+    poly.get_conversation = AsyncMock(return_value=None)
+    poly.get_session_profile_insight = AsyncMock(return_value=None)
+    poly.neighbor_candidates = AsyncMock(return_value=[])
+    poly.rebuild_insights = AsyncMock(
+        return_value=MagicMock(to_dict=MagicMock(return_value={}), total=MagicMock(return_value=0))
+    )
+    poly.list_session_profile_insights = AsyncMock(return_value=[])
+    poly.list_session_enrichment_insights = AsyncMock(return_value=[])
+    poly.list_session_work_event_insights = AsyncMock(return_value=[])
+    poly.list_session_phase_insights = AsyncMock(return_value=[])
+    poly.list_session_tag_rollup_insights = AsyncMock(return_value=[])
+    poly.list_work_thread_insights = AsyncMock(return_value=[])
+    poly.list_day_session_summary_insights = AsyncMock(return_value=[])
+    poly.list_week_session_summary_insights = AsyncMock(return_value=[])
+    poly.list_provider_analytics_insights = AsyncMock(return_value=[])
+    poly.list_session_cost_insights = AsyncMock(return_value=[])
+    poly.list_cost_rollup_insights = AsyncMock(return_value=[])
+    poly.list_archive_debt_insights = AsyncMock(return_value=[])
+    return poly
+
+
 def make_mock_filter(results: Sequence[object] | None = None, **method_overrides: object) -> MagicMock:
     """Create a chaining-capable ConversationFilter mock."""
     filt = MagicMock()

--- a/tests/unit/mcp/test_server_surfaces.py
+++ b/tests/unit/mcp/test_server_surfaces.py
@@ -24,6 +24,7 @@ from tests.infra.mcp import (
     invoke_surface,
     invoke_surface_async,
     make_mock_filter,
+    make_polylogue_mock,
     make_query_store_mock,
     make_simple_conversation,
     make_tag_store_mock,
@@ -469,14 +470,13 @@ class TestExportConversationTool:
             ],
         )
 
-        with patch("polylogue.mcp.server._get_archive_ops") as mock_get_archive_ops:
-            mock_ops = MagicMock()
-            mock_ops.get_conversation_summary = AsyncMock(return_value=_summary_for(projected_input))
+        with patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue:
+            mock_poly = make_polylogue_mock()
             projected = projected_input.with_content_projection(ContentProjectionSpec(include_code=False))
-            mock_ops.get_messages_paginated = AsyncMock(
+            mock_poly.get_messages_paginated = AsyncMock(
                 return_value=(list(projected.messages), len(projected.messages))
             )
-            mock_get_archive_ops.return_value = mock_ops
+            mock_get_polylogue.return_value = mock_poly
 
             result = invoke_surface(
                 mcp_server._tool_manager._tools["get_messages"].fn,
@@ -486,17 +486,17 @@ class TestExportConversationTool:
 
         payload = json.loads(result)
         assert payload["messages"][0]["text"] == "Alpha\n\nOmega"
-        projection = mock_ops.get_messages_paginated.await_args.kwargs["content_projection"]
+        projection = mock_poly.get_messages_paginated.await_args.kwargs["content_projection"]
         assert projection.include_code is False
 
     def test_export_markdown(self: object, simple_conversation: Conversation, mcp_server: MCPServerUnderTest) -> None:
         with (
-            patch("polylogue.mcp.server._get_archive_ops") as mock_get_archive_ops,
+            patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue,
             patch("polylogue.rendering.formatting.format_conversation") as mock_format,
         ):
-            mock_ops = MagicMock()
-            mock_ops.get_conversation = AsyncMock(return_value=simple_conversation)
-            mock_get_archive_ops.return_value = mock_ops
+            mock_poly = make_polylogue_mock()
+            mock_poly.get_conversation = AsyncMock(return_value=simple_conversation)
+            mock_get_polylogue.return_value = mock_poly
             mock_format.return_value = "# Test Conversation\n\nFormatted content"
 
             result = invoke_surface(
@@ -512,10 +512,10 @@ class TestExportConversationTool:
         assert call_args[0][1] == "markdown"
 
     def test_export_not_found(self: object, mcp_server: MCPServerUnderTest) -> None:
-        with patch("polylogue.mcp.server._get_archive_ops") as mock_get_archive_ops:
-            mock_ops = MagicMock()
-            mock_ops.get_conversation = AsyncMock(return_value=None)
-            mock_get_archive_ops.return_value = mock_ops
+        with patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue:
+            mock_poly = make_polylogue_mock()
+            mock_poly.get_conversation = AsyncMock(return_value=None)
+            mock_get_polylogue.return_value = mock_poly
 
             result = invoke_surface(mcp_server._tool_manager._tools["export_conversation"].fn, id="nonexistent")
 
@@ -529,12 +529,12 @@ class TestExportConversationTool:
         mcp_server: MCPServerUnderTest,
     ) -> None:
         with (
-            patch("polylogue.mcp.server._get_archive_ops") as mock_get_archive_ops,
+            patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue,
             patch("polylogue.rendering.formatting.format_conversation") as mock_format,
         ):
-            mock_ops = MagicMock()
-            mock_ops.get_conversation = AsyncMock(return_value=simple_conversation)
-            mock_get_archive_ops.return_value = mock_ops
+            mock_poly = make_polylogue_mock()
+            mock_poly.get_conversation = AsyncMock(return_value=simple_conversation)
+            mock_get_polylogue.return_value = mock_poly
             mock_format.return_value = "# Content"
 
             invoke_surface(

--- a/tests/unit/mcp/test_tool_contracts.py
+++ b/tests/unit/mcp/test_tool_contracts.py
@@ -485,10 +485,10 @@ class TestQueryTools:
 
     @pytest.mark.asyncio
     async def test_neighbor_candidates_exposes_candidate_reasons(self, mcp_server: MCPServerUnderTest) -> None:
-        with patch("polylogue.mcp.server._get_archive_ops") as mock_get_archive_ops:
-            mock_ops = MagicMock()
-            mock_ops.neighbor_candidates = AsyncMock(return_value=[_make_neighbor_candidate()])
-            mock_get_archive_ops.return_value = mock_ops
+        with patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue:
+            mock_poly = make_polylogue_mock()
+            mock_poly.neighbor_candidates = AsyncMock(return_value=[_make_neighbor_candidate()])
+            mock_get_polylogue.return_value = mock_poly
 
             raw = await invoke_surface_async(
                 mcp_server._tool_manager._tools["neighbor_candidates"].fn,
@@ -500,7 +500,7 @@ class TestQueryTools:
         assert payload[0]["conversation"]["id"] == "candidate"
         assert payload[0]["reasons"][0]["kind"] == "nearby_time"
         assert payload[0]["source_conversation_id"] == "target"
-        mock_ops.neighbor_candidates.assert_awaited_once_with(
+        mock_poly.neighbor_candidates.assert_awaited_once_with(
             conversation_id="target",
             query=None,
             provider=None,
@@ -511,19 +511,19 @@ class TestQueryTools:
 
 class TestGetConversationTool:
     def test_get_returns_conversation(self, simple_conversation: Conversation, mcp_server: MCPServerUnderTest) -> None:
-        with patch("polylogue.mcp.server._get_archive_ops") as mock_get_archive_ops:
-            mock_ops = MagicMock()
-            mock_ops.get_conversation_summary = AsyncMock(
+        with patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue:
+            mock_poly = make_polylogue_mock()
+            mock_poly.get_conversation_summary = AsyncMock(
                 return_value=_make_summary(
                     str(simple_conversation.id),
                     provider=Provider.from_string(str(simple_conversation.provider)),
                     title=simple_conversation.display_title,
                 )
             )
-            mock_ops.get_conversation_stats = AsyncMock(
+            mock_poly.get_conversation_stats = AsyncMock(
                 return_value={"total_messages": len(simple_conversation.messages)}
             )
-            mock_get_archive_ops.return_value = mock_ops
+            mock_get_polylogue.return_value = mock_poly
 
             result = invoke_surface(mcp_server._tool_manager._tools["get_conversation"].fn, id="test:conv-123")
 
@@ -533,10 +533,10 @@ class TestGetConversationTool:
         assert "messages" not in conv
 
     def test_get_not_found(self, mcp_server: MCPServerUnderTest) -> None:
-        with patch("polylogue.mcp.server._get_archive_ops") as mock_get_archive_ops:
-            mock_ops = MagicMock()
-            mock_ops.get_conversation_summary = AsyncMock(return_value=None)
-            mock_get_archive_ops.return_value = mock_ops
+        with patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue:
+            mock_poly = make_polylogue_mock()
+            mock_poly.get_conversation_summary = AsyncMock(return_value=None)
+            mock_get_polylogue.return_value = mock_poly
 
             result = invoke_surface(mcp_server._tool_manager._tools["get_conversation"].fn, id="nonexistent")
 
@@ -548,22 +548,19 @@ class TestGetConversationTool:
         long_text = "A" * 2000
         message = make_msg(id="m1", role="assistant", text=long_text)
 
-        with patch("polylogue.mcp.server._get_archive_ops") as mock_get_archive_ops:
-            mock_ops = MagicMock()
-            mock_ops.get_conversation_summary = AsyncMock(return_value=_make_summary("test:long"))
-            mock_ops.get_messages_paginated = AsyncMock(return_value=([message], 1))
-            mock_get_archive_ops.return_value = mock_ops
+        with patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue:
+            mock_poly = make_polylogue_mock()
+            mock_poly.get_messages_paginated = AsyncMock(return_value=([message], 1))
+            mock_get_polylogue.return_value = mock_poly
 
             result = invoke_surface(mcp_server._tool_manager._tools["get_messages"].fn, conversation_id="test:long")
 
         assert json.loads(result)["messages"][0]["text"] == long_text
 
     def test_get_messages_rejects_unknown_message_type(self, mcp_server: MCPServerUnderTest) -> None:
-        with patch("polylogue.mcp.server._get_archive_ops") as mock_get_archive_ops:
-            mock_ops = MagicMock()
-            mock_ops.get_conversation_summary = AsyncMock(return_value=_make_summary("test:long"))
-            mock_ops.get_messages_paginated = AsyncMock(return_value=([], 0))
-            mock_get_archive_ops.return_value = mock_ops
+        with patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue:
+            mock_poly = make_polylogue_mock()
+            mock_get_polylogue.return_value = mock_poly
 
             result = invoke_surface(
                 mcp_server._tool_manager._tools["get_messages"].fn,
@@ -574,14 +571,13 @@ class TestGetConversationTool:
         payload = json.loads(result)
         assert payload["error"] == "internal MCP tool error"
         assert payload["detail"] == "ValueError"
-        mock_ops.get_messages_paginated.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_get_with_nonexistent_id(self, mcp_server: MCPServerUnderTest) -> None:
-        with patch("polylogue.mcp.server._get_archive_ops") as mock_get_archive_ops:
-            mock_ops = MagicMock()
-            mock_ops.get_conversation_summary = AsyncMock(return_value=None)
-            mock_get_archive_ops.return_value = mock_ops
+        with patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue:
+            mock_poly = make_polylogue_mock()
+            mock_poly.get_conversation_summary = AsyncMock(return_value=None)
+            mock_get_polylogue.return_value = mock_poly
 
             result = await invoke_surface_async(
                 mcp_server._tool_manager._tools["get_conversation"].fn, id="nonexistent-id-xyz"
@@ -603,10 +599,10 @@ class TestInsightTools:
             inference_provenance=_inference_provenance(),
             inference=SessionInferencePayload(engaged_duration_ms=120000),
         )
-        with patch("polylogue.mcp.server._get_archive_ops") as mock_get_archive_ops:
-            mock_ops = MagicMock()
-            mock_ops.get_session_profile_insight = AsyncMock(return_value=insight)
-            mock_get_archive_ops.return_value = mock_ops
+        with patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue:
+            mock_poly = make_polylogue_mock()
+            mock_poly.get_session_profile_insight = AsyncMock(return_value=insight)
+            mock_get_polylogue.return_value = mock_poly
 
             raw = await invoke_surface_async(
                 mcp_server._tool_manager._tools["session_profile"].fn,
@@ -760,21 +756,21 @@ class TestInsightTools:
             healthy=False,
             detail="1 pending session-insight row",
         )
-        with patch("polylogue.mcp.server._get_archive_ops") as mock_get_archive_ops:
-            mock_ops = MagicMock()
-            mock_ops.list_session_profile_insights = AsyncMock(return_value=[profile])
-            mock_ops.list_session_enrichment_insights = AsyncMock(return_value=[enrichment])
-            mock_ops.list_session_work_event_insights = AsyncMock(return_value=[work_event])
-            mock_ops.list_session_phase_insights = AsyncMock(return_value=[phase])
-            mock_ops.list_session_tag_rollup_insights = AsyncMock(return_value=[tag_rollup])
-            mock_ops.list_work_thread_insights = AsyncMock(return_value=[thread])
-            mock_ops.list_day_session_summary_insights = AsyncMock(return_value=[day_summary])
-            mock_ops.list_week_session_summary_insights = AsyncMock(return_value=[week_summary])
-            mock_ops.list_provider_analytics_insights = AsyncMock(return_value=[analytics])
-            mock_ops.list_session_cost_insights = AsyncMock(return_value=[session_cost])
-            mock_ops.list_cost_rollup_insights = AsyncMock(return_value=[cost_rollup])
-            mock_ops.list_archive_debt_insights = AsyncMock(return_value=[debt])
-            mock_get_archive_ops.return_value = mock_ops
+        with patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue:
+            mock_poly = make_polylogue_mock()
+            mock_poly.list_session_profile_insights = AsyncMock(return_value=[profile])
+            mock_poly.list_session_enrichment_insights = AsyncMock(return_value=[enrichment])
+            mock_poly.list_session_work_event_insights = AsyncMock(return_value=[work_event])
+            mock_poly.list_session_phase_insights = AsyncMock(return_value=[phase])
+            mock_poly.list_session_tag_rollup_insights = AsyncMock(return_value=[tag_rollup])
+            mock_poly.list_work_thread_insights = AsyncMock(return_value=[thread])
+            mock_poly.list_day_session_summary_insights = AsyncMock(return_value=[day_summary])
+            mock_poly.list_week_session_summary_insights = AsyncMock(return_value=[week_summary])
+            mock_poly.list_provider_analytics_insights = AsyncMock(return_value=[analytics])
+            mock_poly.list_session_cost_insights = AsyncMock(return_value=[session_cost])
+            mock_poly.list_cost_rollup_insights = AsyncMock(return_value=[cost_rollup])
+            mock_poly.list_archive_debt_insights = AsyncMock(return_value=[debt])
+            mock_get_polylogue.return_value = mock_poly
 
             profiles_raw = await invoke_surface_async(
                 mcp_server._tool_manager._tools["session_profiles"].fn,
@@ -955,14 +951,9 @@ class TestStatsTool:
 
 class TestMutationTools:
     def test_add_tag_success(self, mcp_server: MCPServerUnderTest) -> None:
-        with (
-            patch("polylogue.mcp.server._get_query_store") as mock_get_query_store,
-            patch("polylogue.mcp.server._get_tag_store") as mock_get_tag_store,
-        ):
-            mock_get_query_store.return_value = make_query_store_mock(resolved_id="test:conv-123")
-            mock_tag_store = make_tag_store_mock()
-            mock_tag_store.add_tag.return_value = None
-            mock_get_tag_store.return_value = mock_tag_store
+        with patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue:
+            mock_poly = make_polylogue_mock()
+            mock_get_polylogue.return_value = mock_poly
 
             result = invoke_surface(
                 mcp_server._tool_manager._tools["add_tag"].fn, conversation_id="test:conv-123", tag="important"
@@ -970,17 +961,13 @@ class TestMutationTools:
 
         parsed = json.loads(result)
         assert parsed == {"status": "ok", "conversation_id": "test:conv-123", "tag": "important"}
-        mock_tag_store.add_tag.assert_called_once_with("test:conv-123", "important")
+        mock_poly.add_tag.assert_called_once_with("test:conv-123", "important")
 
     def test_add_tag_error(self, mcp_server: MCPServerUnderTest) -> None:
-        with (
-            patch("polylogue.mcp.server._get_query_store") as mock_get_query_store,
-            patch("polylogue.mcp.server._get_tag_store") as mock_get_tag_store,
-        ):
-            mock_get_query_store.return_value = make_query_store_mock(resolved_id="test:conv-123")
-            mock_tag_store = make_tag_store_mock()
-            mock_tag_store.add_tag.side_effect = ValueError("Invalid tag")
-            mock_get_tag_store.return_value = mock_tag_store
+        with patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue:
+            mock_poly = make_polylogue_mock()
+            mock_poly.add_tag.side_effect = ValueError("Invalid tag")
+            mock_get_polylogue.return_value = mock_poly
 
             result = invoke_surface(
                 mcp_server._tool_manager._tools["add_tag"].fn, conversation_id="test:conv-123", tag="invalid"
@@ -992,14 +979,9 @@ class TestMutationTools:
         assert parsed["detail"] == "ValueError"
 
     def test_remove_tag_success(self, mcp_server: MCPServerUnderTest) -> None:
-        with (
-            patch("polylogue.mcp.server._get_query_store") as mock_get_query_store,
-            patch("polylogue.mcp.server._get_tag_store") as mock_get_tag_store,
-        ):
-            mock_get_query_store.return_value = make_query_store_mock(resolved_id="test:conv-123")
-            mock_tag_store = make_tag_store_mock()
-            mock_tag_store.remove_tag.return_value = None
-            mock_get_tag_store.return_value = mock_tag_store
+        with patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue:
+            mock_poly = make_polylogue_mock()
+            mock_get_polylogue.return_value = mock_poly
 
             result = invoke_surface(
                 mcp_server._tool_manager._tools["remove_tag"].fn, conversation_id="test:conv-123", tag="important"
@@ -1007,17 +989,13 @@ class TestMutationTools:
 
         parsed = json.loads(result)
         assert parsed == {"status": "ok", "conversation_id": "test:conv-123", "tag": "important"}
-        mock_tag_store.remove_tag.assert_called_once_with("test:conv-123", "important")
+        mock_poly.remove_tag.assert_called_once_with("test:conv-123", "important")
 
     def test_remove_tag_error(self, mcp_server: MCPServerUnderTest) -> None:
-        with (
-            patch("polylogue.mcp.server._get_query_store") as mock_get_query_store,
-            patch("polylogue.mcp.server._get_tag_store") as mock_get_tag_store,
-        ):
-            mock_get_query_store.return_value = make_query_store_mock(resolved_id="test:conv-123")
-            mock_tag_store = make_tag_store_mock()
-            mock_tag_store.remove_tag.side_effect = RuntimeError("Backend error")
-            mock_get_tag_store.return_value = mock_tag_store
+        with patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue:
+            mock_poly = make_polylogue_mock()
+            mock_poly.remove_tag.side_effect = RuntimeError("Backend error")
+            mock_get_polylogue.return_value = mock_poly
 
             result = invoke_surface(
                 mcp_server._tool_manager._tools["remove_tag"].fn, conversation_id="test:conv-123", tag="important"
@@ -1062,45 +1040,40 @@ class TestMutationTools:
         assert "requires at least one conversation_id" in json.loads(result)["error"]
 
     def test_list_tags_returns_counts(self, mcp_server: MCPServerUnderTest) -> None:
-        with patch("polylogue.mcp.server._get_tag_store") as mock_get_tag_store:
-            mock_tag_store = make_tag_store_mock()
-            mock_tag_store.list_tags.return_value = {"bug": 3, "feature": 5, "urgent": 1}
-            mock_get_tag_store.return_value = mock_tag_store
+        with patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue:
+            mock_poly = make_polylogue_mock()
+            mock_poly.list_tags = AsyncMock(return_value={"bug": 3, "feature": 5, "urgent": 1})
+            mock_get_polylogue.return_value = mock_poly
 
             result = invoke_surface(mcp_server._tool_manager._tools["list_tags"].fn)
 
         assert json.loads(result) == {"bug": 3, "feature": 5, "urgent": 1}
 
     def test_list_tags_with_provider(self, mcp_server: MCPServerUnderTest) -> None:
-        with patch("polylogue.mcp.server._get_tag_store") as mock_get_tag_store:
-            mock_tag_store = make_tag_store_mock()
-            mock_tag_store.list_tags.return_value = {"claude-ai": 2}
-            mock_get_tag_store.return_value = mock_tag_store
+        with patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue:
+            mock_poly = make_polylogue_mock()
+            mock_poly.list_tags = AsyncMock(return_value={"claude-ai": 2})
+            mock_get_polylogue.return_value = mock_poly
 
             result = invoke_surface(mcp_server._tool_manager._tools["list_tags"].fn, provider="claude-ai")
 
         assert json.loads(result) == {"claude-ai": 2}
-        mock_tag_store.list_tags.assert_called_once_with(provider="claude-ai")
+        mock_poly.list_tags.assert_called_once_with(provider="claude-ai")
 
     def test_get_metadata_success(self, mcp_server: MCPServerUnderTest) -> None:
-        with patch("polylogue.mcp.server._get_tag_store") as mock_get_tag_store:
-            mock_tag_store = make_tag_store_mock()
-            mock_tag_store.get_metadata.return_value = {"key": "value", "count": 42}
-            mock_get_tag_store.return_value = mock_tag_store
+        with patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue:
+            mock_poly = make_polylogue_mock()
+            mock_poly.get_metadata = AsyncMock(return_value={"key": "value", "count": 42})
+            mock_get_polylogue.return_value = mock_poly
 
             result = invoke_surface(mcp_server._tool_manager._tools["get_metadata"].fn, conversation_id="test:conv-123")
 
         assert json.loads(result) == {"key": "value", "count": 42}
 
     def test_set_metadata_string_value(self, mcp_server: MCPServerUnderTest) -> None:
-        with (
-            patch("polylogue.mcp.server._get_query_store") as mock_get_query_store,
-            patch("polylogue.mcp.server._get_tag_store") as mock_get_tag_store,
-        ):
-            mock_get_query_store.return_value = make_query_store_mock(resolved_id="test:conv-123")
-            mock_tag_store = make_tag_store_mock()
-            mock_tag_store.update_metadata.return_value = None
-            mock_get_tag_store.return_value = mock_tag_store
+        with patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue:
+            mock_poly = make_polylogue_mock()
+            mock_get_polylogue.return_value = mock_poly
 
             result = invoke_surface(
                 mcp_server._tool_manager._tools["set_metadata"].fn,
@@ -1110,17 +1083,12 @@ class TestMutationTools:
             )
 
         assert json.loads(result)["status"] == "ok"
-        mock_tag_store.update_metadata.assert_called_once_with("test:conv-123", "author", "john")
+        mock_poly.update_metadata.assert_called_once_with("test:conv-123", "author", "john")
 
     def test_set_metadata_json_value(self, mcp_server: MCPServerUnderTest) -> None:
-        with (
-            patch("polylogue.mcp.server._get_query_store") as mock_get_query_store,
-            patch("polylogue.mcp.server._get_tag_store") as mock_get_tag_store,
-        ):
-            mock_get_query_store.return_value = make_query_store_mock(resolved_id="test:conv-123")
-            mock_tag_store = make_tag_store_mock()
-            mock_tag_store.update_metadata.return_value = None
-            mock_get_tag_store.return_value = mock_tag_store
+        with patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue:
+            mock_poly = make_polylogue_mock()
+            mock_get_polylogue.return_value = mock_poly
 
             result = invoke_surface(
                 mcp_server._tool_manager._tools["set_metadata"].fn,
@@ -1130,7 +1098,7 @@ class TestMutationTools:
             )
 
         assert json.loads(result)["status"] == "ok"
-        mock_tag_store.update_metadata.assert_called_once_with("test:conv-123", "config", {"nested": True})
+        mock_poly.update_metadata.assert_called_once_with("test:conv-123", "config", "{'nested': True}")
 
     def test_delete_metadata_success(self, mcp_server: MCPServerUnderTest) -> None:
         with (
@@ -1169,10 +1137,10 @@ class TestMutationTools:
         mock_query_store.delete_conversation.assert_not_called()
 
     def test_delete_with_confirm(self, mcp_server: MCPServerUnderTest) -> None:
-        with patch("polylogue.mcp.server._get_query_store") as mock_get_query_store:
-            mock_query_store = make_query_store_mock(resolved_id="test:conv-123")
-            mock_query_store.delete_conversation.return_value = True
-            mock_get_query_store.return_value = mock_query_store
+        with patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue:
+            mock_poly = make_polylogue_mock()
+            mock_poly.delete_conversation = AsyncMock(return_value=True)
+            mock_get_polylogue.return_value = mock_poly
 
             result = invoke_surface(
                 mcp_server._tool_manager._tools["delete_conversation"].fn,
@@ -1181,7 +1149,7 @@ class TestMutationTools:
             )
 
         assert json.loads(result)["status"] == "deleted"
-        mock_query_store.delete_conversation.assert_called_once_with("test:conv-123")
+        mock_poly.delete_conversation.assert_called_once_with("test:conv-123")
 
     def test_delete_not_found(self, mcp_server: MCPServerUnderTest) -> None:
         # Two not-found shapes: resolve_id returns None (id never existed) vs.
@@ -1202,8 +1170,8 @@ class TestMutationTools:
         assert json.loads(result)["status"] == "not_found"
 
     def test_summary_returns_metadata(self, mcp_server: MCPServerUnderTest) -> None:
-        with patch("polylogue.mcp.server._get_archive_ops") as mock_get_archive_ops:
-            mock_ops = MagicMock()
+        with patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue:
+            mock_poly = make_polylogue_mock()
             mock_summary = _make_summary(
                 "test:conv-123",
                 provider=Provider.CHATGPT,
@@ -1211,9 +1179,9 @@ class TestMutationTools:
                 created_at=datetime(2024, 1, 15, tzinfo=timezone.utc),
                 updated_at=datetime(2024, 1, 15, 11, 0, 0, tzinfo=timezone.utc),
             )
-            mock_ops.get_conversation_summary = AsyncMock(return_value=mock_summary)
-            mock_ops.get_conversation_stats = AsyncMock(return_value={"total_messages": 5})
-            mock_get_archive_ops.return_value = mock_ops
+            mock_poly.get_conversation_summary = AsyncMock(return_value=mock_summary)
+            mock_poly.get_conversation_stats = AsyncMock(return_value={"total_messages": 5})
+            mock_get_polylogue.return_value = mock_poly
 
             result = invoke_surface(mcp_server._tool_manager._tools["get_conversation_summary"].fn, id="test:conv-123")
 
@@ -1224,20 +1192,20 @@ class TestMutationTools:
         assert parsed["message_count"] == 5
 
     def test_summary_not_found(self, mcp_server: MCPServerUnderTest) -> None:
-        with patch("polylogue.mcp.server._get_archive_ops") as mock_get_archive_ops:
-            mock_ops = MagicMock()
-            mock_ops.get_conversation_summary = AsyncMock(return_value=None)
-            mock_get_archive_ops.return_value = mock_ops
+        with patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue:
+            mock_poly = make_polylogue_mock()
+            mock_poly.get_conversation_summary = AsyncMock(return_value=None)
+            mock_get_polylogue.return_value = mock_poly
 
             result = invoke_surface(mcp_server._tool_manager._tools["get_conversation_summary"].fn, id="nonexistent")
 
         assert "not found" in json.loads(result)["error"].lower()
 
     def test_session_tree_returns_list(self, simple_conversation: Conversation, mcp_server: MCPServerUnderTest) -> None:
-        with patch("polylogue.mcp.server._get_archive_ops") as mock_get_archive_ops:
-            mock_ops = MagicMock()
-            mock_ops.get_session_tree = AsyncMock(return_value=[simple_conversation])
-            mock_get_archive_ops.return_value = mock_ops
+        with patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue:
+            mock_poly = make_polylogue_mock()
+            mock_poly.get_session_tree = AsyncMock(return_value=[simple_conversation])
+            mock_get_polylogue.return_value = mock_poly
 
             result = invoke_surface(
                 mcp_server._tool_manager._tools["get_session_tree"].fn, conversation_id="test:conv-123"
@@ -1331,12 +1299,15 @@ class TestMutationTools:
         assert parsed["conversation_count"] == 2
 
     def test_rebuild_session_insights_success(self, mcp_server: MCPServerUnderTest) -> None:
-        with patch("polylogue.mcp.server._get_archive_ops") as mock_get_archive_ops:
-            mock_ops = MagicMock()
-            mock_ops.rebuild_session_insights = AsyncMock(
-                return_value=SessionInsightCounts(profiles=2, work_events=3, phases=1)
+        with patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue:
+            mock_poly = make_polylogue_mock()
+            mock_poly.rebuild_insights = AsyncMock(
+                return_value=MagicMock(
+                    to_dict=MagicMock(return_value={"profiles": 2, "work_events": 3, "phases": 1}),
+                    total=MagicMock(return_value=6),
+                )
             )
-            mock_get_archive_ops.return_value = mock_ops
+            mock_get_polylogue.return_value = mock_poly
 
             result = invoke_surface(
                 mcp_server._tool_manager._tools["rebuild_session_insights"].fn,
@@ -1348,7 +1319,7 @@ class TestMutationTools:
         assert parsed["conversation_count"] == 2
         assert parsed["counts"]["profiles"] == 2
         assert parsed["total"] == 6
-        mock_ops.rebuild_session_insights.assert_awaited_once_with(conversation_ids=["conv-1", "conv-2"])
+        mock_poly.rebuild_insights.assert_awaited_once_with(conversation_ids=["conv-1", "conv-2"])
 
     def test_export_query_results_uses_shared_query_contract(
         self,


### PR DESCRIPTION
13 new API methods. CLI verbs (export/neighbors/tags) switched from ops to API. MCP tools rewired from ArchiveOperations to Polylogue. Type fixes. Drift cleanup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added conversation discovery features including neighbor/near-duplicate candidate discovery and session tree retrieval.
  * Added tag management and conversation metadata operations.
  * Added conversation statistics and summary retrieval.

* **Bug Fixes**
  * Improved error handling for missing conversations with explicit error reporting.

* **API Changes**
  * Message retrieval now returns structured message objects instead of dictionary representations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->