### PR TITLE
feat(cli): polish color, completions, narrow-terminal output (#958)

### DIFF
--- a/polylogue/cli/query_output.py
+++ b/polylogue/cli/query_output.py
@@ -64,7 +64,76 @@ def _display_date(value: datetime | None, date_format: str = "%Y-%m-%d") -> str:
 
 
 def _ellipsize(value: str, max_width: int) -> str:
+    if max_width <= 3:
+        return value[:max_width]
     return (value[: max_width - 3] + "...") if len(value) > max_width else value
+
+
+class _LayoutBreakpoints:
+    """Terminal-width breakpoints for graceful narrow rendering.
+
+    Listed widest-first. The first breakpoint whose ``min_width`` fits the
+    current terminal wins. Below the narrowest breakpoint we drop to a single
+    "id/title" line per row so output stays legible at ~40 columns.
+
+    Pinned at 80 / 60 / 40 so the contract is observable in tests without
+    depending on host terminal size.
+    """
+
+    WIDE_MIN = 80
+    MID_MIN = 60
+    NARROW_MIN = 40
+
+
+def _terminal_width(env: AppEnv) -> int:
+    """Return the rendering terminal width, falling back to 80 columns."""
+    width = getattr(env.ui.console, "width", None)
+    if isinstance(width, int) and width > 0:
+        return width
+    return 80
+
+
+def _summary_list_layout(width: int) -> tuple[str, ...]:
+    """Pick a column set for the conversation-list table at ``width`` columns.
+
+    ``width`` is the rendered terminal width. The selection is deterministic
+    and pinned by ``test_narrow_terminal_layout``; do not reorder columns
+    without updating that contract.
+    """
+    if width >= _LayoutBreakpoints.WIDE_MIN:
+        return ("id", "date", "provider", "title", "msgs")
+    if width >= _LayoutBreakpoints.MID_MIN:
+        # Drop the wide ID column; titles get more room.
+        return ("date", "provider", "title", "msgs")
+    if width >= _LayoutBreakpoints.NARROW_MIN:
+        # Drop provider too; date + title + msgs survives at 40 cols.
+        return ("date", "title", "msgs")
+    # Below the narrowest breakpoint we go single-column.
+    return ("title",)
+
+
+def _search_hit_layout(width: int) -> tuple[str, ...]:
+    """Pick a column set for the search-hit table at ``width`` columns."""
+    if width >= _LayoutBreakpoints.WIDE_MIN:
+        return ("id", "date", "provider", "title", "msgs", "match")
+    if width >= _LayoutBreakpoints.MID_MIN:
+        # Drop ID column; keep match snippet for context.
+        return ("date", "provider", "title", "match")
+    if width >= _LayoutBreakpoints.NARROW_MIN:
+        # Drop provider and date; keep title + match snippet.
+        return ("title", "match")
+    return ("title",)
+
+
+def _title_budget(width: int) -> int:
+    """Title truncation budget for the rendered terminal width."""
+    if width >= _LayoutBreakpoints.WIDE_MIN:
+        return 63
+    if width >= _LayoutBreakpoints.MID_MIN:
+        return max(30, width - 24)
+    if width >= _LayoutBreakpoints.NARROW_MIN:
+        return max(18, width - 18)
+    return max(12, width - 2)
 
 
 def _conversation_list_line(conv: Conversation) -> str:
@@ -427,27 +496,53 @@ async def output_search_hits(
 
     from polylogue.ui.theme import provider_color
 
+    width = _terminal_width(env)
+    columns = _search_hit_layout(width)
+    title_budget = _title_budget(width)
+    snippet_budget = max(20, min(80, width - 24))
+
     table = Table(show_header=True, header_style="bold", box=None, pad_edge=False, show_edge=False)
-    table.add_column("ID", style="dim", max_width=24, no_wrap=True)
-    table.add_column("Date", style="dim")
-    table.add_column("Provider")
-    table.add_column("Title", ratio=1)
-    table.add_column("Msgs", justify="right")
-    table.add_column("Match", ratio=1)
+    for column in columns:
+        if column == "id":
+            table.add_column("ID", style="dim", max_width=24, no_wrap=True)
+        elif column == "date":
+            table.add_column("Date", style="dim")
+        elif column == "provider":
+            table.add_column("Provider")
+        elif column == "title":
+            table.add_column("Title", ratio=1)
+        elif column == "msgs":
+            table.add_column("Msgs", justify="right")
+        elif column == "match":
+            table.add_column("Match", ratio=1)
 
     for hit in hits:
         summary = hit.summary
         date = _display_date(summary.display_date)
-        title = _ellipsize(summary.display_title or str(summary.id)[:20], 54)
+        title = _ellipsize(summary.display_title or str(summary.id)[:20], title_budget)
         count = msg_counts.get(hit.conversation_id, summary.message_count or 0)
         provider_text = Text(summary.provider, style=provider_color(summary.provider).hex)
-        snippet = _ellipsize(hit.snippet or "", 80)
+        snippet = _ellipsize(hit.snippet or "", snippet_budget)
         match = f"{hit.match_surface}/{hit.retrieval_lane}"
         if hit.message_id:
             match = f"{match} {hit.message_id}"
         if snippet:
             match = f"{match}: {snippet}"
-        table.add_row(str(summary.id)[:24], date, provider_text, title, str(count), match)
+        row: list[str | Text] = []
+        for column in columns:
+            if column == "id":
+                row.append(str(summary.id)[:24])
+            elif column == "date":
+                row.append(date)
+            elif column == "provider":
+                row.append(provider_text)
+            elif column == "title":
+                row.append(title)
+            elif column == "msgs":
+                row.append(str(count))
+            elif column == "match":
+                row.append(match)
+        table.add_row(*row)
 
     env.ui.console.print(table)
 
@@ -480,19 +575,41 @@ async def output_summary_list(
 
     from polylogue.ui.theme import provider_color
 
+    width = _terminal_width(env)
+    columns = _summary_list_layout(width)
+    title_budget = _title_budget(width)
+
     table = Table(show_header=True, header_style="bold", box=None, pad_edge=False, show_edge=False)
-    table.add_column("ID", style="dim", max_width=24, no_wrap=True)
-    table.add_column("Date", style="dim")
-    table.add_column("Provider")
-    table.add_column("Title", ratio=1)
-    table.add_column("Msgs", justify="right")
+    for column in columns:
+        if column == "id":
+            table.add_column("ID", style="dim", max_width=24, no_wrap=True)
+        elif column == "date":
+            table.add_column("Date", style="dim")
+        elif column == "provider":
+            table.add_column("Provider")
+        elif column == "title":
+            table.add_column("Title", ratio=1)
+        elif column == "msgs":
+            table.add_column("Msgs", justify="right")
 
     for summary in summaries:
         date = _display_date(summary.display_date)
-        title = _ellipsize(summary.display_title or str(summary.id)[:20], 63)
+        title = _ellipsize(summary.display_title or str(summary.id)[:20], title_budget)
         count = msg_counts.get(str(summary.id), 0)
         provider_text = Text(summary.provider, style=provider_color(summary.provider).hex)
-        table.add_row(str(summary.id)[:24], date, provider_text, title, str(count))
+        row: list[str | Text] = []
+        for column in columns:
+            if column == "id":
+                row.append(str(summary.id)[:24])
+            elif column == "date":
+                row.append(date)
+            elif column == "provider":
+                row.append(provider_text)
+            elif column == "title":
+                row.append(title)
+            elif column == "msgs":
+                row.append(str(count))
+        table.add_row(*row)
 
     env.ui.console.print(table)
 

--- a/polylogue/cli/shared/formatting.py
+++ b/polylogue/cli/shared/formatting.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import sys
 from collections.abc import Mapping
 from pathlib import Path
@@ -21,10 +22,25 @@ def plain_forced_by_env() -> bool:
     return load_polylogue_config().force_plain
 
 
+def no_color_requested() -> bool:
+    """Return True if NO_COLOR is set to any non-empty value.
+
+    Honors the convention documented at https://no-color.org/: presence of a
+    non-empty ``NO_COLOR`` environment variable disables color output, even
+    when the destination is a TTY. The variable is intentionally orthogonal
+    to ``POLYLOGUE_FORCE_PLAIN``: ``NO_COLOR`` is a request to drop ANSI
+    color codes; plain mode is a stronger request that also drops Rich
+    layout primitives (tables, boxes, glyphs).
+    """
+    return bool(os.environ.get("NO_COLOR"))
+
+
 def should_use_plain(*, plain: bool) -> bool:
     if plain:
         return True
     if plain_forced_by_env():
+        return True
+    if no_color_requested():
         return True
     return not (sys.stdout.isatty() and sys.stderr.isatty())
 

--- a/tests/unit/cli/test_color_and_layout.py
+++ b/tests/unit/cli/test_color_and_layout.py
@@ -1,0 +1,179 @@
+"""Contracts for CLI color discipline and narrow-terminal output layout.
+
+Pins two user-visible CLI ergonomics behaviors landed for #958:
+
+* ``NO_COLOR`` (https://no-color.org/ convention) forces plain rendering even
+  on a TTY. This mirrors how ``POLYLOGUE_FORCE_PLAIN`` already behaves and
+  guarantees ANSI-free output for downstream pipelines that set ``NO_COLOR``
+  but cannot opt into the Polylogue-specific override.
+
+* ``output_summary_list`` and ``output_search_hits`` adapt their column set
+  and title-truncation budget to the rendered terminal width, so a 40-column
+  terminal still produces a readable table without horizontal overflow.
+
+Companion to ``test_plain_output_contract.py`` (--plain ANSI guarantees) and
+``test_help_contract.py`` (help structure).
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from click.testing import CliRunner
+
+from polylogue.cli.click_app import cli
+from polylogue.cli.query_output import (
+    _LayoutBreakpoints,
+    _search_hit_layout,
+    _summary_list_layout,
+    _title_budget,
+)
+from polylogue.cli.shared.formatting import (
+    no_color_requested,
+    should_use_plain,
+)
+
+pytestmark = pytest.mark.contract
+
+
+class TestNoColorEnv:
+    """``NO_COLOR`` follows the cross-tool convention and forces plain mode."""
+
+    def test_no_color_detection_respects_presence(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Presence of ``NO_COLOR`` (any non-empty value) requests no color."""
+        monkeypatch.delenv("NO_COLOR", raising=False)
+        assert no_color_requested() is False
+        monkeypatch.setenv("NO_COLOR", "1")
+        assert no_color_requested() is True
+        monkeypatch.setenv("NO_COLOR", "anything-truthy")
+        assert no_color_requested() is True
+
+    def test_no_color_empty_string_is_disabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Empty ``NO_COLOR`` (set but blank) is treated as not requesting."""
+        monkeypatch.setenv("NO_COLOR", "")
+        assert no_color_requested() is False
+
+    def test_should_use_plain_bridges_no_color(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``NO_COLOR`` forces plain mode even when --plain is not passed."""
+        monkeypatch.delenv("POLYLOGUE_FORCE_PLAIN", raising=False)
+        monkeypatch.setenv("NO_COLOR", "1")
+        assert should_use_plain(plain=False) is True
+
+    def test_should_use_plain_no_color_unset_keeps_tty_behavior(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Without ``NO_COLOR`` (and not in a TTY), plain mode comes from non-TTY detection."""
+        monkeypatch.delenv("POLYLOGUE_FORCE_PLAIN", raising=False)
+        monkeypatch.delenv("NO_COLOR", raising=False)
+        # CliRunner / pytest runs non-TTY, so plain falls out of the TTY check.
+        assert should_use_plain(plain=False) is True
+
+    def test_cli_list_with_no_color_produces_no_ansi(
+        self, monkeypatch: pytest.MonkeyPatch, workspace_env: dict[str, object]
+    ) -> None:
+        """End-to-end: ``NO_COLOR=1 polylogue list`` is byte-for-byte ANSI-free.
+
+        Pins the no-color contract end-to-end so the bridge cannot regress
+        silently if ``should_use_plain`` is reworked.
+        """
+        del workspace_env
+        monkeypatch.delenv("POLYLOGUE_FORCE_PLAIN", raising=False)
+        monkeypatch.setenv("NO_COLOR", "1")
+        runner = CliRunner()
+        result = runner.invoke(cli, ["list"], catch_exceptions=True)
+        if result.exception is not None and not isinstance(result.exception, SystemExit):
+            raise result.exception
+        assert "\x1b" not in result.stdout, f"ANSI escape leaked under NO_COLOR: {result.stdout!r}"
+        assert "\x1b" not in result.stderr, f"ANSI escape leaked under NO_COLOR: {result.stderr!r}"
+
+
+class TestNarrowTerminalLayout:
+    """Conversation/search-hit tables degrade gracefully at narrow widths.
+
+    The layout helpers are pure functions and the public contract is:
+
+    * Wide (>=80 cols): show every column.
+    * Mid  (>=60 cols): drop the ID column to make room for titles.
+    * Narrow (>=40 cols): drop provider too; keep date+title+msgs for the
+      conversation list, title+match for search hits.
+    * Below 40 cols: degenerate to a single ``title`` column.
+
+    The mapping is pinned here because downstream syrupy snapshots would not
+    catch a silent column-set drift on a 40-column terminal (the snapshot is
+    pinned at the default 80 columns).
+    """
+
+    @pytest.mark.parametrize(
+        ("width", "expected"),
+        [
+            (200, ("id", "date", "provider", "title", "msgs")),
+            (_LayoutBreakpoints.WIDE_MIN, ("id", "date", "provider", "title", "msgs")),
+            (_LayoutBreakpoints.WIDE_MIN - 1, ("date", "provider", "title", "msgs")),
+            (_LayoutBreakpoints.MID_MIN, ("date", "provider", "title", "msgs")),
+            (_LayoutBreakpoints.MID_MIN - 1, ("date", "title", "msgs")),
+            (_LayoutBreakpoints.NARROW_MIN, ("date", "title", "msgs")),
+            (_LayoutBreakpoints.NARROW_MIN - 1, ("title",)),
+            (20, ("title",)),
+        ],
+    )
+    def test_summary_list_layout(self, width: int, expected: tuple[str, ...]) -> None:
+        assert _summary_list_layout(width) == expected
+
+    @pytest.mark.parametrize(
+        ("width", "expected"),
+        [
+            (200, ("id", "date", "provider", "title", "msgs", "match")),
+            (_LayoutBreakpoints.WIDE_MIN, ("id", "date", "provider", "title", "msgs", "match")),
+            (_LayoutBreakpoints.WIDE_MIN - 1, ("date", "provider", "title", "match")),
+            (_LayoutBreakpoints.MID_MIN, ("date", "provider", "title", "match")),
+            (_LayoutBreakpoints.MID_MIN - 1, ("title", "match")),
+            (_LayoutBreakpoints.NARROW_MIN, ("title", "match")),
+            (_LayoutBreakpoints.NARROW_MIN - 1, ("title",)),
+            (20, ("title",)),
+        ],
+    )
+    def test_search_hit_layout(self, width: int, expected: tuple[str, ...]) -> None:
+        assert _search_hit_layout(width) == expected
+
+    def test_title_budget_monotonic_in_width(self) -> None:
+        """Title budget never grows when terminal width shrinks across breakpoints."""
+        widths = [200, 100, 80, 79, 60, 59, 40, 39, 20]
+        budgets = [_title_budget(w) for w in widths]
+        # Strictly non-increasing across non-equal widths is too strong (we
+        # cap at a per-breakpoint floor); instead assert wide >= mid >= narrow.
+        assert budgets[0] >= budgets[3], "wide budget should be >= mid budget"
+        assert budgets[3] >= budgets[6], "mid budget should be >= narrow budget"
+        assert all(budget > 0 for budget in budgets), f"non-positive title budget: {budgets}"
+
+    def test_title_budget_keeps_room_at_40_cols(self) -> None:
+        """At 40 columns the title still gets at least 18 chars of room."""
+        assert _title_budget(40) >= 18
+
+    def test_title_budget_handles_pathologically_narrow(self) -> None:
+        """A 10-column terminal still returns a positive title budget."""
+        assert _title_budget(10) > 0
+
+
+class TestNoColorIsNotPolylogueSpecific:
+    """``NO_COLOR`` respects the cross-tool environment regardless of Polylogue settings."""
+
+    def test_no_color_overrides_tty_assumption(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Set ``NO_COLOR``, clear ``POLYLOGUE_FORCE_PLAIN``: plain still wins."""
+        monkeypatch.delenv("POLYLOGUE_FORCE_PLAIN", raising=False)
+        monkeypatch.setenv("NO_COLOR", "1")
+        assert should_use_plain(plain=False) is True
+
+    def test_polylogue_force_plain_still_wins_when_no_color_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The existing POLYLOGUE_FORCE_PLAIN path is unchanged."""
+        monkeypatch.delenv("NO_COLOR", raising=False)
+        monkeypatch.setenv("POLYLOGUE_FORCE_PLAIN", "1")
+        assert should_use_plain(plain=False) is True
+
+
+def test_no_color_env_does_not_leak_into_other_tests(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Sanity: tests above use monkeypatch so ``NO_COLOR`` does not bleed.
+
+    Guards against accidentally promoting ``NO_COLOR`` to a global default by
+    mutating ``os.environ`` directly.
+    """
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    assert os.environ.get("NO_COLOR") is None


### PR DESCRIPTION
## Summary

CLI polish pass for #958 covering two concrete user-visible behaviors:
NO_COLOR support and graceful narrow-terminal output. The existing
completions surface (`polylogue/cli/shell_completion_values.py`, last
revised by #1109) already covers the issue's dynamic-completer
acceptance criteria — provider names, conversation IDs, tags, repo,
cwd-prefix, tool names — so this PR does not touch it.

## Problem

- The CLI honored `POLYLOGUE_FORCE_PLAIN` but ignored the cross-tool
  `NO_COLOR` convention (https://no-color.org/). Downstream pipelines
  setting `NO_COLOR=1` still got ANSI escape codes in any TTY path.
- `output_summary_list` and `output_search_hits` built fixed-shape Rich
  tables (ID/Date/Provider/Title/Msgs[/Match]) with a 63-char title
  budget, regardless of terminal width. At narrow widths (≤60 columns)
  the table overflowed; at the 40-column edge it became unreadable.

## Solution

`polylogue/cli/shared/formatting.py`:
- New `no_color_requested()` honors the `NO_COLOR` env var per the
  no-color.org spec (presence of any non-empty value = no color).
- `should_use_plain()` now bridges `NO_COLOR` to plain mode, matching
  the user-visible effect ("no color in output") without touching
  `polylogue/ui/` (owned by another lane). Documented as a deliberate
  short-form: true color-suppression-without-layout-drop would require
  flipping `no_color=False` in `polylogue/ui/facade.py`.

`polylogue/cli/query_output.py`:
- New `_summary_list_layout(width)`, `_search_hit_layout(width)`,
  `_title_budget(width)` helpers pin a deterministic
  wide(≥80)/mid(≥60)/narrow(≥40)/sub-narrow column selection.
- `output_summary_list` and `output_search_hits` consult
  `env.ui.console.width` and assemble columns/rows from the selected
  set; below 40 columns we fall back to a single `title` column rather
  than letting Rich wrap.

`tests/unit/cli/test_color_and_layout.py`:
- Pins `NO_COLOR` detection semantics (presence vs empty), the
  `should_use_plain` bridge, end-to-end `polylogue list` byte-level
  ANSI absence under `NO_COLOR=1`, the layout column sets at every
  breakpoint, and the title-budget monotonicity contract.

Out of scope (deferred to follow-ups):
- True color-only-no-layout-drop under `NO_COLOR` (requires
  `polylogue/ui/facade.py` edit; ui/ is owned by another lane).
- TUI/textual color discipline (#958 explicitly excludes the TUI).
- Standardizing short flag aliases across all subcommands (separate
  ergonomics pass).

## Verification

```
nix develop -c devtools verify --quick   # all 16 steps green
nix develop -c pytest tests/unit/cli/ -q  # 1088 passed, 1 xfailed
```

The new contracts (`test_color_and_layout.py`) cover both behaviors:
13 tests, all pinned to public-observable surfaces (env var, exit
codes, column-set tuples, title-budget integers).

Ref #958

🤖 Generated with [Claude Code](https://claude.com/claude-code)