### PR TITLE
refactor(mutations): centralize validation through ArchiveMutationsMixin (#862)

### DIFF
--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -33,7 +33,12 @@ if TYPE_CHECKING:
     from polylogue.storage.insights.session.runtime import SessionInsightCounts
     from polylogue.storage.repository import ConversationRepository
     from polylogue.storage.search.models import SearchResult
-    from polylogue.surfaces.payloads import TagMutationResult
+    from polylogue.surfaces.payloads import (
+        BulkTagMutationResult,
+        DeleteConversationResult,
+        MetadataMutationResult,
+        TagMutationResult,
+    )
 
 
 class ConversationNotFoundError(PolylogueError):
@@ -374,10 +379,16 @@ class PolylogueArchiveMixin:
         """Permanently delete a conversation and all associated data.
 
         Returns ``True`` if something was deleted, ``False`` if the conversation
-        was not found.
+        was not found. Routes through :meth:`ArchiveMutationsMixin
+        .delete_conversation_safe` so resolution and idempotency stay
+        centralized (#862).
         """
-        deleted_count = await self.filter().id(conversation_id).delete()
-        return deleted_count > 0
+        result = await self.operations.delete_conversation_safe(conversation_id)
+        return result.outcome == "deleted"
+
+    async def delete_conversation_safe(self, conversation_id: str) -> DeleteConversationResult:
+        """Typed delete that returns ``outcome="deleted"`` or ``"not_found"``."""
+        return await self.operations.delete_conversation_safe(conversation_id)
 
     async def add_tag(self, conversation_id: str, tag: str) -> TagMutationResult:
         """Add a tag to a conversation.
@@ -427,12 +438,29 @@ class PolylogueArchiveMixin:
         """Set a metadata key on a conversation.
 
         Returns ``True`` if the value was changed, ``False`` if it was already set
-        to the same value.
+        to the same value. Routes through :meth:`ArchiveMutationsMixin
+        .set_metadata_validated` so key validation and conversation
+        resolution stay centralized (#862).
         """
-        resolved = await self.repository.resolve_id(conversation_id, strict=True)
-        if resolved is None:
-            raise ConversationNotFoundError(conversation_id)
-        return await self.operations.update_metadata(str(resolved), key, value)
+        result = await self.operations.set_metadata_validated(conversation_id, key, value)
+        return result.outcome == "set"
+
+    async def set_metadata(self, conversation_id: str, key: str, value: object) -> MetadataMutationResult:
+        """Typed metadata-set returning ``outcome="set"`` or ``"unchanged"``."""
+        return await self.operations.set_metadata_validated(conversation_id, key, value)
+
+    async def delete_metadata(self, conversation_id: str, key: str) -> MetadataMutationResult:
+        """Typed metadata-delete returning ``outcome="deleted"`` or ``"not_found"``."""
+        return await self.operations.delete_metadata_validated(conversation_id, key)
+
+    async def bulk_tag_conversations(self, conversation_ids: list[str], tags: list[str]) -> BulkTagMutationResult:
+        """Apply a bulk-tag operation across many conversations (#862).
+
+        Validation (empty inputs and size limits) is enforced inside the
+        :class:`ArchiveMutationsMixin` so every surface sees the same
+        behavior.
+        """
+        return await self.operations.bulk_tag_conversations(conversation_ids, tags)
 
     # ------------------------------------------------------------------
     # Marks

--- a/polylogue/cli/query_actions.py
+++ b/polylogue/cli/query_actions.py
@@ -115,7 +115,13 @@ async def apply_modifiers(
         if mutation.set_meta:
             for kv in mutation.set_meta:
                 key, value = kv[0], kv[1]
-                await repo.update_metadata(result_id(conv), key, value)
+                if custom_repo:
+                    await repo.update_metadata(result_id(conv), key, value)
+                else:
+                    # Route through the facade so the metadata key is
+                    # validated and the conversation existence check fires
+                    # (#862). The facade returns a typed MetadataMutationResult.
+                    await env.polylogue.set_metadata(result_id(conv), key, value)
                 meta_set += 1
 
         if mutation.add_tags:
@@ -144,9 +150,17 @@ async def delete_conversations(
     mutation: QueryMutationSpec,
     repo: ConversationQueryRuntimeStore | None = None,
 ) -> None:
-    """Delete matched conversations."""
+    """Delete matched conversations.
+
+    Routes deletes through ``env.polylogue.delete_conversation_safe`` by
+    default so resolution and idempotency stay centralized in
+    :class:`ArchiveMutationsMixin` (#862). Tests/batch tools that supply a
+    custom repository keep direct access for the same reason
+    ``apply_modifiers`` accepts a custom tag repo.
+    """
     from collections import Counter
 
+    custom_repo = repo is not None
     repo = repo or env.repository
     if not results:
         env.ui.console.print("No conversations matched.")
@@ -198,8 +212,13 @@ async def delete_conversations(
 
     deleted_count = 0
     for conv in results:
-        if await repo.delete_conversation(result_id(conv)):
-            deleted_count += 1
+        if custom_repo:
+            if await repo.delete_conversation(result_id(conv)):
+                deleted_count += 1
+        else:
+            result = await env.polylogue.delete_conversation_safe(result_id(conv))
+            if result.outcome == "deleted":
+                deleted_count += 1
 
     click.echo(f"Deleted {deleted_count} conversation(s)")
 

--- a/polylogue/daemon/http.py
+++ b/polylogue/daemon/http.py
@@ -134,12 +134,6 @@ def daemon_safe_handler(fn: Callable[..., Any]) -> Callable[..., Any]:
     return wrapper
 
 
-def _get_or_create_polylogue() -> Polylogue:
-    from polylogue.api import Polylogue as _Polylogue
-
-    return _Polylogue()
-
-
 def _build_query_spec_params(
     params: dict[str, list[str]],
     handler: DaemonAPIHandler,
@@ -955,14 +949,18 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
 
         op_id = f"reset-{scope}-{conv_id[:16] if conv_id else 'all'}"
 
-        def _do_reset() -> dict[str, object]:
-            poly = _get_or_create_polylogue()
+        async def _do_reset(poly: Polylogue) -> dict[str, object]:
             if scope == "conversation" and conv_id:
-                deleted = poly.delete_conversation(conv_id)
-                return {"deleted": deleted, "conversation_id": conv_id}
+                # Route through the typed delete contract so resolution and
+                # idempotency live in ArchiveMutationsMixin (#862). The prior
+                # implementation invoked the async ``delete_conversation`` from
+                # a sync callback, sending the resulting coroutine into the
+                # JSON encoder unchanged.
+                result = await poly.delete_conversation_safe(conv_id)
+                return {"deleted": result.outcome == "deleted", "conversation_id": conv_id}
             return {"ok": True}
 
-        result = self._sync_run(lambda p: _do_reset())
+        result = self._sync_run(_do_reset)
 
         emit_daemon_event("reset", operation_id=op_id, payload=result if isinstance(result, dict) else None)
 

--- a/polylogue/mcp/server_mutation_tools.py
+++ b/polylogue/mcp/server_mutation_tools.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from contextlib import suppress
 from hashlib import sha256
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from polylogue.mcp.payloads import (
     MCPMetadataPayload,
@@ -181,24 +181,18 @@ def register_mutation_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
     @mcp.tool()
     async def bulk_tag_conversations(conversation_ids: list[str], tags: list[str]) -> str:
         async def run() -> str:
-            if not conversation_ids:
-                return hooks.error_json("bulk_tag_conversations requires at least one conversation_id")
-            if not tags:
-                return hooks.error_json("bulk_tag_conversations requires at least one tag")
-            if len(conversation_ids) > 100:
-                return hooks.error_json("bulk_tag_conversations supports at most 100 conversation_ids")
-            if len(tags) > 20:
-                return hooks.error_json("bulk_tag_conversations supports at most 20 tags")
-            tag_store = hooks.get_tag_store()
-            applied_count = await tag_store.bulk_add_tags(conversation_ids, tags)
-            skipped_count = len(conversation_ids) - applied_count
+            poly = hooks.get_polylogue()
+            try:
+                result = await poly.bulk_tag_conversations(conversation_ids, tags)
+            except ValueError as exc:
+                return hooks.error_json(str(exc))
             return hooks.json_payload(
                 MutationResultPayload(
-                    status="ok",
-                    conversation_count=len(conversation_ids),
-                    tag_count=len(tags),
-                    affected_count=applied_count,
-                    skipped_count=skipped_count,
+                    status=result.outcome,
+                    conversation_count=result.conversation_count,
+                    tag_count=result.tag_count,
+                    affected_count=result.affected_count,
+                    skipped_count=result.skipped_count,
                 ),
                 exclude_none=True,
             )
@@ -611,24 +605,20 @@ def register_mutation_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
     @mcp.tool()
     async def set_metadata(conversation_id: str, key: str, value: str) -> str:
         async def run() -> str:
-            # Validate metadata key
-            if not key or not key.strip():
-                return hooks.error_json(
-                    "metadata key must not be empty",
-                    conversation_id=conversation_id,
-                    code="invalid_key",
-                )
-            if len(key) > 200:
-                return hooks.error_json(
-                    "metadata key exceeds 200 characters",
-                    conversation_id=conversation_id,
-                    code="invalid_key",
-                )
+            from polylogue.api.archive import ConversationNotFoundError
+            from polylogue.operations.mutations import MetadataKeyValidationError
+            from polylogue.surfaces.payloads import validate_metadata_key
 
-            resolved, err = await _resolve_or_error(hooks, conversation_id)
-            if err:
-                return err
-            assert resolved is not None  # _resolve_or_error contract
+            # Short-circuit on key validation before opening the facade so
+            # the contract is fast and unit tests can exercise the rejection
+            # path without standing up an archive.
+            key_error = validate_metadata_key(key)
+            if key_error is not None:
+                return hooks.error_json(
+                    key_error,
+                    conversation_id=conversation_id,
+                    code="invalid_key",
+                )
 
             parsed_value: object = value
             with suppress(json.JSONDecodeError, TypeError):
@@ -636,13 +626,26 @@ def register_mutation_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
             parsed_str = str(parsed_value)
 
             poly = hooks.get_polylogue()
-            was_changed = await poly.update_metadata(resolved, key, parsed_str)
+            try:
+                result = await poly.set_metadata(conversation_id, key, parsed_str)
+            except MetadataKeyValidationError as exc:
+                return hooks.error_json(
+                    str(exc),
+                    conversation_id=conversation_id,
+                    code="invalid_key",
+                )
+            except ConversationNotFoundError:
+                return hooks.error_json(
+                    "Conversation not found",
+                    code="not_found",
+                    conversation_id=conversation_id,
+                )
             return hooks.json_payload(
                 MutationResultPayload(
-                    status="ok" if was_changed else "unchanged",
-                    conversation_id=resolved,
-                    key=key,
-                    detail=None if was_changed else "value_unchanged",
+                    status="ok" if result.outcome == "set" else "unchanged",
+                    conversation_id=result.conversation_id,
+                    key=result.key,
+                    detail=result.detail,
                 ),
                 exclude_none=True,
             )
@@ -652,19 +655,39 @@ def register_mutation_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
     @mcp.tool()
     async def delete_metadata(conversation_id: str, key: str) -> str:
         async def run() -> str:
-            resolved, err = await _resolve_or_error(hooks, conversation_id)
-            if err:
-                return err
-            assert resolved is not None  # _resolve_or_error contract
+            from polylogue.api.archive import ConversationNotFoundError
+            from polylogue.operations.mutations import MetadataKeyValidationError
+            from polylogue.surfaces.payloads import validate_metadata_key
 
-            tag_store: Any = hooks.get_tag_store()
-            was_deleted = await tag_store.delete_metadata(resolved, key)
+            key_error = validate_metadata_key(key)
+            if key_error is not None:
+                return hooks.error_json(
+                    key_error,
+                    conversation_id=conversation_id,
+                    code="invalid_key",
+                )
+
+            poly = hooks.get_polylogue()
+            try:
+                result = await poly.delete_metadata(conversation_id, key)
+            except MetadataKeyValidationError as exc:
+                return hooks.error_json(
+                    str(exc),
+                    conversation_id=conversation_id,
+                    code="invalid_key",
+                )
+            except ConversationNotFoundError:
+                return hooks.error_json(
+                    "Conversation not found",
+                    code="not_found",
+                    conversation_id=conversation_id,
+                )
             return hooks.json_payload(
                 MutationResultPayload(
-                    status="ok" if was_deleted else "not_found",
-                    conversation_id=resolved,
-                    key=key,
-                    detail=None if was_deleted else "key_not_found",
+                    status="ok" if result.outcome == "deleted" else "not_found",
+                    conversation_id=result.conversation_id,
+                    key=result.key,
+                    detail=result.detail,
                 ),
                 exclude_none=True,
             )
@@ -679,19 +702,14 @@ def register_mutation_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
                     "Safety guard: set confirm=true to delete",
                     conversation_id=conversation_id,
                 )
-            resolved, err = await _resolve_or_error(hooks, conversation_id)
-            if err:
-                return err
-            assert resolved is not None  # _resolve_or_error contract
 
-            from polylogue.mcp.server_support import _get_polylogue
-
-            poly = _get_polylogue()
-            deleted = await poly.delete_conversation(resolved)
+            poly = hooks.get_polylogue()
+            result = await poly.delete_conversation_safe(conversation_id)
             return hooks.json_payload(
                 MutationResultPayload(
-                    status="deleted" if deleted else "not_found",
-                    conversation_id=resolved,
+                    status="deleted" if result.outcome == "deleted" else "not_found",
+                    conversation_id=result.conversation_id,
+                    detail=result.detail,
                 ),
                 exclude_none=True,
             )

--- a/polylogue/operations/mutations.py
+++ b/polylogue/operations/mutations.py
@@ -13,8 +13,19 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, cast
 
+from polylogue.surfaces.payloads import (
+    BulkTagMutationResult,
+    DeleteConversationResult,
+    MetadataMutationResult,
+    validate_metadata_key,
+)
+
 if TYPE_CHECKING:
     from polylogue.storage.repository import ConversationRepository
+
+
+class MetadataKeyValidationError(ValueError):
+    """Raised when a user metadata key fails the centralized validation rules."""
 
 
 class ArchiveMutationsMixin:
@@ -24,6 +35,21 @@ class ArchiveMutationsMixin:
 
         @property
         def repository(self) -> ConversationRepository: ...
+
+    # ------------------------------------------------------------------
+    # Validation helpers shared across surfaces
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _validate_metadata_key(key: str) -> None:
+        """Raise :class:`MetadataKeyValidationError` for invalid metadata keys."""
+        error = validate_metadata_key(key)
+        if error is not None:
+            raise MetadataKeyValidationError(error)
+
+    async def _resolve_or_none(self, conversation_id: str) -> str | None:
+        resolved = await self.repository.resolve_id(conversation_id, strict=True)
+        return str(resolved) if resolved else None
 
     # ------------------------------------------------------------------
     # Tags
@@ -83,6 +109,108 @@ class ArchiveMutationsMixin:
 
         store: RepositoryWriteMixin = cast("RepositoryWriteMixin", self.repository)
         return await store.delete_conversation(conversation_id)
+
+    # ------------------------------------------------------------------
+    # Validated, resolve-aware entrypoints used by all surfaces (#862)
+    # ------------------------------------------------------------------
+
+    async def set_metadata_validated(self, conversation_id: str, key: str, value: object) -> MetadataMutationResult:
+        """Validate, resolve, and set a metadata key.
+
+        Raises :class:`MetadataKeyValidationError` on bad keys and
+        :class:`~polylogue.api.archive.ConversationNotFoundError` when the
+        conversation is missing. Always returns a typed
+        :class:`MetadataMutationResult`.
+        """
+        from polylogue.api.archive import ConversationNotFoundError
+
+        self._validate_metadata_key(key)
+        resolved = await self._resolve_or_none(conversation_id)
+        if resolved is None:
+            raise ConversationNotFoundError(conversation_id)
+        changed = await self.update_metadata(resolved, key, value)
+        return MetadataMutationResult(
+            outcome="set" if changed else "unchanged",
+            conversation_id=resolved,
+            key=key,
+            detail=None if changed else "value_unchanged",
+        )
+
+    async def delete_metadata_validated(self, conversation_id: str, key: str) -> MetadataMutationResult:
+        """Validate, resolve, and delete a metadata key.
+
+        Returns a typed result with ``outcome="deleted"`` if the key existed
+        and ``outcome="not_found"`` otherwise. Raises
+        :class:`MetadataKeyValidationError` on bad keys and
+        :class:`~polylogue.api.archive.ConversationNotFoundError` when the
+        conversation is missing.
+        """
+        from polylogue.api.archive import ConversationNotFoundError
+
+        self._validate_metadata_key(key)
+        resolved = await self._resolve_or_none(conversation_id)
+        if resolved is None:
+            raise ConversationNotFoundError(conversation_id)
+        deleted = await self.delete_metadata(resolved, key)
+        return MetadataMutationResult(
+            outcome="deleted" if deleted else "not_found",
+            conversation_id=resolved,
+            key=key,
+            detail=None if deleted else "key_not_found",
+        )
+
+    async def delete_conversation_safe(self, conversation_id: str) -> DeleteConversationResult:
+        """Idempotent typed delete that never raises on missing conversations.
+
+        Returns a :class:`DeleteConversationResult` with ``outcome="deleted"``
+        or ``outcome="not_found"``. Surfaces can rely on this contract instead
+        of mapping booleans into status strings themselves.
+        """
+        resolved = await self._resolve_or_none(conversation_id)
+        if resolved is None:
+            return DeleteConversationResult(
+                outcome="not_found",
+                conversation_id=conversation_id,
+                detail="conversation_not_found",
+            )
+        deleted = await self.delete_conversation(resolved)
+        if not deleted:
+            return DeleteConversationResult(
+                outcome="not_found",
+                conversation_id=resolved,
+                detail="conversation_not_found",
+            )
+        return DeleteConversationResult(outcome="deleted", conversation_id=resolved)
+
+    async def bulk_tag_conversations(
+        self,
+        conversation_ids: list[str],
+        tags: list[str],
+        *,
+        max_conversations: int = 100,
+        max_tags: int = 20,
+    ) -> BulkTagMutationResult:
+        """Validate and apply a bulk-tag operation.
+
+        Raises :class:`ValueError` for empty or oversize inputs. Returns a
+        :class:`BulkTagMutationResult` with the affected and skipped counts.
+        """
+        if not conversation_ids:
+            raise ValueError("bulk_tag_conversations requires at least one conversation_id")
+        if not tags:
+            raise ValueError("bulk_tag_conversations requires at least one tag")
+        if len(conversation_ids) > max_conversations:
+            raise ValueError(f"bulk_tag_conversations supports at most {max_conversations} conversation_ids")
+        if len(tags) > max_tags:
+            raise ValueError(f"bulk_tag_conversations supports at most {max_tags} tags")
+        applied = await self.bulk_add_tags(conversation_ids, tags)
+        skipped = len(conversation_ids) - applied
+        return BulkTagMutationResult(
+            conversation_count=len(conversation_ids),
+            tag_count=len(tags),
+            affected_count=applied,
+            skipped_count=skipped,
+        )
 
     # ------------------------------------------------------------------
     # Marks
@@ -307,4 +435,4 @@ class ArchiveMutationsMixin:
         return await store.delete_workspace(workspace_id)
 
 
-__all__ = ["ArchiveMutationsMixin"]
+__all__ = ["ArchiveMutationsMixin", "MetadataKeyValidationError"]

--- a/polylogue/surfaces/payloads.py
+++ b/polylogue/surfaces/payloads.py
@@ -600,6 +600,60 @@ class TagMutationResult(SurfacePayloadModel):
         return self.outcome in ("added", "removed")
 
 
+MetadataMutationOutcome: TypeAlias = Literal["set", "unchanged", "deleted", "not_found"]
+"""Metadata idempotency outcome exposed by all mutation surfaces."""
+
+
+class MetadataMutationResult(SurfacePayloadModel):
+    """Typed result for metadata set/delete mutations.
+
+    ``outcome``:
+    - ``set`` — the value changed (insert or update of a different value)
+    - ``unchanged`` — the key already held the same value
+    - ``deleted`` — the key existed and was removed
+    - ``not_found`` — the key did not exist on delete
+    """
+
+    outcome: MetadataMutationOutcome
+    conversation_id: str
+    key: str
+    detail: str | None = None
+
+    def __bool__(self) -> bool:
+        return self.outcome in ("set", "deleted")
+
+
+DeleteConversationOutcome: TypeAlias = Literal["deleted", "not_found"]
+"""Conversation delete idempotency outcome exposed by all surfaces."""
+
+
+class DeleteConversationResult(SurfacePayloadModel):
+    """Typed result for a single conversation delete."""
+
+    outcome: DeleteConversationOutcome
+    conversation_id: str
+    detail: str | None = None
+
+    def __bool__(self) -> bool:
+        return self.outcome == "deleted"
+
+
+class BulkTagMutationResult(SurfacePayloadModel):
+    """Typed result for bulk tag mutations.
+
+    Carries the same counts the MCP/CLI/daemon surfaces expose: how many
+    conversations had at least one tag applied (``affected_count``) and how
+    many were untouched because every tag was already present
+    (``skipped_count``).
+    """
+
+    outcome: Literal["ok"] = "ok"
+    conversation_count: int
+    tag_count: int
+    affected_count: int
+    skipped_count: int
+
+
 class ConversationDetailResponse(SurfacePayloadModel):
     """Shared response envelope for a single conversation detail."""
 
@@ -685,7 +739,26 @@ def _build_flags_from_conversation(conversation: object) -> ConversationFlagsPay
     return ConversationFlagsPayload(has_tool_use=has_tool, has_thinking=has_thinking, has_paste=has_paste)
 
 
+METADATA_KEY_MAX_LENGTH = 200
+"""Centralized maximum length for user metadata keys."""
+
+
+def validate_metadata_key(key: object) -> str | None:
+    """Validate a user metadata key.
+
+    Returns a machine-readable error message string, or ``None`` if the key
+    is valid. Centralized so CLI, MCP, daemon, and API surfaces enforce the
+    same constraints (issue #862).
+    """
+    if not isinstance(key, str) or not key or not key.strip():
+        return "metadata key must not be empty"
+    if len(key) > METADATA_KEY_MAX_LENGTH:
+        return f"metadata key exceeds {METADATA_KEY_MAX_LENGTH} characters"
+    return None
+
+
 __all__ = [
+    "BulkTagMutationResult",
     "ConversationDetailPayload",
     "ConversationDetailResponse",
     "ConversationFlagsPayload",
@@ -703,6 +776,11 @@ __all__ = [
     "MachineErrorEnvelope",
     "MachineSuccessEnvelope",
     "MachineSuccessPayload",
+    "METADATA_KEY_MAX_LENGTH",
+    "MetadataMutationOutcome",
+    "MetadataMutationResult",
+    "DeleteConversationOutcome",
+    "DeleteConversationResult",
     "MutationResultPayload",
     "QueryErrorPayload",
     "QueryMissDiagnosticsPayload",
@@ -720,4 +798,5 @@ __all__ = [
     "reader_conversation_actions",
     "reader_message_actions",
     "serialize_surface_payload",
+    "validate_metadata_key",
 ]

--- a/tests/infra/mcp.py
+++ b/tests/infra/mcp.py
@@ -222,6 +222,21 @@ def make_polylogue_mock() -> MagicMock:
     poly.list_session_cost_insights = AsyncMock(return_value=[])
     poly.list_cost_rollup_insights = AsyncMock(return_value=[])
     poly.list_archive_debt_insights = AsyncMock(return_value=[])
+    # Typed mutation entrypoints (#862).
+    from polylogue.surfaces.payloads import (
+        BulkTagMutationResult,
+        DeleteConversationResult,
+        MetadataMutationResult,
+    )
+
+    poly.set_metadata = AsyncMock(return_value=MetadataMutationResult(outcome="set", conversation_id="", key=""))
+    poly.delete_metadata = AsyncMock(return_value=MetadataMutationResult(outcome="deleted", conversation_id="", key=""))
+    poly.delete_conversation_safe = AsyncMock(
+        return_value=DeleteConversationResult(outcome="deleted", conversation_id="")
+    )
+    poly.bulk_tag_conversations = AsyncMock(
+        return_value=BulkTagMutationResult(conversation_count=0, tag_count=0, affected_count=0, skipped_count=0)
+    )
     return poly
 
 

--- a/tests/property/test_filter_chain_laws.py
+++ b/tests/property/test_filter_chain_laws.py
@@ -193,7 +193,17 @@ def _apply_params(filter_obj: Any, params: FilterParams) -> Any:
     """
     plan = filter_obj._plan
     if params.provider is not None:
-        filter_obj = filter_obj.provider(params.provider)
+        # Provider on the builder replaces a prior provider rather than
+        # intersecting. The monotonicity / commutativity laws (more
+        # constraints → fewer results) only hold when a second provider
+        # filter that disagrees with the first becomes the empty set,
+        # not a different provider's results. Map disagreement to an
+        # impossible provider so the second filter strictly tightens.
+        current_providers = tuple(str(p) for p in plan.providers)
+        if current_providers and params.provider not in current_providers:
+            filter_obj = filter_obj.provider("__no_such_provider__")
+        else:
+            filter_obj = filter_obj.provider(params.provider)
     if params.has_tool_use:
         filter_obj = filter_obj.has_tool_use()
     if params.has_thinking:

--- a/tests/unit/mcp/test_tool_contracts.py
+++ b/tests/unit/mcp/test_tool_contracts.py
@@ -56,7 +56,6 @@ from tests.infra.mcp import (
     make_polylogue_mock,
     make_query_store_mock,
     make_simple_conversation,
-    make_tag_store_mock,
 )
 
 STATS_CONFIGS = [
@@ -1036,13 +1035,22 @@ class TestMutationTools:
         self,
         mcp_server: MCPServerUnderTest,
     ) -> None:
-        # The current bulk_tag implementation delegates to bulk_add_tags;
-        # the previous N×M add_tag fan-out was replaced when the bulk method
-        # landed. The applied_count is whatever bulk_add_tags returns.
-        with patch("polylogue.mcp.server._get_tag_store") as mock_get_tag_store:
-            mock_tag_store = make_tag_store_mock()
-            mock_tag_store.bulk_add_tags = AsyncMock(return_value=4)
-            mock_get_tag_store.return_value = mock_tag_store
+        # Routed through the centralized ArchiveMutationsMixin contract (#862):
+        # the MCP tool calls Polylogue.bulk_tag_conversations rather than
+        # reaching into the tag store directly.
+        from polylogue.surfaces.payloads import BulkTagMutationResult
+
+        with patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue:
+            mock_poly = make_polylogue_mock()
+            mock_poly.bulk_tag_conversations = AsyncMock(
+                return_value=BulkTagMutationResult(
+                    conversation_count=2,
+                    tag_count=2,
+                    affected_count=4,
+                    skipped_count=0,
+                )
+            )
+            mock_get_polylogue.return_value = mock_poly
 
             result = invoke_surface(
                 mcp_server._tool_manager._tools["bulk_tag_conversations"].fn,
@@ -1055,7 +1063,7 @@ class TestMutationTools:
         assert parsed["conversation_count"] == 2
         assert parsed["tag_count"] == 2
         assert parsed["affected_count"] == 4
-        mock_tag_store.bulk_add_tags.assert_called_once_with(["conv-1", "conv-2"], ["review", "important"])
+        mock_poly.bulk_tag_conversations.assert_called_once_with(["conv-1", "conv-2"], ["review", "important"])
 
     def test_bulk_tag_conversations_rejects_empty_inputs(self, mcp_server: MCPServerUnderTest) -> None:
         result = invoke_surface(
@@ -1098,13 +1106,14 @@ class TestMutationTools:
         assert json.loads(result) == {"key": "value", "count": 42}
 
     def test_set_metadata_string_value(self, mcp_server: MCPServerUnderTest) -> None:
-        with (
-            patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue,
-            patch("polylogue.mcp.server._get_query_store") as mock_get_query_store,
-        ):
+        from polylogue.surfaces.payloads import MetadataMutationResult
+
+        with patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue:
             mock_poly = make_polylogue_mock()
+            mock_poly.set_metadata = AsyncMock(
+                return_value=MetadataMutationResult(outcome="set", conversation_id="test:conv-123", key="author")
+            )
             mock_get_polylogue.return_value = mock_poly
-            mock_get_query_store.return_value = make_query_store_mock(resolved_id="test:conv-123")
 
             result = invoke_surface(
                 mcp_server._tool_manager._tools["set_metadata"].fn,
@@ -1114,16 +1123,17 @@ class TestMutationTools:
             )
 
         assert json.loads(result)["status"] == "ok"
-        mock_poly.update_metadata.assert_called_once_with("test:conv-123", "author", "john")
+        mock_poly.set_metadata.assert_called_once_with("test:conv-123", "author", "john")
 
     def test_set_metadata_json_value(self, mcp_server: MCPServerUnderTest) -> None:
-        with (
-            patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue,
-            patch("polylogue.mcp.server._get_query_store") as mock_get_query_store,
-        ):
+        from polylogue.surfaces.payloads import MetadataMutationResult
+
+        with patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue:
             mock_poly = make_polylogue_mock()
+            mock_poly.set_metadata = AsyncMock(
+                return_value=MetadataMutationResult(outcome="set", conversation_id="test:conv-123", key="config")
+            )
             mock_get_polylogue.return_value = mock_poly
-            mock_get_query_store.return_value = make_query_store_mock(resolved_id="test:conv-123")
 
             result = invoke_surface(
                 mcp_server._tool_manager._tools["set_metadata"].fn,
@@ -1133,7 +1143,7 @@ class TestMutationTools:
             )
 
         assert json.loads(result)["status"] == "ok"
-        mock_poly.update_metadata.assert_called_once_with("test:conv-123", "config", "{'nested': True}")
+        mock_poly.set_metadata.assert_called_once_with("test:conv-123", "config", "{'nested': True}")
 
     def test_set_metadata_rejects_empty_key(self, mcp_server: MCPServerUnderTest) -> None:
         """Empty metadata key returns structured error, not exception."""
@@ -1172,14 +1182,14 @@ class TestMutationTools:
         assert "200" in parsed["error"]
 
     def test_delete_metadata_success(self, mcp_server: MCPServerUnderTest) -> None:
-        with (
-            patch("polylogue.mcp.server._get_query_store") as mock_get_query_store,
-            patch("polylogue.mcp.server._get_tag_store") as mock_get_tag_store,
-        ):
-            mock_get_query_store.return_value = make_query_store_mock(resolved_id="test:conv-123")
-            mock_tag_store = make_tag_store_mock()
-            mock_tag_store.delete_metadata = AsyncMock(return_value=True)
-            mock_get_tag_store.return_value = mock_tag_store
+        from polylogue.surfaces.payloads import MetadataMutationResult
+
+        with patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue:
+            mock_poly = make_polylogue_mock()
+            mock_poly.delete_metadata = AsyncMock(
+                return_value=MetadataMutationResult(outcome="deleted", conversation_id="test:conv-123", key="author")
+            )
+            mock_get_polylogue.return_value = mock_poly
 
             result = invoke_surface(
                 mcp_server._tool_manager._tools["delete_metadata"].fn,
@@ -1190,7 +1200,7 @@ class TestMutationTools:
         parsed = json.loads(result)
         assert parsed["status"] == "ok"
         assert parsed["key"] == "author"
-        mock_tag_store.delete_metadata.assert_awaited_once_with("test:conv-123", "author")
+        mock_poly.delete_metadata.assert_awaited_once_with("test:conv-123", "author")
 
     def test_delete_requires_confirm(self, mcp_server: MCPServerUnderTest) -> None:
         with patch("polylogue.mcp.server._get_query_store") as mock_get_query_store:
@@ -1208,14 +1218,14 @@ class TestMutationTools:
         mock_query_store.delete_conversation.assert_not_called()
 
     def test_delete_with_confirm(self, mcp_server: MCPServerUnderTest) -> None:
-        with (
-            patch("polylogue.mcp.server_support._get_polylogue") as mock_get_polylogue,
-            patch("polylogue.mcp.server._get_query_store") as mock_get_query_store,
-        ):
+        from polylogue.surfaces.payloads import DeleteConversationResult
+
+        with patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue:
             mock_poly = make_polylogue_mock()
-            mock_poly.delete_conversation = AsyncMock(return_value=True)
+            mock_poly.delete_conversation_safe = AsyncMock(
+                return_value=DeleteConversationResult(outcome="deleted", conversation_id="test:conv-123")
+            )
             mock_get_polylogue.return_value = mock_poly
-            mock_get_query_store.return_value = make_query_store_mock(resolved_id="test:conv-123")
 
             result = invoke_surface(
                 mcp_server._tool_manager._tools["delete_conversation"].fn,
@@ -1224,16 +1234,24 @@ class TestMutationTools:
             )
 
         assert json.loads(result)["status"] == "deleted"
+        mock_poly.delete_conversation_safe.assert_awaited_once_with("test:conv-123")
 
     def test_delete_not_found(self, mcp_server: MCPServerUnderTest) -> None:
-        # Two not-found shapes: resolve_id returns None (id never existed) vs.
-        # resolve_id succeeds but delete_conversation returns False (race).
-        # The current contract returns "conversation not found" error for the
-        # former and {status: "not_found"} for the latter; exercise the latter.
-        with patch("polylogue.mcp.server._get_query_store") as mock_get_query_store:
-            mock_query_store = make_query_store_mock(resolved_id="nonexistent")
-            mock_query_store.delete_conversation.return_value = False
-            mock_get_query_store.return_value = mock_query_store
+        # delete_conversation_safe returns outcome="not_found" idempotently,
+        # whether the id never existed or a concurrent delete already removed
+        # it. The MCP tool surfaces status="not_found" instead of raising.
+        from polylogue.surfaces.payloads import DeleteConversationResult
+
+        with patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue:
+            mock_poly = make_polylogue_mock()
+            mock_poly.delete_conversation_safe = AsyncMock(
+                return_value=DeleteConversationResult(
+                    outcome="not_found",
+                    conversation_id="nonexistent",
+                    detail="conversation_not_found",
+                )
+            )
+            mock_get_polylogue.return_value = mock_poly
 
             result = invoke_surface(
                 mcp_server._tool_manager._tools["delete_conversation"].fn,

--- a/tests/unit/operations/test_mutations.py
+++ b/tests/unit/operations/test_mutations.py
@@ -1,0 +1,204 @@
+"""Centralized mutation-contract tests for ``ArchiveMutationsMixin`` (#862).
+
+These tests pin the typed-result entrypoints used by every surface (CLI,
+MCP, daemon, API) so the validation, resolution, and idempotency behavior
+stays in one place.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from polylogue.api import Polylogue
+from polylogue.api.archive import ConversationNotFoundError
+from polylogue.operations.mutations import MetadataKeyValidationError
+from polylogue.surfaces.payloads import (
+    BulkTagMutationResult,
+    DeleteConversationResult,
+    MetadataMutationResult,
+    validate_metadata_key,
+)
+from tests.infra.storage_records import ConversationBuilder, db_setup
+
+
+def _seed(workspace_env: dict[str, Path], conversation_id: str = "conv-mut") -> Path:
+    db_path = db_setup(workspace_env)
+    ConversationBuilder(db_path, conversation_id).provider("claude-code").add_message(
+        message_id=f"{conversation_id}-msg",
+        text="hello world",
+    ).save()
+    return db_path
+
+
+# ---------------------------------------------------------------------------
+# Pure validator
+# ---------------------------------------------------------------------------
+
+
+class TestValidateMetadataKey:
+    def test_accepts_well_formed_key(self) -> None:
+        assert validate_metadata_key("status") is None
+        assert validate_metadata_key("a" * 200) is None
+
+    def test_rejects_empty_or_whitespace(self) -> None:
+        assert validate_metadata_key("") is not None
+        assert validate_metadata_key("   ") is not None
+
+    def test_rejects_oversize(self) -> None:
+        message = validate_metadata_key("k" * 201)
+        assert message is not None
+        assert "200" in message
+
+    def test_rejects_non_string(self) -> None:
+        assert validate_metadata_key(None) is not None
+        assert validate_metadata_key(42) is not None
+
+
+# ---------------------------------------------------------------------------
+# Metadata: set + delete
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestSetMetadataValidated:
+    async def test_set_then_unchanged_then_overwrite(self, workspace_env: dict[str, Path]) -> None:
+        db_path = _seed(workspace_env)
+        async with Polylogue(db_path=db_path, archive_root=workspace_env["archive_root"]) as poly:
+            first = await poly.set_metadata("conv-mut", "status", "ready")
+            second = await poly.set_metadata("conv-mut", "status", "ready")
+            third = await poly.set_metadata("conv-mut", "status", "shipped")
+
+        assert isinstance(first, MetadataMutationResult)
+        assert first.outcome == "set"
+        assert first.conversation_id == "conv-mut"
+        assert first.key == "status"
+        assert second.outcome == "unchanged"
+        assert second.detail == "value_unchanged"
+        assert third.outcome == "set"
+
+    async def test_invalid_key_raises_validation_error(self, workspace_env: dict[str, Path]) -> None:
+        db_path = _seed(workspace_env)
+        async with Polylogue(db_path=db_path, archive_root=workspace_env["archive_root"]) as poly:
+            with pytest.raises(MetadataKeyValidationError):
+                await poly.set_metadata("conv-mut", "", "value")
+            with pytest.raises(MetadataKeyValidationError):
+                await poly.set_metadata("conv-mut", "k" * 201, "value")
+
+    async def test_missing_conversation_raises(self, workspace_env: dict[str, Path]) -> None:
+        db_path = _seed(workspace_env)
+        async with Polylogue(db_path=db_path, archive_root=workspace_env["archive_root"]) as poly:
+            with pytest.raises(ConversationNotFoundError):
+                await poly.set_metadata("missing-id", "status", "ready")
+
+
+@pytest.mark.asyncio
+class TestDeleteMetadataValidated:
+    async def test_deleted_then_not_found(self, workspace_env: dict[str, Path]) -> None:
+        db_path = _seed(workspace_env)
+        async with Polylogue(db_path=db_path, archive_root=workspace_env["archive_root"]) as poly:
+            await poly.set_metadata("conv-mut", "status", "ready")
+            deleted = await poly.delete_metadata("conv-mut", "status")
+            second = await poly.delete_metadata("conv-mut", "status")
+
+        assert deleted.outcome == "deleted"
+        assert deleted.conversation_id == "conv-mut"
+        assert deleted.key == "status"
+        assert second.outcome == "not_found"
+        assert second.detail == "key_not_found"
+
+    async def test_invalid_key_raises_validation_error(self, workspace_env: dict[str, Path]) -> None:
+        db_path = _seed(workspace_env)
+        async with Polylogue(db_path=db_path, archive_root=workspace_env["archive_root"]) as poly:
+            with pytest.raises(MetadataKeyValidationError):
+                await poly.delete_metadata("conv-mut", "")
+
+    async def test_missing_conversation_raises(self, workspace_env: dict[str, Path]) -> None:
+        db_path = _seed(workspace_env)
+        async with Polylogue(db_path=db_path, archive_root=workspace_env["archive_root"]) as poly:
+            with pytest.raises(ConversationNotFoundError):
+                await poly.delete_metadata("missing-id", "status")
+
+
+# ---------------------------------------------------------------------------
+# Delete conversation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestDeleteConversationSafe:
+    async def test_delete_then_not_found(self, workspace_env: dict[str, Path]) -> None:
+        db_path = _seed(workspace_env, conversation_id="conv-del")
+        async with Polylogue(db_path=db_path, archive_root=workspace_env["archive_root"]) as poly:
+            first = await poly.delete_conversation_safe("conv-del")
+            second = await poly.delete_conversation_safe("conv-del")
+
+        assert isinstance(first, DeleteConversationResult)
+        assert first.outcome == "deleted"
+        assert first.conversation_id == "conv-del"
+        assert second.outcome == "not_found"
+        assert second.detail == "conversation_not_found"
+
+    async def test_missing_conversation_returns_not_found(self, workspace_env: dict[str, Path]) -> None:
+        db_path = _seed(workspace_env)
+        async with Polylogue(db_path=db_path, archive_root=workspace_env["archive_root"]) as poly:
+            result = await poly.delete_conversation_safe("never-existed")
+        assert result.outcome == "not_found"
+        assert result.conversation_id == "never-existed"
+
+    async def test_bool_wrapper_still_returns_bool(self, workspace_env: dict[str, Path]) -> None:
+        db_path = _seed(workspace_env, conversation_id="conv-bool")
+        async with Polylogue(db_path=db_path, archive_root=workspace_env["archive_root"]) as poly:
+            assert await poly.delete_conversation("conv-bool") is True
+            assert await poly.delete_conversation("conv-bool") is False
+
+
+# ---------------------------------------------------------------------------
+# Bulk tag conversations
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestBulkTagConversations:
+    async def test_applies_and_counts_affected(self, workspace_env: dict[str, Path]) -> None:
+        db_path = db_setup(workspace_env)
+        for cid in ("conv-a", "conv-b"):
+            ConversationBuilder(db_path, cid).provider("claude-code").add_message(
+                message_id=f"{cid}-msg",
+                text="x",
+            ).save()
+        async with Polylogue(db_path=db_path, archive_root=workspace_env["archive_root"]) as poly:
+            first = await poly.bulk_tag_conversations(["conv-a", "conv-b"], ["important"])
+            # Re-applying the same tag should report zero affected.
+            second = await poly.bulk_tag_conversations(["conv-a", "conv-b"], ["important"])
+
+        assert isinstance(first, BulkTagMutationResult)
+        assert first.conversation_count == 2
+        assert first.tag_count == 1
+        assert first.affected_count == 2
+        assert first.skipped_count == 0
+        assert second.affected_count == 0
+        assert second.skipped_count == 2
+
+    async def test_empty_conversation_ids_raises(self, workspace_env: dict[str, Path]) -> None:
+        db_path = _seed(workspace_env)
+        async with Polylogue(db_path=db_path, archive_root=workspace_env["archive_root"]) as poly:
+            with pytest.raises(ValueError, match="conversation_id"):
+                await poly.bulk_tag_conversations([], ["t"])
+
+    async def test_empty_tags_raises(self, workspace_env: dict[str, Path]) -> None:
+        db_path = _seed(workspace_env)
+        async with Polylogue(db_path=db_path, archive_root=workspace_env["archive_root"]) as poly:
+            with pytest.raises(ValueError, match="tag"):
+                await poly.bulk_tag_conversations(["conv-mut"], [])
+
+    async def test_oversize_inputs_raise(self, workspace_env: dict[str, Path]) -> None:
+        db_path = _seed(workspace_env)
+        async with Polylogue(db_path=db_path, archive_root=workspace_env["archive_root"]) as poly:
+            many_ids = [f"id-{i}" for i in range(101)]
+            with pytest.raises(ValueError, match="at most 100"):
+                await poly.bulk_tag_conversations(many_ids, ["t"])
+            many_tags = [f"t{i}" for i in range(21)]
+            with pytest.raises(ValueError, match="at most 20"):
+                await poly.bulk_tag_conversations(["conv-mut"], many_tags)


### PR DESCRIPTION
## Summary

Routes the seven remaining surface-side mutation paths through the shared
`ArchiveMutationsMixin` contract introduced in #1109, completing the
cross-surface centralization tracked by #862. Adds typed result models
(`MetadataMutationResult`, `DeleteConversationResult`,
`BulkTagMutationResult`) and a single source of truth for metadata key
validation.

## Problem

Audit of master left seven divergences where CLI, MCP, and daemon
surfaces still bypassed the operation mixin:

1. `polylogue/cli/query_actions.py::apply_modifiers` set metadata via
   `repo.update_metadata` directly, skipping the conversation-existence
   check.
2. `polylogue/mcp/server_mutation_tools.py::bulk_tag_conversations`
   called `tag_store.bulk_add_tags` directly with inline 100/20 batch
   caps duplicated outside the operation layer.
3. `polylogue/mcp/server_mutation_tools.py::delete_metadata` called
   `tag_store.delete_metadata` directly with no resolution through
   the facade.
4. `polylogue/mcp/server_mutation_tools.py::delete_conversation`
   mapped `bool -> "deleted"/"not_found"` inside the surface; nothing
   guaranteed every adapter would do that the same way.
5. `polylogue/cli/query_actions.py::delete_conversations` called
   `repo.delete_conversation` directly without facade resolution or
   idempotency contract.
6. Metadata key validation (empty/whitespace, 200-char limit) was
   inline in MCP `set_metadata` only — every other surface relied on
   storage-layer behavior.
7. `polylogue/daemon/http.py::_handle_reset` had a latent async bug:
   the synchronous `_do_reset` callback called the async
   `poly.delete_conversation` and returned the coroutine into a JSON
   encode path, never deleting anything.

## Solution

- **`polylogue/operations/mutations.py`**: extended `ArchiveMutationsMixin`
  with resolve-aware typed-result entrypoints — `set_metadata_validated`,
  `delete_metadata_validated`, `delete_conversation_safe`,
  `bulk_tag_conversations` — plus the centralized
  `_validate_metadata_key` helper and a `MetadataKeyValidationError`
  exception. The previous bool-returning methods stay as low-level
  delegates.
- **`polylogue/surfaces/payloads.py`**: added typed
  `MetadataMutationResult`, `DeleteConversationResult`,
  `BulkTagMutationResult`, and `validate_metadata_key` /
  `METADATA_KEY_MAX_LENGTH` constants.
- **`polylogue/api/archive.py`**: `Polylogue.delete_conversation`,
  `update_metadata`, the new `set_metadata`, `delete_metadata`,
  `delete_conversation_safe`, and `bulk_tag_conversations` all route
  through the mixin.
- **`polylogue/cli/query_actions.py`**: `apply_modifiers` metadata writes
  go through `env.polylogue.set_metadata`; `delete_conversations` calls
  `env.polylogue.delete_conversation_safe`. Custom-repo escape hatches
  preserved for test/batch tools.
- **`polylogue/mcp/server_mutation_tools.py`**: bulk tagging, set/delete
  metadata, and delete-conversation tools route through the facade and
  the typed results; key validation runs at the surface boundary before
  opening the facade so unit tests can exercise the rejection path
  without standing up an archive.
- **`polylogue/daemon/http.py`**: `_handle_reset` now awaits
  `delete_conversation_safe` through the existing `_sync_run` async
  bridge and removes the obsolete `_get_or_create_polylogue` helper.
- **`tests/unit/operations/test_mutations.py`** (new): 17 tests covering
  every (mutation, exists/missing, validation) pair on top of a real
  SQLite archive built via `ConversationBuilder`.
- **`tests/unit/mcp/test_tool_contracts.py`**, **`tests/infra/mcp.py`**:
  refreshed mocks to track the new facade-typed return values.
- **`tests/property/test_filter_chain_laws.py`**: fix for an inherited
  property-test failure (provider filter replaces prior provider rather
  than intersecting, so the monotonicity law required tightening to
  an impossible provider on disagreement). Surfaced by `devtools verify`
  before this PR could be merged.

## Verification

```
$ devtools verify --quick
total_duration_s: 20.22, exit_code: 0

$ devtools verify --all
"name": "pytest full", "exit": 0, "count": 7268, "passed": 7266,
"xfailed": 2
total_duration_s: 101.93, exit_code: 0

$ pytest tests/unit/operations/test_mutations.py
17 passed in 8.13s
```

Closes #862