### PR TITLE
fix(daemon): keep exact FTS scans out of startup

### DIFF
--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -129,10 +129,10 @@ async def _ensure_fts_startup_readiness() -> None:
        death, and subsequent writes silently bypass the FTS index. See
        #1242.
 
-    This path restores obvious broken structure first, then verifies the
-    exact FTS invariant before the daemon starts serving readiness. Search
-    correctness wins over a fast start: a daemon that reports ready while
-    FTS is stale makes the archive unusable.
+    This path restores obvious broken structure first and records a
+    durable freshness state for search request handlers. It deliberately
+    avoids exact full-archive invariant scans: those run from the
+    ambient repair task, after HTTP/status surfaces have bound.
     """
     from polylogue.paths import db_path
     from polylogue.storage.sqlite.connection_profile import open_connection
@@ -147,11 +147,20 @@ async def _ensure_fts_startup_readiness() -> None:
         row = conn.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='messages_fts'").fetchone()
         has_fts_table = row is not None
 
+        from polylogue.storage.fts.freshness import (
+            STALE,
+            UNKNOWN,
+            ensure_fts_freshness_table_sync,
+            message_fts_marked_ready_sync,
+            record_fts_surface_state_sync,
+        )
         from polylogue.storage.fts.fts_lifecycle import (
             ensure_fts_index_sync,
             rebuild_fts_index_sync,
             restore_fts_triggers_sync,
         )
+
+        ensure_fts_freshness_table_sync(conn)
 
         if not has_fts_table:
             logger.warning("daemon: message FTS table missing. Rebuilding once.")
@@ -168,6 +177,12 @@ async def _ensure_fts_startup_readiness() -> None:
                 ", ".join(missing_triggers),
             )
             restore_fts_triggers_sync(conn)
+            record_fts_surface_state_sync(
+                conn,
+                surface="messages_fts",
+                state=STALE,
+                detail=f"startup restored missing triggers: {', '.join(missing_triggers)}",
+            )
 
         ensure_fts_index_sync(conn)
         has_indexable_messages = bool(conn.execute("SELECT 1 FROM messages WHERE text IS NOT NULL LIMIT 1").fetchone())
@@ -178,18 +193,14 @@ async def _ensure_fts_startup_readiness() -> None:
             conn.commit()
             logger.info("daemon: FTS rebuild complete.")
             return
-        from polylogue.storage.fts.freshness import record_fts_invariant_snapshot_sync
-        from polylogue.storage.fts.fts_lifecycle import fts_invariant_snapshot_sync
 
-        snapshot = fts_invariant_snapshot_sync(conn)
-        record_fts_invariant_snapshot_sync(conn, snapshot)
-        if not snapshot.ready:
-            stale_surfaces = ", ".join(surface.name for surface in snapshot.surfaces if not surface.ready)
-            logger.warning("daemon: exact FTS invariant stale on startup (%s). Rebuilding once.", stale_surfaces)
-            rebuild_fts_index_sync(conn)
-            conn.commit()
-            logger.info("daemon: FTS rebuild complete.")
-            return
+        if not message_fts_marked_ready_sync(conn):
+            record_fts_surface_state_sync(
+                conn,
+                surface="messages_fts",
+                state=STALE if missing_triggers else UNKNOWN,
+                detail="startup structural check passed; exact repair pending",
+            )
         conn.commit()
     except Exception:
         logger.warning("daemon: FTS startup check failed", exc_info=True)
@@ -302,8 +313,10 @@ async def _periodic_fts_repair() -> None:
     from polylogue.paths import db_path
 
     db = db_path()
+    delay_s = 30
     while True:
-        await asyncio.sleep(600)  # 10 minutes
+        await asyncio.sleep(delay_s)
+        delay_s = 600  # 10 minutes
         if not db.exists():
             continue
         try:
@@ -316,13 +329,23 @@ async def _periodic_fts_repair() -> None:
 
 def _repair_fts_if_stale_once(db: Path) -> bool:
     """Rebuild FTS once when exact invariants show drift."""
-    from polylogue.storage.fts.freshness import record_fts_invariant_snapshot_sync
-    from polylogue.storage.fts.fts_lifecycle import fts_invariant_snapshot_sync, rebuild_fts_index_sync
+    from polylogue.storage.fts.freshness import message_fts_marked_ready_sync, record_fts_invariant_snapshot_sync
+    from polylogue.storage.fts.fts_lifecycle import (
+        fts_invariant_snapshot_sync,
+        message_fts_readiness_sync,
+        rebuild_fts_index_sync,
+    )
     from polylogue.storage.search.cache import invalidate_search_cache
     from polylogue.storage.sqlite.connection_profile import open_connection
 
     conn = open_connection(db, timeout=30.0)
     try:
+        conn.execute("PRAGMA cache_size = -8192")
+        conn.execute("PRAGMA mmap_size = 0")
+        if message_fts_marked_ready_sync(conn):
+            readiness = message_fts_readiness_sync(conn, verify_total_rows=False)
+            if bool(readiness["ready"]):
+                return False
         snapshot = fts_invariant_snapshot_sync(conn)
         record_fts_invariant_snapshot_sync(conn, snapshot)
         if snapshot.ready:

--- a/polylogue/storage/fts/freshness.py
+++ b/polylogue/storage/fts/freshness.py
@@ -175,25 +175,33 @@ async def mark_all_fts_stale_async(conn: aiosqlite.Connection, *, detail: str) -
 
 
 def message_fts_marked_ready_sync(conn: sqlite3.Connection) -> bool:
+    return message_fts_recorded_state_sync(conn) == READY
+
+
+async def message_fts_marked_ready_async(conn: aiosqlite.Connection) -> bool:
+    return await message_fts_recorded_state_async(conn) == READY
+
+
+def message_fts_recorded_state_sync(conn: sqlite3.Connection) -> str | None:
     if not _table_exists_sync(conn):
-        return False
+        return None
     row = conn.execute(
         "SELECT state FROM fts_freshness_state WHERE surface=?",
         (MESSAGE_SURFACE,),
     ).fetchone()
-    return row is not None and str(row[0]) == READY
+    return None if row is None else str(row[0])
 
 
-async def message_fts_marked_ready_async(conn: aiosqlite.Connection) -> bool:
+async def message_fts_recorded_state_async(conn: aiosqlite.Connection) -> str | None:
     if not await _table_exists_async(conn):
-        return False
+        return None
     row = await (
         await conn.execute(
             "SELECT state FROM fts_freshness_state WHERE surface=?",
             (MESSAGE_SURFACE,),
         )
     ).fetchone()
-    return row is not None and str(row[0]) == READY
+    return None if row is None else str(row[0])
 
 
 __all__ = [
@@ -208,6 +216,8 @@ __all__ = [
     "mark_all_fts_stale_sync",
     "message_fts_marked_ready_async",
     "message_fts_marked_ready_sync",
+    "message_fts_recorded_state_async",
+    "message_fts_recorded_state_sync",
     "record_fts_invariant_snapshot_sync",
     "record_fts_surface_state_async",
     "record_fts_surface_state_sync",

--- a/polylogue/storage/fts/fts_lifecycle.py
+++ b/polylogue/storage/fts/fts_lifecycle.py
@@ -505,11 +505,12 @@ def message_fts_search_readiness_sync(conn: sqlite3.Connection) -> dict[str, int
     from polylogue.storage.fts.freshness import (
         READY,
         STALE,
-        message_fts_marked_ready_sync,
+        message_fts_recorded_state_sync,
         record_fts_surface_state_sync,
     )
 
-    if message_fts_marked_ready_sync(conn):
+    recorded_state = message_fts_recorded_state_sync(conn)
+    if recorded_state == READY:
         return {
             "exists": True,
             "indexed_rows": 0,
@@ -517,6 +518,9 @@ def message_fts_search_readiness_sync(conn: sqlite3.Connection) -> dict[str, int
             "ready": True,
             "triggers_present": True,
         }
+    if recorded_state is not None:
+        readiness = message_fts_readiness_sync(conn, verify_total_rows=False)
+        return {**readiness, "ready": False}
     readiness = message_fts_readiness_sync(conn, verify_total_rows=True)
     if bool(readiness["ready"]):
         with suppress(sqlite3.Error):
@@ -582,11 +586,12 @@ async def message_fts_search_readiness_async(conn: aiosqlite.Connection) -> dict
     from polylogue.storage.fts.freshness import (
         READY,
         STALE,
-        message_fts_marked_ready_async,
+        message_fts_recorded_state_async,
         record_fts_surface_state_async,
     )
 
-    if await message_fts_marked_ready_async(conn):
+    recorded_state = await message_fts_recorded_state_async(conn)
+    if recorded_state == READY:
         return {
             "exists": True,
             "indexed_rows": 0,
@@ -594,6 +599,9 @@ async def message_fts_search_readiness_async(conn: aiosqlite.Connection) -> dict
             "ready": True,
             "triggers_present": True,
         }
+    if recorded_state is not None:
+        readiness = await message_fts_readiness_async(conn, verify_total_rows=False)
+        return {**readiness, "ready": False}
     readiness = await message_fts_readiness_async(conn, verify_total_rows=True)
     if bool(readiness["ready"]):
         with suppress(sqlite3.Error):

--- a/tests/unit/daemon/test_daemon_cli.py
+++ b/tests/unit/daemon/test_daemon_cli.py
@@ -261,7 +261,7 @@ def test_run_live_watcher_stops_on_keyboard_interrupt() -> None:
     assert stopped == [True]
 
 
-def test_ensure_fts_startup_readiness_records_ready_invariant(
+def test_ensure_fts_startup_readiness_marks_unknown_without_exact_scan(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -325,29 +325,31 @@ def test_ensure_fts_startup_readiness_records_ready_invariant(
     def ensure(fake_conn: FakeConnection) -> None:
         ensured.append(fake_conn)
 
-    class ReadySnapshot:
-        ready = True
-        surfaces: tuple[object, ...] = ()
-
-    recorded: list[object] = []
+    recorded: list[dict[str, object]] = []
 
     monkeypatch.setattr("polylogue.paths.db_path", lambda: db)
     monkeypatch.setattr("polylogue.storage.sqlite.connection_profile.open_connection", lambda _db, timeout: conn)
     monkeypatch.setattr("polylogue.storage.fts.fts_lifecycle.ensure_fts_index_sync", ensure)
     monkeypatch.setattr("polylogue.storage.fts.fts_lifecycle.rebuild_fts_index_sync", rebuild)
+    monkeypatch.setattr("polylogue.storage.fts.freshness.ensure_fts_freshness_table_sync", lambda fake_conn: None)
+    monkeypatch.setattr("polylogue.storage.fts.freshness.message_fts_marked_ready_sync", lambda fake_conn: False)
     monkeypatch.setattr(
-        "polylogue.storage.fts.fts_lifecycle.fts_invariant_snapshot_sync", lambda fake_conn: ReadySnapshot()
-    )
-    monkeypatch.setattr(
-        "polylogue.storage.fts.freshness.record_fts_invariant_snapshot_sync",
-        lambda fake_conn, snapshot: recorded.append(snapshot),
+        "polylogue.storage.fts.freshness.record_fts_surface_state_sync",
+        lambda fake_conn, **kwargs: recorded.append(kwargs),
     )
 
     asyncio.run(daemon_cli._ensure_fts_startup_readiness())
 
     assert ensured == [conn]
     assert rebuilds == []
-    assert len(recorded) == 1
+    assert recorded == [
+        {
+            "surface": "messages_fts",
+            "state": "unknown",
+            "detail": "startup structural check passed; exact repair pending",
+        }
+    ]
+    assert all("LEFT JOIN messages_fts_docsize" not in query for query in conn.queries)
     assert conn.committed is True
     assert conn.closed is True
 
@@ -415,6 +417,7 @@ def test_ensure_fts_startup_readiness_rebuilds_empty_fts(
     monkeypatch.setattr("polylogue.storage.sqlite.connection_profile.open_connection", lambda _db, timeout: conn)
     monkeypatch.setattr("polylogue.storage.fts.fts_lifecycle.ensure_fts_index_sync", lambda _conn: None)
     monkeypatch.setattr("polylogue.storage.fts.fts_lifecycle.rebuild_fts_index_sync", rebuild)
+    monkeypatch.setattr("polylogue.storage.fts.freshness.ensure_fts_freshness_table_sync", lambda fake_conn: None)
 
     asyncio.run(daemon_cli._ensure_fts_startup_readiness())
 
@@ -500,16 +503,10 @@ def test_ensure_fts_startup_readiness_rebuilds_when_triggers_missing(
         lambda fake_conn: rebuilds.append(fake_conn),
     )
 
-    class ReadySnapshot:
-        ready = True
-        surfaces: tuple[object, ...] = ()
-
+    monkeypatch.setattr("polylogue.storage.fts.freshness.ensure_fts_freshness_table_sync", lambda fake_conn: None)
+    monkeypatch.setattr("polylogue.storage.fts.freshness.message_fts_marked_ready_sync", lambda fake_conn: False)
     monkeypatch.setattr(
-        "polylogue.storage.fts.fts_lifecycle.fts_invariant_snapshot_sync", lambda fake_conn: ReadySnapshot()
-    )
-    monkeypatch.setattr(
-        "polylogue.storage.fts.freshness.record_fts_invariant_snapshot_sync",
-        lambda fake_conn, snapshot: None,
+        "polylogue.storage.fts.freshness.record_fts_surface_state_sync", lambda fake_conn, **kwargs: None
     )
 
     asyncio.run(daemon_cli._ensure_fts_startup_readiness())


### PR DESCRIPTION
## Summary

Keep daemon startup and search request paths from performing surprise exact FTS invariant scans. Startup now restores obvious FTS structure, records the durable freshness state as `unknown` or `stale` when exact repair is pending, and lets the ambient repair loop own full invariant scans after HTTP/status surfaces have bound.

## Problem

The deployed `aba8d6d3` build regressed under the real archive: `polylogued.service` logged `daemon started` but did not bind `:8765`/`:8766`, while the process sat in disk sleep and read ~25 GB before the freshness table had even been created. Systemd showed ~6.4 GB cgroup memory, but `/proc/$pid/status` showed RSS under 1 GB and `memory.stat` showed the bulk was file cache, so this was SQLite/FTS read amplification charged to the service rather than pure Python heap growth.

## Solution

Startup no longer runs `fts_invariant_snapshot_sync()` for existing populated FTS indexes. It performs bounded structural checks, restores missing triggers, rebuilds only when the FTS table is missing or empty, and records freshness ledger state for request handlers. Search readiness now trusts a `ready` ledger row, and if the ledger explicitly says `unknown`/`stale`, it performs only a cheap structural probe and refuses stale search rather than launching an exact scan from a request path. The ambient FTS repair loop gets a short initial delay so HTTP can bind first, skips exact work when the ledger is ready and structure is still sound, and uses a smaller SQLite cache/mmap profile for exact repair.

## Verification

- `pytest tests/unit/daemon/test_daemon_cli.py tests/unit/storage/test_fts_trigger_lifecycle.py tests/unit/storage/test_fts5.py::test_search_with_empty_fts_rows_raises_descriptive_error tests/unit/core/test_query_retrieval_candidates.py -q` → 25 passed in 0.96s
- `pytest tests/unit/daemon/test_metrics_endpoint.py tests/unit/storage/test_fts5.py::test_search_without_fts_table_raises_descriptive_error tests/unit/storage/test_fts5.py::test_search_with_empty_fts_rows_raises_descriptive_error tests/unit/core/test_query_retrieval_candidates.py -q` → 16 passed in 0.41s
- `ruff format --check polylogue/storage/fts/freshness.py polylogue/storage/fts/fts_lifecycle.py polylogue/daemon/cli.py tests/unit/daemon/test_daemon_cli.py` → 4 files already formatted
- `ruff check polylogue/storage/fts/freshness.py polylogue/storage/fts/fts_lifecycle.py polylogue/daemon/cli.py tests/unit/daemon/test_daemon_cli.py` → All checks passed
- `mypy polylogue/storage/fts/freshness.py polylogue/storage/fts/fts_lifecycle.py polylogue/daemon/cli.py tests/unit/daemon/test_daemon_cli.py` → Success: no issues found in 4 source files
- `devtools verify --quick` → exit_code 0, total_duration_s 45.54
- pre-push `devtools verify --quick` → exit_code 0, total_duration_s 35.62

Ref #1447
