### PR TITLE
fix(daemon): fix FTS commit ordering and quarantine visibility bugs

### DIFF
--- a/polylogue/pipeline/services/ingest_batch/_core.py
+++ b/polylogue/pipeline/services/ingest_batch/_core.py
@@ -879,6 +879,14 @@ def _commit_ingest_results(
     )
     summary.flush_elapsed_s = time.perf_counter() - flush_started
     _observe_current_rss(summary)
+    # Restore FTS triggers BEFORE commit so they are durable with the data.
+    # CREATE TRIGGER is DDL and auto-commits the pending transaction, so the
+    # explicit conn.commit() below becomes a no-op. If restore fails, the
+    # exception propagates before we mark the batch as committed.
+    # See https://github.com/Sinity/polylogue/issues/817
+    from polylogue.storage.fts.fts_lifecycle import restore_fts_triggers_sync
+
+    restore_fts_triggers_sync(conn)
     commit_started = time.perf_counter()
     conn.commit()
     summary.commit_elapsed_s = time.perf_counter() - commit_started

--- a/polylogue/storage/raw/artifacts.py
+++ b/polylogue/storage/raw/artifacts.py
@@ -50,7 +50,7 @@ class RawIngestArtifactState:
 
     @property
     def quarantined(self) -> bool:
-        return not self.parsed and self.parse_error is not None
+        return not self.parsed and (self.parse_error is not None or self.validation_status is ValidationStatus.FAILED)
 
     def needs_validation_backlog(self, *, force_reparse: bool = False) -> bool:
         return self.validation_status is None and (force_reparse or not self.parsed)


### PR DESCRIPTION
## Summary

Two correctness fixes found during #852 mass-execution reconnaissance.

## Problem

1. **FTS commit ordering (#817)**: `restore_fts_triggers_sync()` ran AFTER `conn.commit()` in the finally block. If it failed, data was already committed with suspended FTS triggers, causing silent stale search results.

2. **Quarantine invisibility (#844)**: `RawIngestArtifactState.quarantined` checked only `parse_error`, but strict schema validation failures set `validation_error` without `parse_error`, making them invisible to operators.

## Solution

1. FTS triggers now restored BEFORE `conn.commit()` — if restore fails, the exception propagates before marking the batch committed.

2. `quarantined` property now also checks `validation_status is ValidationStatus.FAILED`.

## Verification

- `devtools verify --quick` — all 14 gates passed
- 2 files, +9/-1

Refs #817 #844 #852

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data ingestion reliability by enhancing transaction handling during processing.
  * Refined artifact quarantine detection logic to better identify and handle problematic items based on validation status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->