### PR TITLE
fix: close scope gaps — bare CLI, ingest contract, FK test

### DIFF
--- a/polylogue/cli/click_app.py
+++ b/polylogue/cli/click_app.py
@@ -40,7 +40,15 @@ def _handle_query_mode(ctx: click.Context) -> None:
 
 
 def _show_stats(env: AppEnv, *, verbose: bool = False) -> None:
-    """Show archive statistics."""
+    """Show fast status when daemon is reachable, otherwise archive summary."""
+    if not verbose:
+        try:
+            from polylogue.cli.commands.status import show_fast_status
+
+            show_fast_status(env)
+            return
+        except Exception:
+            pass
     from polylogue.cli.shared.helpers import print_summary
 
     print_summary(env, verbose=verbose)

--- a/polylogue/cli/commands/ingest.py
+++ b/polylogue/cli/commands/ingest.py
@@ -10,6 +10,7 @@ import click
 
 from polylogue.cli.shared.helpers import fail
 from polylogue.cli.shared.types import AppEnv
+from polylogue.operations.import_contracts import ImportOperation
 
 _DEFAULT_DAEMON_URL = "http://127.0.0.1:8766"
 
@@ -52,21 +53,22 @@ def ingest_command(
 
     try:
         with urlopen(req, timeout=5) as resp:
-            result = json.loads(resp.read())
+            raw = json.loads(resp.read())
     except OSError as exc:
         fail(
             "ingest",
             f"Could not reach daemon at {daemon_url}. Is polylogued running? ({exc})",
         )
 
-    if result.get("ok"):
+    operation = ImportOperation.from_dict(raw)
+    if operation.status not in ("failed", "error"):
         env.ui.console.print(
-            f"[bold green]Scheduled:[/bold green] {result['path']}\n"
-            f"  Operation: {result['operation_id']}\n"
-            f"  {result['message']}"
+            f"[bold green]Scheduled:[/bold green] {operation.path}\n"
+            f"  Operation: {operation.operation_id}\n"
+            f"  {operation.message}"
         )
     else:
-        fail("ingest", result.get("error", "Unknown error"))
+        fail("ingest", operation.error or "Unknown error")
 
 
 __all__ = ["ingest_command"]

--- a/tests/unit/storage/test_backend.py
+++ b/tests/unit/storage/test_backend.py
@@ -1467,3 +1467,50 @@ async def test_get_archive_stats_skips_retrieval_band_status(tmp_path: Path, mon
     assert stats.total_conversations == 0
     assert observed == [False]
     await backend.close()
+
+
+async def test_parent_message_id_self_referential_fk(
+    tmp_path: Path,
+) -> None:
+    """messages.parent_message_id FK uses NO ACTION — conversation-scoped deletion works."""
+    from polylogue.storage.sqlite.async_sqlite import SQLiteBackend
+
+    backend = SQLiteBackend(db_path=tmp_path / "fk.db")
+    repo = ConversationRepository(backend=backend)
+
+    # Create a conversation with self-referential message chain
+    parent = make_message("msg-parent", "conv-fk", role="user", text="Parent")
+    child = make_message(
+        "msg-child",
+        "conv-fk",
+        role="assistant",
+        text="Child",
+        parent_message_id="msg-parent",
+    )
+    grandchild = make_message(
+        "msg-grandchild",
+        "conv-fk",
+        role="user",
+        text="Grandchild",
+        parent_message_id="msg-child",
+    )
+    conv = make_conversation("conv-fk", title="FK Test")
+
+    async with backend.transaction():
+        await backend.save_conversation_record(conv)
+        await backend.save_messages([parent, child, grandchild])
+
+    # Verify all messages exist
+    messages = await backend.get_messages("conv-fk")
+    assert len(messages) == 3
+
+    # Verify self-referential chain is intact
+    child_msg = next(m for m in messages if m.message_id == "msg-child")
+    assert child_msg.parent_message_id == "msg-parent"
+
+    # Deleting conversation cascades to messages (ON DELETE CASCADE on conversation_id FK)
+    assert await repo.delete_conversation("conv-fk") is True
+    assert await backend.get_conversation("conv-fk") is None
+    assert len(await backend.get_messages("conv-fk")) == 0
+
+    await backend.close()


### PR DESCRIPTION
#825: wire bare polylogue to show_fast_status(). #861: CLI ingest uses ImportOperation.from_dict(). #881: add parent_message_id FK regression test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Daemon status display now available in standard mode for faster status checks.

* **Bug Fixes**
  * Import operations now report structured status information including operation ID and path details.
  * Improved error reporting for failed import operations.

* **Tests**
  * Added tests validating message parent-child relationships and cascade deletion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->