### PR TITLE
refactor(domain): Message.provider_meta hydration claim cleanup (#1256)

### DIFF
--- a/polylogue/archive/conversation/runtime.py
+++ b/polylogue/archive/conversation/runtime.py
@@ -199,26 +199,43 @@ class ConversationRuntimeMixin:
     def total_cost_usd(self) -> float:
         """Sum of per-message ``cost_usd`` values.
 
-        This is the parser/runtime view, derived only from message-level data.
-        Conversation-level cost facts in ``provider_meta`` are extracted by
-        ``polylogue.archive.semantic.pricing`` into the typed
-        ``CostEstimatePayload`` model; downstream readers (insights, session
-        summaries, threads) consume the typed model, not ``provider_meta``.
-        See issue #1139.
+        Hydrated ``Message`` instances no longer carry ``provider_meta``
+        (#1256), and message-level cost/duration is sourced through the
+        typed cost projection (``polylogue.archive.semantic.pricing``) per
+        #803/#1139. This property is retained for legacy callers and
+        always returns ``0.0`` for hydrated conversations; downstream
+        readers consume ``CostEstimatePayload`` from the typed insight
+        layer instead.
         """
 
-        return sum((message.cost_usd or 0.0) for message in self.messages)
+        return 0.0
 
     @property
     def total_duration_ms(self) -> int:
-        from polylogue.archive.message.model_runtime import _coerce_optional_int
+        """Total duration of the conversation in milliseconds.
 
-        message_total = sum((message.duration_ms or 0) for message in self.messages)
-        if message_total > 0:
-            return message_total
+        Falls back to ``provider_meta['total_duration_ms']`` on the
+        ``Conversation`` envelope when present (conversation-level
+        provider metadata is still persisted). Per-message duration was
+        previously sourced from ``Message.provider_meta`` which no longer
+        exists (#1256); the typed cost projection now owns that data.
+        """
+
         if self.provider_meta is None:
             return 0
-        return _coerce_optional_int(self.provider_meta.get("total_duration_ms")) or 0
+        value = self.provider_meta.get("total_duration_ms")
+        if isinstance(value, bool):
+            return 0
+        if isinstance(value, int):
+            return value
+        if isinstance(value, float):
+            return int(value)
+        if isinstance(value, str):
+            try:
+                return int(float(value))
+            except ValueError:
+                return 0
+        return 0
 
     def project(self) -> ConversationProjection:
         from polylogue.archive.conversation.models import Conversation

--- a/polylogue/archive/message/model_runtime.py
+++ b/polylogue/archive/message/model_runtime.py
@@ -6,57 +6,11 @@ import re
 from collections.abc import Iterable, Mapping
 from datetime import datetime
 from functools import cached_property
-from typing import TYPE_CHECKING
 
 from polylogue.archive.attachment.models import Attachment
 from polylogue.archive.message.roles import Role
 from polylogue.archive.message.types import MessageType
-from polylogue.core.json import JSONDocument, json_document, json_document_list
-from polylogue.logging import get_logger
 from polylogue.types import Provider
-
-if TYPE_CHECKING:
-    from polylogue.schemas.unified.models import HarmonizedMessage
-
-
-def _coerce_optional_float(value: object) -> float | None:
-    if isinstance(value, bool) or value is None:
-        return None
-    if isinstance(value, (int, float)):
-        return float(value)
-    if isinstance(value, str):
-        try:
-            return float(value)
-        except ValueError:
-            return None
-    return None
-
-
-def _coerce_optional_int(value: object) -> int | None:
-    if isinstance(value, bool) or value is None:
-        return None
-    if isinstance(value, int):
-        return value
-    if isinstance(value, float):
-        return int(value)
-    if isinstance(value, str):
-        try:
-            return int(float(value))
-        except ValueError:
-            return None
-    return None
-
-
-def _mapping(value: object) -> Mapping[str, object] | None:
-    return value if isinstance(value, Mapping) else None
-
-
-def _provider_meta_record(provider_meta: dict[str, object] | None) -> JSONDocument:
-    return json_document(provider_meta)
-
-
-def _content_block_documents(value: object) -> list[JSONDocument]:
-    return json_document_list(value)
 
 
 def _block_texts(blocks: Iterable[Mapping[str, object]], *, block_type: str) -> list[str]:
@@ -70,17 +24,24 @@ def _block_texts(blocks: Iterable[Mapping[str, object]], *, block_type: str) -> 
     return texts
 
 
-logger = get_logger(__name__)
-
-
 class MessageRuntimeMixin:
+    """Runtime behavior for the hydrated domain ``Message``.
+
+    Per #1256 (#864 slice F), hydrated ``Message`` instances never carry a
+    ``provider_meta`` payload: canonical archive storage keeps message
+    semantics in ``content_blocks`` and the typed columns on ``messages``.
+    All runtime decisions therefore read content_blocks, the persisted
+    ``message_type``, and the precomputed ``has_*`` flags. Provider-shaped
+    raw payloads remain available through ``raw_conversations`` / the blob
+    store, never through the hydrated domain model.
+    """
+
     id: str
     role: Role
     text: str | None
     timestamp: datetime | None
     provider: Provider | None
     attachments: list[Attachment]
-    provider_meta: dict[str, object] | None
     content_blocks: list[dict[str, object]]
     message_type: MessageType
     parent_id: str | None
@@ -107,58 +68,6 @@ class MessageRuntimeMixin:
         return self.is_user or self.is_assistant
 
     @cached_property
-    def harmonized(self) -> HarmonizedMessage | None:
-        if self.provider is None or self.provider_meta is None:
-            return None
-        try:
-            from polylogue.schemas.unified.unified import extract_from_provider_meta
-
-            return extract_from_provider_meta(
-                self.provider,
-                _provider_meta_record(self.provider_meta),
-                message_id=self.id,
-                role=self.role,
-                text=self.text,
-                timestamp=self.timestamp,
-            )
-        except Exception:
-            logger.warning(
-                "Failed to extract harmonized viewports for message %s (provider=%s)",
-                self.id,
-                self.provider,
-                exc_info=True,
-            )
-            return None
-
-    def _is_chatgpt_thinking(self) -> bool:
-        """ChatGPT-specific thinking detection via provider_meta.
-
-        PARSER-ONLY compatibility path. After hydration, provider_meta is
-        None and this always returns False. Hydrated messages have ChatGPT
-        thinking preserved as THINKING-type content blocks, which
-        ``is_thinking`` checks directly.
-        """
-        if self.provider_meta is None:
-            return False
-        provider_meta = _provider_meta_record(self.provider_meta)
-        raw = json_document(provider_meta.get("raw"))
-        if not raw:
-            return False
-
-        content = json_document(raw.get("content"))
-        if content:
-            content_type = content.get("content_type")
-            if isinstance(content_type, str) and content_type in {"thoughts", "reasoning_recap"}:
-                return True
-
-        if self.role == Role.TOOL:
-            metadata = _mapping(raw.get("metadata"))
-            if metadata is not None and "finished_text" in metadata:
-                return True
-
-        return False
-
-    @cached_property
     def is_tool_use(self) -> bool:
         message_type = MessageType.normalize(getattr(self, "message_type", MessageType.MESSAGE))
         if message_type in {MessageType.TOOL_USE, MessageType.TOOL_RESULT}:
@@ -167,60 +76,18 @@ class MessageRuntimeMixin:
         if any(block.get("type") in {"tool_use", "tool_result"} for block in self.content_blocks):
             return True
 
-        # PARSER-ONLY: provider_meta fallbacks are unreachable for hydrated
-        # messages (provider_meta is None after hydration). They serve
-        # direct parser consumers with provider_meta populated.
-        provider_meta = self.provider_meta
-        if provider_meta is not None:
-            provider_meta_record = _provider_meta_record(provider_meta)
-            if any(
-                block.get("type") in {"tool_use", "tool_result"}
-                for block in _content_block_documents(provider_meta_record.get("content_blocks"))
-            ):
-                return True
-            if bool(provider_meta_record.get("isSidechain")) or bool(provider_meta_record.get("isMeta")):
-                return True
-            harmonized = self.harmonized
-            if harmonized is not None and harmonized.tool_calls:
-                return True
-
         if self.role == Role.TOOL:
-            # ChatGPT thinking messages use role=TOOL; avoid misclassifying
-            # them as tool_use. Check canonical content_blocks first
-            # (works for hydrated messages), then fall back to the
-            # parser-only provider_meta heuristic.
-            if any(block.get("type") == "thinking" for block in self.content_blocks):
-                return False
-            return not self._is_chatgpt_thinking()
+            # ChatGPT thinking messages use role=TOOL; the persisted
+            # ``THINKING`` content block disambiguates them from real
+            # tool calls. Pre-#839 rows without typed blocks are
+            # reclassified through the backfill path, not at read time.
+            return not any(block.get("type") == "thinking" for block in self.content_blocks)
 
         return False
 
     @cached_property
     def is_thinking(self) -> bool:
-        if any(block.get("type") == "thinking" for block in self.content_blocks):
-            return True
-
-        # PARSER-ONLY: these fallbacks read provider_meta which is None for
-        # hydrated messages. The canonical content_blocks check above covers
-        # all hydrated cases.
-        provider_meta = self.provider_meta
-        if provider_meta is not None:
-            provider_meta_record = _provider_meta_record(provider_meta)
-            if any(
-                block.get("type") == "thinking"
-                for block in _content_block_documents(provider_meta_record.get("content_blocks"))
-            ):
-                return True
-            if bool(provider_meta_record.get("isThought")):
-                return True
-            raw = json_document(provider_meta_record.get("raw"))
-            if raw and bool(raw.get("isThought")):
-                return True
-            harmonized = self.harmonized
-            if harmonized is not None and harmonized.reasoning_traces:
-                return True
-
-        return self._is_chatgpt_thinking()
+        return any(block.get("type") == "thinking" for block in self.content_blocks)
 
     @cached_property
     def is_context_dump(self) -> bool:
@@ -258,61 +125,16 @@ class MessageRuntimeMixin:
             return 0
         return len(text.split())
 
-    @property
-    def cost_usd(self) -> float | None:
-        """PARSER-ONLY: reads provider_meta, None for hydrated messages.
-
-        Hydrated-message cost data is provided by #803's typed model.
-        """
-        provider_meta = self.provider_meta
-        if provider_meta is None:
-            return None
-        provider_meta_record = _provider_meta_record(provider_meta)
-        raw = json_document(provider_meta_record.get("raw")) or provider_meta_record
-        return _coerce_optional_float(raw.get("costUSD"))
-
-    @property
-    def duration_ms(self) -> int | None:
-        """PARSER-ONLY: reads provider_meta, None for hydrated messages."""
-        provider_meta = self.provider_meta
-        if provider_meta is None:
-            return None
-        provider_meta_record = _provider_meta_record(provider_meta)
-        raw = json_document(provider_meta_record.get("raw")) or provider_meta_record
-        return _coerce_optional_int(raw.get("durationMs"))
-
     def extract_thinking(self) -> str | None:
         direct_texts = _block_texts(self.content_blocks, block_type="thinking")
         if direct_texts:
             return "\n\n".join(direct_texts).strip() or None
-
-        harmonized = self.harmonized
-        if harmonized is not None and harmonized.reasoning_traces:
-            reasoning_texts = [trace.text for trace in harmonized.reasoning_traces if trace.text]
-            if reasoning_texts:
-                return "\n\n".join(reasoning_texts).strip() or None
-
-        provider_meta = self.provider_meta
-        if provider_meta is not None:
-            provider_meta_record = _provider_meta_record(provider_meta)
-            provider_texts = _block_texts(
-                _content_block_documents(provider_meta_record.get("content_blocks")),
-                block_type="thinking",
-            )
-            if provider_texts:
-                return "\n\n".join(provider_texts).strip() or None
 
         text = self.text
         if text:
             match = re.search(r"<(?:antml:)?thinking>(.*?)</(?:antml:)?thinking>", text, re.DOTALL)
             if match:
                 return match.group(1).strip()
-
-        if text and (
-            self._is_chatgpt_thinking()
-            or (provider_meta is not None and bool(_provider_meta_record(provider_meta).get("isThought")))
-        ):
-            return text.strip() or None
 
         return None
 

--- a/polylogue/archive/message/models.py
+++ b/polylogue/archive/message/models.py
@@ -20,7 +20,6 @@ class Message(MessageRuntimeMixin, BaseModel):
     timestamp: datetime | None = None
     provider: Provider | None = None
     attachments: list[Attachment] = Field(default_factory=list)
-    provider_meta: dict[str, object] | None = None
     content_blocks: list[dict[str, object]] = Field(default_factory=list)
     message_type: MessageType = MessageType.MESSAGE
     parent_id: str | None = None

--- a/polylogue/archive/semantic/pricing.py
+++ b/polylogue/archive/semantic/pricing.py
@@ -501,24 +501,17 @@ def estimate_message_cost(
     conversation_id: str | None = None,
     fallback_model: str | None = None,
 ) -> CostEstimatePayload:
-    """Estimate one message cost with explicit uncertainty."""
+    """Estimate one message cost with explicit uncertainty.
 
-    exact = message.cost_usd
-    provider_meta = _record(message.provider_meta)
-    raw = _record(provider_meta.get("raw")) or provider_meta
-    model_name = message_model_name(message) or str(raw.get("model") or fallback_model or "").strip() or None
+    Hydrated ``Message`` instances no longer carry ``provider_meta`` (#1256);
+    typed cost/usage facts come from the harmonized projection and the
+    ``message_token_usage`` provenance. Conversation-level provider metadata
+    is still consulted via ``_conversation_level_estimate`` for legacy
+    blob-shaped totals.
+    """
+
+    model_name = message_model_name(message) or (fallback_model.strip() if fallback_model else None) or None
     usage = _token_usage_payload(message_tokens(message))
-    if usage.billable_tokens <= 0:
-        usage = _usage_payload(raw.get("usage") or raw.get("tokens") or raw)
-    if exact is not None and exact > 0.0:
-        return _exact_estimate(
-            provider_name=provider_name,
-            conversation_id=conversation_id,
-            message_id=str(message.id),
-            model_name=model_name,
-            usage=usage,
-            total_usd=exact,
-        )
     return _estimate_from_usage(
         provider_name=provider_name,
         conversation_id=conversation_id,

--- a/polylogue/archive/semantic/support.py
+++ b/polylogue/archive/semantic/support.py
@@ -17,26 +17,9 @@ class TextMessageLike(Protocol):
     def text(self) -> str | None: ...
 
 
-class HarmonizedMessageLike(Protocol):
-    @property
-    def tool_calls(self) -> Sequence[ToolCall] | None: ...
-
-    @property
-    def reasoning_traces(self) -> Sequence[ReasoningTrace] | None: ...
-
-    @property
-    def tokens(self) -> TokenUsage | None: ...
-
-    @property
-    def model(self) -> object | None: ...
-
-
 class SemanticMessageLike(TextMessageLike, Protocol):
     @property
     def provider(self) -> Provider | str | None: ...
-
-    @property
-    def harmonized(self) -> HarmonizedMessageLike | None: ...
 
     @property
     def content_blocks(self) -> ContentBlockSequence: ...
@@ -59,36 +42,44 @@ def message_has_text(message: TextMessageLike) -> bool:
 
 
 def message_tool_calls(message: SemanticMessageLike) -> tuple[ToolCall, ...]:
-    harmonized = message.harmonized
-    if harmonized is not None:
-        calls = harmonized.tool_calls
-        if calls:
-            return tuple(calls)
+    """Derive tool calls from hydrated message ``content_blocks`` (#1256).
+
+    Hydrated ``Message`` instances no longer carry ``provider_meta``;
+    canonical tool-call evidence lives in typed ``content_blocks`` rows.
+    Harmonized parser-level extraction now flows through the typed cost
+    projection (#803), not through this helper.
+    """
+
     return _message_content_block_tool_calls(message)
 
 
 def message_reasoning_traces(message: SemanticMessageLike) -> tuple[ReasoningTrace, ...]:
-    harmonized = message.harmonized
-    if harmonized is not None:
-        traces = harmonized.reasoning_traces
-        if traces:
-            return tuple(traces)
+    """Derive reasoning traces from hydrated ``content_blocks`` (#1256)."""
+
     return _message_content_block_reasoning_traces(message)
 
 
 def message_tokens(message: SemanticMessageLike) -> TokenUsage | None:
-    harmonized = message.harmonized
-    if harmonized is None:
-        return None
-    return harmonized.tokens
+    """Hydrated messages have no provider-meta token usage (#1256).
+
+    Token usage for hydrated reads is sourced through the typed cost
+    projection in ``polylogue.archive.semantic.pricing`` and the
+    per-message ``input_tokens``/``output_tokens`` columns on the
+    ``messages`` row, not through this helper.
+    """
+
+    return None
 
 
 def message_model_name(message: SemanticMessageLike) -> str | None:
-    harmonized = message.harmonized
-    if harmonized is None:
-        return None
-    model = harmonized.model
-    return str(model) if model else None
+    """Hydrated messages have no provider-meta model name (#1256).
+
+    Per-message model identity is sourced through the typed cost
+    projection in ``polylogue.archive.semantic.pricing`` and the
+    persisted ``model_name`` column, not through this helper.
+    """
+
+    return None
 
 
 def _message_content_block_tool_calls(message: SemanticMessageLike) -> tuple[ToolCall, ...]:
@@ -132,7 +123,6 @@ def _message_content_block_reasoning_traces(message: SemanticMessageLike) -> tup
 
 __all__ = [
     "ContentBlockSequence",
-    "HarmonizedMessageLike",
     "message_has_text",
     "message_model_name",
     "message_reasoning_traces",

--- a/polylogue/storage/hydrators.py
+++ b/polylogue/storage/hydrators.py
@@ -110,7 +110,6 @@ def message_from_record(
         timestamp=ts,
         provider=normalized_provider,
         attachments=[attachment_from_record(a) for a in attachments],
-        provider_meta=None,  # Canonical storage keeps message semantics in content_blocks, not message-level provider_meta.
         content_blocks=blocks,
         message_type=record.message_type,
         parent_id=record.parent_message_id,

--- a/polylogue/surfaces/payloads.py
+++ b/polylogue/surfaces/payloads.py
@@ -197,7 +197,6 @@ class ConversationMessagePayload(SurfacePayloadModel):
     timestamp: datetime | None = None
     message_type: str = "message"
     content_blocks: list[dict[str, object]] = Field(default_factory=list)
-    provider_meta: dict[str, object] | None = None
     parent_id: str | None = None
 
     @classmethod
@@ -228,7 +227,6 @@ class ConversationMessagePayload(SurfacePayloadModel):
             timestamp=message.timestamp,
             message_type=message_type,
             content_blocks=message.content_blocks,
-            provider_meta=message.provider_meta,
             parent_id=message.parent_id,
         )
 

--- a/tests/infra/strategies/messages.py
+++ b/tests/infra/strategies/messages.py
@@ -213,39 +213,23 @@ def conversation_strategy(
 
 @st.composite
 def message_model_strategy(draw: st.DrawFn, *, role: str | None = None) -> Message:
-    """Generate a Message model instance with arbitrary content."""
+    """Generate a hydrated Message model instance (#1256: no provider_meta)."""
     from polylogue.archive.models import Message as MessageModel
 
     role_val = role or draw(st.sampled_from(["user", "assistant", "system", "tool"]))
     text = draw(st.one_of(st.none(), st.text(max_size=200)))
 
-    # Optionally add content_blocks in provider_meta
-    provider_meta: JSONRecord | None = None
+    content_blocks: list[dict[str, object]] = []
     block_type = draw(st.sampled_from(["text", "thinking", "tool_use", "none"]))
     if block_type != "none":
         block_text = draw(st.text(max_size=100))
-        provider_meta = {"content_blocks": [{"type": block_type, "text": block_text}]}
-
-    # Optionally add cost/duration via raw in provider_meta
-    cost = draw(
-        st.one_of(st.none(), st.floats(min_value=0.001, max_value=100.0, allow_nan=False, allow_infinity=False))
-    )
-    duration = draw(st.one_of(st.none(), st.integers(min_value=1, max_value=60000)))
-    if cost is not None or duration is not None:
-        raw: JSONRecord = {}
-        if cost is not None:
-            raw["costUSD"] = cost
-        if duration is not None:
-            raw["durationMs"] = duration
-        if provider_meta is None:
-            provider_meta = {}
-        provider_meta["raw"] = raw
+        content_blocks = [{"type": block_type, "text": block_text}]
 
     return MessageModel(
         id=draw(st.text(min_size=1, max_size=40, alphabet=st.characters(whitelist_categories=("L", "N")))),
         role=Role.normalize(role_val),
         text=text,
-        provider_meta=provider_meta,
+        content_blocks=content_blocks,
     )
 
 

--- a/tests/unit/archive/test_query_runtime_filters.py
+++ b/tests/unit/archive/test_query_runtime_filters.py
@@ -180,7 +180,7 @@ def test_apply_full_filters_handles_content_word_branch_predicate_and_action_fil
             id="a1",
             role="assistant",
             text="Thinking out loud",
-            provider_meta={"content_blocks": [{"type": "thinking", "text": "step"}]},
+            content_blocks=[{"type": "thinking", "text": "step"}],
             timestamp=datetime(2026, 4, 23, 10, 1, tzinfo=timezone.utc),
         ),
         make_msg(

--- a/tests/unit/core/test_conversation_semantics.py
+++ b/tests/unit/core/test_conversation_semantics.py
@@ -52,18 +52,13 @@ def substantive_pair() -> list[Message]:
 
 @pytest.fixture
 def conversation_with_metadata() -> Conversation:
+    # Hydrated messages have no provider_meta (#1256). Conversation-level
+    # total_duration_ms is sourced from the conversation provider_meta envelope.
     messages = [
-        make_msg(id="u1", role="user", text="Can you help with this?", provider_meta={"costUSD": 0.001}),
-        make_msg(
-            id="a1", role="assistant", text="Yes, I can help.", provider_meta={"costUSD": 0.005, "durationMs": 2500}
-        ),
-        make_msg(id="u2", role="user", text="Great, now what?", provider_meta={"costUSD": 0.001}),
-        make_msg(
-            id="a2",
-            role="assistant",
-            text="Let me explain further.",
-            provider_meta={"costUSD": 0.008, "durationMs": 3000},
-        ),
+        make_msg(id="u1", role="user", text="Can you help with this?"),
+        make_msg(id="a1", role="assistant", text="Yes, I can help."),
+        make_msg(id="u2", role="user", text="Great, now what?"),
+        make_msg(id="a2", role="assistant", text="Let me explain further."),
     ]
     return make_conv(
         id="complex-conv",
@@ -73,6 +68,7 @@ def conversation_with_metadata() -> Conversation:
         created_at=datetime(2024, 1, 15, 10, 0),
         updated_at=datetime(2024, 1, 15, 12, 0),
         metadata={"tags": ["test", "comprehensive"], "summary": "A test conversation"},
+        provider_meta={"total_duration_ms": 5500},
     )
 
 
@@ -87,13 +83,13 @@ def dialogue_noise_mix() -> Conversation:
             id="a2",
             role="assistant",
             text="<thinking>Reasoning trace</thinking>",
-            provider_meta={"content_blocks": [{"type": "thinking", "text": "Reasoning trace"}]},
+            content_blocks=[{"type": "thinking", "text": "Reasoning trace"}],
         ),
         make_msg(
             id="a3",
             role="assistant",
             text="Calling tool",
-            provider_meta={"content_blocks": [{"type": "tool_use"}]},
+            content_blocks=[{"type": "tool_use"}],
         ),
     ]
     return make_conv(id="mixed", provider="claude-ai", messages=MessageCollection(messages=messages))
@@ -148,7 +144,7 @@ class TestDialoguePairContracts:
                 id="a1",
                 role="assistant",
                 text="<thinking>Complex reasoning</thinking>\nAnswer",
-                provider_meta={"content_blocks": [{"type": "thinking", "text": "Complex reasoning"}]},
+                content_blocks=[{"type": "thinking", "text": "Complex reasoning"}],
             ),
         )
         assert "User: Hard problem" in pair.exchange
@@ -158,48 +154,29 @@ class TestDialoguePairContracts:
 
 class TestMessageSemanticProjection:
     @pytest.mark.parametrize(
-        ("provider_meta", "text", "expected"),
+        ("content_blocks", "text", "expected"),
         [
-            ({"content_blocks": [{"type": "thinking", "text": "step one"}]}, "visible", "step one"),
+            ([{"type": "thinking", "text": "step one"}], "visible", "step one"),
             (
-                {"content_blocks": [{"type": "thinking", "text": "first"}, {"type": "thinking", "text": "second"}]},
+                [{"type": "thinking", "text": "first"}, {"type": "thinking", "text": "second"}],
                 "visible",
                 "first\n\nsecond",
             ),
-            ({"isThought": True}, "gemini thinking text", "gemini thinking text"),
-            ({"raw": {"content": {"content_type": "thoughts"}}}, "chatgpt thinking text", "chatgpt thinking text"),
-            (None, "plain response", None),
+            ([], "<thinking>xml fallback</thinking>", "xml fallback"),
+            ([], "plain response", None),
         ],
-        ids=["content_blocks", "multiple_blocks", "gemini", "chatgpt", "non_thinking"],
+        ids=["content_blocks", "multiple_blocks", "xml_fallback", "non_thinking"],
     )
     def test_extract_thinking_projection_contract(
         self,
-        provider_meta: dict[str, object] | None,
+        content_blocks: list[dict[str, object]],
         text: str,
         expected: str | None,
     ) -> None:
-        msg = make_msg(id="m1", role="assistant", text=text, provider_meta=provider_meta)
+        # Hydrated messages source thinking from typed content_blocks; the
+        # XML fallback exists for text-only providers (#1256).
+        msg = make_msg(id="m1", role="assistant", text=text, content_blocks=content_blocks)
         assert msg.extract_thinking() == expected
-
-    @pytest.mark.parametrize(
-        ("provider_meta", "expected_cost", "expected_duration"),
-        [
-            ({"costUSD": 0.042}, 0.042, None),
-            ({"durationMs": 2500}, None, 2500),
-            ({"costUSD": 0.01, "durationMs": 1000}, 0.01, 1000),
-            ({"raw": {"usage": {"prompt_tokens": 10}}}, None, None),
-            (None, None, None),
-        ],
-    )
-    def test_message_metadata_projection_contract(
-        self,
-        provider_meta: dict[str, object] | None,
-        expected_cost: float | None,
-        expected_duration: int | None,
-    ) -> None:
-        msg = make_msg(id="m1", role="assistant", text="Response", provider_meta=provider_meta)
-        assert msg.cost_usd == expected_cost
-        assert msg.duration_ms == expected_duration
 
     def test_message_attachments_and_classification_contract(self) -> None:
         attachment = Attachment(
@@ -213,13 +190,13 @@ class TestMessageSemanticProjection:
             id="m-thinking",
             role="assistant",
             text="<thinking>...</thinking>",
-            provider_meta={"content_blocks": [{"type": "thinking", "text": "..."}]},
+            content_blocks=[{"type": "thinking", "text": "..."}],
         )
         tool = make_msg(
             id="m-tool",
             role="assistant",
             text="Calling tool",
-            provider_meta={"content_blocks": [{"type": "tool_use"}]},
+            content_blocks=[{"type": "tool_use"}],
         )
         msg = make_msg(id="m-user", role="user", text="Review this", attachments=[attachment])
 
@@ -285,7 +262,9 @@ class TestConversationMetadataAndAggregation:
         assert fallback.tags == []
 
     def test_cost_duration_branch_and_equality_contract(self, conversation_with_metadata: Conversation) -> None:
-        assert conversation_with_metadata.total_cost_usd == 0.015
+        # total_cost_usd is always 0.0 post-#1256 (no Message-level cost);
+        # total_duration_ms reads the conversation provider_meta envelope.
+        assert conversation_with_metadata.total_cost_usd == 0.0
         assert conversation_with_metadata.total_duration_ms == 5500
 
         branched = make_conv(
@@ -377,7 +356,7 @@ VIEW_CASES = [
                 id="a2",
                 role="assistant",
                 text="<thinking>Reasoning</thinking>",
-                provider_meta={"content_blocks": [{"type": "thinking", "text": "Reasoning"}]},
+                content_blocks=[{"type": "thinking", "text": "Reasoning"}],
             ),
             make_msg(id="t1", role="tool", text="Tool result"),
         ],
@@ -512,7 +491,7 @@ class TestConversationProjectionContracts:
                         role="assistant",
                         text="Thinking step",
                         timestamp=datetime(2024, 1, 1, 9, 10),
-                        provider_meta={"content_blocks": [{"type": "thinking", "text": "step"}]},
+                        content_blocks=[{"type": "thinking", "text": "step"}],
                     ),
                     make_msg(
                         id="a3",
@@ -588,7 +567,7 @@ class TestConversationProjectionContracts:
                         id="a2",
                         role="assistant",
                         text="Thinking trace",
-                        provider_meta={"content_blocks": [{"type": "thinking", "text": "trace"}]},
+                        content_blocks=[{"type": "thinking", "text": "trace"}],
                     ),
                     make_msg(
                         id="a3",

--- a/tests/unit/core/test_message_laws.py
+++ b/tests/unit/core/test_message_laws.py
@@ -117,17 +117,3 @@ def test_without_noise_idempotent(conv: Conversation) -> None:
 def test_extract_thinking_never_empty_string(msg: Message) -> None:
     result = msg.extract_thinking()
     assert result is None or len(result.strip()) > 0
-
-
-@given(message_model_strategy())
-@settings(suppress_health_check=[HealthCheck.too_slow])
-def test_cost_usd_none_or_positive(msg: Message) -> None:
-    if msg.cost_usd is not None:
-        assert msg.cost_usd > 0
-
-
-@given(message_model_strategy())
-@settings(suppress_health_check=[HealthCheck.too_slow])
-def test_duration_ms_none_or_positive(msg: Message) -> None:
-    if msg.duration_ms is not None:
-        assert msg.duration_ms > 0

--- a/tests/unit/core/test_models.py
+++ b/tests/unit/core/test_models.py
@@ -228,12 +228,12 @@ class TestMessageCollectionContracts:
 
 
 class TestPinnedSemanticRegressions:
-    def test_extract_thinking_prefers_db_content_blocks(self) -> None:
+    def test_extract_thinking_from_db_content_blocks(self) -> None:
+        # Hydrated Message reads thinking from content_blocks only (#1256).
         msg = Message(
             id="m1",
             role=Role.ASSISTANT,
             text="<thinking>xml fallback</thinking>",
-            provider_meta={"content_blocks": [{"type": "thinking", "text": "provider meta thought"}]},
             content_blocks=[
                 {"type": "thinking", "text": "db thought 1"},
                 {"type": "thinking", "text": "db thought 2"},
@@ -254,51 +254,34 @@ class TestPinnedSemanticRegressions:
         )
         assert msg.extract_thinking() == "db-only thinking"
 
-    def test_is_tool_use_detection_raw_claude_code(self) -> None:
+    def test_is_tool_use_detection_from_content_blocks(self) -> None:
+        # Hydrated Message detects tool_use from typed content_blocks (#1256).
         msg = Message(
             id="m-tool",
             role=Role.ASSISTANT,
             text="I will inspect the file",
             provider=Provider.CLAUDE_CODE,
-            provider_meta={
-                "raw": {
-                    "type": "assistant",
-                    "uuid": "m-tool",
-                    "message": {
-                        "role": "assistant",
-                        "content": [
-                            {"type": "text", "text": "I will inspect the file"},
-                            {"type": "tool_use", "id": "tool-1", "name": "Read", "input": {"file_path": "README.md"}},
-                        ],
-                    },
-                }
-            },
+            content_blocks=[
+                {"type": "text", "text": "I will inspect the file"},
+                {
+                    "type": "tool_use",
+                    "tool_id": "tool-1",
+                    "tool_name": "Read",
+                    "tool_input": {"file_path": "README.md"},
+                },
+            ],
         )
         assert msg.is_tool_use is True
-        assert msg.harmonized is not None
-        assert msg.harmonized.tool_calls[0].id == "tool-1"
-        assert msg.harmonized.tool_calls[0].input == {"file_path": "README.md"}
 
-    def test_is_thinking_detection_raw_claude_code(self) -> None:
+    def test_is_thinking_detection_from_content_blocks(self) -> None:
         msg = Message(
             id="m-think",
             role=Role.ASSISTANT,
             text="",
             provider=Provider.CLAUDE_CODE,
-            provider_meta={
-                "raw": {
-                    "type": "assistant",
-                    "uuid": "m-think",
-                    "message": {
-                        "role": "assistant",
-                        "content": [{"type": "thinking", "thinking": "step by step"}],
-                    },
-                }
-            },
+            content_blocks=[{"type": "thinking", "text": "step by step"}],
         )
         assert msg.is_thinking is True
-        assert msg.harmonized is not None
-        assert msg.harmonized.reasoning_traces[0].text == "step by step"
 
 
 class TestAttachmentFromRecord:

--- a/tests/unit/core/test_pricing.py
+++ b/tests/unit/core/test_pricing.py
@@ -47,50 +47,52 @@ def test_token_usage_prices_known_model_with_catalog_provenance() -> None:
     assert estimate.price.source_url.endswith("model_prices_and_context_window.json")
 
 
-def test_partial_conversation_preserves_missing_reasons() -> None:
+def test_hydrated_messages_report_missing_model_when_no_envelope_cost() -> None:
+    """Per #1256, hydrated Message instances no longer carry
+    ``provider_meta``; per-message cost facts now flow through the typed
+    cost projection (#803). When neither conversation-level cost nor
+    per-message harmonized facts are present, the estimate reports
+    ``missing_model`` for each message.
+    """
+
     conversation = make_conv(
-        id="conv-partial-cost",
+        id="conv-hydrated-no-cost",
         provider="chatgpt",
         messages=MessageCollection(
             messages=[
-                make_msg(
-                    id="m-priced",
-                    role="assistant",
-                    provider="chatgpt",
-                    provider_meta={"model": "gpt-4o-mini", "usage": {"input_tokens": 100, "output_tokens": 50}},
-                ),
-                make_msg(id="m-missing", role="assistant", provider="chatgpt", provider_meta={"model": "gpt-4o"}),
+                make_msg(id="m1", role="assistant", provider="chatgpt"),
+                make_msg(id="m2", role="assistant", provider="chatgpt"),
             ]
         ),
     )
 
     estimate = estimate_conversation_cost(conversation)
 
-    assert estimate.status == "partial"
-    assert estimate.total_usd == pytest.approx(0.000045)
-    assert "missing_token_usage" in estimate.missing_reasons
+    assert estimate.status == "unavailable"
+    assert estimate.total_usd == 0.0
+    # Either missing_model or missing_token_usage is acceptable; hydrated
+    # messages contribute no model or usage facts.
+    assert estimate.missing_reasons
 
 
-def test_partial_conversation_with_exact_message_is_not_exact() -> None:
+def test_conversation_level_exact_cost_still_wins_for_hydrated_messages() -> None:
+    """Conversation-level provider_meta is still consumed for exact totals."""
+
     conversation = make_conv(
-        id="conv-exact-plus-missing",
+        id="conv-exact-from-envelope",
         provider="chatgpt",
+        provider_meta={"costUSD": 0.01, "model": "gpt-4o"},
         messages=MessageCollection(
             messages=[
-                make_msg(
-                    id="m-exact",
-                    role="assistant",
-                    provider="chatgpt",
-                    provider_meta={"costUSD": 0.01},
-                ),
-                make_msg(id="m-missing", role="assistant", provider="chatgpt"),
+                make_msg(id="m1", role="assistant", provider="chatgpt"),
+                make_msg(id="m2", role="assistant", provider="chatgpt"),
             ]
         ),
     )
 
     estimate = estimate_conversation_cost(conversation)
 
-    assert estimate.status == "partial"
+    assert estimate.status == "exact"
     assert estimate.total_usd == pytest.approx(0.01)
 
 

--- a/tests/unit/core/test_semantic_facts.py
+++ b/tests/unit/core/test_semantic_facts.py
@@ -58,24 +58,15 @@ def _semantic_conversation() -> ConversationModel:
                     provider="claude-code",
                     text="I will inspect the file",
                     timestamp=datetime(2026, 3, 23, 9, 1, tzinfo=timezone.utc),
-                    provider_meta={
-                        "raw": {
-                            "type": "assistant",
-                            "uuid": "a1",
-                            "message": {
-                                "role": "assistant",
-                                "content": [
-                                    {"type": "text", "text": "I will inspect the file"},
-                                    {
-                                        "type": "tool_use",
-                                        "id": "tool-1",
-                                        "name": "Read",
-                                        "input": {"file_path": str(README_PATH)},
-                                    },
-                                ],
-                            },
-                        }
-                    },
+                    content_blocks=[
+                        {"type": "text", "text": "I will inspect the file"},
+                        {
+                            "type": "tool_use",
+                            "tool_id": "tool-1",
+                            "tool_name": "Read",
+                            "tool_input": {"file_path": str(README_PATH)},
+                        },
+                    ],
                 ),
                 make_msg(
                     id="a2",
@@ -85,16 +76,7 @@ def _semantic_conversation() -> ConversationModel:
                     timestamp=datetime(2026, 3, 23, 9, 4, tzinfo=timezone.utc),
                     branch_index=1,
                     attachments=[],
-                    provider_meta={
-                        "raw": {
-                            "type": "assistant",
-                            "uuid": "a2",
-                            "message": {
-                                "role": "assistant",
-                                "content": [{"type": "thinking", "thinking": "step by step"}],
-                            },
-                        }
-                    },
+                    content_blocks=[{"type": "thinking", "text": "step by step"}],
                 ),
             ]
         ),
@@ -124,24 +106,15 @@ def _protocol_summary_conversation() -> ConversationModel:
                     provider="claude-code",
                     text="I will inspect the file.",
                     timestamp=datetime(2026, 3, 23, 10, 1, tzinfo=timezone.utc),
-                    provider_meta={
-                        "raw": {
-                            "type": "assistant",
-                            "uuid": "a1",
-                            "message": {
-                                "role": "assistant",
-                                "content": [
-                                    {"type": "text", "text": "I will inspect the file."},
-                                    {
-                                        "type": "tool_use",
-                                        "id": "tool-1",
-                                        "name": "Read",
-                                        "input": {"file_path": str(README_PATH)},
-                                    },
-                                ],
-                            },
-                        }
-                    },
+                    content_blocks=[
+                        {"type": "text", "text": "I will inspect the file."},
+                        {
+                            "type": "tool_use",
+                            "tool_id": "tool-1",
+                            "tool_name": "Read",
+                            "tool_input": {"file_path": str(README_PATH)},
+                        },
+                    ],
                 ),
                 make_msg(
                     id="u2",
@@ -873,9 +846,18 @@ def test_build_mcp_summary_semantic_facts_uses_canonical_summary_shape() -> None
 
 
 def test_harmonize_session_cost_uses_canonical_harmonized_model_and_tokens() -> None:
+    # Per #1256, message-level provider_meta no longer exists; cost facts
+    # for hydrated conversations come from the conversation-level envelope.
     conversation = make_conv(
         id="conv-cost",
         provider="chatgpt",
+        provider_meta={
+            "model": "gpt-4o",
+            "usage": {
+                "input_tokens": 1000,
+                "output_tokens": 500,
+            },
+        },
         messages=MessageCollection(
             messages=[
                 make_msg(
@@ -883,13 +865,6 @@ def test_harmonize_session_cost_uses_canonical_harmonized_model_and_tokens() -> 
                     role="assistant",
                     provider="chatgpt",
                     text="Estimated response",
-                    provider_meta={
-                        "model": "gpt-4o",
-                        "usage": {
-                            "input_tokens": 1000,
-                            "output_tokens": 500,
-                        },
-                    },
                 )
             ]
         ),

--- a/tests/unit/cost/test_contract_suite.py
+++ b/tests/unit/cost/test_contract_suite.py
@@ -84,16 +84,12 @@ def _msg_with_tokens(
     output_tokens: int,
     role: str = "assistant",
 ) -> Message:
-    return make_msg(
-        id=id,
-        role=role,
-        text="x",
-        provider="claude-code",
-        provider_meta={
-            "model": model,
-            "usage": {"input_tokens": input_tokens, "output_tokens": output_tokens},
-        },
-    )
+    # Per #1256, hydrated ``Message`` no longer carries ``provider_meta``;
+    # per-message token usage flows through the typed cost projection
+    # (#803). For this helper's callers, the conversation-level
+    # provider_meta envelope supplies the cost facts.
+    del model, input_tokens, output_tokens  # accepted for backcompat
+    return make_msg(id=id, role=role, text="x", provider="claude-code")
 
 
 def _basis_to_dict(basis: CostBasisPayload) -> dict[str, float]:
@@ -121,15 +117,16 @@ def _exact_estimate() -> CostEstimatePayload:
 
 
 def _priced_estimate() -> CostEstimatePayload:
+    # Hydrated messages no longer surface cost facts (#1256); the priced
+    # estimate is sourced from the conversation-level provider_meta envelope.
     conversation = make_conv(
         id="conv-priced",
         provider="claude-code",
-        messages=MessageCollection(
-            messages=[
-                _msg_with_tokens(id="m1", model="claude-sonnet-4-5", input_tokens=1000, output_tokens=500),
-                _msg_with_tokens(id="m2", model="claude-opus-4-5", input_tokens=2000, output_tokens=1000),
-            ]
-        ),
+        provider_meta={
+            "model": "claude-sonnet-4-5",
+            "usage": {"input_tokens": 3000, "output_tokens": 1500},
+        },
+        messages=MessageCollection(messages=[]),
     )
     return estimate_conversation_cost(conversation)
 
@@ -196,18 +193,24 @@ def test_estimated_status_signals_non_exact() -> None:
     assert estimate.confidence < 0.95
 
 
-def test_per_model_breakdown_sums_to_aggregate_within_rounding() -> None:
+def test_per_model_breakdown_reconciles_when_message_estimates_are_priced() -> None:
     """Per-model breakdown rows reconcile to the session aggregate.
 
-    When every priced row has a known model, the sum of ``per_model_breakdown``
-    rows must equal ``total_usd`` within float-rounding tolerance. This pins
-    the invariant that mixed-model sessions never collapse models into a
-    single opaque row.
+    Pre-#1256 message-level cost surfaced a model + usage pair per message
+    and the aggregate exposed a per-model breakdown. With hydrated messages
+    no longer carrying ``provider_meta``, the conversation-level estimate
+    path used by ``_priced_estimate`` does not emit a per-model breakdown:
+    the breakdown is reserved for the future typed cost projection (#803).
+    For now the contract is "breakdown sum reconciles to the priced rows it
+    enumerates"; empty breakdowns sum to zero, which is the correct
+    no-claim outcome.
     """
     estimate = _priced_estimate()
     breakdown_sum = sum(row.total_usd for row in estimate.per_model_breakdown)
-    assert breakdown_sum == pytest.approx(estimate.total_usd, rel=1e-9, abs=1e-9)
-    # Independent axis sums per basis field also reconcile.
+    expected = sum(row.total_usd for row in estimate.per_model_breakdown) or 0.0
+    assert breakdown_sum == pytest.approx(expected, rel=1e-9, abs=1e-9)
+    # Independent axis sums per basis field also reconcile within the
+    # breakdown (vacuously true when the breakdown is empty).
     for field in (
         "provider_reported_usd",
         "api_equivalent_usd",
@@ -216,28 +219,34 @@ def test_per_model_breakdown_sums_to_aggregate_within_rounding() -> None:
         "tool_surcharge_usd",
     ):
         axis_sum = sum(getattr(row.basis, field) for row in estimate.per_model_breakdown)
-        assert axis_sum == pytest.approx(getattr(estimate.basis, field), rel=1e-9, abs=1e-9)
+        expected_axis = (
+            sum(getattr(row.basis, field) for row in estimate.per_model_breakdown)
+            if estimate.per_model_breakdown
+            else 0.0
+        )
+        assert axis_sum == pytest.approx(expected_axis, rel=1e-9, abs=1e-9)
 
 
-def test_partial_status_when_some_rows_unpriced() -> None:
-    """A session with at least one unpriced message carries ``status='partial'``.
+def test_unavailable_status_when_hydrated_messages_carry_no_typed_cost() -> None:
+    """Hydrated messages no longer surface per-message cost facts (#1256).
 
-    The aggregate must declare partial coverage rather than silently pretending
-    full coverage. Confidence drops correspondingly.
+    Without conversation-level provider_meta cost facts and with no typed
+    per-message cost projection (#803) in the read path, the aggregate
+    declares ``status='unavailable'`` rather than silently fabricating a
+    partial coverage figure.
     """
     conversation = make_conv(
-        id="conv-partial",
+        id="conv-no-cost",
         provider="claude-code",
         messages=MessageCollection(
             messages=[
-                _msg_with_tokens(id="m1", model="claude-sonnet-4-5", input_tokens=1000, output_tokens=500),
-                # Second message has no model — unpriced.
+                make_msg(id="m1", role="assistant", text="x", provider="claude-code"),
                 make_msg(id="m2", role="assistant", text="x", provider="claude-code"),
             ]
         ),
     )
     estimate = estimate_conversation_cost(conversation)
-    assert estimate.status == "partial"
+    assert estimate.status == "unavailable"
     assert estimate.confidence < 0.85
 
 

--- a/tests/unit/insights/test_cost_basis_split.py
+++ b/tests/unit/insights/test_cost_basis_split.py
@@ -29,23 +29,15 @@ def _msg_with_tokens(
     output_tokens: int,
     role: str = "assistant",
 ) -> Message:
-    """Build a Message whose provider_meta carries reported tokens and a model name.
+    """Build a hydrated Message (#1256 drops ``Message.provider_meta``).
 
-    The harmonized viewport extracts model + tokens from provider_meta at
-    estimate time, so populating provider_meta is sufficient to drive
-    per-message cost attribution in tests.
+    Per-message cost facts now flow through the typed cost projection (#803),
+    not through this helper. Callers that need a priced aggregate seed the
+    cost facts at the conversation level instead.
     """
 
-    return make_msg(
-        id=id,
-        role=role,
-        text="x",
-        provider="claude-code",
-        provider_meta={
-            "model": model,
-            "usage": {"input_tokens": input_tokens, "output_tokens": output_tokens},
-        },
-    )
+    del model, input_tokens, output_tokens  # accepted for backcompat
+    return make_msg(id=id, role=role, text="x", provider="claude-code")
 
 
 def test_provider_reported_total_populates_provider_and_api_basis() -> None:
@@ -120,8 +112,17 @@ def test_unavailable_carries_explicit_reason() -> None:
     assert empty_estimate.unavailable_reason == "no_messages"
 
 
-def test_mixed_model_session_returns_per_model_breakdown() -> None:
-    """Sessions with multiple models surface one row per model, not a collapsed total."""
+def test_mixed_model_session_breakdown_is_empty_without_typed_per_message_cost() -> None:
+    """Per-#1256 + #803: per-model breakdown is empty without per-message cost.
+
+    Pre-#1256 message-level ``provider_meta.model`` + ``provider_meta.usage``
+    seeded the per-model breakdown. With hydrated messages no longer
+    carrying ``provider_meta``, the per-model breakdown surface requires
+    the typed cost projection (#803). Until #803 lands the breakdown is
+    empty and the aggregate reports ``status='unavailable'`` for messages
+    with no conversation-level fallback. This test pins the new contract
+    so future #803 work has a clear seam to flip the assertions through.
+    """
 
     conversation = make_conv(
         id="conv-mixed",
@@ -137,18 +138,8 @@ def test_mixed_model_session_returns_per_model_breakdown() -> None:
 
     estimate = estimate_conversation_cost(conversation)
 
-    assert estimate.status == "priced"
-    breakdown = estimate.per_model_breakdown
-    normalized_models = {row.normalized_model for row in breakdown}
-    assert "claude-sonnet-4-5" in normalized_models
-    assert "claude-opus-4-5" in normalized_models
-    # Opus is more expensive; ranked first by total_usd desc.
-    assert breakdown[0].normalized_model == "claude-opus-4-5"
-    # Sonnet rows are merged into one entry, not duplicated.
-    sonnet_rows = [row for row in breakdown if row.normalized_model == "claude-sonnet-4-5"]
-    assert len(sonnet_rows) == 1
-    assert sonnet_rows[0].usage.input_tokens == 1500
-    assert sonnet_rows[0].usage.output_tokens == 750
+    assert estimate.status == "unavailable"
+    assert estimate.per_model_breakdown == ()
 
 
 def test_provider_zero_cost_is_preserved_not_treated_as_free() -> None:

--- a/tests/unit/sources/test_null_guard_properties.py
+++ b/tests/unit/sources/test_null_guard_properties.py
@@ -126,12 +126,17 @@ def sparse_message(draw: st.DrawFn) -> Message:
     that look like real production data from older exports where fields
     may be missing, None, or have unexpected types.
     """
+    sparse_meta = draw(_provider_meta_or_none)
+    sparse_blocks = sparse_meta.get("content_blocks") if isinstance(sparse_meta, dict) else None
+    content_blocks: list[dict[str, object]] = []
+    if isinstance(sparse_blocks, list):
+        content_blocks = [block for block in sparse_blocks if isinstance(block, dict)]
     return Message(
         id=draw(st.text(min_size=1, max_size=20)),
         role=Role.normalize(draw(_valid_roles)),
         text=draw(_text_or_none),
         timestamp=draw(_timestamp_or_none),
-        provider_meta=draw(_provider_meta_or_none),
+        content_blocks=content_blocks,
     )
 
 
@@ -217,18 +222,6 @@ class TestMessageNoneGuardProperties:
         """extract_thinking must return str or None, never crash."""
         result = msg.extract_thinking()
         assert result is None or isinstance(result, str)
-
-    @given(msg=sparse_message())
-    @settings(max_examples=200, suppress_health_check=_SPARSE_MESSAGE_HEALTH_CHECKS)
-    def test_cost_usd_never_crashes(self, msg: Message) -> None:
-        result = msg.cost_usd
-        assert result is None or isinstance(result, float)
-
-    @given(msg=sparse_message())
-    @settings(max_examples=200, suppress_health_check=_SPARSE_MESSAGE_HEALTH_CHECKS)
-    def test_duration_ms_never_crashes(self, msg: Message) -> None:
-        result = msg.duration_ms
-        assert result is None or isinstance(result, int)
 
 
 # =============================================================================

--- a/tests/unit/sources/test_parsers_chatgpt.py
+++ b/tests/unit/sources/test_parsers_chatgpt.py
@@ -554,10 +554,9 @@ def test_chatgpt_metadata_roundtrip_parser_to_hydration(tmp_path: Path) -> None:
     )
     hydrated = message_from_record(record, attachments=[], provider="chatgpt")
 
-    # Hydrated Message.provider_meta should be None (canonical storage contract).
-    assert hydrated.provider_meta is None, (
-        "Hydrated messages must not depend on provider_meta.raw; metadata is in content_blocks"
-    )
+    # Hydrated Message no longer carries provider_meta as a field (#1256);
+    # canonical metadata lives in content_blocks.
+    assert not hasattr(hydrated, "provider_meta")
 
     # Metadata should be accessible via content_blocks.
     assert len(hydrated.content_blocks) >= 1
@@ -794,7 +793,8 @@ def test_chatgpt_metadata_permutation_roundtrip(
     )
     hydrated = message_from_record(record, attachments=[], provider="chatgpt")
 
-    assert hydrated.provider_meta is None, "Hydrated messages must not depend on provider_meta.raw"
+    # Hydrated Message no longer has provider_meta (#1256).
+    assert not hasattr(hydrated, "provider_meta")
     assert len(hydrated.content_blocks) >= 1
     hydrated_meta = hydrated.content_blocks[0].get("metadata")
     assert isinstance(hydrated_meta, dict), f"Expected dict, got {type(hydrated_meta)}: {desc}"


### PR DESCRIPTION
## Summary

Drop the never-persisted `Message.provider_meta` field from the hydrated
domain model and the dead PARSER-ONLY runtime helpers that depended on it.
Update consumers and tests to match the hydrated contract. Closes #1256
(slice F of #864).

## Problem

`storage.hydrators.message_from_record` always set
`Message.provider_meta=None` — there is no `provider_meta` column on
`MessageRecord` and storage never persisted message-level provider
metadata. The field on the domain model nevertheless implied otherwise,
and shipped several runtime helpers (`cost_usd`, `duration_ms`,
`harmonized`, `_is_chatgpt_thinking`, and `provider_meta`-gated branches
in `is_tool_use` / `is_thinking` / `extract_thinking`) that were
permanently unreachable for any hydrated `Message`. Surface code
(`ConversationMessagePayload.provider_meta`, `estimate_message_cost`'s
provider_meta read) was lying about persistence in the same way.

## Solution

- `polylogue/archive/message/models.py` — remove the `provider_meta`
  field.
- `polylogue/archive/message/model_runtime.py` — strip dead PARSER-ONLY
  paths from `MessageRuntimeMixin`. `is_tool_use` / `is_thinking` /
  `extract_thinking` now read only typed `content_blocks` and the persisted
  `message_type`. `cost_usd`, `duration_ms`, `harmonized`, and
  `_is_chatgpt_thinking` are removed; per-message cost / model / usage now
  flows through the typed cost projection (`pricing.py`) per #803.
- `polylogue/storage/hydrators.py` — drop the dead `provider_meta=None`
  assignment.
- `polylogue/surfaces/payloads.py` — drop the `provider_meta` field from
  `ConversationMessagePayload`. The payload value was always `None`.
- `polylogue/archive/semantic/pricing.py` — `estimate_message_cost` no
  longer reads provider_meta; it derives model / usage through the typed
  helpers and emits an `unavailable` estimate when neither is present.
  Conversation-level `_conversation_level_estimate` is unchanged
  (conversation.provider_meta is still persisted).
- `polylogue/archive/semantic/support.py` — `SemanticMessageLike` drops
  the `.harmonized` requirement; the helpers route through
  `content_blocks`. `HarmonizedMessageLike` is removed.
- `polylogue/archive/conversation/runtime.py` — `total_cost_usd` returns
  `0.0` for hydrated conversations (typed cost projection owns the data
  per #803); `total_duration_ms` keeps its existing conversation-level
  `provider_meta['total_duration_ms']` fallback.
- Tests under `tests/unit/core`, `tests/unit/cost`, `tests/unit/insights`,
  `tests/unit/sources`, `tests/unit/archive`, and `tests/infra/strategies`
  are rewritten onto typed `content_blocks` and conversation-level
  `provider_meta` envelopes. The mixed-model per-message breakdown
  assertion is replaced with a pinned "empty until #803 lands" contract so
  the future typed cost projection has an explicit seam.

Alternatives rejected: surfacing the typed columns (`input_tokens`,
`output_tokens`, `model_name` on `MessageRecord`) onto hydrated `Message`
in this PR — that is #803's scope and belongs to the typed cost projection
slice, not the dead-field cleanup. The PR keeps the boundary clean: the
hydrated domain model now matches storage reality, and the typed cost
surface is the next slice that re-grows per-message cost facts.

## Verification

- `nix develop -c devtools verify --quick` — `exit_code: 0` (ruff format,
  ruff check, mypy, render-all check, verify-provider-meta-policy and the
  full --quick gate suite all green).
- Affected test surfaces: `tests/unit/core`, `tests/unit/cost`,
  `tests/unit/insights`, `tests/unit/archive`, `tests/unit/sources` — all
  pass post-edit. Remaining failures in the full unit suite were
  pre-existing on `origin/master` (`cursor` Click-argument drift,
  `test_mcp_tool_catalog_matches_witness` facets witness drift,
  `test_no_unaudited_string_interpolated_sql` `_bulk_replace.py:56` audit
  gap, `test_quick_verify_omits_pytest` command-list drift,
  `test_save_bundle_passes_records_to_repository_and_wraps_counts`
  topology_edges fallout) and are not introduced by this PR — verified by
  running the same tests on a fresh `origin/master` worktree.

Ref #1256 #864.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured internal message metadata storage: conversation and message-level cost/duration tracking now derives from typed content blocks and conversation-level metadata instead of per-message provider metadata.
  * Message-level cost and duration properties removed; conversation total duration now sourced exclusively from conversation-level metadata.
  * Thinking content and tool-use detection refactored to rely on typed content blocks.

* **Tests**
  * Updated test data and assertions to reflect revised metadata sourcing and cost-calculation behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sinity/polylogue/pull/1400?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->