### PR TITLE
feat: add _classify_path routing for browser, build, site, daemon paths (#397)

### DIFF
--- a/polylogue/proof/diffing.py
+++ b/polylogue/proof/diffing.py
@@ -18,16 +18,21 @@ from polylogue.proof.catalog import VerificationCatalog, build_verification_cata
 from polylogue.proof.models import ProofObligation, SubjectRef
 
 ChangeKind = Literal[
+    "browser_extension",
+    "build_config",
+    "docs_media",
     "parser",
     "schema.annotation",
     "provider.capability",
     "command",
+    "daemon_runtime",
     "generated_surface",
     "architecture",
     "coverage_manifest",
     "schema_roundtrip",
     "proof_catalog",
     "operation.spec",
+    "site_template",
     "workflow",
     "test",
     "unknown",
@@ -597,6 +602,16 @@ def _classify_path(path: str) -> ChangeKind:
         return "operation.spec"
     if path.startswith(".github/") or path in {"CONTRIBUTING.md", "CLAUDE.md", "AGENTS.md"}:
         return "workflow"
+    if path.startswith("browser-extension/"):
+        return "browser_extension"
+    if path in {"pyproject.toml", "flake.nix", "flake.lock"}:
+        return "build_config"
+    if path.startswith("polylogue/site/") or path in {"polylogue/templates/style.css"}:
+        return "site_template"
+    if path.startswith("docs/assets/") or path.startswith("docs/media/"):
+        return "docs_media"
+    if path in {"polylogue/pipeline/tail_overlay.py"}:
+        return "daemon_runtime"
     if path.startswith("tests/"):
         return "test"
     return "unknown"
@@ -704,6 +719,17 @@ def _checks_for_change(kind: ChangeKind, *, path: str) -> tuple[RecommendedCheck
             ),
             _check(("devtools", "render-all", "--check"), "workflow docs may feed generated surfaces"),
         )
+    if kind == "browser_extension":
+        return (_check(("devtools", "build-package"), "browser extension sources changed"),)
+    if kind == "build_config":
+        return (
+            _check(("devtools", "verify"), "build configuration changed"),
+            _check(("devtools", "build-package"), "packaging surface may be affected"),
+        )
+    if kind in {"site_template", "docs_media"}:
+        return (_check(("devtools", "render-pages", "--check"), "site template or media changed"),)
+    if kind == "daemon_runtime":
+        return (_check(("pytest", "tests/unit/daemon"), "daemon runtime files changed"),)
     return ()
 
 


### PR DESCRIPTION
## Summary
Routes previously-unknown paths in `_classify_path()` to concrete `ChangeKind` values, eliminating `unknown:*` routing for key maintained surfaces.

## Problem
- **#397**: `devtools affected-obligations` returned `unknown:*` for browser-extension, pyproject.toml, site templates, docs media, and daemon runtime paths

## Solution
- Add 5 new `ChangeKind` values: `browser_extension`, `build_config`, `docs_media`, `daemon_runtime`, `site_template`
- Route `browser-extension/` → `browser_extension`, `pyproject.toml` → `build_config`, `polylogue/site/` → `site_template`, `docs/assets/` → `docs_media`, `polylogue/pipeline/tail_overlay.py` → `daemon_runtime`
- Add `_checks_for_change` entries for all new kinds

## Verification
```
devtools verify --quick  # all checks passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)