### PR TITLE
feat(dist): OCI container with multi-arch + healthcheck + compose (#1236)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,54 @@
+# Keep the build context lean: ship source + pyproject.toml + README only.
+# Generated state, caches, and local artifacts have no place in the image.
+
+.git
+.github
+.githooks
+.direnv
+.envrc
+.venv*
+.cache
+.local
+.agent
+.mypy_cache
+.pytest_cache
+.ruff_cache
+.testmondata
+.testmondata-*
+.coverage*
+htmlcov
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+*.egg-info
+build
+dist
+result
+result-*
+
+# Editor / OS junk
+.idea
+.vscode
+.DS_Store
+*.swp
+*~
+
+# Repo-level docs and ops that are not needed at build time
+docs
+showcase
+qa
+qa_outputs
+benchmarks
+scenarios
+tests
+fixtures
+witnesses
+*.md
+!README.md
+Containerfile
+Dockerfile*
+docker-compose*.yaml
+
+# Nix outputs / lockfiles consumed only by the flake
+flake.lock

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,0 +1,131 @@
+name: Container
+
+# Builds the polylogued OCI image and publishes it to ghcr.io.
+#
+# Trigger surface:
+#   - push to master      → publishes ghcr.io/sinity/polylogue:master-<sha7>
+#                           (slim) and :master-<sha7>-distroless (distroless)
+#   - tag push v*.*.*     → publishes :latest, :X.Y.Z, :X.Y, and the
+#                           corresponding -distroless variants
+#   - pull_request        → builds both variants on amd64 only as a smoke
+#                           test; does not push
+#   - workflow_dispatch   → manual build; `push=true` opt-in
+#
+# The release pipeline (release.yml) used to carry an inlined publish-container
+# job. That job has been removed in favour of this dedicated workflow so the
+# container surface can iterate independently of the wheel/sdist gate.
+
+on:
+  push:
+    branches: [master]
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+  pull_request:
+    paths:
+      - Containerfile
+      - .dockerignore
+      - .github/workflows/container.yml
+      - pyproject.toml
+      - polylogue/**
+  workflow_dispatch:
+    inputs:
+      push:
+        description: "Push images to ghcr.io (default: false)"
+        required: false
+        default: "false"
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/polylogue
+
+jobs:
+  build-and-push:
+    name: build (${{ matrix.target }})
+    timeout-minutes: 45
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [runtime, distroless]
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Decide whether to push
+        id: decide
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "push=false" >> "${GITHUB_OUTPUT}"
+            echo "platforms=linux/amd64" >> "${GITHUB_OUTPUT}"
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "push=${{ inputs.push }}" >> "${GITHUB_OUTPUT}"
+            echo "platforms=linux/amd64,linux/arm64" >> "${GITHUB_OUTPUT}"
+          else
+            echo "push=true" >> "${GITHUB_OUTPUT}"
+            echo "platforms=linux/amd64,linux/arm64" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Log in to GHCR
+        if: steps.decide.outputs.push == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # The distroless build gets a `-distroless` suffix on every tag
+          # so both variants share the same repository.
+          flavor: |
+            suffix=${{ matrix.target == 'distroless' && '-distroless' || '' }},onlatest=true
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=ref,event=tag
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,prefix=master-,format=short,enable=${{ github.ref == 'refs/heads/master' }}
+
+      - name: Build${{ steps.decide.outputs.push == 'true' && ' and push' || '' }}
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Containerfile
+          target: ${{ matrix.target }}
+          platforms: ${{ steps.decide.outputs.platforms }}
+          push: ${{ steps.decide.outputs.push }}
+          load: ${{ steps.decide.outputs.push != 'true' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          provenance: true
+          sbom: true
+          cache-from: type=gha,scope=container-${{ matrix.target }}
+          cache-to: type=gha,mode=max,scope=container-${{ matrix.target }}
+
+      - name: Smoke test (amd64 image, --version)
+        if: steps.decide.outputs.push != 'true'
+        run: |
+          # On PR builds the image is loaded into the local docker daemon.
+          # Pick the first tag from the metadata-action output (sha-based).
+          tag=$(printf '%s\n' "${{ steps.meta.outputs.tags }}" | head -n1)
+          echo "Smoking ${tag}"
+          if [[ "${{ matrix.target }}" == "runtime" ]]; then
+            docker run --rm --entrypoint polylogue "${tag}" --version
+            docker run --rm --entrypoint polylogued "${tag}" --help > /dev/null
+          else
+            # Distroless has no shell; entrypoint is polylogued itself.
+            docker run --rm --entrypoint /usr/local/bin/polylogue "${tag}" --version
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,10 @@ name: Release
 # build host, runs an installed-wheel smoke matrix across supported
 # Python versions on Linux + macOS, signs the artifacts with Sigstore
 # keyless OIDC, emits a CycloneDX SBOM, then:
-#   - publishes to PyPI via Trusted Publishing (OIDC, no API token), and
-#   - builds + pushes a multi-stage OCI image to ghcr.io.
+#   - publishes to PyPI via Trusted Publishing (OIDC, no API token).
+#
+# The OCI image is built and published by `.github/workflows/container.yml`,
+# which fans out across slim + distroless variants and linux/amd64 + linux/arm64.
 #
 # A manual `workflow_dispatch` path exists to dry-run the build/smoke
 # pipeline against any ref without publishing.
@@ -199,39 +201,3 @@ jobs:
           skip-existing: true
           verbose: true
 
-  publish-container:
-    name: publish-container
-    needs: build
-    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish == 'true')
-    timeout-minutes: 25
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - uses: actions/checkout@v6
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Extract image metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ghcr.io/${{ github.repository_owner }}/polylogue
-          tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=ref,event=tag
-            type=raw,value=latest,enable={{is_default_branch}}
-      - uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: ./Containerfile
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max

--- a/Containerfile
+++ b/Containerfile
@@ -1,21 +1,25 @@
 # syntax=docker/dockerfile:1.7
 #
-# Polylogue OCI image. Multi-stage:
-#   1. builder — uses `uv` to build the wheel from the checkout
-#   2. runtime — slim python image, installs only the built wheel
+# Polylogue OCI image. Daemon-first multi-stage build.
 #
-# Exposes three console scripts (polylogue, polylogued, polylogue-mcp) on PATH.
+# Stages:
+#   1. builder    — uses `uv` to build the wheel from the checkout
+#   2. runtime    — slim python image; default; entrypoint = polylogued
+#   3. distroless — gcr.io/distroless/python3-debian12; minimal, no shell
+#
+# Build the default (slim) image:
+#   docker buildx build --target runtime    -t polylogue:slim       .
+# Build the distroless image:
+#   docker buildx build --target distroless -t polylogue:distroless .
+#
+# Console scripts on PATH in the runtime stage:
+#   polylogue, polylogued, polylogue-mcp  (CLI is included for `docker exec` debug)
+#
 # Operators are expected to mount durable state:
-#   -v polylogue-data:/data    (XDG_DATA_HOME — archive SQLite, blobs)
-#   -v polylogue-config:/config (XDG_CONFIG_HOME — polylogue.toml, secrets)
+#   -v polylogue-archive:/data/archive   (POLYLOGUE_ARCHIVE_ROOT — SQLite + blobs)
+#   -v polylogue-config:/etc/polylogue   (POLYLOGUE_CONFIG_DIR — polylogue.toml, secrets)
 #
-# Example invocations:
-#   podman run --rm ghcr.io/sinity/polylogue:latest polylogue --version
-#   podman run --rm -v polylogue-data:/data ghcr.io/sinity/polylogue:latest \
-#     polylogue stats
-#   podman run -d --name polylogued -v polylogue-data:/data \
-#     -v polylogue-config:/config -p 7777:7777 \
-#     ghcr.io/sinity/polylogue:latest polylogued run --enable-api
+# See docs/installation.md and docs/docker-compose.yaml for example invocations.
 
 # ---- builder ------------------------------------------------------------
 FROM python:3.13-slim-bookworm AS builder
@@ -35,41 +39,129 @@ COPY . /src
 # hatch_build.py, so the resulting wheel knows its own version + commit.
 RUN uv build --wheel --out-dir /dist /src
 
-# ---- runtime ------------------------------------------------------------
+# ---- runtime (default) --------------------------------------------------
 FROM python:3.13-slim-bookworm AS runtime
+
+ARG POLYLOGUE_UID=10001
+ARG POLYLOGUE_GID=10001
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
     POLYLOGUE_FORCE_PLAIN=1 \
+    POLYLOGUE_ARCHIVE_ROOT=/data/archive \
+    POLYLOGUE_CONFIG_DIR=/etc/polylogue \
     XDG_DATA_HOME=/data \
-    XDG_CONFIG_HOME=/config \
-    XDG_CACHE_HOME=/cache
+    XDG_CONFIG_HOME=/etc/polylogue \
+    XDG_CACHE_HOME=/var/cache/polylogue \
+    POLYLOGUE_DAEMON_API_HOST=0.0.0.0 \
+    POLYLOGUE_DAEMON_API_PORT=8766
 
 # Runtime deps:
 #   ca-certificates — outbound HTTPS (PyPI, Voyage, Drive)
 #   tini             — PID 1 for clean SIGTERM/SIGINT signalling
+#   curl             — used by HEALTHCHECK against the daemon /api/health endpoint
 RUN apt-get update \
- && apt-get install -y --no-install-recommends ca-certificates tini \
+ && apt-get install -y --no-install-recommends ca-certificates tini curl \
  && rm -rf /var/lib/apt/lists/*
 
-# Install the built wheel without dev/extras. Dependencies are resolved
-# from PyPI against the wheel's declared metadata.
+# Install the built wheel without dev/extras. Dependencies resolve from PyPI
+# against the wheel's declared metadata. The resulting site-packages tree is
+# copied unchanged into the distroless stage below.
 COPY --from=builder /dist/*.whl /tmp/
 RUN pip install --no-cache-dir /tmp/*.whl && rm /tmp/*.whl
 
-# Non-root runtime user; archive writes happen under /data so it must own
-# the mount target. Operators that bind-mount a host path are expected to
-# either chown it to UID 1000 or override --user explicitly.
-RUN groupadd --system --gid 1000 polylogue \
- && useradd  --system --uid 1000 --gid polylogue --home /home/polylogue --create-home polylogue \
- && mkdir -p /data /config /cache \
- && chown -R polylogue:polylogue /data /config /cache
+# Non-root runtime user (UID 10001 by AC). Archive writes happen under
+# /data/archive, config under /etc/polylogue, cache under /var/cache/polylogue.
+# Operators that bind-mount host paths must chown those to UID 10001 or
+# override --user explicitly.
+RUN groupadd --system --gid ${POLYLOGUE_GID} polylogue \
+ && useradd  --system --uid ${POLYLOGUE_UID} --gid polylogue \
+       --home /home/polylogue --create-home polylogue \
+ && mkdir -p /data/archive /etc/polylogue /var/cache/polylogue \
+ && chown -R polylogue:polylogue /data /etc/polylogue /var/cache/polylogue
 
 USER polylogue
 WORKDIR /home/polylogue
-VOLUME ["/data", "/config"]
+VOLUME ["/data/archive", "/etc/polylogue"]
+EXPOSE 8766
 
+# Healthcheck hits the daemon HTTP API. The daemon must be started with
+# --enable-api (the default container CMD does this) for this to succeed.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+  CMD curl --fail --silent --show-error \
+      "http://127.0.0.1:${POLYLOGUE_DAEMON_API_PORT}/api/health" \
+      > /dev/null || exit 1
+
+# tini reaps zombies and forwards signals; the daemon binary is PID 2.
+# --enable-api turns on the HTTP surface used by HEALTHCHECK.
+# --api-host 0.0.0.0 lets the host reach the API across the container boundary;
+# operators that want loopback-only should override the CMD.
 ENTRYPOINT ["/usr/bin/tini", "--"]
-CMD ["polylogue", "--help"]
+CMD ["polylogued", "run", \
+     "--enable-api", \
+     "--api-host", "0.0.0.0", \
+     "--api-port", "8766"]
+
+# OCI image annotations. The release workflow overrides these from
+# docker/metadata-action, but bake conservative defaults so a manual
+# `docker build .` still produces an annotated image.
+LABEL org.opencontainers.image.title="polylogue" \
+      org.opencontainers.image.description="Polylogue AI conversation archive daemon (polylogued) + CLI" \
+      org.opencontainers.image.source="https://github.com/Sinity/polylogue" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.vendor="Sinity"
+
+# ---- distroless (optional) ----------------------------------------------
+# Distroless variant for security-conscious deployments. Reuses the wheel
+# installed into /usr/local in the runtime stage. No shell, no package
+# manager — `docker exec` debugging is not possible against this image.
+#
+# Build with:  docker buildx build --target distroless -t polylogue:distroless .
+#
+# Note: distroless does not ship curl, so HEALTHCHECK is omitted at the
+# image level. Operators using Kubernetes / compose should configure
+# probes against the same /api/health endpoint at the orchestrator layer.
+FROM gcr.io/distroless/python3-debian12:nonroot AS distroless
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    POLYLOGUE_FORCE_PLAIN=1 \
+    POLYLOGUE_ARCHIVE_ROOT=/data/archive \
+    POLYLOGUE_CONFIG_DIR=/etc/polylogue \
+    XDG_DATA_HOME=/data \
+    XDG_CONFIG_HOME=/etc/polylogue \
+    XDG_CACHE_HOME=/var/cache/polylogue \
+    POLYLOGUE_DAEMON_API_HOST=0.0.0.0 \
+    POLYLOGUE_DAEMON_API_PORT=8766 \
+    PATH=/usr/local/bin:/usr/bin:/bin
+
+# Copy the installed Python environment and the console scripts from the
+# runtime stage. site-packages lives under /usr/local/lib/python3.13.
+COPY --from=runtime /usr/local/lib/python3.13 /usr/local/lib/python3.13
+COPY --from=runtime /usr/local/bin/polylogue       /usr/local/bin/polylogue
+COPY --from=runtime /usr/local/bin/polylogued      /usr/local/bin/polylogued
+COPY --from=runtime /usr/local/bin/polylogue-mcp   /usr/local/bin/polylogue-mcp
+
+# Distroless ships /etc/passwd with the `nonroot` user at UID 65532. The
+# `:nonroot` tag selects that user by default; we also chown'd the data
+# directories in the runtime stage but distroless can't run chown, so
+# operators must ensure host bind-mounts allow writes by UID 65532.
+COPY --from=runtime --chown=65532:65532 /data           /data
+COPY --from=runtime --chown=65532:65532 /etc/polylogue  /etc/polylogue
+COPY --from=runtime --chown=65532:65532 /var/cache/polylogue /var/cache/polylogue
+
+USER nonroot
+WORKDIR /home/nonroot
+VOLUME ["/data/archive", "/etc/polylogue"]
+EXPOSE 8766
+
+LABEL org.opencontainers.image.title="polylogue (distroless)" \
+      org.opencontainers.image.description="Polylogue daemon + CLI on distroless python3" \
+      org.opencontainers.image.source="https://github.com/Sinity/polylogue" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.vendor="Sinity"
+
+ENTRYPOINT ["/usr/local/bin/polylogued"]
+CMD ["run", "--enable-api", "--api-host", "0.0.0.0", "--api-port", "8766"]

--- a/docs/docker-compose.yaml
+++ b/docs/docker-compose.yaml
@@ -1,0 +1,79 @@
+# Sample docker-compose.yaml for the polylogued OCI image.
+#
+# Usage:
+#   docker compose -f docs/docker-compose.yaml up -d
+#   docker compose -f docs/docker-compose.yaml exec polylogued polylogue stats
+#   curl http://localhost:8766/api/health
+#
+# The named volumes below keep the SQLite archive and configuration durable
+# across container restarts. Replace `polylogue-archive` / `polylogue-config`
+# with host bind-mount paths if you prefer (chown them to UID 10001 first).
+#
+# Pin the image tag in production. `:latest` is provided for convenience but
+# follows master; use `:vX.Y.Z` (or `:vX.Y.Z-distroless`) for reproducible
+# deploys. See docs/installation.md for the variant matrix.
+
+services:
+  polylogued:
+    image: ghcr.io/sinity/polylogue:latest
+    container_name: polylogued
+    restart: unless-stopped
+
+    # The default CMD already starts the daemon with HTTP API enabled on
+    # 0.0.0.0:8766. Override it here if you need extra flags (e.g. embeddings).
+    # command: ["polylogued", "run", "--enable-api", "--api-host", "0.0.0.0",
+    #           "--api-port", "8766"]
+
+    environment:
+      # Override defaults if needed. The image already exports these.
+      POLYLOGUE_ARCHIVE_ROOT: /data/archive
+      POLYLOGUE_CONFIG_DIR: /etc/polylogue
+      # Required only if the daemon is exposed to non-loopback callers and
+      # you want the API to demand a bearer token. The container's own
+      # HEALTHCHECK uses loopback, which is unauthenticated.
+      # POLYLOGUE_API_AUTH_TOKEN: "change-me"
+
+    volumes:
+      - polylogue-archive:/data/archive
+      - polylogue-config:/etc/polylogue
+      # Mount source export roots read-only so the daemon can ingest them in
+      # place. Adjust to match your provider layout.
+      # - ${HOME}/.claude/projects:/srv/claude:ro
+      # - ${HOME}/.codex/sessions:/srv/codex:ro
+
+    ports:
+      - "8766:8766"   # Daemon HTTP API (/api/health, /api/status, web shell)
+
+    # The image declares HEALTHCHECK against /api/health on 127.0.0.1:8766;
+    # compose surfaces the result via `docker compose ps`. The block below
+    # makes that contract explicit and lets you tighten the timing.
+    healthcheck:
+      test: ["CMD", "curl", "--fail", "--silent", "--show-error",
+             "http://127.0.0.1:8766/api/health"]
+      interval: 30s
+      timeout: 5s
+      start_period: 30s
+      retries: 3
+
+    # Run as the image's built-in non-root UID. If you bind-mount host
+    # directories above, `chown -R 10001:10001 <path>` before starting.
+    user: "10001:10001"
+
+    # Tighten the container's capabilities. The daemon does not need any
+    # of the Linux capability set; cap_drop ALL keeps the threat surface
+    # minimal and is compatible with the existing entrypoint.
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+
+    # Read-only root filesystem with a writable tmpfs for /tmp. All durable
+    # state lives in the declared volumes.
+    read_only: true
+    tmpfs:
+      - /tmp:size=64m
+      - /var/cache/polylogue:size=128m
+
+volumes:
+  polylogue-archive:
+  polylogue-config:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,120 @@
+# Installation
+
+Polylogue ships through several distribution channels. Pick the one that
+matches how you run other tools on the host.
+
+| Channel | Audience | Reference |
+| --- | --- | --- |
+| `pip install polylogue` | Python users on any OS | [PyPI](https://pypi.org/project/polylogue/) |
+| `nix run github:Sinity/polylogue` | NixOS / nix-darwin users | [`flake.nix`](../flake.nix) |
+| `ghcr.io/sinity/polylogue` | Container / Kubernetes / Compose | see below |
+
+This document focuses on the container channel; the other channels are linked
+out so they can evolve independently.
+
+## Container image
+
+The image is published to
+[GitHub Container Registry](https://github.com/Sinity/polylogue/pkgs/container/polylogue)
+by [`.github/workflows/container.yml`](../.github/workflows/container.yml).
+Two variants ship from the same `Containerfile`:
+
+| Tag pattern | Stage | Base | Notes |
+| --- | --- | --- | --- |
+| `:latest`, `:vX.Y.Z`, `:vX.Y`, `:master-<sha>` | `runtime` | `python:3.13-slim-bookworm` | Includes `curl` + `tini`. Default. `docker exec` debug supported. |
+| `:latest-distroless`, `:vX.Y.Z-distroless`, … | `distroless` | `gcr.io/distroless/python3-debian12:nonroot` | No shell, no package manager. Smaller and tighter attack surface. |
+
+Both variants are built for `linux/amd64` and `linux/arm64`.
+
+### Volume contract
+
+The image declares two volumes; mount these to host paths or named volumes:
+
+| Mount point | Environment variable | Purpose |
+| --- | --- | --- |
+| `/data/archive` | `POLYLOGUE_ARCHIVE_ROOT` | SQLite database, FTS indexes, blob store. |
+| `/etc/polylogue` | `POLYLOGUE_CONFIG_DIR` (`XDG_CONFIG_HOME`) | `polylogue.toml`, credentials, OAuth tokens. |
+
+The runtime variant also exposes `8766/tcp` (daemon HTTP API).
+
+Run as the built-in non-root user `polylogue` (UID/GID `10001`). When using
+host bind-mounts, chown the target directories first:
+
+```bash
+mkdir -p /srv/polylogue/{archive,config}
+sudo chown -R 10001:10001 /srv/polylogue
+```
+
+### Quick start
+
+Foreground, daemon HTTP API on the host:
+
+```bash
+docker run --rm \
+  -p 8766:8766 \
+  -v polylogue-archive:/data/archive \
+  -v polylogue-config:/etc/polylogue \
+  ghcr.io/sinity/polylogue:latest
+```
+
+Check the health endpoint:
+
+```bash
+curl http://127.0.0.1:8766/api/health
+```
+
+Run the CLI inside the same image (the runtime variant ships `polylogue` and
+`polylogue-mcp` on `PATH`):
+
+```bash
+docker run --rm \
+  -v polylogue-archive:/data/archive \
+  -v polylogue-config:/etc/polylogue \
+  --entrypoint polylogue \
+  ghcr.io/sinity/polylogue:latest --version
+```
+
+### docker compose
+
+A complete sample lives at [`docs/docker-compose.yaml`](docker-compose.yaml).
+It configures the volume contract, healthcheck, non-root UID, read-only root
+filesystem, and `cap_drop: [ALL]`. Bring it up with:
+
+```bash
+docker compose -f docs/docker-compose.yaml up -d
+docker compose -f docs/docker-compose.yaml ps
+```
+
+### Distroless variant
+
+For deployments that prefer a smaller attack surface and don't need shell
+access for debugging:
+
+```bash
+docker pull ghcr.io/sinity/polylogue:latest-distroless
+docker run --rm -p 8766:8766 \
+  -v polylogue-archive:/data/archive \
+  ghcr.io/sinity/polylogue:latest-distroless
+```
+
+The distroless image omits `HEALTHCHECK` (no `curl` available); configure
+liveness/readiness probes at the orchestrator (compose, Kubernetes) against
+the same `GET /api/health` endpoint.
+
+### Building locally
+
+```bash
+docker buildx build --target runtime    -t polylogue:slim       .
+docker buildx build --target distroless -t polylogue:distroless .
+```
+
+For multi-arch local builds, set `--platform linux/amd64,linux/arm64` and
+arrange a registry to push to (buildx cannot `load` a multi-platform image
+into the local daemon).
+
+### Backup
+
+The archive lives entirely under `POLYLOGUE_ARCHIVE_ROOT`. Backups are file-
+level snapshots of the named volume / bind-mount target. Stop the daemon (or
+use the SQLite `.backup` command from inside the running container) before
+copying to avoid catching mid-checkpoint state.


### PR DESCRIPTION
## Summary

Daemon-first OCI image for `polylogued` with a healthcheck against the daemon HTTP API, a declared volume contract for archive + config, multi-arch publication (`linux/amd64` + `linux/arm64`), a distroless variant, and a sample `docker-compose.yaml`. Image lands on `ghcr.io/sinity/polylogue` via a dedicated `container.yml` workflow.

Closes #1236
Ref #953

## Problem

The only daemon distribution path was a one-stage `Containerfile` built and pushed inline from `release.yml`. That job:
- Built single-arch only (`linux/amd64`).
- Had no `HEALTHCHECK` and no declared `VOLUME` contract — operators had to guess the data + config layout.
- Defaulted to `polylogue --help` instead of starting the daemon, so the image did nothing useful when run without overrides.
- Used UID 1000, not the AC-specified 10001.
- Did not publish a distroless variant.
- Was coupled to the wheel/sdist release pipeline, which meant container changes could not iterate independently.

## Solution

- **`Containerfile`** rewritten:
  - Daemon-first `ENTRYPOINT` (`tini`) + `CMD` (`polylogued run --enable-api --api-host 0.0.0.0 --api-port 8766`). CLI (`polylogue`, `polylogue-mcp`) remains on `PATH` for `docker exec` debug per the issue's decision.
  - Non-root user `polylogue` at UID/GID 10001 (build-arg overridable).
  - `ENV POLYLOGUE_ARCHIVE_ROOT=/data/archive`, `ENV POLYLOGUE_CONFIG_DIR=/etc/polylogue`, matching `VOLUME ["/data/archive", "/etc/polylogue"]`.
  - `EXPOSE 8766`; `HEALTHCHECK` calls `http://127.0.0.1:8766/api/health` (route confirmed in `polylogue/daemon/http.py:626-629`, default `--api-port 8766` from `daemon/cli.py:799`).
  - OCI labels (`title`, `description`, `source`, `licenses`, `vendor`); the workflow overrides these from `docker/metadata-action`.
  - **Distroless stage** (`gcr.io/distroless/python3-debian12:nonroot`) reusing the runtime stage's installed site-packages so both variants stay in lockstep.
- **`.dockerignore`** added: trims build context (no `.git`, `.cache`, `.venv`, tests, docs except README).
- **`.github/workflows/container.yml`**: dedicated workflow with a `[runtime, distroless]` matrix. Builds both for `linux/amd64` + `linux/arm64` via `docker/setup-qemu-action` + `docker/setup-buildx-action`. Publishes to `ghcr.io/sinity/polylogue` on master and on `v*.*.*` tags with semver + `master-<sha>` tagging via `docker/metadata-action` (`-distroless` suffix on the distroless variant). PR builds smoke amd64-only and do not push. Provenance + SBOM attestations enabled.
- **`release.yml`**: dropped the inline `publish-container` job (now owned by `container.yml`); updated the header comment.
- **`docs/docker-compose.yaml`**: full sample exercising the volume contract, healthcheck, named volumes, `user: "10001:10001"`, `read_only: true`, `cap_drop: [ALL]`, `no-new-privileges:true`. Includes commented-out lines for read-only bind-mounts of provider export roots.
- **`docs/installation.md`**: variant matrix (slim vs distroless), volume contract, quick-start, compose pointer, distroless notes (no `curl` → orchestrator-level probes), backup expectations.

Alternatives rejected:
- Keeping the inline `publish-container` step in `release.yml`: rejected — keeps container iteration coupled to wheel/sdist gates and forces every container change to walk the full release matrix.
- Single workflow run with separate jobs per variant + per platform: rejected in favour of buildx's native multi-arch single-job build to share cache between variants and platforms.
- Putting `docker-compose.yaml` at repo root: kept under `docs/` to avoid implying it is the project's canonical deployment manifest.

## Verification

```text
$ nix develop -c devtools verify --quick
  ruff format ... ok
  ruff check ... ok
  mypy ... ok
  render-all ... ok
  verify-topology ... ok
  verify-layering ... ok
  verify-file-budgets ... ok
  verify-test-ownership ... ok
  verify-closure-matrix ... ok
  verify-schema-roundtrip ... ok
  verify-cross-cuts ... ok
  verify-suppressions ... ok
  verify-manifests ... ok
  verify-ci-workflows ... ok
  verify-witness-lifecycle ... ok
  verify-witness-coverage ... ok
  verify-lane-assertions ... ok
  verify-test-infra-currency ... ok
  verification-impact check ... ok
  exit_code: 0
```

`verify-ci-workflows` covers the new `.github/workflows/container.yml`. Docker is not available on the build host, so the image itself is exercised by the new `container.yml` workflow (PR builds smoke `--version` / `--help` on amd64; tag/master builds publish multi-arch).

## Follow-ups

- The distroless stage omits `HEALTHCHECK` (no `curl` in distroless); compose/Kubernetes probes against `/api/health` are documented in `docs/installation.md`. A pure-Python healthcheck binary baked into the image would let us restore `HEALTHCHECK` on the distroless variant — out of scope here.
- Image-size budget (the issue suggests <200MB) is left to the CI build to measure; if the distroless variant misses the budget we can shed extras in a follow-up.