### PR TITLE
feat(dist): publish polylogue-mcp and polylogue-hooks as separate PyPI packages (#1309)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,16 +63,42 @@ jobs:
         run: |
           version=$(uv run python -c "import tomllib, pathlib; print(tomllib.loads(pathlib.Path('pyproject.toml').read_text())['project']['version'])")
           echo "version=${version}" >> "${GITHUB_OUTPUT}"
+      - name: Build polylogue-mcp wrapper distribution (#1309)
+        run: |
+          uv build --out-dir "${RUNNER_TEMP}/dist-mcp" packaging/polylogue-mcp
+          uv run --with twine python -m twine check "${RUNNER_TEMP}/dist-mcp"/*.whl "${RUNNER_TEMP}/dist-mcp"/*.tar.gz
+      - name: Build polylogue-hooks wrapper distribution (#1309)
+        run: |
+          uv build --out-dir "${RUNNER_TEMP}/dist-hooks" packaging/polylogue-hooks
+          uv run --with twine python -m twine check "${RUNNER_TEMP}/dist-hooks"/*.whl "${RUNNER_TEMP}/dist-hooks"/*.tar.gz
       - name: Stage top-level wheel + sdist for downstream jobs
         run: |
           mkdir -p staged-dist
           cp "${RUNNER_TEMP}/dist/dist"/*.whl staged-dist/
           cp "${RUNNER_TEMP}/dist/dist"/*.tar.gz staged-dist/
           ls -la staged-dist/
+      - name: Stage polylogue-mcp + polylogue-hooks wrapper distributions
+        run: |
+          mkdir -p staged-dist-mcp staged-dist-hooks
+          cp "${RUNNER_TEMP}/dist-mcp"/*.whl staged-dist-mcp/
+          cp "${RUNNER_TEMP}/dist-mcp"/*.tar.gz staged-dist-mcp/
+          cp "${RUNNER_TEMP}/dist-hooks"/*.whl staged-dist-hooks/
+          cp "${RUNNER_TEMP}/dist-hooks"/*.tar.gz staged-dist-hooks/
+          ls -la staged-dist-mcp/ staged-dist-hooks/
       - uses: actions/upload-artifact@v7
         with:
           name: distribution-artifacts
           path: staged-dist/*
+          if-no-files-found: error
+      - uses: actions/upload-artifact@v7
+        with:
+          name: distribution-artifacts-mcp
+          path: staged-dist-mcp/*
+          if-no-files-found: error
+      - uses: actions/upload-artifact@v7
+        with:
+          name: distribution-artifacts-hooks
+          path: staged-dist-hooks/*
           if-no-files-found: error
 
   installed-smoke:
@@ -124,6 +150,105 @@ jobs:
           polylogue --plain count
           python -m polylogue --version
 
+  installed-smoke-hooks:
+    # polylogue-hooks has no runtime dependencies, so this smoke installs the
+    # wrapper wheel in isolation (no polylogue, no third-party packages) and
+    # exercises the polylogue-hook console script end-to-end (#1309).
+    name: installed-smoke-hooks (${{ matrix.os }}, py${{ matrix.python-version }})
+    needs: build
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        python-version: ["3.11", "3.12", "3.13"]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: distribution-artifacts-hooks
+          path: dist-hooks/
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install polylogue-hooks wheel into fresh venv (no other deps)
+        shell: bash
+        run: |
+          python -m venv .venv-hooks
+          # shellcheck disable=SC1091
+          source .venv-hooks/bin/activate
+          python -m pip install --upgrade pip
+          wheel=$(ls dist-hooks/*.whl | head -n1)
+          python -m pip install "${wheel}"
+          # Confirm zero third-party runtime closure (only pip/setuptools/wheel + polylogue-hooks).
+          python -m pip list --format=freeze | sort > installed.txt
+          cat installed.txt
+          if grep -vE '^(pip|setuptools|wheel|polylogue-hooks)==' installed.txt; then
+            echo "polylogue-hooks pulled an unexpected runtime dependency" >&2
+            exit 1
+          fi
+      - name: Exercise polylogue-hook console script
+        shell: bash
+        run: |
+          # shellcheck disable=SC1091
+          source .venv-hooks/bin/activate
+          sidecar="${RUNNER_TEMP}/polylogue-hooks-sidecar"
+          mkdir -p "${sidecar}"
+          export POLYLOGUE_HOOK_SIDECAR_DIR="${sidecar}"
+          # Supported event must succeed and write a JSONL record.
+          printf '{"session_id":"abc123","model":"sonnet"}' | polylogue-hook SessionStart
+          test -f "${sidecar}/claude-code-abc123.jsonl"
+          grep -q '"event_type": "SessionStart"' "${sidecar}/claude-code-abc123.jsonl"
+          # Unsupported event must exit non-zero without crashing the harness.
+          if printf '{}' | polylogue-hook NotARealEvent; then
+            echo "polylogue-hook should have rejected an unknown event type" >&2
+            exit 1
+          fi
+
+  installed-smoke-mcp:
+    # polylogue-mcp is a thin wrapper that pins the matching polylogue release.
+    # Install both wheels together and confirm the console script resolves
+    # exactly the same target the full polylogue install does (#1309).
+    name: installed-smoke-mcp (${{ matrix.os }}, py${{ matrix.python-version }})
+    needs: build
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        python-version: ["3.11", "3.12", "3.13"]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: distribution-artifacts
+          path: dist/
+      - uses: actions/download-artifact@v8
+        with:
+          name: distribution-artifacts-mcp
+          path: dist-mcp/
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install polylogue + polylogue-mcp wrapper into fresh venv
+        shell: bash
+        run: |
+          python -m venv .venv-mcp
+          # shellcheck disable=SC1091
+          source .venv-mcp/bin/activate
+          python -m pip install --upgrade pip
+          main_wheel=$(ls dist/*.whl | head -n1)
+          mcp_wheel=$(ls dist-mcp/*.whl | head -n1)
+          python -m pip install "${main_wheel}" "${mcp_wheel}"
+      - name: Smoke polylogue-mcp wrapper console script
+        shell: bash
+        env:
+          POLYLOGUE_FORCE_PLAIN: "1"
+        run: |
+          # shellcheck disable=SC1091
+          source .venv-mcp/bin/activate
+          polylogue-mcp --help > /dev/null
+
   sbom:
     name: sbom
     needs: build
@@ -163,7 +288,7 @@ jobs:
 
   publish-pypi:
     name: publish-pypi
-    needs: [build, installed-smoke, sbom]
+    needs: [build, installed-smoke, installed-smoke-mcp, installed-smoke-hooks, sbom]
     if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish == 'true')
     timeout-minutes: 15
     runs-on: ubuntu-latest
@@ -193,6 +318,84 @@ jobs:
         # in the dist/ directory. The .sigstore bundles are retained as the
         # `signing-artifacts-publish-pypi` workflow artifact attached to the
         # run by sigstore/gh-action-sigstore-python.
+        run: |
+          find dist/ -type f ! \( -name '*.whl' -o -name '*.tar.gz' \) -delete
+          ls -la dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true
+          verbose: true
+
+  publish-pypi-mcp:
+    # Independent Trusted Publisher binding on PyPI is required for this
+    # project name. Register it once via PyPI → Publishing → Add a new pending
+    # publisher with owner=Sinity, repo=polylogue, workflow=release.yml,
+    # environment=pypi-mcp before the first tagged release reaches this job.
+    name: publish-pypi-mcp
+    needs: [build, installed-smoke-mcp, sbom]
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish == 'true')
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi-mcp
+      url: https://pypi.org/project/polylogue-mcp/${{ needs.build.outputs.version }}/
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: distribution-artifacts-mcp
+          path: dist/
+      - name: List artifacts about to be signed and published
+        run: ls -la dist/
+      - name: Sign wheel + sdist with Sigstore (keyless OIDC)
+        uses: sigstore/gh-action-sigstore-python@v3.0.0
+        with:
+          inputs: |
+            ./dist/*.whl
+            ./dist/*.tar.gz
+          upload-signing-artifacts: true
+      - name: Drop Sigstore bundles before PyPI upload
+        run: |
+          find dist/ -type f ! \( -name '*.whl' -o -name '*.tar.gz' \) -delete
+          ls -la dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true
+          verbose: true
+
+  publish-pypi-hooks:
+    # Independent Trusted Publisher binding on PyPI is required for this
+    # project name. Register it once via PyPI → Publishing → Add a new pending
+    # publisher with owner=Sinity, repo=polylogue, workflow=release.yml,
+    # environment=pypi-hooks before the first tagged release reaches this job.
+    name: publish-pypi-hooks
+    needs: [build, installed-smoke-hooks, sbom]
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish == 'true')
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi-hooks
+      url: https://pypi.org/project/polylogue-hooks/${{ needs.build.outputs.version }}/
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: distribution-artifacts-hooks
+          path: dist/
+      - name: List artifacts about to be signed and published
+        run: ls -la dist/
+      - name: Sign wheel + sdist with Sigstore (keyless OIDC)
+        uses: sigstore/gh-action-sigstore-python@v3.0.0
+        with:
+          inputs: |
+            ./dist/*.whl
+            ./dist/*.tar.gz
+          upload-signing-artifacts: true
+      - name: Drop Sigstore bundles before PyPI upload
         run: |
           find dist/ -type f ! \( -name '*.whl' -o -name '*.tar.gz' \) -delete
           ls -la dist/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -269,6 +269,28 @@ Pull requests should:
 Use `Ref #NNN` when the issue should stay open after merge, and `Closes #NNN`
 when the merge should close it.
 
+## Documentation Site Previews
+
+The documentation site (`devtools render-pages` → `.cache/site/`) is
+published to GitHub Pages on every push to `master` via
+`.github/workflows/pages.yml`.
+
+PRs that touch docs, render-pages helpers, or top-level Markdown files
+trigger `.github/workflows/pages-preview.yml`, which rebuilds the site
+and uploads it as a workflow artifact named
+`docs-site-preview-pr-<NNN>`. Download the artifact from the PR's
+Checks → Pages Preview run, extract, and serve locally:
+
+```bash
+unzip docs-site-preview-pr-*.zip -d /tmp/polylogue-docs
+python -m http.server --directory /tmp/polylogue-docs 8000
+```
+
+Per-PR live preview URLs (`/pr/NNN/`) and versioned release trees
+(`/vX.Y.Z/`, plus a `/latest/` alias) are deferred follow-ups under
+#1307 — both require migrating `pages.yml` from the single-target
+`actions/deploy-pages` flow to a branch-based deploy.
+
 ## Repository Settings
 
 The repository should stay aligned with the workflow above:

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -108,6 +108,22 @@ sidecar_dir = "/home/user/.local/share/polylogue/hooks"
 | `hooks_enabled` | `bool` | `False` |
 | `hooks_sidecar_dir` | `str` | `~/.local/share/polylogue/hooks` |
 
+## Installation
+
+`polylogue-hook` is available in three forms:
+
+| Form | Install | Runtime deps |
+| --- | --- | --- |
+| Standalone PyPI package | `pip install polylogue-hooks` | none (stdlib only) |
+| Bundled in main package | `pip install polylogue` | full archive runtime |
+| Bash script | copy `contrib/polylogue-hook` from the repository | `bash`, `python3` |
+
+The `polylogue-hooks` package is the recommended path for environments where
+you do not want the full polylogue runtime closure (for example, inside the AI
+coding agent's own Python environment). The script behaviour is identical
+across all three forms and the version is kept in sync with the main package
+via release-please (#1309).
+
 ## Setup
 
 ### Claude Code

--- a/docs/release.md
+++ b/docs/release.md
@@ -97,6 +97,22 @@ PyPI Trusted Publishing requires a one-time registration on pypi.org under
 is missing the publish step fails with an OIDC error and the tag must be
 re-cut after re-running the workflow.
 
+The same release tag also publishes the wrapper distributions
+[`polylogue-mcp`](https://pypi.org/project/polylogue-mcp/) and
+[`polylogue-hooks`](https://pypi.org/project/polylogue-hooks/) (#1309). Each
+PyPI project needs its own Trusted Publisher binding:
+
+| PyPI project       | `environment`   | Wraps                                       |
+| ------------------ | --------------- | ------------------------------------------- |
+| `polylogue`        | `pypi`          | full archive runtime (CLI + daemon + MCP)   |
+| `polylogue-mcp`    | `pypi-mcp`      | `polylogue-mcp` console script (pins `polylogue==X.Y.Z`) |
+| `polylogue-hooks`  | `pypi-hooks`    | `polylogue-hook` console script (zero runtime deps) |
+
+Register all three pending publishers before the first tagged release reaches
+the `publish-pypi-mcp` / `publish-pypi-hooks` jobs. Each registration uses the
+same `owner = Sinity`, `repo = polylogue`, `workflow = release.yml` triple and
+differs only in the `environment` name.
+
 Sigstore keyless signing requires no project-side configuration; it derives
 identity from the workflow's `id-token: write` OIDC claim and publishes to
 the public Sigstore transparency log. Consumers can verify the bundle with
@@ -118,6 +134,11 @@ polylogue-X.Y.Z-py3-none-any.whl polylogue-X.Y.Z-py3-none-any.whl.sigstore`.
       `podman pull` succeeds.
 - [ ] Smoke `pip install polylogue==X.Y.Z` in a clean venv and run
       `polylogue --help`, `polylogued --help`, `polylogue-mcp --help`.
+- [ ] Smoke `pip install polylogue-mcp==X.Y.Z` in a clean venv and confirm
+      `polylogue-mcp --help` works (pins the matching `polylogue==X.Y.Z`).
+- [ ] Smoke `pip install polylogue-hooks==X.Y.Z` in a clean venv and confirm
+      `polylogue-hook SessionStart` accepts a sample JSON payload on stdin.
+      `pip list` should show only `polylogue-hooks` plus pip/setuptools/wheel.
 - [ ] Smoke the container: `podman run --rm
       ghcr.io/sinity/polylogue:X.Y.Z polylogue --version`.
 - [ ] Confirm the `signing-artifacts-publish-pypi` workflow artifact on the

--- a/packaging/polylogue-hooks/README.md
+++ b/packaging/polylogue-hooks/README.md
@@ -1,0 +1,25 @@
+# polylogue-hooks
+
+Hook adapter for [Polylogue](https://github.com/sinity/polylogue) — captures
+Claude Code and Codex session lifecycle events into the Polylogue daemon's
+sidecar directory.
+
+This distribution is a pure-stdlib Python implementation of the
+`polylogue-hook` console script. It has **no runtime dependencies** and is safe
+to install in minimal environments (e.g. inside the AI coding agent's own
+runtime) without pulling the full `polylogue` archive substrate.
+
+```bash
+pip install polylogue-hooks
+
+# Wire into Claude Code settings.json:
+# "hooks": {
+#   "SessionStart": [{"hooks": [{"type": "command", "command": "polylogue-hook SessionStart"}]}]
+# }
+```
+
+The bash equivalent under `contrib/polylogue-hook` in the main repository
+remains supported for operators who prefer a shell-only install path.
+
+See [docs/hooks.md](https://github.com/sinity/polylogue/blob/master/docs/hooks.md)
+for the full event catalog, sidecar layout, and configuration.

--- a/packaging/polylogue-hooks/pyproject.toml
+++ b/packaging/polylogue-hooks/pyproject.toml
@@ -1,0 +1,42 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "polylogue-hooks"
+version = "0.1.0"  # x-release-please-version
+description = "Polylogue hook adapter for Claude Code / Codex session lifecycle capture"
+readme = "README.md"
+license = { text = "MIT" }
+keywords = ["polylogue", "claude-code", "codex", "hooks", "ai", "archive"]
+authors = [{ name = "Sinity" }]
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Environment :: Console",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: MIT License",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Topic :: Software Development :: Libraries",
+]
+requires-python = ">=3.11"
+# Pure-stdlib implementation: zero runtime dependencies so the hook adapter can
+# be installed in environments that do not want the full polylogue runtime.
+dependencies = []
+
+[project.urls]
+Homepage = "https://github.com/sinity/polylogue"
+Repository = "https://github.com/sinity/polylogue"
+Issues = "https://github.com/sinity/polylogue/issues"
+Documentation = "https://github.com/sinity/polylogue/blob/master/docs/hooks.md"
+
+[project.scripts]
+polylogue-hook = "polylogue_hooks.cli:main"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/polylogue_hooks"]
+
+[tool.hatch.build.targets.sdist]
+include = ["pyproject.toml", "README.md", "src/polylogue_hooks"]

--- a/packaging/polylogue-hooks/src/polylogue_hooks/__init__.py
+++ b/packaging/polylogue-hooks/src/polylogue_hooks/__init__.py
@@ -1,0 +1,13 @@
+"""Polylogue hook adapter — AI coding agent session lifecycle capture.
+
+This package ships the ``polylogue-hook`` console script as a pure-stdlib
+Python implementation so it can be installed without pulling the full
+``polylogue`` runtime closure. The bash equivalent under
+``contrib/polylogue-hook`` in the main repository remains supported for
+operators who prefer a shell-only install path.
+"""
+
+from __future__ import annotations
+
+__all__ = ["__version__"]
+__version__ = "0.1.0"  # x-release-please-version

--- a/packaging/polylogue-hooks/src/polylogue_hooks/cli.py
+++ b/packaging/polylogue-hooks/src/polylogue_hooks/cli.py
@@ -1,0 +1,140 @@
+"""``polylogue-hook`` console-script entrypoint.
+
+Receives a hook event type as ``argv[1]`` and the event payload on stdin as
+JSON. Emits one enriched JSONL record to the Polylogue hook sidecar directory
+where the daemon watcher picks it up.
+
+Mirrors the behaviour of ``contrib/polylogue-hook`` in the main repository so
+that ``pip install polylogue-hooks`` provides the same surface without any
+dependency on the main ``polylogue`` distribution.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Supported event types — kept in sync with docs/hooks.md in the main repo.
+_CLAUDE_CODE_EVENTS = frozenset(
+    {
+        "SessionStart",
+        "Setup",
+        "UserPromptSubmit",
+        "PreToolUse",
+        "PostToolUse",
+        "PostToolUseFailure",
+        "PermissionRequest",
+        "PermissionDenied",
+        "Notification",
+        "Elicitation",
+        "ElicitationResult",
+        "CwdChanged",
+        "FileChanged",
+        "WorktreeCreate",
+        "SubagentStart",
+        "Stop",
+    }
+)
+_CODEX_EVENTS = frozenset(
+    {
+        "SessionStart",
+        "UserPromptSubmit",
+        "PreToolUse",
+        "PostToolUse",
+        "PermissionRequest",
+        "Stop",
+    }
+)
+_ALL_EVENTS = _CLAUDE_CODE_EVENTS | _CODEX_EVENTS
+
+
+def _default_sidecar_dir() -> Path:
+    override = os.environ.get("POLYLOGUE_HOOK_SIDECAR_DIR")
+    if override:
+        return Path(override)
+    xdg_data_home = os.environ.get("XDG_DATA_HOME")
+    base = Path(xdg_data_home) if xdg_data_home else Path.home() / ".local" / "share"
+    return base / "polylogue" / "hooks"
+
+
+def _detect_provider(payload: dict[str, object]) -> str | None:
+    forced = os.environ.get("POLYLOGUE_HOOK_PROVIDER")
+    if forced:
+        return forced
+    if "permission_mode" in payload or "model" in payload:
+        return "claude-code"
+    if "source" in payload:
+        return "codex"
+    return None
+
+
+def _extract_session_id(payload: dict[str, object]) -> str | None:
+    for key in ("session_id", "sessionId", "session"):
+        val = payload.get(key)
+        if isinstance(val, str) and val.strip():
+            return val.strip()
+    return None
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    if not args:
+        print("Usage: polylogue-hook <event-type>", file=sys.stderr)
+        return 1
+
+    event_type = args[0]
+    if event_type not in _ALL_EVENTS:
+        print(f"polylogue-hook: unsupported event type: {event_type}", file=sys.stderr)
+        return 2
+
+    try:
+        payload_text = sys.stdin.read()
+    except (OSError, KeyboardInterrupt) as exc:
+        print(f"polylogue-hook: failed to read stdin: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        payload = json.loads(payload_text)
+    except json.JSONDecodeError as exc:
+        print(f"polylogue-hook: invalid JSON payload: {exc}", file=sys.stderr)
+        return 1
+
+    if not isinstance(payload, dict):
+        print("polylogue-hook: payload must be a JSON object", file=sys.stderr)
+        return 1
+
+    session_id = _extract_session_id(payload)
+    if not session_id:
+        print("polylogue-hook: could not extract session_id from payload", file=sys.stderr)
+        return 1
+
+    provider = _detect_provider(payload)
+    if provider not in ("claude-code", "codex"):
+        print(
+            "polylogue-hook: could not detect provider; set POLYLOGUE_HOOK_PROVIDER=claude-code|codex",
+            file=sys.stderr,
+        )
+        return 1
+
+    record = {
+        "event_type": event_type,
+        "session_id": session_id,
+        "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "provider": provider,
+        "payload": payload,
+    }
+
+    sidecar_dir = _default_sidecar_dir()
+    sidecar_dir.mkdir(parents=True, exist_ok=True)
+    outfile = sidecar_dir / f"{provider}-{session_id}.jsonl"
+    with outfile.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(record, ensure_ascii=False, default=str) + "\n")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packaging/polylogue-mcp/README.md
+++ b/packaging/polylogue-mcp/README.md
@@ -1,0 +1,23 @@
+# polylogue-mcp
+
+MCP server entrypoint for the [Polylogue](https://github.com/sinity/polylogue)
+AI chat archive.
+
+This distribution is a thin wrapper that pins the matching `polylogue` release
+and re-exports the `polylogue-mcp` console script. Install it when you want the
+MCP stdio bridge installed under a stable, narrowly-scoped name without typing
+out the full `polylogue` package name.
+
+```bash
+pip install polylogue-mcp
+polylogue-mcp --help
+```
+
+Note: the runtime dependency closure is identical to `pip install polylogue`
+today, because the MCP server reuses the archive substrate (storage, search,
+repository). Future releases may split runtime dependencies further; the
+PyPI name `polylogue-mcp` is reserved for that direction.
+
+See the [main repository](https://github.com/sinity/polylogue) and the
+[architecture overview](https://github.com/sinity/polylogue/blob/master/docs/architecture.md#3-surfaces)
+for the MCP server's contract surface and tool inventory.

--- a/packaging/polylogue-mcp/pyproject.toml
+++ b/packaging/polylogue-mcp/pyproject.toml
@@ -1,0 +1,49 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "polylogue-mcp"
+version = "0.1.0"  # x-release-please-version
+description = "MCP server entrypoint for the Polylogue AI chat archive"
+readme = "README.md"
+license = { text = "MIT" }
+keywords = ["ai", "mcp", "model-context-protocol", "polylogue", "archive"]
+authors = [{ name = "Sinity" }]
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Environment :: Console",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: MIT License",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Topic :: Software Development :: Libraries",
+]
+requires-python = ">=3.11"
+# Thin wrapper distribution: re-exports the polylogue-mcp console script from
+# the main polylogue distribution. The version pin matches release-please's
+# synchronized X.Y.Z bump across the polylogue, polylogue-mcp, and
+# polylogue-hooks packages (#1309).
+dependencies = [
+  "polylogue==0.1.0",  # x-release-please-version
+]
+
+[project.urls]
+Homepage = "https://github.com/sinity/polylogue"
+Repository = "https://github.com/sinity/polylogue"
+Issues = "https://github.com/sinity/polylogue/issues"
+Documentation = "https://github.com/sinity/polylogue/blob/master/docs/architecture.md"
+
+[project.scripts]
+polylogue-mcp = "polylogue.mcp.cli:main"
+
+[tool.hatch.build.targets.wheel]
+# No package content of our own — this wrapper exists solely to publish the
+# polylogue-mcp PyPI name with a pinned dependency on the main polylogue
+# distribution. The console script target lives in polylogue.mcp.cli.
+bypass-selection = true
+
+[tool.hatch.build.targets.sdist]
+include = ["pyproject.toml", "README.md"]

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -25,7 +25,11 @@
     ".": {
       "package-name": "polylogue",
       "changelog-path": "CHANGELOG.md",
-      "extra-files": []
+      "extra-files": [
+        "packaging/polylogue-mcp/pyproject.toml",
+        "packaging/polylogue-hooks/pyproject.toml",
+        "packaging/polylogue-hooks/src/polylogue_hooks/__init__.py"
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary

Add wrapper distributions under `packaging/` so users can install just the surface they need: `pip install polylogue-mcp` for the MCP stdio bridge, `pip install polylogue-hooks` for the Claude Code / Codex hook adapter, both alongside the existing full `pip install polylogue`.

## Problem

`polylogue-mcp` was bundled as one of three console scripts inside the main `polylogue` wheel, and `polylogue-hook` only shipped as a bash script under `contrib/`. Consumers using only the MCP server or only the hook adapter still had to install the full archive runtime closure (CLI + daemon + storage + Pydantic stack), and there was no PyPI surface for either entrypoint. #1309 carries forward the deferred follow-up from #1234 to give each surface its own PyPI project so install size matches install intent.

## Solution

**Wrapper layout (monorepo, Option B from #1309).** Source stays in the main `polylogue` package; thin wrapper pyproject.tomls under `packaging/<name>/` publish each entrypoint:

- `packaging/polylogue-mcp/pyproject.toml` — depends on `polylogue==X.Y.Z`, re-exports `polylogue-mcp = "polylogue.mcp.cli:main"`. Runtime closure matches the main package today (MCP reuses the archive substrate), but the PyPI name is reserved for future dep-narrowing.
- `packaging/polylogue-hooks/pyproject.toml` — owns its own `polylogue_hooks/cli.py` (pure-stdlib Python port of `contrib/polylogue-hook`). Zero runtime dependencies — safe to install inside the AI agent's own Python environment without pulling polylogue. The bash equivalent in `contrib/` and the bundled-in-`polylogue` form remain supported.

**Release automation (`.github/workflows/release.yml`):**

- `build` job builds + twine-checks all three distributions and uploads them as separate `distribution-artifacts{,-mcp,-hooks}` artifacts.
- New `installed-smoke-mcp` job installs `polylogue` + `polylogue-mcp` together and confirms `polylogue-mcp --help`. Matrix: Ubuntu + macOS × Py3.11/3.12/3.13.
- New `installed-smoke-hooks` job installs **only** the `polylogue-hooks` wheel into a fresh venv, asserts `pip list` shows nothing beyond pip/setuptools/wheel/polylogue-hooks (zero-dep claim verification), and exercises the `polylogue-hook` console script end-to-end including a write to the sidecar directory and a rejection of unsupported events.
- New `publish-pypi-mcp` and `publish-pypi-hooks` jobs sign and publish each wrapper under independent Trusted Publisher bindings (environments `pypi-mcp` / `pypi-hooks`).

**Version sync (`release-please-config.json`):** wrapper `pyproject.toml`s and `polylogue_hooks/__init__.py:__version__` carry `# x-release-please-version` markers, listed under `extra-files`. release-please's synchronized X.Y.Z bump covers all three projects in one release PR — no separate manifests, no version drift.

**Docs:** `docs/release.md` documents the per-package operator checklist and the one-time Trusted Publisher registrations (`pypi-mcp`, `pypi-hooks`). `docs/hooks.md` documents the three install forms (PyPI standalone / bundled / bash contrib).

## Verification

Local builds and isolated installs:

```
$ uv build --out-dir /tmp/wrap packaging/polylogue-mcp
Successfully built /tmp/wrap/polylogue_mcp-0.1.0.tar.gz
Successfully built /tmp/wrap/polylogue_mcp-0.1.0-py3-none-any.whl

$ uv build --out-dir /tmp/wrap packaging/polylogue-hooks
Successfully built /tmp/wrap/polylogue_hooks-0.1.0.tar.gz
Successfully built /tmp/wrap/polylogue_hooks-0.1.0-py3-none-any.whl
```

`polylogue-hooks` standalone install (no polylogue) writes a real sidecar record:

```
$ echo '{"session_id":"abc","model":"sonnet"}' | polylogue-hook SessionStart
$ cat $POLYLOGUE_HOOK_SIDECAR_DIR/claude-code-abc.jsonl
{"event_type": "SessionStart", "session_id": "abc", "timestamp": "...", "provider": "claude-code", "payload": {...}}
```

`polylogue-mcp` wrapper installed alongside the main wheel resolves the existing entrypoint:

```
$ polylogue-mcp --help
Usage: polylogue-mcp [OPTIONS]
  Start the Polylogue MCP stdio bridge.
  ...
```

Local gate:

```
$ devtools verify --quick
... total_duration_s: 45.13, exit_code: 0
```

## Follow-ups / Operator action

PyPI Trusted Publisher registration for the two new project names is a one-time setup step that must happen before the first tagged release reaches the `publish-pypi-mcp` / `publish-pypi-hooks` jobs. Steps in `docs/release.md`.

Closes #1309