### PR TITLE
test(scenarios): replace vacuous clean_stderr invariant and classify lane assertions

### DIFF
--- a/devtools/validation_lane_runtime.py
+++ b/devtools/validation_lane_runtime.py
@@ -32,6 +32,7 @@ def print_lane(lane: LaneEntry, *, indent: str = "") -> None:
     else:
         print(f"{indent}  command: {' '.join(build_lane_command(lane))}")
         print(f"{indent}  timeout: {lane.timeout_s}s")
+        print(f"{indent}  assertion: {lane.assertion.classification.value}")
 
 
 def run_lane(lane: LaneEntry) -> int:

--- a/polylogue/proof/runners.py
+++ b/polylogue/proof/runners.py
@@ -745,6 +745,10 @@ def _run_generated_scenario_family_evidence(
     evidence["status"] = status
     evidence["generated_world"] = attrs.get("generated_world")
     evidence["workload_family"] = attrs.get("workload_family")
+    evidence["evidence_note"] = (
+        "metadata/spec completeness: checks that scenario family subject metadata "
+        "is declared, not that the scenario executes"
+    )
     return _build_envelope(
         obligation,
         status=OutcomeStatus.OK if all(bool(value) for value in checks.values()) else OutcomeStatus.ERROR,
@@ -790,6 +794,10 @@ def _run_generated_scenario_local_evidence(
     evidence["local_deterministic"] = attrs.get("local_deterministic")
     evidence["live_archive_dependency"] = attrs.get("live_archive_dependency")
     evidence["reproducer"] = list(family_reproducer)
+    evidence["evidence_note"] = (
+        "metadata/spec completeness: checks that scenario family declares local/deterministic "
+        "properties in subject metadata, not that the scenario executes"
+    )
     return _build_envelope(
         obligation,
         status=OutcomeStatus.OK if all(bool(value) for value in checks.values()) else OutcomeStatus.ERROR,
@@ -842,6 +850,10 @@ def _run_generated_scenario_semantic_evidence(
     evidence["semantic_claims"] = [dict(claim) for claim in semantic_claims]
     evidence["implemented_claim_families"] = list(implemented)
     evidence["mapped_claim_families"] = list(mapped)
+    evidence["evidence_note"] = (
+        "metadata/spec completeness: checks that scenario family declares semantic claim "
+        "mappings in subject metadata, not that the mapped behavior executes"
+    )
     return _build_envelope(
         obligation,
         status=OutcomeStatus.OK if all(bool(value) for value in checks.values()) else OutcomeStatus.ERROR,

--- a/polylogue/scenarios/__init__.py
+++ b/polylogue/scenarios/__init__.py
@@ -1,6 +1,6 @@
 """Shared scenario models used across verification projections."""
 
-from .assertions import AssertionSpec
+from .assertions import AssertionClass, AssertionSpec, classification_label
 from .cli_surfaces import (
     CliSurfaceFamily,
     CliSurfaceVariant,
@@ -75,7 +75,9 @@ from .sources import NamedScenarioSource
 from .specs import ScenarioSpec
 
 __all__ = [
+    "AssertionClass",
     "AssertionSpec",
+    "classification_label",
     "build_default_corpus_specs",
     "build_corpus_scenarios",
     "build_inferred_corpus_specs",

--- a/polylogue/scenarios/assertions.py
+++ b/polylogue/scenarios/assertions.py
@@ -4,14 +4,53 @@ from __future__ import annotations
 
 import json
 from collections.abc import Callable, Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from enum import Enum
 
 from polylogue.insights.authored_payloads import PayloadDict, payload_float, payload_int, payload_items
 
 
+class AssertionClass(Enum):
+    """Classifies what kind of evidence an AssertionSpec provides.
+
+    The classification is auto-derived from which assertion fields are
+    populated, but callers may override it explicitly when the auto-derived
+    class does not match intent (e.g. a lane that runs pytest tests owns
+    its semantic checks in the test files, not in the AssertionSpec).
+    """
+
+    SMOKE_PROCESS = "smoke/process"
+    SEMANTIC_OUTPUT = "semantic-output"
+    RUNTIME_BUDGET = "runtime-budget"
+    LIVE_OBSERVABILITY = "live-observability"
+    METADATA_SPEC = "metadata/spec"
+
+
+def _classify_assertion(
+    stdout_contains: tuple[str, ...],
+    stdout_not_contains: tuple[str, ...],
+    stdout_is_valid_json: bool,
+    custom: object,
+    benchmark_warn_pct: object,
+    benchmark_fail_pct: object,
+) -> AssertionClass:
+    """Auto-classify an assertion spec from which fields are populated."""
+    if benchmark_warn_pct is not None or benchmark_fail_pct is not None:
+        return AssertionClass.RUNTIME_BUDGET
+    if stdout_contains or stdout_not_contains or stdout_is_valid_json or custom is not None:
+        return AssertionClass.SEMANTIC_OUTPUT
+    return AssertionClass.SMOKE_PROCESS
+
+
 @dataclass(frozen=True)
 class AssertionSpec:
-    """Expected success criteria for an authored executable scenario."""
+    """Expected success criteria for an authored executable scenario.
+
+    The default AssertionSpec(exit_code=0) only checks that the process exits
+    cleanly - it is a smoke/process check, not semantic proof.  Semantic
+    assertions require explicit stdout_contains, stdout_not_contains,
+    stdout_is_valid_json, or custom fields.
+    """
 
     exit_code: int | None = 0
     stdout_contains: tuple[str, ...] = ()
@@ -21,6 +60,21 @@ class AssertionSpec:
     benchmark_warn_pct: float | None = None
     benchmark_fail_pct: float | None = None
     custom: Callable[[str, int], str | None] | None = None
+    classification_override: AssertionClass | None = None
+
+    classification: AssertionClass = field(init=False)
+
+    def __post_init__(self) -> None:
+        """Auto-classify from populated fields unless explicitly overridden."""
+        klass = self.classification_override or _classify_assertion(
+            self.stdout_contains,
+            self.stdout_not_contains,
+            self.stdout_is_valid_json,
+            self.custom,
+            self.benchmark_warn_pct,
+            self.benchmark_fail_pct,
+        )
+        object.__setattr__(self, "classification", klass)
 
     def to_payload(self) -> PayloadDict:
         payload: PayloadDict = {}
@@ -38,6 +92,8 @@ class AssertionSpec:
             payload["benchmark_warn_pct"] = self.benchmark_warn_pct
         if self.benchmark_fail_pct is not None:
             payload["benchmark_fail_pct"] = self.benchmark_fail_pct
+        if self.classification_override is not None:
+            payload["classification"] = self.classification.value
         return payload
 
     @classmethod
@@ -52,6 +108,7 @@ class AssertionSpec:
             stdout_min_lines=payload_int(payload.get("stdout_min_lines"), "stdout_min_lines"),
             benchmark_warn_pct=payload_float(payload.get("benchmark_warn_pct"), "benchmark_warn_pct"),
             benchmark_fail_pct=payload_float(payload.get("benchmark_fail_pct"), "benchmark_fail_pct"),
+            classification_override=_parse_classification(payload.get("classification")),
         )
 
     def validate_process(self, output: str, exit_code: int) -> str | None:
@@ -89,4 +146,20 @@ class AssertionSpec:
         return default if self.benchmark_fail_pct is None else self.benchmark_fail_pct
 
 
-__all__ = ["AssertionSpec"]
+def _parse_classification(value: object) -> AssertionClass | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        try:
+            return AssertionClass(value)
+        except ValueError:
+            return None
+    return None
+
+
+def classification_label(klass: AssertionClass) -> str:
+    """Human-readable label for assertion classification."""
+    return klass.value
+
+
+__all__ = ["AssertionClass", "AssertionSpec", "classification_label"]

--- a/polylogue/showcase/invariants.py
+++ b/polylogue/showcase/invariants.py
@@ -107,15 +107,6 @@ def _check_exit_code(result: ExerciseResult) -> str | None:
     return None
 
 
-def _check_clean_stderr(result: ExerciseResult) -> str | None:
-    """Read commands produce no unexpected stderr."""
-    if result.exercise.writes:
-        return SKIP
-    # We don't have separate stderr in ExerciseResult (CliRunner merges it),
-    # so this invariant checks for error-like patterns in output
-    return None
-
-
 def _check_nonempty_output(result: ExerciseResult) -> str | None:
     """Non-count read commands produce non-empty output."""
     if result.exercise.writes:
@@ -144,11 +135,6 @@ SHOWCASE_INVARIANTS: list[Invariant] = [
         "exit_code",
         "Exit code matches validation spec",
         _check_exit_code,
-    ),
-    Invariant(
-        "clean_stderr",
-        "Read commands produce no unexpected stderr",
-        _check_clean_stderr,
     ),
     Invariant(
         "nonempty_output",

--- a/tests/unit/scenarios/test_assertions.py
+++ b/tests/unit/scenarios/test_assertions.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from polylogue.scenarios import AssertionSpec
+from polylogue.scenarios import AssertionClass, AssertionSpec
 
 
 def test_assertion_spec_validates_process_output() -> None:
@@ -10,14 +10,12 @@ def test_assertion_spec_validates_process_output() -> None:
         stdout_not_contains=("traceback",),
         stdout_min_lines=1,
     )
-
     assert assertion.validate_process("polylogue ok\n", 0) is None
     assert assertion.validate_process("nope\n", 0) == "output missing 'polylogue'"
 
 
 def test_assertion_spec_validates_json_contracts() -> None:
     assertion = AssertionSpec(stdout_is_valid_json=True)
-
     assert assertion.validate_process('{"ok": true}', 0) is None
     error = assertion.validate_process("not-json", 0)
     assert error is not None
@@ -26,6 +24,53 @@ def test_assertion_spec_validates_json_contracts() -> None:
 
 def test_assertion_spec_resolves_benchmark_thresholds() -> None:
     assertion = AssertionSpec(benchmark_warn_pct=12.5, benchmark_fail_pct=25.0)
-
     assert assertion.resolved_benchmark_warn_pct() == 12.5
     assert assertion.resolved_benchmark_fail_pct() == 25.0
+
+
+def test_default_assertion_classifies_as_smoke_process() -> None:
+    assert AssertionSpec().classification is AssertionClass.SMOKE_PROCESS
+    assert AssertionSpec(exit_code=0).classification is AssertionClass.SMOKE_PROCESS
+
+
+def test_stdout_checks_auto_classify_as_semantic_output() -> None:
+    assert AssertionSpec(stdout_contains=("ok",)).classification is AssertionClass.SEMANTIC_OUTPUT
+    assert AssertionSpec(stdout_not_contains=("err",)).classification is AssertionClass.SEMANTIC_OUTPUT
+    assert AssertionSpec(stdout_is_valid_json=True).classification is AssertionClass.SEMANTIC_OUTPUT
+    assert AssertionSpec(stdout_min_lines=5).classification is AssertionClass.SMOKE_PROCESS
+
+
+def test_benchmark_thresholds_auto_classify_as_runtime_budget() -> None:
+    assert AssertionSpec(benchmark_warn_pct=10.0).classification is AssertionClass.RUNTIME_BUDGET
+    assert AssertionSpec(benchmark_fail_pct=25.0).classification is AssertionClass.RUNTIME_BUDGET
+    assert (
+        AssertionSpec(benchmark_warn_pct=10.0, stdout_contains=("ok",)).classification is AssertionClass.RUNTIME_BUDGET
+    )
+
+
+def test_classification_override_preserved() -> None:
+    assertion = AssertionSpec(
+        stdout_contains=("semantic",),
+        classification_override=AssertionClass.METADATA_SPEC,
+    )
+    assert assertion.classification is AssertionClass.METADATA_SPEC
+    assert assertion.validate_process("semantic check\n", 0) is None
+
+
+def test_classification_roundtrips_through_payload() -> None:
+    original = AssertionSpec(
+        stdout_contains=("ok",),
+        classification_override=AssertionClass.LIVE_OBSERVABILITY,
+    )
+    payload = original.to_payload()
+    assert payload["classification"] == "live-observability"
+    rehydrated = AssertionSpec.from_payload(payload)
+    assert rehydrated.classification is AssertionClass.LIVE_OBSERVABILITY
+    assert rehydrated.stdout_contains == ("ok",)
+
+
+def test_smoke_process_does_not_serialize_classification() -> None:
+    assertion = AssertionSpec()
+    payload = assertion.to_payload()
+    assert "classification" not in payload
+    assert AssertionSpec.from_payload(payload).classification is AssertionClass.SMOKE_PROCESS

--- a/tests/unit/showcase/test_invariants_runtime.py
+++ b/tests/unit/showcase/test_invariants_runtime.py
@@ -13,7 +13,6 @@ from polylogue.showcase.invariants import (
     SKIP,
     Invariant,
     InvariantResult,
-    _check_clean_stderr,
     _check_exit_code,
     _check_json_valid,
     _check_nonempty_output,
@@ -90,10 +89,7 @@ def test_exit_code_invariant_uses_assertion_spec() -> None:
     assert _check_exit_code(failing) == "exit code 1, expected 0"
 
 
-def test_clean_stderr_and_nonempty_output_skip_expected_cases() -> None:
-    assert _check_clean_stderr(_make_result(args=("run",), writes=True)) == SKIP
-    assert _check_clean_stderr(_make_result(args=("stats",))) is None
-
+def test_nonempty_output_skip_expected_cases() -> None:
     assert _check_nonempty_output(_make_result(args=("stats", "--count"), output="")) == SKIP
     assert _check_nonempty_output(_make_result(args=("--help",), output="")) == SKIP
     assert _check_nonempty_output(_make_result(args=("--version",), output="")) == SKIP


### PR DESCRIPTION
## Summary

Replace the vacuous `_check_clean_stderr` showcase invariant (always returned success without checking stderr) and add explicit `AssertionClass` classification so lanes and assertions are honest about what kind of evidence they provide.

## Problem

- `_check_clean_stderr()` in `polylogue/showcase/invariants.py` returned `None` (pass) for all read commands without actually checking stderr (CliRunner merges stderr into merged output)
- `AssertionSpec()` defaulted to exit-code-only with no indication it's a smoke/process check, not semantic proof
- `devtools run-validation-lanes --list` didn't distinguish smoke/process lanes from semantic behavior lanes
- Generated scenario proof evidence raners checked static subject metadata but didn't label themselves as metadata/spec completeness

## Solution

1. **Deleted `_check_clean_stderr`** from `polylogue/showcase/invariants.py` and removed from `SHOWCASE_INVARIANTS` registry
2. **Added `AssertionClass` enum** (`SMOKE_PROCESS`, `SEMANTIC_OUTPUT`, `RUNTIME_BUDGET`, `LIVE_OBSERVABILITY`, `METADATA_SPEC`) to `polylogue/scenarios/assertions.py` with auto-classification from populated assertion fields
3. **Default `AssertionSpec()` is `SMOKE_PROCESS`** — exit-code-only default is visibly not semantic proof
4. **Classification shown in lane output** — `print_lane` in `devtools/validation_lane_runtime.py` now prints `assertion: smoke/process`
5. **Generated scenario evidence labeled** — `evidence_note` added to three runner functions in `polylogue/proof/runners.py` noting they check metadata/spec completeness, not executed behavior

## Verification

```bash
pytest tests/unit/scenarios/test_assertions.py -q         # 9 passed (3 existing + 6 new)
devtools run-validation-lanes --lane machine-contract --dry-run  # shows "assertion: smoke/process"
devtools verify --quick                                    # all gates green
```

Pre-existing master branch import error (`_WorkerProgress`) prevents running the full focused test suite (tests/unit/showcase/test_invariants_runtime.py, tests/unit/devtools/test_validation_lanes.py, tests/unit/proof/test_generated_scenario_obligations.py) — this is unrelated and tracked in #866.

Closes #857
Ref #852

## Files changed (7)
- `polylogue/scenarios/assertions.py` — +AssertionClass, auto-classification, classification_override
- `polylogue/scenarios/__init__.py` — export new names
- `polylogue/showcase/invariants.py` — delete _check_clean_stderr
- `polylogue/proof/runners.py` — evidence_note on generated scenario runners
- `devtools/validation_lane_runtime.py` — classification in print_lane
- `tests/unit/scenarios/test_assertions.py` — +6 classification tests
- `tests/unit/showcase/test_invariants_runtime.py` — remove clean_stderr tests