### PR TITLE
feat(dist): browser extension release artifacts + install docs (#1238)

### DIFF
--- a/.github/workflows/extension-release.yml
+++ b/.github/workflows/extension-release.yml
@@ -1,0 +1,155 @@
+name: Extension Release
+
+# Packages the browser-extension/ Manifest V3 source into Chrome (.zip) and
+# Firefox (.xpi) artifacts, runs web-ext lint and the in-tree manifest
+# validator, captures store-submission screenshots via headless Playwright,
+# and uploads the bundle to the corresponding GitHub Release.
+#
+# Trigger surface:
+#   - tag push v*.*.*    → builds, lints, screenshots, attaches to release
+#   - workflow_dispatch  → dry-run build, uploads only as workflow artifacts
+#   - pull_request paths → build + validate only (no upload), smoke gate
+#
+# Versioning: the build script reads `version` from the [project] table of
+# pyproject.toml and rewrites browser-extension/{manifest.json,package.json}
+# to match. The committed sources are normally kept in sync by the
+# release-please bump PR, but a tag push will re-sync defensively before
+# packaging.
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+  pull_request:
+    paths:
+      - browser-extension/**
+      - .github/workflows/extension-release.yml
+  workflow_dispatch:
+    inputs:
+      upload-release:
+        description: "Upload artifacts to an existing release tag (e.g. v0.2.0)"
+        required: false
+        default: ""
+
+permissions:
+  contents: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: build-validate-screenshot
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: browser-extension
+    outputs:
+      version: ${{ steps.summary.outputs.version }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: browser-extension/package-lock.json
+      - name: Install dependencies
+        run: |
+          if [ -f package-lock.json ]; then
+            npm ci
+          else
+            npm install
+          fi
+      - name: Validate manifest (in-tree, fast)
+        run: npm run validate
+      - name: Lint sources
+        run: npm run lint
+      - name: Unit tests
+        run: npm test
+      - name: Build Chrome zip + Firefox xpi
+        run: npm run build
+      - name: Web-ext lint Firefox xpi
+        run: |
+          set -euo pipefail
+          xpi=$(ls dist/polylogue-browser-capture-*-firefox.xpi | head -n1)
+          npx --yes web-ext@8 lint --self-hosted --source-dir <(unzip -p "$xpi" /dev/null 2>/dev/null || true) || true
+          # web-ext lint actually wants a directory; unpack the xpi.
+          mkdir -p dist/firefox-unpacked
+          unzip -qo "$xpi" -d dist/firefox-unpacked
+          npx --yes web-ext@8 lint --source-dir dist/firefox-unpacked
+      - name: Install Playwright Chromium
+        run: npx --yes playwright@1 install --with-deps chromium
+      - name: Capture submission screenshots
+        run: |
+          npm install --no-save playwright@1
+          npm run screenshots
+      - name: Summarize artifacts
+        id: summary
+        run: |
+          set -euo pipefail
+          version=$(node -e "console.log(require('./dist/build-manifest.json').version)")
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+          echo "Built artifacts for version ${version}:"
+          ls -la dist/
+      - name: Upload workflow artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: browser-extension-${{ steps.summary.outputs.version }}
+          path: |
+            browser-extension/dist/polylogue-browser-capture-*-chrome.zip
+            browser-extension/dist/polylogue-browser-capture-*-firefox.xpi
+            browser-extension/dist/build-manifest.json
+            browser-extension/dist/screenshots/**
+          if-no-files-found: error
+
+  attach-to-release:
+    name: attach-to-release
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/v') || github.event.inputs.upload-release != ''
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+      - name: Download workflow artifacts
+        uses: actions/download-artifact@v6
+        with:
+          name: browser-extension-${{ needs.build.outputs.version }}
+          path: artifacts/
+      - name: Resolve target tag
+        id: tag
+        run: |
+          set -euo pipefail
+          if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
+            tag="${GITHUB_REF_NAME}"
+          else
+            tag="${{ github.event.inputs.upload-release }}"
+          fi
+          if [ -z "${tag}" ]; then
+            echo "no target tag — skipping upload" >&2
+            exit 0
+          fi
+          echo "tag=${tag}" >> "${GITHUB_OUTPUT}"
+      - name: Upload artifacts to release
+        if: steps.tag.outputs.tag != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          set -euo pipefail
+          # `gh release upload --clobber` overwrites identically-named
+          # assets so a retried workflow does not 422 on duplicates.
+          gh release upload "${TAG}" \
+            artifacts/polylogue-browser-capture-*-chrome.zip \
+            artifacts/polylogue-browser-capture-*-firefox.xpi \
+            artifacts/build-manifest.json \
+            --clobber --repo "${GITHUB_REPOSITORY}"
+          # Screenshots are uploaded as a tar.gz so the release page does
+          # not balloon with 18 individual PNGs.
+          tar -C artifacts/screenshots -czf store-screenshots-${TAG}.tar.gz .
+          gh release upload "${TAG}" "store-screenshots-${TAG}.tar.gz" \
+            --clobber --repo "${GITHUB_REPOSITORY}"

--- a/browser-extension/README.md
+++ b/browser-extension/README.md
@@ -5,25 +5,60 @@ sessions into Polylogue.
 
 ## Install
 
+There are three supported installation paths. All of them require the
+local receiver to be running first.
+
 ### 1. Start the receiver
 
 ```bash
-polylogue browser-capture serve
+polylogued browser-capture serve
 ```
 
 Keep this terminal open. The receiver runs on `http://127.0.0.1:8765`.
+For normal long-running use, `polylogued run` starts the receiver together
+with live source watching.
 
-### 2. Load the extension in Chrome / Chromium
+### 2a. Chrome / Chromium — unpacked from a clone
+
+For active development against the in-tree source:
 
 1. Open `chrome://extensions`
 2. Enable **Developer mode** (toggle, top right)
 3. Click **Load unpacked** and select this directory (`browser-extension/`)
 4. Pin the extension to the toolbar so the badge is always visible
 
+### 2b. Chrome / Chromium — packed `.zip` from a release
+
+For users who want a stable artifact rather than a working tree:
+
+1. Download `polylogue-browser-capture-<version>-chrome.zip` from the
+   [latest GitHub release](https://github.com/Sinity/polylogue/releases/latest)
+2. Extract the archive somewhere stable
+3. Open `chrome://extensions`, enable **Developer mode**
+4. Click **Load unpacked** and select the extracted directory
+
+The Chrome Web Store listing is tracked separately (see [#1238 follow-up](
+https://github.com/Sinity/polylogue/issues/1238)); until that lands the
+packed-zip path is the supported install for Chromium browsers.
+
+### 2c. Firefox — `.xpi` temporary install
+
+Download `polylogue-browser-capture-<version>-firefox.xpi` from the same
+release. Firefox temporary install:
+
+1. Visit `about:debugging#/runtime/this-firefox`
+2. Click **Load Temporary Add-on…**
+3. Select the downloaded `.xpi`
+
+Temporary installs are cleared when Firefox restarts. AMO-signed permanent
+installs require store submission, which is tracked as follow-up; until
+then either repeat the temporary install or use Firefox Developer Edition /
+Nightly with `xpinstall.signatures.required = false`.
+
 ### 3. Verify it works
 
 ```bash
-polylogue browser-capture status
+polylogued browser-capture status
 ```
 
 Then navigate to `chatgpt.com` or `claude.ai`. The extension badge should
@@ -84,8 +119,44 @@ npm install
 npm test              # vitest
 npm run test:watch    # watch mode
 npm run lint          # eslint
+npm run validate      # in-tree manifest validation
+npm run build         # build Chrome .zip + Firefox .xpi under dist/
+npm run screenshots   # capture store-submission screenshots (Playwright)
 ```
 
 Tests run against deterministic fixture HTML, not live ChatGPT/Claude pages.
 The receiver contract test verifies envelope compatibility with
 `polylogue/browser_capture/models.py`.
+
+## Release Packaging
+
+The release artifacts are built and attached to GitHub Releases by
+[`.github/workflows/extension-release.yml`](../.github/workflows/extension-release.yml).
+On `v*.*.*` tag push the workflow:
+
+1. Runs the in-tree manifest validator (`npm run validate`)
+2. Runs ESLint + Vitest (incl. build-script regression tests)
+3. Builds `polylogue-browser-capture-<version>-chrome.zip` and
+   `polylogue-browser-capture-<version>-firefox.xpi`
+4. Runs `web-ext lint` against the unpacked Firefox bundle
+5. Captures Playwright screenshots of the popup at Chrome Web Store and
+   AMO submission aspect ratios, bundled as `store-screenshots-<tag>.tar.gz`
+6. Uploads all artifacts to the matching GitHub Release (`gh release upload --clobber`)
+
+The build script reads the canonical project version from the [project]
+table of `pyproject.toml` and rewrites `manifest.json` + `package.json`
+to match before packaging. The Firefox manifest is generated separately
+with a `browser_specific_settings.gecko` block so the same source tree
+ships under both stores.
+
+To rebuild locally:
+
+```bash
+cd browser-extension
+npm install
+npm run build
+ls dist/
+```
+
+`scripts/build.mjs` accepts `--version X.Y.Z` and `--out DIR` for ad-hoc
+runs (release smoke testing, manual store submission, etc.).

--- a/browser-extension/package.json
+++ b/browser-extension/package.json
@@ -7,7 +7,11 @@
   "scripts": {
     "test": "vitest run",
     "test:watch": "vitest",
-    "lint": "eslint src/ tests/"
+    "lint": "eslint src/ tests/",
+    "validate": "node scripts/validate-manifest.mjs",
+    "build": "node scripts/build.mjs",
+    "screenshots": "node scripts/screenshots.mjs",
+    "sync-version": "node scripts/build.mjs --sync-only"
   },
   "devDependencies": {
     "@eslint/js": "^9.0.0",

--- a/browser-extension/scripts/build.mjs
+++ b/browser-extension/scripts/build.mjs
@@ -1,0 +1,213 @@
+#!/usr/bin/env node
+// Build packed browser extension artifacts (Chrome .zip + Firefox .xpi).
+//
+// Usage:
+//   node scripts/build.mjs                  # auto-detect version from pyproject.toml
+//   node scripts/build.mjs --version 0.2.0  # override version explicitly
+//   node scripts/build.mjs --out ./dist     # override output directory
+//
+// Produces:
+//   <out>/polylogue-browser-capture-<version>-chrome.zip
+//   <out>/polylogue-browser-capture-<version>-firefox.xpi
+//
+// Side effect: rewrites browser-extension/manifest.json + package.json
+// "version" fields to match the resolved version so the committed source
+// stays in sync with the published artifact. The Firefox artifact uses a
+// dedicated manifest with browser_specific_settings.gecko populated.
+
+import { execFileSync } from "node:child_process";
+import { createWriteStream, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const EXT_ROOT = resolve(__dirname, "..");
+const REPO_ROOT = resolve(EXT_ROOT, "..");
+const FIREFOX_GECKO_ID = "polylogue-browser-capture@sinity.dev";
+
+function parseArgs(argv) {
+  const args = { version: null, out: join(EXT_ROOT, "dist"), syncOnly: false };
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i];
+    if (a === "--version") {
+      args.version = argv[++i];
+    } else if (a === "--out") {
+      args.out = resolve(argv[++i]);
+    } else if (a === "--sync-only") {
+      args.syncOnly = true;
+    } else if (a === "--help" || a === "-h") {
+      process.stdout.write(
+        "Usage: build.mjs [--version X.Y.Z] [--out DIR] [--sync-only]\n",
+      );
+      process.exit(0);
+    } else {
+      process.stderr.write(`unknown argument: ${a}\n`);
+      process.exit(2);
+    }
+  }
+  return args;
+}
+
+function readPyprojectVersion() {
+  const path = join(REPO_ROOT, "pyproject.toml");
+  const text = readFileSync(path, "utf8");
+  // Restrict to the [project] table to avoid matching [tool.*] version pins.
+  const projectSection = text.split(/^\[/m).find((s) => s.startsWith("project]"));
+  if (!projectSection) throw new Error("no [project] table in pyproject.toml");
+  const match = projectSection.match(/^version\s*=\s*"([^"]+)"/m);
+  if (!match) throw new Error("no version = \"...\" in [project] table");
+  return match[1];
+}
+
+function normalizeChromeVersion(v) {
+  // Chrome Web Store requires manifest version of form 1-4 dot-separated
+  // integers, each <= 65535, no leading zeros. Strip any pre-release/dev
+  // suffix (e.g. "0.2.0.dev1+gabc" → "0.2.0").
+  const cleaned = v.replace(/[+-].*$/, "").replace(/\.dev\d*$/, "");
+  const parts = cleaned.split(".").filter((p) => /^\d+$/.test(p));
+  if (parts.length === 0) throw new Error(`cannot derive chrome version from "${v}"`);
+  return parts.slice(0, 4).join(".");
+}
+
+function syncJsonVersion(path, version) {
+  const original = readFileSync(path, "utf8");
+  const data = JSON.parse(original);
+  if (data.version === version) return false;
+  data.version = version;
+  // Preserve trailing newline if present.
+  const serialized = JSON.stringify(data, null, 2) + (original.endsWith("\n") ? "\n" : "");
+  writeFileSync(path, serialized);
+  return true;
+}
+
+function buildFirefoxManifest(manifest) {
+  const fxManifest = JSON.parse(JSON.stringify(manifest));
+  // Firefox does not yet support "service_worker" in MV3; declare a
+  // scripts-array background fallback in addition.
+  if (fxManifest.background && fxManifest.background.service_worker) {
+    fxManifest.background = {
+      ...fxManifest.background,
+      scripts: [fxManifest.background.service_worker],
+    };
+  }
+  fxManifest.browser_specific_settings = {
+    gecko: {
+      id: FIREFOX_GECKO_ID,
+      strict_min_version: "121.0",
+    },
+  };
+  return fxManifest;
+}
+
+function copyTree(src, dst) {
+  // Use cp -a to preserve permissions; portable across CI runners that
+  // ship Node + coreutils (Linux/macOS). Windows is not supported as a
+  // build host for this artifact.
+  execFileSync("cp", ["-a", `${src}/.`, dst], { stdio: "inherit" });
+}
+
+const ARCHIVE_EXCLUDE_DIRS = new Set(["node_modules", "tests", "scripts", "dist", "screenshots"]);
+const ARCHIVE_EXCLUDE_FILES = new Set([
+  "eslint.config.js",
+  "vitest.config.js",
+  "package-lock.json",
+  ".DS_Store",
+]);
+
+function makeArchive(srcDir, archivePath, kind) {
+  // Try zip(1) first (CI runners ship it). Fall back to Python's
+  // zipfile so the build still runs inside the Nix devshell, which
+  // ships Python but not unzip/zip.
+  const which = (bin) => {
+    try {
+      execFileSync("sh", ["-c", `command -v ${bin}`], { stdio: "pipe" });
+      return true;
+    } catch {
+      return false;
+    }
+  };
+  if (which("zip")) {
+    const args = ["-r", "-q", archivePath, "."];
+    for (const dir of ARCHIVE_EXCLUDE_DIRS) args.push("-x", `${dir}/*`);
+    for (const file of ARCHIVE_EXCLUDE_FILES) args.push("-x", file);
+    execFileSync("zip", args, { cwd: srcDir, stdio: "inherit" });
+  } else {
+    const py = `
+import os, sys, zipfile, pathlib
+root = pathlib.Path(sys.argv[1]).resolve()
+out = pathlib.Path(sys.argv[2]).resolve()
+exclude_dirs = set(${JSON.stringify(Array.from(ARCHIVE_EXCLUDE_DIRS))})
+exclude_files = set(${JSON.stringify(Array.from(ARCHIVE_EXCLUDE_FILES))})
+with zipfile.ZipFile(out, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d not in exclude_dirs]
+        for name in filenames:
+            if name in exclude_files:
+                continue
+            full = pathlib.Path(dirpath) / name
+            zf.write(full, full.relative_to(root).as_posix())
+`;
+    execFileSync("python3", ["-c", py, srcDir, archivePath], { stdio: "inherit" });
+  }
+  process.stdout.write(`built ${kind}: ${relative(EXT_ROOT, archivePath)}\n`);
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const rawVersion = args.version ?? readPyprojectVersion();
+  const version = normalizeChromeVersion(rawVersion);
+  process.stdout.write(`polylogue browser-extension build: version ${version} (raw ${rawVersion})\n`);
+
+  const manifestPath = join(EXT_ROOT, "manifest.json");
+  const packagePath = join(EXT_ROOT, "package.json");
+  syncJsonVersion(manifestPath, version);
+  syncJsonVersion(packagePath, version);
+
+  if (args.syncOnly) {
+    process.stdout.write("sync-only mode — skipping archive build\n");
+    return;
+  }
+
+  if (!existsSync(args.out)) mkdirSync(args.out, { recursive: true });
+
+  const stageRoot = mkdtempSync(join(tmpdir(), "polylogue-ext-build-"));
+  try {
+    // --- Chrome artifact ---
+    const chromeDir = join(stageRoot, "chrome");
+    mkdirSync(chromeDir);
+    copyTree(EXT_ROOT, chromeDir);
+    const chromeArchive = join(args.out, `polylogue-browser-capture-${version}-chrome.zip`);
+    if (existsSync(chromeArchive)) rmSync(chromeArchive);
+    makeArchive(chromeDir, chromeArchive, "chrome zip");
+
+    // --- Firefox artifact ---
+    const firefoxDir = join(stageRoot, "firefox");
+    mkdirSync(firefoxDir);
+    copyTree(EXT_ROOT, firefoxDir);
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+    const fxManifest = buildFirefoxManifest(manifest);
+    writeFileSync(join(firefoxDir, "manifest.json"), JSON.stringify(fxManifest, null, 2) + "\n");
+    const firefoxArchive = join(args.out, `polylogue-browser-capture-${version}-firefox.xpi`);
+    if (existsSync(firefoxArchive)) rmSync(firefoxArchive);
+    makeArchive(firefoxDir, firefoxArchive, "firefox xpi");
+
+    // --- Manifest summary for downstream upload jobs ---
+    const summary = {
+      version,
+      raw_version: rawVersion,
+      artifacts: {
+        chrome: relative(args.out, chromeArchive) || chromeArchive,
+        firefox: relative(args.out, firefoxArchive) || firefoxArchive,
+      },
+      firefox_gecko_id: FIREFOX_GECKO_ID,
+    };
+    writeFileSync(join(args.out, "build-manifest.json"), JSON.stringify(summary, null, 2) + "\n");
+    process.stdout.write("wrote build-manifest.json\n");
+  } finally {
+    rmSync(stageRoot, { recursive: true, force: true });
+  }
+}
+
+main();

--- a/browser-extension/scripts/screenshots.mjs
+++ b/browser-extension/scripts/screenshots.mjs
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+// Capture store-submission screenshots of the extension popup.
+//
+// Renders src/popup.html under headless Chromium via Playwright, with the
+// `chrome.storage.local` / `chrome.runtime` APIs stubbed so the popup
+// shows representative state (online, supported page, last capture).
+// Captures the Chrome Web Store + AMO required aspect ratios:
+//
+//   1280x800  (Chrome Web Store small tile)
+//    640x400  (Chrome Web Store small tile alt)
+//    750x1334 (AMO mobile)
+//
+// Usage:
+//   node scripts/screenshots.mjs [--out DIR]
+//
+// Skips gracefully if Playwright is not installed. CI installs it via
+// `npx playwright install chromium`.
+
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const EXT_ROOT = resolve(__dirname, "..");
+
+function parseArgs(argv) {
+  const args = { out: join(EXT_ROOT, "dist", "screenshots") };
+  for (let i = 0; i < argv.length; i += 1) {
+    if (argv[i] === "--out") args.out = resolve(argv[++i]);
+  }
+  return args;
+}
+
+const STATES = [
+  {
+    name: "online-captured",
+    storage: {
+      receiverBaseUrl: "http://127.0.0.1:8765",
+      polylogueState: {
+        online: true,
+        captured: true,
+        provider: "chatgpt",
+        title: "Designing a SQLite blob store",
+        captured_at: new Date(Date.now() - 1000 * 60 * 2).toISOString(),
+        site_supported: true,
+        updated_at: new Date().toISOString(),
+      },
+    },
+  },
+  {
+    name: "online-unsupported",
+    storage: {
+      receiverBaseUrl: "http://127.0.0.1:8765",
+      polylogueState: {
+        online: true,
+        captured: false,
+        site_supported: false,
+        updated_at: new Date().toISOString(),
+      },
+    },
+  },
+  {
+    name: "offline",
+    storage: {
+      receiverBaseUrl: "http://127.0.0.1:8765",
+      polylogueState: {
+        online: false,
+        captured: false,
+        site_supported: true,
+        updated_at: new Date().toISOString(),
+      },
+    },
+  },
+];
+
+const SIZES = [
+  { name: "1280x800", width: 1280, height: 800 },
+  { name: "640x400", width: 640, height: 400 },
+  { name: "750x1334", width: 750, height: 1334 },
+];
+
+async function main() {
+  let playwright;
+  try {
+    playwright = await import("playwright");
+  } catch {
+    process.stdout.write("playwright not installed — skipping screenshots\n");
+    process.stdout.write("install with: npx playwright install chromium\n");
+    return;
+  }
+
+  const args = parseArgs(process.argv.slice(2));
+  if (!existsSync(args.out)) mkdirSync(args.out, { recursive: true });
+
+  const popupPath = join(EXT_ROOT, "src", "popup.html");
+  const popupUrl = pathToFileURL(popupPath).toString();
+  const popupJsPath = join(EXT_ROOT, "src", "popup.js");
+  const popupJsSource = readFileSync(popupJsPath, "utf8");
+
+  const browser = await playwright.chromium.launch();
+  try {
+    for (const state of STATES) {
+      for (const size of SIZES) {
+        const context = await browser.newContext({
+          viewport: { width: size.width, height: size.height },
+          deviceScaleFactor: 2,
+        });
+        const page = await context.newPage();
+        // Inject a minimal chrome.* stub before any popup script runs.
+        await page.addInitScript({
+          content: `
+            const __storage = ${JSON.stringify(state.storage)};
+            globalThis.chrome = {
+              storage: {
+                local: {
+                  get: async (defaults) => {
+                    const out = { ...defaults };
+                    for (const key of Object.keys(defaults)) {
+                      if (key in __storage) out[key] = __storage[key];
+                    }
+                    return out;
+                  },
+                  set: async () => {},
+                },
+              },
+              runtime: {
+                sendMessage: async () => ({ ok: true }),
+                onMessage: { addListener: () => {} },
+              },
+              tabs: {
+                query: async () => [{ id: 1, url: "https://chatgpt.com/c/example" }],
+              },
+              action: {
+                setBadgeText: async () => {},
+                setBadgeBackgroundColor: async () => {},
+              },
+            };
+          `,
+        });
+        await page.goto(popupUrl);
+        // The popup is normally driven by chrome.runtime messaging; run
+        // its actual script so we screenshot real layout, not a mock.
+        await page.addScriptTag({ content: popupJsSource });
+        // Allow async fetch-skipping to settle.
+        await page.waitForTimeout(150);
+        const outFile = join(args.out, `popup-${state.name}-${size.name}.png`);
+        await page.screenshot({ path: outFile, fullPage: false });
+        process.stdout.write(`captured ${outFile}\n`);
+        await context.close();
+      }
+    }
+  } finally {
+    await browser.close();
+  }
+}
+
+main().catch((err) => {
+  process.stderr.write(`screenshot capture failed: ${err.stack || err.message}\n`);
+  process.exit(1);
+});

--- a/browser-extension/scripts/validate-manifest.mjs
+++ b/browser-extension/scripts/validate-manifest.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+// Lightweight in-tree manifest validator.
+//
+// Catches the failure modes we have actually hit during local builds before
+// the heavier web-ext lint is invoked from CI. Specifically:
+//   - manifest_version is 3
+//   - version is 1-4 dot-separated integers, each <= 65535
+//   - all content_scripts[*].js paths exist on disk
+//   - background.service_worker exists on disk
+//   - host_permissions do not include "<all_urls>" or "*://*/*"
+//   - permissions list is a subset of an allowlist (no surprising additions)
+//
+// Exit non-zero with a summary on failure. Intended for `npm run validate`
+// and as a pre-archive gate in scripts/build.mjs callers.
+
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const EXT_ROOT = resolve(__dirname, "..");
+
+const ALLOWED_PERMISSIONS = new Set([
+  "activeTab",
+  "scripting",
+  "storage",
+  "tabs",
+]);
+const ALLOWED_HOST_GLOBS = [
+  /^https:\/\/chatgpt\.com\/\*$/,
+  /^https:\/\/claude\.ai\/\*$/,
+  /^http:\/\/127\.0\.0\.1:\d+\/\*$/,
+];
+
+function fail(errors) {
+  process.stderr.write(`manifest validation failed (${errors.length} issues):\n`);
+  for (const err of errors) process.stderr.write(`  - ${err}\n`);
+  process.exit(1);
+}
+
+function validate(manifestPath) {
+  const errors = [];
+  if (!existsSync(manifestPath)) {
+    fail([`manifest not found at ${manifestPath}`]);
+  }
+  const raw = readFileSync(manifestPath, "utf8");
+  let manifest;
+  try {
+    manifest = JSON.parse(raw);
+  } catch (err) {
+    fail([`manifest is not valid JSON: ${err.message}`]);
+  }
+
+  if (manifest.manifest_version !== 3) {
+    errors.push(`manifest_version must be 3, got ${manifest.manifest_version}`);
+  }
+  if (typeof manifest.version !== "string" || !/^\d+(\.\d+){0,3}$/.test(manifest.version)) {
+    errors.push(`version must be 1-4 dot-separated integers, got ${JSON.stringify(manifest.version)}`);
+  } else {
+    for (const part of manifest.version.split(".")) {
+      if (Number.parseInt(part, 10) > 65535) {
+        errors.push(`version component ${part} exceeds Chrome maximum 65535`);
+      }
+    }
+  }
+  if (!manifest.name) errors.push("name is required");
+  if (!manifest.description) errors.push("description is required");
+
+  for (const perm of manifest.permissions ?? []) {
+    if (!ALLOWED_PERMISSIONS.has(perm)) {
+      errors.push(`permission "${perm}" not in allowlist (declared narrowest set)`);
+    }
+  }
+  for (const host of manifest.host_permissions ?? []) {
+    if (host === "<all_urls>" || host === "*://*/*") {
+      errors.push(`host permission "${host}" is too broad`);
+    }
+    const ok = ALLOWED_HOST_GLOBS.some((re) => re.test(host));
+    if (!ok) errors.push(`host_permission "${host}" not in declared allowlist`);
+  }
+
+  const sw = manifest.background?.service_worker;
+  if (sw) {
+    const swPath = join(EXT_ROOT, sw);
+    if (!existsSync(swPath)) errors.push(`background.service_worker missing on disk: ${sw}`);
+  } else if (!manifest.background?.scripts) {
+    errors.push("background must declare service_worker or scripts");
+  }
+  for (const entry of manifest.content_scripts ?? []) {
+    for (const js of entry.js ?? []) {
+      if (!existsSync(join(EXT_ROOT, js))) {
+        errors.push(`content_script js missing on disk: ${js}`);
+      }
+    }
+  }
+  if (manifest.action?.default_popup) {
+    const popup = join(EXT_ROOT, manifest.action.default_popup);
+    if (!existsSync(popup)) errors.push(`action.default_popup missing on disk: ${manifest.action.default_popup}`);
+  }
+
+  if (errors.length > 0) fail(errors);
+  process.stdout.write(`manifest ok: ${manifestPath} (v${manifest.version})\n`);
+}
+
+const manifestPath = process.argv[2]
+  ? resolve(process.argv[2])
+  : join(EXT_ROOT, "manifest.json");
+validate(manifestPath);

--- a/browser-extension/tests/build.test.js
+++ b/browser-extension/tests/build.test.js
@@ -1,0 +1,92 @@
+// Tests for scripts/build.mjs + scripts/validate-manifest.mjs.
+//
+// These exercise the version sync + Firefox manifest transform + archive
+// emission so a future change to the build pipeline cannot silently break
+// the release artifact shape.
+
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const EXT_ROOT = resolve(__dirname, "..");
+const BUILD = join(EXT_ROOT, "scripts", "build.mjs");
+const VALIDATE = join(EXT_ROOT, "scripts", "validate-manifest.mjs");
+const MANIFEST_PATH = join(EXT_ROOT, "manifest.json");
+const PACKAGE_PATH = join(EXT_ROOT, "package.json");
+
+const ORIGINAL_MANIFEST = readFileSync(MANIFEST_PATH, "utf8");
+const ORIGINAL_PACKAGE = readFileSync(PACKAGE_PATH, "utf8");
+
+function restore() {
+  writeFileSync(MANIFEST_PATH, ORIGINAL_MANIFEST);
+  writeFileSync(PACKAGE_PATH, ORIGINAL_PACKAGE);
+}
+
+describe("validate-manifest.mjs", () => {
+  it("accepts the committed manifest", () => {
+    expect(() => execFileSync("node", [VALIDATE], { stdio: "pipe" })).not.toThrow();
+  });
+
+  it("rejects a manifest with an overly broad host permission", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "polylogue-ext-validate-"));
+    try {
+      const broken = JSON.parse(ORIGINAL_MANIFEST);
+      broken.host_permissions = ["<all_urls>"];
+      const path = join(dir, "manifest.json");
+      writeFileSync(path, JSON.stringify(broken, null, 2));
+      let threw = false;
+      try {
+        execFileSync("node", [VALIDATE, path], { stdio: "pipe" });
+      } catch {
+        threw = true;
+      }
+      expect(threw).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("build.mjs", () => {
+  afterEach(restore);
+
+  it("rewrites manifest + package.json to the requested version", () => {
+    execFileSync("node", [BUILD, "--version", "9.8.7", "--sync-only"], { stdio: "pipe" });
+    const manifest = JSON.parse(readFileSync(MANIFEST_PATH, "utf8"));
+    const pkg = JSON.parse(readFileSync(PACKAGE_PATH, "utf8"));
+    expect(manifest.version).toBe("9.8.7");
+    expect(pkg.version).toBe("9.8.7");
+  });
+
+  it("strips dev/pre-release suffixes before writing the Chrome version", () => {
+    execFileSync("node", [BUILD, "--version", "1.2.3.dev4+gabc", "--sync-only"], { stdio: "pipe" });
+    const manifest = JSON.parse(readFileSync(MANIFEST_PATH, "utf8"));
+    expect(manifest.version).toBe("1.2.3");
+  });
+});
+
+describe("build.mjs full archive emission", () => {
+  let outDir;
+  beforeEach(async () => {
+    outDir = await mkdtemp(join(tmpdir(), "polylogue-ext-out-"));
+  });
+  afterEach(() => {
+    rmSync(outDir, { recursive: true, force: true });
+    restore();
+  });
+
+  it("emits chrome zip + firefox xpi with build-manifest.json", () => {
+    execFileSync("node", [BUILD, "--version", "0.9.0", "--out", outDir], { stdio: "pipe" });
+    expect(existsSync(join(outDir, "build-manifest.json"))).toBe(true);
+    expect(existsSync(join(outDir, "polylogue-browser-capture-0.9.0-chrome.zip"))).toBe(true);
+    expect(existsSync(join(outDir, "polylogue-browser-capture-0.9.0-firefox.xpi"))).toBe(true);
+    const summary = JSON.parse(readFileSync(join(outDir, "build-manifest.json"), "utf8"));
+    expect(summary.version).toBe("0.9.0");
+    expect(summary.firefox_gecko_id).toMatch(/@/);
+  });
+});

--- a/devtools/verify_manifests.py
+++ b/devtools/verify_manifests.py
@@ -23,7 +23,18 @@ from polylogue.verification.manifests.models import validate_manifest
 
 _COVERAGE_AXIS_KEYS = ("domain", "subject", "area", "dimension", "artifact", "platform", "concern")
 _COVERAGE_GAP_SEVERITIES = {"info", "minor", "major", "serious"}
-_EVIDENCE_COMMANDS = {"pytest", "ruff", "mypy", "nix", "polylogue", "polylogued", "polylogue-mcp"}
+_EVIDENCE_COMMANDS = {
+    "pytest",
+    "ruff",
+    "mypy",
+    "nix",
+    "polylogue",
+    "polylogued",
+    "polylogue-mcp",
+    # Browser-extension build pipeline (browser-extension/scripts/*.mjs).
+    "npm",
+    "node",
+}
 _COVERAGE_COMMAND_FIELDS = {"generated_by", "verified_by", "verification_command"}
 _COVERAGE_PATH_FIELDS = {"config_location", "location", "path", "strategies_location"}
 _COVERAGE_PATH_LIST_FIELDS = {"locations", "paths_to_mutate", "tests"}

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -271,3 +271,66 @@ nix build .#polylogue           # the package
 nix build .#api-python          # python interpreter with polylogue importable
 nix flake check                 # smoke + format + lint
 ```
+
+## Browser extension
+
+The Manifest V3 browser-capture extension lives in
+[`browser-extension/`](../browser-extension/) and ships as packed artifacts
+attached to every GitHub release by
+[`.github/workflows/extension-release.yml`](../.github/workflows/extension-release.yml).
+
+| Artifact | Browsers | Use |
+| --- | --- | --- |
+| `polylogue-browser-capture-<version>-chrome.zip` | Chrome, Chromium, Edge, Brave, Vivaldi | Developer-mode unpacked install |
+| `polylogue-browser-capture-<version>-firefox.xpi` | Firefox | Temporary install via `about:debugging` |
+| `store-screenshots-<tag>.tar.gz` | — | Submission media for store listings |
+
+Download the artifacts from the
+[latest release](https://github.com/Sinity/polylogue/releases/latest).
+The version is locked to the polylogue Python project version on the same
+tag — the workflow rewrites `manifest.json` from `pyproject.toml` before
+packaging so the extension version always matches the daemon protocol it
+was built against.
+
+### Install paths
+
+The full per-browser steps live in
+[`browser-extension/README.md`](../browser-extension/README.md#install). At
+a glance:
+
+1. **Start the receiver.** `polylogued browser-capture serve` (or
+   `polylogued run` for the full daemon). Default endpoint
+   `http://127.0.0.1:8765`.
+2. **Chrome / Chromium (unpacked from clone).** `chrome://extensions` →
+   Developer mode → Load unpacked → select `browser-extension/`.
+3. **Chrome / Chromium (packed `.zip`).** Download the release `.zip`,
+   extract, then Load unpacked against the extracted directory.
+4. **Firefox.** Download the release `.xpi`. Visit
+   `about:debugging#/runtime/this-firefox` → Load Temporary Add-on → select
+   the `.xpi`.
+
+### Distribution status
+
+| Channel | Status | Tracking |
+| --- | --- | --- |
+| Packed `.zip` on GitHub Releases | shipped | this doc |
+| Packed `.xpi` on GitHub Releases | shipped | this doc |
+| Chrome Web Store | not submitted (store sign-up + review have non-engineering blockers) | follow-up |
+| Mozilla AMO | not submitted (same blockers) | follow-up |
+
+The extension is local-only by design — it talks to `127.0.0.1:8765` and
+nothing else. See [docs/browser-capture.md](browser-capture.md) for the
+receiver protocol and `docs/daemon-threat-model.md` for the security model.
+
+### Local rebuild
+
+```bash
+cd browser-extension
+npm install
+npm run validate    # in-tree manifest validator
+npm run build       # → dist/polylogue-browser-capture-*-{chrome.zip,firefox.xpi}
+npm run screenshots # optional; needs Playwright Chromium
+```
+
+`scripts/build.mjs --version X.Y.Z` overrides the autodetected version when
+producing a one-off bundle.

--- a/docs/plans/distribution-coverage.yaml
+++ b/docs/plans/distribution-coverage.yaml
@@ -103,6 +103,28 @@ artifacts:
       verify-distribution-surface gate exercises the same wheel that
       the Containerfile installs.
 
+  browser_extension:
+    description: Manifest V3 browser extension (Chrome .zip + Firefox .xpi)
+    build_system: node scripts/build.mjs (pure-JS, zip(1) or python zipfile fallback)
+    config_location: browser-extension/manifest.json + browser-extension/scripts/build.mjs
+    build_command: npm run build
+    install_command: chrome://extensions Load unpacked / about:debugging Load Temporary
+    verification_command: npm run validate
+    ci_build: true
+    ci_test: true
+    notes: >
+      Packed Chrome .zip and Firefox .xpi attached to GitHub Releases by
+      .github/workflows/extension-release.yml on vX.Y.Z tag push. The
+      build script reads the canonical project version from the [project]
+      table of pyproject.toml and rewrites browser-extension/manifest.json
+      + package.json to match before packaging. Firefox manifest is a
+      generated variant with browser_specific_settings.gecko populated.
+      web-ext lint runs against the unpacked Firefox bundle as a CI gate.
+      Playwright captures store-submission screenshots at the Chrome Web
+      Store and AMO required aspect ratios. Store submission itself
+      (Chrome Web Store + Mozilla AMO) is tracked separately under
+      coverage_gaps.browser-extension-store.
+
   devshell:
     description: Nix development shell
     build_system: nix flake (devShells.default)
@@ -184,7 +206,7 @@ coverage_gaps:
     next_evidence: devtools verify-distribution-surface
   - id: distribution.browser-extension-store
     artifact: browser_extension
-    gap: Browser extension is unpacked-install only — no Chrome Web Store / AMO submission yet (issue #953 phase 4).
+    gap: Packed .zip/.xpi ship on GitHub releases (#1238), but Chrome Web Store / Mozilla AMO submission still requires non-engineering store sign-up + review.
     owner: distribution
     severity: minor
     declared_at: "2026-05-17"

--- a/docs/verification-catalog.md
+++ b/docs/verification-catalog.md
@@ -8,10 +8,10 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 
 ## Snapshot
 
-- subjects: `606`
+- subjects: `607`
 - claims: `37`
 - runner bindings: `37`
-- proof obligations: `475`
+- proof obligations: `476`
 
 ## Quality Checks
 
@@ -38,7 +38,7 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | `archive.query_law` | 1 |
 | `artifact.path` | 27 |
 | `assurance.coverage_gap` | 20 |
-| `assurance.coverage_item` | 106 |
+| `assurance.coverage_item` | 107 |
 | `assurance.coverage_manifest` | 9 |
 | `cli.command` | 72 |
 | `cli.json_command` | 5 |
@@ -175,7 +175,7 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | `benchmark_coverage` | `assurance.coverage_item` | 5 |
 | `cli_surface` | `assurance.coverage_item` | 2 |
 | `distribution` | `assurance.coverage_gap` | 7 |
-| `distribution` | `assurance.coverage_item` | 9 |
+| `distribution` | `assurance.coverage_item` | 10 |
 | `distribution` | `assurance.coverage_manifest` | 1 |
 | `docs_media` | `assurance.coverage_gap` | 2 |
 | `docs_media` | `assurance.coverage_item` | 17 |
@@ -297,7 +297,7 @@ This catalog is generated from the proof-obligation kernel. It records subjects,
 | `archive.query.provider_filter_consistency` | 1 |
 | `artifact.path.dependency_closure` | 9 |
 | `assurance.coverage.gap_has_closure_path` | 20 |
-| `assurance.coverage.item_declared` | 106 |
+| `assurance.coverage.item_declared` | 107 |
 | `assurance.coverage.manifest_structured` | 9 |
 | `diagnostic.observable_trace_mapping` | 1 |
 | `error.machine_user_context` | 2 |


### PR DESCRIPTION
## Summary

Ship the Manifest V3 browser-capture extension as packed Chrome `.zip` and
Firefox `.xpi` artifacts attached to GitHub Releases, validated by an
in-tree manifest linter + `web-ext lint`, with Playwright-captured store
submission screenshots and three documented install paths.

## Problem

`browser-extension/` had no packed-release path. The only supported install
was a developer-mode unpacked load from a fresh git clone, which is fine for
contributors but not for the broader "I want to capture my Claude.ai
sessions" audience the daemon already serves. #1238 asked for a `.zip` /
`.xpi` release pipeline, install documentation covering Chromium + Firefox,
and ambitious-tier scaffolding for store auto-submission.

## Solution

Build pipeline (`browser-extension/scripts/`):

- `build.mjs` — reads `version` from the `[project]` table of `pyproject.toml`,
  rewrites `browser-extension/manifest.json` + `package.json` in lock-step,
  generates a Firefox manifest variant with `browser_specific_settings.gecko`
  populated, and emits the archives. Uses `zip(1)` when available and falls
  back to Python's `zipfile` so the build runs inside the Nix devshell
  (which ships Python but no `zip`).
- `validate-manifest.mjs` — catches the failure modes we have actually hit:
  overly broad `host_permissions` (`<all_urls>`, `*://*/*`), missing assets
  on disk, Chrome version-format violations, undeclared permissions.
- `screenshots.mjs` — headless Playwright captures of the popup at the
  Chrome Web Store (1280×800, 640×400) and AMO (750×1334) aspect ratios,
  with three representative `chrome.storage.local` states stubbed
  (online-captured, online-unsupported, offline).
- `tests/build.test.js` — vitest regression suite for version sync,
  dev-suffix stripping (`0.2.0.dev1+gabc → 0.2.0`), and end-to-end archive
  emission.

CI (`.github/workflows/extension-release.yml`):

- Triggers: `v*.*.*` tag push, `workflow_dispatch`, and PRs touching
  `browser-extension/**`.
- Runs validate → lint → vitest → build → `web-ext lint` against the
  unpacked Firefox `.xpi` → Playwright screenshots → `gh release upload
  --clobber` against the matching tag. The screenshot pack is bundled as
  a single `store-screenshots-<tag>.tar.gz` so the release page does not
  balloon with 18 PNGs.
- PR runs stop after the build step (no upload), giving a smoke gate for
  changes to the extension or the workflow itself.

Docs:

- `browser-extension/README.md` and `docs/installation.md` document three
  install paths (unpacked-from-clone, packed `.zip`, Firefox `.xpi`
  temporary install). Store submission is documented as a separate
  decision with non-engineering blockers.
- `docs/plans/distribution-coverage.yaml` declares the `browser_extension`
  artifact with `ci_build: true` / `ci_test: true` and updates the
  pre-existing `distribution.browser-extension-store` gap to reflect
  shipping packed artifacts (vs. unpacked-only previously).

Plumbing:

- `devtools/verify_manifests.py` adds `npm` and `node` to the
  `_EVIDENCE_COMMANDS` allowlist so the new manifest entries resolve
  against the workflow `run:` steps.

## Verification

```
nix develop -c devtools verify --quick     # exit_code: 0
cd browser-extension && npm install && npm test
                                          # 46 tests passed (4 files)
cd browser-extension && npm run lint       # eslint clean
cd browser-extension && npm run validate   # manifest ok
cd browser-extension && npm run build      # chrome zip + firefox xpi + build-manifest.json
python3 -c "import zipfile; z=zipfile.ZipFile('dist/polylogue-browser-capture-0.1.0-firefox.xpi'); ..."
                                          # verified gecko block present, service_worker fallback wired
```

## Out of scope (deferred, documented)

- Chrome Web Store / Mozilla AMO actual submission — store sign-up + review
  has non-engineering blockers (developer accounts, branding/policy
  decisions). The artifact pipeline + screenshot pack is ready for a
  one-click submission when the operator has credentials.
- AMO signing for permanent Firefox installs (requires AMO submission).

Closes #1238