### PR TITLE
feat(topology): typed read model API — ancestors/descendants/siblings/thread (#1261)

### DIFF
--- a/polylogue/api/insights.py
+++ b/polylogue/api/insights.py
@@ -38,6 +38,7 @@ from polylogue.insights.productivity import (
     ProductivityRollupInsightQuery,
 )
 from polylogue.insights.tool_usage import ToolUsageInsight, ToolUsageInsightQuery
+from polylogue.insights.topology import ConversationRef, SessionTopology
 
 if TYPE_CHECKING:
 
@@ -124,6 +125,10 @@ if TYPE_CHECKING:
 
 class _RepositorySurface(Protocol):
     async def get_session_profile(self, conversation_id: str) -> SessionProfile | None: ...
+
+    async def get_session_topology(self, conversation_id: str) -> SessionTopology | None: ...
+
+    async def resolve_id(self, conversation_id: str, *, strict: bool = False) -> object: ...
 
 
 class PolylogueInsightsMixin:
@@ -275,3 +280,79 @@ class PolylogueInsightsMixin:
         if not corrections:
             return base
         return apply_correction_to_classification(base, corrections)
+
+    # ------------------------------------------------------------------
+    # Topology read API (#1261 / #866 slice D)
+    #
+    # Surface the derived ``SessionTopology`` graph as a typed Python API
+    # so MCP, future reader panes, and context packs consume one read
+    # model instead of re-walking parent pointers. Each helper accepts a
+    # short or full conversation ID and resolves it before delegating.
+    # ------------------------------------------------------------------
+
+    async def _resolve_for_topology(self, conversation_id: str) -> str | None:
+        resolved = await self.repository.resolve_id(conversation_id, strict=True)
+        if resolved is None:
+            return None
+        return str(resolved)
+
+    async def get_session_topology(self, conversation_id: str) -> SessionTopology | None:
+        """Return the typed :class:`SessionTopology` for ``conversation_id``.
+
+        Returns ``None`` when the conversation is unknown. Cycles and
+        unresolved native parent edges are surfaced via the topology
+        object itself; see :class:`SessionTopology`.
+        """
+
+        resolved = await self._resolve_for_topology(conversation_id)
+        if resolved is None:
+            return None
+        return await self.repository.get_session_topology(resolved)
+
+    async def get_ancestors(self, conversation_id: str) -> list[ConversationRef]:
+        """Return ancestor refs ordered root → parent.
+
+        Empty list when the conversation is its own topology root, when
+        it is unknown, or when no resolved ancestors exist.
+        """
+
+        resolved = await self._resolve_for_topology(conversation_id)
+        if resolved is None:
+            return []
+        topology = await self.repository.get_session_topology(resolved)
+        if topology is None:
+            return []
+        return topology.ancestor_refs(resolved)
+
+    async def get_descendants(self, conversation_id: str) -> list[ConversationRef]:
+        """Return descendant refs in BFS order."""
+
+        resolved = await self._resolve_for_topology(conversation_id)
+        if resolved is None:
+            return []
+        topology = await self.repository.get_session_topology(resolved)
+        if topology is None:
+            return []
+        return topology.descendant_refs(resolved)
+
+    async def get_siblings(self, conversation_id: str) -> list[ConversationRef]:
+        """Return sibling refs (other children of the resolved parent)."""
+
+        resolved = await self._resolve_for_topology(conversation_id)
+        if resolved is None:
+            return []
+        topology = await self.repository.get_session_topology(resolved)
+        if topology is None:
+            return []
+        return topology.sibling_refs(resolved)
+
+    async def get_thread(self, conversation_id: str) -> list[ConversationRef]:
+        """Return the full lineage thread ordered ancestors → self → descendants."""
+
+        resolved = await self._resolve_for_topology(conversation_id)
+        if resolved is None:
+            return []
+        topology = await self.repository.get_session_topology(resolved)
+        if topology is None:
+            return []
+        return topology.thread_refs(resolved)

--- a/polylogue/insights/topology.py
+++ b/polylogue/insights/topology.py
@@ -62,6 +62,26 @@ class TopologyEdgeKind(str, Enum):
         return cls(branch_type.value)
 
 
+class ConversationRef(BaseModel):
+    """Typed reference to a conversation, returned by topology read APIs.
+
+    Carries the minimal projection that lineage consumers need (id +
+    provider + title + depth) without forcing them to hydrate the full
+    :class:`~polylogue.archive.conversation.models.Conversation`. Slice D
+    of #866: surfaces such as the MCP topology tool, future reader panes,
+    and context packs consume this ref instead of re-walking parent
+    pointers.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    conversation_id: ConversationId
+    provider_name: str = ""
+    title: str | None = None
+    depth: int = 0
+    """Distance from the topology root (root has depth 0)."""
+
+
 class TopologyNode(BaseModel):
     """One conversation in the topology graph."""
 
@@ -74,6 +94,16 @@ class TopologyNode(BaseModel):
     """Distance from the topology root (root has depth 0)."""
 
     is_root: bool = False
+
+    def as_ref(self) -> ConversationRef:
+        """Project this node into a :class:`ConversationRef`."""
+
+        return ConversationRef(
+            conversation_id=self.conversation_id,
+            provider_name=self.provider_name,
+            title=self.title,
+            depth=self.depth,
+        )
 
 
 class TopologyEdge(BaseModel):
@@ -187,8 +217,67 @@ class SessionTopology(BaseModel):
 
         return tuple(edge for edge in self.edges if not edge.resolved)
 
+    # ------------------------------------------------------------------
+    # Typed projection surface (#1261 / #866 slice D)
+    #
+    # These methods return :class:`ConversationRef` lists rather than raw
+    # ``ConversationId`` tuples so callers (Python API, MCP, future reader
+    # panes) get title/provider context without re-fetching conversation
+    # rows. They are layered on top of the existing structural helpers so
+    # ordering semantics stay identical.
+    # ------------------------------------------------------------------
+
+    def _node_index(self) -> dict[str, TopologyNode]:
+        return {str(node.conversation_id): node for node in self.nodes}
+
+    def _refs_for(self, ids: tuple[ConversationId, ...]) -> list[ConversationRef]:
+        index = self._node_index()
+        refs: list[ConversationRef] = []
+        for conv_id in ids:
+            node = index.get(str(conv_id))
+            if node is not None:
+                refs.append(node.as_ref())
+        return refs
+
+    def ancestor_refs(self, conversation_id: str) -> list[ConversationRef]:
+        """Return ancestor :class:`ConversationRef`s ordered root → parent."""
+
+        return self._refs_for(self.ancestors(conversation_id))
+
+    def descendant_refs(self, conversation_id: str) -> list[ConversationRef]:
+        """Return descendant :class:`ConversationRef`s in BFS order."""
+
+        return self._refs_for(self.descendants(conversation_id))
+
+    def sibling_refs(self, conversation_id: str) -> list[ConversationRef]:
+        """Return sibling :class:`ConversationRef`s (shared resolved parent)."""
+
+        return self._refs_for(self.siblings(conversation_id))
+
+    def thread_refs(self, conversation_id: str) -> list[ConversationRef]:
+        """Return the full lineage thread ordered ancestors → self → descendants.
+
+        Use this when the consumer wants a single linearization of the
+        whole sub-lineage rooted at the topology root and reaching every
+        descendant of ``conversation_id``. The self node is included
+        between the ancestors and the descendants — this preserves the
+        topological order ancestors → self → descendants that
+        chronological readers expect.
+        """
+
+        index = self._node_index()
+        target_node = index.get(str(conversation_id))
+        if target_node is None:
+            return []
+        thread: list[ConversationRef] = []
+        thread.extend(self._refs_for(self.ancestors(conversation_id)))
+        thread.append(target_node.as_ref())
+        thread.extend(self._refs_for(self.descendants(conversation_id)))
+        return thread
+
 
 __all__ = [
+    "ConversationRef",
     "SessionTopology",
     "TopologyEdge",
     "TopologyEdgeKind",

--- a/polylogue/mcp/payloads.py
+++ b/polylogue/mcp/payloads.py
@@ -191,6 +191,44 @@ class MCPSessionTreePayload(SurfacePayloadModel):
     total: int
 
 
+class MCPConversationRefPayload(SurfacePayloadModel):
+    """One conversation reference inside a topology payload (#1261)."""
+
+    conversation_id: str
+    provider_name: str = ""
+    title: str | None = None
+    depth: int = 0
+
+
+class MCPTopologyEdgePayload(SurfacePayloadModel):
+    """One resolved or unresolved-native edge inside a topology payload."""
+
+    child_id: str
+    parent_id: str | None
+    parent_native_id: str | None
+    kind: str
+    resolved: bool
+
+
+class MCPSessionTopologyPayload(SurfacePayloadModel):
+    """Typed envelope for ``get_session_topology`` (#1261 / #866 slice D).
+
+    The four ref lists mirror the helper methods on
+    :class:`~polylogue.insights.topology.SessionTopology` so callers do
+    not have to re-derive lineage from the raw node/edge tuples.
+    """
+
+    target_id: str
+    root_id: str
+    cycle_detected: bool
+    nodes: tuple[MCPConversationRefPayload, ...]
+    edges: tuple[MCPTopologyEdgePayload, ...]
+    ancestors: tuple[MCPConversationRefPayload, ...]
+    descendants: tuple[MCPConversationRefPayload, ...]
+    siblings: tuple[MCPConversationRefPayload, ...]
+    thread: tuple[MCPConversationRefPayload, ...]
+
+
 class MCPNeighborCandidatesPayload(SurfacePayloadModel):
     """Bounded envelope for ``neighbor_candidates``.
 
@@ -257,6 +295,49 @@ def session_tree_payload(
 ) -> MCPSessionTreePayload:
     items = tuple(MCPConversationSummaryPayload.from_conversation(conv) for conv in conversations)
     return MCPSessionTreePayload(items=items, total=len(items))
+
+
+def _ref_payload(ref: object) -> MCPConversationRefPayload:
+    # Imported lazily to avoid pulling insights/topology into the module
+    # import graph at module load time.
+    from polylogue.insights.topology import ConversationRef
+
+    assert isinstance(ref, ConversationRef)
+    return MCPConversationRefPayload(
+        conversation_id=str(ref.conversation_id),
+        provider_name=ref.provider_name,
+        title=ref.title,
+        depth=ref.depth,
+    )
+
+
+def session_topology_payload(topology: object, *, conversation_id: str) -> MCPSessionTopologyPayload:
+    """Build the typed MCP payload for ``get_session_topology`` (#1261)."""
+    from polylogue.insights.topology import SessionTopology
+
+    assert isinstance(topology, SessionTopology)
+    nodes = tuple(_ref_payload(node.as_ref()) for node in topology.nodes)
+    edges = tuple(
+        MCPTopologyEdgePayload(
+            child_id=str(edge.child_id),
+            parent_id=str(edge.parent_id) if edge.parent_id is not None else None,
+            parent_native_id=edge.parent_native_id,
+            kind=str(edge.kind.value),
+            resolved=edge.resolved,
+        )
+        for edge in topology.edges
+    )
+    return MCPSessionTopologyPayload(
+        target_id=str(topology.target_id),
+        root_id=str(topology.root_id),
+        cycle_detected=topology.cycle_detected,
+        nodes=nodes,
+        edges=edges,
+        ancestors=tuple(_ref_payload(ref) for ref in topology.ancestor_refs(conversation_id)),
+        descendants=tuple(_ref_payload(ref) for ref in topology.descendant_refs(conversation_id)),
+        siblings=tuple(_ref_payload(ref) for ref in topology.sibling_refs(conversation_id)),
+        thread=tuple(_ref_payload(ref) for ref in topology.thread_refs(conversation_id)),
+    )
 
 
 def neighbor_candidates_payload(

--- a/polylogue/mcp/server_tools.py
+++ b/polylogue/mcp/server_tools.py
@@ -17,6 +17,7 @@ from polylogue.mcp.payloads import (
     conversation_query_result_payload,
     conversation_search_result_payload,
     neighbor_candidates_payload,
+    session_topology_payload,
     session_tree_payload,
 )
 from polylogue.mcp.query_contracts import (
@@ -248,6 +249,27 @@ def register_read_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
             return hooks.json_payload(session_tree_payload(tree))
 
         return await hooks.async_safe_call("get_session_tree", run)
+
+    @mcp.tool()
+    async def get_session_topology(conversation_id: str) -> str:
+        """Return typed lineage topology (ancestors/descendants/siblings/thread).
+
+        Returns the resolved :class:`SessionTopology` graph (#1261 /
+        #866 slice D) plus pre-projected ref lists so external agents can
+        navigate session lineage without re-walking parent pointers.
+        """
+
+        async def run() -> str:
+            poly = hooks.get_polylogue()
+            topology = await poly.get_session_topology(conversation_id)
+            if topology is None:
+                return hooks.error_json(
+                    f"Conversation not found: {conversation_id}",
+                    code="not_found",
+                )
+            return hooks.json_payload(session_topology_payload(topology, conversation_id=str(topology.target_id)))
+
+        return await hooks.async_safe_call("get_session_topology", run)
 
     @mcp.tool()
     async def get_stats_by(group_by: Literal["provider", "month", "year"] = "provider") -> str:

--- a/tests/data/witnesses/mcp-tool-schemas.json
+++ b/tests/data/witnesses/mcp-tool-schemas.json
@@ -1389,6 +1389,22 @@
     }
   },
   {
+    "name": "get_session_topology",
+    "parameters": {
+      "properties": {
+        "conversation_id": {
+          "title": "Conversation Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "conversation_id"
+      ],
+      "title": "get_session_topologyArguments",
+      "type": "object"
+    }
+  },
+  {
     "name": "get_session_tree",
     "parameters": {
       "properties": {

--- a/tests/unit/api/test_topology_api.py
+++ b/tests/unit/api/test_topology_api.py
@@ -1,0 +1,194 @@
+"""Typed topology read-model API contract tests (#1261 / #866 slice D).
+
+These tests pin the four typed lineage methods on the
+:class:`~polylogue.api.Polylogue` facade — ``get_session_topology``,
+``get_ancestors``, ``get_descendants``, ``get_siblings``, and
+``get_thread`` — against synthetic lineages seeded through
+``ConversationBuilder``. They are the public-API equivalent of the
+storage-level coverage in
+``tests/unit/storage/test_session_topology.py`` and exist so future
+refactors of the substrate cannot silently regress the surface contract.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from polylogue.api import Polylogue
+from polylogue.insights.topology import ConversationRef, SessionTopology
+from tests.infra.storage_records import ConversationBuilder, db_setup
+
+
+def _seed_lineage(db_path: Path) -> None:
+    """Seed: root → continuation → fork, with subagent + sidechain off root."""
+
+    ConversationBuilder(db_path, "root").provider("claude-code").title("Root").add_message(
+        role="user", text="kickoff"
+    ).save()
+    ConversationBuilder(db_path, "continuation").provider("claude-code").title("Continuation").parent_conversation(
+        "root"
+    ).branch_type("continuation").add_message(role="user", text="continue").save()
+    ConversationBuilder(db_path, "fork").provider("claude-code").title("Fork").parent_conversation(
+        "continuation"
+    ).branch_type("fork").add_message(role="user", text="fork").save()
+    ConversationBuilder(db_path, "subagent").provider("claude-code").title("Subagent").parent_conversation(
+        "root"
+    ).branch_type("subagent").add_message(role="assistant", text="agent").save()
+    ConversationBuilder(db_path, "sidechain").provider("claude-code").title("Sidechain").parent_conversation(
+        "root"
+    ).branch_type("sidechain").add_message(role="user", text="side").save()
+
+
+@pytest.mark.asyncio
+async def test_get_session_topology_returns_typed_envelope(workspace_env: dict[str, Path]) -> None:
+    db_path = db_setup(workspace_env)
+    _seed_lineage(db_path)
+
+    polylogue = Polylogue(archive_root=workspace_env["archive_root"], db_path=db_path)
+    try:
+        topology = await polylogue.get_session_topology("fork")
+    finally:
+        await polylogue.close()
+
+    assert isinstance(topology, SessionTopology)
+    assert str(topology.root_id) == "root"
+    assert str(topology.target_id) == "fork"
+    assert not topology.cycle_detected
+    assert {str(n.conversation_id) for n in topology.nodes} == {
+        "root",
+        "continuation",
+        "fork",
+        "subagent",
+        "sidechain",
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_ancestors_returns_root_to_parent_refs(workspace_env: dict[str, Path]) -> None:
+    db_path = db_setup(workspace_env)
+    _seed_lineage(db_path)
+
+    polylogue = Polylogue(archive_root=workspace_env["archive_root"], db_path=db_path)
+    try:
+        ancestors = await polylogue.get_ancestors("fork")
+        root_ancestors = await polylogue.get_ancestors("root")
+    finally:
+        await polylogue.close()
+
+    assert all(isinstance(ref, ConversationRef) for ref in ancestors)
+    assert [str(ref.conversation_id) for ref in ancestors] == ["root", "continuation"]
+    # Each ref carries provider/title context so callers do not re-fetch.
+    assert ancestors[0].provider_name == "claude-code"
+    assert ancestors[0].title == "Root"
+    assert ancestors[0].depth == 0
+    # Root has no ancestors.
+    assert root_ancestors == []
+
+
+@pytest.mark.asyncio
+async def test_get_descendants_bfs_order(workspace_env: dict[str, Path]) -> None:
+    db_path = db_setup(workspace_env)
+    _seed_lineage(db_path)
+
+    polylogue = Polylogue(archive_root=workspace_env["archive_root"], db_path=db_path)
+    try:
+        descendants_of_root = await polylogue.get_descendants("root")
+        descendants_of_continuation = await polylogue.get_descendants("continuation")
+        leaf_descendants = await polylogue.get_descendants("fork")
+    finally:
+        await polylogue.close()
+
+    assert {str(ref.conversation_id) for ref in descendants_of_root} == {
+        "continuation",
+        "fork",
+        "subagent",
+        "sidechain",
+    }
+    assert [str(ref.conversation_id) for ref in descendants_of_continuation] == ["fork"]
+    assert leaf_descendants == []
+
+
+@pytest.mark.asyncio
+async def test_get_siblings_excludes_self(workspace_env: dict[str, Path]) -> None:
+    db_path = db_setup(workspace_env)
+    _seed_lineage(db_path)
+
+    polylogue = Polylogue(archive_root=workspace_env["archive_root"], db_path=db_path)
+    try:
+        siblings = await polylogue.get_siblings("subagent")
+        root_siblings = await polylogue.get_siblings("root")
+    finally:
+        await polylogue.close()
+
+    sibling_ids = {str(ref.conversation_id) for ref in siblings}
+    assert sibling_ids == {"continuation", "sidechain"}
+    # Root has no resolved parent, hence no siblings.
+    assert root_siblings == []
+
+
+@pytest.mark.asyncio
+async def test_get_thread_orders_ancestors_self_descendants(workspace_env: dict[str, Path]) -> None:
+    db_path = db_setup(workspace_env)
+    _seed_lineage(db_path)
+
+    polylogue = Polylogue(archive_root=workspace_env["archive_root"], db_path=db_path)
+    try:
+        thread = await polylogue.get_thread("continuation")
+    finally:
+        await polylogue.close()
+
+    ids = [str(ref.conversation_id) for ref in thread]
+    # Ancestors (root) first, then self (continuation), then descendants (fork).
+    assert ids == ["root", "continuation", "fork"]
+
+
+@pytest.mark.asyncio
+async def test_topology_api_unknown_conversation_returns_empty(workspace_env: dict[str, Path]) -> None:
+    db_path = db_setup(workspace_env)
+    _seed_lineage(db_path)
+
+    polylogue = Polylogue(archive_root=workspace_env["archive_root"], db_path=db_path)
+    try:
+        topology = await polylogue.get_session_topology("never-ingested")
+        ancestors = await polylogue.get_ancestors("never-ingested")
+        descendants = await polylogue.get_descendants("never-ingested")
+        siblings = await polylogue.get_siblings("never-ingested")
+        thread = await polylogue.get_thread("never-ingested")
+    finally:
+        await polylogue.close()
+
+    assert topology is None
+    assert ancestors == []
+    assert descendants == []
+    assert siblings == []
+    assert thread == []
+
+
+@pytest.mark.asyncio
+async def test_topology_api_root_only_conversation(workspace_env: dict[str, Path]) -> None:
+    """A conversation with no parent and no children projects an empty graph."""
+
+    db_path = db_setup(workspace_env)
+    ConversationBuilder(db_path, "lonely").provider("claude-code").title("Lonely").add_message(
+        role="user", text="solo"
+    ).save()
+
+    polylogue = Polylogue(archive_root=workspace_env["archive_root"], db_path=db_path)
+    try:
+        topology = await polylogue.get_session_topology("lonely")
+        ancestors = await polylogue.get_ancestors("lonely")
+        descendants = await polylogue.get_descendants("lonely")
+        siblings = await polylogue.get_siblings("lonely")
+        thread = await polylogue.get_thread("lonely")
+    finally:
+        await polylogue.close()
+
+    assert topology is not None
+    assert str(topology.root_id) == "lonely"
+    assert ancestors == []
+    assert descendants == []
+    assert siblings == []
+    # Thread on a lonely node is just that node.
+    assert [str(ref.conversation_id) for ref in thread] == ["lonely"]

--- a/tests/unit/mcp/test_envelope_contracts.py
+++ b/tests/unit/mcp/test_envelope_contracts.py
@@ -50,6 +50,10 @@ TOOL_CONTRACT: dict[str, ToolKind] = {
     "list_conversations": ("envelope", frozenset({"items", "total"})),
     "neighbor_candidates": ("envelope", frozenset({"items", "total", "limit"})),
     "get_session_tree": ("envelope", frozenset({"items", "total"})),
+    "get_session_topology": (
+        "envelope",
+        frozenset({"target_id", "root_id", "nodes", "edges", "ancestors", "descendants", "siblings", "thread"}),
+    ),
     "get_messages": ("envelope", frozenset({"messages", "total"})),
     "raw_artifacts": ("envelope", frozenset({"raw_artifacts", "total"})),
     # ------- mutation list -------
@@ -180,6 +184,7 @@ def _build_typed_envelope_classes() -> dict[str, type[BaseModel]]:
         MCPPaginatedQueryResultPayload,
         MCPPaginatedSearchResultPayload,
         MCPRawArtifactsListPayload,
+        MCPSessionTopologyPayload,
         MCPSessionTreePayload,
     )
 
@@ -188,6 +193,7 @@ def _build_typed_envelope_classes() -> dict[str, type[BaseModel]]:
         "list_conversations": MCPPaginatedQueryResultPayload,
         "neighbor_candidates": MCPNeighborCandidatesPayload,
         "get_session_tree": MCPSessionTreePayload,
+        "get_session_topology": MCPSessionTopologyPayload,
         "get_messages": MCPMessagesListPayload,
         "raw_artifacts": MCPRawArtifactsListPayload,
     }


### PR DESCRIPTION
feat(topology): typed read model API — ancestors/descendants/siblings/thread

Slice D of #866: expose the derived SessionTopology graph as a typed
Python API and an MCP tool so external consumers can navigate session
lineage without re-walking parent pointers.

- Add ConversationRef (id + provider + title + depth) in
  polylogue/insights/topology.py and ancestor_refs / descendant_refs /
  sibling_refs / thread_refs projection methods on SessionTopology.
- Wire get_session_topology / get_ancestors / get_descendants /
  get_siblings / get_thread onto the async Polylogue facade
  (polylogue/api/insights.py). All five accept short or full
  conversation IDs and resolve via repository.resolve_id.
- Add the MCP get_session_topology tool with the typed
  MCPSessionTopologyPayload envelope (nodes + edges + four pre-projected
  ref lists). Classified in TOOL_CONTRACT and committed witness updated.
- Tests in tests/unit/api/test_topology_api.py pin the linear-chain,
  branching-tree, root-only, and unknown-conversation cases through the
  public facade.

Ref #1261 #866.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added conversation topology API to query conversation relationships, including ancestors, descendants, siblings, and thread lineage information.
  * Introduced new MCP tool for retrieving session topology data.

* **Tests**
  * Added comprehensive unit tests for topology query functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sinity/polylogue/pull/1391?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->