### PR TITLE
chore: regen docs/verification-catalog.md to clear master drift

### DIFF
--- a/docs/verification-catalog.md
+++ b/docs/verification-catalog.md
@@ -8,10 +8,10 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 
 ## Snapshot
 
-- subjects: `578`
+- subjects: `579`
 - claims: `37`
 - runner bindings: `37`
-- proof obligations: `469`
+- proof obligations: `470`
 
 ## Quality Checks
 
@@ -38,7 +38,7 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | `archive.query_law` | 1 |
 | `artifact.path` | 25 |
 | `assurance.coverage_gap` | 20 |
-| `assurance.coverage_item` | 105 |
+| `assurance.coverage_item` | 106 |
 | `assurance.coverage_manifest` | 9 |
 | `cli.command` | 54 |
 | `cli.json_command` | 5 |
@@ -157,7 +157,7 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | `benchmark_coverage` | `assurance.coverage_item` | 5 |
 | `cli_surface` | `assurance.coverage_item` | 2 |
 | `distribution` | `assurance.coverage_gap` | 7 |
-| `distribution` | `assurance.coverage_item` | 8 |
+| `distribution` | `assurance.coverage_item` | 9 |
 | `distribution` | `assurance.coverage_manifest` | 1 |
 | `docs_media` | `assurance.coverage_gap` | 2 |
 | `docs_media` | `assurance.coverage_item` | 17 |
@@ -279,7 +279,7 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | `archive.query.provider_filter_consistency` | 1 |
 | `artifact.path.dependency_closure` | 9 |
 | `assurance.coverage.gap_has_closure_path` | 20 |
-| `assurance.coverage.item_declared` | 105 |
+| `assurance.coverage.item_declared` | 106 |
 | `assurance.coverage.manifest_structured` | 9 |
 | `diagnostic.observable_trace_mapping` | 1 |
 | `error.machine_user_context` | 2 |


### PR DESCRIPTION
Same pattern as #1106 — restoring pre-push gate.