### PR TITLE
perf(storage): FTS content-sync for messages_fts + action_events_fts (#1241)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1233,6 +1233,7 @@ These are the commands worth remembering during normal repo work:
 | `devtools build-topology-projection` | Generate docs/plans/topology-target.yaml from the current tree using placement rules. |
 | `devtools render-agents` | Render AGENTS.md from CLAUDE.md and its included files. |
 | `devtools render-all` | Refresh or verify generated docs and agent files. |
+| `devtools render-cli-output-schemas` | Render JSON Schema artifacts for stable CLI output payloads under docs/schemas/cli-output/. |
 | `devtools render-cli-reference` | Render docs/cli-reference.md from live CLI help. |
 | `devtools render-devtools-reference` | Render the command catalog inside docs/devtools.md. |
 | `devtools render-docs-surface` | Render docs/README.md and the README documentation table. |

--- a/polylogue/storage/fts/fts_lifecycle.py
+++ b/polylogue/storage/fts/fts_lifecycle.py
@@ -144,17 +144,19 @@ _MESSAGE_FTS_TRIGGER_DDL = [
 _ACTION_FTS_TRIGGER_DDL = [
     """CREATE TRIGGER IF NOT EXISTS action_events_fts_ai
        AFTER INSERT ON action_events BEGIN
-           INSERT INTO action_events_fts(rowid, event_id, message_id, conversation_id, action_kind, tool_name, text)
+           INSERT INTO action_events_fts(rowid, event_id, message_id, conversation_id, action_kind, normalized_tool_name, search_text)
            VALUES (new.rowid, new.event_id, new.message_id, new.conversation_id, new.action_kind, new.normalized_tool_name, new.search_text);
        END""",
     """CREATE TRIGGER IF NOT EXISTS action_events_fts_ad
        AFTER DELETE ON action_events BEGIN
-           DELETE FROM action_events_fts WHERE rowid = old.rowid;
+           INSERT INTO action_events_fts(action_events_fts, rowid, event_id, message_id, conversation_id, action_kind, normalized_tool_name, search_text)
+           VALUES ('delete', old.rowid, old.event_id, old.message_id, old.conversation_id, old.action_kind, old.normalized_tool_name, old.search_text);
        END""",
     """CREATE TRIGGER IF NOT EXISTS action_events_fts_au
        AFTER UPDATE ON action_events BEGIN
-           DELETE FROM action_events_fts WHERE rowid = old.rowid;
-           INSERT INTO action_events_fts(rowid, event_id, message_id, conversation_id, action_kind, tool_name, text)
+           INSERT INTO action_events_fts(action_events_fts, rowid, event_id, message_id, conversation_id, action_kind, normalized_tool_name, search_text)
+           VALUES ('delete', old.rowid, old.event_id, old.message_id, old.conversation_id, old.action_kind, old.normalized_tool_name, old.search_text);
+           INSERT INTO action_events_fts(rowid, event_id, message_id, conversation_id, action_kind, normalized_tool_name, search_text)
            VALUES (new.rowid, new.event_id, new.message_id, new.conversation_id, new.action_kind, new.normalized_tool_name, new.search_text);
        END""",
 ]
@@ -190,13 +192,13 @@ async def ensure_fts_index_async(conn: aiosqlite.Connection) -> None:
 def rebuild_fts_index_sync(conn: sqlite3.Connection) -> None:
     """Rebuild the full FTS index from persisted archive rows.
 
-    The messages FTS table is configured with ``content='messages'`` (external
-    content). Use the FTS5 'rebuild' control command directly; SQLite rejects
-    'delete-all' for non-contentless tables.
+    Both FTS tables are configured with ``content='<base table>'`` (external
+    content).  The FTS5 'rebuild' control command wipes the index and
+    re-tokenizes from the base table, so an explicit DELETE is unnecessary
+    (and 'delete-all' is rejected for non-contentless tables).
     """
     ensure_fts_index_sync(conn)
     conn.execute(FTS_REBUILD_SQL)
-    conn.execute("DELETE FROM action_events_fts")
     conn.execute(ACTION_FTS_REBUILD_SQL)
 
 
@@ -210,7 +212,6 @@ async def rebuild_fts_index_async(
     """Rebuild the full FTS index from persisted archive rows."""
     await ensure_fts_index_async(conn)
     await conn.execute(FTS_REBUILD_SQL)
-    await conn.execute("DELETE FROM action_events_fts")
     if conversation_ids is not None:
         await repair_fts_index_async(
             conn,
@@ -219,7 +220,6 @@ async def rebuild_fts_index_async(
             progress_desc=progress_desc,
         )
         return
-    await conn.execute(FTS_REBUILD_SQL)
     await conn.execute(ACTION_FTS_REBUILD_SQL)
 
 

--- a/polylogue/storage/fts/sql.py
+++ b/polylogue/storage/fts/sql.py
@@ -24,8 +24,10 @@ FTS_ACTIONS_TABLE_SQL = """
         message_id UNINDEXED,
         conversation_id UNINDEXED,
         action_kind UNINDEXED,
-        tool_name UNINDEXED,
-        text,
+        normalized_tool_name UNINDEXED,
+        search_text,
+        content='action_events',
+        content_rowid='rowid',
         tokenize='unicode61'
     );
 """
@@ -40,16 +42,7 @@ FTS_REBUILD_SQL = """
 """
 
 ACTION_FTS_REBUILD_SQL = """
-    INSERT INTO action_events_fts (rowid, event_id, message_id, conversation_id, action_kind, tool_name, text)
-    SELECT
-        ae.rowid,
-        ae.event_id,
-        ae.message_id,
-        ae.conversation_id,
-        ae.action_kind,
-        ae.normalized_tool_name,
-        ae.search_text
-    FROM action_events ae
+    INSERT INTO action_events_fts(action_events_fts) VALUES('rebuild')
 """
 
 
@@ -87,6 +80,9 @@ def insert_conversation_rows_sql(chunk_size: int) -> str:
 
 def delete_action_rows_sql(chunk_size: int) -> str:
     placeholders = ", ".join("?" for _ in range(chunk_size))
+    # External-content FTS5: DELETE only works when both the base-table row
+    # is reachable (for re-tokenization) AND the FTS rowid is actually
+    # indexed.  Filter against docsize so the statement is idempotent.
     return f"""
         DELETE FROM action_events_fts
         WHERE rowid IN (
@@ -94,13 +90,14 @@ def delete_action_rows_sql(chunk_size: int) -> str:
             FROM action_events ae
             WHERE ae.conversation_id IN ({placeholders})
         )
+        AND rowid IN (SELECT id FROM action_events_fts_docsize)
     """
 
 
 def insert_action_rows_sql(chunk_size: int) -> str:
     placeholders = ", ".join("?" for _ in range(chunk_size))
     return f"""
-        INSERT INTO action_events_fts (rowid, event_id, message_id, conversation_id, action_kind, tool_name, text)
+        INSERT INTO action_events_fts (rowid, event_id, message_id, conversation_id, action_kind, normalized_tool_name, search_text)
         SELECT
             ae.rowid,
             ae.event_id,
@@ -117,7 +114,7 @@ def insert_action_rows_sql(chunk_size: int) -> str:
 def insert_missing_action_rows_sql(chunk_size: int) -> str:
     placeholders = ", ".join("?" for _ in range(chunk_size))
     return f"""
-        INSERT INTO action_events_fts (rowid, event_id, message_id, conversation_id, action_kind, tool_name, text)
+        INSERT INTO action_events_fts (rowid, event_id, message_id, conversation_id, action_kind, normalized_tool_name, search_text)
         SELECT
             ae.rowid,
             ae.event_id,

--- a/polylogue/storage/search/query_builders.py
+++ b/polylogue/storage/search/query_builders.py
@@ -94,7 +94,7 @@ def build_ranked_action_search_query(
         "action_events_fts.message_id",
         "action_events_fts.conversation_id",
         "action_events_fts.action_kind",
-        "action_events_fts.tool_name",
+        "action_events_fts.normalized_tool_name AS tool_name",
         "conversations.provider_name",
         "conversations.source_name",
         "conversations.title",

--- a/polylogue/storage/sqlite/schema_ddl.py
+++ b/polylogue/storage/sqlite/schema_ddl.py
@@ -66,7 +66,9 @@ from polylogue.storage.sqlite.schema_ddl_provider_events import (
     PROVIDER_EVENT_DDL as _PROVIDER_EVENT_DDL,
 )
 
-SCHEMA_VERSION = 3  # Canonical schema. No migration chain: mismatch → re-ingest from source (#1212, #1190, #1240).
+SCHEMA_VERSION = (
+    4  # Canonical schema. No migration chain: mismatch → re-ingest from source (#1212, #1190, #1240, #1241).
+)
 
 
 # Complete target schema applied to fresh databases.

--- a/polylogue/storage/sqlite/schema_ddl_actions.py
+++ b/polylogue/storage/sqlite/schema_ddl_actions.py
@@ -50,15 +50,19 @@ ACTION_FTS_DDL = """
             message_id UNINDEXED,
             conversation_id UNINDEXED,
             action_kind UNINDEXED,
-            tool_name UNINDEXED,
-            text,
+            normalized_tool_name UNINDEXED,
+            search_text,
+            content='action_events',
+            content_rowid='rowid',
             tokenize='unicode61'
         );
 
         CREATE TRIGGER IF NOT EXISTS action_events_fts_ai
         AFTER INSERT ON action_events BEGIN
-            INSERT INTO action_events_fts (rowid, event_id, message_id, conversation_id, action_kind, tool_name, text)
-            VALUES (
+            INSERT INTO action_events_fts (
+                rowid, event_id, message_id, conversation_id,
+                action_kind, normalized_tool_name, search_text
+            ) VALUES (
                 new.rowid,
                 new.event_id,
                 new.message_id,
@@ -71,14 +75,40 @@ ACTION_FTS_DDL = """
 
         CREATE TRIGGER IF NOT EXISTS action_events_fts_ad
         AFTER DELETE ON action_events BEGIN
-            DELETE FROM action_events_fts WHERE rowid = old.rowid;
+            INSERT INTO action_events_fts (
+                action_events_fts, rowid, event_id, message_id, conversation_id,
+                action_kind, normalized_tool_name, search_text
+            ) VALUES (
+                'delete',
+                old.rowid,
+                old.event_id,
+                old.message_id,
+                old.conversation_id,
+                old.action_kind,
+                old.normalized_tool_name,
+                old.search_text
+            );
         END;
 
         CREATE TRIGGER IF NOT EXISTS action_events_fts_au
         AFTER UPDATE ON action_events BEGIN
-            DELETE FROM action_events_fts WHERE rowid = old.rowid;
-            INSERT INTO action_events_fts (rowid, event_id, message_id, conversation_id, action_kind, tool_name, text)
-            VALUES (
+            INSERT INTO action_events_fts (
+                action_events_fts, rowid, event_id, message_id, conversation_id,
+                action_kind, normalized_tool_name, search_text
+            ) VALUES (
+                'delete',
+                old.rowid,
+                old.event_id,
+                old.message_id,
+                old.conversation_id,
+                old.action_kind,
+                old.normalized_tool_name,
+                old.search_text
+            );
+            INSERT INTO action_events_fts (
+                rowid, event_id, message_id, conversation_id,
+                action_kind, normalized_tool_name, search_text
+            ) VALUES (
                 new.rowid,
                 new.event_id,
                 new.message_id,

--- a/tests/unit/storage/test_dead_schema_sweep.py
+++ b/tests/unit/storage/test_dead_schema_sweep.py
@@ -42,8 +42,9 @@ def fresh_schema_db() -> Generator[Mapping[str, sqlite3.Connection], None, None]
 # ---------------------------------------------------------------------------
 
 
-def test_schema_version_is_3() -> None:
-    assert SCHEMA_VERSION == 3
+def test_schema_version_is_4() -> None:
+    # Bumped from 3 → 4 by #1241 (action_events_fts external-content).
+    assert SCHEMA_VERSION == 4
 
 
 def test_content_blocks_table_has_no_media_type_column(fresh_schema_db: Mapping[str, sqlite3.Connection]) -> None:

--- a/tests/unit/storage/test_fts_repair_sql.py
+++ b/tests/unit/storage/test_fts_repair_sql.py
@@ -28,7 +28,9 @@ def test_incremental_fts_repair_deletes_via_base_rowid(test_conn: sqlite3.Connec
     missing_action_sql = " ".join(insert_missing_action_rows_sql(1).split())
     assert "LEFT JOIN action_events_fts_docsize" in missing_action_sql
     assert "LEFT JOIN action_events_fts f" not in missing_action_sql
-    assert "INSERT INTO action_events_fts (rowid," in " ".join(ACTION_FTS_REBUILD_SQL.split())
+    # External-content FTS5 rebuild uses the 'rebuild' control insert
+    # rather than re-projecting every column from action_events (#1241).
+    assert "VALUES('rebuild')" in " ".join(ACTION_FTS_REBUILD_SQL.split())
 
     plan = "\n".join(
         row[3] for row in test_conn.execute(f"EXPLAIN QUERY PLAN {delete_conversation_rows_sql(1)}", ("conv1",))


### PR DESCRIPTION
## Summary

Convert `action_events_fts` from a self-stored FTS5 virtual table into an
external-content view of `action_events`
(`content='action_events', content_rowid='rowid'`).  `messages_fts` was
already on external-content (since #859/b1cc95b5); this PR brings the action
FTS table onto the same footing so both FTS surfaces share one storage
discipline and one trigger pattern.

Schema bump: `SCHEMA_VERSION` 3 → 4.  No migration chain — operators
re-ingest via `polylogue reset --database && polylogued run`
(per `CONTRIBUTING.md` § Schema-Touching Changes and #1212 policy).

Closes #1241.

## Problem

`action_events_fts` was declared without `content=`, so FTS5 stored a full
copy of every event's `search_text`, `normalized_tool_name`, `event_id`,
`message_id`, `conversation_id`, and `action_kind` in the
`action_events_fts_content` shadow table — duplicating data already present
in `action_events`.  `messages_fts` had the same drift class until #859;
the issue (#1241) called for closing the gap on the action FTS surface so
the next FTS-related incident doesn't hit whichever stayed legacy.

## Solution

- `polylogue/storage/sqlite/schema_ddl_actions.py`: FTS5 declaration now
  uses `content='action_events', content_rowid='rowid'`.  Column names
  align with `action_events` (`tool_name` → `normalized_tool_name`,
  `text` → `search_text`) so external-content reads can resolve them by
  name.  Triggers switch from `DELETE FROM action_events_fts WHERE rowid
  = old.rowid` to the FTS5 `'delete'` control insert, matching the
  `messages_fts` pattern (drift-class consistency).
- `polylogue/storage/fts/sql.py`,
  `polylogue/storage/fts/fts_lifecycle.py`: rebuild path uses
  `INSERT INTO action_events_fts(action_events_fts) VALUES('rebuild')`
  instead of re-projecting every column; deletion helpers gate on
  `action_events_fts_docsize` for idempotency (matches the
  `messages_fts` helper); per-row triggers carry the renamed columns.
- `polylogue/storage/search/query_builders.py`: ranked-action search
  CTE aliases `action_events_fts.normalized_tool_name AS tool_name` so
  consumer column names stay stable.
- `polylogue/storage/sqlite/schema_ddl.py`: `SCHEMA_VERSION` 3 → 4.
- Tests: `tests/unit/storage/test_fts_repair_sql.py` updated to assert
  the new rebuild control insert; `test_dead_schema_sweep.py` updated
  to pin `SCHEMA_VERSION == 4`.

Note: `messages_fts` already used external content (since
b1cc95b5 / #859) — this PR does not re-touch its DDL; it only brings the
action FTS table onto the same model.  PR title spans both tables
because issue #1241 framed the work that way and the unified discipline
(both FTS tables now on external content) is the durable claim.

## Verification

- `nix develop -c devtools verify --quick`: `exit_code: 0`.
- `nix develop -c devtools verify --seed-testmon --skip-slow`:
  `8190 passed, 2 xfailed, 0 failed` (pytest in 159 s).
- Focused FTS suite (`tests/unit/storage/test_fts*.py`,
  `test_schema_policy_contracts.py`, `test_action_event_artifacts.py`,
  `test_backend.py`, `tests/unit/pipeline/test_ingest_batch.py`):
  146/146 pass.
- All-unit sweep (`tests/unit/`): 6852 passed, 2 xfailed.
- Storage savings measured on `tier_medium_db` (≈9.2k action events
  over 10k messages):
  - `action_events_fts` shadow tables: 2,007,040 B → 548,864 B
    (**-72.7 %**; -1.46 MB).
  - DB total: 28,602,368 B → 27,041,792 B (-5.5 %; -1.56 MB).
  - Measurement script: standard schema vs. a re-applied old DDL on the
    same seeded `action_events` rows, using `dbstat` to isolate the
    `action_events_fts*` shadow tables.

Issue #1241 asked for "≥2 GB on the lab medium tier".  Medium-tier
production-shape data is ~10 k messages / ~9 k actions; absolute
savings scale roughly linearly with action count (≈160 B per action
event observed here), so the 2 GB figure corresponds to a real-archive
scale (~13 M actions) rather than the medium-tier fixture.  The
percentage saving (72.7 % of the FTS shadow surface) is the
scale-invariant claim landed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)