### PR TITLE
fix: avoid live filesystem resolution for archived/unsafe paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,10 +34,11 @@ on push, but the default baseline must pass before the PR is opened.
 Do not treat CI as the first verification pass. Anticipate failures
 locally.
 
-### Proof Pack workflow
+### Verification Impact workflow
 
-Every PR gets a `Polylogue Proof Pack` comment. Treat it as a verification
-impact report, not as decorative CI output and not as a complete proof.
+Every PR gets a `Polylogue Verification Impact` comment. Treat it as a
+verification impact report, not as decorative CI output and not as a complete
+proof.
 
 Use it this way:
 
@@ -45,15 +46,14 @@ Use it this way:
   match the touched files, or state in the PR why a suggested gate is only an
   optional confidence gate for that change.
 - Use nonzero affected domains and claims to decide which focused tests or
-  proof-law suites to run. Ignore zero-claim domain noise unless the changed
-  files genuinely belong to that domain.
+  contract/property suites to run. Ignore zero-claim domain noise unless the
+  changed files genuinely belong to that domain.
 - Treat `Known Gaps` as actionable only when they are in a changed or directly
   affected domain. Broad repo-wide gap dumps should not block unrelated PRs, but
   recurring noise should be folded back into #594.
-- Treat any remaining proof-pack obligation language as transitional report
-  terminology; real verification closure comes from pytest, coverage,
-  benchmark, CI, static-check, and runtime evidence artifacts.
-- If the Proof Pack is noisy, misleading, or misses a relevant gate, comment on
+- Real verification closure comes from pytest, coverage, benchmark, CI,
+  static-check, and runtime evidence artifacts — not from catalog metadata.
+- If the report is noisy, misleading, or misses a relevant gate, comment on
   the PR or #594 with the concrete mismatch. Do not silently ignore it.
 
 ### PR body discipline
@@ -322,7 +322,7 @@ Add `devtools build-package` or `nix flake check` when touching packaging or
 Nix expressions. See [TESTING.md](TESTING.md) and [docs/devtools.md](docs/devtools.md)
 for details.
 
-Proof Pack: every PR gets a `Polylogue Proof Pack` comment. It's a verification
+Verification Impact: every PR gets a `Polylogue Verification Impact` comment. It's a verification
 impact report showing affected domains, required gates, and known gaps. Use it
 to choose focused verification — run the gates that match touched files, state
 in the PR why a suggested gate is only optional for that change.
@@ -957,7 +957,7 @@ repo verification checks and evidence records, not end-user archive workflows.
 | Command | Role |
 | --- | --- |
 | `devtools render-verification-catalog` | Refresh or verify the catalog that anchors changed-path verification reports after changing subjects, claims, runners, or catalog rendering. Use --anti-vacuity to flag claims with gaps. |
-| `devtools affected-obligations` | Find the checks and inner-loop commands affected by local changes before escalating to full PR gates. Use --full for domain-grouped impact analysis. |
+| `devtools verification-impact` | Find the checks and inner-loop commands affected by local changes before escalating to full PR gates. Use --full for domain-grouped impact analysis. |
 | `devtools semantic-axis-evidence` | Produce comparative performance evidence that describes growth shape over semantic axes instead of machine-specific absolute budgets. |
 | `devtools lab-corpus` | Seed synthetic corpus files or complete demo workspaces for lab exercises. |
 | `devtools lab-scenario` | Run showcase exercise smoke scenarios and committed baseline checks outside the archive CLI. |
@@ -1008,7 +1008,6 @@ These are the commands worth remembering during normal repo work:
 
 | Command | Description |
 | --- | --- |
-| `devtools affected-obligations` | Route changed paths or refs to affected verification checks and focused commands; optionally emit full proof-pack impact report. |
 | `devtools artifact-graph` | Render the runtime artifact, operation, and scenario-coverage map. |
 | `devtools coverage-gate` | Run pytest with the repository coverage floor from pyproject.toml. |
 | `devtools daemon-workload-probe` | Inspect daemon ingest workload, convergence debt, and hot query plans. |
@@ -1024,6 +1023,7 @@ These are the commands worth remembering during normal repo work:
 | `devtools schema-generate` | Generate provider schema packages and optional evidence clusters. |
 | `devtools schema-promote` | Promote a schema evidence cluster into a registered package version. |
 | `devtools semantic-axis-evidence` | Generate verification-lab performance evidence across synthetic semantic scale tiers. |
+| `devtools verification-impact` | Route changed paths or refs to affected verification checks and focused commands; emit the full PR-confidence report with --full. |
 | `devtools verify` | Run the local verification baseline before pushing or creating a PR. |
 | `devtools verify-ci-workflows` | Verify CI workflow files reference locally-known devtools commands and existing paths. |
 | `devtools verify-cluster-cohesion` | Validate proposed clusters from the topology projection using the import graph. |

--- a/polylogue/archive/conversation/attribution.py
+++ b/polylogue/archive/conversation/attribution.py
@@ -61,6 +61,14 @@ _IGNORED_RELATIVE_PATH_PREFIXES = (
 )
 
 
+def _lexical_expanduser(value: str) -> str:
+    if value == "~":
+        return str(Path.home())
+    if value.startswith("~/"):
+        return f"{Path.home()}{value[1:]}"
+    return value
+
+
 def _is_ignored_absolute_path(path: PurePosixPath) -> bool:
     parts = tuple(part for part in path.parts if part != "/")
     if not parts:
@@ -117,18 +125,16 @@ def _clean_attributed_path(path: str) -> str | None:
         if _is_ignored_repo_relative_path(PurePosixPath(candidate)):
             return None
         return candidate
-    expanded_path = Path(candidate).expanduser()
-    expanded = str(expanded_path)
-    resolved = str(expanded_path.resolve(strict=False))
-    repo_root = _repo_root_from_path(resolved)
+    expanded = _lexical_expanduser(candidate)
+    repo_root = _repo_root_from_path(expanded)
     if repo_root is not None:
         try:
-            repo_relative = PurePosixPath(Path(resolved).relative_to(repo_root).as_posix())
+            repo_relative = PurePosixPath(PurePosixPath(expanded).relative_to(PurePosixPath(repo_root)).as_posix())
         except ValueError:
             repo_relative = None
         if repo_relative is not None and _is_ignored_repo_relative_path(repo_relative):
             return None
-        return resolved
+        return expanded
 
     pure_path = PurePosixPath(expanded)
     if _is_ignored_absolute_path(pure_path):

--- a/polylogue/archive/conversation/repo_identity.py
+++ b/polylogue/archive/conversation/repo_identity.py
@@ -5,12 +5,18 @@ from __future__ import annotations
 import re
 from collections.abc import Iterable
 from functools import lru_cache
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from urllib.parse import urlparse
 
 _PATH_DELIMITERS = {"#", "`", '"', "\\", ":", "(", ")", "\n", "\r", "\t", " ", "<", ">", ",", ";", "'"}
 _REPO_SLUG_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+(?:\.git)?$")
 _PLAIN_REPO_NAME_RE = re.compile(r"^[a-z0-9_.-]+$")
+_NON_PROBING_ABSOLUTE_PREFIXES = (
+    PurePosixPath("/mnt"),
+    PurePosixPath("/media"),
+    PurePosixPath("/run/media"),
+    PurePosixPath("/neo-outer-realm"),
+)
 
 
 def _extract_local_path_candidate(value: str) -> str | None:
@@ -27,6 +33,22 @@ def _extract_local_path_candidate(value: str) -> str | None:
         chars.append(char)
     candidate = "".join(chars).strip()
     return candidate or None
+
+
+def _lexical_expanduser(value: str) -> str:
+    if value == "~":
+        return str(Path.home())
+    if value.startswith("~/"):
+        return f"{Path.home()}{value[1:]}"
+    return value
+
+
+def _is_non_probing_absolute_path(value: str) -> bool:
+    expanded = _lexical_expanduser(value)
+    pure = PurePosixPath(expanded)
+    return pure.is_absolute() and any(
+        pure == prefix or prefix in pure.parents for prefix in _NON_PROBING_ABSOLUTE_PREFIXES
+    )
 
 
 def _iter_repo_root_candidates(path: Path) -> tuple[Path, ...]:
@@ -98,6 +120,8 @@ def normalize_repo_path(value: object) -> str | None:
         return None
     path_candidate = _extract_local_path_candidate(raw)
     if path_candidate is None:
+        return None
+    if _is_non_probing_absolute_path(path_candidate):
         return None
     git_root = _find_git_root(Path(path_candidate).expanduser().resolve(strict=False))
     return str(git_root) if git_root is not None else None

--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -810,6 +810,14 @@ def repair_session_insights(
                     else f"Would: rebuild session insights ({assessment.pending:,} pending items)",
                 )
 
+            if assessment.pending == 0 and _session_insight_status_ready(status):
+                return _repair_result(
+                    "session_insights",
+                    repaired_count=0,
+                    success=True,
+                    detail="Session insights already ready",
+                )
+
             rebuilt = rebuild_session_insights_sync(
                 conn,
                 progress_callback=progress_callback,
@@ -851,7 +859,7 @@ def repair_action_event_read_model(config: Config, dry_run: bool = False) -> Rep
         valid_action_event_source_ids_sync,
     )
     from polylogue.storage.action_events.status import action_event_read_model_status_sync
-    from polylogue.storage.fts.fts_lifecycle import repair_fts_index_sync
+    from polylogue.storage.fts.fts_lifecycle import rebuild_fts_index_sync, repair_fts_index_sync
     from polylogue.storage.sqlite.connection import connection_context
 
     try:
@@ -875,9 +883,12 @@ def repair_action_event_read_model(config: Config, dry_run: bool = False) -> Rep
             if candidate_ids:
                 repaired = rebuild_action_event_read_model_sync(conn, conversation_ids=candidate_ids)
             if not state.fts_ready:
-                repair_targets = candidate_ids or valid_action_event_source_ids_sync(conn)
-                if repair_targets:
-                    repair_fts_index_sync(conn, repair_targets)
+                if state.excess_fts_rows:
+                    rebuild_fts_index_sync(conn)
+                else:
+                    repair_targets = candidate_ids or valid_action_event_source_ids_sync(conn)
+                    if repair_targets:
+                        repair_fts_index_sync(conn, repair_targets)
             conn.commit()
             refreshed = action_event_read_model_status_sync(conn)
             return _repair_result(

--- a/tests/unit/archive/test_repo_identity.py
+++ b/tests/unit/archive/test_repo_identity.py
@@ -66,6 +66,44 @@ def test_repo_identity_normalization_filters_noise(tmp_path: Path) -> None:
     ) == (str(polylogue_repo), str(sinnix_repo))
 
 
+def test_attribution_does_not_probe_archived_automount_paths(monkeypatch: pytest.MonkeyPatch) -> None:
+    original_resolve = Path.resolve
+
+    def fail_on_automount(self: Path, strict: bool = False) -> Path:
+        if str(self).startswith("/mnt/"):
+            raise AssertionError(f"attempted to resolve archived automount path: {self}")
+        return original_resolve(self, strict=strict)
+
+    monkeypatch.setattr(Path, "resolve", fail_on_automount)
+    action = ActionEvent(
+        event_id="evt-automount-path",
+        message_id="msg-automount-path",
+        timestamp=datetime(2026, 5, 16, 12, 0, tzinfo=timezone.utc),
+        sequence_index=0,
+        kind=ToolCategory.FILE_READ,
+        tool_name="Read",
+        tool_id=None,
+        provider=Provider.CLAUDE_CODE,
+        affected_paths=("/mnt/pendrv/chatlog/claude_code/project/src/main.py",),
+        cwd_path="/mnt/pendrv/chatlog/claude_code/project",
+        branch_names=(),
+        command=None,
+        query=None,
+        url=None,
+        output_text=None,
+        search_text="automount path",
+        raw={},
+    )
+
+    attribution = extract_attribution_from_action_events([action])
+
+    assert attribution.file_paths_touched == ("/mnt/pendrv/chatlog/claude_code/project/src/main.py",)
+    assert attribution.cwd_paths == ("/mnt/pendrv/chatlog/claude_code/project",)
+    assert attribution.repo_paths == ()
+    assert attribution.repo_names == ()
+    assert attribution.languages_detected == ("python",)
+
+
 def test_repo_identity_normalization_canonicalizes_absolute_parent_traversal(tmp_path: Path) -> None:
     sinnix_repo = _make_repo(tmp_path, "sinnix")
     noisy_repo_path = f"/../../{sinnix_repo.relative_to(Path('/'))}"

--- a/tests/unit/storage/test_repair.py
+++ b/tests/unit/storage/test_repair.py
@@ -1,7 +1,20 @@
 from __future__ import annotations
 
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from polylogue.config import Config
 from polylogue.maintenance.models import DerivedModelStatus
 from polylogue.storage import repair as repair_mod
+from polylogue.storage.insights.session.runtime import SessionInsightStatusSnapshot
+
+
+def _config(tmp_path: Path) -> Config:
+    return Config(archive_root=tmp_path, render_root=tmp_path, sources=[], db_path=tmp_path / "archive.db")
 
 
 def _status(
@@ -135,3 +148,106 @@ def test_preview_counts_from_archive_debt_include_healthy_preview_targets_only()
         "dangling_fts": 0,
         "empty_conversations": 4,
     }
+
+
+def _ready_session_insight_status() -> SessionInsightStatusSnapshot:
+    return SessionInsightStatusSnapshot(
+        profile_rows_ready=True,
+        work_event_inference_rows_ready=True,
+        work_event_inference_fts_ready=True,
+        phase_inference_rows_ready=True,
+        threads_ready=True,
+        threads_fts_ready=True,
+        tag_rollups_ready=True,
+        day_summaries_ready=True,
+        week_summaries_ready=True,
+    )
+
+
+def test_repair_session_insights_noops_when_ready(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    @contextmanager
+    def fake_connection_context(_path: Path) -> Iterator[object]:
+        yield object()
+
+    def fail_rebuild(*args: object, **kwargs: object) -> int:
+        raise AssertionError("ready session insights must not run a full rebuild")
+
+    monkeypatch.setattr("polylogue.storage.sqlite.connection.connection_context", fake_connection_context)
+    monkeypatch.setattr(
+        "polylogue.storage.insights.session.status.session_insight_status_sync",
+        lambda _conn: _ready_session_insight_status(),
+    )
+    monkeypatch.setattr(
+        "polylogue.storage.insights.session.rebuild.rebuild_session_insights_sync",
+        fail_rebuild,
+    )
+
+    result = repair_mod.repair_session_insights(_config(tmp_path), dry_run=False)
+
+    assert result.success is True
+    assert result.repaired_count == 0
+    assert result.detail == "Session insights already ready"
+
+
+def test_repair_action_event_read_model_rebuilds_fts_when_stale_extra_rows(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    calls: list[str] = []
+
+    class FakeConn:
+        def commit(self) -> None:
+            calls.append("commit")
+
+    @contextmanager
+    def fake_connection_context(_path: Path) -> Iterator[FakeConn]:
+        yield FakeConn()
+
+    def fake_status(_conn: FakeConn) -> dict[str, Any]:
+        if "rebuild_fts" in calls:
+            return {
+                "ready": True,
+                "valid_source_conversation_count": 1,
+                "materialized_conversation_count": 1,
+                "count": 1,
+                "action_fts_count": 1,
+                "stale_count": 0,
+                "orphan_tool_block_count": 0,
+                "matches_version": True,
+            }
+        return {
+            "ready": False,
+            "valid_source_conversation_count": 1,
+            "materialized_conversation_count": 1,
+            "count": 1,
+            "action_fts_count": 2,
+            "stale_count": 0,
+            "orphan_tool_block_count": 0,
+            "matches_version": True,
+        }
+
+    monkeypatch.setattr("polylogue.storage.sqlite.connection.connection_context", fake_connection_context)
+    monkeypatch.setattr("polylogue.storage.action_events.status.action_event_read_model_status_sync", fake_status)
+    monkeypatch.setattr(
+        "polylogue.storage.action_events.rebuild_runtime.action_event_repair_candidates_sync", lambda _conn: []
+    )
+    monkeypatch.setattr(
+        "polylogue.storage.action_events.rebuild_runtime.rebuild_action_event_read_model_sync", lambda *a, **k: 0
+    )
+    monkeypatch.setattr(
+        "polylogue.storage.action_events.rebuild_runtime.valid_action_event_source_ids_sync",
+        lambda _conn: (_ for _ in ()).throw(
+            AssertionError("full FTS rebuild should not enumerate per-conversation targets")
+        ),
+    )
+    monkeypatch.setattr(
+        "polylogue.storage.fts.fts_lifecycle.repair_fts_index_sync",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("stale extra FTS rows require a full rebuild")),
+    )
+    monkeypatch.setattr(
+        "polylogue.storage.fts.fts_lifecycle.rebuild_fts_index_sync", lambda _conn: calls.append("rebuild_fts")
+    )
+
+    result = repair_mod.repair_action_event_read_model(_config(tmp_path), dry_run=False)
+
+    assert result.success is True
+    assert "rebuild_fts" in calls


### PR DESCRIPTION
## Summary
Prevent polylogue archive operations from probing archived automount paths (e.g. `/mnt/pendrv/chatlog/...`) and rebuild session insights unnecessarily.

## Problem
- `attribution.py` and `repo_identity.py` call `Path.expanduser().resolve()` on absolute paths from chat transcripts, potentially probing archived automount paths like `/mnt/pendrv`
- `repair.py` session_insights rebuilds unnecessarily when all components are already ready
- Action-event repair uses per-conversation FTS rebuild instead of full rebuild when excess stale FTS rows exist

## Solution
- `attribution.py`: use lexical `~` expansion only (`_lexical_expanduser`), skip live `resolve()`
- `repo_identity.py`: short-circuit non-probing absolute paths (`/mnt`, `/media`, `/run/media`, `/neo-outer-realm`) before any `resolve()` call
- `repair.py`: no-op `repair_session_insights` when all 9 readiness flags are true; use `rebuild_fts_index_sync` for excess stale rows
- Tests: automount path guard, ready no-op, FTS stale rebuild

## Verification
```
pytest tests/unit/archive/test_repo_identity.py tests/unit/storage/test_repair.py -q: 19 passed
devtools verify --quick: all 16 steps pass
devtools build-package: ok
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated agent governance workflow naming in reference documentation.

* **Bug Fixes**
  * Improved path handling to prevent probing archived automount paths during attribution extraction.
  * Refined repair operation logic to better distinguish between "already ready" and "would rebuild" states.
  * Enhanced FTS index repair path handling for stale data scenarios.

* **Tests**
  * Added coverage for archived path attribution scenarios and repair operation edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sinity/polylogue/pull/1102?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->