### PR TITLE
fix(reset): correct SQL column name and missing JOIN (#721)

### DIFF
--- a/polylogue/cli/commands/reset.py
+++ b/polylogue/cli/commands/reset.py
@@ -157,7 +157,7 @@ def reset_command(
         conn = open_connection(_db)
         try:
             rows = conn.execute(
-                "SELECT id FROM conversations WHERE source_path LIKE ?",
+                "SELECT c.conversation_id FROM conversations c JOIN raw_conversations r ON c.raw_id = r.raw_id WHERE r.source_path LIKE ?",
                 (f"{source_path}%",),
             ).fetchall()
             conv_ids = [r[0] for r in rows]


### PR DESCRIPTION
Fix 2 SQL bugs that crashed reset --source: SELECT id→conversation_id, add JOIN with raw_conversations.