### PR TITLE
fix(pipeline): integrate embed stage, remove pipeline_managed hack (#770)

### DIFF
--- a/polylogue/pipeline/run_execution.py
+++ b/polylogue/pipeline/run_execution.py
@@ -291,7 +291,7 @@ async def run_sources(
                 explicit_sequence=explicit_sequence,
                 executed_stages=executed_stages,
             )
-            if not spec.pipeline_managed and spec.name != "embed":
+            if not spec.pipeline_managed:
                 executed_stages.add(spec.name)
                 executed_specs.append(spec)
                 return

--- a/polylogue/pipeline/stage_specs.py
+++ b/polylogue/pipeline/stage_specs.py
@@ -123,7 +123,7 @@ PIPELINE_STAGE_SPECS: dict[str, PipelineStageSpec] = {
         suspend_fts_triggers=True,
         inputs=(StageInput(name="processed_ids"),),
     ),
-    "embed": PipelineStageSpec(name="embed", log_stage="embed", pipeline_managed=False),
+    "embed": PipelineStageSpec(name="embed", log_stage="embed", pipeline_managed=True),
 }
 
 

--- a/tests/unit/pipeline/test_run_sources.py
+++ b/tests/unit/pipeline/test_run_sources.py
@@ -165,7 +165,7 @@ def test_expand_requested_stage_contract() -> None:
 def test_pipeline_stage_specs_cover_leaf_stage_vocabulary() -> None:
     assert set(PIPELINE_STAGE_SPECS) == RUN_LEAF_STAGES
     assert PIPELINE_STAGE_SPECS["parse"].log_stage == "ingest"
-    assert PIPELINE_STAGE_SPECS["embed"].pipeline_managed is False
+    assert PIPELINE_STAGE_SPECS["embed"].pipeline_managed is True
 
 
 def test_stage_specs_preserve_sequence_order_and_fts_policy() -> None:


### PR DESCRIPTION
Set embed stage pipeline_managed=True, remove special-case in run_execution.py.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the embed stage execution during pipeline runs. Previously, the embed stage was incorrectly being skipped during pipeline execution despite being essential to the workflow. Updated stage execution logic and pipeline configuration to ensure the embed stage now runs correctly as part of the standard process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->