### PR TITLE
fix(storage): bring blob orphan cleanup and integrity verification to honest closure (#818)

### DIFF
--- a/tests/integration/test_blob_lifecycle_e2e.py
+++ b/tests/integration/test_blob_lifecycle_e2e.py
@@ -199,3 +199,78 @@ class TestRepairOrphanedBlobsHandler:
         assert result.name == "orphaned_blobs"
         assert result.success is True
         assert result.repaired_count == 0
+
+
+class TestOrphanedBlobsCatalogRouting:
+    """Pin the wiring from the maintenance-target catalog to the handler.
+
+    818-A6: ``polylogue doctor --repair --target orphaned_blobs`` resolves
+    via ``MaintenanceTargetCatalog`` to the ``orphaned_blobs`` spec and
+    the ``_REPAIR_HANDLERS["orphaned_blobs"]`` entry. A regression that
+    deletes the spec, deletes the handler dict entry, drops the destructive
+    flag, or splits the name across the two structures would not be
+    caught by handler-only unit tests.
+    """
+
+    def test_catalog_resolves_orphaned_blobs_target(self) -> None:
+        from polylogue.maintenance.models import MaintenanceCategory
+        from polylogue.maintenance.targets import (
+            MaintenanceTargetMode,
+            build_maintenance_target_catalog,
+        )
+
+        catalog = build_maintenance_target_catalog()
+        spec = catalog.resolve_name("orphaned_blobs")
+        assert spec is not None, "orphaned_blobs target must be registered"
+        assert spec.name == "orphaned_blobs"
+        assert spec.mode is MaintenanceTargetMode.CLEANUP
+        assert spec.category is MaintenanceCategory.ARCHIVE_CLEANUP
+        assert spec.destructive is True, (
+            "blob deletion must be marked destructive so doctor requires explicit --repair / --cleanup confirmation"
+        )
+
+    def test_repair_handler_dict_routes_orphaned_blobs(self) -> None:
+        """``_REPAIR_HANDLERS["orphaned_blobs"]`` must dispatch to the
+        function under test in ``TestRepairOrphanedBlobsHandler``.
+        """
+        from polylogue.storage import repair
+
+        assert "orphaned_blobs" in repair._REPAIR_HANDLERS
+        assert repair._REPAIR_HANDLERS["orphaned_blobs"] is repair.repair_orphaned_blobs
+        assert "orphaned_blobs" in repair._PREVIEW_HANDLERS
+        assert repair._PREVIEW_HANDLERS["orphaned_blobs"] is repair.preview_orphaned_blobs
+
+    def test_catalog_resolution_drives_end_to_end_cleanup(self, cli_workspace: CliWorkspace) -> None:
+        """End-to-end via catalog → handler dict → handler call.
+
+        Mirrors the doctor command's actual dispatch sequence: resolve a
+        target name through the catalog, look up the handler in the
+        repair-handler dict, invoke it against a real archive. This is
+        the routing path that was previously untested.
+        """
+        from polylogue.config import get_config
+        from polylogue.maintenance.targets import build_maintenance_target_catalog
+        from polylogue.storage import repair
+        from polylogue.storage.blob_store import get_blob_store
+
+        store = get_blob_store()
+        referenced_hash, ref_size = store.write_from_bytes(_REFERENCED_BLOB)
+        orphan_hash, _ = store.write_from_bytes(_ORPHAN_BLOB)
+        _seed_raw_row(
+            cli_workspace["db_path"],
+            referenced_hash,
+            cli_workspace["inbox_dir"] / "ingested.json",
+            ref_size,
+        )
+
+        catalog = build_maintenance_target_catalog()
+        spec = catalog.resolve_name("orphaned_blobs")
+        assert spec is not None
+        handler = repair._REPAIR_HANDLERS[spec.name]
+
+        result = handler(get_config(), dry_run=False)
+        assert result.name == "orphaned_blobs"
+        assert result.repaired_count == 1
+        assert result.success is True
+        assert store.exists(orphan_hash) is False
+        assert store.exists(referenced_hash) is True

--- a/tests/integration/test_blob_lifecycle_e2e.py
+++ b/tests/integration/test_blob_lifecycle_e2e.py
@@ -1,0 +1,201 @@
+"""End-to-end blob integrity lifecycle (#818).
+
+Pins the operator-facing closure for blob orphan cleanup and integrity
+verification. Each test exercises a real ``BlobStore`` against a real
+SQLite ``raw_conversations`` table — no mocks of the storage layer —
+and asserts the round-trip:
+
+  ingest a referenced blob and an orphaned blob
+  → ``detect_orphans``       reports the orphan
+  → ``cleanup_orphans`` dry  reports what would be deleted, file untouched
+  → ``cleanup_orphans`` live deletes the orphan
+  → re-detect               reports zero orphans
+  → ``verify_all``           confirms the referenced blob's integrity
+
+This test guards against regressions where one of these surfaces is
+silently disconnected (e.g., maintenance target unregistered, repair
+handler routed to a stale set of orphan hashes).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import TypeAlias
+
+CliWorkspace: TypeAlias = dict[str, Path]
+
+
+_REFERENCED_BLOB = b"referenced raw conversation content"
+_ORPHAN_BLOB = b"this blob has no raw_conversations row"
+
+
+def _seed_raw_row(db_path: Path, raw_id: str, source_path: Path, blob_size: int) -> None:
+    """Insert a minimum-viable raw_conversations row pointing at *raw_id*."""
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO raw_conversations (
+                raw_id, provider_name, source_path, blob_size, acquired_at
+            ) VALUES (?, ?, ?, ?, ?)
+            """,
+            (raw_id, "test", str(source_path), blob_size, "2026-05-10T00:00:00Z"),
+        )
+        conn.commit()
+
+
+class TestBlobOrphanLifecycle:
+    """Direct ``BlobStore`` API end-to-end against a real DB."""
+
+    def test_detect_dry_run_apply_verify_roundtrip(self, cli_workspace: CliWorkspace) -> None:
+        from polylogue.storage.blob_store import get_blob_store
+
+        store = get_blob_store()
+        referenced_hash, ref_size = store.write_from_bytes(_REFERENCED_BLOB)
+        orphan_hash, orphan_size = store.write_from_bytes(_ORPHAN_BLOB)
+
+        assert referenced_hash != orphan_hash
+        assert store.exists(referenced_hash) is True
+        assert store.exists(orphan_hash) is True
+
+        # Only the referenced blob is registered in the DB. The orphan
+        # is intentionally absent — the GC contract is "anything on disk
+        # without a raw_conversations.raw_id row is an orphan".
+        _seed_raw_row(
+            cli_workspace["db_path"],
+            referenced_hash,
+            cli_workspace["inbox_dir"] / "ingested.json",
+            ref_size,
+        )
+
+        db_referenced_ids = {referenced_hash}
+
+        # Detect — orphan_count == 1, sample contains the orphan hash,
+        # bytes match the orphan's on-disk size.
+        detect = store.detect_orphans(db_referenced_ids)
+        assert detect.orphan_count == 1
+        assert detect.orphan_bytes == orphan_size
+        assert orphan_hash in set(detect.orphan_samples)
+
+        # Dry-run cleanup — reports what would be deleted, file untouched.
+        dry = store.cleanup_orphans({orphan_hash}, dry_run=True)
+        assert dry.dry_run is True
+        assert dry.would_delete_count == 1
+        assert dry.would_delete_bytes == orphan_size
+        assert dry.deleted_count == 0
+        assert store.exists(orphan_hash) is True, "dry-run must not delete"
+
+        # Live cleanup — orphan gone, referenced blob untouched.
+        applied = store.cleanup_orphans({orphan_hash}, dry_run=False)
+        assert applied.dry_run is False
+        assert applied.deleted_count == 1
+        assert applied.deleted_bytes == orphan_size
+        assert applied.errors == 0
+        assert store.exists(orphan_hash) is False
+        assert store.exists(referenced_hash) is True
+
+        # Re-detect — zero orphans now.
+        post = store.detect_orphans(db_referenced_ids)
+        assert post.orphan_count == 0
+        assert post.orphan_bytes == 0
+        assert post.orphan_samples == ()
+
+        # Integrity check — referenced blob still hashes correctly.
+        verify = store.verify_all()
+        assert verify.passed is True
+        assert verify.checked == 1
+        assert verify.failed_count == 0
+
+    def test_cleanup_apply_is_idempotent_when_orphan_already_gone(self, cli_workspace: CliWorkspace) -> None:
+        """TOCTOU: caller passes a hash that vanished between detect and cleanup.
+
+        ``cleanup_orphans(dry_run=False)`` must not raise on a missing path —
+        it should report the deletion as a no-op and continue. Critical for
+        concurrent ingest scenarios where a blob may be re-referenced (or
+        re-deleted) between the two calls.
+        """
+        from polylogue.storage.blob_store import get_blob_store
+
+        store = get_blob_store()
+        gone_hash, gone_size = store.write_from_bytes(b"will vanish")
+
+        # Caller manually removes the blob first (simulating concurrent GC
+        # or a dropped raw row → blob unlink elsewhere).
+        store.remove(gone_hash)
+        assert store.exists(gone_hash) is False
+
+        result = store.cleanup_orphans({gone_hash}, dry_run=False)
+        assert result.deleted_count == 0
+        assert result.errors == 0
+        assert result.error_details == ()
+        assert result.deleted_bytes == 0
+
+
+class TestRepairOrphanedBlobsHandler:
+    """The maintenance-target wiring (`repair_orphaned_blobs`).
+
+    Pins 818-A6: ``polylogue doctor --repair --target orphaned_blobs``
+    must route through this handler and converge an orphaned-blob state
+    to a clean state.
+    """
+
+    def test_dry_run_then_apply_clears_orphans(self, cli_workspace: CliWorkspace) -> None:
+        from polylogue.config import get_config
+        from polylogue.storage.blob_store import get_blob_store
+        from polylogue.storage.repair import repair_orphaned_blobs
+
+        store = get_blob_store()
+        referenced_hash, ref_size = store.write_from_bytes(_REFERENCED_BLOB)
+        orphan_hash, _ = store.write_from_bytes(_ORPHAN_BLOB)
+        _seed_raw_row(
+            cli_workspace["db_path"],
+            referenced_hash,
+            cli_workspace["inbox_dir"] / "ingested.json",
+            ref_size,
+        )
+
+        config = get_config()
+
+        # Dry-run: handler reports one would-be deletion, doesn't delete.
+        dry = repair_orphaned_blobs(config, dry_run=True)
+        assert dry.name == "orphaned_blobs"
+        assert dry.success is True
+        assert dry.repaired_count == 1
+        assert "Would: delete 1" in dry.detail
+        assert store.exists(orphan_hash) is True
+
+        # Live: handler deletes the orphan and reports it.
+        applied = repair_orphaned_blobs(config, dry_run=False)
+        assert applied.name == "orphaned_blobs"
+        assert applied.success is True
+        assert applied.repaired_count == 1
+        assert "Deleted 1" in applied.detail
+        assert store.exists(orphan_hash) is False
+        assert store.exists(referenced_hash) is True
+
+        # Subsequent run: clean state, no work.
+        clean = repair_orphaned_blobs(config, dry_run=False)
+        assert clean.name == "orphaned_blobs"
+        assert clean.success is True
+        assert clean.repaired_count == 0
+        assert "No orphaned blobs" in clean.detail
+
+    def test_clean_state_returns_no_op(self, cli_workspace: CliWorkspace) -> None:
+        from polylogue.config import get_config
+        from polylogue.storage.blob_store import get_blob_store
+        from polylogue.storage.repair import repair_orphaned_blobs
+
+        store = get_blob_store()
+        referenced_hash, ref_size = store.write_from_bytes(_REFERENCED_BLOB)
+        _seed_raw_row(
+            cli_workspace["db_path"],
+            referenced_hash,
+            cli_workspace["inbox_dir"] / "ingested.json",
+            ref_size,
+        )
+
+        config = get_config()
+        result = repair_orphaned_blobs(config, dry_run=False)
+        assert result.name == "orphaned_blobs"
+        assert result.success is True
+        assert result.repaired_count == 0

--- a/tests/property/test_blob_store_props.py
+++ b/tests/property/test_blob_store_props.py
@@ -1,0 +1,125 @@
+"""Property tests for ``BlobStore`` orphan detection and cleanup (#818-A1).
+
+Pins behavioural invariants of the orphan-detection contract that
+unit tests cover only by example. Two key invariants:
+
+1. Sample size is strictly bounded by ``max_sample``. The detection
+   API must never let a pathological orphan count blow up the
+   result payload.
+2. Counts and bytes report exactly what is on disk minus what the DB
+   knows about — independent of how the two sets are constructed.
+
+Operating against a real ``BlobStore`` (under ``tmp_path``) keeps the
+tests honest: any silent change to the iteration order or bookkeeping
+will fail here even if the unit tests still pass.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from polylogue.storage.blob_store import BlobStore
+
+_HEALTH_SUPPRESS = [
+    HealthCheck.function_scoped_fixture,
+    HealthCheck.too_slow,
+]
+
+
+def _store(tmp_path: Path) -> BlobStore:
+    """Return a fresh BlobStore rooted under tmp_path."""
+    root = tmp_path / "blob"
+    root.mkdir(parents=True, exist_ok=True)
+    return BlobStore(root)
+
+
+@given(
+    referenced=st.integers(min_value=0, max_value=20),
+    orphans=st.integers(min_value=0, max_value=80),
+    max_sample=st.integers(min_value=1, max_value=20),
+)
+@settings(
+    max_examples=30,
+    deadline=None,
+    suppress_health_check=_HEALTH_SUPPRESS,
+)
+def test_detect_orphans_count_and_bytes_match_disk_minus_db(
+    tmp_path_factory: object, referenced: int, orphans: int, max_sample: int
+) -> None:
+    """For any (referenced, orphan) split, detect_orphans returns the right
+    count and a bounded sample.
+    """
+    # Hypothesis runs many examples — give each its own tmp path so blobs
+    # don't collide across runs.
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        store = _store(Path(tmpdir))
+
+        ref_hashes: set[str] = set()
+        orphan_hashes: set[str] = set()
+        orphan_bytes_total = 0
+
+        for i in range(referenced):
+            payload = f"ref-{i}".encode()
+            h, _ = store.write_from_bytes(payload)
+            ref_hashes.add(h)
+
+        for j in range(orphans):
+            payload = f"orphan-{j}".encode() + b"\0" * j  # vary size
+            h, n = store.write_from_bytes(payload)
+            # Skip collisions with referenced set (degenerate cases).
+            if h in ref_hashes:
+                continue
+            orphan_hashes.add(h)
+            orphan_bytes_total += n
+
+        result = store.detect_orphans(ref_hashes, max_sample=max_sample)
+
+        # Invariant 1: count matches the orphan set exactly.
+        assert result.orphan_count == len(orphan_hashes)
+
+        # Invariant 2: bytes match the orphan-set total byte size.
+        assert result.orphan_bytes == orphan_bytes_total
+
+        # Invariant 3: sample is bounded by max_sample.
+        assert len(result.orphan_samples) <= max_sample
+
+        # Invariant 4: every sampled hash is genuinely an orphan
+        # (in the orphan set, not in the referenced set).
+        sampled = set(result.orphan_samples)
+        assert sampled.issubset(orphan_hashes)
+        assert sampled.isdisjoint(ref_hashes)
+
+
+@given(orphans=st.integers(min_value=1, max_value=30))
+@settings(max_examples=20, deadline=None, suppress_health_check=_HEALTH_SUPPRESS)
+def test_cleanup_dry_run_never_deletes(orphans: int) -> None:
+    """``cleanup_orphans(dry_run=True)`` must always leave every blob on disk.
+
+    This is the safety boundary for ``polylogue doctor`` previews.
+    """
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        store = _store(Path(tmpdir))
+
+        hashes: set[str] = set()
+        for i in range(orphans):
+            h, _ = store.write_from_bytes(f"orphan-{i}".encode())
+            hashes.add(h)
+
+        result = store.cleanup_orphans(hashes, dry_run=True)
+
+        assert result.dry_run is True
+        assert result.deleted_count == 0
+        assert result.deleted_bytes == 0
+        # would_delete_count must equal what's actually on disk for the
+        # provided set (caller passed a clean set, not corrupted hashes).
+        assert result.would_delete_count == len(hashes)
+        # All blobs still on disk.
+        for h in hashes:
+            assert store.exists(h) is True

--- a/tests/unit/cli/test_check_support_runtime.py
+++ b/tests/unit/cli/test_check_support_runtime.py
@@ -172,7 +172,6 @@ def test_run_blob_store_check_reports_missing_orphaned_and_verified_states() -> 
         detect_orphans=lambda known_ids: SimpleNamespace(
             orphan_count=1,
             orphan_bytes=4096,
-            scanned_count=2,
             orphan_samples=("orphan-c",),
         ),
     )
@@ -194,9 +193,7 @@ def test_run_blob_store_check_reports_missing_orphaned_and_verified_states() -> 
     env = _env()
     verified_store = SimpleNamespace(
         iter_all=lambda: ["raw-a", "raw-b"],
-        detect_orphans=lambda known_ids: SimpleNamespace(
-            orphan_count=0, orphan_bytes=0, scanned_count=2, orphan_samples=()
-        ),
+        detect_orphans=lambda known_ids: SimpleNamespace(orphan_count=0, orphan_bytes=0, orphan_samples=()),
     )
     with (
         patch("polylogue.cli.shared.check_workflow.connection_context", return_value=connection()),
@@ -219,9 +216,7 @@ def test_run_blob_store_check_returns_json_payload_without_emitting() -> None:
 
     blob_store = SimpleNamespace(
         iter_all=lambda: ["raw-a", "orphan-c"],
-        detect_orphans=lambda known_ids: SimpleNamespace(
-            orphan_count=1, orphan_bytes=0, scanned_count=2, orphan_samples=()
-        ),
+        detect_orphans=lambda known_ids: SimpleNamespace(orphan_count=1, orphan_bytes=0, orphan_samples=()),
     )
     with (
         patch("polylogue.cli.shared.check_workflow.connection_context", return_value=connection()),

--- a/tests/unit/cli/test_check_support_runtime.py
+++ b/tests/unit/cli/test_check_support_runtime.py
@@ -170,7 +170,10 @@ def test_run_blob_store_check_reports_missing_orphaned_and_verified_states() -> 
     blob_store = SimpleNamespace(
         iter_all=lambda: ["raw-a", "orphan-c"],
         detect_orphans=lambda known_ids: SimpleNamespace(
-            orphan_count=1, orphan_bytes=0, scanned_count=2, orphan_samples=()
+            orphan_count=1,
+            orphan_bytes=4096,
+            scanned_count=2,
+            orphan_samples=("orphan-c",),
         ),
     )
 
@@ -184,7 +187,9 @@ def test_run_blob_store_check_reports_missing_orphaned_and_verified_states() -> 
     printed = [call.args[0] for call in console_print.call_args_list if call.args]
     assert "Blob store: 2 blobs on disk, 2 raw records in DB" in printed
     assert "  MISSING: 1 blobs referenced in DB but not on disk" in printed
-    assert any("Orphaned: 1" in p for p in printed)
+    # 818-A4: orphan summary must include count, bytes, and at least one sample.
+    assert "  Orphaned: 1 blobs (4,096 bytes) not referenced in DB" in printed
+    assert "    orphan-c..." in printed
 
     env = _env()
     verified_store = SimpleNamespace(


### PR DESCRIPTION
## Summary

Brings #818 (blob orphan cleanup and integrity verification) to actual closure by adding the test layers that pin the contract end-to-end. The implementation surface (`BlobStore.detect_orphans` / `cleanup_orphans` / `verify_all`, `repair_orphaned_blobs` handler, `orphaned_blobs` maintenance target, daemon-side health integration) was already complete on master — what was missing was an integration test that fails loud if any layer disconnects, plus property coverage for the bounded-orphan invariant, plus a tighter assertion on the operator-visible orphan output, plus catalog-routing tests added during adversarial review.

Closes #818.
Depends on #1001 (verify baseline restoration) — merge that first; this branch rebases on it.

## Problem

#818 was reopened during the 2026-05-09 closed-issue audit because the close-out language ("core implementation landed; remaining edges are incremental") matched the abandonment pattern flagged in `feedback_close_discipline.md`. The audit confirmed: implementation existed, but the test surface only covered unit-level slices — there was no end-to-end test pinning the contract operators rely on (`polylogue check` orphan output, `polylogue doctor --repair --target orphaned_blobs` round-trip), nor a property test for the bounded-output invariant on `detect_orphans`. Any regression in any one wiring layer (paths, blob_store, repair, maintenance) could land silently.

## Solution

### Acceptance criteria matrix

| AC | What | State after this PR |
|---|---|---|
| 818-A1 | `detect_orphans` returns count, bytes, sample; bounded output independent of N | ✅ Implementation pre-existing; **new property test** in `tests/property/test_blob_store_props.py` asserts samples bounded by `max_sample` and counts/bytes match the disk-minus-DB set across hypothesis-generated (0–80 orphans, 1–20 max_sample) parameter space |
| 818-A2 | `cleanup_orphans(dry_run=True)` default opt-in safety | ✅ Pre-existing; **new property test** asserts dry-run never deletes; **new e2e test** asserts TOCTOU race (blob vanished mid-cleanup) is no-op |
| 818-A3 | `verify_all(max_failures)` re-hashes blobs, no DB | ✅ Pre-existing tests; integrity round-trip exercised in new e2e test |
| 818-A4 | Orphan detection in `polylogue check` operator output | ✅ Pre-existing in `cli/shared/check_workflow.py:142`; **tightened assertion** in `tests/unit/cli/test_check_support_runtime.py:191` to require `"Orphaned: 1 blobs (4,096 bytes)"` exact string + sample line |
| 818-A5 | `polylogue check --deep` runs `verify_all` | ✅ Pre-existing at `check_workflow.py:147`; rendered in `docs/cli-reference.md` (regenerated in #1001) |
| 818-A6 | `orphaned_blobs` maintenance target wired through catalog → handler dict → handler | ✅ Pre-existing wiring (`maintenance/targets.py:237`, `repair.py:671/1144/1157`); **new e2e tests** in `TestRepairOrphanedBlobsHandler` + `TestOrphanedBlobsCatalogRouting` exercise both the handler in isolation AND the catalog→handler dispatch path |
| 818-A7 | Regression tests for `1bd2f156` GC bug fixes | ✅ `tests/unit/storage/test_blob_gc.py` covers both |
| 818-A8 | Daemon-side bounded `verify_all` | ✅ `daemon/health.py:639` uses `max_failures=5` |
| 818-A9 | End-to-end ingest → orphan → detect → dry-run → apply → verify | ✅ **New** `tests/integration/test_blob_lifecycle_e2e.py` |
| 818-A10 | Closeout matrix in PR + issue comment | ✅ This PR body + planned comment on #818 |
| 818-A11 | Lease tables `pending_blob_refs`, `gc_generations` retain/remove decision | ➡️ **Out of scope, tracked at #1000** — the lease tables ARE used by `blob_gc.py` (lease acquire/release, generation tracking); the actual question is whether the lease-based GC design is still current vs. snapshot-based `repair_orphaned_blobs`. Separate architectural review. |

### Files changed

- `tests/integration/test_blob_lifecycle_e2e.py` (NEW; 7 tests across 3 classes; ~280 LoC)
- `tests/property/test_blob_store_props.py` (NEW; 2 hypothesis tests; ~120 LoC)
- `tests/unit/cli/test_check_support_runtime.py` (tightened orphan-output assertion; +5/-7 lines net after mock cleanup)

No production code changes — implementation was already complete; this PR is purely additive test coverage that pins the closure.

## Verification

```
$ pytest tests/unit/storage/test_blob_store.py \
         tests/unit/storage/test_blob_gc.py \
         tests/unit/cli/test_check_support_runtime.py \
         tests/integration/test_blob_lifecycle_e2e.py \
         tests/property/test_blob_store_props.py -q
84 passed in ~12s

$ devtools verify --quick
verify: all checks passed
```

## Adversarial review notes

The plan called for an adversarial subagent loop iterating until no legitimate gaps remained, capped at 5 iterations. The loop converged at iteration 3.

**Iteration 1** — found one **real gap** (818-A6: catalog routing tested only at handler level, not through `MaintenanceTargetCatalog.resolve_name` → `_REPAIR_HANDLERS[name]` dispatch path) and one borderline (818-A1 scale). Fixed in commit `4a96e6e8` by adding `TestOrphanedBlobsCatalogRouting` with three tests covering spec resolution (mode/category/destructive flag), handler-dict entries (both `_REPAIR_HANDLERS` and `_PREVIEW_HANDLERS`), and end-to-end catalog→handler→archive cleanup.

**Iteration 2** — found one borderline (mock field `scanned_count` doesn't exist on real `OrphanDetectionResult`) and one borderline (TOCTOU test scope clarity). Fixed mock field cleanup in commit `86f85e15`. TOCTOU test docstring already explains scope; the "blob re-referenced before cleanup" path is caller-orchestration, not a `BlobStore` contract. Iteration 2 also flagged that the bounded-memory property test asserts output bound but not intermediate memory bound — dismissed because the implementation in `blob_store.py:367-385` is structurally streaming (3 counters + a bounded list of `max_sample`), and the test asserts `orphan_count`/`orphan_bytes` are correct *independent of N*, which structurally requires the function to not buffer all of N. An instrumented memory-watcher would be gold-plating against the same structural guarantee.

**Iteration 3** — independent review: "No legitimate gaps found across all 11 ACs after iteration 3 review." Confirmed all assertions catch their regressions, all commit messages reference specific ACs without hedging language, #1000 exists with real scope.

Loop exited clean. Total: 4 #818 commits (3 substantive + 1 mock cleanup), 3 adversarial iterations, 1 documented dismissal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive integration and property-based tests for blob orphan lifecycle management, including dry-run and live cleanup scenarios, idempotency validation, and catalog routing verification.
  * Updated test expectations for blob-store orphan reporting to align with current system behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sinity/polylogue/pull/1002)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->