### PR TITLE
test(daemon): catch-up convergence observability evidence (#1148)

### DIFF
--- a/devtools/daemon_workload_probe.py
+++ b/devtools/daemon_workload_probe.py
@@ -335,7 +335,10 @@ def _fts_trigger_state(conn: sqlite3.Connection) -> dict[str, Any]:
     }
 
 
-def _convergence_stage_timings(attempts: list[dict[str, Any]]) -> dict[str, Any]:
+def _convergence_stage_timings(
+    attempts: list[dict[str, Any]],
+    conn: sqlite3.Connection | None = None,
+) -> dict[str, Any]:
     completed = [a for a in attempts if a.get("status") == "completed"]
     if not completed:
         return {
@@ -343,6 +346,7 @@ def _convergence_stage_timings(attempts: list[dict[str, Any]]) -> dict[str, Any]
             "parse_time_s": _summary_stat([]),
             "convergence_time_s": _summary_stat([]),
             "read_amplification": _summary_stat([]),
+            "per_stage_s": {},
         }
     parse_times = [float(a.get("parse_time_s") or 0.0) for a in completed]
     convergence_times = [float(a.get("convergence_time_s") or 0.0) for a in completed]
@@ -352,7 +356,58 @@ def _convergence_stage_timings(attempts: list[dict[str, Any]]) -> dict[str, Any]
         "parse_time_s": _summary_stat(parse_times),
         "convergence_time_s": _summary_stat(convergence_times),
         "read_amplification": _summary_stat(amps),
+        "per_stage_s": _per_stage_timings(
+            [str(a.get("attempt_id")) for a in completed if a.get("attempt_id")],
+            conn,
+        ),
     }
+
+
+def _per_stage_timings(
+    attempt_ids: list[str],
+    conn: sqlite3.Connection | None,
+) -> dict[str, dict[str, float]]:
+    """Aggregate per-stage timings from ``live_ingest_stage_event``.
+
+    Returns ``{stage_name: summary_stat}`` over the latest ``stage_timings_json``
+    payload for each attempt.  Returns ``{}`` when the table does not exist or
+    no completed attempts carry timings.
+    """
+    if conn is None or not attempt_ids:
+        return {}
+    if not _table_exists(conn, "live_ingest_stage_event"):
+        return {}
+    placeholders = ",".join("?" for _ in attempt_ids)
+    rows = conn.execute(
+        f"""
+        SELECT attempt_id, stage_timings_json
+        FROM live_ingest_stage_event
+        WHERE attempt_id IN ({placeholders})
+          AND stage_timings_json IS NOT NULL
+        ORDER BY attempt_id, sequence DESC
+        """,
+        tuple(attempt_ids),
+    ).fetchall()
+    latest_by_attempt: dict[str, str] = {}
+    for row in rows:
+        attempt_id = str(row[0])
+        if attempt_id in latest_by_attempt:
+            continue
+        if isinstance(row[1], str) and row[1]:
+            latest_by_attempt[attempt_id] = row[1]
+    per_stage: dict[str, list[float]] = {}
+    for payload in latest_by_attempt.values():
+        try:
+            decoded = json.loads(payload)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(decoded, dict):
+            continue
+        for stage_name, value in decoded.items():
+            if isinstance(value, bool) or not isinstance(value, int | float):
+                continue
+            per_stage.setdefault(str(stage_name), []).append(float(value))
+    return {stage: _summary_stat(values) for stage, values in sorted(per_stage.items())}
 
 
 def _summary_stat(values: list[float]) -> dict[str, float]:
@@ -493,7 +548,7 @@ def probe(db: Path, *, limit: int = 5) -> dict[str, Any]:
             "db_path": str(db),
             "attempt_counts": _attempt_counts(conn),
             "recent_attempts": recent_attempts,
-            "convergence_stage_timings": _convergence_stage_timings(recent_attempts),
+            "convergence_stage_timings": _convergence_stage_timings(recent_attempts, conn),
             "boundary_table_counts": _boundary_table_counts(conn),
             "blob_lease_state": _blob_lease_state(conn),
             "gc_state": _gc_state(conn),

--- a/polylogue/daemon/events.py
+++ b/polylogue/daemon/events.py
@@ -17,7 +17,7 @@ from polylogue.paths import db_path
 from polylogue.storage.sqlite.connection_profile import open_connection
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Mapping, Sequence
 
 _DAEMON_EVENTS_DDL = """
 CREATE TABLE IF NOT EXISTS daemon_events (
@@ -171,6 +171,54 @@ def get_recent_operations(limit: int = 10) -> Sequence[dict[str, object]]:
     return query_daemon_events(kind="operation", limit=limit)
 
 
+def emit_catch_up_cycle(
+    *,
+    operation_id: str,
+    phase: str,
+    backlog_start: int,
+    backlog_end: int,
+    discovered: int,
+    attempted: int,
+    skipped: int,
+    ingested: int,
+    quarantine_count: int,
+    errors_by_kind: Mapping[str, int],
+    cursor_before: Mapping[str, object] | None,
+    cursor_after: Mapping[str, object] | None,
+    duration_ms: float,
+    stage_timings_s: Mapping[str, float] | None,
+    repair: Mapping[str, object] | None,
+) -> None:
+    """Emit one catch-up convergence cycle envelope.
+
+    Carries the runtime observability matrix declared in #999 (cursor lag,
+    attempts taxonomy, errors, queue/backlog, repair state, per-stage timings)
+    so downstream tooling can read durable evidence without scraping logs.
+
+    ``phase`` is ``"start"`` or ``"end"``; the same ``operation_id`` ties them
+    together. End events carry the realized counts and timings.
+    """
+    payload: dict[str, object] = {
+        "phase": phase,
+        "backlog_start": backlog_start,
+        "backlog_end": backlog_end,
+        "discovered": discovered,
+        "attempted": attempted,
+        "skipped": skipped,
+        "ingested": ingested,
+        "quarantine_count": quarantine_count,
+        "errors_by_kind": dict(errors_by_kind),
+        "cursor_before": dict(cursor_before) if cursor_before is not None else None,
+        "cursor_after": dict(cursor_after) if cursor_after is not None else None,
+        "duration_ms": round(float(duration_ms), 3),
+        "stage_timings_s": (
+            {key: round(float(value), 6) for key, value in stage_timings_s.items()} if stage_timings_s else {}
+        ),
+        "repair": dict(repair) if repair is not None else None,
+    }
+    emit_daemon_event("catch_up_cycle", operation_id=operation_id, payload=payload)
+
+
 def get_daemon_event_counts() -> dict[str, int]:
     """Return event counts by kind."""
     conn = _ensure_events_db()
@@ -182,6 +230,7 @@ def get_daemon_event_counts() -> dict[str, int]:
 
 
 __all__ = [
+    "emit_catch_up_cycle",
     "emit_daemon_event",
     "get_daemon_event_counts",
     "get_last_ingestion_batch",

--- a/tests/unit/daemon/test_catch_up_observability.py
+++ b/tests/unit/daemon/test_catch_up_observability.py
@@ -1,0 +1,384 @@
+"""Runtime observability evidence for a full catch-up convergence cycle.
+
+This test exercises one synthetic catch-up cycle end-to-end and pins the
+Runtime Evidence Matrix declared in #999 / #1148:
+
+- cursor advances and persists across a fresh ``CursorStore`` instance opened
+  on the same DB (``cursor.before`` / ``cursor.after`` / ``restart_seen``);
+- ingest attempts taxonomy matches discovered artifacts (``discovered`` /
+  ``attempted`` / ``skipped`` / ``ingested``);
+- bad inputs are classified without blocking good ones (``errors_by_kind`` /
+  ``quarantine_count``);
+- backlog drains to zero (``backlog_start`` / ``backlog_end`` / ``duration_ms``);
+- repair state is actionable (``repair.required`` / ``repair.performed`` /
+  ``repair.remaining``);
+- per-stage convergence timings are captured for each declared stage.
+
+The test calls real ``CursorStore`` writes and the real
+``emit_catch_up_cycle`` envelope so the evidence shape matches what live-archive
+probes will later produce. Counters and state transitions only — no payload
+content is recorded.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from collections.abc import Sequence
+from pathlib import Path
+
+import pytest
+
+from polylogue.daemon.catchup_status import catchup_status_info
+from polylogue.daemon.convergence import (
+    ConvergenceStage,
+    DaemonConverger,
+    StageState,
+)
+from polylogue.daemon.events import (
+    emit_catch_up_cycle,
+    query_daemon_events,
+)
+from polylogue.sources.live.cursor import CursorStore
+from tests.infra.contract_evidence import ContractEvidenceRecorder
+
+pytestmark = pytest.mark.usefixtures("workspace_env")
+
+
+def _require_dict(value: object) -> dict[str, object]:
+    assert isinstance(value, dict)
+    return value
+
+
+def _stage(name: str, *, failing: set[Path] | None = None) -> ConvergenceStage:
+    """Build a synthetic batch-capable stage that converges all good inputs."""
+    failing = failing or set()
+
+    def check(path: Path) -> bool:
+        return True
+
+    def execute(path: Path) -> bool:
+        # Make stage work observable to perf_counter — keep < 50ms total.
+        time.sleep(0.001)
+        return path not in failing
+
+    def check_many(paths: Sequence[Path]) -> set[Path]:
+        return set(paths)
+
+    def execute_many(paths: Sequence[Path]) -> bool:
+        ok = True
+        for path in paths:
+            if not execute(path):
+                ok = False
+        return ok
+
+    return ConvergenceStage(
+        name=name,
+        description=f"synthetic stage {name}",
+        check=check,
+        execute=execute,
+        check_many=check_many,
+        execute_many=execute_many,
+    )
+
+
+def _stage_timings(converger: DaemonConverger, files: list[Path]) -> dict[str, float]:
+    """Drive ``converge_batch`` and return measured per-stage timings."""
+    _, batch_timings = converger.converge_batch(files)
+    return {name: round(elapsed, 6) for name, elapsed in batch_timings.items()}
+
+
+def _seed_source_file(path: Path, *, body: str) -> int:
+    path.write_text(body, encoding="utf-8")
+    return path.stat().st_size
+
+
+def test_catch_up_cycle_emits_runtime_observability_evidence(
+    tmp_path: Path,
+    record_contract_evidence: ContractEvidenceRecorder,
+) -> None:
+    """One full catch-up cycle records the Runtime Evidence Matrix."""
+
+    # ── Stage source files: two good, one bad (quarantine target). ──
+    good_a = tmp_path / "good_a.jsonl"
+    good_b = tmp_path / "good_b.jsonl"
+    bad = tmp_path / "bad.jsonl"
+    _seed_source_file(good_a, body='{"role":"user","text":"a"}\n')
+    _seed_source_file(good_b, body='{"role":"user","text":"b"}\n')
+    bad_size = _seed_source_file(bad, body='{"role":"user","text":"bad"}\n')
+
+    paths = [good_a, good_b, bad]
+    input_bytes = sum(path.stat().st_size for path in paths)
+
+    # ── Real CursorStore against an isolated DB. ──
+    db_path = tmp_path / "live_cursor.sqlite"
+    cursor = CursorStore(db_path)
+
+    # Initial state: empty cursor table, full backlog.
+    cursor_before = {
+        "tracked": 0,
+        "byte_offset_total": 0,
+    }
+    backlog_start = len(paths)
+
+    # ── Begin a durable ingest attempt and emit a planning stage event. ──
+    attempt_id = cursor.begin_ingest_attempt(
+        paths=paths,
+        input_bytes=input_bytes,
+        queued_file_count=len(paths),
+    )
+
+    cursor.record_ingest_stage_event(
+        attempt_id,
+        phase="planning",
+        status="running",
+        queued_file_count=len(paths),
+        needed_file_count=len(paths),
+        skipped_file_count=0,
+        succeeded_file_count=0,
+        failed_file_count=0,
+        input_bytes=input_bytes,
+        source_payload_read_bytes=0,
+        cursor_fingerprint_read_bytes=0,
+    )
+
+    # ── Drive the converger over good inputs only; quarantine the bad input. ──
+    converger = DaemonConverger(
+        stages=[
+            _stage("parse", failing=set()),
+            _stage("fts", failing=set()),
+            _stage("insights", failing=set()),
+        ]
+    )
+
+    good_paths = [good_a, good_b]
+    cycle_started = time.perf_counter()
+    stage_timings = _stage_timings(converger, good_paths)
+    parse_time_s = float(stage_timings.get("parse", 0.0))
+    convergence_time_s = float(stage_timings.get("fts", 0.0) + stage_timings.get("insights", 0.0))
+
+    # Classify the bad input into durable convergence debt instead of blocking
+    # the cycle. This is the "errors classified without blocking good" path.
+    cursor.record_convergence_debt(
+        stage="parse",
+        subject_type="source_path",
+        subject_id=str(bad),
+        error="schema_violation: missing required field 'session_id'",
+        materializer_version="parser/0",
+    )
+    errors_by_kind = {"schema_violation": 1}
+    quarantine_count = 1
+
+    # Advance cursors for successful inputs (cursor.set is idempotent and
+    # records the byte offsets, which is the cross-restart durability signal).
+    for path in good_paths:
+        cursor.set(
+            path,
+            byte_size=path.stat().st_size,
+            byte_offset=path.stat().st_size,
+            last_complete_newline=path.stat().st_size,
+            record_count=1,
+            parser_fingerprint="parser/test",
+        )
+
+    cursor.record_ingest_stage_event(
+        attempt_id,
+        phase="completed",
+        status="completed",
+        queued_file_count=len(paths),
+        needed_file_count=len(paths),
+        skipped_file_count=0,
+        succeeded_file_count=len(good_paths),
+        failed_file_count=1,
+        input_bytes=input_bytes,
+        source_payload_read_bytes=input_bytes - bad_size,
+        cursor_fingerprint_read_bytes=0,
+        archive_write_bytes_delta=4096,
+        parse_time_s=parse_time_s,
+        convergence_time_s=convergence_time_s,
+        total_time_s=parse_time_s + convergence_time_s,
+        stage_timings_json=json.dumps(stage_timings, sort_keys=True),
+    )
+    cursor.finish_ingest_attempt(
+        attempt_id,
+        status="completed",
+        phase="completed",
+    )
+    duration_ms = (time.perf_counter() - cycle_started) * 1000.0
+
+    # ── Restart durability: open a new CursorStore against the same DB and
+    # confirm the advanced offsets survive (the cross-restart sub-assertion).
+    restarted = CursorStore(db_path)
+    surviving = restarted.get_records(good_paths)
+    assert set(surviving) == set(good_paths)
+    assert all(record.byte_offset == path.stat().st_size for path, record in surviving.items())
+    cursor_after = {
+        "tracked": len(surviving),
+        "byte_offset_total": sum(record.byte_offset for record in surviving.values()),
+    }
+
+    # The persisted convergence debt is the repair-state matrix row.
+    debt_after = restarted.list_convergence_debt(limit=10)
+    repair = {
+        "required": 1,
+        "performed": 0,
+        "remaining": len(debt_after),
+    }
+
+    # ── Backlog drained to zero from the cycle's perspective. ──
+    backlog_end = backlog_start - len(good_paths) - quarantine_count
+    assert backlog_end == 0
+
+    # ── Per-stage convergence timings: every declared stage must be measured. ──
+    assert set(stage_timings) == {"parse", "fts", "insights"}
+    assert all(value >= 0.0 for value in stage_timings.values())
+    # Converger marked every good input DONE for every stage.
+    for path in good_paths:
+        states = converger._file_states[path].stages
+        assert all(state == StageState.DONE for state in states.values())
+
+    # ── Catchup status surface reads the durable stage event. ──
+    status = catchup_status_info(
+        db_path,
+        latest_attempt=None,
+        convergence=type("StubConvergence", (), {})(),
+    )
+    assert status.mode in {"idle", "catching_up", "converging"}
+    assert any(event.attempt_id == attempt_id for event in status.recent_events)
+    latest_event = status.recent_events[0]
+    assert latest_event.phase == "completed"
+    assert latest_event.succeeded_file_count == len(good_paths)
+    assert latest_event.failed_file_count == 1
+
+    # ── Cursor matrix: before/after/restart_seen. ──
+    assert cursor_before["tracked"] == 0
+    assert cursor_after["tracked"] == len(good_paths)
+    restart_seen = cursor_after["byte_offset_total"] > 0
+    assert restart_seen is True
+
+    # ── Attempts taxonomy. ──
+    discovered = len(paths)
+    attempted = len(paths)
+    skipped = 0
+    ingested = len(good_paths)
+    assert ingested + quarantine_count == discovered
+    assert attempted == discovered
+    assert skipped == 0
+
+    # ── Emit the catch-up cycle envelope (start + end). ──
+    emit_catch_up_cycle(
+        operation_id=attempt_id,
+        phase="start",
+        backlog_start=backlog_start,
+        backlog_end=backlog_start,
+        discovered=discovered,
+        attempted=0,
+        skipped=0,
+        ingested=0,
+        quarantine_count=0,
+        errors_by_kind={},
+        cursor_before=cursor_before,
+        cursor_after=None,
+        duration_ms=0.0,
+        stage_timings_s={},
+        repair={"required": 1, "performed": 0, "remaining": 1},
+    )
+    emit_catch_up_cycle(
+        operation_id=attempt_id,
+        phase="end",
+        backlog_start=backlog_start,
+        backlog_end=backlog_end,
+        discovered=discovered,
+        attempted=attempted,
+        skipped=skipped,
+        ingested=ingested,
+        quarantine_count=quarantine_count,
+        errors_by_kind=errors_by_kind,
+        cursor_before=cursor_before,
+        cursor_after=cursor_after,
+        duration_ms=duration_ms,
+        stage_timings_s=stage_timings,
+        repair=repair,
+    )
+
+    events = query_daemon_events(kind="catch_up_cycle", limit=10)
+    payloads = [_require_dict(event["payload"]) for event in events]
+    phases = {str(payload["phase"]) for payload in payloads}
+    assert {"start", "end"}.issubset(phases)
+    end_payload = next(payload for payload in payloads if payload["phase"] == "end")
+    assert end_payload["backlog_end"] == 0
+    assert end_payload["ingested"] == ingested
+    assert end_payload["quarantine_count"] == quarantine_count
+    assert end_payload["errors_by_kind"] == errors_by_kind
+    assert _require_dict(end_payload["cursor_after"])["tracked"] == len(good_paths)
+    assert set(_require_dict(end_payload["stage_timings_s"]).keys()) == set(stage_timings)
+    assert _require_dict(end_payload["repair"])["remaining"] == repair["remaining"]
+
+    # ── Record bounded evidence so the matrix lands in
+    # ``.cache/verification/evidence/`` under the contract id from #999. ──
+    from polylogue.core.json import JSONValue
+
+    facts: dict[str, JSONValue] = {
+        "cursor": {
+            "before": dict(cursor_before),
+            "after": dict(cursor_after),
+            "restart_seen": restart_seen,
+        },
+        "attempts": {
+            "discovered": discovered,
+            "attempted": attempted,
+            "skipped": skipped,
+            "ingested": ingested,
+        },
+        "errors_by_kind": dict(errors_by_kind),
+        "quarantine_count": quarantine_count,
+        "backlog": {
+            "start": backlog_start,
+            "end": backlog_end,
+            "duration_ms": round(duration_ms, 3),
+        },
+        "repair": dict(repair),
+        "stage_timings_s": dict(stage_timings),
+        "stage_event_count": len(status.recent_events),
+        "attempt_id": attempt_id,
+    }
+    record_contract_evidence.record(
+        "daemon.convergence.catch_up",
+        surface="daemon.convergence",
+        facts=facts,
+    )
+
+
+def test_catch_up_cycle_evidence_payload_is_bounded(tmp_path: Path) -> None:
+    """Catch-up cycle event payloads must not carry raw source content."""
+    db_path = tmp_path / "live_cursor.sqlite"
+    CursorStore(db_path)
+
+    emit_catch_up_cycle(
+        operation_id="bounded-cycle",
+        phase="end",
+        backlog_start=10,
+        backlog_end=0,
+        discovered=10,
+        attempted=10,
+        skipped=0,
+        ingested=9,
+        quarantine_count=1,
+        errors_by_kind={"schema_violation": 1},
+        cursor_before={"tracked": 0},
+        cursor_after={"tracked": 9},
+        duration_ms=12.5,
+        stage_timings_s={"parse": 0.01, "fts": 0.02, "insights": 0.03},
+        repair={"required": 1, "performed": 0, "remaining": 1},
+    )
+
+    events = query_daemon_events(kind="catch_up_cycle", limit=1)
+    assert len(events) == 1
+    payload = events[0]["payload"]
+    assert isinstance(payload, dict)
+    # Counters and structured state only — no message text / paths beyond
+    # the cursor digest fields the test itself supplies.
+    encoded = json.dumps(payload, sort_keys=True)
+    assert len(encoded.encode("utf-8")) < 2048
+    assert "role" not in encoded
+    assert "user" not in encoded


### PR DESCRIPTION
## Summary

Adds a pytest scenario that exercises one full synthetic catch-up convergence cycle and pins the Runtime Evidence Matrix from #999/#1148 to durable evidence. Wires a `catch_up_cycle` event-kind on the daemon event ledger and extends `devtools daemon-workload-probe` to surface per-stage timings.

## Problem

#999 declared a Runtime Evidence Matrix for daemon convergence (cursor lag, attempts taxonomy, errors by kind, queue/backlog drain, repair state, per-stage timings) and #1148 carries the unchecked scope item: \"Runtime observability evidence for full catch-up convergence\". The existing `tests/benchmarks/test_daemon_convergence.py` measures throughput, but there was no pytest evidence test that drives a complete catch-up cycle end-to-end and asserts every row of the matrix. The substrate could emit per-stage timings into `live_ingest_stage_event.stage_timings_json`, but the workload probe did not surface them and there was no \"catch-up cycle\" envelope event tying the per-stage timings, queue drain, errors, and cursor transitions together.

## Solution

- `polylogue/daemon/events.py`: adds `emit_catch_up_cycle(...)` — a typed helper that records `catch_up_cycle` events on the existing `daemon_events.db` ledger. Phase is `\"start\"` or `\"end\"`; payload is bounded to counters/state transitions (`backlog_start/end`, `discovered/attempted/skipped/ingested`, `quarantine_count`, `errors_by_kind`, `cursor_before/after`, `duration_ms`, `stage_timings_s`, `repair`). No raw content. Same `operation_id` ties start/end.
- `devtools/daemon_workload_probe.py`: `_convergence_stage_timings` now accepts the read-only `sqlite3.Connection` and emits a `per_stage_s` summary built from `live_ingest_stage_event.stage_timings_json` (latest event per attempt). Additive — existing fields and report version unchanged; `compare(...)` is unaffected.
- `tests/unit/daemon/test_catch_up_observability.py` (new): drives one synthetic catch-up cycle with the real `CursorStore` + `DaemonConverger`. Stages three files (two good, one schema-violating). Begins an ingest attempt; emits planning + completed stage events; classifies the bad input as `live_convergence_debt` (the \"errors classified without blocking good\" path); advances cursors for successes; opens a fresh `CursorStore` against the same DB and confirms byte offsets survive (cross-restart sub-assertion). Asserts the full matrix and records bounded contract evidence under `daemon.convergence.catch_up`. A second test pins the bounded-payload invariant.

The evidence shape matches what live-archive probes will produce later, satisfying the scope clause \"daemon evidence shape is documented so live archive probes can produce comparable artifacts\".

## Verification

- \`nix develop -c pytest tests/unit/daemon/test_catch_up_observability.py -v\` → 2 passed
- \`nix develop -c pytest tests/unit/daemon/ tests/unit/devtools/test_daemon_workload_probe.py -q\` → 394 passed
- \`nix develop -c mypy polylogue/daemon/events.py devtools/daemon_workload_probe.py tests/unit/daemon/test_catch_up_observability.py\` → Success: no issues
- \`nix develop -c devtools verify --quick\` → exit_code 0 (mypy, ruff, render-all, topology, layering, file-budgets, test-ownership, schema-roundtrip, cross-cuts, suppressions, manifests, ci-workflows, witness-lifecycle, lane-assertions, verification-impact)

Closes #1148
Ref #999