### PR TITLE
feat(topology): cycle rejection and quarantine (#1260)

### DIFF
--- a/devtools/daemon_workload_probe.py
+++ b/devtools/daemon_workload_probe.py
@@ -25,7 +25,7 @@ from polylogue.storage.sqlite.connection_profile import open_readonly_connection
 
 # Bumped when the JSON shape gains new top-level keys or changes a field type.
 # The compare path uses this to refuse incompatible inputs loudly.
-REPORT_VERSION = 2  # v2 adds top-level `cursor_lag_baselines` (#1349)
+REPORT_VERSION = 3  # v3 adds top-level `topology_quarantine_state` (#1260)
 
 # Tables whose row counts form the convergence "boundary" — daemon work moves
 # rows into and out of these tables, so the deltas describe convergence shape.
@@ -43,6 +43,7 @@ _BOUNDARY_TABLES: tuple[str, ...] = (
     "live_ingest_attempt",
     "live_convergence_debt",
     "pending_blob_refs",
+    "topology_edges",
 )
 
 # Expected FTS-sync triggers.  A missing trigger means the FTS index can drift
@@ -340,6 +341,44 @@ def _boundary_table_counts(conn: sqlite3.Connection) -> dict[str, int]:
     return counts
 
 
+def _topology_quarantine_state(conn: sqlite3.Connection) -> dict[str, Any]:
+    """Report the state of the topology-edge cycle quarantine (#1260).
+
+    Surfaces:
+    - ``table_present`` — is ``topology_edges`` materialized in the database
+    - ``unresolved_count`` — edges still awaiting their parent
+    - ``resolved_count`` — edges whose parent has been ingested
+    - ``quarantined_count`` — edges rejected because they would create a
+      cycle in ``conversations.parent_conversation_id``
+    - ``oldest_quarantined_at`` — oldest ``resolved_at`` timestamp on a
+      quarantined edge (the field is repurposed as the
+      "decision-recorded-at" timestamp for non-resolved terminal states)
+
+    Operators monitor ``quarantined_count`` as a health indicator — a
+    non-zero value means at least one source emitted a cycle and the
+    fast-path graph was prevented from entering it.
+    """
+
+    if not _table_exists(conn, "topology_edges"):
+        return {
+            "table_present": False,
+            "unresolved_count": 0,
+            "resolved_count": 0,
+            "quarantined_count": 0,
+            "oldest_quarantined_at": None,
+        }
+    rows = conn.execute("SELECT status, COUNT(*) AS n FROM topology_edges GROUP BY status").fetchall()
+    status_counts = {str(row[0]): int(row[1]) for row in rows}
+    oldest_row = conn.execute("SELECT MIN(resolved_at) FROM topology_edges WHERE status = 'quarantined'").fetchone()
+    return {
+        "table_present": True,
+        "unresolved_count": int(status_counts.get("unresolved", 0)),
+        "resolved_count": int(status_counts.get("resolved", 0)),
+        "quarantined_count": int(status_counts.get("quarantined", 0)),
+        "oldest_quarantined_at": oldest_row[0] if oldest_row else None,
+    }
+
+
 def _blob_lease_state(conn: sqlite3.Connection) -> dict[str, Any]:
     if not _table_exists(conn, "pending_blob_refs"):
         return {
@@ -627,6 +666,7 @@ def probe(db: Path, *, limit: int = 5) -> dict[str, Any]:
             "recent_attempts": recent_attempts,
             "convergence_stage_timings": _convergence_stage_timings(recent_attempts, conn),
             "boundary_table_counts": _boundary_table_counts(conn),
+            "topology_quarantine_state": _topology_quarantine_state(conn),
             "blob_lease_state": _blob_lease_state(conn),
             "gc_state": _gc_state(conn),
             "fts_trigger_state": _fts_trigger_state(conn),

--- a/polylogue/archive/topology/edge.py
+++ b/polylogue/archive/topology/edge.py
@@ -63,11 +63,20 @@ class TopologyEdgeType(str, Enum):
 
 
 class TopologyEdgeStatus(str, Enum):
-    """Closed lifecycle vocabulary for a topology edge."""
+    """Closed lifecycle vocabulary for a topology edge.
+
+    ``QUARANTINED`` (#1260 / #866 slice C) marks an edge whose resolution
+    would introduce a cycle (e.g. A → B → A) into the
+    ``conversations.parent_conversation_id`` fast-path graph. The resolver
+    refuses to backfill the cycle-creating edge; the edge row is preserved
+    so the operator can audit the cycle path that was rejected. The cycle
+    path is recorded in ``raw_evidence`` as JSON.
+    """
 
     UNRESOLVED = "unresolved"
     RESOLVED = "resolved"
     REPAIRED = "repaired"
+    QUARANTINED = "quarantined"
 
     def __str__(self) -> str:
         return self.value

--- a/polylogue/storage/sqlite/queries/topology_edges.py
+++ b/polylogue/storage/sqlite/queries/topology_edges.py
@@ -11,11 +11,25 @@ Two operations are exposed:
   to ``resolved`` once their parent has been ingested. Used by
   ``save_via_backend`` so out-of-order ingest backfills the resolver state
   the moment the parent lands.
+
+Cycle quarantine (#1260 / #866 slice C)
+---------------------------------------
+Both resolver paths refuse to backfill a child's
+``conversations.parent_conversation_id`` when doing so would introduce a
+cycle into the resolved-parent graph (A→B→A, 3-node, etc., including
+the self-cycle A→A). The offending edge is left in the
+``topology_edges`` table with ``status='quarantined'`` and a
+``raw_evidence`` JSON document recording the detected cycle path so the
+operator can audit which conversation chain was rejected. The child's
+``parent_conversation_id`` is NOT written for quarantined edges — the
+fast-path ancestry walk therefore continues to terminate at the child
+rather than enter the cycle.
 """
 
 from __future__ import annotations
 
 import hashlib
+import json
 from collections.abc import Iterable
 
 import aiosqlite
@@ -90,6 +104,132 @@ async def upsert_topology_edges(
     return written
 
 
+_CYCLE_WALK_BUDGET = 1024
+"""Hard cap on the resolved-parent ancestry walk used by cycle detection.
+
+Any conversation chain longer than this is treated as cyclic regardless
+of whether the actual cycle was reached, because no legitimate
+conversation lineage is expected to exceed it and a runaway walk would
+otherwise pin the resolver."""
+
+
+async def _would_create_cycle(
+    conn: aiosqlite.Connection,
+    *,
+    child_id: str,
+    proposed_parent_id: str,
+) -> list[str] | None:
+    """Return the cycle path if making ``proposed_parent_id`` the parent
+    of ``child_id`` would create a cycle in ``conversations.parent_conversation_id``.
+
+    A cycle exists when ``proposed_parent_id == child_id`` (self-cycle) or
+    when walking ``proposed_parent_id``'s existing ancestry via
+    ``parent_conversation_id`` reaches ``child_id``. Returns ``None`` if no
+    cycle would form. The returned list is the chain
+    ``[child_id, proposed_parent_id, ..., child_id]`` so the operator can
+    see exactly which edge would have closed the loop.
+    """
+
+    # Self-cycle: child claiming itself as parent.
+    if proposed_parent_id == child_id:
+        return [child_id, child_id]
+
+    path: list[str] = [child_id, proposed_parent_id]
+    current = proposed_parent_id
+    steps = 0
+    while True:
+        if steps >= _CYCLE_WALK_BUDGET:
+            # Treat budget-exceeded as cyclic; legitimate chains do not
+            # reach this length and continuing risks a runaway walk.
+            path.append("...budget-exceeded")
+            return path
+        row = await (
+            await conn.execute(
+                "SELECT parent_conversation_id FROM conversations WHERE conversation_id = ?",
+                (current,),
+            )
+        ).fetchone()
+        if row is None:
+            return None
+        next_parent = row["parent_conversation_id"]
+        if next_parent is None:
+            return None
+        if next_parent == child_id:
+            path.append(child_id)
+            return path
+        path.append(next_parent)
+        current = next_parent
+        steps += 1
+
+
+async def _quarantine_edge(
+    conn: aiosqlite.Connection,
+    *,
+    edge_id: str | None,
+    src_conversation_id: str,
+    dst_provider_name: str | None,
+    dst_provider_native_id: str | None,
+    cycle_path: list[str],
+    observed_at: str,
+) -> None:
+    """Mark an edge as quarantined and record the cycle path in raw_evidence.
+
+    If ``edge_id`` is given the update targets that row directly; otherwise
+    the ``(dst_provider_name, dst_provider_native_id)`` lookup is used,
+    matching the resolver-by-parent code path.
+    """
+
+    evidence = json.dumps(
+        {
+            "reason": "cycle_rejected",
+            "cycle_path": cycle_path,
+            "detected_at": observed_at,
+        },
+        sort_keys=True,
+    )
+    if edge_id is not None:
+        await conn.execute(
+            """
+            UPDATE topology_edges
+               SET status = 'quarantined',
+                   raw_evidence = ?,
+                   resolved_at = ?
+             WHERE edge_id = ?
+            """,
+            (evidence, observed_at, edge_id),
+        )
+        return
+    await conn.execute(
+        """
+        UPDATE topology_edges
+           SET status = 'quarantined',
+               raw_evidence = ?,
+               resolved_at = ?
+         WHERE src_conversation_id = ?
+           AND dst_provider_name = ?
+           AND dst_provider_native_id = ?
+        """,
+        (
+            evidence,
+            observed_at,
+            src_conversation_id,
+            dst_provider_name,
+            dst_provider_native_id,
+        ),
+    )
+
+
+async def count_quarantined_topology_edges(conn: aiosqlite.Connection) -> int:
+    """Return the number of topology edges currently in ``quarantined`` state.
+
+    Surfaced through the diagnostic/readiness report (#1260) so cycle
+    rejections are visible to the operator rather than silently absorbed.
+    """
+
+    row = await (await conn.execute("SELECT COUNT(*) AS n FROM topology_edges WHERE status = 'quarantined'")).fetchone()
+    return int(row["n"]) if row is not None else 0
+
+
 async def resolve_topology_edges_for_conversation(
     conn: aiosqlite.Connection,
     *,
@@ -118,11 +258,11 @@ async def resolve_topology_edges_for_conversation(
     running the resolver twice for the same parent produces no further
     changes after the first pass.
     """
-    # Collect the children that the upcoming UPDATE will flip, *before*
-    # the UPDATE runs, so we can use them to backfill the conversations
-    # rows in the same transaction. Selecting child IDs + edge types lets
-    # us avoid issuing one UPDATE per child while still classifying the
-    # branch type per row.
+    # Collect the children that would be flipped, *before* any UPDATE runs,
+    # so we can partition them into (resolved, quarantined) buckets based
+    # on whether backfilling their ``parent_conversation_id`` would create
+    # a cycle (#1260). Per-row processing lets the cycle detector walk the
+    # ancestry of ``conversation_id`` (the proposed parent) for each child.
     cursor = await conn.execute(
         """
         SELECT src_conversation_id, edge_type
@@ -135,34 +275,56 @@ async def resolve_topology_edges_for_conversation(
     )
     pending_rows = list(await cursor.fetchall())
 
-    update_cursor = await conn.execute(
-        """
-        UPDATE topology_edges
-           SET resolved_dst_conversation_id = ?,
-               status = 'resolved',
-               resolved_at = ?
-         WHERE status = 'unresolved'
-           AND dst_provider_name = ?
-           AND dst_provider_native_id = ?
-        """,
-        (conversation_id, resolved_at, provider_name, provider_conversation_id),
-    )
-    flipped = update_cursor.rowcount or 0
+    if not pending_rows:
+        return 0
 
-    if flipped == 0 or not pending_rows:
-        return flipped
-
-    # Backfill the resolved fast-path on each child conversation. The
-    # ``parent_conversation_id IS NULL`` guard preserves whatever was set
-    # at the child's original write time and makes the backfill idempotent;
-    # the ``branch_type`` guard mirrors the same constraint and restricts
-    # writes to the closed ``BranchType`` vocabulary so the CHECK constraint
-    # on ``conversations.branch_type`` cannot be violated by future
-    # ``RESUME`` / ``BRANCH`` / ``REPAIRED`` edge types.
     valid_branch_types: set[str] = {bt.value for bt in BranchType}
+    flipped = 0
     for row in pending_rows:
         child_id = row["src_conversation_id"]
         edge_type = row["edge_type"]
+
+        cycle_path = await _would_create_cycle(
+            conn,
+            child_id=child_id,
+            proposed_parent_id=conversation_id,
+        )
+        if cycle_path is not None:
+            # Quarantine the offending edge instead of resolving it. Leave
+            # ``conversations.parent_conversation_id`` untouched so the
+            # fast-path ancestry walk does not enter the cycle.
+            await _quarantine_edge(
+                conn,
+                edge_id=None,
+                src_conversation_id=child_id,
+                dst_provider_name=provider_name,
+                dst_provider_native_id=provider_conversation_id,
+                cycle_path=cycle_path,
+                observed_at=resolved_at,
+            )
+            continue
+
+        await conn.execute(
+            """
+            UPDATE topology_edges
+               SET resolved_dst_conversation_id = ?,
+                   status = 'resolved',
+                   resolved_at = ?
+             WHERE status = 'unresolved'
+               AND src_conversation_id = ?
+               AND dst_provider_name = ?
+               AND dst_provider_native_id = ?
+            """,
+            (conversation_id, resolved_at, child_id, provider_name, provider_conversation_id),
+        )
+        flipped += 1
+        # Backfill the resolved fast-path on the child conversation. The
+        # ``parent_conversation_id IS NULL`` guard preserves whatever was set
+        # at the child's original write time and makes the backfill idempotent;
+        # the ``branch_type`` guard mirrors the same constraint and restricts
+        # writes to the closed ``BranchType`` vocabulary so the CHECK constraint
+        # on ``conversations.branch_type`` cannot be violated by future
+        # ``RESUME`` / ``BRANCH`` / ``REPAIRED`` edge types.
         branch_type: str | None = edge_type if edge_type in valid_branch_types else None
         await conn.execute(
             """
@@ -220,6 +382,27 @@ async def resolve_unresolved_edges_for_child(
         edge_id = row["edge_id"]
         edge_type = row["edge_type"]
         parent_cid = row["parent_cid"]
+
+        cycle_path = await _would_create_cycle(
+            conn,
+            child_id=src_conversation_id,
+            proposed_parent_id=parent_cid,
+        )
+        if cycle_path is not None:
+            # Quarantine the offending edge (#1260). Do not flip to resolved
+            # and do not backfill the conversations row, so the fast-path
+            # ancestry walk does not enter the cycle.
+            await _quarantine_edge(
+                conn,
+                edge_id=edge_id,
+                src_conversation_id=src_conversation_id,
+                dst_provider_name=None,
+                dst_provider_native_id=None,
+                cycle_path=cycle_path,
+                observed_at=resolved_at,
+            )
+            continue
+
         await conn.execute(
             """
             UPDATE topology_edges
@@ -267,6 +450,7 @@ async def list_topology_edges_for_conversation(
 
 __all__ = [
     "TopologyEdgeStatus",
+    "count_quarantined_topology_edges",
     "list_topology_edges_for_conversation",
     "resolve_topology_edges_for_conversation",
     "resolve_unresolved_edges_for_child",

--- a/polylogue/storage/sqlite/schema_ddl.py
+++ b/polylogue/storage/sqlite/schema_ddl.py
@@ -69,7 +69,7 @@ from polylogue.storage.sqlite.schema_ddl_provider_events import (
     PROVIDER_EVENT_DDL as _PROVIDER_EVENT_DDL,
 )
 
-SCHEMA_VERSION = 6  # Canonical schema. No migration chain: mismatch → re-ingest from source (#1212, #1190, #1240, #1241, #1252, #1258).
+SCHEMA_VERSION = 7  # Canonical schema. No migration chain: mismatch → re-ingest from source (#1212, #1190, #1240, #1241, #1252, #1258, #1260).
 
 
 # Complete target schema applied to fresh databases.

--- a/polylogue/storage/sqlite/schema_ddl_archive.py
+++ b/polylogue/storage/sqlite/schema_ddl_archive.py
@@ -539,7 +539,7 @@ TOPOLOGY_EDGES_DDL = """
             raw_evidence                 TEXT,
             confidence                   REAL NOT NULL DEFAULT 1.0,
             status                       TEXT NOT NULL
-                CHECK (status IN ('unresolved', 'resolved', 'repaired')),
+                CHECK (status IN ('unresolved', 'resolved', 'repaired', 'quarantined')),
             observed_at                  TEXT NOT NULL,
             resolved_at                  TEXT,
             UNIQUE (src_conversation_id, dst_provider_native_id, edge_type)

--- a/tests/unit/insights/test_topology_cycle_rejection.py
+++ b/tests/unit/insights/test_topology_cycle_rejection.py
@@ -1,0 +1,599 @@
+"""Topology cycle rejection and quarantine (#1260 / #866 slice C).
+
+When resolving a topology edge would create a cycle in
+``conversations.parent_conversation_id`` (A → B → A, longer cycles, or
+the self-cycle A → A), the resolver must:
+
+- Refuse to backfill ``parent_conversation_id`` (the fast-path graph
+  must never enter the cycle).
+- Refuse to flip the edge to ``status='resolved'``; instead, mark it
+  ``status='quarantined'`` with a ``raw_evidence`` JSON document that
+  records the detected cycle path so the operator can audit which
+  conversation chain was rejected.
+- Leave non-cyclic edges in the same resolver batch untouched (a cycle
+  on one child does not poison legitimate siblings).
+- Stay idempotent: re-running the resolver on an archive that already
+  contains quarantined edges produces no further changes.
+
+These tests exercise both resolver entry points
+(:func:`resolve_topology_edges_for_conversation` and
+:func:`resolve_unresolved_edges_for_child`) and also assert the
+no-false-positive case on a diamond DAG, which is a legitimate shape
+(B→D, C→D both pointing at D) that some prior implementations confuse
+with a cycle.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from collections.abc import Iterator
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from polylogue.archive.topology.edge import (
+    TopologyEdgeRecord,
+    TopologyEdgeStatus,
+    TopologyEdgeType,
+)
+from polylogue.storage.sqlite.queries.topology_edges import (
+    count_quarantined_topology_edges,
+    resolve_topology_edges_for_conversation,
+    resolve_unresolved_edges_for_child,
+    upsert_topology_edges,
+)
+from polylogue.storage.sqlite.schema_ddl import SCHEMA_DDL, SCHEMA_VERSION
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _bootstrap_db(path: Path) -> None:
+    with sqlite3.connect(path) as conn:
+        conn.executescript(SCHEMA_DDL)
+        conn.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
+        conn.commit()
+
+
+def _insert_conversation(
+    conn: sqlite3.Connection,
+    *,
+    conversation_id: str,
+    provider_name: str,
+    provider_conversation_id: str,
+    parent_conversation_id: str | None = None,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO conversations (
+            conversation_id, provider_name, provider_conversation_id, title,
+            parent_conversation_id, content_hash, created_at, updated_at, version
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            conversation_id,
+            provider_name,
+            provider_conversation_id,
+            f"conv {conversation_id}",
+            parent_conversation_id,
+            f"hash-{conversation_id}",
+            _now(),
+            _now(),
+            1,
+        ),
+    )
+    conn.commit()
+
+
+class _AsyncSqliteAdapter:
+    """Minimal aiosqlite-compatible wrapper around stdlib sqlite3.
+
+    The production query helpers are written against ``aiosqlite``; the
+    only async operations they perform are ``execute``/``fetchone``/
+    ``fetchall``. This adapter lets the unit tests drive them against a
+    plain sqlite3 connection without spinning up the full async runtime.
+    """
+
+    def __init__(self, conn: sqlite3.Connection) -> None:
+        conn.row_factory = sqlite3.Row
+        self._conn = conn
+
+    async def execute(self, sql: str, params: tuple = ()) -> _AsyncCursorAdapter:
+        cursor = self._conn.execute(sql, params)
+        return _AsyncCursorAdapter(cursor)
+
+    def commit(self) -> None:
+        self._conn.commit()
+
+
+class _AsyncCursorAdapter:
+    def __init__(self, cursor: sqlite3.Cursor) -> None:
+        self._cursor = cursor
+
+    async def fetchall(self) -> list[sqlite3.Row]:
+        return list(self._cursor.fetchall())
+
+    async def fetchone(self) -> sqlite3.Row | None:
+        return self._cursor.fetchone()
+
+    @property
+    def rowcount(self) -> int:
+        return self._cursor.rowcount
+
+
+@pytest.fixture
+def cycle_db(tmp_path: Path) -> Iterator[sqlite3.Connection]:
+    db_path = tmp_path / "cycle.sqlite"
+    _bootstrap_db(db_path)
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
+def _seed_edge(
+    conn: sqlite3.Connection,
+    *,
+    src_conversation_id: str,
+    dst_provider_native_id: str,
+    dst_provider_name: str = "codex",
+    edge_type: TopologyEdgeType = TopologyEdgeType.CONTINUATION,
+) -> None:
+    """Insert one unresolved topology edge through the production upsert."""
+
+    import asyncio
+
+    edge = TopologyEdgeRecord(
+        src_conversation_id=src_conversation_id,
+        dst_provider_native_id=dst_provider_native_id,
+        dst_provider_name=dst_provider_name,
+        edge_type=edge_type,
+        status=TopologyEdgeStatus.UNRESOLVED,
+    )
+    asyncio.run(upsert_topology_edges(_AsyncSqliteAdapter(conn), [edge]))  # type: ignore[arg-type]
+
+
+def _run_resolve_for_parent(
+    conn: sqlite3.Connection,
+    *,
+    conversation_id: str,
+    provider_name: str,
+    provider_conversation_id: str,
+) -> int:
+    import asyncio
+
+    return asyncio.run(
+        resolve_topology_edges_for_conversation(
+            _AsyncSqliteAdapter(conn),  # type: ignore[arg-type]
+            conversation_id=conversation_id,
+            provider_name=provider_name,
+            provider_conversation_id=provider_conversation_id,
+            resolved_at=_now(),
+        )
+    )
+
+
+def _run_resolve_for_child(conn: sqlite3.Connection, *, src_conversation_id: str) -> int:
+    import asyncio
+
+    return asyncio.run(
+        resolve_unresolved_edges_for_child(
+            _AsyncSqliteAdapter(conn),  # type: ignore[arg-type]
+            src_conversation_id=src_conversation_id,
+            resolved_at=_now(),
+        )
+    )
+
+
+def _fetch_edge_status(conn: sqlite3.Connection, src_conversation_id: str) -> tuple[str, str | None]:
+    row = conn.execute(
+        "SELECT status, raw_evidence FROM topology_edges WHERE src_conversation_id = ?",
+        (src_conversation_id,),
+    ).fetchone()
+    assert row is not None
+    return str(row["status"]), row["raw_evidence"]
+
+
+def _fetch_parent(conn: sqlite3.Connection, conversation_id: str) -> str | None:
+    row = conn.execute(
+        "SELECT parent_conversation_id FROM conversations WHERE conversation_id = ?",
+        (conversation_id,),
+    ).fetchone()
+    return None if row is None else row["parent_conversation_id"]
+
+
+class TestTwoNodeCycle:
+    """A → B → A (B was already saved with A as parent; A is now landing
+    with a topology edge that would make B its parent)."""
+
+    def test_two_node_cycle_quarantines_edge_and_leaves_parent_null(self, cycle_db: sqlite3.Connection) -> None:
+        # Topology: A's parent_conversation_id will eventually be set to B,
+        # but B already has A as its parent. Resolving A→B is the cycle.
+        _insert_conversation(
+            cycle_db,
+            conversation_id="conv-A",
+            provider_name="codex",
+            provider_conversation_id="native-A",
+            parent_conversation_id=None,
+        )
+        _insert_conversation(
+            cycle_db,
+            conversation_id="conv-B",
+            provider_name="codex",
+            provider_conversation_id="native-B",
+            parent_conversation_id="conv-A",  # B → A already.
+        )
+        # A asserts an unresolved edge to B (this would normally flip to
+        # resolved when B's row was already in place).
+        _seed_edge(
+            cycle_db,
+            src_conversation_id="conv-A",
+            dst_provider_native_id="native-B",
+        )
+
+        # The resolver-by-child code path is what runs when A's own edge
+        # is upserted and we then sweep for matching parent rows.
+        _run_resolve_for_child(cycle_db, src_conversation_id="conv-A")
+
+        status, evidence = _fetch_edge_status(cycle_db, "conv-A")
+        assert status == TopologyEdgeStatus.QUARANTINED.value
+        assert evidence is not None
+        payload = json.loads(evidence)
+        assert payload["reason"] == "cycle_rejected"
+        # The cycle path must include both endpoints.
+        assert "conv-A" in payload["cycle_path"]
+        assert "conv-B" in payload["cycle_path"]
+
+        # And critically, A.parent_conversation_id stays NULL so the
+        # fast-path ancestry walk does not enter the cycle.
+        assert _fetch_parent(cycle_db, "conv-A") is None
+
+    def test_two_node_cycle_via_parent_first_path(self, cycle_db: sqlite3.Connection) -> None:
+        # Same topology but exercised through the parent-first entry point
+        # (parent X is being saved; we look for unresolved edges pointing at X).
+        _insert_conversation(
+            cycle_db,
+            conversation_id="conv-A",
+            provider_name="codex",
+            provider_conversation_id="native-A",
+            parent_conversation_id=None,
+        )
+        _insert_conversation(
+            cycle_db,
+            conversation_id="conv-B",
+            provider_name="codex",
+            provider_conversation_id="native-B",
+            parent_conversation_id="conv-A",
+        )
+        _seed_edge(
+            cycle_db,
+            src_conversation_id="conv-A",
+            dst_provider_native_id="native-B",
+        )
+
+        # B is now being "saved" (already present in conversations from
+        # the fixture), and we sweep edges that point at native-B. Without
+        # cycle detection this would resolve the edge and backfill
+        # A.parent_conversation_id = B, closing the loop.
+        flipped = _run_resolve_for_parent(
+            cycle_db,
+            conversation_id="conv-B",
+            provider_name="codex",
+            provider_conversation_id="native-B",
+        )
+        assert flipped == 0  # nothing was successfully resolved
+
+        status, evidence = _fetch_edge_status(cycle_db, "conv-A")
+        assert status == TopologyEdgeStatus.QUARANTINED.value
+        assert evidence is not None
+        assert _fetch_parent(cycle_db, "conv-A") is None
+
+
+class TestThreeNodeCycle:
+    """A → B → C → A. C is being saved; resolving A→C would close the loop."""
+
+    def test_three_node_cycle_quarantined(self, cycle_db: sqlite3.Connection) -> None:
+        _insert_conversation(
+            cycle_db,
+            conversation_id="conv-A",
+            provider_name="codex",
+            provider_conversation_id="native-A",
+            parent_conversation_id=None,
+        )
+        _insert_conversation(
+            cycle_db,
+            conversation_id="conv-B",
+            provider_name="codex",
+            provider_conversation_id="native-B",
+            parent_conversation_id="conv-A",
+        )
+        _insert_conversation(
+            cycle_db,
+            conversation_id="conv-C",
+            provider_name="codex",
+            provider_conversation_id="native-C",
+            parent_conversation_id="conv-B",
+        )
+        # A asserts unresolved edge to C → resolving would mean
+        # A.parent = C → B → A → cycle.
+        _seed_edge(
+            cycle_db,
+            src_conversation_id="conv-A",
+            dst_provider_native_id="native-C",
+        )
+
+        _run_resolve_for_child(cycle_db, src_conversation_id="conv-A")
+
+        status, evidence = _fetch_edge_status(cycle_db, "conv-A")
+        assert status == TopologyEdgeStatus.QUARANTINED.value
+        payload = json.loads(evidence or "{}")
+        # The recorded path should walk A → C → B → A.
+        assert payload["cycle_path"][0] == "conv-A"
+        assert payload["cycle_path"][-1] == "conv-A"
+        assert "conv-B" in payload["cycle_path"]
+        assert "conv-C" in payload["cycle_path"]
+        assert _fetch_parent(cycle_db, "conv-A") is None
+
+
+class TestSelfCycle:
+    """A → A. The most pathological cycle shape."""
+
+    def test_self_cycle_quarantined(self, cycle_db: sqlite3.Connection) -> None:
+        _insert_conversation(
+            cycle_db,
+            conversation_id="conv-A",
+            provider_name="codex",
+            provider_conversation_id="native-A",
+            parent_conversation_id=None,
+        )
+        # A's edge points at its own native id.
+        _seed_edge(
+            cycle_db,
+            src_conversation_id="conv-A",
+            dst_provider_native_id="native-A",
+        )
+
+        flipped = _run_resolve_for_parent(
+            cycle_db,
+            conversation_id="conv-A",
+            provider_name="codex",
+            provider_conversation_id="native-A",
+        )
+        assert flipped == 0
+
+        status, evidence = _fetch_edge_status(cycle_db, "conv-A")
+        assert status == TopologyEdgeStatus.QUARANTINED.value
+        payload = json.loads(evidence or "{}")
+        assert payload["cycle_path"] == ["conv-A", "conv-A"]
+        assert _fetch_parent(cycle_db, "conv-A") is None
+
+
+class TestDiamondDagNoFalsePositive:
+    """B → D and C → D — D is a shared parent for two children. This is a
+    legitimate diamond DAG, not a cycle, and the resolver must process it
+    cleanly without quarantining either edge."""
+
+    def test_diamond_dag_resolves_both_children(self, cycle_db: sqlite3.Connection) -> None:
+        _insert_conversation(
+            cycle_db,
+            conversation_id="conv-D",
+            provider_name="codex",
+            provider_conversation_id="native-D",
+            parent_conversation_id=None,
+        )
+        _insert_conversation(
+            cycle_db,
+            conversation_id="conv-B",
+            provider_name="codex",
+            provider_conversation_id="native-B",
+            parent_conversation_id=None,
+        )
+        _insert_conversation(
+            cycle_db,
+            conversation_id="conv-C",
+            provider_name="codex",
+            provider_conversation_id="native-C",
+            parent_conversation_id=None,
+        )
+        _seed_edge(
+            cycle_db,
+            src_conversation_id="conv-B",
+            dst_provider_native_id="native-D",
+        )
+        _seed_edge(
+            cycle_db,
+            src_conversation_id="conv-C",
+            dst_provider_native_id="native-D",
+        )
+
+        flipped = _run_resolve_for_parent(
+            cycle_db,
+            conversation_id="conv-D",
+            provider_name="codex",
+            provider_conversation_id="native-D",
+        )
+        assert flipped == 2  # both edges resolved
+
+        for child in ("conv-B", "conv-C"):
+            status, _ = _fetch_edge_status(cycle_db, child)
+            assert status == TopologyEdgeStatus.RESOLVED.value
+            assert _fetch_parent(cycle_db, child) == "conv-D"
+
+
+class TestSiblingNotQuarantined:
+    """A cycle on one child must not quarantine a non-cyclic sibling that
+    happens to share the resolver batch (both pointing at the same parent
+    native id)."""
+
+    def test_cycle_on_one_child_leaves_sibling_resolved(self, cycle_db: sqlite3.Connection) -> None:
+        # X is the parent native id. Two children share it:
+        #   - cyclic: X is descendant of cycle-child, so resolving creates cycle.
+        #   - clean: independent child with no ancestry conflict.
+        _insert_conversation(
+            cycle_db,
+            conversation_id="conv-cycle",
+            provider_name="codex",
+            provider_conversation_id="native-cycle",
+            parent_conversation_id=None,
+        )
+        _insert_conversation(
+            cycle_db,
+            conversation_id="conv-X",
+            provider_name="codex",
+            provider_conversation_id="native-X",
+            parent_conversation_id="conv-cycle",  # X already descends from cycle-child
+        )
+        _insert_conversation(
+            cycle_db,
+            conversation_id="conv-clean",
+            provider_name="codex",
+            provider_conversation_id="native-clean",
+            parent_conversation_id=None,
+        )
+        _seed_edge(
+            cycle_db,
+            src_conversation_id="conv-cycle",
+            dst_provider_native_id="native-X",
+        )
+        _seed_edge(
+            cycle_db,
+            src_conversation_id="conv-clean",
+            dst_provider_native_id="native-X",
+        )
+
+        flipped = _run_resolve_for_parent(
+            cycle_db,
+            conversation_id="conv-X",
+            provider_name="codex",
+            provider_conversation_id="native-X",
+        )
+        # Only the clean child resolved; the cyclic one was quarantined.
+        assert flipped == 1
+
+        cycle_status, _ = _fetch_edge_status(cycle_db, "conv-cycle")
+        clean_status, _ = _fetch_edge_status(cycle_db, "conv-clean")
+        assert cycle_status == TopologyEdgeStatus.QUARANTINED.value
+        assert clean_status == TopologyEdgeStatus.RESOLVED.value
+        assert _fetch_parent(cycle_db, "conv-cycle") is None
+        assert _fetch_parent(cycle_db, "conv-clean") == "conv-X"
+
+
+class TestIdempotency:
+    """Re-running the resolver after quarantine produces no further state
+    changes — the edge stays quarantined, the conversations row stays
+    untouched."""
+
+    def test_resolver_idempotent_on_quarantined_edge(self, cycle_db: sqlite3.Connection) -> None:
+        _insert_conversation(
+            cycle_db,
+            conversation_id="conv-A",
+            provider_name="codex",
+            provider_conversation_id="native-A",
+            parent_conversation_id=None,
+        )
+        _insert_conversation(
+            cycle_db,
+            conversation_id="conv-B",
+            provider_name="codex",
+            provider_conversation_id="native-B",
+            parent_conversation_id="conv-A",
+        )
+        _seed_edge(
+            cycle_db,
+            src_conversation_id="conv-A",
+            dst_provider_native_id="native-B",
+        )
+
+        # First pass quarantines.
+        _run_resolve_for_parent(
+            cycle_db,
+            conversation_id="conv-B",
+            provider_name="codex",
+            provider_conversation_id="native-B",
+        )
+        status1, evidence1 = _fetch_edge_status(cycle_db, "conv-A")
+        assert status1 == TopologyEdgeStatus.QUARANTINED.value
+
+        # Re-running the parent resolver: the edge is no longer
+        # ``unresolved``, so the SELECT returns no candidates and nothing
+        # changes. No spurious second quarantine event, no parent backfill.
+        _run_resolve_for_parent(
+            cycle_db,
+            conversation_id="conv-B",
+            provider_name="codex",
+            provider_conversation_id="native-B",
+        )
+        status2, evidence2 = _fetch_edge_status(cycle_db, "conv-A")
+        assert status2 == TopologyEdgeStatus.QUARANTINED.value
+        assert evidence2 == evidence1  # same payload, untouched
+        assert _fetch_parent(cycle_db, "conv-A") is None
+
+    def test_resolver_for_child_idempotent_on_quarantined_edge(self, cycle_db: sqlite3.Connection) -> None:
+        _insert_conversation(
+            cycle_db,
+            conversation_id="conv-A",
+            provider_name="codex",
+            provider_conversation_id="native-A",
+            parent_conversation_id=None,
+        )
+        _insert_conversation(
+            cycle_db,
+            conversation_id="conv-B",
+            provider_name="codex",
+            provider_conversation_id="native-B",
+            parent_conversation_id="conv-A",
+        )
+        _seed_edge(
+            cycle_db,
+            src_conversation_id="conv-A",
+            dst_provider_native_id="native-B",
+        )
+
+        _run_resolve_for_child(cycle_db, src_conversation_id="conv-A")
+        _run_resolve_for_child(cycle_db, src_conversation_id="conv-A")
+
+        status, _ = _fetch_edge_status(cycle_db, "conv-A")
+        assert status == TopologyEdgeStatus.QUARANTINED.value
+        assert _fetch_parent(cycle_db, "conv-A") is None
+
+
+class TestQuarantineCount:
+    """The diagnostic counter surfaces quarantined edges so the daemon
+    workload probe can warn the operator."""
+
+    def test_count_quarantined_topology_edges(self, cycle_db: sqlite3.Connection) -> None:
+        import asyncio
+
+        # Start with zero.
+        count0 = asyncio.run(count_quarantined_topology_edges(_AsyncSqliteAdapter(cycle_db)))  # type: ignore[arg-type]
+        assert count0 == 0
+
+        # Create a cycle.
+        _insert_conversation(
+            cycle_db,
+            conversation_id="conv-A",
+            provider_name="codex",
+            provider_conversation_id="native-A",
+            parent_conversation_id=None,
+        )
+        _insert_conversation(
+            cycle_db,
+            conversation_id="conv-B",
+            provider_name="codex",
+            provider_conversation_id="native-B",
+            parent_conversation_id="conv-A",
+        )
+        _seed_edge(
+            cycle_db,
+            src_conversation_id="conv-A",
+            dst_provider_native_id="native-B",
+        )
+        _run_resolve_for_child(cycle_db, src_conversation_id="conv-A")
+
+        count1 = asyncio.run(count_quarantined_topology_edges(_AsyncSqliteAdapter(cycle_db)))  # type: ignore[arg-type]
+        assert count1 == 1

--- a/tests/unit/insights/test_topology_cycle_rejection.py
+++ b/tests/unit/insights/test_topology_cycle_rejection.py
@@ -28,7 +28,6 @@ from __future__ import annotations
 import json
 import sqlite3
 from collections.abc import Iterator
-from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
@@ -45,10 +44,12 @@ from polylogue.storage.sqlite.queries.topology_edges import (
     upsert_topology_edges,
 )
 from polylogue.storage.sqlite.schema_ddl import SCHEMA_DDL, SCHEMA_VERSION
+from polylogue.types import ConversationId
+from tests.infra.frozen_clock import fixed_now
 
 
 def _now() -> str:
-    return datetime.now(timezone.utc).isoformat()
+    return fixed_now().isoformat()
 
 
 def _bootstrap_db(path: Path) -> None:
@@ -101,7 +102,7 @@ class _AsyncSqliteAdapter:
         conn.row_factory = sqlite3.Row
         self._conn = conn
 
-    async def execute(self, sql: str, params: tuple = ()) -> _AsyncCursorAdapter:
+    async def execute(self, sql: str, params: tuple[object, ...] = ()) -> _AsyncCursorAdapter:
         cursor = self._conn.execute(sql, params)
         return _AsyncCursorAdapter(cursor)
 
@@ -117,7 +118,8 @@ class _AsyncCursorAdapter:
         return list(self._cursor.fetchall())
 
     async def fetchone(self) -> sqlite3.Row | None:
-        return self._cursor.fetchone()
+        result: sqlite3.Row | None = self._cursor.fetchone()
+        return result
 
     @property
     def rowcount(self) -> int:
@@ -149,7 +151,7 @@ def _seed_edge(
     import asyncio
 
     edge = TopologyEdgeRecord(
-        src_conversation_id=src_conversation_id,
+        src_conversation_id=ConversationId(src_conversation_id),
         dst_provider_native_id=dst_provider_native_id,
         dst_provider_name=dst_provider_name,
         edge_type=edge_type,

--- a/tests/unit/storage/test_dead_schema_sweep.py
+++ b/tests/unit/storage/test_dead_schema_sweep.py
@@ -42,13 +42,15 @@ def fresh_schema_db() -> Generator[Mapping[str, sqlite3.Connection], None, None]
 # ---------------------------------------------------------------------------
 
 
-def test_schema_version_is_6() -> None:
+def test_schema_version_is_7() -> None:
     # Bumped from 3 → 4 by #1241 (action_events_fts external-content),
     # then 4 → 5 by #1252 (first-class attachment native identifiers
     # + upload_origin column for the #1199 attachment library), then
     # 5 → 6 by #1258 (topology_edges table — persisted parent edges
-    # including unresolved references for out-of-order ingest).
-    assert SCHEMA_VERSION == 6
+    # including unresolved references for out-of-order ingest), then
+    # 6 → 7 by #1260 (topology_edges.status gains the 'quarantined'
+    # value for the cycle-rejection slice).
+    assert SCHEMA_VERSION == 7
 
 
 def test_content_blocks_table_has_no_media_type_column(fresh_schema_db: Mapping[str, sqlite3.Connection]) -> None:


### PR DESCRIPTION
## Summary

When resolving a topology edge would create a cycle in the
`conversations.parent_conversation_id` fast-path graph, the resolver
now refuses to backfill the cycle-creating edge. The offending edge is
left in `topology_edges` with `status='quarantined'` and a structured
`raw_evidence` JSON document recording the detected cycle path so the
operator can audit what was rejected. Surfaces the quarantine state in
the daemon workload probe.

Closes #1260. Ref #866 (slice C).

## Problem

#1258 (slice A) made `topology_edges` durable for unresolved parent
references; #1259 (slice B) added the late-parent repair that, on
parent arrival, flips `unresolved` edges to `resolved` and backfills
the child's `parent_conversation_id`. Neither slice protected against
the case where the parent backfill would close a cycle (A → B → A,
longer cycles, self-cycle A → A). Without rejection, the fast-path
ancestry walk used by `derive_session_topology_async`,
`thread_root_id` and other downstream readers could enter an infinite
loop (or terminate only via the existing cycle-safe guards, but with
nonsensical lineage). The #866 / #1260 acceptance criteria require
explicit rejection with structured evidence — no silent drop.

## Solution

- `polylogue/archive/topology/edge.py` — `TopologyEdgeStatus` gains a
  `QUARANTINED` value.
- `polylogue/storage/sqlite/schema_ddl_archive.py` — `topology_edges`
  CHECK constraint extended to allow `quarantined`. `SCHEMA_VERSION` is
  bumped 6 → 7 (no migration chain; per the existing policy, mismatch
  triggers re-ingest from source).
- `polylogue/storage/sqlite/queries/topology_edges.py` — both resolver
  entry points (`resolve_topology_edges_for_conversation` and
  `resolve_unresolved_edges_for_child`) now invoke
  `_would_create_cycle` before any UPDATE. The helper walks the
  proposed parent's existing ancestry via `parent_conversation_id`,
  detects self-cycle and budget-exceeded as cycles, and returns the
  full path so the rejection record is auditable. On cycle:
  `_quarantine_edge` writes `status='quarantined'` plus a JSON
  `{reason, cycle_path, detected_at}` to `raw_evidence`; the
  conversations row is NOT touched. A new helper
  `count_quarantined_topology_edges` is exported for diagnostics.
- `devtools/daemon_workload_probe.py` — adds
  `topology_quarantine_state` (unresolved/resolved/quarantined counts
  + oldest quarantined timestamp) and pulls `topology_edges` into the
  boundary table set. `REPORT_VERSION` bumped 2 → 3.
- `tests/unit/insights/test_topology_cycle_rejection.py` — new
  evidence-bearing tests covering 2-node, 3-node, and self-cycle
  rejection through both resolver entry points; the diamond-DAG
  no-false-positive case (B→D, C→D both legit); the sibling-isolation
  case (cycle on one child must not quarantine a clean sibling sharing
  the parent batch); two idempotency assertions; and the
  `count_quarantined_topology_edges` diagnostic.
- `tests/unit/storage/test_dead_schema_sweep.py` — pin updated for
  SCHEMA_VERSION 7.

### Re-ingest plan

This PR bumps `SCHEMA_VERSION` 6 → 7 by widening the
`topology_edges.status` CHECK to include `quarantined`. Per the
existing schema policy (docs/internals.md § Schema Versioning Model):

- Operator action: `polylogue reset --database && polylogued run`
  re-acquires from source.
- Auto-rebuilt downstream: derived insights and FTS rebuild as part of
  the normal convergence pass; the blob store is unaffected.
- Expected impact: re-ingest time on the order of a normal full
  catch-up; no extra disk usage.

No existing data needs format conversion — the change is purely an
expansion of the allowed status vocabulary.

## Verification

- `nix develop -c pytest tests/unit/insights/test_topology_cycle_rejection.py -x` — 9 passed
- `nix develop -c pytest tests/unit/insights/ tests/unit/storage/test_topology_edges.py -x` — 151 passed (no regressions on the existing slice A/B suite)
- `nix develop -c devtools verify --quick` — exit_code 0 (lint, format, mypy, render-all, manifest gates, verify-test-clock-hygiene)

Two pre-existing failures observed in broader runs (`cli() got an
unexpected keyword argument 'cursor'` in CLI tests, and the
SimpleNamespace `topology_edges` attribute error in
`test_prepare_runtime`) are present on master and unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)