### PR TITLE
fix(daemon): bound FTS startup probes

### DIFF
--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -88,8 +88,6 @@ here to keep the daemon startup path independent of the health-check
 module's import surface.
 """
 
-_STARTUP_FTS_TARGETED_REPAIR_LIMIT = 5_000
-
 
 def _missing_fts_triggers_sync(conn: sqlite3.Connection) -> list[str]:
     placeholders = ",".join("?" for _ in _EXPECTED_FTS_TRIGGERS)
@@ -101,77 +99,18 @@ def _missing_fts_triggers_sync(conn: sqlite3.Connection) -> list[str]:
     return [name for name in _EXPECTED_FTS_TRIGGERS if name not in present]
 
 
-def _missing_message_fts_conversation_ids_sync(
-    conn: sqlite3.Connection,
-    *,
-    limit: int = _STARTUP_FTS_TARGETED_REPAIR_LIMIT,
-) -> list[str]:
-    rows = conn.execute(
-        """
-        SELECT DISTINCT m.conversation_id
-        FROM messages AS m
-        LEFT JOIN messages_fts_docsize AS d ON d.id = m.rowid
-        WHERE m.text IS NOT NULL AND d.id IS NULL
-        ORDER BY m.conversation_id
-        LIMIT ?
-        """,
-        (limit + 1,),
-    ).fetchall()
-    return [str(row[0]) for row in rows]
-
-
-def _excess_message_fts_row_count_sync(conn: sqlite3.Connection) -> int:
-    row = conn.execute(
-        """
-        SELECT COUNT(*)
-        FROM messages_fts_docsize AS d
-        LEFT JOIN messages AS m ON m.rowid = d.id AND m.text IS NOT NULL
-        WHERE m.rowid IS NULL
-        """,
-    ).fetchone()
-    return int(row[0] or 0) if row is not None else 0
-
-
-def _repair_message_fts_gap_sync(conn: sqlite3.Connection, *, indexed_messages: int, indexable_messages: int) -> bool:
-    if indexed_messages >= indexable_messages:
-        return False
-    missing_conversation_ids = _missing_message_fts_conversation_ids_sync(conn)
-    if not missing_conversation_ids:
-        return False
-    if len(missing_conversation_ids) > _STARTUP_FTS_TARGETED_REPAIR_LIMIT:
-        logger.warning(
-            "daemon: message FTS startup gap spans more than %d conversations; falling back to full rebuild.",
-            _STARTUP_FTS_TARGETED_REPAIR_LIMIT,
-        )
-        return False
-
-    from polylogue.storage.fts.fts_lifecycle import repair_message_fts_index_sync
-
-    logger.warning(
-        "daemon: message FTS count mismatch on startup (%d/%d indexed). Repairing %d affected conversation(s).",
-        indexed_messages,
-        indexable_messages,
-        len(missing_conversation_ids),
-    )
-    repair_message_fts_index_sync(conn, missing_conversation_ids)
-    repaired_indexed_messages = int(conn.execute("SELECT COUNT(*) FROM messages_fts_docsize").fetchone()[0] or 0)
-    if repaired_indexed_messages == indexable_messages:
-        logger.info("daemon: targeted message FTS repair complete.")
-        return True
-    logger.warning(
-        "daemon: targeted message FTS repair left mismatch (%d/%d indexed); falling back to full rebuild.",
-        repaired_indexed_messages,
-        indexable_messages,
-    )
-    return False
-
-
 def _table_exists_sync(conn: sqlite3.Connection, table_name: str) -> bool:
     row = conn.execute(
         "SELECT 1 FROM sqlite_master WHERE type IN ('table', 'virtual table') AND name = ? LIMIT 1",
         (table_name,),
     ).fetchone()
     return row is not None
+
+
+def _enable_faulthandler_if_supported() -> None:
+    """Enable faulthandler when stderr exposes a real file descriptor."""
+    with contextlib.suppress(Exception):
+        faulthandler.enable()
 
 
 async def _ensure_fts_startup_readiness() -> None:
@@ -184,11 +123,17 @@ async def _ensure_fts_startup_readiness() -> None:
     2. FTS table exists but is empty while messages exist → rebuild.
     3. FTS triggers missing (the SIGKILL-during-bulk-suspend signature
        called out in ``docs/internals.md`` "FTS5 Model → Risk") →
-       restore triggers and rebuild the FTS index. The bulk-ingest
-       path drops these triggers as DDL (auto-committed); a SIGKILL
-       between the drop and the matching restore leaves them gone
-       across process death, and subsequent writes silently bypass the
-       FTS index. See #1242.
+       restore triggers before serving. The bulk-ingest path drops
+       these triggers as DDL (auto-committed); a SIGKILL between the
+       drop and the matching restore leaves them gone across process
+       death, and subsequent writes silently bypass the FTS index. See
+       #1242.
+
+    This path must stay bounded. Exact FTS freshness checks over the
+    shadow tables are explicit/post-listen maintenance work; on real
+    archives even ``COUNT(*)`` over ``messages_fts_docsize`` can take
+    tens of seconds and fault gigabytes of pages before health sockets
+    are available (#1442).
     """
     from polylogue.paths import db_path
     from polylogue.storage.sqlite.connection_profile import open_connection
@@ -234,32 +179,6 @@ async def _ensure_fts_startup_readiness() -> None:
             conn.commit()
             logger.info("daemon: FTS rebuild complete.")
             return
-        if _table_exists_sync(conn, "conversation_stats") and _table_exists_sync(conn, "messages_fts_docsize"):
-            indexable_messages = int(
-                conn.execute("SELECT COALESCE(SUM(message_count), 0) FROM conversation_stats").fetchone()[0] or 0
-            )
-            indexed_messages = int(conn.execute("SELECT COUNT(*) FROM messages_fts_docsize").fetchone()[0] or 0)
-            if indexable_messages and indexed_messages != indexable_messages:
-                excess_rows = _excess_message_fts_row_count_sync(conn)
-                if excess_rows == 0 and _repair_message_fts_gap_sync(
-                    conn,
-                    indexed_messages=indexed_messages,
-                    indexable_messages=indexable_messages,
-                ):
-                    conn.commit()
-                    return
-                logger.warning(
-                    "daemon: message FTS structural mismatch on startup (%d/%d indexed, %d excess row(s)). "
-                    "Rebuilding once.",
-                    indexed_messages,
-                    indexable_messages,
-                    excess_rows,
-                )
-                rebuild_fts_index_sync(conn)
-                conn.commit()
-                logger.info("daemon: FTS rebuild complete.")
-                return
-
         conn.commit()
     except Exception:
         logger.warning("daemon: FTS startup check failed", exc_info=True)
@@ -988,7 +907,7 @@ def run_command(
 
     This is the entry point for the polylogued systemd service.
     """
-    faulthandler.enable()
+    _enable_faulthandler_if_supported()
     configure_logging()
 
     enable_watch = not no_watch

--- a/tests/unit/daemon/test_daemon_cli.py
+++ b/tests/unit/daemon/test_daemon_cli.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import inspect
 import sqlite3
-from collections.abc import Sequence
 from datetime import timedelta
 from pathlib import Path
 from typing import cast
@@ -308,12 +307,6 @@ def test_ensure_fts_startup_readiness_uses_bounded_probes(
                 return FakeCursor((1,))
             if query == "SELECT 1 FROM messages_fts_docsize LIMIT 1":
                 return FakeCursor((1,))
-            if query == "SELECT 1 FROM sqlite_master WHERE type IN ('table', 'virtual table') AND name = ? LIMIT 1":
-                return FakeCursor((1,))
-            if query == "SELECT COALESCE(SUM(message_count), 0) FROM conversation_stats":
-                return FakeCursor((1,))
-            if query == "SELECT COUNT(*) FROM messages_fts_docsize":
-                return FakeCursor((1,))
             raise AssertionError(f"unexpected query: {query}")
 
         def commit(self) -> None:
@@ -343,7 +336,9 @@ def test_ensure_fts_startup_readiness_uses_bounded_probes(
     assert rebuilds == []
     assert conn.committed is True
     assert conn.closed is True
-    assert all("COUNT(*) FROM messages_fts " not in query for query in conn.queries)
+    assert all("COUNT(*) FROM messages_fts" not in query for query in conn.queries)
+    assert all("COUNT(*) FROM messages_fts_docsize" not in query for query in conn.queries)
+    assert all("LEFT JOIN messages_fts_docsize" not in query for query in conn.queries)
     assert all("COUNT(*) FROM messages WHERE text IS NOT NULL" not in query for query in conn.queries)
 
 
@@ -392,12 +387,6 @@ def test_ensure_fts_startup_readiness_rebuilds_empty_fts(
                 return FakeCursor((1,))
             if query == "SELECT 1 FROM messages_fts_docsize LIMIT 1":
                 return FakeCursor(None)
-            if query == "SELECT 1 FROM sqlite_master WHERE type IN ('table', 'virtual table') AND name = ? LIMIT 1":
-                return FakeCursor((1,))
-            if query == "SELECT COALESCE(SUM(message_count), 0) FROM conversation_stats":
-                return FakeCursor((1,))
-            if query == "SELECT COUNT(*) FROM messages_fts_docsize":
-                return FakeCursor((0,))
             raise AssertionError(f"unexpected query: {query}")
 
         def commit(self) -> None:
@@ -422,183 +411,10 @@ def test_ensure_fts_startup_readiness_rebuilds_empty_fts(
     assert rebuilds == [conn]
     assert conn.committed is True
     assert conn.closed is True
-    assert all("COUNT(*) FROM messages_fts " not in query for query in conn.queries)
+    assert all("COUNT(*) FROM messages_fts" not in query for query in conn.queries)
+    assert all("COUNT(*) FROM messages_fts_docsize" not in query for query in conn.queries)
+    assert all("LEFT JOIN messages_fts_docsize" not in query for query in conn.queries)
     assert all("COUNT(*) FROM messages WHERE text IS NOT NULL" not in query for query in conn.queries)
-
-
-def test_ensure_fts_startup_readiness_rebuilds_stats_count_mismatch(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    from polylogue.daemon import cli as daemon_cli
-
-    db = tmp_path / "polylogue.db"
-    db.write_bytes(b"sqlite placeholder")
-
-    class FakeCursor:
-        def __init__(self, row: tuple[object, ...] | None, rows: list[tuple[object, ...]] | None = None) -> None:
-            self._row = row
-            self._rows = rows if rows is not None else ([] if row is None else [row])
-
-        def fetchone(self) -> tuple[object, ...] | None:
-            return self._row
-
-        def fetchall(self) -> list[tuple[object, ...]]:
-            return self._rows
-
-    class FakeConnection:
-        def __init__(self) -> None:
-            self.queries: list[str] = []
-            self.committed = False
-            self.closed = False
-
-        def execute(self, sql: str, _params: object = ()) -> FakeCursor:
-            query = " ".join(sql.split())
-            self.queries.append(query)
-            if query == "SELECT name FROM sqlite_master WHERE type='table' AND name='messages_fts'":
-                return FakeCursor(("messages_fts",))
-            if query.startswith("SELECT name FROM sqlite_master WHERE type='trigger'"):
-                triggers: list[tuple[object, ...]] = [
-                    ("messages_fts_ai",),
-                    ("messages_fts_ad",),
-                    ("messages_fts_au",),
-                    ("action_events_fts_ai",),
-                    ("action_events_fts_ad",),
-                    ("action_events_fts_au",),
-                ]
-                return FakeCursor(triggers[0], rows=triggers)
-            if query == "SELECT 1 FROM messages WHERE text IS NOT NULL LIMIT 1":
-                return FakeCursor((1,))
-            if query == "SELECT 1 FROM messages_fts_docsize LIMIT 1":
-                return FakeCursor((1,))
-            if query == "SELECT 1 FROM sqlite_master WHERE type IN ('table', 'virtual table') AND name = ? LIMIT 1":
-                return FakeCursor((1,))
-            if query == "SELECT COALESCE(SUM(message_count), 0) FROM conversation_stats":
-                return FakeCursor((5,))
-            if query == "SELECT COUNT(*) FROM messages_fts_docsize":
-                return FakeCursor((6,))
-            if query == (
-                "SELECT COUNT(*) FROM messages_fts_docsize AS d LEFT JOIN messages AS m "
-                "ON m.rowid = d.id AND m.text IS NOT NULL WHERE m.rowid IS NULL"
-            ):
-                return FakeCursor((1,))
-            raise AssertionError(f"unexpected query: {query}")
-
-        def commit(self) -> None:
-            self.committed = True
-
-        def close(self) -> None:
-            self.closed = True
-
-    conn = FakeConnection()
-    rebuilds: list[FakeConnection] = []
-
-    monkeypatch.setattr("polylogue.paths.db_path", lambda: db)
-    monkeypatch.setattr("polylogue.storage.sqlite.connection_profile.open_connection", lambda _db, timeout: conn)
-    monkeypatch.setattr("polylogue.storage.fts.fts_lifecycle.ensure_fts_index_sync", lambda _conn: None)
-    monkeypatch.setattr(
-        "polylogue.storage.fts.fts_lifecycle.rebuild_fts_index_sync",
-        lambda fake_conn: rebuilds.append(fake_conn),
-    )
-
-    asyncio.run(daemon_cli._ensure_fts_startup_readiness())
-
-    assert rebuilds == [conn]
-    assert conn.committed is True
-    assert conn.closed is True
-    assert all("COUNT(*) FROM messages WHERE text IS NOT NULL" not in query for query in conn.queries)
-
-
-def test_ensure_fts_startup_readiness_repairs_missing_message_rows(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    from polylogue.daemon import cli as daemon_cli
-
-    db = tmp_path / "polylogue.db"
-    db.write_bytes(b"sqlite placeholder")
-
-    class FakeCursor:
-        def __init__(self, row: tuple[object, ...] | None, rows: list[tuple[object, ...]] | None = None) -> None:
-            self._row = row
-            self._rows = rows if rows is not None else ([] if row is None else [row])
-
-        def fetchone(self) -> tuple[object, ...] | None:
-            return self._row
-
-        def fetchall(self) -> list[tuple[object, ...]]:
-            return self._rows
-
-    class FakeConnection:
-        def __init__(self) -> None:
-            self.queries: list[str] = []
-            self.committed = False
-            self.closed = False
-            self.doc_count_reads = 0
-
-        def execute(self, sql: str, _params: object = ()) -> FakeCursor:
-            query = " ".join(sql.split())
-            self.queries.append(query)
-            if query == "SELECT name FROM sqlite_master WHERE type='table' AND name='messages_fts'":
-                return FakeCursor(("messages_fts",))
-            if query.startswith("SELECT name FROM sqlite_master WHERE type='trigger'"):
-                triggers: list[tuple[object, ...]] = [
-                    ("messages_fts_ai",),
-                    ("messages_fts_ad",),
-                    ("messages_fts_au",),
-                    ("action_events_fts_ai",),
-                    ("action_events_fts_ad",),
-                    ("action_events_fts_au",),
-                ]
-                return FakeCursor(triggers[0], rows=triggers)
-            if query == "SELECT 1 FROM messages WHERE text IS NOT NULL LIMIT 1":
-                return FakeCursor((1,))
-            if query == "SELECT 1 FROM messages_fts_docsize LIMIT 1":
-                return FakeCursor((1,))
-            if query == "SELECT 1 FROM sqlite_master WHERE type IN ('table', 'virtual table') AND name = ? LIMIT 1":
-                return FakeCursor((1,))
-            if query == "SELECT COALESCE(SUM(message_count), 0) FROM conversation_stats":
-                return FakeCursor((5,))
-            if query == "SELECT COUNT(*) FROM messages_fts_docsize":
-                self.doc_count_reads += 1
-                return FakeCursor((4 if self.doc_count_reads == 1 else 5,))
-            if query == (
-                "SELECT COUNT(*) FROM messages_fts_docsize AS d LEFT JOIN messages AS m "
-                "ON m.rowid = d.id AND m.text IS NOT NULL WHERE m.rowid IS NULL"
-            ):
-                return FakeCursor((0,))
-            if query.startswith("SELECT DISTINCT m.conversation_id FROM messages AS m"):
-                return FakeCursor(("conv-a",), rows=[("conv-a",)])
-            raise AssertionError(f"unexpected query: {query}")
-
-        def commit(self) -> None:
-            self.committed = True
-
-        def close(self) -> None:
-            self.closed = True
-
-    conn = FakeConnection()
-    rebuilds: list[FakeConnection] = []
-    repaired: list[tuple[FakeConnection, Sequence[str]]] = []
-
-    monkeypatch.setattr("polylogue.paths.db_path", lambda: db)
-    monkeypatch.setattr("polylogue.storage.sqlite.connection_profile.open_connection", lambda _db, timeout: conn)
-    monkeypatch.setattr("polylogue.storage.fts.fts_lifecycle.ensure_fts_index_sync", lambda _conn: None)
-    monkeypatch.setattr(
-        "polylogue.storage.fts.fts_lifecycle.rebuild_fts_index_sync",
-        lambda fake_conn: rebuilds.append(fake_conn),
-    )
-    monkeypatch.setattr(
-        "polylogue.storage.fts.fts_lifecycle.repair_message_fts_index_sync",
-        lambda fake_conn, ids: repaired.append((fake_conn, tuple(ids))),
-    )
-
-    asyncio.run(daemon_cli._ensure_fts_startup_readiness())
-
-    assert repaired == [(conn, ("conv-a",))]
-    assert rebuilds == []
-    assert conn.committed is True
-    assert conn.closed is True
 
 
 def test_ensure_fts_startup_readiness_rebuilds_when_triggers_missing(
@@ -647,12 +463,6 @@ def test_ensure_fts_startup_readiness_rebuilds_when_triggers_missing(
                 return FakeCursor((1,))
             if query == "SELECT 1 FROM messages_fts_docsize LIMIT 1":
                 return FakeCursor((1,))
-            if query == "SELECT 1 FROM sqlite_master WHERE type IN ('table', 'virtual table') AND name = ? LIMIT 1":
-                return FakeCursor((1,))
-            if query == "SELECT COALESCE(SUM(message_count), 0) FROM conversation_stats":
-                return FakeCursor((5,))
-            if query == "SELECT COUNT(*) FROM messages_fts_docsize":
-                return FakeCursor((5,))
             raise AssertionError(f"unexpected query: {query}")
 
         def commit(self) -> None:


### PR DESCRIPTION
## Summary

Keeps `polylogued` startup bounded by removing exact message FTS shadow-table counts and gap joins from the pre-listen readiness path. Startup still repairs cheap structural hazards: missing FTS tables, missing triggers, and completely empty message FTS when messages exist.

## Problem

Live deployment of #1441 showed the daemon still scanning `messages_fts_docsize` before binding HTTP sockets. On the production archive, `SELECT COUNT(*) FROM messages_fts_docsize` took about 19s, the join probes exceeded 30s before manual termination, and the systemd service read ~860MB over 5s while reaching a 6G cgroup memory peak. That made restarts unobservable and hostile to the host.

Closes #1442.

## Solution

- Remove the pre-listen exact count and join-based gap repair from `polylogue.daemon.cli._ensure_fts_startup_readiness`.
- Preserve startup recovery for cheap structural failures only.
- Extend daemon CLI tests so the startup path rejects `COUNT(*) FROM messages_fts_docsize` and FTS docsize join probes.
- Guard `faulthandler.enable()` for Click test streams that do not expose `fileno()`.

## Verification

- `pytest tests/unit/daemon/test_daemon_cli.py tests/unit/daemon/test_fts_trigger_drift.py tests/unit/daemon/test_fts_global_repair.py tests/unit/daemon/test_health_contract.py tests/unit/daemon/test_daemon_status.py tests/unit/storage/test_fts_trigger_lifecycle.py tests/unit/storage/test_fts_repair_sql.py tests/unit/storage/test_fts5.py tests/unit/storage/test_fts_bloat_invariants.py tests/unit/storage/test_archive_search_contracts.py -q` → `154 passed in 3.80s`
- `devtools verify --quick` → exit_code 0, total_duration_s 45.42
- pre-push `devtools verify --quick` → exit_code 0, total_duration_s 35.25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced daemon startup fault handling with improved error tolerance for edge cases.

* **Refactor**
  * Streamlined FTS health verification logic during daemon initialization for better performance.
  * Simplified startup readiness checks to reduce unnecessary workload during initialization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sinity/polylogue/pull/1443?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->