### PR TITLE
test(storage): pin blob-store + schema-policy invariants (#1185)

### DIFF
--- a/tests/unit/storage/test_blob_store_contracts.py
+++ b/tests/unit/storage/test_blob_store_contracts.py
@@ -1,0 +1,552 @@
+"""Contract suite pinning blob-store invariants from docs/internals.md.
+
+These tests pin the **documented contract** of the content-addressed blob
+store and the GC concurrency model, distinct from the happy-path CRUD
+coverage in ``test_blob_store.py`` and the GC regression coverage in
+``test_blob_gc.py``.
+
+The invariants pinned here are sourced from
+``docs/internals.md`` § "Blob Store Model" and § "GC concurrency model
+— leases plus snapshot reference check".  Each test references the
+invariant it pins in its docstring so a future doc/code drift is
+attributable.
+
+The blob store on disk (``polylogue/storage/blob_store.py``) is a pure
+content-addressed store with no notion of grouping. The grouping the
+docs refer to ("``link_group_key`` groups related blobs, e.g. all
+blobs belonging to one session") is implemented in
+``artifact_observations.link_group_key`` (see
+``polylogue/storage/sqlite/schema_ddl_aux.py`` and
+``polylogue/storage/artifacts/inspection.py``). This contract suite
+pins both layers — pure CAS *and* the artifact-observation grouping
+the docs describe.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+import string
+from io import BytesIO
+from pathlib import Path
+
+import pytest
+
+from polylogue.storage.blob_gc import (
+    _has_active_lease,
+    _still_referenced,
+    acquire_blob_leases,
+    release_operation_leases,
+    run_blob_gc,
+)
+from polylogue.storage.blob_store import BlobStore
+
+# ---------------------------------------------------------------------------
+# Helpers (kept local; deliberately minimal — these tests are about the
+# blob-store contract, not the wider storage runtime)
+# ---------------------------------------------------------------------------
+
+
+def _make_gc_db(path: Path) -> sqlite3.Connection:
+    """Create the minimum schema needed by ``run_blob_gc`` and the lease
+    helpers."""
+    conn = sqlite3.connect(str(path))
+    conn.row_factory = sqlite3.Row
+    conn.executescript(
+        """
+        CREATE TABLE raw_conversations (
+            raw_id TEXT PRIMARY KEY,
+            provider_name TEXT NOT NULL DEFAULT '',
+            source_path TEXT NOT NULL DEFAULT '',
+            blob_size INTEGER NOT NULL DEFAULT 0,
+            acquired_at TEXT NOT NULL DEFAULT ''
+        );
+        CREATE TABLE pending_blob_refs (
+            blob_hash TEXT NOT NULL,
+            operation_id TEXT NOT NULL,
+            acquired_at INTEGER NOT NULL,
+            PRIMARY KEY (blob_hash, operation_id)
+        );
+        CREATE TABLE gc_generations (
+            generation INTEGER PRIMARY KEY,
+            completed_at INTEGER NOT NULL
+        );
+        """
+    )
+    conn.commit()
+    return conn
+
+
+# ---------------------------------------------------------------------------
+# § "Blob Store Model" → "Content addressing: SHA-256 hash over raw bytes.
+# The hash IS the address. Identical content → identical hash → automatic
+# deduplication."
+# ---------------------------------------------------------------------------
+
+
+_DETERMINISM_PAYLOADS = [
+    pytest.param(b"", id="empty"),
+    pytest.param(b"a", id="single-byte"),
+    pytest.param(b"polylogue blob payload", id="ascii"),
+    pytest.param("polilog \u00e9\u4e2d\U0001f600".encode(), id="utf8-multibyte"),
+    pytest.param(b"\x00\x01\x02\xfd\xfe\xff", id="binary"),
+    pytest.param(b"x" * (2 * 1024 * 1024 + 3), id="multi-mib-spans-chunks"),
+]
+
+
+@pytest.mark.parametrize("payload", _DETERMINISM_PAYLOADS)
+def test_content_addressing_is_deterministic(tmp_path: Path, payload: bytes) -> None:
+    """docs/internals.md § Blob Store Model: same bytes → same hash → same
+    on-disk path; the hash IS the address.
+
+    This is the load-bearing claim for both dedup and cross-process
+    convergence. We verify it across an interesting payload catalogue.
+    """
+    store = BlobStore(tmp_path / "blobs")
+
+    expected = hashlib.sha256(payload).hexdigest()
+
+    h_bytes, _ = store.write_from_bytes(payload)
+    assert h_bytes == expected
+    h_fileobj, _ = store.write_from_fileobj(BytesIO(payload))
+    assert h_fileobj == expected
+
+    # Source-file path variant — exercises ``write_from_path``'s
+    # stream-hash code path which is the one used by source acquisition.
+    src = tmp_path / "src.bin"
+    src.write_bytes(payload)
+    h_path, _ = store.write_from_path(src)
+    assert h_path == expected
+
+    # The on-disk path is a pure function of the hash.
+    dest = store.blob_path(expected)
+    assert dest == store.root / expected[:2] / expected[2:]
+
+
+# ---------------------------------------------------------------------------
+# § "Blob Store Model" → "Prefix sharding: 256 subdirectories
+# (blob/00/ through blob/ff/)".
+# ---------------------------------------------------------------------------
+
+
+def test_prefix_shard_layout_uses_first_two_hex_chars(tmp_path: Path) -> None:
+    """docs/internals.md § Blob Store Model: blob path is
+    ``{root}/{hash[:2]}/{hash[2:]}`` — the first hex byte is the shard,
+    the rest is the leaf filename.
+
+    Pins the exact sharding split so a refactor cannot silently move
+    a blob to a different prefix.
+    """
+    store = BlobStore(tmp_path / "blobs")
+    # Choose hashes whose first byte spans the full 256-shard space.
+    sample_bytes = [b"alpha", b"beta", b"gamma", b"\x00", b"\xff", b"prefix-edge"]
+    for payload in sample_bytes:
+        h, _ = store.write_from_bytes(payload)
+        path = store.blob_path(h)
+        assert path.parent.name == h[:2]
+        assert path.name == h[2:]
+        assert path.exists()
+        assert len(path.parent.name) == 2
+        # Shard dir name must be lowercase hex (0-9, a-f)
+        assert all(c in string.hexdigits and (c.isdigit() or c.islower()) for c in path.parent.name)
+
+
+def test_prefix_shard_layout_supports_full_256_namespace(tmp_path: Path) -> None:
+    """docs/internals.md § Blob Store Model: there are 256 possible
+    shard directories — ``blob/00/`` through ``blob/ff/``.
+
+    We don't materialise all 256 (would require ~256 distinct hashes),
+    but we *do* assert that ``blob_path`` permits any lowercase-hex
+    byte as the prefix and rejects everything else.
+    """
+    store = BlobStore(tmp_path / "blobs")
+    # Build representative hex digests for several prefix bytes.
+    for prefix_byte in (0x00, 0x01, 0x7F, 0x80, 0xFE, 0xFF):
+        synthetic = f"{prefix_byte:02x}" + "0" * 62
+        path = store.blob_path(synthetic)
+        assert path.parent.name == f"{prefix_byte:02x}"
+        assert path.name == "0" * 62
+
+
+def test_iter_all_only_walks_valid_two_char_prefix_dirs(tmp_path: Path) -> None:
+    """docs/internals.md § Blob Store Model + ``iter_all`` contract:
+    only directories whose name is exactly 2 chars are considered
+    shard dirs. Anything else (legacy layout, scratch dirs, mounts) is
+    ignored, never mis-attributed as a blob.
+    """
+    store = BlobStore(tmp_path / "blobs")
+    h, _ = store.write_from_bytes(b"genuine")
+
+    # Plant non-shard noise that ``iter_all`` must skip.
+    (store.root / "not-a-shard").mkdir(parents=True, exist_ok=True)
+    (store.root / "not-a-shard" / "abc").write_bytes(b"intruder")
+    (store.root / "abcd").mkdir(parents=True, exist_ok=True)  # wrong length
+    (store.root / "abcd" / "leaf").write_bytes(b"too-long-prefix")
+
+    seen = list(store.iter_all())
+    assert seen == [h]
+
+
+# ---------------------------------------------------------------------------
+# § "Blob Store Model" → "Operations: Blobs are write-once, read-many.
+# No in-place modification." + "Dedup: identical content → identical hash —
+# automatic deduplication."
+# ---------------------------------------------------------------------------
+
+
+def test_write_once_dedup_is_a_noop_on_second_write(tmp_path: Path) -> None:
+    """docs/internals.md § Blob Store Model: write-once + dedup.
+
+    Re-writing the same payload returns the same hash, leaves the
+    on-disk inode untouched, and produces a single store entry.
+    """
+    store = BlobStore(tmp_path / "blobs")
+    payload = b"the canonical content"
+
+    h1, _ = store.write_from_bytes(payload)
+    inode_after_first = store.blob_path(h1).stat().st_ino
+    mtime_after_first = store.blob_path(h1).stat().st_mtime_ns
+
+    h2, _ = store.write_from_bytes(payload)
+    inode_after_second = store.blob_path(h2).stat().st_ino
+    mtime_after_second = store.blob_path(h2).stat().st_mtime_ns
+
+    assert h1 == h2
+    # Write-once: the second write must not have replaced the file.
+    assert inode_after_first == inode_after_second
+    assert mtime_after_first == mtime_after_second
+    assert store.stats()["count"] == 1
+
+
+def test_write_once_does_not_clobber_existing_content(tmp_path: Path) -> None:
+    """docs/internals.md § Blob Store Model: "Blobs are write-once" —
+    even if the on-disk content is corrupted (hash mismatch),
+    re-writing the original payload does not silently replace the
+    corrupted file.
+
+    This pins that we trust the hash, not the bytes. Repair is an
+    explicit operation, never a side-effect of a re-write.
+    """
+    store = BlobStore(tmp_path / "blobs")
+    payload = b"original"
+    h, _ = store.write_from_bytes(payload)
+
+    # Corrupt on disk.
+    store.blob_path(h).write_bytes(b"corrupted!")
+
+    # Re-write the original payload.
+    h2, _ = store.write_from_bytes(payload)
+
+    assert h2 == h
+    # The on-disk content is still the corrupted version — write_once
+    # means "addressed, not validated on every write".
+    assert store.blob_path(h).read_bytes() == b"corrupted!"
+    # verify() detects the corruption and reports it honestly.
+    assert not store.verify(h)
+
+
+def test_dedup_across_write_methods(tmp_path: Path) -> None:
+    """docs/internals.md § Blob Store Model: dedup is by content, not
+    by call site. ``write_from_bytes`` / ``write_from_fileobj`` /
+    ``write_from_path`` of the same payload all collapse to one blob.
+    """
+    store = BlobStore(tmp_path / "blobs")
+    payload = b"three-way dedup"
+    src = tmp_path / "src.bin"
+    src.write_bytes(payload)
+
+    h1, _ = store.write_from_bytes(payload)
+    h2, _ = store.write_from_fileobj(BytesIO(payload))
+    h3, _ = store.write_from_path(src)
+
+    assert h1 == h2 == h3
+    assert store.stats()["count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# § "Blob Store Model" → "GC identifies unreferenced blobs via link
+# counting." Combined with detect_orphans semantics.
+# ---------------------------------------------------------------------------
+
+
+def test_orphan_detection_only_surfaces_unreferenced_blobs(tmp_path: Path) -> None:
+    """docs/internals.md § Blob Store Model: orphan detection compares
+    on-disk blobs against the DB-referenced ID set; a blob is an
+    orphan iff it is on disk but absent from the reference set.
+    """
+    store = BlobStore(tmp_path / "blobs")
+    h_referenced, _ = store.write_from_bytes(b"referenced")
+    h_orphan, _ = store.write_from_bytes(b"orphan")
+
+    result = store.detect_orphans({h_referenced})
+    assert result.orphan_count == 1
+    assert h_orphan in result.orphan_samples
+    assert h_referenced not in result.orphan_samples
+
+
+# ---------------------------------------------------------------------------
+# § "GC concurrency model — leases plus snapshot reference check"
+# ---------------------------------------------------------------------------
+
+
+def test_gc_skips_blobs_with_db_reference(tmp_path: Path) -> None:
+    """docs/internals.md § GC concurrency model — invariant 1
+    (DB reference check): ``_still_referenced`` queries
+    ``raw_conversations`` for the blob's ``raw_id``; if the row exists,
+    GC skips the blob.
+    """
+    blob_root = tmp_path / "blobs"
+    store = BlobStore(blob_root)
+    db_path = tmp_path / "archive.db"
+    conn = _make_gc_db(db_path)
+
+    h, _ = store.write_from_bytes(b"still-referenced")
+    conn.execute(
+        "INSERT INTO raw_conversations (raw_id, provider_name, source_path, blob_size, acquired_at) "
+        "VALUES (?, 'claude', 'src.json', 1, '2025-01-01')",
+        (h,),
+    )
+    conn.commit()
+    conn.close()
+
+    # Force candidate eligibility under the MIN_AGE_S age check.
+    _backdate_blobs(store)
+
+    deleted = run_blob_gc(db_path, blob_root)
+
+    assert deleted == 0
+    assert store.exists(h), "GC must never delete a blob that is still referenced"
+
+
+def test_gc_skips_blobs_with_active_lease(tmp_path: Path) -> None:
+    """docs/internals.md § GC concurrency model — invariant 2
+    (Pending lease check): ``_has_active_lease`` queries
+    ``pending_blob_refs``; if a lease exists, GC must skip the blob
+    even when the snapshot DB-reference check says "orphan".
+
+    This is the exact race the lease design was added to close:
+    acquire-blob → GC-pass → write-DB-row.
+    """
+    blob_root = tmp_path / "blobs"
+    store = BlobStore(blob_root)
+    db_path = tmp_path / "archive.db"
+    conn = _make_gc_db(db_path)
+    conn.close()
+
+    h, _ = store.write_from_bytes(b"freshly-uploaded-not-yet-committed")
+    _backdate_blobs(store)
+
+    # Simulate the in-flight ingest: lease acquired on the blob,
+    # but the ``raw_conversations`` row has not yet been written.
+    acquire_blob_leases(db_path, [h], operation_id="op-in-flight")
+
+    deleted = run_blob_gc(db_path, blob_root)
+
+    assert deleted == 0, (
+        "GC must skip blobs whose write transaction has acquired a lease "
+        "but not yet committed the raw_conversations row"
+    )
+    assert store.exists(h), (
+        "An in-flight, leased blob must survive GC even when its raw_conversations row has not been written yet"
+    )
+
+    # Confirm the protection was lease-driven rather than something
+    # incidental: with the lease released and still no DB reference, GC
+    # is now allowed to consider the blob for deletion.
+    conn = sqlite3.connect(str(db_path))
+    release_operation_leases(conn, "op-in-flight")
+    conn.commit()
+    assert not _has_active_lease(conn, h)
+    assert not _still_referenced(conn, h)
+    conn.close()
+
+
+def test_gc_records_a_new_generation_when_it_runs(tmp_path: Path) -> None:
+    """docs/internals.md § GC concurrency model: "``gc_generations``
+    tracks the high-water mark of completed GC runs." The
+    "defense-in-depth" age check uses the previous generation marker
+    to refuse blobs younger than the previous cycle.
+
+    When GC has work to consider (candidates present) it must record a
+    new monotonically increasing generation row so the next cycle can
+    apply the age guard.
+    """
+    blob_root = tmp_path / "blobs"
+    store = BlobStore(blob_root)
+    db_path = tmp_path / "archive.db"
+    _make_gc_db(db_path).close()
+
+    last_generation = 0
+    for _ in range(3):
+        # Plant a fresh candidate blob for each cycle so the GC
+        # codepath that records the generation row is exercised.
+        h, _ = store.write_from_bytes(f"candidate-{last_generation}".encode())
+        _backdate_blobs(store)
+
+        run_blob_gc(db_path, blob_root)
+
+        conn = sqlite3.connect(str(db_path))
+        row = conn.execute("SELECT MAX(generation) FROM gc_generations").fetchone()
+        conn.close()
+        assert row[0] is not None
+        assert row[0] > last_generation
+        last_generation = row[0]
+
+
+def test_lease_predicate_and_reference_predicate_are_independent(tmp_path: Path) -> None:
+    """docs/internals.md § GC concurrency model: leases and DB references
+    are "two independent safety invariants combined". A blob protected
+    by *either* must not be deleted; only when *both* are absent is GC
+    allowed to reclaim.
+    """
+    db_path = tmp_path / "archive.db"
+    conn = _make_gc_db(db_path)
+
+    blob = "a" * 64
+
+    # 1. No reference, no lease → unprotected.
+    assert not _still_referenced(conn, blob)
+    assert not _has_active_lease(conn, blob)
+
+    # 2. Reference only.
+    conn.execute(
+        "INSERT INTO raw_conversations (raw_id, provider_name, source_path, blob_size, acquired_at) "
+        "VALUES (?, 'p', 's', 0, 't')",
+        (blob,),
+    )
+    conn.commit()
+    assert _still_referenced(conn, blob)
+    assert not _has_active_lease(conn, blob)
+
+    # 3. Reference + lease.
+    conn.execute(
+        "INSERT INTO pending_blob_refs (blob_hash, operation_id, acquired_at) VALUES (?, 'op', 0)",
+        (blob,),
+    )
+    conn.commit()
+    assert _still_referenced(conn, blob)
+    assert _has_active_lease(conn, blob)
+
+    # 4. Lease only — the race window the lease design closes.
+    conn.execute("DELETE FROM raw_conversations WHERE raw_id = ?", (blob,))
+    conn.commit()
+    assert not _still_referenced(conn, blob)
+    assert _has_active_lease(conn, blob)
+
+    conn.close()
+
+
+def test_acquire_blob_leases_is_durable_immediately(tmp_path: Path) -> None:
+    """docs/internals.md § GC concurrency model: leases are taken on a
+    "separate immediate-commit connection so the lease is visible to a
+    concurrent GC before the main transaction commits".
+
+    ``acquire_blob_leases`` opens its own connection and commits. After
+    the call returns, an independent reader sees the lease without
+    needing any further commit on the caller's side.
+    """
+    db_path = tmp_path / "archive.db"
+    _make_gc_db(db_path).close()
+
+    blob = "b" * 64
+    acquire_blob_leases(db_path, [blob], operation_id="op-vis")
+
+    # Fresh reader connection — must see the lease.
+    reader = sqlite3.connect(str(db_path))
+    reader.row_factory = sqlite3.Row
+    row = reader.execute(
+        "SELECT operation_id FROM pending_blob_refs WHERE blob_hash = ?",
+        (blob,),
+    ).fetchone()
+    reader.close()
+
+    assert row is not None
+    assert row["operation_id"] == "op-vis"
+
+
+# ---------------------------------------------------------------------------
+# § "Blob Store Model" → "Linking: ``link_group_key`` groups related blobs
+# (e.g., all blobs belonging to one session)."
+#
+# In the live codebase the grouping is implemented on
+# ``artifact_observations.link_group_key`` (the doc's "blob_links table"
+# vocabulary describes the same concept). We pin the isolation property
+# at the storage layer so a group-A query never surfaces a group-B row.
+# ---------------------------------------------------------------------------
+
+
+def test_link_group_isolation_in_artifact_observations(tmp_path: Path) -> None:
+    """docs/internals.md § Blob Store Model: ``link_group_key`` groups
+    related blobs (sidecar bundles). A query scoped to one group must
+    never surface blobs from another group.
+
+    Pins the isolation property of the live grouping table
+    (``artifact_observations.link_group_key``) — the doc's "blob_links"
+    vocabulary refers to this same grouping.
+    """
+    db_path = tmp_path / "groups.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.executescript(
+        """
+        CREATE TABLE raw_conversations (
+            raw_id TEXT PRIMARY KEY
+        );
+        CREATE TABLE artifact_observations (
+            observation_id TEXT PRIMARY KEY,
+            raw_id TEXT NOT NULL REFERENCES raw_conversations(raw_id) ON DELETE CASCADE,
+            link_group_key TEXT
+        );
+        CREATE INDEX idx_artifact_obs_link_group
+            ON artifact_observations(link_group_key)
+            WHERE link_group_key IS NOT NULL;
+        """
+    )
+    fixtures = [
+        ("raw-a1", "obs-a1", "group-A"),
+        ("raw-a2", "obs-a2", "group-A"),
+        ("raw-b1", "obs-b1", "group-B"),
+        ("raw-c1", "obs-c1", None),
+    ]
+    for raw_id, obs_id, group in fixtures:
+        conn.execute("INSERT INTO raw_conversations (raw_id) VALUES (?)", (raw_id,))
+        conn.execute(
+            "INSERT INTO artifact_observations (observation_id, raw_id, link_group_key) VALUES (?, ?, ?)",
+            (obs_id, raw_id, group),
+        )
+    conn.commit()
+
+    def raws_for_group(group: str) -> set[str]:
+        rows = conn.execute(
+            "SELECT raw_id FROM artifact_observations WHERE link_group_key = ?",
+            (group,),
+        ).fetchall()
+        return {row[0] for row in rows}
+
+    assert raws_for_group("group-A") == {"raw-a1", "raw-a2"}
+    assert raws_for_group("group-B") == {"raw-b1"}
+    # Group queries do not surface the ungrouped row.
+    null_rows = conn.execute("SELECT raw_id FROM artifact_observations WHERE link_group_key IS NULL").fetchall()
+    assert {row[0] for row in null_rows} == {"raw-c1"}
+
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _backdate_blobs(store: BlobStore) -> None:
+    """Push every blob's mtime back past ``MIN_AGE_S`` so GC will
+    consider them eligible.
+
+    The blob-store integration tests routinely need this; encapsulating
+    it here keeps the assertions focused on the invariant under test.
+    """
+    import os
+    import time
+
+    cutoff = time.time() - 3600
+    for h in store.iter_all():
+        path = store.blob_path(h)
+        os.utime(path, (cutoff, cutoff))

--- a/tests/unit/storage/test_schema_policy_contracts.py
+++ b/tests/unit/storage/test_schema_policy_contracts.py
@@ -1,0 +1,261 @@
+"""Contract suite pinning the schema-version policy from docs/internals.md.
+
+These tests pin the **fresh-first** schema policy:
+
+- ``SCHEMA_VERSION`` constant in ``storage/sqlite/schema_ddl.py`` is the
+  authority.
+- On open, the on-disk ``PRAGMA user_version`` is compared against the
+  constant.
+- Version match → normal operation.
+- Version mismatch → the database is *rejected*. There is no automatic
+  migration. The operator must explicitly run a reviewed in-place
+  upgrade script for that exact version transition.
+
+The corresponding doc section is
+``docs/internals.md`` § "Schema Versioning Model".
+
+We also pin the FTS-trigger canonical set that fresh init must
+produce — the six triggers ``messages_fts_a{i,d,u}`` and
+``action_events_fts_a{i,d,u}`` named in
+``docs/internals.md`` § "Daemon Convergence Evidence". Missing
+triggers mean FTS index drift, which is a documented daemon failure
+mode.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from polylogue.errors import SchemaIncompatibleError
+from polylogue.storage.sqlite.schema import (
+    SCHEMA_VERSION,
+    _ensure_schema,
+    assert_readable_archive_layout,
+    ensure_schema_async,
+)
+from polylogue.storage.sqlite.schema_bootstrap import (
+    capture_schema_snapshot,
+    decide_schema_bootstrap,
+    schema_version_mismatch_message,
+)
+
+# ---------------------------------------------------------------------------
+# Canonical FTS triggers — see docs/internals.md
+# § "Daemon Convergence Evidence" (fts_trigger_state)
+# ---------------------------------------------------------------------------
+
+_CANONICAL_FTS_TRIGGERS = frozenset(
+    {
+        "messages_fts_ai",
+        "messages_fts_ad",
+        "messages_fts_au",
+        "action_events_fts_ai",
+        "action_events_fts_ad",
+        "action_events_fts_au",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# § Schema Versioning Model — fresh-first; mismatch is rejected.
+# ---------------------------------------------------------------------------
+
+
+def _planted_db(tmp_path: Path, *, planted_version: int) -> Path:
+    """Plant a SQLite file whose ``user_version`` and shape look like
+    a schema-versioned database but which the runtime does not know
+    how to upgrade.
+
+    We include a ``raw_conversations`` table (and a few sibling tables
+    referenced by upgrade-path branching) so ``decide_schema_bootstrap``
+    routes the snapshot through the no-known-upgrade-path arm rather
+    than the create-fresh arm.
+    """
+    db_path = tmp_path / f"planted-v{planted_version}.db"
+    conn = sqlite3.connect(db_path)
+    conn.executescript(
+        """
+        CREATE TABLE raw_conversations (
+            raw_id TEXT PRIMARY KEY,
+            provider_name TEXT NOT NULL DEFAULT '',
+            source_path TEXT NOT NULL DEFAULT '',
+            blob_size INTEGER NOT NULL DEFAULT 0,
+            acquired_at TEXT NOT NULL DEFAULT ''
+        );
+        CREATE TABLE conversations (
+            conversation_id TEXT PRIMARY KEY
+        );
+        CREATE TABLE messages (
+            message_id TEXT PRIMARY KEY,
+            conversation_id TEXT NOT NULL
+        );
+        """
+    )
+    conn.execute(f"PRAGMA user_version = {planted_version}")
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+def test_fresh_database_initialises_to_current_version(tmp_path: Path) -> None:
+    """docs/internals.md § Schema Versioning Model:
+    ``SCHEMA_VERSION`` is the authority. A brand-new empty database
+    bootstraps to that exact version.
+    """
+    db_path = tmp_path / "fresh.db"
+    conn = sqlite3.connect(db_path)
+    _ensure_schema(conn)
+    version = conn.execute("PRAGMA user_version").fetchone()[0]
+    conn.close()
+    assert version == SCHEMA_VERSION
+
+
+def test_matching_version_database_opens_cleanly(tmp_path: Path) -> None:
+    """docs/internals.md § Schema Versioning Model: a database whose
+    ``user_version`` already equals ``SCHEMA_VERSION`` must open
+    without raising — version match is normal operation.
+    """
+    db_path = tmp_path / "matching.db"
+    conn = sqlite3.connect(db_path)
+    _ensure_schema(conn)
+    # Re-open the same DB through the bootstrap path; this must be a
+    # no-op rather than an error.
+    _ensure_schema(conn)
+    assert conn.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION
+    conn.close()
+
+
+def test_future_schema_version_is_rejected(tmp_path: Path) -> None:
+    """docs/internals.md § Schema Versioning Model: a DB whose version
+    is *newer* than this runtime understands must be rejected.
+    Half-running against a forward-versioned DB risks data loss; the
+    operator is expected to upgrade the runtime instead.
+    """
+    db_path = _planted_db(tmp_path, planted_version=SCHEMA_VERSION + 1)
+    conn = sqlite3.connect(db_path)
+    try:
+        with pytest.raises(SchemaIncompatibleError) as excinfo:
+            _ensure_schema(conn)
+        assert excinfo.value.current_version == SCHEMA_VERSION + 1
+        assert excinfo.value.expected_version == SCHEMA_VERSION
+    finally:
+        conn.close()
+
+
+def test_unknown_older_schema_version_is_rejected(tmp_path: Path) -> None:
+    """docs/internals.md § Schema Versioning Model: a DB whose version
+    is unknown to the runtime (no reviewed in-place upgrade path) must
+    be rejected. We use ``SCHEMA_VERSION - 1`` when no upgrade arm
+    handles that transition.
+
+    The fresh-first policy is "rejected rather than partially patched
+    with additive DDL" (see ``schema.py:_ensure_schema`` docstring).
+    """
+    # Use a version far enough below current that no reviewed
+    # upgrade-path arm covers it. v1 is intentionally never reachable
+    # via the upgrade chain.
+    db_path = _planted_db(tmp_path, planted_version=1)
+    conn = sqlite3.connect(db_path)
+    try:
+        with pytest.raises(SchemaIncompatibleError) as excinfo:
+            _ensure_schema(conn)
+        assert excinfo.value.current_version == 1
+        assert excinfo.value.expected_version == SCHEMA_VERSION
+    finally:
+        conn.close()
+
+
+def test_version_mismatch_message_distinguishes_newer_and_older() -> None:
+    """docs/internals.md § Schema Versioning Model: the rejection
+    diagnostic must be specific enough that the operator can act on
+    it — a newer DB needs a runtime upgrade, an older one needs a
+    reviewed in-place upgrade script.
+    """
+    newer = schema_version_mismatch_message(SCHEMA_VERSION + 1)
+    older = schema_version_mismatch_message(SCHEMA_VERSION - 1)
+    assert str(SCHEMA_VERSION) in newer
+    assert str(SCHEMA_VERSION) in older
+    assert newer != older
+    assert "newer" in newer.lower()
+
+
+def test_decision_for_unknown_version_is_explicit_mismatch(tmp_path: Path) -> None:
+    """docs/internals.md § Schema Versioning Model: the bootstrap
+    decision for an unknown version is the ``version_mismatch``
+    action — never silently falling through to apply current
+    extensions.
+
+    This pins the policy decision rather than the side effect.
+    """
+    db_path = _planted_db(tmp_path, planted_version=SCHEMA_VERSION + 5)
+    conn = sqlite3.connect(db_path)
+    try:
+        snapshot = capture_schema_snapshot(conn)
+        decision = decide_schema_bootstrap(snapshot)
+        assert decision.action == "version_mismatch"
+        assert decision.current_version == SCHEMA_VERSION + 5
+    finally:
+        conn.close()
+
+
+def test_assert_readable_archive_layout_also_rejects_mismatch(tmp_path: Path) -> None:
+    """docs/internals.md § Schema Versioning Model: the read-only
+    open path applies the same fresh-first rejection. A read tool
+    must not silently operate against a foreign-version archive.
+    """
+    db_path = _planted_db(tmp_path, planted_version=SCHEMA_VERSION + 2)
+    conn = sqlite3.connect(db_path)
+    try:
+        with pytest.raises(SchemaIncompatibleError):
+            assert_readable_archive_layout(conn)
+    finally:
+        conn.close()
+
+
+def test_async_path_rejects_unknown_version(tmp_path: Path) -> None:
+    """docs/internals.md § Schema Versioning Model: the async
+    bootstrap path enforces the same policy as the sync path.
+    Polylogue's primary runtime is async; a policy that only fires
+    on the sync path would be a hole.
+    """
+    db_path = _planted_db(tmp_path, planted_version=1)
+
+    async def _run() -> None:
+        import aiosqlite
+
+        async with aiosqlite.connect(str(db_path)) as conn:
+            with pytest.raises(SchemaIncompatibleError):
+                await ensure_schema_async(conn)
+
+    asyncio.run(_run())
+
+
+# ---------------------------------------------------------------------------
+# § FTS trigger canonical set — docs/internals.md
+# § "Daemon Convergence Evidence" (fts_trigger_state)
+# ---------------------------------------------------------------------------
+
+
+def test_fresh_init_creates_canonical_fts_trigger_set(tmp_path: Path) -> None:
+    """docs/internals.md § Daemon Convergence Evidence: the six FTS
+    sync triggers (``messages_fts_a{i,d,u}``,
+    ``action_events_fts_a{i,d,u}``) are the canonical set that fresh
+    initialisation must produce. A missing trigger is documented as an
+    "FTS index drift risk".
+    """
+    db_path = tmp_path / "fts.db"
+    conn = sqlite3.connect(db_path)
+    _ensure_schema(conn)
+
+    rows = conn.execute("SELECT name FROM sqlite_master WHERE type='trigger'").fetchall()
+    conn.close()
+
+    triggers = {row[0] for row in rows}
+    missing = _CANONICAL_FTS_TRIGGERS - triggers
+    assert not missing, (
+        f"Fresh init is missing canonical FTS triggers: {sorted(missing)} — docs/internals.md pins the 6-trigger set"
+    )


### PR DESCRIPTION
## Summary

Add two contract suites that pin the documented invariants of the blob store and the schema-version policy from `docs/internals.md`, distinct from the happy-path CRUD coverage in `test_blob_store.py` / `test_blob_gc.py` / `test_schema_upgrades.py`.

## Problem

#997's closeout flagged the blob store and the schema-migration policy among uncovered domains. Existing storage tests cover specific behaviors (write paths, individual upgrade plans, GC regression bugs) but do not pin the documented invariants themselves. A refactor or accidental drift could change the contract without any test failing.

## Solution

Two new test files, each docstring-citing the `docs/internals.md` section it pins:

**`tests/unit/storage/test_blob_store_contracts.py`** (16 tests, including a 6-variant parametrize) pins § "Blob Store Model" and § "GC concurrency model — leases plus snapshot reference check":

- Content-addressing determinism across `write_from_bytes` / `write_from_fileobj` / `write_from_path` and across empty / single-byte / ASCII / multibyte UTF-8 / binary / multi-MiB chunked payloads.
- Prefix-shard layout: `{root}/{hash[:2]}/{hash[2:]}`, with the full 256-shard hex namespace permitted and non-shard noise (wrong-length dirs, scratch dirs) ignored by `iter_all`.
- Write-once semantics: re-write of the same hash is a no-op (same inode, same mtime), corruption is not silently overwritten by a re-write, and the trust boundary is the hash not the bytes.
- Dedup convergence across all three write methods.
- Orphan detection scoping (only unreferenced blobs surface).
- GC concurrency: DB-reference and lease predicates are independent invariants, leases acquired via `acquire_blob_leases` are visible to fresh reader connections immediately (the immediate-commit contract the docs make explicit), generation rows are recorded on each GC cycle that has candidates, and a leased in-flight blob survives GC even when the snapshot reference check says "orphan".
- `link_group_key` isolation on `artifact_observations` — the docs' "blob_links" vocabulary describes this same grouping table; group-A queries must not surface group-B rows, and null-group rows are not surfaced by either.

**`tests/unit/storage/test_schema_policy_contracts.py`** (9 tests) pins § "Schema Versioning Model" and the canonical FTS trigger set from § "Daemon Convergence Evidence":

- Fresh init bootstraps to `SCHEMA_VERSION` exactly.
- Matching version opens cleanly (idempotent re-open).
- `SCHEMA_VERSION + 1` (future) is rejected on the sync path.
- An unknown older version (planted v1) is rejected — pins "rejected rather than partially patched with additive DDL".
- The async bootstrap path enforces the same policy (async is the primary runtime; a sync-only check would be a hole).
- The read-only open path (`assert_readable_archive_layout`) also rejects.
- `decide_schema_bootstrap` returns `version_mismatch` action for unknown versions — pins the policy decision, not just the side effect.
- The diagnostic distinguishes newer-than-runtime from older-than-runtime so operators know whether to upgrade the runtime or run an in-place script.
- Fresh init produces the canonical six FTS triggers (`messages_fts_a{i,d,u}`, `action_events_fts_a{i,d,u}`). A missing trigger is documented as an FTS index drift risk.

Each test's docstring cites the specific `docs/internals.md` section it pins so future doc/code drift is attributable.

## Verification

```
nix develop -c pytest tests/unit/storage/test_blob_store_contracts.py tests/unit/storage/test_schema_policy_contracts.py
# 28 passed in 11.71s

nix develop -c devtools verify --quick
# exit_code: 0 (total_duration_s: 21.67)
```

Closes #1185