### PR TITLE
fix(storage): prevent FTS orphans during replacement

### DIFF
--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -99,6 +99,14 @@ def _missing_fts_triggers_sync(conn: sqlite3.Connection) -> list[str]:
     return [name for name in _EXPECTED_FTS_TRIGGERS if name not in present]
 
 
+def _table_exists_sync(conn: sqlite3.Connection, table_name: str) -> bool:
+    row = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type IN ('table', 'virtual table') AND name = ? LIMIT 1",
+        (table_name,),
+    ).fetchone()
+    return row is not None
+
+
 async def _ensure_fts_startup_readiness() -> None:
     """Ensure FTS triggers and index are healthy on daemon startup.
 
@@ -163,6 +171,21 @@ async def _ensure_fts_startup_readiness() -> None:
             conn.commit()
             logger.info("daemon: FTS rebuild complete.")
             return
+        if _table_exists_sync(conn, "conversation_stats") and _table_exists_sync(conn, "messages_fts_docsize"):
+            indexable_messages = int(
+                conn.execute("SELECT COALESCE(SUM(message_count), 0) FROM conversation_stats").fetchone()[0] or 0
+            )
+            indexed_messages = int(conn.execute("SELECT COUNT(*) FROM messages_fts_docsize").fetchone()[0] or 0)
+            if indexable_messages and indexed_messages != indexable_messages:
+                logger.warning(
+                    "daemon: message FTS count mismatch on startup (%d/%d indexed). Rebuilding once.",
+                    indexed_messages,
+                    indexable_messages,
+                )
+                rebuild_fts_index_sync(conn)
+                conn.commit()
+                logger.info("daemon: FTS rebuild complete.")
+                return
 
         conn.commit()
     except Exception:

--- a/polylogue/storage/conversation_replacement.py
+++ b/polylogue/storage/conversation_replacement.py
@@ -27,9 +27,117 @@ async def _table_exists_async(conn: aiosqlite.Connection, table_name: str) -> bo
     return row is not None
 
 
+def _trigger_exists_sync(conn: sqlite3.Connection, trigger_name: str) -> bool:
+    row = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'trigger' AND name = ?",
+        (trigger_name,),
+    ).fetchone()
+    return row is not None
+
+
+async def _trigger_exists_async(conn: aiosqlite.Connection, trigger_name: str) -> bool:
+    row = await (
+        await conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type = 'trigger' AND name = ?",
+            (trigger_name,),
+        )
+    ).fetchone()
+    return row is not None
+
+
 async def _ensure_sqlite_vec_async(conn: aiosqlite.Connection) -> bool:
     loaded, _error = await try_load_sqlite_vec_async(conn)
     return loaded
+
+
+def _purge_message_fts_sync(conn: sqlite3.Connection, conversation_id: str) -> None:
+    if _trigger_exists_sync(conn, "messages_fts_ad"):
+        return
+    if not _table_exists_sync(conn, "messages_fts") or not _table_exists_sync(conn, "messages_fts_docsize"):
+        return
+    conn.execute(
+        """
+        INSERT INTO messages_fts(messages_fts, rowid, message_id, conversation_id, text)
+        SELECT 'delete', m.rowid, m.message_id, m.conversation_id, m.text
+        FROM messages AS m
+        JOIN messages_fts_docsize AS d ON d.id = m.rowid
+        WHERE m.conversation_id = ?
+          AND m.text IS NOT NULL
+        """,
+        (conversation_id,),
+    )
+
+
+async def _purge_message_fts_async(conn: aiosqlite.Connection, conversation_id: str) -> None:
+    if await _trigger_exists_async(conn, "messages_fts_ad"):
+        return
+    if not await _table_exists_async(conn, "messages_fts") or not await _table_exists_async(
+        conn, "messages_fts_docsize"
+    ):
+        return
+    await conn.execute(
+        """
+        INSERT INTO messages_fts(messages_fts, rowid, message_id, conversation_id, text)
+        SELECT 'delete', m.rowid, m.message_id, m.conversation_id, m.text
+        FROM messages AS m
+        JOIN messages_fts_docsize AS d ON d.id = m.rowid
+        WHERE m.conversation_id = ?
+          AND m.text IS NOT NULL
+        """,
+        (conversation_id,),
+    )
+
+
+def _purge_action_fts_sync(conn: sqlite3.Connection, conversation_id: str) -> None:
+    if _trigger_exists_sync(conn, "action_events_fts_ad"):
+        return
+    if (
+        not _table_exists_sync(conn, "action_events")
+        or not _table_exists_sync(conn, "action_events_fts")
+        or not _table_exists_sync(conn, "action_events_fts_docsize")
+    ):
+        return
+    conn.execute(
+        """
+        INSERT INTO action_events_fts(
+            action_events_fts, rowid, event_id, message_id, conversation_id,
+            action_kind, normalized_tool_name, search_text
+        )
+        SELECT
+            'delete', ae.rowid, ae.event_id, ae.message_id, ae.conversation_id,
+            ae.action_kind, ae.normalized_tool_name, ae.search_text
+        FROM action_events AS ae
+        JOIN action_events_fts_docsize AS d ON d.id = ae.rowid
+        WHERE ae.conversation_id = ?
+        """,
+        (conversation_id,),
+    )
+
+
+async def _purge_action_fts_async(conn: aiosqlite.Connection, conversation_id: str) -> None:
+    if await _trigger_exists_async(conn, "action_events_fts_ad"):
+        return
+    if (
+        not await _table_exists_async(conn, "action_events")
+        or not await _table_exists_async(conn, "action_events_fts")
+        or not await _table_exists_async(conn, "action_events_fts_docsize")
+    ):
+        return
+    await conn.execute(
+        """
+        INSERT INTO action_events_fts(
+            action_events_fts, rowid, event_id, message_id, conversation_id,
+            action_kind, normalized_tool_name, search_text
+        )
+        SELECT
+            'delete', ae.rowid, ae.event_id, ae.message_id, ae.conversation_id,
+            ae.action_kind, ae.normalized_tool_name, ae.search_text
+        FROM action_events AS ae
+        JOIN action_events_fts_docsize AS d ON d.id = ae.rowid
+        WHERE ae.conversation_id = ?
+        """,
+        (conversation_id,),
+    )
 
 
 def _invalidate_embedding_state_sync(conn: sqlite3.Connection, conversation_id: str) -> None:
@@ -82,6 +190,8 @@ def replace_conversation_runtime_state_sync(
     }
     _invalidate_embedding_state_sync(conn, conversation_id)
     conn.execute("DELETE FROM attachment_refs WHERE conversation_id = ?", (conversation_id,))
+    _purge_action_fts_sync(conn, conversation_id)
+    _purge_message_fts_sync(conn, conversation_id)
     conn.execute("DELETE FROM messages WHERE conversation_id = ?", (conversation_id,))
     conn.execute("DELETE FROM conversation_stats WHERE conversation_id = ?", (conversation_id,))
     return affected_attachment_ids
@@ -101,6 +211,8 @@ async def replace_conversation_runtime_state_async(
     affected_attachment_ids = {str(row[0]) for row in rows}
     await _invalidate_embedding_state_async(conn, conversation_id)
     await conn.execute("DELETE FROM attachment_refs WHERE conversation_id = ?", (conversation_id,))
+    await _purge_action_fts_async(conn, conversation_id)
+    await _purge_message_fts_async(conn, conversation_id)
     await conn.execute("DELETE FROM messages WHERE conversation_id = ?", (conversation_id,))
     await conn.execute("DELETE FROM conversation_stats WHERE conversation_id = ?", (conversation_id,))
     return affected_attachment_ids

--- a/tests/unit/daemon/test_daemon_cli.py
+++ b/tests/unit/daemon/test_daemon_cli.py
@@ -307,6 +307,12 @@ def test_ensure_fts_startup_readiness_uses_bounded_probes(
                 return FakeCursor((1,))
             if query == "SELECT 1 FROM messages_fts_docsize LIMIT 1":
                 return FakeCursor((1,))
+            if query == "SELECT 1 FROM sqlite_master WHERE type IN ('table', 'virtual table') AND name = ? LIMIT 1":
+                return FakeCursor((1,))
+            if query == "SELECT COALESCE(SUM(message_count), 0) FROM conversation_stats":
+                return FakeCursor((1,))
+            if query == "SELECT COUNT(*) FROM messages_fts_docsize":
+                return FakeCursor((1,))
             raise AssertionError(f"unexpected query: {query}")
 
         def commit(self) -> None:
@@ -385,6 +391,12 @@ def test_ensure_fts_startup_readiness_rebuilds_empty_fts(
                 return FakeCursor((1,))
             if query == "SELECT 1 FROM messages_fts_docsize LIMIT 1":
                 return FakeCursor(None)
+            if query == "SELECT 1 FROM sqlite_master WHERE type IN ('table', 'virtual table') AND name = ? LIMIT 1":
+                return FakeCursor((1,))
+            if query == "SELECT COALESCE(SUM(message_count), 0) FROM conversation_stats":
+                return FakeCursor((1,))
+            if query == "SELECT COUNT(*) FROM messages_fts_docsize":
+                return FakeCursor((0,))
             raise AssertionError(f"unexpected query: {query}")
 
         def commit(self) -> None:
@@ -410,6 +422,84 @@ def test_ensure_fts_startup_readiness_rebuilds_empty_fts(
     assert conn.committed is True
     assert conn.closed is True
     assert all("COUNT(*) FROM messages_fts " not in query for query in conn.queries)
+    assert all("COUNT(*) FROM messages WHERE text IS NOT NULL" not in query for query in conn.queries)
+
+
+def test_ensure_fts_startup_readiness_rebuilds_stats_count_mismatch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from polylogue.daemon import cli as daemon_cli
+
+    db = tmp_path / "polylogue.db"
+    db.write_bytes(b"sqlite placeholder")
+
+    class FakeCursor:
+        def __init__(self, row: tuple[object, ...] | None, rows: list[tuple[object, ...]] | None = None) -> None:
+            self._row = row
+            self._rows = rows if rows is not None else ([] if row is None else [row])
+
+        def fetchone(self) -> tuple[object, ...] | None:
+            return self._row
+
+        def fetchall(self) -> list[tuple[object, ...]]:
+            return self._rows
+
+    class FakeConnection:
+        def __init__(self) -> None:
+            self.queries: list[str] = []
+            self.committed = False
+            self.closed = False
+
+        def execute(self, sql: str, _params: object = ()) -> FakeCursor:
+            query = " ".join(sql.split())
+            self.queries.append(query)
+            if query == "SELECT name FROM sqlite_master WHERE type='table' AND name='messages_fts'":
+                return FakeCursor(("messages_fts",))
+            if query.startswith("SELECT name FROM sqlite_master WHERE type='trigger'"):
+                triggers: list[tuple[object, ...]] = [
+                    ("messages_fts_ai",),
+                    ("messages_fts_ad",),
+                    ("messages_fts_au",),
+                    ("action_events_fts_ai",),
+                    ("action_events_fts_ad",),
+                    ("action_events_fts_au",),
+                ]
+                return FakeCursor(triggers[0], rows=triggers)
+            if query == "SELECT 1 FROM messages WHERE text IS NOT NULL LIMIT 1":
+                return FakeCursor((1,))
+            if query == "SELECT 1 FROM messages_fts_docsize LIMIT 1":
+                return FakeCursor((1,))
+            if query == "SELECT 1 FROM sqlite_master WHERE type IN ('table', 'virtual table') AND name = ? LIMIT 1":
+                return FakeCursor((1,))
+            if query == "SELECT COALESCE(SUM(message_count), 0) FROM conversation_stats":
+                return FakeCursor((5,))
+            if query == "SELECT COUNT(*) FROM messages_fts_docsize":
+                return FakeCursor((6,))
+            raise AssertionError(f"unexpected query: {query}")
+
+        def commit(self) -> None:
+            self.committed = True
+
+        def close(self) -> None:
+            self.closed = True
+
+    conn = FakeConnection()
+    rebuilds: list[FakeConnection] = []
+
+    monkeypatch.setattr("polylogue.paths.db_path", lambda: db)
+    monkeypatch.setattr("polylogue.storage.sqlite.connection_profile.open_connection", lambda _db, timeout: conn)
+    monkeypatch.setattr("polylogue.storage.fts.fts_lifecycle.ensure_fts_index_sync", lambda _conn: None)
+    monkeypatch.setattr(
+        "polylogue.storage.fts.fts_lifecycle.rebuild_fts_index_sync",
+        lambda fake_conn: rebuilds.append(fake_conn),
+    )
+
+    asyncio.run(daemon_cli._ensure_fts_startup_readiness())
+
+    assert rebuilds == [conn]
+    assert conn.committed is True
+    assert conn.closed is True
     assert all("COUNT(*) FROM messages WHERE text IS NOT NULL" not in query for query in conn.queries)
 
 

--- a/tests/unit/storage/test_fts_bloat_invariants.py
+++ b/tests/unit/storage/test_fts_bloat_invariants.py
@@ -149,3 +149,58 @@ def test_messages_fts_deletion_consistency_with_external_content(tmp_path: Path)
         assert beta_hits == 1
     finally:
         conn.close()
+
+
+def test_conversation_replacement_purges_fts_when_delete_triggers_missing(tmp_path: Path) -> None:
+    """Replacement must not orphan FTS rows if bulk ingest has suspended triggers."""
+    from polylogue.storage.conversation_replacement import replace_conversation_runtime_state_sync
+    from polylogue.storage.sqlite.schema_ddl import SCHEMA_DDL
+
+    conn = sqlite3.connect(str(tmp_path / "fts_replace_missing_triggers.db"))
+    try:
+        conn.executescript(SCHEMA_DDL)
+        conn.execute(
+            "INSERT INTO conversations(conversation_id, provider_name, provider_conversation_id, version) "
+            "VALUES('c1','test','pc1',1)"
+        )
+        conn.execute(
+            "INSERT INTO messages(message_id, conversation_id, role, text, provider_name, version) "
+            "VALUES('m1','c1','user','replace orphan needle','test',1)"
+        )
+        conn.execute(
+            """
+            INSERT INTO action_events (
+                event_id, conversation_id, message_id, sequence_index,
+                action_kind, normalized_tool_name, search_text
+            ) VALUES ('a1', 'c1', 'm1', 0, 'shell', 'bash', 'action orphan needle')
+            """
+        )
+        conn.commit()
+        assert conn.execute("SELECT COUNT(*) FROM messages_fts_docsize").fetchone()[0] == 1
+        assert conn.execute("SELECT COUNT(*) FROM action_events_fts_docsize").fetchone()[0] == 1
+
+        conn.execute("DROP TRIGGER messages_fts_ad")
+        conn.execute("DROP TRIGGER action_events_fts_ad")
+        replace_conversation_runtime_state_sync(conn, "c1")
+        conn.commit()
+
+        message_orphans = conn.execute(
+            """
+            SELECT COUNT(*)
+            FROM messages_fts_docsize AS d
+            LEFT JOIN messages AS m ON m.rowid = d.id
+            WHERE m.rowid IS NULL
+            """
+        ).fetchone()[0]
+        action_orphans = conn.execute(
+            """
+            SELECT COUNT(*)
+            FROM action_events_fts_docsize AS d
+            LEFT JOIN action_events AS ae ON ae.rowid = d.id
+            WHERE ae.rowid IS NULL
+            """
+        ).fetchone()[0]
+        assert message_orphans == 0
+        assert action_orphans == 0
+    finally:
+        conn.close()


### PR DESCRIPTION
## Summary

Makes FTS correctness real across daemon catch-up/replacement. Conversation replacement now explicitly removes message/action FTS rows before deleting base rows when FTS delete triggers are missing, and daemon startup restores full FTS parity using cheap stats-table counts before the watcher proceeds.

## Problem

Production drift showed `messages_fts_docsize` overcounting the base `messages` table by about 108k rows with rowids that no longer exist in `messages`. That shape is consistent with deleting/replacing conversation rows while FTS delete triggers are suspended or missing: the base rows disappear, but external-content FTS shadow rows remain. Per-conversation repair then cannot remove those rowids because it only sees current `messages` rows.

FTS must be transparently ready and correct; stale search is not an acceptable steady state.

## Solution

- Add replacement-time FTS purges for message and action-event rows when their delete triggers are absent.
- Purges use the FTS5 external-content `delete` command while the old base rows still exist, so no orphan shadow rows are left behind when `messages` / `action_events` are deleted.
- Keep normal trigger-driven deletes untouched when delete triggers are present, avoiding double deletes.
- Startup readiness still rebuilds on FTS count mismatch, but compares `messages_fts_docsize` to `conversation_stats` instead of scanning the full `messages` table.

## Verification

- `pytest tests/unit/daemon/test_daemon_cli.py::test_ensure_fts_startup_readiness_uses_bounded_probes tests/unit/daemon/test_daemon_cli.py::test_ensure_fts_startup_readiness_rebuilds_empty_fts tests/unit/daemon/test_daemon_cli.py::test_ensure_fts_startup_readiness_rebuilds_stats_count_mismatch tests/unit/daemon/test_daemon_cli.py::test_ensure_fts_startup_readiness_rebuilds_when_triggers_missing tests/unit/storage/test_fts_bloat_invariants.py::test_conversation_replacement_purges_fts_when_delete_triggers_missing tests/unit/storage/test_fts_bloat_invariants.py::test_messages_fts_deletion_consistency_with_external_content -q` → 6 passed
- `python -m mypy polylogue/daemon/cli.py polylogue/storage/conversation_replacement.py tests/unit/daemon/test_daemon_cli.py tests/unit/storage/test_fts_bloat_invariants.py` → success
- `ruff format ... && ruff check ...` → all checks passed
- `devtools render-all --check` → OK
- pre-push `devtools verify --quick` → exit_code 0, total_duration_s 35.58