### PR TITLE
feat(reader): identity-preserving marks across reimport (#1114)

### DIFF
--- a/docs/plans/file-size-budgets.yaml
+++ b/docs/plans/file-size-budgets.yaml
@@ -74,8 +74,8 @@ exceptions:
     reason: "kitchen-sink live-ingest test file (cursor, watcher, batch, debounce, bootstrap); split candidate: per-subject suites under tests/unit/sources/live/"
 
   - path: polylogue/storage/sqlite/schema_bootstrap.py
-    ceiling: 1420
-    reason: "schema bootstrap owns reviewed version branches through v14 (#864, #867); split candidate: per-version upgrade modules"
+    ceiling: 1700
+    reason: "schema bootstrap owns reviewed version branches through v17, including the v15/v16 -> v17 identity-preserving marks rebuild (#864, #867, #1113, #1114); split candidate: per-version upgrade modules"
 
   - path: polylogue/sources/live/batch.py
     ceiling: 1160

--- a/polylogue/storage/repository/archive/writes/conversations.py
+++ b/polylogue/storage/repository/archive/writes/conversations.py
@@ -68,6 +68,7 @@ from polylogue.storage.sqlite.queries import conversations as conversations_q
 from polylogue.storage.sqlite.queries import messages as messages_q
 from polylogue.storage.sqlite.queries import provider_events as provider_events_q
 from polylogue.storage.sqlite.queries import stats as stats_q
+from polylogue.storage.sqlite.queries.conversations_identity import repoint_user_state_by_identity
 
 
 def provider_conversation_id(conversation_id: str, provider: str | None) -> str:
@@ -445,6 +446,13 @@ async def save_via_backend(
                 counts["attachments"] = len(attachments)
             await recount_and_prune_attachments_async(conn, affected_attachment_ids)
             timings["attachments"] = _time.perf_counter() - t0
+
+        # Rebind any orphaned marks/annotations whose identity_key matches the
+        # freshly-written conversation. See #1114 — identity_key survives reset
+        # because conversation_id is deterministic across reimport.
+        t0 = _time.perf_counter()
+        await repoint_user_state_by_identity(conn, conversation.conversation_id)
+        timings["repoint_user_state"] = _time.perf_counter() - t0
 
     total = _time.perf_counter() - t_start
     if total > 2.0:

--- a/polylogue/storage/sqlite/queries/conversations_identity.py
+++ b/polylogue/storage/sqlite/queries/conversations_identity.py
@@ -179,6 +179,26 @@ async def list_tags(conn: aiosqlite.Connection, *, provider: str | None = None) 
 # ---------------------------------------------------------------------------
 
 
+def user_state_identity_key(
+    *,
+    target_type: str,
+    conversation_id: str,
+    message_id: str | None,
+) -> str:
+    """Return the stable identity key used to repoint marks/annotations.
+
+    Matches ``TargetRefPayload`` (``polylogue/surfaces/payloads.py``) so that
+    surface-level and storage-level identity tokens are wire-compatible. The
+    underlying provider IDs are deterministic across reimport, so identity_key
+    survives reset+reingest of the same logical conversation (#1114).
+    """
+    if target_type == "message":
+        if not message_id:
+            raise ValueError("message_id is required for target_type='message'")
+        return f"message:{conversation_id}:{message_id}"
+    return f"conversation:{conversation_id}"
+
+
 async def add_mark(
     conn: aiosqlite.Connection,
     *,
@@ -190,19 +210,25 @@ async def add_mark(
     message_id: str | None = None,
 ) -> bool:
     """Add a mark to a target. Returns True if newly inserted."""
+    identity_key = user_state_identity_key(
+        target_type=target_type,
+        conversation_id=conversation_id,
+        message_id=message_id,
+    )
     cursor = await conn.execute(
         """
         INSERT OR IGNORE INTO user_marks (
             target_type,
             target_id,
+            identity_key,
             conversation_id,
             message_id,
             mark_type,
             created_at
         )
-        VALUES (?, ?, ?, ?, ?, ?)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
         """,
-        (target_type, target_id, conversation_id, message_id, mark_type, created_at),
+        (target_type, target_id, identity_key, conversation_id, message_id, mark_type, created_at),
     )
     await conn.commit()
     return cursor.rowcount > 0
@@ -264,6 +290,88 @@ async def list_marks(
     ]
 
 
+async def repoint_user_state_by_identity(
+    conn: aiosqlite.Connection,
+    conversation_id: str,
+) -> tuple[int, int]:
+    """Rebind orphan marks/annotations to a (re-)imported conversation.
+
+    Implements the read side of #1114: identity_key survives conversation row
+    deletion (FK cascade is ``SET NULL``), and once a logically identical
+    conversation is re-imported its ``conversation_id``/``message_id`` are
+    deterministic, so we can restore the resolved pointers by matching the
+    stored identity_key against the current archive state.
+
+    Returns ``(marks_repointed, annotations_repointed)``.
+    """
+    conv_key = f"conversation:{conversation_id}"
+    msg_key_prefix = f"message:{conversation_id}:"
+
+    # Conversation-target rebinds (target_type='conversation').
+    cursor = await conn.execute(
+        """
+        UPDATE user_marks
+        SET conversation_id = ?
+        WHERE identity_key = ?
+          AND target_type = 'conversation'
+          AND (conversation_id IS NULL OR conversation_id != ?)
+        """,
+        (conversation_id, conv_key, conversation_id),
+    )
+    marks_conv = cursor.rowcount or 0
+    cursor = await conn.execute(
+        """
+        UPDATE user_annotations
+        SET conversation_id = ?
+        WHERE identity_key = ?
+          AND target_type = 'conversation'
+          AND (conversation_id IS NULL OR conversation_id != ?)
+        """,
+        (conversation_id, conv_key, conversation_id),
+    )
+    ann_conv = cursor.rowcount or 0
+
+    # Message-target rebinds: only repoint rows whose message_id is still a
+    # member of the freshly written conversation. Messages that disappeared
+    # from the reimported conversation stay orphaned (NULL conversation_id /
+    # message_id) so callers can distinguish "rebound" from "orphaned by
+    # message drift" without scanning the full annotation table.
+    cursor = await conn.execute(
+        """
+        UPDATE user_marks
+        SET conversation_id = ?, message_id = target_id
+        WHERE identity_key LIKE ?
+          AND target_type = 'message'
+          AND EXISTS (
+              SELECT 1 FROM messages m
+              WHERE m.message_id = user_marks.target_id
+                AND m.conversation_id = ?
+          )
+          AND (conversation_id IS NULL OR message_id IS NULL)
+        """,
+        (conversation_id, f"{msg_key_prefix}%", conversation_id),
+    )
+    marks_msg = cursor.rowcount or 0
+    cursor = await conn.execute(
+        """
+        UPDATE user_annotations
+        SET conversation_id = ?, message_id = target_id
+        WHERE identity_key LIKE ?
+          AND target_type = 'message'
+          AND EXISTS (
+              SELECT 1 FROM messages m
+              WHERE m.message_id = user_annotations.target_id
+                AND m.conversation_id = ?
+          )
+          AND (conversation_id IS NULL OR message_id IS NULL)
+        """,
+        (conversation_id, f"{msg_key_prefix}%", conversation_id),
+    )
+    ann_msg = cursor.rowcount or 0
+
+    return marks_conv + marks_msg, ann_conv + ann_msg
+
+
 # ---------------------------------------------------------------------------
 # User annotations
 # ---------------------------------------------------------------------------
@@ -281,6 +389,11 @@ async def save_annotation(
     message_id: str | None = None,
 ) -> bool:
     """Insert or update an annotation. Returns True if inserted."""
+    identity_key = user_state_identity_key(
+        target_type=target_type,
+        conversation_id=conversation_id,
+        message_id=message_id,
+    )
     cursor = await conn.execute("SELECT 1 FROM user_annotations WHERE annotation_id = ?", (annotation_id,))
     exists = await cursor.fetchone() is not None
     await conn.execute(
@@ -289,22 +402,24 @@ async def save_annotation(
             annotation_id,
             target_type,
             target_id,
+            identity_key,
             conversation_id,
             message_id,
             note_text,
             created_at,
             updated_at
         )
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(annotation_id) DO UPDATE SET
             target_type = excluded.target_type,
             target_id = excluded.target_id,
+            identity_key = excluded.identity_key,
             conversation_id = excluded.conversation_id,
             message_id = excluded.message_id,
             note_text = excluded.note_text,
             updated_at = excluded.updated_at
         """,
-        (annotation_id, target_type, target_id, conversation_id, message_id, note_text, now, now),
+        (annotation_id, target_type, target_id, identity_key, conversation_id, message_id, note_text, now, now),
     )
     await conn.commit()
     return not exists
@@ -642,6 +757,7 @@ __all__ = [
     "list_views",
     "list_workspaces",
     "remove_mark",
+    "repoint_user_state_by_identity",
     "save_annotation",
     "resolve_id",
     "save_recall_pack",
@@ -649,4 +765,5 @@ __all__ = [
     "save_workspace",
     "set_metadata",
     "update_metadata_raw",
+    "user_state_identity_key",
 ]

--- a/polylogue/storage/sqlite/schema.py
+++ b/polylogue/storage/sqlite/schema.py
@@ -177,6 +177,9 @@ def _ensure_schema(conn: sqlite3.Connection) -> None:
             "upgrade_v11_to_v12",
             "upgrade_v12_to_v13",
             "upgrade_v13_to_v14",
+            "upgrade_v14_to_v15",
+            "upgrade_v15_to_v16",
+            "upgrade_v16_to_v17",
         }
         and decision.extension_plan is not None
     ):
@@ -230,6 +233,9 @@ async def ensure_schema_async(conn: aiosqlite.Connection) -> None:
             "upgrade_v11_to_v12",
             "upgrade_v12_to_v13",
             "upgrade_v13_to_v14",
+            "upgrade_v14_to_v15",
+            "upgrade_v15_to_v16",
+            "upgrade_v16_to_v17",
         }
         and decision.extension_plan is not None
     ):

--- a/polylogue/storage/sqlite/schema_bootstrap.py
+++ b/polylogue/storage/sqlite/schema_bootstrap.py
@@ -96,6 +96,9 @@ class SchemaBootstrapDecision:
         "upgrade_v11_to_v12",
         "upgrade_v12_to_v13",
         "upgrade_v13_to_v14",
+        "upgrade_v14_to_v15",
+        "upgrade_v15_to_v16",
+        "upgrade_v16_to_v17",
         "version_mismatch",
     ]
     extension_plan: SchemaExtensionPlan | None = None
@@ -1024,7 +1027,12 @@ def build_v11_to_v12_upgrade_plan(snapshot: SchemaSnapshot) -> SchemaExtensionPl
 
 
 def build_v12_to_v13_upgrade_plan(snapshot: SchemaSnapshot) -> SchemaExtensionPlan:
-    """Promote user marks to target-aware rows and add annotations."""
+    """Promote user marks to target-aware rows and add annotations.
+
+    Includes identity_key (#1114) in the INSERT shape since the canonical
+    ``USER_MARKS_DDL`` carries identity_key NOT NULL from v16 onward; v15->v16
+    will simply observe the column already present and skip its rebuild step.
+    """
 
     from polylogue.storage.sqlite.schema_ddl_archive import USER_ANNOTATIONS_DDL, USER_MARKS_DDL
 
@@ -1038,6 +1046,7 @@ def build_v12_to_v13_upgrade_plan(snapshot: SchemaSnapshot) -> SchemaExtensionPl
                 INSERT OR IGNORE INTO user_marks (
                     target_type,
                     target_id,
+                    identity_key,
                     conversation_id,
                     message_id,
                     mark_type,
@@ -1046,6 +1055,7 @@ def build_v12_to_v13_upgrade_plan(snapshot: SchemaSnapshot) -> SchemaExtensionPl
                 SELECT
                     'conversation',
                     conversation_id,
+                    'conversation:' || conversation_id,
                     conversation_id,
                     NULL,
                     mark_type,
@@ -1073,6 +1083,175 @@ def build_v13_to_v14_upgrade_plan(snapshot: SchemaSnapshot) -> SchemaExtensionPl
     if not snapshot.has_table("reader_workspaces"):
         statements = _split_ddl_into_statements(READER_WORKSPACES_DDL)
     return SchemaExtensionPlan(statements=statements, scripts=())
+
+
+def build_v14_to_v15_upgrade_plan(snapshot: SchemaSnapshot) -> SchemaExtensionPlan:
+    """Add user_corrections table for the learning-feedback loop (#1131)."""
+
+    from polylogue.storage.sqlite.schema_ddl_archive import USER_CORRECTIONS_DDL
+
+    statements: tuple[str, ...] = ()
+    if not snapshot.has_table("user_corrections"):
+        statements = _split_ddl_into_statements(USER_CORRECTIONS_DDL)
+    return SchemaExtensionPlan(statements=statements, scripts=())
+
+
+# ---------------------------------------------------------------------------
+# v16 -> v17: identity-preserving marks/annotations across reimport (#1114)
+# ---------------------------------------------------------------------------
+# v16 (#1113) cascade-deleted marks/annotations whenever the parent conversation
+# row was removed, which violated the #867 acceptance criterion that user
+# metadata survive reimport. v17 rebuilds both tables so that:
+#   - identity_key (the stable surface token: ``conversation:{cid}`` or
+#     ``message:{cid}:{mid}``) becomes a first-class column,
+#   - FK cascades become ``ON DELETE SET NULL`` so rows survive hard delete,
+#   - the legacy CHECK constraints that tied target_id to conversation_id are
+#     dropped (target_id is now the stable identity, conversation_id is a
+#     resolved pointer that may be NULL between delete and reimport).
+# The expanded target_type CHECK list shipped in #1113 (eight kinds) is
+# preserved. Rebuild is in-place via the SQLite copy-and-swap pattern.
+_V16_TO_V17_USER_MARKS_REBUILD_SQL = """
+        CREATE TABLE user_marks_v17 (
+            target_type     TEXT NOT NULL CHECK (target_type IN (
+                'conversation', 'message', 'session', 'work_event',
+                'thread', 'content_block', 'attachment', 'paste_span'
+            )),
+            target_id       TEXT NOT NULL,
+            identity_key    TEXT NOT NULL,
+            conversation_id TEXT REFERENCES conversations(conversation_id) ON DELETE SET NULL,
+            message_id      TEXT REFERENCES messages(message_id) ON DELETE SET NULL,
+            mark_type       TEXT NOT NULL CHECK (mark_type IN ('star', 'pin', 'archive')),
+            created_at      TEXT NOT NULL,
+            PRIMARY KEY (target_type, target_id, mark_type)
+        )
+"""
+
+_V16_TO_V17_USER_MARKS_BACKFILL_SQL = """
+        INSERT INTO user_marks_v17 (
+            target_type, target_id, identity_key, conversation_id, message_id, mark_type, created_at
+        )
+        SELECT
+            target_type,
+            target_id,
+            CASE
+                WHEN target_type = 'message'
+                    THEN 'message:' || conversation_id || ':' || target_id
+                WHEN target_type = 'conversation'
+                    THEN 'conversation:' || conversation_id
+                ELSE target_type || ':' || conversation_id || ':' || target_id
+            END AS identity_key,
+            conversation_id,
+            message_id,
+            mark_type,
+            created_at
+        FROM user_marks
+"""
+
+_V16_TO_V17_USER_ANNOTATIONS_REBUILD_SQL = """
+        CREATE TABLE user_annotations_v17 (
+            annotation_id   TEXT PRIMARY KEY,
+            target_type     TEXT NOT NULL CHECK (target_type IN (
+                'conversation', 'message', 'session', 'work_event',
+                'thread', 'content_block', 'attachment', 'paste_span'
+            )),
+            target_id       TEXT NOT NULL,
+            identity_key    TEXT NOT NULL,
+            conversation_id TEXT REFERENCES conversations(conversation_id) ON DELETE SET NULL,
+            message_id      TEXT REFERENCES messages(message_id) ON DELETE SET NULL,
+            note_text       TEXT NOT NULL,
+            created_at      TEXT NOT NULL,
+            updated_at      TEXT NOT NULL
+        )
+"""
+
+_V16_TO_V17_USER_ANNOTATIONS_BACKFILL_SQL = """
+        INSERT INTO user_annotations_v17 (
+            annotation_id, target_type, target_id, identity_key,
+            conversation_id, message_id, note_text, created_at, updated_at
+        )
+        SELECT
+            annotation_id,
+            target_type,
+            target_id,
+            CASE
+                WHEN target_type = 'message'
+                    THEN 'message:' || conversation_id || ':' || target_id
+                WHEN target_type = 'conversation'
+                    THEN 'conversation:' || conversation_id
+                ELSE target_type || ':' || conversation_id || ':' || target_id
+            END AS identity_key,
+            conversation_id,
+            message_id,
+            note_text,
+            created_at,
+            updated_at
+        FROM user_annotations
+"""
+
+
+def build_v16_to_v17_upgrade_plan(snapshot: SchemaSnapshot) -> SchemaExtensionPlan:
+    """Rebuild user_marks/user_annotations with identity_key and SET NULL FKs (#1114)."""
+
+    from polylogue.storage.sqlite.schema_ddl_archive import USER_ANNOTATIONS_DDL, USER_MARKS_DDL
+
+    statements: list[str] = []
+
+    has_marks = snapshot.has_table("user_marks")
+    marks_columns = snapshot.columns("user_marks") if has_marks else frozenset()
+    marks_needs_rebuild = has_marks and "identity_key" not in marks_columns
+    if marks_needs_rebuild:
+        statements.extend(
+            [
+                _V16_TO_V17_USER_MARKS_REBUILD_SQL,
+                _V16_TO_V17_USER_MARKS_BACKFILL_SQL,
+                "DROP TABLE user_marks",
+                "ALTER TABLE user_marks_v17 RENAME TO user_marks",
+                "CREATE INDEX IF NOT EXISTS idx_user_marks_type ON user_marks(mark_type)",
+                "CREATE INDEX IF NOT EXISTS idx_user_marks_conversation ON user_marks(conversation_id)",
+                "CREATE INDEX IF NOT EXISTS idx_user_marks_message ON user_marks(message_id)",
+                "CREATE INDEX IF NOT EXISTS idx_user_marks_identity_key ON user_marks(identity_key)",
+            ]
+        )
+    elif not has_marks:
+        statements.extend(_split_ddl_into_statements(USER_MARKS_DDL))
+
+    has_ann = snapshot.has_table("user_annotations")
+    ann_columns = snapshot.columns("user_annotations") if has_ann else frozenset()
+    ann_needs_rebuild = has_ann and "identity_key" not in ann_columns
+    if ann_needs_rebuild:
+        statements.extend(
+            [
+                _V16_TO_V17_USER_ANNOTATIONS_REBUILD_SQL,
+                _V16_TO_V17_USER_ANNOTATIONS_BACKFILL_SQL,
+                "DROP TABLE user_annotations",
+                "ALTER TABLE user_annotations_v17 RENAME TO user_annotations",
+                "CREATE INDEX IF NOT EXISTS idx_user_annotations_target ON user_annotations(target_type, target_id)",
+                "CREATE INDEX IF NOT EXISTS idx_user_annotations_conversation ON user_annotations(conversation_id)",
+                "CREATE INDEX IF NOT EXISTS idx_user_annotations_message ON user_annotations(message_id)",
+                "CREATE INDEX IF NOT EXISTS idx_user_annotations_identity_key ON user_annotations(identity_key)",
+            ]
+        )
+    elif not has_ann:
+        statements.extend(_split_ddl_into_statements(USER_ANNOTATIONS_DDL))
+
+    return SchemaExtensionPlan(statements=tuple(statements), scripts=())
+
+
+def build_v15_to_v16_upgrade_plan(snapshot: SchemaSnapshot) -> SchemaExtensionPlan:
+    """Expand user_state target_type CHECK to admit insight kinds (#1113).
+
+    v16 was a fresh-first bump in #1113 (no upgrade chain was added there).
+    This plan exists so the v15 -> current chain can land an archive at v16
+    via the same in-place table rebuild that v16 -> v17 uses; the resulting
+    intermediate state is then carried into v17 by build_v16_to_v17_upgrade_plan
+    chained from _upgrade_tail_statements.
+    """
+
+    # Re-uses the v16->v17 rebuild because the target schema (expanded CHECK,
+    # identity_key column, SET NULL FKs) is reached as part of the same
+    # operation. Returning an empty plan would leave v15 archives stuck at the
+    # v15 CHECK shape, which #1113 explicitly tightened.
+    return build_v16_to_v17_upgrade_plan(snapshot)
 
 
 _DETECTION_WARNINGS_COLUMN_DDL = "ALTER TABLE raw_conversations ADD COLUMN detection_warnings TEXT"
@@ -1105,13 +1284,21 @@ def _upgrade_tail_statements(snapshot: SchemaSnapshot, *, from_version: int) -> 
         statements = (*statements, *build_v12_to_v13_upgrade_plan(snapshot).statements)
     if from_version < 14 <= SCHEMA_VERSION:
         statements = (*statements, *build_v13_to_v14_upgrade_plan(snapshot).statements)
+    if from_version < 15 <= SCHEMA_VERSION:
+        statements = (*statements, *build_v14_to_v15_upgrade_plan(snapshot).statements)
+    if from_version < 16 <= SCHEMA_VERSION:
+        statements = (*statements, *build_v15_to_v16_upgrade_plan(snapshot).statements)
+    # v15->v16 already rebuilds the user-state tables to the v17 shape, so
+    # skip a redundant rebuild when chaining through the v15 entry point.
+    if from_version >= 16 and from_version < 17 <= SCHEMA_VERSION:
+        statements = (*statements, *build_v16_to_v17_upgrade_plan(snapshot).statements)
     return statements
 
 
 def _has_version_upgrade_path(snapshot: SchemaSnapshot) -> bool:
     """Return True when a version-specific upgrade path exists for this snapshot."""
     v = snapshot.current_version
-    return (v == 2 and snapshot.has_table("messages")) or v in (3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13)
+    return (v == 2 and snapshot.has_table("messages")) or v in (3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16)
 
 
 def decide_schema_bootstrap(snapshot: SchemaSnapshot) -> SchemaBootstrapDecision:
@@ -1244,9 +1431,40 @@ def decide_schema_bootstrap(snapshot: SchemaSnapshot) -> SchemaBootstrapDecision
         )
 
     if snapshot.current_version == 13 and SCHEMA_VERSION >= 14:
+        plan = build_v13_to_v14_upgrade_plan(snapshot)
+        extra_stmts = _upgrade_tail_statements(snapshot, from_version=14)
+        if extra_stmts:
+            plan = SchemaExtensionPlan(statements=(*plan.statements, *extra_stmts), scripts=())
         return SchemaBootstrapDecision(
             action="upgrade_v13_to_v14",
-            extension_plan=build_v13_to_v14_upgrade_plan(snapshot),
+            extension_plan=plan,
+            current_version=snapshot.current_version,
+        )
+
+    if snapshot.current_version == 14 and SCHEMA_VERSION >= 15:
+        plan = build_v14_to_v15_upgrade_plan(snapshot)
+        extra_stmts = _upgrade_tail_statements(snapshot, from_version=15)
+        if extra_stmts:
+            plan = SchemaExtensionPlan(statements=(*plan.statements, *extra_stmts), scripts=())
+        return SchemaBootstrapDecision(
+            action="upgrade_v14_to_v15",
+            extension_plan=plan,
+            current_version=snapshot.current_version,
+        )
+
+    if snapshot.current_version == 15 and SCHEMA_VERSION >= 16:
+        # v15 -> v16 rebuilds user-state tables. When chaining onward to v17 the
+        # rebuild already lands the v17 shape, so do not append v16->v17.
+        return SchemaBootstrapDecision(
+            action="upgrade_v15_to_v16",
+            extension_plan=build_v15_to_v16_upgrade_plan(snapshot),
+            current_version=snapshot.current_version,
+        )
+
+    if snapshot.current_version == 16 and SCHEMA_VERSION >= 17:
+        return SchemaBootstrapDecision(
+            action="upgrade_v16_to_v17",
+            extension_plan=build_v16_to_v17_upgrade_plan(snapshot),
             current_version=snapshot.current_version,
         )
 
@@ -1403,6 +1621,9 @@ __all__ = [
     "build_v11_to_v12_upgrade_plan",
     "build_v12_to_v13_upgrade_plan",
     "build_v13_to_v14_upgrade_plan",
+    "build_v14_to_v15_upgrade_plan",
+    "build_v15_to_v16_upgrade_plan",
+    "build_v16_to_v17_upgrade_plan",
     "capture_schema_snapshot",
     "capture_schema_snapshot_async",
     "decide_schema_bootstrap",

--- a/polylogue/storage/sqlite/schema_ddl.py
+++ b/polylogue/storage/sqlite/schema_ddl.py
@@ -66,7 +66,7 @@ from polylogue.storage.sqlite.schema_ddl_provider_events import (
     PROVIDER_EVENT_DDL as _PROVIDER_EVENT_DDL,
 )
 
-SCHEMA_VERSION = 16  # 2026-05-17: user-state targets admit insight kinds (#1113)
+SCHEMA_VERSION = 17  # 2026-05-17: identity-preserving marks/annotations across reimport (#1114, builds on #1113 v16)
 
 
 # Complete target schema applied to fresh databases.

--- a/polylogue/storage/sqlite/schema_ddl_archive.py
+++ b/polylogue/storage/sqlite/schema_ddl_archive.py
@@ -333,6 +333,13 @@ BLOB_LEASE_DDL = """
 # User state — target-aware marks and annotations
 # ---------------------------------------------------------------------------
 
+# NOTE (#1114): ``user_marks`` and ``user_annotations`` survive the conversation
+# row's lifecycle.  ``identity_key`` is the stable surface identifier
+# (``conversation:{cid}`` or ``message:{cid}:{mid}``) used to repoint the
+# resolved ``conversation_id``/``message_id`` columns when a logically identical
+# conversation is re-imported after delete/reset.  Conversation row FKs use
+# ``ON DELETE SET NULL`` so marks/annotations persist across hard delete and are
+# rebound by ``repoint_user_state_by_identity`` once the conversation reappears.
 USER_MARKS_DDL = """
         CREATE TABLE IF NOT EXISTS user_marks (
             target_type     TEXT NOT NULL CHECK (target_type IN (
@@ -340,20 +347,12 @@ USER_MARKS_DDL = """
                 'thread', 'content_block', 'attachment', 'paste_span'
             )),
             target_id       TEXT NOT NULL,
-            conversation_id TEXT NOT NULL REFERENCES conversations(conversation_id) ON DELETE CASCADE,
-            message_id      TEXT REFERENCES messages(message_id) ON DELETE CASCADE,
+            identity_key    TEXT NOT NULL,
+            conversation_id TEXT REFERENCES conversations(conversation_id) ON DELETE SET NULL,
+            message_id      TEXT REFERENCES messages(message_id) ON DELETE SET NULL,
             mark_type       TEXT NOT NULL CHECK (mark_type IN ('star', 'pin', 'archive')),
             created_at      TEXT NOT NULL,
-            PRIMARY KEY (target_type, target_id, mark_type),
-            CHECK (
-                (target_type = 'conversation' AND target_id = conversation_id AND message_id IS NULL)
-                OR
-                (target_type = 'message' AND message_id IS NOT NULL AND target_id = message_id)
-                OR
-                (target_type = 'content_block' AND message_id IS NOT NULL)
-                OR
-                (target_type IN ('session', 'work_event', 'thread', 'attachment', 'paste_span'))
-            )
+            PRIMARY KEY (target_type, target_id, mark_type)
         );
 
         CREATE INDEX IF NOT EXISTS idx_user_marks_type
@@ -364,6 +363,9 @@ USER_MARKS_DDL = """
 
         CREATE INDEX IF NOT EXISTS idx_user_marks_message
             ON user_marks(message_id);
+
+        CREATE INDEX IF NOT EXISTS idx_user_marks_identity_key
+            ON user_marks(identity_key);
 """
 
 USER_ANNOTATIONS_DDL = """
@@ -374,20 +376,12 @@ USER_ANNOTATIONS_DDL = """
                 'thread', 'content_block', 'attachment', 'paste_span'
             )),
             target_id       TEXT NOT NULL,
-            conversation_id TEXT NOT NULL REFERENCES conversations(conversation_id) ON DELETE CASCADE,
-            message_id      TEXT REFERENCES messages(message_id) ON DELETE CASCADE,
+            identity_key    TEXT NOT NULL,
+            conversation_id TEXT REFERENCES conversations(conversation_id) ON DELETE SET NULL,
+            message_id      TEXT REFERENCES messages(message_id) ON DELETE SET NULL,
             note_text       TEXT NOT NULL,
             created_at      TEXT NOT NULL,
-            updated_at      TEXT NOT NULL,
-            CHECK (
-                (target_type = 'conversation' AND target_id = conversation_id AND message_id IS NULL)
-                OR
-                (target_type = 'message' AND message_id IS NOT NULL AND target_id = message_id)
-                OR
-                (target_type = 'content_block' AND message_id IS NOT NULL)
-                OR
-                (target_type IN ('session', 'work_event', 'thread', 'attachment', 'paste_span'))
-            )
+            updated_at      TEXT NOT NULL
         );
 
         CREATE INDEX IF NOT EXISTS idx_user_annotations_target
@@ -398,6 +392,9 @@ USER_ANNOTATIONS_DDL = """
 
         CREATE INDEX IF NOT EXISTS idx_user_annotations_message
             ON user_annotations(message_id);
+
+        CREATE INDEX IF NOT EXISTS idx_user_annotations_identity_key
+            ON user_annotations(identity_key);
 """
 
 # ---------------------------------------------------------------------------

--- a/tests/infra/storage_records.py
+++ b/tests/infra/storage_records.py
@@ -603,10 +603,54 @@ def store_records(
         # parity test exercising those filters would observe an empty
         # result set on every surface.
         _upsert_conversation_stats_sync(db_conn, conversation=conversation, messages=messages)
+        # Mirror save_via_backend's identity-preserving repoint pass (#1114) so
+        # tests that exercise reset/reimport via the sync builder see the same
+        # rebinding behaviour as production async ingest.
+        _repoint_user_state_by_identity_sync(db_conn, conversation.conversation_id)
         # Commit inside lock to ensure atomic transaction boundaries
         db_conn.commit()
 
     return counts
+
+
+def _repoint_user_state_by_identity_sync(conn: sqlite3.Connection, conversation_id: str) -> None:
+    """Sync mirror of ``repoint_user_state_by_identity`` for #1114 test parity."""
+    conv_key = f"conversation:{conversation_id}"
+    msg_key_prefix = f"message:{conversation_id}:"
+    conn.execute(
+        """
+        UPDATE user_marks SET conversation_id = ?
+        WHERE identity_key = ? AND target_type = 'conversation'
+          AND (conversation_id IS NULL OR conversation_id != ?)
+        """,
+        (conversation_id, conv_key, conversation_id),
+    )
+    conn.execute(
+        """
+        UPDATE user_annotations SET conversation_id = ?
+        WHERE identity_key = ? AND target_type = 'conversation'
+          AND (conversation_id IS NULL OR conversation_id != ?)
+        """,
+        (conversation_id, conv_key, conversation_id),
+    )
+    conn.execute(
+        """
+        UPDATE user_marks SET conversation_id = ?, message_id = target_id
+        WHERE identity_key LIKE ? AND target_type = 'message'
+          AND EXISTS (SELECT 1 FROM messages m WHERE m.message_id = user_marks.target_id AND m.conversation_id = ?)
+          AND (conversation_id IS NULL OR message_id IS NULL)
+        """,
+        (conversation_id, f"{msg_key_prefix}%", conversation_id),
+    )
+    conn.execute(
+        """
+        UPDATE user_annotations SET conversation_id = ?, message_id = target_id
+        WHERE identity_key LIKE ? AND target_type = 'message'
+          AND EXISTS (SELECT 1 FROM messages m WHERE m.message_id = user_annotations.target_id AND m.conversation_id = ?)
+          AND (conversation_id IS NULL OR message_id IS NULL)
+        """,
+        (conversation_id, f"{msg_key_prefix}%", conversation_id),
+    )
 
 
 def _upsert_conversation_stats_sync(

--- a/tests/unit/storage/test_marks_identity_preserving.py
+++ b/tests/unit/storage/test_marks_identity_preserving.py
@@ -1,0 +1,246 @@
+"""Identity-preserving marks and annotations across reimport (#1114).
+
+These tests pin the surface contract: user marks and annotations live outside
+the conversation row's lifecycle, keyed by the stable identity key
+(``conversation:{cid}`` and ``message:{cid}:{mid}``), and are rebound to the
+re-imported conversation/message when ingest puts the rows back.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import aiosqlite
+import pytest
+
+from polylogue.api import Polylogue
+from polylogue.storage.sqlite.queries.conversations_identity import (
+    repoint_user_state_by_identity,
+    user_state_identity_key,
+)
+from tests.infra.storage_records import ConversationBuilder, db_setup
+
+
+def _mark_row(db_path: Path) -> tuple[str, str | None, str | None]:
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT identity_key, conversation_id, message_id FROM user_marks WHERE mark_type = 'star'"
+        ).fetchone()
+    assert row is not None
+    return row[0], row[1], row[2]
+
+
+def _annotation_row(db_path: Path, annotation_id: str) -> tuple[str, str | None, str | None]:
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT identity_key, conversation_id, message_id FROM user_annotations WHERE annotation_id = ?",
+            (annotation_id,),
+        ).fetchone()
+    assert row is not None
+    return row[0], row[1], row[2]
+
+
+def test_user_state_identity_key_matches_payload_convention() -> None:
+    """``identity_key`` storage matches the ``TargetRefPayload`` surface token."""
+    assert (
+        user_state_identity_key(
+            target_type="conversation",
+            conversation_id="chatgpt:1",
+            message_id=None,
+        )
+        == "conversation:chatgpt:1"
+    )
+    assert (
+        user_state_identity_key(
+            target_type="message",
+            conversation_id="chatgpt:1",
+            message_id="chatgpt:1:m1",
+        )
+        == "message:chatgpt:1:chatgpt:1:m1"
+    )
+
+
+def test_user_state_identity_key_rejects_message_without_message_id() -> None:
+    with pytest.raises(ValueError, match="message_id is required"):
+        user_state_identity_key(target_type="message", conversation_id="c", message_id=None)
+
+
+@pytest.mark.asyncio
+async def test_add_mark_records_identity_key(workspace_env: dict[str, Path]) -> None:
+    db_path = db_setup(workspace_env)
+    ConversationBuilder(db_path, "conv-id").provider("claude-code").add_message(
+        message_id="msg-id",
+        text="hello",
+    ).save()
+
+    async with Polylogue(db_path=db_path, archive_root=workspace_env["archive_root"]) as poly:
+        assert await poly.add_mark("conv-id", "star") is True
+
+    identity_key, conv_id, msg_id = _mark_row(db_path)
+    assert identity_key == "conversation:conv-id"
+    assert conv_id == "conv-id"
+    assert msg_id is None
+
+
+@pytest.mark.asyncio
+async def test_marks_survive_conversation_delete_and_repoint_on_reimport(
+    workspace_env: dict[str, Path],
+) -> None:
+    """The core #1114 acceptance: mark survives hard delete and rebinds on reimport."""
+    db_path = db_setup(workspace_env)
+    ConversationBuilder(db_path, "conv-id").provider("claude-code").add_message(
+        message_id="msg-id",
+        text="hello",
+    ).save()
+
+    async with Polylogue(db_path=db_path, archive_root=workspace_env["archive_root"]) as poly:
+        assert await poly.add_mark("conv-id", "star") is True
+        assert await poly.save_annotation("ann-1", "conv-id", "important") is True
+
+        # Hard-delete the conversation (FK SET NULL must keep marks alive).
+        assert await poly.delete_conversation("conv-id") is True
+
+        marks_after_delete = await poly.list_marks(conversation_id=None, mark_type="star")
+        annotations_after_delete = await poly.list_annotations()
+        assert {row["target_id"] for row in marks_after_delete} == {"conv-id"}
+        assert {row["annotation_id"] for row in annotations_after_delete} == {"ann-1"}
+
+    identity_key, conv_id, _ = _mark_row(db_path)
+    assert identity_key == "conversation:conv-id"
+    assert conv_id is None, "Hard delete should null the resolved pointer until reimport"
+
+    # Reimport the same logical conversation (deterministic id from provider).
+    ConversationBuilder(db_path, "conv-id").provider("claude-code").add_message(
+        message_id="msg-id",
+        text="hello",
+    ).save()
+
+    identity_key, conv_id, _ = _mark_row(db_path)
+    assert identity_key == "conversation:conv-id"
+    assert conv_id == "conv-id", "Reimport must repoint the resolved conversation_id"
+
+    annotation_id_key, annotation_conv_id, _ = _annotation_row(db_path, "ann-1")
+    assert annotation_id_key == "conversation:conv-id"
+    assert annotation_conv_id == "conv-id"
+
+
+@pytest.mark.asyncio
+async def test_message_target_marks_repoint_on_reimport(workspace_env: dict[str, Path]) -> None:
+    db_path = db_setup(workspace_env)
+    ConversationBuilder(db_path, "conv-id").provider("claude-code").add_message(
+        message_id="msg-id",
+        text="hello",
+    ).save()
+
+    async with Polylogue(db_path=db_path, archive_root=workspace_env["archive_root"]) as poly:
+        assert (
+            await poly.add_mark(
+                "conv-id",
+                "pin",
+                target_type="message",
+                message_id="msg-id",
+            )
+            is True
+        )
+        assert await poly.delete_conversation("conv-id") is True
+
+    # Reimport the same conversation with the same message.
+    ConversationBuilder(db_path, "conv-id").provider("claude-code").add_message(
+        message_id="msg-id",
+        text="hello",
+    ).save()
+
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT identity_key, conversation_id, message_id FROM user_marks WHERE mark_type='pin'"
+        ).fetchone()
+    assert row == ("message:conv-id:msg-id", "conv-id", "msg-id")
+
+
+@pytest.mark.asyncio
+async def test_repoint_leaves_orphan_when_message_disappears_on_reimport(
+    workspace_env: dict[str, Path],
+) -> None:
+    """Message-target marks whose target disappears stay orphaned (NULL pointers)."""
+    db_path = db_setup(workspace_env)
+    ConversationBuilder(db_path, "conv-id").provider("claude-code").add_message(
+        message_id="msg-id",
+        text="hello",
+    ).save()
+
+    async with Polylogue(db_path=db_path, archive_root=workspace_env["archive_root"]) as poly:
+        assert (
+            await poly.add_mark(
+                "conv-id",
+                "pin",
+                target_type="message",
+                message_id="msg-id",
+            )
+            is True
+        )
+        assert await poly.delete_conversation("conv-id") is True
+
+    # Reimport WITHOUT the original message — the message-level mark cannot be
+    # repointed and should remain orphaned (NULL conversation_id/message_id).
+    ConversationBuilder(db_path, "conv-id").provider("claude-code").add_message(
+        message_id="other-msg",
+        text="different",
+    ).save()
+
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT identity_key, conversation_id, message_id FROM user_marks WHERE mark_type='pin'"
+        ).fetchone()
+    assert row == ("message:conv-id:msg-id", None, None)
+
+
+@pytest.mark.asyncio
+async def test_repoint_is_idempotent(workspace_env: dict[str, Path]) -> None:
+    """Repeated repoint calls do not duplicate or re-touch already-bound rows."""
+    db_path = db_setup(workspace_env)
+    ConversationBuilder(db_path, "conv-id").provider("claude-code").add_message(
+        message_id="msg-id",
+        text="hello",
+    ).save()
+
+    async with Polylogue(db_path=db_path, archive_root=workspace_env["archive_root"]) as poly:
+        assert await poly.add_mark("conv-id", "star") is True
+
+    # Direct repoint call without a delete cycle — nothing should change.
+    async with aiosqlite.connect(db_path) as conn:
+        conn.row_factory = aiosqlite.Row
+        first = await repoint_user_state_by_identity(conn, "conv-id")
+        await conn.commit()
+        second = await repoint_user_state_by_identity(conn, "conv-id")
+        await conn.commit()
+    assert first == (0, 0)
+    assert second == (0, 0)
+
+
+@pytest.mark.asyncio
+async def test_user_state_does_not_affect_conversation_content_hash(
+    workspace_env: dict[str, Path],
+) -> None:
+    """User state remains outside the content-hash boundary post-#1114."""
+    db_path = db_setup(workspace_env)
+    ConversationBuilder(db_path, "conv-id").provider("claude-code").add_message(
+        message_id="msg-id",
+        text="hello",
+    ).save()
+
+    with sqlite3.connect(db_path) as conn:
+        before_hash = conn.execute(
+            "SELECT content_hash FROM conversations WHERE conversation_id = 'conv-id'"
+        ).fetchone()[0]
+
+    async with Polylogue(db_path=db_path, archive_root=workspace_env["archive_root"]) as poly:
+        assert await poly.add_mark("conv-id", "star") is True
+        assert await poly.save_annotation("ann-x", "conv-id", "note") is True
+
+    with sqlite3.connect(db_path) as conn:
+        after_hash = conn.execute(
+            "SELECT content_hash FROM conversations WHERE conversation_id = 'conv-id'"
+        ).fetchone()[0]
+
+    assert before_hash == after_hash

--- a/tests/visual/conftest.py
+++ b/tests/visual/conftest.py
@@ -237,17 +237,33 @@ def seed_reader_archive(
                 )
         conn.execute(
             """
-            INSERT INTO user_marks(target_type, target_id, conversation_id, message_id, mark_type, created_at)
-            VALUES (?, ?, ?, ?, ?, ?)
+            INSERT INTO user_marks(target_type, target_id, identity_key, conversation_id, message_id, mark_type, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
             """,
-            ("conversation", "reader-c1", "reader-c1", None, "star", "2026-05-15T00:00:00+00:00"),
+            (
+                "conversation",
+                "reader-c1",
+                "conversation:reader-c1",
+                "reader-c1",
+                None,
+                "star",
+                "2026-05-15T00:00:00+00:00",
+            ),
         )
         conn.execute(
             """
-            INSERT INTO user_marks(target_type, target_id, conversation_id, message_id, mark_type, created_at)
-            VALUES (?, ?, ?, ?, ?, ?)
+            INSERT INTO user_marks(target_type, target_id, identity_key, conversation_id, message_id, mark_type, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
             """,
-            ("conversation", "reader-c1", "reader-c1", None, "pin", "2026-05-15T00:01:00+00:00"),
+            (
+                "conversation",
+                "reader-c1",
+                "conversation:reader-c1",
+                "reader-c1",
+                None,
+                "pin",
+                "2026-05-15T00:01:00+00:00",
+            ),
         )
         conn.execute(
             "INSERT INTO saved_views(view_id, name, query_json, created_at) VALUES (?, ?, ?, ?)",
@@ -261,15 +277,16 @@ def seed_reader_archive(
         conn.execute(
             """
             INSERT INTO user_annotations(
-                annotation_id, target_type, target_id, conversation_id, message_id,
-                note_text, created_at, updated_at
+                annotation_id, target_type, target_id, identity_key,
+                conversation_id, message_id, note_text, created_at, updated_at
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 "reader-ann-c1",
                 "conversation",
                 "reader-c1",
+                "conversation:reader-c1",
                 "reader-c1",
                 None,
                 "This conversation anchors the MK3 reader evidence.",


### PR DESCRIPTION
## Summary

Marks and annotations now survive the conversation row's lifecycle. They
carry a stable ``identity_key`` (e.g. ``conversation:{cid}`` or
``message:{cid}:{mid}``) and the FK from ``user_marks``/``user_annotations``
to ``conversations``/``messages`` uses ``ON DELETE SET NULL`` instead of
cascade. After a logically identical conversation is re-imported, the
``save_via_backend`` path calls ``repoint_user_state_by_identity`` to rebind
the resolved ``conversation_id``/``message_id`` columns from the stored
identity_key.

## Problem

#867's acceptance criteria called for "user metadata survives reimport where
identity evidence is available." The substrate had two parallel systems:
``conversation_user_metadata`` (keyed by identity_key, survived soft delete)
and ``user_marks``/``user_annotations`` (keyed by conversation_id with
``ON DELETE CASCADE``, died on every hard delete). The latter violated the
acceptance criterion: any ``delete_conversation`` followed by re-import
lost marks and notes even though the conversation_id is deterministic
across reimport.

#1114 closes that gap.

## Solution

Storage substrate (option 1 from the issue's design — structurally clean
identity-key column, not a post-hoc reset hook):

- ``polylogue/storage/sqlite/schema_ddl_archive.py``: rebuild
  ``user_marks`` and ``user_annotations`` with ``identity_key TEXT NOT NULL``
  as a first-class column. FK to ``conversations``/``messages`` changes to
  ``ON DELETE SET NULL``, the legacy CHECK that tied ``target_id`` to
  ``conversation_id`` is dropped (``target_id`` is now the stable identity;
  ``conversation_id``/``message_id`` are resolved pointers that may be NULL
  between delete and reimport).
- ``polylogue/storage/sqlite/queries/conversations_identity.py``: new
  ``user_state_identity_key`` helper matches the ``TargetRefPayload`` surface
  convention exactly. ``add_mark`` and ``save_annotation`` compute and
  persist the identity_key on every write. New
  ``repoint_user_state_by_identity`` rebinds orphan rows after a freshly
  written conversation lands; message-target rows are only rebound when the
  message_id is still a member of the reimported conversation, so a
  conversation that loses a message keeps the mark orphaned (NULL pointers)
  rather than silently silently relinking to an unrelated row.
- ``polylogue/storage/repository/archive/writes/conversations.py``:
  ``save_via_backend`` calls ``repoint_user_state_by_identity`` once per
  upsert.

Schema migration:

- ``SCHEMA_VERSION`` bumped 16 -> 17. v16 -> v17 (``build_v16_to_v17_upgrade_plan``)
  rebuilds the two tables in place via the SQLite copy-and-swap pattern and
  backfills ``identity_key`` from the existing ``conversation_id``/``message_id``
  pair. The v15 -> v16 path (filling the gap left by #1113's fresh-first bump)
  reuses the same rebuild so v15 archives reach v17 in one step. The previously
  missing v14 -> v15 plan (#1131) is also added so the chain stays continuous.
- Tail-statement chain at ``_upgrade_tail_statements`` skips the redundant
  v16 -> v17 rebuild when an archive enters via the v15 path.

Tests (``tests/unit/storage/test_marks_identity_preserving.py``):

- ``test_user_state_identity_key_matches_payload_convention`` and
  ``...rejects_message_without_message_id``: identity_key shape contract.
- ``test_add_mark_records_identity_key``: storage round-trip.
- ``test_marks_survive_conversation_delete_and_repoint_on_reimport``: the
  core #1114 acceptance — mark survives hard delete (NULL pointer), gets
  rebound on reimport.
- ``test_message_target_marks_repoint_on_reimport``: message-level rebind.
- ``test_repoint_leaves_orphan_when_message_disappears_on_reimport``:
  message disappears -> mark stays orphaned (no spurious relink).
- ``test_repoint_is_idempotent``: repeated calls are no-ops.
- ``test_user_state_does_not_affect_conversation_content_hash``:
  content-hash exclusion regression for user state.

``tests/infra/storage_records.py`` mirrors the repoint in its sync
``store_records`` builder so tests exercising reset/reimport via the sync
fixture see the same rebinding behaviour as production async ingest.

## Verification

- ``devtools verify --quick`` -> ``"exit_code": 0`` (format + lint + mypy +
  render-all --check + manifest lints).
- ``python3 -m pytest tests/unit/storage/test_schema_upgrades.py tests/unit/storage/test_user_state_contracts.py tests/unit/storage/test_marks_identity_preserving.py tests/unit/storage/test_user_state_target_kinds.py``
  -> ``25 passed``.
- ``python3 -m pytest tests/unit/storage/ tests/unit/cli/test_user_state_command.py tests/unit/daemon/``
  -> ``1250 passed in 71.73s``.
- Manual v15 -> v17 and v16 -> v17 SQLite simulation: identity_key
  backfilled correctly for both conversation and message target rows.

Closes #1114
Ref #867