### PR TITLE
fix(storage): narrow attachment-ref insert to ON CONFLICT DO NOTHING (#820)

### DIFF
--- a/polylogue/core/common.py
+++ b/polylogue/core/common.py
@@ -142,9 +142,10 @@ ON CONFLICT(attachment_id) DO UPDATE SET
 """
 
 _ATTACHMENT_REF_INSERT_SQL = """
-INSERT OR IGNORE INTO attachment_refs (
+INSERT INTO attachment_refs (
     ref_id, attachment_id, conversation_id, message_id, provider_meta
 ) VALUES (?, ?, ?, ?, ?)
+ON CONFLICT(ref_id) DO NOTHING
 """
 
 _IDENTITY_LEDGER_UPSERT_SQL = """

--- a/tests/infra/storage_records.py
+++ b/tests/infra/storage_records.py
@@ -499,13 +499,14 @@ def upsert_attachment(conn: sqlite3.Connection, record: AttachmentRecord) -> boo
     ref_id = _make_ref_id(record.attachment_id, record.conversation_id, record.message_id)
     res = conn.execute(
         """
-        INSERT OR IGNORE INTO attachment_refs (
+        INSERT INTO attachment_refs (
             ref_id,
             attachment_id,
             conversation_id,
             message_id,
             provider_meta
         ) VALUES (?, ?, ?, ?, ?)
+        ON CONFLICT(ref_id) DO NOTHING
         """,
         (
             ref_id,


### PR DESCRIPTION
## Summary

Narrows attachment-ref insertion from `INSERT OR IGNORE` to `INSERT ... ON CONFLICT(ref_id) DO NOTHING`, preserving idempotency on primary key conflicts while surfacing FK violations that should never occur in correct operation.

## Problem

`INSERT OR IGNORE` silently swallows ALL constraint violations including FK integrity errors. This means a missing attachment row (FK violation) would be silently discarded instead of surfaced as a bug.

The `messages.parent_message_id` FK was reviewed and kept as NO ACTION (implicit SQLite default) — message deletion is conversation-scoped and the FK correctly prevents orphaned references.

## Solution

- Replaced `INSERT OR IGNORE` with `INSERT ... ON CONFLICT(ref_id) DO NOTHING` in `core/common.py`
- Updated test infrastructure to match in `tests/infra/storage_records.py`
- Classified all original #820 audit findings as fixed/removed/still-open

## Verification

- `devtools verify --quick` — all 14 gates passed
- 2 files, +4/-2
- Parent message FK: NO ACTION policy confirmed correct for conversation-scoped deletion

Refs #820 #852