### PR TITLE
fix(storage): blob store GC — fix _still_referenced and _candidate_blobs

### DIFF
--- a/polylogue/storage/blob_gc.py
+++ b/polylogue/storage/blob_gc.py
@@ -55,23 +55,12 @@ def _has_active_lease(conn: sqlite3.Connection, blob_hash: str) -> bool:
 def _still_referenced(conn: sqlite3.Connection, blob_hash: str) -> bool:
     """Return True if the blob hash is referenced by any archive row.
 
-    Checks against the content_hash column of messages and conversations,
-    and against attachment rows.
+    Blobs are stored under their ``raw_id`` (SHA-256 of source content).
+    A blob is referenced if any ``raw_conversations`` row carries that
+    ``raw_id`` — meaning the original source file is still in the archive.
     """
     row = conn.execute(
-        "SELECT 1 FROM messages WHERE content_hash = ? LIMIT 1",
-        (blob_hash,),
-    ).fetchone()
-    if row:
-        return True
-    row = conn.execute(
-        "SELECT 1 FROM conversations WHERE content_hash = ? LIMIT 1",
-        (blob_hash,),
-    ).fetchone()
-    if row:
-        return True
-    row = conn.execute(
-        "SELECT 1 FROM attachments WHERE attachment_id = ? LIMIT 1",
+        "SELECT 1 FROM raw_conversations WHERE raw_id = ? LIMIT 1",
         (blob_hash,),
     ).fetchone()
     return row is not None
@@ -84,6 +73,8 @@ def _candidate_blobs(
 ) -> list[tuple[str, float]]:
     """List blob files eligible for GC consideration.
 
+    Blobs are stored in two-level prefix directories: ``{root}/{hh}/{hh...}``.
+    Walks all prefix subdirectories (00–ff) to find actual blob files.
     Returns list of ``(blob_hash, mtime)`` tuples sorted by mtime ascending.
     """
     if not blob_dir.is_dir():
@@ -92,13 +83,23 @@ def _candidate_blobs(
     candidates: list[tuple[str, float]] = []
     now = time.time()
     try:
-        for entry in os.scandir(str(blob_dir)):
-            if (
-                entry.is_file(follow_symlinks=False)
-                and not entry.name.startswith(".")
-                and now - entry.stat().st_mtime >= older_than
-            ):
-                candidates.append((entry.name, entry.stat().st_mtime))
+        for prefix_dir in os.scandir(str(blob_dir)):
+            if not prefix_dir.is_dir(follow_symlinks=False):
+                continue
+            if not prefix_dir.name or len(prefix_dir.name) != 2:
+                continue
+            try:
+                for entry in os.scandir(prefix_dir.path):
+                    if (
+                        entry.is_file(follow_symlinks=False)
+                        and not entry.name.startswith(".")
+                        and now - entry.stat().st_mtime >= older_than
+                    ):
+                        blob_hash = prefix_dir.name + entry.name
+                        candidates.append((blob_hash, entry.stat().st_mtime))
+            except PermissionError:
+                logger.warning("Permission denied scanning blob prefix: %s", prefix_dir.path)
+                continue
     except PermissionError:
         logger.warning("Permission denied scanning blob directory: %s", blob_dir)
         return []


### PR DESCRIPTION
## Summary
Fixes two fatal bugs in blob store GC that accidentally cancel each other out. GC has never been called in production, so no data loss has occurred.

## Problem
1. `_still_referenced()` checked `messages.content_hash` and `conversations.content_hash` — but blobs are keyed by `raw_conversations.raw_id`. A running GC would delete ALL active blobs.
2. `_candidate_blobs()` did a flat `os.scandir()` on the blob root — but blobs live in two-level prefix subdirectories (`{root}/{hh}/{hh...}`). It found zero candidates.
3. Bug #2 accidentally saved the system from bug #1. GC has never been called, so no data loss.

## Solution
- `_still_referenced()`: query `raw_conversations.raw_id` — the actual blob key
- `_candidate_blobs()`: walk prefix subdirectories (00–ff), scan blob files within each, reconstruct full hash from `prefix_dir + filename`
- Both fixes applied together — fixing only one would be catastrophic

## Verification
```
ruff check → ok
ruff format → ok
mypy polylogue/storage/blob_gc.py → ok
devtools verify → all checks passed
```

Ref #818

🤖 Generated with [Claude Code](https://claude.com/claude-code)