### PR TITLE
docs(schema): provider_meta allowlist + classification governance lint (#1255)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1276,6 +1276,7 @@ These are the commands worth remembering during normal repo work:
 | `devtools verify-layering` | Check inter-package imports against declared layering rules from docs/plans/layering.yaml. |
 | `devtools verify-manifests` | Verify internal consistency across all docs/plans/*.yaml manifest files. |
 | `devtools verify-migrations` | Verify migration-completeness against docs/plans/migrations.yaml. |
+| `devtools verify-provider-meta-policy` | Enforce the provider_meta classification policy declared in docs/plans/provider-meta-policy.yaml. |
 | `devtools verify-schema-roundtrip` | Verify committed provider schema packages reload and roundtrip cleanly. |
 | `devtools verify-slos` | Check read-surface latency budgets in docs/plans/slo-catalog.yaml against benchmark measurements. |
 | `devtools verify-suppressions` | Enforce suppression registry expiry dates from docs/plans/suppressions.yaml. |

--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -324,6 +324,21 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
         examples=("devtools verify-file-budgets", "devtools verify-file-budgets --json"),
     ),
     CommandSpec(
+        "verify-provider-meta-policy",
+        "verification",
+        "Enforce the provider_meta classification policy declared in docs/plans/provider-meta-policy.yaml.",
+        "devtools.verify_provider_meta_policy",
+        use_when=(
+            "Block undeclared provider_meta keys and revived tombstones in parsers, "
+            "source-assembly, and insight-rebuild paths. Forces a manifest row whenever "
+            "a new key is written by production code."
+        ),
+        examples=(
+            "devtools verify-provider-meta-policy",
+            "devtools verify-provider-meta-policy --json",
+        ),
+    ),
+    CommandSpec(
         "verify-test-ownership",
         "verification",
         "Verify each production module is imported by at least one unit test.",

--- a/devtools/evidence_dashboard.py
+++ b/devtools/evidence_dashboard.py
@@ -227,6 +227,7 @@ _STATIC_GATE_NAMES: tuple[str, ...] = (
     "verify-topology",
     "verify-layering",
     "verify-file-budgets",
+    "verify-provider-meta-policy",
     "verify-test-ownership",
     "verify-schema-roundtrip",
     "verify-suppressions",

--- a/devtools/verify.py
+++ b/devtools/verify.py
@@ -302,6 +302,10 @@ def build_verify_steps(
                 ("verify-topology", _devtools_cmd("verify-topology")),
                 ("verify-layering", _devtools_cmd("verify-layering")),
                 ("verify-file-budgets", _devtools_cmd("verify-file-budgets")),
+                (
+                    "verify-provider-meta-policy",
+                    _devtools_cmd("verify-provider-meta-policy"),
+                ),
                 ("verify-test-ownership", _devtools_cmd("verify-test-ownership")),
                 ("verify-closure-matrix", _devtools_cmd("verify-closure-matrix")),
                 ("verify-schema-roundtrip", _devtools_cmd("verify-schema-roundtrip", "--all")),

--- a/devtools/verify_provider_meta_policy.py
+++ b/devtools/verify_provider_meta_policy.py
@@ -1,0 +1,317 @@
+"""Enforce the provider_meta classification policy declared in
+``docs/plans/provider-meta-policy.yaml``.
+
+Production parsers, source-assembly modules, and the session-rebuild insight
+loader are scanned for string-literal ``provider_meta`` key writes. Each
+observed key must be declared in the policy manifest with a classification.
+The lint fails on:
+
+- Undeclared keys (new field that requires a manifest row).
+- Stale tombstones (a key marked ``removed`` is still being written).
+- Manifest entries pointing at a key not observed anywhere in the scanned
+  paths (kept as a soft warning so we notice when a parser stops writing a
+  field but the row was not retired to ``removed``).
+
+The lint is intentionally syntactic: it grep-walks production code for
+literal subscripts and ``.get(...)`` reads against the dedicated dict
+variable names ``provider_meta`` and ``conv_meta`` used by the parsers.
+The generic name ``meta`` is intentionally excluded because parsers reuse
+it for upstream provider envelopes, not for our ``provider_meta`` write
+surface. New fields that bypass these patterns will not be detected, and
+that is intended: new ingestion paths still need to land via PR review.
+
+Wired into ``devtools verify --quick``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import sys
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from devtools import repo_root as _get_root
+
+ROOT = _get_root()
+MANIFEST_REL = "docs/plans/provider-meta-policy.yaml"
+
+# Scan paths: production code that writes provider_meta dicts.
+SCAN_ROOTS: tuple[str, ...] = (
+    "polylogue/sources/parsers",
+    "polylogue/sources/assembly_codex.py",
+    "polylogue/sources/assembly_gemini.py",
+    "polylogue/storage/insights/session/rebuild.py",
+)
+
+# Variable names that hold a provider_meta-shaped dict during parser
+# construction. Restricted to the canonical authoring surface — the
+# generic name ``meta`` is intentionally excluded because parsers also
+# use it for upstream provider envelopes (e.g.
+# ``attachment_from_meta(meta=...)``) where a ``.get()`` call reads from
+# a foreign dict, not the provider_meta we own.
+PROVIDER_META_VARS: frozenset[str] = frozenset({"provider_meta", "conv_meta"})
+
+ALLOWED_CLASSIFICATIONS: frozenset[str] = frozenset({"provider-specific-retained", "raw-only", "promoted", "removed"})
+
+
+@dataclass(frozen=True)
+class ManifestField:
+    key: str
+    classification: str
+    scope: str | None
+    providers: tuple[str, ...]
+    promoted_column: str | None
+    note: str | None
+    row_index: int  # for stable reporting
+
+
+@dataclass(frozen=True)
+class Observation:
+    key: str
+    path: str
+    line: int
+
+
+def load_manifest(path: Path) -> list[ManifestField]:
+    data = yaml.safe_load(path.read_text())
+    if not isinstance(data, dict):
+        raise SystemExit(f"{path}: top-level must be a mapping")
+    rows = data.get("fields")
+    if not isinstance(rows, list):
+        raise SystemExit(f"{path}: missing `fields:` list")
+    out: list[ManifestField] = []
+    seen_keys: set[tuple[str, str | None]] = set()
+    for idx, raw_row in enumerate(rows):
+        if not isinstance(raw_row, dict):
+            raise SystemExit(f"{path}: fields[{idx}] is not a mapping")
+        key = raw_row.get("key")
+        classification = raw_row.get("classification")
+        if not isinstance(key, str) or not key:
+            raise SystemExit(f"{path}: fields[{idx}].key must be a non-empty string")
+        if classification not in ALLOWED_CLASSIFICATIONS:
+            raise SystemExit(
+                f"{path}: fields[{idx}].classification={classification!r} not in {sorted(ALLOWED_CLASSIFICATIONS)}"
+            )
+        scope = raw_row.get("scope")
+        if scope is not None and scope not in {"conversation", "message", "attachment"}:
+            raise SystemExit(f"{path}: fields[{idx}].scope={scope!r} must be conversation|message|attachment")
+        dedup_key = (key, scope)
+        if dedup_key in seen_keys:
+            raise SystemExit(f"{path}: duplicate manifest entry for key={key!r} scope={scope!r}")
+        seen_keys.add(dedup_key)
+        providers_raw = raw_row.get("providers", [])
+        providers: tuple[str, ...]
+        if providers_raw is None:
+            providers = ()
+        elif isinstance(providers_raw, list):
+            providers = tuple(str(item) for item in providers_raw)
+        else:
+            raise SystemExit(f"{path}: fields[{idx}].providers must be a list")
+        out.append(
+            ManifestField(
+                key=key,
+                classification=classification,
+                scope=scope,
+                providers=providers,
+                promoted_column=(str(raw_row["promoted_column"]) if "promoted_column" in raw_row else None),
+                note=str(raw_row["note"]) if raw_row.get("note") else None,
+                row_index=idx,
+            )
+        )
+    return out
+
+
+def iter_scan_files(root: Path) -> Iterable[Path]:
+    for rel in SCAN_ROOTS:
+        target = root / rel
+        if target.is_file():
+            yield target
+        elif target.is_dir():
+            for path in target.rglob("*.py"):
+                if "__pycache__" in path.parts:
+                    continue
+                yield path
+
+
+def _string_literal(node: ast.AST) -> str | None:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    return None
+
+
+def collect_observations(path: Path, rel: str) -> list[Observation]:
+    """Walk the AST and collect provider_meta key writes/reads.
+
+    Patterns recognised:
+
+    - ``provider_meta["KEY"] = ...``         (Subscript assignment)
+    - ``provider_meta.get("KEY")``           (.get call)
+    - ``{"KEY": value, ...}`` literal passed as ``provider_meta=`` kwarg
+    - ``meta["KEY"] = ...`` / ``conv_meta[...] = ...`` (same patterns)
+
+    Only string literal keys are observed; dynamic keys are deliberately
+    skipped (they cannot be classified statically).
+    """
+
+    try:
+        tree = ast.parse(path.read_text(), filename=str(path))
+    except SyntaxError:
+        return []
+
+    observations: list[Observation] = []
+
+    def _record(key: str, line: int) -> None:
+        observations.append(Observation(key=key, path=rel, line=line))
+
+    for node in ast.walk(tree):
+        # provider_meta["KEY"] = ...   and   provider_meta["KEY"] inside expressions
+        if isinstance(node, ast.Subscript) and isinstance(node.value, ast.Name) and node.value.id in PROVIDER_META_VARS:
+            literal = _string_literal(node.slice)
+            if literal is not None:
+                _record(literal, node.lineno)
+
+        # provider_meta.get("KEY", ...)
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id in PROVIDER_META_VARS
+            and node.func.attr in {"get", "setdefault", "pop"}
+            and node.args
+        ):
+            literal = _string_literal(node.args[0])
+            if literal is not None:
+                _record(literal, node.lineno)
+
+        # provider_meta={"KEY": ...} as a keyword argument
+        if isinstance(node, ast.keyword) and node.arg == "provider_meta":
+            value = node.value
+            if isinstance(value, ast.Dict):
+                for k in value.keys:
+                    if k is None:
+                        continue
+                    literal = _string_literal(k)
+                    if literal is not None:
+                        _record(literal, k.lineno)
+
+    return observations
+
+
+def lint(root: Path, manifest_path: Path) -> dict[str, Any]:
+    fields = load_manifest(manifest_path)
+    declared_by_key: dict[str, list[ManifestField]] = {}
+    for field in fields:
+        declared_by_key.setdefault(field.key, []).append(field)
+
+    observations: list[Observation] = []
+    for path in iter_scan_files(root):
+        rel = path.relative_to(root).as_posix()
+        observations.extend(collect_observations(path, rel))
+
+    observed_keys: dict[str, list[Observation]] = {}
+    for obs in observations:
+        observed_keys.setdefault(obs.key, []).append(obs)
+
+    undeclared: list[dict[str, Any]] = []
+    revived_tombstones: list[dict[str, Any]] = []
+    unobserved_declared: list[str] = []
+
+    for key, obs_list in sorted(observed_keys.items()):
+        declared = declared_by_key.get(key)
+        if not declared:
+            sample = obs_list[0]
+            undeclared.append(
+                {
+                    "key": key,
+                    "first_seen": f"{sample.path}:{sample.line}",
+                    "write_count": len(obs_list),
+                }
+            )
+            continue
+        if all(field.classification == "removed" for field in declared):
+            sample = obs_list[0]
+            revived_tombstones.append(
+                {
+                    "key": key,
+                    "first_seen": f"{sample.path}:{sample.line}",
+                    "write_count": len(obs_list),
+                }
+            )
+
+    for key, declared in sorted(declared_by_key.items()):
+        if key in observed_keys:
+            continue
+        # If declared as `removed`, absence is expected; otherwise flag soft.
+        if all(field.classification == "removed" for field in declared):
+            continue
+        unobserved_declared.append(key)
+
+    blocking = bool(undeclared or revived_tombstones)
+
+    return {
+        "blocking": blocking,
+        "manifest": manifest_path.relative_to(root).as_posix(),
+        "scanned_paths": list(SCAN_ROOTS),
+        "declared_count": len(fields),
+        "observed_key_count": len(observed_keys),
+        "undeclared": undeclared,
+        "revived_tombstones": revived_tombstones,
+        "unobserved_declared": unobserved_declared,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", type=Path, default=ROOT / MANIFEST_REL)
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+
+    report = lint(ROOT, args.manifest)
+
+    if args.json:
+        json.dump(report, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+    else:
+        manifest = report["manifest"]
+        print(f"provider_meta policy: {manifest}")
+        print(f"    declared fields: {report['declared_count']}")
+        print(f"    observed keys:   {report['observed_key_count']}")
+        if report["undeclared"]:
+            print(f"[BLOCK] undeclared provider_meta keys: {len(report['undeclared'])}")
+            for row in report["undeclared"]:
+                print(f"    {row['key']} (first at {row['first_seen']}, writes={row['write_count']})")
+            print(
+                "    Add each key to docs/plans/provider-meta-policy.yaml with a classification "
+                "(provider-specific-retained | raw-only | promoted | removed)."
+            )
+        if report["revived_tombstones"]:
+            print(
+                f"[BLOCK] revived tombstones (manifest says removed but code still writes): "
+                f"{len(report['revived_tombstones'])}"
+            )
+            for row in report["revived_tombstones"]:
+                print(f"    {row['key']} (first at {row['first_seen']})")
+        if report["unobserved_declared"]:
+            print(f"[warn] manifest entries with no observed writes: {len(report['unobserved_declared'])}")
+            for key in report["unobserved_declared"]:
+                print(f"    {key}")
+            print(
+                "    Either restore the writer, retire the row with classification=removed, "
+                "or accept the soft warning if the key is written behind a dynamic pattern."
+            )
+        if not report["undeclared"] and not report["revived_tombstones"] and not report["unobserved_declared"]:
+            print("provider_meta policy: clean")
+        print()
+        print(f"blocking={report['blocking']}")
+
+    return 1 if report["blocking"] else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -127,6 +127,7 @@ These are the commands worth remembering during normal repo work:
 | `devtools verify-layering` | Check inter-package imports against declared layering rules from docs/plans/layering.yaml. |
 | `devtools verify-manifests` | Verify internal consistency across all docs/plans/*.yaml manifest files. |
 | `devtools verify-migrations` | Verify migration-completeness against docs/plans/migrations.yaml. |
+| `devtools verify-provider-meta-policy` | Enforce the provider_meta classification policy declared in docs/plans/provider-meta-policy.yaml. |
 | `devtools verify-schema-roundtrip` | Verify committed provider schema packages reload and roundtrip cleanly. |
 | `devtools verify-slos` | Check read-surface latency budgets in docs/plans/slo-catalog.yaml against benchmark measurements. |
 | `devtools verify-suppressions` | Enforce suppression registry expiry dates from docs/plans/suppressions.yaml. |

--- a/docs/plans/provider-meta-policy.yaml
+++ b/docs/plans/provider-meta-policy.yaml
@@ -1,0 +1,545 @@
+# Provider-meta classification policy.
+#
+# Source of truth for every `provider_meta` key that production parsers, source
+# assembly, or insight rebuild paths write into either:
+#
+#   - conversation.provider_meta  (ParsedConversation / ConversationRecord)
+#   - message.provider_meta       (ParsedMessage / HarmonizedMessage)
+#   - attachment.provider_meta    (ParsedAttachment)
+#
+# Every key currently written by production code must appear here with a
+# classification. Adding a new key is a code change that requires a manifest
+# row in the same PR; the `devtools verify-provider-meta-policy` lint enforces
+# this at `devtools verify --quick` time.
+#
+# Classifications
+# ===============
+#
+# provider-specific-retained
+#   The field is provider/source-specific and stays inside provider_meta. It is
+#   not promoted to a typed column on conversations/messages because there is
+#   no useful cross-provider semantics for it; downstream code reads it via
+#   provider_meta when it needs the provider-shaped detail. Examples: ChatGPT
+#   gizmo identifiers, Gemini grounding metadata.
+#
+# raw-only
+#   The field carries the verbatim provider payload (`"raw"`, `"chunk"`,
+#   per-message untyped envelopes). It is not part of the harmonized read
+#   surface — it exists so debugging and replay can reach the original shape.
+#   Lint allows these keys but they are documented as never load-bearing for
+#   archive semantics.
+#
+# promoted
+#   The field is semantically universal (cwd, gitBranch, working_directories,
+#   models_used, total_cost_usd, ...) and has already been promoted to a typed
+#   column on the canonical schema. The `provider_meta` entry is retained as a
+#   compatibility/inspection mirror; the typed column is the source of truth.
+#   Removing the mirror is a separate schema-version transition.
+#
+# removed
+#   The key used to be written by production code but no longer is. The row is
+#   kept here as a tombstone so a re-introduction in a future PR has to be a
+#   deliberate manifest edit, not an accidental revival. Lint reports stale
+#   tombstones if it observes a write again.
+#
+# Format
+# ======
+#
+# fields:
+#   - key: "name"
+#     classification: provider-specific-retained | raw-only | promoted | removed
+#     scope: conversation | message | attachment   # (omit for any-scope)
+#     providers: [chatgpt, claude-code, codex, ...]  # producers (optional)
+#     promoted_column: "conversations.git_branch"   # for `promoted`
+#     note: "human-readable rationale"
+#
+# Updated: 2026-05-18 — initial population for #1255 / #864 slice E.
+
+fields:
+  # ---- raw-only: verbatim provider payloads -------------------------------
+  - key: raw
+    classification: raw-only
+    scope: message
+    providers: [chatgpt]
+    note: |
+      Full original provider message dict captured for replay/debug. Never read
+      by the harmonized read surface.
+
+  - key: session
+    classification: raw-only
+    scope: conversation
+    providers: [browser-capture]
+    note: |
+      Raw session envelope copied from browser-capture upload. Used by
+      replay/debug only.
+
+  - key: capture
+    classification: raw-only
+    scope: conversation
+    providers: [browser-capture]
+    note: |
+      Raw capture envelope copied from browser-capture upload.
+
+  - key: chunk
+    classification: raw-only
+    scope: message
+    providers: [gemini]
+    note: |
+      Original gemini chunkedPrompt chunk JSON, retained for replay paths in
+      drive parser fallback shape.
+
+  - key: content_blocks
+    classification: raw-only
+    scope: message
+    providers: [gemini]
+    note: |
+      Pre-typed content-blocks payload used as the staging shape inside the
+      drive parser before promotion to typed ContentBlockRecord rows. Not part
+      of the harmonized read surface.
+
+  - key: reasoning_traces
+    classification: raw-only
+    scope: message
+    providers: [gemini]
+    note: |
+      Pre-typed reasoning-trace payload used inside the drive parser. The
+      harmonized field is `HarmonizedMessage.reasoning_traces`.
+
+  - key: artifact_name
+    classification: raw-only
+    scope: message
+    providers: [antigravity]
+    note: |
+      Filename of the artifact whose body is the message body. Surfaces in
+      rendering but not load-bearing for query semantics.
+
+  # ---- promoted: also exists as a typed column ----------------------------
+  - key: working_directories
+    classification: promoted
+    scope: conversation
+    providers: [claude-code, codex]
+    promoted_column: conversations.working_directories
+    note: |
+      Promoted to the typed `working_directories` array column on
+      conversations. The provider_meta mirror is retained for callers that
+      still read the dict shape during the dual-vocabulary period.
+
+  - key: gitBranch
+    classification: promoted
+    scope: conversation
+    providers: [claude-ai, session-rebuild]
+    promoted_column: conversations.git_branch
+    note: |
+      Mirror of `conversations.git_branch`. Populated by the claude-ai session
+      index path and the session-rebuild insight loader for compatibility.
+
+  - key: git_branch
+    classification: promoted
+    scope: conversation
+    providers: [codex]
+    promoted_column: conversations.git_branch
+    note: |
+      Same semantics as `gitBranch`; codex parser uses the snake_case spelling.
+      Promoted to `conversations.git_branch`.
+
+  - key: cwd
+    classification: promoted
+    scope: conversation
+    providers: [session-rebuild]
+    promoted_column: conversations.working_directories
+    note: |
+      Single-cwd compatibility mirror used by the session-rebuild loader.
+      Conversation-level cwd lives in the typed `working_directories` column.
+
+  - key: git
+    classification: promoted
+    scope: conversation
+    providers: [codex, session-rebuild]
+    promoted_column: conversations.git_repository_url
+    note: |
+      Codex git context dict (repository_url + branch). Repository URL is
+      promoted to `conversations.git_repository_url`; the nested dict is kept
+      for replay/debug callers.
+
+  - key: models_used
+    classification: promoted
+    scope: conversation
+    providers: [claude-code]
+    promoted_column: conversations.models_used
+    note: |
+      Mirror of the typed `models_used` array column on conversations.
+
+  - key: total_cost_usd
+    classification: promoted
+    scope: conversation
+    providers: [claude-code]
+    promoted_column: conversations.total_cost_usd
+    note: |
+      Mirror of the typed cost rollup column on conversations.
+
+  - key: total_duration_ms
+    classification: promoted
+    scope: conversation
+    providers: [claude-code]
+    promoted_column: conversations.total_duration_ms
+    note: |
+      Mirror of the typed duration rollup column on conversations.
+
+  - key: model
+    classification: promoted
+    scope: message
+    providers: [chatgpt, browser-capture, hermes, gemini-cli]
+    promoted_column: messages.model
+    note: |
+      Per-message model identifier; promoted to the typed `messages.model`
+      column. The dict mirror is kept for replay and debug callers.
+
+  - key: tokens
+    classification: promoted
+    scope: message
+    providers: [gemini-cli, browser-capture]
+    promoted_column: messages.tokens
+    note: |
+      Per-message token usage struct; promoted to typed token columns on
+      `messages`.
+
+  # ---- provider-specific-retained: stays inside provider_meta -------------
+  - key: source_family
+    classification: provider-specific-retained
+    scope: conversation
+    providers: [antigravity, gemini-cli, hermes]
+    note: |
+      Source-family tag used by the local-agent parser family before the
+      `Source` dataclass migration completes (#1022). Distinct from the
+      conversation-level Provider enum.
+
+  - key: source_format
+    classification: provider-specific-retained
+    scope: conversation
+    providers: [antigravity]
+    note: |
+      Discriminates the antigravity ingest path (brain-artifact metadata vs
+      language-server markdown export).
+
+  - key: title_source
+    classification: provider-specific-retained
+    scope: conversation
+    providers: [drive, gemini, codex, session-rebuild, claude-ai]
+    note: |
+      Provenance tag for the conversation title (e.g. `imported:title`,
+      `session-index:thread-name`, `first-user-message`). Used by reader UIs
+      to disambiguate placeholder titles.
+
+  - key: display_label
+    classification: provider-specific-retained
+    scope: conversation
+    providers: [gemini]
+    note: Human-readable label override surfaced by the gemini assembly path.
+
+  - key: display_label_source
+    classification: provider-specific-retained
+    scope: conversation
+    providers: [gemini]
+    note: Provenance for `display_label`.
+
+  - key: display_label_reason
+    classification: provider-specific-retained
+    scope: conversation
+    providers: [gemini]
+    note: |
+      Rationale for choosing the `display_label` override (e.g. `weak-title`).
+      Set by gemini assembly via `setdefault` so existing values survive.
+
+  - key: thread_name
+    classification: provider-specific-retained
+    scope: conversation
+    providers: [codex]
+    note: |
+      Codex session-index thread name. Used to display human-meaningful titles
+      where the parser would otherwise fall back to session UUIDs.
+
+  - key: default_model
+    classification: provider-specific-retained
+    scope: conversation
+    providers: [chatgpt]
+    note: ChatGPT conversation-level default model slug.
+
+  - key: gizmo_id
+    classification: provider-specific-retained
+    scope: conversation
+    providers: [chatgpt]
+    note: ChatGPT custom-GPT (gizmo) identifier when the conversation used one.
+
+  - key: gizmo_type
+    classification: provider-specific-retained
+    scope: conversation
+    providers: [chatgpt]
+    note: ChatGPT custom-GPT kind tag.
+
+  - key: is_archived
+    classification: provider-specific-retained
+    scope: conversation
+    providers: [chatgpt]
+    note: ChatGPT archive-flag mirror; not promoted because it has no archive-wide semantics.
+
+  - key: instructions
+    classification: provider-specific-retained
+    scope: conversation
+    providers: [codex]
+    note: Codex session-level instructions blob.
+
+  - key: artifact_path
+    classification: provider-specific-retained
+    scope: conversation
+    providers: [antigravity]
+    note: |
+      Path of the antigravity artifact this conversation row represents.
+      Filesystem-specific, so not promoted.
+
+  - key: session_id
+    classification: provider-specific-retained
+    scope: conversation
+    providers: [antigravity]
+    note: Antigravity session identifier (distinct from cascade_id).
+
+  - key: artifact_type
+    classification: provider-specific-retained
+    scope: conversation
+    providers: [antigravity]
+    note: Antigravity brain-artifact type tag (e.g. plan/note).
+
+  - key: summary
+    classification: provider-specific-retained
+    scope: conversation
+    providers: [antigravity, claude-ai]
+    note: Provider-supplied conversation summary (not the user-generated summary).
+
+  - key: firstPrompt
+    classification: provider-specific-retained
+    scope: conversation
+    providers: [claude-ai]
+    note: Claude.ai session-index first-prompt mirror.
+
+  - key: projectPath
+    classification: provider-specific-retained
+    scope: conversation
+    providers: [claude-ai]
+    note: Claude.ai project path from the session index.
+
+  - key: isSidechain
+    classification: provider-specific-retained
+    scope: conversation
+    providers: [claude-ai]
+    note: Claude.ai sidechain-conversation flag.
+
+  - key: missing_markdown_body
+    classification: provider-specific-retained
+    scope: conversation
+    providers: [antigravity]
+    note: Tombstone flag when the antigravity markdown file was unreadable.
+
+  - key: cascade_id
+    classification: provider-specific-retained
+    scope: conversation
+    providers: [antigravity]
+    note: Antigravity language-server cascade identifier.
+
+  - key: workspace_name
+    classification: provider-specific-retained
+    scope: conversation
+    providers: [antigravity]
+    note: Antigravity workspace name reported by the language server.
+
+  - key: snippet
+    classification: provider-specific-retained
+    scope: conversation
+    providers: [antigravity]
+    note: Antigravity language-server preview snippet.
+
+  - key: antigravity_section
+    classification: provider-specific-retained
+    scope: message
+    providers: [antigravity]
+    note: |
+      Section heading inside the antigravity markdown export from which this
+      message was extracted.
+
+  - key: kind
+    classification: provider-specific-retained
+    scope: conversation
+    providers: [gemini-cli]
+    note: Gemini-CLI session kind tag.
+
+  - key: projectHash
+    classification: provider-specific-retained
+    scope: conversation
+    providers: [gemini-cli]
+    note: Gemini-CLI project hash from the session payload.
+
+  - key: base_url
+    classification: provider-specific-retained
+    scope: conversation
+    providers: [hermes]
+    note: Hermes endpoint base URL.
+
+  - key: platform
+    classification: provider-specific-retained
+    scope: conversation
+    providers: [hermes]
+    note: Hermes platform tag.
+
+  - key: tools
+    classification: provider-specific-retained
+    scope: conversation
+    providers: [hermes]
+    note: Hermes tool inventory list.
+
+  - key: message_count
+    classification: provider-specific-retained
+    scope: conversation
+    providers: [hermes]
+    note: Hermes-reported message count (provider-side, not authoritative).
+
+  - key: citations
+    classification: provider-specific-retained
+    scope: message
+    providers: [chatgpt]
+    note: ChatGPT web-browsing citations payload.
+
+  - key: code_execution
+    classification: provider-specific-retained
+    scope: message
+    providers: [chatgpt]
+    note: ChatGPT code-interpreter aggregate result.
+
+  - key: user_context
+    classification: provider-specific-retained
+    scope: message
+    providers: [chatgpt]
+    note: ChatGPT user-editable context (memory/instructions).
+
+  - key: author_name
+    classification: provider-specific-retained
+    scope: message
+    providers: [chatgpt]
+    note: ChatGPT author.name (tool identity like `dalle`, `browser`, `python`).
+
+  - key: recipient
+    classification: provider-specific-retained
+    scope: message
+    providers: [chatgpt]
+    note: ChatGPT message recipient (tool routing).
+
+  - key: status
+    classification: provider-specific-retained
+    scope: message
+    providers: [chatgpt]
+    note: ChatGPT message status string.
+
+  - key: end_turn
+    classification: provider-specific-retained
+    scope: message
+    providers: [chatgpt]
+    note: ChatGPT end_turn boolean.
+
+  - key: finish_reason
+    classification: provider-specific-retained
+    scope: message
+    providers: [hermes]
+    note: Hermes per-message finish reason.
+
+  - key: isThought
+    classification: provider-specific-retained
+    scope: message
+    providers: [gemini]
+    note: Gemini per-message thought flag.
+
+  - key: tokenCount
+    classification: provider-specific-retained
+    scope: message
+    providers: [gemini]
+    note: Gemini per-message token count (raw provider shape).
+
+  - key: finishReason
+    classification: provider-specific-retained
+    scope: message
+    providers: [gemini]
+    note: Gemini per-message finish reason.
+
+  - key: thinkingBudget
+    classification: provider-specific-retained
+    scope: message
+    providers: [gemini]
+    note: Gemini thinking-budget setting per message.
+
+  - key: safetyRatings
+    classification: provider-specific-retained
+    scope: message
+    providers: [gemini]
+    note: Gemini safety-rating list.
+
+  - key: grounding
+    classification: provider-specific-retained
+    scope: message
+    providers: [gemini]
+    note: Gemini grounding/search metadata.
+
+  - key: branchParent
+    classification: provider-specific-retained
+    scope: message
+    providers: [gemini]
+    note: Gemini branch-parent pointer.
+
+  - key: branchChildren
+    classification: provider-specific-retained
+    scope: message
+    providers: [gemini]
+    note: Gemini branch-children pointers.
+
+  - key: executableCode
+    classification: provider-specific-retained
+    scope: message
+    providers: [gemini]
+    note: Gemini code-execution payload.
+
+  - key: codeExecutionResult
+    classification: provider-specific-retained
+    scope: message
+    providers: [gemini]
+    note: Gemini code-execution result.
+
+  - key: errorMessage
+    classification: provider-specific-retained
+    scope: message
+    providers: [gemini]
+    note: Gemini per-message error string.
+
+  - key: isEdited
+    classification: provider-specific-retained
+    scope: message
+    providers: [gemini]
+    note: Gemini per-message edited flag.
+
+  - key: attachment_kind
+    classification: provider-specific-retained
+    scope: attachment
+    providers: [drive]
+    note: Drive attachment kind tag (`inline_file` | `youtube_video`).
+
+  - key: mimeType
+    classification: provider-specific-retained
+    scope: attachment
+    providers: [drive]
+    note: Drive attachment MIME type.
+
+  - key: sizeBytes
+    classification: provider-specific-retained
+    scope: attachment
+    providers: [drive]
+    note: Drive attachment size in bytes.
+
+  - key: url
+    classification: provider-specific-retained
+    scope: attachment
+    providers: [drive]
+    note: Drive attachment URL (e.g. YouTube link).

--- a/polylogue/verification/manifests/models.py
+++ b/polylogue/verification/manifests/models.py
@@ -710,6 +710,53 @@ class TestOwnershipManifest(BaseModel):
 
 
 # ──────────────────────────────────────────────────────────────────────
+# Provider-meta policy manifest  (provider-meta-policy.yaml)
+# ──────────────────────────────────────────────────────────────────────
+
+
+class ProviderMetaField(BaseModel):
+    """A single classified provider_meta key.
+
+    Backs ``devtools verify-provider-meta-policy`` (#1255 / #864 slice E).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+    key: str
+    classification: str
+    scope: str | None = None
+    providers: list[str] = Field(default_factory=list)
+    promoted_column: str | None = None
+    note: str | None = None
+
+    VALID_CLASSIFICATIONS: ClassVar[frozenset[str]] = frozenset(
+        {"provider-specific-retained", "raw-only", "promoted", "removed"}
+    )
+    VALID_SCOPES: ClassVar[frozenset[str]] = frozenset({"conversation", "message", "attachment"})
+
+    @field_validator("classification")
+    @classmethod
+    def _check_classification(cls, v: str) -> str:
+        if v not in cls.VALID_CLASSIFICATIONS:
+            raise ValueError(f"classification must be one of {sorted(cls.VALID_CLASSIFICATIONS)}, got {v!r}")
+        return v
+
+    @field_validator("scope")
+    @classmethod
+    def _check_scope(cls, v: str | None) -> str | None:
+        if v is not None and v not in cls.VALID_SCOPES:
+            raise ValueError(f"scope must be one of {sorted(cls.VALID_SCOPES)} or null, got {v!r}")
+        return v
+
+
+class ProviderMetaPolicyManifest(BaseModel):
+    """Root of provider-meta-policy.yaml."""
+
+    model_config = ConfigDict(extra="forbid")
+    description: str | None = None
+    fields: list[ProviderMetaField]
+
+
+# ──────────────────────────────────────────────────────────────────────
 # Manifest-type dispatch table
 # ──────────────────────────────────────────────────────────────────────
 
@@ -732,6 +779,7 @@ MANIFEST_MODELS: dict[str, type[BaseModel]] = {
     "docs-media-coverage.yaml": DocsMediaCoverageManifest,
     "test-quality-coverage.yaml": TestQualityCoverageManifest,
     "test-ownership.yaml": TestOwnershipManifest,
+    "provider-meta-policy.yaml": ProviderMetaPolicyManifest,
 }
 
 
@@ -812,6 +860,8 @@ __all__ = [
     "ParityCheckEntry",
     "PerPackageBudget",
     "PlatformCoverage",
+    "ProviderMetaField",
+    "ProviderMetaPolicyManifest",
     "ScenarioCoverageManifest",
     "ScenarioFamily",
     "SecurityControl",


### PR DESCRIPTION
## Summary

Provider_meta is a free-form dict that every parser, source-assembly
module, and insight-rebuild path can write into. This PR introduces a
typed allowlist (`docs/plans/provider-meta-policy.yaml`) and an
AST-based lint (`devtools verify-provider-meta-policy`) wired into
`devtools verify --quick`, so undeclared keys and revived tombstones
become a blocking signal at PR time. Per #864 slice E.

## Problem

Without a declared allowlist there is no way to tell a load-bearing
field (`cwd`, `gitBranch`, `working_directories`) from an inert raw
payload (`raw`, `chunk`, `capture`), nor to spot a key that was
supposed to be retired but is still being written. Adding a new
provider field today is invisible to review — it lands as a quiet
`provider_meta["foo"] = ...` somewhere under
`polylogue/sources/parsers/`.

## Solution

- `docs/plans/provider-meta-policy.yaml` — 71 declared fields covering
  every `provider_meta` key observed across parsers, source assembly,
  and insight rebuild. Each row carries one of four classifications:
  `provider-specific-retained`, `raw-only`, `promoted`, or `removed`
  (tombstone). Rows also record scope, producing providers, optional
  `promoted_column`, and a rationale note.
- `devtools/verify_provider_meta_policy.py` — AST lint that walks
  `polylogue/sources/parsers`, the codex/gemini assembly modules, and
  the session-insight rebuild loader. Collects every string-literal
  key written via `provider_meta[...]` / `conv_meta[...]` subscripts,
  `.get/.setdefault/.pop` reads, and `provider_meta={...}` kwargs.
  Undeclared keys and revived tombstones are blocking; manifest rows
  with no observed writes surface as soft warnings (key may be written
  behind a dynamic pattern). The generic name `meta` is intentionally
  excluded from the scan vars to avoid colliding with upstream
  provider envelopes (e.g. `attachment_from_meta(meta=...)` in
  `base_support.py`).
- Catalog/wiring: new `CommandSpec` in
  `devtools/command_catalog.py`; new step in `build_verify_steps`
  alongside `verify-file-budgets`; added to `_STATIC_GATE_NAMES` in
  `devtools/evidence_dashboard.py`. `docs/devtools.md` regenerated via
  `devtools render-all`.
- `polylogue/verification/manifests/models.py` grows a typed
  `ProviderMetaPolicyManifest` Pydantic model so `verify-manifests`
  validates the YAML (extra=forbid on rows; closed
  classification/scope enums).

## Verification

```
nix develop -c devtools verify-provider-meta-policy
# provider_meta policy: docs/plans/provider-meta-policy.yaml
#     declared fields: 71
#     observed keys:   28
# [warn] manifest entries with no observed writes: 43
# blocking=False  → exit 0

nix develop -c devtools verify --quick
# exit_code: 0, total_duration_s: 38.68
# new gate: verify-provider-meta-policy ran with exit 0
```

The 43 soft warnings correspond to keys written behind dynamic patterns
(loops, conditionals, kwarg expansion). The lint is intentionally
syntactic; per the module docstring, new ingestion paths that bypass
literal-key patterns still need to land via PR review.

Closes #1255
Ref #864