### PR TITLE
test(pipeline): add promoted columns to ingest batch test helper tuple (#864)

### DIFF
--- a/tests/unit/pipeline/test_ingest_batch.py
+++ b/tests/unit/pipeline/test_ingest_batch.py
@@ -132,6 +132,9 @@ def _conversation_data(
         None,
         raw_id,
         "",
+        None,  # working_directories_json
+        None,  # git_branch
+        None,  # git_repository_url
     )
     return ConversationData(
         conversation_id=conversation_id,


### PR DESCRIPTION
## Summary

Adds `working_directories_json`, `git_branch`, and `git_repository_url` to the
batch ingest test helper (`_conversation_data`) so 18-element tuples match the
UPSERT SQL that already has these promoted columns on master.

## Problem

Master already has the promoted columns wired through materialization, upsert,
and row hydration. The test helper was not updated to match — producing
15-element tuples where the UPSERT expects 18.

## Solution

Add 3 `None` values to the test helper tuple at indices 15-17.

## Verification

```
pytest tests/unit/pipeline/test_ingest_batch.py -q  # 26 passed
pytest tests/unit/archive/ tests/unit/storage/ tests/unit/pipeline/ -q  # 1031 passed
```

Refs #864