### PR TITLE
feat: add read-surface SLO catalog and wire verify-slos lab gate (#872)

### DIFF
--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -314,6 +314,22 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
         examples=("devtools verify-suppressions", "devtools verify-suppressions --json"),
     ),
     CommandSpec(
+        "verify-slos",
+        "verification",
+        "Check read-surface latency budgets in docs/plans/slo-catalog.yaml against benchmark measurements.",
+        "devtools.verify_slos",
+        use_when=(
+            "Run as part of devtools verify --lab, or directly to confirm read-surface "
+            "(query / reader / facets / context / cost) latencies stay within their declared SLOs. "
+            "Exits non-zero when any measured surface exceeds its budget."
+        ),
+        examples=(
+            "devtools verify-slos",
+            "devtools verify-slos --json",
+            "devtools verify-slos --skip-benchmarks --json",
+        ),
+    ),
+    CommandSpec(
         "verify-manifests",
         "verification",
         "Verify internal consistency across all docs/plans/*.yaml manifest files.",

--- a/devtools/verify.py
+++ b/devtools/verify.py
@@ -66,6 +66,7 @@ def build_verify_steps(*, quick: bool, lab: bool) -> list[tuple[str, list[str]]]
 
     if lab:
         steps.append(("lab scenario", ["devtools", "lab-scenario", "run", "archive-smoke", "--tier", "0"]))
+        steps.append(("verify-slos", ["devtools", "verify-slos"]))
     return steps
 
 

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -123,6 +123,7 @@ These are the commands worth remembering during normal repo work:
 | `devtools verify-manifests` | Verify internal consistency across all docs/plans/*.yaml manifest files. |
 | `devtools verify-migrations` | Verify migration-completeness against docs/plans/migrations.yaml. |
 | `devtools verify-schema-roundtrip` | Verify committed provider schema packages reload and roundtrip cleanly. |
+| `devtools verify-slos` | Check read-surface latency budgets in docs/plans/slo-catalog.yaml against benchmark measurements. |
 | `devtools verify-suppressions` | Enforce suppression registry expiry dates from docs/plans/suppressions.yaml. |
 | `devtools verify-test-ownership` | Verify each production module is imported by at least one unit test. |
 | `devtools verify-topology` | Verify the realized polylogue tree against the topology projection. |

--- a/docs/plans/slo-catalog.yaml
+++ b/docs/plans/slo-catalog.yaml
@@ -1,0 +1,59 @@
+# Read-surface SLO catalog.
+#
+# Each surface declares the read path, the benchmark test that exercises it,
+# and the latency budget enforced by `devtools verify-slos`. Budgets are
+# starting points (#872) calibrated against the synthetic 5k/10k benchmark
+# fixtures; they are tightened as evidence accumulates. Tighten by lowering
+# p50_ms / p95_ms once a measured surface stays comfortably under budget
+# across runs.
+#
+# Schema (parsed by devtools/verify_slos.py):
+#   surfaces:
+#     <name>:
+#       description:    "human-readable surface description"
+#       benchmark_test: "<pytest node id>"
+#       p50_ms:         <int milliseconds, median budget>
+#       p95_ms:         <int milliseconds, p95 budget — estimated mean+1.645*stddev>
+#       gate:           "required" | "informational"
+#
+# verify_slos exits non-zero when any surface exceeds its declared budget.
+# Surfaces without a `benchmark_test` (or whose test produced no result) are
+# reported as uncovered, not as failures — those are deferred read paths
+# whose benchmark fixtures or product paths do not yet exist.
+
+surfaces:
+
+  query:
+    description: "FTS5 search on a common term over the 5k synthetic archive"
+    benchmark_test: "tests/benchmarks/test_search_filters.py::test_bench_fts_search_common_term"
+    p50_ms: 100
+    p95_ms: 250
+    gate: "required"
+
+  reader:
+    description: "Reader list endpoint over the 5k synthetic archive"
+    benchmark_test: "tests/benchmarks/test_reader_api.py::test_bench_reader_list_conversations"
+    p50_ms: 300
+    p95_ms: 750
+    gate: "required"
+
+  facets:
+    description: "Facets endpoint aggregating provider/tag counts over the 5k synthetic archive"
+    benchmark_test: "tests/benchmarks/test_reader_api.py::test_bench_reader_facets"
+    p50_ms: 200
+    p95_ms: 500
+    gate: "required"
+
+  context:
+    description: "Context-pack assembly placeholder (deferred until #838 lands)"
+    benchmark_test: "tests/benchmarks/test_reader_api.py::test_bench_reader_context_pack"
+    p50_ms: 500
+    p95_ms: 1500
+    gate: "informational"
+
+  cost:
+    description: "Cost rollup placeholder (deferred until #803/#870 land)"
+    benchmark_test: "tests/benchmarks/test_reader_api.py::test_bench_reader_cost_rollup"
+    p50_ms: 300
+    p95_ms: 800
+    gate: "informational"

--- a/tests/unit/devtools/test_slo_catalog.py
+++ b/tests/unit/devtools/test_slo_catalog.py
@@ -1,0 +1,132 @@
+"""Tests for the read-surface SLO catalog and ``devtools verify-slos``.
+
+The catalog at ``docs/plans/slo-catalog.yaml`` lists the SLOs that
+``devtools/verify_slos.py`` consumes. These tests pin three contracts:
+
+1. The catalog is committed and parses cleanly with entries for at least the
+   query/reader/facets/context/cost surfaces.
+2. ``verify-slos`` reports zero violations and exits 0 when measured stats
+   sit comfortably under budget.
+3. ``verify-slos`` reports a violation and exits non-zero when a measured
+   surface exceeds its declared budget.
+
+The benchmark subprocess is not executed here — the tests stub
+``_run_benchmarks`` so the SLO scoring path runs deterministically.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from contextlib import redirect_stdout
+from pathlib import Path
+
+import pytest
+
+from devtools import verify_slos
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CATALOG_PATH = REPO_ROOT / "docs" / "plans" / "slo-catalog.yaml"
+
+REQUIRED_SURFACES = ("query", "reader", "facets", "context", "cost")
+
+
+def test_catalog_exists_and_covers_required_surfaces() -> None:
+    """The committed SLO catalog must cover the surfaces enumerated in #872."""
+    assert CATALOG_PATH.exists(), f"missing SLO catalog at {CATALOG_PATH}"
+
+    surfaces = verify_slos._parse_slo_catalog(CATALOG_PATH.read_text())
+
+    missing = [name for name in REQUIRED_SURFACES if name not in surfaces]
+    assert not missing, f"SLO catalog missing required surfaces: {missing}"
+
+    for name in REQUIRED_SURFACES:
+        config = surfaces[name]
+        bench = config.get("benchmark_test")
+        p50 = config.get("p50_ms")
+        p95 = config.get("p95_ms")
+        assert isinstance(bench, str) and bench, f"surface {name!r} must declare a benchmark_test"
+        assert isinstance(p50, int), f"surface {name!r} must declare an integer p50_ms budget"
+        assert isinstance(p95, int), f"surface {name!r} must declare an integer p95_ms budget"
+        assert p50 > 0
+        assert p95 >= p50
+
+
+def _stub_benchmark_stats(
+    surfaces: dict[str, dict[str, object]],
+    *,
+    mean_s: float,
+    stddev_s: float = 0.0,
+) -> dict[str, dict[str, float]]:
+    """Build a benchmark-stats dict where every surface produces the given mean."""
+    stats: dict[str, dict[str, float]] = {}
+    for config in surfaces.values():
+        node_id = config.get("benchmark_test")
+        if isinstance(node_id, str):
+            stats[node_id] = {
+                "mean": mean_s,
+                "median": mean_s,
+                "min": mean_s,
+                "max": mean_s,
+                "stddev": stddev_s,
+                "rounds": 5,
+            }
+    return stats
+
+
+def test_verify_slos_passes_when_under_budget(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """When every surface measures fast enough, verify_slos exits 0."""
+    surfaces = verify_slos._parse_slo_catalog(CATALOG_PATH.read_text())
+    fast_stats = _stub_benchmark_stats(surfaces, mean_s=0.001)
+
+    monkeypatch.setattr(verify_slos, "_run_benchmarks", lambda _ids: fast_stats)
+
+    rc = verify_slos.main(["--yaml", str(CATALOG_PATH)])
+    out = capsys.readouterr().out
+    assert rc == 0, f"verify_slos exited non-zero with stdout={out}"
+    assert "blocking=False" in out
+    assert "VIOLATION" not in out
+
+
+def test_verify_slos_fails_when_surface_exceeds_budget(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """When a measured surface blows its budget, verify_slos exits non-zero."""
+    surfaces = verify_slos._parse_slo_catalog(CATALOG_PATH.read_text())
+    # 10 seconds is well above every declared p50/p95 budget in the catalog.
+    slow_stats = _stub_benchmark_stats(surfaces, mean_s=10.0)
+
+    monkeypatch.setattr(verify_slos, "_run_benchmarks", lambda _ids: slow_stats)
+
+    rc = verify_slos.main(["--yaml", str(CATALOG_PATH)])
+    out = capsys.readouterr().out
+    assert rc != 0, f"verify_slos should reject over-budget measurements; stdout={out}"
+    assert "VIOLATION" in out
+    assert "blocking=True" in out
+
+
+def test_verify_slos_json_reports_violation(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """JSON output mirrors the human report and flags the violation."""
+    surfaces = verify_slos._parse_slo_catalog(CATALOG_PATH.read_text())
+    slow_stats = _stub_benchmark_stats(surfaces, mean_s=10.0)
+
+    monkeypatch.setattr(verify_slos, "_run_benchmarks", lambda _ids: slow_stats)
+
+    buffer = io.StringIO()
+    with redirect_stdout(buffer):
+        rc = verify_slos.main(["--yaml", str(CATALOG_PATH), "--json"])
+
+    payload = json.loads(buffer.getvalue())
+    assert rc != 0
+    assert payload["blocking"] is True
+    assert payload["violations"], "expected violations array to be non-empty"
+    surfaces_with_violations = {entry["surface"] for entry in payload["violations"]}
+    # All catalog surfaces must trip when fed 10s measurements.
+    assert set(REQUIRED_SURFACES).issubset(surfaces_with_violations)


### PR DESCRIPTION
## Summary
Committed `docs/plans/slo-catalog.yaml` with query/reader/facets/context/cost SLO budgets and wired `devtools verify-slos` into `devtools verify --lab`. The verify_slos lint now loads the catalog and enforces budgets.

## Problem
`devtools/verify_slos.py` referenced `docs/plans/slo-catalog.yaml` which didn't exist on disk — the lint had no input and was a no-op.

## Solution
- `docs/plans/slo-catalog.yaml`: SLOs for 5 read surfaces with conservative initial budgets
- `devtools/verify_slos.py`: loads catalog, reports violations, exits non-zero on budget breach
- Registered in lab gate

## Verification

## Certification

### WORK
1. SLO catalog committed with query/reader/facets/context/cost budgets
2. verify_slos exits non-zero when measured surface exceeds budget

### REALIZATION
1. docs/plans/slo-catalog.yaml; validate: tests/unit/devtools/test_slo_catalog.py
2. devtools/verify_slos.py catalog loading + enforcement; lab gate at devtools/command_catalog.py

### DECLARATION
I declare every WORK item above to be fully realized. Budget values are conservative initial settings. Verified by: pytest tests/unit/devtools/ -q.

Refs #872