### PR TITLE
feat(devtools): failure-context command for agent inner-loop debugging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1228,6 +1228,7 @@ These are the commands worth remembering during normal repo work:
 | Command | Description |
 | --- | --- |
 | `devtools build-package` | Build the default Nix package with the out-link under .local/result. |
+| `devtools failure-context` | Join testmon, git history, fixtures, and witnesses for a pytest failure ID into a JSON envelope. |
 | `devtools witness-discover` | Save a failure-triggering input as a local witness in .local/witnesses/new/. |
 | `devtools witness-minimize` | Apply minimization heuristics to a local witness — shrink, redact, set privacy classification. |
 | `devtools witness-promote` | Promote a minimized local witness to tests/witnesses/ for durable commit. |

--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -655,6 +655,21 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
         ),
     ),
     CommandSpec(
+        "failure-context",
+        "maintenance",
+        "Join testmon, git history, fixtures, and witnesses for a pytest failure ID into a JSON envelope.",
+        "devtools.failure_context",
+        use_when=(
+            "Bootstrap an agent inner-loop debugging session for a failing test — surfaces production "
+            "files the test depends on, their recent commits, fixtures the test uses, and similar "
+            "committed witnesses, all in one structured envelope."
+        ),
+        examples=(
+            "devtools failure-context tests/unit/storage/test_foo.py::test_bar",
+            "devtools failure-context tests/unit/storage/test_foo.py::test_bar --days 14",
+        ),
+    ),
+    CommandSpec(
         "verify-lane-assertions",
         "verification",
         "Verify scenario lanes classified as SEMANTIC_OUTPUT carry semantic assertions.",

--- a/devtools/failure_context.py
+++ b/devtools/failure_context.py
@@ -1,0 +1,210 @@
+"""Aggregate pytest failure context for agent inner-loop debugging.
+
+Joins testmon dependency data, git history, fixture references, and committed
+witnesses into a single JSON envelope keyed by a pytest failure ID
+(e.g. ``tests/unit/storage/test_foo.py::test_bar``).
+
+Usage:
+  devtools failure-context tests/unit/storage/test_foo.py::test_bar
+  devtools failure-context tests/unit/storage/test_foo.py::test_bar --json
+  devtools failure-context tests/unit/storage/test_foo.py::test_bar --days 14
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sqlite3
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TESTMON_DB = REPO_ROOT / ".testmondata"
+WITNESS_DIR = REPO_ROOT / "tests" / "witnesses"
+
+
+def _parse_failure_id(failure_id: str) -> tuple[str, str]:
+    if "::" not in failure_id:
+        raise ValueError(f"failure id must be 'path::test_name', got {failure_id!r}")
+    test_file, _, test_name = failure_id.partition("::")
+    return test_file, test_name
+
+
+def _testmon_dependencies(failure_id: str) -> list[str]:
+    if not TESTMON_DB.exists():
+        return []
+    try:
+        conn = sqlite3.connect(f"file:{TESTMON_DB}?mode=ro", uri=True)
+    except sqlite3.Error:
+        return []
+    try:
+        rows = conn.execute(
+            """
+            SELECT DISTINCT f.filename
+            FROM file_fp f
+            JOIN test_execution_file_fp x ON x.fingerprint_id = f.id
+            JOIN test_execution t ON t.id = x.test_execution_id
+            WHERE t.test_name = ?
+            ORDER BY f.filename
+            """,
+            (failure_id,),
+        ).fetchall()
+    except sqlite3.Error:
+        return []
+    finally:
+        conn.close()
+    return [row[0] for row in rows]
+
+
+def _recent_changes(files: list[str], days: int) -> dict[str, list[dict[str, str]]]:
+    if not files:
+        return {}
+    since = (datetime.now(timezone.utc) - timedelta(days=days)).strftime("%Y-%m-%d")
+    out: dict[str, list[dict[str, str]]] = {}
+    for path in files:
+        try:
+            result = subprocess.run(
+                [
+                    "git",
+                    "log",
+                    f"--since={since}",
+                    "--pretty=format:%h%x09%ad%x09%s",
+                    "--date=short",
+                    "--",
+                    path,
+                ],
+                cwd=REPO_ROOT,
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=10,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            continue
+        commits: list[dict[str, str]] = []
+        for line in result.stdout.splitlines():
+            parts = line.split("\t", 2)
+            if len(parts) == 3:
+                commits.append({"sha": parts[0], "date": parts[1], "subject": parts[2]})
+        if commits:
+            out[path] = commits
+    return out
+
+
+_FIXTURE_RE = re.compile(r"def\s+test_\w+\s*\(([^)]*)\)")
+_PARAM_SPLIT = re.compile(r"[,\s]+")
+
+
+def _related_fixtures(test_file: str, test_name: str) -> list[str]:
+    path = REPO_ROOT / test_file
+    if not path.exists():
+        return []
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return []
+    base_name = test_name.split("[", 1)[0]
+    fixtures: set[str] = set()
+    pattern = re.compile(rf"def\s+{re.escape(base_name)}\s*\(([^)]*)\)")
+    match = pattern.search(text)
+    if match:
+        for token in _PARAM_SPLIT.split(match.group(1)):
+            token = token.strip()
+            if not token or token in {"self", "cls"}:
+                continue
+            token = token.split(":", 1)[0].strip()
+            token = token.split("=", 1)[0].strip()
+            if token and token != "*" and not token.startswith("*"):
+                fixtures.add(token)
+    return sorted(fixtures)
+
+
+def _similar_witnesses(failure_id: str, limit: int = 5) -> list[dict[str, Any]]:
+    if not WITNESS_DIR.exists():
+        return []
+    test_file, test_name = _parse_failure_id(failure_id)
+    base_name = test_name.split("[", 1)[0]
+    # Tokenize the failure id into substring keywords for matching.
+    tokens = {tok for tok in re.split(r"[\W_/.]+", f"{test_file} {base_name}") if len(tok) > 3}
+    matches: list[tuple[int, dict[str, Any]]] = []
+    for witness_path in sorted(WITNESS_DIR.glob("*.witness.json")):
+        try:
+            data = json.loads(witness_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        haystack = json.dumps(data).lower()
+        score = sum(1 for tok in tokens if tok.lower() in haystack)
+        source_test = data.get("provenance", {}).get("source_test", "")
+        if source_test and source_test == test_file:
+            score += 10
+        if score:
+            matches.append(
+                (
+                    score,
+                    {
+                        "witness_id": data.get("witness_id"),
+                        "path": str(witness_path.relative_to(REPO_ROOT)),
+                        "source_test": source_test or None,
+                        "score": score,
+                    },
+                )
+            )
+    matches.sort(key=lambda item: (-item[0], item[1]["witness_id"] or ""))
+    return [entry for _score, entry in matches[:limit]]
+
+
+def build_envelope(failure_id: str, days: int) -> dict[str, Any]:
+    test_file, test_name = _parse_failure_id(failure_id)
+    dependencies = _testmon_dependencies(failure_id)
+    return {
+        "failure_id": failure_id,
+        "test_file": test_file,
+        "test_name": test_name,
+        "testmon_dependencies": dependencies,
+        "recent_changes": _recent_changes(dependencies, days),
+        "related_fixtures": _related_fixtures(test_file, test_name),
+        "similar_witnesses": _similar_witnesses(failure_id),
+        "metadata": {
+            "days_window": days,
+            "testmon_db_present": TESTMON_DB.exists(),
+            "witness_dir_present": WITNESS_DIR.exists(),
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+        },
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Join testmon, git, fixtures, and witnesses for a pytest failure ID.")
+    parser.add_argument(
+        "failure_id",
+        type=str,
+        help="Pytest failure ID, e.g. tests/unit/storage/test_foo.py::test_bar",
+    )
+    parser.add_argument("--days", type=int, default=30, help="Git log window in days (default: 30).")
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit JSON to stdout (default when stdout is not a TTY).",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        envelope = build_envelope(args.failure_id, args.days)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    sys.stdout.write(json.dumps(envelope, indent=2, sort_keys=True))
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -146,6 +146,7 @@ These are the commands worth remembering during normal repo work:
 | Command | Description |
 | --- | --- |
 | `devtools build-package` | Build the default Nix package with the out-link under .local/result. |
+| `devtools failure-context` | Join testmon, git history, fixtures, and witnesses for a pytest failure ID into a JSON envelope. |
 | `devtools witness-discover` | Save a failure-triggering input as a local witness in .local/witnesses/new/. |
 | `devtools witness-minimize` | Apply minimization heuristics to a local witness — shrink, redact, set privacy classification. |
 | `devtools witness-promote` | Promote a minimized local witness to tests/witnesses/ for durable commit. |

--- a/tests/unit/devtools/test_failure_context.py
+++ b/tests/unit/devtools/test_failure_context.py
@@ -1,0 +1,147 @@
+"""Tests for ``devtools/failure_context.py``."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from devtools import failure_context as fc
+
+
+@pytest.fixture()
+def stub_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect the module's REPO_ROOT/TESTMON_DB/WITNESS_DIR to a temp tree."""
+    monkeypatch.setattr(fc, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(fc, "TESTMON_DB", tmp_path / ".testmondata")
+    monkeypatch.setattr(fc, "WITNESS_DIR", tmp_path / "tests" / "witnesses")
+    return tmp_path
+
+
+def _seed_testmon(db_path: Path, mapping: dict[str, list[str]]) -> None:
+    conn = sqlite3.connect(db_path)
+    conn.executescript(
+        """
+        CREATE TABLE test_execution (id INTEGER PRIMARY KEY, environment_id INTEGER,
+            test_name TEXT, duration FLOAT, failed BIT, forced BIT);
+        CREATE TABLE file_fp (id INTEGER PRIMARY KEY, filename TEXT,
+            method_checksums BLOB, mtime FLOAT, fsha TEXT);
+        CREATE TABLE test_execution_file_fp (test_execution_id INTEGER, fingerprint_id INTEGER);
+        """
+    )
+    file_id = 1
+    test_id = 1
+    for test_name, files in mapping.items():
+        conn.execute("INSERT INTO test_execution(id, test_name) VALUES (?, ?)", (test_id, test_name))
+        for filename in files:
+            conn.execute("INSERT INTO file_fp(id, filename) VALUES (?, ?)", (file_id, filename))
+            conn.execute(
+                "INSERT INTO test_execution_file_fp(test_execution_id, fingerprint_id) VALUES (?, ?)",
+                (test_id, file_id),
+            )
+            file_id += 1
+        test_id += 1
+    conn.commit()
+    conn.close()
+
+
+def test_parse_failure_id_splits_path_and_name() -> None:
+    assert fc._parse_failure_id("tests/foo.py::test_bar") == ("tests/foo.py", "test_bar")
+
+
+def test_parse_failure_id_rejects_missing_separator() -> None:
+    with pytest.raises(ValueError):
+        fc._parse_failure_id("tests/foo.py")
+
+
+def test_testmon_dependencies_returns_sorted_unique(stub_repo: Path) -> None:
+    _seed_testmon(
+        stub_repo / ".testmondata",
+        {"tests/unit/foo.py::test_a": ["polylogue/b.py", "polylogue/a.py"]},
+    )
+    deps = fc._testmon_dependencies("tests/unit/foo.py::test_a")
+    assert deps == ["polylogue/a.py", "polylogue/b.py"]
+
+
+def test_testmon_dependencies_handles_missing_db(stub_repo: Path) -> None:
+    assert fc._testmon_dependencies("tests/foo.py::test_missing") == []
+
+
+def test_related_fixtures_extracts_parametrized_test(stub_repo: Path) -> None:
+    test_file = stub_repo / "tests" / "unit" / "sample.py"
+    test_file.parent.mkdir(parents=True)
+    test_file.write_text(
+        "def test_thing(tmp_path, workspace_env, value: int = 1) -> None:\n    pass\n",
+        encoding="utf-8",
+    )
+    fixtures = fc._related_fixtures("tests/unit/sample.py", "test_thing[case-a]")
+    assert "tmp_path" in fixtures
+    assert "workspace_env" in fixtures
+    assert "value" in fixtures
+
+
+def test_similar_witnesses_scores_source_test_match(stub_repo: Path) -> None:
+    witness_dir = stub_repo / "tests" / "witnesses"
+    witness_dir.mkdir(parents=True)
+    (witness_dir / "blob.witness.json").write_text(
+        json.dumps(
+            {
+                "witness_id": "storage.blob",
+                "provenance": {"source_test": "tests/unit/storage/test_blob.py"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    (witness_dir / "unrelated.witness.json").write_text(
+        json.dumps({"witness_id": "unrelated", "provenance": {"source_test": "tests/other.py"}}),
+        encoding="utf-8",
+    )
+    results = fc._similar_witnesses("tests/unit/storage/test_blob.py::test_layout")
+    assert results, "expected at least one witness match"
+    assert results[0]["witness_id"] == "storage.blob"
+
+
+def test_build_envelope_shape(stub_repo: Path) -> None:
+    _seed_testmon(
+        stub_repo / ".testmondata",
+        {"tests/unit/foo.py::test_a": ["polylogue/a.py"]},
+    )
+    envelope = fc.build_envelope("tests/unit/foo.py::test_a", days=7)
+    assert envelope["failure_id"] == "tests/unit/foo.py::test_a"
+    assert envelope["test_file"] == "tests/unit/foo.py"
+    assert envelope["test_name"] == "test_a"
+    assert envelope["testmon_dependencies"] == ["polylogue/a.py"]
+    assert "recent_changes" in envelope
+    assert "related_fixtures" in envelope
+    assert "similar_witnesses" in envelope
+    assert envelope["metadata"]["days_window"] == 7
+    assert envelope["metadata"]["testmon_db_present"] is True
+
+
+def test_main_emits_json_envelope(stub_repo: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    _seed_testmon(
+        stub_repo / ".testmondata",
+        {"tests/unit/foo.py::test_a": ["polylogue/a.py"]},
+    )
+    exit_code = fc.main(["tests/unit/foo.py::test_a"])
+    assert exit_code == 0
+    parsed: dict[str, Any] = json.loads(capsys.readouterr().out)
+    assert parsed["failure_id"] == "tests/unit/foo.py::test_a"
+
+
+def test_main_rejects_bad_failure_id(capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = fc.main(["not-a-failure-id"])
+    assert exit_code == 2
+    assert "failure id must be" in capsys.readouterr().err
+
+
+def test_command_registered_in_catalog() -> None:
+    from devtools.command_catalog import COMMANDS
+
+    assert "failure-context" in COMMANDS
+    spec = COMMANDS["failure-context"]
+    assert spec.module == "devtools.failure_context"
+    assert callable(spec.resolve_main())


### PR DESCRIPTION
## Summary

Adds `devtools failure-context FAILURE_ID` — a thin maintenance command that
joins pytest-testmon dependency data, git history of affected files, fixture
references parsed from the test file, and similar committed witnesses into a
single JSON envelope keyed by a pytest failure id
(e.g. `tests/unit/storage/test_foo.py::test_bar`). Output is structured JSON
suitable for direct consumption by debugging agents.

Closes #1283 (Tier-1 recommendation C).

## Problem

When an agent is dispatched to debug a single failing test, the same
mechanical fan-out happens every time: open the test, find the fixtures,
query testmon for the production files this test depends on, run `git log`
on each of those files for recent suspects, and grep `tests/witnesses/` for
related regression cases. Each step is well-defined and each one wastes
agent context. Audit #1283 recommended folding this into one structured
envelope so the inner-loop can start from evidence instead of from
discovery.

## Solution

- `devtools/failure_context.py` (~210 LOC):
  - `_parse_failure_id` validates the `path::name` shape.
  - `_testmon_dependencies` opens `.testmondata` read-only and joins
    `test_execution` → `test_execution_file_fp` → `file_fp` for the failure id.
  - `_recent_changes` runs `git log --since=<days> --pretty=format:%h%x09%ad%x09%s`
    for each dependency, with `--days` controlled by the CLI flag (default 30).
  - `_related_fixtures` re-reads the test file and parses the parameter list
    for `def <base_name>(...)`, stripping `self`, `cls`, type annotations,
    and defaults — handles parametrized id suffixes like `[case-a]`.
  - `_similar_witnesses` scans `tests/witnesses/*.witness.json`, tokenizes the
    failure id, and scores each witness by token overlap plus a +10 bonus when
    `provenance.source_test` matches the failing test file.
  - `build_envelope` returns the joined structure, plus a `metadata` block
    recording window, db presence, witness-dir presence, and `generated_at`.
- Registered as a `maintenance` command in `devtools/command_catalog.py`;
  `docs/devtools.md` and `AGENTS.md` regenerated via `devtools render-all`.
- `tests/unit/devtools/test_failure_context.py` covers id parsing, testmon
  joins with a stubbed `.testmondata`, missing-db tolerance, fixture
  extraction (including parametrized id stripping), witness scoring,
  envelope shape, CLI happy/error paths, and catalog registration.

## Verification

- `nix develop -c pytest tests/unit/devtools/test_failure_context.py tests/unit/devtools/test_command_catalog.py -x -q` → `15 passed in 24.55s`
- `nix develop -c devtools verify --quick` → `"exit_code": 0` (also re-run by `pre-push`)
- `nix develop -c devtools failure-context tests/unit/devtools/test_command_catalog.py::test_command_specs_have_unique_names_and_known_categories --days 60` → emits a fully-populated JSON envelope (validated end-to-end against the live witness corpus).