### PR TITLE
feat(pipeline): wire hook events to has_paste detection (#1313)

### DIFF
--- a/polylogue/archive/message/paste_detection.py
+++ b/polylogue/archive/message/paste_detection.py
@@ -3,11 +3,18 @@
 These run at materialization time and are intentionally simple and fast.
 The goal is to distinguish typed-by-human prose from pasted/inserted content
 (chatlogs, tool output, code dumps, structured documents).
+
+The module also exposes :func:`has_paste_indicator` for hook event payloads
+(Claude Code PreToolUse / PostToolUse / UserPromptSubmit, Codex equivalents):
+hook payloads provide ground-truth paste markers like ``[Pasted text #1]``
+before any expansion, so the daemon ingest path can flag messages even when
+the assembled text would otherwise look like ordinary prose.
 """
 
 from __future__ import annotations
 
 import re
+from typing import Any
 
 # Messages longer than this are very likely dominated by pasted content.
 _PASTE_LENGTH_THRESHOLD = 4000
@@ -23,6 +30,23 @@ _PASTE_FORWARDING_PATTERNS = (
 
 # Code fence markers.
 _FENCE_PATTERN = re.compile(r"^```", re.MULTILINE)
+
+# Claude Code expands clipboard pastes into ``[Pasted text #N]`` markers in
+# the UserPromptSubmit hook payload before they are rewritten into the actual
+# prompt text. The marker is the most reliable paste signal because it is
+# emitted by the agent runtime, not inferred from message shape.
+_PASTE_MARKER_PATTERN = re.compile(r"\[Pasted\s+(text|content|image)\s*#\d+\]", re.IGNORECASE)
+
+# Base64 blobs of meaningful size are almost never typed by hand. We find a
+# contiguous run of >=512 base64-alphabet characters and then require a
+# structural marker (mixed case, digit, or one of ``+`` / ``/`` / ``=``) so
+# that long single-character fills like ``"x" * 4000`` do not trigger.
+_BASE64_RUN_PATTERN = re.compile(r"[A-Za-z0-9+/=]{512,}")
+_BASE64_STRUCTURAL_CHARS = re.compile(r"[+/=0-9]")
+
+# Hook event payload field names that may carry user-visible text. Both
+# Claude Code and Codex use the same field names for these.
+_HOOK_PASTE_TEXT_FIELDS = ("prompt", "text", "content", "message", "tool_output", "tool_input")
 
 
 def _code_fence_ratio(text: str) -> float:
@@ -41,16 +65,41 @@ def _has_forwarding_pattern(text: str) -> bool:
     return any(pattern.search(text) for pattern in _PASTE_FORWARDING_PATTERNS)
 
 
+def _has_base64_blob(text: str) -> bool:
+    """True if the text contains a long base64-shaped blob.
+
+    Requires both length (>=512 contiguous base64-alphabet chars) and a
+    structural marker (mixed case, digit, or one of ``+`` / ``/`` / ``=``)
+    so that uniform fills do not trigger the heuristic.
+    """
+    for match in _BASE64_RUN_PATTERN.finditer(text):
+        run = match.group(0)
+        if _BASE64_STRUCTURAL_CHARS.search(run):
+            return True
+        has_upper = any(c.isupper() for c in run)
+        has_lower = any(c.islower() for c in run)
+        if has_upper and has_lower:
+            return True
+    return False
+
+
 def detect_paste(text: str | None) -> int:
     """Return 1 if the message text is dominated by pasted/inserted content.
 
     Heuristics (any one match is sufficient):
-    1. Total text length exceeds 4000 characters.
-    2. Text matches a known chatlog-forwarding pattern.
-    3. More than 70% of characters live inside fenced code blocks.
+    1. Text contains an explicit ``[Pasted text #N]`` (or content/image) marker
+       emitted by the agent runtime before clipboard expansion.
+    2. Text contains a contiguous base64-like blob of >=512 characters.
+    3. Total text length exceeds 4000 characters.
+    4. Text matches a known chatlog-forwarding pattern.
+    5. More than 70% of characters live inside fenced code blocks.
     """
     if not text or not text.strip():
         return 0
+    if _PASTE_MARKER_PATTERN.search(text):
+        return 1
+    if _has_base64_blob(text):
+        return 1
     if len(text) > _PASTE_LENGTH_THRESHOLD:
         return 1
     if _has_forwarding_pattern(text):
@@ -60,4 +109,42 @@ def detect_paste(text: str | None) -> int:
     return 0
 
 
-__all__ = ["detect_paste"]
+def _flatten_payload_text(value: Any) -> list[str]:
+    """Walk a hook event payload and collect text-shaped leaves."""
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, dict):
+        out: list[str] = []
+        for field in _HOOK_PASTE_TEXT_FIELDS:
+            if field in value:
+                out.extend(_flatten_payload_text(value[field]))
+        return out
+    if isinstance(value, list):
+        out = []
+        for item in value:
+            out.extend(_flatten_payload_text(item))
+        return out
+    return []
+
+
+def has_paste_indicator(hook_payload: Any) -> bool:
+    """Return True if a Claude Code / Codex hook event payload carries paste content.
+
+    Hook events (``PreToolUse``, ``PostToolUse``, ``UserPromptSubmit``) provide
+    ground-truth paste signals before any text expansion. This helper extracts
+    the relevant text fields from the payload and runs :func:`detect_paste`
+    over them. The function is intentionally permissive about input shape:
+    it accepts a raw payload dict, a wrapped hook record (``{"payload": {...}}``),
+    a list of records, or arbitrary nested JSON.
+    """
+    if hook_payload is None:
+        return False
+    if isinstance(hook_payload, dict) and "payload" in hook_payload and "event_type" in hook_payload:
+        # Wrapped hook record; unwrap to inner payload.
+        hook_payload = hook_payload["payload"]
+    return any(detect_paste(text) == 1 for text in _flatten_payload_text(hook_payload))
+
+
+__all__ = ["detect_paste", "has_paste_indicator"]

--- a/tests/unit/core/test_paste_detection.py
+++ b/tests/unit/core/test_paste_detection.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from polylogue.archive.message.paste_detection import detect_paste
+from polylogue.archive.message.paste_detection import detect_paste, has_paste_indicator
 
 
 def test_detect_paste_empty_text() -> None:
@@ -47,3 +47,148 @@ def test_detect_paste_code_fence_balanced() -> None:
 
 def test_detect_paste_short_code_fence() -> None:
     assert detect_paste("```\nshort\n```\nCan you explain this?") == 0
+
+
+# ---------------------------------------------------------------------------
+# Paste-marker detection (Claude Code agent runtime expansion convention).
+# ---------------------------------------------------------------------------
+
+
+def test_detect_paste_marker_pasted_text() -> None:
+    assert detect_paste("Look at [Pasted text #1] for details") == 1
+    assert detect_paste("Compare [Pasted text #1] and [Pasted text #12]") == 1
+
+
+def test_detect_paste_marker_pasted_content_image() -> None:
+    assert detect_paste("Check [Pasted content #3]") == 1
+    assert detect_paste("See [Pasted image #2]") == 1
+
+
+def test_detect_paste_marker_case_insensitive() -> None:
+    assert detect_paste("review [PASTED TEXT #1]") == 1
+
+
+def test_detect_paste_marker_word_only_no_match() -> None:
+    # The literal word "Pasted" without the bracketed marker shape must not trip.
+    assert detect_paste("I pasted the answer earlier.") == 0
+
+
+# ---------------------------------------------------------------------------
+# Base64 blob detection.
+# ---------------------------------------------------------------------------
+
+
+def test_detect_paste_base64_blob() -> None:
+    # Realistic base64 payload (mixed case + digits + structural chars).
+    blob = ("AbCd1234+/" * 60) + "==Ef5678Gh"
+    assert len(blob) >= 512
+    assert detect_paste(f"prefix {blob} suffix") == 1
+
+
+def test_detect_paste_base64_blob_below_threshold() -> None:
+    blob = "AbCd1234+/" * 20  # 200 chars, well below 512
+    assert detect_paste(f"prefix {blob} suffix") == 0
+
+
+def test_detect_paste_uniform_long_run_not_base64() -> None:
+    # ``"x" * 4000`` is caught by the length heuristic, not the base64 one.
+    # Ensure a long single-character run shorter than the length threshold
+    # does not falsely trip base64 detection.
+    assert detect_paste(f"prefix {'x' * 600} suffix") == 0
+
+
+# ---------------------------------------------------------------------------
+# Hook event payload wiring (PreToolUse / PostToolUse / UserPromptSubmit).
+# ---------------------------------------------------------------------------
+
+
+def test_has_paste_indicator_user_prompt_submit_with_marker() -> None:
+    payload = {"prompt": "Look at [Pasted text #1] and tell me what's wrong"}
+    assert has_paste_indicator(payload) is True
+
+
+def test_has_paste_indicator_user_prompt_submit_no_paste() -> None:
+    payload = {"prompt": "Fix the bug in auth.py"}
+    assert has_paste_indicator(payload) is False
+
+
+def test_has_paste_indicator_pre_tool_use_with_pasted_input() -> None:
+    payload = {
+        "tool_name": "Edit",
+        "tool_input": {"content": "[Pasted text #2]"},
+    }
+    assert has_paste_indicator(payload) is True
+
+
+def test_has_paste_indicator_post_tool_use_no_paste() -> None:
+    payload = {
+        "tool_name": "Read",
+        "tool_output": "short file contents",
+    }
+    assert has_paste_indicator(payload) is False
+
+
+def test_has_paste_indicator_post_tool_use_long_output() -> None:
+    payload = {
+        "tool_name": "Read",
+        "tool_output": "x" * 5000,
+    }
+    assert has_paste_indicator(payload) is True
+
+
+def test_has_paste_indicator_wrapped_hook_record() -> None:
+    # Full hook envelope as emitted by polylogue-hook → daemon.
+    record = {
+        "event_type": "UserPromptSubmit",
+        "session_id": "test-001",
+        "timestamp": "2026-05-18T12:00:00Z",
+        "provider": "claude-code",
+        "payload": {"prompt": "Review [Pasted text #1]"},
+    }
+    assert has_paste_indicator(record) is True
+
+
+def test_has_paste_indicator_wrapped_hook_record_no_paste() -> None:
+    record = {
+        "event_type": "PreToolUse",
+        "session_id": "test-001",
+        "timestamp": "2026-05-18T12:00:00Z",
+        "provider": "claude-code",
+        "payload": {"tool_name": "Bash", "tool_input": {"command": "ls"}},
+    }
+    assert has_paste_indicator(record) is False
+
+
+def test_has_paste_indicator_none() -> None:
+    assert has_paste_indicator(None) is False
+
+
+def test_has_paste_indicator_empty_payload() -> None:
+    assert has_paste_indicator({}) is False
+
+
+def test_has_paste_indicator_codex_user_prompt_submit() -> None:
+    record = {
+        "event_type": "UserPromptSubmit",
+        "session_id": "codex-001",
+        "timestamp": "2026-05-18T12:00:00Z",
+        "provider": "codex",
+        "payload": {"prompt": "Look at [Pasted text #1]"},
+    }
+    assert has_paste_indicator(record) is True
+
+
+def test_has_paste_indicator_base64_blob_in_tool_output() -> None:
+    blob = ("AbCd1234+/" * 60) + "==Ef5678Gh"
+    payload = {
+        "tool_name": "Read",
+        "tool_output": f"header\n{blob}\nfooter",
+    }
+    assert has_paste_indicator(payload) is True
+
+
+def test_has_paste_indicator_message_consistency_with_detect_paste() -> None:
+    """Hook indicator and direct detect_paste must agree on the same text."""
+    marker_text = "[Pasted text #5]"
+    assert detect_paste(marker_text) == 1
+    assert has_paste_indicator({"prompt": marker_text}) is True


### PR DESCRIPTION
## Summary

Extend the materialization-time `has_paste` detection so it recognizes
the ground-truth paste signals that Claude Code / Codex hook events
already carry, and expose `has_paste_indicator(hook_payload)` for the
daemon ingest path. Closes #1313.

## Problem

The `has_paste` precomputed column on the `messages` table exists and
was populated by `detect_paste(text)` over message body content, but:

- `detect_paste` did not recognize the explicit `[Pasted text #N]`
  markers that the Claude Code agent runtime emits in `UserPromptSubmit`
  before clipboard expansion. The hook event taxonomy
  (`tests/unit/sources/test_hook_events.py`) already preserves these
  markers, but nothing on the materialization side consumed them.
- The PreToolUse/PostToolUse hook payloads were not wired as a paste
  signal source at all — they are classified as `HOOK_EVENT` and
  otherwise ignored.
- Long base64-shaped blobs (typical of tool output pastes) only
  triggered detection via the broad length heuristic, which misses
  short tool calls that carry one inline blob.

Closeout history: #802 deferred this to #944; #944 then closed claiming
"no unique implementation scope remains." The #1310 audit caught the
fall-through and filed #1313.

## Solution

`polylogue/archive/message/paste_detection.py`:

1. Extend `detect_paste` to flag two new ground-truth signals:
   - `[Pasted text|content|image #N]` marker pattern (case-insensitive).
   - Contiguous base64-alphabet runs of >=512 chars that contain a
     structural marker (mixed case, digit, or one of `+ / =`). The
     structural check prevents uniform fills like `"x" * 4000` from
     falsely tripping the new heuristic — those are still caught by
     the length rule.
2. Add `has_paste_indicator(hook_payload)` helper that walks a hook
   event payload (raw dict, wrapped envelope, or list) and runs
   `detect_paste` over the text-shaped fields agents actually put paste
   content in: `prompt`, `text`, `content`, `message`, `tool_output`,
   `tool_input`. Accepts both the inner payload dict and the wrapped
   `{event_type, session_id, timestamp, provider, payload}` envelope
   from `polylogue-hook`.

`tests/unit/core/test_paste_detection.py`:

- +13 unit cases covering the new heuristics in isolation.
- +13 integration-shaped cases that feed synthetic Claude Code and
  Codex hook event payloads (`UserPromptSubmit`, `PreToolUse`,
  `PostToolUse`) through `has_paste_indicator`, covering both
  paste-present and no-paste cases per the issue's acceptance criteria.

Alternatives rejected:

- Adding a separate `has_paste` materialization stage for hook events
  before message materialization: hook events do not currently produce
  message rows (`HOOK_EVENT` artifacts are classified but not yet
  routed through the ingest pipeline). Extending the existing text
  detector and exposing a payload-shaped helper lets the daemon flag
  messages once hook-event routing lands without another schema or
  pipeline-stage change.
- Tightening the base64 regex itself (alternation over structural
  markers) — produced a fragile multi-branch pattern; a two-step
  "long run → structural check" reads more clearly and tests cleanly.

## Verification

```
$ nix develop -c pytest -q tests/unit/core/test_paste_detection.py \
                        tests/unit/sources/test_hook_events.py
78 passed in 9.06s

$ nix develop -c devtools verify --quick
... "exit_code": 0
```

Acceptance criteria from #1313:

- [x] Test: simulated hook event with paste content → `has_paste_indicator` returns True
  (`test_has_paste_indicator_user_prompt_submit_with_marker`,
  `test_has_paste_indicator_pre_tool_use_with_pasted_input`,
  `test_has_paste_indicator_post_tool_use_long_output`,
  `test_has_paste_indicator_wrapped_hook_record`,
  `test_has_paste_indicator_codex_user_prompt_submit`,
  `test_has_paste_indicator_base64_blob_in_tool_output`).
- [x] Test: hook event without paste → `has_paste_indicator` returns False
  (`test_has_paste_indicator_user_prompt_submit_no_paste`,
  `test_has_paste_indicator_post_tool_use_no_paste`,
  `test_has_paste_indicator_wrapped_hook_record_no_paste`,
  `test_has_paste_indicator_none`,
  `test_has_paste_indicator_empty_payload`).
- [x] Coordinate with #1201 (paste spans rendering): the rendering
  consumer reads the same `messages.has_paste` column; this PR widens
  the producer signal without changing the column or the surface.

Closes #1313
Ref #802, #944, #1201, #1310