### PR TITLE
feat: show reader annotations in notes panel

### DIFF
--- a/polylogue/daemon/web_shell.py
+++ b/polylogue/daemon/web_shell.py
@@ -156,6 +156,11 @@ html, body { height: 100%; background: var(--bg); color: var(--text);
 .saved-view-item { display: flex; justify-content: space-between; gap: 8px; align-items: center;
   border: 1px solid var(--border); border-radius: var(--radius); padding: 6px; background: var(--panel-subtle); }
 .saved-view-item button { flex-shrink: 0; }
+.annotation-list { display: flex; flex-direction: column; gap: 6px; margin-top: 8px; }
+.annotation-item { border: 1px solid var(--border); border-radius: var(--radius); padding: 6px; background: var(--panel-subtle); }
+.annotation-item .meta { color: var(--text-dim); font-family: var(--font-mono); font-size: 10px; margin-bottom: 4px; }
+.annotation-item .note { color: var(--text); line-height: 1.45; white-space: pre-wrap; font-size: var(--small); }
+.annotation-actions { display: flex; gap: 4px; margin-top: 6px; }
 .raw-block { font-family: var(--font-mono); font-size: 10px; white-space: pre-wrap; word-break: break-all;
   background: var(--panel-subtle); border: 1px solid var(--border); padding: 8px; border-radius: var(--radius);
   max-height: 300px; overflow-y: auto; color: var(--text-muted); }
@@ -252,7 +257,7 @@ var state = {
   conversations: [], selected: null, selectedRaw: null,
   provider: '', query: '', offset: 0, limit: 100, total: 0,
   status: {}, facets: null, inspectorTab: 'info',
-  marks: {}, savedViews: [], userStateError: ''
+  marks: {}, annotations: {}, savedViews: [], userStateError: ''
 };
 
 function esc(s) { return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;'); }
@@ -281,6 +286,9 @@ function setMarkLocal(conversationId, markType, enabled) {
   if (!state.marks[conversationId]) state.marks[conversationId] = {};
   if (enabled) state.marks[conversationId][markType] = true;
   else delete state.marks[conversationId][markType];
+}
+function annotationsFor(conversationId) {
+  return state.annotations[conversationId] || [];
 }
 
 function getConvIdFromURL() {
@@ -327,6 +335,12 @@ async function loadUserState() {
     state.marks = {};
     (marks.items || []).forEach(function(m) {
       setMarkLocal(m.conversation_id, m.mark_type, true);
+    });
+    var annotations = await fetchJSON('/api/user/annotations');
+    state.annotations = {};
+    (annotations.items || []).forEach(function(a) {
+      if (!state.annotations[a.conversation_id]) state.annotations[a.conversation_id] = [];
+      state.annotations[a.conversation_id].push(a);
     });
     var savedViews = await fetchJSON('/api/user/saved-views');
     state.savedViews = savedViews.items || [];
@@ -639,7 +653,25 @@ function renderInspectorNotes(el, c) {
     html += '<div class="inspector-empty">' + esc(state.userStateError) + '</div>';
   }
   html += '</div><div class="inspector-section"><h4>Annotations</h4>'
-    + '<div class="inspector-empty">Annotation storage remains tracked in #867.</div></div>';
+    + '<button class="user-action" onclick="saveAnnotation()">Add note</button>';
+  var annotations = annotationsFor(c.id);
+  if (annotations.length) {
+    html += '<div class="annotation-list">';
+    annotations.forEach(function(a) {
+      var target = a.target_type === 'message' ? ('message ' + (a.message_id || a.target_id)) : 'conversation';
+      html += '<div class="annotation-item">'
+        + '<div class="meta">' + esc(target) + '</div>'
+        + '<div class="note">' + esc(a.note_text || '') + '</div>'
+        + '<div class="annotation-actions">'
+        + '<button class="user-action" onclick="editAnnotation(\'' + escAttr(a.annotation_id) + '\')">Edit</button>'
+        + '<button class="user-action" onclick="deleteAnnotation(\'' + escAttr(a.annotation_id) + '\')">Delete</button>'
+        + '</div></div>';
+    });
+    html += '</div>';
+  } else {
+    html += '<div class="inspector-empty">No annotations on this conversation</div>';
+  }
+  html += '</div>';
   el.innerHTML = html;
 }
 
@@ -691,6 +723,46 @@ function applySavedView(viewId) {
   loadConversations();
   loadFacets();
   renderInspector();
+}
+
+function findAnnotation(annotationId) {
+  var cid = state.selected ? state.selected.id : '';
+  var annotations = annotationsFor(cid);
+  return annotations.find(function(a) { return a.annotation_id === annotationId; }) || null;
+}
+
+async function saveAnnotation(annotationId) {
+  if (!state.selected) return;
+  var existing = annotationId ? findAnnotation(annotationId) : null;
+  var note = window.prompt('Annotation note', existing ? existing.note_text : '');
+  if (!note) return;
+  var id = annotationId || ('annotation-' + Date.now().toString(36));
+  try {
+    await sendJSON('/api/user/annotations', 'POST', {
+      annotation_id: id,
+      conversation_id: state.selected.id,
+      note_text: note
+    });
+    await loadUserState();
+  } catch(e) {
+    state.userStateError = 'Failed to save annotation';
+    renderInspector();
+  }
+}
+
+function editAnnotation(annotationId) {
+  saveAnnotation(annotationId);
+}
+
+async function deleteAnnotation(annotationId) {
+  if (!annotationId) return;
+  try {
+    await sendJSON('/api/user/annotations/' + encodeURIComponent(annotationId), 'DELETE');
+    await loadUserState();
+  } catch(e) {
+    state.userStateError = 'Failed to delete annotation';
+    renderInspector();
+  }
 }
 
 async function loadRawData() {

--- a/tests/visual/conftest.py
+++ b/tests/visual/conftest.py
@@ -254,6 +254,25 @@ def seed_reader_archive(
                 "2026-05-15T00:02:00+00:00",
             ),
         )
+        conn.execute(
+            """
+            INSERT INTO user_annotations(
+                annotation_id, target_type, target_id, conversation_id, message_id,
+                note_text, created_at, updated_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "reader-ann-c1",
+                "conversation",
+                "reader-c1",
+                "reader-c1",
+                None,
+                "This conversation anchors the MK3 reader evidence.",
+                "2026-05-15T00:03:00+00:00",
+                "2026-05-15T00:03:00+00:00",
+            ),
+        )
     conn.commit()
     conn.close()
 

--- a/tests/visual/test_reader_dom_smoke.py
+++ b/tests/visual/test_reader_dom_smoke.py
@@ -54,7 +54,10 @@ def test_reader_search_shell_dom_evidence(reader_workspace: ReaderWorkspace, tmp
         "Focus search",
         "Local",
         "/api/user/marks",
+        "/api/user/annotations",
         "toggleMark",
+        "saveAnnotation",
+        "No annotations on this conversation",
         "Save current view",
         "Saved Views",
     ):
@@ -88,6 +91,7 @@ def test_reader_conversation_deeplink_and_detail_evidence(reader_workspace: Read
         messages = cast(dict[str, object], get_json(base_url, "/api/conversations/reader-c1/messages"))
         raw = cast(dict[str, object], get_json(base_url, "/api/conversations/reader-c1/raw"))
         marks = cast(dict[str, object], get_json(base_url, "/api/user/marks?conversation_id=reader-c1"))
+        annotations = cast(dict[str, object], get_json(base_url, "/api/user/annotations?conversation_id=reader-c1"))
         saved_views = cast(dict[str, object], get_json(base_url, "/api/user/saved-views"))
 
     assert status == 200
@@ -119,6 +123,9 @@ def test_reader_conversation_deeplink_and_detail_evidence(reader_workspace: Read
     assert "raw_artifacts" in raw
     mark_types = {str(item["mark_type"]) for item in cast(list[dict[str, object]], marks["items"])}
     assert mark_types == {"pin", "star"}
+    annotation_items = cast(list[dict[str, object]], annotations["items"])
+    assert annotation_items[0]["annotation_id"] == "reader-ann-c1"
+    assert annotation_items[0]["note_text"] == "This conversation anchors the MK3 reader evidence."
     view_items = cast(list[dict[str, object]], saved_views["items"])
     assert view_items[0]["name"] == "Claude Code reader fixtures"
     assert cast(dict[str, object], view_items[0]["query"])["provider"] == "claude-code"
@@ -132,6 +139,7 @@ def test_reader_conversation_deeplink_and_detail_evidence(reader_workspace: Read
         "tool_message_present": True,
         "raw_endpoint_present": True,
         "mark_types": sorted(mark_types),
+        "annotation_count": len(annotation_items),
         "saved_view_count": len(view_items),
         "private_path_safe": True,
     }


### PR DESCRIPTION
## Summary
Wire durable annotations into the local reader Notes panel so #867 annotation state is visible and editable from the reader, not only from daemon/API/MCP/CLI surfaces.

## Problem
The durable annotation substrate and `/api/user/annotations` routes existed, but the reader Notes tab still showed a placeholder saying annotation storage remained tracked in #867. That meant annotations were implemented but not usable in the primary reader workflow.

## Solution
- Load annotations as part of reader user state and group them by conversation.
- Render annotation cards in the Notes tab with target metadata and note text.
- Add reader controls for add/edit/delete using the existing daemon annotation endpoints.
- Seed the visual fixture with a durable annotation.
- Extend browserless DOM evidence to assert the annotation route, reader action, and seeded annotation payload.

Ref #867

## Verification
- `pytest -q -n0 tests/visual/test_reader_dom_smoke.py tests/unit/daemon/test_web_reader.py::TestReaderUserState::test_annotations_roundtrip_conversation_and_message_targets` -> 5 passed
- `ruff check polylogue/daemon/web_shell.py tests/visual/conftest.py tests/visual/test_reader_dom_smoke.py tests/unit/daemon/test_web_reader.py` -> passed
- `python -m mypy polylogue/daemon/web_shell.py tests/visual/conftest.py tests/visual/test_reader_dom_smoke.py` -> passed
- `devtools verify --quick` -> exit_code 0, total_duration_s 17.15 before commit; pre-push quick gate at `a4d0173f` -> exit_code 0, total_duration_s 18.31
