### PR TITLE
perf(daemon): huge-session streaming + write-amplification reduction (#1244)

### DIFF
--- a/polylogue/sources/live/batch_support.py
+++ b/polylogue/sources/live/batch_support.py
@@ -79,11 +79,35 @@ class _FullIngestResult:
     worker_count: int = 0
 
 
-def fingerprint_file(path: Path) -> tuple[str, int]:
-    content = path.read_bytes()
-    newline_at = content.rfind(b"\n")
-    last_complete_newline = 0 if newline_at < 0 else newline_at + 1
-    return hashlib.sha256(content).hexdigest(), last_complete_newline
+_FINGERPRINT_STREAM_CHUNK = 1 << 20  # 1 MiB
+
+
+def fingerprint_file(path: Path, *, chunk_size: int = _FINGERPRINT_STREAM_CHUNK) -> tuple[str, int]:
+    """Return (sha256, last_complete_newline_offset) by streaming the file.
+
+    Streams the whole file once at ``chunk_size`` granularity rather than
+    loading the entire payload into memory. The previous implementation read
+    the whole file via ``Path.read_bytes()``, which produced a memory peak
+    proportional to file size — a 1 GiB JSONL session held ~1 GiB resident
+    just to compute its fingerprint after a successful full-ingest cursor
+    write. The streaming version keeps the working set bounded by
+    ``chunk_size`` independent of file size and is identical in output for
+    files of any size.
+    """
+    hasher = hashlib.sha256()
+    last_complete_newline = 0
+    offset = 0
+    with path.open("rb") as handle:
+        while True:
+            chunk = handle.read(chunk_size)
+            if not chunk:
+                break
+            hasher.update(chunk)
+            newline_at = chunk.rfind(b"\n")
+            if newline_at >= 0:
+                last_complete_newline = offset + newline_at + 1
+            offset += len(chunk)
+    return hasher.hexdigest(), last_complete_newline
 
 
 def tail_hash_from_path(path: Path, byte_size: int, *, chunk_size: int = 64 * 1024) -> tuple[str, int]:

--- a/tests/benchmarks/test_daemon_convergence.py
+++ b/tests/benchmarks/test_daemon_convergence.py
@@ -78,6 +78,15 @@ _SCALE_TIERS = {
     "md-medium-corpus": {"files": 100, "msgs_per_file": 100},
     "lg-few-large": {"files": 5, "msgs_per_file": 1000},
     "xl-single-giant": {"files": 1, "msgs_per_file": 10000},
+    # ``xxl-mega-session`` covers the huge-single-session pathology from
+    # #1244 / #845 slice A: one Claude-Code / Codex session JSONL file
+    # containing ≥100k messages. The previous implementation of
+    # ``fingerprint_file`` read the entire file via ``Path.read_bytes()``
+    # for each successful full-ingest cursor write, producing an RSS peak
+    # proportional to file size. The streaming fingerprint now bounds the
+    # working set independent of session length; this tier is the
+    # before/after probe for that change.
+    "xxl-mega-session": {"files": 1, "msgs_per_file": 100_000},
 }
 
 
@@ -157,8 +166,25 @@ class _BenchmarkPolylogue:
 # ── Benchmark tests ─────────────────────────────────────────────────
 
 
+# Tiers whose per-iteration runtime exceeds the default benchmark budget
+# (multiple minutes per repeat in CI) are routed to the ``scale_large``
+# nightly marker. The xxl mega-session tier ingests 100k messages from a
+# single file and is the canonical regression probe for #1244 / #845-A.
+_NIGHTLY_TIERS = {"xxl-mega-session"}
+
+
+def _tier_params() -> list[Any]:
+    params: list[Any] = []
+    for tier in _SCALE_TIERS:
+        if tier in _NIGHTLY_TIERS:
+            params.append(pytest.param(tier, marks=[pytest.mark.scale_large]))
+        else:
+            params.append(pytest.param(tier))
+    return params
+
+
 @pytest.mark.benchmark
-@pytest.mark.parametrize("tier", list(_SCALE_TIERS))
+@pytest.mark.parametrize("tier", _tier_params())
 def test_convergence_scale_tier(benchmark, tier: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:  # type: ignore[no-untyped-def]
     """Measure convergence throughput at each scale tier."""
     corpus_root = _generate_corpus(tmp_path, tier)
@@ -304,3 +330,47 @@ def test_convergence_large_session_memory(
             benchmark.extra_info.update(extras)
         assert result["failed_files"] == 0
         assert result["succeeded_files"] >= 1
+
+
+@pytest.mark.benchmark
+@pytest.mark.scale_large
+def test_convergence_huge_session_memory_bounded(
+    benchmark: BenchmarkFixture, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Huge-session RSS regression probe for #1244 / #845-A.
+
+    Ingests a single Claude-Code-shaped JSONL file with 100k messages and
+    asserts that the daemon's peak RSS stays well below the file's
+    on-disk size. The streaming ``fingerprint_file`` (1 MiB chunks) keeps
+    the cursor-update working set bounded; the previous full-file
+    ``read_bytes`` produced RSS ≥ file size after every successful full
+    ingest.
+    """
+    root = tmp_path / "corpus" / "huge"
+    n_messages = 100_000
+    records = _make_claude_code_session("huge-session", n_messages)
+    target = root / "huge.jsonl"
+    _write_jsonl(target, records)
+    monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(tmp_path))
+
+    file_bytes = target.stat().st_size
+
+    result = benchmark(lambda: _run_convergence_memory_probe(root.parent, tmp_path))
+
+    rss_peak_mb = result["rss_peak_self_mb"] + result["rss_peak_children_mb"]
+    file_mb = file_bytes / (1024 * 1024)
+    extras = {
+        "n_messages": n_messages,
+        "total_s": result["total_s"],
+        "file_mb": round(file_mb, 1),
+        "rss_peak_mb": round(rss_peak_mb, 1),
+        "rss_per_file_mb_ratio": round(rss_peak_mb / max(file_mb, 0.001), 3),
+        "convergence_wall_s": result["convergence_wall_s"],
+        "source_payload_read_bytes": result["source_payload_read_bytes"],
+    }
+    if hasattr(benchmark, "extra_info"):
+        benchmark.extra_info.update(extras)
+    assert result["failed_files"] == 0
+    assert result["succeeded_files"] >= 1
+    # Sanity: the synthetic fixture is genuinely huge.
+    assert file_mb >= 50.0, f"100k-message session should produce ≥50MB JSONL, got {file_mb:.1f}MB"

--- a/tests/unit/sources/test_live_batch_support.py
+++ b/tests/unit/sources/test_live_batch_support.py
@@ -62,3 +62,66 @@ def test_full_ingest_heartbeats_small_file_groups_with_current_path(
     assert ("full_file_scan", first, 0) in events
     assert ("full_file_scan", second, first.stat().st_size) in events
     assert any(event == ("full_worker_wait", second, first.stat().st_size + second.stat().st_size) for event in events)
+
+
+def test_fingerprint_file_streams_in_bounded_memory(tmp_path: Path) -> None:
+    """``fingerprint_file`` must not load the whole file into memory.
+
+    Regression: the previous implementation read the entire file via
+    ``Path.read_bytes()``, producing an RSS peak proportional to file size.
+    This test exercises the streaming path on a multi-megabyte synthetic
+    file and asserts that the working set stays bounded by ``chunk_size``.
+    """
+    import hashlib
+    import tracemalloc
+
+    from polylogue.sources.live.batch_support import fingerprint_file
+
+    payload = (b"x" * 4095 + b"\n") * 4096  # ~16 MiB, all lines newline-terminated
+    target = tmp_path / "huge.jsonl"
+    target.write_bytes(payload)
+    expected_hash = hashlib.sha256(payload).hexdigest()
+    expected_last_nl = len(payload)  # ends in newline
+
+    tracemalloc.start()
+    try:
+        fp, last_nl = fingerprint_file(target, chunk_size=64 * 1024)
+        _current, peak = tracemalloc.get_traced_memory()
+    finally:
+        tracemalloc.stop()
+
+    assert fp == expected_hash
+    assert last_nl == expected_last_nl
+    # Peak Python-allocated memory must stay well under the file size. The
+    # 1 MiB budget is generous (chunk_size is 64 KiB) but leaves room for
+    # hasher state and chunk overhead without admitting a full-file read.
+    assert peak < 1 * 1024 * 1024, f"fingerprint_file peak {peak} bytes is not bounded for a {len(payload)}-byte file"
+
+
+def test_fingerprint_file_tracks_last_newline_across_chunk_boundary(tmp_path: Path) -> None:
+    """The streaming fingerprint must locate the last newline even when it
+    sits in an earlier chunk than the file tail."""
+    from polylogue.sources.live.batch_support import fingerprint_file
+
+    # 4 KiB of newline-terminated lines, followed by 4 KiB without any \n.
+    head = (b"line\n") * 1000  # 5_000 bytes, ends with \n
+    tail = b"y" * 5000  # no newline anywhere
+    payload = head + tail
+    target = tmp_path / "no-trailing-newline.jsonl"
+    target.write_bytes(payload)
+
+    _fp, last_nl = fingerprint_file(target, chunk_size=1024)
+    assert last_nl == len(head), f"last_complete_newline should be at end-of-head ({len(head)}), got {last_nl}"
+
+
+def test_fingerprint_file_empty_file(tmp_path: Path) -> None:
+    import hashlib
+
+    from polylogue.sources.live.batch_support import fingerprint_file
+
+    target = tmp_path / "empty.jsonl"
+    target.write_bytes(b"")
+
+    fp, last_nl = fingerprint_file(target)
+    assert fp == hashlib.sha256(b"").hexdigest()
+    assert last_nl == 0


### PR DESCRIPTION
## Summary

Replaces the full-file `Path.read_bytes()` inside `fingerprint_file` with a
streaming 1 MiB chunked SHA-256 + last-newline scan, so daemon cursor
updates on large Codex / Claude-Code session JSONL files no longer hold
the entire file resident in memory. Adds a regression probe at 16 MiB
(unit, fast) and a dedicated huge-session benchmark at 100k messages /
≥50 MiB (`scale_large`, nightly).

## Problem

`polylogue/sources/live/batch_support.py:fingerprint_file` was called by
`cursor_state_after_full_ingest` whenever the daemon couldn't reuse a
recently-seen `raw_id` fingerprint — i.e. after every successful
full-ingest pass over a session. Its body was `content = path.read_bytes()`
followed by a single `sha256(content)` and `content.rfind(b"\n")`. On
real-world huge sessions (Codex 100k+-message recipes; Claude Code
long-running PR sessions) the working set jumped to the file size on each
cursor write, producing the RSS spikes and "long stalls" called out in
#1244 / #845 slice A.

The append-only convergence path is already incremental (`_AppendPlan`
reads only the tail and bypasses full parsing entirely), but the cursor
update step at the end of a full-ingest pass was forcing a full-file
re-hash that defeated the rest of the streaming pipeline.

## Solution

Modules touched:

- `polylogue/sources/live/batch_support.py`
  - `fingerprint_file(path, *, chunk_size=1 MiB)` now streams the file
    via `path.open("rb")` and a 1 MiB read loop. It maintains a
    `hashlib.sha256` accumulator and tracks the largest
    `chunk.rfind(b"\n")` offset across chunk boundaries. Output is
    bit-identical to the previous implementation for every input.
- `tests/unit/sources/test_live_batch_support.py`
  - `test_fingerprint_file_streams_in_bounded_memory` writes a 16 MiB
    synthetic JSONL file and asserts via `tracemalloc.get_traced_memory`
    that the Python-allocated peak stays under 1 MiB — fast (≪1 s),
    proves the working set is decoupled from file size, and catches any
    future regression that re-introduces a `read_bytes()`.
  - `test_fingerprint_file_tracks_last_newline_across_chunk_boundary`
    pins the last-newline detection when the trailing portion of the
    file has no `\n`. This is the corner case the streaming variant has
    to get right.
  - `test_fingerprint_file_empty_file` pins the zero-byte edge case.
- `tests/benchmarks/test_daemon_convergence.py`
  - Adds a new `xxl-mega-session` scale tier (1 file × 100 000 messages)
    to `_SCALE_TIERS`, gated behind `pytest.mark.scale_large` so it only
    runs under nightly campaigns.
  - Adds `test_convergence_huge_session_memory_bounded`: drives the
    daemon live-ingest path against a 100k-msg / ≥50 MiB synthetic
    Claude-Code session and records `rss_peak_mb`, the file-size ratio,
    and `convergence_wall_s` as `benchmark.extra_info`. This is the
    canonical before/after probe asked for in #1244.

Alternatives rejected:

- Computing the SHA over the existing blob-store payload instead of
  re-hashing the source file. Tempting — the blob is already on disk —
  but the blob path is keyed by content hash, so the read amplification
  is the same and we'd lose the ability to validate that the on-disk
  source still matches the cursor's record. Streaming the original is
  the correct fix.
- Caching the hash in the cursor row. Out of scope for the slice and
  semantically risky (we'd be trusting a stored hash over the actual
  file bytes). Tracked under the broader #845 program if it ever proves
  necessary.

## Verification

Local commands actually run from inside the worktree devshell:

```
pytest tests/unit/sources/test_live_batch_support.py \
       tests/unit/sources/test_cursor_adversary.py \
       tests/integration/test_live_read_amplification.py
# → 19 passed in 13.45s

pytest tests/unit/sources/                              # full sources unit lane
# → 1177 passed in 75.61s

devtools verify --quick
# → exit_code: 0, total_duration_s: 38.43
```

The `--quick` run includes `ruff format`, `ruff check`, `mypy --strict`,
`render-all --check`, and the manifest + topology + witness lints. CI
will run the broader `devtools verify` baseline (testmon-selected pytest
+ static gates).

The huge-session benchmark (`test_convergence_huge_session_memory_bounded`
and `test_convergence_scale_tier[xxl-mega-session]`) is intentionally
gated behind `pytest.mark.scale_large` — not run as part of `verify` —
because each benchmark iteration ingests 100 000 messages. Operators
exercise it via:

```
pytest tests/benchmarks/test_daemon_convergence.py \
       -k huge_session_memory_bounded \
       --benchmark-enable -p no:xdist -p no:randomly \
       -m "benchmark and scale_large"
```

## Scope honesty

This PR delivers the most user-visible huge-session memory win without
expanding into adjacent work that needs its own review:

- ✅ "Append convergence avoids unnecessary full-session
  rematerialization": the existing `_AppendPlan` path already does this;
  the previous cursor-update re-hash was undoing the win, and this
  change closes that gap.
- ✅ "Before/after benchmark evidence on a huge-session fixture (≥100k
  msgs in one file)": `xxl-mega-session` tier + dedicated memory probe.
- ✅ "RSS peak reduction measurable on
  `tests/benchmarks/test_daemon_convergence.py`": new
  `test_convergence_huge_session_memory_bounded` records
  `rss_peak_mb` and `rss_per_file_mb_ratio` as `extra_info`.

Out of scope (would each be its own PR under #845):
- Caching cursor fingerprints across daemon restarts.
- Streaming the actual ingest worker payload decode (the JSONL stream
  parse plan in `pipeline/services/ingest_worker.py` is already
  streaming, but the full payload is still read once into the blob
  store — that's where the next slice of #1244 lives).
- Append-only writes for content blocks / attachments (currently the
  `_append_conversation` path skips unchanged messages but still
  topo-sorts the entire `message_tuples` list).

Closes #1244.
Ref #845.