### PR TITLE
fix(daemon): bound FTS health counts

### DIFF
--- a/polylogue/daemon/health.py
+++ b/polylogue/daemon/health.py
@@ -599,6 +599,7 @@ def _check_fts_readiness_medium() -> HealthAlert:
                     FROM sqlite_master
                     WHERE type='table'
                       AND name IN (
+                        'conversation_stats',
                         'messages_fts',
                         'messages_fts_docsize',
                         'action_events_fts'
@@ -609,7 +610,10 @@ def _check_fts_readiness_medium() -> HealthAlert:
             has_messages_fts = "messages_fts" in tables
             has_messages_docsize = "messages_fts_docsize" in tables
             has_action_fts = "action_events_fts" in tables
-            total = conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0]
+            if "conversation_stats" in tables:
+                total = conn.execute("SELECT COALESCE(SUM(message_count), 0) FROM conversation_stats").fetchone()[0]
+            else:
+                total = conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0]
             fts_count = (
                 conn.execute("SELECT COUNT(*) FROM messages_fts_docsize").fetchone()[0] if has_messages_docsize else 0
             )
@@ -621,10 +625,13 @@ def _check_fts_readiness_medium() -> HealthAlert:
             elif has_messages_fts and not has_messages_docsize:
                 severity = HealthSeverity.WARNING
                 message = "FTS docsize table missing"
-            elif gap > 0:
-                gap_pct = 100 * gap / total if total else 0
+            elif gap != 0:
+                gap_pct = 100 * abs(gap) / total if total else 100
                 severity = HealthSeverity.WARNING if gap_pct < 10 else HealthSeverity.ERROR
-                message = f"FTS gap: {gap} of {total} messages unindexed ({gap_pct:.1f}%)"
+                if gap > 0:
+                    message = f"FTS gap: {gap} of {total} messages unindexed ({gap_pct:.1f}%)"
+                else:
+                    message = f"FTS stale rows: {-gap} extra indexed messages over {total} expected ({gap_pct:.1f}%)"
             else:
                 severity = HealthSeverity.OK
                 message = "FTS up to date"

--- a/tests/unit/daemon/test_health_check_paths.py
+++ b/tests/unit/daemon/test_health_check_paths.py
@@ -316,6 +316,69 @@ def test_fts_readiness_counts_docsize_not_virtual_table(
     assert any("messages_fts_docsize" in query for query in queries)
 
 
+def test_fts_readiness_uses_stats_not_message_scan(
+    workspace_env: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    dbf = db_path()
+    dbf.parent.mkdir(parents=True, exist_ok=True)
+    _init_messages_db(dbf, message_rows=999, fts_rows=3)
+    conn = sqlite3.connect(str(dbf))
+    try:
+        conn.execute("CREATE TABLE conversation_stats (conversation_id TEXT PRIMARY KEY, message_count INTEGER)")
+        conn.execute("INSERT INTO conversation_stats VALUES ('c1', 3)")
+        conn.commit()
+    finally:
+        conn.close()
+
+    original_connect = sqlite3.connect
+    queries: list[str] = []
+
+    class GuardedConnection:
+        def __init__(self, inner: sqlite3.Connection) -> None:
+            self._inner = inner
+
+        def execute(self, sql: str, *args: Any, **kwargs: Any) -> sqlite3.Cursor:
+            normalized = " ".join(sql.split()).lower()
+            queries.append(normalized)
+            if normalized == "select count(*) from messages":
+                raise AssertionError("health status must use conversation_stats when available")
+            return self._inner.execute(sql, *args, **kwargs)
+
+        def close(self) -> None:
+            self._inner.close()
+
+    def guarded_connect(path: str) -> GuardedConnection:
+        return GuardedConnection(original_connect(path))
+
+    monkeypatch.setattr("polylogue.daemon.health.sqlite3.connect", guarded_connect)
+
+    alert = _check_fts_readiness_medium()
+
+    assert alert.severity == HealthSeverity.OK
+    assert any("sum(message_count)" in query for query in queries)
+
+
+def test_fts_readiness_flags_stale_extra_rows(
+    workspace_env: dict[str, Path],
+) -> None:
+    dbf = db_path()
+    dbf.parent.mkdir(parents=True, exist_ok=True)
+    _init_messages_db(dbf, message_rows=3, fts_rows=5)
+    conn = sqlite3.connect(str(dbf))
+    try:
+        conn.execute("CREATE TABLE conversation_stats (conversation_id TEXT PRIMARY KEY, message_count INTEGER)")
+        conn.execute("INSERT INTO conversation_stats VALUES ('c1', 3)")
+        conn.commit()
+    finally:
+        conn.close()
+
+    alert = _check_fts_readiness_medium()
+
+    assert alert.severity == HealthSeverity.ERROR
+    assert "stale rows" in alert.message
+
+
 # ---------------------------------------------------------------------------
 # MEDIUM: raw_failures (OK + degraded + RECOVERY)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Make the daemon medium-tier FTS health check use the bounded `conversation_stats` message count when it is available, and report stale over-indexed FTS rows as degraded instead of healthy.

## Problem

The deployed FTS replacement fix restored production FTS parity, but `polylogue --plain status` still timed out while live ingest was processing a large Codex session. The `/api/status` payload includes medium health checks, and `fts_readiness` still scanned `messages` directly. The check also only treated under-indexing as unhealthy, so an overcount drift like the production failure could be reported as OK.

## Solution

`polylogue.daemon.health._check_fts_readiness_medium` now reads `SUM(message_count)` from `conversation_stats` when that table exists, falling back to `COUNT(*) FROM messages` only for minimal or legacy fixtures. Any mismatch between expected message count and `messages_fts_docsize` is degraded: undercounts report unindexed gaps and overcounts report stale extra indexed rows.

## Verification

- `pytest tests/unit/daemon/test_health_check_paths.py::test_fts_readiness_ok tests/unit/daemon/test_health_check_paths.py::test_fts_readiness_error_when_large_gap tests/unit/daemon/test_health_check_paths.py::test_fts_readiness_counts_docsize_not_virtual_table tests/unit/daemon/test_health_check_paths.py::test_fts_readiness_uses_stats_not_message_scan tests/unit/daemon/test_health_check_paths.py::test_fts_readiness_flags_stale_extra_rows -q` → 5 passed
- `python -m ruff format --check polylogue/daemon/health.py tests/unit/daemon/test_health_check_paths.py` → 2 files already formatted
- `python -m ruff check polylogue/daemon/health.py tests/unit/daemon/test_health_check_paths.py` → All checks passed
- `python -m mypy polylogue/daemon/health.py tests/unit/daemon/test_health_check_paths.py` → Success
- pre-push `devtools verify --quick` → exit_code 0, total_duration_s 38.63