### PR TITLE
refactor(surfaces): route TUI, API, CLI completions through ArchiveOperations (#860)

### DIFF
--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -143,6 +143,14 @@ if TYPE_CHECKING:
 
         async def get_conversation_stats(self, conversation_id: str) -> dict[str, int]: ...
 
+        async def get_raw_artifacts_for_conversation(
+            self,
+            conversation_id: str,
+            *,
+            limit: int = 50,
+            offset: int = 0,
+        ) -> tuple[list[object], int]: ...
+
 
 class ConversationNotFoundError(PolylogueError):
     """Raised when a requested conversation does not exist in the archive."""
@@ -311,31 +319,32 @@ class PolylogueArchiveMixin:
         limit: int = 50,
         offset: int = 0,
     ) -> tuple[list[dict[str, object]], int]:
-        """Return paginated raw archive artifact rows for a conversation."""
-        from polylogue.storage.sqlite.queries.raw import get_raw_records_for_conversation as _raw_query
+        """Return paginated raw archive artifact rows for a conversation.
 
-        summary = await self.operations.get_conversation_summary(conversation_id)
-        if summary is None:
-            return [], 0
-        full_id = str(summary.id)
-
-        async with self.repository._backend.connection() as conn:
-            records, total = await _raw_query(conn, full_id, limit=limit, offset=offset)
-            result = []
-            for r in records:
-                result.append(
-                    {
-                        "raw_id": getattr(r, "raw_id", ""),
-                        "provider_name": getattr(r, "provider_name", ""),
-                        "source_path": getattr(r, "source_path", ""),
-                        "source_name": getattr(r, "source_name", None),
-                        "blob_size": getattr(r, "blob_size", 0),
-                        "acquired_at": getattr(r, "acquired_at", None),
-                        "parsed_at": getattr(r, "parsed_at", None),
-                        "validation_status": getattr(r, "validation_status", None),
-                    }
-                )
-            return result, total
+        Delegates to
+        ``ArchiveOperations.get_raw_artifacts_for_conversation()``
+        rather than accessing the private ``_backend`` connection directly.
+        """
+        records, total = await self.operations.get_raw_artifacts_for_conversation(
+            conversation_id,
+            limit=limit,
+            offset=offset,
+        )
+        result: list[dict[str, object]] = []
+        for r in records:
+            result.append(
+                {
+                    "raw_id": getattr(r, "raw_id", ""),
+                    "provider_name": getattr(r, "provider_name", ""),
+                    "source_path": getattr(r, "source_path", ""),
+                    "source_name": getattr(r, "source_name", None),
+                    "blob_size": getattr(r, "blob_size", 0),
+                    "acquired_at": getattr(r, "acquired_at", None),
+                    "parsed_at": getattr(r, "parsed_at", None),
+                    "validation_status": getattr(r, "validation_status", None),
+                }
+            )
+        return result, total
 
     async def query_conversations(
         self,

--- a/polylogue/cli/commands/dashboard.py
+++ b/polylogue/cli/commands/dashboard.py
@@ -13,7 +13,7 @@ def dashboard_command(env: AppEnv) -> None:
     """Launch the dashboard TUI."""
     from polylogue.ui.tui.app import PolylogueApp
 
-    app = PolylogueApp(repository=env.repository)
+    app = PolylogueApp(operations=env.operations)
     app.run()
 
 

--- a/polylogue/cli/shell_completion_values.py
+++ b/polylogue/cli/shell_completion_values.py
@@ -1,9 +1,17 @@
-"""Shell-completion helpers for archive-backed CLI values."""
+"""Shell-completion helpers for archive-backed CLI values.
+
+Conversation ID and tag completions route through
+``ArchiveOperations`` (async, bridged via ``asyncio.run``).
+Repo, CWD-prefix, and tool-name completions still use raw SQL on
+``session_profiles`` / ``action_events`` \u2014 those tables lack
+ArchiveOperations read methods (follow-up in #862 or a successor).
+"""
 
 from __future__ import annotations
 
+import asyncio
 import sqlite3
-from collections.abc import Callable, Mapping
+from collections.abc import Awaitable, Callable, Mapping
 from typing import Final
 
 import click
@@ -12,8 +20,11 @@ from click.shell_completion import CompletionItem
 from polylogue.archive.message.types import MessageType
 from polylogue.archive.query.fields import CompletionSource
 from polylogue.archive.query.spec import QUERY_ACTION_TYPES, QUERY_RETRIEVAL_LANES, QUERY_SEQUENCE_ACTION_TYPES
+from polylogue.operations.archive import ArchiveOperations as _ArchiveOperations
 from polylogue.paths import db_path
 from polylogue.storage.sqlite.connection import open_read_connection
+
+Callback = Callable[[_ArchiveOperations], Awaitable[list[CompletionItem]]]
 
 _PROVIDER_DESCRIPTIONS: Final[dict[str, str]] = {
     "chatgpt": "OpenAI ChatGPT exports",
@@ -61,6 +72,29 @@ def _fetch_rows(sql: str, params: tuple[object, ...]) -> list[sqlite3.Row]:
         return []
 
 
+async def _with_operations(
+    action: Callback,
+) -> list[CompletionItem]:
+    """Create ArchiveOperations, run *action*, and close services."""
+    from polylogue.operations.archive import ArchiveOperations
+    from polylogue.services import build_runtime_services
+
+    services = build_runtime_services()
+    try:
+        operations = ArchiveOperations.from_services(services)
+        return await action(operations)
+    finally:
+        await services.close()
+
+
+def _run_completion(action: Callback) -> list[CompletionItem]:
+    """Bridge an async completion action into the synchronous Click callback world."""
+    try:
+        return list(asyncio.run(_with_operations(action)))
+    except Exception:
+        return []
+
+
 def _rows_to_completion_items(
     rows: list[sqlite3.Row],
     *,
@@ -78,7 +112,7 @@ def _trim_help(value: str, *, limit: int = 72) -> str:
     cleaned = " ".join(value.split())
     if len(cleaned) <= limit:
         return cleaned
-    return cleaned[: limit - 1] + "…"
+    return cleaned[: limit - 1] + chr(0x2026)
 
 
 def _static_completion_items(
@@ -153,42 +187,32 @@ def complete_conversation_ids(
     del ctx, param
     current = incomplete.strip()
     current_lower = current.lower()
-    rows = _fetch_rows(
-        """
-        SELECT
-            conversation_id,
-            provider_name,
-            COALESCE(
-                NULLIF(json_extract(metadata, '$.title'), ''),
-                NULLIF(title, ''),
-                conversation_id
-            ) AS display_title
-        FROM conversations
-        WHERE (
-            ? = ''
-            OR conversation_id LIKE ?
-            OR conversation_id LIKE ?
-            OR LOWER(COALESCE(json_extract(metadata, '$.title'), title, '')) LIKE ?
-        )
-        ORDER BY sort_key DESC, conversation_id ASC
-        LIMIT ?
-        """,
-        (
-            current,
-            f"{current}%",
-            f"%:{current}%",
-            f"%{current_lower}%",
-            _MAX_ID_COMPLETIONS,
-        ),
-    )
-    return _rows_to_completion_items(
-        rows,
-        value_column="conversation_id",
-        help_builder=lambda row: (
-            f"{str(row['provider_name'] or 'unknown')} · "
-            f"{_trim_help(str(row['display_title'] or row['conversation_id']))}"
-        ),
-    )
+
+    if not _db_exists():
+        return []
+
+    async def _query(ops: _ArchiveOperations) -> list[CompletionItem]:
+        conversations = await ops.list_conversations(limit=100)
+        items: list[CompletionItem] = []
+        for conv in conversations:
+            cid = str(conv.id)
+            title = conv.title or ""
+            provider_name = str(conv.provider)
+            display = title or cid
+            if current and not (
+                cid.startswith(current) or (":" in cid and current in cid) or (title and current_lower in title.lower())
+            ):
+                continue
+            items.append(
+                CompletionItem(
+                    cid,
+                    help=f"{provider_name} \u00b7 {_trim_help(display)}",
+                )
+            )
+        items.sort(key=lambda item: item.value)
+        return items[:_MAX_ID_COMPLETIONS]
+
+    return _run_completion(_query)
 
 
 def complete_open_targets(
@@ -206,54 +230,24 @@ def complete_tag_values(
 ) -> list[CompletionItem]:
     del ctx, param
     prefix, current = _split_csv_incomplete(incomplete)
-    rows = _fetch_rows(
-        """
-        SELECT t.name AS tag_name, COUNT(DISTINCT ct.conversation_id) AS cnt
-        FROM conversation_tags ct
-        JOIN tags t ON t.id = ct.tag_id
-        WHERE (? = '' OR t.name LIKE ?)
-        GROUP BY t.name
-        ORDER BY cnt DESC, t.name ASC
-        LIMIT ?
-        """,
-        (
-            current,
-            f"{current}%",
-            _MAX_VALUE_COMPLETIONS,
-        ),
-    )
-    if rows:
-        items = _rows_to_completion_items(
-            rows,
-            value_column="tag_name",
-            help_builder=lambda row: f"{int(row['cnt'])} conversations",
-        )
-        return _with_csv_prefix(items, prefix)
+    current_lower = current.lower()
 
-    # Fallback to JSON metadata for pre-migration archives
-    rows = _fetch_rows(
-        """
-        SELECT
-            t.name AS tag_name,
-            COUNT(*) AS cnt
-        FROM conversation_tags ct
-        JOIN tags t ON t.id = ct.tag_id
-        WHERE (? = '' OR t.name LIKE ?)
-        GROUP BY t.name
-        ORDER BY cnt DESC, t.name ASC
-        LIMIT ?
-        """,
-        (
-            current,
-            f"{current}%",
-            _MAX_VALUE_COMPLETIONS,
-        ),
-    )
-    items = _rows_to_completion_items(
-        rows,
-        value_column="tag_name",
-        help_builder=lambda row: f"{int(row['cnt'])} conversations",
-    )
+    if not _db_exists():
+        return []
+
+    async def _query(ops: _ArchiveOperations) -> list[CompletionItem]:
+        tags = await ops.list_tags()
+        sorted_tags = sorted(tags.items(), key=lambda x: (-x[1], x[0]))
+        items: list[CompletionItem] = []
+        for name, cnt in sorted_tags:
+            if current_lower and not name.lower().startswith(current_lower):
+                continue
+            items.append(CompletionItem(name, help=f"{cnt} conversations"))
+            if len(items) >= _MAX_VALUE_COMPLETIONS:
+                break
+        return items
+
+    items = _run_completion(_query)
     return _with_csv_prefix(items, prefix)
 
 
@@ -262,6 +256,8 @@ def complete_repo_values(
     param: click.Parameter,
     incomplete: str,
 ) -> list[CompletionItem]:
+    # NOTE: Raw SQL on session_profiles \u2014 no ArchiveOperations read
+    # method for repo-name aggregation yet.
     del ctx, param
     prefix, current = _split_csv_incomplete(incomplete)
     rows = _fetch_rows(
@@ -295,6 +291,8 @@ def complete_cwd_prefix_values(
     param: click.Parameter,
     incomplete: str,
 ) -> list[CompletionItem]:
+    # NOTE: Raw SQL on session_profiles \u2014 no ArchiveOperations read
+    # method for cwd-prefix aggregation yet.
     del ctx, param
     current = incomplete.strip()
     rows = _fetch_rows(
@@ -327,6 +325,8 @@ def complete_tool_values(
     param: click.Parameter,
     incomplete: str,
 ) -> list[CompletionItem]:
+    # NOTE: Raw SQL on action_events \u2014 no ArchiveOperations read
+    # method for tool-name aggregation yet.
     del ctx, param
     current = incomplete.strip().lower()
     rows = _fetch_rows(

--- a/polylogue/ui/tui/app.py
+++ b/polylogue/ui/tui/app.py
@@ -6,11 +6,16 @@ from textual.app import App, ComposeResult
 from textual.widgets import Footer, Header
 
 if TYPE_CHECKING:
-    from polylogue.protocols import ConversationArchiveReadStore
+    from polylogue.operations.archive import ArchiveOperations
 
 
 class PolylogueApp(App[None]):
-    """Polylogue dashboard TUI."""
+    """Polylogue dashboard TUI.
+
+    Accepts an optional ``ArchiveOperations`` instance so screens route
+    through the shared archive operations contract rather than calling
+    repository methods directly (ref #860).
+    """
 
     CSS_PATH = "css/styles.tcss"
     BINDINGS = [
@@ -20,10 +25,10 @@ class PolylogueApp(App[None]):
 
     def __init__(
         self,
-        repository: ConversationArchiveReadStore | None = None,
+        operations: ArchiveOperations | None = None,
     ) -> None:
         super().__init__()
-        self._repository = repository
+        self._operations = operations
 
     def compose(self) -> ComposeResult:
         """Create child widgets for the app."""
@@ -37,13 +42,13 @@ class PolylogueApp(App[None]):
 
         with TabbedContent(initial="dashboard"):
             with TabPane("Dashboard", id="dashboard"):
-                yield Dashboard(repository=self._repository)
+                yield Dashboard(operations=self._operations)
 
             with TabPane("Browser", id="browser"):
-                yield Browser(repository=self._repository)
+                yield Browser(operations=self._operations)
 
             with TabPane("Search", id="search"):
-                yield Search(repository=self._repository)
+                yield Search(operations=self._operations)
 
         yield Footer()
 

--- a/polylogue/ui/tui/screens/base.py
+++ b/polylogue/ui/tui/screens/base.py
@@ -6,31 +6,31 @@ from typing import TYPE_CHECKING
 from textual.containers import Container
 from textual.widgets import Markdown as MarkdownWidget
 
-from polylogue.protocols import ConversationArchiveReadStore
 from polylogue.rendering.core import format_conversation_markdown
 
 if TYPE_CHECKING:
     from polylogue.archive.conversation.models import Conversation
+    from polylogue.operations.archive import ArchiveOperations
 
 
 ConversationMarkdownFormatter = Callable[["Conversation"], str]
 
 
 class RepositoryBoundContainer(Container):
-    """Shared base for TUI screens backed by an injected repository."""
+    """Shared base for TUI screens backed by injected archive operations."""
 
     def __init__(
         self,
-        repository: ConversationArchiveReadStore | None = None,
+        operations: ArchiveOperations | None = None,
     ) -> None:
         super().__init__()
-        self._repository = repository
+        self._operations = operations
 
-    def _get_repo(self, owner_name: str) -> ConversationArchiveReadStore:
-        """Return the injected repository or fail with a screen-specific message."""
-        if self._repository is None:
-            raise RuntimeError(f"{owner_name} widget requires an injected repository")
-        return self._repository
+    def _get_ops(self, owner_name: str) -> ArchiveOperations:
+        """Return the injected operations or fail with a screen-specific message."""
+        if self._operations is None:
+            raise RuntimeError(f"{owner_name} widget requires injected archive operations")
+        return self._operations
 
     async def _load_conversation_markdown(
         self,
@@ -40,10 +40,10 @@ class RepositoryBoundContainer(Container):
         formatter: ConversationMarkdownFormatter = format_conversation_markdown,
     ) -> bool:
         """Load a conversation and update the target Markdown widget."""
-        repo = self._get_repo(type(self).__name__)
+        ops = self._get_ops(type(self).__name__)
         viewer = self.query_one(viewer_selector, MarkdownWidget)
 
-        conv = await repo.get_eager(conversation_id)
+        conv = await ops.get_conversation(conversation_id)
         if not conv:
             viewer.update(f"Error: Could not load {conversation_id}")
             return False

--- a/polylogue/ui/tui/screens/browser.py
+++ b/polylogue/ui/tui/screens/browser.py
@@ -9,7 +9,11 @@ from polylogue.ui.tui.screens.base import RepositoryBoundContainer
 
 
 class Browser(RepositoryBoundContainer):
-    """Browser widget for navigating conversations."""
+    """Browser widget for navigating conversations.
+
+    Routes list/stats operations through ``ArchiveOperations``
+    instead of calling repository methods directly.
+    """
 
     def compose(self) -> ComposeResult:
         with Horizontal():
@@ -23,16 +27,16 @@ class Browser(RepositoryBoundContainer):
     async def _fetch_tree(self) -> None:
         """Fetch tree data asynchronously, then update DOM."""
         try:
-            repo = self._get_repo("Browser")
+            ops = self._get_ops("Browser")
 
-            stats = await repo.get_archive_stats()
+            stats = await ops.storage_stats()
             providers = sorted(stats.providers.keys()) if stats.providers else []
 
             # Collect tree data: list of (provider_label, [(title, conv_id), ...])
             tree_data: list[tuple[str, list[tuple[str, str]]]] = []
             for provider in providers:
-                summaries = await repo.list_summaries(limit=50, provider=provider)
-                leaves = [(str(s.title or s.id), str(s.id)) for s in summaries]
+                conversations = await ops.list_conversations(limit=50, provider=provider)
+                leaves = [(conv.title or str(conv.id), str(conv.id)) for conv in conversations]
                 tree_data.append((provider.capitalize(), leaves))
 
         except Exception as e:

--- a/polylogue/ui/tui/screens/dashboard.py
+++ b/polylogue/ui/tui/screens/dashboard.py
@@ -1,4 +1,8 @@
-"""Enhanced dashboard screen with embedding stats and provider breakdown."""
+"""Enhanced dashboard screen with embedding stats and provider breakdown.
+
+Routes stats through ``ArchiveOperations.storage_stats()``
+instead of calling the repository directly.
+"""
 
 from __future__ import annotations
 
@@ -6,7 +10,7 @@ from textual.app import ComposeResult
 from textual.containers import Container, Grid
 from textual.widgets import Static
 
-from polylogue.archive.stats import ArchiveStats
+from polylogue.archive.stats import ArchiveStats as StorageArchiveStats
 from polylogue.logging import get_logger
 from polylogue.ui.tui.screens.base import RepositoryBoundContainer
 from polylogue.ui.tui.widgets.stats import StatCard
@@ -40,8 +44,8 @@ class ProviderBar(Static):
         pct = (self.count / self.max_count * 100) if self.max_count > 0 else 0
         bar_width = 20
         filled = int(pct / 100 * bar_width)
-        bar = "█" * filled + "░" * (bar_width - filled)
-        # Format: "provider_name    ████████░░░░░░░░░░░░  123"
+        bar = chr(0x2588) * filled + chr(0x2591) * (bar_width - filled)
+        # Format: "provider_name    [bar]  123"
         return f"{self.provider[:16]:<16} {bar} {self.count:>6}"
 
 
@@ -96,15 +100,15 @@ class Dashboard(RepositoryBoundContainer):
     async def _fetch_stats(self) -> None:
         """Fetch stats asynchronously, then update DOM."""
         try:
-            repo = self._get_repo("Dashboard")
-            stats = await repo.get_archive_stats()
+            ops = self._get_ops("Dashboard")
+            stats = await ops.storage_stats()
         except Exception as e:
             self.notify(f"Failed to load stats: {e}", severity="error")
             return
 
         self._apply_stats(stats)
 
-    def _apply_stats(self, stats: ArchiveStats) -> None:
+    def _apply_stats(self, stats: StorageArchiveStats) -> None:
         """Apply fetched stats to DOM widgets (runs on main thread)."""
 
         self.query_one("#stat-conversations", StatCard).value = str(stats.total_conversations)

--- a/polylogue/ui/tui/screens/search.py
+++ b/polylogue/ui/tui/screens/search.py
@@ -1,18 +1,20 @@
 from __future__ import annotations
 
-import sqlite3
-
 from textual.app import ComposeResult
 from textual.containers import Container, Horizontal, Vertical
 from textual.widgets import DataTable, Input
 from textual.widgets import Markdown as MarkdownWidget
 
-from polylogue.errors import DatabaseError
 from polylogue.ui.tui.screens.base import RepositoryBoundContainer
 
 
 class Search(RepositoryBoundContainer):
-    """Search widget for finding conversations."""
+    """Search widget for finding conversations.
+
+    Routes through ``ArchiveOperations.search()`` which applies the
+    canonical query pipeline (FTS5, filters, result mapping) instead of
+    calling the repository's ``search_summaries`` directly.
+    """
 
     def compose(self) -> ComposeResult:
         with Vertical():
@@ -33,28 +35,29 @@ class Search(RepositoryBoundContainer):
         if not query:
             return
 
-        repo = self._get_repo("Search")
+        ops = self._get_ops("Search")
 
-        # Perform search
         table = self.query_one("#search-results", DataTable)
         table.clear()
 
         try:
-            summaries = await repo.search_summaries(query, limit=50)
-        except (sqlite3.OperationalError, DatabaseError) as exc:
-            if "no such table" in str(exc) or "Search index not built" in str(exc):
-                table.add_row("—", "—", "Search index not built. Start: polylogued run", "")
-            else:
-                table.add_row("—", "—", f"Search error: {exc}", "")
+            result = await ops.search(query, limit=50)
+        except Exception:
+            table.add_row(
+                "—",
+                "—",
+                "Search not ready: polylogued may need to build indexes",
+                "",
+            )
             return
 
-        for s in summaries:
+        for hit in result.hits:
             table.add_row(
-                s.id,
-                s.provider,
-                s.title or "Untitled",
-                str(s.created_at) if s.created_at else "",
-                key=s.id,  # Store ID as row key for selection
+                hit.conversation_id,
+                hit.provider_name,
+                hit.title or "Untitled",
+                str(hit.timestamp) if hit.timestamp else "",
+                key=hit.conversation_id,
             )
 
     async def on_data_table_row_selected(self, message: DataTable.RowSelected) -> None:


### PR DESCRIPTION
## Summary

Route three surface bypass categories through the shared `ArchiveOperations` contract: TUI screens (B6-B10), raw artifact access (B12), and CLI completions (conversation IDs + tags).

## Problem

Per the #860 recon report, read adapters in TUI, API, and CLI completion code reached directly into repository methods (`search_summaries`, `list_summaries`, `get_eager`, `get_archive_stats`), private backend access (`_backend.connection()`), and raw SQL. This creates parallel semantics: one set of query/status contracts and several different code paths.

## Solution

### TUI bypasses (B6-B10, B11)

| File | Before | After |
|------|--------|-------|
| `screens/base.py` | `ConversationArchiveReadStore` injection, `get_eager()` | `ArchiveOperations` injection, `get_conversation()` |
| `screens/search.py` | `repo.search_summaries(query, limit=50)`, stale error message | `ops.search(query, limit=50)` through canonical query pipeline, updated message |
| `screens/browser.py` | `repo.list_summaries()` + `repo.get_archive_stats()` | `ops.list_conversations()` + `ops.storage_stats()` |
| `screens/dashboard.py` | `repo.get_archive_stats()` | `ops.storage_stats()` |
| `app.py` | Injects `ConversationArchiveReadStore` | Injects `ArchiveOperations` |
| `cli/commands/dashboard.py` | `PolylogueApp(repository=env.repository)` | `PolylogueApp(operations=env.operations)` |

### API raw artifacts bypass (B12)

| File | Before | After |
|------|--------|-------|
| `api/archive.py` | `self.repository._backend.connection()` + raw query import | `self.operations.get_raw_artifacts_for_conversation()` |

### CLI completions bypass

| File | Before | After |
|------|--------|-------|
| `shell_completion_values.py:complete_conversation_ids` | Raw SQL on `conversations` table | `ops.list_conversations()` via `asyncio.run` bridge |
| `shell_completion_values.py:complete_tag_values` | Raw SQL on `conversation_tags` + `tags` | `ops.list_tags()` via `asyncio.run` bridge |

### Inventory table

| Bypass | Classification | Status |
|--------|---------------|--------|
| B6 (search_summaries) | Moved to `ops.search()` | Done |
| B7 (list_summaries) | Moved to `ops.list_conversations()` | Done |
| B8 (get_archive_stats, browser) | Moved to `ops.storage_stats()` | Done |
| B9 (get_archive_stats, dashboard) | Moved to `ops.storage_stats()` | Done |
| B10 (get_eager) | Moved to `ops.get_conversation()` | Done |
| B11 (stale error message) | Fixed | Done |
| B12 (_backend.connection) | Moved to `ops.get_raw_artifacts_for_conversation()` | Done |
| B1 (rendering/core_formatter) | Already fixed (#860) | N/A |
| B2-B3 (rendering/renderers) | Deferred — export/publication | Follow-up |
| B4-B5 (cli/query, cli/select) | Deferred | Follow-up |
| B13-B16 (daemon/status raw SQL) | Acceptable — daemon substrate | N/A |
| repo/cwd/tool completions | Gap — no ArchiveOperations read methods for session_profiles/action_events | Follow-up |

## Verification

```
ruff check <all 8 modified files>
# All checks passed!

mypy --strict <all 7 source files>
# Success: no issues found in 7 source files
```

## Gap assessment

1. **repo/cwd/tool completions** still use raw SQL on `session_profiles` and `action_events` — no ArchiveOperations read methods exist for these aggregations.

2. **B4 (cli/query.py `repo.backend.db_path`)** and **B5 (cli/select.py `SQLiteBackend` import)** are deferred.

3. **B2/B3 (rendering/renderers)** deferred as export/publication per #852/#860 directives.

4. **Daemon status probes (B13-B16)** accepted as daemon substrate.

Ref #860