### PR TITLE
fix(daemon): bound FTS health probes

### DIFF
--- a/polylogue/daemon/fts_status.py
+++ b/polylogue/daemon/fts_status.py
@@ -9,6 +9,33 @@ from pydantic import BaseModel, Field
 
 from polylogue.storage.sqlite.connection_profile import open_readonly_connection
 
+_FTS_SURFACES: tuple[tuple[str, str, str, tuple[str, ...]], ...] = (
+    (
+        "messages_fts",
+        "messages",
+        "messages_fts",
+        ("messages_fts_ai", "messages_fts_ad", "messages_fts_au"),
+    ),
+    (
+        "action_events_fts",
+        "action_events",
+        "action_events_fts",
+        ("action_events_fts_ai", "action_events_fts_ad", "action_events_fts_au"),
+    ),
+    (
+        "session_work_events_fts",
+        "session_work_events",
+        "session_work_events_fts",
+        ("session_work_events_fts_ai", "session_work_events_fts_ad", "session_work_events_fts_au"),
+    ),
+    (
+        "work_threads_fts",
+        "work_threads",
+        "work_threads_fts",
+        ("work_threads_fts_ai", "work_threads_fts_ad", "work_threads_fts_au"),
+    ),
+)
+
 
 class FTSReadiness(BaseModel):
     messages_ready: bool = False
@@ -24,16 +51,49 @@ class FTSReadiness(BaseModel):
     surfaces: dict[str, dict[str, int | bool]] = Field(default_factory=dict)
 
 
+def _table_exists(conn: sqlite3.Connection, table_name: str) -> bool:
+    row = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type IN ('table', 'virtual table') AND name = ? LIMIT 1",
+        (table_name,),
+    ).fetchone()
+    return row is not None
+
+
+def _triggers_present(conn: sqlite3.Connection, trigger_names: tuple[str, ...]) -> bool:
+    placeholders = ",".join("?" for _ in trigger_names)
+    rows = conn.execute(
+        f"SELECT name FROM sqlite_master WHERE type='trigger' AND name IN ({placeholders})",
+        trigger_names,
+    ).fetchall()
+    present = {row[0] for row in rows}
+    return all(name in present for name in trigger_names)
+
+
 def fts_readiness_info(dbf: Path) -> dict[str, object]:
-    """Check FTS table presence and source-count parity through bounded probes."""
+    """Return bounded structural FTS readiness for health/status probes."""
     if not dbf.exists():
         return {"messages_ready": False, "action_events_ready": False, "coverage_pct": 0.0}
     try:
         conn = open_readonly_connection(dbf)
         try:
-            from polylogue.storage.fts.fts_lifecycle import fts_invariant_snapshot_sync
-
-            snapshot = fts_invariant_snapshot_sync(conn)
+            surfaces: dict[str, dict[str, int | bool]] = {}
+            for name, source_table, fts_table, triggers in _FTS_SURFACES:
+                source_exists = _table_exists(conn, source_table)
+                exists = _table_exists(conn, fts_table)
+                triggers_present = exists and _triggers_present(conn, triggers)
+                ready = (exists and triggers_present) if source_exists else not exists
+                surfaces[name] = {
+                    "source_exists": source_exists,
+                    "exists": exists,
+                    "source_rows": 0,
+                    "indexed_rows": 0,
+                    "triggers_present": triggers_present,
+                    "missing_rows": 0,
+                    "excess_rows": 0,
+                    "duplicate_rows": 0,
+                    "ready": ready,
+                    "exact": False,
+                }
         finally:
             conn.close()
     except sqlite3.Error:
@@ -47,34 +107,22 @@ def fts_readiness_info(dbf: Path) -> dict[str, object]:
             "surfaces": {},
         }
 
-    message_indexable_count = snapshot.messages.source_rows
-    message_indexed_count = snapshot.messages.indexed_rows
-    action_event_count = snapshot.action_events.source_rows
-    action_event_indexed_count = snapshot.action_events.indexed_rows
-    coverage_pct = 100.0 if message_indexable_count == 0 else 100 * message_indexed_count / message_indexable_count
+    messages = surfaces["messages_fts"]
+    action_events = surfaces["action_events_fts"]
+    session_work_events = surfaces["session_work_events_fts"]
+    work_threads = surfaces["work_threads_fts"]
+    invariant_ready = all(bool(surface["ready"]) for surface in surfaces.values())
     return {
-        "messages_ready": snapshot.messages.ready,
-        "action_events_ready": snapshot.action_events.ready,
-        "session_work_events_ready": snapshot.session_work_events.ready,
-        "work_threads_ready": snapshot.work_threads.ready,
-        "invariant_ready": snapshot.ready,
-        "message_indexed_count": message_indexed_count,
-        "message_indexable_count": message_indexable_count,
-        "action_event_indexed_count": action_event_indexed_count,
-        "action_event_count": action_event_count,
-        "coverage_pct": round(max(0.0, coverage_pct), 1),
-        "surfaces": {
-            surface.name: {
-                "source_exists": surface.source_exists,
-                "exists": surface.exists,
-                "source_rows": surface.source_rows,
-                "indexed_rows": surface.indexed_rows,
-                "triggers_present": surface.triggers_present,
-                "missing_rows": surface.missing_rows,
-                "excess_rows": surface.excess_rows,
-                "duplicate_rows": surface.duplicate_rows,
-                "ready": surface.ready,
-            }
-            for surface in snapshot.surfaces
-        },
+        "messages_ready": messages["ready"],
+        "action_events_ready": action_events["ready"],
+        "session_work_events_ready": session_work_events["ready"],
+        "work_threads_ready": work_threads["ready"],
+        "invariant_ready": invariant_ready,
+        "message_indexed_count": 0,
+        "message_indexable_count": 0,
+        "action_event_indexed_count": 0,
+        "action_event_count": 0,
+        "coverage_pct": 100.0 if invariant_ready else 0.0,
+        "coverage_exact": False,
+        "surfaces": surfaces,
     }

--- a/tests/unit/daemon/test_daemon_status.py
+++ b/tests/unit/daemon/test_daemon_status.py
@@ -292,7 +292,7 @@ def test_daemon_status_fts_readiness_uses_lightweight_table_probe(tmp_path: Path
     assert readiness["invariant_ready"] is False
 
 
-def test_daemon_status_fts_readiness_uses_exact_message_source_count(tmp_path: Path) -> None:
+def test_daemon_status_fts_readiness_uses_bounded_structural_probes(tmp_path: Path) -> None:
     db = tmp_path / "polylogue.db"
     queries: list[str] = []
     with sqlite3.connect(db) as conn:
@@ -308,6 +308,9 @@ def test_daemon_status_fts_readiness_uses_exact_message_source_count(tmp_path: P
             CREATE TABLE action_events (event_id TEXT);
             CREATE TABLE action_events_fts (text TEXT);
             CREATE TABLE action_events_fts_docsize (id INTEGER PRIMARY KEY, sz BLOB);
+            CREATE TRIGGER action_events_fts_ai AFTER INSERT ON action_events BEGIN SELECT 1; END;
+            CREATE TRIGGER action_events_fts_ad AFTER DELETE ON action_events BEGIN SELECT 1; END;
+            CREATE TRIGGER action_events_fts_au AFTER UPDATE ON action_events BEGIN SELECT 1; END;
             INSERT INTO conversation_stats VALUES ('c1', 2), ('c2', 3);
             INSERT INTO messages(rowid, text) VALUES (1, 'a'), (2, 'b'), (3, 'c'), (4, 'd'), (5, 'e');
             INSERT INTO messages_fts_docsize VALUES (1, x''), (2, x''), (3, x''), (4, x''), (5, x'');
@@ -327,9 +330,13 @@ def test_daemon_status_fts_readiness_uses_exact_message_source_count(tmp_path: P
     ):
         readiness = status_module._fts_readiness_info()
 
-    assert readiness["message_indexable_count"] == 5
-    assert readiness["message_indexed_count"] == 5
-    assert any("COUNT(*) FROM messages WHERE text IS NOT NULL" in query for query in queries)
+    assert readiness["messages_ready"] is True
+    assert readiness["action_events_ready"] is True
+    assert readiness["invariant_ready"] is True
+    assert readiness["coverage_exact"] is False
+    assert all("COUNT(*) FROM messages" not in query for query in queries)
+    assert all("COUNT(*) FROM messages_fts_docsize" not in query for query in queries)
+    assert all("LEFT JOIN messages_fts_docsize" not in query for query in queries)
 
 
 def test_daemon_status_insight_freshness_uses_lightweight_counts(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Replace daemon FTS health/status readiness with bounded structural probes so `/healthz/ready` cannot scan the production archive while catch-up ingest is running.

## Problem

#1443 fixed the startup path, but live verification showed `/healthz/ready` on the API socket still timed out. The route called `fts_readiness_info()`, which delegated to the exact FTS invariant snapshot. On the live archive, those count and anti-join probes over `messages` / `messages_fts_docsize` took tens of seconds and could make readiness unusable even though the daemon was already listening and converging.

## Solution

`polylogue/daemon/fts_status.py` now uses sqlite_master-only structural checks for the daemon health/status surface: source table existence, FTS table existence, and expected trigger presence for each FTS surface. It reports `coverage_exact=false` so the payload is explicit that health readiness is not row-count proof. Exact FTS freshness remains enforced by the search/maintenance invariant paths rather than by the readiness endpoint.

The daemon status test now traces SQL and asserts the health readiness path does not issue `COUNT(*) FROM messages`, `COUNT(*) FROM messages_fts_docsize`, or FTS docsize joins.

Closes #1444

## Verification

- `pytest tests/unit/daemon/test_daemon_status.py tests/unit/daemon/test_health_contract.py -q` -> 30 passed
- `pytest tests/unit/daemon/test_daemon_status.py tests/unit/daemon/test_health_contract.py tests/unit/daemon/test_daemon_cli.py tests/unit/daemon/test_fts_trigger_drift.py tests/unit/storage/test_fts_trigger_lifecycle.py tests/unit/storage/test_fts_repair_sql.py tests/unit/storage/test_fts5.py -q` -> 141 passed
- `devtools verify --quick` -> exit_code 0, total_duration_s 37.18

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Refined full-text search readiness detection to use schema analysis instead of snapshot comparisons.
  * Modified readiness status metrics: coverage now reports simplified values and includes a precision indicator.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sinity/polylogue/pull/1445?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->