### PR TITLE
test(sources): Codex event-stream contract (#1296)

### DIFF
--- a/docs/plans/test-closure-matrix.yaml
+++ b/docs/plans/test-closure-matrix.yaml
@@ -79,10 +79,8 @@ rows:
     representative_tests:
       - tests/unit/sources/test_parsers_codex.py
       - tests/unit/sources/test_parsers_props.py
+      - tests/unit/sources/test_codex_event_stream_contract.py
     gate: required
-    known_gaps:
-      - codex event-stream (`response.completed`, tool deltas) lacks a dedicated
-        contract test; coverage is property-shape only
 
   - domain: sources.parsers.gemini
     target_files:

--- a/tests/data/codex_event_stream/interleaved_stream.jsonl
+++ b/tests/data/codex_event_stream/interleaved_stream.jsonl
@@ -1,0 +1,13 @@
+{"type":"session_meta","payload":{"id":"interleaved-session-1","timestamp":"2025-01-15T12:00:00Z","git":{"branch":"feature/x"}}}
+{"type":"turn_context","payload":{"cwd":"/repo/polylogue"}}
+{"type":"response_item","payload":{"type":"message","id":"msg-user-1","role":"user","timestamp":"2025-01-15T12:00:03Z","content":[{"type":"input_text","text":"Check git status, then read README."}]}}
+{"type":"response_item","payload":{"type":"function_call","id":"fc_1","call_id":"call_git","name":"exec_command","arguments":"{\"cmd\": \"git status\"}"}}
+{"type":"response_item","payload":{"type":"function_call_output","call_id":"call_git","output":"clean"}}
+{"type":"response_item","payload":{"type":"message","id":"msg-asst-1","role":"assistant","timestamp":"2025-01-15T12:00:08Z","content":[{"type":"output_text","text":"Working tree is clean."}]}}
+{"type":"response_item","payload":{"type":"function_call","id":"fc_2","call_id":"call_read","name":"read_file","arguments":"{\"path\": \"README.md\"}"}}
+{"type":"response_item","payload":{"type":"function_call_output","call_id":"call_read","output":"# Polylogue\n"}}
+{"type":"response_item","payload":{"type":"message","id":"msg-asst-2","role":"assistant","timestamp":"2025-01-15T12:00:14Z","content":[{"type":"output_text","text":"README starts with the Polylogue heading."}]}}
+{"type":"response_item","payload":{"type":"message","id":"msg-user-2","role":"user","timestamp":"2025-01-15T12:01:00Z","content":[{"type":"input_text","text":"Thanks."}]}}
+{"type":"compacted","timestamp":"2025-01-15T12:05:00Z","payload":{"message":"Conversation compacted","replacement_history":[{"id":"summary-1"}]}}
+{"type":"turn_context","payload":{"turn_context":{"cwd":"/repo/other"}}}
+{"type":"response_item","payload":{"type":"token_count","input_tokens":120,"output_tokens":40}}

--- a/tests/data/codex_event_stream/text_only_stream.jsonl
+++ b/tests/data/codex_event_stream/text_only_stream.jsonl
@@ -1,0 +1,4 @@
+{"type":"session_meta","payload":{"id":"text-only-session-1","timestamp":"2025-01-15T10:00:00Z","git":{"branch":"main","commit_hash":"deadbeef"},"instructions":"You are helpful."}}
+{"type":"response_item","payload":{"type":"message","id":"msg-user-1","role":"user","timestamp":"2025-01-15T10:00:05Z","content":[{"type":"input_text","text":"What is the capital of France?"}]}}
+{"type":"response_item","payload":{"type":"message","id":"msg-asst-1","role":"assistant","timestamp":"2025-01-15T10:00:08Z","content":[{"type":"output_text","text":"The capital of France is Paris."}]}}
+{"type":"response_item","payload":{"type":"token_count","input_tokens":12,"output_tokens":8}}

--- a/tests/data/codex_event_stream/tool_call_stream.jsonl
+++ b/tests/data/codex_event_stream/tool_call_stream.jsonl
@@ -1,0 +1,6 @@
+{"type":"session_meta","payload":{"id":"tool-call-session-1","timestamp":"2025-01-15T11:00:00Z","instructions":"Use tools."}}
+{"type":"response_item","payload":{"type":"message","id":"msg-user-1","role":"user","timestamp":"2025-01-15T11:00:02Z","content":[{"type":"input_text","text":"List the files in /tmp."}]}}
+{"type":"response_item","payload":{"type":"function_call","id":"fc_1","call_id":"call_abc","name":"exec_command","arguments":"{\"cmd\": \"ls /tmp\"}"}}
+{"type":"response_item","payload":{"type":"function_call_output","call_id":"call_abc","output":"file1.txt\nfile2.txt"}}
+{"type":"response_item","payload":{"type":"message","id":"msg-asst-1","role":"assistant","timestamp":"2025-01-15T11:00:09Z","content":[{"type":"output_text","text":"There are two files: file1.txt and file2.txt."}]}}
+{"type":"response_item","payload":{"type":"token_count","input_tokens":42,"output_tokens":18}}

--- a/tests/unit/sources/test_codex_event_stream_contract.py
+++ b/tests/unit/sources/test_codex_event_stream_contract.py
@@ -1,0 +1,455 @@
+"""Codex event-stream contract tests.
+
+These tests pin the on-disk semantics of the Codex JSONL "streaming envelope"
+shape — what the persisted session records look like once a streaming response
+has been realized. They are explicitly contract-shaped: if OpenAI changes the
+envelope keys, payload type tokens, or call_id pairing semantics, these tests
+should fail with a precise reason naming the broken field.
+
+Catalog payloads live under ``tests/data/codex_event_stream/`` and cover three
+realistic streaming shapes:
+
+- ``text_only_stream.jsonl`` — session_meta + user/assistant text turn +
+  trailing token_count.
+- ``tool_call_stream.jsonl`` — single function_call paired with a
+  function_call_output via ``call_id`` and a concluding assistant message.
+- ``interleaved_stream.jsonl`` — multiple tool turns, mixed assistant
+  messages, turn_context cwd changes, and a compaction event.
+
+Ref #1296.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from polylogue.archive.conversation.branch_type import BranchType
+from polylogue.archive.message.roles import Role
+from polylogue.sources.parsers.base import ParsedConversation
+from polylogue.sources.parsers.codex import looks_like as _looks_like_impl
+from polylogue.sources.parsers.codex import parse as _parse_impl
+from polylogue.sources.parsers.codex import parse_stream
+from polylogue.types import ContentBlockType
+
+CATALOG_DIR = Path(__file__).resolve().parent.parent.parent / "data" / "codex_event_stream"
+
+
+# ---------------------------------------------------------------------------
+# Catalog access helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_catalog(name: str) -> list[object]:
+    path = CATALOG_DIR / name
+    records: list[object] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        records.append(json.loads(line))
+    return records
+
+
+def _parse(payload: list[object], fallback_id: str = "fallback") -> ParsedConversation:
+    return _parse_impl(payload, fallback_id)
+
+
+def _looks_like(payload: list[object]) -> bool:
+    return _looks_like_impl(payload)
+
+
+# ---------------------------------------------------------------------------
+# Catalog smoke — every shape must be detected and parsed without raising
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "fixture",
+    ["text_only_stream.jsonl", "tool_call_stream.jsonl", "interleaved_stream.jsonl"],
+)
+def test_catalog_streams_are_detected_as_codex(fixture: str) -> None:
+    records = _load_catalog(fixture)
+    assert _looks_like(records), f"{fixture} must satisfy looks_like()"
+
+
+@pytest.mark.parametrize(
+    "fixture",
+    ["text_only_stream.jsonl", "tool_call_stream.jsonl", "interleaved_stream.jsonl"],
+)
+def test_catalog_streams_parse_without_raising(fixture: str) -> None:
+    records = _load_catalog(fixture)
+    conversation = _parse(records, fixture)
+    assert conversation.provider_name == "codex"
+    # Each fixture must contribute at least one message — otherwise the
+    # streaming envelope contract is silently dropping content.
+    assert conversation.messages, f"{fixture} produced zero messages"
+
+
+# ---------------------------------------------------------------------------
+# response_item envelope shape — the "streaming envelope" contract
+# ---------------------------------------------------------------------------
+
+
+class TestStreamingEnvelopeShape:
+    """Pin the on-disk streaming envelope contract.
+
+    The persisted Codex JSONL wraps every realized streaming event in a
+    ``response_item`` envelope with a typed ``payload``. These tests pin the
+    contract: the outer ``type`` token, the inner payload ``type`` tokens we
+    consume, and the message-vs-event dispatch.
+    """
+
+    def test_response_item_message_payload_routes_to_messages(self) -> None:
+        records: list[object] = [
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "id": "m1",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": "hi"}],
+                },
+            }
+        ]
+        conversation = _parse(records)
+        assert len(conversation.messages) == 1
+        assert conversation.messages[0].role == Role.ASSISTANT
+        assert conversation.provider_events == []
+
+    def test_response_item_non_message_payload_routes_to_events(self) -> None:
+        records: list[object] = [
+            {
+                "type": "response_item",
+                "payload": {"type": "token_count", "input_tokens": 1, "output_tokens": 2},
+            }
+        ]
+        conversation = _parse(records)
+        assert conversation.messages == []
+        assert [event.event_type for event in conversation.provider_events] == ["token_count"]
+
+    def test_unknown_inner_payload_type_still_recorded_as_provider_event(self) -> None:
+        """Unknown payload type tokens must not be silently dropped.
+
+        This is the canary for OpenAI introducing a new event class — the
+        parser must still surface it as a provider event so downstream
+        consumers can see something is happening.
+        """
+        records: list[object] = [
+            {
+                "type": "response_item",
+                "payload": {"type": "future_event_kind", "data": 7},
+            }
+        ]
+        conversation = _parse(records)
+        assert [event.event_type for event in conversation.provider_events] == ["future_event_kind"]
+
+
+# ---------------------------------------------------------------------------
+# response.completed equivalent — terminal message state
+# ---------------------------------------------------------------------------
+
+
+class TestResponseCompletedContract:
+    """The on-disk equivalent of streaming ``response.completed``.
+
+    In a live stream OpenAI emits a sequence of ``response.delta`` events
+    terminated by ``response.completed``. The Codex CLI realizes those into a
+    single persisted ``response_item`` whose payload is a fully-formed
+    ``message`` (the completed state). The contract this pins:
+
+    - The realized message text equals the concatenation of all output_text
+      segments — there are no partial-token artifacts left over.
+    - A subsequent ``token_count`` event marks the end-of-response boundary
+      and does not corrupt the prior message.
+    - The terminal message timestamp drives ``conversation.updated_at``.
+    """
+
+    def test_completed_message_concatenates_all_output_text_segments(self) -> None:
+        records: list[object] = [
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "id": "m1",
+                    "role": "assistant",
+                    "content": [
+                        {"type": "output_text", "text": "Hello "},
+                        {"type": "output_text", "text": "world."},
+                    ],
+                },
+            }
+        ]
+        conversation = _parse(records)
+        assert len(conversation.messages) == 1
+        text = conversation.messages[0].text or ""
+        assert "Hello" in text and "world." in text
+
+    def test_token_count_after_message_does_not_mutate_prior_message(self) -> None:
+        records: list[object] = [
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "id": "m1",
+                    "role": "assistant",
+                    "timestamp": "2025-01-15T10:00:08Z",
+                    "content": [{"type": "output_text", "text": "Paris."}],
+                },
+            },
+            {
+                "type": "response_item",
+                "payload": {"type": "token_count", "input_tokens": 5, "output_tokens": 2},
+            },
+        ]
+        conversation = _parse(records)
+        assert len(conversation.messages) == 1
+        assert conversation.messages[0].text == "Paris."
+        assert conversation.messages[0].timestamp == "2025-01-15T10:00:08Z"
+        assert [event.event_type for event in conversation.provider_events] == ["token_count"]
+
+    def test_terminal_message_drives_conversation_updated_at(self) -> None:
+        records = _load_catalog("text_only_stream.jsonl")
+        conversation = _parse(records)
+        assert conversation.created_at == "2025-01-15T10:00:00Z"
+        # Updated_at must come from the last assistant message, not from the
+        # trailing token_count event (which has no timestamp).
+        assert conversation.updated_at == "2025-01-15T10:00:08Z"
+
+
+# ---------------------------------------------------------------------------
+# Tool deltas → single tool_use block, paired by call_id
+# ---------------------------------------------------------------------------
+
+
+class TestToolCallStreamingContract:
+    """A realized function_call envelope produces a single tool_use block.
+
+    The streaming protocol may emit multiple tool-call deltas, but the
+    persisted Codex JSONL collapses them into one ``function_call``
+    response_item with the merged ``arguments`` JSON string. This pins that
+    contract along with ``call_id`` round-trip semantics between
+    ``function_call`` and ``function_call_output``.
+    """
+
+    def test_function_call_realizes_as_single_tool_use_block(self) -> None:
+        records = _load_catalog("tool_call_stream.jsonl")
+        conversation = _parse(records, "tool_call_stream")
+
+        tool_use_msgs = [
+            msg
+            for msg in conversation.messages
+            if any(block.type == ContentBlockType.TOOL_USE for block in msg.content_blocks)
+        ]
+        assert len(tool_use_msgs) == 1
+        tool_use_block = next(
+            block for block in tool_use_msgs[0].content_blocks if block.type == ContentBlockType.TOOL_USE
+        )
+        assert tool_use_block.tool_name == "exec_command"
+        assert tool_use_block.tool_id == "call_abc"
+        assert tool_use_block.tool_input == {"cmd": "ls /tmp"}
+
+    def test_function_call_output_produces_paired_tool_result(self) -> None:
+        records = _load_catalog("tool_call_stream.jsonl")
+        conversation = _parse(records, "tool_call_stream")
+
+        tool_results = [
+            (msg, block)
+            for msg in conversation.messages
+            for block in msg.content_blocks
+            if block.type == ContentBlockType.TOOL_RESULT
+        ]
+        assert len(tool_results) == 1
+        result_msg, result_block = tool_results[0]
+        assert result_msg.role == Role.TOOL
+        assert result_block.tool_id == "call_abc"
+        assert result_block.text == "file1.txt\nfile2.txt"
+
+    def test_call_id_pairs_tool_use_and_tool_result(self) -> None:
+        """The cross-message contract: tool_use.tool_id == tool_result.tool_id."""
+        records = _load_catalog("interleaved_stream.jsonl")
+        conversation = _parse(records, "interleaved_stream")
+
+        tool_use_ids = [
+            block.tool_id
+            for msg in conversation.messages
+            for block in msg.content_blocks
+            if block.type == ContentBlockType.TOOL_USE
+        ]
+        tool_result_ids = [
+            block.tool_id
+            for msg in conversation.messages
+            for block in msg.content_blocks
+            if block.type == ContentBlockType.TOOL_RESULT
+        ]
+        assert tool_use_ids == ["call_git", "call_read"]
+        assert tool_result_ids == ["call_git", "call_read"]
+
+
+# ---------------------------------------------------------------------------
+# Truncated / out-of-order / malformed streams
+# ---------------------------------------------------------------------------
+
+
+class TestStreamResilience:
+    """Contract for incomplete and disordered streams.
+
+    The Codex parser is forgiving by design — it does not raise on truncation
+    or reordering, and it must not silently drop content. These tests pin the
+    observable behavior so a future change to "reject with typed error" would
+    fail loudly and intentionally.
+    """
+
+    def test_truncated_stream_keeps_tool_use_without_paired_result(self) -> None:
+        """A function_call with no following function_call_output must still
+        appear in the parsed conversation. Silent drop would be a contract
+        violation — the operator needs to see the partial turn."""
+        records: list[object] = [
+            {
+                "type": "session_meta",
+                "payload": {"id": "truncated", "timestamp": "2025-01-15T13:00:00Z"},
+            },
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "id": "u1",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "Run something."}],
+                },
+            },
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "function_call",
+                    "id": "fc_1",
+                    "call_id": "call_truncated",
+                    "name": "exec_command",
+                    "arguments": '{"cmd": "echo hi"}',
+                },
+            },
+            # function_call_output intentionally absent — stream truncated.
+        ]
+        conversation = _parse(records, "truncated")
+
+        tool_use_ids = [
+            block.tool_id
+            for msg in conversation.messages
+            for block in msg.content_blocks
+            if block.type == ContentBlockType.TOOL_USE
+        ]
+        tool_result_ids = [
+            block.tool_id
+            for msg in conversation.messages
+            for block in msg.content_blocks
+            if block.type == ContentBlockType.TOOL_RESULT
+        ]
+        assert tool_use_ids == ["call_truncated"]
+        assert tool_result_ids == []
+        # The provider_events surface must record the unpaired function_call
+        # so downstream consumers can detect the truncation.
+        assert "function_call" in {event.event_type for event in conversation.provider_events}
+
+    def test_out_of_order_tool_output_before_call_is_preserved(self) -> None:
+        """Output arriving before its call must still be parsed — the parser
+        does not enforce ordering, but it also must not drop either side."""
+        records: list[object] = [
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "function_call_output",
+                    "call_id": "call_oo",
+                    "output": "early-output",
+                },
+            },
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "function_call",
+                    "id": "fc_oo",
+                    "call_id": "call_oo",
+                    "name": "exec_command",
+                    "arguments": '{"cmd": "noop"}',
+                },
+            },
+        ]
+        conversation = _parse(records, "out-of-order")
+
+        tool_blocks = [
+            (block.type, block.tool_id)
+            for msg in conversation.messages
+            for block in msg.content_blocks
+            if block.type in (ContentBlockType.TOOL_USE, ContentBlockType.TOOL_RESULT)
+        ]
+        # Both halves of the pair must survive — order may be insertion order.
+        assert (ContentBlockType.TOOL_RESULT, "call_oo") in tool_blocks
+        assert (ContentBlockType.TOOL_USE, "call_oo") in tool_blocks
+
+    def test_malformed_record_does_not_abort_stream(self) -> None:
+        records: list[object] = [
+            42,  # non-dict garbage
+            {"definitely": "not-a-codex-record"},
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "id": "survivor",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "still here"}],
+                },
+            },
+        ]
+        conversation = _parse(records, "malformed")
+        assert [msg.text for msg in conversation.messages] == ["still here"]
+
+    def test_parse_stream_is_equivalent_to_parse_for_truncated_input(self) -> None:
+        """Streaming consumption (iterator) and list consumption must agree
+        even when the stream is truncated. This is the contract that lets the
+        daemon parse mid-write JSONL files safely."""
+        records = _load_catalog("tool_call_stream.jsonl")[:3]  # drop output + final msg + tokens
+        from_list = _parse(records, "trunc")
+        from_stream = parse_stream(iter(records), "trunc")
+        assert from_list == from_stream
+
+
+# ---------------------------------------------------------------------------
+# Cross-message references (compaction, turn_context, parent session)
+# ---------------------------------------------------------------------------
+
+
+class TestCrossMessageReferences:
+    """Pins the cross-message reference contract carried in the stream."""
+
+    def test_second_session_meta_becomes_parent_continuation(self) -> None:
+        records: list[object] = [
+            {"type": "session_meta", "payload": {"id": "child", "timestamp": "2025-01-15T14:00:00Z"}},
+            {"type": "session_meta", "payload": {"id": "parent", "timestamp": "2025-01-15T13:00:00Z"}},
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "id": "u1",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "continued"}],
+                },
+            },
+        ]
+        conversation = _parse(records, "fallback")
+        assert conversation.provider_conversation_id == "child"
+        assert conversation.parent_conversation_provider_id == "parent"
+        assert conversation.branch_type == BranchType.CONTINUATION
+
+    def test_turn_context_cwd_changes_collected_into_working_directories(self) -> None:
+        records = _load_catalog("interleaved_stream.jsonl")
+        conversation = _parse(records, "interleaved_stream")
+        assert conversation.working_directories == ["/repo/other", "/repo/polylogue"]
+
+    def test_compaction_event_surfaced_with_replacement_history_flag(self) -> None:
+        records = _load_catalog("interleaved_stream.jsonl")
+        conversation = _parse(records, "interleaved_stream")
+        compactions = [e for e in conversation.provider_events if e.event_type == "compaction"]
+        assert len(compactions) == 1
+        assert compactions[0].payload["has_replacement_history"] is True
+        assert compactions[0].payload["summary"] == "Conversation compacted"


### PR DESCRIPTION
## Summary

Adds a dedicated contract test module for the Codex on-disk streaming envelope shape — the realized form of OpenAI's `response.delta` / `response.completed` stream as persisted in Codex JSONL session files. Closes the corresponding `known_gaps` bullet in `docs/plans/test-closure-matrix.yaml`.

## Problem

`docs/plans/test-closure-matrix.yaml` flagged `sources.parsers.codex` as having no dedicated event-stream contract test — coverage was property-shape only. The streaming envelope is the surface most likely to drift on an upstream Codex / OpenAI format change, and the existing parser tests under `tests/unit/sources/test_parsers_codex.py` do not pin: `response_item` message-vs-event dispatch, tool-call `call_id` pairing semantics across `function_call` / `function_call_output`, truncated stream behavior, or the unknown payload-type fallback that protects against silent drops when OpenAI introduces a new event class.

## Solution

- New module `tests/unit/sources/test_codex_event_stream_contract.py` with 22 contract assertions grouped into five concerns:
  1. **Streaming envelope shape** — `response_item` outer envelope, message-vs-event dispatch, unknown payload type surfaces as a provider event (canary for upstream changes).
  2. **`response.completed` terminal state** — multi-segment text concatenation, trailing `token_count` does not corrupt the prior message, terminal message timestamp drives `conversation.updated_at`.
  3. **Tool-call streaming** — `function_call` realizes as a single `tool_use` block; `function_call_output` produces a paired `tool_result`; cross-message `call_id` pairing.
  4. **Stream resilience** — truncated (missing `function_call_output`) keeps the orphan `tool_use` visible; out-of-order pairs survive; malformed records do not abort the stream; `parse_stream` and `parse` agree on truncated input.
  5. **Cross-message references** — second `session_meta` becomes parent + `BranchType.CONTINUATION`; `turn_context` cwd changes collected into `working_directories`; `compacted` event surfaced with `has_replacement_history`.
- Three catalog JSONL fixtures under `tests/data/codex_event_stream/`:
  - `text_only_stream.jsonl` — session_meta + user/assistant text turn + trailing token_count.
  - `tool_call_stream.jsonl` — single function_call paired with function_call_output via `call_id`.
  - `interleaved_stream.jsonl` — multiple tool turns, mixed assistant messages, turn_context cwd changes, compaction event.
- Removes the `known_gaps` bullet from the `sources.parsers.codex` row in `docs/plans/test-closure-matrix.yaml` and registers the new test as a representative test for the domain.

The tests pin the *observable* contract of the current parser (which is intentionally forgiving — it does not raise on truncation or reorder, it must not silently drop content). A future shift to "reject with typed error" would correctly fail these tests and force a deliberate update.

## Verification

```
nix develop -c pytest tests/unit/sources/test_codex_event_stream_contract.py
============================== 22 passed in 8.23s ==============================

nix develop -c devtools verify --quick
"exit_code": 0
```

Ref #1296.