### PR TITLE
fix: close audit gaps — MCP isError, ingestion events, pins wiring (#786, #774, #777)

### DIFF
--- a/polylogue/mcp/server_support.py
+++ b/polylogue/mcp/server_support.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Literal, Protocol, TypeVar, overload
 
 from pydantic import BaseModel
 
+from polylogue.errors import PolylogueError
 from polylogue.logging import get_logger
 from polylogue.mcp.payloads import MCPErrorPayload, MCPFencedCodeBlock
 from polylogue.operations import ArchiveOperations
@@ -135,12 +136,14 @@ def _safe_call(fn_name: str, fn: Callable[[], TResult]) -> TResult | str: ...
 
 
 def _safe_call(fn_name: str, fn: Callable[[], TResult]) -> TResult | str:
-    """Call fn() and return its result, or a JSON error dict on exception."""
+    """Call fn() and return its result. Raises on error so FastMCP sets isError=True."""
     try:
         return fn()
+    except PolylogueError:
+        raise
     except Exception as exc:
         logger.exception("MCP tool %s failed", fn_name)
-        return _json_payload(_exception_error_payload(fn_name, exc), exclude_none=True)
+        raise PolylogueError(f"{fn_name}: {type(exc).__name__}: {exc}") from exc
 
 
 @overload
@@ -156,12 +159,14 @@ async def _async_safe_call(fn_name: str, fn: Callable[[], Awaitable[TResult]]) -
 
 
 async def _async_safe_call(fn_name: str, fn: Callable[[], Awaitable[TResult]]) -> TResult | str:
-    """Async version of _safe_call for async tool handlers."""
+    """Async version of _safe_call. Raises on error so FastMCP sets isError=True."""
     try:
         return await fn()
+    except PolylogueError:
+        raise
     except Exception as exc:
         logger.exception("MCP tool %s failed", fn_name)
-        return _json_payload(_exception_error_payload(fn_name, exc), exclude_none=True)
+        raise PolylogueError(f"{fn_name}: {type(exc).__name__}: {exc}") from exc
 
 
 def _error_json(message: str, **extra: object) -> str:

--- a/polylogue/pipeline/services/ingest_batch/_core.py
+++ b/polylogue/pipeline/services/ingest_batch/_core.py
@@ -916,6 +916,24 @@ async def process_ingest_batch(
             changed=len(batch_summary.changed_conversation_ids),
         )
 
+    try:
+        from polylogue.daemon.events import emit_daemon_event
+
+        emit_daemon_event(
+            "ingestion_batch",
+            payload={
+                "elapsed_s": round(batch_summary.elapsed_s, 2),
+                "records": batch_summary.raw_record_count,
+                "blob_mb": round(batch_summary.total_blob_mb, 1),
+                "conversations": batch_summary.total_convos,
+                "messages": batch_summary.total_msgs,
+                "changed_conversations": len(batch_summary.changed_conversation_ids),
+                "workers": batch_summary.worker_count,
+            },
+        )
+    except Exception:
+        pass
+
     raw_state_update_elapsed_s = await _persist_batch_raw_state_updates(
         service,
         backend,

--- a/polylogue/schemas/generation/schema_builder.py
+++ b/polylogue/schemas/generation/schema_builder.py
@@ -18,12 +18,27 @@ from polylogue.schemas.generation.support import (
     collapse_dynamic_keys,
 )
 from polylogue.schemas.observation import ProviderConfig
+from polylogue.schemas.pinning import load_pins
 from polylogue.schemas.privacy_config import SchemaPrivacyConfig
 from polylogue.schemas.redaction_report import SchemaReport
 from polylogue.schemas.shape_fingerprint import _structure_fingerprint
 
 SchemaInput: TypeAlias = Mapping[str, object]
 SchemaPayload: TypeAlias = JSONDocument
+
+
+def _load_pins_safe(provider: str) -> dict[str, set[str]]:
+    try:
+        pins = load_pins(provider)
+        rejected: dict[str, set[str]] = {}
+        for pin in pins.pins:
+            if pin.action == "reject":
+                rejected.setdefault(pin.path, set()).add(pin.role)
+        return rejected
+    except Exception:
+        return {}
+
+
 MutableSchemaPayload: TypeAlias = JSONDocument
 
 
@@ -68,7 +83,8 @@ def _generate_cluster_schema(
         min_conversation_count=3,
         privacy_config=privacy_config,
     )
-    schema = _annotate_semantic_and_relational(schema, field_stats, artifact_kind=artifact_kind)
+    pins = _load_pins_safe(provider)
+    schema = _annotate_semantic_and_relational(schema, field_stats, artifact_kind=artifact_kind, pins=pins)
     schema["$schema"] = "https://json-schema.org/draft/2020-12/schema"
 
     redaction_report = _build_redaction_report(
@@ -108,6 +124,7 @@ def generate_schema_from_samples(
     annotate: bool = True,
     max_stats_samples: int = 500,
     max_genson_samples: int | None = None,
+    provider: str | None = None,
 ) -> MutableSchemaPayload:
     if not GENSON_AVAILABLE:
         raise ImportError("genson is required for schema generation. Install with: pip install genson")
@@ -137,7 +154,8 @@ def generate_schema_from_samples(
 
         field_stats = _collect_field_stats(stats_samples)
         schema = _annotate_schema(schema, field_stats)
-        schema = _annotate_semantic_and_relational(schema, field_stats)
+        pins = _load_pins_safe(provider) if provider else {}
+        schema = _annotate_semantic_and_relational(schema, field_stats, pins=pins)
 
     schema["$schema"] = "https://json-schema.org/draft/2020-12/schema"
     return schema

--- a/polylogue/schemas/generation/semantic_relations.py
+++ b/polylogue/schemas/generation/semantic_relations.py
@@ -73,6 +73,7 @@ def annotate_semantic_and_relational(
     field_stats: Mapping[str, FieldStats],
     *,
     artifact_kind: str | None = None,
+    pins: dict[str, set[str]] | None = None,
 ) -> JSONDocument: ...
 
 
@@ -82,6 +83,7 @@ def annotate_semantic_and_relational(
     field_stats: Mapping[str, FieldStats],
     *,
     artifact_kind: str | None = None,
+    pins: dict[str, set[str]] | None = None,
 ) -> JSONValue: ...
 
 
@@ -90,6 +92,7 @@ def annotate_semantic_and_relational(
     field_stats: Mapping[str, FieldStats],
     *,
     artifact_kind: str | None = None,
+    pins: dict[str, set[str]] | None = None,
 ) -> JSONValue:
     """Attach semantic-role and relational annotations to a schema."""
     schema_node = _schema_node(schema)
@@ -97,7 +100,7 @@ def annotate_semantic_and_relational(
         return schema
     stats_by_path = dict(field_stats)
     candidates = infer_semantic_roles(stats_by_path, artifact_kind=artifact_kind)
-    best_roles = select_best_roles(candidates)
+    best_roles = select_best_roles(candidates, pins=pins)
     role_by_path: dict[str, tuple[str, float, JSONDocument]] = {}
     for role, candidate in best_roles.items():
         role_by_path[candidate.path] = (role, candidate.confidence, json_document(candidate.evidence))

--- a/polylogue/schemas/generation/support.py
+++ b/polylogue/schemas/generation/support.py
@@ -50,11 +50,13 @@ def _annotate_semantic_and_relational(
     field_stats: FieldStatsMapping,
     *,
     artifact_kind: str | None = None,
+    pins: dict[str, set[str]] | None = None,
 ) -> SchemaPayload:
     return annotate_semantic_and_relational(
         json_document(dict(schema)),
         dict(field_stats),
         artifact_kind=artifact_kind,
+        pins=pins,
     )
 
 

--- a/tests/unit/mcp/test_mcp_edge_cases.py
+++ b/tests/unit/mcp/test_mcp_edge_cases.py
@@ -6,7 +6,6 @@ and concurrent access patterns.
 
 from __future__ import annotations
 
-import json
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -57,26 +56,24 @@ class TestSafeCall:
         result = _safe_call("test", lambda: '{"ok": true}')
         assert '"ok"' in result
 
-    def test_exception_returns_json_error(self) -> None:
+    def test_exception_raises_polylogue_error(self) -> None:
         def failing() -> None:
             raise RuntimeError("DB connection lost")
 
-        result = _safe_call("test_tool", failing)
-        assert result is not None
-        data = json.loads(result)
-        assert data["error"] == "internal MCP tool error"
-        assert data["code"] == -32603  # JSON-RPC internal error
-        assert data["detail"] == "RuntimeError"
-        assert data["tool"] == "test_tool"
+        from polylogue.errors import PolylogueError
+
+        with pytest.raises(PolylogueError, match="test_tool.*RuntimeError"):
+            _safe_call("test_tool", failing)
 
     def test_traceback_not_in_output(self) -> None:
         def failing() -> None:
             raise ValueError("secret internal path /home/user/.db")
 
-        result = _safe_call("test_tool", failing)
-        assert result is not None
-        # _safe_call wraps in JSON, no raw traceback
-        assert "Traceback" not in result
+        from polylogue.errors import PolylogueError
+
+        with pytest.raises(PolylogueError) as exc:
+            _safe_call("test_tool", failing)
+        assert "Traceback" not in str(exc.value)
 
 
 # =============================================================================

--- a/tests/unit/security/test_mcp_security.py
+++ b/tests/unit/security/test_mcp_security.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import json
+import pytest
 
 from polylogue.mcp.server_support import _safe_call
 
@@ -14,36 +14,32 @@ class TestMcpSafeCall:
         result = _safe_call("test_tool", lambda: '{"ok": true}')
         assert result == '{"ok": true}'
 
-    def test_error_returns_json(self: object) -> None:
+    def test_error_raises_polylogue_error(self: object) -> None:
         def failing() -> None:
             raise ValueError("test error message")
 
-        result = _safe_call("test_tool", failing)
-        assert result is not None
-        parsed = json.loads(result)
-        assert parsed["error"] == "internal MCP tool error"
-        assert parsed["code"] == -32603  # JSON-RPC internal error
-        assert parsed["detail"] == "ValueError"
-        assert parsed["tool"] == "test_tool"
+        from polylogue.errors import PolylogueError
 
-    def test_no_traceback_in_error_response(self: object) -> None:
+        with pytest.raises(PolylogueError, match="test_tool.*ValueError"):
+            _safe_call("test_tool", failing)
+
+    def test_no_raw_traceback_in_error(self: object) -> None:
         def failing() -> None:
             raise RuntimeError("internal error")
 
-        result = _safe_call("test_tool", failing)
-        assert result is not None
-        parsed = json.loads(result)
-        assert "traceback" not in parsed
-        assert "Traceback" not in result
-        assert "File " not in result  # No file paths leaked
+        from polylogue.errors import PolylogueError
+
+        with pytest.raises(PolylogueError) as exc:
+            _safe_call("test_tool", failing)
+        assert "Traceback" not in str(exc.value)
 
     def test_no_internal_paths_in_error(self: object) -> None:
         def failing() -> None:
             raise ImportError("No module named 'secret_module'")
 
-        result = _safe_call("test_tool", failing)
-        assert result is not None
-        parsed = json.loads(result)
-        assert parsed["error"] == "internal MCP tool error"
-        assert "/realm/" not in result
-        assert "polylogue/" not in result
+        from polylogue.errors import PolylogueError
+
+        with pytest.raises(PolylogueError) as exc:
+            _safe_call("test_tool", failing)
+        assert "/realm/" not in str(exc.value)
+        assert "polylogue/" not in str(exc.value)


### PR DESCRIPTION
Fix 3 gaps found by adversarial audit: MCP _safe_call now raises PolylogueError so FastMCP sets isError=True; emit ingestion_batch events from ingest pipeline; thread pins through annotation call chain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pin-based constraint support for schema generation workflows.
  * Introduced daemon event tracking for batch ingestion metrics (timing and summary data).

* **Bug Fixes**
  * Improved error handling and exception propagation in safe-call operations.

* **Tests**
  * Updated tests to align with new error handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->