### PR TITLE
fix(daemon): typed RawFailureSample on status payload (#844)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,7 +87,7 @@ Issues and PR bodies are durable artifacts. Write them for a reader who
 has no conversation context — they should stand alone. Include file
 paths, acceptance criteria, and design references where applicable.
 
-<!-- begin include: /realm/project/polylogue/CONTRIBUTING.md -->
+<!-- begin include: /realm/project/polylogue/.claude/worktrees/agent-acb911ae/CONTRIBUTING.md -->
 # Contributing
 
 ## Development Environment
@@ -337,8 +337,8 @@ The PR title becomes the squash-merge subject on `master`. Rules:
 - ≤72 characters, conventional prefix, imperative mood
 - Describes what changed, not what was worked on
 - Accurate — do not claim alignment or unification unless the diff achieves it
-<!-- end include: /realm/project/polylogue/CONTRIBUTING.md -->
-<!-- begin include: /realm/project/polylogue/TESTING.md -->
+<!-- end include: /realm/project/polylogue/.claude/worktrees/agent-acb911ae/CONTRIBUTING.md -->
+<!-- begin include: /realm/project/polylogue/.claude/worktrees/agent-acb911ae/TESTING.md -->
 # Testing
 
 All commands below assume you are inside the project devshell. See
@@ -448,8 +448,8 @@ Never delete:
   shapes.
 - **`tests/unit/security/`**: Security boundary tests.
 
-<!-- end include: /realm/project/polylogue/TESTING.md -->
-<!-- begin include: /realm/project/polylogue/docs/architecture.md -->
+<!-- end include: /realm/project/polylogue/.claude/worktrees/agent-acb911ae/TESTING.md -->
+<!-- begin include: /realm/project/polylogue/.claude/worktrees/agent-acb911ae/docs/architecture.md -->
 # Polylogue Architecture
 
 Polylogue is a local archive for AI conversations. The system has four rings:
@@ -673,8 +673,8 @@ attachments, exports):
 - New semantics go into substrate or insights first, then surfaces adapt.
 - Proof subjects and claims live in `proof/`; devtools commands that exercise
   them live in `devtools/`.
-<!-- end include: /realm/project/polylogue/docs/architecture.md -->
-<!-- begin include: /realm/project/polylogue/docs/internals.md -->
+<!-- end include: /realm/project/polylogue/.claude/worktrees/agent-acb911ae/docs/architecture.md -->
+<!-- begin include: /realm/project/polylogue/.claude/worktrees/agent-acb911ae/docs/internals.md -->
 # Internals Reference
 
 Working map of the live codebase: invariants, hot files, extension points, and
@@ -841,8 +841,8 @@ devtools lab-scenario verify-baselines
 - `.cache/`: disposable caches (hypothesis, pytest, mypy, ruff)
 - `.local/`: untracked outputs (campaigns, showcases, build artifacts)
 - `.local/result`: out-link for `devtools build-package`
-<!-- end include: /realm/project/polylogue/docs/internals.md -->
-<!-- begin include: /realm/project/polylogue/docs/devtools.md -->
+<!-- end include: /realm/project/polylogue/.claude/worktrees/agent-acb911ae/docs/internals.md -->
+<!-- begin include: /realm/project/polylogue/.claude/worktrees/agent-acb911ae/docs/devtools.md -->
 # Developer Tools
 
 Use `devtools` for routine repository maintenance. Call individual
@@ -968,6 +968,7 @@ These are the commands worth remembering during normal repo work:
 | `devtools verify-manifests` | Verify internal consistency across all docs/plans/*.yaml manifest files. |
 | `devtools verify-migrations` | Verify migration-completeness against docs/plans/migrations.yaml. |
 | `devtools verify-schema-roundtrip` | Verify committed provider schema packages reload and roundtrip cleanly. |
+| `devtools verify-slos` | Check read-surface latency budgets in docs/plans/slo-catalog.yaml against benchmark measurements. |
 | `devtools verify-suppressions` | Enforce suppression registry expiry dates from docs/plans/suppressions.yaml. |
 | `devtools verify-test-ownership` | Verify each production module is imported by at least one unit test. |
 | `devtools verify-topology` | Verify the realized polylogue tree against the topology projection. |
@@ -1016,4 +1017,4 @@ Campaign outputs live under `.local/`, not in tracked docs trees.
 
 Keep new repo-local outputs in `.cache/` or `.local/` instead of adding new
 top-level output roots.
-<!-- end include: /realm/project/polylogue/docs/devtools.md -->
+<!-- end include: /realm/project/polylogue/.claude/worktrees/agent-acb911ae/docs/devtools.md -->

--- a/polylogue/cli/commands/status.py
+++ b/polylogue/cli/commands/status.py
@@ -128,6 +128,18 @@ def _show_daemon_status(env: AppEnv, status: dict[str, Any], *, compact: bool = 
     if db_bytes:
         env.ui.console.print(f"  DB: {_fmt_bytes(db_bytes)}  Free: {_fmt_bytes(disk_free)}")
 
+    # Raw failures
+    raw_parse = status.get("raw_parse_failures", 0)
+    raw_val = status.get("raw_validation_failures", 0)
+    raw_quarantined = status.get("raw_quarantined", 0)
+    total_raw = (raw_parse or 0) + (raw_val or 0)
+    if total_raw > 0:
+        fail_color = "red" if total_raw > 10 else "yellow"
+        env.ui.console.print(
+            f"  Raw failures: [{fail_color}]{total_raw} total ({raw_quarantined} quarantined)"
+            f" [{fail_color}]({raw_parse} parse + {raw_val} validation)[/{fail_color}]"
+        )
+
     if not compact:
         checked = status.get("checked_at", "")
         if checked:

--- a/polylogue/daemon/status.py
+++ b/polylogue/daemon/status.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 import contextlib
 import os
+import re
 import sqlite3
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from polylogue.browser_capture.receiver import BrowserCaptureReceiverConfig, receiver_status_payload
 from polylogue.core.json import JSONDocument, json_document
@@ -123,6 +125,57 @@ class LiveIngestAttemptSummary(BaseModel):
     recent: list[LiveIngestAttemptState] = Field(default_factory=list)
 
 
+class RawFailureSample(BaseModel):
+    """One bounded raw-ingest failure record surfaced in daemon status.
+
+    Constructed by ``_raw_failure_info()`` from the ``raw_conversations``
+    table and consumed by the typed ``DaemonStatus`` model. Every surface
+    (CLI, MCP, daemon HTTP) receives the same structured taxonomy.
+    """
+
+    failure_kind: Literal["decode_error", "parse_error", "schema_violation", "unknown"]
+    provider_hint: str | None = None
+    redacted_error: str = ""
+
+    @field_validator("redacted_error", mode="before")
+    @classmethod
+    def _redact_file_paths(cls, v: object) -> str:
+        """Strip absolute file paths from error strings at construction time.
+
+        Replaces absolute Unix paths (starting with ``/``) with
+        ``[redacted]`` so that local filesystem layout is never
+        exposed in status payloads.  URL path segments (e.g.
+        ``https://host/v1/data``) and relative paths are not redacted.
+        """
+        if not isinstance(v, str):
+            return ""
+
+        def _replace(m: re.Match[str]) -> str:
+            start = m.start()
+            # Absolute path at start of string is always redacted.
+            if start == 0:
+                return "[redacted]"
+            prev = v[start - 1]
+            # Keep when preceded by a letter, digit, dot, or colon
+            # (these indicate a URL host segment like "example.com/path").
+            if prev.isalnum() or prev in (".", ":"):
+                return m.group(0)
+            # Keep when the surrounding context contains a URL protocol.
+            # Look back up to 16 chars for "://".
+            prefix = v[max(0, start - 16) : start + 1]
+            if "://" in prefix:
+                return m.group(0)
+            return "[redacted]"
+
+        return _PATH_REDACTION_RE.sub(_replace, v)
+
+
+# Matches candidate absolute Unix paths: a ``/`` followed by one or more
+# path segments (alphanumeric, dots, dashes, underscores).  The
+# ``_redact_file_paths`` validator refines matches with context checks.
+_PATH_REDACTION_RE = re.compile(r"/(?:[a-zA-Z0-9._\-]+/)*[a-zA-Z0-9._\-]+")
+
+
 # ---------------------------------------------------------------------------
 # DaemonStatus — typed model consumed by all surfaces
 # ---------------------------------------------------------------------------
@@ -151,7 +204,7 @@ class DaemonStatus(BaseModel):
     raw_parse_failures: int = 0
     raw_validation_failures: int = 0
     raw_quarantined: int = 0
-    raw_failure_samples: list[dict[str, object]] = Field(default_factory=list)
+    raw_failure_samples: list[RawFailureSample] = Field(default_factory=list)
     raw_detection_warnings: int = 0
     health: DaemonHealth = Field(default_factory=DaemonHealth)
     checked_at: str = ""
@@ -337,23 +390,38 @@ def _raw_failure_info() -> dict[str, object]:
                     )
             except Exception:
                 pass
-            # Bounded failure samples (most recent 50)
-            samples: list[dict[str, object]] = []
+            # Bounded failure samples (most recent 50), typed.
+            samples: list[RawFailureSample] = []
             for row in conn.execute(
-                "SELECT raw_id, source_path, parse_error, validation_status "
+                "SELECT raw_id, provider_name, parse_error, validation_status, validation_error "
                 "FROM raw_conversations "
                 "WHERE parse_error IS NOT NULL OR validation_status = 'FAILED' "
                 "ORDER BY acquired_at DESC LIMIT 50"
             ).fetchall():
-                error_text = row["parse_error"] or ""
-                error_class = error_text.split("\n")[0].strip()[:120] if error_text else None
+                parse_err = str(row[2] or "") if row[2] else ""
+                val_status = str(row[3] or "") if row[3] else ""
+                val_err = str(row[4] or "") if row[4] else ""
+                provider = str(row[1]) if row[1] else None
+
+                # Classify failure kind from the available error signals.
+                if "JSONDecodeError" in parse_err or "decode error" in parse_err.lower():
+                    kind: Literal["decode_error", "parse_error", "schema_violation", "unknown"] = "decode_error"
+                elif val_status == "FAILED":
+                    kind = "schema_violation"
+                elif parse_err:
+                    kind = "parse_error"
+                else:
+                    kind = "unknown"
+
+                # Redacted error text: prefer parse_error, fall back to validation_error.
+                error_text = parse_err or val_err
+
                 samples.append(
-                    {
-                        "raw_id": row["raw_id"],
-                        "source_path": row["source_path"] or "",
-                        "error_class": error_class,
-                        "validation_status": row["validation_status"] or "",
-                    }
+                    RawFailureSample(
+                        failure_kind=kind,
+                        provider_hint=provider,
+                        redacted_error=error_text,
+                    )
                 )
         finally:
             conn.close()
@@ -368,9 +436,10 @@ def _raw_failure_info() -> dict[str, object]:
         return {"parse_failures": 0, "validation_failures": 0, "quarantined": 0, "detection_warnings": 0, "samples": []}
 
 
-def _safe_list_of_dicts(value: object) -> list[dict[str, object]]:
+def _typed_failure_samples(value: object) -> list[RawFailureSample]:
+    """Safely extract typed failure samples from a potentially heterogeneous source."""
     if isinstance(value, list):
-        return [item for item in value if isinstance(item, dict)]
+        return [item for item in value if isinstance(item, RawFailureSample)]
     return []
 
 
@@ -818,7 +887,7 @@ def build_daemon_status(
         raw_parse_failures=_safe_int(raw_failures.get("parse_failures", 0)),
         raw_validation_failures=_safe_int(raw_failures.get("validation_failures", 0)),
         raw_quarantined=_safe_int(raw_failures.get("quarantined", 0)),
-        raw_failure_samples=_safe_list_of_dicts(raw_failures.get("samples")),
+        raw_failure_samples=_typed_failure_samples(raw_failures.get("samples")),
         raw_detection_warnings=_safe_int(raw_failures.get("detection_warnings", 0)),
         daemon_liveness=_check_daemon_liveness(),
         component_state=ComponentState(
@@ -923,6 +992,11 @@ def daemon_status_payload(
                 "alert_count": len(status.health.alerts),
                 "tier_summary": status.health.tier_summary,
             },
+            "raw_parse_failures": status.raw_parse_failures,
+            "raw_validation_failures": status.raw_validation_failures,
+            "raw_quarantined": status.raw_quarantined,
+            "raw_detection_warnings": status.raw_detection_warnings,
+            "raw_failure_samples": [s.model_dump() for s in status.raw_failure_samples],
         }
     )
 
@@ -1005,6 +1079,23 @@ def format_daemon_status_lines(payload: JSONDocument) -> list[str]:
     if isinstance(health, dict):
         overall = health.get("overall_status", "unknown")
         lines.append(f"Health: {overall} ({health.get('alert_count', 0)} alerts)")
+    # Raw failure summary
+    raw_parse = _safe_int(payload.get("raw_parse_failures"))
+    raw_val = _safe_int(payload.get("raw_validation_failures"))
+    raw_quarantined = _safe_int(payload.get("raw_quarantined"))
+    total_raw = raw_parse + raw_val
+    if total_raw > 0:
+        lines.append(
+            f"Raw failures: {total_raw} total ({raw_quarantined} quarantined), {raw_parse} parse + {raw_val} validation"
+        )
+        samples = payload.get("raw_failure_samples")
+        if isinstance(samples, list) and samples:
+            for s in samples[:5]:
+                if isinstance(s, dict):
+                    kind = s.get("failure_kind", "unknown")
+                    hint = s.get("provider_hint") or "?"
+                    error_text = str(s.get("redacted_error", ""))
+                    lines.append(f"  [{kind}] {hint}: {error_text[:120]}")
     # Embedding readiness
     embedding = payload.get("embedding_readiness")
     if isinstance(embedding, dict):
@@ -1028,6 +1119,7 @@ def format_daemon_status_lines(payload: JSONDocument) -> list[str]:
 __all__ = [
     "DaemonStatus",
     "EmbeddingReadiness",
+    "RawFailureSample",
     "build_daemon_status",
     "browser_capture_status_payload",
     "daemon_status_payload",

--- a/tests/unit/daemon/test_raw_failure_sample.py
+++ b/tests/unit/daemon/test_raw_failure_sample.py
@@ -1,0 +1,377 @@
+"""Tests for RawFailureSample Pydantic model and its integration into DaemonStatus."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from pydantic import ValidationError
+
+from polylogue.daemon import status as status_module
+from polylogue.daemon.status import (
+    DaemonStatus,
+    RawFailureSample,
+    _raw_failure_info,
+)
+
+
+class TestRawFailureSampleModel:
+    """Contract tests for the RawFailureSample Pydantic model."""
+
+    def test_constructs_with_valid_fields(self) -> None:
+        sample = RawFailureSample(
+            failure_kind="parse_error",
+            provider_hint="claude-code",
+            redacted_error="malformed JSONL: unexpected token at line 5",
+        )
+        assert sample.failure_kind == "parse_error"
+        assert sample.provider_hint == "claude-code"
+        assert sample.redacted_error == "malformed JSONL: unexpected token at line 5"
+
+    def test_constructs_with_minimal_fields(self) -> None:
+        sample = RawFailureSample(failure_kind="unknown")
+        assert sample.failure_kind == "unknown"
+        assert sample.provider_hint is None
+        assert sample.redacted_error == ""
+
+    def test_rejects_invalid_failure_kind(self) -> None:
+        with pytest.raises(ValidationError):
+            RawFailureSample(failure_kind="invalid_kind")  # type: ignore[arg-type]
+
+    def test_all_valid_failure_kinds(self) -> None:
+        for kind in ("decode_error", "parse_error", "schema_violation", "unknown"):
+            sample = RawFailureSample(failure_kind=kind)  # type: ignore[arg-type]
+            assert sample.failure_kind == kind
+
+    def test_redacts_absolute_file_paths(self) -> None:
+        sample = RawFailureSample(
+            failure_kind="decode_error",
+            redacted_error="JSONDecodeError at /home/user/project/src/file.py:42",
+        )
+        assert "/home/user/project/src/file.py" not in sample.redacted_error
+        assert "JSONDecodeError" in sample.redacted_error
+
+    def test_redacts_realm_paths(self) -> None:
+        sample = RawFailureSample(
+            failure_kind="parse_error",
+            redacted_error="Failed to parse /realm/project/polylogue/data/input.json",
+        )
+        assert "/realm/project/polylogue/data/input.json" not in sample.redacted_error
+        assert "Failed to parse" in sample.redacted_error
+
+    def test_redacts_multiple_paths_in_single_error(self) -> None:
+        sample = RawFailureSample(
+            failure_kind="schema_violation",
+            redacted_error="Schema mismatch: /tmp/a.json vs /nix/store/hash-name/file.py",
+        )
+        assert "/tmp/a.json" not in sample.redacted_error
+        assert "/nix/store" not in sample.redacted_error
+        assert "Schema mismatch" in sample.redacted_error
+
+    def test_preserves_non_path_text(self) -> None:
+        sample = RawFailureSample(
+            failure_kind="parse_error",
+            redacted_error="JSONDecodeError: Expecting value: line 1 column 1",
+        )
+        assert sample.redacted_error == "JSONDecodeError: Expecting value: line 1 column 1"
+
+    def test_handles_empty_redacted_error(self) -> None:
+        sample = RawFailureSample(failure_kind="unknown", redacted_error="")
+        assert sample.redacted_error == ""
+
+    def test_handles_none_redacted_error_coerced(self) -> None:
+        sample = RawFailureSample(failure_kind="unknown", redacted_error=None)  # type: ignore[arg-type]
+        assert sample.redacted_error == ""
+
+    def test_handles_non_string_redacted_error_coerced(self) -> None:
+        sample = RawFailureSample(failure_kind="unknown", redacted_error=42)  # type: ignore[arg-type]
+        assert sample.redacted_error == ""
+
+    def test_model_dump_excludes_raw_paths(self) -> None:
+        sample = RawFailureSample(
+            failure_kind="decode_error",
+            provider_hint="claude-code",
+            redacted_error="Failure in /home/user/secret/data.json: decoding error",
+        )
+        dumped = sample.model_dump()
+        assert "/home/user/secret/data.json" not in dumped["redacted_error"]
+
+
+class TestRawFailureSampleInDaemonStatus:
+    """Integration: DaemonStatus.raw_failure_samples uses typed model."""
+
+    def test_daemon_status_accepts_typed_samples(self) -> None:
+        samples = [
+            RawFailureSample(
+                failure_kind="parse_error",
+                provider_hint="claude-code",
+                redacted_error="bad record at line 3",
+            )
+        ]
+        status = DaemonStatus(raw_failure_samples=samples)
+        assert status.raw_failure_samples == samples
+        assert status.raw_failure_samples[0].failure_kind == "parse_error"
+
+    def test_daemon_status_defaults_to_empty_list(self) -> None:
+        status = DaemonStatus()
+        assert status.raw_failure_samples == []
+
+    def test_daemon_status_model_dump_serializes_samples(self) -> None:
+        samples = [
+            RawFailureSample(
+                failure_kind="schema_violation",
+                provider_hint=None,
+                redacted_error="Missing required field: title",
+            )
+        ]
+        status = DaemonStatus(raw_failure_samples=samples)
+        dumped = status.model_dump()
+        assert isinstance(dumped["raw_failure_samples"], list)
+        assert dumped["raw_failure_samples"][0]["failure_kind"] == "schema_violation"
+        assert dumped["raw_failure_samples"][0]["provider_hint"] is None
+        assert "Missing required field" in dumped["raw_failure_samples"][0]["redacted_error"]
+
+    def test_rejects_non_RawFailureSample_items(self) -> None:
+        with pytest.raises(ValidationError):
+            DaemonStatus(raw_failure_samples=["not a model"])  # type: ignore[list-item]
+
+
+class TestRawFailureInfoProducesTypedSamples:
+    """_raw_failure_info() returns typed RawFailureSample instances."""
+
+    def test_raw_failure_info_samples_are_typed(self, tmp_path: Path) -> None:
+        db = tmp_path / "polylogue.db"
+        with sqlite3.connect(db) as conn:
+            conn.executescript(
+                """
+                CREATE TABLE raw_conversations (
+                    raw_id TEXT PRIMARY KEY,
+                    provider_name TEXT NOT NULL,
+                    payload_provider TEXT,
+                    source_name TEXT,
+                    source_path TEXT NOT NULL,
+                    source_index INTEGER,
+                    blob_size INTEGER NOT NULL,
+                    acquired_at TEXT NOT NULL,
+                    file_mtime TEXT,
+                    parsed_at TEXT,
+                    parse_error TEXT,
+                    validated_at TEXT,
+                    validation_status TEXT,
+                    validation_error TEXT,
+                    validation_drift_count INTEGER DEFAULT 0,
+                    validation_provider TEXT,
+                    validation_mode TEXT,
+                    detection_warnings TEXT
+                );
+                INSERT INTO raw_conversations (
+                    raw_id, provider_name, source_path, blob_size, acquired_at,
+                    parse_error, validation_status
+                ) VALUES (
+                    'raw-1', 'claude-code', '/data/session.jsonl', 1024,
+                    '2025-01-01T00:00:00Z',
+                    'JSONDecodeError: Unterminated string at /home/user/file.py:202',
+                    NULL
+                );
+                """
+            )
+
+        with patch("polylogue.daemon.status.db_path", return_value=db):
+            info = _raw_failure_info()
+
+        samples = info["samples"]
+        assert isinstance(samples, list)
+        assert len(samples) == 1
+        sample = samples[0]
+        assert isinstance(sample, RawFailureSample)
+        assert sample.failure_kind == "decode_error"
+        assert sample.provider_hint == "claude-code"
+        assert "/home/user/file.py" not in sample.redacted_error
+        assert "JSONDecodeError" in sample.redacted_error
+
+    def test_raw_failure_info_schema_violation_kind(self, tmp_path: Path) -> None:
+        db = tmp_path / "polylogue.db"
+        with sqlite3.connect(db) as conn:
+            conn.executescript(
+                """
+                CREATE TABLE raw_conversations (
+                    raw_id TEXT PRIMARY KEY,
+                    provider_name TEXT NOT NULL,
+                    payload_provider TEXT,
+                    source_name TEXT,
+                    source_path TEXT NOT NULL,
+                    source_index INTEGER,
+                    blob_size INTEGER NOT NULL,
+                    acquired_at TEXT NOT NULL,
+                    file_mtime TEXT,
+                    parsed_at TEXT,
+                    parse_error TEXT,
+                    validated_at TEXT,
+                    validation_status TEXT,
+                    validation_error TEXT,
+                    validation_drift_count INTEGER DEFAULT 0,
+                    validation_provider TEXT,
+                    validation_mode TEXT,
+                    detection_warnings TEXT
+                );
+                INSERT INTO raw_conversations (
+                    raw_id, provider_name, source_path, blob_size, acquired_at,
+                    parse_error, validation_status, validation_error
+                ) VALUES (
+                    'raw-2', 'chatgpt', '/data/conv.json', 512,
+                    '2025-02-01T00:00:00Z',
+                    NULL, 'FAILED', 'Missing required field: mapping'
+                );
+                """
+            )
+
+        with patch("polylogue.daemon.status.db_path", return_value=db):
+            info = _raw_failure_info()
+
+        samples = info["samples"]
+        assert len(samples) == 1
+        sample = samples[0]
+        assert isinstance(sample, RawFailureSample)
+        assert sample.failure_kind == "schema_violation"
+        assert sample.provider_hint == "chatgpt"
+
+    def test_raw_failure_info_generic_parse_error_kind(self, tmp_path: Path) -> None:
+        db = tmp_path / "polylogue.db"
+        with sqlite3.connect(db) as conn:
+            conn.executescript(
+                """
+                CREATE TABLE raw_conversations (
+                    raw_id TEXT PRIMARY KEY,
+                    provider_name TEXT NOT NULL,
+                    payload_provider TEXT,
+                    source_name TEXT,
+                    source_path TEXT NOT NULL,
+                    source_index INTEGER,
+                    blob_size INTEGER NOT NULL,
+                    acquired_at TEXT NOT NULL,
+                    file_mtime TEXT,
+                    parsed_at TEXT,
+                    parse_error TEXT,
+                    validated_at TEXT,
+                    validation_status TEXT,
+                    validation_error TEXT,
+                    validation_drift_count INTEGER DEFAULT 0,
+                    validation_provider TEXT,
+                    validation_mode TEXT,
+                    detection_warnings TEXT
+                );
+                INSERT INTO raw_conversations (
+                    raw_id, provider_name, source_path, blob_size, acquired_at,
+                    parse_error, validation_status
+                ) VALUES (
+                    'raw-3', 'unknown', '/data/bad.json', 256,
+                    '2025-03-01T00:00:00Z',
+                    'Some weird error', NULL
+                );
+                """
+            )
+
+        with patch("polylogue.daemon.status.db_path", return_value=db):
+            info = _raw_failure_info()
+
+        samples = info["samples"]
+        assert len(samples) == 1
+        sample = samples[0]
+        assert isinstance(sample, RawFailureSample)
+        # Non-JSON parse error → "parse_error" (the error IS a parse error, just not JSON-specific)
+        assert sample.failure_kind == "parse_error"
+
+    def test_raw_failure_info_empty_when_no_failures(self, tmp_path: Path) -> None:
+        db = tmp_path / "polylogue.db"
+        with sqlite3.connect(db) as conn:
+            conn.executescript(
+                """
+                CREATE TABLE raw_conversations (
+                    raw_id TEXT PRIMARY KEY,
+                    provider_name TEXT NOT NULL,
+                    payload_provider TEXT,
+                    source_name TEXT,
+                    source_path TEXT NOT NULL,
+                    source_index INTEGER,
+                    blob_size INTEGER NOT NULL,
+                    acquired_at TEXT NOT NULL,
+                    file_mtime TEXT,
+                    parsed_at TEXT,
+                    parse_error TEXT,
+                    validated_at TEXT,
+                    validation_status TEXT,
+                    validation_error TEXT,
+                    validation_drift_count INTEGER DEFAULT 0,
+                    validation_provider TEXT,
+                    validation_mode TEXT,
+                    detection_warnings TEXT
+                );
+                """
+            )
+
+        with patch("polylogue.daemon.status.db_path", return_value=db):
+            info = _raw_failure_info()
+
+        assert info["parse_failures"] == 0
+        assert info["validation_failures"] == 0
+        assert info["quarantined"] == 0
+        assert info["samples"] == []
+
+
+class TestRawFailureSampleRedactionPattern:
+    """Verify redaction covers realistic error path patterns."""
+
+    def test_traceback_path_redacted(self) -> None:
+        sample = RawFailureSample(
+            failure_kind="decode_error",
+            redacted_error=(
+                "Traceback (most recent call last):\n"
+                '  File "/nix/store/abc123-python3-3.12.5/lib/python3.12/json/decoder.py", line 355, in raw_decode\n'
+                '    raise JSONDecodeError("Expecting value", s, err.value) from None\n'
+                "json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)"
+            ),
+        )
+        assert "/nix/store" not in sample.redacted_error
+        assert "json.decoder.JSONDecodeError" in sample.redacted_error
+        assert "Expecting value" in sample.redacted_error
+
+    def test_single_segment_path_preserved(self) -> None:
+        """Single-segment paths like /bin or /tmp should be redacted too."""
+        sample = RawFailureSample(
+            failure_kind="parse_error",
+            redacted_error="Failed to open /tmp/out.json for reading",
+        )
+        assert "/tmp/out.json" not in sample.redacted_error
+        assert "Failed to open" in sample.redacted_error
+
+    def test_relative_paths_not_redacted(self) -> None:
+        """Relative paths like src/file.py should not be redacted."""
+        sample = RawFailureSample(
+            failure_kind="parse_error",
+            redacted_error="Missing module: src/file.py not found",
+        )
+        # Relative paths should not match the absolute-path pattern
+        assert "src/file.py" in sample.redacted_error
+
+    def test_urls_not_redacted(self) -> None:
+        """URLs should not be confused with file paths."""
+        sample = RawFailureSample(
+            failure_kind="unknown",
+            redacted_error="Connection failed to https://api.example.com/v1/data",
+        )
+        assert "https://api.example.com/v1/data" in sample.redacted_error
+
+    def test_redaction_marker_present(self) -> None:
+        sample = RawFailureSample(
+            failure_kind="decode_error",
+            redacted_error="Error in /home/user/private/file.py at line 42",
+        )
+        assert "[redacted]" in sample.redacted_error
+        assert "/home/user/private/file.py" not in sample.redacted_error
+
+    def test_null_provider_hint_defaults_to_none(self) -> None:
+        """provider_hint should be None when not provided, not empty string."""
+        sample = RawFailureSample(failure_kind="unknown")
+        assert sample.provider_hint is None


### PR DESCRIPTION
## Summary
Replaces `raw_failure_samples: list[dict[str, object]]` with typed `RawFailureSample` Pydantic model at `polylogue/daemon/status.py`. Every surface (CLI, MCP, daemon HTTP) receives the same structured taxonomy: `failure_kind` (Literal), `provider_hint`, and path-redacted `redacted_error`.

## Solution
- `RawFailureSample` model with `failure_kind: Literal["decode_error", "parse_error", "schema_violation", "unknown"]`, `provider_hint: str | None`, `redacted_error: str`
- `@field_validator("redacted_error")` strips absolute file paths at construction
- `_raw_failure_info()` constructs typed models from raw_conversations query
- CLI rendering (`status.py`) shows raw failure summary with color coding
- Daemon HTTP serializes typed samples via `model_dump()`
- `format_daemon_status_lines()` includes failure taxonomy in text payload

## Certification

### WORK
1. raw_failure_samples is typed (not list[dict[str, object]])
2. Each sample has structured failure_kind, provider_hint, redacted_error
3. Redaction enforced at construction
4. CLI, MCP, daemon HTTP all consume the typed model

### REALIZATION
1. polylogue/daemon/status.py: RawFailureSample model + DaemonStatus.raw_failure_samples typed field
2. polylogue/daemon/status.py: RawFailureSample fields with Literal + validator
3. polylogue/daemon/status.py: _PATH_REDACTION_RE + _redact_file_paths field_validator
4. polylogue/cli/commands/status.py (CLI), polylogue/daemon/status.py:daemon_status_payload (HTTP), format_daemon_status_lines (text)
   test: tests/unit/daemon/test_raw_failure_sample.py

### DECLARATION
I declare every WORK item above to be fully realized by the matching REALIZATION entry, with no deferrals, narrowings, or implicit successors. Verified by: ruff check/formatted; mypy strict; test_raw_failure_sample module covers model contract, redaction, serialization, and daemon integration.

Refs #844

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Daemon status output now displays raw failure metrics, including total failure counts, quarantined items, and breakdown by failure type.

* **Tests**
  * Added comprehensive test coverage for failure sample handling and daemon status validation.

* **Documentation**
  * Updated governance and documentation structure with reorganized content sources.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sinity/polylogue/pull/979)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->