### PR TITLE
ci(pages): auto-publish gh-pages on master merge (#1230)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
   pages: write
   id-token: write
 
@@ -15,35 +15,32 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-and-deploy:
+  build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+      - uses: cachix/install-nix-action@v31
         with:
-          python-version: "3.13"
-          enable-cache: true
-
-      - name: Install dependencies
-        run: uv sync --extra dev --frozen
-
-      - name: Install Pagefind
-        run: |
-          curl -L https://github.com/CloudCannon/pagefind/releases/latest/download/pagefind-v1.3.0-x86_64-unknown-linux-musl.tar.gz | tar xz
-          mv pagefind /usr/local/bin/
+          nix_path: nixpkgs=channel:nixos-unstable
 
       - name: Build site
-        run: uv run devtools render-pages --skip-pagefind --output _site
+        run: nix develop --command devtools render-pages
 
-      - name: Index with Pagefind
-        run: pagefind --site _site/
-
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./_site
-          destination_dir: .
-          force_orphan: true
+          path: .cache/site/
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -231,6 +231,8 @@ routing, and evidence-operator surface.
 <!-- BEGIN GENERATED: docs-surface -->
 ## Documentation
 
+Live site: <https://sinity.github.io/polylogue/> (auto-published on every merge to `master`).
+
 Start with the generated command and architecture references; use [docs/README.md](docs/README.md) for the complete map.
 
 | Document | Description |

--- a/devtools/render_docs_surface.py
+++ b/devtools/render_docs_surface.py
@@ -128,6 +128,8 @@ def build_readme_section(
             "<!-- BEGIN GENERATED: docs-surface -->",
             "## Documentation",
             "",
+            "Live site: <https://sinity.github.io/polylogue/> (auto-published on every merge to `master`).",
+            "",
             "Start with the generated command and architecture references; "
             "use [docs/README.md](docs/README.md) for the complete map.",
             "",


### PR DESCRIPTION
## Summary

Replaces the prior `peaceiris/actions-gh-pages`-based Pages workflow with one
that uses the nix devshell to invoke `devtools render-pages` and publishes via
the GitHub-native `actions/upload-pages-artifact` + `actions/deploy-pages`
pair. Runs on push to `master` and `workflow_dispatch` only. Adds a live-site
link to the generated README documentation surface so the published docs are
discoverable.

## Problem

`devtools render-pages` builds the GitHub Pages site into `.cache/site/`, but
no workflow publishes it on merge to `master` — the published site drifts
from the current state of the repo, and the README has no pointer to a live
URL. Issue #1230.

## Solution

- `.github/workflows/pages.yml` — rewritten to use Nix devshell + the native
  `actions/deploy-pages` flow. Two-job split (`build` → `deploy`) so the
  deployment step runs in the `github-pages` environment and publishes the
  uploaded artifact at `.cache/site/`. Concurrency group `pages` with
  `cancel-in-progress: true` keeps overlapping master pushes from racing.
- `devtools/render_docs_surface.py` — adds a one-line live-site link
  (`https://sinity.github.io/polylogue/`) at the top of the generated
  `## Documentation` section in the README.
- `README.md` — regenerated via `devtools render-all`.
- Repository Pages source set to GitHub Actions (`gh api -X POST repos/Sinity/polylogue/pages -f build_type=workflow`).

The ambitious-expansion items called out on #1230 (per-PR preview deployments
and versioned doc trees per release) are deferred to follow-up #1307 so the
base auto-publish can land cleanly.

## Verification

- `devtools render-all` — regenerates docs-surface, agents, pages cleanly.
- `devtools verify --quick` — exit 0 in 37.6s (format, lint, mypy, render-all
  --check, all manifest/topology/CI-workflows lints green).
- `gh api repos/Sinity/polylogue/pages` confirms `build_type: workflow` and
  `html_url: https://sinity.github.io/polylogue/` post-config.

Closes #1230
Ref #1307