### PR TITLE
docs(storage): document blob GC lease design as kept-by-design (#1000)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -816,8 +816,48 @@ Content-addressed blob storage for large binary data:
   to one session). `blob_links` table maps conversations to their blobs.
 - **Operations**: Blobs are write-once, read-many. No in-place modification.
   GC identifies unreferenced blobs via link counting.
+
+### GC concurrency model — leases plus snapshot reference check
+
+`run_blob_gc` deletes orphan blob files using two independent safety
+invariants combined:
+
+1. **DB reference check** — `_still_referenced` queries
+   `raw_conversations` for the blob's `raw_id`. If a raw record points at
+   the blob, GC skips it. This is the snapshot/mark-and-sweep view of
+   "this blob is in active use right now."
+2. **Pending lease check** — `_has_active_lease` queries
+   `pending_blob_refs` for an in-flight operation that has *announced*
+   it intends to reference the blob but hasn't committed yet. If a write
+   path acquired a lease but its transaction hasn't yet inserted the
+   `raw_conversations` row, the snapshot check alone would
+   misclassify the blob as orphan and delete it.
+
+The lease tables (`pending_blob_refs`, `gc_generations`) are therefore
+load-bearing — they exist specifically to bridge the
+acquire-blob → write-DB-row commit window. Removing them would
+re-open the exact race the lease design was added to close: a GC pass
+running between blob materialization and the corresponding archive
+write would delete blobs the write was about to reference.
+
+The write path that exercises the leases is
+`polylogue/archive/write_effects.py:commit_archive_write_effects` —
+calls `acquire_blob_leases(db_path, blob_hashes, operation_id)` on a
+separate immediate-commit connection so the lease is visible to a
+concurrent GC before the main transaction commits, then calls
+`release_operation_leases(conn, operation_id)` after the commit so
+the blob is now durably referenced by `raw_conversations` and the
+lease can drop.
+
+`gc_generations` tracks the high-water mark of completed GC runs. The
+"defense-in-depth" age check requires candidate blobs to be older than
+the previous generation plus `MIN_AGE_S` so that a brand-new blob is
+never considered for deletion within the same GC run cycle that
+created it.
+
 - **Known issues**: GC has bugs with orphan detection and integrity
-  verification ([#818](https://github.com/Sinity/polylogue/issues/818)).
+  verification ([#818](https://github.com/Sinity/polylogue/issues/818))
+  — independent of the lease design audited above.
 
 ## Debugging Landmarks
 

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -139,8 +139,48 @@ Content-addressed blob storage for large binary data:
   to one session). `blob_links` table maps conversations to their blobs.
 - **Operations**: Blobs are write-once, read-many. No in-place modification.
   GC identifies unreferenced blobs via link counting.
+
+### GC concurrency model — leases plus snapshot reference check
+
+`run_blob_gc` deletes orphan blob files using two independent safety
+invariants combined:
+
+1. **DB reference check** — `_still_referenced` queries
+   `raw_conversations` for the blob's `raw_id`. If a raw record points at
+   the blob, GC skips it. This is the snapshot/mark-and-sweep view of
+   "this blob is in active use right now."
+2. **Pending lease check** — `_has_active_lease` queries
+   `pending_blob_refs` for an in-flight operation that has *announced*
+   it intends to reference the blob but hasn't committed yet. If a write
+   path acquired a lease but its transaction hasn't yet inserted the
+   `raw_conversations` row, the snapshot check alone would
+   misclassify the blob as orphan and delete it.
+
+The lease tables (`pending_blob_refs`, `gc_generations`) are therefore
+load-bearing — they exist specifically to bridge the
+acquire-blob → write-DB-row commit window. Removing them would
+re-open the exact race the lease design was added to close: a GC pass
+running between blob materialization and the corresponding archive
+write would delete blobs the write was about to reference.
+
+The write path that exercises the leases is
+`polylogue/archive/write_effects.py:commit_archive_write_effects` —
+calls `acquire_blob_leases(db_path, blob_hashes, operation_id)` on a
+separate immediate-commit connection so the lease is visible to a
+concurrent GC before the main transaction commits, then calls
+`release_operation_leases(conn, operation_id)` after the commit so
+the blob is now durably referenced by `raw_conversations` and the
+lease can drop.
+
+`gc_generations` tracks the high-water mark of completed GC runs. The
+"defense-in-depth" age check requires candidate blobs to be older than
+the previous generation plus `MIN_AGE_S` so that a brand-new blob is
+never considered for deletion within the same GC run cycle that
+created it.
+
 - **Known issues**: GC has bugs with orphan detection and integrity
-  verification ([#818](https://github.com/Sinity/polylogue/issues/818)).
+  verification ([#818](https://github.com/Sinity/polylogue/issues/818))
+  — independent of the lease design audited above.
 
 ## Debugging Landmarks
 

--- a/polylogue/storage/blob_gc.py
+++ b/polylogue/storage/blob_gc.py
@@ -200,8 +200,19 @@ def acquire_blob_leases(
 ) -> None:
     """Acquire leases on blob hashes to prevent GC during active operations.
 
-    Uses a fresh connection that commits immediately so leases are visible
-    to concurrent GC runs before the main data transaction commits.
+    The lease tables are deliberately retained alongside the
+    snapshot-based reference check in ``_still_referenced`` (audited in
+    #1000). They bridge the acquire-blob → write-DB-row commit window:
+    without leases, a GC pass running between blob materialization and
+    the corresponding ``raw_conversations`` write would misclassify the
+    blob as orphan.
+
+    Uses a fresh connection that commits immediately so leases are
+    visible to concurrent GC runs before the main data transaction
+    commits.
+
+    See ``docs/internals.md`` ("GC concurrency model") for the full
+    contract.
     """
     if not blob_hashes:
         return


### PR DESCRIPTION
## Summary

Closes #1000. Audit-only PR. Confirms the lease tables (``pending_blob_refs``, ``gc_generations``) are still load-bearing and documents *why* they coexist with the snapshot-based ``_still_referenced`` check.

## Audit outcome

Issue #1000 asked whether the lease design has been superseded by the snapshot check. Tracing every external caller of ``acquire_blob_leases`` / ``release_operation_leases`` shows:

- ``polylogue/archive/write_effects.py::commit_archive_write_effects`` is the only external caller. It acquires leases on a separate immediate-commit connection *before* the main archive write transaction commits, then releases them *after* the commit.
- ``run_blob_gc`` enforces both ``_still_referenced`` (snapshot reference check against ``raw_conversations``) **and** ``_has_active_lease`` (in-flight operation check against ``pending_blob_refs``).

The two checks cover different windows: the snapshot check covers blobs already referenced by a committed archive row; the lease check covers blobs the write path has materialized but has not yet inserted into ``raw_conversations``. Removing the lease tables would re-open the exact race the design was added to close.

## Solution

- ``docs/internals.md`` — new "GC concurrency model — leases plus snapshot reference check" section under Blob Store Model.
- ``polylogue/storage/blob_gc.py::acquire_blob_leases`` — docstring cites #1000 and points at the new docs section so the rationale lives next to the code.
- ``AGENTS.md`` — auto-rendered.

No behavioural changes. The audit was the entire scope; no half-removal — either keep the tables and document them, or remove them. This PR keeps and documents.

## Verification

- ``nix develop -c devtools verify --quick`` → all checks passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation describing internal garbage-collection concurrency models and mechanisms. Updated related docstrings for improved clarity.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sinity/polylogue/pull/1015)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->