### PR TITLE
feat(reader): saved queries and named views UI (#1118)

### DIFF
--- a/polylogue/daemon/web_shell.py
+++ b/polylogue/daemon/web_shell.py
@@ -740,13 +740,16 @@ function renderInspectorNotes(el, c) {
       var bits = [];
       if (q.query) bits.push('query=' + q.query);
       if (q.provider) bits.push('provider=' + q.provider);
-      html += '<div class="saved-view-item"><div><div>' + esc(v.name || v.view_id) + '</div>'
+      html += '<div class="saved-view-item" data-view-id="' + escAttr(v.view_id) + '"><div><div>' + esc(v.name || v.view_id) + '</div>'
         + '<div class="value">' + esc(bits.join(' / ') || 'all conversations') + '</div></div>'
-        + '<button class="user-action" onclick="applySavedView(\'' + escAttr(v.view_id) + '\')">Open</button></div>';
+        + '<div style="display:flex;gap:4px;flex-shrink:0">'
+        + '<button class="user-action" onclick="applySavedView(\'' + escAttr(v.view_id) + '\')">Open</button>'
+        + '<button class="user-action" title="Delete saved view" onclick="deleteSavedView(\'' + escAttr(v.view_id) + '\')">Delete</button>'
+        + '</div></div>';
     });
     html += '</div>';
   } else {
-    html += '<div class="inspector-empty">No saved views</div>';
+    html += '<div class="inspector-empty">No saved views. Click "Save current view" to name the current filter chain.</div>';
   }
   if (state.userStateError) {
     html += '<div class="inspector-empty">' + esc(state.userStateError) + '</div>';
@@ -793,22 +796,6 @@ async function toggleMark(markType) {
   renderConversations();
   renderMain();
   renderInspector();
-}
-
-async function saveCurrentView() {
-  var query = {limit: state.limit, offset: 0};
-  if (state.query) query.query = state.query;
-  if (state.provider) query.provider = state.provider;
-  var defaultName = state.query || state.provider || 'All conversations';
-  var name = window.prompt('Saved view name', defaultName);
-  if (!name) return;
-  try {
-    await sendJSON('/api/user/saved-views', 'POST', {name: name, query: query});
-    await loadUserState();
-  } catch(e) {
-    state.userStateError = 'Failed to save view';
-    renderInspector();
-  }
 }
 
 function applySavedView(viewId) {

--- a/polylogue/daemon/web_shell_workspace.py
+++ b/polylogue/daemon/web_shell_workspace.py
@@ -50,6 +50,10 @@ WORKSPACE_HTML = r"""
       <span class="workspace-stat" id="workspace-route-status">single</span>
       <span class="workspace-stat warn" id="workspace-degraded-count"></span>
       <span class="workspace-spacer"></span>
+      <select id="workspace-saved-view-select" title="Saved views" onchange="restoreSavedView(this.value)">
+        <option value="">Saved views</option>
+      </select>
+      <button class="workspace-action" id="workspace-save-view-btn" onclick="saveCurrentView()">Save view</button>
       <select id="workspace-restore-select" title="Restore workspace" onchange="restoreWorkspace(this.value)">
         <option value="">Restore workspace</option>
       </select>
@@ -150,6 +154,20 @@ function renderWorkspaceToolbar() {
     return '<option value="' + escAttr(w.workspace_id) + '">' + esc(w.name || w.workspace_id) + '</option>';
   }).join('');
   select.value = current;
+  // Mirror the same restore-pattern for saved views so they are reachable from
+  // the workspace toolbar (not only via the Notes inspector tab).
+  var viewSelect = document.getElementById('workspace-saved-view-select');
+  if (viewSelect) {
+    var currentView = viewSelect.value;
+    var views = state.savedViews || [];
+    var label = views.length ? 'Saved views (' + views.length + ')' : 'No saved views';
+    viewSelect.innerHTML = '<option value="">' + label + '</option>' + views.map(function(v) {
+      return '<option value="' + escAttr(v.view_id) + '">' + esc(v.name || v.view_id) + '</option>';
+    }).join('');
+    viewSelect.value = currentView;
+    if (!views.length) viewSelect.setAttribute('disabled', 'true');
+    else viewSelect.removeAttribute('disabled');
+  }
   // Disabled-action tooltips per MK3 "disabled actions are part of the design"
   // (docs/design/mk3/docs/11-little-details.md). Stack/Compare need 2+
   // selectable conversations; recall pack and save need at least one target.
@@ -305,6 +323,69 @@ async function saveWorkspace() {
     state.userStateError = 'Failed to save workspace';
     renderInspector();
   }
+}
+
+async function saveCurrentView() {
+  var query = {limit: state.limit, offset: 0};
+  if (state.query) query.query = state.query;
+  if (state.provider) query.provider = state.provider;
+  var defaultName = state.query || state.provider || 'All conversations';
+  var name = window.prompt('Saved view name', defaultName);
+  if (!name) return;
+  name = name.trim();
+  if (!name) {
+    state.userStateError = 'Saved view name cannot be empty';
+    renderInspector();
+    return;
+  }
+  // Naming conflict UX: storage enforces UNIQUE(name). Detect a clash
+  // locally against the loaded list so the operator can choose to overwrite
+  // or pick a new name before the request fires (which would otherwise hit
+  // the SQLite unique constraint with a generic error).
+  var existing = (state.savedViews || []).find(function(v) { return (v.name || '') === name; });
+  if (existing) {
+    if (!window.confirm('A saved view named "' + name + '" already exists. Overwrite it?')) return;
+    try {
+      await sendJSON('/api/user/saved-views/' + encodeURIComponent(existing.view_id), 'DELETE');
+    } catch(e) {
+      state.userStateError = 'Failed to replace existing view';
+      renderInspector();
+      return;
+    }
+  }
+  try {
+    await sendJSON('/api/user/saved-views', 'POST', {name: name, query: query});
+    state.userStateError = '';
+    await loadUserState();
+  } catch(e) {
+    state.userStateError = 'Failed to save view';
+    renderInspector();
+  }
+}
+
+async function deleteSavedView(viewId) {
+  if (!viewId) return;
+  var view = (state.savedViews || []).find(function(v) { return v.view_id === viewId; });
+  var label = view ? (view.name || viewId) : viewId;
+  if (!window.confirm('Delete saved view "' + label + '"?')) return;
+  try {
+    await sendJSON('/api/user/saved-views/' + encodeURIComponent(viewId), 'DELETE');
+    state.userStateError = '';
+    await loadUserState();
+  } catch(e) {
+    state.userStateError = 'Failed to delete saved view';
+    renderInspector();
+  }
+}
+
+function restoreSavedView(viewId) {
+  if (!viewId) return;
+  // Recall the saved query into the active filter chain. applySavedView lives
+  // in the main shell script and reloads conversations + facets, then resets
+  // the select so reselecting the same view re-applies it.
+  applySavedView(viewId);
+  var select = document.getElementById('workspace-saved-view-select');
+  if (select) select.value = '';
 }
 
 async function restoreWorkspace(workspaceId) {

--- a/tests/unit/daemon/test_web_reader.py
+++ b/tests/unit/daemon/test_web_reader.py
@@ -1088,6 +1088,94 @@ class TestReaderInformability:
         assert "'<span class=\"chip q-canonical\">' + esc(c.provider)" in body
 
 
+class TestReaderSavedViewsUI:
+    """Saved-view UI surface (#1118): toolbar entry, save/recall/delete UX,
+    naming-conflict guard, and an explicit empty state for the inspector list.
+
+    The substrate (``/api/user/saved-views`` POST/GET/DELETE) is covered by
+    ``TestReaderUserState``; these tests assert that the web shell exposes the
+    capability end-to-end so the operator can manage saved views without
+    leaving the reader.
+    """
+
+    def test_workspace_toolbar_exposes_saved_view_entry(self, workspace_env: dict[str, Path]) -> None:
+        with _running_server(workspace_env) as (_, base_url):
+            _, _, body = _get_text(base_url, "/")
+        # Dedicated toolbar entry-point so saved views are reachable without
+        # opening the Notes inspector tab (mirrors the Restore workspace
+        # pattern).
+        assert 'id="workspace-saved-view-select"' in body
+        assert 'id="workspace-save-view-btn"' in body
+        # Wired to applySavedView via restoreSavedView; both must be present.
+        assert "function restoreSavedView(" in body
+        assert "function applySavedView(" in body
+        # Toolbar populator must update the select on each render so newly
+        # saved views appear without a full reload.
+        assert "workspace-saved-view-select" in body
+        assert "Saved views (" in body
+
+    def test_save_current_view_handles_naming_conflict(self, workspace_env: dict[str, Path]) -> None:
+        with _running_server(workspace_env) as (_, base_url):
+            _, _, body = _get_text(base_url, "/")
+        # Naming conflict UX: detect locally against state.savedViews, prompt
+        # for overwrite confirmation, replace via DELETE+POST. Empty/whitespace
+        # names are rejected before hitting the wire.
+        assert "Saved view name cannot be empty" in body
+        assert "already exists. Overwrite it?" in body
+        assert "Failed to replace existing view" in body
+
+    def test_saved_view_list_exposes_delete_action(self, workspace_env: dict[str, Path]) -> None:
+        with _running_server(workspace_env) as (_, base_url):
+            _, _, body = _get_text(base_url, "/")
+        # The inspector list must render a Delete button per saved view; the
+        # JS handler is reachable so the operator can prune stale views.
+        assert "function deleteSavedView(" in body
+        assert "Delete saved view" in body
+        assert 'onclick="deleteSavedView(' in body
+
+    def test_saved_view_empty_state_is_actionable(self, workspace_env: dict[str, Path]) -> None:
+        with _running_server(workspace_env) as (_, base_url):
+            _, _, body = _get_text(base_url, "/")
+        # Empty state must point the operator at the action that resolves it
+        # (per MK3 state matrix: each empty state names the next step).
+        assert 'No saved views. Click "Save current view"' in body
+
+    def test_saved_views_endpoint_roundtrip_supports_ui_flow(self, workspace_env: dict[str, Path]) -> None:
+        # End-to-end roundtrip the UI relies on: save, list, then delete via
+        # the inspector Delete button. Catches API regressions that would
+        # silently break the new toolbar surface.
+        with _running_server(workspace_env) as (_, base_url):
+            save_status, saved = _request_json(
+                base_url,
+                "POST",
+                "/api/user/saved-views",
+                payload={
+                    "view_id": "view-ui",
+                    "name": "Reader UI flow",
+                    "query": {"query": "auth", "limit": 25},
+                },
+            )
+            listed = _get_json(base_url, "/api/user/saved-views")
+            delete_status, deleted = _request_json(
+                base_url,
+                "DELETE",
+                "/api/user/saved-views/view-ui",
+            )
+            empty_listing = _get_json(base_url, "/api/user/saved-views")
+
+        saved_payload = cast(dict[str, object], saved)
+        listed_payload = cast(dict[str, object], listed)
+        empty_payload = cast(dict[str, object], empty_listing)
+        items = cast(list[dict[str, object]], listed_payload["items"])
+        assert save_status == 201
+        assert saved_payload["name"] == "Reader UI flow"
+        assert listed_payload["total"] == 1
+        assert items[0]["view_id"] == "view-ui"
+        assert delete_status == 200
+        assert deleted == {"view_id": "view-ui", "deleted": True}
+        assert empty_payload == {"items": [], "total": 0}
+
+
 @pytest.mark.parametrize("path", ["/", "/api/conversations", "/api/facets", "/api/status", "/api/health"])
 def test_each_reader_route_responds_within_a_reasonable_budget(workspace_env: dict[str, Path], path: str) -> None:
     """Each reader-facing route returns within 10 s on a synthetic


### PR DESCRIPTION
## Summary

Wire the existing `/api/user/saved-views` substrate (shipped via #1050-#1057 under the #867 user-state umbrella) into the web reader so an operator can save the current filter chain under a name, recall it, and delete it without leaving the reader. Adds a toolbar entry-point, a Delete affordance, a naming-conflict guard, and an actionable empty state.

## Problem

#1118 calls out the reader UI gap for saved views: the storage table and the HTTP envelope existed, and the Notes inspector tab could already save/open a view, but there was no way to delete an existing view from the UI, no naming-conflict UX (the SQLite `UNIQUE(name)` constraint would surface as an opaque error), and no toolbar-level entry-point — saved views were reachable only by opening the Notes inspector tab on a selected conversation. The acceptance criteria require list/recall/delete affordances, an empty state distinct from a populated one, and naming-conflict handling.

## Solution

- `polylogue/daemon/web_shell_workspace.py`: adds a `Saved views` `<select>` and a `Save view` button to the workspace toolbar (mirroring the existing `Restore workspace` select pattern). Populates the select in `renderWorkspaceToolbar` with `state.savedViews`, disables it when empty, and falls back through `applySavedView` → `loadConversations` + `loadFacets`. Moves `saveCurrentView` and adds `deleteSavedView` here. `saveCurrentView` now trims whitespace, rejects empty names, and detects a naming clash against `state.savedViews` locally — prompting `window.confirm` to overwrite (DELETE the existing view_id, then POST) or abort. `deleteSavedView` confirms by name before issuing the DELETE.
- `polylogue/daemon/web_shell.py`: the Notes inspector list now renders a per-row Delete button next to Open; the empty state is reworded to name the next action (`Click "Save current view" to name the current filter chain.`).
- `tests/unit/daemon/test_web_reader.py`: adds `TestReaderSavedViewsUI` with five tests — toolbar entry-point presence, naming-conflict UX strings, delete-button wiring, actionable empty-state copy, and an HTTP roundtrip (save → list → delete) that catches regressions in the new toolbar surface.

The MCP coverage criterion (#1118 AC: "At least one MCP read tool exposes saved views by id") was already satisfied by `list_saved_views` / `save_saved_view` / `delete_saved_view` in `polylogue/mcp/server_mutation_tools.py` — no change there.

The naming-conflict handling is client-side rather than at the HTTP envelope. The shared `user_state_http.py` is owned by another lane per the dispatch plan and the existing `save_view` SQL is an `INSERT OR REPLACE BY view_id`; the UNIQUE constraint is on `name`, which means a different `view_id` for the same name would 500. Detecting the conflict client-side keeps the UX coherent without changing the contract.

`polylogue/daemon/web_shell.py` net change is −13 LOC (functions moved into the workspace asset module), keeping the file under the 1100-line budget enforced by `verify-file-budgets`.

## Verification

```
nix develop -c pytest tests/unit/daemon/test_web_reader.py -q
# 62 passed in 14.74s (5 new under TestReaderSavedViewsUI)

nix develop -c pytest tests/unit/daemon -q
# 389 passed in 13.45s

nix develop -c devtools verify --quick
# exit_code: 0  (format + lint + mypy + render-all + manifest/lifecycle/topology lints)
```

`devtools verify` (full pytest path) requires `devtools verify --seed-testmon` on this fresh worktree; the affected unit suite was exercised directly above. `render-pages` was re-emitted to clear a pre-existing `.cache/site` drift unrelated to this PR.

Closes #1118