### PR TITLE
docs: make MK3 execution plan actionable

### DIFF
--- a/docs/execution-plan.md
+++ b/docs/execution-plan.md
@@ -95,6 +95,18 @@ work independently. Each worker gets an issue owner, owned files, avoided files,
 first verification command, and expected handoff note in
 `docs/plans/mk3-execution-log.md`.
 
+Use the lightest coordination mode that fits:
+
+- **Same-context helper** for read-only exploration, issue triage, test-output
+  classification, and narrowly scoped code review. The main agent keeps write
+  ownership and folds the findings into the current branch.
+- **Same-branch serialized worker** for small patches where the write set is
+  disjoint and the main agent can review immediately before the next worker
+  starts.
+- **Worktree worker** only when the task is long-running, risky, mechanically
+  large, or likely to need independent commits while the main branch keeps
+  moving.
+
 Good parallel lanes:
 
 - contract worker: TargetRef, reader payloads, query/status envelopes;
@@ -113,6 +125,14 @@ Serialize work when lanes touch the same shared file family:
   changes;
 - `docs/execution-plan.md` and generated docs;
 - any branch that is already waiting on CI for merge readiness.
+
+Before dispatching an autonomous wave, record in the execution log:
+
+- lane and issue owner;
+- coordination mode: same-context, same-branch serialized, or worktree;
+- exact owned and avoided files;
+- first verification command;
+- handoff artifact expected from the worker.
 
 ## Verification Economy
 

--- a/docs/execution-plan.md
+++ b/docs/execution-plan.md
@@ -5,6 +5,23 @@ coordination map, not a replacement for issue acceptance criteria. See
 `docs/architecture-spine.md` for the target shape and `docs/design/mk3/` for
 the current reader/workbench design source material.
 
+## How To Use This Plan
+
+This plan answers three operational questions:
+
+1. What should start next without creating avoidable rework?
+2. Which issue owns the durable acceptance criteria?
+3. What proof has to exist before a wave can claim completion?
+
+Issue bodies remain authoritative for scope. This document keeps the backlog
+coherent across issues by naming dependency order, handoff artifacts, and
+cross-issue exit gates. When an issue is split or closed, update this plan in
+the same PR or issue-maintenance pass.
+
+The coordination scratchpad for active execution is
+`docs/plans/mk3-execution-log.md`. Use it for subagent lane ownership, current
+status, test choices, resource constraints, and handoff notes.
+
 ## Landed
 
 | Subsystem | Status | Closed by |
@@ -13,7 +30,7 @@ the current reader/workbench design source material.
 | Content hash idempotency | Done | #838, #421 |
 | Session insights baseline (profiles, work events, phases, threads) | Landed; rigor hardening remains | Multiple PRs, #1019 |
 | Cost/subscription tracking and outlook slice | Landed; product forecasting remains | #938, #943, #995 |
-| Daemon convergence architecture | Landed; production proof and residual workload remain | #847, #854, #845, #1036 |
+| Daemon convergence architecture | Landed; production proof and residual workload remain under #845/#996/#999 | #847, #854 |
 | Browser extension + receiver | Done | #937, #940 |
 | Identity ledger (stable IDs across re-ingestion) | Done | #775, #963 |
 | MCP server (35+ tools, read/write/admin roles) | Done | Multiple PRs |
@@ -22,32 +39,106 @@ the current reader/workbench design source material.
 | Root artifact cleanup | Done | #954, #966 |
 | Verification baseline (format, lint, mypy, topology, manifests) | Done | #944 |
 | Type tightening (SubjectRef.kind enum) | Done | #421, #968 |
-| CLI mutation flags (--add-tag/--remove-tag) | Done | #862, #967 |
+| CLI mutation flags (--add-tag/--remove-tag) | Done; broader mutation contracts remain under #862 | #967 |
 | Manifest-only conversation prevention | Done | #945 |
 | MCP error sanitization and metadata validation | Done | #948 |
 | CLI format matrix coverage | Done | #949 |
 
-## In Flight
+## Active Lanes
 
-| Substream | Blocked by | Next artifact |
-|-----------|-----------|---------------|
-| Daemon convergence proof and residual workload (#845, #1036) | Deployment via Sinnix for latest merged daemon changes | Production-corpus convergence report and packaged rollout |
-| Source vocabulary and local-agent sources (#1022) | — | Public source-family contract and filter/completion parity |
-| Insight rigor and downstream contracts (#1019) | — | Product-by-product evidence/inference/readiness matrix |
-| MK3 archive workbench integration (#848, #865, #866, #867, #956, #957, #993) | Design pack now committed under `docs/design/mk3/`; active work dissolved into the issues below | Contract-first reader slice: TargetRef, message anchors, enriched reader payload, and visual smoke matrix |
-| Web reader realtime (#957) | — | SSE streaming channel from daemon to reader |
-| Reconciliation ledger (#944) | Open residual owners stay precise | Closeout matrix mapping stale closure claims to owner issues |
+| Lane | Live owners | Next artifact | Why now |
+|------|-------------|---------------|---------|
+| Runtime convergence and host proof | #845, #996, #999, #829 | Packaged daemon rollout plus production-corpus convergence report | The daemon must converge over the real archive; operational proof is the blocking confidence artifact for deployment. |
+| Source and semantic vocabulary | #1022, #839, #864, #1041, #1027 | Source-family contract, typed context/protocol fields, and provider/schema distribution evidence | MK3 reader contracts need typed source/provenance facts before UI can stop scraping provider metadata. |
+| Shared read contracts | #859, #873, #860, #848 | TargetRef/message-envelope/query/facet/status contracts shared by CLI, MCP, API, and daemon HTTP | This is the smallest useful MK3 start because later UI work consumes these envelopes. |
+| Reader evidence and product shell | #848, #865, #956, #993 | Single-conversation reader slice with executable DOM/browser evidence | MK3 must become a verified runtime reader, not only design screenshots. |
+| Topology and durable user state | #866, #867, #993 | Canonical topology read model and TargetRef-based marks/annotations/saved views | Multi-chat workspace, compare, recall packs, and topology panels need these substrates. |
+| Insight and cost rigor | #1019, #994, #995 | Readiness/confidence matrix for insight, cost, similarity, and derived panels | Advanced panels must show real availability, stale, inferred, and partial states. |
+| Verification and throughput | #1026, #997, #998, #594, #590, #1012 | Faster full baseline plus executable proof routing and inherited-failure cleanup | Broad changes are too expensive and too easy to misclaim without a faster, more precise gate. |
+| Distribution and user-facing polish | #869, #953, #952, #958 | Turnkey install/service/docs/CLI package path | Package and docs work should follow runtime/read-surface contracts so it does not document unstable behavior. |
 
-## Queued
+## Dependency Gates
 
-Dependency order (items in each tier are parallelizable):
+Use these gates to decide whether a PR is ready to start, not only whether it
+is ready to merge.
 
-1. **Storage hardening**: blob GC (#818), FTS bloat reduction (#817), daemon safety (#771)
-2. **Archive semantics**: context/protocol artifact storage (#839), provider_meta graduation (#864), source vocabulary (#1022)
-3. **Read surfaces**: MK3 contract slices (#848/#993), search explainability (#873), reader marks (#867), session lineage (#866), insight rigor (#1019)
-4. **Operational surfaces**: maintenance/replay planner (#996), daemon health notifications (#999), read-surface SLOs (#872)
-5. **Verification depth**: systematic test architecture (#997), verifiability dashboard/traceability (#998), evidence quality (#594/#590)
-6. **Product polish**: CLI polish (#958), docs revamp (#952), broad distribution (#953), webui advanced functionality (#993)
+| Gate | Required before | Owner issues | Handoff |
+|------|-----------------|--------------|---------|
+| G1: typed source/provenance vocabulary | Rich reader chips, provenance panels, paste/attachment states | #1022, #839, #864, #1041, #1027 | Shared source-family names and typed fields that replace provider-meta scraping. |
+| G2: shared read envelope | Reader shell, visual smoke, advanced panels | #859, #873, #860 | Versioned list/detail/message/facet/status envelopes and query serialization. |
+| G3: executable reader evidence | Closing #848/#993 rows that claim runtime UI behavior | #865 | Synthetic-data DOM/browser lane with nonblank, private-safe, stateful assertions. |
+| G4: topology read model | Stack, compare, lineage rail, topology explorer | #866 | Ancestor/descendant/sibling/root APIs with unresolved/late-repair/cycle evidence. |
+| G5: TargetRef user state | Marks, annotations, saved views, recall packs, durable workspaces | #867 | Idempotent CRUD and content-hash exclusion for conversation/message targets first. |
+| G6: runtime deployment proof | Distribution docs and system service guidance | #845, #996, #999, #829, #869, #953 | Packaged daemon installed through Sinnix, real archive convergence report, health/status evidence. |
+| G7: faster verification | Large MK3/daemon waves | #1026, #997, #998, #594, #590, #1012 | Focused affected gates, proof routing, and inherited failure cleanup so broad verification is credible. |
+
+## Near-Term PR Candidates
+
+These are deliberately shaped as coherent PR-sized slices. They can run in
+parallel when their write surfaces do not overlap.
+
+| Candidate | Owner issues | Primary files | Acceptance proof |
+|-----------|--------------|---------------|------------------|
+| Define `TargetRef` and message-anchor contract | #859, #848, #867 | `polylogue/surfaces/`, `polylogue/daemon/http.py`, `polylogue/archive/query/`, daemon tests | Conversation/message targets serialize deterministically; reader endpoints expose anchors; unsupported targets return explicit disabled reasons. |
+| Replace reader/provider metadata scraping with typed source fields | #1022, #839, #864 | source parsers, archive models, payloads, schema docs | Header/search chips read typed fields; provider-meta fallback is either removed or marked transitional with tests. |
+| Make reader visual smoke MK3-ready | #865, #848, #956 | `tests/unit/daemon/test_web_reader.py`, possible `tests/visual/`, `devtools/lab_scenario.py` | Synthetic reader evidence covers list/search, conversation detail, empty/no-results, privacy, degraded state, and nonblank output. |
+| Implement paste-span projection MVP | #839, #864, #848, #993 | message/storage projections, payloads, reader API/tests | Explicit span fixture and whole-message fallback fixture render distinct states; typed-only/paste-only copy disables when boundaries are unknown. |
+| Materialize topology edge substrate | #866 | storage DDL, ingest enrichment, archive operations, parser fixtures | Child-before-parent unresolved edge, late repair, cycle quarantine, and sibling/ancestor read tests pass. |
+| Add TargetRef-based marks and annotations | #867, #862 | user-state DDL/repository/API, daemon endpoints, reader tests | Idempotent CRUD works for conversation/message targets; content hash unchanged; reimport preservation tested where identity evidence exists. |
+| Prove packaged daemon convergence | #845, #996, #999, #829, #869 | Sinnix input update, package/service config, daemon docs | Installed service is latest merged Polylogue, real archive converges, health/status and residual workload are recorded. |
+| Reduce verification wall time | #1026, #997, #998, #594/#590 | `devtools/verify.py`, test config, proof routing | `devtools verify --affected --skip-slow` handles small diffs; full non-slow baseline is measured and outliers have owners. |
+
+## Parallel Execution Rules
+
+Parallelize only where ownership is clean enough that agents can commit useful
+work independently. Each worker gets an issue owner, owned files, avoided files,
+first verification command, and expected handoff note in
+`docs/plans/mk3-execution-log.md`.
+
+Good parallel lanes:
+
+- contract worker: TargetRef, reader payloads, query/status envelopes;
+- source/provenance worker: typed source fields, parser/schema evidence;
+- visual evidence worker: synthetic reader DOM/browser lane;
+- topology worker: edge substrate and topology read model;
+- user-state worker: marks, annotations, saved views, recall packs;
+- verification worker: affected-test workflow and proof routing;
+- packaging/deployment worker: Sinnix input, package/service rollout evidence.
+
+Serialize work when lanes touch the same shared file family:
+
+- `polylogue/daemon/http.py` for contract, user-state, and reader evidence
+  changes;
+- storage DDL/schema bootstrap for topology, user-state, and source/provenance
+  changes;
+- `docs/execution-plan.md` and generated docs;
+- any branch that is already waiting on CI for merge readiness.
+
+## Verification Economy
+
+Use narrow evidence first, then broad gates at publication boundaries:
+
+1. Run the subsystem test for the files touched.
+2. Run static/generated checks once the slice is coherent.
+3. Run `devtools verify --quick` before push.
+4. Run full `devtools verify` before PR readiness when runtime semantics
+   changed. For docs-only changes, generated docs and quick verification are
+   sufficient unless the PR claims runtime behavior.
+
+Avoid wasting RAM and wallclock:
+
+- Do not repeatedly run full pytest while the host is under IO pressure, low
+  memory, or active daemon catch-up. Capture that condition in the execution log
+  and use focused tests until pressure clears.
+- Keep browser screenshot evidence out of the quick loop; pair it with a fast
+  DOM/contract smoke lane.
+- For schema/storage changes, run focused storage/parser tests before broad
+  gates.
+- For packaging/deployment, run code checks first, then Nix/service checks, so
+  failures are attributable.
+- When `devtools verify --affected --skip-slow` is available, use it for small
+  changes and reserve full non-slow pytest for merge readiness or high-risk
+  shared behavior.
 
 ## MK3 Integration Waves
 
@@ -57,7 +148,14 @@ detail; the work below closes through the named issue owners.
 
 ### Wave 1 - Reader Contract Spine
 
-Owner issues: #859, #873, #839, #864, #1022, with #848 consuming.
+Owner issues: #859, #873, #839, #864, #1022, #1041, #1027, with #848
+consuming.
+
+Start condition:
+
+- No broad frontend work is needed first. This wave can start immediately if it
+  keeps the first TargetRef scope to conversation/message and treats missing
+  substrate as disabled/partial states.
 
 Scope:
 
@@ -76,9 +174,18 @@ Exit proof:
 - privacy tests proving ordinary reader endpoints do not leak absolute local
   paths.
 
+Handoff to next wave:
+
+- #848 can render a message list without provider-specific frontend inference.
+
 ### Wave 2 - Single-Conversation Reader
 
 Owner issues: #848 and #865.
+
+Start condition:
+
+- Wave 1 exposes stable enough list/detail/message/status payloads for the
+  reader to avoid hand-rolled filters and metadata scraping.
 
 Scope:
 
@@ -97,9 +204,20 @@ Exit proof:
 - fast DOM/contract smoke remains separate from heavier browser screenshot
   evidence.
 
+Handoff to next wave:
+
+- Runtime reader has a stable single-conversation baseline that paste,
+  attachment, topology, and user-state panels can plug into without rewriting
+  the shell.
+
 ### Wave 3 - Paste, Attachments, And Provenance
 
 Owner issues: #839, #864, #848, #993.
+
+Start condition:
+
+- Wave 1 message envelopes exist; Wave 2 reader has fold/action/panel slots for
+  large content and provenance.
 
 Scope:
 
@@ -117,9 +235,19 @@ Exit proof:
 - typed-only/paste-only copy controls disable with specific reasons when spans
   are unavailable.
 
+Handoff to next wave:
+
+- Paste and attachment objects can become workspace/topology/provenance targets
+  without changing their identity vocabulary.
+
 ### Wave 4 - Topology And Multi-Chat Workspace
 
 Owner issues: #866, #993, #848, #865.
+
+Start condition:
+
+- Topology starts in substrate as soon as source/provenance identity is stable
+  enough; stack/compare UI waits for the reader baseline.
 
 Scope:
 
@@ -139,9 +267,19 @@ Exit proof:
 - visual evidence for resolved parent, unresolved parent, subagent cluster,
   fork compare, too-many-lanes, and missing topology states.
 
+Handoff to next wave:
+
+- Workspaces can persist references to topology nodes/edges through TargetRef
+  rather than URL-only conversation IDs.
+
 ### Wave 5 - Durable User State And Advanced Panels
 
 Owner issues: #867, #993, #1019, #995.
+
+Start condition:
+
+- Conversation/message TargetRef is stable. Saved-view work also needs shared
+  query serialization from Wave 1.
 
 Scope:
 
@@ -158,9 +296,19 @@ Exit proof:
 - visual smoke for marked, annotated, pending mutation, failed mutation, stale
   insight, partial cost, and unconfigured similarity states.
 
+Handoff to next wave:
+
+- Reader and realtime code can refer to persisted workspaces and saved views
+  rather than browser-local state.
+
 ### Wave 6 - Realtime And Operational Workbench
 
 Owner issues: #957, #999, #845, #996, #829.
+
+Start condition:
+
+- Runtime daemon health/status contracts are stable enough to report progress,
+  pressure, stale data, and maintenance without reducing daemon scope.
 
 Scope:
 
@@ -178,9 +326,19 @@ Exit proof:
   fallback, maintenance running/failed, and first-run setup;
 - production-corpus convergence report after deployment through Sinnix.
 
+Handoff to next wave:
+
+- Distribution docs can describe real service behavior and operational states,
+  not source-checkout-only development assumptions.
+
 ### Wave 7 - Assurance, Docs, And Distribution
 
 Owner issues: #865, #952, #953, #958, #997, #998, #594, #590.
+
+Start condition:
+
+- Enough runtime reader/workbench behavior exists that screenshots, packaging,
+  and proof reports document product reality rather than intended designs.
 
 Scope:
 
@@ -201,6 +359,18 @@ Exit proof:
 - package/build checks when #953 changes distribution surfaces;
 - issue/PR acceptance matrix marking each MK3 row implemented, deferred to a
   precise child issue, or rejected with rationale.
+
+## Backlog Hygiene Rules
+
+- Do not close a broad tracker because a shell exists. Close only when every
+  row is implemented, split to a named child issue, or explicitly rejected.
+- Do not add new MK3-only planning docs unless the same PR folds the actionable
+  sequence back into this file and the owning GitHub issues.
+- Do not leave TODO comments or skipped tests without an issue number.
+- When an issue is realized, close it and update the `Active Lanes` or
+  `Dependency Gates` row that referenced it.
+- When deployment or production validation changes the plan, record concrete
+  dates and observed evidence in the issue or PR, not only in chat.
 
 ## Frozen / Parked
 

--- a/docs/plans/mk3-execution-log.md
+++ b/docs/plans/mk3-execution-log.md
@@ -1,0 +1,96 @@
+# MK3 Execution Log And Agent Coordination Scratchpad
+
+This file is the durable coordination scratchpad for MK3 and daemon-workbench
+execution. It is intentionally practical: use it to record active slices,
+subagent lanes, test choices, resource constraints, and handoff evidence. Issue
+bodies remain the source of acceptance criteria; this log records execution
+state and cross-agent coordination.
+
+## Current Coordination State
+
+Updated: 2026-05-15
+
+| Lane | Issue owners | Status | Next action | Verification lane |
+|------|--------------|--------|-------------|-------------------|
+| Runtime convergence and host proof | #845, #996, #999, #829, #869 | Ready for deployment/proof slice | Ensure packaged daemon is latest through Sinnix, run real archive convergence, record residual workload | service status, daemon logs, real archive convergence report, targeted daemon tests |
+| Reader contract spine | #859, #873, #839, #864, #1022, #1041, #1027 | Ready to start | Define TargetRef/message anchors and typed reader envelopes | daemon HTTP contract tests, CLI/MCP/API parity tests, privacy tests |
+| Reader evidence shell | #848, #865, #956, #993 | Blocked on enough contract stability for full UI, but evidence harness can advance | Expand synthetic reader DOM/browser smoke toward MK3 states | `pytest tests/unit/daemon/test_web_reader.py`, future browser lane, `devtools verify --quick` |
+| Paste/attachment/provenance | #839, #864, #848, #993 | Blocked on message envelope/provenance vocabulary | Implement paste-span projection MVP after contract spine | focused storage/payload tests, daemon API tests, visual state tests |
+| Topology/workspace | #866, #993, #848, #865 | Substrate can start once source identity is stable | Materialize topology edges before graph UI | topology storage tests, parser fixtures, visual graph states |
+| User state/advanced panels | #867, #993, #1019, #995 | Blocked on TargetRef/query serialization | Add TargetRef-based marks/annotations first | user-state CRUD tests, content-hash exclusion tests, saved-view roundtrip tests |
+| Verification throughput | #1026, #997, #998, #594, #590, #1012 | Ready to start independently | Add affected-test workflow and reduce outlier runtime | `devtools verify --affected --skip-slow`, durations capture, focused regression tests |
+
+## Subagent Parallelization Model
+
+Use subagents when the work can be split by owned files and verified without
+waiting on another agent's next line of code. Each subagent should comment on
+its issue with scope before implementation and commit every successful
+milestone in its branch/worktree.
+
+| Subagent lane | Best for | Owns | Avoids | First check |
+|---------------|----------|------|--------|-------------|
+| Contract worker | TargetRef, reader payloads, API envelopes | `polylogue/surfaces/`, `polylogue/daemon/http.py`, `polylogue/archive/query/`, daemon/API tests | Visual harness and CSS-heavy reader layout | `pytest tests/unit/daemon/ -q -k "api or reader or conversation"` |
+| Source/provenance worker | Typed source fields, provider-meta graduation, Antigravity source shape | parsers, archive models, schema/provider docs, provenance tests | Reader JS/layout and user-state tables | parser fixture tests plus schema roundtrip |
+| Visual evidence worker | Synthetic reader fixture, DOM/browser smoke, evidence manifests | `tests/unit/daemon/test_web_reader.py`, possible `tests/visual/`, `devtools/lab_scenario.py`, visual docs | Storage schema and archive semantics | targeted reader smoke lane |
+| Topology worker | topology edge DDL, ingest repair, topology operations | storage DDL, ingest enrichment, archive operations, topology tests | Reader graph UI until read model exists | `pytest tests/unit/storage/test_session_topology.py -q` or new equivalent |
+| User-state worker | marks, annotations, saved views, recall packs | user-state DDL/repository/API, daemon endpoints, user-state tests | topology schema and reader layout | targeted user-state storage/API tests |
+| Verification worker | affected tests, proof routing, slow-test reduction | `devtools/verify.py`, test config, proof manifests | feature semantics | `devtools verify --quick`, targeted pytest duration captures |
+| Packaging/deployment worker | Sinnix input, Nix package/service, deployment docs | Sinnix flake/module files, packaging docs, daemon service evidence | Polylogue runtime changes unless needed for packaging | `nix flake check`/targeted Nix build plus service smoke |
+
+Serialise work when two lanes must edit the same shared files:
+
+- `polylogue/daemon/http.py`: contract, user-state, and reader evidence lanes.
+- storage DDL/schema bootstrap: topology, user-state, source/provenance lanes.
+- `docs/execution-plan.md`: one planning owner at a time.
+- generated docs: run render commands after all doc edits in a branch.
+
+## Verification Economy
+
+Default inner loop:
+
+1. Run the narrow test for the touched subsystem.
+2. Run static/generated checks once the slice is coherent.
+3. Run `devtools verify --quick` before push.
+4. Run full `devtools verify` before PR readiness when the PR changes runtime
+   semantics, unless the PR explicitly records why a focused gate is sufficient.
+
+Resource rules:
+
+- Do not run full pytest repeatedly while the host is under IO pressure or low
+  memory. Use focused tests and `devtools verify --quick` until the branch is
+  near merge.
+- Prefer `devtools verify --affected --skip-slow` for small changes once the
+  affected-test workflow is implemented.
+- For browser/visual lanes, keep fast DOM/contract smoke separate from the
+  heavier browser screenshot lane.
+- For schema/storage changes, run focused storage/parser tests before broad
+  verification; OOM or timeout evidence should become an issue comment, not a
+  silent retry loop.
+- For packaging/deployment changes, run Nix/service checks after code tests so
+  failures are easier to attribute.
+
+## Execution Entries
+
+### 2026-05-15 - MK3 design pack dissolved into tracker
+
+Outcome:
+
+- `docs/design/mk3/` committed as source evidence.
+- `docs/execution-plan.md` now owns MK3 sequencing through active lanes,
+  dependency gates, PR candidates, and wave handoffs.
+- MK3 issue anchors added to #848, #865, #993, #866, #867, #957, #859, #839,
+  #864, and #956.
+
+Verification:
+
+- `devtools render-docs-surface --check`
+- `devtools render-all --check`
+- `devtools verify --quick`
+- GitHub checks on #1043
+
+Next:
+
+- Use the near-term PR candidates in `docs/execution-plan.md` to dispatch
+  non-overlapping workers.
+- Keep this log updated when a lane starts, blocks, hands off, or changes
+  verification strategy.

--- a/docs/plans/mk3-execution-log.md
+++ b/docs/plans/mk3-execution-log.md
@@ -27,6 +27,19 @@ waiting on another agent's next line of code. Each subagent should comment on
 its issue with scope before implementation and commit every successful
 milestone in its branch/worktree.
 
+Do not default to worktrees. Use the lightest coordination mode that preserves
+clarity:
+
+- **Same-context helper**: read-only research, issue-thread synthesis, test
+  failure classification, review of a proposed patch. The main agent owns all
+  writes.
+- **Same-branch serialized worker**: small implementation slice with disjoint
+  files, reviewed and committed by the main agent before another worker touches
+  adjacent files.
+- **Worktree worker**: long-running or mechanically large implementation that
+  needs independent commits, or any slice whose write set would block the main
+  checkout for too long.
+
 | Subagent lane | Best for | Owns | Avoids | First check |
 |---------------|----------|------|--------|-------------|
 | Contract worker | TargetRef, reader payloads, API envelopes | `polylogue/surfaces/`, `polylogue/daemon/http.py`, `polylogue/archive/query/`, daemon/API tests | Visual harness and CSS-heavy reader layout | `pytest tests/unit/daemon/ -q -k "api or reader or conversation"` |
@@ -43,6 +56,27 @@ Serialise work when two lanes must edit the same shared files:
 - storage DDL/schema bootstrap: topology, user-state, source/provenance lanes.
 - `docs/execution-plan.md`: one planning owner at a time.
 - generated docs: run render commands after all doc edits in a branch.
+
+## Autonomous Execution Launch Checklist
+
+Before starting an autonomous execution wave, write a short entry below with:
+
+- target wave and issue owner;
+- chosen coordination mode for each worker;
+- owned files and avoided files;
+- expected first commit or handoff artifact;
+- first focused test for each worker;
+- broad gate to run once the wave is assembled.
+
+Default launch shape:
+
+1. Same-context helper summarizes issue comments and existing code paths.
+2. Main agent chooses the first blocking implementation slice.
+3. Same-branch serialized workers handle small disjoint edits when useful.
+4. Worktree workers are reserved for topology/schema, verification tooling, or
+   packaging/deployment branches that can progress independently.
+5. Main agent integrates, runs focused checks, updates this log, then escalates
+   to `devtools verify --quick` and PR checks.
 
 ## Verification Economy
 


### PR DESCRIPTION
## Summary

Make the MK3 execution plan operational: add live lanes, dependency gates, PR-sized candidates, subagent parallelization rules, verification-economy guidance, and a tracked execution-log scratchpad.

## Problem

The previous plan correctly folded MK3 into the existing backlog, but it was still too easy for agents to treat the waves as broad aspirations. It did not clearly say which work can start now, which gates block later work, how to split subagents safely, or which tests to run first to avoid wasting RAM and wallclock time.

## Solution

- Replace the loose in-flight/queued section with active lanes tied to live issue owners and next artifacts.
- Add dependency gates for typed provenance, shared read envelopes, visual evidence, topology, user state, runtime deployment proof, and faster verification.
- Add near-term PR candidates with owner issues, likely files, and acceptance proof.
- Add parallel execution rules that name good worker lanes and shared files that require serialization.
- Add verification-economy rules: narrow tests first, quick gate before push, full gate at runtime merge readiness, avoid repeated full pytest during IO/memory pressure.
- Add `docs/plans/mk3-execution-log.md` as the durable coordination scratchpad for subagent lanes, current state, test choices, and handoffs.

## Verification

- `devtools render-all --check` -> sync OK / site cache matches sources
- `devtools verify --quick` -> exit_code 0, 16.94s before commit
- pre-push `devtools verify --quick` -> exit_code 0, 16.98s on `278b3e62`
