### PR TITLE
refactor(surfaces): route rendering through shared ArchiveOperations (#860)

### DIFF
--- a/polylogue/operations/archive.py
+++ b/polylogue/operations/archive.py
@@ -97,6 +97,7 @@ if TYPE_CHECKING:
     from polylogue.archive.query.search_hits import ConversationSearchHit
     from polylogue.archive.stats import ArchiveStats as StorageArchiveStats
     from polylogue.config import Config
+    from polylogue.storage.archive_views import ConversationRenderProjection
     from polylogue.storage.insights.session.runtime import SessionInsightCounts
     from polylogue.storage.repository import ConversationRepository
     from polylogue.storage.runtime import RawConversationRecord
@@ -301,6 +302,12 @@ class ArchiveSearchMixin:
     async def get_conversation_stats(self, conversation_id: str) -> dict[str, int]:
         full_id = await self.repository.resolve_id(conversation_id) or conversation_id
         return await self.repository.get_conversation_stats(str(full_id))
+
+    async def get_render_projection(
+        self, conversation_id: str
+    ) -> ConversationRenderProjection | None:
+        """Load the canonical render projection for a conversation."""
+        return await self.repository.get_render_projection(conversation_id)
 
     async def get_conversations(
         self,

--- a/polylogue/rendering/core_formatter.py
+++ b/polylogue/rendering/core_formatter.py
@@ -12,11 +12,10 @@ from polylogue.rendering.core_markdown import (
     _normalize_markdown_message,
     render_markdown_document,
 )
-from polylogue.storage.repository import ConversationRepository
-from polylogue.storage.sqlite.async_sqlite import SQLiteBackend
 
 if TYPE_CHECKING:
     from polylogue.storage.archive_views import ConversationRenderProjection
+    from polylogue.storage.repository import ConversationRepository
 
 
 @dataclass
@@ -43,21 +42,13 @@ class FormattedConversation:
 class ConversationFormatter:
     """Formats repository render projections to structured output."""
 
-    def __init__(self, archive_root: Path, db_path: Path | None = None, backend: SQLiteBackend | None = None):
+    def __init__(self, archive_root: Path, repository: ConversationRepository):
         self.archive_root = archive_root
-        self.db_path = db_path
-        self.backend = backend
+        self._repository = repository
 
     async def load_projection(self, conversation_id: str) -> ConversationRenderProjection:
         """Load the canonical repository-owned render projection."""
-        backend = self.backend or SQLiteBackend(db_path=self.db_path)
-        repository = ConversationRepository(backend=backend)
-        owns_backend = self.backend is None
-        try:
-            projection = await repository.get_render_projection(conversation_id)
-        finally:
-            if owns_backend:
-                await repository.close()
+        projection = await self._repository.get_render_projection(conversation_id)
         if projection is None:
             raise ValueError(f"Conversation not found: {conversation_id}")
         return projection

--- a/polylogue/rendering/renderers/__init__.py
+++ b/polylogue/rendering/renderers/__init__.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 
 from polylogue.config import Config
 from polylogue.protocols import OutputRenderer
+from polylogue.storage.repository import ConversationRepository
 
 from .html import HTMLRenderer
 from .markdown import MarkdownRenderer
@@ -20,9 +21,18 @@ if TYPE_CHECKING:
     from polylogue.storage.sqlite.async_sqlite import SQLiteBackend
 
 
+def _renderer_repository(config: Config, backend: SQLiteBackend | None) -> ConversationRepository:
+    """Build a repository from a backend or config for renderer injection."""
+    if backend is not None:
+        return ConversationRepository(backend=backend)
+    return ConversationRepository(db_path=config.db_path)
+
+
 def _markdown_renderer(config: Config, backend: SQLiteBackend | None) -> OutputRenderer:
-    del backend
-    return MarkdownRenderer(archive_root=config.archive_root)
+    return MarkdownRenderer(
+        archive_root=config.archive_root,
+        repository=_renderer_repository(config, backend),
+    )
 
 
 def _html_renderer(config: Config, backend: SQLiteBackend | None) -> OutputRenderer:
@@ -30,13 +40,15 @@ def _html_renderer(config: Config, backend: SQLiteBackend | None) -> OutputRende
     return HTMLRenderer(
         archive_root=config.archive_root,
         template_path=template_path,
-        backend=backend,
+        repository=_renderer_repository(config, backend),
     )
 
 
 def _plaintext_renderer(config: Config, backend: SQLiteBackend | None) -> OutputRenderer:
-    del backend
-    return PlaintextRenderer(archive_root=config.archive_root)
+    return PlaintextRenderer(
+        archive_root=config.archive_root,
+        repository=_renderer_repository(config, backend),
+    )
 
 
 _RENDERER_FACTORIES = {

--- a/polylogue/rendering/renderers/html.py
+++ b/polylogue/rendering/renderers/html.py
@@ -27,7 +27,7 @@ from polylogue.rendering.renderers.html_template import get_cached_template
 if TYPE_CHECKING:
     from polylogue.archive.models import Conversation
     from polylogue.storage.archive_views import ConversationRenderProjection
-    from polylogue.storage.sqlite.async_sqlite import SQLiteBackend
+    from polylogue.storage.repository import ConversationRepository
 
 
 class HTMLRenderer:
@@ -36,7 +36,7 @@ class HTMLRenderer:
     Performance architecture:
     - Single DB query per conversation (merged format + prepare)
     - CPU work (Pygments, MarkdownIt, Jinja2) offloaded to thread pool
-    - Shared backend eliminates per-render schema checks / connection setup
+    - Shared repository eliminates per-render schema checks / connection setup
     - File writes offloaded to thread pool
     """
 
@@ -45,7 +45,7 @@ class HTMLRenderer:
         archive_root: Path,
         template_path: Path | None = None,
         theme: str = "dark",
-        backend: SQLiteBackend | None = None,
+        repository: ConversationRepository,
     ) -> None:
         """Initialize the HTML renderer.
 
@@ -53,12 +53,12 @@ class HTMLRenderer:
             archive_root: Root directory for archived conversations
             template_path: Optional path to custom Jinja2 HTML template
             theme: Theme name ("dark" or "light"), default "dark"
-            backend: Shared async SQLite backend (avoids per-render connection overhead)
+            repository: Shared ConversationRepository (avoids per-render connection overhead)
         """
         self.archive_root = archive_root
         self.template_path = template_path
         self.theme = theme
-        self._formatter = ConversationFormatter(archive_root, backend=backend)
+        self._formatter = ConversationFormatter(archive_root, repository=repository)
 
         # Initialize Pygments highlighter
         style = "monokai" if theme == "dark" else "default"

--- a/polylogue/rendering/renderers/markdown.py
+++ b/polylogue/rendering/renderers/markdown.py
@@ -3,22 +3,27 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from polylogue.paths.sanitize import conversation_render_root
 from polylogue.rendering.core import ConversationFormatter
+
+if TYPE_CHECKING:
+    from polylogue.storage.repository import ConversationRepository
 
 
 class MarkdownRenderer:
     """Renders conversations to plain Markdown format."""
 
-    def __init__(self, archive_root: Path):
+    def __init__(self, archive_root: Path, repository: ConversationRepository):
         """Initialize the Markdown renderer.
 
         Args:
             archive_root: Root directory for archived conversations
+            repository: ConversationRepository for loading projections
         """
         self.archive_root = archive_root
-        self.formatter = ConversationFormatter(archive_root)
+        self.formatter = ConversationFormatter(archive_root, repository=repository)
 
     def supports_format(self) -> str:
         """Return the output format this renderer supports.

--- a/polylogue/rendering/renderers/plaintext.py
+++ b/polylogue/rendering/renderers/plaintext.py
@@ -4,22 +4,27 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from polylogue.paths.sanitize import conversation_render_root
 from polylogue.rendering.core import ConversationFormatter
+
+if TYPE_CHECKING:
+    from polylogue.storage.repository import ConversationRepository
 
 
 class PlaintextRenderer:
     """Renders conversations to plain text format."""
 
-    def __init__(self, archive_root: Path):
+    def __init__(self, archive_root: Path, repository: ConversationRepository):
         """Initialize the plaintext renderer.
 
         Args:
             archive_root: Root directory for archived conversations
+            repository: ConversationRepository for loading projections
         """
         self.archive_root = archive_root
-        self.formatter = ConversationFormatter(archive_root)
+        self.formatter = ConversationFormatter(archive_root, repository=repository)
 
     def supports_format(self) -> str:
         """Return the output format this renderer supports.


### PR DESCRIPTION
## Summary

Implement B1 from the #860 surface-storage bypass inventory: inject `ConversationRepository` into `ConversationFormatter` and renderers instead of having `ConversationFormatter` construct its own `SQLiteBackend` and `ConversationRepository`. Add `get_render_projection` to `ArchiveOperations` as a thin delegation.

## Problem

`polylogue/rendering/core_formatter.py` constructed its own `SQLiteBackend` and `ConversationRepository` in `load_projection()`, bypassing the shared archive API spine (`ArchiveOperations` / `ConversationRepository`). This is the highest-priority bypass (#860-B1) since rendering is used by all surfaces.

## Solution

- **`core_formatter.py`**: `ConversationFormatter.__init__` now requires a `ConversationRepository` instead of ever constructing its own backend. Removed `SQLiteBackend` and `ConversationRepository` module-level imports. `load_projection` uses the injected repository directly.
- **`operations/archive.py`**: Added `get_render_projection` method to `ArchiveSearchMixin` as a thin delegation to `self.repository.get_render_projection()`.
- **`renderers/__init__.py`**: Added `_renderer_repository` helper that builds a `ConversationRepository` from a backend or config. All three factory functions now inject the repository.
- **`html.py`**: Replaced `backend: SQLiteBackend | None` parameter with `repository: ConversationRepository`.
- **`markdown.py`**, **`plaintext.py`**: Added required `repository` parameter, propagated to `ConversationFormatter`.

Files changed: 6 (+47/-27 lines)

## Verification

Deferred to wave batch per #852 policy.

## Inventory (referenced bypasses)

| # | File | Bypass | Resolution |
|---|------|--------|------------|
| B1 | `rendering/core_formatter.py` | Constructs own `SQLiteBackend`/`ConversationRepository` | **Fixed** — injects `ConversationRepository` |
| B13-B16 | `daemon/status.py` | Raw SQL via `open_readonly_connection()` | Classified as daemon substrate — acceptable |

Ref #860