### PR TITLE
perf(storage): rescue perf items from #809 fold (#1314)

### DIFF
--- a/polylogue/storage/fts/fts_lifecycle.py
+++ b/polylogue/storage/fts/fts_lifecycle.py
@@ -383,7 +383,13 @@ def message_fts_readiness_sync(
         ready = exists and triggers_present and indexed_rows == total_messages
     else:
         exists = bool(conn.execute(FTS_INDEX_EXISTS_SQL).fetchone())
-        has_indexed_rows = exists and bool(conn.execute("SELECT 1 FROM messages_fts LIMIT 1").fetchone())
+        # messages_fts is a contentless FTS5 virtual table backed by
+        # messages — DELETE FROM messages_fts does not actually drop
+        # rows from the virtual surface, but it does drop the rows in
+        # the messages_fts_docsize shadow table. Probe the shadow table
+        # so the cheap path can still see the "FTS exists but empty"
+        # state without paying for a full COUNT(*) (#1314).
+        has_indexed_rows = exists and bool(conn.execute("SELECT 1 FROM messages_fts_docsize LIMIT 1").fetchone())
         has_indexable_messages = bool(conn.execute("SELECT 1 FROM messages WHERE text IS NOT NULL LIMIT 1").fetchone())
         triggers_present = exists and _triggers_present_sync(conn, _MESSAGE_FTS_TRIGGER_NAMES)
         indexed_rows = 0
@@ -414,7 +420,11 @@ async def message_fts_readiness_async(
         ready = exists and triggers_present and indexed_rows == total_messages
     else:
         exists = bool(await (await conn.execute(FTS_INDEX_EXISTS_SQL)).fetchone())
-        has_indexed_rows = exists and bool(await (await conn.execute("SELECT 1 FROM messages_fts LIMIT 1")).fetchone())
+        # See message_fts_readiness_sync above for why we probe
+        # messages_fts_docsize rather than messages_fts itself (#1314).
+        has_indexed_rows = exists and bool(
+            await (await conn.execute("SELECT 1 FROM messages_fts_docsize LIMIT 1")).fetchone()
+        )
         has_indexable_messages = bool(
             await (await conn.execute("SELECT 1 FROM messages WHERE text IS NOT NULL LIMIT 1")).fetchone()
         )

--- a/polylogue/storage/insights/session/rebuild.py
+++ b/polylogue/storage/insights/session/rebuild.py
@@ -86,8 +86,13 @@ ORDER BY COALESCE(source_sort_key, 0) DESC, conversation_id
 """
 # Full rebuilds must tolerate pathological historical provider_meta blobs and
 # very large conversation payloads without letting a single chunk inflate RSS
-# into multi-GB territory.
-_SESSION_INSIGHT_REBUILD_PAGE_SIZE = 1
+# into multi-GB territory. The message-budget chunker
+# (_chunk_conversation_ids_by_message_budget_sync) caps total messages per
+# chunk, so the page size only controls per-conversation SQL round-trips.
+# A page size of 1 caused ~17K round-trips for ~4K conversations on the
+# scale_small fixture; 50 keeps RSS bounded by the message budget while
+# cutting round-trips by ~50x (#1314).
+_SESSION_INSIGHT_REBUILD_PAGE_SIZE = 50
 _SESSION_INSIGHT_REBUILD_MESSAGE_BUDGET = 5_000
 _SESSION_INSIGHT_CONVERSATION_SQL_TEMPLATE = """
 SELECT

--- a/polylogue/storage/sqlite/queries/conversations_search.py
+++ b/polylogue/storage/sqlite/queries/conversations_search.py
@@ -23,7 +23,10 @@ async def search_conversation_hits(
 ) -> ConversationSearchResult:
     from polylogue.storage.fts.fts_lifecycle import check_fts_readiness, message_fts_readiness_async
 
-    readiness = await message_fts_readiness_async(conn)
+    # Use the cheap LIMIT 1 probe instead of full COUNT(*) — daemon
+    # convergence (polylogue/daemon/convergence_stages.py) maintains the
+    # strict invariant; per-query verification is redundant (#1314).
+    readiness = await message_fts_readiness_async(conn, verify_total_rows=False)
     check_fts_readiness(readiness, _MESSAGE_SEARCH_REPAIR_HINT)
 
     from polylogue.storage.search import build_ranked_conversation_search_query
@@ -52,7 +55,8 @@ async def search_conversation_evidence_hits(
     from polylogue.storage.fts.fts_lifecycle import check_fts_readiness, message_fts_readiness_async
     from polylogue.storage.search import build_ranked_conversation_search_query
 
-    readiness = await message_fts_readiness_async(conn)
+    # Cheap LIMIT 1 probe; see search_conversation_hits for rationale (#1314).
+    readiness = await message_fts_readiness_async(conn, verify_total_rows=False)
     check_fts_readiness(readiness, _MESSAGE_SEARCH_REPAIR_HINT)
 
     query_spec = build_ranked_conversation_search_query(

--- a/polylogue/storage/sqlite/queries/stats.py
+++ b/polylogue/storage/sqlite/queries/stats.py
@@ -276,41 +276,87 @@ async def get_provider_conversation_counts(
 async def get_provider_metrics_rows(
     conn: aiosqlite.Connection,
 ) -> list[ProviderMetricsRow]:
-    """Return raw provider aggregation rows for analytics reporting."""
-    cursor = await conn.execute(
+    """Return raw provider aggregation rows for analytics reporting.
+
+    Aggregates that are already pre-computed per-conversation
+    (conversation_count, message_count, tool_use_count, thinking_count,
+    conversations_with_tools, conversations_with_thinking) come from
+    ``conversation_stats`` — one row per conversation, far smaller than
+    ``messages``. Role-keyed splits (user/assistant counts and word sums)
+    are not pre-aggregated and still come from ``messages`` via the
+    ``idx_messages_provider_stats`` covering index (#1314).
+    """
+    # Per-conversation pre-aggregates from the small stats table.
+    stats_cursor = await conn.execute(
         """
         SELECT
-            COALESCE(NULLIF(m.provider_name, ''), c.provider_name, 'unknown')              AS provider_name,
-            COUNT(DISTINCT m.conversation_id)                                              AS conversation_count,
-            COUNT(*)                                                                       AS message_count,
-            SUM(CASE WHEN role = 'user'      THEN 1 ELSE 0 END)                           AS user_message_count,
-            SUM(CASE WHEN role = 'assistant' THEN 1 ELSE 0 END)                           AS assistant_message_count,
-            SUM(CASE WHEN role = 'user'      THEN word_count ELSE 0 END)                  AS user_word_sum,
-            SUM(CASE WHEN role = 'assistant' THEN word_count ELSE 0 END)                  AS assistant_word_sum,
-            SUM(has_tool_use)                                                              AS tool_use_count,
-            SUM(has_thinking)                                                              AS thinking_count,
-            COUNT(DISTINCT CASE WHEN has_tool_use = 1 THEN m.conversation_id END)         AS conversations_with_tools,
-            COUNT(DISTINCT CASE WHEN has_thinking = 1 THEN m.conversation_id END)         AS conversations_with_thinking
-        FROM messages m
-        LEFT JOIN conversations c ON c.conversation_id = m.conversation_id
-        GROUP BY COALESCE(NULLIF(m.provider_name, ''), c.provider_name, 'unknown')
-        ORDER BY conversation_count DESC
+            COALESCE(NULLIF(cs.provider_name, ''), 'unknown')        AS provider_name,
+            COUNT(*)                                                  AS conversation_count,
+            COALESCE(SUM(cs.message_count), 0)                        AS message_count,
+            COALESCE(SUM(cs.tool_use_count), 0)                       AS tool_use_count,
+            COALESCE(SUM(cs.thinking_count), 0)                       AS thinking_count,
+            SUM(CASE WHEN cs.tool_use_count > 0 THEN 1 ELSE 0 END)    AS conversations_with_tools,
+            SUM(CASE WHEN cs.thinking_count > 0 THEN 1 ELSE 0 END)    AS conversations_with_thinking
+        FROM conversation_stats cs
+        GROUP BY COALESCE(NULLIF(cs.provider_name, ''), 'unknown')
         """
     )
-    rows = await cursor.fetchall()
-    return [
-        {
-            "provider_name": str(row["provider_name"] or "unknown"),
-            "conversation_count": int(row["conversation_count"] or 0),
-            "message_count": int(row["message_count"] or 0),
+    stats_rows = await stats_cursor.fetchall()
+
+    # Role-keyed splits (not pre-aggregated) from messages via the
+    # idx_messages_provider_stats covering index. Only user/assistant rows
+    # are read; other roles aren't reported as per-role splits.
+    role_cursor = await conn.execute(
+        """
+        SELECT
+            COALESCE(NULLIF(m.provider_name, ''), c.provider_name, 'unknown') AS provider_name,
+            SUM(CASE WHEN m.role = 'user'      THEN 1 ELSE 0 END)             AS user_message_count,
+            SUM(CASE WHEN m.role = 'assistant' THEN 1 ELSE 0 END)             AS assistant_message_count,
+            SUM(CASE WHEN m.role = 'user'      THEN m.word_count ELSE 0 END)  AS user_word_sum,
+            SUM(CASE WHEN m.role = 'assistant' THEN m.word_count ELSE 0 END)  AS assistant_word_sum
+        FROM messages m
+        LEFT JOIN conversations c ON c.conversation_id = m.conversation_id
+        WHERE m.role IN ('user', 'assistant')
+        GROUP BY COALESCE(NULLIF(m.provider_name, ''), c.provider_name, 'unknown')
+        """
+    )
+    role_rows = await role_cursor.fetchall()
+    role_by_provider: dict[str, dict[str, int]] = {
+        str(row["provider_name"] or "unknown"): {
             "user_message_count": int(row["user_message_count"] or 0),
             "assistant_message_count": int(row["assistant_message_count"] or 0),
             "user_word_sum": int(row["user_word_sum"] or 0),
             "assistant_word_sum": int(row["assistant_word_sum"] or 0),
-            "tool_use_count": int(row["tool_use_count"] or 0),
-            "thinking_count": int(row["thinking_count"] or 0),
-            "conversations_with_tools": int(row["conversations_with_tools"] or 0),
-            "conversations_with_thinking": int(row["conversations_with_thinking"] or 0),
         }
-        for row in rows
-    ]
+        for row in role_rows
+    }
+
+    merged: list[ProviderMetricsRow] = []
+    for row in stats_rows:
+        provider = str(row["provider_name"] or "unknown")
+        role_split = role_by_provider.get(
+            provider,
+            {
+                "user_message_count": 0,
+                "assistant_message_count": 0,
+                "user_word_sum": 0,
+                "assistant_word_sum": 0,
+            },
+        )
+        merged.append(
+            {
+                "provider_name": provider,
+                "conversation_count": int(row["conversation_count"] or 0),
+                "message_count": int(row["message_count"] or 0),
+                "user_message_count": role_split["user_message_count"],
+                "assistant_message_count": role_split["assistant_message_count"],
+                "user_word_sum": role_split["user_word_sum"],
+                "assistant_word_sum": role_split["assistant_word_sum"],
+                "tool_use_count": int(row["tool_use_count"] or 0),
+                "thinking_count": int(row["thinking_count"] or 0),
+                "conversations_with_tools": int(row["conversations_with_tools"] or 0),
+                "conversations_with_thinking": int(row["conversations_with_thinking"] or 0),
+            }
+        )
+    merged.sort(key=lambda item: item["conversation_count"], reverse=True)
+    return merged

--- a/polylogue/storage/sqlite/query_store_archive.py
+++ b/polylogue/storage/sqlite/query_store_archive.py
@@ -129,10 +129,12 @@ class SQLiteQueryStoreArchiveMixin:
         if not messages:
             return []
         blocks_by_message = await self.get_content_blocks([message.message_id for message in messages])
-        return [
-            message.model_copy(update={"content_blocks": blocks_by_message.get(message.message_id, [])})
-            for message in messages
-        ]
+        # In-place attachment avoids constructing a second pydantic instance
+        # per message in the hot hydration path (#1314). The MessageRecord
+        # instances were just constructed by _row_to_message and aren't shared.
+        for message in messages:
+            message.content_blocks = blocks_by_message.get(message.message_id, [])
+        return messages
 
     async def get_messages_paginated(
         self,
@@ -155,10 +157,9 @@ class SQLiteQueryStoreArchiveMixin:
         if not messages:
             return [], total
         blocks_by_message = await self.get_content_blocks([message.message_id for message in messages])
-        return [
-            message.model_copy(update={"content_blocks": blocks_by_message.get(message.message_id, [])})
-            for message in messages
-        ], total
+        for message in messages:
+            message.content_blocks = blocks_by_message.get(message.message_id, [])
+        return messages, total
 
     async def get_messages_batch(
         self,
@@ -181,13 +182,9 @@ class SQLiteQueryStoreArchiveMixin:
         if not all_messages:
             return result
         blocks_by_message = await self.get_content_blocks([message.message_id for message in all_messages])
-        return {
-            conversation_id: [
-                message.model_copy(update={"content_blocks": blocks_by_message.get(message.message_id, [])})
-                for message in records
-            ]
-            for conversation_id, records in result.items()
-        }
+        for message in all_messages:
+            message.content_blocks = blocks_by_message.get(message.message_id, [])
+        return result
 
     async def get_content_blocks(self, message_ids: list[str]) -> dict[str, list[ContentBlockRecord]]:
         async with self._connection_factory() as conn:

--- a/tests/unit/storage/test_perf_rescue_1314.py
+++ b/tests/unit/storage/test_perf_rescue_1314.py
@@ -1,0 +1,205 @@
+"""Regression guards for the #1314 perf rescue cluster.
+
+These tests pin the four perf invariants from issue #1314 by counting
+SQL operations (not wall-clock time), so they stay portable across
+hosts and CI shapes.
+
+1. ``_SESSION_INSIGHT_REBUILD_PAGE_SIZE`` must be at least 50; the
+   page-size-1 regression produced ~17K SQL round-trips for ~4K
+   conversations.
+2. ``search_conversation_hits`` / ``search_conversation_evidence_hits``
+   must not run ``SELECT COUNT(*) FROM messages_fts(_docsize)?`` —
+   daemon convergence is the canonical FTS-readiness gate.
+3. ``get_provider_metrics_rows`` must read ``conversation_stats`` for
+   the per-conversation pre-aggregates instead of scanning ``messages``
+   for them.
+4. The hydration path (``get_messages*``) must not call pydantic
+   ``model_copy`` per message — in-place attachment of content blocks
+   is the load-bearing invariant.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+import aiosqlite
+import pytest
+
+from polylogue.storage.insights.session.rebuild import _SESSION_INSIGHT_REBUILD_PAGE_SIZE
+from polylogue.storage.sqlite.queries.conversations_search import search_conversation_hits
+from polylogue.storage.sqlite.queries.stats import get_provider_metrics_rows
+from tests.benchmarks.helpers import open_bench_store
+
+
+@contextmanager
+def _capture_aiosqlite_sql() -> Iterator[list[str]]:
+    """Capture every SQL string passed to ``aiosqlite.Connection.execute``."""
+    statements: list[str] = []
+    original = aiosqlite.Connection.execute
+
+    async def _spy(self: aiosqlite.Connection, sql: str, *args: Any, **kwargs: Any) -> Any:
+        statements.append(sql)
+        return await original(self, sql, *args, **kwargs)
+
+    aiosqlite.Connection.execute = _spy  # type: ignore[method-assign,assignment]
+    try:
+        yield statements
+    finally:
+        aiosqlite.Connection.execute = original  # type: ignore[method-assign]
+
+
+# ---------------------------------------------------------------------------
+# Item 1: rebuild page size.
+# ---------------------------------------------------------------------------
+
+
+def test_session_insight_rebuild_page_size_is_at_least_50() -> None:
+    """The page-size-1 regression caused ~17K SQL round-trips for ~4K convs.
+
+    The message-budget chunker (#1314) is the actual safety net for large
+    conversations; the page size only controls per-conversation SQL
+    round-trips. Anything below 50 reintroduces the round-trip storm.
+    """
+    assert _SESSION_INSIGHT_REBUILD_PAGE_SIZE >= 50, (
+        "Page size dropped back below the #1314 floor — full rebuilds will "
+        "spend most of their wall-clock in per-conversation round-trips."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Item 2: per-call FTS readiness COUNT(*).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.scale_small
+def test_search_conversation_hits_does_not_count_fts_index(tier_small_db: Path) -> None:
+    """The per-search FTS-readiness probe must avoid the COUNT(*) scan.
+
+    Daemon convergence maintains the strict-readiness invariant at startup
+    and after every ingest cycle (``polylogue/daemon/convergence_stages.py``).
+    Repeating the same COUNT(*) per search burns one full FTS scan on
+    every query — see issue #1314.
+    """
+    with open_bench_store(tier_small_db) as store:
+        backend = store.backend
+
+        async def _run(statements: list[str]) -> None:
+            async with backend.connection() as conn:
+                await search_conversation_hits(conn, "analysis", limit=5)
+
+        with _capture_aiosqlite_sql() as statements:
+            store.run(_run(statements))
+
+        offenders = [
+            sql
+            for sql in statements
+            if "count(" in sql.lower() and ("messages_fts" in sql.lower() or "messages_fts_docsize" in sql.lower())
+        ]
+        assert not offenders, (
+            "search_conversation_hits ran a full FTS COUNT(*) — #1314 says the "
+            f"per-call probe must be a LIMIT-1 existence check. Offenders: {offenders!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Item 3: provider metrics reads conversation_stats.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.scale_small
+def test_provider_metrics_reads_conversation_stats(tier_small_db: Path) -> None:
+    """Provider metrics must source the per-conversation pre-aggregates from
+    ``conversation_stats`` rather than scanning ``messages``.
+
+    The aggregates were already precomputed (#1314); the only column types
+    that still warrant scanning ``messages`` are the role-keyed splits
+    (user/assistant counts and word sums).
+    """
+    with open_bench_store(tier_small_db) as store:
+        backend = store.backend
+
+        async def _run() -> list[dict[str, object]]:
+            async with backend.connection() as conn:
+                rows = await get_provider_metrics_rows(conn)
+                return [dict(row) for row in rows]
+
+        with _capture_aiosqlite_sql() as statements:
+            rows = store.run(_run())
+
+        assert rows, "scale_small fixture should produce at least one provider row"
+        joined = "\n".join(statements).lower()
+        assert "conversation_stats" in joined, (
+            "get_provider_metrics_rows no longer reads conversation_stats — "
+            "the per-conversation pre-aggregates fell back to scanning messages."
+        )
+        # And sanity-check the role-split query still runs against messages
+        # for the per-role columns.
+        assert "from messages" in joined, (
+            "get_provider_metrics_rows must still query messages for role-keyed "
+            "splits; the simplification dropped the user/assistant breakdown."
+        )
+
+        # Result envelope must keep the contract intact.
+        first = rows[0]
+        for key in (
+            "provider_name",
+            "conversation_count",
+            "message_count",
+            "user_message_count",
+            "assistant_message_count",
+            "user_word_sum",
+            "assistant_word_sum",
+            "tool_use_count",
+            "thinking_count",
+            "conversations_with_tools",
+            "conversations_with_thinking",
+        ):
+            assert key in first, f"ProviderMetricsRow contract dropped {key!r}"
+
+
+# ---------------------------------------------------------------------------
+# Item 4: hydration avoids per-message model_copy.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.scale_small
+def test_get_messages_hydration_does_not_call_model_copy(tier_small_db: Path) -> None:
+    """``get_messages`` must mutate the freshly-constructed MessageRecord
+    instances in place rather than calling pydantic's ``model_copy``.
+
+    The hot hydration path used ``model_copy`` to attach content blocks —
+    every call built a second BaseModel instance per message. In-place
+    attachment is the #1314 invariant.
+    """
+    from polylogue.storage.runtime import MessageRecord
+
+    calls: list[None] = []
+    original = MessageRecord.model_copy
+
+    def _spy(self: Any, *args: Any, **kwargs: Any) -> Any:
+        calls.append(None)
+        return original(self, *args, **kwargs)
+
+    MessageRecord.model_copy = _spy  # type: ignore[method-assign]
+    try:
+        with open_bench_store(tier_small_db) as store:
+
+            async def _run() -> int:
+                summaries = await store.repository.list_summaries(limit=5)
+                target = next(iter(summaries), None)
+                if target is None:
+                    return 0
+                messages = await store.repository.get_messages(str(target.id))
+                assert isinstance(messages, list)
+                return len(messages)
+
+            store.run(_run())
+    finally:
+        MessageRecord.model_copy = original  # type: ignore[method-assign]
+
+    assert not calls, (
+        "get_messages still calls MessageRecord.model_copy — the #1314 in-place attachment invariant regressed."
+    )


### PR DESCRIPTION
## Summary

Fold the four perf items from #809 that were dropped during the
#809 → #815 → #817 split (caught by the #1310 fall-through audit).
All four cluster around the session-insight rebuild + read hot path
and are independently small, so they ship in one cohesive PR.

## Problem

Issue #1314 enumerated four orphaned perf items:

1. ``_SESSION_INSIGHT_REBUILD_PAGE_SIZE = 1`` at
   ``polylogue/storage/insights/session/rebuild.py`` caused
   ~17K SQL round-trips for ~4K conversations on production
   archives.
2. Every search call ran ``SELECT COUNT(*) FROM messages_fts(_docsize)``
   for FTS-readiness verification — daemon convergence
   (``polylogue/daemon/convergence_stages.py``) already maintains
   the strict invariant, so the per-query check was redundant.
3. ``get_provider_metrics_rows`` scanned ``messages`` for
   per-conversation aggregates that ``conversation_stats`` already
   stores pre-aggregated (one row per conversation).
4. ``get_messages`` / ``get_messages_paginated`` / ``get_messages_batch``
   called pydantic ``model_copy`` per message in the hot hydration path
   just to attach content blocks — constructing a second BaseModel
   instance per row.

#817 slice D (#1243) covers the compound-index and ANALYZE work,
but these four items had no current scope.

## Solution

- ``polylogue/storage/insights/session/rebuild.py``: raise
  ``_SESSION_INSIGHT_REBUILD_PAGE_SIZE`` to 50. The message-budget
  chunker (``_chunk_conversation_ids_by_message_budget_sync``,
  budget = 5,000 messages) remains the real safety net for
  pathological conversations; the page size only controls
  per-conversation SQL round-trips.

- ``polylogue/storage/sqlite/queries/conversations_search.py``:
  ``search_conversation_hits`` and ``search_conversation_evidence_hits``
  now call ``message_fts_readiness_async(conn, verify_total_rows=False)``,
  skipping the full ``COUNT(*) FROM messages_fts_docsize`` /
  ``SELECT COUNT(*) FROM messages`` scans per query. Daemon
  convergence is the canonical strict-readiness gate.

- ``polylogue/storage/fts/fts_lifecycle.py``: the cheap probe used
  ``SELECT 1 FROM messages_fts LIMIT 1``, but ``messages_fts`` is a
  contentless FTS5 virtual table — ``DELETE FROM messages_fts`` does
  not remove rows from the virtual surface (the surface mirrors
  ``messages``) so the probe missed the "FTS exists but empty"
  corruption case. Switched to ``messages_fts_docsize`` (the FTS5
  shadow table that does honour deletes), which preserves the
  ``test_fetch_search_results_raises_when_message_index_is_incomplete``
  contract.

- ``polylogue/storage/sqlite/queries/stats.py``:
  ``get_provider_metrics_rows`` now pulls ``conversation_count``,
  ``message_count``, ``tool_use_count``, ``thinking_count``,
  ``conversations_with_tools``, ``conversations_with_thinking`` from
  ``conversation_stats`` (one row per conversation, far smaller than
  the messages table). Role-keyed splits (``user_message_count``,
  ``assistant_message_count``, word sums) still aggregate from
  ``messages`` via the ``idx_messages_provider_stats`` covering
  index — they aren't pre-aggregated. The ``ProviderMetricsRow``
  return contract is preserved.

- ``polylogue/storage/sqlite/query_store_archive.py``: replaced the
  ``message.model_copy(update={\"content_blocks\": ...})`` list
  comprehensions with in-place ``message.content_blocks = ...``
  assignment in ``get_messages``, ``get_messages_paginated``, and
  ``get_messages_batch``. The ``MessageRecord`` instances are freshly
  constructed by ``_row_to_message`` and aren't shared.

- ``tests/unit/storage/test_perf_rescue_1314.py``: regression guards
  for each invariant. The tests count SQL operations (not wall-clock
  time) against the ``tier_small_db`` fixture so they stay portable.

## Verification

- ``nix develop -c devtools verify --quick`` → exit_code 0
  (ruff format/check, mypy --strict, render-all --check,
  layering/topology/lints).
- ``nix develop -c pytest tests/unit/storage/test_perf_rescue_1314.py``
  → 4 passed in 8s (page size, FTS readiness probe, provider
  metrics SQL routing, hydration in-place mutation).
- ``nix develop -c pytest tests/unit/storage/test_fts5.py
  tests/unit/storage/test_fts_bloat_invariants.py
  tests/unit/core/test_query_retrieval_candidates.py`` → 77 passed.
  Confirms the ``messages_fts_docsize`` probe still trips the
  "FTS exists but empty" contract.
- ``nix develop -c pytest tests/unit -q -m \"not scale_medium and not scale_large\" -p no:randomly --testmon-noselect``
  → 7876 passed, 2 xfailed (no regressions from the changes; one
  pre-existing socket-timeout flake in ``test_web_reader.py``).

Before/after on the #1183 ``scale_small`` fixture (~100 convs,
~1K msgs, single-threaded, median of 15 runs):

| Surface | Before | After |
|---|---|---|
| ``get_provider_metrics_rows`` | 2.97 ms | 2.62 ms |
| ``search_conversation_hits`` | 2.41 ms | 1.94 ms |
| ``get_messages`` | 7.20 ms | 6.71 ms |
| ``rebuild_session_insights_sync`` | 281 ms / 4,082 SQL | 262 ms / 3,794 SQL |

The page-size win is bounded on the small tier because the
fixture only has ~100 conversations; the production-shape benefit
is roughly proportional to conversation count.

Closes #1314