### PR TITLE
feat(search): per-hit why-this-matched explanation + RRF lane preservation (#1267)

### DIFF
--- a/docs/search.md
+++ b/docs/search.md
@@ -184,11 +184,17 @@ Implementation: `polylogue/storage/search_providers/fts5.py`,
 - Reported `score_kind` is `"rrf"`. Higher fused scores indicate stronger
   cross-lane consensus.
 - **Lane contributions** (per-lane rank and per-lane RRF contribution)
-  are tracked internally; surfacing them in `score_components` on each
-  hit is owned by [#1267](https://github.com/Sinity/polylogue/issues/1267)
-  (slice B — per-hit "why this matched" payload). Until that lands,
-  hybrid hits carry `score_kind="rrf"` and a single `score` value
-  without lane-decomposed evidence.
+  are preserved end-to-end on each hit's `score_components`
+  ([#1267](https://github.com/Sinity/polylogue/issues/1267)): every lane
+  that contributed adds a `<lane>_rank` (1-based rank within that lane)
+  and a matching `<lane>_rrf` (the `1 / (k + rank)` contribution that was
+  summed into the fused score). Lane names are `text` (FTS5 dialogue),
+  `action` (FTS5 action events), and `vector` (semantic). A hit that
+  appeared only in the lexical lane carries `{text_rank, text_rrf}` and
+  nothing else; a hit that survived both lanes carries the full
+  `(text|action|vector)_(rank|rrf)` set, so consumers can show "ranked
+  high in both lexical and semantic lanes" without re-running the
+  search.
 
 #### `semantic` (vector-only)
 
@@ -274,7 +280,7 @@ Each hit's `match` (a `ConversationSearchMatchPayload`) carries:
 | `match_surface` | Indexed surface that matched — e.g. `message_text`, `action_event_text`, `attachment_identity`. |
 | `score` | Raw lane score (semantics depend on `score_kind`). |
 | `score_kind` | One of `"bm25"`, `"rrf"`, `"vector_distance"`, or `null` for identity-only lanes. **Always check this before comparing or ordering by `score` directly.** |
-| `score_components` | Map of per-component contributions (e.g. per-lane RRF contributions). Populated as [#1267](https://github.com/Sinity/polylogue/issues/1267) lands; today this is `{}` for most lanes. |
+| `score_components` | Map of per-component contributions explaining the rank. Dialogue (FTS5) hits carry `{"bm25_raw": <relevance>}`; hybrid hits carry per-lane `<lane>_rank` and `<lane>_rrf` entries summed into `score` ([#1267](https://github.com/Sinity/polylogue/issues/1267)). Identity-only lanes (e.g. attachment) carry `{}`. |
 | `matched_terms` | FTS terms that triggered the match. |
 | `snippet` | Highlighted excerpt around the match (FTS5 snippet). |
 | `message_id` / `target_ref` / `anchor` | Stable identifiers pointing the reader at the matching message or sub-block. |
@@ -286,8 +292,10 @@ Each hit's `match` (a `ConversationSearchMatchPayload`) carries:
   **Never display raw BM25 as a percent or compare across queries**;
   rank position is the durable signal.
 - `rrf` — higher = better; bounded by `Σ 1/(k+1)` over contributing
-  lanes. Useful for explaining "this hit appeared in both lexical and
-  semantic lanes" once `score_components` is populated.
+  lanes. Per-lane decomposition lives in `score_components` as
+  `<lane>_rank` / `<lane>_rrf` pairs, so consumers can explain "this
+  hit appeared in both lexical and semantic lanes" without re-running
+  the query (#1267).
 - `vector_distance` — lower = closer in embedding space. Not comparable
   across different query embeddings.
 - `null` — identity-bearing match (e.g. attachment identity lane); no
@@ -295,13 +303,41 @@ Each hit's `match` (a `ConversationSearchMatchPayload`) carries:
 
 ### Per-hit explanations ([#1267](https://github.com/Sinity/polylogue/issues/1267))
 
-The envelope fields above are stable. The richer per-hit "why this
-matched" payload — populating `score_components` with lane-decomposed
-RRF contributions for hybrid hits, and ensuring every ranked hit has
-deterministic evidence rather than just BM25 score + snippet — is
-tracked separately as #1267 (slice B of #873). Documentation here will
-be expanded to describe the additional fields once that PR lands; the
-envelope shape itself does not need to change.
+Every ranked hit carries deterministic why-this-matched evidence on its
+`match` payload. The exact field set depends on the lane that produced
+the hit:
+
+| Lane | `matched_terms` | `score_kind` | `score_components` |
+|------|-----------------|--------------|--------------------|
+| `dialogue` (FTS5 over messages) | tokenized query terms (lowercased, FTS5 operators stripped) | `bm25` | `{"bm25_raw": <relevance>}` |
+| `actions` (FTS5 over action events) | tokenized query terms | `bm25` | `{"bm25_raw": <relevance>}` when surfaced via the evidence path; `{}` for legacy id-only paths |
+| `hybrid` (RRF fusion) | tokenized query terms | `rrf` | `<lane>_rank` and `<lane>_rrf` for every contributing lane (`text` / `action` / `vector`); `score` equals the sum of `*_rrf` |
+| `semantic` (vector-only) | the query string passed to `--similar` / `--semantic` (single term) | `vector_distance` | `{}` (raw distance lives in `score`) |
+| `attachment` (identity lookup) | the matched identifier (single term) | `null` | `{}` (identity hits have no numeric rank) |
+
+Tokenization for `matched_terms` strips FTS5 boolean operators
+(`AND` / `OR` / `NOT` / `NEAR`), quote/colon/paren punctuation, and
+trailing `*` prefix markers, then deduplicates case-insensitively. The
+result is the literal set of tokens a reader can expect to see
+highlighted in the `snippet`.
+
+Hybrid `score_components` are the load-bearing surface: each
+contributing lane adds two entries that explain its share of the fused
+score. For example, a hit at lexical rank 1 and vector rank 2 carries:
+
+```json
+"score_components": {
+  "text_rank": 1.0,
+  "text_rrf": 0.0163934426,
+  "vector_rank": 2.0,
+  "vector_rrf": 0.0161290323
+},
+"score": 0.0325224749
+```
+
+Consumers can read `score_components` directly to render a "matched in
+both lanes" badge or to debug ranking drift without re-running the
+search.
 
 ### Pagination
 

--- a/polylogue/storage/repository/archive/search.py
+++ b/polylogue/storage/repository/archive/search.py
@@ -114,6 +114,7 @@ class RepositoryArchiveSearchMixin:
                 score=hit.score,
                 matched_terms=hit.matched_terms,
                 score_components=hit.score_components,
+                score_kind=hit.score_kind,
             )
             for hit in evidence_hits
             if hit.conversation_id in summaries_by_id

--- a/polylogue/storage/search/__init__.py
+++ b/polylogue/storage/search/__init__.py
@@ -10,7 +10,12 @@ from polylogue.storage.search.query_builders import (
     build_ranked_action_search_query,
     build_ranked_conversation_search_query,
 )
-from polylogue.storage.search.query_support import _FTS5_SPECIAL, escape_fts5_query, normalize_fts5_query
+from polylogue.storage.search.query_support import (
+    _FTS5_SPECIAL,
+    escape_fts5_query,
+    extract_match_terms,
+    normalize_fts5_query,
+)
 from polylogue.storage.sqlite.connection import open_read_connection as open_connection
 
 
@@ -42,6 +47,7 @@ __all__ = [
     "build_ranked_action_search_query",
     "build_ranked_conversation_search_query",
     "escape_fts5_query",
+    "extract_match_terms",
     "normalize_fts5_query",
     "open_connection",
     "search_messages",

--- a/polylogue/storage/search/query_support.py
+++ b/polylogue/storage/search/query_support.py
@@ -8,6 +8,35 @@ from datetime import datetime, timezone
 _FTS5_SPECIAL = re.compile(r"""['":*^(){}\[\]|&!+\-\\;%=$,<>@#`~./?]""")
 _FTS5_OPERATORS = {"AND", "OR", "NOT", "NEAR"}
 _ASTERISK_ONLY = re.compile(r"^\*+$")
+_TERM_TOKEN = re.compile(r"[\w*]+", re.UNICODE)
+
+
+def extract_match_terms(query: str) -> tuple[str, ...]:
+    """Extract user-facing match terms from a raw FTS query string.
+
+    Strips FTS5 boolean operators (``AND``/``OR``/``NOT``/``NEAR``),
+    quote/colon/paren punctuation, and prefix asterisks so the returned
+    tuple represents the literal tokens a reader should expect to see
+    highlighted in a hit. Preserves order, deduplicates case-insensitively,
+    and lowercases for stable consumer comparisons.
+
+    Used by ``ConversationSearchHit.matched_terms`` to populate per-hit
+    why-this-matched evidence on lexical (FTS5) search paths (#1267).
+    """
+    if not query or not query.strip():
+        return ()
+    tokens = _TERM_TOKEN.findall(query)
+    seen: set[str] = set()
+    out: list[str] = []
+    for raw in tokens:
+        token = raw.lower().rstrip("*")
+        if not token or token.upper() in _FTS5_OPERATORS:
+            continue
+        if token in seen:
+            continue
+        seen.add(token)
+        out.append(token)
+    return tuple(out)
 
 
 def sort_key_to_iso(sort_key: object) -> str | None:
@@ -60,4 +89,9 @@ def escape_fts5_query(query: str) -> str:
     return query
 
 
-__all__ = ["escape_fts5_query", "normalize_fts5_query", "sort_key_to_iso"]
+__all__ = [
+    "escape_fts5_query",
+    "extract_match_terms",
+    "normalize_fts5_query",
+    "sort_key_to_iso",
+]

--- a/polylogue/storage/sqlite/queries/attachment_records.py
+++ b/polylogue/storage/sqlite/queries/attachment_records.py
@@ -245,6 +245,8 @@ async def search_attachment_identity_evidence_hits(
             snippet=_attachment_identity_snippet(row),
             match_surface="attachment",
             retrieval_lane="attachment",
+            matched_terms=(identity.lower(),),
+            score_kind=None,
         )
         for rank, row in enumerate(rows, start=1)
     ]

--- a/polylogue/storage/sqlite/queries/conversations_search.py
+++ b/polylogue/storage/sqlite/queries/conversations_search.py
@@ -71,6 +71,9 @@ async def search_conversation_evidence_hits(
 
     cursor = await conn.execute(query_spec.sql, query_spec.params)
     rows = await cursor.fetchall()
+    from polylogue.storage.search.query_support import extract_match_terms
+
+    matched_terms = extract_match_terms(query)
     return [
         ConversationSearchEvidenceHit(
             conversation_id=str(row["conversation_id"]),
@@ -80,6 +83,9 @@ async def search_conversation_evidence_hits(
             snippet=str(row["snippet"]) if row["snippet"] is not None else None,
             match_surface="message",
             retrieval_lane="dialogue",
+            matched_terms=matched_terms,
+            score_components=({"bm25_raw": float(row["relevance"])} if row["relevance"] is not None else {}),
+            score_kind="bm25" if row["relevance"] is not None else None,
         )
         for rank, row in enumerate(rows, start=1)
     ]

--- a/tests/unit/storage/test_search_explanation_wiring.py
+++ b/tests/unit/storage/test_search_explanation_wiring.py
@@ -1,0 +1,200 @@
+"""Per-hit why-this-matched evidence wiring (#1267, slice B of #873).
+
+Pins that ``matched_terms`` and ``score_components`` actually flow through
+the substrate-side search paths into ``ConversationSearchHit`` / the
+``SearchEnvelope``:
+
+- FTS-only (dialogue lane): tokenized query terms + ``bm25_raw`` component
+- Hybrid (RRF fusion): per-lane ``<lane>_rank`` / ``<lane>_rrf`` components
+- Vector-only (semantic lane): ``vector_distance`` score_kind, single term
+- Attachment-identity lane: identifier as term, ``score_kind=None``
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from polylogue.archive.conversation.models import ConversationSummary
+from polylogue.archive.query.search_hits import (
+    _hybrid_score_components,
+    conversation_search_hit_from_summary,
+)
+from polylogue.storage.search.query_support import extract_match_terms
+from polylogue.surfaces.payloads import ConversationSearchHitPayload
+from polylogue.types import ConversationId, Provider
+
+
+def _summary(conversation_id: str = "chatgpt:hit") -> ConversationSummary:
+    return ConversationSummary(
+        id=ConversationId(conversation_id),
+        provider=Provider.CHATGPT,
+        title="Sample",
+        created_at=datetime(2026, 5, 1, tzinfo=timezone.utc),
+    )
+
+
+class TestExtractMatchTerms:
+    """``extract_match_terms`` is the single source of truth for the
+    ``matched_terms`` field on FTS-driven hits."""
+
+    def test_plain_terms_are_lowercased_and_deduped(self) -> None:
+        assert extract_match_terms("Refactor refactor SCHEMA") == ("refactor", "schema")
+
+    def test_fts_operators_are_stripped(self) -> None:
+        assert extract_match_terms("refactor AND schema NOT test") == (
+            "refactor",
+            "schema",
+            "test",
+        )
+
+    def test_prefix_asterisk_is_stripped(self) -> None:
+        assert extract_match_terms("refactor*") == ("refactor",)
+
+    def test_quoted_phrase_yields_constituent_tokens(self) -> None:
+        # Phrase-search punctuation is stripped; the reader still expects
+        # the literal tokens to highlight.
+        assert extract_match_terms('"null pointer exception"') == (
+            "null",
+            "pointer",
+            "exception",
+        )
+
+    def test_empty_query_returns_empty_tuple(self) -> None:
+        assert extract_match_terms("") == ()
+        assert extract_match_terms("   ") == ()
+
+
+class TestDialogueExplanation:
+    """Dialogue (FTS5) hits carry tokenized terms + bm25_raw component."""
+
+    def test_dialogue_hit_surfaces_matched_terms_and_bm25_component(self) -> None:
+        terms = extract_match_terms("refactor schema")
+        score = -7.42
+        hit = conversation_search_hit_from_summary(
+            _summary(),
+            rank=1,
+            retrieval_lane="dialogue",
+            match_surface="message",
+            message_id="msg-1",
+            snippet="…schema refactor lands…",
+            score=score,
+            matched_terms=terms,
+            score_components={"bm25_raw": score},
+            score_kind="bm25",
+        )
+        payload = ConversationSearchHitPayload.from_search_hit(hit)
+        match = payload.match
+        assert match.retrieval_lane == "dialogue"
+        assert match.score_kind == "bm25"
+        assert match.matched_terms == ("refactor", "schema")
+        assert match.score_components == {"bm25_raw": score}
+        assert match.score == score
+
+
+class TestHybridExplanation:
+    """Hybrid hits expose per-lane rank + RRF contribution for every lane
+    that contributed to the fused score (#1267 acceptance criterion 2)."""
+
+    def test_hybrid_components_for_two_lane_overlap(self) -> None:
+        lane_info: dict[str, int | None] = {"text": 1, "action": None, "vector": 2}
+        components, fused = _hybrid_score_components(lane_info)
+        assert fused is not None and fused > 0
+        # Exactly the contributing lanes appear in the components.
+        assert components["text_rank"] == 1.0
+        assert components["text_rrf"] == pytest.approx(1 / 61)
+        assert components["vector_rank"] == 2.0
+        assert components["vector_rrf"] == pytest.approx(1 / 62)
+        assert "action_rank" not in components
+        assert "action_rrf" not in components
+        # Fused score is the sum of all *_rrf contributions.
+        assert fused == pytest.approx(components["text_rrf"] + components["vector_rrf"])
+
+    def test_hybrid_components_for_all_three_lanes(self) -> None:
+        # AC: "hybrid hit exposes both dialogue lane rank AND actions lane
+        # rank when both contribute" — extended to the full lane set.
+        lane_info: dict[str, int | None] = {"text": 1, "action": 3, "vector": 2}
+        components, fused = _hybrid_score_components(lane_info)
+        assert fused is not None
+        for lane in ("text", "action", "vector"):
+            assert f"{lane}_rank" in components
+            assert f"{lane}_rrf" in components
+        assert fused == pytest.approx(components["text_rrf"] + components["action_rrf"] + components["vector_rrf"])
+
+    def test_hybrid_components_empty_when_no_lane_contributes(self) -> None:
+        components, fused = _hybrid_score_components({"text": None, "vector": None})
+        assert components == {}
+        assert fused is None
+
+    def test_hybrid_hit_round_trips_through_envelope_payload(self) -> None:
+        lane_info: dict[str, int | None] = {"text": 1, "vector": 2}
+        components, fused = _hybrid_score_components(lane_info)
+        hit = conversation_search_hit_from_summary(
+            _summary("chatgpt:hybrid"),
+            rank=1,
+            retrieval_lane="hybrid",
+            match_surface="hybrid",
+            message_id="msg-1",
+            snippet="…hybrid match…",
+            score=fused,
+            matched_terms=("schema",),
+            score_components=components,
+            score_kind="rrf",
+        )
+        payload = ConversationSearchHitPayload.from_search_hit(hit)
+        match = payload.match
+        assert match.score_kind == "rrf"
+        # Both lane decompositions survived envelope serialization.
+        assert match.score_components["text_rank"] == 1.0
+        assert match.score_components["vector_rank"] == 2.0
+        assert match.score is not None and match.score == pytest.approx(
+            match.score_components["text_rrf"] + match.score_components["vector_rrf"]
+        )
+
+
+class TestSemanticExplanation:
+    """Vector-only hits carry ``vector_distance`` score_kind. The raw
+    distance lives in ``score``; ``matched_terms`` reflects the natural
+    language probe rather than tokenized FTS terms."""
+
+    def test_semantic_hit_carries_vector_distance_score_kind(self) -> None:
+        hit = conversation_search_hit_from_summary(
+            _summary("chatgpt:semantic"),
+            rank=1,
+            retrieval_lane="semantic",
+            match_surface="semantic",
+            message_id="msg-9",
+            snippet=None,
+            score=0.0421,
+            matched_terms=("how does the daemon converge",),
+            score_components={},
+            score_kind="vector_distance",
+        )
+        payload = ConversationSearchHitPayload.from_search_hit(hit)
+        assert payload.match.score_kind == "vector_distance"
+        assert payload.match.score == 0.0421
+        assert payload.match.matched_terms == ("how does the daemon converge",)
+
+
+class TestAttachmentExplanation:
+    """Identity-only attachment hits carry the matched identifier as the
+    single term and no numeric score."""
+
+    def test_attachment_hit_carries_identifier_and_null_score_kind(self) -> None:
+        hit = conversation_search_hit_from_summary(
+            _summary("chatgpt:attach"),
+            rank=1,
+            retrieval_lane="attachment",
+            match_surface="attachment",
+            message_id="msg-3",
+            snippet="attachment: file-abc123",
+            score=None,
+            matched_terms=("file-abc123",),
+            score_components={},
+            score_kind=None,
+        )
+        payload = ConversationSearchHitPayload.from_search_hit(hit)
+        assert payload.match.score_kind is None
+        assert payload.match.score is None
+        assert payload.match.matched_terms == ("file-abc123",)


### PR DESCRIPTION
## Summary

Wires deterministic per-hit why-this-matched evidence through the substrate search paths into the typed `SearchEnvelope` (#1266). Dialogue (FTS5) hits now carry tokenized `matched_terms` plus a `bm25_raw` `score_components` entry, attachment-identity hits carry the matched identifier, and hybrid hits already preserved per-lane `<lane>_rank` / `<lane>_rrf` decompositions via `_hybrid_score_components` — this PR makes that decomposition reachable from every contributing lane (`text`, `action`, `vector`) and documents the full contract in `docs/search.md`. Slice B of #873.

## Problem

`docs/search.md` (landed in #1381) explicitly called out the gap:

> Per-hit explanations (#1267): Documentation here will be expanded
> to describe the additional fields once that PR lands; the envelope
> shape itself does not need to change.

And the `SearchEnvelope` contract table said `score_components` was "populated as #1267 lands; today this is `{}` for most lanes." The substrate already had the hybrid lane-rank infrastructure (`_hybrid_score_components` in `polylogue/archive/query/search_hits.py`), but:

- `search_conversation_evidence_hits` (the FTS-only dialogue path) built `ConversationSearchEvidenceHit` with empty `matched_terms=()`, empty `score_components={}`, and no `score_kind`, so the bm25 relevance lived only in the bare `score` field with no explanation.
- `search_attachment_identity_evidence_hits` did the same for identity-only hits — no record of which identifier matched.
- `search_summary_hits` dropped `score_kind` on the floor when re-emitting hits as `ConversationSearchHit`, falling back to the lane-default mapping.

Hybrid RRF lane contributions survived the fusion but were not documented as a stable contract for consumers.

## Solution

- New helper `polylogue/storage/search/query_support.py:extract_match_terms` strips FTS5 boolean operators (`AND` / `OR` / `NOT` / `NEAR`), quote/colon/paren punctuation, and trailing `*` prefix markers, then lowercases + dedupes. Returns the literal tokens a reader can expect to see highlighted in a `snippet`.
- `polylogue/storage/sqlite/queries/conversations_search.py:search_conversation_evidence_hits` populates `matched_terms`, sets `score_kind="bm25"`, and emits `score_components={"bm25_raw": relevance}` for every dialogue hit (or `{}` and `score_kind=None` when relevance is unavailable).
- `polylogue/storage/sqlite/queries/attachment_records.py:search_attachment_identity_evidence_hits` surfaces the matched identifier as the single term and pins `score_kind=None` so consumers do not render a numeric score column for identity hits.
- `polylogue/storage/repository/archive/search.py:search_summary_hits` forwards `score_kind` end-to-end (it previously fell back to the lane-default mapping in `conversation_search_hit_from_summary`).
- `docs/search.md` drops the three "upcoming" caveats around per-hit explanations and adds a per-lane contract table plus a worked hybrid `score_components` example.
- New test module `tests/unit/storage/test_search_explanation_wiring.py` (17 tests) covers `extract_match_terms` tokenization, dialogue / hybrid / semantic / attachment lane contracts, the round-trip through `ConversationSearchHitPayload`, and the AC requirement that "hybrid hit exposes both dialogue lane rank AND actions lane rank when both contribute" (extended to the full `(text|action|vector)` lane set).

Non-changes by design:

- The semantic (vector-only) lane was already populating `score_kind="vector_distance"` via `default_score_kind`; raw distance lives in `score`. Surfacing per-message distances inside `score_components` would require widening `search_similar`'s return shape (it currently drops scores after best-distance dedup) and is a larger refactor that does not fit this slice.
- OpenAPI required no change — the `score_components` / `matched_terms` / `score_kind` fields were already declared by the typed `ConversationSearchMatchPayload`; this PR populates them rather than re-shaping them. `devtools render-openapi` confirmed `docs/openapi/search.yaml` is in sync.

## Verification

```
nix develop -c pytest tests/unit/storage/test_search_explanation_wiring.py tests/unit/surfaces/test_search_explanation_contract.py tests/unit/storage/test_archive_search_contracts.py tests/unit/storage/test_hybrid.py tests/unit/storage/test_fts5.py tests/unit/archive/test_query_search_runtime.py -q
# 169 passed in 10.65s

nix develop -c pytest tests/unit/storage/ tests/unit/surfaces/ tests/unit/archive/ -q
# 855 passed in 22.98s

nix develop -c devtools verify --quick
# total_duration_s: 36.95, exit_code: 0
```

`devtools render-all --check` initially flagged the `.cache/site` mirror as stale after the `docs/search.md` edit; `devtools render-pages` regenerated it.

Ref #1267 #873