### PR TITLE
perf(daemon): bound startup FTS readiness

### DIFF
--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -40,11 +40,6 @@ logger = get_logger(__name__)
 _pidfile_path: Path | None = None
 
 
-def _fts_status_count(status: dict[str, object]) -> int:
-    value = status.get("count", 0)
-    return value if isinstance(value, int) else 0
-
-
 def _cleanup_pidfile() -> None:
     """Remove the daemon pidfile on exit."""
     global _pidfile_path
@@ -78,11 +73,11 @@ def _verify_pidfile(pidfile: Path) -> bool:
 
 
 async def _ensure_fts_startup_readiness() -> None:
-    """Check FTS coverage on daemon startup, rebuild if incomplete.
+    """Ensure FTS exists on startup without scanning the full archive.
 
-    A gap can only exist from pre-daemon historical data. Once caught up,
-    the write path maintains FTS atomically via commit_archive_write_effects.
-    This check runs once at startup and never again.
+    A complete gap can exist when historical rows predate FTS creation. Partial
+    gaps are repaired by conversation-scoped convergence; startup must not count
+    all messages on every daemon restart.
     """
     from polylogue.paths import archive_root, db_path
     from polylogue.storage.sqlite.connection_profile import open_connection
@@ -94,31 +89,31 @@ async def _ensure_fts_startup_readiness() -> None:
     conn = None
     try:
         conn = open_connection(db, timeout=10.0)
-        total = conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0]
-        if total == 0:
-            conn.close()
-            return
-        from polylogue.storage.fts.fts_lifecycle import fts_index_status_sync
-
-        fts_status = fts_index_status_sync(conn)
-        fts_count = _fts_status_count(fts_status)
-        gap = total - fts_count
-        if gap <= 0:
-            conn.close()
-            return
-
-        logger.warning(
-            "daemon: FTS index incomplete (%d/%d messages, %.1f%% gap). Rebuilding once.",
-            fts_count,
-            total,
-            100 * gap / total,
+        row = conn.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='messages_fts'").fetchone()
+        has_fts_table = row is not None
+        has_indexable_messages = (
+            conn.execute("SELECT 1 FROM messages WHERE text IS NOT NULL LIMIT 1").fetchone() is not None
         )
-        from polylogue.storage.fts.fts_lifecycle import rebuild_fts_index_sync
 
-        rebuild_fts_index_sync(conn)
+        from polylogue.storage.fts.fts_lifecycle import ensure_fts_index_sync, rebuild_fts_index_sync
+
+        if not has_fts_table:
+            logger.warning("daemon: message FTS table missing. Rebuilding once.")
+            rebuild_fts_index_sync(conn)
+            conn.commit()
+            logger.info("daemon: FTS rebuild complete.")
+            return
+
+        ensure_fts_index_sync(conn)
+        has_indexed_messages = conn.execute("SELECT 1 FROM messages_fts_docsize LIMIT 1").fetchone() is not None
+        if has_indexable_messages and not has_indexed_messages:
+            logger.warning("daemon: message FTS is empty while archive has messages. Rebuilding once.")
+            rebuild_fts_index_sync(conn)
+            conn.commit()
+            logger.info("daemon: FTS rebuild complete.")
+            return
+
         conn.commit()
-        new_count = _fts_status_count(fts_index_status_sync(conn))
-        logger.info("daemon: FTS rebuild complete — %d messages indexed.", new_count)
     except Exception:
         logger.warning("daemon: FTS startup check failed", exc_info=True)
     finally:

--- a/tests/unit/daemon/test_daemon_cli.py
+++ b/tests/unit/daemon/test_daemon_cli.py
@@ -245,7 +245,7 @@ def test_run_live_watcher_stops_on_keyboard_interrupt() -> None:
     assert stopped == [True]
 
 
-def test_ensure_fts_startup_readiness_uses_bounded_docsize_count(
+def test_ensure_fts_startup_readiness_uses_bounded_probes(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -264,21 +264,80 @@ def test_ensure_fts_startup_readiness_uses_bounded_docsize_count(
     class FakeConnection:
         def __init__(self) -> None:
             self.queries: list[str] = []
-            self.doc_counts = [1, 3]
             self.committed = False
             self.closed = False
 
         def execute(self, sql: str, _params: object = ()) -> FakeCursor:
             query = " ".join(sql.split())
             self.queries.append(query)
-            if query == "SELECT COUNT(*) FROM messages":
-                return FakeCursor((3,))
             if query == "SELECT name FROM sqlite_master WHERE type='table' AND name='messages_fts'":
                 return FakeCursor(("messages_fts",))
-            if query == "SELECT COUNT(*) FROM messages_fts_docsize":
-                count = self.doc_counts.pop(0) if self.doc_counts else 3
-                return FakeCursor((count,))
-            if query == "SELECT name FROM sqlite_master WHERE type='table' AND name='action_events_fts'":
+            if query == "SELECT 1 FROM messages WHERE text IS NOT NULL LIMIT 1":
+                return FakeCursor((1,))
+            if query == "SELECT 1 FROM messages_fts_docsize LIMIT 1":
+                return FakeCursor((1,))
+            raise AssertionError(f"unexpected query: {query}")
+
+        def commit(self) -> None:
+            self.committed = True
+
+        def close(self) -> None:
+            self.closed = True
+
+    conn = FakeConnection()
+    rebuilds: list[FakeConnection] = []
+    ensured: list[FakeConnection] = []
+
+    def rebuild(fake_conn: FakeConnection) -> None:
+        rebuilds.append(fake_conn)
+
+    def ensure(fake_conn: FakeConnection) -> None:
+        ensured.append(fake_conn)
+
+    monkeypatch.setattr("polylogue.paths.db_path", lambda: db)
+    monkeypatch.setattr("polylogue.storage.sqlite.connection_profile.open_connection", lambda _db, timeout: conn)
+    monkeypatch.setattr("polylogue.storage.fts.fts_lifecycle.ensure_fts_index_sync", ensure)
+    monkeypatch.setattr("polylogue.storage.fts.fts_lifecycle.rebuild_fts_index_sync", rebuild)
+
+    asyncio.run(daemon_cli._ensure_fts_startup_readiness())
+
+    assert ensured == [conn]
+    assert rebuilds == []
+    assert conn.committed is True
+    assert conn.closed is True
+    assert all(not query.startswith("SELECT COUNT(*)") for query in conn.queries)
+
+
+def test_ensure_fts_startup_readiness_rebuilds_empty_fts(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from polylogue.daemon import cli as daemon_cli
+
+    db = tmp_path / "polylogue.db"
+    db.write_bytes(b"sqlite placeholder")
+
+    class FakeCursor:
+        def __init__(self, row: tuple[object, ...] | None) -> None:
+            self._row = row
+
+        def fetchone(self) -> tuple[object, ...] | None:
+            return self._row
+
+    class FakeConnection:
+        def __init__(self) -> None:
+            self.queries: list[str] = []
+            self.committed = False
+            self.closed = False
+
+        def execute(self, sql: str, _params: object = ()) -> FakeCursor:
+            query = " ".join(sql.split())
+            self.queries.append(query)
+            if query == "SELECT name FROM sqlite_master WHERE type='table' AND name='messages_fts'":
+                return FakeCursor(("messages_fts",))
+            if query == "SELECT 1 FROM messages WHERE text IS NOT NULL LIMIT 1":
+                return FakeCursor((1,))
+            if query == "SELECT 1 FROM messages_fts_docsize LIMIT 1":
                 return FakeCursor(None)
             raise AssertionError(f"unexpected query: {query}")
 
@@ -296,6 +355,7 @@ def test_ensure_fts_startup_readiness_uses_bounded_docsize_count(
 
     monkeypatch.setattr("polylogue.paths.db_path", lambda: db)
     monkeypatch.setattr("polylogue.storage.sqlite.connection_profile.open_connection", lambda _db, timeout: conn)
+    monkeypatch.setattr("polylogue.storage.fts.fts_lifecycle.ensure_fts_index_sync", lambda _conn: None)
     monkeypatch.setattr("polylogue.storage.fts.fts_lifecycle.rebuild_fts_index_sync", rebuild)
 
     asyncio.run(daemon_cli._ensure_fts_startup_readiness())
@@ -303,8 +363,7 @@ def test_ensure_fts_startup_readiness_uses_bounded_docsize_count(
     assert rebuilds == [conn]
     assert conn.committed is True
     assert conn.closed is True
-    assert "SELECT COUNT(*) FROM messages_fts" not in conn.queries
-    assert conn.queries.count("SELECT COUNT(*) FROM messages_fts_docsize") == 2
+    assert all(not query.startswith("SELECT COUNT(*)") for query in conn.queries)
 
 
 def test_run_daemon_services_stops_live_watcher_on_failure() -> None:


### PR DESCRIPTION
## Summary

Bounds daemon startup FTS readiness so restarting `polylogued` no longer performs whole-archive `COUNT(*)` checks before live watching starts.

## Problem

Live deployment after #1037 still showed repeated >1 GiB physical reads immediately after each daemon restart. The process was stuck in disk wait before catch-up logs appeared, and the remaining running ingest attempt was not marked abandoned because startup had not reached the live cursor initialization path. The culprit was `_ensure_fts_startup_readiness()` doing exact full archive message and FTS counts every start.

## Solution

Replaced exact startup accounting with bounded probes: check whether the message FTS table exists, whether any indexable message exists, ensure FTS tables/triggers, and rebuild only when FTS is missing or obviously empty while the archive has messages. Partial gaps remain covered by conversation-scoped convergence instead of a full startup scan.

## Verification

- `ruff format polylogue/daemon/cli.py tests/unit/daemon/test_daemon_cli.py`
- `ruff check polylogue/daemon/cli.py tests/unit/daemon/test_daemon_cli.py`
- `pytest tests/unit/daemon/test_daemon_cli.py -q --tb=short` -> `15 passed`
- pre-push `python -m devtools verify --quick` -> all quick gates passed, total 22.03s

Ref #1036