### PR TITLE
fix(daemon): avoid FTS startup scans (#845)

### DIFF
--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -30,6 +30,11 @@ logger = get_logger(__name__)
 _pidfile_path: Path | None = None
 
 
+def _fts_status_count(status: dict[str, object]) -> int:
+    value = status.get("count", 0)
+    return value if isinstance(value, int) else 0
+
+
 def _cleanup_pidfile() -> None:
     """Remove the daemon pidfile on exit."""
     global _pidfile_path
@@ -83,7 +88,10 @@ async def _ensure_fts_startup_readiness() -> None:
         if total == 0:
             conn.close()
             return
-        fts_count = conn.execute("SELECT COUNT(*) FROM messages_fts").fetchone()[0]
+        from polylogue.storage.fts.fts_lifecycle import fts_index_status_sync
+
+        fts_status = fts_index_status_sync(conn)
+        fts_count = _fts_status_count(fts_status)
         gap = total - fts_count
         if gap <= 0:
             conn.close()
@@ -99,7 +107,7 @@ async def _ensure_fts_startup_readiness() -> None:
 
         rebuild_fts_index_sync(conn)
         conn.commit()
-        new_count = conn.execute("SELECT COUNT(*) FROM messages_fts").fetchone()[0]
+        new_count = _fts_status_count(fts_index_status_sync(conn))
         logger.info("daemon: FTS rebuild complete — %d messages indexed.", new_count)
     except Exception:
         logger.warning("daemon: FTS startup check failed", exc_info=True)

--- a/tests/unit/daemon/test_daemon_cli.py
+++ b/tests/unit/daemon/test_daemon_cli.py
@@ -176,6 +176,68 @@ def test_run_live_watcher_stops_on_keyboard_interrupt() -> None:
     assert stopped == [True]
 
 
+def test_ensure_fts_startup_readiness_uses_bounded_docsize_count(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from polylogue.daemon import cli as daemon_cli
+
+    db = tmp_path / "polylogue.db"
+    db.write_bytes(b"sqlite placeholder")
+
+    class FakeCursor:
+        def __init__(self, row: tuple[object, ...] | None) -> None:
+            self._row = row
+
+        def fetchone(self) -> tuple[object, ...] | None:
+            return self._row
+
+    class FakeConnection:
+        def __init__(self) -> None:
+            self.queries: list[str] = []
+            self.doc_counts = [1, 3]
+            self.committed = False
+            self.closed = False
+
+        def execute(self, sql: str, _params: object = ()) -> FakeCursor:
+            query = " ".join(sql.split())
+            self.queries.append(query)
+            if query == "SELECT COUNT(*) FROM messages":
+                return FakeCursor((3,))
+            if query == "SELECT name FROM sqlite_master WHERE type='table' AND name='messages_fts'":
+                return FakeCursor(("messages_fts",))
+            if query == "SELECT COUNT(*) FROM messages_fts_docsize":
+                count = self.doc_counts.pop(0) if self.doc_counts else 3
+                return FakeCursor((count,))
+            if query == "SELECT name FROM sqlite_master WHERE type='table' AND name='action_events_fts'":
+                return FakeCursor(None)
+            raise AssertionError(f"unexpected query: {query}")
+
+        def commit(self) -> None:
+            self.committed = True
+
+        def close(self) -> None:
+            self.closed = True
+
+    conn = FakeConnection()
+    rebuilds: list[FakeConnection] = []
+
+    def rebuild(fake_conn: FakeConnection) -> None:
+        rebuilds.append(fake_conn)
+
+    monkeypatch.setattr("polylogue.paths.db_path", lambda: db)
+    monkeypatch.setattr("polylogue.storage.sqlite.connection_profile.open_connection", lambda _db, timeout: conn)
+    monkeypatch.setattr("polylogue.storage.fts.fts_lifecycle.rebuild_fts_index_sync", rebuild)
+
+    asyncio.run(daemon_cli._ensure_fts_startup_readiness())
+
+    assert rebuilds == [conn]
+    assert conn.committed is True
+    assert conn.closed is True
+    assert "SELECT COUNT(*) FROM messages_fts" not in conn.queries
+    assert conn.queries.count("SELECT COUNT(*) FROM messages_fts_docsize") == 2
+
+
 def test_run_daemon_services_stops_live_watcher_on_failure() -> None:
     from polylogue.daemon import cli as daemon_cli
 


### PR DESCRIPTION
## Summary

Replace the daemon startup FTS coverage check's direct `COUNT(*) FROM messages_fts` calls with the existing docsize-backed FTS status helper. This keeps daemon startup bounded enough to report liveness before live convergence work resumes on large archives.

## Problem

Production deployment of #854 showed `polylogued` blocked before liveness in `_ensure_fts_startup_readiness`. `py-spy` showed the daemon inside the startup FTS check, and the process had already read multiple GB while `PRAGMA user_version` still showed the archive had not reached the later convergence/schema work. The repo already documents that `COUNT(*)` on FTS5 virtual tables is O(N); daemon startup had reintroduced that pattern.

## Solution

`polylogue/daemon/cli.py` now uses `fts_index_status_sync()`, which counts `messages_fts_docsize`, for both the initial gap check and post-rebuild logging. A focused daemon CLI test proves the startup check schedules a rebuild from cheap counts and never issues `COUNT(*) FROM messages_fts`.

## Verification

- `ruff format --check polylogue/daemon/cli.py tests/unit/daemon/test_daemon_cli.py` -> `2 files already formatted`
- `ruff check polylogue/daemon/cli.py tests/unit/daemon/test_daemon_cli.py` -> `All checks passed!`
- `mypy --strict polylogue/daemon/cli.py tests/unit/daemon/test_daemon_cli.py` -> `Success: no issues found in 2 source files`
- `pytest tests/unit/daemon/test_daemon_cli.py -q` -> `12 passed in 11.41s`
- `devtools verify` -> `verify: all checks passed`
- `git push` pre-push quick gate -> `verify: all checks passed`

Ref #845.
