### PR TITLE
feat(reader): insights browser (#1120)

### DIFF
--- a/docs/plans/file-size-budgets.yaml
+++ b/docs/plans/file-size-budgets.yaml
@@ -86,9 +86,9 @@ exceptions:
     reason: "added FK integrity, quarantine regression, FTS commit-ordering tests (#820/#844/#817)"
 
   - path: polylogue/daemon/http.py
-    ceiling: 1380
-    reason: "daemon HTTP route dispatch + read handlers; added cost-panel endpoint (#1122), provenance endpoint (#1125), and topology endpoint (#1121, envelope helpers delegated to daemon/topology_http.py); events dispatcher delegates to daemon/events_http.py (#957); split candidate: per-domain handler modules under daemon/handlers/"
+    ceiling: 1600
+    reason: "daemon HTTP route dispatch + read handlers; added cost-panel endpoint (#1122), provenance endpoint (#1125), topology endpoint (#1121, envelope helpers delegated to daemon/topology_http.py), and insights browser endpoint (#1120); events dispatcher delegates to daemon/events_http.py (#957); split candidate: per-domain handler modules under daemon/handlers/"
 
   - path: polylogue/daemon/web_shell.py
-    ceiling: 1280
-    reason: "single-page reader shell — CSS, HTML region scaffolding, and JS bootstrap; bulk/workspace/provenance/lineage assets already extracted to daemon/web_shell_bulk.py, daemon/web_shell_workspace.py, daemon/web_shell_provenance.py, daemon/web_shell_lineage.py (#1121); added compare action (#1124); split candidate: extract inspector entry-points into daemon/web_shell_inspector.py"
+    ceiling: 1460
+    reason: "single-page reader shell — CSS, HTML region scaffolding, and JS bootstrap; bulk/workspace/provenance/lineage assets already extracted to daemon/web_shell_bulk.py, daemon/web_shell_workspace.py, daemon/web_shell_provenance.py, daemon/web_shell_lineage.py (#1121); added compare action (#1124) and insights browser inspector tab (#1120); split candidate: extract inspector entry-points into daemon/web_shell_inspector.py"

--- a/polylogue/daemon/http.py
+++ b/polylogue/daemon/http.py
@@ -196,6 +196,154 @@ def _empty_cost_payload(conversation_id: str, provider: str | None) -> dict[str,
     }
 
 
+# ---------------------------------------------------------------------------
+# Insights browser helpers (#1120)
+#
+# The insights browser endpoint surfaces the four per-session insight kinds
+# (profile, work-event timeline, phases, work threads) as a single JSON
+# envelope so the reader inspector can render them inline. Each kind carries
+# a readiness chip from the closed vocabulary ``q-ready`` / ``q-partial`` /
+# ``q-missing`` driven by:
+#
+# - ``q-ready``    — the insight is materialized for this conversation.
+# - ``q-missing``  — the insight has no materialized row for this conversation
+#   (the substrate is empty for this scope, not the whole archive).
+# - ``q-partial``  — the insight is materialized but the row count is zero
+#   (e.g. a session profile exists but has no work events recorded).
+#
+# The endpoint never imports insight storage modules directly — it routes
+# through the same public ``Polylogue`` facade adapters that CLI and MCP use
+# (AC#1120, AC#1018).
+# ---------------------------------------------------------------------------
+
+INSIGHT_KINDS: tuple[str, ...] = ("profile", "timeline", "phases", "threads")
+
+
+def _readiness_tag(*, materialized: bool, row_count: int | None = None) -> str:
+    """Map a materialized/row-count pair to the readiness chip vocabulary.
+
+    The chip vocabulary is closed (``q-ready`` / ``q-partial`` / ``q-missing``).
+    Unknown / unmaterialized rows are ``q-missing``; materialized rows with
+    zero downstream rows are ``q-partial`` (the rebuild ran but produced
+    nothing); everything else is ``q-ready``.
+    """
+    if not materialized:
+        return "q-missing"
+    if row_count is not None and row_count <= 0:
+        return "q-partial"
+    return "q-ready"
+
+
+def _parse_insight_includes(raw: str | None) -> tuple[str, ...]:
+    """Resolve the ``?include=`` query param into a stable tuple.
+
+    Returns the canonical insight-kind tuple in :data:`INSIGHT_KINDS` order
+    when *raw* is None or empty (default = include everything). Unknown
+    tokens are dropped; ordering is normalized to :data:`INSIGHT_KINDS`.
+    """
+    if raw is None or not raw.strip():
+        return INSIGHT_KINDS
+    requested = {token.strip().lower() for token in raw.split(",") if token.strip()}
+    if not requested:
+        return INSIGHT_KINDS
+    return tuple(kind for kind in INSIGHT_KINDS if kind in requested)
+
+
+def _provenance_dict(prov: Any) -> dict[str, object]:
+    return {
+        "materializer_version": int(getattr(prov, "materializer_version", 0)),
+        "materialized_at": getattr(prov, "materialized_at", None),
+        "source_updated_at": getattr(prov, "source_updated_at", None),
+        "source_sort_key": getattr(prov, "source_sort_key", None),
+    }
+
+
+def _profile_panel_payload(profile: Any) -> dict[str, object]:
+    """Project a ``SessionProfile`` into the JSON shape served by the reader.
+
+    Uses :meth:`SessionProfile.to_dict` for fidelity to the substrate shape
+    and adds a readiness chip + provenance summary on top.
+    """
+    body = dict(profile.to_dict())
+    return {
+        "readiness_tag": _readiness_tag(materialized=True, row_count=int(body.get("message_count", 0) or 0)),
+        "materialized": True,
+        "profile": body,
+    }
+
+
+def _empty_profile_panel_payload() -> dict[str, object]:
+    return {
+        "readiness_tag": "q-missing",
+        "materialized": False,
+        "profile": None,
+    }
+
+
+def _work_event_panel_payload(events: list[Any]) -> dict[str, object]:
+    items: list[dict[str, object]] = []
+    for ev in events:
+        items.append(
+            {
+                "event_id": ev.event_id,
+                "event_index": int(ev.event_index),
+                "conversation_id": ev.conversation_id,
+                "provider": ev.provider_name,
+                "evidence": ev.evidence.model_dump(mode="json"),
+                "inference": ev.inference.model_dump(mode="json"),
+                "provenance": _provenance_dict(ev.provenance),
+            }
+        )
+    return {
+        "readiness_tag": _readiness_tag(materialized=bool(events), row_count=len(events)),
+        "materialized": bool(events),
+        "count": len(items),
+        "events": items,
+    }
+
+
+def _phase_panel_payload(phases: list[Any]) -> dict[str, object]:
+    items: list[dict[str, object]] = []
+    for ph in phases:
+        items.append(
+            {
+                "phase_id": ph.phase_id,
+                "phase_index": int(ph.phase_index),
+                "conversation_id": ph.conversation_id,
+                "provider": ph.provider_name,
+                "evidence": ph.evidence.model_dump(mode="json"),
+                "inference": ph.inference.model_dump(mode="json"),
+                "provenance": _provenance_dict(ph.provenance),
+            }
+        )
+    return {
+        "readiness_tag": _readiness_tag(materialized=bool(phases), row_count=len(phases)),
+        "materialized": bool(phases),
+        "count": len(items),
+        "phases": items,
+    }
+
+
+def _thread_panel_payload(threads: list[Any]) -> dict[str, object]:
+    items: list[dict[str, object]] = []
+    for th in threads:
+        items.append(
+            {
+                "thread_id": th.thread_id,
+                "root_id": th.root_id,
+                "dominant_repo": th.dominant_repo,
+                "thread": th.thread.model_dump(mode="json"),
+                "provenance": _provenance_dict(th.provenance),
+            }
+        )
+    return {
+        "readiness_tag": _readiness_tag(materialized=bool(threads), row_count=len(threads)),
+        "materialized": bool(threads),
+        "count": len(items),
+        "threads": items,
+    }
+
+
 def _message_type_value(message: object) -> str:
     message_type = getattr(message, "message_type", "")
     if hasattr(message_type, "value"):
@@ -505,6 +653,8 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
             self._handle_get_conversation_provenance(path[2], params)
         elif len(path) == 4 and path[:2] == ["api", "conversations"] and path[3] == "topology":
             self._handle_get_conversation_topology(path[2], params)
+        elif len(path) == 4 and path[:3] == ["api", "insights", "sessions"]:
+            self._handle_get_session_insights(path[3], params)
         elif len(path) == 4 and path[:3] == ["api", "raw_artifacts"]:
             self._handle_get_raw_artifact(path[3])
         else:
@@ -968,6 +1118,107 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
                 return None
             return _empty_cost_payload(conv_id, str(conv.provider) if conv.provider else None)
         return _cost_panel_payload(insights[0])
+
+    # ------------------------------------------------------------------
+    # Handlers: insights browser (#1120)
+    # ------------------------------------------------------------------
+
+    @daemon_safe_handler
+    def _handle_get_session_insights(self, conv_id: str, params: dict[str, list[str]]) -> None:
+        """``GET /api/insights/sessions/{id}?include=profile,timeline,phases,threads``.
+
+        Returns a single typed envelope joining the four per-session insight
+        kinds for *conv_id* — session profile (#1018), work-event timeline
+        (#1133/#1135), phases, and work threads. Each section carries a
+        readiness chip drawn from the closed vocabulary
+        (``q-ready`` / ``q-partial`` / ``q-missing``).
+
+        Unknown conversations return ``404 not_found``. Existing conversations
+        without materialized insights return ``200`` with explicit ``q-missing``
+        per-kind shapes so the panel is never blank (AC#1120).
+        """
+        include_raw = self._get_param(params, "include")
+        includes = _parse_insight_includes(include_raw)
+
+        async def _get(poly: Polylogue) -> object:
+            return await self._do_get_session_insights(poly, conv_id, includes)
+
+        result = self._sync_run(_get)
+        if result is None:
+            self._send_error(HTTPStatus.NOT_FOUND, "not_found")
+            return
+        self._send_json(HTTPStatus.OK, result)
+
+    async def _do_get_session_insights(
+        self,
+        poly: Polylogue,
+        conv_id: str,
+        includes: tuple[str, ...],
+    ) -> object:
+        from polylogue.insights.archive import (
+            ArchiveInsightUnavailableError,
+            SessionPhaseInsightQuery,
+            SessionWorkEventInsightQuery,
+            WorkThreadInsightQuery,
+        )
+
+        # Confirm the conversation exists first: distinguishes "unknown
+        # conversation" (404) from "insights surface unavailable" (200 with
+        # explicit q-missing shapes).
+        conv = await poly.get_conversation(conv_id)
+        if conv is None:
+            return None
+
+        envelope: dict[str, object] = {
+            "conversation_id": conv_id,
+            "provider": str(conv.provider) if conv.provider else None,
+            "include": list(includes),
+            "kinds": {},
+        }
+        kinds = envelope["kinds"]
+        assert isinstance(kinds, dict)
+
+        if "profile" in includes:
+            try:
+                profile = await poly.repository.get_session_profile(conv_id)
+            except ArchiveInsightUnavailableError:
+                # The substrate hasn't materialized this insight kind yet;
+                # surface q-missing rather than 503 the whole envelope.
+                profile = None
+            kinds["profile"] = (
+                _profile_panel_payload(profile) if profile is not None else _empty_profile_panel_payload()
+            )
+
+        if "timeline" in includes:
+            try:
+                # Per-conversation list adapter — same path as MCP `session_work_events`.
+                events = await poly.list_session_work_event_insights(
+                    SessionWorkEventInsightQuery(conversation_id=conv_id, limit=None)
+                )
+            except ArchiveInsightUnavailableError:
+                events = []
+            kinds["timeline"] = _work_event_panel_payload(events)
+
+        if "phases" in includes:
+            try:
+                phases = await poly.list_session_phase_insights(
+                    SessionPhaseInsightQuery(conversation_id=conv_id, limit=None)
+                )
+            except ArchiveInsightUnavailableError:
+                phases = []
+            kinds["phases"] = _phase_panel_payload(phases)
+
+        if "threads" in includes:
+            try:
+                # Work threads are not keyed per-conversation in the substrate;
+                # the reader filters the materialized rows by membership.
+                all_threads = await poly.list_work_thread_insights(WorkThreadInsightQuery(limit=None))
+            except ArchiveInsightUnavailableError:
+                all_threads = []
+            member_threads = [th for th in all_threads if conv_id in (th.thread.session_ids or ())]
+            kinds["threads"] = _thread_panel_payload(member_threads)
+
+        return envelope
 
     # ------------------------------------------------------------------
     # Handlers: per-conversation provenance (#1125)

--- a/polylogue/daemon/web_shell.py
+++ b/polylogue/daemon/web_shell.py
@@ -75,6 +75,14 @@ html, body { height: 100%; background: var(--bg); color: var(--text);
 .chip.q-unresolved { border-color: var(--err); color: var(--err); background: var(--err-bg); }
 .chip.q-unavailable { border-color: var(--text-dim); color: var(--text-dim); background: var(--panel-subtle); }
 .chip.q-redacted { border-color: var(--text-dim); color: var(--text-dim); background: var(--panel-subtle); font-style: italic; }
+/* Insights browser readiness vocabulary (#1120): ready / partial (reuses warn
+   palette above) / missing. q-partial is already defined for cost panels. */
+.chip.q-ready { border-color: var(--ok); color: var(--ok); background: var(--ok-bg); }
+.chip.q-missing { border-color: var(--text-dim); color: var(--text-dim); background: var(--panel-subtle); }
+.insight-section-header { cursor: pointer; user-select: none; }
+.insight-section-header .insight-toggle { display: inline-block; width: 10px; color: var(--text-dim); }
+.inspector-field .value.muted { color: var(--text-dim); font-style: italic; }
+.muted { color: var(--text-dim); }
 
 #sidebar { grid-column: 1; grid-row: 2; display: flex; flex-direction: column;
   background: var(--panel); border-right: 1px solid var(--border); overflow: hidden; }
@@ -253,6 +261,7 @@ __WORKSPACE_HTML__
       <button class="active" data-tab="info">Info</button>
       <button data-tab="cost">Cost</button>
       <button data-tab="lineage">Lineage</button>
+      <button data-tab="insights">Insights</button>
       <button data-tab="raw">Raw</button>
       <button data-tab="notes">Notes</button>
     </div>
@@ -312,7 +321,15 @@ var state = {
   // Per-conversation lineage envelope (#1121). Loaded lazily when the
   // Lineage inspector tab is opened. ``undefined`` means "not loaded
   // yet"; ``{error}`` means "fetch failed".
-  lineage: undefined
+  lineage: undefined,
+  // Insights browser cache (#1120). Keyed by conversation_id; populated
+  // on demand when the Insights inspector tab is opened. Holds the
+  // ``GET /api/insights/sessions/{id}`` envelope: ``{kinds: {profile,
+  // timeline, phases, threads}, include, conversation_id, provider}``.
+  insightsPanels: {},
+  // Per-conversation collapsed-section toggles for the Insights tab.
+  // Keyed as ``"<conversation_id>:<kind>"``; default = expanded.
+  insightsCollapsed: {}
 };
 
 function esc(s) { return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;'); }
@@ -711,8 +728,174 @@ function renderInspector() {
   if (tab === 'info') renderInspectorInfo(el, c);
   else if (tab === 'cost') renderInspectorCost(el, c);
   else if (tab === 'lineage') renderInspectorLineage(el, c);
+  else if (tab === 'insights') renderInspectorInsights(el, c);
   else if (tab === 'raw') renderInspectorRaw(el, c);
   else if (tab === 'notes') renderInspectorNotes(el, c);
+}
+
+// --- Insights browser (#1120) -------------------------------------------
+// Loads /api/insights/sessions/{id} on demand and caches per-conversation
+// in state.insightsPanels. Each kind (profile/timeline/phases/threads)
+// surfaces a readiness chip driven by the daemon-served q-* vocabulary
+// (q-ready / q-partial / q-missing). The panel never goes blank — a
+// kind with no materialized row is rendered with an explicit q-missing
+// chip and a "no rows recorded" body.
+async function loadInsightsPanel(id) {
+  try {
+    var data = await fetchJSON('/api/insights/sessions/' + encodeURIComponent(id));
+    state.insightsPanels[id] = data;
+  } catch(e) {
+    state.insightsPanels[id] = {error: String(e)};
+  }
+  if (state.selected && state.selected.id === id && state.inspectorTab === 'insights') {
+    renderInspector();
+  }
+}
+
+function insightSectionKey(convId, kind) { return convId + ':' + kind; }
+
+function toggleInsightSection(kind) {
+  if (!state.selected) return;
+  var k = insightSectionKey(state.selected.id, kind);
+  state.insightsCollapsed[k] = !state.insightsCollapsed[k];
+  renderInspector();
+}
+
+function readinessChip(tag) {
+  var label = (tag || 'q-missing').replace('q-', '');
+  return '<span class="chip ' + esc(tag || 'q-missing') + '" title="readiness: ' + esc(tag || 'q-missing') + '">' + esc(label) + '</span>';
+}
+
+function insightSectionHeader(convId, kind, title, tag, count) {
+  var collapsed = state.insightsCollapsed[insightSectionKey(convId, kind)];
+  var arrow = collapsed ? '+' : '&minus;';
+  var meta = (count != null) ? ' <span class="muted">(' + esc(String(count)) + ')</span>' : '';
+  return '<h4 class="insight-section-header" onclick="toggleInsightSection(\'' + escAttr(kind) + '\')">'
+    + '<span class="insight-toggle">' + arrow + '</span> '
+    + esc(title) + ' ' + readinessChip(tag) + meta + '</h4>';
+}
+
+function renderInsightProfile(convId, body) {
+  if (!body) body = {readiness_tag: 'q-missing', materialized: false, profile: null};
+  var tag = body.readiness_tag || 'q-missing';
+  var html = insightSectionHeader(convId, 'profile', 'Profile', tag, null);
+  if (state.insightsCollapsed[insightSectionKey(convId, 'profile')]) return html;
+  var prof = body.profile;
+  if (!prof) {
+    html += '<div class="inspector-field"><span class="value muted">No session profile materialized.</span></div>';
+    return html;
+  }
+  var fields = [
+    ['Messages', prof.message_count],
+    ['Substantive', prof.substantive_count],
+    ['Tool uses', prof.tool_use_count],
+    ['Thinking', prof.thinking_count],
+    ['Words', prof.word_count],
+    ['Duration (ms)', prof.total_duration_ms],
+    ['Wall (ms)', prof.wall_duration_ms],
+    ['Tags', (prof.tags || []).join(', ')],
+    ['Auto-tags', (prof.auto_tags || []).join(', ')]
+  ];
+  fields.forEach(function(row) {
+    var v = (row[1] == null || row[1] === '') ? '\u2014' : row[1];
+    html += '<div class="inspector-field"><span class="label">' + esc(row[0]) + '</span>'
+      + '<span class="value">' + esc(String(v)) + '</span></div>';
+  });
+  return html;
+}
+
+function renderInsightTimeline(convId, body) {
+  if (!body) body = {readiness_tag: 'q-missing', count: 0, events: []};
+  var tag = body.readiness_tag || 'q-missing';
+  var count = body.count || (body.events ? body.events.length : 0);
+  var html = insightSectionHeader(convId, 'timeline', 'Work events', tag, count);
+  if (state.insightsCollapsed[insightSectionKey(convId, 'timeline')]) return html;
+  var events = body.events || [];
+  if (!events.length) {
+    html += '<div class="inspector-field"><span class="value muted">No work events recorded.</span></div>';
+    return html;
+  }
+  events.slice(0, 50).forEach(function(ev) {
+    var inf = ev.inference || {};
+    var kind = inf.kind || inf.event_type || 'event';
+    var summary = inf.summary || inf.label || '';
+    html += '<div class="inspector-field"><span class="label">#' + esc(String(ev.event_index)) + ' '
+      + esc(kind) + '</span><span class="value">' + esc(summary) + '</span></div>';
+  });
+  if (events.length > 50) {
+    html += '<div class="inspector-field"><span class="value muted">+' + (events.length - 50) + ' more</span></div>';
+  }
+  return html;
+}
+
+function renderInsightPhases(convId, body) {
+  if (!body) body = {readiness_tag: 'q-missing', count: 0, phases: []};
+  var tag = body.readiness_tag || 'q-missing';
+  var count = body.count || (body.phases ? body.phases.length : 0);
+  var html = insightSectionHeader(convId, 'phases', 'Phases', tag, count);
+  if (state.insightsCollapsed[insightSectionKey(convId, 'phases')]) return html;
+  var phases = body.phases || [];
+  if (!phases.length) {
+    html += '<div class="inspector-field"><span class="value muted">No phases recorded.</span></div>';
+    return html;
+  }
+  phases.forEach(function(ph) {
+    var inf = ph.inference || {};
+    var label = inf.label || inf.phase_type || ('phase ' + ph.phase_index);
+    var summary = inf.summary || '';
+    html += '<div class="inspector-field"><span class="label">#' + esc(String(ph.phase_index)) + ' '
+      + esc(label) + '</span><span class="value">' + esc(summary) + '</span></div>';
+  });
+  return html;
+}
+
+function renderInsightThreads(convId, body) {
+  if (!body) body = {readiness_tag: 'q-missing', count: 0, threads: []};
+  var tag = body.readiness_tag || 'q-missing';
+  var count = body.count || (body.threads ? body.threads.length : 0);
+  var html = insightSectionHeader(convId, 'threads', 'Work threads', tag, count);
+  if (state.insightsCollapsed[insightSectionKey(convId, 'threads')]) return html;
+  var threads = body.threads || [];
+  if (!threads.length) {
+    html += '<div class="inspector-field"><span class="value muted">No work-thread membership recorded.</span></div>';
+    return html;
+  }
+  threads.forEach(function(th) {
+    var t = th.thread || {};
+    var sessionCount = (t.session_ids || []).length || t.session_count || 0;
+    var meta = (th.dominant_repo ? th.dominant_repo + ' \u00b7 ' : '')
+      + sessionCount + ' sessions';
+    html += '<div class="inspector-field"><span class="label">' + esc(th.thread_id.slice(0, 8)) + '</span>'
+      + '<span class="value">' + esc(meta) + '</span></div>';
+  });
+  return html;
+}
+
+function renderInspectorInsights(el, c) {
+  var data = state.insightsPanels[c.id];
+  if (data === undefined) {
+    el.innerHTML = '<div class="inspector-empty">Loading insights...</div>';
+    loadInsightsPanel(c.id);
+    return;
+  }
+  if (data && data.error) {
+    el.innerHTML = '<div class="inspector-empty">Insights surface unavailable</div>';
+    return;
+  }
+  var kinds = data.kinds || {};
+  var html = '<div class="inspector-section">'
+    + renderInsightProfile(c.id, kinds.profile)
+    + '</div>'
+    + '<div class="inspector-section">'
+    + renderInsightTimeline(c.id, kinds.timeline)
+    + '</div>'
+    + '<div class="inspector-section">'
+    + renderInsightPhases(c.id, kinds.phases)
+    + '</div>'
+    + '<div class="inspector-section">'
+    + renderInsightThreads(c.id, kinds.threads)
+    + '</div>';
+  el.innerHTML = html;
 }
 
 // --- Cost panel (#1122) --------------------------------------------------

--- a/tests/unit/daemon/test_insights_browser_endpoint.py
+++ b/tests/unit/daemon/test_insights_browser_endpoint.py
@@ -1,0 +1,301 @@
+"""Insights browser endpoint contracts for the reader (#1120).
+
+``GET /api/insights/sessions/{id}[?include=profile,timeline,phases,threads]``
+returns a single typed envelope joining four per-session insight kinds:
+
+- session profile (#1018)
+- work-event timeline (#1133/#1135)
+- session phases
+- work-thread membership
+
+Each kind carries a readiness chip from the closed vocabulary
+(``q-ready`` / ``q-partial`` / ``q-missing``). Unknown conversations are a
+hard 404. Existing conversations without any materialized insight return
+200 with explicit ``q-missing`` shapes per kind (panel never blank —
+AC#1120).
+
+These tests exercise the pure helpers (``_readiness_tag``,
+``_parse_insight_includes``, panel projectors) and the end-to-end dispatch
+path through the in-process handler harness (same shape as
+``test_cost_panel_endpoint.py``).
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from email.message import Message
+from http import HTTPStatus
+from io import BytesIO
+from pathlib import Path
+from typing import cast
+from unittest.mock import MagicMock
+
+from polylogue.daemon.http import (
+    INSIGHT_KINDS,
+    DaemonAPIHandler,
+    DaemonAPIHTTPServer,
+    _empty_profile_panel_payload,
+    _parse_insight_includes,
+    _phase_panel_payload,
+    _readiness_tag,
+    _thread_panel_payload,
+    _work_event_panel_payload,
+)
+
+# ---------------------------------------------------------------------------
+# In-process handler harness (mirrors test_cost_panel_endpoint.py)
+# ---------------------------------------------------------------------------
+
+
+class _MockServer:
+    auth_token = ""
+    api_host = "127.0.0.1"
+
+
+class _MockHeaders:
+    def __init__(self, headers: dict[str, str] | None = None) -> None:
+        self._headers = headers or {}
+
+    def get(self, key: str, default: str | None = None) -> str | None:
+        return self._headers.get(key, default)
+
+
+def _make_handler(method: str, path: str) -> DaemonAPIHandler:
+    handler = DaemonAPIHandler.__new__(DaemonAPIHandler)
+    handler.server = cast(DaemonAPIHTTPServer, _MockServer())
+    handler.client_address = ("127.0.0.1", 12345)
+    handler.path = path
+    handler.command = method
+    handler.requestline = f"{method} {path} HTTP/1.1"
+    headers: dict[str, str] = {"Content-Length": "0"}
+    handler.headers = cast(Message, _MockHeaders(headers))
+    handler.rfile = BytesIO(b"")
+    handler.wfile = BytesIO()
+    return handler
+
+
+def _capture_responses(handler: DaemonAPIHandler) -> tuple[MagicMock, MagicMock]:
+    send_error = MagicMock()
+    send_json = MagicMock()
+    handler._send_error = send_error  # type: ignore[method-assign]
+    handler._send_json = send_json  # type: ignore[method-assign]
+    return send_error, send_json
+
+
+def _seed_minimum_archive(workspace_env: dict[str, Path]) -> None:
+    """Seed the minimum DB schema with one conversation + one message."""
+    from polylogue.paths import db_path
+    from polylogue.storage.sqlite.schema_ddl_archive import (
+        ARCHIVE_STORAGE_DDL,
+        MESSAGE_FTS_DDL,
+        RECALL_PACKS_DDL,
+        SAVED_VIEWS_DDL,
+        USER_ANNOTATIONS_DDL,
+        USER_MARKS_DDL,
+    )
+
+    dbp = db_path()
+    dbp.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(dbp))
+    try:
+        conn.executescript(ARCHIVE_STORAGE_DDL)
+        conn.executescript(MESSAGE_FTS_DDL)
+        conn.executescript(USER_MARKS_DDL)
+        conn.executescript(USER_ANNOTATIONS_DDL)
+        conn.executescript(SAVED_VIEWS_DDL)
+        conn.executescript(RECALL_PACKS_DDL)
+        conn.execute(
+            "INSERT INTO conversations(conversation_id, provider_name, provider_conversation_id,"
+            " title, content_hash, version) VALUES(?,?,?,?,?,?)",
+            ("ins-1", "claude-code", "p-ins-1", "An ins conv", "hash-ins-1", 1),
+        )
+        conn.execute(
+            "INSERT INTO messages(message_id, conversation_id, role, text, provider_name,"
+            " content_hash, version) VALUES(?,?,?,?,?,?,?)",
+            ("m-ins-1", "ins-1", "user", "hello", "claude-code", "mhash-ins-1", 1),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers: readiness chip vocabulary
+# ---------------------------------------------------------------------------
+
+
+class TestReadinessTagMapping:
+    """``_readiness_tag`` maps materialized/row-count to the readiness chips."""
+
+    def test_unmaterialized_is_missing(self) -> None:
+        assert _readiness_tag(materialized=False) == "q-missing"
+
+    def test_unmaterialized_with_zero_rows_is_missing(self) -> None:
+        # The materialized flag wins — a missing surface cannot be partial.
+        assert _readiness_tag(materialized=False, row_count=0) == "q-missing"
+
+    def test_materialized_with_zero_rows_is_partial(self) -> None:
+        # Rebuild ran but produced nothing — explicit "partial" surface.
+        assert _readiness_tag(materialized=True, row_count=0) == "q-partial"
+
+    def test_materialized_with_rows_is_ready(self) -> None:
+        assert _readiness_tag(materialized=True, row_count=3) == "q-ready"
+
+    def test_materialized_without_row_count_is_ready(self) -> None:
+        # row_count=None (e.g. session profile) defaults to ready.
+        assert _readiness_tag(materialized=True) == "q-ready"
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers: include= parser
+# ---------------------------------------------------------------------------
+
+
+class TestParseIncludes:
+    """``_parse_insight_includes`` resolves include= into a canonical tuple."""
+
+    def test_none_defaults_to_all_kinds(self) -> None:
+        assert _parse_insight_includes(None) == INSIGHT_KINDS
+
+    def test_empty_string_defaults_to_all_kinds(self) -> None:
+        assert _parse_insight_includes("") == INSIGHT_KINDS
+        assert _parse_insight_includes("   ") == INSIGHT_KINDS
+
+    def test_subset_preserves_canonical_order(self) -> None:
+        # Caller passes threads,profile but the canonical order is
+        # profile,timeline,phases,threads — we must normalize.
+        assert _parse_insight_includes("threads,profile") == ("profile", "threads")
+
+    def test_unknown_tokens_are_dropped(self) -> None:
+        assert _parse_insight_includes("profile,not-a-kind,phases") == ("profile", "phases")
+
+    def test_whitespace_and_case_tolerant(self) -> None:
+        assert _parse_insight_includes("  PROFILE , Timeline  ") == ("profile", "timeline")
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers: empty/missing panel shapes
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyPayloads:
+    """Empty-state panels must surface explicit q-missing — never blank."""
+
+    def test_empty_profile_panel_is_q_missing(self) -> None:
+        payload = _empty_profile_panel_payload()
+        assert payload["readiness_tag"] == "q-missing"
+        assert payload["materialized"] is False
+        assert payload["profile"] is None
+
+    def test_empty_work_event_panel_is_q_missing(self) -> None:
+        payload = _work_event_panel_payload([])
+        assert payload["readiness_tag"] == "q-missing"
+        assert payload["materialized"] is False
+        assert payload["count"] == 0
+        assert payload["events"] == []
+
+    def test_empty_phase_panel_is_q_missing(self) -> None:
+        payload = _phase_panel_payload([])
+        assert payload["readiness_tag"] == "q-missing"
+        assert payload["count"] == 0
+        assert payload["phases"] == []
+
+    def test_empty_thread_panel_is_q_missing(self) -> None:
+        payload = _thread_panel_payload([])
+        assert payload["readiness_tag"] == "q-missing"
+        assert payload["count"] == 0
+        assert payload["threads"] == []
+
+    def test_payloads_round_trip_through_json(self) -> None:
+        for payload in (
+            _empty_profile_panel_payload(),
+            _work_event_panel_payload([]),
+            _phase_panel_payload([]),
+            _thread_panel_payload([]),
+        ):
+            json.dumps(payload)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end endpoint dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestInsightsEndpointDispatch:
+    """``GET /api/insights/sessions/{id}`` routes to the insights handler."""
+
+    def test_unknown_conversation_returns_404(self, workspace_env: dict[str, Path]) -> None:
+        _seed_minimum_archive(workspace_env)
+        handler = _make_handler("GET", "/api/insights/sessions/does-not-exist")
+        send_error, send_json = _capture_responses(handler)
+        handler.do_GET()
+        send_json.assert_not_called()
+        send_error.assert_called_once()
+        status, code = send_error.call_args.args
+        assert status == HTTPStatus.NOT_FOUND
+        assert code == "not_found"
+
+    def test_known_conversation_returns_typed_envelope(self, workspace_env: dict[str, Path]) -> None:
+        _seed_minimum_archive(workspace_env)
+        handler = _make_handler("GET", "/api/insights/sessions/ins-1")
+        send_error, send_json = _capture_responses(handler)
+        handler.do_GET()
+        send_error.assert_not_called()
+        send_json.assert_called_once()
+        status, payload = send_json.call_args.args
+        assert status == HTTPStatus.OK
+        assert payload["conversation_id"] == "ins-1"
+        assert payload["include"] == list(INSIGHT_KINDS)
+        kinds = payload["kinds"]
+        assert set(kinds.keys()) == set(INSIGHT_KINDS)
+        # No insights are materialized for the seed; every kind must report
+        # an explicit q-missing readiness chip rather than being absent.
+        for kind in INSIGHT_KINDS:
+            assert kinds[kind]["readiness_tag"] in {"q-ready", "q-partial", "q-missing"}
+            assert "materialized" in kinds[kind]
+        assert kinds["profile"]["readiness_tag"] == "q-missing"
+        assert kinds["timeline"]["readiness_tag"] == "q-missing"
+        assert kinds["phases"]["readiness_tag"] == "q-missing"
+        assert kinds["threads"]["readiness_tag"] == "q-missing"
+
+    def test_include_param_restricts_kinds(self, workspace_env: dict[str, Path]) -> None:
+        _seed_minimum_archive(workspace_env)
+        handler = _make_handler("GET", "/api/insights/sessions/ins-1?include=profile,phases")
+        send_error, send_json = _capture_responses(handler)
+        handler.do_GET()
+        send_error.assert_not_called()
+        send_json.assert_called_once()
+        status, payload = send_json.call_args.args
+        assert status == HTTPStatus.OK
+        assert payload["include"] == ["profile", "phases"]
+        # Only the requested kinds appear — restriction must be honored.
+        assert set(payload["kinds"].keys()) == {"profile", "phases"}
+
+    def test_include_param_with_unknown_tokens_drops_them(self, workspace_env: dict[str, Path]) -> None:
+        _seed_minimum_archive(workspace_env)
+        handler = _make_handler("GET", "/api/insights/sessions/ins-1?include=profile,bogus,timeline")
+        _, send_json = _capture_responses(handler)
+        handler.do_GET()
+        status, payload = send_json.call_args.args
+        assert status == HTTPStatus.OK
+        assert set(payload["kinds"].keys()) == {"profile", "timeline"}
+
+    def test_envelope_carries_provider_and_id(self, workspace_env: dict[str, Path]) -> None:
+        _seed_minimum_archive(workspace_env)
+        handler = _make_handler("GET", "/api/insights/sessions/ins-1")
+        _, send_json = _capture_responses(handler)
+        handler.do_GET()
+        _, payload = send_json.call_args.args
+        assert payload["conversation_id"] == "ins-1"
+        # provider may be string-coerced from the Provider enum.
+        assert payload["provider"]
+
+    def test_envelope_is_json_serialisable(self, workspace_env: dict[str, Path]) -> None:
+        _seed_minimum_archive(workspace_env)
+        handler = _make_handler("GET", "/api/insights/sessions/ins-1")
+        _, send_json = _capture_responses(handler)
+        handler.do_GET()
+        _, payload = send_json.call_args.args
+        # All panel data ships over HTTP as JSON.
+        json.dumps(payload)

--- a/tests/visual/test_reader_dom_smoke.py
+++ b/tests/visual/test_reader_dom_smoke.py
@@ -360,6 +360,83 @@ def test_reader_cost_panel_evidence(reader_workspace: ReaderWorkspace, tmp_path:
     )
 
 
+def test_reader_insights_browser_evidence(reader_workspace: ReaderWorkspace, tmp_path: Path) -> None:
+    """Insights browser endpoint surfaces typed envelope + readiness chips (#1120).
+
+    Pins:
+    - existing conversation returns the four-kind envelope (profile/timeline/
+      phases/threads), each with a chip from the closed q-ready/q-partial/
+      q-missing vocabulary;
+    - unknown conversation returns 404 (not a blank panel);
+    - include= subset honors the request and drops unknown tokens;
+    - shell HTML carries the new ``Insights`` tab + ``renderInspectorInsights``
+      so the panel is reachable through the inspector tab strip and uses
+      the readiness chip CSS classes.
+    """
+    with running_reader_server(reader_workspace) as (_, base_url):
+        status, content_type, shell = get_text(base_url, "/c/reader-c1")
+        known = cast(dict[str, object], get_json(base_url, "/api/insights/sessions/reader-c1"))
+        subset = cast(
+            dict[str, object],
+            get_json(base_url, "/api/insights/sessions/reader-c1?include=profile,bogus,phases"),
+        )
+        unknown_status, _, unknown_body = get_text(base_url, "/api/insights/sessions/does-not-exist")
+
+    assert status == 200
+    assert "text/html" in content_type
+    for phrase in (
+        'data-tab="insights"',
+        "renderInspectorInsights",
+        "loadInsightsPanel",
+        "q-ready",
+        "q-partial",
+        "q-missing",
+        "Work events",
+        "Phases",
+        "Work threads",
+    ):
+        assert phrase in shell, f"missing phrase in shell: {phrase!r}"
+
+    assert known["conversation_id"] == "reader-c1"
+    assert isinstance(known["kinds"], dict)
+    kinds = cast(dict[str, dict[str, object]], known["kinds"])
+    assert set(kinds.keys()) == {"profile", "timeline", "phases", "threads"}
+    for kind, body in kinds.items():
+        assert body["readiness_tag"] in {"q-ready", "q-partial", "q-missing"}, kind
+        assert "materialized" in body
+
+    subset_kinds = cast(dict[str, dict[str, object]], subset["kinds"])
+    assert set(subset_kinds.keys()) == {"profile", "phases"}
+    assert subset["include"] == ["profile", "phases"]
+
+    assert unknown_status == 404
+    unknown_payload = json.loads(unknown_body)
+    assert unknown_payload.get("error") in {"not_found", None}
+
+    assert_no_private_paths(json.dumps(known), context="insights browser envelope")
+    assert_no_private_paths(shell, context="reader shell HTML")
+
+    write_evidence_manifest(
+        tmp_path / "reader-insights-browser-dom-evidence.json",
+        artifact_id="polylogue.local_reader.insights_browser",
+        route="/api/insights/sessions/reader-c1",
+        fixture_id="reader-visual-synthetic-v1",
+        checks={
+            "shell_status": status,
+            "insights_endpoint_status": 200,
+            "unknown_endpoint_status": unknown_status,
+            "kinds_present": sorted(kinds.keys()),
+            "profile_readiness": kinds["profile"]["readiness_tag"],
+            "timeline_readiness": kinds["timeline"]["readiness_tag"],
+            "phases_readiness": kinds["phases"]["readiness_tag"],
+            "threads_readiness": kinds["threads"]["readiness_tag"],
+            "subset_honored": list(subset_kinds.keys()),
+            "chip_vocabulary_in_shell": True,
+            "private_path_safe": True,
+        },
+    )
+
+
 def test_reader_empty_and_degraded_evidence(reader_workspace: ReaderWorkspace, tmp_path: Path) -> None:
     with running_reader_server(reader_workspace, conversations=False) as (_, base_url):
         empty_list = cast(dict[str, object], get_json(base_url, "/api/conversations"))


### PR DESCRIPTION
## Summary

Adds the per-conversation insights browser to the daemon web reader plus
the backing `GET /api/insights/sessions/{id}` endpoint. The panel
surfaces the four per-session insight kinds (session profile,
work-event timeline, session phases, work-thread membership) as a
single typed envelope, with collapsible per-kind sections and an
explicit readiness chip on each.

## Problem

Issue #1120 specifies an insights browser in the reader that exposes
the bounded session insight products (#1018) inline on the
conversation page, with a readiness/freshness chip per panel
(#1019), and reads only through the public insight surfaces — no
direct insight-table queries from the reader.

Until this PR the daemon web shell had no surface onto the per-session
insight substrate landed under #1018 / #1133 / #1135. Selecting a
conversation in the reader exposed Info / Cost / Raw / Notes tabs
only; the materialized profile, work events, phases, and work-thread
membership were reachable through MCP and the CLI but invisible to a
reader operator.

## Solution

- New route `GET /api/insights/sessions/{id}[?include=profile,timeline,
  phases,threads]` in `polylogue/daemon/http.py`. Routes through the
  public facade adapters
  (`Polylogue.repository.get_session_profile`,
  `list_session_work_event_insights`, `list_session_phase_insights`,
  `list_work_thread_insights`) — the same path the CLI and MCP use, so
  the reader does not import insight storage modules directly
  (AC#1120). Includes the `?include=` query parameter to restrict the
  envelope to a subset of kinds; unknown tokens are dropped and the
  canonical kind ordering is preserved.
- Module-level helpers `_readiness_tag`, `_parse_insight_includes`,
  `_profile_panel_payload`, `_work_event_panel_payload`,
  `_phase_panel_payload`, `_thread_panel_payload` project the typed
  insight records into a stable JSON shape. The readiness chip
  vocabulary is closed (`q-ready` / `q-partial` / `q-missing`) and is
  exercised by unit tests.
- Reader inspector gains an `Insights` tab. The renderer lazy-loads
  the endpoint into `state.insightsPanels`, shows one collapsible
  section per kind, surfaces the readiness chip in each section header
  with a row count, and renders a per-kind empty body
  (`No <kind> recorded.`) when the substrate has no rows — the panel
  is never blank (AC#1120).
- Unknown conversations return a hard `404 not_found`. Existing
  conversations without materialized insights return `200` with
  explicit `q-missing` shapes per kind (AC#1120). Each per-kind list
  call is wrapped in a guard against
  `ArchiveInsightUnavailableError` so an unmaterialized substrate
  surfaces as `q-missing` rather than `503` the whole envelope.
- CSS extends the existing MK3 chip vocabulary with `q-ready` and
  `q-missing` palette entries reusing the `--ok` / `--text-dim`
  tokens; adds `.insight-section-header` / `.insight-toggle` /
  `.muted` for the section affordances.
- File-size budgets bumped: `polylogue/daemon/http.py` 1340 -> 1600,
  `polylogue/daemon/web_shell.py` 1280 -> 1460, both with a
  `split candidate` note pointing at the future per-domain handler /
  per-tab decomposition.

## Verification

```
$ nix develop -c pytest tests/unit/daemon/test_insights_browser_endpoint.py \
                 tests/visual/test_reader_dom_smoke.py::test_reader_insights_browser_evidence -p no:randomly
22 passed in 9.27s

$ nix develop -c pytest tests/unit/daemon/test_cost_panel_endpoint.py \
                 tests/visual/test_reader_dom_smoke.py -p no:randomly -q
24 passed in 12.50s

$ nix develop -c devtools verify --quick
... exit_code: 0  (~36s, all gates pass after one render-pages refresh)
```

Unit contracts pin the readiness chip vocabulary mapping
(materialized/row_count -> q-ready/q-partial/q-missing), the
`?include=` parser (None/empty default, subset, unknown-token drop,
canonical ordering), the four panel projector empty shapes, and the
dispatch path (404 for unknown, 200 + typed envelope for known,
`?include=` honored). Visual DOM smoke evidence (#865) pins the
`Insights` inspector tab and the readiness chip vocabulary
(`q-ready` / `q-partial` / `q-missing` plus `Work events`, `Phases`,
`Work threads` section labels) in the shell HTML, and exercises the
live endpoint against the seeded reader workspace including the
subset and unknown-conversation paths.

## Acceptance criteria status (#1120)

- [x] Reader exposes session-profile, work-events, phases, threads
      inline on the conversation page via the new `Insights`
      inspector tab.
- [x] Each panel renders a readiness chip from the closed
      `q-ready` / `q-partial` / `q-missing` vocabulary; missing /
      stale state is explicit (the empty-state body says
      "No <kind> recorded.").
- [x] Reader code does not import insight storage modules directly —
      only the public `Polylogue.list_session_*_insights` adapters
      and `Polylogue.repository.get_session_profile`.
- [x] Tests assert the reader survives stale, missing, and partial
      insight states (each kind defaults to `q-missing`; the handler
      catches `ArchiveInsightUnavailableError` per kind).
- [x] Visual smoke harness (#865) covers the ready / missing /
      partial chip vocabulary in the shell and exercises both the
      known and unknown conversation paths.

Deferred to follow-ups (not in scope for this slice):

- Day-summary and week-summary browse views — the inline conversation
  insights panel is the focus of this PR; the day/week dedicated
  routes are tracked separately as part of #993.
- Provenance-based staleness chip (`stale`) — wiring
  `polylogue.insights.provenance.is_stale` into the readiness chip
  per-kind requires source-high-water-mark plumbing that is out of
  scope here; the readiness chip currently reports
  `q-ready/q-partial/q-missing` based on materialization presence
  and row count.

Closes #1120

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>