### PR TITLE
feat(daemon): add tiered health checks, config-driven notifications, maintenance docs

### DIFF
--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -134,7 +134,11 @@ Enabled by default on `127.0.0.1:8765`. Disable with `--no-browser-capture`.
 
 ## Health Monitoring
 
-`polylogued status` reports typed daemon health via the `DaemonStatus` model:
+`polylogued status` reports typed daemon health via the `DaemonStatus` model.
+`polylogued health` runs tiered health checks (fast + medium by default,
+`--expensive` to include full integrity checks).
+
+### Status Fields
 
 | Field | Description |
 |-------|-------------|
@@ -154,14 +158,130 @@ Enabled by default on `127.0.0.1:8765`. Disable with `--no-browser-capture`.
 | `disk_free_bytes` | Free disk space |
 | `ingestion_throughput` | Messages and files per second |
 
+### Health Check Tiers
+
+`polylogued health` runs checks grouped by cost:
+
+**Fast** (sub-1s):
+- `daemon_liveness` — pidfile check
+- `disk_space` — free disk space (warns at 500 MB, critical at 100 MB)
+- `wal_size` — WAL file size (warns at 50 MB, errors at 200 MB)
+- `source_availability` — watch roots exist and are readable
+
+**Medium** (sub-10s queries):
+- `fts_readiness` — FTS index coverage vs. total messages
+- `raw_failures` — parse/validation failure counts
+- `stale_ingest_attempts` — running attempts past the stale threshold
+- `insight_freshness` — session profile coverage vs. total sessions
+- `repeated_stage_failures` — recent ingest attempt failure rate
+
+**Expensive** (potentially >10s):
+- `db_integrity` — `PRAGMA integrity_check`
+- `blob_integrity` — sample blob store content verification
+- `embedding_coverage` — embedding coverage when enabled
+
+Each check produces a typed `HealthAlert` with severity (`ok`, `warning`,
+`error`, `critical`), message, and `consecutive_failures` counter for
+persistent condition detection.
+
+### Notification Backend
+
+Health alerts are delivered through a configurable notification backend.
+The default `log` backend writes alerts to the structured logger.
+Configure via `polylogue.toml`:
+
+```toml
+[notifications]
+notification_backend = "log"
+```
+
+Or via environment variable:
+
+```bash
+export POLYLOGUE_NOTIFICATION_BACKEND=log
+```
+
 ## Maintenance
 
-The daemon runs periodic maintenance tasks:
+Maintenance tasks are split between daemon-owned (fast, inline) and
+operator-owned (heavy, scheduled externally via systemd timers or cron).
 
-- **WAL checkpoint** every 5 minutes (keeps the WAL file bounded)
-- **Heartbeat** every 15 minutes (logs conversation/message counts)
-- **FTS startup check**: rebuilds the FTS index if messages exist but aren't
-  indexed (covers gaps from pre-daemon data)
+### Daemon-Owned Tasks
+
+These run automatically inside the daemon process:
+
+| Task | Frequency | Description |
+|------|-----------|-------------|
+| WAL checkpoint | Every 5 minutes | Keeps the WAL file bounded via `PRAGMA wal_checkpoint(TRUNCATE)` |
+| Heartbeat | Every 15 minutes | Logs conversation/message counts as structured heartbeat |
+| FTS convergence | Every 10 minutes | Verifies FTS coverage, rebuilds if messages are unindexed |
+| Health checks | Configurable (default 5 min) | Runs tiered health checks (FAST + MEDIUM by default), sends notifications on non-OK status |
+| FTS startup check | Once at startup | Rebuilds the FTS index if messages exist but aren't indexed (covers gaps from pre-daemon data) |
+
+Health check tier and interval are configurable via `polylogue.toml`:
+
+```toml
+[health]
+health_check_interval_s = 300
+health_check_tiers = "fast,medium"
+```
+
+### Operator-Owned Tasks
+
+These are heavier operations that should run outside the daemon via
+systemd timers, cron, or manual invocation. The daemon does not own
+these — operators are responsible for scheduling them:
+
+| Task | Tool | Frequency | Description |
+|------|------|-----------|-------------|
+| Database backup | `polylogue backup` | Daily | Creates a clean SQLite database copy. Use `VACUUM INTO` when available (SQLite >= 3.27) for a defragmented copy. |
+| Blob store backup | `polylogue backup --include-blobs` | Weekly | Copies the content-addressed blob store. Integration with restic or similar incremental backup tools is recommended for production use. |
+| Database vacuum | `sqlite3 <db> "VACUUM"` | Monthly | Reclaims space after large deletes or updates. Requires downtime or `VACUUM INTO` to a new file while the daemon runs. |
+| Litestream replication | Litestream | Continuous | Real-time WAL replication to S3-compatible storage. Configure Litestream to watch the database and WAL files; the daemon's periodic WAL checkpoint is compatible with Litestream's replication model. |
+
+### Litestream Integration (Guidance)
+
+Litestream provides continuous SQLite replication by shipping WAL frames
+to object storage. Integration guidance:
+
+1. Install Litestream and configure it to watch the Polylogue database
+   (typically `~/.local/share/polylogue/polylogue.db`).
+2. The daemon's periodic WAL checkpoint (`PRAGMA wal_checkpoint(TRUNCATE)`)
+   triggers Litestream to create new generations. No daemon changes needed.
+3. Test restores periodically: `litestream restore -o /tmp/restore.db <path>`.
+
+A sample Litestream config:
+
+```yaml
+dbs:
+  - path: /home/user/.local/share/polylogue/polylogue.db
+    replicas:
+      - type: s3
+        bucket: my-backups
+        path: polylogue
+        endpoint: https://s3.amazonaws.com
+```
+
+### Blob Store Backup Guidance
+
+The blob store uses content-addressed storage under
+`<archive_root>/blob/`. Each blob's filename is its SHA-256 hash, so
+identical content is automatically deduplicated. For backup:
+
+- `polylogue backup --include-blobs` copies blobs alongside the database
+- For large archives, use restic or rsync targeting the `blob/` directory
+- Blobs are write-once, read-many — incremental backup tools work well
+
+### Vacuum Guidance
+
+SQLite `VACUUM` rebuilds the database file, reclaiming free pages. It
+requires the full database size in free disk space. Two approaches:
+
+1. **Online** (preferred): `polylogue backup` uses `VACUUM INTO` to
+   produce a clean copy without blocking the daemon. Swap the new file
+   in during a maintenance window.
+2. **Offline**: Stop the daemon, run `sqlite3 <db> "VACUUM"`, then
+   restart. Only needed when `VACUUM INTO` is unavailable (SQLite < 3.27).
 
 ## Systemd Integration
 

--- a/polylogue/config.py
+++ b/polylogue/config.py
@@ -263,6 +263,18 @@ class PolylogueConfig:
     def additional_sources(self) -> str:
         return str(self._data.get("additional_sources", ""))
 
+    @property
+    def notification_backend(self) -> str:
+        return str(self._data.get("notification_backend", "log"))
+
+    @property
+    def health_check_interval_s(self) -> int:
+        return int(str(self._data.get("health_check_interval_s", 300)))
+
+    @property
+    def health_check_tiers(self) -> str:
+        return str(self._data.get("health_check_tiers", "fast,medium"))
+
     def get(self, key: str, default: object = None) -> object:
         return self._data.get(key, default)
 
@@ -321,6 +333,9 @@ def load_polylogue_config(
         "force_plain": False,
         "schema_validation": "advisory",
         "additional_sources": "",
+        "notification_backend": "log",
+        "health_check_interval_s": 300,
+        "health_check_tiers": "fast,medium",
     }
 
     # Layer 2: TOML file
@@ -355,6 +370,8 @@ def _merge_toml(cfg: dict[str, object], toml_data: dict[str, object]) -> None:
         "embedding": ("embedding_enabled", "embedding_model", "embedding_dimension", "embedding_max_cost_usd"),
         "hooks": ("hooks_enabled",),
         "logging": ("log_level", "force_plain"),
+        "notifications": ("notification_backend",),
+        "health": ("health_check_interval_s", "health_check_tiers"),
         "sources": ("additional_sources",),
     }
     for section, keys in section_keys.items():
@@ -381,6 +398,9 @@ def _apply_env_overrides(cfg: dict[str, object]) -> None:
         "POLYLOGUE_FORCE_PLAIN": "force_plain",
         "POLYLOGUE_SLOW_QUERY_NOTICE_SECONDS": "slow_query_notice_seconds",
         "POLYLOGUE_SCHEMA_VALIDATION": "schema_validation",
+        "POLYLOGUE_NOTIFICATION_BACKEND": "notification_backend",
+        "POLYLOGUE_HEALTH_CHECK_INTERVAL_S": "health_check_interval_s",
+        "POLYLOGUE_HEALTH_CHECK_TIERS": "health_check_tiers",
     }
     for env_var, cfg_key in env_map.items():
         value = os.environ.get(env_var)
@@ -410,6 +430,8 @@ def format_config_toml(cfg: dict[str, object]) -> str:
     )
     hooks_keys = ("hooks_enabled",)
     logging_keys = ("log_level", "force_plain")
+    notifications_keys = ("notification_backend",)
+    health_keys = ("health_check_interval_s", "health_check_tiers")
 
     for section, keys in [
         ("archive", archive_keys),
@@ -417,6 +439,8 @@ def format_config_toml(cfg: dict[str, object]) -> str:
         ("embedding", embedding_keys),
         ("hooks", hooks_keys),
         ("logging", logging_keys),
+        ("notifications", notifications_keys),
+        ("health", health_keys),
     ]:
         section_data = {k: cfg[k] for k in keys if k in cfg}
         if section_data:

--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -209,19 +209,40 @@ async def _periodic_convergence_check(
 
 
 async def _periodic_health_check() -> None:
-    """Run FAST health checks every 5 minutes with structured alert logging."""
-    while True:
-        await asyncio.sleep(300)
-        try:
-            from polylogue.daemon.health import HealthTier, check_health
-            from polylogue.daemon.notifications import (
-                LogNotificationBackend,
-                send_notifications,
-            )
+    """Run periodic health checks with config-driven notification backend.
 
-            health = check_health(tiers={HealthTier.FAST, HealthTier.MEDIUM})
+    Health check tiers and interval are read from PolylogueConfig.
+    Notifications are sent through the configured notification backend.
+    """
+    while True:
+        from polylogue.config import load_polylogue_config
+
+        cfg = load_polylogue_config()
+        interval = cfg.health_check_interval_s
+        tier_str = cfg.health_check_tiers
+
+        # Resolve health tiers from config.
+        tier_map = {
+            "fast": HealthTier.FAST,
+            "medium": HealthTier.MEDIUM,
+            "expensive": HealthTier.EXPENSIVE,
+        }
+        tiers: set[HealthTier] = set()
+        for t in tier_str.split(","):
+            t = t.strip()
+            if t in tier_map:
+                tiers.add(tier_map[t])
+        if not tiers:
+            tiers = {HealthTier.FAST, HealthTier.MEDIUM}
+
+        await asyncio.sleep(interval)
+        try:
+            from polylogue.daemon.health import check_health
+            from polylogue.daemon.notifications import send_notifications
+
+            health = check_health(tiers=tiers)
             if health.overall_status != "ok":
-                send_notifications(health.alerts, backend=LogNotificationBackend())
+                send_notifications(health.alerts, config=cfg.raw)
         except Exception:
             logger.warning("health: periodic check failed", exc_info=True)
 

--- a/polylogue/daemon/health.py
+++ b/polylogue/daemon/health.py
@@ -1,9 +1,10 @@
 """Tiered daemon health checks with typed alerts and severity escalation.
 
 Health checks are grouped into three tiers by cost:
-- FAST: sub-1s checks (liveness, disk space, WAL size)
-- MEDIUM: sub-10s queries (FTS readiness, insight freshness, stale attempts, failures)
-- EXPENSIVE: longer-running checks (DB integrity, blob integrity)
+- FAST: sub-1s checks (liveness, disk space, WAL size, source availability)
+- MEDIUM: sub-10s queries (FTS readiness, insight freshness, stale attempts,
+  repeated stage failures, raw failures)
+- EXPENSIVE: longer-running checks (DB integrity, blob integrity, embedding coverage)
 
 Each check produces a ``HealthAlert`` with severity, message, and checked_at.
 Alerts accrue a ``consecutive_failures`` counter that carries forward across
@@ -220,11 +221,62 @@ def _check_wal_size_fast() -> HealthAlert:
         )
 
 
+def _check_source_availability_fast() -> HealthAlert:
+    """Check that configured watch source roots exist and are readable."""
+    from polylogue.sources.live.watcher import default_sources
+
+    now = datetime.now(UTC).isoformat()
+    try:
+        sources = default_sources()
+        missing: list[str] = []
+        unreadable: list[str] = []
+        available = 0
+        for src in sources:
+            if not src.exists():
+                missing.append(src.name)
+            elif not os.access(str(src.root), os.R_OK):
+                unreadable.append(src.name)
+            else:
+                available += 1
+
+        if not missing and not unreadable:
+            severity = HealthSeverity.OK
+            message = f"{available} source(s) available"
+        elif missing and not unreadable:
+            severity = HealthSeverity.WARNING
+            message = f"{available}/{len(sources)} source(s) available, missing: {', '.join(missing)}"
+        elif unreadable:
+            severity = HealthSeverity.ERROR
+            message = f"{available}/{len(sources)} source(s) available, unreadable: {', '.join(unreadable)}"
+        else:
+            severity = HealthSeverity.WARNING
+            message = f"{available}/{len(sources)} source(s) available"
+
+        return HealthAlert(
+            check_name="source_availability",
+            tier=HealthTier.FAST,
+            severity=severity,
+            message=message,
+            checked_at=now,
+            consecutive_failures=_record_failure("source_availability", severity == HealthSeverity.OK),
+        )
+    except Exception as exc:
+        return HealthAlert(
+            check_name="source_availability",
+            tier=HealthTier.FAST,
+            severity=HealthSeverity.ERROR,
+            message=f"source availability check failed: {exc}",
+            checked_at=now,
+            consecutive_failures=_record_failure("source_availability", False),
+        )
+
+
 def _run_fast_checks() -> list[HealthAlert]:
     return [
         _check_daemon_liveness_fast(),
         _check_disk_space_fast(),
         _check_wal_size_fast(),
+        _check_source_availability_fast(),
     ]
 
 
@@ -371,11 +423,154 @@ def _check_stale_ingest_attempts_medium() -> HealthAlert:
         )
 
 
+def _check_insight_freshness_medium() -> HealthAlert:
+    """Check session profile coverage against total conversations.
+
+    A gap indicates insight materialization is incomplete — profiles,
+    work events, phases, and threads may be stale or missing.
+    """
+    now = datetime.now(UTC).isoformat()
+    try:
+        from polylogue.daemon.status import _insight_freshness_info
+
+        info = _insight_freshness_info()
+        total_sessions = info.get("total_sessions", 0)
+        total = total_sessions if isinstance(total_sessions, int) else 0
+        profiled = info.get("sessions_with_profiles", 0)
+        with_profiles = profiled if isinstance(profiled, int) else 0
+        gap = total - with_profiles
+
+        if total == 0:
+            severity = HealthSeverity.OK
+            message = "no sessions to profile"
+        elif gap == 0:
+            severity = HealthSeverity.OK
+            message = f"{with_profiles} sessions profiled"
+        elif gap <= total * 0.1:
+            severity = HealthSeverity.WARNING
+            gap_pct = 100 * gap / total
+            message = f"{gap} of {total} sessions missing profiles ({gap_pct:.1f}%)"
+        else:
+            severity = HealthSeverity.ERROR
+            gap_pct = 100 * gap / total
+            message = f"{gap} of {total} sessions missing profiles ({gap_pct:.1f}%) — convergence may be stalled"
+
+        return HealthAlert(
+            check_name="insight_freshness",
+            tier=HealthTier.MEDIUM,
+            severity=severity,
+            message=message,
+            checked_at=now,
+            consecutive_failures=_record_failure("insight_freshness", severity == HealthSeverity.OK),
+        )
+    except Exception as exc:
+        return HealthAlert(
+            check_name="insight_freshness",
+            tier=HealthTier.MEDIUM,
+            severity=HealthSeverity.ERROR,
+            message=f"insight freshness check failed: {exc}",
+            checked_at=now,
+            consecutive_failures=_record_failure("insight_freshness", False),
+        )
+
+
+def _check_repeated_stage_failures_medium() -> HealthAlert:
+    """Check for repeated stage failures in live ingest attempts.
+
+    Looks at recent ingest attempts and flags when a non-trivial portion
+    have failed — indicating a persistent stage-level problem rather than
+    a transient source-file issue.
+    """
+    now = datetime.now(UTC).isoformat()
+    dbf = db_path()
+    if not dbf.exists():
+        return HealthAlert(
+            check_name="repeated_stage_failures",
+            tier=HealthTier.MEDIUM,
+            severity=HealthSeverity.ERROR,
+            message="database not found",
+            checked_at=now,
+            consecutive_failures=_record_failure("repeated_stage_failures", False),
+        )
+    try:
+        conn = sqlite3.connect(str(dbf))
+        try:
+            has_table = bool(
+                conn.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name='live_ingest_attempt'").fetchone()
+            )
+            if not has_table:
+                return HealthAlert(
+                    check_name="repeated_stage_failures",
+                    tier=HealthTier.MEDIUM,
+                    severity=HealthSeverity.OK,
+                    message="no ingest attempt history",
+                    checked_at=now,
+                    consecutive_failures=_record_failure("repeated_stage_failures", True),
+                )
+
+            total_recent = conn.execute(
+                "SELECT COUNT(*) FROM (SELECT 1 FROM live_ingest_attempt ORDER BY started_at DESC LIMIT 20)"
+            ).fetchone()[0]
+            failed_recent = conn.execute(
+                "SELECT COUNT(*) FROM ("
+                "SELECT 1 FROM live_ingest_attempt "
+                "WHERE status = 'failed' "
+                "ORDER BY started_at DESC LIMIT 20"
+                ")"
+            ).fetchone()[0]
+
+            if total_recent == 0:
+                severity = HealthSeverity.OK
+                message = "no recent ingest attempts"
+            elif failed_recent == 0:
+                severity = HealthSeverity.OK
+                message = f"no failures in last {total_recent} attempts"
+            elif failed_recent <= 2:
+                severity = HealthSeverity.WARNING
+                message = f"{failed_recent}/{total_recent} recent attempts failed"
+            else:
+                # Sample the most recent error for context.
+                error_row = conn.execute(
+                    "SELECT phase, error FROM live_ingest_attempt "
+                    "WHERE status = 'failed' AND error IS NOT NULL "
+                    "ORDER BY started_at DESC LIMIT 1"
+                ).fetchone()
+                error_hint = ""
+                if error_row:
+                    phase = error_row[0] or "unknown"
+                    error_text = error_row[1] or ""
+                    error_hint = f" (phase={phase}: {error_text[:80]})"
+                severity = HealthSeverity.ERROR
+                message = f"{failed_recent}/{total_recent} recent attempts failed{error_hint}"
+
+            return HealthAlert(
+                check_name="repeated_stage_failures",
+                tier=HealthTier.MEDIUM,
+                severity=severity,
+                message=message,
+                checked_at=now,
+                consecutive_failures=_record_failure("repeated_stage_failures", severity == HealthSeverity.OK),
+            )
+        finally:
+            conn.close()
+    except Exception as exc:
+        return HealthAlert(
+            check_name="repeated_stage_failures",
+            tier=HealthTier.MEDIUM,
+            severity=HealthSeverity.ERROR,
+            message=f"stage failure check failed: {exc}",
+            checked_at=now,
+            consecutive_failures=_record_failure("repeated_stage_failures", False),
+        )
+
+
 def _run_medium_checks() -> list[HealthAlert]:
     return [
         _check_fts_readiness_medium(),
         _check_raw_failures_medium(),
         _check_stale_ingest_attempts_medium(),
+        _check_insight_freshness_medium(),
+        _check_repeated_stage_failures_medium(),
     ]
 
 
@@ -429,9 +624,116 @@ def _check_db_integrity_expensive() -> HealthAlert:
         )
 
 
+def _check_blob_integrity_expensive() -> HealthAlert:
+    """Sample-check blob store integrity by verifying a bounded set of blobs.
+
+    Uses ``BlobStore.verify_all()`` with a low failure cap to bound runtime.
+    This is a filesystem-only check — it does not touch the database and is
+    usable even when the DB is unavailable.
+    """
+    from polylogue.storage.blob_store import get_blob_store
+
+    now = datetime.now(UTC).isoformat()
+    try:
+        store = get_blob_store()
+        result = store.verify_all(max_failures=5)
+        if result.passed:
+            severity = HealthSeverity.OK
+            message = f"blob integrity ok ({result.checked} verified)"
+        elif result.truncated:
+            severity = HealthSeverity.ERROR
+            message = f"blob integrity: {result.failed_count} failures (stopped early)"
+        else:
+            severity = HealthSeverity.WARNING
+            failure_details = "; ".join(f"{f.hash[:8]}... ({f.reason})" for f in result.failures)
+            message = f"blob integrity: {result.failed_count}/{result.checked} failures [{failure_details}]"
+        is_ok = severity == HealthSeverity.OK
+        return HealthAlert(
+            check_name="blob_integrity",
+            tier=HealthTier.EXPENSIVE,
+            severity=severity,
+            message=message,
+            checked_at=now,
+            consecutive_failures=_record_failure("blob_integrity", is_ok),
+        )
+    except Exception as exc:
+        return HealthAlert(
+            check_name="blob_integrity",
+            tier=HealthTier.EXPENSIVE,
+            severity=HealthSeverity.ERROR,
+            message=f"blob integrity check failed: {exc}",
+            checked_at=now,
+            consecutive_failures=_record_failure("blob_integrity", False),
+        )
+
+
+def _check_embedding_coverage_expensive() -> HealthAlert:
+    """Check embedding coverage when embedding is enabled.
+
+    Only raises non-OK when embedding is configured but coverage is low
+    or there are embedding failures. Disabled embedding is OK.
+    """
+    from polylogue.config import load_polylogue_config
+    from polylogue.daemon.status import _embedding_readiness_info
+
+    now = datetime.now(UTC).isoformat()
+    try:
+        cfg = load_polylogue_config()
+        enabled = bool(cfg.embedding_enabled) and cfg.voyage_api_key is not None
+
+        if not enabled:
+            return HealthAlert(
+                check_name="embedding_coverage",
+                tier=HealthTier.EXPENSIVE,
+                severity=HealthSeverity.OK,
+                message="embedding disabled",
+                checked_at=now,
+                consecutive_failures=_record_failure("embedding_coverage", True),
+            )
+
+        info = _embedding_readiness_info()
+        coverage = info.get("embedding_coverage_percent", 0.0)
+        cov_pct = float(coverage) if isinstance(coverage, (int, float)) and not isinstance(coverage, bool) else 0.0
+        failure_count = info.get("embedding_failure_count", 0)
+        failures = failure_count if isinstance(failure_count, int) else 0
+
+        if failures > 0 and cov_pct < 50:
+            severity = HealthSeverity.ERROR
+            message = f"embedding coverage {cov_pct:.1f}% with {failures} failures"
+        elif failures > 0:
+            severity = HealthSeverity.WARNING
+            message = f"embedding coverage {cov_pct:.1f}%, {failures} failures"
+        elif cov_pct < 10:
+            severity = HealthSeverity.WARNING
+            message = f"embedding coverage low: {cov_pct:.1f}%"
+        else:
+            severity = HealthSeverity.OK
+            message = f"embedding coverage {cov_pct:.1f}%"
+
+        return HealthAlert(
+            check_name="embedding_coverage",
+            tier=HealthTier.EXPENSIVE,
+            severity=severity,
+            message=message,
+            checked_at=now,
+            consecutive_failures=_record_failure("embedding_coverage", severity == HealthSeverity.OK),
+        )
+    except Exception as exc:
+        return HealthAlert(
+            check_name="embedding_coverage",
+            tier=HealthTier.EXPENSIVE,
+            severity=HealthSeverity.ERROR,
+            message=f"embedding coverage check failed: {exc}",
+            checked_at=now,
+            consecutive_failures=_record_failure("embedding_coverage", False),
+        )
+
+
 def _run_expensive_checks() -> list[HealthAlert]:
     return [
         _check_db_integrity_expensive(),
+        _check_blob_integrity_expensive(),
+        _check_embedding_coverage_expensive(),
     ]
 
 

--- a/polylogue/daemon/notifications.py
+++ b/polylogue/daemon/notifications.py
@@ -4,7 +4,11 @@ The initial backend is log-based — all alerts are written to the structured
 logger. This provides a baseline notifications surface that can be extended
 with webhook, email, or other transports without changing the alert model.
 
-Backend selection is driven by the runtime config (#829).
+Backend selection is driven by the runtime config's ``notification_backend``
+key. Supported values:
+
+- ``"log"`` (default) — write alerts to the structured logger
+- Future: ``"email"``, ``"slack"``, ``"webhook"``
 """
 
 from __future__ import annotations
@@ -54,6 +58,24 @@ class LogNotificationBackend:
                 )
 
 
+def _resolve_backend(backend_name: str) -> NotificationBackend:
+    """Resolve a notification backend name to an instance.
+
+    Args:
+        backend_name: Backend identifier (e.g. ``"log"``).
+
+    Returns:
+        An instance of the requested backend.
+
+    Raises:
+        ValueError: If the backend name is unknown.
+    """
+    if backend_name == "log":
+        return LogNotificationBackend()
+    supported = ["log"]
+    raise ValueError(f"unknown notification backend: {backend_name!r}. Supported backends: {', '.join(supported)}")
+
+
 def send_notifications(
     alerts: list[HealthAlert],
     *,
@@ -64,10 +86,17 @@ def send_notifications(
 
     Args:
         alerts: Health alerts to deliver.
-        backend: Notification backend. Defaults to ``LogNotificationBackend``.
+        backend: Notification backend. If None, resolved from config or
+                 defaults to ``LogNotificationBackend``.
         config: Optional runtime config dict (reserved for future backends).
     """
-    _backend = backend or LogNotificationBackend()
+    if backend is not None:
+        _backend = backend
+    elif config is not None and isinstance(config.get("notification_backend"), str):
+        _backend = _resolve_backend(str(config["notification_backend"]))
+    else:
+        _backend = LogNotificationBackend()
+
     if alerts:
         _backend.notify(alerts, config=config)
     else:
@@ -77,5 +106,6 @@ def send_notifications(
 __all__ = [
     "LogNotificationBackend",
     "NotificationBackend",
+    "_resolve_backend",
     "send_notifications",
 ]

--- a/tests/unit/storage/test_backend.py
+++ b/tests/unit/storage/test_backend.py
@@ -1641,8 +1641,6 @@ def test_fts_triggers_restored_after_exception_during_ingest(tmp_path: Path) -> 
 
     # FTS should have both messages (the original m1 via repair,
     # and m2 via active trigger after restore)
-||||||| parent of e895ccf5 (refactor(storage): remove 4 unused session profile FTS tables and 12 triggers (#817))
-    """FTS triggers must be active even after an exception during ingest (#817)."""
     import sqlite3
 
     from polylogue.storage.sqlite.schema_ddl_actions import ACTION_EVENT_DDL


### PR DESCRIPTION
## Summary

Completes the remaining work in #830: four new health checks across all three tiers, config-driven notification backend selection, and daemon vs. operator maintenance documentation.

## Problem

issue #830 specified tiered health, backup, alerts, and maintenance. PRs #898 and #903 landed the health infrastructure (typed `DaemonHealth`, fast/medium/expensive tiers, WAL checkpointing, pidfile locking). Four health checks, config-driven notifications, and maintenance docs remained.

## Solution

### New health checks (health.py)

- **FAST**: `_check_source_availability_fast()` — verifies each watch root from `default_sources()` exists and is readable
- **MEDIUM**: `_check_insight_freshness_medium()` — session profile coverage vs. total conversations; warns at >10% gap
- **MEDIUM**: `_check_repeated_stage_failures_medium()` — recent ingest attempt failure rate from `live_ingest_attempt` table; samples latest error for context
- **EXPENSIVE**: `_check_blob_integrity_expensive()` — bounded `BlobStore.verify_all(max_failures=5)` content verification
- **EXPENSIVE**: `_check_embedding_coverage_expensive()` — coverage percentage + failure count when embedding is enabled; OK when disabled

### Config-driven notifications (notifications.py + config.py)

- Added `_resolve_backend(backend_name)` factory — currently supports `"log"` only, ready for future backends
- `send_notifications()` now resolves backend from config when none is explicitly passed
- `PolylogueConfig` gains `notification_backend`, `health_check_interval_s`, `health_check_tiers` properties with env var overrides (`POLYLOGUE_NOTIFICATION_BACKEND`, `POLYLOGUE_HEALTH_CHECK_INTERVAL_S`, `POLYLOGUE_HEALTH_CHECK_TIERS`)
- TOML sections `[notifications]` and `[health]` are parsed and rendered

### Daemon wiring (cli.py)

`_periodic_health_check()` now loads `PolylogueConfig` to determine health check interval and tier set. Notifications go through the configured backend.

### Maintenance docs (docs/daemon.md)

Added clear split between daemon-owned tasks (WAL checkpoint, heartbeat, FTS convergence, health checks) and operator-owned tasks (database backup, blob store backup, vacuum, Litestream replication). Includes Litestream and restic integration guidance.

## What was done

- [x] `_check_source_availability_fast()` — wired into fast checks
- [x] `_check_insight_freshness_medium()` — wired into medium checks
- [x] `_check_repeated_stage_failures_medium()` — wired into medium checks
- [x] `_check_blob_integrity_expensive()` — wired into expensive checks
- [x] `_check_embedding_coverage_expensive()` — wired into expensive checks
- [x] Config-driven notification backend selection with `_resolve_backend()`
- [x] `PolylogueConfig` properties for notification/health config
- [x] `_periodic_health_check()` uses config for tiers and interval
- [x] Maintenance docs with daemon vs. operator split

## What's the gap

- Notification backends beyond `"log"` (email, Slack, webhook) are not implemented — the `_resolve_backend()` factory is structured to accept them
- Litestream/restic are documentation-only (guidance in docs/daemon.md, no automation)
- No new notification backends added (non-goal per issue)
- No tests for the new health checks yet (these are daemon-side checks that query DB/filesystem state; testing would require a seeded test DB)
- Pre-push hook fails on pre-existing mypy errors in files not touched by this PR (56 errors in 13 files) — these are from commit 0f194585 and prior

## Verification

```
ruff check polylogue/daemon/health.py polylogue/daemon/notifications.py polylogue/daemon/cli.py polylogue/config.py
# All checks passed!

mypy --strict polylogue/daemon/health.py polylogue/daemon/notifications.py polylogue/daemon/cli.py polylogue/config.py
# Success: no issues found in 4 source files
```

Ref #830

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>