### PR TITLE
perf(verify): structured pytest reports and worker tuning evidence (#1026)

### DIFF
--- a/devtools/verify.py
+++ b/devtools/verify.py
@@ -336,13 +336,13 @@ def build_verify_steps(
         if skip_slow:
             pytest_cmd.extend(["-m", "not slow"])
         if seed_testmon:
-            pytest_cmd.extend(["--testmon", "--testmon-noselect", *_pytest_worker_args(default="8")])
+            pytest_cmd.extend(["--testmon", "--testmon-noselect", *_pytest_worker_args(default="16")])
             steps.append(("pytest seed-testmon", pytest_cmd))
         elif full_pytest:
-            pytest_cmd.extend(_pytest_worker_args(default="8"))
+            pytest_cmd.extend(_pytest_worker_args(default="16"))
             steps.append(("pytest full", pytest_cmd))
         elif testmon_global:
-            pytest_cmd.extend(["--testmon", "--testmon-noselect", *_pytest_worker_args(default="8")])
+            pytest_cmd.extend(["--testmon", "--testmon-noselect", *_pytest_worker_args(default="16")])
             steps.append(("pytest testmon-global", pytest_cmd))
         else:
             pytest_cmd.extend(["--testmon", "-n", "0"])

--- a/devtools/verify.py
+++ b/devtools/verify.py
@@ -127,6 +127,8 @@ def _format_completion_notification(
 HISTORY_PATH = Path(".cache/verify-history.jsonl")
 TESTMON_DATA = Path(".testmondata")
 TESTMON_SEED_STAMP = Path(".cache/testmon/seed.json")
+PYTEST_REPORT_DIR = Path(".cache/verify")
+PYTEST_REPORT_PATH = PYTEST_REPORT_DIR / "last-pytest.json"
 TESTMON_GLOBAL_INVALIDATORS = (
     ".python-version",
     "conftest.py",
@@ -188,7 +190,11 @@ _PYTEST_COUNT_RE = re.compile(
 
 
 def _parse_pytest_test_count(output: str) -> int | None:
-    """Return the total executed-test count from pytest's terminal summary."""
+    """Return the total executed-test count from pytest's terminal summary.
+
+    Used only as a fallback when the structured JSON report is missing or
+    unreadable. The primary path is `_read_pytest_report()`.
+    """
     if "no tests ran" in output:
         return 0
     counts = [int(match.group("count")) for match in _PYTEST_COUNT_RE.finditer(output)]
@@ -197,17 +203,64 @@ def _parse_pytest_test_count(output: str) -> int | None:
     return sum(counts)
 
 
+def _read_pytest_report(path: Path = PYTEST_REPORT_PATH) -> dict[str, Any] | None:
+    """Load the structured pytest-json-report artifact, or None if absent/bad."""
+    try:
+        raw = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(raw, dict):
+        return None
+    return raw
+
+
+def _pytest_metadata_from_report(report: dict[str, Any]) -> dict[str, Any]:
+    """Project a pytest-json-report dict into verify-step metadata."""
+    summary = report.get("summary")
+    metadata: dict[str, Any] = {"report_path": str(PYTEST_REPORT_PATH)}
+    if isinstance(summary, dict):
+        # `total` is collected count; sum the executed outcomes for the
+        # number we previously scraped from the terminal.
+        outcome_keys = ("passed", "failed", "error", "skipped", "xfailed", "xpassed")
+        executed = sum(int(summary.get(k, 0) or 0) for k in outcome_keys)
+        metadata["count"] = executed
+        for key in ("passed", "failed", "error", "skipped", "xfailed", "xpassed", "total"):
+            value = summary.get(key)
+            if isinstance(value, int):
+                metadata[key] = value
+    duration = report.get("duration")
+    if isinstance(duration, (int, float)):
+        metadata["pytest_duration_s"] = round(float(duration), 2)
+    return metadata
+
+
+def _clear_pytest_report() -> None:
+    """Remove a stale report before a pytest step runs."""
+    with contextlib.suppress(FileNotFoundError):
+        PYTEST_REPORT_PATH.unlink()
+
+
 def _run(label: str, cmd: list[str], *, cwd: str | None = None) -> tuple[int, float, dict[str, Any]]:
     t0 = time.monotonic()
     sys.stderr.write(f"  {label} ... ")
     sys.stderr.flush()
+    if label.startswith("pytest"):
+        _clear_pytest_report()
     result = subprocess.run(cmd, cwd=cwd, capture_output=True, text=True)
     elapsed = time.monotonic() - t0
     metadata: dict[str, Any] = {}
     if label.startswith("pytest"):
-        test_count = _parse_pytest_test_count(result.stdout + "\n" + result.stderr)
-        if test_count is not None:
-            metadata["count"] = test_count
+        report = _read_pytest_report()
+        if report is not None:
+            metadata.update(_pytest_metadata_from_report(report))
+        else:
+            # Fallback: terminal scraping when the structured report is
+            # missing (pytest crashed before writing it, or the plugin is
+            # disabled in some lab profile).
+            fallback = _parse_pytest_test_count(result.stdout + "\n" + result.stderr)
+            if fallback is not None:
+                metadata["count"] = fallback
+            metadata["report_path"] = None
     if result.returncode == 0:
         sys.stderr.write(f"ok ({elapsed:.1f}s)\n")
     else:
@@ -268,6 +321,7 @@ def build_verify_steps(
     if not quick and not commit:
         _report_dir = Path(".cache/test-reports")
         _report_dir.mkdir(parents=True, exist_ok=True)
+        PYTEST_REPORT_DIR.mkdir(parents=True, exist_ok=True)
         pytest_cmd = [
             "pytest",
             "-q",
@@ -275,6 +329,9 @@ def build_verify_steps(
             "--ignore=tests/integration",
             "--durations=10",
             f"--junitxml={_report_dir}/verify-latest.xml",
+            "--json-report",
+            "--json-report-omit=collectors,log,streams,warnings",
+            f"--json-report-file={PYTEST_REPORT_PATH}",
         ]
         if skip_slow:
             pytest_cmd.extend(["-m", "not slow"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ dev = [
   "pytest-xdist>=3.5.0",  # Parallel test execution
   "pytest-randomly>=3.0",  # Detect order-dependent tests; adds --randomly-seed
   "pytest-testmon>=2.1.3",  # Per-test affected selection via dependency database
+  "pytest-json-report>=1.5.0",  # Structured JSON report for verify pipeline + dashboard (#1026, #998)
   "pytest-benchmark>=5.0",  # Microbenchmark suite (run with --benchmark-enable -p no:xdist)
   "coverage[toml]>=7.6",
   "hypothesis>=6.152.7",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import sqlite3
@@ -59,7 +60,13 @@ def pytest_configure(config: pytest.Config) -> None:
 
     shm = Path("/dev/shm")
     if shm.is_dir() and (_stat.S_ISVTX & shm.stat().st_mode) and config.option.basetemp is None:
-        config.option.basetemp = str(shm / "pytest-polylogue")
+        # Use a per-checkout suffix so parallel worktrees/agents do not
+        # collide on basetemp cleanup — pytest prunes old basetemps on
+        # startup, which would wipe a peer run's xdist worker dirs and
+        # cause spurious FileNotFoundError under setup (#1026).
+        rootdir = str(config.rootpath)
+        suffix = hashlib.sha1(rootdir.encode("utf-8"), usedforsecurity=False).hexdigest()[:8]
+        config.option.basetemp = str(shm / f"pytest-polylogue-{suffix}")
         sys.stderr.write(f"pytest: basetemp → {config.option.basetemp} (tmpfs, #1026)\n")
 
 
@@ -564,7 +571,10 @@ def seeded_db(tmp_path_factory: pytest.TempPathFactory, worker_id: str) -> Path:
     # isn't available (macOS, CI without tmpfs).
     shm = Path("/dev/shm")
     if shm.is_dir() and (_stat.S_ISVTX & shm.stat().st_mode):
-        shared_root = shm / "pytest-polylogue-seeded"
+        suffix = hashlib.sha1(str(tmp_path_factory.getbasetemp()).encode("utf-8"), usedforsecurity=False).hexdigest()[
+            :8
+        ]
+        shared_root = shm / f"pytest-polylogue-seeded-{suffix}"
     else:
         shared_root = tmp_path_factory.getbasetemp() / "seeded-shared"
     shared_root.mkdir(parents=True, exist_ok=True)

--- a/tests/unit/devtools/test_verify.py
+++ b/tests/unit/devtools/test_verify.py
@@ -8,9 +8,12 @@ from unittest.mock import patch
 import pytest
 
 from devtools.verify import (
+    PYTEST_REPORT_PATH,
     _format_completion_notification,
     _is_testmon_global_invalidator,
     _parse_pytest_test_count,
+    _pytest_metadata_from_report,
+    _read_pytest_report,
     _run,
     _stop_after_failed_step,
     _testmon_preflight,
@@ -52,6 +55,23 @@ def test_default_verify_uses_pytest_testmon() -> None:
     assert "--testmon-noselect" not in command
     assert "-n" in command
     assert "0" in command
+
+
+def test_pytest_step_requests_structured_json_report() -> None:
+    """Every pytest invocation must emit the report consumed by verify and dashboards (#1026)."""
+    for kwargs in (
+        {"seed_testmon": True},
+        {"full_pytest": True},
+        {"testmon_global": True},
+        {},  # default testmon
+    ):
+        steps = build_verify_steps(quick=False, lab=False, skip_slow=False, **kwargs)
+        label, command = steps[-1]
+        assert label.startswith("pytest"), label
+        assert "--json-report" in command, f"{label}: {command}"
+        assert any(arg.startswith("--json-report-file=") for arg in command), label
+        expected_target = f"--json-report-file={PYTEST_REPORT_PATH}"
+        assert expected_target in command, f"{label}: {command}"
 
 
 def test_seed_testmon_runs_full_collection_without_selection(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -179,7 +199,8 @@ def test_parse_pytest_test_count_handles_no_tests() -> None:
     assert _parse_pytest_test_count("no tests ran in 0.02s\n") == 0
 
 
-def test_run_records_pytest_count_metadata() -> None:
+def test_run_records_pytest_count_metadata_from_terminal_fallback() -> None:
+    """When the JSON report is missing, _run falls back to terminal scraping."""
     completed = subprocess.CompletedProcess(
         args=["pytest"],
         returncode=0,
@@ -187,11 +208,72 @@ def test_run_records_pytest_count_metadata() -> None:
         stderr="",
     )
 
-    with patch("devtools.verify.subprocess.run", return_value=completed):
+    with (
+        patch("devtools.verify.subprocess.run", return_value=completed),
+        patch("devtools.verify._read_pytest_report", return_value=None),
+    ):
         rc, _elapsed, metadata = _run("pytest affected", ["pytest"])
 
     assert rc == 0
-    assert metadata == {"count": 4}
+    assert metadata["count"] == 4
+    assert metadata["report_path"] is None
+
+
+def test_run_reads_structured_pytest_report() -> None:
+    """The structured pytest report is the primary metadata source (#1026, #998)."""
+    completed = subprocess.CompletedProcess(
+        args=["pytest"],
+        returncode=0,
+        stdout="",
+        stderr="",
+    )
+    report = {
+        "summary": {"passed": 10, "failed": 1, "skipped": 2, "total": 13},
+        "duration": 4.56,
+    }
+
+    with (
+        patch("devtools.verify.subprocess.run", return_value=completed),
+        patch("devtools.verify._read_pytest_report", return_value=report),
+    ):
+        rc, _elapsed, metadata = _run("pytest testmon", ["pytest"])
+
+    assert rc == 0
+    assert metadata["count"] == 13  # passed+failed+skipped
+    assert metadata["passed"] == 10
+    assert metadata["failed"] == 1
+    assert metadata["skipped"] == 2
+    assert metadata["total"] == 13
+    assert metadata["pytest_duration_s"] == 4.56
+    assert metadata["report_path"] == str(PYTEST_REPORT_PATH)
+
+
+def test_pytest_metadata_handles_empty_summary() -> None:
+    """Robustness: a malformed/empty report still yields a metadata dict."""
+    assert _pytest_metadata_from_report({}) == {"report_path": str(PYTEST_REPORT_PATH)}
+
+
+def test_read_pytest_report_returns_none_for_missing_file(tmp_path: Path) -> None:
+    assert _read_pytest_report(tmp_path / "missing.json") is None
+
+
+def test_read_pytest_report_returns_none_for_invalid_json(tmp_path: Path) -> None:
+    bad = tmp_path / "bad.json"
+    bad.write_text("not json")
+    assert _read_pytest_report(bad) is None
+
+
+def test_read_pytest_report_returns_none_for_non_object(tmp_path: Path) -> None:
+    bad = tmp_path / "list.json"
+    bad.write_text("[1, 2, 3]")
+    assert _read_pytest_report(bad) is None
+
+
+def test_read_pytest_report_parses_valid_payload(tmp_path: Path) -> None:
+    path = tmp_path / "ok.json"
+    path.write_text('{"summary": {"passed": 3}, "duration": 1.0}')
+    parsed = _read_pytest_report(path)
+    assert parsed == {"summary": {"passed": 3}, "duration": 1.0}
 
 
 def test_verify_continues_after_failed_cheap_step(capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/unit/devtools/test_verify.py
+++ b/tests/unit/devtools/test_verify.py
@@ -83,7 +83,7 @@ def test_seed_testmon_runs_full_collection_without_selection(monkeypatch: pytest
     assert "--testmon" in command
     assert "--testmon-noselect" in command
     assert "-n" in command
-    assert "8" in command
+    assert command[command.index("-n") + 1] == "16"
 
 
 def test_full_verify_includes_full_pytest_without_testmon(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -94,7 +94,7 @@ def test_full_verify_includes_full_pytest_without_testmon(monkeypatch: pytest.Mo
     assert label == "pytest full"
     assert "--testmon" not in command
     assert "-n" in command
-    assert "8" in command
+    assert command[command.index("-n") + 1] == "16"
 
 
 def test_seed_testmon_worker_count_can_be_overridden(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -116,7 +116,7 @@ def test_global_testmon_invalidator_runs_full_collection(monkeypatch: pytest.Mon
     assert label == "pytest testmon-global"
     assert "--testmon" in command
     assert "--testmon-noselect" in command
-    assert command[command.index("-n") + 1] == "8"
+    assert command[command.index("-n") + 1] == "16"
 
 
 def test_skip_slow_keeps_testmon_selection_forced() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1477,6 +1477,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-benchmark" },
     { name = "pytest-cov" },
+    { name = "pytest-json-report" },
     { name = "pytest-randomly" },
     { name = "pytest-testmon" },
     { name = "pytest-xdist" },
@@ -1540,6 +1541,7 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.0" },
     { name = "pytest-benchmark", marker = "extra == 'dev'", specifier = ">=5.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4" },
+    { name = "pytest-json-report", marker = "extra == 'dev'", specifier = ">=1.5.0" },
     { name = "pytest-randomly", marker = "extra == 'dev'", specifier = ">=3.0" },
     { name = "pytest-testmon", marker = "extra == 'dev'", specifier = ">=2.1.3" },
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.5.0" },
@@ -1909,6 +1911,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "pytest-json-report"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "pytest-metadata" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4f/d3/765dae9712fcd68d820338908c1337e077d5fdadccd5cacf95b9b0bea278/pytest-json-report-1.5.0.tar.gz", hash = "sha256:2dde3c647851a19b5f3700729e8310a6e66efb2077d674f27ddea3d34dc615de", size = 21241, upload-time = "2022-03-15T21:03:10.2Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/35/d07400c715bf8a88aa0c1ee9c9eb6050ca7fe5b39981f0eea773feeb0681/pytest_json_report-1.5.0-py3-none-any.whl", hash = "sha256:9897b68c910b12a2e48dd849f9a284b2c79a732a8a9cb398452ddd23d3c8c325", size = 13222, upload-time = "2022-03-15T21:03:08.65Z" },
+]
+
+[[package]]
+name = "pytest-metadata"
+version = "3.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a6/85/8c969f8bec4e559f8f2b958a15229a35495f5b4ce499f6b865eac54b878d/pytest_metadata-3.1.1.tar.gz", hash = "sha256:d2a29b0355fbc03f168aa96d41ff88b1a3b44a3b02acbe491801c98a048017c8", size = 9952, upload-time = "2024-02-12T19:38:44.887Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/43/7e7b2ec865caa92f67b8f0e9231a798d102724ca4c0e1f414316be1c1ef2/pytest_metadata-3.1.1-py3-none-any.whl", hash = "sha256:c8e0844db684ee1c798cfa38908d20d67d0463ecb6137c72e91f418558dd5f4b", size = 11428, upload-time = "2024-02-12T19:38:42.531Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Replace the verify pipeline's terminal-summary scraping with a structured pytest JSON report, raise the default xdist worker count from 8 to 16 after measurement, and fix a parallel-worktree basetemp collision that was producing 1000+ spurious test errors.

## Problem

- The verify step parsed pytest's stdout with regex (`_parse_pytest_test_count`) to extract counts. That blocked #998 (verify dashboard) which needs structured fields, and was fragile against any change to pytest's terminal output.
- The default xdist worker count (8) was unmeasured. The 13700K has 16 P-cores + 8 E-cores; n=8 was leaving half the P-cores idle.
- Concurrent pytest runs from sibling worktrees collided on `/dev/shm/pytest-polylogue`. Pytest prunes old basetemps on startup, so one run would delete the other's xdist worker subdirectories mid-flight, raising `FileNotFoundError: /dev/shm/pytest-polylogue/popen-gwN` in pytest_asyncio setup. Observed 1121 errors in a single seed pass attributable to this.

## Solution

- `pyproject.toml`: add `pytest-json-report>=1.5.0` to the `dev` extra.
- `devtools/verify.py`: every pytest invocation now writes `--json-report-file=.cache/verify/last-pytest.json`. `_run()` reads the structured report and projects `passed/failed/error/skipped/xfailed/xpassed/total` plus `pytest_duration_s` into the step metadata stored in `.cache/verify-history.jsonl`. Terminal scraping remains as a fallback only when the report is missing (lab profile that strips plugins, or a pytest crash before the report is written). `_clear_pytest_report()` removes any stale report before each step so we never read someone else's data.
- `devtools/verify.py`: default `_pytest_worker_args(default=...)` raised from 8 to 16, based on measurement of n=4/8/12/16/24 (winner: n=16 at 120s wall vs n=8 at 229s — see commit body).
- `tests/conftest.py`: suffix the tmpfs basetemp and the seeded-corpus shared root with an 8-char hash of the worktree rootpath so concurrent worktrees do not collide.
- `tests/unit/devtools/test_verify.py`: add `test_pytest_step_requests_structured_json_report` (every pytest variant must emit the report path), `test_run_reads_structured_pytest_report` (primary path), retain terminal-fallback test, and small unit tests around `_read_pytest_report` and `_pytest_metadata_from_report`.

## Verification

```
$ nix develop -c pytest tests/unit/devtools/test_verify.py -v
============================== 28 passed in 9.12s ==============================

$ nix develop -c devtools verify --quick
... total_duration_s: 38.64, exit_code: 0

$ nix develop -c devtools verify --seed-testmon --skip-slow
... pytest seed-testmon  duration_s: 211.64
    report_path: .cache/verify/last-pytest.json
    count: 6704, passed: 6688, failed: 14, total: 6704
    pytest_duration_s: 202.89
```

The 14 failures are pre-existing on `master@fc3c43f3` (proof-law completeness, scenario-projection mismatch, benchmark-campaign index drift, json-envelope contract). Confirmed by running the same set in the main checkout — all fail there too. Tracked as inherited baseline debt, not introduced by this PR.

Worker tuning evidence (i7-13700K, 16P+8E cores), each pass runs the same ~6700 unit tests:

| -n | wall  | notes                  |
|----|-------|------------------------|
|  4 | 161s  | underutilized          |
|  8 | 229s  | previous default       |
| 12 | 172s  | coordination tax       |
| 16 | 120s  | winner — matches P-core |
| 24 | 139s  | E-core oversubscription |

Ref #1026
Ref #998