### PR TITLE
fix: report pytest counts in verify notifications

### DIFF
--- a/devtools/verify.py
+++ b/devtools/verify.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import argparse
 import contextlib
 import json
+import re
 import shutil
 import subprocess
 import sys
@@ -97,6 +98,23 @@ def _notify(summary: str) -> None:
         )
 
 
+def _format_completion_notification(
+    *,
+    exit_code: int,
+    total_duration: float,
+    step_results: list[dict[str, Any]],
+) -> str:
+    """Build the desktop notification summary for a completed verify run."""
+    if exit_code == 0:
+        msg = f"PASS ({total_duration:.0f}s)"
+        pytest_step = next((s for s in step_results if str(s["name"]).startswith("pytest")), None)
+        if pytest_step is not None and "count" in pytest_step:
+            msg += f", {pytest_step['count']} tests"
+        return msg
+    failed = [s["name"] for s in step_results if s["exit"] != 0]
+    return f"FAIL ({total_duration:.0f}s) — {', '.join(failed)}"
+
+
 # ── history (JSONL) ────────────────────────────────────────────────
 
 
@@ -143,12 +161,33 @@ def _print_history(file: Path | None = None) -> None:
 # ── step runner ─────────────────────────────────────────────────────
 
 
-def _run(label: str, cmd: list[str], *, cwd: str | None = None) -> tuple[int, float]:
+_PYTEST_COUNT_RE = re.compile(
+    r"\b(?P<count>\d+)\s+"
+    r"(?P<status>passed|failed|error|errors|skipped|xfailed|xpassed|rerun|reruns)\b"
+)
+
+
+def _parse_pytest_test_count(output: str) -> int | None:
+    """Return the total executed-test count from pytest's terminal summary."""
+    if "no tests ran" in output:
+        return 0
+    counts = [int(match.group("count")) for match in _PYTEST_COUNT_RE.finditer(output)]
+    if not counts:
+        return None
+    return sum(counts)
+
+
+def _run(label: str, cmd: list[str], *, cwd: str | None = None) -> tuple[int, float, dict[str, Any]]:
     t0 = time.monotonic()
     sys.stderr.write(f"  {label} ... ")
     sys.stderr.flush()
     result = subprocess.run(cmd, cwd=cwd, capture_output=True, text=True)
     elapsed = time.monotonic() - t0
+    metadata: dict[str, Any] = {}
+    if label.startswith("pytest"):
+        test_count = _parse_pytest_test_count(result.stdout + "\n" + result.stderr)
+        if test_count is not None:
+            metadata["count"] = test_count
     if result.returncode == 0:
         sys.stderr.write(f"ok ({elapsed:.1f}s)\n")
     else:
@@ -157,7 +196,7 @@ def _run(label: str, cmd: list[str], *, cwd: str | None = None) -> tuple[int, fl
             sys.stderr.write(result.stdout + "\n")
         if result.stderr.strip():
             sys.stderr.write(result.stderr + "\n")
-    return result.returncode, elapsed
+    return result.returncode, elapsed, metadata
 
 
 # ── step builder ────────────────────────────────────────────────────
@@ -489,10 +528,12 @@ def main(argv: list[str] | None = None) -> int:
     step_results: list[dict[str, Any]] = []
 
     for label, cmd in steps:
-        if label == "pytest":
+        if label.startswith("pytest"):
             _warn_low_memory()  # check again right before the heavy step
-        rc, elapsed = _run(label, cmd)
-        step_results.append({"name": label, "duration_s": round(elapsed, 2), "exit": rc})
+        rc, elapsed, metadata = _run(label, cmd)
+        step_result: dict[str, Any] = {"name": label, "duration_s": round(elapsed, 2), "exit": rc}
+        step_result.update(metadata)
+        step_results.append(step_result)
         if rc != 0:
             exit_code = rc
 
@@ -537,14 +578,12 @@ def main(argv: list[str] | None = None) -> int:
 
     # Notify on long-running verify.
     if total_duration > 30:
-        if exit_code == 0:
-            test_count = next((s for s in step_results if s["name"] == "pytest"), None)
-            msg = f"PASS ({total_duration:.0f}s)"
-            if test_count:
-                msg += f", {test_count.get('count', '?')} tests"
-            _notify(msg)
-        else:
-            failed = [s["name"] for s in step_results if s["exit"] != 0]
-            _notify(f"FAIL ({total_duration:.0f}s) — {', '.join(failed)}")
+        _notify(
+            _format_completion_notification(
+                exit_code=exit_code,
+                total_duration=total_duration,
+                step_results=step_results,
+            )
+        )
 
     return exit_code

--- a/tests/unit/devtools/test_verify.py
+++ b/tests/unit/devtools/test_verify.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import subprocess
 import sys
+from unittest.mock import patch
 
-from devtools.verify import build_verify_steps
+from devtools.verify import _format_completion_notification, _parse_pytest_test_count, _run, build_verify_steps
 
 
 def test_quick_verify_omits_pytest() -> None:
@@ -46,3 +48,51 @@ def test_lab_verify_delegates_to_lab_scenario() -> None:
         "lab scenario",
         [sys.executable, "-m", "devtools", "lab-scenario", "run", "archive-smoke", "--tier", "0"],
     )
+
+
+def test_parse_pytest_test_count_from_summary() -> None:
+    output = "bringing up nodes...\n\n6 passed, 2 skipped, 1 xfailed in 8.49s\n"
+
+    assert _parse_pytest_test_count(output) == 9
+
+
+def test_parse_pytest_test_count_handles_no_tests() -> None:
+    assert _parse_pytest_test_count("no tests ran in 0.02s\n") == 0
+
+
+def test_run_records_pytest_count_metadata() -> None:
+    completed = subprocess.CompletedProcess(
+        args=["pytest"],
+        returncode=0,
+        stdout="....\n4 passed in 1.23s\n",
+        stderr="",
+    )
+
+    with patch("devtools.verify.subprocess.run", return_value=completed):
+        rc, _elapsed, metadata = _run("pytest affected", ["pytest"])
+
+    assert rc == 0
+    assert metadata == {"count": 4}
+
+
+def test_completion_notification_uses_pytest_count() -> None:
+    summary = _format_completion_notification(
+        exit_code=0,
+        total_duration=118.2,
+        step_results=[
+            {"name": "ruff check", "duration_s": 0.1, "exit": 0},
+            {"name": "pytest affected", "duration_s": 100.0, "exit": 0, "count": 12},
+        ],
+    )
+
+    assert summary == "PASS (118s), 12 tests"
+
+
+def test_completion_notification_omits_unknown_pytest_count() -> None:
+    summary = _format_completion_notification(
+        exit_code=0,
+        total_duration=118.2,
+        step_results=[{"name": "pytest", "duration_s": 100.0, "exit": 0}],
+    )
+
+    assert summary == "PASS (118s)"


### PR DESCRIPTION
## Summary\n\nFix long-running `devtools verify` notifications so pytest runs report the parsed test count instead of `? tests`, and so affected pytest runs get the same metadata path.\n\n## Problem\n\nThe notification formatter looked for a `count` field on the pytest step, but `_run()` only returned exit code and elapsed time. As a result, full verify notifications always used the fallback `? tests`. Affected runs were labeled `pytest affected`, so they also missed the exact-label handling used for memory checks and notifications.\n\n## Solution\n\n- Parse pytest terminal summaries from captured stdout/stderr.\n- Store parsed test counts in verify step metadata and history entries.\n- Format notifications with a count only when a count was actually parsed.\n- Treat labels beginning with `pytest` consistently for low-memory preflight and notification summaries.\n- Add unit coverage for parsing, step metadata, and notification formatting.\n\n## Verification\n\n- `ruff format --check devtools/verify.py tests/unit/devtools/test_verify.py` → 2 files already formatted\n- `ruff check devtools/verify.py tests/unit/devtools/test_verify.py` → All checks passed\n- `mypy devtools/verify.py tests/unit/devtools/test_verify.py` → Success\n- `pytest -q tests/unit/devtools/test_verify.py` → 8 passed\n- `devtools verify --quick` → exit_code 0\n- `devtools verify --affected --skip-slow` → exit_code 0, pytest count 6357