### PR TITLE
feat: wire paste detection, cleanup root artifacts (#947, #954)

### DIFF
--- a/devtools/render_pages.py
+++ b/devtools/render_pages.py
@@ -109,9 +109,9 @@ def main(argv: list[str] | None = None) -> int:
             current_hash = _hash_directory(args.output) if args.output.exists() else ""
             new_hash = _hash_directory(tmp_dir)
             if current_hash != new_hash:
-                print("Error: _site/ is out of sync with sources. Run: devtools render-pages", file=sys.stderr)
+                print(f"Error: {args.output} is out of sync with sources. Run: devtools render-pages", file=sys.stderr)
                 return 1
-            print("OK: _site/ matches sources.")
+            print(f"OK: {args.output} matches sources.")
             return 0
 
     print("Building GitHub Pages site...", file=sys.stderr)

--- a/devtools/render_pages.py
+++ b/devtools/render_pages.py
@@ -44,8 +44,8 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--output",
         type=Path,
-        default=ROOT / "_site",
-        help="Output directory (default: _site/).",
+        default=ROOT / ".cache" / "site",
+        help="Output directory (default: .cache/site/).",
     )
     parser.add_argument(
         "--skip-pagefind",

--- a/polylogue/pipeline/materialization_runtime.py
+++ b/polylogue/pipeline/materialization_runtime.py
@@ -9,6 +9,7 @@ from typing import Protocol, TypeAlias
 
 from polylogue.archive.conversation.branch_type import BranchType
 from polylogue.archive.message.artifacts import classify_text_message_type
+from polylogue.archive.message.paste_detection import detect_paste
 from polylogue.archive.message.roles import Role
 from polylogue.archive.message.types import MessageType
 from polylogue.archive.viewport.viewports import ToolCategory, classify_tool
@@ -319,7 +320,7 @@ def materialize_conversation(
             or message_type in {MessageType.TOOL_USE, MessageType.TOOL_RESULT}
         )
         has_thinking = int(has_thinking_block or message_type == MessageType.THINKING)
-        has_paste = 0
+        has_paste = detect_paste(msg.text)
         if message_type == MessageType.MESSAGE:
             if has_thinking_block:
                 message_type = MessageType.THINKING


### PR DESCRIPTION
## Summary
Wire paste detection into message materialization and clean up project-root pollution.

## Problem
- **#947**: `has_paste` was always initialized to 0 in `materialization_runtime.py` — the `detect_paste()` function existed but was never called during ingest
- **#954**: `MagicMock/` test-artifact directory and `_site/` output directory cluttered the project root

## Solution
- **#947**: Import and call `detect_paste()` in `materialization_runtime.py` (line 322), replacing the `= 0` default
- **#954**: Delete `MagicMock/` directory, move site output from `_site/` to `.cache/site/`

## Verification
```
devtools verify --quick  # all checks passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)