### PR TITLE
perf(daemon): converge hot session ingest serially

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,7 +87,7 @@ Issues and PR bodies are durable artifacts. Write them for a reader who
 has no conversation context — they should stand alone. Include file
 paths, acceptance criteria, and design references where applicable.
 
-<!-- begin include: CONTRIBUTING.md -->
+<!-- begin include: /tmp/polylogue-hot-session/CONTRIBUTING.md -->
 # Contributing
 
 ## Development Environment
@@ -337,8 +337,8 @@ The PR title becomes the squash-merge subject on `master`. Rules:
 - ≤72 characters, conventional prefix, imperative mood
 - Describes what changed, not what was worked on
 - Accurate — do not claim alignment or unification unless the diff achieves it
-<!-- end include: CONTRIBUTING.md -->
-<!-- begin include: TESTING.md -->
+<!-- end include: /tmp/polylogue-hot-session/CONTRIBUTING.md -->
+<!-- begin include: /tmp/polylogue-hot-session/TESTING.md -->
 # Testing
 
 All commands below assume you are inside the project devshell. See
@@ -448,8 +448,8 @@ Never delete:
   shapes.
 - **`tests/unit/security/`**: Security boundary tests.
 
-<!-- end include: TESTING.md -->
-<!-- begin include: docs/architecture.md -->
+<!-- end include: /tmp/polylogue-hot-session/TESTING.md -->
+<!-- begin include: /tmp/polylogue-hot-session/docs/architecture.md -->
 # Polylogue Architecture
 
 Polylogue is a local archive for AI conversations. The system has four rings:
@@ -673,8 +673,8 @@ attachments, exports):
 - New semantics go into substrate or insights first, then surfaces adapt.
 - Proof subjects and claims live in `proof/`; devtools commands that exercise
   them live in `devtools/`.
-<!-- end include: docs/architecture.md -->
-<!-- begin include: docs/internals.md -->
+<!-- end include: /tmp/polylogue-hot-session/docs/architecture.md -->
+<!-- begin include: /tmp/polylogue-hot-session/docs/internals.md -->
 # Internals Reference
 
 Working map of the live codebase: invariants, hot files, extension points, and
@@ -881,8 +881,8 @@ devtools lab-scenario verify-baselines
 - `.cache/`: disposable caches (hypothesis, pytest, mypy, ruff)
 - `.local/`: untracked outputs (campaigns, showcases, build artifacts)
 - `.local/result`: out-link for `devtools build-package`
-<!-- end include: docs/internals.md -->
-<!-- begin include: docs/devtools.md -->
+<!-- end include: /tmp/polylogue-hot-session/docs/internals.md -->
+<!-- begin include: /tmp/polylogue-hot-session/docs/devtools.md -->
 # Developer Tools
 
 Use `devtools` for routine repository maintenance. Call individual
@@ -985,7 +985,6 @@ These are the commands worth remembering during normal repo work:
 | `devtools affected-obligations` | Route changed paths or refs to affected verification-lab proof obligations and focused checks. |
 | `devtools artifact-graph` | Render the runtime artifact, operation, and scenario-coverage map. |
 | `devtools coverage-gate` | Run pytest with the repository coverage floor from pyproject.toml. |
-| `devtools daemon-workload-probe` | Inspect daemon ingest workload, convergence debt, and hot query plans. |
 | `devtools lab-corpus` | Generate verification-lab synthetic corpus fixtures and demo archives. |
 | `devtools lab-scenario` | Run verification-lab showcase scenario sets and baseline checks. |
 | `devtools obligation-diff` | Diff proof obligations between two git refs to surface affected assurance domains. |
@@ -1058,4 +1057,4 @@ Campaign outputs live under `.local/`, not in tracked docs trees.
 
 Keep new repo-local outputs in `.cache/` or `.local/` instead of adding new
 top-level output roots.
-<!-- end include: docs/devtools.md -->
+<!-- end include: /tmp/polylogue-hot-session/docs/devtools.md -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,9 @@ documentation polish do not require an entry.
 
 ### Changed
 
+- Live daemon convergence now drains watcher batches single-flight, records
+  stale cursor-write counters, uses bounded tail hashes for same-size rewrite
+  detection, and exposes recent source-path churn in the daemon workload probe.
 - Session work-event and phase evidence payloads now expose timing/date
   provenance, and work-event insight reads order by event time instead of
   conversation recency.

--- a/devtools/daemon_workload_probe.py
+++ b/devtools/daemon_workload_probe.py
@@ -20,6 +20,15 @@ def _table_exists(conn: sqlite3.Connection, table: str) -> bool:
     return row is not None
 
 
+def _columns(conn: sqlite3.Connection, table: str) -> set[str]:
+    if not _table_exists(conn, table):
+        return set()
+    try:
+        return {str(row[1]) for row in conn.execute(f"PRAGMA table_info({table})")}
+    except sqlite3.Error:
+        return set()
+
+
 def _scalar_int(conn: sqlite3.Connection, sql: str, params: tuple[object, ...] = ()) -> int:
     try:
         row = conn.execute(sql, params).fetchone()
@@ -31,8 +40,11 @@ def _scalar_int(conn: sqlite3.Connection, sql: str, params: tuple[object, ...] =
 def _recent_attempts(conn: sqlite3.Connection, *, limit: int) -> list[dict[str, Any]]:
     if not _table_exists(conn, "live_ingest_attempt"):
         return []
+    columns = _columns(conn, "live_ingest_attempt")
+    stale_expr = "stale_cursor_write_count" if "stale_cursor_write_count" in columns else "0"
+    source_paths_expr = "source_paths_json" if "source_paths_json" in columns else "'[]'"
     rows = conn.execute(
-        """
+        f"""
         SELECT
             attempt_id,
             started_at,
@@ -48,7 +60,9 @@ def _recent_attempts(conn: sqlite3.Connection, *, limit: int) -> list[dict[str, 
             source_payload_read_bytes,
             cursor_fingerprint_read_bytes,
             parse_time_s,
-            convergence_time_s
+            convergence_time_s,
+            {stale_expr},
+            {source_paths_expr}
         FROM live_ingest_attempt
         ORDER BY updated_at DESC, started_at DESC
         LIMIT ?
@@ -78,9 +92,93 @@ def _recent_attempts(conn: sqlite3.Connection, *, limit: int) -> list[dict[str, 
                 "read_amplification": round(read_bytes / input_bytes, 3) if input_bytes > 0 else 0.0,
                 "parse_time_s": float(row[13] or 0.0),
                 "convergence_time_s": float(row[14] or 0.0),
+                "stale_cursor_write_count": int(row[15] or 0),
+                "source_paths": _json_list(row[16]),
             }
         )
     return attempts
+
+
+def _attempt_counts(conn: sqlite3.Connection) -> dict[str, Any]:
+    if not _table_exists(conn, "live_ingest_attempt"):
+        return {"total": 0, "running": 0, "failed": 0, "overlapping_source_paths": []}
+    running_rows = conn.execute(
+        """
+        SELECT source_paths_json
+        FROM live_ingest_attempt
+        WHERE status = 'running'
+        """
+    ).fetchall()
+    path_counts: dict[str, int] = {}
+    for row in running_rows:
+        for path in _json_list(row[0]):
+            path_counts[path] = path_counts.get(path, 0) + 1
+    overlapping = [
+        {"source_path": path, "running_attempt_count": count}
+        for path, count in sorted(path_counts.items())
+        if count > 1
+    ]
+    return {
+        "total": _scalar_int(conn, "SELECT COUNT(*) FROM live_ingest_attempt"),
+        "running": _scalar_int(conn, "SELECT COUNT(*) FROM live_ingest_attempt WHERE status = 'running'"),
+        "failed": _scalar_int(conn, "SELECT COUNT(*) FROM live_ingest_attempt WHERE status = 'failed'"),
+        "stale_cursor_writes": _scalar_int(
+            conn,
+            "SELECT COALESCE(SUM(stale_cursor_write_count), 0) FROM live_ingest_attempt"
+            if "stale_cursor_write_count" in _columns(conn, "live_ingest_attempt")
+            else "SELECT 0",
+        ),
+        "overlapping_source_paths": overlapping[:20],
+    }
+
+
+def _source_path_churn(conn: sqlite3.Connection, *, attempts: list[dict[str, Any]], limit: int) -> list[dict[str, Any]]:
+    if not _table_exists(conn, "raw_conversations"):
+        return []
+    source_paths = sorted({path for attempt in attempts for path in attempt.get("source_paths", []) if path})
+    if not source_paths:
+        return []
+    has_conversations = _table_exists(conn, "conversations")
+    join = "LEFT JOIN conversations AS c ON c.raw_id = r.raw_id" if has_conversations else ""
+    conversation_count = "COUNT(DISTINCT c.conversation_id)" if has_conversations else "0"
+    placeholders = ",".join("?" for _ in source_paths)
+    rows = conn.execute(
+        f"""
+        SELECT
+            r.source_path,
+            COUNT(*) AS raw_count,
+            SUM(CASE WHEN COALESCE(r.source_index, 0) >= 0 THEN 1 ELSE 0 END) AS full_raw_count,
+            SUM(CASE WHEN r.source_index = -1 THEN 1 ELSE 0 END) AS append_raw_count,
+            {conversation_count} AS conversation_count,
+            SUM(COALESCE(r.blob_size, 0)) AS total_blob_bytes,
+            MAX(r.acquired_at) AS latest_acquired_at
+        FROM raw_conversations AS r
+        {join}
+        WHERE r.source_path IN ({placeholders})
+        GROUP BY r.source_path
+        HAVING raw_count > 1
+        ORDER BY raw_count DESC, total_blob_bytes DESC, r.source_path
+        LIMIT ?
+        """,
+        (*source_paths, limit),
+    ).fetchall()
+    items: list[dict[str, Any]] = []
+    for row in rows:
+        raw_count = int(row[1] or 0)
+        conversation_count_value = int(row[4] or 0)
+        items.append(
+            {
+                "source_path": row[0],
+                "raw_count": raw_count,
+                "full_raw_count": int(row[2] or 0),
+                "append_raw_count": int(row[3] or 0),
+                "conversation_count": conversation_count_value,
+                "orphan_raw_count": max(0, raw_count - conversation_count_value),
+                "total_blob_bytes": int(row[5] or 0),
+                "latest_acquired_at": row[6],
+            }
+        )
+    return items
 
 
 def _convergence_debt(conn: sqlite3.Connection) -> dict[str, Any]:
@@ -175,21 +273,13 @@ def probe(db: Path, *, limit: int = 5) -> dict[str, Any]:
         return {"ok": False, "db_path": str(db), "error": "database does not exist"}
     conn = open_readonly_connection(db)
     try:
+        recent_attempts = _recent_attempts(conn, limit=limit)
         return {
             "ok": True,
             "db_path": str(db),
-            "attempt_counts": {
-                "total": _scalar_int(conn, "SELECT COUNT(*) FROM live_ingest_attempt")
-                if _table_exists(conn, "live_ingest_attempt")
-                else 0,
-                "running": _scalar_int(conn, "SELECT COUNT(*) FROM live_ingest_attempt WHERE status = 'running'")
-                if _table_exists(conn, "live_ingest_attempt")
-                else 0,
-                "failed": _scalar_int(conn, "SELECT COUNT(*) FROM live_ingest_attempt WHERE status = 'failed'")
-                if _table_exists(conn, "live_ingest_attempt")
-                else 0,
-            },
-            "recent_attempts": _recent_attempts(conn, limit=limit),
+            "attempt_counts": _attempt_counts(conn),
+            "recent_attempts": recent_attempts,
+            "source_path_churn": _source_path_churn(conn, attempts=recent_attempts, limit=limit),
             "convergence_debt": _convergence_debt(conn),
             "query_plans": _query_plans(conn),
         }
@@ -218,6 +308,9 @@ def main(argv: list[str] | None = None) -> int:
         return 1
     counts = payload["attempt_counts"]
     print(f"  attempts: {counts['total']} total, {counts['running']} running, {counts['failed']} failed")
+    print(f"  stale cursor writes: {counts.get('stale_cursor_writes', 0)}")
+    overlaps = counts.get("overlapping_source_paths") or []
+    print(f"  overlapping source paths: {len(overlaps)}")
     recent = payload["recent_attempts"]
     if recent:
         latest = recent[0]
@@ -229,6 +322,14 @@ def main(argv: list[str] | None = None) -> int:
         )
     debt = payload["convergence_debt"]
     print(f"  convergence debt: {debt['failed_count']} unresolved")
+    churn = payload.get("source_path_churn") or []
+    if churn:
+        worst = churn[0]
+        print(
+            "  hottest source path: "
+            f"{worst['raw_count']} raw rows, {worst['full_raw_count']} full, "
+            f"{worst['append_raw_count']} append, {worst['orphan_raw_count']} orphan"
+        )
     plan_hazards = [
         f"{name}: {hazard}" for name, info in payload["query_plans"].items() for hazard in info.get("hazards", [])
     ]
@@ -236,6 +337,18 @@ def main(argv: list[str] | None = None) -> int:
     for hazard in plan_hazards:
         print(f"    {hazard}")
     return 0
+
+
+def _json_list(value: object) -> list[str]:
+    if not isinstance(value, str) or not value:
+        return []
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError:
+        return []
+    if not isinstance(parsed, list):
+        return []
+    return [str(item) for item in parsed if isinstance(item, str)]
 
 
 if __name__ == "__main__":

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -100,7 +100,6 @@ These are the commands worth remembering during normal repo work:
 | `devtools affected-obligations` | Route changed paths or refs to affected verification-lab proof obligations and focused checks. |
 | `devtools artifact-graph` | Render the runtime artifact, operation, and scenario-coverage map. |
 | `devtools coverage-gate` | Run pytest with the repository coverage floor from pyproject.toml. |
-| `devtools daemon-workload-probe` | Inspect daemon ingest workload, convergence debt, and hot query plans. |
 | `devtools lab-corpus` | Generate verification-lab synthetic corpus fixtures and demo archives. |
 | `devtools lab-scenario` | Run verification-lab showcase scenario sets and baseline checks. |
 | `devtools obligation-diff` | Diff proof obligations between two git refs to surface affected assurance domains. |

--- a/docs/test-quality-workflows.md
+++ b/docs/test-quality-workflows.md
@@ -14,10 +14,10 @@ Current registry snapshot:
 - mutation campaigns: `19`
 - benchmark campaigns: `3`
 - synthetic benchmark campaigns: `7`
-- scenario projections: `244`
+- scenario projections: `214`
 - inferred corpus scenarios: `8`
   - benchmark-campaign: `3`
-  - exercise: `139`
+  - exercise: `109`
   - inferred-corpus-scenario: `8`
   - mutation-campaign: `19`
   - synthetic-benchmark: `7`
@@ -25,16 +25,16 @@ Current registry snapshot:
 
 ## Runtime Coverage
 
-- covered runtime paths: `25`
-- covered runtime artifacts: `50`
-- covered runtime operations: `29`
+- covered runtime paths: `22`
+- covered runtime artifacts: `48`
+- covered runtime operations: `26`
 - covered maintenance targets: `3`
-- covered declared operation targets: `41`
-- uncovered runtime paths: —
-- uncovered runtime artifacts: —
-- uncovered runtime operations: `mutate-add-tag`, `mutate-bulk-tag-conversations`, `mutate-delete-conversation`, `mutate-delete-metadata`, `mutate-remove-tag`, `mutate-set-metadata`
+- covered declared operation targets: `38`
+- uncovered runtime paths: `action-event-repair-loop`, `week-summary-query-loop`, `work-thread-query-loop`
+- uncovered runtime artifacts: `week_session_summary_results`, `work_thread_results`
+- uncovered runtime operations: `mutate-add-tag`, `mutate-bulk-tag-conversations`, `mutate-delete-conversation`, `mutate-delete-metadata`, `mutate-remove-tag`, `mutate-set-metadata`, `project-action-event-readiness`, `query-week-session-summaries`, `query-work-threads`
 - uncovered maintenance targets: `empty_conversations`, `message_type_backfill`, `orphaned_attachments`, `orphaned_blobs`, `orphaned_content_blocks`, `orphaned_messages`, `wal_checkpoint`
-- uncovered declared operation targets: `mutate-add-tag`, `mutate-bulk-tag-conversations`, `mutate-delete-conversation`, `mutate-delete-metadata`, `mutate-remove-tag`, `mutate-set-metadata`
+- uncovered declared operation targets: `mutate-add-tag`, `mutate-bulk-tag-conversations`, `mutate-delete-conversation`, `mutate-delete-metadata`, `mutate-remove-tag`, `mutate-set-metadata`, `project-action-event-readiness`, `query-week-session-summaries`, `query-work-threads`
 
 Inspect the full authored map with:
 
@@ -335,20 +335,6 @@ These are the authored scenario-bearing projections currently feeding runtime co
 | `exercise` | `help-export` | `conversation-query-loop` | `message_fts`<br>`conversation_query_results` | `cli.help`<br>`query-conversations` | — | `generated`<br>`help`<br>`structural` | export help |
 | `exercise` | `help-ingest` | `conversation-query-loop` | `message_fts`<br>`conversation_query_results` | `cli.help`<br>`query-conversations` | — | `generated`<br>`help`<br>`structural` | ingest help |
 | `exercise` | `help-insights` | — | — | `cli.help` | — | `generated`<br>`help`<br>`structural` | insights help |
-| `exercise` | `help-insights-analytics` | `provider-analytics-query-loop` | `session_insight_rows`<br>`provider_analytics_results` | `cli.help`<br>`query-provider-analytics` | — | `generated`<br>`help`<br>`structural` | insights analytics help |
-| `exercise` | `help-insights-cost-rollups` | — | — | `cli.help` | — | `generated`<br>`help`<br>`structural` | insights cost-rollups help |
-| `exercise` | `help-insights-costs` | — | — | `cli.help` | — | `generated`<br>`help`<br>`structural` | insights costs help |
-| `exercise` | `help-insights-day-summaries` | `day-summary-query-loop` | `day_session_summary_rows`<br>`day_session_summary_results` | `cli.help`<br>`query-day-session-summaries` | — | `generated`<br>`help`<br>`structural` | insights day-summaries help |
-| `exercise` | `help-insights-debt` | `archive-debt-query-loop` | `action_event_readiness`<br>`session_insight_readiness`<br>`archive_readiness`<br>`archive_debt_results` | `cli.help`<br>`query-archive-debt` | — | `generated`<br>`help`<br>`structural` | insights debt help |
-| `exercise` | `help-insights-enrichments` | `session-enrichment-query-loop` | `session_profile_rows`<br>`session_enrichment_results` | `cli.help`<br>`query-session-enrichments` | — | `generated`<br>`help`<br>`structural` | insights enrichments help |
-| `exercise` | `help-insights-export` | — | — | `cli.help` | — | `generated`<br>`help`<br>`structural` | insights export help |
-| `exercise` | `help-insights-phases` | `session-phase-query-loop` | `session_phase_rows`<br>`session_phase_results` | `cli.help`<br>`query-session-phases` | — | `generated`<br>`help`<br>`structural` | insights phases help |
-| `exercise` | `help-insights-profiles` | `session-profile-query-loop` | `session_profile_rows`<br>`session_profile_results` | `cli.help`<br>`query-session-profiles` | — | `generated`<br>`help`<br>`structural` | insights profiles help |
-| `exercise` | `help-insights-status` | `session-insight-status-query-loop` | `session_insight_readiness`<br>`session_insight_status_results` | `cli.help`<br>`query-session-insight-status` | — | `generated`<br>`help`<br>`structural` | insights status help |
-| `exercise` | `help-insights-tags` | `session-tag-rollup-query-loop` | `session_tag_rollup_rows`<br>`session_tag_rollup_results` | `cli.help`<br>`query-session-tag-rollups` | — | `generated`<br>`help`<br>`structural` | insights tags help |
-| `exercise` | `help-insights-threads` | `work-thread-query-loop` | `work_thread_rows`<br>`work_thread_fts`<br>`work_thread_results` | `cli.help`<br>`query-work-threads` | — | `generated`<br>`help`<br>`structural` | insights threads help |
-| `exercise` | `help-insights-week-summaries` | `week-summary-query-loop` | `day_session_summary_rows`<br>`week_session_summary_results` | `cli.help`<br>`query-week-session-summaries` | — | `generated`<br>`help`<br>`structural` | insights week-summaries help |
-| `exercise` | `help-insights-work-events` | `session-work-event-query-loop` | `session_work_event_rows`<br>`session_work_event_fts`<br>`session_work_event_results` | `cli.help`<br>`query-session-work-events` | — | `generated`<br>`help`<br>`structural` | insights work-events help |
 | `exercise` | `help-list` | `conversation-query-loop` | `message_fts`<br>`conversation_query_results` | `cli.help`<br>`query-conversations` | — | `generated`<br>`help`<br>`structural` | list help |
 | `exercise` | `help-main` | — | — | — | — | — | Main help screen |
 | `exercise` | `help-maintenance` | `conversation-query-loop` | `message_fts`<br>`conversation_query_results` | `cli.help`<br>`query-conversations` | — | `generated`<br>`help`<br>`structural` | maintenance help |
@@ -361,27 +347,11 @@ These are the authored scenario-bearing projections currently feeding runtime co
 | `exercise` | `help-reset` | `conversation-query-loop` | `message_fts`<br>`conversation_query_results` | `cli.help`<br>`query-conversations` | — | `generated`<br>`help`<br>`structural` | reset help |
 | `exercise` | `help-resume` | `conversation-query-loop` | `message_fts`<br>`conversation_query_results` | `cli.help`<br>`query-conversations` | — | `generated`<br>`help`<br>`structural` | resume help |
 | `exercise` | `help-schema` | — | — | `cli.help` | — | `generated`<br>`help`<br>`structural` | schema help |
-| `exercise` | `help-schema-compare` | — | — | `cli.help` | — | `generated`<br>`help`<br>`structural` | schema compare help |
-| `exercise` | `help-schema-explain` | `schema-explain-query-loop` | `schema_packages`<br>`schema_explanation_results` | `cli.help`<br>`query-schema-explanations` | — | `generated`<br>`help`<br>`structural` | schema explain help |
-| `exercise` | `help-schema-list` | `schema-list-query-loop` | `schema_packages`<br>`schema_cluster_manifests`<br>`inferred_corpus_specs`<br>`inferred_corpus_scenarios`<br>`schema_list_results` | `cli.help`<br>`query-schema-catalog` | — | `generated`<br>`help`<br>`structural` | schema list help |
 | `exercise` | `help-select` | `conversation-query-loop` | `message_fts`<br>`conversation_query_results` | `cli.help`<br>`query-conversations` | — | `generated`<br>`help`<br>`structural` | select help |
 | `exercise` | `help-show` | `conversation-query-loop` | `message_fts`<br>`conversation_query_results` | `cli.help`<br>`query-conversations` | — | `generated`<br>`help`<br>`structural` | show help |
 | `exercise` | `help-stats` | `conversation-query-loop` | `message_fts`<br>`conversation_query_results` | `cli.help`<br>`query-conversations` | — | `generated`<br>`help`<br>`structural` | stats help |
 | `exercise` | `help-status` | `conversation-query-loop` | `message_fts`<br>`conversation_query_results` | `cli.help`<br>`query-conversations` | — | `generated`<br>`help`<br>`structural` | status help |
 | `exercise` | `help-tags` | — | — | `cli.help` | — | `generated`<br>`help`<br>`structural` | tags help |
-| `exercise` | `json-doctor` | `message-fts-readiness-loop`<br>`retrieval-band-readiness-loop` | `message_fts`<br>`action_event_readiness`<br>`session_insight_readiness`<br>`retrieval_band_readiness`<br>`archive_readiness` | `cli.json-contract`<br>`project-archive-readiness` | — | `generated`<br>`json-contract`<br>`maintenance`<br>`readiness` | doctor JSON contract |
-| `exercise` | `json-doctor-action-event-preview` | `action-event-repair-loop` | `action_event_rows`<br>`action_event_fts`<br>`action_event_readiness` | `cli.json-contract`<br>`project-action-event-readiness` | — | `generated`<br>`json-contract`<br>`maintenance`<br>`action-events` | doctor JSON contract |
-| `exercise` | `json-doctor-session-insights-preview` | `session-insight-repair-loop` | `session_insight_rows`<br>`session_insight_fts`<br>`session_insight_readiness` | `cli.json-contract`<br>`project-session-insight-readiness` | — | `generated`<br>`json-contract`<br>`maintenance`<br>`session-insights` | doctor JSON contract |
-| `exercise` | `json-insights-analytics` | `provider-analytics-query-loop` | `session_insight_rows`<br>`provider_analytics_results` | `cli.json-contract`<br>`query-provider-analytics` | — | `generated`<br>`json-contract`<br>`insights`<br>`analytics` | insights analytics JSON contract |
-| `exercise` | `json-insights-day-summaries` | `day-summary-query-loop` | `day_session_summary_rows`<br>`day_session_summary_results` | `cli.json-contract`<br>`query-day-session-summaries` | — | `generated`<br>`json-contract`<br>`insights`<br>`day-summaries` | insights day-summaries JSON contract |
-| `exercise` | `json-insights-phases` | `session-phase-query-loop` | `session_phase_rows`<br>`session_phase_results` | `cli.json-contract`<br>`query-session-phases` | — | `generated`<br>`json-contract`<br>`insights`<br>`phases` | insights phases JSON contract |
-| `exercise` | `json-insights-profiles` | `session-profile-query-loop` | `session_profile_rows`<br>`session_profile_results` | `cli.json-contract`<br>`query-session-profiles` | — | `generated`<br>`json-contract`<br>`insights`<br>`session-profiles` | insights profiles JSON contract |
-| `exercise` | `json-insights-tags` | `session-tag-rollup-query-loop` | `session_tag_rollup_rows`<br>`session_tag_rollup_results` | `cli.json-contract`<br>`query-session-tag-rollups` | — | `generated`<br>`json-contract`<br>`insights`<br>`tags` | insights tags JSON contract |
-| `exercise` | `json-insights-threads` | `work-thread-query-loop` | `work_thread_rows`<br>`work_thread_fts`<br>`work_thread_results` | `cli.json-contract`<br>`query-work-threads` | — | `generated`<br>`json-contract`<br>`insights`<br>`threads` | insights threads JSON contract |
-| `exercise` | `json-insights-week-summaries` | `week-summary-query-loop` | `day_session_summary_rows`<br>`week_session_summary_results` | `cli.json-contract`<br>`query-week-session-summaries` | — | `generated`<br>`json-contract`<br>`insights`<br>`week-summaries` | insights week-summaries JSON contract |
-| `exercise` | `json-insights-work-events` | `session-work-event-query-loop` | `session_work_event_rows`<br>`session_work_event_fts`<br>`session_work_event_results` | `cli.json-contract`<br>`query-session-work-events` | — | `generated`<br>`json-contract`<br>`insights`<br>`work-events` | insights work-events JSON contract |
-| `exercise` | `json-schema-list` | `schema-list-query-loop` | `schema_packages`<br>`schema_cluster_manifests`<br>`inferred_corpus_specs`<br>`inferred_corpus_scenarios`<br>`schema_list_results` | `cli.json-contract`<br>`query-schema-catalog` | — | `generated`<br>`json-contract` | schema list JSON contract |
-| `exercise` | `json-tags` | — | — | `cli.json-contract` | — | `generated`<br>`json-contract` | tags JSON contract |
 | `exercise` | `query-count` | — | — | — | — | — | Count conversations |
 | `exercise` | `query-dialogue-only` | — | — | — | — | — | Latest with dialogue only |
 | `exercise` | `query-filter-provider` | — | — | — | — | — | Filter by provider |

--- a/docs/verification-catalog.md
+++ b/docs/verification-catalog.md
@@ -8,10 +8,10 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 
 ## Snapshot
 
-- subjects: `549`
+- subjects: `530`
 - claims: `41`
 - runner bindings: `41`
-- proof obligations: `605`
+- proof obligations: `552`
 
 ## Quality Checks
 
@@ -40,8 +40,8 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | `assurance.coverage_gap` | 22 |
 | `assurance.coverage_item` | 104 |
 | `assurance.coverage_manifest` | 9 |
-| `cli.command` | 52 |
-| `cli.json_command` | 5 |
+| `cli.command` | 35 |
+| `cli.json_command` | 3 |
 | `diagnostic.observable` | 1 |
 | `error.surface` | 2 |
 | `generated.scenario_family` | 9 |
@@ -78,20 +78,6 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | `polylogue export` | `polylogue/cli/click_app.py` `polylogue export` |
 | `polylogue ingest` | `polylogue/cli/click_app.py` `polylogue ingest` |
 | `polylogue insights` | `polylogue/cli/click_app.py` `polylogue insights` |
-| `polylogue insights analytics` | `polylogue/cli/commands/insights.py:100` `polylogue.cli.commands.insights._make_callback.<locals>.callback` |
-| `polylogue insights cost-rollups` | `polylogue/cli/commands/insights.py:100` `polylogue.cli.commands.insights._make_callback.<locals>.callback` |
-| `polylogue insights costs` | `polylogue/cli/commands/insights.py:100` `polylogue.cli.commands.insights._make_callback.<locals>.callback` |
-| `polylogue insights day-summaries` | `polylogue/cli/commands/insights.py:100` `polylogue.cli.commands.insights._make_callback.<locals>.callback` |
-| `polylogue insights debt` | `polylogue/cli/commands/insights.py:100` `polylogue.cli.commands.insights._make_callback.<locals>.callback` |
-| `polylogue insights enrichments` | `polylogue/cli/commands/insights.py:100` `polylogue.cli.commands.insights._make_callback.<locals>.callback` |
-| `polylogue insights export` | `polylogue/cli/commands/insights.py:234` `polylogue.cli.commands.insights.insights_export_command` |
-| `polylogue insights phases` | `polylogue/cli/commands/insights.py:100` `polylogue.cli.commands.insights._make_callback.<locals>.callback` |
-| `polylogue insights profiles` | `polylogue/cli/commands/insights.py:100` `polylogue.cli.commands.insights._make_callback.<locals>.callback` |
-| `polylogue insights status` | `polylogue/cli/commands/insights.py:189` `polylogue.cli.commands.insights.insights_status_command` |
-| `polylogue insights tags` | `polylogue/cli/commands/insights.py:100` `polylogue.cli.commands.insights._make_callback.<locals>.callback` |
-| `polylogue insights threads` | `polylogue/cli/commands/insights.py:100` `polylogue.cli.commands.insights._make_callback.<locals>.callback` |
-| `polylogue insights week-summaries` | `polylogue/cli/commands/insights.py:100` `polylogue.cli.commands.insights._make_callback.<locals>.callback` |
-| `polylogue insights work-events` | `polylogue/cli/commands/insights.py:100` `polylogue.cli.commands.insights._make_callback.<locals>.callback` |
 | `polylogue list` | `polylogue/cli/click_app.py` `polylogue list` |
 | `polylogue maintenance` | `polylogue/cli/click_app.py` `polylogue maintenance` |
 | `polylogue maintenance plan` | `polylogue/cli/commands/maintenance.py:22` `polylogue.cli.commands.maintenance.plan_command` |
@@ -103,9 +89,6 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | `polylogue reset` | `polylogue/cli/click_app.py` `polylogue reset` |
 | `polylogue resume` | `polylogue/cli/click_app.py` `polylogue resume` |
 | `polylogue schema` | `polylogue/cli/click_app.py` `polylogue schema` |
-| `polylogue schema compare` | `polylogue/cli/commands/schema.py:56` `polylogue.cli.commands.schema.schema_compare` |
-| `polylogue schema explain` | `polylogue/cli/commands/schema.py:94` `polylogue.cli.commands.schema.schema_explain` |
-| `polylogue schema list` | `polylogue/cli/commands/schema.py:45` `polylogue.cli.commands.schema.schema_list` |
 | `polylogue select` | `polylogue/cli/click_app.py` `polylogue select` |
 | `polylogue show` | `polylogue/cli/click_app.py` `polylogue show` |
 | `polylogue stats` | `polylogue/cli/click_app.py` `polylogue stats` |
@@ -286,10 +269,10 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | `assurance.coverage.gap_has_closure_path` | 22 |
 | `assurance.coverage.item_declared` | 104 |
 | `assurance.coverage.manifest_structured` | 9 |
-| `cli.command.help` | 52 |
-| `cli.command.json_envelope` | 5 |
-| `cli.command.no_traceback` | 52 |
-| `cli.command.plain_mode` | 52 |
+| `cli.command.help` | 35 |
+| `cli.command.json_envelope` | 3 |
+| `cli.command.no_traceback` | 35 |
+| `cli.command.plain_mode` | 35 |
 | `diagnostic.observable_trace_mapping` | 1 |
 | `error.machine_user_context` | 2 |
 | `generated.scenario.family_registered` | 9 |

--- a/polylogue/daemon/live_ingest_attempt_models.py
+++ b/polylogue/daemon/live_ingest_attempt_models.py
@@ -40,6 +40,7 @@ class LiveIngestAttemptState(BaseModel):
     worker_in_flight_count: int | None = None
     worker_completed_count: int | None = None
     worker_total_count: int | None = None
+    stale_cursor_write_count: int = 0
     updated_age_s: float | None = None
     stale: bool = False
     completed_at: str | None = None

--- a/polylogue/daemon/status.py
+++ b/polylogue/daemon/status.py
@@ -568,6 +568,7 @@ def _live_ingest_attempt_summary_info() -> LiveIngestAttemptSummary:
             worker_in_flight_expr = "worker_in_flight_count" if "worker_in_flight_count" in columns else "NULL"
             worker_completed_expr = "worker_completed_count" if "worker_completed_count" in columns else "NULL"
             worker_total_expr = "worker_total_count" if "worker_total_count" in columns else "NULL"
+            stale_cursor_write_expr = "stale_cursor_write_count" if "stale_cursor_write_count" in columns else "0"
             rows = conn.execute(
                 f"""
                 SELECT
@@ -598,7 +599,8 @@ def _live_ingest_attempt_summary_info() -> LiveIngestAttemptSummary:
                     {cgroup_swap_expr},
                     {worker_in_flight_expr},
                     {worker_completed_expr},
-                    {worker_total_expr}
+                    {worker_total_expr},
+                    {stale_cursor_write_expr}
                 FROM live_ingest_attempt
                 ORDER BY updated_at DESC, started_at DESC
                 LIMIT 5
@@ -684,6 +686,7 @@ def _live_ingest_attempt_state_from_row(
         worker_in_flight_count=_row_int(row[25]) if len(row) > 25 else None,
         worker_completed_count=_row_int(row[26]) if len(row) > 26 else None,
         worker_total_count=_row_int(row[27]) if len(row) > 27 else None,
+        stale_cursor_write_count=_row_int(row[28]) if len(row) > 28 else 0,
         updated_age_s=updated_age_s,
         stale=stale,
     )

--- a/polylogue/sources/live/batch.py
+++ b/polylogue/sources/live/batch.py
@@ -5,13 +5,12 @@ from __future__ import annotations
 import asyncio
 import time
 from collections.abc import Callable, Iterable
-from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from hashlib import sha256
 from json import dumps as json_dumps
 from json import loads as json_loads
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import TYPE_CHECKING, Any
 
 from polylogue.core.degraded import is_degraded
 from polylogue.core.metrics import (
@@ -55,13 +54,16 @@ from polylogue.sources.live.batch_support import (
     _full_ingest_worker_count,
     _full_parse_progress_groups,
     _FullIngestHeartbeat,
+    _FullIngestResult,
     _jsonl_provider_and_conversation_artifact,
     _parse_path_as_conversation_artifact,
     _parse_payload_as_conversation_artifact,
     _path_size,
     _throttled_phase_heartbeat,
+    cursor_state_after_full_ingest,
     fingerprint_file,
     last_complete_newline_from_tail,
+    tail_hash_from_path,
 )
 from polylogue.sources.live.convergence_debt import (
     ConvergenceDebt,
@@ -85,30 +87,13 @@ logger = get_logger(__name__)
 LiveBatchEventEmitter = Callable[[str, dict[str, object]], None]
 
 
-class LiveSourceRoot(Protocol):
-    @property
-    def name(self) -> str: ...
-
-    @property
-    def root(self) -> Path: ...
-
-
-@dataclass(frozen=True, slots=True)
-class _FullIngestResult:
-    succeeded: list[Path]
-    failed: list[Path]
-    source_payload_read_bytes: int
-    raw_fingerprints: dict[Path, str] = field(default_factory=dict)
-    worker_count: int = 0
-
-
 class LiveBatchProcessor:
     """Run the daemon live ingest batch path without filesystem watching."""
 
     def __init__(
         self,
         polylogue: Polylogue,
-        sources: Iterable[LiveSourceRoot],
+        sources: Iterable[Any],
         *,
         cursor: CursorStore,
         parser_fingerprint: str | Callable[[], str],
@@ -123,6 +108,7 @@ class LiveBatchProcessor:
         self._converger = converger
         self._stop_requested = stop_requested or (lambda: False)
         self._event_emitter = event_emitter
+        self._last_cursor_write_stale = False
 
     async def ingest_files(
         self,
@@ -164,6 +150,7 @@ class LiveBatchProcessor:
         )
         source_payload_read_bytes = 0
         cursor_fingerprint_read_bytes = 0
+        stale_cursor_write_count = 0
         parse_time_s = 0.0
         convergence_time_s = 0.0
         stage_timings: dict[str, float] = {}
@@ -235,7 +222,8 @@ class LiveBatchProcessor:
             debt_by_source_path = debt_by_path(convergence_debt)
             for plan in append_result.succeeded:
                 succeeded_paths.add(plan.path)
-                self._record_append_cursor(plan)
+                if not self._record_append_cursor(plan):
+                    stale_cursor_write_count += 1
                 self._record_convergence_outcome(plan.path, debt_by_source_path.get(plan.path, ()))
             for plan in append_result.failed:
                 failed_paths.append(str(plan.path))
@@ -372,7 +360,10 @@ class LiveBatchProcessor:
                     cursor_fingerprint_read_bytes += self._record_full_cursor(
                         path,
                         raw_fingerprint=full_result.raw_fingerprints.get(path),
+                        raw_byte_size=full_result.raw_byte_sizes.get(path),
                     )
+                    if self._last_cursor_write_stale:
+                        stale_cursor_write_count += 1
                     self._record_convergence_outcome(path, debt_by_source_path.get(path, ()))
                 for path in full_result.failed:
                     failed_paths.append(str(path))
@@ -394,6 +385,7 @@ class LiveBatchProcessor:
             cursor_fingerprint_read_bytes=cursor_fingerprint_read_bytes,
             parse_time_s=parse_time_s,
             convergence_time_s=convergence_time_s,
+            stale_cursor_write_count=stale_cursor_write_count,
         )
 
         db_bytes_after = _path_size(self._cursor._db_path) + _path_size(self._cursor._db_path.with_suffix(".db-wal"))
@@ -423,6 +415,7 @@ class LiveBatchProcessor:
             cgroup_memory_current_mb=read_cgroup_memory_current_mb(),
             cgroup_memory_peak_mb=read_cgroup_memory_peak_mb(),
             cgroup_memory_swap_current_mb=read_cgroup_memory_swap_current_mb(),
+            stale_cursor_write_count=stale_cursor_write_count,
             stage_timings_s={name: round(elapsed, 6) for name, elapsed in stage_timings.items()},
             failed_paths=failed_paths,
         )
@@ -445,6 +438,7 @@ class LiveBatchProcessor:
             convergence_time_s=convergence_time_s,
             total_time_s=metrics.total_time_s,
             stage_timings_s=metrics.stage_timings_s,
+            stale_cursor_write_count=stale_cursor_write_count,
         )
         self._cursor.finish_ingest_attempt(
             attempt_id,
@@ -487,6 +481,7 @@ class LiveBatchProcessor:
             cgroup_memory_current_mb=read_cgroup_memory_current_mb(),
             cgroup_memory_peak_mb=read_cgroup_memory_peak_mb(),
             cgroup_memory_swap_current_mb=read_cgroup_memory_swap_current_mb(),
+            stale_cursor_write_count=0,
             stage_timings_s={},
             failed_paths=[],
         )
@@ -534,6 +529,7 @@ class LiveBatchProcessor:
         try:
             stat = path.stat()
             fp, last_nl = fingerprint_file(path)
+            tail_hash, _tail_bytes = tail_hash_from_path(path, stat.st_size)
         except FileNotFoundError:
             self._cursor.mark_failed(path)
             return 0
@@ -545,6 +541,7 @@ class LiveBatchProcessor:
             last_complete_newline=last_nl,
             parser_fingerprint=self._current_parser_fingerprint(),
             content_fingerprint=fp,
+            tail_hash=tail_hash,
             source_name=self._source_name_for(path),
             st_dev=stat.st_dev,
             st_ino=stat.st_ino,
@@ -556,28 +553,40 @@ class LiveBatchProcessor:
         self._cursor.mark_failed(path)
         return stat.st_size
 
-    def _record_full_cursor(self, path: Path, *, raw_fingerprint: str | None = None) -> int:
+    def _record_full_cursor(
+        self,
+        path: Path,
+        *,
+        raw_fingerprint: str | None = None,
+        raw_byte_size: int | None = None,
+    ) -> int:
+        self._last_cursor_write_stale = False
         try:
             stat = path.stat()
         except FileNotFoundError:
             return 0
-        fp, last_nl, bytes_read = self._cursor_state_after_full_ingest(
+        byte_size = stat.st_size if raw_byte_size is None else raw_byte_size
+        raw_fingerprint = raw_fingerprint or self._latest_raw_fingerprint(path)
+        fp, last_nl, tail_hash, bytes_read = cursor_state_after_full_ingest(
             path,
-            stat.st_size,
+            byte_size,
             raw_fingerprint=raw_fingerprint,
         )
-        self._cursor.set(
+        updated = self._cursor.set(
             path,
-            stat.st_size,
+            byte_size,
             byte_offset=last_nl,
             last_complete_newline=last_nl,
             parser_fingerprint=self._current_parser_fingerprint(),
             content_fingerprint=fp,
+            tail_hash=tail_hash,
             source_name=self._source_name_for(path),
             st_dev=stat.st_dev,
             st_ino=stat.st_ino,
             mtime_ns=stat.st_mtime_ns,
+            allow_backward=stat.st_size <= byte_size,
         )
+        self._last_cursor_write_stale = not updated
         self._cursor.reset_failures(path)
         return bytes_read
 
@@ -661,20 +670,6 @@ class LiveBatchProcessor:
                 [ConvergenceDebt(path=path, stage="convergence", error=str(exc)) for path in unique_paths],
             )
 
-    def _cursor_state_after_full_ingest(
-        self,
-        path: Path,
-        byte_size: int,
-        *,
-        raw_fingerprint: str | None = None,
-    ) -> tuple[str, int, int]:
-        raw_fingerprint = raw_fingerprint or self._latest_raw_fingerprint(path)
-        if raw_fingerprint is None:
-            fp, last_nl = fingerprint_file(path)
-            return fp, last_nl, byte_size
-        last_nl, bytes_read = last_complete_newline_from_tail(path, byte_size)
-        return raw_fingerprint, last_nl, bytes_read
-
     def _latest_raw_fingerprint(self, path: Path) -> str | None:
         try:
             with self._cursor._connect() as conn:
@@ -706,7 +701,7 @@ class LiveBatchProcessor:
         for source in self._sources:
             try:
                 if resolved.is_relative_to(source.root.resolve()):
-                    return source.name
+                    return str(source.name)
             except OSError:
                 continue
         return path.parent.name
@@ -742,6 +737,7 @@ class LiveBatchProcessor:
         blob_store = BlobStore(blob_root)
         raw_records: list[RawConversationRecord] = []
         raw_by_id: dict[str, Path] = {}
+        raw_byte_sizes: dict[Path, int] = {}
         failed: list[Path] = []
         ingested: list[Path] = []
         source_payload_read_bytes = 0
@@ -859,6 +855,7 @@ class LiveBatchProcessor:
                         source_payload_read_bytes=source_payload_read_bytes,
                     )
             ingested.append(path)
+            raw_byte_sizes[path] = stat.st_size
             raw_records.append(
                 RawConversationRecord(
                     raw_id=raw_id,
@@ -920,6 +917,7 @@ class LiveBatchProcessor:
             failed=failed,
             source_payload_read_bytes=source_payload_read_bytes,
             raw_fingerprints={path: raw_id for raw_id, path in raw_by_id.items()},
+            raw_byte_sizes=raw_byte_sizes,
             worker_count=int(getattr(summary, "worker_count", 0)) if raw_records else 0,
         )
 
@@ -1131,23 +1129,26 @@ class LiveBatchProcessor:
             )
             conn.commit()
 
-    def _record_append_cursor(self, plan: _AppendPlan) -> None:
+    def _record_append_cursor(self, plan: _AppendPlan) -> bool:
         content_fingerprint = sha256(f"{plan.cursor_fingerprint or ''}\0{plan.payload_hash}".encode()).hexdigest()
-        self._cursor.set(
+        tail_hash, _tail_bytes = tail_hash_from_path(plan.path, plan.stat_size)
+        updated = self._cursor.set(
             plan.path,
             plan.stat_size,
             byte_offset=plan.last_complete_newline,
             last_complete_newline=plan.last_complete_newline,
             parser_fingerprint=self._current_parser_fingerprint(),
             content_fingerprint=content_fingerprint,
+            tail_hash=tail_hash,
             source_name=plan.source_name,
             st_dev=plan.st_dev,
             st_ino=plan.st_ino,
             mtime_ns=plan.mtime_ns,
         )
         self._cursor.reset_failures(plan.path)
+        return updated
 
 
 # fmt: off
-__all__ = ["LiveBatchMetrics", "LiveBatchProcessor", "_LARGE_FULL_PARSE_PROGRESS_BYTES", "_SMALL_FULL_PARSE_PROGRESS_MAX_BYTES", "_SMALL_FULL_PARSE_PROGRESS_MAX_FILES", "_STREAMING_FULL_INGEST_BYTES", "_full_ingest_worker_count", "_full_parse_progress_groups", "fingerprint_file", "last_complete_newline_from_tail"]
+__all__ = ["LiveBatchMetrics", "LiveBatchProcessor", "_FullIngestResult", "_LARGE_FULL_PARSE_PROGRESS_BYTES", "_SMALL_FULL_PARSE_PROGRESS_MAX_BYTES", "_SMALL_FULL_PARSE_PROGRESS_MAX_FILES", "_STREAMING_FULL_INGEST_BYTES", "_full_ingest_worker_count", "_full_parse_progress_groups", "fingerprint_file", "last_complete_newline_from_tail"]
 # fmt: on

--- a/polylogue/sources/live/batch_observability.py
+++ b/polylogue/sources/live/batch_observability.py
@@ -39,6 +39,7 @@ def record_attempt_progress(
     current_path: Path | None = None,
     error: str | None = None,
     stage_timings_s: dict[str, float] | None = None,
+    stale_cursor_write_count: int | None = None,
 ) -> None:
     rss_current_mb = read_current_rss_mb()
     rss_peak_self_mb = read_peak_rss_self_mb()
@@ -67,6 +68,7 @@ def record_attempt_progress(
         cgroup_memory_current_mb=cgroup_current_mb,
         cgroup_memory_peak_mb=cgroup_peak_mb,
         cgroup_memory_swap_current_mb=cgroup_swap_mb,
+        stale_cursor_write_count=stale_cursor_write_count,
     )
     record_event = getattr(cursor, "record_ingest_stage_event", None)
     if not callable(record_event):

--- a/polylogue/sources/live/batch_support.py
+++ b/polylogue/sources/live/batch_support.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import hashlib
 import time
 from collections.abc import Callable, Iterable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from io import BytesIO
 from pathlib import Path
 from typing import Protocol, cast
@@ -69,11 +69,67 @@ class _AppendResult:
     worker_count: int = 0
 
 
+@dataclass(frozen=True, slots=True)
+class _FullIngestResult:
+    succeeded: list[Path]
+    failed: list[Path]
+    source_payload_read_bytes: int
+    raw_fingerprints: dict[Path, str] = field(default_factory=dict)
+    raw_byte_sizes: dict[Path, int] = field(default_factory=dict)
+    worker_count: int = 0
+
+
 def fingerprint_file(path: Path) -> tuple[str, int]:
     content = path.read_bytes()
     newline_at = content.rfind(b"\n")
     last_complete_newline = 0 if newline_at < 0 else newline_at + 1
     return hashlib.sha256(content).hexdigest(), last_complete_newline
+
+
+def tail_hash_from_path(path: Path, byte_size: int, *, chunk_size: int = 64 * 1024) -> tuple[str, int]:
+    """Return a bounded hash of the recorded file tail."""
+    if byte_size <= 0:
+        return hashlib.sha256(b"").hexdigest(), 0
+    start = max(0, byte_size - chunk_size)
+    with path.open("rb") as handle:
+        handle.seek(start)
+        chunk = handle.read(byte_size - start)
+    return hashlib.sha256(chunk).hexdigest(), len(chunk)
+
+
+def tail_hash_and_last_complete_newline_from_path(
+    path: Path, byte_size: int, *, chunk_size: int = 64 * 1024
+) -> tuple[str, int, int]:
+    """Return tail hash, last complete newline, and bytes read in one pass."""
+    if byte_size <= 0:
+        return hashlib.sha256(b"").hexdigest(), 0, 0
+    bytes_read = 0
+    end = byte_size
+    tail_hash: str | None = None
+    with path.open("rb") as handle:
+        while end > 0:
+            start = max(0, end - chunk_size)
+            handle.seek(start)
+            chunk = handle.read(end - start)
+            bytes_read += len(chunk)
+            if tail_hash is None:
+                tail_hash = hashlib.sha256(chunk).hexdigest()
+            newline_at = chunk.rfind(b"\n")
+            if newline_at >= 0:
+                return tail_hash, start + newline_at + 1, bytes_read
+            end = start
+    return tail_hash or hashlib.sha256(b"").hexdigest(), 0, bytes_read
+
+
+def cursor_state_after_full_ingest(
+    path: Path, byte_size: int, *, raw_fingerprint: str | None
+) -> tuple[str, int, str, int]:
+    if raw_fingerprint is None:
+        fp, last_nl = fingerprint_file(path)
+        tail_hash, _tail_bytes = tail_hash_from_path(path, byte_size)
+        return fp, last_nl, tail_hash, byte_size
+    tail_hash, last_nl, bytes_read = tail_hash_and_last_complete_newline_from_path(path, byte_size)
+    return raw_fingerprint, last_nl, tail_hash, bytes_read
 
 
 def last_complete_newline_from_tail(path: Path, byte_size: int, *, chunk_size: int = 64 * 1024) -> tuple[int, int]:

--- a/polylogue/sources/live/cursor.py
+++ b/polylogue/sources/live/cursor.py
@@ -27,6 +27,7 @@ CREATE TABLE IF NOT EXISTS live_cursor (
     last_record_ts TEXT,
     parser_fingerprint TEXT,
     content_fingerprint TEXT,
+    tail_hash TEXT,
     source_name TEXT,
     -- Stat metadata for fast-path skip (Phase 2 K: #620)
     st_dev INTEGER,
@@ -71,6 +72,7 @@ CREATE TABLE IF NOT EXISTS live_ingest_attempt (
     worker_in_flight_count INTEGER,
     worker_completed_count INTEGER,
     worker_total_count INTEGER,
+    stale_cursor_write_count INTEGER NOT NULL DEFAULT 0,
     source_paths_json TEXT NOT NULL DEFAULT '[]'
 )
 """
@@ -143,6 +145,7 @@ class CursorRecord:
     last_record_ts: str | None = None
     parser_fingerprint: str | None = None
     content_fingerprint: str | None = None
+    tail_hash: str | None = None
     source_name: str | None = None
     st_dev: int | None = None
     st_ino: int | None = None
@@ -185,6 +188,7 @@ class LiveIngestAttempt:
     worker_in_flight_count: int | None = None
     worker_completed_count: int | None = None
     worker_total_count: int | None = None
+    stale_cursor_write_count: int = 0
     source_paths_json: str = "[]"
 
 
@@ -233,14 +237,15 @@ def _cursor_record_from_row(row: sqlite3.Row | tuple[object, ...]) -> CursorReco
         last_record_ts=_optional_str(row[6]),
         parser_fingerprint=_optional_str(row[7]),
         content_fingerprint=_optional_str(row[8]),
-        source_name=_optional_str(row[9]),
-        st_dev=_optional_int(row[10]),
-        st_ino=_optional_int(row[11]),
-        mtime_ns=_optional_int(row[12]),
-        source_generation=_required_int(row[13]) if row[13] is not None else 0,
-        failure_count=_required_int(row[14]) if row[14] is not None else 0,
-        next_retry_at=_optional_str(row[15]),
-        excluded=bool(row[16]) if row[16] is not None else False,
+        tail_hash=_optional_str(row[9]),
+        source_name=_optional_str(row[10]),
+        st_dev=_optional_int(row[11]),
+        st_ino=_optional_int(row[12]),
+        mtime_ns=_optional_int(row[13]),
+        source_generation=_required_int(row[14]) if row[14] is not None else 0,
+        failure_count=_required_int(row[15]) if row[15] is not None else 0,
+        next_retry_at=_optional_str(row[16]),
+        excluded=bool(row[17]) if row[17] is not None else False,
     )
 
 
@@ -270,6 +275,7 @@ class CursorStore:
             "last_record_ts": "TEXT",
             "parser_fingerprint": "TEXT",
             "content_fingerprint": "TEXT",
+            "tail_hash": "TEXT",
             "source_name": "TEXT",
             "st_dev": "INTEGER",
             "st_ino": "INTEGER",
@@ -292,6 +298,7 @@ class CursorStore:
             "worker_in_flight_count": "INTEGER",
             "worker_completed_count": "INTEGER",
             "worker_total_count": "INTEGER",
+            "stale_cursor_write_count": "INTEGER NOT NULL DEFAULT 0",
         }
         for name, definition in attempt_columns.items():
             if name not in existing_attempt:
@@ -408,6 +415,7 @@ class CursorStore:
         worker_in_flight_count: int | None = None,
         worker_completed_count: int | None = None,
         worker_total_count: int | None = None,
+        stale_cursor_write_count: int | None = None,
     ) -> None:
         """Update an in-flight attempt without waiting for batch completion."""
         now = datetime.now(UTC).isoformat()
@@ -433,6 +441,7 @@ class CursorStore:
             "worker_in_flight_count": worker_in_flight_count,
             "worker_completed_count": worker_completed_count,
             "worker_total_count": worker_total_count,
+            "stale_cursor_write_count": stale_cursor_write_count,
         }
         for field, value in optional_fields.items():
             if value is None:
@@ -619,6 +628,7 @@ class CursorStore:
                     worker_in_flight_count,
                     worker_completed_count,
                     worker_total_count,
+                    stale_cursor_write_count,
                     source_paths_json
                 FROM live_ingest_attempt
                 ORDER BY updated_at DESC, started_at DESC
@@ -656,7 +666,8 @@ class CursorStore:
                 worker_in_flight_count=int(row[25]) if row[25] is not None else None,
                 worker_completed_count=int(row[26]) if row[26] is not None else None,
                 worker_total_count=int(row[27]) if row[27] is not None else None,
-                source_paths_json=str(row[28] or "[]"),
+                stale_cursor_write_count=int(row[28] or 0),
+                source_paths_json=str(row[29] or "[]"),
             )
             for row in rows
         ]
@@ -679,6 +690,7 @@ class CursorStore:
                     last_record_ts,
                     parser_fingerprint,
                     content_fingerprint,
+                    tail_hash,
                     source_name,
                     st_dev,
                     st_ino,
@@ -718,6 +730,7 @@ class CursorStore:
                         last_record_ts,
                         parser_fingerprint,
                         content_fingerprint,
+                        tail_hash,
                         source_name,
                         st_dev,
                         st_ino,
@@ -747,6 +760,7 @@ class CursorStore:
         last_record_ts: str | None = None,
         parser_fingerprint: str | None = None,
         content_fingerprint: str | None = None,
+        tail_hash: str | None = None,
         source_name: str | None = None,
         st_dev: int | None = None,
         st_ino: int | None = None,
@@ -755,12 +769,29 @@ class CursorStore:
         failure_count: int | None = None,
         next_retry_at: str | None = None,
         excluded: bool | None = None,
-    ) -> None:
+        allow_backward: bool = False,
+    ) -> bool:
         now = datetime.now(UTC).isoformat()
         offset = byte_size if byte_offset is None else byte_offset
         newline_offset = offset if last_complete_newline is None else last_complete_newline
         excluded_int = 1 if excluded else 0
         with self._connect() as conn:
+            if not allow_backward:
+                existing = conn.execute(
+                    """
+                    SELECT byte_size, byte_offset, parser_fingerprint
+                    FROM live_cursor
+                    WHERE source_path = ?
+                    """,
+                    (str(path),),
+                ).fetchone()
+                if (
+                    existing is not None
+                    and existing[2] == parser_fingerprint
+                    and int(existing[0] or 0) > byte_size
+                    and int(existing[1] or 0) > offset
+                ):
+                    return False
             conn.execute(
                 """
                 INSERT INTO live_cursor (
@@ -772,6 +803,7 @@ class CursorStore:
                     last_record_ts,
                     parser_fingerprint,
                     content_fingerprint,
+                    tail_hash,
                     source_name,
                     st_dev,
                     st_ino,
@@ -782,7 +814,7 @@ class CursorStore:
                     excluded,
                     updated_at
                 )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT (source_path) DO UPDATE SET
                     byte_size = excluded.byte_size,
                     byte_offset = excluded.byte_offset,
@@ -791,6 +823,7 @@ class CursorStore:
                     last_record_ts = excluded.last_record_ts,
                     parser_fingerprint = excluded.parser_fingerprint,
                     content_fingerprint = excluded.content_fingerprint,
+                    tail_hash = excluded.tail_hash,
                     source_name = excluded.source_name,
                     st_dev = excluded.st_dev,
                     st_ino = excluded.st_ino,
@@ -810,6 +843,7 @@ class CursorStore:
                     last_record_ts,
                     parser_fingerprint,
                     content_fingerprint,
+                    tail_hash,
                     source_name,
                     st_dev,
                     st_ino,
@@ -822,6 +856,7 @@ class CursorStore:
                 ),
             )
             conn.commit()
+        return True
 
     def mark_failed(self, path: Path) -> None:
         """Increment failure count and set exponential backoff."""

--- a/polylogue/sources/live/metrics.py
+++ b/polylogue/sources/live/metrics.py
@@ -34,6 +34,7 @@ class LiveBatchMetrics:
     cgroup_memory_current_mb: float | None = None
     cgroup_memory_peak_mb: float | None = None
     cgroup_memory_swap_current_mb: float | None = None
+    stale_cursor_write_count: int = 0
     stage_timings_s: dict[str, float] = field(default_factory=dict)
     failed_paths: list[str] = field(default_factory=list)
 
@@ -74,6 +75,7 @@ class LiveBatchMetrics:
             "cgroup_memory_current_mb": self.cgroup_memory_current_mb,
             "cgroup_memory_peak_mb": self.cgroup_memory_peak_mb,
             "cgroup_memory_swap_current_mb": self.cgroup_memory_swap_current_mb,
+            "stale_cursor_write_count": self.stale_cursor_write_count,
             "stage_timings_s": self.stage_timings_s,
             "failed_paths": self.failed_paths,
         }

--- a/polylogue/sources/live/watcher.py
+++ b/polylogue/sources/live/watcher.py
@@ -23,6 +23,7 @@ from typing import TYPE_CHECKING
 
 from polylogue.logging import get_logger
 from polylogue.sources.live.batch import LiveBatchEventEmitter, LiveBatchProcessor, fingerprint_file
+from polylogue.sources.live.batch_support import tail_hash_from_path
 from polylogue.sources.live.cursor import CursorRecord, CursorStore
 
 if TYPE_CHECKING:
@@ -96,6 +97,7 @@ class LiveWatcher:
         self._converger = converger
         self._pending_paths: set[Path] = set()
         self._pending_scheduled = False
+        self._drain_task: asyncio.Task[None] | None = None
         self._last_batch_at: float = 0.0
         self._batch_lock = asyncio.Lock()
         self._stop = asyncio.Event()
@@ -133,7 +135,11 @@ class LiveWatcher:
         self._stop.set()
 
     def cancel_pending(self) -> None:
-        pass  # No orphaned tasks with the batched model
+        task = self._drain_task
+        if task is not None and not task.done():
+            task.cancel()
+        self._drain_task = None
+        self._pending_scheduled = False
 
     # ------------------------------------------------------------------
     # Catch-up: batch all changed files
@@ -216,33 +222,41 @@ class LiveWatcher:
     def _enqueue(self, path: Path) -> None:
         """Enqueue a path for batched ingestion after debounce."""
         self._pending_paths.add(path)
-        if not self._pending_scheduled:
+        if self._drain_task is None or self._drain_task.done():
             self._pending_scheduled = True
-            asyncio.create_task(self._debounced_batch())
+            self._drain_task = asyncio.create_task(self._debounced_batch())
 
     async def _debounced_batch(self) -> None:
-        """Wait for the debounce window, then flush all pending paths."""
-        await asyncio.sleep(self._debounce_s)
+        """Wait for the debounce window, then drain pending paths serially."""
+        try:
+            await asyncio.sleep(self._debounce_s)
 
-        # Re-check: collect any new arrivals during the sleep.
-        while True:
-            before = len(self._pending_paths)
-            await asyncio.sleep(0.5)
-            after = len(self._pending_paths)
-            if after == before:
-                break
+            while not self._stop.is_set():
+                # Re-check: collect any new arrivals during the quiet window.
+                while True:
+                    before = len(self._pending_paths)
+                    await asyncio.sleep(0.5)
+                    after = len(self._pending_paths)
+                    if after == before:
+                        break
 
-        await self._flush_pending()
+                flushed = await self._flush_pending()
+                if not flushed:
+                    break
+        finally:
+            if self._pending_paths and not self._stop.is_set():
+                self._drain_task = asyncio.create_task(self._debounced_batch())
+            else:
+                self._pending_scheduled = False
+                self._drain_task = None
 
-    async def _flush_pending(self) -> None:
-        """Flush all pending paths in a single batch."""
+    async def _flush_pending(self) -> bool:
+        """Flush one pending path snapshot and report whether work ran."""
         async with self._batch_lock:
             if not self._pending_paths:
-                self._pending_scheduled = False
-                return
+                return False
             paths = list(self._pending_paths)
             self._pending_paths.clear()
-            self._pending_scheduled = False
 
         # Filter to files that actually need work.
         cursor_records = self._cursor.get_records(paths)
@@ -255,7 +269,7 @@ class LiveWatcher:
             if self._needs_work_from_state(path, stat=stat, cursor=cursor_records.get(path)):
                 needed.append(path)
         if not needed:
-            return
+            return bool(paths)
 
         logger.info("live.watcher: batching %d changed file(s)", len(needed))
         await self._ingest_files(
@@ -263,6 +277,7 @@ class LiveWatcher:
             queued_file_count=len(paths),
             skipped_file_count=len(paths) - len(needed),
         )
+        return True
 
     # ------------------------------------------------------------------
     # Shared helpers
@@ -295,7 +310,13 @@ class LiveWatcher:
             # catch-up skip path. Device/inode churn across bind mounts,
             # restored homes, or filesystem rebuilds must not force a full
             # content rehash of every historical session file.
-            return False
+            if cursor.tail_hash is None:
+                return False
+            try:
+                current_tail_hash, _bytes_read = tail_hash_from_path(path, size)
+            except FileNotFoundError:
+                return False
+            return current_tail_hash != cursor.tail_hash
         if cursor.content_fingerprint is None:
             return True
         try:

--- a/tests/unit/sources/test_live_hot_session_convergence.py
+++ b/tests/unit/sources/test_live_hot_session_convergence.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+import polylogue.sources.live.watcher as live_watcher
+from polylogue.sources.live.cursor import CursorStore
+from tests.unit.sources.test_live_watcher import _ingest_one, _make_watcher
+
+
+def test_cursor_rejects_stale_backward_write_for_same_parser(tmp_path: Path) -> None:
+    store = CursorStore(tmp_path / "live.sqlite")
+    p = tmp_path / "session.jsonl"
+    assert store.set(p, 250, byte_offset=250, parser_fingerprint="parser") is True
+
+    assert store.set(p, 100, byte_offset=100, parser_fingerprint="parser") is False
+
+    record = store.get_record(p)
+    assert record is not None
+    assert record.byte_size == 250
+    assert record.byte_offset == 250
+
+
+def test_cursor_allows_explicit_backward_write_for_truncation(tmp_path: Path) -> None:
+    store = CursorStore(tmp_path / "live.sqlite")
+    p = tmp_path / "session.jsonl"
+    store.set(p, 250, byte_offset=250, parser_fingerprint="parser")
+
+    assert store.set(p, 100, byte_offset=100, parser_fingerprint="parser", allow_backward=True) is True
+
+    record = store.get_record(p)
+    assert record is not None
+    assert record.byte_size == 100
+    assert record.byte_offset == 100
+
+
+def test_same_size_rewrite_uses_tail_hash_without_full_prefingerprint(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / "src"
+    root.mkdir()
+    f = root / "session.jsonl"
+    f.write_text('{"a":1}\n')
+    watcher, parse_sources = _make_watcher(tmp_path, root)
+
+    asyncio.run(_ingest_one(watcher, f))
+    assert parse_sources.await_count == 1
+
+    f.write_text('{"b":2}\n')
+    assert f.stat().st_size == len('{"a":1}\n')
+
+    def fail_fingerprint(path: Path) -> tuple[str, int]:
+        raise AssertionError(f"same-size rewrite should not full-fingerprint before ingest: {path}")
+
+    monkeypatch.setattr(live_watcher, "fingerprint_file", fail_fingerprint)
+    asyncio.run(_ingest_one(watcher, f))
+
+    assert parse_sources.await_count == 2
+
+
+def test_legacy_same_size_cursor_without_tail_hash_skips_full_prefingerprint(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / "src"
+    root.mkdir()
+    f = root / "session.jsonl"
+    f.write_text('{"a":1}\n')
+    watcher, parse_sources = _make_watcher(tmp_path, root)
+    stat = f.stat()
+    watcher._cursor.set(
+        f,
+        stat.st_size,
+        parser_fingerprint=live_watcher._PARSER_FINGERPRINT,
+        content_fingerprint="legacy-full-hash",
+    )
+
+    f.write_text('{"b":2}\n')
+
+    def fail_fingerprint(path: Path) -> tuple[str, int]:
+        raise AssertionError(f"legacy same-size cursor should not full-fingerprint: {path}")
+
+    monkeypatch.setattr(live_watcher, "fingerprint_file", fail_fingerprint)
+    asyncio.run(_ingest_one(watcher, f))
+
+    assert parse_sources.await_count == 0
+
+
+def test_debounce_drains_live_events_serially_while_ingest_is_active(tmp_path: Path) -> None:
+    root = tmp_path / "src"
+    root.mkdir()
+    first = root / "first.jsonl"
+    second = root / "second.jsonl"
+    first.write_text('{"a":1}\n')
+    second.write_text('{"b":2}\n')
+    watcher, _parse_sources = _make_watcher(tmp_path, root, debounce_s=0.01)
+    active = 0
+    max_active = 0
+    batches: list[list[Path]] = []
+    entered_first_batch = asyncio.Event()
+    release_first_batch = asyncio.Event()
+
+    async def fake_ingest(
+        paths: list[Path],
+        *,
+        queued_file_count: int | None = None,
+        skipped_file_count: int = 0,
+    ) -> None:
+        del queued_file_count, skipped_file_count
+        nonlocal active, max_active
+        active += 1
+        max_active = max(max_active, active)
+        batches.append(list(paths))
+        if len(batches) == 1:
+            entered_first_batch.set()
+            await release_first_batch.wait()
+        active -= 1
+
+    async def _drive() -> None:
+        watcher._ingest_files = fake_ingest  # type: ignore[method-assign]
+        watcher._enqueue(first)
+        await asyncio.wait_for(entered_first_batch.wait(), timeout=2.0)
+        watcher._enqueue(second)
+        await asyncio.sleep(0.05)
+        release_first_batch.set()
+        while watcher._pending_scheduled or watcher._pending_paths:
+            await asyncio.sleep(0.02)
+
+    asyncio.run(_drive())
+
+    assert max_active == 1
+    assert batches == [[first], [second]]

--- a/tests/unit/sources/test_live_watcher.py
+++ b/tests/unit/sources/test_live_watcher.py
@@ -515,43 +515,6 @@ def test_reingest_when_file_grows(tmp_path: Path) -> None:
     assert parse_sources.await_count == 3
 
 
-def test_same_size_rewrite_is_not_auto_detected(tmp_path: Path) -> None:
-    """Document the watcher's same-size-rewrite limitation (#1003 follow-on).
-
-    The previous behaviour rehashed the entire file on every mtime drift
-    to detect same-size in-place rewrites. That fingerprint cost was the
-    read-amplification storm. The watcher now trusts the
-    (dev, ino, size, content_fingerprint) tuple and ignores mtime drift.
-
-    Cost: same-size in-place content rewrites (rare; vim-edits with
-    ``backupcopy=yes``, manual ``echo > file``, restore from same-sized
-    backup) are not auto-detected. Tail-hash restoration is tracked in
-    #1009.
-
-    Operators can force re-ingest via ``polylogue reset`` / explicit
-    ``polylogue ingest``.
-    """
-    root = tmp_path / "src"
-    root.mkdir()
-    f = root / "session.jsonl"
-    f.write_text('{"a":1}\n')
-    watcher, parse_sources = _make_watcher(tmp_path, root)
-
-    asyncio.run(_ingest_one(watcher, f))
-    assert parse_sources.await_count == 1
-
-    f.write_text('{"b":2}\n')
-    assert f.stat().st_size == len('{"a":1}\n')
-    asyncio.run(_ingest_one(watcher, f))
-
-    # New contract: same-size rewrite is NOT auto-detected. The cost of
-    # detecting it (full-file rehash on every mtime drift) was the storm.
-    assert parse_sources.await_count == 1, (
-        "Same-size rewrite must not trigger re-ingest at watcher stage. "
-        "See #1003 for the storm context, #1009 for the tail-hash restoration."
-    )
-
-
 def test_legacy_size_only_cursor_reingests_to_populate_fingerprint(tmp_path: Path) -> None:
     root = tmp_path / "src"
     root.mkdir()


### PR DESCRIPTION
## Summary

This changes live daemon ingest so hot session files converge through one serial watcher drain, bounded cursor checks, and richer workload diagnostics instead of allowing overlapping live batches to bounce active files between full and append ingest.

## Problem

Live archive evidence showed active Codex/Claude session files repeatedly accumulating full raw rows while the daemon was still processing the same paths. The watcher could schedule a second batch while a prior batch was still ingesting, full-ingest cursor updates used the file size observed at cursor-update time rather than the raw bytes actually parsed, and same-size rewrite handling had no bounded discriminator. That combination could regress cursor state and hide the actual hot-path workload shape from operator diagnostics.

## Solution

- Drain live watcher events single-flight, so changes that arrive during an active ingest remain queued and run after the current batch finishes.
- Add `live_cursor.tail_hash` and use a bounded 64 KiB tail hash for same-size rewrite detection without full-file prehashing.
- Reject stale backward cursor writes for the same parser unless the caller explicitly records a truncation-sized update.
- Carry the raw byte size from full ingest into cursor recording so growing files do not get advanced beyond parsed content.
- Extend daemon status/workload diagnostics with stale cursor-write counters, overlapping running source paths, and recent source-path churn scoped to recent attempts.
- Split focused hot-session convergence tests out of the oversized watcher test file and refresh generated repository surfaces.

## Verification

- `devtools verify --quick` → passed
- `pytest -q tests/unit/sources/test_live_hot_session_convergence.py tests/unit/sources/test_live_watcher.py tests/unit/devtools/test_daemon_workload_probe.py tests/unit/daemon/test_daemon_status.py tests/integration/test_live_read_amplification.py` → `81 passed`
- `python devtools/daemon_workload_probe.py --json --limit 5` against the live archive → reported no overlapping running source paths and exposed the current hot source-path churn counters

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced live daemon convergence with improved watcher batch draining and stale cursor tracking.
  * Added tail-hash optimization for detecting same-size file changes without full re-fingerprinting.
  * Expanded workload diagnostics: new metrics for stale cursor writes, overlapping source paths, and source path churn.

* **Bug Fixes**
  * Improved reliability of cursor state management for backward write detection.

* **Tests**
  * Added comprehensive tests for cursor convergence behavior and watcher event debouncing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sinity/polylogue/pull/1039)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->