### PR TITLE
feat(devtools): verification-impact --paths for speculative routing (#1312)

### DIFF
--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -177,6 +177,7 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
             "devtools verification-impact --full --markdown",
             "devtools verification-impact --path polylogue/sources/parsers/codex.py",
             "devtools verification-impact --json --path docs/verification-catalog.md",
+            "devtools verification-impact --json --paths polylogue/storage/sqlite/schema_ddl.py polylogue/sources/parsers/codex.py",
         ),
     ),
     CommandSpec("run-validation-lanes", "verification", "Run named validation lanes.", "devtools.run_validation_lanes"),

--- a/devtools/verification_impact_cli.py
+++ b/devtools/verification_impact_cli.py
@@ -29,6 +29,17 @@ def main(argv: list[str] | None = None) -> int:
         default=[],
         help="Changed repo-relative path. Repeat to bypass git diff path discovery.",
     )
+    parser.add_argument(
+        "--paths",
+        nargs="+",
+        default=[],
+        metavar="PATH",
+        help=(
+            "Speculative repo-relative path set (nargs+). Equivalent to repeating --path, "
+            "intended for agents asking 'if I touch these files, what gates trip?' before editing. "
+            "Combines with --path entries; presence of either bypasses git diff discovery."
+        ),
+    )
     parser.add_argument("--json", action="store_true", help="Emit a machine-readable affected-check report.")
     parser.add_argument("--markdown", action="store_true", help="Emit a markdown-formatted affected-check report.")
     parser.add_argument(
@@ -42,6 +53,12 @@ def main(argv: list[str] | None = None) -> int:
         help="Exit non-zero when blocking policy fails (only with --full).",
     )
     args = parser.parse_args(argv)
+    combined_paths: list[str] = []
+    seen_paths: set[str] = set()
+    for value in (*args.path, *args.paths):
+        if value and value not in seen_paths:
+            seen_paths.add(value)
+            combined_paths.append(value)
 
     if args.full:
         from devtools import repo_root as _get_root
@@ -57,7 +74,7 @@ def main(argv: list[str] | None = None) -> int:
             root,
             base_ref=args.base_ref,
             head_ref=args.head_ref,
-            changed_paths=args.path or None,
+            changed_paths=combined_paths or None,
         )
         check_result = evaluate_check_policy(full_report)
         if args.check:
@@ -72,7 +89,7 @@ def main(argv: list[str] | None = None) -> int:
             _print_human_report(full_report)
         return 1 if args.check and check_result["status"] != "ok" else 0
 
-    explicit_paths = tuple(args.path)
+    explicit_paths = tuple(combined_paths)
     base_ids: tuple[str, ...] | None
     head_ids: tuple[str, ...] | None
     if explicit_paths:

--- a/tests/unit/devtools/test_verification_impact_cli.py
+++ b/tests/unit/devtools/test_verification_impact_cli.py
@@ -42,6 +42,83 @@ def test_main_human_discovers_paths_from_refs(
     assert "provider.capability.codex" in rendered
 
 
+def test_main_json_routes_speculative_paths_via_paths_flag(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """--paths X Y computes the same envelope as --path X --path Y for speculative routing.
+
+    Used by agents asking 'if I touch these files, what gates trip?' before editing.
+    """
+    rc_paths = verification_impact_cli.main(
+        [
+            "--json",
+            "--paths",
+            "docs/verification-catalog.md",
+            "polylogue/sources/parsers/codex.py",
+        ]
+    )
+    assert rc_paths == 0
+    payload_paths = json.loads(capsys.readouterr().out)
+
+    rc_path = verification_impact_cli.main(
+        [
+            "--json",
+            "--path",
+            "docs/verification-catalog.md",
+            "--path",
+            "polylogue/sources/parsers/codex.py",
+        ]
+    )
+    assert rc_path == 0
+    payload_path = json.loads(capsys.readouterr().out)
+
+    assert payload_paths["changed_paths"] == [
+        "docs/verification-catalog.md",
+        "polylogue/sources/parsers/codex.py",
+    ]
+    # Same envelope shape and routing as the repeated --path form.
+    assert payload_paths == payload_path
+
+
+def test_main_paths_and_path_combine_and_dedupe(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    rc = verification_impact_cli.main(
+        [
+            "--json",
+            "--path",
+            "docs/verification-catalog.md",
+            "--paths",
+            "polylogue/sources/parsers/codex.py",
+            "docs/verification-catalog.md",
+        ]
+    )
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["changed_paths"] == [
+        "docs/verification-catalog.md",
+        "polylogue/sources/parsers/codex.py",
+    ]
+
+
+def test_main_full_paths_speculative_routing(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """--paths works against --full report (clean_tree False, has changed_paths)."""
+    rc = verification_impact_cli.main(
+        [
+            "--full",
+            "--json",
+            "--paths",
+            "polylogue/storage/sqlite/schema_ddl.py",
+        ]
+    )
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["changed_paths"] == ["polylogue/storage/sqlite/schema_ddl.py"]
+    assert payload["clean_tree"] is False
+
+
 def test_main_markdown_renders_affected_obligations(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],


### PR DESCRIPTION
## Summary

Adds `--paths PATH1 PATH2 ...` (nargs+) to `devtools verification-impact` so agents can ask "if I touch these files, what gates trip?" before editing them. Both the simple and `--full` modes accept the new flag; the JSON envelope shape is unchanged.

## Problem

#1283 fall-through (audit #1310): tier-1 recommendation **B** never landed. Tier-1 items A, C, D shipped via #1286, #1285, #1287 respectively. Without `--paths`, agents wanting speculative impact analysis had to either run `git diff` themselves or repeat `--path` for every file, which is awkward when sketching a hypothetical change set.

## Solution

`devtools/verification_impact_cli.py`:

- New `--paths` argparse arg with `nargs="+"`.
- `--path` and `--paths` are combined into `combined_paths` with dedupe (preserving first-seen order).
- Both the simple mode and the `--full` branch consume `combined_paths`; presence of either flag bypasses git diff discovery.

`devtools/command_catalog.py`:

- Added an example invocation showcasing the new shape so it appears in `docs/devtools.md` and the catalog discovery output.

`tests/unit/devtools/test_verification_impact_cli.py`:

- `test_main_json_routes_speculative_paths_via_paths_flag` — asserts `--paths X Y` and `--path X --path Y` produce byte-identical JSON envelopes.
- `test_main_paths_and_path_combine_and_dedupe` — confirms combine + dedupe semantics.
- `test_main_full_paths_speculative_routing` — exercises the `--full` branch (clean_tree False, changed_paths populated).

`docs/topology-status.md` reflects the standard `render-all` re-render.

## Verification

```
nix develop -c pytest tests/unit/devtools/test_verification_impact_cli.py --testmon-noselect -p no:randomly -v
# 6 passed in 14.01s

nix develop -c devtools render-all --check
# all surfaces sync OK

nix develop -c devtools verify --quick
# exit_code: 0  (total_duration_s: 72.32)
```

Pre-push hook (`devtools verify --quick`) also passed automatically: exit 0 in 44.01s.

Closes #1312