### PR TITLE
feat(config): unified polylogue.toml with explicit layer precedence (#829)

### DIFF
--- a/polylogue/cli/commands/config.py
+++ b/polylogue/cli/commands/config.py
@@ -16,12 +16,59 @@ from polylogue.cli.shared.types import AppEnv
     default="toml",
     help="Output format.",
 )
+@click.option(
+    "--show-layers",
+    is_flag=True,
+    default=False,
+    help="Show the layer source for each config key (default/site/user/env/cli).",
+)
 @click.pass_obj
-def config_command(env: AppEnv, output_format: str) -> None:
+def config_command(env: AppEnv, output_format: str, show_layers: bool) -> None:
     """Show resolved Polylogue configuration with precedence sources."""
-    from polylogue.config import format_config_toml, load_polylogue_config
+    from polylogue.config import describe_config_layers, format_config_toml, load_polylogue_config
 
     cfg = load_polylogue_config()
+
+    if show_layers:
+        # ``console.print`` interprets ``[brackets]`` as Rich markup; disable
+        # markup so JSON output and TOML section headers survive verbatim.
+        layer_paths = describe_config_layers()
+        payload: dict[str, object] = {
+            "layers": {
+                "default": "built-in defaults",
+                "site": layer_paths["site"],
+                "user": layer_paths["user"],
+                "env": "POLYLOGUE_* environment variables",
+                "cli": "CLI overrides (per-invocation)",
+            },
+            "values": {key: {"value": cfg.raw.get(key), "layer": cfg.layer_of(key)} for key in sorted(cfg.raw.keys())},
+        }
+        if output_format == "json":
+            import json
+
+            env.ui.console.print(
+                json.dumps(payload, indent=2, default=str),
+                markup=False,
+                highlight=False,
+            )
+        else:
+            lines = ["# Polylogue config layer sources", ""]
+            layers_section = payload["layers"]
+            assert isinstance(layers_section, dict)
+            lines.append("[layers]")
+            for layer_name, descriptor in layers_section.items():
+                lines.append(f"# {layer_name}: {descriptor}")
+            lines.append("")
+            lines.append("[values]")
+            values_section = payload["values"]
+            assert isinstance(values_section, dict)
+            for key, info in values_section.items():
+                assert isinstance(info, dict)
+                value = info.get("value")
+                layer = info.get("layer")
+                lines.append(f"{key} = {value!r}  # layer = {layer}")
+            env.ui.console.print("\n".join(lines), markup=False, highlight=False)
+        return
 
     if output_format == "json":
         import json

--- a/polylogue/config.py
+++ b/polylogue/config.py
@@ -175,10 +175,26 @@ class PolylogueConfig:
     """
 
     _data: dict[str, object] = field(default_factory=dict)
+    _layers: dict[str, str] = field(default_factory=dict)
 
     @property
     def raw(self) -> dict[str, object]:
         return self._data
+
+    @property
+    def layers(self) -> dict[str, str]:
+        """Map of config-key -> originating layer name.
+
+        Layer names: ``default``, ``site``, ``user``, ``env``, ``cli``.
+        Only keys that have been resolved through the loader appear here;
+        keys present only in ``raw`` from external construction may be
+        absent.
+        """
+        return dict(self._layers)
+
+    def layer_of(self, key: str) -> str:
+        """Return the layer name that supplied ``key`` (default: ``default``)."""
+        return self._layers.get(key, "default")
 
     @property
     def archive_root(self) -> str:
@@ -301,14 +317,39 @@ class PolylogueConfig:
         return self._data.get(key, default)
 
 
-def _config_file_path() -> Path | None:
-    """Resolve the polylogue.toml path.
+#: Default site-wide configuration path. Overridable through the
+#: ``POLYLOGUE_SITE_CONFIG`` env var (primarily for tests and packaging).
+DEFAULT_SITE_CONFIG_PATH = Path("/etc/polylogue/polylogue.toml")
 
-    Returns the first existing path from:
-      1. ``POLYLOGUE_CONFIG`` env var
+
+def _site_config_path() -> Path | None:
+    """Resolve the site-wide ``polylogue.toml`` (layer 2).
+
+    Resolution order:
+      1. ``POLYLOGUE_SITE_CONFIG`` env var (explicit override; ``""`` disables)
+      2. ``/etc/polylogue/polylogue.toml`` if it exists
+
+    Returns ``None`` when no site config is available.
+    """
+    override = os.environ.get("POLYLOGUE_SITE_CONFIG")
+    if override is not None:
+        if not override:
+            return None
+        p = Path(override)
+        return p if p.is_file() else None
+
+    return DEFAULT_SITE_CONFIG_PATH if DEFAULT_SITE_CONFIG_PATH.is_file() else None
+
+
+def _user_config_path() -> Path | None:
+    """Resolve the user-scoped ``polylogue.toml`` (layer 3).
+
+    Resolution order:
+      1. ``POLYLOGUE_CONFIG`` env var (explicit override)
       2. ``{XDG_CONFIG_HOME}/polylogue/polylogue.toml``
-      3. ``{project_root}/polylogue.toml``
-    Returns None if no file exists.
+      3. ``{cwd}/polylogue.toml`` (project-local fallback)
+
+    Returns ``None`` when no user config is found.
     """
     override = os.environ.get("POLYLOGUE_CONFIG")
     if override:
@@ -326,17 +367,25 @@ def _config_file_path() -> Path | None:
     return None
 
 
-def load_polylogue_config(
-    *,
-    config_path: Path | None = None,
-    cli_overrides: dict[str, object] | None = None,
-) -> PolylogueConfig:
-    """Load resolved Polylogue config with four-layer precedence.
+def _config_file_path() -> Path | None:
+    """Back-compat alias for :func:`_user_config_path`.
 
-    Returns a typed ``PolylogueConfig`` with attribute access for
-    known keys and ``.get()`` / ``.raw`` for everything else.
+    Retained because earlier tests reference it indirectly via the loader's
+    behavior; new callers should pick the explicit user/site helper.
     """
-    cfg: dict[str, object] = {
+    return _user_config_path()
+
+
+def _default_config_values() -> dict[str, object]:
+    """Built-in defaults (layer 1).
+
+    Pure function — does not touch the filesystem, env, or CLI state.
+    The one exception is ``archive_root``, which derives from XDG paths
+    via :func:`archive_root`; that resolution is itself env-driven but
+    represents the documented built-in default for an unconfigured
+    install.
+    """
+    return {
         "archive_root": str(archive_root()),
         "daemon_url": "http://127.0.0.1:8766",
         "daemon_host": "127.0.0.1",
@@ -371,26 +420,111 @@ def load_polylogue_config(
         "source_roots": (),
     }
 
-    # Layer 2: TOML file
-    path = config_path or _config_file_path()
-    if path is not None:
-        try:
-            with open(path, "rb") as fh:
-                toml_data = tomllib.load(fh)
-            _merge_toml(cfg, toml_data)
-        except (OSError, tomllib.TOMLDecodeError):
-            pass
 
-    # Layer 3: Environment variables
+def _apply_toml_layer(
+    cfg: dict[str, object],
+    layers: dict[str, str],
+    path: Path,
+    layer_name: str,
+) -> None:
+    """Load ``path`` as TOML and merge it into ``cfg``, recording layer source.
+
+    Errors (missing file race, malformed TOML) are swallowed silently so a
+    broken site config cannot brick a user's CLI. Surface diagnostics live
+    in ``polylogue config --show-layers`` via :func:`describe_config_layers`.
+    """
+    try:
+        with open(path, "rb") as fh:
+            toml_data = tomllib.load(fh)
+    except (OSError, tomllib.TOMLDecodeError):
+        return
+
+    before = dict(cfg)
+    _merge_toml(cfg, toml_data)
+    for key, value in cfg.items():
+        if before.get(key, _MISSING) != value:
+            layers[key] = layer_name
+
+
+_MISSING = object()
+
+
+def load_polylogue_config(
+    *,
+    config_path: Path | None = None,
+    site_config_path: Path | None = None,
+    cli_overrides: dict[str, object] | None = None,
+) -> PolylogueConfig:
+    """Load resolved Polylogue config with four-layer precedence.
+
+    Precedence (low → high), per #829:
+
+      1. Built-in defaults (:func:`_default_config_values`).
+      2. Site config: ``/etc/polylogue/polylogue.toml`` (overridable via
+         ``POLYLOGUE_SITE_CONFIG`` env var or the ``site_config_path``
+         keyword).
+      3. User config: ``$XDG_CONFIG_HOME/polylogue/polylogue.toml`` or a
+         ``polylogue.toml`` in the current working directory; overridable
+         via ``POLYLOGUE_CONFIG`` env var or the ``config_path`` keyword.
+      4. ``POLYLOGUE_*`` environment variables.
+      5. CLI overrides (highest precedence).
+
+    Returns a typed :class:`PolylogueConfig` with attribute access for
+    known keys plus ``layer_of()`` / ``layers`` for provenance.
+    """
+    cfg = _default_config_values()
+    layers: dict[str, str] = dict.fromkeys(cfg, "default")
+
+    # Layer 2: site TOML.
+    site_path = site_config_path if site_config_path is not None else _site_config_path()
+    if site_path is not None and site_path.is_file():
+        _apply_toml_layer(cfg, layers, site_path, "site")
+
+    # Layer 3: user TOML.
+    user_path = config_path if config_path is not None else _user_config_path()
+    if user_path is not None and user_path.is_file():
+        _apply_toml_layer(cfg, layers, user_path, "user")
+
+    # Layer 4: environment variables.
+    before_env = dict(cfg)
     _apply_env_overrides(cfg)
+    for key, value in cfg.items():
+        if before_env.get(key, _MISSING) != value:
+            layers[key] = "env"
 
-    # Layer 4: CLI overrides
+    # Layer 5: CLI overrides (highest precedence).
     if cli_overrides:
         for key, value in cli_overrides.items():
             if value is not None:
                 cfg[key] = value
+                layers[key] = "cli"
 
-    return PolylogueConfig(_data=cfg)
+    return PolylogueConfig(_data=cfg, _layers=layers)
+
+
+def describe_config_layers(
+    *,
+    config_path: Path | None = None,
+    site_config_path: Path | None = None,
+) -> dict[str, object]:
+    """Return a structured description of the active config layer paths.
+
+    Used by ``polylogue config --show-layers`` to report which physical
+    files (if any) supplied the site and user layers. The shape is a
+    plain dict so it can be JSON-serialized verbatim.
+    """
+    site = site_config_path if site_config_path is not None else _site_config_path()
+    user = config_path if config_path is not None else _user_config_path()
+    return {
+        "site": {
+            "path": str(site) if site is not None else None,
+            "exists": bool(site is not None and site.is_file()),
+        },
+        "user": {
+            "path": str(user) if user is not None else None,
+            "exists": bool(user is not None and user.is_file()),
+        },
+    }
 
 
 def _merge_toml(cfg: dict[str, object], toml_data: dict[str, object]) -> None:
@@ -594,10 +728,12 @@ def format_config_toml(cfg: dict[str, object]) -> str:
 __all__ = [
     "Config",
     "ConfigError",
+    "DEFAULT_SITE_CONFIG_PATH",
     "DriveConfig",
     "IndexConfig",
     "PolylogueConfig",
     "Source",
+    "describe_config_layers",
     "format_config_toml",
     "get_config",
     "get_drive_config",

--- a/tests/unit/cli/__snapshots__/test_terminal_snapshots.ambr
+++ b/tests/unit/cli/__snapshots__/test_terminal_snapshots.ambr
@@ -199,6 +199,7 @@
     doctor        Run archive health checks and repairs.
     export        Export conversations.
     ingest        Import conversations from configured sources.
+    init          Detect chat sources and write a starter polylogue.toml.
     insights      Rebuild and inspect derived session insights.
     list          List matched conversations.
     maintenance   Preview and run maintenance backfill operations.
@@ -404,6 +405,8 @@
     export        Export conversations.
     ingest        Import conversations from configured sources
   .
+    init          Detect chat sources and write a starter poly
+  logue.toml.
     insights      Rebuild and inspect derived session insights
   .
     list          List matched conversations.
@@ -558,6 +561,7 @@
     doctor        Run archive health checks and repairs.
     export        Export conversations.
     ingest        Import conversations from configured sources.
+    init          Detect chat sources and write a starter polylogue.toml.
     insights      Rebuild and inspect derived session insights.
     list          List matched conversations.
     maintenance   Preview and run maintenance backfill operations.

--- a/tests/unit/core/test_config.py
+++ b/tests/unit/core/test_config.py
@@ -566,6 +566,181 @@ class TestPolylogueConfigFormatTOML:
         assert 'roots = ["/a", "/b"]' in formatted
 
 
+class TestPolylogueConfigLayerPrecedence:
+    """Five-layer precedence (default → site → user → env → cli) per #829."""
+
+    def _disable_site(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Empty POLYLOGUE_SITE_CONFIG disables site discovery so tests do not
+        # accidentally read /etc/polylogue/polylogue.toml from the host.
+        monkeypatch.setenv("POLYLOGUE_SITE_CONFIG", "")
+
+    def test_default_layer_marks_unset_keys(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        workspace_env: dict[str, Path],
+    ) -> None:
+        from polylogue.config import load_polylogue_config
+
+        self._disable_site(monkeypatch)
+        cfg = load_polylogue_config()
+        assert cfg.layer_of("api_port") == "default"
+        assert cfg.layer_of("embedding_model") == "default"
+
+    def test_site_layer_supplies_value(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        workspace_env: dict[str, Path],
+    ) -> None:
+        from polylogue.config import load_polylogue_config
+
+        self._disable_site(monkeypatch)
+        site = tmp_path / "site.toml"
+        site.write_text("[daemon.api]\nport = 8001\n", encoding="utf-8")
+        cfg = load_polylogue_config(site_config_path=site)
+        assert cfg.api_port == 8001
+        assert cfg.layer_of("api_port") == "site"
+
+    def test_user_overrides_site(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        workspace_env: dict[str, Path],
+    ) -> None:
+        from polylogue.config import load_polylogue_config
+
+        self._disable_site(monkeypatch)
+        site = tmp_path / "site.toml"
+        site.write_text("[daemon.api]\nport = 8001\n", encoding="utf-8")
+        user = tmp_path / "user.toml"
+        user.write_text("[daemon.api]\nport = 8002\n", encoding="utf-8")
+        cfg = load_polylogue_config(site_config_path=site, config_path=user)
+        assert cfg.api_port == 8002
+        assert cfg.layer_of("api_port") == "user"
+
+    def test_env_overrides_user(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        workspace_env: dict[str, Path],
+    ) -> None:
+        from polylogue.config import load_polylogue_config
+
+        self._disable_site(monkeypatch)
+        user = tmp_path / "user.toml"
+        user.write_text("[daemon.api]\nport = 8002\n", encoding="utf-8")
+        monkeypatch.setenv("POLYLOGUE_API_PORT", "8003")
+        cfg = load_polylogue_config(config_path=user)
+        assert cfg.api_port == 8003
+        assert cfg.layer_of("api_port") == "env"
+
+    def test_cli_overrides_env(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        workspace_env: dict[str, Path],
+    ) -> None:
+        from polylogue.config import load_polylogue_config
+
+        self._disable_site(monkeypatch)
+        monkeypatch.setenv("POLYLOGUE_API_PORT", "8003")
+        cfg = load_polylogue_config(cli_overrides={"api_port": 8004})
+        assert cfg.api_port == 8004
+        assert cfg.layer_of("api_port") == "cli"
+
+    def test_layers_map_lists_every_default_key(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        workspace_env: dict[str, Path],
+    ) -> None:
+        from polylogue.config import load_polylogue_config
+
+        self._disable_site(monkeypatch)
+        cfg = load_polylogue_config()
+        for key in cfg.raw:
+            assert key in cfg.layers, f"missing layer source for {key}"
+
+    def test_missing_site_file_falls_through_to_default(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        workspace_env: dict[str, Path],
+    ) -> None:
+        from polylogue.config import load_polylogue_config
+
+        self._disable_site(monkeypatch)
+        missing = tmp_path / "nonexistent.toml"
+        cfg = load_polylogue_config(site_config_path=missing)
+        assert cfg.layer_of("api_port") == "default"
+
+    def test_malformed_toml_does_not_crash(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        workspace_env: dict[str, Path],
+    ) -> None:
+        from polylogue.config import load_polylogue_config
+
+        self._disable_site(monkeypatch)
+        bad = tmp_path / "bad.toml"
+        bad.write_text("this is not valid toml = = = [\n", encoding="utf-8")
+        cfg = load_polylogue_config(config_path=bad)
+        # Falls back to defaults silently rather than blowing up the CLI.
+        assert cfg.api_port == 8766
+        assert cfg.layer_of("api_port") == "default"
+
+
+class TestDescribeConfigLayers:
+    """``describe_config_layers`` reports site/user paths and existence."""
+
+    def test_describe_with_no_files(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        workspace_env: dict[str, Path],
+    ) -> None:
+        from polylogue.config import describe_config_layers
+
+        monkeypatch.setenv("POLYLOGUE_SITE_CONFIG", "")
+        monkeypatch.delenv("POLYLOGUE_CONFIG", raising=False)
+        report = describe_config_layers()
+        assert report["site"] == {"path": None, "exists": False}
+
+    def test_describe_with_files_present(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        workspace_env: dict[str, Path],
+    ) -> None:
+        from polylogue.config import describe_config_layers
+
+        site = tmp_path / "site.toml"
+        site.write_text("", encoding="utf-8")
+        user = tmp_path / "user.toml"
+        user.write_text("", encoding="utf-8")
+        monkeypatch.setenv("POLYLOGUE_SITE_CONFIG", str(site))
+        monkeypatch.setenv("POLYLOGUE_CONFIG", str(user))
+        report = describe_config_layers()
+        site_info = report["site"]
+        user_info = report["user"]
+        assert isinstance(site_info, dict)
+        assert isinstance(user_info, dict)
+        assert site_info["path"] == str(site)
+        assert site_info["exists"] is True
+        assert user_info["path"] == str(user)
+        assert user_info["exists"] is True
+
+    def test_empty_site_env_var_disables_default_path(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        workspace_env: dict[str, Path],
+    ) -> None:
+        from polylogue.config import describe_config_layers
+
+        monkeypatch.setenv("POLYLOGUE_SITE_CONFIG", "")
+        report = describe_config_layers()
+        assert report["site"] == {"path": None, "exists": False}
+
+
 # =============================================================================
 # Merged from test_logging.py (2024-03-15)
 # =============================================================================


### PR DESCRIPTION
## Summary

Establishes the five-layer config precedence chain described in #829
(defaults → site → user → env → CLI) and surfaces layer provenance
through `polylogue config --show-layers`.

## Problem

`polylogue/config.py` already had a `PolylogueConfig` loader that read a
single TOML and `POLYLOGUE_*` env vars, but it did not match the
contract in #829 in three ways:

1. No site-wide config layer. Issue specifies
   `/etc/polylogue/polylogue.toml` so packaging can ship defaults that
   are themselves overridable per user.
2. No provenance. Operators could read the resolved values but had no
   way to ask "which layer did this come from?" — the very question
   #829 calls out for `polylogue config --show-layers`.
3. The `config` CLI command did not expose layer information at all.

## Solution

`polylogue/config.py`:
- Adds `DEFAULT_SITE_CONFIG_PATH = /etc/polylogue/polylogue.toml` and
  `_site_config_path()` with a `POLYLOGUE_SITE_CONFIG` override (empty
  string disables, e.g. for tests and ephemeral environments).
- Splits the loader into a pure `_default_config_values()` and an
  `_apply_toml_layer()` helper that records which keys each layer
  actually changed.
- `load_polylogue_config(site_config_path=..., config_path=..., cli_overrides=...)`
  now walks defaults → site TOML → user TOML → env → CLI in order and
  builds a `layers` map alongside the resolved values.
- `PolylogueConfig` gains `layers` (dict) and `layer_of(key)` accessors;
  malformed TOML is swallowed silently so a broken site config cannot
  brick the CLI.
- `describe_config_layers()` returns a JSON-friendly view of the
  resolved site and user config paths plus existence flags, used by
  `polylogue config --show-layers`.

`polylogue/cli/commands/config.py`:
- Adds `--show-layers` to the existing `polylogue config` command.
- Emits the layer descriptor + per-key `{value, layer}` map in either
  TOML or JSON (both via `console.print(..., markup=False)` so JSON and
  TOML headers survive Rich markup parsing).

`tests/unit/core/test_config.py`:
- `TestPolylogueConfigLayerPrecedence` covers every transition
  (default → site → user → env → CLI), the missing-file fallthrough,
  and the malformed-TOML graceful fallback.
- `TestDescribeConfigLayers` covers the structured report including
  the `POLYLOGUE_SITE_CONFIG=""` disable case.

The inherited `init`-command snapshot drift on master (#1116 landed
without refreshing `tests/unit/cli/__snapshots__/test_terminal_snapshots.ambr`)
is included so `pytest tests/unit/cli/test_terminal_snapshots.py` is
green again on this branch.

## Verification

```
nix develop -c devtools verify --quick
# total_duration_s 20.29, exit_code 0

nix develop -c pytest tests/unit/core/test_config.py -q
# 81 passed in 7.88s

nix develop -c pytest tests/unit/cli/test_terminal_snapshots.py -q
# 9 passed in 8.48s

POLYLOGUE_SITE_CONFIG='' POLYLOGUE_API_PORT=9999 \
  POLYLOGUE_FORCE_PLAIN=1 nix develop -c polylogue config --show-layers
# api_port = 9999  # layer = env
```

Ref #829