### PR TITLE
fix(storage): upgrade v7 archives to schema v8

### DIFF
--- a/polylogue/storage/sqlite/schema.py
+++ b/polylogue/storage/sqlite/schema.py
@@ -162,6 +162,7 @@ def _ensure_schema(conn: sqlite3.Connection) -> None:
             "upgrade_v4_to_v6",
             "upgrade_v5_to_v6",
             "upgrade_v6_to_v7",
+            "upgrade_v7_to_v8",
         }
         and decision.extension_plan is not None
     ):
@@ -204,6 +205,7 @@ async def ensure_schema_async(conn: aiosqlite.Connection) -> None:
             "upgrade_v4_to_v6",
             "upgrade_v5_to_v6",
             "upgrade_v6_to_v7",
+            "upgrade_v7_to_v8",
         }
         and decision.extension_plan is not None
     ):

--- a/polylogue/storage/sqlite/schema_bootstrap.py
+++ b/polylogue/storage/sqlite/schema_bootstrap.py
@@ -76,6 +76,7 @@ class SchemaBootstrapDecision:
         "upgrade_v4_to_v6",
         "upgrade_v5_to_v6",
         "upgrade_v6_to_v7",
+        "upgrade_v7_to_v8",
         "version_mismatch",
     ]
     extension_plan: SchemaExtensionPlan | None = None
@@ -821,6 +822,8 @@ def build_v2_to_current_upgrade_plan(snapshot: SchemaSnapshot) -> SchemaExtensio
         extra_statements = (*extra_statements, *_split_ddl_into_statements(IDENTITY_DDL))
     if SCHEMA_VERSION >= 7:
         extra_statements = (*extra_statements, *build_v6_to_v7_upgrade_plan(snapshot).statements)
+    if SCHEMA_VERSION >= 8:
+        extra_statements = (*extra_statements, *build_v7_to_v8_upgrade_plan(snapshot).statements)
     return SchemaExtensionPlan(
         statements=(*v2_to_v3.statements, *v3_to_v4.statements, *extra_statements),
         scripts=(),
@@ -836,6 +839,19 @@ def build_v6_to_v7_upgrade_plan(snapshot: SchemaSnapshot) -> SchemaExtensionPlan
         statements.append(_V6_TO_V7_PROVIDER_EVENTS_BACKFILL_SQL)
         statements.append(_V6_TO_V7_PROVIDER_META_CLEANUP_SQL)
     return SchemaExtensionPlan(statements=tuple(statements), scripts=())
+
+
+def build_v7_to_v8_upgrade_plan(snapshot: SchemaSnapshot) -> SchemaExtensionPlan:
+    """Remove the retired batch-run ledger from existing archives."""
+    assert_supported_archive_layout_snapshot(snapshot)
+
+    return SchemaExtensionPlan(
+        statements=(
+            "DROP INDEX IF EXISTS idx_runs_timestamp",
+            "DROP TABLE IF EXISTS runs",
+        ),
+        scripts=(),
+    )
 
 
 def decide_schema_bootstrap(snapshot: SchemaSnapshot) -> SchemaBootstrapDecision:
@@ -865,6 +881,8 @@ def decide_schema_bootstrap(snapshot: SchemaSnapshot) -> SchemaBootstrapDecision
                 extra_stmts = (*extra_stmts, *_split_ddl_into_statements(IDENTITY_DDL))
             if SCHEMA_VERSION >= 7:
                 extra_stmts = (*extra_stmts, *build_v6_to_v7_upgrade_plan(snapshot).statements)
+            if SCHEMA_VERSION >= 8:
+                extra_stmts = (*extra_stmts, *build_v7_to_v8_upgrade_plan(snapshot).statements)
             plan = SchemaExtensionPlan(
                 statements=(*plan.statements, *extra_stmts),
                 scripts=(),
@@ -886,6 +904,8 @@ def decide_schema_bootstrap(snapshot: SchemaSnapshot) -> SchemaBootstrapDecision
             plan_stmts = (*plan_stmts, *_split_ddl_into_statements(IDENTITY_DDL))
         if SCHEMA_VERSION >= 7:
             plan_stmts = (*plan_stmts, *build_v6_to_v7_upgrade_plan(snapshot).statements)
+        if SCHEMA_VERSION >= 8:
+            plan_stmts = (*plan_stmts, *build_v7_to_v8_upgrade_plan(snapshot).statements)
         plan = SchemaExtensionPlan(
             statements=plan_stmts,
             scripts=(),
@@ -902,6 +922,8 @@ def decide_schema_bootstrap(snapshot: SchemaSnapshot) -> SchemaBootstrapDecision
         plan_statements = _split_ddl_into_statements(IDENTITY_DDL)
         if SCHEMA_VERSION >= 7:
             plan_statements = (*plan_statements, *build_v6_to_v7_upgrade_plan(snapshot).statements)
+        if SCHEMA_VERSION >= 8:
+            plan_statements = (*plan_statements, *build_v7_to_v8_upgrade_plan(snapshot).statements)
         plan = SchemaExtensionPlan(
             statements=plan_statements,
             scripts=(),
@@ -913,9 +935,22 @@ def decide_schema_bootstrap(snapshot: SchemaSnapshot) -> SchemaBootstrapDecision
         )
 
     if snapshot.current_version == 6 and SCHEMA_VERSION >= 7:
+        plan = build_v6_to_v7_upgrade_plan(snapshot)
+        if SCHEMA_VERSION >= 8:
+            plan = SchemaExtensionPlan(
+                statements=(*plan.statements, *build_v7_to_v8_upgrade_plan(snapshot).statements),
+                scripts=(),
+            )
         return SchemaBootstrapDecision(
             action="upgrade_v6_to_v7",
-            extension_plan=build_v6_to_v7_upgrade_plan(snapshot),
+            extension_plan=plan,
+            current_version=snapshot.current_version,
+        )
+
+    if snapshot.current_version == 7 and SCHEMA_VERSION >= 8:
+        return SchemaBootstrapDecision(
+            action="upgrade_v7_to_v8",
+            extension_plan=build_v7_to_v8_upgrade_plan(snapshot),
             current_version=snapshot.current_version,
         )
 
@@ -1042,6 +1077,7 @@ __all__ = [
     "build_v2_to_current_upgrade_plan",
     "build_v2_to_v3_upgrade_plan",
     "build_v3_to_v4_upgrade_plan",
+    "build_v7_to_v8_upgrade_plan",
     "capture_schema_snapshot",
     "capture_schema_snapshot_async",
     "decide_schema_bootstrap",

--- a/tests/unit/storage/test_backend.py
+++ b/tests/unit/storage/test_backend.py
@@ -38,6 +38,7 @@ from polylogue.storage.sqlite.schema_bootstrap import (
     SchemaSnapshot,
     build_current_schema_extension_plan,
     build_v2_to_v3_upgrade_plan,
+    build_v7_to_v8_upgrade_plan,
     decide_schema_bootstrap,
     schema_extension_snapshot_indexes,
     schema_extension_snapshot_tables,
@@ -221,6 +222,59 @@ def test_v2_to_v3_upgrade_plan_skips_backfill_when_message_type_exists() -> None
 
     assert any("idx_messages_conversation_message_type" in statement for statement in plan.statements)
     assert not any(statement.lstrip().startswith("UPDATE messages") for statement in plan.statements)
+
+
+def test_ensure_schema_upgrades_v7_by_dropping_run_ledger(tmp_path: Path) -> None:
+    """The v7->v8 path removes the retired batch-run ledger in place."""
+    db_path = tmp_path / "v7-run-ledger.db"
+    conn = sqlite3.connect(db_path)
+    conn.executescript(
+        """
+        CREATE TABLE raw_conversations (
+            raw_id TEXT PRIMARY KEY,
+            provider_name TEXT NOT NULL,
+            source_path TEXT NOT NULL,
+            blob_size INTEGER NOT NULL,
+            acquired_at TEXT NOT NULL
+        );
+        CREATE TABLE runs (
+            run_id TEXT PRIMARY KEY,
+            timestamp TEXT NOT NULL,
+            plan_snapshot TEXT,
+            counts_json TEXT,
+            drift_json TEXT,
+            indexed INTEGER,
+            duration_ms INTEGER
+        );
+        CREATE INDEX idx_runs_timestamp ON runs(timestamp DESC);
+        INSERT INTO runs (run_id, timestamp) VALUES ('run-1', '2026-05-06T00:00:00+00:00');
+        PRAGMA user_version = 7;
+        """
+    )
+    conn.commit()
+
+    _ensure_schema(conn)
+
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION
+    assert "raw_conversations" in _table_names(conn)
+    assert "runs" not in _table_names(conn)
+    assert (
+        conn.execute("SELECT 1 FROM sqlite_master WHERE type='index' AND name='idx_runs_timestamp'").fetchone() is None
+    )
+    conn.close()
+
+
+def test_v7_to_v8_upgrade_plan_is_run_ledger_only() -> None:
+    """The v8 migration should not carry unrelated archive-wide work."""
+    snapshot = SchemaSnapshot(current_version=7, table_columns={"raw_conversations": frozenset()}, index_sql={})
+
+    plan = build_v7_to_v8_upgrade_plan(snapshot)
+
+    assert plan.scripts == ()
+    assert plan.statements == (
+        "DROP INDEX IF EXISTS idx_runs_timestamp",
+        "DROP TABLE IF EXISTS runs",
+    )
 
 
 def test_ensure_schema_rejects_version_mismatch_without_mutating(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Adds the missing in-place archive upgrade from schema v7 to schema v8 so existing archives can run the daemon build merged in #847.

## Problem

#847 removed the legacy batch-run ledger and bumped `SCHEMA_VERSION` to 8, but the declared upgrade dispatcher still stopped at v6→v7. On the production archive, `polylogued` started successfully but every live convergence batch failed with `Database schema version 7 is incompatible with expected version 8`.

## Solution

Add a narrow `build_v7_to_v8_upgrade_plan()` that drops only the retired `idx_runs_timestamp` index and `runs` table, include that final step in older upgrade chains, and allow the sync/async schema bootstrap paths to execute the new action. Tests pin both the actual `_ensure_schema()` upgrade and the fact that the v8 migration carries no unrelated archive-wide work.

Ref #845

## Verification

- `ruff format --check polylogue/storage/sqlite/schema.py polylogue/storage/sqlite/schema_bootstrap.py tests/unit/storage/test_backend.py`
- `ruff check polylogue/storage/sqlite/schema.py polylogue/storage/sqlite/schema_bootstrap.py tests/unit/storage/test_backend.py`
- `mypy --strict polylogue/storage/sqlite/schema.py polylogue/storage/sqlite/schema_bootstrap.py tests/unit/storage/test_backend.py`
- `pytest tests/unit/storage/test_backend.py tests/unit/storage/test_provider_events_schema.py -q` → `38 passed in 11.54s`
- `devtools verify` → `verify: all checks passed`
- pre-push `devtools verify --quick` → `verify: all checks passed`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added support for database schema version 8 upgrade, which removes the legacy batch-run ledger during the migration process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->