### PR TITLE
fix(cli): register run command

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -156,6 +156,7 @@ Commands:
   raw          Show raw archive artifacts for a conversation.
   reset        Reset database, blob store, assets, rendered outputs, or...
   resume       Reconstruct work-state context for a fresh agent session.
+  run          Run pipeline stages on configured sources and/or transient...
   schema       Inspect schema packages, versions, and evidence.
   select       Select one matched conversation and print a field.
   show         Show matched conversations with default full-content output.
@@ -235,475 +236,71 @@ Options:
 ## Run
 
 ```text
-Usage: polylogue [OPTIONS] COMMAND [ARGS]...
+Usage: polylogue run [OPTIONS] COMMAND1 [ARGS]... [COMMAND2 [ARGS]...]...
 
-  Polylogue - AI conversation archive.
-
-  Query mode (default):
-      polylogue "search terms"
-      polylogue -p claude-ai --since "last week"
-      polylogue --latest --output browser
-
-  Verbs (actions on matched conversations):
-      polylogue "error" -p claude-ai --since 2025-01 list
-      polylogue --has thinking --sort tokens list --limit 10
-      polylogue -p chatgpt count
-      polylogue --provider codex stats --by provider
-      polylogue --latest open
-      polylogue "urgent" --tag review delete --dry-run
-      polylogue list --format json
-
-  Combined filters:
-      polylogue --referenced-path README.md --action file_read list
-      polylogue --action search --action file_edit list
-      polylogue --action-sequence file_read,file_edit,shell list
-      polylogue --action-text "pytest -q" list
-      polylogue "pytest -q tests/unit/core/test_semantic_facts.py" --retrieval-lane actions --limit 5
-      polylogue --tail --provider claude-code --latest list
-      polylogue --action other stats --by tool --format json
-      polylogue --provider claude-code --since 2026-01-01 stats --by repo --format json
-      polylogue --tool bash --exclude-tool read list
-      polylogue --similar "sqlite locking bug in parser" --limit 5
-
-  Modifiers (write operations):
-      polylogue "urgent" --add-tag review
-
-  Run `polylogue <command> --help` for subcommand details.
+  Run pipeline stages on configured sources and/or transient input paths.
 
 Options:
-  -i, --id TEXT                   Conversation ID (exact or prefix match)
-  -c, --contains TEXT             FTS term (repeatable = AND)
-  --exclude-text TEXT             Exclude FTS term
-  --retrieval-lane [auto|dialogue|actions|hybrid]
-                                  Query lane: dialogue FTS, action text, or
-                                  hybrid
-  -p, --provider TEXT             Include providers (comma = OR)
-  --exclude-provider TEXT         Exclude providers
-  -r, --repo TEXT                 Filter by repository name (comma = OR)
-  -t, --tag TEXT                  Include tags (comma = OR, supports
-                                  key:value)
-  --exclude-tag TEXT              Exclude tags
-  --title TEXT                    Title contains
-  --referenced-path TEXT          Referenced file path contains substring
-                                  (repeatable = AND)
-  --cwd-prefix TEXT               Filter conversations whose recorded working
-                                  directory starts with this prefix
-  --action [file_read|file_write|file_edit|shell|git|search|web|agent|subagent|other|none]
-                                  Require semantic action category (repeatable
-                                  = AND)
-  --exclude-action [file_read|file_write|file_edit|shell|git|search|web|agent|subagent|other|none]
-                                  Exclude semantic action category (repeatable
-                                  = AND)
-  --action-sequence TEXT          Require ordered semantic action subsequence
-                                  (comma-separated)
-  --action-text TEXT              Require text within normalized action
-                                  evidence (repeatable = AND)
-  --tool TEXT                     Require normalized tool name (repeatable =
-                                  AND)
-  --exclude-tool TEXT             Exclude normalized tool name (repeatable =
-                                  AND)
-  --similar TEXT                  Semantic similarity query (requires
-                                  embeddings)
-  --has TEXT                      Filter by content: thinking (reasoning),
-                                  tools (calls), summary, attachments
-  --has-tool-use                  Only conversations with tool use (SQL
-                                  pushdown)
-  --has-thinking                  Only conversations with thinking blocks (SQL
-                                  pushdown)
-  --has-paste                     Only conversations with pasted content (SQL
-                                  pushdown)
-  --typed-only                    Only conversations without pasted content
-                                  (typed prose only)
-  --min-messages INTEGER          Minimum message count
-  --max-messages INTEGER          Maximum message count
-  --min-words INTEGER             Minimum total word count
-  --message-type [message|summary|tool_use|tool_result|thinking|context|protocol]
-                                  Filter by message content type (message,
-                                  summary, tool_use, tool_result, thinking,
-                                  context, protocol)
-  --since-session TEXT            Show sessions in same cwd after this
-                                  conversation ID
-  --since TEXT                    After date (ISO, 'yesterday', 'last week')
-  --until TEXT                    Before date
-  -n, --limit INTEGER             Max results
-  --offset INTEGER                Offset for paginated results
-  --latest                        Most recent (= --sort date --limit 1)
-  --sort [date|tokens|messages|words|longest|random]
-                                  Sort by field
-  --reverse                       Reverse sort order
-  --sample INTEGER                Random sample of N conversations
-  -o, --output TEXT               Output destinations: browser, clipboard,
-                                  stdout (comma-separated)
-  -f, --format [markdown|json|html|obsidian|org|yaml|plaintext|csv]
-                                  Output format (for --latest, --stream, or
-                                  verb output)
-  --transform [strip-tools|strip-thinking|strip-all]
-                                  Remove content: strip-tools (tool calls),
-                                  strip-thinking (reasoning), strip-all (both)
-  --no-code-blocks                Exclude fenced and structured code blocks
-                                  from output
-  --no-tool-calls                 Exclude tool invocation records from output
-  --no-tool-outputs               Exclude tool-result payloads from output
-  --no-file-reads                 Exclude file-read payloads while keeping
-                                  other tool output
-  --prose-only                    Show only authored prose text
-  --stream                        Stream output (low memory). Requires
-                                  --latest or -i ID. Incompatible with
-                                  --transform
-  -d, --dialogue-only             Show only user/assistant messages
-  --message-role TEXT             Show only selected message roles (repeatable
-                                  or comma-separated: user, assistant, system,
-                                  tool, unknown)
-  --set TEXT...                   Set metadata key value
-  --add-tag TEXT                  Add tags (comma-separated)
-  --tail                          Tail ahead-of-archive Claude Code source
-                                  state during queries
-  --plain                         Force non-interactive plain output
-  -v, --verbose                   Verbose output
-  --version                       Show the version and exit.
-  -h, --help                      Show this message and exit.
+  --preview      Preview work without writing
+  --source TEXT  Configured source name (repeatable). Accepts 'last' for the
+                 previously synced source.
+  --input PATH   Transient file, directory, or archive path (repeatable).
+                 Accepts .json, .jsonl, .ndjson, .zip.
+  --reparse      Force re-parsing of all raw conversations (clears parse
+                 tracking)
+  -h, --help     Show this message and exit.
 
 Commands:
-  auth         Authenticate with external services (Google Drive for...
-  bulk-export  Bulk export every matched conversation in one process.
-  completions  Generate shell completion scripts.
-  count        Print count of matched conversations.
-  dashboard    Launch the dashboard TUI.
-  delete       Delete matched conversations.
-  diagnostics  Temporal session diagnostics
-  doctor       Health check with optional maintenance and cleanup previews.
-  export       Export one known conversation by ID.
-  ingest       Schedule a file or directory for ingestion by the daemon.
-  insights     Inspect durable archive insights.
-  list         List matched conversations.
-  messages     Show paginated messages for a conversation.
-  neighbors    Show explainable neighboring or near-duplicate candidates.
-  open         Open matched conversation in browser/editor.
-  raw          Show raw archive artifacts for a conversation.
-  reset        Reset database, blob store, assets, rendered outputs, or...
-  resume       Reconstruct work-state context for a fresh agent session.
-  schema       Inspect schema packages, versions, and evidence.
-  select       Select one matched conversation and print a field.
-  show         Show matched conversations with default full-content output.
-  stats        Show statistics for matched conversations.
-  status       Show daemon and archive health.
-  tags         List all tags with conversation counts.
+  acquire      Capture raw payloads only.
+  all          Run the full pipeline.
+  embed        Generate semantic embeddings for conversations.
+  index        Build retrieval and search indexes.
+  materialize  Refresh derived read models.
+  parse        Parse persisted raw backlog into normalized conversations.
+  publish      Render and build the static site.
+  render       Render human-facing publication artifacts.
+  reprocess    Skip acquisition and rerun downstream stages.
+  schema       Infer schemas from acquired raw payloads.
+  site         Generate a static HTML site from the archive.
 ```
 
 ## Run Embed
 
 ```text
-Usage: polylogue [OPTIONS] COMMAND [ARGS]...
+Usage: polylogue run embed [OPTIONS]
 
-  Polylogue - AI conversation archive.
-
-  Query mode (default):
-      polylogue "search terms"
-      polylogue -p claude-ai --since "last week"
-      polylogue --latest --output browser
-
-  Verbs (actions on matched conversations):
-      polylogue "error" -p claude-ai --since 2025-01 list
-      polylogue --has thinking --sort tokens list --limit 10
-      polylogue -p chatgpt count
-      polylogue --provider codex stats --by provider
-      polylogue --latest open
-      polylogue "urgent" --tag review delete --dry-run
-      polylogue list --format json
-
-  Combined filters:
-      polylogue --referenced-path README.md --action file_read list
-      polylogue --action search --action file_edit list
-      polylogue --action-sequence file_read,file_edit,shell list
-      polylogue --action-text "pytest -q" list
-      polylogue "pytest -q tests/unit/core/test_semantic_facts.py" --retrieval-lane actions --limit 5
-      polylogue --tail --provider claude-code --latest list
-      polylogue --action other stats --by tool --format json
-      polylogue --provider claude-code --since 2026-01-01 stats --by repo --format json
-      polylogue --tool bash --exclude-tool read list
-      polylogue --similar "sqlite locking bug in parser" --limit 5
-
-  Modifiers (write operations):
-      polylogue "urgent" --add-tag review
-
-  Run `polylogue <command> --help` for subcommand details.
+  Generate semantic embeddings for conversations.
 
 Options:
-  -i, --id TEXT                   Conversation ID (exact or prefix match)
-  -c, --contains TEXT             FTS term (repeatable = AND)
-  --exclude-text TEXT             Exclude FTS term
-  --retrieval-lane [auto|dialogue|actions|hybrid]
-                                  Query lane: dialogue FTS, action text, or
-                                  hybrid
-  -p, --provider TEXT             Include providers (comma = OR)
-  --exclude-provider TEXT         Exclude providers
-  -r, --repo TEXT                 Filter by repository name (comma = OR)
-  -t, --tag TEXT                  Include tags (comma = OR, supports
-                                  key:value)
-  --exclude-tag TEXT              Exclude tags
-  --title TEXT                    Title contains
-  --referenced-path TEXT          Referenced file path contains substring
-                                  (repeatable = AND)
-  --cwd-prefix TEXT               Filter conversations whose recorded working
-                                  directory starts with this prefix
-  --action [file_read|file_write|file_edit|shell|git|search|web|agent|subagent|other|none]
-                                  Require semantic action category (repeatable
-                                  = AND)
-  --exclude-action [file_read|file_write|file_edit|shell|git|search|web|agent|subagent|other|none]
-                                  Exclude semantic action category (repeatable
-                                  = AND)
-  --action-sequence TEXT          Require ordered semantic action subsequence
-                                  (comma-separated)
-  --action-text TEXT              Require text within normalized action
-                                  evidence (repeatable = AND)
-  --tool TEXT                     Require normalized tool name (repeatable =
-                                  AND)
-  --exclude-tool TEXT             Exclude normalized tool name (repeatable =
-                                  AND)
-  --similar TEXT                  Semantic similarity query (requires
+  -c, --conversation TEXT         Embed a specific conversation by ID
+  --model [voyage-4|voyage-4-large|voyage-4-lite]
+                                  Voyage AI model: voyage-4 (default),
+                                  voyage-4-large, voyage-4-lite
+  -r, --rebuild                   Re-embed all conversations (ignore existing
                                   embeddings)
-  --has TEXT                      Filter by content: thinking (reasoning),
-                                  tools (calls), summary, attachments
-  --has-tool-use                  Only conversations with tool use (SQL
-                                  pushdown)
-  --has-thinking                  Only conversations with thinking blocks (SQL
-                                  pushdown)
-  --has-paste                     Only conversations with pasted content (SQL
-                                  pushdown)
-  --typed-only                    Only conversations without pasted content
-                                  (typed prose only)
-  --min-messages INTEGER          Minimum message count
-  --max-messages INTEGER          Maximum message count
-  --min-words INTEGER             Minimum total word count
-  --message-type [message|summary|tool_use|tool_result|thinking|context|protocol]
-                                  Filter by message content type (message,
-                                  summary, tool_use, tool_result, thinking,
-                                  context, protocol)
-  --since-session TEXT            Show sessions in same cwd after this
-                                  conversation ID
-  --since TEXT                    After date (ISO, 'yesterday', 'last week')
-  --until TEXT                    Before date
-  -n, --limit INTEGER             Max results
-  --offset INTEGER                Offset for paginated results
-  --latest                        Most recent (= --sort date --limit 1)
-  --sort [date|tokens|messages|words|longest|random]
-                                  Sort by field
-  --reverse                       Reverse sort order
-  --sample INTEGER                Random sample of N conversations
-  -o, --output TEXT               Output destinations: browser, clipboard,
-                                  stdout (comma-separated)
-  -f, --format [markdown|json|html|obsidian|org|yaml|plaintext|csv]
-                                  Output format (for --latest, --stream, or
-                                  verb output)
-  --transform [strip-tools|strip-thinking|strip-all]
-                                  Remove content: strip-tools (tool calls),
-                                  strip-thinking (reasoning), strip-all (both)
-  --no-code-blocks                Exclude fenced and structured code blocks
-                                  from output
-  --no-tool-calls                 Exclude tool invocation records from output
-  --no-tool-outputs               Exclude tool-result payloads from output
-  --no-file-reads                 Exclude file-read payloads while keeping
-                                  other tool output
-  --prose-only                    Show only authored prose text
-  --stream                        Stream output (low memory). Requires
-                                  --latest or -i ID. Incompatible with
-                                  --transform
-  -d, --dialogue-only             Show only user/assistant messages
-  --message-role TEXT             Show only selected message roles (repeatable
-                                  or comma-separated: user, assistant, system,
-                                  tool, unknown)
-  --set TEXT...                   Set metadata key value
-  --add-tag TEXT                  Add tags (comma-separated)
-  --tail                          Tail ahead-of-archive Claude Code source
-                                  state during queries
-  --plain                         Force non-interactive plain output
-  -v, --verbose                   Verbose output
-  --version                       Show the version and exit.
+  -s, --stats                     Show embedding statistics only
+  --format [json]                 Output format for embedding statistics
+                                  (requires --stats)
+  -n, --limit INTEGER             Maximum number of conversations to embed
   -h, --help                      Show this message and exit.
-
-Commands:
-  auth         Authenticate with external services (Google Drive for...
-  bulk-export  Bulk export every matched conversation in one process.
-  completions  Generate shell completion scripts.
-  count        Print count of matched conversations.
-  dashboard    Launch the dashboard TUI.
-  delete       Delete matched conversations.
-  diagnostics  Temporal session diagnostics
-  doctor       Health check with optional maintenance and cleanup previews.
-  export       Export one known conversation by ID.
-  ingest       Schedule a file or directory for ingestion by the daemon.
-  insights     Inspect durable archive insights.
-  list         List matched conversations.
-  messages     Show paginated messages for a conversation.
-  neighbors    Show explainable neighboring or near-duplicate candidates.
-  open         Open matched conversation in browser/editor.
-  raw          Show raw archive artifacts for a conversation.
-  reset        Reset database, blob store, assets, rendered outputs, or...
-  resume       Reconstruct work-state context for a fresh agent session.
-  schema       Inspect schema packages, versions, and evidence.
-  select       Select one matched conversation and print a field.
-  show         Show matched conversations with default full-content output.
-  stats        Show statistics for matched conversations.
-  status       Show daemon and archive health.
-  tags         List all tags with conversation counts.
 ```
 
 ## Run Site
 
 ```text
-Usage: polylogue [OPTIONS] COMMAND [ARGS]...
+Usage: polylogue run site [OPTIONS]
 
-  Polylogue - AI conversation archive.
-
-  Query mode (default):
-      polylogue "search terms"
-      polylogue -p claude-ai --since "last week"
-      polylogue --latest --output browser
-
-  Verbs (actions on matched conversations):
-      polylogue "error" -p claude-ai --since 2025-01 list
-      polylogue --has thinking --sort tokens list --limit 10
-      polylogue -p chatgpt count
-      polylogue --provider codex stats --by provider
-      polylogue --latest open
-      polylogue "urgent" --tag review delete --dry-run
-      polylogue list --format json
-
-  Combined filters:
-      polylogue --referenced-path README.md --action file_read list
-      polylogue --action search --action file_edit list
-      polylogue --action-sequence file_read,file_edit,shell list
-      polylogue --action-text "pytest -q" list
-      polylogue "pytest -q tests/unit/core/test_semantic_facts.py" --retrieval-lane actions --limit 5
-      polylogue --tail --provider claude-code --latest list
-      polylogue --action other stats --by tool --format json
-      polylogue --provider claude-code --since 2026-01-01 stats --by repo --format json
-      polylogue --tool bash --exclude-tool read list
-      polylogue --similar "sqlite locking bug in parser" --limit 5
-
-  Modifiers (write operations):
-      polylogue "urgent" --add-tag review
-
-  Run `polylogue <command> --help` for subcommand details.
+  Generate a static HTML site from the archive.
 
 Options:
-  -i, --id TEXT                   Conversation ID (exact or prefix match)
-  -c, --contains TEXT             FTS term (repeatable = AND)
-  --exclude-text TEXT             Exclude FTS term
-  --retrieval-lane [auto|dialogue|actions|hybrid]
-                                  Query lane: dialogue FTS, action text, or
-                                  hybrid
-  -p, --provider TEXT             Include providers (comma = OR)
-  --exclude-provider TEXT         Exclude providers
-  -r, --repo TEXT                 Filter by repository name (comma = OR)
-  -t, --tag TEXT                  Include tags (comma = OR, supports
-                                  key:value)
-  --exclude-tag TEXT              Exclude tags
-  --title TEXT                    Title contains
-  --referenced-path TEXT          Referenced file path contains substring
-                                  (repeatable = AND)
-  --cwd-prefix TEXT               Filter conversations whose recorded working
-                                  directory starts with this prefix
-  --action [file_read|file_write|file_edit|shell|git|search|web|agent|subagent|other|none]
-                                  Require semantic action category (repeatable
-                                  = AND)
-  --exclude-action [file_read|file_write|file_edit|shell|git|search|web|agent|subagent|other|none]
-                                  Exclude semantic action category (repeatable
-                                  = AND)
-  --action-sequence TEXT          Require ordered semantic action subsequence
-                                  (comma-separated)
-  --action-text TEXT              Require text within normalized action
-                                  evidence (repeatable = AND)
-  --tool TEXT                     Require normalized tool name (repeatable =
-                                  AND)
-  --exclude-tool TEXT             Exclude normalized tool name (repeatable =
-                                  AND)
-  --similar TEXT                  Semantic similarity query (requires
-                                  embeddings)
-  --has TEXT                      Filter by content: thinking (reasoning),
-                                  tools (calls), summary, attachments
-  --has-tool-use                  Only conversations with tool use (SQL
-                                  pushdown)
-  --has-thinking                  Only conversations with thinking blocks (SQL
-                                  pushdown)
-  --has-paste                     Only conversations with pasted content (SQL
-                                  pushdown)
-  --typed-only                    Only conversations without pasted content
-                                  (typed prose only)
-  --min-messages INTEGER          Minimum message count
-  --max-messages INTEGER          Maximum message count
-  --min-words INTEGER             Minimum total word count
-  --message-type [message|summary|tool_use|tool_result|thinking|context|protocol]
-                                  Filter by message content type (message,
-                                  summary, tool_use, tool_result, thinking,
-                                  context, protocol)
-  --since-session TEXT            Show sessions in same cwd after this
-                                  conversation ID
-  --since TEXT                    After date (ISO, 'yesterday', 'last week')
-  --until TEXT                    Before date
-  -n, --limit INTEGER             Max results
-  --offset INTEGER                Offset for paginated results
-  --latest                        Most recent (= --sort date --limit 1)
-  --sort [date|tokens|messages|words|longest|random]
-                                  Sort by field
-  --reverse                       Reverse sort order
-  --sample INTEGER                Random sample of N conversations
-  -o, --output TEXT               Output destinations: browser, clipboard,
-                                  stdout (comma-separated)
-  -f, --format [markdown|json|html|obsidian|org|yaml|plaintext|csv]
-                                  Output format (for --latest, --stream, or
-                                  verb output)
-  --transform [strip-tools|strip-thinking|strip-all]
-                                  Remove content: strip-tools (tool calls),
-                                  strip-thinking (reasoning), strip-all (both)
-  --no-code-blocks                Exclude fenced and structured code blocks
-                                  from output
-  --no-tool-calls                 Exclude tool invocation records from output
-  --no-tool-outputs               Exclude tool-result payloads from output
-  --no-file-reads                 Exclude file-read payloads while keeping
-                                  other tool output
-  --prose-only                    Show only authored prose text
-  --stream                        Stream output (low memory). Requires
-                                  --latest or -i ID. Incompatible with
-                                  --transform
-  -d, --dialogue-only             Show only user/assistant messages
-  --message-role TEXT             Show only selected message roles (repeatable
-                                  or comma-separated: user, assistant, system,
-                                  tool, unknown)
-  --set TEXT...                   Set metadata key value
-  --add-tag TEXT                  Add tags (comma-separated)
-  --tail                          Tail ahead-of-archive Claude Code source
-                                  state during queries
-  --plain                         Force non-interactive plain output
-  -v, --verbose                   Verbose output
-  --version                       Show the version and exit.
+  -o, --output PATH               Output directory for generated site
+                                  (default: ~/.local/share/polylogue/site)
+  --title TEXT                    Site title
+  --search / --no-search          Enable client-side search (default: enabled)
+  --search-provider [pagefind|lunr]
+                                  Search index provider (default: pagefind)
+  --dashboard / --no-dashboard    Generate dashboard page (default: enabled)
   -h, --help                      Show this message and exit.
-
-Commands:
-  auth         Authenticate with external services (Google Drive for...
-  bulk-export  Bulk export every matched conversation in one process.
-  completions  Generate shell completion scripts.
-  count        Print count of matched conversations.
-  dashboard    Launch the dashboard TUI.
-  delete       Delete matched conversations.
-  diagnostics  Temporal session diagnostics
-  doctor       Health check with optional maintenance and cleanup previews.
-  export       Export one known conversation by ID.
-  ingest       Schedule a file or directory for ingestion by the daemon.
-  insights     Inspect durable archive insights.
-  list         List matched conversations.
-  messages     Show paginated messages for a conversation.
-  neighbors    Show explainable neighboring or near-duplicate candidates.
-  open         Open matched conversation in browser/editor.
-  raw          Show raw archive artifacts for a conversation.
-  reset        Reset database, blob store, assets, rendered outputs, or...
-  resume       Reconstruct work-state context for a fresh agent session.
-  schema       Inspect schema packages, versions, and evidence.
-  select       Select one matched conversation and print a field.
-  show         Show matched conversations with default full-content output.
-  stats        Show statistics for matched conversations.
-  status       Show daemon and archive health.
-  tags         List all tags with conversation counts.
 ```
 
 ## Insights

--- a/docs/test-quality-workflows.md
+++ b/docs/test-quality-workflows.md
@@ -15,10 +15,10 @@ Current registry snapshot:
 - mutation campaigns: `19`
 - benchmark campaigns: `3`
 - synthetic benchmark campaigns: `6`
-- scenario projections: `245`
+- scenario projections: `255`
 - inferred corpus scenarios: `5`
   - benchmark-campaign: `3`
-  - exercise: `139`
+  - exercise: `149`
   - inferred-corpus-scenario: `5`
   - mutation-campaign: `19`
   - synthetic-benchmark: `6`
@@ -358,9 +358,18 @@ These are the authored scenario-bearing projections currently feeding runtime co
 | `exercise` | `help-raw` | `conversation-query-loop` | `message_fts`<br>`conversation_query_results` | `cli.help`<br>`query-conversations` | — | `generated`<br>`help`<br>`structural` | raw help |
 | `exercise` | `help-reset` | `conversation-query-loop` | `message_fts`<br>`conversation_query_results` | `cli.help`<br>`query-conversations` | — | `generated`<br>`help`<br>`structural` | reset help |
 | `exercise` | `help-resume` | `conversation-query-loop` | `message_fts`<br>`conversation_query_results` | `cli.help`<br>`query-conversations` | — | `generated`<br>`help`<br>`structural` | resume help |
-| `exercise` | `help-run` | — | — | — | — | — | Run subcommand help |
-| `exercise` | `help-run-embed` | — | — | — | — | — | Run embed subcommand help |
-| `exercise` | `help-run-site` | — | — | — | — | — | Run site stage help |
+| `exercise` | `help-run` | — | — | `cli.help` | — | `generated`<br>`help`<br>`structural` | run help |
+| `exercise` | `help-run-acquire` | `source-acquisition-loop` | `configured_sources`<br>`source_payload_stream`<br>`raw_validation_state`<br>`artifact_observation_rows` | `cli.help`<br>`acquire-raw-conversations` | — | `generated`<br>`help`<br>`structural` | run acquire help |
+| `exercise` | `help-run-all` | — | — | `cli.help` | — | `generated`<br>`help`<br>`structural` | run all help |
+| `exercise` | `help-run-embed` | `embedding-materialization-loop` | `archive_conversation_rows`<br>`embedding_metadata_rows`<br>`embedding_status_rows`<br>`message_embedding_vectors` | `cli.help`<br>`materialize-transcript-embeddings` | — | `generated`<br>`help`<br>`structural` | run embed help |
+| `exercise` | `help-run-index` | — | — | `cli.help` | — | `generated`<br>`help`<br>`structural` | run index help |
+| `exercise` | `help-run-materialize` | — | — | `cli.help` | — | `generated`<br>`help`<br>`structural` | run materialize help |
+| `exercise` | `help-run-parse` | `source-acquisition-loop`<br>`raw-reparse-loop`<br>`raw-archive-ingest-loop` | `configured_sources`<br>`source_payload_stream`<br>`raw_validation_state`<br>`artifact_observation_rows`<br>`validation_backlog`<br>`parse_backlog`<br>`parse_quarantine`<br>`archive_conversation_rows` | `cli.help`<br>`acquire-raw-conversations`<br>`plan-validation-backlog`<br>`plan-parse-backlog`<br>`ingest-archive-runtime` | — | `generated`<br>`help`<br>`structural` | run parse help |
+| `exercise` | `help-run-publish` | — | — | `cli.help` | — | `generated`<br>`help`<br>`structural` | run publish help |
+| `exercise` | `help-run-render` | `conversation-render-loop` | `conversation_render_projection`<br>`rendered_conversation_artifacts` | `cli.help`<br>`render-conversations` | — | `generated`<br>`help`<br>`structural` | run render help |
+| `exercise` | `help-run-reprocess` | — | — | `cli.help` | — | `generated`<br>`help`<br>`structural` | run reprocess help |
+| `exercise` | `help-run-schema` | — | — | `cli.help` | — | `generated`<br>`help`<br>`structural` | run schema help |
+| `exercise` | `help-run-site` | `site-publication-loop` | `conversation_render_projection`<br>`site_conversation_pages`<br>`site_publication_manifest`<br>`publication_records` | `cli.help`<br>`publish-site` | — | `generated`<br>`help`<br>`structural` | run site help |
 | `exercise` | `help-schema` | — | — | `cli.help` | — | `generated`<br>`help`<br>`structural` | schema help |
 | `exercise` | `help-schema-compare` | — | — | `cli.help` | — | `generated`<br>`help`<br>`structural` | schema compare help |
 | `exercise` | `help-schema-explain` | `schema-explain-query-loop` | `schema_packages`<br>`schema_explanation_results` | `cli.help`<br>`query-schema-explanations` | — | `generated`<br>`help`<br>`structural` | schema explain help |
@@ -381,6 +390,7 @@ These are the authored scenario-bearing projections currently feeding runtime co
 | `exercise` | `json-insights-threads` | `work-thread-query-loop` | `work_thread_rows`<br>`work_thread_fts`<br>`work_thread_results` | `cli.json-contract`<br>`query-work-threads` | — | `generated`<br>`json-contract`<br>`insights`<br>`threads` | insights threads JSON contract |
 | `exercise` | `json-insights-week-summaries` | `week-summary-query-loop` | `day_session_summary_rows`<br>`week_session_summary_results` | `cli.json-contract`<br>`query-week-session-summaries` | — | `generated`<br>`json-contract`<br>`insights`<br>`week-summaries` | insights week-summaries JSON contract |
 | `exercise` | `json-insights-work-events` | `session-work-event-query-loop` | `session_work_event_rows`<br>`session_work_event_fts`<br>`session_work_event_results` | `cli.json-contract`<br>`query-session-work-events` | — | `generated`<br>`json-contract`<br>`insights`<br>`work-events` | insights work-events JSON contract |
+| `exercise` | `json-run-embed` | `retrieval-band-readiness-loop`<br>`embedding-status-query-loop` | `embedding_metadata_rows`<br>`embedding_status_rows`<br>`message_embedding_vectors`<br>`action_event_readiness`<br>`session_insight_readiness`<br>`retrieval_band_readiness`<br>`embedding_status_results` | `cli.json-contract`<br>`project-retrieval-band-readiness`<br>`query-embedding-status` | — | `generated`<br>`json-contract` | run embed JSON contract |
 | `exercise` | `json-schema-list` | `schema-list-query-loop` | `schema_packages`<br>`schema_cluster_manifests`<br>`inferred_corpus_specs`<br>`inferred_corpus_scenarios`<br>`schema_list_results` | `cli.json-contract`<br>`query-schema-catalog` | — | `generated`<br>`json-contract` | schema list JSON contract |
 | `exercise` | `json-tags` | — | — | `cli.json-contract` | — | `generated`<br>`json-contract` | tags JSON contract |
 | `exercise` | `query-count` | — | — | — | — | — | Count conversations |

--- a/docs/verification-catalog.md
+++ b/docs/verification-catalog.md
@@ -8,10 +8,10 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 
 ## Snapshot
 
-- subjects: `507`
+- subjects: `519`
 - claims: `44`
 - runner bindings: `44`
-- proof obligations: `553`
+- proof obligations: `589`
 
 ## Quality Checks
 
@@ -40,7 +40,7 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | `assurance.coverage_gap` | 23 |
 | `assurance.coverage_item` | 107 |
 | `assurance.coverage_manifest` | 9 |
-| `cli.command` | 45 |
+| `cli.command` | 57 |
 | `cli.json_command` | 5 |
 | `diagnostic.observable` | 1 |
 | `error.surface` | 2 |
@@ -95,6 +95,18 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | `polylogue raw` | `polylogue/cli/query_verbs.py:247` `polylogue.cli.query_verbs.raw_verb` |
 | `polylogue reset` | `polylogue/cli/commands/reset.py:102` `polylogue.cli.commands.reset.reset_command` |
 | `polylogue resume` | `polylogue/cli/commands/resume.py:22` `polylogue.cli.commands.resume.resume_command` |
+| `polylogue run` | `polylogue/cli/commands/run.py:161` `polylogue.cli.commands.run.run_command` |
+| `polylogue run acquire` | `polylogue/cli/commands/run.py:312` `polylogue.cli.commands.run.run_acquire_stage` |
+| `polylogue run all` | `polylogue/cli/commands/run.py:362` `polylogue.cli.commands.run.run_all_stage` |
+| `polylogue run embed` | `polylogue/cli/commands/run.py:466` `polylogue.cli.commands.run.run_embed_stage` |
+| `polylogue run index` | `polylogue/cli/commands/run.py:350` `polylogue.cli.commands.run.run_index_stage` |
+| `polylogue run materialize` | `polylogue/cli/commands/run.py:330` `polylogue.cli.commands.run.run_materialize_stage` |
+| `polylogue run parse` | `polylogue/cli/commands/run.py:324` `polylogue.cli.commands.run.run_parse_stage` |
+| `polylogue run publish` | `polylogue/cli/commands/run.py:368` `polylogue.cli.commands.run.run_publish_stage` |
+| `polylogue run render` | `polylogue/cli/commands/run.py:336` `polylogue.cli.commands.run.run_render_stage` |
+| `polylogue run reprocess` | `polylogue/cli/commands/run.py:356` `polylogue.cli.commands.run.run_reprocess_stage` |
+| `polylogue run schema` | `polylogue/cli/commands/run.py:318` `polylogue.cli.commands.run.run_schema_stage` |
+| `polylogue run site` | `polylogue/cli/commands/run.py:374` `polylogue.cli.commands.run.run_site_stage` |
 | `polylogue schema` | `polylogue/cli/commands/schema.py:38` `polylogue.cli.commands.schema.schema_command` |
 | `polylogue schema compare` | `polylogue/cli/commands/schema.py:56` `polylogue.cli.commands.schema.schema_compare` |
 | `polylogue schema explain` | `polylogue/cli/commands/schema.py:94` `polylogue.cli.commands.schema.schema_explain` |
@@ -282,10 +294,10 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | `assurance.coverage.gap_has_closure_path` | 23 |
 | `assurance.coverage.item_declared` | 107 |
 | `assurance.coverage.manifest_structured` | 9 |
-| `cli.command.help` | 45 |
+| `cli.command.help` | 57 |
 | `cli.command.json_envelope` | 5 |
-| `cli.command.no_traceback` | 45 |
-| `cli.command.plain_mode` | 45 |
+| `cli.command.no_traceback` | 57 |
+| `cli.command.plain_mode` | 57 |
 | `diagnostic.observable_trace_mapping` | 1 |
 | `error.machine_user_context` | 2 |
 | `generated.scenario.family_registered` | 9 |

--- a/polylogue/cli/click_command_registration.py
+++ b/polylogue/cli/click_command_registration.py
@@ -15,11 +15,13 @@ from polylogue.cli.commands.insights import insights_command
 from polylogue.cli.commands.neighbors import neighbors_command
 from polylogue.cli.commands.reset import reset_command
 from polylogue.cli.commands.resume import resume_command
+from polylogue.cli.commands.run import run_command
 from polylogue.cli.commands.schema import schema_command
 from polylogue.cli.commands.status import status_command
 from polylogue.cli.commands.tags import tags_command
 
 ROOT_COMMANDS: tuple[click.Command, ...] = (
+    run_command,
     check_command,
     reset_command,
     status_command,

--- a/tests/unit/cli/test_click_app.py
+++ b/tests/unit/cli/test_click_app.py
@@ -254,6 +254,14 @@ class TestQueryFirstGroupParseArgs:
         assert result.exit_code == 0
         assert "health" in result.output.lower() or "repair" in result.output.lower()
 
+    def test_run_subcommand_dispatches_before_query_mode(self, cli_runner: CliRunner) -> None:
+        from polylogue.cli.click_app import cli
+
+        result = cli_runner.invoke(cli, ["run", "--help"], catch_exceptions=False)
+        assert result.exit_code == 0
+        assert "Run pipeline stages" in result.output
+        assert "materialize" in result.output
+
     def test_positional_args_become_query_terms(self, cli_runner: CliRunner) -> None:
         from polylogue.cli.click_app import cli
 
@@ -518,6 +526,8 @@ class TestCliMetadata:
             "run",
             "doctor",
             "reset",
+            "status",
+            "ingest",
             "auth",
             "completions",
             "dashboard",


### PR DESCRIPTION
## Summary

Restores `polylogue run` as a registered root CLI command.

## Problem

`polylogue.cli.commands.run.run_command` still existed, but `ROOT_COMMANDS` no longer registered it. The query-first router only treats registered root commands as subcommands, so `polylogue --plain run acquire parse materialize render index` was interpreted as query mode with `run` as a search term. This broke Sinnix's `polylogue-run.service` after the system update.

## Solution

- Add `run_command` back to root command registration.
- Add a regression test that `polylogue run --help` dispatches to the run command before query mode.
- Update the root command inventory test to reflect the currently registered `status` and `ingest` commands.
- Regenerate CLI/verification documentation surfaces.

## Verification

- `polylogue run --help` shows the run pipeline stages.
- `pytest tests/unit/cli/test_click_app.py::TestQueryFirstGroupParseArgs::test_run_subcommand_dispatches_before_query_mode tests/unit/cli/test_click_app.py::TestCliMetadata::test_help_flag_lists_subcommands tests/unit/cli/test_click_app.py::TestCliMetadata::test_all_subcommands_registered -q -n 0` -> `3 passed in 1.06s`
- Pre-push quick verification baseline -> `verify: all checks passed`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new "run" CLI command with multiple subcommands for data processing operations including acquire, embed, index, materialize, parse, publish, render, reprocess, schema, and site tasks.

* **Documentation**
  * Expanded CLI reference documentation with detailed usage information for the new run command and subcommands. Updated verification catalog and test quality workflows documentation accordingly.

* **Tests**
  * Added tests to verify new run command registration and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->