### PR TITLE
feat(daemon): FTS-trigger drift detection + auto-repair (#1229)

### DIFF
--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -169,6 +169,12 @@ Enabled by default on `127.0.0.1:8765`. Disable with `--no-browser-capture`.
 - `disk_space` — free disk space (warns at 500 MB, critical at 100 MB)
 - `wal_size` — WAL file size (warns at 50 MB, errors at 200 MB)
 - `source_availability` — watch roots exist and are readable
+- `fts_trigger_drift` — checks the six canonical FTS sync triggers
+  (`messages_fts_a{i,d,u}`, `action_events_fts_a{i,d,u}`); critical when
+  any are missing. With `[health] fts_auto_restore = true` (or
+  `POLYLOGUE_HEALTH_FTS_AUTO_RESTORE=1`), the daemon restores triggers
+  and rebuilds the FTS index in place, then emits a WARNING-level
+  recovery alert so the operator is told the self-heal happened.
 
 **Medium** (sub-10s queries):
 - `fts_readiness` — FTS index coverage vs. total messages

--- a/docs/plans/file-size-budgets.yaml
+++ b/docs/plans/file-size-budgets.yaml
@@ -69,6 +69,10 @@ exceptions:
     ceiling: 1150
     reason: "typed status payloads for failure samples, embedding readiness, tier/notify (#844, #898, #915); split candidate: payload modules per status section"
 
+  - path: polylogue/daemon/health.py
+    ceiling: 1250
+    reason: "tiered health checks (fast/medium/expensive) with typed alerts, including FTS-trigger drift detection + auto-restore (#1229); split candidate: per-tier modules under daemon/health/"
+
   - path: tests/unit/sources/test_live_watcher.py
     ceiling: 1600
     reason: "kitchen-sink live-ingest test file (cursor, watcher, batch, debounce, bootstrap); split candidate: per-subject suites under tests/unit/sources/live/"

--- a/polylogue/config.py
+++ b/polylogue/config.py
@@ -289,6 +289,19 @@ class PolylogueConfig:
         return str(self._data.get("health_check_tiers", "fast,medium"))
 
     @property
+    def health_fts_auto_restore(self) -> bool:
+        """Whether the daemon health loop should auto-restore missing FTS triggers (#1229).
+
+        When true, :func:`polylogue.daemon.health._check_fts_trigger_drift_fast`
+        drops/re-creates the six canonical FTS sync triggers and runs the
+        FTS5 ``rebuild`` command in place when drift is detected. The
+        check still emits a WARNING-level alert so the operator is told
+        the recovery happened. When false (default), drift surfaces as
+        CRITICAL with an operator-facing restore command.
+        """
+        return bool(self._data.get("health_fts_auto_restore", False))
+
+    @property
     def health_convergence_debt(self) -> dict[str, object]:
         """Raw ``[health.convergence_debt]`` table from polylogue.toml.
 
@@ -451,6 +464,7 @@ def _default_config_values() -> dict[str, object]:
         "notification_webhook_url": None,
         "health_check_interval_s": 300,
         "health_check_tiers": "fast,medium",
+        "health_fts_auto_restore": False,
         "watch_debounce_s": 2.0,
         "browser_capture_host": "127.0.0.1",
         "browser_capture_spool_path": "",
@@ -614,6 +628,7 @@ def _merge_toml(cfg: dict[str, object], toml_data: dict[str, object]) -> None:
         "health": {
             "check_interval_s": "health_check_interval_s",
             "check_tiers": "health_check_tiers",
+            "fts_auto_restore": "health_fts_auto_restore",
         },
     }
     for section, key_map in section_keys.items():
@@ -663,6 +678,7 @@ def _apply_env_overrides(cfg: dict[str, object]) -> None:
         "POLYLOGUE_NOTIFICATION_WEBHOOK_URL": "notification_webhook_url",
         "POLYLOGUE_HEALTH_CHECK_INTERVAL_S": "health_check_interval_s",
         "POLYLOGUE_HEALTH_CHECK_TIERS": "health_check_tiers",
+        "POLYLOGUE_HEALTH_FTS_AUTO_RESTORE": "health_fts_auto_restore",
         "POLYLOGUE_API_HOST": "api_host",
         "POLYLOGUE_API_PORT": "api_port",
         "POLYLOGUE_API_AUTH_TOKEN": "api_auth_token",
@@ -759,6 +775,7 @@ def format_config_toml(cfg: dict[str, object]) -> str:
             [
                 ("check_interval_s", "health_check_interval_s"),
                 ("check_tiers", "health_check_tiers"),
+                ("fts_auto_restore", "health_fts_auto_restore"),
             ],
         ),
     ]

--- a/polylogue/daemon/health.py
+++ b/polylogue/daemon/health.py
@@ -271,6 +271,209 @@ def _check_source_availability_fast() -> HealthAlert:
         )
 
 
+_EXPECTED_FTS_TRIGGERS: tuple[str, ...] = (
+    "messages_fts_ai",
+    "messages_fts_ad",
+    "messages_fts_au",
+    "action_events_fts_ai",
+    "action_events_fts_ad",
+    "action_events_fts_au",
+)
+"""Six canonical FTS sync triggers (#1229).
+
+Three for ``messages_fts`` + three for ``action_events_fts``. These are
+restored after every bulk-write window by
+``polylogue/storage/fts/fts_lifecycle.py::restore_fts_triggers_sync``;
+their absence after a SIGKILL during a suspension window leaves the FTS
+indexes silently out of sync with the source tables.
+"""
+
+
+def _find_missing_fts_triggers(conn: sqlite3.Connection) -> list[str]:
+    """Return the names of expected FTS triggers that do not exist."""
+    placeholders = ",".join("?" for _ in _EXPECTED_FTS_TRIGGERS)
+    rows = conn.execute(
+        f"SELECT name FROM sqlite_schema WHERE type='trigger' AND name IN ({placeholders})",
+        _EXPECTED_FTS_TRIGGERS,
+    ).fetchall()
+    present = {row[0] for row in rows}
+    return [name for name in _EXPECTED_FTS_TRIGGERS if name not in present]
+
+
+def _auto_restore_fts_triggers(dbf: object) -> tuple[list[str], bool, str]:
+    """Restore missing FTS triggers and rebuild the FTS index.
+
+    Used by :func:`_check_fts_trigger_drift_fast` when
+    ``health.fts_auto_restore = true``. Restore is metadata-only (drops
+    and re-creates triggers from the canonical DDL in
+    ``polylogue.storage.fts.fts_lifecycle``) and the subsequent rebuild
+    reconstructs the FTS index from the persisted ``messages`` and
+    ``action_events`` rows. Both operations are read-only in the sense
+    that they do not modify user-visible archive data.
+
+    Returns:
+        ``(restored, success, detail)`` — list of trigger names restored,
+        whether the operation succeeded, and an operator-facing detail.
+    """
+    from polylogue.storage.fts.fts_lifecycle import (
+        rebuild_fts_index_sync,
+        restore_fts_triggers_sync,
+    )
+
+    conn = sqlite3.connect(str(dbf), timeout=5.0)
+    try:
+        missing_before = _find_missing_fts_triggers(conn)
+        if not missing_before:
+            return [], True, "no missing triggers to restore"
+        restore_fts_triggers_sync(conn)
+        rebuild_fts_index_sync(conn)
+        conn.commit()
+        missing_after = _find_missing_fts_triggers(conn)
+        if missing_after:
+            return (
+                missing_before,
+                False,
+                (f"restore attempted but {len(missing_after)} trigger(s) still missing: {', '.join(missing_after)}"),
+            )
+        return (
+            missing_before,
+            True,
+            (f"restored {len(missing_before)} trigger(s) and rebuilt FTS index: {', '.join(missing_before)}"),
+        )
+    finally:
+        conn.close()
+
+
+def _check_fts_trigger_drift_fast() -> HealthAlert:
+    """Detect missing FTS sync triggers; auto-restore when configured.
+
+    The six canonical triggers in :data:`_EXPECTED_FTS_TRIGGERS` keep
+    ``messages_fts`` and ``action_events_fts`` in sync with their source
+    tables. A SIGKILL during the bulk-write trigger-suspension window
+    (see ``docs/internals.md`` "FTS5 Model") leaves them dropped, which
+    silently corrupts search results until the next bulk operation
+    restores them.
+
+    Behavior:
+
+    - Missing triggers raise CRITICAL — silent search corruption is a
+      semantic regression, not a perf wart.
+    - When ``health.fts_auto_restore = true`` (env
+      ``POLYLOGUE_HEALTH_FTS_AUTO_RESTORE``) and triggers are missing,
+      the check restores them and rebuilds the FTS index in place. The
+      alert then carries severity WARNING (still surfaced so the
+      operator knows recovery happened) with a ``recovery=`` detail.
+    - Restore failures fall back to CRITICAL with the restore-error
+      detail appended so the operator can intervene.
+    """
+    from polylogue.config import load_polylogue_config
+
+    now = datetime.now(UTC).isoformat()
+    dbf = db_path()
+    if not dbf.exists():
+        return HealthAlert(
+            check_name="fts_trigger_drift",
+            tier=HealthTier.FAST,
+            severity=HealthSeverity.OK,
+            message="no database yet (FTS triggers will be installed at fresh-init)",
+            checked_at=now,
+            consecutive_failures=_record_failure("fts_trigger_drift", True),
+        )
+
+    try:
+        # Read-only inspection first so the cheap healthy path never
+        # opens a writable connection.
+        conn = sqlite3.connect(f"file:{dbf}?mode=ro", uri=True, timeout=2.0)
+        try:
+            missing = _find_missing_fts_triggers(conn)
+        finally:
+            conn.close()
+
+        if not missing:
+            return HealthAlert(
+                check_name="fts_trigger_drift",
+                tier=HealthTier.FAST,
+                severity=HealthSeverity.OK,
+                message=f"all {len(_EXPECTED_FTS_TRIGGERS)} FTS triggers present",
+                checked_at=now,
+                consecutive_failures=_record_failure("fts_trigger_drift", True),
+            )
+
+        restore_cmd = "polylogue check --repair-fts"
+        missing_text = ", ".join(missing)
+        try:
+            cfg = load_polylogue_config()
+            auto_restore = bool(cfg.health_fts_auto_restore)
+        except Exception:
+            auto_restore = False
+
+        if not auto_restore:
+            message = (
+                f"FTS trigger drift: {len(missing)}/{len(_EXPECTED_FTS_TRIGGERS)} missing "
+                f"({missing_text}); restore with `{restore_cmd}` "
+                "(rebuild ~O(messages))"
+            )
+            return HealthAlert(
+                check_name="fts_trigger_drift",
+                tier=HealthTier.FAST,
+                severity=HealthSeverity.CRITICAL,
+                message=message,
+                checked_at=now,
+                consecutive_failures=_record_failure("fts_trigger_drift", False),
+            )
+
+        try:
+            restored, success, detail = _auto_restore_fts_triggers(dbf)
+        except Exception as exc:
+            return HealthAlert(
+                check_name="fts_trigger_drift",
+                tier=HealthTier.FAST,
+                severity=HealthSeverity.CRITICAL,
+                message=(
+                    f"FTS trigger drift: {len(missing)} missing ({missing_text}); "
+                    f"auto-restore failed: {exc}; restore manually with `{restore_cmd}`"
+                ),
+                checked_at=now,
+                consecutive_failures=_record_failure("fts_trigger_drift", False),
+            )
+
+        if success:
+            logger.info(
+                "daemon.health.fts_trigger_drift: auto-restored %d trigger(s): %s",
+                len(restored),
+                ", ".join(restored),
+            )
+            # Surface a WARNING-level recovery event so the notification
+            # backend forwards it to the operator — silent self-heal
+            # would hide the precipitating SIGKILL/suspension-leak.
+            return HealthAlert(
+                check_name="fts_trigger_drift",
+                tier=HealthTier.FAST,
+                severity=HealthSeverity.WARNING,
+                message=f"FTS trigger drift auto-recovered: {detail}",
+                checked_at=now,
+                consecutive_failures=_record_failure("fts_trigger_drift", True),
+            )
+
+        return HealthAlert(
+            check_name="fts_trigger_drift",
+            tier=HealthTier.FAST,
+            severity=HealthSeverity.CRITICAL,
+            message=(f"FTS trigger drift: {detail}; restore manually with `{restore_cmd}`"),
+            checked_at=now,
+            consecutive_failures=_record_failure("fts_trigger_drift", False),
+        )
+    except Exception as exc:
+        return HealthAlert(
+            check_name="fts_trigger_drift",
+            tier=HealthTier.FAST,
+            severity=HealthSeverity.ERROR,
+            message=f"FTS trigger drift check failed: {exc}",
+            checked_at=now,
+            consecutive_failures=_record_failure("fts_trigger_drift", False),
+        )
+
+
 def _check_schema_version_fast() -> HealthAlert:
     """Compare the on-disk ``PRAGMA user_version`` to the runtime ``SCHEMA_VERSION``.
 
@@ -362,6 +565,7 @@ def _run_fast_checks() -> list[HealthAlert]:
         _check_disk_space_fast(),
         _check_wal_size_fast(),
         _check_source_availability_fast(),
+        _check_fts_trigger_drift_fast(),
     ]
 
 
@@ -965,7 +1169,10 @@ __all__ = [
     "HealthAlert",
     "HealthSeverity",
     "HealthTier",
+    "_EXPECTED_FTS_TRIGGERS",
+    "_check_fts_trigger_drift_fast",
     "_check_schema_version_fast",
+    "_find_missing_fts_triggers",
     "check_health",
     "format_health_lines",
 ]

--- a/tests/unit/daemon/test_fts_trigger_drift.py
+++ b/tests/unit/daemon/test_fts_trigger_drift.py
@@ -1,0 +1,380 @@
+"""FTS sync-trigger drift detection and auto-restore (#1229).
+
+The daemon's FAST tier inspects the six canonical FTS triggers
+(``messages_fts_a{i,d,u}`` + ``action_events_fts_a{i,d,u}``) every health
+cycle. A SIGKILL during the bulk-write suspension window (see
+``docs/internals.md`` "FTS5 Model") leaves these triggers dropped and
+silently corrupts search.
+
+This module pins three behaviors:
+
+1. Healthy archive → check is OK.
+2. Missing trigger → check is CRITICAL with the missing-trigger name in
+   the alert message and a restore command suggestion.
+3. With ``[health] fts_auto_restore = true`` configured, the missing
+   triggers are restored in place and the FTS index is rebuilt; the
+   alert is downgraded to WARNING ("auto-recovered") so the operator
+   is still notified that drift happened, and a follow-up check
+   returns to OK.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from polylogue.daemon import health as health_module
+from polylogue.daemon.health import (
+    _EXPECTED_FTS_TRIGGERS,
+    HealthSeverity,
+    HealthTier,
+    _check_fts_trigger_drift_fast,
+    _find_missing_fts_triggers,
+)
+from polylogue.paths import db_path
+from polylogue.storage.fts.fts_lifecycle import (
+    ensure_fts_index_sync,
+    restore_fts_triggers_sync,
+)
+
+# Minimal table shapes needed for the FTS rebuild path to execute. We do
+# not need to mirror the full schema; the auto-restore touches only the
+# FTS5 control surface and the source tables it reads from.
+_MESSAGES_TABLE_SQL = """
+CREATE TABLE IF NOT EXISTS messages (
+    message_id TEXT PRIMARY KEY,
+    conversation_id TEXT NOT NULL,
+    text TEXT
+)
+"""
+
+_ACTION_EVENTS_TABLE_SQL = """
+CREATE TABLE IF NOT EXISTS action_events (
+    event_id TEXT PRIMARY KEY,
+    message_id TEXT,
+    conversation_id TEXT NOT NULL,
+    action_kind TEXT NOT NULL,
+    normalized_tool_name TEXT,
+    search_text TEXT
+)
+"""
+
+
+@pytest.fixture(autouse=True)
+def _reset_failure_counts() -> Iterator[None]:
+    """Each test starts with an empty consecutive-failure map."""
+    health_module._failure_counts.clear()
+    yield
+    health_module._failure_counts.clear()
+
+
+def _seed_archive_with_triggers(path: Path) -> None:
+    """Bootstrap the minimal table set + the canonical FTS triggers.
+
+    The check is schema-agnostic — it only reads ``sqlite_schema`` — but
+    the auto-restore path needs ``messages`` and ``action_events`` to
+    exist (because the FTS5 ``rebuild`` command reads from them).
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(path))
+    try:
+        conn.execute(_MESSAGES_TABLE_SQL)
+        conn.execute(_ACTION_EVENTS_TABLE_SQL)
+        ensure_fts_index_sync(conn)
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _drop_trigger(path: Path, name: str) -> None:
+    conn = sqlite3.connect(str(path))
+    try:
+        conn.execute(f"DROP TRIGGER IF EXISTS {name}")
+        conn.commit()
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Healthy / inventory contract
+# ---------------------------------------------------------------------------
+
+
+def test_expected_fts_trigger_inventory_is_six_canonical_names() -> None:
+    """The contract is six triggers — three per FTS table."""
+    assert len(_EXPECTED_FTS_TRIGGERS) == 6
+    assert set(_EXPECTED_FTS_TRIGGERS) == {
+        "messages_fts_ai",
+        "messages_fts_ad",
+        "messages_fts_au",
+        "action_events_fts_ai",
+        "action_events_fts_ad",
+        "action_events_fts_au",
+    }
+
+
+def test_check_returns_ok_when_database_absent(
+    workspace_env: dict[str, Path],
+) -> None:
+    """Fresh-install path: no DB yet → check passes."""
+    alert = _check_fts_trigger_drift_fast()
+    assert alert.severity == HealthSeverity.OK
+    assert alert.tier == HealthTier.FAST
+    assert "no database yet" in alert.message
+    assert alert.consecutive_failures == 0
+
+
+def test_check_returns_ok_when_all_triggers_present(
+    workspace_env: dict[str, Path],
+) -> None:
+    dbf = db_path()
+    _seed_archive_with_triggers(dbf)
+    alert = _check_fts_trigger_drift_fast()
+    assert alert.severity == HealthSeverity.OK
+    assert alert.tier == HealthTier.FAST
+    assert "all 6 FTS triggers present" in alert.message
+    assert alert.consecutive_failures == 0
+
+
+# ---------------------------------------------------------------------------
+# Drift detection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("dropped", list(_EXPECTED_FTS_TRIGGERS))
+def test_check_detects_any_missing_trigger(
+    workspace_env: dict[str, Path],
+    dropped: str,
+) -> None:
+    """Dropping any of the six canonical triggers must surface as CRITICAL."""
+    dbf = db_path()
+    _seed_archive_with_triggers(dbf)
+    _drop_trigger(dbf, dropped)
+
+    alert = _check_fts_trigger_drift_fast()
+    assert alert.severity == HealthSeverity.CRITICAL
+    assert alert.tier == HealthTier.FAST
+    assert dropped in alert.message
+    assert "restore" in alert.message.lower()
+    assert "polylogue check --repair-fts" in alert.message
+    assert alert.consecutive_failures == 1
+
+
+def test_check_lists_all_missing_triggers_when_several_drop(
+    workspace_env: dict[str, Path],
+) -> None:
+    dbf = db_path()
+    _seed_archive_with_triggers(dbf)
+    _drop_trigger(dbf, "messages_fts_ai")
+    _drop_trigger(dbf, "action_events_fts_ad")
+
+    alert = _check_fts_trigger_drift_fast()
+    assert alert.severity == HealthSeverity.CRITICAL
+    assert "2/6 missing" in alert.message
+    assert "messages_fts_ai" in alert.message
+    assert "action_events_fts_ad" in alert.message
+
+
+def test_find_missing_fts_triggers_helper_returns_canonical_order(
+    workspace_env: dict[str, Path],
+) -> None:
+    dbf = db_path()
+    _seed_archive_with_triggers(dbf)
+    _drop_trigger(dbf, "action_events_fts_au")
+    _drop_trigger(dbf, "messages_fts_ad")
+
+    conn = sqlite3.connect(str(dbf))
+    try:
+        missing = _find_missing_fts_triggers(conn)
+    finally:
+        conn.close()
+    # Order is from _EXPECTED_FTS_TRIGGERS, not from insertion order.
+    assert missing == ["messages_fts_ad", "action_events_fts_au"]
+
+
+# ---------------------------------------------------------------------------
+# Auto-restore (#1229 ambitious expansion)
+# ---------------------------------------------------------------------------
+
+
+def _enable_auto_restore(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Force the health-loop config to flip ``fts_auto_restore`` on.
+
+    Avoids writing a TOML file in tests — the config layer already
+    exposes the flag via ``POLYLOGUE_HEALTH_FTS_AUTO_RESTORE``, which
+    ``load_polylogue_config`` consumes through the env-override layer.
+    """
+    monkeypatch.setenv("POLYLOGUE_HEALTH_FTS_AUTO_RESTORE", "1")
+
+
+def test_auto_restore_repairs_missing_triggers_and_warns(
+    workspace_env: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With auto-restore on, drift self-heals and the alert is WARNING."""
+    dbf = db_path()
+    _seed_archive_with_triggers(dbf)
+    _drop_trigger(dbf, "messages_fts_au")
+    _drop_trigger(dbf, "action_events_fts_ai")
+
+    _enable_auto_restore(monkeypatch)
+
+    alert = _check_fts_trigger_drift_fast()
+    assert alert.severity == HealthSeverity.WARNING
+    assert alert.tier == HealthTier.FAST
+    assert "auto-recovered" in alert.message
+    assert "messages_fts_au" in alert.message
+    assert "action_events_fts_ai" in alert.message
+    # WARNING is a healthy outcome for the consecutive-failure counter:
+    # the check ultimately succeeded, so the counter resets.
+    assert alert.consecutive_failures == 0
+
+    # The triggers must actually be back on disk.
+    conn = sqlite3.connect(str(dbf))
+    try:
+        missing = _find_missing_fts_triggers(conn)
+    finally:
+        conn.close()
+    assert missing == []
+
+    # The next health cycle returns to OK.
+    next_alert = _check_fts_trigger_drift_fast()
+    assert next_alert.severity == HealthSeverity.OK
+    assert "all 6 FTS triggers present" in next_alert.message
+
+
+def test_auto_restore_disabled_by_default_keeps_alert_critical(
+    workspace_env: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without the opt-in flag, drift surfaces as CRITICAL even on a healable archive."""
+    dbf = db_path()
+    _seed_archive_with_triggers(dbf)
+    _drop_trigger(dbf, "messages_fts_ai")
+    # Ensure the env var is not leaking in.
+    monkeypatch.delenv("POLYLOGUE_HEALTH_FTS_AUTO_RESTORE", raising=False)
+
+    alert = _check_fts_trigger_drift_fast()
+    assert alert.severity == HealthSeverity.CRITICAL
+    # The trigger is still missing — no repair was attempted.
+    conn = sqlite3.connect(str(dbf))
+    try:
+        missing = _find_missing_fts_triggers(conn)
+    finally:
+        conn.close()
+    assert "messages_fts_ai" in missing
+
+
+def test_auto_restore_failure_falls_back_to_critical(
+    workspace_env: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the auto-restore raises, the alert remains CRITICAL with the cause."""
+    dbf = db_path()
+    _seed_archive_with_triggers(dbf)
+    _drop_trigger(dbf, "messages_fts_ai")
+    _enable_auto_restore(monkeypatch)
+
+    def _boom(_db: object) -> tuple[list[str], bool, str]:
+        raise RuntimeError("simulated restore failure")
+
+    monkeypatch.setattr(health_module, "_auto_restore_fts_triggers", _boom)
+
+    alert = _check_fts_trigger_drift_fast()
+    assert alert.severity == HealthSeverity.CRITICAL
+    assert "auto-restore failed" in alert.message
+    assert "simulated restore failure" in alert.message
+    assert "polylogue check --repair-fts" in alert.message
+    assert alert.consecutive_failures == 1
+
+
+# ---------------------------------------------------------------------------
+# Notification-backend integration
+# ---------------------------------------------------------------------------
+
+
+def test_drift_alert_routes_through_notification_backend(
+    workspace_env: dict[str, Path],
+) -> None:
+    """The CRITICAL drift alert flows through send_notifications uniformly."""
+    from polylogue.daemon.health import HealthAlert
+    from polylogue.daemon.notifications import send_notifications
+
+    dbf = db_path()
+    _seed_archive_with_triggers(dbf)
+    _drop_trigger(dbf, "messages_fts_ai")
+    alert = _check_fts_trigger_drift_fast()
+    assert alert.severity == HealthSeverity.CRITICAL
+
+    seen: list[HealthAlert] = []
+
+    class _Backend:
+        def notify(
+            self,
+            alerts: list[HealthAlert],
+            *,
+            config: dict[str, object] | None = None,
+        ) -> None:
+            seen.extend(alerts)
+
+    send_notifications([alert], backend=_Backend())
+    assert len(seen) == 1
+    assert seen[0].check_name == "fts_trigger_drift"
+    assert seen[0].severity == HealthSeverity.CRITICAL
+
+
+def test_auto_recovery_alert_routes_through_notification_backend(
+    workspace_env: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The WARNING auto-recovery alert is still forwarded so operators see the self-heal."""
+    from polylogue.daemon.health import HealthAlert
+    from polylogue.daemon.notifications import send_notifications
+
+    dbf = db_path()
+    _seed_archive_with_triggers(dbf)
+    _drop_trigger(dbf, "messages_fts_ai")
+    _enable_auto_restore(monkeypatch)
+
+    alert = _check_fts_trigger_drift_fast()
+    assert alert.severity == HealthSeverity.WARNING
+
+    seen: list[HealthAlert] = []
+
+    class _Backend:
+        def notify(
+            self,
+            alerts: list[HealthAlert],
+            *,
+            config: dict[str, object] | None = None,
+        ) -> None:
+            seen.extend(alerts)
+
+    send_notifications([alert], backend=_Backend())
+    assert len(seen) == 1
+    assert seen[0].check_name == "fts_trigger_drift"
+    assert "auto-recovered" in seen[0].message
+
+
+# ---------------------------------------------------------------------------
+# Helper: the schema-bootstrap path is left untouched by our minimal seed
+# ---------------------------------------------------------------------------
+
+
+def test_restore_fts_triggers_sync_is_idempotent_on_already_healthy_db(
+    workspace_env: dict[str, Path],
+) -> None:
+    """Sanity check on the underlying repair helper used by auto-restore."""
+    dbf = db_path()
+    _seed_archive_with_triggers(dbf)
+    conn = sqlite3.connect(str(dbf))
+    try:
+        restore_fts_triggers_sync(conn)
+        conn.commit()
+        missing = _find_missing_fts_triggers(conn)
+    finally:
+        conn.close()
+    assert missing == []

--- a/tests/unit/daemon/test_health_contract.py
+++ b/tests/unit/daemon/test_health_contract.py
@@ -57,6 +57,7 @@ EXPECTED_FAST_CHECKS: frozenset[str] = frozenset(
         "disk_space",
         "wal_size",
         "source_availability",
+        "fts_trigger_drift",
     }
 )
 EXPECTED_MEDIUM_CHECKS: frozenset[str] = frozenset(


### PR DESCRIPTION
## Summary

Add a fast-tier daemon health check that scans for the six canonical FTS
sync triggers (`messages_fts_a{i,d,u}` + `action_events_fts_a{i,d,u}`)
on every health cycle. Missing triggers surface as CRITICAL with an
operator-facing restore command. With `[health] fts_auto_restore = true`
(or `POLYLOGUE_HEALTH_FTS_AUTO_RESTORE=1`) the daemon restores the
triggers and rebuilds the FTS index in place, then emits a WARNING-level
"auto-recovered" alert so operators still see the self-heal.

## Problem

Per `docs/internals.md` "FTS5 Model", FTS triggers are suspended during
bulk-write windows and restored afterwards. A SIGKILL inside that
window leaves triggers dropped and silently corrupts search results
until the next bulk operation re-installs them. `devtools
daemon-workload-probe` already reports `fts_trigger_state`, but the
daemon itself did not alert on drift — operators learned about the
corruption only when results stopped matching expectations.

## Solution

- `polylogue/daemon/health.py`
  - `_EXPECTED_FTS_TRIGGERS` pins the six canonical trigger names.
  - `_find_missing_fts_triggers()` runs a single
    `SELECT name FROM sqlite_schema WHERE type='trigger' AND name IN (...)`
    on a read-only URI connection — FAST-tier cost.
  - `_check_fts_trigger_drift_fast()` raises CRITICAL on drift, with
    the missing trigger names and a `polylogue check --repair-fts`
    hint in the message.
  - `_auto_restore_fts_triggers()` delegates to the existing
    `storage/fts/fts_lifecycle.py` helpers (`restore_fts_triggers_sync`
    + `rebuild_fts_index_sync`); the check downgrades to WARNING
    ("auto-recovered: ...") on success and stays CRITICAL on restore
    failure with the failure detail appended.
  - Registered into `_run_fast_checks()` so the alert flows through the
    existing `send_notifications()` dispatch (#1335).
- `polylogue/config.py` exposes `health_fts_auto_restore` (TOML
  `[health] fts_auto_restore`, env `POLYLOGUE_HEALTH_FTS_AUTO_RESTORE`,
  default `false`). The default keeps surprise low — restore is opt-in
  per the alert-only-for-destructive-cases guideline.
- `docs/daemon.md` documents the new fast-tier check and the
  auto-restore flag.
- `tests/unit/daemon/test_fts_trigger_drift.py` covers: healthy archive,
  every individual missing-trigger case (parametrized over all six),
  multi-trigger drift, helper canonical-order, auto-restore success
  + idempotent follow-up, default-off behavior, restore-failure
  fallback, and notification-backend routing for both the CRITICAL
  drift alert and the WARNING auto-recovery alert.
- `tests/unit/daemon/test_health_contract.py` adds `fts_trigger_drift`
  to the FAST-tier check inventory contract.
- `docs/plans/file-size-budgets.yaml` grants `polylogue/daemon/health.py`
  ceiling=1250 with a `daemon/health/` submodule split candidate noted.

## Verification

```
$ nix develop -c pytest tests/unit/daemon/test_fts_trigger_drift.py -q
17 passed in 8.52s

$ nix develop -c pytest tests/unit/daemon/ tests/unit/core/test_config.py -q
691 passed in 14.96s

$ nix develop -c devtools verify --quick
... EXIT 0 (total_duration_s 30.29)
```

Closes #1229