### PR TITLE
feat(distribution): PyPI/container packaging readiness (#953)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,3 +75,24 @@ jobs:
       - run: uv run devtools lab-scenario verify-baselines
         env:
           POLYLOGUE_FORCE_PLAIN: "1"
+
+  distribution:
+    # Build wheel + sdist from the checkout, rebuild a wheel from the unpacked
+    # sdist, install each into fresh venvs, and smoke the runtime entrypoints
+    # (polylogue / polylogued / polylogue-mcp). Closes the distribution.wheel-ci
+    # and distribution.sdist-ci gaps tracked under #593 / #953.
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v8.1.0
+        with:
+          python-version: "3.13"
+      - run: uv sync --extra dev --frozen
+      - run: uv run devtools verify-distribution-surface --work-dir "${RUNNER_TEMP}/dist" --keep-work-dir
+        env:
+          POLYLOGUE_FORCE_PLAIN: "1"
+      - uses: actions/upload-artifact@v7
+        with:
+          name: distribution-artifacts
+          path: ${{ runner.temp }}/dist/dist/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,127 @@
+name: Release
+
+# Triggered by pushing an annotated tag matching `vX.Y.Z`. Builds the
+# wheel + sdist, smokes them through verify-distribution-surface, then:
+#   - publishes to PyPI via Trusted Publishing (OIDC, no API token), and
+#   - builds + pushes a multi-stage OCI image to ghcr.io.
+#
+# A manual `workflow_dispatch` path exists to dry-run the build/smoke
+# pipeline against any ref without publishing.
+#
+# PyPI Trusted Publishing must be configured once in the project on
+# pypi.org under "Publishing" → "Add a new pending publisher" with:
+#   owner = Sinity, repo = polylogue, workflow = release.yml,
+#   environment = pypi.
+# See docs/release.md for the operator checklist.
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: "Publish to PyPI and GHCR (false = dry-run build/smoke only)"
+        required: false
+        default: "false"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: build-and-smoke
+    timeout-minutes: 20
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v8.1.0
+        with:
+          python-version: "3.13"
+      - name: Install dev dependencies (frozen lockfile)
+        run: uv sync --extra dev --frozen
+      - name: Build wheel + sdist and smoke installed entrypoints
+        run: uv run devtools verify-distribution-surface --work-dir "${RUNNER_TEMP}/dist" --keep-work-dir
+        env:
+          POLYLOGUE_FORCE_PLAIN: "1"
+      - name: Extract project version from pyproject.toml
+        id: version
+        run: |
+          version=$(uv run python -c "import tomllib, pathlib; print(tomllib.loads(pathlib.Path('pyproject.toml').read_text())['project']['version'])")
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+      - uses: actions/upload-artifact@v7
+        with:
+          name: distribution-artifacts
+          path: ${{ runner.temp }}/dist/dist/*
+          if-no-files-found: error
+
+  publish-pypi:
+    name: publish-pypi
+    needs: build
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish == 'true')
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/polylogue/${{ needs.build.outputs.version }}/
+    permissions:
+      # OIDC token for PyPI Trusted Publishing.
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v6
+        with:
+          name: distribution-artifacts
+          path: dist/
+      - name: Drop work-dir scaffolding (keep only top-level wheel + sdist)
+        # verify-distribution-surface emits the unpacked-sdist tree under
+        # the work-dir; we only want the top-level dist/*.whl and *.tar.gz.
+        run: |
+          find dist/ -mindepth 1 -maxdepth 1 -type d -exec rm -rf {} +
+          ls -la dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true
+          verbose: true
+
+  publish-container:
+    name: publish-container
+    needs: build
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish == 'true')
+    timeout-minutes: 25
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/polylogue
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=ref,event=tag
+            type=raw,value=latest,enable={{is_default_branch}}
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Containerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,14 @@ documentation polish do not require an entry.
 
 ### Added
 
+- Broad-distribution packaging readiness (#953): the
+  `verify-distribution-surface` gate now runs as a `distribution` job in
+  `ci.yml` on every push, a new `release.yml` workflow publishes wheel
+  and sdist to PyPI via OIDC Trusted Publishing on `vX.Y.Z` tag push,
+  and a multi-stage `Containerfile` produces an OCI image that
+  `release.yml` builds and pushes to `ghcr.io/sinity/polylogue` with
+  semver tags. See [`docs/release.md`](docs/release.md) for the cut-time
+  checklist.
 - Local source discovery and parsing for Gemini CLI `~/.gemini/tmp` sessions
   and Hermes `~/.hermes/sessions` session documents, with distinct
   `gemini-cli` / `hermes` source identities.

--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,75 @@
+# syntax=docker/dockerfile:1.7
+#
+# Polylogue OCI image. Multi-stage:
+#   1. builder — uses `uv` to build the wheel from the checkout
+#   2. runtime — slim python image, installs only the built wheel
+#
+# Exposes three console scripts (polylogue, polylogued, polylogue-mcp) on PATH.
+# Operators are expected to mount durable state:
+#   -v polylogue-data:/data    (XDG_DATA_HOME — archive SQLite, blobs)
+#   -v polylogue-config:/config (XDG_CONFIG_HOME — polylogue.toml, secrets)
+#
+# Example invocations:
+#   podman run --rm ghcr.io/sinity/polylogue:latest polylogue --version
+#   podman run --rm -v polylogue-data:/data ghcr.io/sinity/polylogue:latest \
+#     polylogue stats
+#   podman run -d --name polylogued -v polylogue-data:/data \
+#     -v polylogue-config:/config -p 7777:7777 \
+#     ghcr.io/sinity/polylogue:latest polylogued run --enable-api
+
+# ---- builder ------------------------------------------------------------
+FROM python:3.13-slim-bookworm AS builder
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    UV_NO_PROGRESS=1 \
+    UV_LINK_MODE=copy
+
+# uv is the canonical build driver in this repo.
+COPY --from=ghcr.io/astral-sh/uv:0.5.4 /uv /usr/local/bin/uv
+
+WORKDIR /src
+COPY . /src
+
+# Build wheel into /dist. Hatchling embeds polylogue/_build_info.py via
+# hatch_build.py, so the resulting wheel knows its own version + commit.
+RUN uv build --wheel --out-dir /dist /src
+
+# ---- runtime ------------------------------------------------------------
+FROM python:3.13-slim-bookworm AS runtime
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    POLYLOGUE_FORCE_PLAIN=1 \
+    XDG_DATA_HOME=/data \
+    XDG_CONFIG_HOME=/config \
+    XDG_CACHE_HOME=/cache
+
+# Runtime deps:
+#   ca-certificates — outbound HTTPS (PyPI, Voyage, Drive)
+#   tini             — PID 1 for clean SIGTERM/SIGINT signalling
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates tini \
+ && rm -rf /var/lib/apt/lists/*
+
+# Install the built wheel without dev/extras. Dependencies are resolved
+# from PyPI against the wheel's declared metadata.
+COPY --from=builder /dist/*.whl /tmp/
+RUN pip install --no-cache-dir /tmp/*.whl && rm /tmp/*.whl
+
+# Non-root runtime user; archive writes happen under /data so it must own
+# the mount target. Operators that bind-mount a host path are expected to
+# either chown it to UID 1000 or override --user explicitly.
+RUN groupadd --system --gid 1000 polylogue \
+ && useradd  --system --uid 1000 --gid polylogue --home /home/polylogue --create-home polylogue \
+ && mkdir -p /data /config /cache \
+ && chown -R polylogue:polylogue /data /config /cache
+
+USER polylogue
+WORKDIR /home/polylogue
+VOLUME ["/data", "/config"]
+
+ENTRYPOINT ["/usr/bin/tini", "--"]
+CMD ["polylogue", "--help"]

--- a/docs/plans/distribution-coverage.yaml
+++ b/docs/plans/distribution-coverage.yaml
@@ -1,11 +1,14 @@
 # Distribution-coverage manifest.
 #
 # Documents the current state of install-artifact parity across
-# wheel, sdist, and Nix package. The local distribution gate now
-# builds wheel/sdist artifacts, rebuilds from unpacked sdist without
-# .git, and smokes installed runtime entrypoints.
+# wheel, sdist, Nix package, and OCI container. The local distribution
+# gate now builds wheel/sdist artifacts, rebuilds from unpacked sdist
+# without .git, smokes installed runtime entrypoints, and is wired into
+# CI (.github/workflows/ci.yml::distribution). PyPI Trusted Publishing
+# and GHCR container push run from .github/workflows/release.yml on
+# `vX.Y.Z` tag push.
 #
-# Updated 2026-05-02 from realized codebase state.
+# Updated 2026-05-17 for #953 — broad-distribution packaging.
 
 description: >
   Wheel/sdist/Nix install parity for polylogue. Documents build
@@ -17,32 +20,34 @@ artifacts:
     description: Python wheel distribution (bdist_wheel)
     build_system: hatchling
     config_location: pyproject.toml
-    build_command: uv build --wheel .
-    install_command: pip install polylogue-*.whl
+    build_command: devtools verify-distribution-surface
+    install_command: pip install polylogue
     verification_command: devtools verify-distribution-surface
-    ci_build: false
-    ci_test: false
+    ci_build: true
+    ci_test: true
     notes: >
       pyproject.toml uses [build-system] with hatchling.
-      The source-checkout distribution gate builds the wheel,
-      installs it in a fresh environment, smokes polylogue,
-      polylogued, polylogue-mcp, and python -m polylogue. The
-      gate is not yet scheduled in CI.
+      The distribution gate (ci.yml::distribution) builds wheel +
+      sdist, installs each in a fresh venv, and smokes polylogue,
+      polylogued, polylogue-mcp, and python -m polylogue. Tagged
+      releases publish to PyPI via OIDC Trusted Publishing
+      (release.yml::publish-pypi).
 
   sdist:
     description: Python source distribution (sdist)
     build_system: hatchling
     config_location: pyproject.toml
-    build_command: uv build --sdist .
-    install_command: pip install polylogue-*.tar.gz
+    build_command: devtools verify-distribution-surface
+    install_command: pip install polylogue
     verification_command: devtools verify-distribution-surface
-    ci_build: false
-    ci_test: false
+    ci_build: true
+    ci_test: true
     notes: >
       Source distribution embeds polylogue/_build_info.py. The
       distribution gate unpacks the sdist outside .git, rebuilds
       a wheel from it, installs that wheel, and runs the same
-      runtime smoke surface. The gate is not yet scheduled in CI.
+      runtime smoke surface (ci.yml::distribution). Tagged releases
+      publish to PyPI via OIDC Trusted Publishing.
 
   nix_package:
     description: Nix flake package derivation
@@ -70,6 +75,24 @@ artifacts:
       Development install via pip install -e . (hatchling).
       Used locally but not verified in CI. The devshell
       (nix develop) is the canonical dev environment.
+
+  oci_container:
+    description: OCI image with polylogue / polylogued / polylogue-mcp on PATH
+    build_system: Containerfile (multi-stage, uv wheel build + slim runtime)
+    config_location: Containerfile
+    build_command: docker buildx build -f Containerfile .
+    install_command: podman pull ghcr.io/sinity/polylogue:latest
+    ci_build: false
+    ci_test: false
+    notes: >
+      Builder stage uses `uv build --wheel`; runtime stage installs the
+      wheel into python:3.13-slim-bookworm under a non-root user with
+      tini as PID 1. Volumes /data (XDG_DATA_HOME) and /config
+      (XDG_CONFIG_HOME) are declared. Build + push to GHCR runs from
+      release.yml::publish-container on `vX.Y.Z` tag push. Pre-tag CI
+      does not build the image to keep ci.yml fast; the
+      verify-distribution-surface gate exercises the same wheel that
+      the Containerfile installs.
 
   devshell:
     description: Nix development shell
@@ -105,24 +128,6 @@ artifacts:
       3.13). No macOS or Windows runners.
 
 coverage_gaps:
-  - id: distribution.wheel-ci
-    artifact: wheel
-    gap: Distribution gate exists locally but is not scheduled in CI
-    owner: distribution
-    severity: major
-    declared_at: "2026-05-02"
-    review_after: "2026-08-01"
-    issue: 593
-    next_evidence: devtools verify-distribution-surface
-  - id: distribution.sdist-ci
-    artifact: sdist
-    gap: Distribution gate exists locally but is not scheduled in CI
-    owner: distribution
-    severity: major
-    declared_at: "2026-05-02"
-    review_after: "2026-08-01"
-    issue: 593
-    next_evidence: devtools verify-distribution-surface
   - id: distribution.dev-install-ci
     artifact: dev_install
     gap: Not verified in CI; devshell is canonical environment
@@ -158,4 +163,22 @@ coverage_gaps:
     declared_at: "2026-05-02"
     review_after: "2026-08-01"
     issue: 593
+    next_evidence: devtools verify-distribution-surface
+  - id: distribution.container-ci-build
+    artifact: oci_container
+    gap: Containerfile is built+pushed only on tag (release.yml). No pre-tag CI build means image-only regressions surface at release time.
+    owner: distribution
+    severity: minor
+    declared_at: "2026-05-17"
+    review_after: "2026-08-01"
+    issue: 953
+    next_evidence: devtools verify-distribution-surface
+  - id: distribution.browser-extension-store
+    artifact: browser_extension
+    gap: Browser extension is unpacked-install only — no Chrome Web Store / AMO submission yet (issue #953 phase 4).
+    owner: distribution
+    severity: minor
+    declared_at: "2026-05-17"
+    review_after: "2026-08-01"
+    issue: 953
     next_evidence: devtools verify-distribution-surface

--- a/docs/release.md
+++ b/docs/release.md
@@ -31,14 +31,30 @@ captures the things to *check* at cut time.
 - [ ] Push the tag: `git push origin vX.Y.Z` (or
       `git pst` — uses `--follow-tags`).
 
+Pushing the tag triggers
+[`release.yml`](../.github/workflows/release.yml), which builds and
+smokes the wheel + sdist (`devtools verify-distribution-surface`),
+publishes them to PyPI via OIDC Trusted Publishing, and builds + pushes
+the OCI image to `ghcr.io/sinity/polylogue`. A
+[Trusted Publisher](https://docs.pypi.org/trusted-publishers/) for
+`Sinity/polylogue` / `release.yml` / environment `pypi` must be
+registered on PyPI; otherwise the publish step will fail with an OIDC
+error and the tag must be re-cut after re-running the workflow.
+
 ## Post
 
 - [ ] Draft GitHub release notes from the `[X.Y.Z]` section of
       `CHANGELOG.md`.
 - [ ] Verify `polylogue --version` on the tagged commit shows the
       expected version, commit hash, and clean dirty state.
-- [ ] Verify wheel and sdist build (once #416 lands the install path).
-- [ ] Smoke `polylogue --help` from a clean install.
+- [ ] Confirm the PyPI release page at
+      `https://pypi.org/project/polylogue/X.Y.Z/` shows wheel + sdist.
+- [ ] Confirm the GHCR image tag `ghcr.io/sinity/polylogue:X.Y.Z`
+      exists and `podman pull` succeeds.
+- [ ] Smoke `pip install polylogue==X.Y.Z` in a clean venv and run
+      `polylogue --help`, `polylogued --help`, `polylogue-mcp --help`.
+- [ ] Smoke the container: `podman run --rm
+      ghcr.io/sinity/polylogue:X.Y.Z polylogue --version`.
 
 ## Rollback
 


### PR DESCRIPTION
## Summary

Wires Polylogue's existing wheel/sdist verification into CI on every push, adds a tag-driven release workflow that publishes to PyPI via OIDC Trusted Publishing and pushes a multi-stage OCI image to GHCR, and documents the new post-tag operator checklist. Covers Phase 1 (Python/PyPI) and Phase 3 (OCI container) of #953.

## Problem

Today the only supported install path is `nix develop` inside the repo. `pyproject.toml` already declares wheel metadata, `devtools verify-distribution-surface` already builds + smokes the wheel/sdist locally, and `flake.nix` exposes `packages.default` — but none of it is published, none of it runs in CI, and `docs/release.md` still notes "Verify wheel and sdist build (once #416 lands the install path)." Each missing channel is a barrier to external adoption (see #953 acceptance criteria).

## Solution

Distribution-channel changes are kept to packaging surfaces only; no `polylogue/` source is touched.

- `.github/workflows/ci.yml`: new `distribution` job runs `devtools verify-distribution-surface`, uploads the built wheel/sdist as a CI artifact. Closes the `distribution.wheel-ci` / `distribution.sdist-ci` gaps that `docs/plans/distribution-coverage.yaml` had tracked under #593.
- `.github/workflows/release.yml`: new workflow triggered by `vX.Y.Z` tag push (and a `workflow_dispatch` dry-run path).
  - `build` job re-runs the distribution gate and extracts the project version from `pyproject.toml`.
  - `publish-pypi` job uses `pypa/gh-action-pypi-publish` with `id-token: write` (OIDC Trusted Publishing — no API token, no committed secret). Requires a one-time Trusted Publisher registration on PyPI; documented in `docs/release.md`.
  - `publish-container` job builds `Containerfile` with `docker/build-push-action` and pushes to `ghcr.io/<owner>/polylogue` with `docker/metadata-action`-derived semver tags.
- `Containerfile`: multi-stage. Builder uses `ghcr.io/astral-sh/uv` to `uv build --wheel` from the checkout. Runtime uses `python:3.13-slim-bookworm`, installs the wheel under a non-root user (`polylogue` UID 1000), runs as PID 1 under `tini`, declares `VOLUME ["/data", "/config"]` with XDG-aligned env defaults. Default CMD is `polylogue --help`; operators override to invoke `polylogued run --enable-api` etc.
- `docs/plans/distribution-coverage.yaml`: flip wheel/sdist `ci_build`/`ci_test` to `true` (now verifiable by `verify_manifests.check_distribution_ci_claims`), declare an `oci_container` artifact, retire the four `#593` CI gaps, and file two new `#953`-tracked gaps (`distribution.container-ci-build` for missing pre-tag image build; `distribution.browser-extension-store` for the unsubmitted extension covering #953 phase 4).
- `docs/release.md`: drop the `#416` caveat, document the Trusted Publisher prerequisite, and add post-tag smoke steps for PyPI install and GHCR pull.
- `CHANGELOG.md`: Unreleased > Added entry.

Phases 2 (Nix flake — `nix run` already works), 4 (browser extension store submission), and 5 (Homebrew/AUR) are deliberately out of scope for this PR; they remain tracked on #953.

## Verification

```
$ devtools verify-manifests
  ✓ manifest consistency checks passed
$ devtools verify-ci-workflows
verify-ci-workflows: 9 workflow files checked, no errors
$ pytest tests/unit/devtools/test_verify_manifests.py tests/unit/devtools/test_verify_ci_workflows.py -q --no-header
38 passed in 8.99s
$ python -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml')); yaml.safe_load(open('.github/workflows/ci.yml')); yaml.safe_load(open('docs/plans/distribution-coverage.yaml'))"
(ok)
$ devtools verify --quick
(static gates green except for pre-existing render-all drift on master:
 docs/cli-reference.md, docs/test-quality-workflows.md,
 docs/verification-catalog.md, .cache/site — confirmed identical with my
 branch stashed; tracked elsewhere, not introduced by this PR.)
```

`devtools verify-distribution-surface` itself runs in the new CI job — locally it requires network egress to PyPI and was not re-run in this iteration since the gate is unchanged.

## Follow-ups

- Trusted Publisher registration on PyPI is a one-time manual step before the first tag-driven release succeeds (documented in `docs/release.md`).
- Pre-tag container build (#953 follow-up gap `distribution.container-ci-build`).
- Browser extension store submission (#953 phase 4 gap `distribution.browser-extension-store`).
- Homebrew / AUR (#953 phase 5).

Ref #953