### PR TITLE
ci(pages): per-PR previews and versioned doc trees (#1307)

### DIFF
--- a/.github/workflows/pages-preview.yml
+++ b/.github/workflows/pages-preview.yml
@@ -1,0 +1,74 @@
+name: GitHub Pages Preview
+
+# Build the documentation site on every pull request that touches a docs or
+# render-pages surface, and upload the resulting site as a workflow artifact
+# so reviewers can download and inspect it locally.
+#
+# This is the per-PR artifact mode of #1307. Per-PR deployment to a real
+# preview URL (e.g. gh-pages /pr/NNN/) and versioned release trees
+# (/vX.Y.Z/) are deferred — both require switching the master pages.yml
+# from actions/deploy-pages (single-target Pages environment) to a
+# branch-based deploy. Tracked as follow-up issues.
+
+on:
+  pull_request:
+    paths:
+      - "docs/**"
+      - "devtools/render_pages.py"
+      - "devtools/render_*"
+      - ".github/workflows/pages-preview.yml"
+      - ".github/workflows/pages.yml"
+      - "README.md"
+      - "CONTRIBUTING.md"
+      - "TESTING.md"
+      - "CLAUDE.md"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pages-preview-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: cachix/install-nix-action@v31
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+
+      - name: Build site
+        run: nix develop --command devtools render-pages
+
+      - name: Upload preview artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs-site-preview-pr-${{ github.event.pull_request.number || github.run_id }}
+          path: .cache/site/
+          retention-days: 14
+          if-no-files-found: error
+
+      - name: Summary
+        run: |
+          {
+            echo "## Docs preview built"
+            echo ""
+            echo "The rendered site is uploaded as a workflow artifact:"
+            echo ""
+            echo "**docs-site-preview-pr-${{ github.event.pull_request.number || github.run_id }}**"
+            echo ""
+            echo "Download from the workflow run page, extract, and serve locally:"
+            echo ""
+            echo '```bash'
+            echo "unzip docs-site-preview-pr-*.zip -d /tmp/polylogue-docs"
+            echo "python -m http.server --directory /tmp/polylogue-docs 8000"
+            echo '```'
+            echo ""
+            echo "Per-PR live deployment and versioned /vX.Y.Z/ trees are tracked as"
+            echo "follow-ups to #1307."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -176,6 +176,28 @@ Pull requests should:
 Use `Ref #NNN` when the issue should stay open after merge, and `Closes #NNN`
 when the merge should close it.
 
+## Documentation Site Previews
+
+The documentation site (`devtools render-pages` → `.cache/site/`) is
+published to GitHub Pages on every push to `master` via
+`.github/workflows/pages.yml`.
+
+PRs that touch docs, render-pages helpers, or top-level Markdown files
+trigger `.github/workflows/pages-preview.yml`, which rebuilds the site
+and uploads it as a workflow artifact named
+`docs-site-preview-pr-<NNN>`. Download the artifact from the PR's
+Checks → Pages Preview run, extract, and serve locally:
+
+```bash
+unzip docs-site-preview-pr-*.zip -d /tmp/polylogue-docs
+python -m http.server --directory /tmp/polylogue-docs 8000
+```
+
+Per-PR live preview URLs (`/pr/NNN/`) and versioned release trees
+(`/vX.Y.Z/`, plus a `/latest/` alias) are deferred follow-ups under
+#1307 — both require migrating `pages.yml` from the single-target
+`actions/deploy-pages` flow to a branch-based deploy.
+
 ## Repository Settings
 
 The repository should stay aligned with the workflow above:


### PR DESCRIPTION
## Summary

Adds `.github/workflows/pages-preview.yml` so every PR touching docs,
render-pages helpers, or top-level Markdown surfaces builds the
documentation site and uploads it as a downloadable workflow artifact
(`docs-site-preview-pr-<N>`, 14-day retention). CONTRIBUTING.md
documents the download flow and notes the deferred follow-ups.

## Problem

#1307 asks for (a) per-PR preview deployments, (b) preview cleanup on
close, (c) versioned `/vX.Y.Z/` release trees with a `/latest/` alias,
and (d) docs explaining the URL mapping.

The existing `pages.yml` uses `actions/deploy-pages` against the
GitHub-managed `github-pages` environment, which is a **single-target
deployment surface** — every successful deploy atomically replaces the
entire site. There is no per-prefix overlay, so per-PR previews and
versioned trees both require migrating the deploy path off
`actions/deploy-pages` to a `gh-pages` branch-based publisher
(`peaceiris/actions-gh-pages` or equivalent). That migration is a
larger change with its own risk surface (branch protection, history,
404 routing, root-`index.html` switcher) and should not piggy-back on
this PR.

## Solution

- New workflow `pages-preview.yml` runs on `pull_request` filtered to
  docs/render-pages paths. Runs `devtools render-pages`, uploads the
  resulting `.cache/site/` as an artifact, and writes a job summary
  with the artifact name and a local-serve snippet.
- `concurrency` is keyed on `github.ref` so successive pushes to the
  same PR cancel earlier builds.
- `CONTRIBUTING.md` gains a "Documentation Site Previews" section that
  explains the artifact flow and explicitly calls out the deferred
  follow-ups under #1307.
- Master deploy path in `pages.yml` is untouched — no risk of regressing
  the existing auto-publish.

Scope decisions (commented on #1307):

- **Shipped:** per-PR artifact preview + contributor docs.
- **Deferred (will file follow-ups):** per-PR live URLs (`/pr/NNN/`),
  preview cleanup on close, versioned `/vX.Y.Z/` trees, `/latest/`
  alias, version switcher. All require migrating off
  `actions/deploy-pages` to a branch-based deploy.

## Verification

```
nix develop --command devtools verify-ci-workflows
  → verify-ci-workflows: 17 workflow files checked, no errors

nix run nixpkgs#actionlint -- .github/workflows/pages-preview.yml
  → (no output — clean)

nix develop --command devtools render-pages
  → Site built: .cache/site

nix develop --command devtools render-all --check
  → OK: .cache/site matches sources.
```

Ref #1307