### PR TITLE
fix(daemon): keep FTS triggers active during ingest

### DIFF
--- a/polylogue/archive/write_effects.py
+++ b/polylogue/archive/write_effects.py
@@ -31,7 +31,7 @@ def commit_archive_write_effects(
     """Run the canonical post-write side effects for an archive write.
 
     This function:
-    1. Restores FTS triggers (suspended during bulk writes)
+    1. Ensures FTS triggers exist without dropping live triggers
     2. Repairs message FTS for changed conversation IDs
     3. Repairs action-event FTS for changed conversation IDs
     4. Commits the transaction
@@ -55,9 +55,9 @@ def commit_archive_write_effects(
     WriteResult with status, rows_affected, and operation_id.
     """
     from polylogue.storage.fts.fts_lifecycle import (
+        ensure_fts_triggers_sync,
         repair_action_fts_index_sync,
         repair_message_fts_index_sync,
-        restore_fts_triggers_sync,
     )
 
     changed_ids: Sequence[str] = payload.get("changed_conversation_ids", [])
@@ -76,9 +76,9 @@ def commit_archive_write_effects(
 
         acquire_blob_leases(db_path, blob_hashes, operation_id)
 
-    t_restore = time.perf_counter()
-    restore_fts_triggers_sync(conn)
-    restore_elapsed_s = time.perf_counter() - t_restore
+    t_trigger = time.perf_counter()
+    ensure_fts_triggers_sync(conn)
+    trigger_elapsed_s = time.perf_counter() - t_trigger
     message_fts_elapsed_s = 0.0
     action_fts_elapsed_s = 0.0
     if sorted_ids:
@@ -92,14 +92,14 @@ def commit_archive_write_effects(
     t_commit = time.perf_counter()
     conn.commit()
     commit_elapsed_s = time.perf_counter() - t_commit
-    total_effect_elapsed_s = restore_elapsed_s + message_fts_elapsed_s + action_fts_elapsed_s + commit_elapsed_s
+    total_effect_elapsed_s = trigger_elapsed_s + message_fts_elapsed_s + action_fts_elapsed_s + commit_elapsed_s
     if total_effect_elapsed_s >= 1.0:
         logger.info(
-            "slow_archive_write_effects operation=%s conversations=%d restore_fts_s=%.3f "
+            "slow_archive_write_effects operation=%s conversations=%d ensure_fts_triggers_s=%.3f "
             "message_fts_s=%.3f action_fts_s=%.3f commit_s=%.3f total_s=%.3f",
             op.value,
             len(sorted_ids),
-            restore_elapsed_s,
+            trigger_elapsed_s,
             message_fts_elapsed_s,
             action_fts_elapsed_s,
             commit_elapsed_s,

--- a/polylogue/pipeline/services/ingest_batch/_core.py
+++ b/polylogue/pipeline/services/ingest_batch/_core.py
@@ -998,11 +998,8 @@ def _process_ingest_batch_sync(
     heartbeat: IngestHeartbeat | None = None,
     progress: _WorkerProgress | None = None,
     ingest_result_chunk_size: int = 0,
+    suspend_fts_triggers: bool = False,
 ) -> _IngestBatchSummary:
-    from polylogue.storage.fts.fts_lifecycle import (
-        suspend_fts_triggers_sync,
-    )
-
     if progress is None:
         progress = _WorkerProgress()
     summary = _new_ingest_batch_summary(raw_artifacts, ingest_workers=ingest_workers)
@@ -1021,7 +1018,10 @@ def _process_ingest_batch_sync(
     _observe_current_rss(summary)
     changed_ids: set[str] = set()
     try:
-        suspend_fts_triggers_sync(conn)
+        if suspend_fts_triggers:
+            from polylogue.storage.fts.fts_lifecycle import suspend_fts_triggers_sync
+
+            suspend_fts_triggers_sync(conn)
         conn.execute("BEGIN IMMEDIATE")
         _consume_ingest_results(
             conn,
@@ -1058,18 +1058,19 @@ def _process_ingest_batch_sync(
         )
         summary.commit_elapsed_s = time.perf_counter() - commit_started
     except Exception:
-        # Roll back the row writes. The suspend DROP TRIGGER auto-
-        # committed (DDL), so we must explicitly restore triggers so the
-        # database is not left in the SIGKILL-style drift state. If the
-        # restore itself fails, we propagate the original exception
-        # (the daemon startup readiness check is the next safety net).
+        # Roll back the row writes.  If a caller explicitly opted into
+        # dropped-trigger bulk mode, restore triggers before propagating
+        # so ordinary exceptions do not leave the database in a drift
+        # state.  Daemon live ingest leaves triggers active and therefore
+        # has no dropped-trigger window to recover from here.
         with contextlib.suppress(Exception):
             conn.rollback()
-        from polylogue.storage.fts.fts_lifecycle import restore_fts_triggers_sync
+        if suspend_fts_triggers:
+            from polylogue.storage.fts.fts_lifecycle import restore_fts_triggers_sync
 
-        with contextlib.suppress(Exception):
-            restore_fts_triggers_sync(conn)
-            conn.commit()
+            with contextlib.suppress(Exception):
+                restore_fts_triggers_sync(conn)
+                conn.commit()
         raise
     finally:
         conn.close()

--- a/polylogue/storage/fts/fts_lifecycle.py
+++ b/polylogue/storage/fts/fts_lifecycle.py
@@ -175,6 +175,17 @@ def restore_fts_triggers_sync(conn: sqlite3.Connection) -> None:
         conn.execute(ddl)
 
 
+def ensure_fts_triggers_sync(conn: sqlite3.Connection) -> None:
+    """Create missing FTS triggers without dropping existing triggers.
+
+    Steady-state archive writes must not create a dropped-trigger window.
+    ``restore_fts_triggers_sync`` remains the explicit recovery/rebuild path
+    for replacing trigger definitions and repairing global FTS state.
+    """
+    for ddl in _MESSAGE_FTS_TRIGGER_DDL + _ACTION_FTS_TRIGGER_DDL:
+        conn.execute(ddl)
+
+
 def ensure_fts_index_sync(conn: sqlite3.Connection) -> None:
     """Ensure the FTS5 tables and triggers exist on a sync SQLite connection."""
     conn.execute(FTS_MESSAGES_TABLE_SQL)
@@ -483,6 +494,7 @@ __all__ = [
     "check_fts_readiness",
     "ensure_fts_index_async",
     "ensure_fts_index_sync",
+    "ensure_fts_triggers_sync",
     "fts_index_status_async",
     "fts_index_status_sync",
     "message_fts_readiness_async",

--- a/tests/unit/archive/test_write_gateway.py
+++ b/tests/unit/archive/test_write_gateway.py
@@ -25,6 +25,36 @@ def test_write_gateway_commits_effects_on_caller_owned_connection(tmp_path: Path
         assert conn.execute("SELECT 1").fetchone()[0] == 1
 
 
+def test_write_gateway_normal_commit_does_not_drop_fts_triggers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "archive.db"
+    ensured: list[bool] = []
+
+    def ensure_only(_conn: object) -> None:
+        ensured.append(True)
+
+    def fail_restore(_conn: object) -> None:
+        raise AssertionError("normal archive writes must not drop/recreate FTS triggers")
+
+    monkeypatch.setattr("polylogue.storage.fts.fts_lifecycle.ensure_fts_triggers_sync", ensure_only)
+    monkeypatch.setattr("polylogue.storage.fts.fts_lifecycle.restore_fts_triggers_sync", fail_restore)
+
+    with open_connection(db_path) as conn:
+        conn.execute("BEGIN IMMEDIATE")
+        result = ArchiveWriteGateway(db_path).commit_write_sync(
+            WriteOperation.INGEST,
+            {
+                "_connection": conn,
+                "changed_conversation_ids": (),
+            },
+        )
+
+    assert result.status == "committed"
+    assert ensured == [True]
+
+
 @pytest.mark.asyncio
 async def test_write_gateway_async_commit_uses_same_local_effects_path(tmp_path: Path) -> None:
     db_path = tmp_path / "archive.db"

--- a/tests/unit/pipeline/test_ingest_batch.py
+++ b/tests/unit/pipeline/test_ingest_batch.py
@@ -1014,6 +1014,10 @@ def test_process_ingest_batch_sync_commits_fts_repair_and_invalidates_search_cac
         return IngestRecordResult(raw_id=record.raw_id, conversations=[conversation])
 
     monkeypatch.setattr(ingest_batch_core, "ingest_record", fake_ingest_record)
+    monkeypatch.setattr(
+        "polylogue.storage.fts.fts_lifecycle.suspend_fts_triggers_sync",
+        lambda _conn: (_ for _ in ()).throw(AssertionError("live/default ingest must keep FTS triggers active")),
+    )
 
     summary = _process_ingest_batch_sync(
         [raw_record],


### PR DESCRIPTION
## Summary

Remove the steady-state dropped-trigger window from daemon ingest writes. Normal archive write effects now ensure missing FTS triggers without dropping existing triggers, and default ingest keeps FTS triggers active instead of suspending them globally.

## Problem

After #1435 restored the production FTS index and #1436 bounded status health counts, restarting through Sinnix exposed the deeper recurrence source: the daemon was still using global FTS trigger suspension during live ingest, and write effects called `restore_fts_triggers_sync`, which drops and recreates triggers. A restart or kill inside that window leaves all six FTS triggers missing, forcing an expensive startup rebuild and making search freshness fragile.

## Solution

- Add `ensure_fts_triggers_sync`, which creates missing canonical FTS triggers without dropping live triggers.
- Use that non-destructive trigger ensure path in normal archive write effects.
- Make `_process_ingest_batch_sync` keep FTS triggers active by default; the old suspend/restore behavior is now explicit opt-in only.
- Keep destructive `restore_fts_triggers_sync` for explicit startup repair and full rebuild paths.

## Verification

- `pytest tests/unit/archive/test_write_gateway.py::test_write_gateway_normal_commit_does_not_drop_fts_triggers tests/unit/pipeline/test_ingest_batch.py::test_process_ingest_batch_sync_commits_fts_repair_and_invalidates_search_cache -q` → 2 passed
- `python -m ruff format --check polylogue/storage/fts/fts_lifecycle.py polylogue/archive/write_effects.py polylogue/pipeline/services/ingest_batch/_core.py tests/unit/archive/test_write_gateway.py tests/unit/pipeline/test_ingest_batch.py` → 5 files already formatted
- `python -m ruff check polylogue/storage/fts/fts_lifecycle.py polylogue/archive/write_effects.py polylogue/pipeline/services/ingest_batch/_core.py tests/unit/archive/test_write_gateway.py tests/unit/pipeline/test_ingest_batch.py` → All checks passed
- `python -m mypy polylogue/storage/fts/fts_lifecycle.py polylogue/archive/write_effects.py polylogue/pipeline/services/ingest_batch/_core.py tests/unit/archive/test_write_gateway.py tests/unit/pipeline/test_ingest_batch.py` → Success
- pre-push `devtools verify --quick` → exit_code 0, total_duration_s 37.18