### PR TITLE
fix(daemon): make embedding convergence opt in (#845)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -158,8 +158,9 @@ Vector embeddings for semantic search, powered by Voyage AI (`voyage-4`,
 - **Search**: `--similar` flag triggers pure vector search; hybrid mode combines
   FTS5 + vector via Reciprocal Rank Fusion
 - **Integration**: Daemon-side post-ingest embedding is opt-in with
-  `POLYLOGUE_DAEMON_ENABLE_EMBEDDINGS=1`; default live convergence does not call
-  the embedding provider during catch-up ([#828](https://github.com/Sinity/polylogue/issues/828)).
+  `POLYLOGUE_DAEMON_ENABLE_EMBEDDINGS` set to `1`, `true`, or `yes`; default
+  live convergence does not call the embedding provider during catch-up
+  ([#828](https://github.com/Sinity/polylogue/issues/828)).
 
 The embedding pipeline is fully built but dormant (0 messages embedded in
 production). It requires `VOYAGE_API_KEY`, explicit daemon opt-in, and the

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -157,11 +157,13 @@ Vector embeddings for semantic search, powered by Voyage AI (`voyage-4`,
 - **Storage**: `message_embeddings` (vec0), `embeddings_meta`, `embedding_status`
 - **Search**: `--similar` flag triggers pure vector search; hybrid mode combines
   FTS5 + vector via Reciprocal Rank Fusion
-- **Integration**: Daemon-side post-ingest embedding is designed but not yet implemented
-  ([#828](https://github.com/Sinity/polylogue/issues/828))
+- **Integration**: Daemon-side post-ingest embedding is opt-in with
+  `POLYLOGUE_DAEMON_ENABLE_EMBEDDINGS=1`; default live convergence does not call
+  the embedding provider during catch-up ([#828](https://github.com/Sinity/polylogue/issues/828)).
 
 The embedding pipeline is fully built but dormant (0 messages embedded in
-production). It requires `VOYAGE_API_KEY` and the `sqlite-vec` Python package.
+production). It requires `VOYAGE_API_KEY`, explicit daemon opt-in, and the
+`sqlite-vec` Python package.
 
 ## Blob Store
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -52,8 +52,8 @@ Environment variable precedence is:
    auth files.
 4. Drive authentication may override credential and token files through the
    Drive-specific environment variables below.
-5. Vector indexing reads `VOYAGE_API_KEY` when daemon-managed embedding work is
-   enabled.
+5. Vector indexing reads `VOYAGE_API_KEY` only when daemon embedding convergence
+   is explicitly enabled.
 
 These are the supported runtime overrides:
 
@@ -66,6 +66,7 @@ These are the supported runtime overrides:
 | `POLYLOGUE_ARCHIVE_ROOT` | Override the archive root instead of using `$XDG_DATA_HOME/polylogue` |
 | `POLYLOGUE_FORCE_PLAIN` | Force non-interactive plain output |
 | `VOYAGE_API_KEY` | Voyage AI API key for embeddings |
+| `POLYLOGUE_DAEMON_ENABLE_EMBEDDINGS` | Set to `1`, `true`, or `yes` to let daemon convergence call the embedding provider |
 | `POLYLOGUE_CREDENTIAL_PATH` | Drive auth override for the OAuth client JSON path |
 | `POLYLOGUE_TOKEN_PATH` | Drive auth override for the OAuth token path |
 

--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -186,10 +186,11 @@ locking to prevent concurrent instances.
 
 ## Embeddings
 
-When the `VOYAGE_API_KEY` environment variable is set, the daemon can generate
-vector embeddings for message content. Embeddings are stored in the
-`message_embeddings` vec0 virtual table and used by the `--similar` search and
-`hybrid` retrieval lane.
+When `VOYAGE_API_KEY` is set and `POLYLOGUE_DAEMON_ENABLE_EMBEDDINGS=1`, the
+daemon can generate vector embeddings for message content. Embeddings are stored
+in the `message_embeddings` vec0 virtual table and used by the `--similar`
+search and `hybrid` retrieval lane. Embedding convergence is opt-in so ordinary
+daemon catch-up does not make provider API calls.
 
 Check embedding coverage:
 

--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -186,11 +186,12 @@ locking to prevent concurrent instances.
 
 ## Embeddings
 
-When `VOYAGE_API_KEY` is set and `POLYLOGUE_DAEMON_ENABLE_EMBEDDINGS=1`, the
-daemon can generate vector embeddings for message content. Embeddings are stored
-in the `message_embeddings` vec0 virtual table and used by the `--similar`
-search and `hybrid` retrieval lane. Embedding convergence is opt-in so ordinary
-daemon catch-up does not make provider API calls.
+When `VOYAGE_API_KEY` is set and `POLYLOGUE_DAEMON_ENABLE_EMBEDDINGS` is enabled
+(`1`, `true`, or `yes`), the daemon can generate vector embeddings for message
+content. Embeddings are stored in the `message_embeddings` vec0 virtual table
+and used by the `--similar` search and `hybrid` retrieval lane. Embedding
+convergence is opt-in so ordinary daemon catch-up does not make provider API
+calls.
 
 Check embedding coverage:
 

--- a/polylogue/cli/query.py
+++ b/polylogue/cli/query.py
@@ -381,7 +381,7 @@ async def _execute_query_plan(
 
     if plan.selection.similar_text and vector_provider is None:
         click.echo(
-            "Error: --similar requires vector search support, but vector provider initialization failed or is disabled. Check VOYAGE_API_KEY and daemon embedding convergence.",
+            "Error: --similar requires vector search support, but vector provider initialization failed or is disabled. Check VOYAGE_API_KEY and POLYLOGUE_DAEMON_ENABLE_EMBEDDINGS=1/true/yes.",
             err=True,
         )
         raise SystemExit(1)
@@ -389,7 +389,7 @@ async def _execute_query_plan(
         archive_stats = await repo.get_archive_stats()
         if archive_stats.embedded_messages <= 0:
             click.echo(
-                "Error: --similar requires existing embeddings. Enable daemon embedding convergence and let embeddings build before querying.",
+                "Error: --similar requires existing embeddings. Set POLYLOGUE_DAEMON_ENABLE_EMBEDDINGS=1/true/yes and let embeddings build before querying.",
                 err=True,
             )
             raise SystemExit(1)

--- a/polylogue/cli/query.py
+++ b/polylogue/cli/query.py
@@ -381,7 +381,7 @@ async def _execute_query_plan(
 
     if plan.selection.similar_text and vector_provider is None:
         click.echo(
-            "Error: --similar requires vector search support. Configure VOYAGE_API_KEY and daemon-managed embeddings first.",
+            "Error: --similar requires vector search support. Configure VOYAGE_API_KEY and enable daemon embedding convergence first.",
             err=True,
         )
         raise SystemExit(1)
@@ -389,7 +389,7 @@ async def _execute_query_plan(
         archive_stats = await repo.get_archive_stats()
         if archive_stats.embedded_messages <= 0:
             click.echo(
-                "Error: --similar requires existing embeddings. Build embeddings through the daemon before querying.",
+                "Error: --similar requires existing embeddings. Enable daemon embedding convergence and let embeddings build before querying.",
                 err=True,
             )
             raise SystemExit(1)

--- a/polylogue/cli/query.py
+++ b/polylogue/cli/query.py
@@ -381,7 +381,7 @@ async def _execute_query_plan(
 
     if plan.selection.similar_text and vector_provider is None:
         click.echo(
-            "Error: --similar requires vector search support. Configure VOYAGE_API_KEY and enable daemon embedding convergence first.",
+            "Error: --similar requires vector search support, but vector provider initialization failed or is disabled. Check VOYAGE_API_KEY and daemon embedding convergence.",
             err=True,
         )
         raise SystemExit(1)

--- a/polylogue/daemon/convergence_stages.py
+++ b/polylogue/daemon/convergence_stages.py
@@ -6,7 +6,7 @@ ingestion through daemon-side raw-record ingest; daemon convergence stages only
 repair and refresh post-ingest archive state.
 
 - fts: rebuild FTS if messages > indexed count
-- embed: vectorize un-embedded conversations via Voyage API
+- embed: optional vectorization for changed conversations
 - insights: refresh session profiles
 """
 
@@ -376,11 +376,11 @@ def make_insights_stage(db_path: Path) -> ConvergenceStage:
 
 def make_default_convergence_stages(db_path: Path) -> tuple[ConvergenceStage, ...]:
     """Build the daemon's default post-ingest convergence stage set."""
-    return (
-        make_fts_stage(db_path),
-        make_embed_stage(db_path),
-        make_insights_stage(db_path),
-    )
+    stage_list = [make_fts_stage(db_path)]
+    if _embedding_env_enabled():
+        stage_list.append(make_embed_stage(db_path))
+    stage_list.append(make_insights_stage(db_path))
+    return tuple(stage_list)
 
 
 # ── Helpers ────────────────────────────────────────────────────────
@@ -471,7 +471,8 @@ def _fts_needs_repair_for_conversations(conn: sqlite3.Connection, conversation_i
 def _embedding_env_enabled() -> bool:
     import os
 
-    return bool(os.environ.get("VOYAGE_API_KEY"))
+    enabled = os.environ.get("POLYLOGUE_DAEMON_ENABLE_EMBEDDINGS", "").lower() in {"1", "true", "yes"}
+    return enabled and bool(os.environ.get("VOYAGE_API_KEY"))
 
 
 def _pending_embedding_conversation_ids(

--- a/tests/unit/cli/test_query_exec.py
+++ b/tests/unit/cli/test_query_exec.py
@@ -221,7 +221,7 @@ async def test_async_execute_query_errors_for_similar_without_vector_support() -
     mock_echo.assert_called_once()
     assert "requires vector search support" in mock_echo.call_args.args[0]
     assert "initialization failed or is disabled" in mock_echo.call_args.args[0]
-    assert "daemon embedding convergence" in mock_echo.call_args.args[0]
+    assert "POLYLOGUE_DAEMON_ENABLE_EMBEDDINGS=1/true/yes" in mock_echo.call_args.args[0]
 
 
 @pytest.mark.asyncio
@@ -277,7 +277,7 @@ async def test_async_execute_query_errors_for_similar_without_embeddings() -> No
     assert exc_info.value.code == 1
     mock_echo.assert_called_once()
     assert "requires existing embeddings" in mock_echo.call_args.args[0]
-    assert "Enable daemon embedding convergence" in mock_echo.call_args.args[0]
+    assert "POLYLOGUE_DAEMON_ENABLE_EMBEDDINGS=1/true/yes" in mock_echo.call_args.args[0]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/cli/test_query_exec.py
+++ b/tests/unit/cli/test_query_exec.py
@@ -220,7 +220,7 @@ async def test_async_execute_query_errors_for_similar_without_vector_support() -
     assert exc_info.value.code == 1
     mock_echo.assert_called_once()
     assert "requires vector search support" in mock_echo.call_args.args[0]
-    assert "daemon-managed embeddings" in mock_echo.call_args.args[0]
+    assert "enable daemon embedding convergence" in mock_echo.call_args.args[0]
 
 
 @pytest.mark.asyncio
@@ -276,7 +276,7 @@ async def test_async_execute_query_errors_for_similar_without_embeddings() -> No
     assert exc_info.value.code == 1
     mock_echo.assert_called_once()
     assert "requires existing embeddings" in mock_echo.call_args.args[0]
-    assert "Build embeddings through the daemon" in mock_echo.call_args.args[0]
+    assert "Enable daemon embedding convergence" in mock_echo.call_args.args[0]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/cli/test_query_exec.py
+++ b/tests/unit/cli/test_query_exec.py
@@ -220,7 +220,8 @@ async def test_async_execute_query_errors_for_similar_without_vector_support() -
     assert exc_info.value.code == 1
     mock_echo.assert_called_once()
     assert "requires vector search support" in mock_echo.call_args.args[0]
-    assert "enable daemon embedding convergence" in mock_echo.call_args.args[0]
+    assert "initialization failed or is disabled" in mock_echo.call_args.args[0]
+    assert "daemon embedding convergence" in mock_echo.call_args.args[0]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/daemon/test_convergence_stages.py
+++ b/tests/unit/daemon/test_convergence_stages.py
@@ -8,7 +8,12 @@ from pathlib import Path
 import pytest
 
 import polylogue.daemon.convergence_stages as stages
-from polylogue.daemon.convergence_stages import make_embed_stage, make_fts_stage, make_insights_stage
+from polylogue.daemon.convergence_stages import (
+    make_default_convergence_stages,
+    make_embed_stage,
+    make_fts_stage,
+    make_insights_stage,
+)
 from polylogue.storage.insights.session.runtime import SessionInsightCounts
 
 
@@ -177,6 +182,7 @@ def test_embed_stage_scopes_changed_conversations_without_asyncio_run(
         return True
 
     monkeypatch.setenv("VOYAGE_API_KEY", "key")
+    monkeypatch.setenv("POLYLOGUE_DAEMON_ENABLE_EMBEDDINGS", "1")
     monkeypatch.setattr(asyncio, "run", fail_if_used)
     monkeypatch.setattr("polylogue.storage.sqlite.connection_profile.open_connection", fake_open_connection)
     monkeypatch.setattr(
@@ -193,6 +199,30 @@ def test_embed_stage_scopes_changed_conversations_without_asyncio_run(
     assert stage.check_many([path_a, path_b]) == {path_a, path_b}
     assert stage.execute_many([path_a, path_b]) is True
     assert embedded_calls == [["conv-a", "conv-c"]]
+
+
+def test_default_convergence_stages_do_not_embed_without_opt_in(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("VOYAGE_API_KEY", "key")
+    monkeypatch.delenv("POLYLOGUE_DAEMON_ENABLE_EMBEDDINGS", raising=False)
+
+    stage_names = [stage.name for stage in make_default_convergence_stages(tmp_path / "archive.sqlite")]
+
+    assert stage_names == ["fts", "insights"]
+
+
+def test_default_convergence_stages_include_embed_when_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("VOYAGE_API_KEY", "key")
+    monkeypatch.setenv("POLYLOGUE_DAEMON_ENABLE_EMBEDDINGS", "true")
+
+    stage_names = [stage.name for stage in make_default_convergence_stages(tmp_path / "archive.sqlite")]
+
+    assert stage_names == ["fts", "embed", "insights"]
 
 
 def test_insights_stage_batches_sync_rebuild_chunks(


### PR DESCRIPTION
## Summary

Daemon convergence now treats vector embedding rebuilds as an explicit opt-in stage instead of enabling them whenever `VOYAGE_API_KEY` exists. Default live catch-up runs FTS repair and insights refresh only, so daemon startup and convergence do not block on provider API calls unless the operator asks for embedding convergence.

## Problem

Live daemon verification showed `polylogued` stuck in the embed convergence stage during catch-up because the stage was enabled solely by `VOYAGE_API_KEY`. That made ordinary daemon convergence depend on external embedding throughput and obscured the actual ingest/read-model convergence performance work in #845.

## Solution

`make_default_convergence_stages()` now includes the `embed` stage only when both `VOYAGE_API_KEY` is present and `POLYLOGUE_DAEMON_ENABLE_EMBEDDINGS` is set to `1`, `true`, or `yes`. Query error text and daemon/configuration/architecture docs now describe that explicit opt-in contract, and unit tests pin the default stage list with and without the opt-in.

Ref #845

## Verification

- `ruff format --check polylogue/daemon/convergence_stages.py polylogue/cli/query.py tests/unit/daemon/test_convergence_stages.py tests/unit/cli/test_query_exec.py && ruff check polylogue/daemon/convergence_stages.py polylogue/cli/query.py tests/unit/daemon/test_convergence_stages.py tests/unit/cli/test_query_exec.py` — passed.
- `mypy --strict polylogue/daemon/convergence_stages.py polylogue/cli/query.py tests/unit/daemon/test_convergence_stages.py tests/unit/cli/test_query_exec.py` — `Success: no issues found in 4 source files`.
- `pytest tests/unit/daemon/test_convergence_stages.py tests/unit/cli/test_query_exec.py -q` — `75 passed in 13.36s`.
- `devtools render-all --check` — all generated surfaces in sync.
- `devtools verify` — `verify: all checks passed`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architecture, configuration, and daemon documentation to clarify that daemon-side embeddings are now opt-in, requiring explicit environment variable configuration to enable vector search functionality.

* **Chores**
  * Updated error messages to provide clearer guidance on enabling daemon embeddings when using similarity search features.
  * Updated tests to validate the new opt-in embedding behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->