### PR TITLE
test(mcp): per-tool contract coverage for mutation-tools surface (#1294)

### DIFF
--- a/tests/unit/mcp/test_per_tool_contracts.py
+++ b/tests/unit/mcp/test_per_tool_contracts.py
@@ -1,0 +1,695 @@
+"""Per-tool contract coverage for the MCP mutation-tools surface (#1294).
+
+Pins three durable contracts for every ``@mcp.tool()`` registered by
+``polylogue.mcp.server_mutation_tools.register_mutation_tools``:
+
+1. **Argument validation** — each tool has a registered handler, the
+   required parameters are mandatory (omitting them raises ``TypeError``),
+   and at least one input rejection or happy path returns a structured
+   JSON envelope (no raw tracebacks).
+2. **Authorization** — every mutation tool is absent from a ``read``-role
+   server. ``server_tools.register_tools`` gates the whole mutation
+   register on ``role_allows(role, "write")``; this test pins that gate
+   per tool so a future regression that promoted any tool to
+   read-role registration fails loudly.
+3. **Idempotency** — create-twice, delete-missing, update-with-same
+   payload return the documented ``status``/``outcome`` shape rather
+   than crashing.
+
+Tool names are discovered from the admin-role FastMCP server (not a
+hard-coded list) so adding a new ``@mcp.tool()`` without coverage
+fails the discovery test until it is added to ``TOOL_MATRIX``.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+from collections.abc import Iterator
+from typing import Any, cast
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from polylogue.surfaces.payloads import (
+    BulkTagMutationResult,
+    DeleteConversationResult,
+    MetadataMutationResult,
+    TagMutationResult,
+)
+from tests.infra.mcp import (
+    MCPServerUnderTest,
+    invoke_surface,
+    make_polylogue_mock,
+    make_query_store_mock,
+)
+
+# ---------------------------------------------------------------------------
+# Discovery — tools owned by register_mutation_tools.
+# ---------------------------------------------------------------------------
+
+
+def _discover_mutation_tool_names() -> frozenset[str]:
+    """Discover every ``@mcp.tool()`` registered by
+    ``register_mutation_tools``.
+
+    Uses set difference between an admin-role server (everything) and a
+    server with mutation registration skipped. This dynamic derivation
+    means a new mutation tool is automatically picked up.
+    """
+    from polylogue.mcp.server import build_server
+
+    admin = cast(MCPServerUnderTest, build_server(role="admin"))
+    read = cast(MCPServerUnderTest, build_server(role="read"))
+    admin_tools = set(admin._tool_manager._tools.keys())
+    read_tools = set(read._tool_manager._tools.keys())
+    # Mutation tools are in admin but not in read. Maintenance tools are
+    # admin-only too, but they live in server_maintenance_tools and are
+    # excluded by importing the registered names from the mutation module.
+    from polylogue.mcp import server_mutation_tools
+
+    src = inspect.getsource(server_mutation_tools)
+    declared: set[str] = set()
+    for line in src.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("async def ") and "(" in stripped:
+            name = stripped[len("async def ") :].split("(", 1)[0]
+            if name in admin_tools and name not in read_tools:
+                declared.add(name)
+    return frozenset(declared)
+
+
+MUTATION_TOOL_NAMES: frozenset[str] = _discover_mutation_tool_names()
+
+
+# ---------------------------------------------------------------------------
+# Per-tool argument matrix.
+#
+# Each row: tool name -> dict with
+#   "required": set[str] of required kwargs (no defaults)
+#   "happy":   minimal happy-path kwargs
+#   "wrong_type": kwargs that violate a typed contract (e.g. empty string
+#                 where a non-empty string is required, or invalid enum)
+# ---------------------------------------------------------------------------
+
+_CONV_ID = "test:conv-mutation"
+_LONG_STRING = "x" * 10_000
+
+TOOL_MATRIX: dict[str, dict[str, Any]] = {
+    "add_tag": {
+        "required": {"conversation_id", "tag"},
+        "happy": {"conversation_id": _CONV_ID, "tag": "review"},
+    },
+    "remove_tag": {
+        "required": {"conversation_id", "tag"},
+        "happy": {"conversation_id": _CONV_ID, "tag": "review"},
+    },
+    "bulk_tag_conversations": {
+        "required": {"conversation_ids", "tags"},
+        "happy": {"conversation_ids": [_CONV_ID], "tags": ["review"]},
+    },
+    "list_tags": {
+        "required": set(),
+        "happy": {},
+    },
+    "list_marks": {
+        "required": set(),
+        "happy": {},
+    },
+    "add_mark": {
+        "required": {"conversation_id", "mark_type"},
+        "happy": {"conversation_id": _CONV_ID, "mark_type": "star"},
+        "invalid_value": {"conversation_id": _CONV_ID, "mark_type": "bogus"},
+    },
+    "remove_mark": {
+        "required": {"conversation_id", "mark_type"},
+        "happy": {"conversation_id": _CONV_ID, "mark_type": "star"},
+        "invalid_value": {"conversation_id": _CONV_ID, "mark_type": "bogus"},
+    },
+    "list_annotations": {
+        "required": set(),
+        "happy": {},
+    },
+    "save_annotation": {
+        "required": {"annotation_id", "conversation_id", "note_text"},
+        "happy": {"annotation_id": "ann-1", "conversation_id": _CONV_ID, "note_text": "hello"},
+        "empty_string": {"annotation_id": "", "conversation_id": _CONV_ID, "note_text": "hello"},
+    },
+    "delete_annotation": {
+        "required": {"annotation_id"},
+        "happy": {"annotation_id": "ann-1"},
+    },
+    "list_saved_views": {
+        "required": set(),
+        "happy": {},
+    },
+    "save_saved_view": {
+        "required": {"name", "query_json"},
+        "happy": {"name": "view-1", "query_json": "{}"},
+        "invalid_value": {"name": "view-1", "query_json": "not-json"},
+    },
+    "delete_saved_view": {
+        "required": {"view_id"},
+        "happy": {"view_id": "view-1"},
+    },
+    "list_recall_packs": {
+        "required": set(),
+        "happy": {},
+    },
+    "save_recall_pack": {
+        "required": {"pack_id", "label"},
+        "happy": {"pack_id": "pack-1", "label": "lbl", "payload_json": '{"items":[]}'},
+        "invalid_value": {"pack_id": "pack-1", "label": "lbl", "payload_json": "not-json"},
+    },
+    "delete_recall_pack": {
+        "required": {"pack_id"},
+        "happy": {"pack_id": "pack-1"},
+    },
+    "list_workspaces": {
+        "required": set(),
+        "happy": {},
+    },
+    "save_workspace": {
+        "required": {"workspace_id", "name"},
+        "happy": {"workspace_id": "ws-1", "name": "ws"},
+        "invalid_value": {"workspace_id": "ws-1", "name": "ws", "mode": "bogus"},
+    },
+    "delete_workspace": {
+        "required": {"workspace_id"},
+        "happy": {"workspace_id": "ws-1"},
+    },
+    "get_metadata": {
+        "required": {"conversation_id"},
+        "happy": {"conversation_id": _CONV_ID},
+    },
+    "set_metadata": {
+        "required": {"conversation_id", "key", "value"},
+        "happy": {"conversation_id": _CONV_ID, "key": "note", "value": "v"},
+        "invalid_value": {"conversation_id": _CONV_ID, "key": "", "value": "v"},
+    },
+    "delete_metadata": {
+        "required": {"conversation_id", "key"},
+        "happy": {"conversation_id": _CONV_ID, "key": "note"},
+        "invalid_value": {"conversation_id": _CONV_ID, "key": ""},
+    },
+    "delete_conversation": {
+        "required": {"conversation_id"},
+        "happy": {"conversation_id": _CONV_ID, "confirm": True},
+        "missing_confirm": {"conversation_id": _CONV_ID},
+    },
+    "record_correction": {
+        "required": {"conversation_id", "kind", "payload"},
+        "happy": {
+            "conversation_id": _CONV_ID,
+            "kind": "classification_override",
+            "payload": {"label": "research"},
+        },
+        "invalid_value": {
+            "conversation_id": _CONV_ID,
+            "kind": "bogus_kind",
+            "payload": {},
+        },
+    },
+    "list_corrections": {
+        "required": set(),
+        "happy": {},
+    },
+    "clear_corrections": {
+        "required": {"conversation_id"},
+        "happy": {"conversation_id": _CONV_ID},
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Fixtures.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def admin_server() -> MCPServerUnderTest:
+    """Admin-role server — every mutation tool is registered."""
+    from polylogue.mcp.server import build_server
+
+    return cast(MCPServerUnderTest, build_server(role="admin"))
+
+
+@pytest.fixture
+def read_server() -> MCPServerUnderTest:
+    """Read-role server — mutation tools must NOT be registered."""
+    from polylogue.mcp.server import build_server
+
+    return cast(MCPServerUnderTest, build_server(role="read"))
+
+
+@pytest.fixture
+def patched_mutation_seam() -> Iterator[Any]:
+    """Patch the polylogue facade and query store seams used by every
+    mutation tool. Yields the mock polylogue facade so individual tests
+    can override per-method return values.
+    """
+    with (
+        patch("polylogue.mcp.server._get_polylogue") as mock_get_poly,
+        patch("polylogue.mcp.server._get_query_store") as mock_get_query,
+    ):
+        poly = make_polylogue_mock()
+        mock_get_poly.return_value = poly
+        mock_get_query.return_value = make_query_store_mock(resolved_id=_CONV_ID)
+        yield poly
+
+
+# ---------------------------------------------------------------------------
+# 1. Discovery / matrix coverage.
+# ---------------------------------------------------------------------------
+
+
+class TestMutationToolDiscovery:
+    """Every registered mutation tool must appear in TOOL_MATRIX and
+    vice versa.
+    """
+
+    def test_every_mutation_tool_is_in_matrix(self) -> None:
+        missing = MUTATION_TOOL_NAMES - set(TOOL_MATRIX.keys())
+        assert not missing, (
+            f"Mutation tools registered but missing from TOOL_MATRIX: "
+            f"{sorted(missing)}. Add a row covering required params, a "
+            f"happy-path payload, and any invalid-value rejection so this "
+            f"contract test pins their argument shape."
+        )
+
+    def test_no_stale_matrix_entries(self) -> None:
+        stale = set(TOOL_MATRIX.keys()) - MUTATION_TOOL_NAMES
+        assert not stale, (
+            f"TOOL_MATRIX references tools not registered by "
+            f"register_mutation_tools: {sorted(stale)}. Remove them or "
+            f"restore the tool."
+        )
+
+    def test_mutation_tool_count_nonzero(self) -> None:
+        # Sanity floor — there are at least 20 mutation tools today
+        # (marks, annotations, saved views, recall packs, workspaces,
+        # tags, metadata, delete_conversation, learning corrections).
+        assert len(MUTATION_TOOL_NAMES) >= 20, sorted(MUTATION_TOOL_NAMES)
+
+
+# ---------------------------------------------------------------------------
+# 2. Authorization — read role denies every mutation tool.
+# ---------------------------------------------------------------------------
+
+
+class TestMutationToolAuthorization:
+    """Pin the per-tool authorization boundary: a ``read``-role server
+    must NOT register any mutation tool. ``server_tools.register_tools``
+    skips ``register_mutation_tools`` for the read role; this test
+    pins that gate per tool so promoting any single tool to read-role
+    registration fails loudly.
+    """
+
+    @pytest.mark.parametrize("tool_name", sorted(MUTATION_TOOL_NAMES))
+    def test_read_role_omits_mutation_tool(self, read_server: MCPServerUnderTest, tool_name: str) -> None:
+        assert tool_name not in read_server._tool_manager._tools, (
+            f"Tool {tool_name!r} appears in a read-role MCP server. Mutation "
+            f"tools must be gated behind the write role. Check "
+            f"polylogue.mcp.server_tools.register_tools and the role check."
+        )
+
+    @pytest.mark.parametrize("tool_name", sorted(MUTATION_TOOL_NAMES))
+    def test_admin_role_registers_mutation_tool(self, admin_server: MCPServerUnderTest, tool_name: str) -> None:
+        assert tool_name in admin_server._tool_manager._tools
+
+
+# ---------------------------------------------------------------------------
+# 3. Argument validation matrix.
+# ---------------------------------------------------------------------------
+
+
+class TestMutationToolArgumentContracts:
+    """For every mutation tool: required kwargs are mandatory, the
+    happy path produces a structured JSON envelope, and at least one
+    invalid value produces a structured error envelope (no traceback).
+    """
+
+    @pytest.mark.parametrize("tool_name", sorted(MUTATION_TOOL_NAMES))
+    def test_tool_is_registered_and_discoverable(self, admin_server: MCPServerUnderTest, tool_name: str) -> None:
+        tool = admin_server._tool_manager._tools.get(tool_name)
+        assert tool is not None, f"{tool_name} missing from admin-role server"
+        assert callable(tool.fn)
+
+    @pytest.mark.parametrize(
+        "tool_name",
+        sorted(name for name in MUTATION_TOOL_NAMES if TOOL_MATRIX[name]["required"]),
+    )
+    def test_required_kwargs_are_mandatory(
+        self,
+        admin_server: MCPServerUnderTest,
+        patched_mutation_seam: Any,
+        tool_name: str,
+    ) -> None:
+        """Calling the tool with no kwargs at all must raise TypeError
+        for required parameters (FastMCP wraps the handler as a plain
+        coroutine; required params have no defaults).
+        """
+        del patched_mutation_seam  # ensure fixture is applied
+        fn = admin_server._tool_manager._tools[tool_name].fn
+        with pytest.raises(TypeError):
+            invoke_surface(fn)
+
+    @pytest.mark.parametrize("tool_name", sorted(MUTATION_TOOL_NAMES))
+    def test_happy_path_returns_json_envelope(
+        self,
+        admin_server: MCPServerUnderTest,
+        patched_mutation_seam: Any,
+        tool_name: str,
+    ) -> None:
+        """Happy path returns a JSON-parseable string. We do not pin
+        the full payload shape here — :mod:`test_envelope_contracts`
+        owns the registry-wide envelope rule. This pins that the tool
+        does not raise on a minimal valid input.
+        """
+        poly = patched_mutation_seam
+        _arrange_poly_for(poly, tool_name)
+        fn = admin_server._tool_manager._tools[tool_name].fn
+        kwargs = TOOL_MATRIX[tool_name]["happy"]
+        result = invoke_surface(fn, **kwargs)
+        assert isinstance(result, str)
+        parsed = json.loads(result)
+        assert isinstance(parsed, (dict, list))
+
+    @pytest.mark.parametrize(
+        "tool_name",
+        sorted(
+            name
+            for name in MUTATION_TOOL_NAMES
+            if "invalid_value" in TOOL_MATRIX[name] or "empty_string" in TOOL_MATRIX[name]
+        ),
+    )
+    def test_invalid_value_returns_structured_error(
+        self,
+        admin_server: MCPServerUnderTest,
+        patched_mutation_seam: Any,
+        tool_name: str,
+    ) -> None:
+        """Invalid value -> structured ``MCPErrorPayload`` (``error``,
+        ``is_error: true``). No raw traceback bubbling out."""
+        poly = patched_mutation_seam
+        _arrange_poly_for(poly, tool_name)
+        # record_correction's "bogus_kind" rejection happens in the
+        # operations layer (``UnknownCorrectionKindError``). Wire that
+        # into the mock so the MCP tool's error path is exercised.
+        if tool_name == "record_correction":
+            from polylogue.insights.feedback import UnknownCorrectionKindError
+
+            poly.record_correction = AsyncMock(side_effect=UnknownCorrectionKindError("bogus_kind"))
+        fn = admin_server._tool_manager._tools[tool_name].fn
+        kwargs = TOOL_MATRIX[tool_name].get("invalid_value") or TOOL_MATRIX[tool_name]["empty_string"]
+        # The contract is: invalid input becomes a structured error
+        # envelope OR a typed ``PolylogueError`` (FastMCP marshals the
+        # latter into ``isError=True`` for the MCP client). Either way,
+        # no raw traceback bubbles out.
+        from polylogue.errors import PolylogueError
+
+        try:
+            result = invoke_surface(fn, **kwargs)
+        except PolylogueError:
+            return
+        body = json.loads(result)
+        assert body.get("is_error") is True, f"{tool_name}: missing is_error in {body}"
+        assert "error" in body, f"{tool_name}: missing error in {body}"
+
+
+# ---------------------------------------------------------------------------
+# 4. Idempotency contract.
+#
+# Create-twice, delete-missing, and update-with-same-payload paths should
+# return a documented status/outcome envelope, not crash.
+# ---------------------------------------------------------------------------
+
+
+_IDEMPOTENT_CASES = [
+    # (tool_name, kwargs, mock_attr, first_return, second_return,
+    #  first_expected_outcome, second_expected_outcome)
+    pytest.param(
+        "add_tag",
+        {"conversation_id": _CONV_ID, "tag": "review"},
+        "add_tag",
+        TagMutationResult(outcome="added", detail=None),
+        TagMutationResult(outcome="no_op", detail="already_present"),
+        "added",
+        "no_op",
+        id="add_tag_twice",
+    ),
+    pytest.param(
+        "remove_tag",
+        {"conversation_id": _CONV_ID, "tag": "missing"},
+        "remove_tag",
+        TagMutationResult(outcome="not_present", detail="tag_absent"),
+        TagMutationResult(outcome="not_present", detail="tag_absent"),
+        "not_present",
+        "not_present",
+        id="remove_missing_tag",
+    ),
+    pytest.param(
+        "add_mark",
+        {"conversation_id": _CONV_ID, "mark_type": "star"},
+        "add_mark",
+        True,
+        False,
+        "added",
+        "no_op",
+        id="add_mark_twice",
+    ),
+    pytest.param(
+        "remove_mark",
+        {"conversation_id": _CONV_ID, "mark_type": "star"},
+        "remove_mark",
+        False,
+        False,
+        "not_present",
+        "not_present",
+        id="remove_missing_mark",
+    ),
+    pytest.param(
+        "save_annotation",
+        {
+            "annotation_id": "ann-1",
+            "conversation_id": _CONV_ID,
+            "note_text": "n",
+        },
+        "save_annotation",
+        True,
+        False,
+        "added",
+        "updated",
+        id="save_annotation_twice",
+    ),
+    pytest.param(
+        "delete_annotation",
+        {"annotation_id": "missing-ann"},
+        "delete_annotation",
+        False,
+        False,
+        None,
+        None,
+        id="delete_missing_annotation",
+    ),
+    pytest.param(
+        "delete_saved_view",
+        {"view_id": "missing-view"},
+        "delete_view",
+        False,
+        False,
+        None,
+        None,
+        id="delete_missing_saved_view",
+    ),
+    pytest.param(
+        "delete_recall_pack",
+        {"pack_id": "missing-pack"},
+        "delete_recall_pack",
+        False,
+        False,
+        None,
+        None,
+        id="delete_missing_recall_pack",
+    ),
+    pytest.param(
+        "delete_workspace",
+        {"workspace_id": "missing-ws"},
+        "delete_workspace",
+        False,
+        False,
+        None,
+        None,
+        id="delete_missing_workspace",
+    ),
+]
+
+
+class TestMutationToolIdempotency:
+    """Pin create-twice, delete-missing, and update-with-same-payload
+    behaviors so every mutation tool surfaces a documented outcome
+    rather than crashing or returning an inconsistent shape.
+    """
+
+    @pytest.mark.parametrize(
+        "tool_name,kwargs,mock_attr,first_return,second_return,first_outcome,second_outcome",
+        _IDEMPOTENT_CASES,
+    )
+    def test_idempotent_outcomes(
+        self,
+        admin_server: MCPServerUnderTest,
+        patched_mutation_seam: Any,
+        tool_name: str,
+        kwargs: dict[str, Any],
+        mock_attr: str,
+        first_return: Any,
+        second_return: Any,
+        first_outcome: str | None,
+        second_outcome: str | None,
+    ) -> None:
+        poly = patched_mutation_seam
+        # Need separate calls returning different values — patch via
+        # side_effect so the second invocation hits the second case.
+        method = AsyncMock(side_effect=[first_return, second_return])
+        setattr(poly, mock_attr, method)
+        # delete_recall_pack/delete_saved_view tool use poly.delete_view /
+        # poly.delete_recall_pack — already aliased above. For
+        # delete_annotation the tool calls poly.delete_annotation directly.
+
+        fn = admin_server._tool_manager._tools[tool_name].fn
+
+        first_result = json.loads(invoke_surface(fn, **kwargs))
+        second_result = json.loads(invoke_surface(fn, **kwargs))
+
+        assert "is_error" not in first_result, first_result
+        assert "is_error" not in second_result, second_result
+
+        # When an outcome name is declared, pin it on the relevant call.
+        if first_outcome is not None:
+            assert first_result.get("outcome") == first_outcome, first_result
+        if second_outcome is not None:
+            assert second_result.get("outcome") == second_outcome, second_result
+
+        # Both calls must surface a status field (documented envelope).
+        assert "status" in first_result
+        assert "status" in second_result
+
+    def test_delete_conversation_requires_confirm(
+        self,
+        admin_server: MCPServerUnderTest,
+        patched_mutation_seam: Any,
+    ) -> None:
+        """``delete_conversation`` without ``confirm=true`` must return a
+        structured error envelope (safety guard). Confirmed delete must
+        succeed and surface the documented outcome.
+        """
+        poly = patched_mutation_seam
+        poly.delete_conversation_safe = AsyncMock(
+            return_value=DeleteConversationResult(outcome="deleted", conversation_id=_CONV_ID)
+        )
+        fn = admin_server._tool_manager._tools["delete_conversation"].fn
+
+        # Without confirm.
+        unconfirmed = json.loads(invoke_surface(fn, conversation_id=_CONV_ID))
+        assert unconfirmed.get("is_error") is True
+        assert "error" in unconfirmed
+
+        # With confirm.
+        confirmed = json.loads(invoke_surface(fn, conversation_id=_CONV_ID, confirm=True))
+        assert "is_error" not in confirmed
+        assert confirmed.get("status") == "deleted"
+
+    def test_set_metadata_update_with_same_payload(
+        self,
+        admin_server: MCPServerUnderTest,
+        patched_mutation_seam: Any,
+    ) -> None:
+        """``set_metadata`` called twice with the same payload returns a
+        documented outcome rather than raising. The first call returns
+        ``outcome=set``, the second returns ``outcome=unchanged``.
+        """
+        poly = patched_mutation_seam
+        poly.set_metadata = AsyncMock(
+            side_effect=[
+                MetadataMutationResult(outcome="set", conversation_id=_CONV_ID, key="k"),
+                MetadataMutationResult(outcome="unchanged", conversation_id=_CONV_ID, key="k", detail="no_change"),
+            ]
+        )
+        fn = admin_server._tool_manager._tools["set_metadata"].fn
+
+        first = json.loads(invoke_surface(fn, conversation_id=_CONV_ID, key="k", value="v"))
+        second = json.loads(invoke_surface(fn, conversation_id=_CONV_ID, key="k", value="v"))
+
+        assert first.get("status") == "ok"
+        assert second.get("status") == "unchanged"
+
+
+# ---------------------------------------------------------------------------
+# Helpers.
+# ---------------------------------------------------------------------------
+
+
+def _arrange_poly_for(poly: Any, tool_name: str) -> None:
+    """Configure the polylogue facade mock with a sensible default
+    return value for the given tool so the happy-path test does not
+    blow up on missing attribute behaviour.
+    """
+    # Tools that are missing from the shared make_polylogue_mock seam.
+    # Wire each as an AsyncMock so ``await poly.method(...)`` succeeds.
+    poly.list_recall_packs = AsyncMock(return_value=[])
+    poly.create_recall_pack = AsyncMock(return_value=True)
+    poly.delete_recall_pack = AsyncMock(return_value=False)
+    poly.list_workspaces = AsyncMock(return_value=[])
+    poly.save_workspace = AsyncMock(return_value=True)
+    poly.delete_workspace = AsyncMock(return_value=False)
+    poly.record_correction = AsyncMock()
+    poly.list_corrections = AsyncMock(return_value=[])
+    poly.clear_corrections = AsyncMock(return_value=0)
+    poly.delete_correction = AsyncMock(return_value=False)
+    if tool_name == "add_tag":
+        poly.add_tag = AsyncMock(return_value=TagMutationResult(outcome="added"))
+    elif tool_name == "remove_tag":
+        poly.remove_tag = AsyncMock(return_value=TagMutationResult(outcome="removed"))
+    elif tool_name == "bulk_tag_conversations":
+        poly.bulk_tag_conversations = AsyncMock(
+            return_value=BulkTagMutationResult(conversation_count=1, tag_count=1, affected_count=1, skipped_count=0)
+        )
+    elif tool_name == "set_metadata":
+        poly.set_metadata = AsyncMock(
+            return_value=MetadataMutationResult(outcome="set", conversation_id=_CONV_ID, key="note")
+        )
+    elif tool_name == "delete_metadata":
+        poly.delete_metadata = AsyncMock(
+            return_value=MetadataMutationResult(outcome="deleted", conversation_id=_CONV_ID, key="note")
+        )
+    elif tool_name == "delete_conversation":
+        poly.delete_conversation_safe = AsyncMock(
+            return_value=DeleteConversationResult(outcome="deleted", conversation_id=_CONV_ID)
+        )
+    elif tool_name == "record_correction":
+        from polylogue.insights.feedback import CorrectionKind, LearningCorrection
+        from tests.infra.frozen_clock import fixed_now
+
+        poly.record_correction = AsyncMock(
+            return_value=LearningCorrection(
+                conversation_id=_CONV_ID,
+                kind=CorrectionKind.CLASSIFICATION_OVERRIDE,
+                payload={"label": "research"},
+                note=None,
+                created_at=fixed_now(),
+            )
+        )
+    elif tool_name == "list_corrections":
+        poly.list_corrections = AsyncMock(return_value=[])
+    elif tool_name == "clear_corrections":
+        poly.clear_corrections = AsyncMock(return_value=0)
+    elif tool_name == "save_workspace":
+        poly.save_workspace = AsyncMock(return_value=True)
+    elif tool_name == "save_recall_pack":
+        poly.create_recall_pack = AsyncMock(return_value=True)
+    elif tool_name == "save_saved_view":
+        poly.save_view = AsyncMock(return_value=True)
+    elif tool_name == "save_annotation":
+        poly.save_annotation = AsyncMock(return_value=True)
+    elif tool_name == "add_mark":
+        poly.add_mark = AsyncMock(return_value=True)


### PR DESCRIPTION
## Summary

Add `tests/unit/mcp/test_per_tool_contracts.py` — per-tool contract
coverage for the 26 `@mcp.tool()` handlers registered by
`polylogue.mcp.server_mutation_tools.register_mutation_tools` (marks,
annotations, saved views, recall packs, workspaces, tags, metadata,
delete_conversation, learning corrections).

## Problem

`tests/unit/mcp/test_envelope_contracts.py` proves payload shapes but
nobody proves error-handling, argument-validation, idempotency, or
per-tool authorization. #1294 calls out that:

- argument-validation matrix per mutation tool was missing,
- error-class assertions were missing,
- idempotency for create/delete pairs was unproven,
- authorization boundary (read role MUST reject every mutation tool)
  was implicit in `register_tools` but not asserted per tool, so a
  future regression that lifted any one tool out of the role gate
  would not fail.

## Solution

A single new test file parametrized over a dynamically discovered set
of mutation tool names:

- `_discover_mutation_tool_names()` computes the set difference between
  an admin-role FastMCP server and a read-role server, cross-checked
  against the `async def` names in `server_mutation_tools.py`. Adding
  a new `@mcp.tool()` to that module is automatically picked up.
- `TestMutationToolDiscovery` fails when the `TOOL_MATRIX` and the
  discovered set drift apart — a new tool without a row, or a stale
  row for a removed tool.
- `TestMutationToolAuthorization` parametrizes over every mutation
  tool and asserts (a) it is absent from a read-role server and (b)
  present in an admin-role server.
- `TestMutationToolArgumentContracts` proves each tool is registered
  and callable, that required kwargs are mandatory, that the
  happy-path returns a JSON envelope, and that invalid values become
  a structured `MCPErrorPayload` envelope or a typed `PolylogueError`
  (FastMCP marshals the latter into `isError=True`) — never a raw
  traceback.
- `TestMutationToolIdempotency` pins create-twice, delete-missing,
  and update-with-same-payload outcomes through `AsyncMock.side_effect`
  on the polylogue facade, plus a dedicated `delete_conversation`
  safety-guard test (`confirm=true` required) and a `set_metadata`
  update-with-same-payload outcome pin.

Tool-specific mock arrangement lives in `_arrange_poly_for()` —
extends the shared `make_polylogue_mock()` seam with the
recall-pack / workspace / learning-correction methods that are not
currently part of the shared mock surface.

## Verification

```
nix develop -c pytest tests/unit/mcp/test_per_tool_contracts.py
# 146 passed in 11.68s
nix develop -c mypy tests/unit/mcp/test_per_tool_contracts.py
# Success: no issues found in 1 source file
nix develop -c devtools verify --quick
# "exit_code": 0
```

Closes #1294