### PR TITLE
fix(mcp): add pagination envelopes and structured resource errors (#819)

### DIFF
--- a/polylogue/mcp/payloads.py
+++ b/polylogue/mcp/payloads.py
@@ -3,12 +3,34 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Generic, TypeVar
+from typing import TYPE_CHECKING, Generic, Literal, TypeVar
 
 from pydantic import RootModel
 from typing_extensions import TypedDict
 
 from polylogue.core.json import JSONDocument
+from polylogue.mcp.context_pack import (
+    ContextPackActionSummary as MCPContextPackActionSummary,
+    ContextPackConversation as MCPContextPackConversation,
+    ContextPackDateRange as MCPContextPackDateRange,
+    ContextPackMessage as MCPContextPackMessage,
+    ContextPackPayload as MCPContextPackPayload,
+    ContextPackProject as MCPContextPackProject,
+    ContextPackProvenance as MCPContextPackProvenance,
+    ContextPackQueryContext as MCPContextPackQueryContext,
+    ContextPackUnresolvedWork as MCPContextPackUnresolvedWork,
+)
+from polylogue.mcp.context_pack import (
+    ContextPackActionSummary as MCPContextPackActionSummary,
+    ContextPackConversation as MCPContextPackConversation,
+    ContextPackDateRange as MCPContextPackDateRange,
+    ContextPackMessage as MCPContextPackMessage,
+    ContextPackPayload as MCPContextPackPayload,
+    ContextPackProject as MCPContextPackProject,
+    ContextPackProvenance as MCPContextPackProvenance,
+    ContextPackQueryContext as MCPContextPackQueryContext,
+    ContextPackUnresolvedWork as MCPContextPackUnresolvedWork,
+)
 from polylogue.surfaces.payloads import (
     ConversationDetailPayload as MCPConversationDetailPayload,
 )
@@ -57,6 +79,7 @@ class MCPErrorPayload(SurfacePayloadModel):
     detail: str | None = None
     tool: str | None = None
     conversation_id: str | None = None
+    is_error: Literal[True] = True
 
 
 class MCPFencedCodeBlock(TypedDict):
@@ -122,6 +145,27 @@ class MCPConversationSearchNoResultsPayload(SurfacePayloadModel):
     diagnostics: MCPQueryMissDiagnosticsPayload
 
 
+
+class MCPPaginatedQueryResultPayload(SurfacePayloadModel):
+    """Paginated query result envelope for list_conversations."""
+
+    items: tuple[MCPConversationSummaryPayload, ...]
+    total: int
+    limit: int
+    offset: int
+    diagnostics: MCPQueryMissDiagnosticsPayload | None = None
+
+
+class MCPPaginatedSearchResultPayload(SurfacePayloadModel):
+    """Paginated search result envelope for search."""
+
+    hits: tuple[MCPConversationSearchHitPayload, ...]
+    total: int
+    limit: int
+    offset: int
+    diagnostics: MCPQueryMissDiagnosticsPayload | None = None
+
+
 def conversation_summary_list_payload(
     conversations: Sequence[Conversation],
 ) -> MCPConversationSummaryListPayload:
@@ -133,12 +177,19 @@ def conversation_summary_list_payload(
 def conversation_query_result_payload(
     conversations: Sequence[Conversation],
     *,
+    total: int,
+    limit: int,
+    offset: int,
     diagnostics: QueryMissDiagnostics | None = None,
-) -> MCPConversationSummaryListPayload | MCPConversationQueryNoResultsPayload:
-    if conversations or diagnostics is None:
-        return conversation_summary_list_payload(conversations)
-    return MCPConversationQueryNoResultsPayload(
-        diagnostics=MCPQueryMissDiagnosticsPayload.from_diagnostics(diagnostics),
+) -> MCPPaginatedQueryResultPayload:
+    return MCPPaginatedQueryResultPayload(
+        items=tuple(MCPConversationSummaryPayload.from_conversation(conv) for conv in conversations),
+        total=total,
+        limit=limit,
+        offset=offset,
+        diagnostics=(
+            MCPQueryMissDiagnosticsPayload.from_diagnostics(diagnostics) if diagnostics else None
+        ),
     )
 
 
@@ -167,12 +218,25 @@ def conversation_neighbor_candidate_list_payload(
 def conversation_search_result_payload(
     hits: Sequence[ConversationSearchHit],
     *,
+    total: int,
+    limit: int,
+    offset: int,
     diagnostics: QueryMissDiagnostics | None = None,
-) -> MCPConversationSearchHitListPayload | MCPConversationSearchNoResultsPayload:
-    if hits or diagnostics is None:
-        return conversation_search_hit_list_payload(hits)
-    return MCPConversationSearchNoResultsPayload(
-        diagnostics=MCPQueryMissDiagnosticsPayload.from_diagnostics(diagnostics),
+) -> MCPPaginatedSearchResultPayload:
+    return MCPPaginatedSearchResultPayload(
+        hits=tuple(
+            MCPConversationSearchHitPayload.from_search_hit(
+                hit,
+                message_count=hit.summary.message_count,
+            )
+            for hit in hits
+        ),
+        total=total,
+        limit=limit,
+        offset=offset,
+        diagnostics=(
+            MCPQueryMissDiagnosticsPayload.from_diagnostics(diagnostics) if diagnostics else None
+        ),
     )
 
 
@@ -373,6 +437,24 @@ class MCPReadinessReportPayload(SurfacePayloadModel):
 
 __all__ = [
     "MCPArchiveStatsPayload",
+    "MCPContextPackActionSummary",
+    "MCPContextPackConversation",
+    "MCPContextPackDateRange",
+    "MCPContextPackMessage",
+    "MCPContextPackPayload",
+    "MCPContextPackProject",
+    "MCPContextPackProvenance",
+    "MCPContextPackQueryContext",
+    "MCPContextPackUnresolvedWork",
+    "MCPContextPackActionSummary",
+    "MCPContextPackConversation",
+    "MCPContextPackDateRange",
+    "MCPContextPackMessage",
+    "MCPContextPackPayload",
+    "MCPContextPackProject",
+    "MCPContextPackProvenance",
+    "MCPContextPackQueryContext",
+    "MCPContextPackUnresolvedWork",
     "MCPConversationDetailPayload",
     "MCPConversationNeighborCandidateListPayload",
     "MCPConversationNeighborCandidatePayload",

--- a/polylogue/mcp/server_resources.py
+++ b/polylogue/mcp/server_resources.py
@@ -25,7 +25,14 @@ def register_resources(mcp: FastMCP, hooks: ServerCallbacks) -> None:
 
     @mcp.resource("polylogue://stats")
     async def stats_resource() -> str:
-        archive_stats = await hooks.get_archive_ops().storage_stats()
+        try:
+            archive_stats = await hooks.get_archive_ops().storage_stats()
+        except Exception as exc:
+            return hooks.error_json(
+                f"Failed to retrieve archive stats: {exc}",
+                code="internal_error",
+                detail=type(exc).__name__,
+            )
         return hooks.json_payload(
             MCPArchiveStatsPayload.from_archive_stats(
                 archive_stats,
@@ -37,7 +44,14 @@ def register_resources(mcp: FastMCP, hooks: ServerCallbacks) -> None:
 
     @mcp.resource("polylogue://conversations")
     async def conversations_resource() -> str:
-        convs = await MCPConversationQueryRequest().build_spec(hooks.clamp_limit).list(hooks.get_query_store())
+        try:
+            convs = await MCPConversationQueryRequest().build_spec(hooks.clamp_limit).list(hooks.get_query_store())
+        except Exception as exc:
+            return hooks.error_json(
+                f"Failed to list conversations: {exc}",
+                code="internal_error",
+                detail=type(exc).__name__,
+            )
         return hooks.json_payload(conversation_summary_list_payload(convs))
 
     @mcp.resource("polylogue://conversation/{conv_id}")
@@ -45,7 +59,7 @@ def register_resources(mcp: FastMCP, hooks: ServerCallbacks) -> None:
         ops = hooks.get_archive_ops()
         summary = await ops.get_conversation_summary(conv_id)
         if not summary:
-            return hooks.error_json(f"Conversation not found: {conv_id}")
+            return hooks.error_json(f"Conversation not found: {conv_id}", code="not_found")
         stats = await ops.get_conversation_stats(conv_id)
         return hooks.json_payload(
             MCPConversationSummaryPayload.from_summary(
@@ -56,7 +70,14 @@ def register_resources(mcp: FastMCP, hooks: ServerCallbacks) -> None:
 
     @mcp.resource("polylogue://tags")
     async def tags_resource() -> str:
-        tags = await hooks.get_tag_store().list_tags()
+        try:
+            tags = await hooks.get_tag_store().list_tags()
+        except Exception as exc:
+            return hooks.error_json(
+                f"Failed to list tags: {exc}",
+                code="internal_error",
+                detail=type(exc).__name__,
+            )
         return hooks.json_payload(MCPTagCountsPayload(root=tags))
 
     @mcp.resource("polylogue://messages/{conv_id}")
@@ -64,7 +85,7 @@ def register_resources(mcp: FastMCP, hooks: ServerCallbacks) -> None:
         ops = hooks.get_archive_ops()
         summary = await ops.get_conversation_summary(conv_id)
         if summary is None:
-            return hooks.error_json(f"Conversation not found: {conv_id}")
+            return hooks.error_json(f"Conversation not found: {conv_id}", code="not_found")
         canonical_id = str(summary.id)
         messages, total = await ops.get_messages_paginated(canonical_id, limit=20, offset=0)
         from polylogue.mcp.payloads import MCPMessagePayload, MCPMessagesListPayload
@@ -81,13 +102,27 @@ def register_resources(mcp: FastMCP, hooks: ServerCallbacks) -> None:
 
     @mcp.resource("polylogue://session-tree/{conv_id}")
     async def session_tree_resource(conv_id: str) -> str:
-        tree = await hooks.get_archive_ops().get_session_tree(conv_id)
+        try:
+            tree = await hooks.get_archive_ops().get_session_tree(conv_id)
+        except Exception as exc:
+            return hooks.error_json(
+                f"Failed to get session tree for {conv_id}: {exc}",
+                code="internal_error",
+                detail=type(exc).__name__,
+            )
         return hooks.json_payload(conversation_summary_list_payload(tree))
 
     @mcp.resource("polylogue://provider/{name}/recent")
     async def provider_recent_resource(name: str) -> str:
-        spec = MCPConversationQueryRequest(provider=name, sort="date", limit=10).build_spec(hooks.clamp_limit)
-        convs = await spec.list(hooks.get_query_store())
+        try:
+            spec = MCPConversationQueryRequest(provider=name, sort="date", limit=10).build_spec(hooks.clamp_limit)
+            convs = await spec.list(hooks.get_query_store())
+        except Exception as exc:
+            return hooks.error_json(
+                f"Failed to list recent conversations for provider {name}: {exc}",
+                code="internal_error",
+                detail=type(exc).__name__,
+            )
         return hooks.json_payload(conversation_summary_list_payload(convs))
 
     @mcp.resource("polylogue://readiness")

--- a/polylogue/mcp/server_tools.py
+++ b/polylogue/mcp/server_tools.py
@@ -82,6 +82,8 @@ def register_query_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
     ) -> str:
         async def run() -> str:
             ops = hooks.get_archive_ops()
+            clamped_limit = hooks.clamp_limit(limit)
+            clamped_offset = max(0, offset)
             spec = MCPConversationQueryRequest(
                 query=query,
                 retrieval_lane=retrieval_lane,
@@ -108,7 +110,7 @@ def register_query_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
                 sort=sort,
                 reverse=reverse,
                 latest=latest,
-                limit=limit,
+                limit=clamped_limit,
                 has_tool_use=has_tool_use,
                 has_thinking=has_thinking,
                 has_paste=has_paste,
@@ -121,11 +123,20 @@ def register_query_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
                 since_session=since_session,
                 since_session_id=since_session_id,
                 message_type=message_type,
-                offset=offset,
+                offset=clamped_offset,
             ).build_spec(hooks.clamp_limit)
             results = await ops.search_conversation_hits(spec)
+            total = await spec.count(hooks.get_query_store())
             diagnostics = await ops.diagnose_query_miss(spec) if not results else None
-            return hooks.json_payload(conversation_search_result_payload(results, diagnostics=diagnostics))
+            return hooks.json_payload(
+                conversation_search_result_payload(
+                    results,
+                    total=total,
+                    limit=clamped_limit,
+                    offset=clamped_offset,
+                    diagnostics=diagnostics,
+                )
+            )
 
         return await hooks.async_safe_call("search", run)
 
@@ -172,6 +183,8 @@ def register_query_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
     ) -> str:
         async def run() -> str:
             ops = hooks.get_archive_ops()
+            clamped_limit = hooks.clamp_limit(limit)
+            clamped_offset = max(0, offset)
             spec = MCPConversationQueryRequest(
                 provider=provider,
                 retrieval_lane=retrieval_lane,
@@ -197,7 +210,7 @@ def register_query_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
                 sort=sort,
                 reverse=reverse,
                 latest=latest,
-                limit=limit,
+                limit=clamped_limit,
                 has_tool_use=has_tool_use,
                 has_thinking=has_thinking,
                 has_paste=has_paste,
@@ -210,16 +223,25 @@ def register_query_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
                 since_session=since_session,
                 since_session_id=since_session_id,
                 message_type=message_type,
-                offset=offset,
+                offset=clamped_offset,
             ).build_spec(hooks.clamp_limit)
             conversations = await ops.query_conversations(spec)
+            total = await spec.count(hooks.get_query_store())
             diagnostics = None
             if not conversations:
                 try:
                     diagnostics = await ops.diagnose_query_miss(spec)
                 except ConfigError:
                     diagnostics = None
-            return hooks.json_payload(conversation_query_result_payload(conversations, diagnostics=diagnostics))
+            return hooks.json_payload(
+                conversation_query_result_payload(
+                    conversations,
+                    total=total,
+                    limit=clamped_limit,
+                    offset=clamped_offset,
+                    diagnostics=diagnostics,
+                )
+            )
 
         return await hooks.async_safe_call("list_conversations", run)
 


### PR DESCRIPTION
## Summary

Add pagination envelopes to `list_conversations` and `search` MCP tools, and standardize structured error handling across all resource handlers.

## Problem

- `list_conversations` and `search` returned bare JSON arrays with no `total`/`limit`/`offset` metadata, making client-side pagination impossible.
- Resource handlers had inconsistent error patterns: some returned plain strings, some had no error handling at all, and errors were not machine-readable.
- `MCPErrorPayload` lacked an explicit `is_error` field.

## Solution

**Payloads** (`polylogue/mcp/payloads.py`):
- Added `is_error: Literal[True]` to `MCPErrorPayload`.
- Added `MCPPaginatedQueryResultPayload` (items, total, limit, offset, diagnostics) and `MCPPaginatedSearchResultPayload` (hits, total, limit, offset, diagnostics).
- Updated `conversation_query_result_payload()` and `conversation_search_result_payload()` to produce paginated envelopes with total/limit/offset.

**Tools** (`polylogue/mcp/server_tools.py`):
- `search` and `list_conversations` now compute clamped limit/offset, call `spec.count()` for total, and wrap results in paginated envelopes.

**Resources** (`polylogue/mcp/server_resources.py`):
- Added `code="not_found"` to conversation and messages resource not-found error returns.
- Wrapped stats, conversations, tags, session-tree, and provider/recent resource handlers with try/except returning structured `internal_error` payloads.
- readiness resource already had structured error handling.

## Verification

Deferred to wave batch per #852 policy.

Refs #819 #852.