### PR TITLE
feat(insights): resume brief insight with CLI/MCP/facade (#1129)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ documentation polish do not require an entry.
 
 ### Added
 
+- Resume brief is now a first-class durable insight (#1129). `ResumeBrief`
+  carries a typed `provenance` payload citing the session, message,
+  work-event, phase, and work-thread IDs it composed from, with a
+  `materializer_version` consumers can use to invalidate cached renderings.
+  New MCP tool `get_resume_brief(conversation_id, related_limit)` returns the
+  typed brief on the shared single-object envelope; the existing
+  `polylogue resume <session-id>` CLI continues to render the brief and now
+  surfaces the provenance fields via `--format json`.
+
 - Realtime update channel for the daemon web reader (#957): new
   `GET /api/events` Server-Sent Events endpoint streams daemon-event
   notifications (`ingestion_batch`, `ingest`, `reset`, `operation`) so the

--- a/polylogue/insights/resume.py
+++ b/polylogue/insights/resume.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections import Counter
 from collections.abc import Mapping, Sequence
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Protocol
 
 from pydantic import Field
@@ -24,6 +25,21 @@ from polylogue.storage.search.query_support import normalize_fts5_query
 
 if TYPE_CHECKING:
     from polylogue.archive.message.models import Message
+
+
+RESUME_BRIEF_MATERIALIZER_VERSION = 1
+"""Bumped whenever the resume-brief composition contract changes shape.
+
+Owned by ``polylogue/insights/resume.py``. The brief is composed on read
+from already-materialized session insights (profile, enrichment, work
+events, phases, work thread); the version bumps when fields or
+composition semantics change so consumers can invalidate cached
+renderings.
+"""
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
 
 
 class ResumeLastMessage(ArchiveInsightModel):
@@ -101,6 +117,23 @@ class ResumeUncertainty(ArchiveInsightModel):
     detail: str
 
 
+class ResumeProvenance(ArchiveInsightModel):
+    """Cites the substrate rows that contributed to a resume brief.
+
+    Every brief surface (CLI, MCP, reader) must be able to point back at
+    the specific session, message, work-event, phase, and related-session
+    IDs it composed from — no opaque prose.
+    """
+
+    materializer_version: int
+    computed_at: str
+    cited_session_ids: tuple[str, ...] = ()
+    cited_message_ids: tuple[str, ...] = ()
+    cited_work_event_ids: tuple[str, ...] = ()
+    cited_phase_ids: tuple[str, ...] = ()
+    cited_work_thread_id: str | None = None
+
+
 class ResumeBrief(ArchiveInsightModel):
     session_id: str
     facts: ResumeFacts
@@ -108,6 +141,12 @@ class ResumeBrief(ArchiveInsightModel):
     related_sessions: tuple[ResumeRelatedSession, ...] = ()
     uncertainties: tuple[ResumeUncertainty, ...] = ()
     next_steps: tuple[str, ...] = ()
+    provenance: ResumeProvenance = Field(
+        default_factory=lambda: ResumeProvenance(
+            materializer_version=RESUME_BRIEF_MATERIALIZER_VERSION,
+            computed_at=_utc_now_iso(),
+        )
+    )
 
 
 class ResumeOperations(Protocol):
@@ -421,29 +460,49 @@ async def build_resume_brief(
         phases=phases,
         work_thread=work_thread,
     )
+    related_sessions = await _related_sessions(
+        operations,
+        conversation,
+        work_thread,
+        related_limit=related_limit,
+    )
+
+    cited_session_ids: tuple[str, ...] = (conversation_id,) + tuple(
+        related.conversation_id for related in related_sessions
+    )
+    cited_message_ids: tuple[str, ...] = tuple(str(message.id) for message in conversation.messages)
+    cited_work_event_ids: tuple[str, ...] = tuple(event.event_id for event in events[:5])
+    cited_phase_ids: tuple[str, ...] = tuple(phase.phase_id for phase in phases[:5])
+    provenance = ResumeProvenance(
+        materializer_version=RESUME_BRIEF_MATERIALIZER_VERSION,
+        computed_at=_utc_now_iso(),
+        cited_session_ids=cited_session_ids,
+        cited_message_ids=cited_message_ids,
+        cited_work_event_ids=cited_work_event_ids,
+        cited_phase_ids=cited_phase_ids,
+        cited_work_thread_id=work_thread.thread_id if work_thread is not None else None,
+    )
 
     return ResumeBrief(
         session_id=conversation_id,
         facts=_facts_from_conversation(conversation, profile),
         inferences=inferences,
-        related_sessions=await _related_sessions(
-            operations,
-            conversation,
-            work_thread,
-            related_limit=related_limit,
-        ),
+        related_sessions=related_sessions,
         uncertainties=tuple(uncertainties),
         next_steps=_next_steps(conversation, inferences),
+        provenance=provenance,
     )
 
 
 __all__ = [
+    "RESUME_BRIEF_MATERIALIZER_VERSION",
     "ResumeBrief",
     "ResumeFacts",
     "ResumeInferences",
     "ResumeLastMessage",
     "ResumeOperations",
     "ResumePhase",
+    "ResumeProvenance",
     "ResumeRelatedSession",
     "ResumeUncertainty",
     "ResumeWorkEvent",

--- a/polylogue/mcp/server_insight_tools.py
+++ b/polylogue/mcp/server_insight_tools.py
@@ -86,6 +86,25 @@ def register_insight_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
         return await hooks.async_safe_call("session_profile", run)
 
     @mcp.tool()
+    async def get_resume_brief(conversation_id: str, related_limit: int = 6) -> str:
+        """Get a typed resume brief for one archived session.
+
+        The brief composes already-materialized session insights (profile,
+        enrichment, work events, phases, work thread) into a handoff
+        payload. Provenance fields cite the session, message, work-event,
+        and phase IDs that contributed.
+        """
+
+        async def run() -> str:
+            poly = hooks.get_polylogue()
+            brief = await poly.resume_brief(conversation_id, related_limit=related_limit)
+            if brief is None:
+                return hooks.error_json("Conversation not found", code="not_found", conversation_id=conversation_id)
+            return hooks.json_payload(brief, exclude_none=False)
+
+        return await hooks.async_safe_call("get_resume_brief", run)
+
+    @mcp.tool()
     async def archive_coverage() -> str:
         """Show archive coverage statistics."""
 

--- a/tests/data/witnesses/mcp-tool-schemas.json
+++ b/tests/data/witnesses/mcp-tool-schemas.json
@@ -901,6 +901,27 @@
     }
   },
   {
+    "name": "get_resume_brief",
+    "parameters": {
+      "properties": {
+        "conversation_id": {
+          "title": "Conversation Id",
+          "type": "string"
+        },
+        "related_limit": {
+          "default": 6,
+          "title": "Related Limit",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "conversation_id"
+      ],
+      "title": "get_resume_briefArguments",
+      "type": "object"
+    }
+  },
+  {
     "name": "get_session_tree",
     "parameters": {
       "properties": {

--- a/tests/infra/mcp.py
+++ b/tests/infra/mcp.py
@@ -46,6 +46,7 @@ EXPECTED_TOOL_NAMES = {
     "export_query_results",
     "rebuild_session_insights",
     "session_profile",
+    "get_resume_brief",
     "archive_debt",
     "session_profiles",
     "session_enrichments",
@@ -206,6 +207,7 @@ def make_polylogue_mock() -> MagicMock:
     poly.get_messages_paginated = AsyncMock(return_value=([], 0))
     poly.get_conversation = AsyncMock(return_value=None)
     poly.get_session_profile_insight = AsyncMock(return_value=None)
+    poly.resume_brief = AsyncMock(return_value=None)
     poly.neighbor_candidates = AsyncMock(return_value=[])
     poly.rebuild_insights = AsyncMock(
         return_value=MagicMock(to_dict=MagicMock(return_value={}), total=MagicMock(return_value=0))

--- a/tests/unit/core/test_resume.py
+++ b/tests/unit/core/test_resume.py
@@ -104,6 +104,38 @@ async def test_resume_brief_composes_insights_and_related_sessions(cli_workspace
 
 
 @pytest.mark.asyncio
+async def test_resume_brief_provenance_cites_substrate_rows(cli_workspace: dict[str, Path]) -> None:
+    """Provenance must point back at every substrate row composed into the brief."""
+
+    from polylogue.insights.resume import RESUME_BRIEF_MATERIALIZER_VERSION
+
+    db_path = cli_workspace["db_path"]
+    _seed_resume_sessions(db_path)
+    with open_connection(db_path) as conn:
+        rebuild_session_insights_sync(conn)
+
+    archive = Polylogue(archive_root=cli_workspace["archive_root"], db_path=db_path)
+    brief = await archive.resume_brief("resume-child")
+
+    assert brief is not None
+    provenance = brief.provenance
+    assert provenance.materializer_version == RESUME_BRIEF_MATERIALIZER_VERSION
+    assert provenance.computed_at  # ISO timestamp populated
+    # Target session is always first cited.
+    assert provenance.cited_session_ids[0] == "resume-child"
+    # Related sessions discovered via session-tree / work-thread must also be cited.
+    assert "resume-root" in provenance.cited_session_ids
+    # Every message in the target conversation must be cited by ID.
+    assert set(provenance.cited_message_ids) == {"child-u1", "child-a1"}
+    # Work-event provenance cites the substrate IDs, not opaque summaries.
+    assert provenance.cited_work_event_ids
+    for event_id in provenance.cited_work_event_ids:
+        assert event_id  # non-empty
+    # Work thread, when found, is cited by its substrate ID.
+    assert provenance.cited_work_thread_id is not None
+
+
+@pytest.mark.asyncio
 async def test_resume_brief_degrades_when_insights_are_unavailable(cli_workspace: dict[str, Path]) -> None:
     db_path = cli_workspace["db_path"]
     _seed_resume_sessions(db_path)

--- a/tests/unit/mcp/test_contract_evidence.py
+++ b/tests/unit/mcp/test_contract_evidence.py
@@ -317,6 +317,73 @@ class TestToolErrorEnvelopes:
             facts={"is_error": body["is_error"], "code": body.get("code")},
         )
 
+    def test_get_resume_brief_missing_returns_not_found_envelope(
+        self,
+        mcp_server: MCPServerUnderTest,
+        record_contract_evidence: ContractEvidenceRecorder,
+    ) -> None:
+        with patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue:
+            mock_poly = make_polylogue_mock()
+            mock_poly.resume_brief = AsyncMock(return_value=None)
+            mock_get_polylogue.return_value = mock_poly
+
+            result = invoke_surface(
+                mcp_server._tool_manager._tools["get_resume_brief"].fn,
+                conversation_id="missing-session",
+            )
+
+        body = _structured_error(result)
+        assert body.get("code") == "not_found", f"expected code='not_found', got {body!r}"
+        record_contract_evidence.record(
+            "mcp.tool.get_resume_brief.not_found",
+            surface="mcp",
+            facts={"is_error": body["is_error"], "code": body.get("code")},
+        )
+
+    def test_get_resume_brief_returns_typed_brief_payload(
+        self,
+        mcp_server: MCPServerUnderTest,
+        record_contract_evidence: ContractEvidenceRecorder,
+    ) -> None:
+        from polylogue.insights.resume import (
+            RESUME_BRIEF_MATERIALIZER_VERSION,
+            ResumeBrief,
+            ResumeFacts,
+            ResumeInferences,
+            ResumeProvenance,
+        )
+
+        brief = ResumeBrief(
+            session_id="conv-123",
+            facts=ResumeFacts(conversation_id="conv-123", provider_name="claude-code", message_count=2),
+            inferences=ResumeInferences(),
+            provenance=ResumeProvenance(
+                materializer_version=RESUME_BRIEF_MATERIALIZER_VERSION,
+                computed_at="2026-05-17T00:00:00+00:00",
+                cited_session_ids=("conv-123",),
+                cited_message_ids=("m1", "m2"),
+            ),
+        )
+        with patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue:
+            mock_poly = make_polylogue_mock()
+            mock_poly.resume_brief = AsyncMock(return_value=brief)
+            mock_get_polylogue.return_value = mock_poly
+
+            result = invoke_surface(
+                mcp_server._tool_manager._tools["get_resume_brief"].fn,
+                conversation_id="conv-123",
+            )
+
+        payload = json.loads(result)
+        assert payload["session_id"] == "conv-123"
+        assert payload["provenance"]["materializer_version"] == RESUME_BRIEF_MATERIALIZER_VERSION
+        assert "conv-123" in payload["provenance"]["cited_session_ids"]
+        record_contract_evidence.record(
+            "mcp.tool.get_resume_brief.ok",
+            surface="mcp",
+            facts={"session_id": payload["session_id"]},
+        )
+
     def test_bulk_tag_validation_returns_structured_error(
         self,
         mcp_server: MCPServerUnderTest,

--- a/tests/unit/mcp/test_envelope_contracts.py
+++ b/tests/unit/mcp/test_envelope_contracts.py
@@ -64,6 +64,7 @@ TOOL_CONTRACT: dict[str, ToolKind] = {
     "get_conversation_summary": "single_object",
     "get_metadata": "single_object",
     "session_profile": "single_object",
+    "get_resume_brief": "single_object",
     "archive_coverage": "single_object",
     "stats": "single_object",
     "build_context_pack": "single_object",


### PR DESCRIPTION
## Summary

Promote the existing `polylogue/insights/resume.py` helper into a first-class insight surface: `ResumeBrief` gains a typed `ResumeProvenance` payload that cites the session, message, work-event, phase, and work-thread IDs it composed from, plus a `RESUME_BRIEF_MATERIALIZER_VERSION` constant. Add the parallel MCP tool `get_resume_brief(conversation_id, related_limit)` using the established single-object envelope.

## Problem

The resume brief existed as a library helper and was wired to the CLI (`polylogue resume <session-id>`) and the Python facade (`Polylogue.resume_brief`), but #1129 calls for first-class insight semantics: provenance that names the substrate rows that compose the brief, a versioning fence so consumers can invalidate cached renderings, and the MCP surface so agents can pull the brief on the shared envelope shape. Without provenance the brief is opaque prose; without an MCP tool the brief is unreachable from agent context.

## Solution

- `polylogue/insights/resume.py`
  - New `ResumeProvenance` typed model with `materializer_version`, `computed_at`, and four tuples citing substrate IDs: `cited_session_ids`, `cited_message_ids`, `cited_work_event_ids`, `cited_phase_ids`, plus `cited_work_thread_id`.
  - `ResumeBrief` gains a `provenance` field populated by `build_resume_brief()`. Target session is always the first cited session ID; related sessions, every message in the target conversation, and the substrate IDs of the work events / phases referenced in `inferences` are cited.
  - `RESUME_BRIEF_MATERIALIZER_VERSION = 1` — bumped when the composition contract changes.
- `polylogue/mcp/server_insight_tools.py`
  - New `get_resume_brief` MCP tool. Returns the typed brief via `hooks.json_payload(brief)`, or the standard not-found error envelope (`code="not_found"`) when the conversation does not exist. Parallel in shape to the existing `session_profile` single-item tool.
- Tests
  - `tests/unit/core/test_resume.py::test_resume_brief_provenance_cites_substrate_rows` — pins the provenance invariant against the seeded resume-root / resume-child fixtures.
  - `tests/unit/mcp/test_contract_evidence.py` — adds not-found and typed-payload tests that record contract evidence.
  - `tests/unit/mcp/test_envelope_contracts.py` + `tests/infra/mcp.py` — register `get_resume_brief` in the envelope contract matrix, the expected-tools set, and the polylogue mock.
  - `tests/data/witnesses/mcp-tool-schemas.json` — regenerated to include the new tool's wire schema.
- `CHANGELOG.md` — `Unreleased > Added` entry covering the user-visible additions.

### Scope decision (foundation slice)

Per the issue prompt, this is the foundation slice: substrate gains durable provenance + materializer version, the MCP surface is added, and the CLI/facade are already wired. The brief is composed on read from already-materialized session insights (profile, enrichment, work events, phases, work thread) — those tables are the durable substrate. A separate on-disk `session_resume_briefs` table (schema v15 bump, write/read mixins, rebuild registration, readiness flag) is intentionally deferred: the input insights are already durable and add no information that would benefit from a second materialization layer at this point. If a future workload needs to query briefs by predicate (e.g. "all sessions with unresolved blockers"), that follow-up will declare the table and the rebuild semantics.

Acceptance criteria from #1129:
- Typed `ResumeBriefInsight` model with provenance and version: satisfied (`ResumeBrief.provenance`, `RESUME_BRIEF_MATERIALIZER_VERSION`).
- Public read API in `operations/archive.py` returning the insight with provenance: satisfied (existing `build_resume_brief` now returns the provenance-bearing model).
- CLI command renders the brief: satisfied (existing `polylogue resume`; provenance reachable via `--format json`).
- MCP tool returns shared envelope: satisfied (`get_resume_brief`, single-object envelope, classified in `TOOL_CONTRACT`).
- Tests: rebuild contract (existing `test_resume_brief_composes_insights_and_related_sessions`), CLI snapshot (existing `test_resume_*`), MCP envelope (`test_get_resume_brief_returns_typed_brief_payload`), provenance invariant (`test_resume_brief_provenance_cites_substrate_rows`).
- `devtools verify --quick` passes (see Verification).
- Stored on-disk materialization (separate schema table + rebuild registration + readiness flag): deferred as documented above.

## Verification

```
nix develop -c pytest -q tests/unit/core/test_resume.py tests/unit/cli/test_resume.py \
  tests/unit/mcp/test_envelope_contracts.py tests/unit/mcp/test_contract_evidence.py \
  tests/unit/mcp/test_server_surfaces.py tests/unit/mcp/test_tool_schema_witness.py
# 228 passed in 12.10s
nix develop -c mypy --strict polylogue/insights/resume.py polylogue/mcp/server_insight_tools.py \
  tests/unit/core/test_resume.py tests/unit/mcp/test_contract_evidence.py \
  tests/unit/mcp/test_envelope_contracts.py tests/infra/mcp.py
# Success: no issues found in 6 source files
nix develop -c devtools verify --quick
# total_duration_s: 31.37, exit_code: 0
```

Ref #1129