### PR TITLE
test(maintenance): scope filter round-trip and envelope contract across CLI/HTTP/MCP (#1303)

### DIFF
--- a/tests/unit/maintenance/test_planner_filter_narrowing.py
+++ b/tests/unit/maintenance/test_planner_filter_narrowing.py
@@ -1,0 +1,182 @@
+"""Planner narrows ``affected_rows`` when the scope filter narrows the scope (#1303).
+
+The planner's contract with the typed
+:class:`MaintenanceScopeFilter` is that a narrower filter must
+produce a narrower preview — the operator must never see a single-
+conversation plan advertise the full archive's debt as its work.
+
+Pins:
+
+* a ``conversation_ids`` filter clamps ``affected_rows`` to the size
+  of the filter set;
+* the filter is threaded onto the returned :class:`MaintenanceScope`
+  so the envelope echoes it back unchanged;
+* an empty filter does not narrow the preview;
+* a filter with zero conversation ids cannot mask a broader debt by
+  accident (the underlying debt count is preserved when there is no
+  conversation-id narrowing).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from polylogue.config import Config
+from polylogue.maintenance.planner import preview_backfill
+from polylogue.maintenance.scope import MaintenanceScopeFilter
+
+
+def _make_config(tmp_path: Path) -> Config:
+    archive_root = tmp_path / "archive"
+    render_root = tmp_path / "render"
+    archive_root.mkdir(parents=True, exist_ok=True)
+    render_root.mkdir(parents=True, exist_ok=True)
+    return Config(
+        archive_root=archive_root,
+        render_root=render_root,
+        sources=[],
+        db_path=tmp_path / "archive.db",
+    )
+
+
+def _patched_debt(pending: int) -> tuple[Any, Any]:
+    """Return patched debt collector + preview callables advertising ``pending`` rows."""
+    from polylogue.maintenance.models import DerivedModelStatus
+
+    fake_status = DerivedModelStatus(
+        name="session_insights",
+        ready=False,
+        detail=f"{pending} pending",
+        source_documents=pending,
+        materialized_documents=0,
+        stale_rows=pending,
+        missing_provenance_rows=0,
+    )
+
+    def _fake_collect(*_a: Any, **_kw: Any) -> dict[str, DerivedModelStatus]:
+        return {"session_insights": fake_status}
+
+    def _fake_counts(_statuses: dict[str, DerivedModelStatus]) -> dict[str, int]:
+        return {"session_insights": pending}
+
+    return _fake_collect, _fake_counts
+
+
+class TestPlannerNarrowsByConversationIds:
+    """A ``conversation_ids`` filter clamps preview rows to the filter size."""
+
+    def test_single_conversation_filter_clamps_to_one(self, tmp_path: Path) -> None:
+        config = _make_config(tmp_path)
+        collect, counts = _patched_debt(1000)
+        with (
+            patch("polylogue.storage.repair.collect_archive_debt_statuses_sync", collect),
+            patch("polylogue.storage.repair.preview_counts_from_archive_debt", counts),
+        ):
+            narrow = preview_backfill(
+                config,
+                targets=("session_insights",),
+                scope_filter=MaintenanceScopeFilter(conversation_ids=("only-one",)),
+            )
+        assert narrow.affected_rows == 1
+        # And the filter is echoed back on the returned scope so the
+        # envelope can serialize it.
+        assert narrow.scope is not None
+        assert narrow.scope.filter.conversation_ids == ("only-one",)
+
+    def test_multi_conversation_filter_clamps_to_filter_size(self, tmp_path: Path) -> None:
+        config = _make_config(tmp_path)
+        collect, counts = _patched_debt(1000)
+        with (
+            patch("polylogue.storage.repair.collect_archive_debt_statuses_sync", collect),
+            patch("polylogue.storage.repair.preview_counts_from_archive_debt", counts),
+        ):
+            narrow = preview_backfill(
+                config,
+                targets=("session_insights",),
+                scope_filter=MaintenanceScopeFilter(conversation_ids=("c1", "c2", "c3")),
+            )
+        assert narrow.affected_rows == 3
+        assert narrow.scope is not None
+        assert narrow.scope.filter.conversation_ids == ("c1", "c2", "c3")
+
+    def test_conversation_filter_does_not_inflate_when_debt_is_smaller(self, tmp_path: Path) -> None:
+        """A filter naming 100 ids cannot inflate a 2-row debt to 100."""
+        config = _make_config(tmp_path)
+        collect, counts = _patched_debt(2)
+        with (
+            patch("polylogue.storage.repair.collect_archive_debt_statuses_sync", collect),
+            patch("polylogue.storage.repair.preview_counts_from_archive_debt", counts),
+        ):
+            narrow = preview_backfill(
+                config,
+                targets=("session_insights",),
+                scope_filter=MaintenanceScopeFilter(conversation_ids=tuple(f"c{i}" for i in range(100))),
+            )
+        assert narrow.affected_rows == 2
+
+
+class TestPlannerLeavesFilterPassthroughDimensionsIntact:
+    """Filters on dimensions the planner does not yet narrow on are passthrough."""
+
+    @pytest.mark.parametrize(
+        "scope_filter",
+        [
+            MaintenanceScopeFilter(provider="claude"),
+            MaintenanceScopeFilter(source_family="claude-code-session"),
+            MaintenanceScopeFilter(raw_artifact_id="raw-1"),
+            MaintenanceScopeFilter(failure_kind="ValidationError"),
+            MaintenanceScopeFilter(parser_version="v3"),
+        ],
+    )
+    def test_non_conversation_filters_do_not_change_affected_rows(
+        self, tmp_path: Path, scope_filter: MaintenanceScopeFilter
+    ) -> None:
+        """Filter dimensions the planner doesn't yet honor pass through unchanged.
+
+        The repair-fn boundary is advisory (see ``scope.py`` module
+        docstring): non-conversation_ids filters reach the planner and
+        are surfaced on the returned scope, but the preview row count
+        comes from the full debt status until a repair fn learns to
+        narrow on that dimension.
+        """
+        config = _make_config(tmp_path)
+        collect, counts = _patched_debt(50)
+        with (
+            patch("polylogue.storage.repair.collect_archive_debt_statuses_sync", collect),
+            patch("polylogue.storage.repair.preview_counts_from_archive_debt", counts),
+        ):
+            broad = preview_backfill(config, targets=("session_insights",))
+            scoped = preview_backfill(config, targets=("session_insights",), scope_filter=scope_filter)
+        assert broad.affected_rows == 50
+        assert scoped.affected_rows == 50
+        # And the filter still rides through on the scope so the
+        # envelope can echo it.
+        assert scoped.scope is not None
+        assert scoped.scope.filter == scope_filter
+
+
+class TestPlannerWithEmptyFilter:
+    """An empty / default filter must not narrow the preview."""
+
+    def test_default_filter_preserves_full_debt(self, tmp_path: Path) -> None:
+        config = _make_config(tmp_path)
+        collect, counts = _patched_debt(200)
+        with (
+            patch("polylogue.storage.repair.collect_archive_debt_statuses_sync", collect),
+            patch("polylogue.storage.repair.preview_counts_from_archive_debt", counts),
+        ):
+            broad = preview_backfill(config, targets=("session_insights",))
+            explicit_empty = preview_backfill(
+                config,
+                targets=("session_insights",),
+                scope_filter=MaintenanceScopeFilter(),
+            )
+        assert broad.affected_rows == 200
+        assert explicit_empty.affected_rows == 200
+        # Both ought to attach an empty filter onto the scope.
+        assert broad.scope is not None and broad.scope.filter.is_empty()
+        assert explicit_empty.scope is not None and explicit_empty.scope.filter.is_empty()

--- a/tests/unit/maintenance/test_scope_filter_envelope_contract.py
+++ b/tests/unit/maintenance/test_scope_filter_envelope_contract.py
@@ -1,0 +1,345 @@
+"""Cross-surface envelope contract for the typed maintenance scope filter (#1303).
+
+One typed :class:`MaintenanceScopeFilter` must round-trip identically
+through every surface — CLI ``polylogue maintenance plan`` flags, the
+daemon ``POST /api/maintenance/plan`` JSON body, and MCP
+``maintenance_preview`` typed parameters — and every surface must echo
+it back as the same envelope JSON. The test pins:
+
+* CLI argv → planner ``scope_filter`` (every dimension)
+* HTTP POST body → planner ``scope_filter`` (every dimension; nested
+  ``{"scope":{"filter":{...}}}`` envelope and flat top-level form both
+  accepted)
+* MCP typed args → planner ``scope_filter`` (every dimension)
+* All three surfaces serialize the same operation back to a byte-equal
+  ``scope.filter`` envelope payload.
+
+This is the cross-surface coherence assertion that prevents #1196 from
+drifting if any one surface gains a new dimension without the other
+two.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import datetime, timezone
+from io import BytesIO
+from pathlib import Path
+from typing import Any, cast
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from polylogue.cli.commands.maintenance import maintenance_group
+from polylogue.config import Config
+from polylogue.maintenance.envelope import envelope_from_operation
+from polylogue.maintenance.planner import (
+    BackfillKind,
+    BackfillOperation,
+    BackfillStatus,
+    MaintenanceScope,
+)
+from polylogue.maintenance.scope import MaintenanceScopeFilter
+
+# ---------------------------------------------------------------------------
+# Canonical full filter — covers every dimension in one payload
+# ---------------------------------------------------------------------------
+
+
+_SINCE = datetime(2026, 1, 1, tzinfo=timezone.utc)
+_UNTIL = datetime(2026, 2, 1, tzinfo=timezone.utc)
+
+
+def _canonical_filter() -> MaintenanceScopeFilter:
+    return MaintenanceScopeFilter(
+        conversation_ids=("c1", "c2"),
+        provider="claude",
+        source_family="claude-code-session",
+        source_root=Path("/data/claude"),
+        raw_artifact_id="raw-1",
+        time_range=(_SINCE, _UNTIL),
+        failure_kind="ValidationError",
+        parser_version="v3",
+    )
+
+
+def _operation_for(scope_filter: MaintenanceScopeFilter) -> BackfillOperation:
+    return BackfillOperation(
+        operation_id="op-fixed",
+        kind=BackfillKind.DERIVED_REBUILD,
+        targets=("session_insights",),
+        status=BackfillStatus.PENDING,
+        scope=MaintenanceScope(targets=("session_insights",), filter=scope_filter),
+    )
+
+
+def _make_config(tmp_path: Path) -> Config:
+    archive_root = tmp_path / "archive"
+    render_root = tmp_path / "render"
+    archive_root.mkdir(parents=True, exist_ok=True)
+    render_root.mkdir(parents=True, exist_ok=True)
+    return Config(
+        archive_root=archive_root,
+        render_root=render_root,
+        sources=[],
+        db_path=tmp_path / "archive.db",
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI surface — argv to planner call to envelope
+# ---------------------------------------------------------------------------
+
+
+def _invoke_cli_plan(operation: BackfillOperation, tmp_path: Path) -> tuple[dict[str, Any], MaintenanceScopeFilter]:
+    """Run ``polylogue maintenance plan`` and return (envelope JSON, captured filter)."""
+    captured: dict[str, MaintenanceScopeFilter] = {}
+
+    def _capture(_config: Any, *, targets: tuple[str, ...], scope_filter: MaintenanceScopeFilter) -> BackfillOperation:
+        captured["filter"] = scope_filter
+        return operation.__class__(
+            operation_id=operation.operation_id,
+            kind=operation.kind,
+            targets=operation.targets,
+            status=operation.status,
+            scope=MaintenanceScope(targets=targets, filter=scope_filter),
+        )
+
+    runner = CliRunner()
+    archive = tmp_path / "archive"
+    render = tmp_path / "render"
+    archive.mkdir(parents=True, exist_ok=True)
+    render.mkdir(parents=True, exist_ok=True)
+    config_obj = Config(archive_root=archive, render_root=render, sources=[])
+
+    with (
+        patch("polylogue.cli.commands.maintenance.preview_backfill", side_effect=_capture),
+        patch("polylogue.cli.commands.maintenance.archive_root", return_value=archive),
+        patch("polylogue.cli.commands.maintenance.render_root", return_value=render),
+    ):
+        result = runner.invoke(
+            maintenance_group,
+            [
+                "plan",
+                "--target",
+                "session_insights",
+                "--conversation-id",
+                "c1",
+                "--conversation-id",
+                "c2",
+                "--provider",
+                "claude",
+                "--source-family",
+                "claude-code-session",
+                "--source-root",
+                "/data/claude",
+                "--raw-artifact",
+                "raw-1",
+                "--since",
+                "2026-01-01T00:00:00Z",
+                "--until",
+                "2026-02-01T00:00:00Z",
+                "--failure-kind",
+                "ValidationError",
+                "--parser-version",
+                "v3",
+                "--output-format",
+                "json",
+            ],
+            obj=config_obj,
+        )
+
+    assert result.exit_code == 0, result.output
+    payload: dict[str, Any] = json.loads(result.output)
+    return payload, captured["filter"]
+
+
+# ---------------------------------------------------------------------------
+# HTTP surface — POST body to planner call to envelope
+# ---------------------------------------------------------------------------
+
+
+def _invoke_daemon_plan(body: dict[str, Any]) -> tuple[dict[str, Any], MaintenanceScopeFilter]:
+    """Drive ``_handle_maintenance_plan`` with ``body`` and return (envelope, filter)."""
+    from tests.unit.daemon.test_maintenance_endpoints import MockHeaders, _make_handler
+
+    captured: dict[str, MaintenanceScopeFilter] = {}
+
+    def _capture(_config: Any, *, targets: tuple[str, ...], scope_filter: MaintenanceScopeFilter) -> BackfillOperation:
+        captured["filter"] = scope_filter
+        return _operation_for(scope_filter)
+
+    body_raw = json.dumps(body).encode("utf-8")
+    handler = _make_handler("/api/maintenance/plan")
+    cast(MockHeaders, handler.headers)._headers["Content-Length"] = str(len(body_raw))
+    handler.rfile = BytesIO(body_raw)
+
+    sent: dict[str, Any] = {}
+
+    def _capture_send(status: Any, payload: Any) -> None:
+        sent["status"] = status
+        sent["payload"] = payload
+
+    with (
+        patch("polylogue.maintenance.planner.preview_backfill", side_effect=_capture),
+        patch.object(handler, "_send_json", side_effect=_capture_send),
+    ):
+        handler._handle_maintenance_plan()
+
+    return cast(dict[str, Any], sent["payload"]), captured["filter"]
+
+
+# ---------------------------------------------------------------------------
+# MCP surface — typed args to planner call to envelope
+# ---------------------------------------------------------------------------
+
+
+def _invoke_mcp_preview() -> tuple[dict[str, Any], MaintenanceScopeFilter]:
+    """Drive ``maintenance_preview`` with the canonical filter args."""
+    from polylogue.mcp.server import build_server
+
+    captured: dict[str, MaintenanceScopeFilter] = {}
+
+    def _capture(_config: Any, *, targets: tuple[str, ...], scope_filter: MaintenanceScopeFilter) -> BackfillOperation:
+        captured["filter"] = scope_filter
+        return _operation_for(scope_filter)
+
+    server = build_server(role="admin")
+    fn = server._tool_manager._tools["maintenance_preview"].fn
+
+    with patch("polylogue.maintenance.planner.preview_backfill", side_effect=_capture):
+        result = asyncio.run(
+            fn(
+                targets=["session_insights"],
+                conversation_ids=["c1", "c2"],
+                provider="claude",
+                source_family="claude-code-session",
+                source_root="/data/claude",
+                raw_artifact_id="raw-1",
+                since="2026-01-01T00:00:00Z",
+                until="2026-02-01T00:00:00Z",
+                failure_kind="ValidationError",
+                parser_version="v3",
+            )
+        )
+
+    payload: dict[str, Any] = json.loads(result)
+    return payload, captured["filter"]
+
+
+# ---------------------------------------------------------------------------
+# Single-dimension parity tests — one assertion per scope dimension
+# ---------------------------------------------------------------------------
+
+
+class TestCLIArgsBuildScopeFilter:
+    """Each CLI flag round-trips into the matching scope-filter field."""
+
+    def test_every_dimension_reaches_the_planner(self, tmp_path: Path) -> None:
+        _, captured = _invoke_cli_plan(_operation_for(_canonical_filter()), tmp_path)
+        assert captured == _canonical_filter()
+
+
+class TestDaemonBodyBuildsScopeFilter:
+    """HTTP body fields round-trip into the matching scope-filter field."""
+
+    def test_flat_body_every_dimension_reaches_the_planner(self) -> None:
+        body = {
+            "targets": ["session_insights"],
+            "conversation_ids": ["c1", "c2"],
+            "provider": "claude",
+            "source_family": "claude-code-session",
+            "source_root": "/data/claude",
+            "raw_artifact_id": "raw-1",
+            "time_range": [
+                "2026-01-01T00:00:00+00:00",
+                "2026-02-01T00:00:00+00:00",
+            ],
+            "failure_kind": "ValidationError",
+            "parser_version": "v3",
+        }
+        _, captured = _invoke_daemon_plan(body)
+        assert captured == _canonical_filter()
+
+    def test_nested_scope_filter_body_is_accepted(self) -> None:
+        """``{"scope":{"filter":{...}}}`` body shape is honored too.
+
+        The daemon HTTP handler accepts both the flat top-level shape and
+        the nested envelope shape, so a client that echoes a previous
+        envelope's ``scope.filter`` payload still drives the planner
+        with the same filter.
+        """
+        body = {
+            "targets": ["session_insights"],
+            "scope": {"filter": _canonical_filter().to_dict()},
+        }
+        _, captured = _invoke_daemon_plan(body)
+        assert captured == _canonical_filter()
+
+
+class TestMCPArgsBuildScopeFilter:
+    """MCP typed parameters round-trip into the matching scope-filter field."""
+
+    def test_every_dimension_reaches_the_planner(self) -> None:
+        _, captured = _invoke_mcp_preview()
+        assert captured == _canonical_filter()
+
+
+# ---------------------------------------------------------------------------
+# Cross-surface envelope parity
+# ---------------------------------------------------------------------------
+
+
+class TestEnvelopeFilterParity:
+    """All three surfaces emit the same ``scope.filter`` envelope JSON."""
+
+    def test_envelope_filters_match_across_surfaces(self, tmp_path: Path) -> None:
+        # Same operation, three different surfaces. The envelope is the
+        # contract — every surface must produce a byte-equal ``scope.filter``.
+        operation = _operation_for(_canonical_filter())
+
+        cli_payload, cli_filter = _invoke_cli_plan(operation, tmp_path)
+        daemon_payload, daemon_filter = _invoke_daemon_plan(
+            {
+                "targets": ["session_insights"],
+                **_canonical_filter().to_dict(),
+            }
+        )
+        mcp_payload, mcp_filter = _invoke_mcp_preview()
+
+        # 1. Every surface reconstructed the same typed filter.
+        assert cli_filter == daemon_filter == mcp_filter == _canonical_filter()
+
+        # 2. Every surface echoed the same envelope ``scope.filter`` payload.
+        cli_envelope_filter = cli_payload["scope"]["filter"]
+        daemon_envelope_filter = daemon_payload["scope"]["filter"]
+        mcp_envelope_filter = mcp_payload["scope"]["filter"]
+        assert cli_envelope_filter == daemon_envelope_filter == mcp_envelope_filter
+
+        # 3. That envelope payload is exactly the canonical filter's
+        #    JSON-shape — no surface added or dropped dimensions.
+        assert cli_envelope_filter == _canonical_filter().to_dict()
+
+    def test_envelope_filter_round_trips_back_to_typed_filter(self, tmp_path: Path) -> None:
+        """Echoing the envelope ``scope.filter`` payload reconstructs the typed filter."""
+        cli_payload, _ = _invoke_cli_plan(_operation_for(_canonical_filter()), tmp_path)
+        recovered = MaintenanceScopeFilter.from_dict(cli_payload["scope"]["filter"])
+        assert recovered == _canonical_filter()
+
+
+# ---------------------------------------------------------------------------
+# Empty-filter parity — the default "no narrowing" case
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyFilterParity:
+    """An empty filter must serialize identically across surfaces too."""
+
+    def test_envelope_from_empty_operation_matches_canonical_empty(self) -> None:
+        envelope = envelope_from_operation(
+            _operation_for(MaintenanceScopeFilter()),
+            origin="cli",
+            mode="preview",
+        ).to_dict()
+        assert envelope["scope"]["filter"] == MaintenanceScopeFilter().to_dict()

--- a/tests/unit/maintenance/test_scope_filter_envelope_contract.py
+++ b/tests/unit/maintenance/test_scope_filter_envelope_contract.py
@@ -337,9 +337,12 @@ class TestEmptyFilterParity:
     """An empty filter must serialize identically across surfaces too."""
 
     def test_envelope_from_empty_operation_matches_canonical_empty(self) -> None:
-        envelope = envelope_from_operation(
-            _operation_for(MaintenanceScopeFilter()),
-            origin="cli",
-            mode="preview",
-        ).to_dict()
+        envelope = cast(
+            dict[str, Any],
+            envelope_from_operation(
+                _operation_for(MaintenanceScopeFilter()),
+                origin="cli",
+                mode="preview",
+            ).to_dict(),
+        )
         assert envelope["scope"]["filter"] == MaintenanceScopeFilter().to_dict()

--- a/tests/unit/maintenance/test_scope_filter_roundtrip.py
+++ b/tests/unit/maintenance/test_scope_filter_roundtrip.py
@@ -1,0 +1,237 @@
+"""Round-trip contract for :class:`MaintenanceScopeFilter` (#1303).
+
+Pins the typed-filter round-trip independent of any surface:
+
+* ``to_dict()`` always yields a JSON-shaped dict that lists every known
+  dimension exactly once (so absent dimensions stay explicitly
+  ``None`` instead of being silently dropped);
+* ``from_dict(to_dict(filter))`` is the identity for every dimension
+  combination — verified both by example and by a Hypothesis property
+  that draws across all eight dimensions;
+* ``None`` and ``{}`` both rehydrate to the canonical empty filter so
+  surfaces that omit the field do not desynchronize from surfaces that
+  send an empty body.
+
+Companion to :mod:`tests.unit.maintenance.test_scope_filter` (which
+pins the model's shape and frozen-ness) and
+:mod:`tests.unit.maintenance.test_scope_filter_envelope_contract`
+(which pins cross-surface parity).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from polylogue.maintenance.scope import MaintenanceScopeFilter
+
+_EXPECTED_DIMENSIONS = frozenset(
+    {
+        "conversation_ids",
+        "provider",
+        "source_family",
+        "source_root",
+        "raw_artifact_id",
+        "time_range",
+        "failure_kind",
+        "parser_version",
+    }
+)
+
+
+class TestScopeFilterDictShape:
+    """``to_dict`` is byte-stable and exhaustive."""
+
+    def test_to_dict_lists_every_dimension_for_empty_filter(self) -> None:
+        payload = MaintenanceScopeFilter().to_dict()
+        assert set(payload.keys()) == _EXPECTED_DIMENSIONS
+        # Every absent dimension is explicit ``None`` rather than missing.
+        for dim in _EXPECTED_DIMENSIONS:
+            assert payload[dim] is None, f"{dim} should serialize as None when unset"
+
+    def test_to_dict_lists_every_dimension_for_populated_filter(self) -> None:
+        full = MaintenanceScopeFilter(
+            conversation_ids=("c1", "c2"),
+            provider="claude",
+            source_family="claude-code-session",
+            source_root=Path("/data/claude"),
+            raw_artifact_id="raw-1",
+            time_range=(
+                datetime(2026, 1, 1, tzinfo=timezone.utc),
+                datetime(2026, 2, 1, tzinfo=timezone.utc),
+            ),
+            failure_kind="ValidationError",
+            parser_version="v3",
+        )
+        payload = full.to_dict()
+        assert set(payload.keys()) == _EXPECTED_DIMENSIONS
+
+    def test_to_dict_is_json_serializable(self) -> None:
+        """``mode='json'`` must coerce Path/datetime/tuple to JSON primitives.
+
+        Surfaces serialize the payload straight through :func:`json.dumps`
+        without a custom encoder — leaking a ``Path`` or ``datetime`` here
+        would crash the daemon HTTP response or the MCP envelope.
+        """
+        full = MaintenanceScopeFilter(
+            conversation_ids=("c1",),
+            source_root=Path("/data"),
+            time_range=(
+                datetime(2026, 1, 1, tzinfo=timezone.utc),
+                datetime(2026, 2, 1, tzinfo=timezone.utc),
+            ),
+        )
+        text = json.dumps(full.to_dict())
+        # Round-trip via JSON must not lose information.
+        rehydrated = MaintenanceScopeFilter.from_dict(json.loads(text))
+        assert rehydrated == full
+
+
+class TestScopeFilterRoundTrip:
+    """from_dict(to_dict(f)) == f for every dimension combination."""
+
+    @pytest.mark.parametrize(
+        "filter_kwargs",
+        [
+            {},
+            {"conversation_ids": ("c1",)},
+            {"conversation_ids": ("c1", "c2", "c3")},
+            {"provider": "claude"},
+            {"source_family": "claude-code-session"},
+            {"source_root": Path("/data/claude")},
+            {"raw_artifact_id": "raw-abc"},
+            {
+                "time_range": (
+                    datetime(2026, 1, 1, tzinfo=timezone.utc),
+                    datetime(2026, 2, 1, tzinfo=timezone.utc),
+                )
+            },
+            {"failure_kind": "ValidationError"},
+            {"parser_version": "v3"},
+            {
+                "conversation_ids": ("c1", "c2"),
+                "provider": "claude",
+                "source_family": "claude-code-session",
+                "source_root": Path("/data"),
+                "raw_artifact_id": "raw-1",
+                "time_range": (
+                    datetime(2026, 1, 1, tzinfo=timezone.utc),
+                    datetime(2026, 2, 1, tzinfo=timezone.utc),
+                ),
+                "failure_kind": "decode-error",
+                "parser_version": "v3",
+            },
+        ],
+    )
+    def test_round_trip_preserves_filter(self, filter_kwargs: dict[str, Any]) -> None:
+        original = MaintenanceScopeFilter(**filter_kwargs)
+        recovered = MaintenanceScopeFilter.from_dict(original.to_dict())
+        assert recovered == original
+
+    def test_double_round_trip_is_idempotent(self) -> None:
+        original = MaintenanceScopeFilter(
+            conversation_ids=("c1",),
+            provider="claude",
+            source_root=Path("/data"),
+            time_range=(
+                datetime(2026, 1, 1, tzinfo=timezone.utc),
+                datetime(2026, 2, 1, tzinfo=timezone.utc),
+            ),
+        )
+        once = MaintenanceScopeFilter.from_dict(original.to_dict())
+        twice = MaintenanceScopeFilter.from_dict(once.to_dict())
+        assert original == once == twice
+        # The serialized payload itself is byte-stable, too.
+        assert original.to_dict() == once.to_dict() == twice.to_dict()
+
+    def test_from_dict_none_is_empty_filter(self) -> None:
+        assert MaintenanceScopeFilter.from_dict(None) == MaintenanceScopeFilter()
+
+    def test_from_dict_empty_dict_is_empty_filter(self) -> None:
+        assert MaintenanceScopeFilter.from_dict({}) == MaintenanceScopeFilter()
+
+    def test_from_dict_with_explicit_none_dimensions_is_empty(self) -> None:
+        """A payload that names every dimension as ``None`` is the empty filter.
+
+        This is the shape ``to_dict()`` emits, so the empty-filter
+        round-trip must not depend on the caller pruning ``None`` keys.
+        """
+        all_none = dict.fromkeys(_EXPECTED_DIMENSIONS)
+        assert MaintenanceScopeFilter.from_dict(all_none) == MaintenanceScopeFilter()
+
+
+# ---------------------------------------------------------------------------
+# Hypothesis property: round-trip identity across the whole dimension space
+# ---------------------------------------------------------------------------
+
+
+_ASCII_TEXT = st.text(
+    alphabet=st.characters(min_codepoint=0x20, max_codepoint=0x7E),
+    min_size=1,
+    max_size=24,
+)
+
+
+@st.composite
+def _scope_filter_kwargs(draw: Any) -> dict[str, Any]:
+    """Draw kwargs for an arbitrary :class:`MaintenanceScopeFilter`.
+
+    Each dimension is independently present-or-absent, so the property
+    explores the full 2^8 presence lattice rather than only fully-populated
+    or fully-empty filters.
+    """
+    kwargs: dict[str, Any] = {}
+    if draw(st.booleans()):
+        kwargs["conversation_ids"] = tuple(draw(st.lists(_ASCII_TEXT, min_size=1, max_size=4, unique=True)))
+    if draw(st.booleans()):
+        kwargs["provider"] = draw(_ASCII_TEXT)
+    if draw(st.booleans()):
+        kwargs["source_family"] = draw(_ASCII_TEXT)
+    if draw(st.booleans()):
+        kwargs["source_root"] = Path(draw(_ASCII_TEXT))
+    if draw(st.booleans()):
+        kwargs["raw_artifact_id"] = draw(_ASCII_TEXT)
+    if draw(st.booleans()):
+        # Two distinct tz-aware datetimes so the (since, until) ordering
+        # is meaningful but we never have to worry about naive timestamps.
+        since = draw(
+            st.datetimes(
+                min_value=datetime(2020, 1, 1),
+                max_value=datetime(2030, 12, 31),
+                timezones=st.just(timezone.utc),
+            )
+        )
+        until = draw(
+            st.datetimes(
+                min_value=datetime(2020, 1, 1),
+                max_value=datetime(2030, 12, 31),
+                timezones=st.just(timezone.utc),
+            )
+        )
+        kwargs["time_range"] = (since, until)
+    if draw(st.booleans()):
+        kwargs["failure_kind"] = draw(_ASCII_TEXT)
+    if draw(st.booleans()):
+        kwargs["parser_version"] = draw(_ASCII_TEXT)
+    return kwargs
+
+
+@given(_scope_filter_kwargs())
+@settings(
+    max_examples=200,
+    deadline=None,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+def test_round_trip_property(kwargs: dict[str, Any]) -> None:
+    """Property: any valid filter round-trips through ``to_dict``/``from_dict``."""
+    original = MaintenanceScopeFilter(**kwargs)
+    recovered = MaintenanceScopeFilter.from_dict(original.to_dict())
+    assert recovered == original
+    # And the serialized payload is itself byte-stable across one round trip.
+    assert original.to_dict() == recovered.to_dict()


### PR DESCRIPTION
## Summary

Adds three dedicated test files pinning the typed
`MaintenanceScopeFilter` contract — round-trip fidelity,
cross-surface envelope parity, and planner narrowing — so that any
future drift in CLI flags, daemon HTTP body shape, or MCP tool
parameters is caught locally instead of in production.

## Problem

`#1196` introduced `MaintenanceScopeFilter` and the three-surface
(CLI / daemon HTTP / MCP) plumbing, but the original `feat` PR carried
only the minimum contract test. `#1303` was filed to convert the
cross-surface coherence assertion into a first-class test gate, on
the same template that `#819` used for the session-tree envelope and
that `#1247` will reuse for the import-operation contract.

Without these tests, a future surface (or a refactor of the planner
boundary) can silently drop, rename, or mistranslate a scope
dimension. The envelope JSON would still parse — the only signal
would be a downstream behavior bug.

## Solution

Three new test modules under `tests/unit/maintenance/`:

- **`test_scope_filter_roundtrip.py`** — pins `to_dict()` shape (all
  eight known dimensions present, even when set to `None`),
  parametric `from_dict(to_dict(f)) == f` over every dimension
  combination, and a Hypothesis property over the full 2^8 dimension
  presence lattice. Also pins JSON-string round-trip so surfaces can
  serialize the payload without a custom encoder.

- **`test_scope_filter_envelope_contract.py`** — exercises each
  surface end-to-end with one canonical filter that touches every
  dimension:
  - CLI argv via `CliRunner` → planner call captured → envelope JSON
  - daemon HTTP body via `_handle_maintenance_plan` (both flat
    top-level shape and nested `{"scope":{"filter":{...}}}`)
  - MCP `maintenance_preview` typed args via `build_server`
  All three reach the planner with the same typed filter and echo
  back byte-equal `scope.filter` envelope JSON.

- **`test_planner_filter_narrowing.py`** — confirms the planner
  contract: a `conversation_ids` filter clamps `affected_rows` to the
  filter set size (never inflates), other dimensions pass through
  advisorily but still ride on the returned `MaintenanceScope.filter`
  so the envelope echoes them, and an empty filter never narrows the
  preview.

These tests are deliberately separate from the existing
`tests/unit/maintenance/test_scope_filter.py` (which pins the model
shape and frozen-ness) so each file has one clear responsibility.

## Verification

```
nix develop -c pytest \\
  tests/unit/maintenance/test_scope_filter_roundtrip.py \\
  tests/unit/maintenance/test_scope_filter_envelope_contract.py \\
  tests/unit/maintenance/test_planner_filter_narrowing.py -q
# 35 passed in 9.24s
```

Pre-push gate (`devtools verify --quick`) succeeds:

```
"total_duration_s": 35.79,
"exit_code": 0
```

Closes #1303
Ref #1196