### PR TITLE
feat: wire reader user-state controls

### DIFF
--- a/docs/plans/mk3-execution-log.md
+++ b/docs/plans/mk3-execution-log.md
@@ -17,7 +17,7 @@ Updated: 2026-05-15
 | Reader evidence shell | #848, #865, #956, #993 | Blocked on enough contract stability for full UI, but evidence harness can advance | Expand synthetic reader DOM/browser smoke toward MK3 states | `pytest tests/unit/daemon/test_web_reader.py`, future browser lane, `devtools verify --quick` |
 | Paste/attachment/provenance | #839, #864, #848, #993 | Blocked on message envelope/provenance vocabulary | Implement paste-span projection MVP after contract spine | focused storage/payload tests, daemon API tests, visual state tests |
 | Topology/workspace | #866, #993, #848, #865 | Substrate can start once source identity is stable | Materialize topology edges before graph UI | topology storage tests, parser fixtures, visual graph states |
-| User state/advanced panels | #867, #993, #1019, #995 | Active initial API slice | Expose existing conversation marks, saved views, and recall packs through daemon reader APIs; keep annotations/message targets open | daemon user-state API tests, saved-view roundtrip tests, visual state tests |
+| User state/advanced panels | #867, #993, #1019, #995 | Active reader-control slice | Consume durable user-state APIs from the reader shell; keep annotations/message targets and CLI/MCP parity open | visual DOM evidence, daemon user-state API tests, saved-view roundtrip tests |
 | Verification throughput | #1026, #997, #998, #594, #590, #1012 | Ready to start independently | Add affected-test workflow and reduce outlier runtime | `devtools verify --affected --skip-slow`, durations capture, focused regression tests |
 
 ## Subagent Parallelization Model
@@ -242,6 +242,49 @@ Verification:
 - `pytest -q tests/unit/daemon/test_web_reader.py -k "UserState or marks or saved_views or recall_packs"`
 - `pytest -q tests/unit/daemon/test_web_reader.py`
 - `pytest -q tests/visual`
+
+### 2026-05-15 - Reader user-state controls launch
+
+Target:
+
+- #867 follow-on reader UI controls for the durable user-state APIs merged in
+  #1050.
+
+Coordination:
+
+- Main branch: `feature/feat/reader-user-state-controls`.
+- Serialized implementation. The write surface is the single-file static reader
+  shell plus synthetic visual fixtures, so subagent parallelism would add merge
+  friction without useful throughput.
+
+Owned files:
+
+- `polylogue/daemon/web_shell.py`
+- `tests/visual/conftest.py`
+- `tests/visual/test_reader_dom_smoke.py`
+- `docs/plans/mk3-execution-log.md`
+
+Outcome:
+
+- Reader shell loads `/api/user/marks` and `/api/user/saved-views` alongside
+  conversations.
+- Conversation list and detail header display star/pin/archive state from the
+  durable archive tables.
+- Detail header and Notes panel can toggle conversation marks through the
+  daemon API.
+- Notes panel can save the current search/provider view and open saved views
+  using canonical saved-view query JSON.
+- Visual fixtures now seed durable marks and saved views so DOM/API evidence
+  proves the surface is wired to archive state, not local browser state.
+- Kept annotations, message/range targets, CLI parity, and MCP parity open
+  under #867.
+
+Verification:
+
+- `ruff format --check polylogue/daemon/web_shell.py tests/visual/conftest.py tests/visual/test_reader_dom_smoke.py`
+- `ruff check polylogue/daemon/web_shell.py tests/visual/conftest.py tests/visual/test_reader_dom_smoke.py`
+- `mypy polylogue/daemon/web_shell.py tests/visual/conftest.py tests/visual/test_reader_dom_smoke.py`
+- `pytest -q tests/visual tests/unit/daemon/test_web_reader.py -k "reader or UserState or saved_views or marks"`
 
 ### 2026-05-15 - Wave 1 reader query smoke closure
 

--- a/polylogue/daemon/web_shell.py
+++ b/polylogue/daemon/web_shell.py
@@ -77,6 +77,7 @@ html, body { height: 100%; background: var(--bg); color: var(--text);
 .conv-item .conv-meta .flag { font-size: 10px; padding: 0 4px; border-radius: 2px; background: var(--panel-subtle); }
 .conv-item .conv-meta .flag.tool { color: var(--role-tool); }
 .conv-item .conv-meta .flag.think { color: var(--role-thinking); }
+.conv-item .conv-meta .flag.mark { color: var(--warn); border: 1px solid var(--border); }
 .provider-dot { display: inline-block; width: 6px; height: 6px; border-radius: 50%; margin-right: 3px; flex-shrink: 0; }
 .sidebar-state { padding: 16px 12px; color: var(--text-dim); font-size: var(--small); text-align: center; line-height: 1.6; }
 .sidebar-state .state-icon { font-size: 24px; margin-bottom: 6px; opacity: 0.4; }
@@ -84,6 +85,13 @@ html, body { height: 100%; background: var(--bg); color: var(--text);
 #main { grid-column: 2; grid-row: 2; display: flex; flex-direction: column; overflow: hidden; background: var(--bg); }
 #conv-header { padding: 10px 16px; border-bottom: 1px solid var(--border); background: var(--bg-raised); }
 #conv-header h2 { font-size: 15px; font-weight: 500; line-height: 1.3; margin-bottom: 4px; }
+#conv-header .title-row { display: flex; align-items: flex-start; gap: 10px; justify-content: space-between; }
+#conv-header .title-row h2 { flex: 1; min-width: 0; }
+#conv-header .mark-actions { display: flex; gap: 4px; flex-shrink: 0; }
+#conv-header .mark-btn { width: 26px; height: 24px; border-radius: 3px; border: 1px solid var(--border);
+  background: var(--panel-subtle); color: var(--text-muted); cursor: pointer; font-size: var(--small); }
+#conv-header .mark-btn:hover { color: var(--text); border-color: var(--text-dim); }
+#conv-header .mark-btn.active { color: var(--warn); border-color: var(--warn); background: var(--warn-bg); }
 #conv-header .conv-stats { display: flex; gap: 8px; flex-wrap: wrap; align-items: center; font-size: var(--small); color: var(--text-muted); }
 #conv-header .conv-stats .chip { padding: 1px 6px; border-radius: 3px; font-size: var(--small);
   background: var(--panel-subtle); border: 1px solid var(--border); white-space: nowrap; }
@@ -137,6 +145,17 @@ html, body { height: 100%; background: var(--bg); color: var(--text);
 .inspector-section { margin-top: 10px; }
 .inspector-section h4 { font-size: 11px; font-weight: 600; color: var(--text-dim); text-transform: uppercase;
   letter-spacing: 0.6px; margin-bottom: 6px; }
+.user-state-row { display: flex; align-items: center; justify-content: space-between; gap: 8px;
+  padding: 5px 0; border-bottom: 1px solid var(--border); font-size: var(--small); }
+.user-state-row .label { color: var(--text-muted); }
+.user-state-row .value { color: var(--text); font-family: var(--font-mono); font-size: 11px; word-break: break-word; }
+.user-action { background: var(--panel-elevated); border: 1px solid var(--border); color: var(--accent);
+  padding: 4px 8px; border-radius: 3px; cursor: pointer; font-size: var(--small); font-family: var(--font-ui); }
+.user-action:hover { border-color: var(--accent-soft); background: var(--accent-bg); }
+.saved-view-list { display: flex; flex-direction: column; gap: 4px; }
+.saved-view-item { display: flex; justify-content: space-between; gap: 8px; align-items: center;
+  border: 1px solid var(--border); border-radius: var(--radius); padding: 6px; background: var(--panel-subtle); }
+.saved-view-item button { flex-shrink: 0; }
 .raw-block { font-family: var(--font-mono); font-size: 10px; white-space: pre-wrap; word-break: break-all;
   background: var(--panel-subtle); border: 1px solid var(--border); padding: 8px; border-radius: var(--radius);
   max-height: 300px; overflow-y: auto; color: var(--text-muted); }
@@ -232,7 +251,8 @@ var API = '';
 var state = {
   conversations: [], selected: null, selectedRaw: null,
   provider: '', query: '', offset: 0, limit: 100, total: 0,
-  status: {}, facets: null, inspectorTab: 'info'
+  status: {}, facets: null, inspectorTab: 'info',
+  marks: {}, savedViews: [], userStateError: ''
 };
 
 function esc(s) { return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;'); }
@@ -242,6 +262,25 @@ async function fetchJSON(url) {
   var r = await fetch(API + url);
   if (!r.ok) throw new Error(r.status);
   return r.json();
+}
+async function sendJSON(url, method, body) {
+  var opts = {method: method, headers: {'Content-Type': 'application/json'}};
+  if (body !== undefined) opts.body = JSON.stringify(body);
+  var r = await fetch(API + url, opts);
+  if (!r.ok) throw new Error(r.status);
+  return r.json();
+}
+
+function markSetFor(conversationId) {
+  return state.marks[conversationId] || {};
+}
+function hasMark(conversationId, markType) {
+  return !!markSetFor(conversationId)[markType];
+}
+function setMarkLocal(conversationId, markType, enabled) {
+  if (!state.marks[conversationId]) state.marks[conversationId] = {};
+  if (enabled) state.marks[conversationId][markType] = true;
+  else delete state.marks[conversationId][markType];
 }
 
 function getConvIdFromURL() {
@@ -280,6 +319,24 @@ async function loadConversations() {
     renderSidebarState('error', 'Failed to load conversations');
   }
   renderConversations();
+}
+
+async function loadUserState() {
+  try {
+    var marks = await fetchJSON('/api/user/marks');
+    state.marks = {};
+    (marks.items || []).forEach(function(m) {
+      setMarkLocal(m.conversation_id, m.mark_type, true);
+    });
+    var savedViews = await fetchJSON('/api/user/saved-views');
+    state.savedViews = savedViews.items || [];
+    state.userStateError = '';
+  } catch(e) {
+    state.userStateError = 'User state unavailable';
+  }
+  renderConversations();
+  renderMain();
+  renderInspector();
 }
 
 async function loadConversation(id, updateURL) {
@@ -361,6 +418,9 @@ function renderConversations() {
       if (c.flags.has_thinking) flagsHtml += '<span class="flag think">R</span>';
       if (c.flags.has_paste) flagsHtml += '<span class="flag">P</span>';
     }
+    if (hasMark(c.id, 'star')) flagsHtml += '<span class="flag mark" title="Starred">*</span>';
+    if (hasMark(c.id, 'pin')) flagsHtml += '<span class="flag mark" title="Pinned">P</span>';
+    if (hasMark(c.id, 'archive')) flagsHtml += '<span class="flag mark" title="Archived">A</span>';
     var repoHtml = c.repo ? '<span class="chip" style="font-size:10px;padding:0 4px">' + esc(c.repo.split('/').pop()) + '</span>' : '';
     return '<div class="conv-item' + sel + '" data-id="' + escAttr(c.id) + '" onclick="selectConversation(\'' + escAttr(c.id) + '\')">'
       + '<div class="conv-title">' + title + '</div>'
@@ -425,7 +485,11 @@ function renderMain() {
   }
   var c = state.selected;
   var title = esc(c.display_title || c.title || 'Untitled');
-  var headerHtml = '<h2>' + title + '</h2><div class="conv-stats">';
+  var headerHtml = '<div class="title-row"><h2>' + title + '</h2><div class="mark-actions">'
+    + markButtonHtml(c.id, 'star', '*', 'Toggle star')
+    + markButtonHtml(c.id, 'pin', 'P', 'Toggle pin')
+    + markButtonHtml(c.id, 'archive', 'A', 'Toggle archive')
+    + '</div></div><div class="conv-stats">';
   if (c.provider) headerHtml += '<span>' + esc(c.provider) + '</span>';
   if (c.model) headerHtml += '<span class="chip">' + esc(String(c.model)) + '</span>';
   if (c.message_count !== undefined) headerHtml += '<span>' + c.message_count + ' messages</span>';
@@ -482,6 +546,11 @@ function renderMain() {
   }).join('');
 }
 
+function markButtonHtml(conversationId, markType, label, title) {
+  var active = hasMark(conversationId, markType) ? ' active' : '';
+  return '<button class="mark-btn' + active + '" title="' + escAttr(title) + '" onclick="toggleMark(\'' + escAttr(markType) + '\')">' + esc(label) + '</button>';
+}
+
 function renderInspector() {
   var el = document.getElementById('inspector-content');
   if (!state.selected) { el.innerHTML = '<div class="inspector-empty">Select a conversation to inspect</div>'; return; }
@@ -533,8 +602,95 @@ function renderInspectorRaw(el, c) {
 }
 
 function renderInspectorNotes(el, c) {
-  el.innerHTML = '<div class="inspector-section"><h4>Notes</h4>'
-    + '<div class="inspector-empty">Notes are not yet implemented. See <a href="https://github.com/Sinity/polylogue/issues/867" target="_blank" style="color:var(--accent)">#867</a>.</div></div>';
+  var marks = Object.keys(markSetFor(c.id));
+  var querySummary = [];
+  if (state.query) querySummary.push('query=' + state.query);
+  if (state.provider) querySummary.push('provider=' + state.provider);
+  var html = '<div class="inspector-section"><h4>Marks</h4>';
+  if (marks.length) {
+    html += '<div class="user-state-row"><span class="label">Active</span><span class="value">' + esc(marks.sort().join(', ')) + '</span></div>';
+  } else {
+    html += '<div class="inspector-empty">No marks on this conversation</div>';
+  }
+  html += '<div style="display:flex;gap:4px;flex-wrap:wrap;margin-top:8px">'
+    + '<button class="user-action" onclick="toggleMark(\'star\')">Star</button>'
+    + '<button class="user-action" onclick="toggleMark(\'pin\')">Pin</button>'
+    + '<button class="user-action" onclick="toggleMark(\'archive\')">Archive</button>'
+    + '</div></div>';
+  html += '<div class="inspector-section"><h4>Saved Views</h4>'
+    + '<div class="user-state-row"><span class="label">Current</span><span class="value">' + esc(querySummary.join(' / ') || 'all conversations') + '</span></div>'
+    + '<button class="user-action" onclick="saveCurrentView()">Save current view</button>';
+  if (state.savedViews.length) {
+    html += '<div class="saved-view-list" style="margin-top:8px">';
+    state.savedViews.forEach(function(v) {
+      var q = v.query || {};
+      var bits = [];
+      if (q.query) bits.push('query=' + q.query);
+      if (q.provider) bits.push('provider=' + q.provider);
+      html += '<div class="saved-view-item"><div><div>' + esc(v.name || v.view_id) + '</div>'
+        + '<div class="value">' + esc(bits.join(' / ') || 'all conversations') + '</div></div>'
+        + '<button class="user-action" onclick="applySavedView(\'' + escAttr(v.view_id) + '\')">Open</button></div>';
+    });
+    html += '</div>';
+  } else {
+    html += '<div class="inspector-empty">No saved views</div>';
+  }
+  if (state.userStateError) {
+    html += '<div class="inspector-empty">' + esc(state.userStateError) + '</div>';
+  }
+  html += '</div><div class="inspector-section"><h4>Annotations</h4>'
+    + '<div class="inspector-empty">Annotation storage remains tracked in #867.</div></div>';
+  el.innerHTML = html;
+}
+
+async function toggleMark(markType) {
+  if (!state.selected) return;
+  var id = state.selected.id;
+  var enabled = hasMark(id, markType);
+  try {
+    if (enabled) {
+      await sendJSON('/api/user/marks?conversation_id=' + encodeURIComponent(id) + '&mark_type=' + encodeURIComponent(markType), 'DELETE');
+      setMarkLocal(id, markType, false);
+    } else {
+      await sendJSON('/api/user/marks', 'POST', {conversation_id: id, mark_type: markType});
+      setMarkLocal(id, markType, true);
+    }
+    state.userStateError = '';
+  } catch(e) {
+    state.userStateError = 'Failed to update mark';
+  }
+  renderConversations();
+  renderMain();
+  renderInspector();
+}
+
+async function saveCurrentView() {
+  var query = {limit: state.limit, offset: 0};
+  if (state.query) query.query = state.query;
+  if (state.provider) query.provider = state.provider;
+  var defaultName = state.query || state.provider || 'All conversations';
+  var name = window.prompt('Saved view name', defaultName);
+  if (!name) return;
+  try {
+    await sendJSON('/api/user/saved-views', 'POST', {name: name, query: query});
+    await loadUserState();
+  } catch(e) {
+    state.userStateError = 'Failed to save view';
+    renderInspector();
+  }
+}
+
+function applySavedView(viewId) {
+  var view = state.savedViews.find(function(v) { return v.view_id === viewId; });
+  if (!view) return;
+  var query = view.query || {};
+  state.query = query.query || '';
+  state.provider = query.provider || '';
+  state.offset = 0;
+  document.getElementById('search').value = state.query;
+  loadConversations();
+  loadFacets();
+  renderInspector();
 }
 
 async function loadRawData() {
@@ -637,6 +793,7 @@ loadConversations().then(function() {
   if (cid) selectConversation(cid, false);
 });
 loadFacets();
+loadUserState();
 loadStatus();
 setInterval(loadStatus, 30000);
 </script>

--- a/tests/visual/conftest.py
+++ b/tests/visual/conftest.py
@@ -131,7 +131,12 @@ def seed_reader_archive(
     conversations: bool = True,
     message_fts: bool = True,
 ) -> None:
-    from polylogue.storage.sqlite.schema_ddl_archive import ARCHIVE_STORAGE_DDL, MESSAGE_FTS_DDL
+    from polylogue.storage.sqlite.schema_ddl_archive import (
+        ARCHIVE_STORAGE_DDL,
+        MESSAGE_FTS_DDL,
+        SAVED_VIEWS_DDL,
+        USER_MARKS_DDL,
+    )
 
     db = archive_db_path(workspace)
     db.parent.mkdir(parents=True, exist_ok=True)
@@ -139,6 +144,8 @@ def seed_reader_archive(
         db.unlink()
     conn = sqlite3.connect(str(db))
     conn.executescript(ARCHIVE_STORAGE_DDL)
+    conn.executescript(USER_MARKS_DDL)
+    conn.executescript(SAVED_VIEWS_DDL)
     if message_fts:
         conn.executescript(MESSAGE_FTS_DDL)
     if conversations:
@@ -222,6 +229,23 @@ def seed_reader_archive(
                         message_type,
                     ),
                 )
+        conn.execute(
+            "INSERT INTO user_marks(conversation_id, mark_type, created_at) VALUES (?, ?, ?)",
+            ("reader-c1", "star", "2026-05-15T00:00:00+00:00"),
+        )
+        conn.execute(
+            "INSERT INTO user_marks(conversation_id, mark_type, created_at) VALUES (?, ?, ?)",
+            ("reader-c1", "pin", "2026-05-15T00:01:00+00:00"),
+        )
+        conn.execute(
+            "INSERT INTO saved_views(view_id, name, query_json, created_at) VALUES (?, ?, ?, ?)",
+            (
+                "reader-view-claude-code",
+                "Claude Code reader fixtures",
+                json.dumps({"provider": "claude-code", "query": "Hello", "limit": 100, "offset": 0}, sort_keys=True),
+                "2026-05-15T00:02:00+00:00",
+            ),
+        )
     conn.commit()
     conn.close()
 

--- a/tests/visual/test_reader_dom_smoke.py
+++ b/tests/visual/test_reader_dom_smoke.py
@@ -48,7 +48,16 @@ def test_reader_search_shell_dom_evidence(reader_workspace: ReaderWorkspace, tmp
     assert dom.meta_viewport is True
     assert dom.scripts == 1
     assert dom.styles == 1
-    for phrase in ("Select a conversation", "Keyboard Shortcuts", "Focus search", "Local"):
+    for phrase in (
+        "Select a conversation",
+        "Keyboard Shortcuts",
+        "Focus search",
+        "Local",
+        "/api/user/marks",
+        "toggleMark",
+        "Save current view",
+        "Saved Views",
+    ):
         assert phrase in body
 
     checks = {
@@ -78,6 +87,8 @@ def test_reader_conversation_deeplink_and_detail_evidence(reader_workspace: Read
         detail = cast(dict[str, object], get_json(base_url, "/api/conversations/reader-c1"))
         messages = cast(dict[str, object], get_json(base_url, "/api/conversations/reader-c1/messages"))
         raw = cast(dict[str, object], get_json(base_url, "/api/conversations/reader-c1/raw"))
+        marks = cast(dict[str, object], get_json(base_url, "/api/user/marks?conversation_id=reader-c1"))
+        saved_views = cast(dict[str, object], get_json(base_url, "/api/user/saved-views"))
 
     assert status == 200
     assert "text/html" in content_type
@@ -106,6 +117,11 @@ def test_reader_conversation_deeplink_and_detail_evidence(reader_workspace: Read
 
     assert raw["id"] == "reader-c1"
     assert "raw_artifacts" in raw
+    mark_types = {str(item["mark_type"]) for item in cast(list[dict[str, object]], marks["items"])}
+    assert mark_types == {"pin", "star"}
+    view_items = cast(list[dict[str, object]], saved_views["items"])
+    assert view_items[0]["name"] == "Claude Code reader fixtures"
+    assert cast(dict[str, object], view_items[0]["query"])["provider"] == "claude-code"
 
     checks = {
         "status": status,
@@ -115,6 +131,8 @@ def test_reader_conversation_deeplink_and_detail_evidence(reader_workspace: Read
         "message_total": messages["total"],
         "tool_message_present": True,
         "raw_endpoint_present": True,
+        "mark_types": sorted(mark_types),
+        "saved_view_count": len(view_items),
         "private_path_safe": True,
     }
     write_evidence_manifest(


### PR DESCRIPTION
## Summary

Wire the MK3 reader shell to the durable user-state APIs added in #1050 so marks and saved views are visible and actionable in the local reader instead of remaining placeholder text.

## Problem

#867 requires durable marks and saved views to be reader product state, not browser-local or hidden API data. After #1050, the daemon exposed `/api/user/*`, but the web reader still did not load marks, display them in the conversation list/header, toggle them, or save/open query-backed views.

## Solution

- Load `/api/user/marks` and `/api/user/saved-views` during reader startup.
- Display star/pin/archive state in the conversation list and detail header.
- Add header and Notes-panel controls that toggle marks through the daemon API.
- Add saved-view controls that save the current query/provider view and reopen saved query JSON.
- Seed visual fixtures with durable marks and a saved view so DOM/API evidence proves archive-backed state wiring.
- Update the MK3 execution log with the active slice, verification lane, and remaining #867 scope.

Remaining #867 scope: annotation storage, message/range targets, CLI parity, and MCP parity.

Ref #867

## Verification

- `ruff format --check polylogue/daemon/web_shell.py tests/visual/conftest.py tests/visual/test_reader_dom_smoke.py` -> 3 files already formatted
- `ruff check polylogue/daemon/web_shell.py tests/visual/conftest.py tests/visual/test_reader_dom_smoke.py` -> All checks passed
- `mypy polylogue/daemon/web_shell.py tests/visual/conftest.py tests/visual/test_reader_dom_smoke.py` -> Success
- `node -e "... new Function(script) ..."` -> script ok
- `pytest -q tests/visual tests/unit/daemon/test_web_reader.py -k "reader or UserState or saved_views or marks"` -> 45 passed
- `devtools verify --quick` -> exit_code 0
- `devtools verify --affected --skip-slow` -> exit_code 0; pytest count 6361
