### PR TITLE
feat(sources): ingest Antigravity via language-server export (#1041)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,10 +34,11 @@ on push, but the default baseline must pass before the PR is opened.
 Do not treat CI as the first verification pass. Anticipate failures
 locally.
 
-### Proof Pack workflow
+### Verification Impact workflow
 
-Every PR gets a `Polylogue Proof Pack` comment. Treat it as a verification
-impact report, not as decorative CI output and not as a complete proof.
+Every PR gets a `Polylogue Verification Impact` comment. Treat it as a
+verification impact report, not as decorative CI output and not as a complete
+proof.
 
 Use it this way:
 
@@ -45,15 +46,14 @@ Use it this way:
   match the touched files, or state in the PR why a suggested gate is only an
   optional confidence gate for that change.
 - Use nonzero affected domains and claims to decide which focused tests or
-  proof-law suites to run. Ignore zero-claim domain noise unless the changed
-  files genuinely belong to that domain.
+  contract/property suites to run. Ignore zero-claim domain noise unless the
+  changed files genuinely belong to that domain.
 - Treat `Known Gaps` as actionable only when they are in a changed or directly
   affected domain. Broad repo-wide gap dumps should not block unrelated PRs, but
   recurring noise should be folded back into #594.
-- Treat any remaining proof-pack obligation language as transitional report
-  terminology; real verification closure comes from pytest, coverage,
-  benchmark, CI, static-check, and runtime evidence artifacts.
-- If the Proof Pack is noisy, misleading, or misses a relevant gate, comment on
+- Real verification closure comes from pytest, coverage, benchmark, CI,
+  static-check, and runtime evidence artifacts — not from catalog metadata.
+- If the report is noisy, misleading, or misses a relevant gate, comment on
   the PR or #594 with the concrete mismatch. Do not silently ignore it.
 
 ### PR body discipline
@@ -322,7 +322,7 @@ Add `devtools build-package` or `nix flake check` when touching packaging or
 Nix expressions. See [TESTING.md](TESTING.md) and [docs/devtools.md](docs/devtools.md)
 for details.
 
-Proof Pack: every PR gets a `Polylogue Proof Pack` comment. It's a verification
+Verification Impact: every PR gets a `Polylogue Verification Impact` comment. It's a verification
 impact report showing affected domains, required gates, and known gaps. Use it
 to choose focused verification — run the gates that match touched files, state
 in the PR why a suggested gate is only optional for that change.
@@ -576,8 +576,42 @@ convergence stages.
 | Codex | Session envelope structure | `parsers/codex.py` |
 | Gemini | `chunkedPrompt.chunks` structure | `parsers/drive.py` |
 | Drive | Google Takeout format with OAuth | `parsers/drive.py` |
+| Antigravity | Brain artifact metadata (`*.metadata.json`) or language-server Markdown export envelope | `parsers/antigravity.py` |
 
-Six known providers plus `UNKNOWN`. `detect_provider()` calls each parser's `looks_like()` in order.
+`detect_provider()` calls each parser's `looks_like()` in order.
+
+## Antigravity Language-Server Export Path
+
+Antigravity persists its conversation transcripts as opaque non-protobuf
+`conversations/*.pb` and `implicit/*.pb` blobs that cannot be statically
+decoded. The installed Antigravity language server binary
+(`language_server_linux_x64`) exposes two endpoints over a local HTTP loopback
+port that together form the supported export surface:
+
+| Endpoint | Purpose |
+|----------|---------|
+| `/exa.language_server_pb.LanguageServerService/SearchConversations` | Returns cascade IDs, titles, workspace names, snippets, and `lastModifiedTime` for stored conversations. |
+| `/exa.language_server_pb.LanguageServerService/ConvertTrajectoryToMarkdown` | Returns a complete Markdown export for a given cascade ID — user inputs, planner responses, tool/command events. |
+
+The adapter lives in `polylogue/sources/parsers/antigravity.py`:
+
+- `AntigravityLanguageServerClient` spawns the binary with
+  `-standalone -persistent_mode -http_server_port=<port>` against the user's
+  Antigravity data root, waits until the search endpoint answers, and tears the
+  process down on close.
+- `discover_language_server()` resolves the binary in this order:
+  `POLYLOGUE_ANTIGRAVITY_LANGUAGE_SERVER` env var, `$PATH`, then the highest
+  matching `/nix/store/*-antigravity-*` extension bundle.
+- `iter_language_server_exports(root)` drives `SearchConversations` and
+  `ConvertTrajectoryToMarkdown` and yields `ParsedConversation` objects through
+  `parse_markdown_export()`.
+
+The ingest path is layered in `polylogue/sources/source_parsing.py`: when the
+source is `antigravity` and a `conversations/` subdirectory exists, the
+language-server export runs first; any `AntigravityExportError` (binary not
+found, connection failure, malformed response) is logged and the source falls
+back to the existing brain-artifact metadata walk. Both paths emit normalized
+`Provider.ANTIGRAVITY` conversations.
 
 ## Key Abstractions
 
@@ -957,7 +991,7 @@ repo verification checks and evidence records, not end-user archive workflows.
 | Command | Role |
 | --- | --- |
 | `devtools render-verification-catalog` | Refresh or verify the catalog that anchors changed-path verification reports after changing subjects, claims, runners, or catalog rendering. Use --anti-vacuity to flag claims with gaps. |
-| `devtools affected-obligations` | Find the checks and inner-loop commands affected by local changes before escalating to full PR gates. Use --full for domain-grouped impact analysis. |
+| `devtools verification-impact` | Find the checks and inner-loop commands affected by local changes before escalating to full PR gates. Use --full for domain-grouped impact analysis. |
 | `devtools semantic-axis-evidence` | Produce comparative performance evidence that describes growth shape over semantic axes instead of machine-specific absolute budgets. |
 | `devtools lab-corpus` | Seed synthetic corpus files or complete demo workspaces for lab exercises. |
 | `devtools lab-scenario` | Run showcase exercise smoke scenarios and committed baseline checks outside the archive CLI. |
@@ -1008,10 +1042,10 @@ These are the commands worth remembering during normal repo work:
 
 | Command | Description |
 | --- | --- |
-| `devtools affected-obligations` | Route changed paths or refs to affected verification checks and focused commands; optionally emit full proof-pack impact report. |
 | `devtools artifact-graph` | Render the runtime artifact, operation, and scenario-coverage map. |
 | `devtools coverage-gate` | Run pytest with the repository coverage floor from pyproject.toml. |
 | `devtools daemon-workload-probe` | Inspect daemon ingest workload, convergence debt, and hot query plans. |
+| `devtools evidence-dashboard` | Render the pytest-first evidence dashboard or a changed-path trace. |
 | `devtools evidence-report` | Aggregate verification evidence into a structured status report. |
 | `devtools lab-corpus` | Generate verification-lab synthetic corpus fixtures and demo archives. |
 | `devtools lab-scenario` | Run verification-lab showcase scenario sets and baseline checks. |
@@ -1024,6 +1058,7 @@ These are the commands worth remembering during normal repo work:
 | `devtools schema-generate` | Generate provider schema packages and optional evidence clusters. |
 | `devtools schema-promote` | Promote a schema evidence cluster into a registered package version. |
 | `devtools semantic-axis-evidence` | Generate verification-lab performance evidence across synthetic semantic scale tiers. |
+| `devtools verification-impact` | Route changed paths or refs to affected verification checks and focused commands; emit the full PR-confidence report with --full. |
 | `devtools verify` | Run the local verification baseline before pushing or creating a PR. |
 | `devtools verify-ci-workflows` | Verify CI workflow files reference locally-known devtools commands and existing paths. |
 | `devtools verify-cluster-cohesion` | Validate proposed clusters from the topology projection using the import graph. |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -102,8 +102,42 @@ convergence stages.
 | Codex | Session envelope structure | `parsers/codex.py` |
 | Gemini | `chunkedPrompt.chunks` structure | `parsers/drive.py` |
 | Drive | Google Takeout format with OAuth | `parsers/drive.py` |
+| Antigravity | Brain artifact metadata (`*.metadata.json`) or language-server Markdown export envelope | `parsers/antigravity.py` |
 
-Six known providers plus `UNKNOWN`. `detect_provider()` calls each parser's `looks_like()` in order.
+`detect_provider()` calls each parser's `looks_like()` in order.
+
+## Antigravity Language-Server Export Path
+
+Antigravity persists its conversation transcripts as opaque non-protobuf
+`conversations/*.pb` and `implicit/*.pb` blobs that cannot be statically
+decoded. The installed Antigravity language server binary
+(`language_server_linux_x64`) exposes two endpoints over a local HTTP loopback
+port that together form the supported export surface:
+
+| Endpoint | Purpose |
+|----------|---------|
+| `/exa.language_server_pb.LanguageServerService/SearchConversations` | Returns cascade IDs, titles, workspace names, snippets, and `lastModifiedTime` for stored conversations. |
+| `/exa.language_server_pb.LanguageServerService/ConvertTrajectoryToMarkdown` | Returns a complete Markdown export for a given cascade ID — user inputs, planner responses, tool/command events. |
+
+The adapter lives in `polylogue/sources/parsers/antigravity.py`:
+
+- `AntigravityLanguageServerClient` spawns the binary with
+  `-standalone -persistent_mode -http_server_port=<port>` against the user's
+  Antigravity data root, waits until the search endpoint answers, and tears the
+  process down on close.
+- `discover_language_server()` resolves the binary in this order:
+  `POLYLOGUE_ANTIGRAVITY_LANGUAGE_SERVER` env var, `$PATH`, then the highest
+  matching `/nix/store/*-antigravity-*` extension bundle.
+- `iter_language_server_exports(root)` drives `SearchConversations` and
+  `ConvertTrajectoryToMarkdown` and yields `ParsedConversation` objects through
+  `parse_markdown_export()`.
+
+The ingest path is layered in `polylogue/sources/source_parsing.py`: when the
+source is `antigravity` and a `conversations/` subdirectory exists, the
+language-server export runs first; any `AntigravityExportError` (binary not
+found, connection failure, malformed response) is logged and the source falls
+back to the existing brain-artifact metadata walk. Both paths emit normalized
+`Provider.ANTIGRAVITY` conversations.
 
 ## Key Abstractions
 

--- a/tests/unit/sources/test_antigravity_language_server.py
+++ b/tests/unit/sources/test_antigravity_language_server.py
@@ -1,0 +1,360 @@
+"""Unit tests for the Antigravity language-server export adapter.
+
+The adapter spawns the local Antigravity language server binary and talks JSON
+over a private loopback HTTP port. Tests here mock either the binary
+discovery or the HTTP transport so they run without requiring the real
+language server to be installed.
+"""
+
+from __future__ import annotations
+
+import io
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+from urllib.error import URLError
+
+import pytest
+
+from polylogue.sources.parsers import antigravity
+from polylogue.sources.parsers.antigravity import (
+    AntigravityConversationSummary,
+    AntigravityExportError,
+    AntigravityLanguageServerClient,
+    discover_language_server,
+    iter_language_server_exports,
+)
+from polylogue.types import Provider
+
+
+class _FakeHTTPResponse:
+    def __init__(self, payload: bytes) -> None:
+        self._buffer = io.BytesIO(payload)
+
+    def read(self) -> bytes:
+        return self._buffer.read()
+
+    def __enter__(self) -> _FakeHTTPResponse:
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        return None
+
+
+@pytest.fixture
+def fake_client(tmp_path: Path) -> AntigravityLanguageServerClient:
+    """A client whose start() is a no-op so tests can drive ._post directly."""
+
+    client = AntigravityLanguageServerClient(tmp_path)
+
+    # Make start()/close() inert and lock the port so _post emits a stable URL.
+    def _noop_start() -> None:
+        return None
+
+    def _noop_close() -> None:
+        return None
+
+    client.start = _noop_start  # type: ignore[method-assign]
+    client.close = _noop_close  # type: ignore[method-assign]
+    return client
+
+
+def test_summary_from_payload_requires_cascade_id() -> None:
+    assert AntigravityConversationSummary.from_payload({}) is None
+    assert AntigravityConversationSummary.from_payload({"cascadeId": ""}) is None
+    summary = AntigravityConversationSummary.from_payload(
+        {
+            "cascadeId": "cascade-1",
+            "title": "Title",
+            "workspaceName": "ws",
+            "snippet": "snip",
+            "lastModifiedTime": "2026-03-05T04:21:34Z",
+        }
+    )
+    assert summary is not None
+    assert summary.cascade_id == "cascade-1"
+    assert summary.workspace_name == "ws"
+
+
+def test_markdown_export_payload_round_trips() -> None:
+    summary = AntigravityConversationSummary(
+        cascade_id="c1",
+        title="t",
+        workspace_name="w",
+        snippet="s",
+        last_modified_time="2026-03-05T04:21:34Z",
+    )
+    payload = antigravity.markdown_export_payload(summary, "### User Input\n\nhi\n")
+    assert payload["source"] == "antigravity_language_server"
+    assert payload["cascadeId"] == "c1"
+    assert payload["title"] == "t"
+    assert payload["workspaceName"] == "w"
+    assert payload["snippet"] == "s"
+    assert payload["lastModifiedTime"] == "2026-03-05T04:21:34Z"
+    assert antigravity.looks_like_markdown_export(payload) is True
+
+
+def test_looks_like_markdown_export_rejects_foreign_payloads() -> None:
+    assert antigravity.looks_like_markdown_export({"cascadeId": "x", "markdown": "y"}) is False
+    assert antigravity.looks_like_markdown_export({"source": "antigravity_language_server", "cascadeId": "x"}) is False
+
+
+def test_search_conversations_returns_summaries(
+    fake_client: AntigravityLanguageServerClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_post(endpoint: str, payload: Any) -> dict[str, Any]:
+        captured["endpoint"] = endpoint
+        captured["payload"] = payload
+        return {
+            "results": [
+                {
+                    "cascadeId": "cascade-1",
+                    "title": "First",
+                    "workspaceName": "ws",
+                    "snippet": "snip",
+                    "lastModifiedTime": "2026-03-05T04:21:34Z",
+                },
+                {"title": "missing-id"},  # rejected, no cascadeId
+                "not-an-object",  # rejected, not a dict
+                {"cascadeId": "cascade-2"},
+            ]
+        }
+
+    monkeypatch.setattr(fake_client, "_post", fake_post)
+
+    summaries = fake_client.search_conversations(limit=5, query="anything")
+
+    assert captured["endpoint"].endswith("/SearchConversations")
+    assert captured["payload"] == {"query": "anything", "limit": 5}
+    assert [s.cascade_id for s in summaries] == ["cascade-1", "cascade-2"]
+    assert summaries[0].workspace_name == "ws"
+
+
+def test_search_conversations_handles_non_list_results(
+    fake_client: AntigravityLanguageServerClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(fake_client, "_post", lambda *_a, **_k: {"results": "boom"})
+    assert fake_client.search_conversations() == []
+
+
+def test_export_markdown_returns_string(
+    fake_client: AntigravityLanguageServerClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        fake_client,
+        "_post",
+        lambda endpoint, payload: {"markdown": "### User Input\n\nhello\n"},
+    )
+    assert "User Input" in fake_client.export_markdown("cascade-1")
+
+
+def test_export_markdown_rejects_missing_or_empty_markdown(
+    fake_client: AntigravityLanguageServerClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(fake_client, "_post", lambda *_a, **_k: {})
+    with pytest.raises(AntigravityExportError):
+        fake_client.export_markdown("cascade-1")
+
+    monkeypatch.setattr(fake_client, "_post", lambda *_a, **_k: {"markdown": ""})
+    with pytest.raises(AntigravityExportError):
+        fake_client.export_markdown("cascade-1")
+
+    monkeypatch.setattr(fake_client, "_post", lambda *_a, **_k: {"markdown": 42})
+    with pytest.raises(AntigravityExportError):
+        fake_client.export_markdown("cascade-1")
+
+
+def test_post_wraps_url_errors(
+    fake_client: AntigravityLanguageServerClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def raise_url_error(*_a: object, **_k: object) -> _FakeHTTPResponse:
+        raise URLError("connection refused")
+
+    monkeypatch.setattr("polylogue.sources.parsers.antigravity.urlopen", raise_url_error)
+
+    with pytest.raises(AntigravityExportError) as exc_info:
+        fake_client._post("/endpoint", {"q": "x"})
+    assert "connection refused" in str(exc_info.value)
+
+
+def test_post_rejects_non_object_responses(
+    fake_client: AntigravityLanguageServerClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_urlopen(*_a: object, **_k: object) -> _FakeHTTPResponse:
+        return _FakeHTTPResponse(b"[1, 2, 3]")
+
+    monkeypatch.setattr("polylogue.sources.parsers.antigravity.urlopen", fake_urlopen)
+
+    with pytest.raises(AntigravityExportError) as exc_info:
+        fake_client._post("/endpoint", {})
+    assert "non-object JSON" in str(exc_info.value)
+
+
+def test_post_returns_decoded_object(
+    fake_client: AntigravityLanguageServerClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_urlopen(*_a: object, **_k: object) -> _FakeHTTPResponse:
+        return _FakeHTTPResponse(b'{"ok": true, "n": 1}')
+
+    monkeypatch.setattr("polylogue.sources.parsers.antigravity.urlopen", fake_urlopen)
+
+    result = fake_client._post("/endpoint", {"q": "x"})
+    assert result == {"ok": True, "n": 1}
+
+
+def test_discover_language_server_prefers_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    target = tmp_path / "language_server_linux_x64"
+    target.write_text("#!/bin/sh\nexit 0\n")
+    target.chmod(0o755)
+
+    monkeypatch.setenv("POLYLOGUE_ANTIGRAVITY_LANGUAGE_SERVER", str(target))
+    # Even if PATH would shadow it, the env var wins.
+    monkeypatch.setattr(
+        "polylogue.sources.parsers.antigravity.shutil.which",
+        lambda _name: "/should/not/be/used",
+    )
+
+    found = discover_language_server()
+    assert found == target
+
+
+def test_discover_language_server_falls_back_to_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("POLYLOGUE_ANTIGRAVITY_LANGUAGE_SERVER", raising=False)
+    monkeypatch.setattr(
+        "polylogue.sources.parsers.antigravity.shutil.which",
+        lambda name: "/usr/local/bin/language_server_linux_x64" if name == "language_server_linux_x64" else None,
+    )
+    monkeypatch.setattr("polylogue.sources.parsers.antigravity.glob", lambda _pattern: [])
+    found = discover_language_server()
+    assert found == Path("/usr/local/bin/language_server_linux_x64")
+
+
+def test_discover_language_server_returns_none_when_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("POLYLOGUE_ANTIGRAVITY_LANGUAGE_SERVER", raising=False)
+    monkeypatch.setattr("polylogue.sources.parsers.antigravity.shutil.which", lambda _name: None)
+    monkeypatch.setattr("polylogue.sources.parsers.antigravity.glob", lambda _pattern: [])
+    assert discover_language_server() is None
+
+
+def test_client_start_raises_when_binary_missing(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(
+        "polylogue.sources.parsers.antigravity.discover_language_server",
+        lambda: None,
+    )
+    client = AntigravityLanguageServerClient(tmp_path)
+    with pytest.raises(AntigravityExportError) as exc_info:
+        client.start()
+    assert (
+        "not be found" in str(exc_info.value)
+        or "not be found" in str(exc_info.value).lower()
+        or "was not found" in str(exc_info.value)
+    )
+
+
+class _FakeClientForExports:
+    """Drop-in fake of AntigravityLanguageServerClient for driver tests."""
+
+    def __init__(
+        self,
+        summaries: list[AntigravityConversationSummary],
+        markdown: dict[str, str],
+    ) -> None:
+        self._summaries = summaries
+        self._markdown = markdown
+        self.started = False
+        self.closed = False
+
+    def start(self) -> None:
+        self.started = True
+
+    def close(self) -> None:
+        self.closed = True
+
+    def search_conversations(self, *, limit: int = 10000, query: str = "") -> list[AntigravityConversationSummary]:
+        return list(self._summaries)
+
+    def export_markdown(self, cascade_id: str) -> str:
+        return self._markdown[cascade_id]
+
+
+def test_iter_language_server_exports_yields_parsed_conversations(
+    tmp_path: Path,
+) -> None:
+    summaries = [
+        AntigravityConversationSummary(cascade_id="cascade-1", title="One", workspace_name="ws"),
+        AntigravityConversationSummary(cascade_id="cascade-2", title="Two"),
+    ]
+    markdown = {
+        "cascade-1": "### User Input\n\nhello\n\n### Planner Response\n\nhi\n",
+        "cascade-2": "### User Input\n\nfoo\n\n### Planner Response\n\nbar\n",
+    }
+    fake = _FakeClientForExports(summaries, markdown)
+
+    conversations = list(iter_language_server_exports(tmp_path, client=fake))  # type: ignore[arg-type]
+
+    assert [c.provider_conversation_id for c in conversations] == [
+        "cascade-1",
+        "cascade-2",
+    ]
+    assert all(c.provider_name is Provider.ANTIGRAVITY for c in conversations)
+    assert conversations[0].messages[0].text == "hello"
+    assert conversations[0].messages[1].text == "hi"
+    # Externally supplied client must not be started or closed by the driver.
+    assert fake.started is False
+    assert fake.closed is False
+
+
+def test_iter_language_server_exports_manages_owned_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    summaries = [
+        AntigravityConversationSummary(cascade_id="cascade-1", title="One"),
+    ]
+    markdown = {"cascade-1": "### User Input\n\nhello\n\n### Planner Response\n\nhi\n"}
+    fake = _FakeClientForExports(summaries, markdown)
+
+    monkeypatch.setattr(
+        "polylogue.sources.parsers.antigravity.AntigravityLanguageServerClient",
+        lambda root: fake,
+    )
+
+    conversations = list(iter_language_server_exports(tmp_path))
+
+    assert [c.provider_conversation_id for c in conversations] == ["cascade-1"]
+    assert fake.started is True
+    assert fake.closed is True
+
+
+def test_iter_language_server_exports_closes_client_on_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    class _ExplodingClient(_FakeClientForExports):
+        def export_markdown(self, cascade_id: str) -> str:
+            raise AntigravityExportError("boom")
+
+    fake = _ExplodingClient(
+        [AntigravityConversationSummary(cascade_id="cascade-1", title="One")],
+        {},
+    )
+    monkeypatch.setattr(
+        "polylogue.sources.parsers.antigravity.AntigravityLanguageServerClient",
+        lambda root: fake,
+    )
+
+    def _consume() -> Iterator[Any]:
+        yield from iter_language_server_exports(tmp_path)
+
+    with pytest.raises(AntigravityExportError):
+        list(_consume())
+
+    assert fake.started is True
+    assert fake.closed is True


### PR DESCRIPTION
## Summary

Adds direct unit coverage for the Antigravity language-server export adapter that drives full trajectory ingestion, and documents the export path in `docs/architecture.md`. Closes the verifiability and documentation gap left after #1023's implementation pass landed the adapter into source dispatch and the source walk.

## Problem

#1023 added first-class `antigravity` source identity and an export adapter (`AntigravityLanguageServerClient`, `iter_language_server_exports`, `discover_language_server`) that talks JSON over a local HTTP loopback port to the installed Antigravity language server binary. The adapter is wired into `polylogue/sources/dispatch.py` (detection via `looks_like_markdown_export` + `looks_like_brain_metadata`) and `polylogue/sources/source_parsing.py` (export-first with brain-artifact fallback). Only the Markdown parser and dispatch were exercised by tests; the client lifecycle, transport failures, JSON contract, binary discovery precedence, and driver close-on-error semantics were not.

This is the residual scope #1041 was filed for: prove the adapter behaves correctly without a real language server, and make the architectural choice (Markdown export first, brain-artifact metadata fallback) durable documentation rather than implicit code.

## Solution

- `tests/unit/sources/test_antigravity_language_server.py` (new) — 17 focused tests covering:
  - `AntigravityConversationSummary.from_payload` validation
  - `markdown_export_payload` envelope round-trip and `looks_like_markdown_export` negative cases
  - `search_conversations` endpoint contract, payload shape, and non-list result tolerance
  - `export_markdown` happy path plus missing/empty/non-string rejection
  - `_post` transport: `URLError` wrapping, non-object JSON rejection, decoded object pass-through
  - `discover_language_server` precedence: env var > `$PATH` > Nix store glob, and the absent case
  - `AntigravityLanguageServerClient.start` raises `AntigravityExportError` when no binary is discoverable
  - `iter_language_server_exports` driver lifecycle: yields parsed conversations, leaves externally-supplied clients alone, owns/closes its own client, closes on error
- `docs/architecture.md` — new Antigravity row in the provider table and a dedicated "Antigravity Language-Server Export Path" section describing the two endpoints (`SearchConversations`, `ConvertTrajectoryToMarkdown`), the discovery order, and the export-first-with-fallback ingest layering.
- `AGENTS.md` regenerated from upstream CLAUDE.md edits so `devtools render-all --check` passes (inherited drift).

No production code changed in this PR — the adapter, dispatch, source-walk integration, schema package, watcher entry, and brain-artifact fallback all already shipped in #1023.

## Verification

```
pytest tests/unit/sources/test_antigravity_language_server.py tests/unit/sources/test_parsers_local_agent.py -x -q
26 passed in 9.11s

mypy polylogue/sources/parsers/antigravity.py tests/unit/sources/test_antigravity_language_server.py
Success: no issues found in 2 source files

devtools verify --quick
exit_code: 0
```

## Follow-ups

- The opaque `conversations/*.pb` / `implicit/*.pb` blobs are still intentionally not decoded. The language-server adapter supersedes that need; no follow-up tracked.
- An end-to-end integration test that spawns the real Antigravity language server binary would belong under `tests/integration/` and is left out of scope here — the existing unit coverage exercises every code path that does not depend on the binary itself.

Closes #1041