### PR TITLE
perf(daemon): avoid virtual FTS status counts

### DIFF
--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -282,7 +282,13 @@ async def _periodic_convergence_check(
                 total_msgs = conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0]
                 if total_msgs == 0:
                     continue
-                fts_count = conn.execute("SELECT COUNT(*) FROM messages_fts").fetchone()[0]
+                fts_count = (
+                    conn.execute("SELECT COUNT(*) FROM messages_fts_docsize").fetchone()[0]
+                    if conn.execute(
+                        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='messages_fts_docsize'"
+                    ).fetchone()
+                    else 0
+                )
                 gap = total_msgs - fts_count
                 if gap > 0:
                     logger.warning(

--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -144,13 +144,6 @@ async def _ensure_fts_startup_readiness() -> None:
             logger.info("daemon: FTS rebuild complete.")
             return
 
-        ensure_fts_index_sync(conn)
-        # SIGKILL recovery: if any of the six FTS triggers are absent,
-        # a previous bulk-write window was killed between suspend and
-        # restore. ensure_fts_index_sync above re-created them, but the
-        # index itself may have drifted while writes landed without the
-        # trigger sync — rebuild to bring index and source rows back
-        # into agreement.
         missing_triggers = _missing_fts_triggers_sync(conn)
         if missing_triggers:
             logger.warning(
@@ -164,6 +157,7 @@ async def _ensure_fts_startup_readiness() -> None:
             logger.info("daemon: FTS trigger restore + rebuild complete.")
             return
 
+        ensure_fts_index_sync(conn)
         has_indexed_messages = conn.execute("SELECT 1 FROM messages_fts_docsize LIMIT 1").fetchone() is not None
         if has_indexable_messages and not has_indexed_messages:
             logger.warning("daemon: message FTS is empty while archive has messages. Rebuilding once.")

--- a/polylogue/daemon/convergence_stages.py
+++ b/polylogue/daemon/convergence_stages.py
@@ -60,12 +60,12 @@ def make_fts_stage(db_path: Path) -> ConvergenceStage:
                 total = int(conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0])
                 if total == 0:
                     return False
-                fts_count = int(conn.execute("SELECT COUNT(*) FROM messages_fts").fetchone()[0])
+                fts_count = _fts_doc_count(conn, "messages_fts_docsize")
                 if fts_count < total:
                     return True
-                if _table_exists(conn, "action_events") and _table_exists(conn, "action_events_fts"):
+                if _table_exists(conn, "action_events") and _table_exists(conn, "action_events_fts_docsize"):
                     action_total = int(conn.execute("SELECT COUNT(*) FROM action_events").fetchone()[0])
-                    action_fts_count = int(conn.execute("SELECT COUNT(*) FROM action_events_fts").fetchone()[0])
+                    action_fts_count = _fts_doc_count(conn, "action_events_fts_docsize")
                     return action_fts_count < action_total
                 return False
             finally:
@@ -90,7 +90,7 @@ def make_fts_stage(db_path: Path) -> ConvergenceStage:
                 total = int(conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0])
                 rebuild_fts_index_sync(conn)
                 conn.commit()
-                new_count = int(conn.execute("SELECT COUNT(*) FROM messages_fts").fetchone()[0])
+                new_count = _fts_doc_count(conn, "messages_fts_docsize")
                 logger.info("fts: rebuilt — %d/%d indexed", new_count, total)
                 return new_count >= total
             finally:
@@ -516,6 +516,13 @@ def _table_exists(conn: sqlite3.Connection, table: str) -> bool:
         (table,),
     ).fetchone()
     return row is not None
+
+
+def _fts_doc_count(conn: sqlite3.Connection, table: str) -> int:
+    if not _table_exists(conn, table):
+        return 0
+    row = conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()
+    return int(row[0] or 0) if row is not None else 0
 
 
 def _conversation_ids_for_source_path(conn: sqlite3.Connection, path: Path) -> list[str]:

--- a/polylogue/daemon/health.py
+++ b/polylogue/daemon/health.py
@@ -591,19 +591,36 @@ def _check_fts_readiness_medium() -> HealthAlert:
     try:
         conn = sqlite3.connect(str(dbf))
         try:
-            has_messages_fts = bool(
-                conn.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name='messages_fts'").fetchone()
-            )
-            has_action_fts = bool(
-                conn.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name='action_events_fts'").fetchone()
-            )
+            tables = {
+                str(row[0])
+                for row in conn.execute(
+                    """
+                    SELECT name
+                    FROM sqlite_master
+                    WHERE type='table'
+                      AND name IN (
+                        'messages_fts',
+                        'messages_fts_docsize',
+                        'action_events_fts'
+                      )
+                    """
+                ).fetchall()
+            }
+            has_messages_fts = "messages_fts" in tables
+            has_messages_docsize = "messages_fts_docsize" in tables
+            has_action_fts = "action_events_fts" in tables
             total = conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0]
-            fts_count = conn.execute("SELECT COUNT(*) FROM messages_fts").fetchone()[0] if has_messages_fts else 0
+            fts_count = (
+                conn.execute("SELECT COUNT(*) FROM messages_fts_docsize").fetchone()[0] if has_messages_docsize else 0
+            )
             gap = total - fts_count
 
             if not has_messages_fts and not has_action_fts:
                 severity = HealthSeverity.WARNING
                 message = "FTS tables missing"
+            elif has_messages_fts and not has_messages_docsize:
+                severity = HealthSeverity.WARNING
+                message = "FTS docsize table missing"
             elif gap > 0:
                 gap_pct = 100 * gap / total if total else 0
                 severity = HealthSeverity.WARNING if gap_pct < 10 else HealthSeverity.ERROR

--- a/tests/unit/daemon/test_daemon_cli.py
+++ b/tests/unit/daemon/test_daemon_cli.py
@@ -411,6 +411,86 @@ def test_ensure_fts_startup_readiness_rebuilds_empty_fts(
     assert all(not query.startswith("SELECT COUNT(*)") for query in conn.queries)
 
 
+def test_ensure_fts_startup_readiness_rebuilds_when_triggers_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from polylogue.daemon import cli as daemon_cli
+
+    db = tmp_path / "polylogue.db"
+    db.write_bytes(b"sqlite placeholder")
+
+    class FakeCursor:
+        def __init__(self, row: tuple[object, ...] | None, rows: list[tuple[object, ...]] | None = None) -> None:
+            self._row = row
+            self._rows = rows if rows is not None else ([] if row is None else [row])
+
+        def fetchone(self) -> tuple[object, ...] | None:
+            return self._row
+
+        def fetchall(self) -> list[tuple[object, ...]]:
+            return self._rows
+
+    class FakeConnection:
+        def __init__(self) -> None:
+            self.queries: list[str] = []
+            self.committed = False
+            self.closed = False
+
+        def execute(self, sql: str, _params: object = ()) -> FakeCursor:
+            query = " ".join(sql.split())
+            self.queries.append(query)
+            if query == "SELECT name FROM sqlite_master WHERE type='table' AND name='messages_fts'":
+                return FakeCursor(("messages_fts",))
+            if query.startswith("SELECT name FROM sqlite_master WHERE type='trigger'"):
+                # One missing trigger must send startup through restore+rebuild
+                # before ensure_fts_index_sync can hide the drift evidence.
+                triggers: list[tuple[object, ...]] = [
+                    ("messages_fts_ai",),
+                    ("messages_fts_ad",),
+                    ("messages_fts_au",),
+                    ("action_events_fts_ai",),
+                    ("action_events_fts_ad",),
+                ]
+                return FakeCursor(triggers[0], rows=triggers)
+            if query == "SELECT 1 FROM messages WHERE text IS NOT NULL LIMIT 1":
+                return FakeCursor((1,))
+            raise AssertionError(f"unexpected query: {query}")
+
+        def commit(self) -> None:
+            self.committed = True
+
+        def close(self) -> None:
+            self.closed = True
+
+    conn = FakeConnection()
+    ensured: list[FakeConnection] = []
+    restored: list[FakeConnection] = []
+    rebuilds: list[FakeConnection] = []
+
+    monkeypatch.setattr("polylogue.paths.db_path", lambda: db)
+    monkeypatch.setattr("polylogue.storage.sqlite.connection_profile.open_connection", lambda _db, timeout: conn)
+    monkeypatch.setattr(
+        "polylogue.storage.fts.fts_lifecycle.ensure_fts_index_sync", lambda fake_conn: ensured.append(fake_conn)
+    )
+    monkeypatch.setattr(
+        "polylogue.storage.fts.fts_lifecycle.restore_fts_triggers_sync",
+        lambda fake_conn: restored.append(fake_conn),
+    )
+    monkeypatch.setattr(
+        "polylogue.storage.fts.fts_lifecycle.rebuild_fts_index_sync",
+        lambda fake_conn: rebuilds.append(fake_conn),
+    )
+
+    asyncio.run(daemon_cli._ensure_fts_startup_readiness())
+
+    assert ensured == []
+    assert restored == [conn]
+    assert rebuilds == [conn]
+    assert conn.committed is True
+    assert conn.closed is True
+
+
 def test_run_daemon_services_stops_live_watcher_on_failure() -> None:
     from polylogue.daemon import cli as daemon_cli
 

--- a/tests/unit/daemon/test_health_check_paths.py
+++ b/tests/unit/daemon/test_health_check_paths.py
@@ -26,6 +26,7 @@ import sqlite3
 from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -276,6 +277,43 @@ def test_fts_readiness_error_when_large_gap(
     assert alert.severity == HealthSeverity.ERROR
     assert alert.consecutive_failures == 1
     assert "FTS gap" in alert.message
+
+
+def test_fts_readiness_counts_docsize_not_virtual_table(
+    workspace_env: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Production status must not count the FTS5 virtual table directly."""
+    dbf = db_path()
+    dbf.parent.mkdir(parents=True, exist_ok=True)
+    _init_messages_db(dbf, message_rows=3, fts_rows=3)
+
+    original_connect = sqlite3.connect
+    queries: list[str] = []
+
+    class GuardedConnection:
+        def __init__(self, inner: sqlite3.Connection) -> None:
+            self._inner = inner
+
+        def execute(self, sql: str, *args: Any, **kwargs: Any) -> sqlite3.Cursor:
+            normalized = " ".join(sql.split()).lower()
+            queries.append(normalized)
+            if "count(*) from messages_fts" in normalized and "messages_fts_docsize" not in normalized:
+                raise AssertionError("health status must not COUNT(*) the FTS5 virtual table")
+            return self._inner.execute(sql, *args, **kwargs)
+
+        def close(self) -> None:
+            self._inner.close()
+
+    def guarded_connect(path: str) -> GuardedConnection:
+        return GuardedConnection(original_connect(path))
+
+    monkeypatch.setattr("polylogue.daemon.health.sqlite3.connect", guarded_connect)
+
+    alert = _check_fts_readiness_medium()
+
+    assert alert.severity == HealthSeverity.OK
+    assert any("messages_fts_docsize" in query for query in queries)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Use FTS5 docsize shadow tables for daemon status, health, and convergence readiness counts, and fix startup trigger-drift recovery so missing FTS sync triggers cause a rebuild instead of restore-only.

## Problem

After deploying #1430, `polylogue --plain status` still timed out against the real archive. The direct CLI fallback had already been moved to `messages_fts_docsize`, but `/api/status` still called daemon health, whose medium FTS readiness check used `COUNT(*) FROM messages_fts`. The same virtual-table count pattern also remained in periodic convergence and global FTS-stage fallback paths.

Live inspection also showed all six production FTS sync triggers were absent and docsize counts had drifted above source table counts. Startup intended to repair this, but it called `ensure_fts_index_sync()` before checking for missing triggers; that recreated triggers and erased the evidence before the rebuild branch ran.

## Solution

`polylogue/daemon/health.py` now uses `messages_fts_docsize` for FTS row counts and treats a missing docsize table as degraded. `polylogue/daemon/convergence_stages.py` and `polylogue/daemon/cli.py` use the same shadow-table count for global FTS readiness/rebuild checks.

Startup readiness now checks for missing FTS triggers before calling `ensure_fts_index_sync()`. When trigger drift is found, it restores triggers and rebuilds FTS in the same startup pass.

## Verification

- `pytest tests/unit/daemon/test_health_check_paths.py tests/unit/daemon/test_convergence_stages.py -q --tb=short` → 35 passed
- `pytest tests/unit/daemon/test_daemon_cli.py::test_ensure_fts_startup_readiness_uses_bounded_probes tests/unit/daemon/test_daemon_cli.py::test_ensure_fts_startup_readiness_rebuilds_empty_fts tests/unit/daemon/test_daemon_cli.py::test_ensure_fts_startup_readiness_rebuilds_when_triggers_missing tests/unit/daemon/test_health_check_paths.py tests/unit/daemon/test_convergence_stages.py -q --tb=short` → 38 passed
- `mypy polylogue/daemon/health.py polylogue/daemon/convergence_stages.py polylogue/daemon/cli.py tests/unit/daemon/test_health_check_paths.py tests/unit/daemon/test_daemon_cli.py` → Success
- `ruff format --check polylogue/daemon/health.py polylogue/daemon/convergence_stages.py polylogue/daemon/cli.py tests/unit/daemon/test_health_check_paths.py tests/unit/daemon/test_daemon_cli.py` → passed
- `ruff check polylogue/daemon/health.py polylogue/daemon/convergence_stages.py polylogue/daemon/cli.py tests/unit/daemon/test_health_check_paths.py tests/unit/daemon/test_daemon_cli.py` → passed
- `timeout 10 python - <<'PY' ... daemon_status_payload() ... PY` against the real archive → returned successfully
- pre-push `devtools verify --quick` → pass, 35.11s on latest commit