### PR TITLE
feat: add idempotency outcome to tag mutation payloads (#862)

### DIFF
--- a/polylogue/cli/commands/tags.py
+++ b/polylogue/cli/commands/tags.py
@@ -57,19 +57,41 @@ def tags_command(
             was_added = run_coroutine_sync(env.polylogue.add_tag(resolved, add_tag_name))
             status = "ok" if was_added else "unchanged"
             detail = None if was_added else "already_present"
+            outcome = "added" if was_added else "no_op"
             if output_format == "json":
-                emit_success({"status": status, "conversation_id": resolved, "tag": add_tag_name, "detail": detail})
+                emit_success(
+                    {
+                        "status": status,
+                        "conversation_id": resolved,
+                        "tag": add_tag_name,
+                        "detail": detail,
+                        "outcome": outcome,
+                    }
+                )
             else:
-                click.echo(f"Tag '{add_tag_name}' on {resolved}: {status}" + (f" ({detail})" if detail else ""))
+                click.echo(
+                    f"Tag '{add_tag_name}' on {resolved}: {status} ({outcome})" + (f" ({detail})" if detail else "")
+                )
 
         if remove_tag_name:
             was_removed = run_coroutine_sync(env.polylogue.remove_tag(resolved, remove_tag_name))
             status = "ok" if was_removed else "not_found"
             detail = None if was_removed else "tag_not_present"
+            outcome = "removed" if was_removed else "not_present"
             if output_format == "json":
-                emit_success({"status": status, "conversation_id": resolved, "tag": remove_tag_name, "detail": detail})
+                emit_success(
+                    {
+                        "status": status,
+                        "conversation_id": resolved,
+                        "tag": remove_tag_name,
+                        "detail": detail,
+                        "outcome": outcome,
+                    }
+                )
             else:
-                click.echo(f"Tag '{remove_tag_name}' on {resolved}: {status}" + (f" ({detail})" if detail else ""))
+                click.echo(
+                    f"Tag '{remove_tag_name}' on {resolved}: {status} ({outcome})" + (f" ({detail})" if detail else "")
+                )
 
         return
 

--- a/polylogue/mcp/payloads.py
+++ b/polylogue/mcp/payloads.py
@@ -324,6 +324,8 @@ class MCPMutationStatusPayload(SurfacePayloadModel):
     index_exists: bool | None = None
     indexed_messages: int | None = None
     conversation_count: int | None = None
+    outcome: str | None = None
+    """Tag idempotency outcome: ``added``, ``no_op``, ``removed``, or ``not_present``."""
 
 
 class MutationResultPayload(SurfacePayloadModel):
@@ -341,6 +343,9 @@ class MutationResultPayload(SurfacePayloadModel):
     detail: str | None = None
     """Machine-readable detail: ``already_present``, ``tag_not_present``,
     ``key_not_found``, ``value_unchanged``, ``conversation_not_found``."""
+
+    outcome: str | None = None
+    """Tag idempotency outcome: ``added``, ``no_op``, ``removed``, or ``not_present``."""
 
     affected_count: int | None = None
     skipped_count: int | None = None

--- a/polylogue/mcp/server_mutation_tools.py
+++ b/polylogue/mcp/server_mutation_tools.py
@@ -42,6 +42,7 @@ def register_mutation_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
                     conversation_id=resolved,
                     tag=tag,
                     detail=None if was_added else "already_present",
+                    outcome="added" if was_added else "no_op",
                 ),
                 exclude_none=True,
             )
@@ -63,6 +64,7 @@ def register_mutation_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
                     conversation_id=resolved,
                     tag=tag,
                     detail=None if was_removed else "tag_not_present",
+                    outcome="removed" if was_removed else "not_present",
                 ),
                 exclude_none=True,
             )

--- a/tests/unit/mcp/test_tag_idempotency.py
+++ b/tests/unit/mcp/test_tag_idempotency.py
@@ -1,0 +1,195 @@
+"""Verify tag mutation operations surface idempotency outcomes.
+
+Refs #862.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+from tests.infra.mcp import (
+    MCPServerUnderTest,
+    invoke_surface,
+    make_polylogue_mock,
+    make_query_store_mock,
+    make_tag_store_mock,
+)
+
+_ADD_TAG_TOOL = "add_tag"
+_REMOVE_TAG_TOOL = "remove_tag"
+_CONV_ID = "test:conv-tag-1"
+_TAG = "review"
+
+
+class TestTagIdempotencyOutcomes:
+    """Each mutation path must surface the correct outcome value."""
+
+    # ── add_tag ──────────────────────────────────────────────────────
+
+    def test_add_tag_absent_yields_added(self, mcp_server: MCPServerUnderTest) -> None:
+        with (
+            patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue,
+            patch("polylogue.mcp.server._get_query_store") as mock_get_query_store,
+        ):
+            mock_poly = make_polylogue_mock()
+            mock_poly.add_tag = AsyncMock(return_value=True)
+            mock_get_polylogue.return_value = mock_poly
+            mock_get_query_store.return_value = make_query_store_mock(resolved_id=_CONV_ID)
+
+            result = invoke_surface(
+                mcp_server._tool_manager._tools[_ADD_TAG_TOOL].fn,
+                conversation_id=_CONV_ID,
+                tag=_TAG,
+            )
+
+        parsed = json.loads(result)
+        assert parsed["status"] == "ok"
+        assert parsed["outcome"] == "added"
+        assert parsed["tag"] == _TAG
+        assert "detail" not in parsed
+
+    def test_add_tag_already_present_yields_no_op(self, mcp_server: MCPServerUnderTest) -> None:
+        with (
+            patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue,
+            patch("polylogue.mcp.server._get_query_store") as mock_get_query_store,
+        ):
+            mock_poly = make_polylogue_mock()
+            mock_poly.add_tag = AsyncMock(return_value=False)
+            mock_get_polylogue.return_value = mock_poly
+            mock_get_query_store.return_value = make_query_store_mock(resolved_id=_CONV_ID)
+
+            result = invoke_surface(
+                mcp_server._tool_manager._tools[_ADD_TAG_TOOL].fn,
+                conversation_id=_CONV_ID,
+                tag=_TAG,
+            )
+
+        parsed = json.loads(result)
+        assert parsed["status"] == "unchanged"
+        assert parsed["outcome"] == "no_op"
+        assert parsed["detail"] == "already_present"
+        assert parsed["tag"] == _TAG
+
+    def test_add_tag_conversation_not_found(self, mcp_server: MCPServerUnderTest) -> None:
+        with patch("polylogue.mcp.server._get_query_store") as mock_get_query_store:
+            mock_get_query_store.return_value = make_query_store_mock(resolved_id=None)
+
+            result = invoke_surface(
+                mcp_server._tool_manager._tools[_ADD_TAG_TOOL].fn,
+                conversation_id="nonexistent:id",
+                tag=_TAG,
+            )
+
+        parsed = json.loads(result)
+        assert "error" in parsed
+        assert "not found" in parsed["error"].lower()
+
+    # ── remove_tag ───────────────────────────────────────────────────
+
+    def test_remove_tag_present_yields_removed(self, mcp_server: MCPServerUnderTest) -> None:
+        with (
+            patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue,
+            patch("polylogue.mcp.server._get_query_store") as mock_get_query_store,
+        ):
+            mock_poly = make_polylogue_mock()
+            mock_poly.remove_tag = AsyncMock(return_value=True)
+            mock_get_polylogue.return_value = mock_poly
+            mock_get_query_store.return_value = make_query_store_mock(resolved_id=_CONV_ID)
+
+            result = invoke_surface(
+                mcp_server._tool_manager._tools[_REMOVE_TAG_TOOL].fn,
+                conversation_id=_CONV_ID,
+                tag=_TAG,
+            )
+
+        parsed = json.loads(result)
+        assert parsed["status"] == "ok"
+        assert parsed["outcome"] == "removed"
+        assert parsed["tag"] == _TAG
+        assert "detail" not in parsed
+
+    def test_remove_tag_absent_yields_not_present(self, mcp_server: MCPServerUnderTest) -> None:
+        with (
+            patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue,
+            patch("polylogue.mcp.server._get_query_store") as mock_get_query_store,
+        ):
+            mock_poly = make_polylogue_mock()
+            mock_poly.remove_tag = AsyncMock(return_value=False)
+            mock_get_polylogue.return_value = mock_poly
+            mock_get_query_store.return_value = make_query_store_mock(resolved_id=_CONV_ID)
+
+            result = invoke_surface(
+                mcp_server._tool_manager._tools[_REMOVE_TAG_TOOL].fn,
+                conversation_id=_CONV_ID,
+                tag=_TAG,
+            )
+
+        parsed = json.loads(result)
+        assert parsed["status"] == "not_found"
+        assert parsed["outcome"] == "not_present"
+        assert parsed["detail"] == "tag_not_present"
+        assert parsed["tag"] == _TAG
+
+    def test_remove_tag_conversation_not_found(self, mcp_server: MCPServerUnderTest) -> None:
+        with patch("polylogue.mcp.server._get_query_store") as mock_get_query_store:
+            mock_get_query_store.return_value = make_query_store_mock(resolved_id=None)
+
+            result = invoke_surface(
+                mcp_server._tool_manager._tools[_REMOVE_TAG_TOOL].fn,
+                conversation_id="nonexistent:id",
+                tag=_TAG,
+            )
+
+        parsed = json.loads(result)
+        assert "error" in parsed
+        assert "not found" in parsed["error"].lower()
+
+
+class TestBulkTagExcludesOutcome:
+    """bulk_tag_conversations does not carry a per-tag outcome — it uses counts."""
+
+    def test_bulk_tag_has_no_outcome_field(self, mcp_server: MCPServerUnderTest) -> None:
+        with patch("polylogue.mcp.server._get_tag_store") as mock_get_tag_store:
+            mock_tag_store = make_tag_store_mock()
+            mock_tag_store.bulk_add_tags = AsyncMock(return_value=3)
+            mock_get_tag_store.return_value = mock_tag_store
+
+            result = invoke_surface(
+                mcp_server._tool_manager._tools["bulk_tag_conversations"].fn,
+                conversation_ids=["conv-1", "conv-2", "conv-3"],
+                tags=["important"],
+            )
+
+        parsed = json.loads(result)
+        assert parsed["status"] == "ok"
+        assert "outcome" not in parsed
+
+
+class TestMutationResultPayloadRoundtrip:
+    """ensure outcome serializes correctly and exclude_none omits null."""
+
+    def test_outcome_present_in_serialized(self) -> None:
+        from polylogue.mcp.payloads import MutationResultPayload
+
+        payload = MutationResultPayload(
+            status="ok",
+            conversation_id=_CONV_ID,
+            tag=_TAG,
+            outcome="added",
+        )
+        serialized = payload.model_dump_json(exclude_none=True)
+        parsed = json.loads(serialized)
+        assert parsed["outcome"] == "added"
+
+    def test_outcome_omitted_when_none(self) -> None:
+        from polylogue.mcp.payloads import MutationResultPayload
+
+        payload = MutationResultPayload(
+            status="ok",
+            conversation_id=_CONV_ID,
+            tag=_TAG,
+        )
+        serialized = payload.model_dump_json(exclude_none=True)
+        parsed = json.loads(serialized)
+        assert "outcome" not in parsed


### PR DESCRIPTION
## Summary

Add `outcome` field to `MutationResultPayload` and `MCPMutationStatusPayload`
so callers can distinguish the four tag-mutation states without parsing the
status/detail fields.

## Problem

`add_tag` and `remove_tag` returned `status="ok"` without indicating whether
the operation was genuinely new or a no-op on already-present/absent tags.
Callers had to parse the `detail` string (`"already_present"`,
`"tag_not_present"`) to understand what happened. This made it hard to build
reliable automation on top of the mutation API.

## Solution

Added `outcome: str | None` field to both `MutationResultPayload` and
`MCPMutationStatusPayload` in `polylogue/mcp/payloads.py`. The field is
`None`-by-default and omitted from serialization when `None` (backward
compatible).

Computed in `polylogue/mcp/server_mutation_tools.py`:

| Operation    | Condition           | `outcome`      |
|-------------|--------------------|----------------|
| `add_tag`    | tag was added       | `"added"`      |
| `add_tag`    | tag already present | `"no_op"`      |
| `remove_tag` | tag was removed     | `"removed"`    |
| `remove_tag` | tag not present     | `"not_present"`|

CLI output in `polylogue/cli/commands/tags.py` includes outcome in both
human-readable and `--format json` modes.

New tests in `tests/unit/mcp/test_tag_idempotency.py` cover all four outcomes
plus conversation-not-found and serialization roundtrip.

## Verification

```
9 passed in 11.89s  tests/unit/mcp/test_tag_idempotency.py
129 passed in 14.08s  (all tag-related unit tests across mcp/cli/storage)
mypy --strict: no issues found in 4 source files
ruff format/check: clean
```

Refs #862

🤖 Generated with [Claude Code](https://claude.com/claude-code)