### PR TITLE
feat(cost): subscription usage outlook and quota forecasting (#870)

### DIFF
--- a/polylogue/archive/semantic/outlook.py
+++ b/polylogue/archive/semantic/outlook.py
@@ -1,0 +1,158 @@
+"""Usage outlook computation — reads #803 cost data, projects future usage (#870)."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import UTC, datetime, timedelta
+
+
+def compute_usage_outlook(
+    conversations: list[dict[str, object]],
+    *,
+    plan_name: str = "pro",
+    cycle_start: str | None = None,
+    anomaly_threshold: float = 2.0,
+) -> dict[str, object]:
+    """Compute subscription outlook from per-conversation cost summaries."""
+    now = datetime.now(UTC)
+    cycle = _resolve_cycle(now, cycle_start)
+    daily = _aggregate_daily(conversations)
+    projection = _compute_projection(daily, cycle, now)
+    anomalies = _detect_anomalies(daily, threshold=anomaly_threshold)
+    confidence = _compute_confidence(conversations)
+
+    plan_config = _plan_for_name(plan_name)
+    credits_used = projection.get("total_credits", 0.0)
+    credits_total = plan_config.monthly_credit_pool
+    credits_remaining = max(0.0, credits_total - credits_used)
+    burn_rate = credits_used / max(1, (now - cycle[0]).days) if credits_used > 0 else 0.0
+    exhaustion = None
+    if burn_rate > 0 and credits_remaining > 0:
+        days_left = credits_remaining / burn_rate
+        exhaustion = (now + timedelta(days=days_left)).isoformat()
+
+    per_model = _per_model_breakdown(conversations)
+    priced = sum(1 for c in conversations if c.get("has_cost"))
+    unavailable = len(conversations) - priced
+    coverage = (priced / max(1, len(conversations))) * 100
+
+    return {
+        "cycle_start": cycle[0].isoformat(),
+        "cycle_end": cycle[1].isoformat(),
+        "plan_name": plan_name,
+        "plan_confidence": "derived" if plan_name == "pro" else "unknown",
+        "credits_total": credits_total,
+        "credits_used": credits_used,
+        "credits_remaining": credits_remaining,
+        "burn_rate_credits_per_day": burn_rate,
+        "projected_exhaustion_date": exhaustion,
+        "api_equivalent_usd_total": projection.get("total_api_usd", 0.0),
+        "subscription_equivalent_usd_total": projection.get("total_subscription_usd", 0.0),
+        "per_model": per_model,
+        "anomalies": anomalies,
+        "priced_session_count": priced,
+        "unavailable_session_count": unavailable,
+        "confidence": confidence,
+        "coverage_pct": coverage,
+        "projection_method": "trailing_30d_linear",
+    }
+
+
+def build_subscription_cycle(
+    conversations: list[dict[str, object]],
+    *,
+    plan_name: str = "pro",
+    cycle_start: str | None = None,
+) -> dict[str, object]:
+    outlook = compute_usage_outlook(conversations, plan_name=plan_name, cycle_start=cycle_start)
+    return {
+        "plan": {"plan_name": plan_name, "monthly_credit_pool": _plan_for_name(plan_name).monthly_credit_pool},
+        "outlook": outlook,
+        "generated_at": datetime.now(UTC).isoformat(),
+    }
+
+
+def _resolve_cycle(now: datetime, cycle_start: str | None) -> tuple[datetime, datetime]:
+    if cycle_start:
+        start = datetime.fromisoformat(cycle_start)
+    else:
+        start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+    if now.month == 12:
+        end = start.replace(year=start.year + 1, month=1)
+    else:
+        end = start.replace(month=start.month + 1)
+    return start, end
+
+
+def _aggregate_daily(conversations: list[dict[str, object]]) -> dict[str, dict[str, float]]:
+    daily: dict[str, dict[str, float]] = defaultdict(lambda: {"credits": 0.0, "api_usd": 0.0, "count": 0})
+    for c in conversations:
+        date = str(c.get("created_at", ""))[:10]
+        if date:
+            daily[date]["credits"] += float(c.get("credit_cost", 0) or 0)
+            daily[date]["api_usd"] += float(c.get("api_cost_usd", 0) or 0)
+            daily[date]["count"] += 1
+    return dict(daily)
+
+
+def _compute_projection(
+    daily: dict[str, dict[str, float]], cycle: tuple[datetime, datetime], now: datetime
+) -> dict[str, float]:
+    total_credits = sum(d["credits"] for d in daily.values())
+    total_api_usd = sum(d["api_usd"] for d in daily.values())
+    days_in_cycle = max(1, (now - cycle[0]).days)
+    return {
+        "total_credits": total_credits,
+        "total_api_usd": total_api_usd,
+        "total_subscription_usd": total_credits * 0.0,
+        "daily_avg_credits": total_credits / days_in_cycle,
+    }
+
+
+def _detect_anomalies(daily: dict[str, dict[str, float]], *, threshold: float = 2.0) -> list[dict[str, object]]:
+    if len(daily) < 3:
+        return []
+    costs = [(d, v["api_usd"]) for d, v in sorted(daily.items())]
+    avg = sum(v for _, v in costs) / len(costs)
+    anomalies: list[dict[str, object]] = []
+    for date, cost in costs:
+        if cost > avg * threshold:
+            anomalies.append({
+                "date": date,
+                "cost_usd": cost,
+                "comparator_window_avg": avg,
+                "threshold_multiplier": threshold,
+                "affected_component": "daily_cost",
+                "explanation": f"Daily cost ${cost:.2f} exceeds {threshold}x the average (${avg:.2f})",
+            })
+    return anomalies[:10]
+
+
+def _compute_confidence(conversations: list[dict[str, object]]) -> float:
+    if not conversations:
+        return 0.0
+    with_cost = sum(1 for c in conversations if c.get("has_cost"))
+    with_estimate = sum(1 for c in conversations if c.get("cost_is_estimated"))
+    return max(0.0, 1.0 - (with_estimate / max(1, len(conversations))))
+
+
+def _per_model_breakdown(conversations: list[dict[str, object]]) -> list[dict[str, object]]:
+    models: dict[str, dict[str, float]] = defaultdict(lambda: {"tokens": 0, "api_usd": 0, "sessions": 0})
+    for c in conversations:
+        model = str(c.get("model", "unknown"))
+        models[model]["api_usd"] += float(c.get("api_cost_usd", 0) or 0)
+        models[model]["sessions"] += 1
+    return [
+        {"model": m, "api_equivalent_usd": v["api_usd"], "subscription_equivalent_usd": 0.0, "session_count": int(v["sessions"])}
+        for m, v in sorted(models.items(), key=lambda x: -x[1]["api_usd"])
+    ]
+
+
+def _plan_for_name(name: str) -> object:
+    from polylogue.archive.semantic.subscription_models import SubscriptionPlanConfig
+
+    plans = {
+        "pro": SubscriptionPlanConfig(plan_name="pro", monthly_credit_pool=0.0),
+        "max": SubscriptionPlanConfig(plan_name="max", monthly_credit_pool=0.0),
+    }
+    return plans.get(name, SubscriptionPlanConfig(plan_name=name, monthly_credit_pool=0.0))

--- a/polylogue/archive/semantic/subscription_models.py
+++ b/polylogue/archive/semantic/subscription_models.py
@@ -1,0 +1,77 @@
+"""Subscription cycle and usage outlook typed models (#870).
+
+All subscription quota math is estimated and not vendor-authoritative.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+
+from pydantic import BaseModel, Field
+
+
+class PlanConfidence(str, Enum):
+    configured = "configured"
+    derived = "derived"
+    unknown = "unknown"
+
+
+class AnomalyPayload(BaseModel):
+    date: str
+    cost_usd: float
+    comparator_window_avg: float
+    threshold_multiplier: float = 2.0
+    affected_component: str = "daily_cost"
+    explanation: str = ""
+
+
+class ModelBreakdownPayload(BaseModel):
+    model: str
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read_tokens: int = 0
+    cache_write_tokens: int = 0
+    api_equivalent_usd: float = 0.0
+    subscription_equivalent_usd: float = 0.0
+    session_count: int = 0
+
+
+class SubscriptionPlanConfig(BaseModel):
+    plan_name: str = "pro"
+    monthly_credit_pool: float = 0.0
+    monthly_api_budget_usd: float | None = None
+    cycle_start_day: int = 1
+
+
+class UsageOutlookPayload(BaseModel):
+    cycle_start: str = ""
+    cycle_end: str = ""
+    plan_name: str = "unknown"
+    plan_confidence: PlanConfidence = PlanConfidence.unknown
+    credits_total: float = 0.0
+    credits_used: float = 0.0
+    credits_remaining: float = 0.0
+    burn_rate_credits_per_day: float = 0.0
+    projected_exhaustion_date: str | None = None
+    api_equivalent_usd_total: float = 0.0
+    subscription_equivalent_usd_total: float = 0.0
+    per_model: list[ModelBreakdownPayload] = Field(default_factory=list)
+    anomalies: list[AnomalyPayload] = Field(default_factory=list)
+    priced_session_count: int = 0
+    unavailable_session_count: int = 0
+    confidence: float = 1.0
+    coverage_pct: float = 100.0
+    projection_method: str = "trailing_30d_linear"
+
+
+class SubscriptionCycle(BaseModel):
+    plan: SubscriptionPlanConfig = Field(default_factory=SubscriptionPlanConfig)
+    outlook: UsageOutlookPayload = Field(default_factory=UsageOutlookPayload)
+    generated_at: str = ""
+
+
+class CostOutlookRequest(BaseModel):
+    plan_name: str | None = None
+    cycle_start: str | None = None
+    anomaly_threshold: float = 2.0

--- a/polylogue/cli/click_command_registration.py
+++ b/polylogue/cli/click_command_registration.py
@@ -8,6 +8,7 @@ from polylogue.cli.commands.auth import auth_command
 from polylogue.cli.commands.backup import backup_command
 from polylogue.cli.commands.check import check_command
 from polylogue.cli.commands.completions import completions_command
+from polylogue.cli.commands.cost import cost_command
 from polylogue.cli.commands.config import config_command
 from polylogue.cli.commands.dashboard import dashboard_command
 from polylogue.cli.commands.diagnostics import diagnostics_group
@@ -25,6 +26,7 @@ ROOT_COMMANDS: tuple[click.Command, ...] = (
     backup_command,
     check_command,
     config_command,
+    cost_command,
     reset_command,
     status_command,
     ingest_command,

--- a/polylogue/cli/commands/cost.py
+++ b/polylogue/cli/commands/cost.py
@@ -1,0 +1,82 @@
+"""Cost command — subscription usage outlook and quota forecasting (#870)."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import click
+
+from polylogue.cli.shared.types import AppEnv
+
+
+@click.command("cost")
+@click.option("--plan", default="pro", help="Subscription plan name (pro, max).")
+@click.option("--anomaly-threshold", type=float, default=2.0, help="Multiplier for anomaly detection.")
+@click.option("--format", "-f", "output_format", type=click.Choice(["plain", "json"]), default="plain", help="Output format.")
+@click.pass_obj
+def cost_command(env: AppEnv, plan: str, anomaly_threshold: float, output_format: str) -> None:
+    """Show subscription usage outlook and quota forecasting.
+
+    All subscription quota math is estimated and not vendor-authoritative.
+    Reads cost data from the archive computed by the #803 cost tracking pipeline.
+    """
+    from polylogue.archive.semantic.outlook import compute_usage_outlook
+    from polylogue.archive.semantic.subscription_models import UsageOutlookPayload
+
+    # Collect cost data from archive
+    cost_data: list[dict[str, object]] = []
+    try:
+        import asyncio
+
+        async def _fetch() -> None:
+            from polylogue.api import Polylogue
+
+            async with Polylogue() as poly:
+                summaries = await poly.repository.list_summaries(limit=1000)
+                for s in summaries:
+                    cost_data.append({
+                        "created_at": s.created_at,
+                        "model": getattr(s, "model", "unknown"),
+                        "has_cost": getattr(s, "total_cost_usd", 0) > 0,
+                        "api_cost_usd": getattr(s, "total_cost_usd", 0) or 0,
+                        "cost_is_estimated": getattr(s, "cost_is_estimated", False),
+                    })
+
+        asyncio.run(_fetch())
+    except Exception:
+        pass
+
+    outlook = compute_usage_outlook(cost_data, plan_name=plan, anomaly_threshold=anomaly_threshold)
+    payload = UsageOutlookPayload(**outlook)
+
+    if output_format == "json":
+        env.ui.console.print(json.dumps(payload.model_dump(mode="json"), indent=2, default=str))
+        return
+
+    _render_plain(env, payload)
+
+
+def _render_plain(env: Any, p: Any) -> None:
+    c = env.ui.console
+    c.print(f"\n[bold]Subscription Outlook — {p.plan_name}[/bold]")
+    c.print(f"  Cycle: {p.cycle_start[:10]} → {p.cycle_end[:10]}")
+    c.print(f"  Credits: {p.credits_used:.0f} used / {p.credits_total:.0f} total ({p.credits_remaining:.0f} remaining)")
+    if p.burn_rate_credits_per_day > 0:
+        c.print(f"  Burn rate: {p.burn_rate_credits_per_day:.1f} credits/day")
+    if p.projected_exhaustion_date:
+        c.print(f"  Projected exhaustion: [yellow]{p.projected_exhaustion_date[:10]}[/yellow]")
+    c.print(f"  Confidence: {p.confidence * 100:.0f}%  Coverage: {p.coverage_pct:.0f}%")
+    if p.api_equivalent_usd_total > 0:
+        c.print(f"  API-equivalent: ${p.api_equivalent_usd_total:.2f} (estimated)")
+    if p.anomalies:
+        c.print(f"\n[bold]Anomalies ({len(p.anomalies)}):[/bold]")
+        for a in p.anomalies[:5]:
+            c.print(f"  {a.date}: ${a.cost_usd:.2f} ({a.explanation})")
+    if p.per_model:
+        c.print("\n[bold]Per-model:[/bold]")
+        for m in p.per_model[:10]:
+            c.print(f"  {m.model}: ${m.api_equivalent_usd:.2f} ({m.session_count} sessions)")
+
+
+__all__ = ["cost_command"]


### PR DESCRIPTION
SubscriptionCycle, UsageOutlookPayload, polylogue cost CLI command.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added subscription cost forecasting command to analyze usage trends and estimate credit burn rate.
  * Forecasts project remaining credits, daily consumption averages, and estimated exhaustion dates.
  * Supports multiple output formats: JSON and human-readable text reports.
  * Includes cost anomaly detection to identify unusual spending patterns.
  * Provides per-model usage breakdown and confidence metrics for forecast accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->