### PR TITLE
perf(daemon): chunk large live appends

### DIFF
--- a/polylogue/daemon/notification_backends/journald.py
+++ b/polylogue/daemon/notification_backends/journald.py
@@ -49,7 +49,7 @@ class _JournalSender(Protocol):
 
 def _resolve_default_sender() -> _JournalSender:
     try:
-        from systemd import journal  # type: ignore[attr-defined]
+        from systemd import journal  # type: ignore[attr-defined, unused-ignore]
     except ImportError as err:  # pragma: no cover - exercised in test_no_systemd
         raise BackendUnavailableError(
             "notification_backend='journald' requires the 'systemd' Python package "

--- a/polylogue/sources/live/batch.py
+++ b/polylogue/sources/live/batch.py
@@ -987,17 +987,16 @@ class LiveBatchProcessor:
             return None
         if stat.st_size <= cursor.byte_offset:
             return None
-        if stat.st_size - cursor.byte_offset > _MAX_APPEND_PLAN_PAYLOAD_BYTES:
-            return None
         if cursor.st_dev is not None and cursor.st_dev != stat.st_dev:
             return None
         if cursor.st_ino is not None and cursor.st_ino != stat.st_ino:
             return None
 
         start_offset = max(cursor.byte_offset, 0)
+        append_window = min(stat.st_size - start_offset, _MAX_APPEND_PLAN_PAYLOAD_BYTES)
         with path.open("rb") as handle:
             handle.seek(start_offset)
-            payload = handle.read()
+            payload = handle.read(append_window)
         newline_at = payload.rfind(b"\n")
         if newline_at < 0:
             return None

--- a/tests/unit/sources/test_live_batch_support.py
+++ b/tests/unit/sources/test_live_batch_support.py
@@ -169,17 +169,19 @@ def test_unclassified_large_non_jsonl_is_not_streamed_as_conversation_artifact(
     assert _parse_path_as_conversation_artifact(target, provider=Provider.UNKNOWN) is False
 
 
-def test_append_plan_rejects_large_tail_for_streaming_full_ingest(tmp_path: Path) -> None:
+def test_append_plan_chunks_large_tail_without_full_ingest(tmp_path: Path) -> None:
     root = tmp_path / "src"
     root.mkdir()
     path = root / "session.jsonl"
     original = b'{"a":1}\n'
-    appended = b'{"b":"' + (b"x" * _MAX_APPEND_PLAN_PAYLOAD_BYTES) + b'"}\n'
+    first_chunk = b'{"b":"' + (b"x" * (_MAX_APPEND_PLAN_PAYLOAD_BYTES - 128)) + b'"}\n'
+    second_chunk = b'{"c":"' + (b"y" * 512) + b'"}\n'
+    appended = first_chunk + second_chunk
     path.write_bytes(original + appended)
     db_path = tmp_path / "archive.sqlite"
     processor = LiveBatchProcessor(
         cast(Any, SimpleNamespace(archive_root=tmp_path, backend=SimpleNamespace(db_path=db_path))),
-        (WatchSource(name="claude-code", root=root),),
+        (WatchSource(name="chatgpt", root=root),),
         cursor=CursorStore(db_path),
         parser_fingerprint="test-parser",
     )
@@ -196,7 +198,21 @@ def test_append_plan_rejects_large_tail_for_streaming_full_ingest(tmp_path: Path
         mtime_ns=stat.st_mtime_ns,
     )
 
-    assert processor._append_plan(path) is None
+    plan = processor._append_plan(path)
+
+    assert plan is not None
+    assert plan.start_offset == len(original)
+    assert plan.last_complete_newline == len(original) + len(first_chunk)
+    assert plan.stat_size == len(original) + len(appended)
+    assert plan.bytes_read == _MAX_APPEND_PLAN_PAYLOAD_BYTES
+    assert plan.payload == first_chunk
+
+    assert processor._record_append_cursor(plan) is True
+    next_plan = processor._append_plan(path)
+    assert next_plan is not None
+    assert next_plan.start_offset == len(original) + len(first_chunk)
+    assert next_plan.last_complete_newline == len(original) + len(appended)
+    assert next_plan.payload == second_chunk
 
 
 def test_append_ingest_preserves_successes_when_other_plan_fails(


### PR DESCRIPTION
## Summary

Keep the live daemon on the append path when an active JSONL file grows by more than the append window before the cursor catches up. Instead of rejecting the append plan and rereading the whole file, the daemon now reads one bounded complete-line chunk, ingests that chunk, records the cursor behind the remaining tail, and lets the next batch continue from there.

## Problem

Live production attempts showed the largest active Codex session repeatedly falling back to full-file rereads:

- `input_bytes` around 200 MB for the active `019e309f...` session.
- Several attempts had `source_payload_read_bytes` also around 200 MB and parse times of 50-90s.
- Interleaved attempts had tiny source reads, proving the append path itself works when the pending tail stays under the 64 MB ceiling.

That ceiling made the daemon abandon append mode exactly when the active session was growing fastest, which is the worst case for host IO pressure.

## Solution

`LiveBatchProcessor._append_plan()` now caps the append read to `_MAX_APPEND_PLAN_PAYLOAD_BYTES` instead of rejecting large tails outright. It still requires a complete newline inside the bounded window, so it only parses complete JSONL records. The cursor is advanced to the processed newline while `stat_size` remains the full observed file size, causing later batches to continue draining the remaining tail through the same append path.

This preserves daemon scope: no source is skipped, no convergence stage is disabled, and large active sessions still converge. The change only replaces a full reread fallback with bounded append chunks.

The branch also carries the mypy-portable journald import ignore form needed after #1432: focused mypy sees `systemd.journal` as missing while the repo-wide gate treats that ignore as unused, so the ignore explicitly covers both cases.

## Verification

- `pytest tests/unit/sources/test_live_batch_support.py::test_append_plan_chunks_large_tail_without_full_ingest tests/unit/sources/test_live_watcher.py::test_live_append_merges_tail_visible_through_public_archive_read tests/unit/sources/test_live_watcher.py::test_codex_append_uses_existing_session_identity_when_tail_lacks_session_meta -q` → 3 passed
- `ruff format --check polylogue/sources/live/batch.py tests/unit/sources/test_live_batch_support.py polylogue/daemon/notification_backends/journald.py` → clean
- `ruff check polylogue/sources/live/batch.py tests/unit/sources/test_live_batch_support.py polylogue/daemon/notification_backends/journald.py` → clean
- `mypy --strict polylogue/sources/live/batch.py tests/unit/sources/test_live_batch_support.py polylogue/daemon/notification_backends/journald.py` → clean
- `devtools verify --quick` → exit_code 0, total_duration_s 46.06
