### PR TITLE
feat(devtools): render use_when/examples into Click --help

### DIFF
--- a/devtools/click_dispatch.py
+++ b/devtools/click_dispatch.py
@@ -53,20 +53,52 @@ def _print_inventory(*, json: bool) -> None:
             click.echo(f"    {spec.name:<25} {spec.description}")
 
 
+class _PreservedEpilogCommand(click.Command):
+    """Click command that emits the epilog verbatim, preserving newlines."""
+
+    def format_epilog(self, ctx: click.Context, formatter: click.HelpFormatter) -> None:
+        if not self.epilog:
+            return
+        formatter.write("\n")
+        for line in self.epilog.splitlines():
+            formatter.write(line + "\n")
+
+
+def _build_epilog(spec: CommandSpec) -> str | None:
+    """Render ``use_when`` and ``examples`` from a CommandSpec into a help epilog.
+
+    Returns ``None`` when neither field has content so Click omits the
+    section entirely.
+    """
+    sections: list[str] = []
+    if spec.use_when:
+        sections.append(f"Use when:\n  {spec.use_when}")
+    if spec.examples:
+        example_lines = "\n".join(f"  {line}" for line in spec.examples)
+        sections.append(f"Examples:\n{example_lines}")
+    if not sections:
+        return None
+    return "\n\n".join(sections)
+
+
 def _make_command(spec: CommandSpec) -> click.Command:
     """Create a Click command from a CommandSpec.
 
     Args after the command name are forwarded as-is to the spec's
     resolve_main() entrypoint.  The ``--json`` flag is accepted both at
     the root group level (propagated via ctx.obj) and locally on each
-    command.
+    command.  ``--inner-help`` proxies ``--help`` to the wrapped
+    argparse entrypoint so callers can discover sub-flags the catalog
+    does not declare.
     """
     from devtools.command_catalog import COMMANDS
 
-    def callback(args: tuple[str, ...], json_flag: bool = False) -> None:
+    def callback(args: tuple[str, ...], json_flag: bool = False, inner_help: bool = False) -> None:
         ctx = click.get_current_context()
         root_json = ctx.obj.get("json", False) if ctx.obj else False
         argv = list(args)
+        if inner_help:
+            argv = [*argv, "--help"]
         if json_flag or root_json:
             argv = [*argv, "--json"]
         # Resolve at call time so monkeypatching COMMANDS works (used in tests)
@@ -86,11 +118,18 @@ def _make_command(spec: CommandSpec) -> click.Command:
             help="Emit machine-readable JSON for this command.",
             expose_value=True,
         ),
+        click.Option(
+            ["--inner-help", "inner_help"],
+            is_flag=True,
+            help="Forward --help to the wrapped command for its native flag list.",
+            expose_value=True,
+        ),
     ]
 
-    cmd = click.Command(
+    cmd = _PreservedEpilogCommand(
         name=spec.name,
         help=spec.description,
+        epilog=_build_epilog(spec),
         callback=callback,
         params=params,
     )


### PR DESCRIPTION
## Summary

`devtools <cmd> --help` now renders the `use_when` and `examples` fields from the
`CommandSpec` catalog as a help epilog, and a new `--inner-help` flag proxies
`--help` through to the wrapped argparse entrypoint so the native sub-flags are
discoverable.

## Problem

Audit #1283 (Tier-1 recommendation A): every `CommandSpec` carries `use_when`
and `examples`, but those fields only flowed into `docs/devtools.md`. Runtime
`devtools <cmd> --help` showed only the one-line description, so agents had to
read generated docs or source to learn the intended trigger and shape of each
command. The Click wrapper also fully swallowed the wrapped argparse `--help`,
hiding sub-flags (e.g. `devtools verify --quick`, `--lab`, `--seed-testmon`).

## Solution

`devtools/click_dispatch.py`:

- `_build_epilog(spec)` formats `Use when:` and `Examples:` sections from the
  spec.
- `_PreservedEpilogCommand` subclasses `click.Command` and overrides
  `format_epilog` so each authored line is emitted verbatim (default Click
  rewraps and collapses the newlines).
- New `--inner-help` option on every generated subcommand appends `--help` to
  the forwarded argv so the underlying argparse `main(argv)` prints its own
  usage. Cleanly co-exists with Click's own `--help`.

No catalog change required; `CommandSpec` already exposes the fields.

## Verification

- `devtools verify --quick` -> exit 0 (44.95s, full quick baseline).
- `devtools status --help` -> shows `Use when:` + `Examples:` block with the
  three documented invocations from `command_catalog.py`.
- `devtools verify --inner-help` -> prints argparse usage with `--quick`,
  `--seed-testmon`, `--all`, `--full`, `--lab`, `--history`, `--json`.

Ref #1283