### PR TITLE
feat(maintenance): add message_type backfill for pre-#839 rows

### DIFF
--- a/docs/plans/file-size-budgets.yaml
+++ b/docs/plans/file-size-budgets.yaml
@@ -58,8 +58,8 @@ exceptions:
     reason: "tracked split into routing/execution/output suites"
 
   - path: polylogue/storage/repair.py
-    ceiling: 1200
-    reason: "added blob orphan detection, cleanup, and integrity verification (#818)"
+    ceiling: 1300
+    reason: "added blob orphan detection, cleanup, integrity verification (#818), and message_type backfill (#839)"
 
   - path: polylogue/storage/sqlite/schema_bootstrap.py
     ceiling: 1300

--- a/polylogue/maintenance/targets.py
+++ b/polylogue/maintenance/targets.py
@@ -181,6 +181,15 @@ MAINTENANCE_TARGET_SPECS: tuple[MaintenanceTargetSpec, ...] = (
         doctor_repair_operation="index-message-fts",
     ),
     MaintenanceTargetSpec(
+        name="message_type_backfill",
+        mode=MaintenanceTargetMode.REPAIR,
+        category=MaintenanceCategory.DERIVED_REPAIR,
+        destructive=False,
+        description="Backfill message_type for rows ingested before context/protocol classification (#839).",
+        include_preview_when_ready=True,
+        doctor_repair_operation="backfill-message-type",
+    ),
+    MaintenanceTargetSpec(
         name="wal_checkpoint",
         mode=MaintenanceTargetMode.REPAIR,
         category=MaintenanceCategory.DATABASE_MAINTENANCE,

--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -77,6 +77,24 @@ class _SessionInsightRepairAssessment:
 
 
 # ---------------------------------------------------------------------------
+# Unclassified message_type count
+# ---------------------------------------------------------------------------
+
+
+def count_unclassified_message_type_sync(conn: sqlite3.Connection) -> int:
+    """Count messages whose ``message_type`` is still the default ``message``
+    and whose text could carry context or protocol markers.
+
+    This is the preview count for the #839 message_type backfill.
+    """
+    return int(
+        conn.execute(
+            "SELECT COUNT(*) FROM messages WHERE message_type = 'message'  AND text IS NOT NULL AND text != ''"
+        ).fetchone()[0]
+    )
+
+
+# ---------------------------------------------------------------------------
 # Orphan count queries (formerly archive_debt_counts)
 # ---------------------------------------------------------------------------
 
@@ -384,6 +402,7 @@ def collect_archive_debt_statuses_sync(
     session_insights = session_insight_repair_count(statuses)
     action_events = action_event_repair_count(statuses)
     dangling_fts = dangling_fts_repair_count(statuses)
+    _unclassified = count_unclassified_message_type_sync(conn)
 
     debt_statuses = {
         "orphaned_messages": _archive_debt_status(
@@ -429,6 +448,13 @@ def collect_archive_debt_statuses_sync(
             "dangling_fts",
             issue_count=dangling_fts,
             detail="FTS synchronized" if dangling_fts == 0 else f"{dangling_fts:,} dangling FTS rows",
+        ),
+        "message_type_backfill": _archive_debt_status(
+            "message_type_backfill",
+            issue_count=_unclassified,
+            detail="No unclassified messages"
+            if _unclassified == 0
+            else f"{_unclassified:,} candidate messages to classify",
         ),
     }
     if include_expensive:
@@ -1000,10 +1026,109 @@ def repair_wal_checkpoint(config: Config, dry_run: bool = False) -> RepairResult
         )
 
 
+def preview_message_type_backfill(*, count: int) -> RepairResult:
+    """Preview handler for the #839 message_type backfill."""
+    return _repair_result(
+        "message_type_backfill",
+        repaired_count=count,
+        success=True,
+        detail=(f"Would: {count:,} candidate messages to classify" if count else "No unclassified messages"),
+    )
+
+
+def repair_message_type_backfill(config: Config, dry_run: bool = False) -> RepairResult:
+    """Backfill ``message_type`` for pre-#839 rows using ``classify_text_message_type``.
+
+    Iterates messages whose ``message_type`` is still the default ``message``,
+    applies the same classification logic used for new-ingest materialization,
+    and updates to ``context`` or ``protocol`` where markers match.
+
+    Idempotent: rows already classified are skipped by the WHERE clause.
+    """
+    from polylogue.archive.message.artifacts import classify_text_message_type
+    from polylogue.storage.sqlite.connection import connection_context
+
+    try:
+        with connection_context(None) as conn:
+            if dry_run:
+                count = count_unclassified_message_type_sync(conn)
+                return preview_message_type_backfill(count=count)
+
+            updated = 0
+            batch_size = 1000
+            offset = 0
+
+            while True:
+                rows = conn.execute(
+                    "SELECT rowid, message_id, text FROM messages"
+                    " WHERE message_type = 'message'"
+                    "  AND text IS NOT NULL AND text != ''"
+                    " ORDER BY rowid"
+                    " LIMIT ? OFFSET ?",
+                    (batch_size, offset),
+                ).fetchall()
+
+                if not rows:
+                    break
+
+                context_ids: list[int] = []
+                protocol_ids: list[int] = []
+
+                for row in rows:
+                    rowid_val, _message_id, text = row
+                    mt = classify_text_message_type(text)
+                    if mt is not None:
+                        from polylogue.archive.message.types import MessageType
+
+                        if mt == MessageType.CONTEXT:
+                            context_ids.append(rowid_val)
+                        elif mt == MessageType.PROTOCOL:
+                            protocol_ids.append(rowid_val)
+
+                if context_ids:
+                    placeholders = ",".join("?" * len(context_ids))
+                    conn.execute(
+                        f"UPDATE messages SET message_type = 'context' WHERE rowid IN ({placeholders})",
+                        context_ids,
+                    )
+                    updated += conn.total_changes
+
+                if protocol_ids:
+                    placeholders = ",".join("?" * len(protocol_ids))
+                    conn.execute(
+                        f"UPDATE messages SET message_type = 'protocol' WHERE rowid IN ({placeholders})",
+                        protocol_ids,
+                    )
+                    updated += conn.total_changes
+
+                offset += batch_size
+
+            conn.commit()
+            logger.info(
+                "message_type_backfill_complete",
+                updated=updated,
+            )
+            return _repair_result(
+                "message_type_backfill",
+                repaired_count=updated,
+                success=True,
+                detail=f"Classified {updated:,} messages as context or protocol",
+            )
+    except Exception as exc:
+        logger.exception("message_type_backfill_failed", error=str(exc))
+        return _repair_result(
+            "message_type_backfill",
+            repaired_count=0,
+            success=False,
+            detail=f"Backfill failed: {exc}",
+        )
+
+
 _PREVIEW_HANDLERS: dict[str, Callable[..., RepairResult]] = {
     "session_insights": preview_session_insights,
     "action_event_read_model": preview_action_event_read_model,
     "dangling_fts": preview_dangling_fts,
+    "message_type_backfill": preview_message_type_backfill,
     "orphaned_messages": preview_orphaned_messages,
     "orphaned_content_blocks": preview_orphaned_content_blocks,
     "empty_conversations": preview_empty_conversations,
@@ -1015,6 +1140,7 @@ _REPAIR_HANDLERS: dict[str, Callable[..., RepairResult]] = {
     "session_insights": repair_session_insights,
     "action_event_read_model": repair_action_event_read_model,
     "dangling_fts": repair_dangling_fts,
+    "message_type_backfill": repair_message_type_backfill,
     "wal_checkpoint": repair_wal_checkpoint,
     "orphaned_messages": repair_orphaned_messages,
     "orphaned_content_blocks": repair_orphaned_content_blocks,
@@ -1126,6 +1252,7 @@ __all__ = [
     "count_orphaned_blobs_sync",
     "count_orphaned_content_blocks_sync",
     "count_orphaned_messages_sync",
+    "count_unclassified_message_type_sync",
     "dangling_fts_repair_count",
     "preview_action_event_read_model",
     "preview_counts_from_archive_debt",
@@ -1135,10 +1262,12 @@ __all__ = [
     "preview_orphaned_blobs",
     "preview_orphaned_content_blocks",
     "preview_orphaned_messages",
+    "preview_message_type_backfill",
     "preview_session_insights",
     "repair_action_event_read_model",
     "repair_dangling_fts",
     "repair_empty_conversations",
+    "repair_message_type_backfill",
     "repair_orphaned_attachments",
     "repair_orphaned_blobs",
     "repair_orphaned_content_blocks",

--- a/tests/unit/core/test_maintenance_targets.py
+++ b/tests/unit/core/test_maintenance_targets.py
@@ -37,11 +37,12 @@ def test_maintenance_target_catalog_reports_preview_and_help_semantics() -> None
         "session_insights",
         "action_event_read_model",
         "dangling_fts",
+        "message_type_backfill",
     )
     assert catalog.help_text() == (
         "Limit maintenance to named targets such as session_insights, action_event_read_model, "
-        "dangling_fts, wal_checkpoint, orphaned_messages, orphaned_content_blocks, "
-        "empty_conversations, orphaned_attachments, or orphaned_blobs"
+        "dangling_fts, message_type_backfill, wal_checkpoint, orphaned_messages, "
+        "orphaned_content_blocks, empty_conversations, orphaned_attachments, or orphaned_blobs"
     )
 
 

--- a/tests/unit/pipeline/test_message_type_backfill.py
+++ b/tests/unit/pipeline/test_message_type_backfill.py
@@ -1,0 +1,210 @@
+"""Tests for #839 AC #2: backfill pre-#839 message_type rows."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from polylogue.config import Config
+from polylogue.storage.repair import repair_message_type_backfill
+from polylogue.storage.sqlite.connection import connection_context
+from tests.infra.storage_records import ConversationBuilder
+
+
+def _make_db_with_messages(db_path: Path) -> str:
+    """Create a database with test messages, return conv_id."""
+    conv_id = "conv-backfill-1"
+    builder = ConversationBuilder(db_path, conv_id)
+    builder.title("Backfill Test")
+
+    # Context markers (#839 context set)
+    builder.add_message(
+        message_id="ctx-1",
+        role="user",
+        text="<environment_context>\n<cwd>/x</cwd>\n</environment_context>",
+        message_type="message",
+    )
+    builder.add_message(
+        message_id="ctx-2",
+        role="user",
+        text="<system-reminder>ignored</system-reminder>\n\n<system>\nYou are an agent\n</system>",
+        message_type="message",
+    )
+    builder.add_message(
+        message_id="ctx-3",
+        role="user",
+        text="Base directory for this skill: /tmp/skill\n\n# Instructions",
+        message_type="message",
+    )
+
+    # Protocol markers (#839 protocol set)
+    builder.add_message(
+        message_id="proto-1",
+        role="user",
+        text="<bash-input>ls</bash-input>",
+        message_type="message",
+    )
+    builder.add_message(
+        message_id="proto-2",
+        role="user",
+        text="<task-notification><status>completed</status></task-notification>",
+        message_type="message",
+    )
+
+    # Plain messages (should stay 'message')
+    builder.add_message(
+        message_id="plain-1",
+        role="user",
+        text="Hello, how are you?",
+        message_type="message",
+    )
+    builder.add_message(
+        message_id="plain-2",
+        role="assistant",
+        text="I'm doing well, thanks!",
+        message_type="message",
+    )
+
+    # Already-classified messages (should not change)
+    builder.add_message(
+        message_id="already-done",
+        role="user",
+        text="<environment_context>\n<more/>\n</environment_context>",
+        message_type="context",
+    )
+
+    builder.save()
+    return conv_id
+
+
+def _make_config(workspace_env: dict[str, Path], db_path: Path) -> Config:
+    """Create a minimal Config for tests."""
+    return Config(
+        archive_root=Path(workspace_env["archive_root"]),
+        render_root=Path(workspace_env["archive_root"]),
+        sources=[],
+        db_path=db_path,
+    )
+
+
+class TestMessageTypeBackfill:
+    """Integration tests for the #839 message_type backfill repair."""
+
+    def test_backfill_classes_context_messages(
+        self, workspace_env: dict[str, Path], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Messages matching context markers get message_type = 'context'."""
+        db_path = Path(workspace_env["archive_root"]) / "polylogue.db"
+        conv_id = _make_db_with_messages(db_path)
+
+        cfg = _make_config(workspace_env, db_path)
+        monkeypatch.setattr("polylogue.paths.db_path", lambda: db_path)
+
+        result = repair_message_type_backfill(cfg, dry_run=False)
+        assert result.success, result.detail
+        assert result.repaired_count > 0
+
+        with connection_context(db_path) as conn:
+            # Context messages classified
+            for mid in ("ctx-1", "ctx-2", "ctx-3"):
+                row = conn.execute(
+                    "SELECT message_type FROM messages WHERE message_id = ?",
+                    (f"{mid}",),
+                ).fetchone()
+                assert row is not None, f"Missing message {mid}"
+                assert row[0] == "context", f"{mid}: expected context, got {row[0]}"
+
+            # Protocol messages classified
+            for mid in ("proto-1", "proto-2"):
+                row = conn.execute(
+                    "SELECT message_type FROM messages WHERE message_id = ?",
+                    (f"{mid}",),
+                ).fetchone()
+                assert row is not None, f"Missing message {mid}"
+                assert row[0] == "protocol", f"{mid}: expected protocol, got {row[0]}"
+
+            # Plain messages unchanged
+            for mid in ("plain-1", "plain-2"):
+                row = conn.execute(
+                    "SELECT message_type FROM messages WHERE message_id = ?",
+                    (f"{mid}",),
+                ).fetchone()
+                assert row is not None, f"Missing message {mid}"
+                assert row[0] == "message", f"{mid}: expected message, got {row[0]}"
+
+            # Already-classified message unchanged
+            row = conn.execute(
+                "SELECT message_type FROM messages WHERE message_id = ?",
+                ("already-done",),
+            ).fetchone()
+            assert row is not None
+            assert row[0] == "context", f"already-classified: expected context, got {row[0]}"
+
+    def test_backfill_is_idempotent(self, workspace_env: dict[str, Path], monkeypatch: pytest.MonkeyPatch) -> None:
+        """A second run of the backfill is a no-op."""
+        db_path = Path(workspace_env["archive_root"]) / "polylogue.db"
+        _make_db_with_messages(db_path)
+
+        cfg = _make_config(workspace_env, db_path)
+        monkeypatch.setattr("polylogue.paths.db_path", lambda: db_path)
+
+        # First run
+        result1 = repair_message_type_backfill(cfg, dry_run=False)
+        assert result1.success
+        first_count = result1.repaired_count
+        assert first_count > 0
+
+        # Second run: should be a no-op
+        result2 = repair_message_type_backfill(cfg, dry_run=False)
+        assert result2.success
+        assert result2.repaired_count == 0, f"Second run should be no-op, but repaired {result2.repaired_count}"
+
+    def test_backfill_matches_pipeline_classification(
+        self, workspace_env: dict[str, Path], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Backfill uses the same classify_text_message_type as new-ingest pipeline."""
+        from polylogue.archive.message.artifacts import classify_text_message_type
+        from polylogue.archive.message.types import MessageType
+
+        test_cases = [
+            ("<environment_context>\n<cwd>/x</cwd>\n</environment_context>", MessageType.CONTEXT),
+            (
+                "<system-reminder>ignored</system-reminder>\n\n<system>\nYou are an agent\n</system>",
+                MessageType.CONTEXT,
+            ),
+            ("Base directory for this skill: /tmp/skill\n\n# body", MessageType.CONTEXT),
+            ("<bash-input>ls</bash-input>", MessageType.PROTOCOL),
+            ("<task-notification><status>done</status></task-notification>", MessageType.PROTOCOL),
+            (
+                "Caveat: The messages below were generated by the user while running local commands.",
+                MessageType.PROTOCOL,
+            ),
+            ("Hello, how are you?", None),
+            ("I'm an assistant response.", None),
+            ("", None),
+            (None, None),
+        ]
+
+        for text, expected in test_cases:
+            result = classify_text_message_type(text)
+            assert result == expected, f"classify({text!r}) = {result}, expected {expected}"
+
+    def test_dry_run_does_not_mutate(self, workspace_env: dict[str, Path], monkeypatch: pytest.MonkeyPatch) -> None:
+        """Dry-run reports count but does not change any rows."""
+        db_path = Path(workspace_env["archive_root"]) / "polylogue.db"
+        _make_db_with_messages(db_path)
+
+        cfg = _make_config(workspace_env, db_path)
+        monkeypatch.setattr("polylogue.paths.db_path", lambda: db_path)
+
+        result = repair_message_type_backfill(cfg, dry_run=True)
+        assert result.success
+        assert result.repaired_count > 0, "Dry-run should count candidate rows"
+
+        # Verify no rows were mutated
+        with connection_context(db_path) as conn:
+            count = conn.execute(
+                "SELECT COUNT(*) FROM messages WHERE message_type IN ('context', 'protocol')"
+            ).fetchone()[0]
+            assert count == 1, f"Only the pre-existing 'context' row should exist, found {count}"

--- a/tests/unit/pipeline/test_message_type_backfill.py
+++ b/tests/unit/pipeline/test_message_type_backfill.py
@@ -96,7 +96,7 @@ class TestMessageTypeBackfill:
     ) -> None:
         """Messages matching context markers get message_type = 'context'."""
         db_path = Path(workspace_env["archive_root"]) / "polylogue.db"
-        conv_id = _make_db_with_messages(db_path)
+        _make_db_with_messages(db_path)
 
         cfg = _make_config(workspace_env, db_path)
         monkeypatch.setattr("polylogue.paths.db_path", lambda: db_path)


### PR DESCRIPTION
## Summary
Adds an idempotent message_type backfill repair operation that classifies pre-#839 rows (context/protocol markers) using the same `classify_text_message_type` logic as new-ingest materialization.

## Problem
#894 gave new rows CONTEXT/PROTOCOL message types and #977 dropped the runtime classifier fallback. But rows ingested before #894 still have the default `message_type = 'message'`, even when their text matches known context or protocol markers. The existing v2-to-v3 backfill only handles thinking/tool_use/tool_result types.

## Solution
Added `repair_message_type_backfill` in `polylogue/storage/repair.py` that:
- Batches over messages with `message_type = 'message'` and non-empty text
- Applies `classify_text_message_type()` — the same function used at materialization time
- Updates matched rows to `context` or `protocol`
- Is idempotent: second run is a no-op (classified rows no longer match the WHERE clause)

Registered as `message_type_backfill` maintenance target. Accessible via:
```bash
polylogue doctor --repair --target message_type_backfill
```

## Verification
```
pytest tests/unit/pipeline/test_message_type_backfill.py tests/unit/core/test_maintenance_targets.py tests/unit/storage/test_repair.py tests/unit/archive/test_model_runtime_no_runtime_classify.py -q
31 passed
```
Devtools verify --quick passes (pre-existing file-size overages in daemon/status.py and operations/archive.py remain).

Refs #839

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>