### PR TITLE
feat(dist): PyPI trusted-publisher workflow with installed smoke (#1234)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,10 @@
 name: Release
 
 # Triggered by pushing an annotated tag matching `vX.Y.Z`. Builds the
-# wheel + sdist, smokes them through verify-distribution-surface, then:
+# wheel + sdist, smokes them through verify-distribution-surface on the
+# build host, runs an installed-wheel smoke matrix across supported
+# Python versions on Linux + macOS, signs the artifacts with Sigstore
+# keyless OIDC, emits a CycloneDX SBOM, then:
 #   - publishes to PyPI via Trusted Publishing (OIDC, no API token), and
 #   - builds + pushes a multi-stage OCI image to ghcr.io.
 #
@@ -50,20 +53,115 @@ jobs:
         run: uv run devtools verify-distribution-surface --work-dir "${RUNNER_TEMP}/dist" --keep-work-dir
         env:
           POLYLOGUE_FORCE_PLAIN: "1"
+      - name: twine check (PyPI metadata long-description renderability)
+        run: |
+          uv run --with twine python -m twine check "${RUNNER_TEMP}/dist/dist"/*.whl "${RUNNER_TEMP}/dist/dist"/*.tar.gz
       - name: Extract project version from pyproject.toml
         id: version
         run: |
           version=$(uv run python -c "import tomllib, pathlib; print(tomllib.loads(pathlib.Path('pyproject.toml').read_text())['project']['version'])")
           echo "version=${version}" >> "${GITHUB_OUTPUT}"
+      - name: Stage top-level wheel + sdist for downstream jobs
+        run: |
+          mkdir -p staged-dist
+          cp "${RUNNER_TEMP}/dist/dist"/*.whl staged-dist/
+          cp "${RUNNER_TEMP}/dist/dist"/*.tar.gz staged-dist/
+          ls -la staged-dist/
       - uses: actions/upload-artifact@v7
         with:
           name: distribution-artifacts
-          path: ${{ runner.temp }}/dist/dist/*
+          path: staged-dist/*
+          if-no-files-found: error
+
+  installed-smoke:
+    name: installed-smoke (${{ matrix.os }}, py${{ matrix.python-version }})
+    needs: build
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        python-version: ["3.11", "3.12", "3.13"]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/download-artifact@v6
+        with:
+          name: distribution-artifacts
+          path: dist/
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install built wheel into fresh venv
+        shell: bash
+        run: |
+          python -m venv .venv-smoke
+          # shellcheck disable=SC1091
+          source .venv-smoke/bin/activate
+          python -m pip install --upgrade pip
+          wheel=$(ls dist/*.whl | head -n1)
+          echo "Installing ${wheel}"
+          python -m pip install "${wheel}"
+      - name: Smoke installed entrypoints against an empty XDG archive
+        shell: bash
+        env:
+          POLYLOGUE_FORCE_PLAIN: "1"
+        run: |
+          # shellcheck disable=SC1091
+          source .venv-smoke/bin/activate
+          archive_root="${RUNNER_TEMP}/polylogue-archive"
+          mkdir -p "${archive_root}"
+          export POLYLOGUE_ARCHIVE_ROOT="${archive_root}"
+          polylogue --version
+          polylogue --help > /dev/null
+          polylogued --help > /dev/null
+          polylogue-mcp --help > /dev/null
+          # `stats` against an empty XDG archive must not crash on first-run
+          # (covers schema bootstrap on a fresh database).
+          polylogue --plain stats
+          # `--plain count` is the smoke parity with verify-distribution-surface.
+          polylogue --plain count
+          python -m polylogue --version
+
+  sbom:
+    name: sbom
+    needs: build
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v6
+        with:
+          name: distribution-artifacts
+          path: dist/
+      - uses: astral-sh/setup-uv@v8.1.0
+        with:
+          python-version: "3.13"
+      - name: Generate CycloneDX SBOM from built wheel
+        run: |
+          wheel=$(ls dist/*.whl | head -n1)
+          mkdir -p sbom
+          # Resolve the dependency closure inside a fresh venv so the SBOM
+          # reflects what `pip install polylogue==X.Y.Z` would actually pull.
+          uv venv .venv-sbom
+          # shellcheck disable=SC1091
+          source .venv-sbom/bin/activate
+          uv pip install "${wheel}"
+          uv pip install cyclonedx-bom
+          cyclonedx-py environment \
+            --output-format json \
+            --output-file sbom/polylogue-${{ needs.build.outputs.version }}.cdx.json
+          cyclonedx-py environment \
+            --output-format xml \
+            --output-file sbom/polylogue-${{ needs.build.outputs.version }}.cdx.xml
+          ls -la sbom/
+      - uses: actions/upload-artifact@v7
+        with:
+          name: sbom-artifacts
+          path: sbom/*
           if-no-files-found: error
 
   publish-pypi:
     name: publish-pypi
-    needs: build
+    needs: [build, installed-smoke, sbom]
     if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish == 'true')
     timeout-minutes: 15
     runs-on: ubuntu-latest
@@ -71,18 +169,30 @@ jobs:
       name: pypi
       url: https://pypi.org/project/polylogue/${{ needs.build.outputs.version }}/
     permissions:
-      # OIDC token for PyPI Trusted Publishing.
+      # OIDC token for PyPI Trusted Publishing + Sigstore keyless signing.
       id-token: write
+      contents: read
     steps:
       - uses: actions/download-artifact@v6
         with:
           name: distribution-artifacts
           path: dist/
-      - name: Drop work-dir scaffolding (keep only top-level wheel + sdist)
-        # verify-distribution-surface emits the unpacked-sdist tree under
-        # the work-dir; we only want the top-level dist/*.whl and *.tar.gz.
+      - name: List artifacts about to be signed and published
+        run: ls -la dist/
+      - name: Sign wheel + sdist with Sigstore (keyless OIDC)
+        uses: sigstore/gh-action-sigstore-python@v3.0.0
+        with:
+          inputs: |
+            ./dist/*.whl
+            ./dist/*.tar.gz
+          upload-signing-artifacts: true
+      - name: Drop Sigstore bundles before PyPI upload
+        # PyPI's gh-action-pypi-publish rejects anything other than .whl / .tar.gz
+        # in the dist/ directory. The .sigstore bundles are retained as the
+        # `signing-artifacts-publish-pypi` workflow artifact attached to the
+        # run by sigstore/gh-action-sigstore-python.
         run: |
-          find dist/ -mindepth 1 -maxdepth 1 -type d -exec rm -rf {} +
+          find dist/ -type f ! \( -name '*.whl' -o -name '*.tar.gz' \) -delete
           ls -la dist/
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/docs/release.md
+++ b/docs/release.md
@@ -54,10 +54,25 @@ anything different; release-please consumes the existing history.
    commit lands on `master`.
 2. release-please pushes a signed `vX.Y.Z` annotated tag at that commit.
 3. The tag push triggers [`release.yml`](../.github/workflows/release.yml),
-   which builds the wheel + sdist, smokes them via
-   `devtools verify-distribution-surface`, publishes to PyPI via OIDC Trusted
-   Publishing, and builds + pushes the OCI image to
-   `ghcr.io/sinity/polylogue`.
+   which runs, in order:
+   - `build-and-smoke` — builds wheel + sdist, runs
+     `devtools verify-distribution-surface`, and verifies PyPI long-description
+     renderability with `twine check`.
+   - `installed-smoke` matrix — installs the freshly-built wheel into a fresh
+     `python -m venv` on `{ubuntu-latest, macos-latest} × py{3.11, 3.12, 3.13}`
+     and exercises `polylogue --version | --help | stats | count`,
+     `polylogued --help`, `polylogue-mcp --help`, and `python -m polylogue
+     --version` against an empty `POLYLOGUE_ARCHIVE_ROOT`. This is the
+     OS/Python-version coverage gate: PyPI publication waits on it.
+   - `sbom` — emits a CycloneDX SBOM (`*.cdx.json` and `*.cdx.xml`) from the
+     wheel's resolved dependency closure and uploads it as the
+     `sbom-artifacts` workflow artifact.
+   - `publish-pypi` — signs wheel + sdist with Sigstore keyless OIDC
+     (`sigstore/gh-action-sigstore-python`), publishes to PyPI via
+     Trusted Publishing (no API token), and retains the `.sigstore` bundles
+     as the `signing-artifacts-publish-pypi` workflow artifact.
+   - `publish-container` — builds + pushes the OCI image to
+     `ghcr.io/sinity/polylogue`.
 
 If the release PR looks wrong (missing entries, wrong bump, stale title),
 close it without merging and adjust the source commits — release-please will
@@ -68,6 +83,14 @@ PyPI Trusted Publishing requires a one-time registration on pypi.org under
 `repo = polylogue`, `workflow = release.yml`, `environment = pypi`. If this
 is missing the publish step fails with an OIDC error and the tag must be
 re-cut after re-running the workflow.
+
+Sigstore keyless signing requires no project-side configuration; it derives
+identity from the workflow's `id-token: write` OIDC claim and publishes to
+the public Sigstore transparency log. Consumers can verify the bundle with
+`python -m sigstore verify identity --cert-identity
+https://github.com/Sinity/polylogue/.github/workflows/release.yml@refs/tags/vX.Y.Z
+--cert-oidc-issuer https://token.actions.githubusercontent.com
+polylogue-X.Y.Z-py3-none-any.whl polylogue-X.Y.Z-py3-none-any.whl.sigstore`.
 
 ## Post
 
@@ -84,6 +107,10 @@ re-cut after re-running the workflow.
       `polylogue --help`, `polylogued --help`, `polylogue-mcp --help`.
 - [ ] Smoke the container: `podman run --rm
       ghcr.io/sinity/polylogue:X.Y.Z polylogue --version`.
+- [ ] Confirm the `signing-artifacts-publish-pypi` workflow artifact on the
+      release run contains a `.sigstore` bundle for each `*.whl` and `*.tar.gz`.
+- [ ] Confirm the `sbom-artifacts` workflow artifact contains both
+      `polylogue-X.Y.Z.cdx.json` and `polylogue-X.Y.Z.cdx.xml`.
 
 ## Rollback
 


### PR DESCRIPTION
Closes #1234. Follow-up: #1309 (split packages `polylogue-mcp` / `polylogue-hooks`).

## Summary

Extends the existing tag-triggered `release.yml` with the remaining acceptance criteria from #1234: an installed-wheel smoke matrix across Linux + macOS × Python 3.11/3.12/3.13, Sigstore keyless OIDC signing, and a CycloneDX SBOM job. PyPI publish now gates on the smoke matrix.

## Problem

Issue #1234 set acceptance criteria for the PyPI release path: trusted-publisher OIDC publish (no API token), installed-smoke matrix across the supported Python versions, `twine check` gating, and the ambitious additions of Sigstore signing and SBOM emission.

The repo already had a tag-triggered `release.yml` (from earlier #1228 release-please work) that built wheel + sdist, smoked them through `devtools verify-distribution-surface` on a single ubuntu/3.13 builder, and published to PyPI via Trusted Publishing. Missing: cross-OS / cross-Python-version installed-wheel coverage, explicit `twine check`, Sigstore bundles, and SBOM artifacts. The ambitious split-package work (`polylogue-mcp`, `polylogue-hooks` as separate distributions) was scoped out of this PR and tracked as #1309 because it requires a non-trivial `pyproject.toml` refactor.

## Solution

`.github/workflows/release.yml`:
- Added `installed-smoke` matrix job (`fail-fast: false`) over `{ubuntu-latest, macos-latest} × py{3.11, 3.12, 3.13}` = 6 legs. Each leg downloads the `distribution-artifacts` upload from the `build` job, creates a fresh `python -m venv`, installs the wheel with stock `pip`, and exercises:
  - `polylogue --version | --help | --plain stats | --plain count`
  - `polylogued --help`
  - `polylogue-mcp --help`
  - `python -m polylogue --version`

  All against an empty `POLYLOGUE_ARCHIVE_ROOT` so the `stats` call covers fresh-schema bootstrap on first run. `publish-pypi` now declares `needs: [build, installed-smoke, sbom]`, so PyPI publication blocks on the matrix.
- Added `twine check` after the build step so PyPI long-description rendering failures (a common cause of late-stage publish-time errors) surface before the OIDC step.
- Added Sigstore keyless OIDC signing via `sigstore/gh-action-sigstore-python@v3.0.0`. Signs every wheel + sdist; bundles upload as the `signing-artifacts-publish-pypi` workflow artifact. Bundles are then stripped from `dist/` before `pypa/gh-action-pypi-publish` runs because the PyPI uploader rejects non-wheel/non-sdist entries in the upload directory.
- Added `sbom` job using `cyclonedx-bom` to emit both JSON and XML CycloneDX SBOMs derived from the installed wheel's dependency closure. Uploaded as `sbom-artifacts`.
- Build job now stages top-level wheel + sdist under `staged-dist/` so downloads downstream don't pick up the `verify-distribution-surface` work-dir scaffolding (`unpacked-sdist/`, `wheel-install/`, etc.). This replaces the previous in-publish-job `find dist/ -mindepth 1 -maxdepth 1 -type d -exec rm -rf` cleanup.

`docs/release.md`:
- Replaced the single-line `release.yml` description with a per-job topology breakdown (build-and-smoke / installed-smoke / sbom / publish-pypi / publish-container) so the operator-facing checklist explains what each cut-time CI step does.
- Documented the consumer Sigstore verification command (`python -m sigstore verify identity --cert-identity ... --cert-oidc-issuer https://token.actions.githubusercontent.com ...`).
- Added post-cut checks for the `signing-artifacts-publish-pypi` and `sbom-artifacts` workflow artifacts.

Alternatives rejected: split packages in this PR (deferred to #1309 because the `pyproject.toml` refactor and per-package trusted-publisher binding registration are non-trivial); CycloneDX `gh-python-generate-sbom` action (uses an older `cyclonedx-bom` cut without `cyclonedx-py environment`; using the modern CLI directly gives JSON + XML in one go).

## Verification

- `nix develop -c devtools verify --quick` → `exit_code: 0`, `total_duration_s: 40.22` (matches the pre-push hook on `git push`).
- `nix develop -c devtools verify-ci-workflows` → `11 workflow files checked, no errors`.
- `nix develop -c devtools render-all` → no drift produced.

Workflow-end-to-end smoke is deferred to the first tag push (or a `workflow_dispatch` with `publish=false`) since the trusted-publisher path requires OIDC against the real `pypi` GitHub environment. Sigstore keyless signing similarly requires the live OIDC issuer; both are exercised end-to-end on the first `vX.Y.Z` tag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release pipeline with PyPI metadata validation.
  * Added Sigstore keyless signing for distributed packages.
  * Introduced automated smoke testing across platforms (Ubuntu, macOS, Python 3.11–3.13).
  * Added Software Bill of Materials (SBOM) generation in CycloneDX format.

* **Documentation**
  * Updated release process documentation with new validation and signing verification procedures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sinity/polylogue/pull/1311?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->