### PR TITLE
fix(daemon): keep status probes bounded

### DIFF
--- a/polylogue/daemon/status.py
+++ b/polylogue/daemon/status.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel, Field
 
 from polylogue.browser_capture.receiver import BrowserCaptureReceiverConfig, receiver_status_payload
 from polylogue.core.json import JSONDocument, json_document
-from polylogue.paths import blob_store_root, db_path
+from polylogue.paths import db_path
 from polylogue.sources.live import WatchSource
 from polylogue.sources.live.watcher import default_sources
 from polylogue.storage.sqlite.connection_profile import open_readonly_connection
@@ -189,54 +189,73 @@ def _db_size_info() -> dict[str, object]:
 
 
 def _blob_size_info() -> int:
-    root = blob_store_root()
-    if not root.exists():
-        return 0
-    total = 0
-    try:
-        for entry in root.rglob("*"):
-            if entry.is_file():
-                total += entry.stat().st_size
-    except OSError:
-        pass
-    return total
+    # Status must remain responsive while convergence is reading or writing the
+    # archive. A recursive blob-store walk is proportional to archive size and
+    # can make `polylogued status` look hung on production archives.
+    return 0
 
 
 def _fts_readiness_info() -> dict[str, bool]:
-    """Check FTS readiness without importing heavy modules."""
+    """Check FTS table presence through a bounded read-only probe."""
+    dbf = db_path()
+    if not dbf.exists():
+        return {"messages_ready": False, "action_events_ready": False}
     try:
-        from polylogue.config import Config
-        from polylogue.paths import archive_root, render_root
-        from polylogue.readiness import get_readiness
-
-        cfg = Config(archive_root=archive_root(), render_root=render_root(), sources=[])
-        report = get_readiness(cfg, deep=False, probe_only=False)
-        counts = report.counts()
+        conn = open_readonly_connection(dbf)
+        try:
+            tables = {
+                row[0]
+                for row in conn.execute(
+                    """
+                    SELECT name
+                    FROM sqlite_master
+                    WHERE type = 'table'
+                      AND name IN ('messages_fts', 'action_events_fts')
+                    """
+                ).fetchall()
+            }
+        finally:
+            conn.close()
         return {
-            "messages_ready": counts.ok > 0,
-            "action_events_ready": counts.ok > 0,
+            "messages_ready": "messages_fts" in tables,
+            "action_events_ready": "action_events_fts" in tables,
         }
-    except Exception:
+    except sqlite3.Error:
         return {"messages_ready": False, "action_events_ready": False}
 
 
 def _insight_freshness_info() -> dict[str, object]:
-    """Check insight materialization status."""
+    """Check insight materialization status through bounded SQL counts."""
+    dbf = db_path()
+    if not dbf.exists():
+        return {"sessions_with_profiles": 0, "total_sessions": 0}
     try:
-        import asyncio
-
-        from polylogue.api import Polylogue
-
-        async def _check() -> dict[str, object]:
-            async with Polylogue() as p:
-                status = await p.get_session_insight_status()
-                return {
-                    "sessions_with_profiles": getattr(status, "profiled_count", 0),
-                    "total_sessions": getattr(status, "total_count", 0),
-                }
-
-        return asyncio.run(_check())
-    except Exception:
+        conn = open_readonly_connection(dbf)
+        try:
+            tables = {
+                row[0]
+                for row in conn.execute(
+                    """
+                    SELECT name
+                    FROM sqlite_master
+                    WHERE type = 'table'
+                      AND name IN ('conversations', 'session_profiles')
+                    """
+                ).fetchall()
+            }
+            total_sessions = 0
+            sessions_with_profiles = 0
+            if "conversations" in tables:
+                total_sessions = int(conn.execute("SELECT COUNT(*) FROM conversations").fetchone()[0] or 0)
+            if "session_profiles" in tables:
+                sessions_with_profiles = int(conn.execute("SELECT COUNT(*) FROM session_profiles").fetchone()[0] or 0)
+        finally:
+            conn.close()
+        return {
+            "sessions_with_profiles": sessions_with_profiles,
+            "total_sessions": total_sessions,
+        }
+    except sqlite3.Error:
         return {"sessions_with_profiles": 0, "total_sessions": 0}
 
 
@@ -570,10 +589,6 @@ def daemon_status_payload(
         browser_capture_spool_path=browser_capture_spool_path,
     )
 
-    db_info = _db_size_info()
-    blob_size = _blob_size_info()
-    fts = _fts_readiness_info()
-
     return json_document(
         {
             "ok": True,
@@ -583,11 +598,11 @@ def daemon_status_payload(
             "component_state": status.component_state.model_dump(),
             "live": live_source_status_payload(watch_sources),
             "browser_capture": browser_capture_status_payload(browser_capture_spool_path),
-            "db_path": db_info.get("db_path"),
-            "db_size_bytes": db_info.get("db_size_bytes", 0),
-            "wal_size_bytes": db_info.get("wal_size_bytes", 0),
-            "blob_dir_size_bytes": blob_size,
-            "disk_free_bytes": db_info.get("disk_free_bytes", 0),
+            "db_path": str(db_path()),
+            "db_size_bytes": status.db_size_bytes,
+            "wal_size_bytes": status.wal_size_bytes,
+            "blob_dir_size_bytes": status.blob_dir_size_bytes,
+            "disk_free_bytes": status.disk_free_bytes,
             "quick_check_result": "unknown",
             "quick_check_age_s": None,
             "watcher_roots": [str(s.root) for s in watch_sources],
@@ -597,7 +612,7 @@ def daemon_status_payload(
             "live_ingest_attempts": status.live_ingest_attempts.model_dump(),
             "operations": status.current_operations,
             "last_ingestion_batch": last_ingestion,
-            "fts_readiness": fts,
+            "fts_readiness": status.fts_readiness.model_dump(),
         }
     )
 

--- a/tests/unit/daemon/test_daemon_status.py
+++ b/tests/unit/daemon/test_daemon_status.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 import sqlite3
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
+from polylogue.daemon import status as status_module
 from polylogue.daemon.status import build_daemon_status, daemon_status_payload, format_daemon_status_lines
 from polylogue.sources.live.cursor import CursorStore
 
@@ -118,6 +119,77 @@ def test_daemon_status_reports_live_ingest_attempts(tmp_path: Path) -> None:
     assert "Live ingest attempts: 1 running" in lines
     assert "  latest: running full_parse 0/1 files" in lines
     assert "  memory: cgroup 2048.0 MiB peak 4096.0 MiB" in lines
+
+
+def test_daemon_status_payload_reuses_bounded_probe_results(tmp_path: Path) -> None:
+    db = tmp_path / "polylogue.db"
+    db.touch()
+    db_info = Mock(
+        return_value={
+            "db_path": str(db),
+            "db_size_bytes": 11,
+            "wal_size_bytes": 7,
+            "disk_free_bytes": 99,
+        }
+    )
+    blob_info = Mock(return_value=0)
+    fts_info = Mock(return_value={"messages_ready": True, "action_events_ready": True})
+    freshness_info = Mock(return_value={"sessions_with_profiles": 3, "total_sessions": 4})
+
+    with (
+        patch("polylogue.daemon.status.db_path", return_value=db),
+        patch("polylogue.daemon.status._check_daemon_liveness", return_value=True),
+        patch("polylogue.daemon.status._db_size_info", db_info),
+        patch("polylogue.daemon.status._blob_size_info", blob_info),
+        patch("polylogue.daemon.status._fts_readiness_info", fts_info),
+        patch("polylogue.daemon.status._insight_freshness_info", freshness_info),
+    ):
+        payload = daemon_status_payload(sources=())
+
+    assert payload["db_path"] == str(db)
+    assert payload["db_size_bytes"] == 11
+    assert payload["wal_size_bytes"] == 7
+    assert payload["blob_dir_size_bytes"] == 0
+    assert payload["disk_free_bytes"] == 99
+    assert payload["fts_readiness"] == {"messages_ready": True, "action_events_ready": True}
+    assert db_info.call_count == 1
+    assert blob_info.call_count == 1
+    assert fts_info.call_count == 1
+    assert freshness_info.call_count == 1
+
+
+def test_daemon_status_fts_readiness_uses_lightweight_table_probe(tmp_path: Path) -> None:
+    db = tmp_path / "polylogue.db"
+    with sqlite3.connect(db) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE messages_fts (text TEXT);
+            CREATE TABLE action_events_fts (text TEXT);
+            """
+        )
+
+    with patch("polylogue.daemon.status.db_path", return_value=db):
+        readiness = status_module._fts_readiness_info()
+
+    assert readiness == {"messages_ready": True, "action_events_ready": True}
+
+
+def test_daemon_status_insight_freshness_uses_lightweight_counts(tmp_path: Path) -> None:
+    db = tmp_path / "polylogue.db"
+    with sqlite3.connect(db) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE conversations (conversation_id TEXT PRIMARY KEY);
+            CREATE TABLE session_profiles (conversation_id TEXT PRIMARY KEY);
+            INSERT INTO conversations (conversation_id) VALUES ('a'), ('b');
+            INSERT INTO session_profiles (conversation_id) VALUES ('a');
+            """
+        )
+
+    with patch("polylogue.daemon.status.db_path", return_value=db):
+        freshness = status_module._insight_freshness_info()
+
+    assert freshness == {"sessions_with_profiles": 1, "total_sessions": 2}
 
 
 def test_daemon_status_flags_stale_live_ingest_attempts(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Keeps `polylogued status` responsive while the daemon is converging a large archive.

## Problem

During the Sinnix deployment of #847/#850, the daemon was healthy and had live attempt state in SQLite, but `polylogued status --format json` exceeded a 30s timeout while convergence was starting. The status path was doing work that scales with archive size or takes deep archive locks: recursive blob-size walking, deep readiness imports, async insight status, and duplicate status probes.

## Solution

Make the local daemon status path bounded: blob size is reported as unmeasured `0`, FTS readiness and insight freshness use small read-only SQLite probes, and JSON rendering reuses the typed `DaemonStatus` probe results instead of recomputing them. The live busy-daemon probe that timed out before returned in 1.7s with this branch.

Ref #845

## Verification

- `ruff format --check polylogue/daemon/status.py tests/unit/daemon/test_daemon_status.py`
- `ruff check polylogue/daemon/status.py tests/unit/daemon/test_daemon_status.py`
- `mypy --strict polylogue/daemon/status.py tests/unit/daemon/test_daemon_status.py`
- `pytest tests/unit/daemon/test_daemon_status.py -q` → `8 passed in 10.84s`
- `.venv/bin/polylogued status --format json` against the live busy daemon → returned in `1.731s`
- `devtools verify` → `verify: all checks passed`
- pre-push `devtools verify --quick` → `verify: all checks passed`