### PR TITLE
test(parity): close surface parity loop across CLI and MCP adapters (#1060)

### DIFF
--- a/tests/infra/query_cases.py
+++ b/tests/infra/query_cases.py
@@ -7,16 +7,48 @@ from dataclasses import dataclass
 
 @dataclass(frozen=True, slots=True)
 class ArchiveQueryCase:
-    """Expected conversation-id projection for one archive query."""
+    """Expected conversation-id projection for one archive query.
+
+    A case may carry one primary projection axis (``provider`` or
+    ``search_text``) plus optional additional filter axes
+    (``since``/``until``/``limit``/``offset`` and stats-join filters
+    such as ``has_tool_use``).  Adapter surfaces translate the case into
+    the equivalent call shape for their entrypoint so cross-surface
+    parity is asserted on the same filter chain rather than near-misses.
+    """
 
     name: str
     expected_ids: tuple[str, ...]
     provider: str | None = None
     search_text: str | None = None
+    since: str | None = None
+    until: str | None = None
+    limit: int | None = None
+    offset: int = 0
+    has_tool_use: bool = False
+    has_thinking: bool = False
+    min_messages: int | None = None
+    max_messages: int | None = None
+    min_words: int | None = None
 
     @property
     def expected_id_set(self) -> set[str]:
         return set(self.expected_ids)
+
+    @property
+    def has_extended_filters(self) -> bool:
+        """Whether the case carries filter axes beyond the primary projection."""
+        return (
+            self.since is not None
+            or self.until is not None
+            or self.limit is not None
+            or self.offset != 0
+            or self.has_tool_use
+            or self.has_thinking
+            or self.min_messages is not None
+            or self.max_messages is not None
+            or self.min_words is not None
+        )
 
 
 __all__ = ["ArchiveQueryCase"]

--- a/tests/infra/storage_records.py
+++ b/tests/infra/storage_records.py
@@ -595,10 +595,51 @@ def store_records(
             else:
                 counts["skipped_attachments"] += 1
         _prune_attachment_refs(db_conn, conversation.conversation_id, seen_ref_ids)
+        # Mirror the production write path's stats projection so that
+        # surfaces relying on conversation_stats (the stats-join pushdown
+        # filters: min_messages/max_messages/min_words/has_tool_use/…)
+        # see the same precomputed values as production ingest.  Without
+        # this, the test builders produced rows but no stats, and any
+        # parity test exercising those filters would observe an empty
+        # result set on every surface.
+        _upsert_conversation_stats_sync(db_conn, conversation=conversation, messages=messages)
         # Commit inside lock to ensure atomic transaction boundaries
         db_conn.commit()
 
     return counts
+
+
+def _upsert_conversation_stats_sync(
+    conn: sqlite3.Connection,
+    *,
+    conversation: ConversationRecord,
+    messages: list[MessageRecord],
+) -> None:
+    """Sync mirror of ``upsert_conversation_stats`` for test seeding.
+
+    Production routes stats through the async backend; the test
+    ``ConversationBuilder`` uses a sync sqlite3 connection, so we share
+    the same SQL statement constant but execute it synchronously here.
+    """
+    from polylogue.core.common import SQL_STATS_UPSERT
+
+    message_count = len(messages)
+    word_count = sum(m.word_count for m in messages)
+    tool_use_count = sum(1 for m in messages if m.has_tool_use)
+    thinking_count = sum(1 for m in messages if m.has_thinking)
+    paste_count = sum(1 for m in messages if m.has_paste)
+    conn.execute(
+        SQL_STATS_UPSERT,
+        (
+            conversation.conversation_id,
+            conversation.provider_name,
+            message_count,
+            word_count,
+            tool_use_count,
+            thinking_count,
+            paste_count,
+        ),
+    )
 
 
 # =============================================================================

--- a/tests/infra/surfaces.py
+++ b/tests/infra/surfaces.py
@@ -200,7 +200,7 @@ class RepositorySurface:
     async def query_count(self, query_case: ArchiveQueryCase) -> int:
         if query_case.has_extended_filters or query_case.search_text is not None:
             spec = _query_case_to_spec(query_case)
-            return await spec.count(self._repository)
+            return int(await spec.count(self._repository))
         if query_case.provider is not None:
             return await self._repository.count(provider=query_case.provider)
         return len(await self.query_ids(query_case))
@@ -368,7 +368,7 @@ class MCPSurface:
         self._server = build_server(role="admin")
 
     def _tool(self, name: str) -> Any:
-        return self._server._tool_manager._tools[name].fn  # type: ignore[attr-defined]
+        return self._server._tool_manager._tools[name].fn
 
     async def conversation_facts(self, scenario: ArchiveScenario) -> ConversationFacts:
         raise NotImplementedError("MCPSurface only supports query-level projections")

--- a/tests/infra/surfaces.py
+++ b/tests/infra/surfaces.py
@@ -1,11 +1,23 @@
-"""Archive surface adapters for scenario-driven verification tests."""
+"""Archive surface adapters for scenario-driven verification tests.
+
+This module hosts the cross-surface parity harness.  The substrate surfaces
+(``SQLiteRecordSurface``, ``SQLiteHydratedSurface``, ``RepositorySurface``,
+``FacadeSurface``) project the same archive through progressively higher
+abstractions.  The adapter surfaces (``CLISurface``, ``MCPSurface``) close
+the loop on the public surfaces — the Click query CLI and the MCP server
+tools — so any drift between substrate and adapter is caught by the same
+parity assertions.
+"""
 
 from __future__ import annotations
 
+import json
 import sqlite3
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Protocol
+from typing import Any, Protocol
+
+from click.testing import CliRunner
 
 from polylogue.api import Polylogue
 from polylogue.storage.sqlite.connection import open_connection
@@ -125,6 +137,42 @@ class SQLiteHydratedSurface:
         return None
 
 
+def _query_case_to_spec(query_case: ArchiveQueryCase) -> Any:
+    """Build a ConversationQuerySpec from a query case.
+
+    Imported lazily so test modules that never construct spec-routed
+    surfaces avoid the import-time cost of the archive query stack.
+    """
+    from polylogue.archive.query.spec import ConversationQuerySpec
+    from polylogue.types import Provider
+
+    providers: tuple[Any, ...] = ()
+    if query_case.provider is not None:
+        providers = (Provider.from_string(query_case.provider),)
+    # Route the search text through ``contains_terms`` so it follows the
+    # FTS-AND semantics the CLI exposes via --contains; the MCP
+    # list_conversations ``contains`` arg lands on the same spec field
+    # downstream.
+    contains_terms = (query_case.search_text,) if query_case.search_text else ()
+    return ConversationQuerySpec(
+        contains_terms=contains_terms,
+        providers=providers,
+        since=query_case.since,
+        until=query_case.until,
+        limit=query_case.limit,
+        offset=query_case.offset,
+        filter_has_tool_use=query_case.has_tool_use,
+        filter_has_thinking=query_case.has_thinking,
+        min_messages=query_case.min_messages,
+        max_messages=query_case.max_messages,
+        min_words=query_case.min_words,
+    )
+
+
+def _ids_from_conversations(conversations: list[Any]) -> tuple[str, ...]:
+    return _sorted_unique([str(conv.id) for conv in conversations])
+
+
 class RepositorySurface:
     """Async repository projection."""
 
@@ -140,15 +188,19 @@ class RepositorySurface:
         return ArchiveFacts.from_conversations(await self._repository.list(limit=None))
 
     async def query_ids(self, query_case: ArchiveQueryCase) -> tuple[str, ...]:
+        if query_case.has_extended_filters or query_case.search_text is not None:
+            spec = _query_case_to_spec(query_case)
+            conversations = await spec.list(self._repository)
+            return _ids_from_conversations(conversations)
         if query_case.provider is not None:
             conversations = await self._repository.list(provider=query_case.provider, limit=None)
-        elif query_case.search_text is not None:
-            conversations = await self._repository.search(query_case.search_text, limit=100)
-        else:
-            raise ValueError(f"Query case {query_case.name!r} does not define a supported projection")
-        return _sorted_unique([str(conversation.id) for conversation in conversations])
+            return _ids_from_conversations(conversations)
+        raise ValueError(f"Query case {query_case.name!r} does not define a supported projection")
 
     async def query_count(self, query_case: ArchiveQueryCase) -> int:
+        if query_case.has_extended_filters or query_case.search_text is not None:
+            spec = _query_case_to_spec(query_case)
+            return await spec.count(self._repository)
         if query_case.provider is not None:
             return await self._repository.count(provider=query_case.provider)
         return len(await self.query_ids(query_case))
@@ -175,12 +227,14 @@ class FacadeSurface:
         return ArchiveFacts.from_conversations(await self._archive.list_conversations(limit=None))
 
     async def query_ids(self, query_case: ArchiveQueryCase) -> tuple[str, ...]:
+        if query_case.has_extended_filters or query_case.search_text is not None:
+            spec = _query_case_to_spec(query_case)
+            # query_conversations runs the same filter chain that MCP/CLI use.
+            conversations = await self._archive.operations.query_conversations(spec)
+            return _ids_from_conversations(conversations)
         if query_case.provider is not None:
             conversations = await self._archive.list_conversations(provider=query_case.provider, limit=None)
-            return _sorted_unique([str(conversation.id) for conversation in conversations])
-        if query_case.search_text is not None:
-            result = await self._archive.search(query_case.search_text, limit=100)
-            return _sorted_unique([hit.conversation_id for hit in result.hits])
+            return _ids_from_conversations(conversations)
         raise ValueError(f"Query case {query_case.name!r} does not define a supported projection")
 
     async def query_count(self, query_case: ArchiveQueryCase) -> int:
@@ -188,6 +242,170 @@ class FacadeSurface:
 
     async def close(self) -> None:
         await self._archive.close()
+
+
+class CLISurface:
+    """Click-CLI adapter projection.
+
+    Invokes the same ``polylogue [filters] list --format json`` path that
+    operators run, then projects the parsed envelope into the canonical
+    id-tuple shape used by the parity harness.
+
+    Requires ``workspace_env`` (or equivalent ``POLYLOGUE_ARCHIVE_ROOT`` /
+    ``XDG_DATA_HOME`` env vars) so the CLI process resolves the same
+    backing database as the substrate surfaces.
+    """
+
+    name = "cli"
+
+    def __init__(self, *, db_path: Path) -> None:
+        # db_path is held for diagnostics; the CLI resolves it via env vars.
+        self._db_path = db_path
+        self._runner = CliRunner()
+
+    def _invoke(self, query_case: ArchiveQueryCase) -> tuple[int, str]:
+        from polylogue.cli.click_app import cli
+
+        args: list[str] = []
+        if query_case.provider is not None:
+            args.extend(["--provider", query_case.provider])
+        if query_case.since is not None:
+            args.extend(["--since", query_case.since])
+        if query_case.until is not None:
+            args.extend(["--until", query_case.until])
+        if query_case.has_tool_use:
+            args.append("--has-tool-use")
+        if query_case.has_thinking:
+            args.append("--has-thinking")
+        if query_case.min_messages is not None:
+            args.extend(["--min-messages", str(query_case.min_messages)])
+        if query_case.max_messages is not None:
+            args.extend(["--max-messages", str(query_case.max_messages)])
+        if query_case.min_words is not None:
+            args.extend(["--min-words", str(query_case.min_words)])
+        if query_case.limit is not None:
+            args.extend(["--limit", str(query_case.limit)])
+        if query_case.offset:
+            args.extend(["--offset", str(query_case.offset)])
+        # Use --contains for FTS so the option parser routes the term
+        # deterministically as a query token rather than relying on the
+        # positional bare-token interception.
+        if query_case.search_text is not None:
+            args.extend(["--contains", query_case.search_text])
+        args.extend(["list", "--format", "json"])
+        result = self._runner.invoke(cli, args, catch_exceptions=True)
+        if result.exception is not None and not isinstance(result.exception, SystemExit):
+            raise result.exception
+        return result.exit_code, result.output
+
+    async def conversation_facts(self, scenario: ArchiveScenario) -> ConversationFacts:
+        raise NotImplementedError("CLISurface only supports query-level projections")
+
+    async def archive_facts(self) -> ArchiveFacts:
+        raise NotImplementedError("CLISurface only supports query-level projections")
+
+    async def query_ids(self, query_case: ArchiveQueryCase) -> tuple[str, ...]:
+        exit_code, output = self._invoke(query_case)
+        # Empty result: exit 2 with the no_results error envelope (JSON object).
+        if exit_code == 2:
+            try:
+                parsed = json.loads(output)
+            except json.JSONDecodeError as exc:
+                raise AssertionError(f"CLI no-results output is not JSON: {output!r}") from exc
+            if isinstance(parsed, dict) and parsed.get("status") == "error" and parsed.get("code") == "no_results":
+                return ()
+            raise AssertionError(f"CLI exited 2 but envelope is not no_results: {parsed!r}")
+        if exit_code != 0:
+            raise AssertionError(f"polylogue list --format json exited {exit_code} for {query_case.name!r}: {output!r}")
+        try:
+            parsed = json.loads(output)
+        except json.JSONDecodeError as exc:
+            raise AssertionError(f"CLI list output is not JSON ({query_case.name!r}): {output!r}") from exc
+        if not isinstance(parsed, list):
+            raise AssertionError(f"CLI list output is not a JSON array ({query_case.name!r}): {parsed!r}")
+        # Two shapes can land here depending on whether the parent group
+        # routed through pure list mode or the search-hit format:
+        #   * list mode: ``[{"id": ..., ...}, ...]``
+        #   * search-hit mode: ``[{"conversation": {"id": ...}, ...}, ...]``
+        # Both project to the same id tuple for parity comparison.
+        ids: list[str] = []
+        for row in parsed:
+            if not isinstance(row, dict):
+                continue
+            if "id" in row:
+                ids.append(str(row["id"]))
+            elif "conversation" in row and isinstance(row["conversation"], dict):
+                conv = row["conversation"]
+                if "id" in conv:
+                    ids.append(str(conv["id"]))
+        return _sorted_unique(ids)
+
+    async def query_count(self, query_case: ArchiveQueryCase) -> int:
+        return len(await self.query_ids(query_case))
+
+    async def close(self) -> None:
+        return None
+
+
+class MCPSurface:
+    """MCP server-tool adapter projection.
+
+    Invokes ``list_conversations`` directly on the registered FastMCP tool
+    function, bound to a ``RuntimeServices`` instance pointed at the parity
+    database.  This is the same code path MCP clients hit over the JSON-RPC
+    transport.
+    """
+
+    name = "mcp"
+
+    def __init__(self, *, db_path: Path) -> None:
+        from polylogue.mcp.server import build_server
+        from polylogue.mcp.server_support import _set_runtime_services
+        from polylogue.services import build_runtime_services
+
+        self._services = build_runtime_services(db_path=db_path)
+        _set_runtime_services(self._services)
+        self._server = build_server(role="admin")
+
+    def _tool(self, name: str) -> Any:
+        return self._server._tool_manager._tools[name].fn  # type: ignore[attr-defined]
+
+    async def conversation_facts(self, scenario: ArchiveScenario) -> ConversationFacts:
+        raise NotImplementedError("MCPSurface only supports query-level projections")
+
+    async def archive_facts(self) -> ArchiveFacts:
+        raise NotImplementedError("MCPSurface only supports query-level projections")
+
+    async def query_ids(self, query_case: ArchiveQueryCase) -> tuple[str, ...]:
+        # MCP enforces clamped limits (min 1); use a generous ceiling so the
+        # parity matrix is dominated by the case-level expected count rather
+        # than transport-level bounds.
+        request_limit = query_case.limit if query_case.limit is not None else 1000
+        payload_json = await self._tool("list_conversations")(
+            limit=request_limit,
+            provider=query_case.provider,
+            contains=query_case.search_text,
+            since=query_case.since,
+            until=query_case.until,
+            has_tool_use=query_case.has_tool_use,
+            has_thinking=query_case.has_thinking,
+            min_messages=query_case.min_messages,
+            max_messages=query_case.max_messages,
+            min_words=query_case.min_words,
+            offset=query_case.offset,
+        )
+        parsed = json.loads(payload_json)
+        items = parsed.get("items", [])
+        return _sorted_unique([str(item["id"]) for item in items])
+
+    async def query_count(self, query_case: ArchiveQueryCase) -> int:
+        return len(await self.query_ids(query_case))
+
+    async def close(self) -> None:
+        from polylogue.mcp.server_support import _set_runtime_services
+
+        await self._services.close()
+        _set_runtime_services(None)
 
 
 @dataclass(slots=True)
@@ -219,6 +437,29 @@ def build_archive_surface_set(
     )
 
 
+def build_adapter_surface_set(
+    *,
+    db_path: Path,
+    archive_root: Path,
+) -> ArchiveSurfaceSet:
+    """Build the repo/facade/cli/mcp adapter parity set.
+
+    Excludes the raw-SQL projections (``SQLiteRecordSurface``,
+    ``SQLiteHydratedSurface``) because they only express provider and
+    text-search projections; the adapter parity matrix needs to exercise
+    the full filter chain (date range, limit/offset, stats-join
+    pushdowns) which the substrate SQL views cannot project without
+    re-implementing the spec.
+    """
+    surfaces: tuple[ArchiveSurfaceAdapter, ...] = (
+        RepositorySurface(db_path),
+        FacadeSurface(archive_root=archive_root, db_path=db_path),
+        CLISurface(db_path=db_path),
+        MCPSurface(db_path=db_path),
+    )
+    return ArchiveSurfaceSet(surfaces=surfaces)
+
+
 def _provider_counts(conversations: list[ConversationFacts]) -> dict[str, int]:
     counts: dict[str, int] = {}
     for conversation in conversations:
@@ -234,9 +475,12 @@ def _current_archive_scenarios(conn: sqlite3.Connection) -> tuple[ArchiveScenari
 __all__ = [
     "ArchiveSurfaceAdapter",
     "ArchiveSurfaceSet",
+    "CLISurface",
     "FacadeSurface",
+    "MCPSurface",
     "RepositorySurface",
     "SQLiteHydratedSurface",
     "SQLiteRecordSurface",
+    "build_adapter_surface_set",
     "build_archive_surface_set",
 ]

--- a/tests/infra/test_storage_records.py
+++ b/tests/infra/test_storage_records.py
@@ -51,6 +51,9 @@ def test_store_records_commits_within_lock(monkeypatch: pytest.MonkeyPatch) -> N
     monkeypatch.setattr(storage_helpers, "upsert_message", lambda *_: True)
     monkeypatch.setattr(storage_helpers, "upsert_attachment", lambda *_: True)
     monkeypatch.setattr(storage_helpers, "_prune_attachment_refs", lambda *_: None)
+    # The in-memory test connection has no schema, so suppress the stats
+    # upsert that store_records now performs to mirror production.
+    monkeypatch.setattr(storage_helpers, "_upsert_conversation_stats_sync", lambda *_, **__: None)
 
     result = storage_helpers.store_records(
         conversation=make_conversation("test:1", title="Test", content_hash="abc123"),

--- a/tests/unit/storage/test_surface_parity_adapters.py
+++ b/tests/unit/storage/test_surface_parity_adapters.py
@@ -1,0 +1,365 @@
+"""Cross-surface query parity for CLI and MCP adapters (#1060).
+
+These tests close the surface-parity loop on the public read adapters.  The
+substrate parity tests in ``test_query_parity.py`` already pin agreement
+between SQLite, the repository, and the async facade.  The adapter tests
+here add the Click CLI (``polylogue list --format json``) and the MCP
+server tool (``list_conversations``) so any drift between the substrate
+filter chain and the published surfaces is caught locally.
+
+Surface stack exercised here (top to bottom):
+
+  CLISurface  --polylogue list --format json--+
+                                              |
+  MCPSurface  --list_conversations------------+
+                                              |---> ConversationFilter
+  FacadeSurface --Polylogue.operations--------+    --> SQLiteBackend
+                                              |
+  RepositorySurface --ConversationRepository--+
+
+Every parity case is expressed once as an :class:`ArchiveQueryCase` and
+projected through every surface; the assertion is that all surfaces return
+the same id tuple.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Mapping
+from pathlib import Path
+
+import pytest
+
+from tests.infra.archive_scenarios import (
+    ArchiveScenario,
+    ScenarioMessage,
+    seed_workspace_scenarios,
+)
+from tests.infra.contract_evidence import ContractEvidenceRecorder
+from tests.infra.query_cases import ArchiveQueryCase
+from tests.infra.surfaces import (
+    ArchiveSurfaceSet,
+    build_adapter_surface_set,
+)
+
+# ---------------------------------------------------------------------------
+# Scenario corpus
+# ---------------------------------------------------------------------------
+
+
+def _parity_scenarios() -> tuple[ArchiveScenario, ...]:
+    """Provider-diverse scenarios shaped to exercise the parity matrix.
+
+    Each scenario is uniquely identifiable along multiple axes:
+      * provider — three providers, asymmetric counts (1/2/1)
+      * message text — stable FTS tokens (``aardvark``, ``buffalo``)
+      * message volume — counts span 1/2/3/5 so min/max filters bite
+    """
+    return (
+        ArchiveScenario(
+            name="parity-chatgpt-1",
+            provider="chatgpt",
+            title="ChatGPT aardvark conversation",
+            messages=(
+                ScenarioMessage(role="user", text="aardvark question", message_id="parity-chatgpt-1-u1"),
+                ScenarioMessage(role="assistant", text="aardvark answer", message_id="parity-chatgpt-1-a1"),
+            ),
+        ),
+        ArchiveScenario(
+            name="parity-claude-1",
+            provider="claude-code",
+            title="Claude buffalo session",
+            messages=(
+                ScenarioMessage(role="user", text="buffalo question", message_id="parity-claude-1-u1"),
+                ScenarioMessage(role="assistant", text="buffalo answer", message_id="parity-claude-1-a1"),
+                ScenarioMessage(role="user", text="buffalo followup", message_id="parity-claude-1-u2"),
+            ),
+        ),
+        ArchiveScenario(
+            name="parity-claude-2",
+            provider="claude-code",
+            title="Claude long detailed conversation",
+            messages=(
+                ScenarioMessage(role="user", text="long detailed question one", message_id="parity-claude-2-u1"),
+                ScenarioMessage(role="assistant", text="long detailed answer one", message_id="parity-claude-2-a1"),
+                ScenarioMessage(role="user", text="long detailed question two", message_id="parity-claude-2-u2"),
+                ScenarioMessage(role="assistant", text="long detailed answer two", message_id="parity-claude-2-a2"),
+                ScenarioMessage(role="user", text="long detailed question three", message_id="parity-claude-2-u3"),
+            ),
+        ),
+        ArchiveScenario(
+            name="parity-codex-1",
+            provider="codex",
+            title="Codex single-message conversation",
+            messages=(ScenarioMessage(role="user", text="codex isolated request", message_id="parity-codex-1-u1"),),
+        ),
+    )
+
+
+@pytest.fixture()
+def parity_archive(workspace_env: Mapping[str, Path]) -> tuple[Path, tuple[ArchiveScenario, ...]]:
+    scenarios = _parity_scenarios()
+    db_path, _ = seed_workspace_scenarios(workspace_env, scenarios)
+    return db_path, scenarios
+
+
+@pytest.fixture()
+async def adapter_surfaces(
+    workspace_env: Mapping[str, Path],
+    parity_archive: tuple[Path, tuple[ArchiveScenario, ...]],
+) -> AsyncIterator[ArchiveSurfaceSet]:
+    db_path, _ = parity_archive
+    surfaces = build_adapter_surface_set(
+        db_path=db_path,
+        archive_root=workspace_env["archive_root"],
+    )
+    try:
+        yield surfaces
+    finally:
+        await surfaces.close()
+
+
+# ---------------------------------------------------------------------------
+# Parity assertions
+# ---------------------------------------------------------------------------
+
+
+async def _assert_parity(
+    surfaces: ArchiveSurfaceSet,
+    case: ArchiveQueryCase,
+    recorder: ContractEvidenceRecorder,
+    *,
+    contract_root: str,
+) -> tuple[tuple[str, ...], dict[str, tuple[str, ...]]]:
+    """Run ``case`` through every surface and assert id-tuple agreement."""
+    expected = tuple(sorted(case.expected_ids))
+    projections: dict[str, tuple[str, ...]] = {}
+    for surface in surfaces.surfaces:
+        ids = await surface.query_ids(case)
+        projections[surface.name] = ids
+        assert ids == expected, f"{surface.name} returned {ids} for {case.name!r}; expected {expected}"
+        count = await surface.query_count(case)
+        assert count == len(expected), f"{surface.name} count={count} for {case.name!r}; expected {len(expected)}"
+        recorder.record(
+            f"{contract_root}.{surface.name}",
+            surface=surface.name,
+            request={"case": case.name},
+            result={"ids": list(ids), "count": count},
+            facts={"expected_ids": list(expected)},
+        )
+    return expected, projections
+
+
+# ---------------------------------------------------------------------------
+# Provider parity
+# ---------------------------------------------------------------------------
+
+
+class TestProviderParity:
+    @pytest.mark.contract
+    @pytest.mark.asyncio()
+    async def test_provider_chatgpt_parity(
+        self,
+        adapter_surfaces: ArchiveSurfaceSet,
+        record_contract_evidence: ContractEvidenceRecorder,
+    ) -> None:
+        case = ArchiveQueryCase(
+            name="provider-chatgpt",
+            provider="chatgpt",
+            expected_ids=("parity-chatgpt-1",),
+        )
+        await _assert_parity(adapter_surfaces, case, record_contract_evidence, contract_root="query.parity.provider")
+
+    @pytest.mark.contract
+    @pytest.mark.asyncio()
+    async def test_provider_claude_parity(
+        self,
+        adapter_surfaces: ArchiveSurfaceSet,
+        record_contract_evidence: ContractEvidenceRecorder,
+    ) -> None:
+        case = ArchiveQueryCase(
+            name="provider-claude",
+            provider="claude-code",
+            expected_ids=("parity-claude-1", "parity-claude-2"),
+        )
+        await _assert_parity(adapter_surfaces, case, record_contract_evidence, contract_root="query.parity.provider")
+
+    @pytest.mark.contract
+    @pytest.mark.asyncio()
+    async def test_provider_codex_parity(
+        self,
+        adapter_surfaces: ArchiveSurfaceSet,
+        record_contract_evidence: ContractEvidenceRecorder,
+    ) -> None:
+        case = ArchiveQueryCase(
+            name="provider-codex",
+            provider="codex",
+            expected_ids=("parity-codex-1",),
+        )
+        await _assert_parity(adapter_surfaces, case, record_contract_evidence, contract_root="query.parity.provider")
+
+
+# ---------------------------------------------------------------------------
+# Text-search (FTS) parity
+# ---------------------------------------------------------------------------
+
+
+class TestSearchParity:
+    @pytest.mark.contract
+    @pytest.mark.asyncio()
+    async def test_search_unique_token_parity(
+        self,
+        adapter_surfaces: ArchiveSurfaceSet,
+        record_contract_evidence: ContractEvidenceRecorder,
+    ) -> None:
+        case = ArchiveQueryCase(
+            name="search-aardvark",
+            search_text="aardvark",
+            expected_ids=("parity-chatgpt-1",),
+        )
+        await _assert_parity(adapter_surfaces, case, record_contract_evidence, contract_root="query.parity.search")
+
+    @pytest.mark.contract
+    @pytest.mark.asyncio()
+    async def test_search_shared_token_parity(
+        self,
+        adapter_surfaces: ArchiveSurfaceSet,
+        record_contract_evidence: ContractEvidenceRecorder,
+    ) -> None:
+        case = ArchiveQueryCase(
+            name="search-buffalo",
+            search_text="buffalo",
+            expected_ids=("parity-claude-1",),
+        )
+        await _assert_parity(adapter_surfaces, case, record_contract_evidence, contract_root="query.parity.search")
+
+
+# ---------------------------------------------------------------------------
+# Stats-join filter parity — the highest drift risk
+# ---------------------------------------------------------------------------
+
+
+class TestStatsJoinParity:
+    """min_messages/max_messages/min_words are SQL pushdowns via stats join.
+
+    The pushdown is configured per surface in ``_needs_stats_join`` and the
+    spec; if any surface fails to forward a flag, this test catches it.
+    """
+
+    @pytest.mark.contract
+    @pytest.mark.asyncio()
+    async def test_min_messages_filter_parity(
+        self,
+        adapter_surfaces: ArchiveSurfaceSet,
+        record_contract_evidence: ContractEvidenceRecorder,
+    ) -> None:
+        # Counts: chatgpt-1=2, claude-1=3, claude-2=5, codex-1=1.
+        # min_messages=3 → claude-1, claude-2.
+        case = ArchiveQueryCase(
+            name="min-messages-3",
+            min_messages=3,
+            expected_ids=("parity-claude-1", "parity-claude-2"),
+        )
+        await _assert_parity(adapter_surfaces, case, record_contract_evidence, contract_root="query.parity.stats")
+
+    @pytest.mark.contract
+    @pytest.mark.asyncio()
+    async def test_max_messages_filter_parity(
+        self,
+        adapter_surfaces: ArchiveSurfaceSet,
+        record_contract_evidence: ContractEvidenceRecorder,
+    ) -> None:
+        # max_messages=2 → chatgpt-1 (2 msgs), codex-1 (1 msg).
+        case = ArchiveQueryCase(
+            name="max-messages-2",
+            max_messages=2,
+            expected_ids=("parity-chatgpt-1", "parity-codex-1"),
+        )
+        await _assert_parity(adapter_surfaces, case, record_contract_evidence, contract_root="query.parity.stats")
+
+    @pytest.mark.contract
+    @pytest.mark.asyncio()
+    async def test_min_words_filter_parity(
+        self,
+        adapter_surfaces: ArchiveSurfaceSet,
+        record_contract_evidence: ContractEvidenceRecorder,
+    ) -> None:
+        # claude-2 carries 5 messages of ~4 words each → ~20 words; everyone
+        # else is below. min_words=15 → claude-2.
+        case = ArchiveQueryCase(
+            name="min-words-15",
+            min_words=15,
+            expected_ids=("parity-claude-2",),
+        )
+        await _assert_parity(adapter_surfaces, case, record_contract_evidence, contract_root="query.parity.stats")
+
+
+# ---------------------------------------------------------------------------
+# Limit/offset parity
+# ---------------------------------------------------------------------------
+
+
+class TestLimitOffsetParity:
+    @pytest.mark.contract
+    @pytest.mark.asyncio()
+    async def test_provider_with_limit_subset_parity(
+        self,
+        adapter_surfaces: ArchiveSurfaceSet,
+        record_contract_evidence: ContractEvidenceRecorder,
+    ) -> None:
+        """provider=claude-code + limit=1 returns one id; the id must agree across surfaces.
+
+        We don't pin which id is selected (sort order is surface-dependent
+        at this level), only that every surface returns the same single id.
+        """
+        case = ArchiveQueryCase(
+            name="provider-claude-limit-1",
+            provider="claude-code",
+            limit=1,
+            # expected_ids is filled at assert time below — we only require
+            # the size is 1 and surfaces agree on the chosen id.
+            expected_ids=(),
+        )
+        # Use a relaxed parity assertion: collect ids per surface, then
+        # assert all surfaces returned the same single id.
+        seen: dict[str, tuple[str, ...]] = {}
+        for surface in adapter_surfaces.surfaces:
+            ids = await surface.query_ids(case)
+            assert len(ids) == 1, f"{surface.name} returned {len(ids)} ids for limit=1: {ids}"
+            seen[surface.name] = ids
+        ref = next(iter(seen.values()))
+        for name, ids in seen.items():
+            assert ids == ref, f"limit-1 disagreement: {name}={ids} vs reference={ref}"
+        record_contract_evidence.record(
+            "query.parity.limit.adapter-set",
+            surface="adapter-set",
+            request={"case": case.name},
+            result={"per_surface_ids": {k: list(v) for k, v in seen.items()}},
+        )
+
+
+# ---------------------------------------------------------------------------
+# Combined-filter parity — provider + stats-join
+# ---------------------------------------------------------------------------
+
+
+class TestCombinedFilterParity:
+    @pytest.mark.contract
+    @pytest.mark.asyncio()
+    async def test_provider_plus_min_messages_parity(
+        self,
+        adapter_surfaces: ArchiveSurfaceSet,
+        record_contract_evidence: ContractEvidenceRecorder,
+    ) -> None:
+        # claude-code conversations with >= 4 messages → claude-2 only.
+        case = ArchiveQueryCase(
+            name="claude-min-messages-4",
+            provider="claude-code",
+            min_messages=4,
+            expected_ids=("parity-claude-2",),
+        )
+        await _assert_parity(
+            adapter_surfaces,
+            case,
+            record_contract_evidence,
+            contract_root="query.parity.combined",
+        )


### PR DESCRIPTION
## Summary

Extend `tests/infra/surfaces.py` with `CLISurface` and `MCPSurface`
adapter projections so the existing scenario-driven parity harness
exercises the public read adapters (`polylogue list --format json` and
the MCP `list_conversations` tool) alongside the substrate surfaces.
Adds parity tests under `tests/unit/storage/test_surface_parity_adapters.py`
covering provider, FTS, stats-join (min/max messages, min words),
limit/offset, and combined filter axes across four surfaces:
`repository → facade → cli → mcp`.

## Problem

`tests/infra/surfaces.py` covered only the substrate layers (SQLite raw,
hydrated, repository, facade). The CLI and MCP adapters reused the same
`ConversationFilter` chain in production but had no executable contract
forcing them to agree with the substrate on any filter axis. Stats-join
pushdowns (`min_messages`, `max_messages`, `min_words`,
`has_tool_use`/`has_thinking`) were the highest drift risk — they live in
both the spec (forwarded by the CLI and MCP request models) and the
storage layer's `_needs_stats_join` predicate, and any forwarding
mistake in either adapter would silently return wrong answers without
any test catching it.

A second drift surfaced during implementation: the test seeding path in
`tests/infra/storage_records.py:store_records` populated the
`conversations`, `messages`, and `attachments` tables but skipped
`conversation_stats`, so the stats-join filters returned empty results
on every surface for synthetic data — masking real production behavior.

## Solution

- `tests/infra/surfaces.py`
  - New `CLISurface`: invokes `polylogue [filters] list --format json`
    via `CliRunner`, parses both the list-mode array and the search-hit
    envelope shapes (the CLI flips shapes depending on whether `--contains`
    is present), normalizes to the same id tuple the substrate uses.
  - New `MCPSurface`: binds a `RuntimeServices` instance to the parity
    database and invokes `_tool_manager._tools["list_conversations"].fn`
    directly, parsing the `items[*].id` projection.
  - New `build_adapter_surface_set` helper composes
    `repository / facade / cli / mcp` for the adapter-parity matrix
    (excludes the raw-SQL surfaces because they cannot express the
    extended filter axes without re-implementing the spec).
  - Both `RepositorySurface` and `FacadeSurface` now route extended
    filters through a `ConversationQuerySpec` (and
    `Polylogue.operations.query_conversations` for the facade) so the
    spec is the single shared filter contract across all four surfaces.
- `tests/infra/query_cases.py`
  - `ArchiveQueryCase` gains `since`/`until`/`limit`/`offset`,
    `has_tool_use`, `has_thinking`, `min_messages`, `max_messages`,
    `min_words` and a `has_extended_filters` predicate.
- `tests/infra/storage_records.py`
  - `store_records` now upserts `conversation_stats` via a sync mirror
    (`_upsert_conversation_stats_sync`) of the production async
    upsert, sharing the `SQL_STATS_UPSERT` statement constant. Fixes the
    parity gap where stats-join filters returned empty results on
    synthetic data.
- `tests/infra/test_storage_records.py`
  - The in-memory `test_store_records_commits_within_lock` test
    monkeypatches the new sync stats helper to no-op (the in-memory
    connection has no schema, matching how it already stubs the other
    write helpers).
- `tests/unit/storage/test_surface_parity_adapters.py` (new)
  - Provider parity (chatgpt / claude-code / codex)
  - FTS parity (unique token, shared-but-narrow token)
  - Stats-join parity (`min_messages`, `max_messages`, `min_words`)
  - Limit/offset agreement (provider + limit=1 returns the same single id across surfaces)
  - Combined-filter parity (provider + min_messages)

Parity bug fixed in this PR: `store_records` not populating
`conversation_stats`. Drift candidates noted but not pursued: the spec
exposes more pushdowns (`has_paste`, `typed_only`, `message_type`,
`since_session_id`) that this PR's matrix doesn't cover — the harness
supports adding them without further infrastructure.

## Verification

Inside the project devshell:

```
pytest tests/unit/storage/test_surface_parity_adapters.py tests/infra \
       tests/unit/storage/test_query_parity.py \
       tests/unit/storage/test_retrieval_readiness_laws.py
# 50 passed in 9.25s

mypy --strict tests/infra/surfaces.py tests/infra/query_cases.py \
              tests/infra/storage_records.py \
              tests/infra/test_storage_records.py \
              tests/unit/storage/test_surface_parity_adapters.py
# Success: no issues found in 5 source files

devtools verify --quick
# total_duration_s: 30.5, exit_code: 0
```

Ref #1060