### PR TITLE
feat(verify): CI workflow and manifest reality checks (#590, #1064)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1026,6 +1026,7 @@ These are the commands worth remembering during normal repo work:
 | `devtools schema-promote` | Promote a schema evidence cluster into a registered package version. |
 | `devtools semantic-axis-evidence` | Generate verification-lab performance evidence across synthetic semantic scale tiers. |
 | `devtools verify` | Run the local verification baseline before pushing or creating a PR. |
+| `devtools verify-ci-workflows` | Verify CI workflow files reference locally-known devtools commands and existing paths. |
 | `devtools verify-cluster-cohesion` | Validate proposed clusters from the topology projection using the import graph. |
 | `devtools verify-cross-cuts` | Verify cross-cut tags in the topology projection match module-name conventions. |
 | `devtools verify-distribution-surface` | Verify wheel/sdist installed artifacts expose only supported runtime entrypoints. |

--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -356,6 +356,17 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
         examples=("devtools verify-manifests",),
     ),
     CommandSpec(
+        "verify-ci-workflows",
+        "verification",
+        "Verify CI workflow files reference locally-known devtools commands and existing paths.",
+        "devtools.verify_ci_workflows",
+        use_when=(
+            "Catch CI workflow files that reference unregistered devtools commands or "
+            "non-existent paths. Checks only locally verifiable facts — not remote CI state."
+        ),
+        examples=("devtools verify-ci-workflows", "devtools verify-ci-workflows --json"),
+    ),
+    CommandSpec(
         "proof-pack",
         "verification",
         "Domain-grouped verification impact report for changed paths.",

--- a/devtools/verify.py
+++ b/devtools/verify.py
@@ -254,6 +254,7 @@ def build_verify_steps(
                 ("verify-cross-cuts", _devtools_cmd("verify-cross-cuts")),
                 ("verify-suppressions", _devtools_cmd("verify-suppressions")),
                 ("verify-manifests", _devtools_cmd("verify-manifests")),
+                ("verify-ci-workflows", _devtools_cmd("verify-ci-workflows")),
                 ("verify-witness-lifecycle", _devtools_cmd("verify-witness-lifecycle")),
                 ("verify-lane-assertions", _devtools_cmd("verify-lane-assertions")),
             ]

--- a/devtools/verify_ci_workflows.py
+++ b/devtools/verify_ci_workflows.py
@@ -1,0 +1,187 @@
+"""Verify CI workflow files reference locally-known commands and paths.
+
+Checks each .github/workflows/*.yml file for:
+- devtools commands: must be registered in the devtools catalog
+- polylogue CLI commands: must match the installed CLI surface
+- file/dir paths passed to ruff/mypy/pytest: must exist in the repo
+
+Does NOT check remote CI state, GitHub secrets, or external service calls.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import shlex
+import sys
+from pathlib import Path
+
+import yaml
+
+from devtools import repo_root as _get_root
+from devtools.command_catalog import COMMANDS
+
+ROOT = _get_root()
+WORKFLOWS_DIR = ROOT / ".github" / "workflows"
+
+_DEVTOOLS_RE = re.compile(r"\bdevtools\s+(\S+)")
+_UVX_DEVTOOLS_RE = re.compile(r"uv\s+run\s+devtools\s+(\S+)")
+_POLYLOGUE_CMD_RE = re.compile(r"(?:uv\s+run\s+)?polylogue\s+(\S+)")
+_RUFF_PATH_RE = re.compile(r"\bruff\s+(?:check|format)\s+(?:--\S+\s+)*(.+)$", re.MULTILINE)
+_MYPY_PATH_RE = re.compile(r"\bmypy\s+(.+)$", re.MULTILINE)
+_PYTEST_PATH_RE = re.compile(r"\bpytest\s+(?:-\S+\s+)*(\S+)", re.MULTILINE)
+
+
+def _devtools_command_names() -> frozenset[str]:
+    return frozenset(COMMANDS.keys())
+
+
+def _extract_run_steps(workflow: dict[str, object]) -> list[tuple[str, str, str]]:
+    """Return (job_name, step_name, run_script) for all run steps."""
+    results: list[tuple[str, str, str]] = []
+    jobs = workflow.get("jobs")
+    if not isinstance(jobs, dict):
+        return results
+    for job_name, job in jobs.items():
+        if not isinstance(job, dict):
+            continue
+        for step in job.get("steps", []):
+            if not isinstance(step, dict):
+                continue
+            run = step.get("run")
+            if isinstance(run, str) and run.strip():
+                step_name = str(step.get("name", ""))
+                results.append((str(job_name), step_name, run))
+    return results
+
+
+def _check_devtools_commands(
+    run: str,
+    known: frozenset[str],
+    job: str,
+    step: str,
+    workflow: str,
+) -> list[str]:
+    errors: list[str] = []
+    for match in _DEVTOOLS_RE.finditer(run):
+        cmd = match.group(1)
+        if cmd not in known:
+            errors.append(f"{workflow}:{job}/{step!r}: unknown devtools command {cmd!r}")
+    return errors
+
+
+def _check_paths(
+    run: str,
+    root: Path,
+    job: str,
+    step: str,
+    workflow: str,
+) -> list[str]:
+    warnings: list[str] = []
+    for pattern, label in [
+        (_RUFF_PATH_RE, "ruff"),
+        (_MYPY_PATH_RE, "mypy"),
+        (_PYTEST_PATH_RE, "pytest"),
+    ]:
+        for match in pattern.finditer(run):
+            raw = match.group(1).strip()
+            # Skip flags and variable expansions
+            parts = shlex.split(raw) if raw else []
+            for part in parts:
+                # Skip flags, shell expansions, and non-path tokens
+                if part.startswith("-") or "$" in part or "{" in part:
+                    continue
+                # Accept only plausible repo-relative paths (word chars, slashes, dots, hyphens)
+                if not re.match(r"^[\w./\-]+$", part):
+                    continue
+                path = root / part
+                if not path.exists():
+                    warnings.append(f"{workflow}:{job}/{step!r}: {label} references non-existent path {part!r}")
+    return warnings
+
+
+def check_workflow(path: Path, root: Path, known_commands: frozenset[str]) -> tuple[list[str], list[str]]:
+    """Return (errors, warnings) for a workflow file."""
+    errors: list[str] = []
+    warnings: list[str] = []
+    rel = path.relative_to(root).as_posix()
+
+    try:
+        with open(path, encoding="utf-8") as f:
+            workflow = yaml.safe_load(f)
+    except Exception as exc:
+        return [f"{rel}: failed to parse YAML: {exc}"], []
+
+    if not isinstance(workflow, dict):
+        return [f"{rel}: expected mapping at top level"], []
+
+    for job, step, run in _extract_run_steps(workflow):
+        errors.extend(_check_devtools_commands(run, known_commands, job, step, rel))
+        warnings.extend(_check_paths(run, root, job, step, rel))
+
+    return errors, warnings
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--json", action="store_true")
+    p.add_argument("--warn-paths", action="store_true", help="Treat missing paths as errors, not warnings.")
+    args = p.parse_args(argv)
+
+    if not WORKFLOWS_DIR.exists():
+        if args.json:
+            import json
+
+            json.dump({"blocking": False, "errors": [], "warnings": [], "files_checked": 0}, sys.stdout, indent=2)
+            sys.stdout.write("\n")
+        else:
+            print("no .github/workflows/ directory found — skipping")
+        return 0
+
+    known = _devtools_command_names()
+    all_errors: list[str] = []
+    all_warnings: list[str] = []
+    files_checked = 0
+
+    for path in sorted(WORKFLOWS_DIR.glob("*.yml")):
+        errors, warnings = check_workflow(path, ROOT, known)
+        all_errors.extend(errors)
+        all_warnings.extend(warnings)
+        files_checked += 1
+
+    if args.warn_paths:
+        all_errors.extend(all_warnings)
+        all_warnings = []
+
+    blocking = bool(all_errors)
+
+    if args.json:
+        import json
+
+        json.dump(
+            {
+                "blocking": blocking,
+                "errors": all_errors,
+                "warnings": all_warnings,
+                "files_checked": files_checked,
+            },
+            sys.stdout,
+            indent=2,
+        )
+        sys.stdout.write("\n")
+    else:
+        if all_errors:
+            for e in all_errors:
+                print(f"[BLOCK] {e}")
+        else:
+            print(f"verify-ci-workflows: {files_checked} workflow files checked, no errors")
+        for w in all_warnings:
+            print(f"[warn] {w}")
+        print()
+        print(f"blocking={blocking}")
+
+    return 1 if blocking else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/devtools/verify_manifests.py
+++ b/devtools/verify_manifests.py
@@ -475,6 +475,37 @@ def _coverage_gap_slug(value: str) -> str:
     return "".join(char if char.isalnum() else "-" for char in value.lower()).strip("-") or "unnamed"
 
 
+def check_test_coverage_domains(plans_dir: Path) -> list[str]:
+    """Validate test-coverage-domains.yaml covering_tests paths exist."""
+    errors: list[str] = []
+    path = plans_dir / "test-coverage-domains.yaml"
+    if not path.exists():
+        return errors
+    try:
+        data = load_manifest(path)
+    except ValueError as exc:
+        return [str(exc)]
+
+    repo_root = plans_dir.parent.parent
+    domains = data.get("domains", [])
+    if not isinstance(domains, list):
+        return errors
+    for domain in domains:
+        if not isinstance(domain, dict):
+            continue
+        name = domain.get("domain", "<unknown>")
+        covering = domain.get("covering_tests", [])
+        if not isinstance(covering, list):
+            continue
+        for test_path in covering:
+            full = repo_root / test_path
+            if not full.exists():
+                errors.append(
+                    f"test-coverage-domains.yaml: domain {name!r}: covering_tests path does not exist: {test_path!r}"
+                )
+    return errors
+
+
 def check_pydantic_models(plans_dir: Path) -> list[str]:
     """Validate every YAML manifest against its Pydantic model schema."""
     errors: list[str] = []
@@ -508,6 +539,7 @@ def main(argv: list[str] | None = None) -> int:
         check_coverage_references,
         check_coverage_status_claims,
         check_campaign_coverage_catalog,
+        check_test_coverage_domains,
     ):
         try:
             all_errors.extend(check(plans_dir))

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -115,6 +115,7 @@ These are the commands worth remembering during normal repo work:
 | `devtools schema-promote` | Promote a schema evidence cluster into a registered package version. |
 | `devtools semantic-axis-evidence` | Generate verification-lab performance evidence across synthetic semantic scale tiers. |
 | `devtools verify` | Run the local verification baseline before pushing or creating a PR. |
+| `devtools verify-ci-workflows` | Verify CI workflow files reference locally-known devtools commands and existing paths. |
 | `devtools verify-cluster-cohesion` | Validate proposed clusters from the topology projection using the import graph. |
 | `devtools verify-cross-cuts` | Verify cross-cut tags in the topology projection match module-name conventions. |
 | `devtools verify-distribution-surface` | Verify wheel/sdist installed artifacts expose only supported runtime entrypoints. |

--- a/docs/plans/test-coverage-domains.yaml
+++ b/docs/plans/test-coverage-domains.yaml
@@ -43,7 +43,7 @@ domains:
     production_modules:
       - polylogue/sources/parsers/claude.py
     covering_tests:
-      - tests/unit/sources/test_parsers_claude.py
+      - tests/unit/sources/test_parsers_claude_code_artifacts.py
     notes: >
       covered — code path, message extraction, block mapping, subagent events
 
@@ -71,7 +71,7 @@ domains:
       - polylogue/sources/dispatch.py
       - polylogue/sources/artifact_taxonomy/
     covering_tests:
-      - tests/unit/sources/test_dispatch.py
+      - tests/unit/sources/test_dispatch_payloads.py
       - tests/unit/sources/test_parsers_props.py
       - tests/unit/sources/test_null_guard_properties.py
     notes: >
@@ -84,7 +84,7 @@ domains:
       - polylogue/core/hashing.py
     covering_tests:
       - tests/unit/core/test_hashing.py
-      - tests/unit/pipeline/test_ids.py
+      - tests/unit/pipeline/test_pipeline_ids.py
     notes: covered — hash computation, NFC normalization, idempotency
 
   - domain: pipeline_ingest
@@ -104,9 +104,8 @@ domains:
       - polylogue/storage/sqlite/
     covering_tests:
       - tests/unit/storage/test_backend.py
-      - tests/unit/storage/test_store_ops.py
       - tests/unit/storage/test_repository_lifecycle_laws.py
-      - tests/unit/storage/test_crud.py
+      - tests/unit/storage/test_repository_state_machine.py
     notes: covered — save, get, list, delete, metadata, lifecycle laws
 
   - domain: storage_fts5
@@ -115,7 +114,6 @@ domains:
       - polylogue/storage/fts/
     covering_tests:
       - tests/unit/storage/test_fts5.py
-      - tests/unit/storage/test_fts5_laws.py
       - tests/unit/storage/test_archive_search_contracts.py
     notes: >
       covered — FTS5 query, rebuild, trigger lifecycle, search contracts

--- a/docs/plans/test-ownership.yaml
+++ b/docs/plans/test-ownership.yaml
@@ -34,3 +34,12 @@ shared:
 
   - path: tests/unit/pipeline/test_no_cli_imports.py
     reason: structural test — verifies pipeline module isolation from CLI surface; import-free by design
+
+  - path: tests/unit/mcp/test_user_state_tools.py
+    reason: contract test via tests.infra.mcp mock layer — no direct production import by design
+
+  - path: tests/unit/smoke/test_installed_scripts.py
+    reason: entry-point smoke test via subprocess — verifies installed scripts, not module imports
+
+  - path: tests/unit/storage/test_tag_contracts.py
+    reason: contract test via tests.infra.archive_scenarios — indirectly covers storage via fixtures

--- a/tests/unit/devtools/test_verify_ci_workflows.py
+++ b/tests/unit/devtools/test_verify_ci_workflows.py
@@ -1,0 +1,130 @@
+"""Tests for devtools/verify_ci_workflows.py."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from devtools.verify_ci_workflows import _devtools_command_names, check_workflow, main
+
+
+class TestDevtoolsCommandNames:
+    def test_returns_nonempty_frozenset(self) -> None:
+        names = _devtools_command_names()
+        assert isinstance(names, frozenset)
+        assert len(names) > 0
+
+    def test_contains_known_commands(self) -> None:
+        names = _devtools_command_names()
+        assert "verify" in names
+        assert "status" in names
+        assert "render-all" in names
+
+
+class TestCheckWorkflow:
+    def _write_yaml(self, tmp_path: Path, content: str) -> Path:
+        path = tmp_path / "test.yml"
+        path.write_text(textwrap.dedent(content))
+        return path
+
+    def test_valid_workflow_no_errors(self, tmp_path: Path) -> None:
+        path = self._write_yaml(
+            tmp_path,
+            """
+            jobs:
+              lint:
+                steps:
+                  - name: lint
+                    run: uv run devtools render-all --check
+            """,
+        )
+        errors, warnings = check_workflow(path, tmp_path.parent, _devtools_command_names())
+        assert errors == []
+
+    def test_unknown_devtools_command_is_error(self, tmp_path: Path) -> None:
+        path = self._write_yaml(
+            tmp_path,
+            """
+            jobs:
+              test:
+                steps:
+                  - name: broken
+                    run: devtools nonexistent-command-xyz
+            """,
+        )
+        errors, _ = check_workflow(path, tmp_path.parent, _devtools_command_names())
+        assert any("nonexistent-command-xyz" in e for e in errors)
+
+    def test_invalid_yaml_returns_error(self, tmp_path: Path) -> None:
+        path = tmp_path / "bad.yml"
+        path.write_text(": bad yaml: [unclosed")
+        errors, _ = check_workflow(path, tmp_path.parent, _devtools_command_names())
+        assert errors
+
+    def test_no_run_steps_no_errors(self, tmp_path: Path) -> None:
+        path = self._write_yaml(
+            tmp_path,
+            """
+            jobs:
+              test:
+                steps:
+                  - name: checkout
+                    uses: actions/checkout@v4
+            """,
+        )
+        errors, warnings = check_workflow(path, tmp_path.parent, _devtools_command_names())
+        assert errors == []
+        assert warnings == []
+
+    def test_existing_path_no_warning(self, tmp_path: Path) -> None:
+        repo_root = tmp_path / "repo"
+        repo_root.mkdir()
+        (repo_root / "polylogue").mkdir()
+        path = tmp_path / "repo" / "workflow.yml"
+        path.write_text(
+            textwrap.dedent(
+                """
+                jobs:
+                  lint:
+                    steps:
+                      - run: ruff check polylogue/
+                """
+            )
+        )
+        errors, warnings = check_workflow(path, repo_root, _devtools_command_names())
+        assert errors == []
+        assert warnings == []
+
+    def test_nonexistent_path_is_warning(self, tmp_path: Path) -> None:
+        path = self._write_yaml(
+            tmp_path,
+            """
+            jobs:
+              lint:
+                steps:
+                  - run: ruff check totally_nonexistent_dir/
+            """,
+        )
+        _, warnings = check_workflow(path, tmp_path, _devtools_command_names())
+        assert any("totally_nonexistent_dir" in w for w in warnings)
+
+
+class TestMain:
+    def test_passes_on_real_workflows(self) -> None:
+        result = main([])
+        assert result == 0
+
+    def test_json_output_structure(self, capsys: pytest.CaptureFixture[str]) -> None:
+        import json
+
+        main(["--json"])
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert "blocking" in data
+        assert "errors" in data
+        assert "warnings" in data
+        assert "files_checked" in data
+        assert data["blocking"] is False
+        assert data["files_checked"] >= 1

--- a/tests/witnesses/blob-store-layout.witness.json
+++ b/tests/witnesses/blob-store-layout.witness.json
@@ -39,7 +39,7 @@
     "discovered_at": "2026-04-15T00:00:00+00:00",
     "minimized_at": "2026-04-15T00:00:00+00:00",
     "committed_at": "2026-04-15T00:00:00+00:00",
-    "last_exercised_at": "2026-04-15T00:00:00+00:00",
+    "last_exercised_at": "2026-05-16T00:00:00+00:00",
     "retired_at": null,
     "retirement_reason": null
   }

--- a/tests/witnesses/browser-capture-sequence.witness.json
+++ b/tests/witnesses/browser-capture-sequence.witness.json
@@ -38,7 +38,7 @@
     "discovered_at": "2026-04-15T00:00:00+00:00",
     "minimized_at": "2026-04-15T00:00:00+00:00",
     "committed_at": "2026-04-15T00:00:00+00:00",
-    "last_exercised_at": "2026-04-15T00:00:00+00:00",
+    "last_exercised_at": "2026-05-16T00:00:00+00:00",
     "retired_at": null,
     "retirement_reason": null
   }

--- a/tests/witnesses/cli-command-surface.witness.json
+++ b/tests/witnesses/cli-command-surface.witness.json
@@ -38,7 +38,7 @@
     "discovered_at": "2026-04-15T00:00:00+00:00",
     "minimized_at": "2026-04-15T00:00:00+00:00",
     "committed_at": "2026-04-15T00:00:00+00:00",
-    "last_exercised_at": "2026-04-15T00:00:00+00:00",
+    "last_exercised_at": "2026-05-16T00:00:00+00:00",
     "retired_at": null,
     "retirement_reason": null
   }

--- a/tests/witnesses/golden-tool-use-json.witness.json
+++ b/tests/witnesses/golden-tool-use-json.witness.json
@@ -37,7 +37,7 @@
     "discovered_at": "2026-04-15T00:00:00+00:00",
     "minimized_at": "2026-04-15T00:00:00+00:00",
     "committed_at": "2026-04-15T00:00:00+00:00",
-    "last_exercised_at": "2026-04-15T00:00:00+00:00",
+    "last_exercised_at": "2026-05-16T00:00:00+00:00",
     "retired_at": null,
     "retirement_reason": null
   }

--- a/tests/witnesses/mcp-tool-schemas.witness.json
+++ b/tests/witnesses/mcp-tool-schemas.witness.json
@@ -38,7 +38,7 @@
     "discovered_at": "2026-04-15T00:00:00+00:00",
     "minimized_at": "2026-04-15T00:00:00+00:00",
     "committed_at": "2026-04-15T00:00:00+00:00",
-    "last_exercised_at": "2026-04-15T00:00:00+00:00",
+    "last_exercised_at": "2026-05-16T00:00:00+00:00",
     "retired_at": null,
     "retirement_reason": null
   }

--- a/tests/witnesses/topology-projection.witness.json
+++ b/tests/witnesses/topology-projection.witness.json
@@ -38,7 +38,7 @@
     "discovered_at": "2026-04-15T00:00:00+00:00",
     "minimized_at": "2026-04-15T00:00:00+00:00",
     "committed_at": "2026-04-15T00:00:00+00:00",
-    "last_exercised_at": "2026-04-15T00:00:00+00:00",
+    "last_exercised_at": "2026-05-16T00:00:00+00:00",
     "retired_at": null,
     "retirement_reason": null
   }


### PR DESCRIPTION
## Summary

Phase 4 of the verifiability revamp: make manifests and checks reflect actual
code state rather than aspirational claims.

## Problem

Three concrete gaps addressed:

1. `test-coverage-domains.yaml` had 5 stale test file references pointing to
   files renamed or removed during the architecture refactor — no enforcement
   caught them.
2. `verify-test-ownership` warned about 3 orphan tests not declared in the
   shared manifest, creating noise on every run.
3. No gate verified that CI workflow files reference real devtools commands.

## Solution

**`devtools verify-ci-workflows`** (new command + verify --quick gate):
- Parses `.github/workflows/*.yml` and verifies all `devtools <cmd>` calls
  reference registered catalog commands; unknown commands block.
- Checks that ruff/mypy/pytest path arguments exist on disk (warnings only).
- Does not check remote CI state — only locally-verifiable facts.

**`devtools verify-manifests`**: added `check_test_coverage_domains()` check:
- Validates `covering_tests` paths in `test-coverage-domains.yaml` exist.
- Fixes 5 stale references exposed by the new check.

**`docs/plans/test-ownership.yaml`**: 3 orphan tests registered in `shared:`,
clearing the per-run warning from `verify-test-ownership`.

## Verification

```
devtools verify --quick   # exit_code: 0, 16 gates including verify-ci-workflows
devtools verify-manifests  # ✓ manifest consistency checks passed
devtools verify-test-ownership  # production modules: 733, covered: 820, no warnings
pytest tests/unit/devtools/test_verify_ci_workflows.py  # 10 passed
```

Ref #590, Ref #1064