### PR TITLE
feat(benchmarks+devtools): campaigns, SLO, evidence-report (#998, #1063, #997)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1012,6 +1012,7 @@ These are the commands worth remembering during normal repo work:
 | `devtools artifact-graph` | Render the runtime artifact, operation, and scenario-coverage map. |
 | `devtools coverage-gate` | Run pytest with the repository coverage floor from pyproject.toml. |
 | `devtools daemon-workload-probe` | Inspect daemon ingest workload, convergence debt, and hot query plans. |
+| `devtools evidence-report` | Aggregate verification evidence into a structured status report. |
 | `devtools lab-corpus` | Generate verification-lab synthetic corpus fixtures and demo archives. |
 | `devtools lab-scenario` | Run verification-lab showcase scenario sets and baseline checks. |
 | `devtools obligation-diff` | Diff catalog-backed verification checks between two git refs. |

--- a/devtools/benchmark_scenario_catalog.py
+++ b/devtools/benchmark_scenario_catalog.py
@@ -42,6 +42,32 @@ BENCHMARK_SCENARIOS: tuple[BenchmarkCampaignEntry, ...] = (
         ),
         tags=("benchmark", "pipeline"),
     ),
+    BenchmarkCampaignEntry(
+        name="reader-api",
+        description="Reader HTTP API list/get/facets/context-pack/cost-rollup benchmark domain",
+        execution=pytest_execution("tests/benchmarks/test_reader_api.py"),
+        notes=(
+            "Covers reader read-path latency for list, get, facets, and context operations.",
+            "SLO catalog gates are defined in docs/plans/slo-catalog.yaml.",
+        ),
+        origin="authored.benchmark-domain",
+        artifact_targets=("reader_list_results", "reader_facets"),
+        operation_targets=("benchmark.reader.api",),
+        tags=("benchmark", "reader", "api"),
+    ),
+    BenchmarkCampaignEntry(
+        name="daemon-convergence",
+        description="Daemon ingest convergence at synthetic scale tiers — single-file and multi-session",
+        execution=pytest_execution("tests/benchmarks/test_daemon_convergence.py"),
+        notes=(
+            "Measures convergence stage timing at small/medium/large synthetic tiers.",
+            "Run with --benchmark-enable -p no:xdist -o 'addopts='",
+        ),
+        origin="authored.benchmark-domain",
+        artifact_targets=("daemon_convergence_timing",),
+        operation_targets=("benchmark.daemon.convergence",),
+        tags=("benchmark", "daemon", "convergence"),
+    ),
 )
 
 BENCHMARK_SCENARIO_INDEX: dict[str, BenchmarkCampaignEntry] = compile_benchmark_campaigns(BENCHMARK_SCENARIOS)

--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -552,6 +552,17 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
         examples=("devtools verify-layering", "devtools verify-layering --json"),
     ),
     CommandSpec(
+        "evidence-report",
+        "verification",
+        "Aggregate verification evidence into a structured status report.",
+        "devtools.evidence_report",
+        use_when="Review cached verify history, contract evidence, suppressions, witnesses, and benchmark campaigns without running tests.",
+        examples=(
+            "devtools evidence-report",
+            "devtools evidence-report --json",
+        ),
+    ),
+    CommandSpec(
         "witness-discover",
         "maintenance",
         "Save a failure-triggering input as a local witness in .local/witnesses/new/.",

--- a/devtools/evidence_report.py
+++ b/devtools/evidence_report.py
@@ -1,0 +1,302 @@
+"""Aggregate verification evidence into a structured status report.
+
+This command reads cached verification data and produces a status dashboard
+without running tests. It aggregates:
+
+- Verify history (success/failure runs)
+- Contract evidence artifacts
+- Suppression registry state
+- Witness lifecycle
+- Benchmark campaign runs
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter, defaultdict
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from devtools import repo_root as _get_root
+from devtools.verify_suppressions import discover_source_suppressions
+from polylogue.proof.suppressions import load_suppressions
+
+ROOT = _get_root()
+
+
+def _load_verify_history(history_file: Path) -> list[dict[str, Any]]:
+    """Load verify history from JSONL file."""
+    if not history_file.exists():
+        return []
+    entries: list[dict[str, Any]] = []
+    try:
+        with open(history_file) as f:
+            for line in f:
+                if line.strip():
+                    entries.append(json.loads(line))
+    except (OSError, json.JSONDecodeError):
+        pass
+    return entries
+
+
+def _load_contract_evidence(evidence_dir: Path) -> list[dict[str, Any]]:
+    """Load contract evidence artifacts from .json files."""
+    if not evidence_dir.exists():
+        return []
+    artifacts: list[dict[str, Any]] = []
+    try:
+        for json_file in sorted(evidence_dir.glob("*.json")):
+            try:
+                with open(json_file) as f:
+                    data = json.load(f)
+                    artifacts.append(data)
+            except (OSError, json.JSONDecodeError):
+                pass
+    except OSError:
+        pass
+    return artifacts
+
+
+def _load_witnesses(witnesses_dir: Path) -> list[dict[str, Any]]:
+    """Load witness metadata from .witness.json files."""
+    if not witnesses_dir.exists():
+        return []
+    witnesses: list[dict[str, Any]] = []
+    try:
+        for json_file in sorted(witnesses_dir.glob("*.witness.json")):
+            try:
+                with open(json_file) as f:
+                    data = json.load(f)
+                    witnesses.append(data)
+            except (OSError, json.JSONDecodeError):
+                pass
+    except OSError:
+        pass
+    return witnesses
+
+
+def _load_benchmark_campaigns(campaigns_dir: Path) -> list[tuple[str, datetime]]:
+    """Load benchmark campaign run names and dates."""
+    if not campaigns_dir.exists():
+        return []
+    runs: list[tuple[str, datetime]] = []
+    try:
+        for json_file in sorted(campaigns_dir.glob("**/*.json"), reverse=True):
+            try:
+                mtime = datetime.fromtimestamp(json_file.stat().st_mtime, tz=timezone.utc)
+                runs.append((json_file.stem, mtime))
+            except OSError:
+                pass
+    except OSError:
+        pass
+    return runs
+
+
+def _get_last_n_days(entries: list[dict[str, Any]], days: int) -> list[dict[str, Any]]:
+    """Filter entries to last N days."""
+    now = datetime.now(timezone.utc)
+    cutoff = now - timedelta(days=days)
+    result = []
+    for entry in entries:
+        try:
+            ts_str = entry.get("timestamp", "")
+            if ts_str:
+                # Parse ISO 8601 timestamp
+                ts = datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
+                if ts >= cutoff:
+                    result.append(entry)
+        except (ValueError, AttributeError):
+            pass
+    return result
+
+
+def _format_timestamp(ts_str: str | None) -> str:
+    """Format timestamp for display."""
+    if not ts_str:
+        return "unknown"
+    try:
+        dt = datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
+        return dt.strftime("%Y-%m-%d %H:%M")
+    except (ValueError, AttributeError):
+        return ts_str
+
+
+def _is_stale_witness(witness: dict[str, Any], days: int = 30) -> bool:
+    """Check if witness is stale (not exercised in N days)."""
+    lifecycle = witness.get("lifecycle", {})
+    last_exercised = lifecycle.get("last_exercised_at")
+    if not last_exercised:
+        return False
+    try:
+        dt = datetime.fromisoformat(last_exercised.replace("Z", "+00:00"))
+        now = datetime.now(timezone.utc)
+        age_days = (now - dt).days
+        return age_days > days
+    except (ValueError, AttributeError):
+        return False
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Main entry point."""
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--json", action="store_true", help="Output JSON format")
+    args = p.parse_args(argv)
+
+    cache_dir = ROOT / ".cache"
+    verify_history_file = cache_dir / "verify-history.jsonl"
+    evidence_dir = cache_dir / "verification" / "evidence"
+    witnesses_dir = ROOT / "tests" / "witnesses"
+    campaigns_dir = ROOT / ".local" / "benchmark-campaigns"
+
+    # Load all data
+    verify_history = _load_verify_history(verify_history_file)
+    contract_evidence = _load_contract_evidence(evidence_dir)
+    witnesses = _load_witnesses(witnesses_dir)
+    benchmark_runs = _load_benchmark_campaigns(campaigns_dir)
+    registry_path = ROOT / "docs" / "plans" / "suppressions.yaml"
+    registry = load_suppressions(registry=registry_path) if registry_path.exists() else []
+    suppressions = discover_source_suppressions(ROOT, suppressions=registry)
+
+    # Process verify history
+    last_5_runs = verify_history[-5:] if verify_history else []
+    last_30d_runs = _get_last_n_days(verify_history, 30)
+    pass_count = sum(1 for r in last_30d_runs if r.get("exit_code") == 0)
+    fail_count = sum(1 for r in last_30d_runs if r.get("exit_code") != 0)
+
+    # Process contract evidence
+    evidence_by_prefix: dict[str, int] = defaultdict(int)
+    stale_artifacts = []
+    for artifact in contract_evidence:
+        contract = artifact.get("contract", "unknown")
+        prefix = contract.split(".")[0] if contract else "unknown"
+        evidence_by_prefix[prefix] += 1
+        if artifact.get("dirty") or not artifact.get("git_sha"):
+            stale_artifacts.append(contract)
+
+    # Process suppressions
+    suppression_by_kind = Counter(s.kind for s in suppressions)
+    unregistered_suppressions = [s for s in suppressions if not s.registered]
+
+    # Process witnesses
+    stale_witnesses = [w for w in witnesses if _is_stale_witness(w)]
+    witness_names = [w.get("witness_id", "unknown") for w in stale_witnesses]
+
+    # Process benchmark campaigns
+    latest_campaigns: dict[str, datetime] = {}
+    for name, mtime in benchmark_runs:
+        if name not in latest_campaigns or mtime > latest_campaigns[name]:
+            latest_campaigns[name] = mtime
+
+    # Report timestamp
+    now = datetime.now(timezone.utc)
+
+    if args.json:
+        output = {
+            "timestamp": now.isoformat(),
+            "verify_history": {
+                "last_5_runs": [
+                    {
+                        "timestamp": r.get("timestamp"),
+                        "tier": r.get("tier"),
+                        "exit_code": r.get("exit_code"),
+                        "duration_s": r.get("total_duration_s"),
+                    }
+                    for r in last_5_runs
+                ],
+                "last_30_days": {
+                    "total": len(last_30d_runs),
+                    "passed": pass_count,
+                    "failed": fail_count,
+                },
+            },
+            "contract_evidence": {
+                "total_artifacts": len(contract_evidence),
+                "stale_artifacts": len(stale_artifacts),
+                "by_prefix": dict(evidence_by_prefix),
+            },
+            "suppressions": {
+                "total_discovered": len(suppressions),
+                "by_kind": dict(suppression_by_kind),
+                "unregistered": len(unregistered_suppressions),
+            },
+            "witnesses": {
+                "total": len(witnesses),
+                "stale": len(stale_witnesses),
+                "stale_names": witness_names,
+            },
+            "benchmark_campaigns": {
+                "total_campaigns": len(latest_campaigns),
+                "campaigns": [
+                    {"name": name, "latest_run": mtime.isoformat()} for name, mtime in sorted(latest_campaigns.items())
+                ],
+            },
+            "blocking": False,
+        }
+        json.dump(output, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+    else:
+        # Human-readable output
+        print(f"Evidence Report ({now.isoformat()})")
+        print()
+
+        # Verify history section
+        print("VERIFY HISTORY (last 5 runs)")
+        if last_5_runs:
+            for run in reversed(last_5_runs[-5:]):
+                ts = _format_timestamp(run.get("timestamp"))
+                tier = run.get("tier", "unknown")[:5].ljust(5)
+                exit_code = run.get("exit_code", -1)
+                status = "pass" if exit_code == 0 else "fail"
+                duration = run.get("total_duration_s", 0)
+                print(f"  {ts} {tier} {status}  {duration:.2f}s")
+        else:
+            print("  (no history)")
+        print()
+
+        # Contract evidence section
+        print(f"CONTRACT EVIDENCE ({len(contract_evidence)} artifacts, {len(stale_artifacts)} stale)")
+        for prefix in sorted(evidence_by_prefix.keys()):
+            count = evidence_by_prefix[prefix]
+            print(f"  {prefix}: {count} artifacts")
+        print()
+
+        # Suppressions section
+        print("SUPPRESSIONS")
+        total_supp = len(suppressions)
+        if total_supp > 0:
+            kind_str = " ".join(f"{kind}={count}" for kind, count in sorted(suppression_by_kind.items()))
+            print(f"  {total_supp} discovered: {kind_str}")
+            print(f"  {len(unregistered_suppressions)} unregistered")
+        else:
+            print("  (none discovered)")
+        print()
+
+        # Witnesses section
+        print(f"WITNESSES ({len(witnesses)} total, {len(stale_witnesses)} stale)")
+        if stale_witnesses:
+            for name in sorted(witness_names):
+                print(f"  {name}")
+        else:
+            print("  All fresh")
+        print()
+
+        # Benchmark campaigns section
+        print("BENCHMARK CAMPAIGNS")
+        if latest_campaigns:
+            for name in sorted(latest_campaigns.keys()):
+                mtime = latest_campaigns[name]
+                print(f"  {name}: {mtime.strftime('%Y-%m-%d %H:%M')}")
+        else:
+            print("  No local campaign runs found (run devtools benchmark-campaign run <name>)")
+        print()
+
+        print("blocking=False")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -101,6 +101,7 @@ These are the commands worth remembering during normal repo work:
 | `devtools artifact-graph` | Render the runtime artifact, operation, and scenario-coverage map. |
 | `devtools coverage-gate` | Run pytest with the repository coverage floor from pyproject.toml. |
 | `devtools daemon-workload-probe` | Inspect daemon ingest workload, convergence debt, and hot query plans. |
+| `devtools evidence-report` | Aggregate verification evidence into a structured status report. |
 | `devtools lab-corpus` | Generate verification-lab synthetic corpus fixtures and demo archives. |
 | `devtools lab-scenario` | Run verification-lab showcase scenario sets and baseline checks. |
 | `devtools obligation-diff` | Diff catalog-backed verification checks between two git refs. |

--- a/docs/plans/campaign-coverage.yaml
+++ b/docs/plans/campaign-coverage.yaml
@@ -275,3 +275,17 @@ benchmark_campaigns:
     tests:
       - tests/benchmarks/test_storage.py
     status: active
+
+  - name: reader-api
+    description: >
+      Reader HTTP API list/get/facets/context-pack/cost-rollup benchmark domain
+    tests:
+      - tests/benchmarks/test_reader_api.py
+    status: active
+
+  - name: daemon-convergence
+    description: >
+      Daemon ingest convergence at synthetic scale tiers — single-file and multi-session
+    tests:
+      - tests/benchmarks/test_daemon_convergence.py
+    status: active

--- a/docs/plans/slo-catalog.yaml
+++ b/docs/plans/slo-catalog.yaml
@@ -57,3 +57,10 @@ surfaces:
     p50_ms: 300
     p95_ms: 800
     gate: "informational"
+
+  daemon_convergence_single_file:
+    description: "Daemon ingest convergence for a single 1000-message synthetic session"
+    benchmark_test: "tests/benchmarks/test_daemon_convergence.py::test_convergence_single_file_perf"
+    p50_ms: 30000
+    p95_ms: 60000
+    gate: "informational"

--- a/docs/test-quality-workflows.md
+++ b/docs/test-quality-workflows.md
@@ -12,11 +12,11 @@ Current registry snapshot:
 - live lanes: `20`
 - composite lanes: `24`
 - mutation campaigns: `19`
-- benchmark campaigns: `3`
+- benchmark campaigns: `5`
 - synthetic benchmark campaigns: `7`
-- scenario projections: `245`
+- scenario projections: `247`
 - inferred corpus scenarios: `8`
-  - benchmark-campaign: `3`
+  - benchmark-campaign: `5`
   - exercise: `140`
   - inferred-corpus-scenario: `8`
   - mutation-campaign: `19`
@@ -236,7 +236,9 @@ Benchmark comparisons are manual.
 
 | Campaign | Tests | Warn | Fail | Description |
 | --- | --- | ---: | ---: | --- |
+| `daemon-convergence` | `tests/benchmarks/test_daemon_convergence.py` | 0.0% | 0.0% | Daemon ingest convergence at synthetic scale tiers — single-file and multi-session |
 | `pipeline` | `tests/benchmarks/test_pipeline.py` | 0.0% | 0.0% | Index rebuild/update, action-event repair, plus hashing/semantic helper benchmark domain |
+| `reader-api` | `tests/benchmarks/test_reader_api.py` | 0.0% | 0.0% | Reader HTTP API list/get/facets/context-pack/cost-rollup benchmark domain |
 | `search-filters` | `tests/benchmarks/test_search_filters.py` | 0.0% | 0.0% | FTS and ConversationFilter benchmark domain |
 | `storage` | `tests/benchmarks/test_storage.py` | 0.0% | 0.0% | Repository/backend list/get-many/save benchmark domain |
 
@@ -275,7 +277,9 @@ These are the authored scenario-bearing projections currently feeding runtime co
 
 | Source | Projection | Path Targets | Artifact Targets | Operation Targets | Maintenance Targets | Tags | Description |
 | --- | --- | --- | --- | --- | --- | --- | --- |
+| `benchmark-campaign` | `daemon-convergence` | — | `daemon_convergence_timing` | `benchmark.daemon.convergence` | — | `benchmark`<br>`daemon`<br>`convergence` | Daemon ingest convergence at synthetic scale tiers — single-file and multi-session |
 | `benchmark-campaign` | `pipeline` | — | `index_state`<br>`pipeline_helpers` | `benchmark.pipeline.index-and-helpers`<br>`benchmark.repair.action-events` | — | `benchmark`<br>`pipeline` | Index rebuild/update, action-event repair, plus hashing/semantic helper benchmark domain |
+| `benchmark-campaign` | `reader-api` | — | `reader_list_results`<br>`reader_facets` | `benchmark.reader.api` | — | `benchmark`<br>`reader`<br>`api` | Reader HTTP API list/get/facets/context-pack/cost-rollup benchmark domain |
 | `benchmark-campaign` | `search-filters` | — | `conversation_query_results`<br>`message_fts` | `query-conversations`<br>`benchmark.query.search-filters` | — | `benchmark`<br>`search`<br>`filters` | FTS and ConversationFilter benchmark domain |
 | `benchmark-campaign` | `storage` | — | `conversation_rows`<br>`message_rows`<br>`raw_rows` | `benchmark.storage.crud` | — | `benchmark`<br>`storage` | Repository/backend list/get-many/save benchmark domain |
 | `exercise` | `combined-filters` | — | — | — | — | — | Combined provider + date filter |

--- a/docs/verification-catalog.md
+++ b/docs/verification-catalog.md
@@ -8,10 +8,10 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 
 ## Snapshot
 
-- subjects: `549`
+- subjects: `551`
 - claims: `37`
 - runner bindings: `37`
-- proof obligations: `443`
+- proof obligations: `445`
 
 ## Quality Checks
 
@@ -38,7 +38,7 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | `archive.query_law` | 1 |
 | `artifact.path` | 25 |
 | `assurance.coverage_gap` | 22 |
-| `assurance.coverage_item` | 103 |
+| `assurance.coverage_item` | 105 |
 | `assurance.coverage_manifest` | 9 |
 | `cli.command` | 53 |
 | `cli.json_command` | 5 |
@@ -152,7 +152,7 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 
 | Domain | Subject Kind | Count |
 | --- | --- | ---: |
-| `benchmark_coverage` | `assurance.coverage_item` | 3 |
+| `benchmark_coverage` | `assurance.coverage_item` | 5 |
 | `cli_surface` | `assurance.coverage_item` | 2 |
 | `distribution` | `assurance.coverage_gap` | 7 |
 | `distribution` | `assurance.coverage_item` | 8 |
@@ -277,7 +277,7 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | `archive.query.provider_filter_consistency` | 1 |
 | `artifact.path.dependency_closure` | 9 |
 | `assurance.coverage.gap_has_closure_path` | 22 |
-| `assurance.coverage.item_declared` | 103 |
+| `assurance.coverage.item_declared` | 105 |
 | `assurance.coverage.manifest_structured` | 9 |
 | `diagnostic.observable_trace_mapping` | 1 |
 | `error.machine_user_context` | 2 |

--- a/tests/unit/daemon/test_convergence_final_state.py
+++ b/tests/unit/daemon/test_convergence_final_state.py
@@ -1,0 +1,133 @@
+"""Convergence final-state contract test.
+
+Verifies that after daemon live-ingest completes on a synthetic corpus:
+  1. All files succeed — no failures, no silently dropped conversations
+  2. Conversations and messages appear in the archive database
+  3. Post-ingest convergence stages complete without error
+  4. Convergence debt is empty (no pending retry items)
+
+This is a behavioral contract, not a benchmark. It proves that
+convergence leads to a consistent final archive state.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sqlite3
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+
+from polylogue.daemon.convergence import DaemonConverger
+from polylogue.daemon.convergence_stages import make_default_convergence_stages
+from polylogue.sources.live.batch import LiveBatchProcessor
+from polylogue.sources.live.cursor import CursorStore
+from polylogue.sources.live.watcher import WatchSource
+
+
+def _write_claude_code_session(path: Path, session_id: str, n_messages: int) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    records = []
+    for i in range(n_messages):
+        role = "user" if i % 2 == 0 else "assistant"
+        records.append(
+            {
+                "parentUuid": None if i == 0 else f"msg-{session_id}-{i - 1:03d}",
+                "sessionId": session_id,
+                "type": role,
+                "message": {
+                    "role": role,
+                    "content": f"Message {i}: {'The quick brown fox. ' * 5}",
+                },
+                "uuid": f"msg-{session_id}-{i:03d}",
+                "timestamp": f"2026-05-16T00:{i // 60:02d}:{i % 60:02d}.000Z",
+                "cwd": "/realm/project/polylogue",
+                "version": "1.0.6",
+                "isSidechain": False,
+                "userType": "external",
+            }
+        )
+    with open(path, "w") as f:
+        for rec in records:
+            f.write(json.dumps(rec) + "\n")
+
+
+class _MinimalPolylogue:
+    """Minimal polylogue double sufficient for LiveBatchProcessor."""
+
+    def __init__(self, archive_root: Path, db_path: Path) -> None:
+        self.archive_root = archive_root
+        self.backend = SimpleNamespace(db_path=db_path)
+
+
+def test_convergence_produces_consistent_final_archive_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """After live ingest of a synthetic corpus, archive state must be consistent.
+
+    Checks:
+    - All files succeed (no failures)
+    - Conversations and messages are in the archive DB
+    - Convergence stages complete without error
+    - No convergence debt remains
+    """
+    corpus_root = tmp_path / "corpus" / "proj"
+    db_path = tmp_path / "polylogue.db"
+    monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(tmp_path))
+    monkeypatch.setenv("POLYLOGUE_SCHEMA_VALIDATION", "off")
+
+    # Generate 3 sessions with 10 messages each.
+    sessions = [
+        ("aaaa0000-0000-0000-0000-000000000001", 10),
+        ("aaaa0000-0000-0000-0000-000000000002", 10),
+        ("aaaa0000-0000-0000-0000-000000000003", 10),
+    ]
+    files: list[Path] = []
+    for session_id, n_msgs in sessions:
+        p = corpus_root / f"{session_id}.jsonl"
+        _write_claude_code_session(p, session_id, n_msgs)
+        files.append(p)
+
+    converger = DaemonConverger(
+        stages=make_default_convergence_stages(db_path),
+        max_workers=2,
+    )
+    polylogue = _MinimalPolylogue(tmp_path, db_path)
+    processor = LiveBatchProcessor(
+        cast(Any, polylogue),
+        (WatchSource(name="test", root=corpus_root.parent),),
+        cursor=CursorStore(db_path),
+        parser_fingerprint="test-v1",
+        converger=converger,
+    )
+
+    metrics = asyncio.run(processor.ingest_files(files, emit_event=False))
+
+    # ── Ingest completeness ──────────────────────────────────────────
+    assert metrics.failed_file_count == 0, f"Unexpected ingest failures: {metrics.failed_file_count}"
+    assert metrics.succeeded_file_count == len(files), (
+        f"Expected {len(files)} successes, got {metrics.succeeded_file_count}"
+    )
+
+    # ── Archive state correctness ────────────────────────────────────
+    with sqlite3.connect(db_path) as conn:
+        (conv_count,) = conn.execute("SELECT COUNT(*) FROM conversations").fetchone()
+        (msg_count,) = conn.execute("SELECT COUNT(*) FROM messages").fetchone()
+
+    # Each session (3) should produce at least one conversation row.
+    assert conv_count >= len(sessions), f"Expected >= {len(sessions)} conversations, got {conv_count}"
+    # Each session has 10 messages.
+    assert msg_count >= len(sessions) * 10, f"Expected >= {len(sessions) * 10} messages, got {msg_count}"
+
+    # ── Convergence debt ─────────────────────────────────────────────
+    with sqlite3.connect(db_path) as conn:
+        table_exists = conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='live_convergence_debt'"
+        ).fetchone()
+        if table_exists:
+            (debt_count,) = conn.execute("SELECT COUNT(*) FROM live_convergence_debt").fetchone()
+            assert debt_count == 0, f"Expected no convergence debt, found {debt_count} pending items"

--- a/tests/unit/devtools/test_evidence_report.py
+++ b/tests/unit/devtools/test_evidence_report.py
@@ -1,0 +1,129 @@
+"""Tests for ``devtools evidence-report``."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from devtools import evidence_report
+
+
+def test_runs_without_cache(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """evidence-report returns 0 even when no cache data exists."""
+    monkeypatch.setattr(evidence_report, "ROOT", tmp_path)
+    rc = evidence_report.main([])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Evidence Report" in out
+    assert "blocking=False" in out
+
+
+def test_json_output_structure(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """JSON output has required top-level keys."""
+    monkeypatch.setattr(evidence_report, "ROOT", tmp_path)
+    rc = evidence_report.main(["--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert "timestamp" in payload
+    assert "verify_history" in payload
+    assert "contract_evidence" in payload
+    assert "suppressions" in payload
+    assert "witnesses" in payload
+    assert "benchmark_campaigns" in payload
+
+
+def test_reads_verify_history(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Verify history from .cache/verify-history.jsonl is included in output."""
+    monkeypatch.setattr(evidence_report, "ROOT", tmp_path)
+    cache = tmp_path / ".cache"
+    cache.mkdir()
+    history = cache / "verify-history.jsonl"
+    history.write_text(
+        json.dumps(
+            {
+                "timestamp": "2026-05-16T04:00:00+00:00",
+                "tier": "quick",
+                "exit_code": 0,
+                "total_duration_s": 20.5,
+                "steps": [],
+            }
+        )
+        + "\n"
+    )
+    rc = evidence_report.main(["--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    runs = payload["verify_history"]["last_5_runs"]
+    assert len(runs) == 1
+    assert runs[0]["tier"] == "quick"
+    assert runs[0]["exit_code"] == 0
+
+
+def test_reads_contract_evidence(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Contract evidence artifacts are counted and grouped."""
+    monkeypatch.setattr(evidence_report, "ROOT", tmp_path)
+    evidence_dir = tmp_path / ".cache" / "verification" / "evidence"
+    evidence_dir.mkdir(parents=True)
+    artifact = {
+        "contract": "cli.json_envelope",
+        "command": "list",
+        "dirty": False,
+        "git_sha": "abc123",
+        "facts": [],
+    }
+    (evidence_dir / "cli.json_envelope-abc123.json").write_text(json.dumps(artifact))
+
+    rc = evidence_report.main(["--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    evidence = payload["contract_evidence"]
+    assert evidence["total_artifacts"] == 1
+    assert evidence["stale_artifacts"] == 0
+    assert "cli" in evidence["by_prefix"]
+
+
+def test_reads_witnesses(tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch) -> None:
+    """Witness lifecycle data is included."""
+    monkeypatch.setattr(evidence_report, "ROOT", tmp_path)
+    witnesses_dir = tmp_path / "tests" / "witnesses"
+    witnesses_dir.mkdir(parents=True)
+    witness = {
+        "witness_id": "test-witness",
+        "lifecycle": {"last_exercised_at": "2026-05-16T00:00:00+00:00"},
+    }
+    (witnesses_dir / "test-witness.witness.json").write_text(json.dumps(witness))
+
+    rc = evidence_report.main(["--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["witnesses"]["total"] == 1
+    assert payload["witnesses"]["stale"] == 0
+
+
+def test_stale_witness_detection(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Witnesses not exercised in 30+ days are flagged stale."""
+    monkeypatch.setattr(evidence_report, "ROOT", tmp_path)
+    witnesses_dir = tmp_path / "tests" / "witnesses"
+    witnesses_dir.mkdir(parents=True)
+    witness = {
+        "witness_id": "old-witness",
+        "lifecycle": {"last_exercised_at": "2026-01-01T00:00:00+00:00"},
+    }
+    (witnesses_dir / "old.witness.json").write_text(json.dumps(witness))
+
+    rc = evidence_report.main(["--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["witnesses"]["stale"] == 1

--- a/tests/unit/devtools/test_obligation_diff.py
+++ b/tests/unit/devtools/test_obligation_diff.py
@@ -21,7 +21,7 @@ def test_obligation_diff_accepts_ref_flags_and_markdown(
     assert obligation_diff.main(["--base-ref", "origin/master", "--head-ref", "HEAD", "--markdown"]) == 0
 
     rendered = capsys.readouterr().out
-    assert "## Proof Obligations" in rendered
+    assert "## Affected Verification Checks" in rendered
     assert "`origin/master..HEAD`" in rendered
 
 


### PR DESCRIPTION
## Summary

Three coordinated improvements to verification infrastructure: registers missing benchmark campaigns, adds daemon convergence to SLO tracking, and introduces the evidence-report dashboard command.

## Problem

1. `test_reader_api.py` was referenced in `slo-catalog.yaml` but not registered as a benchmark campaign. `test_daemon_convergence.py` existed but was invisible to all tooling.
2. No single view existed showing verification health — verify history, contract evidence, suppression state, witness lifecycle, and benchmark campaigns required reading multiple files.
3. Pre-existing test failure: `test_obligation_diff_accepts_ref_flags_and_markdown` asserted the old "## Proof Obligations" heading.

## Solution

**Benchmark campaigns** (`devtools/benchmark_scenario_catalog.py`, `docs/plans/campaign-coverage.yaml`):
- Registered `reader-api` and `daemon-convergence` as authored benchmark campaigns
- `devtools benchmark-campaign list` now shows 5 campaigns

**SLO catalog** (`docs/plans/slo-catalog.yaml`):
- Added `daemon_convergence_single_file` as an informational SLO entry (30s budget)
- Makes daemon throughput visible in `devtools verify --lab`

**Evidence report** (`devtools/evidence_report.py`):
- New `devtools evidence-report` command
- Reads `.cache/verify-history.jsonl`, `.cache/verification/evidence/*.json`, `tests/witnesses/*.witness.json`, `.local/benchmark-campaigns/`
- Supports `--json` output; always exits 0 (diagnostic, not blocking)
- 6 tests in `tests/unit/devtools/test_evidence_report.py`

**Test fix**: Updated `test_obligation_diff.py` stale heading assertion.

## Verification

```
$ python -m devtools benchmark-campaign list
# 5 campaigns listed including reader-api and daemon-convergence

$ python -m devtools verify-slos
# PASS (6 surfaces) — daemon_convergence_single_file: p50=229ms (≤30000ms)

$ python -m devtools evidence-report
# Evidence Report showing history, 14 contract artifacts, witnesses, campaigns

$ devtools verify --quick
# exit_code: 0
```

Ref #998 #1063 #997 #845

Co-Authored-By: Claude <noreply@anthropic.com>