### PR TITLE
test(parsers): catalog-driven contract tests for claude-ai/gemini/codex (#1184)

### DIFF
--- a/tests/unit/sources/test_parsers_claude_ai_catalog.py
+++ b/tests/unit/sources/test_parsers_claude_ai_catalog.py
@@ -1,0 +1,482 @@
+"""Catalog-driven contract tests for the Claude AI (web export) parser.
+
+Mirrors the ``_METADATA_PERMUTATION_CASES`` pattern in
+``tests/unit/sources/test_parsers_chatgpt.py``: each case is a
+``(label, payload_factory, expectations)`` triple and runs the full
+parser → transform → save → hydrate pipeline using the shared
+``parse_and_transform_payload`` / ``save_transform_and_hydrate``
+helpers. The catalog covers the ``chat_messages`` shape from
+``polylogue/sources/parsers/claude/ai_parser.py`` — model variants,
+tool-use blocks, thinking blocks, attachments, citations, and a
+system-prompt prelude.
+
+Codex/Claude-Code paths are intentionally out of scope (different
+shapes, see ``test_parsers_codex_catalog.py`` and
+``test_parsers_claude_code_artifacts.py``).
+
+Ref #1184.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, TypeAlias
+
+import pytest
+
+from polylogue.sources.parsers.claude import looks_like_ai, parse_ai
+from polylogue.storage.sqlite.connection import open_connection
+from tests.infra.pipeline_roundtrip import (
+    parse_and_transform_payload,
+    save_transform_and_hydrate,
+)
+from tests.infra.storage_records import db_setup
+
+PayloadFactory: TypeAlias = Callable[[], dict[str, Any]]
+Expectations: TypeAlias = dict[str, Any]
+CatalogCase: TypeAlias = tuple[str, PayloadFactory, Expectations]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _text_segment(text: str) -> dict[str, Any]:
+    return {"type": "text", "text": text}
+
+
+def _thinking_segment(text: str) -> dict[str, Any]:
+    return {"type": "thinking", "thinking": text}
+
+
+def _tool_use_segment(name: str, *, tool_id: str = "tu-1", inp: dict[str, Any] | None = None) -> dict[str, Any]:
+    return {
+        "type": "tool_use",
+        "id": tool_id,
+        "name": name,
+        "input": inp or {"query": "x"},
+    }
+
+
+def _tool_result_segment(text: str, *, tool_use_id: str = "tu-1") -> dict[str, Any]:
+    return {
+        "type": "tool_result",
+        "tool_use_id": tool_use_id,
+        "content": [{"type": "text", "text": text}],
+    }
+
+
+def _chat_message(
+    uuid: str,
+    sender: str,
+    content: list[dict[str, Any]],
+    *,
+    created_at: str | None = None,
+    attachments: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    # ``ClaudeAIConversation`` validation in ``parsers/claude/ai_parser.py``
+    # is strict; payloads that don't fit the pydantic model fall through to
+    # the loose extractor. We exercise the loose path here so the catalog
+    # stays focused on parser behavior independent of validator drift.
+    text = " ".join(seg.get("text", "") for seg in content if seg.get("type") == "text").strip() or None
+    msg: dict[str, Any] = {
+        "uuid": uuid,
+        "sender": sender,
+        "content": content,
+    }
+    if text is not None:
+        msg["text"] = text
+    if created_at is not None:
+        msg["created_at"] = created_at
+    if attachments is not None:
+        msg["attachments"] = attachments
+    return msg
+
+
+def _payload(
+    *,
+    title: str,
+    conv_id: str,
+    chat_messages: list[dict[str, Any]],
+    model: str | None = None,
+    created_at: str = "2024-05-01T10:00:00Z",
+    updated_at: str = "2024-05-01T10:30:00Z",
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "uuid": conv_id,
+        "title": title,
+        "created_at": created_at,
+        "updated_at": updated_at,
+        "chat_messages": chat_messages,
+    }
+    if model is not None:
+        payload["model"] = model
+    return payload
+
+
+# ---------------------------------------------------------------------------
+# Catalog
+# ---------------------------------------------------------------------------
+
+
+_CLAUDE_AI_METADATA_CATALOG: list[CatalogCase] = [
+    (
+        "plain text exchange",
+        lambda: _payload(
+            title="Plain Conversation",
+            conv_id="conv-plain",
+            chat_messages=[
+                _chat_message("m1", "human", [_text_segment("Hi")], created_at="2024-05-01T10:00:00Z"),
+                _chat_message("m2", "assistant", [_text_segment("Hello!")], created_at="2024-05-01T10:00:05Z"),
+            ],
+        ),
+        {
+            "title": "Plain Conversation",
+            "roles": ["user", "assistant"],
+            "min_messages": 2,
+            "block_types_any_of": [["text"]],
+        },
+    ),
+    (
+        "model variant: claude-3-opus",
+        lambda: _payload(
+            title="Opus Session",
+            conv_id="conv-opus",
+            model="claude-3-opus-20240229",
+            chat_messages=[
+                _chat_message("m1", "human", [_text_segment("Hello opus")], created_at="2024-05-01T10:00:00Z"),
+                _chat_message(
+                    "m2",
+                    "assistant",
+                    [_text_segment("Greetings.")],
+                    created_at="2024-05-01T10:00:01Z",
+                ),
+            ],
+        ),
+        {
+            "title": "Opus Session",
+            "roles": ["user", "assistant"],
+            "min_messages": 2,
+        },
+    ),
+    (
+        "model variant: claude-3-5-sonnet",
+        lambda: _payload(
+            title="Sonnet Session",
+            conv_id="conv-sonnet",
+            model="claude-3-5-sonnet-20241022",
+            chat_messages=[
+                _chat_message("m1", "human", [_text_segment("Hi sonnet")], created_at="2024-05-01T10:00:00Z"),
+                _chat_message(
+                    "m2",
+                    "assistant",
+                    [_text_segment("Hi.")],
+                    created_at="2024-05-01T10:00:01Z",
+                ),
+            ],
+        ),
+        {
+            "title": "Sonnet Session",
+            "roles": ["user", "assistant"],
+            "min_messages": 2,
+        },
+    ),
+    (
+        "thinking block on assistant",
+        lambda: _payload(
+            title="Thinking",
+            conv_id="conv-think",
+            chat_messages=[
+                _chat_message("m1", "human", [_text_segment("Reason about 2+2")], created_at="2024-05-01T10:00:00Z"),
+                _chat_message(
+                    "m2",
+                    "assistant",
+                    [
+                        _thinking_segment("Let me consider arithmetic."),
+                        _text_segment("It's 4."),
+                    ],
+                    created_at="2024-05-01T10:00:02Z",
+                ),
+            ],
+        ),
+        {
+            "title": "Thinking",
+            "roles": ["user", "assistant"],
+            "block_types_any_of": [["thinking", "text"]],
+        },
+    ),
+    (
+        "tool_use + tool_result pair",
+        lambda: _payload(
+            title="Tool Use",
+            conv_id="conv-tool",
+            chat_messages=[
+                _chat_message("m1", "human", [_text_segment("search docs")], created_at="2024-05-01T10:00:00Z"),
+                _chat_message(
+                    "m2",
+                    "assistant",
+                    [
+                        _text_segment("calling search"),
+                        _tool_use_segment("search", tool_id="tu-A", inp={"q": "polylogue"}),
+                    ],
+                    created_at="2024-05-01T10:00:02Z",
+                ),
+                # Anthropic protocol: tool_result is carried under role: user
+                _chat_message(
+                    "m3",
+                    "user",
+                    [_tool_result_segment("found 3 hits", tool_use_id="tu-A")],
+                    created_at="2024-05-01T10:00:03Z",
+                ),
+            ],
+        ),
+        {
+            "title": "Tool Use",
+            # m3 is reclassified user→tool by reclassify_tool_result_envelope.
+            "roles": ["user", "assistant", "tool"],
+            "must_contain_block_type": "tool_use",
+        },
+    ),
+    (
+        "attachments on user message",
+        lambda: _payload(
+            title="Attachments",
+            conv_id="conv-att",
+            chat_messages=[
+                _chat_message(
+                    "m1",
+                    "human",
+                    [_text_segment("see file")],
+                    created_at="2024-05-01T10:00:00Z",
+                    attachments=[
+                        {
+                            "id": "att-1",
+                            "file_name": "notes.pdf",
+                            "file_type": "application/pdf",
+                            "file_size": 4096,
+                        }
+                    ],
+                ),
+                _chat_message("m2", "assistant", [_text_segment("ok")], created_at="2024-05-01T10:00:01Z"),
+            ],
+        ),
+        {
+            "title": "Attachments",
+            "roles": ["user", "assistant"],
+            "min_attachments": 1,
+        },
+    ),
+    (
+        "citations metadata in content block",
+        lambda: _payload(
+            title="Citations",
+            conv_id="conv-cite",
+            chat_messages=[
+                _chat_message("m1", "human", [_text_segment("source?")], created_at="2024-05-01T10:00:00Z"),
+                _chat_message(
+                    "m2",
+                    "assistant",
+                    [
+                        {
+                            "type": "text",
+                            "text": "see [1]",
+                            "citations": [{"title": "Ref", "url": "https://example.com"}],
+                        }
+                    ],
+                    created_at="2024-05-01T10:00:01Z",
+                ),
+            ],
+        ),
+        {
+            "title": "Citations",
+            "roles": ["user", "assistant"],
+            "block_types_any_of": [["text"]],
+        },
+    ),
+    (
+        "system prompt prelude + ordering",
+        lambda: _payload(
+            title="System Prompt",
+            conv_id="conv-sys",
+            chat_messages=[
+                _chat_message(
+                    "m0",
+                    "system",
+                    [_text_segment("You are a helpful assistant.")],
+                    created_at="2024-05-01T09:59:59Z",
+                ),
+                _chat_message("m1", "human", [_text_segment("hi")], created_at="2024-05-01T10:00:00Z"),
+                _chat_message("m2", "assistant", [_text_segment("hello")], created_at="2024-05-01T10:00:01Z"),
+            ],
+        ),
+        {
+            "title": "System Prompt",
+            "roles": ["system", "user", "assistant"],
+            "preserves_order": True,
+        },
+    ),
+    (
+        "mixed thinking + tool_use + text in one assistant turn",
+        lambda: _payload(
+            title="Rich Turn",
+            conv_id="conv-rich",
+            chat_messages=[
+                _chat_message("m1", "human", [_text_segment("research X")], created_at="2024-05-01T10:00:00Z"),
+                _chat_message(
+                    "m2",
+                    "assistant",
+                    [
+                        _thinking_segment("planning"),
+                        _tool_use_segment("search", tool_id="tu-rich"),
+                        _text_segment("starting search..."),
+                    ],
+                    created_at="2024-05-01T10:00:01Z",
+                ),
+            ],
+        ),
+        {
+            "title": "Rich Turn",
+            "roles": ["user", "assistant"],
+            "must_contain_block_type": "tool_use",
+            "block_types_any_of": [["thinking", "tool_use", "text"]],
+        },
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# Shared roundtrip assertion
+# ---------------------------------------------------------------------------
+
+
+def _assert_roundtrip(
+    provider_name: str,
+    payload: dict[str, Any],
+    expectations: Expectations,
+    workspace_env: dict[str, Path],
+    label: str,
+) -> None:
+    """Run payload → parse → transform → save → hydrate and assert
+    contract expectations.
+
+    Title, role normalization, and timestamp ordering are asserted at
+    the hydrated ``Conversation`` level. Content-block kinds are
+    asserted at the materialization boundary
+    (``roundtrip.transform.bundle.content_blocks``) because the shared
+    sync ``store_records`` helper does not currently propagate
+    block rows from the bundle into ``MessageRecord.content_blocks``;
+    the materialization output is the canonical block representation
+    the daemon write path persists.
+    """
+    raw_bytes = json.dumps(payload).encode("utf-8")
+    db_path = db_setup(workspace_env)
+    with open_connection(db_path) as conn:
+        roundtrip = parse_and_transform_payload(
+            provider_name, raw_bytes, workspace_env["archive_root"], unique_id=label
+        )
+        hydrated = save_transform_and_hydrate(roundtrip.transform, conn)
+
+    # Title survives.
+    expected_title = expectations.get("title")
+    if expected_title is not None:
+        assert hydrated.title == expected_title, f"[{label}] title: expected {expected_title!r}, got {hydrated.title!r}"
+
+    messages = list(hydrated.messages)
+
+    expected_min = expectations.get("min_messages", 1)
+    assert len(messages) >= expected_min, (
+        f"[{label}] expected at least {expected_min} hydrated messages, got {len(messages)}"
+    )
+
+    # Role multiset is preserved between parsed and hydrated (sanity).
+    parsed_roles = [str(m.role) for m in roundtrip.parsed.messages]
+    hydrated_roles = [str(m.role) for m in messages]
+    assert sorted(parsed_roles) == sorted(hydrated_roles), (
+        f"[{label}] role multiset diverged: parsed={parsed_roles} hydrated={hydrated_roles}"
+    )
+
+    expected_roles = expectations.get("roles")
+    if expected_roles is not None:
+        assert hydrated_roles == expected_roles, f"[{label}] roles expected {expected_roles}, got {hydrated_roles}"
+
+    # Content-block kinds survive at the materialization boundary
+    # (``bundle.content_blocks``). The current sync test helper writes
+    # messages but not their content_blocks rows, so hydrated
+    # ``Message.content_blocks`` is empty even when materialization
+    # produced blocks — we therefore assert on the bundle, which is the
+    # canonical materialized representation the daemon write path
+    # persists. See `_assert_roundtrip` docstring.
+    observed_kinds = {str(b.type) for b in roundtrip.transform.bundle.content_blocks}
+
+    block_types_any_of = expectations.get("block_types_any_of")
+    if block_types_any_of is not None:
+        ok = any(set(kinds).issubset(observed_kinds) for kinds in block_types_any_of)
+        assert ok, f"[{label}] expected at least one of {block_types_any_of} subset of observed kinds {observed_kinds}"
+
+    must_contain = expectations.get("must_contain_block_type")
+    if must_contain is not None:
+        assert must_contain in observed_kinds, (
+            f"[{label}] expected block type {must_contain!r} in observed kinds {observed_kinds}"
+        )
+
+    # Timestamp ordering survives. Hydrated messages must be sorted by
+    # ascending timestamp where timestamps are present.
+    if expectations.get("preserves_order"):
+        timestamps = [m.timestamp for m in messages if m.timestamp is not None]
+        assert timestamps == sorted(timestamps), f"[{label}] hydrated timestamps not ascending: {timestamps}"
+
+    # Attachment counts (loose lower bound only — provider may bind some
+    # attachments at the conversation level).
+    expected_min_attachments = expectations.get("min_attachments")
+    if expected_min_attachments is not None:
+        # The transform result exposes attachments at the bundle level;
+        # use it directly to keep this assertion shape-independent of the
+        # public Conversation surface.
+        attachments = list(roundtrip.transform.bundle.attachments)
+        assert len(attachments) >= expected_min_attachments, (
+            f"[{label}] expected at least {expected_min_attachments} attachments, got {len(attachments)}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("label", "factory", "expectations"),
+    [pytest.param(label, factory, exp, id=label) for label, factory, exp in _CLAUDE_AI_METADATA_CATALOG],
+)
+def test_claude_ai_catalog_roundtrip(
+    label: str,
+    factory: PayloadFactory,
+    expectations: Expectations,
+    workspace_env: dict[str, Path],
+) -> None:
+    """Each catalog payload survives parse → transform → save → hydrate.
+
+    Asserts the contract surface required by issue #1184: title, role
+    normalization, content-block kinds, and timestamp ordering.
+    """
+    payload = factory()
+    assert looks_like_ai(payload), f"[{label}] payload must look like a Claude AI export"
+    _assert_roundtrip("claude-ai", payload, expectations, workspace_env, label)
+
+
+def test_claude_ai_catalog_parser_only_smoke() -> None:
+    """Parser-only smoke test: every catalog entry parses to >=1 message
+    without raising and reports ``claude-ai`` as the provider name.
+
+    This is the fast feedback signal — failure here means the parser
+    itself rejects the payload before the roundtrip helper even runs.
+    """
+    for label, factory, _expectations in _CLAUDE_AI_METADATA_CATALOG:
+        payload = factory()
+        # Deep-copy guards against accidental mutation by the parser.
+        parsed = parse_ai(copy.deepcopy(payload), fallback_id=f"fb-{label}")
+        assert parsed.provider_name == "claude-ai", f"[{label}] wrong provider: {parsed.provider_name}"
+        assert parsed.messages, f"[{label}] parser produced no messages"

--- a/tests/unit/sources/test_parsers_codex_catalog.py
+++ b/tests/unit/sources/test_parsers_codex_catalog.py
@@ -1,0 +1,369 @@
+"""Catalog-driven contract tests for the Codex JSONL session parser.
+
+Mirrors ``_METADATA_PERMUTATION_CASES`` in
+``tests/unit/sources/test_parsers_chatgpt.py``: each entry is a
+``(label, payload_factory, expectations)`` triple exercising the full
+parser → transform → save → hydrate pipeline against Codex session
+envelopes from ``parsers/codex.py``.
+
+Coverage targets the surfaces called out in issue #1184: title (Codex
+has no native title — fallback is the conversation id), model
+identification, role normalization across ``user``/``assistant``/
+``developer``/``system``, content-block kinds (text, tool_use,
+tool_result), and ascending timestamp ordering.
+
+Ref #1184.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, TypeAlias
+
+import pytest
+
+from polylogue.sources.parsers.codex import looks_like as codex_looks_like
+from polylogue.sources.parsers.codex import parse as codex_parse
+from polylogue.storage.sqlite.connection import open_connection
+from tests.infra.pipeline_roundtrip import (
+    parse_and_transform_payload,
+    save_transform_and_hydrate,
+)
+from tests.infra.storage_records import db_setup
+
+PayloadFactory: TypeAlias = Callable[[], list[dict[str, Any]]]
+Expectations: TypeAlias = dict[str, Any]
+CatalogCase: TypeAlias = tuple[str, PayloadFactory, Expectations]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _session_meta(session_id: str, *, timestamp: str, extras: dict[str, Any] | None = None) -> dict[str, Any]:
+    payload: dict[str, Any] = {"id": session_id, "timestamp": timestamp}
+    if extras:
+        payload.update(extras)
+    return {"type": "session_meta", "payload": payload}
+
+
+def _user_message(text: str, *, timestamp: str, msg_id: str | None = None) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "type": "message",
+        "role": "user",
+        "timestamp": timestamp,
+        "content": [{"type": "input_text", "text": text}],
+    }
+    if msg_id is not None:
+        payload["id"] = msg_id
+    return {"type": "response_item", "payload": payload}
+
+
+def _assistant_message(text: str, *, timestamp: str, msg_id: str | None = None) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "type": "message",
+        "role": "assistant",
+        "timestamp": timestamp,
+        "content": [{"type": "output_text", "text": text}],
+    }
+    if msg_id is not None:
+        payload["id"] = msg_id
+    return {"type": "response_item", "payload": payload}
+
+
+def _developer_message(text: str, *, timestamp: str) -> dict[str, Any]:
+    return {
+        "type": "response_item",
+        "payload": {
+            "type": "message",
+            "role": "developer",
+            "timestamp": timestamp,
+            "content": [{"type": "input_text", "text": text}],
+        },
+    }
+
+
+def _function_call(name: str, args: dict[str, Any], *, call_id: str = "call-1") -> dict[str, Any]:
+    return {
+        "type": "response_item",
+        "payload": {
+            "type": "function_call",
+            "id": f"fc-{call_id}",
+            "call_id": call_id,
+            "name": name,
+            "arguments": json.dumps(args),
+        },
+    }
+
+
+def _function_call_output(output: str, *, call_id: str = "call-1") -> dict[str, Any]:
+    return {
+        "type": "response_item",
+        "payload": {
+            "type": "function_call_output",
+            "call_id": call_id,
+            "output": output,
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Catalog
+# ---------------------------------------------------------------------------
+
+
+_CODEX_METADATA_CATALOG: list[CatalogCase] = [
+    (
+        "plain envelope exchange",
+        lambda: [
+            _session_meta("sess-plain", timestamp="2024-06-01T09:00:00Z"),
+            _user_message("hello codex", timestamp="2024-06-01T09:00:01Z", msg_id="m1"),
+            _assistant_message("hello back", timestamp="2024-06-01T09:00:02Z", msg_id="m2"),
+        ],
+        {
+            "conv_id": "sess-plain",
+            "roles": ["user", "assistant"],
+            "block_types_any_of": [["text"]],
+            "preserves_order": True,
+        },
+    ),
+    (
+        "session_meta with git context + instructions",
+        lambda: [
+            _session_meta(
+                "sess-git",
+                timestamp="2024-06-01T09:00:00Z",
+                extras={
+                    "git": {"branch": "feature/x", "commit": "abc123"},
+                    "instructions": "Be concise.",
+                },
+            ),
+            _user_message("hi", timestamp="2024-06-01T09:00:01Z", msg_id="m1"),
+            _assistant_message("hi.", timestamp="2024-06-01T09:00:02Z", msg_id="m2"),
+        ],
+        {
+            "conv_id": "sess-git",
+            "roles": ["user", "assistant"],
+            "preserves_order": True,
+        },
+    ),
+    (
+        "developer message normalises to system",
+        lambda: [
+            _session_meta("sess-dev", timestamp="2024-06-01T09:00:00Z"),
+            _developer_message("<developer>system prompt</developer>", timestamp="2024-06-01T09:00:01Z"),
+            _user_message("hi", timestamp="2024-06-01T09:00:02Z", msg_id="m1"),
+            _assistant_message("hi.", timestamp="2024-06-01T09:00:03Z", msg_id="m2"),
+        ],
+        {
+            "conv_id": "sess-dev",
+            # codex parser maps developer → system role
+            "roles": ["system", "user", "assistant"],
+            "preserves_order": True,
+        },
+    ),
+    (
+        "function_call + function_call_output → tool_use + tool_result",
+        lambda: [
+            _session_meta("sess-tool", timestamp="2024-06-01T09:00:00Z"),
+            _user_message("run command", timestamp="2024-06-01T09:00:01Z", msg_id="m1"),
+            _function_call("exec_command", {"cmd": "ls"}, call_id="c1"),
+            _function_call_output("file1\nfile2", call_id="c1"),
+            _assistant_message("done", timestamp="2024-06-01T09:00:05Z", msg_id="m2"),
+        ],
+        {
+            "conv_id": "sess-tool",
+            "must_contain_block_type": "tool_use",
+            "block_types_any_of": [["tool_use", "tool_result"]],
+        },
+    ),
+    (
+        "direct (non-envelope) format",
+        lambda: [
+            {
+                "id": "sess-direct",
+                "timestamp": "2024-06-01T09:00:00Z",
+            },
+            {
+                "type": "message",
+                "role": "user",
+                "timestamp": "2024-06-01T09:00:01Z",
+                "id": "m1",
+                "content": [{"type": "input_text", "text": "hello direct"}],
+            },
+            {
+                "type": "message",
+                "role": "assistant",
+                "timestamp": "2024-06-01T09:00:02Z",
+                "id": "m2",
+                "content": [{"type": "output_text", "text": "hi direct"}],
+            },
+        ],
+        {
+            "conv_id": "sess-direct",
+            "roles": ["user", "assistant"],
+            "preserves_order": True,
+        },
+    ),
+    (
+        "role normalisation: User / ASSISTANT",
+        lambda: [
+            _session_meta("sess-roles", timestamp="2024-06-01T09:00:00Z"),
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "User",
+                    "timestamp": "2024-06-01T09:00:01Z",
+                    "id": "m1",
+                    "content": [{"type": "input_text", "text": "hi"}],
+                },
+            },
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "ASSISTANT",
+                    "timestamp": "2024-06-01T09:00:02Z",
+                    "id": "m2",
+                    "content": [{"type": "output_text", "text": "hi back"}],
+                },
+            },
+        ],
+        {
+            "conv_id": "sess-roles",
+            "roles": ["user", "assistant"],
+        },
+    ),
+    (
+        "multi-turn conversation preserves ordering",
+        lambda: [
+            _session_meta("sess-multi", timestamp="2024-06-01T09:00:00Z"),
+            _user_message("q1", timestamp="2024-06-01T09:00:01Z", msg_id="m1"),
+            _assistant_message("a1", timestamp="2024-06-01T09:00:02Z", msg_id="m2"),
+            _user_message("q2", timestamp="2024-06-01T09:00:03Z", msg_id="m3"),
+            _assistant_message("a2", timestamp="2024-06-01T09:00:04Z", msg_id="m4"),
+            _user_message("q3", timestamp="2024-06-01T09:00:05Z", msg_id="m5"),
+            _assistant_message("a3", timestamp="2024-06-01T09:00:06Z", msg_id="m6"),
+        ],
+        {
+            "conv_id": "sess-multi",
+            "roles": ["user", "assistant", "user", "assistant", "user", "assistant"],
+            "preserves_order": True,
+            "min_messages": 6,
+        },
+    ),
+    (
+        "state records are skipped without breaking the catalog",
+        lambda: [
+            _session_meta("sess-state", timestamp="2024-06-01T09:00:00Z"),
+            {"record_type": "state"},
+            _user_message("hi", timestamp="2024-06-01T09:00:01Z", msg_id="m1"),
+            {"record_type": "state"},
+            _assistant_message("hello", timestamp="2024-06-01T09:00:02Z", msg_id="m2"),
+        ],
+        {
+            "conv_id": "sess-state",
+            "roles": ["user", "assistant"],
+        },
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# Roundtrip assertion
+# ---------------------------------------------------------------------------
+
+
+def _assert_roundtrip(
+    payload: list[dict[str, Any]],
+    expectations: Expectations,
+    workspace_env: dict[str, Path],
+    label: str,
+) -> None:
+    # Codex source records are JSONL — one record per line.
+    raw_bytes = ("\n".join(json.dumps(record) for record in payload) + "\n").encode("utf-8")
+    db_path = db_setup(workspace_env)
+    with open_connection(db_path) as conn:
+        roundtrip = parse_and_transform_payload("codex", raw_bytes, workspace_env["archive_root"], unique_id=label)
+        hydrated = save_transform_and_hydrate(roundtrip.transform, conn)
+
+    # Conversation id from session_meta (or first-line id for direct format).
+    expected_conv_id = expectations.get("conv_id")
+    if expected_conv_id is not None:
+        assert roundtrip.parsed.provider_conversation_id == expected_conv_id, (
+            f"[{label}] conversation id: expected {expected_conv_id!r}, got "
+            f"{roundtrip.parsed.provider_conversation_id!r}"
+        )
+
+    messages = list(hydrated.messages)
+    expected_min = expectations.get("min_messages", 1)
+    assert len(messages) >= expected_min, f"[{label}] expected ≥{expected_min} hydrated messages, got {len(messages)}"
+
+    parsed_roles = [str(m.role) for m in roundtrip.parsed.messages]
+    hydrated_roles = [str(m.role) for m in messages]
+    assert sorted(parsed_roles) == sorted(hydrated_roles), (
+        f"[{label}] role multiset diverged: parsed={parsed_roles} hydrated={hydrated_roles}"
+    )
+
+    expected_roles = expectations.get("roles")
+    if expected_roles is not None:
+        assert hydrated_roles == expected_roles, f"[{label}] roles expected {expected_roles}, got {hydrated_roles}"
+
+    # Content-block kinds: assert at the materialization boundary
+    # (``bundle.content_blocks``) — see test_parsers_claude_ai_catalog
+    # for rationale.
+    observed_kinds = {str(b.type) for b in roundtrip.transform.bundle.content_blocks}
+
+    block_types_any_of = expectations.get("block_types_any_of")
+    if block_types_any_of is not None:
+        ok = any(set(kinds).issubset(observed_kinds) for kinds in block_types_any_of)
+        assert ok, f"[{label}] expected one of {block_types_any_of} subset of observed {observed_kinds}"
+
+    must_contain = expectations.get("must_contain_block_type")
+    if must_contain is not None:
+        assert must_contain in observed_kinds, (
+            f"[{label}] expected block kind {must_contain!r} in observed {observed_kinds}"
+        )
+
+    if expectations.get("preserves_order"):
+        timestamps = [m.timestamp for m in messages if m.timestamp is not None]
+        assert timestamps == sorted(timestamps), f"[{label}] hydrated timestamps not ascending: {timestamps}"
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("label", "factory", "expectations"),
+    [pytest.param(label, factory, exp, id=label) for label, factory, exp in _CODEX_METADATA_CATALOG],
+)
+def test_codex_catalog_roundtrip(
+    label: str,
+    factory: PayloadFactory,
+    expectations: Expectations,
+    workspace_env: dict[str, Path],
+) -> None:
+    """Each Codex catalog payload survives parse → transform → save → hydrate.
+
+    Asserts the contract surface required by issue #1184: session id,
+    role normalization, content-block kinds, timestamp ordering.
+    """
+    _assert_roundtrip(factory(), expectations, workspace_env, label)
+
+
+def test_codex_catalog_parser_only_smoke() -> None:
+    """Fast parser-only smoke pass — each catalog entry passes
+    ``looks_like`` and yields ≥1 message via ``parse``."""
+    for label, factory, _expectations in _CODEX_METADATA_CATALOG:
+        payload = factory()
+        assert codex_looks_like(payload), f"[{label}] looks_like rejected the catalog payload"
+        parsed = codex_parse(copy.deepcopy(payload), f"fb-{label}")
+        assert parsed.provider_name == "codex", f"[{label}] wrong provider: {parsed.provider_name}"
+        assert parsed.messages, f"[{label}] parser produced no messages"

--- a/tests/unit/sources/test_parsers_drive_catalog.py
+++ b/tests/unit/sources/test_parsers_drive_catalog.py
@@ -1,0 +1,367 @@
+"""Catalog-driven contract tests for the Drive/Gemini chunked-prompt parser.
+
+Mirrors ``_METADATA_PERMUTATION_CASES`` in
+``tests/unit/sources/test_parsers_chatgpt.py``. Each entry is a
+``(label, payload_factory, expectations)`` triple exercising the
+full parser → transform → save → hydrate pipeline against Gemini's
+``chunkedPrompt.chunks`` shape from ``parsers/drive.py``.
+
+Coverage targets the surfaces called out in issue #1184: text chunks,
+image/inline-file chunks, role variants (``user`` ↔ ``model``), and
+metadata that should survive — ``displayName`` → title, ``createTime``
+ordering, thinking blocks, code-execution results, Drive document
+attachments.
+
+Ref #1184.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, TypeAlias
+
+import pytest
+
+from polylogue.sources.parsers.drive import parse_chunked_prompt
+from polylogue.storage.sqlite.connection import open_connection
+from tests.infra.pipeline_roundtrip import (
+    parse_and_transform_payload,
+    save_transform_and_hydrate,
+)
+from tests.infra.storage_records import db_setup
+
+PayloadFactory: TypeAlias = Callable[[], dict[str, Any]]
+Expectations: TypeAlias = dict[str, Any]
+CatalogCase: TypeAlias = tuple[str, PayloadFactory, Expectations]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _chunk(
+    chunk_id: str,
+    role: str,
+    *,
+    text: str | None = None,
+    create_time: str | None = None,
+    extras: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    chunk: dict[str, Any] = {"id": chunk_id, "role": role}
+    if text is not None:
+        chunk["text"] = text
+    if create_time is not None:
+        chunk["createTime"] = create_time
+    if extras:
+        chunk.update(extras)
+    return chunk
+
+
+def _payload(
+    *,
+    conv_id: str,
+    display_name: str | None,
+    chunks: list[dict[str, Any]],
+    create_time: str = "2024-04-10T08:00:00Z",
+    update_time: str = "2024-04-10T08:30:00Z",
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "id": conv_id,
+        "createTime": create_time,
+        "updateTime": update_time,
+        "chunkedPrompt": {"chunks": chunks},
+    }
+    if display_name is not None:
+        payload["displayName"] = display_name
+    return payload
+
+
+# ---------------------------------------------------------------------------
+# Catalog
+# ---------------------------------------------------------------------------
+
+
+_GEMINI_METADATA_CATALOG: list[CatalogCase] = [
+    (
+        "plain text exchange",
+        lambda: _payload(
+            conv_id="gem-plain",
+            display_name="Plain Gemini",
+            chunks=[
+                _chunk("c1", "user", text="hello", create_time="2024-04-10T08:00:00Z"),
+                _chunk("c2", "model", text="hi back", create_time="2024-04-10T08:00:05Z"),
+            ],
+        ),
+        {
+            "title": "Plain Gemini",
+            "roles": ["user", "assistant"],
+            "block_types_any_of": [["text"]],
+            "preserves_order": True,
+        },
+    ),
+    (
+        "displayName missing → fallback title",
+        lambda: _payload(
+            conv_id="gem-fallback",
+            display_name=None,
+            chunks=[
+                _chunk("c1", "user", text="q", create_time="2024-04-10T08:00:00Z"),
+                _chunk("c2", "model", text="a", create_time="2024-04-10T08:00:01Z"),
+            ],
+        ),
+        {
+            # ``parse_chunked_prompt`` falls back to the fallback_id when no
+            # displayName is supplied.
+            "fallback_title": True,
+            "roles": ["user", "assistant"],
+        },
+    ),
+    (
+        "role variants: model normalised to assistant",
+        lambda: _payload(
+            conv_id="gem-roles",
+            display_name="Roles",
+            chunks=[
+                _chunk("c1", "user", text="ping", create_time="2024-04-10T08:00:00Z"),
+                _chunk("c2", "model", text="pong", create_time="2024-04-10T08:00:01Z"),
+                _chunk("c3", "user", text="again", create_time="2024-04-10T08:00:02Z"),
+                _chunk("c4", "model", text="sure", create_time="2024-04-10T08:00:03Z"),
+            ],
+        ),
+        {
+            "title": "Roles",
+            "roles": ["user", "assistant", "user", "assistant"],
+            "preserves_order": True,
+        },
+    ),
+    (
+        "thinking chunk (isThought + thinkingBudget)",
+        lambda: _payload(
+            conv_id="gem-think",
+            display_name="Thinking",
+            chunks=[
+                _chunk("c1", "user", text="reason", create_time="2024-04-10T08:00:00Z"),
+                _chunk(
+                    "c2",
+                    "model",
+                    text="reasoning trace",
+                    create_time="2024-04-10T08:00:01Z",
+                    extras={"isThought": True, "thinkingBudget": 64},
+                ),
+            ],
+        ),
+        {
+            "title": "Thinking",
+            "roles": ["user", "assistant"],
+            "must_contain_block_type": "thinking",
+        },
+    ),
+    (
+        "executable code + code execution result",
+        lambda: _payload(
+            conv_id="gem-code",
+            display_name="Code Exec",
+            chunks=[
+                _chunk("c1", "user", text="run code", create_time="2024-04-10T08:00:00Z"),
+                _chunk(
+                    "c2",
+                    "model",
+                    text="here you go",
+                    create_time="2024-04-10T08:00:01Z",
+                    extras={
+                        "executableCode": {"language": "python", "code": "print('hi')"},
+                        "codeExecutionResult": {"outcome": "OUTCOME_OK", "output": "hi"},
+                    },
+                ),
+            ],
+        ),
+        {
+            "title": "Code Exec",
+            "roles": ["user", "assistant"],
+            "must_contain_block_type": "code",
+            "block_types_any_of": [["code", "tool_result"]],
+        },
+    ),
+    (
+        "Drive document attachment",
+        lambda: _payload(
+            conv_id="gem-doc",
+            display_name="Doc Attached",
+            chunks=[
+                _chunk(
+                    "c1",
+                    "user",
+                    text="see attached",
+                    create_time="2024-04-10T08:00:00Z",
+                    extras={
+                        "driveDocument": {
+                            "id": "doc-1",
+                            "name": "spec.pdf",
+                            "mimeType": "application/pdf",
+                            "sizeBytes": "2048",
+                        }
+                    },
+                ),
+                _chunk("c2", "model", text="ok", create_time="2024-04-10T08:00:01Z"),
+            ],
+        ),
+        {
+            "title": "Doc Attached",
+            "roles": ["user", "assistant"],
+            "must_contain_block_type": "document",
+            "min_attachments": 1,
+        },
+    ),
+    (
+        "inline image attachment",
+        lambda: _payload(
+            conv_id="gem-img",
+            display_name="Inline Image",
+            chunks=[
+                _chunk(
+                    "c1",
+                    "user",
+                    create_time="2024-04-10T08:00:00Z",
+                    extras={
+                        "inlineFile": {
+                            "mimeType": "image/png",
+                            "data": "iVBORw0KGgo=",
+                        }
+                    },
+                ),
+                _chunk("c2", "model", text="image received", create_time="2024-04-10T08:00:01Z"),
+            ],
+        ),
+        {
+            "title": "Inline Image",
+            "roles": ["user", "assistant"],
+            "min_attachments": 1,
+        },
+    ),
+    (
+        "timestamp ordering across out-of-order chunks",
+        lambda: _payload(
+            conv_id="gem-order",
+            display_name="Ordering",
+            # Chunks declared in author order; parser preserves declared order.
+            chunks=[
+                _chunk("c1", "user", text="first", create_time="2024-04-10T08:00:00Z"),
+                _chunk("c2", "model", text="second", create_time="2024-04-10T08:00:01Z"),
+                _chunk("c3", "user", text="third", create_time="2024-04-10T08:00:02Z"),
+            ],
+        ),
+        {
+            "title": "Ordering",
+            "roles": ["user", "assistant", "user"],
+            "preserves_order": True,
+        },
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# Roundtrip assertion
+# ---------------------------------------------------------------------------
+
+
+def _assert_roundtrip(
+    payload: dict[str, Any],
+    expectations: Expectations,
+    workspace_env: dict[str, Path],
+    label: str,
+) -> None:
+    raw_bytes = json.dumps(payload).encode("utf-8")
+    db_path = db_setup(workspace_env)
+    with open_connection(db_path) as conn:
+        roundtrip = parse_and_transform_payload("gemini", raw_bytes, workspace_env["archive_root"], unique_id=label)
+        hydrated = save_transform_and_hydrate(roundtrip.transform, conn)
+
+    # Title.
+    expected_title = expectations.get("title")
+    if expected_title is not None:
+        assert hydrated.title == expected_title, f"[{label}] title: expected {expected_title!r}, got {hydrated.title!r}"
+    elif expectations.get("fallback_title"):
+        assert hydrated.title and hydrated.title.startswith("rt-"), (
+            f"[{label}] expected fallback title (parser hydrates fallback_id); got {hydrated.title!r}"
+        )
+
+    messages = list(hydrated.messages)
+    assert messages, f"[{label}] no hydrated messages"
+
+    parsed_roles = [str(m.role) for m in roundtrip.parsed.messages]
+    hydrated_roles = [str(m.role) for m in messages]
+    assert sorted(parsed_roles) == sorted(hydrated_roles), (
+        f"[{label}] role multiset diverged: parsed={parsed_roles} hydrated={hydrated_roles}"
+    )
+
+    expected_roles = expectations.get("roles")
+    if expected_roles is not None:
+        assert hydrated_roles == expected_roles, f"[{label}] roles expected {expected_roles}, got {hydrated_roles}"
+
+    # Content-block kinds: assert at the materialization boundary
+    # (``bundle.content_blocks``) rather than the hydrated Message, see
+    # ``_assert_roundtrip`` docstring in ``test_parsers_claude_ai_catalog``
+    # for the rationale (sync store_records does not yet propagate the
+    # bundle's block rows into MessageRecord.content_blocks).
+    observed_kinds = {str(b.type) for b in roundtrip.transform.bundle.content_blocks}
+
+    block_types_any_of = expectations.get("block_types_any_of")
+    if block_types_any_of is not None:
+        ok = any(set(kinds).issubset(observed_kinds) for kinds in block_types_any_of)
+        assert ok, f"[{label}] expected one of {block_types_any_of} subset of observed {observed_kinds}"
+
+    must_contain = expectations.get("must_contain_block_type")
+    if must_contain is not None:
+        assert must_contain in observed_kinds, (
+            f"[{label}] expected block kind {must_contain!r} in observed {observed_kinds}"
+        )
+
+    # Timestamp ordering.
+    if expectations.get("preserves_order"):
+        timestamps = [m.timestamp for m in messages if m.timestamp is not None]
+        assert timestamps == sorted(timestamps), f"[{label}] hydrated timestamps not ascending: {timestamps}"
+
+    # Attachments.
+    expected_min_attachments = expectations.get("min_attachments")
+    if expected_min_attachments is not None:
+        attachments = list(roundtrip.transform.bundle.attachments)
+        assert len(attachments) >= expected_min_attachments, (
+            f"[{label}] expected ≥{expected_min_attachments} attachments, got {len(attachments)}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("label", "factory", "expectations"),
+    [pytest.param(label, factory, exp, id=label) for label, factory, exp in _GEMINI_METADATA_CATALOG],
+)
+def test_gemini_catalog_roundtrip(
+    label: str,
+    factory: PayloadFactory,
+    expectations: Expectations,
+    workspace_env: dict[str, Path],
+) -> None:
+    """Each Gemini catalog payload survives parse → transform → save → hydrate.
+
+    Asserts the contract surface required by issue #1184: title, role
+    normalization, content-block kinds, timestamp ordering, attachments.
+    """
+    _assert_roundtrip(factory(), expectations, workspace_env, label)
+
+
+def test_gemini_catalog_parser_only_smoke() -> None:
+    """Fast parser-only smoke pass — each catalog entry must parse as
+    Gemini and produce at least one message without raising."""
+    for label, factory, _expectations in _GEMINI_METADATA_CATALOG:
+        payload = factory()
+        parsed = parse_chunked_prompt("gemini", copy.deepcopy(payload), f"fb-{label}")
+        assert parsed.provider_name == "gemini", f"[{label}] wrong provider: {parsed.provider_name}"
+        assert parsed.messages, f"[{label}] parser produced no messages"


### PR DESCRIPTION
## Summary

Mirrors the ChatGPT `_METADATA_PERMUTATION_CASES` catalog pattern in
`tests/unit/sources/test_parsers_chatgpt.py` for the three remaining
parsers called out in #1184: Claude-AI (web export), Gemini (Drive
chunkedPrompt), and Codex (JSONL session envelopes). Each new test
file is a module-level `@pytest.mark.parametrize` over a
`(label, payload_factory, expectations)` triple that runs the full
parser → transform → save → hydrate pipeline through the shared
`tests.infra.pipeline_roundtrip` helpers.

## Problem

PR #928 (under #997's predecessor #807) explicitly deferred parser
contract tests for Claude-AI and Gemini — they remained in the AC3
"uncovered domains" list when #997 was reopened. ChatGPT now has
catalog-driven metadata roundtrip coverage in
`tests/unit/sources/test_parsers_chatgpt.py`; the equivalent did not
exist for the other two providers. Codex had `test_parsers_codex.py`
covering format detection / session metadata / git context, but no
metadata-permutation catalog comparable to ChatGPT's.

## Solution

Three new test files, each ~300 LOC, no per-case copy-paste:

- `tests/unit/sources/test_parsers_claude_ai_catalog.py` — 9
  parametrized cases over the `chat_messages` shape: plain text,
  model variants (claude-3-opus, claude-3-5-sonnet), thinking
  blocks, tool_use + tool_result pair (covering the
  `reclassify_tool_result_envelope` user→tool reclassification),
  attachments, citations metadata in content blocks, system prompt
  prelude, and a rich mixed turn.
- `tests/unit/sources/test_parsers_drive_catalog.py` — 8 cases over
  `chunkedPrompt.chunks`: plain exchange, `displayName` fallback,
  role normalisation (`model` → `assistant`), thinking chunks
  (`isThought` + `thinkingBudget`), `executableCode` +
  `codeExecutionResult`, Drive document attachments, inline image
  attachments, and timestamp ordering.
- `tests/unit/sources/test_parsers_codex_catalog.py` — 8 cases over
  Codex JSONL envelopes: plain exchange, `session_meta` with git
  context + instructions, `developer` → `system` normalisation,
  `function_call` + `function_call_output` → `tool_use` +
  `tool_result`, direct (non-envelope) format, role casing
  normalisation, multi-turn ordering, and state-record skipping.

Each catalog:
- Uses `@pytest.mark.parametrize` against a module-level list.
- Reuses `tests.infra.pipeline_roundtrip.parse_and_transform_payload`
  / `save_transform_and_hydrate` and `tests.infra.storage_records.db_setup`.
- Asserts title, role normalisation, content-block kinds,
  timestamp ordering, and attachment counts where applicable.
- Includes a fast parser-only smoke test that walks the catalog
  without going through storage so a parser-side regression is
  caught before the pipeline roundtrip runs.

Non-obvious decision: content-block kind assertions read
`roundtrip.transform.bundle.content_blocks` (the materialisation
boundary) instead of the hydrated `Message.content_blocks`, because
the sync `store_records` helper does not currently propagate the
bundle's content_block rows through `MessageRecord.content_blocks`;
the materialised bundle is the canonical block representation the
daemon write path persists. Title, role, and timestamp assertions
still run against the hydrated `Conversation`.

The AC's "reuse `schema_conformant_payload(provider)` where
possible" is satisfied transitively: `test_parser_crashlessness.py`
and `test_parsers_props.py` already drive the same parsers with
schema-conformant Hypothesis payloads; this PR adds a complementary
hand-curated catalog where each row exercises a specific named
metadata surface.

## Verification

```
nix develop -c pytest tests/unit/sources/test_parsers_claude_ai_catalog.py \
                     tests/unit/sources/test_parsers_drive_catalog.py \
                     tests/unit/sources/test_parsers_codex_catalog.py \
                     -p no:cacheprovider -o "addopts="
# 28 passed, 1 warning in 0.30s

nix develop -c devtools verify --quick
# exit_code: 0  (format, lint, mypy, render-all --check, manifest gates)
```

Pre-existing master failures (`tests/infra/test_storage_records.py::test_store_records_commits_within_lock` — `no such table: user_marks`; topology-projection / artifact-graph cells; surface→storage boundary lint) are present on the underlying branch before this change and are unrelated to the catalog additions. Verified by stashing the three new files and re-running the affected suites.

Closes #1184