### PR TITLE
fix(storage): FTS trigger commit ordering + SIGKILL safety (#1242)

### DIFF
--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -8,6 +8,7 @@ import contextlib
 import faulthandler
 import fcntl
 import os
+import sqlite3
 import sys
 from contextlib import redirect_stdout
 from datetime import UTC, datetime
@@ -72,12 +73,47 @@ def _verify_pidfile(pidfile: Path) -> bool:
         return False
 
 
-async def _ensure_fts_startup_readiness() -> None:
-    """Ensure FTS exists on startup without scanning the full archive.
+_EXPECTED_FTS_TRIGGERS: tuple[str, ...] = (
+    "messages_fts_ai",
+    "messages_fts_ad",
+    "messages_fts_au",
+    "action_events_fts_ai",
+    "action_events_fts_ad",
+    "action_events_fts_au",
+)
+"""Canonical FTS sync triggers (#1242).
 
-    A complete gap can exist when historical rows predate FTS creation. Partial
-    gaps are repaired by conversation-scoped convergence; startup must not count
-    all messages on every daemon restart.
+Mirrors ``polylogue.daemon.health._EXPECTED_FTS_TRIGGERS``. Defined
+here to keep the daemon startup path independent of the health-check
+module's import surface.
+"""
+
+
+def _missing_fts_triggers_sync(conn: sqlite3.Connection) -> list[str]:
+    placeholders = ",".join("?" for _ in _EXPECTED_FTS_TRIGGERS)
+    rows = conn.execute(
+        f"SELECT name FROM sqlite_master WHERE type='trigger' AND name IN ({placeholders})",
+        _EXPECTED_FTS_TRIGGERS,
+    ).fetchall()
+    present = {row[0] for row in rows}
+    return [name for name in _EXPECTED_FTS_TRIGGERS if name not in present]
+
+
+async def _ensure_fts_startup_readiness() -> None:
+    """Ensure FTS triggers and index are healthy on daemon startup.
+
+    Three failure modes are recovered here:
+
+    1. FTS table missing entirely (historical rows pre-date FTS) →
+       rebuild from messages/action_events.
+    2. FTS table exists but is empty while messages exist → rebuild.
+    3. FTS triggers missing (the SIGKILL-during-bulk-suspend signature
+       called out in ``docs/internals.md`` "FTS5 Model → Risk") →
+       restore triggers and rebuild the FTS index. The bulk-ingest
+       path drops these triggers as DDL (auto-committed); a SIGKILL
+       between the drop and the matching restore leaves them gone
+       across process death, and subsequent writes silently bypass the
+       FTS index. See #1242.
     """
     from polylogue.paths import db_path
     from polylogue.storage.sqlite.connection_profile import open_connection
@@ -86,7 +122,7 @@ async def _ensure_fts_startup_readiness() -> None:
     if not db.exists():
         return
 
-    conn = None
+    conn: sqlite3.Connection | None = None
     try:
         conn = open_connection(db, timeout=10.0)
         row = conn.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='messages_fts'").fetchone()
@@ -95,7 +131,11 @@ async def _ensure_fts_startup_readiness() -> None:
             conn.execute("SELECT 1 FROM messages WHERE text IS NOT NULL LIMIT 1").fetchone() is not None
         )
 
-        from polylogue.storage.fts.fts_lifecycle import ensure_fts_index_sync, rebuild_fts_index_sync
+        from polylogue.storage.fts.fts_lifecycle import (
+            ensure_fts_index_sync,
+            rebuild_fts_index_sync,
+            restore_fts_triggers_sync,
+        )
 
         if not has_fts_table:
             logger.warning("daemon: message FTS table missing. Rebuilding once.")
@@ -105,6 +145,25 @@ async def _ensure_fts_startup_readiness() -> None:
             return
 
         ensure_fts_index_sync(conn)
+        # SIGKILL recovery: if any of the six FTS triggers are absent,
+        # a previous bulk-write window was killed between suspend and
+        # restore. ensure_fts_index_sync above re-created them, but the
+        # index itself may have drifted while writes landed without the
+        # trigger sync — rebuild to bring index and source rows back
+        # into agreement.
+        missing_triggers = _missing_fts_triggers_sync(conn)
+        if missing_triggers:
+            logger.warning(
+                "daemon: FTS triggers missing on startup (%s). "
+                "SIGKILL-during-bulk-suspend signature; restoring and rebuilding FTS index.",
+                ", ".join(missing_triggers),
+            )
+            restore_fts_triggers_sync(conn)
+            rebuild_fts_index_sync(conn)
+            conn.commit()
+            logger.info("daemon: FTS trigger restore + rebuild complete.")
+            return
+
         has_indexed_messages = conn.execute("SELECT 1 FROM messages_fts_docsize LIMIT 1").fetchone() is not None
         if has_indexable_messages and not has_indexed_messages:
             logger.warning("daemon: message FTS is empty while archive has messages. Rebuilding once.")
@@ -118,7 +177,7 @@ async def _ensure_fts_startup_readiness() -> None:
         logger.warning("daemon: FTS startup check failed", exc_info=True)
     finally:
         if conn is not None:
-            with __import__("contextlib").suppress(Exception):
+            with contextlib.suppress(Exception):
                 conn.close()
 
 

--- a/polylogue/pipeline/services/ingest_batch/_core.py
+++ b/polylogue/pipeline/services/ingest_batch/_core.py
@@ -11,6 +11,7 @@ Replaces: parsing_batch.py, parsing_workflow.py, validation_flow.py.
 
 from __future__ import annotations
 
+import contextlib
 import os
 import pickle
 import sqlite3
@@ -935,13 +936,22 @@ def _consume_ingest_results(
         )
 
 
-def _commit_ingest_results(
+def _flush_ingest_results(
     conn: sqlite3.Connection,
     *,
     summary: _IngestBatchSummary,
     materialized_ids: set[str],
     pending_by_parent: dict[str, list[_ConversationEntry]],
 ) -> None:
+    """Flush pending conversation entries without committing.
+
+    The commit + FTS trigger restore + FTS repair are deliberately
+    deferred to ``_commit_sync_ingest_side_effects`` so they land as a
+    single atomic write through the archive write gateway (#1242). This
+    closes the gap where row commit and post-commit FTS repair were two
+    separate transactions: if the repair failed, the data was already
+    committed and the FTS index drifted silently.
+    """
     flush_started = time.perf_counter()
     _flush_pending_conversation_entries(
         conn,
@@ -951,17 +961,6 @@ def _commit_ingest_results(
     )
     summary.flush_elapsed_s = time.perf_counter() - flush_started
     _observe_current_rss(summary)
-    # Restore FTS triggers BEFORE commit so they are durable with the data.
-    # CREATE TRIGGER is DDL and auto-commits the pending transaction, so the
-    # explicit conn.commit() below becomes a no-op. If restore fails, the
-    # exception propagates before we mark the batch as committed.
-    # See https://github.com/Sinity/polylogue/issues/817
-    from polylogue.storage.fts.fts_lifecycle import restore_fts_triggers_sync
-
-    restore_fts_triggers_sync(conn)
-    commit_started = time.perf_counter()
-    conn.commit()
-    summary.commit_elapsed_s = time.perf_counter() - commit_started
 
 
 def _commit_sync_ingest_side_effects(
@@ -1033,29 +1032,44 @@ def _process_ingest_batch_sync(
             progress=progress,
             ingest_result_chunk_size=ingest_result_chunk_size,
         )
-        _commit_ingest_results(
+        _flush_ingest_results(
             conn,
             summary=summary,
             materialized_ids=materialized_ids,
             pending_by_parent=pending_by_parent,
         )
         changed_ids = set(summary.changed_conversation_ids)
+        # Side effects (FTS trigger restore + FTS repair + commit) run
+        # BEFORE we release the connection so the data write and post-
+        # write effects share one transaction. The previous arrangement
+        # ran side effects in a `finally` block — they fired even after
+        # a rollback (silently restoring triggers on top of nothing) and
+        # ran AFTER the row commit, so a failure between commit and FTS
+        # repair would leave the index drifted. See #1242.
+        commit_started = time.perf_counter()
+        _commit_sync_ingest_side_effects(
+            conn,
+            db_path=db_path,
+            changed_conversation_ids=tuple(changed_ids),
+            repair_action_fts=repair_action_fts,
+        )
+        summary.commit_elapsed_s = time.perf_counter() - commit_started
     except Exception:
-        conn.rollback()
+        # Roll back the row writes. The suspend DROP TRIGGER auto-
+        # committed (DDL), so we must explicitly restore triggers so the
+        # database is not left in the SIGKILL-style drift state. If the
+        # restore itself fails, we propagate the original exception
+        # (the daemon startup readiness check is the next safety net).
+        with contextlib.suppress(Exception):
+            conn.rollback()
+        from polylogue.storage.fts.fts_lifecycle import restore_fts_triggers_sync
+
+        with contextlib.suppress(Exception):
+            restore_fts_triggers_sync(conn)
+            conn.commit()
         raise
     finally:
-        try:
-            _commit_sync_ingest_side_effects(
-                conn,
-                db_path=db_path,
-                changed_conversation_ids=tuple(changed_ids),
-                repair_action_fts=repair_action_fts,
-            )
-        except Exception:
-            conn.rollback()
-            raise
-        finally:
-            conn.close()
+        conn.close()
     summary.worker_progress_in_flight = len(progress.in_flight_raw_ids)
     summary.worker_progress_completed = progress.completed_raw_count
     summary.worker_progress_total = progress.total_raw_count

--- a/tests/unit/daemon/test_daemon_cli.py
+++ b/tests/unit/daemon/test_daemon_cli.py
@@ -266,11 +266,15 @@ def test_ensure_fts_startup_readiness_uses_bounded_probes(
     db.write_bytes(b"sqlite placeholder")
 
     class FakeCursor:
-        def __init__(self, row: tuple[object, ...] | None) -> None:
+        def __init__(self, row: tuple[object, ...] | None, rows: list[tuple[object, ...]] | None = None) -> None:
             self._row = row
+            self._rows = rows if rows is not None else ([] if row is None else [row])
 
         def fetchone(self) -> tuple[object, ...] | None:
             return self._row
+
+        def fetchall(self) -> list[tuple[object, ...]]:
+            return self._rows
 
     class FakeConnection:
         def __init__(self) -> None:
@@ -283,6 +287,17 @@ def test_ensure_fts_startup_readiness_uses_bounded_probes(
             self.queries.append(query)
             if query == "SELECT name FROM sqlite_master WHERE type='table' AND name='messages_fts'":
                 return FakeCursor(("messages_fts",))
+            if query.startswith("SELECT name FROM sqlite_master WHERE type='trigger'"):
+                # All six FTS triggers present — no SIGKILL-drift recovery.
+                triggers: list[tuple[object, ...]] = [
+                    ("messages_fts_ai",),
+                    ("messages_fts_ad",),
+                    ("messages_fts_au",),
+                    ("action_events_fts_ai",),
+                    ("action_events_fts_ad",),
+                    ("action_events_fts_au",),
+                ]
+                return FakeCursor(triggers[0], rows=triggers)
             if query == "SELECT 1 FROM messages WHERE text IS NOT NULL LIMIT 1":
                 return FakeCursor((1,))
             if query == "SELECT 1 FROM messages_fts_docsize LIMIT 1":
@@ -329,11 +344,15 @@ def test_ensure_fts_startup_readiness_rebuilds_empty_fts(
     db.write_bytes(b"sqlite placeholder")
 
     class FakeCursor:
-        def __init__(self, row: tuple[object, ...] | None) -> None:
+        def __init__(self, row: tuple[object, ...] | None, rows: list[tuple[object, ...]] | None = None) -> None:
             self._row = row
+            self._rows = rows if rows is not None else ([] if row is None else [row])
 
         def fetchone(self) -> tuple[object, ...] | None:
             return self._row
+
+        def fetchall(self) -> list[tuple[object, ...]]:
+            return self._rows
 
     class FakeConnection:
         def __init__(self) -> None:
@@ -346,6 +365,16 @@ def test_ensure_fts_startup_readiness_rebuilds_empty_fts(
             self.queries.append(query)
             if query == "SELECT name FROM sqlite_master WHERE type='table' AND name='messages_fts'":
                 return FakeCursor(("messages_fts",))
+            if query.startswith("SELECT name FROM sqlite_master WHERE type='trigger'"):
+                triggers: list[tuple[object, ...]] = [
+                    ("messages_fts_ai",),
+                    ("messages_fts_ad",),
+                    ("messages_fts_au",),
+                    ("action_events_fts_ai",),
+                    ("action_events_fts_ad",),
+                    ("action_events_fts_au",),
+                ]
+                return FakeCursor(triggers[0], rows=triggers)
             if query == "SELECT 1 FROM messages WHERE text IS NOT NULL LIMIT 1":
                 return FakeCursor((1,))
             if query == "SELECT 1 FROM messages_fts_docsize LIMIT 1":

--- a/tests/unit/storage/test_fts_trigger_lifecycle.py
+++ b/tests/unit/storage/test_fts_trigger_lifecycle.py
@@ -215,3 +215,106 @@ def test_hypothesis_arbitrary_lifecycle_recoverable(
         assert not unexpected, f"unexpected FTS triggers leaked: {unexpected}"
     finally:
         conn.close()
+
+
+# ---------------------------------------------------------------------------
+# #1242: commit-ordering and SIGKILL-safety regression tests.
+# ---------------------------------------------------------------------------
+
+
+def test_ingest_side_effects_run_in_try_block_not_finally() -> None:
+    """Side effects must NOT be in a finally block (#1242 bug A).
+
+    The previous arrangement ran ``_commit_sync_ingest_side_effects`` in
+    a ``finally`` block, so it fired even after the try block had
+    rolled back — silently restoring triggers on top of nothing, AFTER
+    the data commit had already happened. The regression here is a
+    structural assertion against that shape: the side-effects call must
+    appear inside the try (not the finally) so an exception during the
+    write window propagates without committing.
+    """
+    import ast
+    import inspect
+
+    from polylogue.pipeline.services.ingest_batch import _core
+
+    src = inspect.getsource(_core._process_ingest_batch_sync)
+    tree = ast.parse(src)
+    func = tree.body[0]
+    assert isinstance(func, ast.FunctionDef), "expected a function definition"
+
+    # Find the outer Try in the function body.
+    outer_try: ast.Try | None = None
+    for node in func.body:
+        if isinstance(node, ast.Try):
+            outer_try = node
+            break
+    assert outer_try is not None, "expected an outer try block"
+
+    def _calls_side_effects(stmts: list[ast.stmt]) -> bool:
+        for stmt in stmts:
+            for sub in ast.walk(stmt):
+                if (
+                    isinstance(sub, ast.Call)
+                    and isinstance(sub.func, ast.Name)
+                    and sub.func.id == "_commit_sync_ingest_side_effects"
+                ):
+                    return True
+        return False
+
+    assert _calls_side_effects(outer_try.body), "side effects must run inside try (before commit boundary)"
+    assert not _calls_side_effects(outer_try.finalbody), (
+        "side effects must NOT run in finally (would fire after rollback / after commit)"
+    )
+
+
+def test_sigkill_mid_bulk_recovery_via_daemon_startup(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A bulk-write killed between suspend and restore is recovered on next daemon startup (#1242 bug B).
+
+    Simulates the SIGKILL-during-suspend signature: triggers are dropped
+    and committed, then the "process" dies before restore. The next
+    daemon startup readiness check must detect the missing triggers and
+    rebuild both triggers and the FTS index, restoring the search
+    invariant without operator intervention.
+    """
+    import asyncio
+
+    db_file = tmp_path / "fts_sigkill.db"
+    conn = _bootstrap_fts_db(db_file)
+    try:
+        # Seed two messages so the FTS index has content to rebuild.
+        conn.execute(
+            "INSERT INTO messages (rowid, message_id, conversation_id, text) VALUES (?, ?, ?, ?)",
+            (1, "m1", "c1", "alpha bravo"),
+        )
+        conn.execute(
+            "INSERT INTO messages (rowid, message_id, conversation_id, text) VALUES (?, ?, ?, ?)",
+            (2, "m2", "c1", "charlie delta"),
+        )
+        conn.commit()
+
+        # SIGKILL signature: drop triggers and commit, never restore.
+        suspend_fts_triggers_sync(conn)
+        conn.commit()
+        assert _trigger_names(conn).isdisjoint(_EXPECTED_TRIGGERS)
+    finally:
+        conn.close()
+
+    # New process: daemon startup readiness check must heal the drift.
+    from polylogue.daemon import cli as daemon_cli
+
+    monkeypatch.setattr("polylogue.paths.db_path", lambda: db_file)
+
+    asyncio.run(daemon_cli._ensure_fts_startup_readiness())
+
+    final = sqlite3.connect(str(db_file))
+    try:
+        present = _trigger_names(final)
+        assert set(_EXPECTED_TRIGGERS).issubset(present), (
+            f"daemon startup did not restore all FTS triggers: still missing {set(_EXPECTED_TRIGGERS) - present}"
+        )
+        # FTS index was rebuilt from the persisted messages.
+        indexed = final.execute("SELECT COUNT(*) FROM messages_fts_docsize").fetchone()[0]
+        assert indexed >= 2, f"FTS index not repopulated after recovery: {indexed} rows"
+    finally:
+        final.close()


### PR DESCRIPTION
## Summary

Fix two related FTS trigger lifecycle bugs from #1242 (slice C of #817):
the post-write side effects ran AFTER the row commit in a `finally`
block, and a SIGKILL between trigger-suspend and trigger-restore left
the daemon with no FTS triggers across restarts.

## Problem

**Bug A — commit ordering.** `_process_ingest_batch_sync` ran
`_commit_sync_ingest_side_effects` in a `finally` block, so the
post-commit FTS repair landed in a separate transaction AFTER the row
commit. If the repair raised, data was already durable but the FTS
index drifted silently. The same `finally` also fired after a
`conn.rollback()`, silently restoring triggers on top of nothing and
masking the original exception in some cases.

**Bug B — SIGKILL during bulk suspend.**
`suspend_fts_triggers_sync` is `DROP TRIGGER ...`, which is DDL and
auto-commits the drop. A SIGKILL between the drop and the matching
`restore_fts_triggers_sync` leaves all six FTS triggers absent across
process death, and subsequent writes silently bypass the FTS index.
The daemon startup readiness check rebuilt only when the FTS table was
missing or the docsize shadow was empty — it did not detect this
"triggers gone, stale rows still present" drift signature.

## Solution

- `polylogue/pipeline/services/ingest_batch/_core.py`:
  - Renamed `_commit_ingest_results` → `_flush_ingest_results`; it now
    only flushes pending conversation entries and does not commit.
    The earlier in-function `restore_fts_triggers_sync` + `conn.commit()`
    is removed because the gateway path below performs both atomically.
  - In `_process_ingest_batch_sync`, moved
    `_commit_sync_ingest_side_effects` out of the `finally` block and
    into the try body, immediately after `_flush_ingest_results`.
    This collapses trigger restore + per-conversation FTS repair +
    commit into one effects window through
    `ArchiveWriteGateway.commit_write_sync` →
    `commit_archive_write_effects`.
  - On exception, rollback the row writes and then explicitly
    `restore_fts_triggers_sync` + `conn.commit()` before re-raising, so
    the database is never left in the SIGKILL-drift state from this
    code path.
- `polylogue/daemon/cli.py`:
  - `_ensure_fts_startup_readiness` now enumerates the six canonical
    FTS triggers and, on detected drift (the SIGKILL-during-suspend
    signature), restores triggers and rebuilds the FTS index in one
    startup-time recovery window. Existing FTS-table-missing and
    empty-while-has-messages branches are preserved.
  - Promoted `sqlite3` to a module-level import and replaced the
    inline `__import__("contextlib")` workaround with the module-level
    `contextlib` that already exists.
- `tests/unit/storage/test_fts_trigger_lifecycle.py`:
  - `test_ingest_side_effects_run_in_try_block_not_finally` — AST-level
    structural assertion that pins the commit-ordering fix against
    accidental reversion.
  - `test_sigkill_mid_bulk_recovery_via_daemon_startup` — simulates
    drop + commit + die, runs the daemon startup readiness check in a
    fresh process, asserts trigger restore and FTS rebuild happened.
- `tests/unit/daemon/test_daemon_cli.py`:
  - Existing fake-connection tests teach `FakeCursor.fetchall()` and
    handle the new `sqlite_master WHERE type='trigger'` probe with all
    six expected triggers present (steady-state path).

## Verification

```
nix develop -c pytest tests/unit/storage/test_fts_trigger_lifecycle.py -v
# 7 passed in 13.54s (incl. 2 new #1242 regression tests)

nix develop -c pytest tests/unit/pipeline -x -q
# 336 passed

nix develop -c pytest tests/unit/storage -x -q
# 745 passed

nix develop -c pytest tests/unit/daemon -x -q
# 691 passed

nix develop -c devtools verify --quick
# total_duration_s: 32.37, exit_code: 0
```

Closes #1242. Ref #817.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced daemon startup to automatically detect and restore Full-Text Search indexes if interrupted during prior operations.
* Improved database transaction handling during data ingestion to prevent inconsistent states when errors occur.

## Tests
* Added test coverage for Full-Text Search recovery and resilience under interruption scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sinity/polylogue/pull/1362?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->