### PR TITLE
fix(daemon): target startup FTS gap repair

### DIFF
--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -88,6 +88,8 @@ here to keep the daemon startup path independent of the health-check
 module's import surface.
 """
 
+_STARTUP_FTS_TARGETED_REPAIR_LIMIT = 5_000
+
 
 def _missing_fts_triggers_sync(conn: sqlite3.Connection) -> list[str]:
     placeholders = ",".join("?" for _ in _EXPECTED_FTS_TRIGGERS)
@@ -97,6 +99,71 @@ def _missing_fts_triggers_sync(conn: sqlite3.Connection) -> list[str]:
     ).fetchall()
     present = {row[0] for row in rows}
     return [name for name in _EXPECTED_FTS_TRIGGERS if name not in present]
+
+
+def _missing_message_fts_conversation_ids_sync(
+    conn: sqlite3.Connection,
+    *,
+    limit: int = _STARTUP_FTS_TARGETED_REPAIR_LIMIT,
+) -> list[str]:
+    rows = conn.execute(
+        """
+        SELECT DISTINCT m.conversation_id
+        FROM messages AS m
+        LEFT JOIN messages_fts_docsize AS d ON d.id = m.rowid
+        WHERE m.text IS NOT NULL AND d.id IS NULL
+        ORDER BY m.conversation_id
+        LIMIT ?
+        """,
+        (limit + 1,),
+    ).fetchall()
+    return [str(row[0]) for row in rows]
+
+
+def _excess_message_fts_row_count_sync(conn: sqlite3.Connection) -> int:
+    row = conn.execute(
+        """
+        SELECT COUNT(*)
+        FROM messages_fts_docsize AS d
+        LEFT JOIN messages AS m ON m.rowid = d.id AND m.text IS NOT NULL
+        WHERE m.rowid IS NULL
+        """,
+    ).fetchone()
+    return int(row[0] or 0) if row is not None else 0
+
+
+def _repair_message_fts_gap_sync(conn: sqlite3.Connection, *, indexed_messages: int, indexable_messages: int) -> bool:
+    if indexed_messages >= indexable_messages:
+        return False
+    missing_conversation_ids = _missing_message_fts_conversation_ids_sync(conn)
+    if not missing_conversation_ids:
+        return False
+    if len(missing_conversation_ids) > _STARTUP_FTS_TARGETED_REPAIR_LIMIT:
+        logger.warning(
+            "daemon: message FTS startup gap spans more than %d conversations; falling back to full rebuild.",
+            _STARTUP_FTS_TARGETED_REPAIR_LIMIT,
+        )
+        return False
+
+    from polylogue.storage.fts.fts_lifecycle import repair_message_fts_index_sync
+
+    logger.warning(
+        "daemon: message FTS count mismatch on startup (%d/%d indexed). Repairing %d affected conversation(s).",
+        indexed_messages,
+        indexable_messages,
+        len(missing_conversation_ids),
+    )
+    repair_message_fts_index_sync(conn, missing_conversation_ids)
+    repaired_indexed_messages = int(conn.execute("SELECT COUNT(*) FROM messages_fts_docsize").fetchone()[0] or 0)
+    if repaired_indexed_messages == indexable_messages:
+        logger.info("daemon: targeted message FTS repair complete.")
+        return True
+    logger.warning(
+        "daemon: targeted message FTS repair left mismatch (%d/%d indexed); falling back to full rebuild.",
+        repaired_indexed_messages,
+        indexable_messages,
+    )
+    return False
 
 
 def _table_exists_sync(conn: sqlite3.Connection, table_name: str) -> bool:
@@ -153,14 +220,10 @@ async def _ensure_fts_startup_readiness() -> None:
         if missing_triggers:
             logger.warning(
                 "daemon: FTS triggers missing on startup (%s). "
-                "SIGKILL-during-bulk-suspend signature; restoring and rebuilding FTS index.",
+                "SIGKILL-during-bulk-suspend signature; restoring triggers before freshness repair.",
                 ", ".join(missing_triggers),
             )
             restore_fts_triggers_sync(conn)
-            rebuild_fts_index_sync(conn)
-            conn.commit()
-            logger.info("daemon: FTS trigger restore + rebuild complete.")
-            return
 
         ensure_fts_index_sync(conn)
         has_indexable_messages = bool(conn.execute("SELECT 1 FROM messages WHERE text IS NOT NULL LIMIT 1").fetchone())
@@ -177,10 +240,20 @@ async def _ensure_fts_startup_readiness() -> None:
             )
             indexed_messages = int(conn.execute("SELECT COUNT(*) FROM messages_fts_docsize").fetchone()[0] or 0)
             if indexable_messages and indexed_messages != indexable_messages:
+                excess_rows = _excess_message_fts_row_count_sync(conn)
+                if excess_rows == 0 and _repair_message_fts_gap_sync(
+                    conn,
+                    indexed_messages=indexed_messages,
+                    indexable_messages=indexable_messages,
+                ):
+                    conn.commit()
+                    return
                 logger.warning(
-                    "daemon: message FTS count mismatch on startup (%d/%d indexed). Rebuilding once.",
+                    "daemon: message FTS structural mismatch on startup (%d/%d indexed, %d excess row(s)). "
+                    "Rebuilding once.",
                     indexed_messages,
                     indexable_messages,
+                    excess_rows,
                 )
                 rebuild_fts_index_sync(conn)
                 conn.commit()

--- a/tests/unit/daemon/test_daemon_cli.py
+++ b/tests/unit/daemon/test_daemon_cli.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 import sqlite3
+from collections.abc import Sequence
 from datetime import timedelta
 from pathlib import Path
 from typing import cast
@@ -476,6 +477,11 @@ def test_ensure_fts_startup_readiness_rebuilds_stats_count_mismatch(
                 return FakeCursor((5,))
             if query == "SELECT COUNT(*) FROM messages_fts_docsize":
                 return FakeCursor((6,))
+            if query == (
+                "SELECT COUNT(*) FROM messages_fts_docsize AS d LEFT JOIN messages AS m "
+                "ON m.rowid = d.id AND m.text IS NOT NULL WHERE m.rowid IS NULL"
+            ):
+                return FakeCursor((1,))
             raise AssertionError(f"unexpected query: {query}")
 
         def commit(self) -> None:
@@ -501,6 +507,98 @@ def test_ensure_fts_startup_readiness_rebuilds_stats_count_mismatch(
     assert conn.committed is True
     assert conn.closed is True
     assert all("COUNT(*) FROM messages WHERE text IS NOT NULL" not in query for query in conn.queries)
+
+
+def test_ensure_fts_startup_readiness_repairs_missing_message_rows(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from polylogue.daemon import cli as daemon_cli
+
+    db = tmp_path / "polylogue.db"
+    db.write_bytes(b"sqlite placeholder")
+
+    class FakeCursor:
+        def __init__(self, row: tuple[object, ...] | None, rows: list[tuple[object, ...]] | None = None) -> None:
+            self._row = row
+            self._rows = rows if rows is not None else ([] if row is None else [row])
+
+        def fetchone(self) -> tuple[object, ...] | None:
+            return self._row
+
+        def fetchall(self) -> list[tuple[object, ...]]:
+            return self._rows
+
+    class FakeConnection:
+        def __init__(self) -> None:
+            self.queries: list[str] = []
+            self.committed = False
+            self.closed = False
+            self.doc_count_reads = 0
+
+        def execute(self, sql: str, _params: object = ()) -> FakeCursor:
+            query = " ".join(sql.split())
+            self.queries.append(query)
+            if query == "SELECT name FROM sqlite_master WHERE type='table' AND name='messages_fts'":
+                return FakeCursor(("messages_fts",))
+            if query.startswith("SELECT name FROM sqlite_master WHERE type='trigger'"):
+                triggers: list[tuple[object, ...]] = [
+                    ("messages_fts_ai",),
+                    ("messages_fts_ad",),
+                    ("messages_fts_au",),
+                    ("action_events_fts_ai",),
+                    ("action_events_fts_ad",),
+                    ("action_events_fts_au",),
+                ]
+                return FakeCursor(triggers[0], rows=triggers)
+            if query == "SELECT 1 FROM messages WHERE text IS NOT NULL LIMIT 1":
+                return FakeCursor((1,))
+            if query == "SELECT 1 FROM messages_fts_docsize LIMIT 1":
+                return FakeCursor((1,))
+            if query == "SELECT 1 FROM sqlite_master WHERE type IN ('table', 'virtual table') AND name = ? LIMIT 1":
+                return FakeCursor((1,))
+            if query == "SELECT COALESCE(SUM(message_count), 0) FROM conversation_stats":
+                return FakeCursor((5,))
+            if query == "SELECT COUNT(*) FROM messages_fts_docsize":
+                self.doc_count_reads += 1
+                return FakeCursor((4 if self.doc_count_reads == 1 else 5,))
+            if query == (
+                "SELECT COUNT(*) FROM messages_fts_docsize AS d LEFT JOIN messages AS m "
+                "ON m.rowid = d.id AND m.text IS NOT NULL WHERE m.rowid IS NULL"
+            ):
+                return FakeCursor((0,))
+            if query.startswith("SELECT DISTINCT m.conversation_id FROM messages AS m"):
+                return FakeCursor(("conv-a",), rows=[("conv-a",)])
+            raise AssertionError(f"unexpected query: {query}")
+
+        def commit(self) -> None:
+            self.committed = True
+
+        def close(self) -> None:
+            self.closed = True
+
+    conn = FakeConnection()
+    rebuilds: list[FakeConnection] = []
+    repaired: list[tuple[FakeConnection, Sequence[str]]] = []
+
+    monkeypatch.setattr("polylogue.paths.db_path", lambda: db)
+    monkeypatch.setattr("polylogue.storage.sqlite.connection_profile.open_connection", lambda _db, timeout: conn)
+    monkeypatch.setattr("polylogue.storage.fts.fts_lifecycle.ensure_fts_index_sync", lambda _conn: None)
+    monkeypatch.setattr(
+        "polylogue.storage.fts.fts_lifecycle.rebuild_fts_index_sync",
+        lambda fake_conn: rebuilds.append(fake_conn),
+    )
+    monkeypatch.setattr(
+        "polylogue.storage.fts.fts_lifecycle.repair_message_fts_index_sync",
+        lambda fake_conn, ids: repaired.append((fake_conn, tuple(ids))),
+    )
+
+    asyncio.run(daemon_cli._ensure_fts_startup_readiness())
+
+    assert repaired == [(conn, ("conv-a",))]
+    assert rebuilds == []
+    assert conn.committed is True
+    assert conn.closed is True
 
 
 def test_ensure_fts_startup_readiness_rebuilds_when_triggers_missing(
@@ -545,6 +643,16 @@ def test_ensure_fts_startup_readiness_rebuilds_when_triggers_missing(
                     ("action_events_fts_ad",),
                 ]
                 return FakeCursor(triggers[0], rows=triggers)
+            if query == "SELECT 1 FROM messages WHERE text IS NOT NULL LIMIT 1":
+                return FakeCursor((1,))
+            if query == "SELECT 1 FROM messages_fts_docsize LIMIT 1":
+                return FakeCursor((1,))
+            if query == "SELECT 1 FROM sqlite_master WHERE type IN ('table', 'virtual table') AND name = ? LIMIT 1":
+                return FakeCursor((1,))
+            if query == "SELECT COALESCE(SUM(message_count), 0) FROM conversation_stats":
+                return FakeCursor((5,))
+            if query == "SELECT COUNT(*) FROM messages_fts_docsize":
+                return FakeCursor((5,))
             raise AssertionError(f"unexpected query: {query}")
 
         def commit(self) -> None:
@@ -574,9 +682,9 @@ def test_ensure_fts_startup_readiness_rebuilds_when_triggers_missing(
 
     asyncio.run(daemon_cli._ensure_fts_startup_readiness())
 
-    assert ensured == []
+    assert ensured == [conn]
     assert restored == [conn]
-    assert rebuilds == [conn]
+    assert rebuilds == []
     assert conn.committed is True
     assert conn.closed is True
 


### PR DESCRIPTION
## Summary

Make daemon startup repair small FTS gaps by repairing only the conversations with missing message FTS rows instead of rebuilding the entire archive FTS index. Full rebuild remains for missing/empty FTS tables and structural excess-row corruption.

## Problem

Live deployment of #1440 showed the daemon detecting a 56-row message FTS gap in a 3.67M-message archive and starting a full FTS rebuild before binding the HTTP health surface. That consumed ~21GB reads, ~9GB writes, peaked at the 6G memory-high boundary, left the daemon not listening on 8765/8766, and drove IO PSI severe.

## Solution

Startup now distinguishes missing-row drift from structural corruption. When `messages_fts_docsize` is behind `conversation_stats`, it locates affected `messages.conversation_id` values via the missing rowids and runs `repair_message_fts_index_sync` for those conversations. Missing triggers are restored first and then flow through the same freshness repair path. Excess/stale FTS docsize rows still fall back to a full rebuild because external-content FTS rows cannot be safely deleted without the source row.

## Verification

- `pytest tests/unit/daemon/test_daemon_cli.py::test_ensure_fts_startup_readiness_uses_bounded_probes tests/unit/daemon/test_daemon_cli.py::test_ensure_fts_startup_readiness_rebuilds_empty_fts tests/unit/daemon/test_daemon_cli.py::test_ensure_fts_startup_readiness_rebuilds_stats_count_mismatch tests/unit/daemon/test_daemon_cli.py::test_ensure_fts_startup_readiness_repairs_missing_message_rows tests/unit/daemon/test_daemon_cli.py::test_ensure_fts_startup_readiness_rebuilds_when_triggers_missing tests/unit/cli/test_query_exec.py::test_query_plan_action_retrieval_lane_rejects_unready_action_read_model tests/unit/storage/test_perf_rescue_1314.py::test_search_conversation_hits_does_not_count_fts_index tests/unit/storage/test_retrieval_readiness_laws.py tests/unit/storage/test_fts5.py tests/unit/archive/test_query_search_runtime.py tests/unit/daemon/test_health_check_paths.py tests/unit/daemon/test_daemon_status.py tests/unit/daemon/test_health_contract.py::TestReadinessProbeContract tests/unit/daemon/test_fts_trigger_drift.py tests/unit/storage/test_fts_trigger_lifecycle.py tests/unit/storage/test_fts_repair_sql.py tests/unit/cli/test_insights.py::test_insights_profiles_reject_incomplete_profile_search_index tests/unit/storage/test_fts_escape_in_insights.py -q` — 180 passed in 3.80s
- `devtools verify --quick` — passed in 35.38s

Ref #1439