### PR TITLE
fix(cli): accept cursor option in root callback

### DIFF
--- a/polylogue/cli/click_app.py
+++ b/polylogue/cli/click_app.py
@@ -124,6 +124,7 @@ def cli(
     since_session_id: str | None,
     since: str | None,
     until: str | None,
+    cursor: str | None,
     limit: int | None,
     offset: int,
     latest: bool,


### PR DESCRIPTION
Summary

Adds the missing `cursor` parameter to the root Click callback so registered root options and subcommands can be invoked under the current Click runtime.

Problem

`--cursor` is registered as a query option, so Click passes `cursor=` into `cli()`. The callback signature did not accept it, causing subcommands such as `polylogue status --format json`, `polylogue reset --help`, and `polylogue ingest --help` to fail before their own handlers ran.

Solution

Add the missing callback parameter. No behavior changes are made to cursor handling itself.

Verification

- `ruff format --check polylogue/cli/click_app.py`
- `ruff check polylogue/cli/click_app.py`
- `polylogue reset --help`
- `polylogue status --help`
- pre-push quick gate passed: ruff, mypy, render-all, topology/layering/file-budget/provider/schema/witness checks