### PR TITLE
fix(daemon): requeue live ingest when archive is busy

### DIFF
--- a/polylogue/sources/live/watcher.py
+++ b/polylogue/sources/live/watcher.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import sqlite3
 import stat as stat_module
 from collections.abc import Iterable
 from dataclasses import dataclass
@@ -102,6 +103,7 @@ class LiveWatcher:
         self._drain_task: asyncio.Task[None] | None = None
         self._last_batch_at: float = 0.0
         self._batch_lock = asyncio.Lock()
+        self._ingest_lock = asyncio.Lock()
         self._stop = asyncio.Event()
         self._batch_processor = LiveBatchProcessor(
             polylogue,
@@ -296,25 +298,33 @@ class LiveWatcher:
             paths = list(self._pending_paths)
             self._pending_paths.clear()
 
-        # Filter to files that actually need work.
-        cursor_records = self._cursor.get_records(paths)
-        needed = []
-        for path in paths:
-            try:
-                stat = path.stat()
-            except FileNotFoundError:
-                continue
-            if self._needs_work_from_state(path, stat=stat, cursor=cursor_records.get(path)):
-                needed.append(path)
-        if not needed:
-            return bool(paths)
+        try:
+            # Filter to files that actually need work.
+            cursor_records = self._cursor.get_records(paths)
+            needed = []
+            for path in paths:
+                try:
+                    stat = path.stat()
+                except FileNotFoundError:
+                    continue
+                if self._needs_work_from_state(path, stat=stat, cursor=cursor_records.get(path)):
+                    needed.append(path)
+            if not needed:
+                return bool(paths)
 
-        logger.info("live.watcher: batching %d changed file(s)", len(needed))
-        await self._ingest_files(
-            needed,
-            queued_file_count=len(paths),
-            skipped_file_count=len(paths) - len(needed),
-        )
+            logger.info("live.watcher: batching %d changed file(s)", len(needed))
+            await self._ingest_files(
+                needed,
+                queued_file_count=len(paths),
+                skipped_file_count=len(paths) - len(needed),
+            )
+        except sqlite3.OperationalError as exc:
+            if not _is_database_locked(exc):
+                raise
+            logger.warning("live.watcher: archive busy; requeueing %d changed file(s)", len(paths))
+            async with self._batch_lock:
+                self._pending_paths.update(paths)
+            await asyncio.sleep(self._debounce_s)
         return True
 
     # ------------------------------------------------------------------
@@ -371,11 +381,12 @@ class LiveWatcher:
         skipped_file_count: int = 0,
     ) -> None:
         """Ingest files through the reusable daemon live batch processor."""
-        await self._batch_processor.ingest_files(
-            paths,
-            queued_file_count=queued_file_count,
-            skipped_file_count=skipped_file_count,
-        )
+        async with self._ingest_lock:
+            await self._batch_processor.ingest_files(
+                paths,
+                queued_file_count=queued_file_count,
+                skipped_file_count=skipped_file_count,
+            )
 
     def _source_name_for(self, path: Path) -> str:
         resolved = path.resolve()
@@ -433,6 +444,10 @@ def _cursor_db_path(polylogue: Polylogue) -> Path:
     if isinstance(db_path, Path):
         return db_path
     return Path(polylogue.archive_root) / "polylogue.db"
+
+
+def _is_database_locked(exc: sqlite3.OperationalError) -> bool:
+    return "database is locked" in str(exc).lower()
 
 
 def _retry_due(next_retry_at: str | None) -> bool:

--- a/tests/unit/sources/test_live_watcher_locking.py
+++ b/tests/unit/sources/test_live_watcher_locking.py
@@ -1,0 +1,135 @@
+"""Lock-contention behavior for the live filesystem watcher."""
+
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+
+from polylogue.sources.live import LiveWatcher, WatchSource
+from polylogue.sources.live.cursor import CursorStore
+
+
+def _make_watcher(tmp_path: Path, root: Path, *, debounce_s: float = 0.01) -> LiveWatcher:
+    polylogue = cast(
+        Any,
+        SimpleNamespace(
+            archive_root=tmp_path,
+            backend=SimpleNamespace(db_path=tmp_path / "archive.sqlite"),
+        ),
+    )
+    cursor = CursorStore(tmp_path / "archive.sqlite")
+    return LiveWatcher(polylogue, (WatchSource(name="test", root=root),), debounce_s=debounce_s, cursor=cursor)
+
+
+@pytest.mark.asyncio
+async def test_flush_pending_requeues_when_archive_is_busy(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "src"
+    root.mkdir()
+    source = root / "session.jsonl"
+    source.write_text('{"role":"user","content":"a"}\n')
+    watcher = _make_watcher(tmp_path, root, debounce_s=0)
+    watcher._pending_paths.add(source)
+    calls: list[tuple[list[Path], int | None, int]] = []
+
+    async def locked_ingest(
+        paths: list[Path],
+        *,
+        queued_file_count: int | None = None,
+        skipped_file_count: int = 0,
+    ) -> None:
+        calls.append((paths, queued_file_count, skipped_file_count))
+        raise sqlite3.OperationalError("database is locked")
+
+    monkeypatch.setattr(watcher, "_ingest_files", locked_ingest)
+
+    flushed = await watcher._flush_pending()
+
+    assert flushed is True
+    assert calls == [([source], 1, 0)]
+    assert watcher._pending_paths == {source}
+
+
+@pytest.mark.asyncio
+async def test_flush_pending_reraises_unexpected_sqlite_errors(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "src"
+    root.mkdir()
+    source = root / "session.jsonl"
+    source.write_text('{"role":"user","content":"a"}\n')
+    watcher = _make_watcher(tmp_path, root, debounce_s=0)
+    watcher._pending_paths.add(source)
+
+    async def failing_ingest(
+        paths: list[Path],
+        *,
+        queued_file_count: int | None = None,
+        skipped_file_count: int = 0,
+    ) -> None:
+        del paths, queued_file_count, skipped_file_count
+        raise sqlite3.OperationalError("disk I/O error")
+
+    monkeypatch.setattr(watcher, "_ingest_files", failing_ingest)
+
+    with pytest.raises(sqlite3.OperationalError, match="disk I/O error"):
+        await watcher._flush_pending()
+
+
+@pytest.mark.asyncio
+async def test_ingest_files_serializes_batch_processor_calls(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "src"
+    root.mkdir()
+    first = root / "first.jsonl"
+    second = root / "second.jsonl"
+    watcher = _make_watcher(tmp_path, root)
+    first_started = asyncio.Event()
+    allow_first_finish = asyncio.Event()
+    second_entered = asyncio.Event()
+    active = 0
+    max_active = 0
+    calls: list[Path] = []
+
+    async def ingest_files(
+        paths: list[Path],
+        *,
+        queued_file_count: int | None = None,
+        skipped_file_count: int = 0,
+    ) -> None:
+        del queued_file_count, skipped_file_count
+        nonlocal active, max_active
+        active += 1
+        max_active = max(max_active, active)
+        current = paths[0]
+        calls.append(current)
+        if current == first:
+            first_started.set()
+            await allow_first_finish.wait()
+        else:
+            second_entered.set()
+        active -= 1
+
+    monkeypatch.setattr(watcher._batch_processor, "ingest_files", ingest_files)
+
+    first_task = asyncio.create_task(watcher._ingest_files([first]))
+    await first_started.wait()
+    second_task = asyncio.create_task(watcher._ingest_files([second]))
+    await asyncio.sleep(0.02)
+
+    assert not second_entered.is_set()
+    allow_first_finish.set()
+    await asyncio.gather(first_task, second_task)
+
+    assert calls == [first, second]
+    assert max_active == 1


### PR DESCRIPTION
## Summary

Live watcher batches now survive transient SQLite archive lock contention. The watcher serializes calls into the live batch processor, requeues the exact pending snapshot when SQLite reports `database is locked`, and continues to fail loudly for unrelated SQLite errors.

## Problem

After deploying the large-ingest FTS amplification fix, `polylogued.service` still emitted repeated unhandled `sqlite3.OperationalError: database is locked` traces from `LiveWatcher._flush_pending -> _ingest_files -> CursorStore.begin_ingest_attempt`. That failure mode could drop the in-memory pending snapshot even though the source files still needed ingestion.

## Solution

- Add a watcher-local async ingest lock so overlapping catch-up/live drains cannot concurrently enter the `LiveBatchProcessor`.
- Treat only `database is locked` as transient archive-busy contention, requeueing the drained path snapshot and waiting for the debounce interval before the drain loop retries.
- Preserve hard failure behavior for other `sqlite3.OperationalError` values.
- Add focused lock-contention tests in a separate file so the existing live-watcher test budget remains under its exception cap.

## Verification

- `pytest tests/unit/sources/test_live_watcher.py tests/unit/sources/test_live_watcher_locking.py -q` -> `63 passed in 7.06s`
- `python -m mypy polylogue/sources/live/watcher.py tests/unit/sources/test_live_watcher.py tests/unit/sources/test_live_watcher_locking.py` -> `Success: no issues found in 3 source files`
- `devtools verify --quick` -> `exit_code: 0`, `total_duration_s: 36.42`
- pre-push `devtools verify --quick` -> `exit_code: 0`, `total_duration_s: 36.35`