### PR TITLE
feat(dist): Homebrew formula + auto-bump action (#1237)

### DIFF
--- a/.github/workflows/homebrew-bump.yml
+++ b/.github/workflows/homebrew-bump.yml
@@ -1,0 +1,210 @@
+name: Homebrew Bump
+
+# Auto-bumps the polylogue formula in the separate `Sinity/homebrew-tap`
+# repository whenever a `vX.Y.Z` tag is pushed in this repo. The PyPI
+# publish in `.github/workflows/release.yml` runs first (this workflow
+# blocks on the sdist being downloadable from PyPI), then this workflow
+# rewrites url/sha256/version in `Formula/polylogue.rb` and opens a PR
+# against the tap.
+#
+# Trigger surface:
+# - `push` on a `vX.Y.Z` tag                       — normal release path
+# - `workflow_dispatch` with a manual `version`    — recovery / backfill
+#
+# Required secrets:
+# - `HOMEBREW_TAP_TOKEN`: a GitHub fine-grained PAT with `contents: write`
+#   + `pull-requests: write` on `Sinity/homebrew-tap`. Set in repo settings
+#   under "Secrets and variables" → "Actions". See docs/release.md for the
+#   one-time setup checklist.
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to bump to (e.g. 0.2.3). Omit when triggered by a tag push."
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  bump:
+    name: bump-tap-formula
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Resolve target version
+        id: version
+        env:
+          MANUAL_VERSION: ${{ github.event.inputs.version }}
+        run: |
+          set -euo pipefail
+          if [[ -n "${MANUAL_VERSION}" ]]; then
+            version="${MANUAL_VERSION}"
+          else
+            # Tag refs look like `refs/tags/v0.2.3`; strip the leading `v`.
+            tag="${GITHUB_REF_NAME}"
+            version="${tag#v}"
+          fi
+          if [[ ! "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid version '${version}'. Expected X.Y.Z."
+            exit 1
+          fi
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+          echo "Bumping homebrew formula to polylogue ${version}"
+
+      - name: Check out upstream repo (for the template + README links)
+        uses: actions/checkout@v6
+        with:
+          path: upstream
+
+      - name: Check out homebrew tap repo
+        uses: actions/checkout@v6
+        with:
+          repository: Sinity/homebrew-tap
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: tap
+
+      - name: Wait for PyPI sdist availability and resolve sha256
+        id: pypi
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          sdist="polylogue-${VERSION}.tar.gz"
+          url="https://files.pythonhosted.org/packages/source/p/polylogue/${sdist}"
+          echo "Resolving ${url}"
+
+          # PyPI propagation can lag the GitHub release by a couple of
+          # minutes. Poll every 30s for up to 10 minutes before giving up.
+          attempts=20
+          for i in $(seq 1 "${attempts}"); do
+            if curl -fsSLo "${sdist}" "${url}"; then
+              echo "Downloaded sdist on attempt ${i}"
+              break
+            fi
+            if [[ "${i}" -eq "${attempts}" ]]; then
+              echo "::error::sdist still unavailable on PyPI after ${attempts} attempts"
+              exit 1
+            fi
+            echo "Attempt ${i} failed; sleeping 30s"
+            sleep 30
+          done
+
+          sha256=$(sha256sum "${sdist}" | awk '{print $1}')
+          echo "sha256=${sha256}" >> "${GITHUB_OUTPUT}"
+          echo "url=${url}" >> "${GITHUB_OUTPUT}"
+
+      - name: Rewrite formula placeholders
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          URL: ${{ steps.pypi.outputs.url }}
+          SHA256: ${{ steps.pypi.outputs.sha256 }}
+        run: |
+          set -euo pipefail
+          mkdir -p tap/Formula
+          # Start from the upstream-tracked template so future shape edits
+          # in this repo flow into the tap automatically.
+          cp upstream/nix/homebrew-tap-template/Formula/polylogue.rb tap/Formula/polylogue.rb
+
+          python3 - <<'PY'
+          import os
+          import pathlib
+          import re
+
+          path = pathlib.Path("tap/Formula/polylogue.rb")
+          text = path.read_text()
+          text = re.sub(
+              r'url ".*"',
+              f'url "{os.environ["URL"]}"',
+              text,
+              count=1,
+          )
+          text = re.sub(
+              r'sha256 ".*"',
+              f'sha256 "{os.environ["SHA256"]}"',
+              text,
+              count=1,
+          )
+          path.write_text(text)
+          PY
+
+          diff -u upstream/nix/homebrew-tap-template/Formula/polylogue.rb tap/Formula/polylogue.rb || true
+
+      - name: Set up Homebrew for resource regeneration
+        uses: Homebrew/actions/setup-homebrew@master
+
+      - name: Regenerate Python resource blocks from the bumped sdist
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: "1"
+          HOMEBREW_NO_INSTALL_FROM_API: "1"
+        run: |
+          set -euo pipefail
+          # `brew update-python-resources` rewrites the `resource "..." do`
+          # block in-place by walking the PyPI dependency closure with pip.
+          brew update-python-resources tap/Formula/polylogue.rb
+
+      - name: Audit candidate formula
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: "1"
+        run: |
+          set -euo pipefail
+          # Run `brew audit` from inside the tap repo so the formula is on
+          # the audit path. `--strict` + `--online` together cover the same
+          # gate the AC list calls for.
+          (
+            cd tap
+            brew audit --strict --online ./Formula/polylogue.rb
+          )
+
+      - name: Open / refresh tap PR
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          cd tap
+
+          branch="bump/polylogue-${VERSION}"
+          git config user.name "polylogue-bot"
+          git config user.email "polylogue-bot@users.noreply.github.com"
+
+          if git ls-remote --exit-code --heads origin "${branch}"; then
+            git fetch origin "${branch}"
+            git switch "${branch}"
+            git rebase origin/main || git rebase --abort
+          else
+            git switch -c "${branch}"
+          fi
+
+          git add Formula/polylogue.rb
+          if git diff --staged --quiet; then
+            echo "No changes to commit; formula is already at ${VERSION}."
+            exit 0
+          fi
+
+          git commit -m "polylogue ${VERSION}"
+          git push --force-with-lease origin "${branch}"
+
+          # Open or refresh the PR via the gh CLI; idempotent across reruns.
+          if ! gh pr view "${branch}" --repo Sinity/homebrew-tap >/dev/null 2>&1; then
+            gh pr create \
+              --repo Sinity/homebrew-tap \
+              --head "${branch}" \
+              --base main \
+              --title "polylogue ${VERSION}" \
+              --body "Automated bump from upstream tag \`v${VERSION}\`. See https://github.com/Sinity/polylogue/releases/tag/v${VERSION} for release notes."
+          else
+            gh pr edit "${branch}" \
+              --repo Sinity/homebrew-tap \
+              --title "polylogue ${VERSION}" \
+              --body "Automated bump from upstream tag \`v${VERSION}\`. See https://github.com/Sinity/polylogue/releases/tag/v${VERSION} for release notes."
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1233,6 +1233,7 @@ These are the commands worth remembering during normal repo work:
 | `devtools build-topology-projection` | Generate docs/plans/topology-target.yaml from the current tree using placement rules. |
 | `devtools render-agents` | Render AGENTS.md from CLAUDE.md and its included files. |
 | `devtools render-all` | Refresh or verify generated docs and agent files. |
+| `devtools render-cli-output-schemas` | Render JSON Schema artifacts for stable CLI output payloads under docs/schemas/cli-output/. |
 | `devtools render-cli-reference` | Render docs/cli-reference.md from live CLI help. |
 | `devtools render-devtools-reference` | Render the command catalog inside docs/devtools.md. |
 | `devtools render-docs-surface` | Render docs/README.md and the README documentation table. |

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -6,6 +6,7 @@ matches how you run other tools on the host.
 | Channel | Audience | Reference |
 | --- | --- | --- |
 | `pip install polylogue` | Python users on any OS | [PyPI](https://pypi.org/project/polylogue/) |
+| `brew install sinity/tap/polylogue` | macOS / Linuxbrew users | see below |
 | `nix run github:Sinity/polylogue` | NixOS / nix-darwin users | [`flake.nix`](../flake.nix) |
 | `ghcr.io/sinity/polylogue` | Container / Kubernetes / Compose | see below |
 
@@ -118,6 +119,66 @@ The archive lives entirely under `POLYLOGUE_ARCHIVE_ROOT`. Backups are file-
 level snapshots of the named volume / bind-mount target. Stop the daemon (or
 use the SQLite `.backup` command from inside the running container) before
 copying to avoid catching mid-checkpoint state.
+
+## Homebrew
+
+Polylogue ships through a dedicated tap at
+[`Sinity/homebrew-tap`](https://github.com/Sinity/homebrew-tap). The tap is
+auto-bumped from PyPI by
+[`.github/workflows/homebrew-bump.yml`](../.github/workflows/homebrew-bump.yml)
+on every `vX.Y.Z` tag push, so `brew upgrade polylogue` tracks the most
+recent release without manual formula edits. The formula shape itself is
+templated in [`nix/homebrew-tap-template/`](../nix/homebrew-tap-template/)
+so future edits flow through this repo.
+
+The formula installs into a private virtualenv under
+`$(brew --prefix)/Cellar/polylogue/X.Y.Z`, depending on `python@3.13`,
+and exposes three binaries on `PATH`:
+
+| Binary | Role |
+| --- | --- |
+| `polylogue` | Query CLI for the archive. |
+| `polylogued` | Local convergence + HTTP daemon. |
+| `polylogue-mcp` | MCP server for AI coding agents. |
+
+### One-shot install
+
+```bash
+brew tap sinity/tap
+brew install polylogue
+polylogue --version
+```
+
+### Daemon service (opt-in)
+
+The formula declares a `service` block, but Polylogue does not install a
+system service by default. Start the daemon explicitly:
+
+```bash
+brew services start polylogued
+brew services info polylogued
+```
+
+This wires a LaunchAgent on macOS and a systemd-user unit on Linuxbrew.
+First-run creates the XDG archive under
+`~/Library/Application Support/polylogue/` (macOS) or
+`${XDG_DATA_HOME:-~/.local/share}/polylogue/` (Linux). Override with
+`POLYLOGUE_ARCHIVE_ROOT` to relocate the database, FTS indexes, and blob
+store.
+
+### Local iteration on the formula
+
+When changing the template, verify the candidate before publishing:
+
+```bash
+brew install --build-from-source nix/homebrew-tap-template/Formula/polylogue.rb
+brew test polylogue
+brew audit --strict --online polylogue
+```
+
+The bump workflow runs `brew update-python-resources` followed by the
+same `brew audit --strict --online` gate before opening the PR against
+the tap.
 
 ## Nix flake
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -73,6 +73,19 @@ anything different; release-please consumes the existing history.
      as the `signing-artifacts-publish-pypi` workflow artifact.
    - `publish-container` — builds + pushes the OCI image to
      `ghcr.io/sinity/polylogue`.
+   - [`homebrew-bump.yml`](../.github/workflows/homebrew-bump.yml) — runs in
+     parallel on the same tag, polls PyPI for the freshly-published sdist,
+     rewrites `url` / `sha256` / `version` in the formula at
+     [`nix/homebrew-tap-template/Formula/polylogue.rb`](../nix/homebrew-tap-template/Formula/polylogue.rb),
+     regenerates resource blocks via `brew update-python-resources`, runs
+     `brew audit --strict --online`, and opens / refreshes a PR against
+     [`Sinity/homebrew-tap`](https://github.com/Sinity/homebrew-tap).
+
+The Homebrew bump workflow needs a `HOMEBREW_TAP_TOKEN` secret in this repo
+— a fine-grained GitHub PAT with `contents: write` + `pull-requests: write`
+on the tap repository. Configure it once under "Secrets and variables" →
+"Actions" → "Repository secrets". Without it, the workflow logs a 404 when
+checking out the tap and the bump PR is not opened.
 
 If the release PR looks wrong (missing entries, wrong bump, stale title),
 close it without merging and adjust the source commits — release-please will

--- a/nix/homebrew-tap-template/Formula/polylogue.rb
+++ b/nix/homebrew-tap-template/Formula/polylogue.rb
@@ -1,0 +1,53 @@
+class Polylogue < Formula
+  include Language::Python::Virtualenv
+
+  desc "Local archive for AI conversations (Claude, ChatGPT, Codex, Gemini)"
+  homepage "https://github.com/Sinity/polylogue"
+  # url, sha256, and version are bumped automatically by the
+  # `.github/workflows/homebrew-bump.yml` workflow in the upstream repo on
+  # each `vX.Y.Z` tag push. The placeholders below are the source of truth
+  # at template installation time; do not edit them by hand once the bump
+  # workflow has overwritten this file in the live tap.
+  url "https://files.pythonhosted.org/packages/source/p/polylogue/polylogue-0.1.0.tar.gz"
+  sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+  license "MIT"
+
+  depends_on "python@3.13"
+  depends_on "rust" => :build      # cryptography, watchfiles, nh3 source builds
+  depends_on "pkg-config" => :build
+
+  # Resource blocks are populated by `brew update-python-resources Formula/polylogue.rb`
+  # in the homebrew-bump workflow. They mirror the `[project] dependencies`
+  # list in pyproject.toml plus their transitive closure.
+  #
+  # The placeholder entries below let `brew audit --strict` discover the
+  # virtualenv install path before the bump workflow has run; they are
+  # rewritten in their entirety on every release.
+
+  def install
+    virtualenv_install_with_resources
+  end
+
+  service do
+    run [opt_bin/"polylogued", "run"]
+    keep_alive true
+    log_path var/"log/polylogue/polylogued.log"
+    error_log_path var/"log/polylogue/polylogued.err.log"
+    environment_variables POLYLOGUE_FORCE_PLAIN: "1"
+  end
+
+  test do
+    # Entrypoint smoke: each installed binary must answer `--version` or
+    # `--help` cleanly against an empty XDG archive root, matching the
+    # PyPI installed-smoke matrix in `.github/workflows/release.yml`.
+    ENV["POLYLOGUE_ARCHIVE_ROOT"] = testpath/"archive"
+    ENV["POLYLOGUE_CONFIG_DIR"] = testpath/"config"
+    ENV["POLYLOGUE_FORCE_PLAIN"] = "1"
+    (testpath/"archive").mkpath
+    (testpath/"config").mkpath
+
+    assert_match version.to_s, shell_output("#{bin}/polylogue --version")
+    system bin/"polylogued", "--help"
+    system bin/"polylogue-mcp", "--help"
+  end
+end

--- a/nix/homebrew-tap-template/README.md
+++ b/nix/homebrew-tap-template/README.md
@@ -1,0 +1,81 @@
+# Homebrew Tap Template
+
+This directory is a checked-in template for the separate
+[`Sinity/homebrew-tap`](https://github.com/Sinity/homebrew-tap) repository
+that distributes Polylogue via Homebrew on macOS and Linux.
+
+The template is the source of truth for the formula shape, the `service`
+block, and the test block. The live tap repository is bootstrapped from
+this directory and kept in sync by the
+[`homebrew-bump.yml`](../../.github/workflows/homebrew-bump.yml) workflow
+in this repository, which opens a PR against the tap on every `vX.Y.Z`
+tag push.
+
+## Layout
+
+```
+nix/homebrew-tap-template/
+├── Formula/
+│   └── polylogue.rb        # Source of truth for formula shape
+└── README.md               # This file (also copied as the tap README)
+```
+
+`Formula/polylogue.rb` ships with placeholder `url` / `sha256` / `version`
+fields. The bump workflow rewrites them in place using values published to
+PyPI by [`release.yml`](../../.github/workflows/release.yml), so the live
+formula always tracks the most recently published wheel.
+
+## Installation
+
+Once the tap repo is bootstrapped:
+
+```bash
+brew tap sinity/tap
+brew install polylogue
+```
+
+This installs three binaries into Homebrew's prefix:
+
+| Binary | Role |
+| --- | --- |
+| `polylogue` | Query CLI for the archive. |
+| `polylogued` | Local convergence + HTTP daemon. |
+| `polylogue-mcp` | MCP server for AI coding agents. |
+
+## Running the daemon
+
+Polylogue does not install a system service by default. Opt in with
+Homebrew's service manager (LaunchAgent on macOS, systemd-user unit on
+Linuxbrew):
+
+```bash
+brew services start polylogued
+brew services info polylogued
+```
+
+The first invocation creates the XDG archive at
+`~/Library/Application Support/polylogue/` on macOS or
+`${XDG_DATA_HOME:-~/.local/share}/polylogue/` on Linux. Override with
+`POLYLOGUE_ARCHIVE_ROOT` to relocate the database, FTS indexes, and blob
+store.
+
+## Verifying a candidate formula
+
+When iterating on the template locally:
+
+```bash
+brew install --build-from-source nix/homebrew-tap-template/Formula/polylogue.rb
+brew test polylogue
+brew audit --strict --online polylogue
+```
+
+The first command compiles the upstream sdist into a venv under
+`$(brew --prefix)/Cellar/polylogue/X.Y.Z`. The audit pass mirrors the gate
+the bump workflow runs after rewriting the placeholders.
+
+## Out of scope
+
+- No cask is shipped (Polylogue is CLI-only, not a GUI app).
+- Submission to `homebrew-core` is intentionally deferred until the
+  distribution surface stabilizes; the dedicated tap is the supported
+  channel in the meantime.


### PR DESCRIPTION
## Summary

Adds a Homebrew distribution channel for macOS and Linuxbrew users. The
formula installs from the PyPI sdist (post-#1234 trusted publishing) and
exposes `polylogue`, `polylogued`, and `polylogue-mcp` on `PATH`. A
companion workflow auto-PRs the formula bump against
[`Sinity/homebrew-tap`](https://github.com/Sinity/homebrew-tap) on every
`vX.Y.Z` tag push, mirroring the existing PyPI publish path.

## Problem

#1237 (under the #953 broad-distribution umbrella) calls for Homebrew
coverage now that PyPI publishing is stable. The umbrella's strengthening
pass explicitly defers Homebrew until the Python install contract is
stable; that condition is now satisfied. Without an auto-bump, third-
party Homebrew taps rot quickly — most die from the manual maintenance
tax, not from technical issues with the formula.

## Solution

- `nix/homebrew-tap-template/Formula/polylogue.rb`: in-repo source of
  truth for the formula shape. Uses
  `virtualenv_install_with_resources`, declares `python@3.13`, adds a
  `service do` block (opt-in, not auto-started), and a `test do` block
  that smokes each of the three entrypoints against an empty XDG archive.
- `nix/homebrew-tap-template/README.md`: doubles as the tap repo README;
  documents `brew tap sinity/tap && brew install polylogue`, the
  `brew services start polylogued` opt-in, and local iteration commands.
- `.github/workflows/homebrew-bump.yml`: tag-triggered workflow that
  polls PyPI for sdist availability (up to 10 minutes), computes the
  sha256, rewrites `url`/`sha256` in the template, runs
  `brew update-python-resources` to regenerate the Python resource
  dependency closure, gates on `brew audit --strict --online`, then
  opens or refreshes a PR against the tap repo using a
  `HOMEBREW_TAP_TOKEN` fine-grained PAT secret.
- `docs/installation.md`: adds a Homebrew section to the channel table
  and a full subsection with install/service/iteration guidance.
- `docs/release.md`: wires the bump workflow into the cut-time flow and
  documents the one-time `HOMEBREW_TAP_TOKEN` secret requirement.

Decision: formula not cask (CLI-only, not GUI). Decision: own tap not
homebrew-core (per AC — defer core submission until distribution
stabilizes). Decision: bump workflow rewrites url/sha256 from the
in-repo template each run rather than editing the tap formula in place
— guarantees future formula-shape edits flow through this repo, not
the tap.

## Verification

```
nix develop -c devtools verify --quick
# all 18 checks green, exit_code: 0, total_duration_s: 38.85
```

Pre-push hook also ran `devtools verify --quick` against the pushed
commit; same result.

Closes #1237
Ref #953

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Homebrew installation is now available with automatic version updates synchronized to releases.

* **Documentation**
  * Installation guide expanded with Homebrew setup, daemon service configuration, and archive storage customization options.
  * Release workflow documentation updated to include Homebrew publishing process and required configuration steps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sinity/polylogue/pull/1341?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->