### PR TITLE
refactor(storage): drop unused indexes, columns, tag dead paths, FK drift (#1240)

### DIFF
--- a/docs/plans/schema-inventory.md
+++ b/docs/plans/schema-inventory.md
@@ -126,8 +126,7 @@ The `messages` table intentionally does NOT have a `provider_meta` column. Messa
 | `text` | Block text content. |
 | `tool_name`, `tool_id` | Tool identity for tool_use blocks. |
 | `tool_input` | Tool input as JSON string. |
-| `media_type` | MIME type for media blocks. |
-| `metadata` | Extracted metadata as JSON string. |
+| `metadata` | Extracted metadata as JSON string (carries `media_type` for image/document blocks since #1240). |
 | `semantic_type` | Semantic classification enum. |
 
 All fields are canonical and properly modeled. No provider_meta column — this table is clean.

--- a/polylogue/archive/conversation/models.py
+++ b/polylogue/archive/conversation/models.py
@@ -28,6 +28,10 @@ class ConversationSummary(ConversationSummaryRuntimeMixin, BaseModel):
     branch_type: BranchType | None = None
     message_count: int | None = None
     dialogue_count: int | None = None
+    # #1240: tags are sourced from the M2M conversation_tags table when
+    # hydrated through the repository. Empty by default so that legacy
+    # constructors keep working.
+    tags_m2m: tuple[str, ...] = ()
 
     @field_validator("provider", mode="before")
     @classmethod
@@ -51,6 +55,8 @@ class Conversation(ConversationRuntimeMixin, BaseModel):
     provider_events: tuple[ProviderEvent, ...] = ()
     parent_id: ConversationId | None = None
     branch_type: BranchType | None = None
+    # #1240: tags hydrated from conversation_tags M2M; see ConversationSummary.
+    tags_m2m: tuple[str, ...] = ()
 
     @field_validator("provider", mode="before")
     @classmethod

--- a/polylogue/archive/conversation/runtime.py
+++ b/polylogue/archive/conversation/runtime.py
@@ -94,6 +94,10 @@ class ConversationRuntimeMixin:
 
     @property
     def tags(self) -> list[str]:
+        # #1240: M2M-sourced tags are authoritative once hydrated.
+        m2m = getattr(self, "tags_m2m", None)
+        if m2m:
+            return list(m2m)
         return _metadata_tags(self.metadata)
 
     def filter(self, predicate: Callable[[Message], bool]) -> Self:

--- a/polylogue/archive/conversation/summary_runtime.py
+++ b/polylogue/archive/conversation/summary_runtime.py
@@ -58,6 +58,10 @@ class ConversationSummaryRuntimeMixin:
 
     @property
     def tags(self) -> list[str]:
+        # #1240: prefer M2M-hydrated tags when available.
+        m2m = getattr(self, "tags_m2m", None)
+        if m2m:
+            return list(m2m)
         return _metadata_tags(self.metadata)
 
     @property

--- a/polylogue/core/common.py
+++ b/polylogue/core/common.py
@@ -103,15 +103,14 @@ _CONTENT_BLOCK_UPSERT_SQL = """
 INSERT INTO content_blocks (
     block_id, message_id, conversation_id, block_index,
     type, text, tool_name, tool_id, tool_input,
-    media_type, metadata, semantic_type
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    metadata, semantic_type
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT(message_id, block_index) DO UPDATE SET
     type = excluded.type,
     text = excluded.text,
     tool_name = excluded.tool_name,
     tool_id = excluded.tool_id,
     tool_input = excluded.tool_input,
-    media_type = excluded.media_type,
     metadata = excluded.metadata,
     semantic_type = excluded.semantic_type
 """

--- a/polylogue/pipeline/materialization_runtime.py
+++ b/polylogue/pipeline/materialization_runtime.py
@@ -52,7 +52,6 @@ class MaterializedContentBlock:
     tool_name: str | None
     tool_id: str | None
     tool_input_json: str | None
-    media_type: str | None
     metadata_json: str | None
     semantic_type: SemanticBlockType | None
 
@@ -253,6 +252,14 @@ def _materialize_content_block(
         if detected_lang:
             semantic_metadata = {"language": detected_lang}
 
+    # #1240: media_type is no longer a dedicated column; preserve it under
+    # the existing block-metadata JSON for image/document blocks so the
+    # render/hash roundtrip stays lossless.
+    if block.media_type:
+        base = dict(semantic_metadata) if semantic_metadata else {}
+        base.setdefault("media_type", block.media_type)
+        semantic_metadata = base
+
     metadata_json = json_dumps(semantic_metadata) if semantic_metadata is not None else None
 
     from polylogue.storage.runtime import ContentBlockRecord
@@ -265,7 +272,6 @@ def _materialize_content_block(
         tool_name=block.tool_name,
         tool_id=block.tool_id,
         tool_input_json=tool_input_json,
-        media_type=block.media_type,
         metadata_json=metadata_json,
         semantic_type=semantic_type,
     )

--- a/polylogue/pipeline/prepare_enrichment.py
+++ b/polylogue/pipeline/prepare_enrichment.py
@@ -150,7 +150,6 @@ def enrich_bundle_from_db(
             tool_name=block.tool_name,
             tool_id=block.tool_id,
             tool_input=block.tool_input,
-            media_type=block.media_type,
             metadata=block.metadata,
             semantic_type=block.semantic_type,
         )

--- a/polylogue/pipeline/prepare_transform.py
+++ b/polylogue/pipeline/prepare_transform.py
@@ -97,7 +97,6 @@ def transform_to_records(convo: ParsedConversation, source_name: str, *, archive
                     tool_name=block.tool_name,
                     tool_id=block.tool_id,
                     tool_input=block.tool_input_json,
-                    media_type=block.media_type,
                     metadata=block.metadata_json,
                     semantic_type=block.semantic_type,
                 )

--- a/polylogue/pipeline/services/ingest_worker.py
+++ b/polylogue/pipeline/services/ingest_worker.py
@@ -126,7 +126,6 @@ ContentBlockTuple = tuple[
     str | None,
     str | None,
     str | None,
-    str | None,
     SemanticBlockType | str | None,
 ]
 ActionEventTuple = tuple[
@@ -867,7 +866,6 @@ def _content_block_tuple(
         block.tool_name,
         block.tool_id,
         block.tool_input_json,
-        block.media_type,
         block.metadata_json,
         block.semantic_type,
     )
@@ -1098,7 +1096,6 @@ def _content_block_mapping_for_action_event(
         "tool_name": block.tool_name,
         "tool_id": block.tool_id,
         "tool_input": block.tool_input_json,
-        "media_type": block.media_type,
         "metadata": block.metadata_json,
         "semantic_type": block.semantic_type,
     }

--- a/polylogue/rendering/block_models.py
+++ b/polylogue/rendering/block_models.py
@@ -85,13 +85,15 @@ def _coerce_mapping_block(block: Mapping[str, object]) -> RenderableBlock:
 
 def _coerce_record_block(block: ContentBlockRecord) -> RenderableBlock:
     metadata = _json_mapping(block.metadata)
+    # #1240: media_type lives inside the block-metadata JSON envelope.
+    mime_type = _optional_string(metadata.get("media_type")) if metadata is not None else None
     return RenderableBlock(
         type=block.type.value,
         text=block.text,
         language=_optional_string(metadata.get("language")) if metadata is not None else None,
         url=_optional_string(metadata.get("url")) if metadata is not None else None,
         name=_optional_string(metadata.get("name")) if metadata is not None else None,
-        mime_type=block.media_type,
+        mime_type=mime_type,
         tool_name=block.tool_name,
         tool_id=block.tool_id,
         tool_input=_json_mapping(block.tool_input),

--- a/polylogue/storage/action_events/rows.py
+++ b/polylogue/storage/action_events/rows.py
@@ -142,8 +142,6 @@ def _content_block_mapping(block: ContentBlockRecord) -> dict[str, object]:
         payload["tool_id"] = block.tool_id
     if block.tool_input is not None:
         payload["tool_input"] = block.tool_input
-    if block.media_type is not None:
-        payload["media_type"] = block.media_type
     if block.metadata is not None:
         payload["metadata"] = block.metadata
     if block.semantic_type is not None:

--- a/polylogue/storage/hydrators.py
+++ b/polylogue/storage/hydrators.py
@@ -78,19 +78,26 @@ def message_from_record(
             ts = None
 
     # Domain messages expose semantic content blocks, not storage row identity.
-    blocks = [
-        {
-            "type": str(b.type),
-            "text": b.text,
-            "tool_name": b.tool_name,
-            "tool_id": b.tool_id,
-            "tool_input": _parse_json_blob(b.tool_input),
-            "media_type": b.media_type,
-            "metadata": _parse_json_blob(b.metadata),
-            "semantic_type": str(b.semantic_type) if b.semantic_type is not None else None,
-        }
-        for b in record.content_blocks
-    ]
+    # #1240: media_type is stored inside the block-metadata JSON (image/document
+    # blocks). Lift it back to the top-level for callers that still expect it.
+    blocks = []
+    for b in record.content_blocks:
+        block_metadata = _parse_json_blob(b.metadata)
+        media_type: object = None
+        if isinstance(block_metadata, dict):
+            media_type = block_metadata.get("media_type")
+        blocks.append(
+            {
+                "type": str(b.type),
+                "text": b.text,
+                "tool_name": b.tool_name,
+                "tool_id": b.tool_id,
+                "tool_input": _parse_json_blob(b.tool_input),
+                "media_type": media_type,
+                "metadata": block_metadata,
+                "semantic_type": str(b.semantic_type) if b.semantic_type is not None else None,
+            }
+        )
 
     normalized_provider = None
     if provider is not None:
@@ -130,7 +137,11 @@ def provider_event_from_record(record: ProviderEventRecord) -> ProviderEvent:
     )
 
 
-def conversation_summary_from_record(record: ConversationRecord) -> ConversationSummary:
+def conversation_summary_from_record(
+    record: ConversationRecord,
+    *,
+    tags: tuple[str, ...] = (),
+) -> ConversationSummary:
     """Hydrate a ConversationSummary domain model from a ConversationRecord."""
     return ConversationSummary(
         id=record.conversation_id,
@@ -142,6 +153,7 @@ def conversation_summary_from_record(record: ConversationRecord) -> Conversation
         metadata=record.metadata or {},
         parent_id=record.parent_conversation_id,
         branch_type=record.branch_type,
+        tags_m2m=tags,
     )
 
 
@@ -150,6 +162,8 @@ def conversation_from_records(
     messages: list[MessageRecord],
     attachments: list[AttachmentRecord],
     provider_events: list[ProviderEventRecord] | None = None,
+    *,
+    tags: tuple[str, ...] = (),
 ) -> Conversation:
     """Hydrate a Conversation domain model from records.
 
@@ -191,6 +205,7 @@ def conversation_from_records(
         provider_events=tuple(provider_event_from_record(event) for event in (provider_events or [])),
         parent_id=conversation.parent_conversation_id,
         branch_type=conversation.branch_type,
+        tags_m2m=tags,
     )
 
 

--- a/polylogue/storage/repository/archive/conversations.py
+++ b/polylogue/storage/repository/archive/conversations.py
@@ -30,6 +30,31 @@ class RepositoryArchiveConversationMixin:
         _backend: RepositoryBackendProtocol
         queries: SQLiteQueryStore
 
+    async def _fetch_tags_by_conversation(self, conversation_ids: list[str]) -> dict[str, tuple[str, ...]]:
+        """#1240: batch-fetch M2M tags for hydration of Conversation/ConversationSummary."""
+        if not conversation_ids:
+            return {}
+        result: dict[str, list[str]] = {cid: [] for cid in conversation_ids}
+        async with self._backend.connection() as conn:
+            placeholders = ",".join("?" for _ in conversation_ids)
+            cursor = await conn.execute(
+                f"""
+                SELECT ct.conversation_id AS cid, t.name AS name
+                FROM conversation_tags ct
+                JOIN tags t ON t.id = ct.tag_id
+                WHERE ct.conversation_id IN ({placeholders})
+                ORDER BY t.name
+                """,
+                conversation_ids,
+            )
+            rows = await cursor.fetchall()
+            for row in rows:
+                cid = row["cid"]
+                name = row["name"]
+                if cid in result:
+                    result[cid].append(name)
+        return {cid: tuple(names) for cid, names in result.items()}
+
     async def resolve_id(self, id_prefix: str, *, strict: bool = False) -> ConversationId | None:
         resolved = await self.queries.resolve_id(id_prefix, strict=strict)
         from polylogue.types import ConversationId
@@ -46,7 +71,14 @@ class RepositoryArchiveConversationMixin:
             self.queries.get_attachments(conversation_id),
             self.queries.get_provider_events(conversation_id),
         )
-        return conversation_from_records(conv_record, msg_records, att_records, provider_event_records)
+        tags_by_id = await self._fetch_tags_by_conversation([conversation_id])
+        return conversation_from_records(
+            conv_record,
+            msg_records,
+            att_records,
+            provider_event_records,
+            tags=tags_by_id.get(conversation_id, ()),
+        )
 
     async def get_render_projection(self, conversation_id: str) -> ConversationRenderProjection | None:
         conv_record = await self.queries.get_conversation(conversation_id)
@@ -139,12 +171,14 @@ class RepositoryArchiveConversationMixin:
                 self.queries.get_attachments_batch(present_ids),
                 self.queries.get_provider_events_batch(present_ids),
             )
+        tags_by_id = await self._fetch_tags_by_conversation(present_ids)
         return [
             conversation_from_records(
                 by_id[conversation_id],
                 msgs_by_id.get(conversation_id, []),
                 atts_by_id.get(conversation_id, []),
                 provider_events_by_id.get(conversation_id, []),
+                tags=tags_by_id.get(conversation_id, ()),
             )
             for conversation_id in present_ids
         ]
@@ -153,14 +187,20 @@ class RepositoryArchiveConversationMixin:
         conv_record = await self.queries.get_conversation(conversation_id)
         if not conv_record:
             return None
-        return conversation_summary_from_record(conv_record)
+        tags_by_id = await self._fetch_tags_by_conversation([conversation_id])
+        return conversation_summary_from_record(conv_record, tags=tags_by_id.get(conversation_id, ()))
 
     async def list_summaries_by_query(
         self,
         query: ConversationRecordQuery,
     ) -> list[ConversationSummary]:
         conv_records = await self.queries.list_conversation_summaries(query)
-        return [conversation_summary_from_record(record) for record in conv_records]
+        ids = [str(record.conversation_id) for record in conv_records]
+        tags_by_id = await self._fetch_tags_by_conversation(ids)
+        return [
+            conversation_summary_from_record(record, tags=tags_by_id.get(str(record.conversation_id), ()))
+            for record in conv_records
+        ]
 
     async def list_by_query(
         self,

--- a/polylogue/storage/repository/archive/repository_writes.py
+++ b/polylogue/storage/repository/archive/repository_writes.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING
 
 from polylogue.archive.conversation.models import Conversation
 from polylogue.core.json import JSONDocument, JSONValue
-from polylogue.core.payload_coercion import string_sequence
 from polylogue.insights.feedback import LearningCorrection
 from polylogue.storage.repository.archive.writes.conversations import (
     conversation_to_record,
@@ -137,24 +136,27 @@ class RepositoryWriteMixin:
         return await self._metadata_read_modify_write(conversation_id, _delete)
 
     async def add_tag(self, conversation_id: str, tag: str) -> bool:
+        # #1240: tags are stored only in the M2M tables (tags + conversation_tags).
+        # The previous dual-write into ``conversations.metadata['tags']`` was
+        # legacy bookkeeping for the JSON read-fallback that has been removed.
         if not tag or not tag.strip():
             raise ValueError("tag must be a non-empty string")
         if len(tag) > 200:
             raise ValueError("tag must be at most 200 characters")
 
-        def _add(meta: JSONDocument) -> bool:
-            tags = list(string_sequence(meta.get("tags")))
-            if tag not in tags:
-                tags.append(tag)
-                tag_payload: list[JSONValue] = list(tags)
-                meta["tags"] = tag_payload
-                return True
-            return False
+        async with self._backend.connection() as conn:
+            cursor = await conn.execute(
+                """
+                SELECT 1 FROM conversation_tags ct
+                JOIN tags t ON t.id = ct.tag_id
+                WHERE ct.conversation_id = ? AND t.name = ?
+                """,
+                (conversation_id, tag),
+            )
+            already_present = await cursor.fetchone() is not None
 
-        was_added = await self._metadata_read_modify_write(conversation_id, _add)
-        # Also write to normalized tables for M2M query support
         await self._upsert_normalized_tag(conversation_id, tag)
-        return was_added
+        return not already_present
 
     async def bulk_add_tags(self, conversation_ids: list[str], tags: list[str]) -> int:
         """Add tags to multiple conversations within a single transaction.
@@ -164,7 +166,7 @@ class RepositoryWriteMixin:
             tags: List of tag strings to apply to each conversation.
 
         Returns:
-            Number of conversations whose tags were actually changed.
+            Number of conversations whose tag set was actually changed.
         """
         backend = self._backend
         applied_count = 0
@@ -176,49 +178,37 @@ class RepositoryWriteMixin:
                 )
                 if not await exists.fetchone():
                     continue
-                current = await conversations_q.get_metadata(conn, conversation_id)
-                meta: JSONDocument = dict(current) if current else {}
-                existing_tags = list(string_sequence(meta.get("tags")))
                 changed = False
                 for tag in tags:
-                    if tag not in existing_tags:
-                        existing_tags.append(tag)
+                    await conn.execute("INSERT OR IGNORE INTO tags (name) VALUES (?)", (tag,))
+                    cursor = await conn.execute("SELECT id FROM tags WHERE name = ?", (tag,))
+                    row = await cursor.fetchone()
+                    if row is None:
+                        continue
+                    insert_result = await conn.execute(
+                        "INSERT OR IGNORE INTO conversation_tags (conversation_id, tag_id) VALUES (?, ?)",
+                        (conversation_id, row["id"]),
+                    )
+                    if insert_result.rowcount > 0:
                         changed = True
                 if changed:
-                    tag_payload: list[JSONValue] = list(existing_tags)
-                    meta["tags"] = tag_payload
-                    await conversations_q.update_metadata_raw(
-                        conn,
-                        conversation_id,
-                        meta,
-                    )
-                    # Also write to normalized tables
-                    for tag in tags:
-                        await conn.execute("INSERT OR IGNORE INTO tags (name) VALUES (?)", (tag,))
-                        cursor = await conn.execute("SELECT id FROM tags WHERE name = ?", (tag,))
-                        row = await cursor.fetchone()
-                        if row is not None:
-                            await conn.execute(
-                                "INSERT OR IGNORE INTO conversation_tags (conversation_id, tag_id) VALUES (?, ?)",
-                                (conversation_id, row["id"]),
-                            )
                     applied_count += 1
         return applied_count
 
     async def remove_tag(self, conversation_id: str, tag: str) -> bool:
-        def _remove(meta: JSONDocument) -> bool:
-            tags = list(string_sequence(meta.get("tags")))
-            if tag in tags:
-                tags.remove(tag)
-                tag_payload: list[JSONValue] = list(tags)
-                meta["tags"] = tag_payload
-                return True
-            return False
+        async with self._backend.connection() as conn:
+            cursor = await conn.execute(
+                """
+                SELECT 1 FROM conversation_tags ct
+                JOIN tags t ON t.id = ct.tag_id
+                WHERE ct.conversation_id = ? AND t.name = ?
+                """,
+                (conversation_id, tag),
+            )
+            had_link = await cursor.fetchone() is not None
 
-        was_removed = await self._metadata_read_modify_write(conversation_id, _remove)
-        # Also remove from normalized tables
         await self._delete_normalized_tag(conversation_id, tag)
-        return was_removed
+        return had_link
 
     async def list_tags(self, *, provider: str | None = None) -> dict[str, int]:
         async with self._backend.connection() as conn:

--- a/polylogue/storage/repository/archive/writes/conversations.py
+++ b/polylogue/storage/repository/archive/writes/conversations.py
@@ -212,8 +212,18 @@ def _content_block_record_to_hash_payload(block: ContentBlockRecord) -> dict[str
                 payload["tool_input"] = hash_payload(block.tool_input)
         except Exception:
             payload["tool_input"] = hash_payload(block.tool_input)
-    if block.media_type:
-        payload["media_type"] = _normalize_for_hash(block.media_type)
+    # #1240: media_type is carried inside block.metadata (JSON) for image/document
+    # blocks instead of a dedicated column. Re-extract it so the row-graph hash
+    # matches the parser-side hash computed in pipeline/ids.py.
+    if block.metadata:
+        try:
+            parsed_meta = loads(block.metadata)
+        except Exception:
+            parsed_meta = None
+        if isinstance(parsed_meta, dict):
+            media_type = parsed_meta.get("media_type")
+            if isinstance(media_type, str) and media_type:
+                payload["media_type"] = _normalize_for_hash(media_type)
     return payload
 
 

--- a/polylogue/storage/runtime/archive/records.py
+++ b/polylogue/storage/runtime/archive/records.py
@@ -83,7 +83,6 @@ class ContentBlockRecord(BaseModel):
     tool_name: str | None = None
     tool_id: str | None = None
     tool_input: str | None = None
-    media_type: str | None = None
     metadata: str | None = None
     semantic_type: SemanticBlockType | None = None
 

--- a/polylogue/storage/sqlite/queries/attachment_content_blocks.py
+++ b/polylogue/storage/sqlite/queries/attachment_content_blocks.py
@@ -55,7 +55,6 @@ async def save_content_blocks(
                 record.tool_name,
                 record.tool_id,
                 record.tool_input,
-                record.media_type,
                 record.metadata,
                 record.semantic_type,
             )

--- a/polylogue/storage/sqlite/queries/conversations_identity.py
+++ b/polylogue/storage/sqlite/queries/conversations_identity.py
@@ -150,27 +150,8 @@ async def list_tags(conn: aiosqlite.Connection, *, provider: str | None = None) 
         params,
     )
     rows = list(await cursor.fetchall())
-    if rows:
-        return {row["tag_name"]: row["cnt"] for row in rows}
-
-    # Fallback: read from JSON metadata for archives that haven't been migrated yet
-    json_where = "WHERE metadata IS NOT NULL AND json_extract(metadata, '$.tags') IS NOT NULL"
-    json_params: tuple[str, ...] = ()
-    if provider:
-        json_where += " AND provider_name = ?"
-        json_params = (provider,)
-    cursor = await conn.execute(
-        f"""
-        SELECT tag.value AS tag_name, COUNT(*) AS cnt
-        FROM conversations,
-             json_each(json_extract(metadata, '$.tags')) AS tag
-        {json_where}
-        GROUP BY tag.value
-        ORDER BY cnt DESC
-        """,
-        json_params,
-    )
-    rows = list(await cursor.fetchall())
+    # #1240: M2M (tags + conversation_tags) is the canonical read surface;
+    # the legacy JSON metadata fallback was removed with SCHEMA_VERSION 3.
     return {row["tag_name"]: row["cnt"] for row in rows}
 
 

--- a/polylogue/storage/sqlite/queries/mappers_archive.py
+++ b/polylogue/storage/sqlite/queries/mappers_archive.py
@@ -106,7 +106,6 @@ def _row_to_content_block(row: sqlite3.Row) -> ContentBlockRecord:
         tool_name=_row_text(row, "tool_name"),
         tool_id=_row_text(row, "tool_id"),
         tool_input=_row_text(row, "tool_input"),
-        media_type=_row_text(row, "media_type"),
         metadata=_row_text(row, "metadata"),
         semantic_type=SemanticBlockType.from_string(semantic_type) if semantic_type is not None else None,
     )

--- a/polylogue/storage/sqlite/schema_ddl.py
+++ b/polylogue/storage/sqlite/schema_ddl.py
@@ -66,7 +66,7 @@ from polylogue.storage.sqlite.schema_ddl_provider_events import (
     PROVIDER_EVENT_DDL as _PROVIDER_EVENT_DDL,
 )
 
-SCHEMA_VERSION = 2  # Canonical schema. No migration chain: mismatch → re-ingest from source (#1212, #1190).
+SCHEMA_VERSION = 3  # Canonical schema. No migration chain: mismatch → re-ingest from source (#1212, #1190, #1240).
 
 
 # Complete target schema applied to fresh databases.

--- a/polylogue/storage/sqlite/schema_ddl_archive.py
+++ b/polylogue/storage/sqlite/schema_ddl_archive.py
@@ -140,7 +140,6 @@ ARCHIVE_STORAGE_DDL = """
             tool_name TEXT,
             tool_id TEXT,
             tool_input TEXT,
-            media_type TEXT,
             metadata TEXT,
             semantic_type TEXT,
             UNIQUE (message_id, block_index)
@@ -161,12 +160,6 @@ ARCHIVE_STORAGE_DDL = """
         CREATE INDEX IF NOT EXISTS idx_content_blocks_tool_use_conversation
         ON content_blocks(conversation_id)
         WHERE type = 'tool_use';
-
-        CREATE INDEX IF NOT EXISTS idx_content_blocks_semantic_type
-        ON content_blocks(semantic_type);
-
-        CREATE INDEX IF NOT EXISTS idx_content_blocks_conv_semantic
-        ON content_blocks(conversation_id, semantic_type);
 
         CREATE TABLE IF NOT EXISTS conversation_stats (
             conversation_id TEXT PRIMARY KEY
@@ -233,24 +226,6 @@ ARCHIVE_STORAGE_DDL = """
         CREATE INDEX IF NOT EXISTS idx_attachment_refs_message
         ON attachment_refs(message_id)
         WHERE message_id IS NOT NULL;
-
-        CREATE INDEX IF NOT EXISTS idx_attachments_provider_attachment_id
-        ON attachments(provider_attachment_id);
-
-        CREATE INDEX IF NOT EXISTS idx_attachments_provider_file_id
-        ON attachments(provider_file_id);
-
-        CREATE INDEX IF NOT EXISTS idx_attachments_provider_drive_id
-        ON attachments(provider_drive_id);
-
-        CREATE INDEX IF NOT EXISTS idx_attachment_refs_provider_attachment_id
-        ON attachment_refs(provider_attachment_id);
-
-        CREATE INDEX IF NOT EXISTS idx_attachment_refs_provider_file_id
-        ON attachment_refs(provider_file_id);
-
-        CREATE INDEX IF NOT EXISTS idx_attachment_refs_provider_drive_id
-        ON attachment_refs(provider_drive_id);
 
 """
 

--- a/tests/infra/state_machines.py
+++ b/tests/infra/state_machines.py
@@ -66,7 +66,8 @@ class RepositoryLifecycleHarness:
         return metadata
 
     async def assert_tags(self, expected: dict[str, int], *, provider: str | None = None) -> None:
-        assert await self.repository.list_tags(provider=provider) == expected
+        actual = await self.repository.list_tags(provider=provider)
+        assert actual == expected, f"expected={expected!r} actual={actual!r}"
 
     async def add_tag_and_assert_visible(self, scenario: ArchiveScenario, tag: str) -> None:
         await self.repository.add_tag(scenario.resolved_conversation_id, tag)

--- a/tests/infra/storage_records.py
+++ b/tests/infra/storage_records.py
@@ -13,7 +13,7 @@ from uuid import uuid4
 
 from polylogue.archive.conversation.branch_type import BranchType
 from polylogue.archive.message.roles import Role
-from polylogue.core.json import dumps, require_json_document, require_json_value
+from polylogue.core.json import dumps, loads, require_json_document, require_json_value
 from polylogue.pipeline.prepare import _timestamp_sort_key
 from polylogue.storage.runtime import (
     AttachmentRecord,
@@ -146,6 +146,22 @@ def _coerce_builder_timestamp(value: object) -> str | None | _AutoTimestampSenti
     return _AUTO_TIMESTAMP
 
 
+def _merge_media_type_into_metadata(metadata: str | None, media_type: str | None) -> str | None:
+    """#1240: store media_type inside the block-metadata JSON envelope."""
+    if not media_type:
+        return metadata
+    base: dict[str, object] = {}
+    if metadata:
+        try:
+            parsed = loads(metadata)
+        except Exception:
+            return metadata
+        if isinstance(parsed, dict):
+            base.update(parsed)
+    base.setdefault("media_type", media_type)
+    return dumps(base)
+
+
 def _content_block_record(
     *,
     message_id: str,
@@ -160,6 +176,8 @@ def _content_block_record(
     metadata: str | None = None,
     semantic_type: str | None = None,
 ) -> ContentBlockRecord:
+    # #1240: media_type is now stored inside the block-metadata JSON.
+    merged_metadata = _merge_media_type_into_metadata(metadata, media_type)
     return ContentBlockRecord(
         block_id=ContentBlockRecord.make_id(message_id, block_index),
         message_id=_message_id(message_id),
@@ -170,8 +188,7 @@ def _content_block_record(
         tool_name=tool_name,
         tool_id=tool_id,
         tool_input=tool_input,
-        media_type=media_type,
-        metadata=metadata,
+        metadata=merged_metadata,
         semantic_type=None if semantic_type is None else SemanticBlockType.from_string(semantic_type),
     )
 
@@ -464,8 +481,8 @@ def upsert_message(conn: sqlite3.Connection, record: MessageRecord) -> bool:
             """
             INSERT INTO content_blocks (
                 block_id, message_id, conversation_id, block_index,
-                type, text, tool_name, tool_id, tool_input, media_type, metadata, semantic_type
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                type, text, tool_name, tool_id, tool_input, metadata, semantic_type
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(message_id, block_index) DO UPDATE SET
                 type = excluded.type,
                 text = excluded.text,
@@ -484,7 +501,6 @@ def upsert_message(conn: sqlite3.Connection, record: MessageRecord) -> bool:
                 blk.tool_name,
                 blk.tool_id,
                 blk.tool_input,
-                blk.media_type,
                 blk.metadata,
                 blk.semantic_type,
             ),

--- a/tests/unit/pipeline/test_ingest_batch.py
+++ b/tests/unit/pipeline/test_ingest_batch.py
@@ -206,7 +206,6 @@ def _block_tuple(
         None,
         None,
         None,
-        None,
     )
 
 

--- a/tests/unit/sources/test_parsers_chatgpt.py
+++ b/tests/unit/sources/test_parsers_chatgpt.py
@@ -529,7 +529,6 @@ def test_chatgpt_metadata_roundtrip_parser_to_hydration(tmp_path: Path) -> None:
             tool_name=b.tool_name,
             tool_id=b.tool_id,
             tool_input=b.tool_input_json,
-            media_type=b.media_type,
             metadata=b.metadata_json,
             semantic_type=b.semantic_type,
         )
@@ -770,7 +769,6 @@ def test_chatgpt_metadata_permutation_roundtrip(
             tool_name=b.tool_name,
             tool_id=b.tool_id,
             tool_input=b.tool_input_json,
-            media_type=b.media_type,
             metadata=b.metadata_json,
             semantic_type=b.semantic_type,
         )

--- a/tests/unit/storage/test_dead_schema_sweep.py
+++ b/tests/unit/storage/test_dead_schema_sweep.py
@@ -1,0 +1,174 @@
+"""Contracts pinned by #1240 — the dead-schema sweep.
+
+These tests fail loudly if any of the dropped artifacts return:
+
+- the ``content_blocks.media_type`` column
+- the unused JSON-extract indexes on attachments/attachment_refs
+- the unused semantic_type indexes on content_blocks
+- the legacy JSON tag read fallback
+- the legacy JSON tag dual-write on ``add_tag``
+
+Plus a round-trip law: ``media_type`` survives ingest → store → render via
+the block-metadata JSON envelope.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import tempfile
+from collections.abc import Generator, Mapping
+from pathlib import Path
+
+import pytest
+
+from polylogue.storage.runtime.archive.records import ContentBlockRecord
+from polylogue.storage.sqlite.schema_ddl import SCHEMA_DDL, SCHEMA_VERSION
+
+
+@pytest.fixture()
+def fresh_schema_db() -> Generator[Mapping[str, sqlite3.Connection], None, None]:
+    """Yield a fresh in-memory archive schema for shape introspection."""
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.executescript(SCHEMA_DDL)
+    try:
+        yield {"conn": conn}
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Schema-shape pins
+# ---------------------------------------------------------------------------
+
+
+def test_schema_version_is_3() -> None:
+    assert SCHEMA_VERSION == 3
+
+
+def test_content_blocks_table_has_no_media_type_column(fresh_schema_db: Mapping[str, sqlite3.Connection]) -> None:
+    conn = fresh_schema_db["conn"]
+    cols = {row["name"] for row in conn.execute("PRAGMA table_info(content_blocks)").fetchall()}
+    assert "media_type" not in cols, (
+        f"#1240: content_blocks.media_type was dropped (1 row out of 2.5M in production), "
+        f"current columns: {sorted(cols)}"
+    )
+    # Sanity: metadata + semantic_type still present.
+    assert {"metadata", "semantic_type"}.issubset(cols)
+
+
+def test_content_block_record_has_no_media_type_field() -> None:
+    assert "media_type" not in ContentBlockRecord.model_fields, (
+        "#1240: ContentBlockRecord.media_type was dropped; "
+        "image/document media_type now lives inside the metadata JSON envelope."
+    )
+
+
+@pytest.mark.parametrize(
+    "dead_index",
+    [
+        "idx_attachments_provider_attachment_id",
+        "idx_attachments_provider_file_id",
+        "idx_attachments_provider_drive_id",
+        "idx_attachment_refs_provider_attachment_id",
+        "idx_attachment_refs_provider_file_id",
+        "idx_attachment_refs_provider_drive_id",
+        "idx_content_blocks_semantic_type",
+        "idx_content_blocks_conv_semantic",
+    ],
+)
+def test_dead_indexes_are_absent(
+    dead_index: str,
+    fresh_schema_db: Mapping[str, sqlite3.Connection],
+) -> None:
+    """#1240: the catalog of indexes the issue called out as unused is gone."""
+    conn = fresh_schema_db["conn"]
+    row = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type = 'index' AND name = ?",
+        (dead_index,),
+    ).fetchone()
+    assert row is None, f"#1240: {dead_index!r} should have been dropped"
+
+
+# ---------------------------------------------------------------------------
+# media_type roundtrip via metadata JSON envelope
+# ---------------------------------------------------------------------------
+
+
+def test_media_type_roundtrips_via_metadata_json() -> None:
+    """media_type for image blocks must survive parse → materialize → hydrate."""
+    from polylogue.archive.message.roles import Role
+    from polylogue.pipeline.materialization_runtime import _materialize_content_block
+    from polylogue.sources.parsers.base_models import ParsedContentBlock
+    from polylogue.storage.hydrators import message_from_record
+    from polylogue.storage.runtime.archive.records import MessageRecord
+    from polylogue.types import ContentBlockType, ContentHash, ConversationId, MessageId
+
+    parsed = ParsedContentBlock(type=ContentBlockType.IMAGE, media_type="image/png")
+    materialized = _materialize_content_block(MessageId("m1"), 0, parsed)
+
+    # MaterializedContentBlock no longer carries media_type as a field.
+    assert not hasattr(materialized, "media_type")
+    # …but the metadata JSON envelope does.
+    assert materialized.metadata_json is not None
+    assert "image/png" in materialized.metadata_json
+
+    # Storage record: build from materialized envelope and verify hydration
+    # places media_type back on the renderable block dict.
+    record = ContentBlockRecord(
+        block_id=materialized.block_id,
+        message_id=MessageId("m1"),
+        conversation_id=ConversationId("c1"),
+        block_index=0,
+        type=ContentBlockType.IMAGE,
+        text=None,
+        metadata=materialized.metadata_json,
+        semantic_type=None,
+    )
+    msg_record = MessageRecord(
+        message_id=MessageId("m1"),
+        conversation_id=ConversationId("c1"),
+        role=Role.USER,
+        text=None,
+        content_hash=ContentHash("0" * 64),
+        version=1,
+        content_blocks=[record],
+    )
+    msg = message_from_record(msg_record, [])
+    block_payloads = list(msg.content_blocks)
+    assert block_payloads, "hydrated message must expose its content blocks"
+    assert block_payloads[0]["media_type"] == "image/png"
+
+
+# ---------------------------------------------------------------------------
+# Tag read/write contracts (also asserted in test_tag_contracts.py).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_list_tags_does_not_consult_json_metadata() -> None:
+    """#1240: list_tags reads M2M only; no fallback to ``metadata.tags``."""
+    from polylogue.storage.repository import ConversationRepository
+    from polylogue.storage.sqlite.async_sqlite import SQLiteBackend
+    from tests.infra.storage_records import ConversationBuilder
+
+    with tempfile.TemporaryDirectory() as tmp:
+        db_path = Path(tmp) / "tags.db"
+        ConversationBuilder(db_path, "c1").provider("test").title("x").add_message("m1", text="hi").save()
+
+        # Inject a JSON-only tag value bypassing M2M.
+        with sqlite3.connect(db_path) as conn:
+            conn.execute(
+                "UPDATE conversations SET metadata = ? WHERE conversation_id = ?",
+                ('{"tags": ["ghost"]}', "c1"),
+            )
+            conn.commit()
+
+        backend = SQLiteBackend(db_path=db_path)
+        repo = ConversationRepository(backend=backend)
+        try:
+            listed = await repo.list_tags()
+            assert "ghost" not in listed
+            assert listed == {}
+        finally:
+            await backend.close()

--- a/tests/unit/storage/test_fts5.py
+++ b/tests/unit/storage/test_fts5.py
@@ -400,8 +400,8 @@ def test_update_index_refreshes_action_entries_for_updated_tool_blocks(
     test_conn.execute(
         """
         INSERT INTO content_blocks (
-            block_id, message_id, conversation_id, block_index, type, text, tool_name, tool_id, tool_input, media_type, metadata, semantic_type
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            block_id, message_id, conversation_id, block_index, type, text, tool_name, tool_id, tool_input, metadata, semantic_type
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
             "blk-refresh-0b",
@@ -413,7 +413,6 @@ def test_update_index_refreshes_action_entries_for_updated_tool_blocks(
             "Bash",
             "tool-refresh",
             json.dumps({"command": "ruff check polylogue/archive/action_event/action_events.py"}),
-            None,
             None,
             "shell",
         ),

--- a/tests/unit/storage/test_repository_lifecycle_laws.py
+++ b/tests/unit/storage/test_repository_lifecycle_laws.py
@@ -69,15 +69,21 @@ async def test_repository_metadata_tag_and_delete_lifecycle_laws(workspace_env: 
         await harness.delete_metadata_and_assert_visible(scenario, "missing")
 
         metadata = await harness.repository.get_metadata(scenario.resolved_conversation_id)
-        assert metadata["tags"] == ["initial", "review"]
+        # #1240: tags are M2M-only; conversations.metadata['tags'] is no
+        # longer dual-written by add_tag, so the seeded payload is unchanged
+        # after add_tag("review").
+        assert metadata["tags"] == ["initial"]
         assert metadata["summary"] == "after"
         assert metadata["audit"] == {"status": "checked", "tooling": ["repository", "scenario"]}
+        # M2M reflects the seeded "initial" (written into conversation_tags by
+        # the scenario seeder) plus the "review" added through add_tag.
         await harness.assert_tags({"initial": 1, "review": 1})
 
         await harness.remove_tag_and_assert_visible(scenario, "initial")
         await harness.remove_tag_and_assert_visible(scenario, "initial")
         metadata_after_remove = await harness.repository.get_metadata(scenario.resolved_conversation_id)
-        assert metadata_after_remove["tags"] == ["review"]
+        # remove_tag only touches M2M; the seeded metadata payload is untouched.
+        assert metadata_after_remove["tags"] == ["initial"]
         await harness.assert_tags({"review": 1}, provider="claude-code")
         await harness.assert_archive_agrees(total_conversations=1)
 
@@ -126,9 +132,11 @@ async def test_repository_lifecycle_state_keeps_neighbor_conversations_visible(
         await harness.add_tag_and_assert_visible(target, "review")
         await harness.assert_conversation_visible(neighbor)
         await harness.update_metadata_and_assert_visible(target, "summary", "reviewed")
+        # #1240: add_tag no longer dual-writes into JSON metadata; the seeded
+        # ["target"] payload is unchanged by add_tag("review").
         await harness.assert_metadata_contains(
             target.resolved_conversation_id,
-            {"tags": ["target", "review"], "summary": "reviewed"},
+            {"tags": ["target"], "summary": "reviewed"},
         )
         await harness.assert_metadata_contains(neighbor.resolved_conversation_id, {"tags": ["neighbor"]})
         await harness.delete_conversation_and_assert_absent(target)
@@ -136,6 +144,8 @@ async def test_repository_lifecycle_state_keeps_neighbor_conversations_visible(
         await harness.assert_conversation_visible(neighbor)
         archive_facts = await harness.assert_archive_agrees(total_conversations=1)
         assert archive_facts.conversation_ids == (neighbor.resolved_conversation_id,)
+        # Target's M2M rows cascaded out with delete_conversation; neighbor's
+        # seeded "neighbor" tag remains in M2M.
         await harness.assert_tags({"neighbor": 1})
     finally:
         await harness.close()

--- a/tests/unit/storage/test_store_ops.py
+++ b/tests/unit/storage/test_store_ops.py
@@ -118,6 +118,21 @@ def _content_block(
     metadata: str | None = None,
     semantic_type: str | None = None,
 ) -> ContentBlockRecord:
+    # #1240: media_type now lives inside the metadata JSON envelope.
+    if media_type:
+        from polylogue.core.json import dumps as _json_dumps
+        from polylogue.core.json import loads as _json_loads
+
+        base: dict[str, object] = {}
+        if metadata:
+            try:
+                parsed = _json_loads(metadata)
+            except Exception:
+                parsed = None
+            if isinstance(parsed, dict):
+                base.update(parsed)
+        base.setdefault("media_type", media_type)
+        metadata = _json_dumps(base)
     return ContentBlockRecord(
         block_id=block_id,
         message_id=_message_id(message_id),
@@ -128,7 +143,6 @@ def _content_block(
         tool_name=tool_name,
         tool_id=tool_id,
         tool_input=tool_input,
-        media_type=media_type,
         metadata=metadata,
         semantic_type=None if semantic_type is None else SemanticBlockType.from_string(semantic_type),
     )

--- a/tests/unit/storage/test_tag_contracts.py
+++ b/tests/unit/storage/test_tag_contracts.py
@@ -148,3 +148,74 @@ async def test_tag_validation_rejects_invalid_input(
             await repo.add_tag(scenario.resolved_conversation_id, tag)
     finally:
         await repo.close()
+
+
+# ---------------------------------------------------------------------------
+# #1240: M2M tag tables are the only tag read surface.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_list_tags_ignores_json_metadata_only_tags(workspace_env: Mapping[str, Path]) -> None:
+    """#1240: ``list_tags`` reads only the M2M tables.
+
+    Tags written exclusively into ``conversations.metadata`` (as JSON) must
+    not appear in ``list_tags`` output. The legacy JSON fallback path was
+    removed with SCHEMA_VERSION 3.
+    """
+    scenario = ArchiveScenario(
+        name="json-only-tags",
+        provider="test",
+        title="Legacy JSON tags",
+        messages=(ScenarioMessage(role="user", text="x", message_id="m1"),),
+    )
+    db_path, _ = seed_workspace_scenarios(workspace_env, [scenario])
+
+    # Inject a JSON-only tag value directly into conversations.metadata,
+    # bypassing the M2M tables that the scenario seeder would normally write.
+    import sqlite3
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "UPDATE conversations SET metadata = ? WHERE conversation_id = ?",
+            ('{"tags": ["json-only-tag"]}', scenario.resolved_conversation_id),
+        )
+        conn.commit()
+
+    repo = repository_for_scenario_db(db_path)
+    try:
+        listed = await repo.list_tags()
+        assert "json-only-tag" not in listed, (
+            "list_tags must not surface tags that live only in conversations.metadata JSON"
+        )
+        assert listed == {}, f"expected empty tag list, got {listed!r}"
+    finally:
+        await repo.close()
+
+
+@pytest.mark.asyncio()
+async def test_add_tag_does_not_dual_write_into_metadata_json(workspace_env: Mapping[str, Path]) -> None:
+    """#1240: ``add_tag`` writes only to the M2M tables.
+
+    The legacy dual-write into ``conversations.metadata['tags']`` was
+    removed; ``add_tag`` must not modify the metadata column.
+    """
+    scenario = ArchiveScenario(
+        name="add-tag-no-dual-write",
+        provider="test",
+        title="Add-tag isolation",
+        messages=(ScenarioMessage(role="user", text="x", message_id="m1"),),
+    )
+    db_path, _ = seed_workspace_scenarios(workspace_env, [scenario])
+
+    repo = repository_for_scenario_db(db_path)
+    try:
+        await repo.add_tag(scenario.resolved_conversation_id, "review")
+        metadata = await repo.get_metadata(scenario.resolved_conversation_id)
+        assert "tags" not in metadata, f"add_tag must not write into metadata.tags; got metadata={metadata!r}"
+
+        # And the M2M read surface does see it.
+        listed = await repo.list_tags()
+        assert listed == {"review": 1}
+    finally:
+        await repo.close()


### PR DESCRIPTION
## Summary

Dead-schema sweep slice A for the polylogue archive: drops eight unused
indexes, the rarely-populated `content_blocks.media_type` column, and the
legacy JSON tag read/dual-write paths. Bumps `SCHEMA_VERSION` from 2 to 3
under polylogue's fresh-first (`deletes-then-defines`) policy. Closes #1240.

## Problem

Per the #817 dead-schema audit, the archive ships several SQL artifacts
that are written but never queried:

- six column-based indexes on `attachments` / `attachment_refs`
  (`provider_attachment_id`, `provider_file_id`, `provider_drive_id` on
  both tables). A repo grep for `WHERE.*provider_attachment_id|provider_file_id|provider_drive_id` finds **zero** SQL usage.
- two indexes on `content_blocks.semantic_type` (`idx_content_blocks_semantic_type` and `idx_content_blocks_conv_semantic`). `semantic_type` is written and hydrated but never used in WHERE/GROUP BY.
- `content_blocks.media_type` — production scale shows ~1 of 2.5M rows
  with a non-null value.
- the JSON tag SQL fallback in `list_tags` plus the legacy JSON dual-write
  in `add_tag` / `bulk_add_tags` / `remove_tag`. M2M (`tags` + `conversation_tags`) is the canonical surface and was already the primary read path.
- FK constraint drift: the DDL declares `ON DELETE SET NULL` for
  `conversations.parent_conversation_id`, `conversations.raw_id`,
  `attachment_refs.message_id`, `user_marks`/`user_annotations`, and the
  provider-events foreign keys, but historical production databases have
  `ON DELETE NO ACTION` because SQLite cannot alter FK actions in place.

Carrying these artifacts costs index storage, write amplification, audit
noise, and review friction for any subsequent schema change.

## Solution

**DDL changes** (`polylogue/storage/sqlite/schema_ddl_archive.py`,
`schema_ddl.py`):

- Drop the six attachment(-ref) provider-id indexes and the two
  semantic_type indexes.
- Drop `content_blocks.media_type` column.
- Bump `SCHEMA_VERSION` 2 → 3.

**FK drift resolution.** Per `CONTRIBUTING.md` § "Schema-Touching
Changes" and `docs/internals.md` § "Schema Versioning Model", polylogue
has no migration chain — a `SCHEMA_VERSION` bump rejects mismatched
databases and the operator runs `polylogue reset --database && polylogued
run` to re-ingest from source. The DDL is the truth; the fresh database
that re-ingest produces has the intended `ON DELETE SET NULL`
constraints, closing the drift without an in-place upgrade script (which
would be rejected on policy grounds).

**`content_blocks.media_type` → metadata JSON.** The runtime parser
model `ParsedContentBlock` keeps its `media_type` field. At
materialization (`pipeline/materialization_runtime.py:_materialize_content_block`)
the value is folded into the existing `metadata_json` envelope under the
`"media_type"` key for image/document blocks. Hydration
(`storage/hydrators.py:message_from_record`) reads it back out of the
parsed metadata mapping and lifts it to the top-level
`{"media_type": ...}` key that downstream renderers expect. The
row-graph re-derivation hash in
`storage/repository/archive/writes/conversations.py:_block_hash_payload`
extracts `media_type` from `metadata` so its payload still matches the
parser-side hash in `pipeline/ids.py`. Net effect: same on-wire hash for
image/document blocks; one fewer storage column; rendering round-trip
covered by `tests/unit/storage/test_dead_schema_sweep.py::test_media_type_roundtrips_via_metadata_json`.

**Tag M2M-only.** `list_tags` is now a single query against
`conversation_tags JOIN tags`. `add_tag` / `bulk_add_tags` /
`remove_tag` no longer touch `conversations.metadata['tags']`.
Hydration is wired through a new
`_fetch_tags_by_conversation(ids)` batch helper on the repository
conversation mixin; `Conversation` / `ConversationSummary` gain an
optional `tags_m2m: tuple[str, ...]` field that the existing `.tags`
property prefers when populated, falling back to metadata for
constructors that do not go through the repository hydrator.

**Test infra parity.** `tests/infra/storage_records.py` folds
`media_type=...` into the metadata JSON automatically (helper
`_merge_media_type_into_metadata`) so existing scenario fixtures keep
working. `tests/unit/storage/test_repository_lifecycle_laws.py` updates
its tag/metadata assertions to reflect M2M-only tag semantics.

**Alternatives rejected.**
- Keeping `media_type` as a real column but dropping just its indexes:
  the column is so sparsely populated that the storage and serialization
  surface area is not worth one nullable string.
- Adding a forward migration that ALTERs the FK constraints: prohibited
  by `CONTRIBUTING.md` and `docs/internals.md`. Fresh-first re-ingest is
  the policy resolution.

## Verification

```
$ devtools verify --quick
…
  ruff format ... ok
  ruff check ... ok
  mypy ... ok
  render-all ... ok
  verify-topology … verify-test-infra-currency ... ok
  exit_code: 0

$ pytest -p no:randomly --override-ini="addopts=" \\
    tests/unit/storage/test_dead_schema_sweep.py \\
    tests/unit/storage/test_tag_contracts.py
28 passed in 1.30s

$ pytest -q --ignore=tests/integration
8096 passed, 1 failed, 2 xfailed in 119.10s
```

The one full-suite failure (`tests/property/test_filter_chain_laws.py::test_filter_application_order_is_commutative`)
falsifies identically on master `7a85f3b7` with `git stash` applied —
pre-existing, unrelated to dead-schema sweep, refused from this PR on
scope-discipline grounds and filed as #1338 with a complete repro and
acceptance.

### EXPLAIN QUERY PLAN evidence

Pre-drop (against `SCHEMA_DDL` before this PR):

```
SELECT * FROM attachments WHERE provider_attachment_id = 'x'
  SEARCH attachments USING INDEX idx_attachments_provider_attachment_id (provider_attachment_id=?)
SELECT * FROM attachments WHERE provider_file_id = 'x'
  SEARCH attachments USING INDEX idx_attachments_provider_file_id (provider_file_id=?)
SELECT * FROM attachments WHERE provider_drive_id = 'x'
  SEARCH attachments USING INDEX idx_attachments_provider_drive_id (provider_drive_id=?)
SELECT * FROM attachment_refs WHERE provider_attachment_id = 'x'
  SEARCH attachment_refs USING INDEX idx_attachment_refs_provider_attachment_id (provider_attachment_id=?)
SELECT * FROM attachment_refs WHERE provider_file_id = 'x'
  SEARCH attachment_refs USING INDEX idx_attachment_refs_provider_file_id (provider_file_id=?)
SELECT * FROM attachment_refs WHERE provider_drive_id = 'x'
  SEARCH attachment_refs USING INDEX idx_attachment_refs_provider_drive_id (provider_drive_id=?)
SELECT * FROM content_blocks WHERE semantic_type = 'x'
  SEARCH content_blocks USING INDEX idx_content_blocks_semantic_type (semantic_type=?)
SELECT * FROM content_blocks WHERE conversation_id = 'c' AND semantic_type = 'x'
  SEARCH content_blocks USING INDEX idx_content_blocks_conv_semantic (conversation_id=? AND semantic_type=?)
```

Post-drop (current PR HEAD), same queries:

```
SELECT * FROM attachments WHERE provider_attachment_id = 'x'     → SCAN attachments
SELECT * FROM attachments WHERE provider_file_id = 'x'           → SCAN attachments
SELECT * FROM attachments WHERE provider_drive_id = 'x'          → SCAN attachments
SELECT * FROM attachment_refs WHERE provider_attachment_id = 'x' → SCAN attachment_refs
SELECT * FROM attachment_refs WHERE provider_file_id = 'x'       → SCAN attachment_refs
SELECT * FROM attachment_refs WHERE provider_drive_id = 'x'      → SCAN attachment_refs
SELECT * FROM content_blocks WHERE semantic_type = 'x'           → SCAN content_blocks
SELECT * FROM content_blocks WHERE conversation_id = 'c' AND semantic_type = 'x'
                                                                 → SEARCH USING INDEX idx_content_blocks_conversation
```

No production query falls into any of these SCANs — repo-wide grep for
`WHERE.*provider_attachment_id|provider_file_id|provider_drive_id|semantic_type`
returns zero matches under `polylogue/`. Dropping the indexes therefore
costs nothing live; SQLite still has `idx_content_blocks_conversation`
for the only query shape that touches `content_blocks` by conversation.

## Re-ingest plan

Per `CONTRIBUTING.md` § "Schema-Touching Changes":

- `polylogue reset --database && polylogued run` re-acquires from source.
- The blob store and FTS5 indexes are rebuilt as part of normal
  convergence; no manual recomputation is required for the dropped
  indexes/column.
- End-user impact is dominated by re-ingest time of the existing source
  corpus, which is comparable to any other schema bump in the project's
  history.

## Follow-ups

- #1338 (pre-existing): `test_filter_application_order_is_commutative`
  falsifies with `chatgpt` vs `claude-ai` provider params — pre-existing
  on master, refused from this PR on scope-discipline grounds.

Closes #1240
Ref #817

🤖 Generated with [Claude Code](https://claude.com/claude-code)