### PR TITLE
fix(schemas): exempt message_role fields from privacy threshold, wire detect_drift into audit (#800)

### DIFF
--- a/devtools/schema_audit.py
+++ b/devtools/schema_audit.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 
 from polylogue.cli.shared.schema_rendering import render_schema_audit_result
+from polylogue.config import get_config
 from polylogue.schemas.operator.models import SchemaAuditRequest
 from polylogue.schemas.operator.workflow import audit_schemas
 
@@ -13,13 +14,25 @@ def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Run quality checks on committed schema packages.")
     parser.add_argument("--provider", default=None, help="Audit a specific provider. Defaults to all providers.")
     parser.add_argument("--json", action="store_true", help="Output as JSON.")
+    parser.add_argument(
+        "--check-drift",
+        action="store_true",
+        help="Query live archive data and run detect_drift() against committed schemas.",
+    )
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = _build_parser()
     args = parser.parse_args(argv)
-    report = audit_schemas(SchemaAuditRequest(provider=args.provider))
+    db_path = get_config().db_path if args.check_drift else None
+    report = audit_schemas(
+        SchemaAuditRequest(
+            provider=args.provider,
+            check_drift=bool(args.check_drift),
+            db_path=db_path,
+        )
+    )
     render_schema_audit_result(report=report, json_output=bool(args.json))
     return 0 if report.all_passed else 1
 

--- a/polylogue/schemas/audit/checks.py
+++ b/polylogue/schemas/audit/checks.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from pathlib import Path
 
 from polylogue.core.json import json_document, json_document_list
 from polylogue.core.outcomes import OutcomeCheck as CheckResult
@@ -221,11 +222,79 @@ def check_schema_staleness(schema: Mapping[str, object] | SchemaNode) -> CheckRe
     )
 
 
+def check_schema_drift(
+    schema: Mapping[str, object] | SchemaNode,
+    *,
+    db_path: Path | None = None,
+    provider: str = "",
+    max_samples: int = 50,
+) -> CheckResult:
+    """Check whether committed schema has drifted from live archive data.
+
+    Loads samples from the database and runs detect_drift() against the
+    committed schema.  Reports fields present in live data but missing from
+    the schema.
+    """
+    from polylogue.core.json import json_document
+    from polylogue.schemas.sampling import load_samples_from_db
+    from polylogue.schemas.validator import detect_drift
+
+    if db_path is None or not Path(db_path).exists():
+        return CheckResult(
+            name="schema_drift",
+            status=OutcomeStatus.SKIP,
+            summary="No database available for drift detection",
+        )
+
+    try:
+        samples = load_samples_from_db(provider, db_path=Path(db_path), max_samples=max_samples)
+    except Exception as exc:
+        return CheckResult(
+            name="schema_drift",
+            status=OutcomeStatus.WARNING,
+            summary=f"Failed to load samples for drift detection: {exc}",
+        )
+
+    if not samples:
+        return CheckResult(
+            name="schema_drift",
+            status=OutcomeStatus.SKIP,
+            summary="No samples available for drift detection",
+        )
+
+    root = json_document(schema)
+    all_drift: list[str] = []
+    seen: set[str] = set()
+    for sample in samples:
+        for warning in detect_drift(sample, root, ""):
+            if warning not in seen:
+                seen.add(warning)
+                all_drift.append(warning)
+
+    if not all_drift:
+        return CheckResult(
+            name="schema_drift",
+            status=OutcomeStatus.OK,
+            summary=f"No drift detected across {len(samples)} sample(s)",
+            count=len(samples),
+        )
+
+    unique_drift = list(dict.fromkeys(all_drift))
+    return CheckResult(
+        name="schema_drift",
+        status=OutcomeStatus.WARNING,
+        summary=f"Schema drift detected: {len(unique_drift)} unexpected field(s) in live data",
+        details=unique_drift[:50],
+        count=len(samples),
+    )
+
+
 __all__ = [
     "CheckResult",
     "check_annotation_coverage",
     "check_cross_provider_consistency",
     "check_privacy_guards",
+    "check_schema_drift",
     "check_schema_staleness",
     "check_semantic_roles",
 ]

--- a/polylogue/schemas/audit/workflow.py
+++ b/polylogue/schemas/audit/workflow.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from polylogue.core.outcomes import OutcomeCheck as CheckResult
 from polylogue.core.outcomes import OutcomeStatus
 from polylogue.schemas.audit.checks import (
     check_annotation_coverage,
     check_cross_provider_consistency,
     check_privacy_guards,
+    check_schema_drift,
     check_schema_staleness,
     check_semantic_roles,
 )
@@ -27,7 +30,7 @@ def _scoped(provider: str, check: CheckResult) -> AuditCheck:
     )
 
 
-def audit_provider(provider: str) -> AuditReport:
+def audit_provider(provider: str, *, db_path: Path | None = None) -> AuditReport:
     """Run all audit checks on a single provider's committed schema."""
     report = AuditReport(provider=provider)
 
@@ -56,10 +59,22 @@ def audit_provider(provider: str) -> AuditReport:
     report.checks.append(_scoped(provider, check_annotation_coverage(schema)))
     report.checks.append(_scoped(provider, check_schema_staleness(schema)))
 
+    if db_path is not None:
+        report.checks.append(
+            _scoped(
+                provider,
+                check_schema_drift(schema, db_path=db_path, provider=provider),
+            )
+        )
+
     return report
 
 
-def audit_all_providers(providers: list[str] | None = None) -> AuditReport:
+def audit_all_providers(
+    providers: list[str] | None = None,
+    *,
+    db_path: Path | None = None,
+) -> AuditReport:
     """Run audit checks across all (or specified) providers."""
     from polylogue.schemas.observation import PROVIDERS
 
@@ -68,7 +83,7 @@ def audit_all_providers(providers: list[str] | None = None) -> AuditReport:
 
     schemas = {}
     for provider in provider_list:
-        provider_report = audit_provider(provider)
+        provider_report = audit_provider(provider, db_path=db_path)
         report.checks.extend(provider_report.checks)
         schema = _load_committed_schema(provider)
         if schema:

--- a/polylogue/schemas/generation/field_annotations.py
+++ b/polylogue/schemas/generation/field_annotations.py
@@ -18,6 +18,12 @@ _ENUM_OUTPUT_CAP = 20
 _ENUM_MIN_COUNT = 2
 _ENUM_MIN_FREQ = 0.03
 
+# Semantic roles whose enum values are structural identifiers
+# (e.g. record types, message roles).  These fields bypass the
+# cross-conversation privacy threshold because their values are
+# protocol-level tokens, not user content.
+_STRUCTURAL_ROLE_VALUES = frozenset({"message_role"})
+
 
 def _enum_values(
     field_stats: FieldStats,
@@ -104,10 +110,17 @@ def annotate_schema(
             and fmt not in id_formats
             and not _is_content_field(path)
         ):
+            # Structural fields (e.g. message_role) bypass the
+            # cross-conversation privacy threshold — their values
+            # are protocol-level tokens, not user content.
+            sem_role = schema_node.get("x-polylogue-semantic-role")
+            effective_min_conv = (
+                1 if isinstance(sem_role, str) and sem_role in _STRUCTURAL_ROLE_VALUES else min_conversation_count
+            )
             enum_values = _enum_values(
                 field_stats,
                 path=path,
-                min_conversation_count=min_conversation_count,
+                min_conversation_count=effective_min_conv,
                 privacy_config=privacy_config,
             )
             if enum_values:

--- a/polylogue/schemas/operator/inference.py
+++ b/polylogue/schemas/operator/inference.py
@@ -321,7 +321,10 @@ def promote_schema_cluster(request: SchemaPromoteRequest) -> SchemaPromoteResult
 def audit_schemas(request: SchemaAuditRequest) -> AuditReport:
     from polylogue.schemas.audit.workflow import audit_all_providers, audit_provider
 
-    return audit_provider(request.provider) if request.provider else audit_all_providers()
+    db_path = request.db_path if request.check_drift else None
+    if request.provider:
+        return audit_provider(request.provider, db_path=db_path)
+    return audit_all_providers(db_path=db_path)
 
 
 __all__ = [

--- a/polylogue/schemas/operator/models.py
+++ b/polylogue/schemas/operator/models.py
@@ -309,6 +309,8 @@ class SchemaExplainResult:
 @dataclass(frozen=True)
 class SchemaAuditRequest:
     provider: str | None = None
+    check_drift: bool = False
+    db_path: Path | None = None
 
 
 @dataclass(frozen=True)

--- a/tests/unit/core/test_schema_privacy.py
+++ b/tests/unit/core/test_schema_privacy.py
@@ -419,6 +419,65 @@ class TestStructuralConstantsInIdentifierFields:
 
 
 # =============================================================================
+# Guard 4: Structural role exemption -- message_role bypasses
+#          cross-conversation threshold
+# =============================================================================
+
+
+class TestStructuralRoleExemption:
+    """message_role fields bypass cross-conversation privacy threshold."""
+
+    def test_message_role_bypasses_threshold(self) -> None:
+        """A message_role field includes values from <3 conversations."""
+        values_by_conv = {
+            "conv_A": ["attachment"],
+            "conv_B": ["assistant"],
+            "conv_C": ["assistant"],
+            "conv_D": ["user", "assistant"],
+            "conv_E": ["user"],
+        }
+        flat_samples = [{"type": v} for vals in values_by_conv.values() for v in vals]
+        flat_conv_ids: list[str | None] = [cid for cid, vals in values_by_conv.items() for _ in vals]
+        stats = _collect_field_stats(flat_samples, conversation_ids=flat_conv_ids)
+        schema: dict[str, object] = {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "x-polylogue-semantic-role": "message_role",
+                }
+            },
+        }
+        annotated = _annotate_schema(schema, stats, min_conversation_count=3)
+        type_schema = schema_property(annotated, "type")
+        enum_vals = schema_values(type_schema)
+        assert "attachment" in enum_vals, "message_role field should preserve values even when min_conversation_count=3"
+        assert "assistant" in enum_vals
+        assert "user" in enum_vals
+
+    def test_non_role_field_respects_threshold(self) -> None:
+        """A field without message_role still respects the threshold."""
+        values_by_conv = {
+            "conv_A": ["rare_val"],
+            "conv_B": ["common"],
+            "conv_C": ["common"],
+            "conv_D": ["common"],
+        }
+        flat_samples = [{"status": v} for vals in values_by_conv.values() for v in vals]
+        flat_conv_ids: list[str | None] = [cid for cid, vals in values_by_conv.items() for _ in vals]
+        stats = _collect_field_stats(flat_samples, conversation_ids=flat_conv_ids)
+        schema = {
+            "type": "object",
+            "properties": {"status": {"type": "string"}},
+        }
+        annotated = _annotate_schema(schema, stats, min_conversation_count=3)
+        status_schema = schema_property(annotated, "status")
+        enum_vals = schema_values(status_schema)
+        assert "rare_val" not in enum_vals, "Non-role field should respect min_conversation_count=3"
+        assert "common" in enum_vals
+
+
+# =============================================================================
 # Guard 5: Property test — safe values never resemble PII (Phase 9)
 # =============================================================================
 


### PR DESCRIPTION

## Summary

Three targeted fixes building on PR #887 (pipeline reordering):

1. **message_role fields exempt from privacy threshold**: When a field has
   `x-polylogue-semantic-role="message_role"`, the cross-conversation privacy
   threshold (`min_conversation_count=3`) is bypassed (uses `min=1`). This
   preserves protocol-level record type tokens that were being suppressed.

2. **`detect_drift()` wired into `devtools schema-audit --check-drift`**: New
   `check_schema_drift()` audit check loads samples from the archive DB and runs
   `detect_drift()` against committed schemas.

3. **Tests**: `TestStructuralRoleExemption` verifies that `message_role` values
   survive `min_conversation_count=3` while non-role fields are correctly filtered.

## Problem

The #800 audit found that Claude Code record type values were suppressed from
committed schemas because the privacy threshold treated structural protocol-level
tokens identically to user content. `detect_drift()` existed but was never called
by any audit tool.

## Solution

7 files changed:
- `field_annotations.py`: `_STRUCTURAL_ROLE_VALUES` + `effective_min_conv` logic
- `checks.py`: New `check_schema_drift()` function (78 lines)
- `workflow.py`: `db_path` parameter threaded through audit flow
- `models.py`: `check_drift` + `db_path` fields on `SchemaAuditRequest`
- `inference.py`: Wires `db_path` through `audit_schemas()`
- `schema_audit.py`: `--check-drift` flag
- `test_schema_privacy.py`: `TestStructuralRoleExemption` (2 tests)

## Verification

```bash
pytest tests/unit/core/test_schema_privacy.py -x -q     # 102 passed
ruff check <touched files>                              # All checks passed
mypy --strict <touched files>                           # Success: no issues found
devtools schema-audit --provider claude-code --check-drift  # PASS
```

## What's the gap

- **Schema regeneration from live data** blocked by pre-existing blob store issues (#818).
- **schema-promote end-to-end** not completed due to same blob store issue.
- **Codex parser coverage** deferred to separate issue per #800 scope.
