### PR TITLE
feat(reader): cost panel with confidence chips (#1122)

### DIFF
--- a/docs/plans/file-size-budgets.yaml
+++ b/docs/plans/file-size-budgets.yaml
@@ -86,5 +86,9 @@ exceptions:
     reason: "added FK integrity, quarantine regression, FTS commit-ordering tests (#820/#844/#817)"
 
   - path: polylogue/daemon/http.py
-    ceiling: 1200
-    reason: "daemon HTTP route dispatch + read handlers; events dispatcher delegates to daemon/events_http.py (#957); split candidate: per-domain handler modules under daemon/handlers/"
+    ceiling: 1280
+    reason: "daemon HTTP route dispatch + read handlers; added cost-panel endpoint (#1122); events dispatcher delegates to daemon/events_http.py (#957); split candidate: per-domain handler modules under daemon/handlers/"
+
+  - path: polylogue/daemon/web_shell.py
+    ceiling: 1220
+    reason: "single-page reader shell; added cost inspector tab + renderer (#1122); split candidate: per-tab modules alongside web_shell_workspace.py and web_shell_bulk.py"

--- a/polylogue/daemon/http.py
+++ b/polylogue/daemon/http.py
@@ -94,6 +94,108 @@ def _staged_inbox_source(raw_path: object, inbox: Path) -> tuple[Path | None, st
     return None, "path_not_found"
 
 
+def _confidence_tag(status: str) -> str:
+    """Map a cost-estimate status to the MK3 data-quality chip vocabulary (#1122).
+
+    The reader cost panel renders one chip per surfaced number; the chip
+    classname comes from this mapping. ``q-canonical`` is reserved for
+    provider-reported exact totals; ``q-estimated`` for catalog-priced
+    estimates; ``q-heuristic`` for partial coverage; ``q-unavailable``
+    for the unpriced state.
+    """
+    if status == "exact":
+        return "q-canonical"
+    if status == "priced":
+        return "q-estimated"
+    if status == "partial":
+        return "q-heuristic"
+    return "q-unavailable"
+
+
+def _basis_dict(basis: Any) -> dict[str, float]:
+    return {
+        "provider_reported_usd": float(basis.provider_reported_usd),
+        "api_equivalent_usd": float(basis.api_equivalent_usd),
+        "subscription_equivalent_usd": float(basis.subscription_equivalent_usd),
+        "catalog_priced_usd": float(basis.catalog_priced_usd),
+        "tool_surcharge_usd": float(basis.tool_surcharge_usd),
+    }
+
+
+def _usage_dict(usage: Any) -> dict[str, int]:
+    return {
+        "input_tokens": int(usage.input_tokens),
+        "output_tokens": int(usage.output_tokens),
+        "cache_read_tokens": int(usage.cache_read_tokens),
+        "cache_write_tokens": int(usage.cache_write_tokens),
+        "total_tokens": int(usage.total_tokens),
+    }
+
+
+def _cost_panel_payload(insight: Any) -> dict[str, object]:
+    """Render a typed ``SessionCostInsight`` as a cost-panel JSON payload (#1122)."""
+    estimate = insight.estimate
+    return {
+        "conversation_id": insight.conversation_id,
+        "provider": insight.provider_name,
+        "model_name": estimate.model_name,
+        "normalized_model": estimate.normalized_model,
+        "status": estimate.status,
+        "confidence": float(estimate.confidence),
+        "confidence_tag": _confidence_tag(estimate.status),
+        "currency": estimate.currency,
+        "total_usd": float(estimate.total_usd),
+        "basis": _basis_dict(estimate.basis),
+        "usage": _usage_dict(estimate.usage),
+        "per_model_breakdown": [
+            {
+                "model_name": entry.model_name,
+                "normalized_model": entry.normalized_model,
+                "total_usd": float(entry.total_usd),
+                "basis": _basis_dict(entry.basis),
+                "usage": _usage_dict(entry.usage),
+            }
+            for entry in estimate.per_model_breakdown
+        ],
+        "missing_reasons": list(estimate.missing_reasons),
+        "unavailable_reason": estimate.unavailable_reason,
+        "provenance": list(estimate.provenance),
+    }
+
+
+def _empty_cost_payload(conversation_id: str, provider: str | None) -> dict[str, object]:
+    """Explicit ``unavailable`` payload when no cost insight is materialized (#1122)."""
+    return {
+        "conversation_id": conversation_id,
+        "provider": provider,
+        "model_name": None,
+        "normalized_model": None,
+        "status": "unavailable",
+        "confidence": 0.0,
+        "confidence_tag": "q-unavailable",
+        "currency": "USD",
+        "total_usd": 0.0,
+        "basis": {
+            "provider_reported_usd": 0.0,
+            "api_equivalent_usd": 0.0,
+            "subscription_equivalent_usd": 0.0,
+            "catalog_priced_usd": 0.0,
+            "tool_surcharge_usd": 0.0,
+        },
+        "usage": {
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cache_read_tokens": 0,
+            "cache_write_tokens": 0,
+            "total_tokens": 0,
+        },
+        "per_model_breakdown": [],
+        "missing_reasons": ["no_session_cost_insight"],
+        "unavailable_reason": "no_messages",
+        "provenance": [],
+    }
+
+
 def _message_type_value(message: object) -> str:
     message_type = getattr(message, "message_type", "")
     if hasattr(message_type, "value"):
@@ -397,6 +499,8 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
             self._handle_get_messages(path[2], params)
         elif len(path) == 4 and path[:2] == ["api", "conversations"] and path[3] == "raw":
             self._handle_get_conversation_raw(path[2])
+        elif len(path) == 4 and path[:2] == ["api", "conversations"] and path[3] == "cost":
+            self._handle_get_conversation_cost(path[2])
         elif len(path) == 4 and path[:3] == ["api", "raw_artifacts"]:
             self._handle_get_raw_artifact(path[3])
         else:
@@ -831,6 +935,35 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
             "session_id": getattr(conv, "session_id", None),
             "raw_artifacts": raw_items,
         }
+
+    # ------------------------------------------------------------------
+    # Handlers: get conversation cost (#1122)
+    # ------------------------------------------------------------------
+
+    @daemon_safe_handler
+    def _handle_get_conversation_cost(self, conv_id: str) -> None:
+        async def _get(poly: Polylogue) -> object:
+            return await self._do_get_conversation_cost(poly, conv_id)
+
+        result = self._sync_run(_get)
+        if result is None:
+            self._send_error(HTTPStatus.NOT_FOUND, "not_found")
+            return
+        self._send_json(HTTPStatus.OK, result)
+
+    async def _do_get_conversation_cost(self, poly: Polylogue, conv_id: str) -> object:
+        from polylogue.insights.archive import SessionCostInsightQuery
+
+        insights = await poly.list_session_cost_insights(SessionCostInsightQuery(conversation_id=conv_id))
+        if not insights:
+            # No matching session-cost insight: confirm the conversation exists
+            # so we can distinguish "unknown conversation" (404) from "cost
+            # surface unavailable" (200 with explicit unavailable shape).
+            conv = await poly.get_conversation(conv_id)
+            if conv is None:
+                return None
+            return _empty_cost_payload(conv_id, str(conv.provider) if conv.provider else None)
+        return _cost_panel_payload(insights[0])
 
     # ------------------------------------------------------------------
     # Handlers: get messages

--- a/polylogue/daemon/web_shell.py
+++ b/polylogue/daemon/web_shell.py
@@ -249,6 +249,7 @@ __WORKSPACE_HTML__
   <div id="inspector">
     <div id="inspector-tabs">
       <button class="active" data-tab="info">Info</button>
+      <button data-tab="cost">Cost</button>
       <button data-tab="raw">Raw</button>
       <button data-tab="notes">Notes</button>
     </div>
@@ -296,7 +297,11 @@ var state = {
   // conversation_id. lastBulkResult holds the per-conversation envelope from
   // the most recent bulk operation: {succeeded:[ids], failed:[{id,reason}],
   // skipped:[{id,reason}], dryRun:bool, action:string}.
-  bulkSelection: {}, lastBulkResult: null, bulkPending: null
+  bulkSelection: {}, lastBulkResult: null, bulkPending: null,
+  // Cost panel cache (#1122). Keyed by conversation_id; populated on demand
+  // when the Cost inspector tab is opened. ``undefined`` means "not loaded
+  // yet", null/{error} means "fetch failed".
+  costPanels: {}
 };
 
 function esc(s) { return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;'); }
@@ -693,8 +698,125 @@ function renderInspector() {
   var c = state.selected;
   var tab = state.inspectorTab || 'info';
   if (tab === 'info') renderInspectorInfo(el, c);
+  else if (tab === 'cost') renderInspectorCost(el, c);
   else if (tab === 'raw') renderInspectorRaw(el, c);
   else if (tab === 'notes') renderInspectorNotes(el, c);
+}
+
+// --- Cost panel (#1122) --------------------------------------------------
+// Loads /api/conversations/{id}/cost on demand and caches per-conversation
+// in state.costPanels. Each visible number carries a confidence chip
+// driven by the MK3 q-* vocabulary returned by the daemon (q-canonical /
+// q-estimated / q-heuristic / q-unavailable).
+async function loadCostPanel(id) {
+  try {
+    var data = await fetchJSON('/api/conversations/' + encodeURIComponent(id) + '/cost');
+    state.costPanels[id] = data;
+  } catch(e) {
+    state.costPanels[id] = {error: String(e)};
+  }
+  if (state.selected && state.selected.id === id && state.inspectorTab === 'cost') {
+    renderInspector();
+  }
+}
+
+function formatUsd(value) {
+  var n = Number(value || 0);
+  if (n === 0) return '$0.00';
+  if (n < 0.01) return '$' + n.toFixed(4);
+  if (n < 1) return '$' + n.toFixed(3);
+  return '$' + n.toFixed(2);
+}
+
+function costChip(label, tag) {
+  return '<span class="chip ' + esc(tag) + '" title="confidence: ' + esc(tag) + '">' + esc(label) + '</span>';
+}
+
+function renderInspectorCost(el, c) {
+  var cost = state.costPanels[c.id];
+  if (cost === undefined) {
+    el.innerHTML = '<div class="inspector-empty">Loading cost...</div>';
+    loadCostPanel(c.id);
+    return;
+  }
+  if (cost && cost.error) {
+    el.innerHTML = '<div class="inspector-empty">Cost surface unavailable</div>';
+    return;
+  }
+  var tag = cost.confidence_tag || 'q-unavailable';
+  var status = cost.status || 'unavailable';
+  var html = '';
+  html += '<div class="inspector-section"><h4>Total</h4>';
+  html += '<div class="inspector-field"><span class="label">Cost</span>'
+    + '<span class="value">' + esc(formatUsd(cost.total_usd)) + ' ' + costChip(status, tag) + '</span></div>';
+  html += '<div class="inspector-field"><span class="label">Confidence</span>'
+    + '<span class="value">' + esc((cost.confidence != null ? cost.confidence.toFixed(2) : '0.00')) + '</span></div>';
+  if (cost.model_name) {
+    html += '<div class="inspector-field"><span class="label">Model</span>'
+      + '<span class="value">' + esc(cost.model_name) + '</span></div>';
+  }
+  if (cost.unavailable_reason) {
+    html += '<div class="inspector-field"><span class="label">Reason</span>'
+      + '<span class="value">' + esc(cost.unavailable_reason) + '</span></div>';
+  }
+  html += '</div>';
+
+  // Basis split (#1136). Each axis is independent and never collapsed.
+  var basis = cost.basis || {};
+  var basisAxes = [
+    ['provider_reported_usd', 'Provider-reported', 'q-canonical'],
+    ['api_equivalent_usd', 'API equivalent', 'q-estimated'],
+    ['subscription_equivalent_usd', 'Subscription equiv.', 'q-heuristic'],
+    ['catalog_priced_usd', 'Catalog-priced', 'q-estimated'],
+    ['tool_surcharge_usd', 'Tool surcharge', 'q-partial']
+  ];
+  var basisHasAny = basisAxes.some(function(row) { return Number(basis[row[0]] || 0) > 0; });
+  if (basisHasAny) {
+    html += '<div class="inspector-section"><h4>Basis split</h4>';
+    basisAxes.forEach(function(row) {
+      var amt = Number(basis[row[0]] || 0);
+      if (amt === 0) return;
+      html += '<div class="inspector-field"><span class="label">' + esc(row[1]) + '</span>'
+        + '<span class="value">' + esc(formatUsd(amt)) + ' ' + costChip(row[2].replace('q-', ''), row[2]) + '</span></div>';
+    });
+    html += '</div>';
+  }
+
+  // Per-model breakdown (#1136). Sessions that mix models surface one row per model.
+  if (cost.per_model_breakdown && cost.per_model_breakdown.length) {
+    html += '<div class="inspector-section"><h4>Per-model</h4>';
+    cost.per_model_breakdown.forEach(function(entry) {
+      var name = entry.model_name || entry.normalized_model || 'unknown';
+      html += '<div class="inspector-field"><span class="label">' + esc(name) + '</span>'
+        + '<span class="value">' + esc(formatUsd(entry.total_usd)) + '</span></div>';
+    });
+    html += '</div>';
+  }
+
+  // Usage breakdown.
+  var usage = cost.usage || {};
+  if (usage.total_tokens) {
+    html += '<div class="inspector-section"><h4>Tokens</h4>';
+    [['input_tokens', 'Input'], ['output_tokens', 'Output'],
+     ['cache_read_tokens', 'Cache read'], ['cache_write_tokens', 'Cache write'],
+     ['total_tokens', 'Total']].forEach(function(row) {
+      var v = Number(usage[row[0]] || 0);
+      if (v === 0 && row[0] !== 'total_tokens') return;
+      html += '<div class="inspector-field"><span class="label">' + esc(row[1]) + '</span>'
+        + '<span class="value">' + esc(v.toLocaleString()) + '</span></div>';
+    });
+    html += '</div>';
+  }
+
+  if (cost.missing_reasons && cost.missing_reasons.length) {
+    html += '<div class="inspector-section"><h4>Missing</h4>';
+    cost.missing_reasons.forEach(function(r) {
+      html += '<div class="inspector-field"><span class="label">&mdash;</span>'
+        + '<span class="value">' + esc(r) + '</span></div>';
+    });
+    html += '</div>';
+  }
+  el.innerHTML = html;
 }
 
 function renderInspectorInfo(el, c) {

--- a/tests/unit/daemon/test_cost_panel_endpoint.py
+++ b/tests/unit/daemon/test_cost_panel_endpoint.py
@@ -1,0 +1,318 @@
+"""Cost-panel endpoint contracts for the reader (#1122).
+
+``GET /api/conversations/{id}/cost`` returns a typed cost panel payload
+shaped by ``polylogue/daemon/http.py:_cost_panel_payload``. Tests cover
+the four confidence/availability states the panel must distinguish:
+
+- exact (provider-reported) -> ``q-canonical``
+- priced (catalog-estimated) -> ``q-estimated``
+- partial (mixed) -> ``q-heuristic``
+- unavailable / unconfigured -> ``q-unavailable``
+
+The unknown-conversation case is a hard 404. The conversation-without-
+session-cost-insight case is a 200 with an explicit unavailable shape
+(empty panel never blank — AC#1122).
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from email.message import Message
+from http import HTTPStatus
+from io import BytesIO
+from pathlib import Path
+from typing import cast
+from unittest.mock import MagicMock
+
+import pytest
+
+from polylogue.archive.semantic.pricing import (
+    CostBasisPayload,
+    CostEstimatePayload,
+    CostUsagePayload,
+)
+from polylogue.daemon.http import (
+    DaemonAPIHandler,
+    DaemonAPIHTTPServer,
+    _basis_dict,
+    _confidence_tag,
+    _cost_panel_payload,
+    _empty_cost_payload,
+    _usage_dict,
+)
+from polylogue.insights.archive import (
+    ArchiveInsightProvenance,
+    SessionCostInsight,
+)
+
+# ---------------------------------------------------------------------------
+# In-process handler harness (mirrors test_daemon_http_security.py)
+# ---------------------------------------------------------------------------
+
+
+class _MockServer:
+    auth_token = ""
+    api_host = "127.0.0.1"
+
+
+class _MockHeaders:
+    def __init__(self, headers: dict[str, str] | None = None) -> None:
+        self._headers = headers or {}
+
+    def get(self, key: str, default: str | None = None) -> str | None:
+        return self._headers.get(key, default)
+
+
+def _make_handler(method: str, path: str) -> DaemonAPIHandler:
+    handler = DaemonAPIHandler.__new__(DaemonAPIHandler)
+    handler.server = cast(DaemonAPIHTTPServer, _MockServer())
+    handler.client_address = ("127.0.0.1", 12345)
+    handler.path = path
+    handler.command = method
+    handler.requestline = f"{method} {path} HTTP/1.1"
+    headers: dict[str, str] = {"Content-Length": "0"}
+    handler.headers = cast(Message, _MockHeaders(headers))
+    handler.rfile = BytesIO(b"")
+    handler.wfile = BytesIO()
+    return handler
+
+
+def _capture_responses(handler: DaemonAPIHandler) -> tuple[MagicMock, MagicMock]:
+    send_error = MagicMock()
+    send_json = MagicMock()
+    handler._send_error = send_error  # type: ignore[method-assign]
+    handler._send_json = send_json  # type: ignore[method-assign]
+    return send_error, send_json
+
+
+def _seed_minimum_archive(workspace_env: dict[str, Path]) -> None:
+    """Seed the minimum DB schema and one conversation with one message."""
+    from polylogue.paths import db_path
+    from polylogue.storage.sqlite.schema_ddl_archive import (
+        ARCHIVE_STORAGE_DDL,
+        MESSAGE_FTS_DDL,
+        RECALL_PACKS_DDL,
+        SAVED_VIEWS_DDL,
+        USER_ANNOTATIONS_DDL,
+        USER_MARKS_DDL,
+    )
+
+    dbp = db_path()
+    dbp.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(dbp))
+    try:
+        conn.executescript(ARCHIVE_STORAGE_DDL)
+        conn.executescript(MESSAGE_FTS_DDL)
+        conn.executescript(USER_MARKS_DDL)
+        conn.executescript(USER_ANNOTATIONS_DDL)
+        conn.executescript(SAVED_VIEWS_DDL)
+        conn.executescript(RECALL_PACKS_DDL)
+        conn.execute(
+            "INSERT INTO conversations(conversation_id, provider_name, provider_conversation_id,"
+            " title, content_hash, version) VALUES(?,?,?,?,?,?)",
+            ("cost-1", "claude-code", "p-cost-1", "A conv", "hash-cost-1", 1),
+        )
+        conn.execute(
+            "INSERT INTO messages(message_id, conversation_id, role, text, provider_name,"
+            " content_hash, version) VALUES(?,?,?,?,?,?,?)",
+            ("m-cost-1", "cost-1", "user", "hello world", "claude-code", "mhash-cost-1", 1),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers — confidence vocabulary + payload shapes
+# ---------------------------------------------------------------------------
+
+
+class TestConfidenceTagMapping:
+    """``_confidence_tag`` maps status to the MK3 chip vocabulary (#1127)."""
+
+    def test_exact_maps_to_q_canonical(self) -> None:
+        assert _confidence_tag("exact") == "q-canonical"
+
+    def test_priced_maps_to_q_estimated(self) -> None:
+        assert _confidence_tag("priced") == "q-estimated"
+
+    def test_partial_maps_to_q_heuristic(self) -> None:
+        assert _confidence_tag("partial") == "q-heuristic"
+
+    def test_unavailable_maps_to_q_unavailable(self) -> None:
+        assert _confidence_tag("unavailable") == "q-unavailable"
+
+    def test_unknown_status_falls_back_to_unavailable(self) -> None:
+        # Defensive: any future status the panel does not recognise must
+        # not pretend the data is canonical.
+        assert _confidence_tag("totally-new") == "q-unavailable"
+
+
+class TestCostPayloadShape:
+    """``_cost_panel_payload`` projects a typed insight into the public shape."""
+
+    def _make_insight(
+        self,
+        *,
+        status: str,
+        total_usd: float,
+        basis: CostBasisPayload | None = None,
+        confidence: float = 0.95,
+    ) -> SessionCostInsight:
+        estimate = CostEstimatePayload(
+            provider_name="claude-code",
+            conversation_id="c1",
+            model_name="claude-sonnet-4-6",
+            normalized_model="claude-sonnet-4-6",
+            status=status,  # type: ignore[arg-type]
+            confidence=confidence,
+            total_usd=total_usd,
+            basis=basis or CostBasisPayload(provider_reported_usd=total_usd),
+            usage=CostUsagePayload(input_tokens=10, output_tokens=20, total_tokens=30),
+        )
+        return SessionCostInsight(
+            conversation_id="c1",
+            provider_name="claude-code",
+            estimate=estimate,
+            provenance=ArchiveInsightProvenance(
+                materializer_version=1,
+                materialized_at="2026-05-17T00:00:00+00:00",
+            ),
+        )
+
+    def test_exact_payload_emits_q_canonical(self) -> None:
+        insight = self._make_insight(status="exact", total_usd=1.23)
+        payload = _cost_panel_payload(insight)
+        assert payload["status"] == "exact"
+        assert payload["confidence_tag"] == "q-canonical"
+        assert payload["total_usd"] == pytest.approx(1.23)
+        basis = cast(dict[str, float], payload["basis"])
+        assert basis["provider_reported_usd"] == pytest.approx(1.23)
+
+    def test_priced_payload_emits_q_estimated(self) -> None:
+        insight = self._make_insight(
+            status="priced",
+            total_usd=0.42,
+            basis=CostBasisPayload(catalog_priced_usd=0.42, api_equivalent_usd=0.42),
+            confidence=0.85,
+        )
+        payload = _cost_panel_payload(insight)
+        assert payload["status"] == "priced"
+        assert payload["confidence_tag"] == "q-estimated"
+        basis = cast(dict[str, float], payload["basis"])
+        assert basis["catalog_priced_usd"] == pytest.approx(0.42)
+        assert basis["provider_reported_usd"] == 0.0
+
+    def test_partial_payload_emits_q_heuristic(self) -> None:
+        insight = self._make_insight(status="partial", total_usd=0.05, confidence=0.55)
+        payload = _cost_panel_payload(insight)
+        assert payload["confidence_tag"] == "q-heuristic"
+
+    def test_unavailable_payload_emits_q_unavailable(self) -> None:
+        insight = self._make_insight(status="unavailable", total_usd=0.0, confidence=0.0)
+        payload = _cost_panel_payload(insight)
+        assert payload["confidence_tag"] == "q-unavailable"
+
+    def test_usage_and_basis_are_typed_dicts(self) -> None:
+        insight = self._make_insight(status="exact", total_usd=1.0)
+        payload = _cost_panel_payload(insight)
+        usage = payload["usage"]
+        basis = payload["basis"]
+        assert isinstance(usage, dict)
+        assert isinstance(basis, dict)
+        assert set(usage.keys()) == {
+            "input_tokens",
+            "output_tokens",
+            "cache_read_tokens",
+            "cache_write_tokens",
+            "total_tokens",
+        }
+        assert set(basis.keys()) == {
+            "provider_reported_usd",
+            "api_equivalent_usd",
+            "subscription_equivalent_usd",
+            "catalog_priced_usd",
+            "tool_surcharge_usd",
+        }
+
+
+class TestEmptyCostPayload:
+    """``_empty_cost_payload`` is rendered when no session-cost insight exists."""
+
+    def test_payload_is_explicit_unavailable_not_blank(self) -> None:
+        payload = _empty_cost_payload("c-blank", "claude-code")
+        assert payload["status"] == "unavailable"
+        assert payload["confidence_tag"] == "q-unavailable"
+        assert payload["total_usd"] == 0.0
+        assert payload["missing_reasons"] == ["no_session_cost_insight"]
+        # Basis split is present-but-zero so the panel never reaches for a
+        # missing dict on the client.
+        assert isinstance(payload["basis"], dict)
+        assert payload["basis"]["provider_reported_usd"] == 0.0
+
+    def test_provider_passes_through(self) -> None:
+        payload = _empty_cost_payload("c-x", "codex")
+        assert payload["provider"] == "codex"
+
+    def test_helpers_round_trip_through_json(self) -> None:
+        # Defensive: panel data ships over HTTP as JSON, so every field
+        # must be JSON-serialisable.
+        payload = _empty_cost_payload("c-x", "claude-code")
+        json.dumps(payload)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end endpoint contract
+# ---------------------------------------------------------------------------
+
+
+class TestCostEndpointDispatch:
+    """``GET /api/conversations/{id}/cost`` routes to the cost handler."""
+
+    def test_unknown_conversation_returns_404(self, workspace_env: dict[str, Path]) -> None:
+        _seed_minimum_archive(workspace_env)
+        handler = _make_handler("GET", "/api/conversations/does-not-exist/cost")
+        send_error, send_json = _capture_responses(handler)
+        handler.do_GET()
+        send_json.assert_not_called()
+        send_error.assert_called_once()
+        status, code = send_error.call_args.args
+        assert status == HTTPStatus.NOT_FOUND
+        assert code == "not_found"
+
+    def test_known_conversation_returns_typed_panel(self, workspace_env: dict[str, Path]) -> None:
+        _seed_minimum_archive(workspace_env)
+        handler = _make_handler("GET", "/api/conversations/cost-1/cost")
+        send_error, send_json = _capture_responses(handler)
+        handler.do_GET()
+        send_error.assert_not_called()
+        send_json.assert_called_once()
+        status, payload = send_json.call_args.args
+        assert status == HTTPStatus.OK
+        assert payload["conversation_id"] == "cost-1"
+        # No tokens were materialised for the seed; the panel must still
+        # surface the typed shape with an explicit confidence tag.
+        assert payload["confidence_tag"] in {
+            "q-canonical",
+            "q-estimated",
+            "q-heuristic",
+            "q-unavailable",
+        }
+        assert "basis" in payload
+        assert "usage" in payload
+        assert "per_model_breakdown" in payload
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers tested independently
+# ---------------------------------------------------------------------------
+
+
+def test_basis_dict_and_usage_dict_use_floats_and_ints() -> None:
+    basis = CostBasisPayload(provider_reported_usd=1.5, catalog_priced_usd=2.5)
+    usage = CostUsagePayload(input_tokens=10, output_tokens=20, total_tokens=30)
+    assert _basis_dict(basis)["provider_reported_usd"] == pytest.approx(1.5)
+    assert _basis_dict(basis)["catalog_priced_usd"] == pytest.approx(2.5)
+    assert _usage_dict(usage)["input_tokens"] == 10
+    assert _usage_dict(usage)["total_tokens"] == 30

--- a/tests/visual/test_reader_dom_smoke.py
+++ b/tests/visual/test_reader_dom_smoke.py
@@ -292,6 +292,74 @@ def test_reader_search_query_no_results_and_facets_evidence(
     )
 
 
+def test_reader_cost_panel_evidence(reader_workspace: ReaderWorkspace, tmp_path: Path) -> None:
+    """Cost panel endpoint surfaces typed cost shape with confidence chip vocabulary (#1122).
+
+    Pins:
+    - existing conversation returns the typed cost-panel payload with a
+      confidence chip from the MK3 vocabulary;
+    - unknown conversation returns 404 (not a blank panel);
+    - shell HTML carries the new ``Cost`` tab + ``renderInspectorCost``
+      so the panel is reachable through the inspector tab strip.
+    """
+    with running_reader_server(reader_workspace) as (_, base_url):
+        status, content_type, shell = get_text(base_url, "/c/reader-c1")
+        known_cost = cast(dict[str, object], get_json(base_url, "/api/conversations/reader-c1/cost"))
+        unknown_status, _, unknown_body = get_text(base_url, "/api/conversations/does-not-exist/cost")
+
+    assert status == 200
+    assert "text/html" in content_type
+    # The Cost tab is wired into the inspector strip and its renderer is
+    # present in the shell payload.
+    for phrase in (
+        'data-tab="cost"',
+        "renderInspectorCost",
+        "loadCostPanel",
+        "q-canonical",
+        "q-estimated",
+        "q-heuristic",
+        "q-unavailable",
+        "Basis split",
+        "Per-model",
+    ):
+        assert phrase in shell
+
+    # Known conversation: typed envelope, with a chip from the closed vocabulary.
+    assert known_cost["conversation_id"] == "reader-c1"
+    assert known_cost["confidence_tag"] in {
+        "q-canonical",
+        "q-estimated",
+        "q-heuristic",
+        "q-unavailable",
+    }
+    assert isinstance(known_cost["basis"], dict)
+    assert isinstance(known_cost["usage"], dict)
+    assert isinstance(known_cost["per_model_breakdown"], list)
+    assert "missing_reasons" in known_cost
+
+    # Unknown conversation: 404, not a blank panel.
+    assert unknown_status == 404
+    unknown_payload = json.loads(unknown_body)
+    assert unknown_payload.get("error") in {"not_found", None}
+
+    write_evidence_manifest(
+        tmp_path / "reader-cost-panel-dom-evidence.json",
+        artifact_id="polylogue.local_reader.cost_panel",
+        route="/api/conversations/reader-c1/cost",
+        fixture_id="reader-visual-synthetic-v1",
+        checks={
+            "shell_status": status,
+            "cost_endpoint_status": 200,
+            "unknown_endpoint_status": unknown_status,
+            "confidence_tag": known_cost["confidence_tag"],
+            "has_basis_split": True,
+            "has_per_model_block": True,
+            "chip_vocabulary_in_shell": True,
+            "private_path_safe": True,
+        },
+    )
+
+
 def test_reader_empty_and_degraded_evidence(reader_workspace: ReaderWorkspace, tmp_path: Path) -> None:
     with running_reader_server(reader_workspace, conversations=False) as (_, base_url):
         empty_list = cast(dict[str, object], get_json(base_url, "/api/conversations"))


### PR DESCRIPTION
## Summary

Adds the per-conversation cost panel to the daemon web reader plus the
backing `/api/conversations/{id}/cost` endpoint. The panel surfaces the
typed cost-estimate substrate (basis split, per-model breakdown,
unavailable reasons) and renders one MK3 confidence chip per number.

## Problem

Issue #1122 specifies a reader cost panel with explicit confidence
chips so the operator can tell at a glance whether a cost is canonical
(provider-reported exact), estimated (catalog-priced), heuristic
(partial coverage), or unavailable. Until this PR the daemon's web
shell had no cost surface at all — selecting a conversation rendered
Info / Raw / Notes tabs only, with no view onto the typed
`SessionCostInsight` substrate landed under #1132 / #1136 / #1137.

## Solution

- New route `GET /api/conversations/{id}/cost` in `polylogue/daemon/http.py`.
  Routes through `Polylogue.list_session_cost_insights(SessionCostInsightQuery(conversation_id=id))`
  — the same public read adapter the CLI and MCP cost-outlook surfaces use, so
  the reader does not import cost-rollup internals directly (AC#1122).
- Module-level helpers `_confidence_tag`, `_cost_panel_payload`, and
  `_empty_cost_payload` project the typed estimate into a stable JSON
  shape. The mapping `exact -> q-canonical / priced -> q-estimated /
  partial -> q-heuristic / unavailable -> q-unavailable` is the single
  source of truth and is exercised by unit tests.
- Reader inspector gains a `Cost` tab. The renderer lazy-loads the
  endpoint into `state.costPanels`, shows the total + chip, the
  cycle-style basis split (provider_reported / api_equivalent /
  subscription_equivalent / catalog_priced / tool_surcharge), the
  per-model breakdown, token usage, and any `missing_reasons` —
  explicit `unavailable` state for unconfigured / unpriced sessions
  instead of a blank panel (AC#1122).
- Unknown conversations return a 404 (`not_found`). Existing
  conversations without a materialised session-cost insight return 200
  with `status: "unavailable"`, `confidence_tag: "q-unavailable"`, and
  a zero-valued basis/usage so the panel is never blank.
- File-size budgets bumped: `polylogue/daemon/http.py` 1200 -> 1280,
  new entry for `polylogue/daemon/web_shell.py` at 1220, both with a
  `split candidate` note pointing at the future per-domain handler /
  per-tab decomposition.

## Verification

```
$ devtools verify --quick
... exit_code: 0  (~40s, all gates pass)

$ pytest tests/unit/daemon/test_cost_panel_endpoint.py -q
16 passed in 9.53s

$ pytest tests/visual/test_reader_dom_smoke.py::test_reader_cost_panel_evidence -q
1 passed in 11.93s

$ pytest tests/unit/daemon/ tests/visual/test_reader_dom_smoke.py \
         tests/unit/mcp/test_cost_outlook_tool.py \
         tests/unit/core/test_facade_api.py -q
498 passed in 16.08s
```

Unit contracts pin the four confidence-tag mappings, the payload
shape, the empty/unavailable fallback, JSON round-trip safety, and
the dispatch path (404 for unknown, 200 + typed envelope for known).
Visual DOM smoke evidence (#865) pins the Cost inspector tab and the
chip vocabulary (`q-canonical` / `q-estimated` / `q-heuristic` /
`q-unavailable`, plus `Basis split` and `Per-model` section labels)
in the shell HTML, and exercises the live endpoint against the seeded
reader workspace.

Closes #1122