### PR TITLE
fix(filter): commutativity bug across chatgpt/claude-ai provider params (#1338)

### DIFF
--- a/polylogue/archive/filter/builder.py
+++ b/polylogue/archive/filter/builder.py
@@ -57,6 +57,15 @@ class ConversationFilterBuilderMixin:
         )
 
     def provider(self, *names: Provider | str) -> Self:
+        """Restrict results to one or more providers.
+
+        Multiple calls *accumulate* into a single IN-list with OR
+        semantics — ``.provider("chatgpt").provider("claude-ai")`` yields
+        rows whose provider is chatgpt OR claude-ai, not the empty set.
+        Callers that need replace-on-disagreement semantics must rewrite
+        the plan's ``providers`` field directly. The same OR-accumulation
+        rule applies to :meth:`exclude_provider`.
+        """
         providers = tuple(name if isinstance(name, Provider) else Provider.from_string(name) for name in names)
         return _replace_plan(
             self,
@@ -64,6 +73,7 @@ class ConversationFilterBuilderMixin:
         )
 
     def exclude_provider(self, *names: Provider | str) -> Self:
+        """Exclude one or more providers (OR-accumulating; see :meth:`provider`)."""
         providers = tuple(name if isinstance(name, Provider) else Provider.from_string(name) for name in names)
         return _replace_plan(
             self,

--- a/tests/property/test_filter_chain_laws.py
+++ b/tests/property/test_filter_chain_laws.py
@@ -17,7 +17,7 @@ main independently-testable filter dimensions.
 from __future__ import annotations
 
 import tempfile
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -27,6 +27,7 @@ from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 
 from polylogue import Polylogue
+from polylogue.types import Provider
 from tests.infra.storage_records import ConversationBuilder
 
 # ---------------------------------------------------------------------------
@@ -193,17 +194,24 @@ def _apply_params(filter_obj: Any, params: FilterParams) -> Any:
     """
     plan = filter_obj._plan
     if params.provider is not None:
-        # Provider on the builder replaces a prior provider rather than
-        # intersecting. The monotonicity / commutativity laws (more
-        # constraints → fewer results) only hold when a second provider
-        # filter that disagrees with the first becomes the empty set,
-        # not a different provider's results. Map disagreement to an
-        # impossible provider so the second filter strictly tightens.
-        current_providers = tuple(str(p) for p in plan.providers)
-        if current_providers and params.provider not in current_providers:
-            filter_obj = filter_obj.provider("__no_such_provider__")
+        # ``ConversationFilter.provider`` accumulates names into an IN-list
+        # (OR semantics across the tuple): a second call appends rather than
+        # replaces. The commutativity / monotonicity laws here treat the
+        # composition of two ``FilterParams`` as logical conjunction
+        # (matches A AND matches B). When two provider values disagree,
+        # that conjunction is the empty set. We achieve that by overwriting
+        # the plan's providers tuple with ``(Provider.UNKNOWN,)`` — no
+        # seeded conversation has ``provider == UNKNOWN``, so the predicate
+        # yields zero rows independent of what was there before. (Simply
+        # appending an extra provider name would *grow* the IN-list and
+        # leak rows from the first filter into the result.)
+        params_provider = Provider.from_string(params.provider)
+        current_providers = plan.providers
+        if current_providers and params_provider not in current_providers:
+            filter_obj._plan = replace(plan, providers=(Provider.UNKNOWN,))
+            plan = filter_obj._plan
         else:
-            filter_obj = filter_obj.provider(params.provider)
+            filter_obj = filter_obj.provider(params_provider)
     if params.has_tool_use:
         filter_obj = filter_obj.has_tool_use()
     if params.has_thinking:


### PR DESCRIPTION
## Summary

Fix `test_filter_application_order_is_commutative` (and the adjacent
monotonicity law) by aligning the property-test helper with the actual
`ConversationFilter.provider` contract, and document that contract next
to the builder.

## Problem

`tests/property/test_filter_chain_laws.py::test_filter_application_order_is_commutative`
falsified pre-existing on master with `params_a.provider='chatgpt'` /
`params_b.provider='claude-ai'`:

```
A then B yields: {conv-001..005} (chatgpt rows)
B then A yields: {conv-006..010} (claude-ai rows)
```

The helper had assumed `ConversationFilter.provider(...)` *replaces* a
prior provider when called a second time. The builder actually
accumulates names into a single IN-list (OR semantics), so a chain like
`.provider("chatgpt").provider("claude-ai")` returns rows whose provider
is chatgpt OR claude-ai — not the empty set the law needed.

The previous workaround mapped a disagreement to a sentinel
`.provider("__no_such_provider__")`. `Provider.from_string()` normalizes
unrecognized tokens to `Provider.UNKNOWN`, and that normalization
happens inside `.provider(...)`, so the sentinel collapsed onto a real
enum value and the IN-list still leaked rows.

## Solution

Test-side fix (`tests/property/test_filter_chain_laws.py`): when two
`FilterParams` carry disagreeing providers, overwrite
`filter_obj._plan.providers` directly with `(Provider.UNKNOWN,)`. No
seeded conversation has `provider == UNKNOWN`, so the predicate yields
the intended empty set independently of string normalization. The
agreement branch is unchanged and uses the typed `Provider` value
(rather than re-running `from_string` inside the builder).

Builder-side docstring (`polylogue/archive/filter/builder.py`): add
docstrings on `ConversationFilterBuilderMixin.provider` and
`exclude_provider` documenting the OR-accumulation semantics. The
filter chain itself is unchanged — this is a contract clarification so
future callers don't repeat the misreading that caused the law to
falsify.

Alternatives rejected:

- *Change the builder to replace on second call.* Would break every
  caller that intentionally builds an OR list (CLI `--provider a
  --provider b`, MCP `provider=[...]`, internal facade code).
- *Special-case the sentinel string upstream.* Adds parser noise for a
  test-only concern.

## Verification

Inside `nix develop`:

```bash
pytest -p no:randomly --override-ini="addopts=" \
  tests/property/test_filter_chain_laws.py -v
# 4 passed in 7.95s

devtools verify --quick
# total_duration_s: 35.16, exit_code: 0
```

Closes #1338