### PR TITLE
fix(daemon): cap live full-ingest worker fanout

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -93,6 +93,7 @@ jobs:
           flavor: |
             suffix=${{ matrix.target == 'distroless' && '-distroless' || '' }},onlatest=true
           tags: |
+            type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=ref,event=tag

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1420,9 +1420,9 @@ These are the commands worth remembering during normal repo work:
 | `devtools verify-layering` | Check inter-package imports against declared layering rules from docs/plans/layering.yaml. |
 | `devtools verify-manifests` | Verify internal consistency across all docs/plans/*.yaml manifest files. |
 | `devtools verify-migrations` | Verify migration-completeness against docs/plans/migrations.yaml. |
-| `devtools verify-mutation-freshness` | Verify per-module mutation-campaign artifact freshness against docs/plans/campaign-coverage.yaml (#1304). |
 | `devtools verify-provider-meta-policy` | Enforce the provider_meta classification policy declared in docs/plans/provider-meta-policy.yaml. |
 | `devtools verify-schema-roundtrip` | Verify committed provider schema packages reload and roundtrip cleanly. |
+| `devtools verify-schema-upgrade-lane` | Verify any in-place schema upgrade helper has a paired driving test under tests/unit/storage/migrations/ (#1302). |
 | `devtools verify-slos` | Check read-surface latency budgets in docs/plans/slo-catalog.yaml against benchmark measurements. |
 | `devtools verify-suppressions` | Enforce suppression registry expiry dates from docs/plans/suppressions.yaml. |
 | `devtools verify-test-clock-hygiene` | Verify test files use the frozen_clock fixture instead of reading the host wall clock (#1300). |

--- a/Containerfile
+++ b/Containerfile
@@ -42,10 +42,11 @@ ARG POLYLOGUE_BUILD_DIRTY=False
 RUN python - <<PY
 from pathlib import Path
 
+commit = "${POLYLOGUE_BUILD_COMMIT}"
 dirty = "${POLYLOGUE_BUILD_DIRTY}".strip().lower() in {"1", "true", "yes"}
 Path("polylogue/_build_info.py").write_text(
     'from __future__ import annotations\n\n'
-    f'BUILD_COMMIT = "{POLYLOGUE_BUILD_COMMIT}"\n'
+    f'BUILD_COMMIT = "{commit}"\n'
     f'BUILD_DIRTY = {dirty}\n',
     encoding="utf-8",
 )

--- a/Containerfile
+++ b/Containerfile
@@ -153,6 +153,10 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 # Copy the installed Python environment and the console scripts from the
 # runtime stage. site-packages lives under /usr/local/lib/python3.13.
+COPY --from=runtime /usr/local/bin/python        /usr/local/bin/python
+COPY --from=runtime /usr/local/bin/python3       /usr/local/bin/python3
+COPY --from=runtime /usr/local/bin/python3.13    /usr/local/bin/python3.13
+COPY --from=runtime /usr/local/lib/libpython3.13.so.1.0 /usr/local/lib/libpython3.13.so.1.0
 COPY --from=runtime /usr/local/lib/python3.13 /usr/local/lib/python3.13
 COPY --from=runtime /usr/local/bin/polylogue       /usr/local/bin/polylogue
 COPY --from=runtime /usr/local/bin/polylogued      /usr/local/bin/polylogued

--- a/Containerfile
+++ b/Containerfile
@@ -37,6 +37,19 @@ COPY . /src
 
 # Build wheel into /dist. Hatchling embeds polylogue/_build_info.py via
 # hatch_build.py, so the resulting wheel knows its own version + commit.
+ARG POLYLOGUE_BUILD_COMMIT=container-build
+ARG POLYLOGUE_BUILD_DIRTY=False
+RUN python - <<PY
+from pathlib import Path
+
+dirty = "${POLYLOGUE_BUILD_DIRTY}".strip().lower() in {"1", "true", "yes"}
+Path("polylogue/_build_info.py").write_text(
+    'from __future__ import annotations\n\n'
+    f'BUILD_COMMIT = "{POLYLOGUE_BUILD_COMMIT}"\n'
+    f'BUILD_DIRTY = {dirty}\n',
+    encoding="utf-8",
+)
+PY
 RUN uv build --wheel --out-dir /dist /src
 
 # ---- runtime (default) --------------------------------------------------

--- a/polylogue/sources/live/batch_support.py
+++ b/polylogue/sources/live/batch_support.py
@@ -202,10 +202,12 @@ def _full_parse_progress_groups(paths: list[Path]) -> Iterable[list[Path]]:
 
 
 def _full_ingest_worker_count(records: list[RawConversationRecord]) -> int:
+    """Return the worker count for daemon live full-ingest batches."""
     return _select_ingest_worker_count(records, _live_full_ingest_worker_limit())
 
 
 def _live_full_ingest_worker_limit() -> int:
+    """Resolve the daemon live full-ingest worker cap from the environment."""
     raw_value = os.environ.get("POLYLOGUE_LIVE_FULL_INGEST_WORKERS")
     if raw_value is None or raw_value.strip() == "":
         return _DEFAULT_LIVE_FULL_INGEST_WORKERS

--- a/polylogue/sources/live/batch_support.py
+++ b/polylogue/sources/live/batch_support.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import os
 import time
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field
@@ -23,6 +24,7 @@ _LARGE_FULL_PARSE_PROGRESS_BYTES = 64 * 1024 * 1024
 _SMALL_FULL_PARSE_PROGRESS_MAX_BYTES = 256 * 1024 * 1024
 _SMALL_FULL_PARSE_PROGRESS_MAX_FILES = 256
 _STREAMING_FULL_INGEST_BYTES = 8 * 1024 * 1024
+_DEFAULT_LIVE_FULL_INGEST_WORKERS = 2
 
 
 class _FullIngestHeartbeat(Protocol):
@@ -200,7 +202,17 @@ def _full_parse_progress_groups(paths: list[Path]) -> Iterable[list[Path]]:
 
 
 def _full_ingest_worker_count(records: list[RawConversationRecord]) -> int:
-    return _select_ingest_worker_count(records, None)
+    return _select_ingest_worker_count(records, _live_full_ingest_worker_limit())
+
+
+def _live_full_ingest_worker_limit() -> int:
+    raw_value = os.environ.get("POLYLOGUE_LIVE_FULL_INGEST_WORKERS")
+    if raw_value is None or raw_value.strip() == "":
+        return _DEFAULT_LIVE_FULL_INGEST_WORKERS
+    try:
+        return max(1, int(raw_value))
+    except ValueError:
+        return _DEFAULT_LIVE_FULL_INGEST_WORKERS
 
 
 def _blob_copy_heartbeat(

--- a/tests/unit/sources/test_live_watcher.py
+++ b/tests/unit/sources/test_live_watcher.py
@@ -316,8 +316,9 @@ def test_cursor_migrates_size_only_rows(tmp_path: Path) -> None:
     assert {"byte_offset", "content_fingerprint", "source_name"}.issubset(columns)
 
 
-def test_live_full_ingest_uses_shared_worker_count_policy(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_live_full_ingest_caps_workers_below_batch_policy(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("polylogue.pipeline.services.ingest_batch._core.os.cpu_count", lambda: 16)
+    monkeypatch.delenv("POLYLOGUE_LIVE_FULL_INGEST_WORKERS", raising=False)
     records = [
         RawConversationRecord(
             raw_id=f"raw-{index}",
@@ -336,8 +337,25 @@ def test_live_full_ingest_uses_shared_worker_count_policy(monkeypatch: pytest.Mo
         acquired_at="2026-05-01T00:00:00+00:00",
     )
 
-    assert _full_ingest_worker_count(records) == 16
+    assert _full_ingest_worker_count(records) == 2
     assert _full_ingest_worker_count([giant]) == 1
+
+
+def test_live_full_ingest_worker_cap_can_be_overridden(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("polylogue.pipeline.services.ingest_batch._core.os.cpu_count", lambda: 16)
+    monkeypatch.setenv("POLYLOGUE_LIVE_FULL_INGEST_WORKERS", "4")
+    records = [
+        RawConversationRecord(
+            raw_id=f"raw-{index}",
+            provider_name="claude-code",
+            source_path=f"/tmp/session-{index}.jsonl",
+            blob_size=2 * 1024 * 1024,
+            acquired_at="2026-05-01T00:00:00+00:00",
+        )
+        for index in range(300)
+    ]
+
+    assert _full_ingest_worker_count(records) == 4
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Summary

Caps live full-ingest worker fanout to a conservative default of two workers, with POLYLOGUE_LIVE_FULL_INGEST_WORKERS as an explicit override. Also fixes the container wheel build path so Docker contexts without .git still embed mandatory build metadata, and syncs generated AGENTS.md after the repo render gate reported it stale.

Problem

On sinnix-prime, polylogued reached multi-GB cgroup memory and page-cache pressure while processing a very large production archive: a 54 GB SQLite DB plus a 421 GB blob store. The daemon live path reused the shared batch ingest worker policy, so startup catch-up over hundreds of changed files could fan out to CPU-count process workers. That is appropriate for explicit batch work, but too aggressive for an always-on user daemon.

The PR also exposed an inherited container CI failure already present on master: the Docker build context excludes .git while hatch_build.py requires either git metadata or an embedded polylogue/_build_info.py.

Solution

The live full-ingest helper now passes a daemon-specific worker limit into the shared worker-count policy. The default is two workers; operators can raise or lower it via POLYLOGUE_LIVE_FULL_INGEST_WORKERS. Giant one-record ingest still resolves to one worker through the existing shared policy.

For container builds, the builder stage now writes polylogue/_build_info.py from build args before uv build, preserving mandatory metadata in .git-less Docker contexts.

Verification

- direnv exec . pytest tests/unit/sources/test_live_watcher.py -q
  - 60 passed in 9.37s
- direnv exec . ruff check polylogue/sources/live/batch_support.py tests/unit/sources/test_live_watcher.py
  - All checks passed
- direnv exec . ruff format --check polylogue/sources/live/batch_support.py tests/unit/sources/test_live_watcher.py
  - 2 files already formatted
- git diff --check
  - passed
- .git-less wheel-build simulation with git archive + generated _build_info.py + uv build --wheel
  - Successfully built polylogue-0.1.0-py3-none-any.whl
- devtools render-all --check
  - OK: .cache/site matches sources
- pre-push quick gate
  - ruff format/check, mypy, render-all, verification-impact and repo verification checks passed; exit_code 0