### PR TITLE
test: add reader visual DOM evidence

### DIFF
--- a/docs/plans/mk3-execution-log.md
+++ b/docs/plans/mk3-execution-log.md
@@ -221,3 +221,60 @@ Verification:
 - `pytest -q tests/unit/daemon/test_web_reader.py`
 - `devtools verify --quick`
 - `pytest -q tests/unit/daemon/`
+
+### 2026-05-15 - Wave 2 reader visual DOM evidence launch
+
+Target:
+
+- #865 visual/DOM evidence lane for the MK3 reader, consumed by #848.
+- First executable visual-evidence slice: browserless DOM and API evidence
+  envelopes against the daemon-served reader with synthetic archive data.
+
+Coordination:
+
+- Main branch: `feature/test/reader-visual-dom-evidence`.
+- Serialized implementation. The new `tests/visual/` package, route support,
+  and docs touch a compact shared surface; no worktree worker is useful here.
+
+Owned files:
+
+- `polylogue/daemon/http.py`
+- `tests/visual/`
+- `docs/visual-evidence.md`
+- `docs/plans/mk3-execution-log.md`
+
+Avoided files:
+
+- Browser binary packaging.
+- Full web-shell product redesign.
+- Real archive fixtures or screenshots containing operator data.
+- Storage schema beyond synthetic test seeding.
+
+First gates:
+
+- `pytest -q tests/visual`
+- `pytest -q tests/unit/daemon/test_web_reader.py`
+- `devtools verify --quick`
+
+Outcome:
+
+- Added `tests/visual/` as a dedicated browserless visual/DOM evidence lane.
+- The lane boots the production daemon HTTP server against synthetic archives
+  and writes JSON evidence envelopes for search/list, conversation/detail,
+  query/no-results/facets, empty archive, degraded FTS, and privacy safety.
+- Added `/c/{id}` web-shell serving so conversation deep links can be verified
+  directly without a browser rewrite.
+- Normalized daemon message `message_type` serialization to stable enum values
+  in reader detail and paginated message endpoints.
+- Documented the fast lane split and the remaining browser screenshot gate in
+  `docs/visual-evidence.md`.
+
+Verification:
+
+- `pytest -q tests/visual`
+- `pytest -q tests/unit/daemon/test_web_reader.py`
+- `ruff format --check polylogue/daemon/http.py tests/visual`
+- `ruff check polylogue/daemon/http.py tests/visual`
+- `mypy tests/visual polylogue/daemon/http.py`
+- `devtools verify --quick`
+- `devtools verify --affected --skip-slow`

--- a/docs/visual-evidence.md
+++ b/docs/visual-evidence.md
@@ -1,13 +1,18 @@
 # Reader Visual Smoke Lane
 
-Polylogue's daemon-served local web reader is exercised by an automated
-DOM/contract smoke lane committed in
-[`tests/unit/daemon/test_web_reader.py`](../tests/unit/daemon/test_web_reader.py).
-The lane boots the production `DaemonAPIHTTPServer` against a synthetic
-on-disk archive and drives the live HTTP surface — it never reads the
-operator's real archive, never serves committed sample content, and
-never makes pixel-diff assertions that would freeze aesthetic
-iteration.
+Polylogue's daemon-served local web reader is exercised by two automated
+smoke lanes:
+
+- [`tests/unit/daemon/test_web_reader.py`](../tests/unit/daemon/test_web_reader.py)
+  owns fast endpoint and envelope contracts.
+- [`tests/visual/test_reader_dom_smoke.py`](../tests/visual/test_reader_dom_smoke.py)
+  owns browserless DOM/evidence assertions for the daemon-served shell and
+  reader states.
+
+Both lanes boot the production `DaemonAPIHTTPServer` against a synthetic
+on-disk archive and drive the live HTTP surface — neither reads the operator's
+real archive, serves committed private sample content, or makes pixel-diff
+assertions that would freeze aesthetic iteration.
 
 This page documents the harness so #848, #859, #865, and the design packs
 have a stable reference for what the lane covers and how to run it. MK3 is the
@@ -21,21 +26,23 @@ From the devshell:
 
 ```bash
 nix develop -c pytest tests/unit/daemon/test_web_reader.py
+nix develop -c pytest tests/visual
 ```
 
-The suite is part of the standard unit run — `devtools verify` exercises
-it end to end. There is no separate browser binary or Playwright
-dependency: the lane uses Python's standard `http.server` and
-`urllib.request` against the real `DaemonAPIHTTPServer`.
+Both suites are part of the standard non-integration test run. There is no
+browser binary or Playwright dependency in these fast lanes: they use Python's
+standard `http.server`, `urllib.request`, and `html.parser` against the real
+`DaemonAPIHTTPServer`.
 
 ## Coverage
 
 | Reader state | Artefact id | Routes exercised |
 |---|---|---|
 | List / search | `polylogue.local_reader.search` | `/`, `/api/conversations`, `/api/conversations?query=...`, `/api/facets`, `/api/facets?provider=...`, `/api/facets?query=...` |
-| Detail / conversation | `polylogue.local_reader.conversation` | `/api/conversations/{id}`, `/api/conversations/{id}/messages` |
+| Detail / conversation | `polylogue.local_reader.conversation` | `/c/{id}`, `/api/conversations/{id}`, `/api/conversations/{id}/messages`, `/api/conversations/{id}/raw` |
 | Empty archive | — | `/api/conversations`, `/api/facets` |
-| Privacy boundary | — | `/`, `/api/facets`, `/api/conversations`, `/api/conversations/{id}`, `/api/conversations/{id}/messages` (auditing for absolute local paths) |
+| Degraded FTS | `polylogue.local_reader.degraded` | `/api/conversations?query=...` with message FTS absent |
+| Privacy boundary | — | `/`, `/c/{id}`, `/api/facets`, `/api/conversations`, `/api/conversations/{id}`, `/api/conversations/{id}/messages` (auditing for absolute local paths) |
 | Auth boundary | — | `/api/conversations` with/without `Authorization: Bearer ...` |
 
 The artefact ids match the names referenced in the design packs and in #848 so
@@ -45,11 +52,15 @@ palette screenshots under `docs/design/mk3/screens/`.
 
 ## What the lane checks
 
-- **Page structure.** The HTML payload at `/` contains the five region
+- **Page structure.** The HTML payloads at `/` and `/c/{id}` contain the five region
   hooks (`renderSidebarState`, `renderConversations`, `renderFacets`,
   `renderMain`, `renderInspector`) the JS bundle hydrates. A regression
   that drops a region fails here loudly without depending on pixel
   differences.
+- **Evidence envelopes.** The visual DOM lane writes and reads JSON evidence
+  manifests under pytest temp directories. Each manifest records artifact id,
+  route, fixture id, command, evidence kind, checked structure, private-path
+  status, and the explicit follow-up for the heavier browser screenshot gate.
 - **Envelope shapes.** Every reader-facing JSON envelope is asserted by
   shape: `items`/`messages`/`raw_artifacts` plus `total` for the
   paginated list/detail surfaces, and the search route's `hits`/`total`
@@ -87,8 +98,8 @@ palette screenshots under `docs/design/mk3/screens/`.
   fixtures — the synthetic seeder produces three single-message
   conversations with stable ids so the envelope assertions stay
   reproducible.
-- No browser-binary requirement. The MK3 follow-up in #865 should add a
-  separate browser-backed screenshot lane for the richer reader, stack,
+- No browser-binary requirement in the fast lanes. A later #865 slice should
+  add a separate browser-backed screenshot lane for the richer reader, stack,
   topology, attachment, and degraded-state matrix rather than replacing this
   fast DOM/contract smoke.
 

--- a/polylogue/daemon/http.py
+++ b/polylogue/daemon/http.py
@@ -54,6 +54,13 @@ def _dump_actions(actions: Mapping[str, ReaderActionAvailabilityPayload]) -> dic
     return {name: availability.model_dump(mode="json", exclude_none=True) for name, availability in actions.items()}
 
 
+def _message_type_value(message: object) -> str:
+    message_type = getattr(message, "message_type", "")
+    if hasattr(message_type, "value"):
+        return str(message_type.value)
+    return str(message_type)
+
+
 def daemon_safe_handler(fn: Callable[..., Any]) -> Callable[..., Any]:
     """Decorator that discriminates PolylogueError types to HTTP status codes.
 
@@ -318,7 +325,7 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
     def _dispatch_get(self, path: list[str], params: dict[str, list[str]]) -> None:
         """Dispatch GET requests via route table."""
         # Web shell is the only unauthenticated endpoint (localhost only).
-        if path == [""]:
+        if path == [""] or (len(path) == 2 and path[0] == "c" and bool(path[1])):
             self._serve_web_shell()
             return
 
@@ -688,7 +695,7 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
                     "anchor": reader_anchor("message", msg.id),
                     "actions": _dump_actions(reader_message_actions()),
                     "timestamp": msg.timestamp.isoformat() if msg.timestamp else None,
-                    "message_type": str(getattr(msg, "message_type", "")),
+                    "message_type": _message_type_value(msg),
                     "word_count": msg.word_count,
                     "has_tool_use": bool(msg.has_tool_use) if hasattr(msg, "has_tool_use") else False,
                     "has_thinking": bool(msg.has_thinking) if hasattr(msg, "has_thinking") else False,
@@ -777,7 +784,7 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
                     "anchor": reader_anchor("message", msg.id),
                     "actions": _dump_actions(reader_message_actions()),
                     "timestamp": msg.timestamp.isoformat() if msg.timestamp else None,
-                    "message_type": str(getattr(msg, "message_type", "")),
+                    "message_type": _message_type_value(msg),
                     "word_count": msg.word_count,
                 }
                 for msg in messages

--- a/tests/visual/__init__.py
+++ b/tests/visual/__init__.py
@@ -1,0 +1,1 @@
+"""Executable visual/DOM smoke lanes for reader surfaces."""

--- a/tests/visual/conftest.py
+++ b/tests/visual/conftest.py
@@ -1,0 +1,267 @@
+"""Shared fixtures for reader visual/DOM evidence tests."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import threading
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from html.parser import HTMLParser
+from http.server import HTTPServer
+from pathlib import Path
+from typing import cast
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+import pytest
+
+POLYLOGUE_LOCAL_PATH_PREFIXES = ("/home/", "/Users/", "/realm/", "/var/", "/etc/")
+
+
+@dataclass(frozen=True)
+class ReaderWorkspace:
+    data_root: Path
+    archive_root: Path
+    state_dir: Path
+
+    def as_env(self) -> dict[str, Path]:
+        return {
+            "data_root": self.data_root,
+            "archive_root": self.archive_root,
+            "state_dir": self.state_dir,
+        }
+
+
+class DOMSummary(HTMLParser):
+    """Minimal DOM summary for browserless structural assertions."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.ids: set[str] = set()
+        self.classes: set[str] = set()
+        self.scripts = 0
+        self.styles = 0
+        self.text_parts: list[str] = []
+        self.meta_viewport = False
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        attr_map = {name: value or "" for name, value in attrs}
+        if tag == "script":
+            self.scripts += 1
+        if tag == "style":
+            self.styles += 1
+        if tag == "meta" and attr_map.get("name") == "viewport":
+            self.meta_viewport = True
+        if "id" in attr_map:
+            self.ids.add(attr_map["id"])
+        for cls in attr_map.get("class", "").split():
+            self.classes.add(cls)
+
+    def handle_data(self, data: str) -> None:
+        text = data.strip()
+        if text:
+            self.text_parts.append(text)
+
+    @property
+    def text(self) -> str:
+        return " ".join(self.text_parts)
+
+
+def parse_dom(html: str) -> DOMSummary:
+    parser = DOMSummary()
+    parser.feed(html)
+    return parser
+
+
+def assert_no_private_paths(text: str, *, context: str) -> None:
+    for prefix in POLYLOGUE_LOCAL_PATH_PREFIXES:
+        assert prefix not in text, f"{context} leaked absolute local path with prefix {prefix!r}"
+
+
+def write_evidence_manifest(
+    path: Path,
+    *,
+    artifact_id: str,
+    route: str,
+    fixture_id: str,
+    checks: dict[str, object],
+) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "schema_version": 1,
+        "artifact_id": artifact_id,
+        "command": "pytest -q tests/visual",
+        "fixture_id": fixture_id,
+        "route": route,
+        "evidence_kind": "browserless-dom",
+        "generated_path": path.name,
+        "checks": checks,
+        "manual_review_required": False,
+        "browser_gate_followup": "#865-playwright-screenshot-lane",
+    }
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+    loaded = cast(dict[str, object], json.loads(path.read_text(encoding="utf-8")))
+    assert loaded["artifact_id"] == artifact_id
+    assert loaded["checks"] == checks
+    return loaded
+
+
+@pytest.fixture
+def reader_workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> ReaderWorkspace:
+    workspace = ReaderWorkspace(
+        data_root=tmp_path / "data",
+        archive_root=tmp_path / "archive",
+        state_dir=tmp_path / "state",
+    )
+    monkeypatch.setenv("XDG_DATA_HOME", str(workspace.data_root))
+    monkeypatch.setenv("XDG_STATE_HOME", str(workspace.state_dir))
+    monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(workspace.archive_root))
+    monkeypatch.setenv("POLYLOGUE_SCHEMA_VALIDATION", "off")
+    return workspace
+
+
+def archive_db_path(workspace: ReaderWorkspace) -> Path:
+    return workspace.data_root / "polylogue" / "polylogue.db"
+
+
+def seed_reader_archive(
+    workspace: ReaderWorkspace,
+    *,
+    conversations: bool = True,
+    message_fts: bool = True,
+) -> None:
+    from polylogue.storage.sqlite.schema_ddl_archive import ARCHIVE_STORAGE_DDL, MESSAGE_FTS_DDL
+
+    db = archive_db_path(workspace)
+    db.parent.mkdir(parents=True, exist_ok=True)
+    if db.exists():
+        db.unlink()
+    conn = sqlite3.connect(str(db))
+    conn.executescript(ARCHIVE_STORAGE_DDL)
+    if message_fts:
+        conn.executescript(MESSAGE_FTS_DDL)
+    if conversations:
+        records = [
+            (
+                "reader-c1",
+                "claude-code",
+                "MK3 reader target contract",
+                {"repo": "polylogue", "cwd_display": "project/polylogue", "model": "claude-sonnet"},
+                [
+                    ("reader-c1-m1", "user", "Hello reader, show the target reference contract.", "message", 0, 0, 0),
+                    (
+                        "reader-c1-m2",
+                        "assistant",
+                        "The reader exposes stable anchors and action states.",
+                        "message",
+                        0,
+                        0,
+                        0,
+                    ),
+                    (
+                        "reader-c1-m3",
+                        "tool",
+                        "python -m pytest tests/visual\nstatus: passed",
+                        "tool_result",
+                        1,
+                        0,
+                        0,
+                    ),
+                ],
+            ),
+            (
+                "reader-c2",
+                "chatgpt",
+                "No-results smoke seed",
+                {"repo": "polylogue", "cwd_display": "project/polylogue", "model": "gpt"},
+                [("reader-c2-m1", "user", "Facet query and empty state fixture.", "message", 0, 0, 0)],
+            ),
+            (
+                "reader-c3",
+                "claude-ai",
+                "Paste and privacy fixture",
+                {"repo": "polylogue", "cwd_display": "project/polylogue", "model": "claude"},
+                [("reader-c3-m1", "user", "A synthetic paste-like block with safe content.", "message", 0, 0, 1)],
+            ),
+        ]
+        for conv_id, provider, title, provider_meta, messages in records:
+            conn.execute(
+                """
+                INSERT INTO conversations(
+                    conversation_id, provider_name, provider_conversation_id, title,
+                    content_hash, provider_meta, version
+                )
+                VALUES(?, ?, ?, ?, ?, ?, ?)
+                """,
+                (conv_id, provider, f"provider-{conv_id}", title, f"hash-{conv_id}", json.dumps(provider_meta), 1),
+            )
+            for index, (message_id, role, text, message_type, has_tool, has_thinking, has_paste) in enumerate(messages):
+                conn.execute(
+                    """
+                    INSERT INTO messages(
+                        message_id, conversation_id, role, text, sort_key, provider_name,
+                        content_hash, version, word_count, has_tool_use, has_thinking,
+                        has_paste, message_type
+                    )
+                    VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        message_id,
+                        conv_id,
+                        role,
+                        text,
+                        float(index),
+                        provider,
+                        f"hash-{message_id}",
+                        1,
+                        len(text.split()),
+                        has_tool,
+                        has_thinking,
+                        has_paste,
+                        message_type,
+                    ),
+                )
+    conn.commit()
+    conn.close()
+
+
+@contextmanager
+def running_reader_server(
+    workspace: ReaderWorkspace,
+    *,
+    conversations: bool = True,
+    message_fts: bool = True,
+) -> Iterator[tuple[HTTPServer, str]]:
+    from polylogue.daemon.http import DaemonAPIHandler, DaemonAPIHTTPServer
+
+    seed_reader_archive(workspace, conversations=conversations, message_fts=message_fts)
+    server = DaemonAPIHTTPServer(("127.0.0.1", 0), DaemonAPIHandler)
+    server.auth_token = ""
+    server.api_host = "127.0.0.1"
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, name="reader-visual-smoke", daemon=True)
+    thread.start()
+    try:
+        yield server, f"http://127.0.0.1:{port}"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2.0)
+
+
+def get_json(base_url: str, path: str) -> object:
+    req = Request(f"{base_url}{path}")
+    with urlopen(req, timeout=10) as resp:
+        assert resp.status == 200
+        return json.loads(resp.read())
+
+
+def get_text(base_url: str, path: str) -> tuple[int, str, str]:
+    req = Request(f"{base_url}{path}")
+    try:
+        with urlopen(req, timeout=10) as resp:
+            return resp.status, resp.headers.get("Content-Type", ""), resp.read().decode()
+    except HTTPError as exc:
+        body = exc.read().decode() if exc.fp else ""
+        return exc.code, exc.headers.get("Content-Type", ""), body

--- a/tests/visual/test_reader_dom_smoke.py
+++ b/tests/visual/test_reader_dom_smoke.py
@@ -1,0 +1,200 @@
+"""Daemon-served reader visual/DOM smoke evidence (#865)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import cast
+
+from tests.visual.conftest import (
+    ReaderWorkspace,
+    assert_no_private_paths,
+    get_json,
+    get_text,
+    parse_dom,
+    running_reader_server,
+    write_evidence_manifest,
+)
+
+
+def test_reader_search_shell_dom_evidence(reader_workspace: ReaderWorkspace, tmp_path: Path) -> None:
+    with running_reader_server(reader_workspace) as (_, base_url):
+        status, content_type, body = get_text(base_url, "/")
+
+    assert status == 200
+    assert "text/html" in content_type
+    assert len(body) > 20_000
+    assert "https://cdn" not in body
+    assert_no_private_paths(body, context="reader shell HTML")
+
+    dom = parse_dom(body)
+    expected_ids = {
+        "app",
+        "status-strip",
+        "status-dot",
+        "sidebar",
+        "search",
+        "facet-bar",
+        "conv-list",
+        "main",
+        "conv-header",
+        "msg-list",
+        "inspector",
+        "inspector-tabs",
+        "footer",
+        "help-overlay",
+    }
+    assert expected_ids <= dom.ids
+    assert dom.meta_viewport is True
+    assert dom.scripts == 1
+    assert dom.styles == 1
+    for phrase in ("Select a conversation", "Keyboard Shortcuts", "Focus search", "Local"):
+        assert phrase in body
+
+    checks = {
+        "status": status,
+        "content_type": content_type,
+        "html_bytes": len(body.encode()),
+        "required_ids": sorted(expected_ids),
+        "script_tags": dom.scripts,
+        "style_tags": dom.styles,
+        "viewport_meta": dom.meta_viewport,
+        "private_path_safe": True,
+        "runtime_cdn_free": True,
+    }
+    manifest = write_evidence_manifest(
+        tmp_path / "reader-search-dom-evidence.json",
+        artifact_id="polylogue.local_reader.search",
+        route="/",
+        fixture_id="reader-visual-synthetic-v1",
+        checks=checks,
+    )
+    assert manifest["evidence_kind"] == "browserless-dom"
+
+
+def test_reader_conversation_deeplink_and_detail_evidence(reader_workspace: ReaderWorkspace, tmp_path: Path) -> None:
+    with running_reader_server(reader_workspace) as (_, base_url):
+        status, content_type, shell = get_text(base_url, "/c/reader-c1")
+        detail = cast(dict[str, object], get_json(base_url, "/api/conversations/reader-c1"))
+        messages = cast(dict[str, object], get_json(base_url, "/api/conversations/reader-c1/messages"))
+        raw = cast(dict[str, object], get_json(base_url, "/api/conversations/reader-c1/raw"))
+
+    assert status == 200
+    assert "text/html" in content_type
+    assert "getConvIdFromURL" in shell
+    assert_no_private_paths(shell, context="reader /c deeplink shell")
+    assert_no_private_paths(json.dumps(detail), context="reader detail JSON")
+    assert_no_private_paths(json.dumps(messages), context="reader messages JSON")
+
+    target_ref = cast(dict[str, object], detail["target_ref"])
+    assert target_ref["identity_key"] == "conversation:reader-c1"
+    assert detail["anchor"] == "conversation-reader-c1"
+    assert detail["title"] == "MK3 reader target contract"
+
+    message_items = cast(list[dict[str, object]], messages["messages"])
+    assert messages["total"] == 3
+    assert message_items[0]["target_ref"] == {
+        "target_type": "message",
+        "target_id": "reader-c1-m1",
+        "conversation_id": "reader-c1",
+        "message_id": "reader-c1-m1",
+        "identity_key": "message:reader-c1:reader-c1-m1",
+    }
+    assert message_items[2]["message_type"] == "tool_result"
+    tool_actions = cast(dict[str, dict[str, object]], message_items[2]["actions"])
+    assert tool_actions["copy_text"]["enabled"] is True
+
+    assert raw["id"] == "reader-c1"
+    assert "raw_artifacts" in raw
+
+    checks = {
+        "status": status,
+        "content_type": content_type,
+        "shell_bytes": len(shell.encode()),
+        "conversation_target": target_ref["identity_key"],
+        "message_total": messages["total"],
+        "tool_message_present": True,
+        "raw_endpoint_present": True,
+        "private_path_safe": True,
+    }
+    write_evidence_manifest(
+        tmp_path / "reader-conversation-dom-evidence.json",
+        artifact_id="polylogue.local_reader.conversation",
+        route="/c/reader-c1",
+        fixture_id="reader-visual-synthetic-v1",
+        checks=checks,
+    )
+
+
+def test_reader_search_query_no_results_and_facets_evidence(
+    reader_workspace: ReaderWorkspace,
+    tmp_path: Path,
+) -> None:
+    with running_reader_server(reader_workspace) as (_, base_url):
+        query = cast(dict[str, object], get_json(base_url, "/api/conversations?query=Hello"))
+        no_results = cast(dict[str, object], get_json(base_url, "/api/conversations?query=zzzz_no_match"))
+        facets = cast(dict[str, object], get_json(base_url, "/api/facets?query=Hello"))
+
+    assert query["total"] == 1
+    hits = cast(list[dict[str, object]], query["hits"])
+    hit_target = cast(dict[str, object], hits[0]["target_ref"])
+    hit_match = cast(dict[str, object], hits[0]["match"])
+    match_target = cast(dict[str, object], hit_match["target_ref"])
+    assert hit_target["identity_key"] == "conversation:reader-c1"
+    assert match_target["identity_key"] == "message:reader-c1:reader-c1-m1"
+    assert no_results["total"] == 0
+    assert "diagnostics" in no_results
+    assert facets["scoped_to_query"] is True
+    assert facets["providers"] == {"claude-code": 1}
+    assert_no_private_paths(json.dumps(query), context="reader search JSON")
+    assert_no_private_paths(json.dumps(no_results), context="reader no-results JSON")
+    assert_no_private_paths(json.dumps(facets), context="reader query facets JSON")
+
+    write_evidence_manifest(
+        tmp_path / "reader-query-dom-evidence.json",
+        artifact_id="polylogue.local_reader.search.query",
+        route="/api/conversations?query=Hello",
+        fixture_id="reader-visual-synthetic-v1",
+        checks={
+            "query_total": query["total"],
+            "no_results_total": no_results["total"],
+            "diagnostics_present": "diagnostics" in no_results,
+            "facet_scope": facets["scoped_to_query"],
+            "private_path_safe": True,
+        },
+    )
+
+
+def test_reader_empty_and_degraded_evidence(reader_workspace: ReaderWorkspace, tmp_path: Path) -> None:
+    with running_reader_server(reader_workspace, conversations=False) as (_, base_url):
+        empty_list = cast(dict[str, object], get_json(base_url, "/api/conversations"))
+        empty_facets = cast(dict[str, object], get_json(base_url, "/api/facets"))
+
+    with running_reader_server(reader_workspace, conversations=True, message_fts=False) as (_, base_url):
+        degraded_status, _, degraded_body = get_text(base_url, "/api/conversations?query=Hello")
+
+    assert empty_list["total"] == 0
+    assert empty_list["items"] == []
+    assert empty_facets["total_conversations"] == 0
+    assert degraded_status == 503
+    degraded_payload = json.loads(degraded_body)
+    assert degraded_payload["ok"] is False
+    assert degraded_payload["error"] == "DatabaseError"
+    assert "Search index" in degraded_payload["detail"]
+    assert "Traceback" not in degraded_body
+    assert_no_private_paths(json.dumps(empty_list), context="reader empty list JSON")
+    assert_no_private_paths(degraded_body, context="reader degraded JSON")
+
+    write_evidence_manifest(
+        tmp_path / "reader-degraded-dom-evidence.json",
+        artifact_id="polylogue.local_reader.degraded",
+        route="/api/conversations?query=Hello",
+        fixture_id="reader-visual-synthetic-empty-and-degraded-v1",
+        checks={
+            "empty_total": empty_list["total"],
+            "empty_facets_total": empty_facets["total_conversations"],
+            "degraded_status": degraded_status,
+            "sanitized_error": True,
+            "private_path_safe": True,
+        },
+    )


### PR DESCRIPTION
## Summary

Adds the first executable #865 visual-evidence lane for the daemon-served local reader. The new `tests/visual` package boots the real daemon HTTP server against synthetic archives, checks browserless DOM structure and API state, writes evidence envelopes, and covers search/list, conversation/deeplink, query/no-results/facets, empty archive, degraded FTS, and privacy boundaries.

## Problem

The reader had endpoint contract tests, but #865 still lacked a dedicated visual/DOM evidence lane. That left `/c/{id}` shell deep links, evidence-envelope shape, degraded FTS presentation, and private-path safety outside a visual-smoke-oriented test surface. Adding a full browser screenshot gate would require new browser packaging; the fast lane should work first without browser binaries so it can run reliably in the current devshell and standard pytest discovery.

## Solution

- Add `tests/visual/` with synthetic archive seeding, daemon server fixtures, minimal DOM parsing, private-path checks, and evidence-manifest helpers.
- Add DOM/evidence tests for:
  - `polylogue.local_reader.search` at `/`;
  - `polylogue.local_reader.conversation` at `/c/reader-c1` plus detail/messages/raw APIs;
  - query search, no-results diagnostics, and scoped facets;
  - empty archive and degraded FTS sanitized error state.
- Serve the web shell for `/c/{id}` so conversation deep links are directly verifiable.
- Normalize daemon reader `message_type` serialization to stable enum values instead of `MessageType.X` reprs.
- Update `docs/visual-evidence.md` and the MK3 execution log with the new command, coverage, and remaining browser screenshot follow-up.

Ref #865
Ref #848
Ref #859

## Verification

- `pytest -q tests/visual` → 4 passed
- `pytest -q tests/unit/daemon/test_web_reader.py` → 37 passed
- `ruff format --check polylogue/daemon/http.py tests/visual` → pass
- `ruff check polylogue/daemon/http.py tests/visual` → pass
- `mypy tests/visual polylogue/daemon/http.py` → pass
- `devtools verify --quick` → exit 0
- `devtools verify --affected --skip-slow` → exit 0
- pre-push `devtools verify --quick` → exit 0

## Follow-up

This PR deliberately does not add Playwright/Chromium screenshots. The new browserless lane records `browser_gate_followup` in evidence envelopes so a later #865 slice can add the heavier screenshot gate without replacing the fast DOM/contract smoke.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added conversation deeplink support—users can now directly access specific conversations via `/c/{conversation-id}` paths.
  * Improved message type serialization for enhanced data consistency across the reader.

* **Documentation**
  * Updated visual testing and execution planning documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sinity/polylogue/pull/1047)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->