### PR TITLE
fix(cli): route apply_modifiers tag mutations through custom repo when supplied (#1012)

### DIFF
--- a/polylogue/cli/query_actions.py
+++ b/polylogue/cli/query_actions.py
@@ -63,7 +63,17 @@ async def apply_modifiers(
     mutation: QueryMutationSpec,
     repo: TagStore | None = None,
 ) -> None:
-    """Apply metadata modifiers to matched conversations."""
+    """Apply metadata modifiers to matched conversations.
+
+    When the caller supplies a custom ``repo`` (test harnesses with
+    fictional summaries, batch tools that have already validated
+    existence), tag mutations are routed straight at the repo. With no
+    custom repo, mutations go through ``env.polylogue.add_tag`` so the
+    shared facade enforces idempotency and conversation-existence
+    checks. Mixing the two paths against summaries that are not in
+    the polylogue archive raises ``ConversationNotFoundError`` (#1012).
+    """
+    custom_repo = repo is not None
     repo = repo or env.repository
     if not results:
         env.ui.console.print("No conversations matched.")
@@ -110,9 +120,13 @@ async def apply_modifiers(
 
         if mutation.add_tags:
             for tag in mutation.add_tags:
-                result = await env.polylogue.add_tag(result_id(conv), tag)
-                if result:
+                if custom_repo:
+                    await repo.add_tag(result_id(conv), tag)
                     tags_added += 1
+                else:
+                    result = await env.polylogue.add_tag(result_id(conv), tag)
+                    if result:
+                        tags_added += 1
 
     reports: list[str] = []
     if tags_added:


### PR DESCRIPTION
## Summary

Closes part of #1012. ``apply_modifiers`` always routed ``add_tags`` through ``env.polylogue.add_tag`` even when the caller passed a custom ``repo`` argument, causing every ``test_apply_modifiers_contract`` Hypothesis example to fail with ``ConversationNotFoundError`` because the strategy-built summaries were never persisted to the polylogue archive.

The metadata path already routed correctly through ``repo`` (line 108); only the tag path bypassed the supplied repo, leaving the two paths asymmetric.

## Solution

``polylogue/cli/query_actions.py::apply_modifiers`` now tracks whether the caller supplied a custom ``repo``; when they did, tag mutations are sent directly through ``repo.add_tag``. With no custom repo, the call still falls back to ``env.polylogue.add_tag`` so interactive CLI use keeps the facade's idempotency and conversation-existence checks.

The fix originated as orphan commit ``b6b75442`` on a defunct ``worktree-agent-a81e3a2a`` worktree branch (post-merge cleanup of PR #991 that never got its own follow-up PR). Recovered during a worktree-cleanup audit and integrated as a focused PR.

## Verification

- ``nix develop -c pytest tests/unit/cli/test_query_exec_laws.py::test_apply_modifiers_contract`` → 1 passed (60 Hypothesis examples).
- ``nix develop -c devtools verify --quick`` → all checks passed.

The ``@pytest.mark.xfail`` marker added in PR #1013 should be removed once this lands and the test re-runs cleanly on master. The other two xfails tracked by #1012 (``test_tags_command_plain_paths_cover_empty_hint_and_tabular_counts``, ``test_prose_only_drops_claude_code_protocol_artifacts``) are independent of this fix; see #1016 for the latter.