### PR TITLE
feat: persistent sync bridge, token+source hydration fixes (#726, #803, #864)

### DIFF
--- a/polylogue/api/sync/bridge.py
+++ b/polylogue/api/sync/bridge.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import asyncio
 import atexit
 import threading
-from collections.abc import Awaitable
+from collections.abc import Awaitable, Coroutine
+from concurrent.futures import Future
 from typing import TypeVar
 
 T = TypeVar("T")
@@ -41,6 +42,10 @@ def _stop_worker() -> None:
 atexit.register(_stop_worker)
 
 
+async def _await(awaitable: Awaitable[T]) -> T:
+    return await awaitable
+
+
 def run_coroutine_sync(coro: Awaitable[T]) -> T:
     """Run a coroutine from sync code, even when already inside an event loop.
 
@@ -48,13 +53,14 @@ def run_coroutine_sync(coro: Awaitable[T]) -> T:
     When inside an event loop, delegates to a persistent worker thread
     with its own event loop, avoiding per-call thread creation.
     """
+    wrapper: Coroutine[object, object, T] = _await(coro)
     try:
         asyncio.get_running_loop()
     except RuntimeError:
-        return asyncio.run(coro)
+        return asyncio.run(wrapper)
 
     loop = _ensure_worker()
-    future = asyncio.run_coroutine_threadsafe(coro, loop)
+    future: Future[T] = asyncio.run_coroutine_threadsafe(wrapper, loop)
     return future.result()
 
 

--- a/polylogue/api/sync/bridge.py
+++ b/polylogue/api/sync/bridge.py
@@ -1,41 +1,61 @@
 from __future__ import annotations
 
 import asyncio
+import atexit
 import threading
 from collections.abc import Awaitable
 from typing import TypeVar
 
 T = TypeVar("T")
 
+_worker_loop: asyncio.AbstractEventLoop | None = None
+_worker_thread: threading.Thread | None = None
+_lock = threading.Lock()
 
-async def _await_result(awaitable: Awaitable[T]) -> T:
-    return await awaitable
+
+def _ensure_worker() -> asyncio.AbstractEventLoop:
+    global _worker_loop, _worker_thread
+
+    if _worker_loop is not None and _worker_loop.is_running():
+        return _worker_loop
+
+    with _lock:
+        if _worker_loop is not None and _worker_loop.is_running():
+            return _worker_loop
+        _worker_loop = asyncio.new_event_loop()
+        _worker_thread = threading.Thread(target=_worker_loop.run_forever, daemon=True)
+        _worker_thread.start()
+
+    return _worker_loop
+
+
+def _stop_worker() -> None:
+    global _worker_loop, _worker_thread
+    with _lock:
+        if _worker_loop is not None:
+            _worker_loop.call_soon_threadsafe(_worker_loop.stop)
+            _worker_loop = None
+            _worker_thread = None
+
+
+atexit.register(_stop_worker)
 
 
 def run_coroutine_sync(coro: Awaitable[T]) -> T:
-    """Run a coroutine from sync code, even when already inside an event loop."""
+    """Run a coroutine from sync code, even when already inside an event loop.
+
+    When no event loop is running, uses asyncio.run() directly.
+    When inside an event loop, delegates to a persistent worker thread
+    with its own event loop, avoiding per-call thread creation.
+    """
     try:
         asyncio.get_running_loop()
     except RuntimeError:
-        return asyncio.run(_await_result(coro))
+        return asyncio.run(coro)
 
-    result: list[T] = []
-    error: list[BaseException] = []
-
-    def _worker() -> None:
-        try:
-            result.append(asyncio.run(_await_result(coro)))
-        except BaseException as exc:  # pragma: no cover - re-raised on caller thread
-            error.append(exc)
-
-    thread = threading.Thread(target=_worker, daemon=True)
-    thread.start()
-    thread.join()
-    if error:
-        raise error[0]
-    if not result:
-        raise RuntimeError("Coroutine thread completed without returning a result")
-    return result[0]
+    loop = _ensure_worker()
+    future = asyncio.run_coroutine_threadsafe(coro, loop)
+    return future.result()
 
 
 __all__ = ["run_coroutine_sync"]

--- a/polylogue/storage/sqlite/queries/mappers_archive.py
+++ b/polylogue/storage/sqlite/queries/mappers_archive.py
@@ -58,6 +58,7 @@ def _row_to_conversation(row: sqlite3.Row) -> ConversationRecord:
         parent_conversation_id=ConversationId(parent_conversation_id) if parent_conversation_id is not None else None,
         branch_type=BranchType(branch_type) if branch_type is not None else None,
         raw_id=_row_text(row, "raw_id"),
+        source_name=_row_text(row, "source_name") or "",
     )
 
 
@@ -81,6 +82,11 @@ def _row_to_message(row: sqlite3.Row) -> MessageRecord:
         has_tool_use=_row_int(row, "has_tool_use", 0) or 0,
         has_thinking=_row_int(row, "has_thinking", 0) or 0,
         has_paste=_row_int(row, "has_paste", 0) or 0,
+        input_tokens=_row_int(row, "input_tokens", 0) or 0,
+        output_tokens=_row_int(row, "output_tokens", 0) or 0,
+        cache_read_tokens=_row_int(row, "cache_read_tokens", 0) or 0,
+        cache_write_tokens=_row_int(row, "cache_write_tokens", 0) or 0,
+        model_name=_row_text(row, "model_name"),
         message_type=MessageType.normalize(_row_text(row, "message_type") or "message"),
     )
 


### PR DESCRIPTION
## Summary
Three narrow fixes that eliminate per-call thread overhead on hot sync paths and fix data loss in database read paths.

## Problem
- **#726**: `run_coroutine_sync()` spawned a new thread for every call when inside an event loop — measured as measurable overhead on sync hot paths
- **#803**: `_row_to_message()` silently dropped 5 columns (`input_tokens`, `output_tokens`, `cache_read_tokens`, `cache_write_tokens`, `model_name`) that are correctly written by the UPSERT path — data written but never readable
- **#864**: `_row_to_conversation()` silently dropped `source_name` — also written correctly but never hydrated on read

## Solution
- **#726**: Persistent worker thread with its own event loop, using `run_coroutine_threadsafe()` to delegate. Module-level singleton pattern with `atexit` cleanup.
- **#803**: Add 5 missing field hydrations to `_row_to_message()` in `mappers_archive.py`
- **#864**: Add `source_name` hydration to `_row_to_conversation()` in `mappers_archive.py`

## Verification
```
mypy polylogue/api/sync/bridge.py polylogue/api/sync/__init__.py  # clean
pytest tests/unit/core/test_sync_surface_runtime.py -q  # 42 passed
pytest tests/unit/storage/test_query_mappers.py -q  # passing
devtools verify --quick  # all checks passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Archive records now include token usage metrics and model information for enhanced tracking and analysis capabilities.

* **Refactor**
  * Optimized synchronous coroutine execution for improved performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->