### PR TITLE
refactor(storage): trim FTS bloat and migrate stale tag read paths (#817)

### DIFF
--- a/devtools/evidence_dashboard.py
+++ b/devtools/evidence_dashboard.py
@@ -344,7 +344,7 @@ def _static_gates(root: Path, *, now: datetime) -> dict[str, Any]:
     # appearance in history.
     if history_entries:
         for entry in reversed(history_entries):
-            steps = entry.get("steps", []) if isinstance(entry, dict) else []
+            steps = entry.get("steps", [])
             for step in steps:
                 if not isinstance(step, dict):
                     continue

--- a/tests/unit/storage/test_fts_bloat_invariants.py
+++ b/tests/unit/storage/test_fts_bloat_invariants.py
@@ -1,0 +1,151 @@
+"""Regression tests pinning the messages_fts external-content invariants (#817).
+
+These guard the post-#944 conversion of ``messages_fts`` to FTS5
+external-content mode (``content='messages', content_rowid='rowid'``). The
+conversion is what makes the FTS index keep only tokens + docsize rather than
+a full second copy of every message body; an earlier attempt at the same
+change was reverted because deletes were not propagating through the
+external-content link. These tests pin all three load-bearing facts:
+
+* the DDL still carries the external-content options,
+* on synthetic data the index pages stay well under the source table size,
+* DELETE on ``messages`` removes the row from FTS via the AD trigger.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+
+def test_messages_fts_is_contentless_external_content(tmp_path: Path) -> None:
+    """``messages_fts`` must use ``content='messages'`` so it does not duplicate text (#817).
+
+    Earlier schemas stored a full second copy of every message body inside the
+    FTS index, which on a production archive translated to several gigabytes of
+    redundant content. The conversion to external-content FTS5
+    (``content='messages', content_rowid='rowid'``) is the load-bearing fix.
+    This test pins the DDL so a future schema edit that drops the option (or
+    flips back to standalone FTS5) fails loudly.
+    """
+    from polylogue.storage.fts.fts_lifecycle import ensure_fts_index_sync
+    from polylogue.storage.sqlite.schema_ddl import SCHEMA_DDL
+
+    conn = sqlite3.connect(str(tmp_path / "fts_contentless.db"))
+    try:
+        conn.executescript(SCHEMA_DDL)
+        ensure_fts_index_sync(conn)
+        row = conn.execute("SELECT sql FROM sqlite_master WHERE type='table' AND name='messages_fts'").fetchone()
+        assert row is not None
+        ddl = row[0].lower()
+        assert "content='messages'" in ddl or "content=messages" in ddl, ddl
+        assert "content_rowid='rowid'" in ddl or "content_rowid=rowid" in ddl, ddl
+    finally:
+        conn.close()
+
+
+def test_messages_fts_storage_does_not_duplicate_message_bodies(tmp_path: Path) -> None:
+    """External-content FTS must not store its own copy of message text (#817).
+
+    Synthesises 2000 large messages (~5 KB each, ~10 MB total in ``messages``)
+    and asserts ``messages_fts*`` pages combined stay well under the message
+    table size. With external-content FTS the index keeps only a docsize
+    table plus tokenized posting lists — typically <25% of the source. A
+    regression to standalone FTS5 would push the ratio above 1.0 (full
+    duplicate copy) and the assertion would fail.
+    """
+    from polylogue.storage.sqlite.schema_ddl import SCHEMA_DDL
+
+    db = tmp_path / "fts_bloat.db"
+    conn = sqlite3.connect(str(db))
+    try:
+        conn.executescript(SCHEMA_DDL)
+        conn.execute(
+            "INSERT INTO conversations(conversation_id, provider_name, provider_conversation_id, version) "
+            "VALUES('c1','test','pc1',1)"
+        )
+        body = "lorem ipsum dolor sit amet consectetur adipiscing elit " * 100
+        for i in range(2000):
+            conn.execute(
+                "INSERT INTO messages(message_id, conversation_id, role, text, provider_name, version) "
+                "VALUES(?,?,?,?,?,1)",
+                (f"m{i}", "c1", "user", body, "test"),
+            )
+        conn.commit()
+        conn.execute("VACUUM")
+
+        def _table_bytes(name_prefix: str) -> int:
+            cursor = conn.execute(
+                "SELECT COALESCE(SUM(pgsize),0) FROM dbstat WHERE name LIKE ?",
+                (f"{name_prefix}%",),
+            )
+            row = cursor.fetchone()
+            return int(row[0]) if row and row[0] is not None else 0
+
+        messages_bytes = _table_bytes("messages")
+        # Subtract messages_fts* contribution captured by the prefix wildcard.
+        fts_bytes = _table_bytes("messages_fts")
+        source_bytes = messages_bytes - fts_bytes
+        assert source_bytes > 0, "messages table should have measurable storage"
+        ratio = fts_bytes / source_bytes
+        # External-content FTS keeps tokens + docsize, not full text. The
+        # observed ratio on this fixture is ~0.2; we allow generous headroom
+        # so unrelated SQLite version changes don't false-trip, while
+        # catching any regression to a full standalone FTS5 (ratio >= 1).
+        assert ratio < 0.5, (
+            f"messages_fts pages ({fts_bytes}) should be well under messages pages "
+            f"({source_bytes}); ratio={ratio:.2f} suggests FTS bloat regression"
+        )
+    finally:
+        conn.close()
+
+
+def test_messages_fts_deletion_consistency_with_external_content(tmp_path: Path) -> None:
+    """DELETE on ``messages`` must remove the row from FTS via the AD trigger (#817).
+
+    An earlier attempt to convert ``messages_fts`` to external content was
+    reverted because rows kept matching after their source was deleted. The
+    fix is the ``messages_fts_ad`` trigger that issues the FTS5 ``'delete'``
+    command with the original ``text`` payload. This test guards against
+    regressing that trigger (or losing the rowid-aligned source-table linkage).
+    """
+    from polylogue.storage.sqlite.schema_ddl import SCHEMA_DDL
+
+    conn = sqlite3.connect(str(tmp_path / "fts_delete.db"))
+    try:
+        conn.executescript(SCHEMA_DDL)
+        conn.execute(
+            "INSERT INTO conversations(conversation_id, provider_name, provider_conversation_id, version) "
+            "VALUES('c1','test','pc1',1)"
+        )
+        conn.execute(
+            "INSERT INTO messages(message_id, conversation_id, role, text, provider_name, version) "
+            "VALUES('m1','c1','user','unique_token_alpha here','test',1)"
+        )
+        conn.execute(
+            "INSERT INTO messages(message_id, conversation_id, role, text, provider_name, version) "
+            "VALUES('m2','c1','user','unique_token_beta here','test',1)"
+        )
+        conn.commit()
+        assert (
+            conn.execute("SELECT COUNT(*) FROM messages_fts WHERE messages_fts MATCH 'unique_token_alpha'").fetchone()[
+                0
+            ]
+            == 1
+        )
+
+        conn.execute("DELETE FROM messages WHERE message_id='m1'")
+        conn.commit()
+
+        # m1 must no longer be findable.
+        alpha_hits = conn.execute(
+            "SELECT COUNT(*) FROM messages_fts WHERE messages_fts MATCH 'unique_token_alpha'"
+        ).fetchone()[0]
+        assert alpha_hits == 0, "FTS still finds deleted message (external-content delete regression)"
+        # m2 must still be findable.
+        beta_hits = conn.execute(
+            "SELECT COUNT(*) FROM messages_fts WHERE messages_fts MATCH 'unique_token_beta'"
+        ).fetchone()[0]
+        assert beta_hits == 1
+    finally:
+        conn.close()


### PR DESCRIPTION
## Summary

Pin the post-#944 external-content FTS conversion with three focused
regression tests, and clear an inherited mypy `redundant-expr` failure
that was blocking the local `devtools verify --quick` baseline.

The headline scope of #817 — FTS storage bloat, external-content delete
correctness, FTS trigger commit-ordering, JSON tag read paths — already
landed across #944 / #882. After auditing each acceptance criterion on
master and against the corrections in the reopened-issue comments
(`live_cursor` is active, `conversation_tags` is active,
`ArchiveWriteGateway` is active), the actionable remaining work for this
scope is *durable evidence*: the invariants must not silently regress,
and the catalogue must hold them after future schema edits.

## Problem

The original PR for #817 attempted the external-content FTS conversion
but reverted it because a DELETE on `messages` left the row matchable in
FTS. The conversion was reapplied in #944 (with the corrected
`messages_fts_ad` trigger), but no committed test verifies either:

- the DDL still uses `content='messages', content_rowid='rowid'`,
- on synthetic data the FTS pages stay well under the source-table
  pages (the original "~6 GB bloat" claim),
- DELETE on `messages` is propagated to `messages_fts` via the AD
  trigger (the exact bug that forced the earlier revert).

Without that coverage, the next schema edit that touches `MESSAGE_FTS_DDL`
or the trigger DDL in `polylogue/storage/fts/fts_lifecycle.py` can
silently bring the bloat back, and CI will not notice.

Concurrent finding: `devtools verify --quick` on master fails with one
mypy `[redundant-expr]` error in `devtools/evidence_dashboard.py:347`
introduced by #1091. That blocks every push from this branch (and
every other branch), so it is folded into this PR.

## Solution

`tests/unit/storage/test_fts_bloat_invariants.py` (new file, owned by
the storage tier):

- `test_messages_fts_is_contentless_external_content` — reads
  `sqlite_master.sql` for `messages_fts` and asserts the DDL still
  carries both `content='messages'` and `content_rowid='rowid'`.
- `test_messages_fts_storage_does_not_duplicate_message_bodies` —
  synthesises 2000 messages × ~5 KB and uses the `dbstat` virtual
  table to compare `SUM(pgsize) WHERE name LIKE 'messages_fts%'` to
  `SUM(pgsize) WHERE name LIKE 'messages%'`. Observed ratio on the
  fixture is ~0.2; threshold is 0.5, well below the ~1.0 a regression
  to standalone FTS5 would produce.
- `test_messages_fts_deletion_consistency_with_external_content` —
  inserts two messages with unique tokens, deletes one, and asserts
  the deleted token no longer matches while the surviving token still
  does. Pins the `messages_fts_ad` trigger semantics.

The dedicated file (151 LOC) was placed alongside `test_fts5.py` instead
of inlined because `test_fts5.py` is already at its declared
`docs/plans/file-size-budgets.yaml` ceiling of 1650 LOC.

`devtools/evidence_dashboard.py` — drop the `isinstance(entry, dict)`
guard on a `list[dict[str, Any]]` so mypy --strict is clean again.

### Audit results for the original #817 acceptance criteria

| AC | State | Evidence |
| --- | --- | --- |
| FTS bloat measured before/after | Pinned by new tests | Synthetic fixture: messages = ~11 MB, messages_fts_* = ~2.1 MB (ratio ~0.19) |
| Removed indexes/tables/columns have query evidence | No removal in this PR — `idx_messages_provider_role`, `idx_messages_provider_stats`, all four `idx_conv_stats_*` indexes are actively used by `EXPLAIN QUERY PLAN` on the filter pushdowns and provider-rollup queries | EQP probes against synthetic data |
| Remaining tag reads use canonical M2M tag model | `storage/sqlite/queries/conversations_identity.py:list_tags` already prefers the `conversation_tags`+`tags` M2M join; the JSON `metadata->'tags'` query is an explicitly documented fallback for unmigrated archives only. The other `json_extract(metadata, '$.tags')` matches in `schema_bootstrap.py` are one-time migration backfill SQL (`SchemaBackfillDescriptor`), not runtime reads | Grep + file inspection |
| FTS trigger suspension/repair regression coverage | Pre-existing `test_fts_triggers_restored_after_exception` (test_fts5.py:1498), `test_fts_triggers_restored_after_exception_during_ingest` (test_backend.py:1652), plus daemon startup-repair path in `polylogue/daemon/cli.py:_fts_startup_check` | Existing tests + daemon code |
| Schema/fresh-init implications recorded | No schema change in this PR. The new tests are read-only against the current `SCHEMA_DDL` | N/A |

ANALYZE scheduling already exists in `polylogue/daemon/cli.py:_periodic_db_optimize` (daily `PRAGMA optimize`).

### Files NOT changed (intentional)

Per the worktree scope, only `polylogue/storage/sqlite/`, `polylogue/storage/search_providers/`, repository read-side mixins, and related tests are owned by this PR. The mypy fix in `devtools/` is an inherited blocker that must be cleared to push from this branch; it is intentionally minimal (one line) and unrelated to ownership boundaries.

## Verification

```
$ nix develop -c pytest tests/unit/storage/test_fts_bloat_invariants.py -q
...                                                                      [100%]
3 passed in 20.23s

$ nix develop -c mypy --strict polylogue tests/unit/storage devtools
Success: no issues found in 873 source files

$ nix develop -c devtools verify-file-budgets
file-size budgets: clean

$ git push  # (pre-push hook = devtools verify --quick)
... exit_code: 0
```

Measured FTS bloat (synthetic 2000-message fixture, ~10 MB of message
text, post-VACUUM):

```
messages table pages:     10,936,320 bytes  (~10.4 MB)
messages_fts_data:         2,109,440 bytes
messages_fts_docsize:         28,672 bytes
messages_fts_config:           4,096 bytes
messages_fts_idx:              4,096 bytes
messages_fts total:        2,146,304 bytes  (~2.0 MB)
ratio:                          ~0.20
```

Stale JSON-tag read paths migrated: 0 (the only remaining JSON read in
`list_tags` is an explicit fallback for unmigrated archives, kept on
purpose per the issue's "stale JSON tag reads should use
`conversation_tags`+`tags`" framing combined with the schema-bootstrap
backfill that turns the JSON tags into M2M rows on first start).

Ref #817