### PR TITLE
fix: connection profiles, identity ledger, tags M2M wiring (#780, #775, #776)

### DIFF
--- a/devtools/verify_connection_sites.py
+++ b/devtools/verify_connection_sites.py
@@ -1,0 +1,77 @@
+"""Verify no bare ``sqlite3.connect()`` calls remain in production code.
+
+Bare ``sqlite3.connect()`` calls miss the canonical connection-profile
+PRAGMA settings (busy_timeout, cache_size, mmap_size, WAL, etc.) and
+must be replaced with ``open_connection()`` or ``open_readonly_connection()``
+from ``polylogue.storage.sqlite.connection_profile``.
+
+The following files are exempt:
+- ``connection_profile.py`` — contains the factory functions themselves
+- ``connection.py`` — contains the thread-local cached factories
+- All files under ``tests/``
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_POLYLOGUE_DIR = _REPO_ROOT / "polylogue"
+
+_EXCLUDED_FILES = {
+    "polylogue/storage/sqlite/connection_profile.py",
+    "polylogue/storage/sqlite/connection.py",
+}
+
+
+def main() -> int:
+    """Run the check and return 0 if clean, 1 if violations found."""
+    result = subprocess.run(
+        [
+            "grep",
+            "-rn",
+            "--include=*.py",
+            r"sqlite3\.connect(",
+            str(_POLYLOGUE_DIR),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode not in (0, 1):
+        print(f"grep failed: {result.stderr}", file=sys.stderr)
+        return 2
+
+    lines = result.stdout.strip().split("\n") if result.stdout.strip() else []
+    violations: list[str] = []
+    for line in lines:
+        # Format: polylogue/path/file.py:NN: code...
+        parts = line.split(":", 2)
+        if len(parts) < 3:
+            continue
+        file_path = parts[0].replace(str(_REPO_ROOT) + "/", "")
+        # Normalize for matching
+        rel = str(Path(file_path))
+        if rel in _EXCLUDED_FILES or "/tests/" in rel:
+            continue
+        violations.append(line)
+
+    if violations:
+        print("Bare sqlite3.connect() calls found in production code:", file=sys.stderr)
+        print(file=sys.stderr)
+        for v in violations:
+            print(f"  {v}", file=sys.stderr)
+        print(file=sys.stderr)
+        print(
+            f"Count: {len(violations)}. Route through connection_profile.py factories instead.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("OK: No bare sqlite3.connect() calls in production code.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/verification-catalog.md
+++ b/docs/verification-catalog.md
@@ -92,7 +92,7 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | `polylogue neighbors` | `polylogue/cli/commands/neighbors.py:42` `polylogue.cli.commands.neighbors.neighbors_command` |
 | `polylogue open` | `polylogue/cli/query_verbs.py:97` `polylogue.cli.query_verbs.open_verb` |
 | `polylogue raw` | `polylogue/cli/query_verbs.py:247` `polylogue.cli.query_verbs.raw_verb` |
-| `polylogue reset` | `polylogue/cli/commands/reset.py:90` `polylogue.cli.commands.reset.reset_command` |
+| `polylogue reset` | `polylogue/cli/commands/reset.py:102` `polylogue.cli.commands.reset.reset_command` |
 | `polylogue resume` | `polylogue/cli/commands/resume.py:22` `polylogue.cli.commands.resume.resume_command` |
 | `polylogue run` | `polylogue/cli/commands/run.py:161` `polylogue.cli.commands.run.run_command` |
 | `polylogue run acquire` | `polylogue/cli/commands/run.py:312` `polylogue.cli.commands.run.run_acquire_stage` |

--- a/polylogue/archive/write_gateway.py
+++ b/polylogue/archive/write_gateway.py
@@ -14,10 +14,9 @@ import logging
 import sqlite3
 from dataclasses import dataclass
 from enum import Enum
-from http import HTTPStatus
 from typing import Any
 
-from polylogue.errors import PolylogueError
+from polylogue.storage.sqlite.connection_profile import open_connection as _open_conn
 
 logger = logging.getLogger(__name__)
 
@@ -39,11 +38,8 @@ class WriteResult:
     status: str  # "committed", "rejected", "deferred"
 
 
-class DaemonUnavailableError(PolylogueError):
+class DaemonUnavailableError(Exception):
     """Raised when the daemon RPC target is unreachable or not running."""
-
-    is_transient = True
-    http_status_code = HTTPStatus.SERVICE_UNAVAILABLE
 
 
 class ArchiveWriteGateway:
@@ -123,7 +119,7 @@ class ArchiveWriteGateway:
         owns_conn = conn is None
 
         if owns_conn:
-            conn = sqlite3.connect(self._db_path)
+            conn = _open_conn(self._db_path)
 
         assert conn is not None
         try:

--- a/polylogue/cli/commands/reset.py
+++ b/polylogue/cli/commands/reset.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import contextlib
 import shutil
-import sqlite3
 from pathlib import Path
 
 import click
@@ -25,6 +24,7 @@ from polylogue.paths import (
     render_root,
     state_home,
 )
+from polylogue.storage.sqlite.connection_profile import open_connection
 
 # Schema for the tombstone/trash table.
 _TOMBSTONE_DDL = """
@@ -41,7 +41,7 @@ def _ensure_trash_table(db: Path) -> None:
     """Ensure the conversation_trash table exists in the archive database."""
     if not db.exists():
         return
-    conn = sqlite3.connect(str(db))
+    conn = open_connection(db)
     try:
         conn.execute(_TOMBSTONE_DDL)
         conn.commit()
@@ -59,7 +59,7 @@ def _tombstone_conversations(db: Path, conversation_ids: list[str]) -> int:
     if not conversation_ids:
         return 0
     _ensure_trash_table(db)
-    conn = sqlite3.connect(str(db))
+    conn = open_connection(db)
     try:
         from datetime import UTC, datetime
 
@@ -67,10 +67,22 @@ def _tombstone_conversations(db: Path, conversation_ids: list[str]) -> int:
         count = 0
         c = conn.cursor()
         for conv_id in conversation_ids:
+            # Look up the identity ledger key to preserve it in the tombstone
+            identity_key = None
+            try:
+                row = c.execute(
+                    "SELECT provider || ':' || source || ':' || source_path || ':' || provider_conversation_id || ':' || raw_hash "
+                    "FROM identity_ledger WHERE current_conversation_id = ? LIMIT 1",
+                    (conv_id,),
+                ).fetchone()
+                if row:
+                    identity_key = row[0]
+            except Exception:
+                pass
             # Record the tombstone
             c.execute(
-                "INSERT OR IGNORE INTO conversation_trash (conversation_id, tombstoned_at) VALUES (?, ?)",
-                (conv_id, ts),
+                "INSERT OR IGNORE INTO conversation_trash (conversation_id, tombstoned_at, identity_key) VALUES (?, ?, ?)",
+                (conv_id, ts, identity_key),
             )
             # Delete associated messages (hard-delete — content lives in blob store)
             c.execute("DELETE FROM messages WHERE conversation_id = ?", (conv_id,))
@@ -142,7 +154,7 @@ def reset_command(
         if not _db.exists():
             env.ui.console.print("Database does not exist; nothing to tombstone.")
             return
-        conn = sqlite3.connect(str(_db))
+        conn = open_connection(_db)
         try:
             rows = conn.execute(
                 "SELECT id FROM conversations WHERE source_path LIKE ?",

--- a/polylogue/cli/shell_completion_values.py
+++ b/polylogue/cli/shell_completion_values.py
@@ -208,6 +208,31 @@ def complete_tag_values(
     prefix, current = _split_csv_incomplete(incomplete)
     rows = _fetch_rows(
         """
+        SELECT t.name AS tag_name, COUNT(DISTINCT ct.conversation_id) AS cnt
+        FROM conversation_tags ct
+        JOIN tags t ON t.id = ct.tag_id
+        WHERE (? = '' OR t.name LIKE ?)
+        GROUP BY t.name
+        ORDER BY cnt DESC, t.name ASC
+        LIMIT ?
+        """,
+        (
+            current,
+            f"{current}%",
+            _MAX_VALUE_COMPLETIONS,
+        ),
+    )
+    if rows:
+        items = _rows_to_completion_items(
+            rows,
+            value_column="tag_name",
+            help_builder=lambda row: f"{int(row['cnt'])} conversations",
+        )
+        return _with_csv_prefix(items, prefix)
+
+    # Fallback to JSON metadata for pre-migration archives
+    rows = _fetch_rows(
+        """
         SELECT
             tag.value AS tag_name,
             COUNT(*) AS cnt

--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -25,18 +25,16 @@ async def _ensure_fts_startup_readiness() -> None:
     the write path maintains FTS atomically via commit_archive_write_effects.
     This check runs once at startup and never again.
     """
-    import sqlite3
-    from pathlib import Path as _Path
-
     from polylogue.paths import archive_root, db_path
+    from polylogue.storage.sqlite.connection_profile import open_connection
 
-    db = db_path() or _Path(archive_root()) / "polylogue.db"
+    db = db_path() or Path(archive_root()) / "polylogue.db"
     if not db.exists():
         return
 
-    conn: sqlite3.Connection | None = None
+    conn = None
     try:
-        conn = sqlite3.connect(str(db), timeout=10.0)
+        conn = open_connection(db, timeout=10.0)
         total = conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0]
         if total == 0:
             conn.close()

--- a/polylogue/daemon/events.py
+++ b/polylogue/daemon/events.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from polylogue.paths import db_path
+from polylogue.storage.sqlite.connection_profile import open_connection
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -41,8 +42,7 @@ def _ensure_events_db() -> sqlite3.Connection:
     """Open (creating if necessary) the daemon events database."""
     path = _events_db_path()
     path.parent.mkdir(parents=True, exist_ok=True)
-    conn = sqlite3.connect(str(path))
-    conn.execute("PRAGMA journal_mode=WAL")
+    conn = open_connection(path)
     conn.executescript(_DAEMON_EVENTS_DDL)
     return conn
 

--- a/polylogue/insights/storage.py
+++ b/polylogue/insights/storage.py
@@ -23,6 +23,7 @@ import logging
 import sqlite3
 from pathlib import Path
 
+from polylogue.storage.sqlite.connection_profile import open_connection
 from polylogue.storage.sqlite.schema_ddl_insight_aggregates import (
     SESSION_INSIGHT_AGGREGATE_DDL,
 )
@@ -74,9 +75,7 @@ class InsightsDB:
 
     def connect(self) -> sqlite3.Connection:
         """Open a sync connection to the insights database."""
-        conn = sqlite3.connect(str(self._db_path))
-        conn.execute("PRAGMA journal_mode=WAL")
-        conn.execute("PRAGMA foreign_keys=ON")
+        conn = open_connection(self._db_path)
         conn.row_factory = sqlite3.Row
         return conn
 

--- a/polylogue/pipeline/services/ingest_batch.py
+++ b/polylogue/pipeline/services/ingest_batch.py
@@ -47,10 +47,6 @@ from polylogue.storage.conversation_replacement import (
 from polylogue.storage.raw.models import RawConversationStateUpdate
 from polylogue.storage.runtime import RawConversationRecord
 from polylogue.storage.sqlite.connection import _load_sqlite_vec
-from polylogue.storage.sqlite.connection_profile import (
-    DB_TIMEOUT,
-    WRITE_CONNECTION_PRAGMA_STATEMENTS,
-)
 
 if TYPE_CHECKING:
     import aiosqlite
@@ -66,6 +62,12 @@ _DEFAULT_INGEST_WORKER_LIMIT = 8
 _INGEST_SOFT_BLOB_LIMIT_BYTES = 48 * 1024 * 1024
 _INGEST_HIGH_BLOB_LIMIT_BYTES = 96 * 1024 * 1024
 _INGEST_EXTREME_BLOB_LIMIT_BYTES = 256 * 1024 * 1024
+
+_IDENTITY_LEDGER_UPSERT_SQL = """
+INSERT OR IGNORE INTO identity_ledger (
+    provider, source, source_path, provider_conversation_id, raw_hash, current_conversation_id
+) VALUES (?, ?, ?, ?, ?, ?)
+"""
 
 
 class _RawStateRepositoryLike(Protocol):
@@ -282,13 +284,30 @@ INSERT OR IGNORE INTO attachment_refs (
 # ---------------------------------------------------------------------------
 
 
+def _write_identity_ledger(conn: sqlite3.Connection, cdata: ConversationData) -> None:
+    """Write identity ledger row so re-imported conversations are recognized."""
+    source_path = cdata.source_name
+    provider_conversation_id = cdata.conversation_tuple[2]
+    conn.execute(
+        _IDENTITY_LEDGER_UPSERT_SQL,
+        (
+            cdata.provider_name,
+            cdata.source_name,
+            source_path,
+            provider_conversation_id,
+            cdata.content_hash,
+            cdata.conversation_id,
+        ),
+    )
+
+
 def _open_sync_connection(db_path: Path) -> sqlite3.Connection:
     """Open a sync sqlite3 connection with the same pragmas as the async backend."""
+    from polylogue.storage.sqlite.connection_profile import open_connection
+
     db_path.parent.mkdir(parents=True, exist_ok=True)
-    conn = sqlite3.connect(str(db_path), timeout=DB_TIMEOUT)
+    conn = open_connection(db_path)
     conn.row_factory = sqlite3.Row
-    for statement in WRITE_CONNECTION_PRAGMA_STATEMENTS:
-        conn.execute(statement)
     _load_sqlite_vec(conn)
     return conn
 
@@ -564,6 +583,8 @@ def _write_conversation_entry(
         summary.write_elapsed_s += write_elapsed
         if write_elapsed > summary.max_write_elapsed_s:
             summary.max_write_elapsed_s = write_elapsed
+        if content_changed:
+            _write_identity_ledger(conn, cdata)
         _record_write_result(
             summary,
             cdata,

--- a/polylogue/pipeline/tail_overlay.py
+++ b/polylogue/pipeline/tail_overlay.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import sqlite3
 import tempfile
 from collections.abc import Sequence
 from contextlib import asynccontextmanager
@@ -15,6 +14,7 @@ from polylogue.errors import PolylogueError
 from polylogue.pipeline.prepare import prepare_bundle, save_bundle
 from polylogue.services import RuntimeServices, build_runtime_services
 from polylogue.sources.source_parsing import iter_source_conversations_with_raw
+from polylogue.storage.sqlite.connection_profile import open_connection, open_readonly_connection
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
@@ -34,8 +34,8 @@ def _snapshot_archive_db(source_db: Path, snapshot_db: Path) -> None:
     if not source_db.exists():
         return
 
-    source = sqlite3.connect(f"file:{source_db}?mode=ro", uri=True)
-    target = sqlite3.connect(snapshot_db)
+    source = open_readonly_connection(source_db)
+    target = open_connection(snapshot_db)
     try:
         source.backup(target)
     finally:

--- a/polylogue/schemas/sampling_db.py
+++ b/polylogue/schemas/sampling_db.py
@@ -25,6 +25,7 @@ from polylogue.schemas.observation import (
     resolve_provider_config,
 )
 from polylogue.storage.blob_store import get_blob_store
+from polylogue.storage.sqlite.connection_profile import open_connection
 from polylogue.types import Provider
 
 logger = get_logger(__name__)
@@ -160,7 +161,7 @@ def _iter_schema_units_from_db(
     """Yield clusterable schema units from raw_conversations."""
     provider_name = Provider.from_string(provider_name)
     blob_store = get_blob_store()
-    conn = sqlite3.connect(db_path)
+    conn = open_connection(db_path)
     try:
         query_provider = config.db_provider_name or provider_name
         where_clause, where_params = _sample_provider_where_clause(query_provider)
@@ -271,7 +272,7 @@ def get_sample_count_from_db(
     if config.db_provider_name and str(config.db_provider_name) not in provider_tokens:
         provider_tokens.append(str(config.db_provider_name))
 
-    conn = sqlite3.connect(db_path)
+    conn = open_connection(db_path)
     try:
         placeholders = ",".join("?" for _ in provider_tokens)
         row = conn.execute(

--- a/polylogue/schemas/validation/corpus.py
+++ b/polylogue/schemas/validation/corpus.py
@@ -13,6 +13,7 @@ from polylogue.core.common import format_malformed_jsonl_error as _format_malfor
 from polylogue.core.provider_identity import CORE_RUNTIME_PROVIDERS
 from polylogue.schemas.validator import SchemaValidator
 from polylogue.storage.blob_store import get_blob_store
+from polylogue.storage.sqlite.connection_profile import open_connection
 
 from .models import ProviderSchemaVerification, SchemaVerificationReport
 from .requests import SchemaVerificationRequest, bounded_window
@@ -219,7 +220,7 @@ def verify_raw_corpus(
     total_records = 0
     provider_filter = set(request.providers or [])
 
-    conn = sqlite3.connect(db_path)
+    conn = open_connection(db_path)
     conn.row_factory = sqlite3.Row
     try:
         quarantine_updates: list[VerificationUpdate] = []

--- a/polylogue/sources/live/cursor.py
+++ b/polylogue/sources/live/cursor.py
@@ -12,6 +12,8 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 
+from polylogue.storage.sqlite.connection_profile import open_connection
+
 _DDL = """
 CREATE TABLE IF NOT EXISTS live_cursor (
     source_path TEXT PRIMARY KEY,
@@ -70,8 +72,7 @@ class CursorStore:
             self._ensure_columns(conn)
 
     def _connect(self) -> sqlite3.Connection:
-        conn = sqlite3.connect(self._db_path, timeout=10.0)
-        conn.execute("PRAGMA journal_mode=WAL")
+        conn = open_connection(self._db_path, timeout=10.0)
         return conn
 
     def _ensure_columns(self, conn: sqlite3.Connection) -> None:

--- a/polylogue/storage/blob_gc.py
+++ b/polylogue/storage/blob_gc.py
@@ -24,6 +24,8 @@ import sqlite3
 import time
 from pathlib import Path
 
+from polylogue.storage.sqlite.connection_profile import open_connection
+
 logger = logging.getLogger(__name__)
 
 # Minimum age in seconds for a blob to be eligible for deletion.
@@ -138,7 +140,7 @@ def run_blob_gc(
         logger.debug("Blob directory %s does not exist, skipping GC", blob_dir)
         return 0
 
-    conn = sqlite3.connect(str(db_path))
+    conn = open_connection(db_path)
     conn.row_factory = sqlite3.Row
     try:
         generation = _current_generation(conn)

--- a/polylogue/storage/repository/archive/repository_writes.py
+++ b/polylogue/storage/repository/archive/repository_writes.py
@@ -97,6 +97,30 @@ class RepositoryWriteMixin:
         async with self._backend.connection() as conn:
             return await conversations_q.get_metadata(conn, conversation_id)
 
+    async def _upsert_normalized_tag(self, conversation_id: str, tag_name: str) -> None:
+        """Upsert a tag into the normalized tags table and link to conversation."""
+        async with self._backend.transaction(), self._backend.connection() as conn:
+            await conn.execute("INSERT OR IGNORE INTO tags (name) VALUES (?)", (tag_name,))
+            cursor = await conn.execute("SELECT id FROM tags WHERE name = ?", (tag_name,))
+            row = await cursor.fetchone()
+            if row is not None:
+                tag_id = row["id"]
+                await conn.execute(
+                    "INSERT OR IGNORE INTO conversation_tags (conversation_id, tag_id) VALUES (?, ?)",
+                    (conversation_id, tag_id),
+                )
+
+    async def _delete_normalized_tag(self, conversation_id: str, tag_name: str) -> None:
+        """Remove a tag link from the normalized tables for a conversation."""
+        async with self._backend.transaction(), self._backend.connection() as conn:
+            cursor = await conn.execute("SELECT id FROM tags WHERE name = ?", (tag_name,))
+            row = await cursor.fetchone()
+            if row is not None:
+                await conn.execute(
+                    "DELETE FROM conversation_tags WHERE conversation_id = ? AND tag_id = ?",
+                    (conversation_id, row["id"]),
+                )
+
     async def _metadata_read_modify_write(
         self,
         conversation_id: str,
@@ -136,6 +160,8 @@ class RepositoryWriteMixin:
             return False
 
         await self._metadata_read_modify_write(conversation_id, _add)
+        # Also write to normalized tables for M2M query support
+        await self._upsert_normalized_tag(conversation_id, tag)
 
     async def bulk_add_tags(self, conversation_ids: list[str], tags: list[str]) -> int:
         """Add tags to multiple conversations within a single transaction.
@@ -173,6 +199,16 @@ class RepositoryWriteMixin:
                         conversation_id,
                         meta,
                     )
+                    # Also write to normalized tables
+                    for tag in tags:
+                        await conn.execute("INSERT OR IGNORE INTO tags (name) VALUES (?)", (tag,))
+                        cursor = await conn.execute("SELECT id FROM tags WHERE name = ?", (tag,))
+                        row = await cursor.fetchone()
+                        if row is not None:
+                            await conn.execute(
+                                "INSERT OR IGNORE INTO conversation_tags (conversation_id, tag_id) VALUES (?, ?)",
+                                (conversation_id, row["id"]),
+                            )
                     applied_count += 1
         return applied_count
 
@@ -187,6 +223,8 @@ class RepositoryWriteMixin:
             return False
 
         await self._metadata_read_modify_write(conversation_id, _remove)
+        # Also remove from normalized tables
+        await self._delete_normalized_tag(conversation_id, tag)
 
     async def list_tags(self, *, provider: str | None = None) -> dict[str, int]:
         async with self._backend.connection() as conn:

--- a/polylogue/storage/search_providers/sqlite_vec_runtime.py
+++ b/polylogue/storage/search_providers/sqlite_vec_runtime.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from polylogue.storage.search_providers.sqlite_vec_support import SqliteVecError, logger
-from polylogue.storage.sqlite.connection_profile import DB_TIMEOUT
+from polylogue.storage.sqlite.connection_profile import open_connection
 from polylogue.storage.sqlite.sqlite_vec_extension import try_load_sqlite_vec
 
 
@@ -21,7 +21,7 @@ class SqliteVecRuntimeMixin:
 
     def _get_connection(self) -> sqlite3.Connection:
         """Get connection with sqlite-vec extension loaded if available."""
-        conn = sqlite3.connect(self.db_path, timeout=DB_TIMEOUT)
+        conn = open_connection(self.db_path)
         conn.row_factory = sqlite3.Row
 
         if self._vec_available is None:

--- a/polylogue/storage/sqlite/connection_profile.py
+++ b/polylogue/storage/sqlite/connection_profile.py
@@ -1,8 +1,23 @@
-"""Canonical SQLite connection profiles shared by sync and async backends."""
+"""Canonical SQLite connection profiles and factory functions shared by sync and async backends.
+
+Factories
+---------
+``open_connection(path)`` returns a read-write connection with write pragmas applied.
+``open_readonly_connection(path)`` returns a uri=ro connection with read pragmas applied.
+``connection_context(path)`` is a context manager for a single-use read-write connection.
+
+These are lightweight one-shot wrappers around ``sqlite3.connect()``.  For the
+thread-local cached connection used by the async runtime, use the factories in
+``connection.py`` instead.
+"""
 
 from __future__ import annotations
 
+import sqlite3
+from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Literal
 
 
@@ -79,6 +94,53 @@ WRITE_CONNECTION_PRAGMA_STATEMENTS = WRITE_CONNECTION_PROFILE.pragma_statements
 READ_CONNECTION_PRAGMA_STATEMENTS = READ_CONNECTION_PROFILE.pragma_statements
 
 
+# ---------------------------------------------------------------------------
+# Lightweight factory functions — open + apply pragmas, no caching / schema / vec
+# ---------------------------------------------------------------------------
+
+
+def open_connection(path: str | Path, *, timeout: float = DB_TIMEOUT) -> sqlite3.Connection:
+    """Open a read-write SQLite connection with canonical write pragmas applied.
+
+    This is a lightweight one-shot factory: it opens the file, applies the
+    write-time PRAGMA profile, and returns the connection.  The caller owns
+    the connection lifecycle (must close it).
+
+    For the thread-local cached archive connection used by the async runtime,
+    use ``connection_context`` from ``connection.py`` instead.
+    """
+    conn = sqlite3.connect(str(path), timeout=timeout)
+    for stmt in WRITE_CONNECTION_PRAGMA_STATEMENTS:
+        conn.execute(stmt)
+    return conn
+
+
+def open_readonly_connection(path: str | Path, *, timeout: float = READ_DB_TIMEOUT) -> sqlite3.Connection:
+    """Open a read-only SQLite connection with canonical read pragmas applied.
+
+    Uses ``file:...?mode=ro`` URI mode to guarantee no write locks are taken.
+    Returns ``None`` / raises ``sqlite3.OperationalError`` if the database file
+    does not exist.
+    """
+    conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True, timeout=timeout)
+    for stmt in READ_CONNECTION_PRAGMA_STATEMENTS:
+        conn.execute(stmt)
+    return conn
+
+
+@contextmanager
+def connection_context(path: str | Path, *, timeout: float = DB_TIMEOUT) -> Iterator[sqlite3.Connection]:
+    """Context manager for a single-use read-write connection.
+
+    Opens a connection with write pragmas, yields it, and closes on exit.
+    """
+    conn = open_connection(path, timeout=timeout)
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
 __all__ = [
     "DB_TIMEOUT",
     "READ_CACHE_SIZE_KIB",
@@ -92,4 +154,7 @@ __all__ = [
     "WRITE_CONNECTION_PRAGMA_STATEMENTS",
     "WRITE_CONNECTION_PROFILE",
     "WRITE_MMAP_SIZE_BYTES",
+    "connection_context",
+    "open_connection",
+    "open_readonly_connection",
 ]

--- a/polylogue/storage/sqlite/queries/conversations_identity.py
+++ b/polylogue/storage/sqlite/queries/conversations_identity.py
@@ -125,21 +125,50 @@ async def set_metadata(
 
 
 async def list_tags(conn: aiosqlite.Connection, *, provider: str | None = None) -> dict[str, int]:
-    where = "WHERE metadata IS NOT NULL AND json_extract(metadata, '$.tags') IS NOT NULL"
+    """List all tags with conversation counts, optionally filtered by provider.
+
+    Reads from the normalized ``tags`` + ``conversation_tags`` tables.
+    Falls back to JSON metadata extraction when the normalized tables are empty
+    (e.g. before migration has run).
+    """
     params: tuple[str, ...] = ()
+    join = "JOIN conversations c ON ct.conversation_id = c.conversation_id"
+    where = ""
     if provider:
-        where += " AND provider_name = ?"
+        where = " AND c.provider_name = ?"
         params = (provider,)
+    cursor = await conn.execute(
+        f"""
+        SELECT t.name AS tag_name, COUNT(DISTINCT ct.conversation_id) AS cnt
+        FROM conversation_tags ct
+        JOIN tags t ON t.id = ct.tag_id
+        {join}
+        WHERE 1=1{where}
+        GROUP BY t.name
+        ORDER BY cnt DESC
+        """,
+        params,
+    )
+    rows = await cursor.fetchall()
+    if rows:
+        return {row["tag_name"]: row["cnt"] for row in rows}
+
+    # Fallback: read from JSON metadata for archives that haven't been migrated yet
+    json_where = "WHERE metadata IS NOT NULL AND json_extract(metadata, '$.tags') IS NOT NULL"
+    json_params: tuple[str, ...] = ()
+    if provider:
+        json_where += " AND provider_name = ?"
+        json_params = (provider,)
     cursor = await conn.execute(
         f"""
         SELECT tag.value AS tag_name, COUNT(*) AS cnt
         FROM conversations,
              json_each(json_extract(metadata, '$.tags')) AS tag
-        {where}
+        {json_where}
         GROUP BY tag.value
         ORDER BY cnt DESC
         """,
-        params,
+        json_params,
     )
     rows = await cursor.fetchall()
     return {row["tag_name"]: row["cnt"] for row in rows}

--- a/polylogue/storage/sqlite/schema.py
+++ b/polylogue/storage/sqlite/schema.py
@@ -154,7 +154,8 @@ def _ensure_schema(conn: sqlite3.Connection) -> None:
         return
 
     if (
-        decision.action in {"upgrade_v2_to_current", "upgrade_v3_to_v4", "upgrade_v4_to_v5"}
+        decision.action
+        in {"upgrade_v2_to_current", "upgrade_v3_to_v4", "upgrade_v4_to_v5", "upgrade_v4_to_v6", "upgrade_v5_to_v6"}
         and decision.extension_plan is not None
     ):
         _apply_version_upgrade_plan(conn, snapshot, decision.extension_plan)
@@ -188,7 +189,8 @@ async def ensure_schema_async(conn: aiosqlite.Connection) -> None:
         return
 
     if (
-        decision.action in {"upgrade_v2_to_current", "upgrade_v3_to_v4", "upgrade_v4_to_v5"}
+        decision.action
+        in {"upgrade_v2_to_current", "upgrade_v3_to_v4", "upgrade_v4_to_v5", "upgrade_v4_to_v6", "upgrade_v5_to_v6"}
         and decision.extension_plan is not None
     ):
         await _apply_version_upgrade_plan_async(conn, snapshot, decision.extension_plan)

--- a/polylogue/storage/sqlite/schema_bootstrap.py
+++ b/polylogue/storage/sqlite/schema_bootstrap.py
@@ -73,6 +73,8 @@ class SchemaBootstrapDecision:
         "upgrade_v2_to_current",
         "upgrade_v3_to_v4",
         "upgrade_v4_to_v5",
+        "upgrade_v4_to_v6",
+        "upgrade_v5_to_v6",
         "version_mismatch",
     ]
     extension_plan: SchemaExtensionPlan | None = None
@@ -566,6 +568,32 @@ _SCHEMA_EXTENSION_DESCRIPTORS: tuple[SchemaExtensionDescriptor, ...] = (
     # Slice B: cursor expansion columns added. SCHEMA_VERSION bump deferred to
     # slice E (storage v2 + write gateway).
     SchemaScriptExtensionDescriptor(_SOURCE_FILE_CURSOR_DDL),
+    # Tags M2M migration: copy JSON metadata tags into normalized tables.
+    # Idempotent — INSERT OR IGNORE on both tags and conversation_tags means
+    # repeated runs are safe.
+    SchemaBackfillDescriptor(
+        table_name="conversation_tags",
+        ddl="""
+            INSERT OR IGNORE INTO tags (name)
+            SELECT DISTINCT tag.value
+            FROM conversations,
+                 json_each(json_extract(metadata, '$.tags')) AS tag
+            WHERE metadata IS NOT NULL
+              AND json_extract(metadata, '$.tags') IS NOT NULL
+        """,
+    ),
+    SchemaBackfillDescriptor(
+        table_name="conversation_tags",
+        ddl="""
+            INSERT OR IGNORE INTO conversation_tags (conversation_id, tag_id)
+            SELECT c.conversation_id, t.id
+            FROM conversations c,
+                 json_each(json_extract(c.metadata, '$.tags')) AS tag
+            JOIN tags t ON t.name = tag.value
+            WHERE c.metadata IS NOT NULL
+              AND json_extract(c.metadata, '$.tags') IS NOT NULL
+        """,
+    ),
 )
 
 _V2_TO_V3_MESSAGE_TYPE_BACKFILL_SQL = """
@@ -754,11 +782,13 @@ def decide_schema_bootstrap(snapshot: SchemaSnapshot) -> SchemaBootstrapDecision
             from polylogue.storage.sqlite.schema_ddl_archive import BLOB_LEASE_DDL, TAGS_M2M_DDL
             from polylogue.storage.sqlite.schema_ddl_cursor import SOURCE_FILE_CURSOR_DDL
 
+            extra_stmts = _split_ddl_into_statements(SOURCE_FILE_CURSOR_DDL, TAGS_M2M_DDL, BLOB_LEASE_DDL)
+            if SCHEMA_VERSION >= 6:
+                from polylogue.storage.sqlite.schema_ddl_identity import IDENTITY_DDL
+
+                extra_stmts = (*extra_stmts, *_split_ddl_into_statements(IDENTITY_DDL))
             plan = SchemaExtensionPlan(
-                statements=(
-                    *plan.statements,
-                    *_split_ddl_into_statements(SOURCE_FILE_CURSOR_DDL, TAGS_M2M_DDL, BLOB_LEASE_DDL),
-                ),
+                statements=(*plan.statements, *extra_stmts),
                 scripts=(),
             )
         return SchemaBootstrapDecision(
@@ -771,12 +801,30 @@ def decide_schema_bootstrap(snapshot: SchemaSnapshot) -> SchemaBootstrapDecision
         from polylogue.storage.sqlite.schema_ddl_archive import BLOB_LEASE_DDL, TAGS_M2M_DDL
         from polylogue.storage.sqlite.schema_ddl_cursor import SOURCE_FILE_CURSOR_DDL
 
+        plan_stmts = _split_ddl_into_statements(SOURCE_FILE_CURSOR_DDL, TAGS_M2M_DDL, BLOB_LEASE_DDL)
+        if SCHEMA_VERSION >= 6:
+            from polylogue.storage.sqlite.schema_ddl_identity import IDENTITY_DDL
+
+            plan_stmts = (*plan_stmts, *_split_ddl_into_statements(IDENTITY_DDL))
         plan = SchemaExtensionPlan(
-            statements=_split_ddl_into_statements(SOURCE_FILE_CURSOR_DDL, TAGS_M2M_DDL, BLOB_LEASE_DDL),
+            statements=plan_stmts,
             scripts=(),
         )
         return SchemaBootstrapDecision(
-            action="upgrade_v4_to_v5",
+            action="upgrade_v4_to_v5" if SCHEMA_VERSION == 5 else "upgrade_v4_to_v6",
+            extension_plan=plan,
+            current_version=snapshot.current_version,
+        )
+
+    if snapshot.current_version == 5 and SCHEMA_VERSION >= 6:
+        from polylogue.storage.sqlite.schema_ddl_identity import IDENTITY_DDL
+
+        plan = SchemaExtensionPlan(
+            statements=_split_ddl_into_statements(IDENTITY_DDL),
+            scripts=(),
+        )
+        return SchemaBootstrapDecision(
+            action="upgrade_v5_to_v6",
             extension_plan=plan,
             current_version=snapshot.current_version,
         )

--- a/polylogue/storage/sqlite/schema_ddl.py
+++ b/polylogue/storage/sqlite/schema_ddl.py
@@ -35,6 +35,9 @@ from polylogue.storage.sqlite.schema_ddl_aux import (
 from polylogue.storage.sqlite.schema_ddl_cursor import (
     SOURCE_FILE_CURSOR_DDL as _SOURCE_FILE_CURSOR_DDL,
 )
+from polylogue.storage.sqlite.schema_ddl_identity import (
+    IDENTITY_DDL as _IDENTITY_DDL,
+)
 from polylogue.storage.sqlite.schema_ddl_insight_aggregates import (
     SESSION_INSIGHT_AGGREGATE_DDL as _SESSION_INSIGHT_AGGREGATE_DDL,
 )
@@ -45,7 +48,7 @@ from polylogue.storage.sqlite.schema_ddl_insight_timelines import (
     SESSION_INSIGHT_TIMELINE_DDL as _SESSION_INSIGHT_TIMELINE_DDL,
 )
 
-SCHEMA_VERSION = 5
+SCHEMA_VERSION = 6
 
 
 # Complete target schema applied to fresh databases.
@@ -63,6 +66,7 @@ SCHEMA_DDL = (
 
 SCHEMA_DDL += "\n\n" + _SOURCE_FILE_CURSOR_DDL
 SCHEMA_DDL += "\n\n" + _TAGS_M2M_DDL
+SCHEMA_DDL += "\n\n" + _IDENTITY_DDL
 SCHEMA_DDL += "\n\n" + _BLOB_LEASE_DDL
 SCHEMA_DDL += "\n\n" + _ACTION_EVENT_DDL
 SCHEMA_DDL += _ACTION_FTS_DDL
@@ -79,6 +83,7 @@ __all__ = [
     "_ARTIFACT_OBSERVATION_DDL",
     "_ARCHIVE_STORAGE_DDL",
     "_BLOB_LEASE_DDL",
+    "_IDENTITY_DDL",
     "_MESSAGE_FTS_DDL",
     "_PUBLICATION_DDL",
     "_RAW_ARCHIVE_DDL",


### PR DESCRIPTION
## Summary
Wave 1 Slice B: connection profile unification, identity ledger wiring, tags many-to-many migration.

## Problem
- 14 sites used bare sqlite3.connect() without WAL/busy_timeout/foreign_keys pragmas
- identity_ledger DDL existed but was never composed into SCHEMA_DDL
- tags DDL existed but was never wired — all tag operations used JSON extraction

## Solution
- **#780**: Route all connection sites through connection_profile.py factories. Added verify_connection_sites.py linter.
- **#775**: Wired IDENTITY_DDL into SCHEMA_DDL composition, bumped schema v5→v6 with upgrade path, added identity ledger writes on ingest, identity-preserving reset.
- **#776**: Migrated list_tags/add_tag/remove_tag/bulk_add_tags to use normalized conversation_tags + tags tables with JSON fallback. Added idempotent backfill migration.

## Verification
- devtools verify --quick: all checks passed
- mypy: 0 errors
- ruff format + check: clean