### PR TITLE
test: route reader visual smoke through lab scenario

### DIFF
--- a/devtools/lab_scenario.py
+++ b/devtools/lab_scenario.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import argparse
 import difflib
 import json
+import subprocess
+import sys
 from pathlib import Path
 
 from devtools import repo_root as _get_root
@@ -16,7 +18,7 @@ from polylogue.showcase.qa_runner_workflow import run_qa_session
 from polylogue.showcase.qa_session_payload import generate_qa_session
 from polylogue.showcase.showcase_runner_support import run_exercise
 
-_SCENARIO_NAMES = ("archive-smoke",)
+_SCENARIO_NAMES = ("archive-smoke", "reader-visual-smoke")
 BASELINE_DIR = _get_root() / "tests" / "baselines" / "showcase"
 TIER_0_GROUPS = frozenset({"structural"})
 _ENV_DEPENDENT: frozenset[str] = frozenset({"version"})
@@ -149,27 +151,68 @@ def _build_parser() -> argparse.ArgumentParser:
 def list_scenarios(*, as_json: bool) -> int:
     """List available showcase scenarios with their tier-0 exercise inventory."""
     tier_0 = get_tier_0_exercises()
-    payload = {
-        "scenarios": [
-            {
-                "name": name,
-                "tier_0_exercise_count": len(tier_0),
-                "baseline_dir": str(BASELINE_DIR.relative_to(BASELINE_DIR.parent.parent.parent))
-                if BASELINE_DIR.exists()
-                else None,
-                "baselines_committed": len(list(BASELINE_DIR.glob("*.txt"))) if BASELINE_DIR.exists() else 0,
-            }
-            for name in _SCENARIO_NAMES
-        ]
-    }
+    scenarios: list[dict[str, object]] = [
+        {
+            "name": "archive-smoke",
+            "kind": "showcase",
+            "tier_0_exercise_count": len(tier_0),
+            "baseline_dir": str(BASELINE_DIR.relative_to(BASELINE_DIR.parent.parent.parent))
+            if BASELINE_DIR.exists()
+            else None,
+            "baselines_committed": len(list(BASELINE_DIR.glob("*.txt"))) if BASELINE_DIR.exists() else 0,
+        },
+        {
+            "name": "reader-visual-smoke",
+            "kind": "reader-visual",
+            "command": f"{sys.executable} -m pytest -q tests/visual",
+            "baseline_dir": None,
+            "baselines_committed": 0,
+        },
+    ]
+    payload = {"scenarios": scenarios}
     if as_json:
         print(json.dumps(payload, indent=2))
         return 0
-    for entry in payload["scenarios"]:
-        print(f"{entry['name']:<20s}  tier-0 exercises: {entry['tier_0_exercise_count']}")
+    for entry in scenarios:
+        name = str(entry["name"])
+        if name == "reader-visual-smoke":
+            print(f"{name:<20s}  command: {entry['command']}")
+            continue
+        print(f"{name:<20s}  tier-0 exercises: {entry['tier_0_exercise_count']}")
         if entry["baselines_committed"]:
             print(f"  baselines: {entry['baselines_committed']} ({entry['baseline_dir']})")
     return 0
+
+
+def run_reader_visual_smoke(*, report_dir: Path | None, as_json: bool) -> int:
+    """Run the daemon reader visual/DOM smoke lane."""
+    command = [sys.executable, "-m", "pytest", "-q", "tests/visual"]
+    result = subprocess.run(
+        command,
+        cwd=_get_root(),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    payload: dict[str, object] = {
+        "scenario": "reader-visual-smoke",
+        "command": command,
+        "exit_code": result.returncode,
+        "stdout": result.stdout,
+        "stderr": result.stderr,
+    }
+    if report_dir is not None:
+        report_dir.mkdir(parents=True, exist_ok=True)
+        (report_dir / "reader-visual-smoke.json").write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    if as_json:
+        print(json.dumps(payload, indent=2))
+    else:
+        print("Running reader visual DOM smoke...")
+        if result.stdout:
+            print(result.stdout, end="" if result.stdout.endswith("\n") else "\n")
+        if result.stderr:
+            print(result.stderr, end="" if result.stderr.endswith("\n") else "\n")
+    return result.returncode
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -181,6 +224,8 @@ def main(argv: list[str] | None = None) -> int:
         return list_scenarios(as_json=bool(args.json))
     if args.action != "run":
         parser.error(f"unknown action: {args.action}")
+    if args.scenario == "reader-visual-smoke":
+        return run_reader_visual_smoke(report_dir=args.report_dir, as_json=bool(args.json))
     request = build_qa_session_request(
         synthetic=not bool(args.live),
         source_names=None,

--- a/docs/plans/mk3-execution-log.md
+++ b/docs/plans/mk3-execution-log.md
@@ -186,6 +186,26 @@ Verification:
 - `devtools verify --quick`
 - `devtools verify --affected --skip-slow`
 
+### 2026-05-15 - Reader visual lane lab-scenario wiring
+
+Target:
+
+- #865 operator-facing command for the new fast reader visual/DOM lane.
+
+Outcome:
+
+- Added `devtools lab-scenario run reader-visual-smoke` as the named command
+  wrapper around `pytest -q tests/visual`.
+- `devtools lab-scenario list --json` now distinguishes showcase scenarios
+  from the reader visual lane instead of pretending the visual lane has
+  showcase tier-0 baselines.
+- Added unit coverage for listing and command dispatch with report output.
+
+Verification:
+
+- `pytest -q tests/unit/devtools/test_lab_list_subcommands.py tests/unit/devtools/test_lab_surface.py -k "lab_scenario"`
+- `devtools lab-scenario run reader-visual-smoke --json`
+
 ### 2026-05-15 - Wave 1 reader query smoke closure
 
 Target:

--- a/docs/visual-evidence.md
+++ b/docs/visual-evidence.md
@@ -27,12 +27,14 @@ From the devshell:
 ```bash
 nix develop -c pytest tests/unit/daemon/test_web_reader.py
 nix develop -c pytest tests/visual
+nix develop -c devtools lab-scenario run reader-visual-smoke
 ```
 
 Both suites are part of the standard non-integration test run. There is no
 browser binary or Playwright dependency in these fast lanes: they use Python's
 standard `http.server`, `urllib.request`, and `html.parser` against the real
-`DaemonAPIHTTPServer`.
+`DaemonAPIHTTPServer`. The `devtools lab-scenario` command is the
+operator-facing wrapper for the visual/DOM lane.
 
 ## Coverage
 

--- a/tests/unit/devtools/test_lab_list_subcommands.py
+++ b/tests/unit/devtools/test_lab_list_subcommands.py
@@ -17,6 +17,7 @@ def test_lab_scenario_list_human(capsys: pytest.CaptureFixture[str]) -> None:
     captured = capsys.readouterr()
     assert rc == 0
     assert "archive-smoke" in captured.out
+    assert "reader-visual-smoke" in captured.out
 
 
 def test_lab_scenario_list_json(capsys: pytest.CaptureFixture[str]) -> None:
@@ -27,6 +28,7 @@ def test_lab_scenario_list_json(capsys: pytest.CaptureFixture[str]) -> None:
     assert isinstance(payload, dict)
     assert "scenarios" in payload
     assert any(entry["name"] == "archive-smoke" for entry in payload["scenarios"])
+    assert any(entry["name"] == "reader-visual-smoke" for entry in payload["scenarios"])
 
 
 def test_lab_corpus_list_human(capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/unit/devtools/test_lab_surface.py
+++ b/tests/unit/devtools/test_lab_surface.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from pathlib import Path
 from unittest.mock import patch
 
@@ -117,6 +118,38 @@ def test_lab_scenario_live_archive_smoke_uses_active_archive() -> None:
     assert request.live is True
     assert request.fresh is False
     assert request.ingest is False
+
+
+def test_lab_scenario_reader_visual_smoke_runs_pytest(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    completed = subprocess.CompletedProcess(
+        args=["python", "-m", "pytest", "-q", "tests/visual"],
+        returncode=0,
+        stdout="4 passed\n",
+        stderr="",
+    )
+
+    with patch("devtools.lab_scenario.subprocess.run", return_value=completed) as mock_run:
+        result = lab_scenario.main(
+            [
+                "run",
+                "reader-visual-smoke",
+                "--report-dir",
+                str(tmp_path),
+                "--json",
+            ]
+        )
+
+    assert result == 0
+    command = mock_run.call_args.kwargs["args"] if "args" in mock_run.call_args.kwargs else mock_run.call_args.args[0]
+    assert command[-2:] == ["-q", "tests/visual"]
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["scenario"] == "reader-visual-smoke"
+    assert payload["exit_code"] == 0
+    report = json.loads((tmp_path / "reader-visual-smoke.json").read_text(encoding="utf-8"))
+    assert report["stdout"] == "4 passed\n"
 
 
 def test_lab_scenario_verify_baselines_delegates_to_baseline_runner(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary\n\nRoute the reader visual/DOM smoke lane through the verification-lab operator surface so agents and operators can invoke it as a named scenario instead of remembering the raw pytest path.\n\n## Problem\n\n#1047 added fast reader DOM evidence, but the durable operator command was still `pytest -q tests/visual`. That left the lane outside `devtools lab-scenario list`, outside JSON report output, and easy to miss when following the MK3 execution plan.\n\n## Solution\n\n- Add `reader-visual-smoke` to `devtools lab-scenario` discovery.\n- Dispatch `devtools lab-scenario run reader-visual-smoke` to `pytest -q tests/visual`.\n- Emit JSON and optional report-file output for the lane.\n- Cover scenario discovery and dispatch in devtools unit tests.\n- Document the operator-facing command in the visual evidence docs and execution log.\n\nRef #865\n\n## Verification\n\n- `ruff format --check devtools/lab_scenario.py tests/unit/devtools/test_lab_list_subcommands.py tests/unit/devtools/test_lab_surface.py` → 3 files already formatted\n- `ruff check devtools/lab_scenario.py tests/unit/devtools/test_lab_list_subcommands.py tests/unit/devtools/test_lab_surface.py` → All checks passed\n- `mypy devtools/lab_scenario.py tests/unit/devtools/test_lab_list_subcommands.py tests/unit/devtools/test_lab_surface.py` → Success\n- `pytest -q tests/unit/devtools/test_lab_list_subcommands.py tests/unit/devtools/test_lab_surface.py -k lab_scenario` → 6 passed\n- `devtools lab-scenario run reader-visual-smoke --json` → 4 passed\n- `devtools verify --quick` → exit_code 0\n- `devtools verify --affected --skip-slow` → exit_code 0