### PR TITLE
feat(devtools): evidence dashboard and changed-path traceability (#998)

### DIFF
--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -530,6 +530,22 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
         ),
     ),
     CommandSpec(
+        "evidence-dashboard",
+        "verification",
+        "Render the pytest-first evidence dashboard or a changed-path trace.",
+        "devtools.evidence_dashboard",
+        use_when=(
+            "Inspect pytest health, contract-evidence inventory, coverage, SLO "
+            "catalog, static-gate status, witnesses, and campaign freshness, or "
+            "trace which evidence artifacts cover the changed paths in a PR."
+        ),
+        examples=(
+            "devtools evidence-dashboard --json",
+            "devtools evidence-dashboard --markdown",
+            "devtools evidence-dashboard trace --base origin/master --head HEAD --markdown",
+        ),
+    ),
+    CommandSpec(
         "witness-discover",
         "maintenance",
         "Save a failure-triggering input as a local witness in .local/witnesses/new/.",

--- a/devtools/evidence_dashboard.py
+++ b/devtools/evidence_dashboard.py
@@ -1,0 +1,790 @@
+"""Evidence dashboard and changed-path traceability.
+
+Reads real artifacts emitted by the verification pipeline and presents them
+as a single dashboard for operators and PR consumers. Unlike
+``devtools evidence-report`` (which focuses on verify-history + suppressions),
+this command aggregates the full pytest-first evidence surface introduced by
+PRs #1083/#1086/#1087/#1088:
+
+- pytest health from ``.cache/verify/last-pytest.json``;
+- contract evidence inventory from ``.cache/verification/evidence/*.json``;
+- coverage from ``.coverage`` / ``coverage.xml`` when present;
+- benchmark/SLO catalog rows and their required-artifact coverage;
+- static gate status from ``.cache/verify-history.jsonl``;
+- witness lifecycle counts;
+- mutation/benchmark campaign freshness.
+
+The ``trace`` subcommand walks changed paths through the same artifact sources
+to produce a change -> claim -> evidence -> gate -> merge view suitable for
+PR comments and agent consumption.
+
+All sections are backed by real artifacts. Sections with no underlying file
+are reported as ``"available": false`` with the reason — no aspirational rows.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import xml.etree.ElementTree as ET
+from collections import Counter, defaultdict
+from collections.abc import Sequence
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from devtools import repo_root as _get_root
+from devtools.verification_impact import build_verification_impact_report
+
+ROOT = _get_root()
+
+# Artifact paths (relative to repo root).
+PYTEST_REPORT_REL = Path(".cache/verify/last-pytest.json")
+VERIFY_HISTORY_REL = Path(".cache/verify-history.jsonl")
+LAST_VERIFY_RESULT_REL = Path(".cache/last-verify-result.json")
+EVIDENCE_DIR_REL = Path(".cache/verification/evidence")
+COVERAGE_DATA_REL = Path(".coverage")
+COVERAGE_XML_REL = Path("coverage.xml")
+WITNESSES_COMMITTED_REL = Path("tests/witnesses")
+WITNESSES_LOCAL_REL = Path(".local/witnesses")
+BENCHMARK_CAMPAIGNS_REL = Path(".local/benchmark-campaigns")
+MUTATION_CAMPAIGNS_REL = Path(".local/mutation-campaigns")
+SLO_CATALOG_REL = Path("docs/plans/slo-catalog.yaml")
+
+DEFAULT_STALE_DAYS = 7
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Section: pytest health
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _pytest_health(root: Path, *, now: datetime) -> dict[str, Any]:
+    report_path = root / PYTEST_REPORT_REL
+    if not report_path.exists():
+        return {
+            "available": False,
+            "reason": f"missing {PYTEST_REPORT_REL} — run devtools verify",
+            "path": str(PYTEST_REPORT_REL),
+        }
+    try:
+        raw = json.loads(report_path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        return {
+            "available": False,
+            "reason": f"unreadable {PYTEST_REPORT_REL}: {exc}",
+            "path": str(PYTEST_REPORT_REL),
+        }
+    if not isinstance(raw, dict):
+        return {
+            "available": False,
+            "reason": f"{PYTEST_REPORT_REL} not a JSON object",
+            "path": str(PYTEST_REPORT_REL),
+        }
+    raw_summary = raw.get("summary")
+    summary: dict[str, Any] = raw_summary if isinstance(raw_summary, dict) else {}
+    mtime = datetime.fromtimestamp(report_path.stat().st_mtime, tz=timezone.utc)
+    age_days = (now - mtime).days
+    counts: dict[str, int] = {}
+    for key in ("passed", "failed", "error", "skipped", "xfailed", "xpassed", "total"):
+        value = summary.get(key)
+        if isinstance(value, int):
+            counts[key] = value
+    failed = counts.get("failed", 0) + counts.get("error", 0)
+    status = "ok" if failed == 0 else "fail"
+    return {
+        "available": True,
+        "path": str(PYTEST_REPORT_REL),
+        "status": status,
+        "counts": counts,
+        "duration_s": (round(float(raw["duration"]), 2) if isinstance(raw.get("duration"), (int, float)) else None),
+        "last_run": mtime.isoformat(),
+        "age_days": age_days,
+        "stale": age_days > DEFAULT_STALE_DAYS,
+    }
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Section: contract evidence inventory
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _contract_evidence(root: Path, *, now: datetime, stale_days: int) -> dict[str, Any]:
+    evidence_dir = root / EVIDENCE_DIR_REL
+    if not evidence_dir.exists():
+        return {
+            "available": False,
+            "reason": f"missing {EVIDENCE_DIR_REL} — run pytest contract tests",
+            "path": str(EVIDENCE_DIR_REL),
+        }
+    artifacts: list[dict[str, Any]] = []
+    for json_file in sorted(evidence_dir.glob("*.json")):
+        try:
+            data = json.loads(json_file.read_text())
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(data, dict):
+            continue
+        mtime = datetime.fromtimestamp(json_file.stat().st_mtime, tz=timezone.utc)
+        artifacts.append(
+            {
+                "path": str(json_file.relative_to(root)),
+                "contract": str(data.get("contract", "unknown")),
+                "surface": str(data.get("surface", "unknown")),
+                "test_nodeid": data.get("test_nodeid"),
+                "git_sha": data.get("git_sha"),
+                "dirty": bool(data.get("dirty")),
+                "timestamp": data.get("timestamp"),
+                "mtime": mtime.isoformat(),
+                "age_days": (now - mtime).days,
+            }
+        )
+
+    by_surface: dict[str, Counter[str]] = defaultdict(Counter)
+    stale: list[str] = []
+    dirty: list[str] = []
+    for art in artifacts:
+        by_surface[art["surface"]][art["contract"]] += 1
+        if art["age_days"] > stale_days:
+            stale.append(art["contract"])
+        if art["dirty"]:
+            dirty.append(art["contract"])
+
+    surface_summary = {
+        surface: {
+            "total_artifacts": sum(counts.values()),
+            "unique_contracts": len(counts),
+        }
+        for surface, counts in sorted(by_surface.items())
+    }
+    return {
+        "available": True,
+        "path": str(EVIDENCE_DIR_REL),
+        "total_artifacts": len(artifacts),
+        "unique_contracts": len({art["contract"] for art in artifacts}),
+        "by_surface": surface_summary,
+        "stale_count": len(stale),
+        "stale_contracts": sorted(set(stale)),
+        "dirty_count": len(dirty),
+    }
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Section: coverage
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _coverage(root: Path) -> dict[str, Any]:
+    xml_path = root / COVERAGE_XML_REL
+    data_path = root / COVERAGE_DATA_REL
+    if xml_path.exists():
+        try:
+            tree = ET.parse(xml_path)
+            attrib = tree.getroot().attrib
+            line_rate = float(attrib.get("line-rate", "0"))
+            return {
+                "available": True,
+                "path": str(COVERAGE_XML_REL),
+                "line_rate": round(line_rate, 4),
+                "percent": round(line_rate * 100, 2),
+                "lines_covered": int(attrib["lines-covered"]) if "lines-covered" in attrib else None,
+                "lines_valid": int(attrib["lines-valid"]) if "lines-valid" in attrib else None,
+            }
+        except (OSError, ET.ParseError, ValueError) as exc:
+            return {
+                "available": False,
+                "reason": f"unreadable {COVERAGE_XML_REL}: {exc}",
+                "path": str(COVERAGE_XML_REL),
+            }
+    if data_path.exists():
+        mtime = datetime.fromtimestamp(data_path.stat().st_mtime, tz=timezone.utc)
+        return {
+            "available": True,
+            "path": str(COVERAGE_DATA_REL),
+            "note": "binary .coverage present — run coverage report/xml for percent",
+            "mtime": mtime.isoformat(),
+        }
+    return {
+        "available": False,
+        "reason": "no coverage.xml or .coverage found — run devtools coverage-gate",
+        "path": str(COVERAGE_XML_REL),
+    }
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Section: benchmark / SLO catalog
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _benchmark_slo(root: Path, *, now: datetime) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    campaigns_dir = root / BENCHMARK_CAMPAIGNS_REL
+    if campaigns_dir.exists():
+        runs: list[dict[str, Any]] = []
+        for json_file in sorted(campaigns_dir.glob("**/*.json")):
+            mtime = datetime.fromtimestamp(json_file.stat().st_mtime, tz=timezone.utc)
+            runs.append(
+                {
+                    "name": json_file.stem,
+                    "path": str(json_file.relative_to(root)),
+                    "mtime": mtime.isoformat(),
+                    "age_days": (now - mtime).days,
+                }
+            )
+        out["benchmark_campaigns"] = {
+            "available": True,
+            "path": str(BENCHMARK_CAMPAIGNS_REL),
+            "total_runs": len(runs),
+            "runs": runs,
+        }
+    else:
+        out["benchmark_campaigns"] = {
+            "available": False,
+            "reason": f"missing {BENCHMARK_CAMPAIGNS_REL} — run devtools benchmark-campaign run <name>",
+            "path": str(BENCHMARK_CAMPAIGNS_REL),
+        }
+    slo_path = root / SLO_CATALOG_REL
+    if slo_path.exists():
+        try:
+            from devtools.verify_slos import _parse_slo_catalog
+
+            surfaces = _parse_slo_catalog(slo_path.read_text())
+            required = [
+                name
+                for name, cfg in surfaces.items()
+                if isinstance(cfg.get("gate"), str) and cfg.get("gate") == "required"
+            ]
+            informational = [
+                name
+                for name, cfg in surfaces.items()
+                if isinstance(cfg.get("gate"), str) and cfg.get("gate") == "informational"
+            ]
+            out["slo_catalog"] = {
+                "available": True,
+                "path": str(SLO_CATALOG_REL),
+                "total_surfaces": len(surfaces),
+                "required_surfaces": sorted(required),
+                "informational_surfaces": sorted(informational),
+            }
+        except (OSError, ValueError) as exc:
+            out["slo_catalog"] = {
+                "available": False,
+                "reason": f"unreadable {SLO_CATALOG_REL}: {exc}",
+                "path": str(SLO_CATALOG_REL),
+            }
+    else:
+        out["slo_catalog"] = {
+            "available": False,
+            "reason": f"missing {SLO_CATALOG_REL}",
+            "path": str(SLO_CATALOG_REL),
+        }
+    return out
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Section: static gates (from verify history)
+# ──────────────────────────────────────────────────────────────────────
+
+
+_STATIC_GATE_NAMES: tuple[str, ...] = (
+    "ruff format",
+    "ruff check",
+    "mypy",
+    "render-all",
+    "verify-topology",
+    "verify-layering",
+    "verify-file-budgets",
+    "verify-test-ownership",
+    "verify-schema-roundtrip",
+    "verify-cross-cuts",
+    "verify-suppressions",
+    "verify-manifests",
+    "verify-witness-lifecycle",
+    "verify-lane-assertions",
+)
+
+
+def _static_gates(root: Path, *, now: datetime) -> dict[str, Any]:
+    history_path = root / VERIFY_HISTORY_REL
+    last_result_path = root / LAST_VERIFY_RESULT_REL
+
+    # Prefer last-verify-result.json (the most recent run) then walk back through
+    # history to find the last status for each gate.
+    last_steps: dict[str, dict[str, Any]] = {}
+    last_result_mtime: str | None = None
+    if last_result_path.exists():
+        try:
+            data = json.loads(last_result_path.read_text())
+            result = data.get("result") if isinstance(data, dict) else None
+            if isinstance(result, dict):
+                for step in result.get("steps", []):
+                    if isinstance(step, dict) and isinstance(step.get("name"), str):
+                        last_steps[step["name"]] = step
+                last_result_mtime = result.get("timestamp")
+        except (OSError, json.JSONDecodeError):
+            pass
+
+    history_entries: list[dict[str, Any]] = []
+    if history_path.exists():
+        try:
+            with history_path.open() as fh:
+                for line in fh:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        history_entries.append(json.loads(line))
+                    except json.JSONDecodeError:
+                        continue
+        except OSError:
+            pass
+
+    # Fill in any gates missing from last-verify-result with the most recent
+    # appearance in history.
+    if history_entries:
+        for entry in reversed(history_entries):
+            steps = entry.get("steps", []) if isinstance(entry, dict) else []
+            for step in steps:
+                if not isinstance(step, dict):
+                    continue
+                name = step.get("name")
+                if isinstance(name, str) and name not in last_steps:
+                    last_steps[name] = {**step, "_source": "history", "_run_timestamp": entry.get("timestamp")}
+
+    gates: list[dict[str, Any]] = []
+    for gate_name in _STATIC_GATE_NAMES:
+        step = last_steps.get(gate_name)
+        if step is None:
+            gates.append({"name": gate_name, "available": False, "reason": "no run observed in cached history"})
+            continue
+        exit_code = step.get("exit", -1)
+        gates.append(
+            {
+                "name": gate_name,
+                "available": True,
+                "status": "ok" if exit_code == 0 else "fail",
+                "exit_code": exit_code,
+                "duration_s": step.get("duration_s"),
+                "last_run": step.get("_run_timestamp", last_result_mtime),
+            }
+        )
+    failing = [g for g in gates if g.get("status") == "fail"]
+    return {
+        "available": last_result_path.exists() or history_path.exists(),
+        "history_path": str(VERIFY_HISTORY_REL),
+        "last_result_path": str(LAST_VERIFY_RESULT_REL),
+        "total_gates_tracked": len(_STATIC_GATE_NAMES),
+        "gates_with_status": sum(1 for g in gates if g.get("available")),
+        "failing": [g["name"] for g in failing],
+        "gates": gates,
+        "history_runs": len(history_entries),
+    }
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Section: witnesses
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _witnesses(root: Path) -> dict[str, Any]:
+    committed = root / WITNESSES_COMMITTED_REL
+    local = root / WITNESSES_LOCAL_REL
+    committed_files = sorted(committed.glob("*.witness.json")) if committed.exists() else []
+    local_files = sorted(local.glob("**/*.witness.json")) if local.exists() else []
+    return {
+        "committed": {
+            "available": committed.exists(),
+            "path": str(WITNESSES_COMMITTED_REL),
+            "count": len(committed_files),
+        },
+        "local": {
+            "available": local.exists(),
+            "path": str(WITNESSES_LOCAL_REL),
+            "count": len(local_files),
+        },
+    }
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Section: mutation campaigns
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _mutation_campaigns(root: Path, *, now: datetime) -> dict[str, Any]:
+    mut_dir = root / MUTATION_CAMPAIGNS_REL
+    if not mut_dir.exists():
+        return {
+            "available": False,
+            "reason": f"missing {MUTATION_CAMPAIGNS_REL} — run devtools mutmut-campaign run <name>",
+            "path": str(MUTATION_CAMPAIGNS_REL),
+        }
+    campaigns: dict[str, dict[str, Any]] = {}
+    for child in sorted(mut_dir.iterdir()):
+        if not child.is_dir():
+            continue
+        latest_mtime: float | None = None
+        files = 0
+        for f in child.rglob("*"):
+            if f.is_file():
+                files += 1
+                m = f.stat().st_mtime
+                if latest_mtime is None or m > latest_mtime:
+                    latest_mtime = m
+        entry: dict[str, Any] = {"files": files}
+        if latest_mtime is not None:
+            mtime = datetime.fromtimestamp(latest_mtime, tz=timezone.utc)
+            entry["latest_mtime"] = mtime.isoformat()
+            entry["age_days"] = (now - mtime).days
+        campaigns[child.name] = entry
+    return {
+        "available": True,
+        "path": str(MUTATION_CAMPAIGNS_REL),
+        "total_campaigns": len(campaigns),
+        "campaigns": campaigns,
+    }
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Dashboard assembly
+# ──────────────────────────────────────────────────────────────────────
+
+
+def build_dashboard(root: Path, *, now: datetime | None = None, stale_days: int = DEFAULT_STALE_DAYS) -> dict[str, Any]:
+    """Build the complete evidence-dashboard payload from real artifacts."""
+    when = now or datetime.now(timezone.utc)
+    benchmark_section = _benchmark_slo(root, now=when)
+    return {
+        "schema_version": 1,
+        "generated_at": when.isoformat(),
+        "root": str(root),
+        "pytest": _pytest_health(root, now=when),
+        "contract_evidence": _contract_evidence(root, now=when, stale_days=stale_days),
+        "coverage": _coverage(root),
+        "benchmark_campaigns": benchmark_section["benchmark_campaigns"],
+        "slo_catalog": benchmark_section["slo_catalog"],
+        "static_gates": _static_gates(root, now=when),
+        "witnesses": _witnesses(root),
+        "mutation_campaigns": _mutation_campaigns(root, now=when),
+    }
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Change traceability
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _changed_path_evidence_map(root: Path) -> dict[str, list[dict[str, Any]]]:
+    """Index every contract-evidence artifact by its originating test source path.
+
+    Reads artifacts directly from disk rather than reusing the bounded summary
+    in ``verification_impact`` (which truncates to the most recent 20). The
+    trace surface needs the complete index so every changed test file maps
+    to its committed evidence.
+    """
+    evidence_dir = root / EVIDENCE_DIR_REL
+    by_path: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    if not evidence_dir.exists():
+        return by_path
+    for json_file in sorted(evidence_dir.glob("*.json")):
+        try:
+            payload = json.loads(json_file.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+        nodeid = payload.get("test_nodeid")
+        if not isinstance(nodeid, str) or "::" not in nodeid:
+            continue
+        test_path = nodeid.split("::", 1)[0]
+        by_path[test_path].append(
+            {
+                "path": str(json_file.relative_to(root)),
+                "contract": str(payload.get("contract") or ""),
+                "surface": str(payload.get("surface") or "unknown"),
+                "test_nodeid": nodeid,
+            }
+        )
+    return by_path
+
+
+def build_trace(
+    root: Path,
+    *,
+    base_ref: str = "origin/master",
+    head_ref: str = "HEAD",
+    changed_paths: Sequence[str] | None = None,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Build a change → claim → evidence → gate trace using verification_impact."""
+    when = now or datetime.now(timezone.utc)
+    impact = build_verification_impact_report(
+        root,
+        base_ref=base_ref,
+        head_ref=head_ref,
+        changed_paths=list(changed_paths) if changed_paths is not None else None,
+    )
+
+    evidence_by_path = _changed_path_evidence_map(root)
+
+    # The verification-impact report exposes change subjects either at the
+    # top level (when test fixtures supply a flattened shape) or nested under
+    # the `affected` payload (the real builder output).
+    raw_affected = impact.get("affected")
+    affected: dict[str, Any] = raw_affected if isinstance(raw_affected, dict) else {}
+    raw_subjects = impact.get("change_subjects")
+    if not isinstance(raw_subjects, list):
+        nested = affected.get("change_subjects", [])
+        raw_subjects = nested if isinstance(nested, list) else []
+    change_subjects: list[Any] = raw_subjects
+    raw_refs = impact.get("refs")
+    refs: dict[str, Any] = raw_refs if isinstance(raw_refs, dict) else {}
+    out_base = impact.get("base_ref") or refs.get("base_ref", base_ref)
+    out_head = impact.get("head_ref") or refs.get("head_ref", head_ref)
+    required = impact.get("required_gates") or impact.get("required_pr_gates", [])
+    deployment = impact.get("deployment_gates") or affected.get("deployment_gates", [])
+
+    rows: list[dict[str, Any]] = []
+    for subject in change_subjects:
+        if not isinstance(subject, dict):
+            continue
+        path = subject.get("path")
+        if not isinstance(path, str):
+            continue
+        evidence_arts = evidence_by_path.get(path, [])
+        rows.append(
+            {
+                "path": path,
+                "kind": subject.get("kind"),
+                "reason": subject.get("reason"),
+                "subject_ids": subject.get("subject_ids", []),
+                "operation_names": subject.get("operation_names", []),
+                "surface_names": subject.get("surface_names", []),
+                "checks": subject.get("checks", []),
+                "evidence_artifacts": [
+                    {
+                        "path": art["path"],
+                        "contract": art.get("contract"),
+                        "surface": art.get("surface"),
+                        "test_nodeid": art.get("test_nodeid"),
+                    }
+                    for art in evidence_arts
+                ],
+                "evidence_artifact_count": len(evidence_arts),
+            }
+        )
+
+    return {
+        "schema_version": 1,
+        "generated_at": when.isoformat(),
+        "base_ref": out_base,
+        "head_ref": out_head,
+        "changed_path_count": len(change_subjects),
+        "changes": rows,
+        "required_gates": required,
+        "deployment_gates": deployment,
+    }
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Markdown rendering
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _availability_marker(available: bool) -> str:
+    return "yes" if available else "no"
+
+
+def render_markdown(dashboard: dict[str, Any]) -> str:
+    lines: list[str] = []
+    lines.append(f"# Evidence Dashboard ({dashboard.get('generated_at', 'unknown')})")
+    lines.append("")
+
+    pytest_data = dashboard["pytest"]
+    lines.append("## Pytest health")
+    if pytest_data.get("available"):
+        counts = pytest_data.get("counts", {})
+        stale = " (stale)" if pytest_data.get("stale") else ""
+        lines.append(
+            f"- status: **{pytest_data.get('status')}** — passed={counts.get('passed', 0)}, "
+            f"failed={counts.get('failed', 0)}, xfailed={counts.get('xfailed', 0)}, "
+            f"skipped={counts.get('skipped', 0)}"
+        )
+        lines.append(
+            f"- duration: {pytest_data.get('duration_s', '?')}s, last_run: {pytest_data.get('last_run')}{stale}"
+        )
+    else:
+        lines.append(f"- unavailable: {pytest_data.get('reason')}")
+    lines.append("")
+
+    contract = dashboard["contract_evidence"]
+    lines.append("## Contract evidence")
+    if contract.get("available"):
+        lines.append(
+            f"- total_artifacts: {contract.get('total_artifacts')}, "
+            f"unique_contracts: {contract.get('unique_contracts')}, "
+            f"stale: {contract.get('stale_count')}, dirty: {contract.get('dirty_count')}"
+        )
+        by_surface = contract.get("by_surface", {})
+        for surface, info in sorted(by_surface.items()):
+            lines.append(f"  - {surface}: {info['total_artifacts']} artifacts ({info['unique_contracts']} contracts)")
+    else:
+        lines.append(f"- unavailable: {contract.get('reason')}")
+    lines.append("")
+
+    coverage = dashboard["coverage"]
+    lines.append("## Coverage")
+    if coverage.get("available"):
+        if "percent" in coverage:
+            lines.append(f"- line coverage: {coverage['percent']}% (from {coverage['path']})")
+        else:
+            lines.append(f"- {coverage.get('note', 'present')} ({coverage['path']})")
+    else:
+        lines.append(f"- unavailable: {coverage.get('reason')}")
+    lines.append("")
+
+    bench = dashboard["benchmark_campaigns"]
+    lines.append("## Benchmark campaigns")
+    if bench.get("available"):
+        lines.append(f"- total_runs: {bench.get('total_runs')}")
+    else:
+        lines.append(f"- unavailable: {bench.get('reason')}")
+    lines.append("")
+
+    slo = dashboard["slo_catalog"]
+    lines.append("## SLO catalog")
+    if slo.get("available"):
+        lines.append(
+            f"- surfaces: {slo.get('total_surfaces')} "
+            f"(required={len(slo.get('required_surfaces', []))}, "
+            f"informational={len(slo.get('informational_surfaces', []))})"
+        )
+    else:
+        lines.append(f"- unavailable: {slo.get('reason')}")
+    lines.append("")
+
+    gates = dashboard["static_gates"]
+    lines.append("## Static gates")
+    if gates.get("available"):
+        lines.append(
+            f"- gates with cached status: {gates['gates_with_status']}/{gates['total_gates_tracked']}, "
+            f"failing: {len(gates['failing'])}"
+        )
+        if gates["failing"]:
+            lines.append(f"  - failing: {', '.join(gates['failing'])}")
+    else:
+        lines.append("- unavailable: no verify history found")
+    lines.append("")
+
+    witnesses = dashboard["witnesses"]
+    lines.append("## Witnesses")
+    lines.append(
+        f"- committed: {witnesses['committed']['count']} ({_availability_marker(witnesses['committed']['available'])}), "
+        f"local: {witnesses['local']['count']} ({_availability_marker(witnesses['local']['available'])})"
+    )
+    lines.append("")
+
+    mut = dashboard["mutation_campaigns"]
+    lines.append("## Mutation campaigns")
+    if mut.get("available"):
+        lines.append(f"- total_campaigns: {mut.get('total_campaigns')}")
+    else:
+        lines.append(f"- unavailable: {mut.get('reason')}")
+    lines.append("")
+
+    return "\n".join(lines)
+
+
+def render_trace_markdown(trace: dict[str, Any]) -> str:
+    lines: list[str] = []
+    lines.append(f"# Change Trace {trace['base_ref']}..{trace['head_ref']}")
+    lines.append("")
+    lines.append(f"- changed paths: {trace['changed_path_count']}")
+    lines.append(f"- required PR gates: {len(trace.get('required_gates', []))}")
+    lines.append("")
+    if not trace["changes"]:
+        lines.append("(no recognised change subjects)")
+        return "\n".join(lines)
+    lines.append("## Changes")
+    for row in trace["changes"]:
+        lines.append(f"### {row['path']}")
+        lines.append(f"- kind: {row['kind']}")
+        if row["reason"]:
+            lines.append(f"- reason: {row['reason']}")
+        if row["subject_ids"]:
+            lines.append(f"- subjects: {', '.join(row['subject_ids'])}")
+        if row["surface_names"]:
+            lines.append(f"- surfaces: {', '.join(row['surface_names'])}")
+        lines.append(f"- contract-evidence artifacts: {row['evidence_artifact_count']}")
+        for art in row["evidence_artifacts"][:5]:
+            lines.append(f"  - {art['contract']} ({art['surface']}) -> {art['path']}")
+        if row["checks"]:
+            lines.append("- recommended checks:")
+            for check in row["checks"][:5]:
+                cmd = check.get("command")
+                if isinstance(cmd, list):
+                    lines.append(f"  - `{' '.join(str(c) for c in cmd)}` — {check.get('reason', '')}")
+        lines.append("")
+    return "\n".join(lines)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# CLI
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _emit_dashboard(args: argparse.Namespace) -> int:
+    dashboard = build_dashboard(ROOT, stale_days=args.stale_days)
+    if args.json or not args.markdown:
+        json.dump(dashboard, sys.stdout, indent=2, sort_keys=True)
+        sys.stdout.write("\n")
+    if args.markdown:
+        sys.stdout.write(render_markdown(dashboard))
+        sys.stdout.write("\n")
+    return 0
+
+
+def _emit_trace(args: argparse.Namespace) -> int:
+    paths: list[str] | None = list(args.path) if args.path else None
+    trace = build_trace(ROOT, base_ref=args.base, head_ref=args.head, changed_paths=paths)
+    if args.json or not args.markdown:
+        json.dump(trace, sys.stdout, indent=2, sort_keys=True)
+        sys.stdout.write("\n")
+    if args.markdown:
+        sys.stdout.write(render_trace_markdown(trace))
+        sys.stdout.write("\n")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="Emit JSON output (default).")
+    parser.add_argument("--markdown", action="store_true", help="Emit Markdown output (combinable with --json).")
+    parser.add_argument(
+        "--stale-days",
+        type=int,
+        default=DEFAULT_STALE_DAYS,
+        help=f"Mark contract-evidence artifacts older than N days as stale (default: {DEFAULT_STALE_DAYS}).",
+    )
+    sub = parser.add_subparsers(dest="cmd")
+
+    trace = sub.add_parser("trace", help="Change → claim → evidence → gate trace for the changed paths.")
+    trace.add_argument("--base", default="origin/master", help="Base git ref (default: origin/master).")
+    trace.add_argument("--head", default="HEAD", help="Head git ref (default: HEAD).")
+    trace.add_argument(
+        "--path",
+        action="append",
+        default=[],
+        help="Explicit changed path. Repeat to bypass git diff discovery.",
+    )
+    trace.add_argument("--json", action="store_true", help="Emit JSON output (default).")
+    trace.add_argument("--markdown", action="store_true", help="Emit Markdown output (combinable with --json).")
+
+    args = parser.parse_args(argv)
+    if args.cmd == "trace":
+        return _emit_trace(args)
+    return _emit_dashboard(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -100,6 +100,7 @@ These are the commands worth remembering during normal repo work:
 | `devtools artifact-graph` | Render the runtime artifact, operation, and scenario-coverage map. |
 | `devtools coverage-gate` | Run pytest with the repository coverage floor from pyproject.toml. |
 | `devtools daemon-workload-probe` | Inspect daemon ingest workload, convergence debt, and hot query plans. |
+| `devtools evidence-dashboard` | Render the pytest-first evidence dashboard or a changed-path trace. |
 | `devtools evidence-report` | Aggregate verification evidence into a structured status report. |
 | `devtools lab-corpus` | Generate verification-lab synthetic corpus fixtures and demo archives. |
 | `devtools lab-scenario` | Run verification-lab showcase scenario sets and baseline checks. |

--- a/tests/unit/devtools/test_evidence_dashboard.py
+++ b/tests/unit/devtools/test_evidence_dashboard.py
@@ -1,0 +1,404 @@
+"""Tests for ``devtools evidence-dashboard``."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from devtools import evidence_dashboard
+
+# ──────────────────────────────────────────────────────────────────────
+# helpers
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload))
+
+
+def _write_evidence_artifact(
+    root: Path,
+    *,
+    name: str,
+    contract: str,
+    surface: str,
+    test_nodeid: str,
+    age_days: int = 0,
+    dirty: bool = False,
+) -> Path:
+    evidence_dir = root / evidence_dashboard.EVIDENCE_DIR_REL
+    evidence_dir.mkdir(parents=True, exist_ok=True)
+    artifact = evidence_dir / f"{name}.json"
+    artifact.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "contract": contract,
+                "surface": surface,
+                "test_nodeid": test_nodeid,
+                "timestamp": "2026-05-16T00:00:00+00:00",
+                "git_sha": "abc123",
+                "dirty": dirty,
+            }
+        )
+    )
+    if age_days:
+        ts = datetime.now(timezone.utc) - timedelta(days=age_days)
+        epoch = ts.timestamp()
+        import os
+
+        os.utime(artifact, (epoch, epoch))
+    return artifact
+
+
+# ──────────────────────────────────────────────────────────────────────
+# section: dashboard JSON shape
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_dashboard_runs_on_empty_tree(tmp_path: Path) -> None:
+    dashboard = evidence_dashboard.build_dashboard(tmp_path)
+    assert dashboard["schema_version"] == 1
+    assert dashboard["root"] == str(tmp_path)
+    # All artifact-backed sections report unavailable on a bare tree.
+    for section in (
+        "pytest",
+        "contract_evidence",
+        "coverage",
+        "benchmark_campaigns",
+        "slo_catalog",
+        "mutation_campaigns",
+    ):
+        assert section in dashboard
+        assert dashboard[section]["available"] is False
+    # Static gates and witnesses are still present with empty content.
+    assert "static_gates" in dashboard
+    assert "witnesses" in dashboard
+    assert dashboard["witnesses"]["committed"]["available"] is False
+    assert dashboard["witnesses"]["local"]["available"] is False
+
+
+def test_dashboard_top_level_keys_are_stable(tmp_path: Path) -> None:
+    dashboard = evidence_dashboard.build_dashboard(tmp_path)
+    assert set(dashboard.keys()) == {
+        "schema_version",
+        "generated_at",
+        "root",
+        "pytest",
+        "contract_evidence",
+        "coverage",
+        "benchmark_campaigns",
+        "slo_catalog",
+        "static_gates",
+        "witnesses",
+        "mutation_campaigns",
+    }
+
+
+# ──────────────────────────────────────────────────────────────────────
+# section: pytest health
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_pytest_health_reads_last_pytest_json(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / evidence_dashboard.PYTEST_REPORT_REL,
+        {
+            "duration": 12.34,
+            "summary": {"passed": 100, "failed": 0, "xfailed": 2, "total": 102},
+        },
+    )
+    dashboard = evidence_dashboard.build_dashboard(tmp_path)
+    pytest_data = dashboard["pytest"]
+    assert pytest_data["available"] is True
+    assert pytest_data["status"] == "ok"
+    assert pytest_data["counts"]["passed"] == 100
+    assert pytest_data["counts"]["failed"] == 0
+    assert pytest_data["duration_s"] == 12.34
+
+
+def test_pytest_health_reports_failures(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / evidence_dashboard.PYTEST_REPORT_REL,
+        {"duration": 5.0, "summary": {"passed": 10, "failed": 1, "total": 11}},
+    )
+    dashboard = evidence_dashboard.build_dashboard(tmp_path)
+    assert dashboard["pytest"]["status"] == "fail"
+
+
+# ──────────────────────────────────────────────────────────────────────
+# section: contract evidence
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_contract_evidence_groups_by_surface(tmp_path: Path) -> None:
+    _write_evidence_artifact(
+        tmp_path,
+        name="cli-1",
+        contract="cli.help.root",
+        surface="cli",
+        test_nodeid="tests/unit/cli/test_help.py::test_root",
+    )
+    _write_evidence_artifact(
+        tmp_path,
+        name="cli-2",
+        contract="cli.stats",
+        surface="cli",
+        test_nodeid="tests/unit/cli/test_stats.py::test_stats",
+    )
+    _write_evidence_artifact(
+        tmp_path,
+        name="mcp-1",
+        contract="mcp.search",
+        surface="mcp",
+        test_nodeid="tests/unit/mcp/test_search.py::test_search",
+    )
+    dashboard = evidence_dashboard.build_dashboard(tmp_path)
+    contract = dashboard["contract_evidence"]
+    assert contract["available"] is True
+    assert contract["total_artifacts"] == 3
+    assert contract["unique_contracts"] == 3
+    assert contract["by_surface"]["cli"]["total_artifacts"] == 2
+    assert contract["by_surface"]["cli"]["unique_contracts"] == 2
+    assert contract["by_surface"]["mcp"]["total_artifacts"] == 1
+
+
+def test_contract_evidence_flags_stale_artifacts(tmp_path: Path) -> None:
+    _write_evidence_artifact(
+        tmp_path,
+        name="fresh",
+        contract="cli.fresh",
+        surface="cli",
+        test_nodeid="tests/unit/cli/test_a.py::test_fresh",
+    )
+    _write_evidence_artifact(
+        tmp_path,
+        name="old",
+        contract="cli.old",
+        surface="cli",
+        test_nodeid="tests/unit/cli/test_a.py::test_old",
+        age_days=30,
+    )
+    dashboard = evidence_dashboard.build_dashboard(tmp_path, stale_days=7)
+    contract = dashboard["contract_evidence"]
+    assert contract["stale_count"] == 1
+    assert "cli.old" in contract["stale_contracts"]
+    assert "cli.fresh" not in contract["stale_contracts"]
+
+
+def test_contract_evidence_counts_dirty(tmp_path: Path) -> None:
+    _write_evidence_artifact(
+        tmp_path,
+        name="dirty",
+        contract="cli.dirty",
+        surface="cli",
+        test_nodeid="tests/unit/cli/test.py::test_dirty",
+        dirty=True,
+    )
+    dashboard = evidence_dashboard.build_dashboard(tmp_path)
+    assert dashboard["contract_evidence"]["dirty_count"] == 1
+
+
+# ──────────────────────────────────────────────────────────────────────
+# section: coverage
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_coverage_reads_xml(tmp_path: Path) -> None:
+    (tmp_path / "coverage.xml").write_text(
+        '<?xml version="1.0"?><coverage line-rate="0.9123" lines-covered="9123" lines-valid="10000"></coverage>'
+    )
+    dashboard = evidence_dashboard.build_dashboard(tmp_path)
+    cov = dashboard["coverage"]
+    assert cov["available"] is True
+    assert cov["percent"] == 91.23
+    assert cov["lines_covered"] == 9123
+
+
+def test_coverage_handles_binary_only(tmp_path: Path) -> None:
+    (tmp_path / ".coverage").write_bytes(b"SQLite binary stub")
+    dashboard = evidence_dashboard.build_dashboard(tmp_path)
+    cov = dashboard["coverage"]
+    assert cov["available"] is True
+    assert "binary" in cov["note"]
+
+
+# ──────────────────────────────────────────────────────────────────────
+# section: static gates
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_static_gates_from_last_verify_result(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / evidence_dashboard.LAST_VERIFY_RESULT_REL,
+        {
+            "result": {
+                "timestamp": "2026-05-16T04:00:00+00:00",
+                "steps": [
+                    {"name": "ruff format", "exit": 0, "duration_s": 0.3},
+                    {"name": "ruff check", "exit": 0, "duration_s": 0.1},
+                    {"name": "mypy", "exit": 1, "duration_s": 5.0},
+                ],
+            }
+        },
+    )
+    dashboard = evidence_dashboard.build_dashboard(tmp_path)
+    gates = dashboard["static_gates"]
+    assert gates["available"] is True
+    assert "mypy" in gates["failing"]
+    gate_names = {g["name"] for g in gates["gates"]}
+    assert "ruff format" in gate_names
+    # Gates with no observed run are still listed but unavailable.
+    untracked = [g for g in gates["gates"] if g.get("available") is False]
+    assert len(untracked) >= 1
+
+
+# ──────────────────────────────────────────────────────────────────────
+# section: change trace
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_build_trace_returns_stable_keys(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Trace JSON has stable top-level keys regardless of changed-path content."""
+
+    def _fake_impact(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        return {
+            "base_ref": "origin/master",
+            "head_ref": "HEAD",
+            "change_subjects": [
+                {
+                    "id": "c-1",
+                    "path": "tests/unit/cli/test_help.py",
+                    "kind": "test",
+                    "reason": "test source changed",
+                    "subject_ids": ["cli.help"],
+                    "operation_names": [],
+                    "surface_names": ["cli"],
+                    "checks": [
+                        {"command": ["pytest", "tests/unit/cli/test_help.py"], "reason": "directly changed"},
+                    ],
+                },
+            ],
+            "required_pr_gates": [{"command": ["devtools", "verify"], "reason": "default"}],
+            "deployment_gates": [],
+        }
+
+    monkeypatch.setattr(evidence_dashboard, "build_verification_impact_report", _fake_impact)
+
+    trace = evidence_dashboard.build_trace(tmp_path)
+    assert set(trace.keys()) >= {
+        "schema_version",
+        "generated_at",
+        "base_ref",
+        "head_ref",
+        "changed_path_count",
+        "changes",
+        "required_gates",
+    }
+    assert trace["changed_path_count"] == 1
+    assert trace["changes"][0]["path"] == "tests/unit/cli/test_help.py"
+    assert trace["changes"][0]["evidence_artifact_count"] == 0
+
+
+def test_build_trace_links_evidence_artifacts(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Trace links contract-evidence artifacts to changed paths via test_nodeid."""
+
+    nodeid = "tests/unit/cli/test_help.py::TestRootHelp::test_root"
+    _write_evidence_artifact(
+        tmp_path,
+        name="cli-help",
+        contract="cli.help.root",
+        surface="cli",
+        test_nodeid=nodeid,
+    )
+
+    def _fake_impact(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        return {
+            "base_ref": "origin/master",
+            "head_ref": "HEAD",
+            "change_subjects": [
+                {
+                    "id": "c-1",
+                    "path": "tests/unit/cli/test_help.py",
+                    "kind": "test",
+                    "reason": "test source changed",
+                    "subject_ids": [],
+                    "operation_names": [],
+                    "surface_names": ["cli"],
+                    "checks": [],
+                }
+            ],
+            "required_pr_gates": [],
+            "deployment_gates": [],
+        }
+
+    monkeypatch.setattr(evidence_dashboard, "build_verification_impact_report", _fake_impact)
+
+    trace = evidence_dashboard.build_trace(tmp_path)
+    row = trace["changes"][0]
+    assert row["evidence_artifact_count"] == 1
+    assert row["evidence_artifacts"][0]["contract"] == "cli.help.root"
+
+
+# ──────────────────────────────────────────────────────────────────────
+# section: cli entrypoint
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_cli_dashboard_json(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(evidence_dashboard, "ROOT", tmp_path)
+    rc = evidence_dashboard.main(["--json"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    payload = json.loads(out)
+    assert payload["schema_version"] == 1
+    assert payload["pytest"]["available"] is False
+
+
+def test_cli_dashboard_markdown(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(evidence_dashboard, "ROOT", tmp_path)
+    rc = evidence_dashboard.main(["--markdown"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "# Evidence Dashboard" in out
+    assert "## Pytest health" in out
+    assert "## Contract evidence" in out
+    assert "## Coverage" in out
+    assert "## Static gates" in out
+
+
+def test_cli_trace_json(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(evidence_dashboard, "ROOT", tmp_path)
+
+    def _fake_impact(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        return {
+            "base_ref": "origin/master",
+            "head_ref": "HEAD",
+            "change_subjects": [],
+            "required_pr_gates": [],
+            "deployment_gates": [],
+        }
+
+    monkeypatch.setattr(evidence_dashboard, "build_verification_impact_report", _fake_impact)
+    rc = evidence_dashboard.main(["trace", "--base", "origin/master", "--head", "HEAD", "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["changed_path_count"] == 0
+    assert payload["base_ref"] == "origin/master"


### PR DESCRIPTION
## Summary

Adds `devtools evidence-dashboard` and `devtools evidence-dashboard trace` as the V7/V8 surface for #998 — a pytest-first evidence dashboard built over the real artifacts produced by PRs #1083/#1086/#1087/#1088, plus a changed-path traceability view that links each change to its committed contract evidence and required gates.

## Problem

The pytest-first evidence model is now real: `.cache/verify/last-pytest.json` (#1087), `.cache/verification/evidence/*.json` (100+ artifacts), `.cache/last-verify-result.json`, the SLO catalog with tier/freshness (#1086), and parsed CI workflow facts (#1088) all exist. What was missing was the single surface that reads those artifacts and presents the V7 dashboard / V8 traceability view from #998, without rebuilding a proof-row aggregator.

`devtools evidence-report` overlaps in shape but is anchored to verify-history + suppressions + witnesses. It is intentionally left in place; the new dashboard is a sibling so existing consumers and tests are not disturbed.

## Solution

New module `devtools/evidence_dashboard.py` with sections, each backed by a real artifact (or reported as `available: false` with the reason — no aspirational rows):

- pytest health from `.cache/verify/last-pytest.json` (status, counts, duration, last-run, staleness)
- contract evidence inventory from `.cache/verification/evidence/*.json`, grouped by surface, with stale-artifact and dirty-tree detection
- coverage from `coverage.xml` (line %) or `.coverage` (presence only) when present
- benchmark campaign freshness from `.local/benchmark-campaigns/`
- SLO catalog rows (required vs informational) parsed via the existing `devtools.verify_slos._parse_slo_catalog`
- static gate status from `.cache/last-verify-result.json` (preferred) falling back to `.cache/verify-history.jsonl`
- witness counts (`tests/witnesses/` + `.local/witnesses/`)
- mutation campaign freshness from `.local/mutation-campaigns/`

`evidence-dashboard trace --base <ref> --head <ref>` reuses `build_verification_impact_report` and joins each change subject (by `test_nodeid` → test source path) to the contract-evidence artifacts emitted by that test, plus required PR gates and deployment gates. Output is JSON by default and Markdown when `--markdown` is set; both formats are combinable.

Registered in `devtools/command_catalog.py`, `docs/devtools.md` regenerated.

## Verification

Local commands run:

- `nix develop -c pytest tests/unit/devtools/test_evidence_dashboard.py -v` — 15 passed
- `nix develop -c pytest tests/unit/devtools/test_evidence_dashboard.py tests/unit/devtools/test_evidence_report.py tests/unit/devtools/test_command_catalog.py tests/unit/devtools/test_render_devtools_reference.py -q` — 35 passed
- `nix develop -c mypy devtools/evidence_dashboard.py tests/unit/devtools/test_evidence_dashboard.py` — Success: no issues
- `nix develop -c ruff check devtools/evidence_dashboard.py tests/unit/devtools/test_evidence_dashboard.py` — clean
- `nix develop -c devtools render-all --check` — sync OK
- `nix develop -c devtools verify --quick` — exit_code 0
- `nix develop -c devtools evidence-dashboard --json` — emits dashboard against this worktree, correctly reports missing pytest/coverage/campaign artifacts on the clean fixture worktree, surfaces real SLO catalog rows (3 required, 3 informational) and witness counts
- `nix develop -c devtools evidence-dashboard trace --base origin/master --head HEAD --json` — emits trace; 0 changes on the post-commit working tree, required_gates and deployment_gates populated from the verification-impact pipeline

## Artifact gaps observed

The dashboard reports these as `available: false` because the underlying artifacts don't exist in this worktree:

- `.cache/verify/last-pytest.json` — only produced by `devtools verify` runs that include the pytest step; a fresh worktree without a verify run reports unavailable
- `coverage.xml` / `.coverage` — none committed; `devtools coverage-gate` produces them
- `.local/benchmark-campaigns/` — populated only by `devtools benchmark-campaign run <name>`
- `.local/mutation-campaigns/` — populated only by `devtools mutmut-campaign run <name>`

These gaps are honest: the dashboard does not fabricate values, and each section names the command needed to populate it. The main checkout at `/realm/project/polylogue` is the same shape — the SLO catalog, witnesses, and static-gate cache are present; coverage and pytest-report artifacts depend on operator runs.

Ref #998
Ref #1058

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `evidence-dashboard` developer command with a dashboard mode to visualize verification artifacts, test health, coverage status, and benchmark freshness.
  * Includes a trace subcommand to map changed paths to verification impacts and related evidence.
  * Both modes support JSON and Markdown output formats with configurable thresholds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sinity/polylogue/pull/1091?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->