### PR TITLE
feat(verify): tier SLO catalog and enforce campaign artifact reality (#1063)

### DIFF
--- a/devtools/verify.py
+++ b/devtools/verify.py
@@ -295,7 +295,7 @@ def build_verify_steps(
 
     if lab:
         steps.append(("lab scenario", _devtools_cmd("lab-scenario", "run", "archive-smoke", "--tier", "0")))
-        steps.append(("verify-slos", _devtools_cmd("verify-slos")))
+        steps.append(("verify-slos", _devtools_cmd("verify-slos", "--include-lab")))
     return steps
 
 

--- a/devtools/verify_manifests.py
+++ b/devtools/verify_manifests.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import shlex
 import sys
-from datetime import date
+from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
@@ -296,6 +296,124 @@ def check_campaign_coverage_catalog(plans_dir: Path) -> list[str]:
             },
         )
     )
+    errors.extend(_check_campaign_test_paths(path, data, plans_dir))
+    return errors
+
+
+def _check_campaign_test_paths(
+    path: Path,
+    data: dict[str, object],
+    plans_dir: Path,
+) -> list[str]:
+    """Verify every active campaign declares non-empty tests/paths that exist on disk.
+
+    This closes the manifest-only loophole where a row can carry a name and a
+    description but route nowhere executable.
+    """
+    repo_root = _repo_root_for_plans(plans_dir)
+    errors: list[str] = []
+    for section in ("mutation_campaigns", "benchmark_campaigns"):
+        value = data.get(section)
+        if not isinstance(value, list):
+            continue
+        for index, item in enumerate(value):
+            if not isinstance(item, dict):
+                continue
+            name = item.get("name")
+            label_name = f"{name!r}" if isinstance(name, str) and name.strip() else f"index {index}"
+            status = item.get("status", "active")
+            if status != "active":
+                continue
+            tests = item.get("tests")
+            if not isinstance(tests, list) or not tests:
+                errors.append(
+                    f"{path}: {section} campaign {label_name} declares no tests; "
+                    "active campaigns must point at executable test paths"
+                )
+            else:
+                for test_index, test_path in enumerate(tests):
+                    if not isinstance(test_path, str) or not test_path.strip():
+                        errors.append(
+                            f"{path}: {section} campaign {label_name} tests[{test_index}] must be a non-empty string"
+                        )
+                        continue
+                    candidate = _manifest_path_token(test_path)
+                    if candidate and not _manifest_path_exists(repo_root, candidate):
+                        errors.append(
+                            f"{path}: {section} campaign {label_name} tests[{test_index}] "
+                            f"path does not exist: {candidate!r}"
+                        )
+            if section == "mutation_campaigns":
+                paths_to_mutate = item.get("paths_to_mutate")
+                if not isinstance(paths_to_mutate, list) or not paths_to_mutate:
+                    errors.append(
+                        f"{path}: {section} campaign {label_name} declares no paths_to_mutate; "
+                        "active mutation campaigns must target executable source paths"
+                    )
+            errors.extend(_check_campaign_freshness(path, section, label_name, item, repo_root))
+    return errors
+
+
+def _check_campaign_freshness(
+    path: Path,
+    section: str,
+    label_name: str,
+    item: dict[object, object],
+    repo_root: Path,
+) -> list[str]:
+    """Enforce ``freshness_days`` / ``artifact_glob`` when declared.
+
+    Absent fields stay silent so rows opt in gradually. When declared, the most
+    recent matching artifact must exist, be non-empty, and (if
+    ``freshness_days`` is set) be newer than the declared window. Without an
+    explicit ``artifact_glob``, benchmark campaigns default to
+    ``.local/benchmark-campaigns/*-<name>.json`` — the path written by
+    ``devtools benchmark-campaign run``.
+    """
+    errors: list[str] = []
+    freshness_days = item.get("freshness_days")
+    artifact_glob = item.get("artifact_glob")
+    name = item.get("name")
+    if not isinstance(name, str) or not name.strip():
+        return errors
+
+    fresh_declared = isinstance(freshness_days, int) and freshness_days > 0
+    glob_declared = isinstance(artifact_glob, str) and bool(artifact_glob.strip())
+    if not fresh_declared and not glob_declared:
+        return errors
+
+    if glob_declared:
+        assert isinstance(artifact_glob, str)
+        glob = artifact_glob.strip()
+    elif section == "benchmark_campaigns":
+        glob = f".local/benchmark-campaigns/*-{name}.json"
+    else:
+        errors.append(
+            f"{path}: {section} campaign {label_name} declares freshness_days without "
+            "an artifact_glob; only benchmark_campaigns have a default artifact location"
+        )
+        return errors
+
+    matches = sorted(repo_root.glob(glob))
+    if not matches:
+        errors.append(
+            f"{path}: {section} campaign {label_name} declares artifact glob {glob!r} but no matching artifacts exist"
+        )
+        return errors
+
+    newest = max(matches, key=lambda p: p.stat().st_mtime)
+    if newest.stat().st_size == 0:
+        errors.append(f"{path}: {section} campaign {label_name} newest artifact {newest.name!r} is empty")
+
+    if fresh_declared:
+        assert isinstance(freshness_days, int)
+        age = datetime.now(UTC) - datetime.fromtimestamp(newest.stat().st_mtime, tz=UTC)
+        if age > timedelta(days=freshness_days):
+            errors.append(
+                f"{path}: {section} campaign {label_name} newest artifact {newest.name!r} is "
+                f"{age.days}d old, exceeding freshness_days={freshness_days}"
+            )
+
     return errors
 
 
@@ -340,6 +458,8 @@ def _manifest_named_entries(
     value: object,
     errors: list[str],
 ) -> dict[str, dict[object, object]] | None:
+    if value is None:
+        return {}
     if not isinstance(value, list):
         errors.append(f"{path}: {section!r} must be a list")
         return None

--- a/devtools/verify_slos.py
+++ b/devtools/verify_slos.py
@@ -25,6 +25,8 @@ from devtools.benchmark_results import parse_pytest_benchmark_stats
 ROOT = _get_root()
 SLO_CATALOG = ROOT / "docs" / "plans" / "slo-catalog.yaml"
 SLO_GATES = frozenset({"required", "informational"})
+SLO_TIERS = frozenset({"cheap-local", "lab"})
+DEFAULT_TIER = "cheap-local"
 
 
 # ---------------------------------------------------------------------------
@@ -78,10 +80,23 @@ def _coerce_slo_value(value: str) -> str | int:
 # ---------------------------------------------------------------------------
 
 
-def _collect_benchmark_tests(surfaces: dict[str, dict[str, object]]) -> set[str]:
-    """Collect unique benchmark test node IDs from the SLO catalog."""
+def _collect_benchmark_tests(
+    surfaces: dict[str, dict[str, object]],
+    *,
+    active_tiers: frozenset[str] | None = None,
+) -> set[str]:
+    """Collect unique benchmark test node IDs from the SLO catalog.
+
+    When ``active_tiers`` is provided, only collect tests whose surface tier
+    appears in the set. Surfaces with an invalid tier are skipped (the caller
+    surfaces the catalog error separately).
+    """
     tests: set[str] = set()
-    for _surface_name, config in surfaces.items():
+    for surface_name, config in surfaces.items():
+        if active_tiers is not None:
+            tier, tier_error = _surface_tier(surface_name, config)
+            if tier_error is not None or tier not in active_tiers:
+                continue
         test = config.get("benchmark_test")
         if isinstance(test, str) and test.strip():
             tests.add(test.strip())
@@ -94,6 +109,14 @@ def _surface_gate(surface_name: str, config: dict[str, object]) -> tuple[str | N
     if isinstance(raw_gate, str) and raw_gate in SLO_GATES:
         return raw_gate, None
     return None, f"{surface_name}: invalid gate {raw_gate!r}; expected one of {sorted(SLO_GATES)!r}"
+
+
+def _surface_tier(surface_name: str, config: dict[str, object]) -> tuple[str | None, str | None]:
+    """Return the surface tier, or a catalog error message when invalid."""
+    raw_tier = config.get("tier", DEFAULT_TIER)
+    if isinstance(raw_tier, str) and raw_tier in SLO_TIERS:
+        return raw_tier, None
+    return None, f"{surface_name}: invalid tier {raw_tier!r}; expected one of {sorted(SLO_TIERS)!r}"
 
 
 def _run_benchmarks(test_ids: set[str]) -> dict[str, dict[str, float]]:
@@ -171,6 +194,30 @@ def _estimate_p95(entry_stats: dict[str, float]) -> float:
 # ---------------------------------------------------------------------------
 
 
+def _resolve_active_tiers(
+    *, tier: str | None, include_lab: bool, all_tiers: bool
+) -> tuple[frozenset[str] | None, str | None]:
+    """Resolve which tiers to evaluate from CLI flags.
+
+    Returns ``(tiers, error)``. ``tiers`` is ``None`` when no filter applies
+    (legacy/all-tiers mode), otherwise a frozenset of allowed tier names.
+    ``error`` is a user-facing message when flags are inconsistent.
+    """
+    if all_tiers and (tier is not None or include_lab):
+        return None, "--all-tiers is incompatible with --tier <name> / --include-lab"
+    if all_tiers:
+        return frozenset(SLO_TIERS), None
+    if tier is not None:
+        if tier not in SLO_TIERS:
+            return None, f"--tier {tier!r}: expected one of {sorted(SLO_TIERS)!r}"
+        if include_lab and tier == "cheap-local":
+            return frozenset({"cheap-local", "lab"}), None
+        return frozenset({tier}), None
+    if include_lab:
+        return frozenset({"cheap-local", "lab"}), None
+    return frozenset({DEFAULT_TIER}), None
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--yaml", type=Path, default=SLO_CATALOG)
@@ -180,14 +227,37 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Skip running benchmarks (use with --json to see catalog only)",
     )
+    parser.add_argument(
+        "--tier",
+        choices=sorted(SLO_TIERS),
+        default=None,
+        help="Run only surfaces declared in this tier (default: cheap-local).",
+    )
+    parser.add_argument(
+        "--include-lab",
+        action="store_true",
+        help="Run cheap-local plus lab tier (used by `devtools verify --lab`).",
+    )
+    parser.add_argument(
+        "--all-tiers",
+        action="store_true",
+        help="Run every surface regardless of tier.",
+    )
     args = parser.parse_args(argv)
+
+    active_tiers, tier_error = _resolve_active_tiers(
+        tier=args.tier, include_lab=args.include_lab, all_tiers=args.all_tiers
+    )
+    if tier_error is not None:
+        print(f"verify-slos: {tier_error}", file=sys.stderr)
+        return 2
 
     # 1. Parse SLO catalog
     catalog_text = args.yaml.read_text()
     surfaces = _parse_slo_catalog(catalog_text)
 
-    # 2. Collect benchmark tests
-    test_ids = _collect_benchmark_tests(surfaces)
+    # 2. Collect benchmark tests filtered by active tier
+    test_ids = _collect_benchmark_tests(surfaces, active_tiers=active_tiers)
 
     # 3. Run benchmarks
     benchmark_stats = _run_benchmarks(test_ids) if not args.skip_benchmarks else {}
@@ -198,6 +268,7 @@ def main(argv: list[str] | None = None) -> int:
     missing_required: list[dict[str, object]] = []
     passed: list[dict[str, object]] = []
     uncovered_informational: list[dict[str, object]] = []
+    skipped_tier: list[dict[str, object]] = []
 
     for surface_name, config in surfaces.items():
         gate, gate_error = _surface_gate(surface_name, config)
@@ -205,6 +276,23 @@ def main(argv: list[str] | None = None) -> int:
             catalog_errors.append(gate_error)
             continue
         assert gate is not None
+
+        tier, tier_catalog_error = _surface_tier(surface_name, config)
+        if tier_catalog_error is not None:
+            catalog_errors.append(tier_catalog_error)
+            continue
+        assert tier is not None
+
+        if active_tiers is not None and tier not in active_tiers:
+            skipped_tier.append(
+                {
+                    "surface": surface_name,
+                    "gate": gate,
+                    "tier": tier,
+                    "reason": f"tier {tier!r} not in active tiers {sorted(active_tiers)!r}",
+                }
+            )
+            continue
 
         target_p50 = config.get("p50_ms")
         target_p95 = config.get("p95_ms")
@@ -224,6 +312,7 @@ def main(argv: list[str] | None = None) -> int:
             missing_result: dict[str, object] = {
                 "surface": surface_name,
                 "gate": gate,
+                "tier": tier,
                 "benchmark_test": benchmark_test,
                 "reason": "no benchmark result for this test",
             }
@@ -244,6 +333,7 @@ def main(argv: list[str] | None = None) -> int:
         result: dict[str, object] = {
             "surface": surface_name,
             "gate": gate,
+            "tier": tier,
             "description": config.get("description", ""),
             "benchmark_test": benchmark_test,
             "target_p50_ms": target_p50,
@@ -267,11 +357,13 @@ def main(argv: list[str] | None = None) -> int:
         json.dump(
             {
                 "blocking": blocking,
+                "active_tiers": sorted(active_tiers) if active_tiers is not None else None,
                 "catalog_errors": catalog_errors,
                 "violations": violations,
                 "missing_required": missing_required,
                 "passed": passed,
                 "uncovered_informational": uncovered_informational,
+                "skipped_tier": skipped_tier,
             },
             sys.stdout,
             indent=2,
@@ -317,6 +409,14 @@ def main(argv: list[str] | None = None) -> int:
                 print(f"  {u['surface']}: {u['reason']}")
             print()
 
+        if skipped_tier:
+            print(f"Skipped (tier filter) ({len(skipped_tier)} surfaces):")
+            for s in skipped_tier:
+                print(f"  {s['surface']} [tier={s['tier']}]")
+            print()
+
+        if active_tiers is not None:
+            print(f"active_tiers={sorted(active_tiers)}")
         print(f"blocking={blocking}")
 
     return 1 if blocking else 0

--- a/docs/plans/slo-catalog.yaml
+++ b/docs/plans/slo-catalog.yaml
@@ -15,11 +15,20 @@
 #       p50_ms:         <int milliseconds, median budget>
 #       p95_ms:         <int milliseconds, p95 budget — estimated mean+1.645*stddev>
 #       gate:           "required" | "informational"
+#       tier:           "cheap-local" | "lab"
 #
-# verify_slos exits non-zero when any required surface exceeds its declared
-# budget or fails to produce a benchmark result. Informational rows are visible
-# but non-blocking placeholders for deferred read paths whose benchmark fixtures
-# or product paths do not yet exist.
+# verify_slos exits non-zero when any required surface (in the active tier set)
+# exceeds its declared budget or fails to produce a benchmark result.
+# Informational rows are visible but non-blocking placeholders for deferred read
+# paths whose benchmark fixtures or product paths do not yet exist.
+#
+# Tiering separates execution cost:
+#   * cheap-local — runnable in `devtools verify` defaults. Small fixtures, low
+#     repetition counts, total run under a few seconds. Always enforced.
+#   * lab — heavier benchmarks runnable via `devtools verify --lab` or
+#     `devtools verify-slos --include-lab` (or explicit
+#     `devtools benchmark-campaign run <name>`). Skipped in the default loop
+#     so commit-frequency verification stays fast.
 
 surfaces:
 
@@ -29,6 +38,7 @@ surfaces:
     p50_ms: 100
     p95_ms: 250
     gate: "required"
+    tier: "cheap-local"
 
   reader:
     description: "Reader list endpoint over the 5k synthetic archive"
@@ -36,6 +46,7 @@ surfaces:
     p50_ms: 300
     p95_ms: 750
     gate: "required"
+    tier: "cheap-local"
 
   facets:
     description: "Facets endpoint aggregating provider/tag counts over the 5k synthetic archive"
@@ -43,6 +54,7 @@ surfaces:
     p50_ms: 200
     p95_ms: 500
     gate: "required"
+    tier: "cheap-local"
 
   context:
     description: "Context-pack assembly placeholder (deferred until #838 lands)"
@@ -50,6 +62,7 @@ surfaces:
     p50_ms: 500
     p95_ms: 1500
     gate: "informational"
+    tier: "cheap-local"
 
   cost:
     description: "Cost rollup placeholder (deferred until #803/#870 land)"
@@ -57,6 +70,7 @@ surfaces:
     p50_ms: 300
     p95_ms: 800
     gate: "informational"
+    tier: "cheap-local"
 
   daemon_convergence_single_file:
     description: "Daemon ingest convergence for a single 1000-message synthetic session"
@@ -64,3 +78,4 @@ surfaces:
     p50_ms: 30000
     p95_ms: 60000
     gate: "informational"
+    tier: "lab"

--- a/polylogue/verification/manifests/models.py
+++ b/polylogue/verification/manifests/models.py
@@ -231,6 +231,8 @@ class MutationCampaignEntry(BaseModel):
     paths_to_mutate: list[str]
     tests: list[str]
     status: str = "active"
+    freshness_days: int | None = None
+    artifact_glob: str | None = None
 
     VALID_STATUSES: ClassVar[frozenset[str]] = frozenset({"active", "inactive", "draft", "archived"})
 
@@ -239,6 +241,13 @@ class MutationCampaignEntry(BaseModel):
     def _check_status(cls, v: str) -> str:
         if v not in cls.VALID_STATUSES:
             raise ValueError(f"status must be one of {sorted(cls.VALID_STATUSES)}, got {v!r}")
+        return v
+
+    @field_validator("freshness_days")
+    @classmethod
+    def _check_freshness(cls, v: int | None) -> int | None:
+        if v is not None and v <= 0:
+            raise ValueError(f"freshness_days must be positive, got {v!r}")
         return v
 
 
@@ -250,6 +259,8 @@ class BenchmarkCampaignEntry(BaseModel):
     description: str
     tests: list[str]
     status: str = "active"
+    freshness_days: int | None = None
+    artifact_glob: str | None = None
 
     VALID_STATUSES: ClassVar[frozenset[str]] = frozenset({"active", "inactive", "draft", "archived"})
 
@@ -258,6 +269,13 @@ class BenchmarkCampaignEntry(BaseModel):
     def _check_status(cls, v: str) -> str:
         if v not in cls.VALID_STATUSES:
             raise ValueError(f"status must be one of {sorted(cls.VALID_STATUSES)}, got {v!r}")
+        return v
+
+    @field_validator("freshness_days")
+    @classmethod
+    def _check_freshness(cls, v: int | None) -> int | None:
+        if v is not None and v <= 0:
+            raise ValueError(f"freshness_days must be positive, got {v!r}")
         return v
 
 

--- a/tests/unit/devtools/test_slo_catalog.py
+++ b/tests/unit/devtools/test_slo_catalog.py
@@ -29,6 +29,7 @@ from devtools import verify_slos
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 CATALOG_PATH = REPO_ROOT / "docs" / "plans" / "slo-catalog.yaml"
+BENCH_FIXTURE_DIR = REPO_ROOT / "tests" / "data" / "pytest-benchmark"
 
 REQUIRED_SURFACES = ("query", "reader", "facets", "context", "cost")
 
@@ -170,6 +171,7 @@ surfaces:
         {
             "surface": "reader",
             "gate": "required",
+            "tier": "cheap-local",
             "benchmark_test": "tests/benchmarks/test_reader_api.py::test_missing_required",
             "reason": "no benchmark result for this test",
         }
@@ -208,6 +210,7 @@ surfaces:
         {
             "surface": "cost",
             "gate": "informational",
+            "tier": "cheap-local",
             "benchmark_test": "tests/benchmarks/test_reader_api.py::test_missing_informational",
             "reason": "no benchmark result for this test",
         }
@@ -299,3 +302,226 @@ surfaces:
     assert rc != 0
     assert payload["blocking"] is True
     assert payload["catalog_errors"] == ["reader: required surface must declare benchmark_test (string)"]
+
+
+# ---------------------------------------------------------------------------
+# Tier filtering (Pack B)
+# ---------------------------------------------------------------------------
+
+
+def test_catalog_required_surfaces_are_cheap_local_tier() -> None:
+    """All ``gate: required`` rows must live in the cheap-local tier.
+
+    Promoting a row to ``required`` while leaving it in the ``lab`` tier would
+    create a gate that ``devtools verify`` (default loop) cannot reach but that
+    still blocks PRs once anyone runs the lab loop. Required-but-lab is a
+    contradiction the catalog must forbid by convention.
+    """
+    surfaces = verify_slos._parse_slo_catalog(CATALOG_PATH.read_text())
+    offenders: list[str] = []
+    for name, config in surfaces.items():
+        gate = config.get("gate", "required")
+        tier = config.get("tier", verify_slos.DEFAULT_TIER)
+        if gate == "required" and tier != "cheap-local":
+            offenders.append(f"{name} (tier={tier!r})")
+    assert not offenders, (
+        "required SLO rows must be in the cheap-local tier so the default "
+        f"verify loop can run them; offenders: {offenders}"
+    )
+
+
+def test_lab_tier_surface_skipped_by_default(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Lab-tier rows are skipped (and reported) unless --include-lab is set."""
+    catalog = _write_slo_catalog(
+        tmp_path,
+        """
+surfaces:
+  daemon_lab:
+    description: "Lab-only convergence"
+    benchmark_test: "tests/benchmarks/test_daemon_convergence.py::test_lab_node"
+    p50_ms: 30000
+    p95_ms: 60000
+    gate: "required"
+    tier: "lab"
+""",
+    )
+    captured_ids: dict[str, set[str]] = {"ids": set()}
+
+    def fake_run(ids: set[str]) -> dict[str, dict[str, float]]:
+        captured_ids["ids"] = ids
+        return {}
+
+    monkeypatch.setattr(verify_slos, "_run_benchmarks", fake_run)
+
+    buffer = io.StringIO()
+    with redirect_stdout(buffer):
+        rc = verify_slos.main(["--yaml", str(catalog), "--json"])
+
+    payload = json.loads(buffer.getvalue())
+    assert rc == 0, payload  # lab row is filtered out, so nothing blocks
+    assert payload["active_tiers"] == ["cheap-local"]
+    assert payload["skipped_tier"] == [
+        {
+            "surface": "daemon_lab",
+            "gate": "required",
+            "tier": "lab",
+            "reason": "tier 'lab' not in active tiers ['cheap-local']",
+        }
+    ]
+    assert payload["missing_required"] == []
+    # No tests collected for execution because lab tier was filtered.
+    assert captured_ids["ids"] == set()
+
+
+def test_lab_tier_surface_runs_with_include_lab(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``--include-lab`` adds lab-tier rows to the execution and gating set."""
+    catalog = _write_slo_catalog(
+        tmp_path,
+        """
+surfaces:
+  daemon_lab:
+    description: "Lab-only convergence"
+    benchmark_test: "tests/benchmarks/test_daemon_convergence.py::test_lab_node"
+    p50_ms: 30000
+    p95_ms: 60000
+    gate: "required"
+    tier: "lab"
+""",
+    )
+    captured_ids: dict[str, set[str]] = {"ids": set()}
+
+    def fake_run(ids: set[str]) -> dict[str, dict[str, float]]:
+        captured_ids["ids"] = ids
+        return {}
+
+    monkeypatch.setattr(verify_slos, "_run_benchmarks", fake_run)
+
+    buffer = io.StringIO()
+    with redirect_stdout(buffer):
+        rc = verify_slos.main(["--yaml", str(catalog), "--json", "--include-lab"])
+
+    payload = json.loads(buffer.getvalue())
+    assert rc != 0, payload  # lab row is now active and its artifact is missing
+    assert set(payload["active_tiers"]) == {"cheap-local", "lab"}
+    assert payload["skipped_tier"] == []
+    assert payload["missing_required"] and payload["missing_required"][0]["surface"] == "daemon_lab"
+    assert captured_ids["ids"] == {"tests/benchmarks/test_daemon_convergence.py::test_lab_node"}
+
+
+def test_invalid_tier_is_catalog_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unknown tier values must fail the catalog rather than being guessed."""
+    catalog = _write_slo_catalog(
+        tmp_path,
+        """
+surfaces:
+  query:
+    description: "Search endpoint"
+    benchmark_test: "tests/benchmarks/test_search_filters.py::test_bench_query"
+    p50_ms: 100
+    p95_ms: 200
+    gate: "required"
+    tier: "ci-nightly"
+""",
+    )
+    monkeypatch.setattr(verify_slos, "_run_benchmarks", lambda _ids: {})
+
+    buffer = io.StringIO()
+    with redirect_stdout(buffer):
+        rc = verify_slos.main(["--yaml", str(catalog), "--json", "--all-tiers"])
+
+    payload = json.loads(buffer.getvalue())
+    assert rc != 0
+    assert payload["blocking"] is True
+    assert payload["catalog_errors"] == ["query: invalid tier 'ci-nightly'; expected one of ['cheap-local', 'lab']"]
+
+
+# ---------------------------------------------------------------------------
+# Real pytest-benchmark JSON fixture parsing (Pack B)
+# ---------------------------------------------------------------------------
+
+
+def test_real_pytest_benchmark_json_fixture_parses() -> None:
+    """A committed pytest-benchmark JSON artifact parses through the shared loader.
+
+    Pack B requires at least one real pytest-benchmark artifact to flow through
+    the parser, not just hand-built stats dicts. The fixture was captured from
+    an actual pytest-benchmark run and lives under tests/data/pytest-benchmark/.
+    """
+    fixture = BENCH_FIXTURE_DIR / "reader-status.json"
+    assert fixture.exists(), f"missing benchmark fixture: {fixture}"
+
+    payload = json.loads(fixture.read_text())
+    from devtools.benchmark_results import parse_pytest_benchmark_stats
+
+    stats = parse_pytest_benchmark_stats(payload)
+    assert len(stats) >= 1
+    by_name = {entry.fullname: entry for entry in stats}
+    target = "tests/benchmarks/test_reader_api.py::test_bench_reader_status"
+    assert target in by_name
+    entry = by_name[target]
+    assert entry.mean > 0
+    assert entry.median > 0
+    assert entry.rounds >= 1
+
+
+def test_verify_slos_scores_against_real_pytest_benchmark_fixture(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A real pytest-benchmark JSON drives the SLO scoring path end to end.
+
+    This replaces the stub-only path: we feed the parser the same artifact
+    shape pytest-benchmark writes, then assert verify_slos translates seconds
+    to milliseconds, applies the budget, and reports pass.
+    """
+    fixture_payload = json.loads((BENCH_FIXTURE_DIR / "reader-status.json").read_text())
+    from devtools.benchmark_results import parse_pytest_benchmark_stats
+
+    parsed_stats = {
+        entry.fullname: {
+            "mean": entry.mean,
+            "median": entry.median,
+            "min": entry.minimum,
+            "max": entry.maximum,
+            "stddev": entry.stddev,
+            "rounds": entry.rounds,
+        }
+        for entry in parse_pytest_benchmark_stats(fixture_payload)
+    }
+    assert parsed_stats, "fixture must yield at least one parsed stat"
+
+    catalog = _write_slo_catalog(
+        tmp_path,
+        """
+surfaces:
+  reader_status:
+    description: "Reader status placeholder"
+    benchmark_test: "tests/benchmarks/test_reader_api.py::test_bench_reader_status"
+    p50_ms: 50
+    p95_ms: 100
+    gate: "required"
+    tier: "cheap-local"
+""",
+    )
+    monkeypatch.setattr(verify_slos, "_run_benchmarks", lambda _ids: parsed_stats)
+
+    buffer = io.StringIO()
+    with redirect_stdout(buffer):
+        rc = verify_slos.main(["--yaml", str(catalog), "--json"])
+
+    payload = json.loads(buffer.getvalue())
+    assert rc == 0, payload
+    assert payload["passed"], "expected the real-fixture surface to pass"
+    measured = payload["passed"][0]
+    # fixture median is 0.0011s = 1.1ms; budget is 50ms.
+    assert measured["actual_p50_ms"] < measured["target_p50_ms"]
+    assert measured["actual_p95_ms"] < measured["target_p95_ms"]

--- a/tests/unit/devtools/test_verify_manifests.py
+++ b/tests/unit/devtools/test_verify_manifests.py
@@ -229,11 +229,29 @@ def test_coverage_status_claims_reject_missing_item_with_realized_evidence(tmp_p
     ]
 
 
+def _seed_paths(plans: Path, *relative_paths: str) -> None:
+    """Create empty stand-ins for paths the manifest references.
+
+    ``check_campaign_coverage_catalog`` now requires every active campaign's
+    declared tests (and mutation paths_to_mutate) to exist on disk.
+    """
+    for rel in relative_paths:
+        target = plans / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.touch(exist_ok=True)
+
+
 def test_campaign_coverage_catalog_accepts_authored_catalog(
     tmp_path: Path,
     monkeypatch: MonkeyPatch,
 ) -> None:
     plans = tmp_path
+    _seed_paths(
+        plans,
+        "polylogue/archive/filter/filters.py",
+        "tests/unit/core/test_filters_props.py",
+        "tests/benchmarks/test_storage.py",
+    )
     monkeypatch.setattr(
         verify_manifests,
         "get_authored_scenario_catalog",
@@ -283,6 +301,15 @@ def test_campaign_coverage_catalog_rejects_stale_manifest(
     monkeypatch: MonkeyPatch,
 ) -> None:
     plans = tmp_path
+    # Seed the manifest-declared (old) paths so this test exercises only the
+    # mismatch-vs-authored-catalog assertions; path-existence checks are
+    # covered separately below.
+    _seed_paths(
+        plans,
+        "polylogue/archive/filter/old_filters.py",
+        "tests/unit/core/test_filters_props.py",
+        "tests/benchmarks/test_storage.py",
+    )
     monkeypatch.setattr(
         verify_manifests,
         "get_authored_scenario_catalog",
@@ -349,3 +376,281 @@ domains:
     )
 
     assert verify_manifests.check_assurance_domains(plans) == []
+
+
+# ---------------------------------------------------------------------------
+# Pack C: campaign test-path and freshness/artifact existence enforcement
+# ---------------------------------------------------------------------------
+
+
+def test_campaign_coverage_rejects_missing_test_path(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """A campaign that points at a nonexistent test path must fail."""
+    plans = tmp_path
+    # Seed the mutation source but not the test path.
+    _seed_paths(plans, "polylogue/archive/filter/filters.py")
+    monkeypatch.setattr(
+        verify_manifests,
+        "get_authored_scenario_catalog",
+        lambda: SimpleNamespace(
+            mutation_campaigns=(),
+            benchmark_campaigns=(
+                SimpleNamespace(
+                    name="storage",
+                    description="Storage benchmarks",
+                    tests=("tests/benchmarks/test_storage.py",),
+                ),
+            ),
+        ),
+    )
+    (plans / "campaign-coverage.yaml").write_text(
+        """mutation_campaigns: []
+benchmark_campaigns:
+  - name: storage
+    description: Storage benchmarks
+    tests:
+      - tests/benchmarks/test_storage.py
+    status: active
+""",
+        encoding="utf-8",
+    )
+
+    errors = verify_manifests.check_campaign_coverage_catalog(plans)
+    assert errors == [
+        f"{plans / 'campaign-coverage.yaml'}: benchmark_campaigns campaign 'storage' "
+        "tests[0] path does not exist: 'tests/benchmarks/test_storage.py'"
+    ]
+
+
+def test_campaign_coverage_rejects_empty_tests_list(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """An active campaign with an empty tests list cannot pass."""
+    plans = tmp_path
+    monkeypatch.setattr(
+        verify_manifests,
+        "get_authored_scenario_catalog",
+        lambda: SimpleNamespace(
+            mutation_campaigns=(),
+            benchmark_campaigns=(SimpleNamespace(name="storage", description="d", tests=()),),
+        ),
+    )
+    (plans / "campaign-coverage.yaml").write_text(
+        """mutation_campaigns: []
+benchmark_campaigns:
+  - name: storage
+    description: d
+    tests: []
+    status: active
+""",
+        encoding="utf-8",
+    )
+
+    errors = verify_manifests.check_campaign_coverage_catalog(plans)
+    assert any("declares no tests" in err for err in errors), errors
+
+
+def test_campaign_coverage_freshness_passes_for_recent_artifact(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """A campaign with freshness_days passes when a recent artifact exists."""
+    plans = tmp_path
+    _seed_paths(plans, "tests/benchmarks/test_storage.py")
+    artifact_dir = plans / ".local" / "benchmark-campaigns"
+    artifact_dir.mkdir(parents=True)
+    artifact_path = artifact_dir / "2026-05-16-storage.json"
+    artifact_path.write_text('{"benchmarks": []}', encoding="utf-8")  # non-empty
+    monkeypatch.setattr(
+        verify_manifests,
+        "get_authored_scenario_catalog",
+        lambda: SimpleNamespace(
+            mutation_campaigns=(),
+            benchmark_campaigns=(
+                SimpleNamespace(
+                    name="storage",
+                    description="Storage benchmarks",
+                    tests=("tests/benchmarks/test_storage.py",),
+                ),
+            ),
+        ),
+    )
+    (plans / "campaign-coverage.yaml").write_text(
+        """mutation_campaigns: []
+benchmark_campaigns:
+  - name: storage
+    description: Storage benchmarks
+    tests:
+      - tests/benchmarks/test_storage.py
+    status: active
+    freshness_days: 30
+""",
+        encoding="utf-8",
+    )
+
+    assert verify_manifests.check_campaign_coverage_catalog(plans) == []
+
+
+def test_campaign_coverage_freshness_fails_when_artifact_missing(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """freshness_days without a matching artifact must fail loudly."""
+    plans = tmp_path
+    _seed_paths(plans, "tests/benchmarks/test_storage.py")
+    monkeypatch.setattr(
+        verify_manifests,
+        "get_authored_scenario_catalog",
+        lambda: SimpleNamespace(
+            mutation_campaigns=(),
+            benchmark_campaigns=(
+                SimpleNamespace(
+                    name="storage",
+                    description="Storage benchmarks",
+                    tests=("tests/benchmarks/test_storage.py",),
+                ),
+            ),
+        ),
+    )
+    (plans / "campaign-coverage.yaml").write_text(
+        """mutation_campaigns: []
+benchmark_campaigns:
+  - name: storage
+    description: Storage benchmarks
+    tests:
+      - tests/benchmarks/test_storage.py
+    status: active
+    freshness_days: 7
+""",
+        encoding="utf-8",
+    )
+
+    errors = verify_manifests.check_campaign_coverage_catalog(plans)
+    assert any("no matching artifacts exist" in err for err in errors), errors
+
+
+def test_campaign_coverage_freshness_fails_when_artifact_is_stale(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """An artifact older than freshness_days must trip the staleness check."""
+    import os
+    import time
+
+    plans = tmp_path
+    _seed_paths(plans, "tests/benchmarks/test_storage.py")
+    artifact_dir = plans / ".local" / "benchmark-campaigns"
+    artifact_dir.mkdir(parents=True)
+    artifact_path = artifact_dir / "2020-01-01-storage.json"
+    artifact_path.write_text('{"benchmarks": []}', encoding="utf-8")
+    old_ts = time.time() - 365 * 86400
+    os.utime(artifact_path, (old_ts, old_ts))
+
+    monkeypatch.setattr(
+        verify_manifests,
+        "get_authored_scenario_catalog",
+        lambda: SimpleNamespace(
+            mutation_campaigns=(),
+            benchmark_campaigns=(
+                SimpleNamespace(
+                    name="storage",
+                    description="Storage benchmarks",
+                    tests=("tests/benchmarks/test_storage.py",),
+                ),
+            ),
+        ),
+    )
+    (plans / "campaign-coverage.yaml").write_text(
+        """mutation_campaigns: []
+benchmark_campaigns:
+  - name: storage
+    description: Storage benchmarks
+    tests:
+      - tests/benchmarks/test_storage.py
+    status: active
+    freshness_days: 30
+""",
+        encoding="utf-8",
+    )
+
+    errors = verify_manifests.check_campaign_coverage_catalog(plans)
+    assert any("exceeding freshness_days=30" in err for err in errors), errors
+
+
+def test_campaign_coverage_artifact_glob_must_resolve(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """An explicit artifact_glob must match at least one non-empty artifact."""
+    plans = tmp_path
+    _seed_paths(plans, "tests/benchmarks/test_storage.py")
+    monkeypatch.setattr(
+        verify_manifests,
+        "get_authored_scenario_catalog",
+        lambda: SimpleNamespace(
+            mutation_campaigns=(),
+            benchmark_campaigns=(
+                SimpleNamespace(
+                    name="storage",
+                    description="Storage benchmarks",
+                    tests=("tests/benchmarks/test_storage.py",),
+                ),
+            ),
+        ),
+    )
+    (plans / "campaign-coverage.yaml").write_text(
+        """mutation_campaigns: []
+benchmark_campaigns:
+  - name: storage
+    description: Storage benchmarks
+    tests:
+      - tests/benchmarks/test_storage.py
+    status: active
+    artifact_glob: ".local/never-existed/*.json"
+""",
+        encoding="utf-8",
+    )
+
+    errors = verify_manifests.check_campaign_coverage_catalog(plans)
+    assert any("no matching artifacts exist" in err for err in errors), errors
+
+
+def test_campaign_coverage_inactive_status_skips_path_check(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Inactive campaigns are intentionally exempt from path enforcement."""
+    plans = tmp_path
+    # Note: no seeded paths — they don't exist.
+    monkeypatch.setattr(
+        verify_manifests,
+        "get_authored_scenario_catalog",
+        lambda: SimpleNamespace(
+            mutation_campaigns=(),
+            benchmark_campaigns=(
+                SimpleNamespace(
+                    name="storage",
+                    description="Storage benchmarks",
+                    tests=("tests/benchmarks/test_storage.py",),
+                ),
+            ),
+        ),
+    )
+    (plans / "campaign-coverage.yaml").write_text(
+        """mutation_campaigns: []
+benchmark_campaigns:
+  - name: storage
+    description: Storage benchmarks
+    tests:
+      - tests/benchmarks/test_storage.py
+    status: archived
+""",
+        encoding="utf-8",
+    )
+
+    errors = verify_manifests.check_campaign_coverage_catalog(plans)
+    path_errors = [e for e in errors if "path does not exist" in e]
+    assert path_errors == []


### PR DESCRIPTION
## Summary

Adds a `tier:` axis to the SLO catalog so the default verify loop runs
only cheap-local benchmarks while `--include-lab` (and `devtools verify
--lab`) escalates to lab-tier rows. Extends `check_campaign_coverage_catalog`
to require every active campaign to route to executable test paths,
and to enforce optional `freshness_days` / `artifact_glob` semantics so
declared coverage cannot drift from real artifacts.

## Problem

The SLO catalog let any row be marked `gate: required` regardless of
whether its benchmark fixture was cheap enough to run on every push.
The daemon convergence row (30 s+) was nominally informational but
sat alongside cheap reader/query rows with no contract preventing
someone from promoting it. Meanwhile, every row in `campaign-coverage.yaml`
declared `tests:`, but no check verified those paths existed on disk —
a row could carry a name and description and route nowhere
executable. The Pydantic model accepted `freshness_days` only because
nothing rejected it, and the verifier never inspected artifacts.

## Solution

Pack B — `devtools/verify_slos.py`, `docs/plans/slo-catalog.yaml`,
`devtools/verify.py`, `tests/unit/devtools/test_slo_catalog.py`:

- New `tier: cheap-local | lab` field on every SLO row. Default
  `cheap-local`. Invalid tiers fail the catalog the same way invalid
  gates already do.
- `_collect_benchmark_tests()` and the scoring loop filter by tier.
  Default invocation runs cheap-local. `--include-lab` adds lab;
  `--tier <name>` and `--all-tiers` cover the other operator paths.
  Skipped surfaces are reported in a new `skipped_tier` JSON section.
- `devtools verify --lab` now runs `verify-slos --include-lab`.
- The committed daemon convergence row moves to the lab tier (it was
  already informational; the tier just makes the cost visible).
- New test pins the catalog rule that `gate: required` must imply
  `tier: cheap-local`, so nobody can promote a row into a gate the
  default loop cannot run.
- Pack-B requirement satisfied: `test_real_pytest_benchmark_json_fixture_parses`
  drives `parse_pytest_benchmark_stats` over the committed
  `tests/data/pytest-benchmark/reader-status.json` fixture, and
  `test_verify_slos_scores_against_real_pytest_benchmark_fixture` runs
  the parsed result through `verify_slos.main()` to confirm budget
  arithmetic.

Pack C — `devtools/verify_manifests.py`,
`polylogue/verification/manifests/models.py`,
`tests/unit/devtools/test_verify_manifests.py`:

- `_check_campaign_test_paths` enforces that every active campaign
  declares a non-empty `tests:` list whose entries exist on disk
  (and, for mutation campaigns, the same for `paths_to_mutate`).
  Inactive campaigns are exempt by design.
- Optional `freshness_days` and `artifact_glob` fields added to the
  Pydantic `MutationCampaignEntry` / `BenchmarkCampaignEntry` models
  (`freshness_days` must be positive when set).
- `_check_campaign_freshness` is silent when neither field is
  declared. When either is declared, it requires at least one
  matching artifact, requires the newest match to be non-empty, and
  (with `freshness_days`) checks the artifact mtime against the
  declared window. Benchmark campaigns default the glob to
  `.local/benchmark-campaigns/*-<name>.json`, matching the
  `devtools benchmark-campaign run` output path. Mutation campaigns
  must declare `artifact_glob` explicitly.
- `_manifest_named_entries` now treats a missing campaign section as
  an empty list, so the two enforcement passes compose cleanly when
  manifests omit one section.

The existing pass/reject campaign-catalog tests are updated to seed
the referenced paths so they continue to assert the original
catalog-mismatch contract under the stricter path check.

## Verification

```bash
nix develop -c pytest tests/unit/devtools/test_slo_catalog.py tests/unit/devtools/test_verify_manifests.py
# 35 passed in 9.19s

nix develop -c mypy --strict devtools/verify_slos.py devtools/verify_manifests.py \
    devtools/verify.py polylogue/verification/manifests/models.py \
    tests/unit/devtools/test_slo_catalog.py tests/unit/devtools/test_verify_manifests.py
# Success: no issues found in 6 source files

nix develop -c devtools verify-slos --skip-benchmarks --json
# blocking: True (3 required cheap-local rows missing artifacts — expected)
# active_tiers: ['cheap-local']
# skipped_tier: ['daemon_convergence_single_file']
# missing_required: ['query', 'reader', 'facets']
# uncovered_informational: ['context', 'cost']

nix develop -c devtools verify-manifests
# ✓ manifest consistency checks passed

nix develop -c pytest tests/benchmarks/ --collect-only -q --benchmark-disable
# 56 tests collected in 0.07s — every SLO benchmark_test resolves

nix develop -c devtools verify --quick
# exit_code: 0  (after a pre-existing render-pages refresh)
```

## Follow-ups

- The three required cheap-local SLOs (`query`, `reader`, `facets`)
  are still uncovered until they are actually run; `verify_slos`
  intentionally blocks until a real benchmark JSON lands.
  No campaign rows currently declare `freshness_days`; the field is
  available for opt-in once campaign runs are scheduled.

Ref #1063