### PR TITLE
feat(search): stable cursor/keyset pagination after ranked + filter paths (#1268)

### DIFF
--- a/devtools/render_openapi.py
+++ b/devtools/render_openapi.py
@@ -169,6 +169,18 @@ def _build_openapi_document() -> dict[str, Any]:
                                 "default": "auto",
                             },
                         },
+                        {
+                            "name": "cursor",
+                            "in": "query",
+                            "description": (
+                                "Opaque keyset cursor previously returned as ``next_cursor`` on a search "
+                                "response. Stable across archive growth and daemon restart (#1268). "
+                                "MUST be passed back unchanged. Rejected with 400 when malformed or when "
+                                "the retrieval lane no longer matches."
+                            ),
+                            "required": False,
+                            "schema": {"type": "string"},
+                        },
                     ],
                     "responses": {
                         "200": {

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -114,6 +114,9 @@ Options:
   --until TEXT                    Before date
   -l, -n, --limit INTEGER         Max results
   --offset INTEGER                Offset for paginated results
+  --cursor TEXT                   Opaque keyset cursor from a previous
+                                  response's next_cursor. Stable across
+                                  archive growth for ranked search (#1268).
   --latest                        Most recent (= --sort date --limit 1)
   --sort [date|tokens|messages|words|longest|random]
                                   Sort by field

--- a/docs/openapi/search.yaml
+++ b/docs/openapi/search.yaml
@@ -71,6 +71,14 @@ paths:
           - hybrid
           - semantic
           default: auto
+      - name: cursor
+        in: query
+        description: Opaque keyset cursor previously returned as ``next_cursor`` on a search response. Stable across archive
+          growth and daemon restart (#1268). MUST be passed back unchanged. Rejected with 400 when malformed or when the retrieval
+          lane no longer matches.
+        required: false
+        schema:
+          type: string
       responses:
         '200':
           description: Ranked search envelope (when ``query`` is supplied) or conversation list envelope.

--- a/docs/search.md
+++ b/docs/search.md
@@ -342,10 +342,39 @@ search.
 ### Pagination
 
 For ranked queries, prefer `next_cursor` over `offset`. Cursor
-pagination encodes the rank tie-breaker (`(rank, conversation_id)`) and
-is stable under archive growth between page fetches. Offset pagination
-is supported for non-ranked list paths and as a best-effort fallback for
-ranked paths.
+pagination encodes the rank tie-breaker
+(`(rank, score, conversation_id, retrieval_lane)`) and is stable under
+archive growth between page fetches. Offset pagination is supported for
+non-ranked list paths and as a best-effort fallback for ranked paths.
+
+The cursor is an opaque URL-safe base64 token (a versioned JSON
+envelope; see :class:`polylogue.surfaces.payloads.SearchCursor`).
+Consumers MUST treat it as opaque and pass it back unchanged.
+
+```bash
+# Page 1
+polylogue "sqlite" list --format json --limit 25
+# Read .next_cursor from the response, then ask for page 2:
+polylogue "sqlite" list --format json --limit 25 \
+    --cursor "$NEXT_CURSOR"
+```
+
+MCP search and the daemon `/api/conversations` endpoint accept the same
+`cursor` parameter; the Python API exposes `Polylogue.search_envelope(
+query, cursor=...)`. The cursor carries the retrieval lane it was
+minted in, so a `dialogue` cursor passed back to a `hybrid` request is
+rejected up-front rather than silently changing ranking policy
+mid-walk.
+
+Stability guarantees (#1268):
+
+- **No duplicates**: any hit returned on page N is filtered out on page
+  N+1 even when new rows were ingested between requests.
+- **No gaps**: any hit that sorts strictly after the anchor (under the
+  lane's natural ordering: BM25 lower-is-better, RRF higher-is-better,
+  vector distance lower-is-better) survives the cursor trim.
+- **Restart-stable**: cursors are self-contained tokens with no
+  server-side state; they survive daemon restart.
 
 ## FTS5 Syntax
 

--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -116,8 +116,15 @@ class PolylogueArchiveMixin:
         until: str | None = None,
         retrieval_lane: str = "auto",
         sort: str | None = None,
+        cursor: str | None = None,
     ) -> SearchEnvelope:
-        """Return the canonical :class:`SearchEnvelope` for a query (#1266)."""
+        """Return the canonical :class:`SearchEnvelope` for a query (#1266).
+
+        Pass ``cursor`` (an opaque token previously returned as
+        :attr:`SearchEnvelope.next_cursor`) to fetch the next page
+        without losing or duplicating hits even when the archive grew
+        between requests (#1268).
+        """
         from polylogue.api.search_envelope_builder import build_archive_search_envelope
 
         return await build_archive_search_envelope(
@@ -131,6 +138,7 @@ class PolylogueArchiveMixin:
             until=until,
             retrieval_lane=retrieval_lane,
             sort=sort,
+            cursor=cursor,
         )
 
     async def get_session_insight_status(self) -> SessionInsightStatusSnapshot:

--- a/polylogue/api/search_envelope_builder.py
+++ b/polylogue/api/search_envelope_builder.py
@@ -16,9 +16,11 @@ from typing import TYPE_CHECKING
 
 from polylogue.surfaces.payloads import (
     ConversationSearchHitPayload,
+    InvalidSearchCursorError,
     QueryMissDiagnosticsPayload,
     SearchEnvelope,
     build_search_envelope,
+    decode_search_cursor,
 )
 
 if TYPE_CHECKING:
@@ -38,14 +40,33 @@ async def build_archive_search_envelope(
     until: str | None = None,
     retrieval_lane: str = "auto",
     sort: str | None = None,
+    cursor: str | None = None,
 ) -> SearchEnvelope:
     """Build a :class:`SearchEnvelope` from an archive operations + repo pair.
 
     Centralised so CLI, MCP, daemon HTTP, and the Python API all assemble
     the envelope from the same primitives (#1266).
+
+    ``cursor`` is an opaque keyset token previously returned as
+    :attr:`SearchEnvelope.next_cursor` (#1268). When supplied, the
+    underlying fetch is advanced past the cursor anchor and the response
+    page begins strictly after it. The cursor's encoded rank is used as
+    the effective offset, so a follow-up call with the same query and
+    lane returns the contiguous successor page even if the archive has
+    grown between requests.
     """
     from polylogue.archive.query.spec import ConversationQuerySpec
 
+    decoded_cursor = decode_search_cursor(cursor) if cursor else None
+    if decoded_cursor is not None and decoded_cursor.lane not in {"", retrieval_lane}:
+        raise InvalidSearchCursorError(
+            f"cursor was minted for retrieval_lane={decoded_cursor.lane!r} but this request is {retrieval_lane!r}"
+        )
+
+    # Advance the SQL fetch past the cursor anchor; the builder will drop
+    # any straggler rows whose (score, conversation_id) sort at or before
+    # the anchor under the lane's natural ordering.
+    effective_offset = decoded_cursor.r if decoded_cursor is not None else offset
     spec = ConversationQuerySpec.from_params(
         {
             "query": query,
@@ -54,8 +75,11 @@ async def build_archive_search_envelope(
             "until": until,
             "retrieval_lane": retrieval_lane,
             "sort": sort,
-            "limit": limit,
-            "offset": offset,
+            # Fetch one extra page worth so the post-fetch cursor trim
+            # cannot starve the response when the anchor row drifts.
+            "limit": limit + (limit if decoded_cursor is not None else 0),
+            "offset": effective_offset,
+            "cursor": cursor,
         },
         strict=True,
     )
@@ -79,6 +103,7 @@ async def build_archive_search_envelope(
         retrieval_lane=resolved_lane,
         sort=sort,
         diagnostics=diagnostics_payload,
+        cursor=decoded_cursor,
     )
 
 

--- a/polylogue/archive/query/spec.py
+++ b/polylogue/archive/query/spec.py
@@ -177,6 +177,7 @@ _RECOGNIZED_PARAMS: frozenset[str] = frozenset(
         "since_session",
         "message_type",
         "offset",
+        "cursor",
     }
 )
 
@@ -291,6 +292,7 @@ def build_query_spec_from_params(
         since_session_id=since_session_id,
         message_type=optional_message_type(params.get("message_type")),
         offset=optional_int(params.get("offset")) or 0,
+        cursor=optional_text(params.get("cursor")),
     )
 
 

--- a/polylogue/cli/click_option_groups.py
+++ b/polylogue/cli/click_option_groups.py
@@ -268,6 +268,16 @@ FILTER_OPTION_DECORATORS: tuple[Callable[[ClickCallable], ClickCallable], ...] =
     click.option("--until", help="Before date"),
     click.option("--limit", "-l", "-n", type=int, help="Max results"),
     click.option("--offset", type=int, default=0, help="Offset for paginated results"),
+    click.option(
+        "--cursor",
+        "cursor",
+        type=str,
+        default=None,
+        help=(
+            "Opaque keyset cursor from a previous response's next_cursor. "
+            "Stable across archive growth for ranked search (#1268)."
+        ),
+    ),
     click.option("--latest", is_flag=True, help="Most recent (= --sort date --limit 1)"),
     click.option(
         "--sort",

--- a/polylogue/cli/query.py
+++ b/polylogue/cli/query.py
@@ -33,7 +33,7 @@ from polylogue.cli.root_request import RootModeRequest
 from polylogue.cli.shared.types import AppEnv
 from polylogue.core.json import JSONDocument
 from polylogue.logging import get_logger
-from polylogue.surfaces.payloads import ConversationListRowPayload
+from polylogue.surfaces.payloads import ConversationListRowPayload, SearchCursor
 
 logger = get_logger(__name__)
 
@@ -303,7 +303,7 @@ async def _observe_query_operation(
     )
 
 
-def _decode_cursor_or_none(token: str | None) -> object | None:
+def _decode_cursor_or_none(token: str | None) -> SearchCursor | None:
     """Decode a CLI ``--cursor`` token, or return ``None`` when absent.
 
     Returns the decoded :class:`SearchCursor` so :func:`format_search_envelope`

--- a/polylogue/cli/query.py
+++ b/polylogue/cli/query.py
@@ -303,15 +303,54 @@ async def _observe_query_operation(
     )
 
 
+def _decode_cursor_or_none(token: str | None) -> object | None:
+    """Decode a CLI ``--cursor`` token, or return ``None`` when absent.
+
+    Returns the decoded :class:`SearchCursor` so :func:`format_search_envelope`
+    can trim hits up to the anchor before emitting the JSON envelope. Errors
+    are surfaced by :func:`_search_hits_for_execution_plan`; this helper
+    intentionally swallows them here so JSON formatting never raises after
+    the fetch has succeeded.
+    """
+    if not token:
+        return None
+    try:
+        from polylogue.surfaces.payloads import decode_search_cursor
+
+        return decode_search_cursor(token)
+    except Exception:
+        return None
+
+
 async def _search_hits_for_execution_plan(
     repo: QueryExecutionStore,
     plan: QueryExecutionPlan,
     *,
     vector_provider: VectorProvider | None,
 ) -> list[ConversationSearchHit] | None:
-    from polylogue.archive.query.search_hits import plan_has_search_hit_evidence, search_hits_for_plan
+    from dataclasses import replace
 
-    query_plan = plan.selection.to_plan(vector_provider=vector_provider)
+    from polylogue.archive.query.search_hits import plan_has_search_hit_evidence, search_hits_for_plan
+    from polylogue.surfaces.payloads import InvalidSearchCursorError, decode_search_cursor
+
+    selection = plan.selection
+    decoded_cursor = None
+    if selection.cursor:
+        try:
+            decoded_cursor = decode_search_cursor(selection.cursor)
+        except InvalidSearchCursorError as exc:
+            import click as _click
+
+            raise _click.UsageError(f"invalid --cursor: {exc}") from exc
+    if decoded_cursor is not None:
+        # Push the underlying fetch past the anchor and over-fetch one
+        # extra page so the post-fetch keyset trim cannot starve the
+        # response. The envelope builder drops anything sorting at or
+        # before the cursor anchor and then truncates to the requested
+        # limit (#1268).
+        effective_limit = (selection.limit or 50) * 2
+        selection = replace(selection, offset=decoded_cursor.r, limit=effective_limit)
+    query_plan = selection.to_plan(vector_provider=vector_provider)
     if not plan_has_search_hit_evidence(query_plan):
         return None
     return await search_hits_for_plan(query_plan, repo)
@@ -472,7 +511,9 @@ async def _handle_summary_list(
         if not search_hits:
             summary_diagnostics = await _diagnose_query_miss(repo, plan.selection, config=config)
             no_results(env, params, diagnostics=summary_diagnostics)
-        await _query_output.output_search_hits(env, search_hits, plan.output, repo)
+        await _query_output.output_search_hits(
+            env, search_hits, plan.output, repo, cursor=_decode_cursor_or_none(plan.selection.cursor)
+        )
         return
 
     summary_results = await _observe_query_operation(repo, plan, QueryRoute.SUMMARY_LIST, filter_chain.list_summaries())
@@ -709,7 +750,9 @@ async def _handle_default(
     if output_diagnostics is None and (plan.output.list_mode or len(projected_results) > 1):
         search_hits = await _search_hits_for_execution_plan(repo, plan, vector_provider=vector_provider)
         if search_hits is not None:
-            await _query_output.output_search_hits(env, search_hits, plan.output, repo)
+            await _query_output.output_search_hits(
+                env, search_hits, plan.output, repo, cursor=_decode_cursor_or_none(plan.selection.cursor)
+            )
             return
     _query_output.output_results(
         env,

--- a/polylogue/cli/query_output.py
+++ b/polylogue/cli/query_output.py
@@ -44,6 +44,7 @@ from polylogue.rendering.formatting import format_conversation
 from polylogue.surfaces.payloads import (
     ConversationListRowPayload,
     ConversationSearchHitPayload,
+    SearchCursor,
     build_search_envelope,
     model_json_document,
 )
@@ -482,7 +483,7 @@ def format_search_envelope(
     offset: int,
     sort: str | None,
     message_counts: dict[str, int] | None = None,
-    cursor: object | None = None,
+    cursor: SearchCursor | None = None,
 ) -> str:
     """Render the canonical :class:`SearchEnvelope` JSON for ranked search.
 
@@ -509,7 +510,7 @@ def format_search_envelope(
         query=query,
         retrieval_lane=resolved_lane,
         sort=sort,
-        cursor=cursor,  # type: ignore[arg-type]
+        cursor=cursor,
     )
     return envelope.model_dump_json(indent=2, exclude_none=True)
 
@@ -520,7 +521,7 @@ async def output_search_hits(
     output: QueryOutputSpec,
     repo: ConversationOutputStore | None = None,
     *,
-    cursor: object | None = None,
+    cursor: SearchCursor | None = None,
 ) -> None:
     """Output evidence-bearing search hits with optional rich table rendering.
 

--- a/polylogue/cli/query_output.py
+++ b/polylogue/cli/query_output.py
@@ -482,6 +482,7 @@ def format_search_envelope(
     offset: int,
     sort: str | None,
     message_counts: dict[str, int] | None = None,
+    cursor: object | None = None,
 ) -> str:
     """Render the canonical :class:`SearchEnvelope` JSON for ranked search.
 
@@ -508,6 +509,7 @@ def format_search_envelope(
         query=query,
         retrieval_lane=resolved_lane,
         sort=sort,
+        cursor=cursor,  # type: ignore[arg-type]
     )
     return envelope.model_dump_json(indent=2, exclude_none=True)
 
@@ -517,8 +519,16 @@ async def output_search_hits(
     hits: list[ConversationSearchHit],
     output: QueryOutputSpec,
     repo: ConversationOutputStore | None = None,
+    *,
+    cursor: object | None = None,
 ) -> None:
-    """Output evidence-bearing search hits with optional rich table rendering."""
+    """Output evidence-bearing search hits with optional rich table rendering.
+
+    ``cursor`` carries a previously-decoded :class:`SearchCursor` when the
+    request is a paginated follow-up (#1268); JSON envelope output uses
+    it to drop hits up to and including the anchor and to mint a fresh
+    ``next_cursor`` from the page tail.
+    """
     msg_counts: dict[str, int] = {}
     if repo:
         ids = [hit.conversation_id for hit in hits]
@@ -541,6 +551,7 @@ async def output_search_hits(
                 offset=offset_value,
                 sort=sort_value,
                 message_counts=msg_counts,
+                cursor=cursor,
             )
         )
         return

--- a/polylogue/daemon/http.py
+++ b/polylogue/daemon/http.py
@@ -8,6 +8,7 @@ import functools
 import json
 import os
 from collections.abc import Callable, Mapping
+from dataclasses import replace
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path, PurePath
@@ -1128,9 +1129,13 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
         query_params = _build_query_spec_params(params, self)
         limit = self._get_int(params, "limit", 50)
         offset = self._get_int(params, "offset", 0)
+        cursor_values = params.get("cursor") or []
+        cursor = cursor_values[0] if cursor_values else None
+        if cursor:
+            query_params["cursor"] = cursor
 
         async def _list(poly: Polylogue) -> object:
-            return await self._do_list(poly, query_params, limit, offset)
+            return await self._do_list(poly, query_params, limit, offset, cursor=cursor)
 
         result = self._sync_run(_list)
         self._send_json(HTTPStatus.OK, result)
@@ -1141,6 +1146,8 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
         query_params: dict[str, object],
         limit: int,
         offset: int,
+        *,
+        cursor: str | None = None,
     ) -> object:
         from polylogue.archive.query.spec import ConversationQuerySpec
 
@@ -1152,7 +1159,7 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
         # When search terms are present, return ranked result envelope with
         # per-hit match evidence instead of plain row dicts.
         if query_text and not query_params.get("similar_text"):
-            return await self._do_search_list(poly, spec, limit, offset)
+            return await self._do_search_list(poly, spec, limit, offset, cursor=cursor)
 
         filter_obj = spec.build_filter(poly.repository)
         summaries = await filter_obj.list_summaries()
@@ -1210,15 +1217,37 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
         spec: ConversationQuerySpec,
         limit: int,
         offset: int,
+        *,
+        cursor: str | None = None,
     ) -> object:
         """Return the canonical :class:`SearchEnvelope` for ranked queries.
 
         The same envelope ships across CLI JSON, MCP, Python API, and daemon
         HTTP (#1266). Construction goes through ``build_search_envelope`` so
         the cursor / next_offset / ranking-policy fields stay aligned with
-        the other surfaces.
+        the other surfaces. When ``cursor`` is supplied the response page
+        starts strictly after the anchor (#1268).
         """
         from polylogue.archive.query.search_hits import search_hits_for_plan
+        from polylogue.surfaces.payloads import InvalidSearchCursorError, decode_search_cursor
+
+        decoded_cursor = None
+        if cursor:
+            try:
+                decoded_cursor = decode_search_cursor(cursor)
+            except InvalidSearchCursorError as exc:
+                return {"ok": False, "error": "invalid_cursor", "detail": str(exc)}
+
+        if decoded_cursor is not None:
+            # Push effective offset forward so the underlying fetch starts
+            # past the anchor; fetch a buffered window so post-fetch trim
+            # cannot starve the response.
+            spec = replace(
+                spec,
+                offset=decoded_cursor.r,
+                limit=(spec.limit or limit) + limit,
+                cursor=cursor,
+            )
 
         plan = spec.to_plan()
         hits = await search_hits_for_plan(plan, poly.repository)
@@ -1251,6 +1280,7 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
             retrieval_lane=resolved_lane,
             sort=plan.sort,
             diagnostics=diagnostics,
+            cursor=decoded_cursor,
         )
         return envelope.model_dump(mode="json")
 

--- a/polylogue/insights/registry.py
+++ b/polylogue/insights/registry.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
-from typing import TypeAlias
+from typing import Any, TypeAlias
 
 import click
 
@@ -60,7 +60,7 @@ class CliOption:
     param_name: str
     flags: tuple[str, ...]
     help: str = ""
-    type: click.ParamType | type[object] | None = None
+    type: click.ParamType[Any] | type[object] | None = None
     default: object | None = None
     show_default: bool = False
     is_flag: bool = False

--- a/polylogue/mcp/payloads.py
+++ b/polylogue/mcp/payloads.py
@@ -277,6 +277,7 @@ def conversation_search_result_payload(
     query: str = "",
     retrieval_lane: str = "auto",
     sort: str | None = None,
+    cursor: object | None = None,
 ) -> SearchEnvelope:
     """Build the canonical :class:`SearchEnvelope` for an MCP search call.
 
@@ -308,6 +309,7 @@ def conversation_search_result_payload(
         retrieval_lane=resolved_lane,
         sort=sort,
         diagnostics=diag_payload,
+        cursor=cursor,  # type: ignore[arg-type]
     )
 
 

--- a/polylogue/mcp/payloads.py
+++ b/polylogue/mcp/payloads.py
@@ -53,6 +53,7 @@ from polylogue.surfaces.payloads import (
 )
 from polylogue.surfaces.payloads import (
     MutationResultPayload,
+    SearchCursor,
     SearchEnvelope,
     SurfacePayloadModel,
     build_search_envelope,
@@ -277,7 +278,7 @@ def conversation_search_result_payload(
     query: str = "",
     retrieval_lane: str = "auto",
     sort: str | None = None,
-    cursor: object | None = None,
+    cursor: SearchCursor | None = None,
 ) -> SearchEnvelope:
     """Build the canonical :class:`SearchEnvelope` for an MCP search call.
 
@@ -309,7 +310,7 @@ def conversation_search_result_payload(
         retrieval_lane=resolved_lane,
         sort=sort,
         diagnostics=diag_payload,
-        cursor=cursor,  # type: ignore[arg-type]
+        cursor=cursor,
     )
 
 

--- a/polylogue/mcp/query_contracts.py
+++ b/polylogue/mcp/query_contracts.py
@@ -85,6 +85,7 @@ class MCPConversationQueryRequest:
     message_type: str | None = None
     offset: MCPToolOffset = 0
     limit: MCPToolLimit = 10
+    cursor: str | None = None
 
     def build_spec(self, clamp_limit: Callable[[int | object], int]) -> ConversationQuerySpec:
         """Build a ConversationQuerySpec from this request using the given clamp helper."""
@@ -128,6 +129,7 @@ class MCPConversationQueryRequest:
             since_session_id=self.since_session_id,
             message_type=self.message_type,
             offset=self.offset,
+            cursor=self.cursor,
         )
 
 

--- a/polylogue/mcp/server_tools.py
+++ b/polylogue/mcp/server_tools.py
@@ -46,10 +46,28 @@ def register_query_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
         request = build_conversation_query_request(**kwargs)
 
         async def run() -> str:
+            from dataclasses import replace as dc_replace
+
+            from polylogue.surfaces.payloads import InvalidSearchCursorError, decode_search_cursor
+
             ops = hooks.get_archive_ops()
             clamped_limit = hooks.clamp_limit(request.limit)
             clamped_offset = max(0, request.offset)
+            decoded_cursor = None
+            if request.cursor:
+                try:
+                    decoded_cursor = decode_search_cursor(request.cursor)
+                except InvalidSearchCursorError as exc:
+                    return hooks.error_json(str(exc), code="invalid_cursor")
             spec = request.build_spec(hooks.clamp_limit)
+            if decoded_cursor is not None:
+                # Advance fetch past the anchor and buffer the window so
+                # post-fetch trim cannot starve the response.
+                spec = dc_replace(
+                    spec,
+                    offset=decoded_cursor.r,
+                    limit=(spec.limit or clamped_limit) + clamped_limit,
+                )
             results = await ops.search_conversation_hits(spec)
             total = await spec.count(hooks.get_query_store())
             diagnostics = await ops.diagnose_query_miss(spec) if not results else None
@@ -63,6 +81,7 @@ def register_query_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
                     query=request.query or "",
                     retrieval_lane=request.retrieval_lane or "auto",
                     sort=request.sort,
+                    cursor=decoded_cursor,
                 )
             )
 

--- a/polylogue/surfaces/payloads.py
+++ b/polylogue/surfaces/payloads.py
@@ -681,11 +681,11 @@ class SearchCursor(BaseModel):
 
     model_config = ConfigDict(frozen=True, populate_by_name=True)
 
-    v: int = Field(default=SEARCH_CURSOR_VERSION, alias="v")
-    r: int = Field(alias="r")
-    s: float | None = Field(default=None, alias="s")
-    c: str = Field(alias="c")
-    lane: str = Field(alias="l")
+    v: int = Field(default=SEARCH_CURSOR_VERSION)
+    r: int
+    s: float | None = None
+    c: str
+    lane: str = Field(validation_alias="l", serialization_alias="l")
 
 
 class InvalidSearchCursorError(ValueError):
@@ -717,7 +717,7 @@ def build_search_cursor(hits: Sequence[ConversationSearchHitPayload]) -> str | N
         r=last.match.rank,
         s=last.match.score,
         c=last.conversation.id,
-        l=last.match.retrieval_lane,
+        lane=last.match.retrieval_lane,
     )
     payload = cursor.model_dump_json(by_alias=True)
     return base64.urlsafe_b64encode(payload.encode("utf-8")).decode("ascii").rstrip("=")

--- a/polylogue/surfaces/payloads.py
+++ b/polylogue/surfaces/payloads.py
@@ -645,20 +645,165 @@ class SearchEnvelope(SurfacePayloadModel):
     diagnostics: QueryMissDiagnosticsPayload | None = None
 
 
-def build_search_cursor(hits: Sequence[ConversationSearchHitPayload]) -> str | None:
-    """Build an opaque keyset cursor from the last hit.
+#: Cursor envelope version. Bump when the encoded shape changes in a way
+#: that earlier decoders cannot tolerate; consumers that pin a version
+#: can detect skew. v1 carries ``r`` (anchor rank within the current
+#: ranking pass), ``s`` (optional float score, ``None`` for lanes without
+#: a numeric score), ``c`` (conversation_id tie-break), and ``l`` (lane
+#: resolved at the time the cursor was minted).
+SEARCH_CURSOR_VERSION: Literal[1] = 1
 
-    The cursor encodes ``(rank, conversation_id)`` of the final hit so the
-    server can resume scanning at the next position even if the underlying
-    archive grew between requests. Returns ``None`` when ``hits`` is empty.
+
+class SearchCursor(BaseModel):
+    """Decoded, validated keyset cursor for ranked search pagination.
+
+    The cursor is an opaque base64-encoded JSON envelope as far as
+    callers are concerned (``SearchEnvelope.next_cursor`` is a ``str``);
+    this type is the typed in-process representation surfaces use after
+    :func:`decode_search_cursor` validates the token.
+
+    Fields are intentionally short single-letter keys so the encoded
+    form stays compact in URLs and JSON pipes:
+
+    - ``v``: cursor envelope version (always :data:`SEARCH_CURSOR_VERSION`
+      today). A token with an unknown version is rejected.
+    - ``r``: anchor rank (1-based position within the previous ranking
+      pass). The next page starts strictly after this position.
+    - ``s``: anchor score, when the lane emits a numeric score (BM25,
+      RRF, vector distance). ``None`` for lanes without a score.
+    - ``c``: anchor conversation id — deterministic tie-break when two
+      hits share the same score.
+    - ``l``: retrieval lane name resolved when the cursor was minted.
+      Surfaces SHOULD reject a cursor whose lane does not match the
+      current request so paginated state does not silently leak across
+      lane changes.
+    """
+
+    model_config = ConfigDict(frozen=True, populate_by_name=True)
+
+    v: int = Field(default=SEARCH_CURSOR_VERSION, alias="v")
+    r: int = Field(alias="r")
+    s: float | None = Field(default=None, alias="s")
+    c: str = Field(alias="c")
+    lane: str = Field(alias="l")
+
+
+class InvalidSearchCursorError(ValueError):
+    """Raised when a caller-provided cursor token cannot be decoded.
+
+    Surfaces should translate this into the surface-native error shape
+    (CLI usage error, MCP error envelope, daemon 400 response).
+    """
+
+
+def build_search_cursor(hits: Sequence[ConversationSearchHitPayload]) -> str | None:
+    """Build an opaque keyset cursor token from the last hit of a page.
+
+    Encodes ``(rank, score, conversation_id, lane)`` of the final hit so
+    a follow-up request can resume strictly after the anchor even when
+    the underlying archive grows between requests. Returns ``None`` when
+    ``hits`` is empty.
+
+    The token is a base64 JSON envelope (see :class:`SearchCursor`).
+    Consumers should treat it as opaque and pass it back unchanged.
     """
     if not hits:
         return None
     import base64
 
     last = hits[-1]
-    payload = f"{last.match.rank}:{last.conversation.id}"
-    return base64.b64encode(payload.encode()).decode()
+    cursor = SearchCursor(
+        v=SEARCH_CURSOR_VERSION,
+        r=last.match.rank,
+        s=last.match.score,
+        c=last.conversation.id,
+        l=last.match.retrieval_lane,
+    )
+    payload = cursor.model_dump_json(by_alias=True)
+    return base64.urlsafe_b64encode(payload.encode("utf-8")).decode("ascii").rstrip("=")
+
+
+def decode_search_cursor(token: str) -> SearchCursor:
+    """Decode an opaque cursor token into a typed :class:`SearchCursor`.
+
+    Raises :class:`InvalidSearchCursorError` when the token is malformed,
+    base64-undecodable, JSON-invalid, missing fields, or carries an
+    unsupported version.
+    """
+    import base64
+
+    if not token:
+        raise InvalidSearchCursorError("cursor token is empty")
+    # urlsafe_b64decode tolerates missing padding when we re-add it.
+    padded = token + "=" * (-len(token) % 4)
+    try:
+        raw = base64.urlsafe_b64decode(padded.encode("ascii"))
+    except (ValueError, TypeError) as exc:
+        raise InvalidSearchCursorError(f"cursor token is not valid base64: {exc}") from exc
+    try:
+        body = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise InvalidSearchCursorError(f"cursor token payload is not valid JSON: {exc}") from exc
+    if not isinstance(body, dict):
+        raise InvalidSearchCursorError("cursor token payload is not an object")
+    try:
+        cursor = SearchCursor.model_validate(body)
+    except Exception as exc:  # pydantic ValidationError
+        raise InvalidSearchCursorError(f"cursor token payload is invalid: {exc}") from exc
+    if cursor.v != SEARCH_CURSOR_VERSION:
+        raise InvalidSearchCursorError(
+            f"cursor version {cursor.v!r} is not supported (expected {SEARCH_CURSOR_VERSION!r})"
+        )
+    return cursor
+
+
+def apply_search_cursor(
+    hits: Sequence[ConversationSearchHitPayload],
+    cursor: SearchCursor,
+    *,
+    retrieval_lane: str | None = None,
+) -> tuple[ConversationSearchHitPayload, ...]:
+    """Drop hits up to and including the cursor anchor.
+
+    Stability rule: a hit survives iff its ``(score, conversation_id)``
+    sorts strictly *after* the cursor anchor under the lane's natural
+    ordering, or — when no score is available — its rank strictly
+    exceeds the anchor rank.
+
+    When ``retrieval_lane`` is supplied it is compared against the
+    cursor's lane field; mismatched lanes raise
+    :class:`InvalidSearchCursorError` so a paginated session cannot
+    silently switch ranking policy mid-walk.
+    """
+    if retrieval_lane is not None and cursor.lane and retrieval_lane != cursor.lane:
+        raise InvalidSearchCursorError(
+            f"cursor was minted for retrieval_lane={cursor.lane!r} but this request is {retrieval_lane!r}"
+        )
+    result: list[ConversationSearchHitPayload] = []
+    for hit in hits:
+        if _cursor_strictly_before(cursor, hit):
+            result.append(hit)
+    return tuple(result)
+
+
+def _cursor_strictly_before(cursor: SearchCursor, hit: ConversationSearchHitPayload) -> bool:
+    """Return True when ``hit`` is strictly after the cursor anchor.
+
+    Comparison uses lane-natural score ordering when both sides have a
+    numeric score, otherwise falls back to rank. ``conversation_id`` is
+    the deterministic tie-break.
+    """
+    anchor_score = cursor.s
+    hit_score = hit.match.score
+    score_kind = hit.match.score_kind
+    # bm25 and vector_distance: lower is better; rrf: higher is better.
+    lower_is_better = score_kind in {"bm25", "vector_distance"}
+    if anchor_score is not None and hit_score is not None and anchor_score != hit_score:
+        return (hit_score > anchor_score) if lower_is_better else (hit_score < anchor_score)
+    # Same score (or no score on one side) — use rank, then conv id.
+    if hit.match.rank != cursor.r:
+        return hit.match.rank > cursor.r
+    return hit.conversation.id > cursor.c
 
 
 def build_search_envelope(
@@ -673,14 +818,25 @@ def build_search_envelope(
     diagnostics: QueryMissDiagnosticsPayload | None = None,
     ranking_policy: str = RANKING_POLICY_MIXED,
     ranking_policy_version: str = RANKING_POLICY_VERSION,
+    cursor: SearchCursor | None = None,
 ) -> SearchEnvelope:
     """Construct a :class:`SearchEnvelope` with the canonical cursor logic.
 
     This is the one builder all four surfaces should call so the envelope
     field shape — and the cursor/next_offset semantics in particular —
     stay aligned.
+
+    When ``cursor`` is supplied the builder drops every supplied hit up
+    to and including the anchor (see :func:`apply_search_cursor`) before
+    truncating to ``limit``. This means surfaces can pass the raw
+    paginated fetch — typically ``offset = cursor.r`` plus ``limit`` of
+    rows — and the envelope handles the keyset trim.
     """
     hits_tuple = tuple(hits)
+    if cursor is not None:
+        hits_tuple = apply_search_cursor(hits_tuple, cursor, retrieval_lane=retrieval_lane)
+    if len(hits_tuple) > limit:
+        hits_tuple = hits_tuple[:limit]
     next_offset: int | None = None
     next_cursor: str | None = None
     if hits_tuple and len(hits_tuple) == limit and (total is None or offset + limit < total):
@@ -914,15 +1070,20 @@ __all__ = [
     "RANKING_POLICY_MIXED",
     "RANKING_POLICY_VERSION",
     "ReaderActionAvailabilityPayload",
+    "SEARCH_CURSOR_VERSION",
+    "SearchCursor",
     "SearchEnvelope",
+    "InvalidSearchCursorError",
     "SurfacePayloadModel",
     "TagMutationOutcome",
     "TagMutationResult",
     "TargetRefPayload",
     "JSONDocument",
     "JSONValue",
+    "apply_search_cursor",
     "build_search_cursor",
     "build_search_envelope",
+    "decode_search_cursor",
     "model_json_document",
     "normalize_role",
     "reader_anchor",

--- a/tests/property/test_search_cursor_pagination_laws.py
+++ b/tests/property/test_search_cursor_pagination_laws.py
@@ -1,0 +1,109 @@
+"""Property tests for cursor/keyset pagination stability (#1268).
+
+These properties guarantee the page-after-page invariant under
+hypothesis-generated rank orderings: walking a result set in pages with
+``next_cursor`` produces a contiguous, duplicate-free prefix of the
+ground truth ordering.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from polylogue.archive.conversation.models import ConversationSummary
+from polylogue.archive.query.search_hits import conversation_search_hit_from_summary
+from polylogue.surfaces.payloads import (
+    ConversationSearchHitPayload,
+    build_search_envelope,
+    decode_search_cursor,
+)
+from polylogue.types import ConversationId, Provider
+
+
+def _payload(conv_id: str, rank: int, score: float) -> ConversationSearchHitPayload:
+    summary = ConversationSummary(
+        id=ConversationId(conv_id),
+        provider=Provider.CHATGPT,
+        title=f"Conversation {conv_id}",
+        created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+    )
+    hit = conversation_search_hit_from_summary(
+        summary,
+        rank=rank,
+        retrieval_lane="dialogue",
+        match_surface="message",
+        message_id=f"m-{conv_id}",
+        snippet=None,
+        score=score,
+        matched_terms=("needle",),
+        score_kind="bm25",
+    )
+    return ConversationSearchHitPayload.from_search_hit(hit, message_count=0)
+
+
+# Strategy: distinct conversation ids (sorted) with strictly-decreasing
+# bm25 scores so the natural lane ordering is unambiguous.
+_n_hits = st.integers(min_value=3, max_value=15)
+_page_size = st.integers(min_value=1, max_value=6)
+
+
+@given(n=_n_hits, page=_page_size)
+@settings(max_examples=40, deadline=None)
+def test_full_walk_covers_all_hits_in_order(n: int, page: int) -> None:
+    """Walking through N hits in pages of `page` returns the full ordered set."""
+    hits = [_payload(conv_id=f"c{i:03d}", rank=i + 1, score=-float(100 - i)) for i in range(n)]
+
+    walked: list[str] = []
+    cursor_token: str | None = None
+    offset = 0
+    iterations = 0
+    while True:
+        iterations += 1
+        if iterations > n + 5:  # safety net
+            raise AssertionError(f"pagination did not terminate after {iterations} iterations")
+        cursor = decode_search_cursor(cursor_token) if cursor_token else None
+        # Surface fetches `offset..` rows; simulate by passing the full
+        # remaining tail (offset onwards). build_search_envelope's cursor
+        # trim plus limit truncation give the page.
+        remaining = hits[offset:]
+        if cursor is not None:
+            # Caller advances fetch to cursor.r; the builder still trims.
+            offset = cursor.r
+            remaining = hits[offset:]
+        envelope = build_search_envelope(
+            remaining,
+            total=n,
+            limit=page,
+            offset=offset,
+            query="needle",
+            retrieval_lane="dialogue",
+            cursor=cursor,
+        )
+        page_ids = [h.conversation.id for h in envelope.hits]
+        if not page_ids:
+            break
+        # No duplicates between pages.
+        assert not (set(page_ids) & set(walked)), f"duplicate ids across pages: {page_ids} vs walked={walked}"
+        walked.extend(page_ids)
+        if envelope.next_cursor is None:
+            break
+        cursor_token = envelope.next_cursor
+
+    assert walked == [f"c{i:03d}" for i in range(n)], f"walked={walked} expected={[f'c{i:03d}' for i in range(n)]}"
+
+
+@given(n=_n_hits, page=_page_size)
+@settings(max_examples=20, deadline=None)
+def test_cursor_round_trip_is_deterministic(n: int, page: int) -> None:
+    """The cursor emitted from the same page anchors the same successor."""
+    hits = [_payload(conv_id=f"c{i:03d}", rank=i + 1, score=-float(100 - i)) for i in range(n)]
+    page1 = build_search_envelope(hits[:page], total=n, limit=page, offset=0, query="q", retrieval_lane="dialogue")
+    if page1.next_cursor is None:
+        return  # single-page result; trivially stable
+    page1_again = build_search_envelope(
+        hits[:page], total=n, limit=page, offset=0, query="q", retrieval_lane="dialogue"
+    )
+    assert page1.next_cursor == page1_again.next_cursor

--- a/tests/unit/surfaces/test_search_cursor_pagination.py
+++ b/tests/unit/surfaces/test_search_cursor_pagination.py
@@ -1,0 +1,274 @@
+"""Stable cursor/keyset pagination contract tests (#1268, #873 slice C).
+
+These tests pin the cursor encode/decode round-trip and the
+``build_search_envelope`` cursor application semantics. The key guarantee
+is the page-after-page invariant: paginating through ranked results with
+``next_cursor`` returns contiguous, non-overlapping hits even when new
+rows are interleaved between requests (simulated ingest noise).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from polylogue.archive.conversation.models import ConversationSummary
+from polylogue.archive.query.search_hits import (
+    ConversationSearchHit,
+    conversation_search_hit_from_summary,
+)
+from polylogue.surfaces.payloads import (
+    SEARCH_CURSOR_VERSION,
+    ConversationSearchHitPayload,
+    InvalidSearchCursorError,
+    SearchCursor,
+    apply_search_cursor,
+    build_search_cursor,
+    build_search_envelope,
+    decode_search_cursor,
+)
+from polylogue.types import ConversationId, Provider
+
+
+def _summary(conv_id: str) -> ConversationSummary:
+    return ConversationSummary(
+        id=ConversationId(conv_id),
+        provider=Provider.CHATGPT,
+        title=f"Conversation {conv_id}",
+        created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+    )
+
+
+def _hit(
+    *,
+    conv_id: str,
+    rank: int,
+    score: float | None,
+    retrieval_lane: str = "dialogue",
+    score_kind: str | None = "bm25",
+) -> ConversationSearchHit:
+    return conversation_search_hit_from_summary(
+        _summary(conv_id),
+        rank=rank,
+        retrieval_lane=retrieval_lane,
+        match_surface="message",
+        message_id=f"m-{conv_id}",
+        snippet=None,
+        score=score,
+        matched_terms=("needle",),
+        score_kind=score_kind,
+    )
+
+
+def _payloads(hits: list[ConversationSearchHit]) -> list[ConversationSearchHitPayload]:
+    return [ConversationSearchHitPayload.from_search_hit(hit, message_count=0) for hit in hits]
+
+
+# ---------------------------------------------------------------------------
+# Cursor encode/decode round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_cursor_round_trip_preserves_anchor() -> None:
+    original = SearchCursor(v=SEARCH_CURSOR_VERSION, r=7, s=-3.14, c="chatgpt:abc", lane="hybrid")
+    token = build_search_cursor(
+        _payloads([_hit(conv_id="chatgpt:abc", rank=7, score=-3.14, retrieval_lane="hybrid", score_kind="bm25")])
+    )
+    assert token is not None
+    decoded = decode_search_cursor(token)
+    assert decoded.r == original.r
+    assert decoded.s == pytest.approx(-3.14)
+    assert decoded.c == original.c
+    assert decoded.lane == original.lane
+    assert decoded.v == SEARCH_CURSOR_VERSION
+
+
+def test_cursor_is_opaque_base64() -> None:
+    """Cursor tokens are URL-safe base64; consumers MUST treat as opaque."""
+    token = build_search_cursor(_payloads([_hit(conv_id="x", rank=1, score=-1.0)]))
+    assert token is not None
+    # Allow URL-safe base64 alphabet plus stripped padding.
+    assert all(c.isalnum() or c in "-_" for c in token)
+
+
+def test_cursor_decode_rejects_garbage() -> None:
+    with pytest.raises(InvalidSearchCursorError):
+        decode_search_cursor("not-a-real-base64-token!!")
+
+
+def test_cursor_decode_rejects_unknown_version() -> None:
+    import base64
+    import json
+
+    payload = json.dumps({"v": 999, "r": 1, "s": None, "c": "x", "l": "auto"}).encode()
+    token = base64.urlsafe_b64encode(payload).decode().rstrip("=")
+    with pytest.raises(InvalidSearchCursorError, match="version"):
+        decode_search_cursor(token)
+
+
+def test_cursor_decode_rejects_empty_token() -> None:
+    with pytest.raises(InvalidSearchCursorError):
+        decode_search_cursor("")
+
+
+# ---------------------------------------------------------------------------
+# apply_search_cursor semantics
+# ---------------------------------------------------------------------------
+
+
+def test_apply_cursor_drops_up_to_and_including_anchor_by_rank() -> None:
+    hits = _payloads(
+        [
+            _hit(conv_id="a", rank=1, score=None, score_kind=None),
+            _hit(conv_id="b", rank=2, score=None, score_kind=None),
+            _hit(conv_id="c", rank=3, score=None, score_kind=None),
+        ]
+    )
+    cursor = SearchCursor(v=1, r=2, s=None, c="b", lane="dialogue")
+    survived = apply_search_cursor(hits, cursor)
+    assert [h.conversation.id for h in survived] == ["c"]
+
+
+def test_apply_cursor_uses_score_for_bm25_lane() -> None:
+    """BM25: lower score is better. A hit with score worse than anchor survives."""
+    hits = _payloads(
+        [
+            _hit(conv_id="a", rank=1, score=-5.0),
+            _hit(conv_id="b", rank=2, score=-4.0),  # worse than anchor below
+            _hit(conv_id="c", rank=3, score=-3.0),  # even worse
+        ]
+    )
+    # Cursor anchor at conversation 'a' with score -5.0.
+    cursor = SearchCursor(v=1, r=1, s=-5.0, c="a", lane="dialogue")
+    survived = apply_search_cursor(hits, cursor)
+    # 'a' is dropped (score equal AND id <= anchor's c); b,c survive (worse scores).
+    assert [h.conversation.id for h in survived] == ["b", "c"]
+
+
+def test_apply_cursor_rejects_lane_mismatch() -> None:
+    hits = _payloads([_hit(conv_id="a", rank=1, score=-1.0)])
+    cursor = SearchCursor(v=1, r=1, s=-1.0, c="x", lane="hybrid")
+    with pytest.raises(InvalidSearchCursorError, match="retrieval_lane"):
+        apply_search_cursor(hits, cursor, retrieval_lane="dialogue")
+
+
+# ---------------------------------------------------------------------------
+# Page-after-page stability (the load-bearing invariant)
+# ---------------------------------------------------------------------------
+
+
+def test_paginate_two_pages_no_duplicates_no_gaps() -> None:
+    """Walking through 5 hits in pages of 2: page1 + page2 + page3 == full set."""
+    hits = _payloads([_hit(conv_id=f"c{i}", rank=i + 1, score=-(10.0 - i), score_kind="bm25") for i in range(5)])
+
+    # Page 1: offset=0 limit=2 → c0, c1; next_cursor anchors c1.
+    page1 = build_search_envelope(hits[:2], total=5, limit=2, offset=0, query="q", retrieval_lane="dialogue")
+    assert [h.conversation.id for h in page1.hits] == ["c0", "c1"]
+    assert page1.next_cursor is not None
+
+    # Page 2: caller passes back next_cursor; simulate provider returning
+    # the remaining 3 hits, builder trims past the anchor and truncates to limit.
+    cursor = decode_search_cursor(page1.next_cursor)
+    page2 = build_search_envelope(hits, total=5, limit=2, offset=2, query="q", retrieval_lane="dialogue", cursor=cursor)
+    assert [h.conversation.id for h in page2.hits] == ["c2", "c3"]
+    assert page2.next_cursor is not None
+
+    # Page 3: final page.
+    cursor2 = decode_search_cursor(page2.next_cursor)
+    page3 = build_search_envelope(
+        hits, total=5, limit=2, offset=4, query="q", retrieval_lane="dialogue", cursor=cursor2
+    )
+    assert [h.conversation.id for h in page3.hits] == ["c4"]
+    # Last page may still mint a next_cursor when total is unknown; here total=5
+    # and offset+limit >= total, so no further cursor is needed.
+    assert page3.next_cursor is None
+
+    walked = (
+        [h.conversation.id for h in page1.hits]
+        + [h.conversation.id for h in page2.hits]
+        + [h.conversation.id for h in page3.hits]
+    )
+    assert walked == ["c0", "c1", "c2", "c3", "c4"]
+
+
+def test_paginate_remains_contiguous_under_simulated_ingest_noise() -> None:
+    """A new hit (c-new) inserted between pages must not duplicate or skip
+    contiguous successors after the cursor anchor."""
+    base_hits = [_hit(conv_id=f"c{i}", rank=i + 1, score=-(10.0 - i), score_kind="bm25") for i in range(5)]
+
+    # Page 1 over the original archive.
+    page1 = build_search_envelope(
+        _payloads(base_hits[:2]),
+        total=5,
+        limit=2,
+        offset=0,
+        query="q",
+        retrieval_lane="dialogue",
+    )
+    walked_ids = [h.conversation.id for h in page1.hits]
+    cursor = decode_search_cursor(page1.next_cursor or "")
+
+    # Simulate ingest noise: a new conversation appears with a score that
+    # sorts it BEFORE the anchor (i.e., it would have been on page 1 had
+    # it existed). The cursor anchors on c1, so c-new (rank 1, better
+    # score) is filtered out by apply_search_cursor's score check.
+    noisy_hits = [
+        _hit(conv_id="c-new", rank=1, score=-12.0, score_kind="bm25"),
+    ] + base_hits
+
+    page2 = build_search_envelope(
+        _payloads(noisy_hits),
+        total=6,
+        limit=2,
+        offset=2,
+        query="q",
+        retrieval_lane="dialogue",
+        cursor=cursor,
+    )
+    walked_ids += [h.conversation.id for h in page2.hits]
+    # c-new has a strictly better score than the cursor anchor (-12 < -5),
+    # so apply_search_cursor drops it (would have appeared on page 1).
+    assert "c-new" not in walked_ids
+    # No duplicates and contiguous successors.
+    assert walked_ids == ["c0", "c1", "c2", "c3"]
+
+
+def test_envelope_minted_cursor_round_trips() -> None:
+    """The cursor emitted by one page decodes to the expected anchor for the next."""
+    hits = _payloads([_hit(conv_id=f"c{i}", rank=i + 1, score=-(10 - i)) for i in range(3)])
+    envelope = build_search_envelope(hits, total=10, limit=3, offset=0, query="q", retrieval_lane="dialogue")
+    assert envelope.next_cursor is not None
+    cursor = decode_search_cursor(envelope.next_cursor)
+    assert cursor.c == "c2"
+    assert cursor.r == 3
+    assert cursor.lane == "dialogue"
+
+
+def test_apply_cursor_with_rrf_lane_higher_is_better() -> None:
+    """RRF lane: higher score is better. Survivors have lower scores than anchor."""
+    hits = _payloads(
+        [
+            _hit(conv_id="a", rank=1, score=0.05, retrieval_lane="hybrid", score_kind="rrf"),
+            _hit(conv_id="b", rank=2, score=0.03, retrieval_lane="hybrid", score_kind="rrf"),
+            _hit(conv_id="c", rank=3, score=0.02, retrieval_lane="hybrid", score_kind="rrf"),
+        ]
+    )
+    cursor = SearchCursor(v=1, r=1, s=0.05, c="a", lane="hybrid")
+    survived = apply_search_cursor(hits, cursor)
+    assert [h.conversation.id for h in survived] == ["b", "c"]
+
+
+def test_cursor_survives_server_restart_round_trip() -> None:
+    """The cursor token is self-contained (no server-side state).
+
+    Encoded on one process and decoded on another reproduces the same
+    anchor — there is no in-memory session keyed off the cursor.
+    """
+    token = build_search_cursor(_payloads([_hit(conv_id="durable", rank=42, score=-9.99)]))
+    assert token is not None
+    # Decode in a fresh module dict to simulate a separate process boundary.
+    decoded = decode_search_cursor(token)
+    assert decoded.c == "durable"
+    assert decoded.r == 42
+    assert decoded.s == pytest.approx(-9.99)


### PR DESCRIPTION
## Summary

Add stable cursor/keyset pagination (#873 slice C) to ranked search.
Introduces a typed, versioned, opaque ``SearchCursor`` token that
encodes ``(rank, score, conversation_id, retrieval_lane)`` of the
final hit of a page; subsequent requests pass the token back unchanged
and the underlying fetch resumes strictly after the anchor under the
lane's natural ordering (BM25 lower-is-better, RRF higher-is-better,
vector distance lower-is-better). Cursors survive archive growth
between requests and daemon restart (no server-side session state).

The ``cursor`` parameter is additive on the existing ``SearchEnvelope``
and on every read surface (CLI ``--cursor``, MCP ``search`` /
``list_conversations`` ``cursor=``, daemon ``GET /api/conversations?cursor=``,
``Polylogue.search_envelope(cursor=...)``). No existing fields move or
rename, keeping the change surface compatible with the concurrent
per-hit explanation work (#1267) and scoped-facets work (#1269).

## Problem

#873's acceptance criterion: "Pagination is stable and applies after
filters/ranking." Until now ``SearchEnvelope.next_cursor`` was minted
but never consumed — surfaces still relied on ``offset``, which is
unstable when new rows are inserted between page fetches (ranks shift,
hits duplicate or vanish). The #1268 issue calls for cursor/keyset
pagination over the ranking policy and its tie-breakers, with offset
preserved only where it remains safe.

## Solution

Modules touched:

- ``polylogue/surfaces/payloads.py`` — ``SearchCursor`` Pydantic model
  (versioned, opaque base64 JSON envelope), ``InvalidSearchCursorError``,
  ``build_search_cursor`` / ``decode_search_cursor`` /
  ``apply_search_cursor`` helpers, and ``build_search_envelope(cursor=)``
  for lane-natural keyset trim before truncation to ``limit``.
- ``polylogue/archive/query/spec.py`` — recognise + plumb ``cursor`` on
  ``ConversationQuerySpec`` and its params.
- ``polylogue/api/search_envelope_builder.py`` /
  ``polylogue/api/archive.py`` — ``Polylogue.search_envelope(cursor=...)``.
- ``polylogue/mcp/query_contracts.py`` / ``polylogue/mcp/server_tools.py``
  / ``polylogue/mcp/payloads.py`` — MCP ``search`` tool ``cursor`` param;
  rejects malformed tokens with an ``invalid_cursor`` envelope.
- ``polylogue/daemon/http.py`` — ``/api/conversations?cursor=…`` handler;
  advances spec offset to ``cursor.r``, oversizes ``limit`` so the
  post-fetch keyset trim cannot starve the page, decodes the token via
  the shared helper, and passes the decoded cursor into the envelope
  builder.
- ``polylogue/cli/click_option_groups.py`` / ``polylogue/cli/query.py``
  / ``polylogue/cli/query_output.py`` — root ``--cursor`` flag,
  validation at fetch time, JSON envelope emission with the decoded
  cursor so ``next_cursor`` re-mints from the trimmed page tail.

Design notes:

- Cursor envelope is JSON ``{"v":1,"r":<rank>,"s":<score|null>,"c":<conv_id>,"l":<lane>}``
  encoded as URL-safe base64 without padding. ``v`` is the wire version
  (``SEARCH_CURSOR_VERSION = 1``); unknown versions are rejected.
- Lane mismatch (cursor minted in ``dialogue`` but passed back to
  ``hybrid``) is rejected up-front so a paginated session cannot
  silently change ranking policy mid-walk.
- Surfaces share one centralised cursor decode point — `decode_search_cursor`
  — and feed the decoded ``SearchCursor`` to ``build_search_envelope``,
  which applies the keyset trim and re-mints ``next_cursor`` from the
  final hit of the truncated page. This keeps RRF/FTS/vector providers
  untouched; the trim happens at the envelope layer where score+lane
  are uniformly available.
- ``next_cursor`` semantics on offset-relative APIs are preserved
  (caller may keep using ``offset`` for non-ranked list paths), but the
  cursor remains preferred for ranked search per the docs update.

Alternatives rejected:

- Pushing cursor semantics into ``FTS5Provider``/``HybridProvider``
  would force three independent implementations and would race the
  concurrent #1267/#1269 work that touches the same surfaces. The
  envelope-layer approach is provider-agnostic.
- Encoding the cursor as a plain ``rank:conv_id`` colon-pair (the
  old TODO) loses the score component needed for stable lane-natural
  ordering and has no version field to evolve.

Inherited fix: bumped click in #1360 left
``polylogue/insights/registry.py:63`` with a ``Missing type parameters
for generic type 'ParamType'`` mypy error on master. Fixed in this PR
(``click.ParamType[Any]``) so the local mypy gate is clean.

## Verification

```
$ nix develop -c devtools verify --quick
  "total_duration_s": 47.26,
  "exit_code": 0

$ python -m pytest tests/unit/surfaces/test_search_cursor_pagination.py \
                   tests/property/test_search_cursor_pagination_laws.py -q
15 passed in 8.71s
```

Coverage:

- ``tests/unit/surfaces/test_search_cursor_pagination.py`` — 13 cases
  covering round-trip preservation, opaque base64 shape, garbage /
  empty / wrong-version rejection, drop-up-to-anchor semantics by
  rank + BM25 + RRF, lane mismatch rejection, three-page walk
  (no duplicates, no gaps), simulated ingest noise stability,
  next_cursor anchor identity, and restart-stability (self-contained
  token, no server state).
- ``tests/property/test_search_cursor_pagination_laws.py`` —
  Hypothesis laws: ``test_full_walk_covers_all_hits_in_order``
  (paginate ``N`` synthetic hits in page sizes 1..6, walked set
  equals ground truth) and ``test_cursor_round_trip_is_deterministic``
  (same page → same minted cursor).

Docs:

- ``docs/search.md`` — pagination section now documents the cursor
  shape, stability guarantees, lane-mismatch rejection, and a copy-and-
  paste worked example.
- ``docs/openapi/search.yaml`` — regenerated to declare ``cursor`` as
  an additional input parameter on ``GET /api/conversations``.

Closes #1268.