### PR TITLE
fix(ci): skip provenance/sbom on PR container builds (#1373)

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -110,8 +110,13 @@ jobs:
           load: ${{ steps.decide.outputs.push != 'true' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          provenance: true
-          sbom: true
+          # Attestations produce a manifest list even on single-platform builds,
+          # which the classic docker image store cannot import via --load. Only
+          # emit them on push paths (master / tag / opt-in workflow_dispatch),
+          # where the image is pushed to ghcr.io and never loaded locally.
+          # See #1373.
+          provenance: ${{ steps.decide.outputs.push == 'true' }}
+          sbom: ${{ steps.decide.outputs.push == 'true' }}
           cache-from: type=gha,scope=container-${{ matrix.target }}
           cache-to: type=gha,mode=max,scope=container-${{ matrix.target }}
 


### PR DESCRIPTION
## Summary

Gate `provenance` and `sbom` on `steps.decide.outputs.push == 'true'` in `.github/workflows/container.yml` so attestations are emitted only on push paths (master, tag, opt-in workflow_dispatch) where the image is published to GHCR. PR smoke builds, which set `load: true` to import into the local docker daemon, no longer request attestations and therefore no longer produce a manifest list that the classic docker image store cannot import.

## Problem

The `Container` workflow has been failing on every push to `master` since #1319 merged (2026-05-18), and on every PR that triggers it (dependabot #1357 / #1358 / #1359, etc.). Both matrix jobs (`build (runtime)` and `build (distroless)`) fail with:

```
ERROR: failed to build: docker exporter does not currently support exporting manifest lists
```

Root cause (see #1373): `docker/build-push-action@v6` is configured with `provenance: true` + `sbom: true` + `load: ${{ steps.decide.outputs.push != 'true' }}`. Buildx emits attestations as a manifest list even on a single-platform build, and the classic docker image store cannot import manifest lists via `--load`. The combination has never been compatible (docker/buildx#1533, docker/build-push-action#820). The previous inlined publish-container job in `release.yml` pushed directly to ghcr.io and never hit `--load`, which is why the latent conflict only surfaced after #1319 introduced PR smoke builds.

## Solution

`.github/workflows/container.yml`:

```yaml
provenance: ${{ steps.decide.outputs.push == 'true' }}
sbom:       ${{ steps.decide.outputs.push == 'true' }}
```

This is option 1 from the issue's recommended fixes — the minimal coherent change.

- Push paths (master, tag, `workflow_dispatch` with `push=true`) still produce signed provenance + SBOM attestations on the published image, exactly as before.
- PR / `workflow_dispatch` smoke paths skip attestations. The single-platform image loads cleanly into the local docker daemon and the existing `docker run --rm --entrypoint ... --version` smoke test runs unchanged.
- No code paths touched; no other workflows touched; behavior on published images is preserved.

Alternatives rejected: containerd image store (needs runner-level daemon config, infeasible on hosted runners); OCI tarball + skopeo (more moving parts than the symptom warrants).

## Verification

- Reviewed the failing workflow definition and confirmed the only call sites for `provenance`/`sbom`/`load` are the four lines edited in this PR.
- Confirmed `steps.decide` already gates the push/load decision symmetrically (`push=false`/`load=true` on `pull_request`, `push=true`/no `--load` on master/tag), so reusing that boolean for attestations preserves the published-artifact surface.
- The actual smoke is the Container workflow run on this PR; expectation: both `build (runtime)` and `build (distroless)` go green, and master/tag pushes continue to publish provenance- and SBOM-attested images.

Closes #1373