### PR TITLE
fix(tests): clear inherited test drift (#1180)

### DIFF
--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -1059,6 +1059,24 @@ def repair_message_type_backfill(config: Config, dry_run: bool = False) -> Repai
     return _to_repair_result(run_backfill(config, dry_run=dry_run))
 
 
+def repair_message_embeddings(config: Config, dry_run: bool = False) -> RepairResult:
+    """No-op embedding rebuild stub.
+
+    Embeddings are materialized exclusively by the daemon's embedding stage
+    (see #828); there is no synchronous rebuild path. The maintenance target
+    is registered so planners and surfaces can name the dormant work, but
+    invoking it through ``doctor --repair`` is a no-op that records dormancy
+    rather than failing the run.
+    """
+    verb = "Would skip" if dry_run else "Skipped"
+    return _repair_result(
+        "message_embeddings",
+        repaired_count=0,
+        success=True,
+        detail=f"{verb}: embedding rebuild is daemon-owned and dormant (#828).",
+    )
+
+
 _PREVIEW_HANDLERS: dict[str, Callable[..., RepairResult]] = {
     "session_insights": preview_session_insights,
     "action_event_read_model": preview_action_event_read_model,
@@ -1076,6 +1094,7 @@ _REPAIR_HANDLERS: dict[str, Callable[..., RepairResult]] = {
     "action_event_read_model": repair_action_event_read_model,
     "dangling_fts": repair_dangling_fts,
     "message_type_backfill": repair_message_type_backfill,
+    "message_embeddings": repair_message_embeddings,
     "wal_checkpoint": repair_wal_checkpoint,
     "orphaned_messages": repair_orphaned_messages,
     "orphaned_content_blocks": repair_orphaned_content_blocks,

--- a/tests/data/witnesses/mcp-tool-schemas.json
+++ b/tests/data/witnesses/mcp-tool-schemas.json
@@ -273,6 +273,27 @@
     }
   },
   {
+    "name": "cost_outlook",
+    "parameters": {
+      "properties": {
+        "method": {
+          "default": "linear",
+          "title": "Method",
+          "type": "string"
+        },
+        "plan": {
+          "title": "Plan",
+          "type": "string"
+        }
+      },
+      "required": [
+        "plan"
+      ],
+      "title": "cost_outlookArguments",
+      "type": "object"
+    }
+  },
+  {
     "name": "cost_rollups",
     "parameters": {
       "properties": {
@@ -1607,6 +1628,59 @@
     }
   },
   {
+    "name": "maintenance_execute",
+    "parameters": {
+      "properties": {
+        "dry_run": {
+          "default": false,
+          "title": "Dry Run",
+          "type": "boolean"
+        },
+        "targets": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Targets"
+        }
+      },
+      "title": "maintenance_executeArguments",
+      "type": "object"
+    }
+  },
+  {
+    "name": "maintenance_preview",
+    "parameters": {
+      "properties": {
+        "targets": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Targets"
+        }
+      },
+      "title": "maintenance_previewArguments",
+      "type": "object"
+    }
+  },
+  {
     "name": "neighbor_candidates",
     "parameters": {
       "properties": {
@@ -1659,6 +1733,68 @@
         }
       },
       "title": "neighbor_candidatesArguments",
+      "type": "object"
+    }
+  },
+  {
+    "name": "productivity_rollups",
+    "parameters": {
+      "properties": {
+        "granularity": {
+          "default": "day",
+          "title": "Granularity",
+          "type": "string"
+        },
+        "limit": {
+          "default": 200,
+          "minimum": 1,
+          "title": "Limit",
+          "type": "integer"
+        },
+        "offset": {
+          "default": 0,
+          "minimum": 0,
+          "title": "Offset",
+          "type": "integer"
+        },
+        "provider": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Provider"
+        },
+        "since": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Since"
+        },
+        "until": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Until"
+        }
+      },
+      "title": "productivity_rollupsArguments",
       "type": "object"
     }
   },


### PR DESCRIPTION
## Summary

Two unrelated test failures had accumulated on master and were inherited
into every feature branch's verify run. This PR clears both so the
master baseline goes green again. Closes #1180.

## Problem

Reproduced on a clean `origin/master` checkout:

```
pytest tests/unit/cli/test_check.py::TestCheckCommandSupplementary \
       tests/unit/mcp/test_tool_schema_witness.py
```

5 failures (4 + 1):

- `tests/unit/cli/test_check.py::TestCheckCommandSupplementary` —
  `test_json_output_with_repair`, `test_repair_with_no_issues_shows_message`,
  `test_vacuum_with_repair`, `test_json_output_with_repair_and_vacuum_is_machine_safe`
  all raised `KeyError: 'message_embeddings'` from
  `polylogue/storage/repair.py:run_safe_repairs`. The
  `message_embeddings` maintenance target was added to
  `polylogue/maintenance/targets.py` in #1157 (typed planner contract)
  with `mode=REPAIR`, but no matching entry was added to
  `_REPAIR_HANDLERS`. `run_safe_repairs` then iterated every name from
  `SAFE_REPAIR_TARGETS` and crashed on the missing key.

- `tests/unit/mcp/test_tool_schema_witness.py::test_mcp_tool_catalog_matches_witness`
  failed because the committed witness in
  `tests/data/witnesses/mcp-tool-schemas.json` still contained the
  pre-#1168 catalog. PR #1168 added `cost_outlook` to the MCP server
  (`polylogue/mcp/server_insight_tools.py`); the witness needed
  regeneration. The current registry exposes 64 tools — both
  `cost_outlook` and `cost_rollups`.

## Solution

- `polylogue/storage/repair.py`: add `repair_message_embeddings()` as a
  no-op handler that records the embedding rebuild as dormant (#828).
  The embedding pipeline is daemon-owned and has no synchronous rebuild
  path, so a `doctor --repair` invocation that touches this target
  should report dormancy rather than crash. The catalog continues to
  list the target so planners and surfaces can name the dormant work.
- `tests/data/witnesses/mcp-tool-schemas.json`: regenerate from
  `build_server(role="admin")` per the regeneration recipe in the test
  module docstring.

No production semantics changed: the embedding stub is the smallest
change that closes the crash without inventing a new rebuild contract
that #828 will eventually own.

## Verification

```
pytest tests/unit/cli/test_check.py::TestCheckCommandSupplementary \
       tests/unit/mcp/test_tool_schema_witness.py
# => 25 passed in 10.59s (was 5 failed, 20 passed)

devtools verify --quick
# => "exit_code": 0
```

Closes #1180