### PR TITLE
test: exercise reader query smoke

### DIFF
--- a/docs/plans/mk3-execution-log.md
+++ b/docs/plans/mk3-execution-log.md
@@ -185,3 +185,39 @@ Verification:
 - `pytest -q tests/unit/devtools/test_topology_projection_witness.py`
 - `devtools verify --quick`
 - `devtools verify --affected --skip-slow`
+
+### 2026-05-15 - Wave 1 reader query smoke closure
+
+Target:
+
+- #865 reader smoke follow-up adjacent to #859 TargetRef contracts.
+- Replace skipped query/FTS assertions with executable search and no-results
+  reader checks.
+
+Coordination:
+
+- Main branch: `feature/test/reader-query-smoke`.
+- Serialized same-branch implementation; no helper needed because the editable
+  surface is confined to reader smoke, shared search-match payloads, and the
+  daemon search-hit envelope.
+
+Outcome:
+
+- Seed the synthetic reader archive with the message FTS virtual table/triggers
+  so query endpoints exercise the same readiness path as runtime archives.
+- Unskipped query facets and no-result query smoke tests.
+- Added positive `/api/conversations?query=...` assertions for conversation
+  target refs and match-level message target refs/anchors/actions.
+- Documented the now-realized query smoke coverage in `docs/visual-evidence.md`.
+
+First gates:
+
+- `pytest -q tests/unit/daemon/test_web_reader.py -k "query or search"`
+- `pytest -q tests/unit/daemon/test_web_reader.py`
+
+Verification:
+
+- `pytest -q tests/unit/daemon/test_web_reader.py -k "query or search"`
+- `pytest -q tests/unit/daemon/test_web_reader.py`
+- `devtools verify --quick`
+- `pytest -q tests/unit/daemon/`

--- a/docs/visual-evidence.md
+++ b/docs/visual-evidence.md
@@ -32,7 +32,7 @@ dependency: the lane uses Python's standard `http.server` and
 
 | Reader state | Artefact id | Routes exercised |
 |---|---|---|
-| List / search | `polylogue.local_reader.search` | `/`, `/api/conversations`, `/api/facets`, `/api/facets?provider=...` |
+| List / search | `polylogue.local_reader.search` | `/`, `/api/conversations`, `/api/conversations?query=...`, `/api/facets`, `/api/facets?provider=...`, `/api/facets?query=...` |
 | Detail / conversation | `polylogue.local_reader.conversation` | `/api/conversations/{id}`, `/api/conversations/{id}/messages` |
 | Empty archive | — | `/api/conversations`, `/api/facets` |
 | Privacy boundary | — | `/`, `/api/facets`, `/api/conversations`, `/api/conversations/{id}`, `/api/conversations/{id}/messages` (auditing for absolute local paths) |
@@ -56,9 +56,10 @@ palette screenshots under `docs/design/mk3/screens/`.
   envelope when `?query=` is supplied. Conversation rows, detail headers,
   and messages carry stable `target_ref` objects, deterministic reader
   anchors, and per-target action availability with explicit disabled
-  reasons for actions the current reader cannot perform yet. Facets carry
-  the `scoped_to_query`/`providers` shape and honour the `?provider=`
-  filter contract.
+  reasons for actions the current reader cannot perform yet. Query search
+  hits also carry both conversation-level targets and match-level message
+  targets. Facets carry the `scoped_to_query`/`providers` shape and honour
+  the `?provider=` and `?query=` filter contracts.
 - **Empty / no-results state.** Distinguishes "archive is empty" from
   "query matched no rows", a discrimination the reader UI is required to
   expose.
@@ -93,8 +94,7 @@ palette screenshots under `docs/design/mk3/screens/`.
 
 ## Follow-ups
 
-Two FTS-dependent assertions in the harness are currently `@skip`ped
-with explicit references to a #865 follow-up: query-based facets and
-"no results for query" both require the FTS index to be primed on the
-synthetic archive. Adding the priming is straightforward but out of
-scope for the harness scaffolding.
+The fast lane is still DOM/contract-only. The MK3 follow-up in #865 should add
+a separate browser-backed screenshot lane for the richer reader, stack,
+topology, attachment, and degraded-state matrix rather than replacing this
+unit-speed smoke.

--- a/polylogue/daemon/http.py
+++ b/polylogue/daemon/http.py
@@ -591,6 +591,14 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
             flags = _build_flags_from_conversation(hit.summary)
             conversation_id = str(hit.conversation_id)
             target_ref = TargetRefPayload.conversation(conversation_id)
+            if hit.message_id is not None:
+                match_target_ref = TargetRefPayload.message(conversation_id=conversation_id, message_id=hit.message_id)
+                match_anchor = reader_anchor("message", hit.message_id)
+                match_actions = reader_message_actions()
+            else:
+                match_target_ref = target_ref
+                match_anchor = reader_anchor("conversation", conversation_id)
+                match_actions = reader_conversation_actions()
             hit_dicts.append(
                 {
                     "id": conversation_id,
@@ -613,6 +621,9 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
                         "rank": hit.rank,
                         "retrieval_lane": hit.retrieval_lane,
                         "match_surface": hit.match_surface,
+                        "target_ref": _dump_target_ref(match_target_ref),
+                        "anchor": match_anchor,
+                        "actions": _dump_actions(match_actions),
                         "message_id": hit.message_id,
                         "snippet": hit.snippet,
                         "score": hit.score,

--- a/polylogue/surfaces/payloads.py
+++ b/polylogue/surfaces/payloads.py
@@ -399,6 +399,9 @@ class ConversationSearchMatchPayload(SurfacePayloadModel):
     rank: int
     retrieval_lane: str
     match_surface: str
+    target_ref: TargetRefPayload | None = None
+    anchor: str | None = None
+    actions: dict[str, ReaderActionAvailabilityPayload] = Field(default_factory=dict)
     message_id: str | None = None
     snippet: str | None = None
     score: float | None = None
@@ -419,6 +422,14 @@ class ConversationSearchHitPayload(SurfacePayloadModel):
         *,
         message_count: int | None = None,
     ) -> ConversationSearchHitPayload:
+        if hit.message_id is not None:
+            target_ref = TargetRefPayload.message(conversation_id=hit.conversation_id, message_id=hit.message_id)
+            anchor = reader_anchor("message", hit.message_id)
+            actions = reader_message_actions()
+        else:
+            target_ref = TargetRefPayload.conversation(hit.conversation_id)
+            anchor = reader_anchor("conversation", hit.conversation_id)
+            actions = reader_conversation_actions()
         return cls(
             conversation=ConversationSummaryPayload.from_summary(
                 hit.summary,
@@ -428,6 +439,9 @@ class ConversationSearchHitPayload(SurfacePayloadModel):
                 rank=hit.rank,
                 retrieval_lane=hit.retrieval_lane,
                 match_surface=hit.match_surface,
+                target_ref=target_ref,
+                anchor=anchor,
+                actions=actions,
                 message_id=hit.message_id,
                 snippet=hit.snippet,
                 score=hit.score,

--- a/tests/unit/daemon/test_web_reader.py
+++ b/tests/unit/daemon/test_web_reader.py
@@ -76,12 +76,13 @@ def _running_server(
 def _seed_empty_schema(workspace: dict[str, Path]) -> None:
     import sqlite3
 
-    from polylogue.storage.sqlite.schema_ddl_archive import ARCHIVE_STORAGE_DDL
+    from polylogue.storage.sqlite.schema_ddl_archive import ARCHIVE_STORAGE_DDL, MESSAGE_FTS_DDL
 
     db = _archive_db_path(workspace)
     db.parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(str(db))
     conn.executescript(ARCHIVE_STORAGE_DDL)
+    conn.executescript(MESSAGE_FTS_DDL)
     conn.commit()
     conn.close()
 
@@ -90,12 +91,13 @@ def _seed_test_db(workspace: dict[str, Path]) -> None:
     """Seed a synthetic archive with three single-message conversations."""
     import sqlite3
 
-    from polylogue.storage.sqlite.schema_ddl_archive import ARCHIVE_STORAGE_DDL
+    from polylogue.storage.sqlite.schema_ddl_archive import ARCHIVE_STORAGE_DDL, MESSAGE_FTS_DDL
 
     db = _archive_db_path(workspace)
     db.parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(str(db))
     conn.executescript(ARCHIVE_STORAGE_DDL)
+    conn.executescript(MESSAGE_FTS_DDL)
     for cid, prov, title in [
         ("c1", "claude-code", "Claude Code session about authentication"),
         ("c2", "chatgpt", "ChatGPT debugging conversation"),
@@ -193,15 +195,31 @@ class TestReaderSearchState:
         assert payload["providers"] == {"chatgpt": 1}
         assert "claude-code" not in payload["providers"]
 
-    @pytest.mark.skip(
-        reason="query-based facets need FTS index priming; tracked separately for full reader smoke (#865 follow-up)"
-    )
     def test_facets_query_filter_scopes_counts(self, workspace_env: dict[str, Path]) -> None:
         with _running_server(workspace_env) as (_, base_url):
             payload = _get_json(base_url, "/api/facets?query=Hello")
         assert isinstance(payload, dict)
         assert payload["scoped_to_query"] is True
         assert payload["total_conversations"] == 3
+
+    def test_query_search_envelope_carries_hit_target_refs(self, workspace_env: dict[str, Path]) -> None:
+        with _running_server(workspace_env) as (_, base_url):
+            payload = _get_json(base_url, "/api/conversations?query=Hello")
+        assert isinstance(payload, dict)
+        assert payload["total"] == 3
+        assert len(payload["hits"]) == 3
+        hit = next(item for item in payload["hits"] if item["id"] == "c1")
+        assert hit["target_ref"]["identity_key"] == "conversation:c1"
+        assert hit["anchor"] == "conversation-c1"
+        assert hit["match"]["target_ref"] == {
+            "target_type": "message",
+            "target_id": "m-c1",
+            "conversation_id": "c1",
+            "message_id": "m-c1",
+            "identity_key": "message:c1:m-c1",
+        }
+        assert hit["match"]["anchor"] == "message-m-c1"
+        assert hit["match"]["actions"]["copy_text"]["enabled"] is True
 
 
 # ---------------------------------------------------------------------------
@@ -271,7 +289,6 @@ class TestReaderDegradedStates:
         assert payload["total_conversations"] == 0
         assert payload["providers"] == {}
 
-    @pytest.mark.skip(reason="query route needs FTS index priming on the synthetic archive; tracked as #865 follow-up")
     def test_no_results_query_is_distinguishable_from_empty_archive(self, workspace_env: dict[str, Path]) -> None:
         with _running_server(workspace_env) as (_, base_url):
             payload = _get_json(base_url, "/api/conversations?query=nonexistent_term_xyz")


### PR DESCRIPTION
## Summary

Turns the reader query smoke from skipped assertions into executable coverage. The synthetic reader archive now includes message FTS, query facets run, no-result query state is distinguished from an empty archive, and search-hit envelopes pin both conversation-level and match-level target references.

## Problem

The fast reader smoke lane still had two skipped query assertions because its synthetic archive did not create the message FTS virtual table/triggers that runtime search readiness requires. That meant `/api/conversations?query=...` and `/api/facets?query=...` were not actually covered by the smoke lane after the TargetRef contract landed.

## Solution

- Seed `MESSAGE_FTS_DDL` in both populated and empty reader smoke archives.
- Unskip query-facet and no-results query tests.
- Add a positive `/api/conversations?query=Hello` test that asserts `hits`, conversation target refs, and match-level message target refs/anchors/actions.
- Add match-level target refs, anchors, and action availability to shared search-match payloads and daemon search-hit JSON.
- Refresh visual-evidence docs and the MK3 execution log to reflect the realized query coverage.

Ref #865
Ref #859

## Verification

- `pytest -q tests/unit/daemon/test_web_reader.py -k "query or search"` → 18 passed
- `pytest -q tests/unit/daemon/test_web_reader.py` → 37 passed
- `pytest -q tests/unit/daemon/` → 263 passed
- `devtools verify --quick` → exit 0
- pre-push `devtools verify --quick` → exit 0
