### PR TITLE
perf(daemon): use indexed action FTS probe

### DIFF
--- a/polylogue/daemon/convergence_stages.py
+++ b/polylogue/daemon/convergence_stages.py
@@ -753,20 +753,20 @@ def _repair_changed_conversation_fts(
     if needs.messages:
         repair_message_fts_index_sync(conn, conversation_ids)
     if needs.actions:
-        if _action_fts_has_rows_for_conversations(conn, conversation_ids):
+        if _action_events_exist_for_conversations(conn, conversation_ids):
             repair_action_fts_index_sync(conn, conversation_ids)
         else:
             insert_missing_action_fts_index_sync(conn, conversation_ids)
 
 
-def _action_fts_has_rows_for_conversations(conn: sqlite3.Connection, conversation_ids: Sequence[str]) -> bool:
-    if not conversation_ids or not _table_exists(conn, "action_events_fts"):
+def _action_events_exist_for_conversations(conn: sqlite3.Connection, conversation_ids: Sequence[str]) -> bool:
+    if not conversation_ids or not _table_exists(conn, "action_events"):
         return False
     placeholders = ", ".join("?" for _ in conversation_ids)
     row = conn.execute(
         f"""
         SELECT 1
-        FROM action_events_fts
+        FROM action_events
         WHERE conversation_id IN ({placeholders})
         LIMIT 1
         """,

--- a/tests/unit/daemon/test_convergence_stages.py
+++ b/tests/unit/daemon/test_convergence_stages.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import asyncio
+import sqlite3
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
+from typing import cast
 
 import pytest
 
@@ -140,7 +142,7 @@ def test_fts_stage_repairs_only_missing_action_index_when_messages_current(
         lambda _conn, paths: {Path(paths[0]): ["conv-a"], Path(paths[1]): ["conv-b"]},
     )
     monkeypatch.setattr(stages, "_fts_repair_needs_for_conversations", fake_repair_needs)
-    monkeypatch.setattr(stages, "_action_fts_has_rows_for_conversations", lambda _conn, _ids: False)
+    monkeypatch.setattr(stages, "_action_events_exist_for_conversations", lambda _conn, _ids: False)
 
     stage = make_fts_stage(db_path)
     assert stage.execute_many is not None
@@ -150,6 +152,33 @@ def test_fts_stage_repairs_only_missing_action_index_when_messages_current(
     assert needs_calls == [["conv-a", "conv-b"], ["conv-a", "conv-b"]]
     assert committed is True
     assert rebuilt is False
+
+
+def test_action_event_probe_uses_indexed_base_table() -> None:
+    queries: list[tuple[str, tuple[str, ...]]] = []
+
+    class FakeConnection:
+        def execute(self, sql: str, params: tuple[str, ...] = ()) -> object:
+            queries.append((sql, params))
+            if "sqlite_master" in sql:
+                return _FakeCursor([("action_events",)])
+            if "action_events" in sql:
+                return _FakeCursor([(1,)])
+            raise AssertionError(f"unexpected SQL: {sql}")
+
+    class _FakeCursor:
+        def __init__(self, rows: list[tuple[object, ...]]) -> None:
+            self._rows = rows
+
+        def fetchone(self) -> tuple[object, ...] | None:
+            return self._rows[0] if self._rows else None
+
+    conn = cast(sqlite3.Connection, FakeConnection())
+    assert stages._action_events_exist_for_conversations(conn, ["conv-a", "conv-b"]) is True
+    probe_sql = queries[-1][0]
+    assert "FROM action_events\n" in probe_sql
+    assert "action_events_fts" not in probe_sql
+    assert queries[-1][1] == ("conv-a", "conv-b")
 
 
 def test_embed_stage_scopes_changed_conversations_without_asyncio_run(


### PR DESCRIPTION
## Summary

Use the indexed `action_events` base table to decide whether changed conversations have action rows before repairing action-event FTS during daemon convergence.

## Problem

After #1034 removed the full source-file rehash path, the live production daemon still accumulated heavy reads while converging changed files. `py-spy` showed the remaining busy thread inside `_action_fts_has_rows_for_conversations`, which queried `action_events_fts` by `conversation_id`. On the production archive this behaves like an FTS-table scan during catch-up.

## Solution

The repair decision now probes `action_events(conversation_id)` instead. That table has normal indexes, and the production query plan uses a covering index. The daemon still repairs or inserts the full action FTS rows from the persisted base data; only the existence probe changes.

## Verification

- `pytest tests/unit/daemon/test_convergence_stages.py -q --tb=short` → `10 passed in 7.93s`
- `ruff check polylogue/daemon/convergence_stages.py tests/unit/daemon/test_convergence_stages.py` → `All checks passed!`
- Push hook quick baseline → `exit_code: 0`
- Production query-plan check: `EXPLAIN QUERY PLAN SELECT 1 FROM action_events WHERE conversation_id IN (...) LIMIT 1` → `SEARCH action_events USING COVERING INDEX idx_action_events_sort`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability and accuracy of search index maintenance for action events by enhancing how the system determines when repairs are necessary.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sinity/polylogue/pull/1035)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->