### PR TITLE
fix(devtools): resolve repo root from cwd, not hard-pin (#1209)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -17,13 +17,9 @@
       };
       python = pkgs.python313;
 
-      devtoolsCli = pkgs.writeShellScriptBin "devtools" ''
-        if [ -z "''${POLYLOGUE_REPO_ROOT:-}" ]; then
-          echo "devtools: POLYLOGUE_REPO_ROOT is not set; enter the project devshell first" >&2
-          exit 1
-        fi
-        exec python "$POLYLOGUE_REPO_ROOT/devtools/__main__.py" "$@"
-      '';
+      # Script body lives in nix/devtools-wrapper.sh so it can be unit-tested
+      # directly (see tests/unit/devtools/test_cli_wrapper.py).
+      devtoolsCli = pkgs.writeShellScriptBin "devtools" (builtins.readFile ./nix/devtools-wrapper.sh);
 
       polylogue = pkgs.python313Packages.buildPythonPackage {
         pname = "polylogue";

--- a/nix/devtools-wrapper.sh
+++ b/nix/devtools-wrapper.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# devtools CLI wrapper.
+#
+# Resolves the polylogue checkout from the caller's cwd (via `git
+# rev-parse --show-toplevel`) so the wrapper is worktree-aware: running
+# `devtools` from inside a worktree operates on that worktree, not on
+# whichever checkout's devshell happened to export POLYLOGUE_REPO_ROOT
+# first.
+#
+# Resolution order:
+#   1. git rev-parse --show-toplevel from $PWD (if that root has
+#      devtools/__main__.py)
+#   2. $POLYLOGUE_REPO_ROOT (if set and pointing at a real checkout) —
+#      fallback for callers outside any git checkout (e.g. tarball
+#      extraction) that still set the env var explicitly
+#   3. error out with a clear message
+#
+# Owned by issue #1209; tested in tests/unit/devtools/test_cli_wrapper.py.
+
+set -euo pipefail
+
+resolved=""
+if git_root=$(git rev-parse --show-toplevel 2>/dev/null); then
+  if [ -f "$git_root/devtools/__main__.py" ]; then
+    resolved="$git_root"
+  fi
+fi
+if [ -z "$resolved" ] && [ -n "${POLYLOGUE_REPO_ROOT:-}" ] \
+    && [ -f "$POLYLOGUE_REPO_ROOT/devtools/__main__.py" ]; then
+  resolved="$POLYLOGUE_REPO_ROOT"
+fi
+if [ -z "$resolved" ]; then
+  echo "devtools: cannot locate a polylogue checkout (no git root with devtools/__main__.py, and POLYLOGUE_REPO_ROOT is unset or invalid)" >&2
+  exit 1
+fi
+
+exec python "$resolved/devtools/__main__.py" "$@"

--- a/tests/unit/devtools/test_cli_wrapper.py
+++ b/tests/unit/devtools/test_cli_wrapper.py
@@ -1,0 +1,159 @@
+"""Regression tests for the `devtools` CLI shell wrapper (`nix/devtools-wrapper.sh`).
+
+The wrapper resolves the polylogue checkout from the caller's cwd via
+`git rev-parse --show-toplevel` so it is worktree-aware (issue #1209,
+companion to #1193). These tests guard that contract directly against the
+shell script — the same script is read verbatim into the flake's
+`writeShellScriptBin`, so they cover what Nix actually installs.
+
+The tests do not require Nix or the flake to be built. They invoke
+`bash <wrapper>` in subprocesses with controlled environments.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+# Path to the wrapper script, relative to the repo root the wrapper itself
+# would discover (this test file lives under tests/unit/devtools/).
+REPO_ROOT = Path(__file__).resolve().parents[3]
+WRAPPER = REPO_ROOT / "nix" / "devtools-wrapper.sh"
+
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("bash") is None or shutil.which("git") is None,
+    reason="wrapper test requires bash and git",
+)
+
+
+def _run_wrapper(
+    *args: str,
+    cwd: Path,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    base_env = {
+        # Provide PATH so bash, python, and git are discoverable; otherwise
+        # set HOME to a tmp value so git doesn't read the developer's config.
+        "PATH": os.environ["PATH"],
+        "HOME": str(cwd),
+    }
+    if env is not None:
+        base_env.update(env)
+    return subprocess.run(
+        ["bash", str(WRAPPER), *args],
+        cwd=str(cwd),
+        env=base_env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+
+def _make_fake_checkout(root: Path) -> None:
+    """Create a minimal git repo with a stub devtools/__main__.py that
+    just prints its own __file__ on stdout so the caller can verify which
+    checkout the wrapper resolved."""
+    subprocess.run(["git", "init", "-q", str(root)], check=True)
+    devtools = root / "devtools"
+    devtools.mkdir()
+    (devtools / "__main__.py").write_text("import sys\nprint(__file__)\nprint('args=' + repr(sys.argv[1:]))\n")
+
+
+def test_wrapper_resolves_from_cwd_git_root(tmp_path: Path) -> None:
+    """Calling the wrapper from inside a git checkout should resolve to
+    that checkout, regardless of POLYLOGUE_REPO_ROOT."""
+    checkout = tmp_path / "checkout"
+    checkout.mkdir()
+    _make_fake_checkout(checkout)
+
+    result = _run_wrapper("hello", cwd=checkout)
+    assert result.returncode == 0, result.stderr
+    expected = str(checkout / "devtools" / "__main__.py")
+    assert expected in result.stdout, result.stdout
+    assert "args=['hello']" in result.stdout
+
+
+def test_wrapper_prefers_cwd_over_env_var(tmp_path: Path) -> None:
+    """When POLYLOGUE_REPO_ROOT points to a different checkout but the
+    cwd is inside a valid git checkout, cwd wins. This is the worktree
+    scenario from #1193."""
+    main_checkout = tmp_path / "main"
+    worktree = tmp_path / "worktree"
+    main_checkout.mkdir()
+    worktree.mkdir()
+    _make_fake_checkout(main_checkout)
+    _make_fake_checkout(worktree)
+
+    result = _run_wrapper(
+        cwd=worktree,
+        env={"POLYLOGUE_REPO_ROOT": str(main_checkout)},
+    )
+    assert result.returncode == 0, result.stderr
+    assert str(worktree / "devtools" / "__main__.py") in result.stdout
+    assert str(main_checkout / "devtools" / "__main__.py") not in result.stdout
+
+
+def test_wrapper_falls_back_to_env_var_outside_git(tmp_path: Path) -> None:
+    """When cwd is not in any git checkout, fall back to
+    POLYLOGUE_REPO_ROOT if it points to a real checkout."""
+    fake_checkout = tmp_path / "fake-checkout"
+    fake_checkout.mkdir()
+    devtools = fake_checkout / "devtools"
+    devtools.mkdir()
+    (devtools / "__main__.py").write_text("print(__file__)\n")
+
+    outside_git = tmp_path / "elsewhere"
+    outside_git.mkdir()
+
+    result = _run_wrapper(
+        cwd=outside_git,
+        env={"POLYLOGUE_REPO_ROOT": str(fake_checkout)},
+    )
+    assert result.returncode == 0, result.stderr
+    assert str(fake_checkout / "devtools" / "__main__.py") in result.stdout
+
+
+def test_wrapper_errors_when_no_checkout_resolvable(tmp_path: Path) -> None:
+    """With neither a git checkout nor a valid POLYLOGUE_REPO_ROOT, the
+    wrapper must fail loudly rather than silently picking a wrong path."""
+    outside_git = tmp_path / "elsewhere"
+    outside_git.mkdir()
+
+    result = _run_wrapper(cwd=outside_git, env={})
+    assert result.returncode != 0
+    assert "cannot locate a polylogue checkout" in result.stderr
+
+
+def test_wrapper_ignores_invalid_env_var(tmp_path: Path) -> None:
+    """A stale POLYLOGUE_REPO_ROOT that no longer points at a checkout
+    must not cause the wrapper to invoke a missing __main__.py."""
+    git_root = tmp_path / "real"
+    git_root.mkdir()
+    _make_fake_checkout(git_root)
+
+    stale = tmp_path / "stale-removed"
+    # Note: stale never created.
+
+    result = _run_wrapper(
+        cwd=git_root,
+        env={"POLYLOGUE_REPO_ROOT": str(stale)},
+    )
+    # cwd resolution wins here, env var is ignored because it's invalid.
+    assert result.returncode == 0, result.stderr
+    assert str(git_root / "devtools" / "__main__.py") in result.stdout
+
+
+def test_repo_wrapper_script_has_no_hardcoded_paths() -> None:
+    """The wrapper script itself must not bake in any
+    /realm/project/polylogue path or other developer-specific absolute
+    path. This is the static side of the audit AC for #1209."""
+    body = WRAPPER.read_text()
+    assert "/realm/project/polylogue" not in body
+    # The wrapper may mention POLYLOGUE_REPO_ROOT (as a documented
+    # overridable fallback), but it must not require it.
+    assert "POLYLOGUE_REPO_ROOT is not set" not in body


### PR DESCRIPTION
## Summary

The `devtools` CLI shell wrapper required `POLYLOGUE_REPO_ROOT` and dispatched against it unconditionally. The devshell exports that variable once at entry and it is then inherited by every subshell — including ones cd'd into a worktree — so `devtools verify --quick` run from a worktree silently validated the *main checkout*. This PR makes the wrapper worktree-aware and audits the other CLI wrappers (`polylogue`, `polylogued`, `polylogue-mcp`) for the same anti-pattern.

## Problem

- Observed during PR #1191 implementation, filed as #1193: agent ran `devtools verify --quick` from an isolated worktree, got false-positive green, and the pre-push hook (which also calls `devtools verify --quick`) had the same blind spot.
- #1209 is the audit companion: ensure no installed wrapper in this flake bakes a developer-specific path or inherits the wrong root from env.

## Solution

- Move the wrapper body to `nix/devtools-wrapper.sh` so the same shell script is read into the Nix `writeShellScriptBin` (via `builtins.readFile`) and exercised by unit tests directly — no Nix build required for the regression test.
- New resolution order in the wrapper:
  1. `git rev-parse --show-toplevel` from the caller's cwd, validated by the presence of `devtools/__main__.py`. This is the normal path and makes the wrapper worktree-aware.
  2. `POLYLOGUE_REPO_ROOT`, only when set and pointing at a real checkout. Documented fallback for tarball / non-git extraction cases.
  3. Loud error otherwise. No silent dispatch to a stale or wrong path.
- Audit of the other wrappers:
  - `polylogue`, `polylogued`, `polylogue-mcp` are Python console-script entry points (`[project.scripts]` in `pyproject.toml`) — no path baking, they import the installed package.
  - `flake.nix` `postFixup` wraps them with `wrapProgram` that only scrubs PYTHON* env vars — no path pin.
  - `nix/module.nix` (NixOS module) sets only `POLYLOGUE_CONFIG`; no checkout path.
  - No `/realm/project/polylogue` literal exists anywhere in `flake.nix` or `nix/` (only in a docstring example and test fixtures, both unrelated to the install surface).
- The static side of the audit is enforced by `test_repo_wrapper_script_has_no_hardcoded_paths`, which keeps the script free of `/realm/project/polylogue` and free of any "POLYLOGUE_REPO_ROOT is not set" hard requirement.

The `POLYLOGUE_REPO_ROOT="$PWD"` export in the devshell `shellHook` is retained because it still serves as the documented fallback for tooling that wants an explicit hint; it is no longer load-bearing for `devtools` worktree dispatch.

## Verification

```
$ python -m pytest tests/unit/devtools/test_cli_wrapper.py
6 passed in 8.41s

$ python -m devtools verify --quick
... "exit_code": 0
```

The new tests cover: cwd resolution, cwd-wins-over-env (the #1193 scenario), env-fallback outside git, invalid env-var ignored, no-checkout error path, and the static no-hardcoded-paths guard.

Closes #1209
Closes #1193