### PR TITLE
fix(devtools): silence pipeline-probe detection-fallback traceback

### DIFF
--- a/polylogue/sources/dispatch.py
+++ b/polylogue/sources/dispatch.py
@@ -179,11 +179,19 @@ def _detect_provider_from_raw_bytes(
     try:
         stream = _iter_json_stream(BytesIO(stream_bytes), stream_name)
         payloads = list(islice(stream, 32)) if jsonl_like else list(stream)
-    except Exception:
-        logger.exception(
-            "Provider detection by JSON-stream parsing failed for %s; falling back to %s",
-            stream_name,
-            fallback_provider.value,
+    except Exception as exc:
+        # JSON-stream detection commonly fails on payloads that the
+        # record-shape detectors above already handled (or that simply do
+        # not parse as a record stream — e.g. ChatGPT bundles read via
+        # `devtools pipeline-probe`). Emit a structured WARNING rather
+        # than a Rich traceback so default invocations do not look
+        # broken when the fallback is the intended path.
+        logger.warning(
+            "provider_detection_stream_fallback",
+            stream_name=stream_name,
+            fallback_provider=fallback_provider.value,
+            error_type=type(exc).__name__,
+            error=str(exc),
         )
         return fallback_provider
 


### PR DESCRIPTION
## Summary

`devtools pipeline-probe` prints ~780 lines of Rich traceback to stderr on default invocation, even though stdout JSON is correct and the fallback is the intended path. Replace the bare `logger.exception` in `_detect_provider_from_raw_bytes` with a structured `logger.warning`. Stderr now shows one warning line per stream instead of a stack-trace panel.

## Problem

Audit #1283 (Tier-1 recommendation D) — `devtools pipeline-probe` looks broken on first invocation. The synthetic ChatGPT bundles emitted by the probe fail the record-stream parse path in `polylogue/sources/dispatch.py:181`, which is then caught and logged with `logger.exception(...)`. structlog renders that as a full Rich traceback (locals + chained frames) to stderr. Agents reading the probe output reasonably treat it as failure, even though it is the intended fallback.

Measured before:
```
$ devtools pipeline-probe 2>err.txt >out.txt; wc -l err.txt
781 err.txt
```

## Solution

`polylogue/sources/dispatch.py` — swap `logger.exception(...)` for `logger.warning("provider_detection_stream_fallback", stream_name=..., fallback_provider=..., error_type=..., error=...)`. The fallback semantics are unchanged; only the log shape changes. Inline comment explains why the failure is expected on bundle inputs.

Alternatives rejected: adding a quiet flag (Tier-1 D mentions this) would change the probe's surface; the actual defect is misuse of `logger.exception` for an expected-fallback path. Fix the log call instead.

## Verification

```
$ devtools pipeline-probe 2>err.txt >out.txt; wc -l err.txt; python3 -c "import json; json.load(open('out.txt'))"
11 err.txt
# JSON parses cleanly

$ devtools verify --quick --json | jq '.exit_code'
0
```

Ref #1283