### PR TITLE
test: ground verification in executable evidence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,9 @@ venv/
 .hypothesis/
 .mypy_cache/
 .ruff_cache/
+.testmondata
+.testmondata-shm
+.testmondata-wal
 .benchmarks/
 /artifacts/
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -700,7 +700,7 @@ attachments, exports):
 - `daemon/` — daemon convergence, HTTP API, and web reader
 
 ### Verification (repo health)
-- `proof/` — proof obligations, subject discovery, claim catalog, witnesses
+- `proof/` — verification catalog internals, subject discovery, claim catalog, witnesses
 - `devtools/` — operator tooling, lints, campaigns, rendering
 - `showcase/` — QA exercises, deterministic acceptance tests
 - `tests/` — pytest suite, property tests, integration tests
@@ -966,13 +966,13 @@ devtools status --json
 
 ## Verification Lab Surface
 
-The proof-lab operator surface intentionally lives in `devtools` for now. These commands operate on
-repo proof obligations and evidence records, not end-user archive workflows.
+The verification-lab operator surface intentionally lives in `devtools` for now. These commands operate on
+repo verification checks and evidence records, not end-user archive workflows.
 
 | Command | Role |
 | --- | --- |
-| `devtools render-verification-catalog` | Refresh or verify the proof-obligation catalog that anchors the verification-lab surface after changing proof subjects, claims, runners, or catalog rendering. |
-| `devtools affected-obligations` | Find the proof obligations and inner-loop checks affected by local changes before escalating to full PR gates. |
+| `devtools render-verification-catalog` | Refresh or verify the catalog that anchors changed-path verification reports after changing subjects, claims, runners, or catalog rendering. |
+| `devtools affected-obligations` | Find the checks and inner-loop commands affected by local changes before escalating to full PR gates. |
 | `devtools semantic-axis-evidence` | Produce comparative performance evidence that describes growth shape over semantic axes instead of machine-specific absolute budgets. |
 | `devtools lab-corpus` | Seed synthetic corpus files or complete demo workspaces for lab exercises. |
 | `devtools lab-scenario` | Run showcase exercise smoke scenarios and committed baseline checks outside the archive CLI. |
@@ -1017,19 +1017,19 @@ These are the commands worth remembering during normal repo work:
 | `devtools render-quality-reference` | Render docs/test-quality-workflows.md from live validation, mutation, and benchmark registries. |
 | `devtools render-readme-media` | Generate README media assets (architecture diagrams, flowcharts) under docs/media/. |
 | `devtools render-topology-status` | Render docs/topology-status.md from the topology projection and realized tree. |
-| `devtools render-verification-catalog` | Render the verification-lab proof catalog from obligation registries. |
+| `devtools render-verification-catalog` | Render the verification-lab catalog from check registries. |
 
 ### Verification
 
 | Command | Description |
 | --- | --- |
-| `devtools affected-obligations` | Route changed paths or refs to affected verification-lab proof obligations and focused checks. |
+| `devtools affected-obligations` | Route changed paths or refs to affected verification checks and focused commands. |
 | `devtools artifact-graph` | Render the runtime artifact, operation, and scenario-coverage map. |
 | `devtools coverage-gate` | Run pytest with the repository coverage floor from pyproject.toml. |
 | `devtools daemon-workload-probe` | Inspect daemon ingest workload, convergence debt, and hot query plans. |
 | `devtools lab-corpus` | Generate verification-lab synthetic corpus fixtures and demo archives. |
 | `devtools lab-scenario` | Run verification-lab showcase scenario sets and baseline checks. |
-| `devtools obligation-diff` | Diff proof obligations between two git refs to surface affected assurance domains. |
+| `devtools obligation-diff` | Diff catalog-backed verification checks between two git refs. |
 | `devtools pipeline-probe` | Run typed pipeline probes against synthetic, staged, or archive-subset inputs. |
 | `devtools proof-pack` | Domain-grouped verification impact report for changed paths. |
 | `devtools query-memory-budget` | Measure query-memory envelopes on generated fixtures. |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,9 +25,11 @@ acceptance criteria. Reference it from the PR with `Ref #NNN` or
 
 ### Verification before push
 
-Run `devtools verify` (full, with pytest) before creating any PR. The
-git hooks enforce format and lint on commit and `devtools verify --quick`
-on push, but the full baseline must pass before the PR is opened.
+Run `devtools verify` before creating any PR. The default baseline runs the
+static/generated gates plus pytest-testmon affected tests. Seed the testmon
+database explicitly on a fresh checkout or after harness/dependency changes.
+The git hooks enforce format and lint on commit and `devtools verify --quick`
+on push, but the default baseline must pass before the PR is opened.
 
 Do not treat CI as the first verification pass. Anticipate failures
 locally.
@@ -266,37 +268,16 @@ The repository should stay aligned with the workflow above:
 - allow Update branch for stale PRs
 - do not require an issue for every pull request
 
-## Verification Baseline
+## Git Hooks
 
 The devshell installs git hooks automatically (`core.hooksPath .githooks`):
 
 - **pre-commit**: `ruff format --check` + `ruff check` on staged files.
-- **pre-push**: `devtools verify --quick` (format + lint + render-all --check).
+- **pre-push**: `devtools verify --quick` (format, lint, mypy, generated
+  surfaces, and fast manifest checks).
 
-Before creating a PR, run the default baseline:
-
-```bash
-devtools verify            # static/generated gates + pytest-testmon affected tests
-```
-
-Seed or refresh the pytest-testmon dependency database explicitly after a fresh
-checkout, dependency change, or broad test-harness change:
-
-```bash
-devtools verify --seed-testmon --skip-slow
-```
-
-For an explicit full non-integration pytest diagnostic:
-
-```bash
-devtools verify --all
-```
-
-Add `devtools build-package` or `nix flake check` when touching packaging or
-Nix expressions.
-
-See [TESTING.md](TESTING.md) and [docs/devtools.md](docs/devtools.md) for
-details.
+The pre-push hook is an early failure gate. The PR baseline is the
+`devtools verify` workflow below.
 
 ## Type Checking
 
@@ -336,6 +317,10 @@ source, dependency, and Python-version state. If pytest configuration,
 dependency locks, or shared test infrastructure changed since the seed, the
 default command automatically widens the pytest step to `--testmon-noselect`
 and refreshes dependency data.
+
+Add `devtools build-package` or `nix flake check` when touching packaging or
+Nix expressions. See [TESTING.md](TESTING.md) and [docs/devtools.md](docs/devtools.md)
+for details.
 
 Proof Pack: every PR gets a `Polylogue Proof Pack` comment. It's a verification
 impact report showing affected domains, required gates, and known gaps. Use it

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,7 +130,9 @@ targeting `master`.
 2. Create a branch from `origin/master`.
 3. Work on the branch. Git hooks enforce format and lint on commit, and
    run `devtools verify --quick` on push.
-4. Run `devtools verify` (full, with pytest) before creating the PR.
+4. Run `devtools verify` before creating the PR. The default pytest step uses
+   pytest-testmon affected-test selection; run `devtools verify --seed-testmon`
+   first if the dependency database is not seeded.
 5. Open a pull request. The template has required sections — fill them
    all in. The PR title becomes the squash-merge subject on `master`.
 6. CI must pass. Fix failures on the branch, do not merge with red CI.
@@ -271,19 +273,23 @@ The devshell installs git hooks automatically (`core.hooksPath .githooks`):
 - **pre-commit**: `ruff format --check` + `ruff check` on staged files.
 - **pre-push**: `devtools verify --quick` (format + lint + render-all --check).
 
-Before creating a PR, run the full baseline:
+Before creating a PR, run the default baseline:
 
 ```bash
-devtools verify            # format + lint + render-all --check + pytest
+devtools verify            # static/generated gates + pytest-testmon affected tests
 ```
 
-Or manually:
+Seed or refresh the pytest-testmon dependency database explicitly after a fresh
+checkout, dependency change, or broad test-harness change:
 
 ```bash
-ruff format --check polylogue/ tests/ devtools/
-ruff check polylogue/ tests/ devtools/
-devtools render-all --check
-pytest -q --ignore=tests/integration
+devtools verify --seed-testmon --skip-slow
+```
+
+For an explicit full non-integration pytest diagnostic:
+
+```bash
+devtools verify --all
 ```
 
 Add `devtools build-package` or `nix flake check` when touching packaging or
@@ -308,16 +314,21 @@ runs as part of `devtools verify` and in CI.
 
 ## Verification Baseline
 
-Before creating a PR, run the full local baseline. CI runs the same checks.
+Before creating a PR, run the local baseline. CI runs the same checks, while
+local pytest selection is accelerated by pytest-testmon.
 
 ```bash
-devtools verify            # format + lint + mypy + render-all --check + pytest
+devtools verify            # static/generated gates + pytest-testmon affected tests
+devtools verify --seed-testmon --skip-slow  # seed/update affected-test DB
+devtools verify --all      # explicit full non-integration pytest diagnostic
 devtools verify --quick    # format + lint + mypy + render-all --check (skip tests)
 devtools verify --lab      # explicit lab checks beyond the quick/default loop
 ```
 
 The quick gate runs on `git push` via `.githooks/pre-push`. It's a fast check,
-not a substitute for the full baseline.
+not a substitute for the default baseline. The default command fails fast when
+`.testmondata` and `.cache/testmon/seed.json` are missing; do not rely on
+silent full-suite fallback.
 
 Proof Pack: every PR gets a `Polylogue Proof Pack` comment. It's a verification
 impact report showing affected domains, required gates, and known gaps. Use it
@@ -348,8 +359,11 @@ All commands below assume you are inside the project devshell. See
 ## Running Tests
 
 ```bash
-# Fast unit run (primary workflow)
-pytest -q --ignore=tests/integration
+# Normal repository verification
+devtools verify
+
+# First run after checkout or dependency/test harness changes
+devtools verify --seed-testmon --skip-slow
 
 # Stop on first failure
 pytest -x --ignore=tests/integration
@@ -358,9 +372,18 @@ pytest -x --ignore=tests/integration
 pytest tests/unit/storage/test_hybrid_laws.py
 pytest -k "test_name"
 
-# Full CI parity
+# Explicit full non-integration pytest diagnostic
+devtools verify --all
+
+# Full Nix/CI parity
 nix flake check
 ```
+
+`devtools verify` uses pytest-testmon for per-test affected selection. The
+seed command records `.testmondata` plus `.cache/testmon/seed.json`; those
+files are local generated state and are not committed. If the seed is missing,
+the default command fails with setup guidance instead of silently running the
+whole suite.
 
 For the generated validation-lane, mutation-campaign, and benchmark inventory,
 see [docs/test-quality-workflows.md](docs/test-quality-workflows.md).
@@ -448,7 +471,6 @@ Never delete:
 - **`tests/integration/`**: End-to-end pipeline tests against real archive
   shapes.
 - **`tests/unit/security/`**: Security boundary tests.
-
 <!-- end include: TESTING.md -->
 <!-- begin include: docs/architecture.md -->
 # Polylogue Architecture

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -330,6 +330,13 @@ not a substitute for the default baseline. The default command fails fast when
 `.testmondata` and `.cache/testmon/seed.json` are missing; do not rely on
 silent full-suite fallback.
 
+`devtools verify` does not replay a prior verify result. It always runs the
+static gates and lets pytest-testmon decide affected tests from the current
+source, dependency, and Python-version state. If pytest configuration,
+dependency locks, or shared test infrastructure changed since the seed, the
+default command automatically widens the pytest step to `--testmon-noselect`
+and refreshes dependency data.
+
 Proof Pack: every PR gets a `Polylogue Proof Pack` comment. It's a verification
 impact report showing affected domains, required gates, and known gaps. Use it
 to choose focused verification — run the gates that match touched files, state
@@ -384,6 +391,13 @@ seed command records `.testmondata` plus `.cache/testmon/seed.json`; those
 files are local generated state and are not committed. If the seed is missing,
 the default command fails with setup guidance instead of silently running the
 whole suite.
+
+The default path does not replay cached verify results. Every invocation runs
+the static gates and lets pytest-testmon evaluate current source, package, and
+Python-version state. Changes to pytest configuration, dependency locks, or
+shared test infrastructure automatically widen the pytest step to
+`--testmon-noselect` so the dependency database is refreshed without requiring
+a manual full-suite bypass.
 
 For the generated validation-lane, mutation-campaign, and benchmark inventory,
 see [docs/test-quality-workflows.md](docs/test-quality-workflows.md).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,8 +48,9 @@ Use it this way:
 - Treat `Known Gaps` as actionable only when they are in a changed or directly
   affected domain. Broad repo-wide gap dumps should not block unrelated PRs, but
   recurring noise should be folded back into #594.
-- Read `stable affected obligations` as unchanged obligations touched by the
-  current diff, not as real freshness/SLA evidence.
+- Treat any remaining proof-pack obligation language as transitional report
+  terminology; real verification closure comes from pytest, coverage,
+  benchmark, CI, static-check, and runtime evidence artifacts.
 - If the Proof Pack is noisy, misleading, or misses a relevant gate, comment on
   the PR or #594 with the concrete mismatch. Do not silently ignore it.
 
@@ -312,7 +313,7 @@ Before creating a PR, run the full local baseline. CI runs the same checks.
 ```bash
 devtools verify            # format + lint + mypy + render-all --check + pytest
 devtools verify --quick    # format + lint + mypy + render-all --check (skip tests)
-devtools verify --lab      # verification-lab checks (obligations, proof pack)
+devtools verify --lab      # explicit lab checks beyond the quick/default loop
 ```
 
 The quick gate runs on `git push` via `.githooks/pre-push`. It's a fast check,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1031,7 +1031,7 @@ These are the commands worth remembering during normal repo work:
 | `devtools lab-scenario` | Run verification-lab showcase scenario sets and baseline checks. |
 | `devtools obligation-diff` | Diff proof obligations between two git refs to surface affected assurance domains. |
 | `devtools pipeline-probe` | Run typed pipeline probes against synthetic, staged, or archive-subset inputs. |
-| `devtools proof-pack` | Domain-grouped affected coverage report for vibecode confidence. |
+| `devtools proof-pack` | Domain-grouped verification impact report for changed paths. |
 | `devtools query-memory-budget` | Measure query-memory envelopes on generated fixtures. |
 | `devtools regression-capture` | Capture pipeline-probe summaries as durable local regression cases. |
 | `devtools run-validation-lanes` | Run named validation lanes. |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,8 +46,9 @@ Use it this way:
 - Treat `Known Gaps` as actionable only when they are in a changed or directly
   affected domain. Broad repo-wide gap dumps should not block unrelated PRs, but
   recurring noise should be folded back into #594.
-- Read `stable affected obligations` as unchanged obligations touched by the
-  current diff, not as real freshness/SLA evidence.
+- Treat any remaining proof-pack obligation language as transitional report
+  terminology; real verification closure comes from pytest, coverage,
+  benchmark, CI, static-check, and runtime evidence artifacts.
 - If the Proof Pack is noisy, misleading, or misses a relevant gate, comment on
   the PR or #594 with the concrete mismatch. Do not silently ignore it.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,9 +23,11 @@ acceptance criteria. Reference it from the PR with `Ref #NNN` or
 
 ### Verification before push
 
-Run `devtools verify` (full, with pytest) before creating any PR. The
-git hooks enforce format and lint on commit and `devtools verify --quick`
-on push, but the full baseline must pass before the PR is opened.
+Run `devtools verify` before creating any PR. The default baseline runs the
+static/generated gates plus pytest-testmon affected tests. Seed the testmon
+database explicitly on a fresh checkout or after harness/dependency changes.
+The git hooks enforce format and lint on commit and `devtools verify --quick`
+on push, but the default baseline must pass before the PR is opened.
 
 Do not treat CI as the first verification pass. Anticipate failures
 locally.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -175,37 +175,16 @@ The repository should stay aligned with the workflow above:
 - allow Update branch for stale PRs
 - do not require an issue for every pull request
 
-## Verification Baseline
+## Git Hooks
 
 The devshell installs git hooks automatically (`core.hooksPath .githooks`):
 
 - **pre-commit**: `ruff format --check` + `ruff check` on staged files.
-- **pre-push**: `devtools verify --quick` (format + lint + render-all --check).
+- **pre-push**: `devtools verify --quick` (format, lint, mypy, generated
+  surfaces, and fast manifest checks).
 
-Before creating a PR, run the default baseline:
-
-```bash
-devtools verify            # static/generated gates + pytest-testmon affected tests
-```
-
-Seed or refresh the pytest-testmon dependency database explicitly after a fresh
-checkout, dependency change, or broad test-harness change:
-
-```bash
-devtools verify --seed-testmon --skip-slow
-```
-
-For an explicit full non-integration pytest diagnostic:
-
-```bash
-devtools verify --all
-```
-
-Add `devtools build-package` or `nix flake check` when touching packaging or
-Nix expressions.
-
-See [TESTING.md](TESTING.md) and [docs/devtools.md](docs/devtools.md) for
-details.
+The pre-push hook is an early failure gate. The PR baseline is the
+`devtools verify` workflow below.
 
 ## Type Checking
 
@@ -245,6 +224,10 @@ source, dependency, and Python-version state. If pytest configuration,
 dependency locks, or shared test infrastructure changed since the seed, the
 default command automatically widens the pytest step to `--testmon-noselect`
 and refreshes dependency data.
+
+Add `devtools build-package` or `nix flake check` when touching packaging or
+Nix expressions. See [TESTING.md](TESTING.md) and [docs/devtools.md](docs/devtools.md)
+for details.
 
 Proof Pack: every PR gets a `Polylogue Proof Pack` comment. It's a verification
 impact report showing affected domains, required gates, and known gaps. Use it

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,9 @@ targeting `master`.
 2. Create a branch from `origin/master`.
 3. Work on the branch. Git hooks enforce format and lint on commit, and
    run `devtools verify --quick` on push.
-4. Run `devtools verify` (full, with pytest) before creating the PR.
+4. Run `devtools verify` before creating the PR. The default pytest step uses
+   pytest-testmon affected-test selection; run `devtools verify --seed-testmon`
+   first if the dependency database is not seeded.
 5. Open a pull request. The template has required sections — fill them
    all in. The PR title becomes the squash-merge subject on `master`.
 6. CI must pass. Fix failures on the branch, do not merge with red CI.
@@ -180,19 +182,23 @@ The devshell installs git hooks automatically (`core.hooksPath .githooks`):
 - **pre-commit**: `ruff format --check` + `ruff check` on staged files.
 - **pre-push**: `devtools verify --quick` (format + lint + render-all --check).
 
-Before creating a PR, run the full baseline:
+Before creating a PR, run the default baseline:
 
 ```bash
-devtools verify            # format + lint + render-all --check + pytest
+devtools verify            # static/generated gates + pytest-testmon affected tests
 ```
 
-Or manually:
+Seed or refresh the pytest-testmon dependency database explicitly after a fresh
+checkout, dependency change, or broad test-harness change:
 
 ```bash
-ruff format --check polylogue/ tests/ devtools/
-ruff check polylogue/ tests/ devtools/
-devtools render-all --check
-pytest -q --ignore=tests/integration
+devtools verify --seed-testmon --skip-slow
+```
+
+For an explicit full non-integration pytest diagnostic:
+
+```bash
+devtools verify --all
 ```
 
 Add `devtools build-package` or `nix flake check` when touching packaging or
@@ -217,16 +223,21 @@ runs as part of `devtools verify` and in CI.
 
 ## Verification Baseline
 
-Before creating a PR, run the full local baseline. CI runs the same checks.
+Before creating a PR, run the local baseline. CI runs the same checks, while
+local pytest selection is accelerated by pytest-testmon.
 
 ```bash
-devtools verify            # format + lint + mypy + render-all --check + pytest
+devtools verify            # static/generated gates + pytest-testmon affected tests
+devtools verify --seed-testmon --skip-slow  # seed/update affected-test DB
+devtools verify --all      # explicit full non-integration pytest diagnostic
 devtools verify --quick    # format + lint + mypy + render-all --check (skip tests)
 devtools verify --lab      # explicit lab checks beyond the quick/default loop
 ```
 
 The quick gate runs on `git push` via `.githooks/pre-push`. It's a fast check,
-not a substitute for the full baseline.
+not a substitute for the default baseline. The default command fails fast when
+`.testmondata` and `.cache/testmon/seed.json` are missing; do not rely on
+silent full-suite fallback.
 
 Proof Pack: every PR gets a `Polylogue Proof Pack` comment. It's a verification
 impact report showing affected domains, required gates, and known gaps. Use it

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -222,7 +222,7 @@ Before creating a PR, run the full local baseline. CI runs the same checks.
 ```bash
 devtools verify            # format + lint + mypy + render-all --check + pytest
 devtools verify --quick    # format + lint + mypy + render-all --check (skip tests)
-devtools verify --lab      # verification-lab checks (obligations, proof pack)
+devtools verify --lab      # explicit lab checks beyond the quick/default loop
 ```
 
 The quick gate runs on `git push` via `.githooks/pre-push`. It's a fast check,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -239,6 +239,13 @@ not a substitute for the default baseline. The default command fails fast when
 `.testmondata` and `.cache/testmon/seed.json` are missing; do not rely on
 silent full-suite fallback.
 
+`devtools verify` does not replay a prior verify result. It always runs the
+static gates and lets pytest-testmon decide affected tests from the current
+source, dependency, and Python-version state. If pytest configuration,
+dependency locks, or shared test infrastructure changed since the seed, the
+default command automatically widens the pytest step to `--testmon-noselect`
+and refreshes dependency data.
+
 Proof Pack: every PR gets a `Polylogue Proof Pack` comment. It's a verification
 impact report showing affected domains, required gates, and known gaps. Use it
 to choose focused verification — run the gates that match touched files, state

--- a/README.md
+++ b/README.md
@@ -169,8 +169,8 @@ devtools affected-obligations --path polylogue/cli/query.py
 devtools lab-corpus representative-generate -p chatgpt -n 3
 ```
 
-The verification lab records proof-obligation subjects, claim runners, and
-evidence routing so agents can choose focused checks before escalating to the
+The verification lab records catalog subjects, claim runners, and evidence
+routing so agents can choose focused checks before escalating to the
 full repository baseline.
 
 <!-- BEGIN GENERATED: docs-surface -->
@@ -190,8 +190,8 @@ Start with the generated command and architecture references; use [docs/README.m
 | [MCP Integration](docs/mcp-integration.md) | Model Context Protocol server setup and usage. |
 | [Configuration](docs/configuration.md) | XDG paths, environment variables, and runtime configuration. |
 | [Developer Tools](docs/devtools.md) | `devtools` guide for generated surfaces, validation, and repo hygiene. |
-| [Verification Catalog](docs/verification-catalog.md) | Generated proof-obligation subjects, claims, runners, and catalog self-checks. |
-| [Verification Lab](docs/verification-lab.md) | Accepted command-surface decision for proof catalog, routing, and evidence operators. |
+| [Verification Catalog](docs/verification-catalog.md) | Generated verification subjects, claims, runners, and catalog self-checks. |
+| [Verification Lab](docs/verification-lab.md) | Accepted command-surface decision for verification catalog, routing, and evidence operators. |
 | [Providers](docs/providers/README.md) | Provider-specific parsing and export-format notes. |
 
 <!-- END GENERATED: docs-surface -->

--- a/TESTING.md
+++ b/TESTING.md
@@ -6,8 +6,11 @@ All commands below assume you are inside the project devshell. See
 ## Running Tests
 
 ```bash
-# Fast unit run (primary workflow)
-pytest -q --ignore=tests/integration
+# Normal repository verification
+devtools verify
+
+# First run after checkout or dependency/test harness changes
+devtools verify --seed-testmon --skip-slow
 
 # Stop on first failure
 pytest -x --ignore=tests/integration
@@ -16,9 +19,18 @@ pytest -x --ignore=tests/integration
 pytest tests/unit/storage/test_hybrid_laws.py
 pytest -k "test_name"
 
-# Full CI parity
+# Explicit full non-integration pytest diagnostic
+devtools verify --all
+
+# Full Nix/CI parity
 nix flake check
 ```
+
+`devtools verify` uses pytest-testmon for per-test affected selection. The
+seed command records `.testmondata` plus `.cache/testmon/seed.json`; those
+files are local generated state and are not committed. If the seed is missing,
+the default command fails with setup guidance instead of silently running the
+whole suite.
 
 For the generated validation-lane, mutation-campaign, and benchmark inventory,
 see [docs/test-quality-workflows.md](docs/test-quality-workflows.md).
@@ -106,4 +118,3 @@ Never delete:
 - **`tests/integration/`**: End-to-end pipeline tests against real archive
   shapes.
 - **`tests/unit/security/`**: Security boundary tests.
-

--- a/TESTING.md
+++ b/TESTING.md
@@ -32,6 +32,13 @@ files are local generated state and are not committed. If the seed is missing,
 the default command fails with setup guidance instead of silently running the
 whole suite.
 
+The default path does not replay cached verify results. Every invocation runs
+the static gates and lets pytest-testmon evaluate current source, package, and
+Python-version state. Changes to pytest configuration, dependency locks, or
+shared test infrastructure automatically widen the pytest step to
+`--testmon-noselect` so the dependency database is refreshed without requiring
+a manual full-suite bypass.
+
 For the generated validation-lane, mutation-campaign, and benchmark inventory,
 see [docs/test-quality-workflows.md](docs/test-quality-workflows.md).
 

--- a/devtools/benchmark_campaign.py
+++ b/devtools/benchmark_campaign.py
@@ -14,11 +14,17 @@ from pathlib import Path
 from typing import TypedDict
 
 from devtools import repo_root as _get_root
-from polylogue.core.json import JSONDocument, json_document, json_document_list
+from polylogue.core.json import JSONDocument, json_document
 from polylogue.scenarios import ExecutionKind, ScenarioMetadata, pytest_execution, run_execution
 
 from .authored_scenario_catalog import get_authored_scenario_catalog
 from .benchmark_catalog import BenchmarkCampaignEntry
+from .benchmark_results import (
+    BenchmarkStat,
+    BenchmarkStatRecord,
+    benchmark_stat_record,
+    parse_pytest_benchmark_stats,
+)
 
 ROOT = _get_root()
 ARTIFACT_DIR = Path(".local/benchmark-campaigns")
@@ -28,38 +34,11 @@ DEFAULT_FAIL_PCT = 20.0
 CAMPAIGNS = get_authored_scenario_catalog().benchmark_campaign_index()
 
 
-class BenchmarkStatRecord(TypedDict):
-    name: str
-    fullname: str
-    group: str
-    mean: float
-    median: float
-    minimum: float
-    maximum: float
-    stddev: float
-    rounds: int
-    ops: float | None
-
-
 class RegressionRecord(TypedDict):
     fullname: str
     baseline_mean: float
     current_mean: float
     delta_pct: float
-
-
-@dataclass(frozen=True)
-class BenchmarkStat:
-    name: str
-    fullname: str
-    group: str
-    mean: float
-    median: float
-    minimum: float
-    maximum: float
-    stddev: float
-    rounds: int
-    ops: float | None
 
 
 @dataclass(frozen=True)
@@ -120,58 +99,10 @@ def _default_artifact_path(campaign: str, suffix: str) -> Path:
     return ROOT / ARTIFACT_DIR / f"{date}-{campaign}.{suffix}"
 
 
-def _benchmark_key(entry: JSONDocument) -> str:
-    return str(entry.get("fullname") or entry.get("fullfunc") or entry.get("name"))
-
-
 def _number_value(value: object, *, field: str) -> str | int | float:
     if isinstance(value, bool) or not isinstance(value, (str, int, float)):
         raise ValueError(f"Benchmark payload field {field!r} is not numeric: {value!r}")
     return value
-
-
-def _number_field(payload: JSONDocument, field: str) -> str | int | float:
-    return _number_value(payload[field], field=field)
-
-
-def _float_field(payload: JSONDocument, field: str) -> float:
-    return float(_number_field(payload, field))
-
-
-def _int_field(payload: JSONDocument, field: str) -> int:
-    return int(_number_field(payload, field))
-
-
-def _parse_stats(raw: JSONDocument) -> BenchmarkStat:
-    stats = json_document(raw.get("stats"))
-    mean = _float_field(stats, "mean")
-    return BenchmarkStat(
-        name=str(raw.get("name", "unknown")),
-        fullname=_benchmark_key(raw),
-        group=str(raw.get("group", "benchmark")),
-        mean=mean,
-        median=_float_field(stats, "median"),
-        minimum=_float_field(stats, "min"),
-        maximum=_float_field(stats, "max"),
-        stddev=_float_field(stats, "stddev") if "stddev" in stats else 0.0,
-        rounds=_int_field(stats, "rounds") if "rounds" in stats else 0,
-        ops=(1.0 / mean) if mean > 0 else None,
-    )
-
-
-def _benchmark_stat_record(stat: BenchmarkStat) -> BenchmarkStatRecord:
-    return {
-        "name": stat.name,
-        "fullname": stat.fullname,
-        "group": stat.group,
-        "mean": stat.mean,
-        "median": stat.median,
-        "minimum": stat.minimum,
-        "maximum": stat.maximum,
-        "stddev": stat.stddev,
-        "rounds": stat.rounds,
-        "ops": stat.ops,
-    }
 
 
 def _regression_record(regression: Regression) -> RegressionRecord:
@@ -320,7 +251,7 @@ def run_campaign(
         payload = json.loads(raw_json.read_text())
 
     payload_document = json_document(payload)
-    benchmarks = [_parse_stats(entry) for entry in json_document_list(payload_document.get("benchmarks"))]
+    benchmarks = parse_pytest_benchmark_stats(payload_document)
     benchmarks.sort(key=lambda item: item.mean, reverse=True)
     baseline_result = _load_campaign_result(compare_to) if compare_to else None
     regressions = _compare_results(benchmarks, baseline_result.benchmarks) if baseline_result else []
@@ -343,8 +274,8 @@ def run_campaign(
         runtime_seconds=runtime_seconds,
         exit_code=completed.exit_code,
         machine_info=json_document(payload_document.get("machine_info")),
-        benchmarks=[_benchmark_stat_record(bench) for bench in benchmarks],
-        slowest=[_benchmark_stat_record(bench) for bench in benchmarks[:10]],
+        benchmarks=[benchmark_stat_record(bench) for bench in benchmarks],
+        slowest=[benchmark_stat_record(bench) for bench in benchmarks[:10]],
         compare_to=str(compare_to) if compare_to else None,
         warn_pct=warn_threshold,
         fail_pct=fail_threshold,

--- a/devtools/benchmark_results.py
+++ b/devtools/benchmark_results.py
@@ -1,0 +1,109 @@
+"""Shared pytest-benchmark result parsing."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TypedDict
+
+from polylogue.core.json import JSONDocument, json_document, json_document_list
+
+
+class BenchmarkStatRecord(TypedDict):
+    name: str
+    fullname: str
+    group: str
+    mean: float
+    median: float
+    minimum: float
+    maximum: float
+    stddev: float
+    rounds: int
+    ops: float | None
+
+
+@dataclass(frozen=True)
+class BenchmarkStat:
+    name: str
+    fullname: str
+    group: str
+    mean: float
+    median: float
+    minimum: float
+    maximum: float
+    stddev: float
+    rounds: int
+    ops: float | None
+
+
+def benchmark_key(entry: JSONDocument) -> str:
+    """Return the most stable pytest-benchmark identity for an entry."""
+    return str(entry.get("fullname") or entry.get("fullfunc") or entry.get("name"))
+
+
+def parse_benchmark_stat(raw: JSONDocument) -> BenchmarkStat:
+    """Parse one pytest-benchmark JSON entry."""
+    stats = json_document(raw.get("stats"))
+    mean = _float_field(stats, "mean")
+    raw_group = raw.get("group")
+    return BenchmarkStat(
+        name=str(raw.get("name", "unknown")),
+        fullname=benchmark_key(raw),
+        group=str(raw_group) if raw_group is not None else "benchmark",
+        mean=mean,
+        median=_float_field(stats, "median"),
+        minimum=_float_field(stats, "min"),
+        maximum=_float_field(stats, "max"),
+        stddev=_float_field(stats, "stddev") if "stddev" in stats else 0.0,
+        rounds=_int_field(stats, "rounds") if "rounds" in stats else 0,
+        ops=(1.0 / mean) if mean > 0 else None,
+    )
+
+
+def parse_pytest_benchmark_stats(payload: object) -> list[BenchmarkStat]:
+    """Parse all benchmark entries from a pytest-benchmark JSON payload."""
+    document = json_document(payload)
+    return [parse_benchmark_stat(entry) for entry in json_document_list(document.get("benchmarks"))]
+
+
+def benchmark_stat_record(stat: BenchmarkStat) -> BenchmarkStatRecord:
+    """Convert a parsed benchmark stat to a JSON-serializable campaign record."""
+    return {
+        "name": stat.name,
+        "fullname": stat.fullname,
+        "group": stat.group,
+        "mean": stat.mean,
+        "median": stat.median,
+        "minimum": stat.minimum,
+        "maximum": stat.maximum,
+        "stddev": stat.stddev,
+        "rounds": stat.rounds,
+        "ops": stat.ops,
+    }
+
+
+def _number_value(value: object, *, field: str) -> str | int | float:
+    if isinstance(value, bool) or not isinstance(value, (str, int, float)):
+        raise ValueError(f"Benchmark payload field {field!r} is not numeric: {value!r}")
+    return value
+
+
+def _number_field(payload: JSONDocument, field: str) -> str | int | float:
+    return _number_value(payload[field], field=field)
+
+
+def _float_field(payload: JSONDocument, field: str) -> float:
+    return float(_number_field(payload, field))
+
+
+def _int_field(payload: JSONDocument, field: str) -> int:
+    return int(_number_field(payload, field))
+
+
+__all__ = [
+    "BenchmarkStat",
+    "BenchmarkStatRecord",
+    "benchmark_key",
+    "benchmark_stat_record",
+    "parse_benchmark_stat",
+    "parse_pytest_benchmark_stats",
+]

--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -131,11 +131,11 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
     CommandSpec(
         "render-verification-catalog",
         "generated surfaces",
-        "Render the verification-lab proof catalog from obligation registries.",
+        "Render the verification-lab catalog from check registries.",
         "devtools.render_verification_catalog",
         use_when=(
-            "Refresh or verify the proof-obligation catalog that anchors the verification-lab surface after "
-            "changing proof subjects, claims, runners, or catalog rendering."
+            "Refresh or verify the catalog that anchors changed-path verification reports after "
+            "changing subjects, claims, runners, or catalog rendering."
         ),
         examples=(
             "devtools render-verification-catalog",
@@ -167,9 +167,9 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
     CommandSpec(
         "affected-obligations",
         "verification",
-        "Route changed paths or refs to affected verification-lab proof obligations and focused checks.",
+        "Route changed paths or refs to affected verification checks and focused commands.",
         "devtools.affected_obligations",
-        use_when="Find the proof obligations and inner-loop checks affected by local changes before escalating to full PR gates.",
+        use_when="Find the checks and inner-loop commands affected by local changes before escalating to full PR gates.",
         examples=(
             "devtools affected-obligations --base-ref master --head-ref HEAD",
             "devtools affected-obligations --path polylogue/sources/parsers/codex.py",
@@ -361,7 +361,7 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
         "Domain-grouped verification impact report for changed paths.",
         "devtools.proof_pack",
         use_when=(
-            "Review what a change affects by domain and choose focused gates without reading a raw obligation diff."
+            "Review what a change affects by domain and choose focused gates without reading raw catalog routing."
         ),
         examples=(
             "devtools proof-pack --base-ref origin/master --head-ref HEAD",
@@ -517,7 +517,7 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
     CommandSpec(
         "obligation-diff",
         "verification",
-        "Diff proof obligations between two git refs to surface affected assurance domains.",
+        "Diff catalog-backed verification checks between two git refs.",
         "devtools.obligation_diff",
         use_when=(
             "Before opening a PR, check which assurance domains are affected by "

--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -358,12 +358,10 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
     CommandSpec(
         "proof-pack",
         "verification",
-        "Domain-grouped affected coverage report for vibecode confidence.",
+        "Domain-grouped verification impact report for changed paths.",
         "devtools.proof_pack",
         use_when=(
-            "Get a domain-aware confidence answer about what a change affects, "
-            "instead of an undifferentiated obligation count. Maps changed paths "
-            "to impacted assurance domains with oracle-classified claim counts."
+            "Review what a change affects by domain and choose focused gates without reading a raw obligation diff."
         ),
         examples=(
             "devtools proof-pack --base-ref origin/master --head-ref HEAD",

--- a/devtools/docs_surface.py
+++ b/devtools/docs_surface.py
@@ -67,12 +67,12 @@ DOCS_REFERENCE_ENTRIES: tuple[DocsEntry, ...] = (
     DocsEntry(
         "Verification Catalog",
         "docs/verification-catalog.md",
-        "Generated proof-obligation subjects, claims, runners, and catalog self-checks.",
+        "Generated verification subjects, claims, runners, and catalog self-checks.",
     ),
     DocsEntry(
         "Verification Lab",
         "docs/verification-lab.md",
-        "Accepted command-surface decision for proof catalog, routing, and evidence operators.",
+        "Accepted command-surface decision for verification catalog, routing, and evidence operators.",
     ),
 )
 

--- a/devtools/generated_surfaces.py
+++ b/devtools/generated_surfaces.py
@@ -73,7 +73,7 @@ GENERATED_SURFACES: tuple[GeneratedSurface, ...] = (
     GeneratedSurface(
         name="verification-catalog",
         label="Verification catalog",
-        description="Render docs/verification-catalog.md from proof-obligation registries.",
+        description="Render docs/verification-catalog.md from verification check registries.",
         command=control_plane_argv("render-verification-catalog"),
         main=render_verification_catalog.main,
         inputs=("proof/",),

--- a/devtools/proof_pack.py
+++ b/devtools/proof_pack.py
@@ -32,6 +32,8 @@ from polylogue.proof.diffing import (
 )
 from polylogue.proof.models import EvidenceTaxonomy, RunnerBinding, SubjectRef
 
+_CONTRACT_EVIDENCE_DIR = Path(".cache/verification/evidence")
+
 # Taxonomy human-facing descriptions and actionability guidance.
 _TAXONOMY_DESCRIPTIONS: dict[EvidenceTaxonomy, str] = {
     "executable_behavior": "Pytest nodes, probes, smoke runs, or benchmark commands.",
@@ -236,6 +238,7 @@ def build_proof_pack(
         "manual_review_requirements": _manual_review_requirements(affected_claims),
         "stable_routed_checks": list(affected.obligation_diff.stable_affected),
         "artifact_source_groups": artifact_source_groups,
+        "contract_evidence_artifacts": _contract_evidence_summary(root),
         "known_gaps": known_gaps,
         "additional_known_gaps": additional_known_gaps,
         "oracle_mix": dict(Counter(claim.oracle for claim in affected_claims)),
@@ -388,6 +391,47 @@ def _manual_review_requirements(claims: list[Any]) -> list[dict[str, Any]]:
                 }
             )
     return requirements
+
+
+def _contract_evidence_summary(root: Path) -> dict[str, Any]:
+    evidence_dir = root / _CONTRACT_EVIDENCE_DIR
+    if not evidence_dir.exists():
+        return {
+            "artifact_dir": _CONTRACT_EVIDENCE_DIR.as_posix(),
+            "artifact_count": 0,
+            "by_surface": {},
+            "artifacts": [],
+        }
+
+    artifacts: list[dict[str, Any]] = []
+    by_surface: Counter[str] = Counter()
+    for path in sorted(evidence_dir.glob("*.json")):
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+        surface = str(payload.get("surface") or "unknown")
+        by_surface[surface] += 1
+        artifacts.append(
+            {
+                "path": path.relative_to(root).as_posix(),
+                "contract": str(payload.get("contract") or ""),
+                "surface": surface,
+                "test_nodeid": str(payload.get("test_nodeid") or ""),
+                "git_sha": str(payload.get("git_sha") or ""),
+                "dirty": bool(payload.get("dirty", False)),
+                "timestamp": str(payload.get("timestamp") or ""),
+            }
+        )
+
+    return {
+        "artifact_dir": _CONTRACT_EVIDENCE_DIR.as_posix(),
+        "artifact_count": len(artifacts),
+        "by_surface": dict(sorted(by_surface.items())),
+        "artifacts": artifacts[-20:],
+    }
 
 
 def _known_gaps(
@@ -809,6 +853,10 @@ def render_markdown(report: dict[str, Any]) -> str:
     artifact_source_groups = report.get("artifact_source_groups", {})
     _render_artifact_source_groups_markdown(lines, artifact_source_groups)
 
+    # Real pytest evidence artifacts
+    lines.extend(["", "### Contract Evidence Artifacts"])
+    _render_contract_evidence_markdown(lines, report.get("contract_evidence_artifacts", {}))
+
     # Manual review requirements
     manual_review_requirements = report.get("manual_review_requirements", [])
     if manual_review_requirements:
@@ -861,16 +909,45 @@ def _render_artifact_source_groups_markdown(lines: list[str], groups: dict[str, 
         lines.append("- no affected checks")
         return
 
+    rendered_any = False
     for taxonomy_name in _TAXONOMY_SORT_ORDER:
         group = groups.get(taxonomy_name)
         if not isinstance(group, dict) or group.get("check_count", 0) == 0:
             continue
+        rendered_any = True
         count = group["check_count"]
         description = str(group.get("description", ""))
         artifact_source = str(group.get("artifact_source", taxonomy_name))
         actionable = bool(group.get("actionable", False))
         label = "actionable" if actionable else "does not block"
         lines.append(f"- **{artifact_source}** ({label}): {count} check(s) -- {description}")
+    if not rendered_any:
+        lines.append("- no affected checks")
+
+
+def _render_contract_evidence_markdown(lines: list[str], summary: object) -> None:
+    if not isinstance(summary, dict):
+        lines.append("- none found")
+        return
+    artifact_count = int(summary.get("artifact_count") or 0)
+    artifact_dir = str(summary.get("artifact_dir") or _CONTRACT_EVIDENCE_DIR.as_posix())
+    if artifact_count == 0:
+        lines.append(f"- none found in `{artifact_dir}`")
+        return
+    lines.append(f"- {artifact_count} artifact(s) in `{artifact_dir}`")
+    by_surface = summary.get("by_surface")
+    if isinstance(by_surface, dict) and by_surface:
+        rendered = ", ".join(f"{surface}: {count}" for surface, count in sorted(by_surface.items()))
+        lines.append(f"- by surface: {rendered}")
+    artifacts = summary.get("artifacts")
+    if isinstance(artifacts, list) and artifacts:
+        for artifact in artifacts[:5]:
+            if not isinstance(artifact, dict):
+                continue
+            contract = str(artifact.get("contract") or "unknown")
+            nodeid = str(artifact.get("test_nodeid") or "unknown")
+            path = str(artifact.get("path") or "")
+            lines.append(f"- `{contract}` from `{nodeid}` -> `{path}`")
 
 
 def _checks_payload_merge(
@@ -946,6 +1023,9 @@ def _print_human_report(report: dict[str, Any]) -> None:
     print()
     print(f"Manual review requirements: {len(report.get('manual_review_requirements', []))}")
     print(f"Stable routed checks: {len(report.get('stable_routed_checks', []))}")
+    evidence = report.get("contract_evidence_artifacts", {})
+    if isinstance(evidence, dict):
+        print(f"Contract evidence artifacts: {evidence.get('artifact_count', 0)}")
     print(f"Known gaps: {len(report.get('known_gaps', []))}")
 
     check_result = report.get("check")

--- a/devtools/proof_pack.py
+++ b/devtools/proof_pack.py
@@ -313,7 +313,6 @@ def _domain_payload(domain: str, info: object, claims: list[Any]) -> dict[str, A
     return {
         "domain": domain,
         "description": info_dict.get("description", ""),
-        "maturity": info_dict.get("maturity", "seed"),
         "claim_count": len({claim.id for claim in domain_claims}),
         "oracle_counts": dict(Counter(claim.oracle for claim in domain_claims)),
     }
@@ -334,7 +333,6 @@ def _domain_coverage(domains_data: dict[str, dict[str, Any]], catalog: Any) -> l
             {
                 "domain": domain,
                 "description": info_dict.get("description", ""),
-                "maturity": info_dict.get("maturity", "seed"),
                 "claim_count": len(claims),
                 "obligation_count": obligations_by_domain[domain],
                 "oracle_counts": dict(Counter(claim.oracle for claim in claims)),

--- a/devtools/proof_pack.py
+++ b/devtools/proof_pack.py
@@ -438,10 +438,10 @@ def _subject_assurance_domain(subject: Any) -> str | None:
     return domain if isinstance(domain, str) and domain.strip() else None
 
 
-def build_slop_dashboard(catalog: VerificationCatalog) -> dict[str, Any]:
-    """Analyze the catalog for anti-vacuity violations — "slop" claims.
+def build_anti_vacuity_report(catalog: VerificationCatalog) -> dict[str, Any]:
+    """Analyze the catalog for anti-vacuity violations.
 
-    A claim is slop if ANY of:
+    A claim is flagged if any of:
     - No breaker defined and no tracked exception
     - No runner binding (no executable check)
     - Zero subjects matched (no compiled obligations)
@@ -499,8 +499,8 @@ def build_slop_dashboard(catalog: VerificationCatalog) -> dict[str, Any]:
             "self_referential": self_referential,
             "stale_evidence": bool(stale_evidence),
         }
-        is_slop = any(reasons.values())
-        if is_slop:
+        is_flagged = any(reasons.values())
+        if is_flagged:
             rows.append(
                 {
                     "claim_id": claim.id,
@@ -520,7 +520,7 @@ def build_slop_dashboard(catalog: VerificationCatalog) -> dict[str, Any]:
 
     return {
         "total_claims": len(catalog.claims),
-        "slop_count": len(rows),
+        "flagged_count": len(rows),
         "rows": sorted(rows, key=lambda r: r["claim_id"]),
         "by_reason": {
             "missing_breaker": sum(1 for r in rows if r["missing_breaker"]),
@@ -532,12 +532,12 @@ def build_slop_dashboard(catalog: VerificationCatalog) -> dict[str, Any]:
     }
 
 
-def render_slop_markdown(dashboard: dict[str, Any]) -> str:
-    """Render the slop dashboard as markdown."""
+def render_anti_vacuity_markdown(dashboard: dict[str, Any]) -> str:
+    """Render the anti-vacuity report as markdown."""
     lines = [
-        "## Anti-Vacuity Slop Dashboard",
+        "## Anti-Vacuity Report",
         "",
-        f"**Claims analyzed:** {dashboard['total_claims']}  **Slop claims:** {dashboard['slop_count']}",
+        f"**Claims analyzed:** {dashboard['total_claims']}  **Flagged claims:** {dashboard['flagged_count']}",
         "",
         "### By Reason",
         "",
@@ -550,7 +550,7 @@ def render_slop_markdown(dashboard: dict[str, Any]) -> str:
 
     rows = dashboard["rows"]
     if not rows:
-        lines.append("_No slop claims found._")
+        lines.append("_No flagged claims found._")
         return "\n".join(lines)
 
     lines.extend(
@@ -572,7 +572,7 @@ def render_slop_markdown(dashboard: dict[str, Any]) -> str:
         )
 
     lines.append("")
-    lines.append("### X = slop condition detected. Empty = OK.")
+    lines.append("### X = anti-vacuity condition detected. Empty = OK.")
     return "\n".join(lines)
 
 
@@ -645,12 +645,12 @@ def _click_has_json_flag(cmd: Any) -> bool:
     return False
 
 
-def _print_slop_dashboard(dashboard: dict[str, Any]) -> None:
-    """Print a human-readable slop dashboard to stdout."""
-    print("Anti-Vacuity Slop Dashboard")
+def _print_anti_vacuity_report(dashboard: dict[str, Any]) -> None:
+    """Print a human-readable anti-vacuity report to stdout."""
+    print("Anti-Vacuity Report")
     print(f"{'=' * 40}")
     print(f"Claims analyzed: {dashboard['total_claims']}")
-    print(f"Slop claims:     {dashboard['slop_count']}")
+    print(f"Flagged claims:     {dashboard['flagged_count']}")
     print()
     print("By reason:")
     by_reason = dashboard["by_reason"]
@@ -661,7 +661,7 @@ def _print_slop_dashboard(dashboard: dict[str, Any]) -> None:
 
     rows = dashboard["rows"]
     if not rows:
-        print("No slop claims found.")
+        print("No flagged claims found.")
         return
 
     print(f"{'Claim ID':<55} {'Domain':<25} {'Brk':>3} {'Run':>3} {'Sub':>3} {'Slf':>3} {'Stl':>3}")
@@ -698,9 +698,9 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--markdown", action="store_true", help="Emit PR-comment-ready Markdown.")
     parser.add_argument("--check", action="store_true", help="Exit non-zero when report blocking policy fails.")
     parser.add_argument(
-        "--slop",
+        "--anti-vacuity",
         action="store_true",
-        help="Emit anti-vacuity slop dashboard (claims lacking breakers, runners, subjects, or with stale evidence).",
+        help="Emit anti-vacuity report (claims lacking breakers, runners, subjects, or with stale evidence).",
     )
     parser.add_argument(
         "--discover-subjects",
@@ -711,18 +711,18 @@ def main(argv: list[str] | None = None) -> int:
 
     root = _get_root()
 
-    if args.slop:
+    if args.anti_vacuity:
         catalog = build_verification_catalog()
-        dashboard = build_slop_dashboard(catalog)
+        dashboard = build_anti_vacuity_report(catalog)
         if args.json:
             json.dump(dashboard, sys.stdout, indent=2, sort_keys=True)
             sys.stdout.write("\n")
         elif args.markdown:
-            sys.stdout.write(render_slop_markdown(dashboard))
+            sys.stdout.write(render_anti_vacuity_markdown(dashboard))
             sys.stdout.write("\n")
         else:
-            _print_slop_dashboard(dashboard)
-        return 1 if dashboard["slop_count"] > 0 and args.check else 0
+            _print_anti_vacuity_report(dashboard)
+        return 1 if dashboard["flagged_count"] > 0 and args.check else 0
 
     if args.discover_subjects:
         subjects = discover_click_json_subjects()

--- a/devtools/proof_pack.py
+++ b/devtools/proof_pack.py
@@ -1,11 +1,11 @@
-"""Diff-shaped proof-pack report for PR confidence.
+"""Diff-shaped verification impact report for PR confidence.
 
-Consumes the assurance-domain manifests, proof catalog, and affected-obligation
-routing to produce an operator-facing confidence answer.
+Consumes assurance-domain manifests, the catalog implementation, and
+changed-path routing to produce an operator-facing confidence answer.
 
-The report classifies every affected obligation by evidence taxonomy so agents
-can distinguish executable checks from static declarations, metadata
-completeness assertions, and advisory noise.
+The report classifies each routed check by artifact source so agents can
+distinguish executable tests from static declarations, metadata completeness
+assertions, manual review requirements, and advisory noise.
 """
 
 from __future__ import annotations
@@ -34,12 +34,21 @@ from polylogue.proof.models import EvidenceTaxonomy, RunnerBinding, SubjectRef
 
 # Taxonomy human-facing descriptions and actionability guidance.
 _TAXONOMY_DESCRIPTIONS: dict[EvidenceTaxonomy, str] = {
-    "executable_behavior": "Gates backed by executable checks (tests, probes, smoke runs).",
-    "observability": "Runtime trace or diagnostic observability evidence.",
-    "architectural_static": "Static boundary checks (topology, layering, file budgets).",
-    "metadata_spec": "Metadata and specification completeness -- does not block by itself.",
-    "manual_review": "Requires human agent judgment artifact.",
+    "executable_behavior": "Pytest nodes, probes, smoke runs, or benchmark commands.",
+    "observability": "Runtime trace or diagnostic artifact evidence.",
+    "architectural_static": "Static checks such as topology, layering, file budgets, and manifests.",
+    "metadata_spec": "Documentation or metadata completeness -- does not block by itself.",
+    "manual_review": "Explicit manual review artifact required.",
     "advisory": "Advisory / noise -- tracking only, not a gate.",
+}
+
+_TAXONOMY_ARTIFACT_SOURCE: dict[EvidenceTaxonomy, str] = {
+    "executable_behavior": "pytest_or_command",
+    "observability": "runtime_artifact",
+    "architectural_static": "static_check",
+    "metadata_spec": "metadata_or_docs",
+    "manual_review": "manual_review",
+    "advisory": "advisory",
 }
 
 _TAXONOMY_ACTIONABLE: frozenset[EvidenceTaxonomy] = frozenset(
@@ -118,19 +127,19 @@ def _taxonomy_for_obligation(
     return result
 
 
-def _build_taxonomy_groups(
+def _build_artifact_source_groups(
     affected_obligations: tuple[AffectedObligation, ...],
     *,
     catalog: VerificationCatalog,
     cache: dict[str, EvidenceTaxonomy],
 ) -> dict[str, Any]:
-    """Group affected obligations by evidence taxonomy."""
+    """Group routed checks by their real artifact source."""
     grouped: dict[EvidenceTaxonomy, list[dict[str, Any]]] = defaultdict(list)
     for item in affected_obligations:
         taxonomy = _taxonomy_for_obligation(item.obligation_id, catalog, cache=cache)
         grouped[taxonomy].append(
             {
-                "obligation_id": item.obligation_id,
+                "check_id": item.obligation_id,
                 "claim_id": item.claim_id,
                 "subject_id": item.subject_id,
                 "reasons": list(item.reasons),
@@ -141,10 +150,11 @@ def _build_taxonomy_groups(
     for taxonomy in _TAXONOMY_SORT_ORDER:
         items = grouped.get(taxonomy, [])
         payload[taxonomy] = {
+            "artifact_source": _TAXONOMY_ARTIFACT_SOURCE.get(taxonomy, "advisory"),
             "description": _TAXONOMY_DESCRIPTIONS.get(taxonomy, ""),
             "actionable": taxonomy in _TAXONOMY_ACTIONABLE,
-            "obligation_count": len(items),
-            "obligations": items,
+            "check_count": len(items),
+            "checks": items,
         }
     return payload
 
@@ -200,7 +210,7 @@ def build_proof_pack(
         visible_domains=visible_gap_domains,
     )
     taxonomy_cache: dict[str, EvidenceTaxonomy] = {}
-    taxonomy_groups = _build_taxonomy_groups(
+    artifact_source_groups = _build_artifact_source_groups(
         affected.affected_obligations,
         catalog=catalog,
         cache=taxonomy_cache,
@@ -223,9 +233,9 @@ def build_proof_pack(
         "domain_coverage": _domain_coverage(domains_data, catalog),
         "gate_groups": gate_groups,
         "required_gates": _checks_payload((*affected.inner_loop_checks, *affected.pr_gates)),
-        "agent_judgment_cells": _agent_judgment_cells(affected_claims),
-        "stable_affected_obligations": list(affected.obligation_diff.stable_affected),
-        "taxonomy": taxonomy_groups,
+        "manual_review_requirements": _manual_review_requirements(affected_claims),
+        "stable_routed_checks": list(affected.obligation_diff.stable_affected),
+        "artifact_source_groups": artifact_source_groups,
         "known_gaps": known_gaps,
         "additional_known_gaps": additional_known_gaps,
         "oracle_mix": dict(Counter(claim.oracle for claim in affected_claims)),
@@ -234,9 +244,9 @@ def build_proof_pack(
             "No changed paths -- zero obligations are change-specific. Catalog stats reflect the baseline, not a diff."
             if clean_tree
             else (
-                f"{len(paths)} changed path(s); {affected_count} affected obligations, "
-                f"{stable_count} stable affected. "
-                "Taxonomy distinguishes executable gates from static/metadata obligations."
+                f"{len(paths)} changed path(s); {affected_count} routed check(s), "
+                f"{stable_count} stable routed check(s). "
+                "Artifact-source groups distinguish tests, static checks, metadata, and review requirements."
             )
         ),
     }
@@ -258,15 +268,18 @@ def evaluate_check_policy(report: dict[str, Any]) -> dict[str, Any]:
         elif status == OutcomeStatus.WARNING.value:
             warnings.append(line)
 
-    serious_judgment_cells = [
-        cell
-        for cell in report.get("agent_judgment_cells", [])
-        if isinstance(cell, dict) and cell.get("severity") == "serious" and not _judgment_cell_satisfied(cell)
+    serious_review_requirements = [
+        requirement
+        for requirement in report.get("manual_review_requirements", [])
+        if isinstance(requirement, dict)
+        and requirement.get("severity") == "serious"
+        and not _manual_review_requirement_satisfied(requirement)
     ]
-    for cell in serious_judgment_cells:
+    for requirement in serious_review_requirements:
         errors.append(
-            "affected serious claim needs agent judgment artifact: "
-            f"{cell.get('claim_id')} ({cell.get('oracle')}, {cell.get('independence_level')})"
+            "affected serious claim needs manual review artifact: "
+            f"{requirement.get('claim_id')} ({requirement.get('oracle')}, "
+            f"{requirement.get('independence_level')})"
         )
 
     suppressed = _suppressed_change_subjects(report)
@@ -285,13 +298,15 @@ def evaluate_check_policy(report: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def _judgment_cell_satisfied(cell: dict[str, Any]) -> bool:
-    if cell.get("tracked_exception"):
+def _manual_review_requirement_satisfied(requirement: dict[str, Any]) -> bool:
+    if requirement.get("tracked_exception"):
         return True
-    result = str(cell.get("result") or "").strip().lower()
+    result = str(requirement.get("result") or "").strip().lower()
     if result not in {"accepted", "passed", "pass", "ok"}:
         return False
-    return all(str(cell.get(field) or "").strip() for field in ("artifact", "reviewer", "produced_at", "freshness"))
+    return all(
+        str(requirement.get(field) or "").strip() for field in ("artifact", "reviewer", "produced_at", "freshness")
+    )
 
 
 def _suppressed_change_subjects(report: dict[str, Any]) -> list[str]:
@@ -353,11 +368,11 @@ def _checks_payload(checks: tuple[RecommendedCheck, ...]) -> list[dict[str, Any]
     return payload
 
 
-def _agent_judgment_cells(claims: list[Any]) -> list[dict[str, Any]]:
-    cells: list[dict[str, Any]] = []
+def _manual_review_requirements(claims: list[Any]) -> list[dict[str, Any]]:
+    requirements: list[dict[str, Any]] = []
     for claim in claims:
         if claim.oracle == "manual_review" or claim.independence_level in {"same_source", "self_attesting"}:
-            cells.append(
+            requirements.append(
                 {
                     "claim_id": claim.id,
                     "oracle": claim.oracle,
@@ -369,10 +384,10 @@ def _agent_judgment_cells(claims: list[Any]) -> list[dict[str, Any]]:
                     "produced_at": None,
                     "freshness": None,
                     "result": "tracked_exception" if claim.tracked_exception else "missing",
-                    "reason": "requires agent judgment artifact or independent evidence upgrade",
+                    "reason": "requires manual review artifact or independent evidence upgrade",
                 }
             )
-    return cells
+    return requirements
 
 
 def _known_gaps(
@@ -789,17 +804,17 @@ def render_markdown(report: dict[str, Any]) -> str:
     lines.extend(["", "### Confidence Gates (optional)"])
     _append_gate_lines(lines, gate_groups.get("optional_confidence", []), empty_text="- none")
 
-    # Evidence Taxonomy
-    lines.extend(["", "### Affected Evidence by Taxonomy"])
-    taxonomy = report.get("taxonomy", {})
-    _render_taxonomy_section_markdown(lines, taxonomy)
+    # Artifact-source groups
+    lines.extend(["", "### Affected Checks by Artifact Source"])
+    artifact_source_groups = report.get("artifact_source_groups", {})
+    _render_artifact_source_groups_markdown(lines, artifact_source_groups)
 
-    # Agent Judgment Cells
-    agent_judgment_cells = report.get("agent_judgment_cells", [])
-    if agent_judgment_cells:
-        lines.extend(["", "### Agent Judgment Cells (manual review)"])
-        lines.append(f"_{len(agent_judgment_cells)} cell(s) -- only actionable if severity is 'serious'_")
-        for cell in agent_judgment_cells:
+    # Manual review requirements
+    manual_review_requirements = report.get("manual_review_requirements", [])
+    if manual_review_requirements:
+        lines.extend(["", "### Manual Review Requirements"])
+        lines.append(f"_{len(manual_review_requirements)} requirement(s) -- only blocking when severity is 'serious'_")
+        for cell in manual_review_requirements:
             lines.append(
                 f"- `{cell['claim_id']}` -- result `{cell['result']}`; "
                 f"artifact `{cell['artifact'] or 'missing'}`; "
@@ -828,33 +843,34 @@ def render_markdown(report: dict[str, Any]) -> str:
     catalog_headline = report.get("catalog_headline", {})
     lines.append(
         f"- claims: {catalog_headline.get('claim_count', '?')}, "
-        f"obligations: {catalog_headline.get('obligation_count', '?')}"
+        f"routed checks: {catalog_headline.get('obligation_count', '?')}"
     )
     oracle_str = json.dumps(oracle_mix, sort_keys=True) if oracle_mix else "(none affected)"
     lines.append(f"- oracle mix: `{oracle_str}`")
     cost_str = json.dumps(cost_tier, sort_keys=True) if cost_tier else "(none)"
     lines.append(f"- cost tier: `{cost_str}`")
-    lines.append(f"- stable affected obligations: {len(report.get('stable_affected_obligations', []))}")
-    lines.append(f"- agent judgment cells: {len(agent_judgment_cells)}")
+    lines.append(f"- stable routed checks: {len(report.get('stable_routed_checks', []))}")
+    lines.append(f"- manual review requirements: {len(manual_review_requirements)}")
 
     return "\n".join(lines)
 
 
-def _render_taxonomy_section_markdown(lines: list[str], taxonomy: dict[str, Any]) -> None:
-    """Append taxonomy-grouped obligation tables to markdown lines."""
-    if not taxonomy:
-        lines.append("- no affected obligations")
+def _render_artifact_source_groups_markdown(lines: list[str], groups: dict[str, Any]) -> None:
+    """Append artifact-source grouped check counts to markdown lines."""
+    if not groups:
+        lines.append("- no affected checks")
         return
 
     for taxonomy_name in _TAXONOMY_SORT_ORDER:
-        group = taxonomy.get(taxonomy_name)
-        if not isinstance(group, dict) or group.get("obligation_count", 0) == 0:
+        group = groups.get(taxonomy_name)
+        if not isinstance(group, dict) or group.get("check_count", 0) == 0:
             continue
-        count = group["obligation_count"]
+        count = group["check_count"]
         description = str(group.get("description", ""))
+        artifact_source = str(group.get("artifact_source", taxonomy_name))
         actionable = bool(group.get("actionable", False))
         label = "actionable" if actionable else "does not block"
-        lines.append(f"- **{taxonomy_name}** ({label}): {count} obligation(s) -- {description}")
+        lines.append(f"- **{artifact_source}** ({label}): {count} check(s) -- {description}")
 
 
 def _checks_payload_merge(
@@ -886,8 +902,8 @@ def _print_human_report(report: dict[str, Any]) -> None:
     """Print a taxonomy-aware human-readable verification report."""
     headline = report["catalog_headline"]
     print(
-        f"Verification catalog: {headline['claim_count']} claims, "
-        f"{headline['obligation_count']} obligations, {headline['subject_count']} subjects"
+        f"Verification inventory: {headline['claim_count']} claims, "
+        f"{headline['obligation_count']} routed checks, {headline['subject_count']} subjects"
     )
     print(f"Refs: {report['refs']['base_ref']}..{report['refs']['head_ref']}")
     print(f"Changed paths: {len(report['changed_paths'])}")
@@ -908,27 +924,28 @@ def _print_human_report(report: dict[str, Any]) -> None:
         print("  none beyond always-on PR gates")
     print()
 
-    print("Evidence taxonomy:")
-    taxonomy = report.get("taxonomy", {})
-    if taxonomy:
+    print("Affected checks by artifact source:")
+    artifact_source_groups = report.get("artifact_source_groups", {})
+    if artifact_source_groups:
         for taxonomy_name in _TAXONOMY_SORT_ORDER:
-            group = taxonomy.get(taxonomy_name)
-            if not isinstance(group, dict) or group.get("obligation_count", 0) == 0:
+            group = artifact_source_groups.get(taxonomy_name)
+            if not isinstance(group, dict) or group.get("check_count", 0) == 0:
                 continue
-            count = group["obligation_count"]
+            count = group["check_count"]
+            artifact_source = str(group.get("artifact_source", taxonomy_name))
             actionable = "RUN" if group.get("actionable") else "INFO"
-            print(f"  {taxonomy_name:<25} {count:>4} obligations [{actionable}]")
+            print(f"  {artifact_source:<25} {count:>4} checks [{actionable}]")
             print(f"    {group.get('description', '')}")
     else:
-        print("  no affected obligations")
+        print("  no affected checks")
     print()
 
     print("Confidence gates (optional):")
     for gate in gate_groups.get("optional_confidence", []):
         print(f"  {' '.join(gate['command'])} -- {gate['reason']}")
     print()
-    print(f"Agent judgment cells: {len(report.get('agent_judgment_cells', []))}")
-    print(f"Stable affected obligations: {len(report.get('stable_affected_obligations', []))}")
+    print(f"Manual review requirements: {len(report.get('manual_review_requirements', []))}")
+    print(f"Stable routed checks: {len(report.get('stable_routed_checks', []))}")
     print(f"Known gaps: {len(report.get('known_gaps', []))}")
 
     check_result = report.get("check")

--- a/devtools/proof_pack.py
+++ b/devtools/proof_pack.py
@@ -677,13 +677,13 @@ def _cost_tier_counts(report: Any, catalog: VerificationCatalog) -> dict[str, in
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Diff-shaped proof-pack report for PR confidence.")
+    parser = argparse.ArgumentParser(description="Diff-shaped verification impact report for PR review.")
     parser.add_argument("--base-ref", default="origin/master", help="Base git ref for changed-path discovery.")
     parser.add_argument("--head-ref", default="HEAD", help="Head git ref for changed-path discovery.")
     parser.add_argument("--path", action="append", dest="paths", default=None, help="Changed file path (repeatable).")
     parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
     parser.add_argument("--markdown", action="store_true", help="Emit PR-comment-ready Markdown.")
-    parser.add_argument("--check", action="store_true", help="Exit non-zero when proof-pack blocking policy fails.")
+    parser.add_argument("--check", action="store_true", help="Exit non-zero when report blocking policy fails.")
     parser.add_argument(
         "--slop",
         action="store_true",
@@ -747,12 +747,12 @@ def main(argv: list[str] | None = None) -> int:
 
 
 def render_markdown(report: dict[str, Any]) -> str:
-    """Render a taxonomy-aware Proof Pack as PR-comment-ready markdown."""
+    """Render a taxonomy-aware report as PR-comment-ready markdown."""
     refs = report["refs"]
     context = str(report.get("_context", ""))
     changed_paths_count = len(report.get("changed_paths", []))
     lines = [
-        "## Polylogue Proof Pack",
+        "## Polylogue Verification Impact",
         "",
         f"**Refs:** `{refs['base_ref']}..{refs['head_ref']}`",
         f"**Changed paths:** {changed_paths_count}",
@@ -824,7 +824,7 @@ def render_markdown(report: dict[str, Any]) -> str:
         lines.extend(["", "</details>"])
 
     # Catalog quality summary
-    lines.extend(["", "### Catalog Quality"])
+    lines.extend(["", "### Catalog Checks"])
     oracle_mix = report.get("oracle_mix", {})
     cost_tier = report.get("cost_tier", {})
     catalog_headline = report.get("catalog_headline", {})
@@ -885,10 +885,10 @@ def _append_gate_lines(lines: list[str], gates: list[dict[str, Any]], *, empty_t
 
 
 def _print_human_report(report: dict[str, Any]) -> None:
-    """Print a taxonomy-aware human-readable proof-pack report."""
+    """Print a taxonomy-aware human-readable verification report."""
     headline = report["catalog_headline"]
     print(
-        f"Proof catalog: {headline['claim_count']} claims, "
+        f"Verification catalog: {headline['claim_count']} claims, "
         f"{headline['obligation_count']} obligations, {headline['subject_count']} subjects"
     )
     print(f"Refs: {report['refs']['base_ref']}..{report['refs']['head_ref']}")

--- a/devtools/render_devtools_reference.py
+++ b/devtools/render_devtools_reference.py
@@ -52,8 +52,8 @@ def _render_verification_lab_surface(commands: tuple[CommandSpec, ...]) -> list[
     lines = [
         "## Verification Lab Surface",
         "",
-        "The proof-lab operator surface intentionally lives in `devtools` for now. These commands operate on",
-        "repo proof obligations and evidence records, not end-user archive workflows.",
+        "The verification-lab operator surface intentionally lives in `devtools` for now. These commands operate on",
+        "repo verification checks and evidence records, not end-user archive workflows.",
         "",
         "| Command | Role |",
         "| --- | --- |",

--- a/devtools/verify.py
+++ b/devtools/verify.py
@@ -11,7 +11,7 @@ Tiers:
              Full non-integration pytest run that seeds/updates .testmondata.
   --all/--full
              Explicit full non-integration pytest diagnostic.
-  --lab      Full baseline + verification-lab scenario checks.
+  --lab      Default testmon baseline plus verification-lab scenario and SLO checks.
 
 Output formats:
   --json     Machine-readable JSON to stdout (human progress to stderr).
@@ -217,6 +217,10 @@ def _run(label: str, cmd: list[str], *, cwd: str | None = None) -> tuple[int, fl
         if result.stderr.strip():
             sys.stderr.write(result.stderr + "\n")
     return result.returncode, elapsed, metadata
+
+
+def _stop_after_failed_step(label: str) -> bool:
+    return label.startswith("pytest") or label in {"lab scenario", "verify-slos"}
 
 
 # ── step builder ────────────────────────────────────────────────────
@@ -444,7 +448,12 @@ def main(argv: list[str] | None = None) -> int:
         "--skip-slow", action="store_true", help="Exclude @pytest.mark.slow tests from the pytest step."
     )
     parser.add_argument(
-        "--lab", action="store_true", help="Delegate additional domain proof checks through verification-lab."
+        "--lab",
+        action="store_true",
+        help=(
+            "Run the default pytest-testmon baseline plus verification-lab "
+            "scenario and verify-slos checks; does not imply --all."
+        ),
     )
     parser.add_argument("--history", action="store_true", help="Print last 10 verify runs and exit.")
     parser.add_argument("--json", action="store_true", default=None, help="Write structured JSON to stdout.")
@@ -518,7 +527,8 @@ def main(argv: list[str] | None = None) -> int:
         step_results.append(step_result)
         if rc != 0:
             exit_code = rc
-            break
+            if _stop_after_failed_step(label):
+                break
 
     total_duration = round(time.monotonic() - t0, 2)
 

--- a/devtools/verify.py
+++ b/devtools/verify.py
@@ -6,7 +6,11 @@ the branch is ready to push; non-zero means fix before pushing.
 Tiers:
   --commit   Pre-commit tier: ruff format + check + mypy + proof-pack (~3s warm).
   --quick    Pre-push tier: all non-pytest gates (~15s warm).
-  (default)  Full baseline: all gates + pytest (~3 min).
+  (default)  Baseline with pytest-testmon affected tests.
+  --seed-testmon
+             Full non-integration pytest run that seeds/updates .testmondata.
+  --all/--full
+             Explicit full non-integration pytest diagnostic.
   --lab      Full baseline + verification-lab scenario checks.
 
 Output formats:
@@ -18,7 +22,9 @@ from __future__ import annotations
 
 import argparse
 import contextlib
+import hashlib
 import json
+import os
 import re
 import shutil
 import subprocess
@@ -119,6 +125,8 @@ def _format_completion_notification(
 
 
 HISTORY_PATH = Path(".cache/verify-history.jsonl")
+TESTMON_DATA = Path(".testmondata")
+TESTMON_SEED_STAMP = Path(".cache/testmon/seed.json")
 
 
 def _load_history() -> list[dict[str, Any]]:
@@ -202,88 +210,14 @@ def _run(label: str, cmd: list[str], *, cwd: str | None = None) -> tuple[int, fl
 # ── step builder ────────────────────────────────────────────────────
 
 
-def _changed_files_against_base() -> list[str] | None:
-    """Return files changed against origin/master plus untracked files."""
-    result = subprocess.run(
-        ["git", "diff", "--name-only", "origin/master...HEAD"],
-        capture_output=True,
-        text=True,
-    )
-    if result.returncode != 0:
-        result = subprocess.run(
-            ["git", "diff", "--name-only", "HEAD"],
-            capture_output=True,
-            text=True,
-        )
-    if result.returncode != 0:
-        return None
-    changed = [line for line in result.stdout.splitlines() if line.strip()]
-    untracked = subprocess.run(
-        ["git", "ls-files", "--others", "--exclude-standard"],
-        capture_output=True,
-        text=True,
-    )
-    if untracked.returncode == 0:
-        changed.extend(line for line in untracked.stdout.splitlines() if line.strip())
-    return sorted(set(changed))
-
-
-def _affected_test_files() -> list[str] | None:
-    """Return affected test files, [] for no pytest needed, or None for full pytest."""
-    changed = _changed_files_against_base()
-    if changed is None or not changed:
-        return None
-
-    broad_prefixes = (
-        "tests/conftest.py",
-        "tests/infra/",
-        "pyproject.toml",
-        "uv.lock",
-        "nix/",
-        "flake.",
-    )
-    if any(path == prefix or path.startswith(prefix) for path in changed for prefix in broad_prefixes):
-        return None
-
-    direct_tests = {path for path in changed if path.startswith("tests/") and path.endswith(".py")}
-
-    production_changes = [
-        path
-        for path in changed
-        if path.endswith(".py") and (path.startswith("polylogue/") or path.startswith("devtools/"))
-    ]
-    if not production_changes:
-        return sorted(direct_tests)
-
-    from devtools import verify_test_ownership
-
-    name_to_path = verify_test_ownership.production_module_names()
-    path_to_name = {path: name for name, path in name_to_path.items()}
-    changed_names = {path_to_name[path] for path in production_changes if path in path_to_name}
-    if not changed_names:
-        return None
-
-    affected = set(direct_tests)
-    for test_path in verify_test_ownership.test_files():
-        imports = verify_test_ownership.imports_in(test_path)
-        for imported in imports:
-            if any(
-                imported == name or imported.startswith(name + ".") or name.startswith(imported + ".")
-                for name in changed_names
-            ):
-                affected.add(test_path.relative_to(Path.cwd()).as_posix())
-                break
-
-    return sorted(affected) if affected else None
-
-
 def build_verify_steps(
     *,
     quick: bool,
     lab: bool,
     skip_slow: bool,
     commit: bool = False,
-    affected_tests: list[str] | None = None,
+    seed_testmon: bool = False,
+    full_pytest: bool = False,
 ) -> list[tuple[str, list[str]]]:
     steps: list[tuple[str, list[str]]] = [
         ("ruff format", ["ruff", "format", "--check", "polylogue/", "tests/", "devtools/"]),
@@ -314,12 +248,17 @@ def build_verify_steps(
         pytest_cmd = ["pytest", "-q", "--tb=short", "--ignore=tests/integration"]
         if skip_slow:
             pytest_cmd.extend(["-m", "not slow"])
-        if affected_tests is not None:
-            if affected_tests:
-                pytest_cmd.extend(affected_tests)
-                steps.append(("pytest affected", pytest_cmd))
+        if seed_testmon:
+            pytest_cmd.extend(["--testmon", "--testmon-noselect", *_pytest_worker_args(default="8")])
+            steps.append(("pytest seed-testmon", pytest_cmd))
+        elif full_pytest:
+            pytest_cmd.extend(_pytest_worker_args(default="8"))
+            steps.append(("pytest full", pytest_cmd))
         else:
-            steps.append(("pytest", pytest_cmd))
+            pytest_cmd.extend(["--testmon", "-n", "0"])
+            if skip_slow:
+                pytest_cmd.append("--testmon-forceselect")
+            steps.append(("pytest testmon", pytest_cmd))
 
     if lab:
         steps.append(("lab scenario", _devtools_cmd("lab-scenario", "run", "archive-smoke", "--tier", "0")))
@@ -387,7 +326,7 @@ def _stamp_head() -> None:
 RESULT_CACHE = Path(".cache/last-verify-result.json")
 
 
-def _worktree_fingerprint() -> str:
+def _worktree_fingerprint(*, mode_key: str = "") -> str:
     """Return a hash of HEAD + dirty content so unchanged worktrees skip verify."""
     head = _git_head() or ""
     diff = subprocess.run(
@@ -411,14 +350,53 @@ def _worktree_fingerprint() -> str:
                 with contextlib.suppress(OSError, UnicodeDecodeError):
                     chunks.append(path.read_text(encoding="utf-8"))
         untracked_payload = "\n".join(chunks)
-    payload = f"{head}\n{diff_payload}\n{untracked_payload}"
+    testmon_state = _file_fingerprint(TESTMON_DATA)
+    payload = f"{mode_key}\n{head}\n{diff_payload}\n{untracked_payload}\n.testmondata={testmon_state}"
     return _hash_text(payload)
 
 
 def _hash_text(text: str) -> str:
-    import hashlib
-
     return hashlib.sha256(text.encode()).hexdigest()
+
+
+def _file_fingerprint(path: Path) -> str:
+    if not path.exists() or not path.is_file():
+        return "missing"
+    h = hashlib.sha256()
+    try:
+        with path.open("rb") as f:
+            for chunk in iter(lambda: f.read(1024 * 1024), b""):
+                h.update(chunk)
+    except OSError:
+        return "unreadable"
+    return h.hexdigest()
+
+
+def _pytest_worker_args(*, default: str) -> list[str]:
+    workers = os.environ.get("POLYLOGUE_PYTEST_WORKERS", default).strip() or default
+    return ["-n", workers]
+
+
+def _testmon_preflight(*, seed_testmon: bool, full_pytest: bool, quick: bool, commit: bool) -> str | None:
+    if quick or commit or seed_testmon or full_pytest:
+        return None
+    if TESTMON_DATA.exists() and TESTMON_SEED_STAMP.exists():
+        return None
+    return (
+        "verify: pytest-testmon is not seeded; run `devtools verify --seed-testmon` "
+        "to create .testmondata and .cache/testmon/seed.json before using the default affected-test path.\n"
+    )
+
+
+def _write_testmon_seed_stamp(result: dict[str, Any]) -> None:
+    TESTMON_SEED_STAMP.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "git_head": result.get("git_head"),
+        "testmon_data": _file_fingerprint(TESTMON_DATA),
+        "steps": result.get("steps", []),
+    }
+    TESTMON_SEED_STAMP.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n")
 
 
 def _read_cached_result(fp: str) -> dict[str, Any] | None:
@@ -450,9 +428,16 @@ def _write_cached_result(fp: str, result: dict[str, Any]) -> None:
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Run the local verification baseline.")
     parser.add_argument("--quick", action="store_true", help="Skip pytest and run only fast local gates.")
-    parser.add_argument("--affected", action="store_true", help="Run only tests affected by changed files when known.")
     parser.add_argument(
-        "--all", action="store_true", help="Force the full pytest baseline even with --affected defaults."
+        "--seed-testmon",
+        action="store_true",
+        help="Run full non-integration pytest with --testmon-noselect to seed/update .testmondata.",
+    )
+    parser.add_argument(
+        "--all", action="store_true", help="Force the full non-integration pytest diagnostic instead of testmon."
+    )
+    parser.add_argument(
+        "--full", action="store_true", help="Alias for --all: run full non-integration pytest diagnostic."
     )
     parser.add_argument(
         "--commit", action="store_true", help="Pre-commit tier: format + lint + mypy + proof-pack only."
@@ -480,15 +465,43 @@ def main(argv: list[str] | None = None) -> int:
         tier = "commit"
     elif args.quick:
         tier = "quick"
-    elif args.affected:
-        tier = "affected"
+    elif args.seed_testmon:
+        tier = "seed-testmon"
+    elif args.all or args.full:
+        tier = "full"
     elif args.lab:
         tier = "lab"
+    else:
+        tier = "testmon"
+
+    full_pytest = bool(args.all or args.full)
+    mode_key = json.dumps(
+        {
+            "tier": tier,
+            "skip_slow": bool(args.skip_slow),
+            "quick": bool(args.quick),
+            "commit": bool(args.commit),
+            "lab": bool(args.lab),
+            "seed_testmon": bool(args.seed_testmon),
+            "full_pytest": full_pytest,
+        },
+        sort_keys=True,
+    )
+
+    preflight_error = _testmon_preflight(
+        seed_testmon=bool(args.seed_testmon),
+        full_pytest=full_pytest,
+        quick=bool(args.quick),
+        commit=bool(args.commit),
+    )
+    if preflight_error is not None:
+        sys.stderr.write(preflight_error)
+        return 2
 
     # Worktree-fingerprint cache: if nothing changed since last verify,
     # replay the cached result instantly instead of re-running tests.
     if not args.commit and not args.quick and not args.lab and not args.force:
-        fp = _worktree_fingerprint()
+        fp = _worktree_fingerprint(mode_key=mode_key)
         cached = _read_cached_result(fp)
         if cached is not None:
             ec: int = cached.get("exit_code", 0)
@@ -512,17 +525,14 @@ def main(argv: list[str] | None = None) -> int:
     if not args.quick and not args.commit:
         _warn_low_memory()
 
-    affected_tests = None
-    if args.affected and not args.all and not args.quick and not args.commit:
-        affected_tests = _affected_test_files()
-
     exit_code = 0
     steps = build_verify_steps(
         quick=bool(args.quick),
         commit=bool(args.commit),
         lab=bool(args.lab),
         skip_slow=bool(args.skip_slow),
-        affected_tests=affected_tests,
+        seed_testmon=bool(args.seed_testmon),
+        full_pytest=full_pytest,
     )
 
     step_results: list[dict[str, Any]] = []
@@ -536,6 +546,7 @@ def main(argv: list[str] | None = None) -> int:
         step_results.append(step_result)
         if rc != 0:
             exit_code = rc
+            break
 
     total_duration = round(time.monotonic() - t0, 2)
 
@@ -570,10 +581,12 @@ def main(argv: list[str] | None = None) -> int:
     _save_history(history_entry)
     if exit_code == 0:
         _stamp_head()
+        if args.seed_testmon:
+            _write_testmon_seed_stamp(history_entry)
     # Cache the result keyed by worktree fingerprint — next invocation
     # at the same tree state replays this instantly.
     if not args.commit and not args.quick and not args.lab:
-        fp = _worktree_fingerprint()
+        fp = _worktree_fingerprint(mode_key=mode_key)
         _write_cached_result(fp, history_entry)
 
     # Notify on long-running verify.

--- a/devtools/verify.py
+++ b/devtools/verify.py
@@ -127,6 +127,18 @@ def _format_completion_notification(
 HISTORY_PATH = Path(".cache/verify-history.jsonl")
 TESTMON_DATA = Path(".testmondata")
 TESTMON_SEED_STAMP = Path(".cache/testmon/seed.json")
+TESTMON_GLOBAL_INVALIDATORS = (
+    ".python-version",
+    "conftest.py",
+    "noxfile.py",
+    "pyproject.toml",
+    "pytest.ini",
+    "setup.cfg",
+    "tox.ini",
+    "uv.lock",
+    "tests/conftest.py",
+    "tests/infra/",
+)
 
 
 def _load_history() -> list[dict[str, Any]]:
@@ -218,6 +230,7 @@ def build_verify_steps(
     commit: bool = False,
     seed_testmon: bool = False,
     full_pytest: bool = False,
+    testmon_global: bool = False,
 ) -> list[tuple[str, list[str]]]:
     steps: list[tuple[str, list[str]]] = [
         ("ruff format", ["ruff", "format", "--check", "polylogue/", "tests/", "devtools/"]),
@@ -254,6 +267,9 @@ def build_verify_steps(
         elif full_pytest:
             pytest_cmd.extend(_pytest_worker_args(default="8"))
             steps.append(("pytest full", pytest_cmd))
+        elif testmon_global:
+            pytest_cmd.extend(["--testmon", "--testmon-noselect", *_pytest_worker_args(default="8")])
+            steps.append(("pytest testmon-global", pytest_cmd))
         else:
             pytest_cmd.extend(["--testmon", "-n", "0"])
             if skip_slow:
@@ -321,44 +337,6 @@ def _stamp_head() -> None:
     (stamp_dir / "last-verify-head").write_text(head + "\n")
 
 
-# ── worktree-fingerprint result cache ──────────────────────────────
-
-RESULT_CACHE = Path(".cache/last-verify-result.json")
-
-
-def _worktree_fingerprint(*, mode_key: str = "") -> str:
-    """Return a hash of HEAD + dirty content so unchanged worktrees skip verify."""
-    head = _git_head() or ""
-    diff = subprocess.run(
-        ["git", "diff", "--binary", "HEAD"],
-        capture_output=True,
-        text=True,
-    )
-    diff_payload = diff.stdout
-    unstaged = subprocess.run(
-        ["git", "ls-files", "--others", "--exclude-standard"],
-        capture_output=True,
-        text=True,
-    )
-    untracked_payload = ""
-    if unstaged.returncode == 0:
-        chunks: list[str] = []
-        for raw_path in sorted(line for line in unstaged.stdout.splitlines() if line.strip()):
-            path = Path(raw_path)
-            chunks.append(raw_path)
-            if path.is_file():
-                with contextlib.suppress(OSError, UnicodeDecodeError):
-                    chunks.append(path.read_text(encoding="utf-8"))
-        untracked_payload = "\n".join(chunks)
-    testmon_state = _file_fingerprint(TESTMON_DATA)
-    payload = f"{mode_key}\n{head}\n{diff_payload}\n{untracked_payload}\n.testmondata={testmon_state}"
-    return _hash_text(payload)
-
-
-def _hash_text(text: str) -> str:
-    return hashlib.sha256(text.encode()).hexdigest()
-
-
 def _file_fingerprint(path: Path) -> str:
     if not path.exists() or not path.is_file():
         return "missing"
@@ -375,6 +353,49 @@ def _file_fingerprint(path: Path) -> str:
 def _pytest_worker_args(*, default: str) -> list[str]:
     workers = os.environ.get("POLYLOGUE_PYTEST_WORKERS", default).strip() or default
     return ["-n", workers]
+
+
+def _read_testmon_seed_stamp() -> dict[str, Any] | None:
+    try:
+        raw: object = json.loads(TESTMON_SEED_STAMP.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+    return raw if isinstance(raw, dict) else None
+
+
+def _git_changed_paths(base: str | None) -> set[str] | None:
+    changed: set[str] = set()
+    commands: list[list[str]] = []
+    if base:
+        commands.append(["git", "diff", "--name-only", f"{base}..HEAD"])
+    commands.append(["git", "diff", "--name-only", "HEAD"])
+    commands.append(["git", "ls-files", "--others", "--exclude-standard"])
+
+    for command in commands:
+        result = subprocess.run(command, capture_output=True, text=True)
+        if result.returncode != 0:
+            return None
+        changed.update(line for line in result.stdout.splitlines() if line.strip())
+    return changed
+
+
+def _is_testmon_global_invalidator(path: str) -> bool:
+    if not path:
+        return False
+    if path.endswith((".toml", ".ini", ".cfg")) and (
+        path.startswith("tests/") or path in {"pyproject.toml", "setup.cfg", "tox.ini", "pytest.ini"}
+    ):
+        return True
+    return any(path == invalidator or path.startswith(invalidator) for invalidator in TESTMON_GLOBAL_INVALIDATORS)
+
+
+def _testmon_requires_global_collection() -> bool:
+    seed = _read_testmon_seed_stamp()
+    base = seed.get("git_head") if seed else None
+    changed = _git_changed_paths(base if isinstance(base, str) else None)
+    if changed is None:
+        return True
+    return any(_is_testmon_global_invalidator(path) for path in changed)
 
 
 def _testmon_preflight(*, seed_testmon: bool, full_pytest: bool, quick: bool, commit: bool) -> str | None:
@@ -397,29 +418,6 @@ def _write_testmon_seed_stamp(result: dict[str, Any]) -> None:
         "steps": result.get("steps", []),
     }
     TESTMON_SEED_STAMP.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n")
-
-
-def _read_cached_result(fp: str) -> dict[str, Any] | None:
-    """Return the cached result if the worktree fingerprint matches, else None."""
-    if not RESULT_CACHE.exists():
-        return None
-    try:
-        raw: object = json.loads(RESULT_CACHE.read_text())
-    except (json.JSONDecodeError, OSError):
-        return None
-    if not isinstance(raw, dict):
-        return None
-    cached: dict[str, Any] = raw
-    if cached.get("fingerprint") == fp:
-        result: object = cached.get("result")
-        if isinstance(result, dict):
-            return result
-    return None
-
-
-def _write_cached_result(fp: str, result: dict[str, Any]) -> None:
-    RESULT_CACHE.parent.mkdir(parents=True, exist_ok=True)
-    RESULT_CACHE.write_text(json.dumps({"fingerprint": fp, "result": result}, ensure_ascii=False) + "\n")
 
 
 # ── main ────────────────────────────────────────────────────────────
@@ -450,7 +448,6 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument("--history", action="store_true", help="Print last 10 verify runs and exit.")
     parser.add_argument("--json", action="store_true", default=None, help="Write structured JSON to stdout.")
-    parser.add_argument("--force", action="store_true", help="Bypass worktree-fingerprint cache and re-verify.")
     args = parser.parse_args(sys.argv[1:] if argv is None else argv)
 
     if args.history:
@@ -475,19 +472,6 @@ def main(argv: list[str] | None = None) -> int:
         tier = "testmon"
 
     full_pytest = bool(args.all or args.full)
-    mode_key = json.dumps(
-        {
-            "tier": tier,
-            "skip_slow": bool(args.skip_slow),
-            "quick": bool(args.quick),
-            "commit": bool(args.commit),
-            "lab": bool(args.lab),
-            "seed_testmon": bool(args.seed_testmon),
-            "full_pytest": full_pytest,
-        },
-        sort_keys=True,
-    )
-
     preflight_error = _testmon_preflight(
         seed_testmon=bool(args.seed_testmon),
         full_pytest=full_pytest,
@@ -498,22 +482,9 @@ def main(argv: list[str] | None = None) -> int:
         sys.stderr.write(preflight_error)
         return 2
 
-    # Worktree-fingerprint cache: if nothing changed since last verify,
-    # replay the cached result instantly instead of re-running tests.
-    if not args.commit and not args.quick and not args.lab and not args.force:
-        fp = _worktree_fingerprint(mode_key=mode_key)
-        cached = _read_cached_result(fp)
-        if cached is not None:
-            ec: int = cached.get("exit_code", 0)
-            dur: object = cached.get("total_duration_s", 0)
-            if use_json:
-                _print_json(cached)
-            elif ec == 0:
-                sys.stderr.write(f"verify: HEAD already verified ({dur:.0f}s cached); nothing to do.\n")
-            else:
-                failed = [s["name"] for s in cached.get("steps", []) if s["exit"] != 0]
-                sys.stderr.write(f"verify: HEAD unchanged — cached failures: {', '.join(failed)}\n")
-            return ec
+    testmon_global = (
+        not (args.quick or args.commit or args.seed_testmon or full_pytest) and _testmon_requires_global_collection()
+    )
 
     head = _git_head()
     t0 = time.monotonic()
@@ -533,6 +504,7 @@ def main(argv: list[str] | None = None) -> int:
         skip_slow=bool(args.skip_slow),
         seed_testmon=bool(args.seed_testmon),
         full_pytest=full_pytest,
+        testmon_global=testmon_global,
     )
 
     step_results: list[dict[str, Any]] = []
@@ -577,17 +549,12 @@ def main(argv: list[str] | None = None) -> int:
         else:
             sys.stderr.write(f"\nverify: FAILED ({total_duration:.1f}s) — fix before pushing\n")
 
-    # Persist history, stamp, and worktree-fingerprint cache.
+    # Persist history and stamp.
     _save_history(history_entry)
     if exit_code == 0:
         _stamp_head()
-        if args.seed_testmon:
+        if args.seed_testmon or testmon_global:
             _write_testmon_seed_stamp(history_entry)
-    # Cache the result keyed by worktree fingerprint — next invocation
-    # at the same tree state replays this instantly.
-    if not args.commit and not args.quick and not args.lab:
-        fp = _worktree_fingerprint(mode_key=mode_key)
-        _write_cached_result(fp, history_entry)
 
     # Notify on long-running verify.
     if total_duration > 30:

--- a/devtools/verify_manifests.py
+++ b/devtools/verify_manifests.py
@@ -113,7 +113,7 @@ def check_suppressions(plans_dir: Path) -> list[str]:
 
 
 def check_assurance_domains(plans_dir: Path) -> list[str]:
-    """Validate assurance-domains.yaml references existing issues/claims."""
+    """Validate assurance-domains.yaml stays a documentation inventory."""
     errors: list[str] = []
     path = plans_dir / "assurance-domains.yaml"
     if not path.exists():
@@ -135,10 +135,6 @@ def check_assurance_domains(plans_dir: Path) -> list[str]:
             continue
         if "description" not in domain:
             errors.append(f"{path}: domain {name!r} missing description")
-        maturity = domain.get("maturity")
-        valid_maturity = {"seed", "nascent", "growing", "established", "complete"}
-        if maturity not in valid_maturity:
-            errors.append(f"{path}: domain {name!r} invalid maturity {maturity!r}")
 
     return errors
 

--- a/devtools/verify_slos.py
+++ b/devtools/verify_slos.py
@@ -4,10 +4,10 @@ Reads the SLO catalog from docs/plans/slo-catalog.yaml, runs the
 referenced benchmark tests with pytest-benchmark, then compares the
 measured p50 and p95 latencies against the declared targets.
 
-Exits 0 when all SLOs with benchmark results pass their targets.
-Exits 1 when any surface violates its declared SLO.
-Exits 0 (with warnings) when a surface has no benchmark coverage — these
-are deferred surfaces, not failures.
+Exits 0 when all required SLOs have benchmark results and pass their targets.
+Exits 1 when any required surface violates its declared SLO or has no
+benchmark result. Informational surfaces without benchmark results are reported
+without blocking.
 """
 
 from __future__ import annotations
@@ -23,6 +23,7 @@ from devtools import repo_root as _get_root
 
 ROOT = _get_root()
 SLO_CATALOG = ROOT / "docs" / "plans" / "slo-catalog.yaml"
+SLO_GATES = frozenset({"required", "informational"})
 
 
 # ---------------------------------------------------------------------------
@@ -84,6 +85,14 @@ def _collect_benchmark_tests(surfaces: dict[str, dict[str, object]]) -> set[str]
         if isinstance(test, str) and test.strip():
             tests.add(test.strip())
     return tests
+
+
+def _surface_gate(surface_name: str, config: dict[str, object]) -> tuple[str | None, str | None]:
+    """Return the surface gate, or a catalog error message when invalid."""
+    raw_gate = config.get("gate", "required")
+    if isinstance(raw_gate, str) and raw_gate in SLO_GATES:
+        return raw_gate, None
+    return None, f"{surface_name}: invalid gate {raw_gate!r}; expected one of {sorted(SLO_GATES)!r}"
 
 
 def _run_benchmarks(test_ids: set[str]) -> dict[str, dict[str, float]]:
@@ -188,11 +197,19 @@ def main(argv: list[str] | None = None) -> int:
     benchmark_stats = _run_benchmarks(test_ids) if not args.skip_benchmarks else {}
 
     # 4. Check each surface against its SLO
+    catalog_errors: list[str] = []
     violations: list[dict[str, object]] = []
+    missing_required: list[dict[str, object]] = []
     passed: list[dict[str, object]] = []
-    uncovered: list[dict[str, object]] = []
+    uncovered_informational: list[dict[str, object]] = []
 
     for surface_name, config in surfaces.items():
+        gate, gate_error = _surface_gate(surface_name, config)
+        if gate_error is not None:
+            catalog_errors.append(gate_error)
+            continue
+        assert gate is not None
+
         target_p50 = config.get("p50_ms")
         target_p95 = config.get("p95_ms")
         if not isinstance(target_p50, int) or not isinstance(target_p95, int):
@@ -204,13 +221,16 @@ def main(argv: list[str] | None = None) -> int:
 
         stats = benchmark_stats.get(benchmark_test)
         if stats is None:
-            uncovered.append(
-                {
-                    "surface": surface_name,
-                    "benchmark_test": benchmark_test,
-                    "reason": "no benchmark result for this test",
-                }
-            )
+            missing_result: dict[str, object] = {
+                "surface": surface_name,
+                "gate": gate,
+                "benchmark_test": benchmark_test,
+                "reason": "no benchmark result for this test",
+            }
+            if gate == "required":
+                missing_required.append(missing_result)
+            else:
+                uncovered_informational.append(missing_result)
             continue
 
         actual_p50_ms = stats["median"] * 1000  # pytest-benchmark reports in seconds
@@ -223,6 +243,7 @@ def main(argv: list[str] | None = None) -> int:
 
         result: dict[str, object] = {
             "surface": surface_name,
+            "gate": gate,
             "description": config.get("description", ""),
             "benchmark_test": benchmark_test,
             "target_p50_ms": target_p50,
@@ -241,19 +262,28 @@ def main(argv: list[str] | None = None) -> int:
             violations.append(result)
 
     # 5. Report
+    blocking = bool(catalog_errors or violations or missing_required)
     if args.json:
         json.dump(
             {
-                "blocking": len(violations) > 0,
+                "blocking": blocking,
+                "catalog_errors": catalog_errors,
                 "violations": violations,
+                "missing_required": missing_required,
                 "passed": passed,
-                "uncovered": uncovered,
+                "uncovered_informational": uncovered_informational,
             },
             sys.stdout,
             indent=2,
         )
         sys.stdout.write("\n")
     else:
+        if catalog_errors:
+            print(f"CATALOG ERROR ({len(catalog_errors)} entries):")
+            for error in catalog_errors:
+                print(f"  - {error}")
+            print()
+
         if passed:
             print(f"PASS ({len(passed)} surfaces):")
             for p in passed:
@@ -262,6 +292,12 @@ def main(argv: list[str] | None = None) -> int:
                     f"p50={p['actual_p50_ms']:.1f}ms (target ≤{p['target_p50_ms']}ms), "
                     f"p95={p['actual_p95_ms']:.1f}ms (target ≤{p['target_p95_ms']}ms)"
                 )
+            print()
+
+        if missing_required:
+            print(f"MISSING REQUIRED ({len(missing_required)} surfaces):")
+            for m in missing_required:
+                print(f"  {m['surface']}: {m['benchmark_test']} ({m['reason']})")
             print()
 
         if violations:
@@ -275,15 +311,15 @@ def main(argv: list[str] | None = None) -> int:
                 print(f"  {v['surface']}: {', '.join(parts)}")
             print()
 
-        if uncovered:
-            print(f"Uncovered ({len(uncovered)} surfaces):")
-            for u in uncovered:
+        if uncovered_informational:
+            print(f"Uncovered informational ({len(uncovered_informational)} surfaces):")
+            for u in uncovered_informational:
                 print(f"  {u['surface']}: {u['reason']}")
             print()
 
-        print(f"blocking={len(violations) > 0}")
+        print(f"blocking={blocking}")
 
-    return 1 if violations else 0
+    return 1 if blocking else 0
 
 
 if __name__ == "__main__":

--- a/devtools/verify_slos.py
+++ b/devtools/verify_slos.py
@@ -209,10 +209,14 @@ def main(argv: list[str] | None = None) -> int:
         target_p50 = config.get("p50_ms")
         target_p95 = config.get("p95_ms")
         if not isinstance(target_p50, int) or not isinstance(target_p95, int):
+            if gate == "required":
+                catalog_errors.append(f"{surface_name}: required surface must declare integer p50_ms and p95_ms")
             continue
 
         benchmark_test = config.get("benchmark_test")
         if not isinstance(benchmark_test, str):
+            if gate == "required":
+                catalog_errors.append(f"{surface_name}: required surface must declare benchmark_test (string)")
             continue
 
         stats = benchmark_stats.get(benchmark_test)

--- a/devtools/verify_slos.py
+++ b/devtools/verify_slos.py
@@ -20,6 +20,7 @@ import tempfile
 from pathlib import Path
 
 from devtools import repo_root as _get_root
+from devtools.benchmark_results import parse_pytest_benchmark_stats
 
 ROOT = _get_root()
 SLO_CATALOG = ROOT / "docs" / "plans" / "slo-catalog.yaml"
@@ -138,20 +139,15 @@ def _run_benchmarks(test_ids: set[str]) -> dict[str, dict[str, float]]:
 
         payload = json.loads(json_path.read_text())
 
-    benchmarks = payload.get("benchmarks", [])
     stats: dict[str, dict[str, float]] = {}
-    for entry in benchmarks:
-        fullname = entry.get("fullname") or entry.get("fullfunc") or entry.get("name", "")
-        entry_stats = entry.get("stats") or entry.get("Stats") or {}
-        if not fullname or not entry_stats:
-            continue
-        stats[str(fullname)] = {
-            "mean": float(entry_stats.get("mean", 0)),
-            "median": float(entry_stats.get("median", 0)),
-            "min": float(entry_stats.get("min", 0)),
-            "max": float(entry_stats.get("max", 0)),
-            "stddev": float(entry_stats.get("stddev", 0)) if "stddev" in entry_stats else 0.0,
-            "rounds": int(entry_stats.get("rounds", 0)),
+    for entry in parse_pytest_benchmark_stats(payload):
+        stats[entry.fullname] = {
+            "mean": entry.mean,
+            "median": entry.median,
+            "min": entry.minimum,
+            "max": entry.maximum,
+            "stddev": entry.stddev,
+            "rounds": entry.rounds,
         }
 
     return stats

--- a/devtools/verify_suppressions.py
+++ b/devtools/verify_suppressions.py
@@ -144,7 +144,7 @@ def discover_source_suppressions(
 def _pytest_suppression_lines(text: str) -> list[tuple[str, int]]:
     try:
         tree = ast.parse(text)
-    except SyntaxError:
+    except (SyntaxError, RecursionError, ValueError, MemoryError):
         return []
     results: list[tuple[str, int]] = []
     for node in ast.walk(tree):

--- a/devtools/verify_suppressions.py
+++ b/devtools/verify_suppressions.py
@@ -1,33 +1,69 @@
-"""Enforce the suppression registry expiry dates.
+"""Inspect and enforce suppression registry expiry dates.
 
 Every suppression in ``docs/plans/suppressions.yaml`` must have an expiry
 date. The lint fails when any suppression is past its expiry date, forcing
 review and either renewal or removal.
+
+The command also discovers source-level exception mechanisms so an empty
+registry cannot be mistaken for an absence of suppressions.
 """
 
 from __future__ import annotations
 
 import argparse
+import ast
+import io
 import json
+import re
 import sys
+import tokenize
+from collections import Counter
+from dataclasses import asdict, dataclass
+from fnmatch import fnmatch
 from pathlib import Path
 
 from devtools import repo_root as _get_root
-from polylogue.proof.suppressions import load_suppressions, validate_suppressions
+from polylogue.proof.suppressions import Suppression, load_suppressions, validate_suppressions
 
 ROOT = _get_root()
 REGISTRY = ROOT / "docs" / "plans" / "suppressions.yaml"
+SCAN_DIRS = ("polylogue", "tests", "devtools")
+_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("noqa", re.compile(r"#\s*noqa(?::|\b)")),
+    ("type_ignore", re.compile(r"#\s*type:\s*ignore(?:\[[^]]+\])?")),
+    ("no_cover", re.compile(r"pragma:\s*no cover|coverage:\s*ignore")),
+)
+
+
+@dataclass(frozen=True, slots=True)
+class DiscoveredSuppression:
+    kind: str
+    path: str
+    line: int
+    text: str
+    registered: bool
+
+    def to_payload(self) -> dict[str, object]:
+        return asdict(self)
 
 
 def main(argv: list[str] | None = None) -> int:
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument("--yaml", type=Path, default=REGISTRY)
     p.add_argument("--json", action="store_true")
+    p.add_argument("--scan-root", type=Path, default=ROOT)
+    p.add_argument(
+        "--enforce-discovered",
+        action="store_true",
+        help="Block on discovered source suppressions not covered by registry paths.",
+    )
     args = p.parse_args(argv)
 
     suppressions = load_suppressions(registry=args.yaml)
     errors = validate_suppressions(suppressions)
-    blocking = bool(errors)
+    discovered = discover_source_suppressions(args.scan_root, suppressions=suppressions)
+    unregistered = [item for item in discovered if not item.registered]
+    blocking = bool(errors) or (args.enforce_discovered and bool(unregistered))
 
     if args.json:
         json.dump(
@@ -35,6 +71,10 @@ def main(argv: list[str] | None = None) -> int:
                 "blocking": blocking,
                 "expired": errors,
                 "total": len(suppressions),
+                "discovered_total": len(discovered),
+                "discovered_by_kind": dict(Counter(item.kind for item in discovered)),
+                "unregistered_total": len(unregistered),
+                "unregistered": [item.to_payload() for item in unregistered],
             },
             sys.stdout,
             indent=2,
@@ -46,10 +86,138 @@ def main(argv: list[str] | None = None) -> int:
                 print(f"[BLOCK] {error}")
         else:
             print(f"verify-suppressions: all {len(suppressions)} suppressions current")
+        if discovered:
+            print(f"discovered source suppressions: {len(discovered)}")
+            for kind, count in sorted(Counter(item.kind for item in discovered).items()):
+                print(f"    {kind}: {count}")
+        if unregistered:
+            label = "[BLOCK]" if args.enforce_discovered else "[warn]"
+            print(f"{label} unregistered source suppressions: {len(unregistered)}")
+            for item in unregistered[:20]:
+                print(f"    {item.path}:{item.line}: {item.kind}: {item.text}")
+            if len(unregistered) > 20:
+                print(f"    ... {len(unregistered) - 20} more")
         print()
         print(f"blocking={blocking}")
 
     return 1 if blocking else 0
+
+
+def discover_source_suppressions(
+    root: Path = ROOT,
+    *,
+    suppressions: list[Suppression] | None = None,
+) -> list[DiscoveredSuppression]:
+    """Discover source-level suppression and exception forms."""
+    registry_paths = _registry_paths(suppressions or [])
+    results: list[DiscoveredSuppression] = []
+    for path in _iter_scan_files(root):
+        rel = path.relative_to(root).as_posix()
+        try:
+            text = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+        lines = text.splitlines()
+        results.extend(
+            DiscoveredSuppression(
+                kind=kind,
+                path=rel,
+                line=line,
+                text=_line_text(lines, line),
+                registered=_path_registered(rel, registry_paths),
+            )
+            for kind, line in _pytest_suppression_lines(text)
+        )
+        results.extend(
+            DiscoveredSuppression(
+                kind=kind,
+                path=rel,
+                line=line,
+                text=comment.strip(),
+                registered=_path_registered(rel, registry_paths),
+            )
+            for kind, line, comment in _comment_suppression_lines(text)
+        )
+    return results
+
+
+def _pytest_suppression_lines(text: str) -> list[tuple[str, int]]:
+    try:
+        tree = ast.parse(text)
+    except SyntaxError:
+        return []
+    results: list[tuple[str, int]] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            kind = _pytest_call_kind(node.func)
+            if kind is not None:
+                results.append((kind, node.lineno))
+    return results
+
+
+def _pytest_call_kind(func: ast.expr) -> str | None:
+    parts = _attribute_parts(func)
+    match parts:
+        case ["pytest", "skip"]:
+            return "pytest_skip"
+        case ["pytest", "xfail"]:
+            return "pytest_xfail"
+        case ["pytest", "mark", "xfail"]:
+            return "pytest_xfail"
+        case ["pytest", "mark", "skip" | "skipif"]:
+            return "pytest_skip_marker"
+        case _:
+            return None
+
+
+def _attribute_parts(expr: ast.expr) -> list[str]:
+    if isinstance(expr, ast.Name):
+        return [expr.id]
+    if isinstance(expr, ast.Attribute):
+        return [*_attribute_parts(expr.value), expr.attr]
+    return []
+
+
+def _comment_suppression_lines(text: str) -> list[tuple[str, int, str]]:
+    try:
+        tokens = tokenize.generate_tokens(io.StringIO(text).readline)
+        comments = [(token.start[0], token.string) for token in tokens if token.type == tokenize.COMMENT]
+    except tokenize.TokenError:
+        return []
+    results: list[tuple[str, int, str]] = []
+    for line, comment in comments:
+        for kind, pattern in _PATTERNS:
+            if pattern.search(comment):
+                results.append((kind, line, comment))
+    return results
+
+
+def _line_text(lines: list[str], line: int) -> str:
+    index = line - 1
+    if 0 <= index < len(lines):
+        return lines[index].strip()
+    return ""
+
+
+def _iter_scan_files(root: Path) -> list[Path]:
+    files: list[Path] = []
+    for dirname in SCAN_DIRS:
+        base = root / dirname
+        if not base.exists():
+            continue
+        files.extend(path for path in base.rglob("*.py") if "__pycache__" not in path.parts)
+    return sorted(files)
+
+
+def _registry_paths(suppressions: list[Suppression]) -> tuple[str, ...]:
+    paths: list[str] = []
+    for suppression in suppressions:
+        paths.extend(suppression.paths)
+    return tuple(paths)
+
+
+def _path_registered(path: str, registry_paths: tuple[str, ...]) -> bool:
+    return any(path == registered or fnmatch(path, registered) for registered in registry_paths)
 
 
 if __name__ == "__main__":

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,8 +32,8 @@ Use this map when you need the complete repository documentation surface. The to
 | Document | Description |
 |----------|-------------|
 | [Developer Tools](devtools.md) | `devtools` guide for generated surfaces, validation, and repo hygiene. |
-| [Verification Lab](verification-lab.md) | Accepted command-surface decision for proof catalog, routing, and evidence operators. |
-| [Verification Catalog](verification-catalog.md) | Generated proof-obligation subjects, claims, runners, and catalog self-checks. |
+| [Verification Lab](verification-lab.md) | Accepted command-surface decision for verification catalog, routing, and evidence operators. |
+| [Verification Catalog](verification-catalog.md) | Generated verification subjects, claims, runners, and catalog self-checks. |
 | [Test Quality Workflows](test-quality-workflows.md) | Generated validation lanes, mutation campaigns, and benchmark campaigns. |
 
 ## Contributor Workflow

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -211,7 +211,7 @@ attachments, exports):
 - `daemon/` — daemon convergence, HTTP API, and web reader
 
 ### Verification (repo health)
-- `proof/` — proof obligations, subject discovery, claim catalog, witnesses
+- `proof/` — verification catalog internals, subject discovery, claim catalog, witnesses
 - `devtools/` — operator tooling, lints, campaigns, rendering
 - `showcase/` — QA exercises, deterministic acceptance tests
 - `tests/` — pytest suite, property tests, integration tests

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -40,13 +40,13 @@ devtools status --json
 
 ## Verification Lab Surface
 
-The proof-lab operator surface intentionally lives in `devtools` for now. These commands operate on
-repo proof obligations and evidence records, not end-user archive workflows.
+The verification-lab operator surface intentionally lives in `devtools` for now. These commands operate on
+repo verification checks and evidence records, not end-user archive workflows.
 
 | Command | Role |
 | --- | --- |
-| `devtools render-verification-catalog` | Refresh or verify the proof-obligation catalog that anchors the verification-lab surface after changing proof subjects, claims, runners, or catalog rendering. |
-| `devtools affected-obligations` | Find the proof obligations and inner-loop checks affected by local changes before escalating to full PR gates. |
+| `devtools render-verification-catalog` | Refresh or verify the catalog that anchors changed-path verification reports after changing subjects, claims, runners, or catalog rendering. |
+| `devtools affected-obligations` | Find the checks and inner-loop commands affected by local changes before escalating to full PR gates. |
 | `devtools semantic-axis-evidence` | Produce comparative performance evidence that describes growth shape over semantic axes instead of machine-specific absolute budgets. |
 | `devtools lab-corpus` | Seed synthetic corpus files or complete demo workspaces for lab exercises. |
 | `devtools lab-scenario` | Run showcase exercise smoke scenarios and committed baseline checks outside the archive CLI. |
@@ -91,19 +91,19 @@ These are the commands worth remembering during normal repo work:
 | `devtools render-quality-reference` | Render docs/test-quality-workflows.md from live validation, mutation, and benchmark registries. |
 | `devtools render-readme-media` | Generate README media assets (architecture diagrams, flowcharts) under docs/media/. |
 | `devtools render-topology-status` | Render docs/topology-status.md from the topology projection and realized tree. |
-| `devtools render-verification-catalog` | Render the verification-lab proof catalog from obligation registries. |
+| `devtools render-verification-catalog` | Render the verification-lab catalog from check registries. |
 
 ### Verification
 
 | Command | Description |
 | --- | --- |
-| `devtools affected-obligations` | Route changed paths or refs to affected verification-lab proof obligations and focused checks. |
+| `devtools affected-obligations` | Route changed paths or refs to affected verification checks and focused commands. |
 | `devtools artifact-graph` | Render the runtime artifact, operation, and scenario-coverage map. |
 | `devtools coverage-gate` | Run pytest with the repository coverage floor from pyproject.toml. |
 | `devtools daemon-workload-probe` | Inspect daemon ingest workload, convergence debt, and hot query plans. |
 | `devtools lab-corpus` | Generate verification-lab synthetic corpus fixtures and demo archives. |
 | `devtools lab-scenario` | Run verification-lab showcase scenario sets and baseline checks. |
-| `devtools obligation-diff` | Diff proof obligations between two git refs to surface affected assurance domains. |
+| `devtools obligation-diff` | Diff catalog-backed verification checks between two git refs. |
 | `devtools pipeline-probe` | Run typed pipeline probes against synthetic, staged, or archive-subset inputs. |
 | `devtools proof-pack` | Domain-grouped verification impact report for changed paths. |
 | `devtools query-memory-budget` | Measure query-memory envelopes on generated fixtures. |

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -105,7 +105,7 @@ These are the commands worth remembering during normal repo work:
 | `devtools lab-scenario` | Run verification-lab showcase scenario sets and baseline checks. |
 | `devtools obligation-diff` | Diff proof obligations between two git refs to surface affected assurance domains. |
 | `devtools pipeline-probe` | Run typed pipeline probes against synthetic, staged, or archive-subset inputs. |
-| `devtools proof-pack` | Domain-grouped affected coverage report for vibecode confidence. |
+| `devtools proof-pack` | Domain-grouped verification impact report for changed paths. |
 | `devtools query-memory-budget` | Measure query-memory envelopes on generated fixtures. |
 | `devtools regression-capture` | Capture pipeline-probe summaries as durable local regression cases. |
 | `devtools run-validation-lanes` | Run named validation lanes. |

--- a/docs/execution-plan.md
+++ b/docs/execution-plan.md
@@ -11,7 +11,7 @@ This plan answers three operational questions:
 
 1. What should start next without creating avoidable rework?
 2. Which issue owns the durable acceptance criteria?
-3. What proof has to exist before a wave can claim completion?
+3. What executable evidence has to exist before a wave can claim completion?
 
 Issue bodies remain authoritative for scope. This document keeps the backlog
 coherent across issues by naming dependency order, handoff artifacts, and
@@ -48,13 +48,13 @@ status, test choices, resource constraints, and handoff notes.
 
 | Lane | Live owners | Next artifact | Why now |
 |------|-------------|---------------|---------|
-| Runtime convergence and host proof | #845, #996, #999, #829 | Packaged daemon rollout plus production-corpus convergence report | The daemon must converge over the real archive; operational proof is the blocking confidence artifact for deployment. |
+| Runtime convergence and host evidence | #845, #996, #999, #829 | Packaged daemon rollout plus production-corpus convergence report | The daemon must converge over the real archive; bounded status/health evidence is the blocking deployment artifact. |
 | Source and semantic vocabulary | #1022, #839, #864, #1041, #1027 | Source-family contract, typed context/protocol fields, and provider/schema distribution evidence | MK3 reader contracts need typed source/provenance facts before UI can stop scraping provider metadata. |
 | Shared read contracts | #859, #873, #860, #848 | TargetRef/message-envelope/query/facet/status contracts shared by CLI, MCP, API, and daemon HTTP | This is the smallest useful MK3 start because later UI work consumes these envelopes. |
 | Reader evidence and product shell | #848, #865, #956, #993 | Single-conversation reader slice with executable DOM/browser evidence | MK3 must become a verified runtime reader, not only design screenshots. |
 | Topology and durable user state | #866, #867, #993 | Canonical topology read model and TargetRef-based marks/annotations/saved views | Multi-chat workspace, compare, recall packs, and topology panels need these substrates. |
 | Insight and cost rigor | #1019, #994, #995 | Readiness/confidence matrix for insight, cost, similarity, and derived panels | Advanced panels must show real availability, stale, inferred, and partial states. |
-| Verification and throughput | #1026, #997, #998, #594, #590, #1012 | Faster full baseline plus executable proof routing and inherited-failure cleanup | Broad changes are too expensive and too easy to misclaim without a faster, more precise gate. |
+| Verification and throughput | #1026, #997, #998, #594, #590, #1012 | Affected-test default, pytest evidence artifacts, benchmark/coverage reports, and inherited-failure cleanup | Broad changes are too expensive and too easy to misclaim without a faster, more precise gate. |
 | Distribution and user-facing polish | #869, #953, #952, #958 | Turnkey install/service/docs/CLI package path | Package and docs work should follow runtime/read-surface contracts so it does not document unstable behavior. |
 
 ## Dependency Gates
@@ -69,15 +69,15 @@ is ready to merge.
 | G3: executable reader evidence | Closing #848/#993 rows that claim runtime UI behavior | #865 | Synthetic-data DOM/browser lane with nonblank, private-safe, stateful assertions. |
 | G4: topology read model | Stack, compare, lineage rail, topology explorer | #866 | Ancestor/descendant/sibling/root APIs with unresolved/late-repair/cycle evidence. |
 | G5: TargetRef user state | Marks, annotations, saved views, recall packs, durable workspaces | #867 | Idempotent CRUD and content-hash exclusion for conversation/message targets first. |
-| G6: runtime deployment proof | Distribution docs and system service guidance | #845, #996, #999, #829, #869, #953 | Packaged daemon installed through Sinnix, real archive convergence report, health/status evidence. |
-| G7: faster verification | Large MK3/daemon waves | #1026, #997, #998, #594, #590, #1012 | Focused affected gates, proof routing, and inherited failure cleanup so broad verification is credible. |
+| G6: runtime deployment evidence | Distribution docs and system service guidance | #845, #996, #999, #829, #869, #953 | Packaged daemon installed through Sinnix, real archive convergence report, health/status evidence. |
+| G7: faster verification | Large MK3/daemon waves | #1026, #997, #998, #594, #590, #1012 | Affected-test default, contract evidence artifacts, and inherited failure cleanup so broad verification is credible. |
 
 ## Near-Term PR Candidates
 
 These are deliberately shaped as coherent PR-sized slices. They can run in
 parallel when their write surfaces do not overlap.
 
-| Candidate | Owner issues | Primary files | Acceptance proof |
+| Candidate | Owner issues | Primary files | Acceptance evidence |
 |-----------|--------------|---------------|------------------|
 | Define `TargetRef` and message-anchor contract | #859, #848, #867 | `polylogue/surfaces/`, `polylogue/daemon/http.py`, `polylogue/archive/query/`, daemon tests | Conversation/message targets serialize deterministically; reader endpoints expose anchors; unsupported targets return explicit disabled reasons. |
 | Replace reader/provider metadata scraping with typed source fields | #1022, #839, #864 | source parsers, archive models, payloads, schema docs | Header/search chips read typed fields; provider-meta fallback is either removed or marked transitional with tests. |
@@ -86,7 +86,7 @@ parallel when their write surfaces do not overlap.
 | Materialize topology edge substrate | #866 | storage DDL, ingest enrichment, archive operations, parser fixtures | Child-before-parent unresolved edge, late repair, cycle quarantine, and sibling/ancestor read tests pass. |
 | Add TargetRef-based marks and annotations | #867, #862 | user-state DDL/repository/API, daemon endpoints, reader tests | Idempotent CRUD works for conversation/message targets; content hash unchanged; reimport preservation tested where identity evidence exists. |
 | Prove packaged daemon convergence | #845, #996, #999, #829, #869 | Sinnix input update, package/service config, daemon docs | Installed service is latest merged Polylogue, real archive converges, health/status and residual workload are recorded. |
-| Reduce verification wall time | #1026, #997, #998, #594/#590 | `devtools/verify.py`, test config, proof routing | `devtools verify --affected --skip-slow` handles small diffs; full non-slow baseline is measured and outliers have owners. |
+| Reduce verification wall time | #1026, #997, #998, #594/#590 | `devtools/verify.py`, test config, pytest artifacts | default `devtools verify` runs affected tests; full non-slow baseline is measured explicitly and outliers have owners. |
 
 ## Parallel Execution Rules
 
@@ -114,7 +114,7 @@ Good parallel lanes:
 - visual evidence worker: synthetic reader DOM/browser lane;
 - topology worker: edge substrate and topology read model;
 - user-state worker: marks, annotations, saved views, recall packs;
-- verification worker: affected-test workflow and proof routing;
+- verification worker: affected-test workflow, pytest evidence artifacts, and report cleanup;
 - packaging/deployment worker: Sinnix input, package/service rollout evidence.
 
 Serialize work when lanes touch the same shared file family:
@@ -187,7 +187,7 @@ Scope:
 - Surface message anchors, content-block summaries, paste/attachment counts,
   provenance status, search diagnostics, and source-centered vocabulary.
 
-Exit proof:
+Exit evidence:
 
 - daemon HTTP contract tests for list/search/detail/messages/facets/status;
 - CLI/MCP/API parity checks where the same query spec is used;
@@ -217,7 +217,7 @@ Scope:
 - Keep derived/provenance/user-state panels statusful when substrate is missing
   instead of inventing frontend-only data.
 
-Exit proof:
+Exit evidence:
 
 - #865 browser/DOM lane covers list/search, conversation detail, degraded
   states, nonblank rendering, and private-path safety;
@@ -248,7 +248,7 @@ Scope:
 - Drill into raw artifacts, source runs, hook events, parser evidence, and
   blob/attachment links through sanitized provenance APIs.
 
-Exit proof:
+Exit evidence:
 
 - fixtures for explicit paste spans, heuristic paste fallback, missing
   attachment, quarantined/unsupported attachment, and provenance redaction;
@@ -280,7 +280,7 @@ Scope:
 - Start workspace persistence in URLs and graduate to durable user-state
   storage when #867 is ready.
 
-Exit proof:
+Exit evidence:
 
 - storage tests for unresolved parent, late repair, ambiguous parent, cycle
   quarantine, subagent/sidechain cluster, and sibling/ancestor reads;
@@ -309,7 +309,7 @@ Scope:
 - Surface insights, cost, similarity, and provenance panels with readiness,
   freshness, confidence, missing-data, and disabled/unconfigured states.
 
-Exit proof:
+Exit evidence:
 
 - idempotent CRUD and content-hash exclusion tests for user metadata;
 - saved-view query roundtrip tests;
@@ -339,7 +339,7 @@ Scope:
 - Keep packaging/systemd responsible for service placement, restart, and
   operator control; application code reports health and progress.
 
-Exit proof:
+Exit evidence:
 
 - event contract tests for append/update/snapshot/stale/disconnected states;
 - reader/list DOM smoke for appended messages, stale state, disconnected
@@ -358,7 +358,7 @@ Owner issues: #865, #952, #953, #958, #997, #998, #594, #590.
 Start condition:
 
 - Enough runtime reader/workbench behavior exists that screenshots, packaging,
-  and proof reports document product reality rather than intended designs.
+  and verification reports document product reality rather than intended designs.
 
 Scope:
 
@@ -369,10 +369,10 @@ Scope:
 - Polish CLI output/completions/color as the companion control plane.
 - Package the daemon/web reader/service setup for Nix/PyPI/container/homebrew
   surfaces without source-checkout assumptions.
-- Route proof/verification reports to executable checks instead of
-  metadata-only artifacts.
+- Route verification reports to pytest, coverage, benchmark, CI, and runtime
+  evidence artifacts instead of metadata-only rows.
 
-Exit proof:
+Exit evidence:
 
 - `devtools verify --quick`;
 - full `devtools verify` before PR readiness;

--- a/docs/execution-plan.md
+++ b/docs/execution-plan.md
@@ -156,9 +156,10 @@ Avoid wasting RAM and wallclock:
   gates.
 - For packaging/deployment, run code checks first, then Nix/service checks, so
   failures are attributable.
-- When `devtools verify --affected --skip-slow` is available, use it for small
-  changes and reserve full non-slow pytest for merge readiness or high-risk
-  shared behavior.
+- Keep pytest-testmon seeded with `devtools verify --seed-testmon --skip-slow`.
+  The normal `devtools verify` path runs affected tests; use `devtools verify
+  --all` only as an explicit full non-integration diagnostic or release/CI
+  parity check.
 
 ## MK3 Integration Waves
 

--- a/docs/plans/assurance-domains.yaml
+++ b/docs/plans/assurance-domains.yaml
@@ -1,17 +1,17 @@
 # Assurance-domains coverage matrix.
 #
-# Declares all 25 assurance domains and their current maturity as seed
-# manifests. Each domain documents its verification maturity, whether an
-# oracle is present (`oracle_present`), and the primary evidence type
-# (`oracle`). Maturity levels: seed, nascent, growing, established,
-# mature.
+# Transitional inventory only. This file currently carries proof-era fields
+# such as `oracle_present` and `oracle`; those fields are not evidence and must
+# be replaced by derived pytest/coverage/benchmark/CI state under #1064/#590.
+# Until then, do not treat a maturity or oracle row as verification closure.
 #
 # Updated 2026-04-29 from realized codebase state.
 
 description: >
-  Complete coverage matrix for the 25 polylogue assurance domains.
-  Seed maturity reflects the absence of automated verification gates;
-  nascent maturity indicates partial coverage with gaps.
+  Transitional coverage matrix for the polylogue assurance domains.
+  Rows document known areas and rough historical state; verification
+  closure comes from executable tests, coverage reports, benchmark
+  artifacts, CI checks, and concrete owner issues, not from this file.
 
 domains:
   operational_resilience:
@@ -163,9 +163,9 @@ domains:
     oracle_present: false
     oracle: null
     notes: >
-      Proof catalog exists (polylogue/proof/) with subjects, claims,
-      runners, witnesses, traces. No completeness oracle for what
-      subjects are unclaimed.
+      Transitional proof catalog exists (polylogue/proof/) with subjects,
+      claims, runners, witnesses, traces. #594/#1065 own replacing this
+      with standard artifact reports where the ambition is still useful.
 
   spec_accuracy:
     description: Specifications match observed behavior
@@ -174,8 +174,8 @@ domains:
     oracle: null
     notes: >
       Scenario specs exist (scenarios/) for CLI, insight,
-      operational, and corpus surfaces. No oracle
-      verifying spec-to-behavior correspondence.
+      operational, and corpus surfaces. #997/#1063 own executable
+      pytest/scenario checks for spec-to-behavior correspondence.
 
   migration_safety:
     description: Schema rebuild and transition safety
@@ -217,7 +217,7 @@ domains:
     oracle: drift_check
     notes: >
       query-memory-budget devtools command. Semantic-axis evidence
-      generation. No benchmark baselines committed. Blob store
+      generation. #1063 owns pytest-benchmark artifacts and baselines. Blob store
       archived 2M messages in 53 min.
 
   dependency_closure:
@@ -238,8 +238,8 @@ domains:
     notes: >
       Scenario surface families: CLI, insight, operational, corpus.
       ScenarioSpec base class with assertions, projections,
-      metadata. No systematic coverage audit of which subjects
-      have scenarios.
+      metadata. #1063 owns comparing scenario rows to executed pytest or
+      lab-scenario artifacts.
 
   mutation_coverage:
     description: Mutation testing scope and kill rate
@@ -258,8 +258,8 @@ domains:
     oracle: drift_check
     notes: >
       benchmark-campaign devtools commands exist. pytest-benchmark
-      suite in tests/benchmarks/. No committed baselines or
-      regression gates.
+      suite in tests/benchmarks/. #1063 owns committed/generated baselines
+      and regression gates.
 
   architecture_discipline:
     description: Topology, layering, file-budget, and structural manifest enforcement
@@ -269,7 +269,8 @@ domains:
     notes: >
       verify-topology, verify-layering, verify-file-budgets,
       verify-manifests, schema-roundtrip, and witness lifecycle gates
-      are routed through proof obligations and devtools verify --quick.
+      should report directly as static checks or pytest artifacts rather
+      than routing through proof obligations.
 
   unclassified:
     description: Uncategorized or cross-cutting concerns

--- a/docs/plans/assurance-domains.yaml
+++ b/docs/plans/assurance-domains.yaml
@@ -1,51 +1,37 @@
 # Assurance-domains coverage matrix.
 #
-# Transitional inventory only. This file currently carries proof-era fields
-# such as `oracle_present` and `oracle`; those fields are not evidence and must
-# be replaced by derived pytest/coverage/benchmark/CI state under #1064/#590.
-# Until then, do not treat a maturity or oracle row as verification closure.
+# Transitional inventory only. Verification closure comes from executable
+# artifacts, not editable maturity/oracle rows.
 #
 # Updated 2026-04-29 from realized codebase state.
 
 description: >
   Transitional coverage matrix for the polylogue assurance domains.
-  Rows document known areas and rough historical state; verification
+  Rows document known areas and historical notes; verification
   closure comes from executable tests, coverage reports, benchmark
   artifacts, CI checks, and concrete owner issues, not from this file.
 
 domains:
   operational_resilience:
     description: Runtime stability, crash recovery, repair
-    maturity: seed
-    oracle_present: false
-    oracle: null
     notes: >
       test_corruption_recovery.py covers SQLite corruption (marked slow).
       No automated crash-recovery or restart-fuzz gates.
 
   surface_parity:
     description: CLI/MCP/facade sync/async equivalence
-    maturity: nascent
-    oracle_present: true
-    oracle: construction_sanity
     notes: >
       scenario-surface families exercise CLI and MCP surfaces.
       No systematic sync/async equivalence oracle.
 
   docs_media:
     description: README, screenshots, VHS tapes, documentation freshness
-    maturity: seed
-    oracle_present: false
-    oracle: null
     notes: >
       render-docs-surface is generated; cli-reference is generated.
       No screenshots committed. One VHS tape at .local/readme-demo/example.tape.
 
   security_privacy:
     description: XSS, path traversal, PII, SSRF, command injection
-    maturity: nascent
-    oracle_present: true
-    oracle: proof
     notes: >
       Dedicated security test module (tests/unit/security/).
       Covers path sanitization, token-store perms, exec command
@@ -55,9 +41,6 @@ domains:
 
   distribution:
     description: Wheel/sdist/Nix install parity
-    maturity: seed
-    oracle_present: false
-    oracle: null
     notes: >
       pyproject.toml defines the Python package. flake.nix defines the
       Nix derivation. No automated install-parity verification between
@@ -65,9 +48,6 @@ domains:
 
   test_quality:
     description: Direct coverage, flakiness, fuzz, mock depth
-    maturity: growing
-    oracle_present: true
-    oracle: proof
     notes: >
       Coverage floor at 90% (fail_under). 3963 unit tests pass.
       Hypothesis property tests for parsers, null guards, domain
@@ -76,9 +56,6 @@ domains:
 
   schema_correctness:
     description: Provider schema inference, observation, validation
-    maturity: growing
-    oracle_present: true
-    oracle: proof
     notes: >
       Schema audit (polylogue/schemas/audit/), validation pipeline
       (validation.py, validation_flow.py), verification.py keyset
@@ -87,9 +64,6 @@ domains:
 
   parser_correctness:
     description: Provider parser crashlessness and fidelity
-    maturity: growing
-    oracle_present: true
-    oracle: proof
     notes: >
       Hypothesis property tests ensure parsers never crash on
       schema-conformant input (test_parser_crashlessness.py). Null
@@ -97,9 +71,6 @@ domains:
 
   pipeline_correctness:
     description: Stage independence, idempotency, run integrity
-    maturity: growing
-    oracle_present: true
-    oracle: proof
     notes: >
       test_stage_independence.py covers stage isolation and
       idempotency. Pipeline probes via devtools pipeline-probe.
@@ -107,9 +78,6 @@ domains:
 
   storage_correctness:
     description: CRUD, FTS5, hybrid search, blob store
-    maturity: established
-    oracle_present: true
-    oracle: proof
     notes: >
       test_crud.py is a protected core contract test. test_fts5.py
       covers FTS5 escaping and ranking. test_hybrid_laws.py covers
@@ -118,9 +86,6 @@ domains:
 
   search_correctness:
     description: FTS5, hybrid (RRF), vector search integration
-    maturity: growing
-    oracle_present: true
-    oracle: proof
     notes: >
       Hybrid search fixes documented (limit=0 edge case, RRF
       dedup, providers=[] semantics). FTS5 unicode61 tokenizer.
@@ -128,9 +93,6 @@ domains:
 
   mcp_surface:
     description: MCP tool contracts, server, and tool bindings
-    maturity: growing
-    oracle_present: true
-    oracle: proof
     notes: >
       MCP server tools (server_tools.py, server_maintenance_tools.py,
       server_insight_tools.py, server_mutation_tools.py, server_prompts.py,
@@ -139,9 +101,6 @@ domains:
 
   cli_surface:
     description: CLI commands, query, output, error handling
-    maturity: established
-    oracle_present: true
-    oracle: proof
     notes: >
       14 CLI commands. Query-first dispatch. Terminal snapshot tests
       (syrupy). CLI error-boundary tests (test_cli_error_boundaries.py).
@@ -149,9 +108,6 @@ domains:
 
   api_surface:
     description: Async library API and sync bridge
-    maturity: growing
-    oracle_present: true
-    oracle: proof
     notes: >
       Async API (polylogue/api/) with sync bridge
       (polylogue/api/sync/). API surface covers archive, ingest,
@@ -159,9 +115,6 @@ domains:
 
   spec_completeness:
     description: Verification-lab specification coverage completeness
-    maturity: seed
-    oracle_present: false
-    oracle: null
     notes: >
       Transitional proof catalog exists (polylogue/proof/) with subjects,
       claims, runners, witnesses, traces. #594/#1065 own replacing this
@@ -169,9 +122,6 @@ domains:
 
   spec_accuracy:
     description: Specifications match observed behavior
-    maturity: seed
-    oracle_present: false
-    oracle: null
     notes: >
       Scenario specs exist (scenarios/) for CLI, insight,
       operational, and corpus surfaces. #997/#1063 own executable
@@ -179,9 +129,6 @@ domains:
 
   migration_safety:
     description: Schema rebuild and transition safety
-    maturity: nascent
-    oracle_present: false
-    oracle: null
     notes: >
       Schema is fresh-first rather than migration-chain driven. Version
       mismatch blocks with a reset/re-import diagnostic unless an explicit,
@@ -191,9 +138,6 @@ domains:
 
   provider_coverage:
     description: Known provider support breadth and depth
-    maturity: growing
-    oracle_present: true
-    oracle: proof
     notes: >
       5 known providers (ChatGPT, Claude AI, Claude Code, Codex,
       Gemini) + UNKNOWN. Provider detection by shape, not filename.
@@ -201,9 +145,6 @@ domains:
 
   archive_integrity:
     description: Archive consistency, repair, idempotency
-    maturity: growing
-    oracle_present: true
-    oracle: proof
     notes: >
       Content-hash idempotency (SHA-256 over NFC payload). Repair
       module (storage/repair.py, 1080 LOC). conversation_stats
@@ -212,9 +153,6 @@ domains:
 
   performance:
     description: Query memory budgets, pipeline throughput
-    maturity: nascent
-    oracle_present: true
-    oracle: drift_check
     notes: >
       query-memory-budget devtools command. Semantic-axis evidence
       generation. #1063 owns pytest-benchmark artifacts and baselines. Blob store
@@ -222,9 +160,6 @@ domains:
 
   dependency_closure:
     description: Dependency correctness and completeness
-    maturity: seed
-    oracle_present: false
-    oracle: null
     notes: >
       pyproject.toml dependencies, flake.nix build inputs.
       No automated dependency-closure verification beyond Nix
@@ -232,9 +167,6 @@ domains:
 
   scenario_coverage:
     description: Verification scenario breadth across subjects
-    maturity: nascent
-    oracle_present: true
-    oracle: construction_sanity
     notes: >
       Scenario surface families: CLI, insight, operational, corpus.
       ScenarioSpec base class with assertions, projections,
@@ -243,9 +175,6 @@ domains:
 
   mutation_coverage:
     description: Mutation testing scope and kill rate
-    maturity: growing
-    oracle_present: true
-    oracle: proof
     notes: >
       8 modules under mutation (models, filters, roles, timestamps,
       hashing, json, fts5, hybrid). 955 mutants, ~71% kill rate.
@@ -253,9 +182,6 @@ domains:
 
   benchmark_coverage:
     description: Performance benchmark breadth and baselines
-    maturity: seed
-    oracle_present: true
-    oracle: drift_check
     notes: >
       benchmark-campaign devtools commands exist. pytest-benchmark
       suite in tests/benchmarks/. #1063 owns committed/generated baselines
@@ -263,9 +189,6 @@ domains:
 
   architecture_discipline:
     description: Topology, layering, file-budget, and structural manifest enforcement
-    maturity: growing
-    oracle_present: true
-    oracle: drift_check
     notes: >
       verify-topology, verify-layering, verify-file-budgets,
       verify-manifests, schema-roundtrip, and witness lifecycle gates
@@ -274,7 +197,4 @@ domains:
 
   unclassified:
     description: Uncategorized or cross-cutting concerns
-    maturity: seed
-    oracle_present: false
-    oracle: null
     notes: Placeholder domain for concerns not yet assigned.

--- a/docs/plans/evidence-freshness.yaml
+++ b/docs/plans/evidence-freshness.yaml
@@ -1,10 +1,11 @@
 # Evidence-freshness manifest.
 #
-# Each claim declares its expected evidence refresh cadence.
-# Freshness applies to oracles: proof, smoke, manual_review.
-# Construction_sanity checks are excluded (they validate structure not behavior).
+# Transitional proof-era freshness manifest. Freshness should be derived from
+# pytest/JUnit/json-report, coverage, benchmark, CI, and runtime evidence
+# artifact timestamps/git SHAs under #594/#1065, not from hand-maintained claim
+# rows in this file.
 
-description: Evidence freshness SLA — how often each claim's evidence must be refreshed.
+description: Transitional freshness inventory pending artifact-derived freshness.
 
 freshness_policies:
   per_push:

--- a/docs/plans/mk3-execution-log.md
+++ b/docs/plans/mk3-execution-log.md
@@ -171,6 +171,32 @@ Resource rules:
 
 ## Execution Entries
 
+### 2026-05-15 - Health aggregation evidence
+
+Target:
+
+- #999 daemon health tier contract and aggregation evidence.
+
+Outcome:
+
+- Added a deterministic health aggregation contract test that patches the fast,
+  medium, and expensive tier runners, requests fast+medium, and asserts the
+  expensive tier is excluded while worst-severity aggregation and tier summary
+  counts are correct.
+- The test records `daemon.health.aggregate` evidence with requested tiers,
+  overall status, alert count, tier summary, severities, and
+  `expensive_tier_excluded`.
+
+Artifact example:
+
+- `.cache/verification/evidence/daemon.health.aggregate-*.json`
+
+Verification:
+
+- `pytest -q tests/unit/daemon/test_health_contracts.py`
+- `ruff check tests/unit/daemon/test_health_contracts.py`
+- `mypy --strict tests/unit/daemon/test_health_contracts.py`
+
 ### 2026-05-15 - Notification dispatch evidence
 
 Target:

--- a/docs/plans/mk3-execution-log.md
+++ b/docs/plans/mk3-execution-log.md
@@ -171,6 +171,34 @@ Resource rules:
 
 ## Execution Entries
 
+### 2026-05-15 - Notification dispatch evidence
+
+Target:
+
+- #999 notification dispatch verifiability without adding a speculative
+  non-log production backend.
+
+Outcome:
+
+- Added tests for the actual notification dispatch contract: alert batches are
+  delivered to the selected backend with config, unknown configured backend
+  names fail loudly, and backend exceptions propagate to the daemon periodic
+  health loop's existing catch boundary.
+- The dispatch route records `daemon.notifications.dispatch` evidence with
+  alert count, severities, backend name, call count, and config-forwarding fact.
+- Rate-limit/dedup and any non-log transport remain open product work; this
+  slice pins the current dispatch boundary first.
+
+Artifact example:
+
+- `.cache/verification/evidence/daemon.notifications.dispatch-*.json`
+
+Verification:
+
+- `pytest -q tests/unit/daemon/test_notifications.py`
+- `ruff check tests/unit/daemon/test_notifications.py`
+- `mypy --strict tests/unit/daemon/test_notifications.py`
+
 ### 2026-05-15 - Backup restore/read evidence
 
 Target:

--- a/docs/plans/mk3-execution-log.md
+++ b/docs/plans/mk3-execution-log.md
@@ -18,7 +18,7 @@ Updated: 2026-05-15
 | Paste/attachment/provenance | #839, #864, #848, #993 | Blocked on message envelope/provenance vocabulary | Implement paste-span projection MVP after contract spine | focused storage/payload tests, daemon API tests, visual state tests |
 | Topology/workspace | #866, #993, #848, #865 | Substrate can start once source identity is stable | Materialize topology edges before graph UI | topology storage tests, parser fixtures, visual graph states |
 | User state/advanced panels | #867, #993, #1019, #995 | Active MCP parity slice | Expose marks and saved views through write-role MCP tools; keep annotations/message targets and CLI parity open | MCP mutation tests, saved-view roundtrip tests |
-| Verification throughput | #1026, #997, #998, #594, #590, #1012 | Ready to start independently | Add affected-test workflow and reduce outlier runtime | `devtools verify --affected --skip-slow`, durations capture, focused regression tests |
+| Verification throughput | #1026, #997, #998, #594, #590, #1012 | Active testmon default slice | Keep pytest-testmon seeded, reduce outlier runtime, and remove remaining full-suite reflexes | `devtools verify`, `devtools verify --seed-testmon --skip-slow`, focused regression tests |
 
 ## Active Slice Notes
 
@@ -151,16 +151,17 @@ Default inner loop:
 1. Run the narrow test for the touched subsystem.
 2. Run static/generated checks once the slice is coherent.
 3. Run `devtools verify --quick` before push.
-4. Run full `devtools verify` before PR readiness when the PR changes runtime
-   semantics, unless the PR explicitly records why a focused gate is sufficient.
+4. Run `devtools verify` before PR readiness; it uses pytest-testmon affected
+   selection after a successful seed.
 
 Resource rules:
 
 - Do not run full pytest repeatedly while the host is under IO pressure or low
   memory. Use focused tests and `devtools verify --quick` until the branch is
   near merge.
-- Prefer `devtools verify --affected --skip-slow` for small changes once the
-  affected-test workflow is implemented.
+- Run `devtools verify --seed-testmon --skip-slow` after checkout,
+  dependency/test-harness changes, or when default verify reports a missing
+  seed. Do not use a hand-maintained affected-test router.
 - For browser/visual lanes, keep fast DOM/contract smoke separate from the
   heavier browser screenshot lane.
 - For schema/storage changes, run focused storage/parser tests before broad
@@ -170,6 +171,47 @@ Resource rules:
   failures are easier to attribute.
 
 ## Execution Entries
+
+### 2026-05-15 - Pytest-testmon default affected verification
+
+Target:
+
+- #1059 affected-test default path, replacing the homegrown file/import router
+  with pytest-testmon.
+
+Outcome:
+
+- `devtools verify` now runs the static/generated gates plus
+  `pytest --testmon -n 0` for affected per-test selection.
+- `devtools verify --seed-testmon --skip-slow` is the explicit full
+  non-integration seed/update path. It writes `.testmondata` and
+  `.cache/testmon/seed.json`; default verify refuses ad hoc or missing seed
+  state instead of falling back to the full suite.
+- `devtools verify --all` / `--full` is the explicit full non-integration
+  diagnostic. `--affected` and `_affected_test_files()` were removed.
+- The verify runner now stops after the first failed step, preventing format or
+  lint failures from cascading into expensive pytest runs.
+- Full/seed pytest worker count defaults to 8 and can be adjusted with
+  `POLYLOGUE_PYTEST_WORKERS`; affected testmon runs use `-n 0` to avoid xdist
+  overhead for small selections.
+
+Measured locally:
+
+- Missing seed: `devtools verify --json` exits 2 with seed guidance.
+- Seed: `POLYLOGUE_PYTEST_WORKERS=4 devtools verify --seed-testmon --skip-slow
+  --json` ran 6424 tests, pytest 209.05s, total 231.42s.
+- Default after seed: `devtools verify --json` ran 5 testmon-selected tests,
+  pytest 3.60s, total 24.04s.
+- Default after editing the verify tests: `devtools verify --json` ran 17
+  testmon-selected tests, pytest 7.54s, total 32.57s.
+
+Verification:
+
+- `pytest -q tests/unit/devtools/test_verify.py`
+- `ruff check devtools/verify.py tests/unit/devtools/test_verify.py pyproject.toml`
+- `mypy --strict devtools/verify.py tests/unit/devtools/test_verify.py`
+- `POLYLOGUE_PYTEST_WORKERS=4 devtools verify --seed-testmon --skip-slow --json`
+- `devtools verify --json`
 
 ### 2026-05-15 - Health aggregation evidence
 

--- a/docs/plans/mk3-execution-log.md
+++ b/docs/plans/mk3-execution-log.md
@@ -113,7 +113,7 @@ clarity:
 | Visual evidence worker | Synthetic reader fixture, DOM/browser smoke, evidence manifests | `tests/unit/daemon/test_web_reader.py`, possible `tests/visual/`, `devtools/lab_scenario.py`, visual docs | Storage schema and archive semantics | targeted reader smoke lane |
 | Topology worker | topology edge DDL, ingest repair, topology operations | storage DDL, ingest enrichment, archive operations, topology tests | Reader graph UI until read model exists | `pytest tests/unit/storage/test_session_topology.py -q` or new equivalent |
 | User-state worker | marks, annotations, saved views, recall packs | user-state DDL/repository/API, daemon endpoints, user-state tests | topology schema and reader layout | targeted user-state storage/API tests |
-| Verification worker | affected tests, proof routing, slow-test reduction | `devtools/verify.py`, test config, proof manifests | feature semantics | `devtools verify --quick`, targeted pytest duration captures |
+| Verification worker | affected tests, pytest evidence artifacts, slow-test reduction | `devtools/verify.py`, test config, verification manifests | feature semantics | `devtools verify --quick`, targeted pytest duration captures |
 | Packaging/deployment worker | Sinnix input, Nix package/service, deployment docs | Sinnix flake/module files, packaging docs, daemon service evidence | Polylogue runtime changes unless needed for packaging | `nix flake check`/targeted Nix build plus service smoke |
 
 Serialise work when two lanes must edit the same shared files:
@@ -645,4 +645,46 @@ Verification:
 - `ruff check polylogue/api/archive.py polylogue/cli/commands/user_state.py polylogue/mcp/payloads.py polylogue/mcp/server_mutation_tools.py tests/unit/storage/test_user_state_contracts.py tests/unit/daemon/test_web_reader.py tests/unit/cli/test_user_state_command.py tests/unit/mcp/test_user_state_tools.py`
 - `python -m mypy polylogue/api/archive.py polylogue/cli/commands/user_state.py polylogue/mcp/payloads.py polylogue/mcp/server_mutation_tools.py`
 - `pytest -q -n0 tests/unit/mcp/test_tool_schema_witness.py tests/unit/mcp/test_envelope_contracts.py tests/unit/cli/test_click_app.py::TestCliMetadata::test_all_subcommands_registered tests/unit/mcp/test_user_state_tools.py tests/unit/cli/test_user_state_command.py`
+- `devtools render-all --check`
+
+### 2026-05-15 - verification artifact migration start
+
+Target:
+
+- Stop treating proof/catalog rows as the verification authority.
+- Realize the first reusable pytest artifact mechanism for contract tests.
+- Reframe planning docs and issues around pytest/coverage/benchmark/CI/runtime
+  artifacts.
+
+Owned files:
+
+- `tests/infra/contract_evidence.py`
+- `tests/infra/test_contract_evidence.py`
+- `tests/unit/cli/test_json_envelope_contract.py`
+- `pyproject.toml`
+- `tests/conftest.py`
+- verification planning docs under `docs/` and `docs/plans/`
+
+Outcome:
+
+- Added `record_contract_evidence`, an explicit opt-in pytest fixture that
+  writes bounded JSON artifacts and exposes artifact paths through pytest
+  `record_property`.
+- Added redaction/truncation for repo/home paths and obvious secret assignment
+  strings before evidence reaches disk.
+- Registered the `contract` pytest marker.
+- Wired the CLI JSON envelope matrix to emit `cli.json_envelope` evidence.
+- Wired MCP surface-registration contract tests to emit evidence for tools,
+  resources, resource templates, and prompts.
+- Marked proof-era manifests as transitional inventories, not verification
+  closure.
+- Updated #1058/#1059/#1060/#1062/#1063/#1064/#594/#997/#999 issue bodies so
+  each points at standard mechanisms and concrete owner surfaces.
+
+Verification:
+
+- `pytest -q tests/infra/test_contract_evidence.py tests/unit/cli/test_json_envelope_contract.py tests/unit/mcp/test_server_surfaces.py::TestServerSurfaceRegistration::test_server_surface_contract`
+- `ruff check tests/infra/contract_evidence.py tests/infra/test_contract_evidence.py tests/conftest.py tests/unit/cli/test_json_envelope_contract.py tests/unit/mcp/test_server_surfaces.py`
+- `mypy --strict tests/infra/contract_evidence.py tests/infra/test_contract_evidence.py tests/conftest.py tests/unit/cli/test_json_envelope_contract.py tests/unit/mcp/test_server_surfaces.py`
+- `devtools verify-manifests`
 - `devtools render-all --check`

--- a/docs/plans/mk3-execution-log.md
+++ b/docs/plans/mk3-execution-log.md
@@ -171,6 +171,39 @@ Resource rules:
 
 ## Execution Entries
 
+### 2026-05-15 - Daemon status and convergence evidence artifacts
+
+Target:
+
+- #999 runtime observability evidence through ordinary pytest contract tests.
+
+Coordination:
+
+- Main-agent implementation; the slice only marks existing daemon status and
+  convergence-debt tests with bounded evidence recording.
+
+Outcome:
+
+- `polylogued status --format json` now records a contract evidence artifact
+  containing daemon component status, live source availability counts, browser
+  capture status, stdout sample, and exit code.
+- Convergence-debt retry tests now record source-path and conversation-subject
+  retry evidence: debt before/after, retry count, and source cursor cleanup.
+- Artifacts are written through `tests/infra/contract_evidence.py`, so the
+  mechanism remains pytest-native and does not create a parallel proof layer.
+
+Artifact examples:
+
+- `.cache/verification/evidence/daemon.status.json-*.json`
+- `.cache/verification/evidence/daemon.convergence_debt.source_retry-*.json`
+- `.cache/verification/evidence/daemon.convergence_debt.conversation_retry-*.json`
+
+Verification:
+
+- `pytest -q tests/unit/daemon/test_daemon_cli.py::test_polylogued_status_json_reports_daemon_components tests/unit/daemon/test_daemon_cli.py::test_drain_convergence_debt_retries_due_items_without_source_failure tests/unit/daemon/test_daemon_cli.py::test_drain_convergence_debt_retries_conversation_subjects_without_source_lookup`
+- `ruff check tests/unit/daemon/test_daemon_cli.py`
+- `mypy --strict tests/unit/daemon/test_daemon_cli.py`
+
 ### 2026-05-15 - Verification suppressions reality scan
 
 Target:

--- a/docs/plans/mk3-execution-log.md
+++ b/docs/plans/mk3-execution-log.md
@@ -171,6 +171,34 @@ Resource rules:
 
 ## Execution Entries
 
+### 2026-05-15 - Backup restore/read evidence
+
+Target:
+
+- #999 backup verification acceptance criterion: backup must be readable, not
+  merely created.
+
+Outcome:
+
+- Added a daemon backup contract test that seeds a real archive database, runs
+  `backup_archive`, opens the produced backup through the read-only SQLite path,
+  runs `PRAGMA integrity_check`, and verifies restored conversation/message
+  rows can be queried.
+- The test records bounded `daemon.backup_restore.read` evidence with backup
+  filename, DB size, warning count, integrity status, row counts, and
+  `restore_query_ok`.
+
+Artifact example:
+
+- `.cache/verification/evidence/daemon.backup_restore.read-*.json`
+
+Verification:
+
+- `pytest -q tests/unit/daemon/test_backup.py`
+- `ruff check tests/unit/daemon/test_backup.py`
+- `mypy --strict tests/unit/daemon/test_backup.py`
+- `ruff format --check tests/unit/daemon/test_backup.py`
+
 ### 2026-05-15 - Daemon status and convergence evidence artifacts
 
 Target:

--- a/docs/plans/mk3-execution-log.md
+++ b/docs/plans/mk3-execution-log.md
@@ -171,6 +171,43 @@ Resource rules:
 
 ## Execution Entries
 
+### 2026-05-15 - Verification suppressions reality scan
+
+Target:
+
+- #1062 suppression/exception discipline as a concrete source scan, not only
+  an empty registry expiry lint.
+
+Coordination:
+
+- Main-agent implementation; no subagent needed because the write set is
+  limited to `devtools verify-suppressions` and its unit tests.
+
+Outcome:
+
+- `devtools verify-suppressions` now discovers real source-level exception
+  mechanisms across `polylogue/`, `tests/`, and `devtools/`: `pytest.skip`,
+  `pytest.xfail`, `pytest.mark.skip/skipif/xfail`, `# noqa`,
+  `# type: ignore[...]`, and coverage ignores.
+- Discovery uses Python AST/tokenization rather than text grep so fixture
+  strings do not inflate the report.
+- `--enforce-discovered` blocks unregistered discovered exceptions; default
+  mode reports the current backlog so existing repo debt is visible without
+  hiding behind an empty `docs/plans/suppressions.yaml`.
+
+Observed baseline:
+
+- `devtools verify-suppressions --json`: 175 discovered source exceptions,
+  all currently unregistered; `blocking=False` without
+  `--enforce-discovered`.
+
+Verification:
+
+- `pytest -q tests/unit/devtools/test_verify_suppressions.py`
+- `ruff check devtools/verify_suppressions.py tests/unit/devtools/test_verify_suppressions.py`
+- `mypy --strict devtools/verify_suppressions.py tests/unit/devtools/test_verify_suppressions.py`
+- `devtools verify-suppressions --json`
+
 ### 2026-05-15 - MK3 design pack dissolved into tracker
 
 Outcome:

--- a/docs/plans/mk3-execution-log.md
+++ b/docs/plans/mk3-execution-log.md
@@ -194,6 +194,10 @@ Outcome:
 - Full/seed pytest worker count defaults to 8 and can be adjusted with
   `POLYLOGUE_PYTEST_WORKERS`; affected testmon runs use `-n 0` to avoid xdist
   overhead for small selections.
+- The extra `devtools` worktree-result replay cache was removed. Every
+  invocation now reaches pytest-testmon, which owns package/Python/source
+  invalidation; harness/config/dependency-lock changes automatically widen to
+  `--testmon-noselect` instead of relying on a manual full-suite bypass.
 
 Measured locally:
 

--- a/docs/plans/oracle-quality.yaml
+++ b/docs/plans/oracle-quality.yaml
@@ -1,19 +1,15 @@
 # Oracle-quality taxonomy.
 #
-# Evidence-quality taxonomy mapping each oracle classification to its
-# quality attributes. Adapted from the assurance-ontology reset in
-# project_assurance_ontology_2026_04_27.md.
-#
-# Six oracles: proof, drift_check, construction_sanity, smoke,
-# manual_review, ceremonial.
+# Transitional proof-era taxonomy. #1065/#594 should replace user-facing
+# report language with standard artifact sources: pytest, coverage,
+# benchmark, CI, static checks, fuzz/property campaigns, and runtime evidence.
+# This file is not a source of verification authority.
 #
 # Updated 2026-04-29 from realized codebase state.
 
 description: >
-  Evidence-quality taxonomy for the six oracle classifications used
-  across polylogue assurance domains. Each oracle entry documents
-  what the oracle counts as, its independence level, an example,
-  and its typical use in the verification pipeline.
+  Transitional taxonomy for old oracle classifications. Retained only
+  while #1065/#594 migrate reports to standard artifact language.
 
 oracles:
   proof:

--- a/docs/plans/slo-catalog.yaml
+++ b/docs/plans/slo-catalog.yaml
@@ -16,10 +16,10 @@
 #       p95_ms:         <int milliseconds, p95 budget — estimated mean+1.645*stddev>
 #       gate:           "required" | "informational"
 #
-# verify_slos exits non-zero when any surface exceeds its declared budget.
-# Surfaces without a `benchmark_test` (or whose test produced no result) are
-# reported as uncovered, not as failures — those are deferred read paths
-# whose benchmark fixtures or product paths do not yet exist.
+# verify_slos exits non-zero when any required surface exceeds its declared
+# budget or fails to produce a benchmark result. Informational rows are visible
+# but non-blocking placeholders for deferred read paths whose benchmark fixtures
+# or product paths do not yet exist.
 
 surfaces:
 

--- a/docs/plans/suppressions.yaml
+++ b/docs/plans/suppressions.yaml
@@ -6,6 +6,7 @@
 #   reason:     Why the suppression exists.
 #   expires_at: ISO-8601 date (YYYY-MM-DD). After this date the lint fails.
 #   paths:      File globs or paths the suppression applies to.
-#   claims:     Proof-obligation claim IDs the suppression applies to.
+#   claims:     Legacy proof-obligation claim IDs. Prefer ordinary issue links
+#               and native pytest/Ruff/mypy/coverage enforcement under #1062.
 #
 suppressions: []

--- a/docs/plans/test-coverage-domains.yaml
+++ b/docs/plans/test-coverage-domains.yaml
@@ -261,22 +261,27 @@ domains:
     production_modules:
       - devtools/
     covering_tests:
-      - tests/unit/devtools/test_proof_pack.py
       - tests/unit/devtools/test_quality_registry.py
       - tests/unit/devtools/test_benchmark_campaign.py
       - tests/unit/devtools/test_validation_lanes.py
       - tests/unit/devtools/test_pipeline_probe.py
     notes: partial — core tooling covered; some leaf commands have no direct tests
 
-  - domain: proof
+  - domain: verification_reports
     production_modules:
       - polylogue/proof/
+      - devtools/proof_pack.py
+      - devtools/affected_obligations.py
+      - devtools/obligation_diff.py
     covering_tests:
       - tests/unit/proof/test_generated_scenario_obligations.py
       - tests/unit/devtools/test_proof_pack.py
+      - tests/infra/test_contract_evidence.py
     notes: >
-      partial — scenario obligations and proof pack covered; subject
-      discovery not directly tested
+      transitional — old proof/report tests exist, and contract-evidence
+      artifact tests now provide the replacement direction. #594/#1065 own
+      migrating this domain to reports over pytest/coverage/benchmark/CI
+      artifacts and deleting obsolete proof rows.
 
 # -- Known gaps (from recon report #807) ----------------------------------
 #

--- a/docs/verification-lab.md
+++ b/docs/verification-lab.md
@@ -1,6 +1,6 @@
 # Verification Lab Command Surface
 
-Status: accepted for the current proof-kernel generation. Revisit when proof and
+Status: accepted for the current verification-catalog generation. Revisit when
 evidence runners need a stable end-user distribution surface outside the repo
 control plane.
 
@@ -14,22 +14,22 @@ Selected vertical slices:
 
 | Slice | Command | Role |
 | --- | --- | --- |
-| Catalog | `devtools render-verification-catalog` | Render and check the proof-obligation catalog generated from subjects, claims, runners, and compiled obligations. |
-| Routing | `devtools affected-obligations` | Map changed paths or refs to affected proof obligations and focused verification commands. |
-| Evidence | `devtools semantic-axis-evidence` | Produce comparative proof-envelope performance evidence across semantic scale tiers. |
+| Catalog | `devtools render-verification-catalog` | Render and check the verification catalog generated from subjects, claims, runners, and routed checks. |
+| Routing | `devtools affected-obligations` | Map changed paths or refs to affected verification checks and focused commands. |
+| Evidence | `devtools semantic-axis-evidence` | Produce comparative performance evidence across semantic scale tiers. |
 | Corpus | `devtools lab-corpus` | Generate raw synthetic corpus fixtures or seed complete demo archive workspaces for lab runs. |
 | Scenarios | `devtools lab-scenario` | Run showcase exercise scenario sets and committed showcase baseline checks outside the archive CLI. |
 
-This surface is intentionally a repo operator surface. It works over proof
+This surface is intentionally a repo operator surface. It works over catalog
 subjects, generated docs, changed files, evidence envelopes, and local
 verification artifacts. Archive-facing checks remain in the archive CLI
-where they already belong, such as `polylogue doctor --proof` and schema proof
-rendering. Schema package auditing moved to `devtools schema-audit` so
+where they already belong, such as schema query and audit commands.
+Schema package auditing moved to `devtools schema-audit` so
 repository QA does not pollute first-contact archive help.
 
 ## Catalog Grounding
 
-The decision depends on the proof-obligation catalog from issue #192, not on a
+The decision depends on the verification catalog from issue #192, not on a
 hypothetical future taxonomy. The catalog at
 [`docs/verification-catalog.md`](verification-catalog.md) already records:
 
@@ -37,7 +37,7 @@ hypothetical future taxonomy. The catalog at
 - claims for CLI, schema, provider capability, operation-spec, workflow, and
   semantic archive behavior;
 - runner bindings and trust metadata;
-- compiled obligations that affected-change routing can target.
+- routed checks that changed-path routing can target.
 
 That means the first lab surface can be explicit without moving command
 implementations. `devtools render-verification-catalog` is the catalog slice,
@@ -49,30 +49,29 @@ showcase exercise work that used to overload `polylogue audit`.
 ## Alternatives Rejected
 
 `polylogue-lab` is premature. A separate executable implies a stable public
-distribution and packaging boundary before the proof/evidence runner UX is
-settled.
+distribution and packaging boundary before the evidence runner UX is settled.
 
 `polylogue lab` would put repo verification and source-control operations into
 the archive CLI. That blurs the boundary between archive workflows and
-repository proof obligations.
+repository verification checks.
 
 `polylogue audit` overloaded archive help with repository QA. Keeping the lab
 surface in `devtools` avoids turning archive usage into source-tree ceremony.
 
 Exposing only `devtools render-verification-catalog` is now too narrow. The
-catalog slice exists, but affected-obligation routing and semantic-axis evidence
+catalog slice exists, but changed-path routing and semantic-axis evidence
 also exist and need discoverable operator entry points.
 
 ## Surface Rules
 
-New verification-lab commands should implement a real proof, evidence, routing,
+New verification-lab commands should implement real evidence, routing,
 or catalog operation. They should not be aliases over older overloaded commands.
 
 Generated docs and `devtools --list-commands --json` must keep naming the
 selected surface, so agents and scripts can discover it without scraping prose.
 
-If a future command must operate on user archives rather than repo proof
-obligations, it belongs in the archive CLI or API first, not in the
+If a future command must operate on user archives rather than repo verification
+checks, it belongs in the archive CLI or API first, not in the
 verification-lab surface.
 
 ## Migration Notes

--- a/polylogue/cli/commands/ingest.py
+++ b/polylogue/cli/commands/ingest.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import shutil
 from pathlib import Path
 from urllib.request import Request, urlopen
 
@@ -11,12 +12,37 @@ import click
 from polylogue.cli.shared.helpers import fail
 from polylogue.cli.shared.types import AppEnv
 from polylogue.operations.import_contracts import ImportOperation
+from polylogue.paths import archive_root
 
 _DEFAULT_DAEMON_URL = "http://127.0.0.1:8766"
 
 
 def _daemon_url(env: AppEnv) -> str:
     return getattr(env, "daemon_url", None) or _DEFAULT_DAEMON_URL
+
+
+def _stage_for_daemon(path: Path) -> Path:
+    """Copy a local ingest target into the archive inbox for daemon pickup."""
+    resolved = path.expanduser().resolve()
+    if not resolved.exists():
+        fail("ingest", f"Path does not exist: {resolved}")
+
+    inbox = archive_root() / "inbox"
+    inbox.mkdir(parents=True, exist_ok=True)
+    dest = inbox / resolved.name
+
+    if dest.exists() and resolved == dest.resolve():
+        return dest
+
+    try:
+        if resolved.is_dir():
+            shutil.copytree(resolved, dest, dirs_exist_ok=True)
+        else:
+            shutil.copy2(resolved, dest)
+    except OSError as exc:
+        fail("ingest", f"Could not stage {resolved} in daemon inbox: {exc}")
+
+    return dest
 
 
 @click.command("ingest")
@@ -36,14 +62,13 @@ def ingest_command(
     """Schedule a file or directory for ingestion by the daemon.
 
     Contacts the running polylogued daemon and requests ingestion of
-    PATH. The daemon copies the file into its inbox and begins processing
+    PATH. The command stages the file into the archive inbox and the daemon
+    begins processing
     asynchronously. Use 'polylogue status' to monitor progress.
     """
-    resolved = path.expanduser().resolve()
-    if not resolved.exists():
-        fail("ingest", f"Path does not exist: {resolved}")
+    staged = _stage_for_daemon(path)
 
-    body = json.dumps({"path": str(resolved)}).encode("utf-8")
+    body = json.dumps({"path": str(staged)}).encode("utf-8")
     req = Request(
         f"{daemon_url}/api/ingest",
         data=body,

--- a/polylogue/cli/query.py
+++ b/polylogue/cli/query.py
@@ -224,7 +224,7 @@ def handle_query_mode(
 # Re-exported from the lightweight query_group module so that
 # click_app can import the base class without pulling in the full
 # archive/storage/operations import chain.
-from polylogue.cli.query_group import QueryFirstGroupBase  # noqa: F401, E402, F811
+from polylogue.cli.query_group import QueryFirstGroupBase  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Query execution (original query.py)

--- a/polylogue/cli/query_verbs.py
+++ b/polylogue/cli/query_verbs.py
@@ -14,7 +14,7 @@ import click
 if TYPE_CHECKING:
     from polylogue.cli.root_request import RootModeRequest
 
-from polylogue.cli.click_option_groups import _LazyChoice  # noqa: F401
+from polylogue.cli.click_option_groups import _LazyChoice
 from polylogue.cli.shared.types import AppEnv
 from polylogue.cli.verb_names import VERB_NAMES
 

--- a/polylogue/daemon/convergence_stages.py
+++ b/polylogue/daemon/convergence_stages.py
@@ -46,7 +46,7 @@ class _FtsRepairNeeds:
 def make_fts_stage(db_path: Path) -> ConvergenceStage:
     """Verify FTS coverage and repair gaps."""
 
-    def check(path: Path) -> bool:  # noqa: ARG001
+    def check(path: Path) -> bool:
         if not db_path.exists():
             return False
         from polylogue.storage.sqlite.connection_profile import open_connection
@@ -336,7 +336,7 @@ def make_embed_stage(db_path: Path) -> ConvergenceStage:
 def make_insights_stage(db_path: Path) -> ConvergenceStage:
     """Refresh session insights for conversations missing them."""
 
-    def check(path: Path) -> bool:  # noqa: ARG001
+    def check(path: Path) -> bool:
         if not db_path.exists():
             return False
         from polylogue.storage.sqlite.connection_profile import open_connection
@@ -358,7 +358,7 @@ def make_insights_stage(db_path: Path) -> ConvergenceStage:
         except Exception:
             return False
 
-    def execute(path: Path) -> bool:  # noqa: ARG001
+    def execute(path: Path) -> bool:
         from polylogue.storage.insights.session.rebuild import rebuild_session_insights_sync
         from polylogue.storage.sqlite.connection import open_connection
 

--- a/polylogue/daemon/http.py
+++ b/polylogue/daemon/http.py
@@ -10,6 +10,7 @@ import os
 from collections.abc import Callable, Mapping
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path, PurePath
 from typing import TYPE_CHECKING, Any
 from urllib.parse import parse_qs, urlparse
 
@@ -53,6 +54,41 @@ def _dump_target_ref(target_ref: TargetRefPayload) -> dict[str, object]:
 
 def _dump_actions(actions: Mapping[str, ReaderActionAvailabilityPayload]) -> dict[str, object]:
     return {name: availability.model_dump(mode="json", exclude_none=True) for name, availability in actions.items()}
+
+
+def _staged_inbox_source(raw_path: object, inbox: Path) -> tuple[Path | None, str | None]:
+    """Resolve an ingest request to an existing file already staged in inbox.
+
+    The HTTP API must not copy arbitrary local paths supplied by clients.
+    Clients with local filesystem access stage first; the daemon then
+    schedules the matching inbox entry for its normal watcher/convergence path.
+    """
+    if not isinstance(raw_path, str) or not raw_path.strip():
+        return None, "missing_path"
+
+    source_name = PurePath(raw_path).name
+    if not source_name or source_name in {".", ".."}:
+        return None, "invalid_path"
+
+    try:
+        inbox_root = inbox.resolve()
+        candidates = list(inbox.iterdir())
+    except FileNotFoundError:
+        return None, "path_not_found"
+    except OSError:
+        return None, "path_not_found"
+
+    for candidate in candidates:
+        if candidate.name != source_name:
+            continue
+        resolved = candidate.resolve()
+        try:
+            resolved.relative_to(inbox_root)
+        except ValueError:
+            return None, "invalid_path"
+        return resolved, None
+
+    return None, "path_not_found"
 
 
 def _message_type_value(message: object) -> str:
@@ -952,40 +988,21 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
             self._send_error(HTTPStatus.BAD_REQUEST, "invalid_request")
             return
 
-        ingest_path = body.get("path")
-        if not ingest_path:
-            self._send_error(HTTPStatus.BAD_REQUEST, "missing_path")
-            return
-
-        from pathlib import Path as _Path
-
-        source = _Path(ingest_path).expanduser().resolve()
-        if not source.exists():
-            self._send_error(HTTPStatus.BAD_REQUEST, "path_not_found")
-            return
-
-        # Stage into the archive inbox — the daemon watcher picks it up.
         from polylogue.paths import archive_root
 
         inbox = archive_root() / "inbox"
         inbox.mkdir(parents=True, exist_ok=True)
 
-        import shutil
-
-        dest = inbox / source.name
-        try:
-            if source.is_dir():
-                shutil.copytree(source, dest, dirs_exist_ok=True)
-            else:
-                shutil.copy2(source, dest)
-        except OSError as exc:
-            self._send_json(HTTPStatus.INTERNAL_SERVER_ERROR, {"ok": False, "error": str(exc)})
+        source, error = _staged_inbox_source(body.get("path"), inbox)
+        if error is not None:
+            self._send_error(HTTPStatus.BAD_REQUEST, error)
             return
+        assert source is not None
 
         from polylogue.operations.import_contracts import ImportOperation
 
         op_id = f"ingest-{source.name}"
-        emit_daemon_event("ingest", operation_id=op_id, payload={"path": str(source), "inbox": str(dest)})
+        emit_daemon_event("ingest", operation_id=op_id, payload={"path": str(source), "inbox": str(inbox)})
 
         operation = ImportOperation.pending(
             operation_id=op_id,

--- a/polylogue/daemon/http.py
+++ b/polylogue/daemon/http.py
@@ -172,7 +172,7 @@ def _build_query_spec_params(
 
 def _check_auth_logic(
     auth_token: str | None,
-    client_host: str,  # noqa: ARG001
+    client_host: str,
     auth_header: str,
 ) -> _AuthResult:
     """Pure logic for auth checks — testable without HTTP handler setup."""
@@ -301,7 +301,7 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
     def _sync_run(self, handler: Callable) -> object:  # type: ignore[type-arg]
         return asyncio.run(self._run_archive_query(handler))
 
-    def do_OPTIONS(self) -> None:  # noqa: N802
+    def do_OPTIONS(self) -> None:
         self._send_error(HTTPStatus.METHOD_NOT_ALLOWED, "method_not_allowed")
 
     # ------------------------------------------------------------------
@@ -349,7 +349,7 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
         else:
             self._send_error(HTTPStatus.NOT_FOUND, "not_found")
 
-    def do_GET(self) -> None:  # noqa: N802
+    def do_GET(self) -> None:
         path, params = self._parse_path()
         self._dispatch_get(path, params)
 
@@ -367,7 +367,7 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
         self._send_error(HTTPStatus.FORBIDDEN, "cross_origin_denied")
         return False
 
-    def do_POST(self) -> None:  # noqa: N802
+    def do_POST(self) -> None:
         path, params = self._parse_path()
 
         if not self._check_auth():
@@ -391,7 +391,7 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
             return
         self._send_error(HTTPStatus.NOT_FOUND, "not_found")
 
-    def do_DELETE(self) -> None:  # noqa: N802
+    def do_DELETE(self) -> None:
         path, params = self._parse_path()
 
         if not self._check_auth():

--- a/polylogue/proof/diffing.py
+++ b/polylogue/proof/diffing.py
@@ -1,4 +1,4 @@
-"""Changed-path routing for proof obligations."""
+"""Changed-path routing for verification checks."""
 
 from __future__ import annotations
 
@@ -88,7 +88,7 @@ _DIFF_STATUSES: tuple[DiffStatus, ...] = (
 
 @dataclass(frozen=True, slots=True)
 class RecommendedCheck:
-    """A command recommended by affected-obligation routing."""
+    """A command recommended by changed-path routing."""
 
     command: tuple[str, ...]
     scope: CheckScope
@@ -134,7 +134,7 @@ class ChangeSubject:
 
 @dataclass(frozen=True, slots=True)
 class AffectedObligation:
-    """A proof obligation selected by one or more changed subjects."""
+    """A catalog-backed check selected by one or more changed subjects."""
 
     obligation_id: str
     claim_id: str
@@ -156,7 +156,7 @@ class AffectedObligation:
 
 @dataclass(frozen=True, slots=True)
 class ObligationDiff:
-    """Diff buckets for proof-obligation routing across refs."""
+    """Diff buckets for catalog-backed check routing across refs."""
 
     new: tuple[str, ...] = ()
     dropped: tuple[str, ...] = ()
@@ -191,7 +191,7 @@ class ObligationDiff:
 
 @dataclass(frozen=True, slots=True)
 class AffectedObligationReport:
-    """Complete affected-obligation routing report."""
+    """Complete changed-path verification routing report."""
 
     base_ref: str
     head_ref: str
@@ -238,7 +238,7 @@ def build_affected_obligation_report(
     base_obligation_ids: Iterable[str] | None = None,
     head_obligation_ids: Iterable[str] | None = None,
 ) -> AffectedObligationReport:
-    """Classify changed paths and map them to affected proof obligations."""
+    """Classify changed paths and map them to affected catalog-backed checks."""
     head_catalog = catalog or build_verification_catalog()
     paths = tuple(sorted(dict.fromkeys(_normalize_path(path) for path in changed_paths if path.strip())))
     change_subjects = classify_changed_paths(paths, catalog=head_catalog)
@@ -316,7 +316,7 @@ def route_affected_obligations(
     *,
     catalog: VerificationCatalog | None = None,
 ) -> tuple[AffectedObligation, ...]:
-    """Route change subjects to proof obligations."""
+    """Route change subjects to catalog-backed checks."""
     proof_catalog = catalog or build_verification_catalog()
     obligations_by_subject: dict[str, list[ProofObligation]] = defaultdict(list)
     for obligation in proof_catalog.obligations:
@@ -357,7 +357,7 @@ def diff_obligation_ids(
     affected_ids: Iterable[str],
     suppressed: Iterable[str] = (),
 ) -> ObligationDiff:
-    """Bucket obligation IDs into semantic diff categories."""
+    """Bucket catalog-backed check IDs into semantic diff categories."""
     base = set(base_ids)
     head = set(head_ids)
     affected = set(affected_ids)
@@ -417,9 +417,9 @@ def obligation_ids_for_ref(ref: str) -> tuple[str, ...]:
 
 
 def render_affected_obligations(report: AffectedObligationReport) -> str:
-    """Render a human-readable affected-obligation report."""
+    """Render a human-readable changed-path verification report."""
     lines = [
-        "Affected Obligations",
+        "Affected Verification Checks",
         f"Refs: {report.base_ref}..{report.head_ref}",
         "",
         "Changed Paths:",
@@ -430,13 +430,13 @@ def render_affected_obligations(report: AffectedObligationReport) -> str:
         operations = f"; operations={', '.join(subject.operation_names)}" if subject.operation_names else ""
         surfaces = f"; surfaces={', '.join(subject.surface_names)}" if subject.surface_names else ""
         lines.append(f"- {subject.id}: {subject.reason}{operations}{surfaces}")
-    lines.extend(["", "Obligation Diff:"])
+    lines.extend(["", "Routed Check Diff:"])
     for status in _DIFF_STATUSES:
         values = report.obligation_diff.bucket(status)
         rendered = ", ".join(values[:8]) if values else "—"
         suffix = f" (+{len(values) - 8} more)" if len(values) > 8 else ""
         lines.append(f"- {status}: {rendered}{suffix}")
-    lines.extend(["", "Affected Obligations:"])
+    lines.extend(["", "Affected Checks:"])
     if not report.affected_obligations:
         lines.append("- none")
     for obligation in report.affected_obligations[:30]:
@@ -453,20 +453,20 @@ def render_affected_obligations(report: AffectedObligationReport) -> str:
 
 
 def render_affected_obligations_markdown(report: AffectedObligationReport) -> str:
-    """Render a PR-comment-friendly affected-obligation report."""
+    """Render a PR-comment-friendly changed-path verification report."""
     lines = [
-        "## Proof Obligations",
+        "## Affected Verification Checks",
         "",
         f"**Refs:** `{report.base_ref}..{report.head_ref}`",
         "",
         "### Changed Paths",
     ]
     lines.extend(f"- `{path}`" for path in report.changed_paths) if report.changed_paths else lines.append("- none")
-    lines.extend(["", "### Obligation Diff"])
+    lines.extend(["", "### Routed Check Diff"])
     for status in _DIFF_STATUSES:
         values = report.obligation_diff.bucket(status)
         lines.append(f"- `{status}`: {len(values)}")
-    lines.extend(["", "### Affected Obligations"])
+    lines.extend(["", "### Affected Checks"])
     if not report.affected_obligations:
         lines.append("- none")
     for obligation in report.affected_obligations[:20]:
@@ -651,7 +651,7 @@ def _checks_for_change(kind: ChangeKind, *, path: str) -> tuple[RecommendedCheck
                 ("devtools", "pipeline-probe", "--provider", _provider_for_parser_path(path) or "unknown"),
                 "parser pipeline probe",
             ),
-            _check(("devtools", "affected-obligations", "--path", path), "refresh focused obligation routing"),
+            _check(("devtools", "affected-obligations", "--path", path), "refresh focused changed-path routing"),
         )
     if kind == "schema.annotation":
         return (
@@ -659,15 +659,17 @@ def _checks_for_change(kind: ChangeKind, *, path: str) -> tuple[RecommendedCheck
                 ("pytest", "tests/unit/core/test_schema_annotation_contracts.py"), "schema annotation contract changed"
             ),
             _check(
-                ("pytest", "tests/unit/proof/test_schema_provider_obligations.py"), "schema proof obligations changed"
+                ("pytest", "tests/unit/proof/test_schema_provider_obligations.py"),
+                "schema/provider contract checks changed",
             ),
-            _check(("devtools", "render-verification-catalog", "--check"), "schema subjects feed generated catalog"),
+            _check(("devtools", "render-verification-catalog", "--check"), "schema contract inventory changed"),
         )
     if kind == "command":
         return (
             _check(("pytest", "tests/unit/cli"), "CLI command surface changed"),
             _check(
-                ("pytest", "tests/unit/proof/test_evidence_runners.py"), "CLI proof runners exercise command output"
+                ("pytest", "tests/unit/proof/test_evidence_runners.py"),
+                "CLI contract evidence exercises command output",
             ),
             _check(("devtools", "render-cli-reference", "--check"), "CLI reference is generated from command help"),
         )
@@ -676,7 +678,7 @@ def _checks_for_change(kind: ChangeKind, *, path: str) -> tuple[RecommendedCheck
     if kind == "architecture":
         checks = [
             _check(("devtools", "verify-manifests"), "structural manifest changed"),
-            _check(("devtools", "affected-obligations", "--path", path), "refresh structural obligation routing"),
+            _check(("devtools", "affected-obligations", "--path", path), "refresh structural changed-path routing"),
         ]
         for subject_id in _ARCHITECTURE_PATH_SUBJECTS.get(path, ()):
             if subject_id == "architecture.topology.projection":
@@ -691,8 +693,8 @@ def _checks_for_change(kind: ChangeKind, *, path: str) -> tuple[RecommendedCheck
     if kind == "coverage_manifest":
         return (
             _check(("devtools", "verify-manifests"), "assurance coverage manifest changed"),
-            _check(("devtools", "render-verification-catalog", "--check"), "coverage manifests feed proof subjects"),
-            _check(("devtools", "proof-pack", "--path", path, "--markdown"), "coverage changes feed proof-pack gaps"),
+            _check(("devtools", "render-verification-catalog", "--check"), "coverage manifests feed check inventory"),
+            _check(("devtools", "proof-pack", "--path", path, "--markdown"), "coverage changes feed known-gap report"),
         )
     if kind == "schema_roundtrip":
         return (
@@ -701,10 +703,10 @@ def _checks_for_change(kind: ChangeKind, *, path: str) -> tuple[RecommendedCheck
         )
     if kind == "proof_catalog":
         return (
-            _check(("pytest", "tests/unit/proof"), "proof kernel or catalog changed"),
-            _check(("pytest", "tests/unit/devtools/test_proof_pack.py"), "proof-pack policy or CLI changed"),
+            _check(("pytest", "tests/unit/proof"), "verification catalog implementation changed"),
+            _check(("pytest", "tests/unit/devtools/test_proof_pack.py"), "verification impact report changed"),
             _check(("pytest", "tests/unit/devtools/test_render_verification_catalog.py"), "catalog renderer changed"),
-            _check(("devtools", "proof-pack", "--check"), "proof-pack policy gate changed"),
+            _check(("devtools", "proof-pack", "--check"), "verification report policy gate changed"),
             _check(("devtools", "render-verification-catalog", "--check"), "verification catalog must stay current"),
         )
     if kind == "operation.spec":

--- a/polylogue/sources/parsers/antigravity.py
+++ b/polylogue/sources/parsers/antigravity.py
@@ -99,7 +99,7 @@ class AntigravityLanguageServerClient:
             f"-app_data_dir={self.root.name}",
             "-override_ide_name=antigravity",
         ]
-        self._process = subprocess.Popen(  # noqa: S603
+        self._process = subprocess.Popen(
             cmd,
             stdin=subprocess.DEVNULL,
             stdout=subprocess.DEVNULL,
@@ -162,7 +162,7 @@ class AntigravityLanguageServerClient:
             method="POST",
         )
         try:
-            with urlopen(request, timeout=10.0) as response:  # noqa: S310
+            with urlopen(request, timeout=10.0) as response:
                 loaded = loads(response.read())
         except URLError as exc:
             raise AntigravityExportError(str(exc)) from exc

--- a/polylogue/storage/embeddings/materialization.py
+++ b/polylogue/storage/embeddings/materialization.py
@@ -125,7 +125,7 @@ def embed_conversation_sync(
         if not messages:
             return EmbedConversationOutcome(status="no_messages", conversation_id=full_id, title=title)
         vec_provider.upsert(full_id, messages)
-    except Exception as exc:  # noqa: BLE001 — surfacing as outcome
+    except Exception as exc:
         return EmbedConversationOutcome(status="error", conversation_id=full_id, title=title, error=str(exc))
     return EmbedConversationOutcome(
         status="embedded",

--- a/polylogue/storage/fts/sql.py
+++ b/polylogue/storage/fts/sql.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Protocol
 
 # Re-export canonical chunked from polylogue.core.common.
-from polylogue.core.common import chunked  # noqa: F401
+from polylogue.core.common import chunked
 
 FTS_MESSAGES_TABLE_SQL = """
     CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(

--- a/polylogue/storage/insights/session/rebuild.py
+++ b/polylogue/storage/insights/session/rebuild.py
@@ -14,7 +14,7 @@ from polylogue.archive.conversation.models import Conversation
 from polylogue.archive.session.session_profile import SessionProfile, build_session_analysis, build_session_profile
 
 # Re-export canonical chunked from polylogue.core.common.
-from polylogue.core.common import chunked  # noqa: F401
+from polylogue.core.common import chunked
 from polylogue.protocols import ProgressCallback
 from polylogue.storage.action_events.rows import attach_blocks_to_messages
 from polylogue.storage.hydrators import conversation_from_records

--- a/polylogue/verification/manifests/models.py
+++ b/polylogue/verification/manifests/models.py
@@ -46,22 +46,8 @@ class AssuranceDomainEntry(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
     description: str
-    maturity: str
-    oracle_present: bool = False
-    oracle: str | None = None
     notes: str | None = None
     coverage_gaps: list[str] = Field(default_factory=list)
-
-    VALID_MATURITIES: ClassVar[frozenset[str]] = frozenset(
-        {"seed", "nascent", "growing", "established", "complete", "mature"}
-    )
-
-    @field_validator("maturity")
-    @classmethod
-    def _check_maturity(cls, v: str) -> str:
-        if v not in cls.VALID_MATURITIES:
-            raise ValueError(f"maturity must be one of {sorted(cls.VALID_MATURITIES)}, got {v!r}")
-        return v
 
 
 class AssuranceDomainsManifest(BaseModel):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ dev = [
   "pytest-asyncio>=0.23.0",  # Async test support
   "pytest-xdist>=3.5.0",  # Parallel test execution
   "pytest-randomly>=3.0",  # Detect order-dependent tests; adds --randomly-seed
+  "pytest-testmon>=2.1.3",  # Per-test affected selection via dependency database
   "pytest-benchmark>=5.0",  # Microbenchmark suite (run with --benchmark-enable -p no:xdist)
   "coverage[toml]>=7.6",
   "hypothesis>=6.152.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,7 @@ path = "hatch_build.py"
 addopts = "-ra -n auto --benchmark-disable --benchmark-storage=file://./.cache/pytest-benchmark"
 testpaths = ["tests"]
 asyncio_mode = "auto"
+xfail_strict = true
 cache_dir = ".cache/pytest"
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -196,6 +196,7 @@ select = [
     "B",   # flake8-bugbear
     "C4",  # flake8-comprehensions
     "SIM", # flake8-simplify
+    "RUF100", # unused noqa directives
 ]
 ignore = [
     "E501",  # line too long (handled by formatter)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,6 +124,7 @@ markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
     "integration: marks integration tests (pipeline, CLI end-to-end)",
     "benchmark: marks benchmark tests (run with --benchmark-enable -p no:xdist -p no:randomly)",
+    "contract: marks public contract tests that may emit bounded evidence artifacts",
     "scale(level): parametric scale marker (small/medium/large/stretch)",
     "machine_contract: marks root CLI JSON success/failure contract tests",
     "query_routing: marks query-first CLI routing and read-surface tests",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,7 +27,11 @@ from polylogue.scenarios import CorpusSpec, build_default_corpus_specs
 from polylogue.storage.runtime import RawConversationRecord
 from tests.infra.builders import make_conv, make_msg
 
-pytest_plugins = ("tests.infra.corpus_fixtures", "tests.conftest_witness")
+pytest_plugins = (
+    "tests.infra.contract_evidence",
+    "tests.infra.corpus_fixtures",
+    "tests.conftest_witness",
+)
 
 if TYPE_CHECKING:
     from click.testing import CliRunner

--- a/tests/data/pytest-benchmark/reader-status.json
+++ b/tests/data/pytest-benchmark/reader-status.json
@@ -1,0 +1,68 @@
+{
+  "benchmarks": [
+    {
+      "extra_info": {},
+      "fullname": "tests/benchmarks/test_reader_api.py::test_bench_reader_status",
+      "group": null,
+      "name": "test_bench_reader_status",
+      "options": {
+        "disable_gc": false,
+        "max_time": 1.0,
+        "min_rounds": 5,
+        "min_time": 0.000005,
+        "timer": "time.perf_counter"
+      },
+      "param": null,
+      "params": null,
+      "stats": {
+        "data": [
+          0.001,
+          0.0012,
+          0.0011
+        ],
+        "hd15iqr": 0.0012,
+        "iqr": 0.0001,
+        "iqr_outliers": 0,
+        "iterations": 1,
+        "ld15iqr": 0.001,
+        "max": 0.0012,
+        "mean": 0.0011,
+        "median": 0.0011,
+        "min": 0.001,
+        "ops": 909.0909090909,
+        "outliers": "0;0",
+        "q1": 0.00105,
+        "q3": 0.00115,
+        "rounds": 3,
+        "stddev": 0.0001,
+        "stddev_outliers": 0,
+        "total": 0.0033
+      }
+    }
+  ],
+  "commit_info": {
+    "dirty": true,
+    "id": "0000000000000000000000000000000000000000",
+    "project": "polylogue"
+  },
+  "datetime": "2026-05-15T20:00:00+00:00",
+  "machine_info": {
+    "cpu": {
+      "brand_raw": "Intel(R) Core(TM) i7-13700K"
+    },
+    "machine": "x86_64",
+    "node": "sinnix-prime",
+    "processor": "",
+    "python_build": [
+      "main",
+      "May 1 2026 00:00:00"
+    ],
+    "python_compiler": "GCC",
+    "python_implementation": "CPython",
+    "python_implementation_version": "3.13.12",
+    "python_version": "3.13.12",
+    "release": "6.x",
+    "system": "Linux"
+  },
+  "version": "5.2.3"
+}

--- a/tests/infra/contract_evidence.py
+++ b/tests/infra/contract_evidence.py
@@ -23,7 +23,9 @@ from polylogue.core.json import JSONDocument, JSONValue, require_json_document
 
 _DEFAULT_EVIDENCE_DIR = Path(".cache/verification/evidence")
 _MAX_SAMPLE_CHARS = 2000
+_MAX_JSON_DOCUMENT_BYTES = 8192
 _SECRET_ASSIGNMENT_RE = re.compile(r"(?i)(token|secret|api[_-]?key|password)(=|:)\S+")
+_SECRET_FLAG_RE = re.compile(r"(?i)(--?(?:token|secret|api[_-]?key|password))(?:=|\s+)\S+")
 _UNSAFE_FILENAME_RE = re.compile(r"[^a-zA-Z0-9._-]+")
 
 
@@ -93,7 +95,7 @@ class ContractEvidenceRecorder:
             "dirty": _git_dirty(self.repo_root),
         }
         if command is not None:
-            payload["command"] = [_redact_text(str(part), self.repo_root) for part in command]
+            payload["command"] = _bounded_text(" ".join(str(part) for part in command), self.repo_root)
         if exit_code is not None:
             payload["exit_code"] = exit_code
         if stdout is not None:
@@ -101,11 +103,23 @@ class ContractEvidenceRecorder:
         if stderr is not None:
             payload["stderr_sample"] = _bounded_text(stderr, self.repo_root)
         if request is not None:
-            payload["request"] = _json_document(request, context="contract evidence request")
+            payload["request"] = _bounded_json_document(
+                request,
+                context="contract evidence request",
+                repo_root=self.repo_root,
+            )
         if result is not None:
-            payload["result"] = _json_document(result, context="contract evidence result")
+            payload["result"] = _bounded_json_document(
+                result,
+                context="contract evidence result",
+                repo_root=self.repo_root,
+            )
         if facts is not None:
-            payload["facts"] = _json_document(facts, context="contract evidence facts")
+            payload["facts"] = _bounded_json_document(
+                facts,
+                context="contract evidence facts",
+                repo_root=self.repo_root,
+            )
         return payload
 
 
@@ -137,6 +151,40 @@ def _json_document(value: Mapping[str, JSONValue], *, context: str) -> JSONDocum
     return require_json_document(dict(value), context=context)
 
 
+def _bounded_json_document(
+    value: Mapping[str, JSONValue],
+    *,
+    context: str,
+    repo_root: Path,
+) -> JSONDocument:
+    document = _redacted_json_document(_json_document(value, context=context), repo_root)
+    encoded = json.dumps(document, sort_keys=True, ensure_ascii=False)
+    encoded_bytes = encoded.encode("utf-8")
+    if len(encoded_bytes) <= _MAX_JSON_DOCUMENT_BYTES:
+        return document
+    return {
+        "truncated": True,
+        "original_bytes": len(encoded_bytes),
+        "sample_json": _bounded_text(encoded, repo_root),
+    }
+
+
+def _redacted_json_document(document: JSONDocument, repo_root: Path) -> JSONDocument:
+    redacted = _redacted_json_value(document, repo_root)
+    assert isinstance(redacted, dict)
+    return redacted
+
+
+def _redacted_json_value(value: JSONValue, repo_root: Path) -> JSONValue:
+    if isinstance(value, str):
+        return _redact_text(value, repo_root)
+    if isinstance(value, list):
+        return [_redacted_json_value(item, repo_root) for item in value]
+    if isinstance(value, dict):
+        return {key: _redacted_json_value(item, repo_root) for key, item in value.items()}
+    return value
+
+
 def _bounded_text(text: str, repo_root: Path) -> str:
     redacted = _redact_text(text, repo_root)
     if len(redacted) <= _MAX_SAMPLE_CHARS:
@@ -153,7 +201,8 @@ def _redact_text(text: str, repo_root: Path) -> str:
     for needle, replacement in replacements.items():
         if needle and needle in redacted:
             redacted = redacted.replace(needle, replacement)
-    return _SECRET_ASSIGNMENT_RE.sub(lambda match: f"{match.group(1)}{match.group(2)}<redacted>", redacted)
+    redacted = _SECRET_ASSIGNMENT_RE.sub(lambda match: f"{match.group(1)}{match.group(2)}<redacted>", redacted)
+    return _SECRET_FLAG_RE.sub(lambda match: f"{match.group(1)} <redacted>", redacted)
 
 
 def _git_sha(repo_root: Path) -> str:

--- a/tests/infra/contract_evidence.py
+++ b/tests/infra/contract_evidence.py
@@ -1,0 +1,187 @@
+"""Pytest fixture for bounded contract evidence artifacts.
+
+Contract tests remain ordinary pytest assertions.  This fixture only records a
+small, privacy-bounded artifact after the assertion boundary so reports can
+summarize what was exercised without re-running a parallel proof layer.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import subprocess
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from polylogue.core.json import JSONDocument, JSONValue, require_json_document
+
+_DEFAULT_EVIDENCE_DIR = Path(".cache/verification/evidence")
+_MAX_SAMPLE_CHARS = 2000
+_SECRET_ASSIGNMENT_RE = re.compile(r"(?i)(token|secret|api[_-]?key|password)(=|:)\S+")
+_UNSAFE_FILENAME_RE = re.compile(r"[^a-zA-Z0-9._-]+")
+
+
+@dataclass(frozen=True, slots=True)
+class ContractEvidenceRecorder:
+    """Record bounded evidence for one pytest contract node."""
+
+    nodeid: str
+    repo_root: Path
+    record_property: Callable[[str, object], None]
+
+    def record(
+        self,
+        contract_id: str,
+        *,
+        surface: str,
+        command: Sequence[str] | None = None,
+        request: Mapping[str, JSONValue] | None = None,
+        result: Mapping[str, JSONValue] | None = None,
+        facts: Mapping[str, JSONValue] | None = None,
+        stdout: str | None = None,
+        stderr: str | None = None,
+        exit_code: int | None = None,
+    ) -> Path:
+        """Write one evidence artifact and expose its path to pytest reports."""
+        artifact_dir = _evidence_dir()
+        artifact_dir.mkdir(parents=True, exist_ok=True)
+        artifact_path = artifact_dir / _artifact_filename(self.nodeid, contract_id)
+        payload = self._payload(
+            contract_id=contract_id,
+            surface=surface,
+            command=command,
+            request=request,
+            result=result,
+            facts=facts,
+            stdout=stdout,
+            stderr=stderr,
+            exit_code=exit_code,
+        )
+        artifact_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+        self.record_property("polylogue_contract_id", contract_id)
+        self.record_property("polylogue_contract_surface", surface)
+        self.record_property("polylogue_contract_evidence", str(artifact_path))
+        return artifact_path
+
+    def _payload(
+        self,
+        *,
+        contract_id: str,
+        surface: str,
+        command: Sequence[str] | None,
+        request: Mapping[str, JSONValue] | None,
+        result: Mapping[str, JSONValue] | None,
+        facts: Mapping[str, JSONValue] | None,
+        stdout: str | None,
+        stderr: str | None,
+        exit_code: int | None,
+    ) -> JSONDocument:
+        payload: JSONDocument = {
+            "schema_version": 1,
+            "contract": contract_id,
+            "surface": surface,
+            "test_nodeid": self.nodeid,
+            "timestamp": datetime.now(tz=timezone.utc).isoformat(),
+            "git_sha": _git_sha(self.repo_root),
+            "dirty": _git_dirty(self.repo_root),
+        }
+        if command is not None:
+            payload["command"] = [_redact_text(str(part), self.repo_root) for part in command]
+        if exit_code is not None:
+            payload["exit_code"] = exit_code
+        if stdout is not None:
+            payload["stdout_sample"] = _bounded_text(stdout, self.repo_root)
+        if stderr is not None:
+            payload["stderr_sample"] = _bounded_text(stderr, self.repo_root)
+        if request is not None:
+            payload["request"] = _json_document(request, context="contract evidence request")
+        if result is not None:
+            payload["result"] = _json_document(result, context="contract evidence result")
+        if facts is not None:
+            payload["facts"] = _json_document(facts, context="contract evidence facts")
+        return payload
+
+
+@pytest.fixture
+def record_contract_evidence(
+    request: pytest.FixtureRequest,
+    record_property: Callable[[str, object], None],
+) -> ContractEvidenceRecorder:
+    """Return a recorder for explicit contract-test artifacts."""
+    return ContractEvidenceRecorder(
+        nodeid=request.node.nodeid,
+        repo_root=Path(str(request.config.rootpath)),
+        record_property=record_property,
+    )
+
+
+def _evidence_dir() -> Path:
+    configured = os.environ.get("POLYLOGUE_CONTRACT_EVIDENCE_DIR")
+    return Path(configured) if configured else _DEFAULT_EVIDENCE_DIR
+
+
+def _artifact_filename(nodeid: str, contract_id: str) -> str:
+    slug = _UNSAFE_FILENAME_RE.sub("-", contract_id).strip("-") or "contract"
+    digest = hashlib.sha256(f"{nodeid}\0{contract_id}".encode()).hexdigest()[:16]
+    return f"{slug}-{digest}.json"
+
+
+def _json_document(value: Mapping[str, JSONValue], *, context: str) -> JSONDocument:
+    return require_json_document(dict(value), context=context)
+
+
+def _bounded_text(text: str, repo_root: Path) -> str:
+    redacted = _redact_text(text, repo_root)
+    if len(redacted) <= _MAX_SAMPLE_CHARS:
+        return redacted
+    return f"{redacted[:_MAX_SAMPLE_CHARS]}...<truncated {len(redacted) - _MAX_SAMPLE_CHARS} chars>"
+
+
+def _redact_text(text: str, repo_root: Path) -> str:
+    redacted = text
+    replacements = {
+        str(repo_root): "<repo>",
+        str(Path.home()): "<home>",
+    }
+    for needle, replacement in replacements.items():
+        if needle and needle in redacted:
+            redacted = redacted.replace(needle, replacement)
+    return _SECRET_ASSIGNMENT_RE.sub(lambda match: f"{match.group(1)}{match.group(2)}<redacted>", redacted)
+
+
+def _git_sha(repo_root: Path) -> str:
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=repo_root,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return "unknown"
+    return result.stdout.strip()
+
+
+def _git_dirty(repo_root: Path) -> bool:
+    try:
+        result = subprocess.run(
+            ["git", "status", "--porcelain"],
+            cwd=repo_root,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return True
+    return bool(result.stdout.strip())
+
+
+__all__ = ["ContractEvidenceRecorder", "record_contract_evidence"]

--- a/tests/infra/test_contract_evidence.py
+++ b/tests/infra/test_contract_evidence.py
@@ -44,7 +44,7 @@ def test_record_contract_evidence_writes_bounded_json(
     payload = _load_json(path)
     assert payload["contract"] == "cli.json_envelope"
     assert payload["surface"] == "cli"
-    assert payload["command"] == ["polylogue", "tags", "--format", "json"]
+    assert payload["command"] == "polylogue tags --format json"
     assert payload["exit_code"] == 0
     assert payload["stdout_sample"] == '{"status":"ok","result":{"tags":[]}}'
     assert payload["facts"] == {"parsed_json_status": "ok"}
@@ -78,6 +78,53 @@ def test_record_contract_evidence_redacts_paths_and_secrets(
     assert "token=<redacted>" in combined
     assert "secret:<redacted>" in combined
     assert "api_key=<redacted>" in combined
+
+
+@pytest.mark.contract
+def test_record_contract_evidence_redacts_command_flag_values(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    record_contract_evidence: ContractEvidenceRecorder,
+) -> None:
+    monkeypatch.setenv("POLYLOGUE_CONTRACT_EVIDENCE_DIR", str(tmp_path))
+
+    path = record_contract_evidence.record(
+        "cli.secret_flag",
+        surface="cli",
+        command=("polylogue", "sync", "--api-key", "abc123", "--token=def456"),
+    )
+
+    payload = _load_json(path)
+    command = _json_str(payload, "command")
+    assert "abc123" not in command
+    assert "def456" not in command
+    assert "--api-key <redacted>" in command
+    assert "--token <redacted>" in command
+
+
+@pytest.mark.contract
+def test_record_contract_evidence_bounds_large_json_payloads(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    record_contract_evidence: ContractEvidenceRecorder,
+) -> None:
+    monkeypatch.setenv("POLYLOGUE_CONTRACT_EVIDENCE_DIR", str(tmp_path))
+
+    path = record_contract_evidence.record(
+        "api.large_result",
+        surface="api",
+        result={"blob": "x" * 20_000},
+    )
+
+    payload = _load_json(path)
+    result = payload["result"]
+    assert isinstance(result, dict)
+    assert result["truncated"] is True
+    original_bytes = result["original_bytes"]
+    assert isinstance(original_bytes, int)
+    assert original_bytes > 8192
+    assert isinstance(result["sample_json"], str)
+    assert len(result["sample_json"]) < 3000
 
 
 @pytest.mark.contract

--- a/tests/infra/test_contract_evidence.py
+++ b/tests/infra/test_contract_evidence.py
@@ -1,0 +1,120 @@
+"""Tests for bounded pytest contract evidence artifacts."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from polylogue.core.json import JSONDocument, JSONValue, require_json_document
+from tests.infra.contract_evidence import ContractEvidenceRecorder
+
+
+def _load_json(path: Path) -> JSONDocument:
+    return require_json_document(json.loads(path.read_text(encoding="utf-8")), context="contract evidence artifact")
+
+
+def _json_str(payload: JSONDocument, key: str) -> str:
+    value = payload[key]
+    assert isinstance(value, str)
+    return value
+
+
+@pytest.mark.contract
+def test_record_contract_evidence_writes_bounded_json(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    record_contract_evidence: ContractEvidenceRecorder,
+) -> None:
+    monkeypatch.setenv("POLYLOGUE_CONTRACT_EVIDENCE_DIR", str(tmp_path))
+
+    path = record_contract_evidence.record(
+        "cli.json_envelope",
+        surface="cli",
+        command=("polylogue", "tags", "--format", "json"),
+        exit_code=0,
+        stdout='{"status":"ok","result":{"tags":[]}}',
+        stderr="",
+        facts={"parsed_json_status": "ok"},
+    )
+
+    payload = _load_json(path)
+    assert payload["contract"] == "cli.json_envelope"
+    assert payload["surface"] == "cli"
+    assert payload["command"] == ["polylogue", "tags", "--format", "json"]
+    assert payload["exit_code"] == 0
+    assert payload["stdout_sample"] == '{"status":"ok","result":{"tags":[]}}'
+    assert payload["facts"] == {"parsed_json_status": "ok"}
+    assert _json_str(payload, "test_nodeid").endswith("test_record_contract_evidence_writes_bounded_json")
+
+
+@pytest.mark.contract
+def test_record_contract_evidence_redacts_paths_and_secrets(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    record_contract_evidence: ContractEvidenceRecorder,
+) -> None:
+    monkeypatch.setenv("POLYLOGUE_CONTRACT_EVIDENCE_DIR", str(tmp_path))
+    secret_output = f"path={Path.cwd()} token=super-secret api_key=abc123"
+
+    path = record_contract_evidence.record(
+        "cli.error_privacy",
+        surface="cli",
+        stdout=secret_output,
+        stderr=f"secret:abc123 home={Path.home()}",
+    )
+
+    payload = _load_json(path)
+    combined = f"{payload['stdout_sample']} {payload['stderr_sample']}"
+    assert str(Path.cwd()) not in combined
+    assert str(Path.home()) not in combined
+    assert "super-secret" not in combined
+    assert "abc123" not in combined
+    assert "<repo>" in combined
+    assert "<home>" in combined
+    assert "token=<redacted>" in combined
+    assert "secret:<redacted>" in combined
+    assert "api_key=<redacted>" in combined
+
+
+@pytest.mark.contract
+def test_record_contract_evidence_rejects_non_json_fact_values(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    record_contract_evidence: ContractEvidenceRecorder,
+) -> None:
+    monkeypatch.setenv("POLYLOGUE_CONTRACT_EVIDENCE_DIR", str(tmp_path))
+    bad_facts = cast(Mapping[str, JSONValue], {"path": tmp_path})
+
+    with pytest.raises(TypeError, match="contract evidence facts"):
+        record_contract_evidence.record(
+            "bad.fact",
+            surface="cli",
+            facts=bad_facts,
+        )
+
+
+def test_contract_evidence_recorder_records_pytest_properties(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("POLYLOGUE_CONTRACT_EVIDENCE_DIR", str(tmp_path))
+    properties: dict[str, object] = {}
+
+    def record_property(name: str, value: object) -> None:
+        properties[name] = value
+
+    recorder = ContractEvidenceRecorder(
+        nodeid="tests/unit/example.py::test_example",
+        repo_root=Path.cwd(),
+        record_property=record_property,
+    )
+    path = recorder.record("api.query_parity", surface="api", facts={"ids": ["conv-1"]})
+
+    assert path.exists()
+    assert properties["polylogue_contract_id"] == "api.query_parity"
+    assert properties["polylogue_contract_surface"] == "api"
+    assert isinstance(properties["polylogue_contract_evidence"], str)

--- a/tests/unit/cli/test_check_runtime.py
+++ b/tests/unit/cli/test_check_runtime.py
@@ -15,7 +15,6 @@ Validates readiness checks for the runtime environment, including:
 from __future__ import annotations
 
 import importlib
-import os
 import sqlite3
 from pathlib import Path
 
@@ -338,9 +337,10 @@ class TestRuntimeReadinessCheckResults:
 class TestRuntimeHealthReadOnlyPaths:
     """Tests for runtime readiness with read-only or inaccessible paths."""
 
-    @pytest.mark.skipif(os.name == "nt", reason="Unix-specific permission testing")
     def test_runtime_health_with_readonly_archive_root(self, tmp_path: Path) -> None:
         """Runtime health detects read-only archive_root."""
+        pytest.importorskip("pwd", reason="Unix-specific permission testing")
+
         archive_root = tmp_path / "archive"
         archive_root.mkdir(parents=True, exist_ok=True)
 

--- a/tests/unit/cli/test_command_aux_runtime.py
+++ b/tests/unit/cli/test_command_aux_runtime.py
@@ -199,7 +199,7 @@ def cli_runner() -> CliRunner:
 
 @pytest.mark.xfail(
     reason="provider-aware empty hint and Rich table renderer in tags command not yet implemented (#1012)",
-    strict=False,
+    strict=True,
 )
 def test_tags_command_plain_paths_cover_empty_hint_and_tabular_counts(cli_runner: CliRunner) -> None:
     env = MagicMock()

--- a/tests/unit/cli/test_ingest.py
+++ b/tests/unit/cli/test_ingest.py
@@ -2,6 +2,12 @@
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
+from typing import Any, cast
+from unittest.mock import patch
+from urllib.request import Request
+
 
 def test_ingest_command_registered() -> None:
     """ingest command must be available in the CLI group."""
@@ -23,3 +29,68 @@ def test_ingest_help_includes_inbox_info() -> None:
     assert "daemon" in result.output.lower() or "polylogued" in result.output.lower(), (
         "ingest help should reference the daemon"
     )
+
+
+class _FakeDaemonResponse:
+    def __init__(self, payload: dict[str, object]) -> None:
+        self._payload = payload
+
+    def __enter__(self) -> _FakeDaemonResponse:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return json.dumps(self._payload).encode("utf-8")
+
+
+def test_ingest_command_stages_local_path_before_daemon_request(
+    workspace_env: dict[str, Path],
+    tmp_path: Path,
+) -> None:
+    """CLI owns arbitrary local path reads; HTTP daemon receives inbox path."""
+    from click.testing import CliRunner
+
+    from polylogue.cli.click_app import cli
+
+    source = tmp_path / "source.jsonl"
+    source.write_text('{"type":"session"}\n')
+
+    captured: dict[str, Any] = {}
+
+    def fake_urlopen(req: Request, timeout: int) -> _FakeDaemonResponse:
+        captured["request"] = req
+        captured["timeout"] = timeout
+        assert req.data is not None
+        request_data = cast("bytes", req.data)
+        staged_path = json.loads(request_data.decode("utf-8"))["path"]
+        return _FakeDaemonResponse(
+            {
+                "ok": True,
+                "operation_id": "ingest-source.jsonl",
+                "kind": "import",
+                "status": "pending",
+                "path": staged_path,
+                "message": "scheduled",
+            }
+        )
+
+    runner = CliRunner()
+    with patch("polylogue.cli.commands.ingest.urlopen", side_effect=fake_urlopen):
+        result = runner.invoke(
+            cli,
+            ["ingest", str(source), "--daemon-url", "http://127.0.0.1:8766"],
+        )
+
+    assert result.exit_code == 0, result.output
+    staged = workspace_env["archive_root"] / "inbox" / source.name
+    assert staged.read_text() == source.read_text()
+
+    request = cast("Request", captured["request"])
+    assert request.data is not None
+    request_data = cast("bytes", request.data)
+    body = json.loads(request_data.decode("utf-8"))
+    assert body == {"path": str(staged)}
+    assert body["path"] != str(source)
+    assert captured["timeout"] == 5

--- a/tests/unit/cli/test_json_envelope_contract.py
+++ b/tests/unit/cli/test_json_envelope_contract.py
@@ -23,6 +23,7 @@ from polylogue.cli.shared.machine_errors import (
     success,
 )
 from polylogue.core.json import JSONDocument
+from tests.infra.contract_evidence import ContractEvidenceRecorder
 from tests.infra.json_contracts import envelope_result, extract_json_object, json_object_field, parse_json_object
 
 pytestmark = pytest.mark.machine_contract
@@ -118,16 +119,25 @@ class TestQueryShapedJsonMatrix:
             (["schema", "list", "--format", "json"], "providers"),
         ],
     )
+    @pytest.mark.contract
     def test_format_json_uses_success_envelope(
         self,
         args: list[str],
         result_key: str,
         monkeypatch: pytest.MonkeyPatch,
+        record_contract_evidence: ContractEvidenceRecorder,
     ) -> None:
         parsed = _invoke_json_command(args, monkeypatch)
         assert parsed is not None
         assert parsed["status"] == "ok"
         assert result_key in envelope_result(parsed, context="format json envelope")
+        record_contract_evidence.record(
+            "cli.json_envelope",
+            surface="cli",
+            command=("polylogue", *args),
+            result=parsed,
+            facts={"result_key": result_key, "status": "ok"},
+        )
 
     @pytest.mark.parametrize(
         "args",

--- a/tests/unit/cli/test_query_exec_laws.py
+++ b/tests/unit/cli/test_query_exec_laws.py
@@ -431,10 +431,6 @@ def _summary_group_key(spec: ConversationSummarySpec, dimension: str) -> str:
     return "all"
 
 
-@pytest.mark.xfail(
-    reason="strategy-built summaries are not seeded into the polylogue env, so add_tag raises ConversationNotFoundError (#1012)",
-    strict=False,
-)
 @settings(max_examples=60, deadline=None)
 @given(case=query_mutation_case_strategy())
 def test_apply_modifiers_contract(case: QueryMutationCase) -> None:

--- a/tests/unit/cli/test_terminal_snapshots.py
+++ b/tests/unit/cli/test_terminal_snapshots.py
@@ -15,11 +15,9 @@ from __future__ import annotations
 import pytest
 
 syrupy = pytest.importorskip("syrupy")
+pytest.importorskip("pyte", reason="pyte not installed")
 
-from tests.infra.pty_cli import HAS_PYTE, grid_to_text, run_in_pty, sanitize_grid
-
-# Mark all tests as requiring pyte
-pytestmark = pytest.mark.skipif(not HAS_PYTE, reason="pyte not installed")
+from tests.infra.pty_cli import grid_to_text, run_in_pty, sanitize_grid
 
 
 class TestHelpOutput:

--- a/tests/unit/core/test_content_projection.py
+++ b/tests/unit/core/test_content_projection.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import pytest
-
 from polylogue.archive.attachment.models import Attachment
 from polylogue.archive.message.roles import Role
 from polylogue.archive.message.types import MessageType
@@ -134,10 +132,6 @@ def test_prose_only_drops_attachment_only_messages() -> None:
     assert list(projected.messages) == []
 
 
-@pytest.mark.xfail(
-    reason="prose_only projection still passes through 4 protocol artifact types; tracked at #839 (semantic storage of protocol artifacts)",
-    strict=False,
-)
 def test_prose_only_drops_claude_code_protocol_artifacts() -> None:
     """``prose_only`` drops messages whose stored ``message_type`` is
     PROTOCOL/CONTEXT/TOOL_RESULT and rewrites leading

--- a/tests/unit/daemon/test_backup.py
+++ b/tests/unit/daemon/test_backup.py
@@ -32,6 +32,7 @@ def test_backup_archive_copy_can_be_opened_and_queried(
     assert backup_path.exists()
     with open_read_connection(backup_path) as conn:
         integrity = conn.execute("PRAGMA integrity_check").fetchone()[0]
+        assert integrity == "ok"
         conversation_count = conn.execute(
             "SELECT COUNT(*) FROM conversations WHERE conversation_id = ?",
             ("backup-conv",),
@@ -41,7 +42,6 @@ def test_backup_archive_copy_can_be_opened_and_queried(
             ("backup-conv",),
         ).fetchone()[0]
 
-    assert integrity == "ok"
     assert conversation_count == 1
     assert message_count == 1
     record_contract_evidence.record(

--- a/tests/unit/daemon/test_backup.py
+++ b/tests/unit/daemon/test_backup.py
@@ -1,0 +1,63 @@
+"""Backup verification tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from polylogue.daemon.backup import backup_archive
+from polylogue.storage.sqlite.connection import open_read_connection
+from tests.infra.contract_evidence import ContractEvidenceRecorder
+from tests.infra.storage_records import ConversationBuilder, db_setup
+
+
+@pytest.mark.contract
+def test_backup_archive_copy_can_be_opened_and_queried(
+    workspace_env: dict[str, Path],
+    tmp_path: Path,
+    record_contract_evidence: ContractEvidenceRecorder,
+) -> None:
+    db_path = db_setup(workspace_env)
+    ConversationBuilder(db_path, "backup-conv").provider("claude-code").add_message(
+        role="user",
+        text="backup restore smoke",
+    ).save()
+
+    result = backup_archive(output_dir=tmp_path / "backups")
+
+    assert result.ok
+    assert result.output_path is not None
+    backup_path = Path(result.output_path)
+    assert backup_path.exists()
+    with open_read_connection(backup_path) as conn:
+        integrity = conn.execute("PRAGMA integrity_check").fetchone()[0]
+        conversation_count = conn.execute(
+            "SELECT COUNT(*) FROM conversations WHERE conversation_id = ?",
+            ("backup-conv",),
+        ).fetchone()[0]
+        message_count = conn.execute(
+            "SELECT COUNT(*) FROM messages WHERE conversation_id = ?",
+            ("backup-conv",),
+        ).fetchone()[0]
+
+    assert integrity == "ok"
+    assert conversation_count == 1
+    assert message_count == 1
+    record_contract_evidence.record(
+        "daemon.backup_restore.read",
+        surface="daemon",
+        result={
+            "ok": result.ok,
+            "backup_filename": backup_path.name,
+            "db_size_bytes": result.db_size_bytes,
+            "blob_count": result.blob_count,
+            "warning_count": len(result.warnings),
+        },
+        facts={
+            "integrity_check": integrity,
+            "conversation_count": conversation_count,
+            "message_count": message_count,
+            "restore_query_ok": conversation_count == 1 and message_count == 1,
+        },
+    )

--- a/tests/unit/daemon/test_daemon_cli.py
+++ b/tests/unit/daemon/test_daemon_cli.py
@@ -137,7 +137,7 @@ def test_drain_convergence_debt_retries_due_items_without_source_failure(
             "debt_before": len(debt_before),
             "retried": retried,
             "debt_after": len(debt_after),
-            "cursor_record_remaining": cursor.get_record(source) is not None,
+            "cursor_record_cleared": cursor.get_record(source) is None,
         },
     )
 

--- a/tests/unit/daemon/test_daemon_cli.py
+++ b/tests/unit/daemon/test_daemon_cli.py
@@ -16,6 +16,7 @@ from polylogue.daemon.cli import main
 from polylogue.daemon.convergence import ConvergenceStage
 from polylogue.sources.live import WatchSource
 from polylogue.sources.live.cursor import CursorStore
+from tests.infra.contract_evidence import ContractEvidenceRecorder
 
 
 def test_polylogued_help_lists_watch_command() -> None:
@@ -29,7 +30,11 @@ def test_polylogued_help_lists_watch_command() -> None:
     assert "long-lived Polylogue local services" in result.output
 
 
-def test_polylogued_status_json_reports_daemon_components(tmp_path: Path) -> None:
+@pytest.mark.contract
+def test_polylogued_status_json_reports_daemon_components(
+    tmp_path: Path,
+    record_contract_evidence: ContractEvidenceRecorder,
+) -> None:
     sources = (
         WatchSource(name="exists", root=tmp_path),
         WatchSource(name="missing", root=tmp_path / "missing"),
@@ -56,6 +61,19 @@ def test_polylogued_status_json_reports_daemon_components(tmp_path: Path) -> Non
     assert live["source_count"] == 2
     assert live["existing_source_count"] == 1
     assert browser_capture["spool_path"] == str(tmp_path / "captures")
+    record_contract_evidence.record(
+        "daemon.status.json",
+        surface="daemon",
+        command=("polylogued", "status", "--spool", "<tmp>/captures", "--format", "json"),
+        result=payload,
+        exit_code=result.exit_code,
+        stdout=result.output,
+        facts={
+            "source_count": live["source_count"],
+            "existing_source_count": live["existing_source_count"],
+            "browser_capture_spool_reported": bool(browser_capture["spool_path"]),
+        },
+    )
 
 
 def test_polylogued_status_plain_reports_daemon_components(tmp_path: Path) -> None:
@@ -71,7 +89,11 @@ def test_polylogued_status_plain_reports_daemon_components(tmp_path: Path) -> No
     assert "Browser capture spool:" in result.output
 
 
-def test_drain_convergence_debt_retries_due_items_without_source_failure(tmp_path: Path) -> None:
+@pytest.mark.contract
+def test_drain_convergence_debt_retries_due_items_without_source_failure(
+    tmp_path: Path,
+    record_contract_evidence: ContractEvidenceRecorder,
+) -> None:
     from polylogue.daemon import cli as daemon_cli
 
     db = tmp_path / "polylogue.db"
@@ -96,14 +118,35 @@ def test_drain_convergence_debt_retries_due_items_without_source_failure(tmp_pat
         execute=lambda candidate: candidate == source,
     )
     with patch("polylogue.daemon.convergence_stages.make_default_convergence_stages", return_value=(stage,)):
+        debt_before = cursor.list_convergence_debt()
         retried = daemon_cli._drain_convergence_debt_once(db)
+        debt_after = cursor.list_convergence_debt()
 
     assert retried == 1
-    assert cursor.list_convergence_debt() == []
+    assert debt_after == []
     assert cursor.get_record(source) is None
+    record_contract_evidence.record(
+        "daemon.convergence_debt.source_retry",
+        surface="daemon",
+        request={
+            "stage": "insights",
+            "subject_type": "source_path",
+            "subject_exists": True,
+        },
+        facts={
+            "debt_before": len(debt_before),
+            "retried": retried,
+            "debt_after": len(debt_after),
+            "cursor_record_remaining": cursor.get_record(source) is not None,
+        },
+    )
 
 
-def test_drain_convergence_debt_retries_conversation_subjects_without_source_lookup(tmp_path: Path) -> None:
+@pytest.mark.contract
+def test_drain_convergence_debt_retries_conversation_subjects_without_source_lookup(
+    tmp_path: Path,
+    record_contract_evidence: ContractEvidenceRecorder,
+) -> None:
     from polylogue.daemon import cli as daemon_cli
 
     db = tmp_path / "polylogue.db"
@@ -128,10 +171,26 @@ def test_drain_convergence_debt_retries_conversation_subjects_without_source_loo
         execute_conversations=lambda conversation_ids: tuple(conversation_ids) == ("conv-1",),
     )
     with patch("polylogue.daemon.convergence_stages.make_default_convergence_stages", return_value=(stage,)):
+        debt_before = cursor.list_convergence_debt()
         retried = daemon_cli._drain_convergence_debt_once(db)
+        debt_after = cursor.list_convergence_debt()
 
     assert retried == 1
-    assert cursor.list_convergence_debt() == []
+    assert debt_after == []
+    record_contract_evidence.record(
+        "daemon.convergence_debt.conversation_retry",
+        surface="daemon",
+        request={
+            "stage": "insights",
+            "subject_type": "conversation_id",
+            "source_lookup_required": False,
+        },
+        facts={
+            "debt_before": len(debt_before),
+            "retried": retried,
+            "debt_after": len(debt_after),
+        },
+    )
 
 
 def test_polylogued_browser_capture_help_lists_service_commands() -> None:

--- a/tests/unit/daemon/test_daemon_http_security.py
+++ b/tests/unit/daemon/test_daemon_http_security.py
@@ -19,9 +19,11 @@ of adding a new endpoint includes adding it to ``ENDPOINTS_GET`` /
 
 from __future__ import annotations
 
+import json
 from email.message import Message
 from http import HTTPStatus
 from io import BytesIO
+from pathlib import Path
 from typing import TYPE_CHECKING, cast
 from unittest.mock import MagicMock, patch
 
@@ -334,6 +336,65 @@ class TestPostEndpointAuthAndOriginGate:
         send_error, _ = _capture_responses(handler)
         handler.do_POST()
         send_error.assert_called_once_with(HTTPStatus.FORBIDDEN, "cross_origin_denied")
+
+
+# ---------------------------------------------------------------------------
+# Ingest endpoint — arbitrary local paths are staged by clients, not copied
+# by the daemon from HTTP request data.
+# ---------------------------------------------------------------------------
+
+
+class TestIngestEndpointInboxBoundary:
+    """``POST /api/ingest`` schedules already-staged inbox artifacts only."""
+
+    def test_accepts_absolute_reference_only_by_matching_inbox_entry(
+        self,
+        workspace_env: dict[str, Path],
+    ) -> None:
+        inbox = workspace_env["archive_root"] / "inbox"
+        inbox.mkdir(parents=True)
+        staged = inbox / "session.jsonl"
+        staged.write_text('{"type":"session"}\n')
+
+        body = json.dumps({"path": "/outside/tree/session.jsonl"}).encode("utf-8")
+        handler = _make_handler("POST", "/api/ingest", auth_header="Bearer secret", body=body)
+        send_error, send_json = _capture_responses(handler)
+
+        with (
+            patch("polylogue.paths.archive_root", return_value=workspace_env["archive_root"]),
+            patch("polylogue.daemon.http.emit_daemon_event") as emit_event,
+        ):
+            handler.do_POST()
+
+        send_error.assert_not_called()
+        send_json.assert_called_once()
+        assert send_json.call_args.args[0] == HTTPStatus.ACCEPTED
+        payload = send_json.call_args.args[1]
+        assert payload["path"] == str(staged.resolve())
+        emit_event.assert_called_once()
+        assert emit_event.call_args.kwargs["payload"]["path"] == str(staged.resolve())
+
+    def test_rejects_unstaged_absolute_local_path(
+        self,
+        workspace_env: dict[str, Path],
+        tmp_path: Path,
+    ) -> None:
+        outside = tmp_path / "session.jsonl"
+        outside.write_text('{"type":"session"}\n')
+
+        body = json.dumps({"path": str(outside)}).encode("utf-8")
+        handler = _make_handler("POST", "/api/ingest", auth_header="Bearer secret", body=body)
+        send_error, send_json = _capture_responses(handler)
+
+        with (
+            patch("polylogue.paths.archive_root", return_value=workspace_env["archive_root"]),
+            patch("polylogue.daemon.http.emit_daemon_event") as emit_event,
+        ):
+            handler.do_POST()
+
+        send_error.assert_called_once_with(HTTPStatus.BAD_REQUEST, "path_not_found")
+        send_json.assert_not_called()
+        emit_event.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/daemon/test_health_contracts.py
+++ b/tests/unit/daemon/test_health_contracts.py
@@ -1,0 +1,63 @@
+"""Daemon health aggregation contract tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from polylogue.core.json import JSONValue
+from polylogue.daemon import health as health_module
+from polylogue.daemon.health import HealthAlert, HealthSeverity, HealthTier, check_health
+from tests.infra.contract_evidence import ContractEvidenceRecorder
+
+
+def _alert(name: str, tier: HealthTier, severity: HealthSeverity) -> HealthAlert:
+    return HealthAlert(
+        check_name=name,
+        tier=tier,
+        severity=severity,
+        message=f"{name} {severity.value}",
+        checked_at="2026-05-15T00:00:00+00:00",
+        consecutive_failures=1 if severity != HealthSeverity.OK else 0,
+    )
+
+
+@pytest.mark.contract
+def test_check_health_aggregates_requested_tiers_and_worst_status(
+    monkeypatch: pytest.MonkeyPatch,
+    record_contract_evidence: ContractEvidenceRecorder,
+) -> None:
+    fast_alerts = [
+        _alert("daemon_liveness", HealthTier.FAST, HealthSeverity.OK),
+        _alert("wal_size", HealthTier.FAST, HealthSeverity.WARNING),
+    ]
+    medium_alerts = [_alert("raw_failures", HealthTier.MEDIUM, HealthSeverity.ERROR)]
+    expensive_alerts = [_alert("db_integrity", HealthTier.EXPENSIVE, HealthSeverity.CRITICAL)]
+
+    monkeypatch.setattr(health_module, "_run_fast_checks", lambda: fast_alerts)
+    monkeypatch.setattr(health_module, "_run_medium_checks", lambda: medium_alerts)
+    monkeypatch.setattr(health_module, "_run_expensive_checks", lambda: expensive_alerts)
+
+    health = check_health(tiers={HealthTier.FAST, HealthTier.MEDIUM})
+
+    assert health.overall_status == HealthSeverity.ERROR
+    assert [alert.check_name for alert in health.alerts] == ["daemon_liveness", "wal_size", "raw_failures"]
+    assert health.tier_summary == {
+        "fast": {"ok": 1, "warning": 1, "error": 0, "critical": 0},
+        "medium": {"ok": 0, "warning": 0, "error": 1, "critical": 0},
+    }
+    severities: list[JSONValue] = [alert.severity.value for alert in health.alerts]
+    tier_summary: dict[str, JSONValue] = {tier: dict(counts) for tier, counts in health.tier_summary.items()}
+    record_contract_evidence.record(
+        "daemon.health.aggregate",
+        surface="daemon",
+        request={"tiers": [HealthTier.FAST.value, HealthTier.MEDIUM.value]},
+        result={
+            "overall_status": health.overall_status.value,
+            "alert_count": len(health.alerts),
+            "tier_summary": tier_summary,
+        },
+        facts={
+            "expensive_tier_excluded": all(alert.tier != HealthTier.EXPENSIVE for alert in health.alerts),
+            "severities": severities,
+        },
+    )

--- a/tests/unit/daemon/test_notifications.py
+++ b/tests/unit/daemon/test_notifications.py
@@ -1,0 +1,79 @@
+"""Daemon notification dispatch tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from polylogue.core.json import JSONValue
+from polylogue.daemon.health import HealthAlert, HealthSeverity, HealthTier
+from polylogue.daemon.notifications import send_notifications
+from tests.infra.contract_evidence import ContractEvidenceRecorder
+
+
+class RecordingBackend:
+    def __init__(self) -> None:
+        self.calls: list[tuple[list[HealthAlert], dict[str, object] | None]] = []
+
+    def notify(self, alerts: list[HealthAlert], *, config: dict[str, object] | None = None) -> None:
+        self.calls.append((alerts, config))
+
+
+class FailingBackend:
+    def notify(self, alerts: list[HealthAlert], *, config: dict[str, object] | None = None) -> None:
+        raise RuntimeError("backend unavailable")
+
+
+def _alert(name: str, severity: HealthSeverity) -> HealthAlert:
+    return HealthAlert(
+        check_name=name,
+        tier=HealthTier.FAST,
+        severity=severity,
+        message=f"{name} {severity.value}",
+        checked_at="2026-05-15T00:00:00+00:00",
+        consecutive_failures=1 if severity != HealthSeverity.OK else 0,
+    )
+
+
+@pytest.mark.contract
+def test_send_notifications_routes_alert_batch_to_backend(
+    record_contract_evidence: ContractEvidenceRecorder,
+) -> None:
+    backend = RecordingBackend()
+    config: dict[str, object] = {"notification_backend": "recording", "health_check_interval_s": 30}
+    alerts = [
+        _alert("daemon_liveness", HealthSeverity.OK),
+        _alert("wal_size", HealthSeverity.WARNING),
+        _alert("schema_version", HealthSeverity.CRITICAL),
+    ]
+
+    send_notifications(alerts, backend=backend, config=config)
+
+    assert len(backend.calls) == 1
+    delivered_alerts, delivered_config = backend.calls[0]
+    assert delivered_alerts == alerts
+    assert delivered_config == config
+    severities: list[JSONValue] = [alert.severity.value for alert in delivered_alerts]
+    record_contract_evidence.record(
+        "daemon.notifications.dispatch",
+        surface="daemon",
+        request={
+            "backend": "recording",
+            "alert_count": len(alerts),
+            "severities": severities,
+        },
+        facts={
+            "call_count": len(backend.calls),
+            "config_forwarded": delivered_config == config,
+            "delivered_severities": severities,
+        },
+    )
+
+
+def test_send_notifications_rejects_unknown_backend() -> None:
+    with pytest.raises(ValueError, match="unknown notification backend"):
+        send_notifications([_alert("schema_version", HealthSeverity.ERROR)], config={"notification_backend": "smtp"})
+
+
+def test_send_notifications_propagates_backend_failure() -> None:
+    with pytest.raises(RuntimeError, match="backend unavailable"):
+        send_notifications([_alert("schema_version", HealthSeverity.ERROR)], backend=FailingBackend())

--- a/tests/unit/daemon/test_schema_preflight.py
+++ b/tests/unit/daemon/test_schema_preflight.py
@@ -262,7 +262,7 @@ class _StubCursor:
     def __init__(self, db_path: Path) -> None:
         self._db_path = db_path
 
-    def begin_ingest_attempt(self, **kwargs: object) -> str:  # noqa: ANN401
+    def begin_ingest_attempt(self, **kwargs: object) -> str:
         return "attempt-stub"
 
     def update_ingest_attempt(self, *args: object, **kwargs: object) -> None:

--- a/tests/unit/devtools/test_benchmark_campaign.py
+++ b/tests/unit/devtools/test_benchmark_campaign.py
@@ -8,8 +8,6 @@ from typing import Literal
 from pytest import MonkeyPatch
 
 from devtools.benchmark_campaign import (
-    BenchmarkStat,
-    BenchmarkStatRecord,
     CampaignResult,
     Regression,
     _compare_results,
@@ -18,6 +16,7 @@ from devtools.benchmark_campaign import (
     run_campaign,
 )
 from devtools.benchmark_catalog import BenchmarkCampaignEntry
+from devtools.benchmark_results import BenchmarkStat, BenchmarkStatRecord, parse_pytest_benchmark_stats
 from devtools.benchmark_scenario_catalog import (
     BENCHMARK_SCENARIO_INDEX,
     BENCHMARK_SCENARIOS,
@@ -31,6 +30,9 @@ from polylogue.scenarios import (
     ScenarioProjectionSourceKind,
     pytest_execution,
 )
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+PYTEST_BENCHMARK_FIXTURE = REPO_ROOT / "tests" / "data" / "pytest-benchmark" / "reader-status.json"
 
 
 def _benchmark_record(fullname: str, mean: float) -> BenchmarkStatRecord:
@@ -62,6 +64,27 @@ def test_compare_results_orders_regressions_by_worst_delta() -> None:
 
     assert [item.fullname for item in regressions] == ["bench.a", "bench.b"]
     assert regressions[0] == Regression("bench.a", 1.0, 2.0, 100.0)
+
+
+def test_parse_pytest_benchmark_fixture_matches_real_schema() -> None:
+    payload = json.loads(PYTEST_BENCHMARK_FIXTURE.read_text(encoding="utf-8"))
+
+    stats = parse_pytest_benchmark_stats(payload)
+
+    assert stats == [
+        BenchmarkStat(
+            name="test_bench_reader_status",
+            fullname="tests/benchmarks/test_reader_api.py::test_bench_reader_status",
+            group="benchmark",
+            mean=0.0011,
+            median=0.0011,
+            minimum=0.001,
+            maximum=0.0012,
+            stddev=0.0001,
+            rounds=3,
+            ops=1.0 / 0.0011,
+        )
+    ]
 
 
 def test_compare_artifacts_fails_when_threshold_is_exceeded(tmp_path: Path) -> None:

--- a/tests/unit/devtools/test_proof_pack.py
+++ b/tests/unit/devtools/test_proof_pack.py
@@ -24,12 +24,12 @@ def test_proof_pack_reports_diff_shaped_fields() -> None:
     assert report["gate_groups"]["optional_confidence"]
     assert "oracle_mix" in report
     assert "cost_tier" in report
-    assert "agent_judgment_cells" in report
+    assert "manual_review_requirements" in report
     assert "known_gaps" in report
     assert "additional_known_gaps" in report
-    assert "stable_affected_obligations" in report
+    assert "stable_routed_checks" in report
     assert "catalog_quality_checks" in report
-    assert "taxonomy" in report
+    assert "artifact_source_groups" in report
     assert "clean_tree" in report
     assert "_context" in report
 
@@ -48,8 +48,8 @@ def test_proof_pack_markdown_is_pr_comment_ready() -> None:
     assert "### Required Gates (run now)" in rendered
     assert "### Always-On PR Gates" in rendered
     assert "### Confidence Gates (optional)" in rendered
-    assert "### Affected Evidence by Taxonomy" in rendered
-    assert "stable affected obligations" in rendered
+    assert "### Affected Checks by Artifact Source" in rendered
+    assert "stable routed checks" in rendered
 
 
 def test_proof_pack_surfaces_manifest_known_gaps_for_affected_domains() -> None:
@@ -66,7 +66,7 @@ def test_proof_pack_surfaces_manifest_known_gaps_for_affected_domains() -> None:
     assert "docs_media" in gap_domains | additional_gap_domains
 
 
-def test_proof_pack_markdown_has_taxonomy_section() -> None:
+def test_proof_pack_markdown_has_artifact_source_section() -> None:
     report = build_proof_pack(
         Path.cwd(),
         base_ref="origin/master",
@@ -76,13 +76,13 @@ def test_proof_pack_markdown_has_taxonomy_section() -> None:
 
     rendered = render_markdown(report)
 
-    assert "### Affected Evidence by Taxonomy" in rendered
-    assert "executable_behavior" in rendered
-    assert "architectural_static" in rendered
-    assert "metadata_spec" in rendered
+    assert "### Affected Checks by Artifact Source" in rendered
+    assert "pytest_or_command" in rendered
+    assert "static_check" in rendered
+    assert "metadata_or_docs" in rendered
 
 
-def test_proof_pack_markdown_lists_agent_judgment_cells() -> None:
+def test_proof_pack_markdown_lists_manual_review_requirements() -> None:
     report = build_proof_pack(
         Path.cwd(),
         base_ref="origin/master",
@@ -92,7 +92,7 @@ def test_proof_pack_markdown_lists_agent_judgment_cells() -> None:
 
     rendered = render_markdown(report)
 
-    assert "### Agent Judgment Cells" in rendered
+    assert "### Manual Review Requirements" in rendered
     assert "operation.effect.privacy_safe_evidence" in rendered
     assert "artifact `missing`" in rendered
 
@@ -128,7 +128,7 @@ def test_proof_pack_check_policy_blocks_serious_judgment_cells() -> None:
         head_ref="HEAD",
         changed_paths=["docs/plans/layering.yaml"],
     )
-    report["agent_judgment_cells"] = [
+    report["manual_review_requirements"] = [
         {
             "claim_id": "claim.needs.review",
             "oracle": "manual_review",
@@ -156,7 +156,7 @@ def test_proof_pack_check_policy_allows_tracked_judgment_cells() -> None:
         head_ref="HEAD",
         changed_paths=["docs/plans/layering.yaml"],
     )
-    report["agent_judgment_cells"] = [
+    report["manual_review_requirements"] = [
         {
             "claim_id": "claim.tracked.review",
             "oracle": "manual_review",
@@ -183,7 +183,7 @@ def test_proof_pack_check_policy_allows_completed_judgment_artifact() -> None:
         head_ref="HEAD",
         changed_paths=["docs/plans/layering.yaml"],
     )
-    report["agent_judgment_cells"] = [
+    report["manual_review_requirements"] = [
         {
             "claim_id": "claim.reviewed",
             "oracle": "manual_review",
@@ -238,8 +238,8 @@ def test_clean_tree_report_distinguishes_baseline() -> None:
     assert "No changed paths" in str(report.get("_context", ""))
 
 
-def test_proof_pack_taxonomy_groups_are_present_in_report() -> None:
-    """The report should include taxonomy groups with correct structure."""
+def test_proof_pack_artifact_source_groups_are_present_in_report() -> None:
+    """The report should include artifact-source groups with correct structure."""
     report = build_proof_pack(
         Path.cwd(),
         base_ref="origin/master",
@@ -247,8 +247,8 @@ def test_proof_pack_taxonomy_groups_are_present_in_report() -> None:
         changed_paths=["docs/plans/layering.yaml"],
     )
 
-    taxonomy = report["taxonomy"]
-    assert isinstance(taxonomy, dict)
+    groups = report["artifact_source_groups"]
+    assert isinstance(groups, dict)
     for taxonomy_name in (
         "executable_behavior",
         "observability",
@@ -257,19 +257,21 @@ def test_proof_pack_taxonomy_groups_are_present_in_report() -> None:
         "manual_review",
         "advisory",
     ):
-        assert taxonomy_name in taxonomy
-        group = taxonomy[taxonomy_name]
+        assert taxonomy_name in groups
+        group = groups[taxonomy_name]
+        assert "artifact_source" in group
         assert "description" in group
         assert "actionable" in group
-        assert "obligation_count" in group
-        assert "obligations" in group
+        assert "check_count" in group
+        assert "checks" in group
 
-    assert taxonomy["architectural_static"]["obligation_count"] > 0
-    assert taxonomy["architectural_static"]["actionable"] is True
+    assert groups["architectural_static"]["artifact_source"] == "static_check"
+    assert groups["architectural_static"]["check_count"] > 0
+    assert groups["architectural_static"]["actionable"] is True
 
 
-def test_proof_pack_markdown_shows_taxonomy_labels() -> None:
-    """Markdown output should label actionable vs non-blocking taxonomies."""
+def test_proof_pack_markdown_shows_artifact_source_labels() -> None:
+    """Markdown output should label actionable vs non-blocking artifact sources."""
     report = build_proof_pack(
         Path.cwd(),
         base_ref="origin/master",
@@ -279,6 +281,6 @@ def test_proof_pack_markdown_shows_taxonomy_labels() -> None:
 
     rendered = render_markdown(report)
 
-    assert "architectural_static" in rendered
+    assert "static_check" in rendered
     assert "(actionable)" in rendered
     assert "### Known Gaps (tracking, not blocking)" in rendered

--- a/tests/unit/devtools/test_proof_pack.py
+++ b/tests/unit/devtools/test_proof_pack.py
@@ -44,7 +44,7 @@ def test_proof_pack_markdown_is_pr_comment_ready() -> None:
 
     rendered = render_markdown(report)
 
-    assert "## Polylogue Proof Pack" in rendered
+    assert "## Polylogue Verification Impact" in rendered
     assert "### Required Gates (run now)" in rendered
     assert "### Always-On PR Gates" in rendered
     assert "### Confidence Gates (optional)" in rendered

--- a/tests/unit/devtools/test_proof_pack.py
+++ b/tests/unit/devtools/test_proof_pack.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -30,6 +31,7 @@ def test_proof_pack_reports_diff_shaped_fields() -> None:
     assert "stable_routed_checks" in report
     assert "catalog_quality_checks" in report
     assert "artifact_source_groups" in report
+    assert "contract_evidence_artifacts" in report
     assert "clean_tree" in report
     assert "_context" in report
 
@@ -50,6 +52,7 @@ def test_proof_pack_markdown_is_pr_comment_ready() -> None:
     assert "### Confidence Gates (optional)" in rendered
     assert "### Affected Checks by Artifact Source" in rendered
     assert "stable routed checks" in rendered
+    assert "### Contract Evidence Artifacts" in rendered
 
 
 def test_proof_pack_surfaces_manifest_known_gaps_for_affected_domains() -> None:
@@ -95,6 +98,42 @@ def test_proof_pack_markdown_lists_manual_review_requirements() -> None:
     assert "### Manual Review Requirements" in rendered
     assert "operation.effect.privacy_safe_evidence" in rendered
     assert "artifact `missing`" in rendered
+
+
+def test_proof_pack_summarizes_contract_evidence_artifacts(tmp_path: Path) -> None:
+    evidence_dir = tmp_path / ".cache" / "verification" / "evidence"
+    evidence_dir.mkdir(parents=True)
+    (evidence_dir / "cli-json.json").write_text(
+        json.dumps(
+            {
+                "contract": "cli.json.status",
+                "surface": "cli",
+                "test_nodeid": "tests/unit/cli/test_json.py::test_status",
+                "git_sha": "abc123",
+                "dirty": False,
+                "timestamp": "2026-05-15T00:00:00+00:00",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (evidence_dir / "bad.json").write_text("{", encoding="utf-8")
+
+    report = proof_pack.build_proof_pack(
+        tmp_path,
+        base_ref="origin/master",
+        head_ref="HEAD",
+        changed_paths=["docs/plans/layering.yaml"],
+    )
+
+    summary = report["contract_evidence_artifacts"]
+    assert summary["artifact_count"] == 1
+    assert summary["by_surface"] == {"cli": 1}
+    assert summary["artifacts"][0]["contract"] == "cli.json.status"
+    assert summary["artifacts"][0]["path"] == ".cache/verification/evidence/cli-json.json"
+
+    rendered = render_markdown(report)
+    assert "### Contract Evidence Artifacts" in rendered
+    assert "cli.json.status" in rendered
 
 
 def test_proof_pack_check_policy_blocks_catalog_quality_errors() -> None:
@@ -284,3 +323,16 @@ def test_proof_pack_markdown_shows_artifact_source_labels() -> None:
     assert "static_check" in rendered
     assert "(actionable)" in rendered
     assert "### Known Gaps (tracking, not blocking)" in rendered
+
+
+def test_proof_pack_markdown_labels_empty_artifact_source_groups() -> None:
+    report = build_proof_pack(
+        Path.cwd(),
+        base_ref="origin/master",
+        head_ref="HEAD",
+        changed_paths=["tests/unit/cli/test_json_envelope_contract.py"],
+    )
+
+    rendered = render_markdown(report)
+
+    assert "### Affected Checks by Artifact Source\n- no affected checks" in rendered

--- a/tests/unit/devtools/test_slo_catalog.py
+++ b/tests/unit/devtools/test_slo_catalog.py
@@ -243,3 +243,59 @@ surfaces:
     assert payload["catalog_errors"] == [
         "query: invalid gate 'aspirational'; expected one of ['informational', 'required']"
     ]
+
+
+def test_required_surface_with_malformed_budget_is_catalog_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    catalog = _write_slo_catalog(
+        tmp_path,
+        """
+surfaces:
+  reader:
+    description: "Reader endpoint"
+    benchmark_test: "tests/benchmarks/test_reader_api.py::test_reader"
+    p50_ms: "100"
+    gate: "required"
+""",
+    )
+    monkeypatch.setattr(verify_slos, "_run_benchmarks", lambda _ids: {})
+
+    buffer = io.StringIO()
+    with redirect_stdout(buffer):
+        rc = verify_slos.main(["--yaml", str(catalog), "--json"])
+
+    payload = json.loads(buffer.getvalue())
+    assert rc != 0
+    assert payload["blocking"] is True
+    assert payload["catalog_errors"] == ["reader: required surface must declare integer p50_ms and p95_ms"]
+
+
+def test_required_surface_with_malformed_benchmark_test_is_catalog_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    catalog = _write_slo_catalog(
+        tmp_path,
+        """
+surfaces:
+  reader:
+    description: "Reader endpoint"
+    benchmark_test:
+      - "tests/benchmarks/test_reader_api.py::test_reader"
+    p50_ms: 100
+    p95_ms: 200
+    gate: "required"
+""",
+    )
+    monkeypatch.setattr(verify_slos, "_run_benchmarks", lambda _ids: {})
+
+    buffer = io.StringIO()
+    with redirect_stdout(buffer):
+        rc = verify_slos.main(["--yaml", str(catalog), "--json"])
+
+    payload = json.loads(buffer.getvalue())
+    assert rc != 0
+    assert payload["blocking"] is True
+    assert payload["catalog_errors"] == ["reader: required surface must declare benchmark_test (string)"]

--- a/tests/unit/devtools/test_slo_catalog.py
+++ b/tests/unit/devtools/test_slo_catalog.py
@@ -1,7 +1,7 @@
 """Tests for the read-surface SLO catalog and ``devtools verify-slos``.
 
 The catalog at ``docs/plans/slo-catalog.yaml`` lists the SLOs that
-``devtools/verify_slos.py`` consumes. These tests pin three contracts:
+``devtools/verify_slos.py`` consumes. These tests pin four contracts:
 
 1. The catalog is committed and parses cleanly with entries for at least the
    query/reader/facets/context/cost surfaces.
@@ -9,6 +9,8 @@ The catalog at ``docs/plans/slo-catalog.yaml`` lists the SLOs that
    sit comfortably under budget.
 3. ``verify-slos`` reports a violation and exits non-zero when a measured
    surface exceeds its declared budget.
+4. ``verify-slos`` treats missing benchmark results as blocking for required
+   rows and non-blocking for informational rows.
 
 The benchmark subprocess is not executed here — the tests stub
 ``_run_benchmarks`` so the SLO scoring path runs deterministically.
@@ -74,6 +76,12 @@ def _stub_benchmark_stats(
     return stats
 
 
+def _write_slo_catalog(tmp_path: Path, body: str) -> Path:
+    catalog = tmp_path / "slo-catalog.yaml"
+    catalog.write_text(body)
+    return catalog
+
+
 def test_verify_slos_passes_when_under_budget(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
@@ -130,3 +138,108 @@ def test_verify_slos_json_reports_violation(
     surfaces_with_violations = {entry["surface"] for entry in payload["violations"]}
     # All catalog surfaces must trip when fed 10s measurements.
     assert set(REQUIRED_SURFACES).issubset(surfaces_with_violations)
+
+
+def test_required_missing_benchmark_result_blocks(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Required SLO rows must not pass when their benchmark artifact is absent."""
+    catalog = _write_slo_catalog(
+        tmp_path,
+        """
+surfaces:
+  reader:
+    description: "Reader endpoint"
+    benchmark_test: "tests/benchmarks/test_reader_api.py::test_missing_required"
+    p50_ms: 100
+    p95_ms: 200
+    gate: "required"
+""",
+    )
+    monkeypatch.setattr(verify_slos, "_run_benchmarks", lambda _ids: {})
+
+    buffer = io.StringIO()
+    with redirect_stdout(buffer):
+        rc = verify_slos.main(["--yaml", str(catalog), "--json"])
+
+    payload = json.loads(buffer.getvalue())
+    assert rc != 0
+    assert payload["blocking"] is True
+    assert payload["missing_required"] == [
+        {
+            "surface": "reader",
+            "gate": "required",
+            "benchmark_test": "tests/benchmarks/test_reader_api.py::test_missing_required",
+            "reason": "no benchmark result for this test",
+        }
+    ]
+    assert payload["uncovered_informational"] == []
+
+
+def test_informational_missing_benchmark_result_is_visible_but_nonblocking(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Informational rows can document future SLOs without blocking the gate."""
+    catalog = _write_slo_catalog(
+        tmp_path,
+        """
+surfaces:
+  cost:
+    description: "Cost rollup placeholder"
+    benchmark_test: "tests/benchmarks/test_reader_api.py::test_missing_informational"
+    p50_ms: 100
+    p95_ms: 200
+    gate: "informational"
+""",
+    )
+    monkeypatch.setattr(verify_slos, "_run_benchmarks", lambda _ids: {})
+
+    buffer = io.StringIO()
+    with redirect_stdout(buffer):
+        rc = verify_slos.main(["--yaml", str(catalog), "--json"])
+
+    payload = json.loads(buffer.getvalue())
+    assert rc == 0
+    assert payload["blocking"] is False
+    assert payload["missing_required"] == []
+    assert payload["uncovered_informational"] == [
+        {
+            "surface": "cost",
+            "gate": "informational",
+            "benchmark_test": "tests/benchmarks/test_reader_api.py::test_missing_informational",
+            "reason": "no benchmark result for this test",
+        }
+    ]
+
+
+def test_invalid_slo_gate_is_catalog_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unknown gate values fail the catalog instead of being guessed."""
+    catalog = _write_slo_catalog(
+        tmp_path,
+        """
+surfaces:
+  query:
+    description: "Search endpoint"
+    benchmark_test: "tests/benchmarks/test_search_filters.py::test_bench_query"
+    p50_ms: 100
+    p95_ms: 200
+    gate: "aspirational"
+""",
+    )
+    monkeypatch.setattr(verify_slos, "_run_benchmarks", lambda _ids: {})
+
+    buffer = io.StringIO()
+    with redirect_stdout(buffer):
+        rc = verify_slos.main(["--yaml", str(catalog), "--json"])
+
+    payload = json.loads(buffer.getvalue())
+    assert rc != 0
+    assert payload["blocking"] is True
+    assert payload["catalog_errors"] == [
+        "query: invalid gate 'aspirational'; expected one of ['informational', 'required']"
+    ]

--- a/tests/unit/devtools/test_verify.py
+++ b/tests/unit/devtools/test_verify.py
@@ -2,9 +2,19 @@ from __future__ import annotations
 
 import subprocess
 import sys
+from pathlib import Path
 from unittest.mock import patch
 
-from devtools.verify import _format_completion_notification, _parse_pytest_test_count, _run, build_verify_steps
+import pytest
+
+from devtools.verify import (
+    _format_completion_notification,
+    _parse_pytest_test_count,
+    _run,
+    _testmon_preflight,
+    build_verify_steps,
+    main,
+)
 
 
 def test_quick_verify_omits_pytest() -> None:
@@ -30,11 +40,57 @@ def test_quick_verify_omits_pytest() -> None:
     ]
 
 
-def test_full_verify_includes_pytest() -> None:
+def test_default_verify_uses_pytest_testmon() -> None:
     steps = build_verify_steps(quick=False, lab=False, skip_slow=False)
 
-    labels = [label for label, _command in steps]
-    assert labels[-1] == "pytest"
+    label, command = steps[-1]
+    assert label == "pytest testmon"
+    assert "--testmon" in command
+    assert "--testmon-noselect" not in command
+    assert "-n" in command
+    assert "0" in command
+
+
+def test_seed_testmon_runs_full_collection_without_selection(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("POLYLOGUE_PYTEST_WORKERS", raising=False)
+    steps = build_verify_steps(quick=False, lab=False, skip_slow=False, seed_testmon=True)
+
+    label, command = steps[-1]
+    assert label == "pytest seed-testmon"
+    assert "--testmon" in command
+    assert "--testmon-noselect" in command
+    assert "-n" in command
+    assert "8" in command
+
+
+def test_full_verify_includes_full_pytest_without_testmon(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("POLYLOGUE_PYTEST_WORKERS", raising=False)
+    steps = build_verify_steps(quick=False, lab=False, skip_slow=False, full_pytest=True)
+
+    label, command = steps[-1]
+    assert label == "pytest full"
+    assert "--testmon" not in command
+    assert "-n" in command
+    assert "8" in command
+
+
+def test_seed_testmon_worker_count_can_be_overridden(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("POLYLOGUE_PYTEST_WORKERS", "4")
+
+    steps = build_verify_steps(quick=False, lab=False, skip_slow=False, seed_testmon=True)
+
+    label, command = steps[-1]
+    assert label == "pytest seed-testmon"
+    assert command[command.index("-n") + 1] == "4"
+
+
+def test_skip_slow_keeps_testmon_selection_forced() -> None:
+    steps = build_verify_steps(quick=False, lab=False, skip_slow=True)
+
+    label, command = steps[-1]
+    assert label == "pytest testmon"
+    assert command[command.index("-m") + 1] == "not slow"
+    assert "--testmon-forceselect" in command
 
 
 def test_lab_verify_delegates_to_lab_scenario() -> None:
@@ -48,6 +104,44 @@ def test_lab_verify_delegates_to_lab_scenario() -> None:
         "lab scenario",
         [sys.executable, "-m", "devtools", "lab-scenario", "run", "archive-smoke", "--tier", "0"],
     )
+
+
+def test_testmon_preflight_requires_seed_when_database_missing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    message = _testmon_preflight(seed_testmon=False, full_pytest=False, quick=False, commit=False)
+
+    assert message is not None
+    assert "devtools verify --seed-testmon" in message
+
+
+def test_testmon_preflight_requires_seed_stamp(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".testmondata").write_text("partial")
+
+    message = _testmon_preflight(seed_testmon=False, full_pytest=False, quick=False, commit=False)
+
+    assert message is not None
+    assert ".cache/testmon/seed.json" in message
+
+
+def test_testmon_preflight_accepts_seeded_database(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".testmondata").write_text("seeded")
+    seed_stamp = tmp_path / ".cache" / "testmon" / "seed.json"
+    seed_stamp.parent.mkdir(parents=True)
+    seed_stamp.write_text("{}")
+
+    assert _testmon_preflight(seed_testmon=False, full_pytest=False, quick=False, commit=False) is None
+
+
+def test_testmon_preflight_allows_seed_and_full_without_database(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    assert _testmon_preflight(seed_testmon=True, full_pytest=False, quick=False, commit=False) is None
+    assert _testmon_preflight(seed_testmon=False, full_pytest=True, quick=False, commit=False) is None
 
 
 def test_parse_pytest_test_count_from_summary() -> None:
@@ -73,6 +167,28 @@ def test_run_records_pytest_count_metadata() -> None:
 
     assert rc == 0
     assert metadata == {"count": 4}
+
+
+def test_verify_stops_after_first_failed_step(capsys: pytest.CaptureFixture[str]) -> None:
+    calls: list[str] = []
+
+    def fake_run(label: str, command: list[str]) -> tuple[int, float, dict[str, object]]:
+        calls.append(label)
+        return 1, 0.01, {}
+
+    with (
+        patch("devtools.verify._run", side_effect=fake_run),
+        patch("devtools.verify._git_head", return_value="head"),
+        patch("devtools.verify._save_history"),
+        patch("devtools.verify._stamp_head"),
+        patch("devtools.verify._notify"),
+    ):
+        rc = main(["--quick", "--json"])
+
+    assert rc == 1
+    assert calls == ["ruff format"]
+    payload = capsys.readouterr().out
+    assert '"exit_code": 1' in payload
 
 
 def test_completion_notification_uses_pytest_count() -> None:

--- a/tests/unit/devtools/test_verify.py
+++ b/tests/unit/devtools/test_verify.py
@@ -9,6 +9,7 @@ import pytest
 
 from devtools.verify import (
     _format_completion_notification,
+    _is_testmon_global_invalidator,
     _parse_pytest_test_count,
     _run,
     _testmon_preflight,
@@ -84,6 +85,18 @@ def test_seed_testmon_worker_count_can_be_overridden(monkeypatch: pytest.MonkeyP
     assert command[command.index("-n") + 1] == "4"
 
 
+def test_global_testmon_invalidator_runs_full_collection(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("POLYLOGUE_PYTEST_WORKERS", raising=False)
+
+    steps = build_verify_steps(quick=False, lab=False, skip_slow=False, testmon_global=True)
+
+    label, command = steps[-1]
+    assert label == "pytest testmon-global"
+    assert "--testmon" in command
+    assert "--testmon-noselect" in command
+    assert command[command.index("-n") + 1] == "8"
+
+
 def test_skip_slow_keeps_testmon_selection_forced() -> None:
     steps = build_verify_steps(quick=False, lab=False, skip_slow=True)
 
@@ -91,6 +104,16 @@ def test_skip_slow_keeps_testmon_selection_forced() -> None:
     assert label == "pytest testmon"
     assert command[command.index("-m") + 1] == "not slow"
     assert "--testmon-forceselect" in command
+
+
+def test_global_testmon_invalidators_cover_harness_and_config() -> None:
+    assert _is_testmon_global_invalidator("pyproject.toml")
+    assert _is_testmon_global_invalidator("uv.lock")
+    assert _is_testmon_global_invalidator("tests/conftest.py")
+    assert _is_testmon_global_invalidator("tests/infra/storage_records.py")
+    assert _is_testmon_global_invalidator("tests/unit/pytest.ini")
+    assert not _is_testmon_global_invalidator("polylogue/cli/click_app.py")
+    assert not _is_testmon_global_invalidator("docs/execution-plan.md")
 
 
 def test_lab_verify_delegates_to_lab_scenario() -> None:

--- a/tests/unit/devtools/test_verify.py
+++ b/tests/unit/devtools/test_verify.py
@@ -12,6 +12,7 @@ from devtools.verify import (
     _is_testmon_global_invalidator,
     _parse_pytest_test_count,
     _run,
+    _stop_after_failed_step,
     _testmon_preflight,
     build_verify_steps,
     main,
@@ -192,7 +193,7 @@ def test_run_records_pytest_count_metadata() -> None:
     assert metadata == {"count": 4}
 
 
-def test_verify_stops_after_first_failed_step(capsys: pytest.CaptureFixture[str]) -> None:
+def test_verify_continues_after_failed_cheap_step(capsys: pytest.CaptureFixture[str]) -> None:
     calls: list[str] = []
 
     def fake_run(label: str, command: list[str]) -> tuple[int, float, dict[str, object]]:
@@ -209,9 +210,40 @@ def test_verify_stops_after_first_failed_step(capsys: pytest.CaptureFixture[str]
         rc = main(["--quick", "--json"])
 
     assert rc == 1
-    assert calls == ["ruff format"]
+    assert calls == [label for label, _command in build_verify_steps(quick=True, lab=False, skip_slow=False)]
     payload = capsys.readouterr().out
     assert '"exit_code": 1' in payload
+
+
+def test_verify_stops_after_failed_heavy_step(capsys: pytest.CaptureFixture[str]) -> None:
+    calls: list[str] = []
+
+    def fake_run(label: str, command: list[str]) -> tuple[int, float, dict[str, object]]:
+        calls.append(label)
+        return (1 if label.startswith("pytest") else 0), 0.01, {}
+
+    with (
+        patch("devtools.verify._run", side_effect=fake_run),
+        patch("devtools.verify._git_head", return_value="head"),
+        patch("devtools.verify._save_history"),
+        patch("devtools.verify._stamp_head"),
+        patch("devtools.verify._notify"),
+        patch("devtools.verify._testmon_preflight", return_value=None),
+    ):
+        rc = main(["--json"])
+
+    assert rc == 1
+    assert calls[-1].startswith("pytest")
+    payload = capsys.readouterr().out
+    assert '"exit_code": 1' in payload
+
+
+def test_failed_step_stop_policy_distinguishes_cheap_and_heavy_steps() -> None:
+    assert _stop_after_failed_step("ruff check") is False
+    assert _stop_after_failed_step("verify-layering") is False
+    assert _stop_after_failed_step("pytest testmon") is True
+    assert _stop_after_failed_step("lab scenario") is True
+    assert _stop_after_failed_step("verify-slos") is True
 
 
 def test_completion_notification_uses_pytest_count() -> None:

--- a/tests/unit/devtools/test_verify_manifests.py
+++ b/tests/unit/devtools/test_verify_manifests.py
@@ -333,3 +333,19 @@ benchmark_campaigns:
         f"{plans / 'campaign-coverage.yaml'}: benchmark_campaigns missing catalog campaign 'storage'",
         f"{plans / 'campaign-coverage.yaml'}: benchmark_campaigns declares unknown campaign 'storage-scale'",
     ]
+
+
+def test_assurance_domains_accept_documentation_inventory(tmp_path: Path) -> None:
+    plans = tmp_path
+    (plans / "assurance-domains.yaml").write_text(
+        """description: Documentation inventory
+domains:
+  parser_correctness:
+    description: Provider parser crashlessness and fidelity
+    notes: >
+      Executable evidence lives in parser property tests and schema fixtures.
+""",
+        encoding="utf-8",
+    )
+
+    assert verify_manifests.check_assurance_domains(plans) == []

--- a/tests/unit/devtools/test_verify_suppressions.py
+++ b/tests/unit/devtools/test_verify_suppressions.py
@@ -148,3 +148,12 @@ def test_enforce_discovered_accepts_registered_path(tmp_path: Path, capsys: pyte
     captured = capsys.readouterr()
     assert "blocking=False" in captured.out
     assert "unregistered source suppressions" not in captured.out
+
+
+def test_pytest_suppression_scan_ignores_ast_parse_failures(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail_parse(_text: str) -> object:
+        raise RecursionError("synthetic parser recursion")
+
+    monkeypatch.setattr("devtools.verify_suppressions.ast.parse", fail_parse)
+
+    assert verify_suppressions._pytest_suppression_lines("pytest.mark.xfail()") == []

--- a/tests/unit/devtools/test_verify_suppressions.py
+++ b/tests/unit/devtools/test_verify_suppressions.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -61,7 +62,6 @@ def test_json_output(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None
     rc = verify_suppressions.main(["--yaml", str(yaml), "--json"])
     assert rc == 0
     captured = capsys.readouterr()
-    import json
 
     data = json.loads(captured.out)
     assert data["blocking"] is False
@@ -74,3 +74,77 @@ def test_committed_registry_passes(capsys: pytest.CaptureFixture[str]) -> None:
     assert rc == 0
     captured = capsys.readouterr()
     assert "blocking=False" in captured.out
+
+
+def test_discovers_source_suppressions(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    yaml = _write_registry(tmp_path, "suppressions: []\n")
+    source = tmp_path / "polylogue" / "example.py"
+    source.parent.mkdir()
+    source.write_text(
+        "\n".join(
+            [
+                "import pytest",
+                "pytest.skip('not available')",
+                "pytest.xfail('tracked elsewhere')",
+                "value = dynamic()  # type: ignore[no-any-return]",
+                "def unused(arg):  # noqa: ARG001",
+                "    pass",
+                "def fallback():  # pragma: no cover",
+                "    pass",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    rc = verify_suppressions.main(["--yaml", str(yaml), "--scan-root", str(tmp_path), "--json"])
+
+    assert rc == 0
+    data = json.loads(capsys.readouterr().out)
+    assert data["blocking"] is False
+    assert data["discovered_total"] == 5
+    assert data["unregistered_total"] == 5
+    assert data["discovered_by_kind"] == {
+        "no_cover": 1,
+        "noqa": 1,
+        "pytest_skip": 1,
+        "pytest_xfail": 1,
+        "type_ignore": 1,
+    }
+
+
+def test_enforce_discovered_blocks_unregistered(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    yaml = _write_registry(tmp_path, "suppressions: []\n")
+    source = tmp_path / "tests" / "test_example.py"
+    source.parent.mkdir()
+    source.write_text("@pytest.mark.xfail(reason='tracked elsewhere')\ndef test_x(): ...\n", encoding="utf-8")
+
+    rc = verify_suppressions.main(["--yaml", str(yaml), "--scan-root", str(tmp_path), "--enforce-discovered"])
+
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "[BLOCK] unregistered source suppressions: 1" in captured.out
+    assert "blocking=True" in captured.out
+
+
+def test_enforce_discovered_accepts_registered_path(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    yaml = _write_registry(
+        tmp_path,
+        """suppressions:
+  - id: tracked-exception
+    reason: tracked while the replacement lands
+    expires_at: "2099-12-31"
+    issue: "#1062"
+    paths:
+      - "tests/test_example.py"
+""",
+    )
+    source = tmp_path / "tests" / "test_example.py"
+    source.parent.mkdir()
+    source.write_text("@pytest.mark.xfail(reason='tracked elsewhere')\ndef test_x(): ...\n", encoding="utf-8")
+
+    rc = verify_suppressions.main(["--yaml", str(yaml), "--scan-root", str(tmp_path), "--enforce-discovered"])
+
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "blocking=False" in captured.out
+    assert "unregistered source suppressions" not in captured.out

--- a/tests/unit/mcp/test_server_surfaces.py
+++ b/tests/unit/mcp/test_server_surfaces.py
@@ -15,6 +15,7 @@ from polylogue.archive.models import Conversation, ConversationSummary
 from polylogue.archive.semantic.content_projection import ContentProjectionSpec
 from polylogue.types import ConversationId, Provider
 from tests.infra.builders import make_conv, make_msg
+from tests.infra.contract_evidence import ContractEvidenceRecorder
 from tests.infra.mcp import (
     EXPECTED_PROMPT_NAMES,
     EXPECTED_RESOURCE_TEMPLATE_URIS,
@@ -138,16 +139,27 @@ class TestServerSurfaceRegistration:
             ("prompts", lambda server: set(server._prompt_manager._prompts.keys()), EXPECTED_PROMPT_NAMES),
         ],
     )
+    @pytest.mark.contract
     def test_server_surface_contract(
         self: object,
         surface_attr: str,
         actual_getter: Callable[[MCPServerUnderTest], set[str]],
         expected: set[str],
         mcp_server: MCPServerUnderTest,
+        record_contract_evidence: ContractEvidenceRecorder,
     ) -> None:
         actual = actual_getter(mcp_server)
         missing = expected - actual
         assert not missing, f"Missing {surface_attr}: {sorted(missing)}"
+        record_contract_evidence.record(
+            f"mcp.{surface_attr}.registration",
+            surface="mcp",
+            facts={
+                "surface_attr": surface_attr,
+                "actual_count": len(actual),
+                "expected_count": len(expected),
+            },
+        )
 
     def test_read_role_omits_mutation_and_maintenance_tools(self: object) -> None:
         from polylogue.mcp.server import build_server

--- a/tests/unit/proof/test_diffing.py
+++ b/tests/unit/proof/test_diffing.py
@@ -175,7 +175,7 @@ def test_obligation_diff_buckets_new_dropped_stale_and_suppressed() -> None:
     assert diff.suppressed == ("test:tests/unit/example.py",)
 
 
-def test_human_report_explains_selected_obligations() -> None:
+def test_human_report_explains_selected_checks() -> None:
     catalog = build_verification_catalog()
     report = build_affected_obligation_report(
         ("polylogue/sources/parsers/codex.py",),
@@ -186,7 +186,7 @@ def test_human_report_explains_selected_obligations() -> None:
 
     rendered = render_affected_obligations(report)
 
-    assert "Affected Obligations" in rendered
+    assert "Affected Verification Checks" in rendered
     assert "provider parser semantics can change normalized archive facts" in rendered
     assert "provider.capability.codex" in rendered
     assert "Recommended Inner-Loop Checks" in rendered

--- a/tests/unit/ui/test_tui.py
+++ b/tests/unit/ui/test_tui.py
@@ -5,6 +5,9 @@ from typing import TYPE_CHECKING, TypeAlias
 from unittest.mock import MagicMock
 
 import pytest
+
+pytest.importorskip("textual", reason="Textual not installed")
+
 from textual.pilot import Pilot
 from textual.widgets import DataTable, Input, TabbedContent, Tree
 
@@ -19,7 +22,6 @@ if TYPE_CHECKING:
     from tests.infra.storage_records import ConversationBuilder
 
 pytestmark = pytest.mark.tui
-_skip = pytest.mark.skipif(False, reason="Textual not installed")
 
 
 # ---------------------------------------------------------------------------
@@ -76,7 +78,6 @@ async def _wait_workers(pilot: Pilot[None], *, selector: str | None = None, reje
 # ===========================================================================
 
 
-@_skip
 @pytest.mark.asyncio
 async def test_dashboard_stats_populated(
     storage_repository: ConversationRepository, conversation_builder: ConversationBuilderFactory
@@ -95,7 +96,6 @@ async def test_dashboard_stats_populated(
         assert msgs.value == "3"
 
 
-@_skip
 @pytest.mark.asyncio
 async def test_dashboard_provider_bars(
     storage_repository: ConversationRepository, conversation_builder: ConversationBuilderFactory
@@ -121,7 +121,6 @@ async def test_dashboard_provider_bars(
         assert "1" in claude_bar[0]
 
 
-@_skip
 @pytest.mark.asyncio
 async def test_dashboard_empty_db(storage_repository: ConversationRepository) -> None:
     """Empty DB → graceful '0' display, no errors."""
@@ -140,7 +139,6 @@ async def test_dashboard_empty_db(storage_repository: ConversationRepository) ->
 # ===========================================================================
 
 
-@_skip
 @pytest.mark.asyncio
 async def test_browser_tree_populated(
     storage_repository: ConversationRepository, conversation_builder: ConversationBuilderFactory
@@ -167,7 +165,6 @@ async def test_browser_tree_populated(
         assert len(chatgpt_node.children) >= 1
 
 
-@_skip
 @pytest.mark.asyncio
 async def test_browser_node_selection(
     storage_repository: ConversationRepository, conversation_builder: ConversationBuilderFactory
@@ -200,7 +197,6 @@ async def test_browser_node_selection(
             assert "Hello World" in viewer.source
 
 
-@_skip
 @pytest.mark.asyncio
 async def test_browser_empty_db(storage_repository: ConversationRepository) -> None:
     """Empty DB → direct empty-state leaf shown."""
@@ -229,7 +225,6 @@ async def test_browser_empty_db(storage_repository: ConversationRepository) -> N
 # ===========================================================================
 
 
-@_skip
 @pytest.mark.asyncio
 async def test_search_flow(
     storage_repository: ConversationRepository, conversation_builder: ConversationBuilderFactory
@@ -273,7 +268,6 @@ async def test_search_flow(
         assert "UniqueSearchTerm123" in viewer.source
 
 
-@_skip
 @pytest.mark.asyncio
 async def test_search_no_results(
     storage_repository: ConversationRepository, conversation_builder: ConversationBuilderFactory
@@ -304,7 +298,6 @@ async def test_search_no_results(
         assert table.row_count == 0
 
 
-@_skip
 @pytest.mark.asyncio
 async def test_search_empty_db(storage_repository: ConversationRepository) -> None:
     """Empty DB with FTS table → 0 results, no crash (messages_fts always exists)."""
@@ -330,7 +323,6 @@ async def test_search_empty_db(storage_repository: ConversationRepository) -> No
 # ===========================================================================
 
 
-@_skip
 @pytest.mark.asyncio
 async def test_keyboard_tab_switch(storage_repository: ConversationRepository) -> None:
     """Press Tab key → verify tab changes (basic navigation)."""
@@ -350,7 +342,6 @@ async def test_keyboard_tab_switch(storage_repository: ConversationRepository) -
         assert tabs.active == "search"
 
 
-@_skip
 @pytest.mark.asyncio
 async def test_dark_mode_toggle(storage_repository: ConversationRepository) -> None:
     """Press 'd' → assert dark mode toggles without crashing."""
@@ -365,7 +356,6 @@ async def test_dark_mode_toggle(storage_repository: ConversationRepository) -> N
         assert pilot.app.query_one(Dashboard)
 
 
-@_skip
 @pytest.mark.asyncio
 async def test_search_missing_index_shows_rebuild_hint(
     storage_repository: ConversationRepository, conversation_builder: ConversationBuilderFactory
@@ -407,7 +397,6 @@ def test_repository_bound_container_requires_injected_repo() -> None:
         screen._get_ops("DummyScreen")
 
 
-@_skip
 @pytest.mark.asyncio
 async def test_quit_action(storage_repository: ConversationRepository) -> None:
     """Press 'q' → app exits cleanly."""
@@ -423,7 +412,6 @@ async def test_quit_action(storage_repository: ConversationRepository) -> None:
 # ===========================================================================
 
 
-@_skip
 @pytest.mark.asyncio
 async def test_worker_failure_recovery(
     storage_repository: ConversationRepository, monkeypatch: pytest.MonkeyPatch
@@ -451,7 +439,6 @@ async def test_worker_failure_recovery(
 # ===========================================================================
 
 
-@_skip
 @pytest.mark.asyncio
 async def test_app_startup(storage_repository: ConversationRepository) -> None:
     """Test that the app starts and loads the dashboard."""

--- a/tests/unit/verification/test_breakers.py
+++ b/tests/unit/verification/test_breakers.py
@@ -149,36 +149,36 @@ def _validate_yaml_and_catch(path: Path) -> list[str]:
 
 
 # ══════════════════════════════════════════════════════════════════════
-# D2 — Anti-vacuity slop detection (#594)
+# D2 — Anti-vacuity detection (#594)
 # ══════════════════════════════════════════════════════════════════════
 
 
-def test_slop_dashboard_detects_missing_breakers() -> None:
-    """The slop dashboard must flag claims without breakers."""
-    from devtools.proof_pack import build_slop_dashboard
+def test_anti_vacuity_report_detects_missing_breakers() -> None:
+    """The anti-vacuity report must flag claims without breakers."""
+    from devtools.proof_pack import build_anti_vacuity_report
 
     catalog = build_verification_catalog()
-    dashboard = build_slop_dashboard(catalog)
+    dashboard = build_anti_vacuity_report(catalog)
 
     assert "total_claims" in dashboard
-    assert "slop_count" in dashboard
+    assert "flagged_count" in dashboard
     assert "by_reason" in dashboard
     assert "rows" in dashboard
 
     # At least some missing_breaker claims should exist (new claims may lack them)
     missing_breaker_count = dashboard["by_reason"]["missing_breaker"]
     # We don't assert a specific number — the catalog evolves. But we assert
-    # the dashboard is structured and non-empty (it should have slop).
+    # the dashboard is structured and non-empty (it should have flagged rows).
     assert isinstance(missing_breaker_count, int)
-    assert isinstance(dashboard["slop_count"], int)
+    assert isinstance(dashboard["flagged_count"], int)
 
 
-def test_slop_dashboard_by_reason_breaks_down() -> None:
+def test_anti_vacuity_report_by_reason_breaks_down() -> None:
     """Each reason in by_reason must be a non-negative integer."""
-    from devtools.proof_pack import build_slop_dashboard
+    from devtools.proof_pack import build_anti_vacuity_report
 
     catalog = build_verification_catalog()
-    dashboard = build_slop_dashboard(catalog)
+    dashboard = build_anti_vacuity_report(catalog)
     by_reason = dashboard["by_reason"]
 
     for reason in ("missing_breaker", "missing_runner", "zero_subjects", "self_referential", "stale_evidence"):
@@ -187,22 +187,22 @@ def test_slop_dashboard_by_reason_breaks_down() -> None:
         assert count >= 0, f"{reason} count is negative: {count}"
 
 
-def test_slop_dashboard_json_serializable() -> None:
-    """Slop dashboard output must be JSON-serializable."""
-    from devtools.proof_pack import build_slop_dashboard
+def test_anti_vacuity_report_json_serializable() -> None:
+    """Anti-vacuity report output must be JSON-serializable."""
+    from devtools.proof_pack import build_anti_vacuity_report
 
     catalog = build_verification_catalog()
-    dashboard = build_slop_dashboard(catalog)
+    dashboard = build_anti_vacuity_report(catalog)
     # Should not raise
     json_mod.dumps(dashboard, indent=2, sort_keys=True)
 
 
-def test_slop_dashboard_rows_have_required_fields() -> None:
-    """Each slop row must carry claim_id, severity, and all reason flags."""
-    from devtools.proof_pack import build_slop_dashboard
+def test_anti_vacuity_report_rows_have_required_fields() -> None:
+    """Each anti-vacuity row must carry claim_id, severity, and all reason flags."""
+    from devtools.proof_pack import build_anti_vacuity_report
 
     catalog = build_verification_catalog()
-    dashboard = build_slop_dashboard(catalog)
+    dashboard = build_anti_vacuity_report(catalog)
     required = {
         "claim_id",
         "severity",
@@ -273,15 +273,15 @@ def test_manifests_integration_passes(tmp_path: Path) -> None:
     assert rc == 0, "verify_manifests should pass on committed manifests"
 
 
-def test_slop_dashboard_renders_without_error() -> None:
-    """The slop markdown renderer must handle any dashboard structure."""
-    from devtools.proof_pack import _print_slop_dashboard, build_slop_dashboard, render_slop_markdown
+def test_anti_vacuity_report_renders_without_error() -> None:
+    """The anti-vacuity markdown renderer must handle any dashboard structure."""
+    from devtools.proof_pack import _print_anti_vacuity_report, build_anti_vacuity_report, render_anti_vacuity_markdown
 
     catalog = build_verification_catalog()
-    dashboard = build_slop_dashboard(catalog)
+    dashboard = build_anti_vacuity_report(catalog)
 
     # Should not raise
-    markdown = render_slop_markdown(dashboard)
+    markdown = render_anti_vacuity_markdown(dashboard)
     assert isinstance(markdown, str)
     assert len(markdown) > 0
     assert "Anti-Vacuity" in markdown
@@ -294,9 +294,9 @@ def test_slop_dashboard_renders_without_error() -> None:
     old_stdout = sys_mod.stdout
     try:
         sys_mod.stdout = buf
-        _print_slop_dashboard(dashboard)
+        _print_anti_vacuity_report(dashboard)
     finally:
         sys_mod.stdout = old_stdout
     output = buf.getvalue()
     assert len(output) > 0
-    assert "Slop claims" in output
+    assert "Flagged claims" in output

--- a/uv.lock
+++ b/uv.lock
@@ -1478,6 +1478,7 @@ dev = [
     { name = "pytest-benchmark" },
     { name = "pytest-cov" },
     { name = "pytest-randomly" },
+    { name = "pytest-testmon" },
     { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "syrupy" },
@@ -1540,6 +1541,7 @@ requires-dist = [
     { name = "pytest-benchmark", marker = "extra == 'dev'", specifier = ">=5.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4" },
     { name = "pytest-randomly", marker = "extra == 'dev'", specifier = ">=3.0" },
+    { name = "pytest-testmon", marker = "extra == 'dev'", specifier = ">=2.1.3" },
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.5.0" },
     { name = "python-multipart", specifier = ">=0.0.27" },
     { name = "pyyaml", specifier = ">=6.0" },
@@ -1914,6 +1916,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c4/1d/258a4bf1109258c00c35043f40433be5c16647387b6e7cd5582d638c116b/pytest_randomly-4.0.1.tar.gz", hash = "sha256:174e57bb12ac2c26f3578188490bd333f0e80620c3f47340158a86eca0593cd8", size = 14130, upload-time = "2025-09-12T15:23:00.085Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/33/3e/a4a9227807b56869790aad3e24472a554b585974fe7e551ea350f50897ae/pytest_randomly-4.0.1-py3-none-any.whl", hash = "sha256:e0dfad2fd4f35e07beff1e47c17fbafcf98f9bf4531fd369d9260e2f858bfcb7", size = 8304, upload-time = "2025-09-12T15:22:58.946Z" },
+]
+
+[[package]]
+name = "pytest-testmon"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/1d/3e4230cc67cd6205bbe03c3527500c0ccaf7f0c78b436537eac71590ee4a/pytest_testmon-2.2.0.tar.gz", hash = "sha256:01f488e955ed0e0049777bee598bf1f647dd524e06f544c31a24e68f8d775a51", size = 23108, upload-time = "2025-12-01T07:30:24.76Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/55/ebb3c2f59fb089f08d00f764830d35780fc4e4c41dffcadafa3264682b65/pytest_testmon-2.2.0-py3-none-any.whl", hash = "sha256:2604ca44a54d61a2e830d9ce828b41a837075e4ebc1f81b148add8e90d34815b", size = 25199, upload-time = "2025-12-01T07:30:23.623Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Move the #1058 verification model toward executable artifacts instead of declarative confidence rows. This branch makes pytest-testmon the normal verify path, adds bounded pytest evidence artifacts for daemon contracts, tightens suppression discovery, grounds required SLO rows in benchmark-result presence, and softens proof-pack report language toward verification impact reporting.

## Problem

The verification stack had two practical failures: agents paid for unnecessarily broad pytest runs, and several assurance surfaces could look meaningful without being backed by executable artifacts. Required SLO rows could be missing benchmark output without failing, suppression discovery found source suppressions without reducing the baseline, and proof-pack wording still implied stronger bespoke proof semantics than the underlying tests/artifacts provided.

## Solution

- Default `devtools verify` to pytest-testmon and let testmon own invalidation, with global refresh for config/dependency/test-harness changes.
- Add contract evidence artifacts for daemon runtime/health/notifications/backup readability.
- Discover source-level suppressions and remove the first concrete suppression class (`pytest_skip_marker`).
- Make `devtools verify-slos` validate `gate`, fail missing benchmark results for required SLO rows, and report informational gaps separately.
- Update proof-pack report wording and generated command docs toward verification impact terminology.

## Verification

- `devtools verify --quick` -> exit 0, total 28.26s at a136584c.
- `devtools verify --json` -> testmon-global run: 6449 tests, pytest 149.90s, total 179.44s.
- Immediate `devtools verify --json` rerun -> testmon run: 0 tests, pytest 3.24s, total 34.35s.
- `pytest -q tests/unit/devtools/test_slo_catalog.py` -> 7 passed.
- `ruff check devtools/verify_slos.py tests/unit/devtools/test_slo_catalog.py` -> All checks passed.
- `mypy --strict devtools/verify_slos.py tests/unit/devtools/test_slo_catalog.py` -> Success.
- #1062 worker: `pytest tests/unit/cli/test_check_runtime.py tests/unit/cli/test_terminal_snapshots.py tests/unit/ui/test_tui.py` -> 45 passed.
- #1065 worker: `pytest -q tests/unit/devtools/test_proof_pack.py` -> 13 passed.

Ref #1058
Ref #1059
Ref #1060
Ref #1062
Ref #1063
Ref #1065


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Verification now defaults to pytest-testmon "affected" runs with a seed mode and explicit full-run flag; SLO checks distinguish required vs informational and suppression scans can optionally enforce discovered suppressions.  
  * Test-side contract evidence recording and automatic evidence artifacts added.

* **Documentation**
  * Guidance and docs updated to emphasize executable evidence (tests/coverage/benchmarks/CI) over legacy "proof" wording.

* **Configuration**
  * Added pytest-testmon dev dependency and a `contract` pytest marker.

* **Tests**
  * Many contract-marked tests and helpers added to produce and validate evidence artifacts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sinity/polylogue/pull/1066)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->