### PR TITLE
feat(daemon): webhook notifications for health alerts (#1150)

### DIFF
--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -194,7 +194,7 @@ Configure via `polylogue.toml`:
 
 ```toml
 [notifications]
-notification_backend = "log"
+backend = "log"
 ```
 
 Or via environment variable:
@@ -202,6 +202,52 @@ Or via environment variable:
 ```bash
 export POLYLOGUE_NOTIFICATION_BACKEND=log
 ```
+
+#### Webhook backend
+
+Selecting `backend = "webhook"` POSTs a typed JSON envelope to a
+user-configured URL on every non-OK health tick. The URL is fed through the
+resolved config and must be set; missing or empty URLs raise a typed config
+error at daemon startup rather than silently falling back to `log`.
+
+```toml
+[notifications]
+backend = "webhook"
+webhook_url = "https://hooks.example.invalid/polylogue"
+```
+
+Or via environment variables:
+
+```bash
+export POLYLOGUE_NOTIFICATION_BACKEND=webhook
+export POLYLOGUE_NOTIFICATION_WEBHOOK_URL=https://hooks.example.invalid/polylogue
+```
+
+Envelope shape:
+
+```json
+{
+  "alerts": [
+    {
+      "check_name": "wal_size",
+      "tier": "fast",
+      "severity": "warning",
+      "message": "wal_size warning: 80 MB",
+      "checked_at": "2026-05-17T00:00:00+00:00",
+      "consecutive_failures": 1
+    }
+  ],
+  "emitted_at": 1747440000.123,
+  "daemon_version": "0.6.0+g<sha>"
+}
+```
+
+The backend uses a bounded 5-second per-attempt timeout and a single retry on
+transient failure (network error or HTTP 5xx). 4xx responses are treated as
+permanent client errors and are not retried. Persistent failure surfaces
+through the existing periodic-loop catch boundary in
+`polylogue/daemon/cli.py`; it does not crash the daemon. Dedup and
+rate-limiting are out of scope for this backend.
 
 ## Maintenance
 

--- a/polylogue/config.py
+++ b/polylogue/config.py
@@ -276,6 +276,11 @@ class PolylogueConfig:
         return str(self._data.get("notification_backend", "log"))
 
     @property
+    def notification_webhook_url(self) -> str | None:
+        v = self._data.get("notification_webhook_url")
+        return v if isinstance(v, str) and v else None
+
+    @property
     def health_check_interval_s(self) -> int:
         return int(str(self._data.get("health_check_interval_s", 300)))
 
@@ -410,6 +415,7 @@ def _default_config_values() -> dict[str, object]:
         "force_plain": False,
         "schema_validation": "advisory",
         "notification_backend": "log",
+        "notification_webhook_url": None,
         "health_check_interval_s": 300,
         "health_check_tiers": "fast,medium",
         "watch_debounce_s": 2.0,
@@ -568,7 +574,10 @@ def _merge_toml(cfg: dict[str, object], toml_data: dict[str, object]) -> None:
             "level": "log_level",
             "force_plain": "force_plain",
         },
-        "notifications": {"backend": "notification_backend"},
+        "notifications": {
+            "backend": "notification_backend",
+            "webhook_url": "notification_webhook_url",
+        },
         "health": {
             "check_interval_s": "health_check_interval_s",
             "check_tiers": "health_check_tiers",
@@ -603,6 +612,7 @@ def _apply_env_overrides(cfg: dict[str, object]) -> None:
         "POLYLOGUE_SLOW_QUERY_NOTICE_SECONDS": "slow_query_notice_seconds",
         "POLYLOGUE_SCHEMA_VALIDATION": "schema_validation",
         "POLYLOGUE_NOTIFICATION_BACKEND": "notification_backend",
+        "POLYLOGUE_NOTIFICATION_WEBHOOK_URL": "notification_webhook_url",
         "POLYLOGUE_HEALTH_CHECK_INTERVAL_S": "health_check_interval_s",
         "POLYLOGUE_HEALTH_CHECK_TIERS": "health_check_tiers",
         "POLYLOGUE_API_HOST": "api_host",
@@ -689,7 +699,13 @@ def format_config_toml(cfg: dict[str, object]) -> str:
                 ("force_plain", "force_plain"),
             ],
         ),
-        ("notifications", [("backend", "notification_backend")]),
+        (
+            "notifications",
+            [
+                ("backend", "notification_backend"),
+                ("webhook_url", "notification_webhook_url"),
+            ],
+        ),
         (
             "health",
             [

--- a/polylogue/daemon/notifications.py
+++ b/polylogue/daemon/notifications.py
@@ -1,24 +1,38 @@
 """Notification backends for daemon health alerts and operational events.
 
-The initial backend is log-based — all alerts are written to the structured
-logger. This provides a baseline notifications surface that can be extended
-with webhook, email, or other transports without changing the alert model.
+Two backends ship today:
+
+- ``"log"`` (default) — writes alerts to the structured logger.
+- ``"webhook"`` — POSTs a typed JSON envelope to a user-configured URL.
 
 Backend selection is driven by the runtime config's ``notification_backend``
-key. Supported values:
+key. The webhook backend reads ``notification_webhook_url`` from the same
+config dict.
 
-- ``"log"`` (default) — write alerts to the structured logger
-- Future: ``"email"``, ``"slack"``, ``"webhook"``
+Backends are intentionally fire-and-forget per dispatch call. Dedup,
+rate-limiting, and severity-routing live in sibling concerns; the periodic
+health loop's ``except Exception`` boundary catches persistent failures.
 """
 
 from __future__ import annotations
 
+import time
 from typing import Protocol
+
+import httpx
 
 from polylogue.daemon.health import HealthAlert, HealthSeverity
 from polylogue.logging import get_logger
+from polylogue.version import POLYLOGUE_VERSION
 
 logger = get_logger(__name__)
+
+
+WEBHOOK_TIMEOUT_S = 5.0
+"""Per-attempt HTTP timeout for the webhook backend."""
+
+WEBHOOK_RETRY_BACKOFF_S = 0.5
+"""Backoff between the initial attempt and the single retry."""
 
 
 class NotificationBackend(Protocol):
@@ -27,6 +41,16 @@ class NotificationBackend(Protocol):
     def notify(self, alerts: list[HealthAlert], *, config: dict[str, object] | None = None) -> None:
         """Deliver one or more health alerts."""
         ...
+
+
+class _HTTPPoster(Protocol):
+    """Minimal client surface used by :class:`WebhookNotificationBackend`.
+
+    ``httpx.Client`` satisfies this protocol structurally; tests inject
+    lightweight stubs without depending on the full client surface.
+    """
+
+    def post(self, url: str, *, json: dict[str, object], timeout: float) -> httpx.Response: ...
 
 
 class LogNotificationBackend:
@@ -58,21 +82,135 @@ class LogNotificationBackend:
                 )
 
 
-def _resolve_backend(backend_name: str) -> NotificationBackend:
+class WebhookConfigError(ValueError):
+    """Raised when the webhook backend is selected without a valid URL."""
+
+
+class WebhookNotificationBackend:
+    """POSTs a typed JSON envelope to a user-configured URL.
+
+    Envelope shape:
+
+    .. code-block:: json
+
+        {
+          "alerts": [{"check_name": "...", "tier": "...", "severity": "...",
+                       "message": "...", "checked_at": "...",
+                       "consecutive_failures": N}, ...],
+          "emitted_at": "<unix epoch seconds, float>",
+          "daemon_version": "<polylogue version string>"
+        }
+
+    The backend uses a single bounded-timeout HTTP POST. On transient
+    failure (network error or HTTP 5xx), it retries exactly once after a
+    short backoff. Persistent failure raises ``httpx.HTTPError``; callers
+    are expected to swallow the exception at the periodic-loop boundary
+    (see ``polylogue/daemon/cli.py`` health loop).
+
+    The HTTP client is injected for tests; production uses
+    :class:`httpx.Client`.
+    """
+
+    def __init__(
+        self,
+        url: str,
+        *,
+        timeout: float = WEBHOOK_TIMEOUT_S,
+        max_retries: int = 1,
+        backoff_s: float = WEBHOOK_RETRY_BACKOFF_S,
+        client: _HTTPPoster | None = None,
+    ) -> None:
+        if not url or not isinstance(url, str):
+            raise WebhookConfigError(
+                "notification_webhook_url must be a non-empty string when notification_backend='webhook'"
+            )
+        self._url = url
+        self._timeout = float(timeout)
+        self._max_retries = int(max_retries)
+        self._backoff_s = float(backoff_s)
+        self._client = client
+
+    def notify(self, alerts: list[HealthAlert], *, config: dict[str, object] | None = None) -> None:
+        if not alerts:
+            return
+        envelope = _build_envelope(alerts)
+        attempts = self._max_retries + 1
+        last_error: Exception | None = None
+        for attempt in range(attempts):
+            try:
+                response = self._post(envelope)
+            except httpx.HTTPError as err:
+                last_error = err
+                logger.warning(
+                    "daemon.notifications.webhook: transient error on attempt %d/%d: %s",
+                    attempt + 1,
+                    attempts,
+                    err,
+                )
+            else:
+                if response.status_code < 500:
+                    response.raise_for_status()
+                    logger.debug(
+                        "daemon.notifications.webhook: delivered %d alert(s) (status=%d)",
+                        len(alerts),
+                        response.status_code,
+                    )
+                    return
+                last_error = httpx.HTTPStatusError(
+                    f"server error {response.status_code}", request=response.request, response=response
+                )
+                logger.warning(
+                    "daemon.notifications.webhook: server %d on attempt %d/%d",
+                    response.status_code,
+                    attempt + 1,
+                    attempts,
+                )
+            if attempt < attempts - 1 and self._backoff_s > 0:
+                time.sleep(self._backoff_s)
+        assert last_error is not None  # one of the branches above set it
+        raise last_error
+
+    def _post(self, envelope: dict[str, object]) -> httpx.Response:
+        if self._client is not None:
+            return self._client.post(self._url, json=envelope, timeout=self._timeout)
+        with httpx.Client(timeout=self._timeout) as client:
+            return client.post(self._url, json=envelope)
+
+
+def _build_envelope(alerts: list[HealthAlert]) -> dict[str, object]:
+    """Build the JSON envelope POSTed by :class:`WebhookNotificationBackend`."""
+    return {
+        "alerts": [alert.model_dump(mode="json") for alert in alerts],
+        "emitted_at": time.time(),
+        "daemon_version": POLYLOGUE_VERSION,
+    }
+
+
+def _resolve_backend(backend_name: str, config: dict[str, object] | None = None) -> NotificationBackend:
     """Resolve a notification backend name to an instance.
 
     Args:
-        backend_name: Backend identifier (e.g. ``"log"``).
+        backend_name: Backend identifier (e.g. ``"log"`` or ``"webhook"``).
+        config: Optional runtime config dict, consulted by backends that
+            require additional keys (the webhook backend reads
+            ``notification_webhook_url``).
 
     Returns:
         An instance of the requested backend.
 
     Raises:
         ValueError: If the backend name is unknown.
+        WebhookConfigError: If ``"webhook"`` is selected without a usable
+            ``notification_webhook_url`` value.
     """
     if backend_name == "log":
         return LogNotificationBackend()
-    supported = ["log"]
+    if backend_name == "webhook":
+        url_value: object = (config or {}).get("notification_webhook_url")
+        if not isinstance(url_value, str) or not url_value:
+            raise WebhookConfigError("notification_backend='webhook' requires notification_webhook_url in config")
+        return WebhookNotificationBackend(url_value)
+    supported = ["log", "webhook"]
     raise ValueError(f"unknown notification backend: {backend_name!r}. Supported backends: {', '.join(supported)}")
 
 
@@ -88,12 +226,13 @@ def send_notifications(
         alerts: Health alerts to deliver.
         backend: Notification backend. If None, resolved from config or
                  defaults to ``LogNotificationBackend``.
-        config: Optional runtime config dict (reserved for future backends).
+        config: Optional runtime config dict (forwarded to the resolved
+                backend; required for the webhook backend to read its URL).
     """
     if backend is not None:
         _backend = backend
     elif config is not None and isinstance(config.get("notification_backend"), str):
-        _backend = _resolve_backend(str(config["notification_backend"]))
+        _backend = _resolve_backend(str(config["notification_backend"]), config=config)
     else:
         _backend = LogNotificationBackend()
 
@@ -106,6 +245,10 @@ def send_notifications(
 __all__ = [
     "LogNotificationBackend",
     "NotificationBackend",
+    "WEBHOOK_RETRY_BACKOFF_S",
+    "WEBHOOK_TIMEOUT_S",
+    "WebhookConfigError",
+    "WebhookNotificationBackend",
     "_resolve_backend",
     "send_notifications",
 ]

--- a/tests/unit/daemon/test_notification_webhook.py
+++ b/tests/unit/daemon/test_notification_webhook.py
@@ -1,0 +1,203 @@
+"""Tests for the webhook notification backend.
+
+Covers issue #1150 acceptance criteria:
+- POST shape (URL, method, payload, timeout) asserted with a stub client.
+- Transient 5xx retried exactly once; persistent failure raises.
+- Missing/invalid URL when ``"webhook"`` is selected raises a typed config
+  error at resolve time (not a silent fallback to log).
+- ``_resolve_backend("webhook")`` returns the backend; unknown names still
+  raise the original ``ValueError``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+
+from polylogue.daemon.health import HealthAlert, HealthSeverity, HealthTier
+from polylogue.daemon.notifications import (
+    WEBHOOK_TIMEOUT_S,
+    WebhookConfigError,
+    WebhookNotificationBackend,
+    _resolve_backend,
+    send_notifications,
+)
+
+
+def _alert(name: str = "schema_version", severity: HealthSeverity = HealthSeverity.ERROR) -> HealthAlert:
+    return HealthAlert(
+        check_name=name,
+        tier=HealthTier.FAST,
+        severity=severity,
+        message=f"{name} {severity.value}",
+        checked_at="2026-05-17T00:00:00+00:00",
+        consecutive_failures=2 if severity != HealthSeverity.OK else 0,
+    )
+
+
+class _StubClient:
+    """Test double for ``httpx.Client`` exposing only ``.post``.
+
+    Each scripted response is either an ``httpx.Response`` (returned) or an
+    ``Exception`` (raised). The same instance is replayed across calls so a
+    single test can model retries.
+    """
+
+    def __init__(self, scripted: list[Any]) -> None:
+        self._scripted = list(scripted)
+        self.calls: list[dict[str, Any]] = []
+
+    def post(self, url: str, *, json: dict[str, object], timeout: float) -> httpx.Response:
+        self.calls.append({"url": url, "json": json, "timeout": timeout})
+        if not self._scripted:
+            raise AssertionError("StubClient ran out of scripted responses")
+        item = self._scripted.pop(0)
+        if isinstance(item, Exception):
+            raise item
+        assert isinstance(item, httpx.Response)
+        # Bind a synthetic request so raise_for_status() has the context it expects.
+        item.request = httpx.Request("POST", url)
+        return item
+
+
+def _ok(status: int = 200) -> httpx.Response:
+    return httpx.Response(status_code=status)
+
+
+def _server_error(status: int = 503) -> httpx.Response:
+    return httpx.Response(status_code=status, text="upstream busy")
+
+
+def test_webhook_posts_typed_envelope_to_configured_url() -> None:
+    stub = _StubClient([_ok(202)])
+    backend = WebhookNotificationBackend("https://example/notify", client=stub, backoff_s=0)
+    alerts = [_alert(), _alert("wal_size", HealthSeverity.WARNING)]
+
+    backend.notify(alerts)
+
+    assert len(stub.calls) == 1
+    call = stub.calls[0]
+    assert call["url"] == "https://example/notify"
+    assert call["timeout"] == WEBHOOK_TIMEOUT_S
+    envelope = call["json"]
+    assert set(envelope.keys()) == {"alerts", "emitted_at", "daemon_version"}
+    assert isinstance(envelope["alerts"], list)
+    assert len(envelope["alerts"]) == 2
+    assert envelope["alerts"][0]["check_name"] == "schema_version"
+    assert envelope["alerts"][0]["severity"] == "error"
+    assert envelope["alerts"][0]["tier"] == "fast"
+    assert envelope["alerts"][1]["check_name"] == "wal_size"
+    assert isinstance(envelope["emitted_at"], float)
+    assert isinstance(envelope["daemon_version"], str) and envelope["daemon_version"]
+
+
+def test_webhook_empty_alert_list_is_noop() -> None:
+    stub = _StubClient([])  # no scripted response → blow up if called
+    backend = WebhookNotificationBackend("https://example/notify", client=stub)
+
+    backend.notify([])
+
+    assert stub.calls == []
+
+
+def test_webhook_transient_5xx_retried_once_then_succeeds() -> None:
+    stub = _StubClient([_server_error(502), _ok(200)])
+    backend = WebhookNotificationBackend("https://example/notify", client=stub, backoff_s=0)
+
+    backend.notify([_alert()])
+
+    assert len(stub.calls) == 2
+
+
+def test_webhook_transient_network_error_retried_once_then_succeeds() -> None:
+    stub = _StubClient([httpx.ConnectError("dns broke"), _ok(204)])
+    backend = WebhookNotificationBackend("https://example/notify", client=stub, backoff_s=0)
+
+    backend.notify([_alert()])
+
+    assert len(stub.calls) == 2
+
+
+def test_webhook_persistent_5xx_raises_after_single_retry() -> None:
+    stub = _StubClient([_server_error(503), _server_error(503)])
+    backend = WebhookNotificationBackend("https://example/notify", client=stub, backoff_s=0)
+
+    with pytest.raises(httpx.HTTPError):
+        backend.notify([_alert()])
+
+    assert len(stub.calls) == 2  # initial + one retry, not more
+
+
+def test_webhook_persistent_network_error_raises_after_single_retry() -> None:
+    stub = _StubClient([httpx.ConnectError("nope"), httpx.ConnectError("still nope")])
+    backend = WebhookNotificationBackend("https://example/notify", client=stub, backoff_s=0)
+
+    with pytest.raises(httpx.HTTPError):
+        backend.notify([_alert()])
+
+    assert len(stub.calls) == 2
+
+
+def test_webhook_4xx_is_not_retried_and_surfaces() -> None:
+    """A 4xx response is a permanent client error; do not waste a retry on it."""
+    stub = _StubClient([httpx.Response(status_code=400, text="bad shape")])
+    backend = WebhookNotificationBackend("https://example/notify", client=stub, backoff_s=0)
+
+    with pytest.raises(httpx.HTTPStatusError):
+        backend.notify([_alert()])
+
+    assert len(stub.calls) == 1
+
+
+def test_webhook_missing_url_raises_at_construction() -> None:
+    with pytest.raises(WebhookConfigError):
+        WebhookNotificationBackend("")
+
+
+def test_resolve_backend_webhook_requires_url_in_config() -> None:
+    with pytest.raises(WebhookConfigError):
+        _resolve_backend("webhook", config={"notification_backend": "webhook"})
+
+
+def test_resolve_backend_webhook_returns_backend_when_url_present() -> None:
+    backend = _resolve_backend(
+        "webhook",
+        config={
+            "notification_backend": "webhook",
+            "notification_webhook_url": "https://example/notify",
+        },
+    )
+    assert isinstance(backend, WebhookNotificationBackend)
+
+
+def test_resolve_backend_unknown_name_still_raises_value_error() -> None:
+    with pytest.raises(ValueError, match="unknown notification backend"):
+        _resolve_backend("smtp")
+
+
+def test_send_notifications_dispatches_through_webhook_from_config() -> None:
+    """send_notifications honours config-driven webhook selection end-to-end."""
+    stub = _StubClient([_ok(200)])
+    backend = WebhookNotificationBackend("https://example/notify", client=stub, backoff_s=0)
+
+    send_notifications(
+        [_alert()],
+        backend=backend,
+        config={
+            "notification_backend": "webhook",
+            "notification_webhook_url": "https://example/notify",
+        },
+    )
+
+    assert len(stub.calls) == 1
+
+
+def test_send_notifications_webhook_missing_url_raises_at_resolve_time() -> None:
+    """No silent fallback to log when webhook is selected without a URL."""
+    with pytest.raises(WebhookConfigError):
+        send_notifications(
+            [_alert()],
+            config={"notification_backend": "webhook"},
+        )


### PR DESCRIPTION
## Summary

Add a `WebhookNotificationBackend` alongside the existing
`LogNotificationBackend` so daemon health alerts have a real, non-log
egress route. Selected via `notification_backend = "webhook"` plus
`notification_webhook_url = "https://..."` in `polylogue.toml`.

## Problem

`polylogue/daemon/notifications.py` shipped only
`LogNotificationBackend`, and `_resolve_backend()` rejected any name
other than `"log"` with `ValueError`. The periodic health loop in
`polylogue/daemon/cli.py` therefore had no way to deliver alerts off
the daemon log, leaving the tiered health work shipped via #830 with
no operator-visible egress. This is the open Scope item on #999:
"At least one non-log notification backend if product scope still
requires notifications."

Webhook is the most generic local-first choice: no provider
credentials, no desktop dependency, slots into self-hosted notifiers
(ntfy, gotify, Discord/Slack webhooks).

## Solution

- `polylogue/daemon/notifications.py`
  - `WebhookNotificationBackend` POSTs a typed JSON envelope
    `{alerts, emitted_at, daemon_version}` to a configured URL with a
    5 s per-attempt timeout. On transient failure (network error or
    HTTP 5xx) it retries exactly once after a short backoff. HTTP 4xx
    is treated as a permanent client error and is not retried.
    Persistent failure raises `httpx.HTTPError`; the existing
    `except Exception` boundary in the periodic health loop catches
    it. No buffering, no queue.
  - HTTP client is injected via a structural `_HTTPPoster` Protocol so
    tests can supply a lightweight stub without depending on the full
    `httpx.Client` surface; production uses `httpx.Client` directly.
  - `_resolve_backend("webhook", config=...)` reads
    `notification_webhook_url` from the resolved config dict and
    raises a typed `WebhookConfigError` if it is missing/empty.
    `_resolve_backend("log")` and the unknown-name `ValueError` path
    are preserved.
- `polylogue/config.py`
  - New `notification_webhook_url` flat key in defaults, exposed as
    `PolylogueConfig.notification_webhook_url`, mapped from the
    `[notifications].webhook_url` TOML key, overridable via
    `POLYLOGUE_NOTIFICATION_WEBHOOK_URL`, and emitted by
    `format_config_toml`.
- `tests/unit/daemon/test_notification_webhook.py` (new) covers
  envelope shape (URL, method, timeout, payload), 5xx retry,
  network-error retry, persistent failure raising, 4xx no-retry,
  missing-URL config error at construction and `_resolve_backend`
  time, `send_notifications` end-to-end dispatch, and the preserved
  unknown-name `ValueError`.
- `docs/daemon.md` extended with the webhook config example, env-var
  alternative, envelope shape, and retry/timeout semantics.

Rejected alternative: a generic plugin registry. Two backends do not
yet justify the machinery; `_resolve_backend` still dispatches on the
name string per the issue.

## Verification

- `nix develop -c pytest tests/unit/daemon/test_notification_webhook.py tests/unit/daemon/test_notifications.py -q`
  -> `16 passed in 12.57s`
- `nix develop -c devtools verify --quick` -> `exit_code: 0`
  (`total_duration_s: 25.79`)
- `nix develop -c pytest -q --ignore=tests/integration`
  -> `2 failed, 7355 passed, 2 xfailed in 100.12s`. The two failures
  (`tests/unit/devtools/test_topology_projection_witness.py::test_every_cell_has_target_path`
  and `::test_every_owner_appears_in_files`) reproduce on
  `origin/master` with this branch's files reverted and are unrelated
  to webhook work.
- Manual roundtrip: `[notifications] backend = "webhook"` /
  `webhook_url = "https://x/y"` in `polylogue.toml` loads, env override
  `POLYLOGUE_NOTIFICATION_WEBHOOK_URL` wins, and
  `_resolve_backend("webhook", config=cfg.raw)` returns a
  `WebhookNotificationBackend`.

Closes #1150