### PR TITLE
fix(tests): teach CLI parity adapter the typed search-result envelope

### DIFF
--- a/tests/infra/surfaces.py
+++ b/tests/infra/surfaces.py
@@ -321,13 +321,16 @@ class CLISurface:
             parsed = json.loads(output)
         except json.JSONDecodeError as exc:
             raise AssertionError(f"CLI list output is not JSON ({query_case.name!r}): {output!r}") from exc
-        if not isinstance(parsed, list):
-            raise AssertionError(f"CLI list output is not a JSON array ({query_case.name!r}): {parsed!r}")
-        # Two shapes can land here depending on whether the parent group
-        # routed through pure list mode or the search-hit format:
+        # Three shapes can land here:
         #   * list mode: ``[{"id": ..., ...}, ...]``
         #   * search-hit mode: ``[{"conversation": {"id": ...}, ...}, ...]``
-        # Both project to the same id tuple for parity comparison.
+        #   * typed ranked-result envelope (PR #1370):
+        #     ``{"hits": [{"conversation": {"id": ...}, "match": {...}}, ...], "limit": ..., ...}``
+        # All three project to the same id tuple for parity comparison.
+        if isinstance(parsed, dict) and isinstance(parsed.get("hits"), list):
+            parsed = parsed["hits"]
+        if not isinstance(parsed, list):
+            raise AssertionError(f"CLI list output is not a JSON array ({query_case.name!r}): {parsed!r}")
         ids: list[str] = []
         for row in parsed:
             if not isinstance(row, dict):


### PR DESCRIPTION
## Summary

PR #1370 (typed ranked-result envelope) changed `polylogue list --format json` for search-mode queries to emit `{"hits": [...], "limit": N, "next_cursor": ...}` rather than a bare JSON array. The CLI parity adapter at `tests/infra/surfaces.py:307` still expected a bare array and asserted `not isinstance(parsed, list)`, causing both `test_search_unique_token_parity` and `test_search_shared_token_parity` to fail on every search-mode case on master.

## Solution

When the parsed CLI output is a dict carrying a `hits` array (the typed envelope shape), peel the `hits` and continue with the existing per-row id extraction. The list-mode and search-hit-mode shapes still work unchanged — they hit the same row loop directly.

Updated the inline doc to enumerate all three shapes the adapter now handles.

## Verification

- `nix develop --command pytest tests/unit/storage/test_surface_parity_adapters.py -q` → **10 passed** (was 2 failures on master).
- No production code touched; test-infra only.

## Scope

Single-file, test-infra-only change. Should land before #1379 / #1380 / #1382 (or alongside) so those PRs' CI runs are unmasked by this pre-existing failure.