### PR TITLE
refactor(cost): drop provider_meta fallback reads outside extractors (#1139)

### DIFF
--- a/polylogue/archive/conversation/runtime.py
+++ b/polylogue/archive/conversation/runtime.py
@@ -193,14 +193,17 @@ class ConversationRuntimeMixin:
 
     @property
     def total_cost_usd(self) -> float:
-        from polylogue.archive.message.model_runtime import _coerce_optional_float
+        """Sum of per-message ``cost_usd`` values.
 
-        message_total = sum((message.cost_usd or 0.0) for message in self.messages)
-        if message_total > 0.0:
-            return message_total
-        if self.provider_meta is None:
-            return 0.0
-        return _coerce_optional_float(self.provider_meta.get("total_cost_usd")) or 0.0
+        This is the parser/runtime view, derived only from message-level data.
+        Conversation-level cost facts in ``provider_meta`` are extracted by
+        ``polylogue.archive.semantic.pricing`` into the typed
+        ``CostEstimatePayload`` model; downstream readers (insights, session
+        summaries, threads) consume the typed model, not ``provider_meta``.
+        See issue #1139.
+        """
+
+        return sum((message.cost_usd or 0.0) for message in self.messages)
 
     @property
     def total_duration_ms(self) -> int:

--- a/tests/unit/core/test_conversation_semantics.py
+++ b/tests/unit/core/test_conversation_semantics.py
@@ -306,7 +306,15 @@ class TestConversationMetadataAndAggregation:
         assert branched.assistant_message_count == 3
         assert conversation_with_metadata.model_copy() == conversation_with_metadata
 
-    def test_cost_duration_fall_back_to_conversation_provider_meta(self) -> None:
+    def test_total_cost_usd_does_not_fall_back_to_provider_meta(self) -> None:
+        """Per #1139: Conversation.total_cost_usd is message-only.
+
+        Conversation-level cost in ``provider_meta`` must be consumed via the
+        typed ``pricing.estimate_conversation_cost`` /
+        ``harmonize_session_cost`` extractor path, not via a silent
+        runtime-property fallback.
+        """
+
         conversation = make_conv(
             id="claude-code-session",
             provider="claude-code",
@@ -319,8 +327,11 @@ class TestConversationMetadataAndAggregation:
             provider_meta={"total_cost_usd": "0.75", "total_duration_ms": "3200"},
         )
 
-        assert conversation.total_cost_usd == pytest.approx(0.75)
+        # Runtime property no longer falls back to provider_meta for cost.
+        assert conversation.total_cost_usd == 0.0
+        # Duration still falls back (out of #1139 scope).
         assert conversation.total_duration_ms == 3200
+        # The typed extractor path still surfaces the provider-reported cost.
         assert harmonize_session_cost(conversation) == (0.75, False)
 
 

--- a/tests/unit/insights/test_no_provider_meta_cost_reads.py
+++ b/tests/unit/insights/test_no_provider_meta_cost_reads.py
@@ -1,0 +1,128 @@
+"""Lint-style guard: cost ``provider_meta`` reads must live in extractors only.
+
+#1139 completes the carry-over from #803: cost/usage values in
+``provider_meta`` are extracted into the typed cost read model
+(``polylogue/insights/archive_models.py``, ``CostEstimatePayload`` from
+``polylogue/archive/semantic/pricing.py``). Downstream readers (archive
+runtime, insights, session/threads, storage repositories, CLI/MCP surfaces)
+must consume the typed model, never reach back into ``provider_meta`` for
+cost or token-usage values.
+
+This test fails if a new ``provider_meta``-cost read appears outside the
+allowlisted extractor modules. The allowlist intentionally lists exact module
+paths; broadening it requires an explicit decision documented in this file.
+
+Mirrors the ``verify-layering``/``verify-test-ownership`` pattern: declared
+contract enforced by a focused test rather than ad-hoc convention.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+POLYLOGUE_ROOT = Path(__file__).resolve().parents[3] / "polylogue"
+
+# Keys that name a cost/usage value when read from ``provider_meta``.
+COST_KEYS = frozenset(
+    {
+        "cost",
+        "costUSD",
+        "cost_usd",
+        "total_cost_usd",
+        "usage",
+        "input_tokens",
+        "output_tokens",
+        "cache_creation_input_tokens",
+        "cache_read_input_tokens",
+        "total_tokens",
+    }
+)
+
+# Modules that own provider->typed extraction; ``provider_meta`` cost reads
+# here are the canonical single source of truth for those facts.
+EXTRACTOR_ALLOWLIST = frozenset(
+    {
+        # Parsers: provider wire -> ParsedConversation.provider_meta writes
+        # and (for Message.cost_usd in model_runtime) the parser-only accessor.
+        "polylogue/sources/parsers",
+        "polylogue/sources/providers",
+        # Schema-level coercion of provider_meta into typed sub-models.
+        "polylogue/schemas",
+        # Canonical pricing extractor: provider_meta -> CostEstimatePayload.
+        "polylogue/archive/semantic/pricing.py",
+        # Parser-only Message.cost_usd accessor (documented PARSER-ONLY in
+        # its docstring; returns None for hydrated messages).
+        "polylogue/archive/message/model_runtime.py",
+    }
+)
+
+
+def _is_allowlisted(path: Path) -> bool:
+    rel = path.relative_to(POLYLOGUE_ROOT.parent).as_posix()
+    return any(rel == entry or rel.startswith(entry.rstrip("/") + "/") for entry in EXTRACTOR_ALLOWLIST)
+
+
+def _provider_meta_cost_reads(tree: ast.AST) -> list[tuple[int, str]]:
+    """Return ``(lineno, key)`` for each ``...provider_meta.get("<COST_KEY>")``.
+
+    Also matches ``provider_meta["<COST_KEY>"]`` subscript reads.
+    """
+
+    hits: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        # Match ``X.provider_meta.get("key", ...)``.
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "get"
+            and isinstance(node.func.value, ast.Attribute)
+            and node.func.value.attr == "provider_meta"
+            and node.args
+            and isinstance(node.args[0], ast.Constant)
+            and isinstance(node.args[0].value, str)
+            and node.args[0].value in COST_KEYS
+        ):
+            hits.append((node.lineno, node.args[0].value))
+        # Match ``X.provider_meta["key"]``.
+        elif (
+            isinstance(node, ast.Subscript)
+            and isinstance(node.value, ast.Attribute)
+            and node.value.attr == "provider_meta"
+            and isinstance(node.slice, ast.Constant)
+            and isinstance(node.slice.value, str)
+            and node.slice.value in COST_KEYS
+        ):
+            hits.append((node.lineno, node.slice.value))
+    return hits
+
+
+def test_no_provider_meta_cost_reads_outside_extractors() -> None:
+    offenders: list[str] = []
+    for path in POLYLOGUE_ROOT.rglob("*.py"):
+        if _is_allowlisted(path):
+            continue
+        try:
+            source = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):  # pragma: no cover - defensive
+            continue
+        try:
+            tree = ast.parse(source, filename=str(path))
+        except SyntaxError:  # pragma: no cover - defensive
+            continue
+        for lineno, key in _provider_meta_cost_reads(tree):
+            rel = path.relative_to(POLYLOGUE_ROOT.parent).as_posix()
+            offenders.append(f"{rel}:{lineno} reads provider_meta[{key!r}]")
+    assert not offenders, (
+        "Cost-bearing provider_meta reads must live in extractor modules. "
+        "Consume the typed cost read model (polylogue.insights.archive_models / "
+        "polylogue.archive.semantic.pricing) instead. Offenders:\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_allowlist_entries_exist() -> None:
+    """Guard against bit-rot: every allowlist entry must point at a real path."""
+
+    repo_root = POLYLOGUE_ROOT.parent
+    missing = [entry for entry in EXTRACTOR_ALLOWLIST if not (repo_root / entry).exists()]
+    assert not missing, f"Stale entries in EXTRACTOR_ALLOWLIST: {missing}"


### PR DESCRIPTION
## Summary

Removes the only substrate-level `provider_meta` cost fallback read (`Conversation.total_cost_usd`) so cost reaches downstream readers exclusively through the typed extractor path (`archive.semantic.pricing.estimate_conversation_cost` / `harmonize_session_cost` → `CostEstimatePayload` and the typed insight rollups). Adds an AST-based lint test that fails if any non-extractor module reintroduces such a read.

## Problem

#1139 (carry-over from #803) requires that cost/usage values in `provider_meta` are extracted into the typed cost read model at one canonical location (parsers + `archive/semantic/pricing.py`). Downstream readers — archive runtime, insights, session/threads, storage repositories, CLI/MCP surfaces — must consume the typed model and not silently fall back to `provider_meta`.

Inventory of `provider_meta`-cost reads in `polylogue/` (full table on #1139):

| Site | Classification |
|---|---|
| `sources/parsers/claude/code_parser.py:247` | Extractor (writer) |
| `sources/providers/claude_code_record.py:171-172` | Extractor (typed record) |
| `schemas/extraction.py:248`, `schemas/unified/fallbacks.py:90`, `schemas/unified/provider_meta_coercion.py:86,106,115` | Extractors (schema coercion) |
| `archive/semantic/pricing.py:414-415, 442-448` | Canonical cost extractor |
| `archive/message/model_runtime.py:262-272` | Parser-only `Message.cost_usd` accessor (docstring already says `PARSER-ONLY: ... None for hydrated messages`) |
| `archive/conversation/runtime.py:195-203` | **Downstream reader — the migration target** |

The other files named in #1139's "Files in scope" (`archive/session/*.py`, `storage/insights/**`, `operations/archive.py`, `archive/conversation/threads.py`) were re-audited: they all read `total_cost_usd` from typed insight models (`SessionProfile`, `WorkThread`, `DaySessionSummary`), not from `provider_meta`. No change needed.

**Before / after grep counts** (`grep -rn 'provider_meta.*cost\|costUSD' polylogue/ | grep -v test`):

- Before: 1 substrate-level non-extractor read (`archive/conversation/runtime.py:203`).
- After: 0 non-extractor reads, enforced by a lint test.

## Solution

- `polylogue/archive/conversation/runtime.py`: `Conversation.total_cost_usd` now returns purely `sum(message.cost_usd or 0.0)`; the `provider_meta.get("total_cost_usd")` fallback is removed. Docstring records that conversation-level cost extraction lives in `archive.semantic.pricing`. `total_duration_ms` is unchanged — duration is out of #1139 scope.
- `tests/unit/insights/test_no_provider_meta_cost_reads.py` (new): AST walks every `polylogue/*.py`, flags `X.provider_meta.get("<COST_KEY>")` and `X.provider_meta["<COST_KEY>"]` reads outside a tight `EXTRACTOR_ALLOWLIST` (`sources/parsers`, `sources/providers`, `schemas`, `archive/semantic/pricing.py`, `archive/message/model_runtime.py`). Cost keys: `cost`, `costUSD`, `cost_usd`, `total_cost_usd`, `usage`, `input_tokens`, `output_tokens`, `cache_creation_input_tokens`, `cache_read_input_tokens`, `total_tokens`. A companion test asserts every allowlist entry still exists (prevents bit-rot).
- `tests/unit/core/test_conversation_semantics.py`: the old `test_cost_duration_fall_back_to_conversation_provider_meta` (which documented the removed fallback) is replaced by `test_total_cost_usd_does_not_fall_back_to_provider_meta`, which pins the new contract: runtime property returns `0.0`, `harmonize_session_cost` still returns the provider-reported `0.75` via the typed extractor.

No schema changes, no new cost computation logic — pure migration of a single read site plus the lint guard requested in #1139's acceptance criteria.

Inventory comment posted on #1139: https://github.com/Sinity/polylogue/issues/1139#issuecomment-4469360700.

## Verification

```
nix develop -c pytest tests/unit/insights/test_no_provider_meta_cost_reads.py tests/unit/core/test_conversation_semantics.py -q
# 41 passed in 11.57s

nix develop -c pytest -q -k "cost or pricing or thread or insight or harmoniz" --ignore=tests/integration
# 332 passed in 43.02s

nix develop -c devtools verify --quick
# exit_code: 0

nix develop -c devtools verify --all
# 7344 passed, 2 failed, 2 xfailed
# Failures: tests/unit/devtools/test_topology_projection_witness.py::{test_every_cell_has_target_path, test_every_owner_appears_in_files}
# Pre-existing on master (confirmed via `git stash && pytest ...`); unrelated to cost (topology-projection drift: `polylogue/storage/message_type_backfill.py` missing target, `storage-domain` owner not in vocabulary). Out of scope for #1139.
```

Closes #1139.