### PR TITLE
refactor(config): route source and query contracts through shared control plane

### DIFF
--- a/polylogue/cli/shell_completion_values.py
+++ b/polylogue/cli/shell_completion_values.py
@@ -27,14 +27,14 @@ from polylogue.storage.sqlite.connection import open_read_connection
 Callback = Callable[[_ArchiveOperations], Awaitable[list[CompletionItem]]]
 
 _PROVIDER_DESCRIPTIONS: Final[dict[str, str]] = {
-    "chatgpt": "OpenAI ChatGPT exports",
-    "claude-ai": "Anthropic Claude web exports",
-    "claude-code": "Claude Code local sessions",
-    "codex": "OpenAI Codex sessions",
-    "gemini": "Google AI Studio exports",
-    "gemini-cli": "Gemini CLI local sessions",
-    "hermes": "Hermes agent sessions",
-    "antigravity": "Antigravity local brain artifacts",
+    "chatgpt": "ChatGPT web exports (lab: OpenAI)",
+    "claude-ai": "Claude web exports (lab: Anthropic)",
+    "claude-code": "Claude Code local sessions (source: claude-code)",
+    "codex": "Codex CLI local sessions (source: codex)",
+    "gemini": "Google AI Studio exports (source: aistudio, lab: Google)",
+    "gemini-cli": "Gemini CLI local sessions (source: gemini-cli, lab: Google)",
+    "hermes": "Hermes agent sessions (source: hermes)",
+    "antigravity": "Antigravity brain artifacts (source: antigravity)",
 }
 
 _MAX_ID_COMPLETIONS = 24

--- a/polylogue/config.py
+++ b/polylogue/config.py
@@ -267,6 +267,36 @@ class PolylogueConfig:
     def health_check_tiers(self) -> str:
         return str(self._data.get("health_check_tiers", "fast,medium"))
 
+    @property
+    def watch_debounce_s(self) -> float:
+        return float(str(self._data.get("watch_debounce_s", 2.0)))
+
+    @property
+    def browser_capture_host(self) -> str:
+        return str(self._data.get("browser_capture_host", "127.0.0.1"))
+
+    @property
+    def browser_capture_spool_path(self) -> str:
+        return str(self._data.get("browser_capture_spool_path", ""))
+
+    @property
+    def browser_capture_auth_token(self) -> str | None:
+        v = self._data.get("browser_capture_auth_token")
+        return v if isinstance(v, str) and v else None
+
+    @property
+    def browser_capture_allow_remote(self) -> bool:
+        return bool(self._data.get("browser_capture_allow_remote"))
+
+    @property
+    def source_roots(self) -> tuple[str, ...]:
+        v = self._data.get("source_roots")
+        if isinstance(v, (list, tuple)):
+            return tuple(str(item) for item in v)
+        if isinstance(v, str) and v.strip():
+            return tuple(s.strip() for s in v.split(",") if s.strip())
+        return ()
+
     def get(self, key: str, default: object = None) -> object:
         return self._data.get(key, default)
 
@@ -333,6 +363,12 @@ def load_polylogue_config(
         "notification_backend": "log",
         "health_check_interval_s": 300,
         "health_check_tiers": "fast,medium",
+        "watch_debounce_s": 2.0,
+        "browser_capture_host": "127.0.0.1",
+        "browser_capture_spool_path": "",
+        "browser_capture_auth_token": None,
+        "browser_capture_allow_remote": False,
+        "source_roots": (),
     }
 
     # Layer 2: TOML file
@@ -376,8 +412,17 @@ def _merge_toml(cfg: dict[str, object], toml_data: dict[str, object]) -> None:
             "auth_token": "api_auth_token",
         },
         "daemon.browser_capture": {
+            "host": "browser_capture_host",
             "port": "browser_capture_port",
             "allowed_origins": "browser_capture_allowed_origins",
+            "allow_remote": "browser_capture_allow_remote",
+            "auth_token": "browser_capture_auth_token",
+        },
+        "daemon.watch": {
+            "debounce_s": "watch_debounce_s",
+        },
+        "sources": {
+            "roots": "source_roots",
         },
         "embedding": {
             "enabled": "embedding_enabled",
@@ -407,7 +452,11 @@ def _merge_toml(cfg: dict[str, object], toml_data: dict[str, object]) -> None:
         if isinstance(section_data, dict):
             for short_key, flat_key in key_map.items():
                 if short_key in section_data:
-                    cfg[flat_key] = section_data[short_key]
+                    value = section_data[short_key]
+                    if isinstance(value, list):
+                        cfg[flat_key] = tuple(value)
+                    else:
+                        cfg[flat_key] = value
 
 
 def _apply_env_overrides(cfg: dict[str, object]) -> None:
@@ -422,7 +471,15 @@ def _apply_env_overrides(cfg: dict[str, object]) -> None:
         "POLYLOGUE_NOTIFICATION_BACKEND": "notification_backend",
         "POLYLOGUE_HEALTH_CHECK_INTERVAL_S": "health_check_interval_s",
         "POLYLOGUE_HEALTH_CHECK_TIERS": "health_check_tiers",
+        "POLYLOGUE_API_HOST": "api_host",
+        "POLYLOGUE_API_PORT": "api_port",
+        "POLYLOGUE_API_AUTH_TOKEN": "api_auth_token",
+        "POLYLOGUE_BROWSER_CAPTURE_PORT": "browser_capture_port",
+        "POLYLOGUE_BROWSER_CAPTURE_HOST": "browser_capture_host",
+        "POLYLOGUE_WATCH_DEBOUNCE_S": "watch_debounce_s",
     }
+    # Keys that must be stored as int
+    _int_keys = {"api_port", "daemon_port", "browser_capture_port", "health_check_interval_s"}
     for env_var, cfg_key in env_map.items():
         value = os.environ.get(env_var)
         if value is not None:
@@ -431,6 +488,9 @@ def _apply_env_overrides(cfg: dict[str, object]) -> None:
                 cfg[cfg_key] = True
             elif value.lower() in ("0", "false", "no"):
                 cfg[cfg_key] = False
+            elif cfg_key in _int_keys:
+                with __import__("contextlib").suppress(ValueError):
+                    cfg[cfg_key] = int(value)
             else:
                 cfg[cfg_key] = value
 
@@ -463,9 +523,20 @@ def format_config_toml(cfg: dict[str, object]) -> str:
         (
             "daemon.browser_capture",
             [
+                ("host", "browser_capture_host"),
                 ("port", "browser_capture_port"),
                 ("allowed_origins", "browser_capture_allowed_origins"),
+                ("allow_remote", "browser_capture_allow_remote"),
+                ("auth_token", "browser_capture_auth_token"),
             ],
+        ),
+        (
+            "daemon.watch",
+            [("debounce_s", "watch_debounce_s")],
+        ),
+        (
+            "sources",
+            [("roots", "source_roots")],
         ),
         (
             "embedding",
@@ -503,7 +574,10 @@ def format_config_toml(cfg: dict[str, object]) -> str:
             value = cfg[flat_key]
             if value is None:
                 continue
-            if isinstance(value, str):
+            if isinstance(value, (list, tuple)):
+                items = ", ".join(f'"{v}"' for v in value)
+                section_lines.append(f"{short_key} = [{items}]")
+            elif isinstance(value, str):
                 section_lines.append(f'{short_key} = "{value}"')
             elif isinstance(value, bool):
                 section_lines.append(f"{short_key} = {str(value).lower()}")

--- a/polylogue/core/provider_identity.py
+++ b/polylogue/core/provider_identity.py
@@ -1,4 +1,65 @@
-"""Provider identity normalization shared across runtime and schema flows."""
+"""Provider identity normalization shared across runtime and schema flows.
+
+Vocabulary boundary
+-------------------
+
+Polylogue distinguishes four concepts that the legacy ``provider`` term
+conflated.  This module defines the canonical tokens and alias rules for
+each layer; other code should reference this table when choosing a name
+for a public field, flag, or doc string.
+
+===================== ====================== ===========================================
+Concept                Examples                Where used
+===================== ====================== ===========================================
+**source family**      claude-code, codex,     Public filters, CLI --provider completions,
+                       gemini-cli, aistudio,   daemon source discovery, watcher roots,
+                       hermes, antigravity     MCP list/search params, docs + help text.
+
+**provider / lab**     OpenAI, Google,         Physical schema column ``provider_name``
+                       Anthropic              (storage compat), provider-wire schemas,
+                                              lab/model pricing lookups.
+
+**model identity**     gpt-5, claude-opus-4-7, provider_meta payloads, cost rollups,
+                       gemini-2.5-pro         stats by model.
+
+**configured source    ~/.claude/projects/,    Config TOML ``[sources] roots``, daemon
+   root**              ~/.codex/sessions/,     watcher file system discovery, CLI --root.
+                       /inbox
+===================== ====================== ===========================================
+
+Surviving ``provider`` uses and their classification
+-----------------------------------------------------
+
+=================================== ===================================================
+Location                             Classification
+=================================== ===================================================
+DB column ``provider_name``          Physical schema compatibility — do not rename
+                                     without a reviewed migration.
+``Provider`` enum in types.py        Backend canonical form; maps source-family tokens
+                                     to storage values via ``canonical_runtime_provider``.
+CLI ``--provider`` / ``--exclude-provider``
+                                     Public source-family filter (alias-aware).
+MCP ``provider`` param               Same as CLI — source-family filter.
+``ConversationSummaryPayload.provider``
+                                     Public surface field; carries source-family token.
+Provider-wire schemas under          Lab/provider scope (OpenAI/Google/Anthropic) —
+  ``schemas/providers/``             describes raw export shapes, not ingestion sources.
+Daemon ``/api/facets`` providers     Source-family counts.
+=================================== ===================================================
+
+Key alias rules
+---------------
+
+- ``aistudio`` canonicalizes to ``gemini`` at the storage/enum layer
+  (Google AI Studio exports are Gemini-provider conversations) but
+  remains a distinct *source family* for watcher discovery and source
+  name display.
+- ``gemini-cli`` is a separate runtime/schema token from ``gemini``
+  (different raw export shape, different watcher root).
+- ``hermes`` and ``antigravity`` are distinct source-family tokens with
+  their own watcher roots and schema providers.
+- ``claude`` and ``anthropic`` are aliases for ``claude-ai`` (Claude web).
+"""
 
 from __future__ import annotations
 

--- a/polylogue/daemon/http.py
+++ b/polylogue/daemon/http.py
@@ -20,7 +20,9 @@ from polylogue.errors import PolylogueError
 from polylogue.logging import get_logger
 from polylogue.paths import db_path
 from polylogue.surfaces.payloads import (
+    MutationResultPayload,
     QueryErrorPayload,
+    QueryMissDiagnosticsPayload,
     _build_flags_from_conversation,
     _extract_cwd,
     _extract_repo,
@@ -506,11 +508,10 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
         if not summaries and spec.has_filters():
             with contextlib.suppress(ImportError):
                 from polylogue.config import ConfigError
-                from polylogue.mcp.payloads import MCPQueryMissDiagnosticsPayload
 
                 try:
                     raw_diag = await poly.operations.diagnose_query_miss(spec)
-                    diagnostics = MCPQueryMissDiagnosticsPayload.from_diagnostics(raw_diag)
+                    diagnostics = QueryMissDiagnosticsPayload.from_diagnostics(raw_diag)
                 except ConfigError:
                     pass
 
@@ -553,7 +554,6 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
     ) -> object:
         """Return ranked search hits with match evidence for queries with search terms."""
         from polylogue.archive.query.search_hits import search_hits_for_plan
-        from polylogue.mcp.payloads import MCPQueryMissDiagnosticsPayload
 
         plan = spec.to_plan()
         hits = await search_hits_for_plan(plan, poly.repository)
@@ -564,7 +564,7 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
             with contextlib.suppress(Exception):
                 try:
                     raw_diag = await poly.operations.diagnose_query_miss(spec)
-                    diagnostics = MCPQueryMissDiagnosticsPayload.from_diagnostics(raw_diag)
+                    diagnostics = QueryMissDiagnosticsPayload.from_diagnostics(raw_diag)
                 except Exception:
                     pass
 
@@ -864,7 +864,6 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
         result = self._sync_run(lambda p: _do_reset())
 
         emit_daemon_event("reset", operation_id=op_id, payload=result if isinstance(result, dict) else None)
-        from polylogue.mcp.payloads import MutationResultPayload
 
         deleted = result.get("deleted", False) if isinstance(result, dict) else False
         response = MutationResultPayload(

--- a/polylogue/mcp/payloads.py
+++ b/polylogue/mcp/payloads.py
@@ -52,6 +52,7 @@ from polylogue.surfaces.payloads import (
     ConversationSummaryPayload as MCPConversationSummaryPayload,
 )
 from polylogue.surfaces.payloads import (
+    MutationResultPayload,
     SurfacePayloadModel,
     model_json_document,
     normalize_role,
@@ -367,34 +368,6 @@ class MCPMutationStatusPayload(SurfacePayloadModel):
     conversation_count: int | None = None
     outcome: str | None = None
     """Tag idempotency outcome: ``added``, ``no_op``, ``removed``, or ``not_present``."""
-
-
-class MutationResultPayload(SurfacePayloadModel):
-    """Shared result envelope for tag, metadata, and delete mutations.
-
-    Carries idempotent status codes, context fields, and bulk-operation
-    counts so that CLI, MCP, API, and daemon surfaces all expose the
-    same mutation contract shape.
-    """
-
-    status: str
-    """``ok``, ``deleted``, ``not_found``, ``unchanged``, or ``partial``."""
-
-    conversation_id: str | None = None
-    detail: str | None = None
-    """Machine-readable detail: ``already_present``, ``tag_not_present``,
-    ``key_not_found``, ``value_unchanged``, ``conversation_not_found``."""
-
-    outcome: str | None = None
-    """Tag idempotency outcome: ``added``, ``no_op``, ``removed``, or ``not_present``."""
-
-    affected_count: int | None = None
-    skipped_count: int | None = None
-    tag: str | None = None
-    key: str | None = None
-    conversation_count: int | None = None
-    tag_count: int | None = None
-    applied_count: int | None = None
 
 
 class MCPTagCountsPayload(MCPRootPayload[dict[str, int]]):

--- a/polylogue/surfaces/payloads.py
+++ b/polylogue/surfaces/payloads.py
@@ -496,6 +496,34 @@ class FacetsResponse(SurfacePayloadModel):
     total_messages: int = 0
 
 
+class MutationResultPayload(SurfacePayloadModel):
+    """Shared result envelope for tag, metadata, and delete mutations.
+
+    Carries idempotent status codes, context fields, and bulk-operation
+    counts so that CLI, MCP, API, and daemon surfaces all expose the
+    same mutation contract shape.
+    """
+
+    status: str
+    """``ok``, ``deleted``, ``not_found``, ``unchanged``, or ``partial``."""
+
+    conversation_id: str | None = None
+    detail: str | None = None
+    """Machine-readable detail: ``already_present``, ``tag_not_present``,
+    ``key_not_found``, ``value_unchanged``, ``conversation_not_found``."""
+
+    outcome: str | None = None
+    """Tag idempotency outcome: ``added``, ``no_op``, ``removed``, or ``not_present``."""
+
+    affected_count: int | None = None
+    skipped_count: int | None = None
+    tag: str | None = None
+    key: str | None = None
+    conversation_count: int | None = None
+    tag_count: int | None = None
+    applied_count: int | None = None
+
+
 # ---------------------------------------------------------------------------
 # Payload builder helpers
 # ---------------------------------------------------------------------------
@@ -542,6 +570,7 @@ __all__ = [
     "MachineErrorEnvelope",
     "MachineSuccessEnvelope",
     "MachineSuccessPayload",
+    "MutationResultPayload",
     "QueryErrorPayload",
     "QueryMissDiagnosticsPayload",
     "QueryMissReasonPayload",

--- a/tests/unit/core/test_config.py
+++ b/tests/unit/core/test_config.py
@@ -289,6 +289,284 @@ class TestConfigPublicBoundary:
 
 
 # =============================================================================
+# PolylogueConfig TOML/env/CLI precedence tests (#829)
+# =============================================================================
+
+
+class TestPolylogueConfigDefaults:
+    """PolylogueConfig returns sensible defaults with no TOML or env."""
+
+    def test_archive_root_default(self, workspace_env: dict[str, Path]) -> None:
+        from polylogue.config import load_polylogue_config
+
+        cfg = load_polylogue_config()
+        assert cfg.archive_root
+
+    def test_api_host_default(self, workspace_env: dict[str, Path]) -> None:
+        from polylogue.config import load_polylogue_config
+
+        cfg = load_polylogue_config()
+        assert cfg.api_host == "127.0.0.1"
+
+    def test_api_port_default(self, workspace_env: dict[str, Path]) -> None:
+        from polylogue.config import load_polylogue_config
+
+        cfg = load_polylogue_config()
+        assert cfg.api_port == 8766
+
+    def test_embedding_disabled_by_default(self, workspace_env: dict[str, Path]) -> None:
+        from polylogue.config import load_polylogue_config
+
+        cfg = load_polylogue_config()
+        assert cfg.embedding_enabled is False
+
+    def test_embedding_model_default(self, workspace_env: dict[str, Path]) -> None:
+        from polylogue.config import load_polylogue_config
+
+        cfg = load_polylogue_config()
+        assert cfg.embedding_model == "voyage-4"
+
+    def test_embedding_dimension_default(self, workspace_env: dict[str, Path]) -> None:
+        from polylogue.config import load_polylogue_config
+
+        cfg = load_polylogue_config()
+        assert cfg.embedding_dimension == 1024
+
+    def test_embedding_max_cost_default(self, workspace_env: dict[str, Path]) -> None:
+        from polylogue.config import load_polylogue_config
+
+        cfg = load_polylogue_config()
+        assert cfg.embedding_max_cost_usd == 5.0
+
+    def test_notification_backend_default(self, workspace_env: dict[str, Path]) -> None:
+        from polylogue.config import load_polylogue_config
+
+        cfg = load_polylogue_config()
+        assert cfg.notification_backend == "log"
+
+    def test_health_interval_default(self, workspace_env: dict[str, Path]) -> None:
+        from polylogue.config import load_polylogue_config
+
+        cfg = load_polylogue_config()
+        assert cfg.health_check_interval_s == 300
+
+    def test_health_tiers_default(self, workspace_env: dict[str, Path]) -> None:
+        from polylogue.config import load_polylogue_config
+
+        cfg = load_polylogue_config()
+        assert cfg.health_check_tiers == "fast,medium"
+
+    def test_source_roots_default(self, workspace_env: dict[str, Path]) -> None:
+        from polylogue.config import load_polylogue_config
+
+        cfg = load_polylogue_config()
+        assert cfg.source_roots == ()
+
+    def test_watch_debounce_default(self, workspace_env: dict[str, Path]) -> None:
+        from polylogue.config import load_polylogue_config
+
+        cfg = load_polylogue_config()
+        assert cfg.watch_debounce_s == 2.0
+
+
+class TestPolylogueConfigEnvOverrides:
+    """POLYLOGUE_* env vars override defaults."""
+
+    def test_env_overrides_api_host(self, monkeypatch: pytest.MonkeyPatch, workspace_env: dict[str, Path]) -> None:
+        from polylogue.config import load_polylogue_config
+
+        monkeypatch.setenv("POLYLOGUE_API_HOST", "0.0.0.0")
+        cfg = load_polylogue_config()
+        assert cfg.api_host == "0.0.0.0"
+
+    def test_env_overrides_api_port(self, monkeypatch: pytest.MonkeyPatch, workspace_env: dict[str, Path]) -> None:
+        from polylogue.config import load_polylogue_config
+
+        monkeypatch.setenv("POLYLOGUE_API_PORT", "9999")
+        cfg = load_polylogue_config()
+        assert cfg.api_port == 9999
+
+    def test_env_overrides_api_auth_token(
+        self, monkeypatch: pytest.MonkeyPatch, workspace_env: dict[str, Path]
+    ) -> None:
+        from polylogue.config import load_polylogue_config
+
+        monkeypatch.setenv("POLYLOGUE_API_AUTH_TOKEN", "secret-token")
+        cfg = load_polylogue_config()
+        assert cfg.api_auth_token == "secret-token"
+
+    def test_env_overrides_embedding_enabled(
+        self, monkeypatch: pytest.MonkeyPatch, workspace_env: dict[str, Path]
+    ) -> None:
+        from polylogue.config import load_polylogue_config
+
+        monkeypatch.setenv("POLYLOGUE_DAEMON_ENABLE_EMBEDDINGS", "true")
+        cfg = load_polylogue_config()
+        assert cfg.embedding_enabled is True
+
+    def test_env_overrides_notification_backend(
+        self, monkeypatch: pytest.MonkeyPatch, workspace_env: dict[str, Path]
+    ) -> None:
+        from polylogue.config import load_polylogue_config
+
+        monkeypatch.setenv("POLYLOGUE_NOTIFICATION_BACKEND", "stdout")
+        cfg = load_polylogue_config()
+        assert cfg.notification_backend == "stdout"
+
+    def test_env_overrides_health_interval(
+        self, monkeypatch: pytest.MonkeyPatch, workspace_env: dict[str, Path]
+    ) -> None:
+        from polylogue.config import load_polylogue_config
+
+        monkeypatch.setenv("POLYLOGUE_HEALTH_CHECK_INTERVAL_S", "60")
+        cfg = load_polylogue_config()
+        assert cfg.health_check_interval_s == 60
+
+    def test_env_overrides_health_tiers(self, monkeypatch: pytest.MonkeyPatch, workspace_env: dict[str, Path]) -> None:
+        from polylogue.config import load_polylogue_config
+
+        monkeypatch.setenv("POLYLOGUE_HEALTH_CHECK_TIERS", "fast")
+        cfg = load_polylogue_config()
+        assert cfg.health_check_tiers == "fast"
+
+    def test_env_overrides_browser_capture_port(
+        self, monkeypatch: pytest.MonkeyPatch, workspace_env: dict[str, Path]
+    ) -> None:
+        from polylogue.config import load_polylogue_config
+
+        monkeypatch.setenv("POLYLOGUE_BROWSER_CAPTURE_PORT", "8888")
+        cfg = load_polylogue_config()
+        assert cfg.browser_capture_port == 8888
+
+    def test_env_overrides_watch_debounce(
+        self, monkeypatch: pytest.MonkeyPatch, workspace_env: dict[str, Path]
+    ) -> None:
+        from polylogue.config import load_polylogue_config
+
+        monkeypatch.setenv("POLYLOGUE_WATCH_DEBOUNCE_S", "5.0")
+        cfg = load_polylogue_config()
+        assert cfg.watch_debounce_s == 5.0
+
+
+class TestPolylogueConfigCLIOverrides:
+    """CLI overrides take highest precedence."""
+
+    def test_cli_overrides_api_port(self, workspace_env: dict[str, Path]) -> None:
+        from polylogue.config import load_polylogue_config
+
+        cfg = load_polylogue_config(cli_overrides={"api_port": 7777})
+        assert cfg.api_port == 7777
+
+    def test_cli_overrides_auth_token(self, workspace_env: dict[str, Path]) -> None:
+        from polylogue.config import load_polylogue_config
+
+        cfg = load_polylogue_config(cli_overrides={"api_auth_token": "cli-token"})
+        assert cfg.api_auth_token == "cli-token"
+
+    def test_cli_trumps_env(self, monkeypatch: pytest.MonkeyPatch, workspace_env: dict[str, Path]) -> None:
+        from polylogue.config import load_polylogue_config
+
+        monkeypatch.setenv("POLYLOGUE_API_PORT", "9999")
+        cfg = load_polylogue_config(cli_overrides={"api_port": 7777})
+        assert cfg.api_port == 7777
+
+    def test_cli_overrides_embedding_max_cost(self, workspace_env: dict[str, Path]) -> None:
+        from polylogue.config import load_polylogue_config
+
+        cfg = load_polylogue_config(cli_overrides={"embedding_max_cost_usd": 10.0})
+        assert cfg.embedding_max_cost_usd == 10.0
+
+
+class TestPolylogueConfigTOML:
+    """TOML config file overrides defaults but is overridden by env/CLI."""
+
+    def test_toml_sets_api_port(self, tmp_path: Path, workspace_env: dict[str, Path]) -> None:
+        from polylogue.config import load_polylogue_config
+
+        toml_path = tmp_path / "polylogue.toml"
+        toml_path.write_text(
+            "[daemon.api]\nport = 9998\n",
+            encoding="utf-8",
+        )
+        cfg = load_polylogue_config(config_path=toml_path)
+        assert cfg.api_port == 9998
+
+    def test_toml_sets_browser_capture(self, tmp_path: Path, workspace_env: dict[str, Path]) -> None:
+        from polylogue.config import load_polylogue_config
+
+        toml_path = tmp_path / "polylogue.toml"
+        toml_path.write_text(
+            '[daemon.browser_capture]\nhost = "0.0.0.0"\nport = 9997\n',
+            encoding="utf-8",
+        )
+        cfg = load_polylogue_config(config_path=toml_path)
+        assert cfg.browser_capture_host == "0.0.0.0"
+        assert cfg.browser_capture_port == 9997
+
+    def test_toml_sets_source_roots(self, tmp_path: Path, workspace_env: dict[str, Path]) -> None:
+        from polylogue.config import load_polylogue_config
+
+        toml_path = tmp_path / "polylogue.toml"
+        toml_path.write_text(
+            '[sources]\nroots = ["/tmp/extra", "/tmp/more"]\n',
+            encoding="utf-8",
+        )
+        cfg = load_polylogue_config(config_path=toml_path)
+        assert cfg.source_roots == ("/tmp/extra", "/tmp/more")
+
+    def test_toml_env_cli_precedence(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, workspace_env: dict[str, Path]
+    ) -> None:
+        from polylogue.config import load_polylogue_config
+
+        toml_path = tmp_path / "polylogue.toml"
+        toml_path.write_text(
+            "[daemon.api]\nport = 9000\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("POLYLOGUE_API_PORT", "9001")
+        cfg = load_polylogue_config(config_path=toml_path)
+        # env overrides TOML
+        assert cfg.api_port == 9001
+
+        # CLI overrides env
+        cfg2 = load_polylogue_config(config_path=toml_path, cli_overrides={"api_port": 9002})
+        assert cfg2.api_port == 9002
+
+    def test_toml_sets_embedding(self, tmp_path: Path, workspace_env: dict[str, Path]) -> None:
+        from polylogue.config import load_polylogue_config
+
+        toml_path = tmp_path / "polylogue.toml"
+        toml_path.write_text(
+            '[embedding]\nenabled = true\nmodel = "voyage-3"\ndimension = 512\n',
+            encoding="utf-8",
+        )
+        cfg = load_polylogue_config(config_path=toml_path)
+        assert cfg.embedding_enabled is True
+        assert cfg.embedding_model == "voyage-3"
+        assert cfg.embedding_dimension == 512
+
+
+class TestPolylogueConfigFormatTOML:
+    """format_config_toml produces loadable TOML."""
+
+    def test_roundtrip_defaults(self) -> None:
+        from polylogue.config import format_config_toml, load_polylogue_config
+
+        cfg = load_polylogue_config()
+        formatted = format_config_toml(cfg.raw)
+        assert "[archive]" in formatted
+        assert "[daemon]" in formatted
+
+    def test_source_roots_formatted_as_array(self, workspace_env: dict[str, Path]) -> None:
+        from polylogue.config import format_config_toml, load_polylogue_config
+
+        cfg = load_polylogue_config(cli_overrides={"source_roots": ("/a", "/b")})
+        formatted = format_config_toml(cfg.raw)
+        assert 'roots = ["/a", "/b"]' in formatted
+
+
+# =============================================================================
 # Merged from test_logging.py (2024-03-15)
 # =============================================================================
 

--- a/tests/unit/daemon/test_web_reader.py
+++ b/tests/unit/daemon/test_web_reader.py
@@ -313,6 +313,152 @@ def test_reader_smoke_lane_is_documented() -> None:
     assert "polylogue.local_reader.conversation" in body
 
 
+# ---------------------------------------------------------------------------
+# Shared surface payload contract tests (#859)
+# ---------------------------------------------------------------------------
+
+
+class TestSharedQueryPayloads:
+    """QueryMissDiagnosticsPayload, QueryErrorPayload, and response envelopes."""
+
+    def test_query_error_payload_roundtrip(self) -> None:
+        from polylogue.surfaces.payloads import QueryErrorPayload
+
+        p = QueryErrorPayload(error="QuerySpecError", detail="invalid since: bogus", field="since")
+        d = p.model_dump(mode="json")
+        assert d["ok"] is False
+        assert d["error"] == "QuerySpecError"
+        assert d["detail"] == "invalid since: bogus"
+        assert d["field"] == "since"
+
+    def test_query_error_payload_minimal(self) -> None:
+        from polylogue.surfaces.payloads import QueryErrorPayload
+
+        p = QueryErrorPayload(error="internal_error")
+        d = p.model_dump(mode="json")
+        assert d["ok"] is False
+        assert d["detail"] is None
+        assert d["field"] is None
+
+    def test_query_miss_diagnostics_roundtrip(self) -> None:
+        from polylogue.surfaces.payloads import QueryMissDiagnosticsPayload, QueryMissReasonPayload
+
+        p = QueryMissDiagnosticsPayload(
+            message="No conversations matched the query.",
+            filters=("provider=gemini", "tag=api"),
+            reasons=(QueryMissReasonPayload(code="no_results", severity="info", summary="empty archive"),),
+            archive_conversation_count=42,
+            raw_conversation_count=100,
+        )
+        d = p.model_dump(mode="json")
+        assert d["message"] == "No conversations matched the query."
+        assert d["filters"] == ["provider=gemini", "tag=api"]
+        assert len(d["reasons"]) == 1
+        assert d["archive_conversation_count"] == 42
+
+    def test_conversation_list_response_shape(self) -> None:
+        from polylogue.surfaces.payloads import ConversationListResponse
+
+        r = ConversationListResponse(items=(), total=0, limit=50, offset=0)
+        d = r.model_dump(mode="json")
+        assert d["items"] == []
+        assert d["total"] == 0
+        assert d["limit"] == 50
+        assert d["offset"] == 0
+
+    def test_conversation_list_response_with_diagnostics(self) -> None:
+        from polylogue.surfaces.payloads import (
+            ConversationListResponse,
+            QueryMissDiagnosticsPayload,
+            QueryMissReasonPayload,
+        )
+
+        diag = QueryMissDiagnosticsPayload(
+            message="No results.",
+            filters=("tag=missing",),
+            reasons=(QueryMissReasonPayload(code="no_results", severity="info", summary="no match"),),
+        )
+        r = ConversationListResponse(items=(), total=0, limit=10, offset=0, diagnostics=diag)
+        d = r.model_dump(mode="json")
+        assert d["diagnostics"] is not None
+        assert d["diagnostics"]["message"] == "No results."
+
+    def test_facets_response_shape(self) -> None:
+        from polylogue.surfaces.payloads import FacetsResponse, FacetTimeRange
+
+        r = FacetsResponse(
+            scoped_to_query=False,
+            providers={"claude-code": 10, "chatgpt": 5},
+            total_conversations=15,
+            total_messages=100,
+            time_range=FacetTimeRange(min="2024-01-01", max="2024-12-31"),
+        )
+        d = r.model_dump(mode="json")
+        assert d["scoped_to_query"] is False
+        assert d["providers"] == {"claude-code": 10, "chatgpt": 5}
+        assert d["total_conversations"] == 15
+        assert d["time_range"]["min"] == "2024-01-01"
+
+
+class TestQueryNoResultsDiagnosticPath:
+    """Cross-surface contract: one filtered query → diagnostics path."""
+
+    def test_search_with_bad_date_returns_query_error(self, workspace_env: dict[str, Path]) -> None:
+        """A query with a malformed date produces a QueryErrorPayload-shaped error."""
+        with _running_server(workspace_env) as (_, base_url):
+            status, body = _get_json_ex(base_url, "/api/conversations?since=not-a-date")
+        assert status == 400
+        # The error shape is compatible with QueryErrorPayload
+        assert "error" in body
+        assert body.get("ok") is False
+
+    def test_list_with_no_match_returns_diagnostics(self, workspace_env: dict[str, Path]) -> None:
+        """A list with a tag that doesn't exist returns items=[] with total=0."""
+        with _running_server(workspace_env) as (_, base_url):
+            payload = _get_json(base_url, "/api/conversations?tag=nonexistent")
+        assert isinstance(payload, dict)
+        assert "items" in payload
+        assert "total" in payload
+        assert payload["total"] == 0
+        assert payload["items"] == []
+
+    def test_facets_global_returns_providers(self, workspace_env: dict[str, Path]) -> None:
+        """Unscoped /api/facets returns scoped_to_query=False with provider counts."""
+        with _running_server(workspace_env) as (_, base_url):
+            payload = _get_json(base_url, "/api/facets")
+        assert isinstance(payload, dict)
+        assert payload["scoped_to_query"] is False
+        assert isinstance(payload["providers"], dict)
+
+    def test_facets_scoped_returns_subset(self, workspace_env: dict[str, Path]) -> None:
+        """Scoped /api/facets?provider=... returns scoped_to_query=True."""
+        with _running_server(workspace_env) as (_, base_url):
+            payload = _get_json(base_url, "/api/facets?provider=chatgpt")
+        assert isinstance(payload, dict)
+        assert payload["scoped_to_query"] is True
+
+
+def _get_json_ex(base_url: str, path: str) -> tuple[int, dict[str, object]]:
+    """GET a path and return (status, parsed-body-or-empty-dict).
+
+    Unlike ``_get_json``, this helper reads the response body even for
+    error status codes so contract tests can assert on error-envelope shape.
+    """
+    from urllib.error import HTTPError
+    from urllib.request import Request, urlopen
+
+    req = Request(f"{base_url}{path}")
+    try:
+        with urlopen(req, timeout=5) as resp:
+            return resp.status, json.loads(resp.read().decode())
+    except HTTPError as e:
+        body = e.read().decode() if e.fp else ""
+        try:
+            return e.code, json.loads(body)
+        except (json.JSONDecodeError, ValueError):
+            return e.code, {}
+
+
 @pytest.mark.parametrize("path", ["/", "/api/conversations", "/api/facets", "/api/status", "/api/health"])
 def test_each_reader_route_responds_within_a_reasonable_budget(workspace_env: dict[str, Path], path: str) -> None:
     """Each reader-facing route returns within 10 s on a synthetic


### PR DESCRIPTION
## Summary

Foundation slice for the control-plane/read-surface backlog: one consumed config path, shared query/diagnostics/mutation payloads that daemon/CLI/MCP reuse, and documented source-family vocabulary that stops conflating aistudio/gemini-cli/hermes.

## Problem

- **#829**: `PolylogueConfig` existed but several runtime consumers still read env/path variables directly. Daemon API bind/auth, source roots, browser capture, and watch settings had no env-var or TOML route.
- **#1022**: The `provider` term was overloaded across four distinct concepts (source family, lab, model, source root). No reference table existed to guide implementers.
- **#859**: Daemon HTTP was importing `MCPQueryMissDiagnosticsPayload` and `MutationResultPayload` from `polylogue.mcp.payloads` — a surface import bypass. No shared response envelope was used for list/search/diagnostics.
- **#860**: The daemon-MCP payload import was the most immediate bypass. Remaining bypasses are inventoried in the issue comments and deferred.

## Solution

### 1. Shared surface payloads (removes daemon→MCP import)
- `MutationResultPayload` moved from `polylogue/mcp/payloads.py` to `polylogue/surfaces/payloads.py`; MCP re-exports it.
- Daemon HTTP `_handle_list_conversations` and `_do_search_list` now use `QueryMissDiagnosticsPayload` from shared surfaces instead of `MCPQueryMissDiagnosticsPayload`.
- Daemon HTTP reset handler uses `MutationResultPayload` from shared surfaces.

### 2. Config consolidation (#829)
- `PolylogueConfig` extended with: `browser_capture_host`, `browser_capture_port`, `browser_capture_spool_path`, `browser_capture_auth_token`, `browser_capture_allow_remote`, `watch_debounce_s`, `source_roots`.
- New env vars: `POLYLOGUE_API_HOST`, `POLYLOGUE_API_PORT`, `POLYLOGUE_API_AUTH_TOKEN`, `POLYLOGUE_BROWSER_CAPTURE_PORT`, `POLYLOGUE_BROWSER_CAPTURE_HOST`, `POLYLOGUE_WATCH_DEBOUNCE_S`.
- TOML sections: `[daemon.browser_capture]`, `[daemon.watch]`, `[sources]`.
- Int coercion for port env vars. List→tuple coercion for TOML source roots.

### 3. Source vocabulary contract (#1022)
- Reference table in `polylogue/core/provider_identity.py` distinguishing source family, provider/lab, model identity, and configured source root.
- Classification of every surviving `provider` use (DB column, enum, CLI flag, MCP param, surface field, wire schemas, daemon facets).
- Completion descriptions updated with source-family and lab annotations.

## Verification

```
$ devtools verify
ruff format ... ok
ruff check ... ok
mypy ... ok
render-all ... ok
pytest -q --ignore=tests/integration
6335 passed, 2 skipped, 2 xfailed, 2 xpassed in 216s

$ pytest tests/unit/core/test_config.py -q
70 passed (32 new)

$ pytest tests/unit/daemon/ -q
246 passed, 2 skipped (10 new)

$ pytest tests/unit/mcp/test_tag_idempotency.py tests/unit/mcp/test_envelope_contracts.py tests/unit/mcp/test_server_surfaces.py -q
78 passed
```

The 1 pre-existing failure (`test_query_memory_budget.py::test_main_emits_json_summary` — RSS assertion flake) and 2 re-run-passing Hypothesis flakes are unrelated to this PR.

## Issue matrix

| Issue | Satisfied | Remains open |
|---|---|---|
| **#829** | PolylogueConfig extended with daemon API, browser capture, watch, source roots. 14 env vars total. TOML sections for all new keys. 32 precedence tests. | Daemon CLI `run_command` still uses hardcoded CLI defaults (not resolved from config yet). Source discovery (`get_sources`/`default_sources`) not yet routed through PolylogueConfig. Direct `os.environ` reads in pipeline (`run_stages.py`, `ingest_batch/_core.py`, `search_providers/__init__.py`) still need routing. |
| **#1022** | Vocabulary boundary table added. Completion descriptions updated. Surviving `provider` uses classified. | Physical schema migration (`provider_name` → `source_name` column) deferred. Public `provider` field on payloads preserved for compatibility. |
| **#859** | `MutationResultPayload` in shared surfaces. Daemon HTTP uses shared `QueryMissDiagnosticsPayload`. `ConversationListResponse`, `FacetsResponse`, `QueryErrorPayload` in shared surfaces. 10 cross-surface contract tests. | Daemon HTTP still builds ad-hoc dicts for list/search/get responses (not yet using `ConversationListResponse` model). Full filter param surface on daemon HTTP `/api/conversations` only partial. Facet time_range/action_types/has_flags not populated. |
| **#860** | Daemon HTTP no longer imports from `polylogue.mcp.payloads` (2 imports removed). | Full bypass inventory in #860 comments — B1 (rendering), B4 (CLI vector provider), B6-B10 (TUI), B12 (facade raw artifacts) still need addressing. |

## Surviving direct storage/MCP imports

| Import | Kept/Removed | Reason | Follow-up |
|---|---|---|---|
| `from polylogue.mcp.payloads import MCPQueryMissDiagnosticsPayload` | Removed | Replaced by shared `QueryMissDiagnosticsPayload` | — |
| `from polylogue.mcp.payloads import MutationResultPayload` | Removed via shared re-export | Daemon now imports from `polylogue.surfaces.payloads` | — |

## Follow-up issues

- Route daemon CLI `run_command` defaults through `load_polylogue_config()`.
- Route pipeline `VOYAGE_API_KEY` and `POLYLOGUE_SCHEMA_VALIDATION` reads through config.
- Use typed `ConversationListResponse` in daemon HTTP instead of ad-hoc dicts.
- Address rendering/TUI/facade storage bypasses enumerated in #860.

🤖 Generated with [Claude Code](https://claude.com/claude-code)