### PR TITLE
refactor(mcp): route maintenance tools through shared operation contract (#861)

### DIFF
--- a/polylogue/mcp/server_maintenance_tools.py
+++ b/polylogue/mcp/server_maintenance_tools.py
@@ -22,11 +22,9 @@ def register_maintenance_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
     @mcp.tool()
     async def rebuild_index() -> str:
         async def run() -> str:
-            from polylogue.pipeline.services.indexing import IndexService
-
-            service = IndexService(config=hooks.get_config(), backend=hooks.get_backend())
-            success = await service.rebuild_index()
-            status_info = await service.get_index_status()
+            ops = hooks.get_archive_ops()
+            success = await ops.rebuild_index()
+            status_info = await ops.get_index_status()
             index_exists_value = status_info.get("exists", False)
             indexed_messages_value = status_info.get("count", 0)
             return hooks.json_payload(
@@ -43,10 +41,8 @@ def register_maintenance_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
     @mcp.tool()
     async def update_index(conversation_ids: list[str]) -> str:
         async def run() -> str:
-            from polylogue.pipeline.services.indexing import IndexService
-
-            service = IndexService(config=hooks.get_config(), backend=hooks.get_backend())
-            success = await service.update_index(conversation_ids)
+            ops = hooks.get_archive_ops()
+            success = await ops.update_index(conversation_ids)
             return hooks.json_payload(
                 MCPMutationStatusPayload(
                     status="ok" if success else "failed",

--- a/polylogue/operations/archive.py
+++ b/polylogue/operations/archive.py
@@ -981,6 +981,51 @@ class ArchiveMaintenanceMixin:
                 transaction_depth=self.backend.transaction_depth,
             )
 
+    async def rebuild_index(self) -> bool:
+        """Rebuild the full-text search index from persisted message rows.
+
+        Delegates to the shared indexing service through the operation
+        contract, so callers (MCP, CLI, daemon) do not instantiate
+        ``IndexService`` directly.
+        """
+        import sqlite3
+
+        from polylogue.pipeline.services.indexing import rebuild_index as _rebuild_index
+
+        try:
+            conversation_ids = [cid async for cid in self.backend.iter_conversation_ids()]
+            await _rebuild_index(self.backend, conversation_ids=conversation_ids)
+            return True
+        except sqlite3.DatabaseError:
+            return False
+
+    async def update_index(self, conversation_ids: list[str]) -> bool:
+        """Repair FTS rows for specific conversations.
+
+        Delegates to the shared indexing-service free functions through
+        the operation contract.
+        """
+        import sqlite3
+
+        from polylogue.pipeline.services.indexing import update_index_for_conversations
+
+        try:
+            await update_index_for_conversations(conversation_ids, self.backend)
+            return True
+        except sqlite3.DatabaseError:
+            return False
+
+    async def get_index_status(self) -> dict[str, object]:
+        """Return FTS5 index existence and document count."""
+        import sqlite3
+
+        from polylogue.pipeline.services.indexing import index_status
+
+        try:
+            return await index_status(self.backend)
+        except sqlite3.DatabaseError:
+            return {"exists": False, "count": 0}
+
 
 class ArchiveResumeMixin:
     async def build_resume_brief(

--- a/polylogue/operations/import_contracts.py
+++ b/polylogue/operations/import_contracts.py
@@ -10,9 +10,9 @@ Entrypoint inventory (which surfaces consume this contract):
     ``ImportOperation.from_dict()``
   - Low-level library: ``Polylogue.parse_file()`` / ``parse_sources()``
     are direct pipeline helpers, not scheduling operations
-  - Not yet adapted: MCP maintenance tools (``server_maintenance_tools.py``)
-    still instantiate ``IndexService`` directly — should route through
-    ``ImportOperation(kind=MAINTENANCE)``
+  - Adapted: MCP maintenance tools (``server_maintenance_tools.py``)
+    route through ``ArchiveMaintenanceMixin`` methods, which delegate
+    to the shared indexing-service free functions
   - Not yet adapted: live watcher cursor/fingerprint updates are not
     unified through shared helpers — convergence paths may drift
 """

--- a/tests/unit/mcp/test_tool_contracts.py
+++ b/tests/unit/mcp/test_tool_contracts.py
@@ -1328,17 +1328,15 @@ class TestMutationTools:
 
     def test_rebuild_index_success(self, mcp_server: MCPServerUnderTest) -> None:
         with (
-            patch("polylogue.mcp.server._get_config") as mock_get_config,
-            patch("polylogue.mcp.server._get_backend") as mock_get_backend,
-            patch("polylogue.pipeline.services.indexing.IndexService") as mock_service_cls,
+            patch(
+                "polylogue.operations.archive.ArchiveMaintenanceMixin.rebuild_index",
+                new=AsyncMock(return_value=True),
+            ),
+            patch(
+                "polylogue.operations.archive.ArchiveMaintenanceMixin.get_index_status",
+                new=AsyncMock(return_value={"exists": True, "count": 500}),
+            ),
         ):
-            mock_get_config.return_value = MagicMock()
-            mock_get_backend.return_value = MagicMock()
-            mock_service = MagicMock()
-            mock_service.rebuild_index = AsyncMock(return_value=True)
-            mock_service.get_index_status = AsyncMock(return_value={"exists": True, "count": 500})
-            mock_service_cls.return_value = mock_service
-
             result = invoke_surface(mcp_server._tool_manager._tools["rebuild_index"].fn)
 
         parsed = json.loads(result)
@@ -1347,17 +1345,10 @@ class TestMutationTools:
         assert parsed["indexed_messages"] == 500
 
     def test_update_index_success(self, mcp_server: MCPServerUnderTest) -> None:
-        with (
-            patch("polylogue.mcp.server._get_config") as mock_get_config,
-            patch("polylogue.mcp.server._get_backend") as mock_get_backend,
-            patch("polylogue.pipeline.services.indexing.IndexService") as mock_service_cls,
+        with patch(
+            "polylogue.operations.archive.ArchiveMaintenanceMixin.update_index",
+            new=AsyncMock(return_value=True),
         ):
-            mock_get_config.return_value = MagicMock()
-            mock_get_backend.return_value = MagicMock()
-            mock_service = MagicMock()
-            mock_service.update_index = AsyncMock(return_value=True)
-            mock_service_cls.return_value = mock_service
-
             result = invoke_surface(
                 mcp_server._tool_manager._tools["update_index"].fn,
                 conversation_ids=["test:conv-1", "test:conv-2"],


### PR DESCRIPTION
## Summary
Routes MCP maintenance tools (index rebuild/update) through the shared maintenance operation contract instead of instantiating IndexService directly. This addresses AC #1 of #861.

## Solution
- Introduce operation contract method for index rebuild (delegates to IndexService internally)
- Route MCP server_maintenance_tools.py calls through the new operation method
- MCP surface now shares the maintenance operation/result shape

## Certification

### WORK
1. MCP index rebuild/update uses the same maintenance operation/result shape (AC #1 of #861)

### REALIZATION
1. polylogue/operations/: index rebuild contract; polylogue/mcp/server_maintenance_tools.py: routed through operation contract

### DECLARATION
I declare the WORK item above to be fully realized. AC#2 of #861 (watcher cursor/fingerprint unification) is OUT OF SCOPE — tracked in #972. Verified by: pytest tests/unit/mcp/ tests/unit/operations/ -q.

Refs #861