### PR TITLE
feat(dist): Nix flake module + service + cachix + FlakeHub (#1235)

### DIFF
--- a/.github/workflows/cachix.yml
+++ b/.github/workflows/cachix.yml
@@ -1,0 +1,44 @@
+name: Cachix
+
+# Push polylogue build closures (package + devshell) to the polylogue cachix
+# binary cache on master pushes and tags. Downstream `nix run github:Sinity/polylogue`
+# users with `cache.nixos.org` + `polylogue.cachix.org` configured will hit the
+# cache instead of rebuilding from source.
+#
+# Requires `CACHIX_AUTH_TOKEN` repository secret with write access to the
+# `polylogue` cachix cache.
+
+on:
+  push:
+    branches: [master]
+    tags: ["v[0-9]+.[0-9]+.[0-9]+"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  push:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: cachix/install-nix-action@v31
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: cachix/cachix-action@v15
+        with:
+          name: polylogue
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - name: Build and push package
+        run: nix build .#polylogue --print-out-paths
+      - name: Build and push api-python
+        run: nix build .#api-python --print-out-paths
+      - name: Build and push devshell closure
+        run: |
+          nix develop --profile dev-profile --command true
+          nix path-info ./dev-profile --recursive | cachix push polylogue

--- a/.github/workflows/flakehub.yml
+++ b/.github/workflows/flakehub.yml
@@ -1,0 +1,42 @@
+name: FlakeHub
+
+# Publish the polylogue flake to FlakeHub (https://flakehub.com) for
+# discoverability beyond niche Nix circles. Triggered on release tags
+# matching `vX.Y.Z` and on manual dispatch (e.g. for a rolling `0.1.x`
+# pre-release publish from master).
+#
+# FlakeHub uses OIDC for authentication (no secrets required), keyed off
+# the `id-token: write` permission on this workflow.
+
+on:
+  push:
+    tags: ["v[0-9]+.[0-9]+.[0-9]+"]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag or rolling channel to publish (e.g. 0.1.0-rolling)"
+        required: false
+        default: "0.1.0-rolling"
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: DeterminateSystems/nix-installer-action@main
+      - name: Push flake to FlakeHub
+        uses: DeterminateSystems/flakehub-push@main
+        with:
+          visibility: public
+          rolling: ${{ github.event_name == 'workflow_dispatch' }}
+          rolling-minor: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || '' }}
+          tag: ${{ github.event_name == 'push' && github.ref_name || '' }}

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -118,3 +118,95 @@ The archive lives entirely under `POLYLOGUE_ARCHIVE_ROOT`. Backups are file-
 level snapshots of the named volume / bind-mount target. Stop the daemon (or
 use the SQLite `.backup` command from inside the running container) before
 copying to avoid catching mid-checkpoint state.
+
+## Nix flake
+
+Polylogue ships as a flake. The flake exposes three apps, a default package,
+a NixOS module, and a Home Manager module. Build artifacts for `x86_64-linux`
+are mirrored to the [`polylogue` cachix
+cache](https://polylogue.cachix.org); enable it on a fresh host to avoid
+rebuilding the dependency closure.
+
+The flake is also published to [FlakeHub](https://flakehub.com/flake/Sinity/polylogue)
+for discoverability — either input URL form (`github:` or `https://flakehub.com/f/...`)
+resolves to the same flake.
+
+### One-shot invocation
+
+```bash
+nix run github:Sinity/polylogue                       # polylogue (CLI)
+nix run github:Sinity/polylogue#polylogued -- --help  # daemon
+nix run github:Sinity/polylogue#polylogue-mcp         # MCP server
+```
+
+Enable the binary cache for hit-on-first-pull:
+
+```bash
+nix-env -iA cachix -f https://cachix.org/api/v1/install   # if cachix is not on PATH
+cachix use polylogue
+```
+
+### External flake input
+
+```nix
+{
+  inputs.polylogue.url = "github:Sinity/polylogue";
+  # or, via FlakeHub:
+  # inputs.polylogue.url = "https://flakehub.com/f/Sinity/polylogue/*";
+
+  outputs = { self, nixpkgs, polylogue, ... }: {
+    # Use polylogue.packages.x86_64-linux.default in any derivation
+    # or wire the NixOS / HM module below.
+  };
+}
+```
+
+### NixOS module
+
+```nix
+{ inputs, pkgs, ... }: {
+  imports = [ inputs.polylogue.nixosModules.default ];
+
+  services.polylogue = {
+    enable = true;
+    package = inputs.polylogue.packages.${pkgs.system}.default;
+    settings = {
+      archive.root = "/var/lib/polylogue";
+      daemon.port = 8766;
+    };
+  };
+}
+```
+
+The module wires a `polylogued.service` systemd unit running `polylogued run`
+(watch + browser-capture + HTTP API). All `services.polylogue.settings.*`
+options map to entries in the generated `polylogue.toml` and are documented
+inline in [`nix/module.nix`](../nix/module.nix). Per-unit hardening defaults
+(`Nice = 10`, `IOSchedulingClass = idle`, `MemoryHigh = 1G`, `MemoryMax = 2G`)
+are tunable under `services.polylogue.service.*`.
+
+### Home Manager module
+
+```nix
+{ inputs, pkgs, ... }: {
+  imports = [ inputs.polylogue.homeManagerModules.default ];
+
+  programs.polylogued = {
+    enable = true;
+    package = inputs.polylogue.packages.${pkgs.system}.default;
+    settings.daemon.port = 8766;
+  };
+}
+```
+
+The HM module declares a `systemd.user.services.polylogued` unit. Set
+`programs.polylogued.autoStart = false;` to keep the unit available but not
+started at login.
+
+### Building locally
+
+```bash
+nix build .#polylogue           # the package
+nix build .#api-python          # python interpreter with polylogue importable
+nix flake check                 # smoke + format + lint
+```

--- a/docs/plans/distribution-coverage.yaml
+++ b/docs/plans/distribution-coverage.yaml
@@ -61,7 +61,16 @@ artifacts:
       Nix flake check runs in CI (nix-build gate). nix flake
       check validates the derivation can build. Nix is the
       primary distribution mechanism for the project author.
-      Python version is managed by Nix, not pip.
+      Python version is managed by Nix, not pip. The flake exposes
+      apps.{polylogue,polylogued,polylogue-mcp} for `nix run
+      github:Sinity/polylogue#<app>`, a NixOS module
+      (nixosModules.default) wiring services.polylogue, and a Home
+      Manager module (homeManagerModules.default) wiring
+      programs.polylogued. The cachix workflow
+      (.github/workflows/cachix.yml) pushes the package + devshell
+      closures to the polylogue cachix cache on master pushes and
+      tags; the flakehub workflow (.github/workflows/flakehub.yml)
+      publishes the flake to FlakeHub on tag push.
 
   dev_install:
     description: Editable development install

--- a/flake.nix
+++ b/flake.nix
@@ -295,6 +295,28 @@
 
       formatter.${system} = pkgs.nixfmt;
 
+      apps.${system} = {
+        polylogue = {
+          type = "app";
+          program = "${polylogue}/bin/polylogue";
+        };
+        polylogued = {
+          type = "app";
+          program = "${polylogue}/bin/polylogued";
+        };
+        polylogue-mcp = {
+          type = "app";
+          program = "${polylogue}/bin/polylogue-mcp";
+        };
+        default = {
+          type = "app";
+          program = "${polylogue}/bin/polylogue";
+        };
+      };
+
       nixosModules.default = import ./nix/module.nix;
+      nixosModules.polylogue = import ./nix/module.nix;
+      homeManagerModules.default = import ./nix/hm-module.nix;
+      homeManagerModules.polylogue = import ./nix/hm-module.nix;
     };
 }

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -1,0 +1,194 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.programs.polylogued;
+  inherit (lib) mkEnableOption mkOption types;
+
+  tomlFormat = pkgs.formats.toml { };
+
+  polylogueToml = {
+    archive = lib.optionalAttrs (cfg.settings.archive.root != null) {
+      root = cfg.settings.archive.root;
+    };
+    daemon =
+      let
+        base = lib.optionalAttrs (cfg.settings.daemon != { }) (
+          lib.filterAttrs (_: v: v != null) {
+            host = cfg.settings.daemon.host;
+            port = cfg.settings.daemon.port;
+            watch = cfg.settings.daemon.watch;
+          }
+        );
+        api = lib.optionalAttrs (cfg.settings.daemon-api != { }) {
+          api = lib.filterAttrs (_: v: v != null) {
+            host = cfg.settings.daemon-api.host;
+            port = cfg.settings.daemon-api.port;
+            auth_token = cfg.settings.daemon-api.auth-token;
+          };
+        };
+        browser-capture = lib.optionalAttrs (cfg.settings.browser-capture != { }) {
+          browser-capture = lib.filterAttrs (_: v: v != null) {
+            port = cfg.settings.browser-capture.port;
+            allowed_origins = cfg.settings.browser-capture.allowed-origins;
+          };
+        };
+      in
+      base // api // browser-capture;
+    embedding = lib.optionalAttrs (cfg.settings.embedding != { }) (
+      lib.filterAttrs (_: v: v != null) {
+        enabled = cfg.settings.embedding.enabled;
+        model = cfg.settings.embedding.model;
+        dimension = cfg.settings.embedding.dimension;
+        max_cost_usd = cfg.settings.embedding.max-cost-usd;
+      }
+    );
+    logging = lib.optionalAttrs (cfg.settings.logging != { }) (
+      lib.filterAttrs (_: v: v != null) {
+        level = cfg.settings.logging.level;
+        force_plain = cfg.settings.logging.force-plain;
+      }
+    );
+  };
+
+  configFile = tomlFormat.generate "polylogue.toml" polylogueToml;
+
+in
+{
+  options.programs.polylogued = {
+    enable = mkEnableOption "Polylogue AI conversation archive daemon (user-mode)";
+
+    package = mkOption {
+      type = types.package;
+      description = "The polylogue package to use.";
+    };
+
+    configPath = mkOption {
+      type = types.path;
+      default = configFile;
+      defaultText = "generated TOML from programs.polylogued.settings";
+      description = "Path to polylogue.toml. Generated from settings by default.";
+    };
+
+    autoStart = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Whether to start the polylogued user systemd unit at login (WantedBy default.target).";
+    };
+
+    settings = {
+      archive = {
+        root = mkOption {
+          type = types.nullOr types.str;
+          default = null;
+          description = "Archive root directory (default: $XDG_DATA_HOME/polylogue).";
+        };
+      };
+
+      daemon = {
+        host = mkOption {
+          type = types.nullOr types.str;
+          default = null;
+          description = "Daemon listen host (default: 127.0.0.1).";
+        };
+        port = mkOption {
+          type = types.nullOr types.port;
+          default = null;
+          description = "Daemon listen port (default: 8766).";
+        };
+        watch = mkOption {
+          type = types.nullOr (types.listOf types.str);
+          default = null;
+          description = "Additional watch roots for live ingestion.";
+        };
+      };
+
+      daemon-api = {
+        host = mkOption {
+          type = types.nullOr types.str;
+          default = null;
+          description = "API listen host.";
+        };
+        port = mkOption {
+          type = types.nullOr types.port;
+          default = null;
+          description = "API listen port.";
+        };
+        auth-token = mkOption {
+          type = types.nullOr types.str;
+          default = null;
+          description = "API Bearer auth token.";
+        };
+      };
+
+      browser-capture = {
+        port = mkOption {
+          type = types.nullOr types.port;
+          default = null;
+          description = "Browser capture receiver port.";
+        };
+        allowed-origins = mkOption {
+          type = types.nullOr types.str;
+          default = null;
+          description = "Comma-separated allowed CORS origins.";
+        };
+      };
+
+      embedding = {
+        enabled = mkOption {
+          type = types.nullOr types.bool;
+          default = null;
+          description = "Enable post-ingest embedding generation.";
+        };
+        model = mkOption {
+          type = types.nullOr types.str;
+          default = null;
+          description = "Voyage AI model name.";
+        };
+        dimension = mkOption {
+          type = types.nullOr types.ints.unsigned;
+          default = null;
+          description = "Embedding dimension (default: 1024).";
+        };
+        max-cost-usd = mkOption {
+          type = types.nullOr types.number;
+          default = null;
+          description = "Maximum USD cost for embeddings (0 = unlimited).";
+        };
+      };
+
+      logging = {
+        level = mkOption {
+          type = types.nullOr (types.enum [ "DEBUG" "INFO" "WARNING" "ERROR" ]);
+          default = null;
+          description = "Log level.";
+        };
+        force-plain = mkOption {
+          type = types.nullOr types.bool;
+          default = null;
+          description = "Force plain (non-rich) output.";
+        };
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    systemd.user.services.polylogued = {
+      Unit = {
+        Description = "Polylogue daemon (live watcher, browser capture, HTTP API)";
+        After = [ "network.target" ];
+      };
+      Service = {
+        Type = "simple";
+        ExecStart = "${cfg.package}/bin/polylogued run";
+        Restart = "on-failure";
+        RestartSec = "5s";
+        Environment = "POLYLOGUE_CONFIG=${cfg.configPath}";
+      };
+      Install = lib.mkIf cfg.autoStart {
+        WantedBy = [ "default.target" ];
+      };
+    };
+  };
+}


### PR DESCRIPTION
## Summary

Expose polylogue as a fully external-consumable Nix flake: `nix run
github:Sinity/polylogue#<app>` works without a checkout, a Home Manager
module wires the user-mode daemon, the polylogue cachix cache is
populated on every master push and tag, and the flake is published to
FlakeHub on tag push.

Closes #1235. Ref #953.

## Problem

The existing flake builds the `polylogue` package and exposes a
devshell, and `nix/module.nix` declares a NixOS module. But none of the
external-consumer paths actually worked:

- `nix run github:Sinity/polylogue#polylogued` failed: the flake did
  not declare any `apps.<system>.*` outputs, only `packages`. `nix run`
  fell back to the default package's `meta.mainProgram`, so the
  alternate entrypoints (`polylogued`, `polylogue-mcp`) were not
  addressable by name.
- No Home Manager module existed, so non-NixOS users on home-manager
  could not declaratively enable a per-user `polylogued` unit.
- Every fresh consumer rebuilt the dependency closure from source; no
  binary cache was published.
- The flake was undiscoverable outside niche Nix circles.

## Solution

- `flake.nix`: add
  `apps.x86_64-linux.{polylogue,polylogued,polylogue-mcp,default}`
  pointing at the wrapped entrypoints under
  `polylogue/bin/`. Expose `homeManagerModules.{default,polylogue}`
  alongside the existing `nixosModules.{default,polylogue}`.
- `nix/hm-module.nix` (new): Home Manager module that mirrors
  `nix/module.nix` settings shape (archive, daemon, daemon-api,
  browser-capture, embedding, logging) and wires
  `systemd.user.services.polylogued`. `programs.polylogued.autoStart`
  defaults to `true` (WantedBy=default.target); set `false` to keep
  the unit available but not started at login.
- `.github/workflows/cachix.yml` (new): on master pushes and `vX.Y.Z`
  tags, build `polylogue`, `api-python`, and the devshell closure and
  push them to the `polylogue` cachix cache. Requires
  `CACHIX_AUTH_TOKEN` repository secret.
- `.github/workflows/flakehub.yml` (new): publish the flake to
  FlakeHub on `vX.Y.Z` tag push, with a `workflow_dispatch` path for
  rolling pre-releases. Uses OIDC (`id-token: write`); no FlakeHub
  secret required.
- `docs/installation.md`: new "Nix flake" section documenting one-shot
  `nix run`, the cachix cache enable command, external flake input
  pattern (both `github:` and FlakeHub URLs), NixOS module wiring, Home
  Manager module wiring, and local `nix build` targets.
- `docs/plans/distribution-coverage.yaml`: `nix_package` notes updated
  to describe the new apps, modules, cachix workflow, and flakehub
  workflow.

Non-goal: this PR does not introduce a NixOS VM test for the module —
that belongs in a follow-up under #1235's "Verification" section once
the cachix cache is producing artifacts, so the VM test does not have
to rebuild the full closure on every run.

## Verification

```
$ devtools verify --quick
...
  "total_duration_s": 40.84,
  "exit_code": 0
```

Manual smoke (post-merge, against the published flake): `nix run
github:Sinity/polylogue/master -- --version`, `nix run
github:Sinity/polylogue/master#polylogued -- --help`, `nix run
github:Sinity/polylogue/master#polylogue-mcp -- --help`. The cachix
cache hit on a fresh `nix build` will be visible via `nix path-info
--json` once the first cachix workflow run finishes after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)