### PR TITLE
chore(githooks): detect worktree escape in pre-commit (#1211)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,8 +1,54 @@
 #!/usr/bin/env bash
 # Fast pre-commit gate: format + lint only.
 # Installed automatically by the devshell (shellHook in flake.nix).
+#
+# Worktree-escape detector (#1211):
+#   Agents working in isolated git worktrees occasionally `cd` into a
+#   different directory before committing, which can route the commit to
+#   an unintended branch and corrupt both the worktree and the target
+#   checkout. When git reports a worktree context (the per-worktree git
+#   dir differs from the shared common dir), we resolve the worktree's
+#   real root from `$GIT_DIR/gitdir` and verify that the current working
+#   directory is inside that worktree. If it isn't, we abort with a
+#   clear diagnostic before any commit lands in the wrong place.
+#
+#   Override (for legitimate cross-worktree commit flows):
+#     POLYLOGUE_ALLOW_WORKTREE_ESCAPE=1 git commit ...
 
 set -euo pipefail
+
+# Worktree-escape detection.
+git_dir=$(git rev-parse --git-dir)
+git_common_dir=$(git rev-parse --git-common-dir)
+git_dir_abs=$(cd "$git_dir" && pwd -P)
+git_common_dir_abs=$(cd "$git_common_dir" && pwd -P)
+
+if [ "$git_dir_abs" != "$git_common_dir_abs" ]; then
+  # We are in a linked worktree. The per-worktree gitdir file points at
+  # the worktree's .git file; its parent is the worktree root.
+  if [ -f "$git_dir_abs/gitdir" ]; then
+    worktree_dotgit=$(cat "$git_dir_abs/gitdir")
+    worktree_root=$(cd "$(dirname "$worktree_dotgit")" && pwd -P)
+    pwd_real=$(pwd -P)
+    case "$pwd_real/" in
+      "$worktree_root"/*) ;;
+      *)
+        if [ "${POLYLOGUE_ALLOW_WORKTREE_ESCAPE:-0}" != "1" ]; then
+          echo "pre-commit: worktree escape detected" >&2
+          echo "  expected worktree root: $worktree_root" >&2
+          echo "  current directory:      $pwd_real" >&2
+          echo "  git common dir:         $git_common_dir_abs" >&2
+          echo "  per-worktree git dir:   $git_dir_abs" >&2
+          echo "" >&2
+          echo "  Refusing to commit. cd back into the worktree, or set" >&2
+          echo "  POLYLOGUE_ALLOW_WORKTREE_ESCAPE=1 to override." >&2
+          exit 1
+        fi
+        echo "pre-commit: worktree escape override active (POLYLOGUE_ALLOW_WORKTREE_ESCAPE=1)" >&2
+        ;;
+    esac
+  fi
+fi
 
 # Only check Python files staged for commit, including renames.
 mapfile -d '' staged < <(git diff --cached --name-only -z --diff-filter=ACMR -- '*.py')

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -273,6 +273,13 @@ The repository should stay aligned with the workflow above:
 The devshell installs git hooks automatically (`core.hooksPath .githooks`):
 
 - **pre-commit**: `ruff format --check` + `ruff check` on staged files.
+  Also runs a worktree-escape detector (#1211): when committing from a
+  linked worktree, the hook resolves the worktree root from its per-
+  worktree git dir and aborts if the current working directory has
+  drifted outside that root (a common failure mode when an agent
+  `cd`s into the main checkout from inside a worktree). Set
+  `POLYLOGUE_ALLOW_WORKTREE_ESCAPE=1` for legitimate cross-worktree
+  commit flows.
 - **pre-push**: `devtools verify --quick` (format, lint, mypy, generated
   surfaces, and fast manifest checks).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -180,6 +180,13 @@ The repository should stay aligned with the workflow above:
 The devshell installs git hooks automatically (`core.hooksPath .githooks`):
 
 - **pre-commit**: `ruff format --check` + `ruff check` on staged files.
+  Also runs a worktree-escape detector (#1211): when committing from a
+  linked worktree, the hook resolves the worktree root from its per-
+  worktree git dir and aborts if the current working directory has
+  drifted outside that root (a common failure mode when an agent
+  `cd`s into the main checkout from inside a worktree). Set
+  `POLYLOGUE_ALLOW_WORKTREE_ESCAPE=1` for legitimate cross-worktree
+  commit flows.
 - **pre-push**: `devtools verify --quick` (format, lint, mypy, generated
   surfaces, and fast manifest checks).
 


### PR DESCRIPTION
## Summary

Add a worktree-escape detector to `.githooks/pre-commit`. When git
reports a linked-worktree context, the hook verifies that the current
working directory is inside that worktree's real root and aborts the
commit with a clear diagnostic if it has drifted elsewhere.

## Problem

Agents working in isolated git worktrees occasionally `cd` into a
different directory (most often the main checkout at
`/realm/project/polylogue`) before committing. Git silently routes the
commit to whatever checkout/branch `$PWD` resolves to, which corrupts
both the worktree branch and the unintended target branch. This is
called out as a recurring failure mode in the global agent-orchestration
playbook. There was no pre-commit gate to catch it.

## Solution

`.githooks/pre-commit`:

- Compare `git rev-parse --git-dir` against `git rev-parse --git-common-dir`.
  If they differ, we're in a linked worktree.
- Resolve the worktree's real root from `$GIT_DIR/gitdir` (the file
  inside the per-worktree git dir points at the worktree's `.git` file;
  its parent is the worktree root).
- If `pwd -P` is not under that root, abort with a diagnostic naming the
  expected worktree root, the current directory, the common git dir,
  and the per-worktree git dir.
- Override: `POLYLOGUE_ALLOW_WORKTREE_ESCAPE=1` skips the check for
  legitimate cross-worktree commit flows.

Documented in `CONTRIBUTING.md` under Git Hooks. `AGENTS.md`
regenerated from `CLAUDE.md`.

Closes #1211

## Verification

- Synthetic harness in `/tmp/hook-test` exercising three paths:
  inside-worktree (exit 0), escape (exit 1 with diagnostic), override
  (exit 0 with notice). All passed.
- `devtools verify --quick` → exit 0 (44.32s, all steps green).