### PR TITLE
fix(security): replace regex HTML sanitizer with nh3 (#813)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -35,7 +35,7 @@ jobs:
           mv pagefind /usr/local/bin/
 
       - name: Build site
-        run: uv run devtools render-pages --skip-pagefind
+        run: uv run devtools render-pages --skip-pagefind --output _site
 
       - name: Index with Pagefind
         run: pagefind --site _site/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -932,7 +932,7 @@ These are the commands worth remembering during normal repo work:
 | `devtools render-cli-reference` | Render docs/cli-reference.md from live CLI help. |
 | `devtools render-devtools-reference` | Render the command catalog inside docs/devtools.md. |
 | `devtools render-docs-surface` | Render docs/README.md and the README documentation table. |
-| `devtools render-pages` | Build the GitHub Pages documentation site into _site/. |
+| `devtools render-pages` | Build the GitHub Pages documentation site into .cache/site/. |
 | `devtools render-quality-reference` | Render docs/test-quality-workflows.md from live validation, mutation, and benchmark registries. |
 | `devtools render-readme-media` | Generate README media assets (architecture diagrams, flowcharts) under docs/media/. |
 | `devtools render-topology-status` | Render docs/topology-status.md from the topology projection and realized tree. |

--- a/browser-extension/README.md
+++ b/browser-extension/README.md
@@ -1,42 +1,91 @@
 # Polylogue Browser Capture
 
-This is a local-first Manifest V3 extension for capturing supported web LLM
+Local-first Manifest V3 extension for capturing ChatGPT and Claude.ai
 sessions into Polylogue.
 
-Run the receiver:
+## Install
+
+### 1. Start the receiver
 
 ```bash
 polylogue browser-capture serve
 ```
 
-Then load this directory as an unpacked Chrome extension. The popup shows
-receiver state, current-page support, archive capture state, the last accepted
-capture, and the configured local receiver URL. Captures are posted to
-`http://127.0.0.1:8765/v1/browser-captures`, written into the normal Polylogue
-inbox, and parsed by the normal source dispatch path on the next ingest run.
+Keep this terminal open. The receiver runs on `http://127.0.0.1:8765`.
 
-The extension does not send session content to any remote service. It only
-talks to the local receiver. When the receiver is unavailable, the extension
-badge and popup report the offline state. ChatGPT and Claude.ai are the minimum
-supported provider adapters in this slice.
+### 2. Load the extension in Chrome / Chromium
+
+1. Open `chrome://extensions`
+2. Enable **Developer mode** (toggle, top right)
+3. Click **Load unpacked** and select this directory (`browser-extension/`)
+4. Pin the extension to the toolbar so the badge is always visible
+
+### 3. Verify it works
+
+```bash
+polylogue browser-capture status
+```
+
+Then navigate to `chatgpt.com` or `claude.ai`. The extension badge should
+turn green. Start a conversation — each exchange is captured as you type.
+
+## Supported Sites
+
+| Site | Provider | Notes |
+|------|----------|-------|
+| `chatgpt.com` | ChatGPT | DOM adapter for conversation thread |
+| `claude.ai` | Claude (web) | DOM adapter for chat messages |
+
+The extension only captures content from supported pages. On unsupported
+pages the badge shows grey and no data is sent.
+
+## Health & Privacy
+
+- **Receiver reachable**: badge is green when the local receiver is up
+- **Site supported**: badge shows a document icon when the current page is a known LLM site
+- **Last capture**: popup shows the timestamp and provider of the most recent capture
+- **Offline**: badge turns red when the receiver is down
+- **No background collection**: the extension only reads the DOM when you are actively on a supported page
+- **Local only**: content is posted to `127.0.0.1:8765` and never leaves your machine
+- **Privacy diagnostics**: the popup shows capture counts and timestamps, never message content
+
+## Troubleshooting
+
+| Symptom | Check |
+|---------|-------|
+| Badge is grey | Navigate to a supported page (chatgpt.com or claude.ai) |
+| Badge is red | Receiver is not running — start `polylogue browser-capture serve` |
+| Captures not appearing in archive | Run `polylogue check` to verify the daemon is ingesting |
+| "Failed to load extension" in Chrome | Ensure you selected the `browser-extension/` directory (not `src/`) |
+| Extension not updating | Go to `chrome://extensions`, click the refresh icon on the extension card |
+
+## Architecture
+
+```
+Browser (ChatGPT/Claude DOM)
+    │
+    │  content script reads the DOM
+    ▼
+Extension popup / background
+    │
+    │  HTTP POST to 127.0.0.1:8765
+    ▼
+polylogue browser-capture serve (Python)
+    │
+    │  writes to archive inbox
+    ▼
+polylogued daemon → ingests → FTS index
+```
 
 ## Development
 
-Install dependencies:
-
 ```bash
 npm install
-```
-
-### Tests
-
-```bash
-npm test              # single run (vitest)
+npm test              # vitest
 npm run test:watch    # watch mode
+npm run lint          # eslint
 ```
 
-### Lint
-
-```bash
-npm run lint          # eslint on src/ and tests/
-```
+Tests run against deterministic fixture HTML, not live ChatGPT/Claude pages.
+The receiver contract test verifies envelope compatibility with
+`polylogue/browser_capture/models.py`.

--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -123,7 +123,7 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
     CommandSpec(
         "render-pages",
         "generated surfaces",
-        "Build the GitHub Pages documentation site into _site/.",
+        "Build the GitHub Pages documentation site into .cache/site/.",
         "devtools.render_pages",
         use_when="Build or verify the full GitHub Pages documentation site after changing docs, templates, or design docs.",
         examples=("devtools render-pages", "devtools render-pages --check", "devtools render-pages --serve"),

--- a/devtools/docs_surface.py
+++ b/devtools/docs_surface.py
@@ -24,7 +24,27 @@ DOCS_REFERENCE_ENTRIES: tuple[DocsEntry, ...] = (
     DocsEntry("Library API", "docs/library-api.md", "Async archive API, filters, and query patterns."),
     DocsEntry("Data Model", "docs/data-model.md", "Archive entities, storage shape, and metadata rules."),
     DocsEntry("Configuration", "docs/configuration.md", "XDG paths, environment variables, and runtime configuration."),
+    DocsEntry(
+        "Daemon Threat Model",
+        "docs/daemon-threat-model.md",
+        "Local API threat model — assets, threats, mitigations, and API roles.",
+    ),
+    DocsEntry(
+        "Repository Layout",
+        "docs/repo-layout.md",
+        "Every top-level entry and its purpose.",
+    ),
     DocsEntry("Architecture", "docs/architecture.md", "System rings, ownership boundaries, and data flow."),
+    DocsEntry(
+        "Architecture Spine",
+        "docs/architecture-spine.md",
+        "Target shape, guardrails, and major decisions with rejected alternatives.",
+    ),
+    DocsEntry(
+        "Execution Plan",
+        "docs/execution-plan.md",
+        "Living sequencing plan — landed, in flight, queued, and frozen subsystems.",
+    ),
     DocsEntry("Internals", "docs/internals.md", "Working implementation reference and debugging landmarks."),
     DocsEntry("MCP Integration", "docs/mcp-integration.md", "Model Context Protocol server setup and usage."),
     DocsEntry(

--- a/devtools/generated_surfaces.py
+++ b/devtools/generated_surfaces.py
@@ -82,7 +82,7 @@ GENERATED_SURFACES: tuple[GeneratedSurface, ...] = (
     GeneratedSurface(
         name="pages",
         label="GitHub Pages",
-        description="Build the GitHub Pages documentation site into _site/.",
+        description="Build the GitHub Pages documentation site into .cache/site/.",
         command=control_plane_argv("render-pages"),
         main=render_pages.main,
     ),

--- a/devtools/pages_builder.py
+++ b/devtools/pages_builder.py
@@ -119,7 +119,7 @@ def build_site(config_path: Path | None = None, output_dir: Path | None = None) 
     if config_path is None:
         config_path = ROOT / "pages.toml"
     if output_dir is None:
-        output_dir = ROOT / "_site"
+        output_dir = ROOT / ".cache" / "site"
 
     config = load_pages_config(config_path)
     env = _build_env()

--- a/devtools/render_pages.py
+++ b/devtools/render_pages.py
@@ -1,12 +1,12 @@
 """Orchestrate the GitHub Pages documentation build.
 
 Reads pages.toml, calls feeder render commands, assembles output
-through Jinja2 templates, runs Pagefind, writes _site/.
+through Jinja2 templates, runs Pagefind, writes .cache/site/.
 
 Usage:
-    devtools render-pages              Build _site/
+    devtools render-pages              Build .cache/site/
     devtools render-pages --serve      Build and serve locally
-    devtools render-pages --check      Verify _site/ matches sources
+    devtools render-pages --check      Verify .cache/site/ matches sources
     devtools render-pages --watch      Rebuild on source changes
 """
 
@@ -29,12 +29,12 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--serve",
         action="store_true",
-        help="Serve _site/ on localhost:8080 after building.",
+        help="Serve .cache/site/ on localhost:8080 after building.",
     )
     parser.add_argument(
         "--check",
         action="store_true",
-        help="Verify _site/ is in sync with sources (exit non-zero on drift).",
+        help="Verify .cache/site/ is in sync with sources (exit non-zero on drift).",
     )
     parser.add_argument(
         "--watch",

--- a/docs/architecture-spine.md
+++ b/docs/architecture-spine.md
@@ -1,0 +1,71 @@
+# Architecture Spine
+
+Target shape, guardrails, and major decisions for the Polylogue codebase.
+This is the canonical architectural anchor — `docs/architecture.md` evolves
+with the implementation; this document records the *why* and the *rules*.
+
+## Four Rings
+
+| Ring | Role | Primary modules |
+|------|------|-----------------|
+| **Archive Substrate** | Owns stored meaning: acquisition, parsing, persistence, query | `sources/`, `pipeline/`, `storage/`, `archive/`, `operations/` |
+| **Derived Read Models** | Stored insights computed over the archive | `insights/`, `storage/insights/session/` |
+| **Surfaces** | Expose the archive to users and machines | `cli/`, `mcp/`, `api/`, `rendering/`, `ui/`, `daemon/` |
+| **Verification** | Schema, showcase, devtools, tests | `schemas/`, `showcase/`, `proof/`, `devtools/`, `tests/` |
+
+**Rules:**
+- New semantics go into substrate or insights first, then surfaces adapt.
+- Surfaces may not import substrate internals directly (enforced by `devtools verify-layering`).
+- Archive writes are idempotent by content hash.
+
+## Guardrails
+
+Every `docs/plans/*.yaml` manifest is enforced by a lint in `devtools verify`.
+
+| Manifest | Lint | What it prevents |
+|----------|------|-----------------|
+| `layering.yaml` | `verify-layering` | Surface-to-substrate coupling |
+| `topology-target.yaml` | `verify-topology` | Orphaned/unclassified modules |
+| `file-size-budgets.yaml` | `verify-file-budgets` | Unbounded file growth |
+| `test-ownership.yaml` | `verify-test-ownership` | Untested production modules |
+| `suppressions.yaml` | `verify-suppressions` | Stale suppressions |
+| `campaign-coverage.yaml` | `verify-manifests` | Missing campaign declarations |
+| `migrations.yaml` | `verify-migrations` | Incomplete migration records |
+| `coverage-manifest.yaml` | `verify-manifests` | Stale gap/coverage declarations |
+
+## Major Decisions
+
+### Schema versioning: fresh-first, no migration chains
+- **Chosen**: `SCHEMA_VERSION` constant is the authority. Mismatch = rejected. Explicit reviewed in-place upgrade scripts for transitions.
+- **Rejected**: Alembic/migration chains — complexity, partial state risk, forward/reverse migration burden.
+- **Constraint**: Single SQLite file, WAL mode, operator owns the upgrade.
+
+### Content hash: idempotent by SHA-256 over NFC-normalized payload
+- **Chosen**: Hash over title, timestamps, messages, attachments, content blocks. Excludes user metadata (tags, summaries, notes).
+- **Rejected**: UUID-based identity — breaks idempotency on re-ingest.
+- **Constraint**: User metadata edits must not trigger re-import.
+
+### FTS5: unicode61 tokenizer, no porter stemmer
+- **Chosen**: `unicode61` tokenizer. Triggers on messages table with suspend/resume during bulk ops.
+- **Rejected**: Porter stemmer — not compiled in this SQLite build.
+- **Constraint**: FTS triggers must survive SIGKILL (startup repair check).
+
+### Blob store: content-addressed with SHA-256 prefix sharding
+- **Chosen**: 256 subdirectories (`blob/00/` through `blob/ff/`), write-once, read-many.
+- **Rejected**: Path-based storage — no automatic dedup.
+- **Constraint**: Link counting for GC, unreferenced blobs need explicit cleanup.
+
+### Daemon convergence: explicit stages, no implicit migration
+- **Chosen**: Daemon runs named convergence stages (FTS repair, insight refresh, embedding) on a schedule.
+- **Rejected**: Event-driven cascade — harder to reason about, harder to test.
+- **Constraint**: Local HTTP API is read-only by default; write/mutation requires explicit role.
+
+### MCP server: read/write/admin role split
+- **Chosen**: Three MCP roles. Read tools always available. Write tools require `--role write`. Admin tools require `--role admin`.
+- **Rejected**: Single unrestricted MCP server — unsafe for automated agent use.
+- **Constraint**: `polylogue-mcp` CLI entry point with `--role` flag.
+
+### Browser capture: unpacked extension + local receiver
+- **Chosen**: MV3 Chrome extension captures DOM, posts to local Python receiver, receiver writes to archive.
+- **Rejected**: Cloud-based capture, headless automation — Cloudflare friction on Claude.ai, privacy concerns.
+- **Constraint**: Extension is opt-in per-site; no background capture.

--- a/docs/daemon-threat-model.md
+++ b/docs/daemon-threat-model.md
@@ -1,0 +1,70 @@
+# Daemon Threat Model
+
+The Polylogue daemon (`polylogued`) is a local-first HTTP server that
+serves the archive read API and ingests from the local filesystem.
+
+## Trust Boundary
+
+The daemon binds to `127.0.0.1` only. All requests originate from the
+same machine. There is no network exposure, no TLS, and no authentication
+beyond loopback binding.
+
+## Assets
+
+| Asset | Sensitivity | Exposure |
+|-------|------------|----------|
+| Conversation content (messages, titles, timestamps) | High — personal AI chat history | Read API |
+| User metadata (tags, summaries, notes) | Medium — user-curated | Read + Write API |
+| Session identity (provider, dates, durations) | Low — operational metadata | Read API |
+| Raw artifacts (JSONL payloads) | High — contains full session data | Filesystem only |
+
+## Threats
+
+### Local process reading the API
+- **Risk**: Any process on the machine can `curl http://127.0.0.1:8765/api/...`
+- **Mitigation**: Loopback binding limits exposure to the local machine. This is the same trust model as `localhost` databases, dev servers, and CLI tools.
+- **Residual**: Processes running as the same user can read the SQLite archive directly anyway.
+
+### Extension posting forged captures
+- **Risk**: A malicious browser extension or page could POST to the receiver
+- **Mitigation**: Receiver validates envelope shape and source origin. Only supported provider DOM adapters produce valid captures.
+- **Residual**: Local browser extensions have the same trust as the user's browser profile.
+
+### Daemon process compromise
+- **Risk**: If the daemon binary or its dependencies are compromised
+- **Mitigation**: Nix-supplied dependencies with known hashes. No dynamic code loading.
+- **Residual**: Supply-chain risk is inherited from the Nix/NixOS package closure.
+
+### Archive file tampering
+- **Risk**: Another process modifies the SQLite database or blob store
+- **Mitigation**: SQLite WAL mode provides crash safety, not access control. File permissions are the boundary.
+- **Residual**: Same-user processes can modify the archive. This is inherent to local-first tools.
+
+## Non-Threats
+
+These are explicitly out of scope for the daemon threat model:
+
+- **Multi-user access**: Polylogue is a single-user tool. There is no user isolation.
+- **Network exposure**: The daemon does not bind to `0.0.0.0` or non-loopback interfaces.
+- **Encryption at rest**: Archive content is stored as plaintext SQLite. Disk encryption is the OS's responsibility.
+- **Authentication**: Loopback-only binding is the authentication mechanism. No tokens, no passwords.
+
+## API Roles
+
+The daemon HTTP API is **read-only by default**. Write operations (tags,
+metadata mutations, deletes) require explicit opt-in via the MCP server's
+`--role write` flag and are not exposed through the daemon HTTP surface.
+
+The MCP server has three roles:
+
+| Role | Capabilities |
+|------|-------------|
+| `read` | Query, search, list, get, stats, insights — all safe operations |
+| `write` | Tag management, metadata mutations, conversation deletion |
+| `admin` | Maintenance operations, index rebuilds, insight refresh |
+
+## Future Considerations
+
+- **Unix socket**: Could replace loopback TCP for stronger access control (file permissions on the socket).
+- **Read-only mode**: Could open the SQLite database in read-only mode for the HTTP API, with a separate write connection for ingest.
+- **Secrets in conversations**: API keys and tokens that appear in conversation text are stored as-is. A future redaction layer could strip these.

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -87,7 +87,7 @@ These are the commands worth remembering during normal repo work:
 | `devtools render-cli-reference` | Render docs/cli-reference.md from live CLI help. |
 | `devtools render-devtools-reference` | Render the command catalog inside docs/devtools.md. |
 | `devtools render-docs-surface` | Render docs/README.md and the README documentation table. |
-| `devtools render-pages` | Build the GitHub Pages documentation site into _site/. |
+| `devtools render-pages` | Build the GitHub Pages documentation site into .cache/site/. |
 | `devtools render-quality-reference` | Render docs/test-quality-workflows.md from live validation, mutation, and benchmark registries. |
 | `devtools render-readme-media` | Generate README media assets (architecture diagrams, flowcharts) under docs/media/. |
 | `devtools render-topology-status` | Render docs/topology-status.md from the topology projection and realized tree. |

--- a/docs/execution-plan.md
+++ b/docs/execution-plan.md
@@ -1,0 +1,51 @@
+# Execution Plan
+
+Living sequencing plan for Polylogue subsystem maturation.
+Updated per-PR. See `docs/architecture-spine.md` for the target shape.
+
+## Landed
+
+| Subsystem | Status | Closed by |
+|-----------|--------|-----------|
+| Archive substrate (acquisition, parsing, persistence, FTS, blob store) | Done | Multiple PRs |
+| Content hash idempotency | Done | #838, #421 |
+| Session insights (profiles, work events, phases, threads) | Done | Multiple PRs |
+| Cost/subscription tracking and outlook | Done | #938, #943 |
+| Daemon convergence (named stages) | Done | Multiple PRs |
+| Browser extension + receiver | Done | #937, #940 |
+| Identity ledger (stable IDs across re-ingestion) | Done | #775, #963 |
+| MCP server (35+ tools, read/write/admin roles) | Done | Multiple PRs |
+| CLI context-pack | Done | #968 |
+| Paste detection | Done | #947, #966 |
+| Root artifact cleanup | Done | #954, #966 |
+| Verification baseline (format, lint, mypy, topology, manifests) | Done | #944 |
+| Type tightening (SubjectRef.kind enum) | Done | #421, #968 |
+| CLI mutation flags (--add-tag/--remove-tag) | Done | #862, #967 |
+| Manifest-only conversation prevention | Done | #945 |
+| MCP error sanitization and metadata validation | Done | #948 |
+| CLI format matrix coverage | Done | #949 |
+
+## In Flight
+
+| Substream | Blocked by | Next artifact |
+|-----------|-----------|---------------|
+| Embedding pipeline activation (#828) | VOYAGE_API_KEY + daemon opt-in | Daemon-owned post-ingest embedding convergence |
+| Web reader realtime (#957) | — | SSE streaming channel from daemon to reader |
+
+## Queued
+
+Dependency order (items in each tier are parallelizable):
+
+1. **Storage hardening**: blob GC (#818), FTS bloat reduction (#817), daemon safety (#771)
+2. **Archive semantics**: context/protocol artifact storage (#839), provider_meta graduation (#864)
+3. **Read surfaces**: search explainability (#873), reader marks (#867), session lineage (#866)
+4. **Operational surfaces**: daemon validation failure visibility (#844), maintenance planner (#871), read-surface SLOs (#872)
+5. **Verification depth**: systematic test architecture (#807), structural simplification (#805)
+6. **Product polish**: CLI polish (#958), docs revamp (#952), broad distribution (#953)
+
+## Frozen / Parked
+
+| Subsystem | Freeze reason | Unfreeze condition |
+|-----------|--------------|-------------------|
+| TUI dashboard | Lower priority than web reader | Web reader reaches stable MK2 |
+| Site publication | Lower priority than web reader | Reader docs completion |

--- a/docs/repo-layout.md
+++ b/docs/repo-layout.md
@@ -1,0 +1,40 @@
+# Repository Layout
+
+Every top-level entry has a reason.
+
+| Entry | Purpose | Managed by |
+|-------|---------|------------|
+| `.agent/` | Project-local agent scratch and task history | agents |
+| `.cache/` | Disposable caches (hypothesis, pytest, mypy, ruff, site) | tools |
+| `.claude/` | Claude Code project config (commands, agents, skills) | user |
+| `.coderabbit.yaml` | CodeRabbit review bot configuration | repo |
+| `.direnv/` | direnv layout (devshell activation) | direnv |
+| `.envrc` | direnv entry point (`nix develop`) | repo |
+| `.git/` | Git repository data | git |
+| `.gitattributes` | Git attribute overrides | repo |
+| `.githooks/` | Git hooks (format, lint, quick verify) | repo |
+| `.github/` | GitHub Actions workflows and templates | repo |
+| `.gitignore` | Git ignore rules | repo |
+| `.local/` | Untracked local outputs (campaigns, showcases, build artifacts) | tools |
+| `.venv/` | Python virtual environment (uv) | uv |
+| `AGENTS.md` | Generated agent instructions from CLAUDE.md | devshell |
+| `CHANGELOG.md` | Release changelog | repo |
+| `CLAUDE.md` | Primary project instructions | repo |
+| `CONTRIBUTING.md` | Contribution workflow and conventions | repo |
+| `LICENSE` | Project license | repo |
+| `README.md` | Project readme | repo |
+| `TESTING.md` | Test suite documentation | repo |
+| `browser-extension/` | Chrome MV3 browser capture extension | repo |
+| `contrib/` | Community-contributed integrations | repo |
+| `devtools/` | Developer tooling (verify, render, campaigns) | repo |
+| `docs/` | Architecture, internals, plans, design documents | repo |
+| `flake.lock` | Nix flake lockfile (pinned dependencies) | nix |
+| `flake.nix` | Nix flake definition (devshell, package, checks) | repo |
+| `hatch_build.py` | Hatchling build hook (version injection) | build system |
+| `nix/` | Nix packaging expressions | repo |
+| `pages.toml` | GitHub Pages site configuration | build system |
+| `polylogue/` | Application source code | repo |
+| `pyproject.toml` | Python project metadata and tool config | repo |
+| `systemd/` | Systemd service units for daemon | repo |
+| `tests/` | Test suite | repo |
+| `uv.lock` | uv dependency lockfile | uv |

--- a/polylogue/mcp/server_mutation_tools.py
+++ b/polylogue/mcp/server_mutation_tools.py
@@ -117,6 +117,20 @@ def register_mutation_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
     @mcp.tool()
     async def set_metadata(conversation_id: str, key: str, value: str) -> str:
         async def run() -> str:
+            # Validate metadata key
+            if not key or not key.strip():
+                return hooks.error_json(
+                    "metadata key must not be empty",
+                    conversation_id=conversation_id,
+                    code="invalid_key",
+                )
+            if len(key) > 200:
+                return hooks.error_json(
+                    "metadata key exceeds 200 characters",
+                    conversation_id=conversation_id,
+                    code="invalid_key",
+                )
+
             resolved, err = await _resolve_or_error(hooks, conversation_id)
             if err:
                 return err

--- a/polylogue/mcp/server_support.py
+++ b/polylogue/mcp/server_support.py
@@ -136,14 +136,19 @@ def _safe_call(fn_name: str, fn: Callable[[], TResult]) -> TResult | str: ...
 
 
 def _safe_call(fn_name: str, fn: Callable[[], TResult]) -> TResult | str:
-    """Call fn() and return its result. Raises on error so FastMCP sets isError=True."""
+    """Call fn() and return its result. Raises on error so FastMCP sets isError=True.
+
+    Unexpected exceptions are logged server-side but sanitised before
+    reaching the MCP client — the raised error exposes only the exception
+    type, not the raw message or traceback.
+    """
     try:
         return fn()
     except PolylogueError:
         raise
     except Exception as exc:
         logger.exception("MCP tool %s failed", fn_name)
-        raise PolylogueError(f"{fn_name}: {type(exc).__name__}: {exc}") from exc
+        raise PolylogueError(f"{fn_name}: internal error ({type(exc).__name__})") from exc
 
 
 @overload
@@ -159,14 +164,18 @@ async def _async_safe_call(fn_name: str, fn: Callable[[], Awaitable[TResult]]) -
 
 
 async def _async_safe_call(fn_name: str, fn: Callable[[], Awaitable[TResult]]) -> TResult | str:
-    """Async version of _safe_call. Raises on error so FastMCP sets isError=True."""
+    """Async version of _safe_call. Raises on error so FastMCP sets isError=True.
+
+    Unexpected exceptions are logged server-side but sanitised before
+    reaching the MCP client.
+    """
     try:
         return await fn()
     except PolylogueError:
         raise
     except Exception as exc:
         logger.exception("MCP tool %s failed", fn_name)
-        raise PolylogueError(f"{fn_name}: {type(exc).__name__}: {exc}") from exc
+        raise PolylogueError(f"{fn_name}: internal error ({type(exc).__name__})") from exc
 
 
 def _error_json(message: str, **extra: object) -> str:

--- a/polylogue/pipeline/services/ingest_batch/_core.py
+++ b/polylogue/pipeline/services/ingest_batch/_core.py
@@ -477,6 +477,14 @@ def _write_conversation(
         counts["skipped_provider_events"] = len(cdata.provider_event_tuples)
         return False, counts
 
+    # Guard against manifest-only conversation rows: a new conversation with
+    # zero messages likely came from an interrupted bulk import that registered
+    # the ID before message ingestion completed. Skip it rather than leaving a
+    # row that has message_count=0, work_event_count=0, substantive_count=0.
+    if existing_row is None and not cdata.message_tuples and not force_write:
+        counts["skipped_conversations"] = 1
+        return False, counts
+
     conn.execute(_CONVERSATION_UPSERT_SQL, _resolved_conversation_tuple(conn, cdata))
 
     affected_attachment_ids: set[str] = set()

--- a/polylogue/rendering/renderers/html_sanitizer.py
+++ b/polylogue/rendering/renderers/html_sanitizer.py
@@ -1,42 +1,119 @@
 """HTML sanitization filter for Jinja2 templates.
 
 Provides a ``sanitize_html`` filter that strips dangerous constructs
-(``<script>``, event handler attributes, ``javascript:`` URLs) from
-pre-rendered HTML while preserving safe markup. Intended as a
-defense-in-depth replacement for ``| safe`` in conversation templates.
+(``<script>``, event handler attributes, ``javascript:`` URLs, embedded
+frames, raw SVG/MathML interactivity) from pre-rendered HTML while
+preserving safe markup. Intended as a defense-in-depth replacement for
+``| safe`` in conversation templates.
+
+Backed by ``nh3`` (Rust ``ammonia`` bindings), an HTML5 parser-based
+sanitizer that is robust against the regex bypass classes the prior
+implementation suffered from:
+
+* unquoted event-handler attributes (``<a onclick=alert(1)>``)
+* ``javascript:`` and ``data:`` URIs on any URL-bearing attribute
+* ``<iframe>``/``<object>``/``<embed>`` element injection
+* ``<svg>``/``<math>`` interactivity (event handlers, foreign content)
 """
 
 from __future__ import annotations
 
-import re
+from typing import Final
 
+import nh3
 from markupsafe import Markup
 
-# Closing tag tolerates whitespace AND attribute-like junk before ``>``.
-# Real browsers accept ``</script bar>``, ``</script\t\n>``, etc., even
-# though strict HTML5 forbids them. Match ``</script\s*[^>]*>`` so end
-# tags with whitespace, tabs, newlines, or trailing junk-attributes are
-# all stripped — the previous strict ``</script>`` literal allowed each
-# of those as a sanitizer bypass.
-#
-# Note: regex sanitization is defense-in-depth here; templates already
-# Jinja-autoescape. A proper HTML parser (``bleach``) would be sturdier
-# but is overkill for this filter's role.
-_SCRIPT_RE = re.compile(r"<script[\s>].*?</script\s*[^>]*>", re.IGNORECASE | re.DOTALL)
-_EVENT_ATTR_RE = re.compile(r"\s+on\w+\s*=\s*[\"'][^\"']*[\"']", re.IGNORECASE)
-_JAVASCRIPT_URL_RE = re.compile(r"""href\s*=\s*["']javascript:[^"']*["']""", re.IGNORECASE)
+# Conservative allowlist: structural and inline text formatting tags only.
+# Excludes form, media, object, frame, svg, math, script, and style tags.
+_ALLOWED_TAGS: Final[frozenset[str]] = frozenset(
+    {
+        "a",
+        "abbr",
+        "b",
+        "blockquote",
+        "br",
+        "cite",
+        "code",
+        "dd",
+        "del",
+        "details",
+        "div",
+        "dl",
+        "dt",
+        "em",
+        "h1",
+        "h2",
+        "h3",
+        "h4",
+        "h5",
+        "h6",
+        "hr",
+        "i",
+        "ins",
+        "kbd",
+        "li",
+        "mark",
+        "ol",
+        "p",
+        "pre",
+        "q",
+        "s",
+        "samp",
+        "small",
+        "span",
+        "strong",
+        "sub",
+        "summary",
+        "sup",
+        "table",
+        "tbody",
+        "td",
+        "th",
+        "thead",
+        "tr",
+        "u",
+        "ul",
+        "var",
+    }
+)
+
+# Per-tag attribute allowlist. ``href`` only on ``<a>``; ``class``/``id``
+# everywhere for renderer-driven styling. Event handlers (``on*``) are
+# not in any allowlist and so are stripped by the parser.
+_ALLOWED_ATTRIBUTES: Final[dict[str, set[str]]] = {
+    "*": {"class", "id", "title", "lang", "dir"},
+    "a": {"href"},
+    "abbr": {"title"},
+    "ol": {"start", "type"},
+    "ul": {"type"},
+    "td": {"colspan", "rowspan"},
+    "th": {"colspan", "rowspan", "scope"},
+}
+
+# URL schemes permitted on URL-bearing attributes (currently only
+# ``href`` on ``<a>``). ``javascript:`` and ``data:`` are intentionally
+# absent so they are stripped.
+_ALLOWED_URL_SCHEMES: Final[frozenset[str]] = frozenset({"http", "https", "mailto"})
 
 
 def sanitize_html(html: str) -> Markup:
     """Strip dangerous constructs from pre-rendered HTML.
 
     Removes ``<script>`` tags, event handler attributes (``onclick``,
-    ``onload``, etc.), and ``javascript:`` URLs. Returns a ``Markup``
-    object so Jinja2 autoescaping treats the result as safe HTML.
+    ``onload``, ``onerror`` — including unquoted variants), URL schemes
+    other than ``http``/``https``/``mailto`` (so ``javascript:`` and
+    ``data:`` URIs are dropped from any attribute), and frame/object
+    embedding tags. Returns a ``Markup`` object so Jinja2 autoescaping
+    treats the result as safe HTML.
     """
     if not html:
         return Markup("")
-    sanitized = _SCRIPT_RE.sub("", html)
-    sanitized = _EVENT_ATTR_RE.sub("", sanitized)
-    sanitized = _JAVASCRIPT_URL_RE.sub("", sanitized)
+    sanitized = nh3.clean(
+        html,
+        tags=_ALLOWED_TAGS,
+        attributes=_ALLOWED_ATTRIBUTES,
+        generic_attribute_prefixes={"data-", "aria-"},
+        url_schemes=_ALLOWED_URL_SCHEMES,
+        link_rel="noopener noreferrer",
+    )
     return Markup(sanitized)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dependencies = [
   "pyyaml>=6.0",  # YAML output format
   "typing-extensions>=4.7",  # TypedDict that pydantic accepts on Py<3.12
   "watchfiles>=0.21",  # Rust-backed filesystem watcher for live ingestion
+  "nh3>=0.2.18",  # Rust-backed HTML sanitizer (ammonia bindings) for defense-in-depth
   # Transitive constraints to avoid known CVEs surfaced by pip-audit:
   "cryptography>=48.0.0",  # CVE-2026-39892 (transitive via google-auth)
   "python-multipart>=0.0.27",  # CVE-2026-40347 (transitive via mcp)

--- a/tests/unit/cli/test_deterministic_output.py
+++ b/tests/unit/cli/test_deterministic_output.py
@@ -282,10 +282,11 @@ class TestJsonEnvelopeParametrized:
     @pytest.mark.parametrize(
         "cmd_args,result_key",
         [
-            (["doctor", "--format", "json"], None),  # result has checks, summary, timestamp
-            (["tags", "--format", "json"], "tags"),  # result has tags
+            (["doctor", "--format", "json"], None),
+            (["tags", "--format", "json"], "tags"),
+            (["neighbors", "--format", "json", "--query", "test"], "neighbors"),
         ],
-        ids=["doctor", "tags"],
+        ids=["doctor", "tags", "neighbors"],
     )
     def test_json_envelope_shape(
         self: object,
@@ -311,8 +312,9 @@ class TestJsonEnvelopeParametrized:
         [
             ["doctor", "--format", "json"],
             ["tags", "--format", "json"],
+            ["neighbors", "--format", "json", "--query", "test"],
         ],
-        ids=["doctor", "tags"],
+        ids=["doctor", "tags", "neighbors"],
     )
     def test_json_output_no_ansi(
         self: object,
@@ -347,6 +349,26 @@ class TestJsonEnvelopeParametrized:
         # Round-trip through json.dumps/loads must be lossless
         round_tripped = json.loads(json.dumps(parsed))
         assert round_tripped == parsed
+
+    @pytest.mark.parametrize(
+        "cmd_args,expected_error",
+        [
+            (["tags", "--format", "yaml"], "Invalid value for '--format'"),
+            (["neighbors", "--format", "markdown", "--query", "test"], "Invalid value for '--format'"),
+        ],
+        ids=["tags-yaml-rejected", "neighbors-markdown-rejected"],
+    )
+    def test_json_only_commands_reject_other_formats(
+        self: object,
+        cli_workspace: dict[str, Path],
+        cmd_args: list[str],
+        expected_error: str,
+    ) -> None:
+        """JSON-only commands (tags, neighbors) reject non-json formats with a clear Click error."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--plain", *cmd_args], catch_exceptions=False)
+        assert result.exit_code != 0
+        assert expected_error in result.output
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/mcp/test_mcp_edge_cases.py
+++ b/tests/unit/mcp/test_mcp_edge_cases.py
@@ -62,7 +62,7 @@ class TestSafeCall:
 
         from polylogue.errors import PolylogueError
 
-        with pytest.raises(PolylogueError, match="test_tool.*RuntimeError"):
+        with pytest.raises(PolylogueError, match="test_tool.*internal error"):
             _safe_call("test_tool", failing)
 
     def test_traceback_not_in_output(self) -> None:
@@ -74,6 +74,23 @@ class TestSafeCall:
         with pytest.raises(PolylogueError) as exc:
             _safe_call("test_tool", failing)
         assert "Traceback" not in str(exc.value)
+
+    def test_raw_exception_text_not_leaked(self) -> None:
+        """Exception message content is not exposed to MCP clients."""
+
+        def failing() -> None:
+            raise RuntimeError("secret connection string postgresql://admin:hunter2@db.internal")
+
+        from polylogue.errors import PolylogueError
+
+        with pytest.raises(PolylogueError) as exc:
+            _safe_call("test_tool", failing)
+        error_text = str(exc.value)
+        assert "secret" not in error_text
+        assert "hunter2" not in error_text
+        assert "admin" not in error_text
+        assert "internal error" in error_text
+        assert "RuntimeError" in error_text
 
 
 # =============================================================================

--- a/tests/unit/mcp/test_tool_contracts.py
+++ b/tests/unit/mcp/test_tool_contracts.py
@@ -424,7 +424,7 @@ class TestQueryTools:
             mock_ops.search_conversation_hits = AsyncMock(return_value=[])
             mock_get_archive_ops.return_value = mock_ops
 
-            with pytest.raises(PolylogueError, match="search: ValueError"):
+            with pytest.raises(PolylogueError, match="search: internal error"):
                 await invoke_surface_async(
                     mcp_server._tool_manager._tools["search"].fn,
                     query="hello",
@@ -565,7 +565,7 @@ class TestGetConversationTool:
             mock_poly = make_polylogue_mock()
             mock_get_polylogue.return_value = mock_poly
 
-            with pytest.raises(PolylogueError, match="get_messages: ValueError"):
+            with pytest.raises(PolylogueError, match="get_messages: internal error"):
                 invoke_surface(
                     mcp_server._tool_manager._tools["get_messages"].fn,
                     conversation_id="test:long",
@@ -981,7 +981,7 @@ class TestMutationTools:
             mock_get_polylogue.return_value = mock_poly
             mock_get_query_store.return_value = make_query_store_mock(resolved_id="test:conv-123")
 
-            with pytest.raises(PolylogueError, match="add_tag: ValueError"):
+            with pytest.raises(PolylogueError, match="add_tag: internal error"):
                 invoke_surface(
                     mcp_server._tool_manager._tools["add_tag"].fn, conversation_id="test:conv-123", tag="invalid"
                 )
@@ -1018,7 +1018,7 @@ class TestMutationTools:
             mock_get_polylogue.return_value = mock_poly
             mock_get_query_store.return_value = make_query_store_mock(resolved_id="test:conv-123")
 
-            with pytest.raises(PolylogueError, match="remove_tag: RuntimeError"):
+            with pytest.raises(PolylogueError, match="remove_tag: internal error"):
                 invoke_surface(
                     mcp_server._tool_manager._tools["remove_tag"].fn,
                     conversation_id="test:conv-123",
@@ -1129,6 +1129,42 @@ class TestMutationTools:
 
         assert json.loads(result)["status"] == "ok"
         mock_poly.update_metadata.assert_called_once_with("test:conv-123", "config", "{'nested': True}")
+
+    def test_set_metadata_rejects_empty_key(self, mcp_server: MCPServerUnderTest) -> None:
+        """Empty metadata key returns structured error, not exception."""
+        result = invoke_surface(
+            mcp_server._tool_manager._tools["set_metadata"].fn,
+            conversation_id="test:conv-123",
+            key="",
+            value="some value",
+        )
+        parsed = json.loads(result)
+        assert parsed["is_error"] is True
+        assert "empty" in parsed["error"].lower()
+
+    def test_set_metadata_rejects_whitespace_key(self, mcp_server: MCPServerUnderTest) -> None:
+        """Whitespace-only metadata key returns structured error."""
+        result = invoke_surface(
+            mcp_server._tool_manager._tools["set_metadata"].fn,
+            conversation_id="test:conv-123",
+            key="   ",
+            value="some value",
+        )
+        parsed = json.loads(result)
+        assert parsed["is_error"] is True
+        assert "empty" in parsed["error"].lower()
+
+    def test_set_metadata_rejects_overlong_key(self, mcp_server: MCPServerUnderTest) -> None:
+        """Metadata key exceeding 200 characters returns structured error."""
+        result = invoke_surface(
+            mcp_server._tool_manager._tools["set_metadata"].fn,
+            conversation_id="test:conv-123",
+            key="k" * 201,
+            value="v",
+        )
+        parsed = json.loads(result)
+        assert parsed["is_error"] is True
+        assert "200" in parsed["error"]
 
     def test_delete_metadata_success(self, mcp_server: MCPServerUnderTest) -> None:
         with (

--- a/tests/unit/pipeline/test_ingest_batch.py
+++ b/tests/unit/pipeline/test_ingest_batch.py
@@ -296,10 +296,19 @@ def test_topo_sort_conversation_entries_orders_parent_before_child() -> None:
 
 def test_write_conversation_clears_missing_parent_fk(tmp_path: Path) -> None:
     with open_connection(tmp_path / "ingest.db") as conn:
+        c_msg = _message_tuple(
+            "msg-c",
+            "codex:child",
+            role="user",
+            text="hello",
+            content_hash="hash-c",
+            sort_key=1.0,
+        )
         child = _conversation_data(
             "codex:child",
             content_hash="hash-child",
             parent_conversation_id="codex:missing-parent",
+            message_tuples=[c_msg],
         )
 
         _write_conversation(conn, child)
@@ -315,11 +324,32 @@ def test_write_conversation_clears_missing_parent_fk(tmp_path: Path) -> None:
 
 def test_write_conversation_preserves_existing_parent_fk(tmp_path: Path) -> None:
     with open_connection(tmp_path / "ingest.db") as conn:
-        parent = _conversation_data("codex:parent", content_hash="hash-parent")
+        p_msg = _message_tuple(
+            "msg-p",
+            "codex:parent",
+            role="user",
+            text="parent msg",
+            content_hash="hash-p",
+            sort_key=1.0,
+        )
+        c_msg = _message_tuple(
+            "msg-c",
+            "codex:child",
+            role="user",
+            text="child msg",
+            content_hash="hash-c",
+            sort_key=1.0,
+        )
+        parent = _conversation_data(
+            "codex:parent",
+            content_hash="hash-parent",
+            message_tuples=[p_msg],
+        )
         child = _conversation_data(
             "codex:child",
             content_hash="hash-child",
             parent_conversation_id="codex:parent",
+            message_tuples=[c_msg],
         )
 
         _write_conversation(conn, parent)
@@ -640,6 +670,64 @@ def test_write_conversation_skips_shorter_duplicate_raw_source(tmp_path: Path) -
         assert counts_stale["skipped_conversations"] == 1
         assert [row["text"] for row in messages] == ["first", "second"]
         assert raw_id == "raw-full"
+
+
+def test_write_conversation_skips_new_with_zero_messages(tmp_path: Path) -> None:
+    """A new conversation with zero messages is skipped, not left as a manifest-only row."""
+    with open_connection(tmp_path / "ingest.db") as conn:
+        empty = _conversation_data(
+            "codex:empty-manifest",
+            content_hash="hash-empty",
+            message_tuples=[],
+        )
+        changed, counts = _write_conversation(conn, empty)
+        conn.commit()
+
+        # Verify skipped
+        assert changed is False
+        assert counts["skipped_conversations"] == 1
+
+        # Verify no row was created
+        row = conn.execute(
+            "SELECT conversation_id FROM conversations WHERE conversation_id = ?",
+            ("codex:empty-manifest",),
+        ).fetchone()
+        assert row is None
+
+
+def test_write_conversation_allows_existing_upsert_even_without_messages(tmp_path: Path) -> None:
+    """An existing conversation with a changed hash and zero new messages is still upserted.
+    The guard only blocks *new* conversations from being created without messages.
+    Replacing existing content with empty content is a legitimate content update.
+    """
+    with open_connection(tmp_path / "ingest.db") as conn:
+        msg = _message_tuple(
+            "msg-1",
+            "codex:keep",
+            role="user",
+            text="hello",
+            content_hash="hash-msg",
+            sort_key=1.0,
+        )
+        first = _conversation_data(
+            "codex:keep",
+            content_hash="hash-1",
+            message_tuples=[msg],
+        )
+        _write_conversation(conn, first)
+        conn.commit()
+
+        # Same conversation, different hash, zero messages — should be allowed
+        update = _conversation_data(
+            "codex:keep",
+            content_hash="hash-2",
+            message_tuples=[],
+        )
+        changed, counts = _write_conversation(conn, update)
+        conn.commit()
+
+        assert changed is True
+        assert counts["skipped_conversations"] == 0
 
 
 def test_iter_ingest_results_sync_runs_inline_for_single_worker(
@@ -1000,11 +1088,32 @@ def test_select_ingest_worker_count_respects_limit(monkeypatch: pytest.MonkeyPat
 
 def test_drain_ready_conversation_entries_preserves_late_parent_fk(tmp_path: Path) -> None:
     with open_connection(tmp_path / "ingest.db") as conn:
-        parent = _conversation_data("codex:parent", content_hash="hash-parent")
+        p_msg = _message_tuple(
+            "msg-p",
+            "codex:parent",
+            role="user",
+            text="parent",
+            content_hash="hash-p",
+            sort_key=1.0,
+        )
+        c_msg = _message_tuple(
+            "msg-c",
+            "codex:child",
+            role="user",
+            text="child",
+            content_hash="hash-c",
+            sort_key=1.0,
+        )
+        parent = _conversation_data(
+            "codex:parent",
+            content_hash="hash-parent",
+            message_tuples=[p_msg],
+        )
         child = _conversation_data(
             "codex:child",
             content_hash="hash-child",
             parent_conversation_id="codex:parent",
+            message_tuples=[c_msg],
         )
 
         summary = _IngestBatchSummary()

--- a/tests/unit/rendering/test_html_sanitizer_security.py
+++ b/tests/unit/rendering/test_html_sanitizer_security.py
@@ -1,0 +1,123 @@
+"""Security regression tests for the HTML sanitizer (issue #813).
+
+The previous regex-based implementation had documented bypass classes:
+
+* unquoted event-handler attributes (``<a onclick=alert(1)>``) were not
+  matched by ``_EVENT_ATTR_RE`` which required quoted values
+* ``javascript:`` URI guard only applied to ``href``, not ``src``
+* ``data:`` URIs were never stripped
+* ``<iframe>``/``<object>``/``<embed>`` were left intact
+* ``<svg>``/``<math>`` could carry event handlers
+
+Each test below pins one of those bypass classes against the current
+``nh3``-backed sanitizer.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from polylogue.rendering.renderers.html_sanitizer import sanitize_html
+
+
+@pytest.mark.parametrize(
+    "html",
+    [
+        "<a onclick=alert(1)>x</a>",
+        "<a ONCLICK=alert(1)>x</a>",
+        "<img onerror=alert(1) src=x>",
+        "<button onfocus=alert(1) autofocus>x</button>",
+        "<div onmouseover=alert(1)>x</div>",
+    ],
+)
+def test_unquoted_event_handlers_stripped(html: str) -> None:
+    sanitized = str(sanitize_html(html))
+    lowered = sanitized.lower()
+    assert "alert(1)" not in sanitized
+    assert "onclick" not in lowered
+    assert "onerror" not in lowered
+    assert "onfocus" not in lowered
+    assert "onmouseover" not in lowered
+
+
+@pytest.mark.parametrize(
+    "html",
+    [
+        '<a href="data:text/html,<script>alert(1)</script>">x</a>',
+        "<a href=data:text/html,xss>x</a>",
+        '<img src="data:text/html,<script>alert(1)</script>">',
+        '<iframe src="data:text/html,<script>alert(1)</script>"></iframe>',
+    ],
+)
+def test_data_uris_stripped(html: str) -> None:
+    sanitized = str(sanitize_html(html))
+    assert "data:" not in sanitized.lower()
+    assert "alert(1)" not in sanitized
+
+
+@pytest.mark.parametrize(
+    "html",
+    [
+        '<img src="javascript:alert(1)">',
+        "<img src=javascript:alert(1)>",
+        '<a href="javascript:alert(1)">x</a>',
+        "<a href=javascript:alert(1)>x</a>",
+    ],
+)
+def test_javascript_urls_stripped_on_any_attribute(html: str) -> None:
+    sanitized = str(sanitize_html(html))
+    assert "javascript:" not in sanitized.lower()
+    assert "alert(1)" not in sanitized
+
+
+@pytest.mark.parametrize(
+    "html",
+    [
+        '<iframe src="https://evil.example/xss"></iframe>',
+        '<object data="https://evil.example/x.swf"></object>',
+        '<embed src="https://evil.example/x.swf">',
+        '<frame src="https://evil.example">',
+        '<frameset><frame src="x"></frameset>',
+    ],
+)
+def test_frame_and_object_elements_stripped(html: str) -> None:
+    sanitized = str(sanitize_html(html))
+    lowered = sanitized.lower()
+    assert "<iframe" not in lowered
+    assert "<object" not in lowered
+    assert "<embed" not in lowered
+    assert "<frame" not in lowered
+    assert "<frameset" not in lowered
+    assert "evil.example" not in sanitized
+
+
+@pytest.mark.parametrize(
+    "html",
+    [
+        "<svg onload=alert(1)></svg>",
+        "<svg><script>alert(1)</script></svg>",
+        "<math><mtext><script>alert(1)</script></mtext></math>",
+        "<svg><a href=javascript:alert(1)>x</a></svg>",
+    ],
+)
+def test_svg_and_math_neutralized(html: str) -> None:
+    sanitized = str(sanitize_html(html))
+    lowered = sanitized.lower()
+    assert "alert(1)" not in sanitized
+    assert "onload" not in lowered
+    assert "<script" not in lowered
+    assert "javascript:" not in lowered
+    # SVG/MathML are not on the allowlist; their tags should be dropped.
+    assert "<svg" not in lowered
+    assert "<math" not in lowered
+
+
+def test_safe_links_preserved() -> None:
+    sanitized = str(sanitize_html('<a href="https://example.com">x</a>'))
+    assert 'href="https://example.com"' in sanitized
+    assert ">x</a>" in sanitized
+
+
+def test_mailto_links_preserved() -> None:
+    sanitized = str(sanitize_html('<a href="mailto:a@b.com">m</a>'))
+    assert "mailto:a@b.com" in sanitized

--- a/uv.lock
+++ b/uv.lock
@@ -1209,6 +1209,40 @@ wheels = [
 ]
 
 [[package]]
+name = "nh3"
+version = "0.3.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/5f/1d19bdc7d27238e37f3672cdc02cb77c56a4a86d140cd4f4f23c90df6e16/nh3-0.3.5.tar.gz", hash = "sha256:45855e14ff056064fec77133bfcf7cd691838168e5e17bbef075394954dc9dc8", size = 20743, upload-time = "2026-04-25T10:44:16.066Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/b0/8587ac42a9627ab88e7e221601f1dfccbf4db80b2a29222ea63266dc9abc/nh3-0.3.5-cp314-cp314t-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:23a312224875f72cd16bde417f49071451877e29ef646a60e50fcb69407cc18a", size = 1420126, upload-time = "2026-04-25T10:43:39.834Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/1b/1dbc4d0c43f12e8c1784ede17eaee6f061d4fbe5505757c65c49b2ceab95/nh3-0.3.5-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:387abd011e81959d5a35151a11350a0795c6edeb53ebfa02d2e882dc01299263", size = 793943, upload-time = "2026-04-25T10:43:41.363Z" },
+    { url = "https://files.pythonhosted.org/packages/47/9f/d6758d7a14ee964bf439cc35ae4fa24a763a93399c8ef6f22bd11d532d29/nh3-0.3.5-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:48f45e3e914be93a596431aa143dedf1582557bf41a58153c296048d6e3798c9", size = 841150, upload-time = "2026-04-25T10:43:43.007Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/36/d5d1ae8374612c98f390e1ea7c610fa6c9716259a03bbf4d15b269f40073/nh3-0.3.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:0a09f51806fd51b4fedbf9ea2b61fef388f19aef0d62fe51199d41648be14588", size = 1008415, upload-time = "2026-04-25T10:43:44.324Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/8f/d13a9c3fd2d9c131a2a281737380e9379eb0f8c33fea24c2b923aaafbb15/nh3-0.3.5-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:c357f1d042c67f135a5e6babb2b0e3b9d9224ff4a3543240f597767b01384ffd", size = 1092706, upload-time = "2026-04-25T10:43:45.653Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/57/2f3add7f8680fcc896afa6a675cb2bab09982853ee8af40bad621f6b61c4/nh3-0.3.5-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:38748140bf76383ab7ce2dce0ad4cb663855d8fbc9098f7f3483673d09616a17", size = 1048346, upload-time = "2026-04-25T10:43:46.974Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/c3/2f9e4ffa82863074d1361bfe949bc46393d91b3411579dfbbd090b24cac5/nh3-0.3.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:84bdeb082544fbcb77a12c034dd77d7da0556fdc0727b787eb6214b958c15e29", size = 1029038, upload-time = "2026-04-25T10:43:48.569Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/10/2804deb3f3315184c9cae41702e293c87524b5a21f766b07d7fe3ffbcfbb/nh3-0.3.5-cp314-cp314t-win32.whl", hash = "sha256:c3aae321f67ae66cff2a627115f106a377d4475d10b0e13d97959a13486b9a88", size = 603263, upload-time = "2026-04-25T10:43:49.851Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/a2/f6685248b49f7548fc9a8c335ab3a52f68610b72e8a61576447151e4e2e6/nh3-0.3.5-cp314-cp314t-win_amd64.whl", hash = "sha256:c88605d8d468f7fc1b31e06129bc91d6c96f6c621776c9b504a0da9beac9df5f", size = 616866, upload-time = "2026-04-25T10:43:51.005Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/b6/d8c9018635d4acfefde6b68470daa510eed715a350cbaa2f928ba0609f81/nh3-0.3.5-cp314-cp314t-win_arm64.whl", hash = "sha256:72c5bdedec27fa33de6a5326346ea8aa3fe54f6ac294d54c4b204fb66a9f1e79", size = 602566, upload-time = "2026-04-25T10:43:52.283Z" },
+    { url = "https://files.pythonhosted.org/packages/85/30/d162e99746a2fb1d98bb0ef23af3e201b156cf09f7de867c7390c8fe1c06/nh3-0.3.5-cp38-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:3bb854485c9b33e5bb143ff3e49e577073bc6bc320f0ff8fc316dd89c0d3c101", size = 1442393, upload-time = "2026-04-25T10:43:53.556Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8c/072120d506978ab053e1732d0efa7c86cb478fee0ee098fda0ac0d31cb34/nh3-0.3.5-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:50d401ab2d8e86d59e2126e3ab2a2f45840c405842b626d9a51624b3a33b6878", size = 837722, upload-time = "2026-04-25T10:43:55.073Z" },
+    { url = "https://files.pythonhosted.org/packages/52/86/d4e06e28c5ad1c4b065f89737d02631bd49f1660b6ebcf17a87ffcd201da/nh3-0.3.5-cp38-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:acfd354e61accbe4c74f8017c6e397a776916dfe47c48643cf7fd84ade826f93", size = 822872, upload-time = "2026-04-25T10:43:56.581Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/62/50659255213f241ec5797ae7427464c969397373e83b3659372b341ae869/nh3-0.3.5-cp38-abi3-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:52d877980d7ca01dc3baf3936bf844828bc6f332962227a684ed79c18cce14c3", size = 1100031, upload-time = "2026-04-25T10:43:58.098Z" },
+    { url = "https://files.pythonhosted.org/packages/00/7a/a12ae77593b2fcf3be25df7bc1c01967d0de448bdb4b6c7ec80fe4f5a74f/nh3-0.3.5-cp38-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:207c01801d3e9bb8ec08f08689346bdd30ce15b8bf60013a925d08b5388962a4", size = 1057669, upload-time = "2026-04-25T10:43:59.328Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/71/5647dc04c0233192a3956fc91708822b21403a06508cacf78083c68e7bf0/nh3-0.3.5-cp38-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ea232933394d1d58bf7c4bb348dc4660eae6604e1ae81cd2ba6d9ed80d390f3b", size = 914795, upload-time = "2026-04-25T10:44:00.52Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/0e/bf298920729f216adcb002acf7ea01b90842603d2e4e2ce9b900d9ee8fab/nh3-0.3.5-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fe3a787dc76b50de6bee54ef242f26c41dfe47654428e3e94f0fae5bb6dd2cc1", size = 806976, upload-time = "2026-04-25T10:44:01.743Z" },
+    { url = "https://files.pythonhosted.org/packages/85/01/26761e1dc2b848e65a62c19e5d39ad446283287cd4afddc89f364ab86bc9/nh3-0.3.5-cp38-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:488928988caad25ba14b1eb5bc74e25e21f3b5e40341d956f3ce4a8bc19460dc", size = 834904, upload-time = "2026-04-25T10:44:03.454Z" },
+    { url = "https://files.pythonhosted.org/packages/33/53/0766113e679540ac1edc1b82b1295aecd321eeb75d6fead70109a838b6ee/nh3-0.3.5-cp38-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2c069570b06aa848457713ad7af4a9905691291548c4466a9ad78ee95808382b", size = 857159, upload-time = "2026-04-25T10:44:05.003Z" },
+    { url = "https://files.pythonhosted.org/packages/58/36/734d353dfaf292fed574b8b3092f0ef79dc6404f3879f7faaa61a4701fad/nh3-0.3.5-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:eeedc90ed8c42c327e8e10e621ccfa314fc6cce35d5929f4297ff1cdb89667c4", size = 1018600, upload-time = "2026-04-25T10:44:06.18Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/aa/d9c59c1b49669fcb7bababa55df82385f029ad5c2651f583c3a1141cfdd1/nh3-0.3.5-cp38-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:de8e8621853b6470fe928c684ee0d3f39ea8086cebafe4c416486488dea7b68d", size = 1103530, upload-time = "2026-04-25T10:44:07.68Z" },
+    { url = "https://files.pythonhosted.org/packages/90/b0/cdd210bfb8d9d43fb02fc3c868336b9955934d8e15e66eb1d15a147b8af0/nh3-0.3.5-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:6ea58cc44d274c643b83547ca9654a0b1a817609b160601356f76a2b744c49ad", size = 1061754, upload-time = "2026-04-25T10:44:09.362Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/cb/7a39e72e668c8445bdd95e494b3e21cfdddc68329be8ea3522c8befb46c4/nh3-0.3.5-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e49c9b564e6bcb03ecd2f057213df9a0de15a95812ac9db9600b590db23d3ae9", size = 1040938, upload-time = "2026-04-25T10:44:10.775Z" },
+    { url = "https://files.pythonhosted.org/packages/af/4c/fc2f9ed208a3801a319f59b5fea03cdc20cf3bd8af14be930d3a8de01224/nh3-0.3.5-cp38-abi3-win32.whl", hash = "sha256:559e4c73b689e9a7aa97ac9760b1bc488038d7c1a575aa4ab5a0e19ee9630c0f", size = 611445, upload-time = "2026-04-25T10:44:12.317Z" },
+    { url = "https://files.pythonhosted.org/packages/db/1a/e4c9b5e2ae13e6092c9ec16d8ca30646cb01fcdea245f36c5b08fd21fbd5/nh3-0.3.5-cp38-abi3-win_amd64.whl", hash = "sha256:45e6a65dc88a300a2e3502cb9c8e6d1d6b831d6fba7470643333609c6aab1f30", size = 626502, upload-time = "2026-04-25T10:44:13.682Z" },
+    { url = "https://files.pythonhosted.org/packages/80/7c/19cd0671d1ba2762fb388fc149697d20d0568ccfeef833b11280a619e526/nh3-0.3.5-cp38-abi3-win_arm64.whl", hash = "sha256:8f85285700a18e9f3fc5bff41fe573fa84f81542ef13b48a89f9fecca0474d3b", size = 611069, upload-time = "2026-04-25T10:44:14.934Z" },
+]
+
+[[package]]
 name = "nodeenv"
 version = "1.10.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1411,6 +1445,7 @@ dependencies = [
     { name = "jinja2" },
     { name = "markdown-it-py" },
     { name = "mcp" },
+    { name = "nh3" },
     { name = "orjson" },
     { name = "pydantic" },
     { name = "pygments" },
@@ -1493,6 +1528,7 @@ requires-dist = [
     { name = "mutmut", marker = "extra == 'dev'", specifier = ">=3.0.0" },
     { name = "mutmut", marker = "extra == 'fuzz'", specifier = ">=3.0.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.17,<1.21" },
+    { name = "nh3", specifier = ">=0.2.18" },
     { name = "orjson", specifier = ">=3.11.8" },
     { name = "pip-audit", marker = "extra == 'dev'", specifier = ">=2.7" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.6.0" },


### PR DESCRIPTION
## Summary

Replaces the regex-based HTML sanitizer in
`polylogue/rendering/renderers/html_sanitizer.py` with `nh3` (Rust
ammonia bindings), an HTML5 parser-based sanitizer with a conservative
allowlist. Closes the four bypass classes documented in #813.

## Problem

The previous regex sanitizer had:

- `_EVENT_ATTR_RE` required quoted values, so `<a onclick=alert(1)>`
  (unquoted) was untouched.
- `_JAVASCRIPT_URL_RE` only covered `href`; `src` and other URL-bearing
  attributes were unguarded.
- `data:` URIs were never stripped.
- `<iframe>`/`<object>`/`<embed>`/`<svg>`/`<math>` elements passed
  through with their interactive content intact.

## Solution

- Add `nh3>=0.2.18` to `pyproject.toml` and update `uv.lock`.
- Rewrite `html_sanitizer.py` to call `nh3.clean()` with an explicit
  allowlist: text/structural tags only, `class`/`id`/`aria-*`/`data-*`
  attributes, `href` on `<a>` only, and `url_schemes={http, https, mailto}`.
- Public API unchanged — `sanitize_html(str) -> Markup`. Existing callers
  (`devtools/pages_builder.py`, `polylogue/rendering/renderers/html_template.py`)
  need no changes.
- Add `tests/unit/rendering/test_html_sanitizer_security.py` with one
  parametrized test class per bypass class.

## Verification

```
pytest tests/unit/rendering/ -q
80 passed in 13.45s

devtools verify --quick
verify: all checks passed
```

## Certification

### WORK
Acceptance criteria from #813 (verbatim from issue body and reopen comments):
1. unquoted `onclick`/`on*` attribute handlers stripped
2. `data:` URIs stripped from href and src
3. `javascript:` URIs stripped from src (not just href)
4. iframe/object/embed elements stripped
5. svg/math attribute-handler stripping (or full element strip)

### REALIZATION
1. polylogue/rendering/renderers/html_sanitizer.py:103-110 (nh3.clean with `_ALLOWED_ATTRIBUTES` excluding all `on*` handlers); test: tests/unit/rendering/test_html_sanitizer_security.py::test_unquoted_event_handlers_stripped
2. polylogue/rendering/renderers/html_sanitizer.py:88 (`_ALLOWED_URL_SCHEMES = {http, https, mailto}` — `data` absent); test: tests/unit/rendering/test_html_sanitizer_security.py::test_data_uris_stripped
3. polylogue/rendering/renderers/html_sanitizer.py:88 (same scheme allowlist applies to every URL-bearing attribute, not only `href`); test: tests/unit/rendering/test_html_sanitizer_security.py::test_javascript_urls_stripped_on_any_attribute
4. polylogue/rendering/renderers/html_sanitizer.py:30-77 (`_ALLOWED_TAGS` excludes `iframe`/`object`/`embed`/`frame`/`frameset`); test: tests/unit/rendering/test_html_sanitizer_security.py::test_frame_and_object_elements_stripped
5. polylogue/rendering/renderers/html_sanitizer.py:30-77 (`_ALLOWED_TAGS` excludes `svg`/`math`/`script`, so the entire element and any handlers/foreign content are dropped); test: tests/unit/rendering/test_html_sanitizer_security.py::test_svg_and_math_neutralized

### DECLARATION
I declare every WORK item above to be fully realized by the matching REALIZATION entry, with no deferrals, narrowings, or implicit successors. Verified by: `pytest tests/unit/rendering/ -q` -> `80 passed in 13.45s`.

Closes #813