### PR TITLE
feat(topology): late-parent arrival deterministic edge repair (#1259)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -451,6 +451,58 @@ fixture using the synthetic corpus generator. For tests needing a realistic arch
 generators. `schema_conformant_payload(provider)` produces payloads that match
 each provider's JSON schema.
 
+## Time and Clock
+
+Timestamp-sensitive tests opt into the `frozen_clock` fixture so the test's
+"now" and the production code's "now" coincide. Reading the host wall clock
+directly creates two failure modes: flakiness at threshold edges (cursor lag
+warning/error/critical bands, freshness windows, retry backoff) and snapshot
+churn that hides real regressions.
+
+`tests/infra/frozen_clock.py` exports:
+
+- `FrozenClock` — controlled clock with explicit `advance(seconds)` and
+  `set_time(epoch)` mutators. Reading the clock does not implicitly advance
+  it; a single `now()` read in production code stays stable across the
+  whole call.
+- `freeze_clock(start=..., patch_datetime_in_modules=[...])` — context
+  manager. Patches `time.time` and `time.monotonic` globally for the scope
+  and replaces `datetime` in each named production module with a frozen
+  subclass whose `.now()` reads the clock.
+- `frozen_clock` pytest fixture — yields a `FrozenClock` and honors
+  `@pytest.mark.frozen_clock_modules("polylogue.x.y", ...)` to extend the
+  `datetime.now` patching list per-test.
+- `fixed_now()` — returns a stable `datetime` anchor without patching
+  anything (use only when production code does NOT itself read the clock).
+
+Usage:
+
+```python
+import pytest
+from datetime import timedelta
+from tests.infra.frozen_clock import FrozenClock
+
+
+@pytest.mark.frozen_clock_modules("polylogue.daemon.health")
+def test_lag_alert(frozen_clock: FrozenClock, tmp_path):
+    now = frozen_clock.now()
+    seed_cursor(tmp_path, updated_at=(now - timedelta(seconds=120)).isoformat())
+    alerts = _check_cursor_lag_medium()   # production reads frozen now
+    assert alerts[0].severity == HealthSeverity.WARNING
+```
+
+For a single moment-in-time anchor without patching (e.g. when only
+constructing an opaque metadata timestamp), use `fixed_now()` instead of
+`datetime.now(UTC)`.
+
+The `devtools verify-test-clock-hygiene` lint runs in the default verify
+gate. It rejects any new direct call to `datetime.now`, `datetime.utcnow`,
+`time.time`, or `time.monotonic` from a test file outside the explicit
+allowlist in `docs/plans/test-clock-allowlist.yaml`. Tests that genuinely
+need the host clock (timing benchmarks, fuzz harnesses, the
+`frozen_clock` self-tests) add their path to the allowlist with a
+one-line rationale; everything else migrates to the fixture.
+
 ## QA Exercises
 
 ```bash
@@ -1307,6 +1359,7 @@ These are the commands worth remembering during normal repo work:
 | `devtools verify-schema-roundtrip` | Verify committed provider schema packages reload and roundtrip cleanly. |
 | `devtools verify-slos` | Check read-surface latency budgets in docs/plans/slo-catalog.yaml against benchmark measurements. |
 | `devtools verify-suppressions` | Enforce suppression registry expiry dates from docs/plans/suppressions.yaml. |
+| `devtools verify-test-clock-hygiene` | Verify test files use the frozen_clock fixture instead of reading the host wall clock (#1300). |
 | `devtools verify-test-infra-currency` | Verify tests/infra/ helpers reference only tables that exist in the current SCHEMA_VERSION. |
 | `devtools verify-test-ownership` | Verify each production module is imported by at least one unit test. |
 | `devtools verify-topology` | Verify the realized polylogue tree against the topology projection. |

--- a/polylogue/storage/repository/archive/writes/conversations.py
+++ b/polylogue/storage/repository/archive/writes/conversations.py
@@ -483,6 +483,18 @@ async def save_via_backend(
             provider_conversation_id=conversation.provider_conversation_id,
             resolved_at=now_iso,
         )
+        # Slice B race closure (#1259): if the parent was committed *after*
+        # the in-memory ``PrepareCache`` for this child was built but
+        # *before* this child's save_via_backend ran, the upsert above wrote
+        # the edge as ``unresolved`` even though the parent now exists. Sweep
+        # the child's own unresolved edges and resolve any whose parent is
+        # already in ``conversations``.
+        if topology_edges:
+            await topology_edges_q.resolve_unresolved_edges_for_child(
+                conn,
+                src_conversation_id=str(conversation.conversation_id),
+                resolved_at=now_iso,
+            )
         timings["topology_edges"] = _time.perf_counter() - t0
 
     total = _time.perf_counter() - t_start

--- a/polylogue/storage/sqlite/queries/topology_edges.py
+++ b/polylogue/storage/sqlite/queries/topology_edges.py
@@ -20,6 +20,7 @@ from collections.abc import Iterable
 
 import aiosqlite
 
+from polylogue.archive.conversation.branch_type import BranchType
 from polylogue.archive.topology.edge import TopologyEdgeRecord, TopologyEdgeStatus
 
 
@@ -104,8 +105,37 @@ async def resolve_topology_edges_for_conversation(
     ingested before its parent, its edge is written ``unresolved``; this
     helper runs after the parent's row hits ``conversations`` and flips
     every dangling edge that was waiting for that parent's native id.
+
+    Slice B (#1259 / #866) — also backfills the resolved children's
+    ``conversations.parent_conversation_id`` (and ``branch_type``, where the
+    edge type maps to a valid ``BranchType``) so the fast-path ancestry
+    walk used by ``derive_session_topology_async``, ``thread_root_id`` and
+    other downstream readers benefits from late-parent arrival without
+    requiring the child to be re-ingested. The backfill is conservative:
+    it only writes ``parent_conversation_id`` when the column is NULL and
+    only writes ``branch_type`` when the column is NULL and the edge type
+    is a member of ``BranchType``. This keeps the operation idempotent —
+    running the resolver twice for the same parent produces no further
+    changes after the first pass.
     """
+    # Collect the children that the upcoming UPDATE will flip, *before*
+    # the UPDATE runs, so we can use them to backfill the conversations
+    # rows in the same transaction. Selecting child IDs + edge types lets
+    # us avoid issuing one UPDATE per child while still classifying the
+    # branch type per row.
     cursor = await conn.execute(
+        """
+        SELECT src_conversation_id, edge_type
+          FROM topology_edges
+         WHERE status = 'unresolved'
+           AND dst_provider_name = ?
+           AND dst_provider_native_id = ?
+        """,
+        (provider_name, provider_conversation_id),
+    )
+    pending_rows = await cursor.fetchall()
+
+    update_cursor = await conn.execute(
         """
         UPDATE topology_edges
            SET resolved_dst_conversation_id = ?,
@@ -117,7 +147,34 @@ async def resolve_topology_edges_for_conversation(
         """,
         (conversation_id, resolved_at, provider_name, provider_conversation_id),
     )
-    return cursor.rowcount or 0
+    flipped = update_cursor.rowcount or 0
+
+    if flipped == 0 or not pending_rows:
+        return flipped
+
+    # Backfill the resolved fast-path on each child conversation. The
+    # ``parent_conversation_id IS NULL`` guard preserves whatever was set
+    # at the child's original write time and makes the backfill idempotent;
+    # the ``branch_type`` guard mirrors the same constraint and restricts
+    # writes to the closed ``BranchType`` vocabulary so the CHECK constraint
+    # on ``conversations.branch_type`` cannot be violated by future
+    # ``RESUME`` / ``BRANCH`` / ``REPAIRED`` edge types.
+    valid_branch_types: set[str] = {bt.value for bt in BranchType}
+    for row in pending_rows:
+        child_id = row["src_conversation_id"]
+        edge_type = row["edge_type"]
+        branch_type: str | None = edge_type if edge_type in valid_branch_types else None
+        await conn.execute(
+            """
+            UPDATE conversations
+               SET parent_conversation_id = COALESCE(parent_conversation_id, ?),
+                   branch_type = COALESCE(branch_type, ?)
+             WHERE conversation_id = ?
+            """,
+            (conversation_id, branch_type, child_id),
+        )
+
+    return flipped
 
 
 async def list_topology_edges_for_conversation(

--- a/polylogue/storage/sqlite/queries/topology_edges.py
+++ b/polylogue/storage/sqlite/queries/topology_edges.py
@@ -177,6 +177,74 @@ async def resolve_topology_edges_for_conversation(
     return flipped
 
 
+async def resolve_unresolved_edges_for_child(
+    conn: aiosqlite.Connection,
+    *,
+    src_conversation_id: str,
+    resolved_at: str,
+) -> int:
+    """Resolve any of ``src_conversation_id``'s own unresolved edges whose
+    parent is already in ``conversations``.
+
+    Closes the concurrent-ingest race where the parent's
+    :func:`resolve_topology_edges_for_conversation` pass ran before the
+    child's edge was upserted. After the child's edge lands, this helper
+    sweeps every unresolved edge it just wrote, joins against
+    ``conversations`` on ``(provider_name, provider_conversation_id)``,
+    and flips the edge if a matching parent row now exists.
+
+    Backfills the same ``conversations.parent_conversation_id`` /
+    ``branch_type`` fast-path columns as
+    :func:`resolve_topology_edges_for_conversation`, with the same
+    conservative ``COALESCE`` guards so the operation is idempotent.
+    """
+    cursor = await conn.execute(
+        """
+        SELECT te.edge_id, te.edge_type, c.conversation_id AS parent_cid
+          FROM topology_edges AS te
+          JOIN conversations  AS c
+            ON c.provider_name = te.dst_provider_name
+           AND c.provider_conversation_id = te.dst_provider_native_id
+         WHERE te.src_conversation_id = ?
+           AND te.status = 'unresolved'
+        """,
+        (src_conversation_id,),
+    )
+    rows = await cursor.fetchall()
+    if not rows:
+        return 0
+
+    valid_branch_types: set[str] = {bt.value for bt in BranchType}
+    resolved = 0
+    for row in rows:
+        edge_id = row["edge_id"]
+        edge_type = row["edge_type"]
+        parent_cid = row["parent_cid"]
+        await conn.execute(
+            """
+            UPDATE topology_edges
+               SET resolved_dst_conversation_id = ?,
+                   status = 'resolved',
+                   resolved_at = ?
+             WHERE edge_id = ?
+               AND status = 'unresolved'
+            """,
+            (parent_cid, resolved_at, edge_id),
+        )
+        branch_type: str | None = edge_type if edge_type in valid_branch_types else None
+        await conn.execute(
+            """
+            UPDATE conversations
+               SET parent_conversation_id = COALESCE(parent_conversation_id, ?),
+                   branch_type = COALESCE(branch_type, ?)
+             WHERE conversation_id = ?
+            """,
+            (parent_cid, branch_type, src_conversation_id),
+        )
+        resolved += 1
+    return resolved
+
+
 async def list_topology_edges_for_conversation(
     conn: aiosqlite.Connection,
     conversation_id: str,
@@ -201,5 +269,6 @@ __all__ = [
     "TopologyEdgeStatus",
     "list_topology_edges_for_conversation",
     "resolve_topology_edges_for_conversation",
+    "resolve_unresolved_edges_for_child",
     "upsert_topology_edges",
 ]

--- a/polylogue/storage/sqlite/queries/topology_edges.py
+++ b/polylogue/storage/sqlite/queries/topology_edges.py
@@ -133,7 +133,7 @@ async def resolve_topology_edges_for_conversation(
         """,
         (provider_name, provider_conversation_id),
     )
-    pending_rows = await cursor.fetchall()
+    pending_rows = list(await cursor.fetchall())
 
     update_cursor = await conn.execute(
         """
@@ -210,7 +210,7 @@ async def resolve_unresolved_edges_for_child(
         """,
         (src_conversation_id,),
     )
-    rows = await cursor.fetchall()
+    rows = list(await cursor.fetchall())
     if not rows:
         return 0
 

--- a/tests/unit/storage/test_topology_edges.py
+++ b/tests/unit/storage/test_topology_edges.py
@@ -444,14 +444,20 @@ class TestTopologyLateParentRepair:
                 messages=[ParsedMessage(provider_message_id="pm1", role=Role.USER, text="p")],
             )
             # Ingest the parent twice.
-            for _ in range(2):
-                parent_result = await prepare_records(
-                    parent_parsed,
-                    source_name="codex",
-                    archive_root=tmp_path,
-                    backend=repo.backend,
-                    repository=repo,
-                )
+            parent_result = await prepare_records(
+                parent_parsed,
+                source_name="codex",
+                archive_root=tmp_path,
+                backend=repo.backend,
+                repository=repo,
+            )
+            parent_result = await prepare_records(
+                parent_parsed,
+                source_name="codex",
+                archive_root=tmp_path,
+                backend=repo.backend,
+                repository=repo,
+            )
 
         edges_after = _fetch_edges(db_path)
         child_edges = [e for e in edges_after if e["src_conversation_id"] == child_cid]

--- a/tests/unit/storage/test_topology_edges.py
+++ b/tests/unit/storage/test_topology_edges.py
@@ -625,5 +625,68 @@ class TestTopologyLateParentRepair:
         assert row["parent_conversation_id"] == parent_result.conversation_id
         assert row["branch_type"] == BranchType.FORK.value
 
+    @pytest.mark.asyncio
+    async def test_concurrent_parent_and_child_ingest_resolves(
+        self,
+        workspace_env: WorkspaceEnv,
+        tmp_path: Path,
+    ) -> None:
+        """Concurrent ingest of parent + child must converge to a resolved edge.
+
+        SQLite serializes writes per connection, so the two ``prepare_records``
+        coroutines below execute in some interleaved order. Regardless of which
+        one wins the race, the post-condition is the same: the topology edge
+        is resolved, ``resolved_dst_conversation_id`` points at the parent,
+        and the child's ``parent_conversation_id`` is backfilled.
+        """
+        import asyncio
+
+        db_path = db_setup(workspace_env)
+        async with _make_repository(db_path) as repo:
+            child_parsed = ParsedConversation(
+                provider_name=Provider.CODEX,
+                provider_conversation_id="race-child",
+                title="Race child",
+                messages=[ParsedMessage(provider_message_id="cm1", role=Role.USER, text="c")],
+                parent_conversation_provider_id="race-parent",
+                branch_type=BranchType.CONTINUATION,
+            )
+            parent_parsed = ParsedConversation(
+                provider_name=Provider.CODEX,
+                provider_conversation_id="race-parent",
+                title="Race parent",
+                messages=[ParsedMessage(provider_message_id="pm1", role=Role.USER, text="p")],
+            )
+
+            child_task = prepare_records(
+                child_parsed,
+                source_name="codex",
+                archive_root=tmp_path,
+                backend=repo.backend,
+                repository=repo,
+            )
+            parent_task = prepare_records(
+                parent_parsed,
+                source_name="codex",
+                archive_root=tmp_path,
+                backend=repo.backend,
+                repository=repo,
+            )
+            child_result, parent_result = await asyncio.gather(child_task, parent_task)
+
+        edges = _fetch_edges(db_path)
+        child_edges = [e for e in edges if e["src_conversation_id"] == child_result.conversation_id]
+        assert len(child_edges) == 1
+        assert child_edges[0]["status"] == TopologyEdgeStatus.RESOLVED.value
+        assert child_edges[0]["resolved_dst_conversation_id"] == parent_result.conversation_id
+
+        with open_connection(db_path) as conn:
+            row = conn.execute(
+                "SELECT parent_conversation_id, branch_type FROM conversations WHERE conversation_id = ?",
+                (child_result.conversation_id,),
+            ).fetchone()
+        assert row["parent_conversation_id"] == parent_result.conversation_id
+        assert row["branch_type"] == BranchType.CONTINUATION.value
+
 
 __all__: tuple[str, ...] = ()

--- a/tests/unit/storage/test_topology_edges.py
+++ b/tests/unit/storage/test_topology_edges.py
@@ -309,15 +309,17 @@ class TestTopologyEdgeOutOfOrderResolve:
         assert child_edges[0]["resolved_dst_conversation_id"] == parent_result.conversation_id
         assert child_edges[0]["resolved_at"] is not None
 
-        # Intentional: the child's conversations.parent_conversation_id is NOT
-        # backfilled — the fast path is set at child-write time only. The
-        # topology_edges table is the durable record.
+        # Slice B (#1259 / #866): the late-arriving parent now backfills
+        # the child's ``conversations.parent_conversation_id`` and
+        # ``branch_type`` columns, so the fast-path ancestry walk benefits
+        # without requiring re-ingest of the child.
         with open_connection(db_path) as conn:
             row = conn.execute(
-                "SELECT parent_conversation_id FROM conversations WHERE conversation_id = ?",
+                "SELECT parent_conversation_id, branch_type FROM conversations WHERE conversation_id = ?",
                 (child_cid,),
             ).fetchone()
-        assert row["parent_conversation_id"] is None
+        assert row["parent_conversation_id"] == parent_result.conversation_id
+        assert row["branch_type"] == BranchType.CONTINUATION.value
 
 
 class TestTopologyEdgeIdempotency:
@@ -343,6 +345,285 @@ class TestTopologyEdgeIdempotency:
         edges = _fetch_edges(db_path)
         assert len(edges) == 1
         assert edges[0]["status"] == TopologyEdgeStatus.UNRESOLVED.value
+
+
+class TestTopologyLateParentRepair:
+    """Slice B (#1259 / #866): late-parent arrival deterministic edge repair.
+
+    Covers the slice B acceptance criteria:
+
+    - On insert of the parent conversation, the previously-unresolved edge is
+      repaired (resolved_dst_conversation_id set, status=resolved,
+      resolved_at populated) AND the child conversation's
+      ``parent_conversation_id`` + ``branch_type`` columns are backfilled.
+    - Running the resolver twice produces the same result (idempotent).
+    - When the parent never arrives, the edge stays unresolved and the
+      child's parent_conversation_id stays NULL.
+    - Multiple unresolved children pointing at the same absent parent are
+      all repaired by a single parent ingest.
+    - When the child's ``parent_conversation_id`` was already populated
+      (parent-first fast path), the repair pass does not overwrite it on
+      a subsequent re-ingest of the parent.
+    """
+
+    @pytest.mark.asyncio
+    async def test_late_parent_arrival_backfills_fast_path(
+        self,
+        workspace_env: WorkspaceEnv,
+        tmp_path: Path,
+    ) -> None:
+        db_path = db_setup(workspace_env)
+        async with _make_repository(db_path) as repo:
+            child_cid = await _ingest_synthetic_child(
+                repo=repo,
+                tmp_path=tmp_path,
+                provider=Provider.CODEX,
+                source_name="codex",
+                child_id="late-child",
+                parent_id="late-parent",
+                branch_type=BranchType.SIDECHAIN,
+            )
+
+            # Before parent arrives: fast-path NULL, edge unresolved. The
+            # ``branch_type`` is set on the child at its original write time
+            # from the parser-asserted classification — it does not depend on
+            # the parent being present.
+            with open_connection(db_path) as conn:
+                row = conn.execute(
+                    "SELECT parent_conversation_id, branch_type FROM conversations WHERE conversation_id = ?",
+                    (child_cid,),
+                ).fetchone()
+            assert row["parent_conversation_id"] is None
+            assert row["branch_type"] == BranchType.SIDECHAIN.value
+
+            parent_parsed = ParsedConversation(
+                provider_name=Provider.CODEX,
+                provider_conversation_id="late-parent",
+                title="Late parent",
+                messages=[ParsedMessage(provider_message_id="pm1", role=Role.USER, text="p")],
+            )
+            parent_result = await prepare_records(
+                parent_parsed,
+                source_name="codex",
+                archive_root=tmp_path,
+                backend=repo.backend,
+                repository=repo,
+            )
+
+        # After parent arrives: fast-path AND branch_type backfilled.
+        with open_connection(db_path) as conn:
+            row = conn.execute(
+                "SELECT parent_conversation_id, branch_type FROM conversations WHERE conversation_id = ?",
+                (child_cid,),
+            ).fetchone()
+        assert row["parent_conversation_id"] == parent_result.conversation_id
+        assert row["branch_type"] == BranchType.SIDECHAIN.value
+
+    @pytest.mark.asyncio
+    async def test_repair_is_idempotent_across_parent_reingest(
+        self,
+        workspace_env: WorkspaceEnv,
+        tmp_path: Path,
+    ) -> None:
+        db_path = db_setup(workspace_env)
+        async with _make_repository(db_path) as repo:
+            child_cid = await _ingest_synthetic_child(
+                repo=repo,
+                tmp_path=tmp_path,
+                provider=Provider.CODEX,
+                source_name="codex",
+                child_id="idem-repair-child",
+                parent_id="idem-repair-parent",
+                branch_type=BranchType.SUBAGENT,
+            )
+
+            parent_parsed = ParsedConversation(
+                provider_name=Provider.CODEX,
+                provider_conversation_id="idem-repair-parent",
+                title="Idem parent",
+                messages=[ParsedMessage(provider_message_id="pm1", role=Role.USER, text="p")],
+            )
+            # Ingest the parent twice.
+            for _ in range(2):
+                parent_result = await prepare_records(
+                    parent_parsed,
+                    source_name="codex",
+                    archive_root=tmp_path,
+                    backend=repo.backend,
+                    repository=repo,
+                )
+
+        edges_after = _fetch_edges(db_path)
+        child_edges = [e for e in edges_after if e["src_conversation_id"] == child_cid]
+        assert len(child_edges) == 1
+        assert child_edges[0]["status"] == TopologyEdgeStatus.RESOLVED.value
+        assert child_edges[0]["resolved_dst_conversation_id"] == parent_result.conversation_id
+
+        with open_connection(db_path) as conn:
+            row = conn.execute(
+                "SELECT parent_conversation_id, branch_type FROM conversations WHERE conversation_id = ?",
+                (child_cid,),
+            ).fetchone()
+        assert row["parent_conversation_id"] == parent_result.conversation_id
+        assert row["branch_type"] == BranchType.SUBAGENT.value
+
+    @pytest.mark.asyncio
+    async def test_parent_never_arrives_keeps_edge_unresolved(
+        self,
+        workspace_env: WorkspaceEnv,
+        tmp_path: Path,
+    ) -> None:
+        db_path = db_setup(workspace_env)
+        async with _make_repository(db_path) as repo:
+            child_cid = await _ingest_synthetic_child(
+                repo=repo,
+                tmp_path=tmp_path,
+                provider=Provider.CODEX,
+                source_name="codex",
+                child_id="orphan-child",
+                parent_id="never-arrives",
+                branch_type=BranchType.CONTINUATION,
+            )
+
+            # Ingest a different conversation — its arrival must not
+            # spuriously repair the unrelated unresolved edge.
+            unrelated = ParsedConversation(
+                provider_name=Provider.CODEX,
+                provider_conversation_id="unrelated-parent",
+                title="Unrelated",
+                messages=[ParsedMessage(provider_message_id="m1", role=Role.USER, text="x")],
+            )
+            await prepare_records(
+                unrelated,
+                source_name="codex",
+                archive_root=tmp_path,
+                backend=repo.backend,
+                repository=repo,
+            )
+
+        edges = _fetch_edges(db_path)
+        child_edges = [e for e in edges if e["src_conversation_id"] == child_cid]
+        assert len(child_edges) == 1
+        assert child_edges[0]["status"] == TopologyEdgeStatus.UNRESOLVED.value
+        assert child_edges[0]["resolved_dst_conversation_id"] is None
+
+        with open_connection(db_path) as conn:
+            row = conn.execute(
+                "SELECT parent_conversation_id FROM conversations WHERE conversation_id = ?",
+                (child_cid,),
+            ).fetchone()
+        assert row["parent_conversation_id"] is None
+
+    @pytest.mark.asyncio
+    async def test_multiple_pending_children_repaired_by_single_parent(
+        self,
+        workspace_env: WorkspaceEnv,
+        tmp_path: Path,
+    ) -> None:
+        db_path = db_setup(workspace_env)
+        async with _make_repository(db_path) as repo:
+            child_a = await _ingest_synthetic_child(
+                repo=repo,
+                tmp_path=tmp_path,
+                provider=Provider.CODEX,
+                source_name="codex",
+                child_id="shared-parent-child-a",
+                parent_id="shared-parent",
+                branch_type=BranchType.SIDECHAIN,
+            )
+            child_b = await _ingest_synthetic_child(
+                repo=repo,
+                tmp_path=tmp_path,
+                provider=Provider.CODEX,
+                source_name="codex",
+                child_id="shared-parent-child-b",
+                parent_id="shared-parent",
+                branch_type=BranchType.SUBAGENT,
+            )
+
+            parent_parsed = ParsedConversation(
+                provider_name=Provider.CODEX,
+                provider_conversation_id="shared-parent",
+                title="Shared parent",
+                messages=[ParsedMessage(provider_message_id="pm1", role=Role.USER, text="p")],
+            )
+            parent_result = await prepare_records(
+                parent_parsed,
+                source_name="codex",
+                archive_root=tmp_path,
+                backend=repo.backend,
+                repository=repo,
+            )
+
+        edges = _fetch_edges(db_path)
+        repaired = [e for e in edges if e["src_conversation_id"] in (child_a, child_b)]
+        assert len(repaired) == 2
+        assert all(e["status"] == TopologyEdgeStatus.RESOLVED.value for e in repaired)
+        assert all(e["resolved_dst_conversation_id"] == parent_result.conversation_id for e in repaired)
+
+        with open_connection(db_path) as conn:
+            rows = conn.execute(
+                "SELECT conversation_id, parent_conversation_id, branch_type "
+                "FROM conversations WHERE conversation_id IN (?, ?) "
+                "ORDER BY conversation_id",
+                (child_a, child_b),
+            ).fetchall()
+
+        by_id = {row["conversation_id"]: row for row in rows}
+        assert by_id[child_a]["parent_conversation_id"] == parent_result.conversation_id
+        assert by_id[child_a]["branch_type"] == BranchType.SIDECHAIN.value
+        assert by_id[child_b]["parent_conversation_id"] == parent_result.conversation_id
+        assert by_id[child_b]["branch_type"] == BranchType.SUBAGENT.value
+
+    @pytest.mark.asyncio
+    async def test_repair_does_not_overwrite_existing_fast_path(
+        self,
+        workspace_env: WorkspaceEnv,
+        tmp_path: Path,
+    ) -> None:
+        """Parent-first fast path is preserved when the parent is re-ingested."""
+        db_path = db_setup(workspace_env)
+        async with _make_repository(db_path) as repo:
+            parent_parsed = ParsedConversation(
+                provider_name=Provider.CODEX,
+                provider_conversation_id="preserve-parent",
+                title="Parent",
+                messages=[ParsedMessage(provider_message_id="pm1", role=Role.USER, text="p")],
+            )
+            parent_result = await prepare_records(
+                parent_parsed,
+                source_name="codex",
+                archive_root=tmp_path,
+                backend=repo.backend,
+                repository=repo,
+            )
+            child_cid = await _ingest_synthetic_child(
+                repo=repo,
+                tmp_path=tmp_path,
+                provider=Provider.CODEX,
+                source_name="codex",
+                child_id="preserve-child",
+                parent_id="preserve-parent",
+                branch_type=BranchType.FORK,
+            )
+
+            # Re-ingest the parent — repair pass must be a no-op on the
+            # already-resolved child.
+            await prepare_records(
+                parent_parsed,
+                source_name="codex",
+                archive_root=tmp_path,
+                backend=repo.backend,
+                repository=repo,
+            )
+
+        with open_connection(db_path) as conn:
+            row = conn.execute(
+                "SELECT parent_conversation_id, branch_type FROM conversations WHERE conversation_id = ?",
+                (child_cid,),
+            ).fetchone()
+        assert row["parent_conversation_id"] == parent_result.conversation_id
+        assert row["branch_type"] == BranchType.FORK.value
 
 
 __all__: tuple[str, ...] = ()


### PR DESCRIPTION
## Summary

Slice B of #866 / closes #1259: when a late-arriving parent conversation lands,
the topology resolver now backfills the child's
`conversations.parent_conversation_id` and `branch_type` fast-path columns in
addition to flipping the `topology_edges` row to `resolved`. This restores the
ancestry-walk fast path for out-of-order ingest without requiring re-ingest of
the child, and also closes the concurrent-ingest race between parent and child
prepare cycles.

## Problem

Slice A (#1258, PR #1377) persisted unresolved provider-native parent edges
and added the resolver helper that flipped them to `resolved` when the parent
arrived. But the original `conversations.parent_conversation_id` column was
intentionally left NULL on a late-arriving repair — slice A's own test
asserted this gap. Every downstream that walks `parent_conversation_id`
(session-topology derivation, threads, web reader lineage view) therefore
saw an orphan child until the next time the child itself was re-ingested.

There was also a race: when parent and child were prepared concurrently, the
parent's `PrepareCache` could miss the child's still-pending upsert and the
child's cache could miss the parent's still-pending commit. The parent's
resolver pass then found nothing to flip, and the child's later upsert wrote
`status=unresolved` even though the parent was now in `conversations`.

## Solution

`polylogue/storage/sqlite/queries/topology_edges.py`:

- `resolve_topology_edges_for_conversation` (the parent-arrival path) now
  SELECTs the children it is about to flip and `UPDATE`s each child's
  `conversations.parent_conversation_id` / `branch_type` with `COALESCE`
  so existing fast-path state is preserved and the operation stays
  idempotent across re-ingest. `branch_type` is restricted to the closed
  `BranchType` vocabulary so future `RESUME`/`BRANCH`/`REPAIRED` edge
  kinds cannot violate the CHECK constraint on `conversations.branch_type`.
- New `resolve_unresolved_edges_for_child` runs after the child's own
  upsert in `save_via_backend`. It joins the child's unresolved edges
  against `conversations` on `(provider_name, provider_conversation_id)`
  and flips any edge whose parent now exists — closes the concurrent
  ingest race.

`polylogue/storage/repository/archive/writes/conversations.py`:

- `save_via_backend` calls the new race-closure helper after the existing
  `upsert_topology_edges` + `resolve_topology_edges_for_conversation` pair.

`tests/unit/storage/test_topology_edges.py`:

- Updated the pre-existing slice A test that asserted the gap to assert
  the new repair behavior.
- Added `TestTopologyLateParentRepair` covering: late-parent backfill,
  idempotency across parent re-ingest, no-op when parent never arrives,
  multiple pending children → single parent, parent-first preservation,
  and concurrent parent+child ingest via `asyncio.gather`.

Hash boundary unchanged: topology edges are derived per ingest and stay
outside `conversations.content_hash`, same as user_corrections (#1131).
No schema change.

## Verification

```
nix develop -c devtools verify --quick   # exit 0, 35.6 s
nix develop -c pytest tests/unit/storage/test_topology_edges.py \
                       tests/unit/storage/test_dead_schema_sweep.py \
                       tests/unit/insights/ -q
# 142 passed (insights + topology + dead-schema-sweep)
# 13 passed (test_topology_edges, including the new concurrent ingest test)
```

The concurrent-ingest test (`test_concurrent_parent_and_child_ingest_resolves`)
exercises both the parent-arrival resolver and the new child-side race-closure
helper depending on which coroutine commits first.

Ref #1259 #866.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>