### PR TITLE
feat: expose reader user state through MCP

### DIFF
--- a/docs/plans/mk3-execution-log.md
+++ b/docs/plans/mk3-execution-log.md
@@ -17,7 +17,7 @@ Updated: 2026-05-15
 | Reader evidence shell | #848, #865, #956, #993 | Blocked on enough contract stability for full UI, but evidence harness can advance | Expand synthetic reader DOM/browser smoke toward MK3 states | `pytest tests/unit/daemon/test_web_reader.py`, future browser lane, `devtools verify --quick` |
 | Paste/attachment/provenance | #839, #864, #848, #993 | Blocked on message envelope/provenance vocabulary | Implement paste-span projection MVP after contract spine | focused storage/payload tests, daemon API tests, visual state tests |
 | Topology/workspace | #866, #993, #848, #865 | Substrate can start once source identity is stable | Materialize topology edges before graph UI | topology storage tests, parser fixtures, visual graph states |
-| User state/advanced panels | #867, #993, #1019, #995 | Active reader-control slice | Consume durable user-state APIs from the reader shell; keep annotations/message targets and CLI/MCP parity open | visual DOM evidence, daemon user-state API tests, saved-view roundtrip tests |
+| User state/advanced panels | #867, #993, #1019, #995 | Active MCP parity slice | Expose marks and saved views through write-role MCP tools; keep annotations/message targets and CLI parity open | MCP mutation tests, saved-view roundtrip tests |
 | Verification throughput | #1026, #997, #998, #594, #590, #1012 | Ready to start independently | Add affected-test workflow and reduce outlier runtime | `devtools verify --affected --skip-slow`, durations capture, focused regression tests |
 
 ## Subagent Parallelization Model
@@ -285,6 +285,43 @@ Verification:
 - `ruff check polylogue/daemon/web_shell.py tests/visual/conftest.py tests/visual/test_reader_dom_smoke.py`
 - `mypy polylogue/daemon/web_shell.py tests/visual/conftest.py tests/visual/test_reader_dom_smoke.py`
 - `pytest -q tests/visual tests/unit/daemon/test_web_reader.py -k "reader or UserState or saved_views or marks"`
+
+### 2026-05-15 - MCP user-state parity launch
+
+Target:
+
+- #867 write-role MCP parity for durable conversation marks and saved views.
+
+Coordination:
+
+- Main branch: `feature/feat/mcp-user-state-tools`.
+- Serialized implementation. The slice touches one MCP registration module,
+  typed MCP payloads, and focused MCP contract tests.
+
+Owned files:
+
+- `polylogue/mcp/server_mutation_tools.py`
+- `polylogue/mcp/payloads.py`
+- `tests/unit/mcp/test_tool_contracts.py`
+- `docs/plans/mk3-execution-log.md`
+
+Outcome:
+
+- Added MCP list/add/remove tools for conversation marks.
+- Added MCP list/save/delete tools for saved views.
+- Saved-view MCP writes validate query JSON through strict
+  `ConversationQuerySpec` construction before storing canonical JSON.
+- Mark mutations resolve conversation IDs through the existing query store
+  before calling the shared Polylogue facade.
+- Kept annotations, message/range targets, recall-pack MCP shape, and CLI
+  parity open under #867.
+
+Verification:
+
+- `pytest -q tests/unit/mcp/test_tool_contracts.py -k "mark or saved_view"`
+- `pytest -q tests/unit/mcp/test_user_state_tools.py tests/unit/mcp/test_envelope_contracts.py tests/unit/mcp/test_tool_schema_witness.py`
+- `pytest -q tests/unit/mcp`
+- `devtools verify --quick`
 
 ### 2026-05-15 - Wave 1 reader query smoke closure
 

--- a/polylogue/mcp/payloads.py
+++ b/polylogue/mcp/payloads.py
@@ -392,6 +392,29 @@ class MCPMetadataPayload(SurfacePayloadModel):
         return json.dumps(self.root, indent=2)
 
 
+class MCPUserMarkPayload(SurfacePayloadModel):
+    conversation_id: str
+    mark_type: str
+    created_at: str
+
+
+class MCPUserMarkListPayload(SurfacePayloadModel):
+    items: tuple[MCPUserMarkPayload, ...]
+    total: int
+
+
+class MCPSavedViewPayload(SurfacePayloadModel):
+    view_id: str
+    name: str
+    query: dict[str, object]
+    created_at: str
+
+
+class MCPSavedViewListPayload(SurfacePayloadModel):
+    items: tuple[MCPSavedViewPayload, ...]
+    total: int
+
+
 class MCPStatsByPayload(MCPRootPayload[dict[str, int]]):
     root: dict[str, int]
 
@@ -546,6 +569,10 @@ __all__ = [
     "MCPSessionTreePayload",
     "MCPStatsByPayload",
     "MCPTagCountsPayload",
+    "MCPSavedViewListPayload",
+    "MCPSavedViewPayload",
+    "MCPUserMarkListPayload",
+    "MCPUserMarkPayload",
     "MCPTargetRefPayload",
     "conversation_neighbor_candidate_list_payload",
     "conversation_query_result_payload",

--- a/polylogue/mcp/server_mutation_tools.py
+++ b/polylogue/mcp/server_mutation_tools.py
@@ -8,7 +8,11 @@ from typing import TYPE_CHECKING, Any
 
 from polylogue.mcp.payloads import (
     MCPMetadataPayload,
+    MCPSavedViewListPayload,
+    MCPSavedViewPayload,
     MCPTagCountsPayload,
+    MCPUserMarkListPayload,
+    MCPUserMarkPayload,
     MutationResultPayload,
 )
 
@@ -24,6 +28,21 @@ async def _resolve_or_error(hooks: ServerCallbacks, conversation_id: str) -> tup
     if not resolved:
         return None, hooks.error_json("conversation not found", conversation_id=conversation_id)
     return resolved, None
+
+
+def _saved_view_payload(row: dict[str, str]) -> MCPSavedViewPayload:
+    try:
+        query = json.loads(row["query_json"])
+    except (json.JSONDecodeError, TypeError):
+        query = {}
+    if not isinstance(query, dict):
+        query = {}
+    return MCPSavedViewPayload(
+        view_id=row["view_id"],
+        name=row["name"],
+        query=query,
+        created_at=row["created_at"],
+    )
 
 
 def register_mutation_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
@@ -106,6 +125,131 @@ def register_mutation_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
             return hooks.json_payload(MCPTagCountsPayload(root=tags))
 
         return await hooks.async_safe_call("list_tags", run)
+
+    @mcp.tool()
+    async def list_marks(mark_type: str | None = None, conversation_id: str | None = None) -> str:
+        async def run() -> str:
+            poly = hooks.get_polylogue()
+            rows = await poly.list_marks(mark_type=mark_type, conversation_id=conversation_id)
+            items = tuple(
+                MCPUserMarkPayload(
+                    conversation_id=row["conversation_id"],
+                    mark_type=row["mark_type"],
+                    created_at=row["created_at"],
+                )
+                for row in rows
+            )
+            return hooks.json_payload(MCPUserMarkListPayload(items=items, total=len(items)))
+
+        return await hooks.async_safe_call("list_marks", run)
+
+    @mcp.tool()
+    async def add_mark(conversation_id: str, mark_type: str) -> str:
+        async def run() -> str:
+            if mark_type not in {"star", "pin", "archive"}:
+                return hooks.error_json("mark_type must be one of: star, pin, archive", detail=mark_type)
+            resolved, err = await _resolve_or_error(hooks, conversation_id)
+            if err:
+                return err
+            assert resolved is not None
+            poly = hooks.get_polylogue()
+            created = await poly.add_mark(resolved, mark_type)
+            return hooks.json_payload(
+                MutationResultPayload(
+                    status="ok" if created else "unchanged",
+                    conversation_id=resolved,
+                    detail=None if created else "already_present",
+                    key=mark_type,
+                    outcome="added" if created else "no_op",
+                ),
+                exclude_none=True,
+            )
+
+        return await hooks.async_safe_call("add_mark", run)
+
+    @mcp.tool()
+    async def remove_mark(conversation_id: str, mark_type: str) -> str:
+        async def run() -> str:
+            resolved, err = await _resolve_or_error(hooks, conversation_id)
+            if err:
+                return err
+            assert resolved is not None
+            poly = hooks.get_polylogue()
+            deleted = await poly.remove_mark(resolved, mark_type)
+            return hooks.json_payload(
+                MutationResultPayload(
+                    status="ok" if deleted else "not_found",
+                    conversation_id=resolved,
+                    detail=None if deleted else "mark_not_present",
+                    key=mark_type,
+                    outcome="removed" if deleted else "not_present",
+                ),
+                exclude_none=True,
+            )
+
+        return await hooks.async_safe_call("remove_mark", run)
+
+    @mcp.tool()
+    async def list_saved_views() -> str:
+        async def run() -> str:
+            poly = hooks.get_polylogue()
+            rows = await poly.list_views()
+            items = tuple(_saved_view_payload(row) for row in rows)
+            return hooks.json_payload(MCPSavedViewListPayload(items=items, total=len(items)))
+
+        return await hooks.async_safe_call("list_saved_views", run)
+
+    @mcp.tool()
+    async def save_saved_view(name: str, query_json: str, view_id: str | None = None) -> str:
+        async def run() -> str:
+            if not name.strip():
+                return hooks.error_json("saved view name must not be empty")
+            try:
+                query = json.loads(query_json)
+            except json.JSONDecodeError:
+                return hooks.error_json("query_json must be valid JSON")
+            if not isinstance(query, dict):
+                return hooks.error_json("query_json must encode an object")
+
+            from polylogue.archive.query.spec import ConversationQuerySpec
+
+            try:
+                ConversationQuerySpec.from_params(query, strict=True)
+            except Exception as exc:
+                return hooks.error_json("query_json is not a valid ConversationQuerySpec", detail=type(exc).__name__)
+
+            canonical_query_json = json.dumps(query, sort_keys=True, separators=(",", ":"))
+            poly = hooks.get_polylogue()
+            saved_id = view_id or name.strip().lower().replace(" ", "-")
+            created = await poly.save_view(saved_id, name.strip(), canonical_query_json)
+            saved = await poly.get_view(saved_id)
+            return hooks.json_payload(
+                MutationResultPayload(
+                    status="ok" if created else "unchanged",
+                    detail=None if saved else "saved_view_not_found",
+                    key=saved_id,
+                    outcome="added" if created else "updated",
+                ),
+                exclude_none=True,
+            )
+
+        return await hooks.async_safe_call("save_saved_view", run)
+
+    @mcp.tool()
+    async def delete_saved_view(view_id: str) -> str:
+        async def run() -> str:
+            poly = hooks.get_polylogue()
+            deleted = await poly.delete_view(view_id)
+            return hooks.json_payload(
+                MutationResultPayload(
+                    status="deleted" if deleted else "not_found",
+                    detail=None if deleted else "saved_view_not_found",
+                    key=view_id,
+                ),
+                exclude_none=True,
+            )
+
+        return await hooks.async_safe_call("delete_saved_view", run)
 
     @mcp.tool()
     async def get_metadata(conversation_id: str) -> str:

--- a/polylogue/mcp/server_mutation_tools.py
+++ b/polylogue/mcp/server_mutation_tools.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from contextlib import suppress
+from hashlib import sha256
 from typing import TYPE_CHECKING, Any
 
 from polylogue.mcp.payloads import (
@@ -28,6 +29,17 @@ async def _resolve_or_error(hooks: ServerCallbacks, conversation_id: str) -> tup
     if not resolved:
         return None, hooks.error_json("conversation not found", conversation_id=conversation_id)
     return resolved, None
+
+
+def _mark_type_error(hooks: ServerCallbacks, mark_type: str) -> str | None:
+    if mark_type in {"star", "pin", "archive"}:
+        return None
+    return hooks.error_json("mark_type must be one of: star, pin, archive", detail=mark_type)
+
+
+def _default_saved_view_id(name: str, query_json: str) -> str:
+    digest = sha256(f"{name}\0{query_json}".encode()).hexdigest()
+    return f"saved-view-{digest[:16]}"
 
 
 def _saved_view_payload(row: dict[str, str]) -> MCPSavedViewPayload:
@@ -146,8 +158,9 @@ def register_mutation_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
     @mcp.tool()
     async def add_mark(conversation_id: str, mark_type: str) -> str:
         async def run() -> str:
-            if mark_type not in {"star", "pin", "archive"}:
-                return hooks.error_json("mark_type must be one of: star, pin, archive", detail=mark_type)
+            mark_error = _mark_type_error(hooks, mark_type)
+            if mark_error:
+                return mark_error
             resolved, err = await _resolve_or_error(hooks, conversation_id)
             if err:
                 return err
@@ -170,6 +183,9 @@ def register_mutation_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
     @mcp.tool()
     async def remove_mark(conversation_id: str, mark_type: str) -> str:
         async def run() -> str:
+            mark_error = _mark_type_error(hooks, mark_type)
+            if mark_error:
+                return mark_error
             resolved, err = await _resolve_or_error(hooks, conversation_id)
             if err:
                 return err
@@ -216,17 +232,16 @@ def register_mutation_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
             try:
                 ConversationQuerySpec.from_params(query, strict=True)
             except Exception as exc:
-                return hooks.error_json("query_json is not a valid ConversationQuerySpec", detail=type(exc).__name__)
+                detail = f"{type(exc).__name__}: {exc}"
+                return hooks.error_json("query_json is not a valid ConversationQuerySpec", detail=detail)
 
             canonical_query_json = json.dumps(query, sort_keys=True, separators=(",", ":"))
             poly = hooks.get_polylogue()
-            saved_id = view_id or name.strip().lower().replace(" ", "-")
+            saved_id = view_id or _default_saved_view_id(name.strip(), canonical_query_json)
             created = await poly.save_view(saved_id, name.strip(), canonical_query_json)
-            saved = await poly.get_view(saved_id)
             return hooks.json_payload(
                 MutationResultPayload(
-                    status="ok" if created else "unchanged",
-                    detail=None if saved else "saved_view_not_found",
+                    status="ok",
                     key=saved_id,
                     outcome="added" if created else "updated",
                 ),

--- a/tests/data/witnesses/mcp-tool-schemas.json
+++ b/tests/data/witnesses/mcp-tool-schemas.json
@@ -1,5 +1,26 @@
 [
   {
+    "name": "add_mark",
+    "parameters": {
+      "properties": {
+        "conversation_id": {
+          "title": "Conversation Id",
+          "type": "string"
+        },
+        "mark_type": {
+          "title": "Mark Type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "conversation_id",
+        "mark_type"
+      ],
+      "title": "add_markArguments",
+      "type": "object"
+    }
+  },
+  {
     "name": "add_tag",
     "parameters": {
       "properties": {
@@ -359,6 +380,22 @@
         "key"
       ],
       "title": "delete_metadataArguments",
+      "type": "object"
+    }
+  },
+  {
+    "name": "delete_saved_view",
+    "parameters": {
+      "properties": {
+        "view_id": {
+          "title": "View Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "view_id"
+      ],
+      "title": "delete_saved_viewArguments",
       "type": "object"
     }
   },
@@ -1240,6 +1277,47 @@
     }
   },
   {
+    "name": "list_marks",
+    "parameters": {
+      "properties": {
+        "conversation_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Conversation Id"
+        },
+        "mark_type": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Mark Type"
+        }
+      },
+      "title": "list_marksArguments",
+      "type": "object"
+    }
+  },
+  {
+    "name": "list_saved_views",
+    "parameters": {
+      "properties": {},
+      "title": "list_saved_viewsArguments",
+      "type": "object"
+    }
+  },
+  {
     "name": "list_tags",
     "parameters": {
       "properties": {
@@ -1418,6 +1496,27 @@
     }
   },
   {
+    "name": "remove_mark",
+    "parameters": {
+      "properties": {
+        "conversation_id": {
+          "title": "Conversation Id",
+          "type": "string"
+        },
+        "mark_type": {
+          "title": "Mark Type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "conversation_id",
+        "mark_type"
+      ],
+      "title": "remove_markArguments",
+      "type": "object"
+    }
+  },
+  {
     "name": "remove_tag",
     "parameters": {
       "properties": {
@@ -1435,6 +1534,39 @@
         "tag"
       ],
       "title": "remove_tagArguments",
+      "type": "object"
+    }
+  },
+  {
+    "name": "save_saved_view",
+    "parameters": {
+      "properties": {
+        "name": {
+          "title": "Name",
+          "type": "string"
+        },
+        "query_json": {
+          "title": "Query Json",
+          "type": "string"
+        },
+        "view_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "View Id"
+        }
+      },
+      "required": [
+        "name",
+        "query_json"
+      ],
+      "title": "save_saved_viewArguments",
       "type": "object"
     }
   },

--- a/tests/unit/mcp/test_envelope_contracts.py
+++ b/tests/unit/mcp/test_envelope_contracts.py
@@ -54,6 +54,8 @@ TOOL_CONTRACT: dict[str, ToolKind] = {
     "raw_artifacts": ("envelope", frozenset({"raw_artifacts", "total"})),
     # ------- mutation list -------
     "list_tags": "stats_map",  # RootModel[dict[tag, count]]; small, by design
+    "list_marks": ("envelope", frozenset({"items", "total"})),
+    "list_saved_views": ("envelope", frozenset({"items", "total"})),
     # ------- single record -------
     "get_conversation": "single_object",
     "get_conversation_summary": "single_object",
@@ -67,8 +69,12 @@ TOOL_CONTRACT: dict[str, ToolKind] = {
     "get_stats_by": "stats_map",
     # ------- mutation tools -------
     "add_tag": "operation_result",
+    "add_mark": "operation_result",
     "remove_tag": "operation_result",
+    "remove_mark": "operation_result",
     "bulk_tag_conversations": "operation_result",
+    "save_saved_view": "operation_result",
+    "delete_saved_view": "operation_result",
     "set_metadata": "operation_result",
     "delete_metadata": "operation_result",
     "delete_conversation": "operation_result",

--- a/tests/unit/mcp/test_user_state_tools.py
+++ b/tests/unit/mcp/test_user_state_tools.py
@@ -92,6 +92,18 @@ def test_remove_mark_reports_missing_mark(mcp_server: MCPServerUnderTest) -> Non
     mock_poly.remove_mark.assert_awaited_once_with("test:conv-123", "star")
 
 
+def test_remove_mark_rejects_unknown_type(mcp_server: MCPServerUnderTest) -> None:
+    result = invoke_surface(
+        mcp_server._tool_manager._tools["remove_mark"].fn,
+        conversation_id="conv-123",
+        mark_type="later",
+    )
+
+    parsed = json.loads(result)
+    assert parsed["is_error"] is True
+    assert "star, pin, archive" in parsed["error"]
+
+
 def test_list_saved_views_decodes_query_json(mcp_server: MCPServerUnderTest) -> None:
     with patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue:
         mock_poly = make_polylogue_mock()
@@ -119,14 +131,6 @@ def test_save_saved_view_validates_query_spec(mcp_server: MCPServerUnderTest) ->
     with patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue:
         mock_poly = make_polylogue_mock()
         mock_poly.save_view = AsyncMock(return_value=True)
-        mock_poly.get_view = AsyncMock(
-            return_value={
-                "view_id": "view-1",
-                "name": "Claude Code",
-                "query_json": '{"provider":"claude-code"}',
-                "created_at": "2026-05-15T00:00:00+00:00",
-            }
-        )
         mock_get_polylogue.return_value = mock_poly
 
         result = invoke_surface(
@@ -142,6 +146,27 @@ def test_save_saved_view_validates_query_spec(mcp_server: MCPServerUnderTest) ->
     mock_poly.save_view.assert_awaited_once_with("view-1", "Claude Code", '{"provider":"claude-code"}')
 
 
+def test_save_saved_view_default_id_is_content_addressed(mcp_server: MCPServerUnderTest) -> None:
+    with patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue:
+        mock_poly = make_polylogue_mock()
+        mock_poly.save_view = AsyncMock(return_value=False)
+        mock_get_polylogue.return_value = mock_poly
+
+        result = invoke_surface(
+            mcp_server._tool_manager._tools["save_saved_view"].fn,
+            name="Claude Code",
+            query_json='{"provider":"claude-code"}',
+        )
+
+    parsed = json.loads(result)
+    assert parsed["status"] == "ok"
+    assert parsed["outcome"] == "updated"
+    assert str(parsed["key"]).startswith("saved-view-")
+    saved_id = mock_poly.save_view.await_args.args[0]
+    assert saved_id == parsed["key"]
+    assert saved_id != "claude-code"
+
+
 def test_save_saved_view_rejects_unknown_query_param(mcp_server: MCPServerUnderTest) -> None:
     result = invoke_surface(
         mcp_server._tool_manager._tools["save_saved_view"].fn,
@@ -153,6 +178,7 @@ def test_save_saved_view_rejects_unknown_query_param(mcp_server: MCPServerUnderT
     parsed = json.loads(result)
     assert parsed["is_error"] is True
     assert "ConversationQuerySpec" in parsed["error"]
+    assert "not_a_filter" in parsed["detail"]
 
 
 def test_delete_saved_view_reports_status(mcp_server: MCPServerUnderTest) -> None:

--- a/tests/unit/mcp/test_user_state_tools.py
+++ b/tests/unit/mcp/test_user_state_tools.py
@@ -1,0 +1,169 @@
+"""MCP user-state tool contracts (#867)."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+from tests.infra.mcp import MCPServerUnderTest, invoke_surface, make_polylogue_mock, make_query_store_mock
+
+
+def test_list_marks_returns_typed_items(mcp_server: MCPServerUnderTest) -> None:
+    with patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue:
+        mock_poly = make_polylogue_mock()
+        mock_poly.list_marks = AsyncMock(
+            return_value=[
+                {
+                    "conversation_id": "test:conv-123",
+                    "mark_type": "star",
+                    "created_at": "2026-05-15T00:00:00+00:00",
+                }
+            ]
+        )
+        mock_get_polylogue.return_value = mock_poly
+
+        result = invoke_surface(
+            mcp_server._tool_manager._tools["list_marks"].fn,
+            mark_type="star",
+            conversation_id="test:conv-123",
+        )
+
+    parsed = json.loads(result)
+    assert parsed["total"] == 1
+    assert parsed["items"][0]["mark_type"] == "star"
+    mock_poly.list_marks.assert_awaited_once_with(mark_type="star", conversation_id="test:conv-123")
+
+
+def test_add_mark_resolves_conversation_and_reports_idempotency(mcp_server: MCPServerUnderTest) -> None:
+    with (
+        patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue,
+        patch("polylogue.mcp.server._get_query_store") as mock_get_query_store,
+    ):
+        mock_poly = make_polylogue_mock()
+        mock_poly.add_mark = AsyncMock(return_value=False)
+        mock_get_polylogue.return_value = mock_poly
+        mock_get_query_store.return_value = make_query_store_mock(resolved_id="test:conv-123")
+
+        result = invoke_surface(
+            mcp_server._tool_manager._tools["add_mark"].fn,
+            conversation_id="conv-123",
+            mark_type="pin",
+        )
+
+    parsed = json.loads(result)
+    assert parsed["status"] == "unchanged"
+    assert parsed["conversation_id"] == "test:conv-123"
+    assert parsed["key"] == "pin"
+    assert parsed["detail"] == "already_present"
+    mock_poly.add_mark.assert_awaited_once_with("test:conv-123", "pin")
+
+
+def test_add_mark_rejects_unknown_type(mcp_server: MCPServerUnderTest) -> None:
+    result = invoke_surface(
+        mcp_server._tool_manager._tools["add_mark"].fn,
+        conversation_id="conv-123",
+        mark_type="later",
+    )
+
+    parsed = json.loads(result)
+    assert parsed["is_error"] is True
+    assert "star, pin, archive" in parsed["error"]
+
+
+def test_remove_mark_reports_missing_mark(mcp_server: MCPServerUnderTest) -> None:
+    with (
+        patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue,
+        patch("polylogue.mcp.server._get_query_store") as mock_get_query_store,
+    ):
+        mock_poly = make_polylogue_mock()
+        mock_poly.remove_mark = AsyncMock(return_value=False)
+        mock_get_polylogue.return_value = mock_poly
+        mock_get_query_store.return_value = make_query_store_mock(resolved_id="test:conv-123")
+
+        result = invoke_surface(
+            mcp_server._tool_manager._tools["remove_mark"].fn,
+            conversation_id="conv-123",
+            mark_type="star",
+        )
+
+    parsed = json.loads(result)
+    assert parsed["status"] == "not_found"
+    assert parsed["detail"] == "mark_not_present"
+    mock_poly.remove_mark.assert_awaited_once_with("test:conv-123", "star")
+
+
+def test_list_saved_views_decodes_query_json(mcp_server: MCPServerUnderTest) -> None:
+    with patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue:
+        mock_poly = make_polylogue_mock()
+        mock_poly.list_views = AsyncMock(
+            return_value=[
+                {
+                    "view_id": "view-1",
+                    "name": "Claude Code",
+                    "query_json": '{"provider":"claude-code","query":"Hello"}',
+                    "created_at": "2026-05-15T00:00:00+00:00",
+                }
+            ]
+        )
+        mock_get_polylogue.return_value = mock_poly
+
+        result = invoke_surface(mcp_server._tool_manager._tools["list_saved_views"].fn)
+
+    parsed = json.loads(result)
+    assert parsed["total"] == 1
+    assert parsed["items"][0]["query"] == {"provider": "claude-code", "query": "Hello"}
+    mock_poly.list_views.assert_awaited_once_with()
+
+
+def test_save_saved_view_validates_query_spec(mcp_server: MCPServerUnderTest) -> None:
+    with patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue:
+        mock_poly = make_polylogue_mock()
+        mock_poly.save_view = AsyncMock(return_value=True)
+        mock_poly.get_view = AsyncMock(
+            return_value={
+                "view_id": "view-1",
+                "name": "Claude Code",
+                "query_json": '{"provider":"claude-code"}',
+                "created_at": "2026-05-15T00:00:00+00:00",
+            }
+        )
+        mock_get_polylogue.return_value = mock_poly
+
+        result = invoke_surface(
+            mcp_server._tool_manager._tools["save_saved_view"].fn,
+            name="Claude Code",
+            query_json='{"provider":"claude-code"}',
+            view_id="view-1",
+        )
+
+    parsed = json.loads(result)
+    assert parsed["status"] == "ok"
+    assert parsed["key"] == "view-1"
+    mock_poly.save_view.assert_awaited_once_with("view-1", "Claude Code", '{"provider":"claude-code"}')
+
+
+def test_save_saved_view_rejects_unknown_query_param(mcp_server: MCPServerUnderTest) -> None:
+    result = invoke_surface(
+        mcp_server._tool_manager._tools["save_saved_view"].fn,
+        name="bad",
+        query_json='{"not_a_filter":true}',
+        view_id="bad",
+    )
+
+    parsed = json.loads(result)
+    assert parsed["is_error"] is True
+    assert "ConversationQuerySpec" in parsed["error"]
+
+
+def test_delete_saved_view_reports_status(mcp_server: MCPServerUnderTest) -> None:
+    with patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue:
+        mock_poly = make_polylogue_mock()
+        mock_poly.delete_view = AsyncMock(return_value=True)
+        mock_get_polylogue.return_value = mock_poly
+
+        result = invoke_surface(mcp_server._tool_manager._tools["delete_saved_view"].fn, view_id="view-1")
+
+    parsed = json.loads(result)
+    assert parsed["status"] == "deleted"
+    assert parsed["key"] == "view-1"
+    mock_poly.delete_view.assert_awaited_once_with("view-1")


### PR DESCRIPTION
## Summary

Expose the durable reader user-state substrate through write-role MCP tools for conversation marks and saved views, using typed payloads and existing Polylogue facade methods.

## Problem

#867 user state was now available through daemon HTTP and the reader UI, but MCP clients still could not list or mutate marks or saved views. That left agent-facing recall workflows behind the web surface and kept the MCP wire schema stale relative to the product state now exposed elsewhere.

## Solution

- Add typed MCP payloads for user marks and saved views.
- Register `list_marks`, `add_mark`, and `remove_mark` mutation tools.
- Register `list_saved_views`, `save_saved_view`, and `delete_saved_view` mutation tools.
- Resolve conversation IDs before mark mutations and validate saved-view query JSON through strict `ConversationQuerySpec` construction.
- Classify the new tools in the MCP envelope contract and regenerate the committed tool-schema witness.
- Move user-state MCP tests into a focused file so the existing broad MCP contract file stays under its file-size budget.

Remaining #867 scope: annotations, message/range targets, recall-pack MCP shape, and CLI parity.

Ref #867

## Verification

- `pytest -q tests/unit/mcp/test_tool_contracts.py -k "mark or saved_view"` -> 37 passed
- `pytest -q tests/unit/mcp/test_user_state_tools.py tests/unit/mcp/test_envelope_contracts.py tests/unit/mcp/test_tool_schema_witness.py` -> 33 passed
- `pytest -q tests/unit/mcp` -> 188 passed
- `ruff format --check polylogue/mcp/server_mutation_tools.py polylogue/mcp/payloads.py tests/unit/mcp/test_tool_contracts.py tests/unit/mcp/test_user_state_tools.py tests/unit/mcp/test_envelope_contracts.py` -> 5 files already formatted
- `ruff check polylogue/mcp/server_mutation_tools.py polylogue/mcp/payloads.py tests/unit/mcp/test_tool_contracts.py tests/unit/mcp/test_user_state_tools.py tests/unit/mcp/test_envelope_contracts.py` -> All checks passed
- `mypy polylogue/mcp/server_mutation_tools.py polylogue/mcp/payloads.py tests/unit/mcp/test_tool_contracts.py tests/unit/mcp/test_user_state_tools.py tests/unit/mcp/test_envelope_contracts.py` -> Success
- `devtools verify --quick` -> exit_code 0
- `devtools verify --affected --skip-slow` -> exit_code 0; pytest affected count 8


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added MCP tools to manage conversation marks: create, remove, and list marks
  * Added MCP tools to manage saved query views: save, delete, and list views with proper validation

* **Tests**
  * Added comprehensive unit tests validating user-state tools behavior

* **Documentation**
  * Updated execution log documenting user-state parity launch roadmap

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sinity/polylogue/pull/1052)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->