### PR TITLE
refactor(schema): promote provider-meta fields to canonical columns (#864)

### DIFF
--- a/docs/plans/file-size-budgets.yaml
+++ b/docs/plans/file-size-budgets.yaml
@@ -60,3 +60,7 @@ exceptions:
   - path: polylogue/storage/repair.py
     ceiling: 1200
     reason: "added blob orphan detection, cleanup, and integrity verification (#818)"
+
+  - path: polylogue/storage/sqlite/schema_bootstrap.py
+    ceiling: 1200
+    reason: "added v9→v10 provider-meta promotion migration (#864)"

--- a/polylogue/storage/runtime/archive/records.py
+++ b/polylogue/storage/runtime/archive/records.py
@@ -51,6 +51,10 @@ class ConversationRecord(BaseModel):
     parent_conversation_id: ConversationId | None = None
     branch_type: BranchType | None = None
     raw_id: str | None = None
+    source_name: str = ""
+    working_directories_json: str | None = None
+    git_branch: str | None = None
+    git_repository_url: str | None = None
 
     @property
     def provider(self) -> Provider:
@@ -155,6 +159,9 @@ class AttachmentRecord(BaseModel):
     size_bytes: int | None = None
     path: str | None = None
     provider_meta: JSONObject | None = None
+    provider_attachment_id: str | None = None
+    provider_file_id: str | None = None
+    provider_drive_id: str | None = None
 
     @field_validator("attachment_id", "conversation_id")
     @classmethod

--- a/polylogue/storage/sqlite/schema_bootstrap.py
+++ b/polylogue/storage/sqlite/schema_bootstrap.py
@@ -81,6 +81,7 @@ class SchemaBootstrapDecision:
         "upgrade_v6_to_v7",
         "upgrade_v7_to_v8",
         "upgrade_v8_to_v9",
+        "upgrade_v9_to_v10",
         "version_mismatch",
     ]
     extension_plan: SchemaExtensionPlan | None = None
@@ -867,6 +868,63 @@ def build_v8_to_v9_upgrade_plan(snapshot: SchemaSnapshot) -> SchemaExtensionPlan
     return SchemaExtensionPlan(statements=tuple(statements), scripts=())
 
 
+_PROVIDER_META_PROMOTION_CONVERSATION_DDL = """
+ALTER TABLE conversations ADD COLUMN working_directories_json TEXT;
+ALTER TABLE conversations ADD COLUMN git_branch TEXT;
+ALTER TABLE conversations ADD COLUMN git_repository_url TEXT;
+"""
+
+_PROVIDER_META_PROMOTION_ATTACHMENT_DDL = """
+ALTER TABLE attachments ADD COLUMN provider_attachment_id TEXT;
+ALTER TABLE attachments ADD COLUMN provider_file_id TEXT;
+ALTER TABLE attachments ADD COLUMN provider_drive_id TEXT;
+"""
+
+_PROVIDER_META_PROMOTION_ATTACHMENT_REF_DDL = """
+ALTER TABLE attachment_refs ADD COLUMN provider_attachment_id TEXT;
+ALTER TABLE attachment_refs ADD COLUMN provider_file_id TEXT;
+ALTER TABLE attachment_refs ADD COLUMN provider_drive_id TEXT;
+"""
+
+_PROVIDER_META_PROMOTION_ATTACHMENT_INDEXES_DDL = """
+DROP INDEX IF EXISTS idx_attachments_provider_meta_id;
+DROP INDEX IF EXISTS idx_attachments_provider_meta_provider_id;
+DROP INDEX IF EXISTS idx_attachments_provider_meta_file_id;
+DROP INDEX IF EXISTS idx_attachments_provider_meta_drive_id;
+DROP INDEX IF EXISTS idx_attachment_refs_provider_meta_id;
+DROP INDEX IF EXISTS idx_attachment_refs_provider_meta_provider_id;
+DROP INDEX IF EXISTS idx_attachment_refs_provider_meta_file_id;
+DROP INDEX IF EXISTS idx_attachment_refs_provider_meta_drive_id;
+CREATE INDEX IF NOT EXISTS idx_attachments_provider_attachment_id
+ON attachments(provider_attachment_id);
+CREATE INDEX IF NOT EXISTS idx_attachments_provider_file_id
+ON attachments(provider_file_id);
+CREATE INDEX IF NOT EXISTS idx_attachments_provider_drive_id
+ON attachments(provider_drive_id);
+CREATE INDEX IF NOT EXISTS idx_attachment_refs_provider_attachment_id
+ON attachment_refs(provider_attachment_id);
+CREATE INDEX IF NOT EXISTS idx_attachment_refs_provider_file_id
+ON attachment_refs(provider_file_id);
+CREATE INDEX IF NOT EXISTS idx_attachment_refs_provider_drive_id
+ON attachment_refs(provider_drive_id);
+"""
+
+
+def build_v9_to_v10_upgrade_plan(snapshot: SchemaSnapshot) -> SchemaExtensionPlan:
+    """Promote provider-meta fields to canonical columns (#864)."""
+    assert_supported_archive_layout_snapshot(snapshot)
+
+    statements: list[str] = []
+    if snapshot.has_table("conversations"):
+        statements.extend(s for s in _split_ddl_into_statements(_PROVIDER_META_PROMOTION_CONVERSATION_DDL) if s)
+    if snapshot.has_table("attachments"):
+        statements.extend(s for s in _split_ddl_into_statements(_PROVIDER_META_PROMOTION_ATTACHMENT_DDL) if s)
+    if snapshot.has_table("attachment_refs"):
+        statements.extend(s for s in _split_ddl_into_statements(_PROVIDER_META_PROMOTION_ATTACHMENT_REF_DDL) if s)
+        statements.extend(s for s in _split_ddl_into_statements(_PROVIDER_META_PROMOTION_ATTACHMENT_INDEXES_DDL) if s)
+    return SchemaExtensionPlan(statements=tuple(statements), scripts=())
+
+
 def _upgrade_tail_statements(snapshot: SchemaSnapshot, *, from_version: int) -> tuple[str, ...]:
     statements: tuple[str, ...] = ()
     if from_version < 5 <= SCHEMA_VERSION:
@@ -884,6 +942,8 @@ def _upgrade_tail_statements(snapshot: SchemaSnapshot, *, from_version: int) -> 
         statements = (*statements, *build_v7_to_v8_upgrade_plan(snapshot).statements)
     if from_version < 9 <= SCHEMA_VERSION:
         statements = (*statements, *build_v8_to_v9_upgrade_plan(snapshot).statements)
+    if from_version < 10 <= SCHEMA_VERSION:
+        statements = (*statements, *build_v9_to_v10_upgrade_plan(snapshot).statements)
     return statements
 
 

--- a/polylogue/storage/sqlite/schema_ddl.py
+++ b/polylogue/storage/sqlite/schema_ddl.py
@@ -48,7 +48,7 @@ from polylogue.storage.sqlite.schema_ddl_provider_events import (
     PROVIDER_EVENT_DDL as _PROVIDER_EVENT_DDL,
 )
 
-SCHEMA_VERSION = 9
+SCHEMA_VERSION = 10
 
 
 # Complete target schema applied to fresh databases.

--- a/polylogue/storage/sqlite/schema_ddl_archive.py
+++ b/polylogue/storage/sqlite/schema_ddl_archive.py
@@ -53,7 +53,10 @@ ARCHIVE_STORAGE_DDL = """
             content_hash TEXT NOT NULL DEFAULT '',
             provider_meta TEXT,
             metadata TEXT DEFAULT '{}',
-            source_name TEXT GENERATED ALWAYS AS (json_extract(provider_meta, '$.source')) STORED,
+            source_name TEXT NOT NULL DEFAULT '',
+            working_directories_json TEXT,
+            git_branch TEXT,
+            git_repository_url TEXT,
             version INTEGER NOT NULL,
             parent_conversation_id TEXT REFERENCES conversations(conversation_id) ON DELETE SET NULL,
             branch_type TEXT CHECK (branch_type IN ('continuation', 'sidechain', 'fork', 'subagent') OR branch_type IS NULL),
@@ -64,7 +67,7 @@ ARCHIVE_STORAGE_DDL = """
         ON conversations(provider_name, provider_conversation_id);
 
         CREATE INDEX IF NOT EXISTS idx_conversations_source_name
-        ON conversations(source_name) WHERE source_name IS NOT NULL;
+        ON conversations(source_name);
 
         CREATE INDEX IF NOT EXISTS idx_conversations_parent
         ON conversations(parent_conversation_id) WHERE parent_conversation_id IS NOT NULL;
@@ -185,6 +188,9 @@ ARCHIVE_STORAGE_DDL = """
             path TEXT,
             ref_count INTEGER NOT NULL DEFAULT 0,
             provider_meta TEXT,
+            provider_attachment_id TEXT,
+            provider_file_id TEXT,
+            provider_drive_id TEXT,
             UNIQUE (attachment_id)
         );
 
@@ -194,6 +200,9 @@ ARCHIVE_STORAGE_DDL = """
             conversation_id TEXT NOT NULL,
             message_id TEXT,
             provider_meta TEXT,
+            provider_attachment_id TEXT,
+            provider_file_id TEXT,
+            provider_drive_id TEXT,
             FOREIGN KEY (attachment_id)
                 REFERENCES attachments(attachment_id) ON DELETE CASCADE,
             FOREIGN KEY (conversation_id)
@@ -212,37 +221,23 @@ ARCHIVE_STORAGE_DDL = """
         ON attachment_refs(message_id)
         WHERE message_id IS NOT NULL;
 
-        CREATE INDEX IF NOT EXISTS idx_attachments_provider_meta_id
-        ON attachments(json_extract(provider_meta, '$.id'))
-        WHERE provider_meta IS NOT NULL;
+        CREATE INDEX IF NOT EXISTS idx_attachments_provider_attachment_id
+        ON attachments(provider_attachment_id);
 
-        CREATE INDEX IF NOT EXISTS idx_attachments_provider_meta_provider_id
-        ON attachments(json_extract(provider_meta, '$.provider_id'))
-        WHERE provider_meta IS NOT NULL;
+        CREATE INDEX IF NOT EXISTS idx_attachments_provider_file_id
+        ON attachments(provider_file_id);
 
-        CREATE INDEX IF NOT EXISTS idx_attachments_provider_meta_file_id
-        ON attachments(json_extract(provider_meta, '$.fileId'))
-        WHERE provider_meta IS NOT NULL;
+        CREATE INDEX IF NOT EXISTS idx_attachments_provider_drive_id
+        ON attachments(provider_drive_id);
 
-        CREATE INDEX IF NOT EXISTS idx_attachments_provider_meta_drive_id
-        ON attachments(json_extract(provider_meta, '$.driveId'))
-        WHERE provider_meta IS NOT NULL;
+        CREATE INDEX IF NOT EXISTS idx_attachment_refs_provider_attachment_id
+        ON attachment_refs(provider_attachment_id);
 
-        CREATE INDEX IF NOT EXISTS idx_attachment_refs_provider_meta_id
-        ON attachment_refs(json_extract(provider_meta, '$.id'))
-        WHERE provider_meta IS NOT NULL;
+        CREATE INDEX IF NOT EXISTS idx_attachment_refs_provider_file_id
+        ON attachment_refs(provider_file_id);
 
-        CREATE INDEX IF NOT EXISTS idx_attachment_refs_provider_meta_provider_id
-        ON attachment_refs(json_extract(provider_meta, '$.provider_id'))
-        WHERE provider_meta IS NOT NULL;
-
-        CREATE INDEX IF NOT EXISTS idx_attachment_refs_provider_meta_file_id
-        ON attachment_refs(json_extract(provider_meta, '$.fileId'))
-        WHERE provider_meta IS NOT NULL;
-
-        CREATE INDEX IF NOT EXISTS idx_attachment_refs_provider_meta_drive_id
-        ON attachment_refs(json_extract(provider_meta, '$.driveId'))
-        WHERE provider_meta IS NOT NULL;
+        CREATE INDEX IF NOT EXISTS idx_attachment_refs_provider_drive_id
+        ON attachment_refs(provider_drive_id);
 
 """
 


### PR DESCRIPTION
## Summary

Schema v9→v10: promotes provider_meta fields to canonical columns. Slice 1 (DDL only).

## Problem

Universal archive semantics (source identity, working directories, git context, attachment native IDs) were trapped in provider_meta JSON blobs with 8 JSON expression indexes.

## Solution

**Conversations**: added `working_directories_json`, `git_branch`, `git_repository_url`. Source name is now a real TEXT column instead of a generated column.

**Attachments/attachment_refs**: added `provider_attachment_id`, `provider_file_id`, `provider_drive_id`.

**Indexes**: 8 JSON expression indexes replaced with 6 plain B-tree indexes.

**Migration**: v9→v10 upgrade plan with ALTER TABLE ADD COLUMN + index replacement.

## Verification

- `devtools verify --quick` — all 14 gates passed
- 5 files, +95/-29
- Slice 2 (parsers + materialization) follows

Refs #864 #840 #852