### PR TITLE
fix(suppressions): tighten native enforcement and discipline ledger (#1062)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,10 +34,11 @@ on push, but the default baseline must pass before the PR is opened.
 Do not treat CI as the first verification pass. Anticipate failures
 locally.
 
-### Proof Pack workflow
+### Verification Impact workflow
 
-Every PR gets a `Polylogue Proof Pack` comment. Treat it as a verification
-impact report, not as decorative CI output and not as a complete proof.
+Every PR gets a `Polylogue Verification Impact` comment. Treat it as a
+verification impact report, not as decorative CI output and not as a complete
+proof.
 
 Use it this way:
 
@@ -45,15 +46,14 @@ Use it this way:
   match the touched files, or state in the PR why a suggested gate is only an
   optional confidence gate for that change.
 - Use nonzero affected domains and claims to decide which focused tests or
-  proof-law suites to run. Ignore zero-claim domain noise unless the changed
-  files genuinely belong to that domain.
+  contract/property suites to run. Ignore zero-claim domain noise unless the
+  changed files genuinely belong to that domain.
 - Treat `Known Gaps` as actionable only when they are in a changed or directly
   affected domain. Broad repo-wide gap dumps should not block unrelated PRs, but
   recurring noise should be folded back into #594.
-- Treat any remaining proof-pack obligation language as transitional report
-  terminology; real verification closure comes from pytest, coverage,
-  benchmark, CI, static-check, and runtime evidence artifacts.
-- If the Proof Pack is noisy, misleading, or misses a relevant gate, comment on
+- Real verification closure comes from pytest, coverage, benchmark, CI,
+  static-check, and runtime evidence artifacts — not from catalog metadata.
+- If the report is noisy, misleading, or misses a relevant gate, comment on
   the PR or #594 with the concrete mismatch. Do not silently ignore it.
 
 ### PR body discipline
@@ -322,7 +322,7 @@ Add `devtools build-package` or `nix flake check` when touching packaging or
 Nix expressions. See [TESTING.md](TESTING.md) and [docs/devtools.md](docs/devtools.md)
 for details.
 
-Proof Pack: every PR gets a `Polylogue Proof Pack` comment. It's a verification
+Verification Impact: every PR gets a `Polylogue Verification Impact` comment. It's a verification
 impact report showing affected domains, required gates, and known gaps. Use it
 to choose focused verification — run the gates that match touched files, state
 in the PR why a suggested gate is only optional for that change.
@@ -957,7 +957,7 @@ repo verification checks and evidence records, not end-user archive workflows.
 | Command | Role |
 | --- | --- |
 | `devtools render-verification-catalog` | Refresh or verify the catalog that anchors changed-path verification reports after changing subjects, claims, runners, or catalog rendering. Use --anti-vacuity to flag claims with gaps. |
-| `devtools affected-obligations` | Find the checks and inner-loop commands affected by local changes before escalating to full PR gates. Use --full for domain-grouped impact analysis. |
+| `devtools verification-impact` | Find the checks and inner-loop commands affected by local changes before escalating to full PR gates. Use --full for domain-grouped impact analysis. |
 | `devtools semantic-axis-evidence` | Produce comparative performance evidence that describes growth shape over semantic axes instead of machine-specific absolute budgets. |
 | `devtools lab-corpus` | Seed synthetic corpus files or complete demo workspaces for lab exercises. |
 | `devtools lab-scenario` | Run showcase exercise smoke scenarios and committed baseline checks outside the archive CLI. |
@@ -1008,7 +1008,6 @@ These are the commands worth remembering during normal repo work:
 
 | Command | Description |
 | --- | --- |
-| `devtools affected-obligations` | Route changed paths or refs to affected verification checks and focused commands; optionally emit full proof-pack impact report. |
 | `devtools artifact-graph` | Render the runtime artifact, operation, and scenario-coverage map. |
 | `devtools coverage-gate` | Run pytest with the repository coverage floor from pyproject.toml. |
 | `devtools daemon-workload-probe` | Inspect daemon ingest workload, convergence debt, and hot query plans. |
@@ -1024,6 +1023,7 @@ These are the commands worth remembering during normal repo work:
 | `devtools schema-generate` | Generate provider schema packages and optional evidence clusters. |
 | `devtools schema-promote` | Promote a schema evidence cluster into a registered package version. |
 | `devtools semantic-axis-evidence` | Generate verification-lab performance evidence across synthetic semantic scale tiers. |
+| `devtools verification-impact` | Route changed paths or refs to affected verification checks and focused commands; emit the full PR-confidence report with --full. |
 | `devtools verify` | Run the local verification baseline before pushing or creating a PR. |
 | `devtools verify-ci-workflows` | Verify CI workflow files reference locally-known devtools commands and existing paths. |
 | `devtools verify-cluster-cohesion` | Validate proposed clusters from the topology projection using the import graph. |

--- a/devtools/lab_scenario.py
+++ b/devtools/lab_scenario.py
@@ -96,6 +96,7 @@ def verify_showcase_baselines(*, update: bool) -> int:
     False so that the "no baselines" path fails in <1 ms instead of
     after running all tier-0 subprocesses (#1026).
     """
+    baselines: dict[str, str] = {}
     if not update:
         baselines = load_baselines()
         if not baselines:

--- a/devtools/pipeline_probe/engine.py
+++ b/devtools/pipeline_probe/engine.py
@@ -702,8 +702,8 @@ async def run_probe(request: PipelineProbeRequest) -> ProbeSummary:
             "provenance": _build_probe_provenance(),
             "result": result_payload,
             "run_payload": run_payload,
-            "db_stats": _db_row_counts(db_path_val) if db_path_val is not None else {},
-            "raw_fanout": _db_raw_fanout(db_path_val) if db_path_val is not None else [],
+            "db_stats": _db_row_counts(db_path_val),
+            "raw_fanout": _db_raw_fanout(db_path_val),
         }
     elif probe_mode == PipelineProbeInputMode.SOURCE_SUBSET.value:
         source_paths = _paths(request.source_paths)
@@ -753,8 +753,8 @@ async def run_probe(request: PipelineProbeRequest) -> ProbeSummary:
             "provenance": _build_probe_provenance(source_inputs=source_inputs),
             "result": result_payload,
             "run_payload": run_payload,
-            "db_stats": _db_row_counts(db_path_val) if db_path_val is not None else {},
-            "raw_fanout": _db_raw_fanout(db_path_val) if db_path_val is not None else [],
+            "db_stats": _db_row_counts(db_path_val),
+            "raw_fanout": _db_raw_fanout(db_path_val),
         }
     else:
         sample_per_provider = request.sample_per_provider or 50
@@ -829,8 +829,8 @@ async def run_probe(request: PipelineProbeRequest) -> ProbeSummary:
             "provenance": _build_probe_provenance(manifest_path=manifest_path),
             "result": result_payload,
             "run_payload": run_payload,
-            "db_stats": _db_row_counts(db_path_val) if db_path_val is not None else {},
-            "raw_fanout": _db_raw_fanout(db_path_val) if db_path_val is not None else {},
+            "db_stats": _db_row_counts(db_path_val),
+            "raw_fanout": _db_raw_fanout(db_path_val),
         }
 
     return summary

--- a/devtools/verification_impact.py
+++ b/devtools/verification_impact.py
@@ -342,7 +342,7 @@ def _domain_coverage(domains_data: dict[str, dict[str, Any]], catalog: Any) -> l
         obligations_by_domain[obligation.claim.assurance_domain] += 1
     coverage: list[dict[str, Any]] = []
     for domain, info in sorted(domains_data.items()):
-        info_dict = info if isinstance(info, dict) else {}
+        info_dict = info
         claims = claims_by_domain.get(domain, [])
         coverage.append(
             {
@@ -461,7 +461,7 @@ def _known_gaps(
 
     for domain in affected_domains:
         info = domains_data.get(domain, {})
-        raw_gaps = info.get("coverage_gaps", []) if isinstance(info, dict) else []
+        raw_gaps = info.get("coverage_gaps", [])
         for raw_gap in raw_gaps:
             gaps_by_domain[domain].append(str(raw_gap))
     gap_payloads = [

--- a/devtools/verify_schema_roundtrip.py
+++ b/devtools/verify_schema_roundtrip.py
@@ -94,7 +94,7 @@ def _verify_corpus_roundtrip_for_provider(
 
     Returns a list of failure messages (empty if all records validate).
     """
-    if SyntheticCorpus is None or jsonschema is None:
+    if SyntheticCorpus is None or jsonschema is None:  # type: ignore[redundant-expr]  # defensive: imports may fail
         return ["synthetic corpus or jsonschema not available (import failed)"]
     if provider not in PROVIDER_WIRE_FORMATS:
         return [f"no wire format configured for provider {provider!r}"]
@@ -119,7 +119,7 @@ def _verify_corpus_roundtrip_for_provider(
     parsed_records: list[dict[str, Any]] = []
     for raw_record in records:
         try:
-            raw_text = raw_record.decode("utf-8") if isinstance(raw_record, bytes) else str(raw_record)
+            raw_text = raw_record.decode("utf-8")
             if is_jsonl:
                 for line in raw_text.strip().splitlines():
                     line = line.strip()

--- a/devtools/verify_schema_roundtrip.py
+++ b/devtools/verify_schema_roundtrip.py
@@ -14,14 +14,14 @@ from polylogue.schemas.runtime_registry import SCHEMA_DIR, SchemaRegistry
 try:
     import jsonschema
     from jsonschema import Draft202012Validator
-except ImportError:  # pragma: no cover
+except ImportError:  # pragma: no cover - defensive optional dep
     jsonschema = None
     Draft202012Validator = None
 
 try:
     from polylogue.schemas.synthetic import SyntheticCorpus
     from polylogue.schemas.synthetic.wire_formats import PROVIDER_WIRE_FORMATS
-except ImportError:  # pragma: no cover
+except ImportError:  # pragma: no cover - defensive optional dep
     SyntheticCorpus = None  # type: ignore[misc,assignment]
     PROVIDER_WIRE_FORMATS = {}
 

--- a/devtools/verify_suppressions.py
+++ b/devtools/verify_suppressions.py
@@ -5,7 +5,18 @@ date. The lint fails when any suppression is past its expiry date, forcing
 review and either renewal or removal.
 
 The command also discovers source-level exception mechanisms so an empty
-registry cannot be mistaken for an absence of suppressions.
+registry cannot be mistaken for an absence of suppressions. Beyond raw
+discovery, the scanner enforces discipline rules native tools cannot
+express:
+
+- ``pytest.skip`` / ``pytest.mark.skip`` / ``pytest.mark.skipif`` must
+  carry a substantive ``reason=`` (not empty, ``TODO``, ``skip``, or
+  ``todo``);
+- ``pytest.mark.xfail`` / ``pytest.xfail`` must carry a ``reason=`` that
+  references an issue (``#NNN``) and, for marker form, declare
+  ``strict=True``;
+- broad ``# pragma: no cover`` directives must include an inline
+  justification comment (``# pragma: no cover - <reason>``).
 """
 
 from __future__ import annotations
@@ -18,7 +29,7 @@ import re
 import sys
 import tokenize
 from collections import Counter
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from fnmatch import fnmatch
 from pathlib import Path
 
@@ -34,6 +45,12 @@ _PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
     ("no_cover", re.compile(r"pragma:\s*no cover|coverage:\s*ignore")),
 )
 
+# Reasons that are too generic to count as substantive on a skip/xfail.
+_NON_SUBSTANTIVE_REASONS = frozenset({"", "todo", "skip", "fixme", "xxx", "tbd"})
+
+# Issue link pattern: ``#NNN`` anywhere inside the reason text.
+_ISSUE_REFERENCE_PATTERN = re.compile(r"#\d+")
+
 
 @dataclass(frozen=True, slots=True)
 class DiscoveredSuppression:
@@ -42,6 +59,7 @@ class DiscoveredSuppression:
     line: int
     text: str
     registered: bool
+    discipline_errors: tuple[str, ...] = field(default_factory=tuple)
 
     def to_payload(self) -> dict[str, object]:
         return asdict(self)
@@ -71,7 +89,13 @@ def main(argv: list[str] | None = None) -> int:
     discovered = discover_source_suppressions(args.scan_root, suppressions=suppressions)
     unregistered = [item for item in discovered if not item.registered]
     unregistered_enforced = [item for item in unregistered if item.kind in enforce_kinds] if enforce_kinds else []
-    blocking = bool(errors) or (args.enforce_discovered and bool(unregistered)) or bool(unregistered_enforced)
+    discipline_violations = [item for item in discovered if item.discipline_errors]
+    blocking = (
+        bool(errors)
+        or (args.enforce_discovered and bool(unregistered))
+        or bool(unregistered_enforced)
+        or bool(discipline_violations)
+    )
 
     if args.json:
         json.dump(
@@ -83,8 +107,10 @@ def main(argv: list[str] | None = None) -> int:
                 "discovered_by_kind": dict(Counter(item.kind for item in discovered)),
                 "unregistered_total": len(unregistered),
                 "unregistered_enforced_total": len(unregistered_enforced),
+                "discipline_violations_total": len(discipline_violations),
                 "enforce_kinds": sorted(enforce_kinds),
                 "unregistered": [item.to_payload() for item in unregistered],
+                "discipline_violations": [item.to_payload() for item in discipline_violations],
             },
             sys.stdout,
             indent=2,
@@ -100,6 +126,13 @@ def main(argv: list[str] | None = None) -> int:
             print(f"discovered source suppressions: {len(discovered)}")
             for kind, count in sorted(Counter(item.kind for item in discovered).items()):
                 print(f"    {kind}: {count}")
+        if discipline_violations:
+            print(f"[BLOCK] suppression discipline violations: {len(discipline_violations)}")
+            for item in discipline_violations[:20]:
+                joined = "; ".join(item.discipline_errors)
+                print(f"    {item.path}:{item.line}: {item.kind}: {joined}")
+            if len(discipline_violations) > 20:
+                print(f"    ... {len(discipline_violations) - 20} more")
         if unregistered_enforced:
             print(f"[BLOCK] unregistered {sorted(enforce_kinds)} suppressions: {len(unregistered_enforced)}")
             for item in unregistered_enforced[:20]:
@@ -134,41 +167,114 @@ def discover_source_suppressions(
         except UnicodeDecodeError:
             continue
         lines = text.splitlines()
-        results.extend(
-            DiscoveredSuppression(
-                kind=kind,
-                path=rel,
-                line=line,
-                text=_line_text(lines, line),
-                registered=_path_registered(rel, registry_paths),
+        for kind, line, errors in _pytest_suppression_lines(text):
+            results.append(
+                DiscoveredSuppression(
+                    kind=kind,
+                    path=rel,
+                    line=line,
+                    text=_line_text(lines, line),
+                    registered=_path_registered(rel, registry_paths),
+                    discipline_errors=tuple(errors),
+                )
             )
-            for kind, line in _pytest_suppression_lines(text)
-        )
-        results.extend(
-            DiscoveredSuppression(
-                kind=kind,
-                path=rel,
-                line=line,
-                text=comment.strip(),
-                registered=_path_registered(rel, registry_paths),
+        for kind, line, comment, errors in _comment_suppression_lines(text):
+            results.append(
+                DiscoveredSuppression(
+                    kind=kind,
+                    path=rel,
+                    line=line,
+                    text=comment.strip(),
+                    registered=_path_registered(rel, registry_paths),
+                    discipline_errors=tuple(errors),
+                )
             )
-            for kind, line, comment in _comment_suppression_lines(text)
-        )
     return results
 
 
-def _pytest_suppression_lines(text: str) -> list[tuple[str, int]]:
+def _pytest_suppression_lines(text: str) -> list[tuple[str, int, list[str]]]:
     try:
         tree = ast.parse(text)
     except (SyntaxError, RecursionError, ValueError, MemoryError):
         return []
-    results: list[tuple[str, int]] = []
+    results: list[tuple[str, int, list[str]]] = []
     for node in ast.walk(tree):
         if isinstance(node, ast.Call):
             kind = _pytest_call_kind(node.func)
             if kind is not None:
-                results.append((kind, node.lineno))
+                errors = _pytest_call_discipline_errors(kind, node)
+                results.append((kind, node.lineno, errors))
     return results
+
+
+def _pytest_call_discipline_errors(kind: str, node: ast.Call) -> list[str]:
+    """Return discipline errors for a pytest skip/xfail call."""
+    errors: list[str] = []
+    reason = _extract_reason(node)
+    if kind in ("pytest_skip", "pytest_skip_marker"):
+        if not _is_substantive_reason(reason):
+            errors.append("pytest skip requires substantive reason=")
+    elif kind == "pytest_xfail":
+        if not _is_substantive_reason(reason):
+            errors.append("pytest xfail requires substantive reason=")
+        elif not _ISSUE_REFERENCE_PATTERN.search(reason or ""):
+            errors.append("pytest xfail reason must reference an issue (#NNN)")
+        if _is_marker_xfail(node) and not _has_strict_true(node):
+            errors.append("pytest.mark.xfail must declare strict=True")
+    return errors
+
+
+def _extract_reason(node: ast.Call) -> str | None:
+    """Return the textual value of a ``reason=`` keyword, if any.
+
+    The first positional argument also acts as the reason for ``pytest.skip``
+    and ``pytest.xfail`` (per pytest's API), so it is treated as a reason
+    when present. Both literal strings and f-strings (``JoinedStr``) are
+    recognised, since both express runtime reason content.
+    """
+    for kw in node.keywords:
+        if kw.arg == "reason":
+            value = _reason_value(kw.value)
+            if value is not None:
+                return value
+    if node.args:
+        return _reason_value(node.args[0])
+    return None
+
+
+def _reason_value(expr: ast.expr) -> str | None:
+    if isinstance(expr, ast.Constant) and isinstance(expr.value, str):
+        return expr.value
+    if isinstance(expr, ast.JoinedStr):
+        # f-string: concatenate the literal parts and a placeholder for each
+        # substitution so generic patterns like f"{x}" still register as a
+        # non-substantive reason while informative literals dominate.
+        parts: list[str] = []
+        for value in expr.values:
+            if isinstance(value, ast.Constant) and isinstance(value.value, str):
+                parts.append(value.value)
+            elif isinstance(value, ast.FormattedValue):
+                parts.append("{...}")
+        joined = "".join(parts).strip()
+        return joined or None
+    return None
+
+
+def _is_substantive_reason(reason: str | None) -> bool:
+    if reason is None:
+        return False
+    return reason.strip().lower() not in _NON_SUBSTANTIVE_REASONS
+
+
+def _is_marker_xfail(node: ast.Call) -> bool:
+    return _attribute_parts(node.func) == ["pytest", "mark", "xfail"]
+
+
+def _has_strict_true(node: ast.Call) -> bool:
+    for kw in node.keywords:
+        if kw.arg == "strict" and isinstance(kw.value, ast.Constant) and kw.value.value is True:
+            return True
+    return False
 
 
 def _pytest_call_kind(func: ast.expr) -> str | None:
@@ -194,18 +300,33 @@ def _attribute_parts(expr: ast.expr) -> list[str]:
     return []
 
 
-def _comment_suppression_lines(text: str) -> list[tuple[str, int, str]]:
+def _comment_suppression_lines(text: str) -> list[tuple[str, int, str, list[str]]]:
     try:
         tokens = tokenize.generate_tokens(io.StringIO(text).readline)
         comments = [(token.start[0], token.string) for token in tokens if token.type == tokenize.COMMENT]
     except tokenize.TokenError:
         return []
-    results: list[tuple[str, int, str]] = []
+    results: list[tuple[str, int, str, list[str]]] = []
     for line, comment in comments:
         for kind, pattern in _PATTERNS:
             if pattern.search(comment):
-                results.append((kind, line, comment))
+                errors = _comment_discipline_errors(kind, comment)
+                results.append((kind, line, comment, errors))
     return results
+
+
+_BARE_TYPE_IGNORE = re.compile(r"#\s*type:\s*ignore(?!\[)")
+_NO_COVER_WITH_JUSTIFICATION = re.compile(r"pragma:\s*no cover\s*[-\u2013\u2014#:]\s*\S")
+
+
+def _comment_discipline_errors(kind: str, comment: str) -> list[str]:
+    """Return discipline errors for a suppression comment."""
+    errors: list[str] = []
+    if kind == "type_ignore" and _BARE_TYPE_IGNORE.search(comment):
+        errors.append("bare '# type: ignore' must use bracketed '[error-code]'")
+    if kind == "no_cover" and not _NO_COVER_WITH_JUSTIFICATION.search(comment):
+        errors.append("'# pragma: no cover' must include inline justification (e.g. '- defensive')")
+    return errors
 
 
 def _line_text(lines: list[str], line: int) -> str:

--- a/polylogue/archive/conversation/attribution.py
+++ b/polylogue/archive/conversation/attribution.py
@@ -266,7 +266,7 @@ def extract_attribution(
                 languages.add(lang_name)
 
     normalized_repo_paths = normalize_repo_paths(repo_paths)
-    normalized_repo_names = {str(name).strip() for name in repo_names if isinstance(name, str) and name.strip()}
+    normalized_repo_names = {name.strip() for name in repo_names if name.strip()}
     normalized_repo_names.update(normalize_repo_names(repo_paths=normalized_repo_paths))
     return ConversationAttribution(
         repo_paths=normalized_repo_paths,

--- a/polylogue/archive/coverage.py
+++ b/polylogue/archive/coverage.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from collections import defaultdict
 from collections.abc import Sequence
 from dataclasses import dataclass
-from datetime import date, datetime, timedelta
+from datetime import date, timedelta
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -74,7 +74,7 @@ def analyze_coverage(summaries: Sequence[ConversationSummary]) -> ArchiveCoverag
 
         dt = summary.updated_at or summary.created_at
         if dt:
-            d = dt.date() if isinstance(dt, datetime) else dt
+            d = dt.date()
             provider_dates[provider].append(d)
             all_dates.add(d)
 

--- a/polylogue/archive/session/session_summaries.py
+++ b/polylogue/archive/session/session_summaries.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections import Counter
 from collections.abc import Sequence
 from dataclasses import dataclass
-from datetime import date, datetime
+from datetime import date
 
 from polylogue.archive.conversation.repo_identity import normalize_repo_names
 from polylogue.archive.session.session_profile import SessionProfile
@@ -65,7 +65,7 @@ def _profile_date(profile: SessionProfile) -> date | None:
     timestamp = profile.first_message_at or profile.created_at
     if timestamp is None:
         return None
-    return timestamp.date() if isinstance(timestamp, datetime) else timestamp
+    return timestamp.date()
 
 
 def summarize_day(

--- a/polylogue/cli/__main__.py
+++ b/polylogue/cli/__main__.py
@@ -2,5 +2,5 @@ from __future__ import annotations
 
 from .click_app import main
 
-if __name__ == "__main__":  # pragma: no cover
+if __name__ == "__main__":  # pragma: no cover - script entry point
     main()

--- a/polylogue/cli/query_stats.py
+++ b/polylogue/cli/query_stats.py
@@ -257,7 +257,10 @@ async def output_stats_sql(
             )
             return
 
-    stats = await repo.aggregate_message_stats(conv_ids if has_filters else None)
+    if has_filters:
+        stats = await repo.aggregate_message_stats(conv_ids)
+    else:
+        stats = await repo.aggregate_message_stats()
 
     date_range = ""
     if stats["min_sort_key"] and stats["max_sort_key"]:

--- a/polylogue/cli/query_stats.py
+++ b/polylogue/cli/query_stats.py
@@ -256,10 +256,8 @@ async def output_stats_sql(
                 exit_code=2 if output_format == "json" else None,
             )
             return
-        stats = await repo.aggregate_message_stats()
 
-    if has_filters:
-        stats = await repo.aggregate_message_stats(conv_ids)
+    stats = await repo.aggregate_message_stats(conv_ids if has_filters else None)
 
     date_range = ""
     if stats["min_sort_key"] and stats["max_sort_key"]:
@@ -279,6 +277,8 @@ async def output_stats_sql(
         "date_range": None,
         "filtered": has_filters,
     }
+    pending_embedding_conversations = 0
+    stale_embedding_messages = 0
     if not has_filters:
         assert archive_stats is not None
         pending_embedding_conversations = getattr(archive_stats, "pending_embedding_conversations", 0)
@@ -320,7 +320,7 @@ async def output_stats_sql(
         out(f"Words: ~{stats['words_approx']:,}")
 
     providers = stats.get("providers")
-    if isinstance(providers, dict) and providers:
+    if providers:
         provider_parts = [f"{name} ({count:,})" for name, count in providers.items()]
         out(f"Providers: {', '.join(provider_parts)}")
 

--- a/polylogue/cli/select.py
+++ b/polylogue/cli/select.py
@@ -7,7 +7,7 @@ import subprocess
 import sys
 from dataclasses import dataclass
 from datetime import datetime
-from typing import TYPE_CHECKING, Literal, Protocol, cast
+from typing import TYPE_CHECKING, Literal, NoReturn, Protocol, cast
 
 import click
 
@@ -188,7 +188,7 @@ async def select_conversation_rows(env: AppEnv, request: RootModeRequest, *, lim
     )
 
 
-def _raise_select_query_error(exc: QuerySpecError | QueryPlanError) -> None:
+def _raise_select_query_error(exc: QuerySpecError | QueryPlanError) -> NoReturn:
     if isinstance(exc, QuerySpecError):
         if exc.field in {"since", "until"}:
             click.echo(f"Error: Cannot parse date: '{exc.value}'", err=True)

--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -79,10 +79,10 @@ async def _ensure_fts_startup_readiness() -> None:
     gaps are repaired by conversation-scoped convergence; startup must not count
     all messages on every daemon restart.
     """
-    from polylogue.paths import archive_root, db_path
+    from polylogue.paths import db_path
     from polylogue.storage.sqlite.connection_profile import open_connection
 
-    db = db_path() or Path(archive_root()) / "polylogue.db"
+    db = db_path()
     if not db.exists():
         return
 
@@ -124,10 +124,10 @@ async def _ensure_fts_startup_readiness() -> None:
 
 async def _periodic_wal_checkpoint() -> None:
     """Run WAL checkpoint every 5 minutes to keep the WAL file bounded."""
-    from polylogue.paths import archive_root, db_path
+    from polylogue.paths import db_path
     from polylogue.storage.sqlite.connection_profile import open_connection
 
-    db = db_path() or Path(archive_root()) / "polylogue.db"
+    db = db_path()
     while True:
         await asyncio.sleep(300)  # 5 minutes
         if not db.exists():
@@ -145,10 +145,10 @@ async def _periodic_wal_checkpoint() -> None:
 
 async def _periodic_heartbeat() -> None:
     """Log daemon heartbeat with archive stats every 15 minutes."""
-    from polylogue.paths import archive_root, db_path
+    from polylogue.paths import db_path
     from polylogue.storage.sqlite.connection_profile import open_connection
 
-    db = db_path() or Path(archive_root()) / "polylogue.db"
+    db = db_path()
     while True:
         await asyncio.sleep(900)  # 15 minutes
         if not db.exists():
@@ -178,10 +178,10 @@ async def _periodic_db_optimize() -> None:
     that need it and never blocks reads.  It is NOT a VACUUM and does
     not rewrite the file.
     """
-    from polylogue.paths import archive_root, db_path
+    from polylogue.paths import db_path
     from polylogue.storage.sqlite.connection_profile import open_connection
 
-    db = db_path() or Path(archive_root()) / "polylogue.db"
+    db = db_path()
     while True:
         await asyncio.sleep(86_400)  # 24 hours
         if not db.exists():
@@ -206,10 +206,10 @@ async def _periodic_convergence_check(
     maintains these atomically via commit_archive_write_effects(),
     so gaps should be rare — this catches edge cases like crash recovery.
     """
-    from polylogue.paths import archive_root, db_path
+    from polylogue.paths import db_path
     from polylogue.storage.sqlite.connection_profile import open_connection
 
-    db = db_path() or Path(archive_root()) / "polylogue.db"
+    db = db_path()
     while True:
         await asyncio.sleep(600)  # 10 minutes
         if not db.exists():
@@ -505,9 +505,9 @@ async def run_daemon_services(
         # refresh derived state after successful writes.
         from polylogue.daemon.convergence import DaemonConverger
         from polylogue.daemon.convergence_stages import make_default_convergence_stages
-        from polylogue.paths import archive_root, db_path
+        from polylogue.paths import db_path
 
-        _db = db_path() or Path(archive_root()) / "polylogue.db"
+        _db = db_path()
 
         converger = DaemonConverger(
             stages=make_default_convergence_stages(_db),

--- a/polylogue/daemon/http.py
+++ b/polylogue/daemon/http.py
@@ -258,7 +258,7 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
     def _client_host(self) -> str:
         """Extract client IP from the request."""
         # The client_address is (host, port) from the underlying socket.
-        return self.client_address[0] if self.client_address else "127.0.0.1"
+        return str(self.client_address[0])
 
     def _check_auth(self) -> bool:
         """Validate the Authorization header against the daemon token.

--- a/polylogue/daemon/status.py
+++ b/polylogue/daemon/status.py
@@ -746,6 +746,7 @@ def _embedding_readiness_info() -> dict[str, object]:
     stale = 0
     failure = 0
     total = 0
+    total_conv = 0
     cost = 0.0
 
     try:

--- a/polylogue/mcp/payloads.py
+++ b/polylogue/mcp/payloads.py
@@ -543,7 +543,7 @@ class MCPReadinessCheckPayload(SurfacePayloadModel):
 
 def _extract_readiness_source(report: ReadinessReport) -> str | None:
     provenance = report.provenance
-    if provenance is None or provenance.source is None:
+    if provenance.source is None:
         return None
     return provenance.source
 

--- a/polylogue/mcp/server.py
+++ b/polylogue/mcp/server.py
@@ -58,7 +58,7 @@ def _get_archive_ops() -> ArchiveOperations:
     """Return canonical archive operations for MCP read surfaces."""
     services = _get_runtime_services()
     return ArchiveOperations(
-        config=services.config if services is not None else None,
+        config=services.config,
         repository=_get_repo(),
         backend=_get_backend(),
     )

--- a/polylogue/mcp/server_maintenance_tools.py
+++ b/polylogue/mcp/server_maintenance_tools.py
@@ -30,8 +30,8 @@ def register_maintenance_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
             return hooks.json_payload(
                 MCPMutationStatusPayload(
                     status="ok" if success else "failed",
-                    index_exists=index_exists_value if isinstance(index_exists_value, bool) else False,
-                    indexed_messages=indexed_messages_value if isinstance(indexed_messages_value, int) else 0,
+                    index_exists=bool(index_exists_value),
+                    indexed_messages=int(indexed_messages_value),
                 ),
                 exclude_none=True,
             )

--- a/polylogue/pipeline/services/acquisition.py
+++ b/polylogue/pipeline/services/acquisition.py
@@ -163,7 +163,7 @@ class AcquisitionService:
                 )
                 result.counts["errors"] += 1
                 prior_errors = cursor_state.get("error_count", 0)
-                cursor_state["error_count"] = (prior_errors if isinstance(prior_errors, int) else 0) + 1
+                cursor_state["error_count"] = int(prior_errors) + 1
                 cursor_state["latest_error"] = str(exc)
 
             # Slice B: persist cursor stat fields for all source files after

--- a/polylogue/pipeline/services/ingest_batch/_core.py
+++ b/polylogue/pipeline/services/ingest_batch/_core.py
@@ -528,9 +528,7 @@ def _write_conversation(
 
     # Attachments
     if not content_unchanged:
-        new_attachment_ids = {
-            attachment_id for attachment_id, *_rest in cdata.attachment_tuples if isinstance(attachment_id, str)
-        }
+        new_attachment_ids = {attachment_id for attachment_id, *_rest in cdata.attachment_tuples}
         affected_attachment_ids |= new_attachment_ids
         if cdata.attachment_tuples:
             conn.executemany(_ATTACHMENT_UPSERT_SQL, cdata.attachment_tuples)

--- a/polylogue/schemas/field_stats/models.py
+++ b/polylogue/schemas/field_stats/models.py
@@ -47,7 +47,7 @@ class FieldStats:
             return None
         fmt, count = self.detected_formats.most_common(1)[0]
         if count / self.value_count >= 0.8:
-            return str(fmt) if fmt is not None else None
+            return str(fmt)
         return None
 
     @property

--- a/polylogue/schemas/inference/semantic/conversation_scoring.py
+++ b/polylogue/schemas/inference/semantic/conversation_scoring.py
@@ -73,7 +73,7 @@ def score_title(path: str, fs: FieldStats, all_stats: dict[str, FieldStats]) -> 
         evidence["low_entropy"] = round(fs.approximate_entropy, 2)
 
     if fs.observed_values:
-        slash_count = sum(1 for value in fs.observed_values if isinstance(value, str) and "/" in value)
+        slash_count = sum(1 for value in fs.observed_values if "/" in value)
         slash_ratio = slash_count / len(fs.observed_values)
         if slash_ratio > 0.3:
             score *= 0.3

--- a/polylogue/schemas/validation/corpus.py
+++ b/polylogue/schemas/validation/corpus.py
@@ -8,7 +8,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import TypeAlias
 
-from polylogue.archive.raw_payload import build_raw_payload_envelope
+from polylogue.archive.raw_payload import RawPayloadEnvelope, build_raw_payload_envelope
 from polylogue.core.common import format_malformed_jsonl_error as _format_malformed_jsonl_error
 from polylogue.core.provider_identity import CORE_RUNTIME_PROVIDERS
 from polylogue.schemas.validator import SchemaValidator
@@ -237,6 +237,10 @@ def verify_raw_corpus(
 
             raw_source = blob_store.blob_path(raw_id)
 
+            envelope: RawPayloadEnvelope | None = None
+            payload: object = None
+            malformed_lines = 0
+            malformed_detail: str | None = None
             try:
                 envelope = build_raw_payload_envelope(
                     raw_source,
@@ -303,6 +307,7 @@ def verify_raw_corpus(
                 _report_progress(request.progress_callback)
                 continue
 
+            validator: SchemaValidator
             try:
                 validator = SchemaValidator.for_payload(
                     actual_provider,

--- a/polylogue/sources/live/batch.py
+++ b/polylogue/sources/live/batch.py
@@ -30,6 +30,7 @@ from polylogue.pipeline.services.ingest_batch._core import (
     _INGEST_RESULT_CHUNK_SIZE,
     _process_ingest_batch_sync,
 )
+from polylogue.pipeline.services.ingest_batch._models import _IngestBatchSummary
 from polylogue.sources.dispatch import _detect_provider_from_raw_bytes
 from polylogue.sources.live.batch_observability import (
     conversation_ids_for_source_path,
@@ -871,6 +872,7 @@ class LiveBatchProcessor:
             )
             raw_by_id[raw_id] = path
 
+        summary: _IngestBatchSummary | None = None
         if raw_records:
             self._persist_raw_records(raw_records)
             if heartbeat is not None:

--- a/polylogue/sources/token_store.py
+++ b/polylogue/sources/token_store.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from contextlib import suppress
 from importlib import import_module
 from pathlib import Path
-from typing import Protocol, runtime_checkable
+from typing import Protocol, cast, runtime_checkable
 
 from polylogue.logging import get_logger
 
@@ -93,14 +93,10 @@ class KeyringTokenStore:
     @staticmethod
     def _try_import_keyring() -> KeyringModule | None:
         try:
-            candidate = import_module("keyring")
-            keyring = candidate if isinstance(candidate, KeyringModule) else None
-            if keyring is None:
-                return None
-
+            candidate = cast(KeyringModule, import_module("keyring"))
             # Test that keyring backend is functional
-            keyring.get_keyring()
-            return keyring
+            candidate.get_keyring()
+            return candidate
         except Exception:
             return None
 

--- a/polylogue/storage/action_events/rebuild_loading.py
+++ b/polylogue/storage/action_events/rebuild_loading.py
@@ -49,7 +49,7 @@ async def iter_conversation_id_pages_async(
 ) -> AsyncIterator[list[str]]:
     cursor = await conn.execute(_ALL_ACTION_EVENT_CONVERSATION_IDS_SQL)
     while True:
-        rows = await cursor.fetchmany(page_size)
+        rows = list(await cursor.fetchmany(page_size))
         if not rows:
             break
         yield [str(row["conversation_id"]) for row in rows]

--- a/polylogue/storage/derived/derived_status.py
+++ b/polylogue/storage/derived/derived_status.py
@@ -120,11 +120,10 @@ def _retrieval_metrics(
     return {
         "evidence_retrieval_rows": evidence_rows,
         "expected_evidence_retrieval_rows": expected_evidence_rows,
-        "evidence_retrieval_ready": True and bool(action_status["action_fts_ready"]),
+        "evidence_retrieval_ready": bool(action_status["action_fts_ready"]),
         "inference_retrieval_rows": inference_rows,
         "expected_inference_retrieval_rows": expected_inference_rows,
-        "inference_retrieval_ready": True
-        and session_status.work_event_inference_fts_ready
+        "inference_retrieval_ready": session_status.work_event_inference_fts_ready
         and session_status.phase_inference_rows_ready,
         "enrichment_retrieval_rows": int(metrics["profile_rows"]),
         "expected_enrichment_retrieval_rows": int(metrics["profile_rows"]),

--- a/polylogue/storage/insights/session/rebuild.py
+++ b/polylogue/storage/insights/session/rebuild.py
@@ -182,7 +182,7 @@ async def iter_conversation_id_pages_async(
 ) -> AsyncIterator[list[str]]:
     cursor = await conn.execute(_ALL_CONVERSATION_IDS_SQL)
     while True:
-        rows = await cursor.fetchmany(page_size)
+        rows = list(await cursor.fetchmany(page_size))
         if not rows:
             break
         yield [str(row["conversation_id"]) for row in rows]
@@ -575,6 +575,7 @@ def rebuild_session_insights_sync(
     progress_total: int | None = None,
 ) -> SessionInsightCounts:
     conversation_chunks: Iterable[Sequence[str]]
+    previous_profile_groups: set[tuple[str, str]] = set()
     if conversation_ids is None:
         conn.execute("DELETE FROM session_work_events")
         conn.execute("DELETE FROM session_phases")

--- a/polylogue/storage/insights/session/threads.py
+++ b/polylogue/storage/insights/session/threads.py
@@ -253,7 +253,7 @@ async def iter_root_id_pages_async(
 ) -> AsyncIterator[list[str]]:
     cursor = await conn.execute(_ROOT_THREAD_IDS_SQL)
     while True:
-        rows = await cursor.fetchmany(size)
+        rows = list(await cursor.fetchmany(size))
         if not rows:
             break
         yield [str(row["conversation_id"]) for row in rows]

--- a/polylogue/storage/sqlite/queries/attachment_mutations.py
+++ b/polylogue/storage/sqlite/queries/attachment_mutations.py
@@ -92,13 +92,13 @@ async def prune_attachments(
             """,
             (conversation_id, *keep_attachment_ids),
         )
-        refs_to_remove = await cursor.fetchall()
+        refs_to_remove = list(await cursor.fetchall())
     else:
         cursor = await conn.execute(
             "SELECT attachment_id FROM attachment_refs WHERE conversation_id = ?",
             (conversation_id,),
         )
-        refs_to_remove = await cursor.fetchall()
+        refs_to_remove = list(await cursor.fetchall())
 
     if not refs_to_remove:
         return

--- a/polylogue/storage/sqlite/queries/conversations_identity.py
+++ b/polylogue/storage/sqlite/queries/conversations_identity.py
@@ -81,7 +81,7 @@ async def iter_conversation_ids(
     sql, params = conversation_id_query(source_names=source_names)
     cursor = await conn.execute(sql, params)
     while True:
-        rows = await cursor.fetchmany(page_size)
+        rows = list(await cursor.fetchmany(page_size))
         if not rows:
             break
         for row in rows:
@@ -149,7 +149,7 @@ async def list_tags(conn: aiosqlite.Connection, *, provider: str | None = None) 
         """,
         params,
     )
-    rows = await cursor.fetchall()
+    rows = list(await cursor.fetchall())
     if rows:
         return {row["tag_name"]: row["cnt"] for row in rows}
 
@@ -170,7 +170,7 @@ async def list_tags(conn: aiosqlite.Connection, *, provider: str | None = None) 
         """,
         json_params,
     )
-    rows = await cursor.fetchall()
+    rows = list(await cursor.fetchall())
     return {row["tag_name"]: row["cnt"] for row in rows}
 
 

--- a/polylogue/storage/sqlite/queries/cursor.py
+++ b/polylogue/storage/sqlite/queries/cursor.py
@@ -15,7 +15,7 @@ async def get_known_source_cursors(
     result: dict[str, dict[str, object]] = {}
     cursor = await conn.execute("SELECT source_path, st_dev, st_ino, st_size, mtime_ns FROM source_file_cursor")
     while True:
-        rows = await cursor.fetchmany(1000)
+        rows = list(await cursor.fetchmany(1000))
         if not rows:
             break
         for row in rows:

--- a/polylogue/storage/sqlite/queries/raw_reads.py
+++ b/polylogue/storage/sqlite/queries/raw_reads.py
@@ -116,7 +116,7 @@ async def iter_raw_ids(
     )
     cursor = await conn.execute(sql, params)
     while True:
-        rows = await cursor.fetchmany(page_size)
+        rows = list(await cursor.fetchmany(page_size))
         if not rows:
             break
         for row in rows:
@@ -142,7 +142,7 @@ async def iter_raw_headers(
     )
     cursor = await conn.execute(sql, params)
     while True:
-        rows = await cursor.fetchmany(page_size)
+        rows = list(await cursor.fetchmany(page_size))
         if not rows:
             break
         for row in rows:
@@ -164,7 +164,7 @@ async def get_known_source_mtimes(conn: aiosqlite.Connection) -> dict[str, str]:
     result: dict[str, str] = {}
     cursor = await conn.execute("SELECT source_path, file_mtime FROM raw_conversations WHERE file_mtime IS NOT NULL")
     while True:
-        rows = await cursor.fetchmany(1000)
+        rows = list(await cursor.fetchmany(1000))
         if not rows:
             break
         for row in rows:
@@ -182,7 +182,7 @@ async def get_raw_conversations_batch(conn: aiosqlite.Connection, raw_ids: list[
     )
     records: list[RawConversationRecord] = []
     while True:
-        rows = await cursor.fetchmany(200)
+        rows = list(await cursor.fetchmany(200))
         if not rows:
             break
         records.extend(_row_to_raw_conversation(row) for row in rows)

--- a/polylogue/ui/tui/screens/base.py
+++ b/polylogue/ui/tui/screens/base.py
@@ -45,10 +45,10 @@ class RepositoryBoundContainer(Container):
 
         conv = await ops.get_conversation(conversation_id)
         if not conv:
-            viewer.update(f"Error: Could not load {conversation_id}")
+            await viewer.update(f"Error: Could not load {conversation_id}")
             return False
 
-        viewer.update(formatter(conv))
+        await viewer.update(formatter(conv))
         return True
 
 

--- a/polylogue/ui/tui/screens/dashboard.py
+++ b/polylogue/ui/tui/screens/dashboard.py
@@ -124,4 +124,4 @@ class Dashboard(RepositoryBoundContainer):
 
         for provider, count in sorted_providers[:10]:
             bar = ProviderBar(provider or "unknown", count, max_count)
-            bars_container.mount(bar)
+            _ = bars_container.mount(bar)

--- a/polylogue/ui/tui/screens/search.py
+++ b/polylogue/ui/tui/screens/search.py
@@ -62,7 +62,7 @@ class Search(RepositoryBoundContainer):
 
     async def on_data_table_row_selected(self, message: DataTable.RowSelected) -> None:
         """Handle result selection."""
-        if not message.row_key:
+        if message.row_key.value is None:
             return
 
         conv_id = str(message.row_key.value)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -190,13 +190,15 @@ enable_error_code = [
 line-length = 120
 target-version = "py310"
 cache-dir = ".cache/ruff"
+# Excludes are limited to vendored/build directories; every path below is
+# repository infrastructure, not production code. Audited under #1062 Pack B.
 exclude = [
-    ".git",
-    "__pycache__",
-    "build",
-    "dist",
-    ".venv",
-    "venv",
+    ".git",         # version control metadata
+    "__pycache__",  # bytecode caches
+    "build",        # setuptools build output
+    "dist",         # wheel/sdist artifacts
+    ".venv",        # devshell-managed virtual environment
+    "venv",         # legacy virtual environment fallback
 ]
 
 [tool.ruff.lint]
@@ -217,6 +219,9 @@ ignore = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
+# Per-file ignores are documented justifications, not blanket exemptions.
+# Each entry carries the reason inline so the next reader can re-validate
+# whether the suppression is still load-bearing. Audited under #1062 Pack B.
 "tests/**" = [
     "E402",   # consolidated mega-files have mid-file section imports
     "N803",   # test parameter naming follows test conventions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -174,6 +174,17 @@ files = [
 ignore_missing_imports = true
 disallow_subclassing_any = false  # Pydantic BaseModel seen as Any (plugin incompatible with nix mypy 1.17)
 disallow_untyped_decorators = false  # Click decorators are inherently untyped
+# Tighten suppression discipline so the verify-suppressions scanner is a
+# backstop, not the primary enforcement mechanism (#1062 Pack B).
+enable_error_code = [
+    "ignore-without-code",       # forbid bare `# type: ignore`; require `[error-code]`
+    "redundant-self",            # flag unnecessary explicit Self annotations
+    "redundant-expr",            # flag always-true / always-false subexpressions
+    "possibly-undefined",        # flag names only defined on some branches
+    "truthy-bool",               # flag implicit-truthy use of non-bool types
+    "truthy-iterable",           # flag implicit-truthy use of iterables
+    "unused-awaitable",          # flag awaitables that are constructed but not awaited
+]
 
 [tool.ruff]
 line-length = 120

--- a/tests/conftest_witness.py
+++ b/tests/conftest_witness.py
@@ -39,7 +39,7 @@ def _save_failure_witness(item: pytest.Item, call: pytest.CallInfo[Any]) -> None
     error_msg = ""
     if call.excinfo is not None:
         ex = call.excinfo
-        error_msg = f"{ex.type.__name__}: {ex.value}" if ex.value else str(ex.type)
+        error_msg = f"{ex.type.__name__}: {ex.value}"
 
     traceback_text = ""
     if call.excinfo is not None:

--- a/tests/infra/pty_cli.py
+++ b/tests/infra/pty_cli.py
@@ -211,7 +211,7 @@ def run_in_pty(
         """Convert pyte history line (StaticDefaultDict of Char) to string."""
         if not isinstance(chardict, Mapping) or not chardict:
             return ""
-        max_col = max(chardict.keys()) if chardict else 0
+        max_col = max(chardict.keys())
         chars: list[str] = []
         for index in range(max_col + 1):
             char = chardict[index]

--- a/tests/infra/storage_records.py
+++ b/tests/infra/storage_records.py
@@ -875,7 +875,7 @@ def make_message(
         1 if (block_types & {ContentBlockType.TOOL_USE, ContentBlockType.TOOL_RESULT}) or role_value is Role.TOOL else 0
     )
     has_thinking = 1 if ContentBlockType.THINKING in block_types else 0
-    default_sort_key = _timestamp_sort_key(ts) if ts is not None else None
+    default_sort_key = _timestamp_sort_key(ts)
     default_content_hash = uuid4().hex[:16]
 
     payload: RecordPayload = {

--- a/tests/integration/test_extraction_db.py
+++ b/tests/integration/test_extraction_db.py
@@ -392,7 +392,7 @@ def parse_raw_content(raw_content: bytes, provider: str) -> ParsedPayload:
     which may contain multiple JSON objects on separate lines. JSON providers
     (chatgpt) store a single JSON object.
     """
-    content = raw_content.decode("utf-8") if isinstance(raw_content, bytes) else raw_content
+    content = raw_content.decode("utf-8")
 
     if provider in ("claude-code", "codex", "gemini"):
         # Try single JSON first (e.g. one-line JSONL files)

--- a/tests/integration/test_schema_operator_workflow.py
+++ b/tests/integration/test_schema_operator_workflow.py
@@ -74,7 +74,7 @@ def _extract_json(output: str) -> JsonObject:
 def _extract_result_json(output: str) -> JsonObject:
     """Extract JSON and unwrap the standard success envelope when present."""
     data = _extract_json(output)
-    if isinstance(data, dict) and data.get("status") == "ok" and "result" in data:
+    if data.get("status") == "ok" and "result" in data:
         result = data["result"]
         if isinstance(result, dict):
             return result

--- a/tests/integration/test_workflows.py
+++ b/tests/integration/test_workflows.py
@@ -191,6 +191,7 @@ async def test_render_formats(
     convs = [c for c in convs if c.provider == "chatgpt"]
     assert len(convs) > 0
 
+    output = ""
     if format == "markdown":
         # Markdown formatting path uses ConversationFormatter directly.
         from polylogue.rendering.core import ConversationFormatter

--- a/tests/unit/core/test_message_laws.py
+++ b/tests/unit/core/test_message_laws.py
@@ -116,7 +116,7 @@ def test_without_noise_idempotent(conv: Conversation) -> None:
 @settings(suppress_health_check=[HealthCheck.too_slow])
 def test_extract_thinking_never_empty_string(msg: Message) -> None:
     result = msg.extract_thinking()
-    assert result is None or (isinstance(result, str) and len(result.strip()) > 0)
+    assert result is None or len(result.strip()) > 0
 
 
 @given(message_model_strategy())

--- a/tests/unit/core/test_query_fields.py
+++ b/tests/unit/core/test_query_fields.py
@@ -123,8 +123,7 @@ def test_query_field_catalog_drives_plan_presence_descriptions_and_pushdown() ->
         "since": "2024-01-01T00:00:00+00:00",
     }
     assert all(
-        isinstance(value, (str, int, bool))
-        or (isinstance(value, list) and all(isinstance(item, str) for item in value))
+        not isinstance(value, list) or all(isinstance(item, str) for item in value)
         for value in plan.sql_pushdown_params().values()
     )
 

--- a/tests/unit/daemon/test_web_reader.py
+++ b/tests/unit/daemon/test_web_reader.py
@@ -155,7 +155,7 @@ def _get_text(base_url: str, path: str, *, headers: dict[str, str] | None = None
         with urlopen(req, timeout=10) as resp:
             return resp.status, resp.headers.get("Content-Type", ""), resp.read().decode()
     except HTTPError as exc:
-        body = exc.read().decode() if exc.fp else ""
+        body = exc.read().decode()
         return exc.code, exc.headers.get("Content-Type", ""), body
 
 
@@ -175,7 +175,7 @@ def _request_json(
         with urlopen(req, timeout=10) as resp:
             return resp.status, json.loads(resp.read())
     except HTTPError as exc:
-        raw = exc.read().decode() if exc.fp else "{}"
+        raw = exc.read().decode()
         return exc.code, json.loads(raw)
 
 
@@ -986,7 +986,7 @@ def _get_json_ex(base_url: str, path: str) -> tuple[int, dict[str, object]]:
         with urlopen(req, timeout=5) as resp:
             return resp.status, json.loads(resp.read().decode())
     except HTTPError as e:
-        body = e.read().decode() if e.fp else ""
+        body = e.read().decode()
         try:
             return e.code, json.loads(body)
         except (json.JSONDecodeError, ValueError):

--- a/tests/unit/devtools/test_no_cover_pragmas.py
+++ b/tests/unit/devtools/test_no_cover_pragmas.py
@@ -1,0 +1,50 @@
+"""Backstop discipline test for ``# pragma: no cover`` (#1062).
+
+Mirrors the verify-suppressions scanner's classifier so the codebase keeps
+inline justification on every coverage pragma, independent of whether the
+scanner is wired into a particular CI matrix entry.
+"""
+
+from __future__ import annotations
+
+import re
+
+from devtools import repo_root
+
+ROOT = repo_root()
+SCAN_DIRS = ("polylogue", "tests", "devtools")
+
+_PRAGMA_PATTERN = re.compile(r"pragma:\s*no cover")
+# Match the exact justification grammar the scanner enforces. Allow ASCII
+# hyphen, en-dash, em-dash, hash, or colon as the separator.
+_JUSTIFIED_PRAGMA = re.compile(r"pragma:\s*no cover\s*[-\u2013\u2014#:]\s*\S")
+
+
+def test_no_cover_pragmas_carry_justification() -> None:
+    """Every ``# pragma: no cover`` must be followed by inline rationale.
+
+    Acceptable forms include ``# pragma: no cover - defensive``,
+    ``# pragma: no cover  # script entry``, or
+    ``# pragma: no cover \u2014 returns RootModeRequest``.
+    """
+    offenders: list[str] = []
+    for path in sorted(
+        p
+        for dirname in SCAN_DIRS
+        if (ROOT / dirname).exists()
+        for p in (ROOT / dirname).rglob("*.py")
+        if "__pycache__" not in p.parts
+    ):
+        # Skip this test itself (the pattern appears inside string literals).
+        if path.name in {"test_no_cover_pragmas.py", "test_verify_suppressions.py", "verify_suppressions.py"}:
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            if _PRAGMA_PATTERN.search(line) and not _JUSTIFIED_PRAGMA.search(line):
+                rel = path.relative_to(ROOT).as_posix()
+                offenders.append(f"{rel}:{lineno}: {line.strip()}")
+
+    assert not offenders, "'# pragma: no cover' directives without inline justification:\n  " + "\n  ".join(offenders)

--- a/tests/unit/devtools/test_suppression_discipline.py
+++ b/tests/unit/devtools/test_suppression_discipline.py
@@ -1,0 +1,79 @@
+"""Backstop discipline tests for native suppression enforcement (#1062).
+
+These tests pin the load-bearing invariants the verify-suppressions scanner
+enforces, but read the codebase directly so a regression cannot hide behind
+a configuration change.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from devtools import repo_root
+
+ROOT = repo_root()
+SCAN_DIRS = ("polylogue", "tests", "devtools")
+_BARE_TYPE_IGNORE = re.compile(r"#\s*type:\s*ignore(?!\[)")
+
+
+def _iter_python_sources() -> list[Path]:
+    files: list[Path] = []
+    for dirname in SCAN_DIRS:
+        base = ROOT / dirname
+        if not base.exists():
+            continue
+        files.extend(p for p in base.rglob("*.py") if "__pycache__" not in p.parts)
+    return sorted(files)
+
+
+# Files that legitimately mention the pattern inside string literals (the
+# scanner implementation itself and the tests that exercise it).
+_PATTERN_AUTHORITIES = frozenset(
+    {
+        "devtools/verify_suppressions.py",
+        "tests/unit/devtools/test_verify_suppressions.py",
+        "tests/unit/devtools/test_suppression_discipline.py",
+        "tests/unit/devtools/test_no_cover_pragmas.py",
+    }
+)
+
+
+def test_no_bare_type_ignore_directives() -> None:
+    """Every ``# type: ignore`` must carry a bracketed error code.
+
+    This is the load-bearing claim for ``enable_error_code =
+    ["ignore-without-code"]`` in ``[tool.mypy]``; the mypy gate fails
+    locally, but this test is a grep-level backstop that catches the
+    pattern even if mypy is temporarily disabled in a CI matrix entry.
+    """
+    offenders: list[str] = []
+    for path in _iter_python_sources():
+        rel = path.relative_to(ROOT).as_posix()
+        if rel in _PATTERN_AUTHORITIES:
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            if _BARE_TYPE_IGNORE.search(line):
+                offenders.append(f"{rel}:{lineno}: {line.strip()}")
+    assert not offenders, "bare '# type: ignore' directives found; require bracketed [error-code]:\n  " + "\n  ".join(
+        offenders
+    )
+
+
+def test_pyproject_enables_ignore_without_code() -> None:
+    """``[tool.mypy].enable_error_code`` must include ``ignore-without-code``."""
+    pyproject = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    # Locate the [tool.mypy] section.
+    mypy_section = pyproject.split("[tool.mypy]", 1)
+    assert len(mypy_section) == 2, "expected [tool.mypy] section in pyproject.toml"
+    # Cut to next table header.
+    body = mypy_section[1].split("\n[tool.", 1)[0]
+    assert "enable_error_code" in body, "[tool.mypy] must declare enable_error_code"
+    assert "ignore-without-code" in body, (
+        "[tool.mypy].enable_error_code must include 'ignore-without-code' so "
+        "bare '# type: ignore' is rejected by the mypy gate"
+    )

--- a/tests/unit/devtools/test_verify_suppressions.py
+++ b/tests/unit/devtools/test_verify_suppressions.py
@@ -84,12 +84,12 @@ def test_discovers_source_suppressions(tmp_path: Path, capsys: pytest.CaptureFix
         "\n".join(
             [
                 "import pytest",
-                "pytest.skip('not available')",
-                "pytest.xfail('tracked elsewhere')",
+                "pytest.skip('feature not available on this platform')",
+                "pytest.xfail('tracked in #1062')",
                 "value = dynamic()  # type: ignore[no-any-return]",
                 "def unused(arg):  # noqa: ARG001",
                 "    pass",
-                "def fallback():  # pragma: no cover",
+                "def fallback():  # pragma: no cover - defensive",
                 "    pass",
             ]
         ),
@@ -103,6 +103,7 @@ def test_discovers_source_suppressions(tmp_path: Path, capsys: pytest.CaptureFix
     assert data["blocking"] is False
     assert data["discovered_total"] == 5
     assert data["unregistered_total"] == 5
+    assert data["discipline_violations_total"] == 0
     assert data["discovered_by_kind"] == {
         "no_cover": 1,
         "noqa": 1,
@@ -116,7 +117,10 @@ def test_enforce_discovered_blocks_unregistered(tmp_path: Path, capsys: pytest.C
     yaml = _write_registry(tmp_path, "suppressions: []\n")
     source = tmp_path / "tests" / "test_example.py"
     source.parent.mkdir()
-    source.write_text("@pytest.mark.xfail(reason='tracked elsewhere')\ndef test_x(): ...\n", encoding="utf-8")
+    source.write_text(
+        "import pytest\n@pytest.mark.xfail(reason='tracked in #1062', strict=True)\ndef test_x(): ...\n",
+        encoding="utf-8",
+    )
 
     rc = verify_suppressions.main(["--yaml", str(yaml), "--scan-root", str(tmp_path), "--enforce-discovered"])
 
@@ -140,7 +144,10 @@ def test_enforce_discovered_accepts_registered_path(tmp_path: Path, capsys: pyte
     )
     source = tmp_path / "tests" / "test_example.py"
     source.parent.mkdir()
-    source.write_text("@pytest.mark.xfail(reason='tracked elsewhere')\ndef test_x(): ...\n", encoding="utf-8")
+    source.write_text(
+        "import pytest\n@pytest.mark.xfail(reason='tracked in #1062', strict=True)\ndef test_x(): ...\n",
+        encoding="utf-8",
+    )
 
     rc = verify_suppressions.main(["--yaml", str(yaml), "--scan-root", str(tmp_path), "--enforce-discovered"])
 
@@ -156,4 +163,120 @@ def test_pytest_suppression_scan_ignores_ast_parse_failures(monkeypatch: pytest.
 
     monkeypatch.setattr("devtools.verify_suppressions.ast.parse", fail_parse)
 
-    assert verify_suppressions._pytest_suppression_lines("pytest.mark.xfail()") == []
+    assert verify_suppressions._pytest_suppression_lines("pytest.mark.xfail(strict=True, reason='ref #1')") == []
+
+
+def test_skip_without_reason_is_discipline_violation(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    yaml = _write_registry(tmp_path, "suppressions: []\n")
+    source = tmp_path / "tests" / "test_bad_skip.py"
+    source.parent.mkdir()
+    source.write_text(
+        "import pytest\npytest.skip()\npytest.skip('TODO')\npytest.skip('No claude-code messages')\n",
+        encoding="utf-8",
+    )
+
+    rc = verify_suppressions.main(["--yaml", str(yaml), "--scan-root", str(tmp_path), "--json"])
+    data = json.loads(capsys.readouterr().out)
+
+    assert rc == 1
+    assert data["blocking"] is True
+    # Two of three skips should fail discipline (empty and 'TODO'); the
+    # substantive third must pass.
+    assert data["discipline_violations_total"] == 2
+    for violation in data["discipline_violations"]:
+        assert violation["kind"] == "pytest_skip"
+        assert any("substantive reason" in err for err in violation["discipline_errors"])
+
+
+def test_xfail_without_issue_link_is_violation(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    yaml = _write_registry(tmp_path, "suppressions: []\n")
+    source = tmp_path / "tests" / "test_bad_xfail.py"
+    source.parent.mkdir()
+    source.write_text(
+        "import pytest\n"
+        "@pytest.mark.xfail(reason='broken', strict=True)\n"
+        "def test_a(): pass\n"
+        "@pytest.mark.xfail(reason='tracked in #1062', strict=True)\n"
+        "def test_b(): pass\n"
+        "@pytest.mark.xfail(reason='tracked in #1062')\n"  # missing strict=True
+        "def test_c(): pass\n",
+        encoding="utf-8",
+    )
+
+    rc = verify_suppressions.main(["--yaml", str(yaml), "--scan-root", str(tmp_path), "--json"])
+    data = json.loads(capsys.readouterr().out)
+
+    assert rc == 1
+    assert data["discipline_violations_total"] == 2
+    error_texts = [err for v in data["discipline_violations"] for err in v["discipline_errors"]]
+    assert any("must reference an issue" in err for err in error_texts)
+    assert any("strict=True" in err for err in error_texts)
+
+
+def test_bare_type_ignore_comment_is_violation(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    yaml = _write_registry(tmp_path, "suppressions: []\n")
+    source = tmp_path / "polylogue" / "module.py"
+    source.parent.mkdir()
+    source.write_text(
+        "x = 1  # type: ignore\ny = 2  # type: ignore[attr-defined]\n",
+        encoding="utf-8",
+    )
+
+    rc = verify_suppressions.main(["--yaml", str(yaml), "--scan-root", str(tmp_path), "--json"])
+    data = json.loads(capsys.readouterr().out)
+
+    assert rc == 1
+    assert data["discipline_violations_total"] == 1
+    violation = data["discipline_violations"][0]
+    assert violation["kind"] == "type_ignore"
+    assert any("bare '# type: ignore'" in err for err in violation["discipline_errors"])
+
+
+def test_no_cover_pragma_requires_justification(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    yaml = _write_registry(tmp_path, "suppressions: []\n")
+    source = tmp_path / "polylogue" / "module.py"
+    source.parent.mkdir()
+    source.write_text(
+        "def a():  # pragma: no cover\n    pass\n"
+        "def b():  # pragma: no cover - defensive\n    pass\n"
+        "def c():  # pragma: no cover \u2014 returns RootModeRequest\n    pass\n",
+        encoding="utf-8",
+    )
+
+    rc = verify_suppressions.main(["--yaml", str(yaml), "--scan-root", str(tmp_path), "--json"])
+    data = json.loads(capsys.readouterr().out)
+
+    assert rc == 1
+    assert data["discipline_violations_total"] == 1
+    violation = data["discipline_violations"][0]
+    assert violation["kind"] == "no_cover"
+    assert any("inline justification" in err for err in violation["discipline_errors"])
+
+
+def test_skip_with_fstring_reason_is_substantive(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    yaml = _write_registry(tmp_path, "suppressions: []\n")
+    source = tmp_path / "tests" / "test_fstring_skip.py"
+    source.parent.mkdir()
+    source.write_text(
+        "import pytest\nprovider='codex'\npytest.skip(f'No {provider} messages in seeded database')\n",
+        encoding="utf-8",
+    )
+
+    rc = verify_suppressions.main(["--yaml", str(yaml), "--scan-root", str(tmp_path), "--json"])
+    data = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert data["discipline_violations_total"] == 0
+
+
+def test_committed_codebase_passes_discipline(capsys: pytest.CaptureFixture[str]) -> None:
+    """The committed codebase must satisfy every discipline rule.
+
+    This regression test is the one place that fails fast when a new
+    skip, xfail, no-cover pragma, or bare type-ignore lands without the
+    required metadata. Pack B's burn-down work is what makes it pass.
+    """
+    rc = verify_suppressions.main(["--json"])
+    data = json.loads(capsys.readouterr().out)
+    assert rc == 0, f"committed codebase has discipline violations: {data['discipline_violations']}"
+    assert data["discipline_violations_total"] == 0

--- a/tests/unit/pipeline/test_branching.py
+++ b/tests/unit/pipeline/test_branching.py
@@ -240,7 +240,7 @@ class TestBranchRepositoryTraversal:
 
         assert parent is not None and str(parent.id) == ids["root"]
         assert {str(conv.id) for conv in children} == {ids["continuation"], ids["sidechain"]}
-        assert root is not None and str(root.id) == ids["root"]
+        assert str(root.id) == ids["root"]
         assert {str(conv.id) for conv in tree} == {
             ids["root"],
             ids["continuation"],

--- a/tests/unit/pipeline/test_ingestion_chaos.py
+++ b/tests/unit/pipeline/test_ingestion_chaos.py
@@ -165,7 +165,7 @@ class TestLargeBatchTruncatedLine:
         data = _jsonl_bytes(corrupted)
 
         parsed = [_as_record(record) for record in _iter_jsonl_stream(data)]
-        assert all(isinstance(r, dict) and "type" in r for r in parsed)
+        assert all("type" in r for r in parsed)
 
 
 class TestLargeBatchBadUtf8:

--- a/tests/unit/sources/test_live_watcher.py
+++ b/tests/unit/sources/test_live_watcher.py
@@ -50,7 +50,7 @@ class _FullIngestMock:
         if self.side_effect is not None:
             if isinstance(self.side_effect, BaseException):
                 raise self.side_effect
-            if isinstance(self.side_effect, type) and issubclass(self.side_effect, BaseException):
+            if isinstance(self.side_effect, type):
                 raise self.side_effect()
         return _FullIngestResult(
             succeeded=list(paths),

--- a/tests/unit/sources/test_parsers_base.py
+++ b/tests/unit/sources/test_parsers_base.py
@@ -245,7 +245,7 @@ def test_parse_code_variants(messages: list[object], expected: int | str, desc: 
     result = parse_code(messages, "fallback-id")
     if isinstance(expected, int):
         assert len(result.messages) == expected, f"Failed {desc}"
-    elif isinstance(expected, str) and result.messages:
+    elif result.messages:
         assert result.messages[0].role == expected, f"Failed {desc}"
 
 

--- a/tests/unit/sources/test_parsers_chatgpt.py
+++ b/tests/unit/sources/test_parsers_chatgpt.py
@@ -374,7 +374,7 @@ def test_chatgpt_parse_synthetic_simple() -> None:
             tags=("synthetic", "test", "chatgpt-parser"),
         )
     )[0]
-    data = json.loads(raw) if isinstance(raw, bytes) else raw
+    data = json.loads(raw)
 
     result = chatgpt_parse(data, "simple-test")
 
@@ -398,7 +398,7 @@ def test_chatgpt_parse_synthetic_branching() -> None:
             tags=("synthetic", "test", "chatgpt-parser"),
         )
     )[0]
-    data = json.loads(raw) if isinstance(raw, bytes) else raw
+    data = json.loads(raw)
 
     result = chatgpt_parse(data, "branching-test")
 

--- a/tests/unit/sources/test_parsers_props.py
+++ b/tests/unit/sources/test_parsers_props.py
@@ -260,7 +260,7 @@ def test_provider_looks_like_accepts_generated_payloads(case: ParserCase, data: 
 @settings(max_examples=50)
 def test_extract_messages_from_list_never_invents_messages(messages: list[JSONDocument]) -> None:
     result = extract_messages_from_list(messages)
-    expected = sum(1 for msg in messages if isinstance(msg, dict) and (msg.get("text") or msg.get("content")))
+    expected = sum(1 for msg in messages if msg.get("text") or msg.get("content"))
     assert len(result) <= expected
 
 
@@ -299,11 +299,7 @@ def test_claude_code_message_type_contract(msg: JSONDocument) -> None:
         # says "user" or "assistant".
         raw_content = message.get("content") if isinstance(message, dict) else None
         content_list = raw_content if isinstance(raw_content, list) else []
-        if any(
-            isinstance(block, dict) and block.get("type") == "tool_result"
-            for block in content_list
-            if isinstance(block, dict)
-        ):
+        if any(block.get("type") == "tool_result" for block in content_list if isinstance(block, dict)):
             assert parsed.role in {inner_role, "tool"}
         else:
             assert parsed.role == inner_role

--- a/tests/unit/sources/test_source_laws.py
+++ b/tests/unit/sources/test_source_laws.py
@@ -130,7 +130,7 @@ def _parsed_message(
 ) -> ParsedMessage:
     return ParsedMessage(
         provider_message_id=provider_message_id,
-        role=Role.normalize(role) if isinstance(role, str) else role,
+        role=role if isinstance(role, Role) else Role.normalize(role),
         text=text,
     )
 

--- a/tests/unit/test_protocol_conformance.py
+++ b/tests/unit/test_protocol_conformance.py
@@ -253,20 +253,20 @@ class TestParserModuleInterface:
     def test_chatgpt_exports_parse_and_looks_like(self) -> None:
         import polylogue.sources.parsers.chatgpt as m
 
-        assert callable(m.parse) and callable(m.looks_like)
+        assert hasattr(m, "parse") and hasattr(m, "looks_like")
 
     def test_codex_exports_parse_and_looks_like(self) -> None:
         import polylogue.sources.parsers.codex as m
 
-        assert callable(m.parse) and callable(m.looks_like)
+        assert hasattr(m, "parse") and hasattr(m, "looks_like")
 
     def test_claude_exports_both_parse_functions_and_detectors(self) -> None:
         import polylogue.sources.parsers.claude as m
 
-        assert callable(m.parse_code) and callable(m.parse_ai)
-        assert callable(m.looks_like_code) and callable(m.looks_like_ai)
+        assert hasattr(m, "parse_code") and hasattr(m, "parse_ai")
+        assert hasattr(m, "looks_like_code") and hasattr(m, "looks_like_ai")
         # Symmetric aliases for interface parity with chatgpt/codex
-        assert callable(m.parse) and callable(m.looks_like)
+        assert hasattr(m, "parse") and hasattr(m, "looks_like")
 
     def test_drive_exports_parse_chunked_prompt_and_looks_like(self) -> None:
         import polylogue.sources.parsers.drive as m

--- a/tests/unit/ui/test_tui.py
+++ b/tests/unit/ui/test_tui.py
@@ -353,7 +353,7 @@ async def test_dark_mode_toggle(storage_repository: ConversationRepository) -> N
         await pilot.press("d")
         await pilot.pause()
         assert pilot.app.theme == "textual-dark"
-        assert pilot.app.query_one(Dashboard)
+        assert pilot.app.query_one(Dashboard) is not None
 
 
 @pytest.mark.asyncio
@@ -427,7 +427,7 @@ async def test_worker_failure_recovery(
         await _wait_workers(pilot)
 
         # App should still be running (Dashboard catches errors and notifies)
-        assert pilot.app.query_one(Dashboard)
+        assert pilot.app.query_one(Dashboard) is not None
 
         # Stat cards should still exist (may show "Loading...")
         stat = pilot.app.query_one("#stat-conversations", StatCard)
@@ -445,9 +445,9 @@ async def test_app_startup(storage_repository: ConversationRepository) -> None:
     app = _make_app(storage_repository)
 
     async with app.run_test() as pilot:
-        assert pilot.app.query_one(Dashboard)
-        assert pilot.app.query_one("#stat-conversations")
-        assert pilot.app.query_one("#stat-messages")
+        assert pilot.app.query_one(Dashboard) is not None
+        assert pilot.app.query_one("#stat-conversations") is not None
+        assert pilot.app.query_one("#stat-messages") is not None
 
         await _wait_workers(pilot, selector="#stat-conversations")
 

--- a/tests/visual/conftest.py
+++ b/tests/visual/conftest.py
@@ -377,5 +377,5 @@ def get_text(base_url: str, path: str) -> tuple[int, str, str]:
         with urlopen(req, timeout=10) as resp:
             return resp.status, resp.headers.get("Content-Type", ""), resp.read().decode()
     except HTTPError as exc:
-        body = exc.read().decode() if exc.fp else ""
+        body = exc.read().decode()
         return exc.code, exc.headers.get("Content-Type", ""), body


### PR DESCRIPTION
## Summary

Pack B of #1062: tighten native tooling so the suppression-discovery
scanner becomes a backstop, not the primary enforcement mechanism.
Adds five enforcement layers — bracketed type-ignore, skip discipline,
xfail discipline, no-cover justification, and an audited config-exclude
surface — and burns the codebase down to zero discipline violations.

## Problem

After Pack A landed (RUF100, strict xfail, first suppression burn-down),
the remaining gap was that `# type: ignore` could still be bare, pytest
skips could still ship without substantive reasons, xfails could still
land without issue links or `strict=True`, and broad `# pragma: no
cover` directives could blanket entire functions without an inline
justification. Native tools (mypy, ruff, pytest) had latent codes that
could enforce these directly, but they were not enabled, so the only
gate was the custom scanner — which only counted occurrences.

## Solution

**Layer 1 — mypy native strictness.**
`[tool.mypy].enable_error_code = [ignore-without-code, redundant-self,
redundant-expr, possibly-undefined, truthy-bool, truthy-iterable,
unused-awaitable]`. The primary discipline gate is
`ignore-without-code`, which forbids bare `# type: ignore`. Enabling
the broader codes surfaced 94 latent issues across the codebase;
this PR fixes every one (materializing `Iterable[Row]` via `list(...)`,
removing dead `or`/`isinstance` branches, initializing branch-scoped
locals, awaiting AwaitComplete/AwaitMount, narrowing query_one
assertions to `is not None`, etc.) so the gate ships green.

**Layer 2 — pytest skip discipline.**
The scanner now AST-extracts `reason=` from `pytest.skip`,
`pytest.mark.skip`, and `pytest.mark.skipif` calls (literals and
f-strings) and rejects empty / `TODO` / `skip` / `todo` reasons.

**Layer 3 — pytest xfail discipline.**
`pytest.mark.xfail` and `pytest.xfail` must carry a `reason=` that
references an issue (`#NNN`), and the marker form must declare
`strict=True`. The two existing xfails already satisfy both rules.

**Layer 4 — `# pragma: no cover` classification.**
Every pragma must include an inline justification comment (separator:
hyphen, en-dash, em-dash, hash, or colon). Burn-down: five existing
pragmas in `polylogue/cli/__main__.py` and
`devtools/verify_schema_roundtrip.py` gained justifications.

**Layer 5 — config-exclude audit.**
Surveyed `[tool.ruff]`, `[tool.mypy]`, `[tool.pytest.ini_options]`,
`[tool.coverage.*]`. Findings: coverage and pytest have no excludes;
mypy has no exclude list. Ruff's exclude list contains only standard
build/cache directories — added inline comments documenting the audit
and per-directory justification.

**New synthetic tests** in
`tests/unit/devtools/test_verify_suppressions.py` cover each rule, and
two new repo-level backstop tests
(`test_suppression_discipline.py`, `test_no_cover_pragmas.py`) pin the
load-bearing invariants independent of the scanner. A new committed-
codebase regression test (`test_committed_codebase_passes_discipline`)
fails fast if any non-compliant skip/xfail/no-cover/type-ignore lands
on master.

### Counts

- bare `# type: ignore` offenders fixed: 0 (none existed; the rule is
  now structurally enforced going forward)
- `# pragma: no cover` justifications added: 5
- mypy errors fixed by enabling the new codes: 94
- discipline violations on master after the burn-down: 0
- new tests: 7 in `test_verify_suppressions.py` plus 3 backstop tests
- config-exclude actions: documentation added; no excludes removed
  because all existing entries are vendored/build directories

## Verification

```
nix develop -c mypy                      # Success: no issues found in 1323 source files
nix develop -c ruff check polylogue tests devtools  # All checks passed!
nix develop -c devtools verify-suppressions --json --enforce-discovered
    # blocking=false, discipline_violations_total=0, unregistered_total=0
nix develop -c devtools verify --quick   # exit_code=0
nix develop -c pytest tests/unit/devtools/test_verify_suppressions.py tests/unit/devtools/test_suppression_discipline.py tests/unit/devtools/test_no_cover_pragmas.py
    # 17 passed
```

`devtools verify --seed-testmon --skip-slow` reports 3 inherited
failures unrelated to this PR (one golden-markdown snapshot drift in
`tests/unit/ui/test_ui_visual.py` and two property-test failures in
`tests/property/test_filter_chain_laws.py`), reproduced on master with
a clean `git stash`.

Ref #1062