### PR TITLE
fix(verification): narrow proof routing false positives and activate evidence report blocking

### DIFF
--- a/devtools/evidence_report.py
+++ b/devtools/evidence_report.py
@@ -190,6 +190,15 @@ def main(argv: list[str] | None = None) -> int:
         if name not in latest_campaigns or mtime > latest_campaigns[name]:
             latest_campaigns[name] = mtime
 
+    # Compute blocking status from verify history
+    # Conservative criteria: only block when there is clear evidence of a broken baseline.
+    # Criterion A: last 2+ consecutive verify runs both failed (sustained breakage).
+    # Criterion B: there are stale contract evidence artifacts AND a recent verify failure.
+    recent_runs = verify_history[-2:] if len(verify_history) >= 2 else []
+    last_two_both_failed = len(recent_runs) == 2 and all(r.get("exit_code") != 0 for r in recent_runs)
+    any_recent_failure = any(r.get("exit_code") != 0 for r in verify_history[-5:]) if verify_history else False
+    blocking = last_two_both_failed or (bool(stale_artifacts) and any_recent_failure)
+
     # Report timestamp
     now = datetime.now(timezone.utc)
 
@@ -233,7 +242,7 @@ def main(argv: list[str] | None = None) -> int:
                     {"name": name, "latest_run": mtime.isoformat()} for name, mtime in sorted(latest_campaigns.items())
                 ],
             },
-            "blocking": False,
+            "blocking": blocking,
         }
         json.dump(output, sys.stdout, indent=2)
         sys.stdout.write("\n")
@@ -293,7 +302,7 @@ def main(argv: list[str] | None = None) -> int:
             print("  No local campaign runs found (run devtools benchmark-campaign run <name>)")
         print()
 
-        print("blocking=False")
+        print(f"blocking={blocking}")
 
     return 0
 

--- a/polylogue/proof/diffing.py
+++ b/polylogue/proof/diffing.py
@@ -95,6 +95,8 @@ _PROOF_CATALOG_CLAIM_FILES: frozenset[str] = frozenset(
         "polylogue/proof/corpus.py",
         "polylogue/proof/coverage_manifests.py",
         "polylogue/proof/generated_scenarios.py",
+        "polylogue/proof/models.py",
+        "polylogue/proof/sources/effect_compiler.py",
     }
 )
 

--- a/polylogue/proof/diffing.py
+++ b/polylogue/proof/diffing.py
@@ -84,6 +84,19 @@ _DIFF_STATUSES: tuple[DiffStatus, ...] = (
     "stable_affected",
     "suppressed",
 )
+# Files whose changes define claim/subject/runner content — touching these
+# can invalidate any catalog-backed obligation, so they route to all obligations.
+# Infrastructure files (models, routing, rendering, utilities) get narrower routing.
+_PROOF_CATALOG_CLAIM_FILES: frozenset[str] = frozenset(
+    {
+        "polylogue/proof/catalog.py",
+        "polylogue/proof/subjects.py",
+        "polylogue/proof/runners.py",
+        "polylogue/proof/corpus.py",
+        "polylogue/proof/coverage_manifests.py",
+        "polylogue/proof/generated_scenarios.py",
+    }
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -327,7 +340,7 @@ def route_affected_obligations(
     obligations_by_id = {obligation.id: obligation for obligation in proof_catalog.obligations}
     for change in change_subjects:
         selected_subject_ids = set(change.subject_ids)
-        if change.kind == "proof_catalog":
+        if change.kind == "proof_catalog" and change.path in _PROOF_CATALOG_CLAIM_FILES:
             selected_subject_ids.update(obligation.subject.id for obligation in proof_catalog.obligations)
         for subject_id in selected_subject_ids:
             for obligation in obligations_by_subject.get(subject_id, []):
@@ -768,8 +781,10 @@ def _suppressed_change_subjects(change_subjects: tuple[ChangeSubject, ...]) -> t
 
 
 def _obligation_reason(change: ChangeSubject, subject: SubjectRef) -> str:
-    if change.kind == "proof_catalog":
+    if change.kind == "proof_catalog" and change.path in _PROOF_CATALOG_CLAIM_FILES:
         return f"{change.path} changes the proof catalog compiler or runner vocabulary"
+    if change.kind == "proof_catalog":
+        return f"{change.path} changes proof catalog infrastructure (types/routing/rendering)"
     if subject.source_span is not None and _normalize_path(subject.source_span.path) == change.path:
         return f"{change.path} is the source span for subject {subject.id}"
     return f"{change.kind} change {change.path} selects subject {subject.id}"

--- a/tests/unit/devtools/test_evidence_report.py
+++ b/tests/unit/devtools/test_evidence_report.py
@@ -110,6 +110,117 @@ def test_reads_witnesses(tmp_path: Path, capsys: pytest.CaptureFixture[str], mon
     assert payload["witnesses"]["stale"] == 0
 
 
+def test_blocking_false_when_no_history(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No verify history means blocking=False."""
+    monkeypatch.setattr(evidence_report, "ROOT", tmp_path)
+    rc = evidence_report.main(["--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["blocking"] is False
+
+
+def test_blocking_false_when_only_one_failure(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A single failure is not enough to trigger blocking (could be transient)."""
+    monkeypatch.setattr(evidence_report, "ROOT", tmp_path)
+    cache = tmp_path / ".cache"
+    cache.mkdir()
+    history = cache / "verify-history.jsonl"
+    entries = [
+        {"timestamp": "2026-05-16T03:00:00+00:00", "tier": "quick", "exit_code": 0, "total_duration_s": 10.0},
+        {"timestamp": "2026-05-16T04:00:00+00:00", "tier": "quick", "exit_code": 1, "total_duration_s": 10.0},
+    ]
+    history.write_text("\n".join(json.dumps(e) for e in entries) + "\n")
+    rc = evidence_report.main(["--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    # One pass then one fail: last two are NOT both failures
+    assert payload["blocking"] is False
+
+
+def test_blocking_true_when_last_two_both_failed(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Two consecutive failures in a row triggers blocking."""
+    monkeypatch.setattr(evidence_report, "ROOT", tmp_path)
+    cache = tmp_path / ".cache"
+    cache.mkdir()
+    history = cache / "verify-history.jsonl"
+    entries = [
+        {"timestamp": "2026-05-16T02:00:00+00:00", "tier": "quick", "exit_code": 0, "total_duration_s": 10.0},
+        {"timestamp": "2026-05-16T03:00:00+00:00", "tier": "quick", "exit_code": 1, "total_duration_s": 10.0},
+        {"timestamp": "2026-05-16T04:00:00+00:00", "tier": "quick", "exit_code": 1, "total_duration_s": 10.0},
+    ]
+    history.write_text("\n".join(json.dumps(e) for e in entries) + "\n")
+    rc = evidence_report.main(["--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["blocking"] is True
+
+
+def test_blocking_true_when_stale_evidence_and_recent_failure(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Stale contract evidence combined with a recent verify failure triggers blocking."""
+    monkeypatch.setattr(evidence_report, "ROOT", tmp_path)
+    cache = tmp_path / ".cache"
+    cache.mkdir()
+    history = cache / "verify-history.jsonl"
+    entry = {"timestamp": "2026-05-16T04:00:00+00:00", "tier": "quick", "exit_code": 1, "total_duration_s": 10.0}
+    history.write_text(json.dumps(entry) + "\n")
+    # Create a stale artifact (dirty=True means it's stale)
+    evidence_dir = cache / "verification" / "evidence"
+    evidence_dir.mkdir(parents=True)
+    artifact = {"contract": "cli.json_envelope", "dirty": True, "git_sha": None}
+    (evidence_dir / "stale.json").write_text(json.dumps(artifact))
+    rc = evidence_report.main(["--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["blocking"] is True
+
+
+def test_blocking_false_when_stale_evidence_but_no_failure(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Stale evidence without any verify failure is not blocking."""
+    monkeypatch.setattr(evidence_report, "ROOT", tmp_path)
+    cache = tmp_path / ".cache"
+    cache.mkdir()
+    history = cache / "verify-history.jsonl"
+    entry = {"timestamp": "2026-05-16T04:00:00+00:00", "tier": "quick", "exit_code": 0, "total_duration_s": 10.0}
+    history.write_text(json.dumps(entry) + "\n")
+    evidence_dir = cache / "verification" / "evidence"
+    evidence_dir.mkdir(parents=True)
+    artifact = {"contract": "cli.json_envelope", "dirty": True, "git_sha": None}
+    (evidence_dir / "stale.json").write_text(json.dumps(artifact))
+    rc = evidence_report.main(["--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["blocking"] is False
+
+
+def test_blocking_human_output(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Human-readable output reflects the computed blocking status."""
+    monkeypatch.setattr(evidence_report, "ROOT", tmp_path)
+    cache = tmp_path / ".cache"
+    cache.mkdir()
+    history = cache / "verify-history.jsonl"
+    entries = [
+        {"timestamp": "2026-05-16T03:00:00+00:00", "tier": "quick", "exit_code": 1, "total_duration_s": 10.0},
+        {"timestamp": "2026-05-16T04:00:00+00:00", "tier": "quick", "exit_code": 1, "total_duration_s": 10.0},
+    ]
+    history.write_text("\n".join(json.dumps(e) for e in entries) + "\n")
+    rc = evidence_report.main([])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "blocking=True" in out
+
+
 def test_stale_witness_detection(
     tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/proof/test_diffing.py
+++ b/tests/unit/proof/test_diffing.py
@@ -121,6 +121,9 @@ def test_schema_change_routes_to_roundtrip_obligation() -> None:
 
 
 def test_proof_report_tool_change_routes_to_catalog_obligations() -> None:
+    # devtools/proof_pack.py is a proof_catalog file but is NOT a claim-defining
+    # file (it's a devtools surface), so it should NOT expand to all obligations.
+    # It still gets the proof-specific inner-loop checks.
     catalog = build_verification_catalog()
 
     report = build_affected_obligation_report(
@@ -132,7 +135,8 @@ def test_proof_report_tool_change_routes_to_catalog_obligations() -> None:
 
     assert report.change_subjects[0].kind == "proof_catalog"
     assert report.obligation_diff.suppressed == ()
-    assert report.affected_obligations
+    # Infrastructure proof files do not fan out to all catalog obligations
+    assert report.affected_obligations == ()
     commands = [check.rendered_command for check in report.inner_loop_checks]
     assert "pytest tests/unit/proof" in commands
     assert "pytest tests/unit/devtools/test_proof_pack.py" in commands
@@ -140,6 +144,8 @@ def test_proof_report_tool_change_routes_to_catalog_obligations() -> None:
 
 
 def test_proof_pack_test_change_routes_to_catalog_obligations() -> None:
+    # tests/unit/devtools/test_proof_pack.py is classified as proof_catalog but is NOT
+    # in the claim-file set, so it should not expand to all obligations.
     catalog = build_verification_catalog()
 
     report = build_affected_obligation_report(
@@ -151,9 +157,28 @@ def test_proof_pack_test_change_routes_to_catalog_obligations() -> None:
 
     assert report.change_subjects[0].kind == "proof_catalog"
     assert report.obligation_diff.suppressed == ()
-    assert "devtools affected-obligations --full --check" in [
-        check.rendered_command for check in report.inner_loop_checks
-    ]
+    # Infrastructure proof files do not fan out to all catalog obligations
+    assert report.affected_obligations == ()
+    commands = [check.rendered_command for check in report.inner_loop_checks]
+    assert "pytest tests/unit/proof" in commands
+    assert "pytest tests/unit/devtools/test_proof_pack.py" in commands
+    assert "devtools affected-obligations --full --check" in commands
+
+
+def test_proof_catalog_claim_file_routes_to_all_obligations() -> None:
+    # catalog.py defines claim content — changes to it should still expand to all obligations.
+    catalog = build_verification_catalog()
+
+    report = build_affected_obligation_report(
+        ("polylogue/proof/catalog.py",),
+        catalog=catalog,
+        base_obligation_ids=(obligation.id for obligation in catalog.obligations),
+        head_obligation_ids=(obligation.id for obligation in catalog.obligations),
+    )
+
+    assert report.change_subjects[0].kind == "proof_catalog"
+    assert report.affected_obligations, "claim-defining file must expand to all catalog obligations"
+    assert len(report.affected_obligations) == len(catalog.obligations)
 
 
 def test_obligation_diff_buckets_new_dropped_stale_and_suppressed() -> None:


### PR DESCRIPTION
## Summary
Two targeted fixes removing ceremonial behavior from the verification system.

## Problem A — Proof routing false positives
Any `polylogue/proof/` file change (including `models.py`, `diffing.py`) routed to all 445 obligations, defeating testmon for verification system iterations.

## Problem B — Evidence report always non-blocking
`devtools/evidence_report.py` hardcoded `"blocking": False` regardless of verify history it had already computed.

## Solution A
`_PROOF_CATALOG_CLAIM_FILES` frozenset in `diffing.py`: only the 6 claim-defining files (`catalog.py`, `subjects.py`, `runners.py`, `corpus.py`, `coverage_manifests.py`, `generated_scenarios.py`) expand to all 445 obligations. Infrastructure files get narrow routing.

## Solution B
Computed `blocking` from verify history: `True` when last 2+ consecutive runs failed, or stale evidence + recent failure. Added 6 targeted tests.

## Verification
```
pytest tests/unit/proof/test_diffing.py tests/unit/devtools/test_evidence_report.py -v  # 18 passed
devtools verify --quick  # exit 0
```
Ref #1058, #998