### PR TITLE
docs: reconcile architecture issue map

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -452,6 +452,10 @@ Never delete:
 <!-- begin include: docs/architecture.md -->
 # Polylogue Architecture
 
+For the target shape, guardrails, and architectural decision log, see
+[Architecture Spine](architecture-spine.md). For current sequencing and active
+workstreams, see [Execution Plan](execution-plan.md).
+
 Polylogue is a local archive for AI conversations. The system has four rings:
 
 1. archive substrate

--- a/README.md
+++ b/README.md
@@ -181,6 +181,8 @@ Start with the generated command and architecture references; use [docs/README.m
 | Document | Description |
 |----------|-------------|
 | [Architecture](docs/architecture.md) | System rings, ownership boundaries, and data flow. |
+| [Architecture Spine](docs/architecture-spine.md) | Target shape, guardrails, and major decisions with rejected alternatives. |
+| [Execution Plan](docs/execution-plan.md) | Living sequencing plan — landed, in flight, queued, and frozen subsystems. |
 | [CLI Reference](docs/cli-reference.md) | Generated command reference from live help output. |
 | [Browser Capture](docs/browser-capture.md) | Local browser extension capture for ChatGPT and Claude.ai sessions. |
 | [Library API](docs/library-api.md) | Async archive API, filters, and query patterns. |

--- a/devtools/docs_surface.py
+++ b/devtools/docs_surface.py
@@ -79,6 +79,8 @@ REPO_GUIDE_ENTRIES: tuple[DocsEntry, ...] = (
 
 README_DOC_TITLES: tuple[str, ...] = (
     "Architecture",
+    "Architecture Spine",
+    "Execution Plan",
     "CLI Reference",
     "Browser Capture",
     "Library API",

--- a/devtools/render_docs_surface.py
+++ b/devtools/render_docs_surface.py
@@ -74,7 +74,14 @@ def build_docs_readme(
             "",
             _render_named_table(
                 docs_by_title,
-                ("Architecture", "Data Model", "Internals", "Configuration"),
+                (
+                    "Architecture",
+                    "Architecture Spine",
+                    "Execution Plan",
+                    "Data Model",
+                    "Internals",
+                    "Configuration",
+                ),
                 from_dir="docs",
             ),
             "",

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,8 @@ Use this map when you need the complete repository documentation surface. The to
 | Document | Description |
 |----------|-------------|
 | [Architecture](architecture.md) | System rings, ownership boundaries, and data flow. |
+| [Architecture Spine](architecture-spine.md) | Target shape, guardrails, and major decisions with rejected alternatives. |
+| [Execution Plan](execution-plan.md) | Living sequencing plan — landed, in flight, queued, and frozen subsystems. |
 | [Data Model](data-model.md) | Archive entities, storage shape, and metadata rules. |
 | [Internals](internals.md) | Working implementation reference and debugging landmarks. |
 | [Configuration](configuration.md) | XDG paths, environment variables, and runtime configuration. |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,5 +1,9 @@
 # Polylogue Architecture
 
+For the target shape, guardrails, and architectural decision log, see
+[Architecture Spine](architecture-spine.md). For current sequencing and active
+workstreams, see [Execution Plan](execution-plan.md).
+
 Polylogue is a local archive for AI conversations. The system has four rings:
 
 1. archive substrate

--- a/docs/execution-plan.md
+++ b/docs/execution-plan.md
@@ -1,7 +1,8 @@
 # Execution Plan
 
-Living sequencing plan for Polylogue subsystem maturation.
-Updated per-PR. See `docs/architecture-spine.md` for the target shape.
+Living sequencing plan for Polylogue subsystem maturation. This document is a
+coordination map, not a replacement for issue acceptance criteria. See
+`docs/architecture-spine.md` for the target shape.
 
 ## Landed
 
@@ -9,9 +10,9 @@ Updated per-PR. See `docs/architecture-spine.md` for the target shape.
 |-----------|--------|-----------|
 | Archive substrate (acquisition, parsing, persistence, FTS, blob store) | Done | Multiple PRs |
 | Content hash idempotency | Done | #838, #421 |
-| Session insights (profiles, work events, phases, threads) | Done | Multiple PRs |
-| Cost/subscription tracking and outlook | Done | #938, #943 |
-| Daemon convergence (named stages) | Done | Multiple PRs |
+| Session insights baseline (profiles, work events, phases, threads) | Landed; rigor hardening remains | Multiple PRs, #1019 |
+| Cost/subscription tracking and outlook slice | Landed; product forecasting remains | #938, #943, #995 |
+| Daemon convergence architecture | Landed; production proof and residual workload remain | #847, #854, #845, #1036 |
 | Browser extension + receiver | Done | #937, #940 |
 | Identity ledger (stable IDs across re-ingestion) | Done | #775, #963 |
 | MCP server (35+ tools, read/write/admin roles) | Done | Multiple PRs |
@@ -29,19 +30,22 @@ Updated per-PR. See `docs/architecture-spine.md` for the target shape.
 
 | Substream | Blocked by | Next artifact |
 |-----------|-----------|---------------|
-| Embedding pipeline activation (#828) | VOYAGE_API_KEY + daemon opt-in | Daemon-owned post-ingest embedding convergence |
+| Daemon convergence proof and residual workload (#845, #1036) | Deployment via Sinnix for latest merged daemon changes | Production-corpus convergence report and packaged rollout |
+| Source vocabulary and local-agent sources (#1022) | — | Public source-family contract and filter/completion parity |
+| Insight rigor and downstream contracts (#1019) | — | Product-by-product evidence/inference/readiness matrix |
 | Web reader realtime (#957) | — | SSE streaming channel from daemon to reader |
+| Reconciliation ledger (#944) | Open residual owners stay precise | Closeout matrix mapping stale closure claims to owner issues |
 
 ## Queued
 
 Dependency order (items in each tier are parallelizable):
 
 1. **Storage hardening**: blob GC (#818), FTS bloat reduction (#817), daemon safety (#771)
-2. **Archive semantics**: context/protocol artifact storage (#839), provider_meta graduation (#864)
-3. **Read surfaces**: search explainability (#873), reader marks (#867), session lineage (#866)
-4. **Operational surfaces**: daemon validation failure visibility (#844), maintenance planner (#871), read-surface SLOs (#872)
-5. **Verification depth**: systematic test architecture (#807), structural simplification (#805)
-6. **Product polish**: CLI polish (#958), docs revamp (#952), broad distribution (#953)
+2. **Archive semantics**: context/protocol artifact storage (#839), provider_meta graduation (#864), source vocabulary (#1022)
+3. **Read surfaces**: search explainability (#873), reader marks (#867), session lineage (#866), insight rigor (#1019)
+4. **Operational surfaces**: maintenance/replay planner (#996), daemon health notifications (#999), read-surface SLOs (#872)
+5. **Verification depth**: systematic test architecture (#997), verifiability dashboard/traceability (#998), evidence quality (#594/#590)
+6. **Product polish**: CLI polish (#958), docs revamp (#952), broad distribution (#953), webui advanced functionality (#993)
 
 ## Frozen / Parked
 


### PR DESCRIPTION
## Summary

Refresh the architecture/documentation issue map so current contributors can find the Architecture Spine, Execution Plan, and active residual owners directly from the generated docs surfaces.

## Problem

The docs map did not surface `docs/architecture-spine.md` or `docs/execution-plan.md`, and `docs/execution-plan.md` still presented several stale closed issue numbers as if they were the active work owners. That made recent closed-issue audits harder to trust.

## Solution

- Add Architecture Spine and Execution Plan to the generated README/docs map surfaces.
- Link Architecture Spine and Execution Plan from `docs/architecture.md`.
- Update `docs/execution-plan.md` to distinguish landed baseline slices from still-open workstreams such as #845/#1036, #1019, #1022, #996, #993, #998/#997, and #594/#590.
- Regenerate `README.md`, `docs/README.md`, and `AGENTS.md`.

## Verification

- `devtools render-docs-surface --check` -> sync OK
- `ruff format --check devtools/docs_surface.py devtools/render_docs_surface.py` -> 2 files already formatted
- `ruff check devtools/docs_surface.py devtools/render_docs_surface.py` -> all checks passed
- `devtools verify --quick` -> all checks passed

Full pytest baseline was not run for this docs/generated-surface hygiene branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added two new documentation resources: "Architecture Spine" (for architectural decisions and guardrails) and "Execution Plan" (for current sequencing and workstreams).
  * Enhanced documentation navigation with cross-references across key documents.
  * Updated execution plan with refined workstream statuses and refined language for current active initiatives.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sinity/polylogue/pull/1042)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->