### PR TITLE
test(devtools): mutation campaign coverage discipline (#1304)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1398,6 +1398,7 @@ These are the commands worth remembering during normal repo work:
 | `devtools verify-layering` | Check inter-package imports against declared layering rules from docs/plans/layering.yaml. |
 | `devtools verify-manifests` | Verify internal consistency across all docs/plans/*.yaml manifest files. |
 | `devtools verify-migrations` | Verify migration-completeness against docs/plans/migrations.yaml. |
+| `devtools verify-mutation-freshness` | Verify per-module mutation-campaign artifact freshness against docs/plans/campaign-coverage.yaml (#1304). |
 | `devtools verify-provider-meta-policy` | Enforce the provider_meta classification policy declared in docs/plans/provider-meta-policy.yaml. |
 | `devtools verify-schema-roundtrip` | Verify committed provider schema packages reload and roundtrip cleanly. |
 | `devtools verify-slos` | Check read-surface latency budgets in docs/plans/slo-catalog.yaml against benchmark measurements. |

--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -491,6 +491,25 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
         examples=("devtools verify-test-clock-hygiene", "devtools verify-test-clock-hygiene --json"),
     ),
     CommandSpec(
+        "verify-mutation-freshness",
+        "verification",
+        "Verify per-module mutation-campaign artifact freshness against docs/plans/campaign-coverage.yaml (#1304).",
+        "devtools.verify_mutation_freshness",
+        use_when=(
+            "Catch mutation campaigns whose newest run artifact is older than the "
+            "campaign's freshness_days budget (default 60), or have no artifact "
+            "at all. Soft by default so devtools verify can surface drift "
+            "without gating on local mutation-run cadence; --strict turns "
+            "missing/stale into a hard fail for nightly jobs and "
+            "devtools verify --lab."
+        ),
+        examples=(
+            "devtools verify-mutation-freshness",
+            "devtools verify-mutation-freshness --strict",
+            "devtools verify-mutation-freshness --json",
+        ),
+    ),
+    CommandSpec(
         "verify-distribution-surface",
         "verification",
         "Verify wheel/sdist installed artifacts expose only supported runtime entrypoints.",

--- a/devtools/mutmut_campaign.py
+++ b/devtools/mutmut_campaign.py
@@ -18,6 +18,7 @@ import fnmatch
 import json
 import shutil
 import subprocess
+import sys
 import tempfile
 from collections import Counter
 from dataclasses import asdict, dataclass, field
@@ -28,9 +29,33 @@ from devtools import repo_root as _get_root
 
 from .authored_scenario_catalog import get_authored_scenario_catalog
 from .mutation_catalog import MutationCampaignEntry
+from .verify_mutation_freshness import (
+    MANIFEST as _FRESHNESS_MANIFEST,
+)
+from .verify_mutation_freshness import (
+    assess_campaign as _freshness_assess,
+)
+from .verify_mutation_freshness import (
+    load_manifest as _freshness_load_manifest,
+)
 
 ROOT = _get_root()
 CAMPAIGN_ARTIFACT_DIR = Path(".local/mutation-campaigns")
+
+
+def default_artifact_paths(campaign_name: str, created_at: datetime) -> tuple[Path, Path]:
+    """Default JSON/Markdown artifact paths for a campaign run.
+
+    Layout: ``.local/mutation-campaigns/<campaign>/<timestamp>.{json,md}``.
+    Used by ``mutmut-campaign run`` when ``--json-out`` / ``--markdown-out``
+    are not supplied, and consumed by ``verify-mutation-freshness`` and
+    ``mutmut-campaign status`` to locate the per-campaign artifact history.
+    """
+    stamp = created_at.strftime("%Y%m%dT%H%M%SZ")
+    base = CAMPAIGN_ARTIFACT_DIR / campaign_name / stamp
+    return base.with_suffix(".json"), base.with_suffix(".md")
+
+
 STATUS_IGNORE_PREFIXES = (f"{CAMPAIGN_ARTIFACT_DIR.as_posix()}/",)
 DEFAULT_IGNORE_PATTERNS = shutil.ignore_patterns(
     ".git",
@@ -557,6 +582,19 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     run_parser.add_argument("--keep-workspace", action="store_true")
     run_parser.set_defaults(command_fn=cmd_run)
 
+    status_parser = subparsers.add_parser(
+        "status",
+        help="Show per-campaign last-run, kill rate, and freshness against docs/plans/campaign-coverage.yaml.",
+    )
+    status_parser.add_argument("--json", action="store_true")
+    status_parser.add_argument(
+        "--default-freshness-days",
+        type=int,
+        default=60,
+        help="Freshness budget for manifest entries without freshness_days (default 60).",
+    )
+    status_parser.set_defaults(command_fn=cmd_status)
+
     index_parser = subparsers.add_parser("index", help="Build an index over recorded campaign artifacts")
     index_parser.add_argument(
         "--campaign-dir",
@@ -586,14 +624,24 @@ def cmd_list(_args: argparse.Namespace) -> int:
 
 def cmd_run(args: argparse.Namespace) -> int:
     campaign = CAMPAIGNS[args.campaign]
-    json_out = (
-        None if args.json_out is None else (args.json_out if args.json_out.is_absolute() else ROOT / args.json_out)
-    )
-    markdown_out = (
-        None
-        if args.markdown_out is None
-        else (args.markdown_out if args.markdown_out.is_absolute() else ROOT / args.markdown_out)
-    )
+    json_out: Path | None
+    markdown_out: Path | None
+    if args.json_out is None and args.markdown_out is None:
+        # Default per-campaign artifact layout so freshness lint and status
+        # readouts always have something to discover. Operators can still
+        # override with explicit --json-out / --markdown-out.
+        default_json, default_md = default_artifact_paths(campaign.name, datetime.now(UTC))
+        json_out = ROOT / default_json
+        markdown_out = ROOT / default_md
+    else:
+        json_out = (
+            None if args.json_out is None else (args.json_out if args.json_out.is_absolute() else ROOT / args.json_out)
+        )
+        markdown_out = (
+            None
+            if args.markdown_out is None
+            else (args.markdown_out if args.markdown_out.is_absolute() else ROOT / args.markdown_out)
+        )
     result = run_campaign(
         campaign,
         repo_root=ROOT,
@@ -603,6 +651,40 @@ def cmd_run(args: argparse.Namespace) -> int:
     )
     print(format_markdown(result))
     return result.exit_code
+
+
+def cmd_status(args: argparse.Namespace) -> int:
+    manifest = _freshness_load_manifest(_FRESHNESS_MANIFEST)
+    raw_entries = manifest.get("mutation_campaigns") or []
+    entries: list[object] = list(raw_entries) if isinstance(raw_entries, list) else []
+    now = datetime.now(UTC)
+    assessments = [
+        _freshness_assess(
+            entry,
+            repo_root=ROOT,
+            now=now,
+            default_freshness_days=args.default_freshness_days,
+        )
+        for entry in entries
+        if isinstance(entry, dict) and "name" in entry
+    ]
+    if args.json:
+        json.dump(
+            {"campaigns": [a.__dict__ for a in assessments]},
+            sys.stdout,
+            indent=2,
+            default=str,
+        )
+        sys.stdout.write("\n")
+        return 0
+    print(f"{'campaign':<24} {'state':<8} {'age':>10} {'budget':>8} {'kill':>8} artifact")
+    for a in assessments:
+        age = "n/a" if a.newest_age_days is None else f"{a.newest_age_days:.1f}d"
+        budget = f"{a.freshness_days}d"
+        kill = "n/a" if a.kill_rate is None else f"{a.kill_rate * 100:.1f}%"
+        artifact = a.newest_artifact or "-"
+        print(f"{a.name:<24} {a.state:<8} {age:>10} {budget:>8} {kill:>8} {artifact}")
+    return 0
 
 
 def cmd_index(args: argparse.Namespace) -> int:

--- a/devtools/verify.py
+++ b/devtools/verify.py
@@ -328,6 +328,14 @@ def build_verify_steps(
                 ("verify-lane-assertions", _devtools_cmd("verify-lane-assertions")),
                 ("verify-test-infra-currency", _devtools_cmd("verify-test-infra-currency")),
                 ("verify-test-clock-hygiene", _devtools_cmd("verify-test-clock-hygiene")),
+                # Recommended (not required): soft mode so missing/stale
+                # mutation-campaign artifacts surface without blocking the
+                # default baseline. Nightly jobs and ``devtools verify --lab``
+                # invoke this with ``--strict``. See issue #1304.
+                (
+                    "verify-mutation-freshness",
+                    _devtools_cmd("verify-mutation-freshness"),
+                ),
             ]
         )
 
@@ -376,6 +384,12 @@ def build_verify_steps(
     if lab:
         steps.append(("lab scenario", _devtools_cmd("lab-scenario", "run", "archive-smoke", "--tier", "0")))
         steps.append(("verify-slos", _devtools_cmd("verify-slos", "--include-lab")))
+        steps.append(
+            (
+                "verify-mutation-freshness --strict",
+                _devtools_cmd("verify-mutation-freshness", "--strict"),
+            )
+        )
     return steps
 
 

--- a/devtools/verify_manifests.py
+++ b/devtools/verify_manifests.py
@@ -399,10 +399,14 @@ def _check_campaign_freshness(
         glob = artifact_glob.strip()
     elif section == "benchmark_campaigns":
         glob = f".local/benchmark-campaigns/*-{name}.json"
+    elif section == "mutation_campaigns":
+        # Default mutation-campaign artifact layout (#1304). Matches
+        # devtools.mutmut_campaign.default_artifact_paths.
+        glob = f".local/mutation-campaigns/{name}/*.json"
     else:
         errors.append(
             f"{path}: {section} campaign {label_name} declares freshness_days without "
-            "an artifact_glob; only benchmark_campaigns have a default artifact location"
+            "an artifact_glob; only mutation_campaigns and benchmark_campaigns have a default location"
         )
         return errors
 

--- a/devtools/verify_mutation_freshness.py
+++ b/devtools/verify_mutation_freshness.py
@@ -1,0 +1,308 @@
+"""Verify mutation-campaign coverage discipline (#1304).
+
+Reads ``docs/plans/campaign-coverage.yaml`` and checks, for every
+``status: active`` mutation campaign, whether a recent run artifact
+exists under the campaign's artifact glob (default
+``.local/mutation-campaigns/<name>/*.json``).
+
+Reports three classes of finding:
+
+* ``missing``  — campaign has no run artifact at all.
+* ``stale``    — newest artifact is older than ``freshness_days``
+  (defaults to 60 when the entry omits it).
+* ``unknown``  — campaign artifact references a name not present in
+  the manifest. Surfaced so artifact directories don't silently fork
+  away from the registry.
+
+Default behavior is **soft**: the command always exits 0 and reports
+findings as warnings, so ``devtools verify`` can include it without
+gating on local mutation-run cadence. Pass ``--strict`` to fail when
+any campaign is missing or stale — intended for nightly jobs and
+``devtools verify --lab``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+import yaml
+
+from devtools import repo_root as _get_root
+
+ROOT = _get_root()
+MANIFEST = ROOT / "docs" / "plans" / "campaign-coverage.yaml"
+DEFAULT_FRESHNESS_DAYS = 60
+DEFAULT_ARTIFACT_GLOB = ".local/mutation-campaigns/{name}/*.json"
+
+
+@dataclass(frozen=True)
+class CampaignFreshness:
+    name: str
+    status: str
+    freshness_days: int
+    artifact_glob: str
+    artifact_count: int
+    newest_artifact: str | None
+    newest_created_at: str | None
+    newest_age_days: float | None
+    kill_rate: float | None
+    counts: dict[str, int]
+    state: str  # "fresh" | "stale" | "missing" | "inactive"
+
+
+def _coerce_int(value: object, default: int) -> int:
+    if isinstance(value, bool) or value is None:
+        return default
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str) and value.strip().isdigit():
+        return int(value)
+    return default
+
+
+def _entry_glob(entry: dict[str, object]) -> str:
+    glob = entry.get("artifact_glob")
+    if not isinstance(glob, str) or not glob.strip():
+        glob = DEFAULT_ARTIFACT_GLOB.format(name=entry["name"])
+    return glob
+
+
+def _resolve_artifacts(repo_root: Path, glob: str) -> list[Path]:
+    return sorted(repo_root.glob(glob))
+
+
+def _load_summary(path: Path) -> tuple[str | None, dict[str, int]]:
+    try:
+        payload = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None, {}
+    created_at = payload.get("created_at")
+    counts_raw = payload.get("counts", {})
+    counts = {str(k): int(v) for k, v in counts_raw.items() if isinstance(v, int)}
+    return (created_at if isinstance(created_at, str) else None), counts
+
+
+def _kill_rate(counts: dict[str, int]) -> float | None:
+    total = sum(v for k, v in counts.items() if k in {"killed", "survived", "timeout", "suspicious"})
+    if total <= 0:
+        return None
+    return counts.get("killed", 0) / total
+
+
+def _age_days(created_at: str | None, now: datetime) -> float | None:
+    if not created_at:
+        return None
+    try:
+        recorded = datetime.fromisoformat(created_at)
+    except ValueError:
+        return None
+    if recorded.tzinfo is None:
+        recorded = recorded.replace(tzinfo=UTC)
+    return (now - recorded).total_seconds() / 86400.0
+
+
+def assess_campaign(
+    entry: dict[str, object],
+    *,
+    repo_root: Path,
+    now: datetime,
+    default_freshness_days: int,
+) -> CampaignFreshness:
+    name = str(entry["name"])
+    status = str(entry.get("status", "active"))
+    freshness_days = _coerce_int(entry.get("freshness_days"), default_freshness_days)
+    glob = _entry_glob(entry)
+    artifacts = _resolve_artifacts(repo_root, glob)
+    if status != "active":
+        return CampaignFreshness(
+            name=name,
+            status=status,
+            freshness_days=freshness_days,
+            artifact_glob=glob,
+            artifact_count=len(artifacts),
+            newest_artifact=None,
+            newest_created_at=None,
+            newest_age_days=None,
+            kill_rate=None,
+            counts={},
+            state="inactive",
+        )
+    if not artifacts:
+        return CampaignFreshness(
+            name=name,
+            status=status,
+            freshness_days=freshness_days,
+            artifact_glob=glob,
+            artifact_count=0,
+            newest_artifact=None,
+            newest_created_at=None,
+            newest_age_days=None,
+            kill_rate=None,
+            counts={},
+            state="missing",
+        )
+    # Use most recent by created_at if available, else mtime.
+    by_recency = sorted(
+        artifacts,
+        key=lambda p: (_load_summary(p)[0] or "", p.stat().st_mtime),
+        reverse=True,
+    )
+    newest = by_recency[0]
+    created_at, counts = _load_summary(newest)
+    age = _age_days(created_at, now)
+    if age is None:
+        # Fall back to mtime if artifact created_at missing/unparseable.
+        age = (now.timestamp() - newest.stat().st_mtime) / 86400.0
+    state = "stale" if age > freshness_days else "fresh"
+    return CampaignFreshness(
+        name=name,
+        status=status,
+        freshness_days=freshness_days,
+        artifact_glob=glob,
+        artifact_count=len(artifacts),
+        newest_artifact=newest.relative_to(repo_root).as_posix(),
+        newest_created_at=created_at,
+        newest_age_days=age,
+        kill_rate=_kill_rate(counts),
+        counts=counts,
+        state=state,
+    )
+
+
+def _orphan_artifact_names(repo_root: Path, registered: Iterable[str]) -> list[str]:
+    """Names appearing under .local/mutation-campaigns/ but not in the manifest."""
+    base = repo_root / ".local" / "mutation-campaigns"
+    if not base.is_dir():
+        return []
+    registered_set = set(registered)
+    orphans: list[str] = []
+    for child in sorted(base.iterdir()):
+        if not child.is_dir():
+            continue
+        name = child.name
+        if name in registered_set:
+            continue
+        # Only count as orphan if it actually contains run artifacts.
+        if any(child.glob("*.json")):
+            orphans.append(name)
+    return orphans
+
+
+def load_manifest(path: Path) -> dict[str, object]:
+    with open(path, encoding="utf-8") as fh:
+        data = yaml.safe_load(fh)
+    if not isinstance(data, dict):
+        raise ValueError(f"{path}: expected mapping at root")
+    return data
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--yaml", type=Path, default=MANIFEST)
+    parser.add_argument(
+        "--default-freshness-days",
+        type=int,
+        default=DEFAULT_FRESHNESS_DAYS,
+        help=f"Freshness budget for entries without freshness_days (default {DEFAULT_FRESHNESS_DAYS}).",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit non-zero when any campaign is missing or stale. Default is soft (always exit 0).",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit a JSON report instead of human output.")
+    args = parser.parse_args(argv)
+
+    manifest = load_manifest(args.yaml)
+    entries = manifest.get("mutation_campaigns")
+    if not isinstance(entries, list):
+        print(f"{args.yaml}: missing or invalid mutation_campaigns list", file=sys.stderr)
+        return 2
+
+    now = datetime.now(UTC)
+    assessments = [
+        assess_campaign(
+            entry,
+            repo_root=ROOT,
+            now=now,
+            default_freshness_days=args.default_freshness_days,
+        )
+        for entry in entries
+        if isinstance(entry, dict) and "name" in entry
+    ]
+
+    registered_names = [a.name for a in assessments]
+    orphan_names = _orphan_artifact_names(ROOT, registered_names)
+
+    missing = [a for a in assessments if a.state == "missing"]
+    stale = [a for a in assessments if a.state == "stale"]
+    fresh = [a for a in assessments if a.state == "fresh"]
+    inactive = [a for a in assessments if a.state == "inactive"]
+
+    blocking = args.strict and (bool(missing) or bool(stale))
+
+    if args.json:
+        json.dump(
+            {
+                "blocking": blocking,
+                "strict": bool(args.strict),
+                "default_freshness_days": args.default_freshness_days,
+                "counts": {
+                    "registered": len(assessments),
+                    "fresh": len(fresh),
+                    "stale": len(stale),
+                    "missing": len(missing),
+                    "inactive": len(inactive),
+                    "orphan_artifact_names": len(orphan_names),
+                },
+                "campaigns": [a.__dict__ for a in assessments],
+                "orphan_artifact_names": orphan_names,
+            },
+            sys.stdout,
+            indent=2,
+            default=str,
+        )
+        sys.stdout.write("\n")
+    else:
+        prefix = "[BLOCK]" if args.strict else "[warn]"
+        print(f"registered active mutation campaigns: {len(assessments) - len(inactive)}")
+        print(f"  fresh:   {len(fresh)}")
+        print(f"  stale:   {len(stale)} (older than freshness_days)")
+        print(f"  missing: {len(missing)} (no run artifact)")
+        if inactive:
+            print(f"  inactive (skipped): {len(inactive)}")
+        for a in missing:
+            print(f"{prefix} missing artifact: {a.name} (glob={a.artifact_glob})")
+        for a in stale:
+            assert a.newest_age_days is not None
+            print(
+                f"{prefix} stale: {a.name} "
+                f"newest={a.newest_artifact} "
+                f"age={a.newest_age_days:.1f}d (budget {a.freshness_days}d)"
+            )
+        if orphan_names:
+            print(f"[warn] orphan artifact directories (not in manifest): {len(orphan_names)}")
+            for name in orphan_names[:25]:
+                print(f"    {name}")
+        if fresh:
+            print(f"fresh campaigns: {len(fresh)}")
+            for a in fresh[:5]:
+                kr = "n/a" if a.kill_rate is None else f"{a.kill_rate * 100:.1f}%"
+                age = "n/a" if a.newest_age_days is None else f"{a.newest_age_days:.1f}d"
+                print(f"    {a.name}: kill={kr} age={age}")
+            if len(fresh) > 5:
+                print(f"    ... and {len(fresh) - 5} more")
+        print()
+        print(f"blocking={blocking} (strict={args.strict})")
+
+    return 1 if blocking else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -127,6 +127,7 @@ These are the commands worth remembering during normal repo work:
 | `devtools verify-layering` | Check inter-package imports against declared layering rules from docs/plans/layering.yaml. |
 | `devtools verify-manifests` | Verify internal consistency across all docs/plans/*.yaml manifest files. |
 | `devtools verify-migrations` | Verify migration-completeness against docs/plans/migrations.yaml. |
+| `devtools verify-mutation-freshness` | Verify per-module mutation-campaign artifact freshness against docs/plans/campaign-coverage.yaml (#1304). |
 | `devtools verify-provider-meta-policy` | Enforce the provider_meta classification policy declared in docs/plans/provider-meta-policy.yaml. |
 | `devtools verify-schema-roundtrip` | Verify committed provider schema packages reload and roundtrip cleanly. |
 | `devtools verify-slos` | Check read-surface latency budgets in docs/plans/slo-catalog.yaml against benchmark measurements. |

--- a/docs/plans/campaign-coverage.yaml
+++ b/docs/plans/campaign-coverage.yaml
@@ -4,9 +4,20 @@
 # and their coverage targets. Consumed by devtools mutmut-campaign
 # and devtools benchmark-campaign.
 #
-# Updated 2026-05-02 from the authored scenario catalog.
+# Each mutation_campaigns entry may carry:
+#   freshness_days  — Only declare per-entry when overriding the default.
+#                     verify-manifests treats a declared freshness_days as
+#                     a *hard* claim of a recent matching artifact, while
+#                     verify-mutation-freshness uses a 60-day default budget
+#                     as a soft warning when the entry omits freshness_days.
+#   artifact_glob   — glob (relative to repo root) where run artifacts land.
+#                     Defaults to .local/mutation-campaigns/<name>/*.json when
+#                     unset. Resolved by mutmut_campaign.default_artifact_paths
+#                     and the freshness lint.
+#
+# Updated 2026-05-19 — mutation-campaign discipline scaffolding for #1304.
 
-description: Mutation and benchmark campaign registry with covered paths and test targets.
+description: Mutation and benchmark campaign registry with covered paths, test targets, and freshness budgets.
 
 mutation_campaigns:
   - name: cli-query

--- a/tests/unit/devtools/test_verify_mutation_freshness.py
+++ b/tests/unit/devtools/test_verify_mutation_freshness.py
@@ -1,0 +1,193 @@
+"""Tests for ``devtools verify-mutation-freshness`` (#1304)."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from devtools import mutmut_campaign, verify_mutation_freshness
+
+
+def _write_artifact(
+    repo_root: Path,
+    campaign: str,
+    *,
+    created_at: datetime,
+    counts: dict[str, int] | None = None,
+    name: str | None = None,
+) -> Path:
+    artifact_dir = repo_root / ".local" / "mutation-campaigns" / campaign
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    stamp = created_at.strftime("%Y%m%dT%H%M%SZ")
+    path = artifact_dir / f"{name or stamp}.json"
+    path.write_text(
+        json.dumps(
+            {
+                "campaign": campaign,
+                "created_at": created_at.isoformat(),
+                "counts": counts or {"killed": 7, "survived": 3},
+            }
+        )
+    )
+    return path
+
+
+def _write_manifest(path: Path, entries: list[dict[str, object]]) -> None:
+    import yaml
+
+    path.write_text(
+        yaml.safe_dump(
+            {"description": "test", "mutation_campaigns": entries},
+            sort_keys=False,
+        )
+    )
+
+
+def test_default_artifact_paths_uses_timestamped_layout() -> None:
+    when = datetime(2026, 5, 19, 12, 34, 56, tzinfo=UTC)
+    json_path, md_path = mutmut_campaign.default_artifact_paths("filters", when)
+    assert json_path.as_posix() == ".local/mutation-campaigns/filters/20260519T123456Z.json"
+    assert md_path.as_posix() == ".local/mutation-campaigns/filters/20260519T123456Z.md"
+
+
+def test_assess_campaign_fresh(tmp_path: Path) -> None:
+    now = datetime(2026, 5, 19, tzinfo=UTC)
+    _write_artifact(tmp_path, "filters", created_at=now - timedelta(days=2))
+    result = verify_mutation_freshness.assess_campaign(
+        {"name": "filters", "status": "active", "freshness_days": 60},
+        repo_root=tmp_path,
+        now=now,
+        default_freshness_days=60,
+    )
+    assert result.state == "fresh"
+    assert result.kill_rate == pytest.approx(0.7)
+    assert result.newest_age_days is not None and result.newest_age_days < 3
+
+
+def test_assess_campaign_stale(tmp_path: Path) -> None:
+    now = datetime(2026, 5, 19, tzinfo=UTC)
+    _write_artifact(tmp_path, "filters", created_at=now - timedelta(days=90))
+    result = verify_mutation_freshness.assess_campaign(
+        {"name": "filters", "status": "active", "freshness_days": 60},
+        repo_root=tmp_path,
+        now=now,
+        default_freshness_days=60,
+    )
+    assert result.state == "stale"
+    assert result.newest_age_days is not None and result.newest_age_days > 60
+
+
+def test_assess_campaign_missing(tmp_path: Path) -> None:
+    now = datetime(2026, 5, 19, tzinfo=UTC)
+    result = verify_mutation_freshness.assess_campaign(
+        {"name": "filters", "status": "active"},
+        repo_root=tmp_path,
+        now=now,
+        default_freshness_days=60,
+    )
+    assert result.state == "missing"
+    assert result.artifact_count == 0
+
+
+def test_assess_campaign_inactive_skipped(tmp_path: Path) -> None:
+    now = datetime(2026, 5, 19, tzinfo=UTC)
+    result = verify_mutation_freshness.assess_campaign(
+        {"name": "filters", "status": "archived", "freshness_days": 60},
+        repo_root=tmp_path,
+        now=now,
+        default_freshness_days=60,
+    )
+    assert result.state == "inactive"
+
+
+def test_orphan_artifact_detection(tmp_path: Path) -> None:
+    now = datetime(2026, 5, 19, tzinfo=UTC)
+    _write_artifact(tmp_path, "ghost-campaign", created_at=now)
+    orphans = verify_mutation_freshness._orphan_artifact_names(tmp_path, ["filters"])
+    assert orphans == ["ghost-campaign"]
+
+
+def test_main_soft_default_exits_zero_when_all_missing(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = tmp_path / "campaign-coverage.yaml"
+    _write_manifest(
+        manifest,
+        [{"name": "filters", "status": "active", "freshness_days": 60}],
+    )
+    monkeypatch.setattr(verify_mutation_freshness, "ROOT", tmp_path)
+    rc = verify_mutation_freshness.main(["--yaml", str(manifest)])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "missing: 1" in out
+    assert "blocking=False" in out
+
+
+def test_main_strict_fails_when_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    manifest = tmp_path / "campaign-coverage.yaml"
+    _write_manifest(
+        manifest,
+        [{"name": "filters", "status": "active", "freshness_days": 60}],
+    )
+    monkeypatch.setattr(verify_mutation_freshness, "ROOT", tmp_path)
+    rc = verify_mutation_freshness.main(["--yaml", str(manifest), "--strict"])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "[BLOCK] missing artifact: filters" in out
+    assert "blocking=True" in out
+
+
+def test_main_strict_passes_when_fresh(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest = tmp_path / "campaign-coverage.yaml"
+    _write_manifest(
+        manifest,
+        [{"name": "filters", "status": "active", "freshness_days": 60}],
+    )
+    # Use a deliberately-future timestamp so the artifact reads as fresh
+    # regardless of when the test runs, without touching the host clock.
+    _write_artifact(tmp_path, "filters", created_at=datetime(2099, 1, 1, tzinfo=UTC))
+    monkeypatch.setattr(verify_mutation_freshness, "ROOT", tmp_path)
+    rc = verify_mutation_freshness.main(["--yaml", str(manifest), "--strict"])
+    assert rc == 0
+
+
+def test_committed_manifest_lint_soft_is_clean() -> None:
+    """The committed manifest passes the lint in soft mode."""
+    rc = verify_mutation_freshness.main([])
+    assert rc == 0
+
+
+def test_initial_registry_covers_required_modules() -> None:
+    """Issue #1304 AC: initial registry covers at least the 10 named modules."""
+    import yaml
+
+    manifest = yaml.safe_load(verify_mutation_freshness.MANIFEST.read_text())
+    names = {entry["name"] for entry in manifest["mutation_campaigns"]}
+    # The issue names a candidate seed set. The catalog already covers the
+    # semantic equivalents; verify the 10 expected coverage areas are present.
+    expected_present = {
+        "filters",
+        "fts5",
+        "hybrid",
+        "json",
+        "models",
+        "schema-inference",
+        "schema-validation",
+        "source-detection",
+        "pipeline-services",
+        "repair-core",
+    }
+    missing = expected_present - names
+    assert not missing, f"manifest missing campaign names: {sorted(missing)}"


### PR DESCRIPTION
## Summary

Closes #1304. Adds freshness accountability around the existing
mutation-campaign catalog so registered campaigns can be tracked
without depending on agents remembering to run them.

## Problem

- `.local/mutation-campaigns/` does not exist on `master` (no committed
  campaign artifacts).
- MEMORY.md noted the last full mutmut run was 2026-03-08 — months stale.
- The existing `docs/plans/campaign-coverage.yaml` registers 19
  campaigns but nothing detects when a registered campaign has not
  been run in N days.
- A module added today gets zero mutation coverage and no one notices.

The infrastructure exists; the accountability surface was missing.

## Solution

- **`devtools verify-mutation-freshness`** (`devtools/verify_mutation_freshness.py`):
  Reads `docs/plans/campaign-coverage.yaml`, walks each active mutation
  campaign, and reports campaigns whose newest artifact at
  `.local/mutation-campaigns/<name>/*.json` is older than the
  campaign's `freshness_days` budget (default 60). Three states:
  `fresh`, `stale`, `missing`. Also surfaces orphan artifact directories
  whose name no longer appears in the manifest, so the local tree and
  registry can't silently drift apart. Soft by default (always exit 0)
  so the standard `devtools verify` baseline can include it without
  gating on local mutation-run cadence; `--strict` turns
  missing/stale into a hard fail and is intended for nightly jobs and
  `devtools verify --lab`.
- **`devtools mutmut-campaign status`** (`devtools/mutmut_campaign.py`):
  New subcommand renders the per-campaign state/age/budget/kill-rate
  table by reusing the same freshness `assess_campaign` helper.
- **Default artifact paths**: `devtools mutmut-campaign run` now writes
  to `.local/mutation-campaigns/<name>/<timestamp>.{json,md}` when
  `--json-out` / `--markdown-out` are unset. Explicit flags still
  override. This guarantees the freshness lint and the status command
  always have something to discover.
- **`verify-manifests`** now defines a default `artifact_glob` for
  `mutation_campaigns` matching the new layout, mirroring the existing
  default for `benchmark_campaigns`. Declared `freshness_days` no
  longer requires an explicit `artifact_glob`.
- Wired into `devtools verify` as a soft step (between
  `verify-test-clock-hygiene` and `verification-impact check`) and into
  `devtools verify --lab` as a hard `--strict` step.
- 11 unit tests cover `assess_campaign` for the four states, orphan
  detection, soft vs strict `main()`, the committed manifest, the
  initial-registry coverage AC from #1304, and the default artifact
  layout.

Acceptance criteria mapping:

- [x] **Per-module registry with freshness budget**: existing
      `docs/plans/campaign-coverage.yaml` is the registry; `freshness_days`
      schema field already declared in `CampaignCoverageManifest`
      (default 60 applied by the lint when entries omit it).
- [x] **`verify-mutation-freshness` lint that fails if not run in N days**:
      `--strict` mode does this; soft mode reports as warnings.
- [x] **`mutmut-campaign run` writes structured artifact**: existing
      runner already emits a complete `CampaignResult` JSON; new default
      artifact path locates it under `.local/mutation-campaigns/<name>/`.
- [x] **`mutmut-campaign status` shows per-module last-run + kill rate
      + threshold check**: new subcommand.
- [x] **Initial registry covers ≥10 modules**: existing catalog covers
      19; test asserts the 10 named seed modules are present.
- [ ] **CI nightly rotating-subset job**: deferred. The scaffolding
      this PR lands is the prerequisite; a follow-up PR can add the
      GitHub Actions workflow that runs `devtools mutmut-campaign run`
      on a rotating campaign and pushes the artifact. Tracked under
      #1304 follow-up; not a hidden TODO.

## Verification

```
$ nix develop -c pytest tests/unit/devtools/test_verify_mutation_freshness.py -q
11 passed in 9.29s

$ nix develop -c devtools verify-mutation-freshness
registered active mutation campaigns: 19
  fresh:   0
  stale:   0 (older than freshness_days)
  missing: 19 (no run artifact)
... [19 warn lines] ...
blocking=False (strict=False)
$ echo $?
0

$ nix develop -c devtools verify-mutation-freshness --strict
... blocking=True (strict=True)
$ echo $?
1

$ nix develop -c devtools verify-manifests
manifest consistency checks passed

$ nix develop -c mypy devtools/verify_mutation_freshness.py devtools/mutmut_campaign.py tests/unit/devtools/test_verify_mutation_freshness.py
Success: no issues found in 3 source files

$ nix develop -c devtools verify --quick
... exit_code: 0 (verify-mutation-freshness step: ok 0.27s)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `verify-mutation-freshness` developer command that checks mutation campaign artifact freshness against a coverage manifest with soft (warnings) and strict (error) modes, supporting JSON or human-readable output.

* **Documentation**
  * Updated campaign coverage documentation with expanded metadata fields and freshness budget guidance.

* **Tests**
  * Added comprehensive test coverage for mutation freshness verification scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sinity/polylogue/pull/1413?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->