### PR TITLE
fix(cli): allow status on large archives

### DIFF
--- a/polylogue/cli/commands/status.py
+++ b/polylogue/cli/commands/status.py
@@ -12,7 +12,9 @@ import click
 from polylogue.cli.shared.types import AppEnv
 
 _BUILTIN_DAEMON_URL = "http://127.0.0.1:8766"
+# Bare `polylogue` uses this as a quick probe before falling back to SQLite.
 _FAST_TIMEOUT_S = 1.0
+# Explicit status can wait for large archive health payloads (~20s observed).
 _FULL_TIMEOUT_S = 30.0
 
 

--- a/polylogue/cli/commands/status.py
+++ b/polylogue/cli/commands/status.py
@@ -13,7 +13,7 @@ from polylogue.cli.shared.types import AppEnv
 
 _BUILTIN_DAEMON_URL = "http://127.0.0.1:8766"
 _FAST_TIMEOUT_S = 1.0
-_FULL_TIMEOUT_S = 5.0
+_FULL_TIMEOUT_S = 30.0
 
 
 def _default_daemon_url() -> str:


### PR DESCRIPTION
Summary

Increase the explicit `polylogue status` daemon timeout so large live archives can return the real daemon status payload instead of falling back to a false no-daemon diagnostic.

Problem

On the live workstation archive, `/api/status` can take about 20s after a full rebuild while still returning a healthy daemon payload. The CLI used a 5s timeout for explicit `polylogue status --format json`, caught the timeout as a generic `OSError`, and reported `daemon_liveness=false` / `no_daemon` even though `polylogued.service` was running and listening.

Solution

Keep the bare-command fast probe at 1s, but raise the explicit status command timeout to 30s. Operator-requested status can wait for the complete archive health payload without changing fast startup behavior.

Verification

- `python - <<'PY' ...` import check confirmed `_FULL_TIMEOUT_S == 30.0` and `_FAST_TIMEOUT_S == 1.0`
- `python -m pytest tests/unit/cli/test_json_envelope_contract.py::TestStatusJsonContract -q` -> 2 passed
- pre-push quick gate -> all steps ok, total 44.0s

Note: a broader `tests/unit/cli` run remains red from unrelated existing help snapshot/plain-output/cursor failures on this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased daemon health check timeout to improve CLI stability and reduce premature fallback to local status handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sinity/polylogue/pull/1427?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->