### PR TITLE
refactor(mutations): centralize tag operations through shared contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,7 +87,7 @@ Issues and PR bodies are durable artifacts. Write them for a reader who
 has no conversation context — they should stand alone. Include file
 paths, acceptance criteria, and design references where applicable.
 
-<!-- begin include: /realm/project/polylogue/CONTRIBUTING.md -->
+<!-- begin include: /realm/project/polylogue/.claude/worktrees/agent-a81e3a2a/CONTRIBUTING.md -->
 # Contributing
 
 ## Development Environment
@@ -337,8 +337,8 @@ The PR title becomes the squash-merge subject on `master`. Rules:
 - ≤72 characters, conventional prefix, imperative mood
 - Describes what changed, not what was worked on
 - Accurate — do not claim alignment or unification unless the diff achieves it
-<!-- end include: /realm/project/polylogue/CONTRIBUTING.md -->
-<!-- begin include: /realm/project/polylogue/TESTING.md -->
+<!-- end include: /realm/project/polylogue/.claude/worktrees/agent-a81e3a2a/CONTRIBUTING.md -->
+<!-- begin include: /realm/project/polylogue/.claude/worktrees/agent-a81e3a2a/TESTING.md -->
 # Testing
 
 All commands below assume you are inside the project devshell. See
@@ -448,8 +448,8 @@ Never delete:
   shapes.
 - **`tests/unit/security/`**: Security boundary tests.
 
-<!-- end include: /realm/project/polylogue/TESTING.md -->
-<!-- begin include: /realm/project/polylogue/docs/architecture.md -->
+<!-- end include: /realm/project/polylogue/.claude/worktrees/agent-a81e3a2a/TESTING.md -->
+<!-- begin include: /realm/project/polylogue/.claude/worktrees/agent-a81e3a2a/docs/architecture.md -->
 # Polylogue Architecture
 
 Polylogue is a local archive for AI conversations. The system has four rings:
@@ -673,8 +673,8 @@ attachments, exports):
 - New semantics go into substrate or insights first, then surfaces adapt.
 - Proof subjects and claims live in `proof/`; devtools commands that exercise
   them live in `devtools/`.
-<!-- end include: /realm/project/polylogue/docs/architecture.md -->
-<!-- begin include: /realm/project/polylogue/docs/internals.md -->
+<!-- end include: /realm/project/polylogue/.claude/worktrees/agent-a81e3a2a/docs/architecture.md -->
+<!-- begin include: /realm/project/polylogue/.claude/worktrees/agent-a81e3a2a/docs/internals.md -->
 # Internals Reference
 
 Working map of the live codebase: invariants, hot files, extension points, and
@@ -841,8 +841,8 @@ devtools lab-scenario verify-baselines
 - `.cache/`: disposable caches (hypothesis, pytest, mypy, ruff)
 - `.local/`: untracked outputs (campaigns, showcases, build artifacts)
 - `.local/result`: out-link for `devtools build-package`
-<!-- end include: /realm/project/polylogue/docs/internals.md -->
-<!-- begin include: /realm/project/polylogue/docs/devtools.md -->
+<!-- end include: /realm/project/polylogue/.claude/worktrees/agent-a81e3a2a/docs/internals.md -->
+<!-- begin include: /realm/project/polylogue/.claude/worktrees/agent-a81e3a2a/docs/devtools.md -->
 # Developer Tools
 
 Use `devtools` for routine repository maintenance. Call individual
@@ -1017,4 +1017,4 @@ Campaign outputs live under `.local/`, not in tracked docs trees.
 
 Keep new repo-local outputs in `.cache/` or `.local/` instead of adding new
 top-level output roots.
-<!-- end include: /realm/project/polylogue/docs/devtools.md -->
+<!-- end include: /realm/project/polylogue/.claude/worktrees/agent-a81e3a2a/docs/devtools.md -->

--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -18,6 +18,7 @@ from polylogue.insights.archive import (
 )
 from polylogue.storage.insights.session.runtime import SessionInsightStatusSnapshot
 from polylogue.storage.sqlite.queries.message_query_reads import MessageTypeName
+from polylogue.surfaces.payloads import TagMutationResult
 
 if TYPE_CHECKING:
     from polylogue.archive.conversation.models import Conversation, ConversationSummary
@@ -512,8 +513,6 @@ class PolylogueArchiveMixin:
         - ``outcome="added"`` if the tag was newly added
         - ``outcome="no_op"`` if the tag was already present
         """
-        from polylogue.surfaces.payloads import TagMutationResult
-
         resolved = await self.repository.resolve_id(conversation_id, strict=True)
         if resolved is None:
             raise ConversationNotFoundError(conversation_id)
@@ -533,8 +532,6 @@ class PolylogueArchiveMixin:
         - ``outcome="removed"`` if the tag was removed
         - ``outcome="not_present"`` if the tag was not present
         """
-        from polylogue.surfaces.payloads import TagMutationResult
-
         resolved = await self.repository.resolve_id(conversation_id, strict=True)
         if resolved is None:
             raise ConversationNotFoundError(conversation_id)

--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -505,25 +505,47 @@ class PolylogueArchiveMixin:
         deleted_count = await self.filter().id(conversation_id).delete()
         return deleted_count > 0
 
-    async def add_tag(self, conversation_id: str, tag: str) -> bool:
-        """Add a tag to a conversation. Returns ``True`` if the tag was newly added."""
+    async def add_tag(self, conversation_id: str, tag: str) -> TagMutationResult:
+        """Add a tag to a conversation.
+
+        Returns a ``TagMutationResult`` with:
+        - ``outcome="added"`` if the tag was newly added
+        - ``outcome="no_op"`` if the tag was already present
+        """
+        from polylogue.surfaces.payloads import TagMutationResult
+
         resolved = await self.repository.resolve_id(conversation_id, strict=True)
         if resolved is None:
             raise ConversationNotFoundError(conversation_id)
         from polylogue.storage.repository.archive.repository_writes import RepositoryWriteMixin
 
         store: RepositoryWriteMixin = self.repository
-        return await store.add_tag(str(resolved), tag)
+        was_added = await store.add_tag(str(resolved), tag)
+        return TagMutationResult(
+            outcome="added" if was_added else "no_op",
+            detail=None if was_added else "already_present",
+        )
 
-    async def remove_tag(self, conversation_id: str, tag: str) -> bool:
-        """Remove a tag from a conversation. Returns ``True`` if the tag was removed."""
+    async def remove_tag(self, conversation_id: str, tag: str) -> TagMutationResult:
+        """Remove a tag from a conversation.
+
+        Returns a ``TagMutationResult`` with:
+        - ``outcome="removed"`` if the tag was removed
+        - ``outcome="not_present"`` if the tag was not present
+        """
+        from polylogue.surfaces.payloads import TagMutationResult
+
         resolved = await self.repository.resolve_id(conversation_id, strict=True)
         if resolved is None:
             raise ConversationNotFoundError(conversation_id)
         from polylogue.storage.repository.archive.repository_writes import RepositoryWriteMixin
 
         store: RepositoryWriteMixin = self.repository
-        return await store.remove_tag(str(resolved), tag)
+        was_removed = await store.remove_tag(str(resolved), tag)
+        return TagMutationResult(
+            outcome="removed" if was_removed else "not_present",
+            detail=None if was_removed else "tag_not_present",
+        )
 
     async def get_metadata(self, conversation_id: str) -> dict[str, str]:
         """Return all metadata key-value pairs for a conversation."""

--- a/polylogue/cli/commands/tags.py
+++ b/polylogue/cli/commands/tags.py
@@ -54,43 +54,41 @@ def tags_command(
             raise click.ClickException(f"Conversation not found: {conversation_id}")
 
         if add_tag_name:
-            was_added = run_coroutine_sync(env.polylogue.add_tag(resolved, add_tag_name))
-            status = "ok" if was_added else "unchanged"
-            detail = None if was_added else "already_present"
-            outcome = "added" if was_added else "no_op"
+            result = run_coroutine_sync(env.polylogue.add_tag(resolved, add_tag_name))
+            status = "ok" if result.outcome == "added" else "unchanged"
             if output_format == "json":
                 emit_success(
                     {
                         "status": status,
                         "conversation_id": resolved,
                         "tag": add_tag_name,
-                        "detail": detail,
-                        "outcome": outcome,
+                        "detail": result.detail,
+                        "outcome": result.outcome,
                     }
                 )
             else:
                 click.echo(
-                    f"Tag '{add_tag_name}' on {resolved}: {status} ({outcome})" + (f" ({detail})" if detail else "")
+                    f"Tag '{add_tag_name}' on {resolved}: {status} ({result.outcome})"
+                    + (f" ({result.detail})" if result.detail else "")
                 )
 
         if remove_tag_name:
-            was_removed = run_coroutine_sync(env.polylogue.remove_tag(resolved, remove_tag_name))
-            status = "ok" if was_removed else "not_found"
-            detail = None if was_removed else "tag_not_present"
-            outcome = "removed" if was_removed else "not_present"
+            result = run_coroutine_sync(env.polylogue.remove_tag(resolved, remove_tag_name))
+            status = "ok" if result.outcome == "removed" else "not_found"
             if output_format == "json":
                 emit_success(
                     {
                         "status": status,
                         "conversation_id": resolved,
                         "tag": remove_tag_name,
-                        "detail": detail,
-                        "outcome": outcome,
+                        "detail": result.detail,
+                        "outcome": result.outcome,
                     }
                 )
             else:
                 click.echo(
-                    f"Tag '{remove_tag_name}' on {resolved}: {status} ({outcome})" + (f" ({detail})" if detail else "")
+                    f"Tag '{remove_tag_name}' on {resolved}: {status} ({result.outcome})"
+                    + (f" ({result.detail})" if result.detail else "")
                 )
 
         return

--- a/polylogue/cli/query_actions.py
+++ b/polylogue/cli/query_actions.py
@@ -64,6 +64,9 @@ async def apply_modifiers(
     repo: TagStore | None = None,
 ) -> None:
     """Apply metadata modifiers to matched conversations."""
+    # When the caller passes a custom repo, use it directly.
+    # Otherwise route through the shared facade for centralized idempotency.
+    _custom_repo = repo is not None
     repo = repo or env.repository
     if not results:
         env.ui.console.print("No conversations matched.")
@@ -110,9 +113,13 @@ async def apply_modifiers(
 
         if mutation.add_tags:
             for tag in mutation.add_tags:
-                result = await env.polylogue.add_tag(result_id(conv), tag)
-                if result:
+                if _custom_repo:
+                    await repo.add_tag(result_id(conv), tag)
                     tags_added += 1
+                else:
+                    result = await env.polylogue.add_tag(result_id(conv), tag)
+                    if result:
+                        tags_added += 1
 
     reports: list[str] = []
     if tags_added:

--- a/polylogue/cli/query_actions.py
+++ b/polylogue/cli/query_actions.py
@@ -110,8 +110,9 @@ async def apply_modifiers(
 
         if mutation.add_tags:
             for tag in mutation.add_tags:
-                await repo.add_tag(result_id(conv), tag)
-                tags_added += 1
+                result = await env.polylogue.add_tag(result_id(conv), tag)
+                if result:
+                    tags_added += 1
 
     reports: list[str] = []
     if tags_added:

--- a/polylogue/mcp/server_mutation_tools.py
+++ b/polylogue/mcp/server_mutation_tools.py
@@ -35,14 +35,14 @@ def register_mutation_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
                 return err
             assert resolved is not None  # _resolve_or_error contract
             poly = hooks.get_polylogue()
-            was_added = await poly.add_tag(resolved, tag)
+            result = await poly.add_tag(resolved, tag)
             return hooks.json_payload(
                 MutationResultPayload(
-                    status="ok" if was_added else "unchanged",
+                    status="ok" if result.outcome == "added" else "unchanged",
                     conversation_id=resolved,
                     tag=tag,
-                    detail=None if was_added else "already_present",
-                    outcome="added" if was_added else "no_op",
+                    detail=result.detail,
+                    outcome=result.outcome,
                 ),
                 exclude_none=True,
             )
@@ -57,14 +57,14 @@ def register_mutation_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
                 return err
             assert resolved is not None  # _resolve_or_error contract
             poly = hooks.get_polylogue()
-            was_removed = await poly.remove_tag(resolved, tag)
+            result = await poly.remove_tag(resolved, tag)
             return hooks.json_payload(
                 MutationResultPayload(
-                    status="ok" if was_removed else "not_found",
+                    status="ok" if result.outcome == "removed" else "not_found",
                     conversation_id=resolved,
                     tag=tag,
-                    detail=None if was_removed else "tag_not_present",
-                    outcome="removed" if was_removed else "not_present",
+                    detail=result.detail,
+                    outcome=result.outcome,
                 ),
                 exclude_none=True,
             )

--- a/polylogue/surfaces/payloads.py
+++ b/polylogue/surfaces/payloads.py
@@ -10,7 +10,7 @@ from enum import Enum
 from typing import TYPE_CHECKING, Literal, NotRequired
 
 from pydantic import BaseModel, ConfigDict, Field
-from typing_extensions import TypedDict
+from typing_extensions import TypeAlias, TypedDict
 
 from polylogue.archive.semantic.content_projection import ContentProjectionSpec
 from polylogue.core.json import JSONDocument, JSONValue, require_json_document
@@ -444,6 +444,29 @@ class ConversationListResponse(SurfacePayloadModel):
     diagnostics: QueryMissDiagnosticsPayload | None = None
 
 
+TagMutationOutcome: TypeAlias = Literal["added", "no_op", "removed", "not_present"]
+"""Tag idempotency outcome exposed by all mutation surfaces."""
+
+
+class TagMutationResult(SurfacePayloadModel):
+    """Shared mutation-result contract returned by the archive facade.
+
+    Every surface (CLI, MCP, API, daemon) adapts this same result so the
+    ``bool → outcome`` mapping is centralized in one place.
+
+    Truthiness: ``added`` and ``removed`` are ``True`` (the tag changed);
+    ``no_op`` and ``not_present`` are ``False`` (nothing changed).
+    """
+
+    outcome: TagMutationOutcome
+    detail: str | None = None
+    """Machine-readable detail: ``already_present`` or ``tag_not_present``."""
+
+    def __bool__(self) -> bool:
+        """Backward-compatible truthiness for ``if result:`` patterns."""
+        return self.outcome in ("added", "removed")
+
+
 class ConversationDetailResponse(SurfacePayloadModel):
     """Shared response envelope for a single conversation detail."""
 
@@ -523,6 +546,8 @@ __all__ = [
     "QueryMissDiagnosticsPayload",
     "QueryMissReasonPayload",
     "SurfacePayloadModel",
+    "TagMutationOutcome",
+    "TagMutationResult",
     "JSONDocument",
     "JSONValue",
     "model_json_document",

--- a/polylogue/surfaces/payloads.py
+++ b/polylogue/surfaces/payloads.py
@@ -7,10 +7,10 @@ import sys
 from collections.abc import Mapping, Sequence
 from datetime import datetime
 from enum import Enum
-from typing import TYPE_CHECKING, Literal, NotRequired
+from typing import TYPE_CHECKING, Literal, NotRequired, TypeAlias
 
 from pydantic import BaseModel, ConfigDict, Field
-from typing_extensions import TypeAlias, TypedDict
+from typing_extensions import TypedDict
 
 from polylogue.archive.semantic.content_projection import ContentProjectionSpec
 from polylogue.core.json import JSONDocument, JSONValue, require_json_document

--- a/tests/unit/mcp/test_tag_idempotency.py
+++ b/tests/unit/mcp/test_tag_idempotency.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import json
 from unittest.mock import AsyncMock, patch
 
+from polylogue.surfaces.payloads import TagMutationResult
 from tests.infra.mcp import (
     MCPServerUnderTest,
     invoke_surface,
@@ -22,6 +23,11 @@ _CONV_ID = "test:conv-tag-1"
 _TAG = "review"
 
 
+def _tag_result(outcome: str, detail: str | None = None) -> TagMutationResult:
+    """Build a ``TagMutationResult`` matching the centralized facade contract."""
+    return TagMutationResult(outcome=outcome, detail=detail)  # type: ignore[arg-type]
+
+
 class TestTagIdempotencyOutcomes:
     """Each mutation path must surface the correct outcome value."""
 
@@ -33,7 +39,7 @@ class TestTagIdempotencyOutcomes:
             patch("polylogue.mcp.server._get_query_store") as mock_get_query_store,
         ):
             mock_poly = make_polylogue_mock()
-            mock_poly.add_tag = AsyncMock(return_value=True)
+            mock_poly.add_tag = AsyncMock(return_value=_tag_result("added"))
             mock_get_polylogue.return_value = mock_poly
             mock_get_query_store.return_value = make_query_store_mock(resolved_id=_CONV_ID)
 
@@ -55,7 +61,7 @@ class TestTagIdempotencyOutcomes:
             patch("polylogue.mcp.server._get_query_store") as mock_get_query_store,
         ):
             mock_poly = make_polylogue_mock()
-            mock_poly.add_tag = AsyncMock(return_value=False)
+            mock_poly.add_tag = AsyncMock(return_value=_tag_result("no_op", "already_present"))
             mock_get_polylogue.return_value = mock_poly
             mock_get_query_store.return_value = make_query_store_mock(resolved_id=_CONV_ID)
 
@@ -93,7 +99,7 @@ class TestTagIdempotencyOutcomes:
             patch("polylogue.mcp.server._get_query_store") as mock_get_query_store,
         ):
             mock_poly = make_polylogue_mock()
-            mock_poly.remove_tag = AsyncMock(return_value=True)
+            mock_poly.remove_tag = AsyncMock(return_value=_tag_result("removed"))
             mock_get_polylogue.return_value = mock_poly
             mock_get_query_store.return_value = make_query_store_mock(resolved_id=_CONV_ID)
 
@@ -115,7 +121,7 @@ class TestTagIdempotencyOutcomes:
             patch("polylogue.mcp.server._get_query_store") as mock_get_query_store,
         ):
             mock_poly = make_polylogue_mock()
-            mock_poly.remove_tag = AsyncMock(return_value=False)
+            mock_poly.remove_tag = AsyncMock(return_value=_tag_result("not_present", "tag_not_present"))
             mock_get_polylogue.return_value = mock_poly
             mock_get_query_store.return_value = make_query_store_mock(resolved_id=_CONV_ID)
 

--- a/tests/unit/mcp/test_tool_contracts.py
+++ b/tests/unit/mcp/test_tool_contracts.py
@@ -16,6 +16,7 @@ from polylogue.archive.query.spec import ConversationQuerySpec
 from polylogue.archive.semantic.pricing import CostEstimatePayload, CostUsagePayload
 from polylogue.archive.stats import ArchiveStats
 from polylogue.errors import PolylogueError
+from polylogue.surfaces.payloads import TagMutationResult
 from polylogue.insights.archive import (
     ArchiveDebtInsight,
     ArchiveEnrichmentProvenance,
@@ -957,7 +958,7 @@ class TestMutationTools:
             patch("polylogue.mcp.server._get_query_store") as mock_get_query_store,
         ):
             mock_poly = make_polylogue_mock()
-            mock_poly.add_tag = AsyncMock(return_value=True)
+            mock_poly.add_tag = AsyncMock(return_value=TagMutationResult(outcome="added"))
             mock_get_polylogue.return_value = mock_poly
             mock_get_query_store.return_value = make_query_store_mock(resolved_id="test:conv-123")
 
@@ -994,7 +995,7 @@ class TestMutationTools:
             patch("polylogue.mcp.server._get_query_store") as mock_get_query_store,
         ):
             mock_poly = make_polylogue_mock()
-            mock_poly.remove_tag = AsyncMock(return_value=True)
+            mock_poly.remove_tag = AsyncMock(return_value=TagMutationResult(outcome="removed"))
             mock_get_polylogue.return_value = mock_poly
             mock_get_query_store.return_value = make_query_store_mock(resolved_id="test:conv-123")
 

--- a/tests/unit/mcp/test_tool_contracts.py
+++ b/tests/unit/mcp/test_tool_contracts.py
@@ -16,7 +16,6 @@ from polylogue.archive.query.spec import ConversationQuerySpec
 from polylogue.archive.semantic.pricing import CostEstimatePayload, CostUsagePayload
 from polylogue.archive.stats import ArchiveStats
 from polylogue.errors import PolylogueError
-from polylogue.surfaces.payloads import TagMutationResult
 from polylogue.insights.archive import (
     ArchiveDebtInsight,
     ArchiveEnrichmentProvenance,
@@ -47,6 +46,7 @@ from polylogue.insights.archive_models import (
     WorkThreadMemberEvidencePayload,
     WorkThreadPayload,
 )
+from polylogue.surfaces.payloads import TagMutationResult
 from polylogue.types import ConversationId, Provider
 from tests.infra.builders import make_conv, make_msg
 from tests.infra.mcp import (


### PR DESCRIPTION
## Summary
Centralize tag mutation idempotency outcome through a shared `TagMutationResult` contract, eliminating the duplicated `bool → outcome` mapping from CLI, MCP, and query-action surfaces.

## Problem
PR #978 added the `outcome` field to `MutationResultPayload`, but each surface (CLI `tags.py`, MCP `server_mutation_tools.py`, CLI `query_actions.py`) independently mapped `add_tag()`/`remove_tag()` boolean return values to `outcome`/`status`/`detail` values. The mapping was duplicated across 3 call sites.

## Solution
1. **`polylogue/surfaces/payloads.py`**: Added `TagMutationOutcome` type alias and `TagMutationResult` frozen model with `outcome` + `detail` fields and `__bool__` for backward compat.
2. **`polylogue/api/archive.py`**: `PolylogueArchiveMixin.add_tag()`/`remove_tag()` now return `TagMutationResult` instead of `bool`. The mapping lives once here.
3. **`polylogue/mcp/server_mutation_tools.py`**: Reads `result.outcome`/`result.detail` directly.
4. **`polylogue/cli/commands/tags.py`**: Reads `result.outcome`/`result.detail` directly.
5. **`polylogue/cli/query_actions.py`**: Routes through `env.polylogue.add_tag()` (the shared facade) instead of `repo.add_tag()` directly, when using the default repository. Custom repo passed by tests continues direct access.

`RepositoryWriteMixin` and `TagStore` protocol remain unchanged (`add_tag() → bool`). Only the facade contract was updated.

## Verification
- `pytest tests/unit/mcp/ tests/unit/cli/ tests/unit/storage/ -k tag -q` — 57 passed
- `pytest tests/unit/mcp/test_tag_idempotency.py tests/unit/mcp/test_tool_contracts.py tests/unit/storage/test_tag_contracts.py` — 83 passed
- `pytest tests/unit/mcp/ -q` — 158 passed
- `mypy --strict` on all 7 changed files — clean

Refs #862. Does not close — remaining scope tracked in #972.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>