### PR TITLE
perf(daemon): bound startup FTS checks

### DIFF
--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -127,9 +127,6 @@ async def _ensure_fts_startup_readiness() -> None:
         conn = open_connection(db, timeout=10.0)
         row = conn.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='messages_fts'").fetchone()
         has_fts_table = row is not None
-        indexable_messages = int(
-            conn.execute("SELECT COUNT(*) FROM messages WHERE text IS NOT NULL").fetchone()[0] or 0
-        )
 
         from polylogue.storage.fts.fts_lifecycle import (
             ensure_fts_index_sync,
@@ -158,13 +155,10 @@ async def _ensure_fts_startup_readiness() -> None:
             return
 
         ensure_fts_index_sync(conn)
-        indexed_messages = int(conn.execute("SELECT COUNT(*) FROM messages_fts_docsize").fetchone()[0] or 0)
-        if indexable_messages and indexed_messages != indexable_messages:
-            logger.warning(
-                "daemon: message FTS count mismatch on startup (%d/%d indexed). Rebuilding once.",
-                indexed_messages,
-                indexable_messages,
-            )
+        has_indexable_messages = bool(conn.execute("SELECT 1 FROM messages WHERE text IS NOT NULL LIMIT 1").fetchone())
+        has_indexed_messages = bool(conn.execute("SELECT 1 FROM messages_fts_docsize LIMIT 1").fetchone())
+        if has_indexable_messages and not has_indexed_messages:
+            logger.warning("daemon: message FTS is empty on startup while messages exist. Rebuilding once.")
             rebuild_fts_index_sync(conn)
             conn.commit()
             logger.info("daemon: FTS rebuild complete.")
@@ -257,14 +251,13 @@ async def _periodic_db_optimize() -> None:
 async def _periodic_convergence_check(
     sources: tuple[WatchSource, ...],
 ) -> None:
-    """Periodically verify FTS coverage, insight freshness, and repair gaps.
+    """Periodically retry derived convergence debt.
 
-    This is a safety net that runs every 10 minutes. The write path
-    maintains these atomically via commit_archive_write_effects(),
-    so gaps should be rare — this catches edge cases like crash recovery.
+    The live ingest path schedules per-source/per-conversation convergence
+    work. This safety net retries recorded debt without doing full-archive
+    scans or global FTS rebuilds from the daemon's idle loop.
     """
     from polylogue.paths import db_path
-    from polylogue.storage.sqlite.connection_profile import open_connection
 
     db = db_path()
     while True:
@@ -275,33 +268,6 @@ async def _periodic_convergence_check(
             repaired = await asyncio.to_thread(_drain_convergence_debt_once, db)
             if repaired:
                 logger.info("convergence: retried %d derived debt item(s)", repaired)
-            conn = open_connection(db, timeout=5.0)
-            try:
-                total_msgs = conn.execute("SELECT COUNT(*) FROM messages WHERE text IS NOT NULL").fetchone()[0]
-                if total_msgs == 0:
-                    continue
-                fts_count = (
-                    conn.execute("SELECT COUNT(*) FROM messages_fts_docsize").fetchone()[0]
-                    if conn.execute(
-                        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='messages_fts_docsize'"
-                    ).fetchone()
-                    else 0
-                )
-                gap = total_msgs - fts_count
-                if gap != 0:
-                    logger.warning(
-                        "convergence: FTS count mismatch detected (%d/%d messages, %.1f%%). Rebuilding.",
-                        fts_count,
-                        total_msgs,
-                        100 * abs(gap) / total_msgs,
-                    )
-                    from polylogue.storage.fts.fts_lifecycle import rebuild_fts_index_sync
-
-                    rebuild_fts_index_sync(conn)
-                    conn.commit()
-                    logger.info("convergence: FTS rebuild complete — %d messages indexed.", total_msgs)
-            finally:
-                conn.close()
         except Exception:
             logger.warning("convergence: check failed", exc_info=True)
 
@@ -556,14 +522,6 @@ async def run_daemon_services(
             )
         )
 
-    # Ensure FTS is consistent on startup. A gap can only exist from
-    # pre-daemon historical data; once caught up, the write path maintains
-    # FTS atomically via commit_archive_write_effects(). Skipped when the
-    # schema is structurally unusable for this runtime — opening the DB at
-    # all is what the preflight is preventing.
-    if not watcher_blocked:
-        await _ensure_fts_startup_readiness()
-
     pidfile = Path(archive_root()) / "daemon.pid"
     pidfile_fd: int | None = None
 
@@ -581,6 +539,13 @@ async def run_daemon_services(
     # attempt by an ephemeral instance would still atexit-unlink the live
     # daemon's pidfile.
     _pidfile_path = pidfile
+
+    # Ensure FTS structure is usable on startup. Keep this after pidfile
+    # acquisition so operator status sees the live daemon even if SQLite is
+    # busy, and keep the check bounded so daemon restart is not a full-table
+    # maintenance operation.
+    if not watcher_blocked:
+        await _ensure_fts_startup_readiness()
 
     # Periodic maintenance tasks.
     wal_task = asyncio.create_task(_periodic_wal_checkpoint())

--- a/polylogue/daemon/fts_status.py
+++ b/polylogue/daemon/fts_status.py
@@ -29,7 +29,9 @@ def fts_readiness_info(dbf: Path) -> dict[str, object]:
         try:
             tables = _table_names(conn)
             message_indexable_count = (
-                _count(conn, "SELECT COUNT(*) FROM messages WHERE text IS NOT NULL") if "messages" in tables else 0
+                _count(conn, "SELECT COALESCE(SUM(message_count), 0) FROM conversation_stats")
+                if "conversation_stats" in tables
+                else 0
             )
             message_indexed_count = (
                 _count(conn, "SELECT COUNT(*) FROM messages_fts_docsize") if "messages_fts_docsize" in tables else 0
@@ -66,6 +68,7 @@ def _table_names(conn: sqlite3.Connection) -> set[str]:
         FROM sqlite_master
         WHERE type = 'table'
           AND name IN (
+            'conversation_stats',
             'messages',
             'messages_fts',
             'messages_fts_docsize',

--- a/tests/unit/daemon/test_daemon_cli.py
+++ b/tests/unit/daemon/test_daemon_cli.py
@@ -303,9 +303,9 @@ def test_ensure_fts_startup_readiness_uses_bounded_probes(
                     ("action_events_fts_au",),
                 ]
                 return FakeCursor(triggers[0], rows=triggers)
-            if query == "SELECT COUNT(*) FROM messages WHERE text IS NOT NULL":
+            if query == "SELECT 1 FROM messages WHERE text IS NOT NULL LIMIT 1":
                 return FakeCursor((1,))
-            if query == "SELECT COUNT(*) FROM messages_fts_docsize":
+            if query == "SELECT 1 FROM messages_fts_docsize LIMIT 1":
                 return FakeCursor((1,))
             raise AssertionError(f"unexpected query: {query}")
 
@@ -337,6 +337,7 @@ def test_ensure_fts_startup_readiness_uses_bounded_probes(
     assert conn.committed is True
     assert conn.closed is True
     assert all("COUNT(*) FROM messages_fts " not in query for query in conn.queries)
+    assert all("COUNT(*) FROM messages WHERE text IS NOT NULL" not in query for query in conn.queries)
 
 
 def test_ensure_fts_startup_readiness_rebuilds_empty_fts(
@@ -380,10 +381,10 @@ def test_ensure_fts_startup_readiness_rebuilds_empty_fts(
                     ("action_events_fts_au",),
                 ]
                 return FakeCursor(triggers[0], rows=triggers)
-            if query == "SELECT COUNT(*) FROM messages WHERE text IS NOT NULL":
+            if query == "SELECT 1 FROM messages WHERE text IS NOT NULL LIMIT 1":
                 return FakeCursor((1,))
-            if query == "SELECT COUNT(*) FROM messages_fts_docsize":
-                return FakeCursor((0,))
+            if query == "SELECT 1 FROM messages_fts_docsize LIMIT 1":
+                return FakeCursor(None)
             raise AssertionError(f"unexpected query: {query}")
 
         def commit(self) -> None:
@@ -409,6 +410,7 @@ def test_ensure_fts_startup_readiness_rebuilds_empty_fts(
     assert conn.committed is True
     assert conn.closed is True
     assert all("COUNT(*) FROM messages_fts " not in query for query in conn.queries)
+    assert all("COUNT(*) FROM messages WHERE text IS NOT NULL" not in query for query in conn.queries)
 
 
 def test_ensure_fts_startup_readiness_rebuilds_when_triggers_missing(
@@ -453,8 +455,6 @@ def test_ensure_fts_startup_readiness_rebuilds_when_triggers_missing(
                     ("action_events_fts_ad",),
                 ]
                 return FakeCursor(triggers[0], rows=triggers)
-            if query == "SELECT COUNT(*) FROM messages WHERE text IS NOT NULL":
-                return FakeCursor((1,))
             raise AssertionError(f"unexpected query: {query}")
 
         def commit(self) -> None:

--- a/tests/unit/daemon/test_daemon_status.py
+++ b/tests/unit/daemon/test_daemon_status.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import sqlite3
 from datetime import timedelta
 from pathlib import Path
+from typing import Any, cast
 from unittest.mock import Mock, patch
 
 import pytest
@@ -288,6 +289,42 @@ def test_daemon_status_fts_readiness_uses_lightweight_table_probe(tmp_path: Path
 
     assert readiness["messages_ready"] is True
     assert readiness["action_events_ready"] is True
+
+
+def test_daemon_status_fts_readiness_uses_stats_not_message_scan(tmp_path: Path) -> None:
+    db = tmp_path / "polylogue.db"
+    queries: list[str] = []
+    with sqlite3.connect(db) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE messages (text TEXT);
+            CREATE TABLE conversation_stats (conversation_id TEXT PRIMARY KEY, message_count INTEGER NOT NULL);
+            CREATE TABLE messages_fts (text TEXT);
+            CREATE TABLE messages_fts_docsize (id INTEGER PRIMARY KEY, sz BLOB);
+            CREATE TABLE action_events (event_id TEXT);
+            CREATE TABLE action_events_fts (text TEXT);
+            CREATE TABLE action_events_fts_docsize (id INTEGER PRIMARY KEY, sz BLOB);
+            INSERT INTO conversation_stats VALUES ('c1', 2), ('c2', 3);
+            INSERT INTO messages_fts_docsize VALUES (1, x''), (2, x''), (3, x''), (4, x''), (5, x'');
+            """
+        )
+
+    original_connect = sqlite3.connect
+
+    def traced_connect(*args: Any, **kwargs: Any) -> sqlite3.Connection:
+        conn = original_connect(*args, **kwargs)
+        conn.set_trace_callback(queries.append)
+        return cast(sqlite3.Connection, conn)
+
+    with (
+        patch("polylogue.daemon.status.db_path", return_value=db),
+        patch("polylogue.storage.sqlite.connection_profile.sqlite3.connect", side_effect=traced_connect),
+    ):
+        readiness = status_module._fts_readiness_info()
+
+    assert readiness["message_indexable_count"] == 5
+    assert readiness["message_indexed_count"] == 5
+    assert all("COUNT(*) FROM messages WHERE" not in query for query in queries)
 
 
 def test_daemon_status_insight_freshness_uses_lightweight_counts(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Bounds daemon restart/status FTS probes so ordinary restarts do not scan the full `messages` table or rebuild FTS from the idle convergence loop. The daemon now writes its pidfile before startup FTS readiness and uses existence probes for startup health; status derives source message counts from `conversation_stats` instead of `COUNT(*) FROM messages WHERE text IS NOT NULL`.

## Problem

While deploying #1433 to the real archive, `polylogued` spent about 59 seconds before logging the FTS mismatch and about 10 minutes rebuilding FTS before the watcher started. During that window it had no fresh pidfile, so `polylogue status` reported a stale pidfile for the old process. The expensive startup path was caused by full-table FTS parity counts on a multi-million-row archive, and the idle convergence loop still had another global count/rebuild path.

## Solution

- Acquire the daemon pidfile before FTS startup readiness so operator status does not misclassify a live restart as stale.
- Replace startup FTS parity counts with bounded `SELECT 1 ... LIMIT 1` probes that only rebuild the historical empty-index case.
- Remove global FTS count/rebuild work from `_periodic_convergence_check`; per-source and per-conversation convergence repair remains intact.
- Use `conversation_stats` for daemon FTS status source counts so status avoids scanning `messages`.

## Verification

- `pytest tests/unit/daemon/test_daemon_cli.py::test_ensure_fts_startup_readiness_uses_bounded_probes tests/unit/daemon/test_daemon_cli.py::test_ensure_fts_startup_readiness_rebuilds_empty_fts tests/unit/daemon/test_daemon_cli.py::test_ensure_fts_startup_readiness_rebuilds_when_triggers_missing tests/unit/daemon/test_daemon_status.py::test_daemon_status_fts_readiness_uses_stats_not_message_scan tests/unit/daemon/test_daemon_status.py::test_daemon_status_fts_readiness_uses_lightweight_table_probe -q` → 5 passed
- `python -m mypy polylogue/daemon/cli.py polylogue/daemon/fts_status.py tests/unit/daemon/test_daemon_cli.py tests/unit/daemon/test_daemon_status.py` → success
- `ruff format ... && ruff check ...` → all checks passed
- `devtools render-all --check` → OK
- pre-push `devtools verify --quick` → exit_code 0, total_duration_s 34.75

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized daemon startup by replacing Full Text Search readiness detection with efficient presence checks instead of full message counts.
  * Enhanced message indexable count calculations to use statistics tables instead of scanning individual messages, reducing computational overhead.
  * Refined periodic maintenance logic for improved index convergence handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sinity/polylogue/pull/1434?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->