### PR TITLE
fix(daemon): reduce large ingest FTS amplification

### DIFF
--- a/polylogue/archive/write_effects.py
+++ b/polylogue/archive/write_effects.py
@@ -65,6 +65,7 @@ def commit_archive_write_effects(
     blob_hashes: list[str] = payload.get("_blob_hashes", [])
     operation_id: str = payload.get("_operation_id", "")
     db_path: str | None = payload.get("_db_path")
+    repair_message_fts = bool(payload.get("repair_message_fts", True))
     repair_action_fts = bool(payload.get("repair_action_fts", True))
 
     # Acquire blob GC leases before the main data commit so a concurrent GC
@@ -81,14 +82,14 @@ def commit_archive_write_effects(
     trigger_elapsed_s = time.perf_counter() - t_trigger
     message_fts_elapsed_s = 0.0
     action_fts_elapsed_s = 0.0
-    if sorted_ids:
+    if sorted_ids and repair_message_fts:
         t_message = time.perf_counter()
         repair_message_fts_index_sync(conn, sorted_ids)
         message_fts_elapsed_s = time.perf_counter() - t_message
-        if repair_action_fts:
-            t_action = time.perf_counter()
-            repair_action_fts_index_sync(conn, sorted_ids)
-            action_fts_elapsed_s = time.perf_counter() - t_action
+    if sorted_ids and repair_action_fts:
+        t_action = time.perf_counter()
+        repair_action_fts_index_sync(conn, sorted_ids)
+        action_fts_elapsed_s = time.perf_counter() - t_action
     t_commit = time.perf_counter()
     conn.commit()
     commit_elapsed_s = time.perf_counter() - t_commit

--- a/polylogue/pipeline/services/ingest_batch/_core.py
+++ b/polylogue/pipeline/services/ingest_batch/_core.py
@@ -981,6 +981,7 @@ def _commit_sync_ingest_side_effects(
     *,
     db_path: Path,
     changed_conversation_ids: Sequence[str],
+    repair_message_fts: bool = True,
     repair_action_fts: bool = True,
 ) -> None:
     """Run post-ingest side effects through the canonical write-effects path."""
@@ -989,6 +990,7 @@ def _commit_sync_ingest_side_effects(
         {
             "_connection": conn,
             "changed_conversation_ids": tuple(changed_conversation_ids),
+            "repair_message_fts": repair_message_fts,
             "repair_action_fts": repair_action_fts,
         },
     )
@@ -1004,6 +1006,7 @@ def _process_ingest_batch_sync(
     ingest_workers: int | None,
     measure_ingest_result_size: bool,
     force_write: bool = False,
+    repair_message_fts: bool = True,
     repair_action_fts: bool = True,
     heartbeat: IngestHeartbeat | None = None,
     progress: _WorkerProgress | None = None,
@@ -1028,11 +1031,11 @@ def _process_ingest_batch_sync(
     _observe_current_rss(summary)
     changed_ids: set[str] = set()
     try:
+        conn.execute("BEGIN IMMEDIATE")
         if suspend_fts_triggers:
             from polylogue.storage.fts.fts_lifecycle import suspend_fts_triggers_sync
 
-            suspend_fts_triggers_sync(conn)
-        conn.execute("BEGIN IMMEDIATE")
+            suspend_fts_triggers_sync(conn, mark_stale=False)
         _consume_ingest_results(
             conn,
             raw_artifacts,
@@ -1064,7 +1067,8 @@ def _process_ingest_batch_sync(
             conn,
             db_path=db_path,
             changed_conversation_ids=tuple(changed_ids),
-            repair_action_fts=repair_action_fts,
+            repair_message_fts=repair_message_fts or suspend_fts_triggers,
+            repair_action_fts=repair_action_fts or suspend_fts_triggers,
         )
         summary.commit_elapsed_s = time.perf_counter() - commit_started
         from polylogue.storage.sqlite.wal_checkpoint import maybe_checkpoint_wal

--- a/polylogue/sources/live/append_ingest.py
+++ b/polylogue/sources/live/append_ingest.py
@@ -63,6 +63,7 @@ def ingest_append_plans(owner: _AppendIngestOwner, plans: list[_AppendPlan]) -> 
             validation_mode=str(getattr(getattr(owner._polylogue, "config", None), "validation_mode", "advisory")),
             ingest_workers=1,
             measure_ingest_result_size=False,
+            repair_message_fts=False,
             repair_action_fts=False,
             ingest_result_chunk_size=_INGEST_RESULT_CHUNK_SIZE,
         )

--- a/polylogue/sources/live/batch.py
+++ b/polylogue/sources/live/batch.py
@@ -90,6 +90,7 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 LiveBatchEventEmitter = Callable[[str, dict[str, object]], None]
+_FULL_INGEST_SUSPEND_FTS_TRIGGER_BYTES = 32 * 1024 * 1024
 
 
 class LiveBatchProcessor:
@@ -902,6 +903,9 @@ class LiveBatchProcessor:
         summary: _IngestBatchSummary | None = None
         if raw_records:
             self._persist_raw_records(raw_records)
+            suspend_fts_triggers = any(
+                record.blob_size >= _FULL_INGEST_SUSPEND_FTS_TRIGGER_BYTES for record in raw_records
+            )
             if heartbeat is not None:
                 heartbeat(
                     "full_worker_wait",
@@ -917,8 +921,10 @@ class LiveBatchProcessor:
                 validation_mode=str(getattr(getattr(self._polylogue, "config", None), "validation_mode", "advisory")),
                 ingest_workers=_full_ingest_worker_count(raw_records),
                 measure_ingest_result_size=False,
-                repair_action_fts=False,
+                repair_message_fts=suspend_fts_triggers,
+                repair_action_fts=suspend_fts_triggers,
                 ingest_result_chunk_size=_INGEST_RESULT_CHUNK_SIZE,
+                suspend_fts_triggers=suspend_fts_triggers,
                 heartbeat=None
                 if heartbeat is None
                 else lambda: heartbeat(

--- a/polylogue/storage/fts/fts_lifecycle.py
+++ b/polylogue/storage/fts/fts_lifecycle.py
@@ -166,14 +166,15 @@ async def _triggers_present_async(conn: aiosqlite.Connection, names: tuple[str, 
     return row is not None and row[0] == len(names)
 
 
-async def suspend_fts_triggers_async(conn: aiosqlite.Connection) -> None:
+async def suspend_fts_triggers_async(conn: aiosqlite.Connection, *, mark_stale: bool = True) -> None:
     """Drop FTS triggers to avoid per-row overhead during bulk inserts.
 
     Call rebuild_fts_index_async() after to repopulate the FTS index.
     """
-    from polylogue.storage.fts.freshness import mark_all_fts_stale_async
+    if mark_stale:
+        from polylogue.storage.fts.freshness import mark_all_fts_stale_async
 
-    await mark_all_fts_stale_async(conn, detail="FTS triggers suspended for bulk write")
+        await mark_all_fts_stale_async(conn, detail="FTS triggers suspended for bulk write")
     for name in _FTS_TRIGGER_NAMES:
         await conn.execute(f"DROP TRIGGER IF EXISTS {name}")
 
@@ -229,11 +230,12 @@ _ACTION_FTS_TRIGGER_DDL = [
 ]
 
 
-def suspend_fts_triggers_sync(conn: sqlite3.Connection) -> None:
+def suspend_fts_triggers_sync(conn: sqlite3.Connection, *, mark_stale: bool = True) -> None:
     """Drop FTS triggers for bulk sync operations."""
-    from polylogue.storage.fts.freshness import mark_all_fts_stale_sync
+    if mark_stale:
+        from polylogue.storage.fts.freshness import mark_all_fts_stale_sync
 
-    mark_all_fts_stale_sync(conn, detail="FTS triggers suspended for bulk write")
+        mark_all_fts_stale_sync(conn, detail="FTS triggers suspended for bulk write")
     for name in _FTS_TRIGGER_NAMES:
         conn.execute(f"DROP TRIGGER IF EXISTS {name}")
 

--- a/tests/unit/archive/test_write_gateway.py
+++ b/tests/unit/archive/test_write_gateway.py
@@ -55,6 +55,39 @@ def test_write_gateway_normal_commit_does_not_drop_fts_triggers(
     assert ensured == [True]
 
 
+def test_write_gateway_can_skip_fts_repairs_when_triggers_maintained_rows(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "archive.db"
+    repaired: list[str] = []
+
+    monkeypatch.setattr("polylogue.storage.fts.fts_lifecycle.ensure_fts_triggers_sync", lambda _conn: None)
+    monkeypatch.setattr(
+        "polylogue.storage.fts.fts_lifecycle.repair_message_fts_index_sync",
+        lambda _conn, _ids: repaired.append("messages"),
+    )
+    monkeypatch.setattr(
+        "polylogue.storage.fts.fts_lifecycle.repair_action_fts_index_sync",
+        lambda _conn, _ids: repaired.append("actions"),
+    )
+
+    with open_connection(db_path) as conn:
+        conn.execute("BEGIN IMMEDIATE")
+        result = ArchiveWriteGateway(db_path).commit_write_sync(
+            WriteOperation.INGEST,
+            {
+                "_connection": conn,
+                "changed_conversation_ids": ("c1",),
+                "repair_message_fts": False,
+                "repair_action_fts": False,
+            },
+        )
+
+    assert result.status == "committed"
+    assert repaired == []
+
+
 @pytest.mark.asyncio
 async def test_write_gateway_async_commit_uses_same_local_effects_path(tmp_path: Path) -> None:
     db_path = tmp_path / "archive.db"

--- a/tests/unit/sources/test_live_batch_support.py
+++ b/tests/unit/sources/test_live_batch_support.py
@@ -73,6 +73,48 @@ def test_full_ingest_heartbeats_small_file_groups_with_current_path(
     assert any(event == ("full_worker_wait", second, first.stat().st_size + second.stat().st_size) for event in events)
 
 
+def test_large_full_ingest_suspends_fts_triggers_and_repairs_once(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "sessions"
+    root.mkdir()
+    source = root / "large.jsonl"
+    source.write_text('{"type":"session_meta","payload":{"id":"large"}}\n', encoding="utf-8")
+    db_path = tmp_path / "archive.sqlite"
+    processor = LiveBatchProcessor(
+        cast(Any, SimpleNamespace(archive_root=tmp_path, backend=SimpleNamespace(db_path=db_path))),
+        (WatchSource(name="codex", root=root),),
+        cursor=CursorStore(db_path),
+        parser_fingerprint="test-parser",
+    )
+    captured_kwargs: dict[str, object] = {}
+
+    monkeypatch.setattr("polylogue.sources.live.batch._FULL_INGEST_SUSPEND_FTS_TRIGGER_BYTES", 1)
+    monkeypatch.setattr(
+        "polylogue.sources.live.batch._jsonl_provider_and_conversation_artifact",
+        lambda _path, fallback_provider: (fallback_provider, True),
+    )
+    monkeypatch.setattr(
+        "polylogue.sources.live.batch.BlobStore.write_from_bytes",
+        lambda _store, payload: ("a" * 64, len(payload)),
+    )
+
+    def fake_process_ingest_batch_sync(*args: object, **kwargs: object) -> SimpleNamespace:
+        del args
+        captured_kwargs.update(kwargs)
+        return SimpleNamespace(failed_raw_ids=set(), parse_failures=0, worker_count=1)
+
+    monkeypatch.setattr("polylogue.sources.live.batch._process_ingest_batch_sync", fake_process_ingest_batch_sync)
+
+    result = processor._ingest_full_paths_sync([source], source_name="codex")
+
+    assert result.succeeded == [source]
+    assert captured_kwargs["suspend_fts_triggers"] is True
+    assert captured_kwargs["repair_message_fts"] is True
+    assert captured_kwargs["repair_action_fts"] is True
+
+
 def test_fingerprint_file_streams_in_bounded_memory(tmp_path: Path) -> None:
     """``fingerprint_file`` must not load the whole file into memory.
 
@@ -262,13 +304,19 @@ def test_append_ingest_preserves_successes_when_other_plan_fails(
         ),
     ]
     raw_ids = iter(("raw-ok", "raw-bad"))
+    captured_kwargs: dict[str, object] = {}
     monkeypatch.setattr(
         "polylogue.sources.live.append_ingest.BlobStore.write_from_bytes",
         lambda _store, payload: (next(raw_ids), len(payload)),
     )
+
+    def fake_process_ingest_batch_sync(*args: object, **kwargs: object) -> SimpleNamespace:
+        del args
+        captured_kwargs.update(kwargs)
+        return SimpleNamespace(failed_raw_ids={"raw-bad"}, parse_failures=1, worker_count=1)
+
     monkeypatch.setattr(
-        "polylogue.sources.live.append_ingest._process_ingest_batch_sync",
-        lambda *args, **kwargs: SimpleNamespace(failed_raw_ids={"raw-bad"}, parse_failures=1, worker_count=1),
+        "polylogue.sources.live.append_ingest._process_ingest_batch_sync", fake_process_ingest_batch_sync
     )
 
     owner = Owner()
@@ -278,6 +326,8 @@ def test_append_ingest_preserves_successes_when_other_plan_fails(
     assert result.succeeded == [plans[0]]
     assert result.failed == [plans[1]]
     assert result.worker_count == 1
+    assert captured_kwargs["repair_message_fts"] is False
+    assert captured_kwargs["repair_action_fts"] is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Reduce the remaining live catch-up write amplification for huge single-session files. Live append/full-ingest paths now avoid redundant message FTS repair when active triggers already maintained FTS rows, while large full-ingest batches deliberately suspend triggers inside the ingest transaction and repair the changed conversations once before commit.

## Problem

After #1452 bounded catch-up into file chunks, live validation still showed a single 221 MB Codex session with 31,417 messages spending 314 seconds in `slow_write`, driving severe host IO pressure. The batch was bounded, but the single-conversation write path was still monolithic and FTS-heavy.

The code also had a latent suspended-trigger transaction bug: `_process_ingest_batch_sync` dropped FTS triggers before `BEGIN IMMEDIATE`, so a suspended bulk path could fail with `sqlite3.OperationalError: cannot start a transaction within a transaction`.

## Solution

- Add a `repair_message_fts` switch to the canonical archive write effects path, matching the existing `repair_action_fts` control.
- Keep conservative defaults for ordinary archive writes.
- Make live append ingest opt out of redundant message/action FTS repair because FTS triggers are active for those row writes.
- Make live full ingest suspend FTS triggers for raw records at or above 32 MiB, then force message/action FTS repair once before commit.
- Move sync trigger suspension inside `BEGIN IMMEDIATE` and add `mark_stale=False` for transaction-scoped suspension so an already-ready freshness ledger is not falsely degraded by a transaction that repairs before commit.

Synthetic local probe on a temporary archive with a 12k-message conversation:

- active triggers + post-write message repair: `0.292s`
- suspended triggers + one message repair: `0.143s`

This does not claim the production 31k-message case is solved completely; it removes a known FTS write-amplification layer and fixes the transaction bug. The next live daemon run should verify residual parse/write/insight cost against the real 221 MB session.

## Verification

- `pytest tests/unit/archive/test_write_gateway.py tests/unit/sources/test_live_batch_support.py tests/unit/pipeline/test_ingest_batch.py tests/unit/storage/test_fts_trigger_lifecycle.py tests/unit/storage/test_fts_bloat_invariants.py -q` → `51 passed in 1.16s`
- `python -m mypy polylogue/archive/write_effects.py polylogue/pipeline/services/ingest_batch/_core.py polylogue/sources/live/batch.py polylogue/sources/live/append_ingest.py polylogue/storage/fts/fts_lifecycle.py tests/unit/archive/test_write_gateway.py tests/unit/sources/test_live_batch_support.py` → `Success: no issues found in 7 source files`
- `devtools verify --quick` → PASS, `exit_code: 0`, `total_duration_s: 34.63`
- pre-push `devtools verify --quick` → PASS, `exit_code: 0`, `total_duration_s: 35.15`

`devtools verify` reached pytest-testmon and was stopped after `785.8s` because the affected selector expanded to effectively the full serial suite (`9297` JUnit testcases recorded, `failures=0`, `skipped=2`) and was still running at 99%. That behavior is the existing verification-efficiency problem being tracked separately; I did not restart another broad pytest loop for this small branch.

Ref #1447.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized full-text search maintenance during large file imports to reduce processing overhead.

* **Bug Fixes**
  * Enhanced consistency in search index repair sequencing during data ingestion operations.

* **Tests**
  * Added tests to verify correct behavior for skip-repair scenarios and large file import optimization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sinity/polylogue/pull/1453?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->