### PR TITLE
feat(devtools): xtask auto-log + replay + budget + prune (#1289)

### DIFF
--- a/devtools/click_dispatch.py
+++ b/devtools/click_dispatch.py
@@ -174,14 +174,52 @@ def _make_cli() -> click.Group:
 cli = _make_cli()
 
 
-def main(argv: list[str] | None = None) -> int:
-    """Entry point for programmatic use of the Click-based devtools CLI.
-
-    Converts argv to Click invocation and returns the exit code.
-    """
+def _dispatch(argv: list[str]) -> int:
+    """Run the Click CLI and translate ``SystemExit`` to an int return code."""
     try:
-        cli(args=argv or [], standalone_mode=True)
+        cli(args=argv, standalone_mode=True)
         return 0
     except SystemExit as e:
         code = e.code
         return code if isinstance(code, int) else 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point for programmatic use of the Click-based devtools CLI.
+
+    Converts argv to Click invocation and returns the exit code.  Every
+    invocation appends a JSONL record to ``.agent/xtask/tasks.jsonl`` so
+    agent task history is self-populating (see ``devtools xtask``).  Set
+    ``POLYLOGUE_XTASK_DISABLE=1`` to opt out (also suppressed during a
+    ``devtools xtask replay`` to avoid double-logging the outer wrapper).
+    """
+    import os
+    import time
+
+    from devtools import xtask as xtask_mod
+
+    args_list = list(argv or [])
+    if not args_list or args_list[0].startswith("-"):
+        # Bare invocation or root option only — skip auto-log.
+        return _dispatch(args_list)
+
+    command_name = args_list[0]
+    inner_args = args_list[1:]
+
+    if xtask_mod.auto_log_disabled():
+        return _dispatch(args_list)
+
+    started = time.perf_counter()
+    exit_code = 0
+    try:
+        exit_code = _dispatch(args_list)
+        return exit_code
+    finally:
+        duration_ms = (time.perf_counter() - started) * 1000.0
+        xtask_mod.record_invocation(
+            command=command_name,
+            args=inner_args,
+            duration_ms=duration_ms,
+            exit_code=exit_code,
+            cwd=os.getcwd(),
+        )

--- a/devtools/xtask.py
+++ b/devtools/xtask.py
@@ -8,13 +8,20 @@ Subcommands:
 - ``log`` — Append a structured task record.
 - ``recent`` — Show the N most recent tasks.
 - ``stats`` — Aggregate summary over all recorded tasks.
+- ``replay`` — Re-run a previously logged ``devtools`` invocation.
+- ``budget`` — Enforce per-class p95 latency budgets.
+- ``prune`` — Bound the on-disk JSONL log size.
 """
 
 from __future__ import annotations
 
 import argparse
 import json
+import os
+import subprocess
+import sys
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
 
 from devtools import repo_root as _get_root
@@ -22,20 +29,35 @@ from polylogue.core.json import JSONDocument
 
 XTaskDict = JSONDocument
 
-_XTASK_DIR = _get_root() / ".agent" / "xtask"
-_XTASK_FILE = _XTASK_DIR / "tasks.jsonl"
+
+# ---------------------------------------------------------------------------
+# Storage helpers (path-injectable for tests)
+# ---------------------------------------------------------------------------
 
 
-def _ensure_file() -> None:
-    _XTASK_DIR.mkdir(parents=True, exist_ok=True)
-    if not _XTASK_FILE.exists():
-        _XTASK_FILE.write_text("", encoding="utf-8")
+def xtask_file_path() -> Path:
+    """Return the active xtask JSONL path.
+
+    Honors ``POLYLOGUE_XTASK_FILE`` (used by tests and one-off overrides);
+    otherwise defaults to ``<repo_root>/.agent/xtask/tasks.jsonl``.
+    """
+    override = os.environ.get("POLYLOGUE_XTASK_FILE")
+    if override:
+        return Path(override)
+    return _get_root() / ".agent" / "xtask" / "tasks.jsonl"
 
 
-def _read_tasks() -> list[XTaskDict]:
-    _ensure_file()
+def _ensure_file(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if not path.exists():
+        path.write_text("", encoding="utf-8")
+
+
+def _read_tasks(path: Path | None = None) -> list[XTaskDict]:
+    target = path or xtask_file_path()
+    _ensure_file(target)
     tasks: list[XTaskDict] = []
-    for line in _XTASK_FILE.read_text(encoding="utf-8").strip().splitlines():
+    for line in target.read_text(encoding="utf-8").splitlines():
         line = line.strip()
         if not line:
             continue
@@ -46,10 +68,98 @@ def _read_tasks() -> list[XTaskDict]:
     return tasks
 
 
-def _append_task(task: XTaskDict) -> None:
-    _ensure_file()
-    with _XTASK_FILE.open("a", encoding="utf-8") as fh:
+def _append_task(task: XTaskDict, path: Path | None = None) -> None:
+    target = path or xtask_file_path()
+    _ensure_file(target)
+    with target.open("a", encoding="utf-8") as fh:
         fh.write(json.dumps(task, sort_keys=True) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# Command-class taxonomy
+# ---------------------------------------------------------------------------
+
+
+_CLASS_PREFIXES: tuple[tuple[str, str], ...] = (
+    ("verify", "verify"),
+    ("render", "render"),
+    ("lab", "lab"),
+    ("witness", "witness"),
+    ("mutmut", "campaign"),
+    ("run-validation-lanes", "verify"),
+    ("benchmark", "campaign"),
+    ("run-benchmark", "campaign"),
+    ("schema", "verify"),
+    ("daemon-workload-probe", "query"),
+    ("evidence", "query"),
+    ("artifact-graph", "query"),
+    ("pipeline-probe", "query"),
+    ("query-memory-budget", "query"),
+    ("regression-capture", "query"),
+    ("scenario-projections", "query"),
+    ("semantic-axis-evidence", "verify"),
+    ("coverage-gate", "verify"),
+    ("build-package", "render"),
+    ("build-topology-projection", "render"),
+    ("status", "query"),
+    ("motd", "query"),
+    ("xtask", "query"),
+)
+
+
+def classify_command(command_name: str) -> str:
+    """Classify a devtools command name into a coarse class bucket.
+
+    Classes: ``verify``, ``render``, ``lab``, ``witness``, ``campaign``,
+    ``query``, ``other``.
+    """
+    if not command_name:
+        return "other"
+    head = command_name.split()[0] if " " in command_name else command_name
+    for prefix, klass in _CLASS_PREFIXES:
+        if head == prefix or head.startswith(f"{prefix}-") or head.startswith(f"{prefix}_"):
+            return klass
+    return "other"
+
+
+# ---------------------------------------------------------------------------
+# Auto-log entrypoint (called from click_dispatch.main)
+# ---------------------------------------------------------------------------
+
+
+def record_invocation(
+    *,
+    command: str,
+    args: list[str],
+    duration_ms: float,
+    exit_code: int,
+    cwd: str | None = None,
+    path: Path | None = None,
+) -> None:
+    """Append a single invocation record; never raise.
+
+    Intended for the ``devtools`` harness wrapper. Failures are swallowed
+    so a broken xtask path does not prevent commands from returning.
+    """
+    try:
+        task: dict[str, Any] = {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "command": command,
+            "args": list(args),
+            "duration_ms": round(float(duration_ms), 3),
+            "exit_code": int(exit_code),
+            "cwd": cwd if cwd is not None else os.getcwd(),
+            "class": classify_command(command),
+        }
+        _append_task(task, path=path)
+    except Exception:
+        # Auto-log must never crash the wrapped command.
+        return
+
+
+def auto_log_disabled() -> bool:
+    """Return True when auto-logging is suppressed via env."""
+    return os.environ.get("POLYLOGUE_XTASK_DISABLE", "") not in ("", "0", "false", "False")
 
 
 # ---------------------------------------------------------------------------
@@ -72,6 +182,8 @@ def _cmd_log(args: argparse.Namespace) -> int:
         task["cwd"] = str(args.cwd)
     if args.note is not None:
         task["note"] = args.note
+    if args.command:
+        task["class"] = classify_command(args.command)
 
     _append_task(task)
     if args.json:
@@ -93,12 +205,12 @@ def _cmd_recent(args: argparse.Namespace) -> int:
     if not recent:
         print("no tasks recorded")
         return 0
-    for task in reversed(recent):
+    for idx, task in enumerate(reversed(recent), start=1):
         ts: str = task.get("timestamp", "?")  # type: ignore[assignment]
         cmd: str = task.get("command", "?")  # type: ignore[assignment]
         code = task.get("exit_code")
         dur = task.get("duration_ms")
-        parts: list[str] = [ts, cmd]
+        parts: list[str] = [f"#{idx}", ts, cmd]
         if code is not None:
             parts.append(f"exit={code}")
         if dur is not None:
@@ -110,6 +222,42 @@ def _cmd_recent(args: argparse.Namespace) -> int:
 # ---------------------------------------------------------------------------
 # Subcommand: stats
 # ---------------------------------------------------------------------------
+
+
+def _percentile(values: list[float], pct: float) -> float:
+    """Return the linear-interpolated percentile of a numeric list."""
+    if not values:
+        return 0.0
+    if len(values) == 1:
+        return float(values[0])
+    ordered = sorted(values)
+    k = (len(ordered) - 1) * (pct / 100.0)
+    lo = int(k)
+    hi = min(lo + 1, len(ordered) - 1)
+    if lo == hi:
+        return float(ordered[lo])
+    frac = k - lo
+    return float(ordered[lo] + (ordered[hi] - ordered[lo]) * frac)
+
+
+def _class_distributions(tasks: list[XTaskDict]) -> dict[str, dict[str, float]]:
+    buckets: dict[str, list[float]] = {}
+    for task in tasks:
+        dur = task.get("duration_ms")
+        if dur is None:
+            continue
+        klass = task.get("class") or classify_command(str(task.get("command", "")))
+        buckets.setdefault(str(klass), []).append(float(dur))  # type: ignore[arg-type]
+    return {
+        klass: {
+            "count": float(len(durations)),
+            "median_ms": _percentile(durations, 50),
+            "p95_ms": _percentile(durations, 95),
+            "max_ms": float(max(durations)),
+            "sum_ms": float(sum(durations)),
+        }
+        for klass, durations in buckets.items()
+    }
 
 
 def _cmd_stats(args: argparse.Namespace) -> int:
@@ -147,6 +295,16 @@ def _cmd_stats(args: argparse.Namespace) -> int:
         stats["total_duration_ms"] = total_duration_ms
         stats["avg_duration_ms"] = total_duration_ms / duration_count
 
+    if args.by_class:
+        stats["by_class"] = _class_distributions(tasks)
+
+    slowest: list[XTaskDict] = []
+    if args.slowest and args.slowest > 0:
+        timed = [t for t in tasks if t.get("duration_ms") is not None]
+        timed.sort(key=lambda t: float(t.get("duration_ms", 0)), reverse=True)  # type: ignore[arg-type]
+        slowest = timed[: args.slowest]
+        stats["slowest"] = slowest
+
     if args.json:
         print(json.dumps(stats, indent=2, sort_keys=True))
         return 0
@@ -161,6 +319,166 @@ def _cmd_stats(args: argparse.Namespace) -> int:
     if duration_count > 0:
         print(f"total duration: {total_duration_ms:.0f}ms")
         print(f"avg duration:   {stats['avg_duration_ms']:.0f}ms")
+    if args.by_class:
+        print(f"by class ({len(stats['by_class'])}):")
+        for klass, dist in sorted(stats["by_class"].items()):
+            print(
+                f"  {klass:<10} n={int(dist['count']):>4}  "
+                f"median={dist['median_ms']:.0f}ms  p95={dist['p95_ms']:.0f}ms  "
+                f"max={dist['max_ms']:.0f}ms"
+            )
+    if slowest:
+        print(f"slowest {len(slowest)}:")
+        for task in slowest:
+            cmd_str: str = task.get("command", "?")  # type: ignore[assignment]
+            dur = task.get("duration_ms")
+            ts: str = task.get("timestamp", "?")  # type: ignore[assignment]
+            print(f"  {dur}ms  {cmd_str}  {ts}")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Subcommand: replay
+# ---------------------------------------------------------------------------
+
+
+def _cmd_replay(args: argparse.Namespace) -> int:
+    tasks = _read_tasks()
+    if not tasks:
+        print("no tasks recorded", file=sys.stderr)
+        return 1
+    # ``index`` is 1-based from the most recent task (replay 1 = last task).
+    index = max(1, args.index)
+    if index > len(tasks):
+        print(
+            f"replay index {index} exceeds {len(tasks)} recorded tasks",
+            file=sys.stderr,
+        )
+        return 1
+    task = tasks[-index]
+
+    command_name: str = str(task.get("command", "")).strip()
+    raw_args = task.get("args", [])
+    invocation_args: list[str] = [str(item) for item in raw_args] if isinstance(raw_args, list) else []
+
+    if not command_name:
+        print("task has no recorded command name", file=sys.stderr)
+        return 1
+
+    argv = [command_name, *invocation_args]
+    if args.dry_run or args.json:
+        payload = {
+            "index": index,
+            "timestamp": task.get("timestamp"),
+            "command": command_name,
+            "args": invocation_args,
+            "argv": argv,
+            "cwd": task.get("cwd"),
+            "previous_exit_code": task.get("exit_code"),
+            "previous_duration_ms": task.get("duration_ms"),
+        }
+        if args.json:
+            print(json.dumps(payload, indent=2, sort_keys=True))
+        else:
+            print(json.dumps(payload, indent=2, sort_keys=True))
+        if args.dry_run:
+            return 0
+
+    # Re-run via the devtools entrypoint as a subprocess so the inner run
+    # gets its own auto-log record without recursing inside this process.
+    env = os.environ.copy()
+    cwd = task.get("cwd") if isinstance(task.get("cwd"), str) else None
+    if cwd is not None and not Path(cwd).exists():
+        cwd = None
+    cmd = [sys.executable, "-m", "devtools", *argv]
+    try:
+        completed = subprocess.run(cmd, cwd=cwd, env=env, check=False)
+    except FileNotFoundError as exc:  # python missing — surface clearly
+        print(f"replay failed: {exc}", file=sys.stderr)
+        return 1
+    return int(completed.returncode)
+
+
+# ---------------------------------------------------------------------------
+# Subcommand: budget
+# ---------------------------------------------------------------------------
+
+
+def _cmd_budget(args: argparse.Namespace) -> int:
+    tasks = _read_tasks()
+    distributions = _class_distributions(tasks)
+    target_class = args.class_name
+    dist = distributions.get(target_class)
+    if dist is None or dist["count"] == 0:
+        payload = {
+            "class": target_class,
+            "count": 0,
+            "max_ms": args.max_ms,
+            "status": "no-data",
+        }
+        if args.json:
+            print(json.dumps(payload, indent=2, sort_keys=True))
+        else:
+            print(f"no data for class {target_class}")
+        return 0 if args.allow_empty else 1
+
+    p95 = dist["p95_ms"]
+    within = p95 <= float(args.max_ms)
+    payload = {
+        "class": target_class,
+        "count": int(dist["count"]),
+        "median_ms": dist["median_ms"],
+        "p95_ms": p95,
+        "max_ms_observed": dist["max_ms"],
+        "budget_ms": float(args.max_ms),
+        "within_budget": within,
+        "status": "ok" if within else "over-budget",
+    }
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        symbol = "OK" if within else "OVER"
+        print(
+            f"[{symbol}] class={target_class} n={int(dist['count'])} "
+            f"p95={p95:.0f}ms budget={args.max_ms:.0f}ms "
+            f"median={dist['median_ms']:.0f}ms max={dist['max_ms']:.0f}ms"
+        )
+    return 0 if within else 2
+
+
+# ---------------------------------------------------------------------------
+# Subcommand: prune
+# ---------------------------------------------------------------------------
+
+
+def _cmd_prune(args: argparse.Namespace) -> int:
+    tasks = _read_tasks()
+    if args.keep < 0:
+        print("--keep must be >= 0", file=sys.stderr)
+        return 2
+    before = len(tasks)
+    if args.keep >= before:
+        payload = {"before": before, "after": before, "removed": 0, "keep": args.keep}
+        if args.json:
+            print(json.dumps(payload, indent=2, sort_keys=True))
+        else:
+            print(f"nothing to prune (have {before}, keep {args.keep})")
+        return 0
+    keep_tasks = tasks[-args.keep :] if args.keep > 0 else []
+    path = xtask_file_path()
+    _ensure_file(path)
+    # Atomic-ish rewrite: write to a sibling temp file then replace.
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    with tmp.open("w", encoding="utf-8") as fh:
+        for task in keep_tasks:
+            fh.write(json.dumps(task, sort_keys=True) + "\n")
+    tmp.replace(path)
+    removed = before - len(keep_tasks)
+    payload = {"before": before, "after": len(keep_tasks), "removed": removed, "keep": args.keep}
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(f"pruned {removed} records (kept {len(keep_tasks)} of {before})")
     return 0
 
 
@@ -188,6 +506,48 @@ def main(argv: list[str] | None = None) -> int:
 
     stats_parser = subparsers.add_parser("stats", help="Task statistics.")
     stats_parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
+    stats_parser.add_argument(
+        "--by-class",
+        action="store_true",
+        help="Add per-class duration distributions (median/p95/max).",
+    )
+    stats_parser.add_argument(
+        "--slowest",
+        type=int,
+        default=0,
+        metavar="N",
+        help="Include the N slowest invocations by duration_ms.",
+    )
+
+    replay_parser = subparsers.add_parser("replay", help="Re-run the Nth most recent task (default 1).")
+    replay_parser.add_argument(
+        "index", type=int, nargs="?", default=1, help="1-based offset from most recent (default 1)."
+    )
+    replay_parser.add_argument(
+        "--dry-run", action="store_true", help="Print the resolved invocation without executing."
+    )
+    replay_parser.add_argument(
+        "--json", action="store_true", help="Emit the resolved invocation as JSON before running."
+    )
+
+    budget_parser = subparsers.add_parser("budget", help="Enforce a p95 latency budget for a command class.")
+    budget_parser.add_argument(
+        "--class",
+        dest="class_name",
+        required=True,
+        help="Command class to evaluate (verify, render, lab, witness, campaign, query, other).",
+    )
+    budget_parser.add_argument("--max-ms", type=float, required=True, help="Budget ceiling in milliseconds (p95).")
+    budget_parser.add_argument(
+        "--allow-empty",
+        action="store_true",
+        help="Treat missing data for the class as a pass rather than a failure.",
+    )
+    budget_parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
+
+    prune_parser = subparsers.add_parser("prune", help="Bound the JSONL log size.")
+    prune_parser.add_argument("--keep", type=int, required=True, help="Number of most recent records to retain.")
+    prune_parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
 
     parsed = parser.parse_args(argv)
 
@@ -197,6 +557,12 @@ def main(argv: list[str] | None = None) -> int:
         return _cmd_recent(parsed)
     elif parsed.subcommand == "stats":
         return _cmd_stats(parsed)
+    elif parsed.subcommand == "replay":
+        return _cmd_replay(parsed)
+    elif parsed.subcommand == "budget":
+        return _cmd_budget(parsed)
+    elif parsed.subcommand == "prune":
+        return _cmd_prune(parsed)
     return 1
 
 

--- a/tests/unit/devtools/test_xtask.py
+++ b/tests/unit/devtools/test_xtask.py
@@ -1,0 +1,297 @@
+"""Tests for ``devtools xtask`` task-history surface and harness wiring."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+import devtools.__main__ as devtools_main
+from devtools import xtask
+
+
+@pytest.fixture(autouse=True)
+def isolated_xtask_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect xtask storage into ``tmp_path`` and clear opt-out env."""
+    path = tmp_path / "tasks.jsonl"
+    monkeypatch.setenv("POLYLOGUE_XTASK_FILE", str(path))
+    monkeypatch.delenv("POLYLOGUE_XTASK_DISABLE", raising=False)
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Classification
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("command", "expected"),
+    [
+        ("verify", "verify"),
+        ("verify-topology", "verify"),
+        ("render-all", "render"),
+        ("render-cli-reference", "render"),
+        ("lab-scenario", "lab"),
+        ("lab-corpus", "lab"),
+        ("witness-promote", "witness"),
+        ("witness-minimize", "witness"),
+        ("mutmut-campaign", "campaign"),
+        ("benchmark-campaign", "campaign"),
+        ("run-benchmark-campaigns", "campaign"),
+        ("daemon-workload-probe", "query"),
+        ("status", "query"),
+        ("xtask", "query"),
+        ("totally-unknown-command", "other"),
+        ("", "other"),
+    ],
+)
+def test_classify_command_buckets(command: str, expected: str) -> None:
+    assert xtask.classify_command(command) == expected
+
+
+# ---------------------------------------------------------------------------
+# log / recent / stats round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_log_and_recent_round_trip(isolated_xtask_file: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    assert (
+        xtask.main(
+            [
+                "log",
+                "--command",
+                "verify",
+                "--duration-ms",
+                "1500",
+                "--exit-code",
+                "0",
+                "--cwd",
+                "/repo",
+            ]
+        )
+        == 0
+    )
+    assert xtask.main(["recent", "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert len(payload) == 1
+    entry = payload[0]
+    assert entry["command"] == "verify"
+    assert entry["class"] == "verify"
+    assert entry["duration_ms"] == 1500
+    assert entry["exit_code"] == 0
+
+
+def test_stats_by_class_and_slowest(isolated_xtask_file: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    samples = [
+        ("verify", 1000.0, 0),
+        ("verify", 2000.0, 0),
+        ("verify", 9000.0, 1),
+        ("render-all", 200.0, 0),
+        ("status", 50.0, 0),
+    ]
+    for cmd, dur, code in samples:
+        xtask.record_invocation(
+            command=cmd,
+            args=[],
+            duration_ms=dur,
+            exit_code=code,
+        )
+
+    assert xtask.main(["stats", "--by-class", "--slowest", "2", "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["total"] == 5
+    assert "by_class" in payload
+    verify_dist = payload["by_class"]["verify"]
+    assert verify_dist["count"] == 3
+    assert verify_dist["max_ms"] == 9000.0
+    # median of [1000, 2000, 9000] is 2000
+    assert verify_dist["median_ms"] == 2000.0
+    # slowest contains the two slowest, ordered desc
+    assert [t["duration_ms"] for t in payload["slowest"]] == [9000.0, 2000.0]
+
+
+# ---------------------------------------------------------------------------
+# budget
+# ---------------------------------------------------------------------------
+
+
+def test_budget_passes_when_p95_within(isolated_xtask_file: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    for dur in (100.0, 200.0, 300.0, 400.0, 500.0):
+        xtask.record_invocation(command="verify", args=[], duration_ms=dur, exit_code=0)
+    code = xtask.main(["budget", "--class", "verify", "--max-ms", "1000", "--json"])
+    assert code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["within_budget"] is True
+    assert payload["status"] == "ok"
+
+
+def test_budget_fails_when_p95_exceeds(isolated_xtask_file: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    for dur in (100.0, 200.0, 300.0, 400.0, 50000.0):
+        xtask.record_invocation(command="verify", args=[], duration_ms=dur, exit_code=0)
+    code = xtask.main(["budget", "--class", "verify", "--max-ms", "1000", "--json"])
+    assert code == 2
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["within_budget"] is False
+    assert payload["status"] == "over-budget"
+
+
+def test_budget_no_data_default_fails(isolated_xtask_file: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    code = xtask.main(["budget", "--class", "verify", "--max-ms", "1000", "--json"])
+    assert code == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "no-data"
+
+
+def test_budget_no_data_allow_empty(isolated_xtask_file: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    code = xtask.main(["budget", "--class", "verify", "--max-ms", "1000", "--allow-empty", "--json"])
+    assert code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "no-data"
+
+
+# ---------------------------------------------------------------------------
+# prune
+# ---------------------------------------------------------------------------
+
+
+def test_prune_keeps_latest_n(isolated_xtask_file: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    for i in range(10):
+        xtask.record_invocation(command=f"render-{i}", args=[], duration_ms=float(i), exit_code=0)
+    assert xtask.main(["prune", "--keep", "3", "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["before"] == 10
+    assert payload["after"] == 3
+    assert payload["removed"] == 7
+
+    # Verify the kept records are the latest three
+    lines = isolated_xtask_file.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 3
+    kept = [json.loads(line) for line in lines]
+    assert [t["command"] for t in kept] == ["render-7", "render-8", "render-9"]
+
+
+def test_prune_noop_when_below_keep(isolated_xtask_file: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    xtask.record_invocation(command="verify", args=[], duration_ms=1.0, exit_code=0)
+    assert xtask.main(["prune", "--keep", "10", "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["removed"] == 0
+    assert payload["after"] == 1
+
+
+def test_prune_zero_keeps_nothing(isolated_xtask_file: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    for i in range(3):
+        xtask.record_invocation(command=f"x-{i}", args=[], duration_ms=1.0, exit_code=0)
+    assert xtask.main(["prune", "--keep", "0", "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["after"] == 0
+    assert isolated_xtask_file.read_text(encoding="utf-8") == ""
+
+
+# ---------------------------------------------------------------------------
+# replay
+# ---------------------------------------------------------------------------
+
+
+def test_replay_dry_run_round_trips_argv(isolated_xtask_file: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    xtask.record_invocation(
+        command="render-all",
+        args=["--check", "--verbose"],
+        duration_ms=42.0,
+        exit_code=0,
+        cwd="/tmp/repo",
+    )
+    assert xtask.main(["replay", "--dry-run", "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["command"] == "render-all"
+    assert payload["args"] == ["--check", "--verbose"]
+    assert payload["argv"] == ["render-all", "--check", "--verbose"]
+    assert payload["index"] == 1
+
+
+def test_replay_dry_run_with_explicit_index(isolated_xtask_file: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    xtask.record_invocation(command="status", args=[], duration_ms=10.0, exit_code=0)
+    xtask.record_invocation(command="verify", args=["--quick"], duration_ms=20.0, exit_code=0)
+    # index 2 = the older one (status)
+    assert xtask.main(["replay", "2", "--dry-run", "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["command"] == "status"
+
+
+def test_replay_errors_on_empty(isolated_xtask_file: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    assert xtask.main(["replay"]) == 1
+    assert "no tasks recorded" in capsys.readouterr().err
+
+
+def test_replay_errors_on_out_of_range(isolated_xtask_file: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    xtask.record_invocation(command="status", args=[], duration_ms=1.0, exit_code=0)
+    assert xtask.main(["replay", "5"]) == 1
+    assert "exceeds" in capsys.readouterr().err
+
+
+def test_replay_executes_via_subprocess(isolated_xtask_file: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Replay should shell out to ``python -m devtools <argv>``."""
+    captured: dict[str, object] = {}
+
+    def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[bytes]:
+        captured["cmd"] = list(cmd)
+        captured["cwd"] = kwargs.get("cwd")
+        return subprocess.CompletedProcess(cmd, 0)
+
+    xtask.record_invocation(
+        command="status",
+        args=["--json"],
+        duration_ms=1.0,
+        exit_code=0,
+        cwd=str(isolated_xtask_file.parent),
+    )
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    assert xtask.main(["replay"]) == 0
+    assert captured["cmd"] == [sys.executable, "-m", "devtools", "status", "--json"]
+    assert captured["cwd"] == str(isolated_xtask_file.parent)
+
+
+# ---------------------------------------------------------------------------
+# Harness auto-logging
+# ---------------------------------------------------------------------------
+
+
+def test_devtools_main_auto_logs_invocation(isolated_xtask_file: Path) -> None:
+    """A normal ``devtools`` call appends a record to the JSONL log."""
+    rc = devtools_main.main(["--list-commands", "--json"])
+    assert rc == 0
+    # Root-level option only — by design we skip auto-log for bare options.
+    assert not isolated_xtask_file.exists() or isolated_xtask_file.read_text() == ""
+
+    rc = devtools_main.main(["status", "--json"])
+    # status command may return non-zero in tmp, but we only care that we logged.
+    records = [
+        json.loads(line) for line in isolated_xtask_file.read_text(encoding="utf-8").splitlines() if line.strip()
+    ]
+    assert len(records) == 1
+    entry = records[0]
+    assert entry["command"] == "status"
+    assert entry["class"] == "query"
+    assert "duration_ms" in entry
+    assert "exit_code" in entry
+    assert "timestamp" in entry
+    assert entry["exit_code"] == rc
+
+
+def test_devtools_main_respects_xtask_disable(isolated_xtask_file: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("POLYLOGUE_XTASK_DISABLE", "1")
+    devtools_main.main(["status", "--json"])
+    assert not isolated_xtask_file.exists() or isolated_xtask_file.read_text() == ""
+
+
+def test_record_invocation_swallows_errors(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Auto-log must never raise even if the file path is unwritable."""
+    bad = tmp_path / "ro_dir" / "nope.jsonl"
+    monkeypatch.setenv("POLYLOGUE_XTASK_FILE", str(bad))
+    # Force _ensure_file to fail by making the parent a regular file.
+    bad.parent.parent.mkdir(parents=True, exist_ok=True)
+    bad.parent.write_text("not a dir", encoding="utf-8")
+    # Should not raise:
+    xtask.record_invocation(command="verify", args=[], duration_ms=1.0, exit_code=0)


### PR DESCRIPTION
## Summary

Make `devtools xtask` self-populating. Every `devtools <cmd>` invocation now appends a structured JSONL record (command, args, duration, exit code, cwd, class, timestamp) to `.agent/xtask/tasks.jsonl`, and the surface gains `replay`, `budget`, and `prune` subcommands plus `stats --by-class --slowest`.

## Problem

`devtools xtask` was documented as the agent task-history surface but `.agent/xtask/tasks.jsonl` is empty on master (`wc -l` → 0). No harness hook, devtools wrapper, or CI step ever wrote records — exactly the data needed to prioritize gate-time work and tooling investment was missing. Audit #1283 noted the catalog was "discoverable but unused".

## Solution

- **`devtools/click_dispatch.py`**: the top-level `main()` now wraps every dispatch in a timing + finally block that calls `xtask.record_invocation(...)` on exit. Bare/root-only invocations (`--list-commands`, `--help`) are skipped to avoid noise. Opt-out via `POLYLOGUE_XTASK_DISABLE=1`. Auto-log errors are swallowed so a broken xtask path can never block a command.
- **`devtools/xtask.py`**:
  - Storage path is overridable via `POLYLOGUE_XTASK_FILE` (used by tests, also exposed for one-off overrides).
  - `classify_command()` buckets commands into `verify | render | lab | witness | campaign | query | other` via prefix matching.
  - New `replay [N] [--dry-run] [--json]` re-runs the Nth most recent task by shelling out to `python -m devtools <argv>`. Argument round-trip is faithful (asserted by tests).
  - New `budget --class C --max-ms N [--allow-empty]` exits non-zero (2) when the p95 of the named class exceeds the budget, exits 1 on missing data (0 with `--allow-empty`).
  - New `prune --keep N` retains only the latest N records via atomic sibling-`.tmp` rewrite.
  - `stats` gains `--by-class` (per-class count/median/p95/max/sum) and `--slowest N`.

Alternatives considered:
- Logging inside each `CommandSpec.resolve_main()` instead of `main()` — rejected: would log even direct module-call test paths, and miss the actual user-facing wall-clock cost (Click setup, argv parsing).
- In-process replay — rejected: would double-log because the outer wrapper has not yet returned; subprocess gives clean independent timing for the replayed invocation.

## Verification

```
pytest tests/unit/devtools/test_xtask.py
  -> 33 passed
devtools verify --quick
  -> total_duration_s 45.62, exit_code 0
```

The test suite covers: command classification (15 cases), log/recent/stats round-trip, `--by-class`/`--slowest`, budget pass/fail/no-data/allow-empty, prune keep/noop/zero, replay dry-run/index/empty/out-of-range/subprocess invocation, harness auto-log on/off, and the error-swallowing guarantee.

Closes #1289
Ref #1283