### PR TITLE
fix: address review feedback — P1/P2 bugs in select, status, pins, annotations

### DIFF
--- a/devtools/verify_schema_annotations.py
+++ b/devtools/verify_schema_annotations.py
@@ -10,6 +10,7 @@ Exit 0 when all schemas have annotations, 1 otherwise.
 
 from __future__ import annotations
 
+import gzip
 import json
 from pathlib import Path
 
@@ -32,11 +33,15 @@ def check_provider(provider_dir: Path) -> tuple[str, bool, list[str]]:
         if not elements_dir.exists():
             continue
         for schema_file in sorted(elements_dir.iterdir()):
-            if schema_file.suffix != ".json":
+            if schema_file.suffix not in (".json", ".gz"):
                 continue
             try:
-                data = json.loads(schema_file.read_text(encoding="utf-8"))
-            except (json.JSONDecodeError, OSError) as exc:
+                if schema_file.suffix == ".gz":
+                    with gzip.open(schema_file, "rt", encoding="utf-8") as fh:
+                        data = json.load(fh)
+                else:
+                    data = json.loads(schema_file.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, OSError, gzip.BadGzipFile) as exc:
                 failures.append(f"{version_dir.name}/{schema_file.name}: {exc}")
                 continue
             if _has_semantic_annotations(data):
@@ -92,10 +97,14 @@ def main() -> int:
             if not elements_dir.exists():
                 continue
             for schema_file in sorted(elements_dir.iterdir()):
-                if schema_file.suffix != ".json":
+                if schema_file.suffix not in (".json", ".gz"):
                     continue
                 try:
-                    data = json.loads(schema_file.read_text(encoding="utf-8"))
+                    if schema_file.suffix == ".gz":
+                        with gzip.open(schema_file, "rt", encoding="utf-8") as fh:
+                            data = json.load(fh)
+                    else:
+                        data = json.loads(schema_file.read_text(encoding="utf-8"))
                 except Exception:
                     continue
                 total_annotations += _count_annotations(data)

--- a/polylogue/cli/commands/tags.py
+++ b/polylogue/cli/commands/tags.py
@@ -47,10 +47,8 @@ def tags_command(
         click.echo("Hint: use --add-tag to tag conversations, e.g.: polylogue --latest --add-tag important")
         return
 
-    from rich.console import Console
     from rich.table import Table
 
-    console = Console()
     table = Table(title=f"Tags ({provider or 'all providers'}, {len(tags)} total)")
     table.add_column("Tag", style="bold cyan")
     table.add_column("Count", justify="right", style="green")
@@ -58,7 +56,7 @@ def tags_command(
     for tag, tag_count in tags.items():
         table.add_row(tag, str(tag_count))
 
-    console.print(table)
+    env.ui.print(table)
 
 
 __all__ = ["tags_command"]

--- a/polylogue/cli/select.py
+++ b/polylogue/cli/select.py
@@ -55,12 +55,12 @@ class SelectConversationRow:
     @property
     def label(self) -> str:
         date = self.date or "unknown"
-        return f"{self.provider} | {date} | {self.title}"
+        return f"{self.provider} | {date} | {self.title} | {self.conversation_id}"
 
     @property
     def preview(self) -> str:
         date = self.date or "unknown"
-        return f"Provider: {self.provider}\nDate:     {date}\nTitle:    {self.title}\nID:       {self.conversation_id}"
+        return f"Provider: {self.provider}  Date: {date}  Title: {self.title}  ID: {self.conversation_id}"
 
     def to_json(self) -> JSONDocument:
         return {

--- a/polylogue/daemon/status.py
+++ b/polylogue/daemon/status.py
@@ -182,7 +182,7 @@ def _insight_freshness_info() -> dict[str, object]:
 
 
 def _safe_int(value: object) -> int:
-    if isinstance(value, int | float) and not isinstance(value, bool):
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
         return int(value)
     return 0
 

--- a/polylogue/pipeline/services/ingest_batch/_core.py
+++ b/polylogue/pipeline/services/ingest_batch/_core.py
@@ -919,9 +919,12 @@ async def process_ingest_batch(
         )
 
     try:
+        import asyncio as _asyncio
+
         from polylogue.daemon.events import emit_daemon_event
 
-        emit_daemon_event(
+        await _asyncio.to_thread(
+            emit_daemon_event,
             "ingestion_batch",
             payload={
                 "elapsed_s": round(batch_summary.elapsed_s, 2),
@@ -934,7 +937,7 @@ async def process_ingest_batch(
             },
         )
     except Exception:
-        pass
+        logger.debug("ingest_batch: failed to emit daemon event", exc_info=True)
 
     raw_state_update_elapsed_s = await _persist_batch_raw_state_updates(
         service,

--- a/polylogue/schemas/providers/claude-code/pins.json
+++ b/polylogue/schemas/providers/claude-code/pins.json
@@ -1,14 +1,17 @@
 {
-  "rejected": [
+  "provider": "claude-code",
+  "pins": [
     {
       "path": "$.gitBranch",
       "role": "conversation_title",
-      "reason": "git branch names (e.g. 'master') are not conversation titles — the branch is metadata about the working copy"
+      "action": "reject",
+      "reason": "git branch names (e.g. 'master') are not conversation titles"
     },
     {
       "path": "$.toolUseResult.oldTodos",
       "role": "message_container",
-      "reason": "oldTodos is a todo list from tool results, not a message container — it represents prior task state"
+      "action": "reject",
+      "reason": "oldTodos is a todo list from tool results, not a message container"
     }
   ]
 }


### PR DESCRIPTION
Fix 6 real bugs found by Copilot/Codex reviews:
- select.py: newlines in fzf preview broke line-based input; label without ID broke non-fzf fallback
- status.py: isinstance(value, int | float) TypeError at runtime
- pins.json: wrong format (rejected list vs PinSet pins array)
- verify_schema_annotations.py: didn't read .json.gz element files
- tags.py: standalone Console() ignored --plain mode
- _core.py: emit_daemon_event sync I/O on event loop, silent error suppression

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed type checking in daemon status monitoring
  * Enhanced error logging for daemon event failures

* **Improvements**
  * Schema verification now supports compressed provider schemas
  * Conversation selection now displays conversation ID alongside date and title
  * Updated Claude Code provider configuration with explicit rejection rules
  * Improved UI rendering in tags display

<!-- end of auto-generated comment: release notes by coderabbit.ai -->