### PR TITLE
fix(daemon): bound live catch-up ingest batches

### DIFF
--- a/polylogue/sources/live/watcher.py
+++ b/polylogue/sources/live/watcher.py
@@ -31,6 +31,8 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 _PARSER_FINGERPRINT = "live-batched-v2"
+_CATCH_UP_MAX_BATCH_FILES = 50
+_CATCH_UP_MAX_BATCH_BYTES = 64 * 1024 * 1024
 
 
 @dataclass(frozen=True, slots=True)
@@ -153,17 +155,31 @@ class LiveWatcher:
         plan = self._plan_catch_up(candidates)
 
         if plan.needed:
+            candidate_by_path = {candidate.path: candidate for candidate in plan.candidates}
+            chunks = tuple(self._chunk_catch_up_paths(plan.needed, candidate_by_path))
             logger.info(
-                "live.watcher: catch-up ingesting %d file(s) (%.1f MB), skipped=%d",
+                "live.watcher: catch-up ingesting %d file(s) (%.1f MB), skipped=%d, chunks=%d",
                 len(plan.needed),
                 plan.needed_bytes / 1e6,
                 plan.skipped_file_count,
+                len(chunks),
             )
-            await self._ingest_files(
-                list(plan.needed),
-                queued_file_count=len(plan.candidates),
-                skipped_file_count=plan.skipped_file_count,
-            )
+            for index, chunk in enumerate(chunks, start=1):
+                if self._stop.is_set():
+                    break
+                chunk_bytes = sum(candidate_by_path[path].stat.st_size for path in chunk)
+                logger.info(
+                    "live.watcher: catch-up chunk %d/%d ingesting %d file(s) (%.1f MB)",
+                    index,
+                    len(chunks),
+                    len(chunk),
+                    chunk_bytes / 1e6,
+                )
+                await self._ingest_files(
+                    list(chunk),
+                    queued_file_count=len(plan.candidates) if index == 1 else len(chunk),
+                    skipped_file_count=plan.skipped_file_count if index == 1 else 0,
+                )
 
     def _scan_catch_up_candidates(self, roots: list[Path]) -> tuple[CandidateSourceFile, ...]:
         root_set = {root.resolve() for root in roots}
@@ -214,6 +230,28 @@ class LiveWatcher:
             skipped_file_count=skipped,
             needed_bytes=needed_bytes,
         )
+
+    def _chunk_catch_up_paths(
+        self,
+        paths: tuple[Path, ...],
+        candidate_by_path: dict[Path, CandidateSourceFile],
+    ) -> tuple[tuple[Path, ...], ...]:
+        chunks: list[tuple[Path, ...]] = []
+        current: list[Path] = []
+        current_bytes = 0
+        for path in paths:
+            size = candidate_by_path[path].stat.st_size
+            would_exceed_count = len(current) >= _CATCH_UP_MAX_BATCH_FILES
+            would_exceed_bytes = current_bytes > 0 and current_bytes + size > _CATCH_UP_MAX_BATCH_BYTES
+            if current and (would_exceed_count or would_exceed_bytes):
+                chunks.append(tuple(current))
+                current = []
+                current_bytes = 0
+            current.append(path)
+            current_bytes += size
+        if current:
+            chunks.append(tuple(current))
+        return tuple(chunks)
 
     # ------------------------------------------------------------------
     # Live: debounced batch scheduling

--- a/tests/unit/sources/test_live_catchup_planning.py
+++ b/tests/unit/sources/test_live_catchup_planning.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
@@ -49,3 +50,37 @@ def test_catch_up_plan_carries_statted_candidates_without_payload_reads(
     assert plan.needed == (changed,)
     assert plan.skipped_file_count == 1
     assert plan.needed_bytes == changed.stat().st_size
+
+
+def test_catch_up_ingests_needed_files_in_bounded_chunks(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "src"
+    root.mkdir()
+    files = [root / f"session-{index}.jsonl" for index in range(5)]
+    for index, path in enumerate(files):
+        path.write_text("x" * (index + 1))
+    polylogue = SimpleNamespace(archive_root=tmp_path, backend=None)
+    watcher = LiveWatcher(cast(Any, polylogue), (WatchSource(name="test", root=root),))
+    monkeypatch.setattr(live_watcher, "_CATCH_UP_MAX_BATCH_FILES", 2)
+    monkeypatch.setattr(live_watcher, "_CATCH_UP_MAX_BATCH_BYTES", 100)
+
+    calls: list[tuple[list[Path], int | None, int]] = []
+
+    async def fake_ingest_files(
+        paths: list[Path],
+        *,
+        queued_file_count: int | None = None,
+        skipped_file_count: int = 0,
+    ) -> None:
+        calls.append((paths, queued_file_count, skipped_file_count))
+
+    watcher._ingest_files = fake_ingest_files  # type: ignore[method-assign]
+
+    asyncio.run(watcher._catch_up([root]))
+
+    assert [paths for paths, _queued, _skipped in calls] == [files[:2], files[2:4], files[4:]]
+    assert calls[0][1:] == (5, 0)
+    assert calls[1][1:] == (2, 0)
+    assert calls[2][1:] == (1, 0)


### PR DESCRIPTION
## Summary

Bound daemon catch-up ingestion into serial chunks by file count and source bytes. The daemon still scans and converges the full source set; it just no longer sends every changed startup file into one huge parse/write batch.

## Problem

Live validation after deploying #1451 showed the next resource failure clearly: startup catch-up planned 310 changed files / 460.8 MB and ingested them as one unit. That single batch pushed the daemon back to the systemd 6 GiB high line, accumulated swap, drove high IO PSI, and produced a 172s slow write for a large Codex session.

## Solution

Catch-up now chunks needed paths with bounded defaults: 50 files or 64 MiB of source bytes per batch. Chunks are ingested serially and preserve full convergence scope. The first chunk preserves the whole catch-up queued/skipped context; later chunks report their own bounded sizes.

## Verification

- `pytest tests/unit/sources/test_live_watcher.py::test_catch_up_uses_bulk_cursor_records tests/unit/sources/test_live_watcher.py::test_catch_up_processes_pre_existing_files tests/unit/sources/test_live_catchup_planning.py -q` → 4 passed in 0.26s
- `ruff format --check polylogue/sources/live/watcher.py tests/unit/sources/test_live_watcher.py tests/unit/sources/test_live_catchup_planning.py` → 3 files already formatted
- `ruff check polylogue/sources/live/watcher.py tests/unit/sources/test_live_watcher.py tests/unit/sources/test_live_catchup_planning.py` → All checks passed
- `mypy polylogue/sources/live/watcher.py tests/unit/sources/test_live_catchup_planning.py` → Success: no issues found in 2 source files
- `devtools verify --quick` → exit_code 0, total_duration_s 34.47
- pre-push `devtools verify --quick` → exit_code 0, total_duration_s 34.27

Ref #1447
