### PR TITLE
feat: add typed recall-pack target evidence

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -355,9 +355,10 @@ Options:
   --help  Show this message and exit.
 
 Commands:
-  annotations  Manage conversation and message annotations.
-  marks        Manage conversation and message marks.
-  saved-views  Manage saved query views.
+  annotations   Manage conversation and message annotations.
+  marks         Manage conversation and message marks.
+  recall-packs  Manage recall packs with explicit target evidence.
+  saved-views   Manage saved query views.
 ```
 
 ## Auth

--- a/docs/plans/mk3-execution-log.md
+++ b/docs/plans/mk3-execution-log.md
@@ -528,3 +528,55 @@ Verification:
 - `ruff format --check <changed files>`
 - `ruff check <changed files>`
 - `python -m mypy <changed files>`
+
+### 2026-05-15 - #867 recall-pack target evidence launch
+
+Target:
+
+- Complete the next recall-pack slice without another schema migration by
+  making the stored payload typed and self-describing.
+- Preserve daemon compatibility for legacy `conversation_ids` while allowing
+  explicit conversation/message/mark/annotation items.
+- Add CLI and MCP parity so recall packs are not daemon-only user state.
+
+Coordination:
+
+- Branch: `feature/feat/recall-pack-target-evidence`.
+- Read-only sidecar confirmed existing recall packs only surfaced through the
+  async facade, storage helpers, and daemon `/api/user/recall-packs`; CLI and
+  MCP parity were absent.
+- Implementation kept storage table shape stable and centralized target
+  resolution in the `Polylogue` facade.
+
+Owned files:
+
+- `polylogue/api/archive.py`
+- `polylogue/daemon/user_state_http.py`
+- `polylogue/cli/commands/user_state.py`
+- `polylogue/mcp/payloads.py`
+- `polylogue/mcp/server_mutation_tools.py`
+- user-state storage, daemon, CLI, and MCP tests
+
+Outcome:
+
+- Recall-pack saves now normalize legacy `conversation_ids` and explicit
+  `items` into a payload with `schema_version`, `items`, `resolved_count`, and
+  `degraded_count`.
+- Conversation, message, mark, and annotation items resolve to stable target
+  evidence where possible.
+- Missing conversations/messages/marks/annotations degrade explicitly with
+  `status` and `disabled_reason`.
+- Unsupported future target types are preserved as unsupported degraded items
+  instead of being silently dropped.
+- Added `polylogue user-state recall-packs list/save/delete`.
+- Added MCP `list_recall_packs`, `save_recall_pack`, and
+  `delete_recall_pack`, with envelope classification and regenerated schema
+  witness.
+
+Verification:
+
+- `pytest -q -n0 tests/unit/storage/test_user_state_contracts.py tests/unit/daemon/test_web_reader.py::TestReaderUserState::test_recall_packs_roundtrip_cited_conversations tests/unit/cli/test_user_state_command.py tests/unit/mcp/test_user_state_tools.py`
+- `ruff check polylogue/api/archive.py polylogue/cli/commands/user_state.py polylogue/mcp/payloads.py polylogue/mcp/server_mutation_tools.py tests/unit/storage/test_user_state_contracts.py tests/unit/daemon/test_web_reader.py tests/unit/cli/test_user_state_command.py tests/unit/mcp/test_user_state_tools.py`
+- `python -m mypy polylogue/api/archive.py polylogue/cli/commands/user_state.py polylogue/mcp/payloads.py polylogue/mcp/server_mutation_tools.py`
+- `pytest -q -n0 tests/unit/mcp/test_tool_schema_witness.py tests/unit/mcp/test_envelope_contracts.py tests/unit/cli/test_click_app.py::TestCliMetadata::test_all_subcommands_registered tests/unit/mcp/test_user_state_tools.py tests/unit/cli/test_user_state_command.py`
+- `devtools render-all --check`

--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -793,16 +793,193 @@ class PolylogueArchiveMixin:
     # Recall packs
     # ------------------------------------------------------------------
 
+    async def _resolve_recall_pack_item(self, item: dict[str, object]) -> dict[str, object]:
+        item_type = str(item.get("target_type") or item.get("type") or "conversation")
+        if item_type == "conversation":
+            conversation_id = str(item.get("conversation_id") or item.get("target_id") or item.get("id") or "")
+            resolved = await self.repository.resolve_id(conversation_id, strict=True) if conversation_id else None
+            if resolved is None:
+                return {
+                    "target_type": "conversation",
+                    "target_id": conversation_id,
+                    "conversation_id": conversation_id or None,
+                    "status": "missing",
+                    "disabled_reason": "conversation_not_found",
+                }
+            resolved_id = str(resolved)
+            return {
+                "target_type": "conversation",
+                "target_id": resolved_id,
+                "conversation_id": resolved_id,
+                "status": "resolved",
+                "identity_key": f"conversation:{resolved_id}",
+            }
+
+        if item_type == "message":
+            conversation_id = str(item.get("conversation_id") or "")
+            message_id = str(item.get("message_id") or item.get("target_id") or item.get("id") or "")
+            try:
+                target = await self._resolve_user_state_target(
+                    conversation_id,
+                    target_type="message",
+                    message_id=message_id,
+                )
+            except (ConversationNotFoundError, ValueError) as exc:
+                return {
+                    "target_type": "message",
+                    "target_id": message_id,
+                    "conversation_id": conversation_id or None,
+                    "message_id": message_id or None,
+                    "status": "missing",
+                    "disabled_reason": str(exc) or "message_not_found",
+                }
+            conversation_target_id = str(target["conversation_id"])
+            resolved_message_id = str(target["message_id"])
+            return {
+                "target_type": "message",
+                "target_id": resolved_message_id,
+                "conversation_id": conversation_target_id,
+                "message_id": resolved_message_id,
+                "status": "resolved",
+                "identity_key": f"message:{conversation_target_id}:{resolved_message_id}",
+            }
+
+        if item_type == "annotation":
+            annotation_id = str(item.get("annotation_id") or item.get("target_id") or item.get("id") or "")
+            row = await self.get_annotation(annotation_id) if annotation_id else None
+            if row is None:
+                return {
+                    "target_type": "annotation",
+                    "target_id": annotation_id,
+                    "annotation_id": annotation_id or None,
+                    "status": "missing",
+                    "disabled_reason": "annotation_not_found",
+                }
+            return {
+                "target_type": "annotation",
+                "target_id": row["annotation_id"],
+                "annotation_id": row["annotation_id"],
+                "conversation_id": row["conversation_id"],
+                "message_id": row["message_id"] or None,
+                "annotated_target_type": row["target_type"],
+                "annotated_target_id": row["target_id"],
+                "note_text": row["note_text"],
+                "status": "resolved",
+                "identity_key": f"annotation:{row['annotation_id']}",
+            }
+
+        if item_type == "mark":
+            mark_type = str(item.get("mark_type") or "")
+            mark_target_type = str(item.get("mark_target_type") or item.get("target_ref_type") or "conversation")
+            mark_target_id = str(item.get("mark_target_id") or item.get("target_id") or item.get("id") or "")
+            conversation_id = str(item.get("conversation_id") or "")
+            mark_message_id: str | None = str(item.get("message_id") or "") or None
+            if not mark_type:
+                return {
+                    "target_type": "mark",
+                    "target_id": mark_target_id,
+                    "conversation_id": conversation_id or None,
+                    "message_id": mark_message_id,
+                    "status": "missing",
+                    "disabled_reason": "mark_type_missing",
+                }
+            rows = await self.list_marks(
+                mark_type=mark_type,
+                conversation_id=conversation_id or None,
+                target_type=mark_target_type,
+                target_id=mark_target_id or None,
+                message_id=mark_message_id,
+            )
+            if not rows:
+                return {
+                    "target_type": "mark",
+                    "target_id": f"{mark_target_type}:{mark_target_id}:{mark_type}",
+                    "conversation_id": conversation_id or None,
+                    "message_id": mark_message_id,
+                    "mark_type": mark_type,
+                    "mark_target_type": mark_target_type,
+                    "mark_target_id": mark_target_id,
+                    "status": "missing",
+                    "disabled_reason": "mark_not_found",
+                }
+            row = rows[0]
+            return {
+                "target_type": "mark",
+                "target_id": f"{row['target_type']}:{row['target_id']}:{row['mark_type']}",
+                "conversation_id": row["conversation_id"],
+                "message_id": row["message_id"] or None,
+                "mark_type": row["mark_type"],
+                "mark_target_type": row["target_type"],
+                "mark_target_id": row["target_id"],
+                "status": "resolved",
+                "identity_key": f"mark:{row['target_type']}:{row['target_id']}:{row['mark_type']}",
+            }
+
+        return {
+            "target_type": item_type,
+            "target_id": str(item.get("target_id") or item.get("id") or ""),
+            "status": "unsupported",
+            "disabled_reason": "unsupported_target_type",
+        }
+
+    async def _build_recall_pack_payload(
+        self,
+        *,
+        label: str,
+        conversation_ids: Sequence[str],
+        payload: dict[str, object],
+    ) -> tuple[list[str], str]:
+        raw_items: list[dict[str, object]] = [
+            {"target_type": "conversation", "conversation_id": conversation_id} for conversation_id in conversation_ids
+        ]
+        explicit_items = payload.get("items")
+        if isinstance(explicit_items, list):
+            raw_items.extend(item for item in explicit_items if isinstance(item, dict))
+
+        items = [await self._resolve_recall_pack_item(item) for item in raw_items]
+        resolved_conversation_ids: list[str] = []
+        for item in items:
+            conversation_id = item.get("conversation_id")
+            if (
+                item.get("status") == "resolved"
+                and isinstance(conversation_id, str)
+                and conversation_id not in resolved_conversation_ids
+            ):
+                resolved_conversation_ids.append(conversation_id)
+
+        normalized_payload = {
+            "schema_version": 1,
+            "label": label,
+            "summary": payload.get("summary") or payload.get("reason") or "",
+            "items": items,
+            "resolved_count": sum(1 for item in items if item.get("status") == "resolved"),
+            "degraded_count": sum(1 for item in items if item.get("status") != "resolved"),
+        }
+        for key, value in payload.items():
+            if key not in {"items", "summary", "reason"}:
+                normalized_payload[key] = value
+        import json
+
+        return resolved_conversation_ids, json.dumps(normalized_payload, sort_keys=True, separators=(",", ":"))
+
     async def create_recall_pack(self, pack_id: str, label: str, conversation_id: str, payload_json: str) -> bool:
         """Save a recall pack. Returns ``True`` if newly created."""
         import json
 
         conversation_ids = json.loads(conversation_id) if conversation_id.startswith("[") else [conversation_id]
-        conversation_ids_json = json.dumps(conversation_ids)
+        payload = json.loads(payload_json)
+        if not isinstance(payload, dict):
+            raise ValueError("recall pack payload must be a JSON object")
+        resolved_conversation_ids, normalized_payload_json = await self._build_recall_pack_payload(
+            label=label,
+            conversation_ids=[str(item) for item in conversation_ids],
+            payload=payload,
+        )
+        conversation_ids_json = json.dumps(resolved_conversation_ids, sort_keys=True)
         from polylogue.storage.repository.archive.repository_writes import RepositoryWriteMixin
 
         store: RepositoryWriteMixin = self.repository
-        return await store.save_recall_pack(pack_id, label, conversation_ids_json, payload_json)
+        return await store.save_recall_pack(pack_id, label, conversation_ids_json, normalized_payload_json)
 
     async def get_recall_pack(self, pack_id: str) -> dict[str, str] | None:
         """Get a recall pack by ID."""

--- a/polylogue/cli/commands/user_state.py
+++ b/polylogue/cli/commands/user_state.py
@@ -45,6 +45,16 @@ def _canonical_query_json(query_json: str) -> str:
     return json.dumps(query, sort_keys=True, separators=(",", ":"))
 
 
+def _canonical_json_object(raw_json: str, *, label: str) -> dict[str, object]:
+    try:
+        payload = json.loads(raw_json)
+    except json.JSONDecodeError as exc:
+        raise click.ClickException(f"{label} must be valid JSON") from exc
+    if not isinstance(payload, dict):
+        raise click.ClickException(f"{label} must encode an object")
+    return payload
+
+
 def _default_saved_view_id(name: str, query_json: str) -> str:
     digest = sha256(f"{name}\0{query_json}".encode()).hexdigest()
     return f"saved-view-{digest[:16]}"
@@ -317,6 +327,84 @@ def delete_saved_view_command(env: AppEnv, view_id: str, output_format: str | No
         output_format,
         {"status": "deleted" if deleted else "not_found", "view_id": view_id},
         f"Saved view {view_id}: {'deleted' if deleted else 'not found'}",
+    )
+
+
+@user_state_command.group("recall-packs")
+def recall_packs_group() -> None:
+    """Manage recall packs with explicit target evidence."""
+
+
+@recall_packs_group.command("list")
+@click.option("--format", "-f", "output_format", type=click.Choice(["json"]), default=None)
+@click.pass_obj
+def list_recall_packs_command(env: AppEnv, output_format: str | None) -> None:
+    """List recall packs."""
+    rows = _run(env.polylogue.list_recall_packs())
+    if output_format == "json":
+        emit_success({"items": rows, "total": len(rows)})
+        return
+    if not rows:
+        click.echo("No recall packs found.")
+        return
+    for row in rows:
+        click.echo(f"{row['pack_id']:<24} {row['label']}")
+
+
+@recall_packs_group.command("save")
+@click.argument("pack_id")
+@click.argument("label")
+@click.option("--conversation-id", "conversation_ids", multiple=True)
+@click.option("--item-json", "item_jsons", multiple=True, help="Recall-pack item JSON object.")
+@click.option("--payload-json", default="{}", help="Additional recall-pack payload JSON object.")
+@click.option("--format", "-f", "output_format", type=click.Choice(["json"]), default=None)
+@click.pass_obj
+def save_recall_pack_command(
+    env: AppEnv,
+    pack_id: str,
+    label: str,
+    conversation_ids: tuple[str, ...],
+    item_jsons: tuple[str, ...],
+    payload_json: str,
+    output_format: str | None,
+) -> None:
+    """Create or update a recall pack."""
+    payload = _canonical_json_object(payload_json, label="payload-json")
+    payload_items = payload.get("items", [])
+    if not isinstance(payload_items, list) or not all(isinstance(item, dict) for item in payload_items):
+        raise click.ClickException("payload-json items must be objects")
+    items = list(payload_items)
+    items.extend(_canonical_json_object(raw, label="item-json") for raw in item_jsons)
+    if items:
+        payload["items"] = items
+    created = bool(
+        _run(
+            env.polylogue.create_recall_pack(
+                pack_id,
+                label,
+                json.dumps(list(conversation_ids), sort_keys=True),
+                json.dumps(payload, sort_keys=True, separators=(",", ":")),
+            )
+        )
+    )
+    _json_or_plain(
+        output_format,
+        {"status": "ok", "pack_id": pack_id, "outcome": "added" if created else "updated"},
+        f"Recall pack {pack_id}: {'added' if created else 'updated'}",
+    )
+
+
+@recall_packs_group.command("delete")
+@click.argument("pack_id")
+@click.option("--format", "-f", "output_format", type=click.Choice(["json"]), default=None)
+@click.pass_obj
+def delete_recall_pack_command(env: AppEnv, pack_id: str, output_format: str | None) -> None:
+    """Delete a recall pack."""
+    deleted = bool(_run(env.polylogue.delete_recall_pack(pack_id)))
+    _json_or_plain(
+        output_format,
+        {"status": "deleted" if deleted else "not_found", "pack_id": pack_id},
+        f"Recall pack {pack_id}: {'deleted' if deleted else 'not found'}",
     )
 
 

--- a/polylogue/mcp/payloads.py
+++ b/polylogue/mcp/payloads.py
@@ -434,6 +434,19 @@ class MCPSavedViewListPayload(SurfacePayloadModel):
     total: int
 
 
+class MCPRecallPackPayload(SurfacePayloadModel):
+    pack_id: str
+    label: str
+    conversation_ids: tuple[str, ...]
+    payload: dict[str, object]
+    created_at: str
+
+
+class MCPRecallPackListPayload(SurfacePayloadModel):
+    items: tuple[MCPRecallPackPayload, ...]
+    total: int
+
+
 class MCPStatsByPayload(MCPRootPayload[dict[str, int]]):
     root: dict[str, int]
 
@@ -590,6 +603,8 @@ __all__ = [
     "MCPTagCountsPayload",
     "MCPSavedViewListPayload",
     "MCPSavedViewPayload",
+    "MCPRecallPackListPayload",
+    "MCPRecallPackPayload",
     "MCPUserMarkListPayload",
     "MCPUserMarkPayload",
     "MCPUserAnnotationListPayload",

--- a/polylogue/mcp/server_mutation_tools.py
+++ b/polylogue/mcp/server_mutation_tools.py
@@ -9,6 +9,8 @@ from typing import TYPE_CHECKING, Any
 
 from polylogue.mcp.payloads import (
     MCPMetadataPayload,
+    MCPRecallPackListPayload,
+    MCPRecallPackPayload,
     MCPSavedViewListPayload,
     MCPSavedViewPayload,
     MCPTagCountsPayload,
@@ -55,6 +57,28 @@ def _saved_view_payload(row: dict[str, str]) -> MCPSavedViewPayload:
         view_id=row["view_id"],
         name=row["name"],
         query=query,
+        created_at=row["created_at"],
+    )
+
+
+def _recall_pack_payload(row: dict[str, str]) -> MCPRecallPackPayload:
+    try:
+        conversation_ids = json.loads(row["conversation_ids_json"])
+    except (json.JSONDecodeError, TypeError):
+        conversation_ids = []
+    if not isinstance(conversation_ids, list):
+        conversation_ids = []
+    try:
+        payload = json.loads(row["payload_json"])
+    except (json.JSONDecodeError, TypeError):
+        payload = {}
+    if not isinstance(payload, dict):
+        payload = {}
+    return MCPRecallPackPayload(
+        pack_id=row["pack_id"],
+        label=row["label"],
+        conversation_ids=tuple(str(item) for item in conversation_ids),
+        payload=payload,
         created_at=row["created_at"],
     )
 
@@ -398,6 +422,74 @@ def register_mutation_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
             )
 
         return await hooks.async_safe_call("delete_saved_view", run)
+
+    @mcp.tool()
+    async def list_recall_packs() -> str:
+        async def run() -> str:
+            poly = hooks.get_polylogue()
+            rows = await poly.list_recall_packs()
+            items = tuple(_recall_pack_payload(row) for row in rows)
+            return hooks.json_payload(MCPRecallPackListPayload(items=items, total=len(items)))
+
+        return await hooks.async_safe_call("list_recall_packs", run)
+
+    @mcp.tool()
+    async def save_recall_pack(
+        pack_id: str,
+        label: str,
+        conversation_ids_json: str = "[]",
+        payload_json: str = "{}",
+    ) -> str:
+        async def run() -> str:
+            if not pack_id.strip():
+                return hooks.error_json("pack_id must not be empty")
+            if not label.strip():
+                return hooks.error_json("label must not be empty")
+            try:
+                conversation_ids = json.loads(conversation_ids_json)
+            except json.JSONDecodeError:
+                return hooks.error_json("conversation_ids_json must be valid JSON")
+            if not isinstance(conversation_ids, list):
+                return hooks.error_json("conversation_ids_json must encode a list")
+            try:
+                payload = json.loads(payload_json)
+            except json.JSONDecodeError:
+                return hooks.error_json("payload_json must be valid JSON")
+            if not isinstance(payload, dict):
+                return hooks.error_json("payload_json must encode an object")
+            poly = hooks.get_polylogue()
+            created = await poly.create_recall_pack(
+                pack_id.strip(),
+                label.strip(),
+                json.dumps([str(item) for item in conversation_ids], sort_keys=True),
+                json.dumps(payload, sort_keys=True, separators=(",", ":")),
+            )
+            return hooks.json_payload(
+                MutationResultPayload(
+                    status="ok",
+                    key=pack_id.strip(),
+                    outcome="added" if created else "updated",
+                ),
+                exclude_none=True,
+            )
+
+        return await hooks.async_safe_call("save_recall_pack", run)
+
+    @mcp.tool()
+    async def delete_recall_pack(pack_id: str) -> str:
+        async def run() -> str:
+            poly = hooks.get_polylogue()
+            deleted = await poly.delete_recall_pack(pack_id)
+            return hooks.json_payload(
+                MutationResultPayload(
+                    status="deleted" if deleted else "not_found",
+                    detail=None if deleted else "recall_pack_not_found",
+                    key=pack_id,
+                ),
+                exclude_none=True,
+            )
+
+        return await hooks.async_safe_call("delete_recall_pack", run)
 
     @mcp.tool()
     async def get_metadata(conversation_id: str) -> str:

--- a/tests/data/witnesses/mcp-tool-schemas.json
+++ b/tests/data/witnesses/mcp-tool-schemas.json
@@ -429,6 +429,22 @@
     }
   },
   {
+    "name": "delete_recall_pack",
+    "parameters": {
+      "properties": {
+        "pack_id": {
+          "title": "Pack Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "pack_id"
+      ],
+      "title": "delete_recall_packArguments",
+      "type": "object"
+    }
+  },
+  {
     "name": "delete_saved_view",
     "parameters": {
       "properties": {
@@ -1448,6 +1464,14 @@
     }
   },
   {
+    "name": "list_recall_packs",
+    "parameters": {
+      "properties": {},
+      "title": "list_recall_packsArguments",
+      "type": "object"
+    }
+  },
+  {
     "name": "list_saved_views",
     "parameters": {
       "properties": {},
@@ -1756,6 +1780,37 @@
         "note_text"
       ],
       "title": "save_annotationArguments",
+      "type": "object"
+    }
+  },
+  {
+    "name": "save_recall_pack",
+    "parameters": {
+      "properties": {
+        "conversation_ids_json": {
+          "default": "[]",
+          "title": "Conversation Ids Json",
+          "type": "string"
+        },
+        "label": {
+          "title": "Label",
+          "type": "string"
+        },
+        "pack_id": {
+          "title": "Pack Id",
+          "type": "string"
+        },
+        "payload_json": {
+          "default": "{}",
+          "title": "Payload Json",
+          "type": "string"
+        }
+      },
+      "required": [
+        "pack_id",
+        "label"
+      ],
+      "title": "save_recall_packArguments",
       "type": "object"
     }
   },

--- a/tests/unit/cli/test_user_state_command.py
+++ b/tests/unit/cli/test_user_state_command.py
@@ -30,6 +30,9 @@ def _env() -> MagicMock:
     env.polylogue.list_views = AsyncMock(return_value=[])
     env.polylogue.save_view = AsyncMock(return_value=True)
     env.polylogue.delete_view = AsyncMock(return_value=False)
+    env.polylogue.list_recall_packs = AsyncMock(return_value=[])
+    env.polylogue.create_recall_pack = AsyncMock(return_value=True)
+    env.polylogue.delete_recall_pack = AsyncMock(return_value=False)
     return env
 
 
@@ -145,3 +148,37 @@ def test_user_state_saved_view_rejects_unknown_query_param(cli_runner: CliRunner
 
     assert result.exit_code != 0
     assert "ConversationQuerySpec" in result.output
+
+
+def test_user_state_recall_pack_save_passes_typed_items(cli_runner: CliRunner) -> None:
+    env = _env()
+
+    result = cli_runner.invoke(
+        user_state_command,
+        [
+            "recall-packs",
+            "save",
+            "pack-1",
+            "Handoff",
+            "--conversation-id",
+            "conv-1",
+            "--item-json",
+            '{"target_type":"annotation","annotation_id":"ann-1"}',
+            "--payload-json",
+            '{"summary":"handoff"}',
+            "--format",
+            "json",
+        ],
+        obj=env,
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    payload = _result(result.output)
+    assert payload["pack_id"] == "pack-1"
+    env.polylogue.create_recall_pack.assert_awaited_once_with(
+        "pack-1",
+        "Handoff",
+        '["conv-1"]',
+        '{"items":[{"annotation_id":"ann-1","target_type":"annotation"}],"summary":"handoff"}',
+    )

--- a/tests/unit/daemon/test_web_reader.py
+++ b/tests/unit/daemon/test_web_reader.py
@@ -494,8 +494,17 @@ class TestReaderUserState:
                 payload={
                     "pack_id": "pack-auth",
                     "label": "Auth pack",
-                    "conversation_ids": ["c1", "c2"],
-                    "payload": {"reason": "handoff"},
+                    "conversation_ids": ["c1", "missing-conv"],
+                    "payload": {
+                        "summary": "handoff",
+                        "items": [
+                            {
+                                "target_type": "message",
+                                "conversation_id": "c1",
+                                "message_id": "missing-msg",
+                            }
+                        ],
+                    },
                 },
             )
             listed = _get_json(base_url, "/api/user/recall-packs")
@@ -508,8 +517,17 @@ class TestReaderUserState:
         assert status == 201
         assert saved_payload["created"] is True
         assert listed_payload["total"] == 1
-        assert fetched_payload["conversation_ids"] == ["c1", "c2"]
-        assert fetched_payload["payload"] == {"reason": "handoff"}
+        assert fetched_payload["conversation_ids"] == ["c1"]
+        payload = cast(dict[str, object], fetched_payload["payload"])
+        assert payload["summary"] == "handoff"
+        assert payload["resolved_count"] == 1
+        assert payload["degraded_count"] == 2
+        items = cast(list[dict[str, object]], payload["items"])
+        assert [(item["target_type"], item["status"]) for item in items] == [
+            ("conversation", "resolved"),
+            ("conversation", "missing"),
+            ("message", "missing"),
+        ]
         assert delete_status == 200
         assert deleted == {"pack_id": "pack-auth", "deleted": True}
 

--- a/tests/unit/mcp/test_envelope_contracts.py
+++ b/tests/unit/mcp/test_envelope_contracts.py
@@ -57,6 +57,7 @@ TOOL_CONTRACT: dict[str, ToolKind] = {
     "list_marks": ("envelope", frozenset({"items", "total"})),
     "list_annotations": ("envelope", frozenset({"items", "total"})),
     "list_saved_views": ("envelope", frozenset({"items", "total"})),
+    "list_recall_packs": ("envelope", frozenset({"items", "total"})),
     # ------- single record -------
     "get_conversation": "single_object",
     "get_conversation_summary": "single_object",
@@ -78,6 +79,8 @@ TOOL_CONTRACT: dict[str, ToolKind] = {
     "bulk_tag_conversations": "operation_result",
     "save_saved_view": "operation_result",
     "delete_saved_view": "operation_result",
+    "save_recall_pack": "operation_result",
+    "delete_recall_pack": "operation_result",
     "set_metadata": "operation_result",
     "delete_metadata": "operation_result",
     "delete_conversation": "operation_result",

--- a/tests/unit/mcp/test_user_state_tools.py
+++ b/tests/unit/mcp/test_user_state_tools.py
@@ -313,3 +313,60 @@ def test_delete_saved_view_reports_status(mcp_server: MCPServerUnderTest) -> Non
     assert parsed["status"] == "deleted"
     assert parsed["key"] == "view-1"
     mock_poly.delete_view.assert_awaited_once_with("view-1")
+
+
+def test_recall_pack_tools_roundtrip_typed_payloads(mcp_server: MCPServerUnderTest) -> None:
+    with patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue:
+        mock_poly = make_polylogue_mock()
+        mock_poly.create_recall_pack = AsyncMock(return_value=True)
+        mock_poly.list_recall_packs = AsyncMock(
+            return_value=[
+                {
+                    "pack_id": "pack-1",
+                    "label": "Handoff",
+                    "conversation_ids_json": '["conv-1"]',
+                    "payload_json": (
+                        '{"items":[{"target_type":"conversation","target_id":"conv-1","status":"resolved"}],'
+                        '"resolved_count":1,"degraded_count":0}'
+                    ),
+                    "created_at": "2026-05-15T00:00:00+00:00",
+                }
+            ]
+        )
+        mock_get_polylogue.return_value = mock_poly
+
+        saved = invoke_surface(
+            mcp_server._tool_manager._tools["save_recall_pack"].fn,
+            pack_id="pack-1",
+            label="Handoff",
+            conversation_ids_json='["conv-1"]',
+            payload_json='{"items":[{"target_type":"annotation","annotation_id":"ann-1"}]}',
+        )
+        listed = invoke_surface(mcp_server._tool_manager._tools["list_recall_packs"].fn)
+
+    saved_payload = json.loads(saved)
+    listed_payload = json.loads(listed)
+    assert saved_payload["status"] == "ok"
+    assert saved_payload["outcome"] == "added"
+    assert listed_payload["total"] == 1
+    assert listed_payload["items"][0]["payload"]["resolved_count"] == 1
+    mock_poly.create_recall_pack.assert_awaited_once_with(
+        "pack-1",
+        "Handoff",
+        '["conv-1"]',
+        '{"items":[{"annotation_id":"ann-1","target_type":"annotation"}]}',
+    )
+
+
+def test_delete_recall_pack_reports_status(mcp_server: MCPServerUnderTest) -> None:
+    with patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue:
+        mock_poly = make_polylogue_mock()
+        mock_poly.delete_recall_pack = AsyncMock(return_value=False)
+        mock_get_polylogue.return_value = mock_poly
+
+        result = invoke_surface(mcp_server._tool_manager._tools["delete_recall_pack"].fn, pack_id="pack-1")
+
+    parsed = json.loads(result)
+    assert parsed["status"] == "not_found"
+    assert parsed["detail"] == "recall_pack_not_found"
+    mock_poly.delete_recall_pack.assert_awaited_once_with("pack-1")

--- a/tests/unit/storage/test_user_state_contracts.py
+++ b/tests/unit/storage/test_user_state_contracts.py
@@ -110,3 +110,54 @@ async def test_message_target_user_state_rejects_unknown_messages(workspace_env:
                 target_type="message",
                 message_id="missing-message",
             )
+
+
+@pytest.mark.asyncio
+async def test_recall_pack_items_resolve_and_degrade_explicitly(workspace_env: dict[str, Path]) -> None:
+    db_path = db_setup(workspace_env)
+    ConversationBuilder(db_path, "conv-user-state").provider("claude-code").add_message(
+        message_id="msg-user-state",
+        text="Important message",
+    ).save()
+
+    async with Polylogue(db_path=db_path, archive_root=workspace_env["archive_root"]) as poly:
+        assert await poly.add_mark("conv-user-state", "pin", target_type="message", message_id="msg-user-state")
+        assert await poly.save_annotation(
+            "ann-msg", "conv-user-state", "Message note", target_type="message", message_id="msg-user-state"
+        )
+        created = await poly.create_recall_pack(
+            "pack-user-state",
+            "User state pack",
+            '["conv-user-state","missing-conv"]',
+            (
+                '{"items":['
+                '{"target_type":"message","conversation_id":"conv-user-state","message_id":"msg-user-state"},'
+                '{"target_type":"message","conversation_id":"conv-user-state","message_id":"missing-msg"},'
+                '{"target_type":"mark","mark_target_type":"message","mark_target_id":"msg-user-state","mark_type":"pin","conversation_id":"conv-user-state"},'
+                '{"target_type":"annotation","annotation_id":"ann-msg"},'
+                '{"target_type":"annotation","annotation_id":"missing-ann"},'
+                '{"target_type":"topology_edge","target_id":"edge-1"}'
+                '],"summary":"handoff"}'
+            ),
+        )
+        saved = await poly.get_recall_pack("pack-user-state")
+
+    assert created is True
+    assert saved is not None
+    import json
+
+    conversation_ids = json.loads(saved["conversation_ids_json"])
+    payload = json.loads(saved["payload_json"])
+    assert conversation_ids == ["conv-user-state"]
+    assert payload["schema_version"] == 1
+    assert payload["summary"] == "handoff"
+    assert payload["resolved_count"] == 4
+    assert payload["degraded_count"] == 4
+    item_statuses = {(item["target_type"], item["target_id"]): item["status"] for item in payload["items"]}
+    assert item_statuses[("conversation", "conv-user-state")] == "resolved"
+    assert item_statuses[("conversation", "missing-conv")] == "missing"
+    assert item_statuses[("message", "msg-user-state")] == "resolved"
+    assert item_statuses[("message", "missing-msg")] == "missing"
+    assert item_statuses[("annotation", "ann-msg")] == "resolved"
+    assert item_statuses[("annotation", "missing-ann")] == "missing"
+    assert item_statuses[("topology_edge", "edge-1")] == "unsupported"


### PR DESCRIPTION
## Summary
Add the next #867 recall-pack slice: recall packs now store typed target evidence with explicit resolved/degraded item states, and recall-pack operations have CLI and MCP parity.

## Problem
After target-aware marks, annotations, and saved views landed, recall packs still accepted an opaque payload and only exposed daemon endpoints. That left recall packs unable to cite message, mark, and annotation targets with auditable degraded states, and left operator/agent surfaces without parity.

## Solution
- Normalize recall-pack saves through the `Polylogue` facade into `schema_version: 1` payloads.
- Preserve legacy `conversation_ids` input while converting it to typed conversation items.
- Resolve conversation, message, mark, and annotation items into stable evidence where possible.
- Preserve missing targets with `status` and `disabled_reason` instead of dropping them.
- Preserve unsupported future target kinds as degraded items for later topology/workspace expansion.
- Add `polylogue user-state recall-packs list/save/delete`.
- Add MCP `list_recall_packs`, `save_recall_pack`, and `delete_recall_pack`, with envelope classification and regenerated tool-schema witness.
- Record the slice in `docs/plans/mk3-execution-log.md`.

Ref #867

## Verification
- `pytest -q -n0 tests/unit/storage/test_user_state_contracts.py tests/unit/daemon/test_web_reader.py::TestReaderUserState::test_recall_packs_roundtrip_cited_conversations tests/unit/cli/test_user_state_command.py tests/unit/mcp/test_user_state_tools.py` -> 24 passed
- `pytest -q -n0 tests/unit/mcp/test_tool_schema_witness.py tests/unit/mcp/test_envelope_contracts.py tests/unit/cli/test_click_app.py::TestCliMetadata::test_all_subcommands_registered tests/unit/mcp/test_user_state_tools.py tests/unit/cli/test_user_state_command.py` -> 46 passed
- `ruff check polylogue/api/archive.py polylogue/cli/commands/user_state.py polylogue/mcp/payloads.py polylogue/mcp/server_mutation_tools.py tests/unit/storage/test_user_state_contracts.py tests/unit/daemon/test_web_reader.py tests/unit/cli/test_user_state_command.py tests/unit/mcp/test_user_state_tools.py` -> passed
- `python -m mypy polylogue/api/archive.py polylogue/cli/commands/user_state.py polylogue/mcp/payloads.py polylogue/mcp/server_mutation_tools.py` -> passed
- `devtools render-all --check` -> passed
- `devtools verify --quick` -> exit_code 0, total_duration_s 27.19 before commit; pre-push quick gate at `9dc6a58b` -> exit_code 0, total_duration_s 17.8
