### PR TITLE
fix(cli): keep status responsive under ingest

### DIFF
--- a/polylogue/cli/commands/status.py
+++ b/polylogue/cli/commands/status.py
@@ -14,8 +14,9 @@ from polylogue.cli.shared.types import AppEnv
 _BUILTIN_DAEMON_URL = "http://127.0.0.1:8766"
 # Bare `polylogue` uses this as a quick probe before falling back to SQLite.
 _FAST_TIMEOUT_S = 1.0
-# Explicit status can wait for large archive health payloads (~20s observed).
-_FULL_TIMEOUT_S = 30.0
+# Explicit status is still an operator command; a busy local daemon should fall
+# through to bounded read-only SQLite status instead of hiding the archive.
+_FULL_TIMEOUT_S = 3.0
 
 
 def _default_daemon_url() -> str:
@@ -45,6 +46,20 @@ def _fast_fts_doc_count(conn: Any) -> int:
         return _fast_count(conn, "SELECT COUNT(*) FROM messages_fts_docsize")
     except Exception:
         return 0
+
+
+def _table_exists(conn: Any, table_name: str) -> bool:
+    row = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ? LIMIT 1",
+        (table_name,),
+    ).fetchone()
+    return row is not None
+
+
+def _fast_message_count(conn: Any) -> int:
+    if _table_exists(conn, "conversation_stats"):
+        return _fast_count(conn, "SELECT COALESCE(SUM(message_count), 0) FROM conversation_stats")
+    return _fast_count(conn, "SELECT COUNT(*) FROM messages")
 
 
 @click.command("status")
@@ -207,12 +222,12 @@ def _show_direct_json(env: AppEnv) -> None:
     }
     if db.exists():
         try:
-            from polylogue.storage.sqlite.connection_profile import open_connection
+            from polylogue.storage.sqlite.connection_profile import open_readonly_connection
 
-            conn = open_connection(db)
+            conn = open_readonly_connection(db)
             try:
                 payload["conversations"] = conn.execute("SELECT COUNT(*) FROM conversations").fetchone()[0]
-                payload["messages"] = conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0]
+                payload["messages"] = _fast_message_count(conn)
                 payload["raw_records"] = conn.execute("SELECT COUNT(*) FROM raw_conversations").fetchone()[0]
             finally:
                 conn.close()
@@ -249,12 +264,12 @@ def _show_direct_status(env: AppEnv, *, compact: bool = False) -> None:
         return
 
     try:
-        from polylogue.storage.sqlite.connection_profile import open_connection
+        from polylogue.storage.sqlite.connection_profile import open_readonly_connection
 
-        conn = open_connection(db)
+        conn = open_readonly_connection(db)
         try:
             convs = _fast_count(conn, "SELECT COUNT(*) FROM conversations")
-            msgs = _fast_count(conn, "SELECT COUNT(*) FROM messages")
+            msgs = _fast_message_count(conn)
             raw = _fast_count(conn, "SELECT COUNT(*) FROM raw_conversations")
             fts = _fast_fts_doc_count(conn)
         finally:
@@ -271,7 +286,7 @@ def _show_direct_status(env: AppEnv, *, compact: bool = False) -> None:
         try:
             from polylogue.storage.embeddings.status_payload import embedding_status_payload
 
-            ep = embedding_status_payload(env)
+            ep = embedding_status_payload(env, include_retrieval_bands=False)
             if ep["total_conversations"] > 0:
                 emb_pct = ep["embedding_coverage_percent"]
                 emb_color = "green" if ep["retrieval_ready"] else "dim"

--- a/polylogue/storage/embeddings/status_payload.py
+++ b/polylogue/storage/embeddings/status_payload.py
@@ -142,13 +142,17 @@ def _payload_from_stats(
     }
 
 
-def embedding_status_payload(env: _HasConfig) -> EmbeddingStatusPayload:
+def embedding_status_payload(
+    env: _HasConfig,
+    *,
+    include_retrieval_bands: bool = True,
+) -> EmbeddingStatusPayload:
     """Read canonical embedding-status statistics for operator surfaces."""
     from polylogue.storage.embeddings.embedding_stats import read_embedding_stats_sync
     from polylogue.storage.sqlite.connection import open_read_connection
 
     with open_read_connection(env.config.db_path) as conn:
         total_conversations = _total_conversations(conn)
-        embedding_stats = read_embedding_stats_sync(conn)
+        embedding_stats = read_embedding_stats_sync(conn, include_retrieval_bands=include_retrieval_bands)
 
     return _payload_from_stats(total_conversations=total_conversations, stats=embedding_stats)

--- a/tests/unit/cli/test_status.py
+++ b/tests/unit/cli/test_status.py
@@ -9,11 +9,14 @@ from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
+from click.testing import CliRunner
 
 from polylogue.cli.commands.status import (
+    _FULL_TIMEOUT_S,
     _show_daemon_status,
     _show_direct_json,
     _show_direct_status,
+    status_command,
 )
 from polylogue.cli.shared.types import AppEnv
 
@@ -72,7 +75,9 @@ class TestNoArchiveStatus:
 
         with patch("polylogue.paths.db_path", return_value=fake_db):
             with patch("polylogue.paths.archive_root", return_value=fake_root):
-                with patch("polylogue.storage.sqlite.connection_profile.open_connection", return_value=mock_conn):
+                with patch(
+                    "polylogue.storage.sqlite.connection_profile.open_readonly_connection", return_value=mock_conn
+                ):
                     _show_direct_status(env)
 
         combined = _combined_calls(env)
@@ -97,16 +102,19 @@ class TestNoArchiveStatus:
                 return [self._value]
 
         class FakeConn:
-            def execute(self, sql: str) -> FakeCursor:
+            def execute(self, sql: str, params: tuple[object, ...] | None = None) -> FakeCursor:
                 queries.append(sql)
+                if "sqlite_master" in sql and params == ("conversation_stats",):
+                    return FakeCursor(1)
                 assert "COUNT(*) FROM messages_fts" not in sql
+                assert "COUNT(*) FROM messages" not in sql
+                if "SUM(message_count)" in sql:
+                    return FakeCursor(11)
                 if "conversations" in sql:
                     return FakeCursor(7)
                 if "raw_conversations" in sql:
                     return FakeCursor(9)
                 if "messages_fts_docsize" in sql:
-                    return FakeCursor(11)
-                if "messages" in sql:
                     return FakeCursor(11)
                 return FakeCursor(0)
 
@@ -115,12 +123,30 @@ class TestNoArchiveStatus:
 
         with patch("polylogue.paths.db_path", return_value=fake_db):
             with patch("polylogue.paths.archive_root", return_value=fake_root):
-                with patch("polylogue.storage.sqlite.connection_profile.open_connection", return_value=FakeConn()):
+                with patch(
+                    "polylogue.storage.sqlite.connection_profile.open_readonly_connection", return_value=FakeConn()
+                ):
                     _show_direct_status(env)
 
         combined = _combined_calls(env)
         assert "FTS indexed" in combined
+        assert any("SUM(message_count)" in query for query in queries)
         assert any("messages_fts_docsize" in query for query in queries)
+
+    def test_explicit_status_has_short_daemon_timeout_before_direct_fallback(self) -> None:
+        """Explicit status must not hide behind a daemon blocked on ingest."""
+        env = _make_app_env()
+
+        def raise_timeout(_request: object, *, timeout: float) -> None:
+            assert timeout == _FULL_TIMEOUT_S
+            raise TimeoutError
+
+        with patch("polylogue.cli.commands.status.urlopen", side_effect=raise_timeout):
+            with patch("polylogue.cli.commands.status._show_direct_status") as show_direct:
+                result = CliRunner().invoke(status_command, ["--daemon-url", "http://127.0.0.1:8766"], obj=env)
+
+        assert result.exit_code == 0
+        show_direct.assert_called_once_with(env)
 
     def test_daemon_status_uses_reported_fts_coverage_pct(self) -> None:
         env = _make_app_env()


### PR DESCRIPTION
## Summary

Keep `polylogue status` usable while the daemon is ingesting by bounding the daemon probe and making the direct SQLite fallback use cheap readiness counters.

## Problem

The FTS trigger-safety fix keeps FTS current, but operator status could still become unavailable under live ingest pressure. If `/api/status` was busy, the CLI waited too long and then the direct fallback still touched large read-model paths: full message counts and embedding retrieval-band status could scan expensive tables. That made it hard to confirm that FTS was actually ready during catch-up.

## Solution

- Bound the explicit daemon status probe to 3s, then fall back to local read-only SQLite.
- Use `conversation_stats` for message totals when present instead of `COUNT(*) FROM messages`.
- Keep FTS fallback coverage based on `messages_fts_docsize`, not the FTS virtual table.
- Let embedding status payloads skip retrieval-band scans, and use that cheaper mode from direct CLI status.
- Add tests for the short timeout/fallback path and the stats-backed direct status query shape.

## Verification

- `pytest tests/unit/cli/test_status.py tests/unit/storage/test_embedding_stats.py tests/unit/storage/test_vec.py -q` -> 53 passed.
- `ruff format --check polylogue/cli/commands/status.py polylogue/storage/embeddings/status_payload.py tests/unit/cli/test_status.py && ruff check polylogue/cli/commands/status.py polylogue/storage/embeddings/status_payload.py tests/unit/cli/test_status.py` -> passed.
- `mypy polylogue/cli/commands/status.py polylogue/storage/embeddings/status_payload.py tests/unit/cli/test_status.py` -> success.
- `POLYLOGUE_DAEMON_URL=http://127.0.0.1:1 timeout 12 python -m polylogue.cli --plain status` against the real archive returned `FTS indexed: 100.0%`.
- `devtools verify --quick` -> passed in 43.39s.

Ref #1437

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance**
  * Status command now returns results faster when unable to reach the daemon
  * Optimized database query performance for status report generation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sinity/polylogue/pull/1438?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->