### PR TITLE
chore(tests): quieter pytest default output

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,7 @@ packages = ["polylogue"]
 path = "hatch_build.py"
 
 [tool.pytest.ini_options]
-addopts = "-ra -n auto --benchmark-disable --benchmark-storage=file://./.cache/pytest-benchmark"
+addopts = "-rfE --tb=line -n auto --benchmark-disable --benchmark-storage=file://./.cache/pytest-benchmark"
 testpaths = ["tests"]
 asyncio_mode = "auto"
 xfail_strict = true


### PR DESCRIPTION
## Summary

Switch pytest \`addopts\` from \`-ra\` to \`-rfE --tb=line\`:
- \`-rfE\`: show summary only for **failures** and **errors** (skip the verbose xfail/xpass/skipped summary on every green run)
- \`--tb=line\`: one-line tracebacks on failures (instead of multi-line context)

## Problem

The previous \`-ra\` flag means every pytest invocation prints an "extra summary" for **every** category — including xfailed, xpassed, skipped — which produces a wall of text on routine green runs. During multi-agent workflows where each agent runs \`devtools verify --quick\` and reports the result, this output is the dominant source of conversation-channel notification spam.

## Solution

\`-rfE\` keeps failure and error summaries (which you actually need to act on) while dropping the xfail/xpass/skipped wall. \`--tb=line\` cuts traceback verbosity to one line per failure; full tracebacks remain available with \`pytest -p no:cacheprovider --tb=long\` when debugging.

## Verification

\`devtools verify --quick\` (with the changed config) exits 0. Output is visibly tighter.