### PR TITLE
feat(devtools): comparable daemon-workload-probe reports for convergence proofs (#845)

### DIFF
--- a/devtools/daemon_workload_probe.py
+++ b/devtools/daemon_workload_probe.py
@@ -1,15 +1,60 @@
-"""Read-only daemon workload probe for live ingest and convergence hot paths."""
+"""Read-only daemon workload probe for live ingest and convergence hot paths.
+
+The probe captures a stable, JSON-serializable snapshot of daemon-relevant
+state that can be diffed across convergence cycles.  Operators run::
+
+    devtools daemon-workload-probe --json > before.json
+    # ...run convergence work...
+    devtools daemon-workload-probe --json > after.json
+    devtools daemon-workload-probe --compare before.json after.json
+
+to produce structured before/after evidence (see issue #845).
+"""
 
 from __future__ import annotations
 
 import argparse
 import json
 import sqlite3
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
 from polylogue.paths import db_path as default_db_path
 from polylogue.storage.sqlite.connection_profile import open_readonly_connection
+
+# Bumped when the JSON shape gains new top-level keys or changes a field type.
+# The compare path uses this to refuse incompatible inputs loudly.
+REPORT_VERSION = 1
+
+# Tables whose row counts form the convergence "boundary" — daemon work moves
+# rows into and out of these tables, so the deltas describe convergence shape.
+_BOUNDARY_TABLES: tuple[str, ...] = (
+    "raw_conversations",
+    "conversations",
+    "messages",
+    "content_blocks",
+    "blob_links",
+    "messages_fts_docsize",
+    "action_events",
+    "action_events_fts_docsize",
+    "message_embeddings",
+    "session_profile",
+    "live_ingest_attempt",
+    "live_convergence_debt",
+    "pending_blob_refs",
+)
+
+# Expected FTS-sync triggers.  A missing trigger means the FTS index can drift
+# silently (suspended for bulk operations and never restored, for example).
+_EXPECTED_FTS_TRIGGERS: tuple[str, ...] = (
+    "messages_fts_ai",
+    "messages_fts_ad",
+    "messages_fts_au",
+    "action_events_fts_ai",
+    "action_events_fts_ad",
+    "action_events_fts_au",
+)
 
 
 def _table_exists(conn: sqlite3.Connection, table: str) -> bool:
@@ -101,7 +146,14 @@ def _recent_attempts(conn: sqlite3.Connection, *, limit: int) -> list[dict[str, 
 
 def _attempt_counts(conn: sqlite3.Connection) -> dict[str, Any]:
     if not _table_exists(conn, "live_ingest_attempt"):
-        return {"total": 0, "running": 0, "failed": 0, "overlapping_source_paths": []}
+        return {
+            "total": 0,
+            "running": 0,
+            "completed": 0,
+            "failed": 0,
+            "stale_cursor_writes": 0,
+            "overlapping_source_paths": [],
+        }
     running_rows = conn.execute(
         """
         SELECT source_paths_json
@@ -118,14 +170,16 @@ def _attempt_counts(conn: sqlite3.Connection) -> dict[str, Any]:
         for path, count in sorted(path_counts.items())
         if count > 1
     ]
+    has_stale_col = "stale_cursor_write_count" in _columns(conn, "live_ingest_attempt")
     return {
         "total": _scalar_int(conn, "SELECT COUNT(*) FROM live_ingest_attempt"),
         "running": _scalar_int(conn, "SELECT COUNT(*) FROM live_ingest_attempt WHERE status = 'running'"),
+        "completed": _scalar_int(conn, "SELECT COUNT(*) FROM live_ingest_attempt WHERE status = 'completed'"),
         "failed": _scalar_int(conn, "SELECT COUNT(*) FROM live_ingest_attempt WHERE status = 'failed'"),
         "stale_cursor_writes": _scalar_int(
             conn,
             "SELECT COALESCE(SUM(stale_cursor_write_count), 0) FROM live_ingest_attempt"
-            if "stale_cursor_write_count" in _columns(conn, "live_ingest_attempt")
+            if has_stale_col
             else "SELECT 0",
         ),
         "overlapping_source_paths": overlapping[:20],
@@ -183,7 +237,7 @@ def _source_path_churn(conn: sqlite3.Connection, *, attempts: list[dict[str, Any
 
 def _convergence_debt(conn: sqlite3.Connection) -> dict[str, Any]:
     if not _table_exists(conn, "live_convergence_debt"):
-        return {"failed_count": 0, "retry_due_count": 0, "by_stage": []}
+        return {"failed_count": 0, "by_stage": []}
     rows = conn.execute(
         """
         SELECT stage, COUNT(*) AS failed_count
@@ -197,6 +251,158 @@ def _convergence_debt(conn: sqlite3.Connection) -> dict[str, Any]:
         "failed_count": sum(int(row[1] or 0) for row in rows),
         "by_stage": [{"stage": row[0], "failed_count": int(row[1] or 0)} for row in rows],
     }
+
+
+def _boundary_table_counts(conn: sqlite3.Connection) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for table in _BOUNDARY_TABLES:
+        if _table_exists(conn, table):
+            counts[table] = _scalar_int(conn, f"SELECT COUNT(*) FROM {table}")
+        else:
+            counts[table] = -1
+    return counts
+
+
+def _blob_lease_state(conn: sqlite3.Connection) -> dict[str, Any]:
+    if not _table_exists(conn, "pending_blob_refs"):
+        return {
+            "table_present": False,
+            "pending_lease_count": 0,
+            "distinct_operations": 0,
+            "oldest_acquired_at": None,
+        }
+    pending = _scalar_int(conn, "SELECT COUNT(*) FROM pending_blob_refs")
+    operations = _scalar_int(conn, "SELECT COUNT(DISTINCT operation_id) FROM pending_blob_refs")
+    oldest_row = conn.execute("SELECT MIN(acquired_at) FROM pending_blob_refs").fetchone()
+    oldest = int(oldest_row[0]) if oldest_row is not None and oldest_row[0] is not None else None
+    return {
+        "table_present": True,
+        "pending_lease_count": pending,
+        "distinct_operations": operations,
+        "oldest_acquired_at": oldest,
+    }
+
+
+def _gc_state(conn: sqlite3.Connection) -> dict[str, Any]:
+    if not _table_exists(conn, "gc_generations"):
+        return {
+            "table_present": False,
+            "high_water_generation": 0,
+            "last_completed_at": None,
+            "generation_count": 0,
+        }
+    row = conn.execute(
+        """
+        SELECT
+            COALESCE(MAX(generation), 0) AS high_water,
+            COUNT(*) AS generation_count
+        FROM gc_generations
+        """
+    ).fetchone()
+    high_water = int(row[0] or 0) if row is not None else 0
+    generation_count = int(row[1] or 0) if row is not None else 0
+    completed_row = conn.execute(
+        "SELECT completed_at FROM gc_generations WHERE generation = ? LIMIT 1",
+        (high_water,),
+    ).fetchone()
+    completed_at = int(completed_row[0]) if completed_row is not None and completed_row[0] is not None else None
+    return {
+        "table_present": True,
+        "high_water_generation": high_water,
+        "last_completed_at": completed_at,
+        "generation_count": generation_count,
+    }
+
+
+def _fts_trigger_state(conn: sqlite3.Connection) -> dict[str, Any]:
+    present = sorted(
+        str(row[0])
+        for row in conn.execute(
+            f"""
+            SELECT name FROM sqlite_master
+            WHERE type='trigger' AND name IN ({",".join("?" for _ in _EXPECTED_FTS_TRIGGERS)})
+            """,
+            _EXPECTED_FTS_TRIGGERS,
+        ).fetchall()
+    )
+    expected = set(_EXPECTED_FTS_TRIGGERS)
+    missing = sorted(expected - set(present))
+    return {
+        "expected": list(_EXPECTED_FTS_TRIGGERS),
+        "present": present,
+        "missing": missing,
+        "all_present": not missing,
+    }
+
+
+def _convergence_stage_timings(attempts: list[dict[str, Any]]) -> dict[str, Any]:
+    completed = [a for a in attempts if a.get("status") == "completed"]
+    if not completed:
+        return {
+            "sample_size": 0,
+            "parse_time_s": _summary_stat([]),
+            "convergence_time_s": _summary_stat([]),
+            "read_amplification": _summary_stat([]),
+        }
+    parse_times = [float(a.get("parse_time_s") or 0.0) for a in completed]
+    convergence_times = [float(a.get("convergence_time_s") or 0.0) for a in completed]
+    amps = [float(a.get("read_amplification") or 0.0) for a in completed]
+    return {
+        "sample_size": len(completed),
+        "parse_time_s": _summary_stat(parse_times),
+        "convergence_time_s": _summary_stat(convergence_times),
+        "read_amplification": _summary_stat(amps),
+    }
+
+
+def _summary_stat(values: list[float]) -> dict[str, float]:
+    if not values:
+        return {"min": 0.0, "max": 0.0, "sum": 0.0, "mean": 0.0}
+    total = sum(values)
+    return {
+        "min": round(min(values), 6),
+        "max": round(max(values), 6),
+        "sum": round(total, 6),
+        "mean": round(total / len(values), 6),
+    }
+
+
+def _daemon_resource_signal(attempts: list[dict[str, Any]], conn: sqlite3.Connection) -> dict[str, Any]:
+    """Read the most recent RSS / cgroup snapshot from `live_ingest_attempt`.
+
+    These are the only daemon-RSS signals the probe can read without IPC.
+    The probe is intentionally read-only.
+    """
+
+    if not _table_exists(conn, "live_ingest_attempt"):
+        return {"available": False}
+    columns = _columns(conn, "live_ingest_attempt")
+    optional = (
+        "rss_current_mb",
+        "rss_peak_self_mb",
+        "rss_peak_children_mb",
+        "cgroup_memory_current_mb",
+        "cgroup_memory_peak_mb",
+        "cgroup_memory_swap_current_mb",
+        "worker_in_flight_count",
+        "worker_completed_count",
+        "worker_total_count",
+    )
+    available_columns = [name for name in optional if name in columns]
+    if not available_columns:
+        return {"available": False}
+    select_list = ", ".join(available_columns)
+    row = conn.execute(
+        f"""
+        SELECT {select_list}
+        FROM live_ingest_attempt
+        ORDER BY updated_at DESC, started_at DESC
+        LIMIT 1
+        """
+    ).fetchone()
+    if row is None:
+        return {"available": False}
+    return {"available": True, **{col: row[idx] for idx, col in enumerate(available_columns)}}
 
 
 def _explain(conn: sqlite3.Connection, sql: str, params: tuple[object, ...]) -> list[str]:
@@ -270,15 +476,29 @@ def _query_plans(conn: sqlite3.Connection) -> dict[str, Any]:
 
 def probe(db: Path, *, limit: int = 5) -> dict[str, Any]:
     if not db.exists():
-        return {"ok": False, "db_path": str(db), "error": "database does not exist"}
+        return {
+            "ok": False,
+            "report_version": REPORT_VERSION,
+            "captured_at": _now_iso(),
+            "db_path": str(db),
+            "error": "database does not exist",
+        }
     conn = open_readonly_connection(db)
     try:
         recent_attempts = _recent_attempts(conn, limit=limit)
         return {
             "ok": True,
+            "report_version": REPORT_VERSION,
+            "captured_at": _now_iso(),
             "db_path": str(db),
             "attempt_counts": _attempt_counts(conn),
             "recent_attempts": recent_attempts,
+            "convergence_stage_timings": _convergence_stage_timings(recent_attempts),
+            "boundary_table_counts": _boundary_table_counts(conn),
+            "blob_lease_state": _blob_lease_state(conn),
+            "gc_state": _gc_state(conn),
+            "fts_trigger_state": _fts_trigger_state(conn),
+            "daemon_resource_signal": _daemon_resource_signal(recent_attempts, conn),
             "source_path_churn": _source_path_churn(conn, attempts=recent_attempts, limit=limit),
             "convergence_debt": _convergence_debt(conn),
             "query_plans": _query_plans(conn),
@@ -287,22 +507,268 @@ def probe(db: Path, *, limit: int = 5) -> dict[str, Any]:
         conn.close()
 
 
+# ---------------------------------------------------------------------------
+# Compare mode
+# ---------------------------------------------------------------------------
+
+
+def compare(before: dict[str, Any], after: dict[str, Any]) -> dict[str, Any]:
+    """Produce a structured before/after diff of two probe reports.
+
+    The diff is keyed by canonical sections.  Each section's value contains
+    enough state to be read on its own (no implicit ordering across sections).
+    """
+
+    before_version = int(before.get("report_version", 0))
+    after_version = int(after.get("report_version", 0))
+    if before_version != after_version:
+        return {
+            "ok": False,
+            "error": (
+                f"report_version mismatch: before={before_version} after={after_version}; "
+                "regenerate both reports with the same devtools build"
+            ),
+            "before_version": before_version,
+            "after_version": after_version,
+        }
+    if not before.get("ok") or not after.get("ok"):
+        return {
+            "ok": False,
+            "error": "compare requires two successful probe reports",
+            "before_ok": bool(before.get("ok")),
+            "after_ok": bool(after.get("ok")),
+        }
+
+    before_counts = _coerce_int_map(before.get("attempt_counts") or {})
+    after_counts = _coerce_int_map(after.get("attempt_counts") or {})
+    attempt_delta = {
+        key: {
+            "before": before_counts.get(key, 0),
+            "after": after_counts.get(key, 0),
+            "delta": after_counts.get(key, 0) - before_counts.get(key, 0),
+        }
+        for key in sorted(set(before_counts) | set(after_counts))
+    }
+
+    before_tables = _coerce_int_map(before.get("boundary_table_counts") or {})
+    after_tables = _coerce_int_map(after.get("boundary_table_counts") or {})
+    table_delta = {
+        key: {
+            "before": before_tables.get(key, 0),
+            "after": after_tables.get(key, 0),
+            "delta": after_tables.get(key, 0) - before_tables.get(key, 0),
+        }
+        for key in sorted(set(before_tables) | set(after_tables))
+    }
+
+    before_leases = before.get("blob_lease_state") or {}
+    after_leases = after.get("blob_lease_state") or {}
+    lease_delta = {
+        "pending_lease_count": {
+            "before": int(before_leases.get("pending_lease_count") or 0),
+            "after": int(after_leases.get("pending_lease_count") or 0),
+            "delta": int(after_leases.get("pending_lease_count") or 0)
+            - int(before_leases.get("pending_lease_count") or 0),
+        },
+        "distinct_operations": {
+            "before": int(before_leases.get("distinct_operations") or 0),
+            "after": int(after_leases.get("distinct_operations") or 0),
+            "delta": int(after_leases.get("distinct_operations") or 0)
+            - int(before_leases.get("distinct_operations") or 0),
+        },
+    }
+
+    before_gc = before.get("gc_state") or {}
+    after_gc = after.get("gc_state") or {}
+    gc_delta = {
+        "high_water_generation": {
+            "before": int(before_gc.get("high_water_generation") or 0),
+            "after": int(after_gc.get("high_water_generation") or 0),
+            "delta": int(after_gc.get("high_water_generation") or 0) - int(before_gc.get("high_water_generation") or 0),
+        },
+        "generation_count": {
+            "before": int(before_gc.get("generation_count") or 0),
+            "after": int(after_gc.get("generation_count") or 0),
+            "delta": int(after_gc.get("generation_count") or 0) - int(before_gc.get("generation_count") or 0),
+        },
+    }
+
+    before_fts = before.get("fts_trigger_state") or {}
+    after_fts = after.get("fts_trigger_state") or {}
+    fts_delta = {
+        "all_present_before": bool(before_fts.get("all_present")),
+        "all_present_after": bool(after_fts.get("all_present")),
+        "missing_before": list(before_fts.get("missing") or []),
+        "missing_after": list(after_fts.get("missing") or []),
+        "regressed": sorted(set(after_fts.get("missing") or []) - set(before_fts.get("missing") or [])),
+        "restored": sorted(set(before_fts.get("missing") or []) - set(after_fts.get("missing") or [])),
+    }
+
+    before_debt = before.get("convergence_debt") or {}
+    after_debt = after.get("convergence_debt") or {}
+    debt_delta = {
+        "failed_count": {
+            "before": int(before_debt.get("failed_count") or 0),
+            "after": int(after_debt.get("failed_count") or 0),
+            "delta": int(after_debt.get("failed_count") or 0) - int(before_debt.get("failed_count") or 0),
+        }
+    }
+
+    before_timings = before.get("convergence_stage_timings") or {}
+    after_timings = after.get("convergence_stage_timings") or {}
+    timing_delta: dict[str, Any] = {
+        "sample_size_before": int(before_timings.get("sample_size") or 0),
+        "sample_size_after": int(after_timings.get("sample_size") or 0),
+    }
+    for field in ("parse_time_s", "convergence_time_s", "read_amplification"):
+        b = before_timings.get(field) or {}
+        a = after_timings.get(field) or {}
+        timing_delta[field] = {
+            "mean": {
+                "before": float(b.get("mean") or 0.0),
+                "after": float(a.get("mean") or 0.0),
+                "delta": float(a.get("mean") or 0.0) - float(b.get("mean") or 0.0),
+            },
+            "max": {
+                "before": float(b.get("max") or 0.0),
+                "after": float(a.get("max") or 0.0),
+                "delta": float(a.get("max") or 0.0) - float(b.get("max") or 0.0),
+            },
+        }
+
+    return {
+        "ok": True,
+        "report_version": REPORT_VERSION,
+        "before_captured_at": before.get("captured_at"),
+        "after_captured_at": after.get("captured_at"),
+        "before_db_path": before.get("db_path"),
+        "after_db_path": after.get("db_path"),
+        "attempt_counts": attempt_delta,
+        "boundary_table_counts": table_delta,
+        "blob_lease_state": lease_delta,
+        "gc_state": gc_delta,
+        "fts_trigger_state": fts_delta,
+        "convergence_debt": debt_delta,
+        "convergence_stage_timings": timing_delta,
+    }
+
+
+def _coerce_int_map(source: dict[str, Any]) -> dict[str, int]:
+    """Pull out ``int``-valued entries from a mixed-shape dict.
+
+    The probe stores integer counts alongside list/dict context (for example
+    ``attempt_counts.overlapping_source_paths``).  Compare only diffs the
+    scalar integer fields; non-int values are skipped so the diff stays
+    arithmetic.
+    """
+
+    out: dict[str, int] = {}
+    for key, value in source.items():
+        if isinstance(value, bool):  # bool is int-subclass; reject explicitly
+            continue
+        if isinstance(value, int):
+            out[key] = value
+    return out
+
+
+def _format_compare_human(diff: dict[str, Any]) -> str:
+    if not diff.get("ok"):
+        return f"compare failed: {diff.get('error')}"
+    lines: list[str] = []
+    lines.append("Daemon workload probe — before/after diff")
+    lines.append(f"  before: {diff.get('before_captured_at')} ({diff.get('before_db_path')})")
+    lines.append(f"  after:  {diff.get('after_captured_at')} ({diff.get('after_db_path')})")
+    lines.append("")
+    lines.append("Attempt counts:")
+    for key, entry in diff["attempt_counts"].items():
+        lines.append(f"  {key}: {entry['before']} -> {entry['after']} (Δ {entry['delta']:+d})")
+    lines.append("")
+    lines.append("Boundary table counts:")
+    for key, entry in diff["boundary_table_counts"].items():
+        lines.append(f"  {key}: {entry['before']} -> {entry['after']} (Δ {entry['delta']:+d})")
+    leases = diff["blob_lease_state"]
+    lines.append("")
+    lines.append("Blob lease state:")
+    for key, entry in leases.items():
+        lines.append(f"  {key}: {entry['before']} -> {entry['after']} (Δ {entry['delta']:+d})")
+    gc = diff["gc_state"]
+    lines.append("")
+    lines.append("GC state:")
+    for key, entry in gc.items():
+        lines.append(f"  {key}: {entry['before']} -> {entry['after']} (Δ {entry['delta']:+d})")
+    fts = diff["fts_trigger_state"]
+    lines.append("")
+    lines.append("FTS trigger state:")
+    lines.append(f"  all_present: {fts['all_present_before']} -> {fts['all_present_after']}")
+    if fts["regressed"]:
+        lines.append(f"  regressed (newly missing): {', '.join(fts['regressed'])}")
+    if fts["restored"]:
+        lines.append(f"  restored: {', '.join(fts['restored'])}")
+    if not fts["regressed"] and not fts["restored"]:
+        lines.append("  no trigger drift")
+    debt = diff["convergence_debt"]["failed_count"]
+    lines.append("")
+    lines.append(f"Convergence debt failed_count: {debt['before']} -> {debt['after']} (Δ {debt['delta']:+d})")
+    timings = diff["convergence_stage_timings"]
+    lines.append("")
+    lines.append(
+        f"Convergence stage timings (completed-attempt sample {timings['sample_size_before']} -> "
+        f"{timings['sample_size_after']}):"
+    )
+    for field in ("parse_time_s", "convergence_time_s", "read_amplification"):
+        entry = timings[field]
+        mean = entry["mean"]
+        max_ = entry["max"]
+        lines.append(f"  {field}.mean: {mean['before']:.3f} -> {mean['after']:.3f} (Δ {mean['delta']:+.3f})")
+        lines.append(f"  {field}.max:  {max_['before']:.3f} -> {max_['after']:.3f} (Δ {max_['delta']:+.3f})")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--db", type=Path, default=None, help="Archive SQLite database path")
     parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON")
     parser.add_argument("--limit", type=int, default=5, help="Recent attempt limit")
+    parser.add_argument(
+        "--compare",
+        nargs=2,
+        metavar=("BEFORE", "AFTER"),
+        type=Path,
+        default=None,
+        help="Compare two saved probe reports and report structured deltas",
+    )
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:
     args = _parser().parse_args(argv)
+    if args.compare is not None:
+        before_path, after_path = args.compare
+        try:
+            before_payload = json.loads(Path(before_path).read_text())
+            after_payload = json.loads(Path(after_path).read_text())
+        except (OSError, json.JSONDecodeError) as exc:
+            print(f"failed to read compare inputs: {exc}")
+            return 2
+        diff = compare(before_payload, after_payload)
+        if args.json:
+            print(json.dumps(diff, indent=2, sort_keys=True))
+        else:
+            print(_format_compare_human(diff))
+        return 0 if diff.get("ok") else 1
+
     payload = probe(args.db or default_db_path(), limit=max(1, args.limit))
     if args.json:
         print(json.dumps(payload, indent=2, sort_keys=True))
         return 0 if payload.get("ok") else 1
 
     print(f"Daemon workload probe: {payload.get('db_path')}")
+    print(f"  captured_at: {payload.get('captured_at')}")
     if not payload.get("ok"):
         print(f"  error: {payload.get('error')}")
         return 1
@@ -311,6 +777,26 @@ def main(argv: list[str] | None = None) -> int:
     print(f"  stale cursor writes: {counts.get('stale_cursor_writes', 0)}")
     overlaps = counts.get("overlapping_source_paths") or []
     print(f"  overlapping source paths: {len(overlaps)}")
+    table_counts = payload.get("boundary_table_counts") or {}
+    if table_counts:
+        print("  boundary table counts:")
+        for table, count in table_counts.items():
+            shown = "missing" if count < 0 else str(count)
+            print(f"    {table}: {shown}")
+    leases = payload.get("blob_lease_state") or {}
+    print(
+        "  blob leases: "
+        f"{leases.get('pending_lease_count', 0)} pending across "
+        f"{leases.get('distinct_operations', 0)} operations"
+    )
+    gc = payload.get("gc_state") or {}
+    print(f"  gc: high-water generation {gc.get('high_water_generation', 0)} (count {gc.get('generation_count', 0)})")
+    fts = payload.get("fts_trigger_state") or {}
+    if fts.get("all_present"):
+        print(f"  fts triggers: all {len(fts.get('expected') or [])} present")
+    else:
+        missing = ", ".join(fts.get("missing") or [])
+        print(f"  fts triggers: missing {missing or '(unknown)'}")
     recent = payload["recent_attempts"]
     if recent:
         latest = recent[0]
@@ -320,6 +806,13 @@ def main(argv: list[str] | None = None) -> int:
             f"{latest['succeeded_file_count']}/{latest['needed_file_count']} files, "
             f"read amp {latest['read_amplification']:.2f}x"
         )
+    timings = payload.get("convergence_stage_timings") or {}
+    print(
+        "  completed-attempt timings (n="
+        f"{timings.get('sample_size', 0)}): "
+        f"parse mean {timings.get('parse_time_s', {}).get('mean', 0.0):.3f}s, "
+        f"convergence mean {timings.get('convergence_time_s', {}).get('mean', 0.0):.3f}s"
+    )
     debt = payload["convergence_debt"]
     print(f"  convergence debt: {debt['failed_count']} unresolved")
     churn = payload.get("source_path_churn") or []
@@ -349,6 +842,10 @@ def _json_list(value: object) -> list[str]:
     if not isinstance(parsed, list):
         return []
     return [str(item) for item in parsed if isinstance(item, str)]
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat(timespec="seconds")
 
 
 if __name__ == "__main__":

--- a/devtools/evidence_dashboard.py
+++ b/devtools/evidence_dashboard.py
@@ -344,7 +344,7 @@ def _static_gates(root: Path, *, now: datetime) -> dict[str, Any]:
     # appearance in history.
     if history_entries:
         for entry in reversed(history_entries):
-            steps = entry.get("steps", []) if isinstance(entry, dict) else []
+            steps = entry.get("steps", [])
             for step in steps:
                 if not isinstance(step, dict):
                     continue

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -182,6 +182,58 @@ created it.
   verification ([#818](https://github.com/Sinity/polylogue/issues/818))
   — independent of the lease design audited above.
 
+## Daemon Convergence Evidence
+
+`devtools daemon-workload-probe` produces a stable, JSON-serializable
+snapshot of daemon-relevant state read directly from the archive SQLite
+database. The probe is read-only and does not talk to the running daemon.
+
+For #845-style before/after convergence proofs:
+
+```bash
+devtools daemon-workload-probe --json > before.json
+# ...run convergence work (e.g. polylogued runs, ingest, debt drain)...
+devtools daemon-workload-probe --json > after.json
+devtools daemon-workload-probe --compare before.json after.json
+devtools daemon-workload-probe --compare before.json after.json --json > diff.json
+```
+
+The report has a stable top-level shape carrying its `report_version`,
+`captured_at`, and structured sections that compare diffs arithmetically:
+
+- `attempt_counts` — total/running/completed/failed `live_ingest_attempt`
+  rows plus `stale_cursor_writes` and overlapping running source paths.
+- `recent_attempts` — most recent attempts with read amplification,
+  parse/convergence timings, and source-path bundles.
+- `convergence_stage_timings` — min/max/sum/mean parse/convergence/read-
+  amplification stats over completed attempts.
+- `boundary_table_counts` — row counts for the daemon-relevant tables
+  (`raw_conversations`, `conversations`, `messages`, `content_blocks`,
+  `blob_links`, `messages_fts_docsize`, `action_events`,
+  `action_events_fts_docsize`, `message_embeddings`, `session_profile`,
+  `live_ingest_attempt`, `live_convergence_debt`, `pending_blob_refs`).
+  Missing tables surface as `-1` rather than crashing the probe.
+- `blob_lease_state` — pending lease count, distinct lease operations,
+  oldest `acquired_at`. See the lease/GC concurrency model above.
+- `gc_state` — high-water `gc_generations` row, `last_completed_at`,
+  total generation count.
+- `fts_trigger_state` — the six expected FTS sync triggers
+  (`messages_fts_a{i,d,u}`, `action_events_fts_a{i,d,u}`) with
+  `present`, `missing`, and `all_present` fields. A missing trigger means
+  FTS index drift risk (suspended during bulk operations and not
+  restored, for example).
+- `daemon_resource_signal` — RSS / cgroup memory / worker-progress fields
+  pulled from the most recent `live_ingest_attempt` row (these are the
+  only daemon-RSS signals readable without IPC).
+- `source_path_churn`, `convergence_debt`, `query_plans` — pre-existing
+  read amplification, debt-by-stage, and hot-query EXPLAIN evidence.
+
+The compare mode refuses incompatible `report_version` inputs loudly and
+requires both inputs to be `ok: True`.  Numeric fields produce
+`{before, after, delta}` triples; the FTS trigger section reports
+`regressed` (newly missing) and `restored` separately so trigger drift is
+attributable to a specific convergence cycle.
+
 ## Debugging Landmarks
 
 Cross-check adjacent surfaces after changes:

--- a/tests/unit/devtools/test_daemon_workload_probe.py
+++ b/tests/unit/devtools/test_daemon_workload_probe.py
@@ -1,37 +1,47 @@
 from __future__ import annotations
 
+import json
 import sqlite3
 from pathlib import Path
 
-from devtools.daemon_workload_probe import probe
+import pytest
+
+from devtools.daemon_workload_probe import (
+    REPORT_VERSION,
+    compare,
+    main,
+    probe,
+)
 from polylogue.sources.live.cursor import CursorStore
 from polylogue.storage.sqlite.schema import _ensure_schema
 
 
-def test_daemon_workload_probe_reports_attempts_and_plan_shape(tmp_path: Path) -> None:
-    db = tmp_path / "archive.sqlite"
-    source = tmp_path / "session.jsonl"
+def _seed_minimal_archive(db: Path, source: Path) -> str:
+    """Seed an archive with one raw + conversation + completed live attempt."""
+
     source.write_text('{"a": 1}\n')
     conn = sqlite3.connect(db)
-    _ensure_schema(conn)
-    conn.execute(
-        """
-        INSERT INTO raw_conversations (
-            raw_id, provider_name, source_path, blob_size, acquired_at
-        ) VALUES ('raw-1', 'codex', ?, 0, '2026-01-01T00:00:00Z')
-        """,
-        (str(source),),
-    )
-    conn.execute(
-        """
-        INSERT INTO conversations (
-            conversation_id, provider_name, provider_conversation_id,
-            source_name, content_hash, version, raw_id
-        ) VALUES ('conv-1', 'codex', 'provider-1', 'codex', 'hash-1', 1, 'raw-1')
-        """
-    )
-    conn.commit()
-    conn.close()
+    try:
+        _ensure_schema(conn)
+        conn.execute(
+            """
+            INSERT INTO raw_conversations (
+                raw_id, provider_name, source_path, blob_size, acquired_at
+            ) VALUES ('raw-1', 'codex', ?, 0, '2026-01-01T00:00:00Z')
+            """,
+            (str(source),),
+        )
+        conn.execute(
+            """
+            INSERT INTO conversations (
+                conversation_id, provider_name, provider_conversation_id,
+                source_name, content_hash, version, raw_id
+            ) VALUES ('conv-1', 'codex', 'provider-1', 'codex', 'hash-1', 1, 'raw-1')
+            """
+        )
+        conn.commit()
+    finally:
+        conn.close()
 
     cursor = CursorStore(db)
     attempt_id = cursor.begin_ingest_attempt(paths=[source], input_bytes=10, queued_file_count=1)
@@ -43,6 +53,13 @@ def test_daemon_workload_probe_reports_attempts_and_plan_shape(tmp_path: Path) -
         source_payload_read_bytes=10,
         cursor_fingerprint_read_bytes=0,
     )
+    return attempt_id
+
+
+def test_daemon_workload_probe_reports_attempts_and_plan_shape(tmp_path: Path) -> None:
+    db = tmp_path / "archive.sqlite"
+    source = tmp_path / "session.jsonl"
+    _seed_minimal_archive(db, source)
 
     payload = probe(db)
 
@@ -59,3 +76,180 @@ def test_daemon_workload_probe_reports_missing_database(tmp_path: Path) -> None:
 
     assert payload["ok"] is False
     assert payload["error"] == "database does not exist"
+    # Even on failure, the envelope carries the version and capture timestamp
+    # so compare() can report a structured error instead of crashing.
+    assert payload["report_version"] == REPORT_VERSION
+    assert isinstance(payload["captured_at"], str) and payload["captured_at"]
+
+
+def test_probe_payload_carries_stable_top_level_shape(tmp_path: Path) -> None:
+    db = tmp_path / "archive.sqlite"
+    _seed_minimal_archive(db, tmp_path / "session.jsonl")
+
+    payload = probe(db)
+
+    expected_keys = {
+        "ok",
+        "report_version",
+        "captured_at",
+        "db_path",
+        "attempt_counts",
+        "recent_attempts",
+        "convergence_stage_timings",
+        "boundary_table_counts",
+        "blob_lease_state",
+        "gc_state",
+        "fts_trigger_state",
+        "daemon_resource_signal",
+        "source_path_churn",
+        "convergence_debt",
+        "query_plans",
+    }
+    assert expected_keys.issubset(payload.keys())
+    assert payload["report_version"] == REPORT_VERSION
+
+    # Boundary counts cover the daemon-relevant tables.
+    counts = payload["boundary_table_counts"]
+    assert counts["raw_conversations"] == 1
+    assert counts["conversations"] == 1
+    assert counts["live_ingest_attempt"] == 1
+
+    # FTS trigger state reports the full expected set.
+    fts = payload["fts_trigger_state"]
+    assert fts["all_present"] is True
+    assert set(fts["present"]) == set(fts["expected"])
+    assert fts["missing"] == []
+
+    # GC / lease tables are present after fresh schema init even if empty.
+    assert payload["blob_lease_state"]["table_present"] is True
+    assert payload["blob_lease_state"]["pending_lease_count"] == 0
+    assert payload["gc_state"]["table_present"] is True
+    assert payload["gc_state"]["high_water_generation"] == 0
+
+    # The completed attempt produces a one-sample timing summary.
+    timings = payload["convergence_stage_timings"]
+    assert timings["sample_size"] == 1
+    assert "mean" in timings["parse_time_s"]
+
+    # Payload must be JSON-round-trippable (no datetime, set, Path, etc).
+    assert json.loads(json.dumps(payload))["report_version"] == REPORT_VERSION
+
+
+def test_probe_reports_missing_fts_triggers(tmp_path: Path) -> None:
+    db = tmp_path / "archive.sqlite"
+    _seed_minimal_archive(db, tmp_path / "session.jsonl")
+
+    # Drop one expected FTS sync trigger and verify the probe flags it.
+    conn = sqlite3.connect(db)
+    try:
+        conn.execute("DROP TRIGGER IF EXISTS messages_fts_ai")
+        conn.commit()
+    finally:
+        conn.close()
+
+    payload = probe(db)
+    fts = payload["fts_trigger_state"]
+    assert fts["all_present"] is False
+    assert "messages_fts_ai" in fts["missing"]
+
+
+def test_compare_computes_structured_delta(tmp_path: Path) -> None:
+    db = tmp_path / "archive.sqlite"
+    source = tmp_path / "session.jsonl"
+    _seed_minimal_archive(db, source)
+
+    before_payload = probe(db)
+
+    # Simulate a convergence cycle that added a second raw + conversation +
+    # ran a second live attempt.
+    second_source = tmp_path / "session-2.jsonl"
+    second_source.write_text('{"b": 2}\n')
+    conn = sqlite3.connect(db)
+    try:
+        conn.execute(
+            """
+            INSERT INTO raw_conversations (
+                raw_id, provider_name, source_path, blob_size, acquired_at
+            ) VALUES ('raw-2', 'codex', ?, 0, '2026-01-02T00:00:00Z')
+            """,
+            (str(second_source),),
+        )
+        conn.execute(
+            """
+            INSERT INTO conversations (
+                conversation_id, provider_name, provider_conversation_id,
+                source_name, content_hash, version, raw_id
+            ) VALUES ('conv-2', 'codex', 'provider-2', 'codex', 'hash-2', 1, 'raw-2')
+            """
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    cursor = CursorStore(db)
+    attempt_id = cursor.begin_ingest_attempt(paths=[second_source], input_bytes=20, queued_file_count=1)
+    cursor.update_ingest_attempt(
+        attempt_id,
+        status="completed",
+        phase="done",
+        succeeded_file_count=1,
+        source_payload_read_bytes=20,
+        cursor_fingerprint_read_bytes=0,
+    )
+
+    after_payload = probe(db)
+
+    diff = compare(before_payload, after_payload)
+    assert diff["ok"] is True
+    # Two new attempts (one new + the existing completed one — only the new
+    # one increases the total, the completed/total counters both rise by 1).
+    assert diff["attempt_counts"]["total"]["delta"] == 1
+    assert diff["attempt_counts"]["completed"]["delta"] == 1
+    # New conversation and raw row land in the boundary counts.
+    assert diff["boundary_table_counts"]["conversations"]["delta"] == 1
+    assert diff["boundary_table_counts"]["raw_conversations"]["delta"] == 1
+    assert diff["boundary_table_counts"]["live_ingest_attempt"]["delta"] == 1
+    # No FTS regression.
+    assert diff["fts_trigger_state"]["regressed"] == []
+    # Sample size for completed-attempt timings grew by one.
+    assert diff["convergence_stage_timings"]["sample_size_after"] == 2
+
+
+def test_compare_rejects_version_mismatch() -> None:
+    before = {"ok": True, "report_version": REPORT_VERSION}
+    after = {"ok": True, "report_version": REPORT_VERSION + 99}
+
+    diff = compare(before, after)
+    assert diff["ok"] is False
+    assert "report_version mismatch" in diff["error"]
+
+
+def test_compare_rejects_failed_input() -> None:
+    before = {"ok": False, "report_version": REPORT_VERSION, "error": "db missing"}
+    after = {"ok": True, "report_version": REPORT_VERSION}
+
+    diff = compare(before, after)
+    assert diff["ok"] is False
+    assert "compare requires two successful" in diff["error"]
+
+
+def test_cli_compare_round_trip(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    db = tmp_path / "archive.sqlite"
+    _seed_minimal_archive(db, tmp_path / "session.jsonl")
+
+    before_path = tmp_path / "before.json"
+    after_path = tmp_path / "after.json"
+    before_path.write_text(json.dumps(probe(db)))
+    after_path.write_text(json.dumps(probe(db)))
+
+    exit_code = main(["--compare", str(before_path), str(after_path), "--json"])
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    # The probe imports may surface schema-bootstrap log lines on stdout in
+    # some environments; the compare output itself is the trailing JSON
+    # document.  Slice from the first '{' to the end.
+    out = captured.out
+    diff = json.loads(out[out.index("{") :])
+    assert diff["ok"] is True
+    # No deltas when comparing a snapshot against itself.
+    assert diff["attempt_counts"]["total"]["delta"] == 0
+    assert diff["boundary_table_counts"]["conversations"]["delta"] == 0


### PR DESCRIPTION
## Summary

Adds a stable JSON shape to `devtools daemon-workload-probe` plus a
`--compare BEFORE AFTER` mode so operators can capture and diff
before/after convergence evidence for #845.

## Problem

`devtools daemon-workload-probe` already exposed recent live ingest
attempts, read amplification, source-path churn, convergence debt, and
EXPLAIN hazards, but the JSON shape was not designed for arithmetic
comparison across convergence cycles:

- No `report_version` / `captured_at` — two snapshots could not be
  safely compared.
- No boundary table row counts — the section the daemon actually moves
  rows into and out of was invisible.
- No blob lease / GC generation / FTS trigger state — the convergence-
  safety invariants documented in `docs/internals.md` were unreadable
  from the probe.
- No per-section aggregate timings, so completed-attempt parse vs
  convergence shape required reading raw rows.

#845's remaining acceptance criteria require "structured evidence that
identifies the next blocker" and "before/after benchmark evidence" for
large-session convergence. The probe needed to *enable* that workflow
without committing to a specific convergence change yet.

## Solution

`devtools/daemon_workload_probe.py`:

- Top-level envelope now always carries `report_version` (currently 1)
  and `captured_at` ISO timestamp, including on the missing-DB error
  path so `compare()` can produce a structured error instead of
  crashing.
- New report sections:
  - `boundary_table_counts` for 13 daemon-relevant tables (missing
    tables surface as `-1` not crashes).
  - `blob_lease_state` — pending count, distinct operations, oldest
    `acquired_at` from `pending_blob_refs`.
  - `gc_state` — high-water generation, `last_completed_at`, count.
  - `fts_trigger_state` — present / missing / `all_present` for the six
    expected FTS sync triggers (`messages_fts_a{i,d,u}`,
    `action_events_fts_a{i,d,u}`). A missing trigger is FTS drift risk.
  - `convergence_stage_timings` — min/max/sum/mean parse_time_s,
    convergence_time_s, read_amplification over completed attempts.
  - `daemon_resource_signal` — RSS / cgroup memory / worker-progress
    fields pulled from the most recent `live_ingest_attempt` row (the
    only daemon-RSS signals readable without daemon IPC).
- `compare(before, after)` produces `{before, after, delta}` triples for
  scalar fields, dedicated `regressed`/`restored` sets for FTS
  triggers, and refuses both `report_version` mismatches and non-`ok`
  inputs loudly.
- `devtools daemon-workload-probe --compare BEFORE AFTER [--json]` CLI
  mode for the operator workflow.
- Human-readable summary covers all new sections; JSON output is
  unchanged for old sections and additive for the new ones.

`docs/internals.md`: new "Daemon Convergence Evidence" section
documenting the before/after workflow and report shape so this is the
canonical place to read about it.

`devtools/evidence_dashboard.py`: drive-by fix for the pre-existing
`Found 1 error in 1 file (checked 1332 source files)` mypy failure at
line 347 (`isinstance(entry, dict)` on an already-`dict`-typed iterable
element). This was the only `devtools verify --quick` failure on
`origin/master c5e18f9f` — fixed in scope per §19a (inherited
failures), confirmed by stashing the probe changes and re-running mypy.

Alternative rejected: emitting deltas inline in `probe()`. Kept apart
because operators need to capture both snapshots before any compare can
exist, and storing them as committed JSON files is the artifact #845
ultimately needs.

## Verification

```bash
nix develop -c pytest tests/unit/devtools/test_daemon_workload_probe.py -q --no-cov
# 8 passed in 10.10s

nix develop -c pytest tests/unit/devtools/ -q --no-cov
# 491 passed in 15.40s

nix develop -c mypy --strict devtools/daemon_workload_probe.py tests/unit/devtools/test_daemon_workload_probe.py devtools/evidence_dashboard.py
# Success: no issues found

nix develop -c devtools verify --quick
# total_duration_s: 110.13, exit_code: 0
```

End-to-end CLI smoke (seeded a minimal archive in `/tmp/probe_smoke2`,
ran the probe twice, compared):

```
Daemon workload probe: /tmp/probe_smoke2/archive.sqlite
  captured_at: 2026-05-16T16:05:40+00:00
  attempts: 1 total, 0 running, 0 failed
  fts triggers: all 6 present
  latest: completed done 1/1 files, read amp 1.00x
  completed-attempt timings (n=1): parse mean 0.000s, convergence mean 0.000s

Compare output (snapshot vs itself):
  all_present: True -> True; no trigger drift
  parse_time_s.mean: 0.000 -> 0.000 (Δ +0.000)
  read_amplification.mean: 1.000 -> 1.000 (Δ +0.000)
```

Ref #845