### PR TITLE
fix: final gaps — stale docs, FK surfacing test (#820/#852)

### DIFF
--- a/docs/internals.md
+++ b/docs/internals.md
@@ -66,8 +66,8 @@ needs a stats-table join, update `_needs_stats_join()` in
 `cli/query.py` and MCP parameter in `mcp/`.
 
 **Adding a CLI command**: Register in `cli/command_inventory.py`. Implementation
-goes in `cli/commands/`. The CLI is query-first — bare `polylogue` is search,
-not help.
+goes in `cli/commands/`. The CLI shows fast daemon status on bare invocation
+and falls back to archive summary when the daemon is not running.
 
 **Adding a session insight**: Define the insight model in `insights/`. Add
 storage in `storage/insights/session/`. Wire rebuild logic and register in

--- a/tests/unit/storage/test_backend.py
+++ b/tests/unit/storage/test_backend.py
@@ -1585,3 +1585,37 @@ def test_fts_triggers_restored_before_commit(tmp_path: Path) -> None:
     count = conn.execute("SELECT COUNT(*) FROM messages_fts").fetchone()[0]
     assert count == 2, f"Expected 2 FTS entries, got {count}"
     conn.close()
+
+
+def test_attachment_ref_fk_violation_surfaced(tmp_path: Path) -> None:
+    """ON CONFLICT DO NOTHING surfaces FK violations rather than swallowing them (#820)."""
+    import sqlite3
+
+    from polylogue.storage.sqlite.schema_ddl_archive import ARCHIVE_STORAGE_DDL
+
+    db = tmp_path / "fk_surface.db"
+    conn = sqlite3.connect(str(db))
+    conn.executescript(ARCHIVE_STORAGE_DDL)
+
+    # Create a conversation so the FK to conversations is satisfied
+    conn.execute(
+        "INSERT INTO conversations(conversation_id, provider_name, provider_conversation_id) VALUES(?,?,?)",
+        ("c1", "test", "pc1"),
+    )
+    conn.commit()
+
+    # Try to insert an attachment_ref with a non-existent attachment_id
+    # ON CONFLICT DO NOTHING only handles ref_id conflicts — FK violations still raise
+    try:
+        conn.execute(
+            "INSERT INTO attachment_refs(ref_id, attachment_id, conversation_id) VALUES(?,?,?)",
+            ("ref-1", "nonexistent-attachment", "c1"),
+        )
+        conn.commit()
+        # If we get here, the FK violation was NOT surfaced — this is a bug
+        raise AssertionError("FK violation should have raised IntegrityError")
+    except sqlite3.IntegrityError:
+        # Expected: FK violation surfaced
+        pass
+    finally:
+        conn.close()


### PR DESCRIPTION
#852: fix internals.md. #820: add FK violation surfacing test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CLI behavior documentation to clarify daemon status checking and archive fallback functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->